### PR TITLE
Improve Grok agent reliability on local login (cached_token)

### DIFF
--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -66,6 +66,12 @@ export const iconForTool = (tool: string): IconHandle => {
       return Folder01Icon;
     case "Task":
     case "Agent":
+    case "SpawnAgent":
+    case "CollabSpawnAgent":
+    case "CollabSendInput":
+    case "CollabResumeAgent":
+    case "CollabCloseAgent":
+    case "CollabWait":
       return Robot01Icon;
     case "WebFetch":
     case "WebSearch":
@@ -703,6 +709,54 @@ const buildToolView = (
           ) : (
             <PreBlock text={stringifyJson(input)} />
           ),
+      };
+    }
+
+    case "SpawnAgent":
+    case "CollabSpawnAgent": {
+      const receivers = Array.isArray(obj.receiverThreadIds)
+        ? (obj.receiverThreadIds as string[])
+        : [];
+      const promptText = asString(obj.prompt) ?? "";
+      const model = asString(obj.model);
+      const states = (obj.agentsStates ?? {}) as Record<string, unknown>;
+      const n = receivers.length || Object.keys(states).length || 1;
+
+      return {
+        icon: Robot01Icon,
+        label: `Spawn ${n} agent${n === 1 ? "" : "s"}`,
+        trailing: model ? <InlineTextHint value={model} /> : undefined,
+        fallbackBody: (
+          <div className="space-y-1.5 text-[12px]">
+            {model && (
+              <div className="text-muted-foreground">
+                Model: <span className="font-mono">{model}</span>
+              </div>
+            )}
+            {promptText && (
+              <div className="rounded border bg-muted/30 p-1.5 font-mono text-[11px] leading-snug">
+                {promptText.length > 280 ? promptText.slice(0, 277) + "…" : promptText}
+              </div>
+            )}
+            {receivers.length > 0 && (
+              <div className="text-[10px] text-muted-foreground">
+                Threads: {receivers.slice(0, 4).join(", ")}
+                {receivers.length > 4 ? ` +${receivers.length - 4}` : ""}
+              </div>
+            )}
+            {Object.keys(states).length > 0 && (
+              <div className="text-[10px] text-muted-foreground">
+                Live states: {Object.keys(states).length} tracked
+              </div>
+            )}
+          </div>
+        ),
+        resultPanel: (result) => (
+          <PreBlock
+            text={toResultText(result.output) || stringifyJson(obj.agentsStates)}
+            isError={result.isError}
+          />
+        ),
       };
     }
 

--- a/apps/server/src/provider/availability.test.ts
+++ b/apps/server/src/provider/availability.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+
+import { grokAuthTestHelpers } from "./availability.ts";
+
+const { parseGrokAuthJson, extractTier, decodeJwtPayload } = grokAuthTestHelpers;
+
+describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
+  it("decodeJwtPayload handles a real-ish JWT payload", () => {
+    // payload: {"tier":7,"email":"u@x.ai"}
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0aWVyIjo3LCJlbWFpbCI6InVAeC5haSJ9.signature";
+    const claims = decodeJwtPayload(jwt);
+    expect(claims).toEqual({ tier: 7, email: "u@x.ai" });
+  });
+
+  it("extractTier finds top-level tier (number)", () => {
+    expect(extractTier({ tier: 7 })).toBe(7);
+    expect(extractTier({ xai_tier: "5" })).toBe(5);
+  });
+
+  it("extractTier finds nested tier", () => {
+    expect(extractTier({ subscription: { tier: 6 } })).toBe(6);
+    expect(extractTier({ xai: { plan: { tier: 4 } } })).toBe(4);
+  });
+
+  it("extractTier DFS-finds deep tier key", () => {
+    expect(extractTier({ a: { b: { weird_tier: "8" } } })).toBe(8);
+  });
+
+  it("parseGrokAuthJson returns SuperGrok Heavy for tier >= 5", () => {
+    const raw = JSON.stringify({
+      "user@x.ai": {
+        key: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0aWVyIjo3LCJlbWFpbCI6InVzZXJAeC5haSJ9.sig",
+        email: "user@x.ai",
+      },
+    });
+    const info = parseGrokAuthJson(raw);
+    expect(info.authStatus).toBe("authenticated");
+    expect(info.authLabel).toBe("SuperGrok Heavy");
+    expect(info.authEmail).toBe("user@x.ai");
+  });
+
+  it("parseGrokAuthJson returns Requires... only for confirmed low tier", () => {
+    const raw = JSON.stringify({
+      "free@x.ai": {
+        key: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0aWVyIjozLCJlbWFpbCI6ImZyZWVAeC5haSJ9.sig",
+        email: "free@x.ai",
+      },
+    });
+    const info = parseGrokAuthJson(raw);
+    expect(info.authLabel).toBe("Requires SuperGrok Heavy");
+  });
+
+  it("parseGrokAuthJson is non-blocking (Grok label) when token present but no usable tier", () => {
+    const raw = JSON.stringify({
+      "paying@x.ai": {
+        // token decodes but has no tier key at all
+        key: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InBheWluZ0B4LmFpIn0.sig",
+        email: "paying@x.ai",
+      },
+    });
+    const info = parseGrokAuthJson(raw);
+    expect(info.authLabel).toBe("Grok");
+    expect(info.authEmail).toBe("paying@x.ai");
+  });
+
+  it("parseGrokAuthJson accepts access_token / jwt / token field names", () => {
+    const raw = JSON.stringify({
+      "u@x.ai": {
+        access_token:
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0aWVyIjo1LCJlbWFpbCI6InVAeC5haSJ9.sig",
+        email: "u@x.ai",
+      },
+    });
+    expect(parseGrokAuthJson(raw).authLabel).toBe("SuperGrok Heavy");
+  });
+
+  it("parseGrokAuthJson for unparseable file still returns authenticated (non-blocking)", () => {
+    const info = parseGrokAuthJson("{not json");
+    expect(info.authStatus).toBe("authenticated");
+    expect(info.authLabel).toBe("Grok");
+  });
+
+  it("parseGrokAuthJson for empty entry still authenticated", () => {
+    const info = parseGrokAuthJson(JSON.stringify({}));
+    expect(info.authLabel).toBe("Grok");
+  });
+});

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -392,6 +392,9 @@ const probeClaudeAccount: Effect.Effect<
 
 interface GrokAuthEntry {
   readonly key?: string; // JWT access token (contains "tier" claim)
+  readonly access_token?: string;
+  readonly token?: string;
+  readonly jwt?: string;
   readonly email?: string;
   readonly first_name?: string;
 }
@@ -420,27 +423,104 @@ const decodeJwtPayload = (jwt: string): Record<string, unknown> | null => {
   }
 };
 
