### PR TITLE
fix(cursor): real auth detection + one-click sign-in

### DIFF
--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -1,15 +1,19 @@
-import { ChevronDown, Copy, ExternalLink } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Effect, Fiber, Stream } from "effect";
+import { ChevronDown, Copy, ExternalLink, Loader2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   MODELS_BY_PROVIDER,
   type AgentAvailability,
+  type LoginEvent,
   type ProviderId,
 } from "@memoize/wire";
 
 import { ApiKeyRow } from "~/components/api-key-row";
 import { ProviderIcon } from "~/components/provider-icons";
 import { Button } from "~/components/ui/button";
+import { getRpcClient } from "~/lib/rpc-client";
+import { useProvidersStore } from "~/store/providers";
 import {
   Select,
   SelectItem,
@@ -203,9 +207,12 @@ export function ProviderCard({
             <CodeRow label="Install" command={INSTALL_HINT[providerId]} />
           )}
           {availability?.cliInstalled &&
-            availability.authStatus === "unauthenticated" && (
+            availability.authStatus === "unauthenticated" &&
+            (providerId === "cursor" ? (
+              <CursorSignInRow />
+            ) : (
               <CodeRow label="Sign in" command={LOGIN_HINT[providerId]} />
-            )}
+            ))}
           <SubscriptionRow
             providerId={providerId}
             availability={availability}
@@ -353,6 +360,184 @@ function BlurredEmail({ email }: { email: string }) {
     >
       {email}
     </button>
+  );
+}
+
+/**
+ * One-click sign-in for Cursor. Click → subscribe to `agent.startLogin`,
+ * which spawns `cursor-agent login` server-side and streams progress. The
+ * first `url` event opens the OAuth page in the OS browser; the terminal
+ * `done` event triggers an availability refresh and (on success) collapses
+ * the row. Cancel interrupts the stream, which closes the server-side
+ * scope and SIGTERMs the child process.
+ */
+function CursorSignInRow() {
+  const refresh = useProvidersStore((s) => s.refresh);
+  const [state, setState] = useState<
+    | { kind: "idle" }
+    | { kind: "waiting"; url: string | null }
+    | { kind: "success" }
+    | { kind: "failed"; reason: string }
+  >({ kind: "idle" });
+  const fiberRef = useRef<Fiber.RuntimeFiber<unknown, unknown> | null>(null);
+
+  useEffect(
+    () => () => {
+      const fiber = fiberRef.current;
+      if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
+    },
+    [],
+  );
+
+  const cancel = () => {
+    const fiber = fiberRef.current;
+    if (fiber !== null) {
+      void Effect.runPromise(Fiber.interrupt(fiber));
+      fiberRef.current = null;
+    }
+    setState({ kind: "idle" });
+  };
+
+  const start = async () => {
+    setState({ kind: "waiting", url: null });
+    const client = await getRpcClient();
+    const fiber = Effect.runFork(
+      Stream.runForEach(
+        client.agent.startLogin({ providerId: "cursor" }),
+        (event: LoginEvent) =>
+          Effect.sync(() => {
+            if (event._tag === "url") {
+              openExternal(event.url);
+              setState({ kind: "waiting", url: event.url });
+            } else if (event._tag === "done") {
+              fiberRef.current = null;
+              if (event.ok) {
+                setState({ kind: "success" });
+                void refresh();
+              } else {
+                setState({
+                  kind: "failed",
+                  reason: event.reason ?? "Sign-in failed.",
+                });
+              }
+            }
+            // "log" events are diagnostic-only; ignored in the UI.
+          }),
+      ).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            fiberRef.current = null;
+            setState({
+              kind: "failed",
+              reason: err instanceof Error ? err.message : String(err),
+            });
+          }),
+        ),
+      ),
+    );
+    fiberRef.current = fiber;
+  };
+
+  if (state.kind === "success") {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-emerald-400/30 bg-emerald-500/[0.06] px-3 py-2 text-[11px] text-emerald-200">
+        <span>Signed in. Refreshing…</span>
+      </div>
+    );
+  }
+
+  if (state.kind === "waiting") {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2.5 text-[11px]">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          <span>
+            {state.url === null
+              ? "Starting cursor-agent login…"
+              : "Waiting for browser sign-in…"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {state.url !== null && (
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              onClick={(e) => {
+                e.stopPropagation();
+                openExternal(state.url!);
+              }}
+              className="h-6 px-2 text-[11px]"
+            >
+              <ExternalLink className="mr-1 size-3" aria-hidden />
+              Open browser again
+            </Button>
+          )}
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost"
+            onClick={(e) => {
+              e.stopPropagation();
+              cancel();
+            }}
+            className="h-6 px-2 text-[11px]"
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.kind === "failed") {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="rounded-md border border-rose-400/30 bg-rose-500/[0.06] px-3 py-2 text-[11px] text-rose-200">
+          {state.reason}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={(e) => {
+              e.stopPropagation();
+              void start();
+            }}
+            className="h-6 px-2 text-[11px]"
+          >
+            Try again
+          </Button>
+        </div>
+        <CodeRow label="Or run manually" command={LOGIN_HINT.cursor} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-[11px] font-medium text-muted-foreground">
+        Sign in
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="xs"
+          variant="default"
+          onClick={(e) => {
+            e.stopPropagation();
+            void start();
+          }}
+          className="h-7 px-3 text-[11px]"
+        >
+          Sign in to Cursor
+        </Button>
+        <span className="text-[10px] text-muted-foreground">
+          or run <code className="font-mono">$ {LOGIN_HINT.cursor}</code>
+        </span>
+      </div>
+    </div>
   );
 }
 

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -514,33 +514,74 @@ const probeGeminiAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSyste
       : ({ authStatus: "unauthenticated" } satisfies AccountInfo);
   });
 
