### PR TITLE
phase 4.5: smart permission policy + always-allow + inspector

### DIFF
--- a/apps/renderer/src/components/permission-toast.tsx
+++ b/apps/renderer/src/components/permission-toast.tsx
@@ -1,4 +1,4 @@
-import { ShieldAlert, ShieldCheck, ShieldX } from "lucide-react";
+import { ShieldAlert, ShieldCheck, ShieldX, Zap } from "lucide-react";
 import { useEffect, useMemo } from "react";
 
 import type {
@@ -38,6 +38,10 @@ const kindDetail = (kind: PermissionKind): string => {
 
 const ALLOW_ONCE: PermissionDecision = { _tag: "AllowOnce" };
 const ALLOW_FOR_SESSION: PermissionDecision = { _tag: "AllowForSession" };
+const ALWAYS_ALLOW_FOLDER: PermissionDecision = {
+  _tag: "AlwaysAllow",
+  scope: "folder",
+};
 const DENY: PermissionDecision = { _tag: "Deny" };
 
 /**
@@ -90,6 +94,11 @@ export function PermissionToast({ sessionId }: { sessionId: SessionId }) {
 
   if (head === undefined) return null;
 
+  const persistentDisabled = head.forcePrompt;
+  const persistentTooltip = persistentDisabled
+    ? "Sensitive path — must approve each time"
+    : undefined;
+
   return (
     <div className="border-b border-amber-500/40 bg-amber-500/10 px-4 py-3">
       <div className="mx-auto flex max-w-3xl flex-col gap-2">
@@ -102,6 +111,12 @@ export function PermissionToast({ sessionId }: { sessionId: SessionId }) {
             <div className="mt-1 break-all rounded bg-zinc-950/40 px-2 py-1 font-mono text-xs text-amber-50">
               {kindDetail(head.kind)}
             </div>
+            {head.forcePrompt ? (
+              <div className="mt-1 text-[11px] text-amber-200/80">
+                Sensitive path — &quot;Allow for session&quot; and &quot;Always
+                allow&quot; are disabled here.
+              </div>
+            ) : null}
           </div>
           {requests.length > 1 ? (
             <span className="rounded bg-amber-500/30 px-1.5 py-0.5 text-[10px] font-medium text-amber-100">
@@ -121,11 +136,23 @@ export function PermissionToast({ sessionId }: { sessionId: SessionId }) {
           </button>
           <button
             type="button"
+            disabled={persistentDisabled}
             onClick={() => void decide(head.id, ALLOW_FOR_SESSION)}
-            className="flex items-center gap-1.5 rounded-md border border-emerald-700 bg-emerald-900/40 px-2.5 py-1 text-xs text-emerald-100 hover:bg-emerald-900/70"
+            className="flex items-center gap-1.5 rounded-md border border-emerald-700 bg-emerald-900/40 px-2.5 py-1 text-xs text-emerald-100 hover:bg-emerald-900/70 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-emerald-900/40"
+            title={persistentTooltip}
           >
             <ShieldCheck className="size-3.5" />
-            Allow for this session
+            Allow for session
+          </button>
+          <button
+            type="button"
+            disabled={persistentDisabled}
+            onClick={() => void decide(head.id, ALWAYS_ALLOW_FOLDER)}
+            className="flex items-center gap-1.5 rounded-md border border-violet-700 bg-violet-900/40 px-2.5 py-1 text-xs text-violet-100 hover:bg-violet-900/70 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-violet-900/40"
+            title={persistentTooltip}
+          >
+            <Zap className="size-3.5" />
+            Always allow in project
           </button>
           <button
             type="button"

--- a/apps/renderer/src/components/permissions-inspector.tsx
+++ b/apps/renderer/src/components/permissions-inspector.tsx
@@ -1,0 +1,289 @@
+import { Globe, Pencil, Shield, Terminal, Trash2, Wrench } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import type {
+  FolderId,
+  PermissionKind,
+  SavedDecision,
+} from "@forkzero/wire";
+
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPopup,
+  DialogPortal,
+  DialogTitle,
+  DialogViewport,
+} from "~/components/ui/dialog";
+import { usePermissionsStore } from "../store/permissions.ts";
+
+const kindIcon = (kind: PermissionKind) => {
+  switch (kind._tag) {
+    case "Bash":
+      return <Terminal className="size-3.5 text-amber-300" />;
+    case "FileWrite":
+      return <Pencil className="size-3.5 text-emerald-300" />;
+    case "Network":
+      return <Globe className="size-3.5 text-sky-300" />;
+    case "Other":
+      return <Wrench className="size-3.5 text-zinc-300" />;
+  }
+};
+
+const kindLabel = (kind: PermissionKind): string => {
+  switch (kind._tag) {
+    case "Bash":
+      return kind.command;
+    case "FileWrite":
+      return kind.path;
+    case "Network":
+      return kind.url;
+    case "Other":
+      return `${kind.tool} — ${kind.summary}`;
+  }
+};
+
+const decisionStyles = (decision: SavedDecision["decision"]): string => {
+  switch (decision) {
+    case "AlwaysAllow":
+      return "bg-violet-500/15 text-violet-200 border-violet-500/40";
+    case "AllowForSession":
+      return "bg-emerald-500/15 text-emerald-200 border-emerald-500/40";
+    case "AllowOnce":
+      return "bg-zinc-500/15 text-zinc-200 border-zinc-500/40";
+    case "Deny":
+      return "bg-red-500/15 text-red-200 border-red-500/40";
+  }
+};
+
+const formatDate = (d: Date): string => {
+  const sec = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (sec < 60) return "just now";
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+  return d.toLocaleDateString();
+};
+
+interface PermissionsInspectorProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: FolderId;
+  projectName: string;
+}
+
+/**
+ * Modal listing permission decisions saved against one project. Decisions are
+ * grouped by scope: folder (`AlwaysAllow`) shows up top, session-scoped
+ * `AllowForSession` rows below, and any persisted `AllowOnce`/`Deny` rows
+ * collapsed under "Recent activity". Revoke deletes the row so the next
+ * matching tool call re-prompts.
+ */
+export function PermissionsInspector({
+  open,
+  onOpenChange,
+  projectId,
+  projectName,
+}: PermissionsInspectorProps) {
+  const decisionsByProject = usePermissionsStore((s) => s.decisionsByProject);
+  const loadingByProject = usePermissionsStore(
+    (s) => s.loadingDecisionsByProject,
+  );
+  const loadDecisions = usePermissionsStore((s) => s.loadDecisions);
+  const revoke = usePermissionsStore((s) => s.revoke);
+
+  const decisions = decisionsByProject[projectId] ?? [];
+  const loading = loadingByProject[projectId] === true;
+
+  // Reload every time the modal opens — the user may have hit a prompt
+  // outside this surface and we want fresh state.
+  useEffect(() => {
+    if (open) void loadDecisions(projectId);
+  }, [open, projectId, loadDecisions]);
+
+  const grouped = useMemo(() => {
+    const folder: SavedDecision[] = [];
+    const session: SavedDecision[] = [];
+    const recent: SavedDecision[] = [];
+    for (const d of decisions) {
+      if (d.scope === "folder" && d.decision === "AlwaysAllow") folder.push(d);
+      else if (d.scope === "session" && d.decision === "AllowForSession")
+        session.push(d);
+      else recent.push(d);
+    }
+    return { folder, session, recent };
+  }, [decisions]);
+
+  const [showSession, setShowSession] = useState(true);
+  const [showRecent, setShowRecent] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogBackdrop />
+        <DialogViewport>
+          <DialogPopup
+            className="max-w-2xl"
+            showCloseButton
+          >
+            <div className="flex items-center gap-2 px-6 pt-6">
+              <Shield className="size-4 text-violet-300" />
+              <DialogTitle className="text-base">
+                Permissions — {projectName}
+              </DialogTitle>
+            </div>
+            <div className="max-h-[60vh] overflow-y-auto px-6 pb-4 pt-3 text-sm">
+              {loading && decisions.length === 0 ? (
+                <p className="text-xs text-muted-foreground">Loading…</p>
+              ) : decisions.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  No saved permission decisions for this project yet. They
+                  appear here when you click &quot;Allow for session&quot; or
+                  &quot;Always allow in project&quot; on a permission prompt.
+                </p>
+              ) : (
+                <>
+                  <Section
+                    title="Always allowed in this project"
+                    decisions={grouped.folder}
+                    onRevoke={(id) => void revoke(projectId, id)}
+                    emptyHint="No project-wide allowances yet."
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowSession((v) => !v)}
+                    className="mt-4 flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    {showSession ? "▾" : "▸"} Allowed for past sessions (
+                    {grouped.session.length})
+                  </button>
+                  {showSession && (
+                    <Section
+                      title=""
+                      decisions={grouped.session}
+                      onRevoke={(id) => void revoke(projectId, id)}
+                      emptyHint="No session-scoped allowances."
+                    />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setShowRecent((v) => !v)}
+                    className="mt-4 flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    {showRecent ? "▾" : "▸"} Recent activity (
+                    {grouped.recent.length})
+                  </button>
+                  {showRecent && (
+                    <Section
+                      title=""
+                      decisions={grouped.recent}
+                      onRevoke={(id) => void revoke(projectId, id)}
+                      emptyHint="No recent prompts."
+                    />
+                  )}
+                </>
+              )}
+            </div>
+          </DialogPopup>
+        </DialogViewport>
+      </DialogPortal>
+    </Dialog>
+  );
+}
+
+function Section({
+  title,
+  decisions,
+  onRevoke,
+  emptyHint,
+}: {
+  title: string;
+  decisions: ReadonlyArray<SavedDecision>;
+  onRevoke: (requestId: string) => void;
+  emptyHint: string;
+}) {
+  if (title === "" && decisions.length === 0) {
+    return (
+      <p className="mt-2 text-[11px] text-muted-foreground">{emptyHint}</p>
+    );
+  }
+  return (
+    <div className={title === "" ? "mt-2" : "mt-4"}>
+      {title !== "" ? (
+        <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      ) : null}
+      {decisions.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground">{emptyHint}</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {decisions.map((d) => (
+            <DecisionRow key={d.requestId} decision={d} onRevoke={onRevoke} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function DecisionRow({
+  decision,
+  onRevoke,
+}: {
+  decision: SavedDecision;
+  onRevoke: (requestId: string) => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  return (
+    <li className="flex items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
+      <span className="shrink-0">{kindIcon(decision.kind)}</span>
+      <span
+        className="flex-1 truncate font-mono text-xs text-foreground"
+        title={kindLabel(decision.kind)}
+      >
+        {kindLabel(decision.kind)}
+      </span>
+      <span
+        className={`rounded border px-1.5 py-0.5 text-[10px] ${decisionStyles(
+          decision.decision,
+        )}`}
+      >
+        {decision.decision}
+      </span>
+      <span className="shrink-0 text-[10px] text-muted-foreground">
+        {formatDate(decision.decidedAt)}
+      </span>
+      {confirming ? (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => {
+              onRevoke(decision.requestId);
+              setConfirming(false);
+            }}
+            className="rounded bg-red-500/30 px-2 py-0.5 text-[10px] text-red-100 hover:bg-red-500/50"
+          >
+            Revoke
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="rounded px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="rounded p-1 text-muted-foreground hover:bg-red-500/20 hover:text-red-200"
+          aria-label="Revoke"
+          title="Revoke this decision"
+        >
+          <Trash2 className="size-3.5" />
+        </button>
+      )}
+    </li>
+  );
+}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Play,
   Plus,
   Settings,
+  Shield,
   Sparkles,
   Trash2,
   X,
@@ -41,6 +42,7 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
+import { PermissionsInspector } from "./permissions-inspector.tsx";
 
 const initialsOf = (name: string): string => {
   const parts = name.split(/[-_.\s]+/).filter(Boolean);
@@ -242,6 +244,7 @@ function ProjectRow({
   const displayName = origin?.repo ?? name;
   const avatarUrl = avatarUrlFor(origin);
   const fallbackText = initialsOf(origin?.owner ?? name);
+  const [inspectorOpen, setInspectorOpen] = useState(false);
 
   const visibleSessions = useMemo(
     () =>
@@ -302,6 +305,18 @@ function ProjectRow({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
+            setInspectorOpen(true);
+          }}
+          className="rounded p-0.5 text-muted-foreground opacity-0 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-hover:opacity-100"
+          aria-label={`Permissions for ${displayName}`}
+          title="Permissions"
+        >
+          <Shield className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
             onRemove();
           }}
           className="rounded p-0.5 text-muted-foreground opacity-0 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-hover:opacity-100"
@@ -310,6 +325,13 @@ function ProjectRow({
           <X className="size-3.5" />
         </button>
       </div>
+
+      <PermissionsInspector
+        open={inspectorOpen}
+        onOpenChange={setInspectorOpen}
+        projectId={id}
+        projectName={displayName}
+      />
 
       {isExpanded && (
         <div className="ml-7 flex flex-col gap-0.5 pb-1">

--- a/apps/renderer/src/store/permissions.ts
+++ b/apps/renderer/src/store/permissions.ts
@@ -2,8 +2,10 @@ import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
 import type {
+  FolderId,
   PermissionDecision,
   PermissionRequest,
+  SavedDecision,
   SessionId,
 } from "@forkzero/wire";
 
@@ -22,12 +24,16 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 type PermissionsState = {
   readonly requestsById: Record<string, PermissionRequest>;
   readonly errorBySession: Record<string, string | null>;
+  readonly decisionsByProject: Record<string, ReadonlyArray<SavedDecision>>;
+  readonly loadingDecisionsByProject: Record<string, boolean>;
   readonly start: () => void;
   readonly hydrate: (sessionId: SessionId) => Promise<void>;
   readonly decide: (
     requestId: string,
     decision: PermissionDecision,
   ) => Promise<void>;
+  readonly loadDecisions: (projectId: FolderId) => Promise<void>;
+  readonly revoke: (projectId: FolderId, requestId: string) => Promise<void>;
 };
 
 const formatError = (err: unknown): string => {
@@ -40,9 +46,11 @@ const formatError = (err: unknown): string => {
 
 let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 
-export const usePermissionsStore = create<PermissionsState>((set) => ({
+export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   requestsById: {},
   errorBySession: {},
+  decisionsByProject: {},
+  loadingDecisionsByProject: {},
   start: () => {
     if (streamFiber !== null) return;
     void (async () => {
@@ -100,6 +108,66 @@ export const usePermissionsStore = create<PermissionsState>((set) => ({
       // The server drops the entry on success; a failed decide leaves it in
       // memory and we'll re-hydrate via listPending on the next session
       // mount. No noisy error UI for this case.
+    }
+  },
+  loadDecisions: async (projectId) => {
+    set((s) => ({
+      loadingDecisionsByProject: {
+        ...s.loadingDecisionsByProject,
+        [projectId]: true,
+      },
+    }));
+    try {
+      const client = await getRpcClient();
+      const decisions = await Effect.runPromise(
+        client.permission.listDecisions({ projectId }),
+      );
+      set((s) => ({
+        decisionsByProject: {
+          ...s.decisionsByProject,
+          [projectId]: decisions,
+        },
+        loadingDecisionsByProject: {
+          ...s.loadingDecisionsByProject,
+          [projectId]: false,
+        },
+      }));
+    } catch {
+      set((s) => ({
+        loadingDecisionsByProject: {
+          ...s.loadingDecisionsByProject,
+          [projectId]: false,
+        },
+      }));
+    }
+  },
+  revoke: async (projectId, requestId) => {
+    // Optimistic — drop the row from the cached list before the RPC settles.
+    // If the RPC fails we re-fetch to repair state. In practice a failure
+    // here is a renderer-side bug, not a user-visible state divergence.
+    const before = get().decisionsByProject[projectId];
+    set((s) => ({
+      decisionsByProject: {
+        ...s.decisionsByProject,
+        [projectId]: (s.decisionsByProject[projectId] ?? []).filter(
+          (d) => d.requestId !== requestId,
+        ),
+      },
+    }));
+    try {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.permission.revokeDecision({ requestId }),
+      );
+    } catch {
+      if (before !== undefined) {
+        set((s) => ({
+          decisionsByProject: {
+            ...s.decisionsByProject,
+            [projectId]: before,
+          },
+        }));
+      }
     }
   },
 }));

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -3,6 +3,7 @@ import { SqliteMigrator } from "@effect/sql-sqlite-node";
 import { Migration0001Initial } from "./migrations/0001_initial.ts";
 import { Migration0002Permissions } from "./migrations/0002_permissions.ts";
 import { Migration0003ResumeAndExport } from "./migrations/0003_resume_and_export.ts";
+import { Migration0004PermissionScope } from "./migrations/0004_permission_scope.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -17,5 +18,6 @@ export const MigrationsLive = SqliteMigrator.layer({
     "0001_initial": Migration0001Initial,
     "0002_permissions": Migration0002Permissions,
     "0003_resume_and_export": Migration0003ResumeAndExport,
+    "0004_permission_scope": Migration0004PermissionScope,
   }),
 });

--- a/apps/server/src/persistence/migrations/0004_permission_scope.ts
+++ b/apps/server/src/persistence/migrations/0004_permission_scope.ts
@@ -1,0 +1,23 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Adds project scoping to `permission_decisions`. Existing rows get
+ * `scope='session'` and `project_id=NULL` so the legacy short-circuit
+ * (`session_id` + `kind_key` + `decision='AllowForSession'`) keeps working
+ * untouched. New `AlwaysAllow` rows carry `scope='folder'` and a populated
+ * `project_id` so a per-project lookup can match across sessions.
+ */
+export const Migration0004PermissionScope = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`ALTER TABLE permission_decisions ADD COLUMN project_id TEXT`;
+  yield* sql`
+    ALTER TABLE permission_decisions
+    ADD COLUMN scope TEXT NOT NULL DEFAULT 'session'
+  `;
+  yield* sql`
+    CREATE INDEX idx_permission_decisions_project
+      ON permission_decisions(project_id, kind_tag, kind_key)
+  `;
+});

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -176,6 +176,87 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
 };
 
 /**
+ * Tools the agent can run without a prompt. These are pure reads or
+ * internal-state tools (`TodoWrite`) with no observable blast radius. The
+ * `Read` exception for sensitive paths is enforced separately in
+ * `policyFor` — even read-only tools force a prompt when the target looks
+ * like a secret.
+ */
+const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
+  "Read",
+  "LS",
+  "Glob",
+  "Grep",
+  "NotebookRead",
+  "BashOutput",
+  "TodoWrite",
+]);
+
+/**
+ * Path patterns that always prompt regardless of any prior `AllowForSession`
+ * or `AlwaysAllow` decision. Match anywhere in the path string — agents
+ * tend to use absolute paths, so anchoring to a directory boundary catches
+ * `~/.ssh/...` and `/path/to/repo/.env` alike.
+ */
+const SENSITIVE_PATTERNS: ReadonlyArray<RegExp> = [
+  /(^|\/)\.env(\.|$)/,
+  /(^|\/)credentials(\.[^/]+)?$/i,
+  /(^|\/)\.aws\//,
+  /(^|\/)\.ssh\//,
+  /(^|\/)id_(rsa|ed25519|ecdsa|dsa)(\.pub)?$/,
+  /\.(pem|key|p12|pfx)$/i,
+  /(^|\/)\.netrc$/,
+  /(^|\/)\.pgpass$/,
+];
+
+const isSensitivePath = (p: string): boolean =>
+  SENSITIVE_PATTERNS.some((re) => re.test(p));
+
+type ToolPolicy =
+  | { readonly kind: "auto-allow" }
+  | { readonly kind: "prompt"; readonly forcePrompt: boolean };
+
+/**
+ * Decide whether the SDK's tool call needs to bother the user. The driver
+ * still always reports the tool to the timeline; auto-allow only short-
+ * circuits the prompt itself.
+ */
+const policyFor = (
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): ToolPolicy => {
+  if (READ_ONLY_TOOLS.has(toolName)) {
+    if (toolName === "Read") {
+      const path = typeof toolInput.file_path === "string"
+        ? toolInput.file_path
+        : "";
+      if (path.length > 0 && isSensitivePath(path)) {
+        return { kind: "prompt", forcePrompt: true };
+      }
+    }
+    return { kind: "auto-allow" };
+  }
+  if (
+    toolName === "Edit" ||
+    toolName === "Write" ||
+    toolName === "MultiEdit" ||
+    toolName === "NotebookEdit"
+  ) {
+    const path =
+      typeof toolInput.file_path === "string"
+        ? toolInput.file_path
+        : typeof toolInput.notebook_path === "string"
+          ? (toolInput.notebook_path as string)
+          : "";
+    return {
+      kind: "prompt",
+      forcePrompt: path.length > 0 && isSensitivePath(path),
+    };
+  }
+  return { kind: "prompt", forcePrompt: false };
+};
+
+/**
  * Map a Claude SDK tool invocation onto a wire `PermissionKind`. Tools we
  * don't classify drop into `Other`; the server treats those as auto-allow
  * for now (logged) so the agent loop isn't stalled by every internal `Read`
@@ -225,11 +306,13 @@ const kindForTool = (
  * Hook the driver passes into the SDK's `canUseTool`. Returning a
  * `PermissionDecision` lets the orchestrator (`ProviderService`) plug
  * `PermissionService.request` in directly without the driver reaching
- * across modules.
+ * across modules. `forcePrompt` flows through to the broker so sensitive
+ * paths can't be silenced by prior `AllowForSession` / `AlwaysAllow` rows.
  */
 export type RequestPermission = (
   sessionId: AgentSessionId,
   kind: PermissionKind,
+  options: { readonly forcePrompt: boolean },
 ) => Promise<PermissionDecision>;
 
 /**
@@ -300,6 +383,15 @@ export const startClaudeSession = (
       // `PermissionService`. The renderer's toast eventually fulfills the
       // promise this awaits.
       canUseTool: async (toolName, toolInput) => {
+        const policy = policyFor(toolName, toolInput);
+        if (policy.kind === "auto-allow") {
+          // Read / LS / Glob / Grep / NotebookRead / BashOutput / TodoWrite
+          // skip the prompt entirely. We deliberately don't surface a
+          // `PermissionRequest` event for these — the timeline already
+          // shows the underlying `tool_use`, and a second "I asked for
+          // permission and was given it" row would be pure noise.
+          return { behavior: "allow", updatedInput: toolInput };
+        }
         const kind = kindForTool(toolName, toolInput);
         events.unsafeOffer({
           _tag: "PermissionRequest",
@@ -307,7 +399,9 @@ export const startClaudeSession = (
           kind: toolName,
           details: toolInput,
         });
-        const decision = await requestPermission(sessionId, kind);
+        const decision = await requestPermission(sessionId, kind, {
+          forcePrompt: policy.forcePrompt,
+        });
         if (decision._tag === "Deny") {
           return {
             behavior: "deny",
@@ -315,9 +409,9 @@ export const startClaudeSession = (
           };
         }
         // AllowOnce / AllowForSession / AlwaysAllow → allow. The session
-        // scope is enforced server-side: a second request with the same
-        // (sessionId, kindKey) short-circuits to AllowOnce without
-        // prompting.
+        // and folder scopes are enforced server-side: a second request
+        // with the same (sessionId|projectId, kindKey) short-circuits to
+        // AllowOnce without prompting (unless `forcePrompt` is set).
         return { behavior: "allow", updatedInput: toolInput };
       },
     };

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -168,6 +168,20 @@ const PermissionListPending = ForkzeroRpcs.toLayerHandler(
     Effect.flatMap(PermissionService, (svc) => svc.listPending(sessionId)),
 );
 
+const PermissionListDecisions = ForkzeroRpcs.toLayerHandler(
+  "permission.listDecisions",
+  ({ projectId }) =>
+    Effect.flatMap(PermissionService, (svc) =>
+      svc.listDecisions({ projectId }),
+    ),
+);
+
+const PermissionRevokeDecision = ForkzeroRpcs.toLayerHandler(
+  "permission.revokeDecision",
+  ({ requestId }) =>
+    Effect.flatMap(PermissionService, (svc) => svc.revokeDecision(requestId)),
+);
+
 export const ProviderHandlersLayer = Layer.mergeAll(
   Availability,
   SetCredential,
@@ -192,4 +206,6 @@ export const ProviderHandlersLayer = Layer.mergeAll(
   PermissionRequests,
   PermissionDecide,
   PermissionListPending,
+  PermissionListDecisions,
+  PermissionRevokeDecision,
 );

--- a/apps/server/src/provider/layers/permission-service.ts
+++ b/apps/server/src/provider/layers/permission-service.ts
@@ -1,11 +1,13 @@
 import { SqlClient } from "@effect/sql";
-import { Deferred, Effect, Layer, PubSub, Ref, Stream } from "effect";
+import { Deferred, Effect, Layer, PubSub, Ref, Schema, Stream } from "effect";
 
 import {
+  PermissionKind,
   PermissionRequest,
   PermissionRequestNotFoundError,
+  SavedDecision,
+  type FolderId,
   type PermissionDecision,
-  type PermissionKind,
   type SessionId,
 } from "@forkzero/wire";
 
@@ -22,12 +24,51 @@ interface PendingEntry {
 interface DecisionRow {
   readonly request_id: string;
   readonly session_id: string;
+  readonly project_id: string | null;
   readonly kind_tag: string;
   readonly kind_key: string;
   readonly kind_json: string;
   readonly decision: string;
+  readonly scope: string;
   readonly decided_at: string;
 }
+
+/**
+ * Decisions that should map to `scope='folder'`. Only `AlwaysAllow` is
+ * folder-scoped today; everything else stays session-scoped (even denials,
+ * which we keep for inspector visibility).
+ */
+const scopeForDecision = (decision: PermissionDecision): "session" | "folder" =>
+  decision._tag === "AlwaysAllow" ? "folder" : "session";
+
+const decodeSavedDecision = Schema.decodeUnknown(SavedDecision);
+
+const rowToSavedDecision = (
+  row: DecisionRow,
+): Effect.Effect<SavedDecision, never> =>
+  decodeSavedDecision({
+    requestId: row.request_id,
+    sessionId: row.session_id,
+    projectId: row.project_id,
+    kind: JSON.parse(row.kind_json),
+    decision: row.decision,
+    scope: row.scope,
+    decidedAt: row.decided_at,
+  }).pipe(
+    Effect.catchAll(() =>
+      // Bad row (corrupted scope/decision string) — surface a synthetic Deny
+      // so the inspector still renders. Better than crashing the whole list.
+      decodeSavedDecision({
+        requestId: row.request_id,
+        sessionId: row.session_id,
+        projectId: row.project_id,
+        kind: { _tag: "Other", tool: row.kind_tag, summary: row.kind_key },
+        decision: "Deny",
+        scope: "session",
+        decidedAt: row.decided_at,
+      }).pipe(Effect.orDie),
+    ),
+  );
 
 /**
  * Stable per-kind matching key. Equality on this string is what lets
@@ -65,17 +106,22 @@ export const PermissionServiceLive = Layer.scoped(
       new Map(),
     );
 
-    const findExistingSessionAllow = (
+    const findExistingAllow = (
       sessionId: SessionId,
+      projectId: FolderId,
       kind: PermissionKind,
     ): Effect.Effect<boolean> =>
       sql<DecisionRow>`
-        SELECT request_id, session_id, kind_tag, kind_key, kind_json, decision, decided_at
+        SELECT request_id, session_id, project_id, kind_tag, kind_key,
+               kind_json, decision, scope, decided_at
         FROM permission_decisions
-        WHERE session_id = ${sessionId}
-          AND kind_tag = ${kind._tag}
+        WHERE kind_tag = ${kind._tag}
           AND kind_key = ${kindKey(kind)}
-          AND decision = 'AllowForSession'
+          AND (
+            (session_id = ${sessionId} AND scope = 'session' AND decision = 'AllowForSession')
+            OR
+            (project_id = ${projectId} AND scope = 'folder' AND decision = 'AlwaysAllow')
+          )
         LIMIT 1
       `.pipe(
         Effect.map((rows) => rows.length > 0),
@@ -84,15 +130,19 @@ export const PermissionServiceLive = Layer.scoped(
 
     const persistDecision = (
       request: PermissionRequest,
+      projectId: FolderId,
       decision: PermissionDecision,
     ): Effect.Effect<void> =>
       sql`
         INSERT OR REPLACE INTO permission_decisions
-          (request_id, session_id, kind_tag, kind_key, kind_json, decision, decided_at)
+          (request_id, session_id, project_id, kind_tag, kind_key,
+           kind_json, decision, scope, decided_at)
         VALUES
-          (${request.id}, ${request.sessionId}, ${request.kind._tag},
-           ${kindKey(request.kind)}, ${JSON.stringify(request.kind)},
-           ${decisionTag(decision)}, ${new Date().toISOString()})
+          (${request.id}, ${request.sessionId}, ${projectId},
+           ${request.kind._tag}, ${kindKey(request.kind)},
+           ${JSON.stringify(request.kind)},
+           ${decisionTag(decision)}, ${scopeForDecision(decision)},
+           ${new Date().toISOString()})
       `.pipe(
         Effect.asVoid,
         Effect.catchAll((cause) =>
@@ -102,11 +152,30 @@ export const PermissionServiceLive = Layer.scoped(
         ),
       );
 
-    const request: PermissionServiceShape["request"] = (sessionId, kind) =>
+    /**
+     * Side table — `requestId → projectId` — so `decide()` can persist with
+     * the right `project_id` without re-querying the session row. Cleared
+     * when the request is fulfilled.
+     */
+    const projectByRequest = yield* Ref.make<ReadonlyMap<string, FolderId>>(
+      new Map(),
+    );
+
+    const request: PermissionServiceShape["request"] = (
+      sessionId,
+      kind,
+      options,
+    ) =>
       Effect.gen(function* () {
-        const allowed = yield* findExistingSessionAllow(sessionId, kind);
-        if (allowed) {
-          return { _tag: "AllowOnce" } as PermissionDecision;
+        if (options.forcePrompt !== true) {
+          const allowed = yield* findExistingAllow(
+            sessionId,
+            options.projectId,
+            kind,
+          );
+          if (allowed) {
+            return { _tag: "AllowOnce" } as PermissionDecision;
+          }
         }
 
         const id = nextRequestId();
@@ -115,6 +184,12 @@ export const PermissionServiceLive = Layer.scoped(
           sessionId,
           kind,
           requestedAt: new Date(),
+          forcePrompt: options.forcePrompt === true,
+        });
+        yield* Ref.update(projectByRequest, (m) => {
+          const next = new Map(m);
+          next.set(id, options.projectId);
+          return next;
         });
         const deferred = yield* Deferred.make<PermissionDecision>();
         yield* Ref.update(pending, (m) => {
@@ -136,12 +211,21 @@ export const PermissionServiceLive = Layer.scoped(
             new PermissionRequestNotFoundError({ requestId }),
           );
         }
+        const projects = yield* Ref.get(projectByRequest);
+        const projectId = projects.get(requestId);
         yield* Ref.update(pending, (m) => {
           const next = new Map(m);
           next.delete(requestId);
           return next;
         });
-        yield* persistDecision(entry.request, decision);
+        yield* Ref.update(projectByRequest, (m) => {
+          const next = new Map(m);
+          next.delete(requestId);
+          return next;
+        });
+        if (projectId !== undefined) {
+          yield* persistDecision(entry.request, projectId, decision);
+        }
         yield* Deferred.succeed(entry.deferred, decision);
       });
 
@@ -163,11 +247,51 @@ export const PermissionServiceLive = Layer.scoped(
         }),
       );
 
+    const listDecisions: PermissionServiceShape["listDecisions"] = (filter) =>
+      Effect.gen(function* () {
+        const rows = yield* (filter.projectId !== undefined
+          ? sql<DecisionRow>`
+              SELECT request_id, session_id, project_id, kind_tag, kind_key,
+                     kind_json, decision, scope, decided_at
+              FROM permission_decisions
+              WHERE project_id = ${filter.projectId}
+              ORDER BY decided_at DESC
+            `
+          : sql<DecisionRow>`
+              SELECT request_id, session_id, project_id, kind_tag, kind_key,
+                     kind_json, decision, scope, decided_at
+              FROM permission_decisions
+              ORDER BY decided_at DESC
+            `
+        ).pipe(Effect.catchAll(() => Effect.succeed([] as DecisionRow[])));
+        const out: SavedDecision[] = [];
+        for (const row of rows) {
+          out.push(yield* rowToSavedDecision(row));
+        }
+        return out;
+      });
+
+    const revokeDecision: PermissionServiceShape["revokeDecision"] = (
+      requestId,
+    ) =>
+      sql`
+        DELETE FROM permission_decisions WHERE request_id = ${requestId}
+      `.pipe(
+        Effect.asVoid,
+        Effect.catchAll((cause) =>
+          Effect.logWarning(
+            `[PermissionService] revoke failed: ${String(cause)}`,
+          ),
+        ),
+      );
+
     return {
       request,
       decide,
       listPending,
       requests,
+      listDecisions,
+      revokeDecision,
     } as const;
   }),
 );

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -7,6 +7,7 @@ import {
   AgentSessionStartError,
   type AgentAvailability,
   type AgentEvent,
+  type FolderId,
   type PermissionDecision,
   type PermissionKind,
   type ProviderId,
@@ -60,12 +61,21 @@ export const ProviderServiceLive = Layer.effect(
 
     // The Claude SDK's `canUseTool` callback returns a Promise; here we
     // shim PermissionService.request into that signature using the live
-    // runtime captured at layer construction.
-    const requestPermission = (
-      sessionId: AgentSessionId,
-      kind: PermissionKind,
-    ): Promise<PermissionDecision> =>
-      Runtime.runPromise(runtime)(permissions.request(sessionId, kind));
+    // runtime captured at layer construction. `projectId` is bound at
+    // start() time so the driver doesn't need to know about projects.
+    const buildRequestPermission =
+      (projectId: FolderId) =>
+      (
+        sessionId: AgentSessionId,
+        kind: PermissionKind,
+        options: { readonly forcePrompt: boolean },
+      ): Promise<PermissionDecision> =>
+        Runtime.runPromise(runtime)(
+          permissions.request(sessionId, kind, {
+            projectId,
+            forcePrompt: options.forcePrompt,
+          }),
+        );
 
     const availability = () =>
       Effect.gen(function* () {
@@ -131,7 +141,7 @@ export const ProviderServiceLive = Layer.effect(
               apiKey,
               claudePath,
               sessionId,
-              requestPermission,
+              buildRequestPermission(input.folderId),
               resumeCursor,
             );
           } else {

--- a/apps/server/src/provider/services/permission-service.ts
+++ b/apps/server/src/provider/services/permission-service.ts
@@ -1,10 +1,12 @@
 import { Context, type Effect, type Stream } from "effect";
 
 import type {
+  FolderId,
   PermissionDecision,
   PermissionKind,
   PermissionRequest,
   PermissionRequestNotFoundError,
+  SavedDecision,
   SessionId,
 } from "@forkzero/wire";
 
@@ -25,10 +27,23 @@ import type {
  * mirrors the SDK's own session-scoped suppression and keeps the prompt
  * stream quiet for repeat tool calls within a session.
  */
+/**
+ * Options for `request`. `projectId` is required so folder-scoped
+ * `AlwaysAllow` rows can short-circuit a re-prompt across sessions in the
+ * same project. `forcePrompt` skips the existing-decision lookup entirely —
+ * the driver sets it for sensitive paths so prior `AllowForSession` /
+ * `AlwaysAllow` decisions can't silence them.
+ */
+export interface RequestOptions {
+  readonly projectId: FolderId;
+  readonly forcePrompt?: boolean;
+}
+
 export interface PermissionServiceShape {
   readonly request: (
     sessionId: SessionId,
     kind: PermissionKind,
+    options: RequestOptions,
   ) => Effect.Effect<PermissionDecision>;
 
   readonly decide: (
@@ -41,6 +56,17 @@ export interface PermissionServiceShape {
   ) => Effect.Effect<ReadonlyArray<PermissionRequest>>;
 
   readonly requests: () => Stream.Stream<PermissionRequest>;
+
+  /**
+   * Inspector queries. `listDecisions` returns persisted decisions filtered
+   * by project (or all when no filter is given). `revokeDecision` deletes a
+   * single row by `requestId` so the next matching tool call re-prompts.
+   */
+  readonly listDecisions: (filter: {
+    readonly projectId?: FolderId;
+  }) => Effect.Effect<ReadonlyArray<SavedDecision>>;
+
+  readonly revokeDecision: (requestId: string) => Effect.Effect<void>;
 }
 
 export class PermissionService extends Context.Tag(

--- a/packages/wire/src/permission.ts
+++ b/packages/wire/src/permission.ts
@@ -1,6 +1,7 @@
 import { Rpc } from "@effect/rpc";
 import { Schema } from "effect";
 
+import { FolderId } from "./ids.ts";
 import { SessionId } from "./session.ts";
 
 /**
@@ -51,7 +52,35 @@ export class PermissionRequest extends Schema.Class<PermissionRequest>(
   sessionId: SessionId,
   kind: PermissionKind,
   requestedAt: Schema.DateFromString,
+  /**
+   * Sensitive paths (e.g. `.env`, SSH keys) flip this to `true` server-side.
+   * The renderer disables `AllowForSession` and `AlwaysAllow` for these so
+   * the user can't silence future prompts on them by accident.
+   */
+  forcePrompt: Schema.Boolean,
 }) {}
+
+/**
+ * One row from `permission_decisions`, denormalized for the inspector UI.
+ * Mirrors the table columns but keeps the kind as the structured wire type
+ * so the renderer doesn't re-parse JSON.
+ */
+export class SavedDecision extends Schema.Class<SavedDecision>("SavedDecision")(
+  {
+    requestId: Schema.String,
+    sessionId: SessionId,
+    projectId: Schema.NullOr(FolderId),
+    kind: PermissionKind,
+    decision: Schema.Literal(
+      "AllowOnce",
+      "AllowForSession",
+      "AlwaysAllow",
+      "Deny",
+    ),
+    scope: Schema.Literal("session", "folder", "global"),
+    decidedAt: Schema.DateFromString,
+  },
+) {}
 
 export class PermissionRequestNotFoundError extends Schema.TaggedError<PermissionRequestNotFoundError>()(
   "PermissionRequestNotFoundError",
@@ -93,3 +122,26 @@ export const PermissionListPendingRpc = Rpc.make("permission.listPending", {
   payload: Schema.Struct({ sessionId: SessionId }),
   success: Schema.Array(PermissionRequest),
 });
+
+/**
+ * Inspector RPCs. `listDecisions` returns saved decisions optionally filtered
+ * by project (typical use is per-project from the projects sidebar). `revoke`
+ * deletes a single row by `requestId` so the next matching request re-prompts.
+ */
+export const PermissionListDecisionsRpc = Rpc.make(
+  "permission.listDecisions",
+  {
+    payload: Schema.Struct({
+      projectId: Schema.optional(FolderId),
+    }),
+    success: Schema.Array(SavedDecision),
+  },
+);
+
+export const PermissionRevokeDecisionRpc = Rpc.make(
+  "permission.revokeDecision",
+  {
+    payload: Schema.Struct({ requestId: Schema.String }),
+    success: Schema.Void,
+  },
+);

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -18,8 +18,10 @@ import {
 } from "./git.ts";
 import {
   PermissionDecideRpc,
+  PermissionListDecisionsRpc,
   PermissionListPendingRpc,
   PermissionRequestsRpc,
+  PermissionRevokeDecisionRpc,
 } from "./permission.ts";
 import { PingRpc } from "./ping.ts";
 import {
@@ -100,6 +102,8 @@ export const ForkzeroRpcs = RpcGroup.make(
   PermissionRequestsRpc,
   PermissionDecideRpc,
   PermissionListPendingRpc,
+  PermissionListDecisionsRpc,
+  PermissionRevokeDecisionRpc,
 );
 export type ForkzeroRpcs = typeof ForkzeroRpcs;
 


### PR DESCRIPTION
## Summary

Phase 4 shipped real permission prompts but every tool prompted, including pure reads (`Read`, `LS`, `Grep`, `Glob`). A typical Claude turn would hit 5–15 read tools before any write — the prompts were drowning out genuine permission decisions. This PR closes that gap and adds the project-scoped \"Always allow\" surface that was schema-only in Phase 4.

- **Reads auto-allow.** `Read` / `LS` / `Glob` / `Grep` / `NotebookRead` / `BashOutput` / `TodoWrite` skip the broker entirely. Writes / `Bash` / `WebFetch` / `WebSearch` / `Task` / MCP tools still prompt.
- **Sensitive paths force a prompt.** `.env*`, credentials, `.ssh/*`, `*.pem`, `*.key`, `.netrc`, `.pgpass`, `.aws/*`, SSH key files. Even with a prior `AllowForSession` or `AlwaysAllow`, these paths re-prompt every time. The toast disables the persistent-decision buttons in this state with a tooltip.
- **\"Always allow in project\" button.** Folder-scoped `AlwaysAllow` rows now persist with `scope='folder'` and a `project_id`, and short-circuit re-prompts across sessions in the same project.
- **Permissions inspector.** Shield icon on each project row opens a modal listing saved decisions grouped by scope (folder / session / recent). Per-row revoke deletes the row so the next matching tool call re-prompts.

## Changes

- **Wire** (`packages/wire/src/permission.ts`): `forcePrompt` on `PermissionRequest`; new `SavedDecision` class; `PermissionListDecisionsRpc` + `PermissionRevokeDecisionRpc`.
- **Migration 0004** adds `project_id TEXT` and `scope TEXT NOT NULL DEFAULT 'session'` columns + a project-scoped index. Existing rows keep working unchanged.
- **PermissionService** (server) takes `{ projectId, forcePrompt? }` on `request`; `findExistingAllow` checks both session and folder scopes; new `listDecisions` / `revokeDecision`.
- **Claude driver** gets `READ_ONLY_TOOLS` + `SENSITIVE_PATTERNS` + `policyFor`; `canUseTool` short-circuits auto-allow before invoking the broker.
- **Renderer** toast adds the 4th button and disables persistent-decision buttons when `forcePrompt`. New `permissions-inspector.tsx` modal. Sidebar gets a Shield icon trigger per project.

## Test plan

- [ ] Send: \"List the files in this project, then read \`package.json\`, then read \`.env\` if it exists, then run \`npm install\`.\" Expect no prompts for `LS` or `Read package.json`.
- [ ] If the project has a `.env`, expect a prompt for it with the Allow-for-session and Always-allow buttons visually disabled.
- [ ] On the \`npm install\` prompt, click **Always allow in project**.
- [ ] Open a *new* session in the same project; ask the agent to run \`npm install\` again — expect no prompt.
- [ ] In a *different* project, the same \`npm install\` prompts (folder scope is per-project).
- [ ] Click the Shield icon next to a project name → inspector lists folder-scoped + session-scoped rows. Revoke a folder-scoped row → next session re-prompts for that command.
- [ ] \`sqlite3 ~/Library/Application\\ Support/forkzero/forkzero.sqlite \"SELECT scope, project_id, kind_tag, kind_key, decision FROM permission_decisions\"\` shows \`scope='folder'\` rows for AlwaysAllow and \`scope='session'\` rows for AllowForSession.
- [ ] \`bun run check-types\` and \`bun run build\` clean.

## Out of scope

- `AlwaysAllow scope: 'global'` — schema field unchanged, still no UI.
- Pattern matching (command prefix, path glob) — still exact `kindKey`.
- Codex parity — Codex SDK has no programmatic callback; behavior unchanged from Phase 4.
- Settings page for editing the read-only / sensitive-path lists — both are constants in the driver.