### PR TITLE
ui: compact sidebar counts, iconified tool rows, thinking text

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -1,11 +1,11 @@
 import { MessageSquare } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
-import type { Message, SessionId } from "@forkzero/wire";
+import type { AgentItemId, Message, SessionId } from "@forkzero/wire";
 
 import { useMessagesStore } from "../store/messages.ts";
 import { useSessionsStore } from "../store/sessions.ts";
-import { MessageRow } from "./message-row.tsx";
+import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
 
 const NEAR_BOTTOM_PX = 80;
 
@@ -59,6 +59,31 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     el.scrollTop = el.scrollHeight;
   }, [messages.length]);
 
+  // Pair tool_result rows back to their originating tool_use by AgentItemId.
+  // The driver assigns the SDK's tool_use id to both events, so each
+  // ToolRow can render its own result inline. We only record results that
+  // have a preceding tool_use in this transcript so true orphans (e.g. a
+  // dropped tool_use event) still fall through to a standalone error row
+  // in MessageRow rather than disappearing silently.
+  const resultsByItemId = useMemo(() => {
+    const seenUseIds = new Set<AgentItemId>();
+    const map = new Map<AgentItemId, ToolResultRecord>();
+    for (const m of messages) {
+      if (m.content._tag === "tool_use") {
+        seenUseIds.add(m.content.itemId);
+      } else if (
+        m.content._tag === "tool_result" &&
+        seenUseIds.has(m.content.itemId)
+      ) {
+        map.set(m.content.itemId, {
+          output: m.content.output,
+          isError: m.content.isError,
+        });
+      }
+    }
+    return map;
+  }, [messages]);
+
   return (
     <div
       ref={scrollRef}
@@ -80,7 +105,11 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       ) : (
         <div className="flex flex-col py-2">
           {messages.map((message) => (
-            <MessageRow key={message.id} message={message} />
+            <MessageRow
+              key={message.id}
+              message={message}
+              resultsByItemId={resultsByItemId}
+            />
           ))}
         </div>
       )}

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -1,10 +1,7 @@
 import { structuredPatch } from "diff";
