### PR TITLE
phase 4.6: per-session runtime mode toggle

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1,10 +1,20 @@
-import { Check, ChevronDown, Send, Sparkles, Square } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  Send,
+  ShieldAlert,
+  ShieldCheck,
+  Sparkles,
+  Square,
+  Zap,
+} from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
 import {
   MODELS_BY_PROVIDER,
   type Message,
   type ProviderId,
+  type RuntimeMode,
   type Session,
   type SessionId,
 } from "@forkzero/wire";
@@ -110,15 +120,99 @@ export function ChatComposer({ session }: { session: Session }) {
             </button>
           )}
         </div>
-        <div className="flex items-center justify-between px-1 text-[10px] text-muted-foreground">
+        <div className="flex items-center justify-between gap-2 px-1 text-[10px] text-muted-foreground">
           <ModelPicker
             sessionId={sessionId}
             providerId={session.providerId}
             currentModel={session.model}
           />
-          <span>{inFlight ? "running…" : "idle"}</span>
+          <div className="flex items-center gap-2">
+            <RuntimeModeToggle
+              sessionId={sessionId}
+              current={session.runtimeMode}
+            />
+            <span>{inFlight ? "running…" : "idle"}</span>
+          </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Three-state segmented control for the per-session permission posture.
+ *   - approval-required (shield) — every write/Bash/Network/Task prompts.
+ *   - auto-accept-edits (check)  — file edits skip the prompt; rest still ask.
+ *   - full-access (zap)          — auto-allow everything except sensitive paths.
+ *
+ * The mode is stored on the session row and read live by the SDK's
+ * canUseTool callback, so flipping the switch mid-turn applies to the next
+ * tool call without restarting the conversation.
+ */
+const MODE_META: Record<
+  RuntimeMode,
+  { label: string; title: string; Icon: typeof ShieldAlert }
+> = {
+  "approval-required": {
+    label: "Approve",
+    title: "Prompt for every write / shell / network call",
+    Icon: ShieldAlert,
+  },
+  "auto-accept-edits": {
+    label: "Edits",
+    title: "Auto-allow file edits; still prompt for shell / network / subagent",
+    Icon: ShieldCheck,
+  },
+  "full-access": {
+    label: "YOLO",
+    title:
+      "Auto-allow everything except sensitive paths (.env, credentials, …)",
+    Icon: Zap,
+  },
+};
+
+function RuntimeModeToggle({
+  sessionId,
+  current,
+}: {
+  sessionId: SessionId;
+  current: RuntimeMode;
+}) {
+  const setRuntimeMode = useSessionsStore((s) => s.setRuntimeMode);
+  const modes: ReadonlyArray<RuntimeMode> = [
+    "approval-required",
+    "auto-accept-edits",
+    "full-access",
+  ];
+  return (
+    <div className="flex overflow-hidden rounded border border-border">
+      {modes.map((mode) => {
+        const meta = MODE_META[mode];
+        const Icon = meta.Icon;
+        const active = mode === current;
+        return (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => {
+              if (!active) void setRuntimeMode(sessionId, mode);
+            }}
+            title={meta.title}
+            className={`flex items-center gap-1 px-1.5 py-0.5 text-[10px] transition-colors ${
+              active
+                ? mode === "full-access"
+                  ? "bg-amber-500/20 text-amber-200"
+                  : mode === "auto-accept-edits"
+                    ? "bg-emerald-500/20 text-emerald-200"
+                    : "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/60"
+            }`}
+          >
+            <Icon className="size-3" />
+            <span>{meta.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 import type {
   FolderId,
   ProviderId,
+  RuntimeMode,
   Session,
   SessionId,
 } from "@forkzero/wire";
@@ -31,6 +32,10 @@ type SessionsState = {
   ) => Promise<SessionId | null>;
   readonly rename: (sessionId: SessionId, title: string) => Promise<void>;
   readonly setModel: (sessionId: SessionId, model: string) => Promise<void>;
+  readonly setRuntimeMode: (
+    sessionId: SessionId,
+    runtimeMode: RuntimeMode,
+  ) => Promise<void>;
   readonly refreshOne: (sessionId: SessionId) => Promise<void>;
   readonly archive: (sessionId: SessionId) => Promise<void>;
   readonly unarchive: (sessionId: SessionId) => Promise<void>;
@@ -157,6 +162,36 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
       });
     } catch (err) {
       set({ error: formatError(err) });
+    }
+  },
+  setRuntimeMode: async (sessionId, runtimeMode) => {
+    // Optimistic — patch the local row before the RPC settles so the toggle
+    // feels instant. Server-side update is also fast (single SQL UPDATE +
+    // in-memory cache poke), so the round-trip is invisible in practice.
+    set((s) => {
+      const projectId = findSessionProject(s.sessionsByProject, sessionId);
+      if (projectId === null) return { error: null };
+      const sessions = s.sessionsByProject[projectId] ?? [];
+      return {
+        error: null,
+        sessionsByProject: {
+          ...s.sessionsByProject,
+          [projectId]: sessions.map((session) =>
+            session.id === sessionId ? { ...session, runtimeMode } : session,
+          ),
+        },
+      };
+    });
+    try {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.session.setRuntimeMode({ sessionId, runtimeMode }),
+      );
+    } catch (err) {
+      set({ error: formatError(err) });
+      // Best-effort revert via re-hydrate of the affected project.
+      const projectId = findSessionProject(get().sessionsByProject, sessionId);
+      if (projectId !== null) await get().hydrate(projectId);
     }
   },
   archive: async (sessionId) => {

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -4,6 +4,7 @@ import { Migration0001Initial } from "./migrations/0001_initial.ts";
 import { Migration0002Permissions } from "./migrations/0002_permissions.ts";
 import { Migration0003ResumeAndExport } from "./migrations/0003_resume_and_export.ts";
 import { Migration0004PermissionScope } from "./migrations/0004_permission_scope.ts";
+import { Migration0005RuntimeMode } from "./migrations/0005_runtime_mode.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -19,5 +20,6 @@ export const MigrationsLive = SqliteMigrator.layer({
     "0002_permissions": Migration0002Permissions,
     "0003_resume_and_export": Migration0003ResumeAndExport,
     "0004_permission_scope": Migration0004PermissionScope,
+    "0005_runtime_mode": Migration0005RuntimeMode,
   }),
 });

