### PR TITLE
feat(settings): minimal frame redesign + lime primary

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -30,6 +30,7 @@ import {
 
 import { Card, CardPanel } from "~/components/ui/card";
 import { Frame, FrameFooter } from "~/components/ui/frame";
+import { Button } from "~/components/ui/button";
 import {
   composerDoc,
   createComposerView,
@@ -686,14 +687,14 @@ export function ChatComposer({ session }: { session: Session }) {
                   <Tooltip>
                     <TooltipTrigger
                       render={
-                        <button
-                          type="button"
+                        <Button
+                          variant="outline"
+                          size="icon-sm"
                           onClick={() => void interrupt(sessionId)}
                           aria-label="Interrupt"
-                          className="flex size-7 items-center justify-center rounded-md border border-border/60 bg-background text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
                         >
                           <Square className="size-3.5" />
-                        </button>
+                        </Button>
                       }
                     />
                     <TooltipPopup>Interrupt the running turn</TooltipPopup>
@@ -702,15 +703,15 @@ export function ChatComposer({ session }: { session: Session }) {
                   <Tooltip>
                     <TooltipTrigger
                       render={
-                        <button
-                          type="button"
+                        <Button
+                          variant="default"
+                          size="icon-sm"
                           onClick={() => void submit()}
                           disabled={!canSend}
                           aria-label="Send"
-                          className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
                         >
                           <Send className="size-3.5" />
-                        </button>
+                        </Button>
                       }
                     />
                     <TooltipPopup>Send (Enter)</TooltipPopup>

--- a/apps/renderer/src/components/onboarding/steps/defaults.tsx
+++ b/apps/renderer/src/components/onboarding/steps/defaults.tsx
@@ -92,7 +92,7 @@ export function DefaultsStep() {
               New worktree per chat
             </span>
             <span className="text-[11px] leading-snug text-muted-foreground">
-              Each chat runs on its own branch under <code>.memoize/repo-worktree/</code>.
+              Each chat runs on its own branch under <code>.nuuk/repo-worktree/</code>.
             </span>
           </span>
           <Switch

--- a/apps/renderer/src/components/onboarding/steps/done.tsx
+++ b/apps/renderer/src/components/onboarding/steps/done.tsx
@@ -22,7 +22,7 @@ export function DoneStep({ onFinish }: { onFinish: () => void }) {
         </p>
       </div>
       <Button size="default" onClick={onFinish} className="rounded-full px-6">
-        Open memoize
+        Open Nuuk
       </Button>
     </div>
   );

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -129,7 +129,7 @@ export function ProviderStep() {
       <StepHeader
         kicker="Step 1"
         title="Pick your agent"
-        subtitle="memoize uses your existing CLI credentials — no API keys required."
+        subtitle="Nuuk uses your existing CLI credentials — no API keys required."
       />
 
       <div className="grid grid-cols-2 gap-2.5">
@@ -298,7 +298,7 @@ function ProviderStatus({
           : state.kind === "subscription"
             ? "Your CLI login was detected, but the required paid plan was not confirmed."
             : state.kind === "outdated"
-              ? `${PROVIDER_LABEL[providerId]} ${state.current} is too old; memoize needs ${state.required}.`
+              ? `${PROVIDER_LABEL[providerId]} ${state.current} is too old; Memoize needs ${state.required}.`
               : `${PROVIDER_LABEL[providerId]}'s CLI isn't on your PATH yet.`;
 
   const showLoginBlock = state.kind === "signed-out";

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -116,14 +116,14 @@ export function ProviderCard({
   return (
     <div
       className={cn(
-        "flex flex-col overflow-hidden rounded-lg border border-border/50 bg-card transition-colors",
+        "group flex flex-col bg-card transition-colors first:rounded-t-xl last:rounded-b-xl",
         !enabled && !unmetSubscriptionRequirement && "opacity-70",
       )}
     >
       <button
         type="button"
         onClick={() => setExpanded((e) => !e)}
-        className="flex w-full items-center gap-3 px-3.5 py-3 text-left transition-colors hover:bg-muted/40"
+        className="flex w-full items-center gap-3 px-3.5 py-3 text-left group-first:rounded-t-xl group-last:rounded-b-xl transition-colors hover:bg-muted/40"
       >
         <span className="flex size-7 shrink-0 items-center justify-center">
           <ProviderIcon providerId={providerId} className="size-5" />

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -42,6 +42,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select.tsx";
+import { Switch } from "./ui/switch";
+import { Frame, FrameFooter, FrameHeader } from "./ui/frame.tsx";
+import { Card } from "./ui/card.tsx";
 
 const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude Code",
@@ -303,46 +306,61 @@ function GeneralPane() {
     (s) => s.setOnboardingCompleted,
   );
   const setView = useUiStore((s) => s.setView);
+
   return (
     <>
-      <Section
+      <SettingsFrame
         title="Default permission mode"
+        trailing={
+          <Select
+            value={defaultRuntimeMode}
+            onValueChange={(v) => setDefaultRuntimeMode(v as RuntimeMode)}
+            items={MODES_ORDER.map((m) => ({
+              label: MODE_META[m].label,
+              value: m,
+            }))}
+          >
+            <SelectTrigger size="sm" className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectPopup>
+              {MODES_ORDER.map((mode) => {
+                const m = MODE_META[mode];
+                return (
+                  <SelectItem key={mode} value={mode}>
+                    <div className="flex flex-col">
+                      <span>{m.label}</span>
+                      <span className="text-[10px] text-muted-foreground">
+                        {m.description}
+                      </span>
+                    </div>
+                  </SelectItem>
+                );
+              })}
+            </SelectPopup>
+          </Select>
+        }
         description="How the agent handles tool calls in new sessions. Each session can override this from its composer."
-      >
-        <OptionGroup>
-          {MODES_ORDER.map((mode) => {
-            const m = MODE_META[mode];
-            return (
-              <OptionCard
-                key={mode}
-                icon={m.Icon}
-                title={m.label}
-                description={m.description}
-                active={mode === defaultRuntimeMode}
-                onClick={() => setDefaultRuntimeMode(mode)}
-              />
-            );
-          })}
-        </OptionGroup>
-      </Section>
+      />
+
       <SubagentsSection />
-      <Section
+
+      <SettingsFrame
         title="Onboarding"
-        description="Replay the first-launch welcome flow. Your existing projects and credentials stay put."
-      >
-        <div>
+        trailing={
           <Button
-            variant="outline"
+            variant="settings"
             size="sm"
             onClick={() => {
               setView("chat");
               setOnboardingCompleted(false);
             }}
           >
-            Show onboarding again
+            Show again
           </Button>
-        </div>
-      </Section>
+        }
+        description="Replay the first-launch welcome flow. Your existing projects and credentials stay put."
+      />
     </>
   );
 }
@@ -390,53 +408,72 @@ function ProvidersPane() {
     return map;
   }, [availability]);
 
+  const statusLabel = loading
+    ? "Checking…"
+    : error !== null
+      ? `Probe failed · ${error}`
+      : lastCheckedAt
+        ? `Checked ${formatRelativeTime(lastCheckedAt, now) ?? "just now"}`
+        : availability.length > 0
+          ? "Checked"
+          : "Not checked yet";
+
   return (
     <>
-      <Section
-        title="Installed providers"
-        description="memoize uses your existing CLI credentials — Claude Code, Codex, Grok, Gemini, and Cursor all sign in through their own login flows."
-      >
-        <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <span>
-            {loading
-              ? "Checking…"
-              : error !== null
-                ? `Probe failed · ${error}`
-                : lastCheckedAt
-                  ? `Checked ${formatRelativeTime(lastCheckedAt, now) ?? "just now"}`
-                  : availability.length > 0
-                    ? "Checked"
-                    : "Not checked yet"}
-          </span>
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => void refresh()}
-            disabled={loading}
-            aria-label="Refresh provider status"
-          >
-            <RotateCw
-              className={cn("size-3.5", loading && "animate-spin")}
-              aria-hidden
-            />
-          </Button>
-        </div>
-        <div className="flex flex-col gap-2">
-          {providers.map((pid) => (
-            <ProviderCard
-              key={pid}
-              providerId={pid}
-              availability={availabilityById.get(pid)}
-              loading={loading}
-            />
-          ))}
-        </div>
-      </Section>
-      <Section
+      <Frame>
+        <FrameHeader className="flex flex-row items-center justify-between px-2 py-2 w-full">
+          <p className="text-sm font-semibold text-foreground">
+            Installed providers
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] text-muted-foreground/80">
+              {statusLabel}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => void refresh()}
+              disabled={loading}
+              aria-label="Refresh provider status"
+            >
+              <RotateCw
+                className={cn("size-3.5", loading && "animate-spin")}
+                aria-hidden
+              />
+            </Button>
+          </div>
+        </FrameHeader>
+        <Card>
+          <div className="flex flex-col divide-y divide-border/40">
+            {providers.map((pid) => (
+              <ProviderCard
+                key={pid}
+                providerId={pid}
+                availability={availabilityById.get(pid)}
+                loading={loading}
+              />
+            ))}
+          </div>
+        </Card>
+        <FrameFooter className="px-2 py-1 w-full">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Nuuk uses your existing CLI credentials — Claude Code, Codex,
+            Grok, Gemini, and Cursor all sign in through their own login
+            flows.
+          </p>
+        </FrameFooter>
+      </Frame>
+
+      <SettingsFrame
         title="Default agent"
         description="Which provider new chats start in. Change per session from the composer."
+        flush
       >
-        <OptionGroup columns={3}>
+        <div
+          role="radiogroup"
+          aria-label="Default agent"
+          className="flex flex-col divide-y divide-border/40"
+        >
           {providers
             .filter((pid) => {
               // Hide providers the user has toggled off. Cursor is still
@@ -448,17 +485,27 @@ function ProvidersPane() {
               if (pid === "cursor") return false;
               return true;
             })
-            .map((pid) => (
-              <OptionCard
-                key={pid}
-                iconNode={<ProviderIcon providerId={pid} className="size-4" />}
-                title={PROVIDER_LABEL[pid]}
-                active={pid === defaultProviderId}
-                onClick={() => setDefaultProvider(pid)}
-              />
-            ))}
-        </OptionGroup>
-      </Section>
+            .map((pid) => {
+              const selected = pid === defaultProviderId;
+              return (
+                <button
+                  key={pid}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  onClick={() => setDefaultProvider(pid)}
+                  className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+                >
+                  <ProviderIcon providerId={pid} className="size-4 shrink-0" />
+                  <span className="flex-1 truncate text-sm font-medium text-foreground">
+                    {PROVIDER_LABEL[pid]}
+                  </span>
+                  <RadioCheck active={selected} />
+                </button>
+              );
+            })}
+        </div>
+      </SettingsFrame>
     </>
   );
 }
@@ -471,17 +518,16 @@ function WorkspacePane() {
     (s) => s.setDefaultAutoCreateWorktree,
   );
   return (
-    <Section
-      title="New chat workspace"
-      description="Memoize can run each chat in its own git worktree under .memoize/repo-worktree/, branched off the project's HEAD. Per-repo settings override this default."
-    >
-      <CheckboxField
-        checked={defaultAutoCreateWorktree}
-        onChange={setDefaultAutoCreateWorktree}
-        label="Create a new worktree for new chats by default"
-        description='Pre-selects "New worktree" in the composer&apos;s workspace picker. You can still flip back to "Current checkout" before sending the first message.'
-      />
-    </Section>
+    <SettingsFrame
+      title="Auto-create worktree for new chats"
+      trailing={
+        <Switch
+          checked={defaultAutoCreateWorktree}
+          onCheckedChange={setDefaultAutoCreateWorktree}
+        />
+      }
+      description="When on, each new chat runs in its own git worktree under .nuuk/repo-worktree/, branched off the project's HEAD. Per-repo settings can override this default."
+    />
   );
 }
 
@@ -502,79 +548,107 @@ function SubagentsSection() {
   const setPresetOverride = useSubagentsStore((s) => s.setPresetOverride);
 
   const claudeModels = MODELS_BY_PROVIDER.claude;
-  const claudeModelItems = useMemo(
-    () => claudeModels.map((m) => ({ value: m.id, label: m.label })),
-    [claudeModels],
-  );
 
   return (
-    <Section
-      title="Sub-agents"
-      description="Let your main agent delegate scoped tasks to cheaper models. Saves tokens on long sessions."
-    >
-      <CheckboxField
-        checked={enableForNewSessions}
-        onChange={setEnableForNewSessions}
-        label="Enable sub-agents for new sessions"
-      />
+    <Frame>
+      <FrameHeader className="flex flex-row items-center justify-between px-2 py-2 w-full">
+        <p className="text-sm font-semibold text-foreground">Sub-agents</p>
+        <Switch
+          checked={enableForNewSessions}
+          onCheckedChange={setEnableForNewSessions}
+        />
+      </FrameHeader>
 
-      <div
+      <Card
         className={cn(
-          "flex flex-col gap-0.5 rounded-lg border border-border/50 p-1.5 transition-opacity",
           enableForNewSessions ? "" : "pointer-events-none opacity-50",
         )}
       >
-        {DEFAULT_SUBAGENT_PRESETS.map((preset) => {
-          const ps = presets[preset.name] ?? {
-            enabled: true,
-            overrides: {},
-          };
-          const model = ps.overrides.model ?? preset.definition.model;
-          const rowDisabled = !enableForNewSessions || !ps.enabled;
-          return (
-            <div
-              key={preset.name}
-              className="flex items-center gap-3 rounded-md px-2.5 py-2 transition-colors hover:bg-muted/40"
-            >
-              <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
-                <CheckboxInput
-                  checked={ps.enabled && enableForNewSessions}
-                  disabled={!enableForNewSessions}
-                  onChange={(v) => setPresetEnabled(preset.name, v)}
-                />
-                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="truncate text-sm font-medium leading-none">
-                    {preset.displayName}
+        <div className="flex flex-col divide-y divide-border/40 overflow-hidden">
+          {DEFAULT_SUBAGENT_PRESETS.map((preset) => {
+            const ps = presets[preset.name] ?? {
+              enabled: true,
+              overrides: {},
+            };
+            const currentModel =
+              ps.overrides.model ?? preset.definition.model ?? "";
+            const rowDisabled = !enableForNewSessions || !ps.enabled;
+            return (
+              <div key={preset.name} className="flex flex-col gap-3 px-4 py-3.5">
+                <label className="group flex cursor-pointer items-start gap-3">
+                  <Switch
+                    checked={ps.enabled && enableForNewSessions}
+                    disabled={!enableForNewSessions}
+                    onCheckedChange={(v) => setPresetEnabled(preset.name, v)}
+                    className="mt-0.5 shrink-0"
+                  />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-sm font-semibold leading-none text-foreground">
+                      {preset.displayName}
+                    </span>
+                    <span className="text-xs leading-snug text-muted-foreground">
+                      {preset.summary}
+                    </span>
                   </span>
-                  <span className="truncate text-xs leading-snug text-muted-foreground">
-                    {preset.summary}
-                  </span>
-                </span>
-              </label>
-              <Select
-                value={model ?? ""}
-                disabled={rowDisabled}
-                onValueChange={(next) =>
-                  setPresetOverride(preset.name, { model: next as string })
-                }
-                items={claudeModelItems}
-              >
-                <SelectTrigger size="sm" className="w-auto min-w-44">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectPopup>
-                  {claudeModels.map((m) => (
-                    <SelectItem key={m.id} value={m.id}>
-                      {m.label}
-                    </SelectItem>
-                  ))}
-                </SelectPopup>
-              </Select>
-            </div>
-          );
-        })}
-      </div>
-    </Section>
+                </label>
+
+                <div
+                  className={cn(
+                    "ml-[calc(--spacing(9)+--spacing(3))] flex flex-col gap-2",
+                    rowDisabled && "pointer-events-none opacity-50",
+                  )}
+                >
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-[13px] font-semibold leading-none text-foreground">
+                      Model
+                    </span>
+                    <span className="text-xs leading-snug text-muted-foreground">
+                      Pick which model handles this sub-agent's turns.
+                    </span>
+                  </div>
+                  <div
+                    role="radiogroup"
+                    aria-label={`Model for ${preset.displayName}`}
+                    className="flex flex-col"
+                  >
+                    {claudeModels.map((m) => {
+                      const selected = currentModel === m.id;
+                      return (
+                        <label
+                          key={m.id}
+                          className="group flex cursor-pointer items-center gap-3 py-1.5"
+                        >
+                          <input
+                            type="radio"
+                            name={`subagent-model-${preset.name}`}
+                            value={m.id}
+                            checked={selected}
+                            onChange={() =>
+                              setPresetOverride(preset.name, { model: m.id })
+                            }
+                            className="sr-only"
+                          />
+                          <RadioCheck active={selected} />
+                          <span className="text-sm text-foreground">
+                            {m.label}
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+      <FrameFooter className="px-2 py-1 w-full">
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Let your main agent delegate scoped tasks to cheaper models. Saves
+          tokens on long sessions.
+        </p>
+      </FrameFooter>
+    </Frame>
   );
 }
 
@@ -582,6 +656,146 @@ function SubagentsSection() {
 // Shared building blocks
 // ---------------------------------------------------------------------------
 
+/**
+ * Frame-shaped settings block: outer muted shell with `FrameHeader` (title
+ * + optional trailing action), optional inner `Card` body, and
+ * `FrameFooter` for the description. Use for every settings group that
+ * fits the "title • body • description" shape — sub-agents-style.
+ */
+export function SettingsFrame({
+  title,
+  trailing,
+  description,
+  bodyClassName,
+  flush,
+  children,
+}: {
+  title: string;
+  trailing?: React.ReactNode;
+  description?: React.ReactNode;
+  bodyClassName?: string;
+  /** When true, render children flush inside the Card without inner padding. */
+  flush?: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <Frame>
+      <FrameHeader className="flex flex-row items-center justify-between px-2 py-2 w-full">
+        <p className="text-sm font-semibold text-foreground">{title}</p>
+        {trailing}
+      </FrameHeader>
+      {children && (
+        <Card className={bodyClassName}>
+          {flush ? children : <div className="px-4 py-3">{children}</div>}
+        </Card>
+      )}
+      {description && (
+        <FrameFooter className="px-2 py-1 w-full">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {description}
+          </p>
+        </FrameFooter>
+      )}
+    </Frame>
+  );
+}
+
+/**
+ * Single-surface container for a group of settings rows. Renders one
+ * rounded panel with a subtle muted background — no inner card, no double
+ * nesting. Pair with `SettingsRow` for the row layout.
+ */
+export function SettingsCard({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col divide-y divide-border/40 overflow-hidden rounded-2xl border border-border/40 bg-muted/30",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Compact uppercase header bar for a `SettingsCard`. Single line, optional
+ * leading icon, optional trailing slot (status text, refresh button,
+ * toggle). Renders above the rest of the card content with a bottom
+ * divider courtesy of the parent's `divide-y`.
+ */
+export function SettingsCardHeader({
+  icon: Icon,
+  title,
+  trailing,
+}: {
+  icon?: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  title: string;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <header className="flex h-10 shrink-0 items-center gap-2 px-4 text-muted-foreground">
+      {Icon && <Icon className="size-3.5" aria-hidden />}
+      <span className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+        {title}
+      </span>
+      {trailing && (
+        <div className="flex shrink-0 items-center gap-2">{trailing}</div>
+      )}
+    </header>
+  );
+}
+
+/**
+ * Settings row: title + (optional) description on the left, action on the
+ * right. When `children` are passed instead of `action`, they render under
+ * the title/description (for cases like radio-group pickers).
+ */
+export function SettingsRow({
+  icon: Icon,
+  title,
+  description,
+  action,
+  children,
+}: {
+  icon?: React.ComponentType<{ className?: string }>;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 px-4 py-3.5">
+      <div className="flex items-center gap-3">
+        {Icon && (
+          <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        )}
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="text-sm font-medium text-foreground">{title}</div>
+          {description && (
+            <div className="text-xs leading-snug text-muted-foreground">
+              {description}
+            </div>
+          )}
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Legacy `Section` helper kept for back-compat with call-sites that
+ * haven't been migrated to `SettingsCard` + `SettingsRow`. New code should
+ * prefer those primitives.
+ */
 export function Section({
   title,
   description,
@@ -592,17 +806,11 @@ export function Section({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-3 border-t border-border/40 pt-6 first:border-t-0 first:pt-0">
-      <div className="flex flex-col gap-1">
-        <h2 className="text-sm font-medium text-foreground">{title}</h2>
-        {description && (
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            {description}
-          </p>
-        )}
-      </div>
-      {children}
-    </section>
+    <SettingsCard>
+      <SettingsRow title={title} description={description}>
+        {children}
+      </SettingsRow>
+    </SettingsCard>
   );
 }
 
@@ -710,6 +918,39 @@ function RadioDot({
           active ? "scale-100" : "scale-0",
         )}
       />
+    </span>
+  );
+}
+
+/**
+ * Cleaner radio rendering: filled solid disc with checkmark when selected,
+ * hollow bordered circle when not. No inner-dot pattern.
+ */
+export function RadioCheck({
+  active,
+  className,
+}: {
+  active: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center rounded-full border transition-colors",
+        active
+          ? "border-primary bg-primary"
+          : "border-border bg-background group-hover:border-foreground/60",
+        className,
+      )}
+    >
+      {active && (
+        <Check
+          className="size-2.5 text-primary-foreground"
+          strokeWidth={3.5}
+          aria-hidden
+        />
+      )}
     </span>
   );
 }

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -14,14 +14,14 @@ import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { MODES_ORDER, MODE_META } from "./runtime-mode-meta.ts";
 import {
-  CheckboxField,
-  ModelSelect,
-  OptionCard,
-  OptionGroup,
-  OverrideField,
   PROVIDER_LABEL,
-  Section,
+  RadioCheck,
+  SettingsFrame,
 } from "./settings-page.tsx";
+import { Button } from "./ui/button.tsx";
+import { Card } from "./ui/card.tsx";
+import { Frame, FrameFooter, FrameHeader } from "./ui/frame.tsx";
+import { Switch } from "./ui/switch.tsx";
 
 /**
  * Per-repository settings: provider/model/permission overrides plus
@@ -61,11 +61,11 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
       <ProviderOverrideSection
         defaultProviderId={settings.defaultProviderId}
         defaultModel={settings.defaultModel}
-        onProviderChange={(value) =>
-          void update(projectId, { defaultProviderId: value })
-        }
-        onModelChange={(value) =>
-          void update(projectId, { defaultModel: value })
+        onProviderAndModelChange={(provider, model) =>
+          void update(projectId, {
+            defaultProviderId: provider,
+            defaultModel: model,
+          })
         }
       />
 
@@ -90,57 +90,150 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
 function ProviderOverrideSection({
   defaultProviderId,
   defaultModel,
-  onProviderChange,
-  onModelChange,
+  onProviderAndModelChange,
 }: {
   defaultProviderId: ProviderId | null;
   defaultModel: string | null;
-  onProviderChange: (v: ProviderId | null) => void;
-  onModelChange: (v: string | null) => void;
+  /**
+   * Update provider + model in a single patch. We deliberately don't expose
+   * separate setters: changing only the provider would leave a stale model
+   * id behind, and firing two patches in a row races against the server's
+   * read-then-write so the later response can clobber the earlier one.
+   */
+  onProviderAndModelChange: (
+    provider: ProviderId | null,
+    model: string | null,
+  ) => void;
 }) {
   const globalProviderId = useSettingsStore((s) => s.defaultProviderId);
   const globalModelByProvider = useSettingsStore(
     (s) => s.defaultModelByProvider,
   );
+  const providerEnabled = useSettingsStore((s) => s.providerEnabled);
   const effectiveProvider: ProviderId = defaultProviderId ?? globalProviderId;
   const globalModel = globalModelByProvider[globalProviderId];
   const globalModelLabel =
     MODELS_BY_PROVIDER[globalProviderId].find((m) => m.id === globalModel)
-      ?.label ?? globalModel ?? "—";
+      ?.label ??
+    globalModel ??
+    "—";
   const isOverridden = defaultProviderId !== null || defaultModel !== null;
+
+  // Mirror the global "Default agent" filter: skip providers the user
+  // toggled off, and skip the subscription-gated ones (Grok → SuperGrok
+  // Heavy, Cursor → Cursor Pro) so we don't let the user pick something
+  // that can't actually launch a session.
+  const availableProviders = (
+    ["claude", "codex", "grok", "gemini", "cursor"] as const
+  ).filter((pid) => {
+    if (providerEnabled[pid] === false) return false;
+    if (pid === "grok" || pid === "cursor") return false;
+    return true;
+  });
+
+  const firstModelFor = (pid: ProviderId): string | null =>
+    MODELS_BY_PROVIDER[pid]?.[0]?.id ?? null;
+
+  const onToggle = (next: boolean) => {
+    if (next) {
+      // Turning on: seed override with the currently-effective values so the
+      // user sees the same state, but it's now persisted as a repo override.
+      onProviderAndModelChange(
+        effectiveProvider,
+        globalModelByProvider[effectiveProvider] ??
+          firstModelFor(effectiveProvider),
+      );
+    } else {
+      onProviderAndModelChange(null, null);
+    }
+  };
+
+  const onPickProvider = (pid: ProviderId) => {
+    onProviderAndModelChange(
+      pid,
+      globalModelByProvider[pid] ?? firstModelFor(pid),
+    );
+  };
+
+  const onPickModel = (model: string) => {
+    onProviderAndModelChange(effectiveProvider, model);
+  };
+
   return (
-    <Section
+    <SettingsFrame
       title="Default agent"
+      trailing={<Switch checked={isOverridden} onCheckedChange={onToggle} />}
       description="Override the global default provider and model for new chats in this repo."
+      flush
     >
-      <OverrideField
-        isOverridden={isOverridden}
-        globalLabel={`${PROVIDER_LABEL[globalProviderId]} · ${globalModelLabel}`}
-        onClear={() => {
-          onProviderChange(null);
-          onModelChange(null);
-        }}
-      >
-        <div className="flex flex-col gap-3">
-          <OptionGroup columns={2}>
-            {(["claude", "codex"] as ReadonlyArray<ProviderId>).map((pid) => (
-              <OptionCard
-                key={pid}
-                iconNode={<ProviderIcon providerId={pid} className="size-4" />}
-                title={PROVIDER_LABEL[pid]}
-                active={effectiveProvider === pid}
-                onClick={() => onProviderChange(pid)}
-              />
-            ))}
-          </OptionGroup>
-          <ModelSelect
-            providerId={effectiveProvider}
-            value={defaultModel}
-            onChange={(model) => onModelChange(model)}
-          />
+      {isOverridden ? (
+        <div
+          role="radiogroup"
+          aria-label="Repository default provider"
+          className="flex flex-col divide-y divide-border/40"
+        >
+          {availableProviders.map((pid) => {
+            const selected = effectiveProvider === pid;
+            const models = MODELS_BY_PROVIDER[pid] ?? [];
+            return (
+              <div key={pid} className="flex flex-col">
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  onClick={() => onPickProvider(pid)}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+                >
+                  <ProviderIcon providerId={pid} className="size-4 shrink-0" />
+                  <span className="flex-1 truncate text-sm font-medium text-foreground">
+                    {PROVIDER_LABEL[pid]}
+                  </span>
+                  <RadioCheck active={selected} />
+                </button>
+                {selected && models.length > 0 && (
+                  <div className="flex flex-col gap-1.5 px-4 pb-3 pl-11">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+                      Model
+                    </span>
+                    <div
+                      role="radiogroup"
+                      aria-label={`Model for ${PROVIDER_LABEL[pid]}`}
+                      className="flex flex-col"
+                    >
+                      {models.map((m) => {
+                        const isCurrentModel = defaultModel === m.id;
+                        return (
+                          <button
+                            key={m.id}
+                            type="button"
+                            role="radio"
+                            aria-checked={isCurrentModel}
+                            onClick={() => onPickModel(m.id)}
+                            className="group flex items-center gap-3 py-1.5 text-left"
+                          >
+                            <RadioCheck active={isCurrentModel} />
+                            <span className="text-sm text-foreground">
+                              {m.label}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
-      </OverrideField>
-    </Section>
+      ) : (
+        <p className="px-4 py-3 text-sm text-muted-foreground">
+          Inheriting{" "}
+          <span className="text-foreground">
+            {PROVIDER_LABEL[globalProviderId]} · {globalModelLabel}
+          </span>
+        </p>
+      )}
+    </SettingsFrame>
   );
 }
 
@@ -153,33 +246,57 @@ function RuntimeModeOverrideSection({
 }) {
   const globalMode = useSettingsStore((s) => s.defaultRuntimeMode);
   const effective = currentValue ?? globalMode;
+  const isOverridden = currentValue !== null;
+  const onToggle = (next: boolean) => {
+    if (next) onChange(globalMode);
+    else onChange(null);
+  };
   return (
-    <Section
+    <SettingsFrame
       title="Default permission mode"
+      trailing={<Switch checked={isOverridden} onCheckedChange={onToggle} />}
       description="Override the global permission posture for new chats in this repo."
+      flush
     >
-      <OverrideField
-        isOverridden={currentValue !== null}
-        globalLabel={MODE_META[globalMode].label}
-        onClear={() => onChange(null)}
-      >
-        <OptionGroup>
+      {isOverridden ? (
+        <div
+          role="radiogroup"
+          aria-label="Repository default permission mode"
+          className="flex flex-col divide-y divide-border/40"
+        >
           {MODES_ORDER.map((mode) => {
             const m = MODE_META[mode];
+            const selected = effective === mode;
             return (
-              <OptionCard
+              <button
                 key={mode}
-                icon={m.Icon}
-                title={m.label}
-                description={m.description}
-                active={effective === mode}
+                type="button"
+                role="radio"
+                aria-checked={selected}
                 onClick={() => onChange(mode)}
-              />
+                className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+              >
+                <m.Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="text-sm font-medium text-foreground">
+                    {m.label}
+                  </span>
+                  <span className="text-xs leading-snug text-muted-foreground">
+                    {m.description}
+                  </span>
+                </span>
+                <RadioCheck active={selected} className="mt-0.5" />
+              </button>
             );
           })}
-        </OptionGroup>
-      </OverrideField>
-    </Section>
+        </div>
+      ) : (
+        <p className="px-4 py-3 text-sm text-muted-foreground">
+          Inheriting{" "}
+          <span className="text-foreground">{MODE_META[globalMode].label}</span>
+        </p>
+      )}
+    </SettingsFrame>
   );
 }
 
@@ -235,89 +352,107 @@ function WorktreeSection({
   };
 
   return (
-    <Section
-      title="Worktrees"
-      description="Git worktrees for this repo. Each lives under .memoize/repo-worktree/ on disk."
-    >
-      <div className="flex flex-col gap-3">
-        <CheckboxField
-          checked={autoCreate}
-          onChange={onAutoCreateChange}
-          label="Auto-create a worktree for new chats"
-          description='When on, the composer&apos;s workspace picker pre-selects a fresh worktree. You can still flip back to "Current checkout" before sending the first message.'
-        />
+    <>
+      <SettingsFrame
+        title="Auto-create a worktree for new chats"
+        trailing={
+          <Switch
+            checked={autoCreate}
+            onCheckedChange={onAutoCreateChange}
+          />
+        }
+        description={`When on, the composer's workspace picker pre-selects a fresh worktree. You can still flip back to "Current checkout" before sending the first message.`}
+      />
 
-        {sorted.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-xs text-muted-foreground">
-            No worktrees yet. Memoize creates one for you when you start a new
-            chat.
-          </p>
-        ) : (
-          <ul className="flex flex-col gap-0.5 rounded-lg border border-border/50 p-1.5">
-            {sorted.map((wt) => (
-              <li
-                key={wt.id}
-                className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-md px-2.5 py-2 transition-colors hover:bg-muted/40"
-              >
-                <GitBranch className="size-4 shrink-0 text-muted-foreground" />
-                <div
-                  className="flex min-w-0 flex-col gap-0.5"
-                  title={wt.path}
+      <Frame>
+        <FrameHeader className="flex flex-row items-center justify-between px-2 py-2 w-full">
+          <p className="text-sm font-semibold text-foreground">Worktrees</p>
+          <span className="text-[11px] text-muted-foreground/80">
+            {sorted.length} {sorted.length === 1 ? "worktree" : "worktrees"}
+          </span>
+        </FrameHeader>
+
+        <Card>
+          {sorted.length === 0 ? (
+            <p className="px-4 py-8 text-center text-xs text-muted-foreground">
+              No worktrees yet. Nuuk creates one for you when you start a new
+              chat.
+            </p>
+          ) : (
+            <ul className="flex flex-col divide-y divide-border/40">
+              {sorted.map((wt) => (
+                <li
+                  key={wt.id}
+                  className="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/20"
                 >
-                  <span className="truncate text-sm font-medium text-foreground">
-                    {wt.name}
-                  </span>
-                  <span className="truncate font-mono text-[11px] text-muted-foreground">
-                    {wt.branch}
-                    <span className="text-muted-foreground/60">
-                      {" "}
-                      · off {wt.baseBranch}
-                    </span>
-                  </span>
-                </div>
-                {pendingDirty === wt.name ? (
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={() => void onRemove(wt.id, wt.name, true)}
-                      className="rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1 text-[11px] text-red-400 transition-colors hover:bg-red-500/20"
-                    >
-                      Force remove
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setPendingDirty(null)}
-                      className="rounded-md border border-border/50 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted/40"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => void onRemove(wt.id, wt.name, false)}
-                    className="flex items-center gap-1 rounded-md border border-border/50 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
-                    title="Remove this worktree from disk (branch stays)"
+                  <GitBranch className="size-4 shrink-0 text-muted-foreground" />
+                  <div
+                    className="flex min-w-0 flex-col gap-0.5"
+                    title={wt.path}
                   >
-                    <Trash2 className="size-3" />
-                    Remove
-                  </button>
-                )}
-              </li>
-            ))}
-          </ul>
-        )}
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {wt.name}
+                    </span>
+                    <span className="truncate font-mono text-[11px] text-muted-foreground">
+                      {wt.branch}
+                      <span className="text-muted-foreground/60">
+                        {" "}
+                        · off {wt.baseBranch}
+                      </span>
+                    </span>
+                  </div>
+                  {pendingDirty === wt.name ? (
+                    <div className="flex items-center gap-1.5">
+                      <Button
+                        variant="destructive-outline"
+                        size="sm"
+                        onClick={() => void onRemove(wt.id, wt.name, true)}
+                      >
+                        Force remove
+                      </Button>
+                      <Button
+                        variant="settings"
+                        size="sm"
+                        onClick={() => setPendingDirty(null)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      variant="settings"
+                      size="sm"
+                      onClick={() => void onRemove(wt.id, wt.name, false)}
+                      title="Remove this worktree from disk (branch stays)"
+                    >
+                      <Trash2 className="size-3" />
+                      Remove
+                    </Button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
 
-        {pendingDirty !== null && (
-          <p className="text-xs text-amber-400">
-            {pendingDirty} has uncommitted changes. Force-remove to discard
-            them.
-          </p>
-        )}
-        {pendingError !== null && (
-          <p className="text-xs text-red-400">{pendingError}</p>
-        )}
-      </div>
-    </Section>
+        <FrameFooter className="px-2 py-1 w-full">
+          {pendingDirty !== null ? (
+            <p className="text-xs leading-relaxed text-amber-400">
+              {pendingDirty} has uncommitted changes. Force-remove to discard
+              them.
+            </p>
+          ) : pendingError !== null ? (
+            <p className="text-xs leading-relaxed text-red-400">
+              {pendingError}
+            </p>
+          ) : (
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              Git worktrees for this repo. Each lives under
+              .nuuk/repo-worktree/ on disk.
+            </p>
+          )}
+        </FrameFooter>
+      </Frame>
+    </>
   );
 }

--- a/apps/renderer/src/components/settings/keybindings-editor.tsx
+++ b/apps/renderer/src/components/settings/keybindings-editor.tsx
@@ -29,6 +29,8 @@ import {
 } from "../../lib/default-keybindings";
 import { useKeybindingsStore } from "../../store/keybindings";
 import { Button } from "../ui/button";
+import { Card } from "../ui/card";
+import { Frame, FrameFooter, FrameHeader } from "../ui/frame";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
 import {
   Select,
@@ -242,89 +244,91 @@ export function KeybindingsEditor() {
   }, [rows, query]);
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 flex-col gap-1">
-          <h2 className="text-sm font-medium text-foreground">
-            Keyboard shortcuts
-          </h2>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            Click the pencil on any row to record a new chord. Bindings
-            persist to{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">
-              keybindings.json
-            </code>{" "}
-            in your app data folder; hand-edit there for advanced
-            scoping.
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <ExpandableSearch
-            query={query}
-            onQueryChange={setQuery}
-            isOpen={searchOpen}
-            onOpenChange={setSearchOpen}
-            inputRef={searchRef}
-            countLabel={`${rows.length} bindings`}
-          />
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  className="text-muted-foreground hover:text-foreground"
-                  onClick={() => setIsAdding(true)}
-                  disabled={isAdding}
-                  aria-label="Add keybinding"
-                >
-                  <Plus className="size-3.5" />
-                </Button>
-              }
-            />
-            <TooltipPopup side="top">Add keybinding</TooltipPopup>
-          </Tooltip>
-        </div>
-      </div>
-
+    <div className="flex flex-col gap-4">
       {error !== null && (
         <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
           Failed to load keybindings: {error}
         </div>
       )}
 
-      <div className="overflow-hidden rounded-2xl border border-border/60 bg-card shadow-sm/4">
-        <div className="grid grid-cols-[minmax(140px,1fr)_minmax(200px,1.2fr)_44px] border-b border-border/70 bg-muted/25 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
-          <div>Command</div>
-          <div>Keybinding</div>
-          <div className="text-right">Status</div>
-        </div>
-        <div className="divide-y divide-border/60">
-          {!loaded && (
-            <div className="px-4 py-12 text-center text-sm text-muted-foreground">
-              Loading…
-            </div>
-          )}
-          {loaded && filtered.length === 0 && !isAdding && (
-            <div className="px-4 py-12 text-center text-sm text-muted-foreground">
-              {query.trim().length > 0
-                ? "No keybindings match your search."
-                : "No keybindings."}
-            </div>
-          )}
-          {filtered.map((row) => (
-            <RowEditor key={row.id} row={row} allRows={rows} />
-          ))}
-          {isAdding && (
-            <NewRow
-              allRows={rows}
-              onCancel={() => setIsAdding(false)}
-              onSaved={() => setIsAdding(false)}
+      <Frame>
+        <FrameHeader className="flex flex-row items-center justify-between px-2 py-2 w-full">
+          <p className="text-sm font-semibold text-foreground">
+            Keyboard shortcuts
+          </p>
+          <div className="flex items-center gap-1.5">
+            <ExpandableSearch
+              query={query}
+              onQueryChange={setQuery}
+              isOpen={searchOpen}
+              onOpenChange={setSearchOpen}
+              inputRef={searchRef}
+              countLabel={`${rows.length} bindings`}
             />
-          )}
-        </div>
-      </div>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    className="text-muted-foreground hover:text-foreground"
+                    onClick={() => setIsAdding(true)}
+                    disabled={isAdding}
+                    aria-label="Add keybinding"
+                  >
+                    <Plus className="size-3.5" />
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Add keybinding</TooltipPopup>
+            </Tooltip>
+          </div>
+        </FrameHeader>
+
+        <Card>
+          <div className="grid grid-cols-[minmax(140px,1fr)_minmax(200px,1.2fr)_44px] border-b border-border/40 bg-muted/25 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+            <div>Command</div>
+            <div>Keybinding</div>
+            <div className="text-right">Status</div>
+          </div>
+          <div className="divide-y divide-border/40">
+            {!loaded && (
+              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
+                Loading…
+              </div>
+            )}
+            {loaded && filtered.length === 0 && !isAdding && (
+              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
+                {query.trim().length > 0
+                  ? "No keybindings match your search."
+                  : "No keybindings."}
+              </div>
+            )}
+            {filtered.map((row) => (
+              <RowEditor key={row.id} row={row} allRows={rows} />
+            ))}
+            {isAdding && (
+              <NewRow
+                allRows={rows}
+                onCancel={() => setIsAdding(false)}
+                onSaved={() => setIsAdding(false)}
+              />
+            )}
+          </div>
+        </Card>
+
+        <FrameFooter className="px-2 py-1 w-full">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Click the pencil on any row to record a new chord. Bindings persist
+            to{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">
+              keybindings.json
+            </code>{" "}
+            in your app data folder; hand-edit there for advanced scoping.
+          </p>
+        </FrameFooter>
+      </Frame>
 
       <ResetAllFooter />
     </div>
@@ -779,7 +783,7 @@ function ResetAllFooter() {
       <span className="text-muted-foreground">
         {userRulesCount} custom rule{userRulesCount === 1 ? "" : "s"} active.
       </span>
-      <Button variant="outline" size="sm" onClick={() => void resetAll()}>
+      <Button variant="settings" size="sm" onClick={() => void resetAll()}>
         Reset all to defaults
       </Button>
     </div>

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -52,7 +52,7 @@ export function TopBarLeft() {
       className={`${SECTION_CLASS} pr-1 ${isFullScreen ? "pl-3" : "pl-20"}`}
     >
       <span className="truncate font-semibold tracking-tight text-foreground">
-        memoize
+        Nuuk
       </span>
       <span className="flex-1" />
       <Tooltip>

--- a/apps/renderer/src/components/ui/button.tsx
+++ b/apps/renderer/src/components/ui/button.tsx
@@ -31,7 +31,7 @@ export const buttonVariants = cva(
       },
       variant: {
         default:
-          "not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] border-primary bg-primary text-primary-foreground shadow-primary/24 shadow-xs hover:bg-primary/90 data-pressed:bg-primary/90 *:data-[slot=button-loading-indicator]:text-primary-foreground [:active,[data-pressed]]:inset-shadow-[0_1px_--theme(--color-black/8%)] [:disabled,:active,[data-pressed]]:shadow-none",
+          "not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] border-primary bg-primary text-primary-foreground shadow-primary/24 shadow-xs hover:bg-primary/90 data-pressed:bg-primary/90 *:data-[slot=button-loading-indicator]:text-primary-foreground [:active,[data-pressed]]:inset-shadow-[0_1px_--theme(--color-black/8%)] [:disabled,:active,[data-pressed]]:shadow-none btn-lime-embodied",
         destructive:
           "not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] border-destructive bg-destructive text-white shadow-destructive/24 shadow-xs hover:bg-destructive/90 data-pressed:bg-destructive/90 *:data-[slot=button-loading-indicator]:text-white [:active,[data-pressed]]:inset-shadow-[0_1px_--theme(--color-black/8%)] [:disabled,:active,[data-pressed]]:shadow-none",
         "destructive-outline":
@@ -43,6 +43,14 @@ export const buttonVariants = cva(
           "border-input bg-popover not-dark:bg-clip-padding text-foreground shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] hover:bg-accent/50 data-pressed:bg-accent/50 *:data-[slot=button-loading-indicator]:text-foreground dark:bg-input/32 dark:data-pressed:bg-input/64 dark:hover:bg-input/64 dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] [:disabled,:active,[data-pressed]]:shadow-none",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/90 data-pressed:bg-secondary/90 *:data-[slot=button-loading-indicator]:text-secondary-foreground [:active,[data-pressed]]:bg-secondary/80",
+
+        /* Subtle glass button (glassmorphic secondary) */
+        subtle:
+          "h-10 rounded-[10px] border border-white/10 bg-neutral-primary-reverted-5 px-[10px] text-sm font-semibold text-foreground shadow-[0_2px_1.5px_-0.5px_rgba(0,0,0,0.03),inset_0_2px_3px_0_rgba(255,255,255,0.03)] backdrop-blur-[12px] hover:bg-white/8 active:bg-white/12 data-pressed:bg-white/12 *:data-[slot=button-loading-indicator]:text-foreground before:hidden",
+
+        /* Settings: flat translucent action button used on settings rows. */
+        settings:
+          "rounded-[10px] border-white/8 bg-neutral-primary-reverted-20 text-foreground/90 shadow-none hover:bg-white/14 active:bg-white/16 data-pressed:bg-white/16 *:data-[slot=button-loading-indicator]:text-foreground before:hidden",
       },
     },
   },

--- a/apps/renderer/src/components/ui/switch.tsx
+++ b/apps/renderer/src/components/ui/switch.tsx
@@ -11,7 +11,12 @@ export function Switch({
   return (
     <SwitchPrimitive.Root
       className={cn(
-        "inline-flex h-[calc(var(--thumb-size)+2px)] w-[calc(var(--thumb-size)*2-2px)] shrink-0 items-center rounded-full p-px outline-none transition-[background-color,box-shadow] duration-200 [--thumb-size:--spacing(5)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-checked:bg-primary data-unchecked:bg-input data-disabled:opacity-64 sm:[--thumb-size:--spacing(4)]",
+        "group/switch relative inline-flex h-5 w-8 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-all duration-150 outline-none",
+        "ring-1 ring-(--color-neutral-primary-reverted-20,#ffffff1a)",
+        "data-checked:bg-primary data-checked:ring-primary/60",
+        "data-unchecked:bg-[#1f2123] dark:data-unchecked:bg-[#1c1e20]",
+        "focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       data-slot="switch"
@@ -19,7 +24,18 @@ export function Switch({
     >
       <SwitchPrimitive.Thumb
         className={cn(
-          "pointer-events-none block aspect-square h-full origin-left in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:not-data-disabled:scale-x-110 in-[[role=switch]:active,[data-slot=label]:active,[data-slot=field-label]:active]:rounded-[var(--thumb-size)/calc(var(--thumb-size)*1.1)] rounded-(--thumb-size) bg-background shadow-sm/5 will-change-transform [transition:translate_.15s,border-radius_.15s,scale_.1s_.1s,transform-origin_.15s] data-checked:origin-[var(--thumb-size)_50%] data-checked:translate-x-[calc(var(--thumb-size)-4px)]",
+          "relative block size-3.5 rounded-full transition-all duration-120 ease-out",
+          "shadow-[0_1px_2px_rgba(0,0,0,0.1)] bg-linear-to-b from-black/0 to-black/8",
+          "ring-1",
+          // Light mode
+          "bg-white ring-black/10",
+          // Dark mode — balanced dark knob that looks good on bright lime
+          // (darker than light gray, but not as heavy/black as the surface)
+          "dark:bg-[#484a4d] dark:ring-[#2a2c2e]",
+          // When switch is on (lime track), give the knob a crisper ring so it pops nicely
+          "data-checked:dark:ring-[#3a3c3e]",
+          "data-unchecked:ml-0 data-checked:ml-[14px]",
+          "group-active/switch:scale-[0.92]",
         )}
         data-slot="switch-thumb"
       />

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -222,14 +222,14 @@ body,
   --popover: oklch(1 0 0);
   --popover-foreground: var(--foreground);
 
-  --primary: oklch(0.24 0.008 70);
-  --primary-foreground: oklch(0.985 0.003 75);
+  --primary: oklch(0.62 0.18 102);
+  --primary-foreground: oklch(0.985 0.003 102);
   --secondary: oklch(0.955 0.005 70);
   --secondary-foreground: var(--foreground);
   --muted: oklch(0.955 0.005 70);
   --muted-foreground: oklch(0.52 0.012 70);
-  --accent: oklch(0.955 0.005 70);
-  --accent-foreground: var(--foreground);
+  --accent: oklch(0.94 0.03 102);
+  --accent-foreground: oklch(0.24 0.06 102);
 
   --destructive: oklch(0.585 0.22 27);
   --destructive-foreground: oklch(0.985 0.003 75);
@@ -280,6 +280,7 @@ body,
 }
 
 .dark {
+  /* Keep original surface values exactly as they were (no panel style changes) */
   --background: oklch(0.18 0.004 260);
   --foreground: oklch(0.955 0.004 260);
 
@@ -294,8 +295,12 @@ body,
   --popover: oklch(0.255 0.006 260);
   --popover-foreground: var(--foreground);
 
-  --primary: oklch(0.94 0.004 260);
-  --primary-foreground: oklch(0.18 0.004 260);
+  /* Soft lime accent. Lower L/C than a pure-neon lime so it reads as an
+     accent, not a glare. Reused via --lime across primary/ring/sidebar/
+     glow utilities — change it here and everything follows. */
+  --lime: oklch(0.88 0.15 118);
+  --primary: var(--lime);
+  --primary-foreground: oklch(0.18 0.02 118);
 
   --secondary: oklch(0.305 0.006 260);
   --secondary-foreground: var(--foreground);
@@ -309,20 +314,15 @@ body,
   --destructive: oklch(0.68 0.19 25);
   --destructive-foreground: oklch(0.985 0.003 260);
 
-  --success: oklch(0.72 0.13 155);
+  --success: #26bd6c;
   --success-foreground: oklch(0.18 0.004 260);
 
-  --warning: oklch(0.8 0.12 85);
+  --warning: #f48e2f;
   --warning-foreground: oklch(0.18 0.004 260);
 
-  --info: oklch(0.7 0.09 245);
+  --info: #4778f5;
   --info-foreground: oklch(0.985 0.003 260);
 
-  /* Dark-mode alert surfaces — soft warm hues, dark enough to be a card
-     background. L≈0.36 keeps it clearly "the card is red/amber" while the
-     reduced chroma (compared to `--destructive` at 0.19) keeps it soft, not
-     loud. Hue shifted slightly warm (25→18 for red, 85→70 for amber) so
-     the surface reads warmer than the icon's saturated stroke. */
   --alert-error-bg: oklch(0.36 0.07 18);
   --alert-warning-bg: oklch(0.36 0.06 70);
   --alert-info-bg: oklch(0.36 0.05 240);
@@ -330,32 +330,32 @@ body,
 
   --border: oklch(1 0 0 / 0.09);
   --input: oklch(1 0 0 / 0.14);
-  --ring: oklch(0.65 0.025 260);
+  --ring: var(--lime);
 
   --sidebar: oklch(0.2 0.004 260);
   --sidebar-foreground: oklch(0.955 0.004 260);
 
-  --sidebar-primary: oklch(0.72 0.075 260);
-  --sidebar-primary-foreground: oklch(0.18 0.004 260);
+  --sidebar-primary: var(--lime);
+  --sidebar-primary-foreground: oklch(0.18 0.02 118);
 
   --sidebar-accent: oklch(0.285 0.006 260);
   --sidebar-accent-foreground: var(--foreground);
 
   --sidebar-border: oklch(1 0 0 / 0.09);
-  --sidebar-ring: oklch(0.65 0.025 260);
+  --sidebar-ring: var(--lime);
 
-  --chart-1: oklch(0.72 0.075 260);
-  --chart-2: oklch(0.72 0.12 155);
-  --chart-3: oklch(0.78 0.11 85);
-  --chart-4: oklch(0.72 0.09 295);
-  --chart-5: oklch(0.68 0.17 25);
+  /* Subtle glass button tokens */
+  --color-neutral-primary-reverted-5: #ffffff0d;
+  --color-neutral-primary-reverted-20: #ffffff14;
+  --color-white-3: #ffffff08;
 
-  /* Chat bubble + prose. The user bubble sits one rung above `accent` with
-     a slight blue tint so it reads as a distinct surface, not a button.
-     `--message-text` and `--message-heading` are both dimmed below
-     `--foreground` (0.955) so a long answer feels like a calm read rather
-     than a wall of white. Headings stay only ~0.08 above body so the
-     hierarchy comes from weight + spacing, not blast-bright text. */
+  --chart-1: var(--lime);
+  --chart-2: #26bd6c;
+  --chart-3: #f48e2f;
+  --chart-4: #4778f5;
+  --chart-5: #e6483d;
+
+  /* Chat bubble + prose kept close to original for now */
   --user-bubble: oklch(0.36 0.022 260);
   --user-bubble-foreground: oklch(0.96 0.005 260);
   --message-text: oklch(0.78 0.006 260);
@@ -584,5 +584,74 @@ body,
   /* Image-thumb chips: thumbnail fills the icon slot with no inner bg. */
   .fz-chip[data-kind="image"] .fz-chip-icon:has(.fz-chip-thumb) {
     background-color: transparent;
+  }
+}
+
+/* ============================================================
+   Neon lime + embodied UI enhancements
+   ============================================================ */
+
+/* Lime glow utilities. All alpha layers derived from --lime via color-mix
+   so re-toning the accent (in .dark { --lime: … }) propagates here. */
+@layer components {
+  .neon-lime {
+    color: var(--lime);
+    text-shadow:
+      0 0 4px color-mix(in oklch, var(--lime) 25%, transparent),
+      0 0 12px color-mix(in oklch, var(--lime) 15%, transparent);
+  }
+
+  .shadow-lime-glow {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 20%, transparent),
+      0 0 10px color-mix(in oklch, var(--lime) 25%, transparent),
+      0 0 24px color-mix(in oklch, var(--lime) 15%, transparent);
+  }
+
+  .shadow-lime-glow-strong {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent),
+      0 0 14px color-mix(in oklch, var(--lime) 36%, transparent),
+      0 0 32px color-mix(in oklch, var(--lime) 24%, transparent);
+  }
+
+  /* Embodied primary button */
+  .btn-lime-embodied {
+    transition:
+      box-shadow 120ms cubic-bezier(0.23, 1, 0.32, 1),
+      transform 80ms cubic-bezier(0.23, 1, 0.32, 1),
+      background-color 120ms ease;
+  }
+  .btn-lime-embodied:hover:not(:disabled):not([data-loading]) {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 25%, transparent),
+      0 0 12px color-mix(in oklch, var(--lime) 32%, transparent),
+      var(--tw-shadow, 0 0 #0000);
+    transform: translateY(-0.5px);
+  }
+  .btn-lime-embodied:active:not(:disabled):not([data-loading]),
+  .btn-lime-embodied[data-pressed]:not(:disabled):not([data-loading]) {
+    transform: translateY(0.5px) scale(0.985);
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 15%, transparent),
+      0 0 6px color-mix(in oklch, var(--lime) 20%, transparent),
+      var(--tw-shadow, 0 0 #0000);
+  }
+
+  /* Framed card polish — ensure inner FramePanels get the full layered
+     bevel treatment when nested inside the main shell Frames. */
+  [data-slot="frame"] [data-slot="card"] {
+    box-shadow:
+      0 1px 0 oklch(1 0 0 / 0.035) inset,
+      0 -1px 0 oklch(0 0 0 / 0.25) inset,
+      var(--tw-shadow, 0 0 #0000);
+  }
+}
+
+/* Lime focus ring override for inputs/selects when inside dark framed surfaces */
+@layer base {
+  .dark .focus-lime-ring:focus-visible,
+  .dark [data-slot="input-control"]:has(:focus-visible) {
+    --ring: oklch(0.82 0.17 102 / 0.55);
   }
 }


### PR DESCRIPTION
## Summary
- Rebuild settings (General, Providers, Workspace, Sub-agents, Shortcuts, Repository) on a single `Frame > FrameHeader > Card > FrameFooter` shell — title (+ optional trailing Switch / button / Select) in the header, divided rows in the card, descriptive copy in the footer. Replaces the old double-nested `Frame > Card > CardPanel` look.
- New `RadioCheck` (filled disc + check) replaces nested-dot radios; provider list rows lose individual borders in favor of `divide-y` inside one Card; default-agent and repo override pickers expand the model picker inline under the selected provider.
- Repository override fix: collapse `onProviderChange` + `onModelChange` into a single atomic `onProviderAndModelChange` callback so parallel `update()` RPCs no longer race and revert provider back to Claude when picking Gemini; override list now shows all enabled providers (claude/codex/gemini) instead of just claude/codex.
- New `settings` button variant (flat translucent, `rounded-[10px]`) used across settings action buttons; outline → settings/destructive-outline migration scoped to settings only.
- Dark-mode primary/ring/sidebar/charts switched to a vivid lime, plus subtle glass-button tokens and lime focus-ring utilities.

## Test plan
- [ ] Open Settings (Cmd+,) — walk General → Providers → Workspace → Sub-agents → Shortcuts and confirm single-surface frames, uppercase headers, inline descriptions, flat secondary buttons.
- [ ] Click a repository in the rail → toggle Default agent override → pick Gemini → confirm it sticks (no revert to Claude); pick a model under the selected provider; toggle Permission-mode override; verify Worktree section actions.
- [ ] Onboarding provider step still renders (uses re-exported `PROVIDER_LABEL` from settings-page).
- [ ] `bun run check-types` passes.