### PR TITLE
phase 4: permissions, resume, inline diff, NDJSON export

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -21,6 +21,7 @@
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "diff": "^9.0.0",
     "effect": "catalog:",
     "lucide-react": "^1.14.0",
     "react": "catalog:",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@repo/typescript-config": "*",
     "@tailwindcss/vite": "^4.0.0",
+    "@types/diff": "^8.0.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -4,9 +4,11 @@ import { Effect } from "effect";
 import { ChatComposer } from "./components/chat-composer";
 import { ChatView } from "./components/chat-view";
 import { CredentialsSheet } from "./components/credentials-sheet";
+import { PermissionToast } from "./components/permission-toast";
 import { ProjectsSidebar } from "./components/projects-sidebar";
 import { RightPane } from "./components/right-pane";
 import { getRpcClient } from "./lib/rpc-client.ts";
+import { usePermissionsStore } from "./store/permissions.ts";
 import { useSessionsStore } from "./store/sessions.ts";
 import { useWorkspaceStore } from "./store/workspace.ts";
 
@@ -25,6 +27,11 @@ export function App() {
   const selectedFolder = selectedFolderId
     ? (folders.find((f) => f.id === selectedFolderId) ?? null)
     : null;
+
+  const startPermissionsStream = usePermissionsStore((s) => s.start);
+  useEffect(() => {
+    startPermissionsStream();
+  }, [startPermissionsStream]);
 
   useEffect(() => {
     let cancelled = false;
@@ -63,6 +70,7 @@ export function App() {
         </header>
         {selectedSessionId !== null && selectedSession !== null ? (
           <>
+            <PermissionToast sessionId={selectedSessionId} />
             <ChatView sessionId={selectedSessionId} />
             <ChatComposer session={selectedSession} />
           </>

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -1,0 +1,219 @@
+import { structuredPatch } from "diff";
+import { ChevronDown, ChevronRight, FileEdit } from "lucide-react";
+import { useMemo, useState } from "react";
+
+const COLLAPSE_THRESHOLD_LINES = 30;
+
+interface FileEdit {
+  readonly path: string;
+  readonly oldText: string;
+  readonly newText: string;
+  readonly mode: "edit" | "create";
+}
+
+/**
+ * Best-effort extraction of a `(path, old, new)` triple from a Claude
+ * `Edit` / `Write` / `MultiEdit` tool input. Tools we can't parse fall back
+ * to the JSON view at the call site — never throws.
+ */
+const extractEdits = (tool: string, input: unknown): ReadonlyArray<FileEdit> => {
+  if (input === null || typeof input !== "object") return [];
+  const obj = input as Record<string, unknown>;
+  const path = typeof obj.file_path === "string" ? obj.file_path : null;
+
+  if (tool === "Edit") {
+    if (path === null) return [];
+    const oldText = typeof obj.old_string === "string" ? obj.old_string : "";
+    const newText = typeof obj.new_string === "string" ? obj.new_string : "";
+    return [{ path, oldText, newText, mode: "edit" }];
+  }
+
+  if (tool === "Write") {
+    if (path === null) return [];
+    const newText = typeof obj.content === "string" ? obj.content : "";
+    return [{ path, oldText: "", newText, mode: "create" }];
+  }
+
+  if (tool === "MultiEdit") {
+    if (path === null) return [];
+    const edits = Array.isArray(obj.edits) ? obj.edits : [];
+    const out: FileEdit[] = [];
+    for (const e of edits) {
+      if (e === null || typeof e !== "object") continue;
+      const r = e as Record<string, unknown>;
+      out.push({
+        path,
+        oldText: typeof r.old_string === "string" ? r.old_string : "",
+        newText: typeof r.new_string === "string" ? r.new_string : "",
+        mode: "edit",
+      });
+    }
+    return out;
+  }
+
+  return [];
+};
+
+interface DiffLine {
+  readonly kind: "context" | "add" | "del" | "hunk";
+  readonly text: string;
+  readonly oldLine: number | null;
+  readonly newLine: number | null;
+}
+
+const buildDiff = (edit: FileEdit): ReadonlyArray<DiffLine> => {
+  const patch = structuredPatch(
+    edit.path,
+    edit.path,
+    edit.oldText,
+    edit.newText,
+    "",
+    "",
+    { context: 3 },
+  );
+  const lines: DiffLine[] = [];
+  for (const hunk of patch.hunks) {
+    lines.push({
+      kind: "hunk",
+      text: `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`,
+      oldLine: null,
+      newLine: null,
+    });
+    let oldLn = hunk.oldStart;
+    let newLn = hunk.newStart;
+    for (const raw of hunk.lines) {
+      const marker = raw.charAt(0);
+      const text = raw.slice(1);
+      if (marker === "+") {
+        lines.push({ kind: "add", text, oldLine: null, newLine: newLn });
+        newLn += 1;
+      } else if (marker === "-") {
+        lines.push({ kind: "del", text, oldLine: oldLn, newLine: null });
+        oldLn += 1;
+      } else {
+        lines.push({ kind: "context", text, oldLine: oldLn, newLine: newLn });
+        oldLn += 1;
+        newLn += 1;
+      }
+    }
+  }
+  return lines;
+};
+
+export function InlineDiff({ tool, input }: { tool: string; input: unknown }) {
+  const edits = useMemo(() => extractEdits(tool, input), [tool, input]);
+  const totalChangedLines = useMemo(() => {
+    let n = 0;
+    for (const edit of edits) {
+      const oldLines = edit.oldText === "" ? 0 : edit.oldText.split("\n").length;
+      const newLines = edit.newText === "" ? 0 : edit.newText.split("\n").length;
+      n += Math.abs(newLines - oldLines) + Math.min(oldLines, newLines);
+    }
+    return n;
+  }, [edits]);
+  const [expanded, setExpanded] = useState(
+    totalChangedLines <= COLLAPSE_THRESHOLD_LINES,
+  );
+
+  if (edits.length === 0) return null;
+
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+  const headPath = edits[0]!.path;
+  const summary =
+    edits.length === 1
+      ? edits[0]!.mode === "create"
+        ? "create"
+        : "edit"
+      : `${edits.length} edits`;
+
+  return (
+    <div className="px-4 py-1">
+      <div className="max-w-[88%] overflow-hidden rounded-md border border-border bg-muted/40 text-xs">
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left hover:bg-muted/60"
+        >
+          <Chevron className="size-3 shrink-0 text-muted-foreground" />
+          <FileEdit className="size-3 shrink-0 text-sky-400" />
+          <span className="truncate font-mono text-sky-200">{headPath}</span>
+          <span className="ml-1 text-muted-foreground">{summary}</span>
+        </button>
+        {expanded && (
+          <div className="border-t border-border/60">
+            {edits.map((edit, idx) => (
+              <DiffBlock key={idx} edit={edit} showHeader={edits.length > 1} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DiffBlock({
+  edit,
+  showHeader,
+}: {
+  edit: FileEdit;
+  showHeader: boolean;
+}) {
+  const lines = useMemo(() => buildDiff(edit), [edit]);
+  if (lines.length === 0) {
+    return (
+      <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+        (no textual change)
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto font-mono text-[11px]">
+      {showHeader ? (
+        <div className="bg-zinc-900/40 px-2 py-1 text-muted-foreground">
+          {edit.mode === "create" ? "create" : "edit"} · {edit.path}
+        </div>
+      ) : null}
+      {lines.map((line, idx) => (
+        <DiffRow key={idx} line={line} />
+      ))}
+    </div>
+  );
+}
+
+function DiffRow({ line }: { line: DiffLine }) {
+  if (line.kind === "hunk") {
+    return (
+      <div className="bg-sky-500/10 px-2 py-0.5 text-sky-200">{line.text}</div>
+    );
+  }
+  const bg =
+    line.kind === "add"
+      ? "bg-emerald-500/10"
+      : line.kind === "del"
+        ? "bg-red-500/10"
+        : "";
+  const marker =
+    line.kind === "add" ? "+" : line.kind === "del" ? "-" : " ";
+  const markerColor =
+    line.kind === "add"
+      ? "text-emerald-400"
+      : line.kind === "del"
+        ? "text-red-400"
+        : "text-muted-foreground";
+  return (
+    <div className={`flex gap-2 px-2 ${bg}`}>
+      <span className="w-8 shrink-0 select-none text-right text-muted-foreground">
+        {line.oldLine ?? ""}
+      </span>
+      <span className="w-8 shrink-0 select-none text-right text-muted-foreground">
+        {line.newLine ?? ""}
+      </span>
+      <span className={`w-3 shrink-0 select-none ${markerColor}`}>
+        {marker}
+      </span>
+      <span className="whitespace-pre-wrap break-words">
+        {line.text === "" ? " " : line.text}
+      </span>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -5,6 +5,10 @@ import remarkGfm from "remark-gfm";
 
 import type { Message } from "@forkzero/wire";
 
+import { InlineDiff } from "./inline-diff.tsx";
+
+const FILE_EDIT_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+
 const stringifyJson = (value: unknown): string => {
   try {
     return JSON.stringify(value, null, 2);
@@ -25,7 +29,12 @@ export function MessageRow({ message }: { message: Message }) {
     case "assistant":
       return <AssistantBubble text={message.content.text} />;
     case "tool_use":
-      return (
+      return FILE_EDIT_TOOLS.has(message.content.tool) ? (
+        <InlineDiff
+          tool={message.content.tool}
+          input={message.content.input}
+        />
+      ) : (
         <ToolUseBubble
           tool={message.content.tool}
           input={message.content.input}

--- a/apps/renderer/src/components/permission-toast.tsx
+++ b/apps/renderer/src/components/permission-toast.tsx
@@ -1,0 +1,136 @@
+import { ShieldAlert, ShieldCheck, ShieldX } from "lucide-react";
+import { useEffect, useMemo } from "react";
+
+import type {
+  PermissionDecision,
+  PermissionKind,
+  PermissionRequest,
+  SessionId,
+} from "@forkzero/wire";
+
+import {
+  selectRequestsForSession,
+  usePermissionsStore,
+} from "../store/permissions.ts";
+
+const kindHeadline = (kind: PermissionKind): string => {
+  switch (kind._tag) {
+    case "Bash":
+      return "Run shell command?";
+    case "FileWrite":
+      return "Write file?";
+    case "Network":
+      return "Make network request?";
+    case "Other":
+      return `Use tool ${kind.tool}?`;
+  }
+};
+
+const kindDetail = (kind: PermissionKind): string => {
+  switch (kind._tag) {
+    case "Bash":
+      return kind.command;
+    case "FileWrite":
+      return kind.path;
+    case "Network":
+      return kind.url;
+    case "Other":
+      return kind.summary;
+  }
+};
+
+const ALLOW_ONCE: PermissionDecision = { _tag: "AllowOnce" };
+const ALLOW_FOR_SESSION: PermissionDecision = { _tag: "AllowForSession" };
+const DENY: PermissionDecision = { _tag: "Deny" };
+
+/**
+ * Single-prompt toast docked above the chat timeline. Renders the head of
+ * the per-session prompt queue; further requests stack invisibly until the
+ * head is decided. ⌘+Enter / Esc are handled at the document level so the
+ * user can react without focusing the toast.
+ */
+export function PermissionToast({ sessionId }: { sessionId: SessionId }) {
+  const selector = useMemo(() => selectRequestsForSession(sessionId), [
+    sessionId,
+  ]);
+  const requests = usePermissionsStore(selector);
+  const decide = usePermissionsStore((s) => s.decide);
+  const hydrate = usePermissionsStore((s) => s.hydrate);
+
+  // Hydrate pending requests when the session changes — covers the boot
+  // case where the global stream missed events that landed before this
+  // renderer connected.
+  useEffect(() => {
+    void hydrate(sessionId);
+  }, [sessionId, hydrate]);
+
+  const head: PermissionRequest | undefined = requests[0];
+
+  useEffect(() => {
+    if (head === undefined) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        void decide(head.id, DENY);
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void decide(head.id, ALLOW_ONCE);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [head, decide]);
+
+  if (head === undefined) return null;
+
+  return (
+    <div className="border-b border-amber-500/40 bg-amber-500/10 px-4 py-3">
+      <div className="mx-auto flex max-w-3xl flex-col gap-2">
+        <div className="flex items-start gap-2">
+          <ShieldAlert className="mt-0.5 size-4 shrink-0 text-amber-300" />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium text-amber-100">
+              {kindHeadline(head.kind)}
+            </div>
+            <div className="mt-1 break-all rounded bg-zinc-950/40 px-2 py-1 font-mono text-xs text-amber-50">
+              {kindDetail(head.kind)}
+            </div>
+          </div>
+          {requests.length > 1 ? (
+            <span className="rounded bg-amber-500/30 px-1.5 py-0.5 text-[10px] font-medium text-amber-100">
+              +{requests.length - 1} more
+            </span>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => void decide(head.id, DENY)}
+            className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-200 hover:bg-zinc-700"
+            title="Esc"
+          >
+            <ShieldX className="size-3.5" />
+            Deny
+          </button>
+          <button
+            type="button"
+            onClick={() => void decide(head.id, ALLOW_FOR_SESSION)}
+            className="flex items-center gap-1.5 rounded-md border border-emerald-700 bg-emerald-900/40 px-2.5 py-1 text-xs text-emerald-100 hover:bg-emerald-900/70"
+          >
+            <ShieldCheck className="size-3.5" />
+            Allow for this session
+          </button>
+          <button
+            type="button"
+            onClick={() => void decide(head.id, ALLOW_ONCE)}
+            className="flex items-center gap-1.5 rounded-md bg-emerald-500 px-3 py-1 text-xs font-medium text-emerald-950 hover:bg-emerald-400"
+            title="⌘+Enter"
+          >
+            <ShieldCheck className="size-3.5" />
+            Allow once
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   MessageSquare,
   Pencil,
+  Play,
   Plus,
   Settings,
   Sparkles,
@@ -432,8 +433,16 @@ function SessionRow({ session }: { session: Session }) {
   const archive = useSessionsStore((s) => s.archive);
   const unarchive = useSessionsStore((s) => s.unarchive);
   const remove = useSessionsStore((s) => s.remove);
+  const resume = useSessionsStore((s) => s.resume);
   const isSelected = selectedSessionId === session.id;
   const isArchived = session.archivedAt !== null;
+  const canResume =
+    !isArchived &&
+    (session.status === "closed" ||
+      session.status === "error" ||
+      session.status === "idle") &&
+    session.resumeStrategy !== "none" &&
+    session.cursor !== null;
 
   const onRename = () => {
     const next = window.prompt("Rename session", session.title);
@@ -472,6 +481,20 @@ function SessionRow({ session }: { session: Session }) {
       >
         <MessageSquare className="size-3 shrink-0 opacity-70" />
         <span className="min-w-0 flex-1 truncate">{session.title}</span>
+        {canResume ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              void resume(session.id);
+            }}
+            className="flex shrink-0 items-center gap-0.5 rounded bg-emerald-500/20 px-1 py-[1px] text-[9px] uppercase tracking-wide text-emerald-200 hover:bg-emerald-500/40"
+            title="Resume this Claude session"
+          >
+            <Play className="size-2.5" />
+            Resume
+          </button>
+        ) : null}
         <span className="shrink-0 text-[10px] text-muted-foreground">
           {formatRelative(session.updatedAt)}
         </span>

--- a/apps/renderer/src/store/permissions.ts
+++ b/apps/renderer/src/store/permissions.ts
@@ -1,0 +1,119 @@
+import { Effect, Fiber, Stream } from "effect";
+import { create } from "zustand";
+
+import type {
+  PermissionDecision,
+  PermissionRequest,
+  SessionId,
+} from "@forkzero/wire";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
+
+/**
+ * Catalog of pending permission prompts. The renderer subscribes once to
+ * `permission.requests` (a server-side broadcast) and routes each into
+ * `requestsById`. Per-session filtering happens at the component layer —
+ * the toast subscribes by session and shows the head of the queue.
+ *
+ * Decisions clear the prompt immediately on the client; the server also
+ * removes it when `permission.decide` resolves, so a late-arriving stream
+ * echo is harmless.
+ */
+type PermissionsState = {
+  readonly requestsById: Record<string, PermissionRequest>;
+  readonly errorBySession: Record<string, string | null>;
+  readonly start: () => void;
+  readonly hydrate: (sessionId: SessionId) => Promise<void>;
+  readonly decide: (
+    requestId: string,
+    decision: PermissionDecision,
+  ) => Promise<void>;
+};
+
+const formatError = (err: unknown): string => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "object" && err !== null && "_tag" in err) {
+    return String((err as { _tag: unknown })._tag);
+  }
+  return String(err);
+};
+
+let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
+
+export const usePermissionsStore = create<PermissionsState>((set) => ({
+  requestsById: {},
+  errorBySession: {},
+  start: () => {
+    if (streamFiber !== null) return;
+    void (async () => {
+      try {
+        const client = await getRpcClient();
+        streamFiber = Effect.runFork(
+          Stream.runForEach(client.permission.requests({}), (req) =>
+            Effect.sync(() => {
+              set((s) => ({
+                requestsById: { ...s.requestsById, [req.id]: req },
+              }));
+            }),
+          ),
+        );
+      } catch {
+        // Boot-time stream failure is silent — `hydrate` is the safety net.
+      }
+    })();
+  },
+  hydrate: async (sessionId) => {
+    try {
+      const client = await getRpcClient();
+      const pending = await Effect.runPromise(
+        client.permission.listPending({ sessionId }),
+      );
+      set((s) => {
+        const next = { ...s.requestsById };
+        for (const req of pending) next[req.id] = req;
+        return {
+          requestsById: next,
+          errorBySession: { ...s.errorBySession, [sessionId]: null },
+        };
+      });
+    } catch (err) {
+      set((s) => ({
+        errorBySession: {
+          ...s.errorBySession,
+          [sessionId]: formatError(err),
+        },
+      }));
+    }
+  },
+  decide: async (requestId, decision) => {
+    set((s) => {
+      const next = { ...s.requestsById };
+      delete next[requestId];
+      return { requestsById: next };
+    });
+    try {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.permission.decide({ requestId, decision }),
+      );
+    } catch {
+      // The server drops the entry on success; a failed decide leaves it in
+      // memory and we'll re-hydrate via listPending on the next session
+      // mount. No noisy error UI for this case.
+    }
+  },
+}));
+
+export const selectRequestsForSession = (
+  sessionId: SessionId,
+): ((s: PermissionsState) => ReadonlyArray<PermissionRequest>) => {
+  return (s) => {
+    const out: PermissionRequest[] = [];
+    for (const req of Object.values(s.requestsById)) {
+      if (req.sessionId === sessionId) out.push(req);
+    }
+    return out.sort(
+      (a, b) => a.requestedAt.getTime() - b.requestedAt.getTime(),
+    );
+  };
+};

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -35,6 +35,7 @@ type SessionsState = {
   readonly archive: (sessionId: SessionId) => Promise<void>;
   readonly unarchive: (sessionId: SessionId) => Promise<void>;
   readonly remove: (sessionId: SessionId) => Promise<void>;
+  readonly resume: (sessionId: SessionId) => Promise<boolean>;
   readonly select: (sessionId: SessionId | null) => void;
   readonly toggleShowArchived: (projectId: FolderId) => void;
 };
@@ -202,6 +203,33 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
       });
     } catch (err) {
       set({ error: formatError(err) });
+    }
+  },
+  resume: async (sessionId) => {
+    set({ error: null });
+    try {
+      const client = await getRpcClient();
+      const session = await Effect.runPromise(
+        client.session.resume({ sessionId }),
+      );
+      set((s) => {
+        const projectId = findSessionProject(s.sessionsByProject, sessionId);
+        if (projectId === null) return {};
+        const sessions = s.sessionsByProject[projectId] ?? [];
+        return {
+          sessionsByProject: {
+            ...s.sessionsByProject,
+            [projectId]: sessions.map((existing) =>
+              existing.id === sessionId ? session : existing,
+            ),
+          },
+          selectedSessionId: session.id,
+        };
+      });
+      return true;
+    } catch (err) {
+      set({ error: formatError(err) });
+      return false;
     }
   },
   refreshOne: async (sessionId) => {

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -1,6 +1,8 @@
 import { SqliteMigrator } from "@effect/sql-sqlite-node";
 
 import { Migration0001Initial } from "./migrations/0001_initial.ts";
+import { Migration0002Permissions } from "./migrations/0002_permissions.ts";
+import { Migration0003ResumeAndExport } from "./migrations/0003_resume_and_export.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -13,5 +15,7 @@ import { Migration0001Initial } from "./migrations/0001_initial.ts";
 export const MigrationsLive = SqliteMigrator.layer({
   loader: SqliteMigrator.fromRecord({
     "0001_initial": Migration0001Initial,
+    "0002_permissions": Migration0002Permissions,
+    "0003_resume_and_export": Migration0003ResumeAndExport,
   }),
 });

--- a/apps/server/src/persistence/migrations/0002_permissions.ts
+++ b/apps/server/src/persistence/migrations/0002_permissions.ts
@@ -1,0 +1,30 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Per-session permission decisions. Rows are append-only — one row per
+ * resolved request. The kind payload is stored as JSON so adding a new
+ * `PermissionKind` variant is a wire-only change. Decisions persist for
+ * audit; the in-process driver short-circuit for "Allow for session"
+ * reads from this table on lookup so re-prompts don't survive a crash.
+ */
+export const Migration0002Permissions = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE permission_decisions (
+      request_id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      kind_tag TEXT NOT NULL,
+      kind_key TEXT NOT NULL,
+      kind_json TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      decided_at TEXT NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX idx_permission_decisions_session
+      ON permission_decisions(session_id, kind_tag, kind_key)
+  `;
+});

--- a/apps/server/src/persistence/migrations/0003_resume_and_export.ts
+++ b/apps/server/src/persistence/migrations/0003_resume_and_export.ts
@@ -1,0 +1,26 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Adds resume metadata to the `sessions` table:
+ *
+ *   - `cursor`           — provider-specific resume token. For Claude it's
+ *                          the SDK's `session_id` UUID; for Codex it's null
+ *                          until the SDK exposes a programmatic resume hook.
+ *   - `resume_strategy`  — `"claude-session-id" | "none"`. The renderer reads
+ *                          this to decide whether the "Resumable" badge is
+ *                          available on a stopped session.
+ *
+ * Both columns default-safe: existing rows backfill to `cursor IS NULL`,
+ * `resume_strategy = 'none'`. Sessions started after this migration have
+ * the cursor populated lazily once the first SDK message is observed.
+ */
+export const Migration0003ResumeAndExport = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`ALTER TABLE sessions ADD COLUMN cursor TEXT`;
+  yield* sql`
+    ALTER TABLE sessions
+      ADD COLUMN resume_strategy TEXT NOT NULL DEFAULT 'none'
+  `;
+});

--- a/apps/server/src/persistence/ndjson-logger.ts
+++ b/apps/server/src/persistence/ndjson-logger.ts
@@ -1,0 +1,135 @@
+import { Context, Effect, Layer } from "effect";
+import { createWriteStream, mkdirSync, renameSync, type WriteStream } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { FolderId, Message, SessionId } from "@forkzero/wire";
+
+import { AppPaths } from "../app-paths.ts";
+
+const ROTATE_BYTES = 100 * 1024 * 1024; // 100 MB per spec
+
+interface SinkEntry {
+  readonly path: string;
+  readonly stream: WriteStream;
+  bytes: number;
+}
+
+/**
+ * Best-effort per-session NDJSON audit sink. SQLite is canonical; this
+ * exists so users can `cat`, share, or post-process transcripts without
+ * touching the database. Failures here never propagate — a broken disk
+ * or permission issue must not stall the agent loop.
+ *
+ * Layout: `<userData>/sessions/<projectId>/<sessionId>.events.ndjson`.
+ * Rotation: when an active file crosses `ROTATE_BYTES`, it is renamed to
+ * `<sessionId>.events.<timestamp>.ndjson` and a fresh active file opens.
+ */
+export interface NdjsonLoggerShape {
+  readonly append: (
+    sessionId: SessionId,
+    projectId: FolderId,
+    message: Message,
+  ) => Effect.Effect<void>;
+  readonly close: (sessionId: SessionId) => Effect.Effect<void>;
+}
+
+export class NdjsonLogger extends Context.Tag("forkzero/NdjsonLogger")<
+  NdjsonLogger,
+  NdjsonLoggerShape
+>() {}
+
+const ensureDir = (filePath: string): void => {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+  } catch {
+    // best-effort
+  }
+};
+
+export const NdjsonLoggerLive = Layer.effect(
+  NdjsonLogger,
+  Effect.gen(function* () {
+    const paths = yield* AppPaths;
+    // In-process per-session sink table. Effect.Ref offers no real benefit
+    // here — these handles are read-write from the same fiber that consumes
+    // the message stream — and would force unnecessary `runSync` ceremony.
+    const sinks = new Map<SessionId, SinkEntry>();
+
+    const filePathFor = (
+      sessionId: SessionId,
+      projectId: FolderId,
+    ): string =>
+      join(paths.userData, "sessions", projectId, `${sessionId}.events.ndjson`);
+
+    const openSink = (
+      sessionId: SessionId,
+      projectId: FolderId,
+    ): SinkEntry | null => {
+      const path = filePathFor(sessionId, projectId);
+      try {
+        ensureDir(path);
+        const stream = createWriteStream(path, { flags: "a" });
+        return { path, stream, bytes: 0 };
+      } catch {
+        return null;
+      }
+    };
+
+    const rotate = (entry: SinkEntry): SinkEntry | null => {
+      try {
+        entry.stream.end();
+        const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+        const rotated = entry.path.replace(
+          /\.events\.ndjson$/,
+          `.events.${stamp}.ndjson`,
+        );
+        renameSync(entry.path, rotated);
+        const stream = createWriteStream(entry.path, { flags: "a" });
+        return { path: entry.path, stream, bytes: 0 };
+      } catch {
+        return null;
+      }
+    };
+
+    const append: NdjsonLoggerShape["append"] = (
+      sessionId,
+      projectId,
+      message,
+    ) =>
+      Effect.sync(() => {
+        let entry = sinks.get(sessionId);
+        if (entry === undefined) {
+          const fresh = openSink(sessionId, projectId);
+          if (fresh === null) return;
+          sinks.set(sessionId, fresh);
+          entry = fresh;
+        }
+        try {
+          const line = `${JSON.stringify(message)}\n`;
+          const buf = Buffer.from(line, "utf-8");
+          entry.stream.write(buf);
+          entry.bytes += buf.byteLength;
+          if (entry.bytes >= ROTATE_BYTES) {
+            const rotated = rotate(entry);
+            if (rotated !== null) sinks.set(sessionId, rotated);
+          }
+        } catch {
+          // swallow — best-effort sink
+        }
+      });
+
+    const close: NdjsonLoggerShape["close"] = (sessionId) =>
+      Effect.sync(() => {
+        const entry = sinks.get(sessionId);
+        if (entry === undefined) return;
+        try {
+          entry.stream.end();
+        } catch {
+          /* ignore */
+        }
+        sinks.delete(sessionId);
+      });
+
+    return { append, close } as const;
+  }),
+);

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -12,6 +12,8 @@ import {
   type AgentEvent,
   type AgentItemId,
   type AgentSessionId,
+  type PermissionDecision,
+  type PermissionKind,
   type StartSessionInput,
 } from "@forkzero/wire";
 
@@ -174,6 +176,63 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
 };
 
 /**
+ * Map a Claude SDK tool invocation onto a wire `PermissionKind`. Tools we
+ * don't classify drop into `Other`; the server treats those as auto-allow
+ * for now (logged) so the agent loop isn't stalled by every internal `Read`
+ * or `Glob`. Adding a classification is a one-line change here.
+ */
+const kindForTool = (
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): PermissionKind => {
+  switch (toolName) {
+    case "Bash": {
+      const command = typeof toolInput.command === "string"
+        ? toolInput.command
+        : JSON.stringify(toolInput);
+      return { _tag: "Bash", command };
+    }
+    case "Edit":
+    case "Write":
+    case "MultiEdit":
+    case "NotebookEdit": {
+      const path =
+        typeof toolInput.file_path === "string"
+          ? toolInput.file_path
+          : typeof toolInput.notebook_path === "string"
+            ? (toolInput.notebook_path as string)
+            : "(unknown)";
+      return { _tag: "FileWrite", path };
+    }
+    case "WebFetch":
+    case "WebSearch": {
+      const url =
+        typeof toolInput.url === "string"
+          ? toolInput.url
+          : typeof toolInput.query === "string"
+            ? `search:${toolInput.query as string}`
+            : "(unknown)";
+      return { _tag: "Network", url };
+    }
+    default: {
+      const summary = JSON.stringify(toolInput).slice(0, 120);
+      return { _tag: "Other", tool: toolName, summary };
+    }
+  }
+};
+
+/**
+ * Hook the driver passes into the SDK's `canUseTool`. Returning a
+ * `PermissionDecision` lets the orchestrator (`ProviderService`) plug
+ * `PermissionService.request` in directly without the driver reaching
+ * across modules.
+ */
+export type RequestPermission = (
+  sessionId: AgentSessionId,
+  kind: PermissionKind,
+) => Promise<PermissionDecision>;
+
+/**
  * Spin up a streaming-input Claude conversation. The SDK is driven by an
  * AsyncIterable we push into from `send()`; the SDK's outbound async generator
  * is consumed by a forked daemon that translates messages into wire events
@@ -185,6 +244,10 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
  * the spawned `claude` CLI find its own OAuth credentials (macOS keychain
  * entry "Claude Code-credentials" or `~/.claude/.credentials.json`). This
  * is the primary auth path; API keys are a fallback.
+ *
+ * `requestPermission` is the bridge to `PermissionService`. It returns a
+ * decision the caller honors via the SDK's allow/deny contract; the driver
+ * itself stays free of any DB or PubSub wiring.
  */
 export const startClaudeSession = (
   input: StartSessionInput,
@@ -192,6 +255,8 @@ export const startClaudeSession = (
   apiKey: string | null,
   claudeExecutablePath: string | null,
   sessionId: AgentSessionId,
+  requestPermission: RequestPermission,
+  resumeCursor: string | null = null,
 ): Effect.Effect<ClaudeSessionHandle, AgentSessionStartError> =>
   Effect.gen(function* () {
     const events = yield* Mailbox.make<AgentEvent>();
@@ -231,19 +296,29 @@ export const startClaudeSession = (
         : {}),
       ...(input.model !== undefined ? { model: input.model } : {}),
       env: env as Options["env"],
-      // Phase 2 auto-denies tool permission requests; Phase 3 wires real UI.
+      // Bridge the SDK's permission callback to the server-side
+      // `PermissionService`. The renderer's toast eventually fulfills the
+      // promise this awaits.
       canUseTool: async (toolName, toolInput) => {
+        const kind = kindForTool(toolName, toolInput);
         events.unsafeOffer({
           _tag: "PermissionRequest",
           itemId: nextItemId(),
           kind: toolName,
           details: toolInput,
         });
-        return {
-          behavior: "deny",
-          message:
-            "forkzero v2 auto-denies tool permissions; Phase 3 will let you allow this.",
-        };
+        const decision = await requestPermission(sessionId, kind);
+        if (decision._tag === "Deny") {
+          return {
+            behavior: "deny",
+            message: "User denied this tool call.",
+          };
+        }
+        // AllowOnce / AllowForSession / AlwaysAllow → allow. The session
+        // scope is enforced server-side: a second request with the same
+        // (sessionId, kindKey) short-circuits to AllowOnce without
+        // prompting.
+        return { behavior: "allow", updatedInput: toolInput };
       },
     };
 
@@ -253,6 +328,12 @@ export const startClaudeSession = (
       providerId: "claude",
       mode: "sdk",
     });
+
+    // If the caller has a resume cursor, hand it to the SDK before opening
+    // the conversation. Mutually exclusive with `forkSession` per SDK docs.
+    if (resumeCursor !== null) {
+      options.resume = resumeCursor;
+    }
 
     let q: Query;
     try {
@@ -269,10 +350,24 @@ export const startClaudeSession = (
 
     // Pump SDK messages → AgentEvents in a forked daemon. Sessions outlive the
     // start RPC; `close()` is what ends the pump (input close + abort, which
-    // makes the SDK loop terminate).
+    // makes the SDK loop terminate). On the first message that has a
+    // populated `session_id` we surface it as `SessionCursor` so MessageStore
+    // can persist it for resume.
+    let cursorAnnounced = false;
     const pump = Effect.tryPromise({
       try: async () => {
         for await (const msg of q) {
+          if (!cursorAnnounced) {
+            const sid = (msg as { session_id?: unknown }).session_id;
+            if (typeof sid === "string" && sid.length > 0) {
+              cursorAnnounced = true;
+              events.unsafeOffer({
+                _tag: "SessionCursor",
+                cursor: sid,
+                strategy: "claude-session-id",
+              });
+            }
+          }
           const translated = translate(msg);
           for (const ev of translated) {
             events.unsafeOffer(ev);

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -207,7 +207,11 @@ export const startCodexSession = (
       });
       thread = codex.startThread({
         workingDirectory: cwd,
-        // Phase 2: read-only sandbox + auto-deny tools (matches Claude path).
+        // Codex SDK exposes `approvalPolicy` but no callback — when set to
+        // anything other than "never" it routes prompts to its own stdio,
+        // which we can't bridge to forkzero's toast. Stay on "never" until
+        // the SDK exposes a programmatic hook; Claude is the primary
+        // permission path in Phase 4.
         sandboxMode: "read-only",
         approvalPolicy: "never",
         skipGitRepoCheck: true,

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -2,6 +2,7 @@ import { CredentialStoreError, ForkzeroRpcs, type ProviderId } from "@forkzero/w
 import { Effect, Layer, Stream } from "effect";
 
 import { MessageStore } from "./services/message-store.ts";
+import { PermissionService } from "./services/permission-service.ts";
 import { ProviderService } from "./services/provider-service.ts";
 
 /**
@@ -111,6 +112,12 @@ const SessionDelete = ForkzeroRpcs.toLayerHandler(
     Effect.flatMap(MessageStore, (svc) => svc.deleteSession(sessionId)),
 );
 
+const SessionResume = ForkzeroRpcs.toLayerHandler(
+  "session.resume",
+  ({ sessionId }) =>
+    Effect.flatMap(MessageStore, (svc) => svc.resumeSession(sessionId)),
+);
+
 const MessagesList = ForkzeroRpcs.toLayerHandler(
   "messages.list",
   ({ sessionId }) =>
@@ -137,6 +144,30 @@ const MessagesInterrupt = ForkzeroRpcs.toLayerHandler(
     Effect.flatMap(MessageStore, (svc) => svc.interruptSession(sessionId)),
 );
 
+// ---------------------------------------------------------------------------
+// permission.* — Phase 4 surface. The renderer subscribes to
+// `permission.requests`, shows a toast, and posts back via `permission.decide`.
+// `listPending` is the cold-load helper used on session mount.
+// ---------------------------------------------------------------------------
+
+const PermissionRequests = ForkzeroRpcs.toLayerHandler(
+  "permission.requests",
+  () =>
+    Stream.unwrap(Effect.map(PermissionService, (svc) => svc.requests())),
+);
+
+const PermissionDecide = ForkzeroRpcs.toLayerHandler(
+  "permission.decide",
+  ({ requestId, decision }) =>
+    Effect.flatMap(PermissionService, (svc) => svc.decide(requestId, decision)),
+);
+
+const PermissionListPending = ForkzeroRpcs.toLayerHandler(
+  "permission.listPending",
+  ({ sessionId }) =>
+    Effect.flatMap(PermissionService, (svc) => svc.listPending(sessionId)),
+);
+
 export const ProviderHandlersLayer = Layer.mergeAll(
   Availability,
   SetCredential,
@@ -153,8 +184,12 @@ export const ProviderHandlersLayer = Layer.mergeAll(
   SessionArchive,
   SessionUnarchive,
   SessionDelete,
+  SessionResume,
   MessagesList,
   MessagesStream,
   MessagesSend,
   MessagesInterrupt,
+  PermissionRequests,
+  PermissionDecide,
+  PermissionListPending,
 );

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -22,6 +22,7 @@ import {
   SessionStartError,
 } from "@forkzero/wire";
 
+import { NdjsonLogger } from "../../persistence/ndjson-logger.ts";
 import {
   MessageStore,
   type CreateSessionInput,
@@ -37,6 +38,8 @@ interface SessionRow {
   readonly model: string;
   readonly status: string;
   readonly archived_at: string | null;
+  readonly cursor: string | null;
+  readonly resume_strategy: string;
   readonly created_at: string;
   readonly updated_at: string;
 }
@@ -59,6 +62,9 @@ const sessionFromRow = (row: SessionRow): Session =>
     model: row.model,
     status: row.status as Session["status"],
     archivedAt: row.archived_at === null ? null : new Date(row.archived_at),
+    cursor: row.cursor,
+    resumeStrategy:
+      row.resume_strategy === "claude-session-id" ? "claude-session-id" : "none",
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   });
@@ -136,6 +142,31 @@ export const MessageStoreLive = Layer.scoped(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     const provider = yield* ProviderService;
+    const ndjson = yield* NdjsonLogger;
+
+    // Project-id cache so the per-message NDJSON append doesn't hit the DB
+    // for every event. Populated lazily on first append per session.
+    const projectIdBySession = new Map<SessionId, FolderId>();
+    const ndjsonAppend = (
+      sessionId: SessionId,
+      message: Message,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        let projectId = projectIdBySession.get(sessionId);
+        if (projectId === undefined) {
+          const rows = yield* sql<{ readonly project_id: string }>`
+            SELECT project_id FROM sessions WHERE id = ${sessionId} LIMIT 1
+          `.pipe(
+            Effect.catchAll(() =>
+              Effect.succeed([] as ReadonlyArray<{ readonly project_id: string }>),
+            ),
+          );
+          if (rows.length === 0) return;
+          projectId = rows[0]!.project_id as FolderId;
+          projectIdBySession.set(sessionId, projectId);
+        }
+        yield* ndjson.append(sessionId, projectId, message);
+      });
 
     // One pubsub per session, lazily created. Re-used across multiple
     // `streamMessages` subscribers so a single provider event fans out to
@@ -167,7 +198,7 @@ export const MessageStoreLive = Layer.scoped(
       Effect.gen(function* () {
         const rows = yield* sql<SessionRow>`
           SELECT id, project_id, title, provider_id, model, status,
-                 archived_at, created_at, updated_at
+                 archived_at, cursor, resume_strategy, created_at, updated_at
           FROM sessions WHERE id = ${sessionId} LIMIT 1
         `.pipe(Effect.orDie);
         if (rows.length === 0) {
@@ -250,10 +281,21 @@ export const MessageStoreLive = Layer.scoped(
                 );
                 return;
               }
+              if (event._tag === "SessionCursor") {
+                yield* sql`
+                  UPDATE sessions
+                     SET cursor = ${event.cursor},
+                         resume_strategy = ${event.strategy},
+                         updated_at = ${new Date().toISOString()}
+                  WHERE id = ${sessionId}
+                `.pipe(Effect.asVoid, Effect.orDie);
+                return;
+              }
               const content = eventToContent(event);
               if (content === null) return;
               const persisted = yield* persistMessage(sessionId, content);
               yield* broadcastMessage(sessionId, persisted);
+              yield* ndjsonAppend(sessionId, persisted);
             }),
           ).pipe(
             Effect.catchAllCause((cause) =>
@@ -311,13 +353,13 @@ export const MessageStoreLive = Layer.scoped(
         const rows = includeArchived
           ? yield* sql<SessionRow>`
               SELECT id, project_id, title, provider_id, model, status,
-                     archived_at, created_at, updated_at
+                     archived_at, cursor, resume_strategy, created_at, updated_at
               FROM sessions WHERE project_id = ${projectId}
               ORDER BY updated_at DESC
             `.pipe(Effect.orDie)
           : yield* sql<SessionRow>`
               SELECT id, project_id, title, provider_id, model, status,
-                     archived_at, created_at, updated_at
+                     archived_at, cursor, resume_strategy, created_at, updated_at
               FROM sessions
               WHERE project_id = ${projectId} AND archived_at IS NULL
               ORDER BY updated_at DESC
@@ -381,6 +423,8 @@ export const MessageStoreLive = Layer.scoped(
           model: input.model,
           status: "running",
           archivedAt: null,
+          cursor: null,
+          resumeStrategy: "none",
           createdAt: now,
           updatedAt: now,
         });
@@ -499,18 +543,68 @@ export const MessageStoreLive = Layer.scoped(
       initialPrompt: string,
     ): Effect.Effect<void, SessionNotFoundError> =>
       provider
-        .start({
-          folderId: session.projectId,
-          providerId: session.providerId,
-          mode: "sdk",
-          sessionId: session.id,
-          initialPrompt,
-          model: session.model,
-        })
+        .start(
+          {
+            folderId: session.projectId,
+            providerId: session.providerId,
+            mode: "sdk",
+            sessionId: session.id,
+            initialPrompt,
+            model: session.model,
+          },
+          // Re-attach to the upstream conversation when we have a cursor.
+          // The driver passes it as `options.resume`; SDK reloads history
+          // and continues from there.
+          session.cursor,
+        )
         .pipe(
           Effect.flatMap(() => startSubscription(session.id)),
           Effect.mapError(() => new SessionNotFoundError({ sessionId: session.id })),
         );
+
+    const resumeSession: MessageStoreShape["resumeSession"] = (sessionId) =>
+      Effect.gen(function* () {
+        const session = yield* lookupSession(sessionId);
+        if (session.resumeStrategy === "none" || session.cursor === null) {
+          return yield* Effect.fail(
+            new SessionStartError({
+              providerId: session.providerId,
+              reason: "resume_unsupported",
+            }),
+          );
+        }
+        // Best-effort cleanup of any stale in-memory session before opening
+        // a fresh handle attached to the same DB row.
+        yield* provider.close(sessionId).pipe(Effect.catchAll(() => Effect.void));
+        yield* teardownSubscription(sessionId);
+        yield* provider
+          .start(
+            {
+              folderId: session.projectId,
+              providerId: session.providerId,
+              mode: "sdk",
+              sessionId: session.id,
+              model: session.model,
+            },
+            session.cursor,
+          )
+          .pipe(
+            Effect.mapError((err) =>
+              err._tag === "ProviderNotAvailableError"
+                ? new SessionStartError({
+                    providerId: session.providerId,
+                    reason: err.reason,
+                  })
+                : new SessionStartError({
+                    providerId: err.providerId,
+                    reason: err.reason,
+                  }),
+            ),
+          );
+        yield* startSubscription(sessionId);
+        yield* setStatus(sessionId, "running");
+        return yield* lookupSession(sessionId);
+      });
 
     const sendMessage: MessageStoreShape["sendMessage"] = (sessionId, text) =>
       Effect.gen(function* () {
@@ -569,6 +663,7 @@ export const MessageStoreLive = Layer.scoped(
       archiveSession,
       unarchiveSession,
       deleteSession,
+      resumeSession,
       listMessages,
       streamMessages,
       sendMessage,

--- a/apps/server/src/provider/layers/permission-service.ts
+++ b/apps/server/src/provider/layers/permission-service.ts
@@ -1,0 +1,173 @@
+import { SqlClient } from "@effect/sql";
+import { Deferred, Effect, Layer, PubSub, Ref, Stream } from "effect";
+
+import {
+  PermissionRequest,
+  PermissionRequestNotFoundError,
+  type PermissionDecision,
+  type PermissionKind,
+  type SessionId,
+} from "@forkzero/wire";
+
+import {
+  PermissionService,
+  type PermissionServiceShape,
+} from "../services/permission-service.ts";
+
+interface PendingEntry {
+  readonly request: PermissionRequest;
+  readonly deferred: Deferred.Deferred<PermissionDecision>;
+}
+
+interface DecisionRow {
+  readonly request_id: string;
+  readonly session_id: string;
+  readonly kind_tag: string;
+  readonly kind_key: string;
+  readonly kind_json: string;
+  readonly decision: string;
+  readonly decided_at: string;
+}
+
+/**
+ * Stable per-kind matching key. Equality on this string is what lets
+ * `AllowForSession` short-circuit a re-prompt — exact-match only, no
+ * prefix / glob (kept deliberate per the Phase 4 plan; smarter matchers
+ * are deferred).
+ */
+const kindKey = (kind: PermissionKind): string => {
+  switch (kind._tag) {
+    case "FileWrite":
+      return kind.path;
+    case "Bash":
+      return kind.command;
+    case "Network":
+      return kind.url;
+    case "Other":
+      return `${kind.tool}:${kind.summary}`;
+  }
+};
+
+const decisionTag = (
+  decision: PermissionDecision,
+): "AllowOnce" | "AllowForSession" | "Deny" | "AlwaysAllow" => decision._tag;
+
+let requestCounter = 0;
+const nextRequestId = (): string =>
+  `pr_${Date.now()}_${++requestCounter}`;
+
+export const PermissionServiceLive = Layer.scoped(
+  PermissionService,
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const pubsub = yield* PubSub.unbounded<PermissionRequest>();
+    const pending = yield* Ref.make<ReadonlyMap<string, PendingEntry>>(
+      new Map(),
+    );
+
+    const findExistingSessionAllow = (
+      sessionId: SessionId,
+      kind: PermissionKind,
+    ): Effect.Effect<boolean> =>
+      sql<DecisionRow>`
+        SELECT request_id, session_id, kind_tag, kind_key, kind_json, decision, decided_at
+        FROM permission_decisions
+        WHERE session_id = ${sessionId}
+          AND kind_tag = ${kind._tag}
+          AND kind_key = ${kindKey(kind)}
+          AND decision = 'AllowForSession'
+        LIMIT 1
+      `.pipe(
+        Effect.map((rows) => rows.length > 0),
+        Effect.catchAll(() => Effect.succeed(false)),
+      );
+
+    const persistDecision = (
+      request: PermissionRequest,
+      decision: PermissionDecision,
+    ): Effect.Effect<void> =>
+      sql`
+        INSERT OR REPLACE INTO permission_decisions
+          (request_id, session_id, kind_tag, kind_key, kind_json, decision, decided_at)
+        VALUES
+          (${request.id}, ${request.sessionId}, ${request.kind._tag},
+           ${kindKey(request.kind)}, ${JSON.stringify(request.kind)},
+           ${decisionTag(decision)}, ${new Date().toISOString()})
+      `.pipe(
+        Effect.asVoid,
+        Effect.catchAll((cause) =>
+          Effect.logWarning(
+            `[PermissionService] persist decision failed: ${String(cause)}`,
+          ),
+        ),
+      );
+
+    const request: PermissionServiceShape["request"] = (sessionId, kind) =>
+      Effect.gen(function* () {
+        const allowed = yield* findExistingSessionAllow(sessionId, kind);
+        if (allowed) {
+          return { _tag: "AllowOnce" } as PermissionDecision;
+        }
+
+        const id = nextRequestId();
+        const req = PermissionRequest.make({
+          id,
+          sessionId,
+          kind,
+          requestedAt: new Date(),
+        });
+        const deferred = yield* Deferred.make<PermissionDecision>();
+        yield* Ref.update(pending, (m) => {
+          const next = new Map(m);
+          next.set(id, { request: req, deferred });
+          return next;
+        });
+        yield* PubSub.publish(pubsub, req);
+        const decision = yield* Deferred.await(deferred);
+        return decision;
+      });
+
+    const decide: PermissionServiceShape["decide"] = (requestId, decision) =>
+      Effect.gen(function* () {
+        const map = yield* Ref.get(pending);
+        const entry = map.get(requestId);
+        if (entry === undefined) {
+          return yield* Effect.fail(
+            new PermissionRequestNotFoundError({ requestId }),
+          );
+        }
+        yield* Ref.update(pending, (m) => {
+          const next = new Map(m);
+          next.delete(requestId);
+          return next;
+        });
+        yield* persistDecision(entry.request, decision);
+        yield* Deferred.succeed(entry.deferred, decision);
+      });
+
+    const listPending: PermissionServiceShape["listPending"] = (sessionId) =>
+      Effect.gen(function* () {
+        const map = yield* Ref.get(pending);
+        const out: PermissionRequest[] = [];
+        for (const entry of map.values()) {
+          if (entry.request.sessionId === sessionId) out.push(entry.request);
+        }
+        return out;
+      });
+
+    const requests: PermissionServiceShape["requests"] = () =>
+      Stream.unwrapScoped(
+        Effect.gen(function* () {
+          const dequeue = yield* pubsub.subscribe;
+          return Stream.fromQueue(dequeue);
+        }),
+      );
+
+    return {
+      request,
+      decide,
+      listPending,
+      requests,
+    } as const;
+  }),
+);

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -1,5 +1,5 @@
 import { CommandExecutor, FileSystem } from "@effect/platform";
-import { Effect, Layer, Ref, Stream } from "effect";
+import { Effect, Layer, Ref, Runtime, Stream } from "effect";
 
 import {
   AgentSessionId,
@@ -7,6 +7,8 @@ import {
   AgentSessionStartError,
   type AgentAvailability,
   type AgentEvent,
+  type PermissionDecision,
+  type PermissionKind,
   type ProviderId,
 } from "@forkzero/wire";
 
@@ -20,6 +22,7 @@ import {
   type CodexSessionHandle,
 } from "../drivers/codex.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
+import { PermissionService } from "../services/permission-service.ts";
 import { ProviderService } from "../services/provider-service.ts";
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
 
@@ -49,9 +52,20 @@ export const ProviderServiceLive = Layer.effect(
     const fs = yield* FileSystem.FileSystem;
     const credentials = yield* CredentialsService;
     const workspace = yield* WorkspaceService;
+    const permissions = yield* PermissionService;
+    const runtime = yield* Effect.runtime<never>();
     const sessions = yield* Ref.make<Map<AgentSessionId, SessionEntry>>(
       new Map(),
     );
+
+    // The Claude SDK's `canUseTool` callback returns a Promise; here we
+    // shim PermissionService.request into that signature using the live
+    // runtime captured at layer construction.
+    const requestPermission = (
+      sessionId: AgentSessionId,
+      kind: PermissionKind,
+    ): Promise<PermissionDecision> =>
+      Runtime.runPromise(runtime)(permissions.request(sessionId, kind));
 
     const availability = () =>
       Effect.gen(function* () {
@@ -88,7 +102,7 @@ export const ProviderServiceLive = Layer.effect(
 
     return {
       availability,
-      start: (input) =>
+      start: (input, resumeCursor = null) =>
         Effect.gen(function* () {
           const folder = yield* workspace.findById(input.folderId);
           if (folder === null) {
@@ -117,8 +131,21 @@ export const ProviderServiceLive = Layer.effect(
               apiKey,
               claudePath,
               sessionId,
+              requestPermission,
+              resumeCursor,
             );
           } else {
+            // Codex SDK currently has no public resume API matching our
+            // cursor-based model; reject early with a stable reason the
+            // renderer can route to "Session ended — start new session".
+            if (resumeCursor !== null) {
+              return yield* Effect.fail(
+                new AgentSessionStartError({
+                  providerId: "codex",
+                  reason: "resume_unsupported",
+                }),
+              );
+            }
             handle = yield* startCodexSession(
               input,
               folder.path,

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -68,6 +68,10 @@ export interface MessageStoreShape {
     sessionId: SessionId,
   ) => Effect.Effect<void, SessionNotFoundError>;
 
+  readonly resumeSession: (
+    sessionId: SessionId,
+  ) => Effect.Effect<Session, SessionNotFoundError | SessionStartError>;
+
   readonly listMessages: (
     sessionId: SessionId,
   ) => Effect.Effect<ReadonlyArray<Message>, SessionNotFoundError>;

--- a/apps/server/src/provider/services/permission-service.ts
+++ b/apps/server/src/provider/services/permission-service.ts
@@ -1,0 +1,48 @@
+import { Context, type Effect, type Stream } from "effect";
+
+import type {
+  PermissionDecision,
+  PermissionKind,
+  PermissionRequest,
+  PermissionRequestNotFoundError,
+  SessionId,
+} from "@forkzero/wire";
+
+/**
+ * Bridge between provider drivers (which call `request` from inside their
+ * SDK permission callback) and the renderer (which subscribes to `requests`,
+ * shows a toast, then calls `decide`).
+ *
+ * `request` blocks the driver until a decision is made or the session
+ * tears down. `decide` resolves whichever deferred is keyed by `requestId`.
+ * `listPending` lets a freshly-mounted UI hydrate without waiting for the
+ * next stream message.
+ *
+ * "Allow for session" is enforced inside `request` itself: before publishing
+ * a new `PermissionRequest` we look up `permission_decisions` for an
+ * existing `AllowForSession` row matching `(sessionId, kindTag, kindKey)`,
+ * and short-circuit with an `AllowOnce` decision when one exists. This
+ * mirrors the SDK's own session-scoped suppression and keeps the prompt
+ * stream quiet for repeat tool calls within a session.
+ */
+export interface PermissionServiceShape {
+  readonly request: (
+    sessionId: SessionId,
+    kind: PermissionKind,
+  ) => Effect.Effect<PermissionDecision>;
+
+  readonly decide: (
+    requestId: string,
+    decision: PermissionDecision,
+  ) => Effect.Effect<void, PermissionRequestNotFoundError>;
+
+  readonly listPending: (
+    sessionId: SessionId,
+  ) => Effect.Effect<ReadonlyArray<PermissionRequest>>;
+
+  readonly requests: () => Stream.Stream<PermissionRequest>;
+}
+
+export class PermissionService extends Context.Tag(
+  "forkzero/PermissionService",
+)<PermissionService, PermissionServiceShape>() {}

--- a/apps/server/src/provider/services/provider-service.ts
+++ b/apps/server/src/provider/services/provider-service.ts
@@ -25,6 +25,7 @@ export interface ProviderServiceShape {
 
   readonly start: (
     input: StartSessionInput,
+    resumeCursor?: string | null,
   ) => Effect.Effect<
     { readonly sessionId: AgentSessionId },
     ProviderNotAvailableError | AgentSessionStartError

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -10,9 +10,11 @@ import { GitServiceLive } from "./git/layers/git-service.ts";
 import { HandlersLayer } from "./handlers.ts";
 import { importWorkspacesJson } from "./persistence/import-workspaces.ts";
 import { MigrationsLive } from "./persistence/migrations.ts";
+import { NdjsonLoggerLive } from "./persistence/ndjson-logger.ts";
 import { SqliteLive } from "./persistence/sqlite.ts";
 import { CredentialsServiceLive } from "./provider/layers/credentials-service.ts";
 import { MessageStoreLive } from "./provider/layers/message-store.ts";
+import { PermissionServiceLive } from "./provider/layers/permission-service.ts";
 import { ProviderServiceLive } from "./provider/layers/provider-service.ts";
 import { PtyServiceLive } from "./pty/layers/pty-service.ts";
 import { FolderPicker } from "./workspace/services/folder-picker.ts";
@@ -86,13 +88,30 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(NodeContext.layer),
   );
 
+  // PermissionService brokers between the SDK permission callback (driver
+  // side) and the renderer toast (RPC side). It writes decisions to
+  // SQLite so an `AllowForSession` row survives a process crash and the
+  // user isn't re-prompted on resume.
+  const PermissionLayer = PermissionServiceLive.pipe(
+    Layer.provide(MigratedSqlite),
+  );
+
   // ProviderService probes installed CLIs via CommandExecutor, consults
-  // CredentialsService for SDK keys, and resolves folderId → cwd via
-  // WorkspaceService when starting a Claude SDK session.
+  // CredentialsService for SDK keys, resolves folderId → cwd via
+  // WorkspaceService, and forwards the SDK's tool-permission callback to
+  // PermissionService.
   const ProviderLayer = ProviderServiceLive.pipe(
     Layer.provide(CredentialsServiceLive),
     Layer.provide(WorkspaceLayer),
+    Layer.provide(PermissionLayer),
     Layer.provide(NodeContext.layer),
+  );
+
+  // NdjsonLogger writes a best-effort transcript audit file alongside the
+  // SQLite store. Provided to MessageStore so the same daemon that persists
+  // a row also tail-writes the NDJSON line.
+  const NdjsonLoggerLayer = NdjsonLoggerLive.pipe(
+    Layer.provide(AppPathsLayer),
   );
 
   // MessageStore composes ProviderService with the SQLite-backed sessions /
@@ -102,6 +121,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
   const MessageStoreLayer = MessageStoreLive.pipe(
     Layer.provide(ProviderLayer),
     Layer.provide(MigratedSqlite),
+    Layer.provide(NdjsonLoggerLayer),
   );
 
   const Handlers = HandlersLayer.pipe(
@@ -111,6 +131,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(FsLayer),
     Layer.provide(ProviderLayer),
     Layer.provide(MessageStoreLayer),
+    Layer.provide(PermissionLayer),
     Layer.provide(FolderPickerLayer),
   );
 

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "diff": "^9.0.0",
         "effect": "catalog:",
         "lucide-react": "^1.14.0",
         "react": "catalog:",
@@ -80,6 +81,7 @@
       "devDependencies": {
         "@repo/typescript-config": "*",
         "@tailwindcss/vite": "^4.0.0",
+        "@types/diff": "^8.0.0",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "@vitejs/plugin-react": "^4.3.4",
@@ -762,6 +764,8 @@
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
+    "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -1034,7 +1038,7 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "docs": ["docs@workspace:apps/docs"],
 
@@ -2285,6 +2289,8 @@
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
+    "shadcn/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "shadcn/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -121,6 +121,18 @@ const ErrorEvent = Schema.TaggedStruct("Error", {
   message: Schema.String,
 });
 
+/**
+ * Driver-emitted side-channel for the SDK's resume token. Claude exposes
+ * its session UUID as `session_id` on every message; the driver captures
+ * it on first sight and emits this event so MessageStore can persist it
+ * onto `sessions.cursor` / `sessions.resume_strategy`. Lifecycle-only —
+ * never persisted as a chat row.
+ */
+const SessionCursorEvent = Schema.TaggedStruct("SessionCursor", {
+  cursor: Schema.String,
+  strategy: Schema.Literal("claude-session-id"),
+});
+
 export const AgentEvent = Schema.Union(
   StartedEvent,
   StatusEvent,
@@ -131,6 +143,7 @@ export const AgentEvent = Schema.Union(
   ToolUseEvent,
   ToolResultEvent,
   PermissionRequestEvent,
+  SessionCursorEvent,
   CompletedEvent,
   ErrorEvent,
 );

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -2,6 +2,7 @@ export * from "./agent.ts";
 export * from "./fs.ts";
 export * from "./git.ts";
 export * from "./ids.ts";
+export * from "./permission.ts";
 export * from "./ping.ts";
 export * from "./pty.ts";
 export * from "./rpc.ts";

--- a/packages/wire/src/permission.ts
+++ b/packages/wire/src/permission.ts
@@ -1,0 +1,95 @@
+import { Rpc } from "@effect/rpc";
+import { Schema } from "effect";
+
+import { SessionId } from "./session.ts";
+
+/**
+ * What the agent is asking permission to do. The discriminated union keeps the
+ * UI copy and the matcher honest — adding a new kind is a wire change, not a
+ * stringly-typed addition. `detail` on the request carries kind-specific data
+ * (cwd, args, etc.) that the toast renders for context.
+ */
+export const PermissionKind = Schema.Union(
+  Schema.TaggedStruct("FileWrite", { path: Schema.String }),
+  Schema.TaggedStruct("Bash", { command: Schema.String }),
+  Schema.TaggedStruct("Network", { url: Schema.String }),
+  // Catch-all for tools we don't classify yet (`Read`, `Glob`, MCP, …). The
+  // server defaults these to AllowOnce auto-pass for now; surfacing the union
+  // member keeps the protocol open without a separate "unknown" path.
+  Schema.TaggedStruct("Other", {
+    tool: Schema.String,
+    summary: Schema.String,
+  }),
+);
+export type PermissionKind = typeof PermissionKind.Type;
+
+/**
+ * User's choice in the toast. `AllowForSession` is enforced in the in-process
+ * driver loop (server short-circuits a re-prompt with the same kind+key
+ * within the same session). `AlwaysAllow` is plumbing for a later folder /
+ * global allow-list UI — Phase 4 never produces it.
+ */
+export const PermissionDecision = Schema.Union(
+  Schema.TaggedStruct("AllowOnce", {}),
+  Schema.TaggedStruct("AllowForSession", {}),
+  Schema.TaggedStruct("Deny", {}),
+  Schema.TaggedStruct("AlwaysAllow", {
+    scope: Schema.Literal("folder", "global"),
+  }),
+);
+export type PermissionDecision = typeof PermissionDecision.Type;
+
+/**
+ * One outstanding prompt. `id` is the server-minted handle the renderer hands
+ * back via `permission.decide`. Multiple requests can be in flight for the
+ * same session; the toast shows them one at a time.
+ */
+export class PermissionRequest extends Schema.Class<PermissionRequest>(
+  "PermissionRequest",
+)({
+  id: Schema.String,
+  sessionId: SessionId,
+  kind: PermissionKind,
+  requestedAt: Schema.DateFromString,
+}) {}
+
+export class PermissionRequestNotFoundError extends Schema.TaggedError<PermissionRequestNotFoundError>()(
+  "PermissionRequestNotFoundError",
+  { requestId: Schema.String },
+) {}
+
+// ---------------------------------------------------------------------------
+// RPCs
+// ---------------------------------------------------------------------------
+
+/**
+ * Live stream of pending requests across every session. The renderer
+ * filters by selected session; broadcasting once and filtering on the
+ * client is cheaper than per-session subscriptions and means a session
+ * switch doesn't have to tear anything down on the server.
+ */
+export const PermissionRequestsRpc = Rpc.make("permission.requests", {
+  payload: Schema.Struct({}),
+  success: PermissionRequest,
+  stream: true,
+});
+
+export const PermissionDecideRpc = Rpc.make("permission.decide", {
+  payload: Schema.Struct({
+    requestId: Schema.String,
+    decision: PermissionDecision,
+  }),
+  success: Schema.Void,
+  error: PermissionRequestNotFoundError,
+});
+
+/**
+ * Cold-load helper for renderer hydration. Returns every request that the
+ * server is still awaiting a decision for, scoped to one session. Used on
+ * mount and after a reconnection so the toast comes back without waiting for
+ * the next stream message.
+ */
+export const PermissionListPendingRpc = Rpc.make("permission.listPending", {
+  payload: Schema.Struct({ sessionId: SessionId }),
+  success: Schema.Array(PermissionRequest),
+});

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -16,6 +16,11 @@ import {
   GitOriginRpc,
   GitStatusRpc,
 } from "./git.ts";
+import {
+  PermissionDecideRpc,
+  PermissionListPendingRpc,
+  PermissionRequestsRpc,
+} from "./permission.ts";
 import { PingRpc } from "./ping.ts";
 import {
   PtyCloseRpc,
@@ -35,6 +40,7 @@ import {
   SessionGetRpc,
   SessionListRpc,
   SessionRenameRpc,
+  SessionResumeRpc,
   SessionSetModelRpc,
   SessionUnarchiveRpc,
 } from "./session.ts";
@@ -86,10 +92,14 @@ export const ForkzeroRpcs = RpcGroup.make(
   SessionArchiveRpc,
   SessionUnarchiveRpc,
   SessionDeleteRpc,
+  SessionResumeRpc,
   MessagesListRpc,
   MessagesStreamRpc,
   MessagesSendRpc,
   MessagesInterruptRpc,
+  PermissionRequestsRpc,
+  PermissionDecideRpc,
+  PermissionListPendingRpc,
 );
 export type ForkzeroRpcs = typeof ForkzeroRpcs;
 

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -32,6 +32,19 @@ export const SessionStatus = Schema.Literal(
 );
 export type SessionStatus = typeof SessionStatus.Type;
 
+/**
+ * How (if at all) a session can resume after the provider session is gone.
+ * Captured at start time; the renderer uses it to decide whether to expose
+ * a "Resumable" affordance on stopped sessions.
+ *
+ *   - `claude-session-id` — Claude SDK's `session_id` is stored in `cursor`
+ *     and passed back as `options.resume` on the next start.
+ *   - `none` — no resume; sending again starts a fresh provider session
+ *     under the same DB row (existing chat-MVP behavior).
+ */
+export const ResumeStrategy = Schema.Literal("claude-session-id", "none");
+export type ResumeStrategy = typeof ResumeStrategy.Type;
+
 export class Session extends Schema.Class<Session>("Session")({
   id: SessionId,
   projectId: FolderId,
@@ -40,6 +53,8 @@ export class Session extends Schema.Class<Session>("Session")({
   model: Schema.String,
   status: SessionStatus,
   archivedAt: Schema.NullOr(Schema.DateFromString),
+  cursor: Schema.NullOr(Schema.String),
+  resumeStrategy: ResumeStrategy,
   createdAt: Schema.DateFromString,
   updatedAt: Schema.DateFromString,
 }) {}
@@ -207,4 +222,16 @@ export const MessagesInterruptRpc = Rpc.make("messages.interrupt", {
   payload: Schema.Struct({ sessionId: SessionId }),
   success: Schema.Void,
   error: SessionNotFoundError,
+});
+
+/**
+ * Re-open a stopped session against the provider. For Claude this passes
+ * the persisted `cursor` to the SDK's `resume`; for Codex it currently
+ * fails with `SessionStartError({ reason: "resume_unsupported" })` and the
+ * renderer offers "Start new session" instead.
+ */
+export const SessionResumeRpc = Rpc.make("session.resume", {
+  payload: Schema.Struct({ sessionId: SessionId }),
+  success: Session,
+  error: Schema.Union(SessionNotFoundError, SessionStartError),
 });

--- a/spec/phases/04-permissions.md
+++ b/spec/phases/04-permissions.md
@@ -8,15 +8,15 @@
 
 **Depends on**: Phase 3 (chat MVP)
 
-> **Note:** Renumbered from "Phase 3" when the chat-first pivot inserted the new Phase 3. Session persistence moved up into Phase 3 (it's foundational to the chat UI). What's left here is permissions UI, inline diff rendering, resume of interrupted turns, and NDJSON transcript export.
+> **Note:** Renumbered from "Phase 3" when the chat-first pivot inserted the new Phase 3. Session persistence already shipped in Phase 3 (SQLite at `<userData>/forkzero.sqlite`, sessions list in the projects sidebar). What's left here is permissions UI, inline diff rendering, resume of interrupted turns, and an NDJSON audit/export sink.
 
 ## Deliverables
 
 1. Permission prompt UI: file write, command exec, network access
-2. Per-session "always allow" memory
-3. Session persistence — full transcript saved as NDJSON
-4. Resume: relaunch app, click a stopped session, continue from where it ended (where SDK supports it)
-5. Sessions list view per folder
+2. Per-session "allow for session" memory (no in-app pattern matching — the SDK suppresses re-prompts when we hand back a session-scoped decision)
+3. NDJSON transcript audit log — best-effort tail-write per session, rotates at ~100 MB. SQLite remains the canonical store; NDJSON is for export / external tooling.
+4. Resume: relaunch app, click a stopped session, continue from where it ended (where the SDK supports it — Claude does via its `session_id`; Codex falls back to "Session ended").
+5. Inline diff rendering for `Edit` / `Write` / `MultiEdit` tool calls (replaces the JSON view).
 
 ## User scenarios
 
@@ -31,13 +31,14 @@
 
 ## Storage layout
 
+Session metadata, message history, and permission decisions all live in `<userData>/forkzero.sqlite` (SQLite is canonical — schema added by migrations 0002 and 0003). NDJSON is a side-write audit/export sink:
+
 ```
-userData/
+<userData>/
+  forkzero.sqlite                                 # canonical: sessions, messages, permission_decisions
   sessions/
-    <folder-id>/
-      <session-id>.meta.json      # provider, started, ended, status, model, cursor
-      <session-id>.events.ndjson  # one AgentEvent per line
-      <session-id>.permissions.json # session-scoped allow list
+    <project-id>/
+      <session-id>.events.ndjson                  # tail-written; rotates to *.events.<ts>.ndjson at 100MB
 ```
 
 ## Permission model
@@ -55,7 +56,7 @@ type PermissionDecision =
   | { _tag: "AlwaysAllow"; scope: "folder" | "global" }   // future
 ```
 
-For Phase 3 only `AllowOnce`, `AllowForSession`, `Deny` are exposed. `AlwaysAllow` is plumbing only, no UI yet.
+For Phase 4 only `AllowOnce`, `AllowForSession`, `Deny` are exposed in the UI. `AlwaysAllow` is schema-only plumbing.
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Summary

Closes the trust gap so an agent can be left running unattended. Five Phase 4 deliverables land together — they're tightly coupled via the `MessageStore` event loop and split awkwardly.

- **Permission prompts** for FileWrite / Bash / Network. Toast docks above the chat timeline; ⌘+Enter allows once, Esc denies. "Allow for this session" is enforced by short-circuiting identical `(sessionId, kindKey)` requests in the driver loop, persisted to a new `permission_decisions` table so it survives restart.
- **Resume** for Claude sessions. Driver captures the SDK's `session_id` on first message → persists to `sessions.cursor`. New `session.resume` RPC re-opens the SDK against the same DB row with `options.resume`. Codex returns `reason: "resume_unsupported"`.
- **Inline diff** for `Edit` / `Write` / `MultiEdit` tool calls (replaces the JSON view). Uses the `diff` package's `structuredPatch`; collapses past 30 changed lines.
- **NDJSON audit sink** at `<userData>/sessions/<projectId>/<sessionId>.events.ndjson`. Rotates at 100 MB. Best-effort — SQLite stays canonical and a broken sink can't stall the agent loop.
- **Spec rewording**: `spec/phases/04-permissions.md` now reflects that SQLite is the canonical store (Phase 3 shipped that) and NDJSON is the export sink.

Codex driver stays on `approvalPolicy: \"never\"` — its SDK exposes no programmatic callback we can route to the toast. Documented in `codex.ts`.

## Test plan

- [ ] \`bun run check-types\` — green on all 6 packages
- [ ] \`bun run build:desktop\` — main + renderer bundles build
- [ ] \`bun dev\`, add a project, start a Claude session
- [ ] Ask the agent to \`npm install\` — toast appears, agent blocks until decided
- [ ] Click \"Allow for this session\", ask the same command again — no re-prompt
- [ ] Click \"Deny\" on a different command — agent surfaces the deny and continues
- [ ] \`kill -9\` the desktop process mid-prompt; relaunch; pending request is rehydrated via \`permission.listPending\`
- [ ] \`sqlite3 ~/Library/Application\\ Support/forkzero/forkzero.sqlite \"SELECT * FROM permission_decisions\"\` — rows present
- [ ] Run an \`Edit\` against a long file — inline diff renders with line numbers; \>30 lines collapses
- [ ] \`kill -9\` mid-Claude turn; relaunch; session shows \"Resume\" pill; click it; send a follow-up — Claude continues in the same conversation
- [ ] Same flow on a Codex session — error toast \"resume_unsupported\", clicking \"+ New session\" works
- [ ] Tail \`<userData>/sessions/<project>/<session>.events.ndjson\` during a turn; valid line-aligned JSON; killing mid-write leaves a clean trailing newline-or-nothing