### PR TITLE
Loader cleanup, turn summaries, sidebar status

### DIFF
--- a/apps/renderer/components.json
+++ b/apps/renderer/components.json
@@ -22,6 +22,10 @@
   "menuColor": "default",
   "menuAccent": "subtle",
   "registries": {
-    "@coss": "https://coss.com/ui/r/{name}.json"
+    "@coss": "https://coss.com/ui/r/{name}.json",
+    "@muload": {
+      "url": "https://muload.dev/r/{name}.json",
+      "headers": { "Authorization": "Bearer ${MULOAD_LICENSE_KEY}" }
+    }
   }
 }

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -8,11 +8,10 @@ import {
   Square,
   Upload,
 } from "lucide-react";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 
 import {
   MODELS_BY_PROVIDER,
-  type Message,
   type ProviderId,
   type RuntimeMode,
   type Session,
@@ -69,9 +68,6 @@ const MIN_HEIGHT = 56;
 const MAX_HEIGHT = 240;
 const MAX_ATTACHMENTS_PER_TURN = 20;
 
-// Stable empty-array reference; see chat-view.tsx for rationale.
-const EMPTY_MESSAGES: ReadonlyArray<Message> = [];
-
 type ReasoningLevel = "low" | "medium" | "high";
 const REASONING_LEVELS: ReadonlyArray<ReasoningLevel> = [
   "low",
@@ -81,9 +77,6 @@ const REASONING_LEVELS: ReadonlyArray<ReasoningLevel> = [
 
 export function ChatComposer({ session }: { session: Session }) {
   const sessionId: SessionId = session.id;
-  const messages = useMessagesStore(
-    (s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES,
-  );
   const inFlight = useMessagesStore(
     (s) => s.runningBySession[sessionId] === true,
   );
@@ -420,7 +413,7 @@ export function ChatComposer({ session }: { session: Session }) {
                           type="button"
                           onClick={() => void interrupt(sessionId)}
                           aria-label="Interrupt"
-                          className="flex size-8 shrink-0 self-end items-center justify-center rounded-lg bg-destructive text-destructive-foreground transition-opacity hover:opacity-90"
+                          className="flex size-8 shrink-0 self-end items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
                         >
                           <Square className="size-3.5" />
                         </button>
@@ -479,7 +472,6 @@ export function ChatComposer({ session }: { session: Session }) {
                   sessionId={sessionId}
                   current={session.runtimeMode}
                 />
-                <TurnTimer messages={messages} inFlight={inFlight} />
               </div>
             </FrameFooter>
           </Frame>
@@ -674,62 +666,3 @@ function ReasoningPicker({ sessionId }: { sessionId: SessionId }) {
   );
 }
 
-const formatElapsed = (ms: number): string => {
-  const totalSec = ms / 1000;
-  if (totalSec < 60) return `${totalSec.toFixed(1)}s`;
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec - min * 60;
-  return `${min}m ${sec.toFixed(1)}s`;
-};
-
-/**
- * Live elapsed time for the current turn. Anchors to the most recent user
- * message; ticks while the turn is in flight, then freezes the final value
- * once the assistant lands so the user can see how long the turn took.
- */
-function TurnTimer({
-  messages,
-  inFlight,
-}: {
-  messages: ReadonlyArray<Message>;
-  inFlight: boolean;
-}) {
-  const anchorMs = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const m = messages[i]!;
-      if (m.content._tag === "user") return m.createdAt.getTime();
-    }
-    return null;
-  }, [messages]);
-
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (!inFlight) return;
-    const id = window.setInterval(() => setNow(Date.now()), 100);
-    return () => window.clearInterval(id);
-  }, [inFlight]);
-
-  if (anchorMs === null) {
-    return <span className="text-[10px] text-muted-foreground">idle</span>;
-  }
-
-  // Freeze on the final assistant/tool-result timestamp once the turn ends, so
-  // the displayed value matches the actual turn duration instead of "time
-  // since user spoke".
-  const endMs = inFlight
-    ? now
-    : (messages[messages.length - 1]?.createdAt.getTime() ?? now);
-  const elapsed = Math.max(0, endMs - anchorMs);
-
-  return (
-    <span
-      className={`tabular-nums text-[10px] ${
-        inFlight ? "text-foreground" : "text-muted-foreground"
-      }`}
-      title={inFlight ? "Time on the current turn" : "Last turn duration"}
-    >
-      {inFlight ? "● " : ""}
-      {formatElapsed(elapsed)}
-    </span>
-  );
-}

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -8,10 +8,11 @@ import {
   Square,
   Upload,
 } from "lucide-react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   MODELS_BY_PROVIDER,
+  type Message,
   type ProviderId,
   type RuntimeMode,
   type Session,
@@ -472,6 +473,7 @@ export function ChatComposer({ session }: { session: Session }) {
                   sessionId={sessionId}
                   current={session.runtimeMode}
                 />
+                <SessionTimer sessionId={sessionId} inFlight={inFlight} />
               </div>
             </FrameFooter>
           </Frame>
@@ -666,3 +668,83 @@ function ReasoningPicker({ sessionId }: { sessionId: SessionId }) {
   );
 }
 
+const formatCoarse = (ms: number): string => {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  if (min < 60) return `${min}m`;
+  const hours = Math.floor(min / 60);
+  const mins = min - hours * 60;
+  return mins === 0 ? `${hours}h` : `${hours}h ${mins}m`;
+};
+
+/**
+ * Sum of every turn's duration in this session — start = user message,
+ * end = last message of that turn (or `now` for the in-flight turn). Idle
+ * gaps between a finished assistant reply and the next user prompt are
+ * NOT counted, so an old session that's been sitting open doesn't claim
+ * "47h" of work.
+ */
+function SessionTimer({
+  sessionId,
+  inFlight,
+}: {
+  sessionId: SessionId;
+  inFlight: boolean;
+}) {
+  const messages = useMessagesStore(
+    (s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES,
+  );
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!inFlight) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [inFlight]);
+
+  const totalElapsed = useMemo(() => {
+    let total = 0;
+    let turnStart: number | null = null;
+    let turnLastMs: number | null = null;
+    let turnIsLast = false;
+
+    const closeTurn = (endOverride?: number) => {
+      if (turnStart === null) return;
+      const end = endOverride ?? turnLastMs ?? turnStart;
+      total += Math.max(0, end - turnStart);
+    };
+
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i]!;
+      if (m.content._tag === "user") {
+        if (turnStart !== null) closeTurn();
+        turnStart = m.createdAt.getTime();
+        turnLastMs = turnStart;
+        turnIsLast = i === messages.length - 1;
+      } else if (turnStart !== null) {
+        turnLastMs = m.createdAt.getTime();
+        turnIsLast = i === messages.length - 1;
+      }
+    }
+    if (turnStart !== null) {
+      // The in-flight turn keeps growing until the next message lands; for
+      // a completed last turn we freeze at its final message timestamp.
+      closeTurn(inFlight && turnIsLast !== false ? now : undefined);
+    }
+    return total;
+  }, [messages, inFlight, now]);
+
+  if (messages.length === 0) return null;
+
+  return (
+    <span
+      className="rounded-md border border-border/60 bg-background px-1.5 py-0.5 text-[10px] tabular-nums text-muted-foreground"
+      title="Total time spent across all turns in this session"
+    >
+      {formatCoarse(totalElapsed)}
+    </span>
+  );
+}
+
+const EMPTY_MESSAGES: ReadonlyArray<Message> = [];

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -1,5 +1,12 @@
 import { MessageSquare } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import type { AgentItemId, Message, SessionId } from "@forkzero/wire";
 
