### PR TITLE
phase 1 / pr 4: PtyService + real terminal (one PTY per folder)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,8 @@
     "dev:bundle": "tsdown --watch",
     "dev:electron": "node scripts/dev-electron.mjs",
     "build": "tsdown",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "postinstall": "electron-rebuild -f -w node-pty"
   },
   "dependencies": {
     "@effect/platform": "catalog:",
@@ -16,9 +17,11 @@
     "@effect/rpc": "catalog:",
     "@forkzero/wire": "*",
     "effect": "catalog:",
-    "electron": "^33.2.0"
+    "electron": "^33.2.0",
+    "node-pty": "^1.1.0"
   },
   "devDependencies": {
+    "@electron/rebuild": "^4.0.4",
     "@repo/typescript-config": "*",
     "@types/node": "catalog:",
     "tsdown": "^0.21.10",

--- a/apps/desktop/src/runtime.ts
+++ b/apps/desktop/src/runtime.ts
@@ -8,6 +8,8 @@ import { ForkzeroRpcs } from "@forkzero/wire";
 import { AppPaths } from "./app-paths.ts";
 import { electronServerProtocolLayer } from "./ipc/electron-server-protocol.ts";
 import { PingHandlersLayer } from "./services/ping/handlers.ts";
+import { PtyHandlersLayer } from "./services/pty/pty-handlers.ts";
+import { PtyService } from "./services/pty/pty-service.ts";
 import { WorkspaceHandlersLayer } from "./services/workspace/workspace-handlers.ts";
 import { WorkspaceService } from "./services/workspace/workspace-service.ts";
 
@@ -33,7 +35,8 @@ export const makeMainLayer = (webContents: WebContents, userData: string) => {
   const HandlersLayer = Layer.mergeAll(
     PingHandlersLayer,
     WorkspaceHandlersLayer,
-  ).pipe(Layer.provide(WorkspaceLayer));
+    PtyHandlersLayer,
+  ).pipe(Layer.provide(WorkspaceLayer), Layer.provide(PtyService.Default));
 
   const ServerLayer = RpcServer.layer(ForkzeroRpcs).pipe(
     Layer.provide(HandlersLayer),

--- a/apps/desktop/src/services/pty/pty-handlers.ts
+++ b/apps/desktop/src/services/pty/pty-handlers.ts
@@ -1,0 +1,34 @@
+import { ForkzeroRpcs } from "@forkzero/wire";
+import { Effect, Layer, Stream } from "effect";
+
+import { PtyService } from "./pty-service.ts";
+
+const Open = ForkzeroRpcs.toLayerHandler("pty.open", ({ cwd, cols, rows }) =>
+  Effect.flatMap(PtyService, (svc) => svc.open(cwd, cols, rows)),
+);
+
+const Write = ForkzeroRpcs.toLayerHandler("pty.write", ({ ptyId, data }) =>
+  Effect.flatMap(PtyService, (svc) => svc.write(ptyId, data)),
+);
+
+const Resize = ForkzeroRpcs.toLayerHandler(
+  "pty.resize",
+  ({ ptyId, cols, rows }) =>
+    Effect.flatMap(PtyService, (svc) => svc.resize(ptyId, cols, rows)),
+);
+
+const Close = ForkzeroRpcs.toLayerHandler("pty.close", ({ ptyId }) =>
+  Effect.flatMap(PtyService, (svc) => svc.close(ptyId)),
+);
+
+const Output = ForkzeroRpcs.toLayerHandler("pty.output", ({ ptyId }) =>
+  Stream.unwrap(Effect.map(PtyService, (svc) => svc.subscribe(ptyId))),
+);
+
+export const PtyHandlersLayer = Layer.mergeAll(
+  Open,
+  Write,
+  Resize,
+  Close,
+  Output,
+);

--- a/apps/desktop/src/services/pty/pty-service.ts
+++ b/apps/desktop/src/services/pty/pty-service.ts
@@ -1,0 +1,151 @@
+import * as pty from "node-pty";
+import { Effect, Exit, Mailbox, Ref, Stream } from "effect";
+
+import {
+  PtyDataEvent,
+  PtyExitEvent,
+  PtyId,
+  PtyNotFoundError,
+  PtySpawnError,
+  type PtyEvent,
+} from "@forkzero/wire";
+
+interface ActivePty {
+  readonly pty: pty.IPty;
+  readonly mailbox: Mailbox.Mailbox<typeof PtyEvent.Type, PtyNotFoundError>;
+}
+
+const defaultShell = (): string => {
+  if (process.platform === "win32") {
+    return process.env.COMSPEC ?? "cmd.exe";
+  }
+  return process.env.SHELL ?? "/bin/bash";
+};
+
+export class PtyService extends Effect.Service<PtyService>()(
+  "forkzero/PtyService",
+  {
+    effect: Effect.gen(function* () {
+      const ref = yield* Ref.make<ReadonlyMap<PtyId, ActivePty>>(new Map());
+
+      const open = (
+        cwd: string,
+        cols: number,
+        rows: number,
+      ): Effect.Effect<{ ptyId: PtyId }, PtySpawnError> =>
+        Effect.gen(function* () {
+          const id = PtyId.make(crypto.randomUUID());
+
+          const mailbox = yield* Mailbox.make<
+            typeof PtyEvent.Type,
+            PtyNotFoundError
+          >();
+
+          const child = yield* Effect.try({
+            try: () =>
+              pty.spawn(defaultShell(), [], {
+                name: "xterm-256color",
+                cols,
+                rows,
+                cwd,
+                env: {
+                  ...(process.env as Record<string, string>),
+                  TERM: "xterm-256color",
+                },
+              }),
+            catch: (err) =>
+              new PtySpawnError({
+                reason: err instanceof Error ? err.message : String(err),
+              }),
+          });
+
+          child.onData((bytes) => {
+            mailbox.unsafeOffer(PtyDataEvent.make({ bytes }));
+          });
+
+          child.onExit(({ exitCode, signal }) => {
+            mailbox.unsafeOffer(
+              PtyExitEvent.make({
+                exitCode: exitCode ?? null,
+                signal: signal ?? null,
+              }),
+            );
+            mailbox.unsafeDone(Exit.void);
+            Effect.runSync(
+              Ref.update(ref, (m) => {
+                const next = new Map(m);
+                next.delete(id);
+                return next;
+              }),
+            );
+          });
+
+          yield* Ref.update(ref, (m) => {
+            const next = new Map(m);
+            next.set(id, { pty: child, mailbox });
+            return next;
+          });
+
+          return { ptyId: id };
+        });
+
+      const getActive = (
+        ptyId: PtyId,
+      ): Effect.Effect<ActivePty, PtyNotFoundError> =>
+        Effect.flatMap(Ref.get(ref), (m) => {
+          const active = m.get(ptyId);
+          return active === undefined
+            ? Effect.fail(new PtyNotFoundError({ ptyId }))
+            : Effect.succeed(active);
+        });
+
+      const write = (
+        ptyId: PtyId,
+        data: string,
+      ): Effect.Effect<void, PtyNotFoundError> =>
+        Effect.flatMap(getActive(ptyId), ({ pty: child }) =>
+          Effect.sync(() => child.write(data)),
+        );
+
+      const resize = (
+        ptyId: PtyId,
+        cols: number,
+        rows: number,
+      ): Effect.Effect<void, PtyNotFoundError> =>
+        Effect.flatMap(getActive(ptyId), ({ pty: child }) =>
+          Effect.sync(() => {
+            try {
+              child.resize(Math.max(1, cols), Math.max(1, rows));
+            } catch {
+              // pty may have exited between the renderer's last render and
+              // this resize call — safe to ignore.
+            }
+          }),
+        );
+
+      const close = (
+        ptyId: PtyId,
+      ): Effect.Effect<void, PtyNotFoundError> =>
+        Effect.flatMap(getActive(ptyId), ({ pty: child }) =>
+          Effect.sync(() => {
+            try {
+              child.kill();
+            } catch {
+              // already dead
+            }
+          }),
+        );
+
+      const subscribe = (
+        ptyId: PtyId,
+      ): Stream.Stream<typeof PtyEvent.Type, PtyNotFoundError> =>
+        Stream.unwrap(
+          Effect.map(getActive(ptyId), ({ mailbox }) =>
+            Mailbox.toStream(mailbox),
+          ),
+        );
+
+      return { open, write, resize, close, subscribe } as const;
+    }),
+  },
+) {}

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -5,8 +5,15 @@ import { FolderSidebar } from "./components/folder-sidebar";
 import { TerminalPane } from "./components/terminal-pane";
 import { GitHistoryPane } from "./components/git-history-pane";
 import { getRpcClient } from "./lib/rpc-client.ts";
+import { useWorkspaceStore } from "./store/workspace.ts";
 
 export function App() {
+  const folders = useWorkspaceStore((s) => s.folders);
+  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
+  const selected = selectedFolderId
+    ? (folders.find((f) => f.id === selectedFolderId) ?? null)
+    : null;
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -32,7 +39,9 @@ export function App() {
       <FolderSidebar />
       <main className="flex min-w-0 flex-col border-x border-[var(--color-border)]">
         <header className="flex h-9 items-center px-3 text-xs text-[var(--color-fg-muted)] [-webkit-app-region:drag]">
-          <span className="ml-16 select-none">main · scratch session</span>
+          <span className="ml-16 select-none truncate" title={selected?.path}>
+            {selected ? selected.name : "no folder selected"}
+          </span>
         </header>
         <div className="min-h-0 flex-1">
           <TerminalPane />

--- a/apps/renderer/src/components/folder-sidebar.tsx
+++ b/apps/renderer/src/components/folder-sidebar.tsx
@@ -5,11 +5,13 @@ import { useWorkspaceStore } from "../store/workspace.ts";
 
 export function FolderSidebar() {
   const folders = useWorkspaceStore((s) => s.folders);
+  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
   const error = useWorkspaceStore((s) => s.error);
   const loading = useWorkspaceStore((s) => s.loading);
   const load = useWorkspaceStore((s) => s.load);
   const add = useWorkspaceStore((s) => s.add);
   const remove = useWorkspaceStore((s) => s.remove);
+  const select = useWorkspaceStore((s) => s.select);
 
   useEffect(() => {
     void load();
@@ -44,30 +46,57 @@ export function FolderSidebar() {
             No folders yet. Click + to add one.
           </li>
         )}
-        {folders.map((folder) => (
-          <li key={folder.id}>
-            <div className="group flex items-center gap-2 rounded px-2 py-1.5 hover:bg-[var(--color-border)]/60">
-              <FolderIcon className="size-3.5 shrink-0 text-[var(--color-fg-muted)]" />
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-sm">{folder.name}</div>
-                <div
-                  className="truncate text-[11px] text-[var(--color-fg-muted)]"
-                  title={folder.path}
-                >
-                  {folder.path}
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => void remove(folder.id)}
-                className="rounded p-0.5 text-[var(--color-fg-muted)] opacity-0 hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] group-hover:opacity-100"
-                aria-label={`Remove ${folder.name}`}
+        {folders.map((folder) => {
+          const isSelected = folder.id === selectedFolderId;
+          return (
+            <li key={folder.id}>
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => select(folder.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    select(folder.id);
+                  }
+                }}
+                className={`group flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 ${
+                  isSelected
+                    ? "bg-[var(--color-border)]"
+                    : "hover:bg-[var(--color-border)]/60"
+                }`}
               >
-                <X className="size-3.5" />
-              </button>
-            </div>
-          </li>
-        ))}
+                <FolderIcon
+                  className={`size-3.5 shrink-0 ${
+                    isSelected
+                      ? "text-[var(--color-fg)]"
+                      : "text-[var(--color-fg-muted)]"
+                  }`}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm">{folder.name}</div>
+                  <div
+                    className="truncate text-[11px] text-[var(--color-fg-muted)]"
+                    title={folder.path}
+                  >
+                    {folder.path}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void remove(folder.id);
+                  }}
+                  className="rounded p-0.5 text-[var(--color-fg-muted)] opacity-0 hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] group-hover:opacity-100"
+                  aria-label={`Remove ${folder.name}`}
+                >
+                  <X className="size-3.5" />
+                </button>
+              </div>
+            </li>
+          );
+        })}
       </ul>
     </aside>
   );

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -1,8 +1,33 @@
 import { useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { Effect, Fiber, Stream } from "effect";
+
+import type { Folder, PtyId } from "@forkzero/wire";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
+import { useWorkspaceStore } from "../store/workspace.ts";
 
 export function TerminalPane() {
+  const folders = useWorkspaceStore((s) => s.folders);
+  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
+  const selected = selectedFolderId
+    ? (folders.find((f) => f.id === selectedFolderId) ?? null)
+    : null;
+
+  if (selected === null) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-[var(--color-bg)] text-sm text-[var(--color-fg-muted)]">
+        No folder selected. Add or pick a folder on the left.
+      </div>
+    );
+  }
+
+  // Force a fresh PTY when the folder changes by keying on folder.id.
+  return <PtyTerminal key={selected.id} folder={selected} />;
+}
+
+function PtyTerminal({ folder }: { folder: Folder }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -15,7 +40,7 @@ export function TerminalPane() {
       fontSize: 13,
       lineHeight: 1.3,
       cursorBlink: true,
-      convertEol: true,
+      convertEol: false,
       theme: {
         background: "#0b0b0c",
         foreground: "#e6e6e6",
@@ -28,24 +53,11 @@ export function TerminalPane() {
     term.open(container);
     fit.fit();
 
-    term.writeln("\x1b[38;5;111mzurich\x1b[0m  terminal-for-agents · scaffolding build");
-    term.writeln("type to echo locally — PTY wiring lands in the next plan");
-    term.write("\r\n$ ");
-
-    // Local echo so we can prove the terminal works end-to-end before PTY
-    // wiring exists. Remove once node-pty is bridged in.
-    const onData = term.onData((data) => {
-      for (const ch of data) {
-        const code = ch.charCodeAt(0);
-        if (code === 13) {
-          term.write("\r\n$ ");
-        } else if (code === 127) {
-          term.write("\b \b");
-        } else {
-          term.write(ch);
-        }
-      }
-    });
+    let cancelled = false;
+    let ptyId: PtyId | null = null;
+    let dataDisposable: { dispose: () => void } | null = null;
+    let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
+    let resizeTimer: number | null = null;
 
     const observer = new ResizeObserver(() => {
       try {
@@ -56,12 +68,102 @@ export function TerminalPane() {
     });
     observer.observe(container);
 
+    void (async () => {
+      try {
+        const client = await getRpcClient();
+        if (cancelled) return;
+
+        const { ptyId: id } = await Effect.runPromise(
+          client.pty.open({
+            cwd: folder.path,
+            cols: term.cols,
+            rows: term.rows,
+          }),
+        );
+        if (cancelled) {
+          void Effect.runPromise(client.pty.close({ ptyId: id }));
+          return;
+        }
+        ptyId = id;
+
+        // Pump output stream into xterm.
+        streamFiber = Effect.runFork(
+          Stream.runForEach(client.pty.output({ ptyId: id }), (event) =>
+            Effect.sync(() => {
+              if (event._tag === "data") {
+                term.write(event.bytes);
+              } else {
+                const note =
+                  event.exitCode === null
+                    ? "[process exited]"
+                    : `[process exited with code ${event.exitCode}]`;
+                term.write(`\r\n\x1b[38;5;244m${note}\x1b[0m\r\n`);
+              }
+            }),
+          ),
+        );
+
+        // Forward keystrokes to the pty.
+        dataDisposable = term.onData((data) => {
+          void Effect.runPromise(client.pty.write({ ptyId: id, data })).catch(
+            () => {
+              // pty exited; ignore
+            },
+          );
+        });
+
+        // Send debounced resizes.
+        const sendResize = () => {
+          if (ptyId === null) return;
+          void Effect.runPromise(
+            client.pty.resize({ ptyId, cols: term.cols, rows: term.rows }),
+          ).catch(() => {
+            // ignore
+          });
+        };
+        const onTermResize = term.onResize(() => {
+          if (resizeTimer !== null) window.clearTimeout(resizeTimer);
+          resizeTimer = window.setTimeout(sendResize, 100);
+        });
+        // Also tie the disposable cleanup chain.
+        const prevDispose = dataDisposable.dispose.bind(dataDisposable);
+        dataDisposable = {
+          dispose: () => {
+            prevDispose();
+            onTermResize.dispose();
+          },
+        };
+      } catch (err) {
+        if (cancelled) return;
+        // eslint-disable-next-line no-console
+        console.error("[forkzero] failed to open pty:", err);
+        term.write(
+          "\r\n\x1b[38;5;203mfailed to open terminal — see devtools console\x1b[0m\r\n",
+        );
+      }
+    })();
+
     return () => {
+      cancelled = true;
       observer.disconnect();
-      onData.dispose();
+      dataDisposable?.dispose();
+      if (streamFiber !== null) {
+        void Effect.runPromise(Fiber.interrupt(streamFiber));
+      }
+      if (resizeTimer !== null) window.clearTimeout(resizeTimer);
+      if (ptyId !== null) {
+        const id = ptyId;
+        void getRpcClient().then((client) =>
+          Effect.runPromise(client.pty.close({ ptyId: id })).catch(() => {
+            // already closed
+          }),
+        );
+      }
       term.dispose();
     };
-  }, []);
+  }, [folder.id, folder.path]);
 
-  return <div ref={containerRef} className="h-full w-full bg-[var(--color-bg)] p-2" />;
+  return (
+    <div ref={containerRef} className="h-full w-full bg-[var(--color-bg)] p-2" />
+  );
 }

--- a/apps/renderer/src/store/workspace.ts
+++ b/apps/renderer/src/store/workspace.ts
@@ -7,11 +7,13 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 
 type WorkspaceState = {
   folders: ReadonlyArray<Folder>;
+  selectedFolderId: FolderId | null;
   loading: boolean;
   error: string | null;
   load: () => Promise<void>;
   add: () => Promise<void>;
   remove: (folderId: FolderId) => Promise<void>;
+  select: (folderId: FolderId) => void;
 };
 
 const formatError = (err: unknown): string => {
@@ -22,8 +24,9 @@ const formatError = (err: unknown): string => {
   return String(err);
 };
 
-export const useWorkspaceStore = create<WorkspaceState>((set) => ({
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   folders: [],
+  selectedFolderId: null,
   loading: false,
   error: null,
   load: async () => {
@@ -31,7 +34,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
     try {
       const client = await getRpcClient();
       const folders = await Effect.runPromise(client.workspace.list({}));
-      set({ folders, loading: false });
+      // Auto-select the first folder if nothing is selected yet.
+      const { selectedFolderId } = get();
+      const selected =
+        selectedFolderId !== null &&
+        folders.some((f) => f.id === selectedFolderId)
+          ? selectedFolderId
+          : (folders[0]?.id ?? null);
+      set({ folders, selectedFolderId: selected, loading: false });
     } catch (err) {
       set({ error: formatError(err), loading: false });
     }
@@ -43,7 +53,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
       const path = await Effect.runPromise(client.workspace.pickFolder({}));
       if (path === null) return;
       const folder = await Effect.runPromise(client.workspace.add({ path }));
-      set((s) => ({ folders: [...s.folders, folder] }));
+      set((s) => ({
+        folders: [...s.folders, folder],
+        selectedFolderId: folder.id,
+      }));
     } catch (err) {
       set({ error: formatError(err) });
     }
@@ -53,9 +66,17 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
     try {
       const client = await getRpcClient();
       await Effect.runPromise(client.workspace.remove({ folderId }));
-      set((s) => ({ folders: s.folders.filter((f) => f.id !== folderId) }));
+      set((s) => {
+        const folders = s.folders.filter((f) => f.id !== folderId);
+        const selectedFolderId =
+          s.selectedFolderId === folderId
+            ? (folders[0]?.id ?? null)
+            : s.selectedFolderId;
+        return { folders, selectedFolderId };
+      });
     } catch (err) {
       set({ error: formatError(err) });
     }
   },
+  select: (folderId) => set({ selectedFolderId: folderId }),
 }));

--- a/bun.lock
+++ b/bun.lock
@@ -20,8 +20,10 @@
         "@forkzero/wire": "*",
         "effect": "catalog:",
         "electron": "^33.2.0",
+        "node-pty": "^1.1.0",
       },
       "devDependencies": {
+        "@electron/rebuild": "^4.0.4",
         "@repo/typescript-config": "*",
         "@types/node": "catalog:",
         "tsdown": "^0.21.10",
@@ -202,6 +204,8 @@
 
     "@electron/get": ["@electron/get@2.0.3", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ=="],
 
+    "@electron/rebuild": ["@electron/rebuild@4.0.4", "", { "dependencies": { "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.1.1", "node-abi": "^4.2.0", "node-api-version": "^0.2.1", "node-gyp": "^12.2.0", "read-binary-file-arch": "^1.0.6" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -340,6 +344,8 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -349,6 +355,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -618,6 +626,8 @@
 
     "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 
+    "abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -683,6 +693,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
@@ -803,6 +815,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
@@ -1040,6 +1054,10 @@
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
@@ -1054,13 +1072,23 @@
 
     "next": ["next@16.2.0", "", { "dependencies": { "@next/env": "16.2.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.0", "@next/swc-darwin-x64": "16.2.0", "@next/swc-linux-arm64-gnu": "16.2.0", "@next/swc-linux-arm64-musl": "16.2.0", "@next/swc-linux-x64-gnu": "16.2.0", "@next/swc-linux-x64-musl": "16.2.0", "@next/swc-win32-arm64-msvc": "16.2.0", "@next/swc-win32-x64-msvc": "16.2.0", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NLBVrJy1pbV1Yn00L5sU4vFyAHt5XuSjzrNyFnxo6Com0M0KrL6hHM5B99dbqXb2bE9pm4Ow3Zl1xp6HVY9edQ=="],
 
+    "node-abi": ["node-abi@4.29.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-bGc7hHz6lrdpMqH3XqfiHc5PKzEhjgUj6OLpTXynkLi9JZKyMByI/tdpm4Liu6O2BjtE1lakBWXjOQS1EnSQLQ=="],
+
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-api-version": ["node-api-version@0.2.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
+    "node-gyp": ["node-gyp@12.3.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg=="],
+
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
+    "nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
 
     "normalize-url": ["normalize-url@6.1.0", "", {}, "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="],
 
@@ -1116,6 +1144,8 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
@@ -1139,6 +1169,8 @@
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -1232,6 +1264,8 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
@@ -1300,7 +1334,7 @@
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
@@ -1376,7 +1410,19 @@
 
     "global-agent/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "node-api-version/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "node-gyp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "node-gyp/undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
+
+    "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
@@ -1423,6 +1469,8 @@
     "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev:desktop": "node scripts/dev.mjs",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo run check-types"
+    "check-types": "turbo run check-types",
+    "rebuild:pty": "cd apps/desktop && electron-rebuild -f -w node-pty"
   },
   "devDependencies": {
     "prettier": "catalog:",

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./ids.ts";
 export * from "./ping.ts";
+export * from "./pty.ts";
 export * from "./rpc.ts";
 export * from "./workspace.ts";

--- a/packages/wire/src/pty.ts
+++ b/packages/wire/src/pty.ts
@@ -1,0 +1,68 @@
+import { Rpc } from "@effect/rpc";
+import { Schema } from "effect";
+
+import { PtyId } from "./ids.ts";
+
+/**
+ * Output emitted by a live PTY. The stream completes after the `exit` event;
+ * renderers should treat that as a terminal-closed signal.
+ */
+export const PtyDataEvent = Schema.TaggedStruct("data", {
+  bytes: Schema.String,
+});
+
+export const PtyExitEvent = Schema.TaggedStruct("exit", {
+  exitCode: Schema.NullOr(Schema.Number),
+  signal: Schema.NullOr(Schema.Number),
+});
+
+export const PtyEvent = Schema.Union(PtyDataEvent, PtyExitEvent);
+
+export class PtyNotFoundError extends Schema.TaggedError<PtyNotFoundError>()(
+  "PtyNotFoundError",
+  { ptyId: PtyId },
+) {}
+
+export class PtySpawnError extends Schema.TaggedError<PtySpawnError>()(
+  "PtySpawnError",
+  { reason: Schema.String },
+) {}
+
+export const PtyOpenRpc = Rpc.make("pty.open", {
+  payload: Schema.Struct({
+    cwd: Schema.String,
+    cols: Schema.Number,
+    rows: Schema.Number,
+  }),
+  success: Schema.Struct({ ptyId: PtyId }),
+  error: PtySpawnError,
+});
+
+export const PtyWriteRpc = Rpc.make("pty.write", {
+  payload: Schema.Struct({ ptyId: PtyId, data: Schema.String }),
+  success: Schema.Void,
+  error: PtyNotFoundError,
+});
+
+export const PtyResizeRpc = Rpc.make("pty.resize", {
+  payload: Schema.Struct({
+    ptyId: PtyId,
+    cols: Schema.Number,
+    rows: Schema.Number,
+  }),
+  success: Schema.Void,
+  error: PtyNotFoundError,
+});
+
+export const PtyCloseRpc = Rpc.make("pty.close", {
+  payload: Schema.Struct({ ptyId: PtyId }),
+  success: Schema.Void,
+  error: PtyNotFoundError,
+});
+
+export const PtyOutputRpc = Rpc.make("pty.output", {
+  payload: Schema.Struct({ ptyId: PtyId }),
+  success: PtyEvent,
+  error: PtyNotFoundError,
+  stream: true,
+});

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -2,6 +2,13 @@ import { RpcGroup } from "@effect/rpc";
 
 import { PingRpc } from "./ping.ts";
 import {
+  PtyCloseRpc,
+  PtyOpenRpc,
+  PtyOutputRpc,
+  PtyResizeRpc,
+  PtyWriteRpc,
+} from "./pty.ts";
+import {
   WorkspaceAddRpc,
   WorkspaceListRpc,
   WorkspacePickFolderRpc,
@@ -20,6 +27,11 @@ export const ForkzeroRpcs = RpcGroup.make(
   WorkspaceListRpc,
   WorkspaceRemoveRpc,
   WorkspacePickFolderRpc,
+  PtyOpenRpc,
+  PtyWriteRpc,
+  PtyResizeRpc,
+  PtyCloseRpc,
+  PtyOutputRpc,
 );
 export type ForkzeroRpcs = typeof ForkzeroRpcs;
 


### PR DESCRIPTION
## Summary

- New `pty` domain in `@forkzero/wire` with open/write/resize/close + streaming `pty.output` returning a tagged data/exit event. First use of `Rpc.make({ stream: true })` in the project — the Electron transport handles streamed RPCs without protocol changes.
- `PtyService` (Effect) wraps `node-pty.spawn`, keeps active PTYs in `Ref<Map<PtyId, ActivePty>>`, bridges `onData`/`onExit` callbacks into a `Mailbox` that the streaming handler consumes via `Mailbox.toStream`. Closing the mailbox on exit ends the stream cleanly.
- Workspace store gains `selectedFolderId` + `select`. Sidebar rows are clickable with selected highlight. Auto-select on load (first folder), on add (the new one), on remove (next one).
- TerminalPane keys on `folder.id` so React unmounts/remounts on folder switch — **one PTY per folder lifetime, no background PTYs**, matching `spec/phases/01-foundation.md`. xterm output piped from `pty.output` stream; keystrokes go to `pty.write`; `ResizeObserver` → debounced `pty.resize`. Empty state shown when no folder is selected.
- Header shows the selected folder's name (full path on hover).
- Native build: `@electron/rebuild` dev dep + `apps/desktop` postinstall + root `bun rebuild:pty` script (Bun does not run lifecycle scripts on workspace packages by default — symptom if you forget: `NODE_MODULE_VERSION` mismatch on `pty.spawn`).

## Test plan

- [x] `bun run check-types` clean across all 5 packages
- [x] Dev boot smoke test: `RPC smoke test: {"message":"pong",...}` appears (proves the expanded ForkzeroRpcs group serializes)
- [ ] Manual: click `+`, pick a folder → terminal appears with that cwd, prompt is the user's shell
- [ ] Manual: type `ls`, `pwd`, `git status` — output renders with colors
- [ ] Manual: switch folders — previous PTY closes, new one opens in the new cwd
- [ ] Manual: `exit` in terminal → `[process exited with code 0]` line appears, no crash
- [ ] Manual: quit app → `ps aux | rg node-pty` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)