### PR TITLE
spec: 0.04-MVP code index (@forkzero/index + apps/mcp-server)

### DIFF
--- a/specs/0.04-MVP/README.md
+++ b/specs/0.04-MVP/README.md
@@ -1,0 +1,102 @@
+# MVP 0.04 — Code Index
+
+MVP 0.03 (everything under [../0.03-MVP/](../0.03-MVP/)) brought the chat
+composer to first-class quality. MVP 0.04 turns inward: it gives the bundled
+agent a real understanding of the user's codebase.
+
+Today an agent inside forkzero explores a repo the same way it does
+anywhere — `Bash(rg ...)`, `Read`, `Glob`, iterate. On any real codebase
+this is the dominant cost: 25–40k tokens across 5–8 tool calls before the
+agent has the context to answer or edit. Most of that is *navigation tax*,
+not real work.
+
+0.04 ships a content-addressed code index with hybrid retrieval. The bundled
+agent calls `code_search`, `symbol_lookup`, `find_references`, and
+`read_chunk` instead of grepping. The same engine is also packaged as a
+standalone `apps/mcp-server` so external agents (a terminal `claude`
+session, a Codex session, a Cursor agent) get the same tools.
+
+The wedge: forkzero runs **N parallel agent workspaces on the same repo**
+(via Conductor) — multiple branches checked out side-by-side. Cursor,
+Sourcegraph Cody, Greptile, Continue, Augment all index codebases, but none
+handle this shape. A content-addressed chunk store with per-branch
+manifests makes branch switches a sub-200ms manifest swap, and dedupes
+across workspaces sharing a repo.
+
+## What lands in 0.04
+
+- **Index engine** as a standalone package `@forkzero/index`. Tree-sitter
+  chunking, symbol extraction, content-addressed blob store, per-branch
+  manifest model. SQLite + `sqlite-vec` extension. Engine is transport-agnostic.
+- **3-tier hybrid retrieval**: symbol lookup (Tier 1) → BM25 (Tier 2) →
+  vector + RRF fusion + cross-encoder rerank (Tier 3). A query router
+  classifies the query and picks tiers; fast paths (Tier 1) skip rerank.
+- **Bundled agent integration**. The Claude SDK and Codex SDK adapters
+  register five custom tools (`code_search`, `symbol_lookup`,
+  `find_references`, `read_chunk`, `list_module`) at session start.
+  In-process, no MCP overhead.
+- **Standalone MCP server** as `apps/mcp-server`. A Bun-compiled binary
+  (`forkzero-mcp`) plus an npm package `@forkzero/mcp-server`. stdio
+  transport (default), HTTP transport (optional). Same engine, same tools,
+  reusable by any agent runtime.
+- **Local-first by default.** Embedding model: `nomic-embed-code` ONNX via
+  `transformers.js`. Reranker: `bge-reranker-v2-m3` ONNX. Zero network
+  calls in the default config.
+- **BYOK opt-in for paid backends.** Voyage / Cohere / OpenAI / Jina keys
+  live in `keytar` under the same pattern Phase 2 uses for agent provider
+  keys. Chunks go user → provider directly; forkzero is not in the path.
+- **Branch-aware index**. File watcher + git checkout hook. Switching
+  branches in a Conductor workspace is a manifest swap, not a re-index.
+  Content-addressed dedup means N parallel workspaces on one repo share
+  one blob store.
+- **Renderer scaffolding**. `index.*` RPCs registered in `@forkzero/wire`.
+  A command palette entry (`Cmd+P` → "Search code…") wires the renderer to
+  the index. The primary consumer is the agent; the renderer surface is
+  scaffolding for future UI.
+
+## What's deliberately deferred
+
+- **Cloud team index.** The chunk store is content-addressed and ready to
+  sync; the actual S3-compatible sync worker, encryption keys, and team
+  membership are deferred to a future MVP (sketched as Phase G).
+- **Pay-per-usage billing.** Forkzero-cloud as a paid embedding/rerank
+  proxy is scaffolded as a provider stub but not implemented. ADR 0021
+  documents the call. Adding it later doesn't require re-architecting.
+- **Rust / Go / non-TS grammars at launch.** Forkzero itself is TypeScript;
+  ship TS + JS + TSX + JSON + Markdown grammars first, expand on demand.
+- **Refactor / rename tooling.** The `refs` table powers read-only
+  `find_references`; cross-file rename is out of scope (an LSP server's
+  job, not ours).
+- **Cross-repo search.** One workspace, one index, one repo per query.
+- **In-app re-index UI.** A manual `index.reindex` RPC exists but the
+  surface is hidden behind a debug command for v1.
+
+## Where to read
+
+- [features/code-index.md](features/code-index.md) — engine architecture,
+  storage model, retrieval pipeline, MCP integration, RPC contracts.
+- [roadmap.md](roadmap.md) — 7-phase delivery plan (A–G), acceptance
+  criteria per phase, the experiment harness that gates Phase C.
+- [decisions/0013-index-as-package.md](decisions/0013-index-as-package.md) —
+  why the engine is a package, not a service inside `apps/server`.
+- [decisions/0014-content-addressed-chunk-store.md](decisions/0014-content-addressed-chunk-store.md) —
+  blob store + per-branch manifest; the parallel-workspace wedge.
+- [decisions/0015-tree-sitter-chunking.md](decisions/0015-tree-sitter-chunking.md) —
+  why tree-sitter for chunking and symbol extraction, not LSP.
+- [decisions/0016-hybrid-over-pure-vector.md](decisions/0016-hybrid-over-pure-vector.md) —
+  why BM25 + embeddings + rerank beats pure vector on code.
+- [decisions/0017-branch-aware-manifest.md](decisions/0017-branch-aware-manifest.md) —
+  manifest model and the < 200ms branch-switch budget.
+- [decisions/0018-mcp-server-as-app.md](decisions/0018-mcp-server-as-app.md) —
+  why `apps/mcp-server` is its own app, not a route in `apps/server`.
+- [decisions/0019-sqlite-vec-extension.md](decisions/0019-sqlite-vec-extension.md) —
+  extends ADR 0008; native module rebuild story.
+- [decisions/0020-pluggable-rerank-and-embed.md](decisions/0020-pluggable-rerank-and-embed.md) —
+  embedding and rerank provider abstraction.
+- [decisions/0021-credentials-and-billing.md](decisions/0021-credentials-and-billing.md) —
+  local default → BYOK in 0.04 → forkzero-cloud deferred.
+
+## Status
+
+📐 **Spec** — ready for ADR review and implementation. Phase A starts after
+ADRs 0013–0015 land.

