### PR TITLE
add spec/ — vision, architecture, roadmap, phase docs, ADRs

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,28 @@
+# forkzero — specification
+
+forkzero is a terminal-first desktop app for running coding agents. This directory holds the living specification: vision, architecture, phase roadmap, per-feature designs, and the architecture decision record.
+
+## How to read this
+
+Start at the top, descend as needed:
+
+1. **[vision.md](vision.md)** — why forkzero exists and who it's for
+2. **[architecture.md](architecture.md)** — the stack and how pieces fit together
+3. **[roadmap.md](roadmap.md)** — phase-by-phase plan with effort estimates
+4. **[phases/](phases/)** — detailed scope, acceptance criteria, and contracts per phase
+5. **[features/](features/)** — deep dives per feature surface
+6. **[decisions/](decisions/)** — Architecture Decision Records (ADRs) capturing why we chose X over Y
+
+## How to contribute to the spec
+
+- Spec files are normative. Code that contradicts the spec is a bug — fix one or the other intentionally.
+- New features start as a doc in `spec/features/` before code lands.
+- Significant changes to architecture get an ADR in `spec/decisions/` (next number, never reuse).
+- Phase docs are immutable once a phase ships — write a new phase doc instead of editing history.
+
+## Status legend
+
+- 📐 **Spec** — written but not built
+- 🚧 **Building** — in active implementation
+- ✅ **Shipped** — in `main`, verified end-to-end
+- ⏸️ **Paused** — out of scope for current phase

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -1,0 +1,112 @@
+# Architecture
+
+## Stack
+
+| Layer | Choice | Why |
+|---|---|---|
+| Shell | Electron (latest LTS) | Already scaffolded; broadest desktop reach |
+| Renderer framework | React 19 + TypeScript | Mainstream, hireable, great tooling |
+| Build (renderer) | Vite | Fast HMR; matches React 19 well |
+| Build (main) | tsdown | Fast esbuild-based bundler for Node |
+| Styling | Tailwind v4 | Already in place; minimal runtime |
+| State (renderer, ephemeral) | Zustand backed by Effect Refs | Effect owns truth; Zustand is a thin React surface |
+| State (renderer, persistent) | Effect Layer over JSON file in userData | Inspectable, backupable |
+| IPC | Effect-wrapped preload bridge with typed contracts | One source of truth for channel schemas |
+| Terminal | xterm.js + node-pty | De facto standard |
+| Git | Spawn `git` CLI (no libgit2) | Avoids native binding pain; matches what users have installed |
+| Agent SDKs | `@anthropic-ai/claude-agent-sdk`, OpenAI Codex SDK | First-party clients |
+| Runtime safety | Effect.ts (Schema, Layer, Stream, Cause) | Typed errors, structured concurrency, resource safety |
+| Monorepo | Bun + Turbo | Fast installs, parallel task running |
+
+## Module layout
+
+```
+forkzero/
+  apps/
+    desktop/        # Electron main process — owns OS resources
+      src/
+        main.ts             # Window + lifecycle
+        preload.ts          # contextBridge → renderer
+        runtime.ts          # Composes Effect Layers for main
+        services/
+          pty/              # PTY service (node-pty wrapped in Effect)
+          git/              # Git service (spawn git, parse output)
+          workspace/        # Folder list persistence
+          agent/            # Claude/Codex adapters
+        ipc/
+          channels.ts       # Effect Schema for every channel
+          handlers.ts       # Layer that registers ipcMain handlers
+    renderer/       # React UI — pure UI, talks to main via typed bridge
+      src/
+        runtime.ts          # Renderer-side Effect runtime (lighter)
+        components/         # Pane components
+        store/              # Zustand stores backed by Effect Refs
+        lib/desktop.ts      # Typed IPC client
+  packages/
+    contracts/      # Effect Schemas shared between main and renderer
+      src/
+        terminal.ts
+        git.ts
+        workspace.ts
+        agent.ts
+    ui/             # Shared component primitives
+    typescript-config/
+    eslint-config/
+```
+
+## IPC topology
+
+The preload bridge exposes a single typed object: `window.forkzero`. Every method:
+
+1. Takes a typed input (Effect Schema-decoded on send)
+2. Returns either a `Promise<Output>` (request/response) or a `(handler) => unsubscribe` (subscription)
+3. Maps IPC errors to Effect tagged errors on the renderer
+
+Channel naming: `<service>:<verb>`, e.g. `pty:open`, `git:log`, `workspace:add`.
+
+## Effect Layer model
+
+**Main process layers** (built once at boot):
+
+```
+AppLayer = Layer.mergeAll(
+  NodeServicesLayer,        // FileSystem, Path, Terminal stdin
+  WorkspaceServiceLayer,    // depends on FileSystem, Path
+  PtyServiceLayer,          // depends on Path
+  GitServiceLayer,          // depends on Path
+  AgentServiceLayer,        // depends on Workspace, Pty
+  IpcHandlersLayer          // depends on all above; side-effectful registration
+)
+```
+
+**Renderer layers**:
+
+```
+RendererLayer = Layer.mergeAll(
+  IpcClientLayer,           // typed wrapper around window.forkzero
+  WorkspaceStoreLayer,      // Ref<WorkspaceState> + IPC sync
+  TerminalRegistryLayer,    // Map<TerminalId, xterm instance>
+  AgentSessionRegistryLayer
+)
+```
+
+A small `useEffectRuntime()` hook gives React components access via Zustand subscriptions.
+
+## Threading & concurrency
+
+- **Main process**: Effect runtime with Fibers; PTY/git/agent operations are interruptible.
+- **Renderer**: lightweight Effect runtime, no long-running fibers — mostly request/response.
+- **Streams**: PTY output, git status changes, and agent events are Effect Streams in main, serialized to JSON over IPC, re-materialized as RxJS-style subscriptions in the renderer.
+
+## Persistence
+
+| Data | Location | Format |
+|---|---|---|
+| Folder list | `userData/workspaces.json` | JSON |
+| Per-folder sessions | `userData/sessions/<folder-hash>.json` | JSON |
+| PTY scrollback (recent) | `userData/scrollback/<session-id>.log` | Plain text, capped at N MB |
+| Agent transcripts | `userData/agent-runs/<session-id>.jsonl` | NDJSON |
+| Settings | `userData/settings.json` | JSON |
+| Credentials | OS keychain via `keytar` | Native |
+
+No SQLite in v1. JSON until proven painful.

