### PR TITLE
phase 2 / pr 2: provider domain scaffolding + agent RPC contracts

### DIFF
--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -2,6 +2,7 @@ import { Layer } from "effect";
 
 import { GitHandlersLayer } from "./git/handlers.ts";
 import { PingHandlersLayer } from "./ping/handlers.ts";
+import { ProviderHandlersLayer } from "./provider/handlers.ts";
 import { PtyHandlersLayer } from "./pty/handlers.ts";
 import { WorkspaceHandlersLayer } from "./workspace/handlers.ts";
 
@@ -16,4 +17,5 @@ export const HandlersLayer = Layer.mergeAll(
   WorkspaceHandlersLayer,
   PtyHandlersLayer,
   GitHandlersLayer,
+  ProviderHandlersLayer,
 );

--- a/apps/server/src/provider/drivers/index.ts
+++ b/apps/server/src/provider/drivers/index.ts
@@ -1,0 +1,53 @@
+import type { Effect, Stream } from "effect";
+
+import type {
+  AgentEvent,
+  AgentSessionId,
+  AgentSessionNotFoundError,
+  AgentSessionStartError,
+  AgentTurnId,
+  ProviderId,
+  StartSessionInput,
+} from "@forkzero/wire";
+
+import type { ProviderAdapterError } from "../errors.ts";
+
+/**
+ * Static descriptor every driver provides — the registry uses these to render
+ * the launcher menu before any session has been started. `create` is invoked
+ * lazily when a session is opened so we don't pay SDK init cost at boot.
+ */
+export interface ProviderDriver {
+  readonly providerId: ProviderId;
+  readonly displayName: string;
+  readonly cliBinary: string;
+  readonly create: () => Effect.Effect<ProviderDriverInstance, ProviderAdapterError>;
+}
+
+/**
+ * What a driver instance must expose. SDK adapters (PR 5/6) implement this;
+ * spawn-CLI is not a driver — it's a special PTY launch handled in
+ * `provider/spawn.ts`.
+ */
+export interface ProviderDriverInstance {
+  readonly start: (
+    input: StartSessionInput,
+  ) => Effect.Effect<
+    {
+      readonly sessionId: AgentSessionId;
+      readonly events: Stream.Stream<AgentEvent, AgentSessionStartError>;
+    },
+    AgentSessionStartError
+  >;
+  readonly send: (
+    sessionId: AgentSessionId,
+    text: string,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+  readonly interrupt: (
+    sessionId: AgentSessionId,
+    turnId?: AgentTurnId,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+  readonly close: (
+    sessionId: AgentSessionId,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+}

--- a/apps/server/src/provider/errors.ts
+++ b/apps/server/src/provider/errors.ts
@@ -1,0 +1,28 @@
+import { Data } from "effect";
+
+/**
+ * Server-internal errors for the provider domain. These never cross the wire
+ * — wire-facing errors live in `@forkzero/wire`'s `agent.ts`. Each public
+ * service method maps these to a wire error before failing.
+ */
+
+export class ProviderRegistryError extends Data.TaggedError(
+  "ProviderRegistryError",
+)<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}
+
+export class ProviderAdapterError extends Data.TaggedError(
+  "ProviderAdapterError",
+)<{
+  readonly providerId: string;
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}
+
+export class CredentialsError extends Data.TaggedError("CredentialsError")<{
+  readonly providerId: string;
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -1,0 +1,15 @@
+import { Layer } from "effect";
+
+/**
+ * Provider-domain RPC handlers. Empty in PR 2 — each subsequent PR wires its
+ * RPC into `ForkzeroRpcs` (in `@forkzero/wire`) and adds the matching
+ * `toLayerHandler` here:
+ *
+ *   PR 3 — `agent.availability`
+ *   PR 4 — `agent.setCredential`
+ *   PR 5/6 — `agent.start` / `send` / `interrupt` / `close` / `events`
+ *
+ * Keeping the merge wired now means later PRs are pure additions inside this
+ * file — no plumbing churn.
+ */
+export const ProviderHandlersLayer = Layer.empty;

--- a/apps/server/src/provider/services/provider-adapter.ts
+++ b/apps/server/src/provider/services/provider-adapter.ts
@@ -1,0 +1,49 @@
+import { Context, type Effect, type Stream } from "effect";
+
+import type {
+  AgentEvent,
+  AgentSessionId,
+  AgentSessionNotFoundError,
+  AgentSessionStartError,
+  AgentTurnId,
+  ProviderId,
+  StartSessionInput,
+} from "@forkzero/wire";
+
+import type { ProviderAdapterError } from "../errors.ts";
+
+/**
+ * Per-provider live binding. The registry looks one of these up by
+ * `providerId` and delegates session lifecycle to it. SDK adapters (Claude,
+ * Codex) provide a Layer that contributes a `ProviderAdapter` keyed by their
+ * `providerId`.
+ */
+export interface ProviderAdapterShape {
+  readonly providerId: ProviderId;
+  readonly displayName: string;
+  readonly start: (
+    input: StartSessionInput,
+  ) => Effect.Effect<
+    {
+      readonly sessionId: AgentSessionId;
+      readonly events: Stream.Stream<AgentEvent, AgentSessionStartError>;
+    },
+    AgentSessionStartError | ProviderAdapterError
+  >;
+  readonly send: (
+    sessionId: AgentSessionId,
+    text: string,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+  readonly interrupt: (
+    sessionId: AgentSessionId,
+    turnId?: AgentTurnId,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+  readonly close: (
+    sessionId: AgentSessionId,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+}
+
+export class ProviderAdapter extends Context.Tag("forkzero/ProviderAdapter")<
+  ProviderAdapter,
+  ProviderAdapterShape
+>() {}

--- a/apps/server/src/provider/services/provider-registry.ts
+++ b/apps/server/src/provider/services/provider-registry.ts
@@ -1,0 +1,24 @@
+import { Context, type Effect } from "effect";
+
+import type { ProviderId } from "@forkzero/wire";
+
+import type { ProviderRegistryError } from "../errors.ts";
+import type { ProviderAdapterShape } from "./provider-adapter.ts";
+
+/**
+ * Map from `providerId` to live adapter binding. Populated at boot by
+ * `ProviderAdapterRegistryLive` (PR 5/6) merging the per-provider Layers it
+ * was given. `ProviderService` consults this to route session-lifecycle
+ * RPCs to the right adapter.
+ */
+export interface ProviderRegistryShape {
+  readonly get: (
+    providerId: ProviderId,
+  ) => Effect.Effect<ProviderAdapterShape, ProviderRegistryError>;
+  readonly list: () => Effect.Effect<ReadonlyArray<ProviderAdapterShape>>;
+}
+
+export class ProviderRegistry extends Context.Tag("forkzero/ProviderRegistry")<
+  ProviderRegistry,
+  ProviderRegistryShape
+>() {}

--- a/apps/server/src/provider/services/provider-service.ts
+++ b/apps/server/src/provider/services/provider-service.ts
@@ -1,0 +1,60 @@
+import { Context, type Effect, type Stream } from "effect";
+
+import type {
+  AgentAvailability,
+  AgentEvent,
+  AgentSessionId,
+  AgentSessionNotFoundError,
+  AgentSessionStartError,
+  AgentTurnId,
+  ProviderId,
+  ProviderNotAvailableError,
+  StartSessionInput,
+} from "@forkzero/wire";
+
+import type { CredentialsError } from "../errors.ts";
+
+/**
+ * Public-facing service that the RPC handlers bind to. Every wire RPC
+ * (`agent.availability`, `agent.start`, `agent.send`, …) maps to one method
+ * here. The live impl (PR 5+) composes `ProviderRegistry`, `Credentials`, and
+ * the spawn-CLI helper to satisfy these.
+ */
+export interface ProviderServiceShape {
+  readonly availability: () => Effect.Effect<ReadonlyArray<AgentAvailability>>;
+
+  readonly start: (
+    input: StartSessionInput,
+  ) => Effect.Effect<
+    { readonly sessionId: AgentSessionId },
+    ProviderNotAvailableError | AgentSessionStartError
+  >;
+
+  readonly send: (
+    sessionId: AgentSessionId,
+    text: string,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+
+  readonly interrupt: (
+    sessionId: AgentSessionId,
+    turnId?: AgentTurnId,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+
+  readonly close: (
+    sessionId: AgentSessionId,
+  ) => Effect.Effect<void, AgentSessionNotFoundError>;
+
+  readonly events: (
+    sessionId: AgentSessionId,
+  ) => Stream.Stream<AgentEvent, AgentSessionNotFoundError>;
+
+  readonly setCredential: (
+    providerId: ProviderId,
+    apiKey: string,
+  ) => Effect.Effect<void, CredentialsError>;
+}
+
+export class ProviderService extends Context.Tag("forkzero/ProviderService")<
+  ProviderService,
+  ProviderServiceShape
+>() {}

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -1,0 +1,242 @@
+import { Rpc } from "@effect/rpc";
+import { Schema } from "effect";
+
+import {
+  AgentItemId,
+  AgentSessionId,
+  AgentTurnId,
+  FolderId,
+} from "./ids.ts";
+
+/**
+ * Identifier for a provider implementation (driver). v1 ships claude + codex;
+ * the literal union is the contract — adding a new provider is an additive
+ * change here plus a new driver in `apps/server/src/provider/drivers/`.
+ */
+export const ProviderId = Schema.Literal("claude", "codex");
+export type ProviderId = typeof ProviderId.Type;
+
+/**
+ * How a session is being driven. `spawn-cli` is just a PTY launch with a known
+ * argv; `sdk` runs through the in-process adapter and emits structured events.
+ */
+export const SessionMode = Schema.Literal("spawn-cli", "sdk");
+export type SessionMode = typeof SessionMode.Type;
+
+/**
+ * High-level session lifecycle state. Mirrors what the side-panel chip shows.
+ */
+export const AgentStatus = Schema.Literal(
+  "idle",
+  "starting",
+  "running",
+  "waiting",
+  "closed",
+  "error",
+);
+export type AgentStatus = typeof AgentStatus.Type;
+
+/**
+ * Static availability report for a provider — does the user have the CLI on
+ * PATH, do they have credentials configured for the SDK, what version is
+ * installed. Computed at boot and refreshed when the user changes credentials
+ * or installs a CLI.
+ */
+export const AgentAvailability = Schema.Struct({
+  providerId: ProviderId,
+  displayName: Schema.String,
+  cliInstalled: Schema.Boolean,
+  cliVersion: Schema.optional(Schema.String),
+  cliPath: Schema.optional(Schema.String),
+  sdkConfigured: Schema.Boolean,
+});
+export type AgentAvailability = typeof AgentAvailability.Type;
+
+// ---------------------------------------------------------------------------
+// Event union — emitted on agent.events stream, one row per event. The split
+// is intentionally broad so the renderer can render each kind without a giant
+// switch on payload shape; phases 3+ add fields to existing tags rather than
+// introducing new top-level shapes for the same concept.
+// ---------------------------------------------------------------------------
+
+const StartedEvent = Schema.TaggedStruct("Started", {
+  sessionId: AgentSessionId,
+  providerId: ProviderId,
+  mode: SessionMode,
+});
+
+const StatusEvent = Schema.TaggedStruct("Status", {
+  status: AgentStatus,
+});
+
+const AuthEvent = Schema.TaggedStruct("Auth", {
+  sdkConfigured: Schema.Boolean,
+});
+
+const VersionEvent = Schema.TaggedStruct("Version", {
+  cliVersion: Schema.optional(Schema.String),
+  sdkVersion: Schema.optional(Schema.String),
+});
+
+const CapabilitiesEvent = Schema.TaggedStruct("Capabilities", {
+  capabilities: Schema.Array(Schema.String),
+});
+
+const AssistantMessageEvent = Schema.TaggedStruct("AssistantMessage", {
+  itemId: AgentItemId,
+  text: Schema.String,
+});
+
+const ToolUseEvent = Schema.TaggedStruct("ToolUse", {
+  itemId: AgentItemId,
+  tool: Schema.String,
+  input: Schema.Unknown,
+});
+
+const ToolResultEvent = Schema.TaggedStruct("ToolResult", {
+  itemId: AgentItemId,
+  output: Schema.Unknown,
+  isError: Schema.Boolean,
+});
+
+/**
+ * Phase 3 surface — the SDK asks the user before doing something dangerous
+ * (running a shell command, writing outside the workspace, etc.). v2 just
+ * auto-denies and emits this so the UI can toast "Phase 3 will let you allow
+ * this."
+ */
+const PermissionRequestEvent = Schema.TaggedStruct("PermissionRequest", {
+  itemId: AgentItemId,
+  kind: Schema.String,
+  details: Schema.Unknown,
+});
+
+const CompletedEvent = Schema.TaggedStruct("Completed", {
+  reason: Schema.Literal("ended", "interrupted", "error"),
+});
+
+const ErrorEvent = Schema.TaggedStruct("Error", {
+  message: Schema.String,
+});
+
+export const AgentEvent = Schema.Union(
+  StartedEvent,
+  StatusEvent,
+  AuthEvent,
+  VersionEvent,
+  CapabilitiesEvent,
+  AssistantMessageEvent,
+  ToolUseEvent,
+  ToolResultEvent,
+  PermissionRequestEvent,
+  CompletedEvent,
+  ErrorEvent,
+);
+export type AgentEvent = typeof AgentEvent.Type;
+
+// ---------------------------------------------------------------------------
+// RPC inputs
+// ---------------------------------------------------------------------------
+
+export const StartSessionInput = Schema.Struct({
+  folderId: FolderId,
+  providerId: ProviderId,
+  mode: SessionMode,
+  initialPrompt: Schema.optional(Schema.String),
+});
+export type StartSessionInput = typeof StartSessionInput.Type;
+
+export const SendInput = Schema.Struct({
+  sessionId: AgentSessionId,
+  text: Schema.String,
+});
+export type SendInput = typeof SendInput.Type;
+
+export const InterruptInput = Schema.Struct({
+  sessionId: AgentSessionId,
+  turnId: Schema.optional(AgentTurnId),
+});
+export type InterruptInput = typeof InterruptInput.Type;
+
+export const CloseInput = Schema.Struct({
+  sessionId: AgentSessionId,
+});
+export type CloseInput = typeof CloseInput.Type;
+
+export const SetCredentialInput = Schema.Struct({
+  providerId: ProviderId,
+  apiKey: Schema.String,
+});
+export type SetCredentialInput = typeof SetCredentialInput.Type;
+
+// ---------------------------------------------------------------------------
+// Wire errors
+// ---------------------------------------------------------------------------
+
+export class ProviderNotAvailableError extends Schema.TaggedError<ProviderNotAvailableError>()(
+  "ProviderNotAvailableError",
+  { providerId: ProviderId, reason: Schema.String },
+) {}
+
+export class AgentSessionNotFoundError extends Schema.TaggedError<AgentSessionNotFoundError>()(
+  "AgentSessionNotFoundError",
+  { sessionId: AgentSessionId },
+) {}
+
+export class AgentSessionStartError extends Schema.TaggedError<AgentSessionStartError>()(
+  "AgentSessionStartError",
+  { providerId: ProviderId, reason: Schema.String },
+) {}
+
+export class CredentialStoreError extends Schema.TaggedError<CredentialStoreError>()(
+  "CredentialStoreError",
+  { providerId: ProviderId, reason: Schema.String },
+) {}
+
+// ---------------------------------------------------------------------------
+// RPC definitions. Not yet registered in `ForkzeroRpcs` — handlers come
+// online in PR 3 (availability), PR 4 (credentials), PR 5/6 (sessions). Each
+// of those PRs adds its RPC to the group when its handler exists.
+// ---------------------------------------------------------------------------
+
+export const AgentAvailabilityRpc = Rpc.make("agent.availability", {
+  payload: Schema.Struct({}),
+  success: Schema.Array(AgentAvailability),
+});
+
+export const AgentStartRpc = Rpc.make("agent.start", {
+  payload: StartSessionInput,
+  success: Schema.Struct({ sessionId: AgentSessionId }),
+  error: Schema.Union(ProviderNotAvailableError, AgentSessionStartError),
+});
+
+export const AgentSendRpc = Rpc.make("agent.send", {
+  payload: SendInput,
+  success: Schema.Void,
+  error: AgentSessionNotFoundError,
+});
+
+export const AgentInterruptRpc = Rpc.make("agent.interrupt", {
+  payload: InterruptInput,
+  success: Schema.Void,
+  error: AgentSessionNotFoundError,
+});
+
+export const AgentCloseRpc = Rpc.make("agent.close", {
+  payload: CloseInput,
+  success: Schema.Void,
+  error: AgentSessionNotFoundError,
+});
+
+export const AgentEventsRpc = Rpc.make("agent.events", {
+  payload: Schema.Struct({ sessionId: AgentSessionId }),
+  success: AgentEvent,
+  error: AgentSessionNotFoundError,
+  stream: true,
+});
+
+export const AgentSetCredentialRpc = Rpc.make("agent.setCredential", {
+  payload: SetCredentialInput,
+  success: Schema.Void,
+  error: CredentialStoreError,
+});

--- a/packages/wire/src/ids.ts
+++ b/packages/wire/src/ids.ts
@@ -10,3 +10,12 @@ export type FolderId = typeof FolderId.Type;
 
 export const PtyId = makeEntityId("PtyId");
 export type PtyId = typeof PtyId.Type;
+
+export const AgentSessionId = makeEntityId("AgentSessionId");
+export type AgentSessionId = typeof AgentSessionId.Type;
+
+export const AgentTurnId = makeEntityId("AgentTurnId");
+export type AgentTurnId = typeof AgentTurnId.Type;
+
+export const AgentItemId = makeEntityId("AgentItemId");
+export type AgentItemId = typeof AgentItemId.Type;

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./agent.ts";
 export * from "./git.ts";
 export * from "./ids.ts";
 export * from "./ping.ts";


### PR DESCRIPTION
## Summary

- Adds `packages/wire/src/agent.ts` — full event union (status/auth/version/capabilities + run events), inputs, errors, and `Rpc.make` defs for `agent.{availability,start,send,interrupt,close,events,setCredential}`. Lifted from the broader event shape on purpose so phase 3 doesn't churn the wire.
- Adds `apps/server/src/provider/` skeleton: `errors.ts`, `services/{provider-adapter,provider-registry,provider-service}.ts`, `drivers/index.ts`, empty `handlers.ts` (`Layer.empty`).
- Wires the empty `ProviderHandlersLayer` into the top-level `HandlersLayer` so PR 3+ can add handlers as pure additions.

## Out of scope (next PRs)

- PR 3 — availability detection (PATH probe + version) + spawn-CLI launcher + Cmd+K UI; registers `agent.availability` in `ForkzeroRpcs`
- PR 4 — credentials via `keytar`; registers `agent.setCredential`
- PR 5 — Claude SDK adapter; registers `agent.start` / `send` / `interrupt` / `close` / `events`
- PR 6 — Codex SDK adapter
- PR 7 — agent side panel polish + provider switcher

## Why this is zero-runtime-change

The `ForkzeroRpcs` group is unchanged in this PR — none of the new RPC defs are registered there yet. `ProviderHandlersLayer` is `Layer.empty`. Nothing in the renderer or main process invokes any new code paths.

## Test plan
- [x] `bun run build` — green
- [x] `bun run check-types` — green
- [x] `bun run lint` — green
- [ ] visual: launches and existing flows (folder pick, terminal, git pane) still work — covered by zero-runtime-change argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)