### PR TITLE
fix(desktop): mark electron as bundler-external

### DIFF
--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -15,6 +15,14 @@ const shared = {
   // it pulls in a large CommonJS dep graph (lodash, lazy-val, builder-util)
   // that loads cleanly via Node's resolver but trips bundlers.
   external: [
+    // `electron` MUST be external. At runtime in the main process,
+    // `require("electron")` is intercepted by Electron itself and returns
+    // app/BrowserWindow/etc. as native bindings. If the bundler instead
+    // inlines the `electron` npm package's index.js, that ships
+    // `getElectronPath()` (which reads node_modules/electron/path.txt to
+    // locate the binary) — at runtime that throws "Electron failed to
+    // install correctly, please delete node_modules/electron…".
+    "electron",
     "node-pty",
     "better-sqlite3",
     "bindings",


### PR DESCRIPTION
## Summary
- Fixes the packaged app crashing on launch with `Electron failed to install correctly, please delete node_modules/electron and try installing again`.
- Root cause: `tsdown.config.ts` did not list `electron` in its `external` array. tsdown inlined the npm `electron` package's `index.js` (whose only export is `getElectronPath()` reading `node_modules/electron/path.txt`) into `main.cjs`. At runtime that fired instead of Electron's runtime `require("electron")` resolver returning `app`/`BrowserWindow`/etc.
- Adding `"electron"` to externals restores the correct intercept.

## Test plan
- [x] Rebuilt unsigned `.dmg` locally (`bun run dist:mac:unsigned`)
- [x] Verified `getElectronPath` is no longer present in `dist-electron/main.cjs`
- [x] `require("electron")` is preserved at runtime (`main.cjs:33: let electron = require("electron")`)
- [x] Opened the packaged `.app` — no crash dialog, renderer paints, expected updater 404 on `releases.atom` (the v0.1.0 release is currently a draft)
- [ ] After merge: rotate the broken `v0.1.0` tag + draft release, re-tag from this commit, let CI produce a working signed/notarized DMG