--- a/spec/decisions/0001-electron-over-tauri.md
+++ b/spec/decisions/0001-electron-over-tauri.md
@@ -1,0 +1,26 @@
+# ADR 0001: Electron over Tauri
+
+**Status**: Accepted
+
+**Date**: 2026-05-02
+
+## Context
+
+We need a desktop shell. The two reasonable choices in 2026 are Electron and Tauri.
+
+## Decision
+
+Use Electron.
+
+## Consequences
+
+**Pro**
+- Already scaffolded; switching now wastes work
+- Native node-pty and keytar bindings are well-trodden
+- Easier to ship to Windows/Linux without a Rust toolchain
+
+**Con**
+- Larger install size (~150MB vs ~10MB)
+- Higher idle memory
+
+We accept these costs in v1. Revisit at 2.0 if install size becomes a complaint.

--- a/spec/decisions/0002-effect-from-day-one.md
+++ b/spec/decisions/0002-effect-from-day-one.md
@@ -1,0 +1,29 @@
+# ADR 0002: Effect.ts from day one
+
+**Status**: Accepted
+
+**Date**: 2026-05-02
+
+## Context
+
+Effect.ts offers typed errors, structured concurrency, dependency injection via Layers, and Schema for runtime validation. It also has a steep learning curve.
+
+## Decision
+
+Adopt Effect from day 1 across both processes (main + renderer).
+
+## Why now and not later
+
+- Retrofitting a plain-TS app to Effect is mostly a rewrite of effectful code paths
+- The learning happens regardless; better to amortize over the whole project than spike later
+- The app's core complexity — PTY lifecycles, agent streams, IPC — is exactly what Effect is for
+
+## Constraints
+
+- Renderer's Effect runtime stays light (no long fibers; mostly request/response)
+- React components do not import Effect directly; they read from Zustand stores fed by Effect
+- One `Effect.runFork` per process at boot; no scattered runs
+
+## Cost
+
+Estimates in [roadmap.md](../roadmap.md) include +30% for Effect learning across all phases.

--- a/spec/decisions/0003-bun-monorepo.md
+++ b/spec/decisions/0003-bun-monorepo.md
@@ -1,0 +1,20 @@
+# ADR 0003: Bun + Turbo monorepo
+
+**Status**: Accepted
+
+**Date**: 2026-05-02
+
+## Context
+
+We need a package manager and task runner. Already on Bun + Turbo from the scaffold.
+
+## Decision
+
+Keep it.
+
+## Notes
+
+- Bun's install speed is real and matters for CI
+- Some Electron native modules need `npm rebuild` semantics — Bun handles this in 1.3+
+- Turbo for task graph + cache; no Nx
+- If Bun bites us on a native module, fall back to pnpm for that workspace

--- a/spec/decisions/0004-spawn-cli-and-sdk.md
+++ b/spec/decisions/0004-spawn-cli-and-sdk.md
@@ -1,0 +1,25 @@
+# ADR 0004: Both spawn-CLI and SDK agent integration
+
+**Status**: Accepted
+
+**Date**: 2026-05-02
+
+## Context
+
+We can integrate agents two ways:
+- **Spawn-CLI**: launch the user's installed `claude` / `codex` in a PTY. Trivial. UI is whatever the CLI shows.
+- **SDK**: use the official client library. Structured events, custom UI, richer UX.
+
+## Decision
+
+Ship both. SDK is the headline experience; spawn-CLI is the always-works fallback.
+
+## Why both
+
+- SDK gives us the differentiated product (live tool-use timeline, permission prompts, resume)
+- Spawn-CLI gives us coverage on day 1 — works for anything the user has installed, including agents we haven't written adapters for
+- Spawn-CLI is essentially free once Phase 1 PTY is done
+
+## Implementation note
+
+Spawn-CLI is not implemented as an adapter — it's a special PTY launch. SDK adapters all conform to the `AgentAdapter` interface so they can be added without touching UI.

