### PR TITLE
spec: sub-agents (cost-saving delegation)

### DIFF
--- a/specs/sub-agents/README.md
+++ b/specs/sub-agents/README.md
@@ -1,0 +1,79 @@
+# Sub-agents — cost-saving delegation
+
+MVP 0.01 ([../0.01-MVP/](../0.01-MVP/)) shipped a chat-first desktop app with
+one model per session. MVP 0.02 ([../0.02-MVP/](../0.02-MVP/)) added a file
+viewer and minimal editor on the side. This spec is a **feature PR**, not a
+new MVP cut: it teaches the existing chat surface to delegate scoped sub-tasks
+from the main agent to *cheaper* sub-agents — Opus 4.7 hands "find every API
+endpoint" to Haiku 4.5, gets the summary back, and only the summary lands in
+the main conversation.
+
+The primitive is already in Anthropic's Agent SDK
+([`agents` parameter](https://code.claude.com/docs/en/agent-sdk/subagents) +
+the built-in `Agent` tool). The work here is wiring it through forkzero's
+Effect provider stack and surfacing the nested calls in the chat UI.
+
+## What lands in this PR
+
+- **Sub-agent invocation through the Claude provider.** Pass an `agents` map
+  into `StartSessionInput`; driver forwards it into the SDK. The main agent
+  decides when to delegate based on each sub-agent's `description`.
+- **Three seed sub-agents** shipped as defaults (toggleable in settings):
+  - `research` — Haiku 4.5, read-only tools.
+  - `file-edits` — Sonnet 4.6, file write tools.
+  - `test-runner` — Haiku 4.5, Bash + read.
+  - See [features/preset-library.md](features/preset-library.md).
+- **Wrapper-row UI**: the parent's `Agent` tool call renders as a
+  collapsible row that mirrors the existing tool-row design. Inside, every
+  nested tool call uses the *same* `tool-row.tsx` component — no new card
+  style, just one indent level. A `Prompt` sub-row sits at the top showing
+  the task the parent passed; the sub-agent's closing text renders just
+  before the wrapper closes.
+- **Per-agent token accounting.** The SDK's `result.usage` is captured per
+  agent and surfaced in a small footer (`Opus: 4.2k · Haiku (research):
+  18k · saved ~$0.34`).
+- **Resume parity.** Sub-agent transcripts persist into the session with
+  `parent_item_id`, so closing/reopening the app still renders nested.
+- **Permission interplay.** Sub-agent tool calls flow through the same
+  `canUseTool` callback. The toast prepends `via research-assistant ·
+  Haiku 4.5 ·` so the user sees who's asking. Sensitive-path checks
+  (`.env`, `.ssh/`, `*.pem`) fire regardless of nesting.
+
+## What's deliberately deferred
+
+- **Cross-provider sub-agents** — Claude main → Codex sub (and vice versa).
+  The SDK's `agents` parameter only spawns Claude sub-agents. Cross-provider
+  needs a forkzero-internal MCP bridge tool. Sketched in
+  [features/cross-provider.md](features/cross-provider.md), implemented in
+  a follow-up PR.
+- **User-defined sub-agents in settings UI.** This PR ships preset toggles
+  + per-preset edits. Creating brand-new sub-agents from scratch in the UI
+  comes after we see how the presets get used.
+- **Filesystem-based agents** (`.claude/agents/*.md`). Claude Code parity
+  is nice but not critical for forkzero's chat-first surface.
+- **Multi-level nesting.** The SDK explicitly forbids sub-agents spawning
+  their own sub-agents. Renderer assumes `depth ≤ 1`.
+- **Background sub-agents** (SDK `background: true`). Useful for
+  long-running research that the parent shouldn't block on, but the
+  current chat UI assumes a single linear stream. Revisit after the basic
+  case ships.
+
+## Where to read
+
+- [features/sub-agents.md](features/sub-agents.md) — feature deep dive
+  (wire schema deltas, driver changes, persistence, UI wrapper, permissions,
+  cost accounting)
+- [features/preset-library.md](features/preset-library.md) — the three
+  seed sub-agents
+- [features/cross-provider.md](features/cross-provider.md) — Phase 2
+  sketch for Claude ↔ Codex bridging
+- [decisions/0010-sdk-native-agents-param.md](decisions/0010-sdk-native-agents-param.md)
+  — why we lean on the SDK primitive instead of routing manually
+- [decisions/0011-haiku-as-default-research.md](decisions/0011-haiku-as-default-research.md)
+  — why Haiku 4.5 is the default research model
+- [decisions/0012-codex-bridge-via-mcp.md](decisions/0012-codex-bridge-via-mcp.md)
+  — how the cross-provider bridge will be shaped when we get there
+
+## Status
+
+📐 **Spec** — scoped, awaiting implementation.

--- a/specs/sub-agents/decisions/0010-sdk-native-agents-param.md
+++ b/specs/sub-agents/decisions/0010-sdk-native-agents-param.md
@@ -1,0 +1,143 @@
+# 0010 — Use the SDK's `agents` parameter for sub-agent delegation
+
+Status: Accepted (2026-05-04)
+
+## Context
+
+The sub-agents feature ([../features/sub-agents.md](../features/sub-agents.md))
+needs a way for the main agent to delegate scoped sub-tasks to a cheaper
+model. There are three viable shapes:
+
+1. Use Anthropic's Agent SDK `agents` parameter — the official primitive,
+   built on the SDK's `Agent` (formerly `Task`) tool.
+2. Hand-roll a router on top of the existing single-session SDK calls —
+   parse the parent's intent, decide a model, spawn a fresh `query()`
+   ourselves, plumb the result back as a synthetic assistant message.
+3. Wrap each sub-agent as a custom MCP tool — the parent calls e.g.
+   `forkzero.research(prompt)` and we run it however we like under the
+   hood.
+
+## Options
+
+### Option 1 — SDK-native `agents` parameter
+
+The shape is documented in
+[https://code.claude.com/docs/en/agent-sdk/subagents](https://code.claude.com/docs/en/agent-sdk/subagents):
+
+```ts
+query({
+  prompt: input,
+  options: {
+    allowedTools: [..., "Agent"],
+    agents: {
+      research: {
+        description: "...",
+        prompt: "...",
+        tools: ["Read", "Glob", "Grep"],
+        model: "haiku",
+      },
+    },
+  },
+})
+```
+
+The SDK handles invocation (`Agent` tool_use), context isolation
+(separate fresh context window per sub-agent), result return (final
+message returns as `tool_result`), and `parent_tool_use_id` correlation.
+Forkzero just consumes the existing event stream.
+
+**Pros**
+
+- Zero orchestration code on our side. The SDK is the orchestrator.
+- Anthropic-tested against the same scenarios we want to support
+  (research, file edits, parallel fan-out).
+- Per-sub-agent context isolation is *real* — the sub-agent's tool
+  results don't pollute the parent's context window. Hand-rolling this
+  correctly is non-trivial.
+- New SDK features (resumed sub-agents, background sub-agents,
+  per-invocation model overrides) ship for free as we adopt them.
+- `parent_tool_use_id` already arrives on every SDK message — we just
+  forward it onto the wire as `parentItemId`.
+
+**Cons**
+
+- Locks us deeper into Anthropic's SDK shape. (We're already locked in
+  for the Claude provider; this is incremental, not new.)
+- Only spawns Claude sub-agents. Cross-provider needs a different path
+  (the MCP bridge — see ADR
+  [0012-codex-bridge-via-mcp.md](0012-codex-bridge-via-mcp.md)).
+
+### Option 2 — Hand-roll a router
+
+Detect when the main agent should delegate (regex / heuristic on the
+prompt? embed-and-classify?), call `query()` again with a different
+model, splice the result back into the parent stream as a synthetic
+assistant message.
+
+**Pros**
+
+- Provider-agnostic. The same router handles Claude → Codex, Codex →
+  Claude, Codex → Codex.
+- Full control over routing logic.
+
+**Cons**
+
+- We re-implement what the SDK already does well: context isolation,
+  delegation decisions, tool-set scoping, result correlation. Each
+  sub-feature is a sharp edge (concurrent sub-agents, partial failures,
+  cancellation, resume).
+- Routing decisions get worse than letting the model decide. Asking
+  Opus "should I delegate this to Haiku?" via the `Agent` tool's
+  description-matching is *exactly* the routing layer, run by the
+  smartest part of the system. A regex router will be wrong in subtle
+  ways.
+- Kicking off a fresh `query()` inside an existing one is a tangle of
+  Effect scopes, message ordering, and mailbox coordination we haven't
+  needed yet.
+
+### Option 3 — Each sub-agent as a custom MCP tool
+
+Define `forkzero.research`, `forkzero.file-edits`, `forkzero.test-runner`
+as MCP tools. The parent agent calls them like any other tool.
+
+**Pros**
+
+- Same code path as cross-provider bridging will use anyway (see ADR
+  0012).
+- Fully provider-agnostic.
+
+**Cons**
+
+- For the same-provider case we'd be running our own MCP server *just*
+  to invoke a sub-process of the same SDK we're already using —
+  pointless overhead.
+- The Agent tool's description-driven dispatch + per-invocation model
+  overrides + context isolation are all things we'd be re-doing.
+- No `parent_tool_use_id` for free — we'd synthesize one and hope.
+
+## Decision
+
+**Use the SDK's `agents` parameter (Option 1) for same-provider
+sub-agents.** Cross-provider sub-agents go through the MCP bridge
+(Option 3-style, recorded in ADR 0012). Option 2 is rejected entirely.
+
+The same-provider case is the immediate win (Opus → Haiku for research
+in long sessions); doing it through the SDK's own primitive is the
+shortest path with the strongest correctness guarantees.
+
+## Consequences
+
+- `apps/server/src/provider/drivers/claude.ts` gains an `agents` field
+  in its `Options` construction and `"Agent"` in `allowedTools`. About a
+  dozen lines.
+- `translate()` propagates `parent_tool_use_id` to wire events. About
+  five lines.
+- The wire schema gains optional `parentItemId` on streamed events plus
+  two new events (`SubagentSummary`, `UsageDelta`). Additive only.
+- We accept that cross-provider sub-agents need a different mechanism
+  (the MCP bridge). They can't share the SDK's `agents` primitive —
+  that's an Anthropic-only construct. ADR 0012 covers the bridge.
+- We do **not** add a routing heuristic, intent classifier, or any
+  forkzero-side decision about when to delegate. The main model
+  decides, based on each sub-agent's `description`. Tuning the
+  descriptions is the operator surface.

--- a/specs/sub-agents/decisions/0011-haiku-as-default-research.md
+++ b/specs/sub-agents/decisions/0011-haiku-as-default-research.md
@@ -1,0 +1,91 @@
+# 0011 — Haiku 4.5 as the default model for the `research` preset
+
+Status: Accepted (2026-05-04)
+
+## Context
+
+The `research` sub-agent ([../features/preset-library.md](../features/preset-library.md))
+is the highest-traffic preset by design — almost every Opus session
+spends a meaningful share of tokens on `Glob` / `Grep` / `Read` chains
+just to find the right file before doing the actual reasoning. Routing
+those to a cheaper model is the single biggest win the sub-agents
+feature offers.
+
+We ship one default model for `research`. Picking it sets user
+expectations and (importantly) determines the cost ceiling for any
+Opus session that lights this preset up. The default has to be
+defensible without forcing users to re-tune.
+
+## Options
+
+For Claude, the candidates today (`packages/wire/src/agent.ts:189`):
+
+- Opus 4.7
+- Sonnet 4.6
+- Haiku 4.5
+
+### Opus 4.7
+
+Same model as the parent (most likely). Routing research to Opus saves
+*context*, not *cost* — the wins are real (smaller parent context
+window) but the per-token rate is unchanged. Defeats the framing of
+sub-agents as a cost lever.
+
+### Sonnet 4.6
+
+The "safe middle." Sonnet won't fumble a multi-step grep chain. But it's
+~3× the input rate of Haiku and we don't need its extra reasoning for
+read-only search.
+
+### Haiku 4.5
+
+Cheapest tier, fastest. The risk is whether it's *good enough* for
+search and summarization. Two checks:
+
+1. **Tool-use accuracy.** Haiku 4.5 was Anthropic's first Haiku release
+   trained for solid tool use; benchmarks against the same agentic
+   evals as Sonnet show no regression for simple Read/Glob/Grep
+   patterns. The failure modes Haiku has historically had — code
+   generation accuracy, multi-step reasoning — don't apply when the
+   tool-set is read-only.
+2. **Summarization quality at the boundary.** The summary the sub-agent
+   returns is what the parent sees. If Haiku writes a vague or wrong
+   summary, the parent makes a worse decision. This is the genuine
+   risk.
+
+Mitigation for (2): the preset's prompt explicitly demands "cite file
+paths and line numbers, don't speculate beyond code you've actually
+read." That constraint is enforceable by the parent — if Haiku returns
+a summary without citations, the parent can re-prompt or re-do the
+work itself. The pattern is "trust but verify with cheap citations."
+
+## Decision
+
+**Haiku 4.5 is the default for `research`.**
+
+The cost delta vs. Sonnet 4.6 (~3× cheaper input, ~3× cheaper output)
+is meaningful for the highest-traffic preset, the read-only tool set
+caps the blast radius, and the citation-required prompt makes
+summary errors detectable.
+
+User can change the model in settings — that's why the dropdown
+exists. We ship the most-savings default and let users dial up if they
+hit accuracy issues.
+
+## Consequences
+
+- The seed `research` preset in `apps/renderer/src/lib/subagent-presets.ts`
+  uses `model: "claude-haiku-4-5"`.
+- The `test-runner` preset, which is also search-heavy + parsing, uses
+  Haiku as well (same reasoning).
+- The `file-edits` preset uses Sonnet 4.6 — file edits *do* benefit
+  from Sonnet's better coding accuracy and they're not high-volume
+  enough for the cost delta to matter as much. Different preset,
+  different default; this ADR specifically only covers `research`.
+- If usage data shows Haiku materially under-performing on research
+  tasks (false summaries, missed files), the default flips to Sonnet
+  in a follow-up. This is reversible — just edit the preset.
+- The settings UI's per-preset model dropdown (see
+  [sub-agents.md → Settings](../features/sub-agents.md#settings))
+  exists precisely so users who don't trust Haiku can switch without
+  forking the preset.

--- a/specs/sub-agents/decisions/0012-codex-bridge-via-mcp.md
+++ b/specs/sub-agents/decisions/0012-codex-bridge-via-mcp.md
@@ -1,0 +1,120 @@
+# 0012 — Cross-provider sub-agents go through a custom MCP bridge tool
+
+Status: Accepted (2026-05-04)
+
+## Context
+
+Phase 1 of the sub-agents feature ([../features/sub-agents.md](../features/sub-agents.md))
+uses Anthropic's Agent SDK `agents` parameter, which only spawns Claude
+sub-agents. Phase 2 ([../features/cross-provider.md](../features/cross-provider.md))
+needs the *cross-provider* case: a Claude main agent delegating to a
+Codex (GPT-5) sub-agent and vice versa.
+
+The two SDKs (`@anthropic-ai/claude-agent-sdk` and the OpenAI / Codex
+Responses SDK) don't know about each other. There's no `model: "gpt-5"`
+shortcut in a Claude `AgentDefinition`. Whatever we build has to live
+between the two SDKs.
+
+## Options
+
+### Option 1 — Fork or wrap the Claude SDK to accept Codex sub-agents
+
+Patch the SDK so an `AgentDefinition` with a Codex model id routes to
+our Codex driver internally.
+
+**Pros**
+
+- Same `agents` API users already know.
+- No new tool-call layer.
+
+**Cons**
+
+- We'd be maintaining a fork of `@anthropic-ai/claude-agent-sdk` for
+  every release.
+- The SDK's internals (how it builds tool_use blocks, correlates ids,
+  manages context windows) aren't a stable contract — they change
+  between versions.
+- Doesn't help the reverse direction (Codex main → Claude sub).
+
+### Option 2 — Custom MCP tool that wraps the cross-provider call
+
+Both Claude and Codex SDKs accept MCP servers via standard config. We
+register an in-process MCP server (no socket — `@modelcontextprotocol/sdk`
+supports in-memory transports) that exposes:
+
+- `forkzero.delegate-codex(agent_name, prompt, model?)` → invoked by
+  Claude main sessions.
+- `forkzero.delegate-claude(agent_name, prompt, model?)` → invoked by
+  Codex main sessions.
+
+The bridge tool's implementation:
+
+1. Looks up the named cross-provider preset.
+2. Spins up a sub-session via the *other* provider's existing driver.
+3. Streams events back into the parent's event stream, retagging them
+   with the parent's `Agent` tool_use id as `parentItemId`.
+4. Returns the sub-agent's final text as the MCP tool's `text` content.
+
+**Pros**
+
+- Both SDKs already speak MCP. Zero forking.
+- Each provider's driver stays unchanged — the bridge is a separate
+  module.
+- Works in both directions (Claude → Codex and Codex → Claude) with
+  the same code shape.
+- Phase 1's wire schema (`parentItemId`, `SubagentSummary`,
+  `UsageDelta`) is enough — bridge events look like any other
+  sub-agent's events to the renderer.
+- The MCP tool is the right abstraction philosophically: we're saying
+  "this tool spawns and consults a different agent." MCP exists for
+  exactly this kind of "tool that wraps an external capability."
+
+**Cons**
+
+- Slightly more work than a same-provider sub-agent, since we run our
+  own MCP server.
+- The MCP roundtrip adds a small latency (~10ms in-process).
+- Permission semantics need careful thought: which provider's
+  `canUseTool` decides for the sub-agent's tool calls? (Answer: the
+  target provider's. See the cross-provider feature doc.)
+
+### Option 3 — Hand-roll a router in the wire layer
+
+Same shape as ADR 0010 Option 2: forkzero-side intent classifier picks
+a provider, makes a separate `query()` call, splices the result back.
+
+Already rejected for same-provider in ADR 0010. The reasoning is
+*stronger* for cross-provider: now we'd be re-implementing context
+isolation, tool-call correlation, *and* cross-SDK message format
+translation. No.
+
+## Decision
+
+**Custom MCP bridge tool (Option 2).**
+
+Both SDKs natively support MCP. The bridge stays small (one module,
+`apps/server/src/provider/mcp/forkzero-bridge.ts`) and forkzero stays
+out of the SDKs' guts. The same code path works in both directions.
+
+## Consequences
+
+- New module: `apps/server/src/provider/mcp/forkzero-bridge.ts`
+  exposes the in-memory MCP server. Registered with whichever
+  provider's driver is the *main* agent for a session.
+- Cross-provider preset entries in `apps/renderer/src/lib/subagent-presets.ts`
+  (e.g. `codex-research`, `claude-summarize`).
+- Wire schema gains one new event: `CrossProviderInvocation` so the
+  renderer can show the wrapper-row badge as `Agent → Codex (gpt-5-mini)`.
+  All other Phase 1 events (`parentItemId`, `SubagentSummary`,
+  `UsageDelta`) are reused as-is.
+- The Codex driver gains the same `SENSITIVE_PATTERNS` regex as the
+  Claude driver — sensitive-path checks must fire on both sides of
+  the bridge.
+- Settings page (Phase 1 ships the same-provider section) gains a
+  separate **"Cross-provider"** section in Phase 2.
+- We accept that the bridge's permission decisions for sub-agent tool
+  calls flow through the *target* provider's policy (the Codex driver
+  decides for Codex sub-agent tool calls). Provider-specific
+  semantics — `Bash` vs `shell`, etc. — make this the right cut.
+- Implementation does **not** ship in the Phase 1 PR. The Phase 1 wire
+  schema is designed so Phase 2 is purely additive.

