### PR TITLE
fix(desktop): repair auto-update + open links in OS browser

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -54,8 +54,17 @@ npmRebuild: false
 
 mac:
   category: public.app-category.developer-tools
+  # Two targets, one signed/notarized `.app`:
+  #   * dmg  — what humans download from the Releases page for first install.
+  #   * zip  — what `electron-updater` (Squirrel.Mac under the hood) consumes
+  #            to apply auto-updates. Squirrel.Mac cannot read DMGs; without a
+  #            zip in `latest-mac.yml` the updater throws "ZIP file not
+  #            provided" and every installed copy is stranded on its current
+  #            version. See plans/zip-file-not-provided-jolly-lantern.md.
   target:
     - target: dmg
+      arch: universal
+    - target: zip
       arch: universal
   hardenedRuntime: true
   gatekeeperAssess: false

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -160,16 +160,57 @@ function createMainWindow() {
   // — the renderer asked to leave Electron, not to host another Chromium
   // window inside the app. Allowlist scheme so the bridge can't be coaxed
   // into running arbitrary shell URI handlers.
-  ipcMain.on("app:openExternal", (_event, rawUrl: unknown) => {
-    if (typeof rawUrl !== "string") return;
+  const openHttpExternal = (rawUrl: unknown): boolean => {
+    if (typeof rawUrl !== "string") return false;
     let parsed: URL;
     try {
       parsed = new URL(rawUrl);
     } catch {
+      return false;
+    }
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return false;
+    }
+    void shell.openExternal(parsed.toString());
+    return true;
+  };
+
+  ipcMain.on("app:openExternal", (_event, rawUrl: unknown) => {
+    openHttpExternal(rawUrl);
+  });
+
+  // Markdown links rendered by react-markdown have no `target="_blank"`, so a
+  // click triggers an in-window navigation away from the renderer — the app
+  // would unload and Chromium would render the page inline, indistinguishable
+  // from "the app froze." Intercept those and route to the OS browser.
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    // Allow same-document navigations (dev-server HMR, our own renderer's
+    // file:// load, the privileged `memoize://` scheme). Everything else is
+    // an external link the user clicked.
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
       return;
     }
-    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return;
-    void shell.openExternal(parsed.toString());
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      // In dev the renderer is served from http://localhost:<port> — don't
+      // hijack navigations inside the renderer itself.
+      if (isDevelopment && parsed.origin === new URL(DEV_SERVER_URL).origin) {
+        return;
+      }
+      event.preventDefault();
+      void shell.openExternal(parsed.toString());
+    }
+  });
+
+  // `target="_blank"` and `window.open()` go through the window-open handler
+  // instead of will-navigate. Default behavior is to spawn a new
+  // BrowserWindow hosting the URL — i.e. the "in-app browser" the user was
+  // seeing. Deny the new window and route http(s) externally.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    openHttpExternal(url);
+    return { action: "deny" };
   });
 
   // Boot the Effect runtime once the window's webContents exists. The RPC


### PR DESCRIPTION
## Summary

Two desktop bugs, one PR:

- **Auto-update was broken on every shipped build.** `electron-updater` on macOS uses Squirrel.Mac, which can only consume a **ZIP** of the `.app` bundle — not a DMG. `electron-builder.yml` only declared a `dmg` target, so `latest-mac.yml` shipped without a zip entry and the updater threw `Error: ZIP file not provided`. Adds `target: zip / arch: universal` alongside the existing dmg target. Same signed/notarized `.app`, no extra signing cost. Plan: `plans/zip-file-not-provided-jolly-lantern.md`.
- **Clicking a markdown link replaced the app with the destination page.** `react-markdown` emits `<a href>` with no `target="_blank"`, so a click triggers `will-navigate` and Electron loads the URL inside the main `BrowserWindow` — the renderer disappears and the user sees the linked site where their workspace used to be. `target="_blank"` links hit `setWindowOpenHandler` and Electron defaults to spawning a new in-app Chromium window. Both paths now route http(s) URLs to `shell.openExternal` and deny the navigation / new window. Dev-server origin is whitelisted so Vite HMR isn't hijacked.

### Caveat on the updater fix

Users already on ≤ 0.3.1 cannot be retroactively unstuck — the broken `latest-mac.yml` for 0.3.1 is what their installed updater is pointed at. From the next release onward (0.3.2+) auto-update is self-healing. Worth a one-line callout in the 0.3.2 release notes that 0.3.1 users may need to download the new DMG once manually.

## Test plan

- [ ] `bun run dist:mac:unsigned` produces both `dist/memoize-Alpha-X.Y.Z-universal.dmg` and `dist/memoize-Alpha-X.Y.Z-universal-mac.zip`.
- [ ] `dist/latest-mac.yml` lists both artifacts in `files:` and `path:` points to the `.zip`.
- [ ] The produced zip contains `memoize.app/` at the root.
- [ ] In a dev build, click a markdown link in a chat message → opens in the OS default browser, app stays put.
- [ ] In a dev build, click a `target="_blank"` link (provider card, PR pane, onboarding) → opens in the OS default browser, no in-app Chromium window appears.
- [ ] Vite HMR still works (no will-navigate hijacking of the renderer's own loads).
- [ ] Tag `v0.3.2`, confirm the draft release on GitHub attaches both `.dmg` and `-mac.zip`, promote to published, install 0.3.1 from the old DMG, trigger update check, confirm download completes without the ZIP error.