@@ -7,6 +14,7 @@ import { useMessagesStore } from "../store/messages.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSkillsStore } from "../store/skills.ts";
 import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import { TurnSummary } from "./turn-summary.tsx";
 import { GradientDescent } from "./ui/gradient-descent.tsx";
 
 const NEAR_BOTTOM_PX = 80;
@@ -72,6 +80,29 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   // have a preceding tool_use in this transcript so true orphans (e.g. a
   // dropped tool_use event) still fall through to a standalone error row
   // in MessageRow rather than disappearing silently.
+  // Split the flat message stream into turns: each turn is one user message
+  // (or null for an open response with no preceding user msg) plus every
+  // assistant / thinking / tool message that follows until the next user
+  // message. Used to wrap completed turns in a TurnSummary card.
+  const turns = useMemo(() => {
+    const out: Array<{
+      user: Message | null;
+      body: Message[];
+    }> = [];
+    let current: { user: Message | null; body: Message[] } | null = null;
+    for (const m of messages) {
+      if (m.content._tag === "user") {
+        if (current !== null) out.push(current);
+        current = { user: m, body: [] };
+      } else {
+        if (current === null) current = { user: null, body: [] };
+        current.body.push(m);
+      }
+    }
+    if (current !== null) out.push(current);
+    return out;
+  }, [messages]);
+
   const resultsByItemId = useMemo(() => {
     const seenUseIds = new Set<AgentItemId>();
     const map = new Map<AgentItemId, ToolResultRecord>();
@@ -111,16 +142,48 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
         </div>
       ) : (
         <div className="flex flex-col py-2">
-          {messages.map((message) => (
-            <MessageRow
-              key={message.id}
-              message={message}
-              resultsByItemId={resultsByItemId}
-            />
-          ))}
-          {inFlight && (
-            <WorkingRow messages={messages} />
-          )}
+          {turns.map((turn, idx) => {
+            const isLastTurn = idx === turns.length - 1;
+            const isLive = inFlight && isLastTurn;
+            const hasToolCalls = turn.body.some(
+              (m) => m.content._tag === "tool_use",
+            );
+            // Only collapse into a summary when there's a final assistant
+            // message worth showing as the body — otherwise a turn with
+            // just tool calls would lose its content behind the accordion.
+            const hasFinalText = turn.body.some(
+              (m) =>
+                m.content._tag === "assistant" &&
+                m.content.text.trim().length > 0,
+            );
+            const showSummary = !isLive && hasToolCalls && hasFinalText;
+            const turnKey = turn.user?.id ?? `turn-${idx}`;
+            return (
+              <Fragment key={turnKey}>
+                {turn.user !== null ? (
+                  <MessageRow
+                    message={turn.user}
+                    resultsByItemId={resultsByItemId}
+                  />
+                ) : null}
+                {showSummary ? (
+                  <TurnSummary
+                    body={turn.body}
+                    resultsByItemId={resultsByItemId}
+                  />
+                ) : (
+                  turn.body.map((m) => (
+                    <MessageRow
+                      key={m.id}
+                      message={m}
+                      resultsByItemId={resultsByItemId}
+                    />
+                  ))
+                )}
+              </Fragment>
+            );
+          })}
+          {inFlight && <WorkingRow messages={messages} />}
         </div>
       )}
       {error !== null && (
@@ -155,6 +218,8 @@ function pickDifferent(current: Pattern | null): Pattern {
 }
 
 function WorkingRow({ messages }: { messages: ReadonlyArray<Message> }) {
+  // Anchor to the most recent user message — we want the live "current turn"
+  // elapsed time beside the loader, not the session-wide total.
   const anchorMs = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]!;

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -1,5 +1,5 @@
 import { MessageSquare } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { AgentItemId, Message, SessionId } from "@forkzero/wire";
 
@@ -7,6 +7,7 @@ import { useMessagesStore } from "../store/messages.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSkillsStore } from "../store/skills.ts";
 import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import { GradientDescent } from "./ui/gradient-descent.tsx";
 
 const NEAR_BOTTOM_PX = 80;
 
@@ -24,6 +25,9 @@ const EMPTY_MESSAGES: ReadonlyArray<Message> = [];
 export function ChatView({ sessionId }: { sessionId: SessionId }) {
   const messages = useMessagesStore(
     (s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES,
+  );
+  const inFlight = useMessagesStore(
+    (s) => s.runningBySession[sessionId] === true,
   );
   const error = useMessagesStore((s) => s.errorBySession[sessionId] ?? null);
   const hydrate = useMessagesStore((s) => s.hydrate);
@@ -114,6 +118,9 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
               resultsByItemId={resultsByItemId}
             />
           ))}
+          {inFlight && (
+            <WorkingRow messages={messages} />
+          )}
         </div>
       )}
       {error !== null && (
@@ -121,6 +128,63 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
           {error}
         </div>
       )}
