### PR TITLE
fix(sessions): heal NULL chat_id rows and enforce NOT NULL

### DIFF
--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -11,6 +11,7 @@ import { Migration0008WorktreesAndRepoSettings } from "./migrations/0008_worktre
 import { Migration0009PermissionModeAndToolSearch } from "./migrations/0009_permission_mode_and_tool_search.ts";
 import { Migration0010NestedSessions } from "./migrations/0010_nested_sessions.ts";
 import { Migration0011ChatsTable } from "./migrations/0011_chats_table.ts";
+import { Migration0012ChatIdNotNull } from "./migrations/0012_chat_id_not_null.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -34,5 +35,6 @@ export const MigrationsLive = SqliteMigrator.layer({
       Migration0009PermissionModeAndToolSearch,
     "0010_nested_sessions": Migration0010NestedSessions,
     "0011_chats_table": Migration0011ChatsTable,
+    "0012_chat_id_not_null": Migration0012ChatIdNotNull,
   }),
 });

--- a/apps/server/src/persistence/migrations/0012_chat_id_not_null.ts
+++ b/apps/server/src/persistence/migrations/0012_chat_id_not_null.ts
@@ -1,0 +1,130 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Completes the chat-container backfill 0011 deferred. Two responsibilities:
+ *
+ * 1. Heal `sessions.chat_id` for any row left NULL by 0011. 0011's parent
+ *    walk-up was a single UPDATE, so a chain `A (top) → B → C` only filled
+ *    `B.chat_id` — the subquery saw `C`'s parent (`B`) still NULL at
+ *    statement-evaluation time and produced NULL for `C`. The recursive CTE
+ *    below resolves arbitrarily deep nesting in one statement. Any
+ *    pathological orphan (parent chain never reaches a top-level row) gets a
+ *    fresh chat mirroring its session — same shape 0011 used for the initial
+ *    seed.
+ *
+ * 2. Flip `chat_id` to NOT NULL via a table rebuild (SQLite can't ALTER a
+ *    column constraint in place). Indexes are recreated; FKs from
+ *    `messages.session_id`, `chats.active_session_id`, and
+ *    `sessions.parent_session_id` continue to resolve because the rebuilt
+ *    table is renamed back to `sessions`.
+ *
+ * Dropping `parent_session_id` (also flagged in 0011) is intentionally
+ * deferred — the column is harmless and a separate migration keeps blast
+ * radius small.
+ */
+export const Migration0012ChatIdNotNull = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // Heal: propagate each session's top-level ancestor's chat_id down its
+  // parent chain. Sessions whose ancestor chain reaches a top-level row are
+  // covered here.
+  yield* sql`
+    WITH RECURSIVE ancestor(id, chat_id) AS (
+      SELECT id, chat_id FROM sessions WHERE parent_session_id IS NULL
+      UNION ALL
+      SELECT s.id, a.chat_id
+      FROM sessions s
+      JOIN ancestor a ON s.parent_session_id = a.id
+    )
+    UPDATE sessions
+    SET chat_id = (
+      SELECT chat_id FROM ancestor WHERE ancestor.id = sessions.id
+    )
+    WHERE chat_id IS NULL
+      AND id IN (SELECT id FROM ancestor)
+  `;
+
+  // Orphan heal: anything still NULL is a session whose parent chain never
+  // resolves to a top-level row. Mint a chat per orphan (mirroring 0011's
+  // seed shape) and point the session at it.
+  yield* sql`
+    INSERT INTO chats (
+      id, project_id, worktree_id, title, active_session_id,
+      archived_at, created_at, updated_at
+    )
+    SELECT
+      lower(hex(randomblob(16))),
+      project_id,
+      worktree_id,
+      title,
+      id,
+      archived_at,
+      created_at,
+      updated_at
+    FROM sessions
+    WHERE chat_id IS NULL
+  `;
+
+  yield* sql`
+    UPDATE sessions
+    SET chat_id = (
+      SELECT id FROM chats WHERE chats.active_session_id = sessions.id
+    )
+    WHERE chat_id IS NULL
+  `;
+
+  // Rebuild `sessions` to enforce `chat_id NOT NULL`. SQLite's table-rebuild
+  // idiom: create the replacement, copy rows, drop the original, rename.
+  yield* sql`
+    CREATE TABLE sessions_new (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      provider_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      status TEXT NOT NULL,
+      archived_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      cursor TEXT,
+      resume_strategy TEXT NOT NULL DEFAULT 'none',
+      runtime_mode TEXT NOT NULL DEFAULT 'approval-required',
+      agents_json TEXT,
+      worktree_id TEXT REFERENCES worktrees(id) ON DELETE SET NULL,
+      permission_mode TEXT NOT NULL DEFAULT 'default',
+      tool_search INTEGER NOT NULL DEFAULT 0,
+      parent_session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      forked_from_session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+      forked_from_message_id TEXT
+    )
+  `;
+
+  yield* sql`
+    INSERT INTO sessions_new (
+      id, project_id, title, provider_id, model, status,
+      archived_at, created_at, updated_at,
+      cursor, resume_strategy, runtime_mode, agents_json, worktree_id,
+      permission_mode, tool_search, parent_session_id,
+      chat_id, forked_from_session_id, forked_from_message_id
+    )
+    SELECT
+      id, project_id, title, provider_id, model, status,
+      archived_at, created_at, updated_at,
+      cursor, resume_strategy, runtime_mode, agents_json, worktree_id,
+      permission_mode, tool_search, parent_session_id,
+      chat_id, forked_from_session_id, forked_from_message_id
+    FROM sessions
+  `;
+
+  yield* sql`DROP TABLE sessions`;
+  yield* sql`ALTER TABLE sessions_new RENAME TO sessions`;
+
+  yield* sql`
+    CREATE INDEX idx_sessions_project
+      ON sessions(project_id, archived_at, updated_at DESC)
+  `;
+  yield* sql`CREATE INDEX idx_sessions_parent ON sessions(parent_session_id)`;
+  yield* sql`CREATE INDEX idx_sessions_chat ON sessions(chat_id)`;
+});

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -725,7 +725,25 @@ export const MessageStoreLive = Layer.scoped(
               WHERE project_id = ${projectId} AND archived_at IS NULL
               ORDER BY updated_at DESC
             `.pipe(Effect.orDie);
-        return rows.map(sessionFromRow);
+        // Defensive filter — `chat_id` is NOT NULL since migration 0012, but
+        // any row that somehow slips through with NULL would crash the
+        // Session schema decode and take the entire sidebar / fs / terminal
+        // down with it. Drop and log instead.
+        const usable: SessionRow[] = [];
+        let dropped = 0;
+        for (const row of rows) {
+          if (row.chat_id === null) {
+            dropped += 1;
+            continue;
+          }
+          usable.push(row);
+        }
+        if (dropped > 0) {
+          yield* Effect.logWarning(
+            `[MessageStore] listSessions: dropped ${dropped} row(s) with NULL chat_id (project ${projectId})`,
+          );
+        }
+        return usable.map(sessionFromRow);
       });
 
     /**


### PR DESCRIPTION
## Summary

- Adds migration `0012_chat_id_not_null`: recursive-CTE heal for arbitrary-depth `parent_session_id` chains, per-session chat seed for any orphan whose chain doesn't resolve, then a SQLite table rebuild that flips `sessions.chat_id` to `NOT NULL` and recreates the three indexes (`idx_sessions_project`, `idx_sessions_parent`, `idx_sessions_chat`).
- Belt-and-suspenders filter in `listSessions` drops + warns on any residual `chat_id IS NULL` row so a future regression logs instead of crashing the renderer.

## Why

Migration 0011 left `chat_id` nullable and its single-statement walk-up only resolved one level — a `top → child → grand` chain left the grandchild NULL. The strict `Session` schema (`packages/wire/src/session.ts:103`) then threw `Expected string, actual null` during `listSessions` decode, taking the sidebar, file tree, and terminal down with it.

## Test plan

- [x] `tsc --noEmit` clean on `apps/server`
- [x] End-to-end SQLite smoke (4-level chain + orphan): all rows healed; `PRAGMA table_info` reports `chat_id notnull = 1`; all three indexes restored
- [ ] Restart the app and confirm sidebar / file tree / terminal mount; no `Session (Constructor)` error