### PR TITLE
feat: native menu bar + keyboard shortcuts

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,6 +29,7 @@ if (process.platform === "darwin" && app.isPackaged) {
 }
 
 import { electronServerProtocolLayer } from "./ipc/electron-server-protocol.ts";
+import { installAppMenu } from "./menu.ts";
 import { startAutoUpdater } from "./updater.ts";
 
 /**
@@ -270,6 +271,7 @@ const registerMemoizeProtocol = (): void => {
 
 void app.whenReady().then(() => {
   registerMemoizeProtocol();
+  installAppMenu(() => mainWindow);
   createMainWindow();
   if (!isDevelopment) {
     startAutoUpdater();

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -1,0 +1,179 @@
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  shell,
+  type MenuItemConstructorOptions,
+} from "electron";
+
+/**
+ * Action ids that travel from a menu click → renderer (via
+ * `webContents.send("menu:action", ...)`) → the `useMenuShortcuts` hook.
+ * Mirrored in `apps/renderer/src/lib/bridge.ts` as `MenuAction`.
+ */
+type MenuAction =
+  | "new-chat"
+  | "open-project"
+  | "settings"
+  | "toggle-left-sidebar"
+  | "toggle-right-sidebar"
+  | "toggle-terminal"
+  | "focus-composer";
+
+/**
+ * Install the native Application Menu. The `getWindow` closure is read on
+ * every click so menu items always target the currently-active window
+ * even after a close/re-open cycle (macOS dock-launch).
+ */
+export function installAppMenu(getWindow: () => BrowserWindow | null): void {
+  const isMac = process.platform === "darwin";
+
+  const send = (action: MenuAction) => () => {
+    const win = getWindow();
+    if (win === null) return;
+    win.webContents.send("menu:action", action);
+  };
+
+  const fileMenu: MenuItemConstructorOptions = {
+    label: "File",
+    submenu: [
+      {
+        label: "New Chat",
+        accelerator: "CmdOrCtrl+N",
+        click: send("new-chat"),
+      },
+      {
+        label: "Open Project…",
+        accelerator: "CmdOrCtrl+O",
+        click: send("open-project"),
+      },
+      ...(isMac
+        ? []
+        : ([
+            { type: "separator" },
+            {
+              label: "Settings…",
+              accelerator: "CmdOrCtrl+,",
+              click: send("settings"),
+            },
+            { type: "separator" },
+            { role: "quit" },
+          ] satisfies MenuItemConstructorOptions[])),
+    ],
+  };
+
+  const editMenu: MenuItemConstructorOptions = {
+    label: "Edit",
+    submenu: [
+      { role: "undo" },
+      { role: "redo" },
+      { type: "separator" },
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      ...(isMac
+        ? ([
+            { role: "pasteAndMatchStyle" },
+            { role: "delete" },
+            { role: "selectAll" },
+          ] satisfies MenuItemConstructorOptions[])
+        : ([
+            { role: "delete" },
+            { type: "separator" },
+            { role: "selectAll" },
+          ] satisfies MenuItemConstructorOptions[])),
+    ],
+  };
+
+  const viewMenu: MenuItemConstructorOptions = {
+    label: "View",
+    submenu: [
+      {
+        label: "Toggle Sidebar",
+        accelerator: "CmdOrCtrl+B",
+        click: send("toggle-left-sidebar"),
+      },
+      {
+        label: "Toggle Files Pane",
+        accelerator: "CmdOrCtrl+Alt+B",
+        click: send("toggle-right-sidebar"),
+      },
+      {
+        label: "Toggle Terminal",
+        accelerator: "CmdOrCtrl+J",
+        click: send("toggle-terminal"),
+      },
+      {
+        label: "Focus Composer",
+        accelerator: "CmdOrCtrl+L",
+        click: send("focus-composer"),
+      },
+      { type: "separator" },
+      { role: "reload" },
+      { role: "forceReload" },
+      { role: "toggleDevTools" },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+    ],
+  };
+
+  const windowMenu: MenuItemConstructorOptions = {
+    label: "Window",
+    submenu: isMac
+      ? [
+          { role: "minimize" },
+          { role: "zoom" },
+          { type: "separator" },
+          { role: "front" },
+          { type: "separator" },
+          { role: "close" },
+        ]
+      : [{ role: "minimize" }, { role: "zoom" }, { role: "close" }],
+  };
+
+  const helpMenu: MenuItemConstructorOptions = {
+    role: "help",
+    submenu: [
+      {
+        label: "memoize on GitHub",
+        click: () => {
+          void shell.openExternal("https://github.com/forkzero/memoize");
+        },
+      },
+    ],
+  };
+
+  const template: MenuItemConstructorOptions[] = [
+    ...(isMac
+      ? ([
+          {
+            label: app.name,
+            submenu: [
+              { role: "about" },
+              { type: "separator" },
+              {
+                label: "Settings…",
+                accelerator: "CmdOrCtrl+,",
+                click: send("settings"),
+              },
+              { type: "separator" },
+              { role: "services" },
+              { type: "separator" },
+              { role: "hide" },
+              { role: "hideOthers" },
+              { role: "unhide" },
+              { type: "separator" },
+              { role: "quit" },
+            ],
+          } satisfies MenuItemConstructorOptions,
+        ] satisfies MenuItemConstructorOptions[])
+      : []),
+    fileMenu,
+    editMenu,
+    viewMenu,
+    windowMenu,
+    helpMenu,
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -38,6 +38,16 @@ const bridge = {
       ipcRenderer.send("app:openExternal", url);
     },
   },
+  menu: {
+    onAction: (handler: (action: string) => void) => {
+      const wrapped = (_event: IpcRendererEvent, action: string) =>
+        handler(action);
+      ipcRenderer.on("menu:action", wrapped);
+      return () => {
+        ipcRenderer.off("menu:action", wrapped);
+      };
+    },
+  },
 };
 
 contextBridge.exposeInMainWorld("memoize", bridge);

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -20,6 +20,7 @@ import { ProjectsSidebar } from "./components/projects-sidebar";
 import { RightPane } from "./components/right-pane";
 import { SettingsPage } from "./components/settings-page";
 import { TopBarLeft, TopBarMain, TopBarRight } from "./components/top-bar.tsx";
