### PR TITLE
feat(right-pane): multi-terminal sub-sidebar + in-app browser tab

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -135,6 +135,10 @@ function createMainWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      // Enables the `<webview>` tag the in-app Browser tab uses. The webview
+      // itself still runs with `nodeIntegration: false` in its own process,
+      // so this only unlocks the element, not Node access inside it.
+      webviewTag: true,
     },
   });
 

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from "react";
+import { ArrowLeft, ArrowRight, RotateCw, Star } from "lucide-react";
+
+/**
+ * In-app Browser tab — toolbar (back/forward/refresh/URL bar) + Electron
+ * `<webview>`. The webview runs in its own process with `nodeIntegration:
+ * false` by default so arbitrary user-entered URLs can't reach the host.
+ *
+ * State is held locally: switching away from the Browser tab keeps the
+ * component mounted (RightPane uses `hidden` toggling), so URL bar value
+ * and the underlying webview's history stay alive across tab switches.
+ * Reloading the renderer resets the URL to blank — persistence is out of
+ * scope for v1.
+ */
+export function BrowserPane() {
+  const webviewRef = useRef<HTMLElement | null>(null);
+  const [url, setUrl] = useState<string>("");
+  const [inputValue, setInputValue] = useState<string>("");
+  const [canGoBack, setCanGoBack] = useState(false);
+  const [canGoForward, setCanGoForward] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Wire navigation lifecycle events onto the underlying webview element.
+  // We attach via `addEventListener` because the webview tag isn't a real
+  // React component — it's a Chromium-provided custom element.
+  useEffect(() => {
+    const el = webviewRef.current;
+    if (el === null) return;
+    const wv = el as WebviewElement;
+    const syncNav = () => {
+      try {
+        setCanGoBack(wv.canGoBack());
+        setCanGoForward(wv.canGoForward());
+      } catch {
+        // webview not ready yet — events fire later
+      }
+    };
+    const onDidNavigate = (e: Event) => {
+      const ev = e as Event & { url?: string };
+      if (typeof ev.url === "string") {
+        setUrl(ev.url);
+        setInputValue(ev.url);
+      }
+      syncNav();
+    };
+    const onStart = () => setIsLoading(true);
+    const onStop = () => {
+      setIsLoading(false);
+      syncNav();
+    };
+    el.addEventListener("did-navigate", onDidNavigate);
+    el.addEventListener("did-navigate-in-page", onDidNavigate);
+    el.addEventListener("did-start-loading", onStart);
+    el.addEventListener("did-stop-loading", onStop);
+    el.addEventListener("dom-ready", syncNav);
+    return () => {
+      el.removeEventListener("did-navigate", onDidNavigate);
+      el.removeEventListener("did-navigate-in-page", onDidNavigate);
+      el.removeEventListener("did-start-loading", onStart);
+      el.removeEventListener("did-stop-loading", onStop);
+      el.removeEventListener("dom-ready", syncNav);
+    };
+  }, []);
+
+  const navigate = (next: string) => {
+    const resolved = resolveUrl(next);
+    if (resolved === null) return;
+    setUrl(resolved);
+    setInputValue(resolved);
+    const wv = webviewRef.current as WebviewElement | null;
+    // Setting `src` programmatically also works, but loadURL is more
+    // predictable when the same URL is re-entered (forces a reload).
+    if (wv !== null) {
+      try {
+        void wv.loadURL(resolved);
+      } catch {
+        wv.src = resolved;
+      }
+    }
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (inputValue.trim() === "") return;
+    navigate(inputValue.trim());
+  };
+
+  const go = (dir: "back" | "forward") => {
+    const wv = webviewRef.current as WebviewElement | null;
+    if (wv === null) return;
+    try {
+      if (dir === "back" && wv.canGoBack()) wv.goBack();
+      if (dir === "forward" && wv.canGoForward()) wv.goForward();
+    } catch {
+      // ignore
+    }
+  };
+
+  const reload = () => {
+    const wv = webviewRef.current as WebviewElement | null;
+    if (wv === null) return;
+    try {
+      if (isLoading) wv.stop();
+      else wv.reload();
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-background">
+      <form
+        onSubmit={onSubmit}
+        className="flex h-9 shrink-0 items-center gap-1 border-b border-border px-2 text-xs"
+      >
+        <ToolbarButton
+          onClick={() => go("back")}
+          disabled={!canGoBack}
+          ariaLabel="Back"
+        >
+          <ArrowLeft className="size-3.5" />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => go("forward")}
+          disabled={!canGoForward}
+          ariaLabel="Forward"
+        >
+          <ArrowRight className="size-3.5" />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={reload}
+          disabled={url === ""}
+          ariaLabel={isLoading ? "Stop" : "Reload"}
+        >
+          <RotateCw
+            className={`size-3.5 ${isLoading ? "animate-spin" : ""}`}
+          />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => {
+            /* bookmark placeholder */
+          }}
+          disabled={true}
+          ariaLabel="Bookmark"
+        >
+          <Star className="size-3.5" />
+        </ToolbarButton>
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder="Search or enter URL"
+          spellCheck={false}
+          className="flex-1 rounded bg-transparent px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/70 focus:bg-muted/40"
+        />
+      </form>
+      <div className="relative min-h-0 flex-1">
+        {url === "" ? (
+          <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+            Type a URL above to start browsing.
+          </div>
+        ) : null}
+        <webview
+          ref={webviewRef as unknown as React.RefObject<HTMLElement>}
+          src={url === "" ? "about:blank" : url}
+          allowpopups={true}
+          style={{
+            display: url === "" ? "none" : "flex",
+            width: "100%",
+            height: "100%",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ToolbarButton({
+  onClick,
+  disabled,
+  ariaLabel,
+  children,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  ariaLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+    >
+      {children}
+    </button>
+  );
+}
+
+// Best-effort URL normalization: a string with a scheme passes through,
+// bare host[:port][/path] becomes https://… (except localhost / IP literals
+// which default to http so dev servers work without typing the scheme).
+function resolveUrl(input: string): string | null {
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
+  const isLocal =
+    /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:|\/|$)/i.test(trimmed);
+  return `${isLocal ? "http" : "https"}://${trimmed}`;
+}
+
+// Minimal surface of Electron's WebviewTag we actually use. Keeps the file
+// free of an `electron` import in the renderer (renderer is sandboxed and
+// imports from `electron` would land us in preload territory).
+type WebviewElement = HTMLElement & {
+  src: string;
+  loadURL: (url: string) => Promise<void>;
+  reload: () => void;
+  stop: () => void;
+  goBack: () => void;
+  goForward: () => void;
+  canGoBack: () => boolean;
+  canGoForward: () => boolean;
+};

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -8,6 +8,7 @@ import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
+import { BrowserPane } from "./browser-pane.tsx";
 import { DiffPane } from "./diff-pane.tsx";
 import { FileTree } from "./file-tree.tsx";
 import { PrPane } from "./pr-pane.tsx";
@@ -78,6 +79,12 @@ export function RightPane() {
           tooltip="Pull request title, reviews, comments, and CI"
           badge={renderPrBadge(pr, details)}
         />
+        <TabButton
+          active={tab === "browser"}
+          onClick={() => setTab("browser")}
+          label="Browser"
+          tooltip="In-app browser for dev servers and references"
+        />
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
         {selected === null ? (
@@ -103,6 +110,9 @@ export function RightPane() {
             </div>
             <div hidden={tab !== "pr"} className="min-h-0 flex-1">
               <PrPane folderId={selected.id} worktreeId={worktreeId} />
+            </div>
+            <div hidden={tab !== "browser"} className="min-h-0 flex-1">
+              <BrowserPane />
             </div>
           </>
         )}

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -2,14 +2,53 @@ import { useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Effect, Fiber, Stream } from "effect";
+import { Plus, SquareTerminal, X } from "lucide-react";
 
 import type { FolderId, PtyId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
+import {
+  EMPTY_TERMINALS,
+  type TerminalInstance,
+  terminalsKey,
+  useTerminalsStore,
+} from "../store/terminals.ts";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
+/**
+ * Right-pane terminal host. Owns the per-workspace terminal list + active
+ * selection (`useTerminalsStore`) and mounts a `PtyTerminal` for every
+ * instance, toggling visibility with `hidden` so switching between terminals
+ * preserves each one's xterm scrollback and PTY connection.
+ *
+ * Terminals are ephemeral: closing the renderer kills every PTY because the
+ * `PtyTerminal` cleanup runs on unmount. Persistence across reloads is out
+ * of scope.
+ */
 export function TerminalPane() {
   const ctx = useActiveContext();
+  const ready = ctx.status === "ready" && !ctx.worktreePending;
+  const key = ready ? terminalsKey(ctx.folderId, ctx.worktreeId) : null;
+  const list = useTerminalsStore((s) =>
+    key === null ? EMPTY_TERMINALS : s.byKey[key] ?? EMPTY_TERMINALS,
+  );
+  const activeId = useTerminalsStore((s) =>
+    key === null ? null : s.activeByKey[key] ?? null,
+  );
+  const ensureSeed = useTerminalsStore((s) => s.ensureSeed);
+  const add = useTerminalsStore((s) => s.add);
+  const remove = useTerminalsStore((s) => s.remove);
+  const setActive = useTerminalsStore((s) => s.setActive);
+
+  // Seed a first terminal whenever we land on a workspace with an empty
+  // list. Done in an effect (not render) so we don't call set() during
+  // another component's render.
+  const seedCwd = ctx.status === "ready" ? ctx.rootPath : null;
+  useEffect(() => {
+    if (key === null || !ready || seedCwd === null) return;
+    if (list.length === 0) ensureSeed(key, seedCwd);
+  }, [key, ready, list.length, ensureSeed, seedCwd]);
 
   if (ctx.status === "loading") {
     return (
@@ -35,13 +74,121 @@ export function TerminalPane() {
       </div>
     );
   }
+  if (key === null) return null;
 
-  // `key` includes worktreeId + rootPath so a worktree swap re-mounts with
-  // a fresh PTY rooted in the new path. `folderId` alone wouldn't catch
-  // worktree toggles within the same project. Live cwd migration of an
-  // existing PTY is out of scope.
-  const key = `${ctx.folderId}:${ctx.worktreeId ?? "main"}:${ctx.rootPath}`;
-  return <PtyTerminal key={key} folderId={ctx.folderId} cwd={ctx.rootPath} />;
+  const handleAdd = () => {
+    add(key, ctx.rootPath);
+  };
+  const handleClose = (id: string) => {
+    remove(key, id);
+    // If the user closed the last one, seed a fresh terminal so the pane
+    // is never empty — matches what a developer expects from a terminal
+    // dock: there's always a shell waiting.
+    if (list.length === 1) ensureSeed(key, ctx.rootPath);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 w-full">
+      <TerminalList
+        instances={list}
+        activeId={activeId}
+        onAdd={handleAdd}
+        onSelect={(id) => setActive(key, id)}
+        onClose={handleClose}
+      />
+      <div className="relative flex min-w-0 flex-1 flex-col bg-background">
+        {list.map((inst) => (
+          <div
+            key={inst.id}
+            hidden={inst.id !== activeId}
+            className="absolute inset-0 flex"
+          >
+            <PtyTerminal
+              folderId={ctx.folderId}
+              cwd={inst.cwd}
+              instanceId={inst.id}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TerminalList({
+  instances,
+  activeId,
+  onAdd,
+  onSelect,
+  onClose,
+}: {
+  instances: ReadonlyArray<TerminalInstance>;
+  activeId: string | null;
+  onAdd: () => void;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+}) {
+  const count = instances.length;
+  const label = count === 1 ? "1 Terminal" : `${count} Terminals`;
+  return (
+    <div className="flex w-44 shrink-0 flex-col border-r border-border bg-background/40">
+      <div className="flex h-7 shrink-0 items-center justify-between gap-1 border-b border-border/60 px-2 text-[11px] text-muted-foreground">
+        <span className="truncate">{label}</span>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={onAdd}
+                className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                aria-label="New terminal"
+              >
+                <Plus className="size-3.5" />
+              </button>
+            }
+          />
+          <TooltipPopup>New terminal</TooltipPopup>
+        </Tooltip>
+      </div>
+      <ul className="min-h-0 flex-1 overflow-y-auto py-1">
+        {instances.map((inst) => (
+          <li key={inst.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(inst.id)}
+              className={`group flex w-full items-center gap-1.5 px-2 py-1 text-left text-[12px] transition-colors ${
+                inst.id === activeId
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              }`}
+            >
+              <SquareTerminal className="size-3.5 shrink-0 opacity-70" />
+              <span className="flex-1 truncate">{inst.title}</span>
+              <span
+                role="button"
+                tabIndex={0}
+                aria-label={`Close ${inst.title}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(inst.id);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onClose(inst.id);
+                  }
+                }}
+                className="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-opacity hover:bg-background hover:text-foreground group-hover:opacity-100"
+              >
+                <X className="size-3" />
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 // xterm's canvas/webgl renderer takes literal color strings, not CSS vars,
@@ -58,7 +205,15 @@ function readToken(el: HTMLElement, cssVar: string, fallback: string): string {
   return computed || fallback;
 }
 
-function PtyTerminal({ folderId, cwd }: { folderId: FolderId; cwd: string }) {
+function PtyTerminal({
+  folderId,
+  cwd,
+  instanceId,
+}: {
+  folderId: FolderId;
+  cwd: string;
+  instanceId: string;
+}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -203,7 +358,9 @@ function PtyTerminal({ folderId, cwd }: { folderId: FolderId; cwd: string }) {
       }
       term.dispose();
     };
-  }, [folderId, cwd]);
+    // Instance id is part of the deps so swapping instances re-opens cleanly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folderId, cwd, instanceId]);
 
   return (
     <div ref={containerRef} className="h-full w-full bg-background p-2" />

--- a/apps/renderer/src/store/terminals.ts
+++ b/apps/renderer/src/store/terminals.ts
@@ -1,0 +1,97 @@
+import { create } from "zustand";
+
+import type { FolderId, WorktreeId } from "@memoize/wire";
+
+/**
+ * Renderer-side terminal instances. The PTY itself lives on the server and
+ * is opened lazily by the `PtyTerminal` component when its container mounts
+ * — this store only tracks the list of slots the user wants to see and which
+ * one is focused. PTYs die with the renderer (no rehydration across reloads).
+ *
+ * Keyed by `(folderId, worktreeId)` so each workspace gets its own list and
+ * switching projects/worktrees doesn't shuffle terminals between them.
+ */
+export type TerminalInstance = {
+  readonly id: string;
+  readonly title: string;
+  readonly cwd: string;
+};
+
+type TerminalsState = {
+  readonly byKey: Readonly<Record<string, ReadonlyArray<TerminalInstance>>>;
+  readonly activeByKey: Readonly<Record<string, string | null>>;
+  readonly ensureSeed: (key: string, cwd: string) => void;
+  readonly add: (key: string, cwd: string) => string;
+  readonly remove: (key: string, id: string) => void;
+  readonly setActive: (key: string, id: string) => void;
+};
+
+export const terminalsKey = (
+  folderId: FolderId,
+  worktreeId: WorktreeId | null,
+): string => `${folderId}:${worktreeId ?? "main"}`;
+
+const newId = (): string =>
+  globalThis.crypto?.randomUUID?.() ??
+  `t-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+const nextTitle = (existing: ReadonlyArray<TerminalInstance>): string => {
+  if (existing.length === 0) return "zsh";
+  // "zsh", "zsh 2", "zsh 3" — skip numbers already in use so closing the
+  // middle one and adding again reuses the gap rather than racing past it.
+  const used = new Set(existing.map((t) => t.title));
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `zsh ${n}`;
+    if (!used.has(candidate)) return candidate;
+  }
+  return `zsh ${existing.length + 1}`;
+};
+
+export const useTerminalsStore = create<TerminalsState>((set) => ({
+  byKey: {},
+  activeByKey: {},
+  ensureSeed: (key, cwd) =>
+    set((state) => {
+      if ((state.byKey[key]?.length ?? 0) > 0) return state;
+      const instance: TerminalInstance = { id: newId(), title: "zsh", cwd };
+      return {
+        byKey: { ...state.byKey, [key]: [instance] },
+        activeByKey: { ...state.activeByKey, [key]: instance.id },
+      };
+    }),
+  add: (key, cwd) => {
+    const id = newId();
+    set((state) => {
+      const list = state.byKey[key] ?? [];
+      const instance: TerminalInstance = { id, title: nextTitle(list), cwd };
+      return {
+        byKey: { ...state.byKey, [key]: [...list, instance] },
+        activeByKey: { ...state.activeByKey, [key]: id },
+      };
+    });
+    return id;
+  },
+  remove: (key, id) =>
+    set((state) => {
+      const list = state.byKey[key] ?? [];
+      const idx = list.findIndex((t) => t.id === id);
+      if (idx === -1) return state;
+      const next = list.filter((t) => t.id !== id);
+      const wasActive = state.activeByKey[key] === id;
+      // Pick the previous instance when closing the active one; if that
+      // doesn't exist, fall back to whatever now sits in the same slot.
+      const fallback = wasActive
+        ? (next[Math.max(0, idx - 1)]?.id ?? null)
+        : (state.activeByKey[key] ?? null);
+      return {
+        byKey: { ...state.byKey, [key]: next },
+        activeByKey: { ...state.activeByKey, [key]: fallback },
+      };
+    }),
+  setActive: (key, id) =>
+    set((state) => ({
+      activeByKey: { ...state.activeByKey, [key]: id },
+    })),
+}));
+
+export const EMPTY_TERMINALS: ReadonlyArray<TerminalInstance> = [];

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -32,7 +32,7 @@ export type MainTab = "chat" | "file";
  * Tabs in the right-hand workspace pane. Lifted from `RightPane`'s local
  * state so the native menu (Cmd+J → Toggle Terminal) can drive it.
  */
-export type RightTab = "files" | "terminal" | "changes" | "pr";
+export type RightTab = "files" | "terminal" | "changes" | "pr" | "browser";
 
 /**
  * Which body the file viewer is showing. `edit` is the CodeMirror editor;

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

- **Multi-terminal**: Terminal tab gets a per-workspace sub-sidebar (`store/terminals.ts`) with + to spawn, click-to-switch, hover-X to close. All instances stay mounted under `hidden` toggling so xterm scrollback survives switches; closing the last terminal re-seeds a fresh one. Server-side PTY service already supported many instances — renderer-only change.
- **In-app Browser tab**: 5th right-pane tab driven by Electron `<webview>` with back/forward/refresh and a URL bar. Bare hosts default to `https://`, except `localhost` / `127.0.0.1` which default to `http://` for dev servers. Enabled via `webviewTag: true` in the main `BrowserWindow`'s `webPreferences`; the webview runs in its own sandboxed process with `nodeIntegration: false`.
- Terminals are ephemeral (no rehydration across reloads); browser URL also resets on reload.

## Test plan

- [ ] `bun run dev`, open a project → Terminal tab seeds one zsh; `+` opens a second; switch back and forth, scrollback persists; close one via the hover-X.
- [ ] Closing the last terminal auto-seeds a fresh one (pane never empty).
- [ ] Switch workspaces/worktrees → terminal list is keyed per workspace.
- [ ] Browser tab loads `news.ycombinator.com` and `http://localhost:5173`; back/forward enable correctly; refresh reloads.