### PR TITLE
ui: solid action buttons, Checks tab, minimal status glyphs

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,5 +1,5 @@
 import { RpcSerialization } from "@effect/rpc";
-import { app, BrowserWindow, dialog, net, protocol } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, net, protocol } from "electron";
 import { Effect, Fiber, Layer } from "effect";
 import * as fs from "node:fs/promises";
 import * as Path from "node:path";
@@ -103,6 +103,38 @@ function createMainWindow() {
   mainWindow.on("enter-full-screen", sendFullScreenState);
   mainWindow.on("leave-full-screen", sendFullScreenState);
   mainWindow.webContents.on("did-finish-load", sendFullScreenState);
+
+  // Inline browser: when the renderer asks to "view PR" we open the URL in
+  // a child Chromium window with no node integration rather than handing
+  // off to the user's default browser. Same Chromium process, so the user
+  // doesn't lose context. We allowlist http/https only — any other scheme
+  // is dropped silently to avoid acting as a free `shell.openExternal`.
+  ipcMain.on("app:openInlineUrl", (_event, rawUrl: unknown) => {
+    if (typeof rawUrl !== "string") return;
+    let parsed: URL;
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      return;
+    }
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return;
+    const child = new BrowserWindow({
+      width: 1100,
+      height: 800,
+      minWidth: 480,
+      minHeight: 360,
+      parent: mainWindow ?? undefined,
+      title: parsed.host,
+      autoHideMenuBar: true,
+      backgroundColor: "#0b0b0c",
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+    void child.loadURL(parsed.toString());
+  });
 
   // Boot the Effect runtime once the window's webContents exists. The RPC
   // server protocol is bound to this webContents, so a window restart means

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,5 +1,5 @@
 import { RpcSerialization } from "@effect/rpc";
-import { app, BrowserWindow, dialog, ipcMain, net, protocol } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, net, protocol, shell } from "electron";
 import { Effect, Fiber, Layer } from "effect";
 import * as fs from "node:fs/promises";
 import * as Path from "node:path";
@@ -104,12 +104,11 @@ function createMainWindow() {
   mainWindow.on("leave-full-screen", sendFullScreenState);
   mainWindow.webContents.on("did-finish-load", sendFullScreenState);
 
-  // Inline browser: when the renderer asks to "view PR" we open the URL in
-  // a child Chromium window with no node integration rather than handing
-  // off to the user's default browser. Same Chromium process, so the user
-  // doesn't lose context. We allowlist http/https only — any other scheme
-  // is dropped silently to avoid acting as a free `shell.openExternal`.
-  ipcMain.on("app:openInlineUrl", (_event, rawUrl: unknown) => {
+  // Hand off http(s) URLs to the OS default browser via `shell.openExternal`
+  // — the renderer asked to leave Electron, not to host another Chromium
+  // window inside the app. Allowlist scheme so the bridge can't be coaxed
+  // into running arbitrary shell URI handlers.
+  ipcMain.on("app:openExternal", (_event, rawUrl: unknown) => {
     if (typeof rawUrl !== "string") return;
     let parsed: URL;
     try {
@@ -118,22 +117,7 @@ function createMainWindow() {
       return;
     }
     if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return;
-    const child = new BrowserWindow({
-      width: 1100,
-      height: 800,
-      minWidth: 480,
-      minHeight: 360,
-      parent: mainWindow ?? undefined,
-      title: parsed.host,
-      autoHideMenuBar: true,
-      backgroundColor: "#0b0b0c",
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: true,
-      },
-    });
-    void child.loadURL(parsed.toString());
+    void shell.openExternal(parsed.toString());
   });
 
   // Boot the Effect runtime once the window's webContents exists. The RPC

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -33,6 +33,11 @@ const bridge = {
       };
     },
   },
+  app: {
+    openInlineUrl: (url: string) => {
+      ipcRenderer.send("app:openInlineUrl", url);
+    },
+  },
 };
 
 contextBridge.exposeInMainWorld("forkzero", bridge);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -34,8 +34,8 @@ const bridge = {
     },
   },
   app: {
-    openInlineUrl: (url: string) => {
-      ipcRenderer.send("app:openInlineUrl", url);
+    openExternal: (url: string) => {
+      ipcRenderer.send("app:openExternal", url);
     },
   },
 };

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -17,11 +17,7 @@ import { PermissionToast } from "./components/permission-toast";
 import { ProjectsSidebar } from "./components/projects-sidebar";
 import { RightPane } from "./components/right-pane";
 import { SettingsPage } from "./components/settings-page";
-import {
-  TopBarLeft,
-  TopBarMain,
-  TopBarRight,
-} from "./components/top-bar.tsx";
+import { TopBarLeft, TopBarMain, TopBarRight } from "./components/top-bar.tsx";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { usePermissionsStore } from "./store/permissions.ts";
 import { useSessionsStore } from "./store/sessions.ts";