+    </div>
+  );
+}
+
+const formatElapsed = (ms: number): string => {
+  const totalSec = ms / 1000;
+  if (totalSec < 60) return `${totalSec.toFixed(1)}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec - min * 60;
+  return `${min}m ${sec.toFixed(1)}s`;
+};
+
+const PATTERNS = [
+  "frame",
+  "corners",
+  "checker",
+  "x",
+  "full",
+] as const;
+type Pattern = (typeof PATTERNS)[number];
+
+function pickDifferent(current: Pattern | null): Pattern {
+  const candidates = PATTERNS.filter((p) => p !== current);
+  return candidates[Math.floor(Math.random() * candidates.length)]!;
+}
+
+function WorkingRow({ messages }: { messages: ReadonlyArray<Message> }) {
+  const anchorMs = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]!;
+      if (m.content._tag === "user") return m.createdAt.getTime();
+    }
+    return null;
+  }, [messages]);
+
+  const [now, setNow] = useState(() => Date.now());
+  const [pattern, setPattern] = useState<Pattern>(() => pickDifferent(null));
+  useEffect(() => {
+    const tickId = window.setInterval(() => setNow(Date.now()), 100);
+    const patternId = window.setInterval(
+      () => setPattern((prev) => pickDifferent(prev)),
+      2200,
+    );
+    return () => {
+      window.clearInterval(tickId);
+      window.clearInterval(patternId);
+    };
+  }, []);
+
+  const elapsed = anchorMs === null ? 0 : Math.max(0, now - anchorMs);
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground">
+      <div data-pattern={pattern}>
+        <GradientDescent dotSize={2.5} cellPadding={0.75} speed={1.2} />
+      </div>
+      <span className="tabular-nums">{formatElapsed(elapsed)}</span>
     </div>
   );
 }

--- a/apps/renderer/src/components/file-badge.tsx
+++ b/apps/renderer/src/components/file-badge.tsx
@@ -1,0 +1,28 @@
+import { FileIcon } from "./file-icon.tsx";
+
+const basename = (p: string): string => {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+};
+
+/**
+ * Pill that pairs a Material file-type icon with a filename. Used by tool
+ * rows (Read, Edit, Write, …) to make a path scannable at a glance and to
+ * keep the visual treatment consistent across tools.
+ */
+export function FileBadge({ path }: { path: string }) {
+  const name = basename(path);
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-1.5 py-0.5 text-[11px] text-foreground/90"
+      title={path}
+    >
+      <FileIcon
+        name={name}
+        kind="file"
+        className="inline-flex size-3.5 shrink-0 items-center justify-center"
+      />
+      <span className="truncate font-mono">{name}</span>
+    </span>
+  );
+}

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -61,6 +61,41 @@ interface DiffLine {
   readonly newLine: number | null;
 }
 
+/**
+ * Total +/- line counts across a set of edits, without rendering the diff.
+ * For a `Write` (mode === "create") we count every line in newText as an
+ * addition and skip subtraction.
+ */
+export const diffStats = (
+  edits: ReadonlyArray<FileEdit>,
+): { added: number; removed: number } => {
+  let added = 0;
+  let removed = 0;
+  for (const edit of edits) {
+    if (edit.mode === "create") {
+      added += edit.newText === "" ? 0 : edit.newText.split("\n").length;
+      continue;
+    }
+    const patch = structuredPatch(
+      edit.path,
+      edit.path,
+      edit.oldText,
+      edit.newText,
+      "",
+      "",
+      { context: 0 },
+    );
+    for (const hunk of patch.hunks) {
+      for (const raw of hunk.lines) {
+        const m = raw.charAt(0);
+        if (m === "+") added += 1;
+        else if (m === "-") removed += 1;
+      }
+    }
+  }
+  return { added, removed };
+};
+
 const buildDiff = (edit: FileEdit): ReadonlyArray<DiffLine> => {
   const patch = structuredPatch(
     edit.path,

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Fiber, Stream } from "effect";
 import {
   Archive,
   ArchiveRestore,
@@ -30,6 +30,7 @@ import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { cn, formatCompactNumber } from "~/lib/utils";
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { useMessagesStore } from "../store/messages.ts";
 import { usePrStateStore } from "../store/pr-state.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSessionsStore } from "../store/sessions.ts";
@@ -39,6 +40,7 @@ import { useWorkspaceStore } from "../store/workspace.ts";
 import { BranchIcon, type BranchState } from "./branch-icon.tsx";
 import { PermissionsInspector } from "./permissions-inspector.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
+import { GradientDescent } from "./ui/gradient-descent.tsx";
 
 const initialsOf = (name: string): string => {
   const parts = name.split(/[-_.\s]+/).filter(Boolean);
@@ -557,6 +559,49 @@ function SessionRow({ session }: { session: Session }) {
   const unarchive = useSessionsStore((s) => s.unarchive);
   const remove = useSessionsStore((s) => s.remove);
   const prInfo = usePrStateStore((s) => s.byFolder[session.projectId] ?? null);
+  // Live "agent is working" signal — replaces the branch icon while running
+  // so users scanning the sidebar see at a glance which sessions are busy
+  // even when they're focused on a different chat. The messages store only
+  // maintains streamStatus for the active session, so each SessionRow owns
+  // its own subscription and writes back into the same map. (Active-session
+  // double-writes converge harmlessly.)
+  const isRunning = useMessagesStore(
+    (s) => s.runningBySession[session.id] === true,
+  );
+  useEffect(() => {
+    let cancelled = false;
+    let fiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
+    void (async () => {
+      try {
+        const client = await getRpcClient();
+        if (cancelled) return;
+        fiber = Effect.runFork(
+          Stream.runForEach(
+            client.session.streamStatus({ sessionId: session.id }),
+            (event) =>
+              Effect.sync(() => {
+                if (cancelled) return;
+                useMessagesStore.setState((s) => ({
+                  runningBySession: {
+                    ...s.runningBySession,
+                    [session.id]: event.status === "running",
+                  },
+                }));
+              }),
+          ),
+        );
+      } catch {
+        // Best-effort — sidebar still renders the branch icon if the
+        // status stream is unavailable.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (fiber !== null) {
+        void Effect.runPromise(Fiber.interrupt(fiber)).catch(() => {});
+      }
+    };
+  }, [session.id]);
 
   const isSelected = selectedSessionId === session.id;
   const isArchived = session.archivedAt !== null;
@@ -634,11 +679,31 @@ function SessionRow({ session }: { session: Session }) {
         )}
         title={`${session.providerId} · ${session.model}`}
       >
-        <BranchIcon
-          state={branchState}
-          selected={isSelected}
-          className="ml-3"
-        />
+        {isRunning ? (
+          <span
+            className={cn(
+              "ml-3 inline-flex size-3.5 shrink-0 items-center justify-center",
+              isSelected
+                ? "text-sidebar-accent-foreground"
+                : "text-foreground",
+            )}
+            aria-label="Agent is working"
+            title="Agent is working"
+          >
+            <GradientDescent
+              dotSize={2}
+              cellPadding={0.5}
+              speed={1.4}
+              color="currentColor"
+            />
+          </span>
+        ) : (
+          <BranchIcon
+            state={branchState}
+            selected={isSelected}
+            className="ml-3"
+          />
+        )}
         <span className="min-w-0 flex-1 truncate">{session.title}</span>
         {/* Right-side slot: idle row shows diff stats (if PR open/closed) or
             timestamp (no PR). On hover the slot swaps to a single Archive

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -27,6 +27,37 @@ import {
 
 type IconHandle = Parameters<typeof HugeiconsIcon>[0]["icon"];
 
+/**
+ * Map a tool name to the same Hugeicon used in its expanded ToolRow. Other
+ * surfaces (e.g. the turn-summary icon preview) reuse this so the icons
+ * stay in lockstep across the timeline.
+ */
+export const iconForTool = (tool: string): IconHandle => {
+  switch (tool) {
+    case "Bash":
+      return TerminalIcon;
+    case "Read":
+      return File01Icon;
+    case "Edit":
+    case "Write":
+    case "MultiEdit":
+      return PencilEdit01Icon;
+    case "Grep":
+    case "Glob":
+      return SearchIcon;
+    case "Task":
+    case "Agent":
+      return Robot01Icon;
+    case "WebFetch":
+    case "WebSearch":
+      return GlobeIcon;
+    case "TodoWrite":
+      return CheckListIcon;
+    default:
+      return Wrench01Icon;
+  }
+};
+
 interface ToolResult {
   readonly output: unknown;
   readonly isError: boolean;

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -17,7 +17,13 @@ import remarkGfm from "remark-gfm";
 
 import { cn } from "~/lib/utils";
 
-import { DiffBody, extractEdits, type FileEdit } from "./inline-diff.tsx";
+import { FileBadge } from "./file-badge.tsx";
+import {
+  DiffBody,
+  diffStats,
+  extractEdits,
+  type FileEdit,
+} from "./inline-diff.tsx";
 
 type IconHandle = Parameters<typeof HugeiconsIcon>[0]["icon"];
 
@@ -271,7 +277,7 @@ function ExpandableIconRow({
         ) : null}
       </button>
       {expanded && hasContent ? (
-        <div className="ml-7 mt-1 space-y-2 border-l border-border/60 pl-3 pr-1">
+        <div className="ml-7 mt-1 max-w-2xl space-y-2 overflow-hidden border-l border-border/60 pl-3 pr-1">
           {body}
         </div>
       ) : null}
@@ -357,10 +363,10 @@ const buildToolView = (
         label: "Read",
         trailing:
           path !== null ? (
-            <>
-              <InlineTextHint value={linesHint} />
-              <InlineCodeChip value={basename(path)} />
-            </>
+            <span className="flex items-center gap-2">
+              <span className="text-muted-foreground">{linesHint}</span>
+              <FileBadge path={path} />
+            </span>
           ) : undefined,
         inputPanel:
           path !== null ? (
@@ -398,12 +404,21 @@ const buildToolView = (
           : tool === "MultiEdit"
             ? `MultiEdit (${edits.length})`
             : "Edit";
+      const stats = edits.length > 0 ? diffStats(edits) : null;
       return {
         icon: PencilEdit01Icon,
         label,
         trailing:
           path !== null ? (
-            <InlineCodeChip value={basename(path)} />
+            <span className="flex items-center gap-2 tabular-nums">
+              <FileBadge path={path} />
+              {stats !== null && stats.added > 0 ? (
+                <span className="text-emerald-400">+{stats.added}</span>
+              ) : null}
+              {stats !== null && stats.removed > 0 ? (
+                <span className="text-red-400">-{stats.removed}</span>
+              ) : null}
+            </span>
           ) : undefined,
         fallbackBody:
           edits.length > 0 ? (

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -1,0 +1,223 @@
+import {
+  BubbleChatIcon,
+  Wrench01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import type { AgentItemId, Message } from "@forkzero/wire";
+
+import { cn } from "~/lib/utils";
+
+import { FileBadge } from "./file-badge.tsx";
+import { diffStats, extractEdits } from "./inline-diff.tsx";
+import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import { iconForTool } from "./tool-row.tsx";
+
+const formatElapsed = (ms: number): string => {
+  const totalSec = ms / 1000;
+  if (totalSec < 60) return `${totalSec.toFixed(1)}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = Math.round(totalSec - min * 60);
+  return `${min}m, ${sec}s`;
+};
+
+interface FileStat {
+  readonly path: string;
+  readonly added: number;
+  readonly removed: number;
+}
+
+const aggregateFileStats = (body: ReadonlyArray<Message>): FileStat[] => {
+  const map = new Map<string, { added: number; removed: number }>();
+  for (const m of body) {
+    if (m.content._tag !== "tool_use") continue;
+    const tool = m.content.tool;
+    if (tool !== "Edit" && tool !== "Write" && tool !== "MultiEdit") continue;
+    const edits = extractEdits(tool, m.content.input);
+    if (edits.length === 0) continue;
+    const stats = diffStats(edits);
+    const path = edits[0]!.path;
+    const prev = map.get(path) ?? { added: 0, removed: 0 };
+    map.set(path, {
+      added: prev.added + stats.added,
+      removed: prev.removed + stats.removed,
+    });
+  }
+  return Array.from(map.entries()).map(([path, s]) => ({ path, ...s }));
+};
+
+const findFinalAssistant = (
+  body: ReadonlyArray<Message>,
+): Message | null => {
+  for (let i = body.length - 1; i >= 0; i--) {
+    const m = body[i]!;
+    if (m.content._tag === "assistant") return m;
+  }
+  return null;
+};
+
+const MAX_PREVIEW_ICONS = 5;
+
+/**
+ * Inline summary of a completed turn. The header (chevron + counts + tool
+ * icon preview) toggles the detail rows. The final assistant text always
+ * shows below; the footer carries elapsed time and file edit stats. No
+ * outer card — sections sit flat in the timeline like every other row.
+ */
+export function TurnSummary({
+  body,
+  resultsByItemId,
+}: {
+  body: ReadonlyArray<Message>;
+  resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const toolUses = useMemo(
+    () => body.filter((m) => m.content._tag === "tool_use"),
+    [body],
+  );
+  const messageCount = useMemo(
+    () =>
+      body.filter(
+        (m) =>
+          m.content._tag === "thinking" || m.content._tag === "assistant",
+      ).length,
+    [body],
+  );
+
+  const finalAssistant = useMemo(() => findFinalAssistant(body), [body]);
+  const fileStats = useMemo(() => aggregateFileStats(body), [body]);
+
+  const duration = useMemo(() => {
+    if (body.length === 0) return 0;
+    const start = body[0]!.createdAt.getTime();
+    const end = body[body.length - 1]!.createdAt.getTime();
+    return Math.max(0, end - start);
+  }, [body]);
+
+  const detailRows = useMemo(
+    () => body.filter((m) => m !== finalAssistant),
+    [body, finalAssistant],
+  );
+
+  // Dedupe by icon identity (not tool name) — Edit/Write/MultiEdit share an
+  // icon, as do Grep/Glob, etc. We want one slot per visual, ordered by
+  // first appearance in the turn.
+  const previewIcons = useMemo(() => {
+    const items: { key: string; icon: ReturnType<typeof iconForTool> }[] = [];
+    const seen = new Set<unknown>();
+    for (const m of toolUses) {
+      if (m.content._tag !== "tool_use") continue;
+      const icon = iconForTool(m.content.tool);
+      if (seen.has(icon)) continue;
+      seen.add(icon);
+      items.push({ key: m.id, icon });
+    }
+    return items;
+  }, [toolUses]);
+
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+  const mutedWhenOpen = expanded
+    ? "text-muted-foreground/50"
+    : "text-muted-foreground";
+
+  const overflowCount = previewIcons.length - MAX_PREVIEW_ICONS;
+
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className={cn(
+          "flex w-full items-center gap-3 rounded px-4 py-1.5 text-left text-[11px] transition-colors hover:bg-muted/40",
+          mutedWhenOpen,
+        )}
+      >
+        <Chevron className="size-3.5 shrink-0 opacity-70" />
+        <span className="flex items-center gap-1.5">
+          <HugeiconsIcon
+            icon={Wrench01Icon}
+            strokeWidth={2}
+            aria-hidden="true"
+            className="size-3.5"
+          />
+          <span className="tabular-nums">{toolUses.length}</span>
+          <span>tool {toolUses.length === 1 ? "call" : "calls"}</span>
+        </span>
+        <span className="flex items-center gap-1.5">
+          <HugeiconsIcon
+            icon={BubbleChatIcon}
+            strokeWidth={2}
+            aria-hidden="true"
+            className="size-3.5"
+          />
+          <span className="tabular-nums">{messageCount}</span>
+          <span>{messageCount === 1 ? "message" : "messages"}</span>
+        </span>
+        {previewIcons.length > 0 ? (
+          <span className="flex items-center gap-1.5 opacity-70">
+            {previewIcons.slice(0, MAX_PREVIEW_ICONS).map((p) => (
+              <HugeiconsIcon
+                key={p.key}
+                icon={p.icon}
+                strokeWidth={2}
+                aria-hidden="true"
+                className="size-3.5"
+              />
+            ))}
+            {overflowCount > 0 ? (
+              <span className="tabular-nums">+{overflowCount}</span>
+            ) : null}
+          </span>
+        ) : null}
+      </button>
+
+      {expanded && detailRows.length > 0 ? (
+        <div className="py-1">
+          {detailRows.map((m) => (
+            <MessageRow
+              key={m.id}
+              message={m}
+              resultsByItemId={resultsByItemId}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {finalAssistant !== null && finalAssistant.content._tag === "assistant" ? (
+        <div className="px-4 py-2">
+          <div className="fz-prose max-w-[88%]">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {finalAssistant.content.text}
+            </ReactMarkdown>
+          </div>
+        </div>
+      ) : null}
+
+      <div
+        className={cn(
+          "flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-1.5 text-[11px]",
+          mutedWhenOpen,
+        )}
+      >
+        <span className="tabular-nums">{formatElapsed(duration)}</span>
+        {fileStats.map((f) => (
+          <span key={f.path} className="flex items-center gap-1.5 tabular-nums">
+            <FileBadge path={f.path} />
+            {f.added > 0 ? (
+              <span className="text-emerald-400/80">+{f.added}</span>
+            ) : null}
+            {f.removed > 0 ? (
+              <span className="text-red-400/80">-{f.removed}</span>
+            ) : null}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/ui/gradient-descent.module.css
+++ b/apps/renderer/src/components/ui/gradient-descent.module.css
@@ -1,0 +1,10 @@
+@keyframes gradient-descent {
+  0%, 100% { opacity: 0.16; }
+  12%      { opacity: 1; }
+  30%      { opacity: 0.16; }
+}
+
+.loader :global(.dot) {
+  animation: gradient-descent calc(1.4s / var(--speed, 1)) linear infinite;
+  animation-delay: calc(var(--diag, 0) * 120ms / var(--speed, 1));
+}

--- a/apps/renderer/src/components/ui/gradient-descent.tsx
+++ b/apps/renderer/src/components/ui/gradient-descent.tsx
@@ -1,0 +1,23 @@
+import type { CSSProperties } from 'react';
+import { coords4 } from '~/lib/grid-coords';
+import { loaderStyle, type LoaderProps } from '~/lib/loader-props';
+import styles from './gradient-descent.module.css';
+
+export function GradientDescent(props: LoaderProps = {}) {
+  return (
+    <div
+      className={`loader ${styles.loader}${props.className ? ` ${props.className}` : ''}`}
+      style={loaderStyle(props, { '--grid-size': 4 })}
+      role='status'
+      aria-label={props['aria-label'] ?? 'Loading'}
+    >
+      {coords4.map((c) => (
+        <span
+          key={c.i}
+          className='dot'
+          style={{ '--diag': c.diag } as CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/ui/loaders/grid.css
+++ b/apps/renderer/src/components/ui/loaders/grid.css
@@ -1,0 +1,146 @@
+.loader {
+  --grid-size: 5;
+  --dot-size: 4px;
+  --dot-gap: 3px;
+  --dim: 0.16;
+  --bright: 1;
+  --cycle: 1.6s;
+  --step: 60ms;
+
+  display: grid;
+  grid-template-columns: repeat(var(--grid-size), var(--dot-size));
+  gap: var(--dot-gap);
+  width: max-content;
+}
+
+.loader .dot {
+  width: var(--dot-size);
+  height: var(--dot-size);
+  border-radius: 50%;
+  background: var(--color-dot, #fff);
+  opacity: var(--dim);
+  transform: translateZ(0) scale(1);
+  will-change: transform, opacity;
+}
+
+[data-paused='true'] .loader .dot {
+  animation-play-state: paused;
+  will-change: auto;
+}
+
+/* Pattern masking — applies to any [data-pattern] wrapper around a loader.
+   Hides dots not in the active pattern's index set. Default 'full' has no
+   rule (existing behavior preserved). Indices below are 1-based nth-child
+   positions of dots that should be HIDDEN (i.e. NOT in PATTERN_MASKS). */
+
+/* Diamond — Manhattan distance ≤ 2; hides 12 corner/edge dots */
+[data-pattern='diamond'] > * > *:nth-child(1),
+[data-pattern='diamond'] > * > *:nth-child(2),
+[data-pattern='diamond'] > * > *:nth-child(4),
+[data-pattern='diamond'] > * > *:nth-child(5),
+[data-pattern='diamond'] > * > *:nth-child(6),
+[data-pattern='diamond'] > * > *:nth-child(10),
+[data-pattern='diamond'] > * > *:nth-child(16),
+[data-pattern='diamond'] > * > *:nth-child(20),
+[data-pattern='diamond'] > * > *:nth-child(21),
+[data-pattern='diamond'] > * > *:nth-child(22),
+[data-pattern='diamond'] > * > *:nth-child(24),
+[data-pattern='diamond'] > * > *:nth-child(25),
+
+/* Outline — frame only; hides inner 3×3 (9 dots) */
+[data-pattern='outline'] > * > *:nth-child(7),
+[data-pattern='outline'] > * > *:nth-child(8),
+[data-pattern='outline'] > * > *:nth-child(9),
+[data-pattern='outline'] > * > *:nth-child(12),
+[data-pattern='outline'] > * > *:nth-child(13),
+[data-pattern='outline'] > * > *:nth-child(14),
+[data-pattern='outline'] > * > *:nth-child(17),
+[data-pattern='outline'] > * > *:nth-child(18),
+[data-pattern='outline'] > * > *:nth-child(19),
+
+/* Cross — `+` shape; hides 16 quadrant dots */
+[data-pattern='cross'] > * > *:nth-child(1),
+[data-pattern='cross'] > * > *:nth-child(2),
+[data-pattern='cross'] > * > *:nth-child(4),
+[data-pattern='cross'] > * > *:nth-child(5),
+[data-pattern='cross'] > * > *:nth-child(6),
+[data-pattern='cross'] > * > *:nth-child(7),
+[data-pattern='cross'] > * > *:nth-child(9),
+[data-pattern='cross'] > * > *:nth-child(10),
+[data-pattern='cross'] > * > *:nth-child(16),
+[data-pattern='cross'] > * > *:nth-child(17),
+[data-pattern='cross'] > * > *:nth-child(19),
+[data-pattern='cross'] > * > *:nth-child(20),
+[data-pattern='cross'] > * > *:nth-child(21),
+[data-pattern='cross'] > * > *:nth-child(22),
+[data-pattern='cross'] > * > *:nth-child(24),
+[data-pattern='cross'] > * > *:nth-child(25),
+
+/* Rings — frame + center; hides middle ring around center (8 dots) */
+[data-pattern='rings'] > * > *:nth-child(7),
+[data-pattern='rings'] > * > *:nth-child(8),
+[data-pattern='rings'] > * > *:nth-child(9),
+[data-pattern='rings'] > * > *:nth-child(12),
+[data-pattern='rings'] > * > *:nth-child(14),
+[data-pattern='rings'] > * > *:nth-child(17),
+[data-pattern='rings'] > * > *:nth-child(18),
+[data-pattern='rings'] > * > *:nth-child(19),
+
+/* Rose — 4-petal symmetric flower; hides 12 dots */
+[data-pattern='rose'] > * > *:nth-child(1),
+[data-pattern='rose'] > * > *:nth-child(3),
+[data-pattern='rose'] > * > *:nth-child(5),
+[data-pattern='rose'] > * > *:nth-child(7),
+[data-pattern='rose'] > * > *:nth-child(9),
+[data-pattern='rose'] > * > *:nth-child(11),
+[data-pattern='rose'] > * > *:nth-child(15),
+[data-pattern='rose'] > * > *:nth-child(17),
+[data-pattern='rose'] > * > *:nth-child(19),
+[data-pattern='rose'] > * > *:nth-child(21),
+[data-pattern='rose'] > * > *:nth-child(23),
+[data-pattern='rose'] > * > *:nth-child(25) {
+  /* off-pattern dots stay visible (full 5x5 silhouette preserved) but
+     don't animate — only on-pattern dots pulse, giving the loader its
+     pattern shape via animation, not via masking. */
+  animation: none !important;
+}
+
+/* 4x4 patterns — 16 dots indexed 1..16 row-major:
+    1  2  3  4
+    5  6  7  8
+    9 10 11 12
+   13 14 15 16  */
+
+/* frame — outer ring only; hides inner 4 */
+[data-pattern='frame'] > * > *:nth-child(6),
+[data-pattern='frame'] > * > *:nth-child(7),
+[data-pattern='frame'] > * > *:nth-child(10),
+[data-pattern='frame'] > * > *:nth-child(11),
+
+/* corners — hides 4 corners, leaves chubby plus */
+[data-pattern='corners'] > * > *:nth-child(1),
+[data-pattern='corners'] > * > *:nth-child(4),
+[data-pattern='corners'] > * > *:nth-child(13),
+[data-pattern='corners'] > * > *:nth-child(16),
+
+/* checker — animate one alternating set */
+[data-pattern='checker'] > * > *:nth-child(2),
+[data-pattern='checker'] > * > *:nth-child(4),
+[data-pattern='checker'] > * > *:nth-child(5),
+[data-pattern='checker'] > * > *:nth-child(7),
+[data-pattern='checker'] > * > *:nth-child(10),
+[data-pattern='checker'] > * > *:nth-child(12),
+[data-pattern='checker'] > * > *:nth-child(13),
+[data-pattern='checker'] > * > *:nth-child(15),
+
+/* x — both diagonals only */
+[data-pattern='x'] > * > *:nth-child(2),
+[data-pattern='x'] > * > *:nth-child(3),
+[data-pattern='x'] > * > *:nth-child(5),
+[data-pattern='x'] > * > *:nth-child(8),
+[data-pattern='x'] > * > *:nth-child(9),
+[data-pattern='x'] > * > *:nth-child(12),
+[data-pattern='x'] > * > *:nth-child(14),
+[data-pattern='x'] > * > *:nth-child(15) {
+  animation: none !important;
+}

--- a/apps/renderer/src/components/ui/loaders/reduced-motion.css
+++ b/apps/renderer/src/components/ui/loaders/reduced-motion.css
@@ -1,0 +1,16 @@
+@media (prefers-reduced-motion: reduce) {
+  @keyframes loader-rm-pulse {
+    0%, 100% { opacity: 0.4; }
+    50%      { opacity: 1; }
+  }
+
+  .loader:not([data-preview] *) {
+    animation: loader-rm-pulse 2s ease-in-out infinite;
+  }
+
+  .loader:not([data-preview] *) .dot {
+    animation: none !important;
+    opacity: 0.85 !important;
+    transform: translateZ(0) !important;
+  }
+}

--- a/apps/renderer/src/components/ui/token-stream.module.css
+++ b/apps/renderer/src/components/ui/token-stream.module.css
@@ -1,0 +1,10 @@
+@keyframes token-stream {
+  0%, 100% { opacity: 0.16; }
+  10%      { opacity: 1; }
+  25%      { opacity: 0.16; }
+}
+
+.loader :global(.dot) {
+  animation: token-stream calc(2s / var(--speed, 1)) linear infinite;
+  animation-delay: calc(var(--col, 0) * 320ms / var(--speed, 1));
+}

--- a/apps/renderer/src/components/ui/token-stream.tsx
+++ b/apps/renderer/src/components/ui/token-stream.tsx
@@ -1,0 +1,23 @@
+import type { CSSProperties } from 'react';
+import { coords5 } from '~/lib/grid-coords';
+import { loaderStyle, type LoaderProps } from '~/lib/loader-props';
+import styles from './token-stream.module.css';
+
+export function TokenStream(props: LoaderProps = {}) {
+  return (
+    <div
+      className={`loader ${styles.loader}${props.className ? ` ${props.className}` : ''}`}
+      style={loaderStyle(props)}
+      role='status'
+      aria-label={props['aria-label'] ?? 'Loading'}
+    >
+      {coords5.map((c) => (
+        <span
+          key={c.i}
+          className='dot'
+          style={{ '--col': c.col } as CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/renderer/src/lib/grid-coords.ts
+++ b/apps/renderer/src/lib/grid-coords.ts
@@ -1,0 +1,53 @@
+export type DotCoord = {
+  i: number;
+  col: number;
+  row: number;
+  dist: number;
+  diag: number;
+  antiDiag: number;
+  angle: number;
+  rand: number;
+  cornerDist: number;
+  pairOrder: number;
+};
+
+const SEED = 0x9e3779b1;
+
+function pseudoRandom(seed: number): number {
+  let t = (seed + SEED) >>> 0;
+  t = Math.imul(t ^ (t >>> 16), 2246822507);
+  t = Math.imul(t ^ (t >>> 13), 3266489909);
+  t ^= t >>> 16;
+  return (t >>> 0) / 0xffffffff;
+}
+
+function buildCoords(size: number): DotCoord[] {
+  const center = (size - 1) / 2;
+  const total = size * size;
+  return Array.from({ length: total }, (_, i) => {
+    const col = i % size;
+    const row = Math.floor(i / size);
+    const dx = col - center;
+    const dy = row - center;
+    const angleRad = Math.atan2(dy, dx);
+    const normalized = (angleRad + Math.PI * 2.5) % (Math.PI * 2);
+    return {
+      i,
+      col,
+      row,
+      dist: Math.max(Math.abs(dx), Math.abs(dy)),
+      diag: col + row,
+      antiDiag: col + (size - 1 - row),
+      angle: normalized / (Math.PI * 2),
+      rand: pseudoRandom(i),
+      cornerDist: Math.max(
+        Math.min(col, size - 1 - col),
+        Math.min(row, size - 1 - row),
+      ),
+      pairOrder: Math.min(i, total - 1 - i),
+    };
+  });
+}
+
+export const coords5: DotCoord[] = buildCoords(5);
+export const coords4: DotCoord[] = buildCoords(4);

--- a/apps/renderer/src/lib/loader-props.ts
+++ b/apps/renderer/src/lib/loader-props.ts
@@ -1,0 +1,29 @@
+import type { CSSProperties } from 'react';
+
+export type LoaderProps = {
+  /** Pixel size of each dot. Default 4. */
+  dotSize?: number;
+  /** Padding around each dot inside its grid cell, in px. Default ~1.5 (gap of 3). */
+  cellPadding?: number;
+  /** Animation speed multiplier. 1 = default, 2 = 2x faster. Default 1. */
+  speed?: number;
+  /** Dot color. Any CSS color (hex, rgb, named). Default inherits from --color-dot. */
+  color?: string;
+  /** Pass-through className for the loader root. */
+  className?: string;
+  /** Override the default 'Loading' aria-label. */
+  'aria-label'?: string;
+};
+
+export function loaderStyle(
+  props: LoaderProps,
+  extra?: Record<string, string | number>,
+): CSSProperties {
+  const style: Record<string, string | number> = {};
+  if (props.dotSize != null) style['--dot-size'] = `${props.dotSize}px`;
+  if (props.cellPadding != null) style['--dot-gap'] = `${props.cellPadding * 2}px`;
+  if (props.speed != null) style['--speed'] = props.speed;
+  if (props.color != null) style['--color-dot'] = props.color;
+  if (extra) Object.assign(style, extra);
+  return style as CSSProperties;
+}

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -3,6 +3,8 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
 @import "@fontsource-variable/geist-mono";
+@import "./components/ui/loaders/grid.css";
+@import "./components/ui/loaders/reduced-motion.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -224,6 +224,7 @@ const translate = (
             preview: summarize(text),
           });
           if (!state.emittedThinkingThisTurn) {
+            state.emittedThinkingThisTurn = true;
             out.push({
               _tag: "Thinking",
               itemId: nextItemId(),
@@ -236,6 +237,7 @@ const translate = (
             emittedFromDeltasThisTurn: state.emittedThinkingThisTurn,
           });
           if (!state.emittedThinkingThisTurn) {
+            state.emittedThinkingThisTurn = true;
             out.push({
               _tag: "Thinking",
               itemId: nextItemId(),
@@ -339,6 +341,11 @@ const translate = (
         signatureLen: acc.signatureLength,
         textPreview: summarize(acc.text),
       });
+      // If the assistant-message path already emitted thinking for this
+      // turn (rare ordering: full message arrives before trailing
+      // content_block_stop), skip — otherwise we render the same thought
+      // twice.
+      if (state.emittedThinkingThisTurn) return [];
       if (acc.kind === "redacted_thinking") {
         state.emittedThinkingThisTurn = true;
         return [


### PR DESCRIPTION
## Summary
- New 5×5 / 4×4 dot-grid loaders (`TokenStream`, `GradientDescent`) with pattern masks; replaces the bullet-glyph "agent working" indicator and the red interrupt button with a calmer minimal pair.
- Completed turns collapse into a `TurnSummary` (counts, deduped tool-icon preview, final assistant text, per-file diff stats) — flat rendering for live / no-final-text turns.
- New `FileBadge` chip is wired into Read / Edit / Write tool rows; `inline-diff` exposes `diffStats` for aggregate `+N / -N`.
- Composer drops the per-turn `TurnTimer` and gains a session-total chip (sum of every turn's duration, idle gaps excluded).
- Sidebar: each `SessionRow` now owns a `session.streamStatus` subscription, so the leading branch icon is replaced by a small loader for **any** running session — even when you're focused on a different chat.
- Claude driver: dedup the `Thinking` emit when the SDK delivers the full assistant message before the trailing `content_block_stop`.

## Test plan
- [ ] Send a turn with tools → loader animates beside live elapsed; on completion, summary collapses with counts + final text.
- [ ] Expand a summary → header + footer dim; intermediate rows render between header and final text.
- [ ] Read / Edit rows show `FileBadge`; Edit shows `+N / -N`.
- [ ] Start a session and switch to another → first session's sidebar row swaps the branch icon for a loader; reverts on completion.
- [ ] Confirm Thinking rows are not duplicated for any model invocation.