### PR TITLE
fix(ux): external links, worktree race, oob file chips, image tabs, cmd+w

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -176,6 +176,34 @@ function createMainWindow() {
     void shell.openExternal(parsed.toString());
   });
 
+  // Backstops so any stray http(s) link click in the shell webContents
+  // (markdown anchors without an onClick, target="_blank" forms, etc.)
+  // punts to the OS default browser instead of opening a child Electron
+  // window or navigating the SPA away. The in-app Browser tab uses a
+  // `<webview>` which runs in its own webContents and isn't affected.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        void shell.openExternal(parsed.toString());
+      }
+    } catch {
+      // not a parseable URL — drop silently
+    }
+    return { action: "deny" };
+  });
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        event.preventDefault();
+        void shell.openExternal(parsed.toString());
+      }
+    } catch {
+      // file:// (renderer index) and other internal schemes fall through
+    }
+  });
+
   // Boot the Effect runtime once the window's webContents exists. The RPC
   // server protocol is bound to this webContents, so a window restart means
   // a fresh runtime — the only Effect.runFork in the main process.

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -232,11 +232,18 @@ function MainShell() {
   }, [selectedFolderId, refreshWorktrees]);
 
   // Cmd+W in the menu dispatches `menu:close-tab` over IPC; the renderer
-  // owns the close-tab logic because it knows which chat tab is active.
+  // owns the close-tab logic because it knows which surface is active. If
+  // the file tab is foregrounded we close that; otherwise we fall through
+  // to the chat-tab archive path.
   useEffect(() => {
     const menu = window.memoize?.menu;
     if (menu === undefined) return;
     return menu.onCloseTab(() => {
+      const { activeMainTab, closeFileTab, openFile } = useUiStore.getState();
+      if (activeMainTab === "file" && openFile !== null) {
+        closeFileTab();
+        return;
+      }
       void closeActiveChatTab();
     });
   }, []);

