### PR TITLE
spec: phase-2 architecture (apps/server, transport-swap-ready)

### DIFF
--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -7,106 +7,167 @@
 | Shell | Electron (latest LTS) | Already scaffolded; broadest desktop reach |
 | Renderer framework | React 19 + TypeScript | Mainstream, hireable, great tooling |
 | Build (renderer) | Vite | Fast HMR; matches React 19 well |
-| Build (main) | tsdown | Fast esbuild-based bundler for Node |
-| Styling | Tailwind v4 | Already in place; minimal runtime |
-| State (renderer, ephemeral) | Zustand backed by Effect Refs | Effect owns truth; Zustand is a thin React surface |
-| State (renderer, persistent) | Effect Layer over JSON file in userData | Inspectable, backupable |
-| IPC | Effect-wrapped preload bridge with typed contracts | One source of truth for channel schemas |
+| Build (main + server) | tsdown | Fast esbuild-based bundler for Node |
+| Styling | Tailwind v4 + shadcn (zinc, dark) | Already in place; minimal runtime |
+| State (renderer, ephemeral) | Zustand | Thin React surface |
+| State (renderer, persistent) | Server-owned, RPC-fetched | Single source of truth in `apps/server` |
+| RPC | `@effect/rpc` over a swappable transport | Same contracts work for Electron IPC, WS, anything |
 | Terminal | xterm.js + node-pty | De facto standard |
 | Git | Spawn `git` CLI (no libgit2) | Avoids native binding pain; matches what users have installed |
 | Agent SDKs | `@anthropic-ai/claude-agent-sdk`, OpenAI Codex SDK | First-party clients |
 | Runtime safety | Effect.ts (Schema, Layer, Stream, Cause) | Typed errors, structured concurrency, resource safety |
-| Monorepo | Bun + Turbo | Fast installs, parallel task running |
+| Monorepo | Bun workspaces + Turbo | Fast installs, parallel task running, catalog for shared deps |
+
+## Process model
+
+Today we run as a single Electron main process that imports `apps/server` directly. The architecture is **designed for the day** that changes — see [ADR 0007](decisions/0007-server-as-code-only-app.md). The eventual targets:
+
+| Mode | Process layout | When |
+|---|---|---|
+| **Electron-bundled** (today) | One Electron process; renderer talks to main via Electron IPC; `apps/server` consumed in-process | v1 |
+| **Electron + subprocess server** | Electron main spawns `apps/server` as a Node subprocess; renderer talks to it over WebSocket on a localhost port; SSH + port-forward enables remote access | When we ship remote |
+| **Headless server + remote clients** | `apps/server` as standalone binary; multiple renderers (browser, mobile, CLI) connect over WS | When we ship cloud or multi-client |
+
+The renderer code does not change between these modes — only the transport module it picks. Service code never changes.
 
 ## Module layout
 
 ```
 forkzero/
-  apps/
-    desktop/        # Electron main process — owns OS resources
-      src/
-        main.ts             # Window + lifecycle
-        preload.ts          # contextBridge → renderer
-        runtime.ts          # Composes Effect Layers for main
-        services/
-          pty/              # PTY service (node-pty wrapped in Effect)
-          git/              # Git service (spawn git, parse output)
-          workspace/        # Folder list persistence
-          agent/            # Claude/Codex adapters
-        ipc/
-          channels.ts       # Effect Schema for every channel
-          handlers.ts       # Layer that registers ipcMain handlers
-    renderer/       # React UI — pure UI, talks to main via typed bridge
-      src/
-        runtime.ts          # Renderer-side Effect runtime (lighter)
-        components/         # Pane components
-        store/              # Zustand stores backed by Effect Refs
-        lib/desktop.ts      # Typed IPC client
   packages/
-    wire/           # @forkzero/wire — RPC contracts, schemas, branded IDs
+    wire/                                   # @forkzero/wire — RPC contracts, branded IDs
       src/
-        terminal.ts
-        git.ts
-        workspace.ts
-        agent.ts
-    ui/             # Shared component primitives
+        ping.ts, workspace.ts, pty.ts, git.ts, agent.ts
+        ids.ts                              # branded entity IDs (FolderId, PtyId, SessionId, ...)
+        rpc.ts                              # ForkzeroRpcs = RpcGroup.make(...)
+        index.ts
     typescript-config/
     eslint-config/
+    ui/                                     # repo-shared UI primitives (existing scaffold)
+  apps/
+    server/                                 # main-process service implementations
+      src/
+        workspace/                          # one folder per domain
+          Drivers/                          # per-impl factories (where applicable)
+          Layers/                           # live Effect.Service impls
+          Services/                         # Context.Service tags (interfaces)
+          Errors.ts                         # tagged errors for this domain
+          handlers.ts                       # toLayerHandler bindings for this domain's RPCs
+        pty/                                # same shape
+        git/                                # same shape
+        provider/                           # the agent domain (Claude, Codex, ...)
+          Drivers/                          # ClaudeDriver, CodexDriver — config + factory
+          Layers/                           # ClaudeAdapter, CodexAdapter — live SDK wrappers
+          Services/                         # ProviderAdapter, ProviderRegistry, ProviderService
+          Errors.ts
+          availability.ts                   # PATH probe — `which claude`, `which codex`
+          spawn.ts                          # spawn-CLI helper
+          credentials.ts                    # keychain wrapper
+          handlers.ts
+        app-paths.ts                        # Context.Tag — userData, etc.
+        runtime.ts                          # makeMainLayer(deps) — pure factory, no transport
+        handlers.ts                         # Layer.mergeAll of all per-domain handlers
+        bin.ts                              # standalone entrypoint stub (becomes WS server later)
+    desktop/                                # thin Electron shim
+      src/
+        main.ts                             # Electron lifecycle; imports makeMainLayer
+        preload.ts                          # contextBridge → renderer
+        ipc/
+          electron-server-protocol.ts       # in-process transport
+        app-branding.ts, vibrancy, etc.     # Electron-only utilities
+    renderer/                               # React UI — reused as-is in future browser/mobile clients
+      src/
+        app.tsx, main.tsx, styles.css
+        lib/
+          rpc-client.ts                     # the seam — selects transport based on environment
+          electron-client-protocol.ts       # in-process transport
+          # ws-client-protocol.ts           # added when remote ships
+        components/                         # feature components + ui/ shadcn primitives
+        store/                              # Zustand stores
 ```
 