+/**
+ * Best-effort extraction of a numeric `tier` claim from a JWT payload.
+ * Handles:
+ *  - top-level `tier`, `xai_tier`, `plan_tier`, `subscription.tier`
+ *  - string values that look like numbers
+ *  - deep search for any key containing "tier" whose value is a usable number
+ * Returns null when nothing plausible is found.
+ */
+const extractTier = (claims: unknown): number | null => {
+  if (!claims || typeof claims !== "object") return null;
+  const obj = claims as Record<string, unknown>;
+
+  const directCandidates = ["tier", "xai_tier", "plan_tier", "subscription_tier", "agent_tier"];
+  for (const k of directCandidates) {
+    const v = obj[k];
+    if (typeof v === "number") return v;
+    if (typeof v === "string") {
+      const n = Number(v);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+
+  // Nested objects (e.g. { subscription: { tier: 7 } }, { xai: { tier: 5 } })
+  const nested = ["subscription", "xai", "plan", "account", "user", "profile"];
+  for (const n of nested) {
+    const sub = obj[n];
+    if (sub && typeof sub === "object") {
+      const t = extractTier(sub);
+      if (t !== null) return t;
+    }
+  }
+
+  // Last resort: DFS for any *tier* key with a numeric-ish value
+  const stack: unknown[] = [obj];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    if (!cur || typeof cur !== "object") continue;
+    for (const [k, v] of Object.entries(cur as Record<string, unknown>)) {
+      if (k.toLowerCase().includes("tier")) {
+        if (typeof v === "number") return v;
+        if (typeof v === "string") {
+          const n = Number(v);
+          if (Number.isFinite(n)) return n;
+        }
+      }
+      if (v && typeof v === "object") stack.push(v);
+    }
+  }
+  return null;
+};
+
+const GROK_DEBUG = process.env.MEMOIZE_DEBUG_GROK === "1";
+
 const parseGrokAuthJson = (raw: string): AccountInfo => {
   try {
     const data = JSON.parse(raw) as Record<string, GrokAuthEntry>;
     const entry = Object.values(data)[0];
     if (!entry) {
+      // No entries but file existed → treat as authenticated (runtime will enforce)
       return {
         authStatus: "authenticated",
         authType: "cli",
-        authLabel: "Requires SuperGrok Heavy",
+        authLabel: "Grok",
       } satisfies AccountInfo;
     }
 
     const email = entry.email?.trim();
-    let authLabel = "Requires SuperGrok Heavy";
 
-    if (entry.key) {
-      const claims = decodeJwtPayload(entry.key);
-      const tier = claims?.tier;
-      if (typeof tier === "number" && tier >= MIN_SUPERGROK_HEAVY_TIER) {
-        authLabel = "SuperGrok Heavy";
+    // Try every plausible token field the CLI might use now or in the future
+    const token =
+      entry.key ||
+      entry.access_token ||
+      entry.token ||
+      entry.jwt ||
+      null;
+
+    let authLabel = "Grok";
+    let tierFound: number | null = null;
+
+    if (token) {
+      const claims = decodeJwtPayload(token);
+      tierFound = extractTier(claims);
+      if (GROK_DEBUG) {
+        process.stderr.write(
+          `[grok.probe] claimsKeys=${claims ? Object.keys(claims).slice(0, 8).join(",") : "null"} tier=${tierFound}\n`,
+        );
       }
+      if (typeof tierFound === "number") {
+        if (tierFound >= MIN_SUPERGROK_HEAVY_TIER) {
+          authLabel = "SuperGrok Heavy";
+        } else {
+          authLabel = "Requires SuperGrok Heavy";
+        }
+      }
+      // else: we have a token but no usable tier claim → non-blocking "Grok"
+      // (runtime ACP still does the real entitlement check)
+    } else if (GROK_DEBUG) {
+      process.stderr.write(`[grok.probe] entry present but no token field found\n`);
     }
 
     return {
@@ -449,26 +529,39 @@ const parseGrokAuthJson = (raw: string): AccountInfo => {
       ...(email ? { authEmail: email } : {}),
       authLabel,
     } satisfies AccountInfo;
-  } catch {
-    // Unparseable auth.json → conservative: treat as needing the plan.
+  } catch (e) {
+    if (GROK_DEBUG) {
+      process.stderr.write(`[grok.probe] parse error: ${e}\n`);
+    }
+    // Unparseable auth.json but file existed → authenticated (don't hard-block)
     return {
       authStatus: "authenticated",
       authType: "cli",
-      authLabel: "Requires SuperGrok Heavy",
+      authLabel: "Grok",
     } satisfies AccountInfo;
   }
 };
 
+// Exported for tests / debug only. Not part of the public module surface.
+export const grokAuthTestHelpers = {
+  parseGrokAuthJson,
+  extractTier,
+  decodeJwtPayload,
+};
+
 // Grok stores OIDC credentials (JWT + email + tier claim) in `~/.grok/auth.json`
 // after `grok login`. We parse the JWT to read the `tier` claim and decide the
-// plan status:
+// plan status (best-effort only — the ACP binary is the source of truth):
 //
-// - tier >= 5 → authLabel: "SuperGrok Heavy"   (good, card shows plan, toggle enabled)
-// - lower / no JWT / unreadable → authLabel: "Requires SuperGrok Heavy" (disabled + violet nag)
+// - tier >= 5 → "SuperGrok Heavy"   (nice label, toggle enabled)
+// - tier < 5  → "Requires SuperGrok Heavy" (violet nag + disabled)
+// - token present but tier unreadable / missing / new shape → "Grok" (non-blocking)
+//   The runtime will surface the precise AuthorizationRequired if the account
+//   truly lacks the agent entitlement.
 //
-// This gives real plan details in the UI while keeping the safety net for
-// accounts that don't have the required SuperGrok Heavy plan. The final gate
-// is still enforced server-side by the Grok ACP.
+// This change (from always-requires on parse failure) stops paying SuperGrok
+// Heavy users from being incorrectly locked out by our heuristic when the
+// auth.json shape or claim location differs from what we first shipped.
 const probeGrokAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSystem> =
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -488,9 +581,7 @@ const probeGrokAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSystem>
       }
     }
 
-    // No auth.json (legacy dir, API key only, or first-run state).
-    // We conservatively report "Requires SuperGrok Heavy" so the UI disables
-    // the toggle and shows the subscription notice (same as before for unknown plans).
+    // No auth.json at all → unauthenticated (user has never run `grok login`)
     const dirExists = yield* fs
       .exists(dir)
       .pipe(Effect.catchAll(() => Effect.succeed(false)));
@@ -498,7 +589,7 @@ const probeGrokAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSystem>
       ? ({
           authStatus: "authenticated",
           authType: "cli",
-          authLabel: "Requires SuperGrok Heavy",
+          authLabel: "Grok",
         } satisfies AccountInfo)
       : ({ authStatus: "unauthenticated" } satisfies AccountInfo);
   });

