### PR TITLE
fix(desktop): resolve user's claude CLI from packaged macOS app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to memoize will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] — Unreleased
+
+### Fixed
+- Packaged macOS app could not start new Claude sessions ("Native CLI binary for darwin-arm64 not found"). GUI-launched apps inherit a minimal PATH, so `which claude` never found the user's installed Claude Code binary and the SDK fell back to a bundled native CLI we don't ship. The main process now expands PATH from the user's login shell (via `fix-path`) before the runtime boots, and the server fails with a clear "Claude Code CLI not found on PATH" message when the binary genuinely isn't installed.
+
 ## [0.1.0] — Unreleased
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "memoize",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "memoize desktop app",
   "private": true,
   "author": {
@@ -41,6 +41,7 @@
     "effect": "catalog:",
     "electron-builder": "^25.1.8",
     "electron": "^33.2.0",
+    "fix-path": "^4.0.0",
     "sharp": "^0.34.1",
     "tsdown": "^0.21.10",
     "typescript": "catalog:"

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -10,11 +10,23 @@ import {
   shell,
 } from "electron";
 import { Effect, Fiber, Layer } from "effect";
+import fixPath from "fix-path";
 import * as fs from "node:fs/promises";
 import * as Path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { makeMainLayer } from "@memoize/server";
+
+// macOS GUI apps launched from Finder inherit a minimal PATH
+// (`/usr/bin:/bin:/usr/sbin:/sbin`), not the user's shell PATH. The Claude
+// driver runs `which claude` to locate the user's Claude Code install — that
+// fails under the minimal PATH even when the binary is on Homebrew, nvm, mise,
+// or npm-global. Expand PATH from the login shell before any `Command.make`
+// in the server runs. Dev (`bun run dev`) inherits the terminal's PATH
+// already, so we only do this when packaged. No-op on Windows.
+if (process.platform === "darwin" && app.isPackaged) {
+  fixPath();
+}
 
 import { electronServerProtocolLayer } from "./ipc/electron-server-protocol.ts";
 import { startAutoUpdater } from "./updater.ts";

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -7,7 +7,10 @@ const shared = {
   outExtensions: () => ({ js: ".cjs" }),
   // Workspace packages ship as raw .ts source — bundle them in instead of
   // letting Node try to require() the .ts file at runtime.
-  deps: { alwaysBundle: ["@memoize/wire", "@memoize/server"] },
+  // `fix-path` is ESM-only ("type": "module"). Electron 33 ships Node 20.x
+  // where `require()` of an ESM module throws ERR_REQUIRE_ESM. Bundling it
+  // inline transpiles it to CJS so the main bundle can call it directly.
+  deps: { alwaysBundle: ["@memoize/wire", "@memoize/server", "fix-path"] },
   // Native modules whose loader uses `__dirname` / `module.parent.filename`
   // to locate a `.node` file at runtime — bundling their JS relocates those
   // anchors and the lookup fails. Keep them external so each is require()'d

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -135,12 +135,24 @@ export const ProviderServiceLive = Layer.effect(
           const sessionId = input.sessionId ?? nextSessionId();
           let handle: SessionHandle;
           if (input.providerId === "claude") {
-            // Point the SDK at the user's installed `claude` binary; the
-            // SDK's bundled CLI is shipped as an optional native dep that
-            // doesn't always install. Falls through to bundled if not found.
+            // Point the SDK at the user's installed `claude` binary. We
+            // don't ship the SDK's bundled optional native CLI (216 MB per
+            // arch) — if `which claude` finds nothing here, the SDK would
+            // throw a cryptic "Native CLI binary for darwin-arm64 not
+            // found" error. Surface a clean install-Claude-Code message
+            // instead.
             const claudePath = yield* resolveCliPath("claude").pipe(
               Effect.provideService(CommandExecutor.CommandExecutor, executor),
             );
+            if (claudePath === null) {
+              return yield* Effect.fail(
+                new AgentSessionStartError({
+                  providerId: "claude",
+                  reason:
+                    "Claude Code CLI not found on PATH. Install Claude Code from https://docs.claude.com/en/docs/claude-code and try again.",
+                }),
+              );
+            }
             handle = yield* startClaudeSession(
               input,
               cwd,

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "effect": "catalog:",
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8",
+        "fix-path": "^4.0.0",
         "sharp": "^0.34.1",
         "tsdown": "^0.21.10",
         "typescript": "catalog:",
@@ -1208,6 +1209,8 @@
 
     "default-browser-id": ["default-browser-id@5.0.1", "http://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
+    "default-shell": ["default-shell@2.2.0", "", {}, "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw=="],
+
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
     "defer-to-connect": ["defer-to-connect@2.0.1", "http://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz", {}, "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="],
@@ -1421,6 +1424,8 @@
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "http://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@5.0.0", "http://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "fix-path": ["fix-path@4.0.0", "", { "dependencies": { "shell-path": "^3.0.0" } }, "sha512-g31GX207Tt+psI53ZSaB1egprYbEN0ZYl90aKcO22A2LmCNnFsSq3b5YpoKp3E/QEiWByTXGJOkFQG4S07Bc1A=="],
 
     "flat-cache": ["flat-cache@4.0.1", "http://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
@@ -2252,6 +2257,10 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "http://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shell-env": ["shell-env@4.0.3", "", { "dependencies": { "default-shell": "^2.0.0", "execa": "^5.1.1", "strip-ansi": "^7.0.1" } }, "sha512-Ioe5h+hCDZ7pKL5+JGzbtPvZ5ESMHePZ8nLxohlDL+twmlcmutttMhRkrQOed8DeLT8mkYBgbwZfohe8pqaA3g=="],
+
+    "shell-path": ["shell-path@3.1.0", "", { "dependencies": { "shell-env": "^4.0.1" } }, "sha512-s/9q9PEtcRmDTz69+cJ3yYBAe9yGrL7e46gm2bU4pQ9N48ecPK9QrGFnLwYgb4smOHskx4PL7wCNMktW2AoD+g=="],
+
     "shiki": ["shiki@4.0.2", "http://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "side-channel": ["side-channel@1.1.0", "http://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
@@ -2812,6 +2821,8 @@
 
     "sharp/semver": ["semver@7.7.4", "http://registry.npmjs.org/semver/-/semver-7.7.4.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "shell-env/execa": ["execa@5.1.1", "http://registry.npmjs.org/execa/-/execa-5.1.1.tgz", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
     "simple-update-notifier/semver": ["semver@7.7.4", "http://registry.npmjs.org/semver/-/semver-7.7.4.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "socks/ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
@@ -3007,6 +3018,18 @@
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
     "shadcn/fast-glob/glob-parent": ["glob-parent@5.1.2", "http://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "shell-env/execa/get-stream": ["get-stream@6.0.1", "http://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "shell-env/execa/human-signals": ["human-signals@2.1.0", "http://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "shell-env/execa/is-stream": ["is-stream@2.0.1", "http://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "shell-env/execa/npm-run-path": ["npm-run-path@4.0.1", "http://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "shell-env/execa/signal-exit": ["signal-exit@3.0.7", "http://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "shell-env/execa/strip-final-newline": ["strip-final-newline@2.0.0", "http://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "ssri/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 


### PR DESCRIPTION
## Summary

- Packaged macOS app failed to start any Claude session with `Native CLI binary for darwin-arm64 not found` because GUI apps inherit a minimal PATH and `which claude` couldn't find the user's installed binary, so the SDK fell back to a bundled native CLI we don't ship.
- Expand `process.env.PATH` from the user's login shell at main-process startup (`fix-path`, bundled inline) so `which claude` finds Homebrew / nvm / mise / npm-global installs in the packaged build.
- Surface a clean `AgentSessionStartError` ("Claude Code CLI not found on PATH. Install Claude Code from …") from `provider-service.ts` when the binary genuinely isn't installed, instead of letting the SDK throw its cryptic error.
- Bumps `apps/desktop` to 0.1.1 + CHANGELOG entry.

## Test plan

- [ ] `bun run build` then `cd apps/desktop && bunx electron-builder --mac --universal --dir` succeeds.
- [ ] Open `dist/mac-universal/memoize.app` from Finder; start a Claude session — succeeds when Claude Code is installed.
- [ ] Temporarily remove `claude` from PATH; start a session — surfaces the friendly "Claude Code CLI not found on PATH" error instead of the native-binary one.
- [ ] `bun run dev` still works (fix-path is no-op when not packaged).
- [ ] After merge, tag `v0.1.1` to trigger the release workflow.