### PR TITLE
ui(renderer): polish settings — tokens, radio/checkbox redesign, Inherit toggle

### DIFF
--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -5,7 +5,6 @@ import {
   FolderClosed,
   GitBranch,
   Settings as SettingsIcon,
-  X,
 } from "lucide-react";
 import { useEffect, useMemo } from "react";
 
@@ -26,6 +25,13 @@ import { useWorkspaceStore } from "../store/workspace.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { MODES_ORDER, MODE_META } from "./runtime-mode-meta.ts";
 import { RepositorySettings } from "./settings-repository.tsx";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select.tsx";
 
 const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude Code",
@@ -62,12 +68,8 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
 
 /**
  * Two-pane settings surface. The left rail navigates between global
- * sections (General / Models & Providers / Git) and per-repository
+ * sections (General / Models & Providers / Workspace) and per-repository
  * settings; the right pane renders the active section's form.
- *
- * Defaults persisted in `useSettingsStore` are applied to every new
- * session created from the sidebar's "New chat" button. The composer's
- * popovers can override per-session.
  */
 export function SettingsPage() {
   const setView = useUiStore((s) => s.setView);
@@ -76,34 +78,22 @@ export function SettingsPage() {
   const folders = useWorkspaceStore((s) => s.folders);
   const loadFolders = useWorkspaceStore((s) => s.load);
 
-  // First-mount: surface every project so the rail's Repositories list
-  // doesn't read empty just because the user has been on a different
-  // surface. WorkspaceStore guards against re-fetching when already loaded.
   useEffect(() => {
     if (folders.length === 0) void loadFolders();
   }, [folders.length, loadFolders]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-zinc-950">
-      <header className="flex h-9 shrink-0 items-center justify-between px-3 text-xs text-muted-foreground [-webkit-app-region:drag]">
-        <div className="ml-16 flex items-center gap-1.5 select-none">
-          <button
-            type="button"
-            onClick={() => setView("chat")}
-            aria-label="Back to app"
-            className="flex items-center gap-1 rounded p-1 text-muted-foreground hover:bg-muted/40 hover:text-foreground [-webkit-app-region:no-drag]"
-          >
-            <ArrowLeft className="size-3.5" />
-            <span>Back to app</span>
-          </button>
-        </div>
+    <div className="flex min-h-0 flex-1 flex-col bg-background">
+      <header className="flex h-9 shrink-0 items-center px-3 text-xs text-muted-foreground [-webkit-app-region:drag]">
+        <div className="w-16 shrink-0" />
         <button
           type="button"
           onClick={() => setView("chat")}
-          aria-label="Close settings"
-          className="rounded p-1 text-muted-foreground hover:bg-muted/40 hover:text-foreground [-webkit-app-region:no-drag]"
+          aria-label="Back to app"
+          className="flex items-center gap-1 rounded p-1 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground [-webkit-app-region:no-drag]"
         >
-          <X className="size-3.5" />
+          <ArrowLeft className="size-3.5" />
+          <span>Back to app</span>
         </button>
       </header>
       <div className="flex min-h-0 flex-1">
@@ -112,8 +102,8 @@ export function SettingsPage() {
           onSelect={setSection}
           folders={folders}
         />
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-6">
-          <div className="mx-auto flex w-full max-w-2xl flex-col gap-8">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-10 py-8">
+          <div className="mx-auto flex w-full max-w-2xl flex-col gap-10">
             <SectionTitle section={section} folders={folders} />
             <Pane section={section} />
           </div>
@@ -133,33 +123,31 @@ function Rail({
   folders: ReadonlyArray<Folder>;
 }) {
   return (
-    <nav className="flex w-48 shrink-0 flex-col gap-4 border-r border-border/40 px-3 py-6 text-sm">
+    <nav className="flex w-56 shrink-0 flex-col gap-6 border-r border-border/40 bg-sidebar/40 px-3 py-6 text-sm text-sidebar-foreground">
       <div className="flex flex-col gap-0.5">
         {TOP_RAIL.map((item) => {
           const active =
             section.kind !== "repository" && section.kind === item.section.kind;
           return (
-            <button
+            <RailButton
               key={item.id}
-              type="button"
+              active={active}
               onClick={() => onSelect(item.section)}
-              className={cn(
-                "flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
-                active
-                  ? "bg-accent/40 text-foreground"
-                  : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
-              )}
-            >
-              <item.Icon className="size-4" />
-              <span>{item.label}</span>
-            </button>
+              icon={item.Icon}
+              label={item.label}
+            />
           );
         })}
       </div>
       {folders.length > 0 && (
-        <div className="flex flex-col gap-1">
-          <div className="px-2 text-[11px] uppercase tracking-wider text-muted-foreground/80">
-            Repositories
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between px-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Repositories
+            </span>
+            <span className="rounded-full bg-muted/50 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+              {folders.length}
+            </span>
           </div>
           <div className="flex flex-col gap-0.5">
             {folders.map((f) => {
@@ -167,29 +155,56 @@ function Rail({
                 section.kind === "repository" &&
                 section.projectId === f.id;
               return (
-                <button
+                <RailButton
                   key={f.id}
-                  type="button"
+                  active={active}
                   onClick={() =>
                     onSelect({ kind: "repository", projectId: f.id })
                   }
-                  className={cn(
-                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
-                    active
-                      ? "bg-accent/40 text-foreground"
-                      : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
-                  )}
+                  icon={FolderClosed}
+                  label={f.name}
                   title={f.path}
-                >
-                  <FolderClosed className="size-4 shrink-0" />
-                  <span className="truncate">{f.name}</span>
-                </button>
+                  truncate
+                />
               );
             })}
           </div>
         </div>
       )}
     </nav>
+  );
+}
+
+function RailButton({
+  active,
+  onClick,
+  icon: Icon,
+  label,
+  title,
+  truncate,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  title?: string;
+  truncate?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={cn(
+        "flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        active
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
+      )}
+    >
+      <Icon className="size-4 shrink-0" />
+      <span className={cn(truncate && "truncate")}>{label}</span>
+    </button>
   );
 }
 
@@ -200,15 +215,48 @@ function SectionTitle({
   section: SettingsSection;
   folders: ReadonlyArray<Folder>;
 }) {
-  const title = useMemo(() => {
-    if (section.kind === "general") return "General";
-    if (section.kind === "models") return "Models & Providers";
-    if (section.kind === "workspace") return "Workspace";
+  const { title, subtitle } = useMemo(() => {
+    if (section.kind === "general") {
+      return {
+        title: "General",
+        subtitle: "Defaults for new chats and sub-agents.",
+      };
+    }
+    if (section.kind === "models") {
+      return {
+        title: "Models & Providers",
+        subtitle: "Default provider and model for new sessions.",
+      };
+    }
+    if (section.kind === "workspace") {
+      return {
+        title: "Workspace",
+        subtitle: "How new chats relate to your git checkout.",
+      };
+    }
     const f = folders.find((x) => x.id === section.projectId);
-    return f?.name ?? "Repository";
+    return {
+      title: f?.name ?? "Repository",
+      subtitle: f?.path ?? "",
+    };
   }, [section, folders]);
   return (
-    <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+    <div className="flex flex-col gap-1">
+      <h1 className="text-xl font-semibold tracking-tight text-foreground">
+        {title}
+      </h1>
+      {subtitle && (
+        <p
+          className={cn(
+            "text-sm text-muted-foreground",
+            section.kind === "repository" && "truncate font-mono text-xs",
+          )}
+          title={section.kind === "repository" ? subtitle : undefined}
+        >
+          {subtitle}
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -230,39 +278,21 @@ function GeneralPane() {
         title="Default permission mode"
         description="How the agent handles tool calls in new sessions. Each session can override this from its composer."
       >
-        <div className="flex flex-col gap-2">
+        <OptionGroup>
           {MODES_ORDER.map((mode) => {
             const m = MODE_META[mode];
-            const ItemIcon = m.Icon;
-            const active = mode === defaultRuntimeMode;
             return (
-              <button
+              <OptionCard
                 key={mode}
-                type="button"
+                icon={m.Icon}
+                title={m.label}
+                description={m.description}
+                active={mode === defaultRuntimeMode}
                 onClick={() => setDefaultRuntimeMode(mode)}
-                className={cn(
-                  "grid grid-cols-[1.25rem_1.25rem_1fr_1rem] items-start gap-x-3 rounded-md border px-3 py-3 text-left transition-colors",
-                  active
-                    ? "border-foreground/40 bg-accent/40"
-                    : "border-border/60 hover:bg-muted/40",
-                )}
-              >
-                <ItemIcon className="col-start-2 row-start-1 mt-0.5 size-4 shrink-0" />
-                <div className="col-start-3 row-start-1 flex flex-col gap-1">
-                  <span className="text-sm font-medium leading-none">
-                    {m.label}
-                  </span>
-                  <span className="text-xs text-muted-foreground leading-snug">
-                    {m.description}
-                  </span>
-                </div>
-                {active && (
-                  <Check className="col-start-4 row-start-1 mt-0.5 size-3.5 opacity-80" />
-                )}
-              </button>
+              />
             );
           })}
-        </div>
+        </OptionGroup>
       </Section>
       <SubagentsSection />
     </>
@@ -283,30 +313,17 @@ function ModelsPane() {
       description="New chats start with this provider and model. You can still change them per session from the composer."
     >
       <div className="flex flex-col gap-4">
-        <div className="grid grid-cols-2 gap-2">
-          {providers.map((pid) => {
-            const active = pid === defaultProviderId;
-            return (
-              <button
-                key={pid}
-                type="button"
-                onClick={() => setDefaultProvider(pid)}
-                className={cn(
-                  "flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
-                  active
-                    ? "border-foreground/40 bg-accent/40"
-                    : "border-border/60 hover:bg-muted/40",
-                )}
-              >
-                <ProviderIcon providerId={pid} className="size-4" />
-                <span className="flex-1 text-left">
-                  {PROVIDER_LABEL[pid]}
-                </span>
-                {active && <Check className="size-3.5 opacity-80" />}
-              </button>
-            );
-          })}
-        </div>
+        <OptionGroup columns={2}>
+          {providers.map((pid) => (
+            <OptionCard
+              key={pid}
+              iconNode={<ProviderIcon providerId={pid} className="size-4" />}
+              title={PROVIDER_LABEL[pid]}
+              active={pid === defaultProviderId}
+              onClick={() => setDefaultProvider(pid)}
+            />
+          ))}
+        </OptionGroup>
         <ModelSelect
           providerId={defaultProviderId}
           value={defaultModelByProvider[defaultProviderId]}
@@ -327,26 +344,14 @@ function WorkspacePane() {
   return (
     <Section
       title="New chat workspace"
-      description="Memoize can run each chat in its own git worktree under .memoize/repo-worktree/, branched off the project's HEAD. Per-repo settings under Repositories override this default."
+      description="Memoize can run each chat in its own git worktree under .memoize/repo-worktree/, branched off the project's HEAD. Per-repo settings override this default."
     >
-      <label className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2.5 text-sm">
-        <input
-          type="checkbox"
-          checked={defaultAutoCreateWorktree}
-          onChange={(e) => setDefaultAutoCreateWorktree(e.target.checked)}
-          className="size-4 accent-foreground"
-        />
-        <span className="flex flex-1 flex-col gap-0.5">
-          <span className="font-medium leading-none">
-            Create a new worktree for new chats by default
-          </span>
-          <span className="text-xs text-muted-foreground leading-snug">
-            Pre-selects "New worktree" in the composer's workspace picker on
-            each new chat. You can still flip back to "Current checkout"
-            before sending the first message.
-          </span>
-        </span>
-      </label>
+      <CheckboxField
+        checked={defaultAutoCreateWorktree}
+        onChange={setDefaultAutoCreateWorktree}
+        label="Create a new worktree for new chats by default"
+        description='Pre-selects "New worktree" in the composer&apos;s workspace picker. You can still flip back to "Current checkout" before sending the first message.'
+      />
     </Section>
   );
 }
@@ -354,8 +359,7 @@ function WorkspacePane() {
 /**
  * Sub-agents settings. Master toggle + per-preset toggle. Model dropdowns
  * read the user's overlay; a future "Edit" sheet will surface the prompt
- * + tool subset (out of scope for v1 — the seed values are already
- * sensible defaults).
+ * + tool subset.
  */
 function SubagentsSection() {
   const enableForNewSessions = useSubagentsStore(
@@ -369,26 +373,26 @@ function SubagentsSection() {
   const setPresetOverride = useSubagentsStore((s) => s.setPresetOverride);
 
   const claudeModels = MODELS_BY_PROVIDER.claude;
+  const claudeModelItems = useMemo(
+    () => claudeModels.map((m) => ({ value: m.id, label: m.label })),
+    [claudeModels],
+  );
 
   return (
     <Section
       title="Sub-agents"
       description="Let your main agent delegate scoped tasks to cheaper models. Saves tokens on long sessions."
     >
-      <label className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2.5 text-sm">
-        <input
-          type="checkbox"
-          checked={enableForNewSessions}
-          onChange={(e) => setEnableForNewSessions(e.target.checked)}
-          className="size-4 accent-foreground"
-        />
-        <span className="flex-1">Enable sub-agents for new sessions</span>
-      </label>
+      <CheckboxField
+        checked={enableForNewSessions}
+        onChange={setEnableForNewSessions}
+        label="Enable sub-agents for new sessions"
+      />
 
       <div
         className={cn(
-          "flex flex-col gap-2 rounded-md border border-border/40 p-2",
-          enableForNewSessions ? "" : "opacity-60",
+          "flex flex-col gap-0.5 rounded-lg border border-border/50 p-1.5 transition-opacity",
+          enableForNewSessions ? "" : "pointer-events-none opacity-50",
         )}
       >
         {DEFAULT_SUBAGENT_PRESETS.map((preset) => {
@@ -397,42 +401,46 @@ function SubagentsSection() {
             overrides: {},
           };
           const model = ps.overrides.model ?? preset.definition.model;
+          const rowDisabled = !enableForNewSessions || !ps.enabled;
           return (
             <div
               key={preset.name}
-              className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/30"
+              className="flex items-center gap-3 rounded-md px-2.5 py-2 transition-colors hover:bg-muted/40"
             >
-              <input
-                type="checkbox"
-                checked={ps.enabled && enableForNewSessions}
-                disabled={!enableForNewSessions}
-                onChange={(e) =>
-                  setPresetEnabled(preset.name, e.target.checked)
-                }
-                className="size-4 accent-foreground"
-              />
-              <div className="flex flex-1 flex-col gap-0.5">
-                <span className="text-sm font-medium">
-                  {preset.displayName}
+              <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
+                <CheckboxInput
+                  checked={ps.enabled && enableForNewSessions}
+                  disabled={!enableForNewSessions}
+                  onChange={(v) => setPresetEnabled(preset.name, v)}
+                />
+                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="truncate text-sm font-medium leading-none">
+                    {preset.displayName}
+                  </span>
+                  <span className="truncate text-xs leading-snug text-muted-foreground">
+                    {preset.summary}
+                  </span>
                 </span>
-                <span className="text-xs text-muted-foreground leading-snug">
-                  {preset.summary}
-                </span>
-              </div>
-              <select
+              </label>
+              <Select
                 value={model ?? ""}
-                disabled={!enableForNewSessions || !ps.enabled}
-                onChange={(e) =>
-                  setPresetOverride(preset.name, { model: e.target.value })
+                disabled={rowDisabled}
+                onValueChange={(next) =>
+                  setPresetOverride(preset.name, { model: next as string })
                 }
-                className="rounded-md border border-border/60 bg-background px-2 py-1 text-xs outline-none focus:border-foreground/40 disabled:opacity-50"
+                items={claudeModelItems}
               >
-                {claudeModels.map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.label}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger size="sm" className="w-auto min-w-44">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectPopup>
+                  {claudeModels.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
             </div>
           );
         })}
@@ -441,23 +449,290 @@ function SubagentsSection() {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Shared building blocks
+// ---------------------------------------------------------------------------
+
 export function Section({
   title,
   description,
   children,
 }: {
   title: string;
-  description: string;
+  description?: string;
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-3">
+    <section className="flex flex-col gap-3 border-t border-border/40 pt-6 first:border-t-0 first:pt-0">
       <div className="flex flex-col gap-1">
         <h2 className="text-sm font-medium text-foreground">{title}</h2>
-        <p className="text-xs text-muted-foreground">{description}</p>
+        {description && (
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {description}
+          </p>
+        )}
       </div>
       {children}
     </section>
+  );
+}
+
+export function OptionGroup({
+  children,
+  columns,
+}: {
+  children: React.ReactNode;
+  columns?: 2 | 3;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      className={cn(
+        "gap-2",
+        columns === 2 && "grid grid-cols-2",
+        columns === 3 && "grid grid-cols-3",
+        !columns && "flex flex-col",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function OptionCard({
+  icon: Icon,
+  iconNode,
+  title,
+  description,
+  active,
+  onClick,
+  disabled,
+}: {
+  icon?: React.ComponentType<{ className?: string }>;
+  iconNode?: React.ReactNode;
+  title: string;
+  description?: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  const compact = !description;
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "group flex w-full items-center gap-3 rounded-lg border text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        compact ? "px-3 py-2" : "items-start px-3.5 py-3",
+        active
+          ? "border-foreground/30 bg-accent/40"
+          : "border-border/50 hover:bg-muted/40",
+      )}
+    >
+      <RadioDot active={active} className={compact ? "" : "mt-0.5"} />
+      {(Icon || iconNode) && (
+        <span
+          className={cn(
+            "flex size-4 shrink-0 items-center justify-center text-muted-foreground group-aria-checked:text-foreground",
+            !compact && "mt-0.5",
+          )}
+        >
+          {iconNode ?? (Icon ? <Icon className="size-4" /> : null)}
+        </span>
+      )}
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-sm font-medium leading-none text-foreground">
+          {title}
+        </span>
+        {description && (
+          <span className="text-xs leading-snug text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+function RadioDot({
+  active,
+  className,
+}: {
+  active: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center rounded-full border transition-colors",
+        active
+          ? "border-foreground bg-background"
+          : "border-border bg-background group-hover:border-foreground/60",
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "size-1.5 rounded-full bg-foreground transition-transform duration-150",
+          active ? "scale-100" : "scale-0",
+        )}
+      />
+    </span>
+  );
+}
+
+export function CheckboxField({
+  checked,
+  onChange,
+  label,
+  description,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      className={cn(
+        "group/checkbox flex items-start gap-3 rounded-lg border border-border/50 px-3.5 py-3 text-sm transition-colors hover:bg-muted/40 has-[:focus-visible]:border-foreground/30 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring",
+        disabled && "pointer-events-none opacity-50",
+      )}
+    >
+      <CheckboxInput
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+        className="mt-0.5"
+      />
+      <span className="flex flex-1 flex-col gap-0.5">
+        <span className="font-medium leading-none text-foreground">
+          {label}
+        </span>
+        {description && (
+          <span className="text-xs leading-snug text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}
+
+/**
+ * Visually-styled checkbox: native `<input>` is `sr-only` for accessibility
+ * and form semantics, custom box is rendered as a sibling so we get
+ * `peer-focus-visible` rings + a real checkmark on solid-foreground fill.
+ */
+export function CheckboxInput({
+  checked,
+  onChange,
+  disabled,
+  className,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  return (
+    <span className={cn("relative inline-flex shrink-0", className)}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="peer absolute inset-0 size-4 cursor-pointer opacity-0 disabled:cursor-not-allowed"
+      />
+      <span
+        aria-hidden
+        className={cn(
+          "flex size-4 items-center justify-center rounded-[5px] border transition-colors",
+          "peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-1 peer-focus-visible:ring-offset-background",
+          checked
+            ? "border-foreground bg-foreground"
+            : "border-border bg-background peer-hover:border-foreground/60",
+          disabled && "opacity-50",
+        )}
+      >
+        {checked && (
+          <Check
+            className="size-3 text-background"
+            strokeWidth={3.5}
+            aria-hidden
+          />
+        )}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * "Inherits global ↔ Custom" segmented control for per-repo overrides.
+ * When inheriting, the children dim and clicks bypass. Picking any option
+ * inside `children` flips back to "Custom".
+ */
+export function OverrideField({
+  isOverridden,
+  globalLabel,
+  onClear,
+  children,
+}: {
+  isOverridden: boolean;
+  globalLabel: string;
+  onClear: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2">
+        <div className="inline-flex rounded-md border border-border/50 bg-muted/30 p-0.5 text-xs">
+          <button
+            type="button"
+            onClick={onClear}
+            className={cn(
+              "rounded px-2.5 py-1 transition-colors",
+              !isOverridden
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            Inherit
+          </button>
+          <button
+            type="button"
+            disabled={isOverridden}
+            className={cn(
+              "rounded px-2.5 py-1 transition-colors",
+              isOverridden
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground",
+            )}
+          >
+            Custom
+          </button>
+        </div>
+        {!isOverridden && (
+          <span className="truncate text-xs text-muted-foreground">
+            {globalLabel}
+          </span>
+        )}
+      </div>
+      <div
+        className={cn(
+          "transition-opacity",
+          isOverridden ? "" : "pointer-events-none opacity-50",
+        )}
+      >
+        {children}
+      </div>
+    </div>
   );
 }
 
@@ -471,26 +746,36 @@ export function ModelSelect({
   onChange: (model: string) => void;
 }) {
   const models = MODELS_BY_PROVIDER[providerId] ?? [];
-  // Avoid leaving the saved default pointing at a removed model.
   const normalizedValue =
     value !== null && (models.some((m) => m.id === value) || models.length === 0)
       ? value ?? ""
       : models[0]?.id ?? "";
+  const items = useMemo(
+    () => models.map((m) => ({ value: m.id, label: m.label })),
+    [models],
+  );
   return (
-    <label className="flex flex-col gap-1.5">
-      <span className="text-xs text-muted-foreground">Default model</span>
-      <select
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-muted-foreground">
+        Default model
+      </span>
+      <Select
         value={normalizedValue}
-        onChange={(e) => onChange(e.target.value)}
-        className="rounded-md border border-border/60 bg-background px-2 py-1.5 text-sm outline-none focus:border-foreground/40"
+        onValueChange={(next) => onChange(next as string)}
+        items={items}
       >
-        {models.map((m) => (
-          <option key={m.id} value={m.id}>
-            {m.label}
-          </option>
-        ))}
-      </select>
-    </label>
+        <SelectTrigger size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopup>
+          {models.map((m) => (
+            <SelectItem key={m.id} value={m.id}>
+              {m.label}
+            </SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+    </div>
   );
 }
 
@@ -511,7 +796,5 @@ export function ensureValidDefaultsForRuntime(
   return { providerId: provider, model, runtimeMode: settings.defaultRuntimeMode };
 }
 
-// `FolderId` is referenced by the Repositories rail item; re-exporting the
-// type keeps the settings-page.tsx -> settings-repository.tsx boundary
-// well-typed without a separate types module.
+export { PROVIDER_LABEL };
 export type { FolderId };

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -1,4 +1,4 @@
-import { Check, GitBranch, Trash2 } from "lucide-react";
+import { GitBranch, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import {
@@ -7,19 +7,21 @@ import {
   type ProviderId,
 } from "@memoize/wire";
 
-import { cn } from "~/lib/utils";
 import { useRepositorySettingsStore } from "../store/repository-settings.ts";
 import { useSettingsStore } from "../store/settings.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { MODES_ORDER, MODE_META } from "./runtime-mode-meta.ts";
-import { ModelSelect, Section } from "./settings-page.tsx";
-
-const PROVIDER_LABEL: Record<ProviderId, string> = {
-  claude: "Claude Code",
-  codex: "Codex",
-};
+import {
+  CheckboxField,
+  ModelSelect,
+  OptionCard,
+  OptionGroup,
+  OverrideField,
+  PROVIDER_LABEL,
+  Section,
+} from "./settings-page.tsx";
 
 /**
  * Per-repository settings: provider/model/permission overrides plus
@@ -56,17 +58,7 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
 
   return (
     <>
-      <Section
-        title="Path"
-        description="Where this repository lives on disk."
-      >
-        <div className="rounded-md border border-border/60 bg-background px-3 py-2 font-mono text-xs text-muted-foreground">
-          {folder.path}
-        </div>
-      </Section>
-
       <ProviderOverrideSection
-        projectId={projectId}
         defaultProviderId={settings.defaultProviderId}
         defaultModel={settings.defaultModel}
         onProviderChange={(value) =>
@@ -96,86 +88,58 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
 }
 
 function ProviderOverrideSection({
-  projectId,
   defaultProviderId,
   defaultModel,
   onProviderChange,
   onModelChange,
 }: {
-  projectId: FolderId;
   defaultProviderId: ProviderId | null;
   defaultModel: string | null;
   onProviderChange: (v: ProviderId | null) => void;
   onModelChange: (v: string | null) => void;
 }) {
   const globalProviderId = useSettingsStore((s) => s.defaultProviderId);
+  const globalModelByProvider = useSettingsStore(
+    (s) => s.defaultModelByProvider,
+  );
   const effectiveProvider: ProviderId = defaultProviderId ?? globalProviderId;
+  const globalModel = globalModelByProvider[globalProviderId];
+  const globalModelLabel =
+    MODELS_BY_PROVIDER[globalProviderId].find((m) => m.id === globalModel)
+      ?.label ?? globalModel ?? "—";
+  const isOverridden = defaultProviderId !== null || defaultModel !== null;
   return (
     <Section
       title="Default agent"
-      description="Override the global default provider and model for new chats started in this repo. Leave on global to inherit."
+      description="Override the global default provider and model for new chats in this repo."
     >
-      <div className="flex flex-col gap-3">
-        <div className="grid grid-cols-3 gap-2">
-          <button
-            type="button"
-            onClick={() => onProviderChange(null)}
-            className={cn(
-              "flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
-              defaultProviderId === null
-                ? "border-foreground/40 bg-accent/40"
-                : "border-border/60 hover:bg-muted/40",
-            )}
-            title={`Use global default (${PROVIDER_LABEL[globalProviderId]})`}
-          >
-            <span className="flex-1 text-left">Use global</span>
-            {defaultProviderId === null && (
-              <Check className="size-3.5 opacity-80" />
-            )}
-          </button>
-          {(["claude", "codex"] as ReadonlyArray<ProviderId>).map((pid) => {
-            const active = defaultProviderId === pid;
-            return (
-              <button
+      <OverrideField
+        isOverridden={isOverridden}
+        globalLabel={`${PROVIDER_LABEL[globalProviderId]} · ${globalModelLabel}`}
+        onClear={() => {
+          onProviderChange(null);
+          onModelChange(null);
+        }}
+      >
+        <div className="flex flex-col gap-3">
+          <OptionGroup columns={2}>
+            {(["claude", "codex"] as ReadonlyArray<ProviderId>).map((pid) => (
+              <OptionCard
                 key={pid}
-                type="button"
+                iconNode={<ProviderIcon providerId={pid} className="size-4" />}
+                title={PROVIDER_LABEL[pid]}
+                active={effectiveProvider === pid}
                 onClick={() => onProviderChange(pid)}
-                className={cn(
-                  "flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
-                  active
-                    ? "border-foreground/40 bg-accent/40"
-                    : "border-border/60 hover:bg-muted/40",
-                )}
-              >
-                <ProviderIcon providerId={pid} className="size-4" />
-                <span className="flex-1 text-left">
-                  {PROVIDER_LABEL[pid]}
-                </span>
-                {active && <Check className="size-3.5 opacity-80" />}
-              </button>
-            );
-          })}
-        </div>
-        <div className="flex items-end gap-2">
+              />
+            ))}
+          </OptionGroup>
           <ModelSelect
             providerId={effectiveProvider}
             value={defaultModel}
             onChange={(model) => onModelChange(model)}
           />
-          <button
-            type="button"
-            onClick={() => onModelChange(null)}
-            disabled={defaultModel === null}
-            className="rounded-md border border-border/60 px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/40 disabled:opacity-50"
-            title="Clear override and inherit global default model"
-          >
-            Use global
-          </button>
         </div>
-        <span className="text-[11px] text-muted-foreground">
-          Project: <span className="font-mono">{projectId}</span>
-        </span>
-      </div>
+      </OverrideField>
     </Section>
   );
 }
@@ -184,60 +148,37 @@ function RuntimeModeOverrideSection({
   currentValue,
   onChange,
 }: {
-  currentValue: string | null;
+  currentValue: typeof MODES_ORDER[number] | null;
   onChange: (v: typeof MODES_ORDER[number] | null) => void;
 }) {
+  const globalMode = useSettingsStore((s) => s.defaultRuntimeMode);
+  const effective = currentValue ?? globalMode;
   return (
     <Section
       title="Default permission mode"
       description="Override the global permission posture for new chats in this repo."
     >
-      <div className="flex flex-col gap-2">
-        <button
-          type="button"
-          onClick={() => onChange(null)}
-          className={cn(
-            "flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
-            currentValue === null
-              ? "border-foreground/40 bg-accent/40"
-              : "border-border/60 hover:bg-muted/40",
-          )}
-        >
-          <span className="flex-1 text-left">Use global default</span>
-          {currentValue === null && <Check className="size-3.5 opacity-80" />}
-        </button>
-        {MODES_ORDER.map((mode) => {
-          const m = MODE_META[mode];
-          const ItemIcon = m.Icon;
-          const active = currentValue === mode;
-          return (
-            <button
-              key={mode}
-              type="button"
-              onClick={() => onChange(mode)}
-              className={cn(
-                "grid grid-cols-[1.25rem_1.25rem_1fr_1rem] items-start gap-x-3 rounded-md border px-3 py-3 text-left transition-colors",
-                active
-                  ? "border-foreground/40 bg-accent/40"
-                  : "border-border/60 hover:bg-muted/40",
-              )}
-            >
-              <ItemIcon className="col-start-2 row-start-1 mt-0.5 size-4 shrink-0" />
-              <div className="col-start-3 row-start-1 flex flex-col gap-1">
-                <span className="text-sm font-medium leading-none">
-                  {m.label}
-                </span>
-                <span className="text-xs text-muted-foreground leading-snug">
-                  {m.description}
-                </span>
-              </div>
-              {active && (
-                <Check className="col-start-4 row-start-1 mt-0.5 size-3.5 opacity-80" />
-              )}
-            </button>
-          );
-        })}
-      </div>
+      <OverrideField
+        isOverridden={currentValue !== null}
+        globalLabel={MODE_META[globalMode].label}
+        onClear={() => onChange(null)}
+      >
+        <OptionGroup>
+          {MODES_ORDER.map((mode) => {
+            const m = MODE_META[mode];
+            return (
+              <OptionCard
+                key={mode}
+                icon={m.Icon}
+                title={m.label}
+                description={m.description}
+                active={effective === mode}
+                onClick={() => onChange(mode)}
+              />
+            );
+          })}
+        </OptionGroup>
+      </OverrideField>
     </Section>
   );
 }
@@ -299,46 +240,39 @@ function WorktreeSection({
       description="Git worktrees for this repo. Each lives under .memoize/repo-worktree/ on disk."
     >
       <div className="flex flex-col gap-3">
-        <label className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2.5 text-sm">
-          <input
-            type="checkbox"
-            checked={autoCreate}
-            onChange={(e) => onAutoCreateChange(e.target.checked)}
-            className="size-4 accent-foreground"
-          />
-          <span className="flex flex-1 flex-col gap-0.5">
-            <span className="font-medium leading-none">
-              Auto-create a worktree for new chats
-            </span>
-            <span className="text-xs text-muted-foreground leading-snug">
-              When on, the composer's workspace picker pre-selects a fresh
-              worktree. You can still flip back to "Current checkout"
-              before sending the first message.
-            </span>
-          </span>
-        </label>
+        <CheckboxField
+          checked={autoCreate}
+          onChange={onAutoCreateChange}
+          label="Auto-create a worktree for new chats"
+          description='When on, the composer&apos;s workspace picker pre-selects a fresh worktree. You can still flip back to "Current checkout" before sending the first message.'
+        />
 
         {sorted.length === 0 ? (
-          <p className="rounded-md border border-dashed border-border/40 px-3 py-4 text-center text-xs text-muted-foreground">
-            No worktrees yet. The composer creates one on demand.
+          <p className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-xs text-muted-foreground">
+            No worktrees yet. Memoize creates one for you when you start a new
+            chat.
           </p>
         ) : (
-          <ul className="flex flex-col gap-1 rounded-md border border-border/40 p-1">
+          <ul className="flex flex-col gap-0.5 rounded-lg border border-border/50 p-1.5">
             {sorted.map((wt) => (
               <li
                 key={wt.id}
-                className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/30"
+                className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-md px-2.5 py-2 transition-colors hover:bg-muted/40"
               >
                 <GitBranch className="size-4 shrink-0 text-muted-foreground" />
-                <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="truncate text-sm font-medium">
+                <div
+                  className="flex min-w-0 flex-col gap-0.5"
+                  title={wt.path}
+                >
+                  <span className="truncate text-sm font-medium text-foreground">
                     {wt.name}
                   </span>
                   <span className="truncate font-mono text-[11px] text-muted-foreground">
-                    {wt.branch} · off {wt.baseBranch}
-                  </span>
-                  <span className="truncate font-mono text-[11px] text-muted-foreground/80">
-                    {wt.path}
+                    {wt.branch}
+                    <span className="text-muted-foreground/60">
+                      {" "}
+                      · off {wt.baseBranch}
+                    </span>
                   </span>
                 </div>
                 {pendingDirty === wt.name ? (
@@ -346,14 +280,14 @@ function WorktreeSection({
                     <button
                       type="button"
                       onClick={() => void onRemove(wt.id, wt.name, true)}
-                      className="rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1 text-[11px] text-red-400 hover:bg-red-500/20"
+                      className="rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1 text-[11px] text-red-400 transition-colors hover:bg-red-500/20"
                     >
                       Force remove
                     </button>
                     <button
                       type="button"
                       onClick={() => setPendingDirty(null)}
-                      className="rounded-md border border-border/60 px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted/40"
+                      className="rounded-md border border-border/50 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted/40"
                     >
                       Cancel
                     </button>
@@ -362,7 +296,7 @@ function WorktreeSection({
                   <button
                     type="button"
                     onClick={() => void onRemove(wt.id, wt.name, false)}
-                    className="flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+                    className="flex items-center gap-1 rounded-md border border-border/50 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
                     title="Remove this worktree from disk (branch stays)"
                   >
                     <Trash2 className="size-3" />


### PR DESCRIPTION
## Summary
- Replace hardcoded `bg-zinc-950` with `bg-background`; widen the rail to `w-56` with sidebar tokens; bump page title to `text-xl` with a subtitle (repo path for per-repo panes); drop the raw `FolderId` line and the redundant header `X` button.
- Extract `OptionCard` (with a real radio-dot indicator), `OptionGroup`, `CheckboxField`, `CheckboxInput` (custom styled box + check), and `OverrideField` (an "Inherit / Custom" segmented toggle) — kills 3× duplication of mode/provider cards and the awkward "Use global" sibling-card pattern in per-repo overrides.
- Swap native `<select>` for the design-system `Select` primitive in `ModelSelect` and the sub-agents picker; restructure the sub-agent row so opening the dropdown no longer toggles the row's checkbox.

## Test plan
- [ ] `bun run check-types` (passes locally)
- [ ] Open Settings, walk General / Models & Providers / Workspace and a per-repo entry — verify card hover, radio dot, focus rings, and the Inherit ↔ Custom toggle clear overrides correctly.
- [ ] Toggle sub-agents off, confirm per-preset rows dim and the model dropdown disables; open a model dropdown and confirm it doesn't toggle the row checkbox.
- [ ] Remove a worktree, including the dirty-state Force/Cancel branch.