### PR TITLE
[codex] Add Gemini CLI provider support

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -833,6 +833,7 @@ const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude Code",
   codex: "Codex",
   grok: "Grok",
+  gemini: "Gemini",
 };
 
 function ModelPicker({

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -12,6 +12,7 @@ const UPGRADE_DOCS_URL: Record<ProviderId, string> = {
   claude: "https://docs.claude.com/en/docs/claude-code/setup",
   codex: "https://github.com/openai/codex#installation",
   grok: "https://docs.x.ai/build/overview",
+  gemini: "https://github.com/google-gemini/gemini-cli#installation",
 };
 
 /**

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -28,6 +28,7 @@ const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude",
   codex: "Codex",
   grok: "Grok",
+  gemini: "Gemini",
 };
 
 const lookupModelLabel = (

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -402,7 +402,12 @@ export function ErrorBubble({
             aria-hidden="true"
             className="mt-px size-3.5 shrink-0 text-destructive"
           />
-          <span className="break-words text-muted-foreground">{text}</span>
+          <div className="min-w-0 flex-1">
+            <div className="font-medium text-foreground">Provider error</div>
+            <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
+              {text || "(empty)"}
+            </pre>
+          </div>
           {onDismiss !== undefined && (
             <button
               type="button"

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -1,6 +1,6 @@
 import { AlertCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -21,6 +21,7 @@ import {
 } from "~/lib/icons/material-icons";
 import { cn } from "~/lib/utils";
 
+import { Button } from "./ui/button.tsx";
 import {
   ExitPlanModeRow,
   ThinkingRow,
@@ -351,6 +352,71 @@ const formatResetDetail = (info: RateLimitInfo): string => {
   return "Try again later";
 };
 
+const GEMINI_UPGRADE_COMMAND = "npm i -g @google/gemini-cli@latest";
+
+const isGeminiAcpUpgradeError = (text: string): boolean =>
+  /Gemini CLI.*(?:does not support ACP|--experimental-acp)|Unknown arguments?:.*(?:experimental-acp|experimentalAcp)/is.test(
+    text,
+  );
+
+function GeminiUpgradeCard({
+  onDismiss,
+}: {
+  onDismiss?: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copyCommand = () => {
+    void navigator.clipboard.writeText(GEMINI_UPGRADE_COMMAND).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    });
+  };
+
+  return (
+    <div className="px-4 py-2">
+      <div className="max-w-[34rem] rounded-xl border border-warning/25 bg-alert-warning-bg px-4 py-3 text-xs text-foreground shadow-sm">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg bg-warning/12 text-warning">
+            <HugeiconsIcon
+              icon={AlertCircleIcon}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="size-4"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium text-foreground">
+              Gemini CLI needs an upgrade
+            </div>
+            <p className="mt-1 leading-relaxed text-muted-foreground">
+              Your installed Gemini CLI does not support ACP mode yet, so
+              memoize cannot start Gemini sessions until the CLI is updated.
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <code className="rounded-md border border-border/60 bg-background/60 px-2 py-1 font-mono text-[11px] text-foreground">
+                {GEMINI_UPGRADE_COMMAND}
+              </code>
+              <Button size="xs" variant="outline" onClick={copyCommand}>
+                {copied ? (
+                  <Check className="size-3.5" />
+                ) : (
+                  <Copy className="size-3.5" />
+                )}
+                {copied ? "Copied" : "Copy upgrade command"}
+              </Button>
+              {onDismiss !== undefined && (
+                <Button size="xs" variant="ghost" onClick={onDismiss}>
+                  Dismiss
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ErrorBubble({
   text,
   onDismiss,
@@ -358,6 +424,10 @@ export function ErrorBubble({
   text: string;
   onDismiss?: () => void;
 }) {
+  if (isGeminiAcpUpgradeError(text)) {
+    return <GeminiUpgradeCard onDismiss={onDismiss} />;
+  }
+
   const rateLimit = parseRateLimit(text);
   if (rateLimit !== null) {
     return (

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -16,18 +16,21 @@ const LOGIN_HINT: Record<ProviderId, string> = {
   claude: "claude /login",
   codex: "codex login",
   grok: "grok",
+  gemini: "gemini",
 };
 
 const INSTALL_HINT: Record<ProviderId, string> = {
   claude: "npm i -g @anthropic-ai/claude-code",
   codex: "npm i -g @openai/codex",
   grok: "curl -fsSL https://x.ai/cli/install.sh | bash",
+  gemini: "npm i -g @google/gemini-cli",
 };
 
 const PROVIDER_TAGLINE: Record<ProviderId, string> = {
   claude: "Anthropic · Opus, Sonnet, Haiku",
   codex: "OpenAI · GPT-5 family",
   grok: "xAI · Grok",
+  gemini: "Google · Gemini 3 Pro",
 };
 
 type ProviderState =
@@ -69,7 +72,12 @@ export function ProviderStep() {
   const availability = useProvidersStore((s) => s.availability);
   const loading = useProvidersStore((s) => s.loading);
 
-  const providers: ReadonlyArray<ProviderId> = ["claude", "codex", "grok"];
+  const providers: ReadonlyArray<ProviderId> = [
+    "claude",
+    "codex",
+    "grok",
+    "gemini",
+  ];
 
   return (
     <div className="flex flex-col gap-7">
@@ -79,7 +87,7 @@ export function ProviderStep() {
         subtitle="memoize uses your existing CLI credentials — no API keys required."
       />
 
-      <div className="grid grid-cols-3 gap-2.5">
+      <div className="grid grid-cols-2 gap-2.5">
         {providers.map((pid) => (
           <ProviderCard
             key={pid}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -606,6 +606,7 @@ const LOGIN_HINT: Record<ProviderId, string> = {
   claude: "Run `claude /login` in your terminal",
   codex: "Run `codex login` in your terminal",
   grok: "Run `grok` in your terminal to sign in",
+  gemini: "Run `gemini` in your terminal to sign in",
 };
 
 /**

--- a/apps/renderer/src/components/provider-icons.tsx
+++ b/apps/renderer/src/components/provider-icons.tsx
@@ -1,4 +1,9 @@
-import { ChatGptIcon, ClaudeIcon, GrokIcon } from "@hugeicons/core-free-icons";
+import {
+  ChatGptIcon,
+  ClaudeIcon,
+  GoogleGeminiIcon,
+  GrokIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 
@@ -15,6 +20,7 @@ const ICON_BY_PROVIDER = {
   claude: ClaudeIcon,
   codex: ChatGptIcon,
   grok: GrokIcon,
+  gemini: GoogleGeminiIcon,
 } as const satisfies Record<ProviderId, HugeProps["icon"]>;
 
 /**

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -40,6 +40,7 @@ const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude Code",
   codex: "Codex",
   grok: "Grok",
+  gemini: "Gemini",
 };
 
 type RailItemBase = {

--- a/apps/renderer/src/lib/format-error.ts
+++ b/apps/renderer/src/lib/format-error.ts
@@ -10,6 +10,8 @@ export const formatError = (err: unknown): string => {
   const message = typeof err["message"] === "string" ? err["message"] : null;
   const providerId =
     typeof err["providerId"] === "string" ? err["providerId"] : null;
+  const sessionId =
+    typeof err["sessionId"] === "string" ? err["sessionId"] : null;
 
   if (reason !== null && reason.length > 0) {
     const provider = providerId !== null ? `${providerId}: ` : "";
@@ -17,6 +19,9 @@ export const formatError = (err: unknown): string => {
   }
   if (message !== null && message.length > 0) {
     return tag !== null ? `${tag}: ${message}` : message;
+  }
+  if (sessionId !== null && Object.keys(err).length === 1) {
+    return `Internal session response was routed as an error: ${sessionId}`;
   }
   if (tag !== null) return tag;
 

--- a/apps/renderer/src/lib/format-error.ts
+++ b/apps/renderer/src/lib/format-error.ts
@@ -1,0 +1,28 @@
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export const formatError = (err: unknown): string => {
+  if (err instanceof Error) return err.message;
+  if (!isRecord(err)) return String(err);
+
+  const tag = typeof err["_tag"] === "string" ? err["_tag"] : null;
+  const reason = typeof err["reason"] === "string" ? err["reason"] : null;
+  const message = typeof err["message"] === "string" ? err["message"] : null;
+  const providerId =
+    typeof err["providerId"] === "string" ? err["providerId"] : null;
+
+  if (reason !== null && reason.length > 0) {
+    const provider = providerId !== null ? `${providerId}: ` : "";
+    return tag !== null ? `${tag}: ${provider}${reason}` : `${provider}${reason}`;
+  }
+  if (message !== null && message.length > 0) {
+    return tag !== null ? `${tag}: ${message}` : message;
+  }
+  if (tag !== null) return tag;
+
+  try {
+    return JSON.stringify(err, null, 2);
+  } catch {
+    return String(err);
+  }
+};

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -15,6 +15,7 @@ import type {
 } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { formatError } from "../lib/format-error.ts";
 import { useSessionsStore } from "./sessions.ts";
 import { useWorkspaceStore } from "./workspace.ts";
 
@@ -66,14 +67,6 @@ type ChatsState = {
   readonly remove: (chatId: ChatId) => Promise<void>;
   readonly select: (chatId: ChatId | null) => void;
   readonly toggleShowArchived: (projectId: FolderId) => void;
-};
-
-const formatError = (err: unknown): string => {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "object" && err !== null && "_tag" in err) {
-    return String((err as { _tag: unknown })._tag);
-  }
-  return String(err);
 };
 
 const findChatProject = (

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 
 import type { ComposerInput, Message, SessionId } from "@memoize/wire";
 
+import { formatError } from "../lib/format-error.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { usePrDetailsStore } from "./pr-details.ts";
 import { usePrStateStore } from "./pr-state.ts";
@@ -63,14 +64,6 @@ type MessagesState = {
   /** Silently drop a queue chip — no RPC call. */
   readonly dropFromQueue: (sessionId: SessionId, queueId: string) => void;
   readonly clearError: (sessionId: SessionId) => void;
-};
-
-const formatError = (err: unknown): string => {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "object" && err !== null && "_tag" in err) {
-    return String((err as { _tag: unknown })._tag);
-  }
-  return String(err);
 };
 
 let liveFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;

