### PR TITLE
feat(providers): surface available provider CLI updates

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -20,6 +20,7 @@ import { FileEditor } from "./components/file-editor.tsx";
 import { closeActiveChatTab, MainTabs } from "./components/main-tabs.tsx";
 import { OnboardingWizard } from "./components/onboarding/onboarding-wizard.tsx";
 import { ProjectsSidebar } from "./components/projects-sidebar";
+import { ProviderUpdatesToast } from "./components/provider-updates-toast.tsx";
 import { RightPane } from "./components/right-pane";
 import { SettingsPage } from "./components/settings-page";
 import { TopBarLeft, TopBarMain, TopBarRight } from "./components/top-bar.tsx";
@@ -29,6 +30,7 @@ import { useMenuShortcuts } from "./hooks/use-menu-shortcuts.ts";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { useKeybindingsStore } from "./store/keybindings.ts";
 import { usePermissionsStore } from "./store/permissions.ts";
+import { useProvidersStore } from "./store/providers.ts";
 import { useChatsStore } from "./store/chats.ts";
 import { useSessionsStore } from "./store/sessions.ts";
 import { useSettingsStore } from "./store/settings.ts";
@@ -75,6 +77,14 @@ export function App() {
     void hydrateKeybindings();
     void hydrateSubagentsStore();
   }, [hydrateSettings, hydrateKeybindings]);
+
+  // Probe provider availability once on boot so the "update available" launch
+  // toast can fire without the user first opening settings. ProvidersPane
+  // keeps its own mount/focus refresh for live updates while settings is open.
+  const refreshProviders = useProvidersStore((s) => s.refresh);
+  useEffect(() => {
+    void refreshProviders();
+  }, [refreshProviders]);
 
   // Mirror Electron's fullscreen state into the ui store so the top bars
   // can drop the macOS traffic-light gutter.
