### PR TITLE
feat(desktop): updater controls in app menu + stall recovery

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,7 +35,12 @@ import {
   type MenuAccelerators,
   type MenuCommand,
 } from "./menu.ts";
-import { registerUpdaterDemo, startAutoUpdater } from "./updater.ts";
+import {
+  getLastStatus,
+  onStatusChange,
+  registerUpdaterDemo,
+  startAutoUpdater,
+} from "./updater.ts";
 
 /**
  * Privileged scheme registration. Must run before `app.whenReady()` —
@@ -302,13 +307,43 @@ const sanitizeAccelerators = (raw: unknown): MenuAccelerators => {
 // the menu with these accelerators." Renderer owns the defaults + override
 // resolution since its keybindings store is the live mirror of the JSON
 // config file.
+// Latest values for the two independent inputs that drive the menu shape.
+// `menu:setAccelerators` and the auto-updater status listener both rebuild
+// the menu, but each only knows about its own input — without remembering
+// the other, a status flip would blow away custom keybindings (and vice
+// versa).
+let lastAccelerators: MenuAccelerators = DEFAULT_MENU_ACCELERATORS;
+
 ipcMain.on("menu:setAccelerators", (_event, payload: unknown) => {
-  installAppMenu(() => mainWindow, sanitizeAccelerators(payload));
+  lastAccelerators = sanitizeAccelerators(payload);
+  installAppMenu(() => mainWindow, lastAccelerators, getLastStatus());
 });
 
 void app.whenReady().then(() => {
   registerMemoizeProtocol();
-  installAppMenu(() => mainWindow);
+
+  // Populate the native About panel so "About memoize" shows the current
+  // version + copyright. Without this, Electron's default panel only shows
+  // the app name. macOS reads these once at panel-open time, so it's safe
+  // to call once on startup.
+  app.setAboutPanelOptions({
+    applicationName: "memoize",
+    applicationVersion: app.getVersion(),
+    version: app.getVersion(),
+    copyright: "© Swaraj Bachu",
+    website: "https://github.com/swarajbachu/memoize",
+  });
+
+  // Rebuild the menu whenever the updater status changes so the
+  // "Check for Updates…" item label/enabled state stays live — this is the
+  // user's fallback path when the in-app toast is dismissed or a download
+  // stalls mid-way. The subscription is set up once; the listener runs on
+  // every status flip.
+  onStatusChange((status) => {
+    installAppMenu(() => mainWindow, lastAccelerators, status);
+  });
+
+  installAppMenu(() => mainWindow, lastAccelerators, getLastStatus());
   createMainWindow();
   if (mainWindow !== null) {
     if (isDevelopment) {

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -6,6 +6,14 @@ import {
   type MenuItemConstructorOptions,
 } from "electron";
 
+import type { UpdateStatus } from "@memoize/wire";
+
+import {
+  triggerUpdateCheck,
+  triggerUpdateDownload,
+  triggerUpdateInstall,
+} from "./updater.ts";
+
 /**
  * Action ids that travel from a menu click → renderer (via
  * `webContents.send("menu:action", ...)`) → the keybinding-dispatcher
@@ -48,6 +56,55 @@ export const DEFAULT_MENU_ACCELERATORS: MenuAccelerators = {
   "focus-composer": "CmdOrCtrl+L",
 };
 
+const GITHUB_REPO_URL = "https://github.com/swarajbachu/memoize";
+const GITHUB_RELEASES_URL = `${GITHUB_REPO_URL}/releases`;
+const GITHUB_ISSUE_NEW_URL = `${GITHUB_REPO_URL}/issues/new`;
+
+/**
+ * Shape of the "Check for Updates…" menu entry, derived from the current
+ * updater status. Label + enabled + click target all flip together so the
+ * menu is a complete fallback path even when the in-app toast is missing.
+ */
+function buildUpdateMenuItem(
+  status: UpdateStatus,
+): MenuItemConstructorOptions {
+  switch (status.kind) {
+    case "checking":
+      return { label: "Checking for Updates…", enabled: false };
+    case "available":
+      return {
+        label: `Download Update (v${status.version})…`,
+        click: () => triggerUpdateDownload(),
+      };
+    case "downloading":
+      return {
+        label: `Downloading Update… ${Math.round(status.percent)}%`,
+        enabled: false,
+      };
+    case "ready":
+      return {
+        label: `Install Update & Restart (v${status.version})`,
+        click: () => triggerUpdateInstall(),
+      };
+    case "error":
+      return {
+        label: "Retry Update Check",
+        click: () => triggerUpdateCheck(),
+      };
+    case "not-available":
+      return {
+        label: "Check for Updates… (Up to date)",
+        click: () => triggerUpdateCheck(),
+      };
+    case "idle":
+    default:
+      return {
+        label: "Check for Updates…",
+        click: () => triggerUpdateCheck(),
+      };
+  }
+}
+
 /**
  * Build + install the native Application Menu. Safe to call multiple times
  * — Electron swaps the menu in place, which is how user keybinding edits
@@ -56,12 +113,19 @@ export const DEFAULT_MENU_ACCELERATORS: MenuAccelerators = {
  * `getWindow` is read on every click so menu items always target the
  * currently-active window even after a close/re-open cycle (macOS
  * dock-launch).
+ *
+ * Three independent inputs feed a rebuild:
+ *  - `accelerators` flips when the user edits keybindings,
+ *  - `updateStatus` flips on every electron-updater state change, and
+ *  - the macOS/Windows fork stays the same per-platform.
  */
 export function installAppMenu(
   getWindow: () => BrowserWindow | null,
   accelerators: MenuAccelerators = DEFAULT_MENU_ACCELERATORS,
+  updateStatus: UpdateStatus = { kind: "idle" },
 ): void {
   const isMac = process.platform === "darwin";
+  const isDev = !app.isPackaged;
 
   const sendAction =
     (action: Exclude<MenuCommand, "close-tab">) =>
@@ -80,6 +144,8 @@ export function installAppMenu(
   /** undefined when unbound, so Electron drops the accelerator entirely. */
   const accelOrUndefined = (cmd: MenuCommand): string | undefined =>
     accelerators[cmd] ?? undefined;
+
+  const updateItem = buildUpdateMenuItem(updateStatus);
 
   const fileMenu: MenuItemConstructorOptions = {
     label: "File",
@@ -130,7 +196,6 @@ export function installAppMenu(
       ...(isMac
         ? ([
             { role: "pasteAndMatchStyle" },
-            { role: "delete" },
             { role: "selectAll" },
           ] satisfies MenuItemConstructorOptions[])
         : ([
@@ -159,17 +224,27 @@ export function installAppMenu(
         accelerator: accelOrUndefined("toggle-terminal"),
         click: sendAction("toggle-terminal"),
       },
+      { type: "separator" },
       {
         label: "Focus Composer",
         accelerator: accelOrUndefined("focus-composer"),
         click: sendAction("focus-composer"),
       },
       { type: "separator" },
-      { role: "reload" },
-      { role: "forceReload" },
-      { role: "toggleDevTools" },
-      { type: "separator" },
       { role: "togglefullscreen" },
+      ...(isDev
+        ? ([
+            { type: "separator" },
+            {
+              label: "Developer",
+              submenu: [
+                { role: "reload" },
+                { role: "forceReload" },
+                { role: "toggleDevTools" },
+              ],
+            },
+          ] satisfies MenuItemConstructorOptions[])
+        : []),
     ],
   };
 
@@ -193,9 +268,22 @@ export function installAppMenu(
     role: "help",
     submenu: [
       {
+        label: "View Changelog",
+        click: () => {
+          void shell.openExternal(GITHUB_RELEASES_URL);
+        },
+      },
+      {
+        label: "Report an Issue",
+        click: () => {
+          void shell.openExternal(GITHUB_ISSUE_NEW_URL);
+        },
+      },
+      { type: "separator" },
+      {
         label: "memoize on GitHub",
         click: () => {
-          void shell.openExternal("https://github.com/forkzero/memoize");
+          void shell.openExternal(GITHUB_REPO_URL);
         },
       },
     ],
@@ -208,6 +296,7 @@ export function installAppMenu(
             label: app.name,
             submenu: [
               { role: "about" },
+              updateItem,
               { type: "separator" },
               {
                 label: "Settings…",
@@ -230,7 +319,21 @@ export function installAppMenu(
     editMenu,
     viewMenu,
     windowMenu,
-    helpMenu,
+    // On Windows/Linux the macOS app menu doesn't exist, so surface the
+    // update item at the top of Help instead. (Help is the conventional
+    // fallback location for "Check for Updates" on those platforms.)
+    ...(isMac
+      ? [helpMenu]
+      : ([
+          {
+            ...helpMenu,
+            submenu: [
+              updateItem,
+              { type: "separator" },
+              ...(helpMenu.submenu as MenuItemConstructorOptions[]),
+            ],
+          } satisfies MenuItemConstructorOptions,
+        ] satisfies MenuItemConstructorOptions[])),
   ];
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -21,18 +21,102 @@ import {
 // pushed mid-week without requiring a manual restart-to-check.
 const UPDATE_POLL_MS = 6 * 60 * 60 * 1000;
 
+// If no `download-progress` event fires for this long while in the
+// `downloading` state, treat the download as stalled. electron-updater itself
+// doesn't fire any "stuck" event — the underlying request just hangs — so
+// the toast and menu would otherwise sit forever showing the last percent.
+const DOWNLOAD_STALL_MS = 60_000;
+
 let lastStatus: UpdateStatus = { kind: "idle" };
 let started = false;
 
-export function startAutoUpdater(window: BrowserWindow): void {
+const statusListeners = new Set<(status: UpdateStatus) => void>();
+
+let stallTimer: NodeJS.Timeout | null = null;
+// We auto-retry the *first* stall in a session to absorb transient network
+// flakes (laptop lid, hotel wifi), then surface the error so we don't loop
+// forever on a permanent failure.
+let stallRetried = false;
+
+function clearStallTimer(): void {
+  if (stallTimer !== null) {
+    clearTimeout(stallTimer);
+    stallTimer = null;
+  }
+}
+
+function armStallTimer(): void {
+  clearStallTimer();
+  stallTimer = setTimeout(() => {
+    stallTimer = null;
+    if (lastStatus.kind !== "downloading") return;
+    if (!stallRetried) {
+      stallRetried = true;
+      console.warn("[memoize:updater] download stalled — retrying once");
+      autoUpdater.downloadUpdate().catch((err) => {
+        console.error("[memoize:updater] stall retry failed", err);
+        emit({
+          kind: "error",
+          message: "Download stalled. Check your connection and try again.",
+          retryable: true,
+        });
+      });
+      return;
+    }
+    emit({
+      kind: "error",
+      message: "Download stalled. Check your connection and try again.",
+      retryable: true,
+    });
+  }, DOWNLOAD_STALL_MS);
+}
+
+function emit(status: UpdateStatus): void {
+  lastStatus = status;
+  for (const listener of statusListeners) {
+    try {
+      listener(status);
+    } catch (err) {
+      console.error("[memoize:updater] listener threw", err);
+    }
+  }
+}
+
+/**
+ * Snapshot of the latest update status. Menu rebuilds read this; everyone
+ * else should subscribe via `onStatusChange` instead of polling.
+ */
+export function getLastStatus(): UpdateStatus {
+  return lastStatus;
+}
+
+/**
+ * Subscribe to status transitions. Returns an unsubscribe function. The
+ * native menu uses this to rebuild itself so the "Check for Updates…" item
+ * label tracks the live state even when the renderer toast is dismissed.
+ */
+export function onStatusChange(
+  listener: (status: UpdateStatus) => void,
+): () => void {
+  statusListeners.add(listener);
+  return () => {
+    statusListeners.delete(listener);
+  };
+}
+
+function attachRenderer(window: BrowserWindow): void {
   // Always re-broadcast the most recent status to a (re)attached window so a
   // dev hot-reload or future window-recreate doesn't lose state.
-  const send = (status: UpdateStatus) => {
-    lastStatus = status;
+  const sendToRenderer = (status: UpdateStatus) => {
     if (window.isDestroyed()) return;
     window.webContents.send(UPDATE_STATUS_CHANNEL, status);
   };
-  window.webContents.on("did-finish-load", () => send(lastStatus));
+  statusListeners.add(sendToRenderer);
+  window.webContents.on("did-finish-load", () => sendToRenderer(lastStatus));
+}
+
+export function startAutoUpdater(window: BrowserWindow): void {
+  attachRenderer(window);
 
   if (started) return;
   started = true;
@@ -50,30 +134,40 @@ export function startAutoUpdater(window: BrowserWindow): void {
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = true;
 
-  autoUpdater.on("checking-for-update", () => send({ kind: "checking" }));
-  autoUpdater.on("update-available", (info: UpdateInfo) =>
-    send({
+  autoUpdater.on("checking-for-update", () => {
+    clearStallTimer();
+    emit({ kind: "checking" });
+  });
+  autoUpdater.on("update-available", (info: UpdateInfo) => {
+    clearStallTimer();
+    emit({
       kind: "available",
       version: info.version,
       releaseNotes:
         typeof info.releaseNotes === "string" ? info.releaseNotes : undefined,
       releaseDate: info.releaseDate,
-    }),
-  );
-  autoUpdater.on("update-not-available", () => send({ kind: "not-available" }));
-  autoUpdater.on("download-progress", (p: ProgressInfo) =>
-    send({
+    });
+  });
+  autoUpdater.on("update-not-available", () => {
+    clearStallTimer();
+    emit({ kind: "not-available" });
+  });
+  autoUpdater.on("download-progress", (p: ProgressInfo) => {
+    armStallTimer();
+    emit({
       kind: "downloading",
       percent: p.percent,
       bytesPerSecond: p.bytesPerSecond,
-    }),
-  );
-  autoUpdater.on("update-downloaded", (info: UpdateInfo) =>
-    send({ kind: "ready", version: info.version }),
-  );
-  autoUpdater.on("error", (err: Error) =>
-    send({ kind: "error", message: err.message }),
-  );
+    });
+  });
+  autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
+    clearStallTimer();
+    emit({ kind: "ready", version: info.version });
+  });
+  autoUpdater.on("error", (err: Error) => {
+    clearStallTimer();
+    emit({ kind: "error", message: err.message, retryable: true });
+  });
 
   ipcMain.handle(UPDATE_CHECK_CHANNEL, async () => {
     await autoUpdater.checkForUpdates().catch((err) => {
@@ -101,6 +195,29 @@ export function startAutoUpdater(window: BrowserWindow): void {
 }
 
 /**
+ * Imperative entrypoints for the native menu. These bypass the renderer-bound
+ * IPC bridge (`window.memoize.updates.*`) because menu clicks run in main —
+ * routing through IPC would just bounce back to the same `autoUpdater` calls.
+ */
+export function triggerUpdateCheck(): void {
+  autoUpdater.checkForUpdates().catch((err) => {
+    console.error("[memoize:updater] check failed", err);
+  });
+}
+
+export function triggerUpdateDownload(): void {
+  // Reset the stall retry budget so a manual retry gets a fresh chance.
+  stallRetried = false;
+  autoUpdater.downloadUpdate().catch((err) => {
+    console.error("[memoize:updater] download failed", err);
+  });
+}
+
+export function triggerUpdateInstall(): void {
+  autoUpdater.quitAndInstall();
+}
+
+/**
  * Dev-only IPC bridge for previewing the update banner without cutting a real
  * release. `window.__memoizeUpdateDemo.set(status)` in the renderer round-trips
  * through `memoize:update-demo-set`, which re-broadcasts on the same channel
@@ -109,12 +226,15 @@ export function startAutoUpdater(window: BrowserWindow): void {
  * Call from `main.ts` only when `isDevelopment`. No-op in packaged builds.
  */
 export function registerUpdaterDemo(window: BrowserWindow): void {
+  // Plumb the renderer so demo-pushed statuses reach the banner.
+  attachRenderer(window);
   ipcMain.handle(
     "memoize:update-demo-set",
     (_event, status: UpdateStatus) => {
       if (window.isDestroyed()) return;
-      lastStatus = status;
-      window.webContents.send(UPDATE_STATUS_CHANNEL, status);
+      // Push through `emit` so the menu listener and any other subscribers
+      // see demo events the same way they'd see real ones.
+      emit(status);
     },
   );
 }

--- a/apps/renderer/src/components/update-banner.tsx
+++ b/apps/renderer/src/components/update-banner.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpCircle, CheckCircle2, X } from "lucide-react";
+import { AlertTriangle, ArrowUpCircle, CheckCircle2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -41,8 +41,10 @@ export function UpdateBanner() {
   }, []);
 
   // Re-surface a fresh "available" even if the user dismissed the previous one.
+  // Also re-show on `error` so a silent stall or failed download isn't
+  // invisible — the user needs to see it to retry.
   useEffect(() => {
-    if (status.kind === "available") {
+    if (status.kind === "available" || status.kind === "error") {
       installModeRef.current = null;
       setDismissed(false);
     }
@@ -59,8 +61,7 @@ export function UpdateBanner() {
     dismissed ||
     status.kind === "idle" ||
     status.kind === "checking" ||
-    status.kind === "not-available" ||
-    status.kind === "error"
+    status.kind === "not-available"
   ) {
     return null;
   }
@@ -85,6 +86,10 @@ export function UpdateBanner() {
   const onRestartNow = () => {
     void window.memoize?.updates?.installNow();
   };
+  const onRetry = () => {
+    installModeRef.current = null;
+    void window.memoize?.updates?.check();
+  };
 
   // Portal to document.body so the toast escapes any ancestor that creates a
   // containing block — `<main>` uses `backdrop-blur-3xl`, and any
@@ -100,6 +105,8 @@ export function UpdateBanner() {
         <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
           {status.kind === "ready" ? (
             <CheckCircle2 className="size-4" />
+          ) : status.kind === "error" ? (
+            <AlertTriangle className="size-4" />
           ) : (
             <ArrowUpCircle className="size-4" />
           )}
@@ -109,6 +116,7 @@ export function UpdateBanner() {
             {status.kind === "available" && "Update available"}
             {status.kind === "downloading" && "Downloading update…"}
             {status.kind === "ready" && "Update ready"}
+            {status.kind === "error" && "Update failed"}
           </span>
           <span className="text-[12px] leading-snug text-muted-foreground">
             {status.kind === "available" &&
@@ -121,6 +129,7 @@ export function UpdateBanner() {
               }`}
             {status.kind === "ready" &&
               `Restart to finish installing memoize ${status.version}.`}
+            {status.kind === "error" && status.message}
           </span>
         </div>
         <button
@@ -186,6 +195,28 @@ export function UpdateBanner() {
           >
             Restart now
           </Button>
+        </div>
+      )}
+
+      {status.kind === "error" && (
+        <div className="flex items-center justify-end gap-1.5">
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={onLater}
+            className="rounded-full text-[11px]"
+          >
+            Dismiss
+          </Button>
+          {status.retryable !== false && (
+            <Button
+              size="xs"
+              onClick={onRetry}
+              className="rounded-full text-[11px]"
+            >
+              Try again
+            </Button>
+          )}
         </div>
       )}
     </div>,

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/packages/wire/src/update.ts
+++ b/packages/wire/src/update.ts
@@ -27,4 +27,11 @@ export type UpdateStatus =
       readonly bytesPerSecond: number;
     }
   | { readonly kind: "ready"; readonly version: string }
-  | { readonly kind: "error"; readonly message: string };
+  | {
+      readonly kind: "error";
+      readonly message: string;
+      // Stalls + transient network errors are retryable; signature/integrity
+      // failures are not. Absent means retryable — banner and menu treat
+      // `undefined` as "show Try Again". Set explicit `false` to suppress.
+      readonly retryable?: boolean;
+    };


### PR DESCRIPTION
## Summary

- Native app menu now exposes the auto-updater with a live "Check for Updates…" item that flips through all 7 states (`idle` / `checking` / `available (vX)` / `downloading X%` / `ready` / `error → Retry` / `not-available`). This is the user's fallback path when the in-app toast is dismissed or never appears.
- 60s download-stall watchdog (`apps/desktop/src/updater.ts`) with one-shot auto-retry — electron-updater fires no "stuck" event, so a hung download otherwise sits forever. Surfaces a retryable `error` state if the retry also stalls.
- Banner now renders the `error` state with a "Try again" button and un-dismisses on error, so a failed download isn't silent.
- About panel populated with version + copyright (`app.setAboutPanelOptions`) — previously the default Electron panel only showed the app name.
- Help menu: added "View Changelog" + "Report an Issue"; fixed the broken `github.com/forkzero/memoize` link to `swarajbachu/memoize`.
- `Force Reload` + `Toggle DevTools` moved into a `Developer ▸` submenu under View, visible only when `!app.isPackaged`.

## Why

User on v0.1.1 had v0.2.0 published but no popup, no menu surface, and no way to verify the updater was running. The in-app toast is the only entry point today; if it's dismissed or a download stalls, the user is stuck until next launch.

`packages/wire/src/update.ts` gets a new `retryable?: boolean` on the `error` variant so the banner can decide whether to show "Try again" (transient/network errors yes, signature/integrity errors no).

## Test plan

- [ ] `bun run check-types` passes
- [ ] `bun run dev:desktop` — verify About memoize shows version, Help → memoize on GitHub goes to `swarajbachu/memoize`, View has `Developer ▸` submenu in dev
- [ ] In renderer devtools: `window.__memoizeUpdateDemo.set({ kind: "available", version: "9.9.9" })` — menu item flips to `Download Update (v9.9.9)…`. Cycle through `downloading` / `ready` / `error` payloads and confirm each label
- [ ] Push `{ kind: "downloading", percent: 10, bytesPerSecond: 0 }` — 60s later watchdog fires `error` + retry, banner shows with "Try again", menu shows `Retry Update Check`
- [ ] Packaged build (`bun run dist:mac`): Developer submenu hidden, About panel shows version, "Check for Updates…" actually contacts GitHub
- [ ] End-to-end: install v0.1.4 DMG, launch, wait for poll → banner pops for 0.2.0 AND menu shows `Download Update (v0.2.0)…`. Dismiss banner, install via menu instead