### PR TITLE
fix: lock macOS app to dark appearance

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,5 +1,14 @@
 import { RpcSerialization } from "@effect/rpc";
-import { app, BrowserWindow, dialog, ipcMain, net, protocol, shell } from "electron";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  nativeTheme,
+  net,
+  protocol,
+  shell,
+} from "electron";
 import { Effect, Fiber, Layer } from "effect";
 import * as fs from "node:fs/promises";
 import * as Path from "node:path";
@@ -35,6 +44,13 @@ const isDevelopment = Boolean(DEV_SERVER_URL);
 const APP_NAME = isDevelopment ? "forkzero (Dev)" : "forkzero";
 
 app.setName(APP_NAME);
+
+// Lock the app to macOS's dark appearance so the sidebar vibrancy material
+// always renders in its dark variant. Without this, vibrancy follows the
+// user's system theme — on a light-mode Mac the bright material lets the
+// desktop wallpaper bleed through and washes out the (hardcoded-dark)
+// renderer UI.
+nativeTheme.themeSource = "dark";
 
 let mainWindow: BrowserWindow | null = null;
 let runtimeFiber: Fiber.RuntimeFiber<void, never> | null = null;


### PR DESCRIPTION
## Summary
- Sets `nativeTheme.themeSource = "dark"` in the Electron main process so the sidebar vibrancy material always renders in its dark variant, regardless of the user's macOS system theme.
- Without this, vibrancy follows the system appearance — on a light-mode Mac the bright material lets the desktop wallpaper bleed through and washes out the (hardcoded-dark) renderer UI.
- No renderer changes; vibrancy + transparent window stay as designed.

## Test plan
- [ ] `bun dev` on macOS with System Settings → Appearance set to **Light** and a bright wallpaper visible behind the window — sidebar/right pane render dark, no wash-out.
- [ ] Toggle macOS to **Dark** — app looks identical (confirms it no longer follows system).
- [ ] Quit + relaunch in light mode — first paint is already dark, no flash.
- [ ] Traffic-light buttons still position correctly in windowed and fullscreen.