### PR TITLE
chore(release): 0.3.0 — rename app to "memoize Alpha"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to memoize will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+
+### Changed
+- **App renamed to "memoize Alpha"** to signal that this build is pre-1.0 and may contain bugs. The bundle identifier (`app.memoize.desktop`) is unchanged, so existing installs auto-update to the renamed app in place. Dock title, About panel, and macOS app menu now read "memoize Alpha"; the in-app brand and CLI / URL scheme stay as `memoize`.
+
+### Added
+- Full-pane diff view in the file viewer with a Diff / Edit toggle, so reviewing a tool's edits no longer requires scrolling between two side-by-side columns. (#93)
+- Worktree UX overhaul: new worktrees are created outside the repo root (no more accidental nesting in `git status`), get Pokémon-themed names instead of UUIDs, and the new-chat panel opens instantly instead of waiting for the worktree to materialize. (#92)
+- Local code index (MVP 0.04) — phases A–F land together with auto-reindex on file change, giving the agent a fast structural view of the repo without re-walking the tree on every query. (#86)
+
+### Changed
+- Renderer now has a single source of truth for the active directory and branch, replacing the previous fan-out of duplicated state across panels. (#91)
+
+### Fixed
+- Grok agent reliability on local login — the driver now uses the cached OAuth token instead of re-prompting on every session start. (#78)
+- Cursor driver: ACP now fails fast on auth errors instead of silently retrying, OAuth flow is wired end-to-end, the model list is refreshed on each session, and provider errors surface in the UI instead of being swallowed. (#90)
+- Settings writes occasionally raised `ENOENT` mid-rename when two writes raced. Writes through the config store are now serialized. (#89)
+- Provider boot crashes: codex no longer crashes when spawned without a TTY, missing cursor binaries surface a clear error, and claude/opencode gate correctly on availability. (#88)
+- Onboarding provider step tightened — copy now makes it clear that you pick a provider and go; no extra setup required. (#87)
+
 ## [0.2.1]
 
 ### Added

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: app.memoize.desktop
-productName: memoize
+productName: memoize Alpha
 copyright: © ${author}
 
 # Output the .dmg + latest-mac.yml + blockmap to repo-root/dist so all

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
-  "productName": "memoize",
-  "version": "0.2.1",
+  "productName": "memoize Alpha",
+  "version": "0.3.0",
   "description": "memoize desktop app",
   "private": true,
   "author": {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -65,7 +65,7 @@ protocol.registerSchemesAsPrivileged([
 const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL?.trim() || "";
 const isDevelopment = Boolean(DEV_SERVER_URL);
 
-const APP_NAME = isDevelopment ? "memoize (Dev)" : "memoize";
+const APP_NAME = isDevelopment ? "memoize Alpha (Dev)" : "memoize Alpha";
 
 app.setName(APP_NAME);
 
@@ -339,7 +339,7 @@ void app.whenReady().then(() => {
   // the app name. macOS reads these once at panel-open time, so it's safe
   // to call once on startup.
   app.setAboutPanelOptions({
-    applicationName: "memoize",
+    applicationName: "memoize Alpha",
     applicationVersion: app.getVersion(),
     version: app.getVersion(),
     copyright: "© Swaraj Bachu",


### PR DESCRIPTION
## Summary
- Bumps desktop app version `0.2.1` → `0.3.0` (minor)
- Renames the visible product to **memoize Alpha** to signal pre-1.0 quality
- `appId` is unchanged (`app.memoize.desktop`) so in-the-wild installs auto-update in place — they do not install as a second app
- Adds a `[0.3.0]` CHANGELOG section covering everything that landed since `v0.2.1`

## Why now
Releasing 0.3.0 publicly. Want the visible app name to communicate "this is still alpha, expect bugs" without losing the memoize identity. Pure "Alpha" would have lost the brand entirely; "memoize Alpha" is a defensible middle ground (revert before merge if you'd rather it be literally just `Alpha`).

## Release flow
After merge: tag `v0.3.0` on `main` → `.github/workflows/release.yml` builds, signs, notarizes, and publishes to a **draft** GitHub Release. Draft will be promoted to public so `electron-updater` picks it up for existing installs.

## Test plan
- [ ] CI build succeeds (signed, notarized .dmg + `latest-mac.yml`)
- [ ] Installed app's Dock/menu/About panel reads "memoize Alpha"
- [ ] Existing 0.2.1 install auto-updates to 0.3.0 in place (does not appear as a second app)