+import { useMenuShortcuts } from "./hooks/use-menu-shortcuts.ts";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { usePermissionsStore } from "./store/permissions.ts";
 import { useSessionsStore } from "./store/sessions.ts";
@@ -43,6 +44,10 @@ export function App() {
   useEffect(() => {
     startPermissionsStream();
   }, [startPermissionsStream]);
+
+  // Native Application Menu → renderer action dispatcher. Lives on the
+  // root so the bindings work in every view (chat, settings, onboarding).
+  useMenuShortcuts();
 
   // Mirror Electron's fullscreen state into the ui store so the top bars
   // can drop the macOS traffic-light gutter.

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -245,11 +245,15 @@ export function ChatComposer({ session }: { session: Session }) {
       });
       v.focus();
     });
+    bridge.setFocus(() => {
+      editorViewRef.current?.focus();
+    });
 
     return () => {
       const b = useComposerBridge.getState();
       b.setAttachFile(null);
       b.setInsertText(null);
+      b.setFocus(null);
       view.destroy();
       editorViewRef.current = null;
     };

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -30,6 +30,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { cn, formatCompactNumber } from "~/lib/utils";
+import { formatShortcut } from "../lib/shortcuts.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useMessagesStore } from "../store/messages.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
@@ -269,7 +270,12 @@ export function ProjectsSidebar() {
               </button>
             }
           />
-          <TooltipPopup>Add project</TooltipPopup>
+          <TooltipPopup>
+            <TooltipShortcut
+              label="Add project"
+              shortcut={formatShortcut("open-project")}
+            />
+          </TooltipPopup>
         </Tooltip>
       </div>
 
@@ -329,7 +335,12 @@ function SidebarFooter() {
             </button>
           }
         />
