### PR TITLE
feat(renderer): render answered AskUserQuestion in chat timeline

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -8,7 +8,12 @@ import {
   useState,
 } from "react";
 
-import type { AgentItemId, Message, SessionId } from "@memoize/wire";
+import type {
+  AgentItemId,
+  Message,
+  SessionId,
+  UserQuestionAnswer,
+} from "@memoize/wire";
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { useMessagesStore } from "../store/messages.ts";
@@ -125,6 +130,27 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     return map;
   }, [messages]);
 
+  // Pair `user_question_answer` rows back to their originating
+  // `user_question` by itemId so the `UserInputRow` can render Q + A as one
+  // accordion. Mirrors `resultsByItemId`. Pending (unanswered) questions
+  // stay absent from this map — `MessageRow` returns null for them and the
+  // composer slot owns the live interaction.
+  const answersByItemId = useMemo(() => {
+    const seenQuestionIds = new Set<AgentItemId>();
+    const map = new Map<AgentItemId, ReadonlyArray<UserQuestionAnswer>>();
+    for (const m of messages) {
+      if (m.content._tag === "user_question") {
+        seenQuestionIds.add(m.content.itemId);
+      } else if (
+        m.content._tag === "user_question_answer" &&
+        seenQuestionIds.has(m.content.itemId)
+      ) {
+        map.set(m.content.itemId, m.content.answers);
+      }
+    }
+    return map;
+  }, [messages]);
+
 
   return (
     <div
@@ -173,6 +199,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                   <MessageRow
                     message={turn.user}
                     resultsByItemId={resultsByItemId}
+                    answersByItemId={answersByItemId}
                     sessionId={sessionId}
                   />
                 ) : null}
@@ -180,6 +207,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                   <TurnSummary
                     body={turn.body}
                     resultsByItemId={resultsByItemId}