@@ -167,7 +163,7 @@ export function App() {
           </Panel>
           <Separator className="w-px bg-border transition-colors hover:bg-foreground/20 active:bg-foreground/30" />
           <Panel id="main" minSize="30%">
-            <main className="flex h-full min-h-0 min-w-0 flex-col bg-background">
+            <main className="flex h-full min-h-0 min-w-0 flex-col bg-background/20">
               <TopBarMain folderId={selectedFolderId} />
               {view === "settings" ? (
                 <SettingsPage />
@@ -225,7 +221,7 @@ export function App() {
               if (open !== rightSidebarOpen) setRightSidebarOpen(open);
             }}
           >
-            <div className="flex h-full min-h-0 flex-col bg-background">
+            <div className="flex h-full min-h-0 flex-col bg-background/20">
               <TopBarRight folderId={selectedFolderId} />
               <div className="flex min-h-0 flex-1 flex-col">
                 <RightPane />

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -154,7 +154,7 @@ export function App() {
               if (open !== leftSidebarOpen) setLeftSidebarOpen(open);
             }}
           >
-            <div className="flex h-full min-h-0 flex-col">
+            <div className="flex h-full min-h-0 flex-col bg-background/20">
               <TopBarLeft />
               <div className="flex min-h-0 flex-1 flex-col">
                 <ProjectsSidebar />
@@ -163,7 +163,7 @@ export function App() {
           </Panel>
           <Separator className="w-px bg-border transition-colors hover:bg-foreground/20 active:bg-foreground/30" />
           <Panel id="main" minSize="30%">
-            <main className="flex h-full min-h-0 min-w-0 flex-col bg-background/20">
+            <main className="flex h-full min-h-0 min-w-0 flex-col bg-background/70 backdrop-blur-3xl">
               <TopBarMain folderId={selectedFolderId} />
               {view === "settings" ? (
                 <SettingsPage />
@@ -221,7 +221,7 @@ export function App() {
               if (open !== rightSidebarOpen) setRightSidebarOpen(open);
             }}
           >
-            <div className="flex h-full min-h-0 flex-col bg-background/20">
+            <div className="flex h-full min-h-0 flex-col bg-sidebar/40 backdrop-blur-3xl">
               <TopBarRight folderId={selectedFolderId} />
               <div className="flex min-h-0 flex-1 flex-col">
                 <RightPane />

--- a/apps/renderer/src/components/checks-pane.tsx
+++ b/apps/renderer/src/components/checks-pane.tsx
@@ -1,0 +1,261 @@
+import {
+  CheckCircle2,
+  Circle,
+  CircleDashed,
+  ExternalLink,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+
+import type { FolderId, GitPrInfo } from "@forkzero/wire";
+
+import { softTone, type Tone } from "../lib/tones.ts";
+import { useGitStatusStore } from "../store/git-status.ts";
+import { usePrStateStore } from "../store/pr-state.ts";
+
+const openExternal = (url: string) => {
+  const bridge = window.forkzero?.app;
+  if (bridge !== undefined) {
+    bridge.openExternal(url);
+    return;
+  }
+  // Web preview / dev fallback.
+  window.open(url, "_blank", "noopener,noreferrer");
+};
+
+/**
+ * Right-pane "Checks" tab. Mirrors the workflow state that previously lived
+ * inline in the top bar — branch summary, PR pointer, draft state, and the
+ * aggregated status-check rollup. The top bar keeps only the primary action
+ * (Commit & push / Create PR / Merge) so the chrome stays uncluttered.
+ */
+export function ChecksPane({ folderId }: { folderId: FolderId | null }) {
+  const status = useGitStatusStore((s) =>
+    folderId ? (s.byFolder[folderId] ?? null) : null,
+  );
+  const pr = usePrStateStore((s) =>
+    folderId ? (s.byFolder[folderId] ?? null) : null,
+  );
+
+  if (folderId === null) {
+    return (
+      <Empty>Select a project to see its branch + PR status here.</Empty>
+    );
+  }
+  if (status === null) {
+    return <Empty>Reading branch state…</Empty>;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-3 py-3 text-xs">
+      <Section title="Branch">
+        <Row label="Name">
+          <span className="font-mono text-[11px] text-foreground">
+            {status.branch ?? "(detached)"}
+          </span>
+        </Row>
+        <Row label="Local changes">
+          {status.dirtyFiles > 0 ? (
+            <Pill tone="amber">
+              {status.dirtyFiles} file{status.dirtyFiles === 1 ? "" : "s"}
+            </Pill>
+          ) : (
+            <span className="text-muted-foreground">clean</span>
+          )}
+        </Row>
+        <Row label="Ahead of upstream">
+          {status.ahead > 0 ? (
+            <Pill tone="sky">{status.ahead} commit{status.ahead === 1 ? "" : "s"}</Pill>
+          ) : (
+            <span className="text-muted-foreground">in sync</span>
+          )}
+        </Row>
+      </Section>
+
+      <Section title="Pull request">
+        {pr === null || pr.state === "none" ? (
+          <p className="text-muted-foreground">
+            No pull request open for this branch.
+          </p>
+        ) : (
+          <>
+            <Row label="State">
+              <PrStatePill pr={pr} />
+            </Row>
+            <Row label="Number">
+              {pr.number !== null ? (
+                <span className="font-mono text-foreground">#{pr.number}</span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </Row>
+            <Row label="Diff">
+              <span className="font-mono text-[11px]">
+                <span className="text-emerald-300/90">+{pr.additions}</span>
+                {" "}
+                <span className="text-rose-300/90">−{pr.deletions}</span>
+              </span>
+            </Row>
+            {pr.url !== null ? (
+              <button
+                type="button"
+                onClick={() => openExternal(pr.url!)}
+                className="-mx-1 mt-1 flex items-center gap-1.5 rounded-sm px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+              >
+                <ExternalLink className="size-3" />
+                Open in browser
+              </button>
+            ) : null}
+          </>
+        )}
+      </Section>
+
+      <Section title="Checks">
+        {pr === null || pr.state === "none" ? (
+          <p className="text-muted-foreground">
+            Open a pull request to see CI status here.
+          </p>
+        ) : (
+          <ChecksSummary checks={pr.checks} isDraft={pr.isDraft} />
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-1.5">
+      <h3 className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h3>
+      <div className="flex flex-col gap-1">{children}</div>
+    </section>
+  );
+}
+
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="flex items-center gap-1.5">{children}</span>
+    </div>
+  );
+}
+
+function Pill({
+  tone,
+  children,
+}: {
+  tone: Tone;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={`flex items-center gap-1 rounded-sm px-1.5 py-0.5 font-mono text-[10px] ${softTone(tone)}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function PrStatePill({ pr }: { pr: GitPrInfo }) {
+  if (pr.isDraft) return <Pill tone="zinc">Draft</Pill>;
+  if (pr.state === "merged") return <Pill tone="violet">Merged</Pill>;
+  if (pr.state === "closed") return <Pill tone="rose">Closed</Pill>;
+  if (pr.checks === "failure") return <Pill tone="red">Open · checks failed</Pill>;
+  if (pr.checks === "pending") return <Pill tone="amber">Open · checks running</Pill>;
+  return <Pill tone="emerald">Open</Pill>;
+}
+
+function ChecksSummary({
+  checks,
+  isDraft,
+}: {
+  checks: GitPrInfo["checks"];
+  isDraft: boolean;
+}) {
+  if (isDraft) {
+    return (
+      <Indicator
+        icon={<CircleDashed className="size-4 text-zinc-400" />}
+        title="Draft"
+        body="Mark the PR as ready for review to start running checks."
+      />
+    );
+  }
+  if (checks === "none") {
+    return (
+      <Indicator
+        icon={<Circle className="size-4 text-muted-foreground" />}
+        title="No checks configured"
+        body="There aren't any required status checks on this branch."
+      />
+    );
+  }
+  if (checks === "pending") {
+    return (
+      <Indicator
+        icon={<Loader2 className="size-4 animate-spin text-amber-300" />}
+        title="Checks running"
+        body="At least one status check is still queued or in progress."
+      />
+    );
+  }
+  if (checks === "failure") {
+    return (
+      <Indicator
+        icon={<XCircle className="size-4 text-red-400" />}
+        title="Checks failed"
+        body="One or more checks didn't pass. Inspect the run on GitHub."
+      />
+    );
+  }
+  return (
+    <Indicator
+      icon={<CheckCircle2 className="size-4 text-emerald-400" />}
+      title="All checks passed"
+      body="The branch is clear to merge."
+    />
+  );
+}
+
+function Indicator({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="mt-0.5 shrink-0">{icon}</span>
+      <div className="flex flex-col gap-0.5">
+        <span className="font-medium text-foreground">{title}</span>
+        <span className="text-muted-foreground">{body}</span>
+      </div>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+      {children}
+    </p>
+  );
+}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -27,11 +27,7 @@ import {
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
-import {
-  Tooltip,
-  TooltipPopup,
-  TooltipTrigger,
-} from "~/components/ui/tooltip";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { cn, formatCompactNumber } from "~/lib/utils";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useMessagesStore } from "../store/messages.ts";
@@ -158,7 +154,7 @@ export function ProjectsSidebar() {
     setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
 
   return (
-    <aside className="flex h-full min-h-0 w-full flex-col bg-sidebar/80 backdrop-blur-3xl text-sidebar-foreground">
+    <aside className="flex h-full min-h-0 w-full flex-col backdrop-blur-3xl text-sidebar-foreground">
       <div className="flex items-center justify-between px-3 py-2 text-xs text-muted-foreground">
         <span>Projects</span>
         <Tooltip>

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -1,17 +1,22 @@
-import { FolderTree, TerminalSquare } from "lucide-react";
+import {
+  CircleCheck,
+  CircleDot,
+  FolderTree,
+  Loader2,
+  TerminalSquare,
+  XCircle,
+} from "lucide-react";
 import { useState } from "react";
 
+import { usePrStateStore } from "../store/pr-state.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
+import { ChecksPane } from "./checks-pane.tsx";
 import { FileTree } from "./file-tree.tsx";
 import { RightPaneHeader } from "./right-pane-header.tsx";
 import { TerminalPane } from "./terminal-pane.tsx";
-import {
-  Tooltip,
-  TooltipPopup,
-  TooltipTrigger,
-} from "./ui/tooltip.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
-type Tab = "files" | "terminal";
+type Tab = "files" | "terminal" | "checks";
 
 /**
  * Right-pane shell with two tabs: project file tree and a single PTY scoped
@@ -25,10 +30,28 @@ export function RightPane() {
   const selected = selectedFolderId
     ? (folders.find((f) => f.id === selectedFolderId) ?? null)
     : null;
+  const pr = usePrStateStore((s) =>
+    selectedFolderId ? (s.byFolder[selectedFolderId] ?? null) : null,
+  );
   const [tab, setTab] = useState<Tab>("files");
 
+  // Tiny status glyph next to the "Checks" tab so users get a glance of CI
+  // health without expanding the tab. Mirrors what the top bar's badge tone
+  // signals when the user is on Files / Terminal.
+  let checksGlyph: React.ReactNode = (
+    <CircleDot className="size-3.5 text-muted-foreground" />
+  );
+  if (pr && pr.state === "open" && !pr.isDraft) {
+    if (pr.checks === "pending")
+      checksGlyph = <Loader2 className="size-3.5 animate-spin text-amber-300" />;
+    else if (pr.checks === "failure")
+      checksGlyph = <XCircle className="size-3.5 text-red-400" />;
+    else if (pr.checks === "success")
+      checksGlyph = <CircleCheck className="size-3.5 text-emerald-400" />;
+  }
+
   return (
-    <aside className="flex h-full min-h-0 w-full flex-col bg-sidebar/60">
+    <aside className="flex h-full min-h-0 w-full flex-col bg-sidebar/40">
       {selected ? <RightPaneHeader projectName={selected.name} /> : null}
       <div className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border px-1 text-xs">
         <TabButton
@@ -44,6 +67,13 @@ export function RightPane() {
           icon={<TerminalSquare className="size-3.5" />}
           label="Terminal"
           tooltip="Open a terminal in the project root"
+        />
+        <TabButton
+          active={tab === "checks"}
+          onClick={() => setTab("checks")}
+          icon={checksGlyph}
+          label="Checks"
+          tooltip="Branch + PR + CI status for this project"
         />
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
@@ -61,6 +91,9 @@ export function RightPane() {
             </div>
             <div hidden={tab !== "terminal"} className="min-h-0 flex-1">
               <TerminalPane />
+            </div>
+            <div hidden={tab !== "checks"} className="min-h-0 flex-1">
+              <ChecksPane folderId={selected.id} />
             </div>
           </>
         )}

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -1,11 +1,4 @@
-import {
-  CircleCheck,
-  CircleDot,
-  FolderTree,
-  Loader2,
-  TerminalSquare,
-  XCircle,
-} from "lucide-react";
+import { CircleDot, FolderTree, Loader2, TerminalSquare } from "lucide-react";
 import { useState } from "react";
 
 import { usePrStateStore } from "../store/pr-state.ts";
@@ -43,15 +36,17 @@ export function RightPane() {
   );
   if (pr && pr.state === "open" && !pr.isDraft) {
     if (pr.checks === "pending")
-      checksGlyph = <Loader2 className="size-3.5 animate-spin text-amber-300" />;
+      checksGlyph = (
+        <Loader2 className="size-3.5 animate-spin text-amber-300" />
+      );
     else if (pr.checks === "failure")
-      checksGlyph = <XCircle className="size-3.5 text-red-400" />;
+      checksGlyph = <span className="size-2 rounded-full bg-red-400" />;
     else if (pr.checks === "success")
-      checksGlyph = <CircleCheck className="size-3.5 text-emerald-400" />;
+      checksGlyph = <span className="size-2 rounded-full bg-emerald-400" />;
   }
 
   return (
-    <aside className="flex h-full min-h-0 w-full flex-col bg-sidebar/40">
+    <aside className="flex h-full min-h-0 w-full flex-col">
       {selected ? <RightPaneHeader projectName={selected.name} /> : null}
       <div className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border px-1 text-xs">
         <TabButton

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -3,6 +3,7 @@ import {
   GitBranch,
   GitMerge,
   GitPullRequestArrow,
+  Loader2,
   PanelLeftClose,
   PanelLeftOpen,
   PanelRightClose,
@@ -13,7 +14,12 @@ import { useEffect } from "react";
 
 import type { FolderId } from "@forkzero/wire";
 
-import { softInteractive, softTone, type Tone } from "../lib/tones.ts";
+import {
+  softInteractive,
+  softTone,
+  solidInteractive,
+  type Tone,
+} from "../lib/tones.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
 import { useGitStatusStore } from "../store/git-status.ts";
 import { usePrStateStore } from "../store/pr-state.ts";
@@ -170,21 +176,49 @@ type Workflow =
   | { kind: "idle" }
   | { kind: "dirty"; count: number }
   | { kind: "ahead"; count: number }
-  | { kind: "open-pr"; number: number | null; url: string };
+  | {
+      kind: "open-pr";
+      number: number | null;
+      url: string | null;
+      isDraft: boolean;
+      checks: "none" | "pending" | "success" | "failure";
+    };
 
 const deriveWorkflow = (
   status: { dirtyFiles: number; ahead: number } | null,
-  pr: { state: string; number: number | null; url: string | null } | null,
+  pr: {
+    state: string;
+    number: number | null;
+    url: string | null;
+    isDraft?: boolean;
+    checks?: "none" | "pending" | "success" | "failure";
+  } | null,
 ): Workflow => {
   if (status === null) return { kind: "idle" };
   if (status.dirtyFiles > 0) return { kind: "dirty", count: status.dirtyFiles };
-  if (pr && pr.state === "open" && pr.url !== null) {
-    return { kind: "open-pr", number: pr.number, url: pr.url };
+  if (pr && pr.state === "open") {
+    return {
+      kind: "open-pr",
+      number: pr.number,
+      url: pr.url,
+      isDraft: pr.isDraft === true,
+      checks: pr.checks ?? "none",
+    };
   }
   if (status.ahead > 0 && (pr === null || pr.state === "none")) {
     return { kind: "ahead", count: status.ahead };
   }
   return { kind: "idle" };
+};
+
+const openInline = (url: string) => {
+  const bridge = window.forkzero?.app;
+  if (bridge !== undefined) {
+    bridge.openInlineUrl(url);
+    return;
+  }
+  // Web preview / dev fallback — Electron isn't around to host a child.
+  window.open(url, "_blank", "noopener,noreferrer");
 };
 
 /**
@@ -195,9 +229,9 @@ const deriveWorkflow = (
  *   idle     → empty
  *   dirty    → "<n> changes"  · Commit & push   (amber)
  *   ahead    → "<n> ahead"    · Create PR       (sky)
- *   open-pr  → "#<n>"         · View PR         (emerald)
+ *   open-pr  → "#<n>"         · Merge           (emerald)
  *
- * Draft / checks / merge stages need new fields on `GitPrInfo` and are
+ * Draft / checks-pending stages need new fields on `GitPrInfo` and are
  * deferred — the layout already reserves the space.
  */
 export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
@@ -233,13 +267,26 @@ export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
           </Pill>
         ) : null}
         {workflow.kind === "open-pr" ? (
-          <Pill tone="emerald">#{workflow.number ?? "?"}</Pill>
+          <>
+            <Pill tone={prBadgeTone(workflow)}>#{workflow.number ?? "?"}</Pill>
+            {workflow.isDraft ? <Pill tone="zinc">Draft</Pill> : null}
+            {workflow.checks === "pending" ? (
+              <Pill tone="amber">
+                <Loader2 className="mr-1 size-3 animate-spin" />
+                Checks running
+              </Pill>
+            ) : null}
+            {workflow.checks === "failure" ? (
+              <Pill tone="red">Checks failed</Pill>
+            ) : null}
+          </>
         ) : null}
       </div>
       <div className={`flex shrink-0 items-center gap-1 ${ACTION_CLASS}`}>
         {workflow.kind === "dirty" ? (
           <ActionButton
             tone="amber"
+            variant="solid"
             icon={<Upload className="size-3.5" />}
             label="Commit & push"
             disabled={!composerReady}
@@ -249,6 +296,7 @@ export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
         {workflow.kind === "ahead" ? (
           <ActionButton
             tone="sky"
+            variant="solid"
             icon={<GitPullRequestArrow className="size-3.5" />}
             label="Create PR"
             disabled={!composerReady}
@@ -256,15 +304,35 @@ export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
           />
         ) : null}
         {workflow.kind === "open-pr" ? (
-          <ActionButton
-            tone="emerald"
-            icon={<GitMerge className="size-3.5" />}
-            label="View PR"
-            onClick={() =>
-              window.open(workflow.url, "_blank", "noopener,noreferrer")
-            }
-            trailing={<ExternalLink className="size-3 opacity-70" />}
-          />
+          <>
+            {workflow.url !== null ? (
+              <ActionButton
+                tone="zinc"
+                variant="soft"
+                icon={<ExternalLink className="size-3.5" />}
+                label="View PR"
+                onClick={() => openInline(workflow.url!)}
+              />
+            ) : null}
+            <ActionButton
+              tone="emerald"
+              variant="solid"
+              icon={<GitMerge className="size-3.5" />}
+              label={workflow.isDraft ? "Mark ready" : "Merge"}
+              disabled={
+                !composerReady ||
+                workflow.checks === "pending" ||
+                workflow.checks === "failure"
+              }
+              onClick={() =>
+                sendToComposer(
+                  workflow.isDraft
+                    ? "mark this pull request as ready for review"
+                    : "merge this pull request and delete the branch",
+                )
+              }
+            />
+          </>
         ) : null}
       </div>
     </header>
@@ -281,8 +349,11 @@ function Pill({ tone, children }: { tone: Tone; children: React.ReactNode }) {
   );
 }
 
+type Variant = "solid" | "soft";
+
 function ActionButton({
   tone,
+  variant,
   icon,
   label,
   onClick,
@@ -290,18 +361,21 @@ function ActionButton({
   trailing,
 }: {
   tone: Tone;
+  variant: Variant;
   icon: React.ReactNode;
   label: string;
   onClick: () => void;
   disabled?: boolean;
   trailing?: React.ReactNode;
 }) {
+  const palette =
+    variant === "solid" ? solidInteractive(tone) : softInteractive(tone);
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`flex items-center gap-1.5 rounded-sm px-2 py-1 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${softInteractive(tone)}`}
+      className={`flex items-center gap-1.5 rounded-sm px-2 py-1 text-[11px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${palette}`}
     >
       {icon}
       {label}
@@ -309,3 +383,12 @@ function ActionButton({
     </button>
   );
 }
+
+const prBadgeTone = (
+  w: Extract<Workflow, { kind: "open-pr" }>,
+): Tone => {
+  if (w.checks === "failure") return "red";
+  if (w.checks === "pending") return "amber";
+  if (w.isDraft) return "zinc";
+  return "emerald";
+};

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -1,9 +1,7 @@
 import {
-  ExternalLink,
   GitBranch,
   GitMerge,
   GitPullRequestArrow,
-  Loader2,
   PanelLeftClose,
   PanelLeftOpen,
   PanelRightClose,
@@ -211,15 +209,6 @@ const deriveWorkflow = (
   return { kind: "idle" };
 };
 
-const openInline = (url: string) => {
-  const bridge = window.forkzero?.app;
-  if (bridge !== undefined) {
-    bridge.openInlineUrl(url);
-    return;
-  }
-  // Web preview / dev fallback — Electron isn't around to host a child.
-  window.open(url, "_blank", "noopener,noreferrer");
-};
 
 /**
  * Top bar over the files panel: workflow status pill + primary action,
@@ -262,24 +251,10 @@ export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
           </Pill>
         ) : null}
         {workflow.kind === "ahead" ? (
-          <Pill tone="sky">
-            {workflow.count} ahead
-          </Pill>
+          <Pill tone="sky">{workflow.count} ahead</Pill>
         ) : null}
         {workflow.kind === "open-pr" ? (
-          <>
-            <Pill tone={prBadgeTone(workflow)}>#{workflow.number ?? "?"}</Pill>
-            {workflow.isDraft ? <Pill tone="zinc">Draft</Pill> : null}
-            {workflow.checks === "pending" ? (
-              <Pill tone="amber">
-                <Loader2 className="mr-1 size-3 animate-spin" />
-                Checks running
-              </Pill>
-            ) : null}
-            {workflow.checks === "failure" ? (
-              <Pill tone="red">Checks failed</Pill>
-            ) : null}
-          </>
+          <Pill tone={prBadgeTone(workflow)}>#{workflow.number ?? "?"}</Pill>
         ) : null}
       </div>
       <div className={`flex shrink-0 items-center gap-1 ${ACTION_CLASS}`}>
@@ -304,35 +279,24 @@ export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
           />
         ) : null}
         {workflow.kind === "open-pr" ? (
-          <>
-            {workflow.url !== null ? (
-              <ActionButton
-                tone="zinc"
-                variant="soft"
-                icon={<ExternalLink className="size-3.5" />}
-                label="View PR"
-                onClick={() => openInline(workflow.url!)}
-              />
-            ) : null}
-            <ActionButton
-              tone="emerald"
-              variant="solid"
-              icon={<GitMerge className="size-3.5" />}
-              label={workflow.isDraft ? "Mark ready" : "Merge"}
-              disabled={
-                !composerReady ||
-                workflow.checks === "pending" ||
-                workflow.checks === "failure"
-              }
-              onClick={() =>
-                sendToComposer(
-                  workflow.isDraft
-                    ? "mark this pull request as ready for review"
-                    : "merge this pull request and delete the branch",
-                )
-              }
-            />
-          </>
+          <ActionButton
+            tone="emerald"
+            variant="solid"
+            icon={<GitMerge className="size-3.5" />}
+            label={workflow.isDraft ? "Mark ready" : "Merge"}
+            disabled={
+              !composerReady ||
+              workflow.checks === "pending" ||
+              workflow.checks === "failure"
+            }
+            onClick={() =>
+              sendToComposer(
+                workflow.isDraft
+                  ? "mark this pull request as ready for review"
+                  : "merge this pull request and delete the branch",
+              )
+            }
+          />
         ) : null}
       </div>
     </header>

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -16,9 +16,14 @@ export interface WindowBridge {
   ) => () => void;
 }
 
+export interface AppBridge {
+  readonly openInlineUrl: (url: string) => void;
+}
+
 export interface ForkzeroBridge {
   readonly rpc: RpcBridge;
   readonly window?: WindowBridge;
+  readonly app?: AppBridge;
 }
 
 declare global {

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -17,7 +17,7 @@ export interface WindowBridge {
 }
 
 export interface AppBridge {
-  readonly openInlineUrl: (url: string) => void;
+  readonly openExternal: (url: string) => void;
 }
 
 export interface ForkzeroBridge {

--- a/apps/renderer/src/lib/tones.ts
+++ b/apps/renderer/src/lib/tones.ts
@@ -85,3 +85,40 @@ export const SOFT_TONE_HOVER: Record<Tone, string> = {
 export const softTone = (tone: Tone): string => SOFT_TONE[tone];
 export const softInteractive = (tone: Tone): string =>
   `${SOFT_TONE[tone]} ${SOFT_TONE_HOVER[tone]}`;
+
+/**
+ * Saturated background + white text for primary actions (the GitHub-style
+ * green Merge button, etc.). Use when a button is the unambiguous primary
+ * call-to-action; lean on `softInteractive` for secondary chips.
+ */
+export const SOLID_TONE: Record<Tone, string> = {
+  red: "bg-red-600 text-white hover:bg-red-500 dark:bg-red-500 dark:hover:bg-red-400",
+  orange:
+    "bg-orange-600 text-white hover:bg-orange-500 dark:bg-orange-500 dark:hover:bg-orange-400",
+  amber:
+    "bg-amber-500 text-amber-950 hover:bg-amber-400 dark:bg-amber-400 dark:text-amber-950 dark:hover:bg-amber-300",
+  yellow:
+    "bg-yellow-500 text-yellow-950 hover:bg-yellow-400 dark:bg-yellow-400 dark:text-yellow-950 dark:hover:bg-yellow-300",
+  lime: "bg-lime-500 text-lime-950 hover:bg-lime-400 dark:bg-lime-400 dark:text-lime-950 dark:hover:bg-lime-300",
+  green:
+    "bg-green-600 text-white hover:bg-green-500 dark:bg-green-500 dark:hover:bg-green-400",
+  emerald:
+    "bg-emerald-600 text-white hover:bg-emerald-500 dark:bg-emerald-500 dark:hover:bg-emerald-400",
+  teal: "bg-teal-600 text-white hover:bg-teal-500 dark:bg-teal-500 dark:hover:bg-teal-400",
+  cyan: "bg-cyan-500 text-cyan-950 hover:bg-cyan-400 dark:bg-cyan-400 dark:text-cyan-950 dark:hover:bg-cyan-300",
+  sky: "bg-sky-600 text-white hover:bg-sky-500 dark:bg-sky-500 dark:hover:bg-sky-400",
+  blue: "bg-blue-600 text-white hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400",
+  indigo:
+    "bg-indigo-600 text-white hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400",
+  violet:
+    "bg-violet-600 text-white hover:bg-violet-500 dark:bg-violet-500 dark:hover:bg-violet-400",
+  purple:
+    "bg-purple-600 text-white hover:bg-purple-500 dark:bg-purple-500 dark:hover:bg-purple-400",
+  fuchsia:
+    "bg-fuchsia-600 text-white hover:bg-fuchsia-500 dark:bg-fuchsia-500 dark:hover:bg-fuchsia-400",
+  pink: "bg-pink-600 text-white hover:bg-pink-500 dark:bg-pink-500 dark:hover:bg-pink-400",
+  rose: "bg-rose-600 text-white hover:bg-rose-500 dark:bg-rose-500 dark:hover:bg-rose-400",
+  zinc: "bg-zinc-700 text-white hover:bg-zinc-600 dark:bg-zinc-200 dark:text-zinc-900 dark:hover:bg-zinc-100",
+};
+
+export const solidInteractive = (tone: Tone): string => SOLID_TONE[tone];

--- a/apps/server/src/git/layers/git-service.ts
+++ b/apps/server/src/git/layers/git-service.ts
@@ -127,6 +127,51 @@ const parseRemoteUrl = (url: string): GitOriginInfo | null => {
   return null;
 };
 
+/**
+ * Collapse `gh`'s `statusCheckRollup` into the wire's four-state aggregate.
+ *
+ * A check is "in flight" if its status is anything other than COMPLETED, and
+ * its conclusion (when present) tells us how a completed run landed. External
+ * status checks expose `state` instead and skip `status` entirely. A single
+ * failure beats every other state; otherwise pending beats success; otherwise
+ * if every entry passed it's success. Empty list means no checks defined.
+ */
+const aggregateChecks = (
+  rollup: ReadonlyArray<{
+    status?: string;
+    state?: string;
+    conclusion?: string;
+  }>,
+): GitPrInfo["checks"] => {
+  if (rollup.length === 0) return "none";
+  let pending = false;
+  for (const entry of rollup) {
+    const conclusion = (entry.conclusion ?? "").toUpperCase();
+    const status = (entry.status ?? "").toUpperCase();
+    const state = (entry.state ?? "").toUpperCase();
+    if (
+      conclusion === "FAILURE" ||
+      conclusion === "CANCELLED" ||
+      conclusion === "TIMED_OUT" ||
+      conclusion === "ACTION_REQUIRED" ||
+      state === "FAILURE" ||
+      state === "ERROR"
+    ) {
+      return "failure";
+    }
+    if (
+      status === "QUEUED" ||
+      status === "IN_PROGRESS" ||
+      status === "PENDING" ||
+      state === "PENDING" ||
+      (status !== "COMPLETED" && conclusion === "" && state === "")
+    ) {
+      pending = true;
+    }
+  }
+  return pending ? "pending" : "success";
+};
+
 export const GitServiceLive = Layer.effect(
   GitService,
   Effect.gen(function* () {
@@ -298,6 +343,8 @@ export const GitServiceLive = Layer.effect(
             deletions: 0,
             number: null,
             url: null,
+            isDraft: false,
+            checks: "none",
           });
 
           // `gh pr view --json` returns the PR for the current branch. Exits
@@ -307,7 +354,7 @@ export const GitServiceLive = Layer.effect(
             "pr",
             "view",
             "--json",
-            "state,additions,deletions,number,url,headRefName,baseRefName",
+            "state,additions,deletions,number,url,headRefName,baseRefName,isDraft,statusCheckRollup",
           ]).pipe(
             Effect.catchTags({
               GitNotInstalledError: () => Effect.succeed(""),
@@ -325,6 +372,12 @@ export const GitServiceLive = Layer.effect(
             url?: string;
             headRefName?: string;
             baseRefName?: string;
+            isDraft?: boolean;
+            statusCheckRollup?: ReadonlyArray<{
+              status?: string;
+              state?: string;
+              conclusion?: string;
+            }>;
           };
           try {
             parsed = JSON.parse(stdout) as typeof parsed;
@@ -343,6 +396,13 @@ export const GitServiceLive = Layer.effect(
                   ? "closed"
                   : "none";
 
+          // statusCheckRollup is a heterogeneous array — gh actions use
+          // `status` + `conclusion`, external checks use `state`. We collapse
+          // both into a four-state aggregate.
+          const checks: GitPrInfo["checks"] = aggregateChecks(
+            parsed.statusCheckRollup ?? [],
+          );
+
           return GitPrInfo.make({
             state,
             branch: parsed.headRefName ?? null,
@@ -353,6 +413,8 @@ export const GitServiceLive = Layer.effect(
               typeof parsed.deletions === "number" ? parsed.deletions : 0,
             number: typeof parsed.number === "number" ? parsed.number : null,
             url: parsed.url ?? null,
+            isDraft: parsed.isDraft === true,
+            checks,
           });
         }),
       );

--- a/packages/wire/src/git.ts
+++ b/packages/wire/src/git.ts
@@ -90,6 +90,21 @@ export const GitOriginRpc = Rpc.make("git.origin", {
 export const GitPrState = Schema.Literal("none", "open", "closed", "merged");
 export type GitPrState = typeof GitPrState.Type;
 
+/**
+ * Aggregated CI rollup status for the PR's HEAD commit.
+ *   none    — PR has no required checks, or `gh` couldn't read the rollup.
+ *   pending — at least one check still running / queued.
+ *   success — all checks passed.
+ *   failure — at least one check failed (cancelled / errored counts as fail).
+ */
+export const GitPrChecks = Schema.Literal(
+  "none",
+  "pending",
+  "success",
+  "failure",
+);
+export type GitPrChecks = typeof GitPrChecks.Type;
+
 export class GitPrInfo extends Schema.Class<GitPrInfo>("GitPrInfo")({
   state: GitPrState,
   branch: Schema.NullOr(Schema.String),
@@ -98,6 +113,8 @@ export class GitPrInfo extends Schema.Class<GitPrInfo>("GitPrInfo")({
   deletions: Schema.Number,
   number: Schema.NullOr(Schema.Number),
   url: Schema.NullOr(Schema.String),
+  isDraft: Schema.Boolean,
+  checks: GitPrChecks,
 }) {}
 
 export const GitPrStateRpc = Rpc.make("git.prState", {


### PR DESCRIPTION
## Summary
- Workflow buttons in the top-right top bar are now solid-color (no borders), with the action contracted to a single button per state (Commit & push / Create PR / Merge / Mark ready). PR URLs open in the user's default browser via `shell.openExternal`.
- PR + branch + CI detail moved out of the top bar into a new **Checks** tab in the right pane (alongside Files / Terminal). The top bar keeps just one pill + one action so the chrome stays uncluttered.
- Checks tab uses minimal status glyphs — a small filled dot for success/failure, spinner for pending, neutral `CircleDot` when idle.
- Server: `gh pr view` now also pulls `isDraft` + `statusCheckRollup`, aggregated into a four-state `checks` field on `GitPrInfo` (`none | pending | success | failure`). Renderer drives both the top-bar action gating and the Checks tab off this.

## Test plan
- [ ] Dirty tree → top bar shows "n changes" + solid amber **Commit & push**.
- [ ] Clean + ahead → "n ahead" + solid sky **Create PR**.
- [ ] Open PR, checks pending → emerald `#N` pill in top bar; Checks tab shows spinner with "Checks running"; Merge button disabled.
- [ ] Open PR, checks failed → top bar pill goes red; Checks tab shows red dot + "Checks failed".
- [ ] Open PR, checks passed → emerald dot in tab; **Merge** enabled.
- [ ] Draft PR → top bar action becomes **Mark ready**; tab shows zinc Draft indicator.
- [ ] "Open in browser" in the Checks tab opens in the OS default browser, not in-app.