### PR TITLE
phase 2 / pr 4: credentials service (keychain)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,7 +9,7 @@
     "dev:electron": "node scripts/dev-electron.mjs",
     "build": "tsdown",
     "check-types": "tsc --noEmit",
-    "postinstall": "electron-rebuild -f -w node-pty"
+    "postinstall": "electron-rebuild -f -w node-pty -w keytar"
   },
   "dependencies": {
     "@effect/rpc": "catalog:",

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Effect } from "effect";
 
 import { AgentLauncher } from "./components/agent-launcher";
+import { CredentialsSheet } from "./components/credentials-sheet";
 import { FolderSidebar } from "./components/folder-sidebar";
 import { TerminalPane } from "./components/terminal-pane";
 import { GitHistoryPane } from "./components/git-history-pane";
@@ -50,6 +51,7 @@ export function App() {
       </main>
       <GitHistoryPane />
       <AgentLauncher />
+      <CredentialsSheet />
     </div>
   );
 }

--- a/apps/renderer/src/components/agent-launcher.tsx
+++ b/apps/renderer/src/components/agent-launcher.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from "lucide-react";
+import { KeyRound, Sparkles } from "lucide-react";
 import { useEffect } from "react";
 
 import type { AgentAvailability, ProviderId } from "@forkzero/wire";
@@ -8,10 +8,13 @@ import {
   CommandDialog,
   CommandDialogPopup,
   CommandEmpty,
+  CommandGroup,
+  CommandGroupLabel,
   CommandInput,
   CommandItem,
   CommandList,
   CommandPanel,
+  CommandSeparator,
   CommandShortcut,
 } from "~/components/ui/command";
 import { useAgentsStore } from "../store/agents.ts";