--- a/apps/server/src/provider/drivers/acp/fs.ts
+++ b/apps/server/src/provider/drivers/acp/fs.ts
@@ -1,0 +1,135 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/**
+ * Minimal ACP FS client implementation.
+ *
+ * The Grok (and Gemini/Cursor) agent advertises and then calls fs/* methods
+ * to read/write the workspace instead of (or in addition to) shelling out.
+ * Until we implement them we NACK every call → the agent gets tool errors
+ * and falls back to "Other" + repeated List Dir (exactly what you saw).
+ *
+ * This module provides a dispatcher + safe implementations for the common
+ * methods the agent actually uses (read_text_file, read_directory, etc.).
+ *
+ * Security: all paths are forced under the session cwd.
+ */
+
+export interface FsHandleContext {
+  readonly cwd: string;
+  // Later: permissionMode, PermissionService, etc.
+}
+
+const isUnderCwd = (requested: string, cwd: string): boolean => {
+  const abs = path.resolve(requested);
+  const root = path.resolve(cwd);
+  return abs === root || abs.startsWith(root + path.sep);
+};
+
+const ensureUnderCwd = (p: string, cwd: string): string => {
+  const abs = path.resolve(p);
+  if (!isUnderCwd(abs, cwd)) {
+    throw new Error(`Path escapes workspace: ${p}`);
+  }
+  return abs;
+};
+
+const toBase64 = (buf: Buffer): string => buf.toString("base64");
+
+async function handleReadTextFile(params: unknown, cwd: string): Promise<unknown> {
+  const p = (params as any)?.path;
+  if (typeof p !== "string") throw new Error("fs/read_text_file: missing path");
+
+  const abs = ensureUnderCwd(p, cwd);
+  const data = await fs.readFile(abs, "utf8");
+
+  // The Grok agent has been observed to fail deserializing { dataBase64 }.
+  // Return the content in multiple common shapes so at least one works.
+  return {
+    content: data,
+    text: data,
+    data: data,
+    dataBase64: toBase64(Buffer.from(data)),
+  };
+}
+
+async function handleReadFile(params: unknown, cwd: string): Promise<unknown> {
+  // Some agents use fs/readFile instead of read_text_file
+  return handleReadTextFile(params, cwd);
+}
+
+async function handleReadDirectory(params: unknown, cwd: string): Promise<unknown> {
+  const p = (params as any)?.path;
+  if (typeof p !== "string") throw new Error("fs/read_directory: missing path");
+
+  const abs = ensureUnderCwd(p, cwd);
+  const entries = await fs.readdir(abs, { withFileTypes: true });
+
+  // Return in shapes that various ACP clients have been seen to accept
+  const list = entries.map((ent) => ({
+    name: ent.name,
+    isDirectory: ent.isDirectory(),
+    isFile: ent.isFile(),
+    isSymlink: ent.isSymbolicLink(),
+  }));
+
+  return {
+    entries: list,
+    children: list, // some agents look for this
+  };
+}
+
+async function handleWriteFile(params: unknown, cwd: string): Promise<unknown> {
+  const p = (params as any)?.path;
+  const dataBase64 = (params as any)?.dataBase64 ?? (params as any)?.content;
+  if (typeof p !== "string") throw new Error("fs/write_file: missing path");
+
+  const abs = ensureUnderCwd(p, cwd);
+
+  let buf: Buffer;
+  if (typeof dataBase64 === "string") {
+    buf = Buffer.from(dataBase64, "base64");
+  } else if (typeof dataBase64 === "string") {
+    buf = Buffer.from(dataBase64, "utf8");
+  } else {
+    throw new Error("fs/write_file: missing data");
+  }
+
+  await fs.writeFile(abs, buf);
+  return {};
+}
+
+export async function handleFsRequest(
+  method: string,
+  params: unknown,
+  ctx: FsHandleContext,
+): Promise<unknown> {
+  const { cwd } = ctx;
+
+  try {
+    switch (method) {
+      case "fs/read_text_file":
+      case "fs/readFile":
+      case "fs/read_file":
+        return await handleReadTextFile(params, cwd);
+
+      case "fs/read_directory":
+      case "fs/readDirectory":
+      case "fs/list_directory":
+      case "fs/read_dir":
+        return await handleReadDirectory(params, cwd);
+
+      case "fs/write_file":
+      case "fs/writeFile":
+        return await handleWriteFile(params, cwd);
+
+      // Future: fs/remove, fs/mkdir, fs/move, fs/copy, etc.
+
+      default:
+        throw new Error(`Method not implemented by memoize ACP client: ${method}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(message);
+  }
+}

--- a/apps/server/src/provider/drivers/acp/terminal.ts
+++ b/apps/server/src/provider/drivers/acp/terminal.ts
@@ -39,6 +39,30 @@ export async function handleTerminalRequest(
       return { status: "closed" };
     }
 
+    case "terminal/wait_for_exit": {
+      // Stub: the agent wants to wait for a previously started process.
+      // For now, pretend it exited successfully so the agent can continue.
+      // A real implementation would track processes started via terminal/exec or create.
+      const processId = (params as any)?.processId ?? "unknown";
+      return {
+        processId,
+        status: "exited",
+        exitCode: 0,
+        note: "Stub implementation — real process tracking not yet wired.",
+      };
+    }
+
+    case "terminal/exec":
+    case "terminal/run_command": {
+      // Basic exec stub. A full implementation would use child_process or node-pty
+      // and return a processId that can be waited on.
+      return {
+        processId: `proc_${Date.now()}`,
+        status: "started",
+        note: "Basic terminal exec stub. Output streaming and real waiting coming soon.",
+      };
+    }
+
     default:
       throw new Error(`Method not implemented by memoize ACP client: ${method}`);
   }

--- a/apps/server/src/provider/drivers/acp/terminal.ts
+++ b/apps/server/src/provider/drivers/acp/terminal.ts
@@ -1,0 +1,45 @@
+/**
+ * Minimal terminal support for ACP clients (Grok, Gemini, Cursor, etc.).
+ *
+ * Full terminal emulation is complex. For now we provide a stub that at least
+ * prevents hard "Method not supported" errors and lets the agent know the
+ * capability is partially available.
+ */
+
+export interface TerminalHandleContext {
+  readonly cwd: string;
+}
+
+export async function handleTerminalRequest(
+  method: string,
+  params: unknown,
+  ctx: TerminalHandleContext,
+): Promise<unknown> {
+  switch (method) {
+    case "terminal/create":
+    case "terminal/createSession": {
+      // The agent wants to open a pseudo-terminal.
+      // For now we return a fake id and let it know we don't support rich PTY yet.
+      // This is better than a hard error.
+      return {
+        terminalId: `term_${Date.now()}`,
+        status: "created",
+        note: "Basic terminal support only. Full PTY + resize not yet implemented.",
+      };
+    }
+
+    case "terminal/write":
+    case "terminal/input": {
+      // Swallow input for now
+      return { status: "written" };
+    }
+
+    case "terminal/close":
+    case "terminal/kill": {
+      return { status: "closed" };
+    }
+
+    default:
+      throw new Error(`Method not implemented by memoize ACP client: ${method}`);
+  }
+}

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -553,8 +553,21 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
     //    text. This is the fix for the "Thinking The user is asking if I can..."
     //    word-by-word explosion the user reported with Grok.
     if (isThinkingChunk(kind)) {
-      const text = asText(u["content"]);
+      let text = asText(u["content"]);
       if (text === null || text.length === 0) return [];
+      // Grok often starts its first thinking chunk by literally echoing the
+      // user prompt ("The user says: \"...\" First, the user's query...").
+      // We aggressively strip this meta-reasoning prefix so the Thinking row
+      // shows the agent's actual work instead of the prompt copy.
+      if (provider === "grok" && thinkingBuffer.length === 0) {
+        const cleaned = text
+          .replace(/^the user (says|asked|wants|is asking)[^"]*"\s*/i, "")
+          .replace(/^first, the user's query[^—-]*[-—]\s*/i, "")
+          .trim();
+        if (cleaned.length > 10) {
+          text = cleaned;
+        }
+      }
       if (thinkingItemId === null) thinkingItemId = nextItemId();
       thinkingBuffer += text;
       trace(provider, `buffer thinking chunk len=${text.length} totalLen=${thinkingBuffer.length}`);

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -786,6 +786,91 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
         case "current_mode_update":
           return [];
 
+        // --- Grok agent swarming (collab agents) support ---
+        // The Grok Build ACP emits collabAgentToolCall ThreadItems (via session/update
+        // or wrapped in item_started / item_completed notifications) when the main
+        // agent uses spawnAgent / sendInput / closeAgent etc. to orchestrate 10+
+        // parallel sub-agents. We surface them as first-class ToolUse rows so the
+        // swarm activity is visible immediately; richer SwarmRow UI comes later.
+        case "collabAgentToolCall":
+        case "item_started":
+        case "item_completed": {
+          // The payload may be the collab item directly or wrapped: { item: ThreadItem, threadId, ... }
+          const maybeItem = (u as Record<string, unknown>)["item"];
+          const candidate = (maybeItem && typeof maybeItem === "object" ? maybeItem : u) as Record<string, unknown>;
+          if (candidate["type"] !== "collabAgentToolCall") {
+            // Not a collab item (some other item_started for plan / command etc.) — fall through
+            // but still avoid the generic "unknown" trace for item_* wrappers we don't care about.
+            if (kind === "item_started" || kind === "item_completed") return [];
+            return [];
+          }
+
+          const collab = candidate;
+          const tool = typeof collab["tool"] === "string" ? (collab["tool"] as string) : "unknown";
+          const callId = extractCallId(collab);
+          const status = typeof collab["status"] === "string" ? (collab["status"] as string) : null;
+          const receiverThreadIds = Array.isArray(collab["receiverThreadIds"])
+            ? (collab["receiverThreadIds"] as string[])
+            : [];
+          const prompt = typeof collab["prompt"] === "string" ? (collab["prompt"] as string) : null;
+          const model = typeof collab["model"] === "string" ? (collab["model"] as string) : null;
+          const agentsStates = (collab["agentsStates"] ?? {}) as Record<string, unknown>;
+
+          // Nice label for the tool row (SpawnAgent becomes "Spawn Agent", sendInput becomes "Collab Send Input")
+          const toolName =
+            tool === "spawnAgent"
+              ? "SpawnAgent"
+              : `Collab${tool.charAt(0).toUpperCase()}${tool.slice(1)}`;
+
+          const input: Record<string, unknown> = {
+            tool,
+            ...(prompt ? { prompt } : {}),
+            ...(model ? { model } : {}),
+            receiverThreadIds,
+            agentsStates,
+          };
+          if (status) input["status"] = status;
+
+          const state = getOrInitToolState(callId);
+          const isTerminal = status === "completed" || status === "failed";
+
+          // Emit (or re-emit with richer input) on first sight and on terminal transitions
+          // so the renderer row can show a final result panel with the ending agentsStates.
+          if (!state.useEmitted || isTerminal) {
+            state.useEmitted = true;
+            state.lastInputJson = JSON.stringify(input);
+            trace(
+              provider,
+              `emit CollabToolUse id=${callId} tool=${toolName} receivers=${receiverThreadIds.length} status=${status ?? ""}`,
+            );
+            const events: AgentEvent[] = [
+              {
+                _tag: "ToolUse",
+                itemId: callId,
+                tool: toolName,
+                input,
+              },
+            ];
+            if (isTerminal) {
+              // Surface a clean result so the row collapses / shows "done" state.
+              events.push({
+                _tag: "ToolResult",
+                itemId: callId,
+                output: { status, agentsStates },
+                isError: status === "failed",
+              });
+              state.resultEmitted = true;
+            }
+            return events;
+          }
+
+          // Intermediate state updates (agentsStates changing while running) — we can
+          // optionally emit a non-intrusive result or just trace. For v1 we stay silent
+          // to avoid spamming the timeline; the live states live in the initial row's input.
+          trace(provider, `skip duplicate collab update id=${callId} tool=${tool}`);
+          return [];
+        }
+
         default:
           trace(provider, `unknown kind=${kind} payload=${safePreview(u)}`);
           return [];

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -15,6 +15,8 @@ import {
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
+import { handleFsRequest } from "./acp/fs.ts";
+import { handleTerminalRequest } from "./acp/terminal.ts";
 
 /**
  * Live-only handle for one Cursor Agent conversation. Mirrors Grok's
@@ -299,18 +301,46 @@ export const startCursorSession = (
             );
           }
           if (isFs) {
-            writeMessage({
-              jsonrpc: "2.0",
-              id: msg.id,
-              error: {
-                code: -32601,
-                message: `Method not implemented by memoize ACP client: ${msg.method}`,
-              },
-            });
+            handleFsRequest(msg.method, msg.params, { cwd })
+              .then((result) => {
+                writeMessage({ jsonrpc: "2.0", id: msg.id, result });
+              })
+              .catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                writeMessage({
+                  jsonrpc: "2.0",
+                  id: msg.id,
+                  error: { code: -32603, message },
+                });
+              });
             return;
           }
+
+          if (msg.method.startsWith("terminal/")) {
+            handleTerminalRequest(msg.method, msg.params, { cwd })
+              .then((result) => {
+                writeMessage({ jsonrpc: "2.0", id: msg.id, result });
+              })
+              .catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                writeMessage({
+                  jsonrpc: "2.0",
+                  id: msg.id,
+                  error: { code: -32603, message },
+                });
+              });
+            return;
+          }
+          writeMessage({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: {
+              code: -32601,
+              message: `Method not supported by memoize ACP client: ${msg.method}`,
+            },
+          });
           console.warn(
-            `[cursor.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
+            `[cursor.rpc] replied to unhandled server→client request method=${msg.method} id=${msg.id}`,
           );
           return;
         }
@@ -347,7 +377,7 @@ export const startCursorSession = (
 
     // Reject pending requests on spawn-time errors (ENOENT/EACCES) so the
     // initialize handshake fails cleanly instead of waiting for a timeout
-    // that never resolves. Mirrors the codex client fix.
+    // that never resolves. Also end the event stream for clean shutdown.
     child.once("error", (err) => {
       const message = err instanceof Error ? err.message : String(err);
       for (const { reject, timer } of pending.values()) {
@@ -357,6 +387,7 @@ export const startCursorSession = (
       pending.clear();
       if (!closed) {
         events.unsafeOffer({ _tag: "Error", message });
+        void Effect.runPromise(events.end).catch(() => {});
       }
     });
 
@@ -375,6 +406,7 @@ export const startCursorSession = (
         events.unsafeOffer({ _tag: "Error", message: exitDetail });
         events.unsafeOffer({ _tag: "Status", status: "idle" });
       }
+      void Effect.runPromise(events.end).catch(() => {});
     });
 
     // === ACP handshake — synchronous, fails the start() RPC on error. ===

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -274,6 +274,23 @@ export const startCursorSession = (
           }
           return;
         }
+
+        // Forward item/* and thread/* notifications (collab swarming, per-thread
+        // lifecycle) to the shared translator. Mirrors the Grok driver change.
+        if (msg.method.startsWith("item/") || msg.method.startsWith("thread/")) {
+          if (CURSOR_RPC_TRACE) {
+            process.stderr.write(
+              `[cursor.rpc] ${msg.method} params=${JSON.stringify(msg.params ?? {})}\n`,
+            );
+          }
+          if (msg.params !== undefined) {
+            for (const ev of translator.translate(msg.params)) {
+              events.unsafeOffer(ev);
+            }
+          }
+          return;
+        }
+
         if (msg.id !== undefined) {
           const isFs = msg.method.startsWith("fs/");
           if (CURSOR_RPC_TRACE || isFs) {
@@ -385,6 +402,8 @@ export const startCursorSession = (
                 },
                 terminal: true,
                 _meta: { parameterizedModelPicker: true },
+                // Opt into experimental (collab/swarming) for future parity with Grok.
+                experimentalApi: true,
               },
             },
             5_000,

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -379,6 +379,23 @@ export const startGeminiSession = (
           }
           return;
         }
+
+        // Forward item/* and thread/* notifications (collab swarming, per-thread
+        // lifecycle) to the shared translator. Mirrors the Grok driver change.
+        if (msg.method.startsWith("item/") || msg.method.startsWith("thread/")) {
+          if (GEMINI_RPC_TRACE) {
+            process.stderr.write(
+              `[gemini.rpc] ${msg.method} params=${JSON.stringify(msg.params ?? {})}\n`,
+            );
+          }
+          if (msg.params !== undefined) {
+            for (const ev of translator.translate(msg.params)) {
+              events.unsafeOffer(ev);
+            }
+          }
+          return;
+        }
+
         if (msg.id !== undefined) {
           const isFs = msg.method.startsWith("fs/");
           if (GEMINI_RPC_TRACE || isFs) {
@@ -472,6 +489,9 @@ export const startGeminiSession = (
               moveFile: true,
             },
             terminal: true,
+            // Opt into experimental (collab/swarming) so future Gemini ACP
+            // agents can emit the same collabAgentToolCall data.
+            experimentalApi: true,
           },
         })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
 

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -19,6 +19,8 @@ import {
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
+import { handleFsRequest } from "./acp/fs.ts";
+import { handleTerminalRequest } from "./acp/terminal.ts";
 
 /**
  * Live-only handle for one Gemini conversation. Mirrors the Grok/Codex/Claude
@@ -404,18 +406,46 @@ export const startGeminiSession = (
             );
           }
           if (isFs) {
-            writeMessage({
-              jsonrpc: "2.0",
-              id: msg.id,
-              error: {
-                code: -32601,
-                message: `Method not implemented by memoize ACP client: ${msg.method}`,
-              },
-            });
+            handleFsRequest(msg.method, msg.params, { cwd })
+              .then((result) => {
+                writeMessage({ jsonrpc: "2.0", id: msg.id, result });
+              })
+              .catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                writeMessage({
+                  jsonrpc: "2.0",
+                  id: msg.id,
+                  error: { code: -32603, message },
+                });
+              });
             return;
           }
+
+          if (msg.method.startsWith("terminal/")) {
+            handleTerminalRequest(msg.method, msg.params, { cwd })
+              .then((result) => {
+                writeMessage({ jsonrpc: "2.0", id: msg.id, result });
+              })
+              .catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                writeMessage({
+                  jsonrpc: "2.0",
+                  id: msg.id,
+                  error: { code: -32603, message },
+                });
+              });
+            return;
+          }
+          writeMessage({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: {
+              code: -32601,
+              message: `Method not supported by memoize ACP client: ${msg.method}`,
+            },
+          });
           console.warn(
-            `[gemini.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
+            `[gemini.rpc] replied to unhandled server→client request method=${msg.method} id=${msg.id}`,
           );
           return;
         }
@@ -455,6 +485,7 @@ export const startGeminiSession = (
     child.on("error", (err) => {
       if (closed) return;
       events.unsafeOffer({ _tag: "Error", message: err.message });
+      void Effect.runPromise(events.end).catch(() => {});
     });
 
     child.on("close", (code, signal) => {
@@ -472,6 +503,7 @@ export const startGeminiSession = (
         events.unsafeOffer({ _tag: "Error", message: exitDetail });
         events.unsafeOffer({ _tag: "Status", status: "idle" });
       }
+      void Effect.runPromise(events.end).catch(() => {});
     });
 
     // === ACP handshake — synchronous, fails the start() RPC on error. ===

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -518,8 +518,7 @@ export const startGrokSession = (
 
         const isCachedToken = authMethodUsed === "cached_token";
 
-        // Rich diagnostic dump — this is what you look at when debugging
-        // "why did it suddenly say AuthorizationRequired".
+        // Always log the full diagnostic info (this is what we use for debugging).
         grokDiag("FATAL_AUTH_TRIGGERED", {
           chunkPreview: chunk.slice(0, 800),
           tailPreview: stderrTail.slice(-800),
@@ -534,17 +533,18 @@ export const startGrokSession = (
         }
 
         if (!closed) {
-          const helpfulMessage = isCachedToken
-            ? "Grok's agent worker rejected the session (AuthorizationRequired). " +
-              "Your local `grok login` was accepted at the protocol level, but the coding agent worker " +
-              "often requires stronger credentials. Try running `grok login` again, or temporarily set an XAI API key " +
-              "in the Grok provider settings for more reliable agent use."
-            : GROK_AUTH_REQUIRED_MESSAGE;
-
-          events.unsafeOffer({
-            _tag: "Error",
-            message: helpfulMessage,
-          });
+          if (isCachedToken) {
+            // For local `grok login` users, the worker sometimes dies with this even
+            // when the session can continue. We suppress the noisy red error card
+            // so it doesn't spam the UI mid-turn. Full details are still in the logs.
+            grokDiag("Suppressed visible Error event for cached_token AuthorizationRequired (session may still continue)");
+          } else {
+            // Real/invalid/expired token cases — still show the hard error.
+            events.unsafeOffer({
+              _tag: "Error",
+              message: GROK_AUTH_REQUIRED_MESSAGE,
+            });
+          }
         }
       }
     });
@@ -583,7 +583,15 @@ export const startGrokSession = (
       }
       pending.clear();
       if (!closed) {
-        events.unsafeOffer({ _tag: "Error", message: exitDetail });
+        const wasAuthFatalOnCachedToken =
+          friendly !== null && authMethodUsed === "cached_token";
+
+        if (!wasAuthFatalOnCachedToken) {
+          events.unsafeOffer({ _tag: "Error", message: exitDetail });
+        } else {
+          grokDiag("Suppressed final Error event on close for cached_token auth fatal");
+        }
+
         events.unsafeOffer({ _tag: "Status", status: "idle" });
       }
       // End the mailbox so any renderer subscription / Stream consumer sees

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -16,6 +16,8 @@ import {
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
+import { handleFsRequest } from "./acp/fs.ts";
+import { handleTerminalRequest } from "./acp/terminal.ts";
 
 /**
  * Live-only handle for one Grok conversation. Mirrors Codex/Claude handle
@@ -76,7 +78,45 @@ type PendingResolver = {
   timer: NodeJS.Timeout;
 };
 
+/**
+ * Diagnostic logging for the Grok ACP driver.
+ *
+ *   MEMOIZE_DEBUG_GROK=1        → full RPC trace + diag dumps (recommended when debugging "stops" or auth errors)
+ *   MEMOIZE_DEBUG_GROK_DIAG=1   → only the high-value diagnostic dumps (lighter than full RPC trace)
+ *
+ * When the agent "just stops" or you see repeated AuthorizationRequired:
+ *   1. Run the desktop app from a terminal (`bun run dev` or the packaged build).
+ *   2. `export MEMOIZE_DEBUG_GROK=1`
+ *   3. Reproduce the failure.
+ *   4. Look for lines starting with `[grok.stderr]`, `[grok.diag]`, and `[grok.rpc]`.
+ *      The last 2–4 kB of stderr right before a fatal is usually the smoking gun.
+ */
 const GROK_RPC_TRACE = process.env.MEMOIZE_DEBUG_GROK === "1";
+const GROK_DIAG = process.env.MEMOIZE_DEBUG_GROK === "1" || process.env.MEMOIZE_DEBUG_GROK_DIAG === "1";
+
+// Single source of truth for the user-facing auth failure message so the
+// two variants the user reported ("Run `grok login` again or verify..." vs
+// the slightly longer "Your cached login may have expired...") never diverge.
+export const GROK_AUTH_REQUIRED_MESSAGE =
+  "Grok authentication failed (AuthorizationRequired). " +
+  "Run `grok login` again or verify that your account has the SuperGrok Heavy plan. " +
+  "If the problem persists after logging in, check your plan at https://x.ai/.";
+
+/** Always-on diagnostic helper. Use for anything that helps root-cause "it stops". */
+const grokDiag = (label: string, data?: unknown): void => {
+  if (!GROK_DIAG && !GROK_RPC_TRACE) return;
+  const prefix = `[grok.diag] ${label}`;
+  if (data === undefined) {
+    process.stderr.write(`${prefix}\n`);
+  } else {
+    try {
+      const s = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+      process.stderr.write(`${prefix}: ${s}\n`);
+    } catch {
+      process.stderr.write(`${prefix}: (unserialisable)\n`);
+    }
+  }
+};
 
 /**
  * Detect fatal authorization failures from the grok agent's own stderr.
@@ -85,31 +125,29 @@ const GROK_RPC_TRACE = process.env.MEMOIZE_DEBUG_GROK === "1";
  *   "worker quit with fatal: Transport channel closed, when Auth(AuthorizationRequired)"
  * and dies. We watch for this in real time so we can fail the in-flight
  * prompt *immediately* instead of waiting for the 5-minute timeout, and
- * we can surface a clean actionable message instead of the raw timeout.
+ * we surface the single canonical GROK_AUTH_REQUIRED_MESSAGE.
  */
 const isFatalAuthError = (text: string): boolean => {
   const t = text.toLowerCase();
+  // Be very strict. The grok binary sometimes logs auth state, "waiting",
+  // "transport channel" etc. during normal operation or token refresh.
+  // Only treat as fatal when we see the actual worker-abort messages that
+  // indicate the agent session is dead because of AuthorizationRequired.
   return (
-    t.includes("authorizationrequired") ||
-    t.includes("auth(authorizationrequired)") ||
-    (t.includes("worker quit with fatal") && t.includes("auth")) ||
-    (t.includes("transport channel closed") && t.includes("auth"))
+    (t.includes("worker quit with fatal") && t.includes("authorizationrequired")) ||
+    (t.includes("transport channel closed") && t.includes("authorizationrequired")) ||
+    t.includes("auth(authorizationrequired)")
   );
 };
 
 /**
  * Turn a raw stderr snippet (from the grok binary) into a user-friendly
- * error message. When we see the known fatal auth line we produce a clear,
- * actionable string instead of the confusing "timed out after 300000ms"
- * that the user was getting.
+ * error message. When we see the known fatal auth line we produce the
+ * canonical GROK_AUTH_REQUIRED_MESSAGE.
  */
 const friendlyErrorFromStderr = (rawTail: string): string | null => {
   if (!isFatalAuthError(rawTail)) return null;
-  return (
-    "Grok authentication failed (AuthorizationRequired). " +
-    "Your login may have expired or your account does not have the SuperGrok Heavy tier required for the coding agent. " +
-    "Run `grok login` again, then retry the turn. If the problem persists, check your plan at https://x.ai/."
-  );
+  return GROK_AUTH_REQUIRED_MESSAGE;
 };
 
 /**
@@ -198,11 +236,21 @@ export const startGrokSession = (
     let acpSessionId: string | null = null;
     let nextRpcId = 1;
     let closed = false;
+    /** True once the ACP child has exited (fatal auth, crash, or normal end).
+     *  Further send() calls fail fast with a clear "session ended — start a new chat" message
+     *  instead of queuing doomed RPCs that will 5-minute timeout.
+     */
+    let dead = false;
     let inflight: Promise<void> = Promise.resolve();
     const pending = new Map<number, PendingResolver>();
     // Trailing window of grok's stderr — used to enrich error reports when
     // the JSON-RPC envelope itself is opaque ("Internal error" with no data).
     let stderrTail = "";
+
+    // Which auth method the binary accepted for this session.
+    // Very useful when debugging "AuthorizationRequired" even with a valid login.
+    // Common values: "cached_token" (from `grok login`) or "xai.api_key".
+    let authMethodUsed: string | null = null;
 
     events.unsafeOffer({
       _tag: "Started",
@@ -366,23 +414,54 @@ export const startGrokSession = (
             );
           }
           if (isFs) {
-            // Reply immediately so the agent can continue instead of timing
-            // out on an unhandled client capability.
-            writeMessage({
-              jsonrpc: "2.0",
-              id: msg.id,
-              error: {
-                code: -32601,
-                message: `Method not implemented by memoize ACP client: ${msg.method}`,
-              },
-            });
+            // Real FS support — the agent can now read/write files directly
+            // instead of getting "Method not implemented" tool errors.
+            handleFsRequest(msg.method, msg.params, { cwd })
+              .then((result) => {
+                writeMessage({ jsonrpc: "2.0", id: msg.id, result });
+              })
+              .catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                writeMessage({
+                  jsonrpc: "2.0",
+                  id: msg.id,
+                  error: { code: -32603, message },
+                });
+              });
             return;
           }
-          // For everything else (permission requests, etc.) we still just
-          // warn and let the server time out or proceed.
-          console.warn(
-            `[grok.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
-          );
+
+          if (msg.method.startsWith("terminal/")) {
+            handleTerminalRequest(msg.method, msg.params, { cwd })
+              .then((result) => {
+                writeMessage({ jsonrpc: "2.0", id: msg.id, result });
+              })
+              .catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                writeMessage({
+                  jsonrpc: "2.0",
+                  id: msg.id,
+                  error: { code: -32603, message },
+                });
+              });
+            return;
+          }
+          // For everything else (permission prompts, terminal requests,
+          // collab callbacks, etc.) we still reply with a clean error so the
+          // agent never hangs forever waiting for a response that will never
+          // come. This is a common cause of mysterious mid-turn "stops".
+          writeMessage({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: {
+              code: -32601,
+              message: `Method not supported by memoize ACP client: ${msg.method}`,
+            },
+          });
+          grokDiag("replied to unhandled server→client request", {
+            method: msg.method,
+            id: msg.id,
+          });
           return;
         }
         // Unknown notification — drop.
@@ -422,28 +501,49 @@ export const startGrokSession = (
       // context (auth failures, version mismatch, etc.) instead of just
       // grok's generic JSON-RPC "Internal error".
       stderrTail = (stderrTail + chunk).slice(-4096);
+
+      // Always emit the raw stderr from the grok binary. When the agent
+      // "just stops" or you see AuthorizationRequired, the lines starting
+      // with [grok.stderr] are the primary diagnostic. Run the app from a
+      // terminal and `grep -i auth` or `grep -i fatal` on the output.
       process.stderr.write(`[grok.stderr] ${chunk}`);
 
       // Fast-path: if the agent itself reports a fatal auth failure
       // (token expired / wrong tier), kill the in-flight prompt right now
       // instead of letting the 5-minute timeout fire. This is what the
       // user meant by "not auto stopping".
-      if (isFatalAuthError(chunk) || isFatalAuthError(stderrTail)) {
+      const sawFatal = isFatalAuthError(chunk) || isFatalAuthError(stderrTail);
+      if (sawFatal) {
+        dead = true;
+
+        const isCachedToken = authMethodUsed === "cached_token";
+
+        // Rich diagnostic dump — this is what you look at when debugging
+        // "why did it suddenly say AuthorizationRequired".
+        grokDiag("FATAL_AUTH_TRIGGERED", {
+          chunkPreview: chunk.slice(0, 800),
+          tailPreview: stderrTail.slice(-800),
+          currentPromptRpcId,
+          inflightPending: pending.size,
+          authMethodUsed,
+          isCachedToken,
+        });
+
         if (currentPromptRpcId !== null) {
-          rejectCurrentPrompt(
-            "Grok authentication failed (AuthorizationRequired). " +
-              "Your cached login may have expired or your account lacks the SuperGrok Heavy tier required to use the agent. " +
-              "Run `grok login` again, then retry.",
-          );
+          rejectCurrentPrompt(GROK_AUTH_REQUIRED_MESSAGE);
         }
-        // Surface a clean error immediately so the UI can stop the spinner
-        // and show the auth-classified error card with the "Open settings" button.
+
         if (!closed) {
+          const helpfulMessage = isCachedToken
+            ? "Grok's agent worker rejected the session (AuthorizationRequired). " +
+              "Your local `grok login` was accepted at the protocol level, but the coding agent worker " +
+              "often requires stronger credentials. Try running `grok login` again, or temporarily set an XAI API key " +
+              "in the Grok provider settings for more reliable agent use."
+            : GROK_AUTH_REQUIRED_MESSAGE;
+
           events.unsafeOffer({
             _tag: "Error",
-            message:
-              "Grok authentication failed (AuthorizationRequired). " +
-              "Run `grok login` again or verify that your account has the SuperGrok Heavy plan.",
+            message: helpfulMessage,
           });
         }
       }
@@ -451,11 +551,14 @@ export const startGrokSession = (
 
     child.on("error", (err) => {
       if (closed) return;
+      dead = true;
       events.unsafeOffer({ _tag: "Error", message: err.message });
+      void Effect.runPromise(events.end).catch(() => {});
     });
 
     child.on("close", (code, signal) => {
       rl.close();
+      dead = true;
       const trimmedStderr = stderrTail.trim();
       const friendly = friendlyErrorFromStderr(trimmedStderr);
       const exitDetail =
@@ -464,6 +567,16 @@ export const startGrokSession = (
           : trimmedStderr.length > 0
             ? `Grok ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${trimmedStderr}`
             : `Grok ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;
+
+      grokDiag("child process closed", {
+        code,
+        signal,
+        stderrTailLen: trimmedStderr.length,
+        hadFriendlyAuthError: friendly !== null,
+      });
+      if (trimmedStderr.length > 0) {
+        grokDiag("final stderr tail (last 2k)", trimmedStderr.slice(-2000));
+      }
       for (const { reject, timer } of pending.values()) {
         clearTimeout(timer);
         reject(new Error(exitDetail));
@@ -473,6 +586,11 @@ export const startGrokSession = (
         events.unsafeOffer({ _tag: "Error", message: exitDetail });
         events.unsafeOffer({ _tag: "Status", status: "idle" });
       }
+      // End the mailbox so any renderer subscription / Stream consumer sees
+      // completion instead of hanging forever on a dead session. This prevents
+      // the "stops" symptom where the UI shows the last error but never
+      // transitions to a clean terminal state.
+      void Effect.runPromise(events.end).catch(() => {});
     });
 
     // === ACP handshake — synchronous, fails the start() RPC on error. ===
@@ -502,6 +620,8 @@ export const startGrokSession = (
             .map((m) => (typeof m?.id === "string" ? m.id : null))
             .filter((id): id is string => id !== null),
         );
+        grokDiag("handshake initialize returned authMethods", [...authIds]);
+
         const methodId =
           apiKey !== null && authIds.has("xai.api_key")
             ? "xai.api_key"
@@ -513,10 +633,14 @@ export const startGrokSession = (
             "Grok ACP offered no usable auth method. Run `grok login`, or set GROK_CODE_XAI_API_KEY.",
           );
         }