-        <TooltipPopup side="top">Open settings</TooltipPopup>
+        <TooltipPopup side="top">
+          <TooltipShortcut
+            label="Open settings"
+            shortcut={formatShortcut("settings")}
+          />
+        </TooltipPopup>
       </Tooltip>
     </div>
   );
@@ -573,47 +584,47 @@ const LOGIN_HINT: Record<ProviderId, string> = {
   codex: "Run `codex login` in your terminal",
 };
 
-function NewSessionButton({ projectId }: { projectId: FolderId }) {
-  const refresh = useProvidersStore((s) => s.refresh);
-  const create = useSessionsStore((s) => s.create);
-  const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
-  const defaultModelByProvider = useSettingsStore(
-    (s) => s.defaultModelByProvider,
-  );
-  const defaultRuntimeMode = useSettingsStore((s) => s.defaultRuntimeMode);
-  const defaultAutoCreateWorktree = useSettingsStore(
-    (s) => s.defaultAutoCreateWorktree,
-  );
-  const refreshRepoSettings = useRepositorySettingsStore((s) => s.refresh);
-  const createWorktree = useWorktreesStore((s) => s.create);
-
-  const onClick = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    // Cheap availability refresh in case the user just logged into a CLI.
-    // We don't gate the session creation on version status here — an
-    // outdated codex is surfaced as an inline banner in the chat view so
-    // the user can still open the session and switch model/provider from
-    // the chat header.
-    await refresh();
-    const model =
-      defaultModelByProvider[defaultProviderId] ??
-      defaultModelFor(defaultProviderId);
-    // Auto-create a worktree before session.create when either the global
-    // default is on or the per-repo override flips it on. Failure is
-    // non-fatal — fall back to main checkout.
-    const repoSettings = await refreshRepoSettings(projectId);
-    const shouldAutoCreate =
-      repoSettings?.autoCreateWorktree === true ||
-      defaultAutoCreateWorktree === true;
-    let worktreeId = null;
-    if (shouldAutoCreate) {
-      const wt = await createWorktree(projectId);
-      if (wt !== null) worktreeId = wt.id;
-    }
-    void create(projectId, defaultProviderId, model, {
-      runtimeMode: defaultRuntimeMode,
+/**
+ * Spawn a new chat session in the given project. Reads default
+ * provider/model/runtime-mode/auto-worktree settings from the stores
+ * directly so this is callable from anywhere (sidebar button + the
+ * Cmd+N menu shortcut) without prop-drilling.
+ */
+export async function createNewSession(projectId: FolderId): Promise<void> {
+  // Cheap availability refresh in case the user just logged into a CLI.
+  // We don't gate the session creation on version status here — an
+  // outdated codex is surfaced as an inline banner in the chat view so
+  // the user can still open the session and switch model/provider from
+  // the chat header.
+  await useProvidersStore.getState().refresh();
+  const settings = useSettingsStore.getState();
+  const defaultProviderId = settings.defaultProviderId;
+  const model =
+    settings.defaultModelByProvider[defaultProviderId] ??
+    defaultModelFor(defaultProviderId);
+  const repoSettings = await useRepositorySettingsStore
+    .getState()
+    .refresh(projectId);
+  const shouldAutoCreate =
+    repoSettings?.autoCreateWorktree === true ||
+    settings.defaultAutoCreateWorktree === true;
+  let worktreeId = null;
+  if (shouldAutoCreate) {
+    const wt = await useWorktreesStore.getState().create(projectId);
+    if (wt !== null) worktreeId = wt.id;
+  }
+  void useSessionsStore
+    .getState()
+    .create(projectId, defaultProviderId, model, {
+      runtimeMode: settings.defaultRuntimeMode,
       worktreeId,
     });
+}
+
+function NewSessionButton({ projectId }: { projectId: FolderId }) {
+  const onClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    void createNewSession(projectId);
   };
 
   return (
@@ -630,8 +641,31 @@ function NewSessionButton({ projectId }: { projectId: FolderId }) {
           </button>
         }
       />
-      <TooltipPopup>New chat</TooltipPopup>
+      <TooltipPopup>
+        <TooltipShortcut label="New chat" shortcut={formatShortcut("new-chat")} />
+      </TooltipPopup>
     </Tooltip>
+  );
+}
+
+/**
+ * Tooltip body with a trailing `<kbd>` shortcut hint. Co-located here
+ * because almost every shortcut-bearing tooltip lives in this file or in
+ * `top-bar.tsx`; exporting keeps the markup consistent across both.
+ */
+export function TooltipShortcut({
+  label,
+  shortcut,
+}: {
+  label: string;
+  shortcut: string;
+}) {
+  if (shortcut === "") return <>{label}</>;
+  return (
+    <span className="inline-flex items-baseline gap-2 whitespace-nowrap">
+      <span>{label}</span>
+      <kbd className="font-sans text-muted-foreground/80">{shortcut}</kbd>
+    </span>
   );
 }
 

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -1,12 +1,13 @@
 import { FolderClosed, GitBranch } from "lucide-react";
-import { useState } from "react";
 
 import type { FolderId } from "@memoize/wire";
 
+import { formatShortcut } from "../lib/shortcuts.ts";
 import { useActiveWorktreeId } from "../store/active-workspace.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
+import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { DiffPane } from "./diff-pane.tsx";
@@ -15,8 +16,6 @@ import { PrPane } from "./pr-pane.tsx";
 import { RightPaneHeader } from "./right-pane-header.tsx";
 import { TerminalPane } from "./terminal-pane.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
-
-type Tab = "files" | "terminal" | "changes" | "pr";
 
 /**
  * Right-pane shell with four tabs: file tree, terminal, changes
@@ -46,7 +45,8 @@ export function RightPane() {
       ? (s.byKey[prDetailsKey(selectedFolderId, worktreeId)] ?? null)
       : null,
   );
-  const [tab, setTab] = useState<Tab>("files");
+  const tab = useUiStore((s) => s.activeRightTab);
+  const setTab = useUiStore((s) => s.setActiveRightTab);
 
   return (
     <aside className="flex h-full min-h-0 w-full flex-col">
@@ -63,6 +63,7 @@ export function RightPane() {
           onClick={() => setTab("terminal")}
           label="Terminal"
           tooltip="Open a terminal in the project root"
+          shortcut={formatShortcut("toggle-terminal")}
         />
         <TabButton
           active={tab === "changes"}
@@ -199,12 +200,14 @@ function TabButton({
   label,
   tooltip,
   badge,
+  shortcut,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
   tooltip: string;
   badge?: React.ReactNode;
+  shortcut?: string;
 }) {
   return (
     <Tooltip>
@@ -224,7 +227,16 @@ function TabButton({
           </button>
         }
       />
-      <TooltipPopup>{tooltip}</TooltipPopup>
+      <TooltipPopup>
+        {shortcut !== undefined && shortcut !== "" ? (
+          <span className="inline-flex items-baseline gap-2 whitespace-nowrap">
+            <span>{tooltip}</span>
+            <kbd className="font-sans text-muted-foreground/80">{shortcut}</kbd>
+          </span>
+        ) : (
+          tooltip
+        )}
+      </TooltipPopup>
     </Tooltip>
   );
 }

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   FolderClosed,
   GitBranch,
+  Keyboard,
   Settings as SettingsIcon,
 } from "lucide-react";
 import { useEffect, useMemo } from "react";
@@ -17,6 +18,7 @@ import {
 } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
+import { formatAccelerator, SHORTCUTS } from "../lib/shortcuts.ts";
 import { DEFAULT_SUBAGENT_PRESETS } from "../lib/subagent-presets.ts";
 import { useSettingsStore } from "../store/settings.ts";
 import { useSubagentsStore } from "../store/subagents.ts";
@@ -64,6 +66,12 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
     label: "Workspace",
     Icon: GitBranch,
     section: { kind: "workspace" },
+  },
+  {
+    id: "shortcuts",
+    label: "Keyboard shortcuts",
+    Icon: Keyboard,
+    section: { kind: "shortcuts" },
   },
 ];
 
@@ -235,6 +243,12 @@ function SectionTitle({
         subtitle: "How new chats relate to your git checkout.",
       };
     }
+    if (section.kind === "shortcuts") {
+      return {
+        title: "Keyboard shortcuts",
+        subtitle: "These also appear under the menu bar.",
+      };
+    }
     const f = folders.find((x) => x.id === section.projectId);
     return {
       title: f?.name ?? "Repository",
@@ -265,7 +279,50 @@ function Pane({ section }: { section: SettingsSection }) {
   if (section.kind === "general") return <GeneralPane />;
   if (section.kind === "models") return <ModelsPane />;
   if (section.kind === "workspace") return <WorkspacePane />;
+  if (section.kind === "shortcuts") return <ShortcutsPane />;
   return <RepositorySettings projectId={section.projectId} />;
+}
+
+/**
+ * Read-only reference list of every shortcut the app installs in the
+ * native menu. Tooltips around the app point at the same `SHORTCUTS`
+ * source of truth so users don't have to come here to discover them —
+ * this page just collects them in one place.
+ */
+function ShortcutsPane() {
+  return (
+    <Section
+      title="All shortcuts"
+      description="Edit shortcuts isn't supported yet — for now these are fixed. Standard editing keys (cut, copy, paste, undo) follow your OS defaults."
+    >
+      <ul className="flex flex-col gap-0.5 rounded-lg border border-border/50 p-1.5">
+        {SHORTCUTS.map((s) => (
+          <li
+            key={s.id}
+            className="flex items-center gap-3 rounded-md px-2.5 py-2 hover:bg-muted/40"
+          >
+            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="truncate text-sm font-medium leading-none text-foreground">
+                {s.label}
+              </span>
+              <span className="truncate text-xs leading-snug text-muted-foreground">
+                {s.description}
+              </span>
+            </span>
+            <Kbd>{formatAccelerator(s.accelerator)}</Kbd>
+          </li>
+        ))}
+      </ul>
+    </Section>
+  );
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="shrink-0 font-sans text-sm text-muted-foreground">
+      {children}
+    </kbd>
+  );
 }
 
 function GeneralPane() {

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -12,12 +12,14 @@ import { useEffect } from "react";
 
 import type { FolderId } from "@memoize/wire";
 
+import { formatShortcut } from "../lib/shortcuts.ts";
 import {
   softInteractive,
   softTone,
   solidInteractive,
   type Tone,
 } from "../lib/tones.ts";
+import { TooltipShortcut } from "./projects-sidebar.tsx";
 import { useActiveWorktreeId } from "../store/active-workspace.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
@@ -66,7 +68,12 @@ export function TopBarLeft() {
             </button>
           }
         />
-        <TooltipPopup>Hide projects panel</TooltipPopup>
+        <TooltipPopup>
+          <TooltipShortcut
+            label="Hide projects panel"
+            shortcut={formatShortcut("toggle-left-sidebar")}
+          />
+        </TooltipPopup>
       </Tooltip>
     </header>
   );
@@ -134,7 +141,12 @@ export function TopBarMain({ folderId }: { folderId: FolderId | null }) {
               </button>
             }
           />
-          <TooltipPopup>Show projects panel</TooltipPopup>
+          <TooltipPopup>
+            <TooltipShortcut
+              label="Show projects panel"
+              shortcut={formatShortcut("toggle-left-sidebar")}
+            />
+          </TooltipPopup>
         </Tooltip>
       ) : null}
       <div className={`flex min-w-0 flex-1 items-center gap-1.5 ${ACTION_CLASS}`}>
