### PR TITLE
[codex] Add composer 2.0 spec

### DIFF
--- a/specs/0.03-MVP/README.md
+++ b/specs/0.03-MVP/README.md
@@ -1,0 +1,70 @@
+# MVP 0.03 — Composer 2.0
+
+MVP 0.02 (everything under [../0.02-MVP/](../0.02-MVP/)) brought the file
+viewer/editor to the main pane. MVP 0.03 brings the same level of polish to
+the chat composer: the textarea becomes a real editor with inline atomic
+chips for files and images, slash commands and skills are surfaced inline,
+images are attached by paste/drop, and messages typed mid-turn become
+first-class queued items the user can steer into the running conversation.
+
+## What lands in 0.03
+
+- **Slash commands**. Typing `/` opens a popover with built-in commands
+  (`/clear`, `/new`, `/model`, `/mode`, `/help`) plus the active provider's
+  skills.
+- **Skills**, scoped to the active session's provider. Claude sessions show
+  skills the Claude SDK reports from `~/.claude/skills/` and project-level
+  `.claude/skills/`; Codex sessions show skills the Codex CLI reports from
+  `~/.codex/skills/` and project-level `.codex/skills/`. Forkzero owns no
+  skill directory of its own.
+- **File tagging via `@`**. Typing `@` opens a workspace-aware file picker;
+  picking a file inserts an inline atomic chip (icon | label) at the cursor.
+- **Image attachments** by drag-drop, paste, or paperclip button. Images
+  render as inline atomic chips with a thumbnail; binaries are persisted
+  under the app's userData directory and served back to the renderer via a
+  custom `forkzero://attachments/<id>` protocol. The data model reserves
+  cloud fields so sync can land later without changing message history.
+- **`Enter` to send**, `Shift+Enter` for newline. `Cmd+Enter` continues to
+  work as a backstop.
+- **Mid-turn message queue with Steer**. Pressing `Enter` while a turn is
+  in flight puts the message into a queue rendered as a chip strip above
+  the editor. Each queue chip carries an arrow icon (hover tooltip
+  `"Steer"`) that interrupts the running turn and sends the queued text as
+  the next user turn. Anything still queued when the turn ends naturally
+  auto-flushes in order.
+
+## What's deliberately deferred
+
+- Cloud sync execution. 0.03 defines the local path, database columns,
+  cloud object-key shape, and resolution order; the uploader worker itself
+  is deferred.
+- In-app skill authoring UI. Users edit skill markdown in their editor of
+  choice, in the destination directory of their choice.
+- Image *output* / agent-generated images. 0.03 covers user image *input*.
+- Boundary-aware steer (interrupting only at safe tool-call boundaries
+  rather than mid-token). Useful polish; not in scope for v1.
+- Multi-cursor or rich-text formatting in the composer. The editor is for
+  prose with chips, not for code.
+- Inline-rendered code chips for symbol mentions. The chip primitive
+  supports it; the search backend does not.
+
+## Where to read
+
+- [features/composer.md](features/composer.md) — editor surface, inline
+  chips, slash & file popovers, image attachments, keymap, RPCs.
+- [features/skills.md](features/skills.md) — provider-delegated skill
+  discovery and resolution at send time.
+- [features/queue-and-steer.md](features/queue-and-steer.md) — mid-turn
+  queue, Steer arrow, RPC contract, auto-flush behavior.
+- [decisions/0010-codemirror-composer.md](decisions/0010-codemirror-composer.md) —
+  CodeMirror 6 with a prose preset + atomic widget decorations for the
+  composer.
+- [decisions/0011-skills-via-provider.md](decisions/0011-skills-via-provider.md) —
+  why skill discovery is delegated to the provider driver instead of a
+  forkzero-owned directory.
+- [decisions/0012-steer-via-interrupt.md](decisions/0012-steer-via-interrupt.md) —
+  why "Steer" is interrupt + send rather than mid-stream injection.
+
+## Status
+
+📐 **Spec** — ready for implementation.

--- a/specs/0.03-MVP/decisions/0010-codemirror-composer.md
+++ b/specs/0.03-MVP/decisions/0010-codemirror-composer.md
@@ -1,0 +1,114 @@
+# 0010 — CodeMirror 6 for the chat composer (with atomic widget chips)
+
+Status: Accepted (2026-05-04)
+
+## Context
+
+MVP 0.03 introduces inline atomic chips inside the chat composer:
+file mentions, directory mentions, image attachments, and skill
+invocations all render as `[icon | label]` blocks that the cursor
+treats as one position and that backspace removes whole.
+
+A plain `<textarea>` cannot render inline non-editable atoms — text
+inside a textarea is a flat character stream with no DOM hooks for
+widgets. To deliver the chip UX, the composer needs a real
+text-editing surface.
+
+ADR 0009 (file viewer/editor, MVP 0.02) already chose CodeMirror 6 for
+the in-app file editor on the strength of its extension model. That
+choice is now load-bearing for 0.03 too: if the composer picks a
+different editor, forkzero pays for two editor mental models, two
+selection systems, and two extension surfaces — and the future Cmd+K
+inline-AI command in 0.02's roadmap has to be implemented twice.
+
+## Options
+
+### Option A — CodeMirror 6 with a "prose" preset
+
+- Same dependency forkzero already accepts in ADR 0009.
+- Atomic widget decorations (`Decoration.replace({ widget, atomic: true })`
+  combined with `EditorView.atomicRanges`) are the chip primitive.
+- Selection, cursor stepping, copy/paste, undo, IME, and accessibility
+  are CodeMirror's responsibility.
+- Slash and file triggers, paste/drop image handling, and the Enter
+  keymap are all composable extensions — single mental model.
+- The future Cmd+K-on-selection extension carries forward from the file
+  editor with no additional work.
+- "Prose preset" is a small custom config: no gutter, no line numbers,
+  soft-wrap on, auto-grow with min/max heights, placeholder via the
+  `placeholder` extension.
+
+### Option B — A new rich-text framework (Lexical, Tiptap/ProseMirror, Slate)
+
+- Purpose-built for chip-style inline tokens with first-class APIs.
+- Cost: a new top-level dependency (Lexical ≈ 80 KB, Tiptap+ProseMirror
+  ≈ 130 KB) plus a parallel selection / decoration mental model
+  alongside the CodeMirror surface in the file editor.
+- The Cmd+K-on-selection feature (carried forward from 0.02) would have
+  to be implemented twice — once for the editor (CodeMirror), once for
+  the composer (Lexical/Tiptap).
+
+### Option C — Hand-rolled `contenteditable`
+
+- Smallest possible dependency footprint.
+- Hand-rolling selection, cursor stepping over widget elements, paste
+  sanitization, IME composition, undo/redo, and accessibility for a
+  rich editor is a known sinkhole. Every browser version reveals new
+  edge cases.
+- Even the proposed v1 chip behaviors (backspace whole, arrow-step,
+  atomic copy) would consume substantial composer budget, leaving the
+  popovers and queue tray to a later phase.
+
+## Decision
+
+**Option A: CodeMirror 6 with a prose preset and atomic widget
+decorations for chips.**
+
+It is the only option that:
+
+- Adds zero new dependencies.
+- Lets the file editor and the composer share one selection /
+  decoration / transaction model (so future editor work, including
+  Cmd+K-on-selection, lands in both surfaces from one extension).
+- Has a chip primitive (`Decoration.replace` + `atomicRanges`) that
+  matches the screenshot UX exactly.
+- Trades only the "prose-feel" defaults — and those are addressable
+  with a small extension config.
+
+## Consequences
+
+- The composer host is split, mirroring the 0.02 file editor split:
+
+  ```
+  apps/renderer/src/lib/codemirror/composer.ts            EditorView factory + prose preset
+  apps/renderer/src/lib/codemirror/composer-chips.ts      WidgetType + atomicRange decoration
+  apps/renderer/src/lib/codemirror/composer-triggers.ts   `/` and `@` detection extensions
+  apps/renderer/src/lib/codemirror/composer-keymap.ts     Enter / Shift-Enter / Cmd-Enter
+  apps/renderer/src/components/chat-composer.tsx          React lifecycle, popover wiring
+  ```
+
+  This separation gives slash commands, file tagging, paste/drop image
+  handling, and the queue tray each a single new file rather than a
+  monolithic rewrite.
+
+- The chip DOM is a minimal `<span class="fz-chip">[icon][divider][label]</span>`
+  rendered by a `WidgetType`. Styling is Tailwind-only; no icons live
+  in the widget itself — the React layer renders the icon SVG into the
+  widget's host `span` so Material Icon Theme (added in 0.02) and
+  lucide icons stay in React, not in CodeMirror.
+
+- Document serialization is one direction at submit time: the composer
+  walks the document, treating each chip range as a typed segment and
+  the rest as text. The plain-text token form (`@<relPath>`,
+  `[image: <name>]`, `/<skill-name>`) is what gets persisted in the
+  message row's `text` field; the chip metadata (refs, ids) lives in
+  parallel arrays on `ComposerInput`.
+
+- We do **not** introduce a markdown or rich-text formatting layer in
+  the composer. The editor is for prose with chips, not bold/italic.
+  If future polish wants `**bold**` rendering inside the composer, it
+  comes as another extension; today's scope ends at chips.
+
+- Bundle impact: zero new dependencies (CodeMirror and lucide packages are
+  already in `apps/renderer/package.json` from ADR 0009). The composer
+  extensions add ~10 KB of forkzero-authored code.