-        await request("authenticate", {
+        authMethodUsed = methodId;
+        grokDiag("choosing auth method", { methodId, hasApiKey: apiKey !== null });
+
+        const authResult = await request("authenticate", {
           methodId,
           _meta: { headless: true },
         });
+        grokDiag("authenticate succeeded", { methodId, authMethodUsed, result: authResult });
 
         const sessionResult = (await request("session/new", {
           cwd,
@@ -526,6 +650,7 @@ export const startGrokSession = (
         if (typeof sessionResult.sessionId !== "string") {
           throw new Error("Grok ACP session/new returned no sessionId.");
         }
+        grokDiag("session/new succeeded", { sessionId: sessionResult.sessionId, authMethodUsed });
         return sessionResult.sessionId;
       },
       catch: (cause) =>
@@ -561,18 +686,34 @@ export const startGrokSession = (
 
     const enqueuePrompt = (text: string): void => {
       const sid = acpSessionId;
-      if (sid === null) return;
+      if (sid === null || dead) {
+        // Fast fail so the user doesn't wait for a 5-minute RPC timeout on a dead child.
+        events.unsafeOffer({
+          _tag: "Error",
+          message:
+            "Grok session has ended (authentication failure or process exit). " +
+            "Close this chat and start a new one to continue with Grok.",
+        });
+        events.unsafeOffer({ _tag: "Status", status: "idle" });
+        void Effect.runPromise(events.end).catch(() => {});
+        return;
+      }
       // Plan-mode emulation: grok ACP has no native read-only switch, so
       // prepend a developer-instructions block while plan mode is active.
       const promptText = applyPlanModePrefix(currentMode, text);
       inflight = inflight
         .then(async () => {
-          if (closed) return;
-          if (GROK_RPC_TRACE) {
+          if (closed || dead) return;
+          if (GROK_RPC_TRACE || GROK_DIAG) {
             process.stderr.write(
               `[grok.prompt] enqueue len=${promptText.length} mode=${currentMode}\n`,
             );
           }
+          grokDiag("session/prompt starting", {
+            promptLen: promptText.length,
+            permissionMode: currentMode,
+            model: input.model,
+          });
           try {
             await request(
               "session/prompt",
@@ -592,14 +733,16 @@ export const startGrokSession = (
                 currentPromptRpcId = id;
               },
             );
-            if (GROK_RPC_TRACE) {
+            if (GROK_RPC_TRACE || GROK_DIAG) {
               process.stderr.write(`[grok.prompt] completed\n`);
             }
+            grokDiag("session/prompt completed successfully");
           } catch (cause) {
             const reason = cause instanceof Error ? cause.message : String(cause);
-            if (GROK_RPC_TRACE) {
+            if (GROK_RPC_TRACE || GROK_DIAG) {
               process.stderr.write(`[grok.prompt] failed: ${reason}\n`);
             }
+            grokDiag("session/prompt failed", { reason });
             const isCancellation = /cancel|interrupt/i.test(reason);
             if (!closed && !isCancellation) {
               events.unsafeOffer({
@@ -622,7 +765,7 @@ export const startGrokSession = (
     };
 
     if (input.initialPrompt !== undefined && input.initialPrompt.length > 0) {
-      enqueuePrompt(input.initialPrompt);
+      if (!dead) enqueuePrompt(input.initialPrompt);
     }
 
     const handle: GrokSessionHandle = {

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -328,6 +328,27 @@ export const startGrokSession = (
           }
           return;
         }
+
+        // Grok swarming / collab agents + general thread/item lifecycle.
+        // The ACP server emits item/started, item/completed, thread/* etc.
+        // with payloads containing ThreadItem (including collabAgentToolCall)
+        // and per-thread metadata (nickname, role, states). Forward the
+        // params object to the translator so the new collab handling can
+        // extract them. Only log at trace level to avoid noise in normal use.
+        if (msg.method.startsWith("item/") || msg.method.startsWith("thread/")) {
+          if (GROK_RPC_TRACE) {
+            process.stderr.write(
+              `[grok.rpc] ${msg.method} params=${JSON.stringify(msg.params ?? {})}\n`,
+            );
+          }
+          if (msg.params !== undefined) {
+            for (const ev of translator.translate(msg.params)) {
+              events.unsafeOffer(ev);
+            }
+          }
+          return;
+        }
+
         if (msg.id !== undefined) {
           // Server→client request (fs/*, permission prompts, etc.).
           // We now:
@@ -469,6 +490,10 @@ export const startGrokSession = (
               moveFile: true,
             },
             terminal: true,
+            // Opt into experimental features (collab agents / swarming, richer
+            // thread/item notifications, etc.) so Grok Build will emit the full
+            // collabAgentToolCall stream for 10+ agent swarms.
+            experimentalApi: true,
           },
         })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
 

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -411,6 +411,14 @@ export const MessageStoreLive = Layer.scoped(
       SessionId,
       { agents: Readonly<Record<string, AgentDefinition>>; enableSubagents: boolean }
     >();
+
+    /**
+     * Tracks consecutive times a Grok session died because the internal
+     * agent worker rejected the `cached_token` from `grok login`.
+     * Used to stop hammering restarts when local auth is having issues
+     * with the full coding agent.
+     */
+    const grokAuthWorkerDeathCount = new Map<SessionId, number>();
     const ndjsonAppend = (
       sessionId: SessionId,
       message: Message,
@@ -1589,6 +1597,38 @@ export const MessageStoreLive = Layer.scoped(
             }),
           );
         if (sendResult !== "ok") {
+          const isGrok = session.providerId === "grok";
+          const looksLikeGrokAuthWorkerDeath =
+            isGrok &&
+            /Grok's agent worker rejected the session.*AuthorizationRequired/i.test(
+              sendResult.reason,
+            );
+
+          if (looksLikeGrokAuthWorkerDeath) {
+            const count = (grokAuthWorkerDeathCount.get(sessionId) ?? 0) + 1;
+            grokAuthWorkerDeathCount.set(sessionId, count);
+
+            if (count >= 2) {
+              // Stop auto-restarting. The user is hitting the known
+              // local `grok login` + agent worker auth limitation.
+              const message =
+                `Grok's coding agent worker is repeatedly rejecting the session with AuthorizationRequired, even though your local login appears valid.\n\n` +
+                `This is a known current limitation when using \`grok login\` (cached_token) with the full agent.\n\n` +
+                `You can try:\n` +
+                `• Running \`grok login\` again\n` +
+                `• Temporarily setting an XAI API key in the Grok provider settings\n\n` +
+                `Further automatic restarts have been disabled for this session to avoid spam.`;
+              const persistedError = yield* persistMessage(sessionId, {
+                _tag: "error",
+                message,
+              });
+              yield* broadcastMessage(sessionId, persistedError);
+              yield* ndjsonAppend(sessionId, persistedError);
+              yield* setStatus(sessionId, "idle");
+              return;
+            }
+          }
+
           console.log(
             `[message-store.sendMessage] provider.send failed; restarting provider session for ${sessionId}`,
           );


### PR DESCRIPTION
## Summary

Makes the Grok provider (via \`grok agent stdio\`) significantly more usable when authenticating with normal local \`grok login\` (cached_token), which is the most common flow for many users.

### Key Improvements

- **Auth handling & UX**: 
  - Detect when the agent *worker* rejects the session with \`AuthorizationRequired\` (even when the ACP handshake succeeds).
  - Show a clear, actionable error message explaining the current limitation with local login + full coding agent.
  - **Silence repeated noisy "Provider error" cards** during a session so the UI isn't spammed while the agent is still making progress (full diagnostics remain in console logs).
  - Throttle automatic session restarts after repeated auth worker deaths to prevent spam.

- **FS support for ACP** (Grok + Gemini + Cursor):
  - Proper implementation of \`fs/read_text_file\`, \`fs/read_directory\`, \`fs/write_file\` etc.
  - Compatible response shapes to avoid "failed to deserialize" errors.

- **Terminal support**:
  - Basic implementations/stubs for \`terminal/create\`, \`terminal/wait_for_exit\`, \`terminal/exec\` etc. so agents stop getting constant "Method not implemented" failures.

- **Auth probe**:
  - More robust JWT tier parsing from \`~/.grok/auth.json\`.

- Tests + better error recovery.

These changes reduce the "stops mid-way + error spam" experience on local auth while we wait for upstream improvements on the cached_token + grok-build agent worker path.

**Note**: For the most reliable long-running agent sessions right now, an XAI API key may still be needed in some cases.