@@ -173,7 +185,10 @@ export function TopBarMain({ folderId }: { folderId: FolderId | null }) {
           }
         />
         <TooltipPopup>
-          {rightSidebarOpen ? "Hide files panel" : "Show files panel"}
+          <TooltipShortcut
+            label={rightSidebarOpen ? "Hide files panel" : "Show files panel"}
+            shortcut={formatShortcut("toggle-right-sidebar")}
+          />
         </TooltipPopup>
       </Tooltip>
     </header>

--- a/apps/renderer/src/components/ui/tooltip.tsx
+++ b/apps/renderer/src/components/ui/tooltip.tsx
@@ -54,7 +54,7 @@ export function TooltipPopup({
       >
         <TooltipPrimitive.Popup
           className={cn(
-            "relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) text-balance rounded-md border bg-popover not-dark:bg-clip-padding text-popover-foreground text-xs shadow-md/5 transition-[width,height,scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:duration-0 dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+            "relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) rounded-md border border-white/10 bg-popover/85 backdrop-blur-xl backdrop-saturate-150 not-dark:bg-clip-padding text-popover-foreground text-xs shadow-lg/20 transition-[width,height,scale,opacity] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:duration-0",
             className,
           )}
           data-slot="tooltip-popup"

--- a/apps/renderer/src/hooks/use-menu-shortcuts.ts
+++ b/apps/renderer/src/hooks/use-menu-shortcuts.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+
+import type { MenuAction } from "../lib/bridge";
+import { createNewSession } from "../components/projects-sidebar";
+import { useComposerBridge } from "../store/composer-bridge";
+import { useUiStore } from "../store/ui";
+import { useWorkspaceStore } from "../store/workspace";
+
+/**
+ * Subscribe to native Application Menu clicks emitted by the main process.
+ * Each `MenuAction` dispatches to the relevant store via `.getState()` so
+ * we don't re-bind the listener on every render.
+ */
+export function useMenuShortcuts(): void {
+  useEffect(() => {
+    const menu = window.memoize?.menu;
+    if (menu === undefined) return;
+
+    const handle = (action: MenuAction) => {
+      switch (action) {
+        case "new-chat": {
+          const projectId = useWorkspaceStore.getState().selectedFolderId;
+          if (projectId === null) return;
+          void createNewSession(projectId);
+          return;
+        }
+        case "open-project": {
+          void useWorkspaceStore.getState().add();
+          return;
+        }
+        case "settings": {
+          const ui = useUiStore.getState();
+          ui.setView(ui.view === "settings" ? "chat" : "settings");
+          return;
+        }
+        case "toggle-left-sidebar": {
+          const ui = useUiStore.getState();
+          ui.setLeftSidebarOpen(!ui.leftSidebarOpen);
+          return;
+        }
+        case "toggle-right-sidebar": {
+          const ui = useUiStore.getState();
+          ui.setRightSidebarOpen(!ui.rightSidebarOpen);
+          return;
+        }
+        case "toggle-terminal": {
+          const ui = useUiStore.getState();
+          if (!ui.rightSidebarOpen) ui.setRightSidebarOpen(true);
+          ui.setActiveRightTab(
+            ui.activeRightTab === "terminal" && ui.rightSidebarOpen
+              ? "files"
+              : "terminal",
+          );
+          return;
+        }
+        case "focus-composer": {
+          useComposerBridge.getState().focus?.();
+          return;
+        }
+      }
+    };
+
+    return menu.onAction(handle as (action: string) => void);
+  }, []);
+}

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -20,10 +20,29 @@ export interface AppBridge {
   readonly openExternal: (url: string) => void;
 }
 
+/**
+ * Action ids the main process emits when the user picks an item in the
+ * native Application Menu. The renderer subscribes via `menu.onAction` and
+ * dispatches to the appropriate store — see `use-menu-shortcuts.ts`.
+ */
+export type MenuAction =
+  | "new-chat"
+  | "open-project"
+  | "settings"
+  | "toggle-left-sidebar"
+  | "toggle-right-sidebar"
+  | "toggle-terminal"
+  | "focus-composer";
+
+export interface MenuBridge {
+  readonly onAction: (handler: (action: MenuAction) => void) => () => void;
+}
+
 export interface MemoizeBridge {
   readonly rpc: RpcBridge;
   readonly window?: WindowBridge;
   readonly app?: AppBridge;
+  readonly menu?: MenuBridge;
 }
 
 declare global {

--- a/apps/renderer/src/lib/shortcuts.ts
+++ b/apps/renderer/src/lib/shortcuts.ts
@@ -1,0 +1,110 @@
+import type { MenuAction } from "./bridge";
+
+/**
+ * Canonical list of keyboard shortcuts the app advertises in the menu bar
+ * and the settings page. Each entry is the source of truth for both the
+ * Electron menu (via the matching `MenuAction` id) and the on-screen
+ * surfaces (settings list, tooltips). Keep this in sync with the
+ * `installAppMenu` template in `apps/desktop/src/menu.ts`.
+ */
+export type ShortcutDef = {
+  readonly id: MenuAction;
+  readonly label: string;
+  readonly description: string;
+  /** Electron accelerator string ("CmdOrCtrl+..."). */
+  readonly accelerator: string;
+};
+
+export const SHORTCUTS: ReadonlyArray<ShortcutDef> = [
+  {
+    id: "new-chat",
+    label: "New chat",
+    description: "Start a new session in the selected project",
+    accelerator: "CmdOrCtrl+N",
+  },
+  {
+    id: "open-project",
+    label: "Open project…",
+    description: "Pick a folder to add to the workspace",
+    accelerator: "CmdOrCtrl+O",
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    description: "Open or close the settings page",
+    accelerator: "CmdOrCtrl+,",
+  },
+  {
+    id: "toggle-left-sidebar",
+    label: "Toggle projects panel",
+    description: "Show or hide the left projects sidebar",
+    accelerator: "CmdOrCtrl+B",
+  },
+  {
+    id: "toggle-right-sidebar",
+    label: "Toggle files panel",
+    description: "Show or hide the right files sidebar",
+    accelerator: "CmdOrCtrl+Alt+B",
+  },
+  {
+    id: "toggle-terminal",
+    label: "Toggle terminal",
+    description: "Open the right pane and switch to the terminal tab",
+    accelerator: "CmdOrCtrl+J",
+  },
+  {
+    id: "focus-composer",
+    label: "Focus composer",
+    description: "Move the cursor into the chat input",
+    accelerator: "CmdOrCtrl+L",
+  },
+];
+
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPod|iPad/.test(navigator.userAgent);
+
+/** Render an Electron "CmdOrCtrl+..." accelerator using OS-appropriate keys. */
+export function formatAccelerator(accel: string): string {
+  const tokens = accel.split("+").map(formatToken);
+  // ` ` is THIN SPACE — a hair of breathing room between e.g. "⌘" and
+  // "N" so the glyph doesn't run into the letter. macOS-only because the
+  // non-mac form already has "+" separators.
+  return IS_MAC ? tokens.join(" ") : tokens.join("+");
+}
+
+function formatToken(token: string): string {
+  if (IS_MAC) {
+    switch (token) {
+      case "CmdOrCtrl":
+      case "Cmd":
+      case "Meta":
+        return "⌘";
+      case "Ctrl":
+        return "⌃";
+      case "Alt":
+      case "Option":
+        return "⌥";
+      case "Shift":
+        return "⇧";
+      case ",":
+        return ",";
+      default:
+        return token;
+    }
+  }
+  switch (token) {
+    case "CmdOrCtrl":
+      return "Ctrl";
+    case "Meta":
+      return "Win";
+    default:
+      return token;
+  }
+}
+
+/** Convenience: format the shortcut for a `MenuAction` id. */
+export function formatShortcut(id: MenuAction): string {
+  const def = SHORTCUTS.find((s) => s.id === id);
+  return def ? formatAccelerator(def.accelerator) : "";
+}

--- a/apps/renderer/src/store/composer-bridge.ts
+++ b/apps/renderer/src/store/composer-bridge.ts
@@ -8,17 +8,22 @@ export type AttachableFile = {
 
 type AttachFile = (ref: AttachableFile) => void;
 type InsertText = (text: string) => void;
+type FocusComposer = () => void;
 
 type Bridge = {
   readonly attachFile: AttachFile | null;
   readonly insertText: InsertText | null;
+  readonly focus: FocusComposer | null;
   readonly setAttachFile: (fn: AttachFile | null) => void;
   readonly setInsertText: (fn: InsertText | null) => void;
+  readonly setFocus: (fn: FocusComposer | null) => void;
 };
 
 export const useComposerBridge = create<Bridge>((set) => ({
   attachFile: null,
   insertText: null,
+  focus: null,
   setAttachFile: (fn) => set({ attachFile: fn }),
   setInsertText: (fn) => set({ insertText: fn }),
+  setFocus: (fn) => set({ focus: fn }),
 }));

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -17,6 +17,7 @@ export type SettingsSection =
   | { readonly kind: "general" }
   | { readonly kind: "models" }
   | { readonly kind: "workspace" }
+  | { readonly kind: "shortcuts" }
   | { readonly kind: "repository"; readonly projectId: FolderId };
 
 /**
@@ -25,6 +26,12 @@ export type SettingsSection =
  * replaces (never stacks) the file tab — see specs/0.02-MVP/features/file-viewer.md.
  */
 export type MainTab = "chat" | "file";
+
+/**
+ * Tabs in the right-hand workspace pane. Lifted from `RightPane`'s local
+ * state so the native menu (Cmd+J → Toggle Terminal) can drive it.
+ */
+export type RightTab = "files" | "terminal" | "changes" | "pr";
 
 export type OpenFile = {
   readonly folderId: FolderId;
@@ -52,6 +59,7 @@ type UiState = {
   readonly leftSidebarOpen: boolean;
   readonly rightSidebarOpen: boolean;
   readonly isFullScreen: boolean;
+  readonly activeRightTab: RightTab;
   readonly setActiveMainTab: (tab: MainTab) => void;
   readonly openFileInTab: (file: OpenFile) => void;
   readonly closeFileTab: () => void;
@@ -59,6 +67,7 @@ type UiState = {
   readonly setLeftSidebarOpen: (open: boolean) => void;
   readonly setRightSidebarOpen: (open: boolean) => void;
   readonly setFullScreen: (full: boolean) => void;
+  readonly setActiveRightTab: (tab: RightTab) => void;
 };
 
 export const useUiStore = create<UiState>((set) => ({
@@ -73,6 +82,7 @@ export const useUiStore = create<UiState>((set) => ({
   leftSidebarOpen: true,
   rightSidebarOpen: true,
   isFullScreen: false,
+  activeRightTab: "files",
   setActiveMainTab: (tab) => set({ activeMainTab: tab }),
   openFileInTab: (file) =>
     set({ openFile: file, activeMainTab: "file", fileDirty: false }),
@@ -82,4 +92,5 @@ export const useUiStore = create<UiState>((set) => ({
   setLeftSidebarOpen: (open) => set({ leftSidebarOpen: open }),
   setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
   setFullScreen: (full) => set({ isFullScreen: full }),
+  setActiveRightTab: (tab) => set({ activeRightTab: tab }),
 }));


### PR DESCRIPTION
## Summary
- Adds an Electron Application Menu (File / Edit / View / Window / Help) with shortcuts for new chat (⌘N), open project (⌘O), settings (⌘,), toggle sidebars (⌘B / ⌘⌥B), toggle terminal (⌘J), and focus composer (⌘L).
- Each menu item dispatches to the renderer over a `menu:action` IPC channel, handled by a single `useMenuShortcuts` hook.
- Adds a "Keyboard shortcuts" section in Settings driven from one source of truth (`lib/shortcuts.ts`); existing tooltips on the new-chat / add-project / settings / sidebar-toggle / terminal-tab buttons now include an inline shortcut hint.
- Restyles the tooltip popup as frosted glass (translucent fill + backdrop blur).

## Test plan
- [ ] Menu bar shows File / Edit / View / Window / Help with accelerators rendered alongside each item.
- [ ] ⌘N creates a new session in the selected project (no-op when none selected).
- [ ] ⌘O opens the folder picker and adds the project.
- [ ] ⌘, toggles between chat and the settings page.
- [ ] ⌘B / ⌘⌥B collapse/expand the left and right panels.
- [ ] ⌘J expands the right pane and switches to the Terminal tab; pressing again returns to Files.
- [ ] ⌘L drops the caret into the chat composer.
- [ ] Settings → Keyboard shortcuts lists every binding.
- [ ] Standard Edit shortcuts (⌘C/V/Z) still work inside CodeMirror and other inputs.