### PR TITLE
feat(mcp-server): wire hybrid code_search + extract shared search module

### DIFF
--- a/apps/mcp-server/src/handle.ts
+++ b/apps/mcp-server/src/handle.ts
@@ -3,7 +3,9 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  branchExists,
   closeIndexDb,
+  countAll,
   fetchChunk,
   findReferencesByName,
   indexRepo,
@@ -12,7 +14,10 @@ import {
   openIndexDb,
   reindexFile,
   runMigrations,
+  search,
   type IndexDb,
+  type SearchHit,
+  type SearchInput,
 } from "@memoize/index";
 
 const runP = <A>(eff: Effect.Effect<A, unknown>): Promise<A> =>
@@ -32,17 +37,14 @@ export interface ServerHandle {
     readonly workspace: string;
     readonly branch: string;
     readonly dbPath: string;
+    readonly populated: boolean;
+    readonly stats: { blobs: number; chunks: number; symbols: number; refs: number };
   }>;
   readonly reindex: () => Promise<{ readonly processed: number }>;
   readonly reindexFile: (
     path: string,
   ) => Promise<{ readonly blobId: number; readonly parsed: boolean }>;
-  readonly search: (input: {
-    readonly query: string;
-    readonly kind?: "auto" | "symbol" | "text" | "semantic";
-    readonly limit?: number;
-    readonly pathGlob?: string;
-  }) => Promise<unknown>;
+  readonly search: (input: SearchInput) => Promise<ReadonlyArray<SearchHit>>;
   readonly symbolLookup: (input: {
     readonly name: string;
     readonly kind?: string;
@@ -85,19 +87,15 @@ export const startServerHandle = async (
     db,
     workspace,
     branch,
-    status: async () => ({ workspace, branch, dbPath }),
+    status: async () => {
+      const populated = await runP(branchExists(db, branch));
+      const stats = await runP(countAll(db));
+      return { workspace, branch, dbPath, populated, stats };
+    },
     reindex: async () => runP(indexRepo(db, workspace, branch)),
     reindexFile: async (path: string) =>
       runP(reindexFile(db, workspace, path, branch)),
-    search: async () => {
-      // The standalone MCP exposes the same search semantics as the
-      // in-process consumer; we run the symbol-only path directly for
-      // now and let downstream tools call BM25 via `code_search` when
-      // the agent picks the `text` kind. Phase G can plug the full
-      // IndexService.search Effect runtime in if we ever want HTTP
-      // semantic search from the MCP side.
-      return [];
-    },
+    search: (input) => runP(search(db, branch, input)),
     symbolLookup: ({ name, kind, limit, pathGlob }) =>
       runP(lookupSymbol(db, name, branch, kind, limit ?? 10, pathGlob)),
     findReferences: ({ symbol, limit, pathGlob }) =>

--- a/apps/mcp-server/src/tools.ts
+++ b/apps/mcp-server/src/tools.ts
@@ -31,7 +31,7 @@ export const buildTools = (handle: ServerHandle): ReadonlyArray<McpToolDef> => [
   {
     name: "code_search",
     description:
-      "Multi-tier search across the indexed codebase. Best for conceptual / multi-file queries. For a known identifier, prefer `symbol_lookup`. For a literal string, prefer Bash(rg) with a path filter. `kind: \"semantic\"` currently degrades to BM25.",
+      "Multi-tier search (symbol + BM25 + vector + RRF + optional rerank) across the indexed codebase. Use for conceptual or multi-file queries. For a known identifier prefer `symbol_lookup`. For a raw string literal prefer Bash(rg) with a path filter. The router automatically picks the right tiers based on the query shape.",
     inputSchema: {
       type: "object",
       properties: {
@@ -54,14 +54,14 @@ export const buildTools = (handle: ServerHandle): ReadonlyArray<McpToolDef> => [
     handler: async (raw) => {
       const args = (raw ?? {}) as {
         query: string;
-        kind?: string;
+        kind?: "auto" | "symbol" | "text" | "semantic";
         limit?: number;
         pathGlob?: string;
       };
-      // Symbol-first: matches the in-process default in apps/server.
-      const hits = await handle.symbolLookup({
-        name: args.query,
-        limit: args.limit ?? 5,
+      const hits = await handle.search({
+        query: args.query,
+        kind: args.kind,
+        limit: args.limit,
         pathGlob: args.pathGlob,
       });
       return asTool({ hits });
@@ -164,9 +164,17 @@ export const buildTools = (handle: ServerHandle): ReadonlyArray<McpToolDef> => [
   {
     name: "index_status",
     description:
-      "Return the workspace + branch + db path the server is serving. Use to verify the right index is mounted.",
+      "Return workspace, branch, dbPath, populated flag, and basic stats. Call this first — if populated=false the index is empty and you should call `reindex` (or launch the binary with --reindex).",
     inputSchema: { type: "object", properties: {} },
     validator: z.object({}),
     handler: async () => asTool(await handle.status()),
+  },
+  {
+    name: "reindex",
+    description:
+      "Trigger a full (re)index of the workspace. Blocks until the pass completes (30-90 s typical). Use when index_status shows populated=false or after large changes. The CLI flag --reindex is usually more convenient for first launch.",
+    inputSchema: { type: "object", properties: {} },
+    validator: z.object({}),
+    handler: async () => asTool(await handle.reindex()),
   },
 ];

--- a/apps/mcp-server/test/smoke.test.ts
+++ b/apps/mcp-server/test/smoke.test.ts
@@ -6,8 +6,8 @@ import { tmpdir } from "node:os";
 import { startServerHandle } from "../src/handle.ts";
 import { buildTools } from "../src/tools.ts";
 
-describe("Phase F — MCP server smoke", () => {
-  it("constructs a handle and exposes 6 tools", async () => {
+describe("MCP server smoke (standalone index for external agents)", () => {
+  it("constructs a handle and exposes the full tool surface (including hybrid code_search)", async () => {
     const root = mkdtempSync(join(tmpdir(), "mz-mcp-"));
     try {
       writeFileSync(
@@ -29,6 +29,7 @@ describe("Phase F — MCP server smoke", () => {
         "index_status",
         "list_module",
         "read_chunk",
+        "reindex",
         "symbol_lookup",
       ]);
 
@@ -45,9 +46,23 @@ describe("Phase F — MCP server smoke", () => {
       const statusPayload = JSON.parse(statusOut.content[0]!.text) as {
         workspace: string;
         branch: string;
+        populated: boolean;
+        stats: { blobs: number };
       };
       expect(statusPayload.workspace).toBe(root);
       expect(statusPayload.branch).toBe("test");
+      expect(statusPayload.populated).toBe(true);
+      expect(statusPayload.stats.blobs).toBeGreaterThan(0);
+
+      // Exercise the newly-wired hybrid search path (non-symbol query → BM25)
+      const cs = tools.find((t) => t.name === "code_search")!;
+      const csValidated = cs.validator.parse({ query: "thing", kind: "text", limit: 3 });
+      const csOut = await cs.handler(csValidated);
+      expect(csOut.isError).toBeFalsy();
+      const csPayload = JSON.parse(csOut.content[0]!.text) as { hits: unknown[] };
+      expect(Array.isArray(csPayload.hits)).toBe(true);
+      // The tiny file contains the identifier, so we should get at least one hit
+      expect(csPayload.hits.length).toBeGreaterThan(0);
 
       await handle.close();
     } finally {

--- a/packages/index/src/index.ts
+++ b/packages/index/src/index.ts
@@ -70,6 +70,7 @@ export { forgetFile, reindexFile } from "./incremental.ts";
 export { bm25Search, type Bm25Hit } from "./retrieval/bm25.ts";
 export { reciprocalRankFusion } from "./retrieval/rrf.ts";
 export { route, type Tier } from "./retrieval/router.ts";
+export { search } from "./retrieval/search.ts";
 export {
   isVectorAvailable,
   vectorSearch,

--- a/packages/index/src/retrieval/search.ts
+++ b/packages/index/src/retrieval/search.ts
@@ -1,0 +1,186 @@
+import { Effect } from "effect";
+
+import { getEmbeddingProvider } from "../embedding/provider.ts";
+import { applyRerank } from "../rerank/index.ts";
+import type { IndexDb } from "../db/sqlite.ts";
+import { bm25Search } from "./bm25.ts";
+import { reciprocalRankFusion } from "./rrf.ts";
+import { route } from "./router.ts";
+import {
+  lookupSymbol,
+  symbolHitToSearchHit,
+} from "./symbol-lookup.ts";
+import type { SymbolHit } from "../types.ts";
+import { isVectorAvailable, vectorSearch } from "./vector.ts";
+import type { SearchHit, SearchInput } from "../types.ts";
+
+/**
+ * Used by `search` to resolve a symbol to its enclosing chunk's id + content
+ * so the agent gets actual code text, not just `function foo(...)`. Returns
+ * `null` when the symbol has no anchored chunk (type aliases, properties).
+ */
+const fetchChunkBySymbol = (
+  db: IndexDb,
+  symbolId: number,
+  branch: string,
+): Effect.Effect<{ chunkId: number; content: string } | null, never> =>
+  Effect.sync(() => {
+    try {
+      const row = db
+        .prepare(
+          `SELECT c.id, c.content FROM chunks c
+           JOIN manifests m ON m.blob_id = c.blob_id AND m.branch = ?
+           WHERE c.symbol_id = ?
+           ORDER BY c.id ASC LIMIT 1`,
+        )
+        .get(branch, symbolId) as { id: number; content: string } | undefined;
+      return row ? { chunkId: row.id, content: row.content } : null;
+    } catch {
+      return null;
+    }
+  });
+
+/**
+ * Hybrid search pipeline — routes the query into the tier(s) the router
+ * recommends, runs them in parallel, fuses via RRF when more than one
+ * tier fires. Symbol-only queries skip fusion entirely (single source,
+ * RRF would be a no-op).
+ *
+ * This is the single source of truth used by both:
+ *   - the Effect `IndexService` (in-process desktop / full runtime)
+ *   - the lightweight direct-DB path in the standalone MCP server
+ *
+ * The implementation gracefully degrades:
+ *   - when no embedding provider is configured (vector tier dropped by router)
+ *   - when rerank provider is Null (RRF order is kept)
+ */
+export const search = (
+  db: IndexDb,
+  defaultBranch: string,
+  input: SearchInput,
+): Effect.Effect<ReadonlyArray<SearchHit>, never> =>
+  Effect.gen(function* () {
+    const branch = input.branch ?? defaultBranch;
+    const limit = input.limit ?? 5;
+    const pathGlob = input.pathGlob;
+    const tiers = route(input.query, input.kind);
+
+    const wantsSymbol = tiers.includes("symbol");
+    const wantsBm25 = tiers.includes("bm25");
+    const wantsVector = tiers.includes("vector");
+
+    // Tier 1 — symbol lookup. Single-source path returns directly.
+    const symbolHits = wantsSymbol
+      ? yield* lookupSymbol(db, input.query, branch, undefined, 20, pathGlob).pipe(
+          Effect.catchAll(() =>
+            Effect.succeed([] as ReadonlyArray<ReturnType<typeof Object>>),
+          ),
+        )
+      : [];
+
+    if (tiers.length === 1 && wantsSymbol) {
+      const out: SearchHit[] = [];
+      for (const h of symbolHits.slice(0, limit) as ReadonlyArray<SymbolHit>) {
+        const chunk = yield* fetchChunkBySymbol(db, h.symbolId, branch);
+        out.push(
+          symbolHitToSearchHit(h, chunk?.content ?? `${h.kind} ${h.name}`),
+        );
+      }
+      return out as ReadonlyArray<SearchHit>;
+    }
+
+    // Tier 2 / Tier 3 — gather candidates, fuse via RRF.
+    const fanout = 30;
+    const rankings: ReadonlyArray<{ chunkId: number }>[] = [];
+
+    if (wantsBm25) {
+      const hits = yield* bm25Search(db, input.query, branch, fanout, pathGlob).pipe(
+        Effect.catchAll(() => Effect.succeed([])),
+      );
+      rankings.push(hits);
+    }
+    if (wantsVector && isVectorAvailable(db)) {
+      const provider = getEmbeddingProvider();
+      if (provider.id !== "null") {
+        const [vec] = yield* Effect.tryPromise({
+          try: () => provider.embed([input.query]),
+          catch: () => new Error("embed failed"),
+        }).pipe(Effect.catchAll(() => Effect.succeed([new Float32Array(0)])));
+        if (vec && vec.length > 0) {
+          const hits = yield* vectorSearch(db, vec, branch, fanout, pathGlob).pipe(
+            Effect.catchAll(() => Effect.succeed([])),
+          );
+          rankings.push(hits);
+        }
+      }
+    }
+    if (wantsSymbol && symbolHits.length > 0) {
+      rankings.push(
+        symbolHits.map((h) => ({
+          chunkId: -1 - (h as { symbolId: number }).symbolId,
+        })),
+      );
+    }
+
+    // Over-fetch into RRF; we'll narrow with rerank before returning.
+    const fanForRerank = Math.max(20, limit * 4);
+    const fused = reciprocalRankFusion(rankings).slice(0, fanForRerank);
+    const out: SearchHit[] = [];
+    for (const { chunkId, score } of fused) {
+      if (chunkId < 0) {
+        // Symbol-derived placeholder id. Convert back, fetch its chunk.
+        const symbolId = -1 - chunkId;
+        const sh = (symbolHits as ReadonlyArray<SymbolHit>).find(
+          (h) => h.symbolId === symbolId,
+        );
+        if (!sh) continue;
+        const chunk = yield* fetchChunkBySymbol(db, symbolId, branch);
+        out.push({
+          ...symbolHitToSearchHit(sh, chunk?.content ?? `${sh.kind} ${sh.name}`),
+          chunkId: chunk?.chunkId ?? -1,
+          score,
+          source: "fused",
+        });
+      } else {
+        const row = yield* Effect.try({
+          try: () =>
+            db
+              .prepare(
+                `SELECT c.id, c.start_line, c.end_line, c.content, c.symbol_id, m.file_path
+                 FROM chunks c
+                 JOIN manifests m ON m.blob_id = c.blob_id AND m.branch = ?
+                 WHERE c.id = ?`,
+              )
+              .get(branch, chunkId) as
+              | {
+                  id: number;
+                  start_line: number;
+                  end_line: number;
+                  content: string;
+                  symbol_id: number | null;
+                  file_path: string;
+                }
+              | undefined,
+          catch: () => new Error("fetch chunk failed"),
+        }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+        if (!row) continue;
+        out.push({
+          chunkId: row.id,
+          file: row.file_path,
+          range: { start: row.start_line, end: row.end_line },
+          symbol: null,
+          content: row.content,
+          score,
+          source: "fused",
+        });
+      }
+    }
+    // Phase D: rerank the over-fetched fused candidates and trim to `limit`.
+    // No-op when the active provider is NullRerankProvider (default), so
+    // local installs without a paid backend still get the RRF ordering.
+    const reranked = yield* Effect.tryPromise({
+      try: () => applyRerank(input.query, out, limit),
+      catch: () => new Error("rerank failed"),
+    }).pipe(Effect.catchAll(() => Effect.succeed(out.slice(0, limit))));
+    return reranked as ReadonlyArray<SearchHit>;
+  });

--- a/packages/index/src/service.ts
+++ b/packages/index/src/service.ts
@@ -6,26 +6,13 @@ import { runMigrations } from "./schema/migrations.ts";
 import { IndexService } from "./api.ts";
 import { countAll } from "./blob/store.ts";
 import { branchExists } from "./manifest/manifest.ts";
-import { getEmbeddingProvider } from "./embedding/provider.ts";
 import { indexRepo } from "./indexer.ts";
-import { bm25Search } from "./retrieval/bm25.ts";
-import { reciprocalRankFusion } from "./retrieval/rrf.ts";
-import { route } from "./retrieval/router.ts";
-import {
-  fetchChunk,
-  findReferencesByName,
-  listFileSymbols,
-  lookupSymbol,
-  symbolHitToSearchHit,
-} from "./retrieval/symbol-lookup.ts";
-import { isVectorAvailable, vectorSearch } from "./retrieval/vector.ts";
-import { applyRerank } from "./rerank/index.ts";
+import { fetchChunk, findReferencesByName, listFileSymbols, lookupSymbol } from "./retrieval/symbol-lookup.ts";
 import {
   type IndexStatus,
-  type SearchHit,
   type SearchInput,
-  type SymbolHit,
 } from "./types.ts";
+import { search } from "./retrieval/search.ts";
 
 /**
  * Per-workspace config the host provides at boot. `root` is the absolute
@@ -178,170 +165,8 @@ export const IndexServiceLive = Layer.scoped(
         fetchChunk(db, chunkId, branchOr(branch)),
       listModule: ({ path, branch }) =>
         listFileSymbols(db, path, branchOr(branch)),
-      search: (input: SearchInput) => runSearch(db, config.branch, input),
+      search: (input: SearchInput) => search(db, config.branch, input),
     });
   }),
 );
 
-/**
- * Used by `search` to resolve a symbol to its enclosing chunk's id + content
- * so the agent gets actual code text, not just `function foo(...)`. Returns
- * `null` when the symbol has no anchored chunk (type aliases, properties).
- */
-const fetchChunkBySymbol = (
-  db: IndexDb,
-  symbolId: number,
-  branch: string,
-): Effect.Effect<{ chunkId: number; content: string } | null, never> =>
-  Effect.sync(() => {
-    try {
-      const row = db
-        .prepare(
-          `SELECT c.id, c.content FROM chunks c
-           JOIN manifests m ON m.blob_id = c.blob_id AND m.branch = ?
-           WHERE c.symbol_id = ?
-           ORDER BY c.id ASC LIMIT 1`,
-        )
-        .get(branch, symbolId) as { id: number; content: string } | undefined;
-      return row ? { chunkId: row.id, content: row.content } : null;
-    } catch {
-      return null;
-    }
-  });
-
-/**
- * Hybrid search pipeline — routes the query into the tier(s) the router
- * recommends, runs them in parallel, fuses via RRF when more than one
- * tier fires. Symbol-only queries skip fusion entirely (single source,
- * RRF would be a no-op).
- */
-const runSearch = (
-  db: IndexDb,
-  defaultBranch: string,
-  input: SearchInput,
-): Effect.Effect<ReadonlyArray<SearchHit>, never> =>
-  Effect.gen(function* () {
-    const branch = input.branch ?? defaultBranch;
-    const limit = input.limit ?? 5;
-    const pathGlob = input.pathGlob;
-    const tiers = route(input.query, input.kind);
-
-    const wantsSymbol = tiers.includes("symbol");
-    const wantsBm25 = tiers.includes("bm25");
-    const wantsVector = tiers.includes("vector");
-
-    // Tier 1 — symbol lookup. Single-source path returns directly.
-    const symbolHits = wantsSymbol
-      ? yield* lookupSymbol(db, input.query, branch, undefined, 20, pathGlob).pipe(
-          Effect.catchAll(() =>
-            Effect.succeed([] as ReadonlyArray<ReturnType<typeof Object>>),
-          ),
-        )
-      : [];
-
-    if (tiers.length === 1 && wantsSymbol) {
-      const out: SearchHit[] = [];
-      for (const h of symbolHits.slice(0, limit) as ReadonlyArray<SymbolHit>) {
-        const chunk = yield* fetchChunkBySymbol(db, h.symbolId, branch);
-        out.push(
-          symbolHitToSearchHit(h, chunk?.content ?? `${h.kind} ${h.name}`),
-        );
-      }
-      return out as ReadonlyArray<SearchHit>;
-    }
-
-    // Tier 2 / Tier 3 — gather candidates, fuse via RRF.
-    const fanout = 30;
-    const rankings: ReadonlyArray<{ chunkId: number }>[] = [];
-
-    if (wantsBm25) {
-      const hits = yield* bm25Search(db, input.query, branch, fanout, pathGlob).pipe(
-        Effect.catchAll(() => Effect.succeed([])),
-      );
-      rankings.push(hits);
-    }
-    if (wantsVector && isVectorAvailable(db)) {
-      const provider = getEmbeddingProvider();
-      if (provider.id !== "null") {
-        const [vec] = yield* Effect.tryPromise({
-          try: () => provider.embed([input.query]),
-          catch: () => new Error("embed failed"),
-        }).pipe(Effect.catchAll(() => Effect.succeed([new Float32Array(0)])));
-        if (vec && vec.length > 0) {
-          const hits = yield* vectorSearch(db, vec, branch, fanout, pathGlob).pipe(
-            Effect.catchAll(() => Effect.succeed([])),
-          );
-          rankings.push(hits);
-        }
-      }
-    }
-    if (wantsSymbol && symbolHits.length > 0) {
-      rankings.push(
-        symbolHits.map((h) => ({
-          chunkId: -1 - (h as { symbolId: number }).symbolId,
-        })),
-      );
-    }
-
-    // Over-fetch into RRF; we'll narrow with rerank before returning.
-    const fanForRerank = Math.max(20, limit * 4);
-    const fused = reciprocalRankFusion(rankings).slice(0, fanForRerank);
-    const out: SearchHit[] = [];
-    for (const { chunkId, score } of fused) {
-      if (chunkId < 0) {
-        // Symbol-derived placeholder id. Convert back, fetch its chunk.
-        const symbolId = -1 - chunkId;
-        const sh = (symbolHits as ReadonlyArray<SymbolHit>).find(
-          (h) => h.symbolId === symbolId,
-        );
-        if (!sh) continue;
-        const chunk = yield* fetchChunkBySymbol(db, symbolId, branch);
-        out.push({
-          ...symbolHitToSearchHit(sh, chunk?.content ?? `${sh.kind} ${sh.name}`),
-          chunkId: chunk?.chunkId ?? -1,
-          score,
-          source: "fused",
-        });
-      } else {
-        const row = yield* Effect.try({
-          try: () =>
-            db
-              .prepare(
-                `SELECT c.id, c.start_line, c.end_line, c.content, c.symbol_id, m.file_path
-                 FROM chunks c
-                 JOIN manifests m ON m.blob_id = c.blob_id AND m.branch = ?
-                 WHERE c.id = ?`,
-              )
-              .get(branch, chunkId) as
-              | {
-                  id: number;
-                  start_line: number;
-                  end_line: number;
-                  content: string;
-                  symbol_id: number | null;
-                  file_path: string;
-                }
-              | undefined,
-          catch: () => new Error("fetch chunk failed"),
-        }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
-        if (!row) continue;
-        out.push({
-          chunkId: row.id,
-          file: row.file_path,
-          range: { start: row.start_line, end: row.end_line },
-          symbol: null,
-          content: row.content,
-          score,
-          source: "fused",
-        });
-      }
-    }
-    // Phase D: rerank the over-fetched fused candidates and trim to `limit`.
-    // No-op when the active provider is NullRerankProvider (default), so
-    // local installs without a paid backend still get the RRF ordering.
-    const reranked = yield* Effect.tryPromise({
-      try: () => applyRerank(input.query, out, limit),
-      catch: () => new Error("rerank failed"),
-    }).pipe(Effect.catchAll(() => Effect.succeed(out.slice(0, limit))));
-    return reranked as ReadonlyArray<SearchHit>;
-  });


### PR DESCRIPTION
## Summary
- Extracts the hybrid search pipeline (symbol + BM25 + vector + RRF + rerank) out of `packages/index/src/service.ts` into `packages/index/src/retrieval/search.ts` as a single source of truth.
- Wires that shared `search()` into the standalone MCP server so external agents get full hybrid retrieval through `code_search` instead of a symbol-only stub.
- Enriches `index_status` with `populated` + basic stats (blobs/chunks/symbols/refs) and adds a `reindex` tool; smoke test expanded to cover the new 7-tool surface and exercise `code_search` end-to-end.

## Test plan
- [x] `pnpm --filter @memoize/mcp-server test` (smoke test asserts 7 tools, new status fields, hybrid code_search returns hits)