### PR TITLE
feat(renderer): first-launch onboarding wizard

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -14,6 +14,7 @@ import { ChatView } from "./components/chat-view";
 import { CostFooter } from "./components/cost-footer";
 import { FileEditor } from "./components/file-editor.tsx";
 import { MainTabs } from "./components/main-tabs.tsx";
+import { OnboardingWizard } from "./components/onboarding/onboarding-wizard.tsx";
 import { ProjectsSidebar } from "./components/projects-sidebar";
 import { RightPane } from "./components/right-pane";
 import { SettingsPage } from "./components/settings-page";
@@ -21,6 +22,7 @@ import { TopBarLeft, TopBarMain, TopBarRight } from "./components/top-bar.tsx";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { usePermissionsStore } from "./store/permissions.ts";
 import { useSessionsStore } from "./store/sessions.ts";
+import { useSettingsStore } from "./store/settings.ts";
 import { useUiStore } from "./store/ui.ts";
 import { useWorkspaceStore } from "./store/workspace.ts";
 
@@ -130,6 +132,17 @@ export function App() {
     if (rightSidebarOpen && collapsed) panel.expand();
     if (!rightSidebarOpen && !collapsed) panel.collapse();
   }, [rightPanelRef, rightSidebarOpen]);
+
+  const onboardingCompleted = useSettingsStore((s) => s.onboardingCompleted);
+  if (!onboardingCompleted) {
+    return (
+      <TooltipProvider>
+        <div className="dark relative flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background/40 text-foreground">
+          <OnboardingWizard />
+        </div>
+      </TooltipProvider>
+    );
+  }
 
   if (view === "settings") {
     return (

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -29,30 +29,22 @@ import { useWorkspaceStore } from "./store/workspace.ts";
 const PANEL_GROUP_ID = "memoize.shell.v3";
 const PANEL_IDS = ["projects", "main", "files"];
 
+/**
+ * Root component. Owns only the cross-cutting concerns that need to run in
+ * every mode (permissions stream, fullscreen sync, onboarding gate). The
+ * heavy three-pane shell lives in `MainShell` so its layout hooks don't
+ * initialize while the onboarding wizard is on screen — re-mounting it on
+ * exit is what gives us a clean shell each time.
+ */
 export function App() {
-  const folders = useWorkspaceStore((s) => s.folders);
-  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
-  const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
-  const selectedSession = useSessionsStore((s) => {
-    if (s.selectedSessionId === null) return null;
-    for (const list of Object.values(s.sessionsByProject)) {
-      const match = list.find((session) => session.id === s.selectedSessionId);
-      if (match !== undefined) return match;
-    }
-    return null;
-  });
-  const selectedFolder = selectedFolderId
-    ? (folders.find((f) => f.id === selectedFolderId) ?? null)
-    : null;
-
+  // Cross-cutting subscriptions that should run regardless of view.
   const startPermissionsStream = usePermissionsStore((s) => s.start);
   useEffect(() => {
     startPermissionsStream();
   }, [startPermissionsStream]);
 
-  // Mirror the Electron window's fullscreen state into the ui store so the
-  // top bars can drop the macOS traffic-light gutter — there are no traffic
-  // lights to dodge in native fullscreen.
+  // Mirror Electron's fullscreen state into the ui store so the top bars
+  // can drop the macOS traffic-light gutter.
   const setFullScreen = useUiStore((s) => s.setFullScreen);
   useEffect(() => {
     const win = window.memoize?.window;
@@ -60,26 +52,7 @@ export function App() {
     return win.onFullScreenChange((value) => setFullScreen(value));
   }, [setFullScreen]);
 
-  const view = useUiStore((s) => s.view);
-  const activeMainTab = useUiStore((s) => s.activeMainTab);
-  const openFile = useUiStore((s) => s.openFile);
-  const closeFileTab = useUiStore((s) => s.closeFileTab);
-  const leftSidebarOpen = useUiStore((s) => s.leftSidebarOpen);
-  const setLeftSidebarOpen = useUiStore((s) => s.setLeftSidebarOpen);
-  const rightSidebarOpen = useUiStore((s) => s.rightSidebarOpen);
-  const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
-
-  // Switching projects in the left sidebar closes the file tab — its path
-  // wouldn't resolve under the new project's root anyway. Run only when the
-  // selected folder actually leaves the open file behind.
-  useEffect(() => {
-    if (openFile === null) return;
-    if (selectedFolderId !== null && openFile.folderId === selectedFolderId) {
-      return;
-    }
-    closeFileTab();
-  }, [selectedFolderId, openFile, closeFileTab]);
-
+  // One-shot RPC ping so we know the bridge is alive early.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -99,6 +72,76 @@ export function App() {
       cancelled = true;
     };
   }, []);
+
+  const onboardingCompleted = useSettingsStore((s) => s.onboardingCompleted);
+  const view = useUiStore((s) => s.view);
+
+  if (!onboardingCompleted) {
+    return (
+      <TooltipProvider>
+        <div className="dark relative flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background/40 text-foreground">
+          <OnboardingWizard />
+        </div>
+      </TooltipProvider>
+    );
+  }
+
+  if (view === "settings") {
+    return (
+      <TooltipProvider>
+        <div className="dark flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background/70 text-foreground">
+          <SettingsPage />
+        </div>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <MainShell />
+    </TooltipProvider>
+  );
+}
+
+/**
+ * The three-pane chat shell. Owns its own layout/panel hooks so they
+ * initialize on mount (i.e. only after onboarding is past). Re-mounting
+ * this component on every onboarding exit guarantees the layout starts
+ * from a clean state.
+ */
+function MainShell() {
+  const folders = useWorkspaceStore((s) => s.folders);
+  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
+  const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
+  const selectedSession = useSessionsStore((s) => {
+    if (s.selectedSessionId === null) return null;
+    for (const list of Object.values(s.sessionsByProject)) {
+      const match = list.find((session) => session.id === s.selectedSessionId);
+      if (match !== undefined) return match;
+    }
+    return null;
+  });
+  const selectedFolder = selectedFolderId
+    ? (folders.find((f) => f.id === selectedFolderId) ?? null)
+    : null;
+
+  const activeMainTab = useUiStore((s) => s.activeMainTab);
+  const openFile = useUiStore((s) => s.openFile);
+  const closeFileTab = useUiStore((s) => s.closeFileTab);
+  const leftSidebarOpen = useUiStore((s) => s.leftSidebarOpen);
+  const setLeftSidebarOpen = useUiStore((s) => s.setLeftSidebarOpen);
+  const rightSidebarOpen = useUiStore((s) => s.rightSidebarOpen);
+  const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
+
+  // Switching projects closes the file tab — its path wouldn't resolve
+  // under the new project's root anyway.
+  useEffect(() => {
+    if (openFile === null) return;
+    if (selectedFolderId !== null && openFile.folderId === selectedFolderId) {
+      return;
+    }
+    closeFileTab();
+  }, [selectedFolderId, openFile, closeFileTab]);
 
   const headerLabel = selectedSession
     ? selectedSession.title
@@ -133,120 +176,97 @@ export function App() {
     if (!rightSidebarOpen && !collapsed) panel.collapse();
   }, [rightPanelRef, rightSidebarOpen]);
 
-  const onboardingCompleted = useSettingsStore((s) => s.onboardingCompleted);
-  if (!onboardingCompleted) {
-    return (
-      <TooltipProvider>
-        <div className="dark relative flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background/40 text-foreground">
-          <OnboardingWizard />
-        </div>
-      </TooltipProvider>
-    );
-  }
-
-  if (view === "settings") {
-    return (
-      <TooltipProvider>
-        <div className="dark flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background/70 text-foreground">
-          <SettingsPage />
-        </div>
-      </TooltipProvider>
-    );
-  }
-
   return (
-    <TooltipProvider>
-      <div className="dark flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden text-foreground">
-        <Group
-          id={PANEL_GROUP_ID}
-          orientation="horizontal"
-          defaultLayout={defaultLayout}
-          onLayoutChanged={onLayoutChanged}
-          className="flex-1"
+    <div className="dark flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden text-foreground">
+      <Group
+        id={PANEL_GROUP_ID}
+        orientation="horizontal"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+        className="flex-1"
+      >
+        <Panel
+          id="projects"
+          defaultSize="18%"
+          minSize="180px"
+          maxSize="40%"
+          collapsible
+          collapsedSize="0%"
+          panelRef={leftPanelRef}
+          onResize={(size) => {
+            const open = size.asPercentage > 0;
+            if (open !== leftSidebarOpen) setLeftSidebarOpen(open);
+          }}
         >
-          <Panel
-            id="projects"
-            defaultSize="18%"
-            minSize="180px"
-            maxSize="40%"
-            collapsible
-            collapsedSize="0%"
-            panelRef={leftPanelRef}
-            onResize={(size) => {
-              const open = size.asPercentage > 0;
-              if (open !== leftSidebarOpen) setLeftSidebarOpen(open);
-            }}
-          >
-            <div className="flex h-full min-h-0 flex-col bg-background/20">
-              <TopBarLeft />
-              <div className="flex min-h-0 flex-1 flex-col">
-                <ProjectsSidebar />
-              </div>
+          <div className="flex h-full min-h-0 flex-col bg-background/20">
+            <TopBarLeft />
+            <div className="flex min-h-0 flex-1 flex-col">
+              <ProjectsSidebar />
             </div>
-          </Panel>
-          <Separator className="w-px bg-border transition-colors hover:bg-foreground/20 active:bg-foreground/30" />
-          <Panel id="main" minSize="30%">
-            <main className="flex h-full min-h-0 min-w-0 flex-col bg-background/70 backdrop-blur-3xl">
-              <TopBarMain folderId={selectedFolderId} />
-              <MainTabs
-                headerLabel={headerLabel}
-                headerTitle={selectedFolder?.path}
-                providerId={selectedSession?.providerId}
-                model={selectedSession?.model}
-              />
-              <div
-                hidden={activeMainTab !== "chat"}
-                className="flex min-h-0 flex-1 flex-col"
-              >
-                {selectedSessionId !== null && selectedSession !== null ? (
-                  <>
-                    <ChatView sessionId={selectedSessionId} />
-                    <CostFooter sessionId={selectedSessionId} />
-                    <ChatComposer session={selectedSession} />
-                  </>
-                ) : (
-                  <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
-                    <p>
-                      {selectedFolder === null
-                        ? "Add a project on the left to begin."
-                        : "Pick or create a session in the sidebar."}
-                    </p>
-                  </div>
-                )}
-              </div>
-              {openFile !== null && (
-                <div
-                  hidden={activeMainTab !== "file"}
-                  className="flex min-h-0 flex-1 flex-col"
-                >
-                  <FileEditor />
+          </div>
+        </Panel>
+        <Separator className="w-px bg-border transition-colors hover:bg-foreground/20 active:bg-foreground/30" />
+        <Panel id="main" minSize="30%">
+          <main className="flex h-full min-h-0 min-w-0 flex-col bg-background/70 backdrop-blur-3xl">
+            <TopBarMain folderId={selectedFolderId} />
+            <MainTabs
+              headerLabel={headerLabel}
+              headerTitle={selectedFolder?.path}
+              providerId={selectedSession?.providerId}
+              model={selectedSession?.model}
+            />
+            <div
+              hidden={activeMainTab !== "chat"}
+              className="flex min-h-0 flex-1 flex-col"
+            >
+              {selectedSessionId !== null && selectedSession !== null ? (
+                <>
+                  <ChatView sessionId={selectedSessionId} />
+                  <CostFooter sessionId={selectedSessionId} />
+                  <ChatComposer session={selectedSession} />
+                </>
+              ) : (
+                <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+                  <p>
+                    {selectedFolder === null
+                      ? "Add a project on the left to begin."
+                      : "Pick or create a session in the sidebar."}
+                  </p>
                 </div>
               )}
-            </main>
-          </Panel>
-          <Separator className="w-px bg-border transition-colors hover:bg-foreground/20 active:bg-foreground/30" />
-          <Panel
-            id="files"
-            defaultSize="22%"
-            minSize="220px"
-            maxSize="45%"
-            collapsible
-            collapsedSize="0%"
-            panelRef={rightPanelRef}
-            onResize={(size) => {
-              const open = size.asPercentage > 0;
-              if (open !== rightSidebarOpen) setRightSidebarOpen(open);
-            }}
-          >
-            <div className="flex h-full min-h-0 flex-col bg-sidebar/40 backdrop-blur-3xl">
-              <TopBarRight folderId={selectedFolderId} />
-              <div className="flex min-h-0 flex-1 flex-col">
-                <RightPane />
-              </div>
             </div>
-          </Panel>
-        </Group>
-      </div>
-    </TooltipProvider>
+            {openFile !== null && (
+              <div
+                hidden={activeMainTab !== "file"}
+                className="flex min-h-0 flex-1 flex-col"
+              >
+                <FileEditor />
+              </div>
+            )}
+          </main>
+        </Panel>
+        <Separator className="w-px bg-border transition-colors hover:bg-foreground/20 active:bg-foreground/30" />
+        <Panel
+          id="files"
+          defaultSize="22%"
+          minSize="220px"
+          maxSize="45%"
+          collapsible
+          collapsedSize="0%"
+          panelRef={rightPanelRef}
+          onResize={(size) => {
+            const open = size.asPercentage > 0;
+            if (open !== rightSidebarOpen) setRightSidebarOpen(open);
+          }}
+        >
+          <div className="flex h-full min-h-0 flex-col bg-sidebar/40 backdrop-blur-3xl">
+            <TopBarRight folderId={selectedFolderId} />
+            <div className="flex min-h-0 flex-1 flex-col">
+              <RightPane />
+            </div>
+          </div>
+        </Panel>
+      </Group>
+    </div>
   );
 }

--- a/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
+++ b/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,173 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+import { useProvidersStore } from "../../store/providers.ts";
+import { useSettingsStore } from "../../store/settings.ts";
+import { useWorkspaceStore } from "../../store/workspace.ts";
+import { DefaultsStep } from "./steps/defaults.tsx";
+import { DoneStep } from "./steps/done.tsx";
+import { ProjectStep } from "./steps/project.tsx";
+import { ProviderStep } from "./steps/provider.tsx";
+import { WelcomeStep } from "./steps/welcome.tsx";
+
+type StepId = "welcome" | "provider" | "project" | "defaults" | "done";
+
+const STEPS: ReadonlyArray<StepId> = [
+  "welcome",
+  "provider",
+  "project",
+  "defaults",
+  "done",
+];
+
+/**
+ * First-launch wizard. Mounted at the top of `App` when
+ * `settings.onboardingCompleted === false`. Hydrates providers + workspace
+ * once on mount so the Provider and Project steps render fresh state.
+ */
+export function OnboardingWizard() {
+  const refreshProviders = useProvidersStore((s) => s.refresh);
+  const loadWorkspace = useWorkspaceStore((s) => s.load);
+  const folders = useWorkspaceStore((s) => s.folders);
+  const setOnboardingCompleted = useSettingsStore(
+    (s) => s.setOnboardingCompleted,
+  );
+
+  const [stepIndex, setStepIndex] = useState(0);
+
+  useEffect(() => {
+    void refreshProviders();
+    void loadWorkspace();
+  }, [refreshProviders, loadWorkspace]);
+
+  const stepId = STEPS[stepIndex]!;
+  const isFirst = stepIndex === 0;
+  const isLast = stepId === "done";
+
+  const canAdvance = useMemo(() => {
+    if (stepId === "project") return folders.length > 0;
+    return true;
+  }, [stepId, folders.length]);
+
+  const goNext = useCallback(() => {
+    setStepIndex((i) => Math.min(i + 1, STEPS.length - 1));
+  }, []);
+  const goBack = useCallback(() => {
+    setStepIndex((i) => Math.max(i - 1, 0));
+  }, []);
+  const finish = useCallback(() => {
+    setOnboardingCompleted(true);
+  }, [setOnboardingCompleted]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!e.metaKey && !e.ctrlKey) return;
+      if (e.key === "ArrowLeft" && !isFirst) {
+        e.preventDefault();
+        goBack();
+      } else if (e.key === "ArrowRight" && !isLast && canAdvance) {
+        e.preventDefault();
+        goNext();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isFirst, isLast, canAdvance, goBack, goNext]);
+
+  const skippable = stepId === "project" || stepId === "defaults";
+
+  return (
+    <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden">
+      {/* Ambient color: two soft radial blooms behind a heavy blur for that
+          frosted-vibrancy feel. Sits behind the card, never interactive. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10"
+      >
+        <div className="absolute -top-32 -left-24 size-[28rem] rounded-full bg-[radial-gradient(circle_at_center,theme(colors.indigo.500/0.18),transparent_70%)] blur-3xl" />
+        <div className="absolute -bottom-40 -right-20 size-[32rem] rounded-full bg-[radial-gradient(circle_at_center,theme(colors.fuchsia.500/0.14),transparent_70%)] blur-3xl" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,theme(colors.white/0.04),transparent_60%)]" />
+      </div>
+
+      {/* Drag region so users can move the Electron window. */}
+      <div className="h-9 shrink-0 [-webkit-app-region:drag]" />
+
+      <div className="flex min-h-0 flex-1 items-center justify-center px-6 pb-12">
+        <div className="flex w-full max-w-xl flex-col gap-6">
+          <StepIndicator stepIndex={stepIndex} />
+
+          <div className="min-h-[24rem] px-1 py-2">
+            {stepId === "welcome" && <WelcomeStep />}
+            {stepId === "provider" && <ProviderStep />}
+            {stepId === "project" && <ProjectStep />}
+            {stepId === "defaults" && <DefaultsStep />}
+            {stepId === "done" && <DoneStep onFinish={finish} />}
+          </div>
+
+          {!isLast && (
+            <div className="flex items-center justify-between">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={goBack}
+                disabled={isFirst}
+                className={cn(
+                  "rounded-full px-3 text-muted-foreground hover:text-foreground",
+                  isFirst && "invisible",
+                )}
+              >
+                <ArrowLeft />
+                Back
+              </Button>
+              <div className="flex items-center gap-1">
+                {skippable && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={goNext}
+                    className="rounded-full px-3 text-muted-foreground hover:text-foreground"
+                  >
+                    Skip
+                  </Button>
+                )}
+                <Button
+                  size="default"
+                  onClick={goNext}
+                  disabled={!canAdvance}
+                  className="rounded-full px-5"
+                >
+                  {isFirst ? "Get started" : "Continue"}
+                  <ArrowRight />
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StepIndicator({ stepIndex }: { stepIndex: number }) {
+  return (
+    <div className="flex items-center justify-center gap-1.5">
+      {STEPS.map((id, i) => {
+        const active = i === stepIndex;
+        const done = i < stepIndex;
+        return (
+          <span
+            key={id}
+            className={cn(
+              "h-1 rounded-full transition-all duration-300",
+              active && "w-8 bg-foreground",
+              done && "w-4 bg-foreground/60",
+              !active && !done && "w-4 bg-foreground/15",
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/defaults.tsx
+++ b/apps/renderer/src/components/onboarding/steps/defaults.tsx
@@ -1,0 +1,121 @@
+import { Check } from "lucide-react";
+
+import {
+  ModelSelect,
+} from "~/components/settings-page";
+import { MODE_META, MODES_ORDER } from "~/components/runtime-mode-meta";
+import { Switch } from "~/components/ui/switch";
+import { cn } from "~/lib/utils";
+import { useSettingsStore } from "../../../store/settings.ts";
+import { StepHeader } from "./shared.tsx";
+
+export function DefaultsStep() {
+  const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
+  const defaultModelByProvider = useSettingsStore(
+    (s) => s.defaultModelByProvider,
+  );
+  const setDefaultModel = useSettingsStore((s) => s.setDefaultModel);
+  const defaultRuntimeMode = useSettingsStore((s) => s.defaultRuntimeMode);
+  const setDefaultRuntimeMode = useSettingsStore(
+    (s) => s.setDefaultRuntimeMode,
+  );
+  const defaultAutoCreateWorktree = useSettingsStore(
+    (s) => s.defaultAutoCreateWorktree,
+  );
+  const setDefaultAutoCreateWorktree = useSettingsStore(
+    (s) => s.setDefaultAutoCreateWorktree,
+  );
+
+  return (
+    <div className="flex flex-col gap-7">
+      <StepHeader
+        kicker="Step 3"
+        title="A few quick defaults"
+        subtitle="Tweak any of these later in Settings. Per-chat overrides always win."
+      />
+
+      <div className="flex flex-col gap-5">
+        <FieldRow label="Default model">
+          <ModelSelect
+            providerId={defaultProviderId}
+            value={defaultModelByProvider[defaultProviderId]}
+            onChange={(model) => setDefaultModel(defaultProviderId, model)}
+          />
+        </FieldRow>
+
+        <div className="flex flex-col gap-2.5">
+          <span className="text-[12px] font-medium text-foreground">
+            Permission mode
+          </span>
+          <div className="flex flex-col gap-1.5">
+            {MODES_ORDER.map((mode) => {
+              const m = MODE_META[mode];
+              const active = mode === defaultRuntimeMode;
+              return (
+                <button
+                  key={mode}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setDefaultRuntimeMode(mode)}
+                  className={cn(
+                    "group flex items-center gap-3 rounded-2xl px-3.5 py-2.5 text-left transition-all",
+                    active
+                      ? "bg-white/[0.08]"
+                      : "bg-white/[0.025] hover:bg-white/[0.05]",
+                  )}
+                >
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-xl bg-white/[0.06] text-foreground">
+                    <m.Icon className="size-3.5" strokeWidth={1.75} />
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-[13px] font-medium leading-none text-foreground">
+                      {m.label}
+                    </span>
+                    <span className="text-[11px] leading-snug text-muted-foreground">
+                      {m.description}
+                    </span>
+                  </span>
+                  {active && (
+                    <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-foreground text-background">
+                      <Check className="size-2.5" strokeWidth={3.5} />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <label className="flex cursor-pointer items-center gap-3 rounded-2xl bg-white/[0.025] px-3.5 py-3 transition-colors hover:bg-white/[0.05]">
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="text-[13px] font-medium leading-none text-foreground">
+              New worktree per chat
+            </span>
+            <span className="text-[11px] leading-snug text-muted-foreground">
+              Each chat runs on its own branch under <code>.memoize/repo-worktree/</code>.
+            </span>
+          </span>
+          <Switch
+            checked={defaultAutoCreateWorktree}
+            onCheckedChange={setDefaultAutoCreateWorktree}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function FieldRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-[12px] font-medium text-foreground">{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/done.tsx
+++ b/apps/renderer/src/components/onboarding/steps/done.tsx
@@ -1,0 +1,29 @@
+import { Check } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+
+export function DoneStep({ onFinish }: { onFinish: () => void }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-7 text-center">
+      <div className="relative flex size-16 items-center justify-center">
+        <span className="absolute inset-0 rounded-full bg-emerald-400/15 blur-xl" />
+        <span className="relative flex size-14 items-center justify-center rounded-full bg-emerald-400/15 text-emerald-300">
+          <Check className="size-6" strokeWidth={2.25} />
+        </span>
+      </div>
+      <div className="flex flex-col gap-2.5">
+        <h2 className="text-3xl font-semibold tracking-tight text-foreground">
+          You&apos;re all set
+        </h2>
+        <p className="max-w-sm text-[14px] leading-relaxed text-muted-foreground">
+          Start a chat from the sidebar whenever you&apos;re ready. Replay this
+          flow anytime from{" "}
+          <span className="text-foreground">Settings → General</span>.
+        </p>
+      </div>
+      <Button size="default" onClick={onFinish} className="rounded-full px-6">
+        Open memoize
+      </Button>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/project.tsx
+++ b/apps/renderer/src/components/onboarding/steps/project.tsx
@@ -1,0 +1,89 @@
+import { Check, FolderClosed, FolderPlus } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "~/components/ui/button";
+import { useWorkspaceStore } from "../../../store/workspace.ts";
+import { StepHeader } from "./shared.tsx";
+
+export function ProjectStep() {
+  const folders = useWorkspaceStore((s) => s.folders);
+  const add = useWorkspaceStore((s) => s.add);
+  const error = useWorkspaceStore((s) => s.error);
+  const [busy, setBusy] = useState(false);
+
+  const pick = async () => {
+    setBusy(true);
+    try {
+      await add();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const justAdded = folders[folders.length - 1] ?? null;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <StepHeader
+        kicker="Step 2"
+        title="Add your first project"
+        subtitle="Any folder on your machine — we'll list it in the sidebar, no copies made."
+      />
+
+      {justAdded === null ? (
+        <button
+          type="button"
+          onClick={() => void pick()}
+          disabled={busy}
+          className="group flex flex-col items-center justify-center gap-4 rounded-2xl bg-white/[0.025] px-6 py-12 text-center transition-all hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <span className="flex size-12 items-center justify-center rounded-2xl bg-white/[0.06] text-foreground transition-transform group-hover:scale-105">
+            <FolderPlus className="size-5" strokeWidth={1.5} />
+          </span>
+          <span className="flex flex-col gap-1">
+            <span className="text-[14px] font-medium text-foreground">
+              {busy ? "Opening picker…" : "Choose a folder"}
+            </span>
+            <span className="text-[11px] text-muted-foreground">
+              Click to browse — or drag one in
+            </span>
+          </span>
+        </button>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3 rounded-2xl bg-emerald-400/[0.06] px-4 py-3.5">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white/[0.08] text-foreground">
+              <FolderClosed className="size-4" strokeWidth={1.75} />
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate text-[14px] font-medium text-foreground">
+                {justAdded.name}
+              </span>
+              <span className="truncate font-mono text-[11px] text-muted-foreground">
+                {justAdded.path}
+              </span>
+            </div>
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-emerald-400/20 text-emerald-300">
+              <Check className="size-3" strokeWidth={3} />
+            </span>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void pick()}
+              disabled={busy}
+              className="rounded-full px-3 text-[12px] text-muted-foreground hover:text-foreground"
+            >
+              Pick a different folder
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {error !== null && (
+        <p className="text-[11px] text-destructive">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -1,0 +1,383 @@
+import { Check, Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+
+import type { AgentAvailability, ProviderId } from "@memoize/wire";
+
+import { ProviderIcon } from "~/components/provider-icons";
+import { PROVIDER_LABEL } from "~/components/settings-page";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { cn } from "~/lib/utils";
+import { useProvidersStore } from "../../../store/providers.ts";
+import { useSettingsStore } from "../../../store/settings.ts";
+import { StepHeader } from "./shared.tsx";
+
+const LOGIN_HINT: Record<ProviderId, string> = {
+  claude: "claude /login",
+  codex: "codex login",
+};
+
+const INSTALL_HINT: Record<ProviderId, string> = {
+  claude: "npm i -g @anthropic-ai/claude-code",
+  codex: "npm i -g @openai/codex",
+};
+
+const PROVIDER_TAGLINE: Record<ProviderId, string> = {
+  claude: "Anthropic · Opus, Sonnet, Haiku",
+  codex: "OpenAI · GPT-5 family",
+};
+
+type ProviderState =
+  | { readonly kind: "loading" }
+  | { readonly kind: "missing" } // CLI not installed
+  | { readonly kind: "signed-out" } // CLI installed, not logged in, no API key
+  | { readonly kind: "ready"; readonly via: "cli" | "key" };
+
+function deriveState(
+  providerId: ProviderId,
+  availability: ReadonlyArray<AgentAvailability>,
+  loading: boolean,
+): ProviderState {
+  const a = availability.find((x) => x.providerId === providerId);
+  if (a === undefined) {
+    return loading ? { kind: "loading" } : { kind: "missing" };
+  }
+  if (a.cliLoggedIn) return { kind: "ready", via: "cli" };
+  if (a.hasApiKey) return { kind: "ready", via: "key" };
+  if (!a.cliInstalled) return { kind: "missing" };
+  return { kind: "signed-out" };
+}
+
+export function ProviderStep() {
+  const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
+  const setDefaultProvider = useSettingsStore((s) => s.setDefaultProvider);
+  const availability = useProvidersStore((s) => s.availability);
+  const loading = useProvidersStore((s) => s.loading);
+
+  const providers: ReadonlyArray<ProviderId> = ["claude", "codex"];
+
+  return (
+    <div className="flex flex-col gap-7">
+      <StepHeader
+        kicker="Step 1"
+        title="Pick your agent"
+        subtitle="memoize uses your existing CLI credentials — no API keys required."
+      />
+
+      <div className="grid grid-cols-2 gap-2.5">
+        {providers.map((pid) => (
+          <ProviderCard
+            key={pid}
+            providerId={pid}
+            state={deriveState(pid, availability, loading)}
+            active={pid === defaultProviderId}
+            onClick={() => setDefaultProvider(pid)}
+          />
+        ))}
+      </div>
+
+      <ProviderStatus
+        providerId={defaultProviderId}
+        state={deriveState(defaultProviderId, availability, loading)}
+      />
+    </div>
+  );
+}
+
+function ProviderCard({
+  providerId,
+  state,
+  active,
+  onClick,
+}: {
+  providerId: ProviderId;
+  state: ProviderState;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "group relative flex flex-col items-start gap-2 overflow-hidden rounded-2xl p-4 text-left transition-all",
+        active
+          ? "bg-white/[0.08] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+          : "bg-white/[0.025] hover:bg-white/[0.05]",
+      )}
+    >
+      {active && (
+        <span className="absolute right-3 top-3 flex size-4 items-center justify-center rounded-full bg-foreground text-background">
+          <Check className="size-2.5" strokeWidth={3.5} />
+        </span>
+      )}
+      <div className="flex w-full items-center justify-between">
+        <span className="flex size-9 items-center justify-center rounded-xl bg-white/[0.06] text-foreground">
+          <ProviderIcon providerId={providerId} className="size-4" />
+        </span>
+        {!active && <StateDot state={state} />}
+      </div>
+      <span className="flex flex-col gap-0.5">
+        <span className="text-[15px] font-medium leading-none text-foreground">
+          {PROVIDER_LABEL[providerId]}
+        </span>
+        <span className="text-[11px] leading-snug text-muted-foreground">
+          {PROVIDER_TAGLINE[providerId]}
+        </span>
+      </span>
+      <StateLine state={state} />
+    </button>
+  );
+}
+
+function StateDot({ state }: { state: ProviderState }) {
+  const styles: Record<ProviderState["kind"], string> = {
+    loading: "bg-muted-foreground/40 animate-pulse",
+    missing: "bg-rose-400/80",
+    "signed-out": "bg-amber-400",
+    ready: "bg-emerald-400",
+  };
+  return (
+    <span
+      className={cn(
+        "size-1.5 shrink-0 rounded-full",
+        styles[state.kind],
+      )}
+      aria-hidden
+    />
+  );
+}
+
+function StateLine({ state }: { state: ProviderState }) {
+  const text =
+    state.kind === "loading"
+      ? "Checking…"
+      : state.kind === "missing"
+        ? "Not installed"
+        : state.kind === "signed-out"
+          ? "Sign in required"
+          : state.via === "cli"
+            ? "CLI logged in"
+            : "API key set";
+  const tone =
+    state.kind === "ready"
+      ? "text-emerald-300/90"
+      : state.kind === "signed-out"
+        ? "text-amber-300/90"
+        : state.kind === "missing"
+          ? "text-rose-300/90"
+          : "text-muted-foreground";
+  return (
+    <span className={cn("mt-2 text-[10px] font-medium tracking-wide", tone)}>
+      {text.toUpperCase()}
+    </span>
+  );
+}
+
+function ProviderStatus({
+  providerId,
+  state,
+}: {
+  providerId: ProviderId;
+  state: ProviderState;
+}) {
+  const refresh = useProvidersStore((s) => s.refresh);
+
+  const headline =
+    state.kind === "loading"
+      ? "Checking your machine…"
+      : state.kind === "ready"
+        ? state.via === "cli"
+          ? "Ready to go"
+          : "Ready — using API key"
+        : state.kind === "signed-out"
+          ? "Sign in to the CLI"
+          : "Install the CLI";
+
+  const subline =
+    state.kind === "loading"
+      ? "Probing CLI install + login state."
+      : state.kind === "ready"
+        ? state.via === "cli"
+          ? "We picked up your existing CLI session."
+          : "Stored in your OS keychain."
+        : state.kind === "signed-out"
+          ? "Already installed — just run the login command below."
+          : `${PROVIDER_LABEL[providerId]}'s CLI isn't on your PATH yet.`;
+
+  const showLoginBlock = state.kind === "signed-out";
+  const showInstallBlock = state.kind === "missing";
+  const apiSummary = state.kind === "ready" && state.via === "key";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl bg-white/[0.025] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-foreground">
+            {headline}
+          </span>
+          <span className="text-[11px] leading-snug text-muted-foreground">
+            {subline}
+          </span>
+        </div>
+        <StatusPill state={state} />
+      </div>
+
+      {showInstallBlock && (
+        <CodeRow
+          command={INSTALL_HINT[providerId]}
+          onRecheck={() => void refresh()}
+        />
+      )}
+      {showLoginBlock && (
+        <CodeRow
+          command={LOGIN_HINT[providerId]}
+          onRecheck={() => void refresh()}
+        />
+      )}
+
+      <details className="group/keys">
+        <summary className="cursor-pointer select-none list-none text-[11px] text-muted-foreground hover:text-foreground">
+          {apiSummary
+            ? "API key saved — replace it"
+            : "or paste an API key instead"}
+        </summary>
+        <div className="pt-3">
+          <ApiKeyRow providerId={providerId} />
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function CodeRow({
+  command,
+  onRecheck,
+}: {
+  command: string;
+  onRecheck: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl bg-black/30 px-3 py-2 font-mono text-[12px]">
+      <code className="truncate text-foreground/90">$ {command}</code>
+      <Button
+        size="xs"
+        variant="ghost"
+        onClick={onRecheck}
+        className="h-6 shrink-0 rounded-full px-2.5 text-[11px] text-muted-foreground hover:text-foreground"
+      >
+        Recheck
+      </Button>
+    </div>
+  );
+}
+
+function StatusPill({ state }: { state: ProviderState }) {
+  const map: Record<
+    ProviderState["kind"],
+    { label: string; dot: string; bg: string; text: string }
+  > = {
+    loading: {
+      label: "Checking",
+      dot: "bg-muted-foreground/50",
+      bg: "bg-white/[0.04]",
+      text: "text-muted-foreground",
+    },
+    missing: {
+      label: "Not installed",
+      dot: "bg-rose-400",
+      bg: "bg-rose-400/12",
+      text: "text-rose-300",
+    },
+    "signed-out": {
+      label: "Sign in",
+      dot: "bg-amber-400",
+      bg: "bg-amber-400/12",
+      text: "text-amber-300",
+    },
+    ready: {
+      label: "Connected",
+      dot: "bg-emerald-400",
+      bg: "bg-emerald-400/12",
+      text: "text-emerald-300",
+    },
+  };
+  const s = map[state.kind];
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium",
+        s.bg,
+        s.text,
+      )}
+    >
+      <span className={cn("size-1.5 rounded-full", s.dot)} />
+      {s.label}
+    </span>
+  );
+}
+
+function ApiKeyRow({ providerId }: { providerId: ProviderId }) {
+  const setCredential = useProvidersStore((s) => s.setCredential);
+  const [value, setValue] = useState("");
+  const [reveal, setReveal] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const onSave = async () => {
+    if (value.trim().length === 0) return;
+    setBusy(true);
+    setStatus(null);
+    try {
+      await setCredential(providerId, value.trim());
+      setValue("");
+      setStatus("Saved.");
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            type={reveal ? "text" : "password"}
+            placeholder="paste API key"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            disabled={busy}
+            className="h-9 rounded-xl border-0 bg-white/[0.04]"
+          />
+          <button
+            type="button"
+            onClick={() => setReveal((r) => !r)}
+            className="absolute end-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:text-foreground"
+            aria-label={reveal ? "Hide key" : "Reveal key"}
+            tabIndex={-1}
+          >
+            {reveal ? (
+              <EyeOff className="size-3.5" />
+            ) : (
+              <Eye className="size-3.5" />
+            )}
+          </button>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => void onSave()}
+          disabled={busy || value.trim().length === 0}
+          className="rounded-full px-4"
+        >
+          Save
+        </Button>
+      </div>
+      {status !== null && (
+        <p className="text-[11px] text-muted-foreground">{status}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/shared.tsx
+++ b/apps/renderer/src/components/onboarding/steps/shared.tsx
@@ -1,0 +1,23 @@
+export function StepHeader({
+  kicker,
+  title,
+  subtitle,
+}: {
+  kicker: string;
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
+        {kicker}
+      </span>
+      <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+        {title}
+      </h2>
+      <p className="max-w-md text-[13px] leading-relaxed text-muted-foreground">
+        {subtitle}
+      </p>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/welcome.tsx
+++ b/apps/renderer/src/components/onboarding/steps/welcome.tsx
@@ -1,0 +1,47 @@
+export function WelcomeStep() {
+  return (
+    <div className="flex h-full flex-col gap-10">
+      <div className="flex flex-col gap-3">
+        <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
+          Welcome
+        </span>
+        <h1 className="text-4xl font-semibold leading-[1.05] tracking-tight text-foreground">
+          A calm home for
+          <br />
+          parallel agents.
+        </h1>
+        <p className="max-w-md pt-1 text-[15px] leading-relaxed text-muted-foreground">
+          Run Claude or Codex on your repos — each chat in its own git worktree,
+          each agent on its own thread. We&apos;ll set things up in under a
+          minute.
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-0.5 text-sm">
+        <Row title="Bring your own agent">
+          Claude Code and Codex, using your existing CLI credentials.
+        </Row>
+        <Row title="One worktree per chat">
+          Experiments stay isolated, branches stay tidy.
+        </Row>
+        <Row title="Three quick steps">
+          Pick a provider, add a project, choose your defaults.
+        </Row>
+      </ul>
+    </div>
+  );
+}
+
+function Row({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <li className="flex items-baseline gap-3 py-2">
+      <span className="flex size-1 shrink-0 translate-y-[-3px] rounded-full bg-foreground/40" />
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="font-medium text-foreground">{title}</span>
+        <span className="text-xs leading-snug text-muted-foreground">
+          {children}
+        </span>
+      </span>
+    </li>
+  );
+}

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -25,6 +25,7 @@ import { useWorkspaceStore } from "../store/workspace.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { MODES_ORDER, MODE_META } from "./runtime-mode-meta.ts";
 import { RepositorySettings } from "./settings-repository.tsx";
+import { Button } from "./ui/button.tsx";
 import {
   Select,
   SelectItem,
@@ -272,6 +273,10 @@ function GeneralPane() {
   const setDefaultRuntimeMode = useSettingsStore(
     (s) => s.setDefaultRuntimeMode,
   );
+  const setOnboardingCompleted = useSettingsStore(
+    (s) => s.setOnboardingCompleted,
+  );
+  const setView = useUiStore((s) => s.setView);
   return (
     <>
       <Section
@@ -295,6 +300,23 @@ function GeneralPane() {
         </OptionGroup>
       </Section>
       <SubagentsSection />
+      <Section
+        title="Onboarding"
+        description="Replay the first-launch welcome flow. Your existing projects and credentials stay put."
+      >
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setView("chat");
+              setOnboardingCompleted(false);
+            }}
+          >
+            Show onboarding again
+          </Button>
+        </div>
+      </Section>
     </>
   );
 }

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -26,6 +26,7 @@ type Persisted = {
    * seeds new repos from this value.
    */
   readonly defaultAutoCreateWorktree: boolean;
+  readonly onboardingCompleted: boolean;
 };
 
 const isProviderId = (v: unknown): v is ProviderId =>
@@ -34,25 +35,20 @@ const isProviderId = (v: unknown): v is ProviderId =>
 const isRuntimeMode = (v: unknown): v is RuntimeMode =>
   v === "approval-required" || v === "auto-accept-edits" || v === "full-access";
 
+const freshDefaults = (): Persisted => ({
+  defaultProviderId: DEFAULT_PROVIDER,
+  defaultModelByProvider: seedModels(),
+  defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
+  defaultAutoCreateWorktree: false,
+  onboardingCompleted: false,
+});
+
 const loadPersisted = (): Persisted => {
-  if (typeof window === "undefined") {
-    return {
-      defaultProviderId: DEFAULT_PROVIDER,
-      defaultModelByProvider: seedModels(),
-      defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
-      defaultAutoCreateWorktree: false,
-    };
-  }
+  if (typeof window === "undefined") return freshDefaults();
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw === null) {
-      return {
-        defaultProviderId: DEFAULT_PROVIDER,
-        defaultModelByProvider: seedModels(),
-        defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
-        defaultAutoCreateWorktree: false,
-      };
-    }
+    // Genuine first launch — no blob at all.
+    if (raw === null) return freshDefaults();
     const parsed = JSON.parse(raw) as Partial<Persisted>;
     const seeded = seedModels();
     const models: Record<ProviderId, string> = {
@@ -77,14 +73,16 @@ const loadPersisted = (): Persisted => {
         typeof parsed.defaultAutoCreateWorktree === "boolean"
           ? parsed.defaultAutoCreateWorktree
           : false,
+      // Existing users — blob present but pre-dating the onboarding flag —
+      // skip the wizard. Only a missing blob (handled above) is treated as
+      // first launch.
+      onboardingCompleted:
+        typeof parsed.onboardingCompleted === "boolean"
+          ? parsed.onboardingCompleted
+          : true,
     };
   } catch {
-    return {
-      defaultProviderId: DEFAULT_PROVIDER,
-      defaultModelByProvider: seedModels(),
-      defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
-      defaultAutoCreateWorktree: false,
-    };
+    return freshDefaults();
   }
 };
 
@@ -97,55 +95,44 @@ const persist = (state: Persisted) => {
   }
 };
 
+const snapshot = (s: Persisted): Persisted => ({
+  defaultProviderId: s.defaultProviderId,
+  defaultModelByProvider: s.defaultModelByProvider,
+  defaultRuntimeMode: s.defaultRuntimeMode,
+  defaultAutoCreateWorktree: s.defaultAutoCreateWorktree,
+  onboardingCompleted: s.onboardingCompleted,
+});
+
 type SettingsState = Persisted & {
   readonly setDefaultProvider: (providerId: ProviderId) => void;
   readonly setDefaultModel: (providerId: ProviderId, model: string) => void;
   readonly setDefaultRuntimeMode: (mode: RuntimeMode) => void;
   readonly setDefaultAutoCreateWorktree: (value: boolean) => void;
+  readonly setOnboardingCompleted: (value: boolean) => void;
 };
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
   ...loadPersisted(),
   setDefaultProvider: (providerId) => {
     set({ defaultProviderId: providerId });
-    const s = get();
-    persist({
-      defaultProviderId: s.defaultProviderId,
-      defaultModelByProvider: s.defaultModelByProvider,
-      defaultRuntimeMode: s.defaultRuntimeMode,
-      defaultAutoCreateWorktree: s.defaultAutoCreateWorktree,
-    });
+    persist(snapshot(get()));
   },
   setDefaultModel: (providerId, model) => {
     set((s) => ({
       defaultModelByProvider: { ...s.defaultModelByProvider, [providerId]: model },
     }));
-    const s = get();
-    persist({
-      defaultProviderId: s.defaultProviderId,
-      defaultModelByProvider: s.defaultModelByProvider,
-      defaultRuntimeMode: s.defaultRuntimeMode,
-      defaultAutoCreateWorktree: s.defaultAutoCreateWorktree,
-    });
+    persist(snapshot(get()));
   },
   setDefaultRuntimeMode: (mode) => {
     set({ defaultRuntimeMode: mode });
-    const s = get();
-    persist({
-      defaultProviderId: s.defaultProviderId,
-      defaultModelByProvider: s.defaultModelByProvider,
-      defaultRuntimeMode: s.defaultRuntimeMode,
-      defaultAutoCreateWorktree: s.defaultAutoCreateWorktree,
-    });
+    persist(snapshot(get()));
   },
   setDefaultAutoCreateWorktree: (value) => {
     set({ defaultAutoCreateWorktree: value });
-    const s = get();
-    persist({
-      defaultProviderId: s.defaultProviderId,
-      defaultModelByProvider: s.defaultModelByProvider,
-      defaultRuntimeMode: s.defaultRuntimeMode,
-      defaultAutoCreateWorktree: s.defaultAutoCreateWorktree,
-    });
+    persist(snapshot(get()));
+  },
+  setOnboardingCompleted: (value) => {
+    set({ onboardingCompleted: value });
+    persist(snapshot(get()));
   },
 }));


### PR DESCRIPTION
## Summary
- Five-step welcome flow (Welcome → Provider → Project → Defaults → Done) gated by a new `onboardingCompleted` flag in `memoize.settings.v1`. Genuine first launches see the wizard; existing users are migrated to `true` and skip it.
- Per-provider status pills surface real CLI install + login state so users can tell at a glance whether Claude or Codex is actually wired up, with the panel below adapting between install / sign-in / ready states.
- A "Show onboarding again" reset button lives in Settings → General so the flow can be replayed.
- Visual treatment: translucent surface over an ambient radial bloom, pill-shaped buttons, no hairline borders — meant to feel macOS-native.
- The main three-pane shell is now its own `MainShell` component so `useDefaultLayout` / `usePanelRef` only initialize after the wizard exits, fixing a reload-time regression.

## Test plan
- [ ] Cold launch with no `memoize.settings.v1` → wizard appears on Welcome.
- [ ] Walk Welcome → Provider → Project → Defaults → Done; provider status reflects real CLI state for both Claude and Codex.
- [ ] "Open memoize" on the Done step lands you on the main shell with the picked project selected.
- [ ] Reload the renderer (Cmd+R) — main shell renders correctly, no broken panel layout.
- [ ] Settings → General → "Show onboarding again" replays the flow and returns cleanly when done.
- [ ] Existing users (pre-existing `memoize.settings.v1` blob) launch straight into the main shell, wizard does not appear.