+                    answersByItemId={answersByItemId}
                   />
                 ) : (
                   bodyGroups.map((group) =>
@@ -188,6 +216,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                         key={group.message.id}
                         message={group.message}
                         resultsByItemId={resultsByItemId}
+                        answersByItemId={answersByItemId}
                         sessionId={sessionId}
                       />
                     ) : (
@@ -200,6 +229,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                         children={group.children}
                         summary={group.summary}
                         resultsByItemId={resultsByItemId}
+                        answersByItemId={answersByItemId}
                       />
                     ),
                   )

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -12,6 +12,7 @@ import type {
   Message,
   SessionId,
   SkillRef,
+  UserQuestionAnswer,
 } from "@memoize/wire";
 
 import {
@@ -20,7 +21,12 @@ import {
 } from "~/lib/icons/material-icons";
 import { cn } from "~/lib/utils";
 
-import { ExitPlanModeRow, ThinkingRow, ToolRow } from "./tool-row.tsx";
+import {
+  ExitPlanModeRow,
+  ThinkingRow,
+  ToolRow,
+  UserInputRow,
+} from "./tool-row.tsx";
 
 export interface ToolResultRecord {
   readonly output: unknown;
@@ -52,10 +58,12 @@ const stringifyJson = (value: unknown): string => {
 export function MessageRow({
   message,
   resultsByItemId,
+  answersByItemId,
   sessionId,
 }: {
   message: Message;
   resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
+  answersByItemId?: ReadonlyMap<AgentItemId, ReadonlyArray<UserQuestionAnswer>>;
   sessionId?: SessionId;
 }) {
   switch (message.content._tag) {
@@ -106,14 +114,20 @@ export function MessageRow({
         <ToolErrorRow output={message.content.output} />
       ) : null;
     }
-    case "user_question":
+    case "user_question": {
+      // Pending questions live in the composer slot — ChatComposer swaps the
+      // editor for a QuestionCard. Once answered, the question + the user's
+      // selections render here as a `UserInputRow` accordion so the Q&A
+      // stays visible in scrollback like every other tool call.
+      const answers = answersByItemId?.get(message.content.itemId);
+      if (answers === undefined) return null;
+      return (
+        <UserInputRow questions={message.content.questions} answers={answers} />
+      );
+    }
     case "user_question_answer":
-      // Questions live in the composer slot, not the timeline — pending
-      // ones are rendered by ChatComposer (it swaps the editor for a
-      // QuestionCard); answered ones vanish entirely so the chat scrollback
-      // doesn't accumulate noisy decision rows. The agent's resulting
-      // assistant message is the timeline-visible record of what the
-      // answers led to.
+      // The paired `user_question` row above renders the answer inline, so
+      // the standalone answer row is suppressed.
       return null;
     case "error":
       return <ErrorBubble text={message.content.message} />;

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -6,7 +6,11 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type { AgentItemId, Message } from "@memoize/wire";
+import type {
+  AgentItemId,
+  Message,
+  UserQuestionAnswer,
+} from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 
@@ -50,6 +54,7 @@ export function SubagentRow({
   children,
   summary,
   resultsByItemId,
+  answersByItemId,
 }: {
   readonly agentToolUseId: AgentItemId;
   readonly agentName: string;
@@ -64,6 +69,10 @@ export function SubagentRow({
     readonly isError: boolean;
   } | null;
   readonly resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
+  readonly answersByItemId?: ReadonlyMap<
+    AgentItemId,
+    ReadonlyArray<UserQuestionAnswer>
+  >;
 }) {
   // Auto-expand while running (no summary yet) so the user can watch the
   // sub-agent work. Once finished, collapse to a one-line meta summary.
@@ -128,6 +137,7 @@ export function SubagentRow({
                 key={m.id}
                 message={m}
                 resultsByItemId={resultsByItemId}
+                answersByItemId={answersByItemId}
               />
             ))}
           </div>

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -1,12 +1,15 @@
 import {
   Brain01Icon,
+  BubbleChatIcon,
   CheckListIcon,
+  Copy01Icon,
   File01Icon,
   GlobeIcon,
   PencilEdit01Icon,
   Robot01Icon,
   SearchIcon,
   TerminalIcon,
+  Tick02Icon,
   Wrench01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -15,7 +18,11 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { SessionId } from "@memoize/wire";
+import type {
+  SessionId,
+  UserQuestion,
+  UserQuestionAnswer,
+} from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 
@@ -778,6 +785,134 @@ export function ExitPlanModeRow({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Timeline card for an answered `AskUserQuestion`. While the question is
+ * still pending, the composer slot owns the interaction (see
+ * `ChatComposer`); once the user submits, this card lands inline in
+ * scrollback. Mirrors the `ExitPlanModeRow` card layout — header icon +
+ * label + copy button, body, then a footer with meta on the left and the
+ * status pill on the right.
+ */
+export function UserInputRow({
+  questions,
+  answers,
+}: {
+  readonly questions: ReadonlyArray<UserQuestion>;
+  readonly answers: ReadonlyArray<UserQuestionAnswer>;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    const text = questions
+      .map((q, i) => {
+        const summary = answerSummaryText(q, answers, i);
+        return `Q: ${q.question}\nA: ${summary ?? "(cancelled)"}`;
+      })
+      .join("\n\n");
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div className="py-2">
+      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <HugeiconsIcon icon={BubbleChatIcon} size={14} strokeWidth={2} />
+        <span>User input</span>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={copied ? "Copied" : "Copy Q&A"}
+          title={copied ? "Copied" : "Copy"}
+          className="rounded p-0.5 text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground"
+        >
+          <HugeiconsIcon
+            icon={copied ? Tick02Icon : Copy01Icon}
+            size={12}
+            strokeWidth={2}
+          />
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {questions.map((q, i) => {
+          const summary = answerSummary(q, answers, i);
+          return (
+            <div key={i} className="text-sm">
+              <div className="border-l-2 border-border/60 pl-3 text-foreground/70">
+                {q.question}
+              </div>
+              <div className="mt-1 pl-3 text-foreground">
+                {summary === null ? (
+                  <span className="italic text-muted-foreground">
+                    (cancelled)
+                  </span>
+                ) : (
+                  summary
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
+        <span>
+          {questions.length}{" "}
+          {questions.length === 1 ? "question" : "questions"}
+        </span>
+        <span className="rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-500/90">
+          Answered
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One question's answer formatted for display: selected option labels
+ * joined with `, ` then optionally `· <other>` for free-text. Returns
+ * `null` when the user submitted nothing (cancelled).
+ */
+function answerSummary(
+  question: UserQuestion,
+  answers: ReadonlyArray<UserQuestionAnswer>,
+  index: number,
+): React.ReactNode | null {
+  const a = answers.find((x) => x.questionIndex === index);
+  const picks = (a?.selected ?? []).map(
+    (idx) => question.options[idx] ?? `#${idx}`,
+  );
+  const other = a?.other?.trim() ?? "";
+  if (picks.length === 0 && other.length === 0) return null;
+  return (
+    <>
+      {picks.length > 0 ? picks.join(", ") : null}
+      {picks.length > 0 && other.length > 0 ? " · " : null}
+      {other.length > 0 ? <span className="italic">{other}</span> : null}
+    </>
+  );
+}
+
+/** Plain-text version of `answerSummary` for clipboard export. */
+function answerSummaryText(
+  question: UserQuestion,
+  answers: ReadonlyArray<UserQuestionAnswer>,
+  index: number,
+): string | null {
+  const a = answers.find((x) => x.questionIndex === index);
+  const picks = (a?.selected ?? []).map(
+    (idx) => question.options[idx] ?? `#${idx}`,
+  );
+  const other = a?.other?.trim() ?? "";
+  if (picks.length === 0 && other.length === 0) return null;
+  const parts: string[] = [];
+  if (picks.length > 0) parts.push(picks.join(", "));
+  if (other.length > 0) parts.push(other);
+  return parts.join(" · ");
 }
 
 export function ToolRow({

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -8,7 +8,11 @@ import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { AgentItemId, Message } from "@memoize/wire";
+import type {
+  AgentItemId,
+  Message,
+  UserQuestionAnswer,
+} from "@memoize/wire";
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { cn } from "~/lib/utils";
@@ -73,9 +77,14 @@ const MAX_PREVIEW_ICONS = 5;
 export function TurnSummary({
   body,
   resultsByItemId,
+  answersByItemId,
 }: {
   body: ReadonlyArray<Message>;
   resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
+  answersByItemId?: ReadonlyMap<
+    AgentItemId,
+    ReadonlyArray<UserQuestionAnswer>
+  >;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -193,6 +202,7 @@ export function TurnSummary({
                 key={group.message.id}
                 message={group.message}
                 resultsByItemId={resultsByItemId}
+                answersByItemId={answersByItemId}
               />
             ) : (
               <SubagentRow
@@ -204,6 +214,7 @@ export function TurnSummary({
                 children={group.children}
                 summary={group.summary}
                 resultsByItemId={resultsByItemId}
+                answersByItemId={answersByItemId}
               />
             ),
           )}


### PR DESCRIPTION
## Summary

After a user answers an `AskUserQuestion` prompt, the Q&A pair now lands in scrollback as a "User input" card (chat-bubble icon, copy button, quoted question + chosen answer, "Answered" pill) instead of vanishing once the composer-slot interaction completes. Pending questions still take over the composer slot via `QuestionCard`, and `ExitPlanModeRow` is unchanged.

Threaded a new `answersByItemId` map (mirror of `resultsByItemId`) through `ChatView` → `MessageRow` / `TurnSummary` / `SubagentRow` so the row renders consistently inside collapsed turns and sub-agent runs too.

## Test plan

- [ ] Trigger an `AskUserQuestion` flow, submit answers, confirm "User input" card appears inline in the timeline.
- [ ] Copy button populates clipboard with `Q: ... / A: ...` for each pair.
- [ ] Cancelled answers render as italic `(cancelled)`.
- [ ] Sub-agent that asks a question shows the card nested under its `SubagentRow`.
- [ ] `ExitPlanMode` approve/reject still renders the existing card (no regression).