### PR TITLE
refactor(renderer): single source of truth for active directory + branch

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -34,6 +34,7 @@ import { hydrateSubagentsStore } from "./store/subagents.ts";
 import { useIndexStore } from "./store/code-index.ts";
 import { useUiStore } from "./store/ui.ts";
 import { useWorkspaceStore } from "./store/workspace.ts";
+import { useWorktreesStore } from "./store/worktrees.ts";
 
 const PANEL_GROUP_ID = "memoize.shell.v3";
 const PANEL_IDS = ["projects", "main", "files"];
@@ -183,6 +184,16 @@ function MainShell() {
     void hydrateIndex(selectedFolderId);
   }, [selectedFolderId, hydrateIndex]);
 
+  // Eagerly hydrate worktrees on project select so the active context can
+  // resolve worktree paths without waiting for the chat composer to mount.
+  // Without this, terminal/file-tree/branch label stay in "preparing
+  // worktree" until the user opens the chat tab.
+  const refreshWorktrees = useWorktreesStore((s) => s.refresh);
+  useEffect(() => {
+    if (selectedFolderId === null) return;
+    void refreshWorktrees(selectedFolderId);
+  }, [selectedFolderId, refreshWorktrees]);
+
   // Cmd+W in the menu dispatches `menu:close-tab` over IPC; the renderer
   // owns the close-tab logic because it knows which chat tab is active.
   useEffect(() => {
@@ -256,7 +267,7 @@ function MainShell() {
         <Separator className="w-px bg-border transition-colors hover:bg-foreground/20 active:bg-foreground/30" />
         <Panel id="main" minSize="30%">
           <main className="flex h-full min-h-0 min-w-0 flex-col bg-background/70 backdrop-blur-3xl">
-            <TopBarMain folderId={selectedFolderId} />
+            <TopBarMain />
             <UpdateBanner />
             <IndexProgressBanner />
             <MainTabs
@@ -305,7 +316,7 @@ function MainShell() {
           }}
         >
           <div className="flex h-full min-h-0 flex-col bg-sidebar/40 backdrop-blur-3xl">
-            <TopBarRight folderId={selectedFolderId} />
+            <TopBarRight />
             <div className="flex min-h-0 flex-1 flex-col">
               <RightPane />
             </div>

--- a/apps/renderer/src/components/active-location-chip.tsx
+++ b/apps/renderer/src/components/active-location-chip.tsx
@@ -1,0 +1,62 @@
+import { FolderClosed, GitBranch } from "lucide-react";
+
+import { useActiveContext } from "../store/active-workspace.ts";
+import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
+
+/**
+ * Compact "you are here" strip showing the active project's tail path and
+ * the current branch label. Reads `useActiveContext()` so it stays in
+ * lockstep with the terminal cwd, file-tree root, top-bar branch, and any
+ * other surface that follows the user's selection.
+ *
+ * Renders `null` while no folder is selected — the chat composer is hidden
+ * in that state anyway, so the chip would have no anchor.
+ */
+export function ActiveLocationChip() {
+  const ctx = useActiveContext();
+  const branch = useGitStatusStore((s) => {
+    if (ctx.status !== "ready") return null;
+    return (
+      s.byKey[gitStatusKey(ctx.folderId, ctx.worktreeId)]?.branch ?? null
+    );
+  });
+
+  if (ctx.status !== "ready") return null;
+
+  const tail = tailPathSegments(ctx.rootPath, 2);
+  const onWorktree = ctx.rootKind === "worktree";
+  const Icon = onWorktree ? GitBranch : FolderClosed;
+
+  return (
+    <div className="flex items-center gap-1.5 px-1 pb-1 text-[11px] text-muted-foreground">
+      <Icon className="size-3 shrink-0 opacity-70" />
+      <span className="truncate font-mono opacity-80" title={ctx.rootPath}>
+        {tail}
+      </span>
+      {branch !== null ? (
+        <>
+          <span className="opacity-40">·</span>
+          <span className="truncate font-medium text-foreground/70">
+            {branch}
+          </span>
+        </>
+      ) : null}
+      {onWorktree ? (
+        <span
+          className="size-1.5 shrink-0 rounded-full bg-accent-foreground/60"
+          title="Worktree"
+        />
+      ) : null}
+      {ctx.worktreePending ? (
+        <span className="shrink-0 text-amber-300">syncing…</span>
+      ) : null}
+    </div>
+  );
+}
+
+/** Returns the last `count` segments of an absolute path, joined with `/`. */
+const tailPathSegments = (path: string, count: number): string => {
+  const parts = path.split("/").filter((p) => p.length > 0);
+  if (parts.length <= count) return path;
+  return parts.slice(-count).join("/");
+};

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -31,6 +31,7 @@ import {
   type SessionId,
 } from "@memoize/wire";
 import { ModelPicker } from "./model-picker.tsx";
+import { ActiveLocationChip } from "./active-location-chip.tsx";
 
 import { Card, CardPanel } from "~/components/ui/card";
 import { Frame, FrameFooter } from "~/components/ui/frame";
@@ -578,6 +579,7 @@ export function ChatComposer({ session }: { session: Session }) {
         aria-hidden={showCard || undefined}
       >
         <div className="mx-auto">
+          <ActiveLocationChip />
           <Frame>
             <Card
               className={cn(

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -1,9 +1,7 @@
 import { FolderClosed, GitBranch } from "lucide-react";
 
-import type { FolderId } from "@memoize/wire";
-
 import { formatShortcut } from "../lib/shortcuts.ts";
-import { useActiveWorktreeId } from "../store/active-workspace.ts";
+import { useActiveContext } from "../store/active-workspace.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
@@ -24,12 +22,13 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
  * scrollback, file-tree expansion, and any in-flight PR fetch.
  */
 export function RightPane() {
+  const ctx = useActiveContext();
   const folders = useWorkspaceStore((s) => s.folders);
-  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
+  const selectedFolderId = ctx.status === "ready" ? ctx.folderId : null;
+  const worktreeId = ctx.status === "ready" ? ctx.worktreeId : null;
   const selected = selectedFolderId
     ? (folders.find((f) => f.id === selectedFolderId) ?? null)
     : null;
-  const worktreeId = useActiveWorktreeId(selectedFolderId);
   const status = useGitStatusStore((s) =>
     selectedFolderId
       ? (s.byKey[gitStatusKey(selectedFolderId, worktreeId)] ?? null)
@@ -91,7 +90,7 @@ export function RightPane() {
               hidden={tab !== "files"}
               className="flex min-h-0 flex-1 flex-col"
             >
-              <ActiveWorkspaceChip folderId={selected.id} />
+              <ActiveWorkspaceChip />
               <div className="min-h-0 flex-1 overflow-y-auto">
                 <FileTree key={selected.id} folderId={selected.id} />
               </div>
@@ -117,26 +116,30 @@ export function RightPane() {
  * in the project's main checkout or in a worktree. Read-only label — pick a
  * worktree from the chat composer's workspace picker; this chip just makes
  * the active root visible so users don't get confused by what they're
- * looking at.
+ * looking at. Reads the canonical active context so it can never disagree
+ * with the terminal, top-bar branch, or composer chip.
  */
-function ActiveWorkspaceChip({ folderId }: { folderId: FolderId }) {
-  const worktreeId = useActiveWorktreeId(folderId);
+function ActiveWorkspaceChip() {
+  const ctx = useActiveContext();
   const worktree = useWorktreesStore((s) => {
-    if (worktreeId === null) return null;
-    const list = s.byProject[folderId] ?? EMPTY_WORKTREES;
-    return list.find((w) => w.id === worktreeId) ?? null;
+    if (ctx.status !== "ready" || ctx.worktreeId === null) return null;
+    const list = s.byProject[ctx.folderId] ?? EMPTY_WORKTREES;
+    return list.find((w) => w.id === ctx.worktreeId) ?? null;
   });
-  const Icon = worktreeId === null ? FolderClosed : GitBranch;
-  const label =
-    worktreeId === null ? "Main checkout" : (worktree?.name ?? "Worktree");
-  const sub =
-    worktreeId === null ? null : (worktree?.branch ?? null);
+  if (ctx.status !== "ready") return null;
+  const onWorktree = ctx.rootKind === "worktree";
+  const Icon = onWorktree ? GitBranch : FolderClosed;
+  const label = onWorktree ? (worktree?.name ?? "Worktree") : "Main checkout";
+  const sub = onWorktree ? worktree?.branch ?? null : null;
   return (
     <div className="flex shrink-0 items-center gap-1.5 border-b border-border/40 px-3 py-1.5 text-[11px] text-muted-foreground">
       <Icon className="size-3.5 shrink-0 opacity-70" />
       <span className="truncate font-medium text-foreground/80">{label}</span>
       {sub !== null ? (
         <span className="truncate font-mono opacity-70">· {sub}</span>
+      ) : null}
+      {ctx.worktreePending ? (
+        <span className="shrink-0 text-amber-300">syncing…</span>
       ) : null}
     </div>
   );

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -3,37 +3,45 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Effect, Fiber, Stream } from "effect";
 
-import type { Folder, PtyId } from "@memoize/wire";
+import type { FolderId, PtyId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
-import { useActiveWorkspaceRoot } from "../store/active-workspace.ts";
-import { useWorkspaceStore } from "../store/workspace.ts";
+import { useActiveContext } from "../store/active-workspace.ts";
 
 export function TerminalPane() {
-  const folders = useWorkspaceStore((s) => s.folders);
-  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
-  const selected = selectedFolderId
-    ? (folders.find((f) => f.id === selectedFolderId) ?? null)
-    : null;
-  const activeRoot = useActiveWorkspaceRoot(
-    selectedFolderId ?? ("" as Folder["id"]),
-  );
+  const ctx = useActiveContext();
 
-  if (selected === null) {
+  if (ctx.status === "loading") {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background text-sm text-muted-foreground">
+        Loading workspace…
+      </div>
+    );
+  }
+  if (ctx.status === "empty") {
     return (
       <div className="flex h-full w-full items-center justify-center bg-background text-sm text-muted-foreground">
         No folder selected. Add or pick a folder on the left.
       </div>
     );
   }
+  if (ctx.worktreePending) {
+    // Session is bound to a worktree whose row hasn't arrived yet. Opening
+    // a PTY here would pin it to the folder path — the wrong place — for
+    // the rest of the session's life. Wait instead.
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background text-sm text-muted-foreground">
+        Preparing worktree…
+      </div>
+    );
+  }
 
-  // `key` includes the resolved cwd so toggling a session's worktree
-  // re-mounts the pane with a fresh PTY rooted in the new path. Live cwd
-  // migration of an existing PTY is out of scope.
-  const cwd = activeRoot ?? selected.path;
-  return (
-    <PtyTerminal key={`${selected.id}:${cwd}`} folder={selected} cwd={cwd} />
-  );
+  // `key` includes worktreeId + rootPath so a worktree swap re-mounts with
+  // a fresh PTY rooted in the new path. `folderId` alone wouldn't catch
+  // worktree toggles within the same project. Live cwd migration of an
+  // existing PTY is out of scope.
+  const key = `${ctx.folderId}:${ctx.worktreeId ?? "main"}:${ctx.rootPath}`;
+  return <PtyTerminal key={key} folderId={ctx.folderId} cwd={ctx.rootPath} />;
 }
 
 // xterm's canvas/webgl renderer takes literal color strings, not CSS vars,
@@ -50,7 +58,7 @@ function readToken(el: HTMLElement, cssVar: string, fallback: string): string {
   return computed || fallback;
 }
 
-function PtyTerminal({ folder, cwd }: { folder: Folder; cwd: string }) {
+function PtyTerminal({ folderId, cwd }: { folderId: FolderId; cwd: string }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -195,7 +203,7 @@ function PtyTerminal({ folder, cwd }: { folder: Folder; cwd: string }) {
       }
       term.dispose();
     };
-  }, [folder.id, cwd]);
+  }, [folderId, cwd]);
 
   return (
     <div ref={containerRef} className="h-full w-full bg-background p-2" />

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -24,7 +24,7 @@ import {
   type GlassTone,
 } from "./glass-action.tsx";
 import { TooltipShortcut } from "./projects-sidebar.tsx";
-import { useActiveWorktreeId } from "../store/active-workspace.ts";
+import { useActiveContext } from "../store/active-workspace.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
@@ -89,11 +89,13 @@ export function TopBarLeft() {
  * open/close toggle (always visible — the user expects to find it here
  * regardless of which way the files panel is currently leaning).
  */
-export function TopBarMain({ folderId }: { folderId: FolderId | null }) {
-  // The branch label follows the active session's worktree so users see the
-  // worktree's branch (e.g. happy-otter-42) when they're chatting against it,
-  // not the main checkout's branch.
-  const worktreeId = useActiveWorktreeId(folderId);
+export function TopBarMain() {
+  // Pull folderId + worktreeId from the canonical active context so the
+  // branch label can never disagree with the terminal cwd, file tree root,
+  // or composer chip — they all read from the same hook.
+  const ctx = useActiveContext();
+  const folderId = ctx.status === "ready" ? ctx.folderId : null;
+  const worktreeId = ctx.status === "ready" ? ctx.worktreeId : null;
   const status = useGitStatusStore((s) =>
     folderId
       ? (s.byKey[gitStatusKey(folderId, worktreeId)] ?? null)
@@ -116,6 +118,10 @@ export function TopBarMain({ folderId }: { folderId: FolderId | null }) {
     return () => window.clearInterval(id);
   }, [folderId, refresh, worktreeId]);
 
+  // After a worktree/project switch the status row in `byKey` is keyed by
+  // the *new* (folderId, worktreeId), so reading `status` returns null
+  // until the first refresh lands — which is the correct behavior. No
+  // stale-branch flash during the swap.
   const branchLabel = status?.branch ?? null;
   const showLeftToggle = !leftSidebarOpen;
   // When the left panel is open its own header carries the traffic-light
@@ -265,8 +271,10 @@ const deriveWorkflow = (
  * Draft / checks-pending stages need new fields on `GitPrInfo` and are
  * deferred — the layout already reserves the space.
  */
-export function TopBarRight({ folderId }: { folderId: FolderId | null }) {
-  const worktreeId = useActiveWorktreeId(folderId);
+export function TopBarRight() {
+  const ctx = useActiveContext();
+  const folderId = ctx.status === "ready" ? ctx.folderId : null;
+  const worktreeId = ctx.status === "ready" ? ctx.worktreeId : null;
   const status = useGitStatusStore((s) =>
     folderId
       ? (s.byKey[gitStatusKey(folderId, worktreeId)] ?? null)

--- a/apps/renderer/src/store/active-workspace.ts
+++ b/apps/renderer/src/store/active-workspace.ts
@@ -1,26 +1,147 @@
-import type { FolderId, WorktreeId } from "@memoize/wire";
+import { useMemo } from "react";
+
+import type { FolderId, SessionId, WorktreeId } from "@memoize/wire";
 
 import { useSessionsStore } from "./sessions.ts";
 import { useWorkspaceStore } from "./workspace.ts";
-import { useWorktreesStore } from "./worktrees.ts";
+import { EMPTY_WORKTREES, useWorktreesStore } from "./worktrees.ts";
 
 /**
- * Cross-store selectors that surface the *effective* root for the surfaces
- * that should follow the selected session's worktree (file tree, file
- * editor, terminal, top-bar branch, git status). When no session is selected
- * or the session is on the main checkout, these fall back to the project's
- * `folder.path`.
+ * Canonical "where am I" signal for the renderer. Every surface that needs
+ * to know the current project, session, worktree, or root path — terminal,
+ * file tree, chat composer, top bar, git status — reads from
+ * `useActiveContext()` so they can never disagree.
  *
- * Kept in their own module so any store that wants to read these doesn't
- * pull in the others' types as a side effect.
+ * Before this hook existed, each surface independently called
+ * `useActiveWorkspaceRoot(folderId)` with a different `folderId` source
+ * (terminal: `selectedFolderId`, composer: `session.projectId`, top-bar:
+ * prop), and the underlying selector silently fell back to `folder.path`
+ * when the worktree row wasn't hydrated yet — so the terminal could mount
+ * a PTY in the wrong directory with no signal to the user. The
+ * `worktreePending` flag in the `ready` variant makes that race explicit.
  */
+export type ActiveContext =
+  /** Folders RPC hasn't resolved yet on cold start. */
+  | { readonly status: "loading" }
+  /** Folders loaded, but none selected (empty workspace or after remove). */
+  | { readonly status: "empty" }
+  | {
+      readonly status: "ready";
+      readonly folderId: FolderId;
+      readonly folderPath: string;
+      readonly sessionId: SessionId | null;
+      /**
+       * The worktree the session has bound. `null` when the session runs in
+       * the main checkout — or when no session is selected for this project.
+       */
+      readonly worktreeId: WorktreeId | null;
+      /**
+       * The path consumers should open files / PTYs / git ops in. Equals
+       * the worktree's path when one is bound and hydrated, otherwise the
+       * folder's path. **Never** silently falls back to the folder when a
+       * worktree is bound — see `worktreePending`.
+       */
+      readonly rootPath: string;
+      readonly rootKind: "folder" | "worktree";
+      /**
+       * `true` when the session names a worktreeId but `worktrees.byProject`
+       * doesn't have its row yet. Consumers that would mount a PTY or open
+       * a file in the resolved path should wait (render a placeholder)
+       * instead of using `rootPath` — `rootPath` is `folderPath` in this
+       * state, which is **not** where the user wants to operate.
+       */
+      readonly worktreePending: boolean;
+    };
 
 /**
- * WorktreeId of the given project's currently-selected session, or null when
- * that project's selection is on main checkout. Scoped per-project so
- * switching projects deterministically swaps every panel that reads it
- * (file tree, changes, PR, terminal, top-bar branch) to the new project's
- * own active context — no cross-project session lookup.
+ * Returns the canonical active context. Recomputed on the minimal set of
+ * store-slot changes. Memoized so consumers can pass the object to React
+ * dependency arrays without re-firing on unrelated store updates.
+ */
+export const useActiveContext = (): ActiveContext => {
+  const foldersLoaded = useWorkspaceStore(
+    (s) => !s.loading || s.folders.length > 0,
+  );
+  const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
+  const folderPath = useWorkspaceStore((s) => {
+    if (s.selectedFolderId === null) return null;
+    return s.folders.find((f) => f.id === s.selectedFolderId)?.path ?? null;
+  });
+  const sessionId = useSessionsStore((s) =>
+    selectedFolderId !== null
+      ? s.selectedSessionByProject[selectedFolderId] ?? null
+      : null,
+  );
+  const sessionWorktreeId = useSessionsStore((s) => {
+    if (selectedFolderId === null || sessionId === null) return null;
+    const list = s.sessionsByProject[selectedFolderId] ?? null;
+    if (list === null) return null;
+    return list.find((sess) => sess.id === sessionId)?.worktreeId ?? null;
+  });
+  const worktreePath = useWorktreesStore((s) => {
+    if (selectedFolderId === null || sessionWorktreeId === null) return null;
+    const list = s.byProject[selectedFolderId] ?? EMPTY_WORKTREES;
+    return list.find((w) => w.id === sessionWorktreeId)?.path ?? null;
+  });
+
+  return useMemo<ActiveContext>(() => {
+    if (!foldersLoaded) return { status: "loading" };
+    if (selectedFolderId === null || folderPath === null) {
+      return { status: "empty" };
+    }
+    if (sessionWorktreeId !== null && worktreePath !== null) {
+      return {
+        status: "ready",
+        folderId: selectedFolderId,
+        folderPath,
+        sessionId,
+        worktreeId: sessionWorktreeId,
+        rootPath: worktreePath,
+        rootKind: "worktree",
+        worktreePending: false,
+      };
+    }
+    if (sessionWorktreeId !== null && worktreePath === null) {
+      // Session is bound to a worktree we haven't hydrated yet. Surface this
+      // explicitly — do NOT silently fall back to folderPath.
+      return {
+        status: "ready",
+        folderId: selectedFolderId,
+        folderPath,
+        sessionId,
+        worktreeId: sessionWorktreeId,
+        rootPath: folderPath,
+        rootKind: "folder",
+        worktreePending: true,
+      };
+    }
+    return {
+      status: "ready",
+      folderId: selectedFolderId,
+      folderPath,
+      sessionId,
+      worktreeId: null,
+      rootPath: folderPath,
+      rootKind: "folder",
+      worktreePending: false,
+    };
+  }, [
+    foldersLoaded,
+    selectedFolderId,
+    folderPath,
+    sessionId,
+    sessionWorktreeId,
+    worktreePath,
+  ]);
+};
+
+/**
+ * Per-project lookup of the active session's worktree. Kept for callers
+ * that legitimately scope to a specific project id (the chat composer's
+ * FileTagPopover, which resolves file mentions under the session's own
+ * project even if the user has briefly glanced at another). For surfaces
+ * that should follow the user's current selection, prefer
+ * `useActiveContext()` — it can never disagree with itself across panels.
  */
 export const useActiveWorktreeId = (
   folderId: FolderId | null,
@@ -37,14 +158,17 @@ export const useActiveWorktreeId = (
 };
 
 /**
- * Effective workspace root path for the given project. When the selected
- * session has a worktree under this project, returns the worktree's path;
- * otherwise returns the folder's path. Returns null only when the folder
- * itself isn't loaded yet.
+ * Per-project active root path. See `useActiveWorktreeId` for when to
+ * pick this over `useActiveContext()`. Note: this preserves the legacy
+ * "silent fallback to folder.path when worktree not yet hydrated"
+ * behavior — call `useActiveContext()` if you need to distinguish that
+ * race from a deliberate main-checkout session.
  */
-export const useActiveWorkspaceRoot = (folderId: FolderId): string | null => {
-  const folder = useWorkspaceStore((s) =>
-    s.folders.find((f) => f.id === folderId) ?? null,
+export const useActiveWorkspaceRoot = (
+  folderId: FolderId,
+): string | null => {
+  const folder = useWorkspaceStore(
+    (s) => s.folders.find((f) => f.id === folderId) ?? null,
   );
   const worktreeId = useActiveWorktreeId(folderId);
   const worktree = useWorktreesStore((s) => {


### PR DESCRIPTION
## Summary
- Adds `useActiveContext()` — a canonical "where am I" hook derived atomically from the workspace/sessions/worktrees stores — so the terminal, top bar, right pane, and a new location chip in the composer can never disagree about cwd or branch.
- Surfaces a `worktreePending` flag instead of silently falling back to `folder.path` when a session's worktree row isn't hydrated yet; the terminal now shows a "Preparing worktree…" placeholder rather than opening a PTY in the wrong directory.
- Eagerly hydrates worktrees on project select in `MainShell` so the pending window stays very short, and drops the now-redundant `folderId` prop from the top bars.

## Test plan
- [x] `bun run check-types` passes (8/8 packages)
- [ ] Cold start a project with a worktree-bound session — terminal opens in the worktree path on the first render
- [ ] Rapid project switching — branch label, terminal cwd, file-tree root, and composer chip all swap in lockstep
- [ ] Create a session on a fresh worktree — terminal shows "Preparing worktree…" briefly instead of flashing the folder root