### PR TITLE
fix(worktree): run new chats in their worktree and branch off fresh origin

### DIFF
--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -19,6 +19,7 @@ import {
   TooltipPopup,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
+import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
 import { useChatsStore } from "~/store/chats";
 import { useSettingsStore } from "~/store/settings";
 import { useWorkspaceStore } from "~/store/workspace";
@@ -103,9 +104,14 @@ export function ChatLanding() {
     const model = defaultModelByProvider[defaultProviderId];
     setSubmitError(null);
     setPendingPrompt(trimmed);
+    // Spin up the worktree before creating the chat so the session runs in
+    // it — without this the landing screen promised a worktree (see the
+    // ChatCreatingPanel below) but stranded the agent in the main checkout.
+    const worktreeId = await resolveAutoWorktreeId(selectedFolderId);
     const result = await create(selectedFolderId, defaultProviderId, model, {
       initialPrompt: trimmed,
       runtimeMode: defaultRuntimeMode,
+      worktreeId,
     });
     if (result === null) {
       const reason =

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -30,16 +30,15 @@ import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { cn, formatCompactNumber } from "~/lib/utils";
+import { resolveAutoWorktreeId } from "../lib/auto-worktree.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { useMessagesStore } from "../store/messages.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { useProvidersStore } from "../store/providers.ts";
-import { useRepositorySettingsStore } from "../store/repository-settings.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSettingsStore } from "../store/settings.ts";
-import { useWorktreesStore } from "../store/worktrees.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { BranchIcon, type BranchState } from "./branch-icon.tsx";
@@ -619,17 +618,7 @@ export async function createNewSession(projectId: FolderId): Promise<void> {
     const model =
       settings.defaultModelByProvider[defaultProviderId] ??
       defaultModelFor(defaultProviderId);
-    const repoSettings = await useRepositorySettingsStore
-      .getState()
-      .refresh(projectId);
-    const shouldAutoCreate =
-      repoSettings?.autoCreateWorktree === true ||
-      settings.defaultAutoCreateWorktree === true;
-    let worktreeId = null;
-    if (shouldAutoCreate) {
-      const wt = await useWorktreesStore.getState().create(projectId);
-      if (wt !== null) worktreeId = wt.id;
-    }
+    const worktreeId = await resolveAutoWorktreeId(projectId);
     void useChatsStore
       .getState()
       .create(projectId, defaultProviderId, model, {

--- a/apps/renderer/src/lib/auto-worktree.ts
+++ b/apps/renderer/src/lib/auto-worktree.ts
@@ -1,0 +1,31 @@
+import type { FolderId, WorktreeId } from "@memoize/wire";
+
+import { useRepositorySettingsStore } from "../store/repository-settings.ts";
+import { useSettingsStore } from "../store/settings.ts";
+import { useWorktreesStore } from "../store/worktrees.ts";
+
+/**
+ * Resolve the worktree a freshly-created chat should run in. When per-repo
+ * (`autoCreateWorktree`) or global (`defaultAutoCreateWorktree`) auto-create
+ * is on, this spins up a new worktree and returns its id; otherwise it
+ * returns `null` (chat runs in the main checkout).
+ *
+ * Shared by every chat-creation entry point — the sidebar "New chat" button
+ * and the landing screen — so they can't drift: a divergence here is exactly
+ * what left landing-screen chats stranded in the main repo while the UI
+ * promised a fresh worktree.
+ */
+export async function resolveAutoWorktreeId(
+  projectId: FolderId,
+): Promise<WorktreeId | null> {
+  const settings = useSettingsStore.getState();
+  const repoSettings = await useRepositorySettingsStore
+    .getState()
+    .refresh(projectId);
+  const shouldAutoCreate =
+    repoSettings?.autoCreateWorktree === true ||
+    settings.defaultAutoCreateWorktree === true;
+  if (!shouldAutoCreate) return null;
+  const wt = await useWorktreesStore.getState().create(projectId);
+  return wt?.id ?? null;
+}

--- a/apps/server/src/worktree/layers/worktree-service.ts
+++ b/apps/server/src/worktree/layers/worktree-service.ts
@@ -161,6 +161,38 @@ export const WorktreeServiceLive = Layer.effect(
         );
         const baseBranch = headRefRaw.trim() || "HEAD";
 
+        // Prefer branching off the freshly-fetched `origin/<branch>` rather
+        // than the main repo's local checkout: users live in worktrees and
+        // push from there, so the local base branch (e.g. `main`) is rarely
+        // pulled and goes stale. `git fetch` only touches the remote-tracking
+        // ref — the main checkout is left exactly as-is. Falls back to local
+        // `HEAD` when there's no `origin`, we're offline, the branch isn't on
+        // origin, or HEAD is detached, so worktree creation never fails just
+        // because the network/remote is unavailable.
+        let baseRef = "HEAD";
+        if (baseBranch !== "HEAD") {
+          const fetched = yield* runGit(repoPath, [
+            "fetch",
+            "origin",
+            baseBranch,
+          ]).pipe(
+            Effect.map(() => true),
+            Effect.catchAll(() => Effect.succeed(false)),
+          );
+          if (fetched) {
+            const remoteRefExists = yield* runGit(repoPath, [
+              "rev-parse",
+              "--verify",
+              "--quiet",
+              `refs/remotes/origin/${baseBranch}`,
+            ]).pipe(
+              Effect.map(() => true),
+              Effect.catchAll(() => Effect.succeed(false)),
+            );
+            if (remoteRefExists) baseRef = `origin/${baseBranch}`;
+          }
+        }
+
         // Try a few cool-names before giving up. Disk, DB, and existing-branch
         // collisions all count as "pick another."
         let attempt = 0;
@@ -197,15 +229,15 @@ export const WorktreeServiceLive = Layer.effect(
           if (branchExists) continue;
 
           // git worktree add -b <branch> <target> <baseRef>
-          // baseRef resolves the new branch's start point; use HEAD so we
-          // branch off whatever the user is currently on.
+          // baseRef is the freshly-fetched `origin/<branch>` when available,
+          // otherwise local `HEAD` (see baseRef resolution above).
           const addResult = yield* runGit(repoPath, [
             "worktree",
             "add",
             "-b",
             branch,
             target,
-            "HEAD",
+            baseRef,
           ]).pipe(Effect.either);
           if (addResult._tag === "Left") {
             return yield* Effect.fail(


### PR DESCRIPTION
## Summary

Fixes two worktree defects that surface when auto-create worktree ("work remote") is on.

### Bug 1 — new chats stranded in the main repo
The landing screen (*"What should we build in …?"*) — the most common entry point — showed a *"Branching a fresh worktree off main"* panel but **never created the worktree**. It called `chat.create` without a `worktreeId`, so the server fell back to `cwd = folder.path` and the agent ran in the main checkout instead of the new worktree. The sidebar "New chat" button did it correctly; the two paths had drifted.

**Fix:** extract the worktree-resolution logic into a shared `resolveAutoWorktreeId()` helper (`apps/renderer/src/lib/auto-worktree.ts`) and use it from **both** the landing screen and the sidebar so they can't diverge again.

### Bug 2 — new worktrees branched off stale local `main`
Worktrees were created with `git worktree add -b <branch> <target> HEAD`, branching off the main repo's *local* HEAD. Since users live in worktrees and push from there, local `main` is rarely pulled and goes stale, so new worktrees inherited stale code.

**Fix:** `git fetch origin <branch>` and branch off the freshly-fetched `origin/<branch>`. The main checkout is never touched. Gracefully falls back to local `HEAD` when there's no `origin`, we're offline, the branch isn't on origin, or HEAD is detached — worktree creation never fails just because the remote/network is unavailable.

## Files
- `apps/renderer/src/lib/auto-worktree.ts` (new) — shared worktree-resolution helper
- `apps/renderer/src/components/chat-landing.tsx` — create + pass `worktreeId` (bug 1)
- `apps/renderer/src/components/projects-sidebar.tsx` — use shared helper in `createNewSession`
- `apps/server/src/worktree/layers/worktree-service.ts` — fetch + branch off `origin/<branch>` (bug 2)

## Notes
- **Upstream tracking is unaffected:** branching off `origin/<branch>` may auto-set the new branch's upstream, but `GitService.push` always runs `git push --set-upstream origin <branch>`, which re-points it to the worktree's own remote branch on first push.

## Verification
- `bun run check-types`: renderer and the changed server file pass clean. (The one server error — `availability.test.ts` can't resolve `bun:test` — pre-exists on `main` and is unrelated.)
- Manual (left to reviewer / app run):
  - Auto-create on → submit from the landing screen → confirm session CWD is the worktree under `~/.memoize/...`, not the main repo. Repeat via sidebar "New chat". Toggle off → confirm chats run in the main repo.
  - With local `main` deliberately behind `origin/main`, create a worktree → confirm its branch starts from the `origin/main` tip and local `main` is unchanged. Offline/no-remote repo → creation still succeeds.