-## IPC topology
+### Per-domain folder convention
 
-The preload bridge exposes a single typed object: `window.forkzero`. Every method:
+Every domain in `apps/server/src/` follows this split (mirrors the reference repo so transplanted code lines up 1:1):
 
-1. Takes a typed input (Effect Schema-decoded on send)
-2. Returns either a `Promise<Output>` (request/response) or a `(handler) => unsubscribe` (subscription)
-3. Maps IPC errors to Effect tagged errors on the renderer
+| Folder | Contents | Example |
+|---|---|---|
+| `Drivers/` | Per-impl static configs + factory functions | `ClaudeDriver.ts` exports `{ driverKind, displayName, create }` |
+| `Layers/` | Live `Effect.Service` impls (`Layer.effect(Tag, factory)`) | `ProviderService.ts` (live), `ClaudeAdapter.ts` |
+| `Services/` | `Context.Service` tags — interfaces only, no impls | `ProviderAdapter.ts`, `ProviderService.ts` |
+| `Errors.ts` | Tagged errors for the domain | `ProviderServiceError`, `ProviderAdapterError` |
+| `handlers.ts` | `RpcGroup.toLayerHandler` bindings | `agent.start`, `agent.events`, ... |
+| Top-level `*.ts` | Domain-specific helpers that aren't services | `availability.ts`, `spawn.ts`, `credentials.ts` |
 
