### PR TITLE
feat(file-viewer): full-pane diff view with Diff/Edit toggle

### DIFF
--- a/apps/renderer/src/components/diff-pane.tsx
+++ b/apps/renderer/src/components/diff-pane.tsx
@@ -255,7 +255,13 @@ function FileRow({
       <button
         type="button"
         onClick={() =>
-          openFileInTab({ folderId, worktreeId, path, name: basename(path) })
+          openFileInTab({
+            folderId,
+            worktreeId,
+            path,
+            name: basename(path),
+            view: "diff",
+          })
         }
         className="-mx-1 flex w-[calc(100%+0.5rem)] items-center justify-between gap-2 rounded-sm px-1 py-0.5 text-left transition-colors hover:bg-foreground/5"
         title={tooltip}

--- a/apps/renderer/src/components/file-badge.tsx
+++ b/apps/renderer/src/components/file-badge.tsx
@@ -1,10 +1,19 @@
 import { FileChip } from "./file-chip.tsx";
+import type { FileView } from "~/store/ui";
 
 /**
  * Back-compat wrapper around `FileChip`. Tool rows pass the absolute path
  * the agent saw; the chip uses that as the display string (the tooltip
- * shows the full path) and opens it in the file editor on click.
+ * shows the full path) and opens it in the file editor on click. Pass
+ * `view="diff"` from Edit/Write/MultiEdit rows so clicking the file lands
+ * on the side-by-side diff instead of the CodeMirror editor.
  */
-export function FileBadge({ path }: { path: string }) {
-  return <FileChip relPath={path} absPath={path} />;
+export function FileBadge({
+  path,
+  view,
+}: {
+  path: string;
+  view?: FileView;
+}) {
+  return <FileChip relPath={path} absPath={path} view={view} />;
 }

--- a/apps/renderer/src/components/file-chip.tsx
+++ b/apps/renderer/src/components/file-chip.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from "react";
 import type { FolderId, WorktreeId } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
-import { useUiStore } from "~/store/ui";
+import { useUiStore, type FileView } from "~/store/ui";
 import { FileIcon } from "./file-icon.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
@@ -54,6 +54,7 @@ export function FileChip({
   relPath,
   absPath,
   kind = "file",
+  view,
   className,
 }: {
   /** Path shown in the tooltip + used as the chip label (basename only). */
@@ -65,6 +66,12 @@ export function FileChip({
    */
   readonly absPath?: string;
   readonly kind?: "file" | "directory";
+  /**
+   * Which body the file viewer should open with. Tool rows for Edit/Write/
+   * MultiEdit pass `"diff"` so clicking the file goes straight to the
+   * side-by-side diff; everything else defaults to the CodeMirror editor.
+   */
+  readonly view?: FileView;
   readonly className?: string;
 }) {
   const { folderId, worktreeId } = useFileChipContext();
@@ -84,6 +91,7 @@ export function FileChip({
       path: absPath ?? relPath,
       name,
       worktreeId,
+      view,
     });
   };
 

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -1,6 +1,10 @@
+import { PatchDiff } from "@pierre/diffs/react";
 import { Effect } from "effect";
 import { useEffect, useRef, useState } from "react";
 
+import type { GitDiffResult } from "@memoize/wire";
+
+import { cn } from "~/lib/utils";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import {
   createEditor,
@@ -9,7 +13,11 @@ import {
 } from "../lib/codemirror/setup.ts";
 import { languageForFile } from "../lib/codemirror/languages.ts";
 import { useKeybindingsStore } from "../store/keybindings.ts";
-import { useUiStore, type OpenFile } from "../store/ui.ts";
+import {
+  useUiStore,
+  type FileView,
+  type OpenFile,
+} from "../store/ui.ts";
 
 import type { EditorView } from "@codemirror/view";
 
@@ -32,11 +40,50 @@ const tagOf = (err: unknown): string | null =>
     ? String((err as { _tag: unknown })._tag)
     : null;
 
+/**
+ * Top-level shell for the file tab in the main pane. Renders a Toolbar with
+ * the Diff | Edit segmented control and delegates the body to either a
+ * CodeMirror editor or a side-by-side `@pierre/diffs` patch view. Both
+ * bodies stay mounted across toggles so unsaved CodeMirror edits survive
+ * a quick peek at the diff.
+ */
 export function FileEditor() {
   const openFile = useUiStore((s) => s.openFile);
-  const setFileDirty = useUiStore((s) => s.setFileDirty);
   const closeFileTab = useUiStore((s) => s.closeFileTab);
+  const view = openFile?.view ?? "edit";
 
+  if (openFile === null) {
+    return <Placeholder>No file open.</Placeholder>;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <Toolbar path={openFile.path} view={view} />
+      <CodeMirrorBody
+        openFile={openFile}
+        hidden={view !== "edit"}
+        onClose={closeFileTab}
+      />
+      {view === "diff" ? <DiffViewBody openFile={openFile} /> : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CodeMirror body — loads a file via fs.readFile, mounts the editor once,
+// swaps documents on file change. Cmd+S saves via fs.writeFile.
+// ---------------------------------------------------------------------------
+
+function CodeMirrorBody({
+  openFile,
+  hidden,
+  onClose,
+}: {
+  openFile: OpenFile;
+  hidden: boolean;
+  onClose: () => void;
+}) {
+  const setFileDirty = useUiStore((s) => s.setFileDirty);
   const [state, setState] = useState<EditorState>({ status: "loading" });
   const [conflict, setConflict] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -51,10 +98,9 @@ export function FileEditor() {
   const baselineRef = useRef("");
   const mtimeRef = useRef("");
   const savingRef = useRef(false);
-  const fileRef = useRef<OpenFile | null>(null);
+  const fileRef = useRef<OpenFile | null>(openFile);
   fileRef.current = openFile;
 
-  // ---- save: bound to Cmd+S in the editor keymap -------------------------
   const save = async () => {
     const file = fileRef.current;
     if (file === null) return;
@@ -94,9 +140,6 @@ export function FileEditor() {
   const saveRef = useRef(save);
   saveRef.current = save;
 
-  // ---- editor lifecycle: build once, swap doc on file change -------------
-  // The CodeMirror view stays mounted across file swaps; opening a different
-  // file dispatches a single transaction. No DOM teardown, no re-mount cost.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -113,9 +156,6 @@ export function FileEditor() {
     });
     viewRef.current = view;
 
-    // Live-reconfigure the editor keymap when the user edits keybindings —
-    // `editor.save` (and any future editor.* commands) take effect without
-    // unmounting the view or losing the open document.
     const unsubKeybindings = useKeybindingsStore.subscribe(() => {
       reconfigureEditorKeymap(view, onSave);
     });
@@ -127,9 +167,7 @@ export function FileEditor() {
     };
   }, []);
 
-  // ---- load on file change (or explicit reload) --------------------------
   useEffect(() => {
-    if (openFile === null) return;
     let cancelled = false;
     setState({ status: "loading" });
     setFileDirty(false);
@@ -179,12 +217,12 @@ export function FileEditor() {
     };
   }, [openFile, reloadCount, setFileDirty]);
 
-  if (openFile === null) {
-    return <Placeholder>No file open.</Placeholder>;
-  }
-
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div
+      className="flex min-h-0 flex-1 flex-col"
+      hidden={hidden}
+      aria-hidden={hidden}
+    >
       {(conflict || saveError) && (
         <Banner
           message={conflict ?? saveError ?? ""}
@@ -196,7 +234,7 @@ export function FileEditor() {
           }}
         />
       )}
-      <Toolbar path={openFile.path} saving={saving} />
+      <SavingIndicator saving={saving} />
       <div
         ref={containerRef}
         className="min-h-0 flex-1 overflow-hidden"
@@ -214,7 +252,7 @@ export function FileEditor() {
           <span className="text-destructive">{state.reason}</span>
           <button
             type="button"
-            onClick={closeFileTab}
+            onClick={onClose}
             className="rounded bg-muted px-2 py-1 text-xs hover:bg-muted/70"
           >
             Close
@@ -225,8 +263,93 @@ export function FileEditor() {
   );
 }
 
-function Toolbar({ path, saving }: { path: string; saving: boolean }) {
+// ---------------------------------------------------------------------------
+// Diff body — fetches `git.diff` for the current file and feeds the unified
+// patch string to `@pierre/diffs` `PatchDiff`. Handles untracked/deleted/
+// binary/unchanged states with placeholders so empty diffs don't surprise.
+// ---------------------------------------------------------------------------
+
+type DiffState =
+  | { status: "loading" }
+  | { status: "ready"; result: GitDiffResult }
+  | { status: "error"; reason: string };
+
+function DiffViewBody({ openFile }: { openFile: OpenFile }) {
+  const [state, setState] = useState<DiffState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    void (async () => {
+      try {
+        const client = await getRpcClient();
+        const result = await Effect.runPromise(
+          client.git.diff({
+            folderId: openFile.folderId,
+            worktreeId: openFile.worktreeId,
+            path: openFile.path,
+          }),
+        );
+        if (cancelled) return;
+        setState({ status: "ready", result });
+      } catch (err) {
+        if (cancelled) return;
+        setState({ status: "error", reason: formatError(err) });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [openFile.folderId, openFile.worktreeId, openFile.path]);
+
+  if (state.status === "loading") {
+    return <Placeholder>Loading diff…</Placeholder>;
+  }
+  if (state.status === "error") {
+    return (
+      <Placeholder>
+        <span className="text-destructive">{state.reason}</span>
+      </Placeholder>
+    );
+  }
+
+  const { mode, patch, truncated } = state.result;
+  if (mode === "unchanged") {
+    return <Placeholder>No changes vs HEAD.</Placeholder>;
+  }
+  if (mode === "binary") {
+    return <Placeholder>Binary file — diff preview not supported.</Placeholder>;
+  }
+  if (patch.length === 0) {
+    return <Placeholder>No diff content.</Placeholder>;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {truncated ? (
+        <Banner
+          message="Diff truncated — file too large to render in full."
+          actionLabel={null}
+          onAction={() => {}}
+          onDismiss={() => {}}
+        />
+      ) : null}
+      <div className="fz-diff min-h-0 flex-1 overflow-auto">
+        <PatchDiff patch={patch} disableWorkerPool />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar — path + dirty/saving on the left, Diff/Edit segmented toggle on
+// the right. The saving indicator lives inside CodeMirrorBody so it tracks
+// the actual save call; the toolbar just shows path + dirty + the toggle.
+// ---------------------------------------------------------------------------
+
+function Toolbar({ path, view }: { path: string; view: FileView }) {
   const dirty = useUiStore((s) => s.fileDirty);
+  const setOpenFileView = useUiStore((s) => s.setOpenFileView);
   return (
     <div className="flex shrink-0 items-center gap-3 border-b border-border px-3 py-1 text-[11px] text-muted-foreground">
       <span className="truncate" title={path}>
@@ -238,9 +361,73 @@ function Toolbar({ path, saving }: { path: string; saving: boolean }) {
             <span className="text-warning">●</span> modified
           </span>
         ) : null}
-        {saving ? <span>saving…</span> : null}
-        <span className="opacity-60">⌘S to save</span>
+        {view === "edit" ? (
+          <span className="opacity-60">⌘S to save</span>
+        ) : null}
+        <ViewToggle value={view} onChange={setOpenFileView} />
       </span>
+    </div>
+  );
+}
+
+function ViewToggle({
+  value,
+  onChange,
+}: {
+  value: FileView;
+  onChange: (v: FileView) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      className="flex items-center gap-px rounded-sm border border-border bg-background/60 p-px"
+    >
+      <ToggleButton
+        active={value === "diff"}
+        onClick={() => onChange("diff")}
+        label="Diff"
+      />
+      <ToggleButton
+        active={value === "edit"}
+        onClick={() => onChange("edit")}
+        label="Edit"
+      />
+    </div>
+  );
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "rounded-[3px] px-1.5 py-[1px] text-[10px] font-medium tracking-wide transition-colors",
+        active
+          ? "bg-foreground/10 text-foreground"
+          : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function SavingIndicator({ saving }: { saving: boolean }) {
+  if (!saving) return null;
+  return (
+    <div className="shrink-0 px-3 py-0.5 text-right text-[10px] text-muted-foreground">
+      saving…
     </div>
   );
 }

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -168,7 +168,7 @@ export function DiffBody({
     );
   }
   return (
-    <div className="overflow-x-auto text-[11px]">
+    <div className="fz-diff overflow-x-auto text-[11px]">
       {showHeader ? (
         <div className="border-b border-border/40 bg-muted/40 px-2 py-1 font-mono text-muted-foreground">
           {edit.mode === "create" ? "create" : "edit"} · {edit.path}

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -481,7 +481,7 @@ const buildToolView = (
         trailing:
           path !== null ? (
             <span className="flex items-center gap-2 tabular-nums">
-              <FileBadge path={path} />
+              <FileBadge path={path} view="diff" />
               {stats !== null && stats.added > 0 ? (
                 <span className="text-emerald-400">+{stats.added}</span>
               ) : null}

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -34,6 +34,14 @@ export type MainTab = "chat" | "file";
  */
 export type RightTab = "files" | "terminal" | "changes" | "pr";
 
+/**
+ * Which body the file viewer is showing. `edit` is the CodeMirror editor;
+ * `diff` is the side-by-side patch view (working tree vs HEAD) — wired up
+ * for clicks from the Changes panel and from Edit/Write/MultiEdit tool
+ * rows. Toggled in the toolbar; defaults set per entry point.
+ */
+export type FileView = "edit" | "diff";
+
 export type OpenFile = {
   readonly folderId: FolderId;
   readonly path: string;
@@ -44,6 +52,7 @@ export type OpenFile = {
    * while the file is open. `null` means main checkout.
    */
   readonly worktreeId: WorktreeId | null;
+  readonly view: FileView;
 };
 
 type UiState = {
@@ -62,7 +71,10 @@ type UiState = {
   readonly isFullScreen: boolean;
   readonly activeRightTab: RightTab;
   readonly setActiveMainTab: (tab: MainTab) => void;
-  readonly openFileInTab: (file: OpenFile) => void;
+  readonly openFileInTab: (
+    file: Omit<OpenFile, "view"> & { view?: FileView },
+  ) => void;
+  readonly setOpenFileView: (view: FileView) => void;
   readonly closeFileTab: () => void;
   readonly setFileDirty: (dirty: boolean) => void;
   readonly setLeftSidebarOpen: (open: boolean) => void;
@@ -86,7 +98,13 @@ export const useUiStore = create<UiState>((set) => ({
   activeRightTab: "files",
   setActiveMainTab: (tab) => set({ activeMainTab: tab }),
   openFileInTab: (file) =>
-    set({ openFile: file, activeMainTab: "file", fileDirty: false }),
+    set({
+      openFile: { ...file, view: file.view ?? "edit" },
+      activeMainTab: "file",
+      fileDirty: false,
+    }),
+  setOpenFileView: (view) =>
+    set((s) => (s.openFile === null ? s : { openFile: { ...s.openFile, view } })),
   closeFileTab: () =>
     set({ openFile: null, activeMainTab: "chat", fileDirty: false }),
   setFileDirty: (dirty) => set({ fileDirty: dirty }),

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -395,6 +395,62 @@ body,
   }
 }
 
+/* `@pierre/diffs` ships with stock GitHub-style fire-engine red / spring
+   green and pure white/black surfaces. That reads as a separate widget
+   bolted onto the app. Override the public CSS variables so the diff
+   inherits the app's stone-warm + slate-cool neutrals and uses softer,
+   teal-leaning add / rose-leaning delete colors. The custom properties
+   cascade into the shadow DOM Pierre renders into. */
+@layer components {
+  .fz-diff {
+    /* Surfaces — drop the diff onto the same neutral the pane uses so it
+       reads as part of the app, not a bolted-on widget. Pierre computes
+       its buffer / context / gutter tints from `--diffs-bg` mixed with a
+       `--diffs-mixer` (`#fff` in dark), which pushes toward zinc. We
+       override the computed values directly to keep everything anchored
+       on the app's `--background`. */
+    --diffs-light-bg: var(--background);
+    --diffs-dark-bg: var(--background);
+    --diffs-light: var(--foreground);
+    --diffs-dark: var(--foreground);
+    --diffs-bg-buffer-override: var(--background);
+    --diffs-bg-context-override: var(--background);
+    --diffs-bg-context-gutter-override: var(--bg-subtle);
+    --diffs-bg-separator-override: var(--border);
+
+    /* Add leans hard on the app's lime --primary — true yellow-chartreuse,
+       not teal. Delete stays warm rose so a glance still tells add from
+       delete. The text colors land on the marker / line text; the
+       backgrounds are a faint wash of the same hue against the app bg so
+       a + row reads as "a hint of lime" rather than "a green band." */
+    --diffs-added-light: oklch(0.55 0.2 108);
+    --diffs-added-dark: oklch(0.88 0.2 115);
+    --diffs-deleted-light: oklch(0.55 0.2 22);
+    --diffs-deleted-dark: oklch(0.78 0.15 20);
+    --diffs-modified-light: oklch(0.7 0.13 80);
+    --diffs-modified-dark: oklch(0.82 0.11 82);
+
+    --diffs-bg-addition-override:
+      color-mix(in oklab, var(--diffs-added-dark) 10%, var(--background));
+    --diffs-bg-addition-emphasis-override:
+      color-mix(in oklab, var(--diffs-added-dark) 20%, var(--background));
+    --diffs-bg-addition-number-override:
+      color-mix(in oklab, var(--diffs-added-dark) 14%, var(--bg-subtle));
+    --diffs-bg-deletion-override:
+      color-mix(in oklab, var(--diffs-deleted-dark) 10%, var(--background));
+    --diffs-bg-deletion-emphasis-override:
+      color-mix(in oklab, var(--diffs-deleted-dark) 20%, var(--background));
+    --diffs-bg-deletion-number-override:
+      color-mix(in oklab, var(--diffs-deleted-dark) 14%, var(--bg-subtle));
+
+    /* Typography — same monospace token as the rest of the app, slightly
+       smaller than Pierre's default so a diff doesn't dwarf the chat. */
+    --diffs-font-family: var(--font-mono);
+    --diffs-font-size: 12px;
+    --diffs-line-height: 18px;
+  }
+}
+
 /* Assistant message prose. Tuned for long-read comfort: body sits a touch
    below `--foreground`, headings sharper, code in a contained surface, and
    typographic rhythm (margins, line-height, list indents) calmed down so a

--- a/apps/server/src/git/handlers.ts
+++ b/apps/server/src/git/handlers.ts
@@ -49,6 +49,14 @@ const Changes = MemoizeRpcs.toLayerHandler(
     ),
 );
 
+const Diff = MemoizeRpcs.toLayerHandler(
+  "git.diff",
+  ({ folderId, worktreeId, path }) =>
+    Effect.flatMap(GitService, (svc) =>
+      svc.diff(folderId, path, worktreeId ?? null),
+    ),
+);
+
 const Commit = MemoizeRpcs.toLayerHandler(
   "git.commit",
   ({ folderId, worktreeId, message }) =>
@@ -79,6 +87,7 @@ export const GitHandlersLayer = Layer.mergeAll(
   PrState,
   PrDetails,
   Changes,
+  Diff,
   Commit,
   Push,
   FixFailingChecks,

--- a/apps/server/src/git/layers/git-service.ts
+++ b/apps/server/src/git/layers/git-service.ts
@@ -14,6 +14,7 @@ import {
   GitChange,
   GitCommandError,
   GitCommit,
+  GitDiffResult,
   GitFailingChecksArtifact,
   GitFolderNotFoundError,
   GitNotARepoError,
@@ -28,6 +29,7 @@ import {
   GitStatusSummary,
   type FolderId,
   type GitChangeKind,
+  type GitDiffMode,
   type GitPrCheckRunConclusion,
   type GitPrCheckRunStatus,
   type GitPrReviewState,
@@ -812,6 +814,142 @@ export const GitServiceLive = Layer.effect(
       );
 
     /**
+     * Working-tree-vs-HEAD diff for a single path. The renderer feeds the
+     * returned `patch` directly into `@pierre/diffs` `PatchDiff`. Modes:
+     *   - worktree : tracked + modified (or modified + deleted)
+     *   - deleted  : tracked but missing on disk
+     *   - untracked: not in HEAD — synthesize a /dev/null→file diff so new
+     *                files render the same as edits
+     *   - binary   : git classifies the file as binary (no patch returned)
+     *   - unchanged: clean vs HEAD (empty patch)
+     * Patches over 2 MiB are sliced so the renderer never has to handle a
+     * tens-of-megabytes diff string.
+     */
+    const diff: GitService["Type"]["diff"] = (folderId, p, worktreeId) =>
+      Effect.flatMap(resolvePathForWorktree(folderId, worktreeId), (cwd) =>
+        Effect.gen(function* () {
+          const rel = path.isAbsolute(p) ? path.relative(cwd, p) : p;
+          const MAX_BYTES = 2_000_000;
+
+          const finish = (
+            mode: GitDiffMode,
+            patch: string,
+          ): GitDiffResult => {
+            const bytes = patch.length;
+            const truncated = bytes > MAX_BYTES;
+            return new GitDiffResult({
+              mode,
+              patch: truncated ? patch.slice(0, MAX_BYTES) : patch,
+              truncated,
+              bytes,
+            });
+          };
+
+          // Tracked vs untracked. `ls-files --error-unmatch` exits 1 when the
+          // path isn't in the index — we catch that as "untracked".
+          const tracked = yield* run(folderId, cwd, [
+            "ls-files",
+            "--error-unmatch",
+            "--",
+            rel,
+          ]).pipe(
+            Effect.map(() => true),
+            Effect.catchTag("GitCommandError", () => Effect.succeed(false)),
+          );
+
+          if (!tracked) {
+            // Untracked: build a synthetic /dev/null → file diff so the
+            // renderer treats new files identically to modifications.
+            const exists = yield* fs.exists(path.resolve(cwd, rel)).pipe(
+              Effect.catchAll(() => Effect.succeed(false)),
+            );
+            if (!exists) {
+              return finish("unchanged", "");
+            }
+            const content = yield* fs
+              .readFileString(path.resolve(cwd, rel))
+              .pipe(
+                Effect.catchAll((err) =>
+                  Effect.fail(
+                    new GitCommandError({
+                      folderId,
+                      reason: `read ${rel}: ${String(err)}`,
+                    }),
+                  ),
+                ),
+            );
+            if (content.length === 0) {
+              const header =
+                `diff --git a/${rel} b/${rel}\n` +
+                `new file mode 100644\n` +
+                `--- /dev/null\n` +
+                `+++ b/${rel}\n`;
+              return finish("untracked", header);
+            }
+            const lines = content.split("\n");
+            // A trailing newline yields a final empty element — that line
+            // doesn't get a `+` marker; git emits "\ No newline at end of
+            // file" if it's missing, and nothing if present.
+            const hasTrailingNewline = content.endsWith("\n");
+            const bodyLines = hasTrailingNewline
+              ? lines.slice(0, -1)
+              : lines;
+            const newCount = bodyLines.length;
+            const body = bodyLines.map((l) => `+${l}`).join("\n");
+            const noNewline = hasTrailingNewline
+              ? ""
+              : "\n\\ No newline at end of file";
+            const patch =
+              `diff --git a/${rel} b/${rel}\n` +
+              `new file mode 100644\n` +
+              `--- /dev/null\n` +
+              `+++ b/${rel}\n` +
+              `@@ -0,0 +1,${newCount} @@\n` +
+              body +
+              noNewline +
+              "\n";
+            return finish("untracked", patch);
+          }
+
+          // Tracked. Use numstat to detect binary + unchanged cheaply.
+          const numstat = (yield* run(folderId, cwd, [
+            "diff",
+            "--numstat",
+            "HEAD",
+            "--",
+            rel,
+          ])).trim();
+
+          if (numstat.length === 0) {
+            return finish("unchanged", "");
+          }
+          // Format: "<added>\t<deleted>\t<path>". Binary files report "-\t-".
+          const firstTab = numstat.indexOf("\t");
+          if (firstTab > 0 && numstat.startsWith("-\t-")) {
+            return finish("binary", "");
+          }
+
+          const patch = yield* run(folderId, cwd, [
+            "diff",
+            "--no-color",
+            "--no-ext-diff",
+            "HEAD",
+            "--",
+            rel,
+          ]);
+
+          // Deleted: tracked file missing from working tree. The patch still
+          // reads correctly; we just label the mode so the renderer can show
+          // "(deleted)" context.
+          const stillExists = yield* fs
+            .exists(path.resolve(cwd, rel))
+            .pipe(Effect.catchAll(() => Effect.succeed(false)));
+          const mode: GitDiffMode = stillExists ? "worktree" : "deleted";
+          return finish(mode, patch);
+        }),
+      );
+
+    /**
      * Auto-stage everything tracked + untracked, then create a single commit
      * with the user's message. Mirrors what the user would do in a basic
      * "commit all" UI; matches the GitHub Desktop "Commit Tracked + Untracked"
@@ -1043,6 +1181,7 @@ export const GitServiceLive = Layer.effect(
       prState,
       prDetails,
       changes,
+      diff,
       commit,
       push,
       fixFailingChecks,

--- a/apps/server/src/git/services/git-service.ts
+++ b/apps/server/src/git/services/git-service.ts
@@ -5,6 +5,7 @@ import {
   type GitChange,
   type GitCommandError,
   type GitCommit,
+  type GitDiffResult,
   type GitFailingChecksArtifact,
   type GitFolderNotFoundError,
   type GitNotARepoError,
@@ -49,6 +50,11 @@ export interface GitServiceShape {
     folderId: FolderId,
     worktreeId?: WorktreeId | null,
   ) => Effect.Effect<ReadonlyArray<GitChange>, GitFailure>;
+  readonly diff: (
+    folderId: FolderId,
+    path: string,
+    worktreeId?: WorktreeId | null,
+  ) => Effect.Effect<GitDiffResult, GitFailure>;
   readonly commit: (
     folderId: FolderId,
     message: string,

--- a/packages/wire/src/git.ts
+++ b/packages/wire/src/git.ts
@@ -300,6 +300,38 @@ export const GitChangesRpc = Rpc.make("git.changes", {
   error: GitErrors,
 });
 
+/**
+ * Diff modes returned by `git.diff`. `worktree` is the common case
+ * (tracked file with edits); `untracked` is a synthetic /dev/null diff
+ * for new files; `deleted` means the file is gone from the working
+ * tree but still in HEAD; `binary` and `unchanged` carry no patch text.
+ */
+export const GitDiffMode = Schema.Literal(
+  "worktree",
+  "untracked",
+  "deleted",
+  "binary",
+  "unchanged",
+);
+export type GitDiffMode = typeof GitDiffMode.Type;
+
+export class GitDiffResult extends Schema.Class<GitDiffResult>("GitDiffResult")({
+  mode: GitDiffMode,
+  patch: Schema.String,
+  truncated: Schema.Boolean,
+  bytes: Schema.Number,
+}) {}
+
+export const GitDiffRpc = Rpc.make("git.diff", {
+  payload: Schema.Struct({
+    folderId: FolderId,
+    worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
+    path: Schema.String,
+  }),
+  success: GitDiffResult,
+  error: GitErrors,
+});
+
 export const GitCommitRpc = Rpc.make("git.commit", {
   payload: Schema.Struct({
     folderId: FolderId,

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -26,6 +26,7 @@ import { FsReadFileRpc, FsTreeRpc, FsWriteFileRpc } from "./fs.ts";
 import {
   GitChangesRpc,
   GitCommitRpc,
+  GitDiffRpc,
   GitFixFailingChecksRpc,
   GitHeadChangedRpc,
   GitLogRpc,
@@ -139,6 +140,7 @@ export const MemoizeRpcs = RpcGroup.make(
   GitPrStateRpc,
   GitPrDetailsRpc,
   GitChangesRpc,
+  GitDiffRpc,
   GitCommitRpc,
   GitPushRpc,
   GitFixFailingChecksRpc,


### PR DESCRIPTION
## Summary
- New `git.diff` RPC (worktree vs HEAD, with `/dev/null` synthesis for untracked files, binary + truncation handling); wired through `GitServiceShape` + handlers.
- `OpenFile` gains `view: "edit" | "diff"`; refactored `FileEditor` into a shell with a Diff/Edit segmented toggle and a `PatchDiff` (`@pierre/diffs`) body alongside the existing CodeMirror body, which stays mounted across toggles to preserve unsaved edits.
- Click handlers default `view: "diff"` from the Changes panel and from Edit/Write/MultiEdit tool rows (file tree clicks stay on `edit`); `FileChip` / `FileBadge` thread the new prop.
- New `.fz-diff` CSS class overrides `@pierre/diffs` variables so additions read as the app's lime `--primary` against the app background instead of stock green/red on zinc.

## Test plan
- [ ] Modify a tracked file → click in Changes panel → diff appears; toggle Edit → CodeMirror loads same file; Cmd+S still saves.
- [ ] Run an agent that uses Edit/Write → click file chip in the tool row → main pane opens in diff mode.
- [ ] Create a new untracked file → click in Changes → diff shows all-additions vs `/dev/null`.
- [ ] Open a clean file via the Files tree → opens in Edit; toggle Diff → "No changes vs HEAD."