--- a/specs/0.03-MVP/decisions/0011-skills-via-provider.md
+++ b/specs/0.03-MVP/decisions/0011-skills-via-provider.md
@@ -1,0 +1,115 @@
+# 0011 — Skills are discovered by the active provider, not by forkzero
+
+Status: Accepted (2026-05-04)
+
+## Context
+
+MVP 0.03 surfaces user-authored skills (markdown commands with
+frontmatter) inside the composer's slash popover. The user's stated
+direction was explicit: **forkzero should not own a skill directory of
+its own.** Users already author skills inside their preferred coding
+agent — under `~/.claude/skills/` and project-level `.claude/skills/`
+when working with Claude, under `~/.codex/skills/` and project-level
+`.codex/skills/` when working with Codex. Asking them to maintain a
+third copy under `.forkzero/skills/` would be a tax on every user with
+no offsetting benefit.
+
+The question is **how** to plumb those existing directories into
+forkzero's UI without re-implementing each provider's discovery rules,
+frontmatter conventions, override semantics, or hot-reload signals.
+
+## Options
+
+### Option A — Forkzero owns `.forkzero/skills/`
+
+- A new directory the user has to populate.
+- Simplest implementation: forkzero reads markdown, parses frontmatter,
+  emits a list.
+- Cost: every user maintains a separate skill copy per coding tool;
+  every minor format divergence between Claude/Codex skill formats
+  needs a forkzero-specific re-encoding; every cross-tool skill
+  ergonomic gain in a future Claude or Codex release is invisible to
+  forkzero unless we re-implement it.
+
+### Option B — Forkzero reads provider directories directly
+
+- Forkzero reads `.claude/skills/`, `.codex/skills/`, etc. from disk
+  itself, parsing the frontmatter formats each tool uses.
+- Avoids the "maintain three copies" tax.
+- Cost: forkzero now owns parsing rules for each provider and has to
+  match each provider's discovery semantics (which directories are
+  scanned, project vs. global precedence, override rules,
+  inheritance). Every time a provider changes those rules, forkzero
+  drifts. Frontmatter parsing bugs are forkzero's bugs, not the
+  provider's.
+
+### Option C — Delegate to the provider driver
+
+- Each provider driver exposes `listSkills` and `subscribeSkills`. The
+  underlying tool does the discovery and parsing; forkzero consumes
+  the projected `Skill` shape.
+- For Claude, the Agent SDK already does this work (`settingSources:
+  ["user", "project", "local"]` exposes commands via `init.commands`);
+  the driver projects each entry onto our `Skill` schema.
+- For Codex, the CLI exposes `skills/list` over its RPC interface and
+  emits `SkillsChangedNotification` on changes.
+- Cost: forkzero gains a small cross-provider normalization layer; in
+  return, every change in provider semantics is invisible (and free).
+
+## Decision
+
+**Option C: drivers expose `listSkills` and `subscribeSkills`; the
+renderer never touches the filesystem for skills.**
+
+The choice follows the same logic that gave forkzero its provider
+abstraction in the first place: the Claude SDK and the Codex CLI are
+better at being themselves than forkzero will ever be. Any time an
+inner tool updates its skill semantics — adding new frontmatter
+fields, changing precedence, supporting new directories — forkzero
+inherits those improvements without code changes.
+
+## Consequences
+
+- A small `Skill` schema lives in `packages/wire/src/skill.ts` with
+  the union of fields both providers report (name, scope, description,
+  arguments, optional filePath, providerId). Each driver projects its
+  native shape onto this; renderer code never sees provider-native
+  shapes.
+
+- Skills are **scoped per active session**, by design. The popover
+  shows only the active provider's skills. Switching providers swaps
+  the list. There is no merged "all skills across all providers"
+  view, because skills don't compose across providers — a Claude
+  skill body invokes Claude tools, a Codex skill body invokes Codex
+  tools, and a hypothetical merged view would make it ambiguous what
+  the user is invoking.
+
+- Project-scoped skills shadow global skills with the same name. Both
+  drivers already implement this; forkzero just respects the
+  precedence each driver returns and does not re-sort.
+
+- Hot reload is free. The Claude SDK re-emits `init` (with the new
+  command list) on settings changes; Codex emits
+  `SkillsChangedNotification`. The driver translates these into
+  `subscribeSkills.onChange` calls; the renderer's `skill.stream`
+  subscription pushes the new list to the popover.
+
+- Skill body expansion happens on the provider side. When the user
+  picks a `skill` chip and submits, forkzero passes a `SkillRef
+  { name, scope, args }` to the driver, which calls into the SDK or
+  CLI to invoke the skill. Forkzero never inlines skill body text
+  into the prompt. This keeps forkzero's behavior identical to using
+  the underlying tool directly — users get the same skill semantics
+  they'd get from their CLI.
+
+- Authoring is also out of scope for forkzero. Users edit skill
+  files in their text editor, in the destination directory their
+  provider expects. Future polish (a "New skill" template-drop
+  affordance, an "Edit skill" jump-to-source link) is additive;
+  forkzero owning the format itself would not be.
+
+- We accept that switching providers mid-conversation means switching
+  skill lists mid-conversation. This is not a bug — a user who
+  switches from Claude to Codex on the same session is signaling that
+  the conversation is now Codex-flavored, and the Codex skills are
+  what should appear.

