### PR TITLE
Fix git-not-a-repo UX, dialog crash, and external-file opening

### DIFF
--- a/apps/renderer/src/components/create-project-dialog.tsx
+++ b/apps/renderer/src/components/create-project-dialog.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import type { ProjectTemplate } from "@memoize/wire";
 
 import { Button } from "~/components/ui/button";
-import { Checkbox } from "~/components/ui/checkbox";
+import { CheckboxInput } from "~/components/ui/checkbox-input";
 import {
   Dialog,
   DialogClose,
@@ -238,11 +238,9 @@ export function CreateProjectDialog({
                 : "text-muted-foreground/60",
             )}
           >
-            <Checkbox
+            <CheckboxInput
               checked={alsoCreateGithubRepo}
-              onCheckedChange={(checked) =>
-                setAlsoCreateGithubRepo(checked === true)
-              }
+              onChange={(checked) => setAlsoCreateGithubRepo(checked)}
               disabled={ghAuthenticated !== true}
             />
             Also create a private GitHub repo

--- a/apps/renderer/src/components/diff-pane.tsx
+++ b/apps/renderer/src/components/diff-pane.tsx
@@ -3,7 +3,6 @@ import {
   AlertTriangle,
   ArrowRight,
   CornerDownLeft,
-  GitBranchPlus,
   Loader2,
   Minus,
   Plus,
@@ -19,6 +18,7 @@ import type {
 } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { GitInitCta } from "./git-init-cta.tsx";
 import { gitChangesKey, useGitChangesStore } from "../store/git-changes.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
@@ -139,7 +139,7 @@ export function DiffPane({
           }
         >
           {changesErrorTag === "GitNotARepoError" ? (
-            <InitRepoState folderId={folderId} worktreeId={worktreeId} />
+            <GitInitCta folderId={folderId} worktreeId={worktreeId} />
           ) : changesError !== null ? (
             <p className="text-rose-300/80">Couldn't read git status: {changesError}</p>
           ) : changesLoading && changes === null ? (
@@ -584,66 +584,6 @@ function Section({
       </h3>
       <div className="flex flex-col gap-1">{children}</div>
     </section>
-  );
-}
-
-/**
- * Shown in the Changes tab when the folder isn't a Git repo yet
- * (`GitNotARepoError`). Replaces the raw error dump with a friendly prompt and
- * a one-click "Initialize Git repository" button that runs `git init` and
- * re-reads the working tree.
- */
-function InitRepoState({
-  folderId,
-  worktreeId,
-}: {
-  folderId: FolderId;
-  worktreeId: WorktreeId | null;
-}) {
-  const initRepo = useGitChangesStore((s) => s.initRepo);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const onInit = async () => {
-    if (busy) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await initRepo(folderId, worktreeId);
-    } catch (err) {
-      setError(formatErr(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <div className="flex flex-col items-start gap-2 py-1">
-      <div className="flex flex-col gap-0.5">
-        <span className="font-medium text-foreground">
-          This folder isn't a Git repository
-        </span>
-        <span className="text-muted-foreground">
-          Initialize Git to track changes, commit, and open pull requests.
-        </span>
-      </div>
-      <button
-        type="button"
-        onClick={onInit}
-        disabled={busy}
-        className="flex items-center gap-1.5 rounded-sm bg-emerald-500/15 px-2 py-1 text-[11px] font-medium text-emerald-200 transition-colors hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-40"
-      >
-        {busy ? (
-          <Loader2 className="size-3 animate-spin" />
-        ) : (
-          <GitBranchPlus className="size-3" />
-        )}
-        Initialize Git repository
-      </button>
-      {error !== null ? (
-        <span className="text-rose-300/90">{error}</span>
-      ) : null}
-    </div>
   );
 }
 

--- a/apps/renderer/src/components/file-chip.tsx
+++ b/apps/renderer/src/components/file-chip.tsx
@@ -109,28 +109,36 @@ export function FileChip({
         ? relPath
         : null;
 
-  const canOpen =
+  // A file outside the workspace (or with no workspace context at all) still
+  // opens — via the external-file path, by absolute path. Plan/markdown files
+  // the agent writes elsewhere on disk land here.
+  const externalAbs =
+    kind === "file" && resolvedAbs !== null && !insideWorkspace
+      ? resolvedAbs
+      : null;
+  const canOpenInWorkspace =
     kind === "file" && folderId !== null && workspaceRelPath !== null;
+  const canOpen = canOpenInWorkspace || externalAbs !== null;
 
   const tooltip =
-    kind === "directory"
-      ? `View ${relPath}`
-      : canOpen
-        ? `Open ${relPath}`
-        : looksAbsolute && !insideWorkspace
-          ? `${relPath} — outside this workspace`
-          : relPath;
+    kind === "directory" ? `View ${relPath}` : canOpen ? `Open ${relPath}` : relPath;
 
   const onClick = () => {
-    if (!canOpen || folderId === null || workspaceRelPath === null) return;
-    openFileInTab({
-      kind: "text",
-      folderId,
-      path: workspaceRelPath,
-      name,
-      worktreeId,
-      view,
-    });
+    if (!canOpen) return;
+    if (canOpenInWorkspace && folderId !== null && workspaceRelPath !== null) {
+      openFileInTab({
+        kind: "text",
+        folderId,
+        path: workspaceRelPath,
+        name,
+        worktreeId,
+        view,
+      });
+      return;
+    }
+    if (externalAbs !== null) {
+      openFileInTab({ kind: "external", absPath: externalAbs, name });
+    }
   };
 
   // Rendered as a `<span role="button">` rather than a real `<button>` so the

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -339,6 +339,9 @@ function DiffViewBody({
   openFile: Extract<OpenFile, { kind: "text" }>;
 }) {
   const [state, setState] = useState<DiffState>({ status: "loading" });
+  // Bumped after an in-place `git init` from the no-repo CTA so the diff
+  // re-fetches without the user toggling Edit/Diff to force a remount.
+  const [reload, setReload] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -366,7 +369,7 @@ function DiffViewBody({
     return () => {
       cancelled = true;
     };
-  }, [openFile.folderId, openFile.worktreeId, openFile.path]);
+  }, [openFile.folderId, openFile.worktreeId, openFile.path, reload]);
 
   if (state.status === "loading") {
     return <Placeholder>Loading diff…</Placeholder>;
@@ -379,6 +382,7 @@ function DiffViewBody({
             compact
             folderId={openFile.folderId}
             worktreeId={openFile.worktreeId}
+            onInitialized={() => setReload((n) => n + 1)}
           />
         </Placeholder>
       );

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -5,7 +5,9 @@ import { useEffect, useRef, useState } from "react";
 import type { GitDiffResult } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
+import { classifyGit } from "../lib/git-rpc.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { GitInitCta } from "./git-init-cta.tsx";
 import {
   createEditor,
   languageCompartment,
@@ -71,16 +73,21 @@ export function FileEditor() {
   }
 
   const view = openFile.view;
+  // External files have no git/folder context, so they're edit-only — no diff.
+  const isExternal = openFile.kind === "external";
+  const path = isExternal ? openFile.absPath : openFile.path;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <Toolbar path={openFile.path} view={view} />
+      <Toolbar path={path} view={view} showViewToggle={!isExternal} />
       <CodeMirrorBody
         openFile={openFile}
         hidden={view !== "edit"}
         onClose={closeFileTab}
       />
-      {view === "diff" ? <DiffViewBody openFile={openFile} /> : null}
+      {openFile.kind === "text" && view === "diff" ? (
+        <DiffViewBody openFile={openFile} />
+      ) : null}
     </div>
   );
 }
@@ -109,12 +116,14 @@ function ImageBody({ src, name }: { src: string; name: string }) {
 // swaps documents on file change. Cmd+S saves via fs.writeFile.
 // ---------------------------------------------------------------------------
 
+type EditableFile = Extract<OpenFile, { kind: "text" | "external" }>;
+
 function CodeMirrorBody({
   openFile,
   hidden,
   onClose,
 }: {
-  openFile: Extract<OpenFile, { kind: "text" }>;
+  openFile: EditableFile;
   hidden: boolean;
   onClose: () => void;
 }) {
@@ -133,7 +142,7 @@ function CodeMirrorBody({
   const baselineRef = useRef("");
   const mtimeRef = useRef("");
   const savingRef = useRef(false);
-  const fileRef = useRef<Extract<OpenFile, { kind: "text" }> | null>(openFile);
+  const fileRef = useRef<EditableFile | null>(openFile);
   fileRef.current = openFile;
 
   const save = async () => {
@@ -146,21 +155,31 @@ function CodeMirrorBody({
     setSaveError(null);
     try {
       const client = await getRpcClient();
-      const result = await Effect.runPromise(
-        client.fs.writeFile({
-          folderId: file.folderId,
-          path: file.path,
-          content: docRef.current,
-          expectedMtime: mtimeRef.current,
-          worktreeId: file.worktreeId,
-        }),
-      );
+      const result =
+        file.kind === "external"
+          ? await Effect.runPromise(
+              client.fs.writeExternalFile({
+                path: file.absPath,
+                content: docRef.current,
+                expectedMtime: mtimeRef.current,
+              }),
+            )
+          : await Effect.runPromise(
+              client.fs.writeFile({
+                folderId: file.folderId,
+                path: file.path,
+                content: docRef.current,
+                expectedMtime: mtimeRef.current,
+                worktreeId: file.worktreeId,
+              }),
+            );
       mtimeRef.current = result.mtime;
       baselineRef.current = docRef.current;
       setFileDirty(false);
       setConflict(null);
     } catch (err) {
-      if (tagOf(err) === "FsConflictError") {
+      const tag = tagOf(err);
+      if (tag === "FsConflictError" || tag === "FsExternalConflictError") {
         setConflict(
           "File changed on disk. Reload to discard your changes, or keep editing.",
         );
@@ -211,13 +230,18 @@ function CodeMirrorBody({
     void (async () => {
       try {
         const client = await getRpcClient();
-        const result = await Effect.runPromise(
-          client.fs.readFile({
-            folderId: openFile.folderId,
-            path: openFile.path,
-            worktreeId: openFile.worktreeId,
-          }),
-        );
+        const result =
+          openFile.kind === "external"
+            ? await Effect.runPromise(
+                client.fs.readExternalFile({ path: openFile.absPath }),
+              )
+            : await Effect.runPromise(
+                client.fs.readFile({
+                  folderId: openFile.folderId,
+                  path: openFile.path,
+                  worktreeId: openFile.worktreeId,
+                }),
+              );
         if (cancelled) return;
         if (result.kind === "binary") {
           setState({ status: "binary", size: result.size });
@@ -307,7 +331,7 @@ function CodeMirrorBody({
 type DiffState =
   | { status: "loading" }
   | { status: "ready"; result: GitDiffResult }
-  | { status: "error"; reason: string };
+  | { status: "error"; reason: string; noRepo: boolean };
 
 function DiffViewBody({
   openFile,
@@ -320,20 +344,23 @@ function DiffViewBody({
     let cancelled = false;
     setState({ status: "loading" });
     void (async () => {
-      try {
-        const client = await getRpcClient();
-        const result = await Effect.runPromise(
-          client.git.diff({
-            folderId: openFile.folderId,
-            worktreeId: openFile.worktreeId,
-            path: openFile.path,
-          }),
-        );
-        if (cancelled) return;
-        setState({ status: "ready", result });
-      } catch (err) {
-        if (cancelled) return;
-        setState({ status: "error", reason: formatError(err) });
+      const client = await getRpcClient();
+      const result = await classifyGit(
+        client.git.diff({
+          folderId: openFile.folderId,
+          worktreeId: openFile.worktreeId,
+          path: openFile.path,
+        }),
+      );
+      if (cancelled) return;
+      if (result.ok) {
+        setState({ status: "ready", result: result.value });
+      } else {
+        setState({
+          status: "error",
+          reason: result.message,
+          noRepo: result.tag === "GitNotARepoError",
+        });
       }
     })();
     return () => {
@@ -345,6 +372,17 @@ function DiffViewBody({
     return <Placeholder>Loading diff…</Placeholder>;
   }
   if (state.status === "error") {
+    if (state.noRepo) {
+      return (
+        <Placeholder>
+          <GitInitCta
+            compact
+            folderId={openFile.folderId}
+            worktreeId={openFile.worktreeId}
+          />
+        </Placeholder>
+      );
+    }
     return (
       <Placeholder>
         <span className="text-destructive">{state.reason}</span>
@@ -386,7 +424,15 @@ function DiffViewBody({
 // the actual save call; the toolbar just shows path + dirty + the toggle.
 // ---------------------------------------------------------------------------
 
-function Toolbar({ path, view }: { path: string; view: FileView }) {
+function Toolbar({
+  path,
+  view,
+  showViewToggle = true,
+}: {
+  path: string;
+  view: FileView;
+  showViewToggle?: boolean;
+}) {
   const dirty = useUiStore((s) => s.fileDirty);
   const setOpenFileView = useUiStore((s) => s.setOpenFileView);
   return (
@@ -403,7 +449,9 @@ function Toolbar({ path, view }: { path: string; view: FileView }) {
         {view === "edit" ? (
           <span className="opacity-60">⌘S to save</span>
         ) : null}
-        <ViewToggle value={view} onChange={setOpenFileView} />
+        {showViewToggle ? (
+          <ViewToggle value={view} onChange={setOpenFileView} />
+        ) : null}
       </span>
     </div>
   );

--- a/apps/renderer/src/components/git-init-cta.tsx
+++ b/apps/renderer/src/components/git-init-cta.tsx
@@ -1,0 +1,74 @@
+import { GitBranchPlus, Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import type { FolderId, WorktreeId } from "@memoize/wire";
+
+import { formatError } from "../lib/format-error.ts";
+import { useGitChangesStore } from "../store/git-changes.ts";
+
+/**
+ * Shared empty state shown wherever a git operation fails because the folder
+ * isn't a Git repository (`GitNotARepoError`) — the Changes tab, the PR tab,
+ * and the file Diff view all render this instead of dumping a raw error.
+ * Clicking the button runs `git init` (via the git-changes store, which then
+ * refreshes the status + PR stores too) so every pane recovers at once.
+ *
+ * `compact` drops the explanatory line for tight spots like the Diff pane.
+ */
+export function GitInitCta({
+  folderId,
+  worktreeId,
+  compact = false,
+}: {
+  folderId: FolderId;
+  worktreeId: WorktreeId | null;
+  compact?: boolean;
+}) {
+  const initRepo = useGitChangesStore((s) => s.initRepo);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onInit = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await initRepo(folderId, worktreeId);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-2 py-1">
+      <div className="flex flex-col gap-0.5">
+        <span className="font-medium text-foreground">
+          This folder isn't a Git repository
+        </span>
+        {!compact ? (
+          <span className="text-muted-foreground">
+            Initialize Git to track changes, commit, and open pull requests.
+          </span>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        onClick={onInit}
+        disabled={busy}
+        className="flex items-center gap-1.5 rounded-sm bg-emerald-500/15 px-2 py-1 text-[11px] font-medium text-emerald-200 transition-colors hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {busy ? (
+          <Loader2 className="size-3 animate-spin" />
+        ) : (
+          <GitBranchPlus className="size-3" />
+        )}
+        Initialize Git repository
+      </button>
+      {error !== null ? (
+        <span className="text-rose-300/90">{error}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/git-init-cta.tsx
+++ b/apps/renderer/src/components/git-init-cta.tsx
@@ -19,10 +19,17 @@ export function GitInitCta({
   folderId,
   worktreeId,
   compact = false,
+  onInitialized,
 }: {
   folderId: FolderId;
   worktreeId: WorktreeId | null;
   compact?: boolean;
+  /**
+   * Fired after `git init` succeeds. Surfaces for callers (e.g. the Diff
+   * view) that fetch their own data in a local effect and need to re-run it —
+   * the store-backed tabs update reactively and don't need this.
+   */
+  onInitialized?: () => void;
 }) {
   const initRepo = useGitChangesStore((s) => s.initRepo);
   const [busy, setBusy] = useState(false);
@@ -34,6 +41,7 @@ export function GitInitCta({
     setError(null);
     try {
       await initRepo(folderId, worktreeId);
+      onInitialized?.();
     } catch (err) {
       setError(formatError(err));
     } finally {

--- a/apps/renderer/src/components/pr-pane.tsx
+++ b/apps/renderer/src/components/pr-pane.tsx
@@ -23,6 +23,7 @@ import { softTone, type Tone } from "../lib/tones.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
+import { GitInitCta } from "./git-init-cta.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
 
 const openExternal = (url: string) => {
@@ -63,6 +64,11 @@ export function PrPane({
   const status = useGitStatusStore((s) =>
     folderId ? (s.byKey[gitStatusKey(folderId, worktreeId)] ?? null) : null,
   );
+  const noRepo = useGitStatusStore((s) =>
+    folderId
+      ? s.noRepoByKey[gitStatusKey(folderId, worktreeId)] === true
+      : false,
+  );
   const pr = usePrStateStore((s) =>
     folderId ? (s.byKey[prStateKey(folderId, worktreeId)] ?? null) : null,
   );
@@ -82,6 +88,13 @@ export function PrPane({
 
   if (folderId === null) {
     return <Empty>Select a project to see its PR here.</Empty>;
+  }
+  if (noRepo) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col px-3 py-3 text-xs">
+        <GitInitCta folderId={folderId} worktreeId={worktreeId} />
+      </div>
+    );
   }
   if (status === null) {
     return <Empty>Reading branch state…</Empty>;

--- a/apps/renderer/src/components/ui/checkbox-input.tsx
+++ b/apps/renderer/src/components/ui/checkbox-input.tsx
@@ -1,0 +1,47 @@
+import { Check } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+/**
+ * Native `<input type="checkbox">` styled to match the app's checkbox look.
+ * Used instead of the base-ui `Checkbox` in standalone spots (no surrounding
+ * `Field`/`Form`) — base-ui's checkbox calls `useFormContext` and trips a
+ * dual-React hook error there. A native input has no such dependency.
+ */
+export function CheckboxInput({
+  checked,
+  onChange,
+  disabled,
+  className,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  return (
+    <span className={cn("relative inline-flex shrink-0", className)}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="peer absolute inset-0 size-4 cursor-pointer opacity-0 disabled:cursor-not-allowed"
+      />
+      <span
+        aria-hidden
+        className={cn(
+          "flex size-4 items-center justify-center rounded-[5px] border transition-colors",
+          checked
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-input bg-background",
+          disabled && "opacity-50",
+        )}
+      >
+        {checked ? (
+          <Check className="size-3 text-background" strokeWidth={3.5} aria-hidden />
+        ) : null}
+      </span>
+    </span>
+  );
+}

--- a/apps/renderer/src/lib/format-error.ts
+++ b/apps/renderer/src/lib/format-error.ts
@@ -1,6 +1,16 @@
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+// Tagged errors that carry only ids (no `reason`/`message`) would otherwise
+// fall through to a raw JSON dump like `{ "folderId": "…" }`. Map them to
+// human copy here so any surface that formats them stays readable.
+const TAG_MESSAGES: Record<string, string> = {
+  GitNotARepoError: "This folder isn't a Git repository.",
+  GitFolderNotFoundError: "Project folder not found.",
+  GitNotInstalledError: "Git is not installed.",
+  FsFolderNotFoundError: "Project folder not found.",
+};
+
 export const formatError = (err: unknown): string => {
   if (err instanceof Error) return err.message;
   if (!isRecord(err)) return String(err);
@@ -23,7 +33,7 @@ export const formatError = (err: unknown): string => {
   if (sessionId !== null && Object.keys(err).length === 1) {
     return `Internal session response was routed as an error: ${sessionId}`;
   }
-  if (tag !== null) return tag;
+  if (tag !== null) return TAG_MESSAGES[tag] ?? tag;
 
   try {
     return JSON.stringify(err, null, 2);

--- a/apps/renderer/src/lib/git-rpc.ts
+++ b/apps/renderer/src/lib/git-rpc.ts
@@ -1,0 +1,79 @@
+import { Effect } from "effect";
+
+import type {
+  GitCommandError,
+  GitFolderNotFoundError,
+  GitNotARepoError,
+  GitNotInstalledError,
+} from "@memoize/wire";
+
+import { formatError } from "./format-error.ts";
+
+/**
+ * The four typed failures every `git.*` RPC can return (`GitErrors` in
+ * `packages/wire/src/git.ts`).
+ */
+type GitFailure =
+  | GitNotARepoError
+  | GitNotInstalledError
+  | GitCommandError
+  | GitFolderNotFoundError;
+
+export type GitErrorTag = GitFailure["_tag"];
+
+export type GitRpcResult<A> =
+  | { readonly ok: true; readonly value: A }
+  | {
+      readonly ok: false;
+      readonly tag: GitErrorTag | null;
+      readonly message: string;
+    };
+
+/**
+ * Run a `git.*` RPC effect and classify its outcome into a discriminated
+ * result. The classification happens **inside** the Effect via `catchTags`,
+ * which is the only place the real typed error (`GitNotARepoError`, …) is
+ * visible — a `try/catch` around `Effect.runPromise` only sees an opaque
+ * rejection whose `_tag` is gone, which is why the previous "not a repo"
+ * detection silently never matched. The outer `try/catch` is a last-resort
+ * net for transport/defect failures outside the typed error channel.
+ */
+export const classifyGit = async <A>(
+  effect: Effect.Effect<A, GitFailure>,
+): Promise<GitRpcResult<A>> => {
+  try {
+    return await Effect.runPromise(
+      effect.pipe(
+        Effect.map((value): GitRpcResult<A> => ({ ok: true, value })),
+        Effect.catchTags({
+          GitNotARepoError: () =>
+            Effect.succeed<GitRpcResult<A>>({
+              ok: false,
+              tag: "GitNotARepoError",
+              message: "Not a git repository",
+            }),
+          GitNotInstalledError: () =>
+            Effect.succeed<GitRpcResult<A>>({
+              ok: false,
+              tag: "GitNotInstalledError",
+              message: "Git is not installed",
+            }),
+          GitCommandError: (err) =>
+            Effect.succeed<GitRpcResult<A>>({
+              ok: false,
+              tag: "GitCommandError",
+              message: err.reason,
+            }),
+          GitFolderNotFoundError: () =>
+            Effect.succeed<GitRpcResult<A>>({
+              ok: false,
+              tag: "GitFolderNotFoundError",
+              message: "Folder not found",
+            }),
+        }),
+      ),
+    );
+  } catch (err) {
+    return { ok: false, tag: null, message: formatError(err) };
+  }
+};

--- a/apps/renderer/src/store/git-changes.ts
+++ b/apps/renderer/src/store/git-changes.ts
@@ -3,7 +3,11 @@ import { create } from "zustand";
 
 import type { FolderId, GitChange, WorktreeId } from "@memoize/wire";
 
+import { classifyGit, type GitErrorTag } from "../lib/git-rpc.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { useGitStatusStore } from "./git-status.ts";
+import { usePrDetailsStore } from "./pr-details.ts";
+import { usePrStateStore } from "./pr-state.ts";
 
 /**
  * Per-`(folder, worktree)` list of working-tree changes parsed from
@@ -19,13 +23,14 @@ type GitChangesState = {
   // The error's `_tag` (e.g. "GitNotARepoError"), kept distinct from the
   // human-readable message so the Changes tab can branch on it — most notably
   // to swap the raw error for an "Initialize Git" CTA when there's no repo.
-  readonly errorTagByKey: Record<string, string | null>;
+  readonly errorTagByKey: Record<string, GitErrorTag | null>;
   readonly refresh: (
     folderId: FolderId,
     worktreeId?: WorktreeId | null,
   ) => Promise<void>;
-  // Initialize a git repo in the folder, then refresh so the tab flips from
-  // the empty state to the (now clean) working tree.
+  // Initialize a git repo in the folder, then refresh this store plus the
+  // git-status / PR stores so every tab flips out of its "no repo" state at
+  // once instead of waiting for the next 5s poll.
   readonly initRepo: (
     folderId: FolderId,
     worktreeId?: WorktreeId | null,
@@ -37,37 +42,6 @@ export const gitChangesKey = (
   worktreeId: WorktreeId | null | undefined,
 ): string => `${folderId}:${worktreeId ?? "main"}`;
 
-const formatError = (err: unknown): string => {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "object" && err !== null && "_tag" in err) {
-    return String((err as { _tag: unknown })._tag);
-  }
-  return String(err);
-};
-
-const errorTag = (err: unknown): string | null => {
-  if (typeof err === "object" && err !== null && "_tag" in err) {
-    return String((err as { _tag: unknown })._tag);
-  }
-  return null;
-};
-
-const fetchChanges = async (
-  folderId: FolderId,
-  worktreeId: WorktreeId | null | undefined,
-): Promise<
-  ReadonlyArray<GitChange> | { error: string; tag: string | null }
-> => {
-  try {
-    const client = await getRpcClient();
-    return await Effect.runPromise(
-      client.git.changes({ folderId, worktreeId: worktreeId ?? null }),
-    );
-  } catch (err) {
-    return { error: formatError(err), tag: errorTag(err) };
-  }
-};
-
 export const useGitChangesStore = create<GitChangesState>((set, get) => ({
   byKey: {},
   loadingByKey: {},
@@ -75,25 +49,28 @@ export const useGitChangesStore = create<GitChangesState>((set, get) => ({
   errorTagByKey: {},
   refresh: async (folderId, worktreeId) => {
     const key = gitChangesKey(folderId, worktreeId);
-    const result = await fetchChanges(folderId, worktreeId);
-    set((s) => {
-      const isErr = !Array.isArray(result);
-      const err = isErr
-        ? (result as { error: string; tag: string | null })
-        : null;
-      return {
-        byKey: isErr
-          ? s.byKey
-          : { ...s.byKey, [key]: result as ReadonlyArray<GitChange> },
-        errorByKey: { ...s.errorByKey, [key]: err ? err.error : null },
-        errorTagByKey: { ...s.errorTagByKey, [key]: err ? err.tag : null },
-        loadingByKey: { ...s.loadingByKey, [key]: false },
-      };
-    });
+    const client = await getRpcClient();
+    const result = await classifyGit(
+      client.git.changes({ folderId, worktreeId: worktreeId ?? null }),
+    );
+    set((s) => ({
+      byKey: result.ok ? { ...s.byKey, [key]: result.value } : s.byKey,
+      errorByKey: { ...s.errorByKey, [key]: result.ok ? null : result.message },
+      errorTagByKey: {
+        ...s.errorTagByKey,
+        [key]: result.ok ? null : result.tag,
+      },
+      loadingByKey: { ...s.loadingByKey, [key]: false },
+    }));
   },
   initRepo: async (folderId, worktreeId) => {
     const client = await getRpcClient();
     await Effect.runPromise(client.git.init({ folderId }));
-    await get().refresh(folderId, worktreeId);
+    await Promise.all([
+      get().refresh(folderId, worktreeId),
+      useGitStatusStore.getState().refresh(folderId, worktreeId),
+      usePrStateStore.getState().refresh(folderId, worktreeId),
+      usePrDetailsStore.getState().refresh(folderId, worktreeId),
+    ]);
   },
 }));

--- a/apps/renderer/src/store/git-status.ts
+++ b/apps/renderer/src/store/git-status.ts
@@ -1,8 +1,8 @@
-import { Effect } from "effect";
 import { create } from "zustand";
 
 import type { FolderId, GitStatusSummary, WorktreeId } from "@memoize/wire";
 
+import { classifyGit } from "../lib/git-rpc.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 
 /**
@@ -19,6 +19,10 @@ type StatusMap = Record<string, GitStatusSummary>;
 
 type GitStatusState = {
   readonly byKey: StatusMap;
+  // True when the last fetch failed with `GitNotARepoError` — lets consumers
+  // (e.g. the PR tab) distinguish "this folder has no repo" from "status
+  // hasn't loaded yet", since both leave `byKey` empty.
+  readonly noRepoByKey: Record<string, boolean>;
   readonly refresh: (
     folderId: FolderId,
     worktreeId?: WorktreeId | null,
@@ -30,26 +34,21 @@ export const gitStatusKey = (
   worktreeId: WorktreeId | null | undefined,
 ): string => `${folderId}:${worktreeId ?? "main"}`;
 
-const fetchStatus = async (
-  folderId: FolderId,
-  worktreeId: WorktreeId | null | undefined,
-): Promise<GitStatusSummary | null> => {
-  try {
-    const client = await getRpcClient();
-    return await Effect.runPromise(
-      client.git.status({ folderId, worktreeId: worktreeId ?? null }),
-    );
-  } catch {
-    return null;
-  }
-};
-
 export const useGitStatusStore = create<GitStatusState>((set) => ({
   byKey: {},
+  noRepoByKey: {},
   refresh: async (folderId, worktreeId) => {
-    const summary = await fetchStatus(folderId, worktreeId);
-    if (summary === null) return;
     const key = gitStatusKey(folderId, worktreeId);
-    set((s) => ({ byKey: { ...s.byKey, [key]: summary } }));
+    const client = await getRpcClient();
+    const result = await classifyGit(
+      client.git.status({ folderId, worktreeId: worktreeId ?? null }),
+    );
+    set((s) => ({
+      byKey: result.ok ? { ...s.byKey, [key]: result.value } : s.byKey,
+      noRepoByKey: {
+        ...s.noRepoByKey,
+        [key]: !result.ok && result.tag === "GitNotARepoError",
+      },
+    }));
   },
 }));

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -66,6 +66,18 @@ export type OpenFile =
       readonly kind: "image";
       readonly src: string;
       readonly name: string;
+    }
+  | {
+      /**
+       * A file outside any project folder (e.g. a plan or markdown file the
+       * agent wrote elsewhere on disk). Read/written by absolute path via the
+       * `fs.*ExternalFile` RPCs, which deliberately skip the workspace
+       * sandbox. Edit-only — there's no git/folder context for a diff.
+       */
+      readonly kind: "external";
+      readonly absPath: string;
+      readonly name: string;
+      readonly view: FileView;
     };
 
 type UiState = {
@@ -87,6 +99,9 @@ type UiState = {
   readonly openFileInTab: (
     file:
       | (Omit<Extract<OpenFile, { kind: "text" }>, "view"> & {
+          view?: FileView;
+        })
+      | (Omit<Extract<OpenFile, { kind: "external" }>, "view"> & {
           view?: FileView;
         })
       | Extract<OpenFile, { kind: "image" }>,

--- a/apps/server/src/fs/handlers.ts
+++ b/apps/server/src/fs/handlers.ts
@@ -27,4 +27,23 @@ const WriteFile = MemoizeRpcs.toLayerHandler(
     ),
 );
 
-export const FsHandlersLayer = Layer.mergeAll(Tree, ReadFile, WriteFile);
+const ReadExternalFile = MemoizeRpcs.toLayerHandler(
+  "fs.readExternalFile",
+  ({ path }) => Effect.flatMap(FsService, (svc) => svc.readExternal(path)),
+);
+
+const WriteExternalFile = MemoizeRpcs.toLayerHandler(
+  "fs.writeExternalFile",
+  ({ path, content, expectedMtime }) =>
+    Effect.flatMap(FsService, (svc) =>
+      svc.writeExternal(path, content, expectedMtime),
+    ),
+);
+
+export const FsHandlersLayer = Layer.mergeAll(
+  Tree,
+  ReadFile,
+  WriteFile,
+  ReadExternalFile,
+  WriteExternalFile,
+);

--- a/apps/server/src/fs/layers/fs-service.ts
+++ b/apps/server/src/fs/layers/fs-service.ts
@@ -6,6 +6,9 @@ import { Effect, Layer, Option } from "effect";
 import {
   FsConflictError,
   FsEntry,
+  FsExternalConflictError,
+  FsExternalReadError,
+  FsExternalTooLargeError,
   FsFolderNotFoundError,
   FsPathOutsideError,
   FsReadError,
@@ -267,6 +270,112 @@ export const FsServiceLive = Layer.effect(
         return { mtime: mtimeToString(afterStat.mtime) };
       });
 
-    return { tree, readFile, writeFile } as const;
+    // External (outside-folder) read/write. Same decode / size-cap / mtime
+    // concurrency as readFile/writeFile, but the path is absolute and there's
+    // no folder containment check — deliberately so, to open files the agent
+    // wrote elsewhere on disk. Errors key off `path` instead of `folderId`.
+    const readExternal: FsService["Type"]["readExternal"] = (absPath) =>
+      Effect.gen(function* () {
+        const target = pathSvc.resolve(absPath);
+        const stat = yield* fs.stat(target).pipe(
+          Effect.mapError(
+            (cause) =>
+              new FsExternalReadError({
+                path: absPath,
+                reason: cause.message ?? String(cause),
+              }),
+          ),
+        );
+        const size = Number(stat.size);
+        if (size > MAX_FILE_BYTES) {
+          return yield* Effect.fail(
+            new FsExternalTooLargeError({
+              path: absPath,
+              size,
+              limit: MAX_FILE_BYTES,
+            }),
+          );
+        }
+        const bytes = yield* fs.readFile(target).pipe(
+          Effect.mapError(
+            (cause) =>
+              new FsExternalReadError({
+                path: absPath,
+                reason: cause.message ?? String(cause),
+              }),
+          ),
+        );
+        try {
+          const decoder = new TextDecoder("utf-8", { fatal: true });
+          const content = decoder.decode(bytes);
+          return {
+            kind: "text" as const,
+            content,
+            mtime: mtimeToString(stat.mtime),
+            size,
+          };
+        } catch {
+          return { kind: "binary" as const, size };
+        }
+      });
+
+    const writeExternal: FsService["Type"]["writeExternal"] = (
+      absPath,
+      content,
+      expectedMtime,
+    ) =>
+      Effect.gen(function* () {
+        const target = pathSvc.resolve(absPath);
+        const byteLen = new TextEncoder().encode(content).byteLength;
+        if (byteLen > MAX_FILE_BYTES) {
+          return yield* Effect.fail(
+            new FsExternalTooLargeError({
+              path: absPath,
+              size: byteLen,
+              limit: MAX_FILE_BYTES,
+            }),
+          );
+        }
+        const beforeStat = yield* fs.stat(target).pipe(
+          Effect.mapError(
+            (cause) =>
+              new FsExternalReadError({
+                path: absPath,
+                reason: cause.message ?? String(cause),
+              }),
+          ),
+        );
+        const actualMtime = mtimeToString(beforeStat.mtime);
+        if (actualMtime !== expectedMtime) {
+          return yield* Effect.fail(
+            new FsExternalConflictError({
+              path: absPath,
+              expectedMtime,
+              actualMtime,
+            }),
+          );
+        }
+        yield* fs.writeFileString(target, content).pipe(
+          Effect.mapError(
+            (cause) =>
+              new FsExternalReadError({
+                path: absPath,
+                reason: cause.message ?? String(cause),
+              }),
+          ),
+        );
+        const afterStat = yield* fs.stat(target).pipe(
+          Effect.mapError(
+            (cause) =>
+              new FsExternalReadError({
+                path: absPath,
+                reason: cause.message ?? String(cause),
+              }),
+          ),
+        );
+        return { mtime: mtimeToString(afterStat.mtime) };
+      });
+
+    return { tree, readFile, writeFile, readExternal, writeExternal } as const;
   }),
 );

--- a/apps/server/src/fs/services/fs-service.ts
+++ b/apps/server/src/fs/services/fs-service.ts
@@ -4,6 +4,9 @@ import {
   type FolderId,
   type FsConflictError,
   type FsEntry,
+  type FsExternalConflictError,
+  type FsExternalReadError,
+  type FsExternalTooLargeError,
   type FsFileContent,
   type FsFolderNotFoundError,
   type FsPathOutsideError,
@@ -15,6 +18,8 @@ import {
 type TreeFailure = FsFolderNotFoundError | FsPathOutsideError | FsReadError;
 type ReadFileFailure = TreeFailure | FsTooLargeError;
 type WriteFileFailure = ReadFileFailure | FsConflictError;
+type ReadExternalFailure = FsExternalReadError | FsExternalTooLargeError;
+type WriteExternalFailure = ReadExternalFailure | FsExternalConflictError;
 
 export interface FsServiceShape {
   readonly tree: (
@@ -34,6 +39,14 @@ export interface FsServiceShape {
     expectedMtime: string,
     worktreeId?: WorktreeId | null,
   ) => Effect.Effect<{ readonly mtime: string }, WriteFileFailure>;
+  readonly readExternal: (
+    absPath: string,
+  ) => Effect.Effect<typeof FsFileContent.Type, ReadExternalFailure>;
+  readonly writeExternal: (
+    absPath: string,
+    content: string,
+    expectedMtime: string,
+  ) => Effect.Effect<{ readonly mtime: string }, WriteExternalFailure>;
 }
 
 export class FsService extends Context.Tag("memoize/FsService")<

--- a/packages/wire/src/fs.ts
+++ b/packages/wire/src/fs.ts
@@ -45,10 +45,43 @@ export class FsConflictError extends Schema.TaggedError<FsConflictError>()(
   },
 ) {}
 
+// External-file errors mirror the in-folder ones but key off an absolute
+// `path` instead of a `folderId` — the `fs.*ExternalFile` RPCs operate
+// outside any project folder, so there's no folder id to carry.
+export class FsExternalReadError extends Schema.TaggedError<FsExternalReadError>()(
+  "FsExternalReadError",
+  { path: Schema.String, reason: Schema.String },
+) {}
+
+export class FsExternalTooLargeError extends Schema.TaggedError<FsExternalTooLargeError>()(
+  "FsExternalTooLargeError",
+  { path: Schema.String, size: Schema.Number, limit: Schema.Number },
+) {}
+
+export class FsExternalConflictError extends Schema.TaggedError<FsExternalConflictError>()(
+  "FsExternalConflictError",
+  {
+    path: Schema.String,
+    expectedMtime: Schema.String,
+    actualMtime: Schema.String,
+  },
+) {}
+
 const FsErrors = Schema.Union(
   FsFolderNotFoundError,
   FsPathOutsideError,
   FsReadError,
+);
+
+const FsReadExternalFileErrors = Schema.Union(
+  FsExternalReadError,
+  FsExternalTooLargeError,
+);
+
+const FsWriteExternalFileErrors = Schema.Union(
+  FsExternalReadError,
+  FsExternalTooLargeError,
+  FsExternalConflictError,
 );
 
 const FsReadFileErrors = Schema.Union(
@@ -142,4 +175,36 @@ export const FsWriteFileRpc = Rpc.make("fs.writeFile", {
     mtime: Schema.String,
   }),
   error: FsWriteFileErrors,
+});
+
+/**
+ * Read a file by absolute path, outside any project folder — backs opening
+ * agent-written plan/markdown files that live elsewhere on disk. Same UTF-8
+ * decode, 5 MB cap, and `mtime` concurrency token as `fs.readFile`.
+ * Deliberately not sandboxed to a folder: a local desktop app reading a file
+ * the user explicitly opened.
+ */
+export const FsReadExternalFileRpc = Rpc.make("fs.readExternalFile", {
+  payload: Schema.Struct({
+    path: Schema.String,
+  }),
+  success: FsFileContent,
+  error: FsReadExternalFileErrors,
+});
+
+/**
+ * Write a file by absolute path. Same optimistic-concurrency (`expectedMtime`)
+ * and 5 MB cap as `fs.writeFile`. Pairs with `fs.readExternalFile` for editing
+ * files outside the workspace.
+ */
+export const FsWriteExternalFileRpc = Rpc.make("fs.writeExternalFile", {
+  payload: Schema.Struct({
+    path: Schema.String,
+    content: Schema.String,
+    expectedMtime: Schema.String,
+  }),
+  success: Schema.Struct({
+    mtime: Schema.String,
+  }),
+  error: FsWriteExternalFileErrors,
 });

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -22,7 +22,13 @@ import {
   IndexStatusStreamRpc,
   IndexSymbolLookupRpc,
 } from "./code-index.ts";
-import { FsReadFileRpc, FsTreeRpc, FsWriteFileRpc } from "./fs.ts";
+import {
+  FsReadExternalFileRpc,
+  FsReadFileRpc,
+  FsTreeRpc,
+  FsWriteExternalFileRpc,
+  FsWriteFileRpc,
+} from "./fs.ts";
 import {
   GitChangesRpc,
   GitCommitRpc,
@@ -157,6 +163,8 @@ export const MemoizeRpcs = RpcGroup.make(
   FsTreeRpc,
   FsReadFileRpc,
   FsWriteFileRpc,
+  FsReadExternalFileRpc,
+  FsWriteExternalFileRpc,
   AgentAvailabilityRpc,
   AgentSetCredentialRpc,
   AgentStartRpc,


### PR DESCRIPTION
Follow-up fixes to the now-merged #104, found in real use. **Initialize-Git now actually works** — the old detection sniffed `err._tag` on a caught `Effect.runPromise` rejection (which has no `_tag`), so it never matched; a new `classifyGit()` helper classifies the failure *inside* the Effect (`Effect.catchTags`) and a shared `<GitInitCta>` is wired into the Changes tab, the PR tab (was stuck on "Reading branch state…"), and the file Diff view. The **Create-project dialog no longer crashes** — base-ui's `Checkbox` tripped a dual-React `useFormContext` hook error, replaced with a native checkbox. And you can now **open + edit/save files outside the project folder** via new `fs.readExternalFile`/`fs.writeExternalFile` RPCs (absolute path, deliberately outside the workspace sandbox), an `external` OpenFile variant, and clickable out-of-workspace file chips. Verified with workspace `check-types` (only pre-existing `main` errors remain) and a clean renderer build.