### PR TITLE
style(renderer): cleaner alert UI + fix(codex): replace dead gpt-5-codex slug

### DIFF
--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -60,9 +60,9 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
   };
 
   return (
-    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-3">
+    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl border border-warning/15 bg-warning/5 p-3">
       <div className="flex items-start gap-2.5">
-        <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg bg-amber-400/15 text-amber-300">
+        <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg text-warning">
           <ArrowUpCircle className="size-3.5" />
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -87,7 +87,7 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
       </div>
 
       {command !== null && (
-        <div className="flex items-center justify-between gap-3 rounded-xl bg-black/30 px-3 py-1.5 font-mono text-[11.5px]">
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-border/20 bg-background/40 px-3 py-1.5 font-mono text-[11.5px]">
           <code className="truncate text-foreground/90">$ {command}</code>
           <Button
             size="xs"

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -60,7 +60,7 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
   };
 
   return (
-    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] p-3">
+    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-alert-warning-bg p-3">
       <div className="flex items-start gap-2.5">
         <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg text-warning">
           <ArrowUpCircle className="size-3.5" />

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -60,7 +60,7 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
   };
 
   return (
-    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] p-3">
+    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] p-3">
       <div className="flex items-start gap-2.5">
         <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg text-warning">
           <ArrowUpCircle className="size-3.5" />

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -60,7 +60,7 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
   };
 
   return (
-    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl border border-warning/15 bg-warning/5 p-3">
+    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] p-3">
       <div className="flex items-start gap-2.5">
         <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg text-warning">
           <ArrowUpCircle className="size-3.5" />
