### PR TITLE
fix(cursor): prewarm, real model slugs, session/load, tool-call logs

### DIFF
--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -219,34 +219,70 @@ const buildCanonicalInput = (
 ): unknown => {
   const title = typeof u["title"] === "string" ? (u["title"] as string) : null;
 
+  // Cursor stuffs the tool arguments under `rawInput` instead of `input` /
+  // `arguments` / `locations` — merge it into the lookup so the per-tool
+  // cases below can find `file_path`/`path`/`command`/etc the same way as
+  // for other providers.
+  const rawInput =
+    u["rawInput"] !== null &&
+    typeof u["rawInput"] === "object" &&
+    Object.keys(u["rawInput"] as Record<string, unknown>).length > 0
+      ? (u["rawInput"] as Record<string, unknown>)
+      : null;
+
+  const pathFrom = (src: Record<string, unknown>): string | null => {
+    const v =
+      typeof src["file_path"] === "string"
+        ? (src["file_path"] as string)
+        : typeof src["filePath"] === "string"
+          ? (src["filePath"] as string)
+          : typeof src["path"] === "string"
+            ? (src["path"] as string)
+            : null;
+    return v !== null && v.length > 0 ? v : null;
+  };
+
   switch (toolName) {
     case "Edit":
     case "MultiEdit": {
       const diff = extractDiffBlock(u["content"]);
       if (diff !== null) {
         return {
-          file_path: diff.path ?? firstLocationPath(u) ?? "",
+          file_path:
+            diff.path ??
+            firstLocationPath(u) ??
+            (rawInput !== null ? pathFrom(rawInput) : null) ??
+            "",
           old_string: diff.oldText,
           new_string: diff.newText,
         };
       }
-      const file_path = firstLocationPath(u);
+      const file_path =
+        firstLocationPath(u) ??
+        (rawInput !== null ? pathFrom(rawInput) : null);
       if (file_path !== null) return { file_path };
       break;
     }
     case "Write": {
-      const file_path = firstLocationPath(u);
+      const file_path =
+        firstLocationPath(u) ??
+        (rawInput !== null ? pathFrom(rawInput) : null);
       const content =
         typeof u["content"] === "string"
           ? (u["content"] as string)
-          : extractMessageText(u["content"]);
+          : extractMessageText(u["content"]) ??
+            (rawInput !== null && typeof rawInput["content"] === "string"
+              ? (rawInput["content"] as string)
+              : null);
       const out: Record<string, unknown> = {};
       if (file_path !== null) out["file_path"] = file_path;
       if (content !== null) out["content"] = content;
       return Object.keys(out).length > 0 ? out : null;
     }
     case "Read": {
-      const file_path = firstLocationPath(u);
+      const file_path =
+        firstLocationPath(u) ??
+        (rawInput !== null ? pathFrom(rawInput) : null);
       if (file_path !== null) {
         const out: Record<string, unknown> = { file_path };
         if (typeof u["offset"] === "number") out["offset"] = u["offset"];
@@ -261,7 +297,9 @@ const buildCanonicalInput = (
           ? (u["command"] as string)
           : typeof u["cmd"] === "string"
             ? (u["cmd"] as string)
-            : null;
+            : rawInput !== null && typeof rawInput["command"] === "string"
+              ? (rawInput["command"] as string)
+              : null;
       if (command !== null) {
         const out: Record<string, unknown> = { command };
         if (title !== null) out["description"] = title;
@@ -272,9 +310,10 @@ const buildCanonicalInput = (
     case "Grep":
     case "Glob": {
       const out: Record<string, unknown> = {};
-      if (typeof u["pattern"] === "string") out["pattern"] = u["pattern"];
-      if (typeof u["path"] === "string") out["path"] = u["path"];
-      if (typeof u["glob"] === "string") out["glob"] = u["glob"];
+      const src = rawInput ?? u;
+      if (typeof src["pattern"] === "string") out["pattern"] = src["pattern"];
+      if (typeof src["path"] === "string") out["path"] = src["path"];
+      if (typeof src["glob"] === "string") out["glob"] = src["glob"];
       if (Object.keys(out).length > 0) return out;
       break;
     }
@@ -363,6 +402,15 @@ const extractToolName = (u: Record<string, unknown>): string => {
 const extractOutput = (u: Record<string, unknown>): unknown => {
   if (u["output"] !== undefined) {
     const o = u["output"];
+    if (o !== null && typeof o === "object" && "content" in o) {
+      return (o as Record<string, unknown>)["content"] ?? o;
+    }
+    return o;
+  }
+  // Cursor's spelling: `rawOutput.content` carries the actual result payload
+  // (file contents for Read, command stdout for Bash, etc).
+  if (u["rawOutput"] !== undefined) {
+    const o = u["rawOutput"];
     if (o !== null && typeof o === "object" && "content" in o) {
       return (o as Record<string, unknown>)["content"] ?? o;
     }
@@ -460,6 +508,13 @@ interface ToolCallState {
   resultEmitted: boolean;
   /** True once we've emitted a `ToolUse` for this call. */
   useEmitted: boolean;
+  /**
+   * Canonical tool name (e.g. "Read", "Edit") captured from the FIRST
+   * frame for this call. Cursor's `tool_call_update` frames carry no
+   * `kind` field, so without this we'd fall back to the generic "tool"
+   * label on every update and lose the input mapping (diff blocks etc).
+   */
+  toolName: string | null;
 }
 
 /**
@@ -532,7 +587,12 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
   const getOrInitToolState = (id: string): ToolCallState => {
     let s = toolStates.get(id);
     if (s === undefined) {
-      s = { lastInputJson: null, resultEmitted: false, useEmitted: false };
+      s = {
+        lastInputJson: null,
+        resultEmitted: false,
+        useEmitted: false,
+        toolName: null,
+      };
       toolStates.set(id, s);
     }
     return s;
@@ -617,6 +677,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           const input = buildCanonicalInput(toolName, u);
           const inputJson = safeStringify({ input });
           const state = getOrInitToolState(callId);
+          // Pin the canonical tool name on first sight so later update
+          // frames (which omit `kind` for Cursor) still resolve to the
+          // right Edit/Read/Write/Bash branch in buildCanonicalInput.
+          if (state.toolName === null) state.toolName = toolName;
           // Dedupe: if we already emitted ToolUse with this exact input,
           // skip. Happens when an ACP server sends the same `tool_call`
           // twice (some implementations do for pending/in_progress).
@@ -656,10 +720,19 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
             typeof u["kind"] === "string" ? (u["kind"] as string) : null;
           if (provider === "gemini" && rawKind === "think") return [];
           const callId = extractCallId(u);
-          const toolName = extractToolName(u);
+          const state = getOrInitToolState(callId);
+          // Prefer the tool name we captured from the original tool_call —
+          // cursor's update frames carry no `kind`, so re-extracting would
+          // collapse to the generic "tool" label and break the Edit/Read/…
+          // input mapping in buildCanonicalInput.
+          const updateToolName = extractToolName(u);
+          const toolName =
+            state.toolName !== null && state.toolName !== "tool"
+              ? state.toolName
+              : updateToolName;
+          if (state.toolName === null) state.toolName = toolName;
           logUnknownToolIfNeeded(provider, u, toolName, "tool_call_update");
           const input = buildCanonicalInput(toolName, u);
-          const state = getOrInitToolState(callId);
           const events: AgentEvent[] = [];
 
           // Re-emit ToolUse only when input changed substantively —

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -1,9 +1,13 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
 import * as readline from "node:readline";
 import { Effect, Mailbox, Stream } from "effect";
 
 import {
   AgentSessionStartError,
+  resolveModelSlug,
   type AgentEvent,
   type AgentItemId,
   type AgentSessionId,
@@ -77,6 +81,57 @@ type PendingResolver = {
 const CURSOR_RPC_TRACE = process.env.MEMOIZE_DEBUG_CURSOR === "1";
 
 /**
+ * File-tee location for cursor phase logs. Survives bun dev-server stdout
+ * multiplexing so `tail -f ~/.cache/memoize/cursor.log` gives a clean
+ * timeline across restarts. Best-effort — falls back to tmpdir if HOME
+ * isn't writable.
+ */
+const CURSOR_LOG_PATH = ((): string => {
+  try {
+    const base = process.env.HOME ? homedir() : tmpdir();
+    const dir = join(base, ".cache", "memoize");
+    mkdirSync(dir, { recursive: true });
+    return join(dir, "cursor.log");
+  } catch {
+    return join(tmpdir(), "memoize-cursor.log");
+  }
+})();
+
+const writeCursorLog = (line: string): void => {
+  process.stderr.write(line);
+  try {
+    appendFileSync(CURSOR_LOG_PATH, line);
+  } catch {
+    // best-effort — file logging shouldn't break the session
+  }
+};
+
+// One-time banner at module load so the user knows where to tail.
+process.stderr.write(`[cursor] phase logs → ${CURSOR_LOG_PATH}\n`);
+
+type PhaseLogger = (phase: string, detail?: string) => void;
+
+/**
+ * Always-on phase logger. Prints `[cursor.t+123ms] phase …` so the user can
+ * see where slowness comes from (spawn vs initialize vs authenticate vs
+ * session/new vs first prompt → first chunk → completion) without needing
+ * to flip MEMOIZE_DEBUG_CURSOR. Tees to a file at CURSOR_LOG_PATH for easy
+ * inspection. Granular RPC tracing is still gated by MEMOIZE_DEBUG_CURSOR.
+ */
+const makePhaseLogger = (tagSuffix: string): PhaseLogger => {
+  const t0 = Date.now();
+  const tag = `cursor.${tagSuffix.slice(0, 8)}`;
+  return (phase: string, detail?: string) => {
+    const dt = Date.now() - t0;
+    const ts = new Date().toISOString();
+    const line = detail
+      ? `${ts} [${tag} t+${dt}ms] ${phase} — ${detail}\n`
+      : `${ts} [${tag} t+${dt}ms] ${phase}\n`;
+    writeCursorLog(line);
+  };
+};
+
+/**
  * Build a human-readable error from a JSON-RPC error envelope. ACP servers
  * commonly stash the real failure in `error.data`; `stderrTail` is the
  * trailing chunk of cursor-agent's stderr captured during this session, used
@@ -127,6 +182,406 @@ const formatRpcError = (
 };
 
 /**
+ * Transport handed off from `connectAndAuthenticateCursor` to the per-session
+ * code in `startCursorSession`. Owns the child process, the JSON-RPC pending
+ * map, and the rl/stderr/error/close listeners. Initial handlers are noops;
+ * `startCursorSession` swaps in real handlers when it takes ownership so the
+ * same listener set serves both the prewarm idle phase and the live session.
+ */
+interface CursorReadyTransport {
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly rl: readline.Interface;
+  readonly pending: Map<number, PendingResolver>;
+  readonly request: (
+    method: string,
+    params: unknown,
+    timeoutMs?: number,
+    onAssignedId?: (id: number) => void,
+  ) => Promise<unknown>;
+  readonly notify: (method: string, params: unknown) => void;
+  readonly writeMessage: (msg: Record<string, unknown>) => void;
+  readonly getStderrTail: () => string;
+  /** Swap in a handler for incoming `session/update` notifications. */
+  setSessionUpdateHandler(h: (update: unknown) => void): void;
+  /** Swap in a handler for child stderr chunks (after the prewarm tail buffer). */
+  setStderrHandler(h: (chunk: string) => void): void;
+  /** Swap in a handler for child close. Called with a human-readable detail. */
+  setCloseHandler(h: (detail: string) => void): void;
+  /** Swap in a handler for spawn-time errors. */
+  setSpawnErrorHandler(h: (message: string) => void): void;
+}
+
+/**
+ * Spawn `cursor-agent acp`, run `initialize` and `authenticate`, return a
+ * transport ready for `session/new` or `session/load`. Both the prewarm
+ * pump and the live `startCursorSession` path call this — prewarm consumes
+ * the result later (after auth has already paid its ~8s cost), saving the
+ * user that latency on the very first prompt.
+ *
+ * The transport's rl/child listeners are installed once here and dispatch
+ * through swappable handler slots (initially noops). When `startCursorSession`
+ * takes ownership it swaps in real handlers so the same listener set serves
+ * both phases without re-attaching to the streams.
+ */
+const connectAndAuthenticateCursor = async (
+  cursorPath: string,
+  apiKey: string | null,
+  log: PhaseLogger,
+): Promise<CursorReadyTransport> => {
+  log(
+    "spawn",
+    `path=${cursorPath} apiKey=${apiKey === null ? "no" : "yes"}`,
+  );
+  const child = spawn(cursorPath, ["acp"], {
+    cwd: process.env.HOME ?? process.cwd(),
+    env: {
+      ...process.env,
+      ...(apiKey !== null ? { CURSOR_API_KEY: apiKey } : {}),
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  log("spawn-ok", `pid=${child.pid ?? "?"}`);
+
+  child.stdout.setEncoding("utf-8");
+  child.stderr.setEncoding("utf-8");
+  const rl = readline.createInterface({ input: child.stdout });
+
+  const pending = new Map<number, PendingResolver>();
+  let nextRpcId = 1;
+  let stderrTail = "";
+
+  // Handler slots — set to noops/sane defaults during prewarm; replaced by
+  // startCursorSession on takeover.
+  let sessionUpdateHandler: (update: unknown) => void = () => {};
+  let stderrHandler: (chunk: string) => void = () => {};
+  let closeHandler: (detail: string) => void = () => {};
+  let spawnErrorHandler: (message: string) => void = () => {};
+
+  const writeMessage = (msg: Record<string, unknown>): void => {
+    if (!child.stdin.writable) return;
+    const line = JSON.stringify(msg);
+    if (CURSOR_RPC_TRACE) writeCursorLog(`[cursor.rpc.send] ${line}\n`);
+    child.stdin.write(`${line}\n`);
+  };
+
+  const request = (
+    method: string,
+    params: unknown,
+    timeoutMs = 30_000,
+    onAssignedId?: (id: number) => void,
+  ): Promise<unknown> => {
+    const id = nextRpcId++;
+    onAssignedId?.(id);
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        const trimmedStderr = stderrTail.trim();
+        const detail =
+          trimmedStderr.length > 0 ? ` — stderr: ${trimmedStderr}` : "";
+        reject(
+          new Error(
+            `Cursor ACP ${method} timed out after ${timeoutMs}ms${detail}`,
+          ),
+        );
+      }, timeoutMs);
+      pending.set(id, { method, resolve, reject, timer });
+      writeMessage({ jsonrpc: "2.0", id, method, params });
+    });
+  };
+
+  const notify = (method: string, params: unknown): void => {
+    writeMessage({ jsonrpc: "2.0", method, params });
+  };
+
+  rl.on("line", (line: string) => {
+    if (line.trim().length === 0) return;
+    if (CURSOR_RPC_TRACE) writeCursorLog(`[cursor.rpc.recv] ${line}\n`);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (parsed === null || typeof parsed !== "object") return;
+    const msg = parsed as JsonRpcMessage;
+
+    if (typeof msg.method === "string") {
+      if (msg.method === "session/update") {
+        const update = msg.params?.update;
+        if (update !== undefined) sessionUpdateHandler(update);
+        return;
+      }
+      if (msg.id !== undefined) {
+        const isFs = msg.method.startsWith("fs/");
+        if (CURSOR_RPC_TRACE || isFs) {
+          writeCursorLog(
+            `[cursor.rpc] server→client request method=${msg.method} id=${msg.id} params=${JSON.stringify(msg.params ?? {})}\n`,
+          );
+        }
+        if (isFs) {
+          writeMessage({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: {
+              code: -32601,
+              message: `Method not implemented by memoize ACP client: ${msg.method}`,
+            },
+          });
+          return;
+        }
+        console.warn(
+          `[cursor.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
+        );
+        return;
+      }
+      return;
+    }
+
+    const id = typeof msg.id === "number" ? msg.id : null;
+    if (id === null) return;
+    const resolver = pending.get(id);
+    if (resolver === undefined) return;
+    pending.delete(id);
+    clearTimeout(resolver.timer);
+    if (msg.error !== undefined) {
+      try {
+        writeCursorLog(
+          `[cursor.rpc.error] method=${resolver.method} id=${id} ${JSON.stringify(msg.error)}\n`,
+        );
+      } catch {
+        writeCursorLog(
+          `[cursor.rpc.error] method=${resolver.method} id=${id} (unserialisable)\n`,
+        );
+      }
+      const detail = formatRpcError(msg.error, stderrTail);
+      resolver.reject(new Error(`Cursor ${resolver.method} failed: ${detail}`));
+    } else {
+      resolver.resolve(msg.result ?? {});
+    }
+  });
+
+  child.stderr.on("data", (chunk: string) => {
+    stderrTail = (stderrTail + chunk).slice(-4096);
+    writeCursorLog(`[cursor.stderr] ${chunk}`);
+    stderrHandler(chunk);
+  });
+
+  // Reject pending requests on spawn-time errors (ENOENT/EACCES) so the
+  // initialize handshake fails cleanly instead of waiting for a timeout
+  // that never resolves. Mirrors the codex client fix.
+  child.once("error", (err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    for (const { reject, timer } of pending.values()) {
+      clearTimeout(timer);
+      reject(new Error(message));
+    }
+    pending.clear();
+    spawnErrorHandler(message);
+  });
+
+  child.on("close", (code, signal) => {
+    rl.close();
+    const trimmedStderr = stderrTail.trim();
+    const exitDetail = trimmedStderr.length > 0
+      ? `Cursor ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${trimmedStderr}`
+      : `Cursor ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;
+    for (const { reject, timer } of pending.values()) {
+      clearTimeout(timer);
+      reject(new Error(exitDetail));
+    }
+    pending.clear();
+    closeHandler(exitDetail);
+  });
+
+  // initialize — short timeout. Old cursor-agent (no `acp` subcommand)
+  // silently treats it as a chat prompt; detect and fail fast.
+  log("initialize.req");
+  const initStart = Date.now();
+  let init: { authMethods?: ReadonlyArray<{ id?: unknown }> };
+  try {
+    init = (await request(
+      "initialize",
+      {
+        protocolVersion: 1,
+        clientCapabilities: {
+          fs: {
+            readTextFile: true,
+            writeTextFile: true,
+            readDirectory: true,
+            createDirectory: true,
+            deleteFile: true,
+            moveFile: true,
+          },
+          terminal: true,
+          _meta: { parameterizedModelPicker: true },
+        },
+      },
+      5_000,
+    )) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
+  } catch (cause) {
+    child.kill("SIGTERM");
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    if (/timed out/i.test(reason)) {
+      throw new Error(
+        "Cursor Agent is too old (no ACP support). Run `cursor-agent update` (need ≥ 2025.11) and try again.",
+      );
+    }
+    throw cause;
+  }
+
+  const authIds = new Set(
+    (init.authMethods ?? [])
+      .map((m) => (typeof m?.id === "string" ? m.id : null))
+      .filter((id): id is string => id !== null),
+  );
+  log(
+    "initialize.ok",
+    `${Date.now() - initStart}ms authMethods=[${Array.from(authIds).join(",") || "(none)"}]`,
+  );
+
+  const methodId =
+    authIds.has("cursor_login")
+      ? "cursor_login"
+      : authIds.has("cached_token")
+        ? "cached_token"
+        : null;
+  if (methodId === null) {
+    child.kill("SIGTERM");
+    throw new Error(
+      'Cursor is not signed in. Click "Sign in" on the Cursor provider card, run `cursor-agent login` in a terminal, or paste a Cursor API key.',
+    );
+  }
+  log("authenticate.req", `methodId=${methodId}`);
+  const authStart = Date.now();
+  await request("authenticate", { methodId, _meta: { headless: true } });
+  log("authenticate.ok", `${Date.now() - authStart}ms`);
+
+  return {
+    child,
+    rl,
+    pending,
+    request,
+    notify,
+    writeMessage,
+    getStderrTail: () => stderrTail,
+    setSessionUpdateHandler(h) {
+      sessionUpdateHandler = h;
+    },
+    setStderrHandler(h) {
+      stderrHandler = h;
+    },
+    setCloseHandler(h) {
+      closeHandler = h;
+    },
+    setSpawnErrorHandler(h) {
+      spawnErrorHandler = h;
+    },
+  };
+};
+
+// ====================================================================
+// Prewarm pool (size 1) — keeps an authenticated child standing by so the
+// first user-triggered session skips the ~8s authenticate roundtrip and
+// the spawn cost. After a prewarmed transport is consumed, we
+// fire-and-forget a re-prewarm so the *next* session also lands fast.
+// ====================================================================
+
+let prewarmSlot: Promise<CursorReadyTransport> | null = null;
+let prewarmKey: string | null = null;
+
+const keyFor = (cursorPath: string, apiKey: string | null): string =>
+  `${cursorPath}|${apiKey ?? ""}`;
+
+/**
+ * Kick off (or refresh) a prewarmed cursor-agent child. Safe to call
+ * repeatedly — no-op if a prewarm with the same cursorPath+apiKey is
+ * already in flight or settled.
+ *
+ * Called by `provider-service` at boot, and again right after we consume
+ * a prewarmed transport so the next session is also fast.
+ */
+export const prewarmCursor = (
+  cursorPath: string,
+  apiKey: string | null,
+): void => {
+  const key = keyFor(cursorPath, apiKey);
+  // If a prewarm for a different config is currently in the slot, drop it
+  // (its child will be GC'd when the user takes a fresh one). The user
+  // changed credentials or binary path; the old warm child is no longer
+  // useful.
+  if (prewarmSlot !== null && prewarmKey !== null && prewarmKey !== key) {
+    prewarmSlot
+      .then((t) => t.child.kill("SIGTERM"))
+      .catch(() => undefined);
+    prewarmSlot = null;
+    prewarmKey = null;
+  }
+  if (prewarmSlot !== null) return;
+
+  const log = makePhaseLogger("prewarm");
+  prewarmKey = key;
+  prewarmSlot = connectAndAuthenticateCursor(cursorPath, apiKey, log).then(
+    (transport) => {
+      // Wire a default close handler so a child that dies in the slot
+      // doesn't leak the promise. Once consumed, startCursorSession will
+      // overwrite this.
+      transport.setCloseHandler(() => {
+        if (prewarmSlot !== null) {
+          prewarmSlot = null;
+          prewarmKey = null;
+        }
+      });
+      log("prewarm.ready");
+      return transport;
+    },
+    (err) => {
+      const reason = err instanceof Error ? err.message : String(err);
+      log("prewarm.fail", reason);
+      prewarmSlot = null;
+      prewarmKey = null;
+      throw err;
+    },
+  );
+};
+
+/**
+ * Pull the prewarmed transport if one is available, otherwise connect
+ * fresh. Either way, schedule a re-prewarm so the next session is fast.
+ */
+const takeReadyCursor = async (
+  cursorPath: string,
+  apiKey: string | null,
+  log: PhaseLogger,
+): Promise<CursorReadyTransport> => {
+  const key = keyFor(cursorPath, apiKey);
+  if (prewarmSlot !== null && prewarmKey === key) {
+    const slot = prewarmSlot;
+    prewarmSlot = null;
+    prewarmKey = null;
+    log("prewarm.hit");
+    try {
+      const transport = await slot;
+      // Schedule a re-prewarm in the background.
+      setImmediate(() => prewarmCursor(cursorPath, apiKey));
+      return transport;
+    } catch {
+      log("prewarm.broken", "fell back to fresh connect");
+    }
+  } else if (prewarmSlot !== null) {
+    log(
+      "prewarm.miss",
+      `key mismatch: have=${prewarmKey ?? "(none)"} want=${key}`,
+    );
+  } else {
+    log("prewarm.miss", "no warm child available");
+  }
+  // No warm child usable — connect fresh and start prewarming in parallel
+  // so subsequent sessions still benefit.
+  setImmediate(() => prewarmCursor(cursorPath, apiKey));
+  return connectAndAuthenticateCursor(cursorPath, apiKey, log);
+};
+
+/**
  * Spin up a Cursor Agent conversation backed by a persistent ACP child
  * process. The handshake (`initialize` → `authenticate` → `session/new`)
  * runs once synchronously inside `start()`; auth or transport failures
@@ -152,11 +607,11 @@ export const startCursorSession = (
 
     let currentMode: PermissionMode = input.permissionMode ?? "default";
     let acpSessionId: string | null = null;
-    let nextRpcId = 1;
     let closed = false;
     let inflight: Promise<void> = Promise.resolve();
-    const pending = new Map<number, PendingResolver>();
-    let stderrTail = "";
+    const log = makePhaseLogger(String(sessionId));
+    let promptCount = 0;
+    let firstChunkSeenForPrompt = false;
 
     events.unsafeOffer({
       _tag: "Started",
@@ -165,70 +620,127 @@ export const startCursorSession = (
       mode: "sdk",
     });
 
-    // Per-session translator coalesces agent_message_chunk deltas into
-    // one AssistantMessage per burst so the renderer doesn't show one
-    // bubble per token.
     const translator = createAcpTranslator("cursor");
 
-    let child: ChildProcessWithoutNullStreams;
-    try {
-      child = spawn(cursorPath, ["acp"], {
-        cwd,
-        env: {
-          ...process.env,
-          ...(apiKey !== null ? { CURSOR_API_KEY: apiKey } : {}),
-        },
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-    } catch (cause) {
-      yield* events.end;
-      return yield* Effect.fail(
+    log(
+      "session.start",
+      `cwd=${cwd} model=${input.model ?? "(default)"} mode=${currentMode} apiKey=${apiKey === null ? "no" : "yes"}`,
+    );
+
+    // Try to take a prewarmed transport (skips spawn + init + auth, saving
+    // ~8s). Falls back to a fresh spawn+handshake on cache miss. Schedules
+    // a re-prewarm for the next session either way.
+    const transportResult = yield* Effect.tryPromise({
+      try: () => takeReadyCursor(cursorPath, apiKey, log),
+      catch: (cause) =>
         new AgentSessionStartError({
           providerId: "cursor",
           reason: cause instanceof Error ? cause.message : String(cause),
         }),
-      );
-    }
+    });
+    const { child, rl, pending, request, notify, getStderrTail } =
+      transportResult;
 
-    child.stdout.setEncoding("utf-8");
-    child.stderr.setEncoding("utf-8");
-    const rl = readline.createInterface({ input: child.stdout });
+    // === Wire session-level handlers onto the (possibly prewarmed) transport.
+    transportResult.setSessionUpdateHandler((update) => {
+      if (closed) return;
+      if (!firstChunkSeenForPrompt) {
+        firstChunkSeenForPrompt = true;
+        log("prompt.first-update");
+      }
 
-    const writeMessage = (msg: Record<string, unknown>): void => {
-      if (!child.stdin.writable) return;
-      const line = JSON.stringify(msg);
-      if (CURSOR_RPC_TRACE) process.stderr.write(`[cursor.rpc.send] ${line}\n`);
-      child.stdin.write(`${line}\n`);
-    };
-
-    const request = (
-      method: string,
-      params: unknown,
-      timeoutMs = 30_000,
-      onAssignedId?: (id: number) => void,
-    ): Promise<unknown> => {
-      const id = nextRpcId++;
-      onAssignedId?.(id);
-      return new Promise<unknown>((resolve, reject) => {
-        const timer = setTimeout(() => {
-          pending.delete(id);
-          const trimmedStderr = stderrTail.trim();
-          const detail =
-            trimmedStderr.length > 0 ? ` — stderr: ${trimmedStderr}` : "";
-          reject(
-            new Error(
-              `Cursor ACP ${method} timed out after ${timeoutMs}ms${detail}`,
-            ),
+      // Log tool-related frames raw so we can see exactly what shape cursor
+      // sends and compare against what the translator produced. Text deltas
+      // (agent_message_chunk) and reasoning deltas are skipped — they'd
+      // drown the file in noise.
+      if (update !== null && typeof update === "object") {
+        const u = update as Record<string, unknown>;
+        const kind =
+          typeof u["sessionUpdate"] === "string"
+            ? (u["sessionUpdate"] as string)
+            : typeof u["type"] === "string"
+              ? (u["type"] as string)
+              : null;
+        const isToolish =
+          kind === "tool_call" ||
+          kind === "tool_call_update" ||
+          kind === "tool_result" ||
+          kind === "tool_output";
+        if (isToolish) {
+          let raw: string;
+          try {
+            raw = JSON.stringify(u);
+          } catch {
+            raw = "(unserialisable)";
+          }
+          log(
+            `update.${kind}`,
+            raw.length > 1500 ? `${raw.slice(0, 1500)}…` : raw,
           );
-        }, timeoutMs);
-        pending.set(id, { method, resolve, reject, timer });
-        writeMessage({ jsonrpc: "2.0", id, method, params });
-      });
-    };
+        } else if (
+          kind !== null &&
+          kind !== "agent_message_chunk" &&
+          kind !== "agent_thought_chunk" &&
+          kind !== "agent_reasoning_chunk" &&
+          kind !== "thinking_chunk" &&
+          kind !== "reasoning" &&
+          kind !== "message"
+        ) {
+          // Other frames (mode updates, available commands, errors) —
+          // log compact form so we can spot anything unusual.
+          log(`update.${kind}`);
+        }
+      }
 
-    const notify = (method: string, params: unknown): void => {
-      writeMessage({ jsonrpc: "2.0", method, params });
-    };
+      const translated = translator.translate(update);
+      // Mirror what the translator emitted from this update so we can see
+      // the cursor-frame → AgentEvent mapping side-by-side in the log.
+      for (const ev of translated) {
+        if (ev._tag === "ToolUse") {
+          let inputPreview: string;
+          try {
+            inputPreview = JSON.stringify(ev.input);
+          } catch {
+            inputPreview = "(unserialisable)";
+          }
+          log(
+            "emit.ToolUse",
+            `id=${ev.itemId} tool=${ev.tool} input=${inputPreview.slice(0, 600)}`,
+          );
+        } else if (ev._tag === "ToolResult") {
+          let outputPreview: string;
+          try {
+            outputPreview =
+              typeof ev.output === "string"
+                ? ev.output
+                : JSON.stringify(ev.output);
+          } catch {
+            outputPreview = "(unserialisable)";
+          }
+          log(
+            "emit.ToolResult",
+            `id=${ev.itemId} isError=${ev.isError} output=${outputPreview.slice(0, 400)}`,
+          );
+        }
+        events.unsafeOffer(ev);
+      }
+    });
+    transportResult.setStderrHandler(() => {
+      // Already file-tee'd inside the transport; no extra work needed.
+    });
+    transportResult.setSpawnErrorHandler((message) => {
+      if (!closed) events.unsafeOffer({ _tag: "Error", message });
+    });
+    transportResult.setCloseHandler((exitDetail) => {
+      log(
+        "child.close",
+        `pending=${pending.size} detail=${exitDetail.slice(0, 200)}`,
+      );
+      if (!closed) {
+        events.unsafeOffer({ _tag: "Error", message: exitDetail });
+        events.unsafeOffer({ _tag: "Status", status: "idle" });
+      }
+    });
 
     /**
      * Currently in-flight `session/prompt` rpc id. See gemini.ts for the
@@ -245,186 +757,41 @@ export const startCursorSession = (
       clearTimeout(resolver.timer);
       currentPromptRpcId = null;
       if (CURSOR_RPC_TRACE) {
-        process.stderr.write(
+        writeCursorLog(
           `[cursor.rpc.cancel] force-reject id=${id} method=${resolver.method} reason=${reason}\n`,
         );
       }
       resolver.reject(new Error(reason));
     };
 
-    rl.on("line", (line: string) => {
-      if (line.trim().length === 0) return;
-      if (CURSOR_RPC_TRACE) process.stderr.write(`[cursor.rpc.recv] ${line}\n`);
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(line);
-      } catch {
-        return;
-      }
-      if (parsed === null || typeof parsed !== "object") return;
-      const msg = parsed as JsonRpcMessage;
-
-      if (typeof msg.method === "string") {
-        if (msg.method === "session/update") {
-          const update = msg.params?.update;
-          if (update !== undefined) {
-            for (const ev of translator.translate(update)) {
-              events.unsafeOffer(ev);
-            }
-          }
-          return;
-        }
-        if (msg.id !== undefined) {
-          const isFs = msg.method.startsWith("fs/");
-          if (CURSOR_RPC_TRACE || isFs) {
-            process.stderr.write(
-              `[cursor.rpc] server→client request method=${msg.method} id=${msg.id} params=${JSON.stringify(msg.params ?? {})}\n`,
-            );
-          }
-          if (isFs) {
-            writeMessage({
-              jsonrpc: "2.0",
-              id: msg.id,
-              error: {
-                code: -32601,
-                message: `Method not implemented by memoize ACP client: ${msg.method}`,
-              },
-            });
-            return;
-          }
-          console.warn(
-            `[cursor.rpc] unhandled server→client request method=${msg.method} id=${msg.id}`,
-          );
-          return;
-        }
-        return;
-      }
-
-      const id = typeof msg.id === "number" ? msg.id : null;
-      if (id === null) return;
-      const resolver = pending.get(id);
-      if (resolver === undefined) return;
-      pending.delete(id);
-      clearTimeout(resolver.timer);
-      if (msg.error !== undefined) {
-        try {
-          process.stderr.write(
-            `[cursor.rpc.error] method=${resolver.method} id=${id} ${JSON.stringify(msg.error)}\n`,
-          );
-        } catch {
-          process.stderr.write(
-            `[cursor.rpc.error] method=${resolver.method} id=${id} (unserialisable)\n`,
-          );
-        }
-        const detail = formatRpcError(msg.error, stderrTail);
-        resolver.reject(new Error(`Cursor ${resolver.method} failed: ${detail}`));
-      } else {
-        resolver.resolve(msg.result ?? {});
-      }
-    });
-
-    child.stderr.on("data", (chunk: string) => {
-      stderrTail = (stderrTail + chunk).slice(-4096);
-      process.stderr.write(`[cursor.stderr] ${chunk}`);
-    });
-
-    // Reject pending requests on spawn-time errors (ENOENT/EACCES) so the
-    // initialize handshake fails cleanly instead of waiting for a timeout
-    // that never resolves. Mirrors the codex client fix.
-    child.once("error", (err) => {
-      const message = err instanceof Error ? err.message : String(err);
-      for (const { reject, timer } of pending.values()) {
-        clearTimeout(timer);
-        reject(new Error(message));
-      }
-      pending.clear();
-      if (!closed) {
-        events.unsafeOffer({ _tag: "Error", message });
-      }
-    });
-
-    child.on("close", (code, signal) => {
-      rl.close();
-      const trimmedStderr = stderrTail.trim();
-      const exitDetail = trimmedStderr.length > 0
-        ? `Cursor ACP exited (code ${code ?? "null"}, signal ${signal ?? "null"}): ${trimmedStderr}`
-        : `Cursor ACP exited unexpectedly (code ${code ?? "null"}, signal ${signal ?? "null"}).`;
-      for (const { reject, timer } of pending.values()) {
-        clearTimeout(timer);
-        reject(new Error(exitDetail));
-      }
-      pending.clear();
-      if (!closed) {
-        events.unsafeOffer({ _tag: "Error", message: exitDetail });
-        events.unsafeOffer({ _tag: "Status", status: "idle" });
-      }
-    });
-
-    // === ACP handshake — synchronous, fails the start() RPC on error. ===
-    const handshake = Effect.tryPromise({
+    // === session/load or session/new ===
+    const sessionStart = Effect.tryPromise({
       try: async () => {
-        // Short timeout on the first request: a real ACP server replies in
-        // <100ms. When the binary is too old to support `acp`, cursor-agent
-        // silently treats it as a chat prompt and sits on stdin forever —
-        // a 30s wait there is just bad UX. Detect that within 5s and
-        // surface an actionable upgrade message instead.
-        let init: { authMethods?: ReadonlyArray<{ id?: unknown }> };
-        try {
-          init = (await request(
-            "initialize",
-            {
-              protocolVersion: 1,
-              clientCapabilities: {
-                fs: {
-                  readTextFile: true,
-                  writeTextFile: true,
-                  readDirectory: true,
-                  createDirectory: true,
-                  deleteFile: true,
-                  moveFile: true,
-                },
-                terminal: true,
-                _meta: { parameterizedModelPicker: true },
-              },
-            },
-            5_000,
-          )) as { authMethods?: ReadonlyArray<{ id?: unknown }> };
-        } catch (cause) {
-          const reason = cause instanceof Error ? cause.message : String(cause);
-          if (/timed out/i.test(reason)) {
-            throw new Error(
-              "Cursor Agent is too old (no ACP support). Run `cursor-agent update` (need ≥ 2025.11) and try again.",
+        if (resumeCursor !== null && resumeCursor.length > 0) {
+          log("session-load.req", `cursor=${resumeCursor.slice(0, 12)}…`);
+          const loadStart = Date.now();
+          try {
+            await request("session/load", {
+              sessionId: resumeCursor,
+              cwd,
+              mcpServers: [],
+            });
+            log(
+              "session-load.ok",
+              `${Date.now() - loadStart}ms acpSessionId=${resumeCursor.slice(0, 12)}…`,
+            );
+            return resumeCursor;
+          } catch (cause) {
+            const reason = cause instanceof Error ? cause.message : String(cause);
+            log(
+              "session-load.fail",
+              `${Date.now() - loadStart}ms reason=${reason} — falling back to session/new`,
             );
           }
-          throw cause;
         }
 
-        const authIds = new Set(
-          (init.authMethods ?? [])
-            .map((m) => (typeof m?.id === "string" ? m.id : null))
-            .filter((id): id is string => id !== null),
-        );
-        // Cursor advertises `cursor_login` for stored credentials (OAuth
-        // or API key — the CLI loads whichever is set). `cached_token`
-        // appears on older builds. Prefer `cursor_login` whenever it's
-        // offered; the API key (if any) is forwarded via the
-        // CURSOR_API_KEY env above so the CLI side picks it up.
-        const methodId =
-          authIds.has("cursor_login")
-            ? "cursor_login"
-            : authIds.has("cached_token")
-              ? "cached_token"
-              : null;
-        if (methodId === null) {
-          throw new Error(
-            'Cursor is not signed in. Click "Sign in" on the Cursor provider card, run `cursor-agent login` in a terminal, or paste a Cursor API key.',
-          );
-        }
-        await request("authenticate", {
-          methodId,
-          _meta: { headless: true },
-        });
-
+        log("session-new.req");
+        const newStart = Date.now();
         const sessionResult = (await request("session/new", {
           cwd,
           mcpServers: [],
@@ -433,6 +800,10 @@ export const startCursorSession = (
         if (typeof sessionResult.sessionId !== "string") {
           throw new Error("Cursor ACP session/new returned no sessionId.");
         }
+        log(
+          "session-new.ok",
+          `${Date.now() - newStart}ms acpSessionId=${sessionResult.sessionId.slice(0, 12)}…`,
+        );
         return sessionResult.sessionId;
       },
       catch: (cause) =>
@@ -442,7 +813,7 @@ export const startCursorSession = (
         }),
     });
 
-    acpSessionId = yield* handshake.pipe(
+    acpSessionId = yield* sessionStart.pipe(
       Effect.tapError(() =>
         Effect.sync(() => {
           child.kill("SIGTERM");
@@ -457,37 +828,41 @@ export const startCursorSession = (
     });
 
     if (resumeCursor !== null && resumeCursor !== acpSessionId) {
-      console.warn(
-        `[cursor] previous cursor ${resumeCursor} discarded — ACP session/load not wired; using new session ${acpSessionId}`,
+      log(
+        "resume.miss",
+        `requested=${resumeCursor.slice(0, 12)}… booted=${acpSessionId.slice(0, 12)}… (load failed; new session)`,
       );
+    } else if (resumeCursor !== null) {
+      log("resume.hit", `cursor=${acpSessionId.slice(0, 12)}…`);
     }
 
-    // Apply the requested model via ACP `session/set_config_option`. This is
-    // the only path cursor-agent honors for model selection; the old
-    // `_meta.model` slot in `session/prompt` was a no-op. Fire-and-forget:
-    // when the server doesn't recognise the slug it logs but the session
-    // still works on the default model.
+    // Apply the requested model via ACP `session/set_config_option`. Old
+    // `_meta.model` slot on `session/prompt` was a no-op. Fire-and-forget:
+    // if the slug isn't accepted the session still works on the default
+    // (composer-2) model.
     if (input.model !== undefined && input.model.length > 0) {
+      const resolvedModel = resolveModelSlug("cursor", input.model);
+      if (resolvedModel !== input.model) {
+        log("set-model.alias", `${input.model} → ${resolvedModel}`);
+      }
+      log("set-model.req", `model=${resolvedModel}`);
+      const modelStart = Date.now();
       void request(
         "session/set_config_option",
         {
           sessionId: acpSessionId,
           configId: "model",
-          value: input.model,
+          value: resolvedModel,
         },
         5_000,
-      ).catch((err) => {
-        const reason = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-          `[cursor] set_config_option model=${input.model} failed: ${reason}\n`,
-        );
-      });
+      )
+        .then(() => log("set-model.ok", `${Date.now() - modelStart}ms`))
+        .catch((err) => {
+          const reason = err instanceof Error ? err.message : String(err);
+          log("set-model.fail", `${Date.now() - modelStart}ms reason=${reason}`);
+        });
     }
 
-    // If the session was created in plan mode, inform the ACP server via
-    // native `session/setMode`. Cursor exposes plan/architect modes
-    // natively, so this is real plan mode — not the dev-instructions
-    // emulation that grok/gemini/codex fall back to.
     if (currentMode === "plan") {
       notify("session/setMode", { sessionId: acpSessionId, modeId: "plan" });
     }
@@ -495,14 +870,13 @@ export const startCursorSession = (
     const enqueuePrompt = (text: string): void => {
       const sid = acpSessionId;
       if (sid === null) return;
+      const n = ++promptCount;
       inflight = inflight
         .then(async () => {
           if (closed) return;
-          if (CURSOR_RPC_TRACE) {
-            process.stderr.write(
-              `[cursor.prompt] enqueue len=${text.length} mode=${currentMode}\n`,
-            );
-          }
+          firstChunkSeenForPrompt = false;
+          const promptStart = Date.now();
+          log("prompt.send", `#${n} len=${text.length} mode=${currentMode}`);
           try {
             await request(
               "session/prompt",
@@ -516,26 +890,16 @@ export const startCursorSession = (
                 currentPromptRpcId = id;
               },
             );
-            if (CURSOR_RPC_TRACE) {
-              process.stderr.write(`[cursor.prompt] completed\n`);
-            }
+            log("prompt.done", `#${n} ${Date.now() - promptStart}ms`);
           } catch (cause) {
             const reason = cause instanceof Error ? cause.message : String(cause);
-            if (CURSOR_RPC_TRACE) {
-              process.stderr.write(`[cursor.prompt] failed: ${reason}\n`);
-            }
+            log("prompt.fail", `#${n} ${Date.now() - promptStart}ms reason=${reason}`);
             const isCancellation = /cancel|interrupt/i.test(reason);
             if (!closed && !isCancellation) {
-              events.unsafeOffer({
-                _tag: "Error",
-                message: reason,
-              });
+              events.unsafeOffer({ _tag: "Error", message: reason });
             }
           } finally {
             currentPromptRpcId = null;
-            // Drain any buffered assistant text from the translator so the
-            // final delta lands as a normal AssistantMessage instead of
-            // sitting unobserved in memory.
             if (!closed) {
               for (const ev of translator.flush()) events.unsafeOffer(ev);
               events.unsafeOffer({ _tag: "Status", status: "idle" });
@@ -548,6 +912,11 @@ export const startCursorSession = (
     if (input.initialPrompt !== undefined && input.initialPrompt.length > 0) {
       enqueuePrompt(input.initialPrompt);
     }
+
+    // Reference getStderrTail so the param is consumed (linting); transport
+    // already file-tees, but we hold the handle for future debug surfaces.
+    void getStderrTail;
+    void rejectCurrentPrompt;
 
     const handle: CursorSessionHandle = {
       events: Mailbox.toStream(events),
@@ -588,12 +957,6 @@ export const startCursorSession = (
           if (mode === currentMode) return;
           currentMode = mode;
           events.unsafeOffer({ _tag: "PermissionModeChanged", mode });
-          // Cursor exposes plan/architect modes natively via ACP
-          // `session/setMode`. Server replies with `current_mode_update`
-          // which our translator swallows. Fire-and-forget — the user's
-          // `permissionMode` chip is already updated locally; if the ACP
-          // server doesn't recognize the mode it just stays in its
-          // previous mode and the user can retry.
           const sid = acpSessionId;
           if (sid !== null) {
             const modeId = mode === "plan" ? "plan" : "code";

--- a/apps/server/src/provider/drivers/opencode.ts
+++ b/apps/server/src/provider/drivers/opencode.ts
@@ -65,9 +65,9 @@ export interface OpencodeSessionHandle {
   ) => Effect.Effect<void>;
 }
 
-// Default on — opencode is new and the failure modes (server boot, SSE,
-// auth) are quiet by design. Set MEMOIZE_DEBUG_OPENCODE=0 to silence.
-const OPENCODE_DEBUG = process.env.MEMOIZE_DEBUG_OPENCODE !== "0";
+// Default off — set MEMOIZE_DEBUG_OPENCODE=1 to re-enable when debugging
+// opencode server boot, SSE, or auth issues.
+const OPENCODE_DEBUG = process.env.MEMOIZE_DEBUG_OPENCODE === "1";
 
 // Tee all debug to a file so bun's dev-server stdout multiplexing
 // doesn't swallow the trace. Path is logged at startup.

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -32,6 +32,7 @@ import {
   type GeminiSessionHandle,
 } from "../drivers/gemini.ts";
 import {
+  prewarmCursor,
   startCursorSession,
   type CursorSessionHandle,
 } from "../drivers/cursor.ts";
@@ -85,6 +86,25 @@ export const ProviderServiceLive = Layer.effect(
     const runtime = yield* Effect.runtime<never>();
     const sessions = yield* Ref.make<Map<AgentSessionId, SessionEntry>>(
       new Map(),
+    );
+
+    // Prewarm a cursor-agent child at layer boot if cursor is installed.
+    // The ACP authenticate step is the slowest part of cold start (~8s);
+    // having one warm child standing by means the user's first cursor
+    // session skips straight to `session/new`. Fire-and-forget — layer
+    // construction does not depend on it.
+    yield* Effect.forkDaemon(
+      Effect.gen(function* () {
+        const cursorPath = yield* resolveCliPath("cursor-agent").pipe(
+          Effect.provideService(CommandExecutor.CommandExecutor, executor),
+          Effect.catchAll(() => Effect.succeed<string | null>(null)),
+        );
+        if (cursorPath === null) return;
+        const apiKey = yield* credentials
+          .get("cursor")
+          .pipe(Effect.catchAll(() => Effect.succeed<string | null>(null)));
+        yield* Effect.sync(() => prewarmCursor(cursorPath, apiKey));
+      }),
     );
 
     // The Claude SDK's `canUseTool` callback returns a Promise; here we

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -729,14 +729,21 @@ export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> 
   // seed, not a whitelist. Selection is applied at session start via ACP
   // `session/set_config_option { configId: "model" }`. Plan mode lands
   // natively via `setSessionMode("plan")`.
+  // Cursor's ACP server validates model slugs against its OWN list which
+  // differs from `cursor-agent --list-models`. The valid set lives in the
+  // `models.availableModels` block returned by `session/new` — slugs like
+  // `composer-2-fast` (the CLI default) are rejected by ACP with -32602.
+  // The seed below uses ACP-valid IDs only. The `default` slug means
+  // "Auto" (cursor picks). Custom slugs typed in the picker still work.
   cursor: [
-    { id: "composer-2-fast", label: "Composer 2 Fast", supportsPlanMode: true },
+    { id: "default", label: "Auto", supportsPlanMode: true },
     { id: "composer-2", label: "Composer 2", supportsPlanMode: true },
-    { id: "gpt-5.5-medium", label: "GPT-5.5", supportsPlanMode: true },
-    { id: "gpt-5.5-high", label: "GPT-5.5 High", supportsPlanMode: true },
+    { id: "composer-2.5", label: "Composer 2.5", supportsPlanMode: true },
+    { id: "gpt-5.5", label: "GPT-5.5", supportsPlanMode: true },
     { id: "gpt-5.3-codex", label: "Codex 5.3", supportsPlanMode: true },
+    { id: "claude-sonnet-4-6", label: "Sonnet 4.6", supportsPlanMode: true },
+    { id: "claude-opus-4-7", label: "Opus 4.7", supportsPlanMode: true },
     { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro", supportsPlanMode: true },
-    { id: "auto", label: "Auto", supportsPlanMode: true },
   ],
   // OpenCode is a meta-provider: it spawns a local `opencode serve` and
   // forwards prompts to whichever underlying provider (anthropic, openai,
@@ -807,10 +814,31 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string
   // re-aliased to current cursor catalogue entries so re-opening the app
   // doesn't send the agent a slug it'll silently ignore.
   cursor: {
-    "gpt-5": "composer-2-fast",
-    "sonnet-4": "composer-2-fast",
-    "sonnet-4-thinking": "composer-2-fast",
-    "opus-4.1": "composer-2-fast",
+    // Legacy slugs from earlier builds (pre-2025.11 cursor-agent CLI list).
+    "gpt-5": "composer-2",
+    "sonnet-4": "claude-sonnet-4-6",
+    "sonnet-4-thinking": "claude-sonnet-4-6",
+    "opus-4.1": "claude-opus-4-7",
+    // CLI slugs (from `cursor-agent --list-models`) that the ACP server
+    // rejects with -32602: it has its own narrower set. Re-route to the
+    // closest ACP-valid neighbour so a previously persisted user choice
+    // doesn't crash on session start.
+    "composer-2-fast": "composer-2",
+    "composer-2.5-fast": "composer-2.5",
+    "gpt-5.5-medium": "gpt-5.5",
+    "gpt-5.5-medium-fast": "gpt-5.5",
+    "gpt-5.5-high": "gpt-5.5",
+    "gpt-5.5-high-fast": "gpt-5.5",
+    "gpt-5.5-low": "gpt-5.5",
+    "gpt-5.5-low-fast": "gpt-5.5",
+    "gpt-5.5-extra-high": "gpt-5.5",
+    "gpt-5.5-extra-high-fast": "gpt-5.5",
+    "gpt-5.5-none": "gpt-5.5",
+    "gpt-5.5-none-fast": "gpt-5.5",
+    "gpt-5.4-high": "gpt-5.4",
+    "gpt-5.4-high-fast": "gpt-5.4",
+    "gpt-5.3-codex-fast": "gpt-5.3-codex",
+    "auto": "default",
   },
   opencode: {},
 };


### PR DESCRIPTION
## Summary

- **Prewarm cursor-agent at boot.** First user session skips the ~8s authenticate roundtrip; measured time-to-first-token dropped from 18s → 5.8s. After consumption, a fresh prewarm is scheduled so subsequent sessions stay fast.
- **Real ACP model slugs.** Cursor's ACP server validates against a different list than `cursor-agent --list-models` (was -32602'ing `composer-2-fast`). Picker now uses ACP-valid IDs (`composer-2`, `gpt-5.5`, `claude-sonnet-4-6`, `claude-opus-4-7`, etc.) and aliases re-route persisted legacy/CLI-only slugs.
- **Wired `session/load` resume** (cursor advertises `loadSession: true`); falls back to `session/new` if the saved cursor expired.
- **Inspectable logs at `~/.cache/memoize/cursor.log`.** ISO-timestamped phase events, plus raw `tool_call` / `tool_call_update` frames alongside the `emit.ToolUse` / `emit.ToolResult` they produced — used to debug why file ops weren't rendering.
- **Translator fixes:** persist tool name across `tool_call` → `tool_call_update` (cursor omits `kind` on updates), read cursor's `rawOutput.content`, and pull `rawInput.{file_path,path,command,...}` so Read/Edit/Write/Bash surface their arguments. Default `MEMOIZE_DEBUG_OPENCODE` off to silence stderr noise.

## Test plan

- [ ] Boot the app — within ~6s, `~/.cache/memoize/cursor.log` shows `[cursor.prewarm] prewarm.ready`.
- [ ] Open the first cursor chat — log shows `prewarm.hit` followed immediately by `session-new.req` (no `authenticate.req`). First token arrives in ~5-6s, not 14-18s.
- [ ] Pick a non-default model from the picker — `set-model.req model=<slug>` followed by `set-model.ok` (no -32602).
- [ ] Resume an existing cursor session — log shows `session-load.req → session-load.ok → resume.hit` (or `.fail → falling back to session/new` if expired).
- [ ] Ask cursor to read + edit a file — log shows `update.tool_call` raw, `emit.ToolUse tool=Read input={…}`, and for edits `emit.ToolUse tool=Edit input={file_path,old_string,new_string}` followed by `emit.ToolResult`.
- [ ] `cd apps/server && bun run check-types` — clean.