### PR TITLE
fix(cursor): ACP fail-fast, OAuth auth, fresh models, surfaced errors

### DIFF
--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, FolderClosed, FolderPlus, Send } from "lucide-react";
+import { Check, ChevronDown, FolderClosed, FolderPlus, Send, X } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
 import type { FolderId } from "@memoize/wire";
@@ -64,6 +64,7 @@ export function ChatLanding() {
   );
 
   const [text, setText] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const selectedFolder = useMemo(
@@ -88,15 +89,23 @@ export function ChatLanding() {
   const canSend =
     text.trim().length > 0 && selectedFolderId !== null && !creating;
 
-  const submit = (): void => {
+  const submit = async (): Promise<void> => {
     if (!canSend || selectedFolderId === null) return;
     const trimmed = text.trim();
     const model = defaultModelByProvider[defaultProviderId];
     setText("");
-    void create(selectedFolderId, defaultProviderId, model, {
+    setSubmitError(null);
+    const result = await create(selectedFolderId, defaultProviderId, model, {
       initialPrompt: trimmed,
       runtimeMode: defaultRuntimeMode,
     });
+    if (result === null) {
+      const reason =
+        useChatsStore.getState().error ??
+        `Couldn't start ${defaultProviderId}. Check that its CLI is installed and signed in.`;
+      setSubmitError(reason);
+      setText(trimmed);
+    }
   };
 
   const onSuggest = (prompt: string) => {
@@ -118,17 +127,35 @@ export function ChatLanding() {
           {headline}
         </h1>
 
+        {submitError !== null && (
+          <div className="flex items-start gap-2 rounded-lg border border-rose-400/30 bg-rose-500/[0.08] px-3 py-2 text-[12px] text-rose-200">
+            <span className="mt-px shrink-0">⚠</span>
+            <span className="flex-1 leading-snug">{submitError}</span>
+            <button
+              type="button"
+              onClick={() => setSubmitError(null)}
+              aria-label="Dismiss error"
+              className="-mr-1 shrink-0 rounded p-0.5 text-rose-200/80 hover:bg-rose-500/[0.12] hover:text-rose-100"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        )}
+
         <Frame>
           <Card className="rounded-xl border-border/50">
             <CardPanel className="relative flex flex-col gap-2 px-3 py-2">
               <textarea
                 ref={textareaRef}
                 value={text}
-                onChange={(e) => setText(e.target.value)}
+                onChange={(e) => {
+                  setText(e.target.value);
+                  if (submitError !== null) setSubmitError(null);
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();
-                    submit();
+                    void submit();
                   }
                 }}
                 placeholder={
@@ -146,7 +173,7 @@ export function ChatLanding() {
                       <Button
                         variant="default"
                         size="icon-sm"
-                        onClick={submit}
+                        onClick={() => void submit()}
                         disabled={!canSend}
                         aria-label="Send"
                       >

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -133,6 +133,13 @@ export function ModelPicker(props: ModelPickerProps) {
   const [expandedGroup, setExpandedGroup] = useState<ProviderId | null>(
     providerId,
   );
+  // Inline feedback for failed picks. The session-mode handlers
+  // (createSession / setSessionProvider / setSessionModel) used to fire-
+  // and-forget, so a failed switch (cursor-agent not installed, ACP
+  // handshake timeout, etc.) just closed the popover with no clue why.
+  // We now await them and surface the reason here.
+  const [pickError, setPickError] = useState<string | null>(null);
+  const [picking, setPicking] = useState(false);
   const popupRef = useRef<HTMLDivElement | null>(null);
 
   // Forward open state to parent so ChatComposer can block Enter submit
@@ -148,6 +155,8 @@ export function ModelPicker(props: ModelPickerProps) {
       setEvents(readModelPickerEvents());
       setScope("all");
       setExpandedGroup(providerId);
+      setPickError(null);
+      setPicking(false);
     }
   }, [open, providerId]);
 
@@ -241,7 +250,7 @@ export function ModelPicker(props: ModelPickerProps) {
       .filter((g) => g.models.length > 0);
   }, [scope, query, allModels, pickableProviders, providerId]);
 
-  const handlePick = (pid: ProviderId, modelId: string) => {
+  const handlePick = async (pid: ProviderId, modelId: string) => {
     if (isDefault) {
       setDefaultProvider(pid);
       setDefaultModel(pid, modelId);
@@ -255,15 +264,41 @@ export function ModelPicker(props: ModelPickerProps) {
     const runtimeMode = (props as any).runtimeMode as RuntimeMode | undefined;
 
     const isCross = pid !== providerId;
-    if (isCross && !isFresh && chatId !== undefined) {
-      void createSession(chatId, pid, modelId, { runtimeMode });
-    } else if (isCross) {
-      void setSessionProvider(sessionId, pid, modelId);
-    } else if (modelId !== currentModel) {
-      void setSessionModel(sessionId, modelId);
+    // Await whatever store call we kick off so we can keep the popover
+    // open + show the reason if it fails. Previously these were `void`-d
+    // and the popover always closed, swallowing SessionStartError from
+    // a missing/broken CLI behind a silent close.
+    setPickError(null);
+    setPicking(true);
+    try {
+      if (isCross && !isFresh && chatId !== undefined) {
+        const newId = await createSession(chatId, pid, modelId, { runtimeMode });
+        if (newId === null) {
+          const reason =
+            useSessionsStore.getState().error ??
+            `Couldn't start ${pid}. Check that its CLI is installed and signed in.`;
+          setPickError(reason);
+          return;
+        }
+      } else if (isCross) {
+        const result = await setSessionProvider(sessionId, pid, modelId);
+        if (!result.ok) {
+          setPickError(result.reason);
+          return;
+        }
+      } else if (modelId !== currentModel) {
+        await setSessionModel(sessionId, modelId);
+        const reason = useSessionsStore.getState().error;
+        if (reason !== null) {
+          setPickError(reason);
+          return;
+        }
+      }
+      pushModelPickerEvent({ providerId: pid, modelId });
+      setOpen(false);
+    } finally {
+      setPicking(false);
     }
-    pushModelPickerEvent({ providerId: pid, modelId });
-    setOpen(false);
   };
 
   const currentLabel =
@@ -325,7 +360,7 @@ export function ModelPicker(props: ModelPickerProps) {
       if (target === undefined) return;
       e.preventDefault();
       e.stopPropagation();
-      handlePickRef.current(target.providerId, target.modelId);
+      void handlePickRef.current(target.providerId, target.modelId);
     };
     document.addEventListener("keydown", onKeyDown, true);
     return () => document.removeEventListener("keydown", onKeyDown, true);
@@ -398,7 +433,19 @@ export function ModelPicker(props: ModelPickerProps) {
               </div>
             </div>
 
-            <div className="flex-1 overflow-y-auto px-2 pb-2">
+            {pickError !== null && (
+              <div className="mx-2.5 mb-1.5 flex items-start gap-2 rounded-md border border-rose-400/30 bg-rose-500/[0.08] px-2.5 py-2 text-[11px] text-rose-200">
+                <span className="mt-px shrink-0">⚠</span>
+                <span className="leading-snug">{pickError}</span>
+              </div>
+            )}
+
+            <div
+              className={cn(
+                "flex-1 overflow-y-auto px-2 pb-2",
+                picking && "pointer-events-none opacity-60",
+              )}
+            >
               {showEmpty && (
                 <div className="px-3 py-6 text-center text-muted-foreground text-xs">
                   No models match.

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -328,9 +328,19 @@ export const startCursorSession = (
       process.stderr.write(`[cursor.stderr] ${chunk}`);
     });
 
-    child.on("error", (err) => {
-      if (closed) return;
-      events.unsafeOffer({ _tag: "Error", message: err.message });
+    // Reject pending requests on spawn-time errors (ENOENT/EACCES) so the
+    // initialize handshake fails cleanly instead of waiting for a timeout
+    // that never resolves. Mirrors the codex client fix.
+    child.once("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      for (const { reject, timer } of pending.values()) {
+        clearTimeout(timer);
+        reject(new Error(message));
+      }
+      pending.clear();
+      if (!closed) {
+        events.unsafeOffer({ _tag: "Error", message });
+      }
     });
 
     child.on("close", (code, signal) => {
@@ -353,35 +363,54 @@ export const startCursorSession = (
     // === ACP handshake — synchronous, fails the start() RPC on error. ===
     const handshake = Effect.tryPromise({
       try: async () => {
-        const init = (await request("initialize", {
-          protocolVersion: 1,
-          clientCapabilities: {
-            fs: {
-              readTextFile: true,
-              writeTextFile: true,
-              readDirectory: true,
-              createDirectory: true,
-              deleteFile: true,
-              moveFile: true,
+        // Short timeout on the first request: a real ACP server replies in
+        // <100ms. When the binary is too old to support `acp`, cursor-agent
+        // silently treats it as a chat prompt and sits on stdin forever —
+        // a 30s wait there is just bad UX. Detect that within 5s and
+        // surface an actionable upgrade message instead.
+        let init: { authMethods?: ReadonlyArray<{ id?: unknown }> };
+        try {
+          init = (await request(
+            "initialize",
+            {
+              protocolVersion: 1,
+              clientCapabilities: {
+                fs: {
+                  readTextFile: true,
+                  writeTextFile: true,
+                  readDirectory: true,
+                  createDirectory: true,
+                  deleteFile: true,
+                  moveFile: true,
+                },
+                terminal: true,
+                _meta: { parameterizedModelPicker: true },
+              },
             },
-            terminal: true,
-          },
-        })) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
+            5_000,
+          )) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
+        } catch (cause) {
+          const reason = cause instanceof Error ? cause.message : String(cause);
+          if (/timed out/i.test(reason)) {
+            throw new Error(
+              "Cursor Agent is too old (no ACP support). Run `cursor-agent update` (need ≥ 2025.11) and try again.",
+            );
+          }
+          throw cause;
+        }
 
         const authIds = new Set(
           (init.authMethods ?? [])
             .map((m) => (typeof m?.id === "string" ? m.id : null))
             .filter((id): id is string => id !== null),
         );
-        // Cursor advertises `cursor_login` for OAuth-style credentials and
-        // `cached_token` once a prior `cursor-agent login` has stored one.
-        // When an API key is set we prefer `cursor_login` (the CLI handles
-        // the key/token translation server-side); otherwise use the cached
-        // token. We don't fall back to `cursor_login` without an API key —
-        // that silently sends the user into an OAuth dance the ACP child
-        // can't complete, masking "not signed in" behind a vague error.
+        // Cursor advertises `cursor_login` for stored credentials (OAuth
+        // or API key — the CLI loads whichever is set). `cached_token`
+        // appears on older builds. Prefer `cursor_login` whenever it's
+        // offered; the API key (if any) is forwarded via the
+        // CURSOR_API_KEY env above so the CLI side picks it up.
         const methodId =
-          apiKey !== null && authIds.has("cursor_login")
+          authIds.has("cursor_login")
             ? "cursor_login"
             : authIds.has("cached_token")
               ? "cached_token"
@@ -433,6 +462,28 @@ export const startCursorSession = (
       );
     }
 
+    // Apply the requested model via ACP `session/set_config_option`. This is
+    // the only path cursor-agent honors for model selection; the old
+    // `_meta.model` slot in `session/prompt` was a no-op. Fire-and-forget:
+    // when the server doesn't recognise the slug it logs but the session
+    // still works on the default model.
+    if (input.model !== undefined && input.model.length > 0) {
+      void request(
+        "session/set_config_option",
+        {
+          sessionId: acpSessionId,
+          configId: "model",
+          value: input.model,
+        },
+        5_000,
+      ).catch((err) => {
+        const reason = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[cursor] set_config_option model=${input.model} failed: ${reason}\n`,
+        );
+      });
+    }
+
     // If the session was created in plan mode, inform the ACP server via
     // native `session/setMode`. Cursor exposes plan/architect modes
     // natively, so this is real plan mode — not the dev-instructions
@@ -458,10 +509,7 @@ export const startCursorSession = (
               {
                 sessionId: sid,
                 prompt: [{ type: "text", text }],
-                _meta: {
-                  permissionMode: currentMode,
-                  ...(input.model !== undefined ? { model: input.model } : {}),
-                },
+                _meta: { permissionMode: currentMode },
               },
               5 * 60_000,
               (id) => {

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -723,21 +723,20 @@ export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> 
       supportsWebSearch: "queryOnly",
     },
   ],
-  // Cursor's CLI exposes models via the ACP session config-option picker;
-  // these are the slugs `cursor-agent --model` advertises today. Like grok,
-  // the picker accepts any model the agent knows, so a custom slug typed by
-  // the user still works — this list is the default shown in the picker.
-  // Cursor has native plan mode via ACP `setSessionMode("plan")`.
+  // Cursor's CLI exposes its full catalog through `cursor-agent models`
+  // (113 entries as of 2026-05). We surface a curated shortlist here; custom
+  // slugs typed in the picker still work because this is just the default
+  // seed, not a whitelist. Selection is applied at session start via ACP
+  // `session/set_config_option { configId: "model" }`. Plan mode lands
+  // natively via `setSessionMode("plan")`.
   cursor: [
-    { id: "gpt-5", label: "GPT-5", supportsPlanMode: true },
-    { id: "sonnet-4", label: "Claude Sonnet 4", supportsPlanMode: true },
-    {
-      id: "sonnet-4-thinking",
-      label: "Claude Sonnet 4 (Thinking)",
-      optionDescriptors: [reasoningSelectDescriptor("medium")],
-      supportsPlanMode: true,
-    },
-    { id: "opus-4.1", label: "Claude Opus 4.1", supportsPlanMode: true },
+    { id: "composer-2-fast", label: "Composer 2 Fast", supportsPlanMode: true },
+    { id: "composer-2", label: "Composer 2", supportsPlanMode: true },
+    { id: "gpt-5.5-medium", label: "GPT-5.5", supportsPlanMode: true },
+    { id: "gpt-5.5-high", label: "GPT-5.5 High", supportsPlanMode: true },
+    { id: "gpt-5.3-codex", label: "Codex 5.3", supportsPlanMode: true },
+    { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro", supportsPlanMode: true },
+    { id: "auto", label: "Auto", supportsPlanMode: true },
   ],
   // OpenCode is a meta-provider: it spawns a local `opencode serve` and
   // forwards prompts to whichever underlying provider (anthropic, openai,
@@ -803,7 +802,16 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string
     "gemini-3-pro": "gemini-3-pro-preview",
     "gemini-3.1-pro-preview": "gemini-3-pro-preview",
   },
-  cursor: {},
+  // Cursor retired the old `gpt-5` / `sonnet-4*` / `opus-4.x` slugs sometime
+  // around 2025-11. Existing user settings persisted by earlier builds get
+  // re-aliased to current cursor catalogue entries so re-opening the app
+  // doesn't send the agent a slug it'll silently ignore.
+  cursor: {
+    "gpt-5": "composer-2-fast",
+    "sonnet-4": "composer-2-fast",
+    "sonnet-4-thinking": "composer-2-fast",
+    "opus-4.1": "composer-2-fast",
+  },
   opencode: {},
 };
 


### PR DESCRIPTION
## Summary

Cursor was broken end-to-end: ACP handshake hung for 30s on older `cursor-agent` builds, OAuth-only users got "not signed in" even after `cursor-agent login`, the hardcoded model list pointed at retired slugs (`gpt-5`, `sonnet-4`, …), and selecting Cursor in the empty-state composer silently failed.

- **Fail fast on stale cursor-agent** — 5s timeout on `initialize`; on timeout we surface "Cursor Agent is too old. Run `cursor-agent update` (need ≥ 2025.11)" instead of waiting 30s.
- **Fix OAuth auth** — always prefer `cursor_login` when advertised. Previously gated on `apiKey !== null`, which broke users with stored OAuth creds.
- **Real model selection** — apply choice via ACP `session/set_config_option { configId: "model" }` after `session/new`; advertise `_meta.parameterizedModelPicker`. The old `_meta.model` in `session/prompt` was a no-op.
- **Refresh model list** — replaced retired slugs with `composer-2-fast` (default), `composer-2`, `gpt-5.5-medium`, `gpt-5.5-high`, `gpt-5.3-codex`, `gemini-3.1-pro`, `auto`. Aliased retired ids so existing settings still boot.
- **Surface session-start errors** — empty-state chat-landing and the in-chat model picker now `await` create/setProvider/setModel and render a rose banner with the failure reason. Closes the "popover just closes" silent-failure path.
- **Defense-in-depth spawn errors** — `child.once("error", …)` rejects pending requests on ENOENT/EACCES so the handshake fails cleanly.

## Test plan
- [ ] Old `cursor-agent` installed → pick cursor model in chat: ~5s, banner reads "Cursor Agent is too old…"; no 30s hang.
- [ ] New `cursor-agent`, `cursor-agent logout && cursor-agent login` (OAuth, no `CURSOR_API_KEY`) → cursor session boots, prompt streams a reply.
- [ ] Model picker shows fresh cursor slugs (composer-2-fast, gpt-5.5-medium, gemini-3.1-pro, …); picked model is reflected in the first stream-json chunk's `model` field.
- [ ] Empty-state composer → pick cursor, send a prompt; if session-start fails, rose banner appears above the composer with the reason. Clears on next keystroke.
- [ ] In-chat model picker → cross-provider switch on a stale provider keeps the popover open and shows the error inline rather than silently closing.
- [ ] `bun run check-types` clean in `apps/server`, `apps/renderer`, `packages/wire`.