### PR TITLE
feat(new-session): instant tab + loading panel, background provider boot

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -166,10 +166,32 @@ function MainShell() {
       ? s.creatingByProject[selectedFolderId] === true
       : false,
   );
+  // Active chat = the chat owning the selected session (if any), else the
+  // sidebar's selected chat. Mirrors `MainTabs.activeChatId` so the
+  // booting-session loading panel and the tab strip stay in lockstep when
+  // the chats store is mid-transition.
+  const selectedChatId = useChatsStore((s) => s.selectedChatId);
+  const activeChatId =
+    selectedSession?.chatId ?? selectedChatId ?? null;
+  // Mirror `NewChatTabButton.creating` so the chat surface flips to the
+  // loading panel the moment the user clicks "+", even before the
+  // optimistic session row lands (~200ms RPC). Once the new row is
+  // inserted with status="booting", `creatingForActiveChat` clears and
+  // the booting check below carries the panel through the provider boot.
+  const creatingForActiveChat = useSessionsStore((s) =>
+    activeChatId !== null ? s.creatingByChat[activeChatId] === true : false,
+  );
+  const selectedSessionBooting = selectedSession?.status === "booting";
+  const showSessionBootingPanel =
+    !creatingChat && (selectedSessionBooting || creatingForActiveChat);
   const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
   const defaultAutoCreateWorktree = useSettingsStore(
     (s) => s.defaultAutoCreateWorktree,
   );
+  // Provider label for the session-boot panel — falls back to the user's
+  // default when no session is selected yet (the brief click → RPC window).
+  const bootingProviderId =
+    selectedSession?.providerId ?? defaultProviderId;
 
   const activeMainTab = useUiStore((s) => s.activeMainTab);
   const openFile = useUiStore((s) => s.openFile);