-// Cursor Agent stores OAuth credentials under `~/.local/share/cursor-agent/`
-// after `cursor-agent login`. The directory is also created on first install
-// regardless of auth state, so its mere presence isn't a perfect proxy — but
-// it's the best we have without driving the ACP probe. The renderer also
-// flips to "ready" via `hasApiKey` once a key lands in the keychain.
+// Strip ANSI escape sequences (cursor-positioning, colors, etc). The
+// cursor-agent CLI emits a TUI-style status frame before its final answer,
+// e.g. ` Starting login process...\n[2K[1A[2K[G\n Not logged in`. We only
+// want to read the final human-readable line.
+const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const stripAnsi = (raw: string): string => raw.replace(ANSI_PATTERN, "");
+
+// `cursor-agent status` is the CLI's own auth signal. It prints either
+// "Not logged in" or a positive line — `Logged in as <email>` on newer
+// builds, `Login successful!` on older ones. The directory at
+// `~/.local/share/cursor-agent/` is created on install regardless of
+// login state, so we never trust it.
 //
-// Like Grok, we can't verify the user's plan from the CLI alone — driving
-// agent sessions through `cursor-agent acp` requires an active Cursor Pro
-// (or higher) subscription, but the OAuth artifact alone doesn't tell us
-// whether that plan is active. Carry the requirement in `authLabel` so the
-// card surfaces "Requires Cursor Pro subscription" + a subscribe CTA, and
-// the user finds out before they hit a session-runtime 403.
-const probeCursorAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSystem> =
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = join(homedir(), ".local", "share", "cursor-agent");
-    const exists = yield* fs
-      .exists(path)
-      .pipe(Effect.catchAll(() => Effect.succeed(false)));
-    return exists
-      ? ({
-          authStatus: "authenticated",
-          authType: "cli",
-          authLabel: "Requires Cursor Pro",
-        } satisfies AccountInfo)
-      : ({ authStatus: "unauthenticated" } satisfies AccountInfo);
-  });
+// We don't set the "Requires Cursor Pro" gating label, even though the
+// ACP runtime does need a paid plan: cursor-agent has no `whoami`/`me`
+// subcommand, so once a user is signed in we have no way to tell Pro
+// from non-Pro. Falsely labelling every signed-in user as gated nags
+// people who already pay. The ACP server enforces the real check at
+// session start and surfaces a clear error there if the plan is missing.
+const CURSOR_EMAIL_PATTERN = /[\w.+-]+@[\w.-]+\.\w+/;
+
+const parseCursorStatusOutput = (raw: string): AccountInfo => {
+  const cleanedRaw = stripAnsi(raw);
+  const cleaned = cleanedRaw.toLowerCase();
+  if (cleaned.includes("not logged in") || cleaned.includes("not signed in")) {
+    return { authStatus: "unauthenticated" };
+  }
+  const emailMatch = cleanedRaw.match(CURSOR_EMAIL_PATTERN);
+  if (
+    cleaned.includes("logged in as") ||
+    cleaned.includes("signed in as") ||
+    cleaned.includes("login successful") ||
+    cleaned.includes("authenticated") ||
+    emailMatch !== null
+  ) {
+    return {
+      authStatus: "authenticated",
+      authType: "cli",
+      ...(emailMatch !== null ? { authEmail: emailMatch[0] } : {}),
+    } satisfies AccountInfo;
+  }
+  return { authStatus: "unknown" };
+};
+
+const probeCursorAccount: Effect.Effect<
+  AccountInfo,
+  never,
+  CommandExecutor.CommandExecutor
+> = Effect.gen(function* () {
+  const executor = yield* CommandExecutor.CommandExecutor;
+  const result = yield* Effect.gen(function* () {
+    const proc = yield* executor.start(Command.make("cursor-agent", "status"));
+    const stdout = yield* collectText(proc.stdout);
+    const stderr = yield* collectText(proc.stderr);
+    const exitCode = yield* proc.exitCode;
+    return { stdout, stderr, exitCode };
+  }).pipe(
+    Effect.scoped,
+    Effect.timeoutOption(PROBE_TIMEOUT),
+    Effect.catchAll(() => Effect.succeedNone),
+  );
+  if (result._tag !== "Some") {
+    return { authStatus: "unknown" } satisfies AccountInfo;
+  }
+  // Exit code is not a reliable signal — the CLI returns 0 even when not
+  // logged in. Parse the text instead.
+  return parseCursorStatusOutput(`${result.value.stdout}\n${result.value.stderr}`);
+});
 
 // OpenCode stores per-provider credentials in `~/.local/share/opencode/auth.json`
 // after `opencode auth login <provider>`. Each top-level key is a provider id

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -376,20 +376,19 @@ export const startCursorSession = (
         // Cursor advertises `cursor_login` for OAuth-style credentials and
         // `cached_token` once a prior `cursor-agent login` has stored one.
         // When an API key is set we prefer `cursor_login` (the CLI handles
-        // the key/token translation server-side); otherwise fall back to
-        // the cached token. If neither is available, fail with a clear
-        // message so the user knows what to run.
+        // the key/token translation server-side); otherwise use the cached
+        // token. We don't fall back to `cursor_login` without an API key —
+        // that silently sends the user into an OAuth dance the ACP child
+        // can't complete, masking "not signed in" behind a vague error.
         const methodId =
           apiKey !== null && authIds.has("cursor_login")
             ? "cursor_login"
             : authIds.has("cached_token")
               ? "cached_token"
-              : authIds.has("cursor_login")
-                ? "cursor_login"
-                : null;
+              : null;
         if (methodId === null) {
           throw new Error(
-            "Cursor ACP offered no usable auth method. Run `cursor-agent login`, or set CURSOR_API_KEY.",
+            'Cursor is not signed in. Click "Sign in" on the Cursor provider card, run `cursor-agent login` in a terminal, or paste a Cursor API key.',
           );
         }
         await request("authenticate", {

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -9,6 +9,7 @@ import { Effect, Layer, Stream } from "effect";
 
 import { resolveCliPath } from "./availability.ts";
 import { loadOpencodeInventory } from "./drivers/opencode.ts";
+import { startProviderLogin } from "./services/login-service.ts";
 import { MessageStore } from "./services/message-store.ts";
 import { PermissionService } from "./services/permission-service.ts";
 import { ProviderService } from "./services/provider-service.ts";
@@ -64,6 +65,17 @@ const Events = MemoizeRpcs.toLayerHandler("agent.events", ({ sessionId }) =>
   Stream.unwrap(
     Effect.map(ProviderService, (svc) => svc.events(sessionId)),
   ),
+);
+
+// Renderer subscribes to this when the user clicks the "Sign in" button on a
+// provider card. Today only the cursor handler does real work — it spawns
+// `cursor-agent login`, extracts the OAuth URL, and streams progress back.
+// When the renderer unsubscribes (cancel, navigate away, IPC drop), the
+// stream's scope closes and the child process is SIGTERM'd by the service's
+// finalizer.
+const StartLogin = MemoizeRpcs.toLayerHandler(
+  "agent.startLogin",
+  ({ providerId }) => startProviderLogin(providerId),
 );
 
 // Renderer calls this on first open of the opencode model picker to refresh
@@ -373,6 +385,7 @@ export const ProviderHandlersLayer = Layer.mergeAll(
   Interrupt,
   Close,
   Events,
+  StartLogin,
   OpencodeInventory,
   SessionList,
   SessionGet,

--- a/apps/server/src/provider/services/login-service.ts
+++ b/apps/server/src/provider/services/login-service.ts
@@ -1,0 +1,146 @@
+import { Effect, Mailbox, type Scope, Stream } from "effect";
+import {
+  spawn,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import * as readline from "node:readline";
+import { homedir } from "node:os";
+
+import {
+  AgentSessionStartError,
+  type LoginEvent,
+  type ProviderId,
+} from "@memoize/wire";
+
+// Cursor-agent's login command prints an OAuth URL to stdout (or to stderr
+// inside its TUI frame) and waits for the user to complete the flow in their
+// browser. We anchor on the cursor.com / cursor.sh / cursor.so hosts to avoid
+// matching install-instruction URLs the CLI may also print on startup.
+const CURSOR_URL_PATTERN =
+  /https?:\/\/[^\s]*cursor\.(?:com|sh|so)\/[^\s]*/i;
+const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+/**
+ * Spawn a provider's interactive login subcommand and stream progress back
+ * to the renderer. Today only `cursor` has a real handler — other providers
+ * resolve to an immediate `{ kind: "done", ok: false, reason: … }`.
+ *
+ * Cancellation: the stream is wrapped in `Stream.unwrapScoped`, so when the
+ * renderer unsubscribes (or the IPC drops), the scope closes and the
+ * registered finalizer kills the child process with SIGTERM (escalating to
+ * SIGKILL after a short grace period).
+ */
+export const startProviderLogin = (
+  providerId: ProviderId,
+): Stream.Stream<LoginEvent, AgentSessionStartError> => {
+  if (providerId !== "cursor") {
+    const event: LoginEvent = {
+      _tag: "done",
+      ok: false,
+      reason: `Login flow not supported for ${providerId}`,
+    };
+    return Stream.succeed(event);
+  }
+  return Stream.unwrapScoped(spawnCursorLogin);
+};
+
+const spawnCursorLogin: Effect.Effect<
+  Stream.Stream<LoginEvent>,
+  AgentSessionStartError,
+  Scope.Scope
+> = Effect.gen(function* () {
+  const mailbox = yield* Mailbox.make<LoginEvent>();
+
+  // Spawn into the user's home dir — login doesn't touch the project tree
+  // and we don't want a project-local stale state to interfere.
+  let child: ChildProcessWithoutNullStreams;
+  try {
+    child = spawn("cursor-agent", ["login"], {
+      cwd: homedir(),
+      env: process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (cause) {
+    yield* mailbox.end;
+    return yield* Effect.fail(
+      new AgentSessionStartError({
+        providerId: "cursor",
+        reason: cause instanceof Error ? cause.message : String(cause),
+      }),
+    );
+  }
+
+  child.stdout.setEncoding("utf-8");
+  child.stderr.setEncoding("utf-8");
+
+  let urlEmitted = false;
+  let exited = false;
+
+  const handleLine = (raw: string): void => {
+    const cleaned = raw.replace(ANSI_PATTERN, "").trim();
+    if (cleaned.length === 0) return;
+    mailbox.unsafeOffer({ _tag: "log", text: cleaned });
+    if (!urlEmitted) {
+      const m = cleaned.match(CURSOR_URL_PATTERN);
+      if (m !== null) {
+        urlEmitted = true;
+        mailbox.unsafeOffer({ _tag: "url", url: m[0] });
+      }
+    }
+  };
+
+  const rlOut = readline.createInterface({ input: child.stdout });
+  const rlErr = readline.createInterface({ input: child.stderr });
+  rlOut.on("line", handleLine);
+  rlErr.on("line", handleLine);
+
+  child.once("exit", (code, signal) => {
+    exited = true;
+    const ok = code === 0;
+    const reason = ok
+      ? undefined
+      : signal !== null
+        ? `cursor-agent login was terminated (${signal})`
+        : `cursor-agent login exited with code ${code ?? "?"}`;
+    mailbox.unsafeOffer({
+      _tag: "done",
+      ok,
+      ...(reason !== undefined ? { reason } : {}),
+    });
+    void mailbox.end.pipe(Effect.runPromise);
+  });
+
+  child.once("error", (err) => {
+    exited = true;
+    mailbox.unsafeOffer({
+      _tag: "done",
+      ok: false,
+      reason: err.message,
+    });
+    void mailbox.end.pipe(Effect.runPromise);
+  });
+
+  yield* Effect.addFinalizer(() =>
+    Effect.sync(() => {
+      rlOut.close();
+      rlErr.close();
+      if (exited) return;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+      setTimeout(() => {
+        if (!exited) {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            /* ignore */
+          }
+        }
+      }, 1_000);
+    }),
+  );
+
+  return Mailbox.toStream(mailbox);
+});

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -987,3 +987,28 @@ export const AgentOpencodeInventoryRpc = Rpc.make("agent.opencodeInventory", {
   // the same shape the renderer already knows how to surface.
   error: AgentSessionStartError,
 });
+
+// ---------------------------------------------------------------------------
+// One-click sign-in flow. The renderer subscribes to `agent.startLogin`,
+// which spawns the provider's `login` subcommand server-side, extracts the
+// OAuth URL the CLI prints, and reports progress back as a stream of
+// `LoginEvent`s. Today only `cursor` has a real handler; other providers
+// resolve to an immediate `done(ok=false)`.
+// ---------------------------------------------------------------------------
+
+export const LoginEvent = Schema.Union(
+  Schema.TaggedStruct("url", { url: Schema.String }),
+  Schema.TaggedStruct("log", { text: Schema.String }),
+  Schema.TaggedStruct("done", {
+    ok: Schema.Boolean,
+    reason: Schema.optional(Schema.String),
+  }),
+);
+export type LoginEvent = typeof LoginEvent.Type;
+
+export const AgentStartLoginRpc = Rpc.make("agent.startLogin", {
+  payload: Schema.Struct({ providerId: ProviderId }),
+  success: LoginEvent,
+  error: AgentSessionStartError,
+  stream: true,
+});

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -8,6 +8,7 @@ import {
   AgentOpencodeInventoryRpc,
   AgentSendRpc,
   AgentSetCredentialRpc,
+  AgentStartLoginRpc,
   AgentStartRpc,
 } from "./agent.ts";
 import { AttachmentTouchRpc, AttachmentUploadRpc } from "./attachment.ts";
@@ -142,6 +143,7 @@ export const MemoizeRpcs = RpcGroup.make(
   AgentCloseRpc,
   AgentEventsRpc,
   AgentOpencodeInventoryRpc,
+  AgentStartLoginRpc,
   ChatListRpc,
   ChatGetRpc,
   ChatCreateRpc,


### PR DESCRIPTION
## Summary

- **Stop misreporting auth.** `probeCursorAccount` was treating the
  existence of `~/.local/share/cursor-agent/` as proof of login, but that
  directory is created on first install (it holds the CLI's JS bundle
  under `versions/<v>/…`). Every fresh install was flagged as
  authenticated. Replaced with a probe that runs `cursor-agent status`
  and parses the output — `Not logged in` → unauthenticated, `Logged in
  as`/`Login successful`/email → authenticated, anything else → unknown.
- **Drop the blanket "Requires Cursor Pro" label.** `cursor-agent` has
  no `whoami`/`me` subcommand, so once a user is signed in we can't
  tell Pro from non-Pro. Falsely labelling every signed-in user as gated
  was nagging people who already pay. The ACP server enforces the real
  plan check at session start.
- **Add one-click Sign in to Cursor.** New streaming RPC
  `agent.startLogin` plus a server-side `login-service` that spawns
  `cursor-agent login`, ANSI-strips stdout/stderr, extracts the OAuth
  URL (anchored on `cursor.com|sh|so`), and emits `LoginEvent`s
  (`url` / `log` / `done`). Renderer card replaces the old
  copy-and-run `CodeRow` (Cursor only) with a button that opens the URL
  via `shell.openExternal`, shows a waiting/cancel UI, and refreshes
  availability on success. Stream cancellation tears the child down
  via `acquireRelease` → SIGTERM (→ SIGKILL grace).
- **Tighten the ACP auth waterfall.** `drivers/cursor.ts` was silently
  retrying `cursor_login` even without an API key, masking "not signed
  in" behind a vague handshake error. Now throws a clear
  *"Cursor is not signed in. Click 'Sign in' on the Cursor provider
  card, run \`cursor-agent login\`, or paste a Cursor API key."*

Other CLI providers (claude/grok/gemini/codex/opencode) keep their
existing copy-the-command `CodeRow` pattern — only Cursor gets the
one-click flow in this PR.

## Test plan

- [ ] `bun run check-types` passes (verified locally)
- [ ] `bun run build` passes (verified locally)
- [ ] **Signed out:** Cursor card shows yellow dot + "Sign in required"
      + **Sign in to Cursor** button (not "Requires Cursor Pro")
- [ ] **Click Sign in:** card flips to "Waiting for browser sign-in…",
      browser opens to Cursor OAuth URL, completing OAuth flips the
      card to "Authenticated" with email shown
- [ ] **Cancel:** clicking Cancel during the wait state stops the
      spinner; `pgrep cursor-agent` shows no orphan child
- [ ] **Already signed in:** card shows green dot + email; **no**
      "Requires Cursor Pro" nag for users who have Pro
- [ ] **Driver error path:** starting a Cursor session while signed
      out surfaces the new "Cursor is not signed in. Click 'Sign in'…"
      message in the session event stream
- [ ] **Unknown state:** if `cursor-agent status` hangs >4s the card
      falls back to a gray "unknown" state instead of claiming either
      direction