### PR TITLE
feat(claude): Opus 4.8 + Ultracode + plan-mode always prompts

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -5,6 +5,7 @@ import {
   FolderClosed,
   GitBranch,
   Gauge,
+  Info,
   Lock,
   Map,
   Paperclip,
@@ -890,11 +891,15 @@ function ReasoningPicker({
 
   // For opencode, the variant list is per-model and lives on the live
   // inventory (`provider.list()` → `model.variants`). For other providers
-  // it's the static reasoning descriptor curated in `MODELS_BY_PROVIDER`.
+  // it's the static reasoning/effort descriptor curated in
+  // `MODELS_BY_PROVIDER`. Claude's descriptor is keyed `effort` (with
+  // tiers up through ultracode/ultrathink); everything else uses
+  // `reasoning`.
   const resolved = useMemo((): {
     label: string;
     options: ReadonlyArray<{ id: string; label: string }>;
     defaultId: string;
+    descriptorId: string;
   } | null => {
     if (providerId === "opencode") {
       if (opencodeInventory === null) return null;
@@ -910,29 +915,37 @@ function ReasoningPicker({
             : m.variants.includes("high")
               ? "high"
               : m.variants[0]!,
+          descriptorId: "reasoning",
         };
       }
       return null;
     }
     const descriptor = findModelDescriptor(providerId, model);
-    const reasoningDescriptor = descriptor?.optionDescriptors?.find(
+    const selectDescriptor = descriptor?.optionDescriptors?.find(
       (d): d is SelectOptionDescriptor =>
-        d.kind === "select" && d.id === "reasoning",
+        d.kind === "select" && (d.id === "reasoning" || d.id === "effort"),
     );
-    if (reasoningDescriptor === undefined) return null;
+    if (selectDescriptor === undefined) return null;
     return {
-      label: reasoningDescriptor.label,
-      options: reasoningDescriptor.options,
-      defaultId: reasoningDescriptor.defaultId ?? "medium",
+      label: selectDescriptor.label,
+      options: selectDescriptor.options,
+      defaultId: selectDescriptor.defaultId ?? "medium",
+      descriptorId: selectDescriptor.id,
     };
   }, [providerId, model, opencodeInventory]);
 
   const defaultId = resolved?.defaultId ?? "medium";
-  const storageKey = `memoize.reasoning.${sessionId}`;
+  const descriptorId = resolved?.descriptorId ?? "reasoning";
+  const storageKey = `memoize.modelOptions.${sessionId}.${descriptorId}`;
   const [level, setLevel] = useState<string>(() => {
     if (typeof window === "undefined") return defaultId;
     const stored = window.sessionStorage.getItem(storageKey);
     if (stored !== null) return stored;
+    // One-shot legacy migration so users mid-session keep their pick.
+    const legacy = window.sessionStorage.getItem(
+      `memoize.reasoning.${sessionId}`,
+    );
+    if (legacy !== null && legacy.length > 0) return legacy;
     return defaultId;
   });
 
@@ -949,16 +962,27 @@ function ReasoningPicker({
   };
 
   const activeLabel = options.find((o) => o.id === level)?.label ?? level;
+  const isUltracode = level === "ultracode";
 
   return (
     <Menu>
       <MenuTrigger
-        className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-foreground hover:bg-muted/60 data-[popup-open]:bg-muted/60"
+        className={cn(
+          "flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] transition-colors data-[popup-open]:bg-muted/60",
+          isUltracode
+            ? "bg-gradient-to-r from-rose-400/90 via-amber-300/90 via-emerald-400/90 via-sky-400/90 to-violet-400/90 text-white shadow-sm/10 hover:opacity-95"
+            : "text-foreground hover:bg-muted/60",
+        )}
         aria-label={resolved.label}
-        title={`${resolved.label} for the next message`}
+        title={
+          isUltracode
+            ? "Ultracode — max reasoning + automatic workflow orchestration."
+            : `${resolved.label} for the next message`
+        }
       >
         <Gauge className="size-3" />
         <span>{activeLabel}</span>
+        {isUltracode && <Info className="size-3 opacity-90" aria-hidden />}
         <ChevronDown className="size-3 opacity-60" />
       </MenuTrigger>
       <MenuPopup side="top" align="start" className="w-44">

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -1,4 +1,11 @@
-import { ArrowUpRight, Check, ChevronDown, ChevronRight, Search as SearchIcon } from "lucide-react";
+import {
+  ArrowUpRight,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Info,
+  Search as SearchIcon,
+} from "lucide-react";
 import {
   Fragment,
   useCallback,
@@ -18,7 +25,9 @@ import type {
 } from "@memoize/wire";
 import {
   MODELS_BY_PROVIDER,
+  findModelDescriptor,
   type Message,
+  type SelectOptionDescriptor,
 } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
@@ -63,6 +72,14 @@ interface ModelPickerEntry {
   providerId: ProviderId;
   modelId: string;
   label: string;
+  /** When true, render the rainbow Ultracode chip on this row. */
+  ultracode?: boolean;
+  /**
+   * When set, render a small context-window pill on this row. We only show
+   * a pill when the model's `contextWindow` descriptor defaults to `"1m"`
+   * — otherwise the chip would clutter every legacy 200k row.
+   */
+  contextWindowLabel?: string;
 }
 
 type Scope = ProviderId | "all";
@@ -194,7 +211,27 @@ export function ModelPicker(props: ModelPickerProps) {
     const out: ModelPickerEntry[] = [];
     for (const pid of pickableProviders) {
       for (const m of modelsForProvider(pid)) {
-        out.push({ providerId: pid, modelId: m.id, label: m.label });
+        const descriptor = findModelDescriptor(pid, m.id);
+        const ctxDescriptor = descriptor?.optionDescriptors?.find(
+          (d): d is SelectOptionDescriptor =>
+            d.kind === "select" && d.id === "contextWindow",
+        );
+        const ctxDefault = ctxDescriptor?.defaultId;
+        const ctxLabel =
+          ctxDescriptor !== undefined
+            ? ctxDescriptor.options.find((o) => o.id === ctxDefault)?.label
+            : undefined;
+        // Only surface a pill when the default is the larger window —
+        // 200k-by-default rows would be noise.
+        const contextWindowLabel =
+          ctxDefault === "1m" ? ctxLabel ?? "1M" : undefined;
+        out.push({
+          providerId: pid,
+          modelId: m.id,
+          label: m.label,
+          ultracode: descriptor?.ultracode?.available === true,
+          ...(contextWindowLabel !== undefined ? { contextWindowLabel } : {}),
+        });
       }
     }
     return out;
@@ -251,6 +288,19 @@ export function ModelPicker(props: ModelPickerProps) {
       .filter((g) => g.models.length > 0);
   }, [scope, query, allModels, pickableProviders, providerId]);
 
+  // When the user picks an Ultracode-eligible model (today: Opus 4.8), seed
+  // the per-session `effort` to `"ultracode"` so the rainbow chip lights up
+  // out of the box. Skipped if the user has already picked an effort for
+  // this session — their explicit choice wins.
+  const seedUltracodeDefault = (sessionId: SessionId, modelId: string) => {
+    if (typeof window === "undefined") return;
+    const descriptor = findModelDescriptor("claude", modelId);
+    if (descriptor?.ultracode?.available !== true) return;
+    const key = `memoize.modelOptions.${sessionId}.effort`;
+    if (window.sessionStorage.getItem(key) !== null) return;
+    window.sessionStorage.setItem(key, "ultracode");
+  };
+
   const handlePick = async (pid: ProviderId, modelId: string) => {
     if (isDefault) {
       setDefaultProviderAndModel(pid, modelId);
@@ -294,6 +344,7 @@ export function ModelPicker(props: ModelPickerProps) {
           return;
         }
       }
+      seedUltracodeDefault(sessionId, modelId);
       pushModelPickerEvent({ providerId: pid, modelId });
       setOpen(false);
     } finally {
@@ -686,7 +737,25 @@ function ModelRow({
           className="size-3.5 shrink-0 text-muted-foreground"
         />
       )}
-      <span className="flex-1 truncate">{entry.label}</span>
+      <span className="truncate">{entry.label}</span>
+      {entry.ultracode === true && (
+        <span
+          title="Ultracode — max reasoning + automatic workflow orchestration."
+          className="flex items-center gap-0.5 rounded-md bg-gradient-to-r from-rose-400 via-amber-300 via-emerald-400 via-sky-400 to-violet-400 px-1.5 py-px text-[10px] font-medium text-white shadow-sm/10"
+        >
+          Ultracode
+          <Info className="size-2.5 opacity-80" aria-hidden />
+        </span>
+      )}
+      {entry.contextWindowLabel !== undefined && (
+        <span
+          title={`${entry.contextWindowLabel} context window`}
+          className="rounded bg-muted/70 px-1 py-px text-[10px] font-medium text-muted-foreground"
+        >
+          {entry.contextWindowLabel}
+        </span>
+      )}
+      <span className="flex-1" />
       {opensNewTab && (
         <ArrowUpRight
           className="size-3 text-muted-foreground/70"

--- a/apps/renderer/src/components/runtime-mode-meta.ts
+++ b/apps/renderer/src/components/runtime-mode-meta.ts
@@ -1,4 +1,4 @@
-import { Lock, LockOpen, PencilLine } from "lucide-react";
+import { Lock, LockOpen, PencilLine, Terminal } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import type { RuntimeMode } from "@memoize/wire";
@@ -7,6 +7,10 @@ import type { RuntimeMode } from "@memoize/wire";
  * Shared label/description/icon for each runtime mode. Used by the composer's
  * permission menu and the Settings page's "Default permission mode" radio
  * cards so they stay perfectly in sync.
+ *
+ * Descriptions spell out exactly which tools each mode skips and which it
+ * still prompts on — the user feedback was that the previous one-line
+ * copy left them guessing why `Auto-accept edits` still asked for Bash.
  */
 export type ModeMeta = {
   readonly label: string;
@@ -17,17 +21,26 @@ export type ModeMeta = {
 export const MODE_META: Record<RuntimeMode, ModeMeta> = {
   "approval-required": {
     label: "Supervised",
-    description: "Ask before commands and file changes.",
+    description:
+      "Asks before every Bash, file edit, web request, or MCP call. Read-only tools (Read, Glob, Grep, LS) are always free.",
     Icon: Lock,
   },
   "auto-accept-edits": {
     label: "Auto-accept edits",
-    description: "Auto-approve edits, ask before other actions.",
+    description:
+      "Auto-allows Edit, Write, MultiEdit, NotebookEdit. Still asks for Bash, WebFetch/WebSearch, and other tools.",
     Icon: PencilLine,
+  },
+  "auto-accept-edits-and-bash": {
+    label: "Auto-accept edits + Bash",
+    description:
+      "Auto-allows edits and Bash commands. Still asks for WebFetch/WebSearch and other tools.",
+    Icon: Terminal,
   },
   "full-access": {
     label: "Full access",
-    description: "Allow commands and edits without prompts.",
+    description:
+      "Auto-allows everything. Plan mode and sensitive paths (.env, .ssh, credentials, keys) still prompt.",
     Icon: LockOpen,
   },
 };
@@ -35,5 +48,6 @@ export const MODE_META: Record<RuntimeMode, ModeMeta> = {
 export const MODES_ORDER: ReadonlyArray<RuntimeMode> = [
   "approval-required",
   "auto-accept-edits",
+  "auto-accept-edits-and-bash",
   "full-access",
 ];

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -761,11 +761,11 @@ export function ExitPlanModeRow({
         : null
       : null;
 
-  const status: "pending" | "approved" | "rejected" =
+  const status: "pending" | "approved" | "cancelled" =
     result === undefined
       ? "pending"
       : result.isError
-        ? "rejected"
+        ? "cancelled"
         : "approved";
 
   // Find the open permission request for this session's ExitPlanMode.
@@ -810,7 +810,7 @@ export function ExitPlanModeRow({
               }
               className="rounded-md px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
             >
-              Reject
+              Cancel
             </button>
             <button
               type="button"
@@ -846,7 +846,7 @@ export function ExitPlanModeRow({
               : "text-muted-foreground",
           )}
         >
-          {status === "approved" ? "Approved" : "Rejected"}
+          {status === "approved" ? "Approved" : "Cancelled"}
         </span>
       </div>
     </>

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -40,19 +40,40 @@ const NETWORK_PATTERN =
  * persists to sessionStorage. For opencode the value is a variant name
  * (`high`, `medium`, `super-high`, …) that comes from the live inventory,
  * so we pass it through as-is instead of enforcing the codex enum.
+ *
+ * Multiple keys are supported — the Claude provider uses `effort` for
+ * its reasoning tier (with values `low | medium | high | xhigh | max |
+ * ultracode | ultrathink`), `fastMode` / `thinking` booleans, and
+ * `contextWindow` (`200k | 1m`). Non-Claude providers use `reasoning`.
  * Returns `null` when nothing has been set so the RPC payload stays
  * clean (drivers default to model presets).
  */
+const SESSION_MODEL_OPTION_KEYS: ReadonlyArray<string> = [
+  "reasoning",
+  "effort",
+  "fastMode",
+  "thinking",
+  "contextWindow",
+];
 const readSessionModelOptions = (
   sessionId: SessionId,
 ): Record<string, string> | null => {
   if (typeof window === "undefined") return null;
   const out: Record<string, string> = {};
-  const reasoning = window.sessionStorage.getItem(
-    `memoize.reasoning.${sessionId}`,
-  );
-  if (reasoning !== null && reasoning.length > 0) {
-    out["reasoning"] = reasoning;
+  for (const key of SESSION_MODEL_OPTION_KEYS) {
+    const v = window.sessionStorage.getItem(
+      `memoize.modelOptions.${sessionId}.${key}`,
+    );
+    if (v !== null && v.length > 0) out[key] = v;
+  }
+  // Backwards compat — the previous schema stored reasoning under a
+  // bare `memoize.reasoning.<sessionId>` key. Read it if the new key
+  // wasn't set so existing sessions don't lose their picker selection.
+  if (out["reasoning"] === undefined) {
+    const legacy = window.sessionStorage.getItem(
+      `memoize.reasoning.${sessionId}`,
+    );
+    if (legacy !== null && legacy.length > 0) out["reasoning"] = legacy;
   }
   return Object.keys(out).length === 0 ? null : out;
 };

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -86,6 +86,7 @@ const isProviderId = (v: unknown): v is ProviderId =>
 const isRuntimeMode = (v: unknown): v is SettingsFile["defaultRuntimeMode"] =>
   v === "approval-required" ||
   v === "auto-accept-edits" ||
+  v === "auto-accept-edits-and-bash" ||
   v === "full-access";
 
 /**

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -816,9 +816,18 @@ const policyFor = (
   toolInput: Record<string, unknown>,
   runtimeMode: RuntimeMode,
 ): ToolPolicy => {
-  // 0. Our own AskUserQuestion is the user-facing prompt — gating it
-  //    behind a separate "Use tool AskUserQuestion?" toast is double
-  //    prompting. Always auto-allow.
+  // 0a. Plan-mode exit is ALWAYS a user decision. Regardless of runtime
+  //     mode — including `full-access` — `ExitPlanMode` must surface the
+  //     Approve / Cancel card in the renderer. Without `forcePrompt: true`
+  //     a prior `AllowForSession` could silence it, and without putting
+  //     this branch ahead of every other auto-allow `full-access` would
+  //     short-circuit the prompt entirely.
+  if (toolName === "ExitPlanMode") {
+    return { kind: "prompt", forcePrompt: true };
+  }
+  // 0b. Our own AskUserQuestion is the user-facing prompt — gating it
+  //     behind a separate "Use tool AskUserQuestion?" toast is double
+  //     prompting. Always auto-allow.
   if (isAskUserQuestion(toolName)) {
     return { kind: "auto-allow" };
   }
@@ -849,7 +858,15 @@ const policyFor = (
     return { kind: "auto-allow" };
   }
 
-  // 4. full-access — auto-allow anything that survived the sensitive-path check.
+  // 3b. auto-accept-edits-and-bash — file edits AND Bash auto-allow;
+  //     WebFetch / WebSearch / MCP / Other still prompt.
+  if (runtimeMode === "auto-accept-edits-and-bash") {
+    if (FILE_EDIT_TOOLS.has(toolName)) return { kind: "auto-allow" };
+    if (toolName === "Bash") return { kind: "auto-allow" };
+  }
+
+  // 4. full-access — auto-allow anything that survived the sensitive-path
+  //    + plan-mode checks above.
   if (runtimeMode === "full-access") {
     return { kind: "auto-allow" };
   }
@@ -915,6 +932,79 @@ export type RequestPermission = (
   kind: PermissionKind,
   options: { readonly forcePrompt: boolean },
 ) => Promise<PermissionDecision>;
+
+/**
+ * Resolve the SDK `effort` field and the per-session `settings` slice from
+ * the FE picker's `modelOptions`. Mirrors the t3code reference:
+ *   - `ultracode`  → `effort: "xhigh"` + `settings.ultracode: true`
+ *   - `ultrathink` → prompt-injected (driver-side prefix added at send()
+ *                    time); SDK `effort` stays unset so the model still
+ *                    uses its default tier.
+ *   - `low | medium | high | xhigh | max` pass straight through, clamped
+ *     by what the SDK type accepts.
+ *   - Anything else (or missing) falls back to `"high"`.
+ *
+ * `fastMode` (Opus only) and `thinking` (Haiku 4.5) ride on `settings`.
+ *
+ * The returned object is spread into the `Options` literal so omitted
+ * fields don't override SDK defaults.
+ */
+type ClaudeSdkEffort = "low" | "medium" | "high" | "xhigh" | "max";
+type EffortAndSettings = {
+  effort?: ClaudeSdkEffort;
+  settings?: Record<string, unknown>;
+};
+const effortAndSettings = (
+  modelOptions: Readonly<Record<string, string>> | undefined,
+): EffortAndSettings => {
+  const raw =
+    modelOptions?.["effort"] ?? modelOptions?.["reasoning"] ?? undefined;
+  const ultracode = raw === "ultracode";
+  const ultrathink = raw === "ultrathink";
+  const sdkEffort: ClaudeSdkEffort | undefined = (() => {
+    if (ultrathink) return undefined; // prompt-injected; no SDK knob
+    if (ultracode) return "xhigh"; // Claude Code preset → xhigh + ultracode flag
+    if (
+      raw === "low" ||
+      raw === "medium" ||
+      raw === "high" ||
+      raw === "xhigh" ||
+      raw === "max"
+    ) {
+      return raw;
+    }
+    return "high";
+  })();
+
+  const settings: Record<string, unknown> = {};
+  if (ultracode) settings["ultracode"] = true;
+  if (modelOptions?.["fastMode"] === "true") settings["fastMode"] = true;
+  if (modelOptions?.["thinking"] === "true") {
+    settings["alwaysThinkingEnabled"] = true;
+  } else if (modelOptions?.["thinking"] === "false") {
+    settings["alwaysThinkingEnabled"] = false;
+  }
+
+  return {
+    ...(sdkEffort !== undefined ? { effort: sdkEffort } : {}),
+    ...(Object.keys(settings).length > 0 ? { settings } : {}),
+  };
+};
+
+/**
+ * If the user's effort selection is `ultrathink`, prepend the literal word
+ * to the prompt and unset the SDK effort knob. Mirrors t3code's
+ * `promptInjectedValues` contract. Driver hooks call this before forwarding
+ * the user's text to the SDK.
+ */
+export const applyUltrathinkPrefix = (
+  modelOptions: Readonly<Record<string, string>> | undefined,
+  text: string,
+): string => {
+  const raw =
+    modelOptions?.["effort"] ?? modelOptions?.["reasoning"] ?? undefined;
+  return raw === "ultrathink" ? `ultrathink\n\n${text}` : text;
+};
 
 /**
  * Spin up a streaming-input Claude conversation. The SDK is driven by an
@@ -1215,20 +1305,21 @@ export const startClaudeSession = (
         "Phase 4 — Propose. Call ExitPlanMode with a concise plan: what changes, where, and how to verify.",
       ].join("\n"),
       // Reasoning effort: mapped from FE picker via `input.modelOptions
-      // .reasoning` (the per-model descriptor in
-      // `MODELS_BY_PROVIDER[claude]` declares which models expose this).
-      // Falls back to "high" when omitted to preserve prior default. We
-      // pair it with an explicit `display: "summarized"` because Opus
+      // .effort` (or legacy `reasoning`). The per-model descriptor in
+      // `MODELS_BY_PROVIDER[claude]` declares which tiers each model
+      // exposes. Special values:
+      //   - `ultracode`  → SDK `effort: "xhigh"` + `settings.ultracode: true`
+      //   - `ultrathink` → prompt-injected at `send()` time; SDK `effort`
+      //                    stays unset.
+      // Falls back to "high" when omitted.
+      //
+      // We pair it with an explicit `display: "summarized"` because Opus
       // 4.7 defaults the adaptive-thinking display to "omitted" — without
       // this override our `thinking_delta` chunks arrive empty (only
       // signatures), which would break the streaming thinking UI. Other
       // Claude 4 models default to "summarized" so this is a no-op for
       // them.
-      effort: (() => {
-        const r = input.modelOptions?.["reasoning"];
-        if (r === "low" || r === "medium" || r === "high") return r;
-        return "high";
-      })(),
+      ...effortAndSettings(input.modelOptions),
       thinking: { type: "adaptive", display: "summarized" },
       forwardSubagentText: true,
       // Surfaces thinking deltas in the partial-message stream so we
@@ -1355,8 +1446,13 @@ export const startClaudeSession = (
       events: Mailbox.toStream(events),
       send: (text, attachmentRefs) =>
         Effect.promise(async () => {
+          // Ultrathink is the only `effort` tier that's not forwarded to
+          // the SDK as a knob — instead the literal word `"ultrathink"` is
+          // prepended to the user's prompt. The session-level modelOptions
+          // were captured at start() so we can apply the prefix here.
+          const promptText = applyUltrathinkPrefix(input.modelOptions, text);
           console.log(
-            `[claude.send] sessionId=${sessionId} textLen=${text.length} attachments=${attachmentRefs?.length ?? 0}`,
+            `[claude.send] sessionId=${sessionId} textLen=${promptText.length} attachments=${attachmentRefs?.length ?? 0}`,
           );
           const attachmentBlocks =
             attachmentRefs !== undefined && attachmentRefs.length > 0
@@ -1370,11 +1466,13 @@ export const startClaudeSession = (
                     ? { type: "text", textLen: b.text.length }
                     : { type: b.type, media_type: b.source.media_type, base64Len: b.source.data.length },
                 ),
-                { type: "text", textLen: text.length },
+                { type: "text", textLen: promptText.length },
               ],
             )}`,
           );
-          inputChannel.push(userMessageOf(text, sessionId, attachmentBlocks));
+          inputChannel.push(
+            userMessageOf(promptText, sessionId, attachmentBlocks),
+          );
         }),
       interrupt: () =>
         Effect.tryPromise({

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -108,6 +108,7 @@ const parseAgents = (
 const RUNTIME_MODES: ReadonlySet<RuntimeMode> = new Set([
   "approval-required",
   "auto-accept-edits",
+  "auto-accept-edits-and-bash",
   "full-access",
 ]);
 

--- a/apps/server/src/repository-settings/layers/repository-settings-service.ts
+++ b/apps/server/src/repository-settings/layers/repository-settings-service.ts
@@ -25,6 +25,7 @@ const isProviderId = (v: unknown): v is ProviderId =>
 const isRuntimeMode = (v: unknown): v is RuntimeMode =>
   v === "approval-required" ||
   v === "auto-accept-edits" ||
+  v === "auto-accept-edits-and-bash" ||
   v === "full-access";
 
 const rowToSettings = (

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -51,11 +51,15 @@ export type AgentStatus = typeof AgentStatus.Type;
  *   - `approval-required` — prompt every write/Bash/Network/Task/MCP call.
  *   - `auto-accept-edits` — also auto-allow Edit / Write / MultiEdit /
  *     NotebookEdit. Bash / Network / Task / MCP still prompt.
- *   - `full-access` — auto-allow everything except sensitive paths.
+ *   - `auto-accept-edits-and-bash` — auto-allow file edits AND Bash. Network
+ *     (WebFetch / WebSearch) and MCP/Other still prompt.
+ *   - `full-access` — auto-allow everything except sensitive paths. Plan
+ *     mode (ExitPlanMode) ALWAYS prompts regardless of runtime mode.
  */
 export const RuntimeMode = Schema.Literal(
   "approval-required",
   "auto-accept-edits",
+  "auto-accept-edits-and-bash",
   "full-access",
 );
 export type RuntimeMode = typeof RuntimeMode.Type;
@@ -88,14 +92,27 @@ export const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
 /**
  * Canonical reasoning effort levels exposed to the user. Providers map these
  * to their native concept:
- *   - Claude → `maxThinkingTokens` (low=5k, medium=15k, high=60k)
- *   - Codex → `reasoning_effort` enum (low/medium/high pass through)
+ *   - Claude → `maxThinkingTokens` (low=5k, medium=15k, high=60k) + SDK
+ *     `effort` enum (low/medium/high/xhigh/max). `ultracode` is a Claude
+ *     Code preset that normalizes to `xhigh` + `settings.ultracode: true`.
+ *     `ultrathink` is prompt-injected (the literal word is prepended to the
+ *     user prompt); SDK `effort` stays unset.
+ *   - Codex → `reasoning_effort` enum (low/medium/high pass through; higher
+ *     tiers fall back to `high`).
  *   - Gemini Pro → `thinkingConfig.thinkingBudget` (low=4k, medium=16k, high=32k)
  *
  * Providers/models that don't support thinking simply omit the descriptor
  * from `ModelDescriptor.optionDescriptors`, which hides the FE picker.
  */
-export const ReasoningLevel = Schema.Literal("low", "medium", "high");
+export const ReasoningLevel = Schema.Literal(
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultracode",
+  "ultrathink",
+);
 export type ReasoningLevel = typeof ReasoningLevel.Type;
 
 /**
@@ -111,6 +128,14 @@ export const SelectOptionDescriptor = Schema.Struct({
     Schema.Struct({ id: Schema.String, label: Schema.String }),
   ),
   defaultId: Schema.optional(Schema.String),
+  /**
+   * Option ids in this list are *prompt-injected* rather than forwarded to
+   * the SDK as a knob value. The driver prepends the option id (e.g. the
+   * literal word `"ultrathink"`) to the user prompt and unsets the
+   * underlying SDK field. Used by Claude's `effort` descriptor for the
+   * `ultrathink` tier.
+   */
+  promptInjectedValues: Schema.optional(Schema.Array(Schema.String)),
 });
 export type SelectOptionDescriptor = typeof SelectOptionDescriptor.Type;
 
@@ -586,11 +611,21 @@ export interface ModelOption {
   readonly optionDescriptors?: ReadonlyArray<OptionDescriptor>;
   readonly supportsPlanMode?: boolean;
   readonly supportsWebSearch?: "native" | "queryOnly";
+  /**
+   * When set, the renderer renders a rainbow "Ultracode" chip + info icon on
+   * this model's picker row, and the composer footer surfaces an Ultracode
+   * toggle pill. Server-side, picking this model defaults
+   * `modelOptions.effort = "ultracode"`, which the Claude driver normalizes
+   * to `effort: "xhigh"` + `settings.ultracode: true` on the SDK options.
+   * Today only Opus 4.8 advertises this.
+   */
+  readonly ultracode?: { readonly available: true };
 }
 
 /**
- * Standard reasoning-level descriptor reused across providers that support
- * thinking. Keep id/options aligned with `ReasoningLevel`.
+ * Standard 3-level reasoning descriptor for Codex/Gemini/Cursor and the
+ * `reasoning` knob name used across non-Claude providers. Keep id/options
+ * aligned with `ReasoningLevel`.
  */
 const reasoningSelectDescriptor = (
   defaultId: ReasoningLevel = "medium",
@@ -606,25 +641,157 @@ const reasoningSelectDescriptor = (
   defaultId,
 });
 
+/**
+ * Per-model effort descriptor for the Claude provider. Each model declares
+ * its own supported tiers (see `MODELS_BY_PROVIDER.claude` below); `ultracode`
+ * and `ultrathink` are special — see `ReasoningLevel` docs. The knob id is
+ * `effort` (matching the Claude SDK + t3code reference) rather than
+ * `reasoning` to make driver-side mapping explicit.
+ */
+const claudeEffortDescriptor = (args: {
+  options: ReadonlyArray<{ id: string; label: string }>;
+  defaultId: string;
+  promptInjectedValues?: ReadonlyArray<string>;
+}): SelectOptionDescriptor => ({
+  kind: "select",
+  id: "effort",
+  label: "Reasoning",
+  options: args.options,
+  defaultId: args.defaultId,
+  ...(args.promptInjectedValues !== undefined
+    ? { promptInjectedValues: args.promptInjectedValues }
+    : {}),
+});
+
+/**
+ * Boolean descriptor for Claude's per-model toggles. `fastMode` halves the
+ * token cost and roughly doubles throughput at the cost of some quality;
+ * `thinking` enables Haiku 4.5's always-on adaptive thinking.
+ */
+const claudeBooleanDescriptor = (
+  id: string,
+  label: string,
+): BooleanOptionDescriptor => ({
+  kind: "boolean",
+  id,
+  label,
+});
+
+/**
+ * Standard `contextWindow` descriptor used by every Claude 4.x model that
+ * supports the 1M variant. Driver-side, picking `"1m"` rewrites the API
+ * model id to `${slug}[1m]`. We default to `"1m"` because Anthropic now
+ * routes most Claude 4.x sessions to the 1M window by default.
+ */
+const claudeContextWindowDescriptor = (): SelectOptionDescriptor => ({
+  kind: "select",
+  id: "contextWindow",
+  label: "Context Window",
+  options: [
+    { id: "200k", label: "200k" },
+    { id: "1m", label: "1M" },
+  ],
+  defaultId: "1m",
+});
+
 export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> = {
+  // Claude 4.x catalog (May 2026). Effort tiers and per-model knobs match
+  // the published Claude Agent SDK contract — see also the t3code reference
+  // (`/Users/whizzy/Developer/temp/t3code/.../ClaudeProvider.ts`) which
+  // ships the same lineup. Ordering = newest first so the picker accordion
+  // expands Opus 4.8 by default.
   claude: [
+    {
+      id: "claude-opus-4-8",
+      label: "Opus 4.8",
+      optionDescriptors: [
+        claudeEffortDescriptor({
+          options: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "xhigh", label: "Extra High" },
+            { id: "max", label: "Max" },
+            { id: "ultracode", label: "Ultracode" },
+            { id: "ultrathink", label: "Ultrathink" },
+          ],
+          defaultId: "high",
+          promptInjectedValues: ["ultrathink"],
+        }),
+        claudeBooleanDescriptor("fastMode", "Fast Mode"),
+        claudeContextWindowDescriptor(),
+      ],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+      ultracode: { available: true },
+    },
     {
       id: "claude-opus-4-7",
       label: "Opus 4.7",
-      optionDescriptors: [reasoningSelectDescriptor("high")],
+      optionDescriptors: [
+        claudeEffortDescriptor({
+          options: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "xhigh", label: "Extra High" },
+            { id: "max", label: "Max" },
+            { id: "ultrathink", label: "Ultrathink" },
+          ],
+          defaultId: "xhigh",
+          promptInjectedValues: ["ultrathink"],
+        }),
+        claudeBooleanDescriptor("fastMode", "Fast Mode"),
+        claudeContextWindowDescriptor(),
+      ],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
+      id: "claude-opus-4-6",
+      label: "Opus 4.6",
+      optionDescriptors: [
+        claudeEffortDescriptor({
+          options: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "max", label: "Max" },
+            { id: "ultrathink", label: "Ultrathink" },
+          ],
+          defaultId: "high",
+          promptInjectedValues: ["ultrathink"],
+        }),
+        claudeBooleanDescriptor("fastMode", "Fast Mode"),
+        claudeContextWindowDescriptor(),
+      ],
       supportsPlanMode: true,
       supportsWebSearch: "native",
     },
     {
       id: "claude-sonnet-4-6",
       label: "Sonnet 4.6",
-      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      optionDescriptors: [
+        claudeEffortDescriptor({
+          options: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "max", label: "Max" },
+            { id: "ultrathink", label: "Ultrathink" },
+          ],
+          defaultId: "high",
+          promptInjectedValues: ["ultrathink"],
+        }),
+        claudeContextWindowDescriptor(),
+      ],
       supportsPlanMode: true,
       supportsWebSearch: "native",
     },
     {
       id: "claude-haiku-4-5",
       label: "Haiku 4.5",
+      optionDescriptors: [claudeBooleanDescriptor("thinking", "Thinking")],
       supportsPlanMode: true,
       supportsWebSearch: "native",
     },
@@ -792,7 +959,25 @@ export const findModelDescriptor = (
  * sessions don't crash.
  */
 export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string>> = {
-  claude: {},
+  // Short / vendor-formatted slugs and pre-pricing-reset names route to the
+  // canonical 4.x slugs above. Mirror of t3code's
+  // `MODEL_SLUG_ALIASES_BY_PROVIDER[CLAUDE_DRIVER_KIND]` so a user typing
+  // `opus` or `sonnet-4.6` resolves the same in both apps.
+  claude: {
+    opus: "claude-opus-4-8",
+    "opus-4.8": "claude-opus-4-8",
+    "claude-opus-4.8": "claude-opus-4-8",
+    "opus-4.7": "claude-opus-4-7",
+    "claude-opus-4.7": "claude-opus-4-7",
+    "opus-4.6": "claude-opus-4-6",
+    "claude-opus-4.6": "claude-opus-4-6",
+    sonnet: "claude-sonnet-4-6",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "claude-sonnet-4.6": "claude-sonnet-4-6",
+    haiku: "claude-haiku-4-5",
+    "haiku-4.5": "claude-haiku-4-5",
+    "claude-haiku-4.5": "claude-haiku-4-5",
+  },
   codex: {
     "gpt-5-codex": "gpt-5.4",
     "gpt-5": "gpt-5.4",
@@ -832,7 +1017,14 @@ export interface ModelPricing {
 }
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
-  "claude-opus-4-7": { input: 15, output: 75, cacheRead: 1.5, cacheCreate: 18.75 },
+  // 2026-05 Anthropic pricing reset — every Opus 4.x tier landed at the
+  // same $5/$25 per-million numbers. `fastMode` (Opus only) doubles those
+  // to $10 in / $50 out for ~2.5x throughput; we don't encode that here,
+  // the renderer's cost footer applies the multiplier when the session
+  // flips the boolean. 1M context window: no per-token premium.
+  "claude-opus-4-8": { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
+  "claude-opus-4-7": { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
+  "claude-opus-4-6": { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
   "claude-sonnet-4-6": { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
   "claude-haiku-4-5": { input: 1, output: 5, cacheRead: 0.1, cacheCreate: 1.25 },
 };


### PR DESCRIPTION
## Summary

Three buckets of fixes the user reported together:

1. **Plan-mode approval was silently auto-approved in `full-access`.** `ExitPlanMode` was falling into the `runtimeMode === "full-access"` branch of `policyFor()` and getting auto-allowed — the plan card rendered with no Approve/Cancel buttons. The card now always shows them.
2. **Runtime-mode menu was vague.** Sharpened the descriptions so each mode spells out exactly what it auto-allows vs. still prompts, and added a 4th tier **Auto-accept edits + Bash** for the "I trust shell but not network" middle ground.
3. **Claude model catalog refresh** to match Anthropic's May 2026 lineup: Opus 4.8 / 4.7 / 4.6, Sonnet 4.6, Haiku 4.5. Per-model effort tiers (`low | medium | high | xhigh | max | ultracode | ultrathink`), `fastMode` toggle on Opus, 1M context window default. Opus 4.8 lights up a rainbow **Ultracode** chip + Info icon in both the picker row and the composer footer.

### Highlights
- `policyFor()` force-prompts `ExitPlanMode` ahead of every auto-allow branch — works under every runtime mode.
- Plan-card button: **Reject → Cancel**; resolved-state pill: **Rejected → Cancelled**.
- `Auto-accept edits + Bash` runtime tier added across wire + driver + 3 server-side `isRuntimeMode` guards + renderer meta.
- `MODELS_BY_PROVIDER.claude` rewritten with per-model effort + `fastMode` + `contextWindow` (default `1m`) descriptors.
- `SelectOptionDescriptor` gained `promptInjectedValues` for the `ultrathink` tier (prepended to the user prompt; SDK effort stays unset).
- Driver maps `ultracode → effort: "xhigh" + settings.ultracode: true`; `fastMode` / `thinking` flow through `settings`.
- ReasoningPicker keys on `id === "reasoning" | "effort"`; messages-store reads the full bag (`effort | reasoning | fastMode | thinking | contextWindow`); legacy `memoize.reasoning.<session>` storage key still works.
- Picker seeds `effort = "ultracode"` on first Opus 4.8 pick so the rainbow chip lights up out of the box.
- `MODEL_PRICING` updated to May 2026 reset ($5/$25 across Opus 4.x); `MODEL_ALIASES_BY_PROVIDER.claude` populated with short slugs (`opus`, `sonnet-4.6`, `claude-haiku-4.5`, …).

## Test plan

- [x] `bun --bun turbo run check-types` — 8/8 packages pass
- [x] `bun --bun turbo run lint` — pass
- [x] `packages/index` tests (21) pass
- [x] `apps/mcp-server` tests (2) pass
- [ ] Open a Claude session in **Full access**, ask the agent to make a plan → confirm the plan card lands with **Approve / Cancel** (not auto-approved)
- [ ] Click **Approve** → confirm `permissionMode` flips from `plan` back to `default` and the agent proceeds
- [ ] Open the runtime-mode menu in **Auto-accept edits** → confirm the description spells out "Edit/Write/MultiEdit/NotebookEdit auto, Bash + Network prompt"
- [ ] Switch to **Auto-accept edits + Bash** → confirm Bash auto-allows but WebFetch/WebSearch still prompt
- [ ] Pick **Opus 4.8** from the picker → confirm the rainbow **Ultracode** chip renders both in the picker row and in the composer footer, and the **1M** pill appears next to the model label
- [ ] Switch the reasoning chip to **Extra High** → confirm the rainbow gradient swaps for the normal chip styling
- [ ] Pick **Sonnet 4.6** / **Opus 4.7** / **Opus 4.6** / **Haiku 4.5** → confirm each row's descriptor set renders correctly (effort tiers, fastMode where applicable, 1M pill where applicable)