### PR TITLE
fix(permissions): stable selector for permission toast

### DIFF
--- a/apps/renderer/src/components/permission-toast.tsx
+++ b/apps/renderer/src/components/permission-toast.tsx
@@ -8,10 +8,7 @@ import type {
   SessionId,
 } from "@forkzero/wire";
 
-import {
-  selectRequestsForSession,
-  usePermissionsStore,
-} from "../store/permissions.ts";
+import { usePermissionsStore } from "../store/permissions.ts";
 
 const kindHeadline = (kind: PermissionKind): string => {
   switch (kind._tag) {
@@ -50,12 +47,22 @@ const DENY: PermissionDecision = { _tag: "Deny" };
  * user can react without focusing the toast.
  */
 export function PermissionToast({ sessionId }: { sessionId: SessionId }) {
-  const selector = useMemo(() => selectRequestsForSession(sessionId), [
-    sessionId,
-  ]);
-  const requests = usePermissionsStore(selector);
+  // Select the stable map; derive the per-session list in useMemo. Returning
+  // a freshly-allocated filtered array directly from a Zustand selector
+  // breaks useSyncExternalStore's snapshot-equality check and triggers an
+  // infinite re-render loop.
+  const requestsById = usePermissionsStore((s) => s.requestsById);
   const decide = usePermissionsStore((s) => s.decide);
   const hydrate = usePermissionsStore((s) => s.hydrate);
+
+  const requests = useMemo<ReadonlyArray<PermissionRequest>>(() => {
+    const out: PermissionRequest[] = [];
+    for (const req of Object.values(requestsById)) {
+      if (req.sessionId === sessionId) out.push(req);
+    }
+    out.sort((a, b) => a.requestedAt.getTime() - b.requestedAt.getTime());
+    return out;
+  }, [requestsById, sessionId]);
 
   // Hydrate pending requests when the session changes — covers the boot
   // case where the global stream missed events that landed before this

--- a/apps/renderer/src/store/permissions.ts
+++ b/apps/renderer/src/store/permissions.ts
@@ -104,16 +104,3 @@ export const usePermissionsStore = create<PermissionsState>((set) => ({
   },
 }));
 
-export const selectRequestsForSession = (
-  sessionId: SessionId,
-): ((s: PermissionsState) => ReadonlyArray<PermissionRequest>) => {
-  return (s) => {
-    const out: PermissionRequest[] = [];
-    for (const req of Object.values(s.requestsById)) {
-      if (req.sessionId === sessionId) out.push(req);
-    }
-    return out.sort(
-      (a, b) => a.requestedAt.getTime() - b.requestedAt.getTime(),
-    );
-  };
-};


### PR DESCRIPTION
## Summary

Follow-up to #20. The permission toast crashed with \"Maximum update depth exceeded\" because its Zustand selector returned a freshly-allocated filtered+sorted array on every read — `useSyncExternalStore` saw a new snapshot each render and looped.

Mirrors the pattern already in \`chat-view.tsx\`: select the stable \`requestsById\` map, derive the per-session sorted list in \`useMemo\`. Also drops the now-unused \`selectRequestsForSession\` helper from the store.

## Test plan

- [ ] \`bun run check-types\` — green
- [ ] \`bun dev\`, open a Claude session — no console error, no infinite loop
- [ ] Trigger a permission prompt — toast renders, decisions still flow