### PR TITLE
feat(top-bar): glass workflow buttons + Fix actions for failing CI

### DIFF
--- a/apps/renderer/src/components/glass-action.tsx
+++ b/apps/renderer/src/components/glass-action.tsx
@@ -1,0 +1,80 @@
+import type * as React from "react";
+
+export type GlassTone = "amber" | "pink" | "green" | "blue" | "red" | "zinc";
+
+const TONE_VAR: Record<GlassTone, string> = {
+  amber: "var(--accent-amber)",
+  pink: "var(--accent-pink)",
+  green: "var(--accent-green)",
+  blue: "var(--accent-blue)",
+  red: "var(--accent-red)",
+  zinc: "var(--accent-zinc)",
+};
+
+const toneStyle = (tone: GlassTone): React.CSSProperties =>
+  ({ ["--tone" as string]: TONE_VAR[tone] }) as React.CSSProperties;
+
+/**
+ * Workflow-state chip — glass-tinted pill that pairs with the action button.
+ * Drives the bg + inset highlight + text color via the shared `--tone` CSS
+ * var read by `.glass-tone` in styles.css.
+ */
+export function GlassChip({
+  tone,
+  children,
+}: {
+  tone: GlassTone;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <span
+      className="glass-tone flex shrink-0 items-center rounded-md px-2 py-0.5 font-mono text-[10px] font-semibold tracking-tight"
+      style={toneStyle(tone)}
+    >
+      {children}
+    </span>
+  );
+}
+
+/**
+ * Workflow primary button — filled glass with subtle inset highlight, tinted
+ * by tone. Used in the top bar (commit / push / merge / etc.) and in the
+ * Developer settings pane.
+ */
+export function GlassActionButton({
+  tone,
+  icon,
+  label,
+  onClick,
+  disabled,
+}: {
+  tone: GlassTone;
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={toneStyle(tone)}
+      className="glass-tone flex h-7 items-center gap-1.5 rounded-[10px] px-2.5 text-[11px] font-semibold tracking-tight transition-colors disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:size-3.5 [&_svg]:opacity-90"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+export const GLASS_TONES: ReadonlyArray<GlassTone> = [
+  "amber",
+  "pink",
+  "green",
+  "blue",
+  "red",
+  "zinc",
+];
+
+export const GLASS_TONE_VARS: Record<GlassTone, string> = TONE_VAR;

--- a/apps/renderer/src/components/pr-pane.tsx
+++ b/apps/renderer/src/components/pr-pane.tsx
@@ -486,6 +486,8 @@ function PrStatePill({ pr }: { pr: GitPrInfo }) {
   if (pr.isDraft) return <Pill tone="zinc">Draft</Pill>;
   if (pr.state === "merged") return <Pill tone="violet">Merged</Pill>;
   if (pr.state === "closed") return <Pill tone="rose">Closed</Pill>;
+  if (pr.mergeable === "conflicting")
+    return <Pill tone="red">Open · conflicts</Pill>;
   if (pr.checks === "failure")
     return <Pill tone="red">Open · checks failed</Pill>;
   if (pr.checks === "pending")

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -152,7 +152,12 @@ function renderChangesBadge(dirtyFiles: number): React.ReactNode {
 }
 
 function renderPrBadge(
-  pr: { state: string; isDraft: boolean; checks: string } | null,
+  pr: {
+    state: string;
+    isDraft: boolean;
+    checks: string;
+    mergeable: string;
+  } | null,
   details:
     | {
         comments: ReadonlyArray<unknown>;
@@ -163,6 +168,13 @@ function renderPrBadge(
 ): React.ReactNode {
   if (pr === null || pr.state === "none") return null;
   if (pr.state === "open" && !pr.isDraft) {
+    if (pr.mergeable === "conflicting") {
+      return (
+        <span className="flex items-center text-rose-300" title="Merge conflicts">
+          <span className="size-2 rounded-full bg-rose-400" />
+        </span>
+      );
+    }
     if (pr.checks === "failure") {
       const failing =
         details === null

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -2,6 +2,7 @@ import {
   ArrowLeft,
   Box,
   Check,
+  FlaskConical,
   FolderClosed,
   GitBranch,
   Keyboard,
@@ -32,6 +33,7 @@ import { useWorkspaceStore } from "../store/workspace.ts";
 import { ProviderCard } from "./provider-card.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { MODES_ORDER, MODE_META } from "./runtime-mode-meta.ts";
+import { DeveloperPane } from "./settings/developer-pane.tsx";
 import { KeybindingsPane } from "./settings/keybindings-editor.tsx";
 import { RepositorySettings } from "./settings-repository.tsx";
 import { Button } from "./ui/button.tsx";
@@ -86,7 +88,19 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
     Icon: Keyboard,
     section: { kind: "shortcuts" },
   },
+  // Dev-only visual playground (accent swatches + workflow chip/button
+  // showcase). Filtered out of production bundles below.
+  {
+    id: "developer",
+    label: "Developer",
+    Icon: FlaskConical,
+    section: { kind: "developer" },
+  },
 ];
+
+const VISIBLE_RAIL: ReadonlyArray<RailItemBase> = import.meta.env.DEV
+  ? TOP_RAIL
+  : TOP_RAIL.filter((i) => i.id !== "developer");
 
 /**
  * Two-pane settings surface. The left rail navigates between global
@@ -147,7 +161,7 @@ function Rail({
   return (
     <nav className="flex w-56 shrink-0 flex-col gap-6 border-r border-border/40 bg-sidebar/40 px-3 py-6 text-sm text-sidebar-foreground">
       <div className="flex flex-col gap-0.5">
-        {TOP_RAIL.map((item) => {
+        {VISIBLE_RAIL.map((item) => {
           const active =
             section.kind !== "repository" && section.kind === item.section.kind;
           return (
@@ -263,6 +277,12 @@ function SectionTitle({
         subtitle: "These also appear under the menu bar.",
       };
     }
+    if (section.kind === "developer") {
+      return {
+        title: "Developer",
+        subtitle: "Accent palette + workflow chip/button states (dev builds only).",
+      };
+    }
     const f = folders.find((x) => x.id === section.projectId);
     return {
       title: f?.name ?? "Repository",
@@ -294,6 +314,7 @@ function Pane({ section }: { section: SettingsSection }) {
   if (section.kind === "providers") return <ProvidersPane />;
   if (section.kind === "workspace") return <WorkspacePane />;
   if (section.kind === "shortcuts") return <KeybindingsPane />;
+  if (section.kind === "developer") return <DeveloperPane />;
   return <RepositorySettings projectId={section.projectId} />;
 }
 

--- a/apps/renderer/src/components/settings/developer-pane.tsx
+++ b/apps/renderer/src/components/settings/developer-pane.tsx
@@ -1,0 +1,161 @@
+import {
+  GitMerge,
+  GitPullRequestArrow,
+  TriangleAlert,
+  Upload,
+  Wrench,
+} from "lucide-react";
+
+import {
+  GlassActionButton,
+  GlassChip,
+  GLASS_TONES,
+  GLASS_TONE_VARS,
+  type GlassTone,
+} from "../glass-action.tsx";
+
+/**
+ * Dev-only visual playground. Renders the accent palette + every state of
+ * the top-bar workflow chip/button so we can tune colors without driving the
+ * real surface (which requires a real git state + PR to exercise). Hidden in
+ * production via the rail filter in `settings-page.tsx`.
+ */
+export function DeveloperPane(): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-10">
+      <PaletteSection />
+      <WorkflowStatesSection />
+    </div>
+  );
+}
+
+const EXTRA_TOKENS: ReadonlyArray<{ name: string; cssVar: string }> = [
+  { name: "lime", cssVar: "var(--lime)" },
+  { name: "background", cssVar: "var(--background)" },
+  { name: "muted", cssVar: "var(--muted)" },
+  { name: "border", cssVar: "var(--border)" },
+];
+
+function PaletteSection(): React.ReactElement {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-xs font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+        Accent palette
+      </h2>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {GLASS_TONES.map((tone) => (
+          <Swatch
+            key={tone}
+            name={`accent-${tone}`}
+            cssVar={GLASS_TONE_VARS[tone]}
+          />
+        ))}
+        {EXTRA_TOKENS.map((t) => (
+          <Swatch key={t.name} name={t.name} cssVar={t.cssVar} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Swatch({
+  name,
+  cssVar,
+}: {
+  name: string;
+  cssVar: string;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border/40 bg-muted/30 p-3">
+      <div
+        className="size-10 shrink-0 rounded-lg border border-white/8"
+        style={{ backgroundColor: cssVar }}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-sm font-medium text-foreground">{name}</span>
+        <span className="truncate font-mono text-[10px] text-muted-foreground">
+          {cssVar}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+type WorkflowDemo = {
+  label: string;
+  tone: GlassTone;
+  chip: string;
+  action: { label: string; icon: React.ReactNode };
+};
+
+const WORKFLOW_DEMOS: ReadonlyArray<WorkflowDemo> = [
+  {
+    label: "dirty",
+    tone: "amber",
+    chip: "1 change",
+    action: { label: "Commit & push", icon: <Upload /> },
+  },
+  {
+    label: "ahead",
+    tone: "pink",
+    chip: "2 ahead",
+    action: { label: "Create PR", icon: <GitPullRequestArrow /> },
+  },
+  {
+    label: "open-pr",
+    tone: "green",
+    chip: "#142",
+    action: { label: "Merge", icon: <GitMerge /> },
+  },
+  {
+    label: "open-pr · draft",
+    tone: "zinc",
+    chip: "#142",
+    action: { label: "Mark ready", icon: <GitMerge /> },
+  },
+  {
+    label: "open-pr · checks failing",
+    tone: "red",
+    chip: "#142",
+    action: { label: "Fix actions", icon: <Wrench /> },
+  },
+  {
+    label: "open-pr · conflicts",
+    tone: "red",
+    chip: "#142",
+    action: { label: "Resolve conflicts", icon: <TriangleAlert /> },
+  },
+];
+
+function noop(): void {}
+
+function WorkflowStatesSection(): React.ReactElement {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-xs font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+        Top-bar workflow states
+      </h2>
+      <div className="flex flex-col divide-y divide-border/40 overflow-hidden rounded-xl border border-border/40 bg-muted/30">
+        {WORKFLOW_DEMOS.map((s) => (
+          <div
+            key={s.label}
+            className="flex items-center justify-between gap-3 px-3 py-2.5"
+          >
+            <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+              {s.label}
+            </span>
+            <div className="flex items-center gap-2">
+              <GlassChip tone={s.tone}>{s.chip}</GlassChip>
+              <GlassActionButton
+                tone={s.tone}
+                icon={s.action.icon}
+                label={s.action.label}
+                onClick={noop}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -2,23 +2,27 @@ import {
   GitBranch,
   GitMerge,
   GitPullRequestArrow,
+  Loader2,
   PanelLeftClose,
   PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
+  TriangleAlert,
   Upload,
+  Wrench,
 } from "lucide-react";
-import { useEffect } from "react";
+import { Effect } from "effect";
+import { useEffect, useState } from "react";
 
-import type { FolderId } from "@memoize/wire";
+import type { FolderId, WorktreeId } from "@memoize/wire";
 
+import { getRpcClient } from "../lib/rpc-client.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
 import {
-  softInteractive,
-  softTone,
-  solidInteractive,
-  type Tone,
-} from "../lib/tones.ts";
+  GlassActionButton,
+  GlassChip,
+  type GlassTone,
+} from "./glass-action.tsx";
 import { TooltipShortcut } from "./projects-sidebar.tsx";
 import { useActiveWorktreeId } from "../store/active-workspace.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
@@ -205,8 +209,21 @@ type Workflow =
       url: string | null;
       isDraft: boolean;
       checks: "none" | "pending" | "success" | "failure";
+      mergeable: "clean" | "conflicting" | "unknown";
     };
 
+/**
+ * Priority is the user's next sensible action, in order of urgency:
+ *   1. dirty   — uncommitted files in the working tree
+ *   2. ahead   — local commits not yet pushed (regardless of PR state — if
+ *                there are unpushed commits, that's what the user should do
+ *                next, not stare at failing checks on stale code)
+ *   3. open-pr — a PR exists and the working tree + upstream are in sync
+ *   4. idle    — nothing to do
+ *
+ * Each kind carries only the fields its button needs, so the renderer
+ * doesn't have to re-narrow PR shape downstream.
+ */
 const deriveWorkflow = (
   status: { dirtyFiles: number; ahead: number } | null,
   pr: {
@@ -215,10 +232,12 @@ const deriveWorkflow = (
     url: string | null;
     isDraft?: boolean;
     checks?: "none" | "pending" | "success" | "failure";
+    mergeable?: "clean" | "conflicting" | "unknown";
   } | null,
 ): Workflow => {
   if (status === null) return { kind: "idle" };
   if (status.dirtyFiles > 0) return { kind: "dirty", count: status.dirtyFiles };
+  if (status.ahead > 0) return { kind: "ahead", count: status.ahead };
   if (pr && pr.state === "open") {
     return {
       kind: "open-pr",
@@ -226,10 +245,8 @@ const deriveWorkflow = (
       url: pr.url,
       isDraft: pr.isDraft === true,
       checks: pr.checks ?? "none",
+      mergeable: pr.mergeable ?? "unknown",
     };
-  }
-  if (status.ahead > 0 && (pr === null || pr.state === "none")) {
-    return { kind: "ahead", count: status.ahead };
   }
   return { kind: "idle" };
 };
@@ -276,49 +293,75 @@ export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
     <header className={`${SECTION_CLASS} justify-between px-2`}>
       <div className={`flex min-w-0 flex-1 items-center gap-2 ${ACTION_CLASS}`}>
         {workflow.kind === "dirty" ? (
-          <Pill tone="amber">
+          <GlassChip tone="amber">
             {workflow.count} change{workflow.count === 1 ? "" : "s"}
-          </Pill>
+          </GlassChip>
         ) : null}
         {workflow.kind === "ahead" ? (
-          <Pill tone="sky">{workflow.count} ahead</Pill>
+          <GlassChip tone="pink">{workflow.count} ahead</GlassChip>
         ) : null}
         {workflow.kind === "open-pr" ? (
-          <Pill tone={prBadgeTone(workflow)}>#{workflow.number ?? "?"}</Pill>
+          <GlassChip tone={openPrChipTone(workflow)}>
+            #{workflow.number ?? "?"}
+          </GlassChip>
         ) : null}
       </div>
       <div className={`flex shrink-0 items-center gap-1 ${ACTION_CLASS}`}>
         {workflow.kind === "dirty" ? (
-          <ActionButton
+          <GlassActionButton
             tone="amber"
-            variant="solid"
-            icon={<Upload className="size-3.5" />}
+            icon={<Upload />}
             label="Commit & push"
             disabled={!composerReady}
             onClick={() => sendToComposer("commit and push the current changes")}
           />
         ) : null}
         {workflow.kind === "ahead" ? (
-          <ActionButton
-            tone="sky"
-            variant="solid"
-            icon={<GitPullRequestArrow className="size-3.5" />}
-            label="Create PR"
+          <GlassActionButton
+            tone="pink"
+            icon={<GitPullRequestArrow />}
+            label={pr && pr.state === "open" ? "Push commits" : "Create PR"}
             disabled={!composerReady}
-            onClick={() => sendToComposer("create a pull request for this branch")}
+            onClick={() =>
+              sendToComposer(
+                pr && pr.state === "open"
+                  ? "push the unpushed commits on this branch"
+                  : "create a pull request for this branch",
+              )
+            }
           />
         ) : null}
-        {workflow.kind === "open-pr" ? (
-          <ActionButton
-            tone="emerald"
-            variant="solid"
-            icon={<GitMerge className="size-3.5" />}
-            label={workflow.isDraft ? "Mark ready" : "Merge"}
-            disabled={
-              !composerReady ||
-              workflow.checks === "pending" ||
-              workflow.checks === "failure"
+        {workflow.kind === "open-pr" && workflow.mergeable === "conflicting" ? (
+          <GlassActionButton
+            tone="red"
+            icon={<TriangleAlert />}
+            label="Resolve conflicts"
+            disabled={!composerReady}
+            onClick={() =>
+              sendToComposer(
+                "this pull request has merge conflicts — help me resolve them",
+              )
             }
+          />
+        ) : null}
+        {workflow.kind === "open-pr" &&
+        workflow.mergeable !== "conflicting" &&
+        workflow.checks === "failure" &&
+        folderId !== null ? (
+          <FixActionsButton
+            folderId={folderId}
+            worktreeId={worktreeId}
+            disabled={!composerReady}
+          />
+        ) : null}
+        {workflow.kind === "open-pr" &&
+        workflow.mergeable !== "conflicting" &&
+        workflow.checks !== "failure" ? (
+          <GlassActionButton
+            tone={workflow.isDraft ? "zinc" : "green"}
+            icon={<GitMerge />}
+            label={workflow.isDraft ? "Mark ready" : "Merge"}
+            disabled={!composerReady || workflow.checks === "pending"}
             onClick={() =>
               sendToComposer(
                 workflow.isDraft
@@ -333,56 +376,75 @@ export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
   );
 }
 
-function Pill({ tone, children }: { tone: Tone; children: React.ReactNode }) {
-  return (
-    <span
-      className={`flex shrink-0 items-center rounded-sm px-1.5 py-0.5 font-mono text-[10px] tracking-tight ${softTone(tone)}`}
-    >
-      {children}
-    </span>
-  );
-}
-
-type Variant = "solid" | "soft";
-
-function ActionButton({
-  tone,
-  variant,
-  icon,
-  label,
-  onClick,
-  disabled,
-  trailing,
-}: {
-  tone: Tone;
-  variant: Variant;
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-  trailing?: React.ReactNode;
-}) {
-  const palette =
-    variant === "solid" ? solidInteractive(tone) : softInteractive(tone);
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={`flex items-center gap-1.5 rounded-sm px-2 py-1 text-[11px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${palette}`}
-    >
-      {icon}
-      {label}
-      {trailing}
-    </button>
-  );
-}
-
-const prBadgeTone = (
+const openPrChipTone = (
   w: Extract<Workflow, { kind: "open-pr" }>,
-): Tone => {
+): GlassTone => {
+  if (w.mergeable === "conflicting") return "red";
   if (w.checks === "failure") return "red";
   if (w.checks === "pending") return "amber";
   if (w.isDraft) return "zinc";
-  return "emerald";
+  return "green";
 };
+
+/**
+ * Failing-checks CTA. On click, asks the server to drop a captured
+ * `.memoize/failing-checks-<ts>.txt` artifact, then attaches it to the
+ * composer as `@<relPath>` and primes the agent with a short instruction so
+ * the user just has to hit send.
+ *
+ * Stateful (loading spinner) because the server has to call `gh run view
+ * --log-failed` once per failing run; on a chunky pipeline this can take a
+ * couple seconds.
+ */
+function FixActionsButton({
+  folderId,
+  worktreeId,
+  disabled,
+}: {
+  folderId: FolderId;
+  worktreeId: WorktreeId | null;
+  disabled: boolean;
+}) {
+  const [loading, setLoading] = useState(false);
+  const attachFile = useComposerBridge((s) => s.attachFile);
+  const insertText = useComposerBridge((s) => s.insertText);
+  const focusComposer = useComposerBridge((s) => s.focus);
+  const setActiveMainTab = useUiStore((s) => s.setActiveMainTab);
+
+  const onClick = async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const client = await getRpcClient();
+      const artifact = await Effect.runPromise(
+        client.git.fixFailingChecks({ folderId, worktreeId }),
+      );
+      setActiveMainTab("chat");
+      attachFile?.({
+        relPath: artifact.relPath,
+        absPath: artifact.absPath,
+        kind: "file",
+      });
+      insertText?.(
+        `Please look at the failing CI checks captured in this log and fix them.`,
+      );
+      focusComposer?.();
+    } catch {
+      // Server already surfaces a GitCommandError; nothing useful to render
+      // in-place. The user can retry — leave the button enabled.
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <GlassActionButton
+      tone="red"
+      icon={loading ? <Loader2 className="animate-spin" /> : <Wrench />}
+      label={loading ? "Capturing…" : "Fix actions"}
+      disabled={disabled || loading}
+      onClick={onClick}
+    />
+  );
+}
+

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -18,6 +18,7 @@ export type SettingsSection =
   | { readonly kind: "providers" }
   | { readonly kind: "workspace" }
   | { readonly kind: "shortcuts" }
+  | { readonly kind: "developer" }
   | { readonly kind: "repository"; readonly projectId: FolderId };
 
 /**

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -302,6 +302,16 @@ body,
   --primary: var(--lime);
   --primary-foreground: oklch(0.18 0.02 122);
 
+  /* Accent palette for stateful surfaces (PR card, status pills). Inspired
+     by but softer than the obvious rgb(245,68,181)/rgb(42,189,101)/
+     rgb(17,179,231) trio — oklch lets us keep them perceptually balanced. */
+  --accent-pink: oklch(0.7 0.2 0);
+  --accent-green: oklch(0.74 0.16 150);
+  --accent-blue: oklch(0.74 0.13 230);
+  --accent-amber: oklch(0.82 0.16 80);
+  --accent-red: oklch(0.66 0.22 25);
+  --accent-zinc: oklch(0.74 0.01 260);
+
   --secondary: oklch(0.305 0.006 260);
   --secondary-foreground: var(--foreground);
 
@@ -645,6 +655,43 @@ body,
       0 1px 0 oklch(1 0 0 / 0.035) inset,
       0 -1px 0 oklch(0 0 0 / 0.25) inset,
       var(--tw-shadow, 0 0 #0000);
+  }
+
+  /* Tinted glass surfaces (PR card states, status buttons). Reads --tone
+     from a per-instance CSS var, e.g.
+       <div class="glass-tone" style={{ "--tone": "var(--accent-blue)" }}>
+     The bg + inset highlight + text color all derive from one var so we
+     never duplicate per-tone classes. */
+  .glass-tone {
+    background-color: color-mix(in oklch, var(--tone) 14%, transparent);
+    color: color-mix(in oklch, var(--tone) 88%, white);
+    box-shadow:
+      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.04),
+      inset 0 1px 0 0 color-mix(in oklch, var(--tone) 24%, transparent),
+      inset 0 2px 3px 0 color-mix(in oklch, var(--tone) 14%, transparent);
+    backdrop-filter: blur(12px);
+  }
+  .glass-tone:hover:not(:disabled) {
+    background-color: color-mix(in oklch, var(--tone) 20%, transparent);
+  }
+  .glass-tone:active:not(:disabled) {
+    background-color: color-mix(in oklch, var(--tone) 26%, transparent);
+  }
+
+  /* Untinted glass — same shape, neutral palette. Used for secondary actions. */
+  .glass-neutral {
+    background-color: var(--color-neutral-primary-reverted-5);
+    color: var(--foreground);
+    box-shadow:
+      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.03),
+      inset 0 2px 3px 0 rgba(255, 255, 255, 0.03);
+    backdrop-filter: blur(12px);
+  }
+  .glass-neutral:hover:not(:disabled) {
+    background-color: var(--color-neutral-primary-reverted-20);
+  }
+  .glass-neutral:active:not(:disabled) {
+    background-color: rgba(255, 255, 255, 0.16);
   }
 }
 

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -295,12 +295,12 @@ body,
   --popover: oklch(0.255 0.006 260);
   --popover-foreground: var(--foreground);
 
-  /* Soft lime accent. Lower L/C than a pure-neon lime so it reads as an
-     accent, not a glare. Reused via --lime across primary/ring/sidebar/
-     glow utilities — change it here and everything follows. */
-  --lime: oklch(0.88 0.15 118);
+  /* Bright lime accent. Reused via --lime across primary/ring/sidebar/
+     glow utilities — change it here and everything follows. Hue/chroma
+     intentionally a touch off the obvious neon pin so it reads as ours. */
+  --lime: oklch(0.94 0.2 122);
   --primary: var(--lime);
-  --primary-foreground: oklch(0.18 0.02 118);
+  --primary-foreground: oklch(0.18 0.02 122);
 
   --secondary: oklch(0.305 0.006 260);
   --secondary-foreground: var(--foreground);
@@ -336,7 +336,7 @@ body,
   --sidebar-foreground: oklch(0.955 0.004 260);
 
   --sidebar-primary: var(--lime);
-  --sidebar-primary-foreground: oklch(0.18 0.02 118);
+  --sidebar-primary-foreground: oklch(0.18 0.02 122);
 
   --sidebar-accent: oklch(0.285 0.006 260);
   --sidebar-accent-foreground: var(--foreground);

--- a/apps/server/src/git/handlers.ts
+++ b/apps/server/src/git/handlers.ts
@@ -63,6 +63,14 @@ const Push = MemoizeRpcs.toLayerHandler(
     Effect.flatMap(GitService, (svc) => svc.push(folderId, worktreeId ?? null)),
 );
 
+const FixFailingChecks = MemoizeRpcs.toLayerHandler(
+  "git.fixFailingChecks",
+  ({ folderId, worktreeId }) =>
+    Effect.flatMap(GitService, (svc) =>
+      svc.fixFailingChecks(folderId, worktreeId ?? null),
+    ),
+);
+
 export const GitHandlersLayer = Layer.mergeAll(
   Log,
   Status,
@@ -73,4 +81,5 @@ export const GitHandlersLayer = Layer.mergeAll(
   Changes,
   Commit,
   Push,
+  FixFailingChecks,
 );

--- a/apps/server/src/git/layers/git-service.ts
+++ b/apps/server/src/git/layers/git-service.ts
@@ -1,4 +1,4 @@
-import { Command, CommandExecutor } from "@effect/platform";
+import { Command, CommandExecutor, FileSystem, Path } from "@effect/platform";
 import {
   Duration,
   Effect,
@@ -14,6 +14,7 @@ import {
   GitChange,
   GitCommandError,
   GitCommit,
+  GitFailingChecksArtifact,
   GitFolderNotFoundError,
   GitNotARepoError,
   GitNotInstalledError,
@@ -302,6 +303,8 @@ export const GitServiceLive = Layer.effect(
     const workspace = yield* WorkspaceService;
     const worktrees = yield* WorktreeService;
     const executor = yield* CommandExecutor.CommandExecutor;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
 
     const resolvePath = (
       folderId: FolderId,
@@ -487,6 +490,7 @@ export const GitServiceLive = Layer.effect(
             url: null,
             isDraft: false,
             checks: "none",
+            mergeable: "unknown",
           });
 
           // `gh pr view --json` returns the PR for the current branch. Exits
@@ -496,7 +500,7 @@ export const GitServiceLive = Layer.effect(
             "pr",
             "view",
             "--json",
-            "state,additions,deletions,number,url,headRefName,baseRefName,isDraft,statusCheckRollup",
+            "state,additions,deletions,number,url,headRefName,baseRefName,isDraft,statusCheckRollup,mergeable",
           ]).pipe(
             Effect.catchTags({
               GitNotInstalledError: () => Effect.succeed(""),
@@ -515,6 +519,7 @@ export const GitServiceLive = Layer.effect(
             headRefName?: string;
             baseRefName?: string;
             isDraft?: boolean;
+            mergeable?: string;
             statusCheckRollup?: ReadonlyArray<{
               status?: string;
               state?: string;
@@ -557,6 +562,7 @@ export const GitServiceLive = Layer.effect(
             url: parsed.url ?? null,
             isDraft: parsed.isDraft === true,
             checks,
+            mergeable: mapMergeable(parsed.mergeable),
           });
         }),
       );
@@ -577,6 +583,18 @@ export const GitServiceLive = Layer.effect(
           return "pending";
         default:
           return "commented";
+      }
+    };
+
+    const mapMergeable = (raw: string | undefined): GitPrInfo["mergeable"] => {
+      switch ((raw ?? "").toUpperCase()) {
+        case "MERGEABLE":
+        case "CLEAN":
+          return "clean";
+        case "CONFLICTING":
+          return "conflicting";
+        default:
+          return "unknown";
       }
     };
 
@@ -623,6 +641,7 @@ export const GitServiceLive = Layer.effect(
       url: null,
       isDraft: false,
       checks: "none",
+      mergeable: "unknown",
       additions: 0,
       deletions: 0,
       title: "",
@@ -643,7 +662,7 @@ export const GitServiceLive = Layer.effect(
             "pr",
             "view",
             "--json",
-            "state,additions,deletions,number,url,headRefName,baseRefName,isDraft,statusCheckRollup,title,body,author,comments,reviews,files",
+            "state,additions,deletions,number,url,headRefName,baseRefName,isDraft,statusCheckRollup,title,body,author,comments,reviews,files,mergeable",
           ]).pipe(
             Effect.catchTags({
               GitNotInstalledError: () => Effect.succeed(""),
@@ -662,6 +681,7 @@ export const GitServiceLive = Layer.effect(
             headRefName?: string;
             baseRefName?: string;
             isDraft?: boolean;
+            mergeable?: string;
             title?: string;
             body?: string;
             author?: { login?: string };
@@ -764,6 +784,7 @@ export const GitServiceLive = Layer.effect(
             url: parsed.url ?? null,
             isDraft: parsed.isDraft === true,
             checks,
+            mergeable: mapMergeable(parsed.mergeable),
             additions:
               typeof parsed.additions === "number" ? parsed.additions : 0,
             deletions:
@@ -841,6 +862,144 @@ export const GitServiceLive = Layer.effect(
         }),
       );
 
+    /**
+     * Capture logs from every failing GitHub Actions run on the current PR
+     * and drop them in `<worktree>/.memoize/failing-checks-<ts>.txt` so the
+     * renderer can attach the file to the composer (`@.memoize/...txt`) and
+     * ask the agent to fix it.
+     *
+     * Failing runs are detected via `gh pr view --json statusCheckRollup`;
+     * the run ID is parsed from each entry's `detailsUrl` (the
+     * `/actions/runs/<id>/...` segment). For each unique run we shell to
+     * `gh run view <id> --log-failed`, concatenate with a header, and write
+     * a single artifact. `.memoize/` is already excluded from git via the
+     * worktree layer + repo .gitignore, so the file won't pollute status.
+     */
+    const fixFailingChecks: GitService["Type"]["fixFailingChecks"] = (
+      folderId,
+      worktreeId,
+    ) =>
+      Effect.flatMap(resolvePathForWorktree(folderId, worktreeId), (cwd) =>
+        Effect.gen(function* () {
+          const stdout = yield* ghRun(folderId, cwd, [
+            "pr",
+            "view",
+            "--json",
+            "statusCheckRollup",
+          ]);
+
+          type RollupEntry = {
+            name?: string;
+            status?: string;
+            state?: string;
+            conclusion?: string;
+            detailsUrl?: string;
+            targetUrl?: string;
+          };
+          let rollup: ReadonlyArray<RollupEntry> = [];
+          try {
+            const parsed = JSON.parse(stdout) as {
+              statusCheckRollup?: ReadonlyArray<RollupEntry>;
+            };
+            rollup = parsed.statusCheckRollup ?? [];
+          } catch {
+            // fall through with empty rollup
+          }
+
+          const failing = rollup.filter((c) => {
+            const conclusion = (c.conclusion ?? c.state ?? "").toUpperCase();
+            return (
+              conclusion === "FAILURE" ||
+              conclusion === "CANCELLED" ||
+              conclusion === "TIMED_OUT" ||
+              conclusion === "ACTION_REQUIRED"
+            );
+          });
+
+          // Map each failing check to its workflow-run ID. gh emits two URL
+          // shapes: actions runs (`/actions/runs/<id>/job/<jobId>`) and
+          // external check URLs (no run id). Skip the latter — we can't
+          // pull logs for them.
+          const runIds = new Set<string>();
+          const failingNames: Array<string> = [];
+          for (const c of failing) {
+            failingNames.push(c.name ?? "(unnamed)");
+            const url = c.detailsUrl ?? c.targetUrl ?? "";
+            const m = /\/actions\/runs\/(\d+)/.exec(url);
+            if (m !== null && m[1] !== undefined) runIds.add(m[1]);
+          }
+
+          const sections: Array<string> = [];
+          for (const id of runIds) {
+            const log = yield* ghRun(folderId, cwd, [
+              "run",
+              "view",
+              id,
+              "--log-failed",
+            ]).pipe(
+              Effect.catchTag("GitCommandError", () =>
+                Effect.succeed(`(failed to fetch logs for run ${id})\n`),
+              ),
+            );
+            sections.push(`==== run ${id} ====\n${log.trim()}\n`);
+          }
+
+          const header =
+            failingNames.length === 0
+              ? "No failing checks found.\n"
+              : `Failing checks (${failingNames.length}):\n` +
+                failingNames.map((n) => `  - ${n}`).join("\n") +
+                "\n";
+          const body =
+            sections.length > 0
+              ? sections.join("\n")
+              : "(no actions run logs available — checks may be external or pending)\n";
+
+          const dir = path.join(cwd, ".memoize");
+          yield* fs
+            .makeDirectory(dir, { recursive: true })
+            .pipe(
+              Effect.catchAll((err) =>
+                Effect.fail(
+                  new GitCommandError({
+                    folderId,
+                    reason: `failed to create .memoize/: ${String(err)}`,
+                  }),
+                ),
+              ),
+            );
+
+          // Filesystem-safe ISO-ish timestamp (drop sub-second precision +
+          // colons that break some shells).
+          const ts = new Date()
+            .toISOString()
+            .replace(/[:.]/g, "-")
+            .replace(/-\d{3}Z$/, "Z");
+          const fileName = `failing-checks-${ts}.txt`;
+          const absPath = path.join(dir, fileName);
+          const relPath = `.memoize/${fileName}`;
+
+          yield* fs
+            .writeFileString(absPath, `${header}\n${body}`)
+            .pipe(
+              Effect.catchAll((err) =>
+                Effect.fail(
+                  new GitCommandError({
+                    folderId,
+                    reason: `failed to write ${relPath}: ${String(err)}`,
+                  }),
+                ),
+              ),
+            );
+
+          return GitFailingChecksArtifact.make({
+            relPath,
+            absPath,
+            failingCount: failingNames.length,
+          });
+        }),
+      );
+
     // Per-subscription stream: a forked fiber polls HEAD every 2s and pushes
     // into a Mailbox only when the SHA changes. The fiber is scoped to the
     // stream's lifetime, so interrupting the renderer's subscription stops
@@ -887,6 +1046,7 @@ export const GitServiceLive = Layer.effect(
       changes,
       commit,
       push,
+      fixFailingChecks,
     } as const;
   }),
 );

--- a/apps/server/src/git/services/git-service.ts
+++ b/apps/server/src/git/services/git-service.ts
@@ -5,6 +5,7 @@ import {
   type GitChange,
   type GitCommandError,
   type GitCommit,
+  type GitFailingChecksArtifact,
   type GitFolderNotFoundError,
   type GitNotARepoError,
   type GitNotInstalledError,
@@ -57,6 +58,10 @@ export interface GitServiceShape {
     folderId: FolderId,
     worktreeId?: WorktreeId | null,
   ) => Effect.Effect<{ readonly output: string }, GitFailure>;
+  readonly fixFailingChecks: (
+    folderId: FolderId,
+    worktreeId?: WorktreeId | null,
+  ) => Effect.Effect<GitFailingChecksArtifact, GitFailure>;
 }
 
 export class GitService extends Context.Tag("memoize/GitService")<

--- a/packages/wire/src/git.ts
+++ b/packages/wire/src/git.ts
@@ -112,6 +112,15 @@ export const GitPrChecks = Schema.Literal(
 );
 export type GitPrChecks = typeof GitPrChecks.Type;
 
+/**
+ * Merge-conflict state from `gh pr view --json mergeable`.
+ *   clean       — GitHub says the PR is mergeable.
+ *   conflicting — at least one path in the branch conflicts with the base.
+ *   unknown     — GitHub hasn't computed it yet, no PR exists, or `gh` couldn't read it.
+ */
+export const GitPrMergeable = Schema.Literal("clean", "conflicting", "unknown");
+export type GitPrMergeable = typeof GitPrMergeable.Type;
+
 export class GitPrInfo extends Schema.Class<GitPrInfo>("GitPrInfo")({
   state: GitPrState,
   branch: Schema.NullOr(Schema.String),
@@ -122,6 +131,7 @@ export class GitPrInfo extends Schema.Class<GitPrInfo>("GitPrInfo")({
   url: Schema.NullOr(Schema.String),
   isDraft: Schema.Boolean,
   checks: GitPrChecks,
+  mergeable: GitPrMergeable,
 }) {}
 
 export const GitPrStateRpc = Rpc.make("git.prState", {
@@ -203,6 +213,7 @@ export class GitPrDetails extends Schema.Class<GitPrDetails>("GitPrDetails")({
   url: Schema.NullOr(Schema.String),
   isDraft: Schema.Boolean,
   checks: GitPrChecks,
+  mergeable: GitPrMergeable,
   additions: Schema.Number,
   deletions: Schema.Number,
   title: Schema.String,
@@ -222,6 +233,30 @@ export const GitPrDetailsRpc = Rpc.make("git.prDetails", {
     worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
   }),
   success: GitPrDetails,
+  error: GitErrors,
+});
+
+/**
+ * Captured CI failure artifact. The server pulled logs for every failing
+ * check via `gh run view --log-failed`, concatenated them with run-name
+ * dividers, and wrote them to `.memoize/failing-checks-<ts>.txt` inside the
+ * worktree. The renderer attaches `relPath` to the composer so the agent can
+ * read it as `@<relPath>`.
+ */
+export class GitFailingChecksArtifact extends Schema.Class<GitFailingChecksArtifact>(
+  "GitFailingChecksArtifact",
+)({
+  relPath: Schema.String,
+  absPath: Schema.String,
+  failingCount: Schema.Number,
+}) {}
+
+export const GitFixFailingChecksRpc = Rpc.make("git.fixFailingChecks", {
+  payload: Schema.Struct({
+    folderId: FolderId,
+    worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
+  }),
+  success: GitFailingChecksArtifact,
   error: GitErrors,
 });
 

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -14,6 +14,7 @@ import { FsReadFileRpc, FsTreeRpc, FsWriteFileRpc } from "./fs.ts";
 import {
   GitChangesRpc,
   GitCommitRpc,
+  GitFixFailingChecksRpc,
   GitHeadChangedRpc,
   GitLogRpc,
   GitOriginRpc,
@@ -128,6 +129,7 @@ export const MemoizeRpcs = RpcGroup.make(
   GitChangesRpc,
   GitCommitRpc,
   GitPushRpc,
+  GitFixFailingChecksRpc,
   FsTreeRpc,
   FsReadFileRpc,
   FsWriteFileRpc,


### PR DESCRIPTION
## Summary

- Top-bar workflow chip + button restyled as filled glass (rounded-[10px], subtle inset highlight, backdrop blur, tone-tinted via a single `--tone` CSS var). Shared primitives in `components/glass-action.tsx` so dev page + top bar render the same elements.
- Priority fix: unpushed commits now beat open-PR state, and a failing-checks CTA no longer surfaces when the user hasn't pushed yet. New `mergeable` field on `GitPrInfo`/`GitPrDetails` (from `gh pr view --json mergeable`) adds a red "Resolve conflicts" CTA + a conflict dot on the PR tab badge.
- New "Fix actions" CTA replaces the disabled Merge button when checks fail: invokes a new `git.fixFailingChecks` RPC that walks failing run IDs, shells `gh run view --log-failed` per run, concatenates the output with dividers, drops the artifact at `.memoize/failing-checks-<ts>.txt`, then attaches it to the composer as `@<relPath>` and primes a fix prompt.
- Brightens the lime accent (`oklch(0.94 0.2 122)`) and adds an accent palette (`--accent-pink/green/blue/amber/red/zinc`) plus `.glass-tone` / `.glass-neutral` utilities. Dev-only Developer pane in Settings shows the palette + every workflow state side-by-side.

## Test plan

- [ ] Open a worktree with uncommitted changes → top bar shows amber "X changes · Commit & push"
- [ ] Commit but don't push → shows pink "X ahead · Create PR / Push commits" (regardless of any existing PR)
- [ ] Open PR with passing checks → shows green "#N · Merge"
- [ ] Open PR with failing checks → shows red "#N · Fix actions"; clicking captures logs, switches to chat, attaches `.memoize/failing-checks-<ts>.txt`, primes prompt
- [ ] Open PR with merge conflicts → red "#N · Resolve conflicts"; tab badge shows red dot
- [ ] Settings → Developer (dev build only) renders palette + workflow states