### PR TITLE
fix: image + PDF attachments reach the model

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -750,7 +750,7 @@ function SessionTimer({
 
     for (let i = 0; i < messages.length; i++) {
       const m = messages[i]!;
-      if (m.content._tag === "user") {
+      if (m.content._tag === "user" || m.content._tag === "user_rich") {
         if (turnStart !== null) closeTurn();
         turnStart = m.createdAt.getTime();
         turnLastMs = turnStart;

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -91,7 +91,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     }> = [];
     let current: { user: Message | null; body: Message[] } | null = null;
     for (const m of messages) {
-      if (m.content._tag === "user") {
+      if (m.content._tag === "user" || m.content._tag === "user_rich") {
         if (current !== null) out.push(current);
         current = { user: m, body: [] };
       } else {
@@ -223,7 +223,8 @@ function WorkingRow({ messages }: { messages: ReadonlyArray<Message> }) {
   const anchorMs = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]!;
-      if (m.content._tag === "user") return m.createdAt.getTime();
+      if (m.content._tag === "user" || m.content._tag === "user_rich")
+        return m.createdAt.getTime();
     }
     return null;
   }, [messages]);

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -5,8 +5,15 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { AgentItemId, Message } from "@forkzero/wire";
+import type {
+  AgentItemId,
+  AttachmentRef,
+  FileRef,
+  Message,
+  SkillRef,
+} from "@forkzero/wire";
 
+import { getFileIconUrl } from "~/lib/icons/material-icons";
 import { cn } from "~/lib/utils";
 
 import { ThinkingRow, ToolRow } from "./tool-row.tsx";
@@ -43,6 +50,15 @@ export function MessageRow({
   switch (message.content._tag) {
     case "user":
       return <UserBubble text={message.content.text} />;
+    case "user_rich":
+      return (
+        <UserBubble
+          text={message.content.text}
+          attachments={message.content.attachments}
+          fileRefs={message.content.fileRefs}
+          skillRefs={message.content.skillRefs}
+        />
+      );
     case "assistant":
       return <AssistantBubble text={message.content.text} />;
     case "thinking":
@@ -75,11 +91,107 @@ export function MessageRow({
   }
 }
 
-function UserBubble({ text }: { text: string }) {
+/**
+ * Strip the inline chip tokens (`[image:<id>]`, `@<path>`, `/<skill>`) from
+ * text we render in the user bubble. The chips are surfaced as visual
+ * thumbnails / chips below the bubble, so showing the raw token in-line is
+ * just noise. Tokens for chip kinds the row didn't receive (legacy `user`
+ * content, copy-pasted text) pass through unchanged.
+ */
+const stripChipTokens = (
+  text: string,
+  attachments: ReadonlyArray<AttachmentRef>,
+  fileRefs: ReadonlyArray<FileRef>,
+  skillRefs: ReadonlyArray<SkillRef>,
+): string => {
+  let out = text;
+  for (const a of attachments) {
+    out = out.replaceAll(`[image:${a.id}]`, "");
+  }
+  // Attachments uploaded but submitted while still holding the renderer-side
+  // temp id — we strip them defensively too so the bubble doesn't show
+  // `[image:pending-xxx]`.
+  out = out.replace(/\[image:pending-[a-z0-9]+\]/gi, "");
+  for (const f of fileRefs) {
+    out = out.replaceAll(`@${f.relPath}`, f.relPath);
+  }
+  for (const s of skillRefs) {
+    out = out.replaceAll(`/${s.name}`, `/${s.name}`);
+  }
+  return out.replace(/[ \t]{2,}/g, " ").trim();
+};
+
+function UserBubble({
+  text,
+  attachments,
+  fileRefs,
+  skillRefs,
+}: {
+  text: string;
+  attachments?: ReadonlyArray<AttachmentRef>;
+  fileRefs?: ReadonlyArray<FileRef>;
+  skillRefs?: ReadonlyArray<SkillRef>;
+}) {
+  const hasChips =
+    (attachments !== undefined && attachments.length > 0) ||
+    (fileRefs !== undefined && fileRefs.length > 0) ||
+    (skillRefs !== undefined && skillRefs.length > 0);
+  const display = hasChips
+    ? stripChipTokens(text, attachments ?? [], fileRefs ?? [], skillRefs ?? [])
+    : text;
+  const truncate = (name: string): string =>
+    name.length > 28 ? `${name.slice(0, 25)}...` : name;
   return (
     <div className="flex justify-end px-4 py-2">
-      <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 text-sm text-user-bubble-foreground">
-        {text}
+      <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 text-sm text-user-bubble-foreground">
+        {hasChips ? (
+          <div className="mb-1.5 flex flex-wrap items-center gap-1.5">
+            {(attachments ?? []).map((a) => {
+              const isImage = a.mimeType.startsWith("image/");
+              const iconUrl = isImage ? null : getFileIconUrl(a.originalName);
+              return (
+                <a
+                  key={a.id}
+                  href={`forkzero://attachments/${a.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={a.originalName}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted/60"
+                >
+                  {isImage ? (
+                    <img
+                      src={`forkzero://attachments/${a.id}`}
+                      alt=""
+                      className="size-4 rounded object-cover"
+                    />
+                  ) : iconUrl !== null ? (
+                    <img src={iconUrl} alt="" className="size-4" />
+                  ) : null}
+                  <span className="truncate">{truncate(a.originalName)}</span>
+                </a>
+              );
+            })}
+            {(fileRefs ?? []).map((f) => (
+              <span
+                key={f.relPath}
+                className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground"
+              >
+                @{f.relPath}
+              </span>
+            ))}
+            {(skillRefs ?? []).map((s) => (
+              <span
+                key={s.name}
+                className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground"
+              >
+                /{s.name}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {display.length > 0 ? (
+          <div className="whitespace-pre-wrap break-words">{display}</div>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/renderer/src/composer/segment-parser.ts
+++ b/apps/renderer/src/composer/segment-parser.ts
@@ -12,16 +12,18 @@ import { allChips } from "../lib/codemirror/composer-chips.ts";
 
 /**
  * Walk the editor state and assemble a wire-shaped `ComposerInput`. The
- * returned `text` is the document as-is — chips are kept inline as their
- * canonical tokens (`@<relPath>`, `/<skill>`, `[image:<id>]`) so providers
- * that don't read the typed arrays still see something sensible. Drivers
- * that *do* read the arrays expand them server-side.
+ * returned `text` keeps `@<relPath>` / `/<skill>` chip tokens inline (drivers
+ * read them as plain text) but strips `[image:<id>]` markers — image
+ * attachments cross the wire as real Anthropic image content blocks built
+ * from the `attachments` array, so the inline marker would be redundant
+ * noise in the user's prompt to the model.
  */
 export const parseComposerInput = (
   state: EditorState,
   providerId: ProviderId,
 ): ComposerInput => {
-  const text = state.doc.toString();
+  const rawText = state.doc.toString();
+  const text = rawText.replace(/\[image:[^\]]+\]/g, "").replace(/[ \t]{2,}/g, " ").trim();
   const chips = allChips(state);
 
   const fileRefs: FileRef[] = [];

--- a/apps/server/src/attachment/layers/attachment-service.ts
+++ b/apps/server/src/attachment/layers/attachment-service.ts
@@ -113,6 +113,26 @@ export const AttachmentServiceLive = Layer.scoped(
         };
       });
 
+    const read: AttachmentServiceShape["read"] = (id) =>
+      Effect.gen(function* () {
+        interface Row {
+          readonly mime_type: string;
+          readonly original_name: string;
+        }
+        const rows = yield* sql<Row>`
+          SELECT mime_type, original_name FROM attachments WHERE id = ${id}
+        `.pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<Row>));
+        const row = rows[0];
+        if (row === undefined) return null;
+        const ext = extForUpload(row.mime_type, row.original_name);
+        const absPath = pathSvc.join(dir, blobFilename(id, ext));
+        const bytes = yield* fs
+          .readFile(absPath)
+          .pipe(Effect.orElseSucceed(() => null));
+        if (bytes === null) return null;
+        return { bytes, mimeType: row.mime_type };
+      });
+
     const touch: AttachmentServiceShape["touch"] = (ids) =>
       Ref.update(lastTouched, (m) => {
         const next = new Map(m);
@@ -180,6 +200,6 @@ export const AttachmentServiceLive = Layer.scoped(
     );
     yield* Effect.addFinalizer(() => Fiber.interrupt(gcFiber));
 
-    return { upload, touch } satisfies AttachmentServiceShape;
+    return { upload, touch, read } satisfies AttachmentServiceShape;
   }),
 );

--- a/apps/server/src/attachment/services/attachment-service.ts
+++ b/apps/server/src/attachment/services/attachment-service.ts
@@ -28,6 +28,11 @@ export interface AttachmentServiceShape {
     UploadFailure
   >;
   readonly touch: (ids: ReadonlyArray<string>) => Effect.Effect<void>;
+  readonly read: (
+    id: string,
+  ) => Effect.Effect<
+    { readonly bytes: Uint8Array; readonly mimeType: string } | null
+  >;
 }
 
 export class AttachmentService extends Context.Tag("forkzero/AttachmentService")<

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -12,11 +12,14 @@ import {
   type AgentEvent,
   type AgentItemId,
   type AgentSessionId,
+  type AttachmentRef,
   type PermissionDecision,
   type PermissionKind,
   type RuntimeMode,
   type StartSessionInput,
 } from "@forkzero/wire";
+
+import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 
 /**
  * Live-only handle for one Claude SDK conversation. The orchestrator
@@ -25,10 +28,51 @@ import {
  */
 export interface ClaudeSessionHandle {
   readonly events: Stream.Stream<AgentEvent>;
-  readonly send: (text: string) => Effect.Effect<void>;
+  readonly send: (
+    text: string,
+    attachments?: ReadonlyArray<AttachmentRef>,
+  ) => Effect.Effect<void>;
   readonly interrupt: () => Effect.Effect<void>;
   readonly close: () => Effect.Effect<void>;
 }
+
+/**
+ * Anthropic accepts these media types as image content blocks. Anything else
+ * (HEIC, BMP, raw bytes) gets dropped with a console warning rather than
+ * forwarded as an unsupported block — the SDK would reject the whole turn.
+ */
+const SUPPORTED_IMAGE_MIME = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+type AnthropicImageMediaType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif"
+  | "image/webp";
+
+type UserContentBlock =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source: {
+        type: "base64";
+        media_type: AnthropicImageMediaType;
+        data: string;
+      };
+    }
+  | {
+      type: "document";
+      source: {
+        type: "base64";
+        media_type: "application/pdf";
+        data: string;
+      };
+      title?: string;
+    };
 
 /**
  * Tiny promise-backed async input channel. The Claude SDK's streaming-input
@@ -81,11 +125,15 @@ class UserInputChannel implements AsyncIterable<SDKUserMessage> {
   }
 }
 
-const userMessageOf = (text: string, sessionId: string): SDKUserMessage => ({
+const userMessageOf = (
+  text: string,
+  sessionId: string,
+  attachmentBlocks: ReadonlyArray<UserContentBlock> = [],
+): SDKUserMessage => ({
   type: "user",
   message: {
     role: "user",
-    content: [{ type: "text", text }],
+    content: [...attachmentBlocks, { type: "text", text }],
   },
   parent_tool_use_id: null,
   session_id: sessionId,
@@ -620,11 +668,74 @@ export const startClaudeSession = (
   requestPermission: RequestPermission,
   getRuntimeMode: GetRuntimeMode,
   resumeCursor: string | null = null,
-): Effect.Effect<ClaudeSessionHandle, AgentSessionStartError> =>
+): Effect.Effect<ClaudeSessionHandle, AgentSessionStartError, AttachmentService> =>
   Effect.gen(function* () {
+    const attachments = yield* AttachmentService;
     const events = yield* Mailbox.make<AgentEvent>();
     const inputChannel = new UserInputChannel();
     const abort = new AbortController();
+
+    const buildAttachmentBlocks = (
+      refs: ReadonlyArray<AttachmentRef>,
+    ): Promise<ReadonlyArray<UserContentBlock>> =>
+      Promise.all(
+        refs.map(async (ref): Promise<UserContentBlock | null> => {
+          if (ref.id.startsWith("pending-")) {
+            console.warn(
+              `[claude.attach] skipping pending attachment id=${ref.id} (upload didn't finish before send)`,
+            );
+            return null;
+          }
+          // Browsers report "image/jpg" sometimes — Anthropic only accepts
+          // the canonical "image/jpeg" name.
+          const normalizedMime =
+            ref.mimeType.toLowerCase() === "image/jpg"
+              ? "image/jpeg"
+              : ref.mimeType.toLowerCase();
+          const isImage = SUPPORTED_IMAGE_MIME.has(normalizedMime);
+          const isPdf = normalizedMime === "application/pdf";
+          if (!isImage && !isPdf) {
+            console.warn(
+              `[claude.attach] dropping unsupported mime id=${ref.id} mime=${ref.mimeType}`,
+            );
+            return null;
+          }
+          const blob = await Effect.runPromise(attachments.read(ref.id));
+          if (blob === null) {
+            console.warn(
+              `[claude.attach] blob not found id=${ref.id} (db row missing or file deleted)`,
+            );
+            return null;
+          }
+          const base64 = Buffer.from(blob.bytes).toString("base64");
+          console.log(
+            `[claude.attach] built ${
+              isPdf ? "document" : "image"
+            } block id=${ref.id} mime=${normalizedMime} bytes=${blob.bytes.byteLength} base64Len=${base64.length}`,
+          );
+          if (isPdf) {
+            return {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: base64,
+              },
+              title: ref.originalName,
+            };
+          }
+          return {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: normalizedMime as AnthropicImageMediaType,
+              data: base64,
+            },
+          };
+        }),
+      ).then((blocks) =>
+        blocks.filter((b): b is NonNullable<typeof b> => b !== null),
+      );
 
     if (input.initialPrompt !== undefined && input.initialPrompt.length > 0) {
       inputChannel.push(userMessageOf(input.initialPrompt, sessionId));
@@ -780,9 +891,28 @@ export const startClaudeSession = (
 
     const handle: ClaudeSessionHandle = {
       events: Mailbox.toStream(events),
-      send: (text) =>
-        Effect.sync(() => {
-          inputChannel.push(userMessageOf(text, sessionId));
+      send: (text, attachmentRefs) =>
+        Effect.promise(async () => {
+          console.log(
+            `[claude.send] sessionId=${sessionId} textLen=${text.length} attachments=${attachmentRefs?.length ?? 0}`,
+          );
+          const attachmentBlocks =
+            attachmentRefs !== undefined && attachmentRefs.length > 0
+              ? await buildAttachmentBlocks(attachmentRefs)
+              : [];
+          console.log(
+            `[claude.send] pushing user message: attachmentBlocks=${attachmentBlocks.length} content=${JSON.stringify(
+              [
+                ...attachmentBlocks.map((b) =>
+                  b.type === "text"
+                    ? { type: "text", textLen: b.text.length }
+                    : { type: b.type, media_type: b.source.media_type, base64Len: b.source.data.length },
+                ),
+                { type: "text", textLen: text.length },
+              ],
+            )}`,
+          );
+          inputChannel.push(userMessageOf(text, sessionId, attachmentBlocks));
         }),
       interrupt: () =>
         Effect.tryPromise({

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -11,6 +11,7 @@ import {
   type AgentEvent,
   type AgentItemId,
   type AgentSessionId,
+  type AttachmentRef,
   type StartSessionInput,
 } from "@forkzero/wire";
 
@@ -25,7 +26,10 @@ import {
  */
 export interface CodexSessionHandle {
   readonly events: Stream.Stream<AgentEvent>;
-  readonly send: (text: string) => Effect.Effect<void>;
+  readonly send: (
+    text: string,
+    attachments?: ReadonlyArray<AttachmentRef>,
+  ) => Effect.Effect<void>;
   readonly interrupt: () => Effect.Effect<void>;
   readonly close: () => Effect.Effect<void>;
 }
@@ -276,8 +280,13 @@ export const startCodexSession = (
 
     const handle: CodexSessionHandle = {
       events: Mailbox.toStream(events),
-      send: (text) =>
+      send: (text, attachmentRefs) =>
         Effect.sync(() => {
+          if (attachmentRefs !== undefined && attachmentRefs.length > 0) {
+            console.warn(
+              `[codex] dropping ${attachmentRefs.length} attachment(s); image input not yet supported on Codex driver`,
+            );
+          }
           enqueueTurn(text);
         }),
       interrupt: () =>

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -150,10 +150,29 @@ const SessionStreamStatus = ForkzeroRpcs.toLayerHandler(
 
 const MessagesSend = ForkzeroRpcs.toLayerHandler(
   "messages.send",
-  ({ sessionId, text, input }) =>
-    Effect.flatMap(MessageStore, (svc) =>
-      svc.sendMessage(sessionId, input?.text ?? text ?? ""),
-    ),
+  ({ sessionId, text, input }) => {
+    console.log(
+      `[rpc.messages.send] sessionId=${sessionId} hasInput=${input !== undefined} attachments=${
+        input?.attachments?.length ?? 0
+      } fileRefs=${input?.fileRefs?.length ?? 0} skillRefs=${
+        input?.skillRefs?.length ?? 0
+      } textLen=${(input?.text ?? text ?? "").length}`,
+    );
+    if (input?.attachments !== undefined && input.attachments.length > 0) {
+      console.log(
+        `[rpc.messages.send] attachments: ${JSON.stringify(input.attachments)}`,
+      );
+    }
+    return Effect.flatMap(MessageStore, (svc) =>
+      svc.sendMessage(
+        sessionId,
+        input?.text ?? text ?? "",
+        input?.attachments,
+        input?.fileRefs,
+        input?.skillRefs,
+      ),
+    );
+  },
 );
 
 const MessagesInterrupt = ForkzeroRpcs.toLayerHandler(

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -13,6 +13,8 @@ import {
   Message,
   MessageId,
   type AgentEvent,
+  type AttachmentRef,
+  type FileRef,
   type FolderId,
   type MessageContent,
   type MessageRole,
@@ -22,6 +24,7 @@ import {
   SessionId,
   SessionNotFoundError,
   SessionStartError,
+  type SkillRef,
 } from "@forkzero/wire";
 
 import { NdjsonLogger } from "../../persistence/ndjson-logger.ts";
@@ -673,10 +676,17 @@ export const MessageStoreLive = Layer.scoped(
      * Restart the provider for `session` under the same persisted id so the
      * message history stays attached to the same row. Used after a process
      * restart wipes the provider's in-memory session map.
+     *
+     * The user's text + attachments are pushed via `provider.send` after the
+     * session opens, NOT via `StartSessionInput.initialPrompt`. The
+     * initialPrompt path only knows about plain text — routing through
+     * `send` reuses the image-block builder so attachments survive the
+     * restart instead of dropping silently.
      */
     const restartProviderSession = (
       session: Session,
-      initialPrompt: string,
+      text: string,
+      attachments: ReadonlyArray<AttachmentRef>,
     ): Effect.Effect<void, SessionNotFoundError> => {
       runtimeModeBySession.set(session.id, session.runtimeMode);
       return provider
@@ -686,7 +696,6 @@ export const MessageStoreLive = Layer.scoped(
             providerId: session.providerId,
             mode: "sdk",
             sessionId: session.id,
-            initialPrompt,
             model: session.model,
           },
           // Re-attach to the upstream conversation when we have a cursor.
@@ -697,6 +706,7 @@ export const MessageStoreLive = Layer.scoped(
         )
         .pipe(
           Effect.flatMap(() => startSubscription(session.id)),
+          Effect.flatMap(() => provider.send(session.id, text, attachments)),
           Effect.mapError(() => new SessionNotFoundError({ sessionId: session.id })),
         );
     };
@@ -747,13 +757,45 @@ export const MessageStoreLive = Layer.scoped(
         return yield* lookupSession(sessionId);
       });
 
-    const sendMessage: MessageStoreShape["sendMessage"] = (sessionId, text) =>
+    const sendMessage: MessageStoreShape["sendMessage"] = (
+      sessionId,
+      text,
+      attachments,
+      fileRefs,
+      skillRefs,
+    ) =>
       Effect.gen(function* () {
         const session = yield* lookupSession(sessionId);
-        const persisted = yield* persistMessage(sessionId, {
-          _tag: "user",
-          text,
-        });
+        // Drop "pending-*" placeholder ids — those are renderer-side temp
+        // tokens for attachments whose upload didn't finish before submit.
+        // The bytes don't exist server-side, so forwarding them would just
+        // make the driver log a 404 per attachment.
+        const cleanAttachments = (attachments ?? []).filter(
+          (a) => !a.id.startsWith("pending-"),
+        );
+        const hasRichSegments =
+          cleanAttachments.length > 0 ||
+          (fileRefs ?? []).length > 0 ||
+          (skillRefs ?? []).length > 0;
+        const content: MessageContent = hasRichSegments
+          ? {
+              _tag: "user_rich",
+              text,
+              attachments: cleanAttachments,
+              fileRefs: fileRefs ?? [],
+              skillRefs: skillRefs ?? [],
+            }
+          : { _tag: "user", text };
+        const persisted = yield* persistMessage(sessionId, content);
+        // Pin the attachments so the GC sweep treats them as referenced —
+        // a separate row per (message, attachment) keeps the existing
+        // GC join intact.
+        for (const a of cleanAttachments) {
+          yield* sql`
+            INSERT OR IGNORE INTO message_attachments (message_id, attachment_id)
+            VALUES (${persisted.id}, ${a.id})
+          `.pipe(Effect.ignoreLogged);
+        }
         yield* broadcastMessage(sessionId, persisted);
         // Auto-title: if the session is still on its placeholder title, derive
         // one from the user's first real message. Cheaper and more accurate
@@ -770,14 +812,24 @@ export const MessageStoreLive = Layer.scoped(
         // First attempt: push into the existing provider session. If that
         // session is gone (provider dropped it across an app restart) start
         // a fresh one under the same id, then push.
-        const sendResult = yield* provider.send(sessionId, text).pipe(
-          Effect.matchEffect({
-            onFailure: () => Effect.succeed("retry" as const),
-            onSuccess: () => Effect.succeed("ok" as const),
-          }),
+        console.log(
+          `[message-store.sendMessage] sessionId=${sessionId} cleanAttachments=${cleanAttachments.length} (orig=${
+            (attachments ?? []).length
+          })`,
         );
+        const sendResult = yield* provider
+          .send(sessionId, text, cleanAttachments)
+          .pipe(
+            Effect.matchEffect({
+              onFailure: () => Effect.succeed("retry" as const),
+              onSuccess: () => Effect.succeed("ok" as const),
+            }),
+          );
         if (sendResult === "retry") {
-          yield* restartProviderSession(session, text);
+          console.log(
+            `[message-store.sendMessage] provider.send failed; restarting provider session for ${sessionId}`,
+          );
+          yield* restartProviderSession(session, text, cleanAttachments);
         }
         yield* setStatus(sessionId, "running");
       });

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -23,6 +23,7 @@ import {
   startCodexSession,
   type CodexSessionHandle,
 } from "../drivers/codex.ts";
+import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
 import { PermissionService } from "../services/permission-service.ts";
 import { ProviderService } from "../services/provider-service.ts";
@@ -55,6 +56,7 @@ export const ProviderServiceLive = Layer.effect(
     const credentials = yield* CredentialsService;
     const workspace = yield* WorkspaceService;
     const permissions = yield* PermissionService;
+    const attachmentService = yield* AttachmentService;
     const runtime = yield* Effect.runtime<never>();
     const sessions = yield* Ref.make<Map<AgentSessionId, SessionEntry>>(
       new Map(),
@@ -147,7 +149,7 @@ export const ProviderServiceLive = Layer.effect(
               buildRequestPermission(input.folderId),
               runtimeModeGetter,
               resumeCursor,
-            );
+            ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else {
             // Codex SDK currently has no public resume API matching our
             // cursor-based model; reject early with a stable reason the
@@ -174,8 +176,10 @@ export const ProviderServiceLive = Layer.effect(
           });
           return { sessionId };
         }),
-      send: (sessionId, text) =>
-        Effect.flatMap(lookup(sessionId), ({ handle }) => handle.send(text)),
+      send: (sessionId, text, attachments) =>
+        Effect.flatMap(lookup(sessionId), ({ handle }) =>
+          handle.send(text, attachments),
+        ),
       interrupt: (sessionId) =>
         Effect.flatMap(lookup(sessionId), ({ handle }) => handle.interrupt()),
       close: (sessionId) =>

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -1,6 +1,8 @@
 import { Context, type Effect, type Stream } from "effect";
 
 import type {
+  AttachmentRef,
+  FileRef,
   FolderId,
   Message,
   ProviderId,
@@ -10,6 +12,7 @@ import type {
   SessionNotFoundError,
   SessionStartError,
   SessionStatus,
+  SkillRef,
 } from "@forkzero/wire";
 
 /**
@@ -109,6 +112,9 @@ export interface MessageStoreShape {
   readonly sendMessage: (
     sessionId: SessionId,
     text: string,
+    attachments?: ReadonlyArray<AttachmentRef>,
+    fileRefs?: ReadonlyArray<FileRef>,
+    skillRefs?: ReadonlyArray<SkillRef>,
   ) => Effect.Effect<void, SessionNotFoundError>;
 
   readonly interruptSession: (

--- a/apps/server/src/provider/services/provider-service.ts
+++ b/apps/server/src/provider/services/provider-service.ts
@@ -7,6 +7,7 @@ import type {
   AgentSessionNotFoundError,
   AgentSessionStartError,
   AgentTurnId,
+  AttachmentRef,
   ProviderId,
   ProviderNotAvailableError,
   RuntimeMode,
@@ -43,6 +44,7 @@ export interface ProviderServiceShape {
   readonly send: (
     sessionId: AgentSessionId,
     text: string,
+    attachments?: ReadonlyArray<AttachmentRef>,
   ) => Effect.Effect<void, AgentSessionNotFoundError>;
 
   readonly interrupt: (

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -107,6 +107,17 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(MigratedSqlite),
   );
 
+  // AttachmentService writes uploaded image bytes under userData and runs
+  // the GC sweep that reaps orphaned blobs. Disk I/O comes from
+  // NodeContext; persistence joins MigratedSqlite. Defined before
+  // ProviderLayer because the Claude driver reads attachment bytes when
+  // building image content blocks for outbound user messages.
+  const AttachmentLayer = AttachmentServiceLive.pipe(
+    Layer.provide(MigratedSqlite),
+    Layer.provide(AppPathsLayer),
+    Layer.provide(NodeContext.layer),
+  );
+
   // ProviderService probes installed CLIs via CommandExecutor, consults
   // CredentialsService for SDK keys, resolves folderId → cwd via
   // WorkspaceService, and forwards the SDK's tool-permission callback to
@@ -115,6 +126,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(CredentialsServiceLive),
     Layer.provide(WorkspaceLayer),
     Layer.provide(PermissionLayer),
+    Layer.provide(AttachmentLayer),
     Layer.provide(NodeContext.layer),
   );
 
@@ -133,15 +145,6 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(ProviderLayer),
     Layer.provide(MigratedSqlite),
     Layer.provide(NdjsonLoggerLayer),
-  );
-
-  // AttachmentService writes uploaded image bytes under userData and runs
-  // the GC sweep that reaps orphaned blobs. Disk I/O comes from
-  // NodeContext; persistence joins MigratedSqlite.
-  const AttachmentLayer = AttachmentServiceLive.pipe(
-    Layer.provide(MigratedSqlite),
-    Layer.provide(AppPathsLayer),
-    Layer.provide(NodeContext.layer),
   );
 
   // SkillBridge surfaces the user's per-provider skill library to the

--- a/packages/wire/src/attachment.ts
+++ b/packages/wire/src/attachment.ts
@@ -28,7 +28,7 @@ export class AttachmentBadMimeError extends Schema.TaggedError<AttachmentBadMime
 export const AttachmentUploadRpc = Rpc.make("attachments.upload", {
   payload: Schema.Struct({
     sessionId: SessionId,
-    bytes: Schema.Uint8ArrayFromSelf,
+    bytes: Schema.Uint8ArrayFromBase64,
     mimeType: Schema.String,
     originalName: Schema.String,
   }),


### PR DESCRIPTION
## Summary

End-to-end fix so chat attachments actually reach Claude. The renderer was uploading bytes and rendering chips, but `messages.send` dropped the attachments array, the `restartProviderSession` retry path went through `initialPrompt` (text-only), and the upload RPC schema used `Uint8ArrayFromSelf` over JSON serialization — so `JSON.stringify(uint8array)` produced `{"0":137,...}` and the server rejected the upload before bytes ever landed on disk.

## Changes

- **Wire**: `attachments.upload` now uses `Schema.Uint8ArrayFromBase64` so bytes survive JSON serialization on the bridge.
- **Driver**: Claude driver reads each attachment via `AttachmentService.read(id)` and prepends an Anthropic `image` (png/jpeg/gif/webp, with `image/jpg` → `image/jpeg` normalization) or `document` (application/pdf) content block onto the user message.
- **Restart path**: `restartProviderSession` now opens the SDK with no `initialPrompt` and routes the turn through `provider.send(text, attachments)` so the image-block builder runs after a process restart.
- **Persistence**: `MessageStore.sendMessage` accepts attachments/fileRefs/skillRefs, persists `user_rich`, and inserts `message_attachments` rows so the GC sweep keeps referenced blobs alive.
- **UI**: User bubble renders `user_rich` with material-icon chips (PDF, doc, etc.) for non-image attachments and inline thumbnails for images; chip tokens stripped from the displayed text body. `SessionTimer` and turn-grouping in `chat-view` now recognise `user_rich` as a turn boundary (was stuck at 0.0s for any turn with attachments).
- **Codex**: accepts the new `attachments` param but logs a warning and drops it — the Codex SDK doesn't expose image input yet.

## Test plan

- [ ] Drop a PNG into the composer, send "what's in this image?" — model describes the image
- [ ] Drop a PDF, send "summarize this" — model summarizes the PDF
- [ ] Restart the dev app mid-session, send a new image — image still reaches the model (covers the restart-fork path)
- [ ] Verify the user-message bubble shows compact chips with material icons, not raw `[image:<id>]` text or emoji
- [ ] Verify `SessionTimer` ticks past 0.0s on a turn that started with an attachment