--- a/specs/0.04-MVP/decisions/0013-index-as-package.md
+++ b/specs/0.04-MVP/decisions/0013-index-as-package.md
@@ -1,0 +1,160 @@
+# ADR 0013 — `@forkzero/index` as a standalone package
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+0.04 introduces a code index with tree-sitter chunking, symbol extraction,
+hybrid retrieval (BM25 + vector + rerank), a content-addressed blob store,
+and per-branch manifests. The engine has multiple consumers:
+
+1. The desktop server (`apps/server`) — consumes the engine in-process and
+   exposes `index.*` RPCs to the renderer.
+2. A standalone MCP binary (`apps/mcp-server`) — wraps the engine for
+   external agents (terminal Claude Code, Codex, Cursor) over the
+   Model Context Protocol.
+3. A future cloud-sync worker (deferred Phase G) — would push the
+   content-addressed blob store to S3-compatible storage for team sharing.
+
+The engine is non-trivial: SQL schema + migrations, tree-sitter grammars,
+chunking, symbol extraction, FTS5 + sqlite-vec wrappers, rerank/embed
+provider abstractions, a query router, RRF fusion, file watcher hooks. It
+has its own tests, its own native-module surface, and its own version of
+SQLite extensions.
+
+If we land the engine as a service inside `apps/server`, the MCP binary
+either has to import from `apps/server` (pulling in Electron + RPC
+machinery it doesn't need) or duplicate the engine. Both are bad.
+
+## Decision
+
+Ship the engine as a standalone workspace package: **`@forkzero/index`**.
+
+### Layout
+
+```
+packages/index/
+  package.json
+  src/
+    api.ts                            # exported Effect Service contract
+    schema/migrations/                # SQL files
+    chunker/                          # tree-sitter chunking
+    symbols/                          # symbol extraction + ref resolution
+    retrieval/
+      symbol-lookup.ts                # Tier 1
+      bm25.ts                         # FTS5 wrapper
+      vector.ts                       # sqlite-vec wrapper
+      rerank.ts                       # cross-encoder caller
+      router.ts                       # query classification
+      fuse.ts                         # reciprocal rank fusion
+    manifest/                         # branch model
+    watcher/                          # incremental file-change indexer
+    embedding/                        # pluggable embedding providers
+```
+
+### Public API
+
+The package exports an Effect Service (`IndexService`) with a Default
+Layer that wires the SQL client, embedding provider, and rerank provider.
+Consumers compose it into their own runtime — `apps/server` adds it to
+the main-process Layer alongside `WorkspaceService`, `ProviderService`,
+etc. `apps/mcp-server` adds it to a minimal Layer with no Electron, no
+RPC.
+
+```ts
+// packages/index/src/api.ts
+export class IndexService extends Effect.Service<IndexService>()(
+  "IndexService",
+  {
+    effect: Effect.gen(function* () { /* ... */ }),
+    accessors: true,
+  }
+) {}
+```
+
+### Catalog entries
+
+Native dependencies live in the root catalog (per ADR 0006):
+
+- `tree-sitter` and grammar packages (`tree-sitter-typescript`, etc.)
+- `sqlite-vec` (SQLite extension binding)
+- `@huggingface/transformers` (ONNX inference for nomic-embed-code +
+  bge-reranker-v2-m3)
+- `@parcel/watcher` (native file watcher)
+- `blake3` (faster than `crypto.createHash('sha256')`)
+- `@modelcontextprotocol/sdk` (used by `apps/mcp-server`, not the package
+  itself)
+
+### What stays out of the package
+
+- Electron-specific code (lives in `apps/desktop`).
+- IPC / RPC wiring (lives in `apps/server`).
+- MCP transport (lives in `apps/mcp-server`).
+- Renderer UI (lives in `apps/renderer`).
+
+The package is **transport-agnostic**: it knows about SQLite, tree-sitter,
+embeddings — not about how callers reach it.
+
+## Consequences
+
+### Positive
+
+- One implementation, multiple consumers. No drift between desktop and
+  MCP binary.
+- `apps/mcp-server` doesn't import Electron or RPC machinery — it can be
+  bundled as a small standalone binary via `bun build --compile`.
+- The package is independently testable: `bun --filter @forkzero/index test`
+  runs unit + integration tests without booting Electron.
+- Future cloud-sync worker is a third consumer, not a fork.
+- `IndexService` plugs into the existing Effect Layer pattern with no
+  special-casing — same shape as `WorkspaceService`, `ProviderService`.
+
+### Negative
+
+- One more package in the monorepo to maintain.
+- Native modules (`tree-sitter`, `sqlite-vec`, `@parcel/watcher`,
+  `transformers.js`'s ONNX runtime) need rebuild handling for Electron in
+  `apps/desktop`. Adds to the existing rebuild list (see ADR 0019).
+- Effect Service patterns are now expected in a non-app package. The
+  `@forkzero/wire` package is contract-only; this is the first package
+  with implementation. We accept the precedent.
+
+## Alternatives considered
+
+### Service inside `apps/server`
+
+- Pro: matches existing `apps/server/src/<domain>/` pattern.
+- Con: `apps/mcp-server` would either import from `apps/server` (pulling
+  in Electron-relevant code) or fork the engine. Either way, drift
+  becomes a maintenance hazard — and the standalone binary picks up
+  cruft.
+
+### Multiple per-domain packages (`@forkzero/index-chunker`,
+`@forkzero/index-retrieval`, etc.)
+
+- Pro: smaller individual packages.
+- Con: premature partitioning. The engine is one concept and changes
+  cross domains routinely. Splitting it forces every cross-domain change
+  to negotiate package boundaries — same anti-pattern ADR 0005 warned
+  against for `@forkzero/wire`.
+
+### Fork the engine for the MCP binary
+
+- Pro: each consumer optimizes for its shape.
+- Con: drift is inevitable. The whole point of the index is that the
+  bundled agent and external agents see the *same* answers from the *same*
+  data. Fork-and-drift breaks the value prop.
+
+## What we deliberately rejected
+
+- Putting the engine in `@forkzero/wire`. Wire is contract-only.
+- Making `apps/server` a peer of the engine instead of a consumer.
+- Bundling MCP transport into the engine package — keeps the package
+  transport-agnostic.
+
+## Reference
+
+This mirrors how `@forkzero/wire` is structured (one package, multiple
+consumers — main and renderer) and ADR 0007's transport-agnostic split.
+The index is the second cross-cutting package; it follows the same rule.

--- a/specs/0.04-MVP/decisions/0014-content-addressed-chunk-store.md
+++ b/specs/0.04-MVP/decisions/0014-content-addressed-chunk-store.md
@@ -1,0 +1,190 @@
+# ADR 0014 — Content-addressed chunk store + per-branch manifest
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+Forkzero's value prop, sharpened by Conductor workspaces, is **N parallel
+agent workspaces on the same repo** — multiple branches checked out
+side-by-side, multiple agents iterating in parallel. Existing code-index
+products (Cursor, Sourcegraph Cody, Greptile, Continue, Augment) struggle
+here: they either re-index per branch (slow, expensive, redundant) or
+share one stale index across branches (wrong file contents on the branch
+the agent is actually on).
+
+A typical scenario:
+
+- User has 5 Conductor workspaces open against the same repo
+- Each workspace is on a different branch with 95% file overlap
+- Naive per-branch indexing: 5× the storage, 5× the parsing, 5× the
+  embedding API spend
+- Naive shared index: agents searching from workspace B get results from
+  whatever branch was last indexed
+
+Both are bad. We need an architecture where:
+
+- The 95% common file content is stored once
+- Per-branch views are cheap to build and cheap to switch
+- File edits in one workspace don't invalidate other workspaces
+- Branch switches happen in milliseconds, not minutes
+
+Git solved this exact problem decades ago: blobs are content-addressed by
+SHA, and a tree object maps paths to blob SHAs. Switching branches is
+swapping the active tree, not rewriting blobs. We adopt the same shape.
+
+## Decision
+
+Store all parsed content in a **content-addressed blob store**, with
+**per-branch manifests** that map file paths to blob hashes for a given
+branch.
+
+### Schema (one SQLite file per workspace)
+
+```sql
+blobs (
+  id          INTEGER PRIMARY KEY,
+  sha         BLOB NOT NULL UNIQUE,    -- blake3 of file content
+  language    TEXT,
+  size        INTEGER NOT NULL,
+  parsed_at   INTEGER
+);
+
+chunks (
+  id          INTEGER PRIMARY KEY,
+  blob_id     INTEGER NOT NULL REFERENCES blobs(id),
+  kind        TEXT NOT NULL,
+  start_line  INTEGER NOT NULL,
+  end_line    INTEGER NOT NULL,
+  symbol_id   INTEGER REFERENCES symbols(id),
+  content     TEXT NOT NULL
+);
+
+symbols (
+  id          INTEGER PRIMARY KEY,
+  blob_id     INTEGER NOT NULL,
+  name        TEXT NOT NULL,
+  kind        TEXT NOT NULL,
+  signature   TEXT,
+  start_line  INTEGER, end_line INTEGER,
+  parent_id   INTEGER REFERENCES symbols(id),
+  exported    INTEGER NOT NULL DEFAULT 0
+);
+
+manifests (
+  branch       TEXT NOT NULL,
+  file_path    TEXT NOT NULL,
+  blob_id      INTEGER NOT NULL,
+  PRIMARY KEY (branch, file_path)
+);
+CREATE INDEX manifests_blob ON manifests(blob_id);
+```
+
+### Why blake3 (not sha256)
+
+- ~3× faster on small files than sha256
+- 256-bit, collision-resistant
+- Native module is small, well-maintained
+- We're computing a SHA per file on every save — speed adds up
+
+### Branch switch algorithm
+
+```
+diff = manifests[from_branch] symmetric_difference manifests[to_branch]
+for (path, old_blob, new_blob) in diff:
+  if new_blob is None: delete manifests[to_branch][path]   # file removed
+  else:                upsert manifests[to_branch][path] = new_blob
+emit "branch_switched"  →  router rebinds queries to the new branch
+```
+
+No re-parsing for unchanged blobs. Storage cost: one row per (branch,
+path) pair, plus the deduped blobs themselves.
+
+### Garbage collection
+
+A blob is GC-eligible when no manifest references it. Run a periodic GC
+that deletes orphaned blobs (and their chunks/symbols/embeddings).
+
+```sql
+DELETE FROM blobs WHERE id NOT IN (SELECT DISTINCT blob_id FROM manifests);
+```
+
+Triggered on idle, or explicitly via `index.gc` RPC.
+
+### Workspace sharing across Conductor
+
+One blob store per **repo identity** (`git rev-parse --show-toplevel` on
+the original clone), not per workspace. Conductor workspaces on the same
+repo share the underlying blob store; each workspace contributes a
+manifest keyed by branch. Five workspaces on five branches = one blob
+store, five manifest sets.
+
+The DB file lives at:
+
+```
+<userData>/index/<repo-id>/forkzero-index.sqlite
+```
+
+`<repo-id>` is `blake3(absolute_path_of_origin_clone)` — stable across
+Conductor workspaces of the same repo.
+
+## Consequences
+
+### Positive
+
+- 5 Conductor workspaces on the same repo: 1× storage, not 5×.
+- Branch switch < 200ms target is achievable (manifest swap is a SQL
+  transaction over a few hundred rows).
+- File edits invalidate only the changed blob — embeddings, symbols,
+  chunks for unchanged blobs persist.
+- Symmetric difference between branches gives us "what changed" cheaply,
+  reusable for future features (incremental review, diff-aware retrieval).
+- Cloud sync (deferred Phase G) is straightforward: blobs are already
+  content-addressed; sync becomes "push blobs missing on remote, push
+  manifest deltas."
+
+### Negative
+
+- Manifest table can grow large on repos with many branches and many
+  files. Mitigation: index on `branch` and `blob_id`; VACUUM periodically.
+- GC complexity: have to be careful not to delete blobs still referenced
+  by checked-out worktrees. Mitigation: GC only on idle, with explicit
+  manifest scan first.
+- Adds blake3 native module (one more rebuild target).
+
+## Alternatives considered
+
+### Per-branch SQLite files
+
+- Pro: simpler mental model.
+- Con: 5× storage and parsing. Branch switch means switching DB
+  connections. Doesn't dedupe.
+
+### Single index, branch as a column on every row
+
+- Pro: simpler schema.
+- Con: every query needs a `WHERE branch = ?` filter. Indexes get
+  bloated. No deduplication.
+
+### File modtime as the dedup key
+
+- Pro: cheaper than hashing.
+- Con: modtime changes when you `touch` a file; dedup breaks. Hashing is
+  cheap with blake3 — pay it.
+
+### Reuse git's own object store
+
+- Pro: free dedup.
+- Con: requires the user's repo to be a git repo (forkzero supports
+  non-git folders too); requires reading git internals; forkzero would
+  have a hard time managing untracked / generated files.
+
+## What we deliberately rejected
+
+- Storing chunks per branch instead of per blob. Chunks are deterministic
+  on blob content; deriving them from blob_id is the right shape.
+- Sharing blob stores across repos. Blob hash collision across different
+  codebases is astronomical, but the conceptual confusion isn't worth
+  the savings.
+- A pure git-tree-walking strategy that skips the manifest table. We
+  need to support non-git directories and untracked files.