--- a/specs/0.03-MVP/decisions/0012-steer-via-interrupt.md
+++ b/specs/0.03-MVP/decisions/0012-steer-via-interrupt.md
@@ -1,0 +1,130 @@
+# 0012 — Steer uses interrupt + send, not mid-stream injection
+
+Status: Accepted (2026-05-04)
+
+## Context
+
+MVP 0.03 adds a mid-turn queue to the chat composer. When the user
+types while a turn is running and presses `Enter`, the input is queued
+instead of being dropped or blocked. Each queued chip has an arrow
+affordance with a `"Steer"` tooltip. Clicking the arrow should move
+that queued input into the active conversation immediately.
+
+There are two possible meanings for "steer":
+
+- Inject the queued user message into the currently streaming turn.
+- Interrupt the currently streaming turn, then send the queued input as
+  the next user turn.
+
+The product behavior needs to feel immediate, but it also has to map to
+provider capabilities that exist today. The system should not invent an
+internal semantic that providers cannot faithfully execute.
+
+## Options
+
+### Option A — True mid-stream injection
+
+The renderer would send the queued user input while the assistant is
+still streaming, and the server would attempt to splice that input into
+the active provider turn.
+
+Pros:
+
+- Feels like the user is steering the exact active thought.
+- Could avoid ending the assistant's partial response early.
+
+Cons:
+
+- The current provider integrations do not expose a stable "append user
+  message to active turn" primitive.
+- Tool calls, permission prompts, and streamed deltas create ambiguous
+  ordering. A message injected while a tool call is in progress could be
+  interpreted before, during, or after the tool result depending on the
+  provider.
+- History becomes hard to explain: the transcript would show a user
+  message that was not a normal turn boundary.
+
+### Option B — Interrupt, drain, then send
+
+Clicking Steer interrupts the active provider turn, waits for any
+required post-interrupt cleanup, then sends the queued input through the
+same path as a normal composer submission.
+
+Pros:
+
+- Maps directly to provider primitives available today: interrupt the
+  active turn, then submit a new user message.
+- Keeps transcript ordering honest. The assistant's partial response
+  ends, then the user message appears, then a new assistant response
+  starts.
+- Reuses the existing `messages.send` pipeline for text, file refs,
+  image attachments, and skill refs.
+- Works consistently for queue chips with rich `ComposerInput`, not
+  just plain text.
+
+Cons:
+
+- The assistant's current response ends immediately, even if it was
+  mid-sentence.
+- A future provider might support cleaner turn-boundary steering, but
+  v1 cannot assume that shape.
+
+### Option C — Queue only, no Steer
+
+The composer would let users queue messages while a turn runs, but the
+queue would flush only after the assistant finishes naturally.
+
+Pros:
+
+- Simplest implementation.
+- No interrupt behavior to reason about.
+
+Cons:
+
+- Does not satisfy the requested Steer affordance.
+- Fails the main user workflow: correcting or redirecting the assistant
+  before it spends more time on the wrong path.
+
+## Decision
+
+**Option B: Steer is interrupt + send.**
+
+When the user clicks the queue chip's arrow:
+
+1. The renderer removes the queued chip optimistically.
+2. The renderer calls `messages.steer({ sessionId, input })`.
+3. The server asks the active provider driver to interrupt the running
+   turn.
+4. The driver drains any provider-required post-interrupt messages.
+5. The server sends the queued `ComposerInput` as the next user turn.
+
+This is the only v1 behavior that is both understandable in the
+transcript and implementable against the available provider APIs.
+
+## Consequences
+
+- The timeline shows an explicit turn boundary. A partial assistant
+  message may appear before the steered user message; that is expected.
+- Queue chips can contain text, file refs, image attachments, and skill
+  refs because the final step reuses the normal `messages.send` input
+  shape.
+- `MessagesSteerRpc` returns `SteerUnsupportedError` for future
+  providers that cannot interrupt. The two 0.03 provider drivers declare
+  support.
+- The Send/Interrupt button should avoid flashing idle between the
+  interrupt and the new turn. The store keeps the session marked
+  running until the steered send has been dispatched.
+- The renderer still supports auto-flush. If the user never clicks
+  Steer, queued messages send in order when the running turn completes
+  naturally.
+
+## Future Work
+
+- **Boundary-aware Steer**. Defer the interrupt until the next safe
+  boundary, such as after a tool call result lands, so partial
+  assistant output is less abrupt.
+- **Provider-native steering**. If a provider eventually exposes a true
+  mid-turn steering primitive, add it behind the driver capability
+  contract without changing the queue UI.
+- **Persistent queues**. If queue chips become long-lived drafts,
+  persist them in SQLite instead of keeping them renderer-only.