--- a/apps/server/src/persistence/migrations/0005_runtime_mode.ts
+++ b/apps/server/src/persistence/migrations/0005_runtime_mode.ts
@@ -1,0 +1,18 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Adds `runtime_mode` to `sessions`. Default is `approval-required` — the
+ * safe default that matches existing behavior (every write / shell / network
+ * tool prompts). Existing rows get the default automatically; the toggle in
+ * the chat header lets the user move sessions to `auto-accept-edits` or
+ * `full-access` once they trust the agent.
+ */
+export const Migration0005RuntimeMode = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    ALTER TABLE sessions
+    ADD COLUMN runtime_mode TEXT NOT NULL DEFAULT 'approval-required'
+  `;
+});

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -14,6 +14,7 @@ import {
   type AgentSessionId,
   type PermissionDecision,
   type PermissionKind,
+  type RuntimeMode,
   type StartSessionInput,
 } from "@forkzero/wire";
 
@@ -216,43 +217,68 @@ type ToolPolicy =
   | { readonly kind: "auto-allow" }
   | { readonly kind: "prompt"; readonly forcePrompt: boolean };
 
+const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
+  "Edit",
+  "Write",
+  "MultiEdit",
+  "NotebookEdit",
+]);
+
+const editPathOf = (toolInput: Record<string, unknown>): string =>
+  typeof toolInput.file_path === "string"
+    ? toolInput.file_path
+    : typeof toolInput.notebook_path === "string"
+      ? (toolInput.notebook_path as string)
+      : "";
+
 /**
- * Decide whether the SDK's tool call needs to bother the user. The driver
- * still always reports the tool to the timeline; auto-allow only short-
- * circuits the prompt itself.
+ * Decide whether the SDK's tool call needs to bother the user. Layered:
+ *
+ *   1. Sensitive paths always force a prompt (`forcePrompt: true`) — this is
+ *      the safety net that survives every other allow rule, including
+ *      `full-access` mode.
+ *   2. Read-only tools auto-allow.
+ *   3. `auto-accept-edits` mode short-circuits file edits.
+ *   4. `full-access` mode short-circuits everything else.
+ *   5. Otherwise, prompt.
  */
 const policyFor = (
   toolName: string,
   toolInput: Record<string, unknown>,
+  runtimeMode: RuntimeMode,
 ): ToolPolicy => {
-  if (READ_ONLY_TOOLS.has(toolName)) {
-    if (toolName === "Read") {
-      const path = typeof toolInput.file_path === "string"
-        ? toolInput.file_path
-        : "";
-      if (path.length > 0 && isSensitivePath(path)) {
-        return { kind: "prompt", forcePrompt: true };
-      }
+  // 1. Sensitive paths — checked before any auto-allow. Even YOLO mode prompts.
+  if (toolName === "Read") {
+    const path = typeof toolInput.file_path === "string"
+      ? toolInput.file_path
+      : "";
+    if (path.length > 0 && isSensitivePath(path)) {
+      return { kind: "prompt", forcePrompt: true };
     }
+  }
+  if (FILE_EDIT_TOOLS.has(toolName)) {
+    const path = editPathOf(toolInput);
+    if (path.length > 0 && isSensitivePath(path)) {
+      return { kind: "prompt", forcePrompt: true };
+    }
+  }
+
+  // 2. Read-only tools — always free, regardless of mode.
+  if (READ_ONLY_TOOLS.has(toolName)) {
     return { kind: "auto-allow" };
   }
-  if (
-    toolName === "Edit" ||
-    toolName === "Write" ||
-    toolName === "MultiEdit" ||
-    toolName === "NotebookEdit"
-  ) {
-    const path =
-      typeof toolInput.file_path === "string"
-        ? toolInput.file_path
-        : typeof toolInput.notebook_path === "string"
-          ? (toolInput.notebook_path as string)
-          : "";
-    return {
-      kind: "prompt",
-      forcePrompt: path.length > 0 && isSensitivePath(path),
-    };
+
+  // 3. auto-accept-edits — file edits skip the prompt; everything else falls
+  //    through to the regular prompt flow.
+  if (runtimeMode === "auto-accept-edits" && FILE_EDIT_TOOLS.has(toolName)) {
+    return { kind: "auto-allow" };
   }
+
+  // 4. full-access — auto-allow anything that survived the sensitive-path check.
+  if (runtimeMode === "full-access") {
+    return { kind: "auto-allow" };
+  }
+
   return { kind: "prompt", forcePrompt: false };
 };
 
@@ -332,6 +358,13 @@ export type RequestPermission = (
  * decision the caller honors via the SDK's allow/deny contract; the driver
  * itself stays free of any DB or PubSub wiring.
  */
+/**
+ * Live read of the per-session runtime mode. Called inside `canUseTool` so
+ * the user toggling the chat header takes effect on the next tool call —
+ * no SDK restart needed.
+ */
+export type GetRuntimeMode = () => RuntimeMode;
+
 export const startClaudeSession = (
   input: StartSessionInput,
   cwd: string,
@@ -339,6 +372,7 @@ export const startClaudeSession = (
   claudeExecutablePath: string | null,
   sessionId: AgentSessionId,
   requestPermission: RequestPermission,
+  getRuntimeMode: GetRuntimeMode,
   resumeCursor: string | null = null,
 ): Effect.Effect<ClaudeSessionHandle, AgentSessionStartError> =>
   Effect.gen(function* () {
@@ -383,7 +417,7 @@ export const startClaudeSession = (
       // `PermissionService`. The renderer's toast eventually fulfills the
       // promise this awaits.
       canUseTool: async (toolName, toolInput) => {
-        const policy = policyFor(toolName, toolInput);
+        const policy = policyFor(toolName, toolInput, getRuntimeMode());
         if (policy.kind === "auto-allow") {
           // Read / LS / Glob / Grep / NotebookRead / BashOutput / TodoWrite
           // skip the prompt entirely. We deliberately don't surface a

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -118,6 +118,14 @@ const SessionResume = ForkzeroRpcs.toLayerHandler(
     Effect.flatMap(MessageStore, (svc) => svc.resumeSession(sessionId)),
 );
 
+const SessionSetRuntimeMode = ForkzeroRpcs.toLayerHandler(
+  "session.setRuntimeMode",
+  ({ sessionId, runtimeMode }) =>
+    Effect.flatMap(MessageStore, (svc) =>
+      svc.setRuntimeMode(sessionId, runtimeMode),
+    ),
+);
+
 const MessagesList = ForkzeroRpcs.toLayerHandler(
   "messages.list",
   ({ sessionId }) =>
@@ -199,6 +207,7 @@ export const ProviderHandlersLayer = Layer.mergeAll(
   SessionUnarchive,
   SessionDelete,
   SessionResume,
+  SessionSetRuntimeMode,
   MessagesList,
   MessagesStream,
   MessagesSend,

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -9,6 +9,7 @@ import {
 } from "effect";
 
 import {
+  DEFAULT_RUNTIME_MODE,
   Message,
   MessageId,
   type AgentEvent,
@@ -16,6 +17,7 @@ import {
   type MessageContent,
   type MessageRole,
   type ProviderId,
+  type RuntimeMode,
   Session,
   SessionId,
   SessionNotFoundError,
@@ -28,7 +30,10 @@ import {
   type CreateSessionInput,
   type MessageStoreShape,
 } from "../services/message-store.ts";
-import { ProviderService } from "../services/provider-service.ts";
+import {
+  ProviderService,
+  type GetRuntimeMode,
+} from "../services/provider-service.ts";
 
 interface SessionRow {
   readonly id: string;
@@ -40,9 +45,21 @@ interface SessionRow {
   readonly archived_at: string | null;
   readonly cursor: string | null;
   readonly resume_strategy: string;
+  readonly runtime_mode: string;
   readonly created_at: string;
   readonly updated_at: string;
 }
+
+const RUNTIME_MODES: ReadonlySet<RuntimeMode> = new Set([
+  "approval-required",
+  "auto-accept-edits",
+  "full-access",
+]);
+
+const runtimeModeFromRow = (raw: string): RuntimeMode =>
+  RUNTIME_MODES.has(raw as RuntimeMode)
+    ? (raw as RuntimeMode)
+    : DEFAULT_RUNTIME_MODE;
 
 interface MessageRow {
   readonly id: string;
@@ -65,6 +82,7 @@ const sessionFromRow = (row: SessionRow): Session =>
     cursor: row.cursor,
     resumeStrategy:
       row.resume_strategy === "claude-session-id" ? "claude-session-id" : "none",
+    runtimeMode: runtimeModeFromRow(row.runtime_mode),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   });
@@ -147,6 +165,16 @@ export const MessageStoreLive = Layer.scoped(
     // Project-id cache so the per-message NDJSON append doesn't hit the DB
     // for every event. Populated lazily on first append per session.
     const projectIdBySession = new Map<SessionId, FolderId>();
+
+    /**
+     * Live runtime-mode cache. The driver reads this through the getter we
+     * hand to `provider.start`, so a renderer-driven `setRuntimeMode` takes
+     * effect on the next tool call without restarting the SDK. Populated on
+     * every `provider.start` and on `setRuntimeMode`.
+     */
+    const runtimeModeBySession = new Map<SessionId, RuntimeMode>();
+    const getRuntimeModeFor = (sessionId: SessionId): RuntimeMode =>
+      runtimeModeBySession.get(sessionId) ?? DEFAULT_RUNTIME_MODE;
     const ndjsonAppend = (
       sessionId: SessionId,
       message: Message,
@@ -198,7 +226,8 @@ export const MessageStoreLive = Layer.scoped(
       Effect.gen(function* () {
         const rows = yield* sql<SessionRow>`
           SELECT id, project_id, title, provider_id, model, status,