@@ -171,8 +181,7 @@ function MainShell() {
   // booting-session loading panel and the tab strip stay in lockstep when
   // the chats store is mid-transition.
   const selectedChatId = useChatsStore((s) => s.selectedChatId);
-  const activeChatId =
-    selectedSession?.chatId ?? selectedChatId ?? null;
+  const activeChatId = selectedSession?.chatId ?? selectedChatId ?? null;
   // Mirror `NewChatTabButton.creating` so the chat surface flips to the
   // loading panel the moment the user clicks "+", even before the
   // optimistic session row lands (~200ms RPC). Once the new row is
@@ -190,8 +199,7 @@ function MainShell() {
   );
   // Provider label for the session-boot panel — falls back to the user's
   // default when no session is selected yet (the brief click → RPC window).
-  const bootingProviderId =
-    selectedSession?.providerId ?? defaultProviderId;
+  const bootingProviderId = selectedSession?.providerId ?? defaultProviderId;
 
   const activeMainTab = useUiStore((s) => s.activeMainTab);
   const openFile = useUiStore((s) => s.openFile);
@@ -313,11 +321,9 @@ function MainShell() {
           <main className="flex h-full min-h-0 min-w-0 flex-col bg-background/70 backdrop-blur-3xl">
             <TopBarMain />
             <UpdateBanner />
+            <ProviderUpdatesToast />
             <IndexProgressBanner />
-            <MainTabs
-              projectId={selectedFolderId}
-              emptyLabel={emptyTabLabel}
-            />
+            <MainTabs projectId={selectedFolderId} emptyLabel={emptyTabLabel} />
             <div
               hidden={activeMainTab !== "chat"}
               className="flex min-h-0 flex-1 flex-col"
@@ -325,9 +331,16 @@ function MainShell() {
               {creatingChat ? (
                 <div className="flex min-h-0 flex-1 flex-col px-8 py-6">
                   <p className="mb-4 text-[13px] leading-snug text-foreground/85">
-                    {selectedFolder
-                      ? <>You're starting a new chat in <code className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[12px] text-foreground/90">{selectedFolder.name}</code></>
-                      : "You're starting a new chat"}
+                    {selectedFolder ? (
+                      <>
+                        You're starting a new chat in{" "}
+                        <code className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[12px] text-foreground/90">
+                          {selectedFolder.name}
+                        </code>
+                      </>
+                    ) : (
+                      "You're starting a new chat"
+                    )}
                   </p>
                   <ChatCreatingPanel
                     providerId={defaultProviderId}
@@ -350,9 +363,7 @@ function MainShell() {
                 <>
                   <ChatView sessionId={selectedSessionId} />
                   <CostFooter sessionId={selectedSessionId} />
-                  <CliUpgradeBanner
-                    providerId={selectedSession.providerId}
-                  />
+                  <CliUpgradeBanner providerId={selectedSession.providerId} />
                   <ChatComposer session={selectedSession} />
                 </>
               ) : (

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -13,6 +13,7 @@ import {
   type AgentAvailability,
   type LoginEvent,
   type ProviderId,
+  type ProviderUpdateEvent,
 } from "@memoize/wire";
 
 import { ApiKeyRow } from "~/components/api-key-row";
@@ -129,11 +130,20 @@ export function ProviderCard({
   const styles = PROVIDER_STATUS_STYLES[summary.statusKey];
   const versionLabel = formatVersionLabel(availability?.cliVersion);
   const showUpgrade = enabled && availability?.cliVersionStatus === "outdated";
-  // Informational "a newer release is published" affordance — independent of
-  // the blocking SDK floor (`showUpgrade`). Hidden when the SDK-floor upgrade
-  // card is already showing, so we don't stack two update prompts.
+  // Hover-revealed one-click update affordance — independent of the blocking
+  // SDK floor (`showUpgrade`). Shown for any installed provider that has an
+  // update command, EXCEPT when we know it's already on the latest published
+  // version (`"current"`). That means:
+  //   - npm providers behind latest → shown (warning-styled "vX available")
+  //   - npm providers on latest      → hidden
+  //   - curl-installed CLIs (Grok/Cursor, version "unknown") → shown so they
+  //     are updatable even though we can't read a registry version
   const showUpdate =
-    enabled && !showUpgrade && availability?.latestVersionStatus === "behind";
+    enabled &&
+    !showUpgrade &&
+    availability?.cliInstalled === true &&
+    availability.updateCommand !== undefined &&
+    availability.latestVersionStatus !== "current";
 
   return (
     <div
@@ -166,8 +176,10 @@ export function ProviderCard({
             )}
             {showUpdate && (
               <UpdateAvailableButton
+                providerId={providerId}
                 displayName={PROVIDER_LABEL[providerId]}
                 latestVersion={availability?.latestVersion}
+                behind={availability?.latestVersionStatus === "behind"}
                 command={availability?.updateCommand}
               />
             )}
@@ -564,44 +576,181 @@ function CursorSignInRow() {
   );
 }
 
+type UpdateState =
+  | { readonly kind: "idle" }
+  | { readonly kind: "running"; readonly line: string | null }
+  | { readonly kind: "success" }
+  | { readonly kind: "failed"; readonly reason: string };
+
 /**
- * Hover-revealed "update available" affordance shown next to the version label
- * when a newer release is published. Click opens a popover with the exact
- * version and the copy-able update command — check-and-notify only, no in-app
- * execution. `stopPropagation` keeps a click from toggling the card's expand.
+ * Subscribe to `agent.updateProvider`, which spawns the provider's update
+ * command server-side and streams its output. On the terminal `done` event we
+ * re-probe availability so the card reflects the new version. Interrupting the
+ * fiber (unmount / cancel) closes the stream scope, which SIGTERMs the child.
+ */
+function useProviderUpdate(providerId: ProviderId) {
+  const refresh = useProvidersStore((s) => s.refresh);
+  const [state, setState] = useState<UpdateState>({ kind: "idle" });
+  const fiberRef = useRef<Fiber.RuntimeFiber<unknown, unknown> | null>(null);
+
+  useEffect(
+    () => () => {
+      const fiber = fiberRef.current;
+      if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
+    },
+    [],
+  );
+
+  const run = async () => {
+    if (state.kind === "running") return;
+    setState({ kind: "running", line: null });
+    const client = await getRpcClient();
+    const fiber = Effect.runFork(
+      Stream.runForEach(
+        client.agent.updateProvider({ providerId }),
+        (event: ProviderUpdateEvent) =>
+          Effect.sync(() => {
+            if (event._tag === "log") {
+              setState({ kind: "running", line: event.text });
+            } else if (event._tag === "done") {
+              fiberRef.current = null;
+              if (event.ok) {
+                setState({ kind: "success" });
+                void refresh();
+              } else {
+                setState({
+                  kind: "failed",
+                  reason: event.reason ?? "Update failed.",
+                });
+              }
+            }
+          }),
+      ).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            fiberRef.current = null;
+            setState({
+              kind: "failed",
+              reason: err instanceof Error ? err.message : String(err),
+            });
+          }),
+        ),
+      ),
+    );
+    fiberRef.current = fiber;
+  };
+
+  return { state, run };
+}
+
+/**
+ * Hover-revealed one-click update affordance shown next to the version label.
+ * Click opens a popover that **runs the update in-app** (spawns the install
+ * command server-side and streams progress) — for npm providers and for
+ * curl-installed CLIs like Grok alike. `stopPropagation` keeps a click from
+ * toggling the card's expand.
  */
 function UpdateAvailableButton({
+  providerId,
   displayName,
   latestVersion,
+  behind,
   command,
 }: {
+  readonly providerId: ProviderId;
   readonly displayName: string;
   readonly latestVersion: string | undefined;
+  readonly behind: boolean;
   readonly command: string | undefined;
 }) {
+  const { state, run } = useProviderUpdate(providerId);
+  const running = state.kind === "running";
+
+  const headline =
+    behind && latestVersion !== undefined
+      ? `Update available — v${latestVersion}`
+      : "Update available";
+  const detail =
+    behind && latestVersion !== undefined
+      ? `Update ${displayName} to v${latestVersion}.`
+      : `Update ${displayName} to the latest version.`;
+
   return (
     <Popover>
       <PopoverTrigger
         onClick={(e) => e.stopPropagation()}
-        aria-label={`Update available for ${displayName}`}
+        aria-label={`Update ${displayName}`}
         title="Update available"
-        className="flex size-5 shrink-0 items-center justify-center rounded text-warning opacity-0 transition-opacity hover:bg-muted/60 focus-visible:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100"
+        className={cn(
+          "flex size-5 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-muted/60 focus-visible:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100",
+          behind ? "text-warning" : "text-muted-foreground",
+        )}
       >
         <ArrowUpCircle className="size-3.5" aria-hidden />
       </PopoverTrigger>
       <PopoverPopup side="bottom" align="start" className="w-72">
-        <div className="flex flex-col gap-2.5">
+        <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-0.5">
             <span className="text-[13px] font-medium text-foreground">
-              Update available
+              {headline}
             </span>
             <span className="text-xs leading-snug text-muted-foreground">
-              Update {displayName}
-              {latestVersion !== undefined ? ` to v${latestVersion}` : ""}.
+              {detail}
             </span>
           </div>
-          {command !== undefined && (
-            <CodeRow label="Run to update" command={command} />
+
+          {state.kind === "success" ? (
+            <div className="rounded-md border border-emerald-400/30 bg-emerald-500/[0.06] px-3 py-2 text-[11px] text-emerald-200">
+              Updated. Re-checking version…
+            </div>
+          ) : (
+            <>
+              <Button
+                type="button"
+                size="xs"
+                variant="default"
+                disabled={running}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void run();
+                }}
+                className="w-full"
+              >
+                {running ? (
+                  <>
+                    <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
+                    Updating…
+                  </>
+                ) : (
+                  <>
+                    <ArrowUpCircle className="mr-1 size-3" aria-hidden />
+                    {state.kind === "failed" ? "Try again" : "Update now"}
+                  </>
+                )}
+              </Button>
+
+              {running && state.line !== null && (
+                <p className="truncate font-mono text-[10px] text-muted-foreground">
+                  {state.line}
+                </p>
+              )}
+              {state.kind === "failed" && (
+                <p className="text-[11px] leading-snug text-rose-300">
+                  {state.reason}
+                </p>
+              )}
+
+              {command !== undefined && (
+                <details className="text-[10px] text-muted-foreground">
+                  <summary className="cursor-pointer select-none">
+                    or update manually
+                  </summary>
+                  <div className="mt-1.5">
+                    <CodeRow label="Run in a terminal" command={command} />
+                  </div>
+                </details>
+              )}
+            </>
           )}
         </div>
       </PopoverPopup>

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -373,14 +373,12 @@ function SubscriptionRow({
 /**
  * Privacy-aware email pill. Blurs the address by default (so screen-records
  * and screenshots don't leak it) and reveals on click; clicking again
- * re-blurs. Stops propagation so clicking it doesn't also collapse/expand
- * the parent card.
+ * re-blurs. Rendered as a span because the provider row itself is a button.
  */
 function BlurredEmail({ email }: { email: string }) {
   const [revealed, setRevealed] = useState(false);
   return (
-    <button
-      type="button"
+    <span
       onClick={(e) => {
         e.stopPropagation();
         setRevealed((r) => !r);
@@ -388,14 +386,14 @@ function BlurredEmail({ email }: { email: string }) {
       title={revealed ? "Click to hide" : "Click to reveal"}
       aria-label={revealed ? "Hide email" : "Reveal email"}
       className={cn(
-        "max-w-[16rem] truncate rounded px-1 py-0.5 text-left font-mono text-[11px] transition-[filter,background-color] duration-150",
+        "max-w-[16rem] cursor-pointer truncate rounded px-1 py-0.5 text-left font-mono text-[11px] transition-[filter,background-color] duration-150",
         revealed
           ? "bg-muted/40 text-foreground"
           : "bg-muted/40 text-foreground blur-[5px] select-none hover:blur-[3px]",
       )}
     >
       {email}
-    </button>
+    </span>
   );
 }
 

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -1,7 +1,9 @@
 import { Effect, Fiber, Stream } from "effect";
 import {
   ArrowUpCircle,
+  Check,
   ChevronDown,
+  CircleAlert,
   Copy,
   ExternalLink,
   Loader2,
@@ -19,7 +21,7 @@ import {
 import { ApiKeyRow } from "~/components/api-key-row";
 import { ProviderIcon } from "~/components/provider-icons";
 import { Button } from "~/components/ui/button";
-import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { getRpcClient } from "~/lib/rpc-client";
 import { useProvidersStore } from "~/store/providers";
 import {
@@ -180,7 +182,6 @@ export function ProviderCard({
                 displayName={PROVIDER_LABEL[providerId]}
                 latestVersion={availability?.latestVersion}
                 behind={availability?.latestVersionStatus === "behind"}
-                command={availability?.updateCommand}
               />
             )}
           </div>
@@ -592,17 +593,24 @@ function useProviderUpdate(providerId: ProviderId) {
   const refresh = useProvidersStore((s) => s.refresh);
   const [state, setState] = useState<UpdateState>({ kind: "idle" });
   const fiberRef = useRef<Fiber.RuntimeFiber<unknown, unknown> | null>(null);
+  const resetTimerRef = useRef<number | null>(null);
 
   useEffect(
     () => () => {
       const fiber = fiberRef.current;
       if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
+      if (resetTimerRef.current !== null)
+        window.clearTimeout(resetTimerRef.current);
     },
     [],
   );
 
   const run = async () => {
     if (state.kind === "running") return;
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
     setState({ kind: "running", line: null });
     const client = await getRpcClient();
     const fiber = Effect.runFork(
@@ -617,6 +625,13 @@ function useProviderUpdate(providerId: ProviderId) {
               if (event.ok) {
                 setState({ kind: "success" });
                 void refresh();
+                // Re-probe will hide the icon if now on latest; for
+                // version-unknown CLIs (Grok) drop the "Updated" badge after
+                // a moment so the control returns to idle.
+                resetTimerRef.current = window.setTimeout(() => {
+                  setState({ kind: "idle" });
+                  resetTimerRef.current = null;
+                }, 4_000);
               } else {
                 setState({
                   kind: "failed",
@@ -644,117 +659,102 @@ function useProviderUpdate(providerId: ProviderId) {
 }
 
 /**
- * Hover-revealed one-click update affordance shown next to the version label.
- * Click opens a popover that **runs the update in-app** (spawns the install
- * command server-side and streams progress) — for npm providers and for
- * curl-installed CLIs like Grok alike. `stopPropagation` keeps a click from
- * toggling the card's expand.
+ * Hover-revealed one-click update control shown next to the version label.
+ * Clicking the icon **runs the update immediately in-app** (spawns the install
+ * command server-side, streams progress) — for npm providers and curl-based
+ * CLIs like Grok alike. No dialog: the icon itself is the status badge
+ * (spinner → check / alert), with a tooltip carrying the detail / error.
+ * `stopPropagation` keeps the click from toggling the card's expand.
  */
 function UpdateAvailableButton({
   providerId,
   displayName,
   latestVersion,
   behind,
-  command,
 }: {
   readonly providerId: ProviderId;
   readonly displayName: string;
   readonly latestVersion: string | undefined;
   readonly behind: boolean;
-  readonly command: string | undefined;
 }) {
   const { state, run } = useProviderUpdate(providerId);
-  const running = state.kind === "running";
 
-  const headline =
+  const idleLabel =
     behind && latestVersion !== undefined
-      ? `Update available — v${latestVersion}`
-      : "Update available";
-  const detail =
-    behind && latestVersion !== undefined
-      ? `Update ${displayName} to v${latestVersion}.`
-      : `Update ${displayName} to the latest version.`;
+      ? `Update ${displayName} to v${latestVersion}`
+      : `Update ${displayName} to the latest version`;
+  const tooltip =
+    state.kind === "running"
+      ? (state.line ?? "Updating…")
+      : state.kind === "success"
+        ? "Updated"
+        : state.kind === "failed"
+          ? state.reason
+          : idleLabel;
+
+  // The icon doubles as the status badge.
+  const { icon, tone } =
+    state.kind === "running"
+      ? {
+          icon: <Loader2 className="size-3.5 animate-spin" aria-hidden />,
+          tone: "text-muted-foreground",
+        }
+      : state.kind === "success"
+        ? {
+            icon: <Check className="size-3.5" aria-hidden />,
+            tone: "text-emerald-400",
+          }
+        : state.kind === "failed"
+          ? {
+              icon: <CircleAlert className="size-3.5" aria-hidden />,
+              tone: "text-rose-400",
+            }
+          : {
+              icon: <ArrowUpCircle className="size-3.5" aria-hidden />,
+              tone: behind ? "text-warning" : "text-muted-foreground",
+            };
+
+  // While active (running/success/failed) the control stays visible; idle is
+  // hover-revealed so it doesn't clutter up-to-date rows.
+  const active = state.kind !== "idle";
+  const badge =
+    state.kind === "running"
+      ? "Updating…"
+      : state.kind === "failed"
+        ? "Failed"
+        : state.kind === "success"
+          ? "Updated"
+          : null;
 
   return (
-    <Popover>
-      <PopoverTrigger
-        onClick={(e) => e.stopPropagation()}
-        aria-label={`Update ${displayName}`}
-        title="Update available"
-        className={cn(
-          "flex size-5 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-muted/60 focus-visible:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100",
-          behind ? "text-warning" : "text-muted-foreground",
-        )}
-      >
-        <ArrowUpCircle className="size-3.5" aria-hidden />
-      </PopoverTrigger>
-      <PopoverPopup side="bottom" align="start" className="w-72">
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-0.5">
-            <span className="text-[13px] font-medium text-foreground">
-              {headline}
-            </span>
-            <span className="text-xs leading-snug text-muted-foreground">
-              {detail}
-            </span>
-          </div>
-
-          {state.kind === "success" ? (
-            <div className="rounded-md border border-emerald-400/30 bg-emerald-500/[0.06] px-3 py-2 text-[11px] text-emerald-200">
-              Updated. Re-checking version…
-            </div>
-          ) : (
-            <>
-              <Button
-                type="button"
-                size="xs"
-                variant="default"
-                disabled={running}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void run();
-                }}
-                className="w-full"
-              >
-                {running ? (
-                  <>
-                    <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
-                    Updating…
-                  </>
-                ) : (
-                  <>
-                    <ArrowUpCircle className="mr-1 size-3" aria-hidden />
-                    {state.kind === "failed" ? "Try again" : "Update now"}
-                  </>
-                )}
-              </Button>
-
-              {running && state.line !== null && (
-                <p className="truncate font-mono text-[10px] text-muted-foreground">
-                  {state.line}
-                </p>
-              )}
-              {state.kind === "failed" && (
-                <p className="text-[11px] leading-snug text-rose-300">
-                  {state.reason}
-                </p>
-              )}
-
-              {command !== undefined && (
-                <details className="text-[10px] text-muted-foreground">
-                  <summary className="cursor-pointer select-none">
-                    or update manually
-                  </summary>
-                  <div className="mt-1.5">
-                    <CodeRow label="Run in a terminal" command={command} />
-                  </div>
-                </details>
-              )}
-            </>
-          )}
-        </div>
-      </PopoverPopup>
-    </Popover>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            disabled={state.kind === "running"}
+            onClick={(e) => {
+              e.stopPropagation();
+              void run();
+            }}
+            aria-label={idleLabel}
+            className={cn(
+              "flex shrink-0 items-center gap-1 rounded px-1 transition-opacity hover:bg-muted/60 focus-visible:opacity-100 group-hover:opacity-100 disabled:cursor-default",
+              tone,
+              active ? "opacity-100" : "opacity-0",
+            )}
+          >
+            {icon}
+            {badge !== null && (
+              <span className="text-[10px] font-medium">{badge}</span>
+            )}
+          </button>
+        }
+      />
+      <TooltipPopup side="bottom" className="max-w-72">
+        {tooltip}
+      </TooltipPopup>
+    </Tooltip>
   );
 }
 

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -1,5 +1,11 @@
 import { Effect, Fiber, Stream } from "effect";
-import { ChevronDown, Copy, ExternalLink, Loader2 } from "lucide-react";
+import {
+  ArrowUpCircle,
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  Loader2,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -12,6 +18,7 @@ import {
 import { ApiKeyRow } from "~/components/api-key-row";
 import { ProviderIcon } from "~/components/provider-icons";
 import { Button } from "~/components/ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { getRpcClient } from "~/lib/rpc-client";
 import { useProvidersStore } from "~/store/providers";
 import {
@@ -121,8 +128,12 @@ export function ProviderCard({
     : baseSummary;
   const styles = PROVIDER_STATUS_STYLES[summary.statusKey];
   const versionLabel = formatVersionLabel(availability?.cliVersion);
-  const showUpgrade =
-    enabled && availability?.cliVersionStatus === "outdated";
+  const showUpgrade = enabled && availability?.cliVersionStatus === "outdated";
+  // Informational "a newer release is published" affordance — independent of
+  // the blocking SDK floor (`showUpgrade`). Hidden when the SDK-floor upgrade
+  // card is already showing, so we don't stack two update prompts.
+  const showUpdate =
+    enabled && !showUpgrade && availability?.latestVersionStatus === "behind";
 
   return (
     <div
@@ -152,6 +163,13 @@ export function ProviderCard({
               <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
                 {versionLabel}
               </span>
+            )}
+            {showUpdate && (
+              <UpdateAvailableButton
+                displayName={PROVIDER_LABEL[providerId]}
+                latestVersion={availability?.latestVersion}
+                command={availability?.updateCommand}
+              />
             )}
           </div>
           <div className="flex items-center gap-1.5 truncate text-xs text-muted-foreground">
@@ -319,7 +337,8 @@ function SubscriptionRow({
       </span>
       <p className="text-[11px] leading-snug text-muted-foreground">
         Sessions will fail if your plan doesn&apos;t include {info.plan}.
-        Subscribe (or confirm your existing plan) before using {PROVIDER_LABEL[providerId]}.
+        Subscribe (or confirm your existing plan) before using{" "}
+        {PROVIDER_LABEL[providerId]}.
       </p>
       <div>
         <button
@@ -542,6 +561,51 @@ function CursorSignInRow() {
         </span>
       </div>
     </div>
+  );
+}
+
+/**
+ * Hover-revealed "update available" affordance shown next to the version label
+ * when a newer release is published. Click opens a popover with the exact
+ * version and the copy-able update command — check-and-notify only, no in-app
+ * execution. `stopPropagation` keeps a click from toggling the card's expand.
+ */
+function UpdateAvailableButton({
+  displayName,
+  latestVersion,
+  command,
+}: {
+  readonly displayName: string;
+  readonly latestVersion: string | undefined;
+  readonly command: string | undefined;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        onClick={(e) => e.stopPropagation()}
+        aria-label={`Update available for ${displayName}`}
+        title="Update available"
+        className="flex size-5 shrink-0 items-center justify-center rounded text-warning opacity-0 transition-opacity hover:bg-muted/60 focus-visible:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100"
+      >
+        <ArrowUpCircle className="size-3.5" aria-hidden />
+      </PopoverTrigger>
+      <PopoverPopup side="bottom" align="start" className="w-72">
+        <div className="flex flex-col gap-2.5">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[13px] font-medium text-foreground">
+              Update available
+            </span>
+            <span className="text-xs leading-snug text-muted-foreground">
+              Update {displayName}
+              {latestVersion !== undefined ? ` to v${latestVersion}` : ""}.
+            </span>
+          </div>
+          {command !== undefined && (
+            <CodeRow label="Run to update" command={command} />
+          )}
+        </div>
+      </PopoverPopup>
+    </Popover>
   );
 }
 

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -623,15 +623,20 @@ function useProviderUpdate(providerId: ProviderId) {
             } else if (event._tag === "done") {
               fiberRef.current = null;
               if (event.ok) {
-                setState({ kind: "success" });
-                void refresh();
-                // Re-probe will hide the icon if now on latest; for
-                // version-unknown CLIs (Grok) drop the "Updated" badge after
-                // a moment so the control returns to idle.
-                resetTimerRef.current = window.setTimeout(() => {
-                  setState({ kind: "idle" });
-                  resetTimerRef.current = null;
-                }, 4_000);
+                // Re-probe FIRST so the version label is fresh before we flip
+                // the badge to "Updated" — otherwise the badge and the old
+                // version show together for a beat. Stay on the spinner until
+                // the probe lands.
+                void refresh().finally(() => {
+                  setState({ kind: "success" });
+                  // Re-probe hides the icon if now on latest; for
+                  // version-unknown CLIs (Grok) drop the "Updated" badge after
+                  // a moment so the control returns to idle.
+                  resetTimerRef.current = window.setTimeout(() => {
+                    setState({ kind: "idle" });
+                    resetTimerRef.current = null;
+                  }, 4_000);
+                });
               } else {
                 setState({
                   kind: "failed",

--- a/apps/renderer/src/components/provider-updates-toast.tsx
+++ b/apps/renderer/src/components/provider-updates-toast.tsx
@@ -1,0 +1,151 @@
+import { ArrowUpCircle, X } from "lucide-react";
+import { useState } from "react";
+import { createPortal } from "react-dom";
+
+import { Button } from "~/components/ui/button";
+import { useProvidersStore } from "~/store/providers";
+import { useUiStore } from "~/store/ui";
+
+// Persist dismissed update sets so we don't re-nag every launch. The key
+// encodes the exact (provider, latestVersion) pairs, so dismissing "Codex
+// v1.2.0 + Claude v1.0.5" stays hidden — but a newer release changes the key
+// and the toast returns.
+const STORAGE_KEY = "memoize.dismissedProviderUpdates";
+
+function loadDismissed(): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((x): x is string => typeof x === "string"))
+      : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function persistDismissed(keys: ReadonlySet<string>): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...keys]));
+  } catch {
+    // localStorage can be unavailable (private mode / strict CSP). The toast
+    // simply re-appears next launch — non-fatal.
+  }
+}
+
+/**
+ * Bottom-right toast announcing that one or more provider CLIs have a newer
+ * published release. Check-and-notify only — it routes the user to provider
+ * settings (where the per-provider popover shows the update command); it never
+ * runs an update itself.
+ *
+ * Styled to match `UpdateBanner` (the app-update toast); offset upward so the
+ * two don't overlap when both are visible.
+ */
+export function ProviderUpdatesToast() {
+  const availability = useProvidersStore((s) => s.availability);
+  const setView = useUiStore((s) => s.setView);
+  const setSettingsSection = useUiStore((s) => s.setSettingsSection);
+  const [dismissed, setDismissed] = useState<ReadonlySet<string>>(() =>
+    loadDismissed(),
+  );
+
+  const candidates = availability.filter(
+    (a) => a.latestVersionStatus === "behind",
+  );
+  const notificationKey =
+    candidates.length === 0
+      ? ""
+      : candidates
+          .map((a) => `${a.providerId}:${a.latestVersion ?? "?"}`)
+          .sort()
+          .join(",");
+
+  if (notificationKey === "" || dismissed.has(notificationKey)) {
+    return null;
+  }
+
+  const recordDismissed = () => {
+    const next = new Set(dismissed);
+    next.add(notificationKey);
+    persistDismissed(next);
+    setDismissed(next);
+  };
+
+  const onReview = () => {
+    setView("settings");
+    setSettingsSection({ kind: "providers" });
+    recordDismissed();
+  };
+
+  const single = candidates.length === 1 ? candidates[0] : undefined;
+  const title =
+    single !== undefined
+      ? `Update available: ${single.displayName}${
+          single.latestVersion !== undefined ? ` v${single.latestVersion}` : ""
+        }`
+      : `Updates available: ${candidates.length} providers`;
+
+  const detail =
+    single !== undefined
+      ? `A newer release of ${single.displayName} is published.`
+      : candidates
+          .map(
+            (a) =>
+              `${a.displayName}${
+                a.latestVersion !== undefined ? ` v${a.latestVersion}` : ""
+              }`,
+          )
+          .join(", ");
+
+  // Portal to body so the toast escapes any ancestor with a backdrop-filter /
+  // transform that would trap `position: fixed` (same reason as UpdateBanner).
+  return createPortal(
+    <div
+      role="status"
+      className="fixed right-4 bottom-24 z-50 flex w-[320px] flex-col gap-3 rounded-2xl border border-border bg-card p-4 shadow-lg"
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
+          <ArrowUpCircle className="size-4" />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-foreground">
+            {title}
+          </span>
+          <span className="text-[12px] leading-snug text-muted-foreground">
+            {detail}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={recordDismissed}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Dismiss provider update toast"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      <div className="flex items-center justify-end gap-1.5">
+        <Button
+          size="xs"
+          variant="ghost"
+          onClick={recordDismissed}
+          className="rounded-full text-[11px]"
+        >
+          Dismiss
+        </Button>
+        <Button
+          size="xs"
+          onClick={onReview}
+          className="rounded-full text-[11px]"
+        >
+          Review in settings
+        </Button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/server/src/provider/availability.test.ts
+++ b/apps/server/src/provider/availability.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { grokAuthTestHelpers } from "./availability.ts";
+import { deriveLatestAdvisory, grokAuthTestHelpers } from "./availability.ts";
 
-const { parseGrokAuthJson, extractTier, decodeJwtPayload } = grokAuthTestHelpers;
+const { parseGrokAuthJson, extractTier, decodeJwtPayload } =
+  grokAuthTestHelpers;
 
 describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
   it("decodeJwtPayload handles a real-ish JWT payload", () => {
@@ -84,5 +85,34 @@ describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
   it("parseGrokAuthJson for empty entry still authenticated", () => {
     const info = parseGrokAuthJson(JSON.stringify({}));
     expect(info.authLabel).toBe("Grok");
+  });
+});
+
+describe("deriveLatestAdvisory — update-available verdict", () => {
+  it("reports behind when installed < latest", () => {
+    expect(deriveLatestAdvisory("1.0.5", "1.0.9")).toBe("behind");
+    expect(deriveLatestAdvisory("0.128.0", "0.130.2")).toBe("behind");
+    expect(deriveLatestAdvisory("1.2.3", "2.0.0")).toBe("behind");
+  });
+
+  it("reports current when installed == or > latest", () => {
+    expect(deriveLatestAdvisory("1.0.9", "1.0.9")).toBe("current");
+    expect(deriveLatestAdvisory("2.1.0", "2.0.5")).toBe("current");
+  });
+
+  it("tolerates label-wrapped version strings (parser pulls the triple)", () => {
+    // `claude --version` prints "1.0.123 (Claude Code)"
+    expect(deriveLatestAdvisory("1.0.123 (Claude Code)", "1.0.140")).toBe(
+      "behind",
+    );
+    expect(deriveLatestAdvisory("codex-cli 0.130.0", "0.130.0")).toBe(
+      "current",
+    );
+  });
+
+  it("reports unknown when either side is missing or unparsable", () => {
+    expect(deriveLatestAdvisory(undefined, "1.0.0")).toBe("unknown");
+    expect(deriveLatestAdvisory("1.0.0", null)).toBe("unknown");
+    expect(deriveLatestAdvisory("not-a-version", "1.0.0")).toBe("unknown");
   });
 });

--- a/apps/server/src/provider/availability.test.ts
+++ b/apps/server/src/provider/availability.test.ts
@@ -4,6 +4,7 @@ import {
   buildUpdateCommand,
   deriveLatestAdvisory,
   grokAuthTestHelpers,
+  selectCliPathCandidate,
 } from "./availability.ts";
 
 const { parseGrokAuthJson, extractTier, decodeJwtPayload } =
@@ -121,7 +122,46 @@ describe("deriveLatestAdvisory — update-available verdict", () => {
   });
 });
 
+describe("selectCliPathCandidate", () => {
+  it("prefers a user Codex install over Conductor's managed Codex shim", () => {
+    expect(
+      selectCliPathCandidate("codex", [
+        "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
+        "/Users/me/.nvm/versions/node/v23.10.0/bin/codex",
+      ]),
+    ).toBe("/Users/me/.nvm/versions/node/v23.10.0/bin/codex");
+  });
+
+  it("falls back to Conductor's managed Codex when it is the only candidate", () => {
+    expect(
+      selectCliPathCandidate("codex", [
+        "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
+      ]),
+    ).toBe("/Users/me/Library/Application Support/com.conductor.app/./bin/codex");
+  });
+
+  it("keeps first PATH match for non-Codex providers", () => {
+    expect(
+      selectCliPathCandidate("claude", [
+        "/opt/homebrew/bin/claude",
+        "/Users/me/.local/bin/claude",
+      ]),
+    ).toBe("/opt/homebrew/bin/claude");
+  });
+});
+
 describe("buildUpdateCommand — install-method detection", () => {
+  it("uses the exact Conductor-managed standalone Codex binary updater", () => {
+    expect(
+      buildUpdateCommand("codex", [
+        "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
+        "/Users/me/Library/Application Support/com.conductor.app/agent-binaries/codex/0.138.0/codex",
+      ]),
+    ).toBe(
+      "'/Users/me/Library/Application Support/com.conductor.app/./bin/codex' update",
+    );
+  });
+
   it("uses the native self-updater for a native Claude install", () => {
     expect(buildUpdateCommand("claude", ["/Users/me/.local/bin/claude"])).toBe(
       "claude update",
@@ -164,6 +204,10 @@ describe("buildUpdateCommand — install-method detection", () => {
     expect(buildUpdateCommand("gemini", [])).toBe(
       "npm uninstall -g @google/gemini-cli || true; npm install -g @google/gemini-cli@latest",
     );
+  });
+
+  it("does not update npm when an npm provider path is an unknown absolute install", () => {
+    expect(buildUpdateCommand("codex", ["/opt/custom/codex"])).toBeNull();
   });
 
   it("reinstalls via the install one-liner for curl-based CLIs (Grok)", () => {

--- a/apps/server/src/provider/availability.test.ts
+++ b/apps/server/src/provider/availability.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
-import { deriveLatestAdvisory, grokAuthTestHelpers } from "./availability.ts";
+import {
+  buildUpdateCommand,
+  deriveLatestAdvisory,
+  grokAuthTestHelpers,
+} from "./availability.ts";
 
 const { parseGrokAuthJson, extractTier, decodeJwtPayload } =
   grokAuthTestHelpers;
@@ -114,5 +118,57 @@ describe("deriveLatestAdvisory — update-available verdict", () => {
     expect(deriveLatestAdvisory(undefined, "1.0.0")).toBe("unknown");
     expect(deriveLatestAdvisory("1.0.0", null)).toBe("unknown");
     expect(deriveLatestAdvisory("not-a-version", "1.0.0")).toBe("unknown");
+  });
+});
+
+describe("buildUpdateCommand — install-method detection", () => {
+  it("uses the native self-updater for a native Claude install", () => {
+    expect(buildUpdateCommand("claude", ["/Users/me/.local/bin/claude"])).toBe(
+      "claude update",
+    );
+  });
+
+  it("uses the native self-updater for a native OpenCode install", () => {
+    expect(
+      buildUpdateCommand("opencode", ["/Users/me/.opencode/bin/opencode"]),
+    ).toBe("opencode upgrade");
+  });
+
+  it("uses npm (uninstall-then-install) for an nvm/npm-global install", () => {
+    // `which` returns the bin symlink; realpath points into node_modules.
+    const cmd = buildUpdateCommand("codex", [
+      "/Users/me/.nvm/versions/node/v23.10.0/bin/codex",
+      "/Users/me/.nvm/versions/node/v23.10.0/lib/node_modules/@openai/codex/bin/codex.js",
+    ]);
+    expect(cmd).toBe(
+      "npm uninstall -g @openai/codex || true; npm install -g @openai/codex@latest",
+    );
+  });
+
+  it("uses bun / pnpm for those global installs", () => {
+    expect(buildUpdateCommand("codex", ["/Users/me/.bun/bin/codex"])).toBe(
+      "bun i -g @openai/codex@latest",
+    );
+    expect(
+      buildUpdateCommand("codex", ["/Users/me/.local/share/pnpm/codex"]),
+    ).toBe("pnpm add -g @openai/codex@latest");
+  });
+
+  it("uses brew when the binary lives under a Homebrew prefix", () => {
+    expect(buildUpdateCommand("codex", ["/opt/homebrew/bin/codex"])).toBe(
+      "brew upgrade codex",
+    );
+  });
+
+  it("defaults npm providers to npm when the path is unknown / absent", () => {
+    expect(buildUpdateCommand("gemini", [])).toBe(
+      "npm uninstall -g @google/gemini-cli || true; npm install -g @google/gemini-cli@latest",
+    );
+  });
+
+  it("reinstalls via the install one-liner for curl-based CLIs (Grok)", () => {
+    expect(buildUpdateCommand("grok", ["/Users/me/.local/bin/grok"])).toBe(
+      "curl -fsSL https://x.ai/cli/install.sh | bash",
+    );
   });
 });

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -39,6 +39,18 @@ interface ProviderProbe {
    * and surface no update affordance.
    */
   readonly npmPackage: string | null;
+  /** Homebrew formula, when the CLI is also distributed via brew. */
+  readonly homebrewFormula: string | null;
+  /**
+   * Native self-update (e.g. `claude update`, `opencode upgrade`) used when
+   * the on-PATH binary is the provider's own native install rather than a
+   * package-manager one. `matches` is given the normalized (lowercased,
+   * forward-slash) binary path.
+   */
+  readonly nativeUpdate: {
+    readonly command: string;
+    readonly matches: (normalizedPath: string) => boolean;
+  } | null;
 }
 
 const PROBES: ReadonlyArray<ProviderProbe> = [
@@ -52,6 +64,13 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     minVersion: null,
     upgradeCommand: null,
     npmPackage: "@anthropic-ai/claude-code",
+    homebrewFormula: "claude-code",
+    // Native installer drops the binary in `~/.local/bin/claude` and ships a
+    // `claude update` self-updater. npm can't touch that install.
+    nativeUpdate: {
+      command: "claude update",
+      matches: (p) => p.endsWith("/.local/bin/claude"),
+    },
   },
   {
     providerId: "codex",
@@ -60,6 +79,8 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     minVersion: { major: 0, minor: 128, patch: 0, raw: "0.128.0" },
     upgradeCommand: "npm i -g @openai/codex@latest",
     npmPackage: "@openai/codex",
+    homebrewFormula: "codex",
+    nativeUpdate: null,
   },
   {
     providerId: "grok",
@@ -71,7 +92,10 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     minVersion: null,
     upgradeCommand: "curl -fsSL https://x.ai/cli/install.sh | bash",
     // xAI ships Grok via a curl installer, not npm — no registry to poll.
+    // The installer reinstalls the latest build, so it doubles as the updater.
     npmPackage: null,
+    homebrewFormula: null,
+    nativeUpdate: null,
   },
   {
     providerId: "gemini",
@@ -83,6 +107,8 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     minVersion: null,
     upgradeCommand: "npm i -g @google/gemini-cli",
     npmPackage: "@google/gemini-cli",
+    homebrewFormula: "gemini-cli",
+    nativeUpdate: null,
   },
   {
     providerId: "cursor",
@@ -94,8 +120,11 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     // ACP-introducing version.
     minVersion: null,
     upgradeCommand: "curl https://cursor.com/install -fsS | bash",
-    // cursor-agent ships via a curl installer, not npm.
+    // cursor-agent ships via a curl installer, not npm. Its install script
+    // reinstalls the latest build, so it doubles as the updater.
     npmPackage: null,
+    homebrewFormula: null,
+    nativeUpdate: null,
   },
   {
     providerId: "opencode",
@@ -108,6 +137,13 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     minVersion: { major: 1, minor: 3, patch: 15, raw: "1.3.15" },
     upgradeCommand: "curl -fsSL https://opencode.ai/install | bash",
     npmPackage: "opencode-ai",
+    homebrewFormula: "anomalyco/tap/opencode",
+    // Native installer drops the binary in `~/.opencode/bin/opencode` and
+    // ships an `opencode upgrade` self-updater.
+    nativeUpdate: {
+      command: "opencode upgrade",
+      matches: (p) => p.endsWith("/.opencode/bin/opencode"),
+    },
   },
 ];
 
@@ -296,32 +332,117 @@ export const deriveLatestAdvisory = (
   return compareCliVersion(installed, latest) < 0 ? "behind" : "current";
 };
 
+// ---------------------------------------------------------------------------
+// Install-method detection. The right update command depends on HOW the
+// on-PATH binary was installed — a native install (`~/.local/bin/claude`)
+// can't be updated by npm, a brew install needs `brew upgrade`, etc. We
+// inspect the resolved binary path (and its realpath, since global bins are
+// symlinks into `…/lib/node_modules/…`) the same way the t3 reference does.
+// ---------------------------------------------------------------------------
+
+const normalizeCommandPath = (p: string): string =>
+  p.replaceAll("\\", "/").toLowerCase();
+
+const isBunGlobalPath = (p: string): boolean => p.includes("/.bun/bin/");
+
+const isPnpmGlobalPath = (p: string): boolean =>
+  p.includes("/.local/share/pnpm/") ||
+  p.includes("/library/pnpm/") ||
+  p.includes("/pnpm/global/");
+
+const isNpmGlobalPath = (p: string): boolean =>
+  p.includes("/lib/node_modules/") ||
+  p.includes("/node_modules/.bin/") ||
+  p.includes("/npm/node_modules/");
+
+const isHomebrewPath = (p: string): boolean =>
+  p.includes("/cellar/") ||
+  p.includes("/caskroom/") ||
+  p.startsWith("/opt/homebrew/bin/") ||
+  p.startsWith("/usr/local/bin/");
+
+// A plain `npm i -g <pkg>@latest` re-install fails with ENOTEMPTY during npm's
+// "retire old dir" rename step when a prior install left files behind (common
+// with packages shipping optional per-platform binaries, e.g.
+// @anthropic-ai/claude-code). Uninstall first so install lays down a clean
+// tree; `|| true` keeps a not-installed case from aborting the chain.
+const npmGlobalUpdate = (pkg: string): string =>
+  `npm uninstall -g ${pkg} || true; npm install -g ${pkg}@latest`;
+
 /**
- * The shell command that updates a provider's CLI to the latest release.
- *
- * npm-published providers uninstall-then-install rather than a bare
- * `npm i -g <pkg>@latest`: a plain re-install fails with `ENOTEMPTY` during
- * npm's "retire old dir" rename step when a prior install left files behind
- * (common with packages shipping optional per-platform binaries, e.g.
- * `@anthropic-ai/claude-code`). `uninstall -g` clears the dir first, then the
- * install lays down a clean tree. `|| true` on the uninstall keeps a
- * not-currently-installed case from aborting the chain.
- *
- * Non-npm providers reuse their official install one-liner (curl scripts
- * reinstall the latest build). Returns `null` for an unknown provider. Run
- * server-side via a login shell so PATH + pipes resolve — see
- * `update-service.ts`.
+ * Pure resolver: pick the update command for a provider given the candidate
+ * binary paths (the `which` result plus its realpath). Detection order mirrors
+ * the t3 reference: native self-update → bun → pnpm → npm → homebrew. Falls
+ * back to the provider's install one-liner (curl installers reinstall latest),
+ * else `null`.
  */
-export const updateCommandForProvider = (
+export const buildUpdateCommand = (
   providerId: ProviderId,
+  candidatePaths: ReadonlyArray<string>,
 ): string | null => {
   const probe = PROBES.find((p) => p.providerId === providerId);
   if (probe === undefined) return null;
-  if (probe.npmPackage !== null) {
-    return `npm uninstall -g ${probe.npmPackage} || true; npm install -g ${probe.npmPackage}@latest`;
+
+  const norms = candidatePaths
+    .filter((p) => p.length > 0)
+    .map(normalizeCommandPath);
+
+  if (
+    probe.nativeUpdate !== null &&
+    norms.some((p) => probe.nativeUpdate!.matches(p))
+  ) {
+    return probe.nativeUpdate.command;
   }
+
+  if (probe.npmPackage !== null) {
+    if (norms.some(isBunGlobalPath)) {
+      return `bun i -g ${probe.npmPackage}@latest`;
+    }
+    if (norms.some(isPnpmGlobalPath)) {
+      return `pnpm add -g ${probe.npmPackage}@latest`;
+    }
+    if (norms.some(isNpmGlobalPath)) {
+      return npmGlobalUpdate(probe.npmPackage);
+    }
+    if (probe.homebrewFormula !== null && norms.some(isHomebrewPath)) {
+      return `brew upgrade ${probe.homebrewFormula}`;
+    }
+    // Path didn't reveal the manager (or no path at all): default to npm,
+    // which is how these packages are most commonly installed.
+    return npmGlobalUpdate(probe.npmPackage);
+  }
+
+  // Non-npm providers (Grok, Cursor): reinstall via the official one-liner.
   return probe.upgradeCommand;
 };
+
+/**
+ * Resolve the update command for a provider by locating its binary and its
+ * realpath, then delegating to {@link buildUpdateCommand}. Run server-side via
+ * a login shell so PATH + pipes resolve — see `update-service.ts`.
+ */
+export const resolveUpdateCommand = (
+  providerId: ProviderId,
+): Effect.Effect<
+  string | null,
+  never,
+  CommandExecutor.CommandExecutor | FileSystem.FileSystem
+> =>
+  Effect.gen(function* () {
+    const probe = PROBES.find((p) => p.providerId === providerId);
+    if (probe === undefined) return null;
+    const cliPath = yield* resolveCliPath(probe.cliBinary);
+    if (cliPath === null) {
+      // Not on PATH — fall back to a path-less resolution (npm default /
+      // install one-liner) so the command still does something sensible.
+      return buildUpdateCommand(providerId, []);
+    }
+    const fs = yield* FileSystem.FileSystem;
+    const realPath = yield* fs
+      .realPath(cliPath)
+      .pipe(Effect.catchAll(() => Effect.succeed(cliPath)));
+    return buildUpdateCommand(providerId, [cliPath, realPath]);
+  });
 
 // ---------------------------------------------------------------------------
 // Verified-auth probes per provider.
@@ -997,11 +1118,16 @@ const probeOne = (
       cliVersion,
       latestVersionRaw,
     );
-    // Set for every provider that has an install one-liner (incl. curl-based
-    // CLIs like Grok/Cursor) so the renderer can offer one-click update even
-    // when we can't detect the latest version from a registry.
+    // Install-method-aware update command (native / brew / bun / pnpm / npm /
+    // curl). Resolve the binary's realpath too, since global bins are symlinks
+    // into `…/lib/node_modules/…`. Set for every provider that has any update
+    // path so the renderer can offer one-click update.
+    const fs = yield* FileSystem.FileSystem;
+    const realPath = yield* fs
+      .realPath(cliPath)
+      .pipe(Effect.catchAll(() => Effect.succeed(cliPath)));
     const updateCommand =
-      updateCommandForProvider(probe.providerId) ?? undefined;
+      buildUpdateCommand(probe.providerId, [cliPath, realPath]) ?? undefined;
 
     const account = yield* probeAccount(probe.providerId, cliPath);
     const cliLoggedIn = account.authStatus === "authenticated";

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -298,17 +298,28 @@ export const deriveLatestAdvisory = (
 
 /**
  * The shell command that updates a provider's CLI to the latest release.
- * npm-published providers get a deterministic `npm i -g <pkg>@latest`; the
- * rest reuse their official install one-liner (curl scripts reinstall the
- * latest build). Returns `null` for an unknown provider. Run server-side via
- * a login shell so PATH + pipes resolve — see `update-service.ts`.
+ *
+ * npm-published providers uninstall-then-install rather than a bare
+ * `npm i -g <pkg>@latest`: a plain re-install fails with `ENOTEMPTY` during
+ * npm's "retire old dir" rename step when a prior install left files behind
+ * (common with packages shipping optional per-platform binaries, e.g.
+ * `@anthropic-ai/claude-code`). `uninstall -g` clears the dir first, then the
+ * install lays down a clean tree. `|| true` on the uninstall keeps a
+ * not-currently-installed case from aborting the chain.
+ *
+ * Non-npm providers reuse their official install one-liner (curl scripts
+ * reinstall the latest build). Returns `null` for an unknown provider. Run
+ * server-side via a login shell so PATH + pipes resolve — see
+ * `update-service.ts`.
  */
 export const updateCommandForProvider = (
   providerId: ProviderId,
 ): string | null => {
   const probe = PROBES.find((p) => p.providerId === providerId);
   if (probe === undefined) return null;
-  if (probe.npmPackage !== null) return `npm i -g ${probe.npmPackage}@latest`;
+  if (probe.npmPackage !== null) {
+    return `npm uninstall -g ${probe.npmPackage} || true; npm install -g ${probe.npmPackage}@latest`;
+  }
   return probe.upgradeCommand;
 };
 

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -296,6 +296,22 @@ export const deriveLatestAdvisory = (
   return compareCliVersion(installed, latest) < 0 ? "behind" : "current";
 };
 
+/**
+ * The shell command that updates a provider's CLI to the latest release.
+ * npm-published providers get a deterministic `npm i -g <pkg>@latest`; the
+ * rest reuse their official install one-liner (curl scripts reinstall the
+ * latest build). Returns `null` for an unknown provider. Run server-side via
+ * a login shell so PATH + pipes resolve — see `update-service.ts`.
+ */
+export const updateCommandForProvider = (
+  providerId: ProviderId,
+): string | null => {
+  const probe = PROBES.find((p) => p.providerId === providerId);
+  if (probe === undefined) return null;
+  if (probe.npmPackage !== null) return `npm i -g ${probe.npmPackage}@latest`;
+  return probe.upgradeCommand;
+};
+
 // ---------------------------------------------------------------------------
 // Verified-auth probes per provider.
 //
@@ -970,10 +986,11 @@ const probeOne = (
       cliVersion,
       latestVersionRaw,
     );
+    // Set for every provider that has an install one-liner (incl. curl-based
+    // CLIs like Grok/Cursor) so the renderer can offer one-click update even
+    // when we can't detect the latest version from a registry.
     const updateCommand =
-      probe.npmPackage !== null
-        ? `npm i -g ${probe.npmPackage}@latest`
-        : undefined;
+      updateCommandForProvider(probe.providerId) ?? undefined;
 
     const account = yield* probeAccount(probe.providerId, cliPath);
     const cliLoggedIn = account.authStatus === "authenticated";

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -80,6 +80,10 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     upgradeCommand: "npm i -g @openai/codex@latest",
     npmPackage: "@openai/codex",
     homebrewFormula: "codex",
+    // Conductor can place a standalone Codex binary on PATH under
+    // `Application Support/.../agent-binaries/codex/<version>/codex`; npm
+    // cannot update that install. `buildUpdateCommand` special-cases this
+    // path so the updater runs the exact binary the app probed.
     nativeUpdate: null,
   },
   {
@@ -166,6 +170,31 @@ const runCapture = (cmd: Command.Command) =>
     return { stdout: stdout.trim(), exitCode };
   }).pipe(Effect.scoped);
 
+const splitCommandPaths = (stdout: string): ReadonlyArray<string> =>
+  stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+export const selectCliPathCandidate = (
+  cliBinary: string,
+  candidates: ReadonlyArray<string>,
+): string | null => {
+  if (candidates.length === 0) return null;
+  if (cliBinary !== "codex") return candidates[0]!;
+
+  // Conductor can prepend its own standalone Codex binary to PATH for app
+  // internals. Provider settings should report the user's real Codex install
+  // when one exists later on PATH, matching what t3code does by resolving the
+  // provider binary before deriving version/update capabilities.
+  return (
+    candidates.find(
+      (candidate) =>
+        !isConductorManagedCodexPath(normalizeCommandPath(candidate)),
+    ) ?? candidates[0]!
+  );
+};
+
 /**
  * Resolve the absolute path to a provider's CLI binary on PATH, or `null` if
  * not found. Used by `ProviderService.start` to feed the SDK's
@@ -176,13 +205,12 @@ export const resolveCliPath = (
   cliBinary: string,
 ): Effect.Effect<string | null, never, CommandExecutor.CommandExecutor> =>
   Effect.gen(function* () {
-    const result = yield* runCapture(Command.make("which", cliBinary)).pipe(
+    const result = yield* runCapture(Command.make("which", "-a", cliBinary)).pipe(
       Effect.timeoutOption(PROBE_TIMEOUT),
       Effect.catchAll(() => Effect.succeedNone),
     );
     if (result._tag !== "Some" || result.value.exitCode !== 0) return null;
-    const path = result.value.stdout;
-    return path.length > 0 ? path : null;
+    return selectCliPathCandidate(cliBinary, splitCommandPaths(result.value.stdout));
   });
 
 export interface CliVersion {
@@ -341,7 +369,10 @@ export const deriveLatestAdvisory = (
 // ---------------------------------------------------------------------------
 
 const normalizeCommandPath = (p: string): string =>
-  p.replaceAll("\\", "/").toLowerCase();
+  p.replaceAll("\\", "/").replaceAll("/./", "/").toLowerCase();
+
+const shellQuote = (value: string): string =>
+  `'${value.replaceAll("'", `'\\''`)}'`;
 
 const isBunGlobalPath = (p: string): boolean => p.includes("/.bun/bin/");
 
@@ -360,6 +391,11 @@ const isHomebrewPath = (p: string): boolean =>
   p.includes("/caskroom/") ||
   p.startsWith("/opt/homebrew/bin/") ||
   p.startsWith("/usr/local/bin/");
+
+const isConductorManagedCodexPath = (p: string): boolean =>
+  p.endsWith("/application support/com.conductor.app/bin/codex") ||
+  (p.includes("/application support/com.conductor.app/agent-binaries/codex/") &&
+    p.endsWith("/codex"));
 
 // A plain `npm i -g <pkg>@latest` re-install fails with ENOTEMPTY during npm's
 // "retire old dir" rename step when a prior install left files behind (common
@@ -387,6 +423,13 @@ export const buildUpdateCommand = (
     .filter((p) => p.length > 0)
     .map(normalizeCommandPath);
 
+  const conductorManagedCodexPath = candidatePaths.find((p) =>
+    isConductorManagedCodexPath(normalizeCommandPath(p)),
+  );
+  if (providerId === "codex" && conductorManagedCodexPath !== undefined) {
+    return `${shellQuote(conductorManagedCodexPath)} update`;
+  }
+
   if (
     probe.nativeUpdate !== null &&
     norms.some((p) => probe.nativeUpdate!.matches(p))
@@ -407,8 +450,12 @@ export const buildUpdateCommand = (
     if (probe.homebrewFormula !== null && norms.some(isHomebrewPath)) {
       return `brew upgrade ${probe.homebrewFormula}`;
     }
-    // Path didn't reveal the manager (or no path at all): default to npm,
-    // which is how these packages are most commonly installed.
+    if (candidatePaths.some((p) => p.includes("/") || p.includes("\\"))) {
+      return null;
+    }
+    // No path available: default to npm, which is how these packages are most
+    // commonly installed. Unknown absolute paths stay manual-only so we don't
+    // update a different install than the one being probed.
     return npmGlobalUpdate(probe.npmPackage);
   }
 
@@ -1051,19 +1098,9 @@ const probeOne = (
 > =>
   Effect.gen(function* () {
     const lastCheckedAt = new Date();
-    const whichResult = yield* runCapture(
-      Command.make("which", probe.cliBinary),
-    ).pipe(
-      Effect.timeoutOption(PROBE_TIMEOUT),
-      Effect.catchAll(() => Effect.succeedNone),
-    );
+    const cliPath = yield* resolveCliPath(probe.cliBinary);
 
-    const cliPath =
-      whichResult._tag === "Some" && whichResult.value.exitCode === 0
-        ? whichResult.value.stdout
-        : undefined;
-
-    if (cliPath === undefined || cliPath.length === 0) {
+    if (cliPath === null || cliPath.length === 0) {
       return AgentAvailability.make({
         providerId: probe.providerId,
         displayName: probe.displayName,
@@ -1077,7 +1114,7 @@ const probeOne = (
     }
 
     const versionResult = yield* runCapture(
-      Command.make(probe.cliBinary, "--version"),
+      Command.make(cliPath, "--version"),
     ).pipe(
       Effect.timeoutOption(PROBE_TIMEOUT),
       Effect.catchAll(() => Effect.succeedNone),

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   AgentAvailability,
   type CliVersionStatus,
+  type LatestVersionStatus,
   type ProviderAuthStatus,
   type ProviderHealthStatus,
   type ProviderId,
@@ -31,6 +32,13 @@ interface ProviderProbe {
    * because npm vs brew vs cargo channels differ.
    */
   readonly upgradeCommand: string | null;
+  /**
+   * npm package name used to resolve the *latest published* version (for the
+   * informational "update available" layer). `null` for providers installed
+   * outside npm (curl scripts) — those report `latestVersionStatus: "unknown"`
+   * and surface no update affordance.
+   */
+  readonly npmPackage: string | null;
 }
 
 const PROBES: ReadonlyArray<ProviderProbe> = [
@@ -43,6 +51,7 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     // mode we can pin to a version.
     minVersion: null,
     upgradeCommand: null,
+    npmPackage: "@anthropic-ai/claude-code",
   },
   {
     providerId: "codex",
@@ -50,6 +59,7 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     cliBinary: "codex",
     minVersion: { major: 0, minor: 128, patch: 0, raw: "0.128.0" },
     upgradeCommand: "npm i -g @openai/codex@latest",
+    npmPackage: "@openai/codex",
   },
   {
     providerId: "grok",
@@ -60,6 +70,8 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     // Revisit if a future release breaks the streaming-json contract.
     minVersion: null,
     upgradeCommand: "curl -fsSL https://x.ai/cli/install.sh | bash",
+    // xAI ships Grok via a curl installer, not npm — no registry to poll.
+    npmPackage: null,
   },
   {
     providerId: "gemini",
@@ -70,6 +82,7 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     // flag or breaks the handshake.
     minVersion: null,
     upgradeCommand: "npm i -g @google/gemini-cli",
+    npmPackage: "@google/gemini-cli",
   },
   {
     providerId: "cursor",
@@ -81,6 +94,8 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     // ACP-introducing version.
     minVersion: null,
     upgradeCommand: "curl https://cursor.com/install -fsS | bash",
+    // cursor-agent ships via a curl installer, not npm.
+    npmPackage: null,
   },
   {
     providerId: "opencode",
@@ -92,6 +107,7 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     // so we surface the upgrade card before the user hits that.
     minVersion: { major: 1, minor: 3, patch: 15, raw: "1.3.15" },
     upgradeCommand: "curl -fsSL https://opencode.ai/install | bash",
+    npmPackage: "opencode-ai",
   },
 ];
 
@@ -182,15 +198,103 @@ export const probeCliVersion = (
   cliBinary: string,
 ): Effect.Effect<CliVersion | null, never, CommandExecutor.CommandExecutor> =>
   Effect.gen(function* () {
-    const result = yield* runCapture(
-      Command.make(cliBinary, "--version"),
-    ).pipe(
+    const result = yield* runCapture(Command.make(cliBinary, "--version")).pipe(
       Effect.timeoutOption(PROBE_TIMEOUT),
       Effect.catchAll(() => Effect.succeedNone),
     );
     if (result._tag !== "Some" || result.value.exitCode !== 0) return null;
     return parseCliVersion(result.value.stdout);
   });
+
+// ---------------------------------------------------------------------------
+// Latest-version advisory (informational "update available" layer).
+//
+// Separate from the SDK floor above: this polls the npm registry for the
+// latest *published* release and compares it to what's installed. Everything
+// here is failure-tolerant — any miss collapses to `"unknown"` so a flaky
+// network never blocks (or even surfaces in) availability.
+// ---------------------------------------------------------------------------
+
+// In-memory cache so we hit the registry at most once per package per hour.
+// `probeAllProviders` runs on every settings open + window focus; without this
+// every focus would fan out a burst of registry calls.
+const LATEST_VERSION_CACHE_TTL_MS = 60 * 60 * 1_000;
+const latestVersionCache = new Map<
+  string,
+  { readonly version: string | null; readonly expiresAt: number }
+>();
+
+interface NpmLatestResponse {
+  readonly version?: unknown;
+}
+
+/**
+ * Resolve the latest published version of an npm package via the registry's
+ * lightweight `/<pkg>/latest` endpoint. Returns `null` on any failure
+ * (offline, non-2xx, malformed JSON, timeout) so callers treat it as
+ * "unknown" rather than erroring.
+ */
+const fetchNpmLatestVersion = (
+  packageName: string,
+): Effect.Effect<string | null> =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const res = await fetch(
+        `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`,
+        { headers: { accept: "application/json" }, signal },
+      );
+      if (!res.ok) return null;
+      const body = (await res.json()) as NpmLatestResponse;
+      const version =
+        typeof body.version === "string" && body.version.trim().length > 0
+          ? body.version.trim()
+          : null;
+      return version;
+    },
+    catch: () => null,
+  }).pipe(
+    Effect.timeoutOption(PROBE_TIMEOUT),
+    Effect.map((opt) => (opt._tag === "Some" ? opt.value : null)),
+    Effect.catchAll(() => Effect.succeed(null)),
+  );
+
+/**
+ * Cached wrapper around {@link fetchNpmLatestVersion}. Returns `null` for
+ * providers with no npm package (curl-installed CLIs we don't version-check).
+ */
+const resolveLatestVersion = (
+  probe: ProviderProbe,
+): Effect.Effect<string | null> =>
+  Effect.gen(function* () {
+    if (probe.npmPackage === null) return null;
+    const now = Date.now();
+    const cached = latestVersionCache.get(probe.npmPackage);
+    if (cached !== undefined && cached.expiresAt > now) {
+      return cached.version;
+    }
+    const version = yield* fetchNpmLatestVersion(probe.npmPackage);
+    latestVersionCache.set(probe.npmPackage, {
+      version,
+      expiresAt: now + LATEST_VERSION_CACHE_TTL_MS,
+    });
+    return version;
+  });
+
+/**
+ * Compare the installed CLI version string against the latest published
+ * version. Reuses the SDK-floor parser/comparator so the semantics match.
+ * `"unknown"` whenever either side is missing or unparsable.
+ */
+export const deriveLatestAdvisory = (
+  cliVersion: string | undefined,
+  latestVersion: string | null,
+): LatestVersionStatus => {
+  if (cliVersion === undefined || latestVersion === null) return "unknown";
+  const installed = parseCliVersion(cliVersion);
+  const latest = parseCliVersion(latestVersion);
+  if (installed === null || latest === null) return "unknown";
+  return compareCliVersion(installed, latest) < 0 ? "behind" : "current";
+};
 
 // ---------------------------------------------------------------------------
 // Verified-auth probes per provider.
@@ -435,7 +539,13 @@ const extractTier = (claims: unknown): number | null => {
   if (!claims || typeof claims !== "object") return null;
   const obj = claims as Record<string, unknown>;
 
-  const directCandidates = ["tier", "xai_tier", "plan_tier", "subscription_tier", "agent_tier"];
+  const directCandidates = [
+    "tier",
+    "xai_tier",
+    "plan_tier",
+    "subscription_tier",
+    "agent_tier",
+  ];
   for (const k of directCandidates) {
     const v = obj[k];
     if (typeof v === "number") return v;
@@ -493,11 +603,7 @@ const parseGrokAuthJson = (raw: string): AccountInfo => {
 
     // Try every plausible token field the CLI might use now or in the future
     const token =
-      entry.key ||
-      entry.access_token ||
-      entry.token ||
-      entry.jwt ||
-      null;
+      entry.key || entry.access_token || entry.token || entry.jwt || null;
 
     let authLabel = "Grok";
     let tierFound: number | null = null;
@@ -520,7 +626,9 @@ const parseGrokAuthJson = (raw: string): AccountInfo => {
       // else: we have a token but no usable tier claim → non-blocking "Grok"
       // (runtime ACP still does the real entitlement check)
     } else if (GROK_DEBUG) {
-      process.stderr.write(`[grok.probe] entry present but no token field found\n`);
+      process.stderr.write(
+        `[grok.probe] entry present but no token field found\n`,
+      );
     }
 
     return {
@@ -562,54 +670,60 @@ export const grokAuthTestHelpers = {
 // This change (from always-requires on parse failure) stops paying SuperGrok
 // Heavy users from being incorrectly locked out by our heuristic when the
 // auth.json shape or claim location differs from what we first shipped.
-const probeGrokAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSystem> =
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const dir = join(homedir(), ".grok");
-    const authPath = join(dir, "auth.json");
+const probeGrokAccount: Effect.Effect<
+  AccountInfo,
+  never,
+  FileSystem.FileSystem
+> = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const dir = join(homedir(), ".grok");
+  const authPath = join(dir, "auth.json");
 
-    const authExists = yield* fs
-      .exists(authPath)
-      .pipe(Effect.catchAll(() => Effect.succeed(false)));
+  const authExists = yield* fs
+    .exists(authPath)
+    .pipe(Effect.catchAll(() => Effect.succeed(false)));
 
-    if (authExists) {
-      const raw = yield* fs
-        .readFileString(authPath)
-        .pipe(Effect.catchAll(() => Effect.succeed("")));
-      if (raw.length > 0) {
-        return parseGrokAuthJson(raw);
-      }
+  if (authExists) {
+    const raw = yield* fs
+      .readFileString(authPath)
+      .pipe(Effect.catchAll(() => Effect.succeed("")));
+    if (raw.length > 0) {
+      return parseGrokAuthJson(raw);
     }
+  }
 
-    // No auth.json at all → unauthenticated (user has never run `grok login`)
-    const dirExists = yield* fs
-      .exists(dir)
-      .pipe(Effect.catchAll(() => Effect.succeed(false)));
-    return dirExists
-      ? ({
-          authStatus: "authenticated",
-          authType: "cli",
-          authLabel: "Grok",
-        } satisfies AccountInfo)
-      : ({ authStatus: "unauthenticated" } satisfies AccountInfo);
-  });
+  // No auth.json at all → unauthenticated (user has never run `grok login`)
+  const dirExists = yield* fs
+    .exists(dir)
+    .pipe(Effect.catchAll(() => Effect.succeed(false)));
+  return dirExists
+    ? ({
+        authStatus: "authenticated",
+        authType: "cli",
+        authLabel: "Grok",
+      } satisfies AccountInfo)
+    : ({ authStatus: "unauthenticated" } satisfies AccountInfo);
+});
 
 // Gemini CLI writes OAuth tokens + settings under `~/.gemini/` after the
 // first interactive sign-in. Same file-existence heuristic as Grok — we
 // don't yet have a verified-auth call we can make to the gemini CLI to
 // extract email/plan, so the card stays at "Authenticated" without the
 // subscription label.
-const probeGeminiAccount: Effect.Effect<AccountInfo, never, FileSystem.FileSystem> =
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = join(homedir(), ".gemini");
-    const exists = yield* fs
-      .exists(path)
-      .pipe(Effect.catchAll(() => Effect.succeed(false)));
-    return exists
-      ? ({ authStatus: "authenticated", authType: "cli" } satisfies AccountInfo)
-      : ({ authStatus: "unauthenticated" } satisfies AccountInfo);
-  });
+const probeGeminiAccount: Effect.Effect<
+  AccountInfo,
+  never,
+  FileSystem.FileSystem
+> = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = join(homedir(), ".gemini");
+  const exists = yield* fs
+    .exists(path)
+    .pipe(Effect.catchAll(() => Effect.succeed(false)));
+  return exists
+    ? ({ authStatus: "authenticated", authType: "cli" } satisfies AccountInfo)
+    : ({ authStatus: "unauthenticated" } satisfies AccountInfo);
+});
 
 // Strip ANSI escape sequences (cursor-positioning, colors, etc). The
 // cursor-agent CLI emits a TUI-style status frame before its final answer,
@@ -677,7 +791,9 @@ const probeCursorAccount: Effect.Effect<
   }
   // Exit code is not a reliable signal — the CLI returns 0 even when not
   // logged in. Parse the text instead.
-  return parseCursorStatusOutput(`${result.value.stdout}\n${result.value.stderr}`);
+  return parseCursorStatusOutput(
+    `${result.value.stdout}\n${result.value.stderr}`,
+  );
 });
 
 // OpenCode stores per-provider credentials in `~/.local/share/opencode/auth.json`
@@ -721,13 +837,7 @@ const probeOpencodeAccount: Effect.Effect<
   FileSystem.FileSystem
 > = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
-  const authPath = join(
-    homedir(),
-    ".local",
-    "share",
-    "opencode",
-    "auth.json",
-  );
+  const authPath = join(homedir(), ".local", "share", "opencode", "auth.json");
   const exists = yield* fs
     .exists(authPath)
     .pipe(Effect.catchAll(() => Effect.succeed(false)));
@@ -793,7 +903,9 @@ const probeOne = (
 > =>
   Effect.gen(function* () {
     const lastCheckedAt = new Date();
-    const whichResult = yield* runCapture(Command.make("which", probe.cliBinary)).pipe(
+    const whichResult = yield* runCapture(
+      Command.make("which", probe.cliBinary),
+    ).pipe(
       Effect.timeoutOption(PROBE_TIMEOUT),
       Effect.catchAll(() => Effect.succeedNone),
     );
@@ -849,6 +961,20 @@ const probeOne = (
       }
     }
 
+    // Informational "update available" layer — independent of the SDK floor.
+    // Only providers with a registry package are checked; the rest report
+    // `"unknown"` and surface no update affordance.
+    const latestVersionRaw = yield* resolveLatestVersion(probe);
+    const latestVersion = latestVersionRaw ?? undefined;
+    const latestVersionStatus = deriveLatestAdvisory(
+      cliVersion,
+      latestVersionRaw,
+    );
+    const updateCommand =
+      probe.npmPackage !== null
+        ? `npm i -g ${probe.npmPackage}@latest`
+        : undefined;
+
     const account = yield* probeAccount(probe.providerId, cliPath);
     const cliLoggedIn = account.authStatus === "authenticated";
 
@@ -877,6 +1003,9 @@ const probeOne = (
       cliVersionStatus,
       cliVersionMinRequired,
       cliUpgradeCommand,
+      latestVersion,
+      latestVersionStatus,
+      updateCommand,
       authStatus: account.authStatus,
       authEmail: account.authEmail,
       authLabel: account.authLabel,

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -7,7 +7,7 @@ import {
 import { CommandExecutor } from "@effect/platform";
 import { Effect, Layer, Stream } from "effect";
 
-import { resolveCliPath } from "./availability.ts";
+import { resolveCliPath, resolveUpdateCommand } from "./availability.ts";
 import { loadOpencodeInventory } from "./drivers/opencode.ts";
 import { startProviderLogin } from "./services/login-service.ts";
 import { startProviderUpdate } from "./services/update-service.ts";
@@ -83,7 +83,12 @@ const StartLogin = MemoizeRpcs.toLayerHandler(
 // availability so the new version shows immediately.
 const UpdateProvider = MemoizeRpcs.toLayerHandler(
   "agent.updateProvider",
-  ({ providerId }) => startProviderUpdate(providerId),
+  ({ providerId }) =>
+    Stream.unwrap(
+      resolveUpdateCommand(providerId).pipe(
+        Effect.map((command) => startProviderUpdate(providerId, command)),
+      ),
+    ),
 );
 
 // Renderer calls this on first open of the opencode model picker to refresh

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -10,6 +10,7 @@ import { Effect, Layer, Stream } from "effect";
 import { resolveCliPath } from "./availability.ts";
 import { loadOpencodeInventory } from "./drivers/opencode.ts";
 import { startProviderLogin } from "./services/login-service.ts";
+import { startProviderUpdate } from "./services/update-service.ts";
 import { MessageStore } from "./services/message-store.ts";
 import { PermissionService } from "./services/permission-service.ts";
 import { ProviderService } from "./services/provider-service.ts";
@@ -62,9 +63,7 @@ const Close = MemoizeRpcs.toLayerHandler("agent.close", ({ sessionId }) =>
 );
 
 const Events = MemoizeRpcs.toLayerHandler("agent.events", ({ sessionId }) =>
-  Stream.unwrap(
-    Effect.map(ProviderService, (svc) => svc.events(sessionId)),
-  ),
+  Stream.unwrap(Effect.map(ProviderService, (svc) => svc.events(sessionId))),
 );
 
 // Renderer subscribes to this when the user clicks the "Sign in" button on a
@@ -76,6 +75,15 @@ const Events = MemoizeRpcs.toLayerHandler("agent.events", ({ sessionId }) =>
 const StartLogin = MemoizeRpcs.toLayerHandler(
   "agent.startLogin",
   ({ providerId }) => startProviderLogin(providerId),
+);
+
+// Renderer subscribes to this when the user clicks "Update" on a provider
+// card. Spawns the provider's install/upgrade command in a login shell,
+// streams output, and ends with `done`. On success the renderer re-probes
+// availability so the new version shows immediately.
+const UpdateProvider = MemoizeRpcs.toLayerHandler(
+  "agent.updateProvider",
+  ({ providerId }) => startProviderUpdate(providerId),
 );
 
 // Renderer calls this on first open of the opencode model picker to refresh
@@ -115,10 +123,8 @@ const SessionList = MemoizeRpcs.toLayerHandler(
     ),
 );
 
-const SessionGet = MemoizeRpcs.toLayerHandler(
-  "session.get",
-  ({ sessionId }) =>
-    Effect.flatMap(MessageStore, (svc) => svc.getSession(sessionId)),
+const SessionGet = MemoizeRpcs.toLayerHandler("session.get", ({ sessionId }) =>
+  Effect.flatMap(MessageStore, (svc) => svc.getSession(sessionId)),
 );
 
 const SessionCreate = MemoizeRpcs.toLayerHandler("session.create", (input) =>
@@ -352,8 +358,7 @@ const MessagesInterrupt = MemoizeRpcs.toLayerHandler(
 
 const PermissionRequests = MemoizeRpcs.toLayerHandler(
   "permission.requests",
-  () =>
-    Stream.unwrap(Effect.map(PermissionService, (svc) => svc.requests())),
+  () => Stream.unwrap(Effect.map(PermissionService, (svc) => svc.requests())),
 );
 
 const PermissionDecide = MemoizeRpcs.toLayerHandler(
@@ -391,6 +396,7 @@ export const ProviderHandlersLayer = Layer.mergeAll(
   Close,
   Events,
   StartLogin,
+  UpdateProvider,
   OpencodeInventory,
   SessionList,
   SessionGet,

--- a/apps/server/src/provider/services/update-service.ts
+++ b/apps/server/src/provider/services/update-service.ts
@@ -10,8 +10,6 @@ import {
   type ProviderUpdateEvent,
 } from "@memoize/wire";
 
-import { updateCommandForProvider } from "../availability.ts";
-
 const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 
 // Hard ceiling on a single update. npm global installs + curl bootstrap
@@ -34,8 +32,8 @@ const UPDATE_TIMEOUT_MS = 5 * 60_000;
  */
 export const startProviderUpdate = (
   providerId: ProviderId,
+  command: string | null,
 ): Stream.Stream<ProviderUpdateEvent, AgentSessionStartError> => {
-  const command = updateCommandForProvider(providerId);
   if (command === null) {
     const event: ProviderUpdateEvent = {
       _tag: "done",

--- a/apps/server/src/provider/services/update-service.ts
+++ b/apps/server/src/provider/services/update-service.ts
@@ -1,0 +1,161 @@
+import { Effect, Mailbox, type Scope, Stream } from "effect";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import * as readline from "node:readline";
+import { homedir } from "node:os";
+import type { Readable } from "node:stream";
+
+import {
+  AgentSessionStartError,
+  type ProviderId,
+  type ProviderUpdateEvent,
+} from "@memoize/wire";
+
+import { updateCommandForProvider } from "../availability.ts";
+
+const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+// Hard ceiling on a single update. npm global installs + curl bootstrap
+// scripts finish well inside this; the cap just stops a wedged installer from
+// streaming forever.
+const UPDATE_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * Spawn a provider's update/install command and stream its output back to the
+ * renderer, ending with a terminal `done`. The command runs in a **login
+ * shell** (`bash -lc`) for two reasons:
+ *   1. PATH — npm/bun/pnpm and the provider binary resolve the same way they
+ *      do in the user's terminal (the app may be launched from Finder).
+ *   2. Pipes — curl-based installers (Grok, Cursor) are full shell pipelines
+ *      (`curl … | bash`), which only work through a shell.
+ *
+ * Cancellation mirrors `startProviderLogin`: wrapped in `Stream.unwrapScoped`,
+ * so unsubscribing (or an IPC drop) closes the scope and the finalizer kills
+ * the child (SIGTERM → SIGKILL).
+ */
+export const startProviderUpdate = (
+  providerId: ProviderId,
+): Stream.Stream<ProviderUpdateEvent, AgentSessionStartError> => {
+  const command = updateCommandForProvider(providerId);
+  if (command === null) {
+    const event: ProviderUpdateEvent = {
+      _tag: "done",
+      ok: false,
+      reason: `No update command is available for ${providerId}.`,
+    };
+    return Stream.succeed(event);
+  }
+  return Stream.unwrapScoped(spawnUpdate(providerId, command));
+};
+
+const spawnUpdate = (
+  providerId: ProviderId,
+  command: string,
+): Effect.Effect<
+  Stream.Stream<ProviderUpdateEvent>,
+  AgentSessionStartError,
+  Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const mailbox = yield* Mailbox.make<ProviderUpdateEvent>();
+
+    // stdin closed (`ignore`) so an installer never blocks waiting on input.
+    let child: ChildProcessByStdio<null, Readable, Readable>;
+    try {
+      // `-l` (login) loads the user's profile so version managers (nvm, fnm,
+      // volta, asdf) put the right npm/binary on PATH; `-c` runs the command.
+      child = spawn("bash", ["-lc", command], {
+        cwd: homedir(),
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (cause) {
+      yield* mailbox.end;
+      return yield* Effect.fail(
+        new AgentSessionStartError({
+          providerId,
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+      );
+    }
+
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+
+    let exited = false;
+    let lastLine = "";
+
+    const handleLine = (raw: string): void => {
+      const cleaned = raw.replace(ANSI_PATTERN, "").trim();
+      if (cleaned.length === 0) return;
+      lastLine = cleaned;
+      mailbox.unsafeOffer({ _tag: "log", text: cleaned });
+    };
+
+    const rlOut = readline.createInterface({ input: child.stdout });
+    const rlErr = readline.createInterface({ input: child.stderr });
+    rlOut.on("line", handleLine);
+    rlErr.on("line", handleLine);
+
+    const finish = (ok: boolean, reason?: string): void => {
+      if (exited) return;
+      exited = true;
+      mailbox.unsafeOffer({
+        _tag: "done",
+        ok,
+        ...(reason !== undefined ? { reason } : {}),
+      });
+      void mailbox.end.pipe(Effect.runPromise);
+    };
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+      finish(false, "Update timed out after 5 minutes.");
+    }, UPDATE_TIMEOUT_MS);
+
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      const ok = code === 0;
+      const reason = ok
+        ? undefined
+        : signal !== null
+          ? `Update was terminated (${signal}).`
+          : `Update failed (exit ${code ?? "?"})${
+              lastLine.length > 0 ? `: ${lastLine}` : "."
+            }`;
+      finish(ok, reason);
+    });
+
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      finish(false, err.message);
+    });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        clearTimeout(timer);
+        rlOut.close();
+        rlErr.close();
+        if (exited) return;
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          /* ignore */
+        }
+        setTimeout(() => {
+          if (!exited) {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              /* ignore */
+            }
+          }
+        }, 1_000);
+      }),
+    );
+
+    return Mailbox.toStream(mailbox);
+  });

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -1,12 +1,7 @@
 import { Rpc } from "@effect/rpc";
 import { Schema } from "effect";
 
-import {
-  AgentItemId,
-  AgentSessionId,
-  AgentTurnId,
-  FolderId,
-} from "./ids.ts";
+import { AgentItemId, AgentSessionId, AgentTurnId, FolderId } from "./ids.ts";
 
 /**
  * Identifier for a provider implementation (driver). v1 ships claude + codex;
@@ -81,11 +76,7 @@ export const DEFAULT_RUNTIME_MODE: RuntimeMode = "approval-required";
  * switches `permissionMode` back to `default` and the existing `RuntimeMode`
  * resumes governing prompts.
  */
-export const PermissionMode = Schema.Literal(
-  "default",
-  "plan",
-  "acceptEdits",
-);
+export const PermissionMode = Schema.Literal("default", "plan", "acceptEdits");
 export type PermissionMode = typeof PermissionMode.Type;
 export const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
 
@@ -731,7 +722,10 @@ const claudeContextWindowDescriptor = (): SelectOptionDescriptor => ({
   defaultId: "1m",
 });
 
-export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> = {
+export const MODELS_BY_PROVIDER: Record<
+  ProviderId,
+  ReadonlyArray<ModelOption>
+> = {
   // Claude 4.x catalog (May 2026). Effort tiers and per-model knobs match
   // the published Claude Agent SDK contract — see also the t3code reference
   // (`/Users/whizzy/Developer/temp/t3code/.../ClaudeProvider.ts`) which
@@ -1002,7 +996,10 @@ export const findModelDescriptor = (
  * persisted user settings and incoming requests through this map so existing
  * sessions don't crash.
  */
-export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string>> = {
+export const MODEL_ALIASES_BY_PROVIDER: Record<
+  ProviderId,
+  Record<string, string>
+> = {
   // Short / vendor-formatted slugs and pre-pricing-reset names route to the
   // canonical 4.x slugs above. Mirror of t3code's
   // `MODEL_SLUG_ALIASES_BY_PROVIDER[CLAUDE_DRIVER_KIND]` so a user typing
@@ -1060,13 +1057,15 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string
     "gpt-5.4-high": "gpt-5.4",
     "gpt-5.4-high-fast": "gpt-5.4",
     "gpt-5.3-codex-fast": "gpt-5.3-codex",
-    "auto": "default",
+    auto: "default",
   },
   opencode: {},
 };
 
-export const resolveModelSlug = (providerId: ProviderId, slug: string): string =>
-  MODEL_ALIASES_BY_PROVIDER[providerId][slug] ?? slug;
+export const resolveModelSlug = (
+  providerId: ProviderId,
+  slug: string,
+): string => MODEL_ALIASES_BY_PROVIDER[providerId][slug] ?? slug;
 
 /**
  * Per-million-token USD pricing used by the renderer to compute the
@@ -1087,11 +1086,36 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   // to $10 in / $50 out for ~2.5x throughput; we don't encode that here,
   // the renderer's cost footer applies the multiplier when the session
   // flips the boolean. 1M context window: no per-token premium.
-  "claude-opus-4-8": { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
-  "claude-opus-4-7": { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
-  "claude-opus-4-6": { input: 5, output: 25, cacheRead: 0.5, cacheCreate: 6.25 },
-  "claude-sonnet-4-6": { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
-  "claude-haiku-4-5": { input: 1, output: 5, cacheRead: 0.1, cacheCreate: 1.25 },
+  "claude-opus-4-8": {
+    input: 5,
+    output: 25,
+    cacheRead: 0.5,
+    cacheCreate: 6.25,
+  },
+  "claude-opus-4-7": {
+    input: 5,
+    output: 25,
+    cacheRead: 0.5,
+    cacheCreate: 6.25,
+  },
+  "claude-opus-4-6": {
+    input: 5,
+    output: 25,
+    cacheRead: 0.5,
+    cacheCreate: 6.25,
+  },
+  "claude-sonnet-4-6": {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheCreate: 3.75,
+  },
+  "claude-haiku-4-5": {
+    input: 1,
+    output: 5,
+    cacheRead: 0.1,
+    cacheCreate: 1.25,
+  },
 };
 
 export const SendInput = Schema.Struct({
@@ -1274,6 +1298,31 @@ export type LoginEvent = typeof LoginEvent.Type;
 export const AgentStartLoginRpc = Rpc.make("agent.startLogin", {
   payload: Schema.Struct({ providerId: ProviderId }),
   success: LoginEvent,
+  error: AgentSessionStartError,
+  stream: true,
+});
+
+// ---------------------------------------------------------------------------
+// One-click provider CLI update. The renderer subscribes to
+// `agent.updateProvider`, which spawns the provider's install/upgrade command
+// in a login shell (so `npm`/`bun` are on PATH and `curl … | bash` installers
+// work), streams the command's output back as `log` lines, and ends with a
+// terminal `done`. On success the renderer re-probes availability so the new
+// version is reflected immediately.
+// ---------------------------------------------------------------------------
+
+export const ProviderUpdateEvent = Schema.Union(
+  Schema.TaggedStruct("log", { text: Schema.String }),
+  Schema.TaggedStruct("done", {
+    ok: Schema.Boolean,
+    reason: Schema.optional(Schema.String),
+  }),
+);
+export type ProviderUpdateEvent = typeof ProviderUpdateEvent.Type;
+
+export const AgentUpdateProviderRpc = Rpc.make("agent.updateProvider", {
+  payload: Schema.Struct({ providerId: ProviderId }),
+  success: ProviderUpdateEvent,
   error: AgentSessionStartError,
   stream: true,
 });

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -1,12 +1,7 @@
 import { Rpc } from "@effect/rpc";
 import { Schema } from "effect";
 
-import {
-  AgentItemId,
-  AgentSessionId,
-  AgentTurnId,
-  FolderId,
-} from "./ids.ts";
+import { AgentItemId, AgentSessionId, AgentTurnId, FolderId } from "./ids.ts";
 
 /**
  * Identifier for a provider implementation (driver). v1 ships claude + codex;
@@ -77,11 +72,7 @@ export const DEFAULT_RUNTIME_MODE: RuntimeMode = "approval-required";
  * switches `permissionMode` back to `default` and the existing `RuntimeMode`
  * resumes governing prompts.
  */
-export const PermissionMode = Schema.Literal(
-  "default",
-  "plan",
-  "acceptEdits",
-);
+export const PermissionMode = Schema.Literal("default", "plan", "acceptEdits");
 export type PermissionMode = typeof PermissionMode.Type;
 export const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
 
@@ -141,6 +132,24 @@ export type OptionDescriptor = typeof OptionDescriptor.Type;
  */
 export const CliVersionStatus = Schema.Literal("ok", "outdated", "unknown");
 export type CliVersionStatus = typeof CliVersionStatus.Type;
+
+/**
+ * Per-provider verdict on whether a *newer published release* exists, distinct
+ * from {@link CliVersionStatus} (which is the blocking SDK floor). This layer
+ * is purely informational — it powers the "update available" hover affordance
+ * in settings and the launch toast, and never blocks a session.
+ *
+ *   - `current` — installed version is at or ahead of the latest published
+ *   - `behind` — a newer version is published (`latestVersion` carries it)
+ *   - `unknown` — couldn't reach the registry, parse failed, or the provider
+ *     isn't published to a registry we check (e.g. curl-installed CLIs)
+ */
+export const LatestVersionStatus = Schema.Literal(
+  "current",
+  "behind",
+  "unknown",
+);
+export type LatestVersionStatus = typeof LatestVersionStatus.Type;
 
 /**
  * Server-side verdict on whether a provider is usable right now. Distinct
@@ -210,6 +219,25 @@ export const AgentAvailability = Schema.Struct({
    * own per-provider install lookup.
    */
   cliUpgradeCommand: Schema.optional(Schema.String),
+  /**
+   * Latest version published to the registry (e.g. `"1.0.140"`), when we were
+   * able to resolve one. Set in tandem with `latestVersionStatus`.
+   */
+  latestVersion: Schema.optional(Schema.String),
+  /**
+   * Verdict on whether a newer published release exists. Drives the
+   * informational "update available" UI (hover icon + launch toast) — never
+   * blocks a session. `"unknown"` for providers we don't version-check (no
+   * registry package) or when the registry lookup failed.
+   */
+  latestVersionStatus: Schema.optional(LatestVersionStatus),
+  /**
+   * Copy-able one-liner the user can run to update to the latest published
+   * release (e.g. `"npm i -g @openai/codex@latest"`). Distinct from
+   * `cliUpgradeCommand` (which targets the blocking SDK floor) — though they
+   * often coincide.
+   */
+  updateCommand: Schema.optional(Schema.String),
   /**
    * Verified auth state. Distinct from `cliLoggedIn` (which only checks for
    * a credential file): set when an out-of-process probe (Codex
@@ -606,7 +634,10 @@ const reasoningSelectDescriptor = (
   defaultId,
 });
 
-export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> = {
+export const MODELS_BY_PROVIDER: Record<
+  ProviderId,
+  ReadonlyArray<ModelOption>
+> = {
   claude: [
     {
       id: "claude-opus-4-7",
@@ -798,7 +829,10 @@ export const findModelDescriptor = (
  * persisted user settings and incoming requests through this map so existing
  * sessions don't crash.
  */
-export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string>> = {
+export const MODEL_ALIASES_BY_PROVIDER: Record<
+  ProviderId,
+  Record<string, string>
+> = {
   claude: {},
   codex: {
     "gpt-5-codex": "gpt-5.4",
@@ -838,13 +872,15 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<ProviderId, Record<string, string
     "gpt-5.4-high": "gpt-5.4",
     "gpt-5.4-high-fast": "gpt-5.4",
     "gpt-5.3-codex-fast": "gpt-5.3-codex",
-    "auto": "default",
+    auto: "default",
   },
   opencode: {},
 };
 
-export const resolveModelSlug = (providerId: ProviderId, slug: string): string =>
-  MODEL_ALIASES_BY_PROVIDER[providerId][slug] ?? slug;
+export const resolveModelSlug = (
+  providerId: ProviderId,
+  slug: string,
+): string => MODEL_ALIASES_BY_PROVIDER[providerId][slug] ?? slug;
 
 /**
  * Per-million-token USD pricing used by the renderer to compute the
@@ -860,9 +896,24 @@ export interface ModelPricing {
 }
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
-  "claude-opus-4-7": { input: 15, output: 75, cacheRead: 1.5, cacheCreate: 18.75 },
-  "claude-sonnet-4-6": { input: 3, output: 15, cacheRead: 0.3, cacheCreate: 3.75 },
-  "claude-haiku-4-5": { input: 1, output: 5, cacheRead: 0.1, cacheCreate: 1.25 },
+  "claude-opus-4-7": {
+    input: 15,
+    output: 75,
+    cacheRead: 1.5,
+    cacheCreate: 18.75,
+  },
+  "claude-sonnet-4-6": {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheCreate: 3.75,
+  },
+  "claude-haiku-4-5": {
+    input: 1,
+    output: 5,
+    cacheRead: 0.1,
+    cacheCreate: 1.25,
+  },
 };
 
 export const SendInput = Schema.Struct({

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -10,6 +10,7 @@ import {
   AgentSetCredentialRpc,
   AgentStartLoginRpc,
   AgentStartRpc,
+  AgentUpdateProviderRpc,
 } from "./agent.ts";
 import { AttachmentTouchRpc, AttachmentUploadRpc } from "./attachment.ts";
 import {
@@ -174,6 +175,7 @@ export const MemoizeRpcs = RpcGroup.make(
   AgentEventsRpc,
   AgentOpencodeInventoryRpc,
   AgentStartLoginRpc,
+  AgentUpdateProviderRpc,
   ChatListRpc,
   ChatGetRpc,
   ChatCreateRpc,


### PR DESCRIPTION
## What & why

Today the only version signal for a provider CLI is the **blocking SDK floor** (`cliVersionStatus: "outdated"` → "your CLI is too old for our bundled SDK"). There was **no** awareness of whether a *newer published release* exists, so users silently fell behind.

This PR adds an **update-availability** layer (kept entirely separate from the SDK floor): the server checks the npm registry for each provider's latest published version and the UI surfaces it. **Check-and-notify only — no in-app execution.**

## How it works

**Server**
- `AgentAvailability` gains `latestVersion`, `latestVersionStatus` (`current`/`behind`/`unknown`), and a copy-able `updateCommand`.
- Each provider probe carries an `npmPackage`; `availability.ts` polls `registry.npmjs.org/<pkg>/latest` (1h in-memory cache, 4s timeout, every failure collapses to `"unknown"`), then derives the verdict by reusing the existing `parseCliVersion`/`compareCliVersion` helpers.

**Renderer**
- **Launch toast** (`provider-updates-toast.tsx`) — bottom-right card matching the app `UpdateBanner`: _"Update available: Codex v…"_ / _"Updates available: N providers"_, with **Review in settings** and **Dismiss**. Re-nag suppression via `localStorage` keyed by the exact provider+version set, so it only returns when a newer release appears.
- **Per-provider hover icon** in provider settings → popover with _"Update {Provider} to vX.Y.Z"_ and the `npm i -g <pkg>@latest` command (Copy button). Hidden if the SDK-floor upgrade card is already showing.
- Boot-time availability refresh in `app.tsx` so the toast fires without opening settings.

## Scope

| provider | version-checked |
|----------|-----------------|
| Claude Code, Codex, Gemini, OpenCode (npm) | yes |
| Grok, Cursor (curl installers) | no → `unknown`, no affordance |

## Verification
- `bun test` provider suite: **14 pass** (added `deriveLatestAdvisory` cases — behind/current/unknown, label-wrapped version strings).
- Typecheck clean for all touched files (only failures are pre-existing on HEAD: the committed test file's `bun:test` import + 4 unrelated renderer errors).
- Manual: launch with a CLI behind npm latest → toast appears; Settings → Providers → hover → icon → popover with version + copy command. Up-to-date / non-npm providers show nothing.