--- a/apps/renderer/src/components/composer/composer-chip-overlay.tsx
+++ b/apps/renderer/src/components/composer/composer-chip-overlay.tsx
@@ -101,16 +101,21 @@ export function ComposerChipOverlay({
     const onClick = (e: MouseEvent) => {
       const chip = findChip(e.target);
       if (chip === null) return;
-      const absPath = chip.dataset.absPath;
       const relPath = chip.dataset.relPath;
       const entryKind = chip.dataset.entryKind;
-      if (absPath === undefined || relPath === undefined) return;
+      if (relPath === undefined) return;
       if (entryKind === "directory") return;
       e.preventDefault();
       e.stopPropagation();
+      // The chip's dataset.relPath is already project-root-relative — that's
+      // the shape `fs.readFile` expects. Passing absPath would round-trip
+      // through `resolveInsideFolder` and reject with FsPathOutsideError
+      // when the workspace happens to live under a different root than the
+      // composer suggested.
       openFileInTab({
+        kind: "text",
         folderId: projectId,
-        path: absPath,
+        path: relPath,
         name: basename(relPath),
         worktreeId,
       });

--- a/apps/renderer/src/components/diff-pane.tsx
+++ b/apps/renderer/src/components/diff-pane.tsx
@@ -256,6 +256,7 @@ function FileRow({
         type="button"
         onClick={() =>
           openFileInTab({
+            kind: "text",
             folderId,
             worktreeId,
             path,

--- a/apps/renderer/src/components/file-chip.tsx
+++ b/apps/renderer/src/components/file-chip.tsx
@@ -4,6 +4,8 @@ import type { FolderId, WorktreeId } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 import { useUiStore, type FileView } from "~/store/ui";
+import { useWorkspaceStore } from "~/store/workspace";
+import { useWorktreesStore } from "~/store/worktrees";
 import { FileIcon } from "./file-icon.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
@@ -76,19 +78,55 @@ export function FileChip({
 }) {
   const { folderId, worktreeId } = useFileChipContext();
   const openFileInTab = useUiStore((s) => s.openFileInTab);
+  const folderPath = useWorkspaceStore((s) => {
+    if (folderId === null) return null;
+    return s.folders.find((f) => f.id === folderId)?.path ?? null;
+  });
+  const worktreePath = useWorktreesStore((s) => {
+    if (folderId === null || worktreeId === null) return null;
+    const list = s.byProject[folderId] ?? [];
+    return list.find((w) => w.id === worktreeId)?.path ?? null;
+  });
 
   const name = basename(relPath);
+
+  // Resolve the chip's effective root + workspace-relative path. Tool rows
+  // sometimes carry an absolute path from another workspace (Conductor
+  // side-checkouts, sibling repos); opening those would trigger
+  // `FsPathOutsideError` on the server. Detect early, surface as a
+  // non-clickable chip with an explanatory tooltip.
+  const rootPath = worktreePath ?? folderPath;
+  const looksAbsolute = absPath !== undefined || relPath.startsWith("/");
+  const resolvedAbs = absPath ?? (relPath.startsWith("/") ? relPath : null);
+  const insideWorkspace =
+    rootPath !== null &&
+    resolvedAbs !== null &&
+    (resolvedAbs === rootPath || resolvedAbs.startsWith(`${rootPath}/`));
+  const workspaceRelPath =
+    insideWorkspace && resolvedAbs !== null && rootPath !== null
+      ? resolvedAbs.slice(rootPath.length + 1)
+      : !looksAbsolute
+        ? relPath
+        : null;
+
   const canOpen =
-    kind === "file" && folderId !== null && (absPath !== undefined || relPath.startsWith("/"));
+    kind === "file" && folderId !== null && workspaceRelPath !== null;
 
   const tooltip =
-    kind === "directory" ? `View ${relPath}` : canOpen ? `Open ${relPath}` : relPath;
+    kind === "directory"
+      ? `View ${relPath}`
+      : canOpen
+        ? `Open ${relPath}`
+        : looksAbsolute && !insideWorkspace
+          ? `${relPath} — outside this workspace`
+          : relPath;
 
   const onClick = () => {
-    if (!canOpen || folderId === null) return;
+    if (!canOpen || folderId === null || workspaceRelPath === null) return;
     openFileInTab({
+      kind: "text",
       folderId,
-      path: absPath ?? relPath,
+      path: workspaceRelPath,
       name,
       worktreeId,
       view,

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -28,10 +28,21 @@ type EditorState =
   | { status: "error"; reason: string };
 
 const formatError = (err: unknown): string => {
-  if (err instanceof Error) return err.message;
   if (typeof err === "object" && err !== null && "_tag" in err) {
-    return String((err as { _tag: unknown })._tag);
+    const tag = String((err as { _tag: unknown })._tag);
+    if (tag === "FsPathOutsideError") {
+      const p =
+        "path" in (err as Record<string, unknown>)
+          ? String((err as { path: unknown }).path)
+          : null;
+      return p === null
+        ? "This file is outside the current project."
+        : `This file is outside the current project (${p}).`;
+    }
+    if (err instanceof Error) return err.message;
+    return tag;
   }
+  if (err instanceof Error) return err.message;
   return String(err);
 };
 
@@ -50,11 +61,16 @@ const tagOf = (err: unknown): string | null =>
 export function FileEditor() {
   const openFile = useUiStore((s) => s.openFile);
   const closeFileTab = useUiStore((s) => s.closeFileTab);
-  const view = openFile?.view ?? "edit";
 
   if (openFile === null) {
     return <Placeholder>No file open.</Placeholder>;
   }
+
+  if (openFile.kind === "image") {
+    return <ImageBody src={openFile.src} name={openFile.name} />;
+  }
+
+  const view = openFile.view;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -69,6 +85,25 @@ export function FileEditor() {
   );
 }
 
+/**
+ * Inline image preview — used for attachment screenshots so clicking the
+ * thumbnail keeps the user inside the app rather than punting to the OS
+ * handler. No toolbar, no read RPC; the privileged `memoize://` scheme
+ * (see `apps/desktop/src/main.ts`) lets the renderer fetch the bytes
+ * directly.
+ */
+function ImageBody({ src, name }: { src: string; name: string }) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-black/40 p-4">
+      <img
+        src={src}
+        alt={name}
+        className="max-h-full max-w-full object-contain"
+      />
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // CodeMirror body — loads a file via fs.readFile, mounts the editor once,
 // swaps documents on file change. Cmd+S saves via fs.writeFile.
@@ -79,7 +114,7 @@ function CodeMirrorBody({
   hidden,
   onClose,
 }: {
-  openFile: OpenFile;
+  openFile: Extract<OpenFile, { kind: "text" }>;
   hidden: boolean;
   onClose: () => void;
 }) {
@@ -98,7 +133,7 @@ function CodeMirrorBody({
   const baselineRef = useRef("");
   const mtimeRef = useRef("");
   const savingRef = useRef(false);
-  const fileRef = useRef<OpenFile | null>(openFile);
+  const fileRef = useRef<Extract<OpenFile, { kind: "text" }> | null>(openFile);
   fileRef.current = openFile;
 
   const save = async () => {
@@ -274,7 +309,11 @@ type DiffState =
   | { status: "ready"; result: GitDiffResult }
   | { status: "error"; reason: string };
 
-function DiffViewBody({ openFile }: { openFile: OpenFile }) {
+function DiffViewBody({
+  openFile,
+}: {
+  openFile: Extract<OpenFile, { kind: "text" }>;
+}) {
   const [state, setState] = useState<DiffState>({ status: "loading" });
 
   useEffect(() => {

--- a/apps/renderer/src/components/file-tree.tsx
+++ b/apps/renderer/src/components/file-tree.tsx
@@ -129,6 +129,7 @@ export function FileTree({ folderId }: { folderId: FolderId }) {
         return;
       }
       openFileInTab({
+        kind: "text",
         folderId,
         path: entry.path,
         name: entry.name,

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -148,8 +148,8 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
           <FileTabButton
             active={activeMainTab === "file"}
             name={openFile.name}
-            path={openFile.path}
-            dirty={fileDirty}
+            path={openFile.kind === "text" ? openFile.path : openFile.name}
+            dirty={openFile.kind === "text" ? fileDirty : false}
             onClick={() => setActiveMainTab("file")}
             onClose={closeFileTab}
           />

--- a/apps/renderer/src/components/markdown-body.tsx
+++ b/apps/renderer/src/components/markdown-body.tsx
@@ -2,14 +2,41 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 /**
- * Shared markdown surface for PR descriptions, comments, and review bodies.
- * Reuses the `fz-prose` typography class already tuned for chat messages so
- * link colors / list spacing / code blocks stay consistent across the app.
+ * Shared markdown surface for PR descriptions, comments, review bodies, and
+ * assistant chat bubbles. Reuses the `fz-prose` typography class already
+ * tuned for chat messages so link colors / list spacing / code blocks stay
+ * consistent across the app.
+ *
+ * All http(s) anchors are intercepted and handed to `shell.openExternal` via
+ * the preload bridge so a click never navigates the renderer or opens a
+ * child Electron window — every clicked link lands in the user's default
+ * browser. Non-http schemes (e.g. `memoize://attachments/...`) are left to
+ * their own handlers.
  */
 export function MarkdownBody({ children }: { children: string }) {
   return (
     <div className="fz-prose">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ href, children, ...rest }) => (
+            <a
+              {...rest}
+              href={href}
+              onClick={(e) => {
+                if (typeof href !== "string") return;
+                if (!/^https?:\/\//i.test(href)) return;
+                e.preventDefault();
+                window.memoize?.app.openExternal(href);
+              }}
+            >
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -9,9 +9,6 @@ import {
   Settings,
 } from "lucide-react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-
 import type {
   AgentItemId,
   AttachmentRef,
@@ -29,6 +26,7 @@ import { useMessagesStore, type ChatError } from "~/store/messages";
 import { useUiStore } from "~/store/ui";
 
 import { FileChip } from "./file-chip.tsx";
+import { MarkdownBody } from "./markdown-body.tsx";
 import {
   ExitPlanModeRow,
   ThinkingRow,
@@ -200,18 +198,14 @@ function UserBubble({
             {(attachments ?? []).map((a) => {
               const isImage = a.mimeType.startsWith("image/");
               const iconUrl = isImage ? null : getFileIconUrl(a.originalName);
-              return (
-                <a
-                  key={a.id}
-                  href={`memoize://attachments/${a.id}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  title={a.originalName}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted/60"
-                >
+              const src = `memoize://attachments/${a.id}`;
+              const className =
+                "inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted/60";
+              const inner = (
+                <>
                   {isImage ? (
                     <img
-                      src={`memoize://attachments/${a.id}`}
+                      src={src}
                       alt=""
                       className="size-4 rounded object-cover"
                     />
@@ -219,6 +213,37 @@ function UserBubble({
                     <img src={iconUrl} alt="" className="size-4" />
                   ) : null}
                   <span className="truncate">{truncate(a.originalName)}</span>
+                </>
+              );
+              if (isImage) {
+                return (
+                  <button
+                    key={a.id}
+                    type="button"
+                    title={a.originalName}
+                    className={className}
+                    onClick={() =>
+                      useUiStore.getState().openFileInTab({
+                        kind: "image",
+                        src,
+                        name: a.originalName,
+                      })
+                    }
+                  >
+                    {inner}
+                  </button>
+                );
+              }
+              return (
+                <a
+                  key={a.id}
+                  href={src}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={a.originalName}
+                  className={className}
+                >
+                  {inner}
                 </a>
               );
             })}
@@ -251,8 +276,8 @@ function UserBubble({
 function AssistantBubble({ text }: { text: string }) {
   return (
     <div className="px-4 py-2">
-      <div className="fz-prose max-w-[88%]">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+      <div className="max-w-[88%]">
+        <MarkdownBody>{text}</MarkdownBody>
       </div>
     </div>
   );

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -42,18 +42,31 @@ export type RightTab = "files" | "terminal" | "changes" | "pr" | "browser";
  */
 export type FileView = "edit" | "diff";
 
-export type OpenFile = {
-  readonly folderId: FolderId;
-  readonly path: string;
-  readonly name: string;
-  /**
-   * Worktree the file lives in. Persisted on the OpenFile so a save still
-   * targets the right tree even if the user switches selected sessions
-   * while the file is open. `null` means main checkout.
-   */
-  readonly worktreeId: WorktreeId | null;
-  readonly view: FileView;
-};
+/**
+ * Discriminated by `kind`. `text` is the project-root-relative path the file
+ * editor reads via `fs.readFile`; `image` is a raw URL the renderer renders
+ * inline (currently used for `memoize://attachments/<id>` so screenshots
+ * stay inside the app instead of bouncing to the OS handler).
+ */
+export type OpenFile =
+  | {
+      readonly kind: "text";
+      readonly folderId: FolderId;
+      readonly path: string;
+      readonly name: string;
+      /**
+       * Worktree the file lives in. Persisted on the OpenFile so a save
+       * still targets the right tree even if the user switches selected
+       * sessions while the file is open. `null` means main checkout.
+       */
+      readonly worktreeId: WorktreeId | null;
+      readonly view: FileView;
+    }
+  | {
+      readonly kind: "image";
+      readonly src: string;
+      readonly name: string;
+    };
 
 type UiState = {
   readonly view: View;
@@ -72,7 +85,11 @@ type UiState = {
   readonly activeRightTab: RightTab;
   readonly setActiveMainTab: (tab: MainTab) => void;
   readonly openFileInTab: (
-    file: Omit<OpenFile, "view"> & { view?: FileView },
+    file:
+      | (Omit<Extract<OpenFile, { kind: "text" }>, "view"> & {
+          view?: FileView;
+        })
+      | Extract<OpenFile, { kind: "image" }>,
   ) => void;
   readonly setOpenFileView: (view: FileView) => void;
   readonly closeFileTab: () => void;
@@ -99,12 +116,18 @@ export const useUiStore = create<UiState>((set) => ({
   setActiveMainTab: (tab) => set({ activeMainTab: tab }),
   openFileInTab: (file) =>
     set({
-      openFile: { ...file, view: file.view ?? "edit" },
+      openFile:
+        file.kind === "image"
+          ? file
+          : { ...file, view: file.view ?? "edit" },
       activeMainTab: "file",
       fileDirty: false,
     }),
   setOpenFileView: (view) =>
-    set((s) => (s.openFile === null ? s : { openFile: { ...s.openFile, view } })),
+    set((s) => {
+      if (s.openFile === null || s.openFile.kind !== "text") return s;
+      return { openFile: { ...s.openFile, view } };
+    }),
   closeFileTab: () =>
     set({ openFile: null, activeMainTab: "chat", fileDirty: false }),
   setFileDirty: (dirty) => set({ fileDirty: dirty }),

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -1398,6 +1398,23 @@ export const MessageStoreLive = Layer.scoped(
           UPDATE sessions SET worktree_id = ${worktreeId}, updated_at = ${nowIso}
           WHERE chat_id = ${chatId}
         `.pipe(Effect.asVoid, Effect.orDie);
+        // Background-booted sessions (chat.create → session.create with
+        // background=true) already spawned a provider CLI in the OLD cwd
+        // before the user got a chance to pick a worktree. Kill those so
+        // the next `sendMessage` lazy-restarts via `restartProviderSession`,
+        // which reads the now-updated `session.worktreeId` and resolves
+        // `cwdForWorktree` to the new path. Without this teardown the
+        // first user message would land in the wrong working tree.
+        const memberSessions = yield* sql<{ readonly id: string }>`
+          SELECT id FROM sessions
+          WHERE chat_id = ${chatId} AND archived_at IS NULL
+        `.pipe(Effect.orDie);
+        for (const row of memberSessions) {
+          const sid = row.id as SessionId;
+          yield* provider.close(sid).pipe(Effect.catchAll(() => Effect.void));
+          yield* interruptProviderFiber(sid);
+          yield* setStatus(sid, "idle");
+        }
         return yield* lookupChat(chatId);
       });
 


### PR DESCRIPTION
## Summary
- Every clicked link now opens in the OS default browser: `setWindowOpenHandler` + `will-navigate` interceptors in the shell process, plus a `components.a` override in `MarkdownBody` (assistant bubbles now share that policy).
- `chat.setWorktree` tears down each member session's provider + event-pump fiber so the next user message lazy-restarts in the freshly picked worktree cwd — fixes new-chat → pick-worktree → first edit landing in the main checkout.
- `FileChip` resolves the effective workspace root (folder or worktree), renders out-of-workspace abs paths as non-clickable with a tooltip, and normalises inside-paths to project-relative before `fs.readFile`; composer chip overlay now sends `relPath` directly. `FsPathOutsideError` gets a friendlier message in the file editor.
- `OpenFile` is now a discriminated `text | image` union; screenshot attachments open inline in a new `ImageBody` instead of bouncing to Preview; Cmd+W closes the active file tab when foregrounded, otherwise falls through to chat-tab archive.

## Test plan
- [ ] Click an http(s) link in chat / PR markdown — opens in system browser, app does not navigate or spawn the in-app Browser tab.
- [ ] New chat → "New worktree" before sending a message → ask agent to create a file at the repo root; verify the file lands in the worktree path, not the main checkout.
- [ ] Click a tool-row file chip whose abs path points outside the workspace — chip is non-clickable with an explanatory tooltip; inside-workspace chips still open.
- [ ] Paste a screenshot, send, click the thumbnail — image renders inline in a new file tab.
- [ ] Cmd+W with file tab focused closes the file tab; Cmd+W with a chat tab focused archives the session as before.