### PR TITLE
fix(config-store): serialize settings.json writes to kill rename ENOENT

### DIFF
--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -101,8 +101,9 @@ export function ModelPicker(props: ModelPickerProps) {
   const setSessionModel = useSessionsStore((s) => s.setModel);
   const setSessionProvider = useSessionsStore((s) => s.setProvider);
   const createSession = useSessionsStore((s) => s.create);
-  const setDefaultProvider = useSettingsStore((s) => s.setDefaultProvider);
-  const setDefaultModel = useSettingsStore((s) => s.setDefaultModel);
+  const setDefaultProviderAndModel = useSettingsStore(
+    (s) => s.setDefaultProviderAndModel,
+  );
 
   const availability = useProvidersStore((s) => s.availability);
   const opencodeInventory = useOpencodeInventory((s) => s.inventory);
@@ -243,8 +244,7 @@ export function ModelPicker(props: ModelPickerProps) {
 
   const handlePick = (pid: ProviderId, modelId: string) => {
     if (isDefault) {
-      setDefaultProvider(pid);
-      setDefaultModel(pid, modelId);
+      setDefaultProviderAndModel(pid, modelId);
       pushModelPickerEvent({ providerId: pid, modelId });
       setOpen(false);
       return;

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -100,6 +100,15 @@ type SettingsState = SettingsSlice & {
   readonly hydrate: () => Promise<void>;
   readonly setDefaultProvider: (providerId: ProviderId) => void;
   readonly setDefaultModel: (providerId: ProviderId, model: string) => void;
+  /**
+   * Set both the default provider and that provider's default model in one
+   * patch. The model picker treats picking a model as a single user action;
+   * sending two separate RPCs raced on the server's atomic-write tmp file.
+   */
+  readonly setDefaultProviderAndModel: (
+    providerId: ProviderId,
+    model: string,
+  ) => void;
   readonly setDefaultRuntimeMode: (mode: RuntimeMode) => void;
   readonly setDefaultAutoCreateWorktree: (value: boolean) => void;
   readonly setOnboardingCompleted: (value: boolean) => void;
@@ -187,6 +196,21 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const client = await getRpcClient();
       await Effect.runPromise(
         client.settings.update({ patch: { defaultModelByProvider: next } }),
+      );
+    })();
+  },
+  setDefaultProviderAndModel: (providerId, model) => {
+    const next = { ...get().defaultModelByProvider, [providerId]: model };
+    set({ defaultProviderId: providerId, defaultModelByProvider: next });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({
+          patch: {
+            defaultProviderId: providerId,
+            defaultModelByProvider: next,
+          },
+        }),
       );
     })();
   },

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -1,4 +1,5 @@
 import * as fsSync from "node:fs";
+import { randomBytes } from "node:crypto";
 
 import { FileSystem, Path } from "@effect/platform";
 import { Effect, Layer, PubSub, Ref, Stream } from "effect";
@@ -233,18 +234,42 @@ export const ConfigStoreServiceLive = Layer.scoped(
         }
       });
 
+    // One semaphore per path. Concurrent writes to the same file (e.g. the
+    // model-picker firing `defaultProviderId` and `defaultModelByProvider`
+    // back-to-back; or migrateLocalStorage racing the first updateSettings)
+    // would otherwise both pick the same `<path>.tmp` and the second
+    // rename ENOENTs because the first already renamed the tmp away.
+    const writeLocks = new Map<string, Effect.Semaphore>();
+    const lockFor = (
+      absPath: string,
+    ): Effect.Effect<Effect.Semaphore> =>
+      Effect.gen(function* () {
+        const existing = writeLocks.get(absPath);
+        if (existing) return existing;
+        const sem = yield* Effect.makeSemaphore(1);
+        writeLocks.set(absPath, sem);
+        return sem;
+      });
+
     /**
-     * Atomic write — write the contents to `<absPath>.tmp` and rename over
-     * the target so a crash during write never leaves a partial file.
+     * Atomic write — write the contents to a unique `<absPath>.<rand>.tmp`
+     * and rename over the target so a crash during write never leaves a
+     * partial file. Serialised per-path so concurrent callers don't race
+     * on the tmp filename.
      */
     const writeAtomically = (
       absPath: string,
       contents: string,
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
-        const tmp = `${absPath}.tmp`;
-        yield* fs.writeFileString(tmp, contents).pipe(Effect.orDie);
-        yield* fs.rename(tmp, absPath).pipe(Effect.orDie);
+        const sem = yield* lockFor(absPath);
+        yield* sem.withPermits(1)(
+          Effect.gen(function* () {
+            const tmp = `${absPath}.${randomBytes(6).toString("hex")}.tmp`;
+            yield* fs.writeFileString(tmp, contents).pipe(Effect.orDie);
+            yield* fs.rename(tmp, absPath).pipe(Effect.orDie);
+          }),
+        );
       });
 
     const initialSettingsRaw = yield* readJsonOrNull(settingsPath);


### PR DESCRIPTION
## Summary

- Server: every concurrent call to `writeAtomically` against the same path picked `<path>.tmp` and raced on rename — the second one ENOENT'd. Serialised via a per-path `Effect.makeSemaphore(1)` and switched to a unique `<path>.<rand>.tmp` per call so concurrent writes never collide on the tmp filename either.
- Renderer: model-picker fired `setDefaultProvider` + `setDefaultModel` as two separate fire-and-forget RPCs, which is what surfaced the race in normal use. Collapsed into one `setDefaultProviderAndModel` that sends a single combined patch — one user action, one RPC.

## Repro before this PR

1. Open model picker on the default chip
2. Click any model that switches provider
3. Observe the ENOENT in DevTools:
   ```
   SystemError: NotFound: FileSystem.rename (.../settings.json.tmp): ENOENT
   ```

## Test plan

- [x] `bun run check-types` — all 8 packages clean
- [ ] Restart desktop, change default model several times in quick succession, verify no console errors
- [ ] Verify `settings.json` actually reflects each pick (read `.../memoize (Dev)/settings.json` between picks)
- [ ] Onboarding flow (which triggers migrateLocalStorage + first updateSettings near-simultaneously) completes without ENOENT