--- a/specs/0.03-MVP/features/composer.md
+++ b/specs/0.03-MVP/features/composer.md
@@ -1,0 +1,523 @@
+# Feature: Composer 2.0
+
+The chat composer in MVP 0.02 is a plain `<textarea>` with `Cmd+Enter`
+submit. It has no slash commands, no file or image attachments, and no
+useful behavior when a user types while a turn is in flight. MVP 0.03
+turns the composer into a real editor: a CodeMirror 6 surface that
+renders inline atomic chips for files and images, opens popovers on `/`
+and `@`, accepts dropped images, sends on `Enter`, and queues anything
+typed mid-turn as a steerable chip above the editor.
+
+This document covers the editor itself, the popovers, and the
+attachment pipeline. Skills (which appear in the slash popover) are
+specified separately in [skills.md](skills.md). The mid-turn queue and
+Steer affordance are in [queue-and-steer.md](queue-and-steer.md). The
+choice of editor library is recorded in
+[../decisions/0010-codemirror-composer.md](../decisions/0010-codemirror-composer.md).
+
+## Behavior
+
+### Editor surface
+
+CodeMirror 6 mounted in a "prose" preset:
+
+- No gutter, no line numbers, no fold markers.
+- Soft-wrap on; horizontal scroll off.
+- Auto-grow from a 56 px single-line height to a 240 px max, then
+  scroll internally — same range the textarea uses today
+  (`apps/renderer/src/components/chat-composer.tsx:38-39`).
+- Placeholder rendered via `@codemirror/view`'s `placeholder` extension:
+  `"Send a message…  Enter to send · Shift+Enter for newline"`.
+- The editor host is split (`lib/codemirror/composer.ts` factory +
+  `composer-chips.ts` + `composer-triggers.ts` + paste/drop handlers)
+  for the same reason ADR 0009 gave: a future `Cmd+K`-on-selection
+  inline command lands as one extension, not a rewrite.
+
+### Inline chips
+
+Files, directories, images, and skill invocations render as inline
+**atomic widget decorations**. The chip DOM is:
+
+```html
+<span class="fz-chip" data-kind="file|directory|image|skill">
+  <span class="fz-chip-icon"><!-- icon SVG --></span>
+  <span class="fz-chip-divider"></span>
+  <span class="fz-chip-label">specs</span>
+</span>
+```
+
+Styling matches the screenshots the user supplied: rounded `border`,
+muted-foreground icon, a thin vertical divider between icon and label,
+tabular label. Chip variants:
+
+| Variant       | Icon source                                                                 | Label                  |
+| ------------- | --------------------------------------------------------------------------- | ---------------------- |
+| `file`        | Material Icon Theme (basename → extension), via `lib/icons/material-icons.ts` (added in 0.02) | basename               |
+| `directory`   | Material Icon Theme folder icon (open / closed by no state — chips are not expandable) | last path segment      |
+| `image`       | a square thumbnail (32×32, object-fit cover) sourced from blob URL → `forkzero://attachments/<id>` | original filename      |
+| `skill`       | lucide `Sparkles`                                                           | skill name             |
+
+Selection / editing semantics for any chip:
+
+- The chip occupies one logical position in the document
+  (`atomicRanges` decoration). Cursor cannot land inside it.
+- Arrow keys step over the chip in one keypress.
+- `Backspace` at the right edge of a chip, or `Delete` at its left
+  edge, removes the entire chip.
+- Click on a chip selects the range covering the chip; a follow-up
+  Backspace/Delete removes it.
+- Copy/cut serialize the chip back to its source token (`@<relPath>`,
+  the original image filename in square brackets, or `/<skill-name>`)
+  so paste-into-other-apps works.
+- Drag the chip body to move it within the editor.
+
+### Slash trigger (`/`)
+
+The slash trigger is detected by a CodeMirror `ViewPlugin`
+(`composer-triggers.ts`) that watches doc/selection changes:
+
+- A `/` is a trigger only when preceded by start-of-input or whitespace.
+- The trigger range is `/<query>` where `<query>` is the run of
+  non-whitespace characters following the slash.
+- While the trigger is active, the plugin emits an event that the React
+  layer subscribes to and uses to position `SlashCommandPopover` above
+  the editor.
+- Typing keeps the popover open with the new query; whitespace, `Esc`,
+  or moving the caret out of the trigger range closes it.
+
+`SlashCommandPopover` is backed by `~/components/ui/command.tsx` (the
+existing base-ui autocomplete). Sections in display order:
+
+1. **Commands** — built-ins (resolve client-side; see "Built-in
+   commands").
+2. **Provider commands** — slash commands surfaced by the active
+   provider beyond the built-ins (some providers expose their own).
+3. **Skills** — project-scoped first, then global. Each row shows the
+   skill name, a one-line description, and a subtle scope tag
+   (`project` / `global`).
+
+Confirming a popover row:
+
+- Built-in commands replace the `/<query>` range with the canonical
+  command token (still plain text — they execute on send, e.g.
+  `/clear` clears editor + queue, `/model gpt-4` sets the model). The
+  popover closes; the user can press `Enter` again to submit if they
+  want, or keep typing.
+- A skill confirmation replaces the `/<query>` range with a `skill`
+  chip carrying `{ name, scope, args: "" }`. The user types arguments
+  after the chip if the skill takes them.
+
+Keyboard inside the popover:
+
+- `↑`/`↓` move; `Enter` and `Tab` confirm; `Esc` closes; typing
+  filters.
+- While the popover is open, `Enter` does **not** submit the message.
+
+### File trigger (`@`)
+
+Mirror of the slash trigger:
+
+- `@` is a trigger only when preceded by start-of-input or whitespace.
+- Range: `@<query>`.
+- `FileTagPopover` shows results from `workspace.searchFiles`
+  (`packages/wire/src/workspace.ts`).
+- Confirming a result inserts a `file` or `directory` chip at the
+  trigger range (the `@<query>` text is consumed).
+- Same keyboard model as the slash popover.
+
+### Image attachments
+
+The composer accepts images from three sources:
+
+- **Paste**. `EventHandler` extension intercepts `paste` events and
+  filters `event.clipboardData.files` to entries with `mimeType`
+  starting with `image/`.
+- **Drop**. A wrapping React component owns `onDragOver` / `onDragEnter`
+  / `onDragLeave` / `onDrop`, tracks nested-drag depth in a ref so the
+  drop overlay doesn't flicker on hover transitions, and ignores drops
+  that contain no image files.
+- **Add-image button** in the composer footer (lucide `Paperclip`) for
+  accessibility and non-DnD users; opens an `<input type="file" multiple
+  accept="image/*">`.
+
+For each accepted image:
+
+1. Renderer computes a `blob` URL via `URL.createObjectURL(file)` for
+   immediate preview.
+2. An `image` chip is inserted at the cursor with `src=<blob URL>` and
+   the original filename as the label.
+3. Renderer reads the file as `Uint8Array` (`FileReader.readAsArrayBuffer`)
+   and calls `attachments.upload({sessionId, bytes, mimeType,
+   originalName})`.
+4. On success, the chip's preview src swaps from the blob URL to
+   `forkzero://attachments/<id>`. The blob URL is revoked.
+5. The chip carries an `AttachmentRef` in the `ComposerInput`'s
+   `attachments` array when the message is submitted.
+
+Limits, validated client-side and re-validated server-side:
+
+- `MAX_IMAGE_BYTES = 100 * 1024 * 1024` (100 MB) per image.
+- `MAX_ATTACHMENTS_PER_TURN = 20`.
+- `mimeType` must start with `image/`.
+
+If a drop exceeds either limit, the offending files are dropped with a
+toast: `"Image too large (max 100 MB)"` or `"Maximum 20 attachments per
+turn — N image(s) dropped"`.
+
+### Attachment storage and cloud plan
+
+0.03 stores image input locally first. The upload RPC is intentionally
+named `attachments.upload` even though v1 writes to disk, because the
+composer should not care whether the final backing store is local,
+remote, or both.
+
+Local storage is the source of truth in 0.03:
+
+```
+<userDataDir>/attachments/<sessionSegment>-<uuid>.<ext>
+```
+
+The renderer never reads this path directly. It stores only
+`AttachmentRef.id` and renders images through
+`forkzero://attachments/<id>`. The desktop protocol handler resolves the
+id to the local blob and returns the correct `content-type`.
+
+The database reserves the future cloud shape on day one:
+
+```sql
+remote_url     TEXT,  -- final fetchable URL when cloud sync exists
+remote_key     TEXT,  -- "attachments/<workspaceId>/<sessionId>/<id>.<ext>"
+remote_status  TEXT   -- NULL | "pending" | "uploaded" | "failed"
+```
+
+Resolution order for rendering:
+
+1. If `remote_url` is set and local blob is missing, use `remote_url`.
+2. Otherwise use `forkzero://attachments/<id>`.
+3. If neither resolves, render the image chip in a missing-attachment
+   state with filename and size.
+
+The future sync worker uploads local blobs to
+`attachments/<workspaceId>/<sessionId>/<id>.<ext>`, sets `remote_key`,
+fills `remote_url`, and marks `remote_status = "uploaded"`. It is not
+part of 0.03's implementation scope, but the schema and message format
+make the migration additive.
+
+### Built-in commands
+
+Hardcoded in `apps/renderer/src/composer/builtin-commands.ts`. They
+execute client-side at send time without a server roundtrip.
+
+| Command          | Action                                                              |
+| ---------------- | ------------------------------------------------------------------- |
+| `/clear`         | Clear the editor and the per-session queue. No turn is sent.        |
+| `/new`           | Create a new session in the current project (calls `session.create`). |
+| `/model <id>`    | Switch the session's model (calls `session.setModel`).              |
+| `/mode <name>`   | Switch the session's runtime mode (calls `session.setRuntimeMode`). |
+| `/help`          | Open a popover listing all commands and skills with descriptions.   |
+
+A built-in is detected at send time by checking the document's plain
+text against the leading `/` token. Built-ins always supersede skills
+with the same name.
+
+### Keymap
+
+| Keys                          | Action                                                       |
+| ----------------------------- | ------------------------------------------------------------ |
+| `Enter`                       | Submit (if non-empty and no popover is open).                |
+| `Shift+Enter`                 | Newline.                                                     |
+| `Cmd+Enter` / `Ctrl+Enter`    | Submit (backstop — kept for muscle memory from 0.02).        |
+| `Esc`                         | Close the active popover; if none, blur the editor.          |
+| `Tab` (inside popover)        | Confirm the highlighted popover row.                         |
+| `Backspace` adjacent to chip  | Remove the chip.                                             |
+
+### Submit pipeline
+
+When the user submits:
+
+1. Composer walks the document. Plain text spans become text segments;
+   chips become typed segments (`AttachmentRef`, `FileRef`, `SkillRef`).
+2. The result is assembled into a `ComposerInput`:
+
+   ```ts
+   {
+     text: string,                  // raw text including `@…` and `/…` tokens
+     attachments: AttachmentRef[],
+     fileRefs: FileRef[],
+     skillRefs: SkillRef[],
+   }
+   ```
+
+3. If `runningBySession[sessionId] === true` (mirror of the
+   `streamStatus` subscription in `apps/renderer/src/store/messages.ts:97`),
+   the input is **queued** instead of sent. See
+   [queue-and-steer.md](queue-and-steer.md) for queue behavior.
+4. Otherwise, the input is sent via `messages.send` and the editor is
+   cleared.
+
+Built-in commands intercept the pipeline before step 3: a leading `/clear`
+clears the editor and queue; `/new`, `/model`, `/mode` call the matching
+RPC and clear the editor; `/help` opens the help popover.
+
+## RPC contracts
+
+Added to `packages/wire/`:
+
+```ts
+// packages/wire/src/composer.ts (new)
+export const AttachmentRef = Schema.Struct({
+  id: Schema.String,                      // "<sessionSegment>-<uuid>"
+  mimeType: Schema.String,
+  originalName: Schema.String,
+});
+
+export const FileRef = Schema.Struct({
+  relPath: Schema.String,
+  absPath: Schema.String,
+});
+
+export const SkillRef = Schema.Struct({
+  name: Schema.String,
+  scope: Schema.Literal("global", "project"),
+  args: Schema.String,
+});
+
+export class ComposerInput extends Schema.Class<ComposerInput>("ComposerInput")({
+  text: Schema.String,
+  attachments: Schema.Array(AttachmentRef),
+  fileRefs: Schema.Array(FileRef),
+  skillRefs: Schema.Array(SkillRef),
+}) {}
+
+// packages/wire/src/attachment.ts (new)
+export const AttachmentUploadRpc = Rpc.make("attachments.upload", {
+  payload: Schema.Struct({
+    sessionId: SessionId,
+    bytes: Schema.Uint8Array,
+    mimeType: Schema.String,
+    originalName: Schema.String,
+  }),
+  success: Schema.Struct({
+    id: Schema.String,
+    sizeBytes: Schema.Number,
+    mimeType: Schema.String,
+    ext: Schema.String,
+  }),
+  error: Schema.Union(
+    AttachmentTooLargeError,
+    AttachmentBadMimeError,
+    SessionNotFoundError,
+  ),
+});
+
+export const AttachmentTouchRpc = Rpc.make("attachments.touch", {
+  payload: Schema.Struct({ ids: Schema.Array(Schema.String) }),
+  success: Schema.Void,
+});
+
+// packages/wire/src/workspace.ts (new)
+export const WorkspaceSearchFilesRpc = Rpc.make("workspace.searchFiles", {
+  payload: Schema.Struct({
+    projectId: FolderId,
+    query: Schema.String,
+    limit: Schema.optional(Schema.Number),   // default 20
+  }),
+  success: Schema.Array(Schema.Struct({
+    relPath: Schema.String,
+    absPath: Schema.String,
+    kind: Schema.Literal("file", "directory"),
+  })),
+  error: FsFolderNotFoundError,
+});
+
+// packages/wire/src/session.ts (edit)
+// MessagesSendRpc payload changes from { sessionId, text } to
+// { sessionId, input: ComposerInput }. Old callsites in
+// apps/renderer/src/store/messages.ts wrap the string in a
+// ComposerInput shell with empty arrays.
+//
+// MessageContent gains a new tagged variant:
+const UserRichContent = Schema.TaggedStruct("user_rich", {
+  text: Schema.String,
+  attachments: Schema.Array(AttachmentRef),
+  fileRefs: Schema.Array(FileRef),
+  skillRefs: Schema.Array(SkillRef),
+});
+// The existing UserContent ("user") stays — old rows render unchanged.
+```
+
+The new RPC groups (`attachment`, `workspace`, `composer`,
+`skill` — see [skills.md](skills.md)) are registered in
+`packages/wire/src/rpc.ts`.
+
+## Server-side attachment store
+
+Disk layout under Electron's `app.getPath("userData")`:
+
+```
+<userDataDir>/attachments/<sessionSegment>-<uuid>.<ext>
+```
+
+- `<sessionSegment>` is the lowercase session id sanitized to
+  `[a-z0-9-]`, capped at 80 chars.
+- `<uuid>` is a v4 UUID.
+- `<ext>` is derived from MIME via `apps/server/src/attachment/image-mime.ts`
+  (`image/png` → `.png`, `image/jpeg` → `.jpg`, `image/webp` → `.webp`,
+  `image/gif` → `.gif`; everything else → `.bin`).
+
+SQLite tables added (no message-level migration — `messages.content_json`
+is already a JSON column):
+
+```sql
+CREATE TABLE attachments (
+  id            TEXT PRIMARY KEY,         -- "<sessionSegment>-<uuid>"
+  session_id    TEXT NOT NULL,
+  mime_type     TEXT NOT NULL,
+  size_bytes    INTEGER NOT NULL,
+  original_name TEXT NOT NULL,
+  created_at    TEXT NOT NULL,
+  remote_url    TEXT,                      -- nullable; future cloud fetch URL
+  remote_key    TEXT,                      -- nullable; future cloud object key
+  remote_status TEXT                       -- NULL | "pending" | "uploaded" | "failed"
+);
+
+CREATE TABLE message_attachments (
+  message_id    TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  attachment_id TEXT NOT NULL REFERENCES attachments(id),
+  PRIMARY KEY (message_id, attachment_id)
+);
+```
+
+Garbage collection (`apps/server/src/attachment/attachment-store.ts`):
+
+- Runs once at app start and once per 24 h while running.
+- Deletes blob files + `attachments` rows where: no row in
+  `message_attachments` references the id, **and** `created_at` is
+  older than 24 h, **and** the renderer has not heartbeat the id in
+  the last 90 s.
+- Renderer heartbeat: `useAttachmentsStore` calls `attachments.touch`
+  every 30 s with the ids currently in any composer draft or queue
+  chip. The server keeps an in-memory `lastTouchedAt[id]` map.
+
+### `forkzero://attachments/<id>` protocol
+
+`apps/desktop/src/main.ts` registers a custom protocol so `<img src>`
+can resolve attachment ids without a JS roundtrip:
+
+```ts
+protocol.handle("forkzero", (request) => {
+  // parse <id> from request.url; map to <userDataDir>/attachments/<id>.<ext>
+  // return new Response(stream, { headers: { "content-type": mime } })
+});
+```
+
+The renderer prefers `forkzero://` URLs in `<img>` tags both for live
+chips (after upload) and for past-message rendering.
+
+## Renderer state
+
+```ts
+// apps/renderer/src/store/attachments.ts (new)
+type AttachmentDraft = { id: string; mimeType: string; originalName: string };
+activeDraftIds: Set<string>;                 // touched on heartbeat every 30s
+uploadOne(sessionId, file): Promise<AttachmentRef>;
+
+// apps/renderer/src/store/messages.ts (edit)
+send(sessionId, input: ComposerInput): Promise<void>;   // was (sessionId, text)
+```
+
+Composer-local state lives inside `ChatComposer` and the CodeMirror
+view; it is not lifted into Zustand.
+
+## Components added / changed
+
+| File                                                                  | Status | Purpose                                                                  |
+| --------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------ |
+| `apps/renderer/src/components/chat-composer.tsx`                      | edit   | Replace textarea with CodeMirror; mount popovers, queue tray, attachment chips. |
+| `apps/renderer/src/lib/codemirror/composer.ts`                        | new    | EditorView factory for prose mode + composer extensions.                  |
+| `apps/renderer/src/lib/codemirror/composer-chips.ts`                  | new    | `WidgetType` + `atomicRange` decoration + chip DOM renderer.              |
+| `apps/renderer/src/lib/codemirror/composer-triggers.ts`               | new    | `/` and `@` detection extensions; emits trigger events.                   |
+| `apps/renderer/src/lib/codemirror/composer-keymap.ts`                 | new    | Enter/Shift-Enter/Cmd-Enter keymap; popover-aware Enter swallow.          |
+| `apps/renderer/src/components/composer/slash-command-popover.tsx`     | new    | Popover backed by `ui/command.tsx`; sections for Commands / Provider / Skills. |
+| `apps/renderer/src/components/composer/file-tag-popover.tsx`          | new    | File picker popover; uses `workspace.searchFiles`.                        |
+| `apps/renderer/src/components/composer/attachment-chip.tsx`           | new    | React renderer for chip DOM; reuses `lib/icons/material-icons.ts` from 0.02. |
+| `apps/renderer/src/components/composer/queue-tray.tsx`                | new    | Chip strip above the editor for queued messages (see queue-and-steer.md). |
+| `apps/renderer/src/composer/segment-parser.ts`                        | new    | Pure document-walk that builds `ComposerInput` from editor state.         |
+| `apps/renderer/src/composer/builtin-commands.ts`                      | new    | The five built-in commands and their resolvers.                           |
+| `apps/renderer/src/store/skills.ts`                                   | new    | Per-session skill list, fed by `skill.stream`. (see skills.md)             |
+| `apps/renderer/src/store/attachments.ts`                              | new    | Upload + heartbeat.                                                       |
+| `apps/renderer/src/store/messages.ts`                                 | edit   | `send` now takes `ComposerInput`; queue + steer state added in queue-and-steer.md. |
+| `apps/desktop/src/main.ts`                                            | edit   | Register `forkzero://attachments/<id>` protocol handler.                  |
+| `apps/server/src/attachment/attachment-store.ts`                      | new    | Disk write under userData, GC sweep, heartbeat tracking.                  |
+| `apps/server/src/attachment/image-mime.ts`                            | new    | MIME → extension map.                                                     |
+| `apps/server/src/workspace/file-search.ts`                            | new    | `.gitignore`-aware walker for `workspace.searchFiles`.                    |
+| `apps/server/src/provider/services/provider-service.ts`               | edit   | Accept `ComposerInput`; expand `fileRefs` (read file contents at send).   |
+| `apps/server/src/provider/drivers/claude.ts`                          | edit   | Map `attachments` to image content blocks; honor `skillRefs`.             |
+| `apps/server/src/provider/drivers/codex.ts`                           | edit   | Drop attachments with toast (Codex CLI image-input not supported); honor `skillRefs`. |
+| `packages/wire/src/composer.ts`                                       | new    | `ComposerInput`, `AttachmentRef`, `FileRef`, `SkillRef`.                  |
+| `packages/wire/src/attachment.ts`                                     | new    | Upload + Touch RPCs.                                                      |
+| `packages/wire/src/workspace.ts`                                      | new    | Search-files RPC.                                                         |
+| `packages/wire/src/session.ts`                                        | edit   | `UserRichContent` + updated `MessagesSendRpc` payload.                    |
+| `packages/wire/src/rpc.ts`                                            | edit   | Register new RPC groups.                                                  |
+
+## Acceptance criteria
+
+A1. Typing `/cl` shows `/clear` highlighted in the popover; pressing
+    `Enter` confirms it (the popover closes and the editor still shows
+    `/clear`); pressing `Enter` again clears the editor and any queue
+    chips.
+
+A2. With `~/.claude/skills/rate.md` present and a Claude session active,
+    typing `/r` shows `rate` under Skills; pressing `Enter` inserts a
+    `skill` chip (sparkles icon | "rate") into the editor.
+
+A3. Switching the same session to Codex hides Claude skills and shows
+    skills the Codex CLI reports from `~/.codex/skills/` (covered also
+    in [skills.md](skills.md)).
+
+A4. Typing `@chat-comp` shows file matches; pressing `Enter` inserts a
+    `file` chip (TS-icon | `chat-composer.tsx`) at the cursor; the
+    `@<query>` literal is consumed.
+
+A5. With the cursor immediately after any chip, pressing `Backspace`
+    removes the entire chip in one keypress; `Delete` from the position
+    immediately before the chip does the same.
+
+A6. Dropping a PNG inserts an `image` chip with a thumbnail; the chip's
+    `<img src>` is a blob URL until `attachments.upload` resolves, then
+    swaps to `forkzero://attachments/<id>`. The blob URL is revoked.
+
+A7. With a non-empty editor and no popover open, `Enter` submits;
+    `Shift+Enter` inserts a newline; `Cmd+Enter` also submits.
+
+A8. While `runningBySession[sessionId] === true`, pressing `Enter`
+    creates a queue chip and clears the editor (see
+    [queue-and-steer.md](queue-and-steer.md)).
+
+A9. After restarting the app, opening a past session renders historic
+    image attachments via `forkzero://attachments/<id>` (no missing
+    images).
+
+A10. Dragging a 110 MB image onto the composer shows a toast `"Image too
+     large (max 100 MB)"` and inserts no chip.
+
+A11. Dropping 25 images at once accepts the first 20 and shows a toast
+     `"Maximum 20 attachments per turn — 5 image(s) dropped"`.
+
+A12. `bun run check-types` passes for `apps/renderer`, `apps/server`,
+     and `packages/wire`.
+
+## Future hooks (intentional shape, not built yet)
+
+- **`Cmd+K` on selection** carries forward from 0.02. The same CodeMirror
+  extension that powers it for the file editor (ADR 0009) plugs into
+  the composer because both surfaces share the same editor host.
+- **Cloud sync** of attachments via `attachments.remote_url`. A sync
+  worker uploads orphan-pending blobs to a cloud bucket, fills the
+  column, and the renderer prefers the remote URL when set.
+- **Boundary-aware steer** — defer the interrupt until the next
+  tool-call boundary so the assistant's last completed thought is
+  preserved. See [queue-and-steer.md](queue-and-steer.md).
+- **Symbol-mention chips** — extend the `@` trigger so `@functionName`
+  resolves to a `code` chip pointing at a definition. The chip
+  primitive supports it; only the search backend needs work.

--- a/specs/0.03-MVP/features/queue-and-steer.md
+++ b/specs/0.03-MVP/features/queue-and-steer.md
@@ -1,0 +1,253 @@
+# Feature: Mid-turn queue and Steer
+
+In MVP 0.02, while a turn is in flight the composer's Send button swaps
+to Interrupt (`apps/renderer/src/components/chat-composer.tsx:111-126`).
+The user can keep typing, but submission is blocked: anything they type
+either has to be remembered until the turn ends, or thrown away.
+
+MVP 0.03 turns those mid-turn typed thoughts into first-class queued
+messages with a steerable affordance. Pressing `Enter` while a turn is
+running puts the current `ComposerInput` into a per-session queue; the
+queued message appears as a chip strip above the editor (inside the
+composer card). Each queue chip carries an arrow icon: **hovering shows
+a tooltip "Steer"**; **clicking interrupts the running turn and sends
+the queued message immediately as the next user turn**.
+
+The choice of "interrupt + send" over true mid-stream injection is
+recorded in [../decisions/0012-steer-via-interrupt.md](../decisions/0012-steer-via-interrupt.md).
+
+## Behavior
+
+### Queueing
+
+- The composer reads `runningBySession[sessionId]` from
+  `useMessagesStore` (sourced from the existing `streamStatus`
+  subscription, `apps/renderer/src/store/messages.ts:97-125`).
+- When the user submits while `running === true`, the composer calls
+  `queue(sessionId, input)` instead of `send(sessionId, input)` and
+  clears the editor.
+- Queued items are append-only; ordering is preserved.
+- The queue is **per session** — switching sessions hides the current
+  queue and shows the destination session's queue (if any).
+- Queue state is renderer-only; it lives in `useMessagesStore` and
+  does not survive an app reload. (Reasoning: queued messages are
+  ephemeral by user intent. If the app restarts mid-turn, the user
+  is making a recovery decision anyway.)
+
+### `QueueTray`
+
+The tray is mounted **inside the composer card**, above the editor,
+so it visually attaches to the input rather than floating in the
+timeline:
+
+```
+┌─ Frame ─────────────────────────────────────────────┐
+│ ┌─ Card ──────────────────────────────────────────┐ │
+│ │ ┌─ QueueTray ─────────────────────────────────┐ │ │
+│ │ │  [📝 also check the codex driver  ↑  ×]    │ │ │
+│ │ │  [📝 and update the README        ↑  ×]    │ │ │
+│ │ └────────────────────────────────────────────┘ │ │
+│ │ ┌─ CodeMirror ───────────────────────────────┐ │ │
+│ │ │  …                                         │ │ │
+│ │ └────────────────────────────────────────────┘ │ │
+│ └────────────────────────────────────────────────┘ │
+│ FrameFooter (model picker, mode, timer, etc.)      │
+└────────────────────────────────────────────────────┘
+```
+
+Each chip:
+
+- Subtle pill: `border-border/60 bg-muted/40`, vertical-center
+  flex-row.
+- 1-line text preview, truncated with `text-overflow: ellipsis`.
+  Overflow tooltip shows the full message on hover after a 500 ms
+  delay.
+- **Steer arrow** on the right (lucide `ArrowUp`). On hover, the
+  existing `Tooltip` from `~/components/ui/tooltip.tsx` shows
+  `"Steer"`. Click semantics below.
+- A small `×` (lucide `X`) drops the chip silently with no RPC call.
+- If a chip carries attachments, the chip count appears as a tiny
+  pill next to the text (e.g. `+2 image`); chips do not unfurl.
+
+### Steer click
+
+Clicking the arrow on a queue chip calls
+`steerFromQueue(sessionId, queueId)`:
+
+1. The store removes the chip from the queue (optimistic — the user
+   is committing to send).
+2. The store calls `messages.steer({ sessionId, input })` over RPC.
+3. The provider driver:
+   - Issues an interrupt against the running provider session.
+   - Drains any post-interrupt messages that the SDK still emits
+     (e.g. a Claude `ResultMessage` with `subtype:
+     "error_during_execution"`).
+   - Sends the queued `ComposerInput` as the next user turn (same
+     pipeline as `messages.send`).
+4. The renderer's existing message stream picks up the new user
+   message; the Send/Interrupt button stays "running" continuously
+   because the steer issues the new turn before the status drops.
+
+### Auto-flush at end of turn
+
+When the running turn ends naturally (assistant lands without a steer),
+the messages store hooks the existing status-stream subscription
+(`apps/renderer/src/store/messages.ts:97-125`):
+
+- On the `running → idle | closed` transition, if
+  `queueBySession[sessionId]` is non-empty, the store iterates the
+  queue in order and calls `messages.send` for each `ComposerInput`,
+  awaiting each one before sending the next so the provider sees a
+  single chain rather than racing turns.
+- After the queue drains, a toast appears: `"Queue cleared (N
+  message(s) sent)"`.
+- If a `messages.send` call errors, the loop stops, the remaining
+  chips stay in the queue, and an error toast surfaces. The user can
+  retry the head chip via its arrow (which now means "send next" since
+  no turn is running) or drop it.
+
+### Editor focus
+
+When the queue is non-empty, the editor itself remains active and
+accepts text — the user can keep composing while their previous
+inputs sit in the queue. When the queue is empty, the tray collapses
+(no zero-height ghost row).
+
+## RPC contract
+
+Added next to `MessagesSendRpc` in `packages/wire/src/session.ts`:
+
+```ts
+export class SteerUnsupportedError extends Schema.TaggedError<SteerUnsupportedError>()(
+  "SteerUnsupportedError",
+  { providerId: ProviderId },
+) {}
+
+export const MessagesSteerRpc = Rpc.make("messages.steer", {
+  payload: Schema.Struct({
+    sessionId: SessionId,
+    input: ComposerInput,
+  }),
+  success: Schema.Void,
+  error: Schema.Union(SessionNotFoundError, SteerUnsupportedError),
+});
+```
+
+`SteerUnsupportedError` is wired through the schema for forward
+compatibility with future providers that don't support interrupt;
+both 0.03 drivers (Claude, Codex) report `canSteer: true` and never
+return this error.
+
+## Driver behavior
+
+Both drivers implement the same shape; only the underlying mechanism
+differs.
+
+### Claude driver
+
+```
+1. await sdkClient.interrupt();
+2. for await (msg of sdkClient.receiveResponse()) {
+     if (msg.type === "result") break;     // drain the interrupted turn
+   }
+3. await dispatchSendInput(sessionId, input);   // same path messages.send takes
+```
+
+The drain in step 2 matches the Claude Agent SDK guidance for
+post-interrupt cleanup: an interrupt produces a final result message
+that must be consumed before the next query is issued.
+
+### Codex driver
+
+```
+1. await codexClient.request("turn/interrupt");
+2. // No drain needed; Codex's response stream closes on interrupt.
+3. await dispatchSendInput(sessionId, input);
+```
+
+## Renderer state
+
+Added to `apps/renderer/src/store/messages.ts`:
+
+```ts
+type QueuedMessage = {
+  id: string;                         // local uuid
+  input: ComposerInput;
+  createdAt: Date;
+};
+
+readonly queueBySession: Record<SessionId, ReadonlyArray<QueuedMessage>>;
+readonly queue:          (sessionId: SessionId, input: ComposerInput) => void;
+readonly steerFromQueue: (sessionId: SessionId, queueId: string) => Promise<void>;
+readonly dropFromQueue:  (sessionId: SessionId, queueId: string) => void;
+```
+
+Auto-flush is wired into the existing `streamStatus` `Effect.runFork`
+block (`apps/renderer/src/store/messages.ts:97-125`): when the
+`wasRunning && !isRunning` branch fires, after the existing
+`refresh(projectId)` call, the store also iterates and drains the
+queue for `sessionId`.
+
+Heartbeats: any attachments referenced by queued messages are kept
+alive by the same `attachments.touch` heartbeat the composer uses for
+draft attachments (see [composer.md](composer.md)).
+
+## Components added / changed
+
+| File                                                       | Status | Purpose                                                       |
+| ---------------------------------------------------------- | ------ | ------------------------------------------------------------- |
+| `apps/renderer/src/components/composer/queue-tray.tsx`     | new    | Chip strip above the editor; renders queue chips.             |
+| `apps/renderer/src/components/composer/queue-chip.tsx`     | new    | Single chip — preview, Steer arrow + tooltip, drop button.    |
+| `apps/renderer/src/components/chat-composer.tsx`           | edit   | Mount `QueueTray` inside the card, above the editor.          |
+| `apps/renderer/src/store/messages.ts`                      | edit   | `queueBySession`, `queue`, `steerFromQueue`, `dropFromQueue`; auto-flush hook. |
+| `apps/server/src/provider/services/provider-service.ts`    | edit   | `steer(sessionId, input)` orchestrator.                       |
+| `apps/server/src/provider/drivers/claude.ts`               | edit   | `steer` impl: interrupt → drain → send.                       |
+| `apps/server/src/provider/drivers/codex.ts`                | edit   | `steer` impl: interrupt → send.                               |
+| `packages/wire/src/session.ts`                             | edit   | `SteerUnsupportedError` + `MessagesSteerRpc`.                 |
+| `packages/wire/src/rpc.ts`                                 | edit   | Register the new RPC.                                         |
+
+## Acceptance criteria
+
+Q1. While a turn is running, pressing `Enter` on a non-empty editor
+    creates a queue chip in `QueueTray` and clears the editor; no
+    message is sent.
+
+Q2. Hovering the arrow icon on any queue chip shows a tooltip
+    `"Steer"` after the standard tooltip delay.
+
+Q3. Clicking the arrow ends the running assistant turn (the timeline
+    shows the assistant's partial output as final), then a new user
+    turn begins immediately with the queued text — no idle gap in the
+    Send/Interrupt indicator.
+
+Q4. If the assistant's turn lands while the queue still has items, the
+    items auto-flush in order. A toast `"Queue cleared (N message(s)
+    sent)"` appears once the last item is sent.
+
+Q5. Clicking the `×` on a chip removes it silently — no RPC call, no
+    toast.
+
+Q6. The queue is per-session: switching to another session hides the
+    chips; switching back shows them again. App reload clears all
+    queues.
+
+Q7. A queue chip carrying attachments keeps its attachments alive
+    across the running turn — when it auto-flushes (or is steered),
+    the resulting message still references the same
+    `forkzero://attachments/<id>` URLs.
+
+Q8. `bun run check-types` passes for `apps/renderer`, `apps/server`,
+    and `packages/wire`.
+
+## Future hooks (intentional shape, not built yet)
+
+- **Boundary-aware Steer**. Interrupt at the next tool-call boundary
+  rather than mid-token so the assistant's last completed thought is
+  preserved. Implementable as a driver-side guard that queues the
+  interrupt until the active tool result lands. Decision recorded in
+  [../decisions/0012-steer-via-interrupt.md](../decisions/0012-steer-via-interrupt.md).
+- **Reorder / merge queue chips**. Drag-to-reorder, plus a merge
+  affordance ("send these as one message"). Out of scope for v1.
+- **Persist queue across reload**. Currently the queue is in-memory.
+  If users start typing long backlogs, persisting per-session queues
+  to the existing SQLite layer is a small, additive change.

--- a/specs/0.03-MVP/features/skills.md
+++ b/specs/0.03-MVP/features/skills.md
@@ -1,0 +1,218 @@
+# Feature: Skills
+
+A "skill" in forkzero is a markdown command the user has authored in
+their coding-agent tool of choice. Skill discovery is **delegated** to
+the active provider — forkzero owns no skill directory of its own.
+
+For a Claude session, skills come from `~/.claude/skills/` (global) and
+project-level `.claude/skills/` (multiple between cwd and the repo
+root). For a Codex session they come from `~/.codex/skills/` and
+project-level `.codex/skills/`. The user's existing skill files just
+work.
+
+This document covers discovery, the wire schema, and the resolution
+path at send time. The popover UI that surfaces skills lives in
+[composer.md](composer.md). The rationale for delegating to providers
+is in [../decisions/0011-skills-via-provider.md](../decisions/0011-skills-via-provider.md).
+
+## Behavior
+
+### Discovery
+
+Each provider driver knows how to ask its underlying agent for the
+list of available skills:
+
+- **Claude** — driver uses `@anthropic-ai/claude-agent-sdk` with
+  `settingSources: ["user", "project", "local"]`. The SDK reads
+  `~/.claude/skills/`, project `.claude/skills/`, and `.claude/skills.local/`
+  on startup and exposes the parsed list via the `init` event's
+  `commands` field. The driver projects each entry onto the `Skill`
+  schema below.
+- **Codex** — driver issues `client.request("skills/list", { cwds:
+  [projectCwd] })` over the Codex CLI's RPC interface. The CLI walks
+  `.codex/skills/` between cwd and repo root plus `~/.codex/skills/`
+  and returns parsed metadata.
+
+Both drivers normalize results into the same `Skill` shape so the
+renderer is provider-agnostic.
+
+### Scoping
+
+- Skills are **scoped per active session**. Switching the session's
+  provider replaces the visible skill list — the popover's Skills
+  section refreshes immediately. Switching projects re-runs discovery
+  with the new `projectCwd`.
+- A project-scoped skill (one found under the project's local
+  `.claude/skills/` or `.codex/skills/`) **shadows** a global skill
+  with the same name. Both sources are returned in the list with a
+  `scope` tag so the popover can show a small badge; the project entry
+  appears first.
+
+### Hot reload
+
+Both SDKs already report changes:
+
+- Claude SDK emits messages of type `system` with subtype `init` again
+  whenever the user's settings change in a way that affects commands.
+  The driver re-runs discovery on these.
+- Codex CLI emits `SkillsChangedNotification` over its RPC channel.
+  The driver re-runs discovery on each.
+
+After re-discovery, the driver's `subscribeSkills.onChange` callback
+fires; the server pushes the new list to subscribers of `skill.stream`;
+the renderer's popover re-renders without an app restart.
+
+The target latency is "appears within a couple of seconds of saving
+the file"; no hard SLA.
+
+### Authoring
+
+Authoring is out of scope for 0.03. Users create and edit skills in
+their preferred text editor, in the directory their provider expects.
+Forkzero introduces no skill format of its own.
+
+## Driver capability
+
+`apps/server/src/provider/drivers/index.ts` (or the existing driver
+interface file — confirm at implementation time) gains:
+
+```ts
+interface ProviderDriver {
+  // …existing methods…
+  listSkills(opts: { projectCwd: string }): Promise<Skill[]>;
+  subscribeSkills(opts: {
+    sessionId: SessionId;
+    onChange: () => void;
+  }): () => void;          // returns unsubscribe
+}
+```
+
+## RPC contracts
+
+```ts
+// packages/wire/src/skill.ts (new)
+export class Skill extends Schema.Class<Skill>("Skill")({
+  name: Schema.String,                              // "rate"
+  scope: Schema.Literal("global", "project"),
+  description: Schema.String,
+  arguments: Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      description: Schema.String,
+      optional: Schema.Boolean,
+    }),
+  ),
+  filePath: Schema.NullOr(Schema.String),           // jump-to-source if provider exposes it
+  providerId: ProviderId,
+}) {}
+
+export const SkillListRpc = Rpc.make("skill.list", {
+  payload: Schema.Struct({ sessionId: SessionId }),
+  success: Schema.Array(Skill),
+  error: SessionNotFoundError,
+});
+
+export const SkillStreamRpc = Rpc.make("skill.stream", {
+  payload: Schema.Struct({ sessionId: SessionId }),
+  success: Schema.Array(Skill),                     // full list on each emission
+  error: SessionNotFoundError,
+  stream: true,
+});
+```
+
+`skill.list` is one-shot for the initial hydrate; `skill.stream` emits
+the new full list on every provider change notification — same pattern
+as `messages.stream` in `packages/wire/src/session.ts:243`.
+
+## Renderer state
+
+```ts
+// apps/renderer/src/store/skills.ts (new)
+type SkillsState = {
+  readonly skillsBySession: Record<SessionId, ReadonlyArray<Skill>>;
+  readonly hydrate: (sessionId: SessionId) => Promise<void>;
+};
+```
+
+The store mirrors the Fiber pattern in
+`apps/renderer/src/store/messages.ts:97-125`: a single live fiber
+subscribes to `skill.stream` for the current session; switching
+sessions tears it down and starts a new one. The slash command
+popover reads `skillsBySession[activeSessionId]`.
+
+## Resolution at send time
+
+When the user confirms a skill row in the slash popover, the editor
+inserts a `skill` chip carrying `{ name, scope, args: "" }`. Anything
+the user types after the chip is treated as the `args` payload (free
+text — provider-specific argument parsing happens on the provider
+side; forkzero passes the raw string).
+
+At send time, the composer walks the document and produces:
+
+```ts
+ComposerInput = {
+  text: "/<skill-name> [args] …",
+  attachments: [],
+  fileRefs: [],
+  skillRefs: [{ name, scope, args }],
+}
+```
+
+`ProviderService.send` (`apps/server/src/provider/services/provider-service.ts`)
+inspects `skillRefs` and calls into the driver:
+
+- **Claude driver** — invokes the SDK's command-invocation path
+  (`init.commands` exposes both names and a callable handle); the SDK
+  expands the skill body before sending to the model.
+- **Codex driver** — sends the equivalent `skills/run` request (CLI
+  expands the body before invoking the model).
+
+Forkzero never inlines the skill body into the prompt. Expansion is
+the provider's responsibility, which keeps skill semantics identical
+to using the underlying CLI directly.
+
+## Components added / changed
+
+| File                                         | Status | Purpose                                                  |
+| -------------------------------------------- | ------ | -------------------------------------------------------- |
+| `packages/wire/src/skill.ts`                 | new    | `Skill` schema + `skill.list` / `skill.stream` RPCs.     |
+| `packages/wire/src/rpc.ts`                   | edit   | Register the skill RPC group.                            |
+| `apps/server/src/provider/drivers/claude.ts` | edit   | Implement `listSkills` from `init.commands`; `subscribeSkills` on init re-emits. |
+| `apps/server/src/provider/drivers/codex.ts`  | edit   | Implement `listSkills` via `skills/list`; `subscribeSkills` on `SkillsChangedNotification`. |
+| `apps/server/src/skill/skill-bridge.ts`      | new    | Thin handler that wires `skill.list` / `skill.stream` to the active session's driver. |
+| `apps/renderer/src/store/skills.ts`          | new    | Per-session skill list, fed by `skill.stream`.           |
+| `apps/renderer/src/components/composer/slash-command-popover.tsx` | edit / new (tracked in composer.md) | Renders the Skills section. |
+
+## Acceptance criteria
+
+S1. With a Claude session active and no skill files, the slash popover
+    shows only the Commands section. Creating
+    `~/.claude/skills/foo.md` (with valid frontmatter) makes `foo`
+    appear in the popover within 2 s, no app restart.
+
+S2. With both `~/.claude/skills/foo.md` and `<project>/.claude/skills/foo.md`
+    present, the popover shows a single `foo` row tagged `project`.
+    The body of the project file is what executes when invoked.
+
+S3. Switching the session's provider from Claude to Codex (or back)
+    clears the popover's Skills section and replaces it with the new
+    provider's list. No global "merged across providers" view.
+
+S4. Confirming a skill row inserts a `skill` chip into the editor.
+    Submitting the message yields a `ComposerInput` whose `skillRefs`
+    contains exactly one entry with the skill's name, scope, and any
+    text the user typed after the chip as `args`.
+
+## Future hooks (intentional shape, not built yet)
+
+- **In-app authoring UI** — a "New skill" affordance that drops a
+  templated markdown file into the right directory for the active
+  provider. Schema reserves `filePath` so a future "Edit skill" link
+  in the popover can `shell.openExternal` to it.
+- **Skill argument typing** — current shape carries description and
+  optional flag; a future schema field for `type: "path" | "string"`
+  would let the popover offer typed argument autocompletion.
+- **Cross-provider skill aliasing** — out of scope here, but the
+  `Skill` shape carries `providerId` so a future "convert skill to
+  Codex format" command has the data it needs.


### PR DESCRIPTION
Adds the MVP 0.03 Composer 2.0 spec covering slash commands, inline file/image chips, skill discovery, image attachment storage, and mid-turn queue/Steer behavior.

The spec includes feature docs for composer, skills, queue-and-steer, plus ADRs for CodeMirror, provider-owned skills, and Steer as interrupt + send.

Validation: reviewed the uncommitted diff, pushed the branch, and checked `git diff origin/main...` to confirm the PR contains only the seven new spec files.