@@ -28,6 +31,7 @@ export function AgentLauncher() {
   const refresh = useAgentsStore((s) => s.refresh);
   const availability = useAgentsStore((s) => s.availability);
   const launch = useAgentsStore((s) => s.launch);
+  const openCredentials = useAgentsStore((s) => s.setCredentialsOpen);
   const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
   const folders = useWorkspaceStore((s) => s.folders);
   const selected = selectedFolderId
@@ -59,6 +63,11 @@ export function AgentLauncher() {
     launch(selected.id, avail);
   };
 
+  const onOpenCredentials = () => {
+    setOpen(false);
+    openCredentials(true);
+  };
+
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
       <CommandDialogPopup>
@@ -67,33 +76,50 @@ export function AgentLauncher() {
             <CommandInput placeholder="Run an agent here…" />
             <CommandList>
               <CommandEmpty>No agents available.</CommandEmpty>
-              {availability.map((avail) => {
-                const installed = avail.cliInstalled;
-                const label = installed
-                  ? `${avail.displayName} (CLI)`
-                  : `Install ${avail.displayName}`;
-                return (
-                  <CommandItem
-                    key={avail.providerId}
-                    value={`${avail.providerId}-${label}`}
-                    onClick={() => onPick(avail)}
-                    className={
-                      installed
-                        ? undefined
-                        : "text-muted-foreground"
-                    }
-                  >
-                    <Sparkles className="size-4" />
-                    <span className="flex-1">{label}</span>
-                    {installed && avail.cliVersion !== undefined && (
-                      <CommandShortcut>{avail.cliVersion}</CommandShortcut>
-                    )}
-                    {!installed && (
-                      <CommandShortcut>not installed</CommandShortcut>
-                    )}
-                  </CommandItem>
-                );
-              })}
+              <CommandGroup>
+                <CommandGroupLabel>Run agent</CommandGroupLabel>
+                {availability.map((avail) => {
+                  const installed = avail.cliInstalled;
+                  const label = installed
+                    ? `${avail.displayName} (CLI)`
+                    : `Install ${avail.displayName}`;
+                  return (
+                    <CommandItem
+                      key={avail.providerId}
+                      value={`run-${avail.providerId}-${label}`}
+                      onClick={() => onPick(avail)}
+                      className={
+                        installed ? undefined : "text-muted-foreground"
+                      }
+                    >
+                      <Sparkles className="size-4" />
+                      <span className="flex-1">{label}</span>
+                      {installed && avail.cliVersion !== undefined && (
+                        <CommandShortcut>{avail.cliVersion}</CommandShortcut>
+                      )}
+                      {!installed && (
+                        <CommandShortcut>not installed</CommandShortcut>
+                      )}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+              <CommandSeparator />
+              <CommandGroup>
+                <CommandGroupLabel>Settings</CommandGroupLabel>
+                <CommandItem
+                  value="settings-credentials"
+                  onClick={onOpenCredentials}
+                >
+                  <KeyRound className="size-4" />
+                  <span className="flex-1">Provider credentials…</span>
+                  <CommandShortcut>
+                    {availability.filter((a) => a.sdkConfigured).length}
+                    {" / "}
+                    {availability.length}
+                  </CommandShortcut>
+                </CommandItem>
+              </CommandGroup>
             </CommandList>
           </CommandPanel>
         </Command>

--- a/apps/renderer/src/components/credentials-sheet.tsx
+++ b/apps/renderer/src/components/credentials-sheet.tsx
@@ -1,0 +1,114 @@
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+
+import type { AgentAvailability, ProviderId } from "@forkzero/wire";
+
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import {
+  Sheet,
+  SheetDescription,
+  SheetHeader,
+  SheetPanel,
+  SheetPopup,
+  SheetTitle,
+} from "~/components/ui/sheet";
+import { useAgentsStore } from "../store/agents.ts";
+
+export function CredentialsSheet() {
+  const open = useAgentsStore((s) => s.credentialsOpen);
+  const setOpen = useAgentsStore((s) => s.setCredentialsOpen);
+  const availability = useAgentsStore((s) => s.availability);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetPopup side="right">
+        <SheetHeader>
+          <SheetTitle>Provider credentials</SheetTitle>
+          <SheetDescription>
+            API keys are stored in your OS keychain and only sent to the
+            provider's SDK. They never appear in logs or transcripts.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetPanel>
+          <div className="flex flex-col gap-4">
+            {availability.map((a) => (
+              <ProviderRow key={a.providerId} availability={a} />
+            ))}
+          </div>
+        </SheetPanel>
+      </SheetPopup>
+    </Sheet>
+  );
+}
+
+function ProviderRow({ availability }: { availability: AgentAvailability }) {
+  const setCredential = useAgentsStore((s) => s.setCredential);
+  const [value, setValue] = useState("");
+  const [reveal, setReveal] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const onSave = async (id: ProviderId) => {
+    if (value.trim().length === 0) return;
+    setBusy(true);
+    setStatus(null);
+    try {
+      await setCredential(id, value.trim());
+      setValue("");
+      setStatus("Saved.");
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border bg-muted/30 p-3">
+      <div className="flex items-center justify-between">
+        <Label className="font-medium">{availability.displayName}</Label>
+        <span
+          className={
+            availability.sdkConfigured
+              ? "text-emerald-500 text-xs"
+              : "text-muted-foreground text-xs"
+          }
+        >
+          {availability.sdkConfigured ? "configured" : "not set"}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            type={reveal ? "text" : "password"}
+            placeholder="paste API key"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            disabled={busy}
+          />
+          <button
+            type="button"
+            onClick={() => setReveal((r) => !r)}
+            className="absolute end-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:text-foreground"
+            aria-label={reveal ? "Hide key" : "Reveal key"}
+            tabIndex={-1}
+          >
+            {reveal ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+          </button>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => void onSave(availability.providerId)}
+          disabled={busy || value.trim().length === 0}
+        >
+          Save
+        </Button>
+      </div>
+      {status !== null && (
+        <p className="text-muted-foreground text-xs">{status}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/renderer/src/store/agents.ts
+++ b/apps/renderer/src/store/agents.ts
@@ -27,10 +27,13 @@ type AgentsState = {
   loading: boolean;
   error: string | null;
   launcherOpen: boolean;
+  credentialsOpen: boolean;
   runs: Record<string, AgentRun>;
   refresh: () => Promise<void>;
   setLauncherOpen: (open: boolean) => void;
   toggleLauncher: () => void;
+  setCredentialsOpen: (open: boolean) => void;
+  setCredential: (providerId: ProviderId, apiKey: string) => Promise<void>;
   launch: (folderId: FolderId, availability: AgentAvailability) => void;
   clearRun: (folderId: FolderId) => void;
 };
@@ -50,6 +53,7 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
   loading: false,
   error: null,
   launcherOpen: false,
+  credentialsOpen: false,
   runs: {},
   refresh: async () => {
     set({ loading: true, error: null });
@@ -63,6 +67,20 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
   },
   setLauncherOpen: (open) => set({ launcherOpen: open }),
   toggleLauncher: () => set({ launcherOpen: !get().launcherOpen }),
+  setCredentialsOpen: (open) => set({ credentialsOpen: open }),
+  setCredential: async (providerId, apiKey) => {
+    try {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.agent.setCredential({ providerId, apiKey }),
+      );
+      // Refresh availability so `sdkConfigured` reflects the new state.
+      await get().refresh();
+    } catch (err) {
+      set({ error: formatError(err) });
+      throw err;
+    }
+  },
   launch: (folderId, avail) => {
     if (!avail.cliInstalled || avail.cliPath === undefined) return;
     nonceCounter += 1;

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -26,6 +26,7 @@
     "@effect/rpc": "catalog:",
     "@forkzero/wire": "*",
     "effect": "catalog:",
+    "keytar": "^7.9.0",
     "node-pty": "^1.1.0"
   },
   "devDependencies": {

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -1,18 +1,35 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { CredentialStoreError, ForkzeroRpcs, type ProviderId } from "@forkzero/wire";
 import { Effect, Layer } from "effect";
 
 import { ProviderService } from "./services/provider-service.ts";
 
 /**
- * Provider-domain RPC handlers. Each subsequent PR adds a `toLayerHandler` here
- * as it registers its RPC into `ForkzeroRpcs` (in `@forkzero/wire`):
+ * Provider-domain RPC handlers. Each subsequent PR adds a `toLayerHandler`
+ * here as it registers its RPC into `ForkzeroRpcs` (in `@forkzero/wire`):
  *
  *   PR 3 — `agent.availability`         ← here
- *   PR 4 — `agent.setCredential`
+ *   PR 4 — `agent.setCredential`        ← here
  *   PR 5/6 — `agent.start` / `send` / `interrupt` / `close` / `events`
  */
 const Availability = ForkzeroRpcs.toLayerHandler("agent.availability", () =>
   Effect.flatMap(ProviderService, (svc) => svc.availability()),
 );
 
-export const ProviderHandlersLayer = Layer.mergeAll(Availability);
+const SetCredential = ForkzeroRpcs.toLayerHandler(
+  "agent.setCredential",
+  ({ providerId, apiKey }) =>
+    Effect.flatMap(ProviderService, (svc) =>
+      svc.setCredential(providerId, apiKey).pipe(
+        Effect.catchTag("CredentialsError", (err) =>
+          Effect.fail(
+            new CredentialStoreError({
+              providerId: err.providerId as ProviderId,
+              reason: err.reason,
+            }),
+          ),
+        ),
+      ),
+    ),
+);
+
+export const ProviderHandlersLayer = Layer.mergeAll(Availability, SetCredential);

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -1,0 +1,67 @@
+import keytar from "keytar";
+import { Effect, Layer } from "effect";
+
+import { type ProviderId } from "@forkzero/wire";
+
+import { CredentialsError } from "../errors.ts";
+import { CredentialsService } from "../services/credentials-service.ts";
+
+const SERVICE_NAME = "forkzero";
+
+/**
+ * Keychain entries are namespaced as `apiKey:<providerId>` under the
+ * `forkzero` service. Listing uses `findCredentials(SERVICE_NAME)` and filters
+ * to the `apiKey:` prefix — keeps room for future credential kinds (refresh
+ * tokens, OAuth state) without colliding with API keys.
+ */
+const accountFor = (providerId: ProviderId): string => `apiKey:${providerId}`;
+
+const KNOWN_PROVIDERS: ReadonlyArray<ProviderId> = ["claude", "codex"];
+
+const isKnownProvider = (id: string): id is ProviderId =>
+  (KNOWN_PROVIDERS as ReadonlyArray<string>).includes(id);
+
+const tryKeychain = <A>(
+  providerId: ProviderId | "*",
+  thunk: () => Promise<A>,
+): Effect.Effect<A, CredentialsError> =>
+  Effect.tryPromise({
+    try: thunk,
+    catch: (cause) =>
+      new CredentialsError({
+        providerId: providerId === "*" ? "" : providerId,
+        reason: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      }),
+  });
+
+export const CredentialsServiceLive = Layer.succeed(
+  CredentialsService,
+  CredentialsService.of({
+    get: (providerId) =>
+      tryKeychain(providerId, () =>
+        keytar.getPassword(SERVICE_NAME, accountFor(providerId)),
+      ),
+    set: (providerId, apiKey) =>
+      tryKeychain(providerId, () =>
+        keytar.setPassword(SERVICE_NAME, accountFor(providerId), apiKey),
+      ),
+    remove: (providerId) =>
+      tryKeychain(providerId, () =>
+        keytar.deletePassword(SERVICE_NAME, accountFor(providerId)),
+      ).pipe(Effect.asVoid),
+    listConfigured: () =>
+      tryKeychain("*", () => keytar.findCredentials(SERVICE_NAME)).pipe(
+        Effect.map((entries) => {
+          const out: ProviderId[] = [];
+          for (const { account } of entries) {
+            const idx = account.indexOf(":");
+            if (idx === -1 || account.slice(0, idx) !== "apiKey") continue;
+            const id = account.slice(idx + 1);
+            if (isKnownProvider(id) && !out.includes(id)) out.push(id);
+          }
+          return out;
+        }),
+      ),
+  }),
+);

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -1,23 +1,47 @@
 import { CommandExecutor } from "@effect/platform";
 import { Effect, Layer, Stream } from "effect";
 
+import { type AgentAvailability, type ProviderId } from "@forkzero/wire";
+
 import { probeAllProviders } from "../availability.ts";
+import { CredentialsService } from "../services/credentials-service.ts";
 import { ProviderService } from "../services/provider-service.ts";
 
 /**
- * Live `ProviderService`. Today only `availability()` is reachable — it's the
- * only method bound in `provider/handlers.ts`. The session-lifecycle methods
- * (`start`/`send`/`interrupt`/`close`/`events`) are placeholders that die if
- * called; they aren't reachable through the wire because their RPCs aren't
- * registered in `ForkzeroRpcs` yet (PR 5/6 wires them).
+ * Live `ProviderService`. Today `availability()` and `setCredential()` are
+ * reachable — they're the methods bound in `provider/handlers.ts`. The
+ * session-lifecycle methods (`start`/`send`/`interrupt`/`close`/`events`) are
+ * placeholders that die if called; they aren't reachable through the wire
+ * because their RPCs aren't registered in `ForkzeroRpcs` yet (PR 5/6 wires
+ * them).
  */
 export const ProviderServiceLive = Layer.effect(
   ProviderService,
   Effect.gen(function* () {
     const executor = yield* CommandExecutor.CommandExecutor;
+    const credentials = yield* CredentialsService;
 
     const availability = () =>
-      probeAllProviders.pipe(Effect.provideService(CommandExecutor.CommandExecutor, executor));
+      Effect.gen(function* () {
+        const list = yield* probeAllProviders.pipe(
+          Effect.provideService(CommandExecutor.CommandExecutor, executor),
+        );
+        // listConfigured is best-effort — a keychain failure here shouldn't
+        // wipe out the CLI-installed picture, since the launcher still works
+        // for spawn-CLI without an API key.
+        const configured = yield* credentials.listConfigured().pipe(
+          Effect.catchAll(() =>
+            Effect.succeed([] as ReadonlyArray<ProviderId>),
+          ),
+        );
+        const configuredSet = new Set<ProviderId>(configured);
+        return list.map(
+          (a): AgentAvailability => ({
+            ...a,
+            sdkConfigured: configuredSet.has(a.providerId),
+          }),
+        );
+      });
 
     const notImplemented = Effect.die(
       "ProviderService session methods are not implemented yet (PR 5+)",
@@ -29,8 +53,9 @@ export const ProviderServiceLive = Layer.effect(
       send: () => notImplemented as never,
       interrupt: () => notImplemented as never,
       close: () => notImplemented as never,
-      events: () => Stream.die("ProviderService.events not implemented yet (PR 5+)"),
-      setCredential: () => notImplemented as never,
+      events: () =>
+        Stream.die("ProviderService.events not implemented yet (PR 5+)"),
+      setCredential: (providerId, apiKey) => credentials.set(providerId, apiKey),
     };
   }),
 );

--- a/apps/server/src/provider/services/credentials-service.ts
+++ b/apps/server/src/provider/services/credentials-service.ts
@@ -1,0 +1,33 @@
+import { Context, type Effect } from "effect";
+
+import type { ProviderId } from "@forkzero/wire";
+
+import type { CredentialsError } from "../errors.ts";
+
+/**
+ * OS-keychain-backed credential store keyed by `providerId`. Used by the SDK
+ * adapters (PR 5/6) to retrieve API keys without ever surfacing them to
+ * renderer code. Set via the `agent.setCredential` RPC; never returned over
+ * the wire — only `listConfigured()` is renderer-visible (used by the
+ * `sdkConfigured` flag in `AgentAvailability`).
+ */
+export interface CredentialsServiceShape {
+  readonly get: (
+    providerId: ProviderId,
+  ) => Effect.Effect<string | null, CredentialsError>;
+  readonly set: (
+    providerId: ProviderId,
+    apiKey: string,
+  ) => Effect.Effect<void, CredentialsError>;
+  readonly remove: (
+    providerId: ProviderId,
+  ) => Effect.Effect<void, CredentialsError>;
+  readonly listConfigured: () => Effect.Effect<
+    ReadonlyArray<ProviderId>,
+    CredentialsError
+  >;
+}
+
+export class CredentialsService extends Context.Tag(
+  "forkzero/CredentialsService",
+)<CredentialsService, CredentialsServiceShape>() {}

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -7,6 +7,7 @@ import { ForkzeroRpcs } from "@forkzero/wire";
 import { AppPaths } from "./app-paths.ts";
 import { GitServiceLive } from "./git/layers/git-service.ts";
 import { HandlersLayer } from "./handlers.ts";
+import { CredentialsServiceLive } from "./provider/layers/credentials-service.ts";
 import { ProviderServiceLive } from "./provider/layers/provider-service.ts";
 import { PtyServiceLive } from "./pty/layers/pty-service.ts";
 import { FolderPicker } from "./workspace/services/folder-picker.ts";
@@ -54,8 +55,10 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(NodeContext.layer),
   );
 
-  // ProviderService probes installed CLIs via CommandExecutor.
+  // ProviderService probes installed CLIs via CommandExecutor and consults
+  // CredentialsService to compute `sdkConfigured` per provider.
   const ProviderLayer = ProviderServiceLive.pipe(
+    Layer.provide(CredentialsServiceLive),
     Layer.provide(NodeContext.layer),
   );
 

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@effect/rpc": "catalog:",
         "@forkzero/wire": "*",
         "effect": "catalog:",
+        "keytar": "^7.9.0",
         "node-pty": "^1.1.0",
       },
       "devDependencies": {
@@ -792,9 +793,13 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.25", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA=="],
 
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -805,6 +810,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
@@ -830,7 +837,7 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -895,6 +902,8 @@
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
     "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -1022,6 +1031,8 @@
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
@@ -1080,6 +1091,8 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -1111,6 +1124,8 @@
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -1160,6 +1175,8 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -1169,6 +1186,8 @@
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
@@ -1288,6 +1307,8 @@
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
+    "keytar": ["keytar@7.9.0", "", { "dependencies": { "node-addon-api": "^4.3.0", "prebuild-install": "^7.0.1" } }, "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
@@ -1372,6 +1393,8 @@
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
@@ -1386,6 +1409,8 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -1394,7 +1419,7 @@
 
     "node-abi": ["node-abi@4.29.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-bGc7hHz6lrdpMqH3XqfiHc5PKzEhjgUj6OLpTXynkLi9JZKyMByI/tdpm4Liu6O2BjtE1lakBWXjOQS1EnSQLQ=="],
 
-    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+    "node-addon-api": ["node-addon-api@4.3.0", "", {}, "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="],
 
     "node-api-version": ["node-api-version@0.2.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q=="],
 
@@ -1494,6 +1519,8 @@
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
@@ -1528,6 +1555,8 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-day-picker": ["react-day-picker@9.14.0", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "@tabby_ai/hijri-converter": "1.0.5", "date-fns": "^4.1.0", "date-fns-jalali": "4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="],
@@ -1539,6 +1568,8 @@
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
@@ -1586,6 +1617,8 @@
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
@@ -1632,6 +1665,10 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -1659,6 +1696,8 @@
     "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ=="],
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "stringify-object": ["stringify-object@5.0.0", "", { "dependencies": { "get-own-enumerable-keys": "^1.0.0", "is-obj": "^3.0.0", "is-regexp": "^3.1.0" } }, "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg=="],
 
@@ -1688,6 +1727,10 @@
 
     "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
@@ -1715,6 +1758,8 @@
     "tsdown": ["tsdown@0.21.10", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.0", "hookable": "^6.1.1", "import-without-cache": "^0.3.3", "obug": "^2.1.1", "picomatch": "^4.0.4", "rolldown": "1.0.0-rc.17", "rolldown-plugin-dts": "^0.23.2", "semver": "^7.7.4", "tinyexec": "^1.1.1", "tinyglobby": "^0.2.16", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "unrun": "^0.2.37" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.10", "@tsdown/exe": "0.21.10", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "typescript", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "turbo": ["turbo@2.9.7", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.7", "@turbo/darwin-arm64": "2.9.7", "@turbo/linux-64": "2.9.7", "@turbo/linux-arm64": "2.9.7", "@turbo/windows-64": "2.9.7", "@turbo/windows-arm64": "2.9.7" }, "bin": { "turbo": "bin/turbo" } }, "sha512-epxzqVO2s0IxcSWcgb+qKrtco8isfe7g3VtiS6hkYnEK4A9XQDZbrtavQ6MtWR1KoQn+1fUomaQth2rfRHlUlg=="],
 
@@ -1864,6 +1909,8 @@
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
+    "@parcel/watcher/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -1934,11 +1981,17 @@
 
     "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
+    "node-pty/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "prebuild-install/node-abi": ["node-abi@3.90.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -1955,6 +2008,8 @@
     "shadcn/postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
 
     "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "tsdown/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -2055,6 +2110,8 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
+    "prebuild-install/node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shadcn/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -1,6 +1,9 @@
 import { RpcGroup } from "@effect/rpc";
 
-import { AgentAvailabilityRpc } from "./agent.ts";
+import {
+  AgentAvailabilityRpc,
+  AgentSetCredentialRpc,
+} from "./agent.ts";
 import {
   GitHeadChangedRpc,
   GitLogRpc,
@@ -48,6 +51,7 @@ export const ForkzeroRpcs = RpcGroup.make(
   GitHeadChangedRpc,
   GitOriginRpc,
   AgentAvailabilityRpc,
+  AgentSetCredentialRpc,
 );
 export type ForkzeroRpcs = typeof ForkzeroRpcs;
 


### PR DESCRIPTION
## Summary

OS-keychain-backed API key storage for the SDK adapters that land in PR 5/6. Keys never cross the wire — only \`listConfigured()\` is reachable from the renderer (used to flip the \`sdkConfigured\` flag in \`AgentAvailability\`).

- **Deps** — \`keytar\` in \`@forkzero/server\`; desktop \`electron-rebuild\` postinstall now rebuilds it for Electron's ABI.
- **Wire** — registered \`AgentSetCredentialRpc\` in \`ForkzeroRpcs\`.
- **Server** — \`CredentialsService\` (Tag + Live) wrapping keytar, namespaced as \`forkzero\` service / \`apiKey:<providerId>\` account so future credential kinds don't collide. \`ProviderService.availability()\` consults it for the per-provider \`sdkConfigured\` flag. The handler maps internal \`CredentialsError\` to the wire-level \`CredentialStoreError\` at the boundary.
- **Renderer** — \`agents\` store gains \`setCredential()\` and a \`credentialsOpen\` flag; \`<CredentialsSheet>\` is a right-side sheet with a password input (with reveal toggle) per provider and a configured/not-set badge. The launcher gets a "Provider credentials…" entry that shows configured-count and opens the sheet.

## Out of scope

- PR 5/6 — Claude / Codex SDK adapters that actually consume \`CredentialsService.get()\`
- PR 7 — polish + acceptance pass
- NDJSON transcripts (Phase 3) — credentials never enter any log path today; verified by inspection

## Base branch

This PR targets \`swarajbachu/phase2-pr3-availability\` (PR #13). It will retarget to \`main\` automatically once PR #13 lands.

## Test plan

- [ ] \`bun install && bun run dev\` boots; keytar binding rebuilds for Electron
- [ ] ⌘K → "Provider credentials…" → sheet opens, lists Claude + Codex
- [ ] Paste an API key, Save → row badge flips to "configured"; \`sdkConfigured\` reflected next time \`agent.availability\` is queried
- [ ] App restart → key persists in keychain (verify via Keychain Access.app on macOS)
- [ ] \`bun run check-types\` clean; \`bun run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)