-import { ChevronDown, ChevronRight, FileEdit } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
-const COLLAPSE_THRESHOLD_LINES = 30;
-
-interface FileEdit {
+export interface FileEdit {
   readonly path: string;
   readonly oldText: string;
   readonly newText: string;
@@ -16,7 +13,10 @@ interface FileEdit {
  * `Edit` / `Write` / `MultiEdit` tool input. Tools we can't parse fall back
  * to the JSON view at the call site — never throws.
  */
-const extractEdits = (tool: string, input: unknown): ReadonlyArray<FileEdit> => {
+export const extractEdits = (
+  tool: string,
+  input: unknown,
+): ReadonlyArray<FileEdit> => {
   if (input === null || typeof input !== "object") return [];
   const obj = input as Record<string, unknown>;
   const path = typeof obj.file_path === "string" ? obj.file_path : null;
@@ -100,58 +100,7 @@ const buildDiff = (edit: FileEdit): ReadonlyArray<DiffLine> => {
   return lines;
 };
 
-export function InlineDiff({ tool, input }: { tool: string; input: unknown }) {
-  const edits = useMemo(() => extractEdits(tool, input), [tool, input]);
-  const totalChangedLines = useMemo(() => {
-    let n = 0;
-    for (const edit of edits) {
-      const oldLines = edit.oldText === "" ? 0 : edit.oldText.split("\n").length;
-      const newLines = edit.newText === "" ? 0 : edit.newText.split("\n").length;
-      n += Math.abs(newLines - oldLines) + Math.min(oldLines, newLines);
-    }
-    return n;
-  }, [edits]);
-  const [expanded, setExpanded] = useState(
-    totalChangedLines <= COLLAPSE_THRESHOLD_LINES,
-  );
-
-  if (edits.length === 0) return null;
-
-  const Chevron = expanded ? ChevronDown : ChevronRight;
-  const headPath = edits[0]!.path;
-  const summary =
-    edits.length === 1
-      ? edits[0]!.mode === "create"
-        ? "create"
-        : "edit"
-      : `${edits.length} edits`;
-
-  return (
-    <div className="px-4 py-1">
-      <div className="max-w-[88%] overflow-hidden rounded-md border border-border bg-muted/40 text-xs">
-        <button
-          type="button"
-          onClick={() => setExpanded((e) => !e)}
-          className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left hover:bg-muted/60"
-        >
-          <Chevron className="size-3 shrink-0 text-muted-foreground" />
-          <FileEdit className="size-3 shrink-0 text-sky-400" />
-          <span className="truncate font-mono text-sky-200">{headPath}</span>
-          <span className="ml-1 text-muted-foreground">{summary}</span>
-        </button>
-        {expanded && (
-          <div className="border-t border-border/60">
-            {edits.map((edit, idx) => (
-              <DiffBlock key={idx} edit={edit} showHeader={edits.length > 1} />
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function DiffBlock({
+export function DiffBody({
   edit,
   showHeader,
 }: {
@@ -212,7 +161,7 @@ function DiffRow({ line }: { line: DiffLine }) {
         {marker}
       </span>
       <span className="whitespace-pre-wrap break-words">
-        {line.text === "" ? " " : line.text}
+        {line.text === "" ? " " : line.text}
       </span>
     </div>
   );

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -5,11 +5,16 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { Message } from "@forkzero/wire";
+import type { AgentItemId, Message } from "@forkzero/wire";
 
 import { cn } from "~/lib/utils";
 
 import { ThinkingRow, ToolRow } from "./tool-row.tsx";
+
+export interface ToolResultRecord {
+  readonly output: unknown;
+  readonly isError: boolean;
+}
 
 const stringifyJson = (value: unknown): string => {
   try {
@@ -23,8 +28,18 @@ const stringifyJson = (value: unknown): string => {
  * Render a single chat row. Variants are dispatched on `content._tag` rather
  * than `role` because role collapses tool_use and assistant text into one
  * bucket, but their visual treatment differs.
+ *
+ * `resultsByItemId` lets `tool_use` rows render their paired `tool_result`
+ * inline. Standalone `tool_result` rows are suppressed when they pair with
+ * a tool_use; only orphan errors fall through to the standalone error row.
  */
-export function MessageRow({ message }: { message: Message }) {
+export function MessageRow({
+  message,
+  resultsByItemId,
+}: {
+  message: Message;
+  resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
+}) {
   switch (message.content._tag) {
     case "user":
       return <UserBubble text={message.content.text} />;
@@ -39,12 +54,22 @@ export function MessageRow({ message }: { message: Message }) {
       );
     case "tool_use":
       return (
-        <ToolRow tool={message.content.tool} input={message.content.input} />
+        <ToolRow
+          tool={message.content.tool}
+          input={message.content.input}
+          result={resultsByItemId.get(message.content.itemId)}
+        />
       );
-    case "tool_result":
+    case "tool_result": {
+      // Suppress paired results — the matching ToolRow renders them inline.
+      // Only orphan errors (no tool_use found, e.g. driver dropped the use
+      // event) surface as a standalone error row.
+      const paired = resultsByItemId.has(message.content.itemId);
+      if (paired) return null;
       return message.content.isError ? (
         <ToolErrorRow output={message.content.output} />
       ) : null;
+    }
     case "error":
       return <ErrorBubble text={message.content.message} />;
   }

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -1,13 +1,15 @@
-import { ChevronDown, ChevronRight, Wrench } from "lucide-react";
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import type { Message } from "@forkzero/wire";
 
-import { InlineDiff } from "./inline-diff.tsx";
+import { cn } from "~/lib/utils";
 
-const FILE_EDIT_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+import { ToolRow } from "./tool-row.tsx";
 
 const stringifyJson = (value: unknown): string => {
   try {
@@ -29,24 +31,13 @@ export function MessageRow({ message }: { message: Message }) {
     case "assistant":
       return <AssistantBubble text={message.content.text} />;
     case "tool_use":
-      return FILE_EDIT_TOOLS.has(message.content.tool) ? (
-        <InlineDiff
-          tool={message.content.tool}
-          input={message.content.input}
-        />
-      ) : (
-        <ToolUseBubble
-          tool={message.content.tool}
-          input={message.content.input}
-        />
+      return (
+        <ToolRow tool={message.content.tool} input={message.content.input} />
       );
     case "tool_result":
-      return (
-        <ToolResultBubble
-          output={message.content.output}
-          isError={message.content.isError}
-        />
-      );
+      return message.content.isError ? (
+        <ToolErrorRow output={message.content.output} />
+      ) : null;
     case "error":
       return <ErrorBubble text={message.content.message} />;
   }
@@ -74,74 +65,46 @@ function AssistantBubble({ text }: { text: string }) {
   );
 }
 
-function ToolUseBubble({ tool, input }: { tool: string; input: unknown }) {
+function ToolErrorRow({ output }: { output: unknown }) {
   const [expanded, setExpanded] = useState(false);
   const Chevron = expanded ? ChevronDown : ChevronRight;
+  const text = typeof output === "string" ? output : stringifyJson(output);
+  const firstLine = text.split("\n", 1)[0] ?? "";
   return (
-    <div className="px-4 py-1">
-      <div className="max-w-[88%] rounded-md border border-border bg-muted/40 text-xs">
-        <button
-          type="button"
-          onClick={() => setExpanded((e) => !e)}
-          className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left hover:bg-muted/60"
-        >
-          <Chevron className="size-3 shrink-0 text-muted-foreground" />
-          <Wrench className="size-3 shrink-0 text-amber-400" />
-          <span className="font-mono text-amber-200">{tool}</span>
-          <span className="ml-1 text-muted-foreground">tool call</span>
-        </button>
-        {expanded && (
-          <pre className="overflow-x-auto border-t border-border/60 px-2 py-2 font-mono text-[11px] text-muted-foreground">
-            {stringifyJson(input)}
-          </pre>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function ToolResultBubble({
-  output,
-  isError,
-}: {
-  output: unknown;
-  isError: boolean;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const Chevron = expanded ? ChevronDown : ChevronRight;
-  const text =
-    typeof output === "string" ? output : stringifyJson(output);
-  return (
-    <div className="px-4 py-1">
-      <div
-        className={`max-w-[88%] rounded-md border text-xs ${
-          isError
-            ? "border-red-500/40 bg-red-500/10"
-            : "border-border bg-muted/40"
-        }`}
+    <div className="px-4">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs hover:bg-red-500/10"
       >
-        <button
-          type="button"
-          onClick={() => setExpanded((e) => !e)}
-          className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left hover:bg-muted/60"
-        >
-          <Chevron className="size-3 shrink-0 text-muted-foreground" />
-          <span className={isError ? "text-red-300" : "text-emerald-300"}>
-            {isError ? "tool error" : "tool result"}
-          </span>
-        </button>
-        {expanded && (
-          <pre
-            className={`overflow-x-auto border-t px-2 py-2 font-mono text-[11px] ${
-              isError
-                ? "border-red-500/30 text-red-200"
-                : "border-border/60 text-muted-foreground"
-            }`}
-          >
+        <div className="relative grid size-4 shrink-0 place-items-center">
+          <HugeiconsIcon
+            icon={AlertCircleIcon}
+            strokeWidth={2}
+            aria-hidden="true"
+            className={cn(
+              "col-start-1 row-start-1 size-3.5 text-red-400 transition-opacity duration-150 ease-out",
+              "group-hover:opacity-0 motion-reduce:transition-none",
+            )}
+          />
+          <Chevron
+            aria-hidden="true"
+            className={cn(
+              "col-start-1 row-start-1 size-3.5 text-red-400 opacity-0 transition-opacity duration-150 ease-out",
+              "group-hover:opacity-100 motion-reduce:transition-none",
+            )}
+          />
+        </div>
+        <span className="font-medium text-red-300">Error</span>
+        <span className="truncate text-red-200/80">{firstLine}</span>
+      </button>
+      {expanded ? (
+        <div className="ml-7 mt-1 border-l border-red-500/30 pl-3">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] text-red-200">
             {text || "(empty)"}
           </pre>
-        )}
-      </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -9,7 +9,7 @@ import type { Message } from "@forkzero/wire";
 
 import { cn } from "~/lib/utils";
 
-import { ToolRow } from "./tool-row.tsx";
+import { ThinkingRow, ToolRow } from "./tool-row.tsx";
 
 const stringifyJson = (value: unknown): string => {
   try {
@@ -30,6 +30,13 @@ export function MessageRow({ message }: { message: Message }) {
       return <UserBubble text={message.content.text} />;
     case "assistant":
       return <AssistantBubble text={message.content.text} />;
+    case "thinking":
+      return (
+        <ThinkingRow
+          text={message.content.text}
+          redacted={message.content.redacted}
+        />
+      );
     case "tool_use":
       return (
         <ToolRow tool={message.content.tool} input={message.content.input} />

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -28,7 +28,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
-import { cn } from "~/lib/utils";
+import { cn, formatCompactNumber } from "~/lib/utils";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { usePrStateStore } from "../store/pr-state.ts";
 import { useProvidersStore } from "../store/providers.ts";
@@ -623,31 +623,31 @@ function SessionRow({ session }: { session: Session }) {
             timestamp (no PR). The three-dot menu fades over the same slot on
             hover so the row never reflows. tabular-nums keeps digit widths
             stable when the elapsed time ticks. */}
-        <div className="relative flex h-4 w-[64px] shrink-0 items-center justify-end">
-          <span
-            className={cn(
-              "tabular-nums text-[10px] transition-opacity duration-150 ease-out group-hover:opacity-0 motion-reduce:transition-none",
-              showDiff && prInfo !== null && prInfo.state === "open"
-                ? "text-emerald-400/90"
-                : showDiff
-                  ? "text-purple-300/80"
-                  : "text-muted-foreground",
+        <div className="relative flex h-4 w-16 shrink-0 items-center justify-end">
+          <span className="tabular-nums text-[10px] text-muted-foreground transition-opacity duration-150 ease-out motion-reduce:transition-none group-hover:hidden">
+            {showDiff && prInfo !== null ? (
+              <>
+                <span className="text-emerald-400">
+                  +{formatCompactNumber(prInfo.additions)}
+                </span>{" "}
+                <span className="text-red-400">
+                  −{formatCompactNumber(prInfo.deletions)}
+                </span>
+              </>
+            ) : (
+              formatRelative(session.updatedAt)
             )}
-          >
-            {showDiff && prInfo !== null
-              ? `+${prInfo.additions} −${prInfo.deletions}`
-              : formatRelative(session.updatedAt)}
           </span>
           <MenuTrigger
             onClick={(e) => e.stopPropagation()}
-            className="absolute inset-y-0 right-0 flex items-center rounded p-0.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out hover:text-sidebar-accent-foreground group-hover:opacity-100 data-[popup-open]:opacity-100 motion-reduce:transition-none"
+            className=" items-center rounded p-0.5 text-muted-foreground hidden transition-opacity duration-150 ease-out hover:text-sidebar-accent-foreground group-hover:flex data-popup-open:opacity-100 motion-reduce:transition-none"
             aria-label={`Actions for ${session.title}`}
           >
             <MoreHorizontal className="size-3.5" />
           </MenuTrigger>
         </div>
       </li>
-      <MenuPopup align="end" className="min-w-[160px]">
+      <MenuPopup align="end" className="min-w-40">
         <MenuItem
           onClick={onRename}
           className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -15,7 +15,7 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   defaultModelFor,
@@ -591,12 +591,33 @@ function SessionRow({ session }: { session: Session }) {
     void remove(session.id);
   };
 
+  // Right-click context menu uses a virtual anchor positioned at the cursor.
+  // The visible button on hover (Archive / Unarchive) is the primary action;
+  // the full action set (Rename / Archive / Delete) lives in the context menu.
+  const [menuOpen, setMenuOpen] = useState(false);
+  const anchorRef = useRef<{ getBoundingClientRect: () => DOMRect } | null>(
+    null,
+  );
+
+  const onContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const x = e.clientX;
+    const y = e.clientY;
+    const rect = new DOMRect(x, y, 0, 0);
+    anchorRef.current = { getBoundingClientRect: () => rect };
+    setMenuOpen(true);
+  };
+
+  const PrimaryActionIcon = isArchived ? ArchiveRestore : Archive;
+  const primaryActionLabel = isArchived ? "Unarchive" : "Archive";
+
   return (
-    <Menu>
+    <>
       <li
         role="button"
         tabIndex={0}
         onClick={() => select(session.id)}
+        onContextMenu={onContextMenu}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -620,9 +641,9 @@ function SessionRow({ session }: { session: Session }) {
         />
         <span className="min-w-0 flex-1 truncate">{session.title}</span>
         {/* Right-side slot: idle row shows diff stats (if PR open/closed) or
-            timestamp (no PR). The three-dot menu fades over the same slot on
-            hover so the row never reflows. tabular-nums keeps digit widths
-            stable when the elapsed time ticks. */}
+            timestamp (no PR). On hover the slot swaps to a single Archive
+            (or Unarchive) action — no menu glyph; the rest of the actions
+            live behind right-click. tabular-nums keeps digit widths stable. */}
         <div className="relative flex h-4 w-16 shrink-0 items-center justify-end">
           <span className="tabular-nums text-[10px] text-muted-foreground transition-opacity duration-150 ease-out motion-reduce:transition-none group-hover:hidden">
             {showDiff && prInfo !== null ? (
@@ -638,48 +659,60 @@ function SessionRow({ session }: { session: Session }) {
               formatRelative(session.updatedAt)
             )}
           </span>
-          <MenuTrigger
-            onClick={(e) => e.stopPropagation()}
-            className=" items-center rounded p-0.5 text-muted-foreground hidden transition-opacity duration-150 ease-out hover:text-sidebar-accent-foreground group-hover:flex data-popup-open:opacity-100 motion-reduce:transition-none"
-            aria-label={`Actions for ${session.title}`}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              void (isArchived ? unarchive(session.id) : archive(session.id));
+            }}
+            className="hidden items-center rounded p-0.5 text-muted-foreground transition-opacity duration-150 ease-out hover:text-sidebar-accent-foreground group-hover:flex motion-reduce:transition-none"
+            aria-label={`${primaryActionLabel} ${session.title}`}
+            title={primaryActionLabel}
           >
-            <MoreHorizontal className="size-3.5" />
-          </MenuTrigger>
+            <PrimaryActionIcon className="size-3.5" />
+          </button>
         </div>
       </li>
-      <MenuPopup align="end" className="min-w-40">
-        <MenuItem
-          onClick={onRename}
-          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+      <Menu open={menuOpen} onOpenChange={setMenuOpen}>
+        <MenuPopup
+          anchor={anchorRef.current ?? undefined}
+          align="start"
+          side="bottom"
+          className="min-w-40"
         >
-          <Pencil className="size-3.5" />
-          Rename
-        </MenuItem>
-        {isArchived ? (
           <MenuItem
-            onClick={() => void unarchive(session.id)}
+            onClick={onRename}
             className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
           >
-            <ArchiveRestore className="size-3.5" />
-            Unarchive
+            <Pencil className="size-3.5" />
+            Rename
           </MenuItem>
-        ) : (
+          {isArchived ? (
+            <MenuItem
+              onClick={() => void unarchive(session.id)}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+            >
+              <ArchiveRestore className="size-3.5" />
+              Unarchive
+            </MenuItem>
+          ) : (
+            <MenuItem
+              onClick={() => void archive(session.id)}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+            >
+              <Archive className="size-3.5" />
+              Archive
+            </MenuItem>
+          )}
           <MenuItem
-            onClick={() => void archive(session.id)}
-            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+            onClick={onDelete}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-red-300 hover:bg-red-500/20"
           >
-            <Archive className="size-3.5" />
-            Archive
+            <Trash2 className="size-3.5" />
+            Delete
           </MenuItem>
-        )}
-        <MenuItem
-          onClick={onDelete}
-          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-red-300 hover:bg-red-500/20"
-        >
-          <Trash2 className="size-3.5" />
-          Delete
-        </MenuItem>
-      </MenuPopup>
-    </Menu>
+        </MenuPopup>
+      </Menu>
+    </>
   );
 }

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -12,12 +12,19 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import { cn } from "~/lib/utils";
 
 import { DiffBody, extractEdits, type FileEdit } from "./inline-diff.tsx";
 
 type IconHandle = Parameters<typeof HugeiconsIcon>[0]["icon"];
+
+interface ToolResult {
+  readonly output: unknown;
+  readonly isError: boolean;
+}
 
 const stringifyJson = (value: unknown): string => {
   try {
@@ -35,44 +42,193 @@ const basename = (p: string): string => {
   return i === -1 ? p : p.slice(i + 1);
 };
 
+const dirname = (p: string): string => {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? "" : p.slice(0, i + 1);
+};
+
 const truncate = (s: string, max: number): string =>
   s.length > max ? s.slice(0, max - 1) + "…" : s;
 
-const JsonBody = ({ value }: { value: unknown }) => (
-  <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
-    {stringifyJson(value)}
-  </pre>
-);
-
-const editsBody = (edits: ReadonlyArray<FileEdit>): React.ReactNode => (
-  <div className="overflow-hidden rounded border border-border/60">
-    {edits.map((edit, i) => (
-      <DiffBody key={i} edit={edit} showHeader={edits.length > 1} />
-    ))}
-  </div>
-);
-
 /**
- * Single-line collapsible row used by tool calls and thinking blocks. The
- * leading slot is a fixed-size grid cell that holds the contextual icon
- * (idle) and a chevron (hover) in the same cell — same swap pattern the
- * project sidebar uses for avatar↔chevron and session row uses for
- * branch↔archive.
+ * Coerce a tool_result `output` into displayable text. The Anthropic SDK
+ * sometimes returns a string, sometimes an array of content blocks (each
+ * with its own `text`); fall back to JSON for anything stranger.
  */
+const toResultText = (output: unknown): string => {
+  if (typeof output === "string") return output;
+  if (output === null || output === undefined) return "";
+  if (Array.isArray(output)) {
+    const parts: string[] = [];
+    for (const block of output) {
+      if (block === null || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+      if (typeof b.text === "string") parts.push(b.text);
+    }
+    if (parts.length > 0) return parts.join("\n");
+  }
+  return stringifyJson(output);
+};
+
+// First-sentence (or first-line) teaser, with whitespace collapsed and
+// hard-capped so a single fat row doesn't blow up the timeline.
+const firstSentence = (text: string, hardCap = 160): string => {
+  const flat = text.replace(/\s+/g, " ").trim();
+  if (flat.length === 0) return "";
+  const periodIdx = flat.indexOf(". ");
+  const newlineIdx = flat.indexOf("\n");
+  const stops = [periodIdx, newlineIdx].filter((i) => i > 0);
+  const cut = stops.length > 0 ? Math.min(...stops) + 1 : flat.length;
+  return truncate(flat.slice(0, cut).trim(), hardCap);
+};
+
+// ---------------------------------------------------------------------------
+// Visual primitives
+// ---------------------------------------------------------------------------
+
+function InlineCodeChip({ value }: { value: string }) {
+  return (
+    <span className="ml-1 truncate rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+      {value}
+    </span>
+  );
+}
+
+function InlineTextHint({ value }: { value: string }) {
+  return (
+    <span className="ml-1 truncate text-muted-foreground italic">
+      {value}
+    </span>
+  );
+}
+
+function TerminalBlock({
+  command,
+  output,
+  isError,
+}: {
+  command?: string;
+  output?: string;
+  isError?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
+        isError ? "border border-red-500/30" : "",
+      )}
+    >
+      {command !== undefined ? (
+        <div className="whitespace-pre-wrap break-words text-foreground/90">
+          <span className="select-none text-muted-foreground">$ </span>
+          {command}
+        </div>
+      ) : null}
+      {output !== undefined && output.length > 0 ? (
+        <div
+          className={cn(
+            "whitespace-pre-wrap break-words",
+            command !== undefined ? "mt-2" : "",
+            isError ? "text-red-200" : "text-foreground/80",
+          )}
+        >
+          {output}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ErrorPill() {
+  return (
+    <span className="mr-2 rounded bg-red-500/20 px-1.5 py-0.5 font-medium text-[10px] text-red-300">
+      Error
+    </span>
+  );
+}
+
+function FileListBlock({ paths }: { paths: ReadonlyArray<string> }) {
+  if (paths.length === 0) {
+    return (
+      <p className="text-[11px] italic text-muted-foreground">No matches.</p>
+    );
+  }
+  return (
+    <ul className="space-y-0.5 font-mono text-[11px]">
+      {paths.map((p, i) => {
+        const dir = dirname(p);
+        const base = basename(p);
+        return (
+          <li key={i} className="truncate">
+            <span className="text-muted-foreground">{dir}</span>
+            <span className="text-foreground/90">{base}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function MarkdownBlock({ text }: { text: string }) {
+  return (
+    <div className="prose prose-invert prose-sm max-w-none break-words text-[12px] [&>:first-child]:mt-0 [&>:last-child]:mb-0 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_pre>code]:bg-transparent [&_pre>code]:p-0">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+    </div>
+  );
+}
+
+function PreBlock({
+  text,
+  isError,
+}: {
+  text: string;
+  isError?: boolean;
+}) {
+  return (
+    <pre
+      className={cn(
+        "overflow-x-auto whitespace-pre-wrap break-words rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px]",
+        isError ? "border border-red-500/30 text-red-200" : "text-foreground/80",
+      )}
+    >
+      {text || "(empty)"}
+    </pre>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result extractors (per tool)
+// ---------------------------------------------------------------------------
+
+const splitLines = (s: string): ReadonlyArray<string> => {
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return [];
+  return trimmed.split("\n").map((line) => line.trim()).filter((l) => l.length > 0);
+};
+
+// Grep / Glob results are usually one path per line, sometimes followed
+// by a header like "Found N files". Filter out obvious headers.
+const parseFileList = (output: string): ReadonlyArray<string> => {
+  const lines = splitLines(output);
+  return lines.filter((l) => !/^found\s+\d+\s+/i.test(l) && !/^no\s+/i.test(l));
+};
+
+// ---------------------------------------------------------------------------
+// Expandable row primitive (icon ↔ chevron hover swap, click to toggle)
+// ---------------------------------------------------------------------------
+
 function ExpandableIconRow({
   icon,
   label,
-  summary,
+  trailing,
   body,
-  labelClassName,
-  summaryClassName,
+  hasContent,
 }: {
   icon: IconHandle;
-  label: string;
-  summary: string | null;
+  label: React.ReactNode;
+  trailing?: React.ReactNode;
   body: React.ReactNode;
-  labelClassName?: string;
-  summaryClassName?: string;
+  hasContent: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const Chevron = expanded ? ChevronDown : ChevronRight;
@@ -80,8 +236,11 @@ function ExpandableIconRow({
     <div className="px-4">
       <button
         type="button"
-        onClick={() => setExpanded((e) => !e)}
-        className="group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs hover:bg-muted/40"
+        onClick={() => hasContent && setExpanded((e) => !e)}
+        className={cn(
+          "group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs",
+          hasContent ? "hover:bg-muted/40 cursor-pointer" : "cursor-default",
+        )}
       >
         <div className="relative grid size-4 shrink-0 place-items-center">
           <HugeiconsIcon
@@ -90,72 +249,141 @@ function ExpandableIconRow({
             aria-hidden="true"
             className={cn(
               "col-start-1 row-start-1 size-3.5 text-muted-foreground transition-opacity duration-150 ease-out",
-              "group-hover:opacity-0 motion-reduce:transition-none",
+              hasContent ? "group-hover:opacity-0" : "",
+              "motion-reduce:transition-none",
             )}
           />
-          <Chevron
-            aria-hidden="true"
-            className={cn(
-              "col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
-              "group-hover:opacity-100 motion-reduce:transition-none",
-            )}
-          />
+          {hasContent ? (
+            <Chevron
+              aria-hidden="true"
+              className={cn(
+                "col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
+                "group-hover:opacity-100 motion-reduce:transition-none",
+              )}
+            />
+          ) : null}
         </div>
-        <span className={cn("font-medium text-foreground/90", labelClassName)}>
-          {label}
-        </span>
-        {summary !== null ? (
-          <span className={cn("truncate text-muted-foreground", summaryClassName)}>
-            {summary}
+        <span className="font-medium text-foreground/90 shrink-0">{label}</span>
+        {trailing !== undefined ? (
+          <span className="min-w-0 flex-1 truncate flex items-center">
+            {trailing}
           </span>
         ) : null}
       </button>
-      {expanded ? (
-        <div className="ml-7 mt-1 border-l border-border/60 pl-3">{body}</div>
+      {expanded && hasContent ? (
+        <div className="ml-7 mt-1 space-y-2 border-l border-border/60 pl-3 pr-1">
+          {body}
+        </div>
       ) : null}
     </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Per-tool views
+// ---------------------------------------------------------------------------
+
 interface ToolView {
   readonly icon: IconHandle;
   readonly label: string;
-  readonly summary: string | null;
-  readonly body: React.ReactNode;
+  readonly trailing?: React.ReactNode;
+  readonly inputPanel?: React.ReactNode;
+  readonly resultPanel?: (result: ToolResult) => React.ReactNode;
+  readonly fallbackBody?: React.ReactNode;
 }
 
-const buildToolView = (tool: string, input: unknown): ToolView => {
+// Line-count derived from a tool result's textual output. Used by Read /
+// Grep / Glob to summarise "how much did this return?" in the collapsed row.
+const lineCountOf = (output: unknown): number => {
+  const text = toResultText(output);
+  if (text.length === 0) return 0;
+  return text.split("\n").length;
+};
+
+const buildToolView = (
+  tool: string,
+  input: unknown,
+  result: ToolResult | undefined,
+): ToolView => {
   const obj =
     input !== null && typeof input === "object"
       ? (input as Record<string, unknown>)
       : {};
 
   switch (tool) {
-    case "Read": {
-      const path = asString(obj.file_path);
-      return {
-        icon: File01Icon,
-        label: "Read",
-        summary: path !== null ? basename(path) : null,
-        body: <JsonBody value={input} />,
-      };
-    }
-
     case "Bash": {
       const cmd = asString(obj.command);
       const desc = asString(obj.description);
       return {
         icon: TerminalIcon,
-        label: "Bash",
-        summary: desc ?? (cmd !== null ? truncate(cmd, 80) : null),
-        body:
-          cmd !== null ? (
-            <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] text-foreground/80">
-              {cmd}
-            </pre>
-          ) : (
-            <JsonBody value={input} />
-          ),
+        label: desc ?? "Bash",
+        trailing:
+          cmd !== null ? <InlineCodeChip value={truncate(cmd, 120)} /> : undefined,
+        inputPanel:
+          cmd !== null ? <TerminalBlock command={cmd} /> : undefined,
+        resultPanel: (result) => (
+          <TerminalBlock
+            output={toResultText(result.output) || "(no output)"}
+            isError={result.isError}
+          />
+        ),
+        fallbackBody:
+          cmd === null ? (
+            <PreBlock text={stringifyJson(input)} />
+          ) : undefined,
+      };
+    }
+
+    case "Read": {
+      const path = asString(obj.file_path);
+      const offset = typeof obj.offset === "number" ? obj.offset : null;
+      const limit = typeof obj.limit === "number" ? obj.limit : null;
+      const range =
+        offset !== null || limit !== null
+          ? `lines ${offset ?? 1}–${(offset ?? 1) + (limit ?? 0) - 1}`
+          : null;
+      // Once the result is in we can show "N lines" — until then, a "…"
+      // placeholder so the row's geometry doesn't shift when the result
+      // arrives a frame later.
+      const lines = result !== undefined ? lineCountOf(result.output) : null;
+      const linesHint =
+        lines !== null
+          ? lines === 0
+            ? "(empty)"
+            : `${lines} line${lines === 1 ? "" : "s"}`
+          : "…";
+      return {
+        icon: File01Icon,
+        label: "Read",
+        trailing:
+          path !== null ? (
+            <>
+              <InlineTextHint value={linesHint} />
+              <InlineCodeChip value={basename(path)} />
+            </>
+          ) : undefined,
+        inputPanel:
+          path !== null ? (
+            <p className="font-mono text-[11px] text-muted-foreground break-all">
+              {path}
+              {range !== null ? ` · ${range}` : null}
+            </p>
+          ) : undefined,
+        resultPanel: (result) => {
+          const text = toResultText(result.output);
+          const lineCount = text.length === 0 ? 0 : text.split("\n").length;
+          return (
+            <div className="space-y-1">
+              <p className="text-[11px] text-muted-foreground">
+                {lineCount} line{lineCount === 1 ? "" : "s"}
+              </p>
+              <PreBlock
+                text={truncate(text, 4000)}
+                isError={result.isError}
+              />
+            </div>
+          );
+        },
       };
     }
 
@@ -173,9 +401,28 @@ const buildToolView = (tool: string, input: unknown): ToolView => {
       return {
         icon: PencilEdit01Icon,
         label,
-        summary: path !== null ? basename(path) : null,
-        body:
-          edits.length > 0 ? editsBody(edits) : <JsonBody value={input} />,
+        trailing:
+          path !== null ? (
+            <InlineCodeChip value={basename(path)} />
+          ) : undefined,
+        fallbackBody:
+          edits.length > 0 ? (
+            <div className="overflow-hidden rounded border border-border/60">
+              {edits.map((edit, i) => (
+                <DiffBody
+                  key={i}
+                  edit={edit as FileEdit}
+                  showHeader={edits.length > 1}
+                />
+              ))}
+            </div>
+          ) : (
+            <PreBlock text={stringifyJson(input)} />
+          ),
+        resultPanel: (result) =>
+          result.isError ? (
+            <PreBlock text={toResultText(result.output)} isError />
+          ) : null,
       };
     }
 
@@ -183,38 +430,123 @@ const buildToolView = (tool: string, input: unknown): ToolView => {
       const pattern = asString(obj.pattern);
       const path = asString(obj.path);
       const glob = asString(obj.glob);
-      const where = path ?? glob;
+      const type = asString(obj.type);
+      const where = path ?? glob ?? type;
+      const matches =
+        result !== undefined && !result.isError
+          ? parseFileList(toResultText(result.output)).length
+          : null;
+      const matchesHint =
+        matches !== null
+          ? matches === 0
+            ? "no matches"
+            : `${matches} match${matches === 1 ? "" : "es"}`
+          : null;
       return {
         icon: SearchIcon,
         label: "Grep",
-        summary:
-          pattern !== null
-            ? where !== null
-              ? `${pattern} in ${where}`
-              : pattern
-            : null,
-        body: <JsonBody value={input} />,
+        trailing:
+          pattern !== null ? (
+            <>
+              <InlineCodeChip value={pattern} />
+              {where !== null ? <InlineTextHint value={`in ${where}`} /> : null}
+              {matchesHint !== null ? (
+                <InlineTextHint value={`· ${matchesHint}`} />
+              ) : null}
+            </>
+          ) : undefined,
+        inputPanel:
+          pattern !== null ? (
+            <div className="text-[11px] text-muted-foreground space-y-0.5">
+              <div>
+                pattern <span className="font-mono text-foreground/90">{pattern}</span>
+              </div>
+              {where !== null ? (
+                <div>
+                  scope <span className="font-mono text-foreground/90">{where}</span>
+                </div>
+              ) : null}
+            </div>
+          ) : undefined,
+        resultPanel: (result) => {
+          const text = toResultText(result.output);
+          if (result.isError) return <PreBlock text={text} isError />;
+          const paths = parseFileList(text);
+          return paths.length > 0 ? (
+            <FileListBlock paths={paths} />
+          ) : (
+            <PreBlock text={text || "No matches."} />
+          );
+        },
       };
     }
 
     case "Glob": {
       const pattern = asString(obj.pattern);
+      const matches =
+        result !== undefined && !result.isError
+          ? parseFileList(toResultText(result.output)).length
+          : null;
+      const matchesHint =
+        matches !== null
+          ? matches === 0
+            ? "no matches"
+            : `${matches} file${matches === 1 ? "" : "s"}`
+          : null;
       return {
         icon: SearchIcon,
         label: "Glob",
-        summary: pattern,
-        body: <JsonBody value={input} />,
+        trailing:
+          pattern !== null ? (
+            <>
+              <InlineCodeChip value={pattern} />
+              {matchesHint !== null ? (
+                <InlineTextHint value={`· ${matchesHint}`} />
+              ) : null}
+            </>
+          ) : undefined,
+        resultPanel: (result) => {
+          const text = toResultText(result.output);
+          if (result.isError) return <PreBlock text={text} isError />;
+          const paths = parseFileList(text);
+          return paths.length > 0 ? (
+            <FileListBlock paths={paths} />
+          ) : (
+            <PreBlock text={text || "No matches."} />
+          );
+        },
       };
     }
 
     case "Task":
     case "Agent": {
       const desc = asString(obj.description) ?? asString(obj.subagent_type);
+      const prompt = asString(obj.prompt);
       return {
         icon: Robot01Icon,
         label: "Agent",
-        summary: desc,
-        body: <JsonBody value={input} />,
+        trailing: desc !== null ? <InlineTextHint value={desc} /> : undefined,
+        inputPanel:
+          prompt !== null ? (
+            <div className="space-y-1">
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Prompt
+              </p>
+              <PreBlock text={prompt} />
+            </div>
+          ) : undefined,
+        resultPanel: (result) => {
+          const text = toResultText(result.output);
+          if (result.isError) return <PreBlock text={text} isError />;
+          return (
+            <div className="space-y-1">
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Reply
+              </p>
+              <MarkdownBlock text={text || "(empty)"} />
+            </div>
+          );
+        },
       };
     }
 
@@ -223,8 +555,13 @@ const buildToolView = (tool: string, input: unknown): ToolView => {
       return {
         icon: GlobeIcon,
         label: "WebFetch",
-        summary: url,
-        body: <JsonBody value={input} />,
+        trailing: url !== null ? <InlineCodeChip value={url} /> : undefined,
+        resultPanel: (result) => (
+          <PreBlock
+            text={truncate(toResultText(result.output), 4000)}
+            isError={result.isError}
+          />
+        ),
       };
     }
 
@@ -233,18 +570,45 @@ const buildToolView = (tool: string, input: unknown): ToolView => {
       return {
         icon: GlobeIcon,
         label: "WebSearch",
-        summary: q,
-        body: <JsonBody value={input} />,
+        trailing: q !== null ? <InlineCodeChip value={q} /> : undefined,
+        resultPanel: (result) => (
+          <PreBlock
+            text={truncate(toResultText(result.output), 4000)}
+            isError={result.isError}
+          />
+        ),
       };
     }
 
     case "TodoWrite": {
-      const todos = Array.isArray(obj.todos) ? obj.todos.length : null;
+      const todos = Array.isArray(obj.todos) ? obj.todos : null;
       return {
         icon: CheckListIcon,
         label: "TodoWrite",
-        summary: todos !== null ? `${todos} todos` : null,
-        body: <JsonBody value={input} />,
+        trailing:
+          todos !== null ? (
+            <InlineTextHint value={`${todos.length} todos`} />
+          ) : undefined,
+        fallbackBody:
+          todos !== null ? (
+            <ul className="space-y-0.5 text-[11px]">
+              {todos.map((t, i) => {
+                if (t === null || typeof t !== "object")
+                  return <li key={i}>{stringifyJson(t)}</li>;
+                const r = t as Record<string, unknown>;
+                const content = asString(r.content) ?? asString(r.activeForm) ?? "";
+                const status = asString(r.status) ?? "";
+                return (
+                  <li key={i} className="font-mono">
+                    <span className="text-muted-foreground">[{status}]</span>{" "}
+                    {content}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <PreBlock text={stringifyJson(input)} />
+          ),
       };
     }
 
@@ -252,21 +616,62 @@ const buildToolView = (tool: string, input: unknown): ToolView => {
       return {
         icon: Wrench01Icon,
         label: tool,
-        summary: null,
-        body: <JsonBody value={input} />,
+        fallbackBody: <PreBlock text={stringifyJson(input)} />,
+        resultPanel: (result) => (
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
+        ),
       };
     }
   }
 };
 
-export function ToolRow({ tool, input }: { tool: string; input: unknown }) {
-  const view = buildToolView(tool, input);
+export function ToolRow({
+  tool,
+  input,
+  result,
+}: {
+  tool: string;
+  input: unknown;
+  result?: ToolResult;
+}) {
+  const view = buildToolView(tool, input, result);
+
+  const sections: React.ReactNode[] = [];
+  if (view.inputPanel !== undefined) sections.push(view.inputPanel);
+  if (view.fallbackBody !== undefined) sections.push(view.fallbackBody);
+  if (result !== undefined && view.resultPanel !== undefined) {
+    const rendered = view.resultPanel(result);
+    if (rendered !== null) {
+      sections.push(
+        <div key="result">
+          {result.isError ? (
+            <div className="mb-1 flex items-center">
+              <ErrorPill />
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Result
+              </span>
+            </div>
+          ) : (
+            <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+              Result
+            </p>
+          )}
+          {rendered}
+        </div>,
+      );
+    }
+  }
+
   return (
     <ExpandableIconRow
       icon={view.icon}
       label={view.label}
-      summary={view.summary}
-      body={view.body}
+      trailing={view.trailing}
+      hasContent={sections.length > 0}
+      body={sections.length > 0 ? sections : null}
     />
   );
 }
@@ -278,27 +683,35 @@ export function ThinkingRow({
   text: string;
   redacted: boolean;
 }) {
-  const summary = redacted
+  // Three states:
+  // 1. redacted — model thought but content is policy-hidden
+  // 2. empty text — provider stripped or didn't deliver thinking content
+  // 3. plain text — render as markdown
+  const isEmpty = !redacted && text.length === 0;
+  const teaser = redacted
     ? "(redacted)"
-    : text.length > 0
-      ? truncate(text.replace(/\s+/g, " ").trim(), 100)
-      : null;
+    : isEmpty
+      ? "(no content provided)"
+      : firstSentence(text);
   const body = redacted ? (
     <p className="whitespace-pre-wrap text-[11px] italic leading-relaxed text-muted-foreground/70">
       Thought content was redacted by the model.
     </p>
-  ) : (
-    <p className="whitespace-pre-wrap text-[11px] leading-relaxed text-muted-foreground">
-      {text}
+  ) : isEmpty ? (
+    <p className="whitespace-pre-wrap text-[11px] italic leading-relaxed text-muted-foreground/70">
+      The provider acknowledged a thinking block but didn't deliver any text.
+      This usually means the SDK CLI filtered it before forwarding.
     </p>
+  ) : (
+    <MarkdownBlock text={text} />
   );
   return (
     <ExpandableIconRow
       icon={Brain01Icon}
       label="Thinking"
-      summary={summary}
+      trailing={<InlineTextHint value={teaser} />}
+      hasContent
       body={body}
-      summaryClassName="italic"
     />
   );
 }

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -684,14 +684,18 @@ export function ThinkingRow({
   redacted: boolean;
 }) {
   // Three states:
-  // 1. redacted — model thought but content is policy-hidden
-  // 2. empty text — provider stripped or didn't deliver thinking content
-  // 3. plain text — render as markdown
+  // 1. redacted — model thought but content is policy-hidden (rare;
+  //    `redacted_thinking` content blocks).
+  // 2. empty text — Anthropic's SDK / CLI receives the signature but
+  //    strips every `thinking_delta` chunk before forwarding to us. The
+  //    model did think, we just never see the words. We render a row
+  //    anyway so the timeline accurately reflects what happened.
+  // 3. plain text — render as markdown.
   const isEmpty = !redacted && text.length === 0;
   const teaser = redacted
     ? "(redacted)"
     : isEmpty
-      ? "(no content provided)"
+      ? "(content not exposed by SDK)"
       : firstSentence(text);
   const body = redacted ? (
     <p className="whitespace-pre-wrap text-[11px] italic leading-relaxed text-muted-foreground/70">
@@ -699,8 +703,10 @@ export function ThinkingRow({
     </p>
   ) : isEmpty ? (
     <p className="whitespace-pre-wrap text-[11px] italic leading-relaxed text-muted-foreground/70">
-      The provider acknowledged a thinking block but didn't deliver any text.
-      This usually means the SDK CLI filtered it before forwarding.
+      The model produced a thinking block (the SDK forwarded its signed
+      receipt) but the underlying text was filtered out by Anthropic's
+      agent SDK before it reached us. We can&apos;t expose the actual
+      thoughts without bypassing the official SDK.
     </p>
   ) : (
     <MarkdownBlock text={text} />

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -1,0 +1,262 @@
+import {
+  Brain01Icon,
+  CheckListIcon,
+  File01Icon,
+  GlobeIcon,
+  PencilEdit01Icon,
+  Robot01Icon,
+  SearchIcon,
+  TerminalIcon,
+  Wrench01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import { cn } from "~/lib/utils";
+
+import { DiffBody, extractEdits, type FileEdit } from "./inline-diff.tsx";
+
+type IconHandle = Parameters<typeof HugeiconsIcon>[0]["icon"];
+
+interface ToolView {
+  readonly icon: IconHandle;
+  readonly label: string;
+  readonly summary: string | null;
+  readonly body: React.ReactNode;
+}
+
+const stringifyJson = (value: unknown): string => {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const asString = (v: unknown): string | null =>
+  typeof v === "string" && v.length > 0 ? v : null;
+
+const basename = (p: string): string => {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+};
+
+const truncate = (s: string, max: number): string =>
+  s.length > max ? s.slice(0, max - 1) + "…" : s;
+
+const JsonBody = ({ value }: { value: unknown }) => (
+  <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
+    {stringifyJson(value)}
+  </pre>
+);
+
+const editsBody = (edits: ReadonlyArray<FileEdit>): React.ReactNode => (
+  <div className="overflow-hidden rounded border border-border/60">
+    {edits.map((edit, i) => (
+      <DiffBody key={i} edit={edit} showHeader={edits.length > 1} />
+    ))}
+  </div>
+);
+
+const buildView = (tool: string, input: unknown): ToolView => {
+  const obj =
+    input !== null && typeof input === "object"
+      ? (input as Record<string, unknown>)
+      : {};
+
+  switch (tool) {
+    case "Read": {
+      const path = asString(obj.file_path);
+      return {
+        icon: File01Icon,
+        label: "Read",
+        summary: path !== null ? basename(path) : null,
+        body: <JsonBody value={input} />,
+      };
+    }
+
+    case "Bash": {
+      const cmd = asString(obj.command);
+      const desc = asString(obj.description);
+      return {
+        icon: TerminalIcon,
+        label: "Bash",
+        summary: desc ?? (cmd !== null ? truncate(cmd, 80) : null),
+        body:
+          cmd !== null ? (
+            <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] text-foreground/80">
+              {cmd}
+            </pre>
+          ) : (
+            <JsonBody value={input} />
+          ),
+      };
+    }
+
+    case "Edit":
+    case "Write":
+    case "MultiEdit": {
+      const path = asString(obj.file_path);
+      const edits = extractEdits(tool, input);
+      const label =
+        tool === "Write"
+          ? "Write"
+          : tool === "MultiEdit"
+            ? `MultiEdit (${edits.length})`
+            : "Edit";
+      return {
+        icon: PencilEdit01Icon,
+        label,
+        summary: path !== null ? basename(path) : null,
+        body:
+          edits.length > 0 ? editsBody(edits) : <JsonBody value={input} />,
+      };
+    }
+
+    case "Grep": {
+      const pattern = asString(obj.pattern);
+      const path = asString(obj.path);
+      const glob = asString(obj.glob);
+      const where = path ?? glob;
+      return {
+        icon: SearchIcon,
+        label: "Grep",
+        summary:
+          pattern !== null
+            ? where !== null
+              ? `${pattern} in ${where}`
+              : pattern
+            : null,
+        body: <JsonBody value={input} />,
+      };
+    }
+
+    case "Glob": {
+      const pattern = asString(obj.pattern);
+      return {
+        icon: SearchIcon,
+        label: "Glob",
+        summary: pattern,
+        body: <JsonBody value={input} />,
+      };
+    }
+
+    case "Task":
+    case "Agent": {
+      const desc = asString(obj.description) ?? asString(obj.subagent_type);
+      return {
+        icon: Robot01Icon,
+        label: "Agent",
+        summary: desc,
+        body: <JsonBody value={input} />,
+      };
+    }
+
+    case "Think":
+    case "Thinking": {
+      const text = asString(obj.thought) ?? asString(obj.text);
+      return {
+        icon: Brain01Icon,
+        label: "Thinking",
+        summary: text !== null ? truncate(text, 100) : null,
+        body:
+          text !== null ? (
+            <p className="whitespace-pre-wrap text-[11px] leading-relaxed text-muted-foreground">
+              {text}
+            </p>
+          ) : (
+            <JsonBody value={input} />
+          ),
+      };
+    }
+
+    case "WebFetch": {
+      const url = asString(obj.url);
+      return {
+        icon: GlobeIcon,
+        label: "WebFetch",
+        summary: url,
+        body: <JsonBody value={input} />,
+      };
+    }
+
+    case "WebSearch": {
+      const q = asString(obj.query);
+      return {
+        icon: GlobeIcon,
+        label: "WebSearch",
+        summary: q,
+        body: <JsonBody value={input} />,
+      };
+    }
+
+    case "TodoWrite": {
+      const todos = Array.isArray(obj.todos) ? obj.todos.length : null;
+      return {
+        icon: CheckListIcon,
+        label: "TodoWrite",
+        summary: todos !== null ? `${todos} todos` : null,
+        body: <JsonBody value={input} />,
+      };
+    }
+
+    default: {
+      return {
+        icon: Wrench01Icon,
+        label: tool,
+        summary: null,
+        body: <JsonBody value={input} />,
+      };
+    }
+  }
+};
+
+export function ToolRow({ tool, input }: { tool: string; input: unknown }) {
+  const [expanded, setExpanded] = useState(false);
+  const view = buildView(tool, input);
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div className="px-4">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs hover:bg-muted/40"
+      >
+        {/* Single icon slot: tool icon at rest, chevron on hover. Both live
+            in the same grid cell so the row never reflows. Mirrors the
+            avatar/chevron swap on the project sidebar header. */}
+        <div className="relative grid size-4 shrink-0 place-items-center">
+          <HugeiconsIcon
+            icon={view.icon}
+            strokeWidth={2}
+            aria-hidden="true"
+            className={cn(
+              "col-start-1 row-start-1 size-3.5 text-muted-foreground transition-opacity duration-150 ease-out",
+              "group-hover:opacity-0 motion-reduce:transition-none",
+            )}
+          />
+          <Chevron
+            aria-hidden="true"
+            className={cn(
+              "col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
+              "group-hover:opacity-100 motion-reduce:transition-none",
+            )}
+          />
+        </div>
+        <span className="font-medium text-foreground/90">{view.label}</span>
+        {view.summary !== null ? (
+          <span className="truncate text-muted-foreground">
+            {view.summary}
+          </span>
+        ) : null}
+      </button>
+      {expanded ? (
+        <div className="ml-7 mt-1 border-l border-border/60 pl-3">
+          {view.body}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -19,13 +19,6 @@ import { DiffBody, extractEdits, type FileEdit } from "./inline-diff.tsx";
 
 type IconHandle = Parameters<typeof HugeiconsIcon>[0]["icon"];
 
-interface ToolView {
-  readonly icon: IconHandle;
-  readonly label: string;
-  readonly summary: string | null;
-  readonly body: React.ReactNode;
-}
-
 const stringifyJson = (value: unknown): string => {
   try {
     return JSON.stringify(value, null, 2);
@@ -59,7 +52,79 @@ const editsBody = (edits: ReadonlyArray<FileEdit>): React.ReactNode => (
   </div>
 );
 
-const buildView = (tool: string, input: unknown): ToolView => {
+/**
+ * Single-line collapsible row used by tool calls and thinking blocks. The
+ * leading slot is a fixed-size grid cell that holds the contextual icon
+ * (idle) and a chevron (hover) in the same cell — same swap pattern the
+ * project sidebar uses for avatar↔chevron and session row uses for
+ * branch↔archive.
+ */
+function ExpandableIconRow({
+  icon,
+  label,
+  summary,
+  body,
+  labelClassName,
+  summaryClassName,
+}: {
+  icon: IconHandle;
+  label: string;
+  summary: string | null;
+  body: React.ReactNode;
+  labelClassName?: string;
+  summaryClassName?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+  return (
+    <div className="px-4">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs hover:bg-muted/40"
+      >
+        <div className="relative grid size-4 shrink-0 place-items-center">
+          <HugeiconsIcon
+            icon={icon}
+            strokeWidth={2}
+            aria-hidden="true"
+            className={cn(
+              "col-start-1 row-start-1 size-3.5 text-muted-foreground transition-opacity duration-150 ease-out",
+              "group-hover:opacity-0 motion-reduce:transition-none",
+            )}
+          />
+          <Chevron
+            aria-hidden="true"
+            className={cn(
+              "col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
+              "group-hover:opacity-100 motion-reduce:transition-none",
+            )}
+          />
+        </div>
+        <span className={cn("font-medium text-foreground/90", labelClassName)}>
+          {label}
+        </span>
+        {summary !== null ? (
+          <span className={cn("truncate text-muted-foreground", summaryClassName)}>
+            {summary}
+          </span>
+        ) : null}
+      </button>
+      {expanded ? (
+        <div className="ml-7 mt-1 border-l border-border/60 pl-3">{body}</div>
+      ) : null}
+    </div>
+  );
+}
+
+interface ToolView {
+  readonly icon: IconHandle;
+  readonly label: string;
+  readonly summary: string | null;
+  readonly body: React.ReactNode;
+}
+
+const buildToolView = (tool: string, input: unknown): ToolView => {
   const obj =
     input !== null && typeof input === "object"
       ? (input as Record<string, unknown>)
@@ -153,24 +218,6 @@ const buildView = (tool: string, input: unknown): ToolView => {
       };
     }
 
-    case "Think":
-    case "Thinking": {
-      const text = asString(obj.thought) ?? asString(obj.text);
-      return {
-        icon: Brain01Icon,
-        label: "Thinking",
-        summary: text !== null ? truncate(text, 100) : null,
-        body:
-          text !== null ? (
-            <p className="whitespace-pre-wrap text-[11px] leading-relaxed text-muted-foreground">
-              {text}
-            </p>
-          ) : (
-            <JsonBody value={input} />
-          ),
-      };
-    }
-
     case "WebFetch": {
       const url = asString(obj.url);
       return {
@@ -213,50 +260,45 @@ const buildView = (tool: string, input: unknown): ToolView => {
 };
 
 export function ToolRow({ tool, input }: { tool: string; input: unknown }) {
-  const [expanded, setExpanded] = useState(false);
-  const view = buildView(tool, input);
-  const Chevron = expanded ? ChevronDown : ChevronRight;
-
+  const view = buildToolView(tool, input);
   return (
-    <div className="px-4">
-      <button
-        type="button"
-        onClick={() => setExpanded((e) => !e)}
-        className="group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs hover:bg-muted/40"
-      >
-        {/* Single icon slot: tool icon at rest, chevron on hover. Both live
-            in the same grid cell so the row never reflows. Mirrors the
-            avatar/chevron swap on the project sidebar header. */}
-        <div className="relative grid size-4 shrink-0 place-items-center">
-          <HugeiconsIcon
-            icon={view.icon}
-            strokeWidth={2}
-            aria-hidden="true"
-            className={cn(
-              "col-start-1 row-start-1 size-3.5 text-muted-foreground transition-opacity duration-150 ease-out",
-              "group-hover:opacity-0 motion-reduce:transition-none",
-            )}
-          />
-          <Chevron
-            aria-hidden="true"
-            className={cn(
-              "col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
-              "group-hover:opacity-100 motion-reduce:transition-none",
-            )}
-          />
-        </div>
-        <span className="font-medium text-foreground/90">{view.label}</span>
-        {view.summary !== null ? (
-          <span className="truncate text-muted-foreground">
-            {view.summary}
-          </span>
-        ) : null}
-      </button>
-      {expanded ? (
-        <div className="ml-7 mt-1 border-l border-border/60 pl-3">
-          {view.body}
-        </div>
-      ) : null}
-    </div>
+    <ExpandableIconRow
+      icon={view.icon}
+      label={view.label}
+      summary={view.summary}
+      body={view.body}
+    />
+  );
+}
+
+export function ThinkingRow({
+  text,
+  redacted,
+}: {
+  text: string;
+  redacted: boolean;
+}) {
+  const summary = redacted
+    ? "(redacted)"
+    : text.length > 0
+      ? truncate(text.replace(/\s+/g, " ").trim(), 100)
+      : null;
+  const body = redacted ? (
+    <p className="whitespace-pre-wrap text-[11px] italic leading-relaxed text-muted-foreground/70">
+      Thought content was redacted by the model.
+    </p>
+  ) : (
+    <p className="whitespace-pre-wrap text-[11px] leading-relaxed text-muted-foreground">
+      {text}
+    </p>
+  );
+  return (
+    <ExpandableIconRow
+      icon={Brain01Icon}
+      label="Thinking"
+      summary={summary}
+      body={body}
+      summaryClassName="italic"
+    />
   );
 }

--- a/apps/renderer/src/lib/utils.ts
+++ b/apps/renderer/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
+
+const compactNumberFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+export function formatCompactNumber(n: number): string {
+  return compactNumberFormatter.format(n).toLowerCase();
+}

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -138,9 +138,15 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
             text: block.text,
           });
         } else if (block.type === "tool_use") {
+          // Use the SDK-assigned tool_use id as the wire item id so the
+          // matching tool_result can pair to its tool_use on the renderer.
+          const id =
+            typeof (block as { id?: unknown }).id === "string"
+              ? ((block as { id: string }).id as AgentItemId)
+              : nextItemId();
           out.push({
             _tag: "ToolUse",
-            itemId: nextItemId(),
+            itemId: id,
             tool: block.name,
             input: block.input,
           });
@@ -173,9 +179,18 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
     if (Array.isArray(content)) {
       for (const block of content) {
         if (block.type === "tool_result") {
+          // Pair to the originating tool_use by the SDK's correlation id;
+          // fall back to a fresh id only if the SDK omits it (shouldn't
+          // happen for valid tool_result blocks).
+          const id =
+            typeof (block as { tool_use_id?: unknown }).tool_use_id ===
+            "string"
+              ? ((block as { tool_use_id: string })
+                  .tool_use_id as AgentItemId)
+              : nextItemId();
           out.push({
             _tag: "ToolResult",
-            itemId: nextItemId(),
+            itemId: id,
             output: block.content ?? null,
             isError: block.is_error === true,
           });
@@ -429,6 +444,12 @@ export const startClaudeSession = (
         ? { pathToClaudeCodeExecutable: claudeExecutablePath }
         : {}),
       ...(input.model !== undefined ? { model: input.model } : {}),
+      // Adaptive thinking is the model-side default for Opus 4.6+ but
+      // setting it explicitly makes the contract obvious and survives
+      // future default changes. Subagent text/thinking is forwarded so a
+      // Task call's nested reasoning shows up in the timeline.
+      thinking: { type: "adaptive" },
+      forwardSubagentText: true,
       env: env as Options["env"],
       // Bridge the SDK's permission callback to the server-side
       // `PermissionService`. The renderer's toast eventually fulfills the

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -120,17 +120,78 @@ const scrubInheritedClaudeMarkers = (
 
 
 /**
- * Translate one SDKMessage into zero-or-more wire AgentEvents. Phase 2 keeps
- * the mapping shallow — assistant text + tool_use + tool_result + result.
- * Other SDK message kinds (status, hooks, plugin install, …) are ignored;
- * Phase 3 will surface a richer subset.
+ * Per-turn accumulator for thinking_delta / redacted_thinking blocks. The
+ * SDK delivers raw `content_block_*` events when `includePartialMessages`
+ * is on; we stitch them back together because the completed assistant
+ * message has the `thinking` field stripped (SDK policy).
+ *
+ * Keyed by `index` from the stream events, which is stable within one
+ * message but resets per turn — `message_start` clears the map.
  */
-const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
+interface ThinkingAccumulator {
+  kind: "thinking" | "redacted_thinking";
+  text: string;
+  signatureLength: number;
+}
+
+interface TranslateState {
+  thinkingByIndex: Map<number, ThinkingAccumulator>;
+  emittedThinkingThisTurn: boolean;
+}
+
+const newTranslateState = (): TranslateState => ({
+  thinkingByIndex: new Map(),
+  emittedThinkingThisTurn: false,
+});
+
+// Off by default; enable with FORKZERO_DEBUG_THINKING=1 when diagnosing
+// thinking-block delivery. One JSON object per line so terminal
+// scrollback / `grep` / `tee logfile` all preserve every field — Node's
+// default util.inspect spans multiple lines and gets chopped by
+// line-oriented tools.
+const THINKING_DEBUG = process.env.FORKZERO_DEBUG_THINKING === "1";
+const tlog = (event: string, payload: Record<string, unknown> = {}): void => {
+  if (!THINKING_DEBUG) return;
+  let line: string;
+  try {
+    line = JSON.stringify({ event, ...payload });
+  } catch {
+    line = JSON.stringify({ event, error: "unserializable payload" });
+  }
+  // eslint-disable-next-line no-console
+  console.error(`[claude-driver/thinking] ${line}`);
+};
+const summarize = (value: unknown, max = 200): string => {
+  try {
+    const s = typeof value === "string" ? value : JSON.stringify(value);
+    return s.length > max ? `${s.slice(0, max)}…(${s.length}b)` : s;
+  } catch {
+    return String(value);
+  }
+};
+
+/**
+ * Translate one SDKMessage into zero-or-more wire AgentEvents. Mostly
+ * stateless, but the `state` carries thinking-delta accumulators across
+ * `stream_event` messages so we can emit one Thinking event per content
+ * block at its `content_block_stop`.
+ */
+const translate = (
+  msg: SDKMessage,
+  state: TranslateState,
+): ReadonlyArray<AgentEvent> => {
+  tlog("sdk-msg", {
+    type: (msg as { type?: unknown }).type,
+    hasMessage: "message" in (msg as object),
+    sessionId: (msg as { session_id?: unknown }).session_id,
+  });
   if (msg.type === "assistant") {
     const out: AgentEvent[] = [];
     const content = msg.message.content;
+    const blockTypes: string[] = [];
     if (Array.isArray(content)) {
       for (const block of content) {
+        blockTypes.push(String((block as { type?: unknown }).type));
         if (block.type === "text" && typeof block.text === "string") {
           out.push({
             _tag: "AssistantMessage",
@@ -138,8 +199,6 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
             text: block.text,
           });
         } else if (block.type === "tool_use") {
-          // Use the SDK-assigned tool_use id as the wire item id so the
-          // matching tool_result can pair to its tool_use on the renderer.
           const id =
             typeof (block as { id?: unknown }).id === "string"
               ? ((block as { id: string }).id as AgentItemId)
@@ -154,23 +213,171 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
           block.type === "thinking" &&
           typeof (block as { thinking?: unknown }).thinking === "string"
         ) {
-          out.push({
-            _tag: "Thinking",
-            itemId: nextItemId(),
-            text: (block as { thinking: string }).thinking,
-            redacted: false,
+          // Fallback: if the partial-message deltas didn't deliver
+          // anything for this turn (e.g. SDK strips them too), at least
+          // emit whatever the assistant message has — even if `thinking`
+          // is empty — so a row appears and we know thinking happened.
+          const text = (block as { thinking: string }).thinking;
+          tlog("assistant.thinking-block", {
+            textLen: text.length,
+            emittedFromDeltasThisTurn: state.emittedThinkingThisTurn,
+            preview: summarize(text),
           });
+          if (!state.emittedThinkingThisTurn) {
+            out.push({
+              _tag: "Thinking",
+              itemId: nextItemId(),
+              text,
+              redacted: false,
+            });
+          }
         } else if (block.type === "redacted_thinking") {
-          out.push({
+          tlog("assistant.redacted-thinking-block", {
+            emittedFromDeltasThisTurn: state.emittedThinkingThisTurn,
+          });
+          if (!state.emittedThinkingThisTurn) {
+            out.push({
+              _tag: "Thinking",
+              itemId: nextItemId(),
+              text: "",
+              redacted: true,
+            });
+          }
+        }
+      }
+    }
+    tlog("assistant.blocks", { types: blockTypes, emitted: out.length });
+    return out;
+  }
+  if (msg.type === "stream_event") {
+    const ev = (msg as { event?: unknown }).event as
+      | Record<string, unknown>
+      | undefined;
+    if (ev === undefined || typeof ev.type !== "string") {
+      tlog("stream_event.malformed", { event: summarize(ev) });
+      return [];
+    }
+    if (ev.type === "message_start") {
+      state.thinkingByIndex.clear();
+      state.emittedThinkingThisTurn = false;
+      tlog("stream_event.message_start");
+      return [];
+    }
+    if (ev.type === "content_block_start") {
+      const index = typeof ev.index === "number" ? ev.index : null;
+      const block = ev.content_block as Record<string, unknown> | undefined;
+      tlog("stream_event.content_block_start", {
+        index,
+        blockType: block?.type,
+        block: summarize(block),
+      });
+      if (index === null || block === undefined) return [];
+      if (block.type === "thinking") {
+        state.thinkingByIndex.set(index, {
+          kind: "thinking",
+          text: "",
+          signatureLength: 0,
+        });
+      } else if (block.type === "redacted_thinking") {
+        state.thinkingByIndex.set(index, {
+          kind: "redacted_thinking",
+          text: "",
+          signatureLength: 0,
+        });
+      }
+      return [];
+    }
+    if (ev.type === "content_block_delta") {
+      const index = typeof ev.index === "number" ? ev.index : null;
+      const delta = ev.delta as Record<string, unknown> | undefined;
+      if (index === null || delta === undefined) {
+        tlog("stream_event.content_block_delta.malformed", {
+          index,
+          delta: summarize(delta),
+        });
+        return [];
+      }
+      const acc = state.thinkingByIndex.get(index);
+      if (delta.type === "thinking_delta") {
+        const chunk =
+          typeof delta.thinking === "string" ? delta.thinking : "";
+        tlog("stream_event.thinking_delta", {
+          index,
+          chunkLen: chunk.length,
+          chunkPreview: summarize(chunk, 80),
+          haveAccumulator: acc !== undefined,
+        });
+        if (acc !== undefined) acc.text += chunk;
+      } else if (delta.type === "signature_delta") {
+        // signatures confirm thinking happened even when text is empty
+        const sig =
+          typeof delta.signature === "string" ? delta.signature : "";
+        tlog("stream_event.signature_delta", { index, sigLen: sig.length });
+        if (acc !== undefined) acc.signatureLength += sig.length;
+      } else if (
+        delta.type !== "text_delta" &&
+        delta.type !== "input_json_delta"
+      ) {
+        tlog("stream_event.other_delta", {
+          index,
+          deltaType: delta.type,
+          delta: summarize(delta),
+        });
+      }
+      return [];
+    }
+    if (ev.type === "content_block_stop") {
+      const index = typeof ev.index === "number" ? ev.index : null;
+      if (index === null) return [];
+      const acc = state.thinkingByIndex.get(index);
+      if (acc === undefined) return [];
+      state.thinkingByIndex.delete(index);
+      tlog("stream_event.content_block_stop[thinking]", {
+        index,
+        kind: acc.kind,
+        textLen: acc.text.length,
+        signatureLen: acc.signatureLength,
+        textPreview: summarize(acc.text),
+      });
+      if (acc.kind === "redacted_thinking") {
+        state.emittedThinkingThisTurn = true;
+        return [
+          {
             _tag: "Thinking",
             itemId: nextItemId(),
             text: "",
             redacted: true,
-          });
-        }
+          },
+        ];
       }
+      if (acc.text.length > 0) {
+        state.emittedThinkingThisTurn = true;
+        return [
+          {
+            _tag: "Thinking",
+            itemId: nextItemId(),
+            text: acc.text,
+            redacted: false,
+          },
+        ];
+      }
+      // Empty thinking + a non-zero signature still indicates a thought
+      // was produced — render the empty placeholder so the user can see
+      // it happened. (If signature is also zero, drop silently.)
+      if (acc.signatureLength > 0) {
+        state.emittedThinkingThisTurn = true;
+        return [
+          {
+            _tag: "Thinking",
+            itemId: nextItemId(),
+            text: "",
+            redacted: false,
+          },
+        ];
+      }
+      return [];
     }
-    return out;
+    return [];
   }
   if (msg.type === "user") {
     // Tool results come back as user messages with tool_result content blocks.
@@ -444,12 +651,20 @@ export const startClaudeSession = (
         ? { pathToClaudeCodeExecutable: claudeExecutablePath }
         : {}),
       ...(input.model !== undefined ? { model: input.model } : {}),
-      // Adaptive thinking is the model-side default for Opus 4.6+ but
-      // setting it explicitly makes the contract obvious and survives
-      // future default changes. Subagent text/thinking is forwarded so a
-      // Task call's nested reasoning shows up in the timeline.
-      thinking: { type: "adaptive" },
+      // `effort: "high"` enables deep reasoning. We pair it with an
+      // explicit `display: "summarized"` because Opus 4.7 defaults the
+      // adaptive-thinking display to "omitted" — meaning the API
+      // intentionally returns empty thinking text plus a signature.
+      // Without this override, our `thinking_delta` chunks arrive empty
+      // even though the model thought (we see `signature_delta` only).
+      // Other Claude 4 models default to "summarized" so this is a
+      // no-op for them.
+      effort: "high",
+      thinking: { type: "adaptive", display: "summarized" },
       forwardSubagentText: true,
+      // Surfaces thinking deltas in the partial-message stream so we
+      // can render thinking as it streams in.
+      includePartialMessages: true,
       env: env as Options["env"],
       // Bridge the SDK's permission callback to the server-side
       // `PermissionService`. The renderer's toast eventually fulfills the
@@ -520,6 +735,7 @@ export const startClaudeSession = (
     // populated `session_id` we surface it as `SessionCursor` so MessageStore
     // can persist it for resume.
     let cursorAnnounced = false;
+    const translateState = newTranslateState();
     const pump = Effect.tryPromise({
       try: async () => {
         for await (const msg of q) {
@@ -534,7 +750,7 @@ export const startClaudeSession = (
               });
             }
           }
-          const translated = translate(msg);
+          const translated = translate(msg, translateState);
           for (const ev of translated) {
             events.unsafeOffer(ev);
           }

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -144,6 +144,23 @@ const translate = (msg: SDKMessage): ReadonlyArray<AgentEvent> => {
             tool: block.name,
             input: block.input,
           });
+        } else if (
+          block.type === "thinking" &&
+          typeof (block as { thinking?: unknown }).thinking === "string"
+        ) {
+          out.push({
+            _tag: "Thinking",
+            itemId: nextItemId(),
+            text: (block as { thinking: string }).thinking,
+            redacted: false,
+          });
+        } else if (block.type === "redacted_thinking") {
+          out.push({
+            _tag: "Thinking",
+            itemId: nextItemId(),
+            text: "",
+            redacted: true,
+          });
         }
       }
     }

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -103,6 +103,7 @@ const roleForContent = (content: MessageContent): MessageRole => {
     case "user":
       return "user";
     case "assistant":
+    case "thinking":
     case "tool_use":
       return "assistant";
     case "tool_result":
@@ -122,6 +123,13 @@ const eventToContent = (event: AgentEvent): MessageContent | null => {
   switch (event._tag) {
     case "AssistantMessage":
       return { _tag: "assistant", text: event.text };
+    case "Thinking":
+      return {
+        _tag: "thinking",
+        itemId: event.itemId,
+        text: event.text,
+        redacted: event.redacted,
+      };
     case "ToolUse":
       return {
         _tag: "tool_use",

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -89,6 +89,12 @@ const AssistantMessageEvent = Schema.TaggedStruct("AssistantMessage", {
   text: Schema.String,
 });
 
+const ThinkingEvent = Schema.TaggedStruct("Thinking", {
+  itemId: AgentItemId,
+  text: Schema.String,
+  redacted: Schema.Boolean,
+});
+
 const ToolUseEvent = Schema.TaggedStruct("ToolUse", {
   itemId: AgentItemId,
   tool: Schema.String,
@@ -140,6 +146,7 @@ export const AgentEvent = Schema.Union(
   VersionEvent,
   CapabilitiesEvent,
   AssistantMessageEvent,
+  ThinkingEvent,
   ToolUseEvent,
   ToolResultEvent,
   PermissionRequestEvent,

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -101,6 +101,18 @@ const AssistantContent = Schema.TaggedStruct("assistant", {
   text: Schema.String,
 });
 
+/**
+ * Extended-thinking / reasoning text emitted by the model before its final
+ * answer. `redacted` mirrors Anthropic's `redacted_thinking` blocks where
+ * the content is hidden but the row still appears so users see something
+ * was thought about.
+ */
+const ThinkingContent = Schema.TaggedStruct("thinking", {
+  itemId: AgentItemId,
+  text: Schema.String,
+  redacted: Schema.Boolean,
+});
+
 const ToolUseContent = Schema.TaggedStruct("tool_use", {
   itemId: AgentItemId,
   tool: Schema.String,
@@ -126,6 +138,7 @@ const ErrorContent = Schema.TaggedStruct("error", {
 export const MessageContent = Schema.Union(
   UserContent,
   AssistantContent,
+  ThinkingContent,
   ToolUseContent,
   ToolResultContent,
   ErrorContent,


### PR DESCRIPTION
## Summary

Branch reshapes the chat timeline and sidebar around a calmer single-line idiom and finally surfaces Claude's thinking text.

- **Sidebar counts** — diff totals format compactly (\`6.2k\`, \`1.2m\`) via a new \`formatCompactNumber\` helper; \`+\` is green, \`−\` is red.
- **Session row** — three-dot menu replaced with a single Archive (or Unarchive) action that swaps in via the icon ↔ chevron hover-swap pattern. Rename / Archive / Delete moved to a right-click context menu anchored at the cursor.
- **Tool rows** — tool_use rows are now one line each, iconified via @hugeicons (File / Terminal / Pencil / Search / Robot / Globe / Brain / ListTodo / Wrench fallback), with per-tool collapsed and expanded views: Bash shows description + command chip → terminal block with stdout/stderr; Read shows line count + filename → content excerpt; Edit/Write/MultiEdit shows the existing diff; Grep shows pattern + scope + match count → file list; Task shows description → prompt + markdown reply.
- **tool_use ↔ tool_result pairing** — driver uses the SDK's \`block.id\` / \`block.tool_use_id\` as the wire \`itemId\` so the renderer can collapse the result into its parent row. Successful tool_result rows are dropped from the timeline; orphan errors fall through to a standalone red row.
- **Thinking text** — adaptive thinking with \`display: \"summarized\"\` (Opus 4.7 defaults to \`\"omitted\"\` and silently strips text), \`includePartialMessages: true\`, and per-content-block accumulation of \`thinking_delta\` chunks emit a Thinking AgentEvent at \`content_block_stop\`. Renderer ThinkingRow distinguishes redacted, empty (provider stripped), and rendered states.
- **Diagnostics** — \`FORKZERO_DEBUG_THINKING=1\` emits one JSON log line per SDK message / stream event for diagnosing provider redaction (off by default).

## Test plan

- [ ] \`bun run check-types\` passes across all workspaces.
- [ ] Sidebar shows \`+1.2k\` green and \`−385\` red on a project with PR diff stats; layout doesn't reflow.
- [ ] Hovering a session row swaps the right-side slot from diff/timestamp to an Archive icon; clicking archives without prompting.
- [ ] Right-clicking a session row opens a menu with Rename / Archive (or Unarchive) / Delete at the cursor.
- [ ] Run a session that exercises Read, Bash, Grep, Edit, Task; each row is one line, click to expand, results render inside the row (no separate tool_result rows).
- [ ] Run a thinking-heavy prompt against Opus 4.7; Thinking row shows the first sentence as a teaser and expands to the full markdown thought.