--- a/spec/features/agent-integration.md
+++ b/spec/features/agent-integration.md
@@ -1,0 +1,44 @@
+# Feature: Agent integration
+
+Two modes per provider: spawn-CLI (always available if installed) and SDK (structured experience).
+
+## Adapter contract
+
+Every provider implements:
+
+```ts
+interface AgentAdapter {
+  id: AgentId
+  displayName: string
+  detectAvailability(): Effect<AgentAvailability, never>
+  startSession(input: StartSessionInput): Effect<SessionHandle, AgentError>
+}
+
+interface SessionHandle {
+  sessionId: string
+  events: Stream<AgentEvent, AgentError>
+  send(text: string): Effect<void, AgentError>
+  interrupt(): Effect<void>
+  close(): Effect<void>
+}
+```
+
+## Event normalization
+
+All adapters emit the same `AgentEvent` union (see [phases/02-agents.md](../phases/02-agents.md)). UI is provider-agnostic.
+
+## Provider notes
+
+### Claude Code (`@anthropic-ai/claude-agent-sdk`)
+- Native streaming events, native tool-use events — direct map
+- Permission API → our `PermissionRequest` event
+- Resume: supported via session id
+
+### OpenAI Codex
+- Translate streaming responses into `AssistantMessage`
+- Tool use → map to `ToolUse` / `ToolResult`
+- Resume: depends on SDK version; treat as best-effort
+
+## Credentials
+
+`keytar` keyed by `"forkzero:<provider>:apiKey"`. Never logged, never written to disk in plaintext.

