### PR TITLE
fix(renderer): keep composer editor mounted across permission/question cards

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -476,38 +476,41 @@ export function ChatComposer({ session }: { session: Session }) {
     attachFiles(files);
   };
 
-  if (headPermission !== undefined) {
-    return (
-      <div className="shrink-0 px-3 pb-3 pt-2">
-        <div className="mx-auto">
-          <PermissionCard
-            head={headPermission}
-            queueSize={pendingPermissions.length}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  if (pendingQuestion !== null) {
-    return (
-      <div className="shrink-0 px-3 pb-3 pt-2">
-        <div className="mx-auto">
-          <QuestionCard
-            sessionId={sessionId}
-            itemId={pendingQuestion.itemId}
-            questions={pendingQuestion.questions}
-          />
-        </div>
-      </div>
-    );
-  }
-
   const inPlanMode = session.permissionMode === "plan";
+  // Keep the editor mounted at all times. Permissions / questions render as
+  // a sibling above it, and we hide the editor block with `display: none`
+  // while a card is up. Unmounting the editor branch detaches the CodeMirror
+  // view from the DOM, and the view-creation `useEffect` (empty deps) never
+  // re-runs to re-attach it — so the host reappears blank: no placeholder,
+  // cursor won't land. Staying mounted also preserves any in-progress draft
+  // when a permission prompt interrupts mid-typing.
+  const showCard = headPermission !== undefined || pendingQuestion !== null;
 
   return (
     <TooltipProvider delay={0}>
-      <div className="shrink-0 px-3 pb-3 pt-2">
+      {showCard ? (
+        <div className="shrink-0 px-3 pb-3 pt-2">
+          <div className="mx-auto">
+            {headPermission !== undefined ? (
+              <PermissionCard
+                head={headPermission}
+                queueSize={pendingPermissions.length}
+              />
+            ) : pendingQuestion !== null ? (
+              <QuestionCard
+                sessionId={sessionId}
+                itemId={pendingQuestion.itemId}
+                questions={pendingQuestion.questions}
+              />
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+      <div
+        className="shrink-0 px-3 pb-3 pt-2"
+        style={showCard ? { display: "none" } : undefined}
+        aria-hidden={showCard || undefined}
+      >
         <div className="mx-auto">
           <Frame>
             <Card

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -193,6 +193,38 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
             // rendering for collapsed turns; sub-agents inside a collapsed
             // turn render via TurnSummary's existing path.
             const bodyGroups = groupMessages(turn.body);
+            // Hoist ExitPlanMode rows out of TurnSummary so the Plan card
+            // (and its resolved accordion) stays a top-level row in
+            // scrollback — it's a user-facing decision, not just another
+            // tool call to bury in the "N tool calls" rollup.
+            const planMessages = turn.body.filter(
+              (m) =>
+                m.content._tag === "tool_use" &&
+                m.content.tool === "ExitPlanMode",
+            );
+            const planItemIds = new Set(
+              planMessages.flatMap((m) =>
+                m.content._tag === "tool_use" ? [m.content.itemId] : [],
+              ),
+            );
+            const summaryBody =
+              planMessages.length === 0
+                ? turn.body
+                : turn.body.filter((m) => {
+                    if (
+                      m.content._tag === "tool_use" &&
+                      m.content.tool === "ExitPlanMode"
+                    ) {
+                      return false;
+                    }
+                    if (
+                      m.content._tag === "tool_result" &&
+                      planItemIds.has(m.content.itemId)
+                    ) {
+                      return false;
+                    }
+                    return true;
+                  });
             return (
               <Fragment key={turnKey}>
                 {turn.user !== null ? (
@@ -204,11 +236,22 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                   />
                 ) : null}
                 {showSummary ? (
-                  <TurnSummary
-                    body={turn.body}
-                    resultsByItemId={resultsByItemId}
-                    answersByItemId={answersByItemId}
-                  />
+                  <>
+                    {planMessages.map((m) => (
+                      <MessageRow
+                        key={m.id}
+                        message={m}
+                        resultsByItemId={resultsByItemId}
+                        answersByItemId={answersByItemId}
+                        sessionId={sessionId}
+                      />
+                    ))}
+                    <TurnSummary
+                      body={summaryBody}
+                      resultsByItemId={resultsByItemId}
+                      answersByItemId={answersByItemId}
+                    />
+                  </>
                 ) : (
                   bodyGroups.map((group) =>
                     group.kind === "single" ? (

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -734,26 +734,54 @@ export function ExitPlanModeRow({
   });
   const decide = usePermissionsStore((s) => s.decide);
 
-  return (
-    <div className="px-4 py-2">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+  // Pending plans need the Approve / Reject buttons visible inline so the
+  // user can act without an extra click — keep the full card layout.
+  // Resolved plans (approved / rejected) collapse into the same icon-row
+  // accordion the rest of the timeline uses, with the plan body behind the
+  // chevron and the status pill pinned to the body footer.
+  if (status === "pending") {
+    return (
+      <div className="px-4 py-2">
+        <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
           <HugeiconsIcon icon={CheckListIcon} size={14} strokeWidth={2} />
           <span>Plan</span>
         </div>
-        {status !== "pending" ? (
-          <span
-            className={cn(
-              "rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
-              status === "approved"
-                ? "text-emerald-500/90"
-                : "text-muted-foreground",
-            )}
-          >
-            {status === "approved" ? "Approved" : "Rejected"}
-          </span>
+        {plan === null ? (
+          <p className="text-sm italic text-muted-foreground">
+            (No plan body.)
+          </p>
+        ) : (
+          <MarkdownBody>{plan}</MarkdownBody>
+        )}
+        {pendingRequest !== null ? (
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() =>
+                void decide(pendingRequest.id, { _tag: "Deny" })
+              }
+              className="rounded-md px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            >
+              Reject
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                void decide(pendingRequest.id, { _tag: "AllowOnce" })
+              }
+              className="rounded-md bg-foreground px-3 py-1 text-xs font-medium text-background hover:opacity-90"
+            >
+              Approve
+            </button>
+          </div>
         ) : null}
       </div>
+    );
+  }
+
+  const teaser = plan === null ? "(No plan body.)" : firstSentence(plan);
+  const body = (
+    <>
       {plan === null ? (
         <p className="text-sm italic text-muted-foreground">
           (No plan body.)
@@ -761,29 +789,29 @@ export function ExitPlanModeRow({
       ) : (
         <MarkdownBody>{plan}</MarkdownBody>
       )}
-      {status === "pending" && pendingRequest !== null ? (
-        <div className="mt-4 flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={() =>
-              void decide(pendingRequest.id, { _tag: "Deny" })
-            }
-            className="rounded-md px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-          >
-            Reject
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              void decide(pendingRequest.id, { _tag: "AllowOnce" })
-            }
-            className="rounded-md bg-foreground px-3 py-1 text-xs font-medium text-background hover:opacity-90"
-          >
-            Approve
-          </button>
-        </div>
-      ) : null}
-    </div>
+      <div className="mt-3 flex items-center justify-end text-[11px] text-muted-foreground">
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+            status === "approved"
+              ? "text-emerald-500/90"
+              : "text-muted-foreground",
+          )}
+        >
+          {status === "approved" ? "Approved" : "Rejected"}
+        </span>
+      </div>
+    </>
+  );
+
+  return (
+    <ExpandableIconRow
+      icon={CheckListIcon}
+      label="Plan"
+      trailing={<InlineTextHint value={teaser} />}
+      hasContent
+      body={body}
+    />
   );
 }
 

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -817,26 +817,18 @@ export function UserInputRow({
     });
   };
 
-  return (
-    <div className="px-4 py-2">
-      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
-        <HugeiconsIcon icon={BubbleChatIcon} size={14} strokeWidth={2} />
-        <span>User input</span>
-        <button
-          type="button"
-          onClick={copy}
-          aria-label={copied ? "Copied" : "Copy Q&A"}
-          title={copied ? "Copied" : "Copy"}
-          className="rounded p-0.5 text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground"
-        >
-          <HugeiconsIcon
-            icon={copied ? Tick02Icon : Copy01Icon}
-            size={12}
-            strokeWidth={2}
-          />
-        </button>
-      </div>
+  // Collapsed teaser: first question + its answer (or "cancelled"), flattened
+  // and truncated like ThinkingRow / ToolRow trailing hints so the row reads
+  // as one calm line in scrollback.
+  const firstQ = questions[0];
+  const teaser = (() => {
+    if (firstQ === undefined) return "";
+    const ans = answerSummaryText(firstQ, answers, 0) ?? "(cancelled)";
+    return firstSentence(`${firstQ.question} · ${ans}`);
+  })();
 
+  const body = (
+    <>
       <div className="space-y-3">
         {questions.map((q, i) => {
           const summary = answerSummary(q, answers, i);
@@ -860,15 +852,40 @@ export function UserInputRow({
       </div>
 
       <div className="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
-        <span>
-          {questions.length}{" "}
-          {questions.length === 1 ? "question" : "questions"}
-        </span>
+        <div className="flex items-center gap-2">
+          <span>
+            {questions.length}{" "}
+            {questions.length === 1 ? "question" : "questions"}
+          </span>
+          <button
+            type="button"
+            onClick={copy}
+            aria-label={copied ? "Copied" : "Copy Q&A"}
+            title={copied ? "Copied" : "Copy"}
+            className="rounded p-0.5 text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground"
+          >
+            <HugeiconsIcon
+              icon={copied ? Tick02Icon : Copy01Icon}
+              size={12}
+              strokeWidth={2}
+            />
+          </button>
+        </div>
         <span className="rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-500/90">
           Answered
         </span>
       </div>
-    </div>
+    </>
+  );
+
+  return (
+    <ExpandableIconRow
+      icon={BubbleChatIcon}
+      label="User input"
+      trailing={<InlineTextHint value={teaser} />}
+      hasContent
+      body={body}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- When a `PermissionCard` or `QuestionCard` took over the composer via an early `return`, React unmounted the editor's host `<div>`, detaching the CodeMirror DOM. The view-creation `useEffect` has empty deps so it never re-attached the view when the card resolved — the input frame redrew blank: no placeholder, cursor wouldn't land, typing did nothing.
- Collapsed the three early returns into one: the card now renders as a sibling above the editor, and the editor block stays mounted at all times (hidden with `display: none` while a card is up). Any in-progress draft also survives a permission interrupt mid-typing.

## Test plan

- [ ] Trigger a tool that needs a permission prompt → answer it → click the composer → cursor lands, placeholder shows, typing works.
- [ ] Same flow with an `AskUserQuestion` (`QuestionCard`) instead of a permission.
- [ ] Type some draft text, let a permission card pop, answer it → draft is still there.
- [ ] Switch sessions and back → editor still usable.
- [ ] With a card showing, the hidden editor is `aria-hidden` and not tabbable.