--- a/specs/sub-agents/features/cross-provider.md
+++ b/specs/sub-agents/features/cross-provider.md
@@ -1,0 +1,256 @@
+# Feature: Cross-provider sub-agents (Phase 2)
+
+The Phase 1 spec ([sub-agents.md](sub-agents.md)) ships sub-agents
+*within* the Claude provider — Opus 4.7 delegates to Haiku 4.5 / Sonnet
+4.6, all through Anthropic's SDK. That's the immediate win.
+
+Phase 2 closes the loop the other way: a Claude main agent can delegate
+to a **Codex** sub-agent (and a Codex main agent can delegate to a
+Claude sub-agent) when the cheap-or-better model lives on the *other*
+provider. Use cases:
+
+- "Use a small Codex model for high-volume code search" — GPT-5 mini
+  variants are cheap and good at keyword search.
+- "Use Claude Haiku for summarization mid-Codex-session" — when the
+  user starts in Codex but needs Claude's better summarization for one
+  step.
+- "Run two providers in parallel for higher-recall research" — fan
+  out, agree on the answer.
+
+This document is a **full sketch** — wire shape, runtime, error
+handling, UI — but no implementation lands in the Phase 1 PR. The Phase
+1 wire format is designed so Phase 2 is purely additive.
+
+## The constraint we're working around
+
+Anthropic's Agent SDK and OpenAI's Codex SDK don't know about each
+other. Each `query()` call lives entirely within its provider's
+process — the SDK's `agents` parameter only spawns same-provider
+sub-agents. There's no `model: "gpt-5"` shortcut you can drop into a
+Claude `AgentDefinition`.
+
+What both SDKs **do** support is **MCP tools** — model-side function
+calls into a server we control. Both providers will happily call an
+arbitrary tool, await its result, and incorporate the result into the
+conversation. So the bridge is shaped as an **in-process MCP server**
+that exposes tools like `forkzero.delegate-codex` and
+`forkzero.delegate-claude`, registered with whichever provider is
+currently the *main* agent.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  apps/server (single Effect runtime, both providers loaded)      │
+│                                                                  │
+│   ┌─ Claude main session ─┐         ┌─ Codex sub-session ──┐     │
+│   │  Opus 4.7             │  call   │  gpt-5-mini          │     │
+│   │  query({              │ ──────▶ │  (spun up by bridge) │     │
+│   │    mcpServers: {      │         │                      │     │
+│   │      forkzero: …      │         │                      │     │
+│   │    }                  │ ◀────── │                      │     │
+│   │  })                   │ result  │                      │     │
+│   └───────────────────────┘         └──────────────────────┘     │
+│              │                                  │                │
+│              └──────────── ProviderService ─────┘                │
+│                          (parent/child link)                     │
+└──────────────────────────────────────────────────────────────────┘
+                  │                            │
+                  ▼                            ▼
+              Wire RPC                    Wire RPC
+                  │                            │
+                  ▼                            ▼
+       ┌─────── Renderer ────────────────────────────┐
+       │  one chat view, single transcript,          │
+       │  Codex sub-session events nested under      │
+       │  the parent's `Agent` wrapper row           │
+       └─────────────────────────────────────────────┘
+```
+
+## New piece: `apps/server/src/provider/mcp/forkzero-bridge.ts`
+
+An in-process MCP server (no socket, no subprocess — `@modelcontextprotocol/sdk`
+supports in-memory transports). Exposes two tools:
+
+```ts
+// Registered with whichever provider is the main agent.
+{
+  name: "forkzero.delegate-codex",
+  description:
+    "Delegate a scoped sub-task to a Codex (GPT-5) sub-agent. Use " +
+    "when the parent is on Claude and a cheaper Codex model is the " +
+    "better fit (e.g. high-volume keyword search). The sub-agent runs " +
+    "in its own context, returns only the final summary.",
+  inputSchema: {
+    type: "object",
+    required: ["agent_name", "prompt"],
+    properties: {
+      agent_name: { type: "string", enum: ["research", "file-edits", /* … */] },
+      prompt:     { type: "string" },
+      model:      { type: "string" }, // optional override, defaults to preset
+    },
+  },
+}
+
+{
+  name: "forkzero.delegate-claude",
+  description: "Reverse direction. Used when main is Codex.",
+  inputSchema: { /* same shape */ },
+}
+```
+
+When invoked, the bridge:
+
+1. Looks up the named cross-provider sub-agent preset (see
+   "Cross-provider preset library" below).
+2. Spins up a sub-session via the *other* provider's driver.
+   `claude.start({ providerId: "codex", … })` becomes
+   `codex.start({ providerId: "codex", … })` on the bridge code path.
+3. Pipes that sub-session's `AgentEvent` stream into the parent's
+   stream, **rewriting** each event to include the parent's `Agent`
+   tool_use id as `parentItemId`. The renderer therefore sees one
+   continuous stream and groups normally.
+4. Captures the sub-session's final assistant text and returns it as
+   the MCP tool's `text` content. The Claude SDK then synthesizes a
+   `tool_result` for that tool_use and the conversation continues.
+5. Emits a `SubagentSummary` event matching the Phase 1 schema, plus
+   `UsageDelta` events tagged with the cross-provider model.
+
+The parent driver doesn't need to know about Codex at all — it just
+sees an MCP tool call and an MCP tool result. Same code path as any
+other MCP tool.
+
+## Wire deltas — additive on top of Phase 1
+
+The Phase 1 schema already supports cross-provider almost as-is:
+
+- `parentItemId` works regardless of which provider emitted the
+  event — the bridge tags Codex sub-session events with the parent's
+  Claude `tool_use.id`, and the renderer groups by id.
+- `SubagentSummary.model` is `Schema.String`, accepts `"gpt-5-mini"`
+  alongside `"claude-haiku-4-5"`.
+- `UsageDelta.model` ditto.
+
+The only **new** event Phase 2 needs:
+
+```ts
+const CrossProviderInvocationEvent = Schema.TaggedStruct("CrossProviderInvocation", {
+  itemId: AgentItemId,             // matches the bridge tool_use
+  fromProvider: ProviderId,         // "claude"
+  toProvider: ProviderId,           // "codex"
+  agentName: Schema.String,         // "research"
+  model: Schema.String,             // "gpt-5-mini"
+});
+```
+
+This is emitted *before* the sub-session starts producing events, so
+the renderer can show the wrapper row's badge as
+`Agent → Codex (gpt-5-mini)` instead of just `Agent`.
+
+## Cross-provider preset library
+
+Lives next to the Phase 1 presets in
+`apps/renderer/src/lib/subagent-presets.ts`, but tagged
+`crossProvider: true`. Initial seeds:
+
+- **`codex-research`** — GPT-5 mini, Read/Glob/Grep. Same role as
+  `research` but uses Codex. Useful when the user is running on Claude
+  Opus and wants the *cheapest* possible search.
+- **`claude-summarize`** — Haiku 4.5, Read/Grep. Used by Codex main
+  sessions when the user wants Claude's summarization quality for one
+  step.
+
+The settings UI ([sub-agents.md → Settings](sub-agents.md#settings))
+gains a new section header **"Cross-provider"** below the same-provider
+list. Each row shows the source provider → target provider plus the
+target model.
+
+## Permissions across providers
+
+Cross-provider sub-agent tool calls flow through the **target** provider's
+`canUseTool` — i.e. a Codex sub-agent's tool calls are decided by the
+Codex driver's policy. Reasoning: each provider's tool semantics differ
+slightly (Codex `shell` vs Claude `Bash`), so the policy code that
+already understands those differences should keep deciding.
+
+What the bridge *does* unify:
+
+- Sensitive-path checks fire on both sides (already true for Claude;
+  Phase 2 mirrors the same `SENSITIVE_PATTERNS` regex into the Codex
+  driver).
+- Permission toasts label the agent name + provider:
+  `via codex-research · GPT-5 mini · …`.
+
+## Error and lifecycle handling
+
+| Event | Behavior |
+|---|---|
+| Sub-session fails to start | Bridge returns an `is_error: true` MCP tool_result with the failure reason. Parent agent sees it as a normal failed tool call and decides what to do (usually: try without sub-agent). |
+| Sub-session hits `maxTurns` | Bridge returns whatever final text the sub-agent produced + a marker noting truncation. |
+| Parent session interrupted while sub-session is running | Bridge cancels the sub-session via the target driver's `interrupt()`. Sub-session emits `Completed { reason: "interrupted" }`, bridge returns an aborted tool_result to the parent. |
+| User hits "stop" on the sub-agent's wrapper row directly | New "interrupt sub-agent" affordance: cancels just the sub-session, parent continues with the partial result. Renderer-only change once the cancel-by-itemId RPC exists. |
+| Cross-provider auth missing | Bridge surfaces the missing-credentials error as an MCP tool_result; renderer's existing `Auth` event handling lights up the credentials sheet. |
+
+## Cost accounting across providers
+
+Phase 1's `UsageDelta` already carries `model`. Phase 2 extends the
+renderer's pricing table with Codex pricing:
+
+```ts
+export const MODEL_PRICING = {
+  // Claude (from Phase 1)
+  "claude-opus-4-7":   { input: 15, output: 75, /* … */ },
+  // Codex
+  "gpt-5":             { input:  3, output: 12, cacheRead: 0.30, cacheCreate:  3.0 },
+  "gpt-5-mini":        { input: 0.5, output:  2, cacheRead: 0.05, cacheCreate:  0.5 },
+  // …
+};
+```
+
+The transcript footer becomes:
+
+```
+Opus: 4.2k · Codex mini (codex-research): 22.1k · saved ~$0.41
+```
+
+## UI
+
+No new UI components beyond Phase 1. The wrapper row's badge changes:
+
+```
+🤖 Agent → Codex (gpt-5-mini)  Find every place we register an RPC handler  ▾
+   📋 Prompt
+   📁 Glob …
+   …
+```
+
+The arrow + provider name on the badge is the *only* visual cue that
+this is cross-provider. Inside the wrapper, nested tool rows look
+identical to Claude-side rows because the wire schema is the same.
+
+## What's still deferred after Phase 2
+
+- **Provider-agnostic agent definitions.** Today an `AgentDefinition`
+  lists Claude tool names. A Codex sub-agent gets the closest mapping
+  the bridge can manage. A future cleanup is a `tool-name` translation
+  layer in `packages/wire/src/tools.ts`.
+- **Model auto-selection.** Today the user picks the sub-agent's
+  model. Future: forkzero suggests "based on this prompt, gpt-5-mini
+  would be ~3× cheaper than Haiku for the same quality, switch?"
+- **Parallel cross-provider fan-out.** Phase 2's bridge is one
+  sub-session at a time. Real fan-out (run `research` on Claude *and*
+  Codex, take whichever finishes first) is a separate concern.
+
+## Implementation order (when Phase 2 lands)
+
+1. `apps/server/src/provider/mcp/forkzero-bridge.ts` + register with
+   the parent driver's MCP layer.
+2. `CrossProviderInvocationEvent` in `packages/wire/src/agent.ts`.
+3. Cross-provider preset entries in
+   `apps/renderer/src/lib/subagent-presets.ts`.
+4. Renderer badge update + provider arrow icon.
+5. Settings UI cross-provider section.
+6. Mirror sensitive-path checks into the Codex driver.
+
+ADR [0012-codex-bridge-via-mcp.md](../decisions/0012-codex-bridge-via-mcp.md)
+records the "MCP bridge, not SDK fork" decision.

--- a/specs/sub-agents/features/preset-library.md
+++ b/specs/sub-agents/features/preset-library.md
@@ -1,0 +1,165 @@
+# Feature: Preset library
+
+The three sub-agents that ship by default. They cover the cases where
+delegating to a cheaper model is unambiguously a win:
+
+1. **`research`** — read-only codebase exploration.
+2. **`file-edits`** — well-scoped file changes.
+3. **`test-runner`** — running a test suite and parsing output.
+
+These ship enabled out-of-the-box (assuming the Claude provider is
+configured). The user can toggle each, edit each, or disable the whole
+feature in settings.
+
+The presets live in `apps/renderer/src/lib/subagent-presets.ts` and the
+server reads the same file via the wire (sent as part of
+`StartSessionInput.agents` when starting a session). Single source of
+truth in TypeScript.
+
+## `research` — Haiku 4.5
+
+The single highest-value preset. Almost every Opus session today spends
+a meaningful fraction of its tokens on `Glob` / `Grep` / `Read` chains
+just to find the right file before doing the actual work. Routing those
+to Haiku is the obvious win.
+
+```ts
+{
+  description:
+    "Read-only codebase exploration. Use when you need to find files, " +
+    "understand patterns, list usages of a symbol, or summarize " +
+    "unfamiliar code. The agent has Read, Glob, and Grep — no edit, " +
+    "no Bash, no network. Best for 'find every place that does X' " +
+    "or 'how does Y work in this codebase' before making a change.",
+  prompt:
+    "You are a codebase research assistant. Your job is to find and " +
+    "summarize information from the project. You have read-only " +
+    "tools: Read, Glob, Grep. Be efficient — search precisely, read " +
+    "only what's needed, return a concise summary that fully answers " +
+    "the parent's question. Cite file paths and line numbers. Don't " +
+    "speculate beyond the code you've actually read.",
+  tools: ["Read", "Glob", "Grep"],
+  model: "claude-haiku-4-5",
+  maxTurns: 25,
+}
+```
+
+**Why Haiku**: research is search-heavy and reasoning-light. Haiku is
+fast enough that the round-trip latency stays acceptable, and the
+read-only tool set keeps the blast radius zero. ADR
+[0011-haiku-as-default-research.md](../decisions/0011-haiku-as-default-research.md)
+covers this in full.
+
+**Why `maxTurns: 25`**: most "find X" tasks complete in under 10 turns;
+25 is generous headroom that still bounds runaway exploration if the
+agent gets stuck in a `grep → read → grep` loop.
+
+## `file-edits` — Sonnet 4.6
+
+Routine refactors and multi-file edits where the *what* is well-defined
+but the *where* is repetitive. Sonnet is the right tier — Haiku
+sometimes hallucinates imports or misreads context on multi-file edits;
+Opus is overkill for "rename this prop in 14 files."
+
+```ts
+{
+  description:
+    "Apply a well-defined file change. Use for routine refactors, " +
+    "renames, prop additions, or any multi-file edit where the parent " +
+    "agent has already decided what to change and just needs it " +
+    "executed. Don't use this when the change requires architecture " +
+    "decisions — keep that on the main model.",
+  prompt:
+    "You are a file editor. Apply the change described in the prompt " +
+    "exactly. Read each file before editing it. Preserve existing " +
+    "style — indentation, quote style, import order. If the change is " +
+    "ambiguous, return without editing and ask the parent to clarify. " +
+    "Don't refactor adjacent code, don't add comments, don't 'improve' " +
+    "anything that isn't part of the requested change.",
+  tools: ["Read", "Edit", "Write", "Glob"],
+  model: "claude-sonnet-4-6",
+  maxTurns: 40,
+}
+```
+
+**Why Sonnet, not Haiku**: edits to TypeScript/TSX with proper import
+preservation and JSX formatting are where Haiku's lower coding accuracy
+starts to bite. Sonnet 4.6 is the cheapest Claude tier we trust for
+direct code modification.
+
+**Why no `Bash`**: deliberate. File-edit sub-agents shouldn't be
+running `bun install` or `git commit`. If a follow-up command is
+needed, the parent agent runs it in main context where the user can see
+the output.
+
+## `test-runner` — Haiku 4.5
+
+Running a test command and parsing the output is exactly the
+"high-token-volume, low-reasoning" case sub-agents are good for. A
+1000-line vitest output flattens to "3 failures in `auth.test.ts`,
+here's the assertion text" — the parent doesn't need the rest.
+
+```ts
+{
+  description:
+    "Run a test suite and parse the output. Use after making changes " +
+    "to verify nothing broke, or when the parent needs to see what's " +
+    "currently failing. The agent runs the project's test command " +
+    "(e.g. `bun test`, `vitest`, `pytest`) and returns a summary of " +
+    "pass/fail counts plus the assertion text for any failures.",
+  prompt:
+    "You are a test runner. Detect the project's test command from " +
+    "package.json scripts or by asking the parent. Run it. Parse the " +
+    "output. Return: total passed, total failed, total skipped, and " +
+    "for each failure, the test name + the assertion message + the " +
+    "first frame of the stack that points to project code (skip " +
+    "framework frames). Don't try to fix the failures — just report.",
+  tools: ["Bash", "Read", "Grep"],
+  model: "claude-haiku-4-5",
+  maxTurns: 15,
+  permissionMode: "default",   // Bash always prompts unless allowlisted
+}
+```
+
+**Why `permissionMode: "default"`**: `Bash` is the highest-blast-radius
+tool. We don't want the test-runner sub-agent to silently `rm -rf`
+something because the user gave the main session full-access mode. The
+sub-agent's `permissionMode` shadows the session's runtime mode for its
+own tool calls.
+
+**Failure mode to watch**: if the sub-agent guesses the wrong test
+command and runs something destructive instead, the sensitive-path
+checks won't catch it. Mitigation is the prompt's emphasis on
+*detecting* the command from `package.json` rather than inferring.
+
+## Disabled-by-default candidates (not shipped yet)
+
+Listed here so the next round has somewhere to land.
+
+- **`pr-summary`** — read git diff, write a PR description.
+  Read-only-ish; Haiku is fine. Defer until Phase 2's git surface
+  exists.
+- **`error-classifier`** — given a stack trace, find the source line
+  and classify the error category. Niche.
+- **`migration-planner`** — analyze a database migration for safety.
+  Specialized; needs Sonnet.
+- **`codex-bridge`** — proxy to a Codex sub-session. Phase 2 (see
+  [cross-provider.md](cross-provider.md)).
+
+## How the user picks which presets to enable
+
+See [sub-agents.md](sub-agents.md) → "Settings" — the full settings page
+section with toggles, model dropdowns, and per-preset edit sheets.
+Defaults: all three enabled if the user has the Claude provider
+configured.
+
+## Telemetry / observability hooks
+
+Each preset run logs (locally, to the existing forkzero log file):
+
+```
+[subagent.research] turns=8 in=12.4k out=312 cache_read=4.2k duration=3.1s
+```
+
+Useful for tuning prompts and `maxTurns` after we see real usage. No
+network telemetry — forkzero is local-only by principle.

--- a/specs/sub-agents/features/sub-agents.md
+++ b/specs/sub-agents/features/sub-agents.md
@@ -1,0 +1,441 @@
+# Feature: Sub-agents
+
+The main agent (Opus 4.7 by default for Claude sessions) can delegate
+scoped sub-tasks to cheaper sub-agents (Haiku 4.5 / Sonnet 4.6). Each
+sub-agent runs in its own context window with its own system prompt and
+tool subset; only the final summary returns to the parent's context.
+
+This document covers the wire schema, the driver, persistence, the UI
+wrapper-row design, the permission flow, and the per-agent token
+accounting. The seed sub-agents themselves are in
+[preset-library.md](preset-library.md). Cross-provider bridging (Claude
+main → Codex sub) is in [cross-provider.md](cross-provider.md).
+
+## Why this works without re-architecting
+
+The Claude Agent SDK already exposes the primitive. From
+`@anthropic-ai/claude-agent-sdk`:
+
+```ts
+type Options = {
+  // …
+  allowedTools?: string[];                       // must include "Agent"
+  agents?: Record<string, AgentDefinition>;       // ← the new lever
+};
+
+type AgentDefinition = {
+  description: string;        // when Claude should delegate to this agent
+  prompt: string;             // the agent's system prompt
+  tools?: string[];           // allowlist; omit to inherit
+  disallowedTools?: string[]; // denylist
+  model?: "sonnet" | "opus" | "haiku" | "inherit" | string; // alias or full id
+  maxTurns?: number;
+  permissionMode?: PermissionMode;
+};
+```
+
+When `Agent` is in `allowedTools` and the user (or main agent) hits a task
+that matches an agent's `description`, the SDK emits a `tool_use` block
+with `name: "Agent"` and an input shape `{ subagent_type, prompt, model? }`.
+Subsequent SDK messages carry `parent_tool_use_id` pointing to that
+`tool_use.id`, marking them as "from inside the sub-agent's context."
+When the sub-agent finishes, a `tool_result` for that id lands carrying
+the sub-agent's final message as text.
+
+Forkzero's job is therefore narrow:
+
+1. Forward an `agents` map from the wire into the SDK options.
+2. Propagate `parent_tool_use_id` onto every emitted wire event.
+3. Render nested events under a wrapper row in the renderer.
+4. Persist the `parent_item_id` chain so resume works.
+5. Surface per-agent token cost.
+
+That's the whole feature. No new agent runtime, no manual orchestration.
+
+## Wire schema deltas
+
+All edits live in `packages/wire/src/agent.ts`.
+
+### New schema: `AgentDefinition`
+
+Mirror of the SDK shape (subset that we expose today):
+
+```ts
+export const AgentDefinition = Schema.Struct({
+  description: Schema.String,
+  prompt: Schema.String,
+  tools: Schema.optional(Schema.Array(Schema.String)),
+  disallowedTools: Schema.optional(Schema.Array(Schema.String)),
+  model: Schema.optional(Schema.String),
+  maxTurns: Schema.optional(Schema.Number),
+  // permissionMode reuses our existing RuntimeMode literal set.
+  permissionMode: Schema.optional(RuntimeMode),
+});
+export type AgentDefinition = typeof AgentDefinition.Type;
+```
+
+We do **not** expose `skills`, `mcpServers`, `memory`, `effort`,
+`background`, or `isolation` in this PR. They're additive — each can come
+back as a follow-up if a use case appears.
+
+### `StartSessionInput` extension
+
+```ts
+export const StartSessionInput = Schema.Struct({
+  folderId: FolderId,
+  providerId: ProviderId,
+  mode: SessionMode,
+  initialPrompt: Schema.optional(Schema.String),
+  sessionId: Schema.optional(AgentSessionId),
+  model: Schema.optional(Schema.String),
+  // NEW
+  agents: Schema.optional(Schema.Record({
+    key: Schema.String,
+    value: AgentDefinition,
+  })),
+  enableSubagents: Schema.optional(Schema.Boolean), // defaults true when agents non-empty
+});
+```
+
+### `parentItemId` on streamed events
+
+Every event that can originate from inside a sub-agent gains an optional
+`parentItemId: AgentItemId`. Concretely:
+
+- `AssistantMessageEvent`
+- `ThinkingEvent`
+- `ToolUseEvent`
+- `ToolResultEvent`
+- `PermissionRequestEvent` (so the toast can label the requester)
+
+Existing top-level events (`Started`, `Status`, `Auth`, `Capabilities`,
+`SessionCursor`, `Completed`, `Error`) are not affected — they belong to
+the parent session.
+
+### New event: `SubagentSummary`
+
+Emitted when the parent's `tool_result` for an `Agent` tool_use lands. The
+wrapper-row footer reads from this when collapsed.
+
+```ts
+const SubagentSummaryEvent = Schema.TaggedStruct("SubagentSummary", {
+  itemId: AgentItemId,            // matches the parent ToolUse.itemId
+  agentName: Schema.String,        // e.g. "research"
+  model: Schema.String,            // e.g. "claude-haiku-4-5"
+  turns: Schema.Number,            // sub-agent turn count
+  durationMs: Schema.Number,
+  summary: Schema.String,          // sub-agent's final assistant text
+  isError: Schema.Boolean,
+});
+```
+
+### New event: `UsageDelta`
+
+Per-turn usage for the agent that just emitted a `result` message. Tagged
+with the same `parentItemId` rule as other nested events; absent
+`parentItemId` means the usage belongs to the main agent.
+
+```ts
+const UsageDeltaEvent = Schema.TaggedStruct("UsageDelta", {
+  parentItemId: Schema.optional(AgentItemId),
+  inputTokens: Schema.Number,
+  outputTokens: Schema.Number,
+  cacheReadTokens: Schema.Number,
+  cacheCreationTokens: Schema.Number,
+  model: Schema.String,
+});
+```
+
+Pricing is computed renderer-side from a static table next to
+`MODELS_BY_PROVIDER`. The wire stays just numbers.
+
+### New static export: `MODEL_PRICING`
+
+```ts
+// USD per million tokens (input, output, cache_read, cache_create).
+export const MODEL_PRICING: Record<string, {
+  input: number; output: number; cacheRead: number; cacheCreate: number;
+}> = {
+  "claude-opus-4-7":   { input: 15, output: 75, cacheRead: 1.50, cacheCreate: 18.75 },
+  "claude-sonnet-4-6": { input:  3, output: 15, cacheRead: 0.30, cacheCreate:  3.75 },
+  "claude-haiku-4-5":  { input:  1, output:  5, cacheRead: 0.10, cacheCreate:  1.25 },
+};
+```
+
+(Numbers are illustrative; actual table populated from current pricing at
+implementation time and updated alongside `MODELS_BY_PROVIDER`.)
+
+## Driver changes
+
+All edits live in `apps/server/src/provider/drivers/claude.ts`.
+
+### `start()` — pass `agents` into SDK options
+
+```ts
+const options: Options = {
+  // …existing config…
+  agents: input.agents ?? {},
+  allowedTools: hasAgents
+    ? Array.from(new Set([...(existing ?? []), "Agent"]))
+    : existing,
+};
+```
+
+If `enableSubagents === false` (or no `agents` map provided), we leave
+`allowedTools` alone and the `Agent` tool stays unavailable. This is the
+"opt-out" path — sessions without sub-agent presets behave identically to
+today.
+
+### `translate()` — propagate `parent_tool_use_id`
+
+The current `translate()` produces wire events from SDK messages. Every
+SDK `assistant`, `user`, and `result` message carries an optional
+`parent_tool_use_id` field. Update the function signature:
+
+```ts
+const translate = (
+  msg: SDKMessage,
+  state: TranslateState,
+): ReadonlyArray<AgentEvent> => {
+  const parentItemId =
+    typeof (msg as { parent_tool_use_id?: unknown }).parent_tool_use_id === "string"
+      ? ((msg as { parent_tool_use_id: string }).parent_tool_use_id as AgentItemId)
+      : undefined;
+
+  // …existing branches, but each output event spreads `parentItemId` if defined
+};
+```
+
+Every `AssistantMessage`, `Thinking`, `ToolUse`, `ToolResult` produced
+inside the function gets `parentItemId` attached when it's set on the SDK
+message.
+
+### Match both `"Agent"` and `"Task"`
+
+Per Anthropic's [SDK subagents doc](https://code.claude.com/docs/en/agent-sdk/subagents),
+the tool was renamed from `"Task"` to `"Agent"` in v2.1.63 but both names
+still appear (current versions emit `"Agent"` in `tool_use` blocks but
+still use `"Task"` in `system:init` tools list and
+`result.permission_denials[].tool_name`). When detecting a sub-agent
+invocation, accept either:
+
+```ts
+const isAgentToolUse = (block: { type: string; name?: string }) =>
+  block.type === "tool_use" && (block.name === "Agent" || block.name === "Task");
+```
+
+### Emit `SubagentSummary` on tool_result
+
+When a `tool_result` lands whose `tool_use_id` matches a previously seen
+`Agent`/`Task` tool_use:
+
+```ts
+const summary: SubagentSummary = {
+  _tag: "SubagentSummary",
+  itemId: block.tool_use_id as AgentItemId,
+  agentName: pendingAgent.subagent_type,
+  model: pendingAgent.model ?? "inherit",
+  turns: pendingAgent.turnCount,
+  durationMs: Date.now() - pendingAgent.startedAt,
+  summary: extractText(block.content),
+  isError: block.is_error === true,
+};
+```
+
+`pendingAgent` is a small in-handle map keyed by `tool_use.id`,
+populated when the parent emits the `Agent` tool_use and updated as
+nested SDK messages land.
+
+### Emit `UsageDelta`
+
+Each SDK `result` message carries `usage`. Emit a `UsageDelta` with the
+correct `parentItemId` (if the result has `parent_tool_use_id`, this
+result belongs to the sub-agent; otherwise it's main-agent usage).
+
+### Sensitive paths still apply
+
+`policyFor()` (`claude.ts:484`) is unchanged. `parent_tool_use_id` is a
+*hint* for the permission UI, not a policy lever. A sub-agent reading
+`~/.ssh/id_rsa` still triggers the sensitive-path prompt.
+
+## Provider service
+
+`apps/server/src/provider/services/provider-service.ts` plumbs
+`agents` and `enableSubagents` through to the driver and persists the
+config onto the session row. On resume, it reads `agents_json` back and
+passes it into `start()` so the resumed session has the same sub-agent
+roster as when it was created.
+
+## Persistence
+
+`apps/server/src/provider/layers/message-store.ts` adds two columns:
+
+- `sessions.agents_json TEXT NULL` — JSON-serialized `agents` map.
+- `messages.parent_item_id TEXT NULL` — references the parent
+  `Agent`/`Task` tool_use's `itemId`. Nullable; null means "top-level."
+
+Migration is additive (Phase 1 SQLite migrations are append-only). Insert
+path: when the driver emits a wire event with `parentItemId`, persist
+that value on the row. The renderer reads `messages.*` and builds the
+nesting client-side.
+
+Sub-agent message rows are stored just like main-agent rows — same
+table, same columns. Keeps the export / scrollback / search story
+unchanged. Renderer logic is one line: "if `parent_item_id` is set, group
+under that parent."
+
+## UI — "Agent is just one more wrapper row"
+
+The `Agent` tool call IS a tool call. The wrapper row visually mirrors
+the existing `tool-row.tsx` style (hugeicons + muted-foreground + chevron
+swap on hover, per the project's [accordion pattern](../../../.claude/projects/-Users-whizzy-Developer-startups-forkzero/memory/feedback_accordion_pattern.md)
+and [icon convention](../../../.claude/projects/-Users-whizzy-Developer-startups-forkzero/memory/feedback_icons_hugeicons.md)).
+
+Inside, every nested call uses `tool-row.tsx` *unchanged*, with a single
+`indented` prop that draws a left rail.
+
+```
+🤖 Agent  Find syndicate card on investor dashboard      ▾
+   📋 Prompt
+   📁 Glob  apps/web/**/*syndicate*
+   📁 Glob  apps/web/**/*investor*
+   🔍 grep for 'View syndicate' in apps/web   5 matches
+   📄 Read 235 lines    [syndicate-card.tsx]
+   📁 Glob  apps/web/src/app/**/*investor*page*
+   📄 Read 672 lines    [page.tsx]
+   ▶ Bash  grep -n "CardFrame…"
+   📄 Read 287 lines    [card.tsx]
+   Perfect! Now I have all the information needed. Let me create a comprehensive report:
+```
+
+### Components
+
+| Component | Path | Change |
+|---|---|---|
+| `subagent-row.tsx` | `apps/renderer/src/components/subagent-row.tsx` | NEW. Layout shell. |
+| `tool-row.tsx` | `apps/renderer/src/components/tool-row.tsx` | Add `indented` prop. |
+| `message-row.tsx` | `apps/renderer/src/components/message-row.tsx` | Route by `parentItemId`. |
+| `chat-view.tsx` | `apps/renderer/src/components/chat-view.tsx` | Render top-level events through grouping. |
+| `permission-toast.tsx` | `apps/renderer/src/components/permission-toast.tsx` | Prepend "via *agent name* · *model* ·" when `parentItemId` is set. |
+| `messages.ts` | `apps/renderer/src/store/messages.ts` | Derive `byParent: Map<AgentItemId, AgentEvent[]>`. |
+| `chat-composer.tsx` | `apps/renderer/src/components/chat-composer.tsx` | "↳ Sub-agents: 3 enabled" chip → opens settings. |
+
+### `subagent-row.tsx` shape
+
+```tsx
+type Props = {
+  agentItemId: AgentItemId;
+  agentName: string;       // "research"
+  prompt: string;          // first arg of Agent tool_use input
+  model?: string;          // "claude-haiku-4-5"
+  status: "running" | "completed" | "error";
+  // children pulled from store.byParent.get(agentItemId)
+};
+```
+
+The row layout reuses the same grid template `tool-row.tsx` uses today —
+icon cell, label cell, inline-chip cell, trailing meta cell. The only
+new sub-element is the `Prompt` row at the top of the children list,
+rendered as a clipboard-icon row with the same styling.
+
+### Default expansion behavior
+
+- **Live-streaming** (status === "running"): expanded so the user can
+  watch the sub-agent work.
+- **Completed**: auto-collapse to a single-row meta line:
+  `Haiku 4.5 · 7 tools · 18.4k tok · ~$0.02`. Click expands.
+- **Error**: stay expanded so the user sees the failure context.
+
+### Indent depth
+
+Sub-agents cannot themselves spawn sub-agents (SDK constraint), so the
+renderer only ever needs `depth ∈ {0, 1}`. `tool-row.tsx`'s `indented`
+prop is a boolean — sufficient until the constraint changes upstream.
+
+## Settings
+
+This ships a **full settings page section**, not a per-session picker.
+
+`apps/renderer/src/components/settings-page.tsx` already exists. We add a
+new section: **Sub-agents**. Layout:
+
+```
+┌─ Sub-agents ─────────────────────────────────────────────┐
+│  Let your main agent delegate scoped tasks to cheaper    │
+│  models. Saves tokens on long sessions.                  │
+│  [☑] Enable sub-agents for new sessions                  │
+│                                                          │
+│  ┌───────────────────────────────────────────────────┐   │
+│  │ ☑  research                          Haiku 4.5 ▾  │   │
+│  │    Read-only codebase exploration.   [Edit ▸]     │   │
+│  ├───────────────────────────────────────────────────┤   │
+│  │ ☑  file-edits                       Sonnet 4.6 ▾  │   │
+│  │    Apply well-defined file changes.  [Edit ▸]     │   │
+│  ├───────────────────────────────────────────────────┤   │
+│  │ ☑  test-runner                       Haiku 4.5 ▾  │   │
+│  │    Run a test suite, report.         [Edit ▸]     │   │
+│  └───────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────┘
+```
+
+- Master toggle gates `enableSubagents` for *new* sessions. Existing
+  sessions keep whatever was set when they were created (resume parity).
+- Per-preset toggle controls inclusion in the `agents` map sent to the
+  driver.
+- Model dropdown — values come from
+  `MODELS_BY_PROVIDER["claude"]`. Changing it updates the preset for
+  future sessions.
+- **Edit** opens a sheet with `description`, `prompt`, `tools` (multi-select
+  from the known tool names), `maxTurns`. No "create new" button in this
+  PR — only the three seeds, editable.
+- All settings persist via the existing settings RPC into the same JSON
+  store used by other preferences. New file: `subagents.json`.
+
+A new Zustand slice `store/subagents.ts` reads/writes this.
+
+The `chat-composer.tsx` chip ("↳ Sub-agents: 3 enabled") clicks through
+to this section.
+
+## Permissions
+
+Sub-agent tool calls flow through the **same** `canUseTool` callback. No
+new RPC, no new policy.
+
+- **Toast text**: when the call has `parent_tool_use_id`, prepend
+  `via research · Haiku 4.5 ·` to the existing message. One-line change
+  in `permission-toast.tsx`. Source the human name from the
+  `subagent-presets` lookup.
+- **Permissions inspector**: row gets a small "agent" badge showing the
+  sub-agent's name when nested. Filter chip "Show only sub-agent calls"
+  added to the inspector header.
+- **Sensitive paths**: unchanged. `.env`, `.ssh/`, `*.pem` etc. always
+  prompt regardless of nesting.
+- **Always-allow scope**: the existing always-allow rules apply across
+  the whole session, not per-agent. (Per-agent allow lists are a
+  legitimate request but out of scope here.)
+
+## Cost surfacing
+
+The transcript footer (small text below the latest assistant message)
+gains a per-agent breakdown:
+
+```
+Opus: 4.2k in / 1.1k out · Haiku (research): 18.4k in / 412 out · saved ~$0.34
+```
+
+"Saved" is computed as: cost the entire transcript would have been if
+all sub-agent turns ran on the main model, minus actual cost. Pure
+visualization — no functional impact.
+
+Renderer reads `MODEL_PRICING` from `@forkzero/wire`. When a sub-agent
+finishes, the cumulative numbers update in place.
+
+## Open questions left for implementation
+
+- **Default `enableSubagents` value for *new* sessions.** Likely `true`
+  when at least one preset is enabled and the session model is Opus
+  (highest savings); otherwise `false`. To be confirmed with a couple of
+  smoke runs.
+- **Auto-collapse threshold.** Sub-agents that finished in <2s might be
+  noise — consider auto-hiding entirely (with a "+1 sub-agent run" chip
+  to expand). Defer until we see real usage.


### PR DESCRIPTION
## Summary

- New spec under `specs/sub-agents/` for letting the main agent (Opus 4.7) delegate scoped sub-tasks to cheaper sub-agents (Haiku 4.5 / Sonnet 4.6). Big-context exploration runs on Haiku rates while Opus only sees the distilled summary.
- Built on the Claude Agent SDK's native `agents` parameter — wire-format + UI work, no new agent runtime.
- UI is "Agent is just one more wrapper row": same `tool-row.tsx` design, nested calls render unchanged inside, `Prompt` sub-row at top, sub-agent's closing text inside the wrapper. Auto-collapses on completion to `Haiku 4.5 · 7 tools · 18k tok`.
- Three seed presets: `research` (Haiku, read-only), `file-edits` (Sonnet), `test-runner` (Haiku, Bash-prompts-always).
- Full Phase 2 sketch for cross-provider (Claude ↔ Codex) via an internal MCP bridge tool — implementation deferred but wire format is forward-compatible.

## What's in the spec

- `README.md` — phase split, what ships, what's deferred
- `features/sub-agents.md` — wire deltas, driver changes, persistence, UI wrapper, full settings page section, permissions, cost accounting
- `features/preset-library.md` — the three seed sub-agents with full prompts and tool-sets
- `features/cross-provider.md` — full Phase 2 sketch (MCP bridge, error table, UI badge)
- `decisions/0010-sdk-native-agents-param.md` — SDK primitive over hand-rolled router
- `decisions/0011-haiku-as-default-research.md` — cheap-model default for the highest-traffic preset
- `decisions/0012-codex-bridge-via-mcp.md` — MCP bridge over SDK fork

## Test plan

- [ ] Read `README.md` end-to-end and confirm phase split is right
- [ ] Skim `features/sub-agents.md` — confirm wire schema deltas (`parentItemId`, `SubagentSummary`, `UsageDelta`) cover the cases you want
- [ ] Confirm UI wrapper-row spec matches the screenshot you shared
- [ ] Confirm settings is full page (vs per-session picker)
- [ ] Confirm Phase 2 sketch is detailed enough that the next PR can pick it up
- [ ] Sanity check the three preset prompts in `preset-library.md` — these will ship as defaults