### PR TITLE
fix: worktree path layout + scoped @-mentions + chip-rendered fileRefs

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -545,6 +545,7 @@ export function ChatComposer({ session }: { session: Session }) {
                       trigger={trigger}
                       view={editorViewRef.current}
                       projectId={session.projectId}
+                      worktreeId={session.worktreeId}
                       onClose={() => setTrigger(null)}
                     />
                   )

--- a/apps/renderer/src/components/composer/file-tag-popover.tsx
+++ b/apps/renderer/src/components/composer/file-tag-popover.tsx
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import { Folder } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
-import type { FolderId } from "@forkzero/wire";
+import type { FolderId, WorktreeId } from "@forkzero/wire";
 
 import {
   getFileIconUrl,
@@ -20,6 +20,7 @@ export interface FileTagPopoverProps {
   readonly trigger: ActiveTrigger;
   readonly view: EditorView;
   readonly projectId: FolderId;
+  readonly worktreeId: WorktreeId | null;
   readonly onClose: () => void;
 }
 
@@ -38,6 +39,7 @@ export function FileTagPopover({
   trigger,
   view,
   projectId,
+  worktreeId,
   onClose,
 }: FileTagPopoverProps) {
   const [hits, setHits] = useState<readonly SearchHit[]>([]);
@@ -55,6 +57,7 @@ export function FileTagPopover({
             projectId,
             query,
             limit: 20,
+            worktreeId,
           }),
         );
         if (!cancelled) {
@@ -70,7 +73,7 @@ export function FileTagPopover({
       cancelled = true;
       window.clearTimeout(id);
     };
-  }, [projectId, query]);
+  }, [projectId, worktreeId, query]);
 
   const confirm = (hit: SearchHit) => {
     const token = `@${hit.relPath}`;

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -14,7 +14,10 @@ import type {
   SkillRef,
 } from "@forkzero/wire";
 
-import { getFileIconUrl } from "~/lib/icons/material-icons";
+import {
+  getFileIconUrl,
+  getFolderIconUrl,
+} from "~/lib/icons/material-icons";
 import { cn } from "~/lib/utils";
 
 import { ExitPlanModeRow, ThinkingRow, ToolRow } from "./tool-row.tsx";
@@ -23,6 +26,11 @@ export interface ToolResultRecord {
   readonly output: unknown;
   readonly isError: boolean;
 }
+
+const basename = (p: string): string => {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+};
 
 const stringifyJson = (value: unknown): string => {
   try {
@@ -134,7 +142,7 @@ const stripChipTokens = (
   // `[image:pending-xxx]`.
   out = out.replace(/\[image:pending-[a-z0-9]+\]/gi, "");
   for (const f of fileRefs) {
-    out = out.replaceAll(`@${f.relPath}`, f.relPath);
+    out = out.replaceAll(`@${f.relPath}`, "");
   }
   for (const s of skillRefs) {
     out = out.replaceAll(`/${s.name}`, `/${s.name}`);
@@ -192,14 +200,25 @@ function UserBubble({
                 </a>
               );
             })}
-            {(fileRefs ?? []).map((f) => (
-              <span
-                key={f.relPath}
-                className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground"
-              >
-                @{f.relPath}
-              </span>
-            ))}
+            {(fileRefs ?? []).map((f) => {
+              const name = basename(f.relPath);
+              const iconUrl =
+                f.kind === "directory"
+                  ? getFolderIconUrl(name, false)
+                  : getFileIconUrl(name);
+              return (
+                <span
+                  key={f.relPath}
+                  title={f.relPath}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground"
+                >
+                  {iconUrl !== null ? (
+                    <img src={iconUrl} alt="" className="size-4" />
+                  ) : null}
+                  <span className="truncate">{truncate(name)}</span>
+                </span>
+              );
+            })}
             {(skillRefs ?? []).map((s) => (
               <span
                 key={s.name}

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -112,9 +112,12 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
   );
 
   // FileSearchService backs the composer's `@` file picker. Same deps as
-  // FsLayer — recursive walk skipping common heavy directories.
+  // FsLayer — recursive walk skipping common heavy directories. WorktreeLayer
+  // lets the search reroot at a worktree's path when the renderer passes
+  // `worktreeId`, so a session on a worktree only sees its own files.
   const FileSearchLayer = FileSearchServiceLive.pipe(
     Layer.provide(WorkspaceLayer),
+    Layer.provide(WorktreeLayer),
     Layer.provide(NodeContext.layer),
   );
 

--- a/apps/server/src/workspace/handlers.ts
+++ b/apps/server/src/workspace/handlers.ts
@@ -38,9 +38,9 @@ const SetSelected = ForkzeroRpcs.toLayerHandler(
 
 const SearchFiles = ForkzeroRpcs.toLayerHandler(
   "workspace.searchFiles",
-  ({ projectId, query, limit }) =>
+  ({ projectId, query, limit, worktreeId }) =>
     Effect.flatMap(FileSearchService, (svc) =>
-      svc.search(projectId, query, limit),
+      svc.search(projectId, query, limit, worktreeId ?? null),
     ),
 );
 

--- a/apps/server/src/workspace/layers/file-search.ts
+++ b/apps/server/src/workspace/layers/file-search.ts
@@ -6,6 +6,7 @@ import fuzzysort from "fuzzysort";
 
 import { FsFolderNotFoundError } from "@forkzero/wire";
 
+import { WorktreeService } from "../../worktree/services/worktree-service.ts";
 import {
   FileSearchService,
   type FileSearchHit,
@@ -48,6 +49,7 @@ export const FileSearchServiceLive = Layer.effect(
   FileSearchService,
   Effect.gen(function* () {
     const workspace = yield* WorkspaceService;
+    const worktrees = yield* WorktreeService;
     const fs = yield* FileSystem.FileSystem;
     const pathSvc = yield* Path.Path;
 
@@ -55,6 +57,7 @@ export const FileSearchServiceLive = Layer.effect(
       folderId,
       query,
       limit,
+      worktreeId,
     ) =>
       Effect.gen(function* () {
         const folder = yield* workspace.findById(folderId);
@@ -62,7 +65,18 @@ export const FileSearchServiceLive = Layer.effect(
           return yield* Effect.fail(new FsFolderNotFoundError({ folderId }));
         }
         const cap = limit && limit > 0 ? limit : DEFAULT_LIMIT;
-        const rootAbs = pathSvc.resolve(folder.path);
+
+        // Reroot at the worktree's path when one is supplied and it belongs
+        // to this project. Mismatched worktree → silent fallback to the
+        // project root; matches `FsTreeRpc`'s contract.
+        let root = folder.path;
+        if (worktreeId) {
+          const wt = yield* worktrees.get(worktreeId);
+          if (wt !== null && wt.projectId === folderId) {
+            root = wt.path;
+          }
+        }
+        const rootAbs = pathSvc.resolve(root);
 
         // Collect every candidate (subject to depth/visit caps), then rank
         // with fuzzysort. The substring matcher we used previously couldn't

--- a/apps/server/src/workspace/services/file-search.ts
+++ b/apps/server/src/workspace/services/file-search.ts
@@ -3,6 +3,7 @@ import { Context, type Effect } from "effect";
 import {
   type FolderId,
   type FsFolderNotFoundError,
+  type WorktreeId,
 } from "@forkzero/wire";
 
 export interface FileSearchHit {
@@ -18,11 +19,16 @@ export interface FileSearchServiceShape {
    * other heavyweight directories. Caps results at `limit` (default 20).
    * An empty `query` returns the first `limit` entries from a depth-first
    * walk — handy as a "what's in here" view when the popover first opens.
+   *
+   * `worktreeId`, when set, reroots the walk at the worktree's path so a
+   * session running on a worktree only sees that worktree's files. Falls
+   * back to the project root if the worktree doesn't belong to `folderId`.
    */
   readonly search: (
     folderId: FolderId,
     query: string,
     limit?: number,
+    worktreeId?: WorktreeId | null,
   ) => Effect.Effect<ReadonlyArray<FileSearchHit>, FsFolderNotFoundError>;
 }
 

--- a/apps/server/src/worktree/layers/worktree-service.ts
+++ b/apps/server/src/worktree/layers/worktree-service.ts
@@ -38,7 +38,6 @@ const rowToWorktree = (row: WorktreeRow): Worktree =>
     createdAt: new Date(row.created_at),
   });
 
-const DEFAULT_BASE_REL = Path.join(".forkzero", "repo-worktree");
 const EXCLUDE_LINE = ".forkzero/";
 
 export const WorktreeServiceLive = Layer.effect(
@@ -95,8 +94,8 @@ export const WorktreeServiceLive = Layer.effect(
     /**
      * Append `.forkzero/` to the repo's `.git/info/exclude` if it isn't
      * already there. Idempotent. We patch this on first worktree create so
-     * the in-repo `.forkzero/repo-worktree/` tree doesn't show up as
-     * untracked, without touching the user's `.gitignore`.
+     * the in-repo `.forkzero/` tree doesn't show up as untracked, without
+     * touching the user's `.gitignore`.
      */
     const ensureExclude = (repoPath: string) =>
       Effect.gen(function* () {
@@ -159,7 +158,10 @@ export const WorktreeServiceLive = Layer.effect(
           );
         }
         const repoPath = folder.path;
-        const baseDir = Path.join(repoPath, DEFAULT_BASE_REL);
+        // Layout: <repo>/.forkzero/<repo-name>/<branch>/. Grouping by repo
+        // name keeps `ls .forkzero/` legible when a project hosts many
+        // worktrees ("branches of pangyo") instead of a generic bucket.
+        const baseDir = Path.join(repoPath, ".forkzero", folder.name);
 
         yield* ensureExclude(repoPath);
         yield* fs

--- a/packages/wire/src/workspace.ts
+++ b/packages/wire/src/workspace.ts
@@ -2,7 +2,7 @@ import { Rpc } from "@effect/rpc";
 import { Schema } from "effect";
 
 import { FsFolderNotFoundError } from "./fs.ts";
-import { FolderId } from "./ids.ts";
+import { FolderId, WorktreeId } from "./ids.ts";
 
 export class Folder extends Schema.Class<Folder>("Folder")({
   id: FolderId,
@@ -62,12 +62,19 @@ export const WorkspaceSetSelectedRpc = Rpc.make("workspace.setSelected", {
  * Walk the project's file tree honouring `.gitignore` and return up to
  * `limit` matches against `query`. Backs the composer's `@` file picker.
  * Empty `query` returns the most recently touched entries (server's call).
+ *
+ * When `worktreeId` is set the walk is rooted at the worktree's path instead
+ * of the project's main checkout, so a session running on a worktree only
+ * surfaces files that actually live in that worktree. Mirrors the optional
+ * `worktreeId` on the `fs.*` RPCs; the server falls back to the project root
+ * silently if the worktree doesn't belong to `projectId`.
  */
 export const WorkspaceSearchFilesRpc = Rpc.make("workspace.searchFiles", {
   payload: Schema.Struct({
     projectId: FolderId,
     query: Schema.String,
     limit: Schema.optional(Schema.Number),
+    worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
   }),
   success: Schema.Array(
     Schema.Struct({


### PR DESCRIPTION
## Summary

- Worktrees create at `.forkzero/<repo-name>/<branch>/` instead of the generic `.forkzero/repo-worktree/<name>/` bucket; existing rows keep working since `path` is stored absolute.
- `workspace.searchFiles` now accepts an optional `worktreeId` and reroots the walk at the worktree's path — sessions on a worktree only surface their own files. Mirrors the `fs.*` RPC shape.
- User-bubble file mentions render as icon + basename chips matching the composer style; the raw `@<relPath>` token is fully stripped from the bubble text.

## Test plan

- [ ] Create a fresh worktree from the composer chip menu; `ls .forkzero/<repo-name>/` shows the cool-name dir.
- [ ] On a worktree session, `@`-search only surfaces worktree files; no leakage from the main checkout or sibling worktrees.
- [ ] Send a message with a file mention; the user bubble shows the chip with no raw path text.