@@ -303,6 +325,17 @@ function MainShell() {
                   <ChatCreatingPanel
                     providerId={defaultProviderId}
                     willCreateWorktree={defaultAutoCreateWorktree}
+                    prompt=""
+                  />
+                </div>
+              ) : showSessionBootingPanel ? (
+                <div className="flex min-h-0 flex-1 flex-col px-8 py-6">
+                  <p className="mb-4 text-[13px] leading-snug text-foreground/85">
+                    Starting a new tab in this chat
+                  </p>
+                  <ChatCreatingPanel
+                    providerId={bootingProviderId}
+                    willCreateWorktree={false}
                     prompt=""
                   />
                 </div>

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -18,7 +18,7 @@ import { useSettingsStore } from "../store/settings.ts";
 import { useUiStore } from "../store/ui.ts";
 import { FileIcon } from "./file-icon.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
-import { Beacon } from "./ui/loaders";
+import { Beacon, Diffusion } from "./ui/loaders";
 
 type Props = {
   readonly projectId: FolderId | null;
@@ -334,6 +334,9 @@ function ChatTabButton({
 function NewChatTabButton({ chatId }: { chatId: import("@memoize/wire").ChatId }) {
   const refresh = useProvidersStore((s) => s.refresh);
   const create = useSessionsStore((s) => s.create);
+  const creating = useSessionsStore(
+    (s) => s.creatingByChat[chatId] === true,
+  );
   const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
   const defaultModelByProvider = useSettingsStore(
     (s) => s.defaultModelByProvider,
@@ -341,9 +344,14 @@ function NewChatTabButton({ chatId }: { chatId: import("@memoize/wire").ChatId }
   const defaultRuntimeMode = useSettingsStore((s) => s.defaultRuntimeMode);
 
   // Creates a new session inside the active chat. Worktree is inherited
-  // from the chat row server-side.
+  // from the chat row server-side. Skip the awaited provider refresh when
+  // we already have a default model cached — saves 100–500ms per click on
+  // the warm path; cold cache still pays for the round-trip.
   const onClick = async () => {
-    await refresh();
+    if (creating) return;
+    if (defaultModelByProvider[defaultProviderId] === undefined) {
+      await refresh();
+    }
     const model =
       defaultModelByProvider[defaultProviderId] ??
       defaultModelFor(defaultProviderId);
@@ -356,11 +364,18 @@ function NewChatTabButton({ chatId }: { chatId: import("@memoize/wire").ChatId }
     <button
       type="button"
       onClick={() => void onClick()}
+      disabled={creating}
       title="New tab in this chat"
       aria-label="New tab in this chat"
-      className="relative flex items-center justify-center rounded px-2 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+      className="relative flex items-center justify-center rounded px-2 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
     >
-      <Plus className="size-3.5" />
+      {creating ? (
+        <span className="inline-flex size-3.5 items-center justify-center">
+          <Diffusion dotSize={3} cellPadding={1} />
+        </span>
+      ) : (
+        <Plus className="size-3.5" />
+      )}
     </button>
   );
 }

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -130,6 +130,12 @@ function useSessionRunningSubscriptions(
                       [id]: event.status === "running",
                     },
                   }));
+                  // Mirror the full status into the session row so the
+                  // chat surface can branch on `booting` (loading panel)
+                  // vs `idle` (composer ready) without a second stream.
+                  useSessionsStore
+                    .getState()
+                    .setSessionStatus(id, event.status);
                 }),
             ),
           );

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -44,6 +44,15 @@ type SessionsState = {
   readonly selectedSessionByProject: Record<string, SessionId | null>;
   readonly showArchivedByProject: Record<string, boolean>;
   readonly loadingByProject: Record<string, boolean>;
+  /**
+   * Per-chat in-flight flag for `create()`. Drives the tab-strip "+"
+   * button's icon + disabled state and the loading panel that takes over
+   * the chat surface while a new tab is booting. Cleared when the RPC
+   * resolves (success or failure) — note the server-side boot continues
+   * after the RPC returns; the chat surface keeps showing the panel via
+   * `Session.status === "booting"` until the provider handshake completes.
+   */
+  readonly creatingByChat: Record<string, boolean>;
   readonly error: string | null;
   readonly hydrate: (projectId: FolderId) => Promise<void>;
   readonly create: (
@@ -57,6 +66,16 @@ type SessionsState = {
       toolSearch?: boolean;
     },
   ) => Promise<SessionId | null>;
+  /**
+   * Patch the cached `Session.status` for a session. Called by the
+   * `session.streamStatus` subscription so the renderer's view of
+   * `Session.status` reflects post-boot transitions
+   * (`booting` → `idle` / `running` / `error`).
+   */
+  readonly setSessionStatus: (
+    sessionId: SessionId,
+    status: Session["status"],
+  ) => void;
   readonly rename: (sessionId: SessionId, title: string) => Promise<void>;
   readonly setModel: (sessionId: SessionId, model: string) => Promise<void>;
   readonly setRuntimeMode: (
@@ -117,6 +136,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
   selectedSessionByProject: {},
   showArchivedByProject: {},
   loadingByProject: {},
+  creatingByChat: {},
   error: null,
   hydrate: async (projectId) => {
     set((s) => ({
@@ -142,7 +162,10 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
     }
   },
   create: async (chatId, providerId, model, opts) => {
-    set({ error: null });
+    set((s) => ({
+      error: null,
+      creatingByChat: { ...s.creatingByChat, [chatId]: true },
+    }));
     try {
       const client = await getRpcClient();
       // Sub-agent presets are Claude-only this PR — Codex sessions ship
@@ -178,13 +201,37 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
             ...s.selectedSessionByProject,
             [projectId]: session.id,
           },
+          creatingByChat: { ...s.creatingByChat, [chatId]: false },
         };
       });
       return session.id;
     } catch (err) {
-      set({ error: formatError(err) });
+      set((s) => ({
+        error: formatError(err),
+        creatingByChat: { ...s.creatingByChat, [chatId]: false },
+      }));
       return null;
     }
+  },
+  setSessionStatus: (sessionId, status) => {
+    set((s) => {
+      const projectId = findSessionProject(s.sessionsByProject, sessionId);
+      if (projectId === null) return s;
+      const list = s.sessionsByProject[projectId] ?? [];
+      let changed = false;
+      const next = list.map((row) => {
+        if (row.id !== sessionId || row.status === status) return row;
+        changed = true;
+        return { ...row, status } as Session;
+      });
+      if (!changed) return s;
+      return {
+        sessionsByProject: {
+          ...s.sessionsByProject,
+          [projectId]: next,
+        },
+      };
+    });
   },
   rename: async (sessionId, title) => {
     set({ error: null });

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -134,6 +134,11 @@ const SessionCreate = MemoizeRpcs.toLayerHandler("session.create", (input) =>
       enableSubagents: input.enableSubagents,
       permissionMode: input.permissionMode,
       toolSearch: input.toolSearch,
+      // Detach `provider.start` so the new in-chat tab appears in
+      // ~hundreds of ms; the booting status flips when the CLI handshake
+      // finishes (or fails). Chat-create stays synchronous to preserve
+      // its existing staged loading panel timing.
+      background: true,
     }),
   ),
 );

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -707,6 +707,12 @@ export const MessageStoreLive = Layer.scoped(
     yield* sql`
       UPDATE sessions SET status = 'idle' WHERE status = 'running'
     `.pipe(Effect.orDie);
+    // Sessions left in `booting` from a crashed daemon never finished the
+    // provider handshake — surface them as failed starts so the renderer
+    // shows a closable tab instead of a stuck spinner.
+    yield* sql`
+      UPDATE sessions SET status = 'error' WHERE status = 'booting'
+    `.pipe(Effect.orDie);
 
     const listSessions: MessageStoreShape["listSessions"] = (
       projectId,
@@ -802,16 +808,15 @@ export const MessageStoreLive = Layer.scoped(
           chatRow.worktree_id === null
             ? null
             : (chatRow.worktree_id as unknown as WorktreeId);
-        // Provider mints the canonical session id; we mirror it into the row
-        // so the in-memory map and the persisted row stay in lockstep. New
-        // sessions always start at the default runtime mode — `canUseTool`
-        // can't fire until provider.start returns, so resolving sessionId
-        // through a closure is safe.
-        let mintedSessionId: SessionId | null = null;
+        // Mint the session id up-front so the row + caches exist BEFORE
+        // `provider.start` runs. Background-mode callers (`session.create`)
+        // can then return immediately and let the slow CLI boot flip the
+        // status out of `"booting"` from a daemon fiber.
+        const sessionId = SessionId.make(
+          `s_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+        );
         const newSessionRuntimeMode: GetRuntimeMode = () =>
-          mintedSessionId === null
-            ? DEFAULT_RUNTIME_MODE
-            : getRuntimeModeFor(mintedSessionId);
+          getRuntimeModeFor(sessionId);
         const effectiveEnableSubagents =
           input.enableSubagents ??
           (input.agents !== undefined && Object.keys(input.agents).length > 0);
@@ -819,12 +824,136 @@ export const MessageStoreLive = Layer.scoped(
         const initialPermissionMode =
           input.permissionMode ?? DEFAULT_PERMISSION_MODE;
         const initialToolSearch = input.toolSearch ?? false;
-        const started = yield* provider
+        const initialRuntimeMode = input.runtimeMode ?? DEFAULT_RUNTIME_MODE;
+        runtimeModeBySession.set(sessionId, initialRuntimeMode);
+        permissionModeBySession.set(sessionId, initialPermissionMode);
+        if (input.agents !== undefined && Object.keys(input.agents).length > 0) {
+          agentsBySession.set(sessionId, {
+            agents: input.agents,
+            enableSubagents: effectiveEnableSubagents,
+          });
+        }
+        const now = new Date();
+        const nowIso = now.toISOString();
+        const title = input.title?.trim() || titleFromInitial(input.initialPrompt);
+        const agentsJson =
+          input.agents !== undefined && Object.keys(input.agents).length > 0
+            ? JSON.stringify({
+                agents: input.agents,
+                enableSubagents: effectiveEnableSubagents,
+              })
+            : null;
+        const hasInitial =
+          input.initialPrompt !== undefined &&
+          input.initialPrompt.trim().length > 0;
+        const background = input.background === true;
+        const postBootStatus: Session["status"] = hasInitial
+          ? "running"
+          : "idle";
+        // Synchronous mode (chat.create) inserts with the final post-boot
+        // status because it waits for `provider.start` below — the row is
+        // never visible to the renderer in `booting`. Background mode
+        // (session.create) inserts as `booting`; the daemon flips it.
+        const rowStatus: Session["status"] = background
+          ? "booting"
+          : postBootStatus;
+        if (background) {
+          yield* sql`
+            INSERT INTO sessions
+              (id, project_id, title, provider_id, model, status, runtime_mode,
+               agents_json, worktree_id, chat_id, permission_mode,
+               tool_search, created_at, updated_at)
+            VALUES
+              (${sessionId}, ${projectId}, ${title}, ${input.providerId},
+               ${input.model}, ${rowStatus}, ${initialRuntimeMode},
+               ${agentsJson}, ${worktreeId}, ${input.chatId},
+               ${initialPermissionMode}, ${initialToolSearch ? 1 : 0},
+               ${nowIso}, ${nowIso})
+          `.pipe(Effect.orDie);
+          yield* sql`
+            UPDATE chats
+            SET active_session_id = ${sessionId}, updated_at = ${nowIso}
+            WHERE id = ${input.chatId}
+          `.pipe(Effect.asVoid, Effect.orDie);
+          if (hasInitial) {
+            yield* persistMessage(sessionId, {
+              _tag: "user",
+              text: input.initialPrompt!,
+            });
+          }
+          // Detach the boot so the RPC reply happens immediately. The status
+          // pubsub fans the eventual transition out to the renderer via
+          // `session.streamStatus`; on failure we mark `error` and log so
+          // the user sees a closable failed tab instead of a stuck spinner.
+          yield* Effect.forkDaemon(
+            provider
+              .start(
+                {
+                  folderId: projectId,
+                  providerId: input.providerId,
+                  mode: "sdk",
+                  sessionId,
+                  initialPrompt: input.initialPrompt,
+                  model: input.model,
+                  agents: input.agents,
+                  enableSubagents: effectiveEnableSubagents,
+                  cwdOverride,
+                  permissionMode: initialPermissionMode,
+                  toolSearch: initialToolSearch,
+                },
+                null,
+                newSessionRuntimeMode,
+              )
+              .pipe(
+                Effect.flatMap(() =>
+                  Effect.gen(function* () {
+                    yield* setStatus(sessionId, postBootStatus);
+                    yield* startSubscription(sessionId);
+                  }),
+                ),
+                Effect.catchAll((err) =>
+                  Effect.gen(function* () {
+                    yield* Effect.logWarning(
+                      `[MessageStore] provider.start failed for session ${sessionId} (${input.providerId}): ${err.reason}`,
+                    );
+                    yield* setStatus(sessionId, "error");
+                  }),
+                ),
+              ),
+          );
+          return Session.make({
+            id: sessionId,
+            projectId,
+            title,
+            providerId: input.providerId,
+            model: input.model,
+            status: "booting",
+            archivedAt: null,
+            cursor: null,
+            resumeStrategy: "none",
+            runtimeMode: initialRuntimeMode,
+            worktreeId,
+            chatId: input.chatId,
+            forkedFromSessionId: null,
+            forkedFromMessageId: null,
+            permissionMode: initialPermissionMode,
+            toolSearch: initialToolSearch,
+            createdAt: now,
+            updatedAt: now,
+          });
+        }
+        // Synchronous boot — used by `chat.create` so its existing staged
+        // loading panel (which animates over the full ~60s wait) stays in
+        // lockstep with the actual provider handshake. Boot failures bubble
+        // back as `SessionStartError`; the caller (`createChat`) rolls back
+        // the chat row in that case.
+        yield* provider
           .start(
             {
               folderId: projectId,
               providerId: input.providerId,
               mode: "sdk",
+              sessionId,
               initialPrompt: input.initialPrompt,
               model: input.model,
               agents: input.agents,
@@ -849,34 +978,6 @@ export const MessageStoreLive = Layer.scoped(
                   }),
             ),
           );
-        const sessionId = started.sessionId;
-        mintedSessionId = sessionId;
-        const initialRuntimeMode = input.runtimeMode ?? DEFAULT_RUNTIME_MODE;
-        runtimeModeBySession.set(sessionId, initialRuntimeMode);
-        permissionModeBySession.set(sessionId, initialPermissionMode);
-        if (input.agents !== undefined && Object.keys(input.agents).length > 0) {
-          agentsBySession.set(sessionId, {
-            agents: input.agents,
-            enableSubagents: effectiveEnableSubagents,
-          });
-        }
-        const now = new Date();
-        const nowIso = now.toISOString();
-        const title = input.title?.trim() || titleFromInitial(input.initialPrompt);
-        const agentsJson =
-          input.agents !== undefined && Object.keys(input.agents).length > 0
-            ? JSON.stringify({
-                agents: input.agents,
-                enableSubagents: effectiveEnableSubagents,
-              })
-            : null;
-        // A fresh session is only "running" if the caller handed in an initial
-        // prompt — otherwise the provider has spun up but no turn is in flight,
-        // so the renderer should see `idle` and show Send (not Interrupt).
-        const hasInitial =
-          input.initialPrompt !== undefined &&
-          input.initialPrompt.trim().length > 0;
-        const initialStatus: Session["status"] = hasInitial ? "running" : "idle";
         yield* sql`
           INSERT INTO sessions
             (id, project_id, title, provider_id, model, status, runtime_mode,
@@ -884,13 +985,11 @@ export const MessageStoreLive = Layer.scoped(
              tool_search, created_at, updated_at)
           VALUES
             (${sessionId}, ${projectId}, ${title}, ${input.providerId},
-             ${input.model}, ${initialStatus}, ${initialRuntimeMode},
+             ${input.model}, ${rowStatus}, ${initialRuntimeMode},
              ${agentsJson}, ${worktreeId}, ${input.chatId},
              ${initialPermissionMode}, ${initialToolSearch ? 1 : 0},
              ${nowIso}, ${nowIso})
         `.pipe(Effect.orDie);
-        // Mark this session as the chat's last-active tab so the next
-        // sidebar click lands on it.
         yield* sql`
           UPDATE chats
           SET active_session_id = ${sessionId}, updated_at = ${nowIso}
@@ -909,7 +1008,7 @@ export const MessageStoreLive = Layer.scoped(
           title,
           providerId: input.providerId,
           model: input.model,
-          status: initialStatus,
+          status: postBootStatus,
           archivedAt: null,
           cursor: null,
           resumeStrategy: "none",

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -75,6 +75,16 @@ export interface CreateSessionInput {
    * the flag is here so 0.04's code-index MCP servers can ride on it.
    */
   readonly toolSearch?: boolean;
+  /**
+   * Defer `provider.start` to a background fiber and return as soon as the
+   * row is inserted. The returned `Session` has `status = "booting"`; a
+   * status pubsub event fires when boot finishes (`idle`/`running`) or
+   * fails (`error`). Used by the `session.create` RPC so a new in-chat tab
+   * appears in ~hundreds of ms instead of ~60s. `chat.create` keeps the
+   * default synchronous behavior so its existing staged loading panel
+   * timing is preserved.
+   */
+  readonly background?: boolean;
 }
 
 export interface CreateChatInput {

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -37,12 +37,17 @@ export type SessionId = AgentSessionId;
 
 /**
  * Persisted lifecycle state of a session. Mirrors the `sessions.status` column.
+ * `booting`  — row exists; provider boot (CLI spawn + SDK handshake) is in
+ *              flight on a background fiber. Transitions to `idle`/`running`
+ *              on success, `error` on failure. Stale `booting` rows from a
+ *              crashed daemon are cleaned up at boot.
  * `idle`     — row exists but no provider session is currently driving it.
  * `running`  — provider session is alive; `agent.events` is being consumed.
  * `closed`   — turn ended normally or session was closed by the user.
  * `error`    — provider terminated the session with an error.
  */
 export const SessionStatus = Schema.Literal(
+  "booting",
   "idle",
   "running",
   "closed",


### PR DESCRIPTION
## Summary

Clicking `+` on a chat's tab strip used to silently freeze the UI for ~60 s while `provider.start` spawned the CLI subprocess and waited for the SDK handshake. Now the new tab appears in ~hundreds of ms with a staged loading panel, and the slow boot runs on a daemon fiber.

- **Server:** `session.create` inserts the row with `status="booting"` and returns immediately; `provider.start` runs on a forked daemon and flips the status to `idle`/`running` on success or `error` on failure (boot recovery promotes stale `booting` rows from a crashed daemon to `error`). `chat.create` keeps the synchronous boot path so its existing staged loading panel timing is preserved — gated by a new `background?: boolean` flag on `CreateSessionInput`.
- **Renderer:** `NewChatTabButton` swaps `+` for a Diffusion spinner and disables itself while creating, and skips the awaited `providers.refresh()` when the default model is already cached. A new `creatingByChat` flag in the sessions store plus a `Session.status === "booting"` check (mirrored from the existing `streamStatus` subscription) drives `ChatCreatingPanel` to take over the chat surface — replacing the old session's view — until the provider handshake completes.
- **Wire:** adds `"booting"` to the `SessionStatus` literal union.

## Test plan

- [ ] `bun run check-types` (pre-existing `bun:test` error in `availability.test.ts` is unrelated).
- [ ] `bun run dev`, open a chat with ≥1 existing session, click `+` on the tab strip: spinner appears instantly, button is disabled, the booting panel replaces the old session view, the new tab is auto-selected, and when boot completes the panel disappears and the empty composer takes over.
- [ ] Spam-click `+` — only one session is created.
- [ ] Force a boot failure (e.g. rename `claude` binary) and confirm the tab lands in `error` status with a warning logged.
- [ ] Verify the existing `chat.create` flow (sidebar `+` / ChatLanding submit) is unchanged.