### PR TITLE
feat(grok): add xAI Grok provider via ACP (Agent Client Protocol)

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -805,6 +805,7 @@ function PlanModeToggle({
 const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  grok: "Grok",
 };
 
 function ModelPicker({

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -11,6 +11,7 @@ import { useProvidersStore } from "../store/providers.ts";
 const UPGRADE_DOCS_URL: Record<ProviderId, string> = {
   claude: "https://docs.claude.com/en/docs/claude-code/setup",
   codex: "https://github.com/openai/codex#installation",
+  grok: "https://docs.x.ai/build/overview",
 };
 
 /**

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -16,6 +16,7 @@ type Props = {
 const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude",
   codex: "Codex",
+  grok: "Grok",
 };
 
 const lookupModelLabel = (

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -15,16 +15,19 @@ import { StepHeader } from "./shared.tsx";
 const LOGIN_HINT: Record<ProviderId, string> = {
   claude: "claude /login",
   codex: "codex login",
+  grok: "grok",
 };
 
 const INSTALL_HINT: Record<ProviderId, string> = {
   claude: "npm i -g @anthropic-ai/claude-code",
   codex: "npm i -g @openai/codex",
+  grok: "curl -fsSL https://x.ai/cli/install.sh | bash",
 };
 
 const PROVIDER_TAGLINE: Record<ProviderId, string> = {
   claude: "Anthropic · Opus, Sonnet, Haiku",
   codex: "OpenAI · GPT-5 family",
+  grok: "xAI · Grok",
 };
 
 type ProviderState =
@@ -66,7 +69,7 @@ export function ProviderStep() {
   const availability = useProvidersStore((s) => s.availability);
   const loading = useProvidersStore((s) => s.loading);
 
-  const providers: ReadonlyArray<ProviderId> = ["claude", "codex"];
+  const providers: ReadonlyArray<ProviderId> = ["claude", "codex", "grok"];
 
   return (
     <div className="flex flex-col gap-7">
@@ -76,7 +79,7 @@ export function ProviderStep() {
         subtitle="memoize uses your existing CLI credentials — no API keys required."
       />
 
-      <div className="grid grid-cols-2 gap-2.5">
+      <div className="grid grid-cols-3 gap-2.5">
         {providers.map((pid) => (
           <ProviderCard
             key={pid}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -582,6 +582,7 @@ function ProjectActionsMenu({
 const LOGIN_HINT: Record<ProviderId, string> = {
   claude: "Run `claude /login` in your terminal",
   codex: "Run `codex login` in your terminal",
+  grok: "Run `grok` in your terminal to sign in",
 };
 
 /**

--- a/apps/renderer/src/components/provider-icons.tsx
+++ b/apps/renderer/src/components/provider-icons.tsx
@@ -1,4 +1,4 @@
-import { ChatGptIcon, ClaudeIcon } from "@hugeicons/core-free-icons";
+import { ChatGptIcon, ClaudeIcon, GrokIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 
@@ -14,6 +14,7 @@ type ProviderIconProps = Omit<HugeProps, "icon"> & {
 const ICON_BY_PROVIDER = {
   claude: ClaudeIcon,
   codex: ChatGptIcon,
+  grok: GrokIcon,
 } as const satisfies Record<ProviderId, HugeProps["icon"]>;
 
 /**

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -39,6 +39,7 @@ import {
 const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  grok: "Grok",
 };
 
 type RailItemBase = {

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -15,6 +15,7 @@ const DEFAULT_RUNTIME_MODE: RuntimeMode = "approval-required";
 const seedModels = (): Record<ProviderId, string> => ({
   claude: defaultModelFor("claude"),
   codex: defaultModelFor("codex"),
+  grok: defaultModelFor("grok"),
 });
 
 type Persisted = {
@@ -31,7 +32,7 @@ type Persisted = {
 };
 
 const isProviderId = (v: unknown): v is ProviderId =>
-  v === "claude" || v === "codex";
+  v === "claude" || v === "codex" || v === "grok";
 
 const isRuntimeMode = (v: unknown): v is RuntimeMode =>
   v === "approval-required" || v === "auto-accept-edits" || v === "full-access";
@@ -67,6 +68,12 @@ const loadPersisted = (): Persisted => {
         typeof parsed.defaultModelByProvider?.codex === "string"
           ? parsed.defaultModelByProvider.codex
           : seeded.codex,
+      ),
+      grok: resolveModelSlug(
+        "grok",
+        typeof parsed.defaultModelByProvider?.grok === "string"
+          ? parsed.defaultModelByProvider.grok
+          : seeded.grok,
       ),
     };
     return {

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -44,6 +44,16 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     minVersion: { major: 0, minor: 128, patch: 0, raw: "0.128.0" },
     upgradeCommand: "npm i -g @openai/codex@latest",
   },
+  {
+    providerId: "grok",
+    displayName: "Grok",
+    cliBinary: "grok",
+    // No floor yet — xAI ships Grok Build CLI as a single official channel
+    // and hasn't published an SDK we'd need to keep in lock-step with.
+    // Revisit if a future release breaks the streaming-json contract.
+    minVersion: null,
+    upgradeCommand: "curl -fsSL https://x.ai/cli/install.sh | bash",
+  },
 ];
 
 const PROBE_TIMEOUT = Duration.seconds(4);
@@ -189,6 +199,19 @@ const probeCodexLogin: Effect.Effect<boolean, never, FileSystem.FileSystem> =
     return yield* fs.exists(path).pipe(Effect.catchAll(() => Effect.succeed(false)));
   });
 
+// Grok writes both browser-OAuth credentials and `config.toml` under
+// `~/.grok/` on first authenticated launch. The directory's presence is a
+// cheap proxy for "they've completed at least one login"; we don't read it.
+// If the user only sets `GROK_CODE_XAI_API_KEY` and never opens the TUI the
+// dir may not exist — that's fine, the renderer still flips to "ready" via
+// `hasApiKey` once a key is saved in the keychain.
+const probeGrokLogin: Effect.Effect<boolean, never, FileSystem.FileSystem> =
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = join(homedir(), ".grok");
+    return yield* fs.exists(path).pipe(Effect.catchAll(() => Effect.succeed(false)));
+  });
+
 const probeLogin = (
   providerId: ProviderId,
 ): Effect.Effect<boolean, never, FileSystem.FileSystem | CommandExecutor.CommandExecutor> => {
@@ -197,6 +220,8 @@ const probeLogin = (
       return probeClaudeLogin;
     case "codex":
       return probeCodexLogin;
+    case "grok":
+      return probeGrokLogin;
   }
 };
 

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -1,0 +1,629 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import * as readline from "node:readline";
+import { Effect, Mailbox, Stream } from "effect";
+
+import {
+  AgentSessionStartError,
+  type AgentEvent,
+  type AgentItemId,
+  type AgentSessionId,
+  type AttachmentRef,
+  type PermissionMode,
+  type StartSessionInput,
+  type UserQuestionAnswer,
+} from "@memoize/wire";
+
+import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+
+/**
+ * Live-only handle for one Grok conversation. Mirrors Codex/Claude handle
+ * shape so `ProviderService` routes RPCs without caring which provider
+ * backs the session.
+ *
+ * Grok has no embeddable JS SDK; instead we drive it via ACP — the agent
+ * runs as `grok agent stdio`, a JSON-RPC server on stdin/stdout. One
+ * persistent child per session (Claude-style), not one spawn per turn
+ * (Codex-style). The conversation is identified by an ACP-minted
+ * `sessionId` returned from `session/new`; we surface that as a
+ * `SessionCursor { strategy: "grok-session-id" }` so it persists.
+ */
+export interface GrokSessionHandle {
+  readonly events: Stream.Stream<AgentEvent>;
+  readonly send: (
+    text: string,
+    attachments?: ReadonlyArray<AttachmentRef>,
+  ) => Effect.Effect<void>;
+  readonly interrupt: () => Effect.Effect<void>;
+  readonly close: () => Effect.Effect<void>;
+  /**
+   * Cached locally and passed as `_meta.permissionMode` on the next
+   * `session/prompt`. ACP doesn't yet document a live mode-switch method,
+   * so this is best-effort — the server may ignore it. We always emit
+   * `PermissionModeChanged` so the renderer chip stays in sync.
+   */
+  readonly setPermissionMode: (mode: PermissionMode) => Effect.Effect<void>;
+  /**
+   * No ACP `UserQuestion` primitive yet — match Codex/Grok-headless and
+   * stay a no-op so RPC routing remains uniform.
+   */
+  readonly answerQuestion: (
+    itemId: AgentItemId,
+    answers: ReadonlyArray<UserQuestionAnswer>,
+  ) => Effect.Effect<void>;
+}
+
+let itemCounter = 0;
+const nextItemId = (): AgentItemId =>
+  `i_${Date.now()}_${++itemCounter}` as AgentItemId;
+
+/**
+ * Translate one ACP `session/update` payload into zero or more
+ * `AgentEvent`s. The only fully-documented variant is `agent_message_chunk`
+ * with `{ content: { text } }`. The other branches mirror the Codex/Claude
+ * translators by analogy — adjust to the real shapes once captured
+ * (see plan Verification step 1).
+ */
+const translateSessionUpdate = (update: unknown): ReadonlyArray<AgentEvent> => {
+  if (update === null || typeof update !== "object") return [];
+  const u = update as Record<string, unknown>;
+  const kind = typeof u["sessionUpdate"] === "string"
+    ? (u["sessionUpdate"] as string)
+    : null;
+  if (kind === null) return [];
+
+  const asText = (v: unknown): string | null => {
+    if (typeof v === "string") return v;
+    if (v !== null && typeof v === "object" && "text" in v) {
+      const t = (v as { text: unknown }).text;
+      return typeof t === "string" ? t : null;
+    }
+    return null;
+  };
+
+  switch (kind) {
+    case "agent_message_chunk": {
+      const text = asText(u["content"]);
+      if (text === null || text.length === 0) return [];
+      return [
+        {
+          _tag: "AssistantMessage",
+          itemId: nextItemId(),
+          text,
+        },
+      ];
+    }
+    case "agent_thought_chunk":
+    case "agent_reasoning_chunk":
+    case "thinking_chunk": {
+      const text = asText(u["content"]);
+      if (text === null || text.length === 0) return [];
+      return [
+        {
+          _tag: "Thinking",
+          itemId: nextItemId(),
+          text,
+          redacted: false,
+        },
+      ];
+    }
+    case "tool_call":
+    case "tool_use": {
+      const id =
+        typeof u["toolCallId"] === "string"
+          ? ((u["toolCallId"] as string) as AgentItemId)
+          : typeof u["id"] === "string"
+            ? ((u["id"] as string) as AgentItemId)
+            : nextItemId();
+      const tool =
+        typeof u["tool"] === "string"
+          ? (u["tool"] as string)
+          : typeof u["name"] === "string"
+            ? (u["name"] as string)
+            : "tool";
+      const input = u["input"] ?? u["arguments"] ?? null;
+      return [
+        {
+          _tag: "ToolUse",
+          itemId: id,
+          tool,
+          input,
+        },
+      ];
+    }
+    case "tool_result":
+    case "tool_output": {
+      const id =
+        typeof u["toolCallId"] === "string"
+          ? ((u["toolCallId"] as string) as AgentItemId)
+          : typeof u["id"] === "string"
+            ? ((u["id"] as string) as AgentItemId)
+            : nextItemId();
+      const output = u["output"] ?? u["content"] ?? u["result"] ?? null;
+      const isError = u["isError"] === true || u["is_error"] === true;
+      return [
+        {
+          _tag: "ToolResult",
+          itemId: id,
+          output,
+          isError,
+        },
+      ];
+    }
+    case "error":
+    case "agent_error": {
+      // Pull useful detail from multiple possible fields. ACP doesn't
+      // pin the error payload shape, and grok itself sometimes nests the
+      // real reason under `data`/`details`/`error`.
+      const detail =
+        typeof u["message"] === "string" && (u["message"] as string).length > 0
+          ? (u["message"] as string)
+          : typeof u["error"] === "string"
+            ? (u["error"] as string)
+            : typeof u["details"] === "string"
+              ? (u["details"] as string)
+              : typeof u["data"] === "string"
+                ? (u["data"] as string)
+                : null;
+      const message =
+        detail !== null && detail.length > 0
+          ? detail
+          : (() => {
+              try {
+                const serialized = JSON.stringify(u);
+                return serialized === "{}"
+                  ? "Grok agent reported an error with no detail."
+                  : `Grok agent error: ${serialized}`;
+              } catch {
+                return "Grok agent reported an error.";
+              }
+            })();
+      return [{ _tag: "Error", message }];
+    }
+    default:
+      console.warn(`[grok.translate] unknown sessionUpdate=${kind}`);
+      return [];
+  }
+};
+
+interface JsonRpcError {
+  readonly code?: number;
+  readonly message?: string;
+  readonly data?: unknown;
+}
+
+interface JsonRpcMessage {
+  readonly id?: number | string;
+  readonly method?: string;
+  readonly params?: { update?: unknown };
+  readonly result?: unknown;
+  readonly error?: JsonRpcError;
+}
+
+type PendingResolver = {
+  method: string;
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+  timer: NodeJS.Timeout;
+};
+
+const GROK_RPC_TRACE = process.env.MEMOIZE_DEBUG_GROK === "1";
+
+/**
+ * Build a human-readable error from a JSON-RPC error envelope. ACP servers
+ * commonly stash the real failure in `error.data` and leave `error.message`
+ * as a generic "Internal error" — surfacing only `error.message` would
+ * leave the user staring at "Internal error" with no clue what broke
+ * (auth failure, missing model entitlement, network, etc.).
+ *
+ * `stderrTail` is the trailing chunk of grok's stderr captured during this
+ * session; when the JSON-RPC envelope is empty (literally no message/data),
+ * stderr is often the only signal we have about what actually went wrong
+ * — e.g. xAI auth errors print to stderr before the server replies.
+ */
+const formatRpcError = (
+  err: JsonRpcError,
+  stderrTail: string,
+): string => {
+  const parts: string[] = [];
+  if (typeof err.message === "string" && err.message.length > 0) {
+    parts.push(err.message);
+  }
+  if (err.data !== undefined && err.data !== null) {
+    if (typeof err.data === "string") {
+      parts.push(err.data);
+    } else if (typeof err.data === "object") {
+      const d = err.data as Record<string, unknown>;
+      const detail =
+        typeof d["message"] === "string"
+          ? (d["message"] as string)
+          : typeof d["error"] === "string"
+            ? (d["error"] as string)
+            : typeof d["details"] === "string"
+              ? (d["details"] as string)
+              : typeof d["reason"] === "string"
+                ? (d["reason"] as string)
+                : null;
+      if (detail !== null && detail.length > 0) {
+        parts.push(detail);
+      } else {
+        try {
+          const serialized = JSON.stringify(err.data);
+          if (serialized !== "{}" && serialized.length > 0) parts.push(serialized);
+        } catch {
+          // unserialisable — fall through
+        }
+      }
+    }
+  }
+  if (parts.length === 0) {
+    const trimmedStderr = stderrTail.trim();
+    if (trimmedStderr.length > 0) parts.push(trimmedStderr);
+    else parts.push("Grok ACP returned an error with no detail.");
+  }
+  if (typeof err.code === "number") parts.push(`(code ${err.code})`);
+  return parts.join(" — ");
+};
+
+/**
+ * Spin up a Grok conversation backed by a persistent ACP child process.
+ * The handshake (`initialize` → `authenticate` → `session/new`) runs once
+ * synchronously inside `start()`; auth or transport failures surface there
+ * so the orchestrator can fail the session-create RPC cleanly.
+ *
+ * `apiKey` is forwarded as `GROK_CODE_XAI_API_KEY` on the child env. When
+ * null the child reads cached credentials from `~/.grok/` (browser-OAuth
+ * `grok login` flow). `xai.api_key` auth method is preferred when a key
+ * is set; otherwise `cached_token`.
+ */
+export const startGrokSession = (
+  input: StartSessionInput,
+  cwd: string,
+  apiKey: string | null,
+  grokPath: string,
+  sessionId: AgentSessionId,
+  resumeCursor: string | null = null,
+): Effect.Effect<GrokSessionHandle, AgentSessionStartError, AttachmentService> =>
+  Effect.gen(function* () {
+    // Keep AttachmentService in the requirement set so layer wiring stays
+    // uniform with the other drivers; attachments themselves are not yet
+    // wired through ACP's `prompt: [{ type: "image", ... }]` shape.
+    yield* AttachmentService;
+    const events = yield* Mailbox.make<AgentEvent>();
+
+    let currentMode: PermissionMode = input.permissionMode ?? "default";
+    let acpSessionId: string | null = null;
+    let nextRpcId = 1;
+    let closed = false;
+    let inflight: Promise<void> = Promise.resolve();
+    const pending = new Map<number, PendingResolver>();
+    // Trailing window of grok's stderr — used to enrich error reports when
+    // the JSON-RPC envelope itself is opaque ("Internal error" with no data).
+    let stderrTail = "";
+
+    events.unsafeOffer({
+      _tag: "Started",
+      sessionId,
+      providerId: "grok",
+      mode: "sdk",
+    });
+
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(grokPath, ["agent", "stdio"], {
+        cwd,
+        env: {
+          ...process.env,
+          ...(apiKey !== null ? { GROK_CODE_XAI_API_KEY: apiKey } : {}),
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (cause) {
+      yield* events.end;
+      return yield* Effect.fail(
+        new AgentSessionStartError({
+          providerId: "grok",
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+      );
+    }
+
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    const rl = readline.createInterface({ input: child.stdout });
+
+    const writeMessage = (msg: Record<string, unknown>): void => {
+      if (!child.stdin.writable) return;
+      const line = JSON.stringify(msg);
+      if (GROK_RPC_TRACE) process.stderr.write(`[grok.rpc.send] ${line}\n`);
+      child.stdin.write(`${line}\n`);
+    };
+
+    const request = (
+      method: string,
+      params: unknown,
+      timeoutMs = 30_000,
+    ): Promise<unknown> => {
+      const id = nextRpcId++;
+      return new Promise<unknown>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          const trimmedStderr = stderrTail.trim();
+          const detail =
+            trimmedStderr.length > 0 ? ` — stderr: ${trimmedStderr}` : "";
+          reject(
+            new Error(
+              `Grok ACP ${method} timed out after ${timeoutMs}ms${detail}`,
+            ),
+          );
+        }, timeoutMs);
+        pending.set(id, { method, resolve, reject, timer });
+        writeMessage({ jsonrpc: "2.0", id, method, params });
+      });
+    };
+
+    const notify = (method: string, params: unknown): void => {
+      writeMessage({ jsonrpc: "2.0", method, params });
+    };
+
+    rl.on("line", (line: string) => {
+      if (line.trim().length === 0) return;
+      if (GROK_RPC_TRACE) process.stderr.write(`[grok.rpc.recv] ${line}\n`);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // Non-JSON line on stdout (e.g. a tracing log leak). Drop silently
+        // — assistant text rides typed `session/update` notifications.
+        return;
+      }
+      if (parsed === null || typeof parsed !== "object") return;
+      const msg = parsed as JsonRpcMessage;
+
+      // Notifications and server→client requests both carry `method`.
+      if (typeof msg.method === "string") {
+        if (msg.method === "session/update") {
+          const update = msg.params?.update;
+          if (update !== undefined) {
+            for (const ev of translateSessionUpdate(update)) {
+              events.unsafeOffer(ev);
+            }
+          }
+          return;
+        }
+        if (msg.id !== undefined) {
+          // Server→client request. Permission prompts likely land here once
+          // ACP spec is verified; for now log and ignore so the turn either
+          // proceeds or times out grok-side. Wiring to PermissionService is
+          // an open follow-up.
+          console.warn(
+            `[grok.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
+          );
+          return;
+        }
+        // Unknown notification — drop.
+        return;
+      }
+
+      // Response to one of our outbound requests.
+      const id = typeof msg.id === "number" ? msg.id : null;
+      if (id === null) return;
+      const resolver = pending.get(id);
+      if (resolver === undefined) return;
+      pending.delete(id);
+      clearTimeout(resolver.timer);
+      if (msg.error !== undefined) {
+        // Always log the raw error envelope on stderr so the developer can
+        // see what grok actually said (the formatted user-facing message
+        // strips structure for readability). Cheap insurance against
+        // shape-mismatch surprises in the undocumented ACP error format.
+        try {
+          process.stderr.write(
+            `[grok.rpc.error] method=${resolver.method} id=${id} ${JSON.stringify(msg.error)}\n`,
+          );
+        } catch {
+          process.stderr.write(
+            `[grok.rpc.error] method=${resolver.method} id=${id} (unserialisable)\n`,
+          );
+        }
+        const detail = formatRpcError(msg.error, stderrTail);
+        resolver.reject(new Error(`Grok ${resolver.method} failed: ${detail}`));
+      } else {
+        resolver.resolve(msg.result ?? {});
+      }
+    });
+
+    child.stderr.on("data", (chunk: string) => {
+      // Keep a rolling tail so errors can include the actual stderr
+      // context (auth failures, version mismatch, etc.) instead of just
+      // grok's generic JSON-RPC "Internal error".
+      stderrTail = (stderrTail + chunk).slice(-4096);
+      process.stderr.write(`[grok.stderr] ${chunk}`);
+    });
+
+    child.on("error", (err) => {
+      if (closed) return;
+      events.unsafeOffer({ _tag: "Error", message: err.message });
+    });
+
+    child.on("close", (code, signal) => {
+      rl.close();
+      const trimmedStderr = stderrTail.trim();
+      const exitDetail = trimmedStderr.length > 0
+        ? `Grok ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${trimmedStderr}`
+        : `Grok ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;
+      for (const { reject, timer } of pending.values()) {
+        clearTimeout(timer);
+        reject(new Error(exitDetail));
+      }
+      pending.clear();
+      if (!closed) {
+        events.unsafeOffer({ _tag: "Error", message: exitDetail });
+        events.unsafeOffer({ _tag: "Status", status: "idle" });
+      }
+    });
+
+    // === ACP handshake — synchronous, fails the start() RPC on error. ===
+    const handshake = Effect.tryPromise({
+      try: async () => {
+        const init = (await request("initialize", {
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: true, writeTextFile: true },
+            terminal: true,
+          },
+        })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
+
+        const authIds = new Set(
+          (init.authMethods ?? [])
+            .map((m) => (typeof m?.id === "string" ? m.id : null))
+            .filter((id): id is string => id !== null),
+        );
+        const methodId =
+          apiKey !== null && authIds.has("xai.api_key")
+            ? "xai.api_key"
+            : authIds.has("cached_token")
+              ? "cached_token"
+              : null;
+        if (methodId === null) {
+          throw new Error(
+            "Grok ACP offered no usable auth method. Run `grok login`, or set GROK_CODE_XAI_API_KEY.",
+          );
+        }
+        await request("authenticate", {
+          methodId,
+          _meta: { headless: true },
+        });
+
+        const sessionResult = (await request("session/new", {
+          cwd,
+          mcpServers: [],
+        })) as { sessionId?: unknown };
+
+        if (typeof sessionResult.sessionId !== "string") {
+          throw new Error("Grok ACP session/new returned no sessionId.");
+        }
+        return sessionResult.sessionId;
+      },
+      catch: (cause) =>
+        new AgentSessionStartError({
+          providerId: "grok",
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+    });
+
+    acpSessionId = yield* handshake.pipe(
+      Effect.tapError(() =>
+        Effect.sync(() => {
+          child.kill("SIGTERM");
+        }),
+      ),
+    );
+
+    events.unsafeOffer({
+      _tag: "SessionCursor",
+      cursor: acpSessionId,
+      strategy: "grok-session-id",
+    });
+
+    // ACP doesn't (yet) expose `session/load` in the published surface, so a
+    // resumeCursor from a prior process can't actually rejoin the prior
+    // server-side conversation. We persist the new id and move on; the user
+    // sees a fresh agent context. Wire `session/load` once it's documented.
+    if (resumeCursor !== null && resumeCursor !== acpSessionId) {
+      console.warn(
+        `[grok] previous cursor ${resumeCursor} discarded — ACP session/load not wired; using new session ${acpSessionId}`,
+      );
+    }
+
+    const enqueuePrompt = (text: string): void => {
+      const sid = acpSessionId;
+      if (sid === null) return;
+      inflight = inflight
+        .then(async () => {
+          if (closed) return;
+          try {
+            await request(
+              "session/prompt",
+              {
+                sessionId: sid,
+                prompt: [{ type: "text", text }],
+                // Server may ignore unknown keys; pass mode + model as
+                // metadata so a future ACP rev can honour them without a
+                // driver change.
+                _meta: {
+                  permissionMode: currentMode,
+                  ...(input.model !== undefined ? { model: input.model } : {}),
+                },
+              },
+              5 * 60_000,
+            );
+          } catch (cause) {
+            if (!closed) {
+              events.unsafeOffer({
+                _tag: "Error",
+                message: cause instanceof Error ? cause.message : String(cause),
+              });
+            }
+          } finally {
+            if (!closed) {
+              events.unsafeOffer({ _tag: "Status", status: "idle" });
+            }
+          }
+        })
+        .catch(() => undefined);
+    };
+
+    if (input.initialPrompt !== undefined && input.initialPrompt.length > 0) {
+      enqueuePrompt(input.initialPrompt);
+    }
+
+    const handle: GrokSessionHandle = {
+      events: Mailbox.toStream(events),
+      send: (text, attachmentRefs) =>
+        Effect.sync(() => {
+          if (attachmentRefs !== undefined && attachmentRefs.length > 0) {
+            // ACP `prompt: [{ type: "image", ... }]` shape isn't wired yet;
+            // drop with a warn so the text turn still goes through.
+            console.warn(
+              `[grok.attach] dropping ${attachmentRefs.length} attachment(s) — ACP image content shape not wired`,
+            );
+          }
+          enqueuePrompt(text);
+        }),
+      interrupt: () =>
+        Effect.sync(() => {
+          const sid = acpSessionId;
+          if (sid === null) return;
+          // Best-effort cancel. We deliberately do NOT SIGINT the child —
+          // that would kill the persistent agent and end every future send
+          // for this session. If `session/cancel` isn't recognised the
+          // server replies with an error we ignore.
+          notify("session/cancel", { sessionId: sid });
+        }),
+      close: () =>
+        Effect.gen(function* () {
+          closed = true;
+          for (const { reject, timer } of pending.values()) {
+            clearTimeout(timer);
+            reject(new Error("Grok session closed"));
+          }
+          pending.clear();
+          try {
+            child.stdin.end();
+          } catch {
+            // ignore — stdin may already be closed by the child
+          }
+          child.kill("SIGTERM");
+          rl.close();
+          yield* events.end;
+        }),
+      setPermissionMode: (mode) =>
+        Effect.sync(() => {
+          if (mode === currentMode) return;
+          currentMode = mode;
+          events.unsafeOffer({ _tag: "PermissionModeChanged", mode });
+        }),
+      answerQuestion: () => Effect.void,
+    };
+    return handle;
+  });

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -23,6 +23,10 @@ import {
   startCodexSession,
   type CodexSessionHandle,
 } from "../drivers/codex.ts";
+import {
+  startGrokSession,
+  type GrokSessionHandle,
+} from "../drivers/grok.ts";
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
 import { PermissionService } from "../services/permission-service.ts";
@@ -38,7 +42,7 @@ import { WorkspaceService } from "../../workspace/services/workspace-service.ts"
  * own their own scope so `close()` is the canonical teardown — there is no
  * autocleanup tied to the renderer subscription.
  */
-type SessionHandle = ClaudeSessionHandle | CodexSessionHandle;
+type SessionHandle = ClaudeSessionHandle | CodexSessionHandle | GrokSessionHandle;
 type SessionEntry = {
   readonly providerId: ProviderId;
   readonly handle: SessionHandle;
@@ -134,7 +138,32 @@ export const ProviderServiceLive = Layer.effect(
           );
           const sessionId = input.sessionId ?? nextSessionId();
           let handle: SessionHandle;
-          if (input.providerId === "claude") {
+          if (input.providerId === "grok") {
+            // Same story as Claude/Codex: hand the driver the user's
+            // installed `grok` binary (no bundled CLI in our package).
+            // Surface a clean install message rather than letting spawn
+            // fail with ENOENT inside the driver.
+            const grokPath = yield* resolveCliPath("grok").pipe(
+              Effect.provideService(CommandExecutor.CommandExecutor, executor),
+            );
+            if (grokPath === null) {
+              return yield* Effect.fail(
+                new AgentSessionStartError({
+                  providerId: "grok",
+                  reason:
+                    "Grok CLI not found on PATH. Install Grok from https://x.ai/cli and try again.",
+                }),
+              );
+            }
+            handle = yield* startGrokSession(
+              input,
+              cwd,
+              apiKey,
+              grokPath,
+              sessionId,
+              resumeCursor,
+            ).pipe(Effect.provideService(AttachmentService, attachmentService));
+          } else if (input.providerId === "claude") {
             // Point the SDK at the user's installed `claude` binary. We
             // don't ship the SDK's bundled optional native CLI (216 MB per
             // arch) — if `which claude` finds nothing here, the SDK would

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -13,7 +13,7 @@ import {
  * the literal union is the contract — adding a new provider is an additive
  * change here plus a new driver in `apps/server/src/provider/drivers/`.
  */
-export const ProviderId = Schema.Literal("claude", "codex");
+export const ProviderId = Schema.Literal("claude", "codex", "grok");
 export type ProviderId = typeof ProviderId.Type;
 
 /**
@@ -250,7 +250,11 @@ const ErrorEvent = Schema.TaggedStruct("Error", {
  */
 const SessionCursorEvent = Schema.TaggedStruct("SessionCursor", {
   cursor: Schema.String,
-  strategy: Schema.Literal("claude-session-id", "codex-thread-id"),
+  strategy: Schema.Literal(
+    "claude-session-id",
+    "codex-thread-id",
+    "grok-session-id",
+  ),
 });
 
 /**
@@ -404,6 +408,19 @@ export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> 
     { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
     { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
   ],
+  // Seed list — Grok CLI's `-m` flag accepts any model id it knows, so a
+  // custom slug typed by the user still works; this list is just what the
+  // picker shows by default. `grok-build` is the only model free-tier
+  // accounts can run (verified via `grok models`); the rest unlock with a
+  // SuperGrok subscription. Passing a slug the account can't access yields
+  // a clean 403 surfaced through grok's streaming-json `type: "error"`
+  // envelope, so no client-side validation needed.
+  grok: [
+    { id: "grok-build", label: "Grok Build" },
+    { id: "grok-4", label: "Grok 4" },
+    { id: "grok-4-fast", label: "Grok 4 Fast" },
+    { id: "grok-code-fast-1", label: "Grok Code Fast" },
+  ],
 };
 
 export const defaultModelFor = (providerId: ProviderId): string =>
@@ -421,6 +438,7 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string
     "gpt-5-codex": "gpt-5.4",
     "gpt-5": "gpt-5.4",
   },
+  grok: {},
 };
 
 export const resolveModelSlug = (providerId: ProviderId, slug: string): string =>


### PR DESCRIPTION
## Summary
- New `grok` provider end-to-end: wire schema, availability probe (`~/.grok/` login check), and a persistent ACP driver (`grok agent stdio`) that speaks JSON-RPC — `initialize` → `authenticate` (xai.api_key or cached_token) → `session/new`, then `session/prompt` per turn with `session/update` notifications translated into `AgentEvent`s.
- Error surface includes the failing method, JSON-RPC `error.data`, and a stderr tail so failures like *"SuperGrok Heavy subscription required"* land in the toast instead of a bare "Internal error". `MEMOIZE_DEBUG_GROK=1` adds raw frame tracing.
- Renderer wired: `GrokIcon`, install/login hints, `grid-cols-3` onboarding layout, and `Record<ProviderId, …>` maps updated across composer, sidebar, settings, upgrade banner, and main-tabs.

## Test plan
- [ ] `bun run check-types` passes (verified).
- [ ] Onboarding shows the Grok card with install/login hints.
- [ ] New chat with Grok issues the ACP handshake; turn renders `AssistantMessage` rows; `Status: idle` flips composer back at end.
- [ ] Multi-turn reuses the same ACP child (no second `session/new`); interrupt sends `session/cancel` without killing the persistent agent.
- [ ] Provider switch on a fresh chat works without restart.