@@ -87,7 +87,7 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
       </div>
 
       {command !== null && (
-        <div className="flex items-center justify-between gap-3 rounded-lg border border-border/20 bg-background/40 px-3 py-1.5 font-mono text-[11.5px]">
+        <div className="flex items-center justify-between gap-3 rounded-lg bg-background/40 px-3 py-1.5 font-mono text-[11.5px]">
           <code className="truncate text-foreground/90">$ {command}</code>
           <Button
             size="xs"

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -199,7 +199,7 @@ export function FileEditor() {
       )}
       {state.status === "error" && (
         <Placeholder>
-          <span className="text-red-300">{state.reason}</span>
+          <span className="text-destructive">{state.reason}</span>
           <button
             type="button"
             onClick={closeFileTab}
@@ -221,7 +221,11 @@ function Toolbar({ path, saving }: { path: string; saving: boolean }) {
         {path}
       </span>
       <span className="ml-auto flex items-center gap-2">
-        {dirty ? <span className="text-yellow-300">● modified</span> : null}
+        {dirty ? (
+          <span className="text-muted-foreground">
+            <span className="text-warning">●</span> modified
+          </span>
+        ) : null}
         {saving ? <span>saving…</span> : null}
         <span className="opacity-60">⌘S to save</span>
       </span>
@@ -241,13 +245,13 @@ function Banner({
   onDismiss: () => void;
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-2 border-b border-border bg-yellow-500/10 px-3 py-1.5 text-[11px] text-yellow-200">
-      <span className="flex-1">{message}</span>
+    <div className="flex shrink-0 items-center gap-2 border-b border-warning/15 bg-warning/5 px-3 py-1.5 text-[11px] text-foreground">
+      <span className="flex-1 text-muted-foreground">{message}</span>
       {actionLabel && (
         <button
           type="button"
           onClick={onAction}
-          className="rounded bg-yellow-500/20 px-2 py-0.5 hover:bg-yellow-500/30"
+          className="rounded bg-accent px-2 py-0.5 text-foreground hover:bg-accent/80"
         >
           {actionLabel}
         </button>
@@ -256,7 +260,7 @@ function Banner({
         type="button"
         onClick={onDismiss}
         aria-label="Dismiss"
-        className="rounded px-1 text-yellow-200/80 hover:text-yellow-100"
+        className="rounded px-1 text-muted-foreground hover:text-foreground"
       >
         ×
       </button>

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -245,7 +245,7 @@ function Banner({
   onDismiss: () => void;
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-2 bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] px-3 py-1.5 text-[11px] text-foreground">
+    <div className="flex shrink-0 items-center gap-2 bg-alert-warning-bg px-3 py-1.5 text-[11px] text-foreground">
       <span className="flex-1 text-muted-foreground">{message}</span>
       {actionLabel && (
         <button

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -245,7 +245,7 @@ function Banner({
   onDismiss: () => void;
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-2 border-b border-warning/15 bg-warning/5 px-3 py-1.5 text-[11px] text-foreground">
+    <div className="flex shrink-0 items-center gap-2 bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] px-3 py-1.5 text-[11px] text-foreground">
       <span className="flex-1 text-muted-foreground">{message}</span>
       {actionLabel && (
         <button

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -245,7 +245,7 @@ function Banner({
   onDismiss: () => void;
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-2 bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] px-3 py-1.5 text-[11px] text-foreground">
+    <div className="flex shrink-0 items-center gap-2 bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] px-3 py-1.5 text-[11px] text-foreground">
       <span className="flex-1 text-muted-foreground">{message}</span>
       {actionLabel && (
         <button

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -271,7 +271,7 @@ function ToolErrorRow({ output }: { output: unknown }) {
       <button
         type="button"
         onClick={() => setExpanded((e) => !e)}
-        className="group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs hover:bg-red-500/10"
+        className="group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs hover:bg-accent"
       >
         <div className="relative grid size-4 shrink-0 place-items-center">
           <HugeiconsIcon
@@ -279,24 +279,24 @@ function ToolErrorRow({ output }: { output: unknown }) {
             strokeWidth={2}
             aria-hidden="true"
             className={cn(
-              "col-start-1 row-start-1 size-3.5 text-red-400 transition-opacity duration-150 ease-out",
+              "col-start-1 row-start-1 size-3.5 text-destructive transition-opacity duration-150 ease-out",
               "group-hover:opacity-0 motion-reduce:transition-none",
             )}
           />
           <Chevron
             aria-hidden="true"
             className={cn(
-              "col-start-1 row-start-1 size-3.5 text-red-400 opacity-0 transition-opacity duration-150 ease-out",
+              "col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
               "group-hover:opacity-100 motion-reduce:transition-none",
             )}
           />
         </div>
-        <span className="font-medium text-red-300">Error</span>
-        <span className="truncate text-red-200/80">{firstLine}</span>
+        <span className="font-medium text-foreground">Error</span>
+        <span className="truncate text-muted-foreground">{firstLine}</span>
       </button>
       {expanded ? (
-        <div className="ml-7 mt-1 border-l border-red-500/30 pl-3">
-          <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] text-red-200">
+        <div className="ml-7 mt-1 border-l border-border/60 pl-3">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
             {text || "(empty)"}
           </pre>
         </div>
@@ -362,52 +362,52 @@ export function ErrorBubble({
   if (rateLimit !== null) {
     return (
       <div className="px-4 py-2">
-        <div className="max-w-[88%] rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+        <div className="max-w-[88%] rounded-xl border border-warning/15 bg-warning/5 px-3 py-2 text-xs text-foreground">
           <div className="flex items-center gap-2">
             <HugeiconsIcon
               icon={AlertCircleIcon}
               strokeWidth={2}
               aria-hidden="true"
-              className="size-3.5 shrink-0 text-amber-300"
+              className="size-3.5 shrink-0 text-warning"
             />
-            <span className="font-medium text-amber-100">
+            <span className="font-medium text-foreground">
               Rate limit reached
             </span>
-            <span className="text-amber-200/50">·</span>
-            <span className="text-amber-200/90">
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-muted-foreground">
               {formatResetDetail(rateLimit)}
             </span>
             {onDismiss !== undefined && (
               <button
                 type="button"
                 onClick={onDismiss}
-                className="ml-auto rounded px-1.5 py-0.5 text-amber-200/70 hover:bg-amber-500/15 hover:text-amber-100"
+                className="ml-auto rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
               >
                 Dismiss
               </button>
             )}
           </div>
-          <div className="mt-1 break-words text-amber-200/70">{text}</div>
+          <div className="mt-1 break-words text-muted-foreground">{text}</div>
         </div>
       </div>
     );
   }
   return (
     <div className="px-4 py-2">
-      <div className="max-w-[88%] rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+      <div className="max-w-[88%] rounded-xl border border-destructive/15 bg-destructive/5 px-3 py-2 text-xs text-foreground">
         <div className="flex items-start gap-2">
           <HugeiconsIcon
             icon={AlertCircleIcon}
             strokeWidth={2}
             aria-hidden="true"
-            className="mt-px size-3.5 shrink-0 text-red-400"
+            className="mt-px size-3.5 shrink-0 text-destructive"
           />
-          <span className="break-words">{text}</span>
+          <span className="break-words text-muted-foreground">{text}</span>
           {onDismiss !== undefined && (
             <button
               type="button"
               onClick={onDismiss}
-              className="ml-auto rounded px-1.5 py-0.5 text-red-200/70 hover:bg-red-500/15 hover:text-red-100"
+              className="ml-auto rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
             >
               Dismiss
             </button>

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -362,7 +362,7 @@ export function ErrorBubble({
   if (rateLimit !== null) {
     return (
       <div className="px-4 py-2">
-        <div className="max-w-[88%] rounded-xl border border-warning/15 bg-warning/5 px-3 py-2 text-xs text-foreground">
+        <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] px-3 py-2 text-xs text-foreground">
           <div className="flex items-center gap-2">
             <HugeiconsIcon
               icon={AlertCircleIcon}
@@ -394,7 +394,7 @@ export function ErrorBubble({
   }
   return (
     <div className="px-4 py-2">
-      <div className="max-w-[88%] rounded-xl border border-destructive/15 bg-destructive/5 px-3 py-2 text-xs text-foreground">
+      <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))] px-3 py-2 text-xs text-foreground">
         <div className="flex items-start gap-2">
           <HugeiconsIcon
             icon={AlertCircleIcon}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -362,7 +362,7 @@ export function ErrorBubble({
   if (rateLimit !== null) {
     return (
       <div className="px-4 py-2">
-        <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] px-3 py-2 text-xs text-foreground">
+        <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] px-3 py-2 text-xs text-foreground">
           <div className="flex items-center gap-2">
             <HugeiconsIcon
               icon={AlertCircleIcon}
@@ -394,7 +394,7 @@ export function ErrorBubble({
   }
   return (
     <div className="px-4 py-2">
-      <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))] px-3 py-2 text-xs text-foreground">
+      <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))] px-3 py-2 text-xs text-foreground">
         <div className="flex items-start gap-2">
           <HugeiconsIcon
             icon={AlertCircleIcon}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -362,7 +362,7 @@ export function ErrorBubble({
   if (rateLimit !== null) {
     return (
       <div className="px-4 py-2">
-        <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] px-3 py-2 text-xs text-foreground">
+        <div className="max-w-[88%] rounded-xl bg-alert-warning-bg px-3 py-2 text-xs text-foreground">
           <div className="flex items-center gap-2">
             <HugeiconsIcon
               icon={AlertCircleIcon}
@@ -394,7 +394,7 @@ export function ErrorBubble({
   }
   return (
     <div className="px-4 py-2">
-      <div className="max-w-[88%] rounded-xl bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))] px-3 py-2 text-xs text-foreground">
+      <div className="max-w-[88%] rounded-xl bg-alert-error-bg px-3 py-2 text-xs text-foreground">
         <div className="flex items-start gap-2">
           <HugeiconsIcon
             icon={AlertCircleIcon}

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -164,7 +164,7 @@ function TerminalBlock({
       className={cn(
         "rounded px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
         isError
-          ? "bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))]"
+          ? "bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))]"
           : "bg-zinc-900/70",
       )}
     >
@@ -239,7 +239,7 @@ function PreBlock({
       className={cn(
         "overflow-x-auto whitespace-pre-wrap break-words rounded px-3 py-2 font-mono text-[11px] text-foreground/80",
         isError
-          ? "bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))]"
+          ? "bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))]"
           : "bg-zinc-900/70",
       )}
     >

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -163,7 +163,7 @@ function TerminalBlock({
     <div
       className={cn(
         "rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
-        isError ? "border border-red-500/30" : "",
+        isError ? "border border-destructive/15" : "",
       )}
     >
       {command !== undefined ? (
@@ -177,7 +177,7 @@ function TerminalBlock({
           className={cn(
             "whitespace-pre-wrap break-words",
             command !== undefined ? "mt-2" : "",
-            isError ? "text-red-200" : "text-foreground/80",
+            "text-foreground/80",
           )}
         >
           {output}
@@ -189,7 +189,7 @@ function TerminalBlock({
 
 function ErrorPill() {
   return (
-    <span className="mr-2 rounded bg-red-500/20 px-1.5 py-0.5 font-medium text-[10px] text-red-300">
+    <span className="mr-2 rounded bg-destructive/12 px-1.5 py-0.5 font-medium text-[10px] text-destructive">
       Error
     </span>
   );
@@ -236,7 +236,7 @@ function PreBlock({
     <pre
       className={cn(
         "overflow-x-auto whitespace-pre-wrap break-words rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px]",
-        isError ? "border border-red-500/30 text-red-200" : "text-foreground/80",
+        isError ? "border border-destructive/15 text-foreground/80" : "text-foreground/80",
       )}
     >
       {text || "(empty)"}

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -164,7 +164,7 @@ function TerminalBlock({
       className={cn(
         "rounded px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
         isError
-          ? "bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))]"
+          ? "bg-alert-error-bg"
           : "bg-zinc-900/70",
       )}
     >
@@ -239,7 +239,7 @@ function PreBlock({
       className={cn(
         "overflow-x-auto whitespace-pre-wrap break-words rounded px-3 py-2 font-mono text-[11px] text-foreground/80",
         isError
-          ? "bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))]"
+          ? "bg-alert-error-bg"
           : "bg-zinc-900/70",
       )}
     >

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -162,8 +162,10 @@ function TerminalBlock({
   return (
     <div
       className={cn(
-        "rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
-        isError ? "border border-destructive/15" : "",
+        "rounded px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
+        isError
+          ? "bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))]"
+          : "bg-zinc-900/70",
       )}
     >
       {command !== undefined ? (
@@ -235,8 +237,10 @@ function PreBlock({
   return (
     <pre
       className={cn(
-        "overflow-x-auto whitespace-pre-wrap break-words rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px]",
-        isError ? "border border-destructive/15 text-foreground/80" : "text-foreground/80",
+        "overflow-x-auto whitespace-pre-wrap break-words rounded px-3 py-2 font-mono text-[11px] text-foreground/80",
+        isError
+          ? "bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))]"
+          : "bg-zinc-900/70",
       )}
     >
       {text || "(empty)"}

--- a/apps/renderer/src/components/ui/alert.tsx
+++ b/apps/renderer/src/components/ui/alert.tsx
@@ -2,25 +2,26 @@ import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 import { cn } from "~/lib/utils";
 
-// Minimal alert surface. The card carries a very subtle warm tint via the
-// semantic color (~5% bg, ~15% border) — barely perceptible but enough to
-// differentiate the surface. The icon is the only place the color reads at
-// full strength. No accent bars, no loud washes.
+// Minimal alert surface. The card uses a solid full-opacity warm tint —
+// `color-mix` blends ~14% of the semantic color into `--card` so the surface
+// reads as a single hard color (e.g. a dark warm red for error in dark
+// mode), not a transparent wash on top of the page. No borders.
 const alertVariants = cva(
-  "relative grid w-full items-start gap-x-2 gap-y-0.5 rounded-xl border px-3.5 py-3 text-foreground text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[calc(var(--spacing)*4)_1fr_auto] has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 [&>svg]:h-lh [&>svg]:w-4",
+  "relative grid w-full items-start gap-x-2 gap-y-0.5 rounded-xl px-3.5 py-3 text-foreground text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[calc(var(--spacing)*4)_1fr_auto] has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 [&>svg]:h-lh [&>svg]:w-4",
   {
     defaultVariants: {
       variant: "default",
     },
     variants: {
       variant: {
-        default:
-          "border-border/20 bg-muted/30 [&>svg]:text-muted-foreground",
+        default: "bg-card [&>svg]:text-muted-foreground",
         error:
-          "border-destructive/15 bg-destructive/5 [&>svg]:text-destructive",
-        info: "border-info/15 bg-info/5 [&>svg]:text-info",
-        success: "border-success/15 bg-success/5 [&>svg]:text-success",
-        warning: "border-warning/15 bg-warning/5 [&>svg]:text-warning",
+          "bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))] [&>svg]:text-destructive",
+        info: "bg-[color-mix(in_oklch,var(--info)_14%,var(--card))] [&>svg]:text-info",
+        success:
+          "bg-[color-mix(in_oklch,var(--success)_14%,var(--card))] [&>svg]:text-success",
+        warning:
+          "bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] [&>svg]:text-warning",
       },
     },
   },

--- a/apps/renderer/src/components/ui/alert.tsx
+++ b/apps/renderer/src/components/ui/alert.tsx
@@ -16,12 +16,12 @@ const alertVariants = cva(
       variant: {
         default: "bg-card [&>svg]:text-muted-foreground",
         error:
-          "bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))] [&>svg]:text-destructive",
-        info: "bg-[color-mix(in_oklch,var(--info)_22%,var(--card))] [&>svg]:text-info",
+          "bg-alert-error-bg [&>svg]:text-destructive",
+        info: "bg-alert-info-bg [&>svg]:text-info",
         success:
-          "bg-[color-mix(in_oklch,var(--success)_22%,var(--card))] [&>svg]:text-success",
+          "bg-alert-success-bg [&>svg]:text-success",
         warning:
-          "bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] [&>svg]:text-warning",
+          "bg-alert-warning-bg [&>svg]:text-warning",
       },
     },
   },

--- a/apps/renderer/src/components/ui/alert.tsx
+++ b/apps/renderer/src/components/ui/alert.tsx
@@ -16,12 +16,12 @@ const alertVariants = cva(
       variant: {
         default: "bg-card [&>svg]:text-muted-foreground",
         error:
-          "bg-[color-mix(in_oklch,var(--destructive)_14%,var(--card))] [&>svg]:text-destructive",
-        info: "bg-[color-mix(in_oklch,var(--info)_14%,var(--card))] [&>svg]:text-info",
+          "bg-[color-mix(in_oklch,var(--destructive)_22%,var(--card))] [&>svg]:text-destructive",
+        info: "bg-[color-mix(in_oklch,var(--info)_22%,var(--card))] [&>svg]:text-info",
         success:
-          "bg-[color-mix(in_oklch,var(--success)_14%,var(--card))] [&>svg]:text-success",
+          "bg-[color-mix(in_oklch,var(--success)_22%,var(--card))] [&>svg]:text-success",
         warning:
-          "bg-[color-mix(in_oklch,var(--warning)_14%,var(--card))] [&>svg]:text-warning",
+          "bg-[color-mix(in_oklch,var(--warning)_22%,var(--card))] [&>svg]:text-warning",
       },
     },
   },

--- a/apps/renderer/src/components/ui/alert.tsx
+++ b/apps/renderer/src/components/ui/alert.tsx
@@ -2,8 +2,12 @@ import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 import { cn } from "~/lib/utils";
 
+// Minimal alert surface. The card carries a very subtle warm tint via the
+// semantic color (~5% bg, ~15% border) — barely perceptible but enough to
+// differentiate the surface. The icon is the only place the color reads at
+// full strength. No accent bars, no loud washes.
 const alertVariants = cva(
-  "relative grid w-full items-start gap-x-2 gap-y-0.5 rounded-xl border px-3.5 py-3 text-card-foreground text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[calc(var(--spacing)*4)_1fr_auto] has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 [&>svg]:h-lh [&>svg]:w-4",
+  "relative grid w-full items-start gap-x-2 gap-y-0.5 rounded-xl border px-3.5 py-3 text-foreground text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[calc(var(--spacing)*4)_1fr_auto] has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 [&>svg]:h-lh [&>svg]:w-4",
   {
     defaultVariants: {
       variant: "default",
@@ -11,12 +15,12 @@ const alertVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-transparent dark:bg-input/32 [&>svg]:text-muted-foreground",
+          "border-border/20 bg-muted/30 [&>svg]:text-muted-foreground",
         error:
-          "border-destructive/32 bg-destructive/4 [&>svg]:text-destructive",
-        info: "border-info/32 bg-info/4 [&>svg]:text-info",
-        success: "border-success/32 bg-success/4 [&>svg]:text-success",
-        warning: "border-warning/32 bg-warning/4 [&>svg]:text-warning",
+          "border-destructive/15 bg-destructive/5 [&>svg]:text-destructive",
+        info: "border-info/15 bg-info/5 [&>svg]:text-info",
+        success: "border-success/15 bg-success/5 [&>svg]:text-success",
+        warning: "border-warning/15 bg-warning/5 [&>svg]:text-warning",
       },
     },
   },

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import {
   defaultModelFor,
+  resolveModelSlug,
   type ProviderId,
   type RuntimeMode,
 } from "@memoize/wire";
@@ -51,15 +52,22 @@ const loadPersisted = (): Persisted => {
     if (raw === null) return freshDefaults();
     const parsed = JSON.parse(raw) as Partial<Persisted>;
     const seeded = seedModels();
+    // Rewrite dead slugs (e.g. `gpt-5-codex` from older builds) through
+    // `resolveModelSlug` so a stale localStorage doesn't keep sending a
+    // model the current Codex CLI rejects.
     const models: Record<ProviderId, string> = {
-      claude:
+      claude: resolveModelSlug(
+        "claude",
         typeof parsed.defaultModelByProvider?.claude === "string"
           ? parsed.defaultModelByProvider.claude
           : seeded.claude,
-      codex:
+      ),
+      codex: resolveModelSlug(
+        "codex",
         typeof parsed.defaultModelByProvider?.codex === "string"
           ? parsed.defaultModelByProvider.codex
           : seeded.codex,
+      ),
     };
     return {
       defaultProviderId: isProviderId(parsed.defaultProviderId)

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -87,6 +87,15 @@ body,
   --color-bg-overlay: var(--bg-overlay);
   --color-text-faint: var(--text-faint);
 
+  /* Alert surface tints. Distinct from `--destructive` / `--warning` (which
+     are pure saturated tokens for icons/text). These are dedicated card
+     surfaces — soft, warm, darker hues that read as "this card is red" /
+     "this card is amber" without being a loud saturated wash. */
+  --color-alert-error-bg: var(--alert-error-bg);
+  --color-alert-warning-bg: var(--alert-warning-bg);
+  --color-alert-info-bg: var(--alert-info-bg);
+  --color-alert-success-bg: var(--alert-success-bg);
+
   /* Chat + prose tokens. Kept separate from `primary` so the assistant
      prose body and the user bubble can be tuned independently of buttons. */
   --color-user-bubble: var(--user-bubble);
@@ -231,6 +240,13 @@ body,
   --info: oklch(0.62 0.16 245);
   --info-foreground: oklch(0.985 0.003 75);
 
+  /* Light-mode alert surfaces — soft warm tints, light enough to keep dark
+     foreground text legible. */
+  --alert-error-bg: oklch(0.95 0.035 25);
+  --alert-warning-bg: oklch(0.95 0.04 80);
+  --alert-info-bg: oklch(0.95 0.035 240);
+  --alert-success-bg: oklch(0.95 0.04 150);
+
   --border: oklch(0.9 0.006 70);
   --input: oklch(0.9 0.006 70);
   --ring: oklch(0.62 0.012 70);
@@ -301,6 +317,16 @@ body,
 
   --info: oklch(0.7 0.09 245);
   --info-foreground: oklch(0.985 0.003 260);
+
+  /* Dark-mode alert surfaces — soft warm hues, dark enough to be a card
+     background. L≈0.36 keeps it clearly "the card is red/amber" while the
+     reduced chroma (compared to `--destructive` at 0.19) keeps it soft, not
+     loud. Hue shifted slightly warm (25→18 for red, 85→70 for amber) so
+     the surface reads warmer than the icon's saturated stroke. */
+  --alert-error-bg: oklch(0.36 0.07 18);
+  --alert-warning-bg: oklch(0.36 0.06 70);
+  --alert-info-bg: oklch(0.36 0.05 240);
+  --alert-success-bg: oklch(0.36 0.06 150);
 
   --border: oklch(1 0 0 / 0.09);
   --input: oklch(1 0 0 / 0.14);

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -8,6 +8,7 @@ import { Effect, Mailbox, Stream } from "effect";
 
 import {
   AgentSessionStartError,
+  resolveModelSlug,
   type AgentEvent,
   type AgentItemId,
   type AgentSessionId,
@@ -284,7 +285,9 @@ export const startCodexSession = (
         sandboxMode: sandbox.sandboxMode,
         approvalPolicy: sandbox.approvalPolicy,
         skipGitRepoCheck: true,
-        ...(input.model !== undefined ? { model: input.model } : {}),
+        ...(input.model !== undefined
+          ? { model: resolveModelSlug("codex", input.model) }
+          : {}),
         // `input.agents` is deliberately ignored — the Codex SDK has no
         // sub-agents primitive. Cross-provider delegation is sketched in
         // specs/sub-agents/decisions/0012-codex-bridge-via-mcp.md and

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -399,13 +399,32 @@ export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> 
     { id: "claude-haiku-4-5", label: "Haiku 4.5" },
   ],
   codex: [
-    { id: "gpt-5-codex", label: "GPT-5 Codex" },
-    { id: "gpt-5", label: "GPT-5" },
+    { id: "gpt-5.4", label: "GPT-5.4" },
+    { id: "gpt-5.4-mini", label: "GPT-5.4 mini" },
+    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+    { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
   ],
 };
 
 export const defaultModelFor = (providerId: ProviderId): string =>
   MODELS_BY_PROVIDER[providerId][0]!.id;
+
+/**
+ * Aliases for codex model slugs that no longer work — current Codex CLI rejects
+ * `gpt-5-codex` / `gpt-5` when the user is on a ChatGPT account. We rewrite
+ * persisted user settings and incoming requests through this map so existing
+ * sessions don't crash.
+ */
+export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string>> = {
+  claude: {},
+  codex: {
+    "gpt-5-codex": "gpt-5.4",
+    "gpt-5": "gpt-5.4",
+  },
+};
+
+export const resolveModelSlug = (providerId: ProviderId, slug: string): string =>
+  MODEL_ALIASES_BY_PROVIDER[providerId][slug] ?? slug;
 
 /**
  * Per-million-token USD pricing used by the renderer to compute the


### PR DESCRIPTION
## Summary

- **Alert UI refresh** — every alert-shaped surface in the renderer (Alert primitive, ErrorBubble variants, ToolErrorRow, CliUpgradeBanner, FileEditor conflict banner, TerminalBlock/PreBlock error states, ErrorPill) now uses one minimal recipe: hairline `border-{semantic}/15`, `bg-{semantic}/5` wash for subtle warmth, icon in full semantic color, body text muted. No more loud red/yellow/amber boxes.
- **Codex model slug fix** — Codex CLI 0.130+ rejects `gpt-5-codex` (and bare `gpt-5`) for ChatGPT-account users, killing sessions with a 400. Replaced the picker with current names (`gpt-5.4` default, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`) and added `resolveModelSlug` that rewrites the dead slugs to `gpt-5.4` both in `loadPersisted` (auto-migrating stale localStorage) and at the codex driver boundary (so resumed sessions can't punch the bad slug through).

## Test plan

- [ ] Launch the desktop app — confirm an existing user with `gpt-5-codex` in localStorage starts a Codex session successfully (slug auto-migrates to `gpt-5.4`).
- [ ] Force a chat error and a rate-limit-shaped error — verify `ErrorBubble` reads as a subtle warm card with a colored icon, no surrounding red/amber box.
- [ ] Set provider CLI to outdated and modify a file externally while the editor is open — verify `CliUpgradeBanner` and `FileEditor` conflict banner both use the same minimal warning look.
- [ ] Run a tool that fails — verify `ToolErrorRow`, `TerminalBlock`, and `ErrorPill` all read minimal with destructive-colored icons only.
- [ ] Toggle light/dark theme — confirm the `{semantic}/5` washes still read sensibly in both.