### PR TITLE
fix(dev): unbreak `bun run dev` and xterm first-render crash

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -16,10 +16,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = resolve(__dirname, "..");
 const require = createRequire(import.meta.url);
 
-const devServerUrl = process.env.VITE_DEV_SERVER_URL?.trim();
-if (!devServerUrl) {
-  throw new Error("VITE_DEV_SERVER_URL is required for desktop development");
-}
+// Default matches apps/renderer/vite.config.ts. waitForResources() below polls
+// the port until vite comes up, so the boot order across `bun run dev` (turbo
+// runs renderer + desktop in parallel) and `bun run dev:desktop` (the root
+// orchestrator script) both work without explicit synchronization.
+const devServerUrl =
+  process.env.VITE_DEV_SERVER_URL?.trim() || "http://localhost:5733";
 const devServer = new URL(devServerUrl);
 const devPort = Number.parseInt(devServer.port, 10);
 if (!Number.isInteger(devPort) || devPort <= 0) {
@@ -89,9 +91,11 @@ function startApp() {
   if (shuttingDown || currentApp !== null) return;
 
   const electronPath = require("electron");
-  const app = spawn(electronPath, [".", "--zurich-dev"], {
+  const app = spawn(electronPath, [".", "--forkzero-dev"], {
     cwd: desktopDir,
-    env: { ...process.env },
+    // Pass the resolved dev URL through explicitly so main.ts sees it even
+    // when bun/turbo invoked us without setting the env var.
+    env: { ...process.env, VITE_DEV_SERVER_URL: devServerUrl },
     stdio: "inherit",
   });
   currentApp = app;

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -51,7 +51,19 @@ function PtyTerminal({ folder }: { folder: Folder }) {
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(container);
-    fit.fit();
+
+    // Don't fit synchronously — the parent grid hasn't laid out yet on first
+    // render, so xterm's renderer has no dimensions and FitAddon throws
+    // "Cannot read properties of undefined (reading 'dimensions')". The
+    // ResizeObserver below fires once after observe with real measurements.
+    const safeFit = () => {
+      if (container.clientWidth === 0 || container.clientHeight === 0) return;
+      try {
+        fit.fit();
+      } catch {
+        // ignore — happens during teardown when the container is detached
+      }
+    };
 
     let cancelled = false;
     let ptyId: PtyId | null = null;
@@ -59,13 +71,7 @@ function PtyTerminal({ folder }: { folder: Folder }) {
     let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
     let resizeTimer: number | null = null;
 
-    const observer = new ResizeObserver(() => {
-      try {
-        fit.fit();
-      } catch {
-        // ignore — happens during teardown when the container is detached
-      }
-    });
+    const observer = new ResizeObserver(safeFit);
     observer.observe(container);
 
     void (async () => {


### PR DESCRIPTION
## Summary

Two small fixes that block PR-4 smoke testing.

- **\`bun run dev\` (the turbo path) was broken** because turbo runs each package's \`dev\` script in parallel without orchestration, so \`apps/desktop/scripts/dev-electron.mjs\` saw no \`VITE_DEV_SERVER_URL\` and threw immediately. Fix: default it to \`http://localhost:5733\` (the renderer vite default) and explicitly inject it into Electron's spawn env. \`waitForResources()\` already polls the port, so turbo's parallel boot just works. \`bun run dev:desktop\` (via \`scripts/dev.mjs\`) keeps working too.
- **xterm crashed on first render** with \`Cannot read properties of undefined (reading 'dimensions')\` because \`fit.fit()\` was called synchronously after \`term.open()\` — before the parent grid had laid out, so xterm's renderer had no dimensions. The ResizeObserver fires on observe with real measurements, so let it own the initial fit; added a zero-dimension guard.

## Test plan

- [x] \`bun run check-types\` clean
- [x] \`bun run dev\` boots; pong appears in the renderer console
- [x] Terminal renders without the dimensions TypeError, prompt is the user's shell, \`ls\` shows real output with colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)