### PR TITLE
Implement real terminal/output execution for ACP agents (Grok, Gemini, Cursor)

### DIFF
--- a/apps/server/src/provider/drivers/acp/fs.ts
+++ b/apps/server/src/provider/drivers/acp/fs.ts
@@ -42,13 +42,13 @@ export interface FsHandleContext {
   readonly getPermissionMode?: () => PermissionMode;
 }
 
-const isUnderCwd = (requested: string, cwd: string): boolean => {
+export const isUnderCwd = (requested: string, cwd: string): boolean => {
   const abs = path.resolve(requested);
   const root = path.resolve(cwd);
   return abs === root || abs.startsWith(root + path.sep);
 };
 
-const ensureUnderCwd = (p: string, cwd: string): string => {
+export const ensureUnderCwd = (p: string, cwd: string): string => {
   const abs = path.resolve(p);
   if (!isUnderCwd(abs, cwd)) {
     throw new Error(`Path escapes workspace: ${p}`);

--- a/apps/server/src/provider/drivers/acp/terminal.ts
+++ b/apps/server/src/provider/drivers/acp/terminal.ts
@@ -1,23 +1,292 @@
 /**
- * Minimal terminal support for ACP clients (Grok, Gemini, Cursor, etc.).
+ * Terminal support for ACP clients (Grok, Gemini, Cursor, etc.).
  *
- * Full terminal emulation is complex. For now we provide a stub that at least
- * prevents hard "Method not supported" errors and lets the agent know the
- * capability is partially available.
+ * Implements the canonical ACP terminal lifecycle backed by node:child_process:
+ *   terminal/create      → spawn a process, return { terminalId }
+ *   terminal/output      → { output, truncated, exitStatus }
+ *   terminal/wait_for_exit → await exit, return { exitStatus }
+ *   terminal/kill        → SIGTERM (+SIGKILL fallback)
+ *   terminal/release     → kill if running + drop the record
  *
- * The context is kept compatible with FsHandleContext so drivers can pass
- * the same object; permission wiring for exec will be added in Phase 2.
+ * This is what lets ACP agents actually run shell commands (e.g. `gh pr create`,
+ * `git push`) and read their output — previously these were stubs that returned
+ * fake success and never executed anything, so the agent reported the shell as
+ * blocked.
+ *
+ * Execution is gated through the shared Bash permission policy + PermissionService
+ * (via ctx.requestPermission) exactly like Claude/Codex Bash and ACP fs writes.
+ * When the permission callbacks are not wired by the driver (transitional state),
+ * we fall back to auto-allow so existing sessions keep working.
+ *
+ * Security: the working directory is forced under the session cwd via
+ * ensureUnderCwd (shared with acp/fs.ts).
  */
+
+import { type ChildProcess, spawn } from "node:child_process";
+
+import type {
+  AgentSessionId,
+  FolderId,
+  PermissionDecision,
+  PermissionKind,
+  PermissionMode,
+  RuntimeMode,
+} from "@memoize/wire";
+
+import { getBashPolicy } from "../../policy.ts";
+import { ensureUnderCwd } from "./fs.ts";
 
 export interface TerminalHandleContext {
   readonly cwd: string;
-  readonly sessionId?: import("@memoize/wire").AgentSessionId;
-  readonly projectId?: import("@memoize/wire").FolderId;
+  readonly sessionId?: AgentSessionId;
+  readonly projectId?: FolderId;
   readonly requestPermission?: (
-    kind: import("@memoize/wire").PermissionKind,
+    kind: PermissionKind,
     options: { readonly forcePrompt: boolean },
-  ) => Promise<import("@memoize/wire").PermissionDecision>;
-  readonly getRuntimeMode?: () => import("@memoize/wire").RuntimeMode;
+  ) => Promise<PermissionDecision>;
+  readonly getRuntimeMode?: () => RuntimeMode;
+  readonly getPermissionMode?: () => PermissionMode;
+}
+
+interface ExitStatus {
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+}
+
+interface TerminalRecord {
+  readonly child: ChildProcess;
+  output: string;
+  truncated: boolean;
+  readonly byteLimit: number;
+  exitStatus: ExitStatus | null;
+  /** Resolves once the child closes; resolves immediately if already exited. */
+  readonly exited: Promise<ExitStatus>;
+}
+
+/** Default cap on captured output (most-recent bytes are kept). */
+const DEFAULT_OUTPUT_BYTE_LIMIT = 1024 * 1024; // 1 MiB
+
+/** Live terminals keyed by the id we hand back to the agent. */
+const terminals = new Map<string, TerminalRecord>();
+let terminalCounter = 0;
+const nextTerminalId = (): string => `term_${Date.now()}_${++terminalCounter}`;
+
+/** Append output, keeping only the most-recent `byteLimit` bytes. */
+const appendOutput = (rec: TerminalRecord, chunk: string): void => {
+  rec.output += chunk;
+  if (Buffer.byteLength(rec.output, "utf8") > rec.byteLimit) {
+    const buf = Buffer.from(rec.output, "utf8");
+    rec.output = buf.subarray(buf.length - rec.byteLimit).toString("utf8");
+    rec.truncated = true;
+  }
+};
+
+/**
+ * Normalize the `env` param into a plain record. The ACP spec models env as
+ * `Array<{ name, value }>`, but agents have also been seen to pass a plain
+ * object — accept both.
+ */
+const normalizeEnv = (raw: unknown): Record<string, string> => {
+  const out: Record<string, string> = {};
+  if (raw == null) return out;
+  if (Array.isArray(raw)) {
+    for (const entry of raw) {
+      const name = (entry as { name?: unknown })?.name;
+      const value = (entry as { value?: unknown })?.value;
+      if (typeof name === "string") {
+        out[name] = typeof value === "string" ? value : String(value ?? "");
+      }
+    }
+    return out;
+  }
+  if (typeof raw === "object") {
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      out[k] = typeof v === "string" ? v : String(v ?? "");
+    }
+  }
+  return out;
+};
+
+/** Pull the terminal id out of params under any of the shapes agents use. */
+const idOf = (params: unknown): string | undefined => {
+  const p = params as Record<string, unknown> | null | undefined;
+  const id = p?.terminalId ?? p?.processId ?? p?.id;
+  return typeof id === "string" ? id : undefined;
+};
+
+const recordOf = (params: unknown, method: string): TerminalRecord => {
+  const id = idOf(params);
+  if (id === undefined) throw new Error(`${method}: missing terminalId`);
+  const rec = terminals.get(id);
+  if (rec === undefined) throw new Error(`${method}: unknown terminalId ${id}`);
+  return rec;
+};
+
+/**
+ * Gate command execution through the shared Bash policy + PermissionService.
+ * Throws on Deny so the JSON-RPC reply to the agent becomes an error.
+ */
+async function ensureBashPermission(
+  ctx: TerminalHandleContext,
+  command: string,
+): Promise<void> {
+  const requestPermission = ctx.requestPermission;
+  const getRuntimeMode = ctx.getRuntimeMode;
+
+  // Transitional: no permission service wired yet → auto-allow.
+  if (!requestPermission || !getRuntimeMode) return;
+
+  const policy = getBashPolicy(
+    command,
+    getRuntimeMode(),
+    ctx.getPermissionMode?.(),
+  );
+
+  if (policy.kind === "auto-allow") return;
+
+  const decision = await requestPermission(
+    { _tag: "Bash", command },
+    { forcePrompt: policy.forcePrompt },
+  );
+
+  if (decision._tag === "Deny") {
+    throw new Error(`Permission denied for command: ${command}`);
+  }
+}
+
+async function createTerminal(
+  params: unknown,
+  ctx: TerminalHandleContext,
+): Promise<unknown> {
+  const p = (params ?? {}) as Record<string, unknown>;
+
+  const command = typeof p.command === "string" ? p.command : "";
+  if (command.length === 0) throw new Error("terminal/create: missing command");
+
+  const args = Array.isArray(p.args)
+    ? p.args.filter((a): a is string => typeof a === "string")
+    : [];
+  const env = normalizeEnv(p.env);
+  const byteLimit =
+    typeof p.outputByteLimit === "number" && p.outputByteLimit > 0
+      ? p.outputByteLimit
+      : DEFAULT_OUTPUT_BYTE_LIMIT;
+  const requestedCwd =
+    typeof p.cwd === "string" && p.cwd.length > 0 ? p.cwd : ctx.cwd;
+  const spawnCwd = ensureUnderCwd(requestedCwd, ctx.cwd);
+
+  // Human-readable command for the permission prompt.
+  const displayCommand =
+    args.length > 0 ? `${command} ${args.join(" ")}` : command;
+  await ensureBashPermission(ctx, displayCommand);
+
+  // If the agent gave us argv, run the program directly. Otherwise treat
+  // `command` as a shell line so `gh pr create ... && git push` style commands
+  // (pipes, &&, env expansion) work as the agent expects.
+  const useShell = args.length === 0;
+  const child = useShell
+    ? spawn(command, {
+        cwd: spawnCwd,
+        env: { ...process.env, ...env },
+        shell: true,
+        stdio: ["pipe", "pipe", "pipe"],
+      })
+    : spawn(command, args, {
+        cwd: spawnCwd,
+        env: { ...process.env, ...env },
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+  const terminalId = nextTerminalId();
+
+  let resolveExit!: (status: ExitStatus) => void;
+  const exited = new Promise<ExitStatus>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const rec: TerminalRecord = {
+    child,
+    output: "",
+    truncated: false,
+    byteLimit,
+    exitStatus: null,
+    exited,
+  };
+  terminals.set(terminalId, rec);
+
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => appendOutput(rec, chunk));
+  child.stderr?.on("data", (chunk: string) => appendOutput(rec, chunk));
+  child.on("error", (err) => {
+    appendOutput(
+      rec,
+      `\n[spawn error] ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    if (rec.exitStatus === null) {
+      const status: ExitStatus = { exitCode: null, signal: null };
+      rec.exitStatus = status;
+      resolveExit(status);
+    }
+  });
+  child.on("close", (code, signal) => {
+    if (rec.exitStatus !== null) return;
+    const status: ExitStatus = { exitCode: code, signal: signal ?? null };
+    rec.exitStatus = status;
+    resolveExit(status);
+  });
+
+  // Return terminalId (canonical ACP) plus a processId alias for any agent
+  // variant still keyed on the old exec/run_command shape.
+  return { terminalId, processId: terminalId };
+}
+
+function terminalOutput(params: unknown): unknown {
+  const rec = recordOf(params, "terminal/output");
+  return {
+    output: rec.output,
+    truncated: rec.truncated,
+    exitStatus: rec.exitStatus,
+  };
+}
+
+async function waitForExit(params: unknown): Promise<unknown> {
+  const rec = recordOf(params, "terminal/wait_for_exit");
+  const status = rec.exitStatus ?? (await rec.exited);
+  return { exitStatus: status };
+}
+
+function writeInput(params: unknown): unknown {
+  const rec = recordOf(params, "terminal/write");
+  const p = params as Record<string, unknown>;
+  const data = p?.data ?? p?.input ?? p?.text;
+  if (typeof data === "string") rec.child.stdin?.write(data);
+  return { status: "written" };
+}
+
+function killTerminal(params: unknown): unknown {
+  const rec = recordOf(params, "terminal/kill");
+  if (rec.exitStatus === null) {
+    rec.child.kill("SIGTERM");
+    const timer = setTimeout(() => {
+      if (rec.exitStatus === null) rec.child.kill("SIGKILL");
+    }, 2000);
+    timer.unref?.();
+  }
+  return {};
+}
+
+function releaseTerminal(params: unknown): unknown {
+  const id = idOf(params);
+  if (id !== undefined) {
+    const rec = terminals.get(id);
+    if (rec !== undefined && rec.exitStatus === null) {
+      rec.child.kill("SIGKILL");
+    }
+    terminals.delete(id);
+  }
+  return {};
 }
 
 export async function handleTerminalRequest(
@@ -25,55 +294,37 @@ export async function handleTerminalRequest(
   params: unknown,
   ctx: TerminalHandleContext,
 ): Promise<unknown> {
-  switch (method) {
-    case "terminal/create":
-    case "terminal/createSession": {
-      // The agent wants to open a pseudo-terminal.
-      // For now we return a fake id and let it know we don't support rich PTY yet.
-      // This is better than a hard error.
-      return {
-        terminalId: `term_${Date.now()}`,
-        status: "created",
-        note: "Basic terminal support only. Full PTY + resize not yet implemented.",
-      };
-    }
+  try {
+    switch (method) {
+      case "terminal/create":
+      case "terminal/createSession":
+      // Legacy aliases that also embed a command to run.
+      case "terminal/exec":
+      case "terminal/run_command":
+        return await createTerminal(params, ctx);
 
-    case "terminal/write":
-    case "terminal/input": {
-      // Swallow input for now
-      return { status: "written" };
-    }
+      case "terminal/output":
+        return terminalOutput(params);
 
-    case "terminal/close":
-    case "terminal/kill": {
-      return { status: "closed" };
-    }
+      case "terminal/wait_for_exit":
+        return await waitForExit(params);
 
-    case "terminal/wait_for_exit": {
-      // Stub: the agent wants to wait for a previously started process.
-      // For now, pretend it exited successfully so the agent can continue.
-      // A real implementation would track processes started via terminal/exec or create.
-      const processId = (params as any)?.processId ?? "unknown";
-      return {
-        processId,
-        status: "exited",
-        exitCode: 0,
-        note: "Stub implementation — real process tracking not yet wired.",
-      };
-    }
+      case "terminal/write":
+      case "terminal/input":
+        return writeInput(params);
 
-    case "terminal/exec":
-    case "terminal/run_command": {
-      // Basic exec stub. A full implementation would use child_process or node-pty
-      // and return a processId that can be waited on.
-      return {
-        processId: `proc_${Date.now()}`,
-        status: "started",
-        note: "Basic terminal exec stub. Output streaming and real waiting coming soon.",
-      };
-    }
+      case "terminal/kill":
+        return killTerminal(params);
 
-    default:
-      throw new Error(`Method not implemented by memoize ACP client: ${method}`);
+      case "terminal/release":
+      case "terminal/close":
+        return releaseTerminal(params);
+
+      default:
+        throw new Error(`Method not implemented by memoize ACP client: ${method}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(message);
   }
 }

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -12,7 +12,11 @@ import {
   type AgentItemId,
   type AgentSessionId,
   type AttachmentRef,
+  type FolderId,
+  type PermissionDecision,
+  type PermissionKind,
   type PermissionMode,
+  type RuntimeMode,
   type StartSessionInput,
   type UserQuestionAnswer,
 } from "@memoize/wire";
@@ -21,6 +25,7 @@ import { AttachmentService } from "../../attachment/services/attachment-service.
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
+import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
 
 /**
  * Live-only handle for one Cursor Agent conversation. Mirrors Grok's
@@ -217,6 +222,25 @@ interface CursorReadyTransport {
    * in the project cwd as soon as it takes ownership.
    */
   setSessionCwd(cwd: string): void;
+  /**
+   * Wire the permission/runtime-mode callbacks used to gate fs writes and
+   * terminal command execution. Until set (prewarm phase), the handlers fall
+   * back to auto-allow. `startCursorSession` installs the real callbacks on
+   * takeover so commands route through PermissionService.
+   */
+  setAcpPermissionContext(ctx: AcpPermissionContext): void;
+}
+
+/** Permission/runtime-mode callbacks shared by the ACP fs + terminal handlers. */
+interface AcpPermissionContext {
+  readonly sessionId?: AgentSessionId;
+  readonly projectId?: FolderId;
+  readonly requestPermission?: (
+    kind: PermissionKind,
+    options: { readonly forcePrompt: boolean },
+  ) => Promise<PermissionDecision>;
+  readonly getRuntimeMode?: () => RuntimeMode;
+  readonly getPermissionMode?: () => PermissionMode;
 }
 
 /**
@@ -267,6 +291,11 @@ const connectAndAuthenticateCursor = async (
   // Sandbox root for client-side fs/terminal requests. Defaults to $HOME
   // until startCursorSession swaps in the project cwd.
   let sessionCwd: string = process.env.HOME ?? process.cwd();
+  // Permission/runtime-mode callbacks for fs writes + terminal exec. Empty
+  // during prewarm (handlers auto-allow); startCursorSession swaps in the
+  // real PermissionService bridge on takeover.
+  let acpPermissionContext: AcpPermissionContext = {};
+  const acpHandlerContext = () => ({ cwd: sessionCwd, ...acpPermissionContext });
 
   const writeMessage = (msg: Record<string, unknown>): void => {
     if (!child.stdin.writable) return;
@@ -347,7 +376,7 @@ const connectAndAuthenticateCursor = async (
         }
         const replyId = msg.id;
         if (isFs) {
-          handleFsRequest(msg.method, msg.params, { cwd: sessionCwd })
+          handleFsRequest(msg.method, msg.params, acpHandlerContext())
             .then((result) => {
               writeMessage({ jsonrpc: "2.0", id: replyId, result });
             })
@@ -362,7 +391,7 @@ const connectAndAuthenticateCursor = async (
           return;
         }
         if (isTerminal) {
-          handleTerminalRequest(msg.method, msg.params, { cwd: sessionCwd })
+          handleTerminalRequest(msg.method, msg.params, acpHandlerContext())
             .then((result) => {
               writeMessage({ jsonrpc: "2.0", id: replyId, result });
             })
@@ -550,6 +579,9 @@ const connectAndAuthenticateCursor = async (
     setSessionCwd(next) {
       sessionCwd = next;
     },
+    setAcpPermissionContext(ctx) {
+      acpPermissionContext = ctx;
+    },
   };
 };
 
@@ -673,6 +705,8 @@ export const startCursorSession = (
   apiKey: string | null,
   cursorPath: string,
   sessionId: AgentSessionId,
+  requestPermission: RequestPermission,
+  getRuntimeMode: GetRuntimeMode,
   resumeCursor: string | null = null,
 ): Effect.Effect<CursorSessionHandle, AgentSessionStartError, AttachmentService> =>
   Effect.gen(function* () {
@@ -719,6 +753,17 @@ export const startCursorSession = (
     // project cwd before cursor's fs/* and terminal/* server→client
     // requests start flowing — handleFsRequest sandboxes paths under this.
     transportResult.setSessionCwd(cwd);
+
+    // Gate fs writes + terminal command execution through PermissionService +
+    // RuntimeMode, exactly like Claude/Codex/Grok. `currentMode` is read live.
+    transportResult.setAcpPermissionContext({
+      sessionId,
+      projectId: input.folderId,
+      requestPermission: (kind, options) =>
+        requestPermission(sessionId, kind, options),
+      getRuntimeMode,
+      getPermissionMode: () => currentMode,
+    });
 
     // === Wire session-level handlers onto the (possibly prewarmed) transport.
     transportResult.setSessionUpdateHandler((update) => {

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -21,6 +21,7 @@ import { createAcpTranslator } from "./acp/translate.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
+import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
 
 /**
  * Live-only handle for one Gemini conversation. Mirrors the Grok/Codex/Claude
@@ -227,6 +228,8 @@ export const startGeminiSession = (
   apiKey: string | null,
   geminiPath: string,
   sessionId: AgentSessionId,
+  requestPermission: RequestPermission,
+  getRuntimeMode: GetRuntimeMode,
   resumeCursor: string | null = null,
 ): Effect.Effect<GeminiSessionHandle, AgentSessionStartError, AttachmentService> =>
   Effect.gen(function* () {
@@ -237,6 +240,22 @@ export const startGeminiSession = (
     const events = yield* Mailbox.make<AgentEvent>();
 
     let currentMode: PermissionMode = input.permissionMode ?? "default";
+
+    // Shared context for the ACP fs/* and terminal/* handlers so file writes
+    // and command execution are gated through PermissionService + RuntimeMode,
+    // exactly like Claude/Codex. `currentMode` is read live.
+    const acpHandlerContext = () => ({
+      cwd,
+      sessionId,
+      projectId: input.folderId,
+      requestPermission: (
+        kind: import("@memoize/wire").PermissionKind,
+        options: { readonly forcePrompt: boolean },
+      ) => requestPermission(sessionId, kind, options),
+      getRuntimeMode,
+      getPermissionMode: () => currentMode,
+    });
+
     let acpSessionId: string | null = null;
     let nextRpcId = 1;
     let closed = false;
@@ -406,7 +425,7 @@ export const startGeminiSession = (
             );
           }
           if (isFs) {
-            handleFsRequest(msg.method, msg.params, { cwd })
+            handleFsRequest(msg.method, msg.params, acpHandlerContext())
               .then((result) => {
                 writeMessage({ jsonrpc: "2.0", id: msg.id, result });
               })
@@ -422,7 +441,7 @@ export const startGeminiSession = (
           }
 
           if (msg.method.startsWith("terminal/")) {
-            handleTerminalRequest(msg.method, msg.params, { cwd })
+            handleTerminalRequest(msg.method, msg.params, acpHandlerContext())
               .then((result) => {
                 writeMessage({ jsonrpc: "2.0", id: msg.id, result });
               })

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -18,6 +18,7 @@ import { createAcpTranslator } from "./acp/translate.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
+import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
 
 /**
  * Live-only handle for one Grok conversation. Mirrors Codex/Claude handle
@@ -230,6 +231,8 @@ export const startGrokSession = (
   apiKey: string | null,
   grokPath: string,
   sessionId: AgentSessionId,
+  requestPermission: RequestPermission,
+  getRuntimeMode: GetRuntimeMode,
   resumeCursor: string | null = null,
 ): Effect.Effect<GrokSessionHandle, AgentSessionStartError, AttachmentService> =>
   Effect.gen(function* () {
@@ -240,6 +243,23 @@ export const startGrokSession = (
     const events = yield* Mailbox.make<AgentEvent>();
 
     let currentMode: PermissionMode = input.permissionMode ?? "default";
+
+    // Shared context handed to the ACP fs/* and terminal/* handlers so file
+    // writes and command execution are gated through PermissionService +
+    // RuntimeMode, exactly like Claude/Codex. `currentMode` is read live so a
+    // mid-session mode toggle takes effect on the next tool call.
+    const acpHandlerContext = () => ({
+      cwd,
+      sessionId,
+      projectId: input.folderId,
+      requestPermission: (
+        kind: import("@memoize/wire").PermissionKind,
+        options: { readonly forcePrompt: boolean },
+      ) => requestPermission(sessionId, kind, options),
+      getRuntimeMode,
+      getPermissionMode: () => currentMode,
+    });
+
     let acpSessionId: string | null = null;
     let nextRpcId = 1;
     let closed = false;
@@ -433,7 +453,7 @@ export const startGrokSession = (
           if (isFs) {
             // Real FS support — the agent can now read/write files directly
             // instead of getting "Method not implemented" tool errors.
-            handleFsRequest(msg.method, msg.params, { cwd })
+            handleFsRequest(msg.method, msg.params, acpHandlerContext())
               .then((result) => {
                 writeMessage({ jsonrpc: "2.0", id: msg.id, result });
               })
@@ -449,7 +469,7 @@ export const startGrokSession = (
           }
 
           if (msg.method.startsWith("terminal/")) {
-            handleTerminalRequest(msg.method, msg.params, { cwd })
+            handleTerminalRequest(msg.method, msg.params, acpHandlerContext())
               .then((result) => {
                 writeMessage({ jsonrpc: "2.0", id: msg.id, result });
               })

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -201,6 +201,8 @@ export const ProviderServiceLive = Layer.effect(
               apiKey,
               geminiPath,
               sessionId,
+              buildRequestPermission(input.folderId),
+              runtimeModeGetter,
               resumeCursor,
             ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else if (input.providerId === "grok") {
@@ -226,6 +228,8 @@ export const ProviderServiceLive = Layer.effect(
               apiKey,
               grokPath,
               sessionId,
+              buildRequestPermission(input.folderId),
+              runtimeModeGetter,
               resumeCursor,
             ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else if (input.providerId === "opencode") {
@@ -279,6 +283,8 @@ export const ProviderServiceLive = Layer.effect(
               apiKey,
               cursorPath,
               sessionId,
+              buildRequestPermission(input.folderId),
+              runtimeModeGetter,
               resumeCursor,
             ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else if (input.providerId === "claude") {

--- a/apps/server/src/provider/policy.ts
+++ b/apps/server/src/provider/policy.ts
@@ -98,6 +98,47 @@ export const getFsPolicy = (
 };
 
 // ---------------------------------------------------------------------------
-// Future: Bash policy surface can live here too when terminal.exec is wired.
-// export const getBashPolicy = (command: string, runtimeMode, ...) => ...
+// Bash / terminal command policy (used by ACP handleTerminalRequest)
 // ---------------------------------------------------------------------------
+
+export type BashPolicy =
+  | { readonly kind: "auto-allow" }
+  | { readonly kind: "prompt"; readonly forcePrompt: boolean };
+
+/**
+ * Decide whether an ACP terminal command should prompt the user.
+ *
+ * Mirrors Claude's `policyFor` handling of the Bash tool exactly so ACP
+ * agents (Grok, Gemini, Cursor) get the same gating as the SDK drivers:
+ *  1. plan mode → always prompt (forcePrompt) — never silently run commands.
+ *  2. full-access → auto-allow.
+ *  3. auto-accept-edits → still prompt. Unlike file edits, command execution
+ *     is NOT auto-accepted in this mode (matches Claude: only FILE_EDIT_TOOLS
+ *     skip the prompt under auto-accept-edits, Bash falls through).
+ *  4. default (approval-required) → prompt (forcePrompt: false).
+ *
+ * `command` is accepted for future per-command heuristics (e.g. forcing a
+ * prompt on obviously destructive commands) but is not inspected yet.
+ */
+export const getBashPolicy = (
+  command: string,
+  runtimeMode: RuntimeMode,
+  permissionMode?: PermissionMode,
+): BashPolicy => {
+  void command;
+
+  // 1. Plan mode never silently runs commands.
+  if (permissionMode === "plan") {
+    return { kind: "prompt", forcePrompt: true };
+  }
+
+  // 2. full-access — auto-allow anything.
+  if (runtimeMode === "full-access") {
+    return { kind: "auto-allow" };
+  }
+
+  // 3. auto-accept-edits — commands still prompt (only file edits are auto-
+  //    accepted in this mode, matching Claude).
+  // 4. Default — prompt.
+  return { kind: "prompt", forcePrompt: false };
+};


### PR DESCRIPTION
## Problem

When a user asks the **Grok** agent to *create a PR*, it fails with an error about not having access to the terminal/output — the shell is reported as blocked.

**Root cause:** Grok (and Gemini/Cursor) run over **ACP** (a JSON-RPC bridge). The client advertised `terminal: true` during the handshake, but the client-side `terminal/*` handler in `acp/terminal.ts` was a **pure stub**: it returned fake `terminalId`/`processId` values, swallowed input, and `terminal/wait_for_exit` always returned `exitCode: 0` with **no captured output**. So when Grok ran `gh pr create` / `git push` through a terminal it got fake success, never received real output, couldn't confirm the PR, and gave up. PR creation was blocked by the dead terminal — not a missing feature.

Claude works because the Claude SDK runs Bash in-process and gates it through `PermissionService`. This PR makes the ACP terminal do the same.

## Changes

- **`acp/terminal.ts`** — rewrote the stub into real execution via `node:child_process`. Canonical ACP lifecycle backed by a per-terminal record map:
  - `terminal/create` spawns the process (shell line when no argv, direct exec when `args` given), captures stdout+stderr into a byte-capped buffer, returns `{ terminalId }`.
  - `terminal/output` → real `{ output, truncated, exitStatus }`.
  - `terminal/wait_for_exit` → actually awaits exit, returns `{ exitStatus: { exitCode, signal } }`.
  - `terminal/kill` (SIGTERM→SIGKILL), `terminal/release`, `terminal/write` (stdin).
  - Kept all legacy aliases (`exec`, `run_command`, `createSession`, `close`, `input`) so no method an agent emits regresses.
  - cwd forced under the session root via `ensureUnderCwd` (now exported from `acp/fs.ts`).
- **`policy.ts`** — added `getBashPolicy`, mirroring Claude's `policyFor` Bash gating exactly: `full-access` → auto-allow, `plan` → always prompt, otherwise prompt. `auto-accept-edits` does **not** auto-accept commands (only file edits do, matching Claude).
- **`grok.ts` / `gemini.ts` / `cursor.ts`** — thread `requestPermission` + `getRuntimeMode` through and build a shared handler context so terminal exec **and** fs writes route through `PermissionService`. (Grok's fs writes were previously silently auto-allowed.) Cursor uses a settable permission-context slot since its transport is prewarmed before session takeover.
- **`provider-service.ts`** — passes `buildRequestPermission(input.folderId)` + `runtimeModeGetter` into the three ACP drivers, like the existing Codex/Claude call sites.

## Result

Ask Grok to create a PR → it runs `gh pr create` / `git push` through a real terminal, you get a Bash permission prompt (unless in full-access/auto-accept), the command executes, output flows back, and Grok confirms the PR URL. Denying the prompt returns a clean error instead of fake success.

## Testing

- `bun run check-types` (apps/server): clean — zero errors in touched files (the one remaining error is a pre-existing `bun:test` types issue in `availability.test.ts`, untouched).
- Manual (requires desktop app + authed `grok`/`gh`): open a Grok session in a git repo, ask it to create a PR, confirm the permission prompt, real output, and PR URL. Set `GROK_RPC_TRACE=1` to watch the `terminal/create → output → wait_for_exit` round-trip. Verify the denial path and smoke-test one command each on Gemini and Cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)