### PR TITLE
fix(renderer): scope active context per project + unstick composer

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -157,6 +157,15 @@ export function ChatComposer({ session }: { session: Session }) {
   useEffect(() => {
     void hydratePermissions(sessionId);
   }, [sessionId, hydratePermissions]);
+  // Reconcile permission requests whenever the running flag transitions
+  // true → false. A turn that ended (or aborted) sometimes leaves a stale
+  // pending-permission row in the client cache — the row's UI then takes
+  // over the composer slot and looks like the input is disabled. Re-asking
+  // the server clears anything it already resolved.
+  useEffect(() => {
+    if (inFlight) return;
+    void hydratePermissions(sessionId);
+  }, [inFlight, sessionId, hydratePermissions]);
   const headPermission = pendingPermissions[0];
 
   const [hasText, setHasText] = useState(false);

--- a/apps/renderer/src/components/composer/file-chip-hover.tsx
+++ b/apps/renderer/src/components/composer/file-chip-hover.tsx
@@ -39,7 +39,7 @@ export function FileChipHover({
   const [state, setState] = useState<HoverState | null>(null);
   const hideTimer = useRef<number | null>(null);
   const openFileInTab = useUiStore((s) => s.openFileInTab);
-  const worktreeId = useActiveWorktreeId();
+  const worktreeId = useActiveWorktreeId(projectId);
 
   useEffect(() => {
     const host = hostRef.current;

--- a/apps/renderer/src/components/cost-footer.tsx
+++ b/apps/renderer/src/components/cost-footer.tsx
@@ -142,13 +142,19 @@ export function CostFooter({ sessionId }: { sessionId: SessionId }) {
       const counterModel =
         slot.parentItemId === null ? slot.model : (mainModel ?? slot.model);
       counterfactualUsd += usdFor(counterModel, slot.bucket);
+      // Sub-agent `result` events sometimes ship without a model field —
+      // the driver tags those "unknown". Tokens are real, so still print
+      // them; drop the unhelpful label.
+      const tokens = `${formatTokens(slot.bucket.inputTokens)} in / ${formatTokens(slot.bucket.outputTokens)} out`;
+      if (slot.model === "unknown") {
+        lines.push(tokens);
+        continue;
+      }
       const label =
         slot.parentItemId === null
           ? labelForModel(slot.model)
           : `${labelForModel(slot.model)} (${slot.agentName})`;
-      lines.push(
-        `${label}: ${formatTokens(slot.bucket.inputTokens)} in / ${formatTokens(slot.bucket.outputTokens)} out`,
-      );
+      lines.push(`${label}: ${tokens}`);
     }
     const saved = counterfactualUsd - actualUsd;
     return { lines, saved };

--- a/apps/renderer/src/components/file-tree.tsx
+++ b/apps/renderer/src/components/file-tree.tsx
@@ -12,6 +12,7 @@ import {
 import { useComposerBridge } from "../store/composer-bridge.ts";
 import { useUiStore } from "../store/ui.ts";
 import { FileIcon } from "./file-icon.tsx";
+import { Skeleton } from "./ui/skeleton.tsx";
 import {
   Tooltip,
   TooltipPopup,
@@ -49,7 +50,7 @@ export function FileTree({ folderId }: { folderId: FolderId }) {
   // Follow the selected session's worktree when it has one. The reset effect
   // depends on `worktreeId` so toggling worktrees re-roots the tree without
   // unmounting; passing it through `fs.tree` swaps the server-side root.
-  const worktreeId = useActiveWorktreeId();
+  const worktreeId = useActiveWorktreeId(folderId);
   const [rootState, setRootState] = useState<DirState>({ status: "loading" });
   const [childStates, setChildStates] = useState<Record<string, DirState>>({});
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
@@ -166,7 +167,19 @@ export function FileTree({ folderId }: { folderId: FolderId }) {
   );
 
   if (rootState.status === "loading") {
-    return <Empty>Loading…</Empty>;
+    return (
+      <ul
+        className="flex flex-col gap-1 px-2 py-1"
+        aria-label="Loading project files"
+      >
+        {[80, 64, 72, 56, 88, 60, 76].map((w, i) => (
+          <li key={i} className="flex items-center gap-1.5 px-1 py-1">
+            <Skeleton className="size-3.5 shrink-0" />
+            <Skeleton className="h-3" style={{ width: `${w}%` }} />
+          </li>
+        ))}
+      </ul>
+    );
   }
   if (rootState.status === "error") {
     return <Empty>{rootState.reason}</Empty>;

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -1,6 +1,8 @@
 import { FolderClosed, GitBranch } from "lucide-react";
 import { useState } from "react";
 
+import type { FolderId } from "@memoize/wire";
+
 import { useActiveWorktreeId } from "../store/active-workspace.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
@@ -28,7 +30,7 @@ export function RightPane() {
   const selected = selectedFolderId
     ? (folders.find((f) => f.id === selectedFolderId) ?? null)
     : null;
-  const worktreeId = useActiveWorktreeId();
+  const worktreeId = useActiveWorktreeId(selectedFolderId);
   const status = useGitStatusStore((s) =>
     selectedFolderId
       ? (s.byKey[gitStatusKey(selectedFolderId, worktreeId)] ?? null)
@@ -116,8 +118,8 @@ export function RightPane() {
  * the active root visible so users don't get confused by what they're
  * looking at.
  */
-function ActiveWorkspaceChip({ folderId }: { folderId: string }) {
-  const worktreeId = useActiveWorktreeId();
+function ActiveWorkspaceChip({ folderId }: { folderId: FolderId }) {
+  const worktreeId = useActiveWorktreeId(folderId);
   const worktree = useWorktreesStore((s) => {
     if (worktreeId === null) return null;
     const list = s.byProject[folderId] ?? EMPTY_WORKTREES;

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -82,7 +82,7 @@ export function TopBarMain({ folderId }: { folderId: FolderId | null }) {
   // The branch label follows the active session's worktree so users see the
   // worktree's branch (e.g. happy-otter-42) when they're chatting against it,
   // not the main checkout's branch.
-  const worktreeId = useActiveWorktreeId();
+  const worktreeId = useActiveWorktreeId(folderId);
   const status = useGitStatusStore((s) =>
     folderId
       ? (s.byKey[gitStatusKey(folderId, worktreeId)] ?? null)
@@ -234,7 +234,7 @@ const deriveWorkflow = (
  * deferred — the layout already reserves the space.
  */
 export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
-  const worktreeId = useActiveWorktreeId();
+  const worktreeId = useActiveWorktreeId(folderId);
   const status = useGitStatusStore((s) =>
     folderId
       ? (s.byKey[gitStatusKey(folderId, worktreeId)] ?? null)

--- a/apps/renderer/src/store/active-workspace.ts
+++ b/apps/renderer/src/store/active-workspace.ts
@@ -15,17 +15,25 @@ import { useWorktreesStore } from "./worktrees.ts";
  * pull in the others' types as a side effect.
  */
 
-/** WorktreeId of the selected session, or null when on main checkout. */
-export const useActiveWorktreeId = (): WorktreeId | null => {
-  const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
-  const sessionsByProject = useSessionsStore((s) => s.sessionsByProject);
-  if (selectedSessionId === null) return null;
-  for (const list of Object.values(sessionsByProject)) {
-    for (const sess of list) {
-      if (sess.id === selectedSessionId) return sess.worktreeId;
-    }
-  }
-  return null;
+/**
+ * WorktreeId of the given project's currently-selected session, or null when
+ * that project's selection is on main checkout. Scoped per-project so
+ * switching projects deterministically swaps every panel that reads it
+ * (file tree, changes, PR, terminal, top-bar branch) to the new project's
+ * own active context — no cross-project session lookup.
+ */
+export const useActiveWorktreeId = (
+  folderId: FolderId | null,
+): WorktreeId | null => {
+  const sessionId = useSessionsStore((s) =>
+    folderId !== null ? s.selectedSessionByProject[folderId] ?? null : null,
+  );
+  const sessions = useSessionsStore((s) =>
+    folderId !== null ? s.sessionsByProject[folderId] ?? null : null,
+  );
+  if (sessionId === null || sessions === null) return null;
+  const found = sessions.find((sess) => sess.id === sessionId);
+  return found?.worktreeId ?? null;
 };
 
 /**
@@ -38,7 +46,7 @@ export const useActiveWorkspaceRoot = (folderId: FolderId): string | null => {
   const folder = useWorkspaceStore((s) =>
     s.folders.find((f) => f.id === folderId) ?? null,
   );
-  const worktreeId = useActiveWorktreeId();
+  const worktreeId = useActiveWorktreeId(folderId);
   const worktree = useWorktreesStore((s) => {
     if (worktreeId === null) return null;
     const list = s.byProject[folderId] ?? [];

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -87,8 +87,19 @@ const stopLiveFiber = async () => {
     tasks.push(Effect.runPromise(Fiber.interrupt(statusFiber)));
     statusFiber = null;
   }
+  const prevSessionId = liveSessionId;
   liveSessionId = null;
   await Promise.all(tasks);
+  // Drop the prior session's "running" flag — a stale `true` from the
+  // interrupted subscription would otherwise outlive the new hydrate and
+  // pin the composer on Interrupt forever.
+  if (prevSessionId !== null) {
+    useMessagesStore.setState((s) => {
+      if (s.runningBySession[prevSessionId] !== true) return s;
+      const { [prevSessionId]: _drop, ...rest } = s.runningBySession;
+      return { runningBySession: rest };
+    });
+  }
 };
 
 const newQueueId = (): string =>
@@ -191,69 +202,83 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
       // across the whole tool-call loop. When a turn ends we also refresh
       // the project's PR state so freshly pushed branches recolor the
       // branch icon without waiting for the user to click around.
-      statusFiber = Effect.runFork(
-        Stream.runForEach(
-          client.session.streamStatus({ sessionId }),
-          (event) =>
-            Effect.sync(() => {
-              const wasRunning = get().runningBySession[sessionId] === true;
-              const isRunning = event.status === "running";
-              set((s) => ({
-                runningBySession: {
-                  ...s.runningBySession,
-                  [sessionId]: isRunning,
-                },
-              }));
-              if (wasRunning && !isRunning) {
-                // Refresh PR state for this session's specific (project,
-                // worktree) pair — a turn that pushed commits on a worktree's
-                // branch shouldn't touch the main checkout's cache entry.
-                const sessions = useSessionsStore
-                  .getState()
-                  .sessionsByProject;
-                for (const list of Object.values(sessions)) {
-                  const sess = list.find((s) => s.id === sessionId);
-                  if (sess !== undefined) {
-                    void usePrStateStore
-                      .getState()
-                      .refresh(sess.projectId, sess.worktreeId);
-                    void usePrDetailsStore
-                      .getState()
-                      .refresh(sess.projectId, sess.worktreeId);
-                    break;
-                  }
-                }
-
-                // Auto-flush: when a turn lands and the queue is non-empty,
-                // send the queued items in order. Each send awaits the
-                // previous so the provider sees a single linear chain.
-                const queued = get().queueBySession[sessionId] ?? [];
-                if (queued.length > 0) {
-                  void (async () => {
-                    for (const q of queued) {
-                      try {
-                        await get().send(sessionId, q.input);
-                      } catch {
-                        // Stop on first error; remaining chips stay in the
-                        // queue and the user can retry by clicking Steer
-                        // (which is a no-op send when no turn is running).
-                        return;
-                      }
-                      set((s) => ({
-                        queueBySession: {
-                          ...s.queueBySession,
-                          [sessionId]: (s.queueBySession[sessionId] ?? []).filter(
-                            (it) => it.id !== q.id,
-                          ),
-                        },
-                      }));
-                    }
-                  })();
+      // Reset the running flag if the status stream ever errors — otherwise
+      // a transient RPC failure (server restart, dropped connection) leaves
+      // `runningBySession[sessionId]` pinned `true`, and the composer is
+      // stuck showing Interrupt with no way back to Send.
+      const resetOnStreamEnd = Effect.sync(() => {
+        useMessagesStore.setState((s) => {
+          if (s.runningBySession[sessionId] !== true) return s;
+          return {
+            runningBySession: { ...s.runningBySession, [sessionId]: false },
+          };
+        });
+      });
+      const statusProgram = Stream.runForEach(
+        client.session.streamStatus({ sessionId }).pipe(
+          Stream.catchAll((err) => {
+            console.error("[messages] status stream errored", err);
+            return Stream.empty;
+          }),
+        ),
+        (event) =>
+          Effect.sync(() => {
+            const wasRunning = get().runningBySession[sessionId] === true;
+            const isRunning = event.status === "running";
+            set((s) => ({
+              runningBySession: {
+                ...s.runningBySession,
+                [sessionId]: isRunning,
+              },
+            }));
+            if (wasRunning && !isRunning) {
+              // Refresh PR state for this session's specific (project,
+              // worktree) pair — a turn that pushed commits on a worktree's
+              // branch shouldn't touch the main checkout's cache entry.
+              const sessions = useSessionsStore.getState().sessionsByProject;
+              for (const list of Object.values(sessions)) {
+                const sess = list.find((s) => s.id === sessionId);
+                if (sess !== undefined) {
+                  void usePrStateStore
+                    .getState()
+                    .refresh(sess.projectId, sess.worktreeId);
+                  void usePrDetailsStore
+                    .getState()
+                    .refresh(sess.projectId, sess.worktreeId);
+                  break;
                 }
               }
-            }),
-        ),
-      );
+
+              // Auto-flush: when a turn lands and the queue is non-empty,
+              // send the queued items in order. Each send awaits the
+              // previous so the provider sees a single linear chain.
+              const queued = get().queueBySession[sessionId] ?? [];
+              if (queued.length > 0) {
+                void (async () => {
+                  for (const q of queued) {
+                    try {
+                      await get().send(sessionId, q.input);
+                    } catch {
+                      // Stop on first error; remaining chips stay in the
+                      // queue and the user can retry by clicking Steer
+                      // (which is a no-op send when no turn is running).
+                      return;
+                    }
+                    set((s) => ({
+                      queueBySession: {
+                        ...s.queueBySession,
+                        [sessionId]: (s.queueBySession[sessionId] ?? []).filter(
+                          (it) => it.id !== q.id,
+                        ),
+                      },
+                    }));
+                  }
+                })();
+              }
+            }
+          }),
+      ).pipe(Effect.ensuring(resetOnStreamEnd));
+      statusFiber = Effect.runFork(statusProgram);
     } catch (err) {
       set((s) => ({
         errorBySession: {
@@ -280,11 +305,15 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
       await Effect.runPromise(client.messages.send(payload));
       void useSessionsStore.getState().refreshOne(sessionId);
     } catch (err) {
+      // Reset the optimistic running flag — otherwise a failed send leaves
+      // the composer stuck on Interrupt with no path back to Send (the
+      // status stream won't emit "idle" if the server never saw the turn).
       set((s) => ({
         errorBySession: {
           ...s.errorBySession,
           [sessionId]: formatError(err),
         },
+        runningBySession: { ...s.runningBySession, [sessionId]: false },
       }));
     }
   },

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -18,6 +18,7 @@ import {
   buildAgentsForNewSession,
   useSubagentsStore,
 } from "./subagents.ts";
+import { useWorkspaceStore } from "./workspace.ts";
 
 /**
  * Per-project session catalog. Sessions are scoped to a project, archived
@@ -27,7 +28,19 @@ import {
  */
 type SessionsState = {
   readonly sessionsByProject: Record<string, ReadonlyArray<Session>>;
+  /**
+   * Mirror of `selectedSessionByProject[selectedFolderId]`. Kept as live state
+   * (not a derived selector) so existing call sites can subscribe to it
+   * directly without a per-render workspace lookup. Synced from
+   * `selectedSessionByProject` by a workspace subscription at module init.
+   */
   readonly selectedSessionId: SessionId | null;
+  /**
+   * Per-project last-selected session. Switching projects restores the
+   * previously-active session for the new project so file tree, changes,
+   * PR badge, terminal cwd, and the chat all swap together.
+   */
+  readonly selectedSessionByProject: Record<string, SessionId | null>;
   readonly showArchivedByProject: Record<string, boolean>;
   readonly loadingByProject: Record<string, boolean>;
   readonly error: string | null;
@@ -108,6 +121,7 @@ const findSessionProject = (
 export const useSessionsStore = create<SessionsState>((set, get) => ({
   sessionsByProject: {},
   selectedSessionId: null,
+  selectedSessionByProject: {},
   showArchivedByProject: {},
   loadingByProject: {},
   error: null,
@@ -167,6 +181,10 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
             [projectId]: [session, ...existing],
           },
           selectedSessionId: session.id,
+          selectedSessionByProject: {
+            ...s.selectedSessionByProject,
+            [projectId]: session.id,
+          },
         };
       });
       return session.id;
@@ -323,7 +341,19 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
       // Re-hydrate the affected project so visibility honors showArchived.
       const projectId = findSessionProject(get().sessionsByProject, sessionId);
       if (projectId !== null) await get().hydrate(projectId);
-      if (get().selectedSessionId === sessionId) set({ selectedSessionId: null });
+      set((s) => {
+        const wasSelected = s.selectedSessionId === sessionId;
+        const clearPerProject =
+          projectId !== null &&
+          s.selectedSessionByProject[projectId] === sessionId;
+        if (!wasSelected && !clearPerProject) return s;
+        return {
+          selectedSessionId: wasSelected ? null : s.selectedSessionId,
+          selectedSessionByProject: clearPerProject
+            ? { ...s.selectedSessionByProject, [projectId!]: null }
+            : s.selectedSessionByProject,
+        };
+      });
     } catch (err) {
       set({ error: formatError(err) });
     }
@@ -348,6 +378,9 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
         const projectId = findSessionProject(s.sessionsByProject, sessionId);
         if (projectId === null) return {};
         const sessions = s.sessionsByProject[projectId] ?? [];
+        const perProject = s.selectedSessionByProject[projectId] === sessionId
+          ? { ...s.selectedSessionByProject, [projectId]: null }
+          : s.selectedSessionByProject;
         return {
           sessionsByProject: {
             ...s.sessionsByProject,
@@ -355,6 +388,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
           },
           selectedSessionId:
             s.selectedSessionId === sessionId ? null : s.selectedSessionId,
+          selectedSessionByProject: perProject,
         };
       });
     } catch (err) {
@@ -380,6 +414,10 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
             ),
           },
           selectedSessionId: session.id,
+          selectedSessionByProject: {
+            ...s.selectedSessionByProject,
+            [projectId]: session.id,
+          },
         };
       });
       return true;
@@ -411,7 +449,42 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
       // Silent — refreshOne is a best-effort follow-up after send().
     }
   },
-  select: (sessionId) => set({ selectedSessionId: sessionId }),
+  select: (sessionId) => {
+    if (sessionId === null) {
+      set((s) => {
+        const activeProjectId = useWorkspaceStore.getState().selectedFolderId;
+        return {
+          selectedSessionId: null,
+          selectedSessionByProject:
+            activeProjectId !== null
+              ? { ...s.selectedSessionByProject, [activeProjectId]: null }
+              : s.selectedSessionByProject,
+        };
+      });
+      return;
+    }
+    const projectId = findSessionProject(get().sessionsByProject, sessionId);
+    // Write the per-project slot FIRST so the workspace.select below sees
+    // the freshly-set slot when its subscriber fires — otherwise the
+    // subscriber would briefly mirror the stale slot value.
+    set((s) => ({
+      selectedSessionId: sessionId,
+      selectedSessionByProject:
+        projectId !== null
+          ? { ...s.selectedSessionByProject, [projectId]: sessionId }
+          : s.selectedSessionByProject,
+    }));
+    // If the session lives in a different project than the currently-active
+    // one, switch projects too. Without this the chat would jump to the new
+    // session but the right pane, top bar, terminal cwd, etc. would stay on
+    // the old project — the "click does nothing visible" symptom.
+    if (
+      projectId !== null &&
+      useWorkspaceStore.getState().selectedFolderId !== projectId
+    ) {
+      void useWorkspaceStore.getState().select(projectId);
+    }
+  },
   toggleShowArchived: (projectId) => {
     set((s) => ({
       showArchivedByProject: {
@@ -422,3 +495,18 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
     void get().hydrate(projectId);
   },
 }));
+
+// Mirror `selectedSessionId` from the active project's per-project slot.
+// Switching projects automatically restores whichever session was last
+// selected for the new project; if none, the chat clears (no stale session
+// from the previous project leaks across).
+useWorkspaceStore.subscribe((ws, prev) => {
+  if (ws.selectedFolderId === prev.selectedFolderId) return;
+  const slot =
+    ws.selectedFolderId !== null
+      ? useSessionsStore.getState().selectedSessionByProject[ws.selectedFolderId] ?? null
+      : null;
+  if (useSessionsStore.getState().selectedSessionId !== slot) {
+    useSessionsStore.setState({ selectedSessionId: slot });
+  }
+});


### PR DESCRIPTION
## Summary

- Project switching now propagates to every panel. Each project remembers its own selected session in `useSessionsStore.selectedSessionByProject`, and `useActiveWorktreeId(folderId)` derives per-project — so file tree, changes, PR badge, terminal cwd, and top-bar branch all swap together. Selecting a session in another project also flips the active project so the right pane and chat stay in sync.
- Composer no longer gets pinned on Interrupt when things go wrong: the status stream now has a `Stream.catchAll` + `Effect.ensuring` reset, `send()`'s catch clears the optimistic running flag, `stopLiveFiber` clears the prior session's flag, and `chat-composer` re-hydrates pending permissions on running→idle so a stale card can't cover the editor.
- File-tree loading state shows skeleton rows instead of the "Loading…" placeholder, and the cost footer drops the unhelpful `unknown:` label while still showing the in/out token counts.

## Test plan

- [ ] Open two projects, click between them — file tree, changes, PR, terminal cwd, top-bar branch all switch
- [ ] Switch a session's worktree via the workspace picker — panels re-root without project change
- [ ] Kill the server mid-turn; composer returns to Send (not stuck on Interrupt)
- [ ] Click a session in a non-active project — active project and chat both flip to it
- [ ] Confirm cost footer shows `19 in / 3.4k out` (no "unknown:" prefix) on sub-agent rows