--- a/specs/0.04-MVP/decisions/0015-tree-sitter-chunking.md
+++ b/specs/0.04-MVP/decisions/0015-tree-sitter-chunking.md
@@ -1,0 +1,176 @@
+# ADR 0015 — Tree-sitter for chunking and symbol extraction
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+The index needs two structured views over source code:
+
+1. **Chunks**: contiguous spans of code we can store, embed, and return as
+   search results. Naïve fixed-window chunking (every 40 lines) hurts
+   retrieval quality — splitting a function across two chunks means
+   neither chunk standalone makes sense.
+2. **Symbols**: named entities (functions, classes, types, exported
+   constants) with their location, signature, and parent scope. This
+   powers Tier 1 symbol lookup, which handles ~60–70% of agent queries.
+
+Both require parsing. Three options:
+
+- **Regex-based heuristics** (`ctags`-style): fast, multi-language, but
+  fragile on modern syntax (template literals, JSX, decorators). Misses
+  refs entirely without a real parser.
+- **Language Server Protocol (LSP) servers**: exact symbol info via real
+  type checkers. But spinning up `tsserver`, `gopls`, `pylsp` etc. is
+  heavy (each is a separate process, each loads a project graph),
+  per-language drift is real, and refs accuracy comes at a startup cost
+  measured in seconds-to-minutes on big repos.
+- **Tree-sitter**: incremental parser, ~80 grammars, fast, no project-wide
+  state, runs in-process. Trade-off: refs accuracy is 70–80% (no full
+  type resolution), and resolved by structural rules in the AST.
+
+## Decision
+
+Use **tree-sitter** for chunking and symbol extraction, in-process.
+
+### Grammars (v1)
+
+- `tree-sitter-typescript` (handles `.ts` and `.tsx`)
+- `tree-sitter-javascript` (`.js`, `.jsx`, `.mjs`, `.cjs`)
+- `tree-sitter-json`
+- `tree-sitter-markdown`
+
+Loaded on demand. Python / Go / Rust ship later when there's user demand.
+Forkzero itself is TypeScript; ship for the first-party use case first.
+
+### Chunking strategy
+
+```
+walk AST top-down:
+  if node.type ∈ FUNCTION_LIKE:        # function/method/arrow/class
+    emit chunk(start, end, kind, content, symbol)
+    do not descend into the body
+  elif node.type ∈ CLASS_LIKE:
+    emit chunk(start, end, kind="class", content, symbol)
+    descend (so methods become their own chunks)
+  elif node.type == top_level_statement:
+    accumulate into a 40-line sliding window chunk
+```
+
+This gives us function-level granularity for the things agents actually
+search for, while still capturing top-level imports, types, and module
+glue.
+
+### Symbol extraction
+
+Use tree-sitter **queries** (`.scm` files) to declaratively pluck
+symbols. Example for TypeScript:
+
+```scheme
+(function_declaration
+  name: (identifier) @symbol.name) @symbol.body
+[kind=function]
+
+(class_declaration
+  name: (type_identifier) @symbol.name) @symbol.body
+[kind=class]
+
+(method_definition
+  name: (property_identifier) @symbol.name) @symbol.body
+[kind=method]
+
+(type_alias_declaration
+  name: (type_identifier) @symbol.name) @symbol.body
+[kind=type]
+
+(export_statement (variable_declaration
+  (variable_declarator name: (identifier) @symbol.name))) @symbol.body
+[kind=const, exported=true]
+```
+
+These queries are stable across grammar versions, declarative, and
+testable.
+
+### Reference extraction
+
+Walk identifier nodes; resolve via lexical scope only:
+
+- Local-scope match → known
+- Module-scope match → known (matches `imports + exports` in same file)
+- Cross-file → record by name; resolve at query time against the symbols
+  table
+
+This gets us 70–80% accurate refs. For the missing 20–30% (imported names
+that shadow a local; namespaces; ambient module declarations), we accept
+false negatives in v1 and revisit if eval shows they matter.
+
+### Incremental parsing
+
+Tree-sitter is incremental: when a file changes, we feed the old tree +
+the edit and get a new tree without reparsing untouched regions. File
+edit re-index target: < 50ms.
+
+## Consequences
+
+### Positive
+
+- One parser library, ~80 grammars supported (we ship 4 now, more on
+  demand).
+- In-process: no subprocess management, no language-server lifecycle.
+- Incremental: file edits are cheap.
+- Tree-sitter queries are declarative and language-agnostic to read.
+- The `web-tree-sitter` (WASM) variant exists if we ever want to run the
+  same chunker in the renderer for live previews — same code, same
+  output.
+- Tree-sitter is widely used (GitHub uses it for syntax highlighting,
+  Neovim, Helix, etc.). Mature, fast, well-tested.
+
+### Negative
+
+- 70–80% refs accuracy for cross-file resolution. Documented; revisit if
+  it becomes a real problem.
+- Native modules: `tree-sitter` and per-language grammars compile to
+  native. Add to the Electron rebuild list (see ADR 0019).
+- Each new language costs us a grammar dependency + a query file + a
+  test fixture. Acceptable per-language cost.
+
+## Alternatives considered
+
+### LSP servers (tsserver, gopls, etc.)
+
+- Pro: full type resolution; refs accuracy near 100%.
+- Con: per-language process management; project-graph startup time
+  (seconds to minutes); high memory; per-language drift in capabilities.
+  Not worth it for v1's "agent-friendly fast lookup" goal — and we can
+  layer LSP-derived enrichment in later if eval shows we need it.
+
+### `ctags` / `universal-ctags`
+
+- Pro: fast, mature, language-agnostic.
+- Con: regex-based; struggles with modern syntax; no incremental updates;
+  no refs.
+
+### `ast-grep`
+
+- Pro: also tree-sitter-based, mature query language.
+- Con: it's a CLI tool. We want library access. We're using tree-sitter
+  directly anyway; ast-grep is one more layer.
+
+### Build our own parsers per language
+
+- Pro: maximum control.
+- Con: insane.
+
+## What we deliberately rejected
+
+- Per-language LSP integration in v1.
+- A non-tree-sitter chunker (regex + heuristics).
+- Sub-function chunking (every 5–10 lines). Loses the locality benefit
+  that makes function-shaped chunks well-suited to retrieval.
+
+## Reference
+
+Tree-sitter is the same parser GitHub, Neovim, Helix, Zed, and Cursor's
+indexer use. Standard choice for this shape of problem. The query files
+will live under `packages/index/src/chunker/queries/<language>.scm` and
+ship with the package.

--- a/specs/0.04-MVP/decisions/0016-hybrid-over-pure-vector.md
+++ b/specs/0.04-MVP/decisions/0016-hybrid-over-pure-vector.md
@@ -1,0 +1,153 @@
+# ADR 0016 — Hybrid retrieval over pure vector
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+The popular framing of "code search via vector DB" assumes embeddings
+alone are the right retrieval method. They aren't, on code. Published
+benchmarks (BEIR, CodeSearchNet, custom evaluations from Sourcegraph and
+Cursor) consistently show:
+
+- **BM25 alone** beats embeddings alone on identifier-heavy queries
+  (function names, type names, file paths) — a huge slice of what agents
+  actually search for.
+- **Embeddings alone** beat BM25 on conceptual / paraphrased queries
+  ("code that handles retries on a 503").
+- **Symbol lookup** (exact-name SQL match against a symbols table) beats
+  both for the ~60% of agent queries that already know the name.
+- **Reciprocal Rank Fusion + cross-encoder rerank** of BM25 + vector
+  candidates outperforms either retrieval method alone by 15–25% on
+  NDCG@10, and outperforms vector + rerank by 8–12%.
+
+The rerank step is the highest-leverage component: a cross-encoder scores
+each (query, chunk) pair properly, which is 5–10× more accurate than
+embedding cosine similarity but too slow to run at retrieval time. Run on
+top-50 fused candidates, it lifts top-5 quality 2–3×.
+
+Pure-vector pitches "we have a vector DB" — but what wins is
+*architectural fit*: route to the right method per query, fuse, rerank.
+
+## Decision
+
+Build a **3-tier hybrid retrieval pipeline**:
+
+```
+Tier 1 — Symbol lookup (SQL on symbols table)
+Tier 2 — BM25 (SQLite FTS5, trigram tokenizer)
+Tier 3 — Vector (sqlite-vec) + RRF fusion + cross-encoder rerank
+```
+
+A query router classifies the query and picks tiers:
+
+```
+looksLikeSymbol(q)    → Tier 1 only             (~60% of agent queries)
+looksLikeCode(q)      → Tier 1 + Tier 2         (~20%)
+isNaturalLanguage(q)  → Tier 3                  (~20%)
+ambiguous             → all three, fused
+```
+
+### Reciprocal Rank Fusion
+
+```
+fused_score(chunk) = Σ_methods 1 / (k + rank_method(chunk))
+```
+
+`k = 60` per the original RRF paper. One-line algorithm, hard to beat.
+Combines BM25 and vector candidates without needing them to share a
+score scale.
+
+### Cross-encoder rerank
+
+After fusion returns top-20, rerank with a cross-encoder
+(bge-reranker-v2-m3 by default; pluggable to Voyage / Cohere). The
+reranker scores each (query, chunk_text) pair; output is reordered by
+relevance score.
+
+Rerank is **always on for Tier 3**. For Tier 1 and Tier 1+2 paths,
+results are already exact-match shaped — rerank skipped to save latency.
+
+### Why not pure vector?
+
+- 60–70% of agent queries are exact-name lookups. Embeddings approximate
+  this with cosine similarity; SQL exact-match nails it in <1ms with no
+  embedding model needed.
+- BM25 is free (FTS5 is built into SQLite), fast (5ms), and excellent at
+  identifier-heavy queries.
+- Vector adds the conceptual recall that BM25 misses. Combined with
+  rerank, this is where the lift comes from — but vector alone leaves
+  the ~80% Tier 1 + Tier 2 wins on the table.
+
+### Why not skip rerank?
+
+- The reranker is the single highest-leverage component. Top-5 quality
+  goes from "okay" to "consistently right." Tokens-per-task budget
+  depends on this — a wrong top-5 means the agent issues another query
+  and we're back to grep-tax cost.
+
+## Consequences
+
+### Positive
+
+- Each tier handles what it's best at. No method is asked to do
+  everything.
+- Tier 1 latency (<1ms) handles the bulk of queries — no embedding
+  inference needed for most agent calls.
+- Search works **before embeddings exist**: chunks not yet embedded fall
+  back to BM25. The system is graceful under partial-index conditions.
+- Adding a new method (graph-based, e.g.) is dropping in a new tier
+  without rewriting.
+
+### Negative
+
+- More moving parts than pure vector. Three retrieval methods, a router,
+  a fuser, a reranker.
+- Router heuristics need maintenance — we'll discover query shapes that
+  misclassify and need to add cases.
+- Local rerank model adds ~120MB of weights. Acceptable for desktop;
+  documented in ADR 0020.
+
+## Alternatives considered
+
+### Pure vector (Cosine on embeddings only)
+
+- Pro: simplest mental model.
+- Con: leaves 60–70% of queries on the table (Tier 1 wins). And without
+  rerank, top-5 quality is 20% worse on NDCG.
+
+### BM25 only
+
+- Pro: zero infra cost, comes free with SQLite.
+- Con: misses conceptual queries entirely. Agents asking "how is auth
+  retried" get nothing useful.
+
+### Vector + rerank, no symbol lookup
+
+- Pro: simpler than three tiers.
+- Con: every agent query pays embedding-inference + rerank cost, even
+  when a SQL `WHERE name = ?` would have answered in 1ms. Wastes
+  latency and burns embedding API credits unnecessarily for BYOK users.
+
+### Let the agent pick the tier
+
+- Pro: agent has more context about what it wants.
+- Con: agents are bad at picking — they default to "search everything"
+  or guess the wrong tier. Better to expose four named tools
+  (`code_search`, `symbol_lookup`, `find_references`, `read_chunk`) so
+  the choice happens at tool-selection time, not via a `kind` parameter.
+
+## What we deliberately rejected
+
+- Pure vector marketing. The product is "your agent gets the right
+  context in one shot." The implementation is hybrid; we don't pitch
+  the implementation.
+- Reranker-on-everything. Tier 1's exact match doesn't need it.
+- A single mega-search tool. Separate named tools route better.
+
+## Reference
+
+RRF paper: Cormack, Clarke, Buettcher 2009. Cross-encoder rerank: see
+the cross-encoder family (`bge-reranker-v2-m3`, Voyage rerank-2, Cohere
+rerank-3). Sourcegraph and Cursor have published numbers showing hybrid
++ rerank dominates pure vector on code retrieval.