--- a/apps/renderer/src/store/providers.ts
+++ b/apps/renderer/src/store/providers.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 
 import type { AgentAvailability, ProviderId } from "@memoize/wire";
 
+import { formatError } from "../lib/format-error.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 
 /**
@@ -21,14 +22,6 @@ type ProvidersState = {
     providerId: ProviderId,
     apiKey: string,
   ) => Promise<void>;
-};
-
-const formatError = (err: unknown): string => {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "object" && err !== null && "_tag" in err) {
-    return String((err as { _tag: unknown })._tag);
-  }
-  return String(err);
 };
 
 export const useProvidersStore = create<ProvidersState>((set, get) => ({

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -14,6 +14,7 @@ import type {
 } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { formatError } from "../lib/format-error.ts";
 import {
   buildAgentsForNewSession,
   useSubagentsStore,
@@ -98,14 +99,6 @@ type SessionsState = {
   readonly resume: (sessionId: SessionId) => Promise<boolean>;
   readonly select: (sessionId: SessionId | null) => void;
   readonly toggleShowArchived: (projectId: FolderId) => void;
-};
-
-const formatError = (err: unknown): string => {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "object" && err !== null && "_tag" in err) {
-    return String((err as { _tag: unknown })._tag);
-  }
-  return String(err);
 };
 
 const findSessionProject = (

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -16,6 +16,7 @@ const seedModels = (): Record<ProviderId, string> => ({
   claude: defaultModelFor("claude"),
   codex: defaultModelFor("codex"),
   grok: defaultModelFor("grok"),
+  gemini: defaultModelFor("gemini"),
 });
 
 type Persisted = {
@@ -32,7 +33,7 @@ type Persisted = {
 };
 
 const isProviderId = (v: unknown): v is ProviderId =>
-  v === "claude" || v === "codex" || v === "grok";
+  v === "claude" || v === "codex" || v === "grok" || v === "gemini";
 
 const isRuntimeMode = (v: unknown): v is RuntimeMode =>
   v === "approval-required" || v === "auto-accept-edits" || v === "full-access";
@@ -74,6 +75,12 @@ const loadPersisted = (): Persisted => {
         typeof parsed.defaultModelByProvider?.grok === "string"
           ? parsed.defaultModelByProvider.grok
           : seeded.grok,
+      ),
+      gemini: resolveModelSlug(
+        "gemini",
+        typeof parsed.defaultModelByProvider?.gemini === "string"
+          ? parsed.defaultModelByProvider.gemini
+          : seeded.gemini,
       ),
     };
     return {

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -54,6 +54,16 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     minVersion: null,
     upgradeCommand: "curl -fsSL https://x.ai/cli/install.sh | bash",
   },
+  {
+    providerId: "gemini",
+    displayName: "Gemini",
+    cliBinary: "gemini",
+    // We speak ACP directly via `gemini --experimental-acp`, so there's no
+    // SDK pin to keep in lock-step with. Revisit if Google renames the
+    // flag or breaks the handshake.
+    minVersion: null,
+    upgradeCommand: "npm i -g @google/gemini-cli",
+  },
 ];
 
 const PROBE_TIMEOUT = Duration.seconds(4);
@@ -212,6 +222,19 @@ const probeGrokLogin: Effect.Effect<boolean, never, FileSystem.FileSystem> =
     return yield* fs.exists(path).pipe(Effect.catchAll(() => Effect.succeed(false)));
   });
 
+// Gemini CLI writes its OAuth tokens and settings under `~/.gemini/` after
+// the first interactive sign-in. Same heuristic as Grok — directory presence
+// is a cheap proxy for "they've completed at least one login". If the user
+// only sets `GEMINI_API_KEY` and never runs the CLI interactively, the dir
+// may not exist; the renderer still flips to "ready" via `hasApiKey` once
+// a key is saved in the keychain.
+const probeGeminiLogin: Effect.Effect<boolean, never, FileSystem.FileSystem> =
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = join(homedir(), ".gemini");
+    return yield* fs.exists(path).pipe(Effect.catchAll(() => Effect.succeed(false)));
+  });
+
 const probeLogin = (
   providerId: ProviderId,
 ): Effect.Effect<boolean, never, FileSystem.FileSystem | CommandExecutor.CommandExecutor> => {
@@ -222,6 +245,8 @@ const probeLogin = (
       return probeCodexLogin;
     case "grok":
       return probeGrokLogin;
+    case "gemini":
+      return probeGeminiLogin;
   }
 };
 

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -207,6 +207,22 @@ type PendingResolver = {
 
 const GEMINI_RPC_TRACE = process.env.MEMOIZE_DEBUG_GEMINI === "1";
 
+const formatGeminiDiagnostics = (diagnostics: string): string => {
+  const trimmed = diagnostics.trim();
+  if (trimmed.length === 0) return trimmed;
+  if (
+    /Unknown arguments?:.*(?:experimental-acp|experimentalAcp|acp)/is.test(
+      trimmed,
+    )
+  ) {
+    return [
+      "Installed Gemini CLI does not support ACP mode (`gemini --experimental-acp`).",
+      "Upgrade Gemini CLI with `npm i -g @google/gemini-cli@latest`, then restart memoize.",
+    ].join("\n");
+  }
+  return trimmed;
+};
+
 const formatRpcError = (
   err: JsonRpcError,
   diagnosticTail: string,
@@ -244,12 +260,12 @@ const formatRpcError = (
     }
   }
   if (parts.length === 0) {
-    const trimmedDiagnostics = diagnosticTail.trim();
+    const trimmedDiagnostics = formatGeminiDiagnostics(diagnosticTail);
     if (trimmedDiagnostics.length > 0) parts.push(trimmedDiagnostics);
     else parts.push("Gemini ACP returned an error with no detail.");
   }
   if (typeof err.code === "number") parts.push(`(code ${err.code})`);
-  const trimmedDiagnostics = diagnosticTail.trim();
+  const trimmedDiagnostics = formatGeminiDiagnostics(diagnosticTail);
   if (trimmedDiagnostics.length > 0 && parts.every((p) => p !== trimmedDiagnostics)) {
     parts.push(`Diagnostics:\n${trimmedDiagnostics}`);
   }
@@ -352,7 +368,7 @@ export const startGeminiSession = (
       return new Promise<unknown>((resolve, reject) => {
         const timer = setTimeout(() => {
           pending.delete(id);
-          const diagnostics = diagnosticTail();
+          const diagnostics = formatGeminiDiagnostics(diagnosticTail());
           const detail = diagnostics.length > 0 ? ` — ${diagnostics}` : "";
           reject(
             new Error(
@@ -443,7 +459,7 @@ export const startGeminiSession = (
 
     child.on("close", (code, signal) => {
       rl.close();
-      const diagnostics = diagnosticTail();
+      const diagnostics = formatGeminiDiagnostics(diagnosticTail());
       const exitDetail = diagnostics.length > 0
         ? `Gemini ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${diagnostics}`
         : `Gemini ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -1,0 +1,619 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import * as readline from "node:readline";
+import { Effect, Mailbox, Stream } from "effect";
+
+import {
+  AgentSessionStartError,
+  type AgentEvent,
+  type AgentItemId,
+  type AgentSessionId,
+  type AttachmentRef,
+  type PermissionMode,
+  type StartSessionInput,
+  type UserQuestionAnswer,
+} from "@memoize/wire";
+
+import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+
+/**
+ * Live-only handle for one Gemini conversation. Mirrors the Grok/Codex/Claude
+ * handle shape so `ProviderService` routes RPCs without caring which provider
+ * backs the session.
+ *
+ * Google's `@google/gemini-cli` exposes an ACP server via
+ * `gemini --experimental-acp` — the exact same JSON-RPC protocol Grok uses.
+ * One persistent child per session (Claude-style), not one spawn per turn
+ * (Codex-style). The conversation is identified by an ACP-minted `sessionId`
+ * returned from `session/new`; we surface that as a
+ * `SessionCursor { strategy: "grok-session-id" }` (intentional shared label —
+ * the persistence shape is identical to Grok's; renaming the literal would
+ * be a migration of its own).
+ */
+export interface GeminiSessionHandle {
+  readonly events: Stream.Stream<AgentEvent>;
+  readonly send: (
+    text: string,
+    attachments?: ReadonlyArray<AttachmentRef>,
+  ) => Effect.Effect<void>;
+  readonly interrupt: () => Effect.Effect<void>;
+  readonly close: () => Effect.Effect<void>;
+  /**
+   * Cached locally and passed as `_meta.permissionMode` on the next
+   * `session/prompt`. ACP doesn't yet document a live mode-switch method,
+   * so this is best-effort — the server may ignore it. We always emit
+   * `PermissionModeChanged` so the renderer chip stays in sync.
+   */
+  readonly setPermissionMode: (mode: PermissionMode) => Effect.Effect<void>;
+  /**
+   * No ACP `UserQuestion` primitive yet — match Grok and stay a no-op so
+   * RPC routing remains uniform.
+   */
+  readonly answerQuestion: (
+    itemId: AgentItemId,
+    answers: ReadonlyArray<UserQuestionAnswer>,
+  ) => Effect.Effect<void>;
+}
+
+let itemCounter = 0;
+const nextItemId = (): AgentItemId =>
+  `i_${Date.now()}_${++itemCounter}` as AgentItemId;
+
+/**
+ * Translate one ACP `session/update` payload into zero or more
+ * `AgentEvent`s. Shape assumptions mirror the Grok translator — the ACP
+ * spec leaves a lot underspecified, so the non-`agent_message_chunk`
+ * branches are best-effort and may need tightening once we capture
+ * real Gemini traces.
+ */
+const translateSessionUpdate = (update: unknown): ReadonlyArray<AgentEvent> => {
+  if (update === null || typeof update !== "object") return [];
+  const u = update as Record<string, unknown>;
+  const kind = typeof u["sessionUpdate"] === "string"
+    ? (u["sessionUpdate"] as string)
+    : null;
+  if (kind === null) return [];
+
+  const asText = (v: unknown): string | null => {
+    if (typeof v === "string") return v;
+    if (v !== null && typeof v === "object" && "text" in v) {
+      const t = (v as { text: unknown }).text;
+      return typeof t === "string" ? t : null;
+    }
+    return null;
+  };
+
+  switch (kind) {
+    case "agent_message_chunk": {
+      const text = asText(u["content"]);
+      if (text === null || text.length === 0) return [];
+      return [
+        {
+          _tag: "AssistantMessage",
+          itemId: nextItemId(),
+          text,
+        },
+      ];
+    }
+    case "agent_thought_chunk":
+    case "agent_reasoning_chunk":
+    case "thinking_chunk": {
+      const text = asText(u["content"]);
+      if (text === null || text.length === 0) return [];
+      return [
+        {
+          _tag: "Thinking",
+          itemId: nextItemId(),
+          text,
+          redacted: false,
+        },
+      ];
+    }
+    case "tool_call":
+    case "tool_use": {
+      const id =
+        typeof u["toolCallId"] === "string"
+          ? ((u["toolCallId"] as string) as AgentItemId)
+          : typeof u["id"] === "string"
+            ? ((u["id"] as string) as AgentItemId)
+            : nextItemId();
+      const tool =
+        typeof u["tool"] === "string"
+          ? (u["tool"] as string)
+          : typeof u["name"] === "string"
+            ? (u["name"] as string)
+            : "tool";
+      const input = u["input"] ?? u["arguments"] ?? null;
+      return [
+        {
+          _tag: "ToolUse",
+          itemId: id,
+          tool,
+          input,
+        },
+      ];
+    }
+    case "tool_result":
+    case "tool_output": {
+      const id =
+        typeof u["toolCallId"] === "string"
+          ? ((u["toolCallId"] as string) as AgentItemId)
+          : typeof u["id"] === "string"
+            ? ((u["id"] as string) as AgentItemId)
+            : nextItemId();
+      const output = u["output"] ?? u["content"] ?? u["result"] ?? null;
+      const isError = u["isError"] === true || u["is_error"] === true;
+      return [
+        {
+          _tag: "ToolResult",
+          itemId: id,
+          output,
+          isError,
+        },
+      ];
+    }
+    case "error":
+    case "agent_error": {
+      const detail =
+        typeof u["message"] === "string" && (u["message"] as string).length > 0
+          ? (u["message"] as string)
+          : typeof u["error"] === "string"
+            ? (u["error"] as string)
+            : typeof u["details"] === "string"
+              ? (u["details"] as string)
+              : typeof u["data"] === "string"
+                ? (u["data"] as string)
+                : null;
+      const message =
+        detail !== null && detail.length > 0
+          ? detail
+          : (() => {
+              try {
+                const serialized = JSON.stringify(u);
+                return serialized === "{}"
+                  ? "Gemini agent reported an error with no detail."
+                  : `Gemini agent error: ${serialized}`;
+              } catch {
+                return "Gemini agent reported an error.";
+              }
+            })();
+      return [{ _tag: "Error", message }];
+    }
+    default:
+      console.warn(`[gemini.translate] unknown sessionUpdate=${kind}`);
+      return [];
+  }
+};
+
+interface JsonRpcError {
+  readonly code?: number;
+  readonly message?: string;
+  readonly data?: unknown;
+}
+
+interface JsonRpcMessage {
+  readonly id?: number | string;
+  readonly method?: string;
+  readonly params?: { update?: unknown };
+  readonly result?: unknown;
+  readonly error?: JsonRpcError;
+}
+
+type PendingResolver = {
+  method: string;
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+  timer: NodeJS.Timeout;
+};
+
+const GEMINI_RPC_TRACE = process.env.MEMOIZE_DEBUG_GEMINI === "1";
+
+const formatRpcError = (
+  err: JsonRpcError,
+  diagnosticTail: string,
+  rawEnvelope?: string,
+): string => {
+  const parts: string[] = [];
+  if (typeof err.message === "string" && err.message.length > 0) {
+    parts.push(err.message);
+  }
+  if (err.data !== undefined && err.data !== null) {
+    if (typeof err.data === "string") {
+      parts.push(err.data);
+    } else if (typeof err.data === "object") {
+      const d = err.data as Record<string, unknown>;
+      const detail =
+        typeof d["message"] === "string"
+          ? (d["message"] as string)
+          : typeof d["error"] === "string"
+            ? (d["error"] as string)
+            : typeof d["details"] === "string"
+              ? (d["details"] as string)
+              : typeof d["reason"] === "string"
+                ? (d["reason"] as string)
+                : null;
+      if (detail !== null && detail.length > 0) {
+        parts.push(detail);
+      } else {
+        try {
+          const serialized = JSON.stringify(err.data);
+          if (serialized !== "{}" && serialized.length > 0) parts.push(serialized);
+        } catch {
+          // unserialisable — fall through
+        }
+      }
+    }
+  }
+  if (parts.length === 0) {
+    const trimmedDiagnostics = diagnosticTail.trim();
+    if (trimmedDiagnostics.length > 0) parts.push(trimmedDiagnostics);
+    else parts.push("Gemini ACP returned an error with no detail.");
+  }
+  if (typeof err.code === "number") parts.push(`(code ${err.code})`);
+  const trimmedDiagnostics = diagnosticTail.trim();
+  if (trimmedDiagnostics.length > 0 && parts.every((p) => p !== trimmedDiagnostics)) {
+    parts.push(`Diagnostics:\n${trimmedDiagnostics}`);
+  }
+  if (rawEnvelope !== undefined && rawEnvelope.length > 0) {
+    parts.push(`Raw JSON-RPC error:\n${rawEnvelope}`);
+  }
+  return parts.join(" — ");
+};
+
+/**
+ * Spin up a Gemini conversation backed by a persistent ACP child process.
+ * The handshake (`initialize` → `authenticate` → `session/new`) runs once
+ * synchronously inside `start()`; auth or transport failures surface there
+ * so the orchestrator can fail the session-create RPC cleanly.
+ *
+ * `apiKey` is forwarded as `GEMINI_API_KEY` on the child env. When null,
+ * the CLI falls back to cached OAuth credentials under `~/.gemini/` (run
+ * `gemini` interactively to sign in). We prefer the API-key auth method
+ * when a key is set; otherwise `oauth-personal` / `cached_token`.
+ */
+export const startGeminiSession = (
+  input: StartSessionInput,
+  cwd: string,
+  apiKey: string | null,
+  geminiPath: string,
+  sessionId: AgentSessionId,
+  resumeCursor: string | null = null,
+): Effect.Effect<GeminiSessionHandle, AgentSessionStartError, AttachmentService> =>
+  Effect.gen(function* () {
+    // Keep AttachmentService in the requirement set so layer wiring stays
+    // uniform with the other drivers; attachments themselves are not yet
+    // wired through ACP's `prompt: [{ type: "image", ... }]` shape.
+    yield* AttachmentService;
+    const events = yield* Mailbox.make<AgentEvent>();
+
+    let currentMode: PermissionMode = input.permissionMode ?? "default";
+    let acpSessionId: string | null = null;
+    let nextRpcId = 1;
+    let closed = false;
+    let inflight: Promise<void> = Promise.resolve();
+    const pending = new Map<number, PendingResolver>();
+    let stderrTail = "";
+    let stdoutNoiseTail = "";
+
+    const diagnosticTail = (): string => {
+      const parts: string[] = [];
+      const trimmedStderr = stderrTail.trim();
+      const trimmedStdout = stdoutNoiseTail.trim();
+      if (trimmedStderr.length > 0) parts.push(`stderr:\n${trimmedStderr}`);
+      if (trimmedStdout.length > 0) {
+        parts.push(`non-JSON stdout:\n${trimmedStdout}`);
+      }
+      return parts.join("\n\n");
+    };
+
+    events.unsafeOffer({
+      _tag: "Started",
+      sessionId,
+      providerId: "gemini",
+      mode: "sdk",
+    });
+
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(geminiPath, ["--experimental-acp"], {
+        cwd,
+        env: {
+          ...process.env,
+          ...(apiKey !== null ? { GEMINI_API_KEY: apiKey } : {}),
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (cause) {
+      yield* events.end;
+      return yield* Effect.fail(
+        new AgentSessionStartError({
+          providerId: "gemini",
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+      );
+    }
+
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    const rl = readline.createInterface({ input: child.stdout });
+
+    const writeMessage = (msg: Record<string, unknown>): void => {
+      if (!child.stdin.writable) return;
+      const line = JSON.stringify(msg);
+      if (GEMINI_RPC_TRACE) process.stderr.write(`[gemini.rpc.send] ${line}\n`);
+      child.stdin.write(`${line}\n`);
+    };
+
+    const request = (
+      method: string,
+      params: unknown,
+      timeoutMs = 30_000,
+    ): Promise<unknown> => {
+      const id = nextRpcId++;
+      return new Promise<unknown>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          const diagnostics = diagnosticTail();
+          const detail = diagnostics.length > 0 ? ` — ${diagnostics}` : "";
+          reject(
+            new Error(
+              `Gemini ACP ${method} timed out after ${timeoutMs}ms${detail}`,
+            ),
+          );
+        }, timeoutMs);
+        pending.set(id, { method, resolve, reject, timer });
+        writeMessage({ jsonrpc: "2.0", id, method, params });
+      });
+    };
+
+    const notify = (method: string, params: unknown): void => {
+      writeMessage({ jsonrpc: "2.0", method, params });
+    };
+
+    rl.on("line", (line: string) => {
+      if (line.trim().length === 0) return;
+      if (GEMINI_RPC_TRACE) process.stderr.write(`[gemini.rpc.recv] ${line}\n`);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // Known issue: Gemini CLI sometimes emits plain text to stdout
+        // alongside the JSON-RPC stream (google-gemini/gemini-cli#22647).
+        // Log to stderr so the leak is visible during debugging, but don't
+        // abort — assistant content rides typed `session/update` frames.
+        stdoutNoiseTail = (stdoutNoiseTail + `${line}\n`).slice(-4096);
+        process.stderr.write(`[gemini.stdout.nonjson] ${line}\n`);
+        return;
+      }
+      if (parsed === null || typeof parsed !== "object") return;
+      const msg = parsed as JsonRpcMessage;
+
+      if (typeof msg.method === "string") {
+        if (msg.method === "session/update") {
+          const update = msg.params?.update;
+          if (update !== undefined) {
+            for (const ev of translateSessionUpdate(update)) {
+              events.unsafeOffer(ev);
+            }
+          }
+          return;
+        }
+        if (msg.id !== undefined) {
+          console.warn(
+            `[gemini.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
+          );
+          return;
+        }
+        return;
+      }
+
+      const id = typeof msg.id === "number" ? msg.id : null;
+      if (id === null) return;
+      const resolver = pending.get(id);
+      if (resolver === undefined) return;
+      pending.delete(id);
+      clearTimeout(resolver.timer);
+      if (msg.error !== undefined) {
+        let rawEnvelope = "";
+        try {
+          rawEnvelope = JSON.stringify(msg.error, null, 2);
+          process.stderr.write(
+            `[gemini.rpc.error] method=${resolver.method} id=${id} ${rawEnvelope}\n`,
+          );
+        } catch {
+          process.stderr.write(
+            `[gemini.rpc.error] method=${resolver.method} id=${id} (unserialisable)\n`,
+          );
+        }
+        const detail = formatRpcError(msg.error, diagnosticTail(), rawEnvelope);
+        resolver.reject(new Error(`Gemini ${resolver.method} failed: ${detail}`));
+      } else {
+        resolver.resolve(msg.result ?? {});
+      }
+    });
+
+    child.stderr.on("data", (chunk: string) => {
+      stderrTail = (stderrTail + chunk).slice(-4096);
+      process.stderr.write(`[gemini.stderr] ${chunk}`);
+    });
+
+    child.on("error", (err) => {
+      if (closed) return;
+      events.unsafeOffer({ _tag: "Error", message: err.message });
+    });
+
+    child.on("close", (code, signal) => {
+      rl.close();
+      const diagnostics = diagnosticTail();
+      const exitDetail = diagnostics.length > 0
+        ? `Gemini ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${diagnostics}`
+        : `Gemini ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;
+      for (const { reject, timer } of pending.values()) {
+        clearTimeout(timer);
+        reject(new Error(exitDetail));
+      }
+      pending.clear();
+      if (!closed) {
+        events.unsafeOffer({ _tag: "Error", message: exitDetail });
+        events.unsafeOffer({ _tag: "Status", status: "idle" });
+      }
+    });
+
+    // === ACP handshake — synchronous, fails the start() RPC on error. ===
+    const handshake = Effect.tryPromise({
+      try: async () => {
+        const init = (await request("initialize", {
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: true, writeTextFile: true },
+            terminal: true,
+          },
+        })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
+
+        const authIds = new Set(
+          (init.authMethods ?? [])
+            .map((m) => (typeof m?.id === "string" ? m.id : null))
+            .filter((id): id is string => id !== null),
+        );
+        const methodId =
+          apiKey !== null && authIds.has("gemini-api-key")
+            ? "gemini-api-key"
+            : authIds.has("oauth-personal")
+              ? "oauth-personal"
+              : authIds.has("cached_token")
+                ? "cached_token"
+                : null;
+        if (methodId === null) {
+          throw new Error(
+            "Gemini ACP offered no usable auth method. Run `gemini` to sign in, or save a Gemini API key.",
+          );
+        }
+        await request("authenticate", {
+          methodId,
+          _meta:
+            methodId === "gemini-api-key" && apiKey !== null
+              ? { "api-key": apiKey, headless: true }
+              : { headless: true },
+        });
+
+        const sessionResult = (await request("session/new", {
+          cwd,
+          mcpServers: [],
+        })) as { sessionId?: unknown };
+
+        if (typeof sessionResult.sessionId !== "string") {
+          throw new Error("Gemini ACP session/new returned no sessionId.");
+        }
+        return sessionResult.sessionId;
+      },
+      catch: (cause) =>
+        new AgentSessionStartError({
+          providerId: "gemini",
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+    });
+
+    acpSessionId = yield* handshake.pipe(
+      Effect.tapError(() =>
+        Effect.sync(() => {
+          child.kill("SIGTERM");
+        }),
+      ),
+    );
+
+    events.unsafeOffer({
+      _tag: "SessionCursor",
+      cursor: acpSessionId,
+      strategy: "grok-session-id",
+    });
+
+    if (resumeCursor !== null && resumeCursor !== acpSessionId) {
+      console.warn(
+        `[gemini] previous cursor ${resumeCursor} discarded — ACP session/load not wired; using new session ${acpSessionId}`,
+      );
+    }
+
+    const enqueuePrompt = (text: string): void => {
+      const sid = acpSessionId;
+      if (sid === null) return;
+      inflight = inflight
+        .then(async () => {
+          if (closed) return;
+          try {
+            await request(
+              "session/prompt",
+              {
+                sessionId: sid,
+                prompt: [{ type: "text", text }],
+                _meta: {
+                  permissionMode: currentMode,
+                  ...(input.model !== undefined ? { model: input.model } : {}),
+                },
+              },
+              5 * 60_000,
+            );
+          } catch (cause) {
+            if (!closed) {
+              events.unsafeOffer({
+                _tag: "Error",
+                message: cause instanceof Error ? cause.message : String(cause),
+              });
+            }
+          } finally {
+            if (!closed) {
+              events.unsafeOffer({ _tag: "Status", status: "idle" });
+            }
+          }
+        })
+        .catch(() => undefined);
+    };
+
+    if (input.initialPrompt !== undefined && input.initialPrompt.length > 0) {
+      enqueuePrompt(input.initialPrompt);
+    }
+
+    const handle: GeminiSessionHandle = {
+      events: Mailbox.toStream(events),
+      send: (text, attachmentRefs) =>
+        Effect.sync(() => {
+          if (attachmentRefs !== undefined && attachmentRefs.length > 0) {
+            console.warn(
+              `[gemini.attach] dropping ${attachmentRefs.length} attachment(s) — ACP image content shape not wired`,
+            );
+          }
+          enqueuePrompt(text);
+        }),
+      interrupt: () =>
+        Effect.sync(() => {
+          const sid = acpSessionId;
+          if (sid === null) return;
+          // Best-effort cancel; do NOT SIGINT the child or the persistent
+          // session dies for every subsequent send.
+          notify("session/cancel", { sessionId: sid });
+        }),
+      close: () =>
+        Effect.gen(function* () {
+          closed = true;
+          for (const { reject, timer } of pending.values()) {
+            clearTimeout(timer);
+            reject(new Error("Gemini session closed"));
+          }
+          pending.clear();
+          try {
+            child.stdin.end();
+          } catch {
+            // ignore — stdin may already be closed by the child
+          }
+          child.kill("SIGTERM");
+          rl.close();
+          yield* events.end;
+        }),
+      setPermissionMode: (mode) =>
+        Effect.sync(() => {
+          if (mode === currentMode) return;
+          currentMode = mode;
+          events.unsafeOffer({ _tag: "PermissionModeChanged", mode });
+        }),
+      answerQuestion: () => Effect.void,
+    };
+    return handle;
+  });

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -16,7 +16,12 @@ const SERVICE_NAME = "memoize";
  */
 const accountFor = (providerId: ProviderId): string => `apiKey:${providerId}`;
 
-const KNOWN_PROVIDERS: ReadonlyArray<ProviderId> = ["claude", "codex"];
+const KNOWN_PROVIDERS: ReadonlyArray<ProviderId> = [
+  "claude",
+  "codex",
+  "grok",
+  "gemini",
+];
 
 const isKnownProvider = (id: string): id is ProviderId =>
   (KNOWN_PROVIDERS as ReadonlyArray<string>).includes(id);

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -331,6 +331,35 @@ const titleFromInitial = (prompt: string | undefined): string => {
   return truncated.length > 0 ? truncated : "New chat";
 };
 
+const formatProviderFailure = (cause: unknown): string => {
+  if (cause instanceof Error) return cause.message;
+  if (cause !== null && typeof cause === "object") {
+    const record = cause as Record<string, unknown>;
+    const tag = typeof record["_tag"] === "string" ? record["_tag"] : null;
+    const reason =
+      typeof record["reason"] === "string" ? record["reason"] : null;
+    const providerId =
+      typeof record["providerId"] === "string" ? record["providerId"] : null;
+    const sessionId =
+      typeof record["sessionId"] === "string" ? record["sessionId"] : null;
+    if (reason !== null && reason.length > 0) {
+      const provider = providerId !== null ? `${providerId}: ` : "";
+      return tag !== null ? `${tag}: ${provider}${reason}` : `${provider}${reason}`;
+    }
+    if (sessionId !== null) {
+      return tag !== null
+        ? `${tag}: ${sessionId}`
+        : `No active provider process for session ${sessionId}.`;
+    }
+    try {
+      return JSON.stringify(cause, null, 2);
+    } catch {
+      return String(cause);
+    }
+  }
+  return String(cause);
+};
+
 export const MessageStoreLive = Layer.scoped(
   MessageStore,
   Effect.gen(function* () {
@@ -1361,7 +1390,7 @@ export const MessageStoreLive = Layer.scoped(
       session: Session,
       text: string,
       attachments: ReadonlyArray<AttachmentRef>,
-    ): Effect.Effect<void, SessionNotFoundError> => {
+    ): Effect.Effect<void, SessionStartError> => {
       runtimeModeBySession.set(session.id, session.runtimeMode);
       permissionModeBySession.set(session.id, session.permissionMode);
       const subagents = agentsFor(session.id);
@@ -1392,8 +1421,21 @@ export const MessageStoreLive = Layer.scoped(
               Effect.flatMap(() =>
                 provider.send(session.id, text, attachments),
               ),
-              Effect.mapError(
-                () => new SessionNotFoundError({ sessionId: session.id }),
+              Effect.mapError((err) =>
+                err._tag === "ProviderNotAvailableError"
+                  ? new SessionStartError({
+                      providerId: session.providerId,
+                      reason: err.reason,
+                    })
+                  : err._tag === "AgentSessionStartError"
+                    ? new SessionStartError({
+                        providerId: err.providerId,
+                        reason: err.reason,
+                      })
+                    : new SessionStartError({
+                        providerId: session.providerId,
+                        reason: formatProviderFailure(err),
+                      }),
               ),
             ),
         ),
@@ -1520,15 +1562,46 @@ export const MessageStoreLive = Layer.scoped(
           .send(sessionId, text, cleanAttachments, fileRefs, skillRefs)
           .pipe(
             Effect.matchEffect({
-              onFailure: () => Effect.succeed("retry" as const),
+              onFailure: (err) =>
+                Effect.succeed({
+                  _tag: "retry" as const,
+                  reason: formatProviderFailure(err),
+                }),
               onSuccess: () => Effect.succeed("ok" as const),
             }),
           );
-        if (sendResult === "retry") {
+        if (sendResult !== "ok") {
           console.log(
             `[message-store.sendMessage] provider.send failed; restarting provider session for ${sessionId}`,
           );
-          yield* restartProviderSession(session, text, cleanAttachments);
+          const restartResult = yield* restartProviderSession(
+            session,
+            text,
+            cleanAttachments,
+          ).pipe(
+            Effect.matchEffect({
+              onFailure: (err) =>
+                Effect.succeed({
+                  _tag: "failed" as const,
+                  reason: formatProviderFailure(err),
+                }),
+              onSuccess: () => Effect.succeed({ _tag: "ok" as const }),
+            }),
+          );
+          if (restartResult._tag === "failed") {
+            const message =
+              `Provider restart failed after send could not find an active session.\n\n` +
+              `Initial send failure:\n${sendResult.reason}\n\n` +
+              `Restart failure:\n${restartResult.reason}`;
+            const persistedError = yield* persistMessage(sessionId, {
+              _tag: "error",
+              message,
+            });
+            yield* broadcastMessage(sessionId, persistedError);
+            yield* ndjsonAppend(sessionId, persistedError);
+            yield* setStatus(sessionId, "idle");
+            return;
+          }
         }
         yield* setStatus(sessionId, "running");
       });

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -27,6 +27,10 @@ import {
   startGrokSession,
   type GrokSessionHandle,
 } from "../drivers/grok.ts";
+import {
+  startGeminiSession,
+  type GeminiSessionHandle,
+} from "../drivers/gemini.ts";
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
 import { PermissionService } from "../services/permission-service.ts";
@@ -42,7 +46,11 @@ import { WorkspaceService } from "../../workspace/services/workspace-service.ts"
  * own their own scope so `close()` is the canonical teardown — there is no
  * autocleanup tied to the renderer subscription.
  */
-type SessionHandle = ClaudeSessionHandle | CodexSessionHandle | GrokSessionHandle;
+type SessionHandle =
+  | ClaudeSessionHandle
+  | CodexSessionHandle
+  | GrokSessionHandle
+  | GeminiSessionHandle;
 type SessionEntry = {
   readonly providerId: ProviderId;
   readonly handle: SessionHandle;
@@ -138,7 +146,31 @@ export const ProviderServiceLive = Layer.effect(
           );
           const sessionId = input.sessionId ?? nextSessionId();
           let handle: SessionHandle;
-          if (input.providerId === "grok") {
+          if (input.providerId === "gemini") {
+            // Same story as Grok: hand the driver the user's installed
+            // `gemini` binary. Surface a clean install message rather than
+            // letting spawn fail with ENOENT inside the driver.
+            const geminiPath = yield* resolveCliPath("gemini").pipe(
+              Effect.provideService(CommandExecutor.CommandExecutor, executor),
+            );
+            if (geminiPath === null) {
+              return yield* Effect.fail(
+                new AgentSessionStartError({
+                  providerId: "gemini",
+                  reason:
+                    "Gemini CLI not found on PATH. Install via `npm i -g @google/gemini-cli` and try again.",
+                }),
+              );
+            }
+            handle = yield* startGeminiSession(
+              input,
+              cwd,
+              apiKey,
+              geminiPath,
+              sessionId,
+              resumeCursor,
+            ).pipe(Effect.provideService(AttachmentService, attachmentService));
+          } else if (input.providerId === "grok") {
             // Same story as Claude/Codex: hand the driver the user's
             // installed `grok` binary (no bundled CLI in our package).
             // Surface a clean install message rather than letting spawn

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -13,7 +13,7 @@ import {
  * the literal union is the contract — adding a new provider is an additive
  * change here plus a new driver in `apps/server/src/provider/drivers/`.
  */
-export const ProviderId = Schema.Literal("claude", "codex", "grok");
+export const ProviderId = Schema.Literal("claude", "codex", "grok", "gemini");
 export type ProviderId = typeof ProviderId.Type;
 
 /**
@@ -421,6 +421,14 @@ export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> 
     { id: "grok-4-fast", label: "Grok 4 Fast" },
     { id: "grok-code-fast-1", label: "Grok Code Fast" },
   ],
+  // Gemini CLI accepts any model slug it knows via the ACP `_meta.model`
+  // hint; this list is just what the picker offers by default.
+  gemini: [
+    { id: "gemini-3-pro-preview", label: "Gemini 3 Pro" },
+    { id: "gemini-3-flash-preview", label: "Gemini 3 Flash" },
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  ],
 };
 
 export const defaultModelFor = (providerId: ProviderId): string =>
@@ -439,6 +447,10 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string
     "gpt-5": "gpt-5.4",
   },
   grok: {},
+  gemini: {
+    "gemini-3-pro": "gemini-3-pro-preview",
+    "gemini-3.1-pro-preview": "gemini-3-pro-preview",
+  },
 };
 
 export const resolveModelSlug = (providerId: ProviderId, slug: string): string =>


### PR DESCRIPTION
## Summary
Adds Gemini CLI as a first-class provider through ACP, including availability probing, provider selection, icons, settings defaults, and model options.

The Gemini driver now formats ACP diagnostics clearly, preserves JSON-RPC/stderr detail, handles unsupported CLI versions, and shows a dedicated upgrade card in the chat UI.

Credential readiness now includes Grok and Gemini API keys, and renderer error formatting preserves provider `reason` fields instead of collapsing them to generic tags.

## Validation
- `bun run check-types`
