### PR TITLE
fix(grok): ignore transient AuthorizationRequired ACP noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to memoize will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Grok sessions no longer abort mid-turn when the ACP child surfaces transient `AuthorizationRequired` noise inside `session/update` error frames while the turn is still completing normally. The shared ACP translator now filters that frame on the grok channel so in-flight prompts aren't rejected and the session doesn't flip to idle prematurely.
+
 ## [0.3.2]
 
 ### Added

--- a/apps/server/src/provider/drivers/acp/grok-auth-noise.ts
+++ b/apps/server/src/provider/drivers/acp/grok-auth-noise.ts
@@ -1,0 +1,18 @@
+/**
+ * Grok's ACP child occasionally prints transient AuthorizationRequired noise
+ * on stderr or in session/update error frames even while the session keeps
+ * running and the turn completes normally. Treat these as ignorable — surfacing
+ * them as provider errors would reject the in-flight prompt, emit an Error
+ * event, and flip the session to idle while the agent is still working.
+ */
+export const isIgnorableGrokAuthNoise = (text: string): boolean => {
+  const t = text.toLowerCase();
+  return (
+    t.includes("authorizationrequired") ||
+    t.includes("auth(authorizationrequired)") ||
+    (t.includes("grok authentication failed") &&
+      t.includes("authorizationrequired")) ||
+    (t.includes("worker quit with fatal") && t.includes("auth")) ||
+    (t.includes("transport channel closed") && t.includes("auth"))
+  );
+};

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -1,5 +1,7 @@
 import type { AgentEvent, AgentItemId } from "@memoize/wire";
 
+import { isIgnorableGrokAuthNoise } from "./grok-auth-noise.ts";
+
 /**
  * Shared translator for Agent Client Protocol (ACP) `session/update` frames.
  * Lifted out of grok.ts / gemini.ts / cursor.ts which each carried a near-
@@ -1235,6 +1237,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
                     ? `${providerLabel} agent reported an error with no detail.`
                     : `${providerLabel} agent error: ${serialized}`;
                 })();
+          if (provider === "grok" && isIgnorableGrokAuthNoise(message)) {
+            trace(provider, `ignored auth noise: ${safePreview(message)}`);
+            return [];
+          }
           return [{ _tag: "Error", message }];
         }
 


### PR DESCRIPTION
## Summary
- Grok's ACP child occasionally prints `AuthorizationRequired` noise on stderr or in `session/update` error frames while the turn is still completing normally. Previously we treated this as a fatal auth failure: rejected the in-flight prompt, surfaced an Error event, and flipped the session to idle — even though the agent was still working.
- Replaced the eager fatal-auth detection in `grok.ts` with a shared `isIgnorableGrokAuthNoise` helper that filters these messages out of stderr exit detail, prompt failure reasons, and the ACP translator's error frames.
- Stops in-flight Grok turns from being aborted mid-stream by transient auth noise.

## Test plan
- [ ] Start a Grok session that emits `AuthorizationRequired` on stderr mid-turn; confirm the turn completes and no Error event is surfaced.
- [ ] Verify a real auth failure (no cached login) still produces a usable error path via the ACP server's session-start check.
- [ ] Confirm cancel / interrupt behavior on Grok prompts is unchanged.