--- a/specs/0.04-MVP/decisions/0017-branch-aware-manifest.md
+++ b/specs/0.04-MVP/decisions/0017-branch-aware-manifest.md
@@ -1,0 +1,165 @@
+# ADR 0017 — Branch-aware manifest model
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+ADR 0014 established the content-addressed blob store and per-branch
+manifest schema. This ADR locks in the *operational* contract: when does
+the manifest update, how does branch detection happen, what's the
+expected switch latency, and what guarantees do we make under
+concurrent agent activity.
+
+Conductor's parallel-workspace pattern raises specific cases:
+
+- Workspace A is on `main`, agent is mid-stream issuing `code_search`.
+  Workspace B switches its branch. A's queries must continue against
+  `main`, not bleed into B's branch.
+- A user runs `git checkout` from the right-pane terminal (Phase 2's
+  PTY). The index needs to detect this and update the active branch
+  for that workspace.
+- A user creates a new branch with `git checkout -b foo`. The new branch
+  inherits the current manifest (it's the same tree at creation time).
+- A 1000-file branch switch shouldn't block the agent for seconds.
+
+## Decision
+
+### Per-workspace active branch
+
+Each forkzero workspace tracks its own *active branch* in memory.
+`IndexService.search` accepts a `branch?` param; when omitted, it uses
+the workspace's active branch. Workspace A's queries never see B's
+manifest, even though both share the underlying blob store.
+
+```ts
+// apps/server/src/index/index-service.ts
+class IndexService {
+  search(input: SearchInput, ctx: WorkspaceContext) {
+    const branch = input.branch ?? ctx.activeBranch
+    return engine.search({ ...input, branch })
+  }
+}
+```
+
+### Branch detection
+
+Two sources of truth, in priority order:
+
+1. **Explicit RPC** — `index.setBranch(branch: string)` from the
+   renderer when the workspace UI changes branch. Authoritative when
+   present.
+2. **Git watcher** — watches `<workspace>/.git/HEAD` (a tiny file that
+   changes on every checkout). On change, parse it, update active
+   branch, kick off manifest reconciliation.
+
+We do **not** parse PTY output to detect `git checkout`. That's
+fragile (custom shells, aliases, output formatting). The `.git/HEAD`
+watch is reliable.
+
+### Manifest reconciliation
+
+When the active branch changes from `from` to `to`:
+
+```
+1. compute walk(workspace, to_branch)
+   → emit (path, blob_sha) for each file in working tree
+2. for each (path, sha):
+     blob = upsert blobs(sha, ...)         -- inserts if new
+     if new blob:
+       parse, chunk, extract symbols, enqueue embeddings
+     upsert manifests(to_branch, path, blob.id)
+3. delete manifests(to_branch, path) for paths no longer present
+4. activeBranch[workspace] = to
+5. fire IndexBranchSwitched event (renderer can refresh search UI)
+```
+
+Steps 2–3 happen in one SQL transaction. New blobs that need parsing
+happen *after* the transaction commits — the manifest swap doesn't wait
+for parsing/embedding.
+
+### Latency contract
+
+| Scenario | Target |
+|---|---|
+| Manifest swap (no new blobs) | < 50ms |
+| Branch switch with ~10 changed files | < 200ms |
+| Branch switch with 1000 changed files | < 1s for manifest, parsing async |
+| File edit → re-index | < 50ms |
+
+We do **not** block agent queries during reconciliation. Mid-flight
+queries against `from_branch` complete against `from_branch`'s manifest.
+New queries arriving after the swap see `to_branch`. Stale results from
+a query started before the swap are accepted — agents handle this fine.
+
+### Untracked and ignored files
+
+- `.gitignore` is respected by default
+- An `index-ignore` file at the workspace root can extend ignores
+- Generated files (e.g., `dist/`) are excluded by default ignores
+- Untracked files **are indexed** (the agent should see new files the
+  user is working on). They live in the manifest under the active
+  branch even though git doesn't track them.
+
+### New branches
+
+`git checkout -b foo` from `main`: the watcher fires; reconciliation
+walks the working tree (which is identical to `main` at creation); the
+new manifest gets the same blob_ids as `main`. Net new rows in
+`manifests` only — no re-parsing.
+
+### Concurrent workspaces
+
+Two Conductor workspaces (A on `main`, B on `feature`) run agents in
+parallel. Each writes its own `(branch, path, blob_id)` rows. SQLite's
+default WAL mode handles the concurrency. Reads are non-blocking.
+
+## Consequences
+
+### Positive
+
+- Branch switches feel instant in UI even on huge changesets.
+- Parallel workspaces don't step on each other.
+- Detection is reliable (file watcher on `.git/HEAD` is bulletproof).
+- The agent always sees its workspace's branch, never bleeds.
+
+### Negative
+
+- File watcher overhead per workspace. With 5 Conductor workspaces, 5
+  `.git/HEAD` watches plus 5 working-tree watches. `@parcel/watcher`
+  handles this fine, but we should profile.
+- Stale-result tolerance for in-flight queries during a swap. Documented
+  as acceptable; agents handle it. If users report weirdness, we can
+  add per-query branch capture as a tightening.
+
+## Alternatives considered
+
+### Re-index on every branch switch
+
+- Pro: simplest code.
+- Con: violates the < 200ms target. Defeats the parallel-workspace
+  value prop.
+
+### Branch as a label on chunks (no manifest table)
+
+- Pro: simpler schema.
+- Con: every query needs a `WHERE branch = ?` filter. Can't dedupe
+  cross-branch.
+
+### Detect branch by parsing PTY output
+
+- Pro: works without git internals.
+- Con: fragile across shells, aliases, custom prompts. Discarded.
+
+### Use libgit2 / nodegit
+
+- Pro: rich git API.
+- Con: heavy native dependency for one feature. Watching `.git/HEAD`
+  + a small wrapper around `git rev-parse HEAD` is enough.
+
+## What we deliberately rejected
+
+- Blocking agent queries during reconciliation.
+- Cross-workspace branch sharing (each workspace has its own active
+  branch by design).
+- A unified "current branch" — Conductor's whole point is parallelism.

--- a/specs/0.04-MVP/decisions/0018-mcp-server-as-app.md
+++ b/specs/0.04-MVP/decisions/0018-mcp-server-as-app.md
@@ -1,0 +1,169 @@
+# ADR 0018 — MCP server as a standalone app (`apps/mcp-server`)
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+The index engine (`@forkzero/index`, ADR 0013) has two consumers in
+0.04: the desktop server and an MCP server for external agents. The
+external-MCP shape lets users connect *any* agent runtime (terminal
+Claude Code, Codex, Cursor's agent mode, custom scripts) to the same
+index, getting the same tools forkzero's bundled agent uses.
+
+Distribution shape questions:
+
+- Is the MCP server a route inside `apps/server`, or its own app?
+- Does it ship with the desktop, or as a standalone binary?
+- Does it run only when forkzero is open, or independently?
+- How do users without forkzero installed get it?
+
+The honest goal: forkzero's index becomes useful **even if the user is
+running `claude` in a terminal without the desktop app.** That's the
+distribution play — same engine, two transports, available everywhere
+agents are.
+
+## Decision
+
+Ship the MCP server as a separate workspace app: **`apps/mcp-server`**.
+
+### Layout
+
+```
+apps/mcp-server/
+  package.json                      # name: "@forkzero/mcp-server"
+  src/
+    bin.ts                          # CLI entry — `forkzero-mcp [opts]`
+    server.ts                       # MCP server boot
+    tools/
+      code-search.ts
+      symbol-lookup.ts
+      find-references.ts
+      read-chunk.ts
+      list-module.ts
+      index-status.ts
+    runtime.ts                      # Effect Layer composing IndexService.Default
+```
+
+### Transport
+
+- **stdio** (default) — `forkzero-mcp --workspace /path` reads/writes
+  JSON-RPC over stdin/stdout. This is what `~/.claude/mcp.json` and
+  Codex's MCP config expect.
+- **HTTP** (optional) — `forkzero-mcp --http :7421 --workspace /path`
+  exposes the same MCP endpoints over HTTP for runtimes that prefer
+  HTTP (or for IDE plugins).
+
+Both transports use `@modelcontextprotocol/sdk` server primitives.
+
+### Distribution
+
+Three channels:
+
+1. **npm** — `npx @forkzero/mcp-server --workspace .` works for users
+   with Node ≥ 22. Lowest-friction entry.
+2. **Bun-compiled binaries** — `bun build --compile` produces
+   `forkzero-mcp` per OS. No Node required. Distributed via GitHub
+   Releases and Homebrew.
+3. **Bundled in the desktop app** — the binary lives inside the
+   forkzero app bundle so users who installed the desktop also get
+   `forkzero-mcp` on PATH.
+
+### Authentication and key handling
+
+The MCP server does **not** mount the desktop's keytar. If a user wants
+paid embeddings/rerank when running `forkzero-mcp` standalone, they
+provide keys via env vars (`VOYAGE_API_KEY`, etc.) — same env vars the
+desktop reads after fetching them from keytar. This way:
+
+- Standalone MCP server is self-contained, no Electron dependencies
+- No accidental cross-process credential leaks
+- Local default works zero-config
+
+When the MCP server is *invoked from inside the desktop app* (e.g., for
+testing), it inherits the env including keys the desktop already
+loaded.
+
+### Workspace argument
+
+`--workspace <path>` is required. Defaults to `process.cwd()` if
+omitted. The server opens (or creates) the index DB at the path
+described in ADR 0014 (`<userData>/index/<repo-id>/forkzero-index.sqlite`),
+which means desktop and standalone share the same DB when run on the
+same repo. Users on a forkzero-managed index get warm-started search.
+
+### Why a separate app, not a route in `apps/server`
+
+`apps/server` pulls in IPC + RPC machinery for Electron. The MCP server
+shouldn't pay that cost — it's a different process model (single CLI
+invocation, stdio-attached) and a different bundle size target.
+Separate app keeps each focused and Bun-compilable.
+
+`@forkzero/index` is the shared substrate. Both apps consume it. No
+code duplication; no cross-contamination of transport concerns.
+
+### Why npm + binary, not just binary
+
+- npm is the de-facto channel for MCP servers (`npx ...` is what every
+  example in MCP docs shows). Skipping it cuts off discovery.
+- Binaries handle the no-Node case (rare but real, especially among
+  users who are already wary of Node ecosystem bloat).
+
+## Consequences
+
+### Positive
+
+- Forkzero's index reaches users who don't run the desktop app.
+- The MCP binary is small (no Electron, no React, no Effect RPC).
+- Same engine, same data, same answers across desktop and MCP.
+- npm distribution doubles as marketing (`@forkzero/mcp-server` is
+  searchable, installable, recommendable).
+
+### Negative
+
+- Two apps to keep in sync. Mitigated by `@forkzero/index` being the
+  source of truth; both apps are thin wrappers.
+- npm publishing pipeline (CI workflow, version bumps) is one more
+  thing to maintain.
+- Bun-compiled binaries per OS = a release matrix.
+
+## Alternatives considered
+
+### MCP route inside `apps/server`
+
+- Pro: one app to deploy.
+- Con: external agents can't use it without the desktop running. Loses
+  the distribution shape entirely.
+
+### Just the binary, no npm
+
+- Pro: simpler release pipeline.
+- Con: cuts off the dominant MCP install path. `npx @scope/server` is
+  what users expect.
+
+### MCP server as a feature inside Cursor / Continue / etc.
+
+- Pro: zero distribution work for us.
+- Con: vendor-coupled. We'd be a feature of those products, not a
+  product. Doesn't extend to terminal Claude Code or Codex.
+
+### HTTP-only (no stdio)
+
+- Pro: simpler to debug.
+- Con: stdio is what `~/.claude/mcp.json` and Codex configs expect by
+  default. Users would need to configure a port + URL. Higher friction.
+
+## What we deliberately rejected
+
+- Bundling MCP transport into `@forkzero/index`. Keeps the package
+  transport-agnostic.
+- Spinning up the MCP server on demand from `apps/desktop`. The
+  desktop's bundled agent uses `IndexService` in-process; users who
+  want external MCP access run `forkzero-mcp` themselves.
+
+## Reference
+
+The Model Context Protocol spec (modelcontextprotocol.io) and SDK
+(`@modelcontextprotocol/sdk`) define the wire format. Cursor's,
+Sourcegraph's, and Anthropic's published MCP servers follow the same
+shape: separate binary, stdio default, HTTP optional. We match.

--- a/specs/0.04-MVP/decisions/0019-sqlite-vec-extension.md
+++ b/specs/0.04-MVP/decisions/0019-sqlite-vec-extension.md
@@ -1,0 +1,176 @@
+# ADR 0019 — SQLite + sqlite-vec for vector search (extends ADR 0008)
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+ADR 0008 established SQLite + `@effect/sql-sqlite-node` (with
+`better-sqlite3`) as forkzero's persistence engine. 0.04 adds vector
+search to the index. Three places that vector storage could live:
+
+- A separate vector DB (LanceDB, Qdrant, Chroma, Weaviate)
+- A SQLite extension that adds vector columns
+- An in-memory index (FAISS, hnswlib) backed by serialized files
+
+The forkzero principles (ADR 0007: server is the only source of truth;
+ADR 0008: single-file portability; local-first) point at "stay inside
+SQLite if at all possible." Adding a second persistence engine adds a
+second backup story, a second failure mode, a second startup
+dependency. Avoid.
+
+`sqlite-vec` is a SQLite extension by Alex Garcia (also author of
+sqlite-utils ecosystem tools, very actively maintained). It adds:
+
+- A `vec0` virtual table type for dense vectors
+- KNN search via `MATCH` syntax
+- Integer quantization for compression
+- ~5MB native binary, distributable via npm
+- Battle-tested in production (used by Datasette, several Cursor-like
+  IDEs, and recent versions of Open WebUI)
+
+Performance: KNN search over 100k 768-dim vectors is ~5-20ms on a
+modern laptop. That's comfortably inside our Tier 3 latency budget
+(rerank dominates at 100-300ms).
+
+## Decision
+
+Use **`sqlite-vec`** as the vector storage engine. It plugs into the
+existing SQLite database file via SQLite's extension loading API.
+
+### Wiring
+
+```ts
+// packages/index/src/runtime.ts
+import * as sqliteVec from "sqlite-vec"
+
+const Database = yield* SqlClient.SqlClient
+yield* Effect.sync(() => {
+  const handle = (Database as any).rawDatabase  // exposed by @effect/sql-sqlite-node
+  sqliteVec.load(handle)
+})
+```
+
+### Schema
+
+```sql
+-- 768 dim default to match nomic-embed-code (the default embed model).
+-- We store dim metadata so the engine refuses to mix models.
+CREATE VIRTUAL TABLE chunk_vec USING vec0(
+  chunk_id INTEGER PRIMARY KEY,
+  embedding FLOAT[768]
+);
+
+-- A separate table stores which model produced the embeddings.
+-- If the user switches embed model, we throw on inconsistent dims and
+-- offer a "reindex embeddings" path.
+CREATE TABLE embedding_meta (
+  model     TEXT PRIMARY KEY,
+  dim       INTEGER NOT NULL,
+  created   INTEGER NOT NULL
+);
+```
+
+### Native module rebuild
+
+`sqlite-vec` ships prebuilt binaries via npm. For Electron, we add it
+to the existing `electron-rebuild -w` list alongside `keytar`,
+`node-pty`, `better-sqlite3`, and the new tree-sitter / blake3 /
+@parcel/watcher modules.
+
+### Catalog entry
+
+```json
+"sqlite-vec": "catalog:"
+```
+
+Per ADR 0006, native modules used by 2+ workspaces (here, `apps/server`
+and `apps/mcp-server` via `@forkzero/index`) are catalogued.
+
+### Embedding lifecycle
+
+- New chunks are inserted with no embedding (`embedding IS NULL` in
+  `chunk_vec` is *not* possible — we omit the row entirely).
+- The async embedding worker pulls chunks lacking a vec row, embeds
+  them in batches of 64, inserts into `chunk_vec`.
+- Search queries gracefully handle chunks missing embeddings —
+  `vec0` returns only chunks with embeddings; BM25 still searches all
+  chunks; fusion combines.
+
+### Migrations
+
+`sqlite-vec` virtual tables are created in numbered SQL migration files
+following the ADR 0008 pattern:
+
+```
+packages/index/src/schema/migrations/
+  0001-init.sql              # base tables
+  0002-add-chunk-vec.sql     # vec0 virtual table
+  0003-add-embedding-meta.sql
+```
+
+Migrations are run via `@effect/sql/Migrator` at engine startup.
+
+## Consequences
+
+### Positive
+
+- One file, one backup story. The user's index lives in their
+  workspace's `forkzero-index.sqlite`.
+- Same query engine for vector + BM25 + symbol — joins across them are
+  trivial (`JOIN chunks ON chunks.id = chunk_vec.chunk_id`).
+- Schema migrations follow the existing ADR 0008 pattern; no new
+  migration tooling.
+- `vec0` performance is good enough: KNN over 100k chunks in 5-20ms.
+- Active maintenance + community.
+
+### Negative
+
+- One more native module in the rebuild pipeline. Not free, but
+  marginal cost on top of what we already maintain.
+- `sqlite-vec` is younger than the SQLite core. Treat new releases
+  with caution; pin the version explicitly.
+- Vector quantization (the int8 / int4 features) is on the cutting
+  edge — we don't enable it in v1; revisit if storage becomes a
+  problem.
+
+## Alternatives considered
+
+### LanceDB (separate file/process)
+
+- Pro: best-in-class vector engine, growing momentum.
+- Con: separate persistence engine, separate backup story, second DB
+  to manage. Doesn't fit the "single-file portability" principle of
+  ADR 0008.
+
+### Qdrant / Chroma / Weaviate (server)
+
+- Pro: full vector DB.
+- Con: server process to run. Overkill for desktop, hostile to
+  local-first.
+
+### FAISS / hnswlib in-memory + serialize on disk
+
+- Pro: fastest vector search at small-to-medium scale.
+- Con: two stores to keep in sync (SQLite for metadata, hnswlib for
+  vectors). Crash recovery is complex. Not worth the speed gain at our
+  scale.
+
+### Pure SQLite + cosine similarity in SQL
+
+- Pro: no extension required.
+- Con: SQLite has no native dot-product. Computing cosine in SQL means
+  a full scan; doesn't scale beyond a few thousand chunks.
+
+## What we deliberately rejected
+
+- Multiple embedding models per workspace. One model per workspace,
+  enforced by `embedding_meta`. Switching models requires re-embed.
+- Storing raw vectors as TEXT/BLOB in `chunks` and computing similarity
+  manually. The right abstraction is `vec0`.
+
+## Reference
+
+`sqlite-vec` repo: github.com/asg017/sqlite-vec. ADR 0008 establishes
+SQLite + `@effect/sql-sqlite-node` as the persistence baseline that
+this ADR extends.

--- a/specs/0.04-MVP/decisions/0020-pluggable-rerank-and-embed.md
+++ b/specs/0.04-MVP/decisions/0020-pluggable-rerank-and-embed.md
@@ -1,0 +1,165 @@
+# ADR 0020 — Pluggable rerank and embed providers
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+The index needs an embedding model (Tier 3 vector search) and a rerank
+model (Tier 3 final ranking). Both have meaningful trade-offs along
+quality / speed / cost / privacy axes:
+
+- **Local default** (free, private, but quality is below SOTA)
+- **Voyage / Cohere / OpenAI** (paid, SOTA quality, requires API key,
+  chunks leave the user's machine)
+- **Forkzero-cloud** (deferred — see ADR 0021)
+
+Different users have different needs. A solo developer indexing a
+private repo wants local-only. A team OK with sharing chunks with
+Voyage wants SOTA quality. A curious user wants to A/B compare. The
+architecture has to make the choice user-configurable without entangling
+the engine's internals.
+
+## Decision
+
+Define two **provider abstractions** in `@forkzero/index` —
+`EmbeddingProvider` and `RerankProvider` — and ship multiple
+implementations. The user picks via config (env var or
+`forkzero-index.config.json` in the workspace).
+
+### EmbeddingProvider contract
+
+```ts
+// packages/index/src/embedding/api.ts
+export interface EmbeddingProvider {
+  readonly id: string                          // "nomic-local", "voyage", ...
+  readonly model: string                        // "nomic-embed-code", "voyage-code-3", ...
+  readonly dim: number                          // 768, 1024, ...
+  embedBatch(
+    texts: ReadonlyArray<string>
+  ): Effect<ReadonlyArray<Float32Array>, EmbeddingError>
+}
+```
+
+### RerankProvider contract
+
+```ts
+// packages/index/src/retrieval/rerank.ts
+export interface RerankProvider {
+  readonly id: string                          // "bge-local", "voyage", ...
+  readonly model: string
+  rerank(
+    query: string,
+    chunks: ReadonlyArray<{ id: number; text: string }>
+  ): Effect<ReadonlyArray<{ id: number; score: number }>, RerankError>
+}
+```
+
+### Implementations shipped in 0.04
+
+Embedding:
+
+| Provider | Implementation | Default? |
+|---|---|---|
+| `nomic-local` | `@huggingface/transformers` ONNX runtime, `nomic-ai/nomic-embed-code` | **yes** |
+| `voyage` | HTTP client → Voyage API, `voyage-code-3` | opt-in |
+| `openai` | HTTP client → OpenAI Embeddings API, `text-embedding-3-large` | opt-in |
+| `jina` | HTTP client → Jina API (or local `jina-code-v2` ONNX) | opt-in |
+
+Rerank:
+
+| Provider | Implementation | Default? |
+|---|---|---|
+| `bge-local` | `@huggingface/transformers` ONNX, `BAAI/bge-reranker-v2-m3` | **yes** |
+| `voyage` | HTTP client → Voyage rerank-2 | opt-in |
+| `cohere` | HTTP client → Cohere rerank-3 | opt-in |
+| `none` | identity function (skip rerank) | for benchmarks |
+
+### Provider switching
+
+The active provider is selected by the engine at startup:
+
+```ts
+// pseudo-config
+{
+  "embed": "nomic-local",   // or "voyage" | "openai" | "jina"
+  "rerank": "bge-local"     // or "voyage" | "cohere" | "none"
+}
+```
+
+If the embed provider changes (different `dim`), the engine throws on
+boot — `embedding_meta.dim` will mismatch the existing `vec0` schema.
+The user is shown a clear error: "Re-index required to switch embed
+model." Rerank can be swapped freely (no persistent state).
+
+### Credential storage
+
+API-based providers read keys from `keytar` (in `apps/server`) or env
+vars (in `apps/mcp-server`). The provider abstraction never touches
+keytar directly — `apps/server`'s `IndexService` injects env into the
+provider when constructing the engine. See ADR 0021.
+
+### Bundled model weights
+
+`nomic-embed-code` (~280MB ONNX) and `bge-reranker-v2-m3` (~120MB ONNX)
+weights ship inside the desktop app bundle. First-run extraction; no
+network call. For the `apps/mcp-server` standalone binary, weights
+either bundle in (Bun supports embedding files at compile time) or
+download on first use (configurable).
+
+## Consequences
+
+### Positive
+
+- Users choose between privacy (local) and quality (paid) without
+  modifying engine code.
+- Adding a new provider (Cohere, Mistral, a future forkzero-cloud) is
+  a new file, not a refactor.
+- Benchmarking is straightforward — swap providers and re-run the eval.
+- The provider boundary contains all network code, all credential
+  reads, all error mapping. The engine stays clean.
+
+### Negative
+
+- Bundled local models add ~400MB to the desktop install. Documented;
+  on disk, not in RAM until first use.
+- Each provider has its own error model (rate limits, auth failures,
+  network errors). The abstraction maps these into our `EmbeddingError`
+  / `RerankError` taxonomy, but the cases proliferate.
+- Different embed models have different optimal context windows; we
+  truncate to the smaller of the model's context and our chunk size.
+
+## Alternatives considered
+
+### Hardcode one embed + one rerank
+
+- Pro: simpler.
+- Con: forecloses BYOK and cloud. The whole pricing-strategy
+  conversation (ADR 0021) becomes much harder if every user has the
+  same provider.
+
+### Provider as a compile-time decision
+
+- Pro: smaller install if you only want one.
+- Con: can't switch without rebuilding. Bad for users who experiment.
+
+### Make every chunk's embedding a Promise resolved by whoever calls
+search
+
+- Pro: total flexibility.
+- Con: every search becomes its own embed operation. Defeats the
+  caching benefit of pre-embedding chunks.
+
+## What we deliberately rejected
+
+- Mix-and-match per-query providers. One workspace, one embed model,
+  one rerank model.
+- Forkzero-managed key escrow in 0.04. ADR 0021 defers this.
+- Streaming embeddings. Embeddings are batch in nature; streaming
+  doesn't help our async-worker model.
+
+## Reference
+
+The provider pattern matches the agent integration adapter pattern
+(`AgentAdapter` in `0.01-MVP/features/agent-integration.md`): one
+contract, multiple implementations, swappable at runtime.

--- a/specs/0.04-MVP/decisions/0021-credentials-and-billing.md
+++ b/specs/0.04-MVP/decisions/0021-credentials-and-billing.md
@@ -1,0 +1,160 @@
+# ADR 0021 — Credentials & billing model
+
+Date: 2026-05-06
+Status: Accepted
+
+## Context
+
+ADR 0020 makes embedding and rerank providers pluggable. Some providers
+are local (free, private). Some are API-based (Voyage, Cohere, OpenAI,
+Jina) — these need credentials, and someone has to pay the bill.
+
+There are three credible billing shapes for paid providers:
+
+| Shape | What user does | Where forkzero is in the path | Forkzero infra needed |
+|---|---|---|---|
+| **Local** | Nothing | Not in the path | None |
+| **BYOK** | Pastes their own key in Settings | Not in the path; chunks go user → provider directly | None |
+| **Forkzero-cloud** | Subscribes; we proxy | In the path; chunks traverse our proxy | Auth, billing, rate limit, abuse mitigation, support |
+
+The temptation with "make it a service" is to ship Forkzero-cloud
+day-one. The reality of running Forkzero-cloud:
+
+- Backend service (key management, rate limiting, key rotation, observability)
+- Stripe + sales tax / VAT in 30+ jurisdictions
+- Abuse mitigation (free-trial farming; runaway agents — one bug = $1000
+  charged to your name)
+- "Your code never leaves your machine" claim breaks (chunks pass through
+  our proxy; embeddings are partially invertible to recover content)
+- Pricing design (per-query? per-million-tokens? subscription?)
+- Customer support: refunds, billing disputes, outages
+- Margin reality: Voyage charges ~$0.06/1M tokens. A 30% markup is
+  ~$0.02/1M tokens. Sustainable at scale; not at startup.
+
+We can build this later. Building it before adoption is a fixed cost
+without a revenue base.
+
+## Decision
+
+**0.04 ships local + BYOK only.** Forkzero-cloud is deferred. The
+architecture leaves the door open: the provider abstraction (ADR 0020)
+treats `forkzero-cloud` as one more provider. Adding it later is
+two new files plus a billing service, not re-architecting.
+
+### Local (default)
+
+`nomic-embed-code` for embeddings, `bge-reranker-v2-m3` for rerank.
+Both run in-process via `@huggingface/transformers` ONNX runtime. Zero
+network calls. Works out of the box.
+
+### BYOK (opt-in)
+
+User pastes API keys in **Settings → Index** (renderer). Storage uses
+the existing `keytar` pattern from agent integration (Phase 2), with new
+slots:
+
+```
+forkzero:embed:voyage     → VOYAGE_API_KEY
+forkzero:embed:openai     → OPENAI_API_KEY
+forkzero:embed:jina       → JINA_API_KEY
+forkzero:rerank:cohere    → COHERE_API_KEY
+forkzero:rerank:voyage    → VOYAGE_API_KEY
+```
+
+When the user selects a paid provider, `apps/server` reads the matching
+key from keytar at engine startup and injects it into the provider via
+env var. Keys never logged. Never written to disk in plaintext. Never
+sent to forkzero servers (because there are none in 0.04).
+
+For the standalone MCP server (`apps/mcp-server`), keys come from env
+vars directly — the binary doesn't access keytar.
+
+### Forkzero-cloud (deferred)
+
+A `forkzero-cloud` provider stub exists in 0.04 but throws "not yet
+available" if selected. This is intentional:
+
+- The UI surface ("Forkzero-cloud — coming soon") signals to users
+  that this option exists.
+- Pre-allocates a name in the provider registry so future config can
+  reference it without breaking change.
+- Forces us to keep the provider abstraction honest (if we couldn't
+  drop in `forkzero-cloud` later, the abstraction would be wrong).
+
+When we eventually ship Forkzero-cloud (a future MVP, not 0.04):
+
+- Implement the `forkzero-cloud` embed and rerank providers (HTTP
+  clients hitting our proxy)
+- Build `apps/billing-proxy` (or run as a service)
+- Add Stripe integration, key issuance, rate limiting
+- Document the privacy trade-off honestly
+
+### Why pre-stub `forkzero-cloud` now
+
+If we leave it out entirely, future ADRs may need to reshape the
+provider contract to fit a billing model we hadn't imagined. By
+landing the stub today, we're forced to think about:
+
+- Does the contract pass enough metadata for billing (user ID,
+  workspace ID, query token counts)?
+- Does the rerank result include cost data?
+- Is there a notion of "session" that bundles many embed + rerank
+  calls?
+
+These questions surface now, cheaply, while changing the contract is
+a one-package-touch.
+
+## Consequences
+
+### Positive
+
+- 0.04 ships a useful, complete product without a billing system.
+- BYOK costs nothing to support — same pattern as Phase 2 agent keys.
+- The cloud option exists conceptually; users see it labeled and know
+  it's planned.
+- When we do build Forkzero-cloud, the architecture doesn't change.
+
+### Negative
+
+- Forkzero-cloud users have to wait. We won't have recurring revenue
+  from this product surface in 0.04.
+- BYOK requires users to sign up at Voyage / Cohere / OpenAI etc.,
+  which is friction. Some users will abandon and use local-only.
+- The "coming soon" label in Settings is debt — it sets an expectation
+  we have to deliver on.
+
+## Alternatives considered
+
+### (a) BYOK only, defer forkzero-cloud forever
+
+- Pro: zero billing complexity, ever.
+- Con: forecloses recurring revenue and team-shared cloud index.
+  Forkzero stays an OSS tool. Possibly fine; possibly limiting.
+
+### (b) Ship pay-per-usage in 0.04 alongside BYOK
+
+- Pro: revenue from day one.
+- Con: huge fixed cost (Stripe, tax, abuse, support) on top of the
+  index work itself. Doubles 0.04's scope. Likely delays shipping
+  by a quarter.
+
+### (c) BYOK in 0.04 + scaffold forkzero-cloud stub now (chosen)
+
+- Pro: ship 0.04 fast; preserve optionality; exercise the abstraction.
+- Con: stub debt (must follow through eventually).
+
+## What we deliberately rejected
+
+- Forkzero-cloud as the *default*. Local-first is the principle (matches
+  ADR 0007's local-only-v1 stance).
+- Storing API keys in plaintext config. Keytar is the standard.
+- Per-query keys (passing keys with each request). Provider holds the
+  key for its lifetime.
+- Forking the engine to support a "managed" version separately. One
+  engine, one set of providers — billing rides on top.
+
+## Reference
+
+ADR 0020 defines the provider abstraction this ADR sits on. The keytar
+pattern matches `0.01-MVP/features/agent-integration.md`'s credentials
+section.

--- a/specs/0.04-MVP/features/code-index.md
+++ b/specs/0.04-MVP/features/code-index.md
@@ -1,0 +1,477 @@
+# Feature: Code Index
+
+A content-addressed code index with hybrid retrieval. Two consumers: the
+bundled agent (in-process via `apps/server`) and external agents (over MCP
+via `apps/mcp-server`). One engine, one chunk store, two transports.
+
+## Why this exists
+
+Agents inside forkzero spend most of their token budget on navigation —
+`Bash(rg ...)` → `Read` → repeat. On a real codebase: 25–40k tokens across
+5–8 tool calls before the agent has the context to work. Most of that is
+*tax*, not value.
+
+Existing tools (Cursor, Sourcegraph Cody, Greptile, Continue, Augment) all
+build codebase indexes. None handle the **N parallel agent workspaces on
+the same repo** shape that Conductor + forkzero already produces. That's
+the wedge: not "vector DB for code," but "the only index built for the
+parallel-workspace agent workflow."
+
+## Goals
+
+1. **Tokens-per-task ↓ 3–10×** vs. baseline grep agent on real forkzero tasks.
+2. **Wall-clock-per-task ↓ 2–3×** (driven by fewer LLM round-trips, not
+   faster retrieval).
+3. **Branch switches in < 200 ms**, not minutes — Conductor workspace
+   ergonomics demand this.
+4. **Local-first**, zero network calls in the default config.
+5. **Reusable**: forkzero is one consumer, not the only consumer.
+
+## Non-goals
+
+- Cloud team index (deferred to a future MVP).
+- IDE-grade rename / refactor (call graphs are read-only, no edits).
+- More than one embedding model per workspace.
+- Cross-repo search.
+
+## Package + app layout
+
+The engine is a **package**, not a service. Putting it in a package keeps
+it transport-agnostic — `apps/server` consumes it directly, `apps/mcp-server`
+wraps it as MCP, and a future cloud-sync worker is a third consumer.
+
+```
+packages/
+  index/                              # @forkzero/index — pure engine
+    src/
+      schema/migrations/              # SQL files
+      chunker/                        # tree-sitter chunking
+      symbols/                        # symbol extraction + ref resolution
+      retrieval/
+        symbol-lookup.ts              # Tier 1
+        bm25.ts                       # FTS5 wrapper
+        vector.ts                     # sqlite-vec wrapper
+        rerank.ts                     # cross-encoder caller
+        router.ts                     # query classification
+        fuse.ts                       # reciprocal rank fusion
+      manifest/                       # branch model
+      watcher/                        # incremental file-change indexer
+      embedding/                      # pluggable embedding providers
+      api.ts                          # exported Effect Service contract
+
+apps/
+  server/
+    src/
+      index/                          # consumes @forkzero/index
+        index-service.ts              # Effect.Service wrapping the engine
+        index-handlers.ts             # RPC handlers → renderer
+  mcp-server/                         # NEW — standalone MCP app
+    src/
+      server.ts                       # MCP stdio + HTTP entry
+      tools/                          # MCP tool wrappers
+      bin.ts                          # `forkzero-mcp` executable
+```
+
+The desktop renderer never talks to the index directly — it goes through
+`apps/server` via existing RPC, preserving ADR 0007 (server is the only
+source of truth).
+
+See [ADR 0013](../decisions/0013-index-as-package.md) for the package vs
+service decision.
+
+## Storage model — content-addressed chunk store
+
+All indexed content lives in **one SQLite file** per workspace (extends
+ADR 0008).
+
+```sql
+-- One row per unique blob (file content) we've ever seen, keyed by SHA.
+-- Switching branches doesn't re-add blobs we already have.
+blobs (
+  id          INTEGER PRIMARY KEY,
+  sha         BLOB NOT NULL UNIQUE,
+  language    TEXT,
+  size        INTEGER NOT NULL,
+  parsed_at   INTEGER
+);
+
+-- One row per chunk inside a blob.
+chunks (
+  id          INTEGER PRIMARY KEY,
+  blob_id     INTEGER NOT NULL REFERENCES blobs(id),
+  kind        TEXT NOT NULL,             -- function|class|method|window
+  start_line  INTEGER NOT NULL,
+  end_line    INTEGER NOT NULL,
+  symbol_id   INTEGER REFERENCES symbols(id),
+  content     TEXT NOT NULL              -- materialized for FTS + reads
+);
+
+-- One row per named entity.
+symbols (
+  id          INTEGER PRIMARY KEY,
+  blob_id     INTEGER NOT NULL,
+  name        TEXT NOT NULL,
+  kind        TEXT NOT NULL,             -- function|class|type|const|...
+  signature   TEXT,
+  start_line  INTEGER, end_line INTEGER,
+  parent_id   INTEGER REFERENCES symbols(id),
+  exported    INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX symbols_name ON symbols(name);
+CREATE INDEX symbols_parent ON symbols(parent_id);
+
+-- References (callers/usages).
+refs (
+  id          INTEGER PRIMARY KEY,
+  symbol_id   INTEGER NOT NULL,
+  blob_id     INTEGER NOT NULL,
+  start_line  INTEGER, end_line INTEGER,
+  context     TEXT
+);
+
+-- Vector index via sqlite-vec extension. Lazy: chunks not yet embedded
+-- still work via BM25 / symbol lookup.
+CREATE VIRTUAL TABLE chunk_vec USING vec0(
+  chunk_id INTEGER PRIMARY KEY,
+  embedding FLOAT[768]
+);
+
+-- Full-text via FTS5.
+CREATE VIRTUAL TABLE chunks_fts USING fts5(
+  content, content='chunks', content_rowid='id',
+  tokenize = "trigram"
+);
+
+-- Per-branch manifest. Switching branches = swap rows here.
+manifests (
+  branch       TEXT NOT NULL,
+  file_path    TEXT NOT NULL,
+  blob_id      INTEGER NOT NULL,
+  PRIMARY KEY (branch, file_path)
+);
+CREATE INDEX manifests_blob ON manifests(blob_id);
+```
+
+**Why content-addressed.** Five Conductor workspaces on the same repo
+means five branches checked out concurrently. With a content-addressed
+store, the common 95% of files dedupe across branches; only the changed
+files cost re-parsing. Switching branches is a manifest swap, not a
+re-index.
+
+See [ADR 0014](../decisions/0014-content-addressed-chunk-store.md) for the
+chunk store; [ADR 0017](../decisions/0017-branch-aware-manifest.md) for
+the manifest model.
+
+## Indexing pipeline
+
+```
+on workspace open:
+  walk respecting .gitignore + index-ignore patterns
+  for each file:
+    sha = blake3(content)              -- blake3 > sha256 for speed
+    if blobs[sha] exists: skip parse
+    else:
+      lang = detect(file)
+      tree = tree-sitter.parse(content, lang)
+      chunks = extract_chunks(tree)    -- prefer function/class boundaries
+      symbols = extract_symbols(tree)  -- name, kind, signature, parent
+      refs    = extract_refs(tree)     -- via tree-sitter scope queries
+      insert blobs, chunks, symbols, refs
+      enqueue chunks for embedding (async, batched 64 per request)
+  upsert manifests(branch, file, blob_id)
+
+on file change (watcher):
+  same as above for one file; tree-sitter is incremental
+
+on branch switch:
+  diff old_manifest vs new_manifest
+  swap changed rows
+  no re-parsing for unchanged blobs
+```
+
+Initial index of a forkzero-sized repo (~80k LOC TypeScript): target
+60–120s. Per-file change: 10–50ms. Branch switch: < 200ms.
+
+**Tree-sitter grammars** loaded on demand: TypeScript, JavaScript, TSX,
+JSON, Markdown for v1. Python / Go / Rust shipped on demand.
+
+See [ADR 0015](../decisions/0015-tree-sitter-chunking.md) for tree-sitter
+vs LSP-based extraction.
+
+## Retrieval — 3-tier hybrid
+
+Given a query, *which retrieval method runs?* The router classifies,
+executes, fuses.
+
+```ts
+interface SearchInput {
+  query: string
+  branch?: string                       // defaults to active
+  kind?: "auto" | "symbol" | "text" | "semantic"
+  limit?: number                        // default 5
+}
+
+interface SearchHit {
+  chunkId: number
+  file: string
+  range: { start: number; end: number }
+  symbol?: { name: string; kind: string }
+  content: string
+  score: number
+  source: "symbol" | "bm25" | "vector" | "fused"
+}
+
+function route(input: SearchInput): Tier[] {
+  if (input.kind && input.kind !== "auto") return [tierFor(input.kind)]
+  if (looksLikeSymbol(input.query))   return ["symbol"]            // Tier 1
+  if (looksLikeCode(input.query))     return ["symbol", "bm25"]    // Tier 1+2
+  if (isNaturalLanguage(input.query)) return ["bm25", "vector"]    // Tier 3
+  return ["symbol", "bm25", "vector"]                              // run all
+}
+```
+
+**Heuristics.** `looksLikeSymbol`: matches `^[A-Z][a-zA-Z0-9_]*$` or
+`^[a-z][a-zA-Z0-9_]*$` with no whitespace, ≤ 3 tokens. `looksLikeCode`:
+contains `{}`, `;`, `()`, `=>`, or `import`. `isNaturalLanguage`: > 4
+words and contains a stopword.
+
+### Tier 1 — Symbol lookup
+
+```sql
+SELECT s.*, b.* FROM symbols s
+JOIN blobs b ON b.id = s.blob_id
+JOIN manifests m ON m.blob_id = b.id AND m.branch = ?
+WHERE s.name = ? OR s.name LIKE ?
+ORDER BY (s.exported DESC), length(s.name) ASC
+LIMIT ?
+```
+
+< 1ms. Returns ~50 tokens per hit. Wins for ~60–70% of agent queries.
+
+### Tier 2 — BM25 over chunk content
+
+```sql
+SELECT c.id, bm25(chunks_fts) AS rank, c.*
+FROM chunks_fts JOIN chunks c ON c.id = chunks_fts.rowid
+JOIN manifests m ON m.blob_id = c.blob_id AND m.branch = ?
+WHERE chunks_fts MATCH ?
+ORDER BY rank LIMIT 50
+```
+
+5ms. SQLite FTS5 trigram tokenizer handles code identifiers well.
+
+### Tier 3 — Vector + fused rerank
+
+```ts
+const candidates = await Promise.all([
+  bm25Search(query, branch, 50),
+  vectorSearch(await embed(query), branch, 50),
+])
+const fused = reciprocalRankFusion(candidates, k = 60).slice(0, 20)
+const reranked = await rerank(query, fused.map(c => c.content))
+return reranked.slice(0, limit)
+```
+
+**Reciprocal Rank Fusion** (one-line, hard to beat):
+
+```
+score(chunk) = Σ_methods 1 / (k + rank_method(chunk))
+```
+
+See [ADR 0016](../decisions/0016-hybrid-over-pure-vector.md) for why
+hybrid beats pure vector on code retrieval benchmarks.
+
+## Reranking
+
+Pluggable cross-encoder.
+
+| Backend | Where | Latency | Cost | Quality |
+|---|---|---|---|---|
+| **bge-reranker-v2-m3** (local, ONNX via `transformers.js`) | in-process | 100–300ms / batch of 20 | $0 | strong |
+| **Voyage rerank-2** | API | 80–200ms | ~$0.05 / 1000 q | best on code |
+| **Cohere rerank-3** | API | 100–300ms | ~$0.10 / 1000 q | strong, robust |
+| **none** | — | 0 | $0 | -20% NDCG |
+
+Default for v1: `bge-reranker-v2-m3` local. The reranker is **always on
+for Tier 3**; for Tier 1 and 2-only paths it's skipped. It dominates
+Tier 3 latency budget but lifts top-5 quality 2–3× over cosine similarity
+alone — the single highest-leverage component.
+
+## Embedding model
+
+Pluggable.
+
+| Backend | Dim | Where | Cost | Quality on code |
+|---|---|---|---|---|
+| **voyage-code-3** | 1024 | API | ~$0.06 / 1M tok | SOTA |
+| **jina-code-v2** | 768 | API or local | low / $0 | strong |
+| **nomic-embed-code** | 768 | local (ONNX) | $0 | good |
+| **bge-code-v1** | 1024 | local | $0 | good |
+
+Default for v1: `nomic-embed-code` local. Embedding is async — chunks sit
+in a queue and are embedded opportunistically. **Search works before
+embeddings exist**; uncovered chunks fall back to BM25.
+
+See [ADR 0020](../decisions/0020-pluggable-rerank-and-embed.md) for the
+provider abstraction.
+
+## Credentials & billing
+
+Three concentric tiers. **Only the first two ship in 0.04.**
+
+| Tier | Mode | What user does | Where forkzero is in the path |
+|---|---|---|---|
+| **1. Local** (default) | nomic-embed-code + bge-reranker-v2-m3 via `transformers.js` | Nothing. Works out of the box. | Not in the path. |
+| **2. BYOK** | User pastes their Voyage / Cohere / OpenAI / Jina key | One-time: paste key in Settings → Index | Not in the path. Chunks go user → provider directly. |
+| **3. Forkzero-cloud** (deferred) | Pay forkzero (subscription or metered); we proxy | Sign up, swipe card | In the path — chunks traverse forkzero's proxy. |
+
+**BYOK storage** uses the existing `keytar` pattern from agent integration
+(see [agent-integration.md](../../0.01-MVP/features/agent-integration.md)),
+same shape, new key slots:
+
+```
+forkzero:embed:voyage     → VOYAGE_API_KEY
+forkzero:embed:openai     → OPENAI_API_KEY
+forkzero:embed:jina       → JINA_API_KEY
+forkzero:rerank:cohere    → COHERE_API_KEY
+forkzero:rerank:voyage    → VOYAGE_API_KEY
+```
+
+Never logged. Never written to disk in plaintext. Never sent to forkzero
+servers (because there are none in 0.04).
+
+See [ADR 0021](../decisions/0021-credentials-and-billing.md) for why
+pay-per-usage is deferred.
+
+## MCP integration
+
+Two consumption shapes.
+
+### Shape 1 — In-process (forkzero's bundled agent)
+
+`apps/server` consumes `@forkzero/index` directly. The Claude Code SDK and
+Codex SDK adapters register five custom tools at session start:
+
+```ts
+// apps/server/src/provider/drivers/claude.ts (additions)
+registerTool("code_search",     IndexService.search)
+registerTool("symbol_lookup",   IndexService.symbolLookup)
+registerTool("find_references", IndexService.findReferences)
+registerTool("read_chunk",      IndexService.readChunk)
+registerTool("list_module",     IndexService.listModule)
+```
+
+No MCP overhead. Function call → Effect → SQLite. Lowest latency.
+
+### Shape 2 — External MCP server (`apps/mcp-server`)
+
+A standalone binary that any agent runtime can spawn. Implements the
+Model Context Protocol over stdio (default) and HTTP (optional).
+
+```
+forkzero-mcp --workspace /path/to/repo
+forkzero-mcp --workspace /path/to/repo --http :7421
+```
+
+Distribution:
+
+- npm: `npx @forkzero/mcp-server`
+- Bun standalone binary via `bun build --compile` (single executable per OS)
+- Bundled inside the desktop app for users who want their forkzero-managed
+  index served to outside agents
+
+Tool surface (mirrors Shape 1):
+
+```jsonc
+[
+  { "name": "code_search",
+    "inputSchema": { "query": "string", "kind": "auto|symbol|text|semantic", "branch": "string?", "limit": "number?" } },
+  { "name": "symbol_lookup",
+    "inputSchema": { "name": "string", "kind": "string?" } },
+  { "name": "find_references",
+    "inputSchema": { "symbol": "string", "limit": "number?" } },
+  { "name": "read_chunk",
+    "inputSchema": { "chunkId": "number" } },
+  { "name": "list_module",
+    "inputSchema": { "path": "string" } },
+  { "name": "index_status",
+    "inputSchema": {} }
+]
+```
+
+A typical external-agent setup (terminal Claude Code) drops a line in
+`~/.claude/mcp.json`:
+
+```json
+{ "servers": { "forkzero": { "command": "forkzero-mcp", "args": ["--workspace", "."] } } }
+```
+
+…and gets the same tools as the bundled agent.
+
+See [ADR 0018](../decisions/0018-mcp-server-as-app.md) for why
+`apps/mcp-server` is its own app.
+
+### Why both shapes
+
+- In-process is faster (no MCP serialization, no extra process).
+- External MCP server makes the index reusable — Cursor, Codex, arbitrary
+  agents share the same engine without forking it.
+- One engine, one chunk store, one set of tests. Keeping the engine in a
+  package and the transports in apps prevents drift.
+
+## RPC contracts (renderer ↔ server)
+
+New methods in `packages/wire/src/index.ts`:
+
+```ts
+"index.status"        // {} → { state: "idle" | "indexing" | "ready" | "error", progress?: { processed: number; total: number } }
+"index.search"        // SearchInput → SearchHit[]
+"index.symbolLookup"  // { name, kind? } → SymbolHit[]
+"index.findReferences"// { symbol } → RefHit[]
+"index.readChunk"     // { chunkId } → ChunkContent
+"index.listModule"    // { path } → SymbolSummary[]
+"index.reindex"       // {} → void  (manual trigger)
+```
+
+A command palette entry (`Cmd+P` → "Search code…") wires the renderer to
+`index.search`. The primary consumer is the agent; the renderer surface is
+scaffolding for future UI.
+
+## Verification
+
+1. **Unit tests** (`bun --filter @forkzero/index test`): chunker fixtures,
+   symbol extraction fixtures, manifest swap, RRF correctness, router
+   classification edge cases.
+2. **Integration tests** (`apps/server`): reindex this repo, run a sample
+   of `index.search` calls, assert top-1 hit on known-symbol queries.
+3. **Eval harness** (`tools/index-eval/`): 20 hand-curated tasks (find a
+   specific function; explain a module; locate a bug class; trace a flow
+   through services). Run `bun run eval` which invokes a real agent twice
+   — once with grep-only, once with index tools — and reports a CSV of
+   `tokens, wall_seconds, succeeded`.
+4. **MCP smoke test**: spawn `apps/mcp-server` from a script; connect via
+   the `@modelcontextprotocol/sdk` client; call each tool with a fixture
+   query; assert response shape.
+5. **Manual dogfood**: open forkzero on the forkzero repo itself; ask the
+   bundled agent "where is the PTY service spun up and how does it stream
+   data to the renderer?"; observe it answers in 1–2 tool calls instead
+   of 5+.
+6. **Branch-switch benchmark**: measure manifest swap time across `main`
+   ↔ `swarajbachu/0.04-index-spec` ↔ a hypothetical 1000-file-changed branch.
+
+## Open questions
+
+These are real decisions still to make — flag for discussion before
+Phase B freezes:
+
+1. **Reranker default install size.** bge-reranker-v2-m3 weights are
+   ~120MB. Acceptable bundled, or default-off with an explicit toggle?
+2. **Eval harness — synthetic vs. real tasks.** Curating 20 *real* tasks
+   is best signal but slow. Phase B accept synthetic fixtures first, with
+   the real eval gating Phase C?
+3. **Refs accuracy floor.** Tree-sitter alone gets 70–80% accurate refs;
+   full TS resolution needs `ts-morph` (heavy). Recommendation: ship
+   tree-sitter-only; upgrade later if evals show false negatives matter.
+4. **MCP server distribution.** Ship `@forkzero/mcp-server` as a separate
+   npm package from day 1, or bundle inside the Electron app first?
+   Recommendation: ship the npm package in Phase F.

--- a/specs/0.04-MVP/roadmap.md
+++ b/specs/0.04-MVP/roadmap.md
@@ -1,0 +1,137 @@
+# 0.04 Roadmap
+
+Estimates assume a single developer, ~6 productive hours/day, with a capable
+LLM pair-programmer. Effect-touching work has 30% headroom baked in.
+
+Phases ordered by ROI. Each phase ends with a measurable result. Phases B
+and C have explicit gating experiments — if the numbers don't materialize,
+we reconsider before continuing.
+
+## Phase A — Foundation (~1 week)
+
+Tree-sitter chunker, symbol extractor, SQLite schema, content-addressed
+blob store, manifest model. **No retrieval yet.**
+
+- `packages/index/` scaffold + Effect Service contract
+- ADR 0013 — `@forkzero/index` as standalone package
+- ADR 0014 — content-addressed chunk store + per-branch manifest
+- ADR 0015 — tree-sitter for chunking & symbols
+- TypeScript + JavaScript + TSX grammars only
+- Migrations under `packages/index/src/schema/migrations/`
+- Tests: index forkzero itself; assert chunk count, symbol count, blob
+  dedup across two branches with shared files
+
+**Acceptance:** `bun --filter @forkzero/index test` passes; indexing this
+repo produces > 5,000 chunks and > 2,000 symbols; switching `main` ↔ a
+branch with one changed file results in exactly one new blob row.
+
+## Phase B — Symbol-search MVP + experiment (~3 days)
+
+**Tier 1 only**, no embeddings. Wired into the bundled Claude agent. Run
+the experiment that justifies the rest of the work.
+
+- `IndexService.symbolLookup`, `findReferences`, `readChunk`, `listModule`
+- Register tools in the Claude SDK adapter (`apps/server/src/provider/drivers/claude.ts`)
+- Build a 20-task evaluation harness under `tools/index-eval/`:
+  task descriptions, fixtures, scoring (token usage, wall time, success)
+- Run baseline (grep agent) vs. Tier-1-enabled
+
+**Acceptance:** Tier-1 agent uses ≤ 50% baseline tokens on ≥ 70% of tasks.
+If we miss this bar, **stop and reconsider** before building Tier 3.
+Numbers logged to `specs/0.04-MVP/eval/phase-b.md`.
+
+## Phase C — BM25 + embeddings + RRF (~1 week)
+
+Tier 2 + Tier 3 retrieval. **No rerank yet** — this phase isolates the
+fusion lift from the rerank lift.
+
+- FTS5 virtual table, sqlite-vec extension wired
+- ADR 0019 — sqlite-vec extension (extends ADR 0008)
+- Embedding provider abstraction (default: nomic-embed-code local)
+- ADR 0020 — pluggable rerank and embed
+- Async embedding worker — chunks queue, batches of 64
+- Reciprocal Rank Fusion implementation
+- ADR 0016 — hybrid retrieval over pure vector
+- Re-run the 20-task harness
+
+**Acceptance:** Hybrid agent (no rerank) uses ≤ 35% baseline tokens on
+≥ 80% of tasks. Vector + BM25 alone shows clear lift over Tier 1.
+
+## Phase D — Reranker (~3 days)
+
+Cross-encoder rerank for Tier 3.
+
+- bge-reranker-v2-m3 via transformers.js (default, local)
+- Pluggable Voyage / Cohere backends behind keytar-stored keys
+- Top-5 reranked replaces top-5 fused
+- Re-run the harness
+
+**Acceptance:** NDCG@5 on the eval set up ≥ 20% over Phase C; tokens-per-task
+budget down further (target ≤ 25% baseline).
+
+## Phase E — Watcher + branch model (~4 days)
+
+Incremental updates and fast branch switches.
+
+- File watcher via `@parcel/watcher` (fast, native, no chokidar polling)
+- Branch detection: hook `git checkout` via `apps/server/src/git/`
+- ADR 0017 — branch-aware manifest
+- Manifest swap path proven against Conductor workspaces (5 branches)
+
+**Acceptance:** Branch switch < 200ms on a repo with > 10k files; file edit
+re-indexes only the changed file in < 50ms; running 5 Conductor workspaces
+on the same repo uses one shared blob store (deduped).
+
+## Phase F — `apps/mcp-server` packaging (~1 week)
+
+Standalone MCP binary, npm-distributable, Bun-compiled.
+
+- `apps/mcp-server` scaffold using `@modelcontextprotocol/sdk`
+- ADR 0018 — MCP server as standalone app
+- stdio transport (default), HTTP transport (optional)
+- All five tools registered, JSON Schema validated
+- `bun build --compile` produces `forkzero-mcp` per OS
+- npm publish: `@forkzero/mcp-server`
+- ADR 0021 — credentials and billing (BYOK in 0.04, cloud deferred)
+- Smoke test: terminal Claude Code session pointed at the MCP server can
+  call all five tools end-to-end
+
+**Acceptance:** `npx @forkzero/mcp-server --workspace .` runs; an external
+agent (terminal `claude`) using only `forkzero-mcp` tools (no built-in
+grep) finishes ≥ 80% of the eval harness tasks.
+
+## Phase G — Cloud team index (deferred)
+
+Out of scope for 0.04. Spec'd separately in a future MVP.
+
+- S3-compatible chunk-store sync (the blob store is already content-addressed)
+- Per-team encryption keys
+- Embedding inversion mitigation (research, not yet a decision)
+- Forkzero-cloud as a paid embedding/rerank proxy
+
+## Total
+
+| Milestone | Calendar |
+|---|---|
+| Phase A foundation | end week 1 |
+| Phase B Tier-1 + experiment gate | end week 1 |
+| Phase C hybrid retrieval | end week 2 |
+| Phase D rerank | mid week 3 |
+| Phase E watcher + branches | end week 3 |
+| Phase F MCP server published | end week 4 |
+| 0.04 release | week 4 |
+| Phase G cloud (deferred) | future MVP |
+
+## Beyond 0.04
+
+ADR 0007's transport-agnostic split keeps these costs bounded — each
+becomes a focused PR, not a redesign.
+
+| Milestone | What changes |
+|---|---|
+| Cloud team index | Drop in a sync worker over the existing content-addressed blob store; add `forkzero-cloud` provider for embed/rerank. |
+| Symbol-aware refactors | The `refs` table is already populated — building rename/extract on top is incremental. |
+| Cross-repo search | Index multiple workspaces under one query — needs a workspace-spanning manifest layer. |
+
+See [ADR 0013](decisions/0013-index-as-package.md) for the rules that keep
+these costs bounded.


### PR DESCRIPTION
## Summary
- Drafts the 0.04 code-index spec under `specs/0.04-MVP/`: README, roadmap (phases A-G), feature doc, and 9 ADRs (0013-0021).
- Engine ships as a standalone package `@forkzero/index` consumed by `apps/server` in-process and a new `apps/mcp-server` for external agents over MCP.
- Content-addressed blob store + per-branch manifests target the parallel-Conductor-workspace shape competitors don't handle (<200ms branch switch, dedup across workspaces sharing a repo).
- Hybrid retrieval (symbol lookup → BM25 → vector + RRF fusion + cross-encoder rerank) over pure vector; local-first defaults (nomic-embed-code + bge-reranker-v2-m3) with BYOK opt-in via keytar; pay-per-usage deferred behind a `forkzero-cloud` provider stub.

## Test plan
- [ ] Review README + roadmap for scope and acceptance criteria
- [ ] Review ADRs 0013-0015 (ship-blocking for Phase A)
- [ ] Review ADRs 0016-0021 and flag any decisions to revisit before implementation
- [ ] Confirm the four open questions in `features/code-index.md`