### PR TITLE
phase 2 / pr 3: agent availability + spawn-CLI launcher

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Effect } from "effect";
 
+import { AgentLauncher } from "./components/agent-launcher";
 import { FolderSidebar } from "./components/folder-sidebar";
 import { TerminalPane } from "./components/terminal-pane";
 import { GitHistoryPane } from "./components/git-history-pane";
@@ -48,6 +49,7 @@ export function App() {
         </div>
       </main>
       <GitHistoryPane />
+      <AgentLauncher />
     </div>
   );
 }

--- a/apps/renderer/src/components/agent-launcher.tsx
+++ b/apps/renderer/src/components/agent-launcher.tsx
@@ -1,0 +1,103 @@
+import { Sparkles } from "lucide-react";
+import { useEffect } from "react";
+
+import type { AgentAvailability, ProviderId } from "@forkzero/wire";
+
+import {
+  Command,
+  CommandDialog,
+  CommandDialogPopup,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandPanel,
+  CommandShortcut,
+} from "~/components/ui/command";
+import { useAgentsStore } from "../store/agents.ts";
+import { useWorkspaceStore } from "../store/workspace.ts";
+
+const INSTALL_DOCS: Record<ProviderId, string> = {
+  claude: "https://docs.claude.com/en/docs/claude-code",
+  codex: "https://github.com/openai/codex",
+};
+
+export function AgentLauncher() {
+  const open = useAgentsStore((s) => s.launcherOpen);
+  const setOpen = useAgentsStore((s) => s.setLauncherOpen);
+  const refresh = useAgentsStore((s) => s.refresh);
+  const availability = useAgentsStore((s) => s.availability);
+  const launch = useAgentsStore((s) => s.launch);
+  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
+  const folders = useWorkspaceStore((s) => s.folders);
+  const selected = selectedFolderId
+    ? (folders.find((f) => f.id === selectedFolderId) ?? null)
+    : null;
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Cmd/Ctrl+K toggles the launcher.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        useAgentsStore.getState().toggleLauncher();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const onPick = (avail: AgentAvailability) => {
+    if (!avail.cliInstalled) {
+      window.open(INSTALL_DOCS[avail.providerId], "_blank", "noopener");
+      return;
+    }
+    if (selected === null) return;
+    launch(selected.id, avail);
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandDialogPopup>
+        <Command>
+          <CommandPanel>
+            <CommandInput placeholder="Run an agent here…" />
+            <CommandList>
+              <CommandEmpty>No agents available.</CommandEmpty>
+              {availability.map((avail) => {
+                const installed = avail.cliInstalled;
+                const label = installed
+                  ? `${avail.displayName} (CLI)`
+                  : `Install ${avail.displayName}`;
+                return (
+                  <CommandItem
+                    key={avail.providerId}
+                    value={`${avail.providerId}-${label}`}
+                    onClick={() => onPick(avail)}
+                    className={
+                      installed
+                        ? undefined
+                        : "text-muted-foreground"
+                    }
+                  >
+                    <Sparkles className="size-4" />
+                    <span className="flex-1">{label}</span>
+                    {installed && avail.cliVersion !== undefined && (
+                      <CommandShortcut>{avail.cliVersion}</CommandShortcut>
+                    )}
+                    {!installed && (
+                      <CommandShortcut>not installed</CommandShortcut>
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandList>
+          </CommandPanel>
+        </Command>
+      </CommandDialogPopup>
+    </CommandDialog>
+  );
+}

--- a/apps/renderer/src/components/folder-sidebar.tsx
+++ b/apps/renderer/src/components/folder-sidebar.tsx
@@ -1,11 +1,12 @@
 import { Effect } from "effect";
-import { Plus, X } from "lucide-react";
+import { Plus, Sparkles, X } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import type { FolderId, GitOriginInfo } from "@forkzero/wire";
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { useAgentsStore } from "../store/agents.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 
 const initialsOf = (name: string): string => {
@@ -31,6 +32,7 @@ export function FolderSidebar() {
   const add = useWorkspaceStore((s) => s.add);
   const remove = useWorkspaceStore((s) => s.remove);
   const select = useWorkspaceStore((s) => s.select);
+  const openLauncher = useAgentsStore((s) => s.setLauncherOpen);
 
   // Resolved per-folder origin info, keyed by FolderId. Fetched lazily; missing
   // / failed lookups stay undefined and the row falls back to initials.
@@ -73,14 +75,26 @@ export function FolderSidebar() {
       </div>
       <div className="flex items-center justify-between px-3 py-2 text-xs text-muted-foreground">
         <span>Projects</span>
-        <button
-          type="button"
-          onClick={() => void add()}
-          className="rounded p-1 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-          aria-label="Add project"
-        >
-          <Plus className="size-3.5" />
-        </button>
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() => openLauncher(true)}
+            disabled={selectedFolderId === null}
+            className="rounded p-1 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label="Run agent here"
+            title="Run agent here (⌘K)"
+          >
+            <Sparkles className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => void add()}
+            className="rounded p-1 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            aria-label="Add project"
+          >
+            <Plus className="size-3.5" />
+          </button>
+        </div>
       </div>
 
       {error !== null && (

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -3,14 +3,18 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Effect, Fiber, Stream } from "effect";
 
-import type { Folder, PtyId } from "@forkzero/wire";
+import type { Folder, PtyCommand, PtyId } from "@forkzero/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { useAgentsStore } from "../store/agents.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 
 export function TerminalPane() {
   const folders = useWorkspaceStore((s) => s.folders);
   const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
+  const run = useAgentsStore((s) =>
+    selectedFolderId ? (s.runs[selectedFolderId] ?? null) : null,
+  );
   const selected = selectedFolderId
     ? (folders.find((f) => f.id === selectedFolderId) ?? null)
     : null;
@@ -23,8 +27,11 @@ export function TerminalPane() {
     );
   }
 
-  // Force a fresh PTY when the folder changes by keying on folder.id.
-  return <PtyTerminal key={selected.id} folder={selected} />;
+  // Force a fresh PTY when the folder or pending agent run changes. The nonce
+  // bumps every time the user picks a launcher item, so re-selecting the same
+  // provider relaunches a fresh CLI.
+  const key = run !== null ? `${selected.id}:${run.nonce}` : selected.id;
+  return <PtyTerminal key={key} folder={selected} command={run?.command ?? null} />;
 }
 
 // xterm's canvas/webgl renderer takes literal color strings, not CSS vars,
@@ -41,7 +48,13 @@ function readToken(el: HTMLElement, cssVar: string, fallback: string): string {
   return computed || fallback;
 }
 
-function PtyTerminal({ folder }: { folder: Folder }) {
+function PtyTerminal({
+  folder,
+  command,
+}: {
+  folder: Folder;
+  command: PtyCommand | null;
+}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -103,6 +116,7 @@ function PtyTerminal({ folder }: { folder: Folder }) {
             cwd: folder.path,
             cols: term.cols,
             rows: term.rows,
+            ...(command !== null ? { command } : {}),
           }),
         );
         if (cancelled) {
@@ -186,7 +200,7 @@ function PtyTerminal({ folder }: { folder: Folder }) {
       }
       term.dispose();
     };
-  }, [folder.id, folder.path]);
+  }, [folder.id, folder.path, command]);
 
   return (
     <div ref={containerRef} className="h-full w-full bg-background p-2" />

--- a/apps/renderer/src/store/agents.ts
+++ b/apps/renderer/src/store/agents.ts
@@ -1,0 +1,87 @@
+import { Effect } from "effect";
+import { create } from "zustand";
+
+import type {
+  AgentAvailability,
+  FolderId,
+  PtyCommand,
+  ProviderId,
+} from "@forkzero/wire";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
+
+/**
+ * One CLI launch request per folder. The terminal-pane keys its mount on
+ * `(folderId, nonce)` so bumping the nonce reopens a fresh PTY hosting the
+ * agent CLI instead of the default shell. Returning to the default shell is
+ * just `clear(folderId)` — the next folder switch re-mounts with no command.
+ */
+export type AgentRun = {
+  readonly providerId: ProviderId;
+  readonly command: PtyCommand;
+  readonly nonce: number;
+};
+
+type AgentsState = {
+  availability: ReadonlyArray<AgentAvailability>;
+  loading: boolean;
+  error: string | null;
+  launcherOpen: boolean;
+  runs: Record<string, AgentRun>;
+  refresh: () => Promise<void>;
+  setLauncherOpen: (open: boolean) => void;
+  toggleLauncher: () => void;
+  launch: (folderId: FolderId, availability: AgentAvailability) => void;
+  clearRun: (folderId: FolderId) => void;
+};
+
+const formatError = (err: unknown): string => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "object" && err !== null && "_tag" in err) {
+    return String((err as { _tag: unknown })._tag);
+  }
+  return String(err);
+};
+
+let nonceCounter = 0;
+
+export const useAgentsStore = create<AgentsState>((set, get) => ({
+  availability: [],
+  loading: false,
+  error: null,
+  launcherOpen: false,
+  runs: {},
+  refresh: async () => {
+    set({ loading: true, error: null });
+    try {
+      const client = await getRpcClient();
+      const list = await Effect.runPromise(client.agent.availability({}));
+      set({ availability: list, loading: false });
+    } catch (err) {
+      set({ error: formatError(err), loading: false });
+    }
+  },
+  setLauncherOpen: (open) => set({ launcherOpen: open }),
+  toggleLauncher: () => set({ launcherOpen: !get().launcherOpen }),
+  launch: (folderId, avail) => {
+    if (!avail.cliInstalled || avail.cliPath === undefined) return;
+    nonceCounter += 1;
+    set((s) => ({
+      runs: {
+        ...s.runs,
+        [folderId]: {
+          providerId: avail.providerId,
+          command: { cmd: avail.cliPath!, args: [] },
+          nonce: nonceCounter,
+        },
+      },
+      launcherOpen: false,
+    }));
+  },
+  clearRun: (folderId) =>
+    set((s) => {
+      const next = { ...s.runs };
+      delete next[folderId];
+      return { runs: next };
+    }),
+}));

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -1,0 +1,90 @@
+import { Command, CommandExecutor } from "@effect/platform";
+import { Duration, Effect, Stream } from "effect";
+
+import { AgentAvailability, type ProviderId } from "@forkzero/wire";
+
+interface ProviderProbe {
+  readonly providerId: ProviderId;
+  readonly displayName: string;
+  readonly cliBinary: string;
+}
+
+const PROBES: ReadonlyArray<ProviderProbe> = [
+  { providerId: "claude", displayName: "Claude Code", cliBinary: "claude" },
+  { providerId: "codex", displayName: "Codex", cliBinary: "codex" },
+];
+
+const PROBE_TIMEOUT = Duration.seconds(4);
+
+const collectText = (
+  s: Stream.Stream<Uint8Array, import("@effect/platform/Error").PlatformError>,
+) =>
+  s.pipe(
+    Stream.decodeText("utf-8"),
+    Stream.runFold("", (acc, chunk) => acc + chunk),
+  );
+
+const runCapture = (cmd: Command.Command) =>
+  Effect.gen(function* () {
+    const executor = yield* CommandExecutor.CommandExecutor;
+    const proc = yield* executor.start(cmd);
+    const stdout = yield* collectText(proc.stdout);
+    const exitCode = yield* proc.exitCode;
+    return { stdout: stdout.trim(), exitCode };
+  }).pipe(Effect.scoped);
+
+const probeOne = (
+  probe: ProviderProbe,
+): Effect.Effect<AgentAvailability, never, CommandExecutor.CommandExecutor> =>
+  Effect.gen(function* () {
+    const whichResult = yield* runCapture(Command.make("which", probe.cliBinary)).pipe(
+      Effect.timeoutOption(PROBE_TIMEOUT),
+      Effect.catchAll(() => Effect.succeedNone),
+    );
+
+    const cliPath =
+      whichResult._tag === "Some" && whichResult.value.exitCode === 0
+        ? whichResult.value.stdout
+        : undefined;
+
+    if (cliPath === undefined || cliPath.length === 0) {
+      return AgentAvailability.make({
+        providerId: probe.providerId,
+        displayName: probe.displayName,
+        cliInstalled: false,
+        sdkConfigured: false,
+      });
+    }
+
+    const versionResult = yield* runCapture(
+      Command.make(probe.cliBinary, "--version"),
+    ).pipe(
+      Effect.timeoutOption(PROBE_TIMEOUT),
+      Effect.catchAll(() => Effect.succeedNone),
+    );
+
+    const cliVersion =
+      versionResult._tag === "Some" && versionResult.value.exitCode === 0
+        ? versionResult.value.stdout.split(/\r?\n/)[0]?.trim() || undefined
+        : undefined;
+
+    return AgentAvailability.make({
+      providerId: probe.providerId,
+      displayName: probe.displayName,
+      cliInstalled: true,
+      cliVersion,
+      cliPath,
+      sdkConfigured: false,
+    });
+  });
+
+/**
+ * Probe each known provider for CLI install status + version. Pure helper —
+ * `ProviderService.availability()` calls this and adds the SDK-configured
+ * field once `CredentialsService` lands in PR 4.
+ */
+export const probeAllProviders: Effect.Effect<
+  ReadonlyArray<AgentAvailability>,
+  never,
+  CommandExecutor.CommandExecutor
+> = Effect.all(PROBES.map(probeOne), { concurrency: "unbounded" });

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -1,15 +1,18 @@
-import { Layer } from "effect";
+import { ForkzeroRpcs } from "@forkzero/wire";
+import { Effect, Layer } from "effect";
+
+import { ProviderService } from "./services/provider-service.ts";
 
 /**
- * Provider-domain RPC handlers. Empty in PR 2 — each subsequent PR wires its
- * RPC into `ForkzeroRpcs` (in `@forkzero/wire`) and adds the matching
- * `toLayerHandler` here:
+ * Provider-domain RPC handlers. Each subsequent PR adds a `toLayerHandler` here
+ * as it registers its RPC into `ForkzeroRpcs` (in `@forkzero/wire`):
  *
- *   PR 3 — `agent.availability`
+ *   PR 3 — `agent.availability`         ← here
  *   PR 4 — `agent.setCredential`
  *   PR 5/6 — `agent.start` / `send` / `interrupt` / `close` / `events`
- *
- * Keeping the merge wired now means later PRs are pure additions inside this
- * file — no plumbing churn.
  */
-export const ProviderHandlersLayer = Layer.empty;
+const Availability = ForkzeroRpcs.toLayerHandler("agent.availability", () =>
+  Effect.flatMap(ProviderService, (svc) => svc.availability()),
+);
+
+export const ProviderHandlersLayer = Layer.mergeAll(Availability);

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -1,0 +1,36 @@
+import { CommandExecutor } from "@effect/platform";
+import { Effect, Layer, Stream } from "effect";
+
+import { probeAllProviders } from "../availability.ts";
+import { ProviderService } from "../services/provider-service.ts";
+
+/**
+ * Live `ProviderService`. Today only `availability()` is reachable — it's the
+ * only method bound in `provider/handlers.ts`. The session-lifecycle methods
+ * (`start`/`send`/`interrupt`/`close`/`events`) are placeholders that die if
+ * called; they aren't reachable through the wire because their RPCs aren't
+ * registered in `ForkzeroRpcs` yet (PR 5/6 wires them).
+ */
+export const ProviderServiceLive = Layer.effect(
+  ProviderService,
+  Effect.gen(function* () {
+    const executor = yield* CommandExecutor.CommandExecutor;
+
+    const availability = () =>
+      probeAllProviders.pipe(Effect.provideService(CommandExecutor.CommandExecutor, executor));
+
+    const notImplemented = Effect.die(
+      "ProviderService session methods are not implemented yet (PR 5+)",
+    );
+
+    return {
+      availability,
+      start: () => notImplemented as never,
+      send: () => notImplemented as never,
+      interrupt: () => notImplemented as never,
+      close: () => notImplemented as never,
+      events: () => Stream.die("ProviderService.events not implemented yet (PR 5+)"),
+      setCredential: () => notImplemented as never,
+    };
+  }),
+);

--- a/apps/server/src/pty/handlers.ts
+++ b/apps/server/src/pty/handlers.ts
@@ -3,8 +3,10 @@ import { Effect, Layer, Stream } from "effect";
 
 import { PtyService } from "./services/pty-service.ts";
 
-const Open = ForkzeroRpcs.toLayerHandler("pty.open", ({ cwd, cols, rows }) =>
-  Effect.flatMap(PtyService, (svc) => svc.open(cwd, cols, rows)),
+const Open = ForkzeroRpcs.toLayerHandler(
+  "pty.open",
+  ({ cwd, cols, rows, command }) =>
+    Effect.flatMap(PtyService, (svc) => svc.open(cwd, cols, rows, command)),
 );
 
 const Write = ForkzeroRpcs.toLayerHandler("pty.write", ({ ptyId, data }) =>

--- a/apps/server/src/pty/layers/pty-service.ts
+++ b/apps/server/src/pty/layers/pty-service.ts
@@ -29,7 +29,7 @@ export const PtyServiceLive = Layer.effect(
   Effect.gen(function* () {
     const ref = yield* Ref.make<ReadonlyMap<PtyId, ActivePty>>(new Map());
 
-    const open: PtyService["Type"]["open"] = (cwd, cols, rows) =>
+    const open: PtyService["Type"]["open"] = (cwd, cols, rows, command) =>
       Effect.gen(function* () {
         const id = PtyId.make(crypto.randomUUID());
 
@@ -38,9 +38,12 @@ export const PtyServiceLive = Layer.effect(
           PtyNotFoundError
         >();
 
+        const cmd = command?.cmd ?? defaultShell();
+        const args = command?.args ?? [];
+
         const child = yield* Effect.try({
           try: () =>
-            pty.spawn(defaultShell(), [], {
+            pty.spawn(cmd, [...args], {
               name: "xterm-256color",
               cols,
               rows,

--- a/apps/server/src/pty/services/pty-service.ts
+++ b/apps/server/src/pty/services/pty-service.ts
@@ -1,6 +1,7 @@
 import { Context, type Effect, type Stream } from "effect";
 
 import {
+  type PtyCommand,
   type PtyEvent,
   type PtyId,
   type PtyNotFoundError,
@@ -12,6 +13,7 @@ export interface PtyServiceShape {
     cwd: string,
     cols: number,
     rows: number,
+    command?: PtyCommand,
   ) => Effect.Effect<{ readonly ptyId: PtyId }, PtySpawnError>;
   readonly write: (
     ptyId: PtyId,

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -7,6 +7,7 @@ import { ForkzeroRpcs } from "@forkzero/wire";
 import { AppPaths } from "./app-paths.ts";
 import { GitServiceLive } from "./git/layers/git-service.ts";
 import { HandlersLayer } from "./handlers.ts";
+import { ProviderServiceLive } from "./provider/layers/provider-service.ts";
 import { PtyServiceLive } from "./pty/layers/pty-service.ts";
 import { FolderPicker } from "./workspace/services/folder-picker.ts";
 import { WorkspaceServiceLive } from "./workspace/layers/workspace-service.ts";
@@ -53,10 +54,16 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(NodeContext.layer),
   );
 
+  // ProviderService probes installed CLIs via CommandExecutor.
+  const ProviderLayer = ProviderServiceLive.pipe(
+    Layer.provide(NodeContext.layer),
+  );
+
   const Handlers = HandlersLayer.pipe(
     Layer.provide(WorkspaceLayer),
     Layer.provide(PtyServiceLive),
     Layer.provide(GitLayer),
+    Layer.provide(ProviderLayer),
     Layer.provide(FolderPickerLayer),
   );
 

--- a/packages/wire/src/pty.ts
+++ b/packages/wire/src/pty.ts
@@ -28,11 +28,24 @@ export class PtySpawnError extends Schema.TaggedError<PtySpawnError>()(
   { reason: Schema.String },
 ) {}
 
+/**
+ * Optional override for what process the PTY hosts. Omitted → host the user's
+ * default login shell (Phase 1 behavior). Present → spawn `cmd` with `args` as
+ * the PTY's foreground process, used by spawn-CLI agent launches so closing
+ * the pane terminates the agent rather than just one shell among many.
+ */
+export const PtyCommand = Schema.Struct({
+  cmd: Schema.String,
+  args: Schema.Array(Schema.String),
+});
+export type PtyCommand = typeof PtyCommand.Type;
+
 export const PtyOpenRpc = Rpc.make("pty.open", {
   payload: Schema.Struct({
     cwd: Schema.String,
     cols: Schema.Number,
     rows: Schema.Number,
+    command: Schema.optional(PtyCommand),
   }),
   success: Schema.Struct({ ptyId: PtyId }),
   error: PtySpawnError,

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -1,5 +1,6 @@
 import { RpcGroup } from "@effect/rpc";
 
+import { AgentAvailabilityRpc } from "./agent.ts";
 import {
   GitHeadChangedRpc,
   GitLogRpc,
@@ -46,6 +47,7 @@ export const ForkzeroRpcs = RpcGroup.make(
   GitStatusRpc,
   GitHeadChangedRpc,
   GitOriginRpc,
+  AgentAvailabilityRpc,
 );
 export type ForkzeroRpcs = typeof ForkzeroRpcs;
 


### PR DESCRIPTION
## Summary

First user-visible Phase 2 slice: detect installed agent CLIs and launch them in the terminal pane via Cmd+K.

- **Wire** — `PtyOpenRpc` payload gains optional `command: { cmd, args }`; `AgentAvailabilityRpc` is now registered in `ForkzeroRpcs`.
- **Server** — `provider/availability.ts` probes `which claude` / `which codex` and their `--version` (4s timeout each) using `@effect/platform` Command. `ProviderService` Live exposes `availability()`; the session methods are unreachable placeholders until PR 5+ binds their RPCs.
- **Server PTY** — `PtyService.open` honors the new `command` override; default-shell behavior unchanged when omitted.
- **Renderer** — Zustand `agents` store, `<AgentLauncher>` Cmd+K palette built on the existing shadcn `CommandDialog`, and a "Run agent here" button in the folder sidebar. Selecting an installed provider re-mounts the terminal pane on a fresh PTY hosting the agent CLI; missing CLIs show a greyed row that opens install docs.

## Out of scope (later PRs)

- PR 4 — credentials service (keychain) + `sdkConfigured` field
- PR 5/6 — Claude / Codex SDK adapters + structured agent-event side panel
- PR 7 — polish + acceptance pass

## Test plan

- [ ] \`bun run dev\` boots; Phase 1 features (folder list, default shell, git pane) work unchanged
- [ ] With \`claude\` on PATH: ⌘K → "Claude Code (CLI)" → terminal pane in selected folder runs \`claude\`
- [ ] Without \`claude\` on PATH: row labelled "Install Claude Code", shown greyed, opens docs in external browser
- [ ] \`bun run check-types\` clean; \`bun run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)