### PR TITLE
ui: cleaner palette, prose tokens, underlined tabs, composer top-anchor

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -83,7 +83,7 @@ export function App() {
       <div className="flex w-[260px] shrink-0 flex-col">
         <ProjectsSidebar />
       </div>
-      <main className="flex min-h-0 min-w-0 flex-1 flex-col border-x border-border bg-zinc-950">
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col border-x border-border bg-background">
         {view === "settings" ? (
           <SettingsPage />
         ) : (
@@ -91,6 +91,8 @@ export function App() {
             <MainTabs
               headerLabel={headerLabel}
               headerTitle={selectedFolder?.path}
+              providerId={selectedSession?.providerId}
+              model={selectedSession?.model}
             />
             <div
               hidden={activeMainTab !== "chat"}
@@ -123,7 +125,7 @@ export function App() {
           </>
         )}
       </main>
-      <div className="flex w-[320px] shrink-0 flex-col bg-zinc-950">
+      <div className="flex w-[320px] shrink-0 flex-col bg-background">
         <RightPane />
       </div>
     </div>

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -149,7 +149,10 @@ export function ChatComposer({ session }: { session: Session }) {
     setTrigger(null);
   };
 
-  const dispatchBuiltin = (parsed: { command: BuiltinCommand; args: string }): void => {
+  const dispatchBuiltin = (parsed: {
+    command: BuiltinCommand;
+    args: string;
+  }): void => {
     switch (parsed.command.name) {
       case "clear":
         // Editor is already cleared by the caller; nothing else to do.
@@ -222,9 +225,7 @@ export function ChatComposer({ session }: { session: Session }) {
 
       void uploadOne(sessionId, file)
         .then((ref) => {
-          const finalUrl = isImage
-            ? `forkzero://attachments/${ref.id}`
-            : "";
+          const finalUrl = isImage ? `forkzero://attachments/${ref.id}` : "";
           editorViewRef.current?.dispatch({
             effects: updateImageChipEffect.of({
               previousId: tempId,
@@ -302,11 +303,14 @@ export function ChatComposer({ session }: { session: Session }) {
   // Forget any stale tempId-keyed attachments when the composer unmounts —
   // the heartbeat tracks ids, so dropping unattached blobs is enough to
   // let the GC reap them.
-  useEffect(() => () => {
-    // No-op for now: forgetActive is called per-id only when a chip is
-    // dropped explicitly. Server GC handles long-lived orphans.
-    void forgetActive;
-  }, [forgetActive]);
+  useEffect(
+    () => () => {
+      // No-op for now: forgetActive is called per-id only when a chip is
+      // dropped explicitly. Server GC handles long-lived orphans.
+      void forgetActive;
+    },
+    [forgetActive],
+  );
 
   const submit = (): boolean => {
     // Don't submit while a popover is open — Enter belongs to the popover.
@@ -350,10 +354,10 @@ export function ChatComposer({ session }: { session: Session }) {
   return (
     <TooltipProvider>
       <div className="shrink-0 px-3 pb-3 pt-2">
-        <div className="mx-auto max-w-3xl">
-          <Frame className="bg-muted/40">
+        <div className="mx-auto">
+          <Frame>
             <Card
-              className="rounded-xl border-border/50"
+              className="rounded-xl border-border/50 min-h-30"
               onDragEnter={onDragEnter}
               onDragOver={onDragOver}
               onDragLeave={onDragLeave}
@@ -361,9 +365,7 @@ export function ChatComposer({ session }: { session: Session }) {
               onPaste={onPaste}
             >
               {isDragging && (
-                <div
-                  className="pointer-events-none absolute inset-1 z-40 flex items-center justify-center rounded-lg border border-dashed border-accent-foreground/40 bg-popover/80 backdrop-blur-sm"
-                >
+                <div className="pointer-events-none absolute inset-1 z-40 flex items-center justify-center rounded-lg border border-dashed border-accent-foreground/40 bg-popover/80 backdrop-blur-sm">
                   <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
                     <Upload className="size-3.5" />
                     <span>Drop files to attach</span>
@@ -378,7 +380,7 @@ export function ChatComposer({ session }: { session: Session }) {
                 onChange={onPickFiles}
               />
               <QueueTray sessionId={sessionId} />
-              <CardPanel className="relative flex items-end gap-2 px-3 py-2">
+              <CardPanel className="relative flex items-stretch gap-2 px-3 py-2">
                 {trigger !== null && editorViewRef.current !== null ? (
                   trigger.kind === "slash" ? (
                     <SlashCommandPopover
@@ -418,7 +420,7 @@ export function ChatComposer({ session }: { session: Session }) {
                           type="button"
                           onClick={() => void interrupt(sessionId)}
                           aria-label="Interrupt"
-                          className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-destructive text-destructive-foreground transition-opacity hover:opacity-90"
+                          className="flex size-8 shrink-0 self-end items-center justify-center rounded-lg bg-destructive text-destructive-foreground transition-opacity hover:opacity-90"
                         >
                           <Square className="size-3.5" />
                         </button>
@@ -435,7 +437,7 @@ export function ChatComposer({ session }: { session: Session }) {
                           onClick={() => void submit()}
                           disabled={!canSend}
                           aria-label="Send"
-                          className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                          className="flex size-8 shrink-0 self-end items-center justify-center rounded-lg bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
                         >
                           <Send className="size-3.5" />
                         </button>
@@ -461,7 +463,9 @@ export function ChatComposer({ session }: { session: Session }) {
                       </button>
                     }
                   />
-                  <TooltipPopup>Attach files (paste / drop also work)</TooltipPopup>
+                  <TooltipPopup>
+                    Attach files (paste / drop also work)
+                  </TooltipPopup>
                 </Tooltip>
                 <ModelPicker
                   sessionId={sessionId}

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -1,11 +1,30 @@
-import { MessageSquare, X } from "lucide-react";
+import { X } from "lucide-react";
+
+import { MODELS_BY_PROVIDER, type ProviderId } from "@forkzero/wire";
 
 import { useUiStore } from "../store/ui.ts";
 import { FileIcon } from "./file-icon.tsx";
+import { ProviderIcon } from "./provider-icons.tsx";
 
 type Props = {
   readonly headerLabel: string;
   readonly headerTitle?: string;
+  readonly providerId?: ProviderId;
+  readonly model?: string;
+};
+
+const PROVIDER_LABEL: Record<ProviderId, string> = {
+  claude: "Claude",
+  codex: "Codex",
+};
+
+const lookupModelLabel = (
+  providerId: ProviderId | undefined,
+  model: string | undefined,
+): string | null => {
+  if (providerId === undefined || model === undefined) return null;
+  const opt = MODELS_BY_PROVIDER[providerId].find((m) => m.id === model);
+  return opt?.label ?? model;
 };
 
 /**
@@ -13,24 +32,39 @@ type Props = {
  * appears when a file has been opened from the right-side tree. The empty
  * region at the right keeps the macOS window-drag handle alive — the prior
  * static `<header>` did the same with `[-webkit-app-region:drag]`.
+ *
+ * Active state is signalled by a 2px bottom underline on the tab itself,
+ * not a filled background — keeps the strip flat and lets the chat surface
+ * read as one continuous panel with the body below.
  */
-export function MainTabs({ headerLabel, headerTitle }: Props) {
+export function MainTabs({ headerLabel, headerTitle, providerId, model }: Props) {
   const activeMainTab = useUiStore((s) => s.activeMainTab);
   const setActiveMainTab = useUiStore((s) => s.setActiveMainTab);
   const openFile = useUiStore((s) => s.openFile);
   const closeFileTab = useUiStore((s) => s.closeFileTab);
   const fileDirty = useUiStore((s) => s.fileDirty);
 
+  const modelLabel = lookupModelLabel(providerId, model);
+  const tabTitle =
+    providerId && modelLabel
+      ? `${headerTitle ?? headerLabel} — ${PROVIDER_LABEL[providerId]} · ${modelLabel}`
+      : headerTitle;
+
   return (
-    <header className="flex h-9 shrink-0 items-stretch border-b border-border [-webkit-app-region:drag]">
-      <div className="ml-16 flex items-stretch gap-0.5 [-webkit-app-region:no-drag]">
+    <header className="flex h-10 shrink-0 items-stretch border-b border-border [-webkit-app-region:drag]">
+      <div className="ml-16 flex items-stretch gap-1 [-webkit-app-region:no-drag]">
         <TabButton
           active={activeMainTab === "chat"}
           onClick={() => setActiveMainTab("chat")}
           label={headerLabel}
-          title={headerTitle}
-          icon={
-            <MessageSquare className="size-3.5 shrink-0 text-muted-foreground" />
+          title={tabTitle}
+          leading={
+            providerId ? (
+              <ProviderIcon
+                providerId={providerId}
+                className="size-3.5 shrink-0 text-foreground"
+              />
+            ) : null
           }
         />
         {openFile && (
@@ -54,26 +88,26 @@ function TabButton({
   onClick,
   label,
   title,
-  icon,
+  leading,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
   title?: string;
-  icon: React.ReactNode;
+  leading?: React.ReactNode;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
       title={title ?? label}
-      className={`flex max-w-[240px] items-center gap-1.5 px-3 text-[11px] transition-colors ${
+      className={`relative flex max-w-[280px] items-center gap-2 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
         active
-          ? "bg-muted text-foreground"
-          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          ? "text-foreground after:bg-foreground"
+          : "text-muted-foreground hover:text-foreground after:bg-transparent"
       }`}
     >
-      {icon}
+      {leading}
       <span className="truncate">{label}</span>
     </button>
   );
@@ -96,10 +130,10 @@ function FileTabButton({
 }) {
   return (
     <div
-      className={`group flex max-w-[280px] items-center gap-1.5 px-2 text-[11px] transition-colors ${
+      className={`group relative flex max-w-[280px] items-center gap-1.5 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
         active
-          ? "bg-muted text-foreground"
-          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          ? "text-foreground after:bg-foreground"
+          : "text-muted-foreground hover:text-foreground after:bg-transparent"
       }`}
     >
       <button
@@ -121,7 +155,7 @@ function FileTabButton({
         type="button"
         onClick={onClose}
         aria-label="Close file"
-        className="rounded p-0.5 opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100"
+        className="relative z-10 rounded p-0.5 opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100"
       >
         <X className="size-3" />
       </button>

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -78,7 +78,7 @@ export function MessageRow({
 function UserBubble({ text }: { text: string }) {
   return (
     <div className="flex justify-end px-4 py-2">
-      <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl rounded-tr-sm bg-primary px-3 py-2 text-sm text-primary-foreground">
+      <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 text-sm text-user-bubble-foreground">
         {text}
       </div>
     </div>
@@ -88,10 +88,8 @@ function UserBubble({ text }: { text: string }) {
 function AssistantBubble({ text }: { text: string }) {
   return (
     <div className="px-4 py-2">
-      <div className="max-w-[88%] text-sm leading-relaxed">
-        <div className="prose prose-invert prose-sm max-w-none break-words [&>:first-child]:mt-0 [&>:last-child]:mb-0 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_pre>code]:bg-transparent [&_pre>code]:p-0">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
-        </div>
+      <div className="fz-prose max-w-[88%]">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
       </div>
     </div>
   );

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -22,7 +22,7 @@ export function RightPane() {
   const [tab, setTab] = useState<Tab>("files");
 
   return (
-    <aside className="flex h-full min-h-0 w-full flex-col bg-zinc-950">
+    <aside className="flex h-full min-h-0 w-full flex-col">
       <div className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border px-1 text-xs">
         <TabButton
           active={tab === "files"}

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -85,6 +85,18 @@ body,
   --color-bg-overlay: var(--bg-overlay);
   --color-text-faint: var(--text-faint);
 
+  /* Chat + prose tokens. Kept separate from `primary` so the assistant
+     prose body and the user bubble can be tuned independently of buttons. */
+  --color-user-bubble: var(--user-bubble);
+  --color-user-bubble-foreground: var(--user-bubble-foreground);
+  --color-message-text: var(--message-text);
+  --color-message-heading: var(--message-heading);
+  --color-message-code: var(--message-code);
+  --color-message-code-bg: var(--message-code-bg);
+  --color-message-pre-bg: var(--message-pre-bg);
+  --color-message-quote: var(--message-quote);
+  --color-message-rule: var(--message-rule);
+
   /* Charts — kept for the shadcn convention; unused right now. */
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
@@ -181,124 +193,151 @@ body,
 }
 
 /* ---------- Light theme ---------- */
-/* Zinc-tinted neutrals (hue 286). Cool gray, no warm tint. Light mode
-   exists for parity / future toggle but we ship dark-by-default. */
+/* Warm stone neutrals (hue 70). Subtle warmth, no cool blue cast. Light
+   mode exists for parity / future toggle but we ship dark-by-default. */
 :root {
   --radius: 0.625rem;
 
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 286);
+  --background: oklch(0.99 0.003 75);
+  --foreground: oklch(0.18 0.008 70);
 
-  --bg-subtle: oklch(0.985 0 0);
-  --bg-elevated: oklch(0.967 0.001 286);
-  --bg-overlay: oklch(0.92 0.004 286);
-  --text-faint: oklch(0.705 0.015 286);
+  --bg-subtle: oklch(0.975 0.004 75);
+  --bg-elevated: oklch(0.955 0.005 70);
+  --bg-overlay: oklch(0.91 0.006 70);
+  --text-faint: oklch(0.62 0.012 70);
 
   --card: oklch(1 0 0);
   --card-foreground: var(--foreground);
   --popover: oklch(1 0 0);
   --popover-foreground: var(--foreground);
 
-  --primary: oklch(0.21 0.006 286);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286);
+  --primary: oklch(0.24 0.008 70);
+  --primary-foreground: oklch(0.985 0.003 75);
+  --secondary: oklch(0.955 0.005 70);
   --secondary-foreground: var(--foreground);
-  --muted: oklch(0.967 0.001 286);
-  --muted-foreground: oklch(0.552 0.014 286);
-  --accent: oklch(0.967 0.001 286);
+  --muted: oklch(0.955 0.005 70);
+  --muted-foreground: oklch(0.52 0.012 70);
+  --accent: oklch(0.955 0.005 70);
   --accent-foreground: var(--foreground);
 
-  --destructive: oklch(0.577 0.245 27.3);
-  --destructive-foreground: oklch(0.985 0 0);
-  --success: oklch(0.696 0.17 162.5);
-  --success-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.769 0.188 70.1);
-  --warning-foreground: oklch(0.21 0.006 286);
-  --info: oklch(0.623 0.214 259.8);
-  --info-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.585 0.22 27);
+  --destructive-foreground: oklch(0.985 0.003 75);
+  --success: oklch(0.66 0.15 150);
+  --success-foreground: oklch(0.985 0.003 75);
+  --warning: oklch(0.78 0.16 75);
+  --warning-foreground: oklch(0.24 0.008 70);
+  --info: oklch(0.62 0.16 245);
+  --info-foreground: oklch(0.985 0.003 75);
 
-  --border: oklch(0.92 0.004 286);
-  --input: oklch(0.92 0.004 286);
-  --ring: oklch(0.705 0.015 286);
+  --border: oklch(0.9 0.006 70);
+  --input: oklch(0.9 0.006 70);
+  --ring: oklch(0.62 0.012 70);
 
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 286);
-  --sidebar-primary: oklch(0.21 0.006 286);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286);
-  --sidebar-accent-foreground: oklch(0.21 0.006 286);
-  --sidebar-border: oklch(0.92 0.004 286);
-  --sidebar-ring: oklch(0.705 0.015 286);
+  --sidebar: oklch(0.975 0.004 75);
+  --sidebar-foreground: oklch(0.18 0.008 70);
+  --sidebar-primary: oklch(0.24 0.008 70);
+  --sidebar-primary-foreground: oklch(0.985 0.003 75);
+  --sidebar-accent: oklch(0.955 0.005 70);
+  --sidebar-accent-foreground: oklch(0.24 0.008 70);
+  --sidebar-border: oklch(0.9 0.006 70);
+  --sidebar-ring: oklch(0.62 0.012 70);
 
   --chart-1: oklch(0.646 0.222 41.1);
   --chart-2: oklch(0.6 0.118 184.7);
   --chart-3: oklch(0.398 0.07 227.4);
   --chart-4: oklch(0.828 0.189 84.4);
   --chart-5: oklch(0.769 0.188 70.1);
+
+  /* Chat bubble + prose. Independent of `primary` so we can keep button
+     primary punchy without bleaching message text. */
+  --user-bubble: oklch(0.93 0.012 260);
+  --user-bubble-foreground: oklch(0.22 0.01 260);
+  --message-text: oklch(0.28 0.008 260);
+  --message-heading: oklch(0.18 0.01 260);
+  --message-code: oklch(0.42 0.05 30);
+  --message-code-bg: oklch(0.95 0.006 260);
+  --message-pre-bg: oklch(0.97 0.005 260);
+  --message-quote: oklch(0.46 0.01 260);
+  --message-rule: oklch(0.88 0.005 260);
 }
 
-/* ---------- Dark theme (default) ---------- */
-/* Same zinc hue (286). Lightness ramp tuned softer than typical "OLED dark":
-     0.20   background      (body — soft, not pitch black)
-     0.235  bg-subtle       (sidebar bg behind translucency)
-     0.265  card / popover  (raised surfaces)
-     0.295  bg-elevated     (between card and accent)
-     0.33   muted/secondary/accent  (subtle bg, hover)
-     0.37   bg-overlay      (top-of-stack hover, scrollbars)
-
-   Text ladder: foreground → muted-foreground → text-faint */
 .dark {
-  --background: oklch(0.2 0.005 286);
-  --foreground: oklch(0.985 0 0);
+  --background: oklch(0.18 0.004 260);
+  --foreground: oklch(0.955 0.004 260);
 
-  --bg-subtle: oklch(0.235 0.005 286);
-  --bg-elevated: oklch(0.295 0.006 286);
-  --bg-overlay: oklch(0.37 0.008 286);
-  --text-faint: oklch(0.6 0.013 286);
+  --bg-subtle: oklch(0.225 0.005 260);
+  --bg-elevated: oklch(0.275 0.006 260);
+  --bg-overlay: oklch(0.35 0.008 260);
+  --text-faint: oklch(0.58 0.006 260);
 
-  --card: oklch(0.265 0.006 286);
+  --card: oklch(0.225 0.005 260);
   --card-foreground: var(--foreground);
-  --popover: oklch(0.265 0.006 286);
+
+  --popover: oklch(0.255 0.006 260);
   --popover-foreground: var(--foreground);
 
-  --primary: oklch(0.92 0.004 286);
-  --primary-foreground: oklch(0.265 0.006 286);
-  --secondary: oklch(0.33 0.007 286);
+  --primary: oklch(0.94 0.004 260);
+  --primary-foreground: oklch(0.18 0.004 260);
+
+  --secondary: oklch(0.305 0.006 260);
   --secondary-foreground: var(--foreground);
-  --muted: oklch(0.33 0.007 286);
-  --muted-foreground: oklch(0.74 0.014 286);
-  --accent: oklch(0.33 0.007 286);
+
+  --muted: oklch(0.305 0.006 260);
+  --muted-foreground: oklch(0.72 0.006 260);
+
+  --accent: oklch(0.32 0.008 260);
   --accent-foreground: var(--foreground);
 
-  --destructive: oklch(0.704 0.191 22.2);
-  --destructive-foreground: oklch(0.985 0 0);
-  --success: oklch(0.696 0.17 162.5);
-  --success-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.769 0.188 70.1);
-  --warning-foreground: oklch(0.265 0.006 286);
-  --info: oklch(0.623 0.214 259.8);
-  --info-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.68 0.19 25);
+  --destructive-foreground: oklch(0.985 0.003 260);
 
-  --border: oklch(1 0 0 / 0.12);
-  --input: oklch(1 0 0 / 0.18);
-  --ring: oklch(0.59 0.014 286);
+  --success: oklch(0.72 0.13 155);
+  --success-foreground: oklch(0.18 0.004 260);
 
-  --sidebar: oklch(0.235 0.005 286);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.33 0.007 286);
+  --warning: oklch(0.8 0.12 85);
+  --warning-foreground: oklch(0.18 0.004 260);
+
+  --info: oklch(0.7 0.09 245);
+  --info-foreground: oklch(0.985 0.003 260);
+
+  --border: oklch(1 0 0 / 0.09);
+  --input: oklch(1 0 0 / 0.14);
+  --ring: oklch(0.65 0.025 260);
+
+  --sidebar: oklch(0.2 0.004 260);
+  --sidebar-foreground: oklch(0.955 0.004 260);
+
+  --sidebar-primary: oklch(0.72 0.075 260);
+  --sidebar-primary-foreground: oklch(0.18 0.004 260);
+
+  --sidebar-accent: oklch(0.285 0.006 260);
   --sidebar-accent-foreground: var(--foreground);
-  --sidebar-border: oklch(1 0 0 / 0.12);
-  --sidebar-ring: oklch(0.59 0.014 286);
 
-  --chart-1: oklch(0.546 0.245 262.9);
-  --chart-2: oklch(0.696 0.17 162.5);
-  --chart-3: oklch(0.769 0.188 70.1);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.4);
+  --sidebar-border: oklch(1 0 0 / 0.09);
+  --sidebar-ring: oklch(0.65 0.025 260);
+
+  --chart-1: oklch(0.72 0.075 260);
+  --chart-2: oklch(0.72 0.12 155);
+  --chart-3: oklch(0.78 0.11 85);
+  --chart-4: oklch(0.72 0.09 295);
+  --chart-5: oklch(0.68 0.17 25);
+
+  /* Chat bubble + prose. The user bubble sits one rung above `accent` with
+     a slight blue tint so it reads as a distinct surface, not a button.
+     `--message-text` and `--message-heading` are both dimmed below
+     `--foreground` (0.955) so a long answer feels like a calm read rather
+     than a wall of white. Headings stay only ~0.08 above body so the
+     hierarchy comes from weight + spacing, not blast-bright text. */
+  --user-bubble: oklch(0.36 0.022 260);
+  --user-bubble-foreground: oklch(0.96 0.005 260);
+  --message-text: oklch(0.78 0.006 260);
+  --message-heading: oklch(0.88 0.006 260);
+  --message-code: oklch(0.82 0.04 60);
+  --message-code-bg: oklch(0.28 0.008 260);
+  --message-pre-bg: oklch(0.235 0.006 260);
+  --message-quote: oklch(0.66 0.008 260);
+  --message-rule: oklch(1 0 0 / 0.08);
 }
-
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -315,6 +354,135 @@ body,
   samp,
   pre {
     font-family: var(--font-mono);
+  }
+}
+
+/* Assistant message prose. Tuned for long-read comfort: body sits a touch
+   below `--foreground`, headings sharper, code in a contained surface, and
+   typographic rhythm (margins, line-height, list indents) calmed down so a
+   long answer reads like a published doc instead of a wall of bold tags. */
+@layer components {
+  .fz-prose {
+    color: var(--message-text);
+    font-size: 0.9rem;
+    line-height: 1.65;
+    word-break: break-word;
+  }
+  .fz-prose > :first-child {
+    margin-top: 0;
+  }
+  .fz-prose > :last-child {
+    margin-bottom: 0;
+  }
+  .fz-prose p {
+    margin: 0.6em 0;
+  }
+  .fz-prose h1,
+  .fz-prose h2,
+  .fz-prose h3,
+  .fz-prose h4,
+  .fz-prose h5,
+  .fz-prose h6 {
+    color: var(--message-heading);
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    margin: 1.4em 0 0.5em;
+  }
+  .fz-prose h1 {
+    font-size: 1.4em;
+  }
+  .fz-prose h2 {
+    font-size: 1.2em;
+  }
+  .fz-prose h3 {
+    font-size: 1.05em;
+  }
+  .fz-prose h4,
+  .fz-prose h5,
+  .fz-prose h6 {
+    font-size: 1em;
+  }
+  .fz-prose strong {
+    color: var(--message-heading);
+    font-weight: 600;
+  }
+  .fz-prose a {
+    color: var(--info);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--info), transparent 60%);
+    text-underline-offset: 0.2em;
+  }
+  .fz-prose a:hover {
+    text-decoration-color: var(--info);
+  }
+  .fz-prose ul,
+  .fz-prose ol {
+    margin: 0.6em 0;
+    padding-left: 1.4em;
+  }
+  .fz-prose li {
+    margin: 0.2em 0;
+  }
+  .fz-prose li::marker {
+    color: var(--text-faint);
+  }
+  .fz-prose blockquote {
+    margin: 0.8em 0;
+    padding: 0.1em 0 0.1em 0.9em;
+    border-left: 2px solid var(--message-rule);
+    color: var(--message-quote);
+    font-style: normal;
+  }
+  .fz-prose hr {
+    border: 0;
+    border-top: 1px solid var(--message-rule);
+    margin: 1.2em 0;
+  }
+  .fz-prose code {
+    font-family: var(--font-mono);
+    font-size: 0.86em;
+    color: var(--message-code);
+    background-color: var(--message-code-bg);
+    padding: 0.1em 0.35em;
+    border-radius: 0.3rem;
+  }
+  .fz-prose pre {
+    background-color: var(--message-pre-bg);
+    border: 1px solid var(--message-rule);
+    border-radius: 0.5rem;
+    padding: 0.85em 1em;
+    margin: 0.8em 0;
+    overflow-x: auto;
+    font-size: 0.84em;
+    line-height: 1.55;
+  }
+  .fz-prose pre code {
+    color: var(--message-text);
+    background: transparent;
+    padding: 0;
+    font-size: inherit;
+  }
+  .fz-prose table {
+    width: auto;
+    border-collapse: collapse;
+    margin: 0.8em 0;
+    font-size: 0.92em;
+  }
+  .fz-prose th,
+  .fz-prose td {
+    border: 1px solid var(--message-rule);
+    padding: 0.4em 0.7em;
+    text-align: left;
+  }
+  .fz-prose th {
+    color: var(--message-heading);
+    font-weight: 600;
+    background-color: color-mix(
+      in srgb,
+      var(--message-pre-bg),
+      transparent 40%
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Retunes the dark palette to a warmer-cool stone with a softer lightness ramp, and adds dedicated tokens for chat bubbles and assistant prose (`--user-bubble`, `--message-text`, `--message-heading`, `--message-code-bg`, `--message-pre-bg`, …) so the message body can be calmer than `--primary` without bleaching button surfaces.
- Adds a hand-tuned `.fz-prose` component class to replace `prose prose-invert` in `MessageRow` — dimmed headings, contained code blocks, GFM table styling.
- Top-bar tabs now show the provider logo (Claude / Codex via existing `ProviderIcon`) instead of the generic `MessageSquare`, and the active state is a 2px underline instead of a filled muted background.
- Chat composer panel switched from `items-end` to `items-stretch` with `self-end` on the send/interrupt buttons, so when the min-height grows the cursor starts at the top instead of being pinned to the bottom.
- Right pane drops its hard `bg-zinc-950` and inherits the themed background.

## Test plan
- [ ] Reload renderer, confirm chat tab shows Claude/Codex logo + underline-only active state
- [ ] Send a markdown-heavy assistant message; verify body is dim, headings only slightly brighter, code blocks contained
- [ ] Type in composer; cursor begins at the top of the taller min-height box, send button stays bottom-right