--- a/spec/features/folder-management.md
+++ b/spec/features/folder-management.md
@@ -1,0 +1,37 @@
+# Feature: Folder management
+
+The sidebar is the spine of the app. Folders are the unit of work.
+
+## Behavior
+
+- Sidebar lists folders in user-defined order (drag to reorder, Phase 2+)
+- `+` button opens OS folder picker
+- Folders are referenced by absolute path; the `id` is a stable hash of the path
+- Removing a folder from the sidebar does not delete the folder on disk
+- Right-click → Reveal in Finder / Show path / Remove
+
+## Validation when adding
+
+- Reject if path doesn't exist or isn't a directory
+- Reject duplicates (same canonical path)
+- Warn (don't reject) for very large folders (>10k files at top level) — shown as a one-line note, no modal
+
+## Persistence
+
+`userData/workspaces.json`:
+
+```json
+{
+  "version": 1,
+  "folders": [
+    { "id": "ab12...", "path": "/Users/me/code/proj", "name": "proj", "addedAt": "2026-05-02T..." }
+  ],
+  "activeId": "ab12..."
+}
+```
+
+## Edge cases
+
+- Path becomes invalid (folder deleted) — show in sidebar with red dot, disable selection
+- Path moved (basename matches but dir gone) — same as deleted; user removes manually
+- Symlinks — resolve to canonical path before hashing

--- a/spec/features/git-history.md
+++ b/spec/features/git-history.md
@@ -1,0 +1,30 @@
+# Feature: Git history
+
+Always-visible feed of recent commits for the active folder, plus a status summary.
+
+## What we show in Phase 1
+
+- Branch name + dirty file count at top
+- List of last 50 commits: short SHA, subject, author, relative time
+- Click commit → copy SHA (Phase 1); diff viewer (Phase 4)
+
+## How we get the data
+
+Spawn `git` directly:
+
+```
+git -C <folder> log -50 --pretty=format:%H%x00%h%x00%s%x00%an%x00%aI%x00%P
+git -C <folder> status --porcelain=v2 --branch
+```
+
+Parse with simple split on `\x00` and `\n`. No `simple-git` or libgit2.
+
+## Live updates
+
+Poll `git rev-parse HEAD` every 2s on the active folder. If SHA changes, refetch log + status.
+
+## Failure modes
+
+- Folder isn't a git repo: pane shows "Not a git repository" with a "Run `git init`?" button
+- `git` not on PATH: pane shows "Install git to use this feature" with link
+- Repo is in detached HEAD / rebase / merge: status pane shows the state explicitly

--- a/spec/features/terminal.md
+++ b/spec/features/terminal.md
@@ -1,0 +1,26 @@
+# Feature: Terminal
+
+xterm.js renders, node-pty backs it. One terminal per folder in Phase 1; multiple in Phase 4.
+
+## Lifecycle
+
+1. Renderer requests `pty:open` with cols/rows/folderId
+2. Main spawns `node-pty` with `process.env.SHELL ?? '/bin/bash'`, cwd = folder.path
+3. Main returns `ptyId`; renderer subscribes to `pty:output`
+4. On unmount or folder switch, renderer calls `pty:close`; main sends SIGHUP, waits 1s, then SIGKILL
+
+## Resize
+
+Debounced 100ms. Renderer sends `pty:resize` after layout settles.
+
+## Encoding
+
+UTF-8 throughout. Output chunks are passed verbatim — xterm handles ANSI.
+
+## Scrollback
+
+In-memory only in Phase 1. xterm's internal scrollback (default 1000 lines) is the truth. Phase 3 adds optional disk persistence.
+
+## Activity signaling (Phase 2+)
+
+Main maintains a "last output at" timestamp per PTY. Used by sidebar to show a dot when a non-active terminal has output.

--- a/spec/phases/01-foundation.md
+++ b/spec/phases/01-foundation.md
@@ -1,0 +1,149 @@
+# Phase 1 — Foundation
+
+**Goal**: a usable single-user MVP. Pick a folder, run a real shell in it, see the git log of that folder live-updating.
+
+**Status**: 📐 Spec
+
+**Estimate**: ~4 weeks
+
+## Deliverables
+
+1. Folder sidebar with persistence
+2. PTY-backed terminal pane (one terminal per active folder)
+3. Live git history pane
+4. Effect runtime + Layer architecture established in both processes
+5. Typed IPC contracts package
+
+## Out of scope (deferred)
+
+- Multiple terminals per folder (Phase 4)
+- Agent integration (Phase 2)
+- Permission prompts (Phase 3)
+- Diff viewer (Phase 4)
+
+## User scenarios
+
+### S1 — First launch
+> I open the app for the first time. The sidebar is empty with a `+` button and a hint "Add a folder to begin." I click `+`, the OS folder picker opens, I pick `~/code/myproject`. The folder appears in the sidebar, automatically selected. The center pane is a shell with `~/code/myproject` as cwd. The right pane shows the last 50 commits.
+
+### S2 — Restart
+> I quit and reopen. My folder list is preserved. The previously active folder is restored. The terminal starts fresh; it does not try to reattach to the old PTY.
+
+### S3 — Switch folder
+> I have three folders. I click another. The center terminal is replaced with a new shell in that folder. The git pane reloads. The previous folder's terminal is killed.
+
+### S4 — Live git
+> I run `git commit` in the terminal. Within ~1s, the new commit appears at the top of the right pane.
+
+## Architecture decisions for this phase
+
+- **One terminal per folder.** Simpler state. Multi-tab is Phase 4.
+- **No background folders.** Switching folders kills the previous PTY. Avoids resource leaks before we have UI for it.
+- **Polling, not fs-watch, for git.** Poll `git log -1 --format=%H` every 2s on the active folder. Only re-fetch full log when HEAD changes. Cheap, robust, no native dependencies.
+- **PTY scrollback not persisted** in this phase. Phase 3 adds it.
+
+## IPC contracts (in `packages/contracts/`)
+
+```ts
+// workspace.ts
+export const WorkspaceFolder = Schema.Struct({
+  id: Schema.String,             // stable hash of path
+  path: Schema.String,           // absolute
+  name: Schema.String,           // display name (basename by default)
+  addedAt: Schema.Date,
+})
+
+// pty.ts
+export const PtyOpenInput = Schema.Struct({
+  folderId: Schema.String,
+  cols: Schema.Number.pipe(Schema.between(1, 1000)),
+  rows: Schema.Number.pipe(Schema.between(1, 500)),
+})
+export const PtyOutputEvent = Schema.Struct({
+  ptyId: Schema.String,
+  chunk: Schema.String,          // utf-8
+})
+export const PtyExitedEvent = Schema.Struct({
+  ptyId: Schema.String,
+  code: Schema.Number,
+  signal: Schema.optional(Schema.String),
+})
+
+// git.ts
+export const GitCommit = Schema.Struct({
+  sha: Schema.String,
+  shortSha: Schema.String,
+  subject: Schema.String,
+  authorName: Schema.String,
+  authoredAt: Schema.Date,
+  parents: Schema.Array(Schema.String),
+})
+export const GitStatusSummary = Schema.Struct({
+  branch: Schema.optional(Schema.String),
+  ahead: Schema.Number,
+  behind: Schema.Number,
+  dirtyFiles: Schema.Number,
+})
+```
+
+## IPC channels
+
+| Channel | Direction | Input | Output |
+|---|---|---|---|
+| `workspace:list` | renderer → main | none | `WorkspaceFolder[]` |
+| `workspace:add` | renderer → main | `{ path }` | `WorkspaceFolder` |
+| `workspace:remove` | renderer → main | `{ id }` | `void` |
+| `workspace:pickFolder` | renderer → main | none | `string \| null` (cancelable) |
+| `pty:open` | renderer → main | `PtyOpenInput` | `{ ptyId }` |
+| `pty:write` | renderer → main | `{ ptyId, data }` | `void` |
+| `pty:resize` | renderer → main | `{ ptyId, cols, rows }` | `void` |
+| `pty:close` | renderer → main | `{ ptyId }` | `void` |
+| `pty:output` | main → renderer (stream) | `{ ptyId }` | stream of `PtyOutputEvent` |
+| `pty:exited` | main → renderer (stream) | `{ ptyId }` | `PtyExitedEvent` |
+| `git:log` | renderer → main | `{ folderId, limit }` | `GitCommit[]` |
+| `git:status` | renderer → main | `{ folderId }` | `GitStatusSummary` |
+| `git:headChanged` | main → renderer (stream) | `{ folderId }` | `{ sha }` |
+
+## Critical files to create / modify
+
+- **Modify**: `apps/desktop/src/main.ts` — wire `IpcHandlersLayer` into app boot
+- **Modify**: `apps/desktop/src/preload.ts` — typed bridge for all channels above
+- **Create**: `apps/desktop/src/runtime.ts` — Layer composition for main process
+- **Create**: `apps/desktop/src/services/pty/` — `PtyService` Effect Layer
+- **Create**: `apps/desktop/src/services/git/` — `GitService` Effect Layer
+- **Create**: `apps/desktop/src/services/workspace/` — `WorkspaceService` Effect Layer
+- **Create**: `apps/desktop/src/ipc/channels.ts` — channel registration table
+- **Create**: `apps/desktop/src/ipc/handlers.ts` — Layer that registers handlers
+- **Create**: `packages/contracts/` — new package with all schemas above
+- **Modify**: `apps/renderer/src/components/sidebar.tsx` — wire to `workspace:*`
+- **Modify**: `apps/renderer/src/components/terminal-pane.tsx` — replace local echo with PTY
+- **Modify**: `apps/renderer/src/components/git-history-pane.tsx` — replace mock with `git:log`
+- **Create**: `apps/renderer/src/runtime.ts` — renderer Effect runtime
+- **Create**: `apps/renderer/src/store/workspace.ts` — Zustand store
+- **Create**: `apps/renderer/src/lib/desktop.ts` — typed IPC client (extend existing)
+
+## Acceptance criteria
+
+- [ ] Cold-start to terminal-prompt under 2s on M-series
+- [ ] All four user scenarios above pass manually
+- [ ] `bun run typecheck` clean across all packages
+- [ ] Killing a PTY (close folder, quit app) leaves no orphaned `node-pty` processes (verify with `ps`)
+- [ ] Workspace list survives app restart
+- [ ] No `any` in IPC contract files
+- [ ] Effect Layer composition lives in one place per process; no `Effect.runPromise` calls outside the runtime entry points
+
+## Verification
+
+1. `bun install && bun run dev` launches the Electron app
+2. Click `+`, pick a real folder — folder appears in sidebar
+3. Quit, relaunch — folder still there
+4. Type `ls`, `pwd`, `git status` in the terminal; output renders correctly with colors
+5. Right pane shows the actual `git log` output for the folder
+6. Run `git commit --allow-empty -m "test"` in the terminal — new commit appears at top within 2s
+7. `ps aux | rg node-pty` after app quit returns nothing
+
+## Risks
+
+- **Effect learning curve.** Mitigation: Phase 1 uses Effect for service definition + Layer wiring + Schema, but defers Streams across IPC if it bogs down. We can serialize streams as polling in the worst case.
+- **node-pty native build issues.** Mitigation: pin Electron version; use `electron-rebuild` in postinstall.
+- **Vite + Electron preload sandboxing gotchas.** Mitigation: keep preload minimal; do all logic in main.

--- a/spec/phases/02-agents.md
+++ b/spec/phases/02-agents.md
@@ -1,0 +1,129 @@
+# Phase 2 — Agents
+
+**Goal**: running an agent in a folder is a first-class action. Two modes: spawn the CLI in the terminal (works for everything) or use the SDK with a structured side panel.
+
+**Status**: 📐 Spec
+
+**Estimate**: ~4 weeks
+
+**Depends on**: Phase 1
+
+## Deliverables
+
+1. Detect installed `claude` and `codex` CLIs (PATH lookup + version check)
+2. Sidebar action: "Run agent here" → menu of detected agents → spawn in terminal
+3. Claude Code SDK adapter (Effect Service)
+4. OpenAI Codex SDK adapter (Effect Service)
+5. Agent side panel: streaming events, tool calls, file writes, status
+6. Provider switcher per session
+7. Credential management via OS keychain (`keytar`)
+
+## User scenarios
+
+### S1 — Spawn-CLI quick start
+> I have a folder open. I press `Cmd+K`, type "claude", hit enter. A new terminal opens (or current terminal if empty) and runs `claude` with cwd set to the folder. From here it's whatever the CLI does.
+
+### S2 — SDK-integrated session
+> I click "New agent session" → "Claude Code (SDK)". A side panel opens to the right of the terminal showing: status (idle/running/waiting), a live stream of tool calls (Read, Edit, Bash), each expandable. The terminal is still there for me to type in alongside.
+
+### S3 — Provider switch
+> Mid-session I want to try Codex on the same prompt. I click the provider chip → "Codex". Current session stays in history; a new session starts with the same opening prompt.
+
+### S4 — Missing credentials
+> I select Claude SDK but I haven't set up an API key. The panel shows a "Set API key" button that opens a settings sheet. Key is stored via `keytar`.
+
+## Architecture
+
+**Adapter pattern** for agents. Each provider implements the same interface:
+
+```ts
+interface AgentAdapter {
+  readonly id: "claude" | "codex"
+  readonly displayName: string
+  detectAvailability: Effect<AgentAvailability, AgentError>
+  startSession(input: StartSessionInput): Effect<AgentSession, AgentError>
+  // AgentSession exposes: events: Stream<AgentEvent>, sendMessage, interrupt, close
+}
+```
+
+**Spawn-CLI** is not an adapter — it's just a special PTY launch with a known argv. Lives in `services/agent/spawn.ts`.
+
+**SDK adapters** wrap the official SDK in an Effect Service. They translate SDK callbacks/streams into a uniform `AgentEvent` discriminated union:
+
+```ts
+type AgentEvent =
+  | { _tag: "Started"; sessionId: string }
+  | { _tag: "AssistantMessage"; text: string }
+  | { _tag: "ToolUse"; tool: string; input: unknown; id: string }
+  | { _tag: "ToolResult"; id: string; output: unknown; isError: boolean }
+  | { _tag: "PermissionRequest"; kind: PermissionKind; details: unknown }  // Phase 3
+  | { _tag: "Completed"; reason: "ended" | "interrupted" | "error" }
+  | { _tag: "Error"; cause: AgentError }
+```
+
+## IPC contracts
+
+```ts
+// agent.ts (in packages/contracts)
+export const AgentAvailability = Schema.Struct({
+  id: Schema.Literal("claude", "codex"),
+  cliInstalled: Schema.Boolean,
+  cliVersion: Schema.optional(Schema.String),
+  sdkConfigured: Schema.Boolean,    // credentials present
+})
+
+export const StartSessionInput = Schema.Struct({
+  folderId: Schema.String,
+  provider: Schema.Literal("claude", "codex"),
+  mode: Schema.Literal("spawn-cli", "sdk"),
+  initialPrompt: Schema.optional(Schema.String),
+})
+```
+
+## IPC channels (additions)
+
+| Channel | Direction | Notes |
+|---|---|---|
+| `agent:availability` | renderer → main | Returns `AgentAvailability[]` |
+| `agent:start` | renderer → main | Returns `{ sessionId }` |
+| `agent:send` | renderer → main | `{ sessionId, text }` |
+| `agent:interrupt` | renderer → main | `{ sessionId }` |
+| `agent:close` | renderer → main | `{ sessionId }` |
+| `agent:events` | main → renderer (stream) | per-session event stream |
+| `agent:setCredential` | renderer → main | `{ provider, key }` — writes to keychain |
+
+## New files
+
+- `apps/desktop/src/services/agent/`
+  - `availability.ts` — PATH lookup, version probe
+  - `spawn.ts` — spawn-CLI launcher
+  - `claude.ts` — Claude SDK adapter (Effect Service)
+  - `codex.ts` — Codex SDK adapter (Effect Service)
+  - `events.ts` — `AgentEvent` schema + serialization
+  - `credentials.ts` — `keytar` wrapper as Effect Service
+- `apps/renderer/src/components/agent-panel.tsx` — side panel
+- `apps/renderer/src/components/agent-event-row.tsx` — one event row
+- `apps/renderer/src/components/agent-launcher.tsx` — Cmd+K launcher
+
+## Acceptance criteria
+
+- [ ] On a machine with `claude` in PATH, "Run agent here" → "Claude (CLI)" launches it in the active folder's terminal
+- [ ] On a machine without `claude` installed, the menu item is grayed out with "Install Claude Code" link
+- [ ] Starting an SDK session streams `AssistantMessage` events to the panel within 2s of API response
+- [ ] Tool-use events render with the tool name and a collapsed JSON input; click to expand
+- [ ] Interrupting a session stops streaming within 500ms
+- [ ] Credentials never appear in process listings, logs, or NDJSON transcripts
+- [ ] Switching provider mid-conversation starts a new session, preserves the old one in the sessions list
+
+## Verification
+
+1. Spawn-CLI: with `claude` installed, full flow works
+2. SDK: with `ANTHROPIC_API_KEY` set in keychain, ask "list files in this folder" → see Read tool calls stream in
+3. Repeat with Codex SDK
+4. Quit during an active SDK session — no orphan processes; restart shows session in history (Phase 3 makes it resumable)
+
+## Risks
+
+- **SDK API changes.** Both SDKs are pre-1.0. Pin versions; wrap in adapter so updates are localized.
+- **Long-running streams across IPC.** Mitigation: chunked JSON over IPC with backpressure (Effect Stream → IPC frames).
+- **Permission prompts come from the SDK before Phase 3 ships.** For Phase 2 we auto-deny anything dangerous and surface a "Phase 3 will let you allow this" toast.

--- a/spec/phases/03-permissions-and-sessions.md
+++ b/spec/phases/03-permissions-and-sessions.md
@@ -1,0 +1,70 @@
+# Phase 3 — Permissions & sessions
+
+**Goal**: agents become trustworthy enough to leave running unattended.
+
+**Status**: 📐 Spec
+
+**Estimate**: ~2 weeks
+
+**Depends on**: Phase 2
+
+## Deliverables
+
+1. Permission prompt UI: file write, command exec, network access
+2. Per-session "always allow" memory
+3. Session persistence — full transcript saved as NDJSON
+4. Resume: relaunch app, click a stopped session, continue from where it ended (where SDK supports it)
+5. Sessions list view per folder
+
+## User scenarios
+
+### S1 — Permission prompt
+> Agent wants to run `npm install`. A toast appears at the top of the agent panel: "Run `npm install`?" with buttons: Allow once / Allow for this session / Deny. I pick "Allow for this session" — same command later in the same session doesn't re-prompt.
+
+### S2 — Restart resume
+> I'm mid-task, app crashes (or I quit). I reopen. The folder shows a "Resumable session" badge. I click it. The transcript loads. I send a new message; the SDK resumes from the last cursor.
+
+### S3 — Audit trail
+> I want to know what an agent did last week. I open the folder, click the sessions list, pick a date. Full transcript is there. I click any tool-use to see exact arguments and results.
+
+## Storage layout
+
+```
+userData/
+  sessions/
+    <folder-id>/
+      <session-id>.meta.json      # provider, started, ended, status, model, cursor
+      <session-id>.events.ndjson  # one AgentEvent per line
+      <session-id>.permissions.json # session-scoped allow list
+```
+
+## Permission model
+
+```ts
+type PermissionKind =
+  | { _tag: "FileWrite"; path: string }
+  | { _tag: "Bash"; command: string }
+  | { _tag: "Network"; url: string }
+
+type PermissionDecision =
+  | { _tag: "AllowOnce" }
+  | { _tag: "AllowForSession" }
+  | { _tag: "Deny" }
+  | { _tag: "AlwaysAllow"; scope: "folder" | "global" }   // future
+```
+
+For Phase 3 only `AllowOnce`, `AllowForSession`, `Deny` are exposed. `AlwaysAllow` is plumbing only, no UI yet.
+
+## Acceptance criteria
+
+- [ ] Permission prompts block agent execution until decided (no race conditions)
+- [ ] "Allow for session" is honored for exact-match commands; near-matches re-prompt
+- [ ] Crash recovery: kill -9 the app mid-session, relaunch, transcript is intact
+- [ ] Resume works for Claude SDK (verify cursor handling)
+- [ ] Resume falls back gracefully for Codex if SDK lacks resume — shows "Session ended, start new"
+- [ ] NDJSON transcript size capped (rotate at 100MB per session)
+
+## Risks
+
+- **Permission prompt UX is hard to get right.** Mitigation: copy patterns from existing CLI permission flows; iterate after dogfooding.
+- **Cursor/resume semantics differ across SDKs.** Mitigation: explicit `ResumeStrategy` per adapter, with "no resume" as a valid value.

--- a/spec/phases/04-polish-and-distribution.md
+++ b/spec/phases/04-polish-and-distribution.md
@@ -1,0 +1,36 @@
+# Phase 4 — Polish & distribution
+
+**Goal**: ship a 1.0 that someone other than you would happily install.
+
+**Status**: 📐 Spec
+
+**Estimate**: ~3 weeks
+
+**Depends on**: Phase 3
+
+## Deliverables
+
+1. Multiple terminals per folder (tab strip)
+2. Git diff viewer (per-commit + working tree)
+3. Branch indicator + simple branch switcher
+4. Themes (light + dark + one accent)
+5. Keybindings, listed in a discoverable cheat sheet
+6. Auto-update via electron-updater
+7. macOS code signing + notarization
+8. Linux AppImage build
+9. Windows installer (signed if budget allows)
+10. Public landing page + install instructions
+
+## Acceptance criteria
+
+- [ ] Cmd+T opens new terminal tab in active folder
+- [ ] Click any commit in git pane → diff viewer with file tree + side-by-side diff
+- [ ] Branch indicator shows current branch + dirty state in folder sidebar
+- [ ] Theme switch is instant (no flash)
+- [ ] Auto-update prompts on app start when update available
+- [ ] Notarized DMG installs cleanly on a fresh macOS
+
+## Risks
+
+- **Notarization is fiddly.** Mitigation: use `electron-notarize` and a CI workflow with Apple credentials in secrets.
+- **Diff viewer scope creep.** Mitigation: use an existing component (e.g. react-diff-view) — do not write our own.

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -1,0 +1,60 @@
+# Roadmap
+
+Estimates assume a single developer, ~6 productive hours/day, with a capable LLM pair-programmer. **Add 30% to anything Effect-touching while learning** — these estimates already include that headroom.
+
+## Phase 1 — Foundation (≈4 weeks)
+
+Make the scaffold real. By the end you can pick a folder, run a real shell in it, and watch the git history update as you commit.
+
+- Folder sidebar with `+` button and persistence
+- Real PTY terminal per folder (one terminal per folder in this phase)
+- Real `git log` + status pane
+- Effect runtime + Layer architecture in both processes
+- Typed IPC contracts in `packages/contracts`
+
+→ See [phases/01-foundation.md](phases/01-foundation.md)
+
+## Phase 2 — Agents (≈4 weeks)
+
+The headline. Run Claude Code / Codex as either a spawned CLI in the terminal (cheap fallback) or via SDK with a structured side panel showing tool calls and proposed edits.
+
+- Detect installed `claude` / `codex` CLIs; one-click "run in this folder"
+- Claude Code SDK adapter with streaming events
+- Codex SDK adapter
+- Tool-call timeline UI alongside the terminal
+- Agent provider switcher per session
+
+→ See [phases/02-agents.md](phases/02-agents.md)
+
+## Phase 3 — Permissions & sessions (≈2 weeks)
+
+Make agents trustworthy enough to leave running.
+
+- Permission prompts: file write, command run, network access
+- Per-session "always allow X" memory
+- Session persistence + resume across app restart
+- Agent run transcripts (NDJSON) for replay/audit
+
+→ See [phases/03-permissions-and-sessions.md](phases/03-permissions-and-sessions.md)
+
+## Phase 4 — Polish & distribution (≈3 weeks)
+
+Make it shippable.
+
+- Multiple terminals per folder (tabs)
+- Git diff viewer (per commit, vs working tree)
+- Branch indicator + switcher
+- Themes + keybindings
+- Auto-update via electron-updater
+- macOS signing & notarization (Linux + Windows packaging follow)
+
+→ See [phases/04-polish-and-distribution.md](phases/04-polish-and-distribution.md)
+
+## Total
+
+| Milestone | Calendar |
+|---|---|
+| Personal-use MVP (Phase 1) | ~4 weeks |
+| Public alpha (Phases 1–2) | ~8 weeks |
+| Public beta (Phases 1–3) | ~10 weeks |
+| 1.0 (Phases 1–4) | **~3–4 months** |

--- a/spec/vision.md
+++ b/spec/vision.md
@@ -1,0 +1,36 @@
+# Vision
+
+## What forkzero is
+
+A desktop app where coding agents are first-class citizens. The terminal is the main canvas. You add folders to a sidebar, open one, and either type into the terminal yourself or hand the keyboard to an agent. Git history of the open project is always visible alongside.
+
+## What forkzero is not
+
+- Not a full IDE. We do not own the editor surface — open files in your editor of choice.
+- Not a chat app. Conversations happen inside terminals or agent panels, not in a separate "chat" UI.
+- Not cloud. Everything runs on the user's machine; agent credentials stay local.
+- Not multi-user / collaborative. Single-user desktop tool.
+
+## Target user
+
+A developer who:
+- Already uses Claude Code / Codex CLI from a terminal
+- Wants to run agents in parallel across multiple repos without juggling tmux panes
+- Wants to see what the agent did (git diff, log) without leaving the app
+- Is comfortable with the command line — we optimize for keyboard, not mouse
+
+## Principles
+
+1. **Terminal first.** Every feature must coexist with "I just want to type into a shell." Don't hide the prompt behind UI.
+2. **Local by default.** No telemetry without an explicit opt-in. No cloud features in v1.
+3. **Open formats.** Sessions, history, and config stored as files a user can read and back up.
+4. **One way to do each thing.** Resist configuration sprawl; pick a default, document the why.
+5. **Boring tech where possible.** Effect.ts is the one ambitious choice — everything else is the obvious option.
+
+## Non-goals (v1)
+
+- Plugin/extension system
+- Multiple windows or detachable panes
+- Remote / SSH workspaces
+- Built-in code editor
+- Cloud sync of sessions


### PR DESCRIPTION
## Summary

- Establishes `spec/` as the project's living specification: vision, architecture, 4-phase roadmap, per-feature deep-dives, and 4 ADRs
- Locks in the stack: Electron + React 19 + Effect.ts from day 1 + Bun/Turbo monorepo, with both spawn-CLI and SDK-integrated agent modes for Claude Code and Codex
- No code changes — this is the design contract that subsequent phase PRs will implement

## Test plan

- [ ] Skim `spec/README.md` → `vision.md` → `roadmap.md` → `phases/01-foundation.md` to confirm the docs read top-down
- [ ] Confirm Phase 1 IPC contracts and channel table match the intended surface before implementation starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)