### PR TITLE
ui: rich rate-limit error bubble with reset time

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -14,7 +14,7 @@ import { groupMessages } from "../lib/group-messages.ts";
 import { useMessagesStore } from "../store/messages.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSkillsStore } from "../store/skills.ts";
-import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import { ErrorBubble, MessageRow, type ToolResultRecord } from "./message-row.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { TurnSummary } from "./turn-summary.tsx";
 import { GradientDescent } from "./ui/gradient-descent.tsx";
@@ -40,6 +40,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     (s) => s.runningBySession[sessionId] === true,
   );
   const error = useMessagesStore((s) => s.errorBySession[sessionId] ?? null);
+  const clearError = useMessagesStore((s) => s.clearError);
   const hydrate = useMessagesStore((s) => s.hydrate);
   const hydrateSkills = useSkillsStore((s) => s.hydrate);
 
@@ -207,9 +208,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
         </div>
       )}
       {error !== null && (
-        <div className="mx-4 my-2 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200">
-          {error}
-        </div>
+        <ErrorBubble text={error} onDismiss={() => clearError(sessionId)} />
       )}
     </div>
   );

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -251,11 +251,114 @@ function ToolErrorRow({ output }: { output: unknown }) {
   );
 }
 
-function ErrorBubble({ text }: { text: string }) {
+type RateLimitInfo = {
+  readonly resetText?: string;
+  readonly period?: "weekly" | "monthly" | "daily";
+};
+
+// Parse rate-limit / usage-limit messages emitted by Claude Code, the
+// Anthropic SDK, or other providers. We see them as plain strings (the
+// wire ErrorEvent carries no structured metadata) so this is best-effort
+// pattern matching against the human-readable text.
+const parseRateLimit = (text: string): RateLimitInfo | null => {
+  const isRateLimit =
+    /usage limit|rate[-\s]?limit|quota|429|too many requests|overloaded|hit your limit/i.test(
+      text,
+    );
+  if (!isRateLimit) return null;
+
+  const resetMatch =
+    text.match(
+      /reset(?:s|ing)?(?:\s+at)?\s+(\d{1,2}(?::\d{2})?\s*[ap]m(?:\s*\([^)]+\))?)/i,
+    ) ??
+    text.match(
+      /try again at\s+(\d{1,2}(?::\d{2})?\s*[ap]m(?:\s*\([^)]+\))?)/i,
+    ) ??
+    text.match(/reset(?:s|ing)?(?:\s+at)?\s+(\d{4}-\d{2}-\d{2}[T0-9:.Z+\-]*)/i);
+
+  const lower = text.toLowerCase();
+  const period: RateLimitInfo["period"] = lower.includes("monthly")
+    ? "monthly"
+    : lower.includes("weekly")
+      ? "weekly"
+      : lower.includes("daily")
+        ? "daily"
+        : undefined;
+
+  return { resetText: resetMatch?.[1], period };
+};
+
+const formatResetDetail = (info: RateLimitInfo): string => {
+  if (info.resetText !== undefined) return `Resets ${info.resetText}`;
+  if (info.period !== undefined) {
+    const label = info.period.charAt(0).toUpperCase() + info.period.slice(1);
+    return `${label} limit`;
+  }
+  return "Try again later";
+};
+
+export function ErrorBubble({
+  text,
+  onDismiss,
+}: {
+  text: string;
+  onDismiss?: () => void;
+}) {
+  const rateLimit = parseRateLimit(text);
+  if (rateLimit !== null) {
+    return (
+      <div className="px-4 py-2">
+        <div className="max-w-[88%] rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          <div className="flex items-center gap-2">
+            <HugeiconsIcon
+              icon={AlertCircleIcon}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="size-3.5 shrink-0 text-amber-300"
+            />
+            <span className="font-medium text-amber-100">
+              Rate limit reached
+            </span>
+            <span className="text-amber-200/50">·</span>
+            <span className="text-amber-200/90">
+              {formatResetDetail(rateLimit)}
+            </span>
+            {onDismiss !== undefined && (
+              <button
+                type="button"
+                onClick={onDismiss}
+                className="ml-auto rounded px-1.5 py-0.5 text-amber-200/70 hover:bg-amber-500/15 hover:text-amber-100"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+          <div className="mt-1 break-words text-amber-200/70">{text}</div>
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="px-4 py-2">
       <div className="max-w-[88%] rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200">
-        {text}
+        <div className="flex items-start gap-2">
+          <HugeiconsIcon
+            icon={AlertCircleIcon}
+            strokeWidth={2}
+            aria-hidden="true"
+            className="mt-px size-3.5 shrink-0 text-red-400"
+          />
+          <span className="break-words">{text}</span>
+          {onDismiss !== undefined && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="ml-auto rounded px-1.5 py-0.5 text-red-200/70 hover:bg-red-500/15 hover:text-red-100"
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Detect rate-limit / usage-limit error messages (Claude Code, Anthropic SDK, generic 429/overloaded) and render a polished amber bubble with **Rate limit reached · Resets <time>** instead of the bare upstream string.
- Falls back to **Monthly limit** / **Try again later** when the message lacks a parseable reset time. Non-rate-limit errors keep red but gain the alert icon.
- Both variants accept an optional Dismiss button; chat-view's session-level error now reuses ErrorBubble so RPC failures get the same treatment.

## Test plan
- [ ] Trigger a Claude usage-limit error (or mock a message containing "usage limit"/"resets at 5pm") and confirm the amber bubble + parsed reset time render.
- [ ] Trigger a non-rate-limit error and confirm the red bubble still renders with the alert icon.
- [ ] Confirm the Dismiss button on the session-level error clears it via clearError(sessionId).