### PR TITLE
spec: pivot to chat-first MVP

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,8 @@
 # forkzero — specification
 
-forkzero is a terminal-first desktop app for running coding agents. This directory holds the living specification: vision, architecture, phase roadmap, per-feature designs, and the architecture decision record.
+forkzero is a chat-first desktop app for working with coding agents (Claude Code, Codex). Three-pane layout: projects + sessions on the left, chat in the middle, files + terminal on the right. Sessions persist in SQLite. This directory holds the living specification: vision, architecture, phase roadmap, per-feature designs, and the architecture decision record.
+
+> **Spec pivoted on 2026-05-03** from terminal-first to chat-first. Phases 1–2 (foundation + agent backend) shipped under the old direction; their backend code is reused unchanged. Phase 3 (chat MVP) is the new direction's first phase. See `vision.md` for the current product shape and `roadmap.md` for the new phase numbering.
 
 ## How to read this
 

--- a/spec/decisions/0008-sqlite-persistence.md
+++ b/spec/decisions/0008-sqlite-persistence.md
@@ -1,0 +1,64 @@
+# ADR 0008 — SQLite + @effect/sql for persistence
+
+Date: 2026-05-03
+Status: Accepted
+
+## Context
+
+Phase 3 introduces persisted projects, sessions, and messages. We need:
+
+- A real database (sessions and messages can grow into thousands of rows; JSON blobs don't scale).
+- Effect-shaped DI so persistence is just another Layer alongside `WorkspaceService`, `ProviderService`, etc.
+- Migrations we can ship and never break.
+- Single-file portability — the user can back up or `sqlite3` into the data.
+- Server-side only — renderer never reads the DB directly (preserves ADR 0007's transport seam).
+
+## Decision
+
+Use **SQLite** as the storage engine and **`@effect/sql-sqlite-node`** as the client, with **`@effect/sql/Migrator`** for schema evolution. Database file at `<userData>/forkzero.sqlite`. All access goes through repository Layers in `apps/server/src/persistence/`.
+
+### Why SQLite
+
+- Zero-config, single file, fast for local desktop use.
+- Universal tooling (`sqlite3`, DataGrip, etc.) — users can inspect their own data.
+- No server process to manage.
+- Native module is already an accepted cost (we ship `keytar` and `node-pty` which need electron-rebuild; SQLite joins them).
+
+### Why `@effect/sql-sqlite-node` over alternatives
+
+- **Drizzle / Kysely:** Excellent libraries, but layering them under Effect means writing a wrapper. `@effect/sql` already speaks Effect natively (`SqlClient`, `SqlSchema.findOne`, etc.) and the `Migrator` is integrated.
+- **Raw `better-sqlite3`:** Too low-level. We'd reinvent migrations, query helpers, and DI.
+- **`@effect/sql-sqlite-bun`:** Right shape, wrong runtime — Electron's main process is Node, not Bun.
+
+### Why migrations as numbered SQL files
+
+- Same pattern the reference codebase uses; battle-tested.
+- One migration per schema change, never edit a shipped migration.
+- `effect_sql_migrations` table tracks applied migrations automatically.
+
+### Native module rebuild
+
+`@effect/sql-sqlite-node` depends on `better-sqlite3` (or `node:sqlite` on Node ≥22.16 — we lock to `better-sqlite3` for Electron compatibility). Add it to the existing `electron-rebuild -w` list alongside `keytar` and `node-pty`.
+
+## Consequences
+
+### Positive
+- Persistence becomes an ordinary Effect Layer.
+- Type-safe queries via `SqlSchema`.
+- Schema migrations are explicit and reviewable in PRs.
+- DB file is portable and inspectable.
+
+### Negative
+- Adds another native module to the rebuild pipeline.
+- Migrations require discipline — once shipped, a migration can't be edited, only superseded.
+- Effect SQL has a learning curve for contributors who haven't seen it.
+
+## Alternatives considered
+
+- **JSON files per project.** Considered for the MVP; rejected because session message lists grow unbounded and atomic updates over JSON are a pain.
+- **PostgreSQL via Docker.** Overkill for a single-user desktop app.
+- **IndexedDB in the renderer.** Breaks ADR 0007 (renderer can't be the source of truth if a CLI client wants the same data later).
+
+## Reference
+
+The pattern mirrors the persistence layer in mature Effect codebases: repository Layers expose typed methods, `SqlClient` is provided once at the top of the Layer graph, migrations live under `apps/server/src/persistence/migrations/`. This is the same shape ADR 0007 already enables for the server-as-code-only app.

--- a/spec/features/agent-integration.md
+++ b/spec/features/agent-integration.md
@@ -1,5 +1,7 @@
 # Feature: Agent integration
 
+> **UI surface updated for Phase 3.** Spawn-CLI mode (Cmd+K → "Run Claude (CLI)") is dropped from the v1 UI — the chat surface only drives SDK mode. The CLI is still reachable from the right-pane terminal (a user can manually run `claude` or `codex` there). The adapter contract below describes the SDK path, which is the only path the chat surface uses.
+
 Two modes per provider: spawn-CLI (always available if installed) and SDK (structured experience).
 
 ## Adapter contract

--- a/spec/features/git-history.md
+++ b/spec/features/git-history.md
@@ -1,5 +1,7 @@
 # Feature: Git history
 
+> **Deprecated.** This feature shipped in Phase 1 and is removed from the v1 UI in Phase 3 (chat-first MVP). The `git.*` RPCs in `@forkzero/wire` and `GitService` in `apps/server` remain, but they are no longer wired into any UI. We may bring this back as a right-pane tab post-1.0 if there's demand. See [phases/03-chat-mvp.md](../phases/03-chat-mvp.md) for the new layout.
+
 Always-visible feed of recent commits for the active folder, plus a status summary.
 
 ## What we show in Phase 1

--- a/spec/features/terminal.md
+++ b/spec/features/terminal.md
@@ -1,6 +1,6 @@
 # Feature: Terminal
 
-xterm.js renders, node-pty backs it. One terminal per folder in Phase 1; multiple in Phase 4.
+xterm.js renders, node-pty backs it. **In Phase 3 (chat MVP) the terminal moves from the main canvas to a tab in the right pane** — one terminal per project, persisted across session switches within that project. The "multiple terminals per folder" deliverable from the old Phase 4 plan is dropped from v1; if a user wants more terminals they open a real terminal alongside.
 
 ## Lifecycle
 

--- a/spec/phases/02-agents.md
+++ b/spec/phases/02-agents.md
@@ -1,8 +1,10 @@
-# Phase 2 — Agents
+# Phase 2 — Agents (backend)
 
 **Goal**: running an agent in a folder is a first-class action. Two modes: spawn the CLI in the terminal (works for everything) or use the SDK with a structured side panel.
 
-**Status**: 📐 Spec
+**Status**: ✅ Backend shipped. UI shell (Cmd+K launcher + single right-side timeline panel) is **superseded by [Phase 3 — Chat-first MVP](03-chat-mvp.md)**. The backend (provider availability, credentials, Claude/Codex SDK adapters, `agent.events` stream) is reused unchanged in Phase 3.
+
+> **Heads up:** This file describes the original terminal-first plan. It is kept for history. The current product direction is chat-first — see `vision.md` and `phases/03-chat-mvp.md`.
 
 **Estimate**: ~4 weeks
 

--- a/spec/phases/03-chat-mvp.md
+++ b/spec/phases/03-chat-mvp.md
@@ -1,0 +1,187 @@
+# Phase 3 — Chat-first MVP
+
+Status: 📐 Spec
+
+## Goal
+
+Replace forkzero's terminal-first UI shell with a three-pane chat IDE. By the end of Phase 3 a user can: pick a project from the left sidebar, open a chat session, send messages with markdown rendering, watch tool calls expand inline, browse the project's file tree on the right, and run shell commands in a side terminal. Sessions persist across app restart and can be archived.
+
+The backend shipped in Phase 2 (provider adapters, credentials, `agent.events` stream) is reused unchanged. What changes is: persistence, layout, the chat surface, and dropping the launcher / git pane.
+
+## Layout
+
+```
+┌────────────────┬────────────────────────────────┬──────────────────┐
+│  Projects      │  Chat                          │  Files / Terminal│
+└────────────────┴────────────────────────────────┴──────────────────┘
+```
+
+Three resizable columns. Left and right are collapsible (≥768px width threshold). Center is always visible.
+
+### Left — projects + sessions
+
+- Project list (today's "folders"). `+ New project` opens the OS folder picker.
+- Each project expands to show its sessions, ordered by `updatedAt` desc.
+- Sessions: title (auto-generated from first user message, editable), `archived` flag (archived sessions hidden behind a toggle), `+ New session` button per project.
+- Right-click / long-press on a session: rename, archive, delete.
+- Selecting a session loads its message history into the center pane.
+
+### Center — chat
+
+- Message timeline (scrollable, auto-scroll on new message unless user has scrolled up).
+- Roles: `user` (right-aligned), `assistant` (left-aligned), `tool` (inline collapsible blocks within the assistant's turn).
+- Markdown + code blocks rendered (`react-markdown` + `shiki` for syntax highlighting).
+- Tool calls render as expandable rows: header shows tool name + one-line summary, expanded shows JSON input + output.
+- `edit_file` tool calls render a unified diff (Phase 4 polish; Phase 3 ships the JSON view first).
+- Composer at the bottom: textarea + model picker dropdown + send button. `Cmd/Ctrl+Enter` sends.
+- Composer disabled while a turn is in flight; an "Interrupt" button replaces send during a turn.
+
+### Right — files + terminal (tabbed)
+
+- **Files tab.** Read-only file tree of the project. Lazy-load directories. Click a file → preview in a sheet (Phase 3 ships file path + size; full preview is Phase 4 polish).
+- **Terminal tab.** Reuses Phase 1's PTY service. One terminal per project, persisted across session switches within the same project.
+- Tab bar at top of the right pane. Pane is collapsible.
+
+## Persistence
+
+SQLite via `@effect/sql-sqlite-node` + `@effect/sql/Migrator`. Database file at `<userData>/forkzero.sqlite`. See [ADR 0008](../decisions/0008-sqlite-persistence.md) for the full rationale.
+
+### Schema (initial migration)
+
+```sql
+-- projects: a folder the user has added to forkzero.
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,                 -- existing FolderId from Phase 1
+  path TEXT NOT NULL,
+  name TEXT NOT NULL,
+  default_model TEXT,                  -- last model used, restored on new session
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- sessions: one chat thread within a project.
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,                 -- AgentSessionId
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  provider_id TEXT NOT NULL,           -- "claude" | "codex"
+  model TEXT NOT NULL,                 -- e.g. "claude-opus-4-7"
+  status TEXT NOT NULL,                -- "idle" | "running" | "closed" | "error"
+  archived_at TEXT,                    -- NULL = active
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX idx_sessions_project ON sessions(project_id, archived_at, updated_at DESC);
+
+-- messages: user/assistant turns, plus inline tool-call rows.
+CREATE TABLE messages (
+  id TEXT PRIMARY KEY,                 -- AgentItemId (or new MessageId)
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,                  -- "user" | "assistant" | "tool"
+  kind TEXT NOT NULL,                  -- "text" | "tool_use" | "tool_result" | "error"
+  content_json TEXT NOT NULL,          -- shape varies by kind
+  created_at TEXT NOT NULL
+);
+CREATE INDEX idx_messages_session ON messages(session_id, created_at);
+```
+
+Schema changes ship as numbered migrations under `apps/server/src/persistence/migrations/`. We never edit a shipped migration; we add a new one.
+
+### How events become rows
+
+The Phase 2 `AgentEvent` stream (over `agent.events` RPC) is consumed by a `MessageStore` service in the server. As events arrive, they're persisted to `messages` and re-broadcast to the renderer over the existing stream. The renderer never reads SQLite directly — it goes through RPCs, which means the WS-server extraction story still works.
+
+## RPC additions
+
+New methods (added to `ForkzeroRpcs` in `packages/wire`):
+
+- `session.list(projectId, includeArchived)` → `Session[]`
+- `session.create(projectId, providerId, model, initialPrompt?)` → `Session` (replaces `agent.start`)
+- `session.rename(sessionId, title)`
+- `session.archive(sessionId)` / `session.unarchive(sessionId)`
+- `session.delete(sessionId)`
+- `messages.list(sessionId)` → `Message[]` (cold-load history)
+- `messages.stream(sessionId)` → `Stream<Message>` (live updates; renames `agent.events` and broadens it to include user messages)
+- `fs.tree(projectId, path?)` → directory listing for the right-pane Files tab
+
+`agent.start` / `agent.send` / `agent.interrupt` / `agent.close` stay; they become internal to `session.*` (renderer no longer calls them directly).
+
+## What gets removed
+
+- `apps/renderer/src/components/agent-launcher.tsx` (Cmd+K launcher) — replaced by `+ New session` button.
+- `apps/renderer/src/components/agent-panel.tsx` — replaced by the chat surface.
+- `apps/renderer/src/components/agent-event-row.tsx` — replaced by per-role chat rows.
+- `apps/renderer/src/components/git-history-pane.tsx` — git history is no longer in the v1 UI. (Code lives in git history if we want to bring it back as a tab later.)
+- `git.log` / `git.status` / `git.headChanged` / `git.origin` RPCs — kept in `packages/wire` for now (cheap to keep) but unwired from the UI.
+
+## Sub-PR breakdown
+
+Seven PRs. Each independently shippable.
+
+### PR 1 — SQLite + persistence scaffolding
+- Add `@effect/sql` + `@effect/sql-sqlite-node` deps, write `apps/server/src/persistence/Sqlite.ts` (client + Migrator layer).
+- Migration `001_initial.sql` with `projects`, `sessions`, `messages` tables.
+- `ProjectRepository`, `SessionRepository`, `MessageRepository` Layers (CRUD; no business logic yet).
+- DB file at `<userData>/forkzero.sqlite`; `:memory:` flag for tests.
+- No UI changes. Existing folders backfill into `projects` on boot.
+
+### PR 2 — session RPCs + MessageStore
+- Add `session.*` and `messages.*` RPCs to `@forkzero/wire`.
+- `MessageStore` service: subscribes to `AgentEvent` stream from Phase 2, persists each event as a `messages` row, re-emits.
+- Wire `session.create` to call existing `agent.start` internally.
+- Old `agent.*` RPCs stay (still used by `MessageStore` internally).
+
+### PR 3 — left sidebar (projects + sessions)
+- New `components/projects-sidebar.tsx` — list projects, expand to sessions, `+ New session`, right-click menu (rename / archive / delete).
+- Replace `folder-sidebar.tsx` content; keep the existing folder picker / persistence path.
+- `store/sessions.ts` — Zustand store with `sessions` keyed by project, selected session, hydration via `session.list`.
+
+### PR 4 — chat surface (center pane)
+- New `components/chat-view.tsx` — message timeline + auto-scroll.
+- New `components/chat-composer.tsx` — textarea + model picker + send/interrupt.
+- New `components/message-row.tsx` — user / assistant / tool variants.
+- `react-markdown` + `shiki` for rendering. No diff viewer yet.
+- Hooks up `messages.list` for cold load + `messages.stream` for live.
+
+### PR 5 — right pane (files + terminal tabs)
+- New `components/right-pane.tsx` with tabs.
+- `components/file-tree.tsx` — lazy-loading tree backed by `fs.tree` RPC.
+- `fs.tree` server impl using `@effect/platform` `FileSystem` (skip `.git`, `node_modules`).
+- Terminal tab: reuse existing `terminal-pane.tsx`.
+- Drop `git-history-pane.tsx` from layout.
+
+### PR 6 — model picker + per-session model persistence
+- Add `model` field to `StartSessionInput` (wire) + `sessions.model` column.
+- Renderer composer dropdown lists provider × model combinations (claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5, gpt-5-codex, etc.).
+- Default model: project's `default_model`, or last-used.
+
+### PR 7 — polish + acceptance pass
+- Auto-title sessions from first user message (truncate to 60 chars).
+- Empty states: no projects, no sessions, missing API key, network error.
+- Walk every Phase 3 acceptance criterion below; flip status to ✅ Shipped.
+
+## Acceptance criteria
+
+A1. Add a project. Open a session. Send a message. Assistant streams back; markdown renders; tool calls expand on click.
+
+A2. Quit the app mid-conversation. Reopen. Project + session list intact. Selecting the session shows full history.
+
+A3. Archive a session. It disappears from the default list; toggling "Show archived" shows it again. Unarchive restores.
+
+A4. With both Claude and Codex API keys set, open the model picker — both providers and their models are listed. Switching model in the composer applies to the next message.
+
+A5. Right pane Files tab: project tree renders. Click a folder, it expands.
+
+A6. Right pane Terminal tab: PTY opens in project root. `pnpm dev` runs and streams output.
+
+A7. Quit during an active turn. Reopen. Session shows up to the last persisted event with a "(interrupted)" marker. Sending again starts a new turn.
+
+A8. Interrupt button: clicking it during a turn aborts it within ~500ms. The partial assistant message is preserved.
+
+## Non-goals (deferred to Phase 4+)
+
+- Permission prompts UI (still auto-deny in Phase 3)
+- File preview / inline diff rendering
+- Session search
+- "Always allow X" memory
+- NDJSON transcript export

--- a/spec/phases/04-permissions.md
+++ b/spec/phases/04-permissions.md
@@ -1,12 +1,14 @@
-# Phase 3 — Permissions & sessions
+# Phase 4 — Permissions & quality
 
-**Goal**: agents become trustworthy enough to leave running unattended.
+**Goal**: agents become trustworthy enough to leave running unattended. Add the missing UX around the chat MVP (real permission prompts, inline diffs, resume).
 
 **Status**: 📐 Spec
 
 **Estimate**: ~2 weeks
 
-**Depends on**: Phase 2
+**Depends on**: Phase 3 (chat MVP)
+
+> **Note:** Renumbered from "Phase 3" when the chat-first pivot inserted the new Phase 3. Session persistence moved up into Phase 3 (it's foundational to the chat UI). What's left here is permissions UI, inline diff rendering, resume of interrupted turns, and NDJSON transcript export.
 
 ## Deliverables
 

--- a/spec/phases/05-polish.md
+++ b/spec/phases/05-polish.md
@@ -1,4 +1,4 @@
-# Phase 4 — Polish & distribution
+# Phase 5 — Polish & distribution
 
 **Goal**: ship a 1.0 that someone other than you would happily install.
 
@@ -6,7 +6,9 @@
 
 **Estimate**: ~3 weeks
 
-**Depends on**: Phase 3
+**Depends on**: Phase 4
+
+> **Note:** Renumbered from "Phase 4" when the chat-first pivot inserted Phase 3 (chat MVP). The "multiple terminals per folder (tabs)" deliverable from the original Phase 4 is dropped — the v1 UI has one terminal per project in the right pane and that's enough. Git diff viewer / branch indicator / branch switcher are also dropped (the old git-history pane is removed in Phase 3). What remains: cross-project session search, themes, keybindings, code signing, auto-update, multi-OS packaging.
 
 ## Deliverables
 

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -1,73 +1,79 @@
 # Roadmap
 
-Estimates assume a single developer, ~6 productive hours/day, with a capable LLM pair-programmer. **Add 30% to anything Effect-touching while learning** — these estimates already include that headroom.
+Estimates assume a single developer, ~6 productive hours/day, with a capable LLM pair-programmer. Effect-touching work has 30% headroom baked in.
 
-## Phase 1 — Foundation (≈4 weeks)
+## Phase 1 — Foundation ✅ (shipped)
 
-Make the scaffold real. By the end you can pick a folder, run a real shell in it, and watch the git history update as you commit.
-
-- Folder sidebar with `+` button and persistence
-- Real PTY terminal per folder (one terminal per folder in this phase)
-- Real `git log` + status pane
+- Folder sidebar + persistence
+- Real PTY terminal
 - Effect runtime + Layer architecture in both processes
-- Typed IPC contracts in `packages/wire`
+- Typed RPC contracts in `packages/wire`
 
-→ See [phases/01-foundation.md](phases/01-foundation.md)
+## Phase 2 — Agents (backend) ✅ (shipped)
 
-## Phase 2 — Agents (≈4 weeks)
+- Provider availability detection (Claude / Codex CLIs + SDK keys)
+- Keychain-backed credentials
+- Claude SDK adapter + Codex SDK adapter
+- Streaming `AgentEvent` union over RPC
 
-The headline. Run Claude Code / Codex as either a spawned CLI in the terminal (cheap fallback) or via SDK with a structured side panel showing tool calls and proposed edits.
+The UI shipped in Phase 2 (Cmd+K launcher + single right-side timeline panel) is **deprecated** — see Phase 3 for the chat-first replacement. The backend (RPCs, drivers, credentials) is unchanged and reused.
 
-- Detect installed `claude` / `codex` CLIs; one-click "run in this folder"
-- Claude Code SDK adapter with streaming events
-- Codex SDK adapter
-- Tool-call timeline UI alongside the terminal
-- Agent provider switcher per session
+## Phase 3 — Chat-first MVP (next, ~3–4 weeks)
 
-→ See [phases/02-agents.md](phases/02-agents.md)
+The pivot. Replace the terminal-first shell with a three-pane chat IDE.
 
-## Phase 3 — Permissions & sessions (≈2 weeks)
+- SQLite persistence layer (`@effect/sql-sqlite-node` + `@effect/sql/Migrator`)
+- Projects → sessions → messages schema; sessions are persisted + archivable
+- Three-pane layout: projects/sessions sidebar, chat in center, files+terminal on the right
+- Chat composer with model picker; markdown + code rendering
+- Tool calls render inline as collapsible blocks
+- Right pane: file tree (read-only) + terminal tab
+- Drop the Cmd+K launcher and the single-session right panel; drop the git history pane
 
-Make agents trustworthy enough to leave running.
+→ See [phases/03-chat-mvp.md](phases/03-chat-mvp.md)
 
-- Permission prompts: file write, command run, network access
+## Phase 4 — Permissions & quality (~2 weeks)
+
+Make the agent trustworthy enough to leave running.
+
+- Permission prompts UI (file write / shell command / network) — replace Phase 2's auto-deny
 - Per-session "always allow X" memory
-- Session persistence + resume across app restart
-- Agent run transcripts (NDJSON) for replay/audit
+- Resume an interrupted session after restart
+- Inline diff rendering for `edit_file` tool calls
+- NDJSON transcript export per session
 
-→ See [phases/03-permissions-and-sessions.md](phases/03-permissions-and-sessions.md)
+→ See [phases/04-permissions.md](phases/04-permissions.md)
 
-## Phase 4 — Polish & distribution (≈3 weeks)
+## Phase 5 — Polish & distribution (~3 weeks)
 
-Make it shippable.
-
-- Multiple terminals per folder (tabs)
-- Git diff viewer (per commit, vs working tree)
-- Branch indicator + switcher
+- Session search across projects
+- Bulk archive / delete
 - Themes + keybindings
+- macOS code signing & notarization
 - Auto-update via electron-updater
-- macOS signing & notarization (Linux + Windows packaging follow)
+- Linux + Windows packaging
 
-→ See [phases/04-polish-and-distribution.md](phases/04-polish-and-distribution.md)
+→ See [phases/05-polish.md](phases/05-polish.md)
 
 ## Total
 
 | Milestone | Calendar |
 |---|---|
-| Personal-use MVP (Phase 1) | ~4 weeks |
-| Public alpha (Phases 1–2) | ~8 weeks |
-| Public beta (Phases 1–3) | ~10 weeks |
-| 1.0 (Phases 1–4) | **~3–4 months** |
+| Backend complete (Phases 1–2) | shipped |
+| Chat MVP private alpha (Phase 3) | ~4 weeks from now |
+| Trust release (Phase 4) | ~6 weeks from now |
+| 1.0 (Phases 1–5) | ~10 weeks from now |
 
-## Beyond 1.0 (post-roadmap, designed for from day one)
+## Beyond 1.0
 
-The architecture (`apps/server` as a code-only app today, designed for extraction; transport-agnostic renderer) supports these without re-architecture. Each becomes a focused PR rather than a redesign.
+ADR 0007's transport-agnostic split keeps these costs bounded — each becomes a focused PR, not a redesign.
 
-| Milestone | What changes | Estimate |
-|---|---|---|
-| **Remote desktop access** | `apps/server/src/bin.ts` becomes a real WS server boot; Electron spawns it as a subprocess; renderer's transport seam picks WS when running outside Electron. SSH + port-forward enables remote use. | ~1 week |
-| **CLI client** | New `apps/cli/` consuming `@forkzero/wire` over the WS transport. | ~1 week |
-| **Multi-window / multi-renderer** | Multiple Electron renderers (or browser tabs) connected to one backend. Backend already supports it; just wire window management. | ~3 days |
-| **Mobile client** | Native or web-based mobile app speaking WS to a desktop's server over LAN/tunnel. Re-uses `apps/renderer` as a packaging target where feasible. | TBD |
+| Milestone | What changes |
+|---|---|
+| Remote desktop access | `apps/server/src/bin.ts` becomes a real WS server boot; renderer's transport seam picks WS when running outside Electron. |
+| CLI client | New `apps/cli/` consuming `@forkzero/wire` over the WS transport. |
+| Multi-window | Multiple Electron renderers connected to one backend — backend already supports it. |
+| Mobile client | Native or web mobile app speaking WS to a desktop's server over LAN/tunnel. |
 
-See [ADR 0007](decisions/0007-server-as-code-only-app.md) for the architectural rules that keep these costs bounded.
+See [ADR 0007](decisions/0007-server-as-code-only-app.md) for the rules that keep these costs bounded.
+See [ADR 0008](decisions/0008-sqlite-persistence.md) for the persistence story underpinning Phase 3.

--- a/spec/vision.md
+++ b/spec/vision.md
@@ -2,35 +2,62 @@
 
 ## What forkzero is
 
-A desktop app where coding agents are first-class citizens. The terminal is the main canvas. You add folders to a sidebar, open one, and either type into the terminal yourself or hand the keyboard to an agent. Git history of the open project is always visible alongside.
+A desktop app for working with coding agents (Claude Code, Codex) chat-first. You add a project to the sidebar, open a session, and chat with an agent that has full access to that project's files. The agent does the work; you review the diff. A file tree and a real terminal sit on the right so you can run `pnpm dev`, `tsc --noEmit`, or `ls` without leaving the app.
+
+The mental model is closer to Cursor's "Composer" or T3 Chat, not VS Code. The chat is the canvas; the file tree and terminal are tools you reach for when needed.
 
 ## What forkzero is not
 
-- Not a full IDE. We do not own the editor surface — open files in your editor of choice.
-- Not a chat app. Conversations happen inside terminals or agent panels, not in a separate "chat" UI.
-- Not cloud. Everything runs on the user's machine; agent credentials stay local.
-- Not multi-user / collaborative. Single-user desktop tool.
+- **Not an editor.** We don't own the editor surface. Open files in your editor of choice; forkzero shows file contents inline in chat, but doesn't let you edit them in-app.
+- **Not a terminal-first tool.** The terminal is on the right panel, available, but it's not the primary surface. If you want a terminal-first agent UX, use Claude Code or Codex CLI directly.
+- **Not cloud.** Sessions, messages, credentials live on disk. No telemetry without opt-in.
+- **Not multi-user / collaborative.** Single-user desktop tool.
 
 ## Target user
 
 A developer who:
-- Already uses Claude Code / Codex CLI from a terminal
-- Wants to run agents in parallel across multiple repos without juggling tmux panes
-- Wants to see what the agent did (git diff, log) without leaving the app
-- Is comfortable with the command line — we optimize for keyboard, not mouse
+- Already pays for / uses Claude Code, Codex, or both
+- Wants chat-first agent interaction (read assistant prose, expand tool calls inline) over a terminal stream
+- Runs many projects, wants per-project session history that persists across restart, and wants to archive sessions instead of deleting them
+- Needs a real terminal occasionally (run dev server, run a script, sanity-check a path) but doesn't live in it
 
 ## Principles
 
-1. **Terminal first.** Every feature must coexist with "I just want to type into a shell." Don't hide the prompt behind UI.
-2. **Local by default.** No telemetry without an explicit opt-in. No cloud features in v1.
-3. **Open formats.** Sessions, history, and config stored as files a user can read and back up.
-4. **One way to do each thing.** Resist configuration sprawl; pick a default, document the why.
-5. **Boring tech where possible.** Effect.ts is the one ambitious choice — everything else is the obvious option.
+1. **Chat-first.** The center of the screen is a message timeline + composer. Tool calls render inline as collapsible blocks. Markdown + code is rendered, not raw.
+2. **One project, many sessions.** Each project has a list of sessions (active + archived). Sessions persist; closing the app does not lose them.
+3. **Local by default.** SQLite on disk, keychain for credentials, no telemetry without opt-in.
+4. **Open formats.** Sessions and messages live in a SQLite database the user can read with `sqlite3`. Credentials in the OS keychain.
+5. **One way to do each thing.** Resist configuration sprawl. Pick a default, document the why.
+6. **Boring tech where possible.** Effect.ts + SQLite + React. No bespoke databases, no custom protocols.
+
+## Layout (MVP)
+
+```
+┌────────────────┬────────────────────────────────┬──────────────────┐
+│  Projects      │  Chat                          │  Files / Terminal│
+│  └ Project A   │  ┌──────────────────────────┐  │  ┌─────────────┐ │
+│    ├ session 1 │  │ assistant: Sure, I'll... │  │  │ src/        │ │
+│    ├ session 2 │  │   ▸ tool: read_file …    │  │  │ ├ index.ts  │ │
+│    └ archived  │  │   ▸ tool: edit_file …    │  │  │ └ …         │ │
+│  └ Project B   │  │ user: actually, …        │  │  ├─────────────┤ │
+│    └ session 1 │  └──────────────────────────┘  │  │ $ pnpm dev  │ │
+│  + New project │  ┌──────────────────────────┐  │  │ Listening … │ │
+│                │  │ [model: claude-opus-4.7]│  │  └─────────────┘ │
+│                │  │ Type a message…         │  │                  │
+│                │  └──────────────────────────┘  │                  │
+└────────────────┴────────────────────────────────┴──────────────────┘
+```
+
+Left: workspace + sessions (persisted, archivable, "+ new session" button).
+Center: chat timeline + composer. Composer has a model picker.
+Right: tabbed pane — **Files** (read-only file tree of the project) and **Terminal** (a real PTY that opens in the project root). Right pane is collapsible.
 
 ## Non-goals (v1)
 
-- Plugin/extension system
-- Multiple windows or detachable panes
+- In-app code editor / file editing
+- Plugin / extension system
+- Multiple windows / detachable panes
 - Remote / SSH workspaces
-- Built-in code editor
 - Cloud sync of sessions
+- Collaboration / shared sessions
+- Mobile / web client (architecture supports it post-1.0; not on the v1 roadmap)


### PR DESCRIPTION
## Summary
- Pivots forkzero from terminal-first to chat-first. Three-pane layout: projects + sessions on the left, chat in the center, files + terminal on the right.
- Phases 1–2 (foundation + agent backend) marked shipped; their backend code (provider availability, credentials, Claude/Codex SDK adapters, `agent.events`) is reused unchanged.
- New Phase 3 (chat MVP) replaces the Phase 2 UI shell. Old Phases 3/4 renumbered to 4/5.
- ADR 0008 locks SQLite + `@effect/sql-sqlite-node` + `@effect/sql/Migrator` as the persistence story.

## Phase 3 PR breakdown (in `spec/phases/03-chat-mvp.md`)
1. SQLite + persistence scaffolding (schema, repositories, migrator)
2. Session/message RPCs + `MessageStore` that persists `AgentEvent`s
3. Left sidebar: projects + sessions tree, archive, rename
4. Chat surface (timeline + composer with model picker, markdown + shiki)
5. Right pane: files (read-only tree) + terminal tabs
6. Per-session model persistence + provider × model picker
7. Polish + acceptance pass

## What gets removed in Phase 3
- `agent-launcher.tsx` (Cmd+K launcher) → replaced by "+ New session"
- `agent-panel.tsx` + `agent-event-row.tsx` → replaced by chat surface
- `git-history-pane.tsx` → removed from v1 UI; `git.*` RPCs kept
- "Multiple terminals per folder" deliverable from old Phase 4 → dropped

## Test plan
- [ ] Read `spec/vision.md` and confirm the new product shape matches the screenshot
- [ ] Read `spec/phases/03-chat-mvp.md` schema and acceptance criteria
- [ ] Read ADR 0008 and confirm `@effect/sql-sqlite-node` is the right choice (vs Drizzle / `better-sqlite3` direct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)