### PR TITLE
chore: rename forkzero → memoize

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@effect/rpc": "catalog:",
-    "@forkzero/server": "*",
-    "@forkzero/wire": "*",
+    "@memoize/server": "*",
+    "@memoize/wire": "*",
     "better-sqlite3": "^12.9.0",
     "effect": "catalog:",
     "electron": "^33.2.0",

--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -91,7 +91,7 @@ function startApp() {
   if (shuttingDown || currentApp !== null) return;
 
   const electronPath = require("electron");
-  const app = spawn(electronPath, [".", "--forkzero-dev"], {
+  const app = spawn(electronPath, [".", "--memoize-dev"], {
     cwd: desktopDir,
     // Pass the resolved dev URL through explicitly so main.ts sees it even
     // when bun/turbo invoked us without setting the env var.

--- a/apps/desktop/src/ipc/electron-server-protocol.ts
+++ b/apps/desktop/src/ipc/electron-server-protocol.ts
@@ -3,7 +3,7 @@ import type { FromClientEncoded } from "@effect/rpc/RpcMessage";
 import { ipcMain, type WebContents } from "electron";
 import { Effect, Exit, Layer, Mailbox, Stream } from "effect";
 
-import { IPC_CHANNEL } from "@forkzero/wire";
+import { IPC_CHANNEL } from "@memoize/wire";
 
 /**
  * RpcServer.Protocol implementation for Electron IPC. Modeled on

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -14,21 +14,21 @@ import * as fs from "node:fs/promises";
 import * as Path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { makeMainLayer } from "@forkzero/server";
+import { makeMainLayer } from "@memoize/server";
 
 import { electronServerProtocolLayer } from "./ipc/electron-server-protocol.ts";
 
 /**
  * Privileged scheme registration. Must run before `app.whenReady()` —
  * Electron freezes the scheme registry once the app is ready, so a late
- * call silently fails and `<img src="forkzero://...">` errors out with no
+ * call silently fails and `<img src="memoize://...">` errors out with no
  * obvious cause. `secure: true` puts the scheme in the same trust class as
  * `https`; `supportFetchAPI` lets the renderer use `fetch()` against it;
  * `stream: true` lets us hand back a body that the renderer can stream.
  */
 protocol.registerSchemesAsPrivileged([
   {
-    scheme: "forkzero",
+    scheme: "memoize",
     privileges: {
       secure: true,
       standard: true,
@@ -41,7 +41,7 @@ protocol.registerSchemesAsPrivileged([
 const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL?.trim() || "";
 const isDevelopment = Boolean(DEV_SERVER_URL);
 
-const APP_NAME = isDevelopment ? "forkzero (Dev)" : "forkzero";
+const APP_NAME = isDevelopment ? "memoize (Dev)" : "memoize";
 
 app.setName(APP_NAME);
 
@@ -156,7 +156,7 @@ function createMainWindow() {
           // Boot-time layer failures (sqlite open, migrator, config) are
           // unrecoverable — surface the cause and bail. Quiet
           // success-after-restart is preferable to a half-running app.
-          console.error("[forkzero] fatal boot error", cause);
+          console.error("[memoize] fatal boot error", cause);
           app.exit(1);
         }),
       ),
@@ -196,7 +196,7 @@ function createMainWindow() {
 }
 
 /**
- * Resolve `forkzero://attachments/<id>` to a file under
+ * Resolve `memoize://attachments/<id>` to a file under
  * `<userDataDir>/attachments/`. The id has no extension on the wire so we
  * scan the directory for a file with the matching stem. Anything outside
  * the host `attachments` is rejected — no path traversal, no other hosts.
@@ -212,17 +212,17 @@ const MIME_BY_EXT: Record<string, string> = {
   avif: "image/avif",
 };
 
-const registerForkzeroProtocol = (): void => {
+const registerMemoizeProtocol = (): void => {
   const attachmentsDir = Path.join(app.getPath("userData"), "attachments");
 
-  protocol.handle("forkzero", async (request) => {
+  protocol.handle("memoize", async (request) => {
     const url = new URL(request.url);
     if (url.host !== ATTACHMENTS_HOST) {
       return new Response(null, { status: 404 });
     }
 
     // The path is `/<id>`; sanitise to a single segment so a crafted url
-    // like `forkzero://attachments/../foo` cannot escape `attachmentsDir`.
+    // like `memoize://attachments/../foo` cannot escape `attachmentsDir`.
     const id = decodeURIComponent(url.pathname.replace(/^\//, ""));
     if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
       return new Response(null, { status: 400 });
@@ -256,7 +256,7 @@ const registerForkzeroProtocol = (): void => {
 };
 
 void app.whenReady().then(() => {
-  registerForkzeroProtocol();
+  registerMemoizeProtocol();
   createMainWindow();
 
   app.on("activate", () => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from "electron";
 
-import { IPC_CHANNEL } from "@forkzero/wire";
+import { IPC_CHANNEL } from "@memoize/wire";
 
 /**
  * Preload bridge — the only seam between the renderer and the main process.
@@ -40,4 +40,4 @@ const bridge = {
   },
 };
 
-contextBridge.exposeInMainWorld("forkzero", bridge);
+contextBridge.exposeInMainWorld("memoize", bridge);

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -7,7 +7,7 @@ const shared = {
   outExtensions: () => ({ js: ".cjs" }),
   // Workspace packages ship as raw .ts source — bundle them in instead of
   // letting Node try to require() the .ts file at runtime.
-  deps: { alwaysBundle: ["@forkzero/wire", "@forkzero/server"] },
+  deps: { alwaysBundle: ["@memoize/wire", "@memoize/server"] },
   // Native modules whose loader uses `__dirname` / `module.parent.filename`
   // to locate a `.node` file at runtime — bundling their JS relocates those
   // anchors and the lookup fails. Keep them external so each is require()'d

--- a/apps/renderer/index.html
+++ b/apps/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>forkzero</title>
+    <title>memoize</title>
     <style>
       /* No background here — it would block macOS vibrancy from showing
          through transparent panes (sidebar). Per-pane bg lives in app.tsx

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -26,7 +26,7 @@
     "@effect/rpc": "catalog:",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@fontsource-variable/inter": "^5.2.8",
-    "@forkzero/wire": "*",
+    "@memoize/wire": "*",
     "@hugeicons/core-free-icons": "^4.1.1",
     "@hugeicons/react": "^1.1.6",
     "@lezer/highlight": "^1.2.0",

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -24,7 +24,7 @@ import { useSessionsStore } from "./store/sessions.ts";
 import { useUiStore } from "./store/ui.ts";
 import { useWorkspaceStore } from "./store/workspace.ts";
 
-const PANEL_GROUP_ID = "forkzero.shell.v3";
+const PANEL_GROUP_ID = "memoize.shell.v3";
 const PANEL_IDS = ["projects", "main", "files"];
 
 export function App() {
@@ -53,7 +53,7 @@ export function App() {
   // lights to dodge in native fullscreen.
   const setFullScreen = useUiStore((s) => s.setFullScreen);
   useEffect(() => {
-    const win = window.forkzero?.window;
+    const win = window.memoize?.window;
     if (win === undefined) return;
     return win.onFullScreenChange((value) => setFullScreen(value));
   }, [setFullScreen]);
@@ -86,11 +86,11 @@ export function App() {
         const result = await Effect.runPromise(client.ping.ping({}));
         if (cancelled) return;
         // eslint-disable-next-line no-console
-        console.log("[forkzero] RPC smoke test:", JSON.stringify(result));
+        console.log("[memoize] RPC smoke test:", JSON.stringify(result));
       } catch (error) {
         if (cancelled) return;
         // eslint-disable-next-line no-console
-        console.error("[forkzero] RPC smoke test failed:", error);
+        console.error("[memoize] RPC smoke test failed:", error);
       }
     })();
     return () => {

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -23,7 +23,7 @@ import {
   type RuntimeMode,
   type Session,
   type SessionId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { Card, CardPanel } from "~/components/ui/card";
 import { Frame, FrameFooter } from "~/components/ui/frame";
@@ -291,7 +291,7 @@ export function ChatComposer({ session }: { session: Session }) {
   /**
    * Insert chips for `files`. Image files render with a thumbnail; other types
    * (PDFs, docs, archives) get a generic file-icon chip. The chip's underlying
-   * token swaps from a temp id to a `forkzero://attachments/<id>` URL once the
+   * token swaps from a temp id to a `memoize://attachments/<id>` URL once the
    * upload resolves. Files beyond the per-turn cap are dropped with a warning.
    */
   const attachFiles = (files: readonly File[]): void => {
@@ -335,7 +335,7 @@ export function ChatComposer({ session }: { session: Session }) {
 
       void uploadOne(sessionId, file)
         .then((ref) => {
-          const finalUrl = isImage ? `forkzero://attachments/${ref.id}` : "";
+          const finalUrl = isImage ? `memoize://attachments/${ref.id}` : "";
           editorViewRef.current?.dispatch({
             effects: updateImageChipEffect.of({
               previousId: tempId,
@@ -849,7 +849,7 @@ function ModelPicker({
  * sessionStorage so reloads keep the chosen level visible.
  */
 function ReasoningPicker({ sessionId }: { sessionId: SessionId }) {
-  const storageKey = `forkzero.reasoning.${sessionId}`;
+  const storageKey = `memoize.reasoning.${sessionId}`;
   const [level, setLevel] = useState<ReasoningLevel>(() => {
     if (typeof window === "undefined") return "medium";
     const stored = window.sessionStorage.getItem(storageKey);

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 
-import type { AgentItemId, Message, SessionId } from "@forkzero/wire";
+import type { AgentItemId, Message, SessionId } from "@memoize/wire";
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { useMessagesStore } from "../store/messages.ts";

--- a/apps/renderer/src/components/composer/file-chip-hover.tsx
+++ b/apps/renderer/src/components/composer/file-chip-hover.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
-import type { FolderId } from "@forkzero/wire";
+import type { FolderId } from "@memoize/wire";
 
 import { useActiveWorktreeId } from "~/store/active-workspace.ts";
 import { useUiStore } from "~/store/ui.ts";

--- a/apps/renderer/src/components/composer/file-tag-popover.tsx
+++ b/apps/renderer/src/components/composer/file-tag-popover.tsx
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import { Folder } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
-import type { FolderId, WorktreeId } from "@forkzero/wire";
+import type { FolderId, WorktreeId } from "@memoize/wire";
 
 import {
   getFileIconUrl,

--- a/apps/renderer/src/components/composer/queue-chip.tsx
+++ b/apps/renderer/src/components/composer/queue-chip.tsx
@@ -1,6 +1,6 @@
 import { ArrowUp, X } from "lucide-react";
 
-import type { SessionId } from "@forkzero/wire";
+import type { SessionId } from "@memoize/wire";
 
 import {
   Tooltip,

--- a/apps/renderer/src/components/composer/queue-tray.tsx
+++ b/apps/renderer/src/components/composer/queue-tray.tsx
@@ -1,4 +1,4 @@
-import type { SessionId } from "@forkzero/wire";
+import type { SessionId } from "@memoize/wire";
 
 import { useMessagesStore } from "../../store/messages.ts";
 import { QueueChip } from "./queue-chip.tsx";

--- a/apps/renderer/src/components/composer/slash-command-popover.tsx
+++ b/apps/renderer/src/components/composer/slash-command-popover.tsx
@@ -2,7 +2,7 @@ import { type EditorView } from "@codemirror/view";
 import fuzzysort from "fuzzysort";
 import { useEffect, useMemo, useState } from "react";
 
-import type { ProviderId, Skill } from "@forkzero/wire";
+import type { ProviderId, Skill } from "@memoize/wire";
 
 import {
   filterBuiltins,

--- a/apps/renderer/src/components/cost-footer.tsx
+++ b/apps/renderer/src/components/cost-footer.tsx
@@ -5,7 +5,7 @@ import {
   type AgentItemId,
   type Message,
   type SessionId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { useMessagesStore } from "../store/messages.ts";
 

--- a/apps/renderer/src/components/credentials-sheet.tsx
+++ b/apps/renderer/src/components/credentials-sheet.tsx
@@ -1,7 +1,7 @@
 import { Eye, EyeOff } from "lucide-react";
 import { useState } from "react";
 
-import type { AgentAvailability, ProviderId } from "@forkzero/wire";
+import type { AgentAvailability, ProviderId } from "@memoize/wire";
 
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -28,7 +28,7 @@ export function CredentialsSheet() {
           <SheetTitle>Settings · API keys</SheetTitle>
           <SheetDescription>
             Most users don&apos;t need this. Run <code>claude /login</code> or{" "}
-            <code>codex login</code> in your terminal and forkzero uses those
+            <code>codex login</code> in your terminal and memoize uses those
             credentials automatically. API keys here are an advanced fallback,
             stored in your OS keychain and only sent to the provider&apos;s SDK.
           </SheetDescription>

--- a/apps/renderer/src/components/diff-pane.tsx
+++ b/apps/renderer/src/components/diff-pane.tsx
@@ -15,7 +15,7 @@ import type {
   GitChange,
   GitChangeKind,
   WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { gitChangesKey, useGitChangesStore } from "../store/git-changes.ts";

--- a/apps/renderer/src/components/file-tree.tsx
+++ b/apps/renderer/src/components/file-tree.tsx
@@ -2,7 +2,7 @@ import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Effect } from "effect";
 
-import type { FolderId, FsEntry } from "@forkzero/wire";
+import type { FolderId, FsEntry } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import {

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -1,6 +1,6 @@
 import { X } from "lucide-react";
 
-import { MODELS_BY_PROVIDER, type ProviderId } from "@forkzero/wire";
+import { MODELS_BY_PROVIDER, type ProviderId } from "@memoize/wire";
 
 import { useUiStore } from "../store/ui.ts";
 import { FileIcon } from "./file-icon.tsx";

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -12,7 +12,7 @@ import type {
   Message,
   SessionId,
   SkillRef,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import {
   getFileIconUrl,
@@ -181,7 +181,7 @@ function UserBubble({
               return (
                 <a
                   key={a.id}
-                  href={`forkzero://attachments/${a.id}`}
+                  href={`memoize://attachments/${a.id}`}
                   target="_blank"
                   rel="noreferrer"
                   title={a.originalName}
@@ -189,7 +189,7 @@ function UserBubble({
                 >
                   {isImage ? (
                     <img
-                      src={`forkzero://attachments/${a.id}`}
+                      src={`memoize://attachments/${a.id}`}
                       alt=""
                       className="size-4 rounded object-cover"
                     />

--- a/apps/renderer/src/components/permission-card.tsx
+++ b/apps/renderer/src/components/permission-card.tsx
@@ -4,7 +4,7 @@ import type {
   PermissionDecision,
   PermissionKind,
   PermissionRequest,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 

--- a/apps/renderer/src/components/permissions-inspector.tsx
+++ b/apps/renderer/src/components/permissions-inspector.tsx
@@ -5,7 +5,7 @@ import type {
   FolderId,
   PermissionKind,
   SavedDecision,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import {
   Dialog,

--- a/apps/renderer/src/components/pr-pane.tsx
+++ b/apps/renderer/src/components/pr-pane.tsx
@@ -17,7 +17,7 @@ import type {
   GitPrInfo,
   GitPrReviewState,
   WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { softTone, type Tone } from "../lib/tones.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
@@ -26,7 +26,7 @@ import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { MarkdownBody } from "./markdown-body.tsx";
 
 const openExternal = (url: string) => {
-  const bridge = window.forkzero?.app;
+  const bridge = window.memoize?.app;
   if (bridge !== undefined) {
     bridge.openExternal(url);
     return;

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -23,7 +23,7 @@ import {
   type GitOriginInfo,
   type ProviderId,
   type Session,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
@@ -433,7 +433,7 @@ function ProjectActionsMenu({
 }
 
 // One-line login hint per provider — the user runs this in their terminal
-// and forkzero picks up the credentials automatically on next refresh.
+// and memoize picks up the credentials automatically on next refresh.
 const LOGIN_HINT: Record<ProviderId, string> = {
   claude: "Run `claude /login` in your terminal",
   codex: "Run `codex login` in your terminal",

--- a/apps/renderer/src/components/provider-icons.tsx
+++ b/apps/renderer/src/components/provider-icons.tsx
@@ -2,7 +2,7 @@ import { ChatGptIcon, ClaudeIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 
-import type { ProviderId } from "@forkzero/wire";
+import type { ProviderId } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 

--- a/apps/renderer/src/components/question-card.tsx
+++ b/apps/renderer/src/components/question-card.tsx
@@ -9,7 +9,7 @@ import type {
   SessionId,
   UserQuestion,
   UserQuestionAnswer,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 

--- a/apps/renderer/src/components/runtime-mode-meta.ts
+++ b/apps/renderer/src/components/runtime-mode-meta.ts
@@ -1,7 +1,7 @@
 import { Lock, LockOpen, PencilLine } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
-import type { RuntimeMode } from "@forkzero/wire";
+import type { RuntimeMode } from "@memoize/wire";
 
 /**
  * Shared label/description/icon for each runtime mode. Used by the composer's

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -15,7 +15,7 @@ import {
   type FolderId,
   type ProviderId,
   type RuntimeMode,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 import { DEFAULT_SUBAGENT_PRESETS } from "../lib/subagent-presets.ts";
@@ -327,7 +327,7 @@ function WorkspacePane() {
   return (
     <Section
       title="New chat workspace"
-      description="Forkzero can run each chat in its own git worktree under .forkzero/repo-worktree/, branched off the project's HEAD. Per-repo settings under Repositories override this default."
+      description="Memoize can run each chat in its own git worktree under .memoize/repo-worktree/, branched off the project's HEAD. Per-repo settings under Repositories override this default."
     >
       <label className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2.5 text-sm">
         <input

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -5,7 +5,7 @@ import {
   MODELS_BY_PROVIDER,
   type FolderId,
   type ProviderId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 import { useRepositorySettingsStore } from "../store/repository-settings.ts";
@@ -296,7 +296,7 @@ function WorktreeSection({
   return (
     <Section
       title="Worktrees"
-      description="Git worktrees for this repo. Each lives under .forkzero/repo-worktree/ on disk."
+      description="Git worktrees for this repo. Each lives under .memoize/repo-worktree/ on disk."
     >
       <div className="flex flex-col gap-3">
         <label className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2.5 text-sm">

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -6,7 +6,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type { AgentItemId, Message } from "@forkzero/wire";
+import type { AgentItemId, Message } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -3,7 +3,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Effect, Fiber, Stream } from "effect";
 
-import type { Folder, PtyId } from "@forkzero/wire";
+import type { Folder, PtyId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useActiveWorkspaceRoot } from "../store/active-workspace.ts";
@@ -170,7 +170,7 @@ function PtyTerminal({ folder, cwd }: { folder: Folder; cwd: string }) {
       } catch (err) {
         if (cancelled) return;
         // eslint-disable-next-line no-console
-        console.error("[forkzero] failed to open pty:", err);
+        console.error("[memoize] failed to open pty:", err);
         term.write(
           "\r\n\x1b[38;5;203mfailed to open terminal — see devtools console\x1b[0m\r\n",
         );

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -15,7 +15,7 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { SessionId } from "@forkzero/wire";
+import type { SessionId } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { useEffect } from "react";
 
-import type { FolderId } from "@forkzero/wire";
+import type { FolderId } from "@memoize/wire";
 
 import {
   softInteractive,
@@ -50,7 +50,7 @@ export function TopBarLeft() {
       className={`${SECTION_CLASS} pr-1 ${isFullScreen ? "pl-3" : "pl-20"}`}
     >
       <span className="truncate font-semibold tracking-tight text-foreground">
-        forkzero
+        memoize
       </span>
       <span className="flex-1" />
       <Tooltip>

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -8,7 +8,7 @@ import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { AgentItemId, Message } from "@forkzero/wire";
+import type { AgentItemId, Message } from "@memoize/wire";
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { cn } from "~/lib/utils";

--- a/apps/renderer/src/composer/builtin-commands.ts
+++ b/apps/renderer/src/composer/builtin-commands.ts
@@ -1,4 +1,4 @@
-import type { ProviderId } from "@forkzero/wire";
+import type { ProviderId } from "@memoize/wire";
 
 /**
  * One slash-prefixed command surfaced in the composer popover.

--- a/apps/renderer/src/composer/segment-parser.ts
+++ b/apps/renderer/src/composer/segment-parser.ts
@@ -6,7 +6,7 @@ import {
   type FileRef,
   type ProviderId,
   type SkillRef,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { allChips } from "../lib/codemirror/composer-chips.ts";
 

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -1,6 +1,6 @@
 /**
  * Shape of the preload bridge that the main process exposes onto
- * `window.forkzero`. The renderer's RPC client transport reads/writes raw
+ * `window.memoize`. The renderer's RPC client transport reads/writes raw
  * encoded RPC frames; serialization + framing happen at the Effect RPC layer.
  */
 export interface RpcBridge {
@@ -20,7 +20,7 @@ export interface AppBridge {
   readonly openExternal: (url: string) => void;
 }
 
-export interface ForkzeroBridge {
+export interface MemoizeBridge {
   readonly rpc: RpcBridge;
   readonly window?: WindowBridge;
   readonly app?: AppBridge;
@@ -28,15 +28,15 @@ export interface ForkzeroBridge {
 
 declare global {
   interface Window {
-    forkzero?: ForkzeroBridge;
+    memoize?: MemoizeBridge;
   }
 }
 
-export function getBridge(): ForkzeroBridge {
-  const bridge = globalThis.window?.forkzero;
+export function getBridge(): MemoizeBridge {
+  const bridge = globalThis.window?.memoize;
   if (!bridge) {
     throw new Error(
-      "forkzero bridge missing — preload.ts did not load. Are we running outside Electron?",
+      "memoize bridge missing — preload.ts did not load. Are we running outside Electron?",
     );
   }
   return bridge;

--- a/apps/renderer/src/lib/codemirror/composer-chips.ts
+++ b/apps/renderer/src/lib/codemirror/composer-chips.ts
@@ -68,7 +68,7 @@ export const clearChipsEffect = StateEffect.define<void>();
 /**
  * Swap the metadata of an existing image chip in place — used when an
  * upload resolves and the renderer wants to replace the blob: preview URL
- * with the durable `forkzero://attachments/<id>` URL without disturbing the
+ * with the durable `memoize://attachments/<id>` URL without disturbing the
  * cursor or the chip's position in the doc.
  */
 export const updateImageChipEffect = StateEffect.define<{

--- a/apps/renderer/src/lib/codemirror/setup.ts
+++ b/apps/renderer/src/lib/codemirror/setup.ts
@@ -14,7 +14,7 @@ import {
   lineNumbers,
 } from "@codemirror/view";
 
-import { forkzeroTheme } from "./theme.ts";
+import { memoizeTheme } from "./theme.ts";
 
 // One compartment for the language extension so opening a different file
 // reconfigures it via a single transaction instead of rebuilding the view.
@@ -60,7 +60,7 @@ export const createEditor = ({
             },
           },
         ]),
-        forkzeroTheme,
+        memoizeTheme,
         languageCompartment.of(language ?? []),
         EditorView.updateListener.of((u) => {
           if (u.docChanged) onChange(u.state.doc.toString());

--- a/apps/renderer/src/lib/codemirror/theme.ts
+++ b/apps/renderer/src/lib/codemirror/theme.ts
@@ -6,7 +6,7 @@ import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { tags as t } from "@lezer/highlight";
 
-// Palette aligned with the rest of forkzero's chrome (zinc-950 surface,
+// Palette aligned with the rest of memoize's chrome (zinc-950 surface,
 // zinc-400/500 muted-foreground). Syntax accents are deliberately desaturated
 // so the editor reads as part of the chat IDE rather than a separate VS Code.
 const PALETTE = {
@@ -178,7 +178,7 @@ const highlightStyle = HighlightStyle.define([
   { tag: t.invalid, color: PALETTE.invalid },
 ]);
 
-export const forkzeroTheme: Extension = [
+export const memoizeTheme: Extension = [
   editorTheme,
   syntaxHighlighting(highlightStyle),
 ];

--- a/apps/renderer/src/lib/group-messages.ts
+++ b/apps/renderer/src/lib/group-messages.ts
@@ -1,4 +1,4 @@
-import type { AgentItemId, Message } from "@forkzero/wire";
+import type { AgentItemId, Message } from "@memoize/wire";
 
 export type RenderGroup =
   | { readonly kind: "single"; readonly message: Message }

--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -1,7 +1,7 @@
 import { RpcClient, RpcGroup, RpcSerialization } from "@effect/rpc";
 import { Effect, Layer, ManagedRuntime, Scope } from "effect";
 
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 
 import { getBridge } from "./bridge.ts";
 import { electronClientProtocolLayer } from "./electron-client-protocol.ts";
@@ -14,10 +14,10 @@ import { electronClientProtocolLayer } from "./electron-client-protocol.ts";
  * background fibers (response demux, error reconciliation). We hand the
  * client a long-lived scope that lives until the page unloads.
  */
-type ForkzeroClient = RpcClient.RpcClient<RpcGroup.Rpcs<typeof ForkzeroRpcs>>;
+type MemoizeClient = RpcClient.RpcClient<RpcGroup.Rpcs<typeof MemoizeRpcs>>;
 
 let runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never> | null = null;
-let cachedClient: Promise<ForkzeroClient> | null = null;
+let cachedClient: Promise<MemoizeClient> | null = null;
 
 function getRuntime() {
   if (runtime === null) {
@@ -29,13 +29,13 @@ function getRuntime() {
   return runtime;
 }
 
-export function getRpcClient(): Promise<ForkzeroClient> {
+export function getRpcClient(): Promise<MemoizeClient> {
   if (cachedClient === null) {
     const rt = getRuntime();
     cachedClient = rt.runPromise(
       Effect.gen(function* () {
         const scope = yield* Scope.make();
-        return yield* RpcClient.make(ForkzeroRpcs).pipe(Scope.extend(scope));
+        return yield* RpcClient.make(MemoizeRpcs).pipe(Scope.extend(scope));
       }),
     );
   }

--- a/apps/renderer/src/lib/subagent-presets.ts
+++ b/apps/renderer/src/lib/subagent-presets.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition } from "@forkzero/wire";
+import type { AgentDefinition } from "@memoize/wire";
 
 /**
  * One named preset the user can toggle and edit. The `name` is the key the

--- a/apps/renderer/src/store/active-workspace.ts
+++ b/apps/renderer/src/store/active-workspace.ts
@@ -1,4 +1,4 @@
-import type { FolderId, WorktreeId } from "@forkzero/wire";
+import type { FolderId, WorktreeId } from "@memoize/wire";
 
 import { useSessionsStore } from "./sessions.ts";
 import { useWorkspaceStore } from "./workspace.ts";

--- a/apps/renderer/src/store/attachments.ts
+++ b/apps/renderer/src/store/attachments.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { AttachmentRef, SessionId } from "@forkzero/wire";
+import type { AttachmentRef, SessionId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/git-changes.ts
+++ b/apps/renderer/src/store/git-changes.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { FolderId, GitChange, WorktreeId } from "@forkzero/wire";
+import type { FolderId, GitChange, WorktreeId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/git-status.ts
+++ b/apps/renderer/src/store/git-status.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { FolderId, GitStatusSummary, WorktreeId } from "@forkzero/wire";
+import type { FolderId, GitStatusSummary, WorktreeId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -1,7 +1,7 @@
 import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
-import type { ComposerInput, Message, SessionId } from "@forkzero/wire";
+import type { ComposerInput, Message, SessionId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { usePrDetailsStore } from "./pr-details.ts";

--- a/apps/renderer/src/store/permissions.ts
+++ b/apps/renderer/src/store/permissions.ts
@@ -7,7 +7,7 @@ import type {
   PermissionRequest,
   SavedDecision,
   SessionId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/pr-details.ts
+++ b/apps/renderer/src/store/pr-details.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { FolderId, GitPrDetails, WorktreeId } from "@forkzero/wire";
+import type { FolderId, GitPrDetails, WorktreeId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/pr-state.ts
+++ b/apps/renderer/src/store/pr-state.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { FolderId, GitPrInfo, WorktreeId } from "@forkzero/wire";
+import type { FolderId, GitPrInfo, WorktreeId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/providers.ts
+++ b/apps/renderer/src/store/providers.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { AgentAvailability, ProviderId } from "@forkzero/wire";
+import type { AgentAvailability, ProviderId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/repository-settings.ts
+++ b/apps/renderer/src/store/repository-settings.ts
@@ -5,7 +5,7 @@ import type {
   FolderId,
   RepositorySettings,
   RepositorySettingsPatch,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -11,7 +11,7 @@ import type {
   SessionId,
   UserQuestionAnswer,
   WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import {

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -4,9 +4,9 @@ import {
   defaultModelFor,
   type ProviderId,
   type RuntimeMode,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
-const STORAGE_KEY = "forkzero.settings.v1";
+const STORAGE_KEY = "memoize.settings.v1";
 
 const DEFAULT_PROVIDER: ProviderId = "claude";
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "approval-required";

--- a/apps/renderer/src/store/skills.ts
+++ b/apps/renderer/src/store/skills.ts
@@ -1,7 +1,7 @@
 import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
-import type { SessionId, Skill } from "@forkzero/wire";
+import type { SessionId, Skill } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/subagents.ts
+++ b/apps/renderer/src/store/subagents.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-import type { AgentDefinition } from "@forkzero/wire";
+import type { AgentDefinition } from "@memoize/wire";
 
 import {
   DEFAULT_SUBAGENT_PRESETS,
@@ -12,7 +12,7 @@ import {
  * Per-preset overlay. Stores any field the user changed; `undefined`
  * fields fall back to the seed. We keep a separate overlay (rather than
  * cloning the full definition into storage) so seed updates from new
- * forkzero builds reach the user — a future tweak to the `research`
+ * memoize builds reach the user — a future tweak to the `research`
  * prompt would have applied retroactively had they not edited it.
  */
 interface PresetState {
@@ -73,7 +73,7 @@ export const useSubagentsStore = create<SubagentsState>()(
         }),
     }),
     {
-      name: "forkzero.subagents",
+      name: "memoize.subagents",
       version: 1,
     },
   ),

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-import type { FolderId, WorktreeId } from "@forkzero/wire";
+import type { FolderId, WorktreeId } from "@memoize/wire";
 
 /**
  * Top-level renderer view. The settings page replaces the chat surface in the

--- a/apps/renderer/src/store/workspace.ts
+++ b/apps/renderer/src/store/workspace.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { Folder, FolderId } from "@forkzero/wire";
+import type { Folder, FolderId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/store/worktrees.ts
+++ b/apps/renderer/src/store/worktrees.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { create } from "zustand";
 
-import type { FolderId, Worktree, WorktreeId } from "@forkzero/wire";
+import type { FolderId, Worktree, WorktreeId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -79,7 +79,7 @@ body,
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 
-  /* Forkzero extras: extra rungs on the surface ladder. The semantic shadcn
+  /* Memoize extras: extra rungs on the surface ladder. The semantic shadcn
      tokens (background → card → muted → accent) form a 4-step ramp; these
      fill in the gaps for hover/elevated/popover-on-popover surfaces. */
   --color-bg-subtle: var(--bg-subtle);

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@forkzero/server",
+  "name": "@memoize/server",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -29,7 +29,7 @@
     "@effect/sql": "catalog:",
     "@effect/sql-sqlite-node": "catalog:",
     "better-sqlite3": "^12.9.0",
-    "@forkzero/wire": "*",
+    "@memoize/wire": "*",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
     "keytar": "^7.9.0",

--- a/apps/server/src/app-paths.ts
+++ b/apps/server/src/app-paths.ts
@@ -6,7 +6,7 @@ import { Context } from "effect";
  * would resolve them from `XDG_DATA_HOME` or similar. Services yield this tag
  * instead of importing electron themselves — that's the rule from ADR 0007.
  */
-export class AppPaths extends Context.Tag("forkzero/AppPaths")<
+export class AppPaths extends Context.Tag("memoize/AppPaths")<
   AppPaths,
   {
     readonly userData: string;

--- a/apps/server/src/attachment/handlers.ts
+++ b/apps/server/src/attachment/handlers.ts
@@ -1,9 +1,9 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer } from "effect";
 
 import { AttachmentService } from "./services/attachment-service.ts";
 
-const Upload = ForkzeroRpcs.toLayerHandler(
+const Upload = MemoizeRpcs.toLayerHandler(
   "attachments.upload",
   ({ sessionId, bytes, mimeType, originalName }) =>
     Effect.flatMap(AttachmentService, (svc) =>
@@ -11,7 +11,7 @@ const Upload = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const Touch = ForkzeroRpcs.toLayerHandler("attachments.touch", ({ ids }) =>
+const Touch = MemoizeRpcs.toLayerHandler("attachments.touch", ({ ids }) =>
   Effect.flatMap(AttachmentService, (svc) => svc.touch(ids)),
 );
 

--- a/apps/server/src/attachment/layers/attachment-service.ts
+++ b/apps/server/src/attachment/layers/attachment-service.ts
@@ -6,7 +6,7 @@ import { Duration, Effect, Fiber, Layer, Ref, Schedule } from "effect";
 
 import {
   AttachmentTooLargeError,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { AppPaths } from "../../app-paths.ts";
 import { extForUpload } from "../image-mime.ts";

--- a/apps/server/src/attachment/services/attachment-service.ts
+++ b/apps/server/src/attachment/services/attachment-service.ts
@@ -5,7 +5,7 @@ import type {
   AttachmentTooLargeError,
   SessionId,
   SessionNotFoundError,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 export type UploadFailure =
   | AttachmentTooLargeError
@@ -35,7 +35,7 @@ export interface AttachmentServiceShape {
   >;
 }
 
-export class AttachmentService extends Context.Tag("forkzero/AttachmentService")<
+export class AttachmentService extends Context.Tag("memoize/AttachmentService")<
   AttachmentService,
   AttachmentServiceShape
 >() {}

--- a/apps/server/src/fs/handlers.ts
+++ b/apps/server/src/fs/handlers.ts
@@ -1,9 +1,9 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer } from "effect";
 
 import { FsService } from "./services/fs-service.ts";
 
-const Tree = ForkzeroRpcs.toLayerHandler(
+const Tree = MemoizeRpcs.toLayerHandler(
   "fs.tree",
   ({ folderId, path, worktreeId }) =>
     Effect.flatMap(FsService, (svc) =>
@@ -11,7 +11,7 @@ const Tree = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const ReadFile = ForkzeroRpcs.toLayerHandler(
+const ReadFile = MemoizeRpcs.toLayerHandler(
   "fs.readFile",
   ({ folderId, path, worktreeId }) =>
     Effect.flatMap(FsService, (svc) =>
@@ -19,7 +19,7 @@ const ReadFile = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const WriteFile = ForkzeroRpcs.toLayerHandler(
+const WriteFile = MemoizeRpcs.toLayerHandler(
   "fs.writeFile",
   ({ folderId, path, content, expectedMtime, worktreeId }) =>
     Effect.flatMap(FsService, (svc) =>

--- a/apps/server/src/fs/layers/fs-service.ts
+++ b/apps/server/src/fs/layers/fs-service.ts
@@ -12,7 +12,7 @@ import {
   FsTooLargeError,
   type FolderId,
   type WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
 import { WorktreeService } from "../../worktree/services/worktree-service.ts";

--- a/apps/server/src/fs/services/fs-service.ts
+++ b/apps/server/src/fs/services/fs-service.ts
@@ -10,7 +10,7 @@ import {
   type FsReadError,
   type FsTooLargeError,
   type WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 type TreeFailure = FsFolderNotFoundError | FsPathOutsideError | FsReadError;
 type ReadFileFailure = TreeFailure | FsTooLargeError;
@@ -36,7 +36,7 @@ export interface FsServiceShape {
   ) => Effect.Effect<{ readonly mtime: string }, WriteFileFailure>;
 }
 
-export class FsService extends Context.Tag("forkzero/FsService")<
+export class FsService extends Context.Tag("memoize/FsService")<
   FsService,
   FsServiceShape
 >() {}

--- a/apps/server/src/git/handlers.ts
+++ b/apps/server/src/git/handlers.ts
@@ -1,19 +1,19 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer, Stream } from "effect";
 
 import { GitService } from "./services/git-service.ts";
 
-const Log = ForkzeroRpcs.toLayerHandler("git.log", ({ folderId, limit }) =>
+const Log = MemoizeRpcs.toLayerHandler("git.log", ({ folderId, limit }) =>
   Effect.flatMap(GitService, (svc) => svc.log(folderId, limit)),
 );
 
-const Status = ForkzeroRpcs.toLayerHandler(
+const Status = MemoizeRpcs.toLayerHandler(
   "git.status",
   ({ folderId, worktreeId }) =>
     Effect.flatMap(GitService, (svc) => svc.status(folderId, worktreeId ?? null)),
 );
 
-const HeadChanged = ForkzeroRpcs.toLayerHandler(
+const HeadChanged = MemoizeRpcs.toLayerHandler(
   "git.headChanged",
   ({ folderId }) =>
     Stream.unwrap(
@@ -21,11 +21,11 @@ const HeadChanged = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const Origin = ForkzeroRpcs.toLayerHandler("git.origin", ({ folderId }) =>
+const Origin = MemoizeRpcs.toLayerHandler("git.origin", ({ folderId }) =>
   Effect.flatMap(GitService, (svc) => svc.origin(folderId)),
 );
 
-const PrState = ForkzeroRpcs.toLayerHandler(
+const PrState = MemoizeRpcs.toLayerHandler(
   "git.prState",
   ({ folderId, worktreeId }) =>
     Effect.flatMap(GitService, (svc) =>
@@ -33,7 +33,7 @@ const PrState = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const PrDetails = ForkzeroRpcs.toLayerHandler(
+const PrDetails = MemoizeRpcs.toLayerHandler(
   "git.prDetails",
   ({ folderId, worktreeId }) =>
     Effect.flatMap(GitService, (svc) =>
@@ -41,7 +41,7 @@ const PrDetails = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const Changes = ForkzeroRpcs.toLayerHandler(
+const Changes = MemoizeRpcs.toLayerHandler(
   "git.changes",
   ({ folderId, worktreeId }) =>
     Effect.flatMap(GitService, (svc) =>
@@ -49,7 +49,7 @@ const Changes = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const Commit = ForkzeroRpcs.toLayerHandler(
+const Commit = MemoizeRpcs.toLayerHandler(
   "git.commit",
   ({ folderId, worktreeId, message }) =>
     Effect.flatMap(GitService, (svc) =>
@@ -57,7 +57,7 @@ const Commit = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const Push = ForkzeroRpcs.toLayerHandler(
+const Push = MemoizeRpcs.toLayerHandler(
   "git.push",
   ({ folderId, worktreeId }) =>
     Effect.flatMap(GitService, (svc) => svc.push(folderId, worktreeId ?? null)),

--- a/apps/server/src/git/layers/git-service.ts
+++ b/apps/server/src/git/layers/git-service.ts
@@ -31,7 +31,7 @@ import {
   type GitPrCheckRunStatus,
   type GitPrReviewState,
   type WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
 import { WorktreeService } from "../../worktree/services/worktree-service.ts";

--- a/apps/server/src/git/services/git-service.ts
+++ b/apps/server/src/git/services/git-service.ts
@@ -13,7 +13,7 @@ import {
   type GitPrInfo,
   type GitStatusSummary,
   type WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 type GitFailure =
   | GitNotARepoError
@@ -59,7 +59,7 @@ export interface GitServiceShape {
   ) => Effect.Effect<{ readonly output: string }, GitFailure>;
 }
 
-export class GitService extends Context.Tag("forkzero/GitService")<
+export class GitService extends Context.Tag("memoize/GitService")<
   GitService,
   GitServiceShape
 >() {}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Public surface of `@forkzero/server`. The Electron shim consumes this; a
+ * Public surface of `@memoize/server`. The Electron shim consumes this; a
  * future headless server boot script (`bin.ts`) re-exports it too. Anything
  * not re-exported here is internal — keep the surface minimal.
  */

--- a/apps/server/src/persistence/import-workspaces.ts
+++ b/apps/server/src/persistence/import-workspaces.ts
@@ -3,7 +3,7 @@ import { SqlClient } from "@effect/sql";
 import { Effect, Schema } from "effect";
 import * as Path from "node:path";
 
-import { Folder, FolderId } from "@forkzero/wire";
+import { Folder, FolderId } from "@memoize/wire";
 
 import { AppPaths } from "../app-paths.ts";
 
@@ -47,7 +47,7 @@ export const importWorkspacesJson = Effect.gen(function* () {
     Effect.flatMap(Schema.decode(WorkspaceFile)),
     Effect.catchAllCause((cause) =>
       Effect.logWarning(
-        "[forkzero] workspaces.json present but unreadable; skipping import",
+        "[memoize] workspaces.json present but unreadable; skipping import",
       ).pipe(
         Effect.zipRight(Effect.logDebug(cause)),
         Effect.as(null),
@@ -75,6 +75,6 @@ export const importWorkspacesJson = Effect.gen(function* () {
     .pipe(Effect.catchAll(() => Effect.void));
 
   yield* Effect.logInfo(
-    `[forkzero] imported ${decoded.folders.length} project(s) from workspaces.json`,
+    `[memoize] imported ${decoded.folders.length} project(s) from workspaces.json`,
   );
 });

--- a/apps/server/src/persistence/migrations/0008_worktrees_and_repo_settings.ts
+++ b/apps/server/src/persistence/migrations/0008_worktrees_and_repo_settings.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 /**
  * Worktrees + per-repository settings.
  *
- *  - `worktrees` rows track each `git worktree` forkzero owns for a project.
+ *  - `worktrees` rows track each `git worktree` memoize owns for a project.
  *    Removed from disk via `WorktreeService.remove`; cascades from the
  *    parent project so deleting a project drops the rows too (the disk
  *    removal step happens before the DB delete in the service so we never

--- a/apps/server/src/persistence/ndjson-logger.ts
+++ b/apps/server/src/persistence/ndjson-logger.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect";
 import { createWriteStream, mkdirSync, renameSync, type WriteStream } from "node:fs";
 import { dirname, join } from "node:path";
 
-import type { FolderId, Message, SessionId } from "@forkzero/wire";
+import type { FolderId, Message, SessionId } from "@memoize/wire";
 
 import { AppPaths } from "../app-paths.ts";
 
@@ -33,7 +33,7 @@ export interface NdjsonLoggerShape {
   readonly close: (sessionId: SessionId) => Effect.Effect<void>;
 }
 
-export class NdjsonLogger extends Context.Tag("forkzero/NdjsonLogger")<
+export class NdjsonLogger extends Context.Tag("memoize/NdjsonLogger")<
   NdjsonLogger,
   NdjsonLoggerShape
 >() {}

--- a/apps/server/src/persistence/sqlite.ts
+++ b/apps/server/src/persistence/sqlite.ts
@@ -7,9 +7,9 @@ import { AppPaths } from "../app-paths.ts";
 /**
  * Live SQLite client for the chat-MVP persistence layer. Resolves the DB
  * file path against `AppPaths.userData` (provided by the host shim — Electron
- * today, WS server tomorrow). Honors `FORKZERO_SQLITE_MEMORY=1` for tests
+ * today, WS server tomorrow). Honors `MEMOIZE_SQLITE_MEMORY=1` for tests
  * and isolated benches; otherwise the file lives at
- * `<userData>/forkzero.sqlite` so a user can `sqlite3` into it.
+ * `<userData>/memoize.sqlite` so a user can `sqlite3` into it.
  *
  * `SqliteClient.layer` produces both `SqliteClient` (sqlite-specific:
  * `export`, `backup`, `loadExtension`) and the generic `SqlClient` —
@@ -19,9 +19,9 @@ export const SqliteLive = Layer.unwrapEffect(
   Effect.gen(function* () {
     const paths = yield* AppPaths;
     const filename =
-      process.env.FORKZERO_SQLITE_MEMORY === "1"
+      process.env.MEMOIZE_SQLITE_MEMORY === "1"
         ? ":memory:"
-        : join(paths.userData, "forkzero.sqlite");
+        : join(paths.userData, "memoize.sqlite");
     return SqliteClient.layer({ filename });
   }),
 );

--- a/apps/server/src/ping/handlers.ts
+++ b/apps/server/src/ping/handlers.ts
@@ -1,4 +1,4 @@
-import { ForkzeroRpcs, PingResult } from "@forkzero/wire";
+import { MemoizeRpcs, PingResult } from "@memoize/wire";
 import { Effect, Layer } from "effect";
 
 /**
@@ -8,7 +8,7 @@ import { Effect, Layer } from "effect";
  * Each domain registers handlers per-method via `toLayerHandler` so domains
  * compose without one needing to know about every other RPC in the group.
  */
-const PingPing = ForkzeroRpcs.toLayerHandler("ping.ping", () =>
+const PingPing = MemoizeRpcs.toLayerHandler("ping.ping", () =>
   Effect.succeed(PingResult.make({ message: "pong", receivedAt: new Date() })),
 );
 

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -3,7 +3,7 @@ import { Duration, Effect, Stream } from "effect";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
-import { AgentAvailability, type ProviderId } from "@forkzero/wire";
+import { AgentAvailability, type ProviderId } from "@memoize/wire";
 
 interface ProviderProbe {
   readonly providerId: ProviderId;

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -24,7 +24,7 @@ import {
   type StartSessionInput,
   type UserQuestion,
   type UserQuestionAnswer,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 
@@ -70,13 +70,13 @@ const toSdkPermissionMode = (mode: PermissionMode): SdkPermissionMode =>
 /**
  * Name we register the in-process AskUserQuestion tool under. The SDK
  * exposes MCP tools to the model as `mcp__<server>__<tool>`, so the
- * model sees `mcp__forkzero__ask_user_question` and the translator
+ * model sees `mcp__memoize__ask_user_question` and the translator
  * matches on that exact prefix to emit `UserQuestion` instead of a
  * generic `ToolUse`.
  */
-const FORKZERO_MCP_NAME = "forkzero";
+const MEMOIZE_MCP_NAME = "memoize";
 const ASK_USER_QUESTION_TOOL = "ask_user_question";
-const ASK_USER_QUESTION_FQN = `mcp__${FORKZERO_MCP_NAME}__${ASK_USER_QUESTION_TOOL}`;
+const ASK_USER_QUESTION_FQN = `mcp__${MEMOIZE_MCP_NAME}__${ASK_USER_QUESTION_TOOL}`;
 
 /**
  * Anthropic accepts these media types as image content blocks. Anything else
@@ -185,7 +185,7 @@ let itemCounter = 0;
 const nextItemId = (): AgentItemId =>
   `i_${Date.now()}_${++itemCounter}` as AgentItemId;
 
-// Markers Claude Code injects into every subprocess it spawns. If forkzero
+// Markers Claude Code injects into every subprocess it spawns. If memoize
 // is launched from a Claude Code terminal these get inherited, and the
 // nested `claude` binary then loads a different parent's session state
 // instead of the user's `claude /login` OAuth. Strip them so our spawn
@@ -295,12 +295,12 @@ const extractTextFromContent = (content: unknown): string => {
   return "";
 };
 
-// Off by default; enable with FORKZERO_DEBUG_THINKING=1 when diagnosing
+// Off by default; enable with MEMOIZE_DEBUG_THINKING=1 when diagnosing
 // thinking-block delivery. One JSON object per line so terminal
 // scrollback / `grep` / `tee logfile` all preserve every field — Node's
 // default util.inspect spans multiple lines and gets chopped by
 // line-oriented tools.
-const THINKING_DEBUG = process.env.FORKZERO_DEBUG_THINKING === "1";
+const THINKING_DEBUG = process.env.MEMOIZE_DEBUG_THINKING === "1";
 const tlog = (event: string, payload: Record<string, unknown> = {}): void => {
   if (!THINKING_DEBUG) return;
   let line: string;
@@ -785,7 +785,7 @@ const editPathOf = (toolInput: Record<string, unknown>): string =>
 /**
  * Match every "ask the user a question" surface we know about. The
  * Claude SDK has a built-in `AskUserQuestion` tool (PascalCase) that
- * the model can call; we register our own `mcp__forkzero__ask_user_question`
+ * the model can call; we register our own `mcp__memoize__ask_user_question`
  * to drive a renderer card. Either form should bypass the permission
  * toast — asking permission to ask a question is double-prompting.
  *
@@ -1013,7 +1013,7 @@ export const startClaudeSession = (
 
     // Pass `process.env` through, but scrub any "we are inside another
     // Claude Code session" markers that Claude Code injects into its child
-    // shells. When forkzero is launched from a Claude Code terminal (very
+    // shells. When memoize is launched from a Claude Code terminal (very
     // common during dev), the shell inherits CLAUDECODE=1,
     // CLAUDE_CODE_ENTRYPOINT, CLAUDE_CODE_EXECPATH, and friends — which
     // confuses the spawned `claude` binary's auth resolver into thinking
@@ -1130,8 +1130,8 @@ export const startClaudeSession = (
       { alwaysLoad: true },
     );
 
-    const forkzeroMcpServer = createSdkMcpServer({
-      name: FORKZERO_MCP_NAME,
+    const memoizeMcpServer = createSdkMcpServer({
+      name: MEMOIZE_MCP_NAME,
       tools: [askUserQuestionToolDefinition],
       alwaysLoad: !(input.toolSearch ?? false),
     });
@@ -1181,10 +1181,10 @@ export const startClaudeSession = (
               (t) => !subagentOptions.allowedTools!.includes(t),
             )),
       ],
-      mcpServers: { [FORKZERO_MCP_NAME]: forkzeroMcpServer },
+      mcpServers: { [MEMOIZE_MCP_NAME]: memoizeMcpServer },
       permissionMode: toSdkPermissionMode(initialPermissionMode),
       // Trim the SDK's stock plan-mode body to nudge the agent toward
-      // forkzero's two structured-interaction tools. The SDK still wraps
+      // memoize's two structured-interaction tools. The SDK still wraps
       // this with its read-only enforcement preamble + ExitPlanMode
       // protocol footer.
       planModeInstructions: [

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -15,7 +15,7 @@ import {
   type PermissionMode,
   type StartSessionInput,
   type UserQuestionAnswer,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 /**
  * Live-only handle for one Codex SDK conversation. Mirrors `ClaudeSessionHandle`
@@ -224,7 +224,7 @@ export const startCodexSession = (
         workingDirectory: cwd,
         // Codex SDK exposes `approvalPolicy` but no callback — when set to
         // anything other than "never" it routes prompts to its own stdio,
-        // which we can't bridge to forkzero's toast. Stay on "never" until
+        // which we can't bridge to memoize's toast. Stay on "never" until
         // the SDK exposes a programmatic hook; Claude is the primary
         // permission path in Phase 4.
         sandboxMode: "read-only",

--- a/apps/server/src/provider/drivers/index.ts
+++ b/apps/server/src/provider/drivers/index.ts
@@ -8,7 +8,7 @@ import type {
   AgentTurnId,
   ProviderId,
   StartSessionInput,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import type { ProviderAdapterError } from "../errors.ts";
 

--- a/apps/server/src/provider/errors.ts
+++ b/apps/server/src/provider/errors.ts
@@ -2,7 +2,7 @@ import { Data } from "effect";
 
 /**
  * Server-internal errors for the provider domain. These never cross the wire
- * — wire-facing errors live in `@forkzero/wire`'s `agent.ts`. Each public
+ * — wire-facing errors live in `@memoize/wire`'s `agent.ts`. Each public
  * service method maps these to a wire error before failing.
  */
 

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -1,4 +1,4 @@
-import { CredentialStoreError, ForkzeroRpcs, type ProviderId } from "@forkzero/wire";
+import { CredentialStoreError, MemoizeRpcs, type ProviderId } from "@memoize/wire";
 import { Effect, Layer, Stream } from "effect";
 
 import { MessageStore } from "./services/message-store.ts";
@@ -7,17 +7,17 @@ import { ProviderService } from "./services/provider-service.ts";
 
 /**
  * Provider-domain RPC handlers. Each subsequent PR adds a `toLayerHandler`
- * here as it registers its RPC into `ForkzeroRpcs` (in `@forkzero/wire`):
+ * here as it registers its RPC into `MemoizeRpcs` (in `@memoize/wire`):
  *
  *   PR 3 — `agent.availability`         ← here
  *   PR 4 — `agent.setCredential`        ← here
  *   PR 5/6 — `agent.start` / `send` / `interrupt` / `close` / `events`
  */
-const Availability = ForkzeroRpcs.toLayerHandler("agent.availability", () =>
+const Availability = MemoizeRpcs.toLayerHandler("agent.availability", () =>
   Effect.flatMap(ProviderService, (svc) => svc.availability()),
 );
 
-const SetCredential = ForkzeroRpcs.toLayerHandler(
+const SetCredential = MemoizeRpcs.toLayerHandler(
   "agent.setCredential",
   ({ providerId, apiKey }) =>
     Effect.flatMap(ProviderService, (svc) =>
@@ -34,25 +34,25 @@ const SetCredential = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const Start = ForkzeroRpcs.toLayerHandler("agent.start", (input) =>
+const Start = MemoizeRpcs.toLayerHandler("agent.start", (input) =>
   Effect.flatMap(ProviderService, (svc) => svc.start(input)),
 );
 
-const Send = ForkzeroRpcs.toLayerHandler("agent.send", ({ sessionId, text }) =>
+const Send = MemoizeRpcs.toLayerHandler("agent.send", ({ sessionId, text }) =>
   Effect.flatMap(ProviderService, (svc) => svc.send(sessionId, text)),
 );
 
-const Interrupt = ForkzeroRpcs.toLayerHandler(
+const Interrupt = MemoizeRpcs.toLayerHandler(
   "agent.interrupt",
   ({ sessionId, turnId }) =>
     Effect.flatMap(ProviderService, (svc) => svc.interrupt(sessionId, turnId)),
 );
 
-const Close = ForkzeroRpcs.toLayerHandler("agent.close", ({ sessionId }) =>
+const Close = MemoizeRpcs.toLayerHandler("agent.close", ({ sessionId }) =>
   Effect.flatMap(ProviderService, (svc) => svc.close(sessionId)),
 );
 
-const Events = ForkzeroRpcs.toLayerHandler("agent.events", ({ sessionId }) =>
+const Events = MemoizeRpcs.toLayerHandler("agent.events", ({ sessionId }) =>
   Stream.unwrap(
     Effect.map(ProviderService, (svc) => svc.events(sessionId)),
   ),
@@ -64,7 +64,7 @@ const Events = ForkzeroRpcs.toLayerHandler("agent.events", ({ sessionId }) =>
 // store composes them and they're useful for low-level testing).
 // ---------------------------------------------------------------------------
 
-const SessionList = ForkzeroRpcs.toLayerHandler(
+const SessionList = MemoizeRpcs.toLayerHandler(
   "session.list",
   ({ projectId, includeArchived }) =>
     Effect.flatMap(MessageStore, (svc) =>
@@ -72,13 +72,13 @@ const SessionList = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const SessionGet = ForkzeroRpcs.toLayerHandler(
+const SessionGet = MemoizeRpcs.toLayerHandler(
   "session.get",
   ({ sessionId }) =>
     Effect.flatMap(MessageStore, (svc) => svc.getSession(sessionId)),
 );
 
-const SessionCreate = ForkzeroRpcs.toLayerHandler("session.create", (input) =>
+const SessionCreate = MemoizeRpcs.toLayerHandler("session.create", (input) =>
   Effect.flatMap(MessageStore, (svc) =>
     svc.createSession({
       projectId: input.projectId,
@@ -96,43 +96,43 @@ const SessionCreate = ForkzeroRpcs.toLayerHandler("session.create", (input) =>
   ),
 );
 
-const SessionRename = ForkzeroRpcs.toLayerHandler(
+const SessionRename = MemoizeRpcs.toLayerHandler(
   "session.rename",
   ({ sessionId, title }) =>
     Effect.flatMap(MessageStore, (svc) => svc.renameSession(sessionId, title)),
 );
 
-const SessionSetModel = ForkzeroRpcs.toLayerHandler(
+const SessionSetModel = MemoizeRpcs.toLayerHandler(
   "session.setModel",
   ({ sessionId, model }) =>
     Effect.flatMap(MessageStore, (svc) => svc.setModel(sessionId, model)),
 );
 
-const SessionArchive = ForkzeroRpcs.toLayerHandler(
+const SessionArchive = MemoizeRpcs.toLayerHandler(
   "session.archive",
   ({ sessionId }) =>
     Effect.flatMap(MessageStore, (svc) => svc.archiveSession(sessionId)),
 );
 
-const SessionUnarchive = ForkzeroRpcs.toLayerHandler(
+const SessionUnarchive = MemoizeRpcs.toLayerHandler(
   "session.unarchive",
   ({ sessionId }) =>
     Effect.flatMap(MessageStore, (svc) => svc.unarchiveSession(sessionId)),
 );
 
-const SessionDelete = ForkzeroRpcs.toLayerHandler(
+const SessionDelete = MemoizeRpcs.toLayerHandler(
   "session.delete",
   ({ sessionId }) =>
     Effect.flatMap(MessageStore, (svc) => svc.deleteSession(sessionId)),
 );
 
-const SessionResume = ForkzeroRpcs.toLayerHandler(
+const SessionResume = MemoizeRpcs.toLayerHandler(
   "session.resume",
   ({ sessionId }) =>
     Effect.flatMap(MessageStore, (svc) => svc.resumeSession(sessionId)),
 );
 
-const SessionSetRuntimeMode = ForkzeroRpcs.toLayerHandler(
+const SessionSetRuntimeMode = MemoizeRpcs.toLayerHandler(
   "session.setRuntimeMode",
   ({ sessionId, runtimeMode }) =>
     Effect.flatMap(MessageStore, (svc) =>
@@ -140,7 +140,7 @@ const SessionSetRuntimeMode = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const SessionSetPermissionMode = ForkzeroRpcs.toLayerHandler(
+const SessionSetPermissionMode = MemoizeRpcs.toLayerHandler(
   "session.setPermissionMode",
   ({ sessionId, mode }) =>
     Effect.flatMap(MessageStore, (svc) =>
@@ -148,19 +148,19 @@ const SessionSetPermissionMode = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const SessionAnswerQuestion = ForkzeroRpcs.toLayerHandler(
+const SessionAnswerQuestion = MemoizeRpcs.toLayerHandler(
   "session.answerQuestion",
   ({ sessionId, itemId, answers }) =>
     Effect.flatMap(MessageStore, (svc) =>
       svc.answerQuestion(
         sessionId,
-        itemId as import("@forkzero/wire").AgentItemId,
+        itemId as import("@memoize/wire").AgentItemId,
         answers,
       ),
     ),
 );
 
-const SessionSetWorktree = ForkzeroRpcs.toLayerHandler(
+const SessionSetWorktree = MemoizeRpcs.toLayerHandler(
   "session.setWorktree",
   ({ sessionId, worktreeId }) =>
     Effect.flatMap(MessageStore, (svc) =>
@@ -168,13 +168,13 @@ const SessionSetWorktree = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const MessagesList = ForkzeroRpcs.toLayerHandler(
+const MessagesList = MemoizeRpcs.toLayerHandler(
   "messages.list",
   ({ sessionId }) =>
     Effect.flatMap(MessageStore, (svc) => svc.listMessages(sessionId)),
 );
 
-const MessagesStream = ForkzeroRpcs.toLayerHandler(
+const MessagesStream = MemoizeRpcs.toLayerHandler(
   "messages.stream",
   ({ sessionId }) =>
     Stream.unwrap(
@@ -182,7 +182,7 @@ const MessagesStream = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const SessionStreamStatus = ForkzeroRpcs.toLayerHandler(
+const SessionStreamStatus = MemoizeRpcs.toLayerHandler(
   "session.streamStatus",
   ({ sessionId }) =>
     Stream.unwrap(
@@ -190,7 +190,7 @@ const SessionStreamStatus = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const MessagesSend = ForkzeroRpcs.toLayerHandler(
+const MessagesSend = MemoizeRpcs.toLayerHandler(
   "messages.send",
   ({ sessionId, text, input }) => {
     console.log(
@@ -217,7 +217,7 @@ const MessagesSend = ForkzeroRpcs.toLayerHandler(
   },
 );
 
-const MessagesInterrupt = ForkzeroRpcs.toLayerHandler(
+const MessagesInterrupt = MemoizeRpcs.toLayerHandler(
   "messages.interrupt",
   ({ sessionId }) =>
     Effect.flatMap(MessageStore, (svc) => svc.interruptSession(sessionId)),
@@ -229,25 +229,25 @@ const MessagesInterrupt = ForkzeroRpcs.toLayerHandler(
 // `listPending` is the cold-load helper used on session mount.
 // ---------------------------------------------------------------------------
 
-const PermissionRequests = ForkzeroRpcs.toLayerHandler(
+const PermissionRequests = MemoizeRpcs.toLayerHandler(
   "permission.requests",
   () =>
     Stream.unwrap(Effect.map(PermissionService, (svc) => svc.requests())),
 );
 
-const PermissionDecide = ForkzeroRpcs.toLayerHandler(
+const PermissionDecide = MemoizeRpcs.toLayerHandler(
   "permission.decide",
   ({ requestId, decision }) =>
     Effect.flatMap(PermissionService, (svc) => svc.decide(requestId, decision)),
 );
 
-const PermissionListPending = ForkzeroRpcs.toLayerHandler(
+const PermissionListPending = MemoizeRpcs.toLayerHandler(
   "permission.listPending",
   ({ sessionId }) =>
     Effect.flatMap(PermissionService, (svc) => svc.listPending(sessionId)),
 );
 
-const PermissionListDecisions = ForkzeroRpcs.toLayerHandler(
+const PermissionListDecisions = MemoizeRpcs.toLayerHandler(
   "permission.listDecisions",
   ({ projectId }) =>
     Effect.flatMap(PermissionService, (svc) =>
@@ -255,7 +255,7 @@ const PermissionListDecisions = ForkzeroRpcs.toLayerHandler(
     ),
 );
 
-const PermissionRevokeDecision = ForkzeroRpcs.toLayerHandler(
+const PermissionRevokeDecision = MemoizeRpcs.toLayerHandler(
   "permission.revokeDecision",
   ({ requestId }) =>
     Effect.flatMap(PermissionService, (svc) => svc.revokeDecision(requestId)),

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -1,16 +1,16 @@
 import keytar from "keytar";
 import { Effect, Layer } from "effect";
 
-import { type ProviderId } from "@forkzero/wire";
+import { type ProviderId } from "@memoize/wire";
 
 import { CredentialsError } from "../errors.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
 
-const SERVICE_NAME = "forkzero";
+const SERVICE_NAME = "memoize";
 
 /**
  * Keychain entries are namespaced as `apiKey:<providerId>` under the
- * `forkzero` service. Listing uses `findCredentials(SERVICE_NAME)` and filters
+ * `memoize` service. Listing uses `findCredentials(SERVICE_NAME)` and filters
  * to the `apiKey:` prefix — keeps room for future credential kinds (refresh
  * tokens, OAuth state) without colliding with API keys.
  */

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -30,7 +30,7 @@ import {
   SessionStartError,
   type SkillRef,
   type WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { WorktreeService } from "../../worktree/services/worktree-service.ts";
 

--- a/apps/server/src/provider/layers/permission-service.ts
+++ b/apps/server/src/provider/layers/permission-service.ts
@@ -9,7 +9,7 @@ import {
   type FolderId,
   type PermissionDecision,
   type SessionId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import {
   PermissionService,

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -12,7 +12,7 @@ import {
   type PermissionDecision,
   type PermissionKind,
   type ProviderId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { probeAllProviders, resolveCliPath } from "../availability.ts";
 import {

--- a/apps/server/src/provider/services/credentials-service.ts
+++ b/apps/server/src/provider/services/credentials-service.ts
@@ -1,6 +1,6 @@
 import { Context, type Effect } from "effect";
 
-import type { ProviderId } from "@forkzero/wire";
+import type { ProviderId } from "@memoize/wire";
 
 import type { CredentialsError } from "../errors.ts";
 
@@ -30,5 +30,5 @@ export interface CredentialsServiceShape {
 }
 
 export class CredentialsService extends Context.Tag(
-  "forkzero/CredentialsService",
+  "memoize/CredentialsService",
 )<CredentialsService, CredentialsServiceShape>() {}

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -19,7 +19,7 @@ import type {
   SkillRef,
   UserQuestionAnswer,
   WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 /**
  * Persistence-backed orchestration of chat sessions and their message log.
@@ -193,7 +193,7 @@ export interface MessageStoreShape {
   ) => Effect.Effect<void, SessionNotFoundError>;
 }
 
-export class MessageStore extends Context.Tag("forkzero/MessageStore")<
+export class MessageStore extends Context.Tag("memoize/MessageStore")<
   MessageStore,
   MessageStoreShape
 >() {}

--- a/apps/server/src/provider/services/permission-service.ts
+++ b/apps/server/src/provider/services/permission-service.ts
@@ -8,7 +8,7 @@ import type {
   PermissionRequestNotFoundError,
   SavedDecision,
   SessionId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 /**
  * Bridge between provider drivers (which call `request` from inside their
@@ -70,5 +70,5 @@ export interface PermissionServiceShape {
 }
 
 export class PermissionService extends Context.Tag(
-  "forkzero/PermissionService",
+  "memoize/PermissionService",
 )<PermissionService, PermissionServiceShape>() {}

--- a/apps/server/src/provider/services/provider-adapter.ts
+++ b/apps/server/src/provider/services/provider-adapter.ts
@@ -8,7 +8,7 @@ import type {
   AgentTurnId,
   ProviderId,
   StartSessionInput,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import type { ProviderAdapterError } from "../errors.ts";
 
@@ -43,7 +43,7 @@ export interface ProviderAdapterShape {
   ) => Effect.Effect<void, AgentSessionNotFoundError>;
 }
 
-export class ProviderAdapter extends Context.Tag("forkzero/ProviderAdapter")<
+export class ProviderAdapter extends Context.Tag("memoize/ProviderAdapter")<
   ProviderAdapter,
   ProviderAdapterShape
 >() {}

--- a/apps/server/src/provider/services/provider-registry.ts
+++ b/apps/server/src/provider/services/provider-registry.ts
@@ -1,6 +1,6 @@
 import { Context, type Effect } from "effect";
 
-import type { ProviderId } from "@forkzero/wire";
+import type { ProviderId } from "@memoize/wire";
 
 import type { ProviderRegistryError } from "../errors.ts";
 import type { ProviderAdapterShape } from "./provider-adapter.ts";
@@ -18,7 +18,7 @@ export interface ProviderRegistryShape {
   readonly list: () => Effect.Effect<ReadonlyArray<ProviderAdapterShape>>;
 }
 
-export class ProviderRegistry extends Context.Tag("forkzero/ProviderRegistry")<
+export class ProviderRegistry extends Context.Tag("memoize/ProviderRegistry")<
   ProviderRegistry,
   ProviderRegistryShape
 >() {}

--- a/apps/server/src/provider/services/provider-service.ts
+++ b/apps/server/src/provider/services/provider-service.ts
@@ -15,7 +15,7 @@ import type {
   RuntimeMode,
   StartSessionInput,
   UserQuestionAnswer,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import type { CredentialsError } from "../errors.ts";
 
@@ -88,7 +88,7 @@ export interface ProviderServiceShape {
   ) => Effect.Effect<void, AgentSessionNotFoundError>;
 }
 
-export class ProviderService extends Context.Tag("forkzero/ProviderService")<
+export class ProviderService extends Context.Tag("memoize/ProviderService")<
   ProviderService,
   ProviderServiceShape
 >() {}

--- a/apps/server/src/pty/handlers.ts
+++ b/apps/server/src/pty/handlers.ts
@@ -1,29 +1,29 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer, Stream } from "effect";
 
 import { PtyService } from "./services/pty-service.ts";
 
-const Open = ForkzeroRpcs.toLayerHandler(
+const Open = MemoizeRpcs.toLayerHandler(
   "pty.open",
   ({ cwd, cols, rows, command }) =>
     Effect.flatMap(PtyService, (svc) => svc.open(cwd, cols, rows, command)),
 );
 
-const Write = ForkzeroRpcs.toLayerHandler("pty.write", ({ ptyId, data }) =>
+const Write = MemoizeRpcs.toLayerHandler("pty.write", ({ ptyId, data }) =>
   Effect.flatMap(PtyService, (svc) => svc.write(ptyId, data)),
 );
 
-const Resize = ForkzeroRpcs.toLayerHandler(
+const Resize = MemoizeRpcs.toLayerHandler(
   "pty.resize",
   ({ ptyId, cols, rows }) =>
     Effect.flatMap(PtyService, (svc) => svc.resize(ptyId, cols, rows)),
 );
 
-const Close = ForkzeroRpcs.toLayerHandler("pty.close", ({ ptyId }) =>
+const Close = MemoizeRpcs.toLayerHandler("pty.close", ({ ptyId }) =>
   Effect.flatMap(PtyService, (svc) => svc.close(ptyId)),
 );
 
-const Output = ForkzeroRpcs.toLayerHandler("pty.output", ({ ptyId }) =>
+const Output = MemoizeRpcs.toLayerHandler("pty.output", ({ ptyId }) =>
   Stream.unwrap(Effect.map(PtyService, (svc) => svc.subscribe(ptyId))),
 );
 

--- a/apps/server/src/pty/layers/pty-service.ts
+++ b/apps/server/src/pty/layers/pty-service.ts
@@ -8,7 +8,7 @@ import {
   PtyNotFoundError,
   PtySpawnError,
   type PtyEvent,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { PtyService } from "../services/pty-service.ts";
 

--- a/apps/server/src/pty/services/pty-service.ts
+++ b/apps/server/src/pty/services/pty-service.ts
@@ -6,7 +6,7 @@ import {
   type PtyId,
   type PtyNotFoundError,
   type PtySpawnError,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 export interface PtyServiceShape {
   readonly open: (
@@ -32,7 +32,7 @@ export interface PtyServiceShape {
   ) => Stream.Stream<typeof PtyEvent.Type, PtyNotFoundError>;
 }
 
-export class PtyService extends Context.Tag("forkzero/PtyService")<
+export class PtyService extends Context.Tag("memoize/PtyService")<
   PtyService,
   PtyServiceShape
 >() {}

--- a/apps/server/src/repository-settings/handlers.ts
+++ b/apps/server/src/repository-settings/handlers.ts
@@ -1,15 +1,15 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer } from "effect";
 
 import { RepositorySettingsService } from "./services/repository-settings-service.ts";
 
-const Get = ForkzeroRpcs.toLayerHandler(
+const Get = MemoizeRpcs.toLayerHandler(
   "repositorySettings.get",
   ({ projectId }) =>
     Effect.flatMap(RepositorySettingsService, (svc) => svc.get(projectId)),
 );
 
-const Update = ForkzeroRpcs.toLayerHandler(
+const Update = MemoizeRpcs.toLayerHandler(
   "repositorySettings.update",
   ({ projectId, patch }) =>
     Effect.flatMap(RepositorySettingsService, (svc) =>

--- a/apps/server/src/repository-settings/layers/repository-settings-service.ts
+++ b/apps/server/src/repository-settings/layers/repository-settings-service.ts
@@ -6,7 +6,7 @@ import {
   type ProviderId,
   RepositorySettings,
   type RuntimeMode,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { RepositorySettingsService } from "../services/repository-settings-service.ts";
 

--- a/apps/server/src/repository-settings/services/repository-settings-service.ts
+++ b/apps/server/src/repository-settings/services/repository-settings-service.ts
@@ -4,7 +4,7 @@ import {
   type FolderId,
   type RepositorySettings,
   type RepositorySettingsPatch,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 export interface RepositorySettingsServiceShape {
   /**
@@ -27,5 +27,5 @@ export interface RepositorySettingsServiceShape {
 }
 
 export class RepositorySettingsService extends Context.Tag(
-  "forkzero/RepositorySettingsService",
+  "memoize/RepositorySettingsService",
 )<RepositorySettingsService, RepositorySettingsServiceShape>() {}

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -2,7 +2,7 @@ import { NodeContext } from "@effect/platform-node";
 import { RpcServer } from "@effect/rpc";
 import { Layer } from "effect";
 
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 
 import { AppPaths } from "./app-paths.ts";
 import { AttachmentServiceLive } from "./attachment/layers/attachment-service.ts";
@@ -32,7 +32,7 @@ import { WorktreeServiceLive } from "./worktree/layers/worktree-service.ts";
  * UI-toolkit-specific. See ADR 0007 for the rules that make WS extraction
  * cheap later.
  *
- * - `userData`: where persistence files (forkzero.sqlite, OS keychain) live.
+ * - `userData`: where persistence files (memoize.sqlite, OS keychain) live.
  *   Electron resolves this from `app.getPath("userData")`; a headless
  *   server resolves it from `XDG_DATA_HOME` or a CLI flag.
  * - `folderPicker`: a callback returning the user-chosen path. Electron
@@ -80,7 +80,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(NodeContext.layer),
   );
 
-  // WorktreeService manages forkzero-owned `git worktree` checkouts. Same
+  // WorktreeService manages memoize-owned `git worktree` checkouts. Same
   // shape as GitLayer + the SqlClient for persisting the rows.
   const WorktreeLayer = WorktreeServiceLive.pipe(
     Layer.provide(WorkspaceLayer),
@@ -199,7 +199,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(FolderPickerLayer),
   );
 
-  const ServerLayer = RpcServer.layer(ForkzeroRpcs).pipe(
+  const ServerLayer = RpcServer.layer(MemoizeRpcs).pipe(
     Layer.provide(Handlers),
     Layer.provide(deps.serverProtocol),
   );

--- a/apps/server/src/skill/handlers.ts
+++ b/apps/server/src/skill/handlers.ts
@@ -1,13 +1,13 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer, Stream } from "effect";
 
 import { SkillBridge } from "./services/skill-bridge.ts";
 
-const SkillList = ForkzeroRpcs.toLayerHandler("skill.list", ({ sessionId }) =>
+const SkillList = MemoizeRpcs.toLayerHandler("skill.list", ({ sessionId }) =>
   Effect.flatMap(SkillBridge, (svc) => svc.list(sessionId)),
 );
 
-const SkillStream = ForkzeroRpcs.toLayerHandler(
+const SkillStream = MemoizeRpcs.toLayerHandler(
   "skill.stream",
   ({ sessionId }) =>
     Stream.unwrap(

--- a/apps/server/src/skill/layers/skill-bridge.ts
+++ b/apps/server/src/skill/layers/skill-bridge.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 
 import { Effect, Layer, PubSub, Stream } from "effect";
 
-import type { ProviderId, Skill } from "@forkzero/wire";
+import type { ProviderId, Skill } from "@memoize/wire";
 
 import { MessageStore } from "../../provider/services/message-store.ts";
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";

--- a/apps/server/src/skill/layers/skill-discovery.ts
+++ b/apps/server/src/skill/layers/skill-discovery.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { FileSystem } from "@effect/platform";
 import { Effect, Layer } from "effect";
 
-import { Skill, type ProviderId } from "@forkzero/wire";
+import { Skill, type ProviderId } from "@memoize/wire";
 
 import { SkillDiscoveryService } from "../services/skill-discovery.ts";
 
@@ -17,7 +17,7 @@ interface RawSkill {
 
 /**
  * Parse YAML-like frontmatter at the top of a SKILL.md / prompt file.
- * Forkzero only needs `name`, `description`, and `argument-hint`; we
+ * Memoize only needs `name`, `description`, and `argument-hint`; we
  * deliberately keep the parser minimal — full YAML support belongs in
  * the provider, not here. Anything we don't recognise is ignored.
  */

--- a/apps/server/src/skill/services/skill-bridge.ts
+++ b/apps/server/src/skill/services/skill-bridge.ts
@@ -4,7 +4,7 @@ import type {
   SessionId,
   SessionNotFoundError,
   Skill,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 /**
  * Per-session skill listing, plus a live feed that re-emits the full list
@@ -21,7 +21,7 @@ export interface SkillBridgeShape {
   ) => Stream.Stream<ReadonlyArray<Skill>, SessionNotFoundError>;
 }
 
-export class SkillBridge extends Context.Tag("forkzero/SkillBridge")<
+export class SkillBridge extends Context.Tag("memoize/SkillBridge")<
   SkillBridge,
   SkillBridgeShape
 >() {}

--- a/apps/server/src/skill/services/skill-discovery.ts
+++ b/apps/server/src/skill/services/skill-discovery.ts
@@ -1,6 +1,6 @@
 import { Context, type Effect } from "effect";
 
-import type { ProviderId, Skill } from "@forkzero/wire";
+import type { ProviderId, Skill } from "@memoize/wire";
 
 /**
  * Per-provider skill discovery on disk.
@@ -22,5 +22,5 @@ export interface SkillDiscoveryServiceShape {
 }
 
 export class SkillDiscoveryService extends Context.Tag(
-  "forkzero/SkillDiscoveryService",
+  "memoize/SkillDiscoveryService",
 )<SkillDiscoveryService, SkillDiscoveryServiceShape>() {}

--- a/apps/server/src/workspace/handlers.ts
+++ b/apps/server/src/workspace/handlers.ts
@@ -1,19 +1,19 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer } from "effect";
 
 import { FileSearchService } from "./services/file-search.ts";
 import { FolderPicker } from "./services/folder-picker.ts";
 import { WorkspaceService } from "./services/workspace-service.ts";
 
-const Add = ForkzeroRpcs.toLayerHandler("workspace.add", ({ path }) =>
+const Add = MemoizeRpcs.toLayerHandler("workspace.add", ({ path }) =>
   Effect.flatMap(WorkspaceService, (ws) => ws.add(path)),
 );
 
-const List = ForkzeroRpcs.toLayerHandler("workspace.list", () =>
+const List = MemoizeRpcs.toLayerHandler("workspace.list", () =>
   Effect.flatMap(WorkspaceService, (ws) => ws.list()),
 );
 
-const Remove = ForkzeroRpcs.toLayerHandler(
+const Remove = MemoizeRpcs.toLayerHandler(
   "workspace.remove",
   ({ folderId }) =>
     Effect.flatMap(WorkspaceService, (ws) => ws.remove(folderId)),
@@ -22,21 +22,21 @@ const Remove = ForkzeroRpcs.toLayerHandler(
 // Folder picking is a host-shell operation. The server only knows the tag —
 // the Electron shim (or any other host) provides the live impl. Keeps this
 // handler — and apps/server as a whole — free of UI-toolkit imports.
-const PickFolder = ForkzeroRpcs.toLayerHandler("workspace.pickFolder", () =>
+const PickFolder = MemoizeRpcs.toLayerHandler("workspace.pickFolder", () =>
   Effect.flatMap(FolderPicker, (picker) => picker.pick()),
 );
 
-const GetSelected = ForkzeroRpcs.toLayerHandler("workspace.getSelected", () =>
+const GetSelected = MemoizeRpcs.toLayerHandler("workspace.getSelected", () =>
   Effect.flatMap(WorkspaceService, (ws) => ws.getSelected()),
 );
 
-const SetSelected = ForkzeroRpcs.toLayerHandler(
+const SetSelected = MemoizeRpcs.toLayerHandler(
   "workspace.setSelected",
   ({ folderId }) =>
     Effect.flatMap(WorkspaceService, (ws) => ws.setSelected(folderId)),
 );
 
-const SearchFiles = ForkzeroRpcs.toLayerHandler(
+const SearchFiles = MemoizeRpcs.toLayerHandler(
   "workspace.searchFiles",
   ({ projectId, query, limit, worktreeId }) =>
     Effect.flatMap(FileSearchService, (svc) =>

--- a/apps/server/src/workspace/layers/file-search.ts
+++ b/apps/server/src/workspace/layers/file-search.ts
@@ -4,7 +4,7 @@ import { FileSystem, Path } from "@effect/platform";
 import { Effect, Layer } from "effect";
 import fuzzysort from "fuzzysort";
 
-import { FsFolderNotFoundError } from "@forkzero/wire";
+import { FsFolderNotFoundError } from "@memoize/wire";
 
 import { WorktreeService } from "../../worktree/services/worktree-service.ts";
 import {

--- a/apps/server/src/workspace/layers/workspace-service.ts
+++ b/apps/server/src/workspace/layers/workspace-service.ts
@@ -9,7 +9,7 @@ import {
   WorkspaceDuplicatePathError,
   WorkspaceInvalidPathError,
   WorkspaceNotFoundError,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { WorkspaceService } from "../services/workspace-service.ts";
 

--- a/apps/server/src/workspace/services/file-search.ts
+++ b/apps/server/src/workspace/services/file-search.ts
@@ -4,7 +4,7 @@ import {
   type FolderId,
   type FsFolderNotFoundError,
   type WorktreeId,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 export interface FileSearchHit {
   readonly relPath: string;
@@ -32,7 +32,7 @@ export interface FileSearchServiceShape {
   ) => Effect.Effect<ReadonlyArray<FileSearchHit>, FsFolderNotFoundError>;
 }
 
-export class FileSearchService extends Context.Tag("forkzero/FileSearchService")<
+export class FileSearchService extends Context.Tag("memoize/FileSearchService")<
   FileSearchService,
   FileSearchServiceShape
 >() {}

--- a/apps/server/src/workspace/services/folder-picker.ts
+++ b/apps/server/src/workspace/services/folder-picker.ts
@@ -8,7 +8,7 @@ import { Context, type Effect } from "effect";
  *
  * Returns the chosen absolute path, or null if the user cancelled.
  */
-export class FolderPicker extends Context.Tag("forkzero/FolderPicker")<
+export class FolderPicker extends Context.Tag("memoize/FolderPicker")<
   FolderPicker,
   {
     readonly pick: () => Effect.Effect<string | null>;

--- a/apps/server/src/workspace/services/workspace-service.ts
+++ b/apps/server/src/workspace/services/workspace-service.ts
@@ -6,7 +6,7 @@ import {
   type WorkspaceDuplicatePathError,
   type WorkspaceInvalidPathError,
   type WorkspaceNotFoundError,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 export interface WorkspaceServiceShape {
   readonly add: (
@@ -28,7 +28,7 @@ export interface WorkspaceServiceShape {
   ) => Effect.Effect<Folder | null>;
 }
 
-export class WorkspaceService extends Context.Tag("forkzero/WorkspaceService")<
+export class WorkspaceService extends Context.Tag("memoize/WorkspaceService")<
   WorkspaceService,
   WorkspaceServiceShape
 >() {}

--- a/apps/server/src/worktree/handlers.ts
+++ b/apps/server/src/worktree/handlers.ts
@@ -1,23 +1,23 @@
-import { ForkzeroRpcs } from "@forkzero/wire";
+import { MemoizeRpcs } from "@memoize/wire";
 import { Effect, Layer } from "effect";
 
 import { WorktreeService } from "./services/worktree-service.ts";
 
-const Create = ForkzeroRpcs.toLayerHandler(
+const Create = MemoizeRpcs.toLayerHandler(
   "worktree.create",
   ({ projectId }) =>
     Effect.flatMap(WorktreeService, (svc) => svc.create(projectId)),
 );
 
-const List = ForkzeroRpcs.toLayerHandler("worktree.list", ({ projectId }) =>
+const List = MemoizeRpcs.toLayerHandler("worktree.list", ({ projectId }) =>
   Effect.flatMap(WorktreeService, (svc) => svc.list(projectId)),
 );
 
-const Get = ForkzeroRpcs.toLayerHandler("worktree.get", ({ worktreeId }) =>
+const Get = MemoizeRpcs.toLayerHandler("worktree.get", ({ worktreeId }) =>
   Effect.flatMap(WorktreeService, (svc) => svc.get(worktreeId)),
 );
 
-const Remove = ForkzeroRpcs.toLayerHandler(
+const Remove = MemoizeRpcs.toLayerHandler(
   "worktree.remove",
   ({ worktreeId, force }) =>
     Effect.flatMap(WorktreeService, (svc) => svc.remove(worktreeId, force ?? false)),

--- a/apps/server/src/worktree/layers/worktree-service.ts
+++ b/apps/server/src/worktree/layers/worktree-service.ts
@@ -11,7 +11,7 @@ import {
   WorktreeId,
   WorktreeNotFoundError,
   WorktreeRemoveError,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
 import { generateCoolName } from "../cool-name.ts";
@@ -38,7 +38,7 @@ const rowToWorktree = (row: WorktreeRow): Worktree =>
     createdAt: new Date(row.created_at),
   });
 
-const EXCLUDE_LINE = ".forkzero/";
+const EXCLUDE_LINE = ".memoize/";
 
 export const WorktreeServiceLive = Layer.effect(
   WorktreeService,
@@ -92,9 +92,9 @@ export const WorktreeServiceLive = Layer.effect(
       );
 
     /**
-     * Append `.forkzero/` to the repo's `.git/info/exclude` if it isn't
+     * Append `.memoize/` to the repo's `.git/info/exclude` if it isn't
      * already there. Idempotent. We patch this on first worktree create so
-     * the in-repo `.forkzero/` tree doesn't show up as untracked, without
+     * the in-repo `.memoize/` tree doesn't show up as untracked, without
      * touching the user's `.gitignore`.
      */
     const ensureExclude = (repoPath: string) =>
@@ -158,10 +158,10 @@ export const WorktreeServiceLive = Layer.effect(
           );
         }
         const repoPath = folder.path;
-        // Layout: <repo>/.forkzero/<repo-name>/<branch>/. Grouping by repo
-        // name keeps `ls .forkzero/` legible when a project hosts many
+        // Layout: <repo>/.memoize/<repo-name>/<branch>/. Grouping by repo
+        // name keeps `ls .memoize/` legible when a project hosts many
         // worktrees ("branches of pangyo") instead of a generic bucket.
-        const baseDir = Path.join(repoPath, ".forkzero", folder.name);
+        const baseDir = Path.join(repoPath, ".memoize", folder.name);
 
         yield* ensureExclude(repoPath);
         yield* fs

--- a/apps/server/src/worktree/services/worktree-service.ts
+++ b/apps/server/src/worktree/services/worktree-service.ts
@@ -8,7 +8,7 @@ import {
   type WorktreeId,
   type WorktreeNotFoundError,
   type WorktreeRemoveError,
-} from "@forkzero/wire";
+} from "@memoize/wire";
 
 export interface WorktreeServiceShape {
   readonly create: (
@@ -29,7 +29,7 @@ export interface WorktreeServiceShape {
   >;
 }
 
-export class WorktreeService extends Context.Tag("forkzero/WorktreeService")<
+export class WorktreeService extends Context.Tag("memoize/WorktreeService")<
   WorktreeService,
   WorktreeServiceShape
 >() {}

--- a/bun.lock
+++ b/bun.lock
@@ -15,8 +15,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@effect/rpc": "catalog:",
-        "@forkzero/server": "*",
-        "@forkzero/wire": "*",
+        "@memoize/server": "*",
+        "@memoize/wire": "*",
         "better-sqlite3": "^12.9.0",
         "effect": "catalog:",
         "electron": "^33.2.0",
@@ -69,10 +69,10 @@
         "@effect/rpc": "catalog:",
         "@fontsource-variable/geist-mono": "^5.2.7",
         "@fontsource-variable/inter": "^5.2.8",
-        "@forkzero/wire": "*",
         "@hugeicons/core-free-icons": "^4.1.1",
         "@hugeicons/react": "^1.1.6",
         "@lezer/highlight": "^1.2.0",
+        "@memoize/wire": "*",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.1",
@@ -108,7 +108,7 @@
       },
     },
     "apps/server": {
-      "name": "@forkzero/server",
+      "name": "@memoize/server",
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.126",
@@ -117,7 +117,7 @@
         "@effect/rpc": "catalog:",
         "@effect/sql": "catalog:",
         "@effect/sql-sqlite-node": "catalog:",
-        "@forkzero/wire": "*",
+        "@memoize/wire": "*",
         "@openai/codex-sdk": "^0.128.0",
         "better-sqlite3": "^12.9.0",
         "effect": "catalog:",
@@ -171,7 +171,7 @@
       },
     },
     "packages/wire": {
-      "name": "@forkzero/wire",
+      "name": "@memoize/wire",
       "version": "0.0.0",
       "dependencies": {
         "@effect/rpc": "catalog:",
@@ -440,10 +440,6 @@
 
     "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "http://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
 
-    "@forkzero/server": ["@forkzero/server@workspace:apps/server"],
-
-    "@forkzero/wire": ["@forkzero/wire@workspace:packages/wire"],
-
     "@hono/node-server": ["@hono/node-server@1.19.14", "http://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.1.1", "http://registry.npmjs.org/@hugeicons/core-free-icons/-/core-free-icons-4.1.1.tgz", {}, "sha512-teqIBvPHl90ygIwKyJwTxOH8aNp1X1PjDTcMvLkEwdPxPD+8mssrZ5kXKIAJJFYPsz69a8LYQY0UPid4PAdavg=="],
@@ -557,6 +553,10 @@
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "http://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "http://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@memoize/server": ["@memoize/server@workspace:apps/server"],
+
+    "@memoize/wire": ["@memoize/wire@workspace:packages/wire"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "http://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "forkzero",
+  "name": "memoize",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@forkzero/wire",
+  "name": "@memoize/wire",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -442,7 +442,7 @@ export class CredentialStoreError extends Schema.TaggedError<CredentialStoreErro
 ) {}
 
 // ---------------------------------------------------------------------------
-// RPC definitions. Not yet registered in `ForkzeroRpcs` — handlers come
+// RPC definitions. Not yet registered in `MemoizeRpcs` — handlers come
 // online in PR 3 (availability), PR 4 (credentials), PR 5/6 (sessions). Each
 // of those PRs adds its RPC to the group when its handler exists.
 // ---------------------------------------------------------------------------

--- a/packages/wire/src/attachment.ts
+++ b/packages/wire/src/attachment.ts
@@ -23,7 +23,7 @@ export class AttachmentBadMimeError extends Schema.TaggedError<AttachmentBadMime
 /**
  * Upload an image attachment for a session. Bytes land under the desktop
  * app's userData directory; the returned id is what the renderer stores on
- * `ComposerInput.attachments` and renders via `forkzero://attachments/<id>`.
+ * `ComposerInput.attachments` and renders via `memoize://attachments/<id>`.
  */
 export const AttachmentUploadRpc = Rpc.make("attachments.upload", {
   payload: Schema.Struct({

--- a/packages/wire/src/composer.ts
+++ b/packages/wire/src/composer.ts
@@ -6,7 +6,7 @@ import { ProviderId } from "./agent.ts";
  * Reference to an uploaded attachment. The renderer carries this on
  * `ComposerInput` and on persisted user-rich messages; the actual bytes live
  * under the desktop app's userData directory and are served to the renderer
- * via the `forkzero://attachments/<id>` custom protocol.
+ * via the `memoize://attachments/<id>` custom protocol.
  *
  * `id` shape: `<sessionSegment>-<uuid>` (sanitised session id + v4 UUID).
  */
@@ -31,7 +31,7 @@ export type FileRef = typeof FileRef.Type;
 
 /**
  * Reference to a provider-defined skill the user invoked from the slash
- * popover. Forkzero never inlines the skill body; the driver expands it
+ * popover. Memoize never inlines the skill body; the driver expands it
  * provider-side so semantics match the underlying CLI.
  */
 export const SkillRef = Schema.Struct({

--- a/packages/wire/src/repository-settings.ts
+++ b/packages/wire/src/repository-settings.ts
@@ -25,7 +25,7 @@ export class RepositorySettings extends Schema.Class<RepositorySettings>(
   autoCreateWorktree: Schema.Boolean,
   /**
    * Optional override for the worktree base dir. `null` means
-   * `<repoPath>/.forkzero/repo-worktree/`.
+   * `<repoPath>/.memoize/repo-worktree/`.
    */
   worktreeBaseDir: Schema.NullOr(Schema.String),
 }) {}

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -84,7 +84,7 @@ import {
  *
  * Add new RPCs by importing them here and including them in the group.
  */
-export const ForkzeroRpcs = RpcGroup.make(
+export const MemoizeRpcs = RpcGroup.make(
   PingRpc,
   WorkspaceAddRpc,
   WorkspaceListRpc,
@@ -152,7 +152,7 @@ export const ForkzeroRpcs = RpcGroup.make(
   RepositorySettingsUpdateRpc,
   SessionSetWorktreeRpc,
 );
-export type ForkzeroRpcs = typeof ForkzeroRpcs;
+export type MemoizeRpcs = typeof MemoizeRpcs;
 
 /**
  * The Electron IPC channel name used to transport RPC frames in both
@@ -162,4 +162,4 @@ export type ForkzeroRpcs = typeof ForkzeroRpcs;
  * Renderer → main: `ipcRenderer.send(IPC_CHANNEL, frame)`
  * Main → renderer: `webContents.send(IPC_CHANNEL, frame)`
  */
-export const IPC_CHANNEL = "forkzero:rpc" as const;
+export const IPC_CHANNEL = "memoize:rpc" as const;

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -63,7 +63,7 @@ export type ResumeStrategy = typeof ResumeStrategy.Type;
 // `RuntimeMode` and `DEFAULT_RUNTIME_MODE` are defined in `agent.ts` so the
 // new `AgentDefinition.permissionMode` can reuse the same literal set
 // without an import cycle. Re-exported above for back-compat with the
-// existing `import { RuntimeMode } from "@forkzero/wire"` callers.
+// existing `import { RuntimeMode } from "@memoize/wire"` callers.
 
 export class Session extends Schema.Class<Session>("Session")({
   id: SessionId,

--- a/packages/wire/src/skill.ts
+++ b/packages/wire/src/skill.ts
@@ -5,7 +5,7 @@ import { ProviderId } from "./agent.ts";
 import { SessionId, SessionNotFoundError } from "./session.ts";
 
 /**
- * One skill discovered by a provider driver. Forkzero owns no skill format;
+ * One skill discovered by a provider driver. Memoize owns no skill format;
  * the driver normalises the underlying agent's parsed metadata into this
  * shape so the renderer is provider-agnostic.
  */

--- a/packages/wire/src/worktree.ts
+++ b/packages/wire/src/worktree.ts
@@ -4,9 +4,9 @@ import { Schema } from "effect";
 import { FolderId, WorktreeId } from "./ids.ts";
 
 /**
- * A git worktree owned by forkzero. Lives at `<repoPath>/.forkzero/repo-worktree/<name>/`
+ * A git worktree owned by memoize. Lives at `<repoPath>/.memoize/repo-worktree/<name>/`
  * by default; the user can override the base dir per-repo. Branch is always
- * `forkzero/<name>` so the `forkzero/` prefix lets users grep their git
+ * `memoize/<name>` so the `memoize/` prefix lets users grep their git
  * branch list cleanly.
  */
 export class Worktree extends Schema.Class<Worktree>("Worktree")({

--- a/specs/0.01-MVP/README.md
+++ b/specs/0.01-MVP/README.md
@@ -1,6 +1,6 @@
-# forkzero — specification
+# memoize — specification
 
-forkzero is a chat-first desktop app for working with coding agents (Claude Code, Codex). Three-pane layout: projects + sessions on the left, chat in the middle, files + terminal on the right. Sessions persist in SQLite. This directory holds the living specification: vision, architecture, phase roadmap, per-feature designs, and the architecture decision record.
+memoize is a chat-first desktop app for working with coding agents (Claude Code, Codex). Three-pane layout: projects + sessions on the left, chat in the middle, files + terminal on the right. Sessions persist in SQLite. This directory holds the living specification: vision, architecture, phase roadmap, per-feature designs, and the architecture decision record.
 
 > **Spec pivoted on 2026-05-03** from terminal-first to chat-first. Phases 1–2 (foundation + agent backend) shipped under the old direction; their backend code is reused unchanged. Phase 3 (chat MVP) is the new direction's first phase. See `vision.md` for the current product shape and `roadmap.md` for the new phase numbering.
 
@@ -8,7 +8,7 @@ forkzero is a chat-first desktop app for working with coding agents (Claude Code
 
 Start at the top, descend as needed:
 
-1. **[vision.md](vision.md)** — why forkzero exists and who it's for
+1. **[vision.md](vision.md)** — why memoize exists and who it's for
 2. **[architecture.md](architecture.md)** — the stack and how pieces fit together
 3. **[roadmap.md](roadmap.md)** — phase-by-phase plan with effort estimates
 4. **[phases/](phases/)** — detailed scope, acceptance criteria, and contracts per phase

--- a/specs/0.01-MVP/architecture.md
+++ b/specs/0.01-MVP/architecture.md
@@ -33,13 +33,13 @@ The renderer code does not change between these modes — only the transport mod
 ## Module layout
 
 ```
-forkzero/
+memoize/
   packages/
-    wire/                                   # @forkzero/wire — RPC contracts, branded IDs
+    wire/                                   # @memoize/wire — RPC contracts, branded IDs
       src/
         ping.ts, workspace.ts, pty.ts, git.ts, agent.ts
         ids.ts                              # branded entity IDs (FolderId, PtyId, SessionId, ...)
-        rpc.ts                              # ForkzeroRpcs = RpcGroup.make(...)
+        rpc.ts                              # MemoizeRpcs = RpcGroup.make(...)
         index.ts
     typescript-config/
     eslint-config/
@@ -155,8 +155,8 @@ No SQLite in v1. JSON until proven painful.
 
 See [ADR 0005](decisions/0005-package-layout.md) for the full rules. Highlights:
 
-- Single contracts package: `@forkzero/wire` with one file per domain
-- Internal package namespace: `@forkzero/*`
+- Single contracts package: `@memoize/wire` with one file per domain
+- Internal package namespace: `@memoize/*`
 - Service classes: `<Domain>Service` (no `*Engine`, no `*FileSystem`, no bare verbs)
 - RPC method names: dotted-lowercase string literals passed directly to `Rpc.make("...", ...)` — no central enum
 - Branded IDs for every entity that crosses the wire

--- a/specs/0.01-MVP/decisions/0005-package-layout.md
+++ b/specs/0.01-MVP/decisions/0005-package-layout.md
@@ -12,15 +12,15 @@ Other terminal-for-agents apps split their server into a dozen domain packages (
 
 ## Decision
 
-### One contracts package: `@forkzero/wire`
+### One contracts package: `@memoize/wire`
 
-All RPC contracts, branded IDs, and cross-process schemas live in a single workspace package: `@forkzero/wire`. Inside, **one file per domain** (`ping.ts`, `workspace.ts`, `pty.ts`, `git.ts`). One `RpcGroup` (`ForkzeroRpcs`) collects every `Rpc.make(...)`.
+All RPC contracts, branded IDs, and cross-process schemas live in a single workspace package: `@memoize/wire`. Inside, **one file per domain** (`ping.ts`, `workspace.ts`, `pty.ts`, `git.ts`). One `RpcGroup` (`MemoizeRpcs`) collects every `Rpc.make(...)`.
 
 **Why one package, not many:** the wire format is the boundary. Splitting it across packages forces every new RPC to negotiate package membership. One package, one file per domain, lets us add an RPC by editing one file and re-exporting from `index.ts`.
 
-### Internal package naming: `@forkzero/*`
+### Internal package naming: `@memoize/*`
 
-All packages we create live under `@forkzero/*` (e.g. `@forkzero/wire`). Pre-existing repo-shared config packages keep their `@repo/*` namespace (`@repo/typescript-config`, `@repo/eslint-config`, `@repo/ui`) — they're scaffolding that came with the Turborepo template, not domain code.
+All packages we create live under `@memoize/*` (e.g. `@memoize/wire`). Pre-existing repo-shared config packages keep their `@repo/*` namespace (`@repo/typescript-config`, `@repo/eslint-config`, `@repo/ui`) — they're scaffolding that came with the Turborepo template, not domain code.
 
 **Why not mix scoped and unscoped:** a single namespace makes it obvious at a glance whether a dependency is ours or third-party.
 
@@ -106,7 +106,7 @@ apps/server/src/                          # NEW — main-process service impleme
   app-paths.ts, runtime.ts, handlers.ts, bin.ts
 
 apps/desktop/src/                          # thin Electron shim
-  main.ts                                  # imports makeMainLayer from @forkzero/server
+  main.ts                                  # imports makeMainLayer from @memoize/server
   preload.ts
   ipc/electron-server-protocol.ts          # transport stays in apps/desktop
 

--- a/specs/0.01-MVP/decisions/0007-server-as-code-only-app.md
+++ b/specs/0.01-MVP/decisions/0007-server-as-code-only-app.md
@@ -39,7 +39,7 @@ apps/
                                 # Tomorrow: WS server boot.
   desktop/                      # thin Electron shim
     src/
-      main.ts                   # Electron lifecycle. Imports runtime from @forkzero/server.
+      main.ts                   # Electron lifecycle. Imports runtime from @memoize/server.
       preload.ts                # contextBridge
       ipc/                      # electron-server-protocol — Electron-bound transport
   renderer/                     # React UI
@@ -94,5 +94,5 @@ When any of these become priority, we add the relevant bits without restructurin
 ## How we'll know we got it right
 
 - Phase 2 ships without revisiting transport.
-- The day someone asks for "let me SSH into my desktop and use forkzero from my laptop browser," the PR touches `apps/server/src/bin.ts`, `apps/server/src/transports/ws.ts`, `apps/desktop/src/main.ts`, and `apps/renderer/src/lib/rpc-client.ts` — and nothing in any service.
+- The day someone asks for "let me SSH into my desktop and use memoize from my laptop browser," the PR touches `apps/server/src/bin.ts`, `apps/server/src/transports/ws.ts`, `apps/desktop/src/main.ts`, and `apps/renderer/src/lib/rpc-client.ts` — and nothing in any service.
 - New service domains (Phase 3 permissions, Phase 4 diff viewer) follow the same `apps/server/src/<domain>/{Drivers,Layers,Services,Errors.ts}` pattern without anyone asking where they should live.

--- a/specs/0.01-MVP/decisions/0008-sqlite-persistence.md
+++ b/specs/0.01-MVP/decisions/0008-sqlite-persistence.md
@@ -15,7 +15,7 @@ Phase 3 introduces persisted projects, sessions, and messages. We need:
 
 ## Decision
 
-Use **SQLite** as the storage engine and **`@effect/sql-sqlite-node`** as the client, with **`@effect/sql/Migrator`** for schema evolution. Database file at `<userData>/forkzero.sqlite`. All access goes through repository Layers in `apps/server/src/persistence/`.
+Use **SQLite** as the storage engine and **`@effect/sql-sqlite-node`** as the client, with **`@effect/sql/Migrator`** for schema evolution. Database file at `<userData>/memoize.sqlite`. All access goes through repository Layers in `apps/server/src/persistence/`.
 
 ### Why SQLite
 

--- a/specs/0.01-MVP/features/agent-integration.md
+++ b/specs/0.01-MVP/features/agent-integration.md
@@ -43,4 +43,4 @@ All adapters emit the same `AgentEvent` union (see [phases/02-agents.md](../phas
 
 ## Credentials
 
-`keytar` keyed by `"forkzero:<provider>:apiKey"`. Never logged, never written to disk in plaintext.
+`keytar` keyed by `"memoize:<provider>:apiKey"`. Never logged, never written to disk in plaintext.

--- a/specs/0.01-MVP/features/git-history.md
+++ b/specs/0.01-MVP/features/git-history.md
@@ -1,6 +1,6 @@
 # Feature: Git history
 
-> **Deprecated.** This feature shipped in Phase 1 and is removed from the v1 UI in Phase 3 (chat-first MVP). The `git.*` RPCs in `@forkzero/wire` and `GitService` in `apps/server` remain, but they are no longer wired into any UI. We may bring this back as a right-pane tab post-1.0 if there's demand. See [phases/03-chat-mvp.md](../phases/03-chat-mvp.md) for the new layout.
+> **Deprecated.** This feature shipped in Phase 1 and is removed from the v1 UI in Phase 3 (chat-first MVP). The `git.*` RPCs in `@memoize/wire` and `GitService` in `apps/server` remain, but they are no longer wired into any UI. We may bring this back as a right-pane tab post-1.0 if there's demand. See [phases/03-chat-mvp.md](../phases/03-chat-mvp.md) for the new layout.
 
 Always-visible feed of recent commits for the active folder, plus a status summary.
 

--- a/specs/0.01-MVP/phases/03-chat-mvp.md
+++ b/specs/0.01-MVP/phases/03-chat-mvp.md
@@ -4,7 +4,7 @@ Status: ✅ Shipped
 
 ## Goal
 
-Replace forkzero's terminal-first UI shell with a three-pane chat IDE. By the end of Phase 3 a user can: pick a project from the left sidebar, open a chat session, send messages with markdown rendering, watch tool calls expand inline, browse the project's file tree on the right, and run shell commands in a side terminal. Sessions persist across app restart and can be archived.
+Replace memoize's terminal-first UI shell with a three-pane chat IDE. By the end of Phase 3 a user can: pick a project from the left sidebar, open a chat session, send messages with markdown rendering, watch tool calls expand inline, browse the project's file tree on the right, and run shell commands in a side terminal. Sessions persist across app restart and can be archived.
 
 The backend shipped in Phase 2 (provider adapters, credentials, `agent.events` stream) is reused unchanged. What changes is: persistence, layout, the chat surface, and dropping the launcher / git pane.
 
@@ -44,12 +44,12 @@ Three resizable columns. Left and right are collapsible (≥768px width threshol
 
 ## Persistence
 
-SQLite via `@effect/sql-sqlite-node` + `@effect/sql/Migrator`. Database file at `<userData>/forkzero.sqlite`. See [ADR 0008](../decisions/0008-sqlite-persistence.md) for the full rationale.
+SQLite via `@effect/sql-sqlite-node` + `@effect/sql/Migrator`. Database file at `<userData>/memoize.sqlite`. See [ADR 0008](../decisions/0008-sqlite-persistence.md) for the full rationale.
 
 ### Schema (initial migration)
 
 ```sql
--- projects: a folder the user has added to forkzero.
+-- projects: a folder the user has added to memoize.
 CREATE TABLE projects (
   id TEXT PRIMARY KEY,                 -- existing FolderId from Phase 1
   path TEXT NOT NULL,
@@ -93,7 +93,7 @@ The Phase 2 `AgentEvent` stream (over `agent.events` RPC) is consumed by a `Mess
 
 ## RPC additions
 
-New methods (added to `ForkzeroRpcs` in `packages/wire`):
+New methods (added to `MemoizeRpcs` in `packages/wire`):
 
 - `session.list(projectId, includeArchived)` → `Session[]`
 - `session.create(projectId, providerId, model, initialPrompt?)` → `Session` (replaces `agent.start`)
@@ -122,11 +122,11 @@ Seven PRs. Each independently shippable.
 - Add `@effect/sql` + `@effect/sql-sqlite-node` deps, write `apps/server/src/persistence/Sqlite.ts` (client + Migrator layer).
 - Migration `001_initial.sql` with `projects`, `sessions`, `messages` tables.
 - `ProjectRepository`, `SessionRepository`, `MessageRepository` Layers (CRUD; no business logic yet).
-- DB file at `<userData>/forkzero.sqlite`; `:memory:` flag for tests.
+- DB file at `<userData>/memoize.sqlite`; `:memory:` flag for tests.
 - No UI changes. Existing folders backfill into `projects` on boot.
 
 ### PR 2 — session RPCs + MessageStore
-- Add `session.*` and `messages.*` RPCs to `@forkzero/wire`.
+- Add `session.*` and `messages.*` RPCs to `@memoize/wire`.
 - `MessageStore` service: subscribes to `AgentEvent` stream from Phase 2, persists each event as a `messages` row, re-emits.
 - Wire `session.create` to call existing `agent.start` internally.
 - Old `agent.*` RPCs stay (still used by `MessageStore` internally).

--- a/specs/0.01-MVP/phases/04-permissions.md
+++ b/specs/0.01-MVP/phases/04-permissions.md
@@ -8,7 +8,7 @@
 
 **Depends on**: Phase 3 (chat MVP)
 
-> **Note:** Renumbered from "Phase 3" when the chat-first pivot inserted the new Phase 3. Session persistence already shipped in Phase 3 (SQLite at `<userData>/forkzero.sqlite`, sessions list in the projects sidebar). What's left here is permissions UI, inline diff rendering, resume of interrupted turns, and an NDJSON audit/export sink.
+> **Note:** Renumbered from "Phase 3" when the chat-first pivot inserted the new Phase 3. Session persistence already shipped in Phase 3 (SQLite at `<userData>/memoize.sqlite`, sessions list in the projects sidebar). What's left here is permissions UI, inline diff rendering, resume of interrupted turns, and an NDJSON audit/export sink.
 
 ## Deliverables
 
@@ -31,11 +31,11 @@
 
 ## Storage layout
 
-Session metadata, message history, and permission decisions all live in `<userData>/forkzero.sqlite` (SQLite is canonical — schema added by migrations 0002 and 0003). NDJSON is a side-write audit/export sink:
+Session metadata, message history, and permission decisions all live in `<userData>/memoize.sqlite` (SQLite is canonical — schema added by migrations 0002 and 0003). NDJSON is a side-write audit/export sink:
 
 ```
 <userData>/
-  forkzero.sqlite                                 # canonical: sessions, messages, permission_decisions
+  memoize.sqlite                                 # canonical: sessions, messages, permission_decisions
   sessions/
     <project-id>/
       <session-id>.events.ndjson                  # tail-written; rotates to *.events.<ts>.ndjson at 100MB

--- a/specs/0.01-MVP/roadmap.md
+++ b/specs/0.01-MVP/roadmap.md
@@ -71,7 +71,7 @@ ADR 0007's transport-agnostic split keeps these costs bounded — each becomes a
 | Milestone | What changes |
 |---|---|
 | Remote desktop access | `apps/server/src/bin.ts` becomes a real WS server boot; renderer's transport seam picks WS when running outside Electron. |
-| CLI client | New `apps/cli/` consuming `@forkzero/wire` over the WS transport. |
+| CLI client | New `apps/cli/` consuming `@memoize/wire` over the WS transport. |
 | Multi-window | Multiple Electron renderers connected to one backend — backend already supports it. |
 | Mobile client | Native or web mobile app speaking WS to a desktop's server over LAN/tunnel. |
 

--- a/specs/0.01-MVP/vision.md
+++ b/specs/0.01-MVP/vision.md
@@ -1,14 +1,14 @@
 # Vision
 
-## What forkzero is
+## What memoize is
 
 A desktop app for working with coding agents (Claude Code, Codex) chat-first. You add a project to the sidebar, open a session, and chat with an agent that has full access to that project's files. The agent does the work; you review the diff. A file tree and a real terminal sit on the right so you can run `pnpm dev`, `tsc --noEmit`, or `ls` without leaving the app.
 
 The mental model is closer to Cursor's "Composer" or T3 Chat, not VS Code. The chat is the canvas; the file tree and terminal are tools you reach for when needed.
 
-## What forkzero is not
+## What memoize is not
 
-- **Not an editor.** We don't own the editor surface. Open files in your editor of choice; forkzero shows file contents inline in chat, but doesn't let you edit them in-app.
+- **Not an editor.** We don't own the editor surface. Open files in your editor of choice; memoize shows file contents inline in chat, but doesn't let you edit them in-app.
 - **Not a terminal-first tool.** The terminal is on the right panel, available, but it's not the primary surface. If you want a terminal-first agent UX, use Claude Code or Codex CLI directly.
 - **Not cloud.** Sessions, messages, credentials live on disk. No telemetry without opt-in.
 - **Not multi-user / collaborative.** Single-user desktop tool.

--- a/specs/0.02-MVP/README.md
+++ b/specs/0.02-MVP/README.md
@@ -14,7 +14,7 @@ click-to-open, and a minimal editor that can save changes back to disk.
 - **Two-tab main pane**: a permanent **Chat** tab and at most **one** file
   tab. Opening a different file replaces (never stacks) the file tab.
 - **Minimal editor** based on CodeMirror 6 with language packs for the
-  formats forkzero users edit most (TS/TSX/JS/JSON/Markdown/HTML/CSS/Python/
+  formats memoize users edit most (TS/TSX/JS/JSON/Markdown/HTML/CSS/Python/
   Rust/Go), dirty-dot indicator, `Cmd/Ctrl+S` to save.
 - **Conflict-aware writes** via mtime-based optimistic concurrency: the
   server rejects writes if the file changed on disk since we read it.

--- a/specs/0.02-MVP/decisions/0009-codemirror-over-monaco.md
+++ b/specs/0.02-MVP/decisions/0009-codemirror-over-monaco.md
@@ -64,7 +64,7 @@ It is the only option that's both minimal *now* (sub-200 KB after
 language packs) and structured the way the future Cmd+K-on-selection
 work needs to work (selection, decorations, and content-changing
 transactions are core APIs). Monaco is the right choice for an IDE,
-not for forkzero. A `<textarea>` would force a rewrite as soon as we
+not for memoize. A `<textarea>` would force a rewrite as soon as we
 add the first interesting editor command.
 
 ## Consequences
@@ -79,7 +79,7 @@ add the first interesting editor command.
   `lib/codemirror/languages.ts` + `components/file-editor.tsx`) so the
   future inline-AI command extension lives in one new file rather than
   reshaping the React tree.
-- We do **not** ship LSP integration or IntelliSense in 0.02. If forkzero
+- We do **not** ship LSP integration or IntelliSense in 0.02. If memoize
   later wants completions, the path is `@codemirror/autocomplete` plus
-  a forkzero-specific completion source (likely backed by the agent),
+  a memoize-specific completion source (likely backed by the agent),
   not pulling in Monaco.

--- a/specs/0.02-MVP/features/file-viewer.md
+++ b/specs/0.02-MVP/features/file-viewer.md
@@ -1,7 +1,7 @@
 # Feature: File viewer & editor
 
 The right-pane file tree is the only window onto the user's project
-filesystem inside forkzero. In MVP 0.01 it was a read-only browse surface
+filesystem inside memoize. In MVP 0.01 it was a read-only browse surface
 with generic file/folder icons. MVP 0.02 turns it into a working editor:
 type-aware icons, click-to-open in the main pane, and a save-capable
 minimal editor.

--- a/specs/0.03-MVP/README.md
+++ b/specs/0.03-MVP/README.md
@@ -15,14 +15,14 @@ first-class queued items the user can steer into the running conversation.
 - **Skills**, scoped to the active session's provider. Claude sessions show
   skills the Claude SDK reports from `~/.claude/skills/` and project-level
   `.claude/skills/`; Codex sessions show skills the Codex CLI reports from
-  `~/.codex/skills/` and project-level `.codex/skills/`. Forkzero owns no
+  `~/.codex/skills/` and project-level `.codex/skills/`. Memoize owns no
   skill directory of its own.
 - **File tagging via `@`**. Typing `@` opens a workspace-aware file picker;
   picking a file inserts an inline atomic chip (icon | label) at the cursor.
 - **Image attachments** by drag-drop, paste, or paperclip button. Images
   render as inline atomic chips with a thumbnail; binaries are persisted
   under the app's userData directory and served back to the renderer via a
-  custom `forkzero://attachments/<id>` protocol. The data model reserves
+  custom `memoize://attachments/<id>` protocol. The data model reserves
   cloud fields so sync can land later without changing message history.
 - **`Enter` to send**, `Shift+Enter` for newline. `Cmd+Enter` continues to
   work as a backstop.
@@ -61,7 +61,7 @@ first-class queued items the user can steer into the running conversation.
   composer.
 - [decisions/0011-skills-via-provider.md](decisions/0011-skills-via-provider.md) —
   why skill discovery is delegated to the provider driver instead of a
-  forkzero-owned directory.
+  memoize-owned directory.
 - [decisions/0012-steer-via-interrupt.md](decisions/0012-steer-via-interrupt.md) —
   why "Steer" is interrupt + send rather than mid-stream injection.
 

--- a/specs/0.03-MVP/decisions/0010-codemirror-composer.md
+++ b/specs/0.03-MVP/decisions/0010-codemirror-composer.md
@@ -17,7 +17,7 @@ text-editing surface.
 ADR 0009 (file viewer/editor, MVP 0.02) already chose CodeMirror 6 for
 the in-app file editor on the strength of its extension model. That
 choice is now load-bearing for 0.03 too: if the composer picks a
-different editor, forkzero pays for two editor mental models, two
+different editor, memoize pays for two editor mental models, two
 selection systems, and two extension surfaces — and the future Cmd+K
 inline-AI command in 0.02's roadmap has to be implemented twice.
 
@@ -25,7 +25,7 @@ inline-AI command in 0.02's roadmap has to be implemented twice.
 
 ### Option A — CodeMirror 6 with a "prose" preset
 
-- Same dependency forkzero already accepts in ADR 0009.
+- Same dependency memoize already accepts in ADR 0009.
 - Atomic widget decorations (`Decoration.replace({ widget, atomic: true })`
   combined with `EditorView.atomicRanges`) are the chip primitive.
 - Selection, cursor stepping, copy/paste, undo, IME, and accessibility
@@ -111,4 +111,4 @@ It is the only option that:
 
 - Bundle impact: zero new dependencies (CodeMirror and lucide packages are
   already in `apps/renderer/package.json` from ADR 0009). The composer
-  extensions add ~10 KB of forkzero-authored code.
+  extensions add ~10 KB of memoize-authored code.

--- a/specs/0.03-MVP/decisions/0011-skills-via-provider.md
+++ b/specs/0.03-MVP/decisions/0011-skills-via-provider.md
@@ -1,4 +1,4 @@
-# 0011 — Skills are discovered by the active provider, not by forkzero
+# 0011 — Skills are discovered by the active provider, not by memoize
 
 Status: Accepted (2026-05-04)
 
@@ -6,54 +6,54 @@ Status: Accepted (2026-05-04)
 
 MVP 0.03 surfaces user-authored skills (markdown commands with
 frontmatter) inside the composer's slash popover. The user's stated
-direction was explicit: **forkzero should not own a skill directory of
+direction was explicit: **memoize should not own a skill directory of
 its own.** Users already author skills inside their preferred coding
 agent — under `~/.claude/skills/` and project-level `.claude/skills/`
 when working with Claude, under `~/.codex/skills/` and project-level
 `.codex/skills/` when working with Codex. Asking them to maintain a
-third copy under `.forkzero/skills/` would be a tax on every user with
+third copy under `.memoize/skills/` would be a tax on every user with
 no offsetting benefit.
 
 The question is **how** to plumb those existing directories into
-forkzero's UI without re-implementing each provider's discovery rules,
+memoize's UI without re-implementing each provider's discovery rules,
 frontmatter conventions, override semantics, or hot-reload signals.
 
 ## Options
 
-### Option A — Forkzero owns `.forkzero/skills/`
+### Option A — Memoize owns `.memoize/skills/`
 
 - A new directory the user has to populate.
-- Simplest implementation: forkzero reads markdown, parses frontmatter,
+- Simplest implementation: memoize reads markdown, parses frontmatter,
   emits a list.
 - Cost: every user maintains a separate skill copy per coding tool;
   every minor format divergence between Claude/Codex skill formats
-  needs a forkzero-specific re-encoding; every cross-tool skill
+  needs a memoize-specific re-encoding; every cross-tool skill
   ergonomic gain in a future Claude or Codex release is invisible to
-  forkzero unless we re-implement it.
+  memoize unless we re-implement it.
 
-### Option B — Forkzero reads provider directories directly
+### Option B — Memoize reads provider directories directly
 
-- Forkzero reads `.claude/skills/`, `.codex/skills/`, etc. from disk
+- Memoize reads `.claude/skills/`, `.codex/skills/`, etc. from disk
   itself, parsing the frontmatter formats each tool uses.
 - Avoids the "maintain three copies" tax.
-- Cost: forkzero now owns parsing rules for each provider and has to
+- Cost: memoize now owns parsing rules for each provider and has to
   match each provider's discovery semantics (which directories are
   scanned, project vs. global precedence, override rules,
-  inheritance). Every time a provider changes those rules, forkzero
-  drifts. Frontmatter parsing bugs are forkzero's bugs, not the
+  inheritance). Every time a provider changes those rules, memoize
+  drifts. Frontmatter parsing bugs are memoize's bugs, not the
   provider's.
 
 ### Option C — Delegate to the provider driver
 
 - Each provider driver exposes `listSkills` and `subscribeSkills`. The
-  underlying tool does the discovery and parsing; forkzero consumes
+  underlying tool does the discovery and parsing; memoize consumes
   the projected `Skill` shape.
 - For Claude, the Agent SDK already does this work (`settingSources:
   ["user", "project", "local"]` exposes commands via `init.commands`);
   the driver projects each entry onto our `Skill` schema.
 - For Codex, the CLI exposes `skills/list` over its RPC interface and
   emits `SkillsChangedNotification` on changes.
-- Cost: forkzero gains a small cross-provider normalization layer; in
+- Cost: memoize gains a small cross-provider normalization layer; in
   return, every change in provider semantics is invisible (and free).
 
 ## Decision
@@ -61,11 +61,11 @@ frontmatter conventions, override semantics, or hot-reload signals.
 **Option C: drivers expose `listSkills` and `subscribeSkills`; the
 renderer never touches the filesystem for skills.**
 
-The choice follows the same logic that gave forkzero its provider
+The choice follows the same logic that gave memoize its provider
 abstraction in the first place: the Claude SDK and the Codex CLI are
-better at being themselves than forkzero will ever be. Any time an
+better at being themselves than memoize will ever be. Any time an
 inner tool updates its skill semantics — adding new frontmatter
-fields, changing precedence, supporting new directories — forkzero
+fields, changing precedence, supporting new directories — memoize
 inherits those improvements without code changes.
 
 ## Consequences
@@ -85,7 +85,7 @@ inherits those improvements without code changes.
   the user is invoking.
 
 - Project-scoped skills shadow global skills with the same name. Both
-  drivers already implement this; forkzero just respects the
+  drivers already implement this; memoize just respects the
   precedence each driver returns and does not re-sort.
 
 - Hot reload is free. The Claude SDK re-emits `init` (with the new
@@ -95,18 +95,18 @@ inherits those improvements without code changes.
   subscription pushes the new list to the popover.
 
 - Skill body expansion happens on the provider side. When the user
-  picks a `skill` chip and submits, forkzero passes a `SkillRef
+  picks a `skill` chip and submits, memoize passes a `SkillRef
   { name, scope, args }` to the driver, which calls into the SDK or
-  CLI to invoke the skill. Forkzero never inlines skill body text
-  into the prompt. This keeps forkzero's behavior identical to using
+  CLI to invoke the skill. Memoize never inlines skill body text
+  into the prompt. This keeps memoize's behavior identical to using
   the underlying tool directly — users get the same skill semantics
   they'd get from their CLI.
 
-- Authoring is also out of scope for forkzero. Users edit skill
+- Authoring is also out of scope for memoize. Users edit skill
   files in their text editor, in the destination directory their
   provider expects. Future polish (a "New skill" template-drop
   affordance, an "Edit skill" jump-to-source link) is additive;
-  forkzero owning the format itself would not be.
+  memoize owning the format itself would not be.
 
 - We accept that switching providers mid-conversation means switching
   skill lists mid-conversation. This is not a bug — a user who
@@ -120,7 +120,7 @@ The original wording assumed the underlying tool exposes discovery via
 its SDK or RPC interface (`init.commands` for Claude, `skills/list` for
 Codex). In practice the Claude Agent SDK only exposes
 `Query.supportedCommands()` once a `query()` call is in flight, which
-forkzero doesn't have at popover-open time — sessions are started
+memoize doesn't have at popover-open time — sessions are started
 lazily on first send. Spawning an ephemeral `query()` purely to list
 skills costs a real model handshake.
 

--- a/specs/0.03-MVP/features/composer.md
+++ b/specs/0.03-MVP/features/composer.md
@@ -54,7 +54,7 @@ tabular label. Chip variants:
 | ------------- | --------------------------------------------------------------------------- | ---------------------- |
 | `file`        | Material Icon Theme (basename → extension), via `lib/icons/material-icons.ts` (added in 0.02) | basename               |
 | `directory`   | Material Icon Theme folder icon (open / closed by no state — chips are not expandable) | last path segment      |
-| `image`       | a square thumbnail (32×32, object-fit cover) sourced from blob URL → `forkzero://attachments/<id>` | original filename      |
+| `image`       | a square thumbnail (32×32, object-fit cover) sourced from blob URL → `memoize://attachments/<id>` | original filename      |
 | `skill`       | lucide `Sparkles`                                                           | skill name             |
 
 Selection / editing semantics for any chip:
@@ -150,7 +150,7 @@ For each accepted image:
    and calls `attachments.upload({sessionId, bytes, mimeType,
    originalName})`.
 4. On success, the chip's preview src swaps from the blob URL to
-   `forkzero://attachments/<id>`. The blob URL is revoked.
+   `memoize://attachments/<id>`. The blob URL is revoked.
 5. The chip carries an `AttachmentRef` in the `ComposerInput`'s
    `attachments` array when the message is submitted.
 
@@ -179,7 +179,7 @@ Local storage is the source of truth in 0.03:
 
 The renderer never reads this path directly. It stores only
 `AttachmentRef.id` and renders images through
-`forkzero://attachments/<id>`. The desktop protocol handler resolves the
+`memoize://attachments/<id>`. The desktop protocol handler resolves the
 id to the local blob and returns the correct `content-type`.
 
 The database reserves the future cloud shape on day one:
@@ -193,7 +193,7 @@ remote_status  TEXT   -- NULL | "pending" | "uploaded" | "failed"
 Resolution order for rendering:
 
 1. If `remote_url` is set and local blob is missing, use `remote_url`.
-2. Otherwise use `forkzero://attachments/<id>`.
+2. Otherwise use `memoize://attachments/<id>`.
 3. If neither resolves, render the image chip in a missing-attachment
    state with filename and size.
 
@@ -399,19 +399,19 @@ Garbage collection (`apps/server/src/attachment/attachment-store.ts`):
   every 30 s with the ids currently in any composer draft or queue
   chip. The server keeps an in-memory `lastTouchedAt[id]` map.
 
-### `forkzero://attachments/<id>` protocol
+### `memoize://attachments/<id>` protocol
 
 `apps/desktop/src/main.ts` registers a custom protocol so `<img src>`
 can resolve attachment ids without a JS roundtrip:
 
 ```ts
-protocol.handle("forkzero", (request) => {
+protocol.handle("memoize", (request) => {
   // parse <id> from request.url; map to <userDataDir>/attachments/<id>.<ext>
   // return new Response(stream, { headers: { "content-type": mime } })
 });
 ```
 
-The renderer prefers `forkzero://` URLs in `<img>` tags both for live
+The renderer prefers `memoize://` URLs in `<img>` tags both for live
 chips (after upload) and for past-message rendering.
 
 ## Renderer state
@@ -447,7 +447,7 @@ view; it is not lifted into Zustand.
 | `apps/renderer/src/store/skills.ts`                                   | new    | Per-session skill list, fed by `skill.stream`. (see skills.md)             |
 | `apps/renderer/src/store/attachments.ts`                              | new    | Upload + heartbeat.                                                       |
 | `apps/renderer/src/store/messages.ts`                                 | edit   | `send` now takes `ComposerInput`; queue + steer state added in queue-and-steer.md. |
-| `apps/desktop/src/main.ts`                                            | edit   | Register `forkzero://attachments/<id>` protocol handler.                  |
+| `apps/desktop/src/main.ts`                                            | edit   | Register `memoize://attachments/<id>` protocol handler.                  |
 | `apps/server/src/attachment/attachment-store.ts`                      | new    | Disk write under userData, GC sweep, heartbeat tracking.                  |
 | `apps/server/src/attachment/image-mime.ts`                            | new    | MIME → extension map.                                                     |
 | `apps/server/src/workspace/file-search.ts`                            | new    | `.gitignore`-aware walker for `workspace.searchFiles`.                    |
@@ -485,7 +485,7 @@ A5. With the cursor immediately after any chip, pressing `Backspace`
 
 A6. Dropping a PNG inserts an `image` chip with a thumbnail; the chip's
     `<img src>` is a blob URL until `attachments.upload` resolves, then
-    swaps to `forkzero://attachments/<id>`. The blob URL is revoked.
+    swaps to `memoize://attachments/<id>`. The blob URL is revoked.
 
 A7. With a non-empty editor and no popover open, `Enter` submits;
     `Shift+Enter` inserts a newline; `Cmd+Enter` also submits.
@@ -495,7 +495,7 @@ A8. While `runningBySession[sessionId] === true`, pressing `Enter`
     [queue-and-steer.md](queue-and-steer.md)).
 
 A9. After restarting the app, opening a past session renders historic
-    image attachments via `forkzero://attachments/<id>` (no missing
+    image attachments via `memoize://attachments/<id>` (no missing
     images).
 
 A10. Dragging a 110 MB image onto the composer shows a toast `"Image too

--- a/specs/0.03-MVP/features/queue-and-steer.md
+++ b/specs/0.03-MVP/features/queue-and-steer.md
@@ -234,7 +234,7 @@ Q6. The queue is per-session: switching to another session hides the
 Q7. A queue chip carrying attachments keeps its attachments alive
     across the running turn — when it auto-flushes (or is steered),
     the resulting message still references the same
-    `forkzero://attachments/<id>` URLs.
+    `memoize://attachments/<id>` URLs.
 
 Q8. `bun run check-types` passes for `apps/renderer`, `apps/server`,
     and `packages/wire`.

--- a/specs/0.03-MVP/features/skills.md
+++ b/specs/0.03-MVP/features/skills.md
@@ -1,8 +1,8 @@
 # Feature: Skills
 
-A "skill" in forkzero is a markdown command the user has authored in
+A "skill" in memoize is a markdown command the user has authored in
 their coding-agent tool of choice. Skill discovery is **delegated** to
-the active provider — forkzero owns no skill directory of its own.
+the active provider — memoize owns no skill directory of its own.
 
 For a Claude session, skills come from `~/.claude/skills/` (global) and
 project-level `.claude/skills/` (multiple between cwd and the repo
@@ -69,7 +69,7 @@ the file"; no hard SLA.
 
 Authoring is out of scope for 0.03. Users create and edit skills in
 their preferred text editor, in the directory their provider expects.
-Forkzero introduces no skill format of its own.
+Memoize introduces no skill format of its own.
 
 ## Driver capability
 
@@ -146,7 +146,7 @@ When the user confirms a skill row in the slash popover, the editor
 inserts a `skill` chip carrying `{ name, scope, args: "" }`. Anything
 the user types after the chip is treated as the `args` payload (free
 text — provider-specific argument parsing happens on the provider
-side; forkzero passes the raw string).
+side; memoize passes the raw string).
 
 At send time, the composer walks the document and produces:
 
@@ -168,7 +168,7 @@ inspects `skillRefs` and calls into the driver:
 - **Codex driver** — sends the equivalent `skills/run` request (CLI
   expands the body before invoking the model).
 
-Forkzero never inlines the skill body into the prompt. Expansion is
+Memoize never inlines the skill body into the prompt. Expansion is
 the provider's responsibility, which keeps skill semantics identical
 to using the underlying CLI directly.
 

--- a/specs/0.04-MVP/README.md
+++ b/specs/0.04-MVP/README.md
@@ -4,7 +4,7 @@ MVP 0.03 (everything under [../0.03-MVP/](../0.03-MVP/)) brought the chat
 composer to first-class quality. MVP 0.04 turns inward: it gives the bundled
 agent a real understanding of the user's codebase.
 
-Today an agent inside forkzero explores a repo the same way it does
+Today an agent inside memoize explores a repo the same way it does
 anywhere — `Bash(rg ...)`, `Read`, `Glob`, iterate. On any real codebase
 this is the dominant cost: 25–40k tokens across 5–8 tool calls before the
 agent has the context to answer or edit. Most of that is *navigation tax*,
@@ -16,7 +16,7 @@ agent calls `code_search`, `symbol_lookup`, `find_references`, and
 standalone `apps/mcp-server` so external agents (a terminal `claude`
 session, a Codex session, a Cursor agent) get the same tools.
 
-The wedge: forkzero runs **N parallel agent workspaces on the same repo**
+The wedge: memoize runs **N parallel agent workspaces on the same repo**
 (via Conductor) — multiple branches checked out side-by-side. Cursor,
 Sourcegraph Cody, Greptile, Continue, Augment all index codebases, but none
 handle this shape. A content-addressed chunk store with per-branch
@@ -25,7 +25,7 @@ across workspaces sharing a repo.
 
 ## What lands in 0.04
 
-- **Index engine** as a standalone package `@forkzero/index`. Tree-sitter
+- **Index engine** as a standalone package `@memoize/index`. Tree-sitter
   chunking, symbol extraction, content-addressed blob store, per-branch
   manifest model. SQLite + `sqlite-vec` extension. Engine is transport-agnostic.
 - **3-tier hybrid retrieval**: symbol lookup (Tier 1) → BM25 (Tier 2) →
@@ -36,7 +36,7 @@ across workspaces sharing a repo.
   `find_references`, `read_chunk`, `list_module`) at session start.
   In-process, no MCP overhead.
 - **Standalone MCP server** as `apps/mcp-server`. A Bun-compiled binary
-  (`forkzero-mcp`) plus an npm package `@forkzero/mcp-server`. stdio
+  (`memoize-mcp`) plus an npm package `@memoize/mcp-server`. stdio
   transport (default), HTTP transport (optional). Same engine, same tools,
   reusable by any agent runtime.
 - **Local-first by default.** Embedding model: `nomic-embed-code` ONNX via
@@ -44,12 +44,12 @@ across workspaces sharing a repo.
   calls in the default config.
 - **BYOK opt-in for paid backends.** Voyage / Cohere / OpenAI / Jina keys
   live in `keytar` under the same pattern Phase 2 uses for agent provider
-  keys. Chunks go user → provider directly; forkzero is not in the path.
+  keys. Chunks go user → provider directly; memoize is not in the path.
 - **Branch-aware index**. File watcher + git checkout hook. Switching
   branches in a Conductor workspace is a manifest swap, not a re-index.
   Content-addressed dedup means N parallel workspaces on one repo share
   one blob store.
-- **Renderer scaffolding**. `index.*` RPCs registered in `@forkzero/wire`.
+- **Renderer scaffolding**. `index.*` RPCs registered in `@memoize/wire`.
   A command palette entry (`Cmd+P` → "Search code…") wires the renderer to
   the index. The primary consumer is the agent; the renderer surface is
   scaffolding for future UI.
@@ -59,10 +59,10 @@ across workspaces sharing a repo.
 - **Cloud team index.** The chunk store is content-addressed and ready to
   sync; the actual S3-compatible sync worker, encryption keys, and team
   membership are deferred to a future MVP (sketched as Phase G).
-- **Pay-per-usage billing.** Forkzero-cloud as a paid embedding/rerank
+- **Pay-per-usage billing.** Memoize-cloud as a paid embedding/rerank
   proxy is scaffolded as a provider stub but not implemented. ADR 0021
   documents the call. Adding it later doesn't require re-architecting.
-- **Rust / Go / non-TS grammars at launch.** Forkzero itself is TypeScript;
+- **Rust / Go / non-TS grammars at launch.** Memoize itself is TypeScript;
   ship TS + JS + TSX + JSON + Markdown grammars first, expand on demand.
 - **Refactor / rename tooling.** The `refs` table powers read-only
   `find_references`; cross-file rename is out of scope (an LSP server's
@@ -94,7 +94,7 @@ across workspaces sharing a repo.
 - [decisions/0020-pluggable-rerank-and-embed.md](decisions/0020-pluggable-rerank-and-embed.md) —
   embedding and rerank provider abstraction.
 - [decisions/0021-credentials-and-billing.md](decisions/0021-credentials-and-billing.md) —
-  local default → BYOK in 0.04 → forkzero-cloud deferred.
+  local default → BYOK in 0.04 → memoize-cloud deferred.
 
 ## Status
 

--- a/specs/0.04-MVP/decisions/0013-index-as-package.md
+++ b/specs/0.04-MVP/decisions/0013-index-as-package.md
@@ -1,4 +1,4 @@
-# ADR 0013 — `@forkzero/index` as a standalone package
+# ADR 0013 — `@memoize/index` as a standalone package
 
 Date: 2026-05-06
 Status: Accepted
@@ -29,7 +29,7 @@ machinery it doesn't need) or duplicate the engine. Both are bad.
 
 ## Decision
 
-Ship the engine as a standalone workspace package: **`@forkzero/index`**.
+Ship the engine as a standalone workspace package: **`@memoize/index`**.
 
 ### Layout
 
@@ -104,7 +104,7 @@ embeddings — not about how callers reach it.
   MCP binary.
 - `apps/mcp-server` doesn't import Electron or RPC machinery — it can be
   bundled as a small standalone binary via `bun build --compile`.
-- The package is independently testable: `bun --filter @forkzero/index test`
+- The package is independently testable: `bun --filter @memoize/index test`
   runs unit + integration tests without booting Electron.
 - Future cloud-sync worker is a third consumer, not a fork.
 - `IndexService` plugs into the existing Effect Layer pattern with no
@@ -117,7 +117,7 @@ embeddings — not about how callers reach it.
   `transformers.js`'s ONNX runtime) need rebuild handling for Electron in
   `apps/desktop`. Adds to the existing rebuild list (see ADR 0019).
 - Effect Service patterns are now expected in a non-app package. The
-  `@forkzero/wire` package is contract-only; this is the first package
+  `@memoize/wire` package is contract-only; this is the first package
   with implementation. We accept the precedent.
 
 ## Alternatives considered
@@ -130,14 +130,14 @@ embeddings — not about how callers reach it.
   becomes a maintenance hazard — and the standalone binary picks up
   cruft.
 
-### Multiple per-domain packages (`@forkzero/index-chunker`,
-`@forkzero/index-retrieval`, etc.)
+### Multiple per-domain packages (`@memoize/index-chunker`,
+`@memoize/index-retrieval`, etc.)
 
 - Pro: smaller individual packages.
 - Con: premature partitioning. The engine is one concept and changes
   cross domains routinely. Splitting it forces every cross-domain change
   to negotiate package boundaries — same anti-pattern ADR 0005 warned
-  against for `@forkzero/wire`.
+  against for `@memoize/wire`.
 
 ### Fork the engine for the MCP binary
 
@@ -148,13 +148,13 @@ embeddings — not about how callers reach it.
 
 ## What we deliberately rejected
 
-- Putting the engine in `@forkzero/wire`. Wire is contract-only.
+- Putting the engine in `@memoize/wire`. Wire is contract-only.
 - Making `apps/server` a peer of the engine instead of a consumer.
 - Bundling MCP transport into the engine package — keeps the package
   transport-agnostic.
 
 ## Reference
 
-This mirrors how `@forkzero/wire` is structured (one package, multiple
+This mirrors how `@memoize/wire` is structured (one package, multiple
 consumers — main and renderer) and ADR 0007's transport-agnostic split.
 The index is the second cross-cutting package; it follows the same rule.

--- a/specs/0.04-MVP/decisions/0014-content-addressed-chunk-store.md
+++ b/specs/0.04-MVP/decisions/0014-content-addressed-chunk-store.md
@@ -5,7 +5,7 @@ Status: Accepted
 
 ## Context
 
-Forkzero's value prop, sharpened by Conductor workspaces, is **N parallel
+Memoize's value prop, sharpened by Conductor workspaces, is **N parallel
 agent workspaces on the same repo** — multiple branches checked out
 side-by-side, multiple agents iterating in parallel. Existing code-index
 products (Cursor, Sourcegraph Cody, Greptile, Continue, Augment) struggle
@@ -122,7 +122,7 @@ store, five manifest sets.
 The DB file lives at:
 
 ```
-<userData>/index/<repo-id>/forkzero-index.sqlite
+<userData>/index/<repo-id>/memoize-index.sqlite
 ```
 
 `<repo-id>` is `blake3(absolute_path_of_origin_clone)` — stable across
@@ -175,8 +175,8 @@ Conductor workspaces of the same repo.
 ### Reuse git's own object store
 
 - Pro: free dedup.
-- Con: requires the user's repo to be a git repo (forkzero supports
-  non-git folders too); requires reading git internals; forkzero would
+- Con: requires the user's repo to be a git repo (memoize supports
+  non-git folders too); requires reading git internals; memoize would
   have a hard time managing untracked / generated files.
 
 ## What we deliberately rejected

--- a/specs/0.04-MVP/decisions/0015-tree-sitter-chunking.md
+++ b/specs/0.04-MVP/decisions/0015-tree-sitter-chunking.md
@@ -41,7 +41,7 @@ Use **tree-sitter** for chunking and symbol extraction, in-process.
 - `tree-sitter-markdown`
 
 Loaded on demand. Python / Go / Rust ship later when there's user demand.
-Forkzero itself is TypeScript; ship for the first-party use case first.
+Memoize itself is TypeScript; ship for the first-party use case first.
 
 ### Chunking strategy
 

--- a/specs/0.04-MVP/decisions/0017-branch-aware-manifest.md
+++ b/specs/0.04-MVP/decisions/0017-branch-aware-manifest.md
@@ -27,7 +27,7 @@ Conductor's parallel-workspace pattern raises specific cases:
 
 ### Per-workspace active branch
 
-Each forkzero workspace tracks its own *active branch* in memory.
+Each memoize workspace tracks its own *active branch* in memory.
 `IndexService.search` accepts a `branch?` param; when omitted, it uses
 the workspace's active branch. Workspace A's queries never see B's
 manifest, even though both share the underlying blob store.

--- a/specs/0.04-MVP/decisions/0018-mcp-server-as-app.md
+++ b/specs/0.04-MVP/decisions/0018-mcp-server-as-app.md
@@ -5,20 +5,20 @@ Status: Accepted
 
 ## Context
 
-The index engine (`@forkzero/index`, ADR 0013) has two consumers in
+The index engine (`@memoize/index`, ADR 0013) has two consumers in
 0.04: the desktop server and an MCP server for external agents. The
 external-MCP shape lets users connect *any* agent runtime (terminal
 Claude Code, Codex, Cursor's agent mode, custom scripts) to the same
-index, getting the same tools forkzero's bundled agent uses.
+index, getting the same tools memoize's bundled agent uses.
 
 Distribution shape questions:
 
 - Is the MCP server a route inside `apps/server`, or its own app?
 - Does it ship with the desktop, or as a standalone binary?
-- Does it run only when forkzero is open, or independently?
-- How do users without forkzero installed get it?
+- Does it run only when memoize is open, or independently?
+- How do users without memoize installed get it?
 
-The honest goal: forkzero's index becomes useful **even if the user is
+The honest goal: memoize's index becomes useful **even if the user is
 running `claude` in a terminal without the desktop app.** That's the
 distribution play — same engine, two transports, available everywhere
 agents are.
@@ -31,9 +31,9 @@ Ship the MCP server as a separate workspace app: **`apps/mcp-server`**.
 
 ```
 apps/mcp-server/
-  package.json                      # name: "@forkzero/mcp-server"
+  package.json                      # name: "@memoize/mcp-server"
   src/
-    bin.ts                          # CLI entry — `forkzero-mcp [opts]`
+    bin.ts                          # CLI entry — `memoize-mcp [opts]`
     server.ts                       # MCP server boot
     tools/
       code-search.ts
@@ -47,10 +47,10 @@ apps/mcp-server/
 
 ### Transport
 
-- **stdio** (default) — `forkzero-mcp --workspace /path` reads/writes
+- **stdio** (default) — `memoize-mcp --workspace /path` reads/writes
   JSON-RPC over stdin/stdout. This is what `~/.claude/mcp.json` and
   Codex's MCP config expect.
-- **HTTP** (optional) — `forkzero-mcp --http :7421 --workspace /path`
+- **HTTP** (optional) — `memoize-mcp --http :7421 --workspace /path`
   exposes the same MCP endpoints over HTTP for runtimes that prefer
   HTTP (or for IDE plugins).
 
@@ -60,19 +60,19 @@ Both transports use `@modelcontextprotocol/sdk` server primitives.
 
 Three channels:
 
-1. **npm** — `npx @forkzero/mcp-server --workspace .` works for users
+1. **npm** — `npx @memoize/mcp-server --workspace .` works for users
    with Node ≥ 22. Lowest-friction entry.
 2. **Bun-compiled binaries** — `bun build --compile` produces
-   `forkzero-mcp` per OS. No Node required. Distributed via GitHub
+   `memoize-mcp` per OS. No Node required. Distributed via GitHub
    Releases and Homebrew.
 3. **Bundled in the desktop app** — the binary lives inside the
-   forkzero app bundle so users who installed the desktop also get
-   `forkzero-mcp` on PATH.
+   memoize app bundle so users who installed the desktop also get
+   `memoize-mcp` on PATH.
 
 ### Authentication and key handling
 
 The MCP server does **not** mount the desktop's keytar. If a user wants
-paid embeddings/rerank when running `forkzero-mcp` standalone, they
+paid embeddings/rerank when running `memoize-mcp` standalone, they
 provide keys via env vars (`VOYAGE_API_KEY`, etc.) — same env vars the
 desktop reads after fetching them from keytar. This way:
 
@@ -88,9 +88,9 @@ loaded.
 
 `--workspace <path>` is required. Defaults to `process.cwd()` if
 omitted. The server opens (or creates) the index DB at the path
-described in ADR 0014 (`<userData>/index/<repo-id>/forkzero-index.sqlite`),
+described in ADR 0014 (`<userData>/index/<repo-id>/memoize-index.sqlite`),
 which means desktop and standalone share the same DB when run on the
-same repo. Users on a forkzero-managed index get warm-started search.
+same repo. Users on a memoize-managed index get warm-started search.
 
 ### Why a separate app, not a route in `apps/server`
 
@@ -99,7 +99,7 @@ shouldn't pay that cost — it's a different process model (single CLI
 invocation, stdio-attached) and a different bundle size target.
 Separate app keeps each focused and Bun-compilable.
 
-`@forkzero/index` is the shared substrate. Both apps consume it. No
+`@memoize/index` is the shared substrate. Both apps consume it. No
 code duplication; no cross-contamination of transport concerns.
 
 ### Why npm + binary, not just binary
@@ -113,15 +113,15 @@ code duplication; no cross-contamination of transport concerns.
 
 ### Positive
 
-- Forkzero's index reaches users who don't run the desktop app.
+- Memoize's index reaches users who don't run the desktop app.
 - The MCP binary is small (no Electron, no React, no Effect RPC).
 - Same engine, same data, same answers across desktop and MCP.
-- npm distribution doubles as marketing (`@forkzero/mcp-server` is
+- npm distribution doubles as marketing (`@memoize/mcp-server` is
   searchable, installable, recommendable).
 
 ### Negative
 
-- Two apps to keep in sync. Mitigated by `@forkzero/index` being the
+- Two apps to keep in sync. Mitigated by `@memoize/index` being the
   source of truth; both apps are thin wrappers.
 - npm publishing pipeline (CI workflow, version bumps) is one more
   thing to maintain.
@@ -155,11 +155,11 @@ code duplication; no cross-contamination of transport concerns.
 
 ## What we deliberately rejected
 
-- Bundling MCP transport into `@forkzero/index`. Keeps the package
+- Bundling MCP transport into `@memoize/index`. Keeps the package
   transport-agnostic.
 - Spinning up the MCP server on demand from `apps/desktop`. The
   desktop's bundled agent uses `IndexService` in-process; users who
-  want external MCP access run `forkzero-mcp` themselves.
+  want external MCP access run `memoize-mcp` themselves.
 
 ## Reference
 

--- a/specs/0.04-MVP/decisions/0019-sqlite-vec-extension.md
+++ b/specs/0.04-MVP/decisions/0019-sqlite-vec-extension.md
@@ -6,14 +6,14 @@ Status: Accepted
 ## Context
 
 ADR 0008 established SQLite + `@effect/sql-sqlite-node` (with
-`better-sqlite3`) as forkzero's persistence engine. 0.04 adds vector
+`better-sqlite3`) as memoize's persistence engine. 0.04 adds vector
 search to the index. Three places that vector storage could live:
 
 - A separate vector DB (LanceDB, Qdrant, Chroma, Weaviate)
 - A SQLite extension that adds vector columns
 - An in-memory index (FAISS, hnswlib) backed by serialized files
 
-The forkzero principles (ADR 0007: server is the only source of truth;
+The memoize principles (ADR 0007: server is the only source of truth;
 ADR 0008: single-file portability; local-first) point at "stay inside
 SQLite if at all possible." Adding a second persistence engine adds a
 second backup story, a second failure mode, a second startup
@@ -85,7 +85,7 @@ to the existing `electron-rebuild -w` list alongside `keytar`,
 ```
 
 Per ADR 0006, native modules used by 2+ workspaces (here, `apps/server`
-and `apps/mcp-server` via `@forkzero/index`) are catalogued.
+and `apps/mcp-server` via `@memoize/index`) are catalogued.
 
 ### Embedding lifecycle
 
@@ -116,7 +116,7 @@ Migrations are run via `@effect/sql/Migrator` at engine startup.
 ### Positive
 
 - One file, one backup story. The user's index lives in their
-  workspace's `forkzero-index.sqlite`.
+  workspace's `memoize-index.sqlite`.
 - Same query engine for vector + BM25 + symbol — joins across them are
   trivial (`JOIN chunks ON chunks.id = chunk_vec.chunk_id`).
 - Schema migrations follow the existing ADR 0008 pattern; no new

--- a/specs/0.04-MVP/decisions/0020-pluggable-rerank-and-embed.md
+++ b/specs/0.04-MVP/decisions/0020-pluggable-rerank-and-embed.md
@@ -12,7 +12,7 @@ quality / speed / cost / privacy axes:
 - **Local default** (free, private, but quality is below SOTA)
 - **Voyage / Cohere / OpenAI** (paid, SOTA quality, requires API key,
   chunks leave the user's machine)
-- **Forkzero-cloud** (deferred — see ADR 0021)
+- **Memoize-cloud** (deferred — see ADR 0021)
 
 Different users have different needs. A solo developer indexing a
 private repo wants local-only. A team OK with sharing chunks with
@@ -22,10 +22,10 @@ the engine's internals.
 
 ## Decision
 
-Define two **provider abstractions** in `@forkzero/index` —
+Define two **provider abstractions** in `@memoize/index` —
 `EmbeddingProvider` and `RerankProvider` — and ship multiple
 implementations. The user picks via config (env var or
-`forkzero-index.config.json` in the workspace).
+`memoize-index.config.json` in the workspace).
 
 ### EmbeddingProvider contract
 
@@ -113,7 +113,7 @@ download on first use (configurable).
 
 - Users choose between privacy (local) and quality (paid) without
   modifying engine code.
-- Adding a new provider (Cohere, Mistral, a future forkzero-cloud) is
+- Adding a new provider (Cohere, Mistral, a future memoize-cloud) is
   a new file, not a refactor.
 - Benchmarking is straightforward — swap providers and re-run the eval.
 - The provider boundary contains all network code, all credential
@@ -154,7 +154,7 @@ search
 
 - Mix-and-match per-query providers. One workspace, one embed model,
   one rerank model.
-- Forkzero-managed key escrow in 0.04. ADR 0021 defers this.
+- Memoize-managed key escrow in 0.04. ADR 0021 defers this.
 - Streaming embeddings. Embeddings are batch in nature; streaming
   doesn't help our async-worker model.
 

--- a/specs/0.04-MVP/decisions/0021-credentials-and-billing.md
+++ b/specs/0.04-MVP/decisions/0021-credentials-and-billing.md
@@ -11,14 +11,14 @@ Jina) — these need credentials, and someone has to pay the bill.
 
 There are three credible billing shapes for paid providers:
 
-| Shape | What user does | Where forkzero is in the path | Forkzero infra needed |
+| Shape | What user does | Where memoize is in the path | Memoize infra needed |
 |---|---|---|---|
 | **Local** | Nothing | Not in the path | None |
 | **BYOK** | Pastes their own key in Settings | Not in the path; chunks go user → provider directly | None |
-| **Forkzero-cloud** | Subscribes; we proxy | In the path; chunks traverse our proxy | Auth, billing, rate limit, abuse mitigation, support |
+| **Memoize-cloud** | Subscribes; we proxy | In the path; chunks traverse our proxy | Auth, billing, rate limit, abuse mitigation, support |
 
-The temptation with "make it a service" is to ship Forkzero-cloud
-day-one. The reality of running Forkzero-cloud:
+The temptation with "make it a service" is to ship Memoize-cloud
+day-one. The reality of running Memoize-cloud:
 
 - Backend service (key management, rate limiting, key rotation, observability)
 - Stripe + sales tax / VAT in 30+ jurisdictions
@@ -36,9 +36,9 @@ without a revenue base.
 
 ## Decision
 
-**0.04 ships local + BYOK only.** Forkzero-cloud is deferred. The
+**0.04 ships local + BYOK only.** Memoize-cloud is deferred. The
 architecture leaves the door open: the provider abstraction (ADR 0020)
-treats `forkzero-cloud` as one more provider. Adding it later is
+treats `memoize-cloud` as one more provider. Adding it later is
 two new files plus a billing service, not re-architecting.
 
 ### Local (default)
@@ -54,42 +54,42 @@ the existing `keytar` pattern from agent integration (Phase 2), with new
 slots:
 
 ```
-forkzero:embed:voyage     → VOYAGE_API_KEY
-forkzero:embed:openai     → OPENAI_API_KEY
-forkzero:embed:jina       → JINA_API_KEY
-forkzero:rerank:cohere    → COHERE_API_KEY
-forkzero:rerank:voyage    → VOYAGE_API_KEY
+memoize:embed:voyage     → VOYAGE_API_KEY
+memoize:embed:openai     → OPENAI_API_KEY
+memoize:embed:jina       → JINA_API_KEY
+memoize:rerank:cohere    → COHERE_API_KEY
+memoize:rerank:voyage    → VOYAGE_API_KEY
 ```
 
 When the user selects a paid provider, `apps/server` reads the matching
 key from keytar at engine startup and injects it into the provider via
 env var. Keys never logged. Never written to disk in plaintext. Never
-sent to forkzero servers (because there are none in 0.04).
+sent to memoize servers (because there are none in 0.04).
 
 For the standalone MCP server (`apps/mcp-server`), keys come from env
 vars directly — the binary doesn't access keytar.
 
-### Forkzero-cloud (deferred)
+### Memoize-cloud (deferred)
 
-A `forkzero-cloud` provider stub exists in 0.04 but throws "not yet
+A `memoize-cloud` provider stub exists in 0.04 but throws "not yet
 available" if selected. This is intentional:
 
-- The UI surface ("Forkzero-cloud — coming soon") signals to users
+- The UI surface ("Memoize-cloud — coming soon") signals to users
   that this option exists.
 - Pre-allocates a name in the provider registry so future config can
   reference it without breaking change.
 - Forces us to keep the provider abstraction honest (if we couldn't
-  drop in `forkzero-cloud` later, the abstraction would be wrong).
+  drop in `memoize-cloud` later, the abstraction would be wrong).
 
-When we eventually ship Forkzero-cloud (a future MVP, not 0.04):
+When we eventually ship Memoize-cloud (a future MVP, not 0.04):
 
-- Implement the `forkzero-cloud` embed and rerank providers (HTTP
+- Implement the `memoize-cloud` embed and rerank providers (HTTP
   clients hitting our proxy)
 - Build `apps/billing-proxy` (or run as a service)
 - Add Stripe integration, key issuance, rate limiting
 - Document the privacy trade-off honestly
 
-### Why pre-stub `forkzero-cloud` now
+### Why pre-stub `memoize-cloud` now
 
 If we leave it out entirely, future ADRs may need to reshape the
 provider contract to fit a billing model we hadn't imagined. By
@@ -112,11 +112,11 @@ a one-package-touch.
 - BYOK costs nothing to support — same pattern as Phase 2 agent keys.
 - The cloud option exists conceptually; users see it labeled and know
   it's planned.
-- When we do build Forkzero-cloud, the architecture doesn't change.
+- When we do build Memoize-cloud, the architecture doesn't change.
 
 ### Negative
 
-- Forkzero-cloud users have to wait. We won't have recurring revenue
+- Memoize-cloud users have to wait. We won't have recurring revenue
   from this product surface in 0.04.
 - BYOK requires users to sign up at Voyage / Cohere / OpenAI etc.,
   which is friction. Some users will abandon and use local-only.
@@ -125,11 +125,11 @@ a one-package-touch.
 
 ## Alternatives considered
 
-### (a) BYOK only, defer forkzero-cloud forever
+### (a) BYOK only, defer memoize-cloud forever
 
 - Pro: zero billing complexity, ever.
 - Con: forecloses recurring revenue and team-shared cloud index.
-  Forkzero stays an OSS tool. Possibly fine; possibly limiting.
+  Memoize stays an OSS tool. Possibly fine; possibly limiting.
 
 ### (b) Ship pay-per-usage in 0.04 alongside BYOK
 
@@ -138,14 +138,14 @@ a one-package-touch.
   index work itself. Doubles 0.04's scope. Likely delays shipping
   by a quarter.
 
-### (c) BYOK in 0.04 + scaffold forkzero-cloud stub now (chosen)
+### (c) BYOK in 0.04 + scaffold memoize-cloud stub now (chosen)
 
 - Pro: ship 0.04 fast; preserve optionality; exercise the abstraction.
 - Con: stub debt (must follow through eventually).
 
 ## What we deliberately rejected
 
-- Forkzero-cloud as the *default*. Local-first is the principle (matches
+- Memoize-cloud as the *default*. Local-first is the principle (matches
   ADR 0007's local-only-v1 stance).
 - Storing API keys in plaintext config. Keytar is the standard.
 - Per-query keys (passing keys with each request). Provider holds the

--- a/specs/0.04-MVP/features/code-index.md
+++ b/specs/0.04-MVP/features/code-index.md
@@ -6,26 +6,26 @@ via `apps/mcp-server`). One engine, one chunk store, two transports.
 
 ## Why this exists
 
-Agents inside forkzero spend most of their token budget on navigation —
+Agents inside memoize spend most of their token budget on navigation —
 `Bash(rg ...)` → `Read` → repeat. On a real codebase: 25–40k tokens across
 5–8 tool calls before the agent has the context to work. Most of that is
 *tax*, not value.
 
 Existing tools (Cursor, Sourcegraph Cody, Greptile, Continue, Augment) all
 build codebase indexes. None handle the **N parallel agent workspaces on
-the same repo** shape that Conductor + forkzero already produces. That's
+the same repo** shape that Conductor + memoize already produces. That's
 the wedge: not "vector DB for code," but "the only index built for the
 parallel-workspace agent workflow."
 
 ## Goals
 
-1. **Tokens-per-task ↓ 3–10×** vs. baseline grep agent on real forkzero tasks.
+1. **Tokens-per-task ↓ 3–10×** vs. baseline grep agent on real memoize tasks.
 2. **Wall-clock-per-task ↓ 2–3×** (driven by fewer LLM round-trips, not
    faster retrieval).
 3. **Branch switches in < 200 ms**, not minutes — Conductor workspace
    ergonomics demand this.
 4. **Local-first**, zero network calls in the default config.
-5. **Reusable**: forkzero is one consumer, not the only consumer.
+5. **Reusable**: memoize is one consumer, not the only consumer.
 
 ## Non-goals
 
@@ -42,7 +42,7 @@ wraps it as MCP, and a future cloud-sync worker is a third consumer.
 
 ```
 packages/
-  index/                              # @forkzero/index — pure engine
+  index/                              # @memoize/index — pure engine
     src/
       schema/migrations/              # SQL files
       chunker/                        # tree-sitter chunking
@@ -62,14 +62,14 @@ packages/
 apps/
   server/
     src/
-      index/                          # consumes @forkzero/index
+      index/                          # consumes @memoize/index
         index-service.ts              # Effect.Service wrapping the engine
         index-handlers.ts             # RPC handlers → renderer
   mcp-server/                         # NEW — standalone MCP app
     src/
       server.ts                       # MCP stdio + HTTP entry
       tools/                          # MCP tool wrappers
-      bin.ts                          # `forkzero-mcp` executable
+      bin.ts                          # `memoize-mcp` executable
 ```
 
 The desktop renderer never talks to the index directly — it goes through
@@ -189,7 +189,7 @@ on branch switch:
   no re-parsing for unchanged blobs
 ```
 
-Initial index of a forkzero-sized repo (~80k LOC TypeScript): target
+Initial index of a memoize-sized repo (~80k LOC TypeScript): target
 60–120s. Per-file change: 10–50ms. Branch switch: < 200ms.
 
 **Tree-sitter grammars** loaded on demand: TypeScript, JavaScript, TSX,
@@ -319,25 +319,25 @@ provider abstraction.
 
 Three concentric tiers. **Only the first two ship in 0.04.**
 
-| Tier | Mode | What user does | Where forkzero is in the path |
+| Tier | Mode | What user does | Where memoize is in the path |
 |---|---|---|---|
 | **1. Local** (default) | nomic-embed-code + bge-reranker-v2-m3 via `transformers.js` | Nothing. Works out of the box. | Not in the path. |
 | **2. BYOK** | User pastes their Voyage / Cohere / OpenAI / Jina key | One-time: paste key in Settings → Index | Not in the path. Chunks go user → provider directly. |
-| **3. Forkzero-cloud** (deferred) | Pay forkzero (subscription or metered); we proxy | Sign up, swipe card | In the path — chunks traverse forkzero's proxy. |
+| **3. Memoize-cloud** (deferred) | Pay memoize (subscription or metered); we proxy | Sign up, swipe card | In the path — chunks traverse memoize's proxy. |
 
 **BYOK storage** uses the existing `keytar` pattern from agent integration
 (see [agent-integration.md](../../0.01-MVP/features/agent-integration.md)),
 same shape, new key slots:
 
 ```
-forkzero:embed:voyage     → VOYAGE_API_KEY
-forkzero:embed:openai     → OPENAI_API_KEY
-forkzero:embed:jina       → JINA_API_KEY
-forkzero:rerank:cohere    → COHERE_API_KEY
-forkzero:rerank:voyage    → VOYAGE_API_KEY
+memoize:embed:voyage     → VOYAGE_API_KEY
+memoize:embed:openai     → OPENAI_API_KEY
+memoize:embed:jina       → JINA_API_KEY
+memoize:rerank:cohere    → COHERE_API_KEY
+memoize:rerank:voyage    → VOYAGE_API_KEY
 ```
 
-Never logged. Never written to disk in plaintext. Never sent to forkzero
+Never logged. Never written to disk in plaintext. Never sent to memoize
 servers (because there are none in 0.04).
 
 See [ADR 0021](../decisions/0021-credentials-and-billing.md) for why
@@ -347,9 +347,9 @@ pay-per-usage is deferred.
 
 Two consumption shapes.
 
-### Shape 1 — In-process (forkzero's bundled agent)
+### Shape 1 — In-process (memoize's bundled agent)
 
-`apps/server` consumes `@forkzero/index` directly. The Claude Code SDK and
+`apps/server` consumes `@memoize/index` directly. The Claude Code SDK and
 Codex SDK adapters register five custom tools at session start:
 
 ```ts
@@ -369,15 +369,15 @@ A standalone binary that any agent runtime can spawn. Implements the
 Model Context Protocol over stdio (default) and HTTP (optional).
 
 ```
-forkzero-mcp --workspace /path/to/repo
-forkzero-mcp --workspace /path/to/repo --http :7421
+memoize-mcp --workspace /path/to/repo
+memoize-mcp --workspace /path/to/repo --http :7421
 ```
 
 Distribution:
 
-- npm: `npx @forkzero/mcp-server`
+- npm: `npx @memoize/mcp-server`
 - Bun standalone binary via `bun build --compile` (single executable per OS)
-- Bundled inside the desktop app for users who want their forkzero-managed
+- Bundled inside the desktop app for users who want their memoize-managed
   index served to outside agents
 
 Tool surface (mirrors Shape 1):
@@ -403,7 +403,7 @@ A typical external-agent setup (terminal Claude Code) drops a line in
 `~/.claude/mcp.json`:
 
 ```json
-{ "servers": { "forkzero": { "command": "forkzero-mcp", "args": ["--workspace", "."] } } }
+{ "servers": { "memoize": { "command": "memoize-mcp", "args": ["--workspace", "."] } } }
 ```
 
 …and gets the same tools as the bundled agent.
@@ -439,7 +439,7 @@ scaffolding for future UI.
 
 ## Verification
 
-1. **Unit tests** (`bun --filter @forkzero/index test`): chunker fixtures,
+1. **Unit tests** (`bun --filter @memoize/index test`): chunker fixtures,
    symbol extraction fixtures, manifest swap, RRF correctness, router
    classification edge cases.
 2. **Integration tests** (`apps/server`): reindex this repo, run a sample
@@ -452,7 +452,7 @@ scaffolding for future UI.
 4. **MCP smoke test**: spawn `apps/mcp-server` from a script; connect via
    the `@modelcontextprotocol/sdk` client; call each tool with a fixture
    query; assert response shape.
-5. **Manual dogfood**: open forkzero on the forkzero repo itself; ask the
+5. **Manual dogfood**: open memoize on the memoize repo itself; ask the
    bundled agent "where is the PTY service spun up and how does it stream
    data to the renderer?"; observe it answers in 1–2 tool calls instead
    of 5+.
@@ -472,6 +472,6 @@ Phase B freezes:
 3. **Refs accuracy floor.** Tree-sitter alone gets 70–80% accurate refs;
    full TS resolution needs `ts-morph` (heavy). Recommendation: ship
    tree-sitter-only; upgrade later if evals show false negatives matter.
-4. **MCP server distribution.** Ship `@forkzero/mcp-server` as a separate
+4. **MCP server distribution.** Ship `@memoize/mcp-server` as a separate
    npm package from day 1, or bundle inside the Electron app first?
    Recommendation: ship the npm package in Phase F.

--- a/specs/0.04-MVP/roadmap.md
+++ b/specs/0.04-MVP/roadmap.md
@@ -13,15 +13,15 @@ Tree-sitter chunker, symbol extractor, SQLite schema, content-addressed
 blob store, manifest model. **No retrieval yet.**
 
 - `packages/index/` scaffold + Effect Service contract
-- ADR 0013 — `@forkzero/index` as standalone package
+- ADR 0013 — `@memoize/index` as standalone package
 - ADR 0014 — content-addressed chunk store + per-branch manifest
 - ADR 0015 — tree-sitter for chunking & symbols
 - TypeScript + JavaScript + TSX grammars only
 - Migrations under `packages/index/src/schema/migrations/`
-- Tests: index forkzero itself; assert chunk count, symbol count, blob
+- Tests: index memoize itself; assert chunk count, symbol count, blob
   dedup across two branches with shared files
 
-**Acceptance:** `bun --filter @forkzero/index test` passes; indexing this
+**Acceptance:** `bun --filter @memoize/index test` passes; indexing this
 repo produces > 5,000 chunks and > 2,000 symbols; switching `main` ↔ a
 branch with one changed file results in exactly one new blob row.
 
@@ -90,14 +90,14 @@ Standalone MCP binary, npm-distributable, Bun-compiled.
 - ADR 0018 — MCP server as standalone app
 - stdio transport (default), HTTP transport (optional)
 - All five tools registered, JSON Schema validated
-- `bun build --compile` produces `forkzero-mcp` per OS
-- npm publish: `@forkzero/mcp-server`
+- `bun build --compile` produces `memoize-mcp` per OS
+- npm publish: `@memoize/mcp-server`
 - ADR 0021 — credentials and billing (BYOK in 0.04, cloud deferred)
 - Smoke test: terminal Claude Code session pointed at the MCP server can
   call all five tools end-to-end
 
-**Acceptance:** `npx @forkzero/mcp-server --workspace .` runs; an external
-agent (terminal `claude`) using only `forkzero-mcp` tools (no built-in
+**Acceptance:** `npx @memoize/mcp-server --workspace .` runs; an external
+agent (terminal `claude`) using only `memoize-mcp` tools (no built-in
 grep) finishes ≥ 80% of the eval harness tasks.
 
 ## Phase G — Cloud team index (deferred)
@@ -107,7 +107,7 @@ Out of scope for 0.04. Spec'd separately in a future MVP.
 - S3-compatible chunk-store sync (the blob store is already content-addressed)
 - Per-team encryption keys
 - Embedding inversion mitigation (research, not yet a decision)
-- Forkzero-cloud as a paid embedding/rerank proxy
+- Memoize-cloud as a paid embedding/rerank proxy
 
 ## Total
 
@@ -129,7 +129,7 @@ becomes a focused PR, not a redesign.
 
 | Milestone | What changes |
 |---|---|
-| Cloud team index | Drop in a sync worker over the existing content-addressed blob store; add `forkzero-cloud` provider for embed/rerank. |
+| Cloud team index | Drop in a sync worker over the existing content-addressed blob store; add `memoize-cloud` provider for embed/rerank. |
 | Symbol-aware refactors | The `refs` table is already populated — building rename/extract on top is incremental. |
 | Cross-repo search | Index multiple workspaces under one query — needs a workspace-spanning manifest layer. |
 

--- a/specs/sub-agents/README.md
+++ b/specs/sub-agents/README.md
@@ -10,7 +10,7 @@ the main conversation.
 
 The primitive is already in Anthropic's Agent SDK
 ([`agents` parameter](https://code.claude.com/docs/en/agent-sdk/subagents) +
-the built-in `Agent` tool). The work here is wiring it through forkzero's
+the built-in `Agent` tool). The work here is wiring it through memoize's
 Effect provider stack and surfacing the nested calls in the chat UI.
 
 ## What lands in this PR
@@ -43,14 +43,14 @@ Effect provider stack and surfacing the nested calls in the chat UI.
 
 - **Cross-provider sub-agents** — Claude main → Codex sub (and vice versa).
   The SDK's `agents` parameter only spawns Claude sub-agents. Cross-provider
-  needs a forkzero-internal MCP bridge tool. Sketched in
+  needs a memoize-internal MCP bridge tool. Sketched in
   [features/cross-provider.md](features/cross-provider.md), implemented in
   a follow-up PR.
 - **User-defined sub-agents in settings UI.** This PR ships preset toggles
   + per-preset edits. Creating brand-new sub-agents from scratch in the UI
   comes after we see how the presets get used.
 - **Filesystem-based agents** (`.claude/agents/*.md`). Claude Code parity
-  is nice but not critical for forkzero's chat-first surface.
+  is nice but not critical for memoize's chat-first surface.
 - **Multi-level nesting.** The SDK explicitly forbids sub-agents spawning
   their own sub-agents. Renderer assumes `depth ≤ 1`.
 - **Background sub-agents** (SDK `background: true`). Useful for

--- a/specs/sub-agents/decisions/0010-sdk-native-agents-param.md
+++ b/specs/sub-agents/decisions/0010-sdk-native-agents-param.md
@@ -14,7 +14,7 @@ model. There are three viable shapes:
    parse the parent's intent, decide a model, spawn a fresh `query()`
    ourselves, plumb the result back as a synthetic assistant message.
 3. Wrap each sub-agent as a custom MCP tool — the parent calls e.g.
-   `forkzero.research(prompt)` and we run it however we like under the
+   `memoize.research(prompt)` and we run it however we like under the
    hood.
 
 ## Options
@@ -44,7 +44,7 @@ query({
 The SDK handles invocation (`Agent` tool_use), context isolation
 (separate fresh context window per sub-agent), result return (final
 message returns as `tool_result`), and `parent_tool_use_id` correlation.
-Forkzero just consumes the existing event stream.
+Memoize just consumes the existing event stream.
 
 **Pros**
 
@@ -97,7 +97,7 @@ assistant message.
 
 ### Option 3 — Each sub-agent as a custom MCP tool
 
-Define `forkzero.research`, `forkzero.file-edits`, `forkzero.test-runner`
+Define `memoize.research`, `memoize.file-edits`, `memoize.test-runner`
 as MCP tools. The parent agent calls them like any other tool.
 
 **Pros**
@@ -138,6 +138,6 @@ shortest path with the strongest correctness guarantees.
   (the MCP bridge). They can't share the SDK's `agents` primitive —
   that's an Anthropic-only construct. ADR 0012 covers the bridge.
 - We do **not** add a routing heuristic, intent classifier, or any
-  forkzero-side decision about when to delegate. The main model
+  memoize-side decision about when to delegate. The main model
   decides, based on each sub-agent's `description`. Tuning the
   descriptions is the operator surface.

--- a/specs/sub-agents/decisions/0012-codex-bridge-via-mcp.md
+++ b/specs/sub-agents/decisions/0012-codex-bridge-via-mcp.md
@@ -42,9 +42,9 @@ Both Claude and Codex SDKs accept MCP servers via standard config. We
 register an in-process MCP server (no socket — `@modelcontextprotocol/sdk`
 supports in-memory transports) that exposes:
 
-- `forkzero.delegate-codex(agent_name, prompt, model?)` → invoked by
+- `memoize.delegate-codex(agent_name, prompt, model?)` → invoked by
   Claude main sessions.
-- `forkzero.delegate-claude(agent_name, prompt, model?)` → invoked by
+- `memoize.delegate-claude(agent_name, prompt, model?)` → invoked by
   Codex main sessions.
 
 The bridge tool's implementation:
@@ -80,7 +80,7 @@ The bridge tool's implementation:
 
 ### Option 3 — Hand-roll a router in the wire layer
 
-Same shape as ADR 0010 Option 2: forkzero-side intent classifier picks
+Same shape as ADR 0010 Option 2: memoize-side intent classifier picks
 a provider, makes a separate `query()` call, splices the result back.
 
 Already rejected for same-provider in ADR 0010. The reasoning is
@@ -93,12 +93,12 @@ translation. No.
 **Custom MCP bridge tool (Option 2).**
 
 Both SDKs natively support MCP. The bridge stays small (one module,
-`apps/server/src/provider/mcp/forkzero-bridge.ts`) and forkzero stays
+`apps/server/src/provider/mcp/memoize-bridge.ts`) and memoize stays
 out of the SDKs' guts. The same code path works in both directions.
 
 ## Consequences
 
-- New module: `apps/server/src/provider/mcp/forkzero-bridge.ts`
+- New module: `apps/server/src/provider/mcp/memoize-bridge.ts`
   exposes the in-memory MCP server. Registered with whichever
   provider's driver is the *main* agent for a session.
 - Cross-provider preset entries in `apps/renderer/src/lib/subagent-presets.ts`

--- a/specs/sub-agents/features/cross-provider.md
+++ b/specs/sub-agents/features/cross-provider.md
@@ -33,8 +33,8 @@ What both SDKs **do** support is **MCP tools** — model-side function
 calls into a server we control. Both providers will happily call an
 arbitrary tool, await its result, and incorporate the result into the
 conversation. So the bridge is shaped as an **in-process MCP server**
-that exposes tools like `forkzero.delegate-codex` and
-`forkzero.delegate-claude`, registered with whichever provider is
+that exposes tools like `memoize.delegate-codex` and
+`memoize.delegate-claude`, registered with whichever provider is
 currently the *main* agent.
 
 ## Architecture
@@ -47,7 +47,7 @@ currently the *main* agent.
 │   │  Opus 4.7             │  call   │  gpt-5-mini          │     │
 │   │  query({              │ ──────▶ │  (spun up by bridge) │     │
 │   │    mcpServers: {      │         │                      │     │
-│   │      forkzero: …      │         │                      │     │
+│   │      memoize: …      │         │                      │     │
 │   │    }                  │ ◀────── │                      │     │
 │   │  })                   │ result  │                      │     │
 │   └───────────────────────┘         └──────────────────────┘     │
@@ -67,7 +67,7 @@ currently the *main* agent.
        └─────────────────────────────────────────────┘
 ```
 
-## New piece: `apps/server/src/provider/mcp/forkzero-bridge.ts`
+## New piece: `apps/server/src/provider/mcp/memoize-bridge.ts`
 
 An in-process MCP server (no socket, no subprocess — `@modelcontextprotocol/sdk`
 supports in-memory transports). Exposes two tools:
@@ -75,7 +75,7 @@ supports in-memory transports). Exposes two tools:
 ```ts
 // Registered with whichever provider is the main agent.
 {
-  name: "forkzero.delegate-codex",
+  name: "memoize.delegate-codex",
   description:
     "Delegate a scoped sub-task to a Codex (GPT-5) sub-agent. Use " +
     "when the parent is on Claude and a cheaper Codex model is the " +
@@ -93,7 +93,7 @@ supports in-memory transports). Exposes two tools:
 }
 
 {
-  name: "forkzero.delegate-claude",
+  name: "memoize.delegate-claude",
   description: "Reverse direction. Used when main is Codex.",
   inputSchema: { /* same shape */ },
 }
@@ -235,7 +235,7 @@ identical to Claude-side rows because the wire schema is the same.
   the bridge can manage. A future cleanup is a `tool-name` translation
   layer in `packages/wire/src/tools.ts`.
 - **Model auto-selection.** Today the user picks the sub-agent's
-  model. Future: forkzero suggests "based on this prompt, gpt-5-mini
+  model. Future: memoize suggests "based on this prompt, gpt-5-mini
   would be ~3× cheaper than Haiku for the same quality, switch?"
 - **Parallel cross-provider fan-out.** Phase 2's bridge is one
   sub-session at a time. Real fan-out (run `research` on Claude *and*
@@ -243,7 +243,7 @@ identical to Claude-side rows because the wire schema is the same.
 
 ## Implementation order (when Phase 2 lands)
 
-1. `apps/server/src/provider/mcp/forkzero-bridge.ts` + register with
+1. `apps/server/src/provider/mcp/memoize-bridge.ts` + register with
    the parent driver's MCP layer.
 2. `CrossProviderInvocationEvent` in `packages/wire/src/agent.ts`.
 3. Cross-provider preset entries in

--- a/specs/sub-agents/features/preset-library.md
+++ b/specs/sub-agents/features/preset-library.md
@@ -155,11 +155,11 @@ configured.
 
 ## Telemetry / observability hooks
 
-Each preset run logs (locally, to the existing forkzero log file):
+Each preset run logs (locally, to the existing memoize log file):
 
 ```
 [subagent.research] turns=8 in=12.4k out=312 cache_read=4.2k duration=3.1s
 ```
 
 Useful for tuning prompts and `maxTurns` after we see real usage. No
-network telemetry — forkzero is local-only by principle.
+network telemetry — memoize is local-only by principle.

--- a/specs/sub-agents/features/sub-agents.md
+++ b/specs/sub-agents/features/sub-agents.md
@@ -42,7 +42,7 @@ Subsequent SDK messages carry `parent_tool_use_id` pointing to that
 When the sub-agent finishes, a `tool_result` for that id lands carrying
 the sub-agent's final message as text.
 
-Forkzero's job is therefore narrow:
+Memoize's job is therefore narrow:
 
 1. Forward an `agents` map from the wire into the SDK options.
 2. Propagate `parent_tool_use_id` onto every emitted wire event.
@@ -288,8 +288,8 @@ under that parent."
 
 The `Agent` tool call IS a tool call. The wrapper row visually mirrors
 the existing `tool-row.tsx` style (hugeicons + muted-foreground + chevron
-swap on hover, per the project's [accordion pattern](../../../.claude/projects/-Users-whizzy-Developer-startups-forkzero/memory/feedback_accordion_pattern.md)
-and [icon convention](../../../.claude/projects/-Users-whizzy-Developer-startups-forkzero/memory/feedback_icons_hugeicons.md)).
+swap on hover, per the project's [accordion pattern](../../../.claude/projects/-Users-whizzy-Developer-startups-memoize/memory/feedback_accordion_pattern.md)
+and [icon convention](../../../.claude/projects/-Users-whizzy-Developer-startups-memoize/memory/feedback_icons_hugeicons.md)).
 
 Inside, every nested call uses `tool-row.tsx` *unchanged*, with a single
 `indented` prop that draws a left rail.
@@ -427,7 +427,7 @@ Opus: 4.2k in / 1.1k out · Haiku (research): 18.4k in / 412 out · saved ~$0.34
 all sub-agent turns ran on the main model, minus actual cost. Pure
 visualization — no functional impact.
 
-Renderer reads `MODEL_PRICING` from `@forkzero/wire`. When a sub-agent
+Renderer reads `MODEL_PRICING` from `@memoize/wire`. When a sub-agent
 finishes, the cumulative numbers update in place.
 
 ## Open questions left for implementation


### PR DESCRIPTION
## Summary
- Renames the app from `forkzero` to `memoize` across packages (`@memoize/server`, `@memoize/wire`), source identifiers (`MemoizeRpcs`, `MemoizeBridge`, `MEMOIZE_*` env vars), the `memoize://` URL scheme, the `Context.Tag("memoize/AppPaths")` tag, all specs/decisions docs, and the README.
- Electron `APP_NAME` also flips to `memoize`, so the userData path moves to `~/Library/Application Support/memoize` — existing local dev sessions/SQLite under `forkzero` are orphaned (delete the old dir whenever).
- GitHub remote was renamed separately to `swarajbachu/memoize`; old URL auto-redirects.

## Test plan
- [x] `bun install` regenerates lockfile cleanly
- [x] `bun run check-types` passes on all 6 packages
- [ ] Manual: launch the desktop app and verify it boots with the new name (fresh userData)