### PR TITLE
feat(drivers): unified ACP translator + per-model capabilities + reliable interrupt

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -16,12 +16,14 @@ import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   MODELS_BY_PROVIDER,
+  findModelDescriptor,
   type AgentAvailability,
   type Message,
   type PermissionMode,
   type PermissionRequest,
   type ProviderId,
   type RuntimeMode,
+  type SelectOptionDescriptor,
   type Session,
   type SessionId,
 } from "@memoize/wire";
@@ -86,12 +88,6 @@ const MIN_HEIGHT = 56;
 const MAX_HEIGHT = 240;
 const MAX_ATTACHMENTS_PER_TURN = 20;
 
-type ReasoningLevel = "low" | "medium" | "high";
-const REASONING_LEVELS: ReadonlyArray<ReasoningLevel> = [
-  "low",
-  "medium",
-  "high",
-];
 
 export function ChatComposer({ session }: { session: Session }) {
   const sessionId: SessionId = session.id;
@@ -655,11 +651,18 @@ export function ChatComposer({ session }: { session: Session }) {
                   providerId={session.providerId}
                   currentModel={session.model}
                 />
-                <ReasoningPicker sessionId={sessionId} />
-                <PlanModeToggle
+                <ReasoningPicker
                   sessionId={sessionId}
-                  current={session.permissionMode}
+                  providerId={session.providerId}
+                  model={session.model}
                 />
+                {(findModelDescriptor(session.providerId, session.model)
+                  ?.supportsPlanMode ?? true) && (
+                  <PlanModeToggle
+                    sessionId={sessionId}
+                    current={session.permissionMode}
+                  />
+                )}
               </div>
               <div className="flex items-center gap-2">
                 <RuntimeModeToggle
@@ -878,12 +881,12 @@ function ModelPicker({
     return (Object.keys(MODELS_BY_PROVIDER) as ReadonlyArray<ProviderId>).filter(
       (pid) => {
         if (pid === providerId) return true;
-        // Subscription-gated providers (Grok → SuperGrok Heavy,
-        // Cursor → Cursor Pro) are intentionally unselectable until we
-        // can verify the plan — see SUBSCRIPTION_GATED in provider-card.
-        // Mirror the list here rather than importing it cross-feature;
-        // the set is small and rare.
-        if (pid === "grok" || pid === "cursor") return false;
+        // Cursor still has an unconditional subscription gate (we haven't
+        // wired plan detection from its auth store yet). Grok is no longer
+        // auto-excluded here because a successful `~/.grok/auth.json` login
+        // (with email + tier) now produces a clean authenticated state and
+        // the toggle is allowed.
+        if (pid === "cursor") return false;
         if (providerEnabled[pid] === false) return false;
         const a = availabilityById.get(pid);
         if (a !== undefined && a.status === "error") return false;
@@ -959,45 +962,67 @@ function ModelPicker({
 }
 
 /**
- * Reasoning effort selector. UI-only for now — wire integration is a
- * follow-up (codex driver needs to forward `--reasoning-effort`, claude
- * driver maps to thinking budget). State is per-session and lives in
- * sessionStorage so reloads keep the chosen level visible.
+ * Reasoning effort selector. Visible only when the current model declares
+ * a `reasoning` SelectOptionDescriptor in `MODELS_BY_PROVIDER`. Selection
+ * is per-session and persisted to sessionStorage; the messages store reads
+ * it back at send time and forwards as `modelOptions.reasoning`.
  */
-function ReasoningPicker({ sessionId }: { sessionId: SessionId }) {
+function ReasoningPicker({
+  sessionId,
+  providerId,
+  model,
+}: {
+  sessionId: SessionId;
+  providerId: ProviderId;
+  model: string;
+}) {
+  const descriptor = findModelDescriptor(providerId, model);
+  const reasoningDescriptor = descriptor?.optionDescriptors?.find(
+    (d): d is SelectOptionDescriptor => d.kind === "select" && d.id === "reasoning",
+  );
+  const defaultId = reasoningDescriptor?.defaultId ?? "medium";
+
   const storageKey = `memoize.reasoning.${sessionId}`;
-  const [level, setLevel] = useState<ReasoningLevel>(() => {
-    if (typeof window === "undefined") return "medium";
+  const [level, setLevel] = useState<string>(() => {
+    if (typeof window === "undefined") return defaultId;
     const stored = window.sessionStorage.getItem(storageKey);
-    return stored === "low" || stored === "high" ? stored : "medium";
+    if (stored !== null) return stored;
+    return defaultId;
   });
 
+  if (reasoningDescriptor === undefined) return null;
+
+  const options = reasoningDescriptor.options;
+
   const onChange = (next: string) => {
-    if (next !== "low" && next !== "medium" && next !== "high") return;
+    if (!options.some((o) => o.id === next)) return;
     setLevel(next);
     if (typeof window !== "undefined") {
       window.sessionStorage.setItem(storageKey, next);
     }
   };
 
+  const activeLabel =
+    options.find((o) => o.id === level)?.label ?? level;
+
   return (
     <Menu>
       <MenuTrigger
         className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-foreground hover:bg-muted/60 data-[popup-open]:bg-muted/60"
-        aria-label="Reasoning effort"
-        title="Reasoning effort for the next message"
+        aria-label={reasoningDescriptor.label}
+        title={`${reasoningDescriptor.label} for the next message`}
       >
         <Gauge className="size-3" />
-        <span className="capitalize">{level}</span>
+        <span>{activeLabel}</span>
         <ChevronDown className="size-3 opacity-60" />
       </MenuTrigger>
       <MenuPopup side="top" align="start" className="w-44">
         <MenuGroup>
-          <MenuGroupLabel>Reasoning effort</MenuGroupLabel>
+          <MenuGroupLabel>{reasoningDescriptor.label}</MenuGroupLabel>
           <MenuRadioGroup value={level} onValueChange={onChange}>
-            {REASONING_LEVELS.map((l) => (
-              <MenuRadioItem key={l} value={l}>
-                <span className="capitalize">{l}</span>
+            {options.map((o) => (
+              <MenuRadioItem key={o.id} value={o.id}>
+                {o.label}
               </MenuRadioItem>
             ))}
           </MenuRadioGroup>

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -65,6 +65,7 @@ type ProviderState =
   | { readonly kind: "missing" } // CLI not installed
   | { readonly kind: "outdated"; readonly current: string; readonly required: string; readonly command: string | null } // installed but below SDK floor
   | { readonly kind: "signed-out" } // CLI installed, not logged in, no API key
+  | { readonly kind: "subscription"; readonly plan: string } // logged in but missing required paid plan (e.g. SuperGrok Heavy)
   | { readonly kind: "ready"; readonly via: "cli" | "key" };
 
 function deriveState(
@@ -88,7 +89,23 @@ function deriveState(
       command: a.cliUpgradeCommand ?? null,
     };
   }
-  if (a.cliLoggedIn) return { kind: "ready", via: "cli" };
+
+  // For subscription-gated providers (grok, cursor), the server-side probe
+  // (parseGrokAuthJson etc.) sets authLabel to "Requires SuperGrok Heavy"
+  // (or equivalent) when the JWT tier is insufficient, even if cliLoggedIn
+  // is true. We surface this as a distinct state so onboarding no longer
+  // lies to paying users who already have the plan.
+  if (a.cliLoggedIn) {
+    const subInfo = SUBSCRIPTION_INFO[providerId];
+    const unmet =
+      subInfo !== undefined &&
+      (a.authLabel ?? "").toLowerCase().includes("require");
+    if (unmet) {
+      return { kind: "subscription", plan: subInfo.plan };
+    }
+    return { kind: "ready", via: "cli" };
+  }
+
   if (a.hasApiKey) return { kind: "ready", via: "key" };
   return { kind: "signed-out" };
 }
@@ -179,7 +196,11 @@ function ProviderCard({
       </span>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <StateLine state={state} />
-        {SUBSCRIPTION_INFO[providerId] !== undefined && (
+        {/* Only show the "Subscription" badge when the probe actually
+            detected an unmet plan requirement. Users with a valid tier
+            (authLabel = "SuperGrok Heavy") see a normal "CLI logged in"
+            card without the badge. */}
+        {state.kind === "subscription" && (
           <span className="rounded-full bg-violet-500/[0.12] px-1.5 py-px text-[9px] font-medium uppercase tracking-wide text-violet-300">
             Subscription
           </span>
@@ -195,6 +216,7 @@ function StateDot({ state }: { state: ProviderState }) {
     missing: "bg-rose-400/80",
     outdated: "bg-amber-400",
     "signed-out": "bg-amber-400",
+    subscription: "bg-amber-400",
     ready: "bg-emerald-400",
   };
   return (
@@ -218,13 +240,17 @@ function StateLine({ state }: { state: ProviderState }) {
           ? "Update required"
           : state.kind === "signed-out"
             ? "Sign in required"
-            : state.via === "cli"
-              ? "CLI logged in"
-              : "API key set";
+            : state.kind === "subscription"
+              ? "Subscription required"
+              : state.via === "cli"
+                ? "CLI logged in"
+                : "API key set";
   const tone =
     state.kind === "ready"
       ? "text-emerald-300/90"
-      : state.kind === "signed-out" || state.kind === "outdated"
+      : state.kind === "signed-out" ||
+          state.kind === "outdated" ||
+          state.kind === "subscription"
         ? "text-amber-300/90"
         : state.kind === "missing"
           ? "text-rose-300/90"
@@ -254,9 +280,11 @@ function ProviderStatus({
           : "Ready — using API key"
         : state.kind === "signed-out"
           ? "Sign in to the CLI"
-          : state.kind === "outdated"
-            ? "Update the CLI"
-            : "Install the CLI";
+          : state.kind === "subscription"
+            ? "Subscription required"
+            : state.kind === "outdated"
+              ? "Update the CLI"
+              : "Install the CLI";
 
   const subline =
     state.kind === "loading"
@@ -267,15 +295,23 @@ function ProviderStatus({
           : "Stored in your OS keychain."
         : state.kind === "signed-out"
           ? "Already installed — just run the login command below."
-          : state.kind === "outdated"
-            ? `${PROVIDER_LABEL[providerId]} ${state.current} is too old; memoize needs ${state.required}.`
-            : `${PROVIDER_LABEL[providerId]}'s CLI isn't on your PATH yet.`;
+          : state.kind === "subscription"
+            ? "Your CLI login was detected, but the required paid plan was not confirmed."
+            : state.kind === "outdated"
+              ? `${PROVIDER_LABEL[providerId]} ${state.current} is too old; memoize needs ${state.required}.`
+              : `${PROVIDER_LABEL[providerId]}'s CLI isn't on your PATH yet.`;
 
   const showLoginBlock = state.kind === "signed-out";
   const showInstallBlock = state.kind === "missing";
   const showUpgradeBlock = state.kind === "outdated";
   const apiSummary = state.kind === "ready" && state.via === "key";
-  const subscription = SUBSCRIPTION_INFO[providerId];
+
+  // Only show the violet subscription nag when the probe explicitly told us
+  // the plan requirement is unmet (authLabel contains "Requires"). If the
+  // user has a valid SuperGrok Heavy JWT (tier >= 5), authLabel will be
+  // "SuperGrok Heavy" and we treat them as ready (no nag).
+  const subscriptionInfo = SUBSCRIPTION_INFO[providerId];
+  const showSubscriptionNotice = state.kind === "subscription";
 
   return (
     <div className="flex flex-col gap-3 rounded-2xl bg-white/[0.025] p-4">
@@ -291,11 +327,11 @@ function ProviderStatus({
         <StatusPill state={state} />
       </div>
 
-      {subscription !== undefined && (
+      {showSubscriptionNotice && subscriptionInfo !== undefined && (
         <SubscriptionNotice
           providerId={providerId}
-          plan={subscription.plan}
-          url={subscription.url}
+          plan={subscriptionInfo.plan}
+          url={subscriptionInfo.url}
         />
       )}
 
@@ -412,6 +448,12 @@ function StatusPill({ state }: { state: ProviderState }) {
     },
     "signed-out": {
       label: "Sign in",
+      dot: "bg-amber-400",
+      bg: "bg-amber-400/12",
+      text: "text-amber-300",
+    },
+    subscription: {
+      label: "Subscribe",
       dot: "bg-amber-400",
       bg: "bg-amber-400/12",
       text: "text-amber-300",

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -51,10 +51,11 @@ const LOGIN_HINT: Record<ProviderId, string> = {
 };
 
 /**
- * Provider-specific subscription pages. When a provider gates session
- * driving behind a paid plan (Grok → SuperGrok Heavy), the card renders
- * an inline notice + this button so the user lands on the upgrade flow
- * before they hit a session-runtime 403.
+ * Providers that have a known paid-plan requirement for full agent usage.
+ * For Grok we now decode the `tier` claim from `~/.grok/auth.json` JWT:
+ *   - tier >= 5 → authLabel = "SuperGrok Heavy" (positive, shows plan, toggle works)
+ *   - lower / unknown → authLabel = "Requires SuperGrok Heavy" → violet nag + disabled
+ * The frontend only forces the subscription alarm/disable when the label contains "Requires".
  */
 const SUBSCRIPTION_INFO: Partial<
   Record<ProviderId, { readonly plan: string; readonly url: string }>
@@ -76,32 +77,37 @@ export function ProviderCard({
   const subscription = SUBSCRIPTION_INFO[providerId];
   const persistedEnabled =
     useSettingsStore((s) => s.providerEnabled[providerId]) ?? true;
-  // Subscription-gated providers (Grok → SuperGrok Heavy) can never be
-  // "enabled" until the user confirms the upgrade — until we have a way
-  // to actually verify the plan from the CLI, we force the toggle off so
-  // sessions can't be launched into a doomed 403. The visible state lies
-  // to the user with intent: the underlying persisted value is whatever
-  // they set, but the rendering + composer filter treat it as off.
-  const enabled = subscription !== undefined ? false : persistedEnabled;
+
+  // For providers that have a known subscription gate (grok, cursor), we only
+  // force-disable + show the violet alarm *when the server probe explicitly
+  // tells us the requirement is unmet* (i.e. authLabel contains "Requires").
+  // Once the user has a real login (auth.json with email/tier), the probe
+  // returns clean "authenticated + authEmail" and we treat the card normally.
+  // This removes the permanent "you still need to subscribe" lie for paying
+  // Grok users while still protecting people on free tiers from silent 403s.
+  const unmetSubscriptionRequirement =
+    subscription !== undefined &&
+    availability?.authLabel?.toLowerCase().includes("require") === true;
+
+  const enabled = unmetSubscriptionRequirement ? false : persistedEnabled;
   const setProviderEnabled = useSettingsStore((s) => s.setProviderEnabled);
   const baseSummary = useMemo(
     () => getProviderSummary(availability, enabled, loading),
     [availability, enabled, loading],
   );
-  // Promote the card to the violet "subscription" status when this provider
-  // is plan-gated, regardless of whether the CLI itself reports
-  // authenticated. The headline reads "Subscription required" so the dot
-  // color isn't doing all the work.
-  const summary =
-    subscription !== undefined
-      ? {
-          ...baseSummary,
-          statusKey: "subscription" as const,
-          headline: `Requires ${subscription.plan}`,
-          detail: null,
-          authEmail: null,
-        }
-      : baseSummary;
+  // Only force the violet "subscription" status + "Requires ..." headline
+  // when the backend probe says the plan requirement is still unmet.
+  // For a user with a valid Grok login the card will now show the normal
+  // emerald "Authenticated as <email>" (or "Authenticated") state.
+  const summary = unmetSubscriptionRequirement
+    ? {
+        ...baseSummary,
+        statusKey: "subscription" as const,
+        headline: `Requires ${subscription!.plan}`,
+        detail: null,
+        authEmail: null,
+      }
+    : baseSummary;
   const styles = PROVIDER_STATUS_STYLES[summary.statusKey];
   const versionLabel = formatVersionLabel(availability?.cliVersion);
   const showUpgrade =
@@ -111,7 +117,7 @@ export function ProviderCard({
     <div
       className={cn(
         "flex flex-col overflow-hidden rounded-lg border border-border/50 bg-card transition-colors",
-        !enabled && subscription === undefined && "opacity-70",
+        !enabled && !unmetSubscriptionRequirement && "opacity-70",
       )}
     >
       <button
@@ -149,20 +155,20 @@ export function ProviderCard({
         </div>
         <Switch
           checked={enabled}
-          disabled={subscription !== undefined}
+          disabled={unmetSubscriptionRequirement}
           onClick={(e) => e.stopPropagation()}
           onCheckedChange={(value) => {
-            if (subscription !== undefined) return;
+            if (unmetSubscriptionRequirement) return;
             setProviderEnabled(providerId, value);
           }}
           aria-label={
-            subscription !== undefined
-              ? `${PROVIDER_LABEL[providerId]} requires a ${subscription.plan} subscription`
+            unmetSubscriptionRequirement
+              ? `${PROVIDER_LABEL[providerId]} requires a ${subscription!.plan} subscription`
               : `Enable ${PROVIDER_LABEL[providerId]}`
           }
           title={
-            subscription !== undefined
-              ? `Requires ${subscription.plan} subscription`
+            unmetSubscriptionRequirement
+              ? `Requires ${subscription!.plan} subscription`
               : undefined
           }
         />
@@ -197,7 +203,10 @@ export function ProviderCard({
             availability.authStatus === "unauthenticated" && (
               <CodeRow label="Sign in" command={LOGIN_HINT[providerId]} />
             )}
-          <SubscriptionRow providerId={providerId} />
+          <SubscriptionRow
+            providerId={providerId}
+            availability={availability}
+          />
 
           <ModelDefault providerId={providerId} />
 
@@ -250,12 +259,6 @@ function ModelDefault({ providerId }: { providerId: ProviderId }) {
 }
 
 /**
- * Subscription-gate notice for providers that need a paid plan beyond the
- * CLI's local OAuth (Grok → SuperGrok Heavy). The card shows this whenever
- * `SUBSCRIPTION_INFO[providerId]` is set; clicking the button opens the
- * provider's subscribe page in the user's default browser.
- */
-/**
  * Open a URL in the user's OS browser via the preload bridge (Electron's
  * `shell.openExternal`). Falls back to `window.open` for web/dev contexts.
  * We intentionally avoid an in-app webview here: a paid-checkout flow
@@ -270,9 +273,31 @@ const openExternal = (url: string) => {
   window.open(url, "_blank", "noopener,noreferrer");
 };
 
-function SubscriptionRow({ providerId }: { providerId: ProviderId }) {
+/**
+ * Subscription / plan notice for providers that gate behind a paid tier
+ * (Grok → SuperGrok Heavy, Cursor → Cursor Pro).
+ *
+ * - If the server probe reports an unmet requirement (authLabel contains
+ *   "Requires"), we show the strong violet alarm box + Subscribe CTA.
+ * - If the user has a successful login (clean authenticated + email from
+ *   auth.json), we render nothing — the card already shows "Authenticated
+ *   as <email>" and the toggle works. The plan gate is still real and will
+ *   be reported by the ACP at runtime with a helpful error.
+ */
+function SubscriptionRow({
+  providerId,
+  availability,
+}: {
+  providerId: ProviderId;
+  availability?: AgentAvailability;
+}) {
   const info = SUBSCRIPTION_INFO[providerId];
   if (info === undefined) return null;
+
+  const unmet =
+    availability?.authLabel?.toLowerCase().includes("require") === true;
+  if (!unmet) return null;
+
   return (
     <div className="flex flex-col gap-1.5 rounded-md border border-violet-400/25 bg-violet-500/[0.06] px-3 py-2.5">
       <span className="text-[11px] font-medium text-violet-300">

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -481,14 +481,13 @@ function ProvidersPane() {
         <OptionGroup columns={3}>
           {providers
             .filter((pid) => {
-              // Hide providers the user has toggled off, and the
-              // subscription-gated ones (Grok → SuperGrok Heavy, Cursor →
-              // Cursor Pro) — they can't be launched until we can verify
-              // the plan, so picking them as "default" would just route
-              // the user into a doomed 403 on the next new chat. Mirrors
-              // the composer's provider-picker filter.
+              // Hide providers the user has toggled off. Cursor is still
+              // excluded because it has an unconditional subscription gate.
+              // Grok is allowed once the user has a real login (the probe
+              // now surfaces email from auth.json and does not force a
+              // "Requires..." label).
               if (providerEnabled[pid] === false) return false;
-              if (pid === "grok" || pid === "cursor") return false;
+              if (pid === "cursor") return false;
               return true;
             })
             .map((pid) => (

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -4,6 +4,7 @@ import {
   CheckListIcon,
   Copy01Icon,
   File01Icon,
+  Folder01Icon,
   GlobeIcon,
   PencilEdit01Icon,
   Robot01Icon,
@@ -48,14 +49,20 @@ export const iconForTool = (tool: string): IconHandle => {
     case "Bash":
       return TerminalIcon;
     case "Read":
+    case "ReadFile":
       return File01Icon;
     case "Edit":
     case "Write":
+    case "WriteFile":
     case "MultiEdit":
       return PencilEdit01Icon;
     case "Grep":
     case "Glob":
+    case "Search":
       return SearchIcon;
+    case "ListDir":
+    case "ListDirectory":
+      return Folder01Icon;
     case "Task":
     case "Agent":
       return Robot01Icon;
@@ -64,8 +71,18 @@ export const iconForTool = (tool: string): IconHandle => {
       return GlobeIcon;
     case "TodoWrite":
       return CheckListIcon;
-    default:
+    default: {
+      // Heuristic fallback for any Grok-native or future tool we haven't
+      // wired an exact case for yet. "list dir", "read file", "run shell"
+      // etc. will now get a reasonable icon instead of the generic wrench.
+      const t = tool.toLowerCase();
+      if (t.includes("dir") || t.includes("folder") || t.includes("list")) return Folder01Icon;
+      if (t.includes("file") || t.includes("read") || t.includes("write")) return File01Icon;
+      if (t.includes("bash") || t.includes("shell") || t.includes("cmd") || t.includes("exec")) return TerminalIcon;
+      if (t.includes("search") || t.includes("grep") || t.includes("glob")) return SearchIcon;
+      if (t.includes("web") || t.includes("http")) return GlobeIcon;
       return Wrench01Icon;
+    }
   }
 };
 
@@ -689,9 +706,20 @@ const buildToolView = (
     }
 
     default: {
+      // Produce a human-friendly label even for completely unknown tools
+      // (Grok's future native tools, custom MCP tools, etc.). We title-case
+      // and replace underscores so "list_dir" or "run_terminal_cmd" look
+      // reasonable instead of the raw token the user was seeing.
+      const niceLabel = tool
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+        .replace(/[_\-.]+/g, " ")
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+        .join(" ");
       return {
-        icon: Wrench01Icon,
-        label: tool,
+        icon: iconForTool(tool), // will pick a heuristic icon
+        label: niceLabel || "Tool",
         fallbackBody: <PreBlock text={stringifyJson(input)} />,
         resultPanel: (result) => (
           <PreBlock

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -632,12 +632,27 @@ const buildToolView = (
         icon: GlobeIcon,
         label: "WebSearch",
         trailing: q !== null ? <InlineCodeChip value={q} /> : undefined,
-        resultPanel: (result) => (
-          <PreBlock
-            text={truncate(toResultText(result.output), 4000)}
-            isError={result.isError}
-          />
-        ),
+        resultPanel: (result) => {
+          // ACP providers (Gemini/Grok) don't surface search results
+          // through ACP frames — only the fact that a search ran. Show a
+          // muted hint instead of an empty pre block so the row carries
+          // information even without results. Claude/Codex emit real
+          // result text and fall through to the PreBlock path.
+          const text = toResultText(result.output);
+          if (text.trim().length === 0 && !result.isError) {
+            return (
+              <p className="px-1 text-[11px] text-muted-foreground italic">
+                (no results returned)
+              </p>
+            );
+          }
+          return (
+            <PreBlock
+              text={truncate(text, 4000)}
+              isError={result.isError}
+            />
+          );
+        },
       };
     }
 

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -31,7 +31,7 @@ export type ChatError =
   | { readonly kind: "generic"; readonly message: string };
 
 const AUTH_PATTERN =
-  /\b401\b|\bunauthorized\b|expired token|invalid_grant|signed?\s?out|sign\s?in required|please log in/i;
+  /\b401\b|\bunauthorized\b|expired token|invalid_grant|signed?\s?out|sign\s?in required|please log in|authorizationrequired|auth\(authorizationrequired\)|authentication failed/i;
 const NETWORK_PATTERN =
   /\b(network|fetch|econn|enotfound|etimedout|timeout|getaddrinfo)\b/i;
 

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -35,6 +35,24 @@ const AUTH_PATTERN =
 const NETWORK_PATTERN =
   /\b(network|fetch|econn|enotfound|etimedout|timeout|getaddrinfo)\b/i;
 
+/**
+ * Read the per-session model-option bag the composer's ReasoningPicker
+ * persists to sessionStorage. Returns `null` when nothing has been set so
+ * the RPC payload stays clean (drivers default to model presets).
+ */
+const readSessionModelOptions = (
+  sessionId: SessionId,
+): Record<string, string> | null => {
+  if (typeof window === "undefined") return null;
+  const reasoning = window.sessionStorage.getItem(
+    `memoize.reasoning.${sessionId}`,
+  );
+  if (reasoning === "low" || reasoning === "medium" || reasoning === "high") {
+    return { reasoning };
+  }
+  return null;
+};
+
 const classifyMessage = (
   message: string,
   providerId?: ProviderId,
@@ -361,10 +379,15 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     }));
     try {
       const client = await getRpcClient();
+      // Pick up the per-session reasoning selection the composer's
+      // ReasoningPicker persists to sessionStorage. Drivers that don't
+      // implement reasoning silently ignore it; only models whose
+      // descriptor advertises a `reasoning` option even show the picker.
+      const modelOptions = readSessionModelOptions(sessionId);
       const payload =
         typeof input === "string"
-          ? { sessionId, text: input }
-          : { sessionId, input };
+          ? { sessionId, text: input, ...(modelOptions !== null ? { modelOptions } : {}) }
+          : { sessionId, input, ...(modelOptions !== null ? { modelOptions } : {}) };
       await Effect.runPromise(client.messages.send(payload));
       void useSessionsStore.getState().refreshOne(sessionId);
     } catch (err) {

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -373,26 +373,111 @@ const probeClaudeAccount: Effect.Effect<
     : parseClaudeCredentials(raw);
 });
 
-// Grok writes browser-OAuth credentials + `config.toml` under `~/.grok/`
-// on first authenticated launch; directory presence is a cheap proxy for
-// "completed at least one login". If only `GROK_CODE_XAI_API_KEY` is set,
-// the dir may not exist — the renderer still flips to "ready" via
-// `hasApiKey` once a key lands in the keychain.
+interface GrokAuthEntry {
+  readonly key?: string; // JWT access token (contains "tier" claim)
+  readonly email?: string;
+  readonly first_name?: string;
+}
+
+/**
+ * Minimum `tier` value from the xAI OIDC JWT that includes SuperGrok Heavy
+ * (the plan required for full Grok coding agent / `grok agent stdio` access).
+ * Lower tiers will be treated as "requires subscription" (disabled + nag).
+ */
+const MIN_SUPERGROK_HEAVY_TIER = 5;
+
+/** Base64url decode + parse a JWT payload (no signature verification). */
+const decodeJwtPayload = (jwt: string): Record<string, unknown> | null => {
+  try {
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return null;
+    const payloadPart = parts[1];
+    if (!payloadPart) return null;
+    let b64 = payloadPart.replace(/-/g, "+").replace(/_/g, "/");
+    // Pad to multiple of 4
+    b64 += "===".slice((b64.length + 3) % 4);
+    const json = Buffer.from(b64, "base64").toString("utf8");
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+};
+
+const parseGrokAuthJson = (raw: string): AccountInfo => {
+  try {
+    const data = JSON.parse(raw) as Record<string, GrokAuthEntry>;
+    const entry = Object.values(data)[0];
+    if (!entry) {
+      return {
+        authStatus: "authenticated",
+        authType: "cli",
+        authLabel: "Requires SuperGrok Heavy",
+      } satisfies AccountInfo;
+    }
+
+    const email = entry.email?.trim();
+    let authLabel = "Requires SuperGrok Heavy";
+
+    if (entry.key) {
+      const claims = decodeJwtPayload(entry.key);
+      const tier = claims?.tier;
+      if (typeof tier === "number" && tier >= MIN_SUPERGROK_HEAVY_TIER) {
+        authLabel = "SuperGrok Heavy";
+      }
+    }
+
+    return {
+      authStatus: "authenticated",
+      authType: "cli",
+      ...(email ? { authEmail: email } : {}),
+      authLabel,
+    } satisfies AccountInfo;
+  } catch {
+    // Unparseable auth.json → conservative: treat as needing the plan.
+    return {
+      authStatus: "authenticated",
+      authType: "cli",
+      authLabel: "Requires SuperGrok Heavy",
+    } satisfies AccountInfo;
+  }
+};
+
+// Grok stores OIDC credentials (JWT + email + tier claim) in `~/.grok/auth.json`
+// after `grok login`. We parse the JWT to read the `tier` claim and decide the
+// plan status:
 //
-// We can't currently verify the user's subscription tier from the CLI
-// alone — Grok's agent CLI requires an active SuperGrok Heavy plan to
-// actually drive sessions, but the OAuth artifact alone doesn't tell us
-// whether that plan is active. Carry the requirement in `authLabel` so
-// the card surfaces "Requires SuperGrok Heavy subscription" + a subscribe
-// CTA, and the user finds out before they hit a session-runtime 403.
+// - tier >= 5 → authLabel: "SuperGrok Heavy"   (good, card shows plan, toggle enabled)
+// - lower / no JWT / unreadable → authLabel: "Requires SuperGrok Heavy" (disabled + violet nag)
+//
+// This gives real plan details in the UI while keeping the safety net for
+// accounts that don't have the required SuperGrok Heavy plan. The final gate
+// is still enforced server-side by the Grok ACP.
 const probeGrokAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSystem> =
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = join(homedir(), ".grok");
-    const exists = yield* fs
-      .exists(path)
+    const dir = join(homedir(), ".grok");
+    const authPath = join(dir, "auth.json");
+
+    const authExists = yield* fs
+      .exists(authPath)
       .pipe(Effect.catchAll(() => Effect.succeed(false)));
-    return exists
+
+    if (authExists) {
+      const raw = yield* fs
+        .readFileString(authPath)
+        .pipe(Effect.catchAll(() => Effect.succeed("")));
+      if (raw.length > 0) {
+        return parseGrokAuthJson(raw);
+      }
+    }
+
+    // No auth.json (legacy dir, API key only, or first-run state).
+    // We conservatively report "Requires SuperGrok Heavy" so the UI disables
+    // the toggle and shows the subscription notice (same as before for unknown plans).
+    const dirExists = yield* fs
+      .exists(dir)
+      .pipe(Effect.catchAll(() => Effect.succeed(false)));
+    return dirExists
       ? ({
           authStatus: "authenticated",
           authType: "cli",

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -83,30 +83,85 @@ const extractCallId = (u: Record<string, unknown>): AgentItemId => {
 };
 
 /**
- * Map an ACP `kind` string (lowercase, single word) to the Claude-canonical
- * tool name the renderer's tool-row switch expects.
+ * Convert a snake_case or camelCase identifier into a nice TitleCase label
+ * suitable for display in the UI (e.g. "list_dir" → "List Dir",
+ * "readFile" → "Read File"). Used both for unknown tool normalization and
+ * as the fallback label in the renderer when we still don't have an exact
+ * mapping.
+ */
+const toNiceToolLabel = (raw: string): string => {
+  if (!raw) return "Tool";
+  // Split on underscores or camelCase boundaries
+  const words = raw
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+  return words.join(" ");
+};
+
+/**
+ * Map an ACP `kind` (or tool name) string to the Claude-canonical tool name
+ * the renderer's ToolRow switch + iconForTool expect. We now handle the
+ * full set of common Grok / ACP FS & shell tools so "list_dir", "read_file"
+ * etc. stop showing up as the generic "tool" / "Other" rows the user saw.
  */
 const normalizeAcpKind = (rawKind: string): string => {
-  switch (rawKind) {
+  const k = rawKind.toLowerCase();
+  switch (k) {
     case "read":
+    case "read_file":
+    case "readfile":
       return "Read";
     case "bash":
     case "execute":
+    case "run_command":
+    case "run_terminal_cmd":
+    case "shell":
+    case "shell_command":
+    case "terminal":
       return "Bash";
     case "edit":
+    case "edit_file":
+    case "editfile":
       return "Edit";
     case "write":
+    case "write_file":
+    case "writefile":
       return "Write";
     case "grep":
+    case "search":
+    case "search_files":
+    case "searchfiles":
       return "Grep";
     case "glob":
+    case "glob_files":
+    case "globfiles":
       return "Glob";
-    case "search":
+    case "websearch":
+    case "web_search":
       return "WebSearch";
+    case "webfetch":
+    case "web_fetch":
     case "fetch":
+    case "fetch_url":
       return "WebFetch";
+    case "list_dir":
+    case "listdir":
+    case "list_directory":
+    case "directory":
+      return "ListDir";
+    case "multi_edit":
+    case "multiedit":
+      return "MultiEdit";
+    case "todo_write":
+    case "todowrite":
+      return "TodoWrite";
     default:
-      return rawKind.charAt(0).toUpperCase() + rawKind.slice(1);
+      // Fall back to a clean Title Case label (handles the rest of Grok's
+      // native tools gracefully even if we haven't wired a dedicated case
+      // in the renderer yet).
+      return toNiceToolLabel(rawKind);
   }
 };
 
@@ -258,12 +313,50 @@ const buildCanonicalInput = (
 };
 
 const extractToolName = (u: Record<string, unknown>): string => {
+  // Direct fields first (most ACP implementations put the kind here)
   const kind = typeof u["kind"] === "string" ? (u["kind"] as string) : null;
-  if (kind !== null) return normalizeAcpKind(kind);
-  if (typeof u["tool"] === "string") return u["tool"] as string;
-  if (typeof u["name"] === "string") return u["name"] as string;
-  if (typeof u["execution"] === "string") return u["execution"] as string;
-  if (typeof u["command"] === "string") return u["command"] as string;
+  if (kind !== null && kind.length > 0) return normalizeAcpKind(kind);
+
+  if (typeof u["tool"] === "string" && u["tool"].length > 0) return u["tool"] as string;
+  if (typeof u["name"] === "string" && u["name"].length > 0) return u["name"] as string;
+  if (typeof u["execution"] === "string" && u["execution"].length > 0) return u["execution"] as string;
+  if (typeof u["command"] === "string" && u["command"].length > 0) return u["command"] as string;
+
+  // Grok (and some other agents) sometimes nest the tool identity under
+  // toolCall / tool_call / toolInfo. Look one level deeper so we don't
+  // fall back to the useless generic "tool" label the user reported.
+  const nestedCandidates = [
+    u["toolCall"],
+    u["tool_call"],
+    u["toolInfo"],
+    u["tool_info"],
+    u["call"],
+  ];
+  for (const cand of nestedCandidates) {
+    if (cand && typeof cand === "object") {
+      const c = cand as Record<string, unknown>;
+      const nestedKind = typeof c["kind"] === "string" ? (c["kind"] as string) : null;
+      if (nestedKind && nestedKind.length > 0) return normalizeAcpKind(nestedKind);
+      const nestedName =
+        (typeof c["name"] === "string" && c["name"]) ||
+        (typeof c["tool"] === "string" && c["tool"]) ||
+        (typeof c["command"] === "string" && c["command"]);
+      if (nestedName && typeof nestedName === "string" && nestedName.length > 0) {
+        return normalizeAcpKind(nestedName);
+      }
+    }
+  }
+
+  // Last-ditch: sometimes the title/description of the call *is* the tool
+  // (e.g. Grok sends title: "list_dir" with no kind). Use it.
+  const title = typeof u["title"] === "string" ? (u["title"] as string) : null;
+  if (title && title.length > 0 && title.length < 40) {
+    // Heuristic: if it looks like a tool identifier, normalize it.
+    if (/^[a-z0-9_]+$/i.test(title)) return normalizeAcpKind(title);
+  }
+
+  // Give the caller a chance to log the raw payload under debug before we
+  // return the ultimate fallback.
   return "tool";
 };
 
@@ -298,6 +391,26 @@ const safeStringify = (u: Record<string, unknown>): string => {
 };
 
 /**
+ * When extractToolName still returns the generic fallback "tool", dump the
+ * full raw ACP update under the existing ACP debug flag so we can quickly
+ * add the missing mapping on the next Grok (or Gemini/Cursor) release.
+ * This directly implements the user's request for "add some logs".
+ */
+const logUnknownToolIfNeeded = (
+  provider: AcpProviderTag,
+  u: Record<string, unknown>,
+  toolName: string,
+  phase: string,
+): void => {
+  if (toolName !== "tool") return;
+  if (!ACP_TRACE) return;
+  trace(
+    provider,
+    `unknown tool ${phase} — raw payload=${safePreview(u, 800)}`,
+  );
+};
+
+/**
  * Whether the update kind contributes to an in-flight assistant message
  * burst. ACP streams text as many tiny `agent_message_chunk` frames
  * (sometimes mid-token, like `monore` + `po`); the renderer would render
@@ -306,6 +419,18 @@ const safeStringify = (u: Record<string, unknown>): string => {
  */
 const isAssistantTextChunk = (kind: string): boolean =>
   kind === "agent_message_chunk" || kind === "message";
+
+/**
+ * Whether the update kind is a streaming thinking/reasoning delta.
+ * Grok (and other ACP agents) emit one token per `agent_thought_chunk` /
+ * `thinking_chunk`. Without coalescing we would emit a separate Thinking
+ * row for every word — exactly the bug the user reported.
+ */
+const isThinkingChunk = (kind: string): boolean =>
+  kind === "agent_thought_chunk" ||
+  kind === "agent_reasoning_chunk" ||
+  kind === "thinking_chunk" ||
+  kind === "reasoning";
 
 interface AcpTranslator {
   /**
@@ -349,6 +474,14 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
   // each flush.
   let assistantBuffer = "";
   let assistantItemId: AgentItemId | null = null;
+
+  // Parallel buffer for thinking/reasoning chunks (Grok agent streams these
+  // one token at a time). We coalesce them into a single Thinking event so
+  // the UI shows one nice collapsible "Thinking" row instead of 20 one-word
+  // rows.
+  let thinkingBuffer = "";
+  let thinkingItemId: AgentItemId | null = null;
+
   const toolStates = new Map<string, ToolCallState>();
 
   const flushAssistant = (): ReadonlyArray<AgentEvent> => {
@@ -365,6 +498,35 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
     assistantBuffer = "";
     assistantItemId = null;
     return [ev];
+  };
+
+  const flushThinking = (): ReadonlyArray<AgentEvent> => {
+    if (thinkingBuffer.length === 0) return [];
+    const ev: AgentEvent = {
+      _tag: "Thinking",
+      itemId: thinkingItemId ?? nextItemId(),
+      text: thinkingBuffer,
+      redacted: false,
+    };
+    trace(
+      provider,
+      `flush Thinking itemId=${ev.itemId} len=${thinkingBuffer.length} preview=${safePreview(thinkingBuffer)}`,
+    );
+    thinkingBuffer = "";
+    thinkingItemId = null;
+    return [ev];
+  };
+
+  /**
+   * Drain any pending thinking + assistant text. Order: thinking first
+   * (the model usually emits reasoning before its final answer), then the
+   * assistant message. Used both on explicit flush() and before every
+   * non-streaming event.
+   */
+  const flushPending = (): ReadonlyArray<AgentEvent> => {
+    const t = flushThinking();
+    const a = flushAssistant();
+    return t.length === 0 ? a : a.length === 0 ? t : [...t, ...a];
   };
 
   const getOrInitToolState = (id: string): ToolCallState => {
@@ -387,8 +549,19 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           : null;
     if (kind === null) return [];
 
-    // Coalesce: append to buffer, don't emit yet. The next non-chunk
-    // event (or `flush`) will drain.
+    // 1. Thinking / reasoning delta — buffer (coalesce) exactly like assistant
+    //    text. This is the fix for the "Thinking The user is asking if I can..."
+    //    word-by-word explosion the user reported with Grok.
+    if (isThinkingChunk(kind)) {
+      const text = asText(u["content"]);
+      if (text === null || text.length === 0) return [];
+      if (thinkingItemId === null) thinkingItemId = nextItemId();
+      thinkingBuffer += text;
+      trace(provider, `buffer thinking chunk len=${text.length} totalLen=${thinkingBuffer.length}`);
+      return [];
+    }
+
+    // 2. Assistant text delta — buffer, don't emit yet.
     if (isAssistantTextChunk(kind)) {
       const text =
         kind === "message"
@@ -401,9 +574,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
       return [];
     }
 
-    // Any non-chunk event flushes the buffered assistant text first so
-    // the order on the wire is "all-text-so-far → next thing".
-    const flushed = flushAssistant();
+    // 3. Any other event: flush both pending thinking + assistant text first
+    //    so the timeline order stays correct ("reasoning burst → next tool /
+    //    final answer").
+    const flushed = flushPending();
 
     const tail = ((): ReadonlyArray<AgentEvent> => {
       switch (kind) {
@@ -439,6 +613,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
 
           const callId = extractCallId(u);
           const toolName = extractToolName(u);
+          logUnknownToolIfNeeded(provider, u, toolName, "tool_call");
           const input = buildCanonicalInput(toolName, u);
           const inputJson = safeStringify({ input });
           const state = getOrInitToolState(callId);
@@ -482,6 +657,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           if (provider === "gemini" && rawKind === "think") return [];
           const callId = extractCallId(u);
           const toolName = extractToolName(u);
+          logUnknownToolIfNeeded(provider, u, toolName, "tool_call_update");
           const input = buildCanonicalInput(toolName, u);
           const state = getOrInitToolState(callId);
           const events: AgentEvent[] = [];
@@ -621,7 +797,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
 
   return {
     translate: translateOne,
-    flush: flushAssistant,
+    flush: flushPending,
   };
 };
 

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -1,0 +1,640 @@
+import type { AgentEvent, AgentItemId } from "@memoize/wire";
+
+/**
+ * Shared translator for Agent Client Protocol (ACP) `session/update` frames.
+ * Lifted out of grok.ts / gemini.ts / cursor.ts which each carried a near-
+ * identical copy. The renderer expects every provider's tool calls to look
+ * like Claude's (see the "Normalized Tool-Call Contract" doc-block above
+ * `ToolUseEvent` in `packages/wire/src/agent.ts`), so this translator
+ * coerces ACP frames into that shape.
+ *
+ * Per-provider quirks (Gemini's `kind === "think"` skip, etc.) live in a
+ * single `provider` switch instead of three forks of the same function.
+ *
+ * Set `MEMOIZE_DEBUG_ACP=1` to trace every translator decision to stderr
+ * (kind, status, what events were emitted). Pair with `MEMOIZE_DEBUG_<P>`
+ * (GEMINI/GROK/CURSOR) for raw JSON-RPC frame logs in the drivers.
+ */
+
+export type AcpProviderTag = "grok" | "gemini" | "cursor";
+
+const ACP_TRACE = process.env.MEMOIZE_DEBUG_ACP === "1";
+
+const trace = (provider: AcpProviderTag, msg: string): void => {
+  if (!ACP_TRACE) return;
+  process.stderr.write(`[acp.${provider}] ${msg}\n`);
+};
+
+const safePreview = (v: unknown, max = 240): string => {
+  try {
+    const s = typeof v === "string" ? v : JSON.stringify(v);
+    if (s === undefined) return "undefined";
+    return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+  } catch {
+    return "(unserialisable)";
+  }
+};
+
+let itemCounter = 0;
+const nextItemId = (): AgentItemId =>
+  `i_acp_${Date.now()}_${++itemCounter}` as AgentItemId;
+
+const tryParseJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+};
+
+const asText = (v: unknown): string | null => {
+  if (typeof v === "string") return v;
+  if (v !== null && typeof v === "object" && "text" in v) {
+    const t = (v as { text: unknown }).text;
+    return typeof t === "string" ? t : null;
+  }
+  return null;
+};
+
+const extractMessageText = (content: unknown): string | null => {
+  if (!Array.isArray(content)) return asText(content);
+  const parts: string[] = [];
+  for (const item of content) {
+    if (item !== null && typeof item === "object" && "text" in item) {
+      const t = (item as Record<string, unknown>)["text"];
+      if (typeof t === "string") parts.push(t);
+    }
+  }
+  return parts.length > 0 ? parts.join("") : null;
+};
+
+const extractCallId = (u: Record<string, unknown>): AgentItemId => {
+  const raw =
+    typeof u["toolCallId"] === "string"
+      ? u["toolCallId"]
+      : typeof u["call_id"] === "string"
+        ? u["call_id"]
+        : typeof u["callId"] === "string"
+          ? u["callId"]
+          : typeof u["id"] === "string"
+            ? u["id"]
+            : null;
+  return raw !== null ? (raw as AgentItemId) : nextItemId();
+};
+
+/**
+ * Map an ACP `kind` string (lowercase, single word) to the Claude-canonical
+ * tool name the renderer's tool-row switch expects.
+ */
+const normalizeAcpKind = (rawKind: string): string => {
+  switch (rawKind) {
+    case "read":
+      return "Read";
+    case "bash":
+    case "execute":
+      return "Bash";
+    case "edit":
+      return "Edit";
+    case "write":
+      return "Write";
+    case "grep":
+      return "Grep";
+    case "glob":
+      return "Glob";
+    case "search":
+      return "WebSearch";
+    case "fetch":
+      return "WebFetch";
+    default:
+      return rawKind.charAt(0).toUpperCase() + rawKind.slice(1);
+  }
+};
+
+const firstLocationPath = (u: Record<string, unknown>): string | null => {
+  const locations = u["locations"];
+  if (!Array.isArray(locations) || locations.length === 0) return null;
+  const loc = locations[0];
+  if (loc === null || typeof loc !== "object") return null;
+  const p = (loc as Record<string, unknown>)["path"];
+  return typeof p === "string" ? p : null;
+};
+
+/**
+ * Walk an ACP `tool_call.content` array (or single block) and pluck the
+ * first `diff` block if present. Gemini's ACP emits these for `edit` calls:
+ *   `{ type: "diff", path, oldText, newText }`
+ * (older variants spell them `old_text` / `new_text`).
+ */
+const extractDiffBlock = (
+  content: unknown,
+): { path?: string; oldText: string; newText: string } | null => {
+  const items = Array.isArray(content) ? content : [content];
+  for (const item of items) {
+    if (item === null || typeof item !== "object") continue;
+    const b = item as Record<string, unknown>;
+    if (b["type"] !== "diff") continue;
+    const oldText =
+      typeof b["oldText"] === "string"
+        ? (b["oldText"] as string)
+        : typeof b["old_text"] === "string"
+          ? (b["old_text"] as string)
+          : null;
+    const newText =
+      typeof b["newText"] === "string"
+        ? (b["newText"] as string)
+        : typeof b["new_text"] === "string"
+          ? (b["new_text"] as string)
+          : null;
+    if (oldText === null || newText === null) continue;
+    const path = typeof b["path"] === "string" ? (b["path"] as string) : undefined;
+    return { path, oldText, newText };
+  }
+  return null;
+};
+
+/**
+ * Build a canonical `input` object for the given tool name. ACP frames put
+ * the same info in several different fields depending on provider/version,
+ * so we look in each common spelling. The keys we emit match the
+ * "Normalized Tool-Call Contract" enumerated next to `ToolUseEvent`.
+ */
+const buildCanonicalInput = (
+  toolName: string,
+  u: Record<string, unknown>,
+): unknown => {
+  const title = typeof u["title"] === "string" ? (u["title"] as string) : null;
+
+  switch (toolName) {
+    case "Edit":
+    case "MultiEdit": {
+      const diff = extractDiffBlock(u["content"]);
+      if (diff !== null) {
+        return {
+          file_path: diff.path ?? firstLocationPath(u) ?? "",
+          old_string: diff.oldText,
+          new_string: diff.newText,
+        };
+      }
+      const file_path = firstLocationPath(u);
+      if (file_path !== null) return { file_path };
+      break;
+    }
+    case "Write": {
+      const file_path = firstLocationPath(u);
+      const content =
+        typeof u["content"] === "string"
+          ? (u["content"] as string)
+          : extractMessageText(u["content"]);
+      const out: Record<string, unknown> = {};
+      if (file_path !== null) out["file_path"] = file_path;
+      if (content !== null) out["content"] = content;
+      return Object.keys(out).length > 0 ? out : null;
+    }
+    case "Read": {
+      const file_path = firstLocationPath(u);
+      if (file_path !== null) {
+        const out: Record<string, unknown> = { file_path };
+        if (typeof u["offset"] === "number") out["offset"] = u["offset"];
+        if (typeof u["limit"] === "number") out["limit"] = u["limit"];
+        return out;
+      }
+      break;
+    }
+    case "Bash": {
+      const command =
+        typeof u["command"] === "string"
+          ? (u["command"] as string)
+          : typeof u["cmd"] === "string"
+            ? (u["cmd"] as string)
+            : null;
+      if (command !== null) {
+        const out: Record<string, unknown> = { command };
+        if (title !== null) out["description"] = title;
+        return out;
+      }
+      break;
+    }
+    case "Grep":
+    case "Glob": {
+      const out: Record<string, unknown> = {};
+      if (typeof u["pattern"] === "string") out["pattern"] = u["pattern"];
+      if (typeof u["path"] === "string") out["path"] = u["path"];
+      if (typeof u["glob"] === "string") out["glob"] = u["glob"];
+      if (Object.keys(out).length > 0) return out;
+      break;
+    }
+    case "WebSearch": {
+      const query =
+        typeof u["query"] === "string"
+          ? (u["query"] as string)
+          : typeof u["q"] === "string"
+            ? (u["q"] as string)
+            : title;
+      if (query !== null) return { query };
+      break;
+    }
+    case "WebFetch": {
+      const url = typeof u["url"] === "string" ? (u["url"] as string) : null;
+      if (url !== null) {
+        const out: Record<string, unknown> = { url };
+        if (title !== null) out["prompt"] = title;
+        return out;
+      }
+      break;
+    }
+  }
+
+  // Generic fallback — preserve whatever the provider sent so the renderer
+  // can still render *something* even for tool names we don't recognize.
+  if (u["input"] !== undefined) return u["input"];
+  if (u["arguments"] !== undefined) {
+    const a = u["arguments"];
+    return typeof a === "string" ? tryParseJson(a) : a;
+  }
+  if (u["command"] !== undefined) return { command: u["command"] };
+  const file_path = firstLocationPath(u);
+  if (file_path !== null) return { file_path };
+  return title !== null ? { description: title } : null;
+};
+
+const extractToolName = (u: Record<string, unknown>): string => {
+  const kind = typeof u["kind"] === "string" ? (u["kind"] as string) : null;
+  if (kind !== null) return normalizeAcpKind(kind);
+  if (typeof u["tool"] === "string") return u["tool"] as string;
+  if (typeof u["name"] === "string") return u["name"] as string;
+  if (typeof u["execution"] === "string") return u["execution"] as string;
+  if (typeof u["command"] === "string") return u["command"] as string;
+  return "tool";
+};
+
+const extractOutput = (u: Record<string, unknown>): unknown => {
+  if (u["output"] !== undefined) {
+    const o = u["output"];
+    if (o !== null && typeof o === "object" && "content" in o) {
+      return (o as Record<string, unknown>)["content"] ?? o;
+    }
+    return o;
+  }
+  if (u["content"] !== undefined) return u["content"];
+  if (u["result"] !== undefined) return u["result"];
+  return null;
+};
+
+const extractErrorDetail = (u: Record<string, unknown>): string | null => {
+  const fields = ["message", "error", "details", "data"] as const;
+  for (const f of fields) {
+    const v = u[f];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return null;
+};
+
+const safeStringify = (u: Record<string, unknown>): string => {
+  try {
+    return JSON.stringify(u);
+  } catch {
+    return "(unserialisable)";
+  }
+};
+
+/**
+ * Whether the update kind contributes to an in-flight assistant message
+ * burst. ACP streams text as many tiny `agent_message_chunk` frames
+ * (sometimes mid-token, like `monore` + `po`); the renderer would render
+ * each as its own bubble unless we coalesce. Anything else flushes the
+ * buffer.
+ */
+const isAssistantTextChunk = (kind: string): boolean =>
+  kind === "agent_message_chunk" || kind === "message";
+
+interface AcpTranslator {
+  /**
+   * Translate one ACP `session/update` payload. May return zero events
+   * (chunk got buffered for coalescing) or multiple (a flush of buffered
+   * assistant text plus the new event).
+   */
+  translate(update: unknown): ReadonlyArray<AgentEvent>;
+  /**
+   * Drain any buffered assistant text as a final `AssistantMessage` event.
+   * Call when the turn ends (`stopReason`) or the session closes so the
+   * last burst doesn't sit silently in memory.
+   */
+  flush(): ReadonlyArray<AgentEvent>;
+}
+
+/**
+ * Per-tool-call state we keep so we can dedupe events. ACP servers re-send
+ * `tool_call_update` frames for the same id as a call progresses (pending →
+ * in_progress → completed); without dedupe each update becomes its own row
+ * in the renderer.
+ */
+interface ToolCallState {
+  /** What we last emitted as `ToolUse.input` — used to skip identical re-emits. */
+  lastInputJson: string | null;
+  /** True once we've emitted a `ToolResult` for this call. */
+  resultEmitted: boolean;
+  /** True once we've emitted a `ToolUse` for this call. */
+  useEmitted: boolean;
+}
+
+/**
+ * Create a per-session translator. Stateful because:
+ *   1. ACP's `agent_message_chunk` is a delta protocol — we buffer
+ *      consecutive chunks into one logical `AssistantMessage` event.
+ *   2. `tool_call_update` is also a delta protocol — we dedupe so the
+ *      renderer doesn't show a stack of "Read foo.ts" rows for one read.
+ */
+export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => {
+  // Buffer for the in-flight assistant message text. Reset to "" after
+  // each flush.
+  let assistantBuffer = "";
+  let assistantItemId: AgentItemId | null = null;
+  const toolStates = new Map<string, ToolCallState>();
+
+  const flushAssistant = (): ReadonlyArray<AgentEvent> => {
+    if (assistantBuffer.length === 0) return [];
+    const ev: AgentEvent = {
+      _tag: "AssistantMessage",
+      itemId: assistantItemId ?? nextItemId(),
+      text: assistantBuffer,
+    };
+    trace(
+      provider,
+      `flush AssistantMessage itemId=${ev.itemId} len=${assistantBuffer.length} preview=${safePreview(assistantBuffer)}`,
+    );
+    assistantBuffer = "";
+    assistantItemId = null;
+    return [ev];
+  };
+
+  const getOrInitToolState = (id: string): ToolCallState => {
+    let s = toolStates.get(id);
+    if (s === undefined) {
+      s = { lastInputJson: null, resultEmitted: false, useEmitted: false };
+      toolStates.set(id, s);
+    }
+    return s;
+  };
+
+  const translateOne = (update: unknown): ReadonlyArray<AgentEvent> => {
+    if (update === null || typeof update !== "object") return [];
+    const u = update as Record<string, unknown>;
+    const kind =
+      typeof u["sessionUpdate"] === "string"
+        ? (u["sessionUpdate"] as string)
+        : typeof u["type"] === "string"
+          ? (u["type"] as string)
+          : null;
+    if (kind === null) return [];
+
+    // Coalesce: append to buffer, don't emit yet. The next non-chunk
+    // event (or `flush`) will drain.
+    if (isAssistantTextChunk(kind)) {
+      const text =
+        kind === "message"
+          ? extractMessageText(u["content"])
+          : asText(u["content"]);
+      if (text === null || text.length === 0) return [];
+      if (assistantItemId === null) assistantItemId = nextItemId();
+      assistantBuffer += text;
+      trace(provider, `buffer message chunk len=${text.length} totalLen=${assistantBuffer.length}`);
+      return [];
+    }
+
+    // Any non-chunk event flushes the buffered assistant text first so
+    // the order on the wire is "all-text-so-far → next thing".
+    const flushed = flushAssistant();
+
+    const tail = ((): ReadonlyArray<AgentEvent> => {
+      switch (kind) {
+        case "agent_thought_chunk":
+        case "agent_reasoning_chunk":
+        case "thinking_chunk":
+        case "reasoning": {
+          const text = asText(u["content"]);
+          if (text === null || text.length === 0) return [];
+          trace(provider, `emit Thinking len=${text.length}`);
+          return [
+            { _tag: "Thinking", itemId: nextItemId(), text, redacted: false },
+          ];
+        }
+
+        case "tool_call":
+        case "tool_use":
+        case "function_call":
+        case "custom_tool_call":
+        case "tool_search_call":
+        case "local_shell_call":
+        case "web_search_call":
+        case "image_generation_call": {
+          const rawKind =
+            typeof u["kind"] === "string" ? (u["kind"] as string) : null;
+          // Gemini emits a `think` tool call to advertise an internal
+          // thought — we already surface those via `thinking_chunk`,
+          // so don't double-render as a tool row.
+          if (provider === "gemini" && rawKind === "think") {
+            trace(provider, `skip think tool_call`);
+            return [];
+          }
+
+          const callId = extractCallId(u);
+          const toolName = extractToolName(u);
+          const input = buildCanonicalInput(toolName, u);
+          const inputJson = safeStringify({ input });
+          const state = getOrInitToolState(callId);
+          // Dedupe: if we already emitted ToolUse with this exact input,
+          // skip. Happens when an ACP server sends the same `tool_call`
+          // twice (some implementations do for pending/in_progress).
+          if (state.useEmitted && state.lastInputJson === inputJson) {
+            trace(
+              provider,
+              `skip duplicate tool_call id=${callId} tool=${toolName}`,
+            );
+            return [];
+          }
+          state.useEmitted = true;
+          state.lastInputJson = inputJson;
+          trace(
+            provider,
+            `emit ToolUse id=${callId} tool=${toolName} input=${safePreview(input)}`,
+          );
+          return [
+            {
+              _tag: "ToolUse",
+              itemId: callId,
+              tool: toolName,
+              input,
+            },
+          ];
+        }
+
+        // ACP sends `tool_call_update` frames to amend an in-flight call.
+        // Three shapes we care about:
+        //   - completed Read/Bash/Search → content carries result text
+        //   - completed Edit → content carries a `diff` block (input)
+        //   - status/title bump only → no new info
+        // Dedupe carefully so progress updates don't stack rows in the
+        // renderer: re-emit ToolUse only if the input meaningfully
+        // changed (e.g. a diff arrived), and emit ToolResult once.
+        case "tool_call_update": {
+          const rawKind =
+            typeof u["kind"] === "string" ? (u["kind"] as string) : null;
+          if (provider === "gemini" && rawKind === "think") return [];
+          const callId = extractCallId(u);
+          const toolName = extractToolName(u);
+          const input = buildCanonicalInput(toolName, u);
+          const state = getOrInitToolState(callId);
+          const events: AgentEvent[] = [];
+
+          // Re-emit ToolUse only when input changed substantively —
+          // typically when a diff block first appears for an Edit. If the
+          // input is identical to what we last emitted, skip.
+          if (input !== null) {
+            const inputJson = safeStringify({ input });
+            if (state.lastInputJson !== inputJson) {
+              state.lastInputJson = inputJson;
+              state.useEmitted = true;
+              trace(
+                provider,
+                `emit ToolUse(update) id=${callId} tool=${toolName} input=${safePreview(input)}`,
+              );
+              events.push({
+                _tag: "ToolUse",
+                itemId: callId,
+                tool: toolName,
+                input,
+              });
+            } else {
+              trace(
+                provider,
+                `skip duplicate tool_call_update id=${callId} tool=${toolName}`,
+              );
+            }
+          }
+
+          const content = u["content"];
+          const hasContent =
+            content !== undefined &&
+            Array.isArray(content) &&
+            (content as ReadonlyArray<unknown>).length > 0;
+          const isDiffOnly =
+            hasContent && extractDiffBlock(content) !== null;
+          const status = typeof u["status"] === "string" ? u["status"] : null;
+          const completed = status === "completed" || status === "failed";
+
+          // Emit a ToolResult at most once per call. Triggers:
+          //   - Non-diff content arrived (the actual result payload)
+          //   - Status flipped to completed/failed (terminal — even if
+          //     there's no content, the renderer needs to know the call
+          //     finished so spinners stop).
+          if (!state.resultEmitted && ((hasContent && !isDiffOnly) || completed)) {
+            state.resultEmitted = true;
+            const output = extractOutput(u);
+            const isError =
+              u["isError"] === true ||
+              u["is_error"] === true ||
+              status === "failed";
+            trace(
+              provider,
+              `emit ToolResult id=${callId} tool=${toolName} status=${status ?? "(none)"} isError=${isError} output=${safePreview(output)}`,
+            );
+            events.push({
+              _tag: "ToolResult",
+              itemId: callId,
+              output,
+              isError,
+            });
+          } else if (state.resultEmitted) {
+            trace(
+              provider,
+              `skip late tool_call_update id=${callId} (result already emitted)`,
+            );
+          }
+
+          return events;
+        }
+
+        case "tool_result":
+        case "tool_output":
+        case "function_call_output":
+        case "custom_tool_call_output":
+        case "tool_search_output": {
+          const callId = extractCallId(u);
+          const state = getOrInitToolState(callId);
+          if (state.resultEmitted) {
+            trace(
+              provider,
+              `skip duplicate ${kind} id=${callId} (result already emitted)`,
+            );
+            return [];
+          }
+          state.resultEmitted = true;
+          const isError = u["isError"] === true || u["is_error"] === true;
+          const output = extractOutput(u);
+          trace(
+            provider,
+            `emit ToolResult(${kind}) id=${callId} isError=${isError} output=${safePreview(output)}`,
+          );
+          return [
+            {
+              _tag: "ToolResult",
+              itemId: callId,
+              output,
+              isError,
+            },
+          ];
+        }
+
+        case "error":
+        case "agent_error": {
+          const detail = extractErrorDetail(u);
+          const providerLabel =
+            provider === "grok"
+              ? "Grok"
+              : provider === "cursor"
+                ? "Cursor"
+                : "Gemini";
+          const message =
+            detail !== null
+              ? detail
+              : (() => {
+                  const serialized = safeStringify(u);
+                  return serialized === "{}"
+                    ? `${providerLabel} agent reported an error with no detail.`
+                    : `${providerLabel} agent error: ${serialized}`;
+                })();
+          return [{ _tag: "Error", message }];
+        }
+
+        case "available_commands_update":
+        case "current_mode_update":
+          return [];
+
+        default:
+          trace(provider, `unknown kind=${kind} payload=${safePreview(u)}`);
+          return [];
+      }
+    })();
+
+    return flushed.length === 0 ? tail : [...flushed, ...tail];
+  };
+
+  return {
+    translate: translateOne,
+    flush: flushAssistant,
+  };
+};
+
+/**
+ * Convenience wrapper for callers that don't need stateful coalescing
+ * (e.g. unit tests). Equivalent to calling `createAcpTranslator(...).
+ * translate(update)` once then flushing — useful when each update is a
+ * one-off and you want any buffered text emitted immediately.
+ */
+export const translateAcpSessionUpdate = (
+  update: unknown,
+  provider: AcpProviderTag,
+): ReadonlyArray<AgentEvent> => {
+  const t = createAcpTranslator(provider);
+  return [...t.translate(update), ...t.flush()];
+};

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -1195,15 +1195,21 @@ export const startClaudeSession = (
         `Phase 3 — Ask. When a real fork in the road exists (which library, which scope, which approach), call ${ASK_USER_QUESTION_FQN} with the choices instead of guessing.`,
         "Phase 4 — Propose. Call ExitPlanMode with a concise plan: what changes, where, and how to verify.",
       ].join("\n"),
-      // `effort: "high"` enables deep reasoning. We pair it with an
-      // explicit `display: "summarized"` because Opus 4.7 defaults the
-      // adaptive-thinking display to "omitted" — meaning the API
-      // intentionally returns empty thinking text plus a signature.
-      // Without this override, our `thinking_delta` chunks arrive empty
-      // even though the model thought (we see `signature_delta` only).
-      // Other Claude 4 models default to "summarized" so this is a
-      // no-op for them.
-      effort: "high",
+      // Reasoning effort: mapped from FE picker via `input.modelOptions
+      // .reasoning` (the per-model descriptor in
+      // `MODELS_BY_PROVIDER[claude]` declares which models expose this).
+      // Falls back to "high" when omitted to preserve prior default. We
+      // pair it with an explicit `display: "summarized"` because Opus
+      // 4.7 defaults the adaptive-thinking display to "omitted" — without
+      // this override our `thinking_delta` chunks arrive empty (only
+      // signatures), which would break the streaming thinking UI. Other
+      // Claude 4 models default to "summarized" so this is a no-op for
+      // them.
+      effort: (() => {
+        const r = input.modelOptions?.["reasoning"];
+        if (r === "low" || r === "medium" || r === "high") return r;
+        return "high";
+      })(),
       thinking: { type: "adaptive", display: "summarized" },
       forwardSubagentText: true,
       // Surfaces thinking deltas in the partial-message stream so we

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -17,6 +17,7 @@ import {
 } from "@memoize/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import { applyPlanModePrefix } from "./planMode.ts";
 import { CodexAppServerClient } from "../codex-app-server-client.ts";
 import type { ServerNotification } from "../codex-app-protocol/ServerNotification";
 import type { ServerRequest } from "../codex-app-protocol/ServerRequest";
@@ -188,11 +189,14 @@ const translateItem = (
       ];
     case "webSearch":
       if (phase !== "completed") return [];
+      // Use the Claude-canonical "WebSearch" tool name so the renderer's
+      // tool-row switch picks up the globe icon + result rendering.
+      // `query` is the canonical input key per the wire contract.
       return [
         {
           _tag: "ToolUse",
           itemId: item.id as AgentItemId,
-          tool: "web_search",
+          tool: "WebSearch",
           input: { query: item.query, action: item.action },
         },
       ];
@@ -394,13 +398,27 @@ export const startCodexSession = (
       if (commandHandled) return;
 
       emit({ _tag: "Status", status: "running" });
+      // Plan-mode emulation: Codex has no native "plan" runtime mode, so
+      // prepend a developer-instructions block while plan mode is active.
+      // The sandbox policy still gates writes, so this is belt-and-braces.
+      const promptText = applyPlanModePrefix(currentMode, text);
+      // Reasoning effort: forwarded from FE picker via
+      // `input.modelOptions.reasoning`. Pass through low/medium/high
+      // directly — Codex accepts the same literal set we use in wire's
+      // `ReasoningLevel`.
+      const reasoning = input.modelOptions?.["reasoning"];
+      const effort: "low" | "medium" | "high" | null =
+        reasoning === "low" || reasoning === "medium" || reasoning === "high"
+          ? reasoning
+          : null;
       const turn = await app.request<{ turn: { id: string } }>("turn/start", {
         threadId: activeThreadId,
-        input: [...(await buildUserInput(text, attachmentRefs, fileRefs, skillRefs))],
+        input: [...(await buildUserInput(promptText, attachmentRefs, fileRefs, skillRefs))],
         cwd,
         approvalPolicy: "never",
         sandboxPolicy: toSandboxPolicy(currentMode, cwd),
         model: input.model ?? null,
+        ...(effort !== null ? { effort } : {}),
       });
       currentTurnId = turn.turn.id;
     };

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -14,6 +14,7 @@ import {
 } from "@memoize/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import { createAcpTranslator } from "./acp/translate.ts";
 
 /**
  * Live-only handle for one Cursor Agent conversation. Mirrors Grok's
@@ -51,133 +52,6 @@ export interface CursorSessionHandle {
   ) => Effect.Effect<void>;
 }
 
-let itemCounter = 0;
-const nextItemId = (): AgentItemId =>
-  `i_${Date.now()}_${++itemCounter}` as AgentItemId;
-
-/**
- * Translate one ACP `session/update` payload into zero or more
- * `AgentEvent`s. Cursor's ACP server emits the same shapes as Grok per the
- * ACP spec; the handler is a direct copy of grok.ts's translator.
- */
-const translateSessionUpdate = (update: unknown): ReadonlyArray<AgentEvent> => {
-  if (update === null || typeof update !== "object") return [];
-  const u = update as Record<string, unknown>;
-  const kind = typeof u["sessionUpdate"] === "string"
-    ? (u["sessionUpdate"] as string)
-    : null;
-  if (kind === null) return [];
-
-  const asText = (v: unknown): string | null => {
-    if (typeof v === "string") return v;
-    if (v !== null && typeof v === "object" && "text" in v) {
-      const t = (v as { text: unknown }).text;
-      return typeof t === "string" ? t : null;
-    }
-    return null;
-  };
-
-  switch (kind) {
-    case "agent_message_chunk": {
-      const text = asText(u["content"]);
-      if (text === null || text.length === 0) return [];
-      return [
-        {
-          _tag: "AssistantMessage",
-          itemId: nextItemId(),
-          text,
-        },
-      ];
-    }
-    case "agent_thought_chunk":
-    case "agent_reasoning_chunk":
-    case "thinking_chunk": {
-      const text = asText(u["content"]);
-      if (text === null || text.length === 0) return [];
-      return [
-        {
-          _tag: "Thinking",
-          itemId: nextItemId(),
-          text,
-          redacted: false,
-        },
-      ];
-    }
-    case "tool_call":
-    case "tool_use": {
-      const id =
-        typeof u["toolCallId"] === "string"
-          ? ((u["toolCallId"] as string) as AgentItemId)
-          : typeof u["id"] === "string"
-            ? ((u["id"] as string) as AgentItemId)
-            : nextItemId();
-      const tool =
-        typeof u["tool"] === "string"
-          ? (u["tool"] as string)
-          : typeof u["name"] === "string"
-            ? (u["name"] as string)
-            : "tool";
-      const input = u["input"] ?? u["arguments"] ?? null;
-      return [
-        {
-          _tag: "ToolUse",
-          itemId: id,
-          tool,
-          input,
-        },
-      ];
-    }
-    case "tool_result":
-    case "tool_output": {
-      const id =
-        typeof u["toolCallId"] === "string"
-          ? ((u["toolCallId"] as string) as AgentItemId)
-          : typeof u["id"] === "string"
-            ? ((u["id"] as string) as AgentItemId)
-            : nextItemId();
-      const output = u["output"] ?? u["content"] ?? u["result"] ?? null;
-      const isError = u["isError"] === true || u["is_error"] === true;
-      return [
-        {
-          _tag: "ToolResult",
-          itemId: id,
-          output,
-          isError,
-        },
-      ];
-    }
-    case "error":
-    case "agent_error": {
-      const detail =
-        typeof u["message"] === "string" && (u["message"] as string).length > 0
-          ? (u["message"] as string)
-          : typeof u["error"] === "string"
-            ? (u["error"] as string)
-            : typeof u["details"] === "string"
-              ? (u["details"] as string)
-              : typeof u["data"] === "string"
-                ? (u["data"] as string)
-                : null;
-      const message =
-        detail !== null && detail.length > 0
-          ? detail
-          : (() => {
-              try {
-                const serialized = JSON.stringify(u);
-                return serialized === "{}"
-                  ? "Cursor agent reported an error with no detail."
-                  : `Cursor agent error: ${serialized}`;
-              } catch {
-                return "Cursor agent reported an error.";
-              }
-            })();
-      return [{ _tag: "Error", message }];
-    }
-    default:
-      console.warn(`[cursor.translate] unknown sessionUpdate=${kind}`);
-      return [];
-  }
-};
 
 interface JsonRpcError {
   readonly code?: number;
@@ -291,6 +165,11 @@ export const startCursorSession = (
       mode: "sdk",
     });
 
+    // Per-session translator coalesces agent_message_chunk deltas into
+    // one AssistantMessage per burst so the renderer doesn't show one
+    // bubble per token.
+    const translator = createAcpTranslator("cursor");
+
     let child: ChildProcessWithoutNullStreams;
     try {
       child = spawn(cursorPath, ["acp"], {
@@ -326,8 +205,10 @@ export const startCursorSession = (
       method: string,
       params: unknown,
       timeoutMs = 30_000,
+      onAssignedId?: (id: number) => void,
     ): Promise<unknown> => {
       const id = nextRpcId++;
+      onAssignedId?.(id);
       return new Promise<unknown>((resolve, reject) => {
         const timer = setTimeout(() => {
           pending.delete(id);
@@ -349,6 +230,28 @@ export const startCursorSession = (
       writeMessage({ jsonrpc: "2.0", method, params });
     };
 
+    /**
+     * Currently in-flight `session/prompt` rpc id. See gemini.ts for the
+     * rationale — interrupt needs to force-reject the pending request so
+     * the `inflight` chain unblocks.
+     */
+    let currentPromptRpcId: number | null = null;
+    const rejectCurrentPrompt = (reason: string): void => {
+      const id = currentPromptRpcId;
+      if (id === null) return;
+      const resolver = pending.get(id);
+      if (resolver === undefined) return;
+      pending.delete(id);
+      clearTimeout(resolver.timer);
+      currentPromptRpcId = null;
+      if (CURSOR_RPC_TRACE) {
+        process.stderr.write(
+          `[cursor.rpc.cancel] force-reject id=${id} method=${resolver.method} reason=${reason}\n`,
+        );
+      }
+      resolver.reject(new Error(reason));
+    };
+
     rl.on("line", (line: string) => {
       if (line.trim().length === 0) return;
       if (CURSOR_RPC_TRACE) process.stderr.write(`[cursor.rpc.recv] ${line}\n`);
@@ -365,7 +268,7 @@ export const startCursorSession = (
         if (msg.method === "session/update") {
           const update = msg.params?.update;
           if (update !== undefined) {
-            for (const ev of translateSessionUpdate(update)) {
+            for (const ev of translator.translate(update)) {
               events.unsafeOffer(ev);
             }
           }
@@ -507,12 +410,25 @@ export const startCursorSession = (
       );
     }
 
+    // If the session was created in plan mode, inform the ACP server via
+    // native `session/setMode`. Cursor exposes plan/architect modes
+    // natively, so this is real plan mode — not the dev-instructions
+    // emulation that grok/gemini/codex fall back to.
+    if (currentMode === "plan") {
+      notify("session/setMode", { sessionId: acpSessionId, modeId: "plan" });
+    }
+
     const enqueuePrompt = (text: string): void => {
       const sid = acpSessionId;
       if (sid === null) return;
       inflight = inflight
         .then(async () => {
           if (closed) return;
+          if (CURSOR_RPC_TRACE) {
+            process.stderr.write(
+              `[cursor.prompt] enqueue len=${text.length} mode=${currentMode}\n`,
+            );
+          }
           try {
             await request(
               "session/prompt",
@@ -525,16 +441,32 @@ export const startCursorSession = (
                 },
               },
               5 * 60_000,
+              (id) => {
+                currentPromptRpcId = id;
+              },
             );
+            if (CURSOR_RPC_TRACE) {
+              process.stderr.write(`[cursor.prompt] completed\n`);
+            }
           } catch (cause) {
-            if (!closed) {
+            const reason = cause instanceof Error ? cause.message : String(cause);
+            if (CURSOR_RPC_TRACE) {
+              process.stderr.write(`[cursor.prompt] failed: ${reason}\n`);
+            }
+            const isCancellation = /cancel|interrupt/i.test(reason);
+            if (!closed && !isCancellation) {
               events.unsafeOffer({
                 _tag: "Error",
-                message: cause instanceof Error ? cause.message : String(cause),
+                message: reason,
               });
             }
           } finally {
+            currentPromptRpcId = null;
+            // Drain any buffered assistant text from the translator so the
+            // final delta lands as a normal AssistantMessage instead of
+            // sitting unobserved in memory.
             if (!closed) {
+              for (const ev of translator.flush()) events.unsafeOffer(ev);
               events.unsafeOffer({ _tag: "Status", status: "idle" });
             }
           }
@@ -585,6 +517,17 @@ export const startCursorSession = (
           if (mode === currentMode) return;
           currentMode = mode;
           events.unsafeOffer({ _tag: "PermissionModeChanged", mode });
+          // Cursor exposes plan/architect modes natively via ACP
+          // `session/setMode`. Server replies with `current_mode_update`
+          // which our translator swallows. Fire-and-forget — the user's
+          // `permissionMode` chip is already updated locally; if the ACP
+          // server doesn't recognize the mode it just stays in its
+          // previous mode and the user can retry.
+          const sid = acpSessionId;
+          if (sid !== null) {
+            const modeId = mode === "plan" ? "plan" : "code";
+            notify("session/setMode", { sessionId: sid, modeId });
+          }
         }),
       answerQuestion: () => Effect.void,
     };

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -275,6 +275,23 @@ export const startCursorSession = (
           return;
         }
         if (msg.id !== undefined) {
+          const isFs = msg.method.startsWith("fs/");
+          if (CURSOR_RPC_TRACE || isFs) {
+            process.stderr.write(
+              `[cursor.rpc] server→client request method=${msg.method} id=${msg.id} params=${JSON.stringify(msg.params ?? {})}\n`,
+            );
+          }
+          if (isFs) {
+            writeMessage({
+              jsonrpc: "2.0",
+              id: msg.id,
+              error: {
+                code: -32601,
+                message: `Method not implemented by memoize ACP client: ${msg.method}`,
+              },
+            });
+            return;
+          }
           console.warn(
             `[cursor.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
           );
@@ -339,7 +356,14 @@ export const startCursorSession = (
         const init = (await request("initialize", {
           protocolVersion: 1,
           clientCapabilities: {
-            fs: { readTextFile: true, writeTextFile: true },
+            fs: {
+              readTextFile: true,
+              writeTextFile: true,
+              readDirectory: true,
+              createDirectory: true,
+              deleteFile: true,
+              moveFile: true,
+            },
             terminal: true,
           },
         })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -380,6 +380,23 @@ export const startGeminiSession = (
           return;
         }
         if (msg.id !== undefined) {
+          const isFs = msg.method.startsWith("fs/");
+          if (GEMINI_RPC_TRACE || isFs) {
+            process.stderr.write(
+              `[gemini.rpc] server→client request method=${msg.method} id=${msg.id} params=${JSON.stringify(msg.params ?? {})}\n`,
+            );
+          }
+          if (isFs) {
+            writeMessage({
+              jsonrpc: "2.0",
+              id: msg.id,
+              error: {
+                code: -32601,
+                message: `Method not implemented by memoize ACP client: ${msg.method}`,
+              },
+            });
+            return;
+          }
           console.warn(
             `[gemini.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
           );
@@ -446,7 +463,14 @@ export const startGeminiSession = (
         const init = (await request("initialize", {
           protocolVersion: 1,
           clientCapabilities: {
-            fs: { readTextFile: true, writeTextFile: true },
+            fs: {
+              readTextFile: true,
+              writeTextFile: true,
+              readDirectory: true,
+              createDirectory: true,
+              deleteFile: true,
+              moveFile: true,
+            },
             terminal: true,
           },
         })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -1,4 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as readline from "node:readline";
 import { Effect, Mailbox, Stream } from "effect";
 
@@ -14,6 +17,8 @@ import {
 } from "@memoize/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import { createAcpTranslator } from "./acp/translate.ts";
+import { applyPlanModePrefix } from "./planMode.ts";
 
 /**
  * Live-only handle for one Gemini conversation. Mirrors the Grok/Codex/Claude
@@ -54,295 +59,6 @@ export interface GeminiSessionHandle {
   ) => Effect.Effect<void>;
 }
 
-let itemCounter = 0;
-const nextItemId = (): AgentItemId =>
-  `i_${Date.now()}_${++itemCounter}` as AgentItemId;
-
-/**
- * Translate one ACP `session/update` payload into zero or more
- * `AgentEvent`s. The ACP v1 spec uses `"sessionUpdate"` as the
- * discriminator but the ResponseItem shape (v2+) uses `"type"` — we
- * check both so either format works with Gemini's evolving ACP impl.
- *
- * ACP v1 sessionUpdate values:
- *   agent_message_chunk, agent_thought_chunk, thinking_chunk,
- *   tool_call, tool_use, tool_result, tool_output,
- *   function_call, function_call_output,
- *   custom_tool_call, custom_tool_call_output,
- *   tool_search_call, tool_search_output,
- *   local_shell_call, web_search_call,
- *   error, agent_error
- *
- * Gemini-specific (nonstandard) type values:
- *   tool_call_update, available_commands_update
- *
- * ACP v2 ResponseItem type values (also accepted):
- *   message, function_call, custom_tool_call, tool_search_call,
- *   local_shell_call, web_search_call, image_generation_call,
- *   function_call_output, custom_tool_call_output, tool_search_output,
- *   compaction, context_compaction
- */
-const translateSessionUpdate = (update: unknown): ReadonlyArray<AgentEvent> => {
-  if (update === null || typeof update !== "object") return [];
-  const u = update as Record<string, unknown>;
-  const kind =
-    typeof u["sessionUpdate"] === "string"
-      ? (u["sessionUpdate"] as string)
-      : typeof u["type"] === "string"
-        ? (u["type"] as string)
-        : null;
-  if (kind === null) return [];
-
-  const asText = (v: unknown): string | null => {
-    if (typeof v === "string") return v;
-    if (v !== null && typeof v === "object" && "text" in v) {
-      const t = (v as { text: unknown }).text;
-      return typeof t === "string" ? t : null;
-    }
-    return null;
-  };
-
-  const extractMessageText = (content: unknown): string | null => {
-    if (!Array.isArray(content)) return asText(content);
-    const parts: string[] = [];
-    for (const item of content) {
-      if (item !== null && typeof item === "object" && "text" in item) {
-        const t = (item as Record<string, unknown>)["text"];
-        if (typeof t === "string") parts.push(t);
-      }
-    }
-    return parts.length > 0 ? parts.join("") : null;
-  };
-
-  const extractCallId = (): AgentItemId => {
-    const raw =
-      typeof u["toolCallId"] === "string"
-        ? u["toolCallId"]
-        : typeof u["call_id"] === "string"
-          ? u["call_id"]
-          : typeof u["id"] === "string"
-            ? u["id"]
-            : typeof (u as Record<string, unknown>)["callId"] === "string"
-              ? (u as Record<string, unknown>)["callId"]
-              : null;
-    return raw !== null ? (raw as AgentItemId) : nextItemId();
-  };
-
-  const extractToolName = (): string => {
-    return typeof u["tool"] === "string"
-      ? (u["tool"] as string)
-      : typeof u["name"] === "string"
-        ? (u["name"] as string)
-        : typeof u["kind"] === "string"
-          ? (u["kind"] as string)
-          : typeof u["execution"] === "string"
-            ? (u["execution"] as string)
-            : typeof u["command"] === "string"
-              ? (u["command"] as string)
-              : "tool";
-  };
-
-  const extractInput = (): unknown => {
-    if (u["input"] !== undefined) return u["input"];
-    if (u["arguments"] !== undefined) {
-      const a = u["arguments"];
-      if (typeof a === "string") {
-        try {
-          return JSON.parse(a);
-        } catch {
-          return a;
-        }
-      }
-      return a;
-    }
-    if (u["command"] !== undefined) return { command: u["command"] };
-    if (u["cmd"] !== undefined) return { command: u["cmd"] };
-    if (Array.isArray(u["locations"]) && u["locations"].length > 0) {
-      const loc = (u["locations"] as Array<Record<string, unknown>>)[0];
-      if (loc !== undefined && typeof loc["path"] === "string") return { path: loc["path"] };
-    }
-    return null;
-  };
-
-  const extractOutput = (): unknown => {
-    if (u["output"] !== undefined) {
-      const o = u["output"];
-      if (o !== null && typeof o === "object" && "content" in o) {
-        return (o as Record<string, unknown>)["content"] ?? o;
-      }
-      return o;
-    }
-    if (u["content"] !== undefined) return u["content"];
-    if (u["result"] !== undefined) return u["result"];
-    return null;
-  };
-
-  const normalizeGeminiTool = (rawKind: string): string => {
-    switch (rawKind) {
-      case "read": return "Read";
-      case "bash": return "Bash";
-      case "edit": return "Edit";
-      case "write": return "Write";
-      case "grep": return "Grep";
-      case "glob": return "Glob";
-      case "search": return "WebSearch";
-      case "fetch": return "WebFetch";
-      default: return rawKind.charAt(0).toUpperCase() + rawKind.slice(1);
-    }
-  };
-
-  const buildGeminiInput = (u: Record<string, unknown>, geminiKind: string | null): unknown => {
-    const input: Record<string, unknown> = {};
-    if (typeof u["title"] === "string") {
-      input["description"] = u["title"];
-    }
-    switch (geminiKind) {
-      case "read":
-      case "edit":
-      case "write": {
-        const locations = u["locations"];
-        if (Array.isArray(locations) && locations.length > 0) {
-          const loc = locations[0];
-          if (loc !== null && typeof loc === "object" && typeof (loc as Record<string, unknown>)["path"] === "string") {
-            input["file_path"] = (loc as Record<string, unknown>)["path"];
-          }
-        }
-        break;
-      }
-      case "bash": {
-        if (typeof u["command"] === "string") input["command"] = u["command"];
-        else if (typeof u["cmd"] === "string") input["command"] = u["cmd"];
-        break;
-      }
-      case "grep":
-      case "glob": {
-        if (typeof u["pattern"] === "string") input["pattern"] = u["pattern"];
-        if (typeof u["path"] === "string") input["path"] = u["path"];
-        break;
-      }
-    }
-    return Object.keys(input).length > 0 ? input : null;
-  };
-
-  switch (kind) {
-    case "agent_message_chunk":
-    case "message": {
-      const text =
-        kind === "message"
-          ? extractMessageText(u["content"])
-          : asText(u["content"]);
-      if (text === null || text.length === 0) return [];
-      return [
-        {
-          _tag: "AssistantMessage",
-          itemId: nextItemId(),
-          text,
-        },
-      ];
-    }
-    case "agent_thought_chunk":
-    case "agent_reasoning_chunk":
-    case "thinking_chunk":
-    case "reasoning": {
-      const text = asText(u["content"]);
-      if (text === null || text.length === 0) return [];
-      return [
-        {
-          _tag: "Thinking",
-          itemId: nextItemId(),
-          text,
-          redacted: false,
-        },
-      ];
-    }
-    case "tool_call":
-    case "tool_use":
-    case "function_call":
-    case "custom_tool_call":
-    case "tool_search_call":
-    case "local_shell_call":
-    case "web_search_call":
-    case "image_generation_call": {
-      const geminiToolKind = typeof u["kind"] === "string" ? (u["kind"] as string) : null;
-      if (geminiToolKind === "think") return [];
-      const toolName = geminiToolKind !== null ? normalizeGeminiTool(geminiToolKind) : extractToolName();
-      const input = geminiToolKind !== null ? buildGeminiInput(u, geminiToolKind) : extractInput();
-      console.log(
-        `[gemini.translate.tool] initCallId=${extractCallId()} tool=${toolName} input=${JSON.stringify(input).slice(0, 2048)}`,
-      );
-      return [
-        {
-          _tag: "ToolUse" as const,
-          itemId: extractCallId(),
-          tool: toolName,
-          input,
-        },
-      ];
-    }
-    case "tool_call_update":
-    case "available_commands_update":
-      return [];
-    case "tool_result":
-    case "tool_output":
-    case "function_call_output":
-    case "custom_tool_call_output":
-    case "tool_search_output": {
-      console.log(
-        `[gemini.translate.result] kind=${kind} raw=${JSON.stringify(u).slice(0, 4096)}`,
-      );
-      const isError = u["isError"] === true || u["is_error"] === true;
-      const toolResult = {
-        _tag: "ToolResult" as const,
-        itemId: extractCallId(),
-        output: extractOutput(),
-        isError,
-      };
-      console.log(
-        `[gemini.translate.result] → ToolResult itemId=${toolResult.itemId} output=${JSON.stringify(toolResult.output).slice(0, 2048)}`,
-      );
-      return [toolResult];
-    }
-    case "error":
-    case "agent_error": {
-      const detail =
-        typeof u["message"] === "string" && (u["message"] as string).length > 0
-          ? (u["message"] as string)
-          : typeof u["error"] === "string"
-            ? (u["error"] as string)
-            : typeof u["details"] === "string"
-              ? (u["details"] as string)
-              : typeof u["data"] === "string"
-                ? (u["data"] as string)
-                : null;
-      const message =
-        detail !== null && detail.length > 0
-          ? detail
-          : (() => {
-              try {
-                const serialized = JSON.stringify(u);
-                return serialized === "{}"
-                  ? "Gemini agent reported an error with no detail."
-                  : `Gemini agent error: ${serialized}`;
-              } catch {
-                return "Gemini agent reported an error.";
-              }
-            })();
-      return [{ _tag: "Error", message }];
-    }
-    case "available_commands_update":
-      return [];
-    default:
-      console.warn(
-        `[gemini.translate] unknown sessionUpdate/type=${kind} payload=${((): string => {
-          try {
-            const s = JSON.stringify(u).slice(0, 2048);
-            return s.length > 0 ? s : "(empty)";
-          } catch { return "(unserialisable)"; }
-        })()}`,
-      );
-      return [];
-  }
-};
 
 interface JsonRpcError {
   readonly code?: number;
@@ -436,6 +152,63 @@ const formatRpcError = (
 };
 
 /**
+ * Add `cwd` to `~/.gemini/trustedFolders.json` so the CLI's folder-trust
+ * check passes. Without this, Gemini logs `Skipping project agents due to
+ * untrusted folder` and disables project hooks / project agents / ripgrep.
+ *
+ * File format: `{ "<absolute-path>": "TRUST_FOLDER" }` (per the official
+ * gemini-cli docs, docs/cli/trusted-folders.md). We always merge — never
+ * overwrite — because the user may have trusted other folders manually.
+ *
+ * Best-effort: if any fs op fails the CLI just stays in safe mode, so we
+ * swallow errors via `Effect.ignore`.
+ */
+const ensureGeminiFolderTrusted = (cwd: string): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const home = os.homedir();
+    if (home.length === 0) return;
+    const geminiDir = path.join(home, ".gemini");
+    const trustedFile = path.join(geminiDir, "trustedFolders.json");
+    const absCwd = path.resolve(cwd);
+
+    const current = yield* Effect.tryPromise(() =>
+      fs.promises.readFile(trustedFile, "utf-8"),
+    ).pipe(
+      Effect.flatMap((raw) =>
+        Effect.try(() => {
+          const parsed: unknown = JSON.parse(raw);
+          if (
+            parsed === null ||
+            typeof parsed !== "object" ||
+            Array.isArray(parsed)
+          ) {
+            return {} as Record<string, string>;
+          }
+          return parsed as Record<string, string>;
+        }),
+      ),
+      Effect.catchAll(() => Effect.succeed({} as Record<string, string>)),
+    );
+
+    if (current[absCwd] === "TRUST_FOLDER") return;
+
+    const next = { ...current, [absCwd]: "TRUST_FOLDER" };
+
+    yield* Effect.tryPromise(() =>
+      fs.promises.mkdir(geminiDir, { recursive: true, mode: 0o700 }),
+    ).pipe(Effect.ignore);
+
+    yield* Effect.tryPromise(() =>
+      fs.promises.writeFile(trustedFile, JSON.stringify(next, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      }),
+    ).pipe(Effect.ignore);
+
+    yield* Effect.logInfo(`gemini: trusted folder ${absCwd}`);
+  });
+
+/**
  * Spin up a Gemini conversation backed by a persistent ACP child process.
  * The handshake (`initialize` → `authenticate` → `session/new`) runs once
  * synchronously inside `start()`; auth or transport failures surface there
@@ -488,6 +261,13 @@ export const startGeminiSession = (
       mode: "sdk",
     });
 
+    yield* ensureGeminiFolderTrusted(cwd);
+
+    // Per-session translator coalesces agent_message_chunk deltas into
+    // one AssistantMessage per burst so the renderer doesn't show one
+    // bubble per token.
+    const translator = createAcpTranslator("gemini");
+
     let child: ChildProcessWithoutNullStreams;
     try {
       child = spawn(geminiPath, ["--experimental-acp"], {
@@ -523,8 +303,10 @@ export const startGeminiSession = (
       method: string,
       params: unknown,
       timeoutMs = 30_000,
+      onAssignedId?: (id: number) => void,
     ): Promise<unknown> => {
       const id = nextRpcId++;
+      onAssignedId?.(id);
       return new Promise<unknown>((resolve, reject) => {
         const timer = setTimeout(() => {
           pending.delete(id);
@@ -543,6 +325,30 @@ export const startGeminiSession = (
 
     const notify = (method: string, params: unknown): void => {
       writeMessage({ jsonrpc: "2.0", method, params });
+    };
+
+    /**
+     * Currently in-flight `session/prompt` rpc id. We track this so
+     * `interrupt()` can both (a) send `session/cancel` to the agent AND
+     * (b) force-reject the pending request, which unblocks the `inflight`
+     * promise chain so subsequent `send()` calls don't queue behind a
+     * dead request.
+     */
+    let currentPromptRpcId: number | null = null;
+    const rejectCurrentPrompt = (reason: string): void => {
+      const id = currentPromptRpcId;
+      if (id === null) return;
+      const resolver = pending.get(id);
+      if (resolver === undefined) return;
+      pending.delete(id);
+      clearTimeout(resolver.timer);
+      currentPromptRpcId = null;
+      if (GEMINI_RPC_TRACE) {
+        process.stderr.write(
+          `[gemini.rpc.cancel] force-reject id=${id} method=${resolver.method} reason=${reason}\n`,
+        );
+      }
+      resolver.reject(new Error(reason));
     };
 
     rl.on("line", (line: string) => {
@@ -567,7 +373,7 @@ export const startGeminiSession = (
         if (msg.method === "session/update") {
           const update = msg.params?.update;
           if (update !== undefined) {
-            for (const ev of translateSessionUpdate(update)) {
+            for (const ev of translator.translate(update)) {
               events.unsafeOffer(ev);
             }
           }
@@ -711,31 +517,59 @@ export const startGeminiSession = (
     const enqueuePrompt = (text: string): void => {
       const sid = acpSessionId;
       if (sid === null) return;
+      // Plan-mode emulation: gemini ACP has no native read-only switch, so
+      // prepend a developer-instructions block while plan mode is active.
+      const promptText = applyPlanModePrefix(currentMode, text);
       inflight = inflight
         .then(async () => {
           if (closed) return;
+          if (GEMINI_RPC_TRACE) {
+            process.stderr.write(
+              `[gemini.prompt] enqueue len=${promptText.length} mode=${currentMode}\n`,
+            );
+          }
           try {
             await request(
               "session/prompt",
               {
                 sessionId: sid,
-                prompt: [{ type: "text", text }],
+                prompt: [{ type: "text", text: promptText }],
                 _meta: {
                   permissionMode: currentMode,
                   ...(input.model !== undefined ? { model: input.model } : {}),
                 },
               },
               5 * 60_000,
+              (id) => {
+                currentPromptRpcId = id;
+              },
             );
+            if (GEMINI_RPC_TRACE) {
+              process.stderr.write(`[gemini.prompt] completed\n`);
+            }
           } catch (cause) {
-            if (!closed) {
+            const reason = cause instanceof Error ? cause.message : String(cause);
+            if (GEMINI_RPC_TRACE) {
+              process.stderr.write(`[gemini.prompt] failed: ${reason}\n`);
+            }
+            // Cancellation is a clean stop, not an error condition — the
+            // user already knows they interrupted. Surface other failures
+            // (timeouts, transport errors, server-side rejections) so the
+            // chat bubble shows them.
+            const isCancellation = /cancel|interrupt/i.test(reason);
+            if (!closed && !isCancellation) {
               events.unsafeOffer({
                 _tag: "Error",
-                message: cause instanceof Error ? cause.message : String(cause),
+                message: reason,
               });
             }
           } finally {
+            currentPromptRpcId = null;
+            // Drain any buffered assistant text from the translator so the
+            // final delta lands as a normal AssistantMessage instead of
+            // sitting unobserved in memory.
             if (!closed) {
+              for (const ev of translator.flush()) events.unsafeOffer(ev);
               events.unsafeOffer({ _tag: "Status", status: "idle" });
             }
           }
@@ -762,9 +596,20 @@ export const startGeminiSession = (
         Effect.sync(() => {
           const sid = acpSessionId;
           if (sid === null) return;
+          if (GEMINI_RPC_TRACE) {
+            process.stderr.write(
+              `[gemini.interrupt] sid=${sid} pendingPrompt=${currentPromptRpcId ?? "(none)"}\n`,
+            );
+          }
           // Best-effort cancel; do NOT SIGINT the child or the persistent
           // session dies for every subsequent send.
           notify("session/cancel", { sessionId: sid });
+          // Force-reject the in-flight `session/prompt` request so the
+          // `inflight` promise chain unblocks. Without this, if Gemini's
+          // CLI doesn't honour `session/cancel` (or responds slowly), the
+          // user's next message queues behind a dead request and the
+          // session feels stuck.
+          rejectCurrentPrompt("Interrupted by user");
         }),
       close: () =>
         Effect.gen(function* () {

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -14,6 +14,8 @@ import {
 } from "@memoize/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import { createAcpTranslator } from "./acp/translate.ts";
+import { applyPlanModePrefix } from "./planMode.ts";
 
 /**
  * Live-only handle for one Grok conversation. Mirrors Codex/Claude handle
@@ -52,248 +54,6 @@ export interface GrokSessionHandle {
   ) => Effect.Effect<void>;
 }
 
-let itemCounter = 0;
-const nextItemId = (): AgentItemId =>
-  `i_${Date.now()}_${++itemCounter}` as AgentItemId;
-
-/**
- * Translate one ACP `session/update` payload into zero or more
- * `AgentEvent`s. The ACP v1 spec uses `"sessionUpdate"` as the
- * discriminator but the ResponseItem shape (v2+) uses `"type"` — we
- * check both so either format works.
- *
- * ACP v1 sessionUpdate values:
- *   agent_message_chunk, agent_thought_chunk, thinking_chunk,
- *   tool_call, tool_use, tool_result, tool_output,
- *   function_call, function_call_output,
- *   custom_tool_call, custom_tool_call_output,
- *   tool_search_call, tool_search_output,
- *   local_shell_call, web_search_call,
- *   error, agent_error
- *
- * Gemini-specific (nonstandard) type values:
- *   tool_call_update, available_commands_update
- *
- * ACP v2 ResponseItem type values (also accepted):
- *   message, function_call, custom_tool_call, tool_search_call,
- *   local_shell_call, web_search_call, image_generation_call,
- *   function_call_output, custom_tool_call_output, tool_search_output,
- *   compaction, context_compaction
- */
-const translateSessionUpdate = (update: unknown): ReadonlyArray<AgentEvent> => {
-  if (update === null || typeof update !== "object") return [];
-  const u = update as Record<string, unknown>;
-  const kind =
-    typeof u["sessionUpdate"] === "string"
-      ? (u["sessionUpdate"] as string)
-      : typeof u["type"] === "string"
-        ? (u["type"] as string)
-        : null;
-  if (kind === null) return [];
-
-  const asText = (v: unknown): string | null => {
-    if (typeof v === "string") return v;
-    if (v !== null && typeof v === "object" && "text" in v) {
-      const t = (v as { text: unknown }).text;
-      return typeof t === "string" ? t : null;
-    }
-    return null;
-  };
-
-  const extractMessageText = (content: unknown): string | null => {
-    if (!Array.isArray(content)) return asText(content);
-    const parts: string[] = [];
-    for (const item of content) {
-      if (item !== null && typeof item === "object" && "text" in item) {
-        const t = (item as Record<string, unknown>)["text"];
-        if (typeof t === "string") parts.push(t);
-      }
-    }
-    return parts.length > 0 ? parts.join("") : null;
-  };
-
-  const extractCallId = (): AgentItemId => {
-    const raw =
-      typeof u["toolCallId"] === "string"
-        ? u["toolCallId"]
-        : typeof u["call_id"] === "string"
-          ? u["call_id"]
-          : typeof u["id"] === "string"
-            ? u["id"]
-            : typeof (u as Record<string, unknown>)["callId"] === "string"
-              ? (u as Record<string, unknown>)["callId"]
-              : null;
-    return raw !== null ? (raw as AgentItemId) : nextItemId();
-  };
-
-  const extractToolName = (): string => {
-    return typeof u["tool"] === "string"
-      ? (u["tool"] as string)
-      : typeof u["name"] === "string"
-        ? (u["name"] as string)
-        : typeof u["execution"] === "string"
-          ? (u["execution"] as string)
-          : typeof u["command"] === "string"
-            ? (u["command"] as string)
-            : "tool";
-  };
-
-  const extractInput = (): unknown => {
-    if (u["input"] !== undefined) return u["input"];
-    if (u["arguments"] !== undefined) {
-      const a = u["arguments"];
-      if (typeof a === "string") {
-        try {
-          return JSON.parse(a);
-        } catch {
-          return a;
-        }
-      }
-      return a;
-    }
-    if (u["command"] !== undefined) return { command: u["command"] };
-    return null;
-  };
-
-  const extractOutput = (): unknown => {
-    if (u["output"] !== undefined) {
-      const o = u["output"];
-      if (o !== null && typeof o === "object" && "content" in o) {
-        return (o as Record<string, unknown>)["content"] ?? o;
-      }
-      return o;
-    }
-    if (u["content"] !== undefined) return u["content"];
-    if (u["result"] !== undefined) return u["result"];
-    return null;
-  };
-
-  switch (kind) {
-    case "agent_message_chunk":
-    case "message": {
-      const text =
-        kind === "message"
-          ? extractMessageText(u["content"])
-          : asText(u["content"]);
-      if (text === null || text.length === 0) return [];
-      return [
-        {
-          _tag: "AssistantMessage",
-          itemId: nextItemId(),
-          text,
-        },
-      ];
-    }
-    case "agent_thought_chunk":
-    case "agent_reasoning_chunk":
-    case "thinking_chunk":
-    case "reasoning": {
-      const text = asText(u["content"]);
-      if (text === null || text.length === 0) return [];
-      return [
-        {
-          _tag: "Thinking",
-          itemId: nextItemId(),
-          text,
-          redacted: false,
-        },
-      ];
-    }
-    case "tool_call":
-    case "tool_use":
-    case "tool_call_update":
-    case "function_call":
-    case "custom_tool_call":
-    case "tool_search_call":
-    case "local_shell_call":
-    case "web_search_call":
-    case "image_generation_call": {
-      if (GROK_RPC_TRACE) {
-        process.stderr.write(
-          `[grok.translate.tool] kind=${kind} payload=${JSON.stringify(u).slice(0, 4096)}\n`,
-        );
-      }
-      const toolUse = {
-        _tag: "ToolUse" as const,
-        itemId: extractCallId(),
-        tool: extractToolName(),
-        input: extractInput(),
-      };
-      if (GROK_RPC_TRACE) {
-        process.stderr.write(
-          `[grok.translate.tool] → ToolUse itemId=${toolUse.itemId} tool=${toolUse.tool} input=${JSON.stringify(toolUse.input).slice(0, 2048)}\n`,
-        );
-      }
-      return [toolUse];
-    }
-    case "tool_result":
-    case "tool_output":
-    case "function_call_output":
-    case "custom_tool_call_output":
-    case "tool_search_output": {
-      if (GROK_RPC_TRACE) {
-        process.stderr.write(
-          `[grok.translate.result] kind=${kind} payload=${JSON.stringify(u).slice(0, 4096)}\n`,
-        );
-      }
-      const isError = u["isError"] === true || u["is_error"] === true;
-      const toolResult = {
-        _tag: "ToolResult" as const,
-        itemId: extractCallId(),
-        output: extractOutput(),
-        isError,
-      };
-      if (GROK_RPC_TRACE) {
-        process.stderr.write(
-          `[grok.translate.result] → ToolResult itemId=${toolResult.itemId} output=${JSON.stringify(toolResult.output).slice(0, 2048)}\n`,
-        );
-      }
-      return [toolResult];
-    }
-    case "error":
-    case "agent_error": {
-      // Pull useful detail from multiple possible fields. ACP doesn't
-      // pin the error payload shape, and grok itself sometimes nests the
-      // real reason under `data`/`details`/`error`.
-      const detail =
-        typeof u["message"] === "string" && (u["message"] as string).length > 0
-          ? (u["message"] as string)
-          : typeof u["error"] === "string"
-            ? (u["error"] as string)
-            : typeof u["details"] === "string"
-              ? (u["details"] as string)
-              : typeof u["data"] === "string"
-                ? (u["data"] as string)
-                : null;
-      const message =
-        detail !== null && detail.length > 0
-          ? detail
-          : (() => {
-              try {
-                const serialized = JSON.stringify(u);
-                return serialized === "{}"
-                  ? "Grok agent reported an error with no detail."
-                  : `Grok agent error: ${serialized}`;
-              } catch {
-                return "Grok agent reported an error.";
-              }
-            })();
-      return [{ _tag: "Error", message }];
-    }
-    case "available_commands_update":
-      return [];
-    default:
-      console.warn(
-        `[grok.translate] unknown sessionUpdate/type=${kind} payload=${((): string => {
-          try {
-            const s = JSON.stringify(u).slice(0, 2048);
-            return s.length > 0 ? s : "(empty)";
-          } catch { return "(unserialisable)"; }
-        })()}`,
-      );
-      return [];
-  }
-};
 
 interface JsonRpcError {
   readonly code?: number;
@@ -417,6 +177,11 @@ export const startGrokSession = (
       mode: "sdk",
     });
 
+    // Per-session translator coalesces agent_message_chunk deltas into
+    // one AssistantMessage per burst so the renderer doesn't show one
+    // bubble per token.
+    const translator = createAcpTranslator("grok");
+
     let child: ChildProcessWithoutNullStreams;
     try {
       child = spawn(grokPath, ["agent", "stdio"], {
@@ -452,8 +217,10 @@ export const startGrokSession = (
       method: string,
       params: unknown,
       timeoutMs = 30_000,
+      onAssignedId?: (id: number) => void,
     ): Promise<unknown> => {
       const id = nextRpcId++;
+      onAssignedId?.(id);
       return new Promise<unknown>((resolve, reject) => {
         const timer = setTimeout(() => {
           pending.delete(id);
@@ -475,6 +242,28 @@ export const startGrokSession = (
       writeMessage({ jsonrpc: "2.0", method, params });
     };
 
+    /**
+     * Currently in-flight `session/prompt` rpc id. See gemini.ts for the
+     * rationale — interrupt needs to force-reject the pending request so
+     * the `inflight` chain unblocks.
+     */
+    let currentPromptRpcId: number | null = null;
+    const rejectCurrentPrompt = (reason: string): void => {
+      const id = currentPromptRpcId;
+      if (id === null) return;
+      const resolver = pending.get(id);
+      if (resolver === undefined) return;
+      pending.delete(id);
+      clearTimeout(resolver.timer);
+      currentPromptRpcId = null;
+      if (GROK_RPC_TRACE) {
+        process.stderr.write(
+          `[grok.rpc.cancel] force-reject id=${id} method=${resolver.method} reason=${reason}\n`,
+        );
+      }
+      resolver.reject(new Error(reason));
+    };
+
     rl.on("line", (line: string) => {
       if (line.trim().length === 0) return;
       if (GROK_RPC_TRACE) process.stderr.write(`[grok.rpc.recv] ${line}\n`);
@@ -494,7 +283,7 @@ export const startGrokSession = (
         if (msg.method === "session/update") {
           const update = msg.params?.update;
           if (update !== undefined) {
-            for (const ev of translateSessionUpdate(update)) {
+            for (const ev of translator.translate(update)) {
               events.unsafeOffer(ev);
             }
           }
@@ -648,15 +437,23 @@ export const startGrokSession = (
     const enqueuePrompt = (text: string): void => {
       const sid = acpSessionId;
       if (sid === null) return;
+      // Plan-mode emulation: grok ACP has no native read-only switch, so
+      // prepend a developer-instructions block while plan mode is active.
+      const promptText = applyPlanModePrefix(currentMode, text);
       inflight = inflight
         .then(async () => {
           if (closed) return;
+          if (GROK_RPC_TRACE) {
+            process.stderr.write(
+              `[grok.prompt] enqueue len=${promptText.length} mode=${currentMode}\n`,
+            );
+          }
           try {
             await request(
               "session/prompt",
               {
                 sessionId: sid,
-                prompt: [{ type: "text", text }],
+                prompt: [{ type: "text", text: promptText }],
                 // Server may ignore unknown keys; pass mode + model as
                 // metadata so a future ACP rev can honour them without a
                 // driver change.
@@ -666,16 +463,32 @@ export const startGrokSession = (
                 },
               },
               5 * 60_000,
+              (id) => {
+                currentPromptRpcId = id;
+              },
             );
+            if (GROK_RPC_TRACE) {
+              process.stderr.write(`[grok.prompt] completed\n`);
+            }
           } catch (cause) {
-            if (!closed) {
+            const reason = cause instanceof Error ? cause.message : String(cause);
+            if (GROK_RPC_TRACE) {
+              process.stderr.write(`[grok.prompt] failed: ${reason}\n`);
+            }
+            const isCancellation = /cancel|interrupt/i.test(reason);
+            if (!closed && !isCancellation) {
               events.unsafeOffer({
                 _tag: "Error",
-                message: cause instanceof Error ? cause.message : String(cause),
+                message: reason,
               });
             }
           } finally {
+            currentPromptRpcId = null;
+            // Drain any buffered assistant text from the translator so the
+            // final delta lands as a normal AssistantMessage instead of
+            // sitting unobserved in memory.
             if (!closed) {
+              for (const ev of translator.flush()) events.unsafeOffer(ev);
               events.unsafeOffer({ _tag: "Status", status: "idle" });
             }
           }
@@ -704,11 +517,19 @@ export const startGrokSession = (
         Effect.sync(() => {
           const sid = acpSessionId;
           if (sid === null) return;
+          if (GROK_RPC_TRACE) {
+            process.stderr.write(
+              `[grok.interrupt] sid=${sid} pendingPrompt=${currentPromptRpcId ?? "(none)"}\n`,
+            );
+          }
           // Best-effort cancel. We deliberately do NOT SIGINT the child —
           // that would kill the persistent agent and end every future send
           // for this session. If `session/cancel` isn't recognised the
           // server replies with an error we ignore.
           notify("session/cancel", { sessionId: sid });
+          // Force-reject the in-flight prompt so the inflight chain
+          // unblocks even if grok's ACP doesn't honour `session/cancel`.
+          rejectCurrentPrompt("Interrupted by user");
         }),
       close: () =>
         Effect.gen(function* () {

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -79,6 +79,40 @@ type PendingResolver = {
 const GROK_RPC_TRACE = process.env.MEMOIZE_DEBUG_GROK === "1";
 
 /**
+ * Detect fatal authorization failures from the grok agent's own stderr.
+ * When the cached token is missing/expired/insufficient (SuperGrok Heavy
+ * tier required), the agent prints:
+ *   "worker quit with fatal: Transport channel closed, when Auth(AuthorizationRequired)"
+ * and dies. We watch for this in real time so we can fail the in-flight
+ * prompt *immediately* instead of waiting for the 5-minute timeout, and
+ * we can surface a clean actionable message instead of the raw timeout.
+ */
+const isFatalAuthError = (text: string): boolean => {
+  const t = text.toLowerCase();
+  return (
+    t.includes("authorizationrequired") ||
+    t.includes("auth(authorizationrequired)") ||
+    (t.includes("worker quit with fatal") && t.includes("auth")) ||
+    (t.includes("transport channel closed") && t.includes("auth"))
+  );
+};
+
+/**
+ * Turn a raw stderr snippet (from the grok binary) into a user-friendly
+ * error message. When we see the known fatal auth line we produce a clear,
+ * actionable string instead of the confusing "timed out after 300000ms"
+ * that the user was getting.
+ */
+const friendlyErrorFromStderr = (rawTail: string): string | null => {
+  if (!isFatalAuthError(rawTail)) return null;
+  return (
+    "Grok authentication failed (AuthorizationRequired). " +
+    "Your login may have expired or your account does not have the SuperGrok Heavy tier required for the coding agent. " +
+    "Run `grok login` again, then retry the turn. If the problem persists, check your plan at https://x.ai/."
+  );
+};
+
+/**
  * Build a human-readable error from a JSON-RPC error envelope. ACP servers
  * commonly stash the real failure in `error.data` and leave `error.message`
  * as a generic "Internal error" — surfacing only `error.message` would
@@ -225,6 +259,11 @@ export const startGrokSession = (
         const timer = setTimeout(() => {
           pending.delete(id);
           const trimmedStderr = stderrTail.trim();
+          const friendly = friendlyErrorFromStderr(trimmedStderr);
+          if (friendly !== null) {
+            reject(new Error(friendly));
+            return;
+          }
           const detail =
             trimmedStderr.length > 0 ? ` — stderr: ${trimmedStderr}` : "";
           reject(
@@ -290,10 +329,36 @@ export const startGrokSession = (
           return;
         }
         if (msg.id !== undefined) {
-          // Server→client request. Permission prompts likely land here once
-          // ACP spec is verified; for now log and ignore so the turn either
-          // proceeds or times out grok-side. Wiring to PermissionService is
-          // an open follow-up.
+          // Server→client request (fs/*, permission prompts, etc.).
+          // We now:
+          //  - Log verbosely under the existing GROK_RPC_TRACE flag so the
+          //    user (and we) can see exactly which tools Grok tries to call
+          //    on the client ("add some logs").
+          //  - For fs/* methods we reply with a clean "not implemented yet"
+          //    error so the agent does not hang waiting for a response.
+          //    This often makes Grok fall back to its own well-named internal
+          //    tools (list_dir etc.) which our translator now renders nicely.
+          const isFs = msg.method.startsWith("fs/");
+          if (GROK_RPC_TRACE || isFs) {
+            process.stderr.write(
+              `[grok.rpc] server→client request method=${msg.method} id=${msg.id} params=${JSON.stringify(msg.params ?? {})}\n`,
+            );
+          }
+          if (isFs) {
+            // Reply immediately so the agent can continue instead of timing
+            // out on an unhandled client capability.
+            writeMessage({
+              jsonrpc: "2.0",
+              id: msg.id,
+              error: {
+                code: -32601,
+                message: `Method not implemented by memoize ACP client: ${msg.method}`,
+              },
+            });
+            return;
+          }
+          // For everything else (permission requests, etc.) we still just
+          // warn and let the server time out or proceed.
           console.warn(
             `[grok.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
           );
@@ -337,6 +402,30 @@ export const startGrokSession = (
       // grok's generic JSON-RPC "Internal error".
       stderrTail = (stderrTail + chunk).slice(-4096);
       process.stderr.write(`[grok.stderr] ${chunk}`);
+
+      // Fast-path: if the agent itself reports a fatal auth failure
+      // (token expired / wrong tier), kill the in-flight prompt right now
+      // instead of letting the 5-minute timeout fire. This is what the
+      // user meant by "not auto stopping".
+      if (isFatalAuthError(chunk) || isFatalAuthError(stderrTail)) {
+        if (currentPromptRpcId !== null) {
+          rejectCurrentPrompt(
+            "Grok authentication failed (AuthorizationRequired). " +
+              "Your cached login may have expired or your account lacks the SuperGrok Heavy tier required to use the agent. " +
+              "Run `grok login` again, then retry.",
+          );
+        }
+        // Surface a clean error immediately so the UI can stop the spinner
+        // and show the auth-classified error card with the "Open settings" button.
+        if (!closed) {
+          events.unsafeOffer({
+            _tag: "Error",
+            message:
+              "Grok authentication failed (AuthorizationRequired). " +
+              "Run `grok login` again or verify that your account has the SuperGrok Heavy plan.",
+          });
+        }
+      }
     });
 
     child.on("error", (err) => {
@@ -347,9 +436,13 @@ export const startGrokSession = (
     child.on("close", (code, signal) => {
       rl.close();
       const trimmedStderr = stderrTail.trim();
-      const exitDetail = trimmedStderr.length > 0
-        ? `Grok ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${trimmedStderr}`
-        : `Grok ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;
+      const friendly = friendlyErrorFromStderr(trimmedStderr);
+      const exitDetail =
+        friendly !== null
+          ? friendly
+          : trimmedStderr.length > 0
+            ? `Grok ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${trimmedStderr}`
+            : `Grok ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;
       for (const { reject, timer } of pending.values()) {
         clearTimeout(timer);
         reject(new Error(exitDetail));
@@ -367,7 +460,14 @@ export const startGrokSession = (
         const init = (await request("initialize", {
           protocolVersion: 1,
           clientCapabilities: {
-            fs: { readTextFile: true, writeTextFile: true },
+            fs: {
+              readTextFile: true,
+              writeTextFile: true,
+              readDirectory: true,
+              createDirectory: true,
+              deleteFile: true,
+              moveFile: true,
+            },
             terminal: true,
           },
         })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };

--- a/apps/server/src/provider/drivers/planMode.ts
+++ b/apps/server/src/provider/drivers/planMode.ts
@@ -1,0 +1,32 @@
+import type { PermissionMode } from "@memoize/wire";
+
+/**
+ * Developer-instructions prefix that emulates plan mode for providers that
+ * don't have a native equivalent. The Claude Agent SDK has `permissionMode:
+ * "plan"`, Cursor's ACP has `setSessionMode("plan")`, but Codex/Grok/Gemini
+ * don't expose a runtime read-only switch — so we prepend this block to the
+ * user's prompt while plan mode is active.
+ *
+ * The model is still free to ignore it, which is why we ALSO keep
+ * `RuntimeMode: "approval-required"` as the safety net for any tool call
+ * that wants to mutate state.
+ */
+export const PLAN_MODE_INSTRUCTIONS =
+  "PLAN MODE — you are in read-only planning mode. Investigate the " +
+  "codebase, ask clarifying questions if needed, then propose a concrete " +
+  "plan. DO NOT modify files, run mutating commands, or invoke any tool " +
+  "that writes to disk or the network. When you have a complete plan, " +
+  "present it for approval and wait for the user to confirm before " +
+  "exiting plan mode.";
+
+/**
+ * Wrap a user-supplied prompt with the plan-mode developer-instructions
+ * prefix iff plan mode is active. No-op for `default` / `acceptEdits`.
+ */
+export const applyPlanModePrefix = (
+  permissionMode: PermissionMode,
+  text: string,
+): string =>
+  permissionMode === "plan"
+    ? `${PLAN_MODE_INSTRUCTIONS}\n\n---\n\n${text}`
+    : text;

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -79,6 +79,49 @@ export type PermissionMode = typeof PermissionMode.Type;
 export const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
 
 /**
+ * Canonical reasoning effort levels exposed to the user. Providers map these
+ * to their native concept:
+ *   - Claude → `maxThinkingTokens` (low=5k, medium=15k, high=60k)
+ *   - Codex → `reasoning_effort` enum (low/medium/high pass through)
+ *   - Gemini Pro → `thinkingConfig.thinkingBudget` (low=4k, medium=16k, high=32k)
+ *
+ * Providers/models that don't support thinking simply omit the descriptor
+ * from `ModelDescriptor.optionDescriptors`, which hides the FE picker.
+ */
+export const ReasoningLevel = Schema.Literal("low", "medium", "high");
+export type ReasoningLevel = typeof ReasoningLevel.Type;
+
+/**
+ * A single UI control a model exposes. The renderer renders these
+ * dynamically from `ModelDescriptor.optionDescriptors`, so adding a new
+ * per-model knob is a wire change + driver change — no FE switch needed.
+ */
+export const SelectOptionDescriptor = Schema.Struct({
+  kind: Schema.Literal("select"),
+  id: Schema.String,
+  label: Schema.String,
+  options: Schema.Array(
+    Schema.Struct({ id: Schema.String, label: Schema.String }),
+  ),
+  defaultId: Schema.optional(Schema.String),
+});
+export type SelectOptionDescriptor = typeof SelectOptionDescriptor.Type;
+
+export const BooleanOptionDescriptor = Schema.Struct({
+  kind: Schema.Literal("boolean"),
+  id: Schema.String,
+  label: Schema.String,
+  defaultValue: Schema.optional(Schema.Boolean),
+});
+export type BooleanOptionDescriptor = typeof BooleanOptionDescriptor.Type;
+
+export const OptionDescriptor = Schema.Union(
+  SelectOptionDescriptor,
+  BooleanOptionDescriptor,
+);
+export type OptionDescriptor = typeof OptionDescriptor.Type;
+
+/**
  * Per-provider verdict on whether the installed CLI is new enough for the
  * SDK we ship against.
  *
@@ -248,6 +291,36 @@ const ThinkingEvent = Schema.TaggedStruct("Thinking", {
   parentItemId: Schema.optional(AgentItemId),
 });
 
+/**
+ * Normalized Tool-Call Contract
+ * -----------------------------
+ * All drivers emit `ToolUseEvent` / `ToolResultEvent` with the canonical
+ * shape Claude produces. The renderer at
+ * `apps/renderer/src/components/tool-row.tsx` switches on `tool` and reads
+ * specific keys out of `input` — to keep every provider's row rendering
+ * identical, ACP drivers translate native frames into these shapes
+ * (`apps/server/src/provider/drivers/acp/translate.ts`).
+ *
+ *   tool          input keys                              result `output`
+ *   ---------     ------------------------------------    -------------------
+ *   Edit          { file_path, old_string, new_string }   diff text or {}
+ *   MultiEdit     { file_path, edits: [...] }             diff text or {}
+ *   Write         { file_path, content }                  ""
+ *   Read          { file_path, offset?, limit? }          file slice (string
+ *                                                          or [{type:"text"}])
+ *   Bash          { command, description? }               stdout/stderr text
+ *   Grep          { pattern, path?, glob?, output_mode? } match listing
+ *   Glob          { pattern, path? }                      file listing
+ *   WebSearch     { query }                               result array (or
+ *                                                          empty for
+ *                                                          `queryOnly` models)
+ *   WebFetch      { url, prompt? }                        page summary text
+ *   TodoWrite     { todos: [...] }                        ""
+ *
+ * Adding a new tool: extend this block AND add a `case` in tool-row.tsx so
+ * the renderer knows how to label/render it. Unknown tools fall through to
+ * the default Wrench row, which is correct but unstyled.
+ */
 const ToolUseEvent = Schema.TaggedStruct("ToolUse", {
   itemId: AgentItemId,
   tool: Schema.String,
@@ -468,31 +541,115 @@ export const StartSessionInput = Schema.Struct({
    * for 0.04.
    */
   toolSearch: Schema.optional(Schema.Boolean),
+  /**
+   * Opaque per-model knob values. Keys map to
+   * `ModelDescriptor.optionDescriptors[].id` (e.g. `"reasoning"`); values
+   * are the selected option id (`"low" | "medium" | "high"`) for selects
+   * or `"true" | "false"` for booleans. Drivers consume what they support
+   * and ignore the rest — the FE composer renders only the descriptors
+   * the current model declared, so no value should arrive that the driver
+   * can't interpret.
+   */
+  modelOptions: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
 });
 export type StartSessionInput = typeof StartSessionInput.Type;
 
 /**
- * Curated list of provider × model pairs the renderer offers in the
- * new-session picker. Source of truth so the dropdown and the server agree
- * on what's selectable. Adding a model here is the only change needed —
- * drivers pass the string through to the SDK as-is.
+ * What each model declares about itself — the source of truth the renderer
+ * uses to decide whether to show the reasoning picker, plan-mode toggle,
+ * and to label WebSearch result behavior. Driver behavior is keyed off the
+ * same descriptors so FE and BE stay in lockstep.
+ *
+ *   - `optionDescriptors`: per-model knobs the composer renders (reasoning,
+ *     etc.). Omitting the descriptor hides the control.
+ *   - `supportsPlanMode`: whether the plan-mode toggle is shown for this
+ *     model. `true` for every model today (native for Claude/Cursor,
+ *     emulated via dev-instructions prefix for Codex/Grok/Gemini); set
+ *     `false` only when there's a hard reason not to allow planning.
+ *   - `supportsWebSearch`: `"native"` (driver emits real results),
+ *     `"queryOnly"` (driver emits the query but no results), or omitted
+ *     (provider doesn't search).
  */
 export interface ModelOption {
   readonly id: string;
   readonly label: string;
+  readonly optionDescriptors?: ReadonlyArray<OptionDescriptor>;
+  readonly supportsPlanMode?: boolean;
+  readonly supportsWebSearch?: "native" | "queryOnly";
 }
+
+/**
+ * Standard reasoning-level descriptor reused across providers that support
+ * thinking. Keep id/options aligned with `ReasoningLevel`.
+ */
+const reasoningSelectDescriptor = (
+  defaultId: ReasoningLevel = "medium",
+): SelectOptionDescriptor => ({
+  kind: "select",
+  id: "reasoning",
+  label: "Reasoning",
+  options: [
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Medium" },
+    { id: "high", label: "High" },
+  ],
+  defaultId,
+});
 
 export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> = {
   claude: [
-    { id: "claude-opus-4-7", label: "Opus 4.7" },
-    { id: "claude-sonnet-4-6", label: "Sonnet 4.6" },
-    { id: "claude-haiku-4-5", label: "Haiku 4.5" },
+    {
+      id: "claude-opus-4-7",
+      label: "Opus 4.7",
+      optionDescriptors: [reasoningSelectDescriptor("high")],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
+      id: "claude-sonnet-4-6",
+      label: "Sonnet 4.6",
+      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
+      id: "claude-haiku-4-5",
+      label: "Haiku 4.5",
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
   ],
   codex: [
-    { id: "gpt-5.4", label: "GPT-5.4" },
-    { id: "gpt-5.4-mini", label: "GPT-5.4 mini" },
-    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
-    { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
+    {
+      id: "gpt-5.4",
+      label: "GPT-5.4",
+      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
+      id: "gpt-5.4-mini",
+      label: "GPT-5.4 mini",
+      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
+      id: "gpt-5.3-codex",
+      label: "GPT-5.3 Codex",
+      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
+      id: "gpt-5.3-codex-spark",
+      label: "GPT-5.3 Codex Spark",
+      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
   ],
   // Seed list — Grok CLI's `-m` flag accepts any model id it knows, so a
   // custom slug typed by the user still works; this list is just what the
@@ -502,33 +659,94 @@ export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> 
   // a clean 403 surfaced through grok's streaming-json `type: "error"`
   // envelope, so no client-side validation needed.
   grok: [
-    { id: "grok-build", label: "Grok Build" },
-    { id: "grok-4", label: "Grok 4" },
-    { id: "grok-4-fast", label: "Grok 4 Fast" },
-    { id: "grok-code-fast-1", label: "Grok Code Fast" },
+    {
+      id: "grok-build",
+      label: "Grok Build",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
+      id: "grok-4",
+      label: "Grok 4",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
+      id: "grok-4-fast",
+      label: "Grok 4 Fast",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
+      id: "grok-code-fast-1",
+      label: "Grok Code Fast",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
   ],
   // Gemini CLI accepts any model slug it knows via the ACP `_meta.model`
-  // hint; this list is just what the picker offers by default.
+  // hint; this list is just what the picker offers by default. Gemini's
+  // ACP server does not expose a runtime reasoning-effort knob (the
+  // native gemini CLI doesn't show one either), so no reasoning descriptor
+  // is declared — the FE picker is hidden across the whole provider.
   gemini: [
-    { id: "gemini-3-pro-preview", label: "Gemini 3 Pro" },
-    { id: "gemini-3-flash-preview", label: "Gemini 3 Flash" },
-    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+    {
+      id: "gemini-3-pro-preview",
+      label: "Gemini 3 Pro",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
+      id: "gemini-3-flash-preview",
+      label: "Gemini 3 Flash",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
+      id: "gemini-2.5-pro",
+      label: "Gemini 2.5 Pro",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
+      id: "gemini-2.5-flash",
+      label: "Gemini 2.5 Flash",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
   ],
   // Cursor's CLI exposes models via the ACP session config-option picker;
   // these are the slugs `cursor-agent --model` advertises today. Like grok,
   // the picker accepts any model the agent knows, so a custom slug typed by
   // the user still works — this list is the default shown in the picker.
+  // Cursor has native plan mode via ACP `setSessionMode("plan")`.
   cursor: [
-    { id: "gpt-5", label: "GPT-5" },
-    { id: "sonnet-4", label: "Claude Sonnet 4" },
-    { id: "sonnet-4-thinking", label: "Claude Sonnet 4 (Thinking)" },
-    { id: "opus-4.1", label: "Claude Opus 4.1" },
+    { id: "gpt-5", label: "GPT-5", supportsPlanMode: true },
+    { id: "sonnet-4", label: "Claude Sonnet 4", supportsPlanMode: true },
+    {
+      id: "sonnet-4-thinking",
+      label: "Claude Sonnet 4 (Thinking)",
+      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      supportsPlanMode: true,
+    },
+    { id: "opus-4.1", label: "Claude Opus 4.1", supportsPlanMode: true },
   ],
 };
 
 export const defaultModelFor = (providerId: ProviderId): string =>
   MODELS_BY_PROVIDER[providerId][0]!.id;
+
+/**
+ * Look up a model's descriptor by `(providerId, modelId)`. Returns
+ * `undefined` when the slug isn't in our curated list (e.g. user typed
+ * a custom slug), in which case the caller should fall through to
+ * provider-level defaults.
+ */
+export const findModelDescriptor = (
+  providerId: ProviderId,
+  modelId: string,
+): ModelOption | undefined =>
+  MODELS_BY_PROVIDER[providerId].find((m) => m.id === modelId);
 
 /**
  * Aliases for codex model slugs that no longer work — current Codex CLI rejects
@@ -575,6 +793,14 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
 export const SendInput = Schema.Struct({
   sessionId: AgentSessionId,
   text: Schema.String,
+  /**
+   * Per-turn override of the session's `modelOptions` (see
+   * `StartSessionInput.modelOptions`). When omitted, drivers reuse the
+   * value supplied at session start.
+   */
+  modelOptions: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
 });
 export type SendInput = typeof SendInput.Type;
 


### PR DESCRIPTION
## Summary

Streamlines the multi-provider driver layer so every provider (claude, codex, grok, gemini, cursor) renders tool calls, plan mode, reasoning levels, and web search identically on the FE — with Claude as the canonical reference shape. Includes the prior commit on this branch plus fixes for the issues that surfaced while testing Gemini.

### What changed

**Per-model capability descriptors** (`packages/wire/src/agent.ts`)
- Every model in `MODELS_BY_PROVIDER` now carries `optionDescriptors`, `supportsPlanMode`, `supportsWebSearch` instead of a hardcoded provider-level table. Modeled on t3code's pattern — the FE composer renders pickers/toggles dynamically from each model's descriptor, so adding a new provider/model requires declaring its capabilities or the controls don't appear.
- New `ReasoningLevel` + `OptionDescriptor` + `findModelDescriptor()` helpers.
- `StartSessionInput` and `SendInput` carry an opaque `modelOptions: Record<string, string>` bag (e.g. `{ reasoning: "high" }`) that drivers interpret per their descriptor.

**Shared ACP translator** (`apps/server/src/provider/drivers/acp/translate.ts`, NEW)
- One `createAcpTranslator(provider)` factory replaces three near-identical `translateSessionUpdate` copies in grok/gemini/cursor.
- **Coalesces `agent_message_chunk` deltas** into one `AssistantMessage` per burst — fixes Gemini's mid-token wrapping (`monore`+`po` became two bubbles).
- **Dedupes `tool_call_update` frames** with per-call state so progress updates (pending → in_progress → completed) don't stack rows in the renderer.
- **Extracts diff content** from ACP `tool_call.content` so Gemini's Edit rows render the diff body like Claude.
- **Fixes Read result emission**: the old logic dropped file content when locations were still present.
- Normalizes tool names to Claude-canonical (Edit, Read, Bash, WebSearch, etc.) so the renderer's switch hits the right case for every provider.

**Plan mode for every provider** (`apps/server/src/provider/drivers/planMode.ts`, NEW)
- Claude: native SDK `permissionMode: "plan"` (existing).
- Cursor: native ACP `session/setMode` with `modeId: "plan"`.
- Codex/Grok/Gemini: emulated via shared `applyPlanModePrefix()` developer-instructions prefix in `send()`. Toggle stays visible everywhere instead of hiding for non-native providers.

**Reasoning levels wired end-to-end** (driver-side)
- Claude → SDK `effort` (low/medium/high → maxThinkingTokens shorthand).
- Codex → `turn/start.effort` (`ReasoningEffort` enum).
- Gemini: no reasoning descriptor declared (Gemini CLI doesn't surface a runtime knob), so the picker is hidden.
- Composer reads the selected level from sessionStorage; messages store forwards it as `modelOptions.reasoning` on every send.

**Interrupt + stuck-session fix** (all three ACP drivers)
- `notify("session/cancel")` alone wasn't unblocking the in-flight `session/prompt` Promise — drivers now also track the prompt's rpc id and force-reject it on interrupt. Without this, the `inflight` Promise chain stayed blocked on a dead request and the user's next message queued behind it. Cancellation rejections filter out of error events so the chat doesn't show "Interrupted by user" as a failure.

**Gemini auto-trust** (`apps/server/src/provider/drivers/gemini.ts`)
- Effect-based `ensureGeminiFolderTrusted(cwd)` writes the cwd into `~/.gemini/trustedFolders.json` before spawn, fixing the `Skipping project agents due to untrusted folder` crash. Uses `Effect.tryPromise` + `Effect.ignore` — no raw try/catch.

**WebSearch normalization** (`apps/renderer/src/components/tool-row.tsx`)
- Codex now emits Claude-canonical `tool: "WebSearch"` (was `"web_search"`).
- Renderer shows `(no results returned)` muted hint when output is empty (covers Gemini/Grok which can search but don't surface results through ACP).

**Onboarding subscription state** (`apps/renderer/src/components/onboarding/steps/provider.tsx`)
- New `"subscription"` state distinct from `"ready"` for providers like Grok where the CLI is logged in but the JWT tier doesn't meet the paid-plan floor. The "Subscription" badge only appears when the probe actually detected an unmet requirement.

**Trace logging**
- `MEMOIZE_DEBUG_ACP=1` traces every translator decision (kind, dedupe verdict, emitted events).
- `MEMOIZE_DEBUG_<PROVIDER>=1` traces RPC frames, prompt lifecycle, and cancel reasons.

## Test plan

- [ ] Start a Gemini session in any project folder → no `Skipping project agents` in stderr, `~/.gemini/trustedFolders.json` has the cwd entry
- [ ] Ask Gemini to read a 200-line file → tool row shows "200 lines" pill + file preview (matches Claude)
- [ ] Ask Gemini to edit a known file → diff body renders below the row
- [ ] Send a long-running Gemini prompt, hit Interrupt → status returns to idle within ~1s; next send goes through immediately
- [ ] Toggle plan mode on Codex/Grok/Gemini → driver logs the `PLAN MODE` prefix; agent's response is a written plan with no file mutations
- [ ] Toggle plan mode on Cursor → driver sends `session/setMode("plan")` and the response confirms
- [ ] Reasoning picker shows for Claude (Opus/Sonnet) and Codex; hidden for Haiku, Gemini (all), Grok, Cursor (non-thinking models)
- [ ] WebSearch row shows the query for all providers; `(no results returned)` footer for Gemini/Grok
- [ ] Sub-second assistant streaming on Gemini renders as one bubble per turn (no mid-word splits)
- [ ] Hit Interrupt rapidly while a prompt is in flight → no stuck "Interrupted by user" error in the chat bubble