-                 archived_at, cursor, resume_strategy, created_at, updated_at
+                 archived_at, cursor, resume_strategy, runtime_mode,
+                 created_at, updated_at
           FROM sessions WHERE id = ${sessionId} LIMIT 1
         `.pipe(Effect.orDie);
         if (rows.length === 0) {
@@ -353,13 +382,15 @@ export const MessageStoreLive = Layer.scoped(
         const rows = includeArchived
           ? yield* sql<SessionRow>`
               SELECT id, project_id, title, provider_id, model, status,
-                     archived_at, cursor, resume_strategy, created_at, updated_at
+                     archived_at, cursor, resume_strategy, runtime_mode,
+                     created_at, updated_at
               FROM sessions WHERE project_id = ${projectId}
               ORDER BY updated_at DESC
             `.pipe(Effect.orDie)
           : yield* sql<SessionRow>`
               SELECT id, project_id, title, provider_id, model, status,
-                     archived_at, cursor, resume_strategy, created_at, updated_at
+                     archived_at, cursor, resume_strategy, runtime_mode,
+                     created_at, updated_at
               FROM sessions
               WHERE project_id = ${projectId} AND archived_at IS NULL
               ORDER BY updated_at DESC
@@ -372,15 +403,27 @@ export const MessageStoreLive = Layer.scoped(
     ) =>
       Effect.gen(function* () {
         // Provider mints the canonical session id; we mirror it into the row
-        // so the in-memory map and the persisted row stay in lockstep.
+        // so the in-memory map and the persisted row stay in lockstep. New
+        // sessions always start at the default runtime mode — `canUseTool`
+        // can't fire until provider.start returns, so resolving sessionId
+        // through a closure is safe.
+        let mintedSessionId: SessionId | null = null;
+        const newSessionRuntimeMode: GetRuntimeMode = () =>
+          mintedSessionId === null
+            ? DEFAULT_RUNTIME_MODE
+            : getRuntimeModeFor(mintedSessionId);
         const started = yield* provider
-          .start({
-            folderId: input.projectId,
-            providerId: input.providerId,
-            mode: "sdk",
-            initialPrompt: input.initialPrompt,
-            model: input.model,
-          })
+          .start(
+            {
+              folderId: input.projectId,
+              providerId: input.providerId,
+              mode: "sdk",
+              initialPrompt: input.initialPrompt,
+              model: input.model,
+            },
+            null,
+            newSessionRuntimeMode,
+          )
           .pipe(
             Effect.mapError((err) =>
               err._tag === "ProviderNotAvailableError"
@@ -395,6 +438,8 @@ export const MessageStoreLive = Layer.scoped(
             ),
           );
         const sessionId = started.sessionId;
+        mintedSessionId = sessionId;
+        runtimeModeBySession.set(sessionId, DEFAULT_RUNTIME_MODE);
         const now = new Date();
         const nowIso = now.toISOString();
         const title = input.title?.trim() || titleFromInitial(input.initialPrompt);
@@ -425,6 +470,7 @@ export const MessageStoreLive = Layer.scoped(
           archivedAt: null,
           cursor: null,
           resumeStrategy: "none",
+          runtimeMode: DEFAULT_RUNTIME_MODE,
           createdAt: now,
           updatedAt: now,
         });
@@ -440,6 +486,27 @@ export const MessageStoreLive = Layer.scoped(
           UPDATE sessions SET title = ${title}, updated_at = ${new Date().toISOString()}
           WHERE id = ${sessionId}
         `.pipe(Effect.orDie);
+      });
+
+    /**
+     * Update the per-session runtime mode. Persists immediately. The driver's
+     * `canUseTool` callback observes the new value via `provider.start`'s
+     * runtime-mode getter on the next tool call — no need to restart the SDK.
+     */
+    const setRuntimeMode: MessageStoreShape["setRuntimeMode"] = (
+      sessionId,
+      runtimeMode,
+    ) =>
+      Effect.gen(function* () {
+        yield* lookupSession(sessionId);
+        const nowIso = new Date().toISOString();
+        yield* sql`
+          UPDATE sessions SET runtime_mode = ${runtimeMode}, updated_at = ${nowIso}
+          WHERE id = ${sessionId}
+        `.pipe(Effect.orDie);
+        // Poke the in-memory cache so the next `canUseTool` invocation picks
+        // up the new mode without restarting the SDK.
+        runtimeModeBySession.set(sessionId, runtimeMode);
       });
 
     /**
@@ -541,8 +608,9 @@ export const MessageStoreLive = Layer.scoped(
     const restartProviderSession = (
       session: Session,
       initialPrompt: string,
-    ): Effect.Effect<void, SessionNotFoundError> =>
-      provider
+    ): Effect.Effect<void, SessionNotFoundError> => {
+      runtimeModeBySession.set(session.id, session.runtimeMode);
+      return provider
         .start(
           {
             folderId: session.projectId,
@@ -556,11 +624,13 @@ export const MessageStoreLive = Layer.scoped(
           // The driver passes it as `options.resume`; SDK reloads history
           // and continues from there.
           session.cursor,
+          () => getRuntimeModeFor(session.id),
         )
         .pipe(
           Effect.flatMap(() => startSubscription(session.id)),
           Effect.mapError(() => new SessionNotFoundError({ sessionId: session.id })),
         );
+    };
 
     const resumeSession: MessageStoreShape["resumeSession"] = (sessionId) =>
       Effect.gen(function* () {
@@ -577,6 +647,7 @@ export const MessageStoreLive = Layer.scoped(
         // a fresh handle attached to the same DB row.
         yield* provider.close(sessionId).pipe(Effect.catchAll(() => Effect.void));
         yield* teardownSubscription(sessionId);
+        runtimeModeBySession.set(session.id, session.runtimeMode);
         yield* provider
           .start(
             {
@@ -587,6 +658,7 @@ export const MessageStoreLive = Layer.scoped(
               model: session.model,
             },
             session.cursor,
+            () => getRuntimeModeFor(session.id),
           )
           .pipe(
             Effect.mapError((err) =>
@@ -660,6 +732,7 @@ export const MessageStoreLive = Layer.scoped(
       createSession,
       renameSession,
       setModel,
+      setRuntimeMode,
       archiveSession,
       unarchiveSession,
       deleteSession,

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -5,6 +5,7 @@ import {
   AgentSessionId,
   AgentSessionNotFoundError,
   AgentSessionStartError,
+  DEFAULT_RUNTIME_MODE,
   type AgentAvailability,
   type AgentEvent,
   type FolderId,
@@ -112,8 +113,10 @@ export const ProviderServiceLive = Layer.effect(
 
     return {
       availability,
-      start: (input, resumeCursor = null) =>
+      start: (input, resumeCursor = null, getRuntimeMode) =>
         Effect.gen(function* () {
+          const runtimeModeGetter =
+            getRuntimeMode ?? (() => DEFAULT_RUNTIME_MODE);
           const folder = yield* workspace.findById(input.folderId);
           if (folder === null) {
             return yield* Effect.fail(
@@ -142,6 +145,7 @@ export const ProviderServiceLive = Layer.effect(
               claudePath,
               sessionId,
               buildRequestPermission(input.folderId),
+              runtimeModeGetter,
               resumeCursor,
             );
           } else {

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -4,6 +4,7 @@ import type {
   FolderId,
   Message,
   ProviderId,
+  RuntimeMode,
   Session,
   SessionId,
   SessionNotFoundError,
@@ -54,6 +55,16 @@ export interface MessageStoreShape {
   readonly setModel: (
     sessionId: SessionId,
     model: string,
+  ) => Effect.Effect<void, SessionNotFoundError>;
+
+  /**
+   * Update the per-session permission posture. The change applies to the
+   * next tool call — running `canUseTool` callbacks observe the new value
+   * via the runtime-mode getter `ProviderService` hands the driver.
+   */
+  readonly setRuntimeMode: (
+    sessionId: SessionId,
+    runtimeMode: RuntimeMode,
   ) => Effect.Effect<void, SessionNotFoundError>;
 
   readonly archiveSession: (

--- a/apps/server/src/provider/services/provider-service.ts
+++ b/apps/server/src/provider/services/provider-service.ts
@@ -9,10 +9,18 @@ import type {
   AgentTurnId,
   ProviderId,
   ProviderNotAvailableError,
+  RuntimeMode,
   StartSessionInput,
 } from "@forkzero/wire";
 
 import type { CredentialsError } from "../errors.ts";
+
+/**
+ * Live-read of the per-session runtime mode. Bound at start time and read by
+ * the driver each time the SDK invokes `canUseTool`, so a renderer toggle
+ * mid-session takes effect on the next tool call.
+ */
+export type GetRuntimeMode = () => RuntimeMode;
 
 /**
  * Public-facing service that the RPC handlers bind to. Every wire RPC
@@ -26,6 +34,7 @@ export interface ProviderServiceShape {
   readonly start: (
     input: StartSessionInput,
     resumeCursor?: string | null,
+    getRuntimeMode?: GetRuntimeMode,
   ) => Effect.Effect<
     { readonly sessionId: AgentSessionId },
     ProviderNotAvailableError | AgentSessionStartError

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -44,6 +44,7 @@ import {
   SessionRenameRpc,
   SessionResumeRpc,
   SessionSetModelRpc,
+  SessionSetRuntimeModeRpc,
   SessionUnarchiveRpc,
 } from "./session.ts";
 import {
@@ -95,6 +96,7 @@ export const ForkzeroRpcs = RpcGroup.make(
   SessionUnarchiveRpc,
   SessionDeleteRpc,
   SessionResumeRpc,
+  SessionSetRuntimeModeRpc,
   MessagesListRpc,
   MessagesStreamRpc,
   MessagesSendRpc,

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -45,6 +45,26 @@ export type SessionStatus = typeof SessionStatus.Type;
 export const ResumeStrategy = Schema.Literal("claude-session-id", "none");
 export type ResumeStrategy = typeof ResumeStrategy.Type;
 
+/**
+ * How permission prompts behave for this session.
+ *
+ *   - `approval-required` — prompt every write/Bash/Network/Task/MCP call.
+ *     Read-only tools auto-allow. Sensitive paths force a prompt regardless
+ *     of any other allow rule. **Default for new sessions** — safe by default.
+ *   - `auto-accept-edits` — also auto-allow `Edit` / `Write` / `MultiEdit` /
+ *     `NotebookEdit`. Bash / Network / Task / MCP still prompt. Sensitive
+ *     paths still force a prompt.
+ *   - `full-access` — auto-allow everything except sensitive paths (which
+ *     still prompt — the safety net the user opted into is preserved).
+ */
+export const RuntimeMode = Schema.Literal(
+  "approval-required",
+  "auto-accept-edits",
+  "full-access",
+);
+export type RuntimeMode = typeof RuntimeMode.Type;
+export const DEFAULT_RUNTIME_MODE: RuntimeMode = "approval-required";
+
 export class Session extends Schema.Class<Session>("Session")({
   id: SessionId,
   projectId: FolderId,
@@ -55,6 +75,7 @@ export class Session extends Schema.Class<Session>("Session")({
   archivedAt: Schema.NullOr(Schema.DateFromString),
   cursor: Schema.NullOr(Schema.String),
   resumeStrategy: ResumeStrategy,
+  runtimeMode: RuntimeMode,
   createdAt: Schema.DateFromString,
   updatedAt: Schema.DateFromString,
 }) {}
@@ -234,4 +255,18 @@ export const SessionResumeRpc = Rpc.make("session.resume", {
   payload: Schema.Struct({ sessionId: SessionId }),
   success: Session,
   error: Schema.Union(SessionNotFoundError, SessionStartError),
+});
+
+/**
+ * Set the per-session permission posture. Takes effect on the next tool call —
+ * if a turn is in flight when the toggle changes, the running canUseTool
+ * callbacks observe the new mode without restarting the SDK.
+ */
+export const SessionSetRuntimeModeRpc = Rpc.make("session.setRuntimeMode", {
+  payload: Schema.Struct({
+    sessionId: SessionId,
+    runtimeMode: RuntimeMode,
+  }),
+  success: Schema.Void,
+  error: SessionNotFoundError,
 });


### PR DESCRIPTION
## Summary

Adds a three-state permission posture per session — surfaced as a segmented control in the chat composer footer next to the model picker. Toggling the mode takes effect on the next tool call (no SDK restart) because the driver reads the value through a getter `MessageStore` keeps in sync with the DB row.

## The three modes

| Mode | Reads | File edits | Bash / Network / Task / MCP | Sensitive paths |
|---|---|---|---|---|
| `approval-required` (default) | auto-allow | **prompt** | **prompt** | force prompt |
| `auto-accept-edits` | auto-allow | auto-allow | **prompt** | force prompt |
| `full-access` (\"YOLO\") | auto-allow | auto-allow | auto-allow | force prompt |

Sensitive paths (`.env`, `.ssh/*`, `*.pem`, etc.) always force a prompt — the safety net the user opted into in Phase 4.5 is preserved in every mode.

## Architecture

- **Wire** (\`packages/wire/src/session.ts\`): \`RuntimeMode = \"approval-required\" | \"auto-accept-edits\" | \"full-access\"\`. Added to \`Session\` schema. New \`SessionSetRuntimeModeRpc\`.
- **Migration 0005**: \`sessions.runtime_mode TEXT NOT NULL DEFAULT 'approval-required'\`. Existing rows get the safe default automatically.
- **Driver** (\`claude.ts\`): \`policyFor\` takes \`runtimeMode\` and applies the layered rules (sensitive paths first, then read-only short-circuit, then mode-based bypasses). \`canUseTool\` reads the mode via a \`getRuntimeMode: () => RuntimeMode\` getter, so renderer-driven changes apply mid-session.
- **\`MessageStore\`** holds an in-memory \`runtimeModeBySession\` map. \`setRuntimeMode\` updates SQL + the map. The map is rehydrated on \`createSession\` / \`restartProviderSession\` / \`resumeSession\`.
- **Renderer**: \`useSessionsStore.setRuntimeMode\` (optimistic) + a 3-button segmented control in \`chat-composer.tsx\`.

## Test plan

- [ ] Open a session — segmented control reads \"Approve\" highlighted.
- [ ] Send a Bash command — prompt appears as before.
- [ ] Click \"Edits\" — re-send a turn that hits \`Edit\` / \`Write\`. No prompt.
- [ ] Same session, ask agent to run \`npm install\` — prompts (Bash still gated).
- [ ] Click \"YOLO\" — \`npm install\` no longer prompts.
- [ ] Ask agent to read \`.env\` — prompts even in YOLO mode (sensitive-path safety net).
- [ ] Switch back to \"Approve\" mid-turn — next tool call prompts again, no restart.
- [ ] \`sqlite3 ~/Library/Application\\ Support/forkzero/forkzero.sqlite \"SELECT id, runtime_mode FROM sessions\"\` shows the persisted column.
- [ ] \`bun run check-types\` and \`bun run build\` clean.

## Out of scope

- Per-tool overrides (e.g. \"always prompt for Bash even in YOLO\") — defer.
- Codex parity — Codex SDK still has no programmatic approval callback; the toggle reads/writes the column but has no effect on Codex sessions.
- Persisting per-project default mode — every new session starts at \`approval-required\`.