-Channel naming: `<service>:<verb>`, e.g. `pty:open`, `git:log`, `workspace:add`.
+Single-impl domains (Phase 1's `pty`, `git`, `workspace`) still use the same split — `Layers/` has one file, `Services/` has one file, `Drivers/` may be empty. The uniform shape makes onboarding cheap; growth is invisible.
+
+## Transport boundary
+
+The renderer never names a transport directly. Everywhere uses:
+
+```ts
+// apps/renderer/src/lib/rpc-client.ts
+export async function getRpcClient() { ... }
+```
+
+Today this returns an Electron-IPC-backed client. Tomorrow it returns a WS-backed client when running in a browser, or Electron-IPC when running inside the Electron renderer. **No call site changes.**
+
+The same is true on the server side: `apps/server/src/runtime.ts` exports a pure `makeMainLayer(deps)` that knows nothing about how it'll be reached. The transport wrapper lives outside (`apps/desktop/src/ipc/electron-server-protocol.ts` today, `apps/server/src/transports/ws.ts` tomorrow).
+
+This is the rule that makes the eventual extraction a wiring change, not a refactor.
 
 ## Effect Layer model
 
-**Main process layers** (built once at boot):
+**Server layers** (built once at boot via `makeMainLayer({ userData, ... })`):
 
 ```
-AppLayer = Layer.mergeAll(
-  NodeServicesLayer,        // FileSystem, Path, Terminal stdin
-  WorkspaceServiceLayer,    // depends on FileSystem, Path
-  PtyServiceLayer,          // depends on Path
-  GitServiceLayer,          // depends on Path
-  AgentServiceLayer,        // depends on Workspace, Pty
-  IpcHandlersLayer          // depends on all above; side-effectful registration
+ServerLayer = Layer.mergeAll(
+  NodeContext.layer,                        // FileSystem, Path, CommandExecutor
+  AppPathsLayer,                            // userData, etc. — typed Context tag
+  WorkspaceLayer,                           // depends on FileSystem, AppPaths
+  PtyLayer,                                 // depends on AppPaths
+  GitLayer,                                 // depends on Workspace, CommandExecutor
+  ProviderLayer,                            // depends on Workspace, Credentials
+  CredentialsLayer,                         // depends on AppPaths
+  HandlersLayer                             // top-level mergeAll of all per-domain handlers
 )
 ```
 
-**Renderer layers**:
+**Renderer layers**: minimal. Zustand stores hold UI state; `getRpcClient()` returns a long-lived RPC client with `Scope.extend(rendererScope)` (see [ADR 0007](decisions/0007-server-as-code-only-app.md) and Phase 1 decisions log for the why).
 
-```
-RendererLayer = Layer.mergeAll(
-  IpcClientLayer,           // typed wrapper around window.forkzero
-  WorkspaceStoreLayer,      // Ref<WorkspaceState> + IPC sync
-  TerminalRegistryLayer,    // Map<TerminalId, xterm instance>
-  AgentSessionRegistryLayer
-)
-```
+## Streaming
 
-A small `useEffectRuntime()` hook gives React components access via Zustand subscriptions.
-
-## Threading & concurrency
-
-- **Main process**: Effect runtime with Fibers; PTY/git/agent operations are interruptible.
-- **Renderer**: lightweight Effect runtime, no long-running fibers — mostly request/response.
-- **Streams**: PTY output, git status changes, and agent events are Effect Streams in main, serialized to JSON over IPC, re-materialized as RxJS-style subscriptions in the renderer.
+Streaming RPCs (`pty.output`, `git.headChanged`, `agent.events`) follow a uniform pattern in the server: per-subscription `Mailbox<Event, Error>` + `Stream.unwrapScoped(Effect.gen { forkScoped pump; return Mailbox.toStream(mb) })`. The forked fiber dies when the renderer interrupts the subscription — clean teardown, no leaks. See `apps/server/src/pty/Layers/PtyService.ts` and `apps/server/src/git/Layers/GitService.ts` for the canonical shape.
 
 ## Persistence
 
 | Data | Location | Format |
 |---|---|---|
-| Folder list | `userData/workspaces.json` | JSON |
-| Per-folder sessions | `userData/sessions/<folder-hash>.json` | JSON |
-| PTY scrollback (recent) | `userData/scrollback/<session-id>.log` | Plain text, capped at N MB |
-| Agent transcripts | `userData/agent-runs/<session-id>.jsonl` | NDJSON |
-| Settings | `userData/settings.json` | JSON |
-| Credentials | OS keychain via `keytar` | Native |
+| Folder list + selection | `userData/workspaces.json` | JSON, atomic write+rename |
+| Per-folder agent sessions | `userData/sessions/<folder-hash>.json` (Phase 3) | JSON |
+| Agent run transcripts | `userData/agent-runs/<session-id>.jsonl` (Phase 3) | NDJSON |
+| Settings | `userData/settings.json` (Phase 3) | JSON |
+| Credentials | OS keychain via `keytar` (Phase 2) | Native |
 
 No SQLite in v1. JSON until proven painful.
+
+## Naming
+
+See [ADR 0005](decisions/0005-package-layout.md) for the full rules. Highlights:
+
+- Single contracts package: `@forkzero/wire` with one file per domain
+- Internal package namespace: `@forkzero/*`
+- Service classes: `<Domain>Service` (no `*Engine`, no `*FileSystem`, no bare verbs)
+- RPC method names: dotted-lowercase string literals passed directly to `Rpc.make("...", ...)` — no central enum
+- Branded IDs for every entity that crosses the wire
+- Per-domain folders use `Drivers/Layers/Services/Errors.ts` split (Phase 2+); single-impl domains land with the same structure for uniformity
+
+## Decision references
+
+- [ADR 0001 — Electron over Tauri](decisions/0001-electron-over-tauri.md)
+- [ADR 0002 — Effect from day one](decisions/0002-effect-from-day-one.md)
+- [ADR 0003 — Bun monorepo](decisions/0003-bun-monorepo.md)
+- [ADR 0004 — Spawn-CLI and SDK](decisions/0004-spawn-cli-and-sdk.md)
+- [ADR 0005 — Package layout & naming](decisions/0005-package-layout.md)
+- [ADR 0006 — Bun catalog + overrides](decisions/0006-bun-catalog.md)
+- [ADR 0007 — `apps/server` as a code-only app](decisions/0007-server-as-code-only-app.md)

--- a/spec/decisions/0005-package-layout.md
+++ b/spec/decisions/0005-package-layout.md
@@ -56,7 +56,11 @@ export const FolderId = makeEntityId("FolderId");
 
 **Why brand:** prevents `PtyId` from being passed where `FolderId` is expected, even though both are strings at runtime. Cost: zero. Caught: a real class of bugs.
 
-### Per-domain folder layout (apps/desktop)
+### Per-domain folder layout (apps/server)
+
+> **Updated 2026-05-03 by [ADR 0007](0007-server-as-code-only-app.md):** services moved from `apps/desktop/src/services/` to `apps/server/src/`, and the per-domain shape adopted the reference repo's split. The original "flat" rule below is preserved for context — see the **Updated rule** below it.
+
+**Original rule (Phase 1):**
 
 ```
 apps/desktop/src/services/<domain>/
@@ -64,36 +68,54 @@ apps/desktop/src/services/<domain>/
   <domain>-handlers.ts   # RPC handler implementations
 ```
 
-**Flat. No `Layers/` and `Services/` subdirs per domain.** Split a domain into subfolders only when it grows past ~300 LOC and the split actually clarifies things.
+Flat. No `Layers/` and `Services/` subdirs. Split only when a domain grew past ~300 LOC.
 
-**Why flat:** at v1 sizes, subdirs add navigation cost without clarifying anything. A domain folder with two files is faster to read than a domain folder with two folders that each contain one file.
+**Updated rule (Phase 2 onwards):**
+
+```
+apps/server/src/<domain>/
+  Drivers/                # per-impl static configs + factories (e.g. ClaudeDriver, CodexDriver)
+  Layers/                 # live Effect.Service impls (Layer.effect(Tag, factory))
+  Services/               # Context.Service tags — interfaces only
+  Errors.ts               # tagged errors for the domain
+  handlers.ts             # toLayerHandler bindings
+  <misc helpers>.ts       # availability.ts, spawn.ts, credentials.ts, etc.
+```
+
+Single-impl domains (Phase 1's `pty`, `git`, `workspace`) still use the same split — `Layers/` has one file, `Services/` has one file, `Drivers/` may be empty.
+
+**Why uniform split now (overriding "flat-until-scale"):**
+
+1. The reference architecture uses this split. Code we lift from there transplants 1:1 if our paths match.
+2. Phase 2 introduces the agent domain, which already justifies the split (multiple drivers + adapters + a registry + a service).
+3. Inconsistency between domains has higher onboarding cost than uniform "small-but-split" structure.
+4. Renaming Phase 1's three single-file services into the split is a one-time mechanical refactor (PR-6).
 
 ### File naming
 
 - Files: `kebab-case.ts` (`workspace-service.ts`, `electron-server-protocol.ts`)
 - Folders: singular kebab-case (`service/`, `ipc/`, not `services/` for the inner domain folder — but the parent `services/` is plural, since it contains many)
 
-### App layout (current)
+### App layout (Phase 2 onwards)
+
+See [`spec/architecture.md`](../architecture.md) for the canonical layout. Summary:
 
 ```
-apps/desktop/src/
-  main.ts               # window + lifecycle
-  preload.ts            # contextBridge → renderer
-  runtime.ts            # composes Effect Layers for the main runtime
-  ipc/
-    electron-server-protocol.ts
-    handlers.ts         # registers all *-handlers in one place
-  services/<domain>/
-    <domain>-service.ts
-    <domain>-handlers.ts
+apps/server/src/                          # NEW — main-process service implementations
+  <domain>/                                # Drivers/Layers/Services/Errors.ts/handlers.ts
+  app-paths.ts, runtime.ts, handlers.ts, bin.ts
+
+apps/desktop/src/                          # thin Electron shim
+  main.ts                                  # imports makeMainLayer from @forkzero/server
+  preload.ts
+  ipc/electron-server-protocol.ts          # transport stays in apps/desktop
 
 apps/renderer/src/
   app.tsx, main.tsx, styles.css
   lib/
-    bridge.ts                       # window.forkzero typing
+    rpc-client.ts                          # the seam — selects transport
     electron-client-protocol.ts
-    rpc-client.ts                   # uses Scope.extend(longLivedScope)
-  store/<domain>.ts                 # Zustand stores
+  store/<domain>.ts
   components/<name>.tsx
 ```
 
@@ -107,6 +129,6 @@ apps/renderer/src/
 
 - Splitting `wire` into per-domain packages — forces package coordination per RPC.
 - Central `WS_METHODS`-style enum of method names — doubles the change footprint.
-- Per-domain `Layers/` + `Services/` subdirs — premature partitioning.
+- ~~Per-domain `Layers/` + `Services/` subdirs — premature partitioning.~~ **Reversed by [ADR 0007](0007-server-as-code-only-app.md):** the per-domain split is now adopted uniformly so we match the reference repo's layout and Phase 2 code transplants line up 1:1.
 - Inconsistent service suffixes (`*Engine`, `*FileSystem`, bare verbs) — readers shouldn't have to learn a per-domain vocabulary.
 - A `packages/shared/` junk drawer — when we have a real cross-cutting utility, we'll create a focused package for it.

--- a/spec/decisions/0007-server-as-code-only-app.md
+++ b/spec/decisions/0007-server-as-code-only-app.md
@@ -1,0 +1,98 @@
+# ADR 0007: `apps/server` as a code-only app, designed for future extraction
+
+**Status**: Accepted
+
+**Date**: 2026-05-03
+
+## Context
+
+Phase 1 put all main-process services (`workspace`, `pty`, `git`) inside `apps/desktop/src/services/`. That worked for a single Electron-only target. Phase 2 introduces the agent domain, which is structurally heavier (Driver / Adapter / Service / Registry split) and will eventually carry features the reference architecture exposes through a separate process — remote sessions, headless/CLI clients, multi-client renderers, future mobile clients connecting to a desktop over the network.
+
+We now know we want to be able to:
+
+1. SSH into a desktop and connect to it from another machine (browser pointing at the running server).
+2. Ship a CLI client that talks to the same backend.
+3. Ship a mobile client (someday) that connects to a user's desktop over LAN/tunnel.
+4. Have multiple renderer processes/windows talk to the same backend.
+
+The reference architecture solves (1)–(4) by running the backend as a standalone Bun WS server. Their renderer code (`apps/web/`) is transport-agnostic — Electron loads it from disk and talks to a localhost server, browsers load it from a URL and talk to a remote server.
+
+Doing the full extraction *now* (real subprocess, port discovery, WS transport) is a 2–3 week diversion before Phase 2 features can ship. Doing nothing leaves us with a layout that has to be re-architected when remote becomes a priority.
+
+## Decision
+
+Adopt **Path 2**: create `apps/server/` as a structurally separate "app" that today is consumed by `apps/desktop/main.ts` via direct in-process import, but is designed so that extraction to a real WS server is a localized, low-risk PR later.
+
+### What lives where
+
+```
+packages/
+  wire/                         # RPC contracts — transport-agnostic by definition
+apps/
+  server/                       # main-process service implementations
+    src/
+      <domain>/                 # workspace, pty, git, provider — t3code Drivers/Layers/Services split
+      app-paths.ts              # Context.Tag for OS-paths (no electron import)
+      runtime.ts                # makeMainLayer(deps) — pure factory, no transport
+      handlers.ts               # mergeAll of all per-domain handlers
+      bin.ts                    # standalone entrypoint stub. Today: just re-exports runtime.
+                                # Tomorrow: WS server boot.
+  desktop/                      # thin Electron shim
+    src/
+      main.ts                   # Electron lifecycle. Imports runtime from @forkzero/server.
+      preload.ts                # contextBridge
+      ipc/                      # electron-server-protocol — Electron-bound transport
+  renderer/                     # React UI
+    src/
+      lib/
+        rpc-client.ts           # the seam — picks transport based on environment
+        electron-client-protocol.ts  # in-process transport
+        # ws-client-protocol.ts (added when remote ships)
+```
+
+### Hard rules that keep extraction cheap
+
+These rules turn "future WS extraction" from a refactor into a wiring change:
+
+1. **`apps/server/` may NOT import from `electron` or any electron-only package.** Not even via `import type`. If a service needs an electron-provided value (userData path, app version, etc.), it consumes it from `AppPaths` (or a new typed Context tag) — `apps/desktop/main.ts` is the single place electron leaks in.
+2. **`apps/server/` may NOT import from `apps/desktop/` or `apps/renderer/`.** Strict one-direction dependency.
+3. **`apps/server/src/runtime.ts` exports `makeMainLayer(deps: { userData: string, ... }): Layer<...>`.** Pure factory, no side effects, no transport. Both `apps/desktop/main.ts` (today) and `apps/server/src/bin.ts` (future WS server) call it.
+4. **All transport-related code lives outside `apps/server/`.** `electron-server-protocol.ts` and `electron-client-protocol.ts` stay in `apps/desktop/src/ipc/` and `apps/renderer/src/lib/` respectively. When WS lands, its server side goes in `apps/server/src/transports/ws.ts` (the only place WS is allowed inside the package); its client side goes in `apps/renderer/src/lib/`.
+5. **Renderer transport selection is centralized in `apps/renderer/src/lib/rpc-client.ts`.** Today: returns Electron protocol. Tomorrow: returns Electron protocol when running inside Electron, WS protocol otherwise. Other renderer code calls `getRpcClient()` and never names a transport directly.
+6. **`apps/server/package.json` has no electron, no node-pty in `dependencies` directly... actually wait — node-pty is required for the PTY service.** Pragmatic exception: native modules (node-pty) live as deps of `apps/server` because that's where the service is, and electron-rebuild from `apps/desktop` finds them via Bun's hoisted layout. This is the only "leak" — node-pty assumes a Node ABI; remote/headless servers can't provide a real PTY, so a real WS deployment would need to gate the PTY domain or supply a different impl. Document and accept.
+
+### Why "app" not "package"
+
+Naming-wise, `apps/server` matches the reference repo's layout, so transplanting code from there is mechanical (paths line up). The `apps/` vs `packages/` distinction in monorepo conventions is soft — `apps/` typically means "runnable thing." Today our `apps/server` is not separately runnable (`bin.ts` is a stub); it ships with `apps/desktop`. When `bin.ts` becomes a real WS server boot, the naming retroactively fits the convention without a rename.
+
+### What this lets us defer
+
+The following are *enabled* by this layout but *not built* yet:
+
+- Real subprocess spawn of `apps/server` from `apps/desktop/main.ts`
+- Port discovery + readiness signaling (`backendPort`, `backendReadiness` patterns from the reference)
+- WebSocket transport (`ws-server-protocol.ts`, `ws-client-protocol.ts`)
+- CLI client (`apps/cli/`) that connects over WS
+- Mobile client (someday) that connects over LAN/tunnel
+- Multi-window support (multiple renderers connected to one backend)
+
+When any of these become priority, we add the relevant bits without restructuring services or contracts. Estimated cost of the future WS extraction PR: ~1 week, isolated to transport modules + `bin.ts` + `apps/desktop/main.ts` startup orchestration.
+
+## Consequences
+
+- Phase 2 can ship on schedule (no transport refactor blocking it).
+- Every Phase 2 service is built once and works in both modes (in-process today, WS tomorrow) without modification.
+- The layout matches the reference repo, so lifting code (especially `provider/`) is mechanical.
+- One actual cost: `apps/desktop/main.ts` always pays a small wiring tax — it has to bridge electron paths into `apps/server`'s typed context tags. Worth it.
+
+## What we deliberately rejected
+
+- **Path 1: full WS extraction now.** ~3 weeks. Useful only if remote is the headline feature for v1. It isn't — agents are.
+- **Path 3: ship Electron IPC + WS in parallel from day one.** ~2 weeks. Pays full distributed-systems cost (process lifecycle, port collision, reconnection) before we have a single user asking for remote. Defer.
+- **Keeping services in `apps/desktop/src/services/`.** Locks us to Electron-bundled forever. Every future remote/CLI/mobile feature would require moving everything anyway, plus all the API churn from the move.
+
+## How we'll know we got it right
+
+- Phase 2 ships without revisiting transport.
+- The day someone asks for "let me SSH into my desktop and use forkzero from my laptop browser," the PR touches `apps/server/src/bin.ts`, `apps/server/src/transports/ws.ts`, `apps/desktop/src/main.ts`, and `apps/renderer/src/lib/rpc-client.ts` — and nothing in any service.
+- New service domains (Phase 3 permissions, Phase 4 diff viewer) follow the same `apps/server/src/<domain>/{Drivers,Layers,Services,Errors.ts}` pattern without anyone asking where they should live.

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -58,3 +58,16 @@ Make it shippable.
 | Public alpha (Phases 1–2) | ~8 weeks |
 | Public beta (Phases 1–3) | ~10 weeks |
 | 1.0 (Phases 1–4) | **~3–4 months** |
+
+## Beyond 1.0 (post-roadmap, designed for from day one)
+
+The architecture (`apps/server` as a code-only app today, designed for extraction; transport-agnostic renderer) supports these without re-architecture. Each becomes a focused PR rather than a redesign.
+
+| Milestone | What changes | Estimate |
+|---|---|---|
+| **Remote desktop access** | `apps/server/src/bin.ts` becomes a real WS server boot; Electron spawns it as a subprocess; renderer's transport seam picks WS when running outside Electron. SSH + port-forward enables remote use. | ~1 week |
+| **CLI client** | New `apps/cli/` consuming `@forkzero/wire` over the WS transport. | ~1 week |
+| **Multi-window / multi-renderer** | Multiple Electron renderers (or browser tabs) connected to one backend. Backend already supports it; just wire window management. | ~3 days |
+| **Mobile client** | Native or web-based mobile app speaking WS to a desktop's server over LAN/tunnel. Re-uses `apps/renderer` as a packaging target where feasible. | TBD |
+
+See [ADR 0007](decisions/0007-server-as-code-only-app.md) for the architectural rules that keep these costs bounded.


### PR DESCRIPTION
## Summary
- New ADR 0007 commits to extracting main-process services into a code-only \`apps/server/\` workspace (Path 2 of three considered) — designed today for in-process Electron import, designed tomorrow for spawn-as-subprocess + WS server so remote / CLI / multi-window / mobile clients become a focused PR instead of a re-architecture.
- Locks 5 hard rules that keep the future extraction cheap (no electron imports in \`apps/server\`, no apps/desktop imports, pure \`makeMainLayer(deps)\` factory, transport modules outside, centralized renderer transport seam).
- Adopts the reference repo's per-domain \`Drivers/Layers/Services/Errors.ts/handlers.ts\` split uniformly so transplanted code lines up 1:1; reverses ADR 0005's flat-per-domain rule with reasoning preserved.
- \`spec/architecture.md\` rewritten with the new layout, three eventual process modes (Electron-bundled → Electron+subprocess → headless+remote), and the transport boundary made explicit.
- \`spec/roadmap.md\` gains a "Beyond 1.0" section so the remote / CLI / multi-window / mobile direction is on-paper, not just in the ADR.

Pure docs — no code changes. Implementation lands in PR-6 (refactor) and PR-7/8/9 (Phase 2 agent work).

## Test plan
- [ ] Read ADR 0007 end-to-end; confirm the 5 hard rules + node-pty pragmatic exception read correctly
- [ ] Read updated architecture.md; confirm layout + process modes match the intent
- [ ] Confirm ADR 0005's reversal note is clear enough that a future contributor won't try to undo it
- [ ] Confirm roadmap.md "Beyond 1.0" section sets the right expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)