### PR TITLE
phase 2 / pr 6: codex SDK adapter

### DIFF
--- a/apps/renderer/src/components/agent-launcher.tsx
+++ b/apps/renderer/src/components/agent-launcher.tsx
@@ -109,9 +109,7 @@ export function AgentLauncher() {
                     </CommandItem>
                   );
                 })}
-                {availability
-                  .filter((a) => a.providerId === "claude")
-                  .map((avail) => {
+                {availability.map((avail) => {
                     const ready = avail.sdkConfigured;
                     const label = `${avail.displayName} (SDK)`;
                     return (

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.126",
+    "@openai/codex-sdk": "^0.128.0",
     "@effect/platform": "catalog:",
     "@effect/platform-node": "catalog:",
     "@effect/rpc": "catalog:",

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -1,0 +1,290 @@
+import {
+  Codex,
+  type Thread,
+  type ThreadEvent,
+  type ThreadItem,
+} from "@openai/codex-sdk";
+import { Effect, Mailbox, Stream } from "effect";
+
+import {
+  AgentSessionStartError,
+  type AgentEvent,
+  type AgentItemId,
+  type AgentSessionId,
+  type StartSessionInput,
+} from "@forkzero/wire";
+
+/**
+ * Live-only handle for one Codex SDK conversation. Mirrors `ClaudeSessionHandle`
+ * — the orchestrator owns the sessionId → handle map and forwards RPCs here.
+ *
+ * Codex's Thread API is turn-scoped (each `runStreamed` is one turn) rather
+ * than the streaming-input loop Claude uses. We model `send()` as "start a new
+ * turn"; only one turn runs at a time per session, so a second `send()` while
+ * a turn is in flight is queued behind the current one.
+ */
+export interface CodexSessionHandle {
+  readonly events: Stream.Stream<AgentEvent>;
+  readonly send: (text: string) => Effect.Effect<void>;
+  readonly interrupt: () => Effect.Effect<void>;
+  readonly close: () => Effect.Effect<void>;
+}
+
+let itemCounter = 0;
+const nextItemId = (): AgentItemId =>
+  `i_${Date.now()}_${++itemCounter}` as AgentItemId;
+
+/**
+ * Translate one Codex ThreadItem into zero-or-more wire AgentEvents. We only
+ * surface the kinds that have a meaningful UI in Phase 2; reasoning, todo
+ * lists, and web search show up as `AssistantMessage` summaries so the panel
+ * isn't silent. Phase 3 will give them dedicated rows.
+ */
+const translateItem = (
+  item: ThreadItem,
+  phase: "started" | "completed",
+): ReadonlyArray<AgentEvent> => {
+  switch (item.type) {
+    case "agent_message":
+      // Only emit on completion to avoid double-rendering streaming partials.
+      if (phase !== "completed") return [];
+      return [
+        {
+          _tag: "AssistantMessage",
+          itemId: nextItemId(),
+          text: item.text,
+        },
+      ];
+    case "reasoning":
+      if (phase !== "completed") return [];
+      return [
+        {
+          _tag: "AssistantMessage",
+          itemId: nextItemId(),
+          text: `(reasoning) ${item.text}`,
+        },
+      ];
+    case "command_execution":
+      if (phase === "started") {
+        return [
+          {
+            _tag: "ToolUse",
+            itemId: nextItemId(),
+            tool: "command_execution",
+            input: { command: item.command },
+          },
+        ];
+      }
+      return [
+        {
+          _tag: "ToolResult",
+          itemId: nextItemId(),
+          output: {
+            command: item.command,
+            exit_code: item.exit_code,
+            output: item.aggregated_output,
+          },
+          isError: item.status === "failed",
+        },
+      ];
+    case "file_change":
+      if (phase !== "completed") return [];
+      return [
+        {
+          _tag: "ToolUse",
+          itemId: nextItemId(),
+          tool: "file_change",
+          input: { changes: item.changes },
+        },
+        {
+          _tag: "ToolResult",
+          itemId: nextItemId(),
+          output: { changes: item.changes, status: item.status },
+          isError: item.status === "failed",
+        },
+      ];
+    case "mcp_tool_call":
+      if (phase === "started") {
+        return [
+          {
+            _tag: "ToolUse",
+            itemId: nextItemId(),
+            tool: `${item.server}/${item.tool}`,
+            input: item.arguments,
+          },
+        ];
+      }
+      return [
+        {
+          _tag: "ToolResult",
+          itemId: nextItemId(),
+          output: item.result ?? item.error ?? null,
+          isError: item.status === "failed",
+        },
+      ];
+    case "web_search":
+      if (phase !== "completed") return [];
+      return [
+        {
+          _tag: "ToolUse",
+          itemId: nextItemId(),
+          tool: "web_search",
+          input: { query: item.query },
+        },
+      ];
+    case "todo_list":
+      if (phase !== "completed") return [];
+      return [
+        {
+          _tag: "AssistantMessage",
+          itemId: nextItemId(),
+          text:
+            "todo:\n" +
+            item.items
+              .map((t) => `${t.completed ? "[x]" : "[ ]"} ${t.text}`)
+              .join("\n"),
+        },
+      ];
+    case "error":
+      return [
+        {
+          _tag: "Error",
+          message: item.message,
+        },
+      ];
+    default:
+      return [];
+  }
+};
+
+const translateEvent = (ev: ThreadEvent): ReadonlyArray<AgentEvent> => {
+  switch (ev.type) {
+    case "thread.started":
+    case "turn.started":
+      return [];
+    case "item.started":
+      return translateItem(ev.item, "started");
+    case "item.updated":
+      return [];
+    case "item.completed":
+      return translateItem(ev.item, "completed");
+    case "turn.completed":
+      // Turn ends but session stays open — don't emit Completed here.
+      return [];
+    case "turn.failed":
+      return [{ _tag: "Error", message: ev.error.message }];
+    case "error":
+      return [{ _tag: "Error", message: ev.message }];
+    default:
+      return [];
+  }
+};
+
+/**
+ * Spin up a Codex conversation. Codex doesn't expose a streaming-input mode,
+ * so each `send()` launches a fresh `runStreamed` turn against the same
+ * Thread. A small queue serializes overlapping sends; `interrupt()` aborts
+ * the in-flight turn but leaves the thread alive for subsequent sends.
+ *
+ * `apiKey` is read from the keychain by the caller and passed to the SDK
+ * constructor. `null` is tolerated — the SDK will fall back to Codex CLI
+ * default auth (`~/.codex/auth.json`).
+ */
+export const startCodexSession = (
+  input: StartSessionInput,
+  cwd: string,
+  apiKey: string | null,
+  sessionId: AgentSessionId,
+): Effect.Effect<CodexSessionHandle, AgentSessionStartError> =>
+  Effect.gen(function* () {
+    const events = yield* Mailbox.make<AgentEvent>();
+
+    let codex: Codex;
+    let thread: Thread;
+    try {
+      codex = new Codex({
+        ...(apiKey !== null ? { apiKey } : {}),
+      });
+      thread = codex.startThread({
+        workingDirectory: cwd,
+        // Phase 2: read-only sandbox + auto-deny tools (matches Claude path).
+        sandboxMode: "read-only",
+        approvalPolicy: "never",
+        skipGitRepoCheck: true,
+      });
+    } catch (cause) {
+      yield* events.end;
+      return yield* Effect.fail(
+        new AgentSessionStartError({
+          providerId: "codex",
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+      );
+    }
+
+    events.unsafeOffer({
+      _tag: "Started",
+      sessionId,
+      providerId: "codex",
+      mode: "sdk",
+    });
+
+    // Per-turn abort + serialization. `currentAbort` is the abort controller
+    // for whichever turn is in flight (null between turns); `pending` chains
+    // sends so they run sequentially against the same thread.
+    let currentAbort: AbortController | null = null;
+    let pending: Promise<void> = Promise.resolve();
+    let closed = false;
+
+    const runTurn = async (text: string): Promise<void> => {
+      if (closed) return;
+      const abort = new AbortController();
+      currentAbort = abort;
+      try {
+        const { events: turnEvents } = await thread.runStreamed(text, {
+          signal: abort.signal,
+        });
+        for await (const ev of turnEvents) {
+          for (const out of translateEvent(ev)) {
+            events.unsafeOffer(out);
+          }
+        }
+      } catch (cause) {
+        if (!closed) {
+          events.unsafeOffer({
+            _tag: "Error",
+            message: cause instanceof Error ? cause.message : String(cause),
+          });
+        }
+      } finally {
+        if (currentAbort === abort) currentAbort = null;
+      }
+    };
+
+    const enqueueTurn = (text: string): void => {
+      pending = pending.then(() => runTurn(text));
+    };
+
+    if (input.initialPrompt !== undefined && input.initialPrompt.length > 0) {
+      enqueueTurn(input.initialPrompt);
+    }
+
+    const handle: CodexSessionHandle = {
+      events: Mailbox.toStream(events),
+      send: (text) =>
+        Effect.sync(() => {
+          enqueueTurn(text);
+        }),
+      interrupt: () =>
+        Effect.sync(() => {
+          currentAbort?.abort();
+        }),
+      close: () =>
+        Effect.gen(function* () {
+          closed = true;
+          currentAbort?.abort();
+          yield* events.end;
+        }),
+    };
+    return handle;
+  });

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -5,7 +5,6 @@ import {
   AgentSessionId,
   AgentSessionNotFoundError,
   AgentSessionStartError,
-  ProviderNotAvailableError,
   type AgentAvailability,
   type AgentEvent,
   type ProviderId,
@@ -16,6 +15,10 @@ import {
   startClaudeSession,
   type ClaudeSessionHandle,
 } from "../drivers/claude.ts";
+import {
+  startCodexSession,
+  type CodexSessionHandle,
+} from "../drivers/codex.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
 import { ProviderService } from "../services/provider-service.ts";
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
@@ -29,9 +32,10 @@ import { WorkspaceService } from "../../workspace/services/workspace-service.ts"
  * own their own scope so `close()` is the canonical teardown — there is no
  * autocleanup tied to the renderer subscription.
  */
+type SessionHandle = ClaudeSessionHandle | CodexSessionHandle;
 type SessionEntry = {
   readonly providerId: ProviderId;
-  readonly handle: ClaudeSessionHandle;
+  readonly handle: SessionHandle;
 };
 
 let sessionCounter = 0;
@@ -84,15 +88,6 @@ export const ProviderServiceLive = Layer.effect(
       availability,
       start: (input) =>
         Effect.gen(function* () {
-          if (input.providerId !== "claude") {
-            return yield* Effect.fail(
-              new ProviderNotAvailableError({
-                providerId: input.providerId,
-                reason:
-                  "Only Claude SDK is wired in this build (Codex lands in PR 6).",
-              }),
-            );
-          }
           const folder = yield* workspace.findById(input.folderId);
           if (folder === null) {
             return yield* Effect.fail(
@@ -102,16 +97,14 @@ export const ProviderServiceLive = Layer.effect(
               }),
             );
           }
-          const apiKey = yield* credentials.get("claude").pipe(
+          const apiKey = yield* credentials.get(input.providerId).pipe(
             Effect.catchAll(() => Effect.succeed<string | null>(null)),
           );
           const sessionId = nextSessionId();
-          const handle = yield* startClaudeSession(
-            input,
-            folder.path,
-            apiKey,
-            sessionId,
-          );
+          const handle: SessionHandle =
+            input.providerId === "claude"
+              ? yield* startClaudeSession(input, folder.path, apiKey, sessionId)
+              : yield* startCodexSession(input, folder.path, apiKey, sessionId);
           yield* Ref.update(sessions, (map) => {
             const next = new Map(map);
             next.set(sessionId, { providerId: input.providerId, handle });

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@effect/platform-node": "catalog:",
         "@effect/rpc": "catalog:",
         "@forkzero/wire": "*",
+        "@openai/codex-sdk": "^0.128.0",
         "effect": "catalog:",
         "keytar": "^7.9.0",
         "node-pty": "^1.1.0",
@@ -525,6 +526,22 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@openai/codex": ["@openai/codex@0.128.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.128.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.128.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.128.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.128.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.128.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.128.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.128.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.128.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.128.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.128.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ=="],
+
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.128.0", "", { "dependencies": { "@openai/codex": "0.128.0" } }, "sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.128.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.128.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 


### PR DESCRIPTION
## Summary
- Adds `@openai/codex-sdk` driver at `apps/server/src/provider/drivers/codex.ts` mirroring the Claude adapter shape (events Stream / send / interrupt / close).
- `ProviderService.start` dispatches on `providerId` instead of rejecting non-claude; `SessionEntry` holds a union handle.
- Launcher exposes "Codex (SDK)" once a Codex API key is in the keychain.

## Notes
- One `Thread` per session. `send()` enqueues a `runStreamed` turn; turns serialize on a promise chain. `interrupt()` aborts the in-flight turn but leaves the thread alive for follow-ups. `close()` aborts + ends the mailbox.
- `ThreadEvent → AgentEvent` translation covers agent_message, command_execution, file_change, mcp_tool_call, web_search, todo_list, error, turn.failed.
- Phase 2 contract preserved: `sandboxMode: "read-only"` + `approvalPolicy: "never"` (auto-deny). Phase 3 will wire real approvals.

## Test plan
- [ ] `bun run check-types` clean
- [ ] `bun run lint` clean
- [ ] With Codex API key set in keychain, Cmd+K → "Codex (SDK)" → events stream into the side panel
- [ ] Mid-turn interrupt aborts and surfaces an Error event; the same session can accept a follow-up `send`
- [ ] Quit during an active run: no orphan codex processes (`ps aux | rg codex`)
- [ ] Phase 1/2 regressions: folder add, terminal, git pane, Claude SDK still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)