### PR TITLE
fix(providers): codex spawn crash, missing cursor, claude/opencode gating

### DIFF
--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -173,7 +173,6 @@ export function ModelPicker(props: ModelPickerProps) {
     return (Object.keys(MODELS_BY_PROVIDER) as ReadonlyArray<ProviderId>).filter(
       (pid) => {
         if (pid === providerId) return true;
-        if (pid === "cursor") return false;
         if (providerEnabled[pid] === false) return false;
         const a = availabilityById.get(pid);
         return a?.status !== "error";

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -69,6 +69,10 @@ const SUBSCRIPTION_INFO: Partial<
 > = {
   grok: { plan: "SuperGrok Heavy", url: "https://grok.com/#subscribe" },
   cursor: { plan: "Cursor Pro", url: "https://cursor.com/pricing" },
+  claude: {
+    plan: "Claude Pro",
+    url: "https://www.anthropic.com/pricing#claude-code",
+  },
 };
 
 export function ProviderCard({

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -308,7 +308,11 @@ const probeCodexAccount = (codexPath: string): Effect.Effect<AccountInfo> =>
 const CLAUDE_SUB_LABEL: Record<string, string> = {
   max: "Claude Max Subscription",
   pro: "Claude Pro Subscription",
-  free: "Free",
+  // Claude Code agent usage requires a paid plan. Free / unknown tiers
+  // surface as "Requires …" so the renderer's existing subscription-gate
+  // rail (matches authLabel.includes("require")) disables the toggle and
+  // shows the Subscribe CTA, same as Grok/Cursor.
+  free: "Requires Claude Pro",
 };
 
 interface ClaudeCredentialBlob {
@@ -330,14 +334,16 @@ const parseClaudeCredentials = (raw: string): AccountInfo => {
   if (!oauth) return { authStatus: "authenticated" };
   const sub = oauth.subscriptionType?.toLowerCase();
   const email = oauth.emailAddress ?? oauth.email;
+  // Missing or unrecognised subscription tier → treat as needing Claude Pro,
+  // matching the explicit `free` branch in CLAUDE_SUB_LABEL.
+  const authLabel =
+    sub && CLAUDE_SUB_LABEL[sub]
+      ? CLAUDE_SUB_LABEL[sub]
+      : "Requires Claude Pro";
   return {
     authStatus: "authenticated",
     authType: "oauth",
-    ...(sub && CLAUDE_SUB_LABEL[sub]
-      ? { authLabel: CLAUDE_SUB_LABEL[sub] }
-      : sub
-        ? { authLabel: `Claude ${sub[0]!.toUpperCase()}${sub.slice(1)}` }
-        : {}),
+    authLabel,
     ...(email ? { authEmail: email } : {}),
   };
 };

--- a/apps/server/src/provider/codex-app-server-client.ts
+++ b/apps/server/src/provider/codex-app-server-client.ts
@@ -88,6 +88,16 @@ export class CodexAppServerClient {
       const text = String(chunk).trim();
       if (text.length > 0) console.warn(`[codex-app-server] ${text}`);
     });
+    // Without this listener, a spawn-time failure (ENOENT when codex isn't on
+    // PATH, EACCES on a non-executable file) becomes an uncaught exception
+    // that crashes the whole process. Surface it as a rejection of every
+    // pending request — including the `initialize` we're about to await —
+    // so callers see a normal Effect failure they already know how to catch.
+    child.once("error", (err) => {
+      bootstrap.closed = true;
+      for (const p of bootstrap.pending.values()) p.reject(err as Error);
+      bootstrap.pending.clear();
+    });
     child.once("exit", (code, signal) => {
       bootstrap.closed = true;
       const reason = new Error(

--- a/apps/server/src/provider/drivers/opencode.ts
+++ b/apps/server/src/provider/drivers/opencode.ts
@@ -1143,6 +1143,10 @@ interface InventoryProviderModel {
   // protocol does carry it on each model — `Object.keys` of this map gives
   // the variant names (e.g. `["high", "medium", "low"]`).
   readonly variants?: Record<string, unknown>;
+  readonly status?: "alpha" | "beta" | "deprecated" | "active";
+  readonly capabilities?: {
+    readonly toolcall?: boolean;
+  };
 }
 
 interface InventoryProvider {
@@ -1150,6 +1154,17 @@ interface InventoryProvider {
   readonly name: string;
   readonly models: { readonly [key: string]: InventoryProviderModel };
 }
+
+// OpenCode reports every model its provider definitions know about — alpha,
+// beta, deprecated, audio-only, etc. For agentic chat we need active models
+// that support tool calls; everything else just clutters the picker (and
+// would fail mid-session). Mirrors what the SDK type declares on `Model`
+// (status + capabilities.toolcall).
+const isUsableInventoryModel = (m: InventoryProviderModel): boolean => {
+  if (m.status !== undefined && m.status !== "active") return false;
+  if (m.capabilities?.toolcall === false) return false;
+  return true;
+};
 
 const collectInventoryProviders = (
   all: ReadonlyArray<InventoryProvider>,
@@ -1162,6 +1177,7 @@ const collectInventoryProviders = (
       id: p.id,
       name: p.name,
       models: Object.values(p.models)
+        .filter(isUsableInventoryModel)
         .map((m) => ({
           id: `${p.id}/${m.id}`,
           label: m.name,
@@ -1169,6 +1185,7 @@ const collectInventoryProviders = (
         }))
         .sort((a, b) => a.label.localeCompare(b.label)),
     }))
+    .filter((p) => p.models.length > 0)
     .sort((a, b) => a.name.localeCompare(b.name));
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

- `CodexAppServerClient.start` now attaches a child `error` listener so spawn ENOENT (codex not on PATH) and EACCES rejections flow through `Effect.tryPromise.catch` instead of becoming uncaught exceptions that crash the app.
- Removed the hard-coded `cursor` exclusion in the model picker; the standard enable + availability gates handle it.
- Claude free-tier and unknown subscription tiers now report `"Requires Claude Pro"`, reusing the existing Grok/Cursor subscription-gate rail to disable the toggle and show a Subscribe CTA.
- OpenCode inventory filters out non-active (alpha/beta/deprecated) and non-toolcall models and drops providers that end up empty.

## Test plan
- [ ] Without \`codex\` on PATH, app launches and a Claude session opens with no uncaught exception in main-process logs.
- [ ] Cursor appears as a provider group in the model picker.
- [ ] Claude card with a free-tier oauth credential shows the violet \"Requires Claude Pro\" notice and disabled toggle; Pro/Max accounts still work.
- [ ] OpenCode model picker no longer lists deprecated / alpha / non-toolcall models after \`opencode auth login\`.