### PR TITLE
feat(browser): in-app agent browser driving the existing webview

### DIFF
--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { ArrowLeft, ArrowRight, RotateCw, Star } from "lucide-react";
+import { Effect, Fiber, Stream } from "effect";
+
+import { BrowserCommandResult, type BrowserCommandRequest } from "@memoize/wire";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
+import { useUiStore } from "../store/ui.ts";
+import { BrowserShutter } from "./browser-shutter.tsx";
 
 /**
  * In-app Browser tab — toolbar (back/forward/refresh/URL bar) + Electron
@@ -14,11 +21,16 @@ import { ArrowLeft, ArrowRight, RotateCw, Star } from "lucide-react";
  */
 export function BrowserPane() {
   const webviewRef = useRef<HTMLElement | null>(null);
+  // Ring buffer of console messages + page errors, captured per page load so
+  // `browser_console` can report them to the agent. Cleared on navigation.
+  const consoleBufferRef = useRef<string[]>([]);
   const [url, setUrl] = useState<string>("");
   const [inputValue, setInputValue] = useState<string>("");
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  // Bumped each time the agent takes a screenshot — drives the shutter flash.
+  const [shutterNonce, setShutterNonce] = useState(0);
 
   // Wire navigation lifecycle events onto the underlying webview element.
   // We attach via `addEventListener` because the webview tag isn't a real
@@ -43,22 +55,104 @@ export function BrowserPane() {
       }
       syncNav();
     };
-    const onStart = () => setIsLoading(true);
+    const onStart = () => {
+      setIsLoading(true);
+      // Fresh page — drop the previous page's console history.
+      consoleBufferRef.current = [];
+    };
     const onStop = () => {
       setIsLoading(false);
       syncNav();
+    };
+    const LEVELS = ["log", "info", "warning", "error"] as const;
+    const onConsole = (e: Event) => {
+      const ev = e as Event & {
+        level?: number;
+        message?: string;
+        line?: number;
+        sourceId?: string;
+      };
+      const level = LEVELS[ev.level ?? 0] ?? "log";
+      const where = ev.sourceId ? ` (${ev.sourceId}:${ev.line ?? 0})` : "";
+      const line = `[${level}] ${ev.message ?? ""}${where}`;
+      const buf = consoleBufferRef.current;
+      buf.push(line);
+      if (buf.length > 200) buf.splice(0, buf.length - 200);
+    };
+    const onFailLoad = (e: Event) => {
+      const ev = e as Event & {
+        errorDescription?: string;
+        validatedURL?: string;
+      };
+      if (ev.errorDescription) {
+        consoleBufferRef.current.push(
+          `[error] page load failed: ${ev.errorDescription} ${ev.validatedURL ?? ""}`.trim(),
+        );
+      }
     };
     el.addEventListener("did-navigate", onDidNavigate);
     el.addEventListener("did-navigate-in-page", onDidNavigate);
     el.addEventListener("did-start-loading", onStart);
     el.addEventListener("did-stop-loading", onStop);
     el.addEventListener("dom-ready", syncNav);
+    el.addEventListener("console-message", onConsole);
+    el.addEventListener("did-fail-load", onFailLoad);
     return () => {
       el.removeEventListener("did-navigate", onDidNavigate);
       el.removeEventListener("did-navigate-in-page", onDidNavigate);
       el.removeEventListener("did-start-loading", onStart);
       el.removeEventListener("did-stop-loading", onStop);
       el.removeEventListener("dom-ready", syncNav);
+      el.removeEventListener("console-message", onConsole);
+      el.removeEventListener("did-fail-load", onFailLoad);
+    };
+  }, []);
+
+  // Agent browser executor. Subscribe once to the server's `browser.commands`
+  // broadcast and drive the webview for each command, replying on
+  // `browser.respond`. Commands run serially (runForEach awaits each) so the
+  // agent's navigate→screenshot sequence can't race. The component stays
+  // mounted while a project is open, so this subscription lives as long as the
+  // pane does.
+  useEffect(() => {
+    let fiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
+    let cancelled = false;
+    void (async () => {
+      const client = await getRpcClient();
+      if (cancelled) return;
+      fiber = Effect.runFork(
+        Stream.runForEach(client.browser.commands({}), (req) =>
+          Effect.promise(() => executeBrowserCommand(req)),
+        ),
+      );
+    })();
+
+    const executeBrowserCommand = async (
+      req: BrowserCommandRequest,
+    ): Promise<void> => {
+      // Always surface the action: force the Browser tab visible. This also
+      // un-hides the webview so `capturePage` works (it returns an empty
+      // image for a `display:none` element).
+      useUiStore.getState().setActiveRightTab("browser");
+      const wv = webviewRef.current as WebviewElement | null;
+      const result = await runBrowserCommand(req, wv, {
+        setUrl,
+        setInputValue,
+        flashShutter: () => setShutterNonce((n) => n + 1),
+        readConsole: () => consoleBufferRef.current.join("\n"),
+      });
+      try {
+        const client = await getRpcClient();
+        await Effect.runPromise(client.browser.respond({ result }));
+      } catch {
+        // A failed respond just means this command times out server-side;
+        // the agent gets a clean "browser didn't respond" tool result.
+      }
+    };
+
+    return () => {
+      cancelled = true;
+      if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
     };
   }, []);
 
@@ -170,9 +264,352 @@ export function BrowserPane() {
             height: "100%",
           }}
         />
+        <BrowserShutter nonce={shutterNonce} />
       </div>
     </div>
   );
+}
+
+/**
+ * Drive the webview for one agent browser command and build the reply. Pure
+ * helper (no React state beyond the passed-in setters) so the executor effect
+ * stays small. Never throws — failures come back as `{ ok: false, error }`.
+ */
+async function runBrowserCommand(
+  req: BrowserCommandRequest,
+  wv: WebviewElement | null,
+  hooks: {
+    setUrl: (u: string) => void;
+    setInputValue: (u: string) => void;
+    flashShutter: () => void;
+    readConsole: () => string;
+  },
+): Promise<BrowserCommandResult> {
+  const fail = (error: string) =>
+    BrowserCommandResult.make({ id: req.id, ok: false, error });
+  if (wv === null) {
+    return fail("The in-app browser is not available in this window.");
+  }
+  const command = req.command;
+  try {
+    switch (command._tag) {
+      case "Navigate": {
+        const resolved = resolveUrl(command.url);
+        if (resolved === null) return fail(`Invalid URL: ${command.url}`);
+        hooks.setUrl(resolved);
+        hooks.setInputValue(resolved);
+        await loadAndWait(wv, resolved);
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          url: safeCall(() => wv.getURL(), resolved),
+          title: safeCall(() => wv.getTitle(), ""),
+        });
+      }
+      case "Screenshot": {
+        const current = safeCall(() => wv.getURL(), "");
+        if (current === "" || current === "about:blank") {
+          return fail("No page is loaded — navigate to a URL first.");
+        }
+        // The tab was just made visible; give the compositor a beat to paint
+        // before capturing, otherwise the frame can come back blank.
+        await delay(180);
+        const image = await wv.capturePage();
+        if (image.isEmpty()) {
+          return fail("Screenshot came back empty — the page may still be loading.");
+        }
+        const base64 = image.toDataURL().replace(/^data:image\/png;base64,/, "");
+        hooks.flashShutter();
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          url: current,
+          title: safeCall(() => wv.getTitle(), ""),
+          screenshot: base64,
+        });
+      }
+      case "Snapshot": {
+        const raw = await wv.executeJavaScript(SNAPSHOT_JS);
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          url: safeCall(() => wv.getURL(), ""),
+          title: safeCall(() => wv.getTitle(), ""),
+          snapshot: typeof raw === "string" ? raw : JSON.stringify(raw ?? []),
+        });
+      }
+      case "Click": {
+        if (!isValidRef(command.ref)) return fail("Invalid element ref.");
+        const res = await runJsObject(
+          wv,
+          `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot the page first.' }); el.scrollIntoView({ block:'center', inline:'center' }); el.click(); return JSON.stringify({ ok:true, detail:'Clicked ' + ((el.innerText||el.getAttribute('aria-label')||el.tagName)||'').slice(0,60) }); })()`,
+        );
+        return resultFromJs(req.id, res, `Clicked ${command.ref}.`);
+      }
+      case "Type": {
+        if (!isValidRef(command.ref)) return fail("Invalid element ref.");
+        const submit = command.submit === true;
+        const res = await runJsObject(
+          wv,
+          `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot first.' }); el.focus(); const v = ${JSON.stringify(command.text)}; const tag = el.tagName; if (tag === 'INPUT' || tag === 'TEXTAREA') { const proto = tag === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype; const d = Object.getOwnPropertyDescriptor(proto, 'value'); if (d && d.set) d.set.call(el, v); else el.value = v; } else { el.textContent = v; } el.dispatchEvent(new Event('input', { bubbles:true })); el.dispatchEvent(new Event('change', { bubbles:true })); if (${submit ? "true" : "false"}) { el.dispatchEvent(new KeyboardEvent('keydown', { key:'Enter', keyCode:13, which:13, bubbles:true })); el.dispatchEvent(new KeyboardEvent('keyup', { key:'Enter', keyCode:13, which:13, bubbles:true })); const f = el.form; if (f && typeof f.requestSubmit === 'function') { try { f.requestSubmit(); } catch (e) {} } } return JSON.stringify({ ok:true, detail:'Typed into ' + ((el.getAttribute('name')||el.getAttribute('aria-label')||el.tagName)||'') }); })()`,
+        );
+        return resultFromJs(req.id, res, `Typed into ${command.ref}.`);
+      }
+      case "Wait": {
+        if (typeof command.selector === "string" && command.selector.length > 0) {
+          const res = await runJsObject(
+            wv,
+            `(async () => { const sel = ${JSON.stringify(command.selector)}; const deadline = Date.now() + 10000; while (Date.now() < deadline) { if (document.querySelector(sel)) return JSON.stringify({ ok:true, detail:'Element appeared: ' + sel }); await new Promise(r => setTimeout(r, 150)); } return JSON.stringify({ ok:false, error:'Timed out (10s) waiting for ' + sel }); })()`,
+          );
+          return resultFromJs(req.id, res, "Done waiting.");
+        }
+        const ms = Math.min(Math.max(command.ms ?? 500, 0), 15000);
+        await delay(ms);
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          detail: `Waited ${ms}ms.`,
+        });
+      }
+      case "Scroll": {
+        if (typeof command.ref === "string" && command.ref.length > 0) {
+          if (!isValidRef(command.ref)) return fail("Invalid element ref.");
+          const res = await runJsObject(
+            wv,
+            `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot first.' }); el.scrollIntoView({ block:'center', inline:'center' }); return JSON.stringify({ ok:true, detail:'Scrolled element into view.' }); })()`,
+          );
+          return resultFromJs(req.id, res, "Scrolled into view.");
+        }
+        const dir = command.direction ?? "down";
+        const res = await runJsObject(
+          wv,
+          `(() => { const dir = ${JSON.stringify(dir)}; const h = window.innerHeight; if (dir === 'top') window.scrollTo({ top:0, behavior:'instant' }); else if (dir === 'bottom') window.scrollTo({ top:document.body.scrollHeight, behavior:'instant' }); else if (dir === 'up') window.scrollBy({ top:-Math.round(h*0.85), behavior:'instant' }); else window.scrollBy({ top:Math.round(h*0.85), behavior:'instant' }); const atBottom = (window.innerHeight + window.scrollY) >= document.body.scrollHeight - 4; return JSON.stringify({ ok:true, detail:'Scrolled ' + dir + (atBottom ? ' (reached bottom).' : '.') }); })()`,
+        );
+        return resultFromJs(req.id, res, `Scrolled ${dir}.`);
+      }
+      case "Hover": {
+        if (!isValidRef(command.ref)) return fail("Invalid element ref.");
+        const res = await runJsObject(
+          wv,
+          `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot first.' }); el.scrollIntoView({ block:'center' }); const r = el.getBoundingClientRect(); const opts = { bubbles:true, clientX: r.left + r.width/2, clientY: r.top + r.height/2 }; for (const t of ['pointerover','mouseover','pointerenter','mouseenter','mousemove']) { el.dispatchEvent(new MouseEvent(t, opts)); } return JSON.stringify({ ok:true, detail:'Hovered ' + ((el.innerText||el.getAttribute('aria-label')||el.tagName)||'').slice(0,40) }); })()`,
+        );
+        return resultFromJs(req.id, res, `Hovered ${command.ref}.`);
+      }
+      case "Select": {
+        if (!isValidRef(command.ref)) return fail("Invalid element ref.");
+        const res = await runJsObject(
+          wv,
+          `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot first.' }); if (el.tagName !== 'SELECT') return JSON.stringify({ ok:false, error:'That ref is not a <select> dropdown.' }); const want = ${JSON.stringify(command.value)}; const opt = Array.from(el.options).find((o) => o.value === want || (o.textContent||'').trim() === want); if (!opt) return JSON.stringify({ ok:false, error:'No option matching "' + want + '".' }); el.value = opt.value; el.dispatchEvent(new Event('input', { bubbles:true })); el.dispatchEvent(new Event('change', { bubbles:true })); return JSON.stringify({ ok:true, detail:'Selected ' + (opt.textContent||opt.value) }); })()`,
+        );
+        return resultFromJs(req.id, res, `Selected ${command.value}.`);
+      }
+      case "Press": {
+        const refClause =
+          typeof command.ref === "string" && command.ref.length > 0
+            ? (isValidRef(command.ref)
+                ? `document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]')`
+                : null)
+            : `(document.activeElement || document.body)`;
+        if (refClause === null) return fail("Invalid element ref.");
+        const res = await runJsObject(
+          wv,
+          `(() => { const el = ${refClause}; if (!el) return JSON.stringify({ ok:false, error:'No target element — re-snapshot first.' }); if (typeof el.focus === 'function') el.focus(); const key = ${JSON.stringify(command.key)}; const isEnter = key === 'Enter'; const opts = { key, bubbles:true, cancelable:true }; el.dispatchEvent(new KeyboardEvent('keydown', opts)); el.dispatchEvent(new KeyboardEvent('keyup', opts)); if (isEnter && el.form && typeof el.form.requestSubmit === 'function') { try { el.form.requestSubmit(); } catch (e) {} } return JSON.stringify({ ok:true, detail:'Pressed ' + key }); })()`,
+        );
+        return resultFromJs(req.id, res, `Pressed ${command.key}.`);
+      }
+      case "Read": {
+        const refExpr =
+          typeof command.ref === "string" && command.ref.length > 0
+            ? (isValidRef(command.ref)
+                ? `document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]')`
+                : null)
+            : `document.body`;
+        if (refExpr === null) return fail("Invalid element ref.");
+        const raw = await wv.executeJavaScript(
+          `(() => { const el = ${refExpr}; if (!el) return ''; return (el.innerText || el.textContent || '').replace(/\\n{3,}/g, '\\n\\n').trim().slice(0, 8000); })()`,
+        );
+        const text = typeof raw === "string" ? raw : "";
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          url: safeCall(() => wv.getURL(), ""),
+          title: safeCall(() => wv.getTitle(), ""),
+          text: text.length > 0 ? text : "(no visible text)",
+        });
+      }
+      case "History": {
+        if (command.action === "back") {
+          if (!safeCall(() => wv.canGoBack(), false)) {
+            return fail("Can't go back — no earlier page in history.");
+          }
+          wv.goBack();
+        } else if (command.action === "forward") {
+          if (!safeCall(() => wv.canGoForward(), false)) {
+            return fail("Can't go forward — no later page in history.");
+          }
+          wv.goForward();
+        } else {
+          wv.reload();
+        }
+        await waitForStop(wv);
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          url: safeCall(() => wv.getURL(), ""),
+          title: safeCall(() => wv.getTitle(), ""),
+          detail: `Did ${command.action}.`,
+        });
+      }
+      case "Console": {
+        const log = hooks.readConsole();
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          text: log,
+        });
+      }
+      case "Login": {
+        // Pull the dummy secret out-of-band (renderer-only RPC) and inject it
+        // straight into the page. The password never returns to the agent —
+        // only the ok/detail below, which omit it.
+        const client = await getRpcClient();
+        const secret = await Effect.runPromise(
+          client.browser.fillForOrigin({ origin: command.origin }),
+        );
+        if (secret === null) {
+          return fail(
+            `No saved credential for ${command.origin}. Add a dummy login in Settings → Browser.`,
+          );
+        }
+        const res = await runJsObject(
+          wv,
+          `(() => { const U = ${JSON.stringify(secret.username)}; const P = ${JSON.stringify(secret.password)}; const pw = document.querySelector('input[type="password"]'); if (!pw) return JSON.stringify({ ok:false, error:'No password field on this page — navigate to the login form first.' }); let user = document.querySelector('input[autocomplete="username"], input[type="email"], input[name*="user" i], input[name*="email" i], input[id*="user" i], input[id*="email" i]'); if (!user) { user = Array.from(document.querySelectorAll('input')).find((i) => /^(text|email|)$/.test(i.type)) || null; } const setVal = (el, v) => { const proto = el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype; const d = Object.getOwnPropertyDescriptor(proto, 'value'); if (d && d.set) d.set.call(el, v); else el.value = v; el.dispatchEvent(new Event('input', { bubbles:true })); el.dispatchEvent(new Event('change', { bubbles:true })); }; if (user) setVal(user, U); setVal(pw, P); const form = pw.form; if (form && typeof form.requestSubmit === 'function') { try { form.requestSubmit(); return JSON.stringify({ ok:true, detail:'Filled and submitted the login form.' }); } catch (e) {} } pw.dispatchEvent(new KeyboardEvent('keydown', { key:'Enter', keyCode:13, which:13, bubbles:true })); return JSON.stringify({ ok:true, detail:'Filled the saved credentials and pressed Enter.' }); })()`,
+        );
+        return resultFromJs(req.id, res, "Submitted the saved login.");
+      }
+    }
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+// Snapshot refs are minted as `e<number>` — validate before string-injecting
+// into a querySelector so a crafted ref can't break out of the selector.
+const isValidRef = (ref: string): boolean => /^e\d+$/.test(ref);
+
+/** Run page JS that returns a JSON string and parse it; null on any failure. */
+async function runJsObject(
+  wv: WebviewElement,
+  code: string,
+): Promise<{ ok: boolean; error?: string; detail?: string } | null> {
+  const raw = await wv.executeJavaScript(code);
+  if (typeof raw !== "string") return null;
+  try {
+    return JSON.parse(raw) as { ok: boolean; error?: string; detail?: string };
+  } catch {
+    return null;
+  }
+}
+
+const resultFromJs = (
+  id: string,
+  res: { ok: boolean; error?: string; detail?: string } | null,
+  fallbackDetail: string,
+): BrowserCommandResult =>
+  res === null
+    ? BrowserCommandResult.make({
+        id,
+        ok: false,
+        error: "The page did not respond to the action.",
+      })
+    : BrowserCommandResult.make({
+        id,
+        ok: res.ok,
+        ...(res.ok
+          ? { detail: res.detail ?? fallbackDetail }
+          : { error: res.error ?? "Action failed." }),
+      });
+
+/**
+ * Page-side DOM snapshot. Clears stale refs, then tags every visible
+ * interactive element with a fresh `data-mz-ref` and returns a compact JSON
+ * array `[{ ref, role, name, value, tag }]` for the agent to target.
+ */
+const SNAPSHOT_JS = `(() => {
+  document.querySelectorAll('[data-mz-ref]').forEach((e) => e.removeAttribute('data-mz-ref'));
+  const sel = 'a[href], button, input, textarea, select, [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="tab"], [role="menuitem"], [onclick], [contenteditable="true"]';
+  const out = [];
+  let i = 0;
+  for (const el of document.querySelectorAll(sel)) {
+    const rect = el.getBoundingClientRect();
+    const style = window.getComputedStyle(el);
+    const visible = rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none' && Number(style.opacity || '1') > 0.05 && rect.bottom > 0 && rect.right > 0 && rect.top < window.innerHeight + 400;
+    if (!visible) continue;
+    if (el.disabled) continue;
+    const ref = 'e' + (++i);
+    el.setAttribute('data-mz-ref', ref);
+    const tag = el.tagName.toLowerCase();
+    const role = el.getAttribute('role') || (tag === 'a' ? 'link' : tag);
+    const name = (el.getAttribute('aria-label') || el.getAttribute('placeholder') || (el.innerText || '').trim() || el.getAttribute('name') || el.getAttribute('title') || el.getAttribute('value') || '').replace(/\\s+/g, ' ').trim().slice(0, 80);
+    const value = (el.value != null ? String(el.value) : '').slice(0, 80);
+    out.push({ ref, role, name, value, tag });
+    if (out.length >= 200) break;
+  }
+  return JSON.stringify(out);
+})()`;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const safeCall = <T,>(fn: () => T, fallback: T): T => {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+};
+
+/**
+ * Load a URL and resolve once the page settles (or a 20s cap, so a hung load
+ * can't pin the agent's command). Resolves on the first `did-stop-loading`
+ * or `did-fail-load` after the load starts.
+ */
+/** Wait for the next `did-stop-loading` (or a 15s cap) after a history nav. */
+function waitForStop(wv: WebviewElement): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      wv.removeEventListener("did-stop-loading", finish);
+      wv.removeEventListener("did-fail-load", finish);
+      resolve();
+    };
+    wv.addEventListener("did-stop-loading", finish);
+    wv.addEventListener("did-fail-load", finish);
+    setTimeout(finish, 15000);
+  });
+}
+
+function loadAndWait(wv: WebviewElement, url: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      wv.removeEventListener("did-stop-loading", finish);
+      wv.removeEventListener("did-fail-load", finish);
+      resolve();
+    };
+    wv.addEventListener("did-stop-loading", finish);
+    wv.addEventListener("did-fail-load", finish);
+    try {
+      void wv.loadURL(url).catch(() => finish());
+    } catch {
+      wv.src = url;
+    }
+    setTimeout(finish, 20000);
+  });
 }
 
 function ToolbarButton({
@@ -223,4 +660,15 @@ type WebviewElement = HTMLElement & {
   goForward: () => void;
   canGoBack: () => boolean;
   canGoForward: () => boolean;
+  getURL: () => string;
+  getTitle: () => string;
+  capturePage: () => Promise<NativeImageLike>;
+  executeJavaScript: (code: string) => Promise<unknown>;
+};
+
+// Minimal surface of Electron's NativeImage we touch from the renderer.
+// `toDataURL` keeps us off `Buffer`, which the sandboxed renderer lacks.
+type NativeImageLike = {
+  toDataURL: () => string;
+  isEmpty: () => boolean;
 };

--- a/apps/renderer/src/components/browser-shutter.tsx
+++ b/apps/renderer/src/components/browser-shutter.tsx
@@ -1,0 +1,48 @@
+/**
+ * Camera-shutter flash overlaid on the browser pane when the agent takes a
+ * screenshot. Purely decorative — `pointer-events:none` so it never eats
+ * clicks. Keyed by a nonce the executor bumps right after `capturePage()`
+ * resolves; bumping the key remounts the element so the CSS animation
+ * replays every shot.
+ *
+ * Respects `prefers-reduced-motion`: the keyframes collapse to a single brief
+ * dim instead of a white flash + scale for users who opt out of motion.
+ */
+export function BrowserShutter({ nonce }: { nonce: number }) {
+  // nonce === 0 is the initial mount — nothing has been captured yet, so
+  // render nothing (avoids a stray flash on first paint).
+  if (nonce === 0) return null;
+  return (
+    <>
+      <style>{SHUTTER_CSS}</style>
+      <div
+        key={nonce}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-10 memoize-browser-shutter"
+      />
+    </>
+  );
+}
+
+const SHUTTER_CSS = `
+@keyframes memoize-shutter-flash {
+  0%   { opacity: 0; transform: scale(1.04); }
+  8%   { opacity: 0.85; }
+  100% { opacity: 0; transform: scale(1); }
+}
+@keyframes memoize-shutter-dim {
+  0%   { opacity: 0; }
+  20%  { opacity: 0.4; }
+  100% { opacity: 0; }
+}
+.memoize-browser-shutter {
+  background: white;
+  animation: memoize-shutter-flash 420ms ease-out forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .memoize-browser-shutter {
+    background: black;
+    animation: memoize-shutter-dim 320ms ease-out forwards;
+  }
+}
+`;

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -5,11 +5,19 @@ import {
   FlaskConical,
   FolderClosed,
   GitBranch,
+  Globe,
   Keyboard,
+  Plus,
   RotateCw,
   Settings as SettingsIcon,
+  Trash2,
+  TriangleAlert,
 } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+import { Effect } from "effect";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
 
 import {
   MODELS_BY_PROVIDER,
@@ -82,6 +90,12 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
     label: "Workspace",
     Icon: GitBranch,
     section: { kind: "workspace" },
+  },
+  {
+    id: "browser",
+    label: "Browser",
+    Icon: Globe,
+    section: { kind: "browser" },
   },
   {
     id: "shortcuts",
@@ -272,6 +286,12 @@ function SectionTitle({
         subtitle: "How new chats relate to your git checkout.",
       };
     }
+    if (section.kind === "browser") {
+      return {
+        title: "Browser",
+        subtitle: "Dummy test logins the agent browser can autofill.",
+      };
+    }
     if (section.kind === "shortcuts") {
       return {
         title: "Keyboard shortcuts",
@@ -314,9 +334,172 @@ function Pane({ section }: { section: SettingsSection }) {
   if (section.kind === "general") return <GeneralPane />;
   if (section.kind === "providers") return <ProvidersPane />;
   if (section.kind === "workspace") return <WorkspacePane />;
+  if (section.kind === "browser") return <BrowserSettingsPane />;
   if (section.kind === "shortcuts") return <KeybindingsPane />;
   if (section.kind === "developer") return <DeveloperPane />;
   return <RepositorySettings projectId={section.projectId} />;
+}
+
+interface BrowserCredRow {
+  readonly origin: string;
+  readonly username: string;
+}
+
+/**
+ * Browser settings — manage the DUMMY/TEST logins the agent browser autofills
+ * via `browser_login`. Passwords go straight to the OS keychain (write-only
+ * from here; the list RPC never returns them). The warning banner is
+ * load-bearing: real credentials must never live here.
+ */
+function BrowserSettingsPane() {
+  const [creds, setCreds] = useState<ReadonlyArray<BrowserCredRow>>([]);
+  const [origin, setOrigin] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const load = async () => {
+    const client = await getRpcClient();
+    const list = await Effect.runPromise(client.browser.listCredentials({}));
+    setCreds(list.map((c) => ({ origin: c.origin, username: c.username })));
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const add = async () => {
+    if (origin.trim() === "" || password === "") return;
+    setBusy(true);
+    try {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.browser.setCredential({
+          origin: origin.trim(),
+          username: username.trim(),
+          password,
+        }),
+      );
+      setOrigin("");
+      setUsername("");
+      setPassword("");
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (target: string) => {
+    const client = await getRpcClient();
+    await Effect.runPromise(client.browser.removeCredential({ origin: target }));
+    await load();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-2 rounded-xl border border-amber-400/30 bg-amber-400/10 px-3 py-2.5 text-[12px] leading-relaxed text-amber-200">
+        <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+        <span>
+          <strong className="font-semibold">Dummy / test logins only.</strong>{" "}
+          Never store a real or production password here. These are for seeded
+          accounts on dev and staging sites you ask the agent to verify. The
+          agent never sees the password — it's injected straight into the page.
+        </span>
+      </div>
+
+      <SettingsFrame
+        title="Saved logins"
+        description="The agent calls browser_login with a site's origin; you'll always be asked to approve before it submits."
+      >
+        <div className="flex flex-col gap-3">
+          {creds.length === 0 ? (
+            <p className="text-[13px] text-muted-foreground">
+              No saved logins yet.
+            </p>
+          ) : (
+            <ul className="flex flex-col divide-y divide-border/40">
+              {creds.map((c) => (
+                <li
+                  key={c.origin}
+                  className="flex items-center gap-3 py-2 first:pt-0 last:pb-0"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13px] font-medium text-foreground">
+                      {c.origin}
+                    </p>
+                    <p className="truncate text-[12px] text-muted-foreground">
+                      {c.username || "(no username)"} · ••••••••
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void remove(c.origin)}
+                    aria-label={`Remove login for ${c.origin}`}
+                    className="flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="flex flex-col gap-2 border-t border-border/40 pt-3">
+            <CredInput
+              placeholder="Origin (https://app.example.com)"
+              value={origin}
+              onChange={setOrigin}
+            />
+            <CredInput
+              placeholder="Username / email"
+              value={username}
+              onChange={setUsername}
+            />
+            <CredInput
+              placeholder="Password (dummy)"
+              value={password}
+              onChange={setPassword}
+              type="password"
+            />
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                onClick={() => void add()}
+                disabled={busy || origin.trim() === "" || password === ""}
+              >
+                <Plus className="size-3.5" />
+                Add login
+              </Button>
+            </div>
+          </div>
+        </div>
+      </SettingsFrame>
+    </div>
+  );
+}
+
+function CredInput({
+  placeholder,
+  value,
+  onChange,
+  type = "text",
+}: {
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: "text" | "password";
+}) {
+  return (
+    <input
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      spellCheck={false}
+      autoComplete="off"
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded-lg border border-border/50 bg-background px-3 py-1.5 text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 focus:border-border"
+    />
+  );
 }
 
 function GeneralPane() {

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -1,6 +1,8 @@
 import {
   Brain01Icon,
+  BrowserIcon,
   BubbleChatIcon,
+  Camera01Icon,
   CheckListIcon,
   Copy01Icon,
   File01Icon,
@@ -78,7 +80,15 @@ export const iconForTool = (tool: string): IconHandle => {
       return GlobeIcon;
     case "TodoWrite":
       return CheckListIcon;
+    case "mcp__memoize__browser_navigate":
+      return BrowserIcon;
+    case "mcp__memoize__browser_screenshot":
+      return Camera01Icon;
     default: {
+      // Agent browser tools arrive as their MCP FQN; match by suffix so the
+      // exact-case list above stays the source of truth.
+      if (tool.endsWith("__browser_screenshot")) return Camera01Icon;
+      if (tool.includes("__browser_")) return BrowserIcon;
       // Heuristic fallback for any Grok-native or future tool we haven't
       // wired an exact case for yet. "list dir", "read file", "run shell"
       // etc. will now get a reasonable icon instead of the generic wrench.
@@ -908,6 +918,177 @@ const buildToolView = (
             text={toResultText(result.output) || stringifyJson(obj.agentsStates)}
             isError={result.isError}
           />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_navigate": {
+      const targetUrl = asString(obj.url);
+      return {
+        icon: BrowserIcon,
+        label: "Browse",
+        trailing:
+          targetUrl !== null ? (
+            <InlineTextHint value={truncate(targetUrl, 64)} />
+          ) : undefined,
+        resultPanel: (result) => (
+          <PreBlock
+            text={toResultText(result.output) || "(loaded)"}
+            isError={result.isError}
+          />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_screenshot": {
+      return {
+        icon: Camera01Icon,
+        label: "Screenshot",
+        trailing: <InlineTextHint value="in-app browser" />,
+        resultPanel: (result) =>
+          result.isError ? (
+            <PreBlock text={toResultText(result.output)} isError />
+          ) : (
+            <span className="text-[11px] text-muted-foreground">
+              Captured the visible page.
+            </span>
+          ),
+      };
+    }
+
+    case "mcp__memoize__browser_snapshot": {
+      return {
+        icon: BrowserIcon,
+        label: "Read page",
+        trailing: <InlineTextHint value="elements" />,
+        resultPanel: (result) => (
+          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_click": {
+      const ref = asString(obj.ref);
+      return {
+        icon: BrowserIcon,
+        label: "Click",
+        trailing: ref !== null ? <InlineTextHint value={ref} /> : undefined,
+        resultPanel: (result) => (
+          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_type": {
+      const typed = asString(obj.text);
+      return {
+        icon: BrowserIcon,
+        label: "Type",
+        trailing:
+          typed !== null ? (
+            <InlineTextHint value={truncate(typed, 48)} />
+          ) : undefined,
+        resultPanel: (result) => (
+          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_wait": {
+      const sel = asString(obj.selector);
+      const ms = typeof obj.ms === "number" ? `${obj.ms}ms` : null;
+      return {
+        icon: BrowserIcon,
+        label: "Wait",
+        trailing: <InlineTextHint value={sel ?? ms ?? "settle"} />,
+      };
+    }
+
+    case "mcp__memoize__browser_scroll": {
+      const dir = asString(obj.direction);
+      const ref = asString(obj.ref);
+      return {
+        icon: BrowserIcon,
+        label: "Scroll",
+        trailing: <InlineTextHint value={ref ?? dir ?? "down"} />,
+      };
+    }
+
+    case "mcp__memoize__browser_hover": {
+      const ref = asString(obj.ref);
+      return {
+        icon: BrowserIcon,
+        label: "Hover",
+        trailing: ref !== null ? <InlineTextHint value={ref} /> : undefined,
+      };
+    }
+
+    case "mcp__memoize__browser_select": {
+      const value = asString(obj.value);
+      return {
+        icon: BrowserIcon,
+        label: "Select",
+        trailing:
+          value !== null ? <InlineTextHint value={truncate(value, 40)} /> : undefined,
+        resultPanel: (result) => (
+          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_press": {
+      const key = asString(obj.key);
+      return {
+        icon: BrowserIcon,
+        label: "Press",
+        trailing: key !== null ? <InlineTextHint value={key} /> : undefined,
+      };
+    }
+
+    case "mcp__memoize__browser_read": {
+      return {
+        icon: File01Icon,
+        label: "Read page",
+        resultPanel: (result) => (
+          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_history": {
+      const action = asString(obj.action);
+      return {
+        icon: BrowserIcon,
+        label:
+          action === "back"
+            ? "Back"
+            : action === "forward"
+              ? "Forward"
+              : "Reload",
+      };
+    }
+
+    case "mcp__memoize__browser_console": {
+      return {
+        icon: TerminalIcon,
+        label: "Console",
+        resultPanel: (result) => (
+          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+        ),
+      };
+    }
+
+    case "mcp__memoize__browser_login": {
+      const origin = asString(obj.origin);
+      return {
+        icon: BrowserIcon,
+        label: "Log in",
+        trailing:
+          origin !== null ? (
+            <InlineTextHint value={truncate(origin, 48)} />
+          ) : undefined,
+        resultPanel: (result) => (
+          <PreBlock text={toResultText(result.output)} isError={result.isError} />
         ),
       };
     }

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -17,6 +17,7 @@ export type SettingsSection =
   | { readonly kind: "general" }
   | { readonly kind: "providers" }
   | { readonly kind: "workspace" }
+  | { readonly kind: "browser" }
   | { readonly kind: "shortcuts" }
   | { readonly kind: "developer" }
   | { readonly kind: "repository"; readonly projectId: FolderId };

--- a/apps/server/src/provider/drivers/browser-tools.ts
+++ b/apps/server/src/provider/drivers/browser-tools.ts
@@ -1,0 +1,365 @@
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+import type { BrowserCommand, BrowserCommandResult } from "@memoize/wire";
+
+/**
+ * Promise-returning send bound to one agent session. Provider-service closes
+ * over the session id and the Effect runtime so these tool handlers — which
+ * the Claude SDK invokes as plain async functions — stay free of any Effect
+ * wiring. Mirrors how `buildIndexTools` binds the workspace handle.
+ */
+export type BrowserSend = (
+  command: BrowserCommand,
+) => Promise<BrowserCommandResult>;
+
+/**
+ * Standard text tool result from a command outcome: the `detail` note on
+ * success (or `fallback`), or the `error` with `isError` on failure.
+ */
+const textResult = (result: BrowserCommandResult, fallback: string) => ({
+  content: [
+    {
+      type: "text" as const,
+      text: result.ok
+        ? (result.detail ?? fallback)
+        : (result.error ?? "Action failed."),
+    },
+  ],
+  ...(result.ok ? {} : { isError: true as const }),
+});
+
+/**
+ * Build the in-process MCP tool definitions for the agent browser. They drive
+ * the app's existing on-screen `<webview>` (round-tripping through the
+ * renderer) rather than spinning up a headless Chrome, so the user watches
+ * every action live. Phase 1: navigate + screenshot. Interaction
+ * (snapshot/click/type) and login arrive in later phases as new tools here.
+ *
+ * Descriptions are blunt on purpose — the model reads them to choose the
+ * browser over `WebFetch`: this one renders JS, shows the user what's
+ * happening, and can screenshot what it sees.
+ */
+export const buildBrowserTools = (send: BrowserSend) => [
+  tool(
+    "browser_navigate",
+    "Open a URL in the app's in-app browser (the Browser tab the user can see). Use this — not WebFetch — when you need to render a real page (JS apps, dev servers, dashboards) or are about to screenshot or interact with it. The page loads in the shared on-screen webview so the user watches live. Returns the final URL and page title once the page settles.",
+    {
+      url: z
+        .string()
+        .min(1)
+        .describe(
+          "Absolute URL to load. Include the scheme (https:// or http:// for localhost dev servers).",
+        ),
+    },
+    async (args) => {
+      const result = await send({ _tag: "Navigate", url: args.url });
+      if (!result.ok) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: result.error ?? "Navigation failed.",
+            },
+          ],
+          isError: true,
+        };
+      }
+      const title = result.title ?? "";
+      const finalUrl = result.url ?? args.url;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Loaded ${finalUrl}${title.length > 0 ? ` — "${title}"` : ""}.`,
+          },
+        ],
+      };
+    },
+  ),
+
+  tool(
+    "browser_screenshot",
+    "Capture what the in-app browser is currently showing (the visible viewport) and return it as an image you can see. The user sees a camera-shutter flash when this fires. Use it to verify a page rendered correctly, read content that didn't come through as text, or confirm the result of an action. Navigate first if nothing is loaded.",
+    {},
+    async () => {
+      const result = await send({ _tag: "Screenshot" });
+      if (!result.ok || result.screenshot === undefined) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                result.error ??
+                "Could not capture a screenshot — make sure a page is loaded in the Browser tab.",
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: "image" as const,
+            data: result.screenshot,
+            mimeType: "image/png" as const,
+          },
+        ],
+      };
+    },
+  ),
+
+  tool(
+    "browser_snapshot",
+    "List the interactive and visible elements on the current page — links, buttons, inputs, etc. — each with a stable `ref`, its role, accessible name, and current value. Read this BEFORE clicking or typing: you target elements by `ref`, never by coordinates. Cheaper and more reliable than a screenshot for figuring out what's on the page and what to do next.",
+    {},
+    async () => {
+      const result = await send({ _tag: "Snapshot" });
+      if (!result.ok || result.snapshot === undefined) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: result.error ?? "Could not snapshot the page.",
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: "text" as const, text: result.snapshot }],
+      };
+    },
+  ),
+
+  tool(
+    "browser_click",
+    "Click an element by the `ref` you got from browser_snapshot. Re-snapshot first if the page changed — refs are only valid for the snapshot that produced them. Requires user approval.",
+    {
+      ref: z
+        .string()
+        .min(1)
+        .describe("The `ref` of the target element from a recent browser_snapshot."),
+    },
+    async (args) => {
+      const result = await send({ _tag: "Click", ref: args.ref });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: result.ok
+              ? (result.detail ?? `Clicked ${args.ref}.`)
+              : (result.error ?? "Click failed."),
+          },
+        ],
+        ...(result.ok ? {} : { isError: true }),
+      };
+    },
+  ),
+
+  tool(
+    "browser_type",
+    "Type text into the input/textarea identified by `ref` (from browser_snapshot). Replaces the field's current value. Set `submit: true` to press Enter afterward (submit a search box or login form). Requires user approval.",
+    {
+      ref: z.string().min(1).describe("The `ref` of the target input from a recent browser_snapshot."),
+      text: z.string().describe("The text to type into the field."),
+      submit: z
+        .boolean()
+        .optional()
+        .describe("Press Enter after typing (e.g. to submit the form)."),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "Type",
+        ref: args.ref,
+        text: args.text,
+        ...(args.submit !== undefined ? { submit: args.submit } : {}),
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: result.ok
+              ? (result.detail ?? `Typed into ${args.ref}.`)
+              : (result.error ?? "Type failed."),
+          },
+        ],
+        ...(result.ok ? {} : { isError: true }),
+      };
+    },
+  ),
+
+  tool(
+    "browser_wait",
+    "Pause for the page to settle after a navigation or AJAX update. Give `selector` to wait until a CSS selector appears (up to ~10s), or `ms` for a fixed delay. Use sparingly — prefer re-snapshotting.",
+    {
+      ms: z.number().int().positive().max(15000).optional(),
+      selector: z.string().min(1).optional(),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "Wait",
+        ...(args.ms !== undefined ? { ms: args.ms } : {}),
+        ...(args.selector !== undefined ? { selector: args.selector } : {}),
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: result.ok
+              ? (result.detail ?? "Done waiting.")
+              : (result.error ?? "Wait failed."),
+          },
+        ],
+        ...(result.ok ? {} : { isError: true }),
+      };
+    },
+  ),
+
+  tool(
+    "browser_scroll",
+    "Scroll the page. Use `direction` (down/up/top/bottom) to move the viewport, or pass a `ref` from browser_snapshot to scroll that element into view. Snapshot again after scrolling — new elements may have come into view with fresh refs.",
+    {
+      direction: z.enum(["up", "down", "top", "bottom"]).optional(),
+      ref: z
+        .string()
+        .optional()
+        .describe("Scroll this snapshot ref into view instead of moving the viewport."),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "Scroll",
+        ...(args.direction !== undefined ? { direction: args.direction } : {}),
+        ...(args.ref !== undefined ? { ref: args.ref } : {}),
+      });
+      return textResult(result, "Scrolled.");
+    },
+  ),
+
+  tool(
+    "browser_hover",
+    "Hover the pointer over an element by `ref` (from browser_snapshot) to reveal hover menus, tooltips, or lazy content. Snapshot again afterward to pick up anything that appeared.",
+    { ref: z.string().min(1) },
+    async (args) => {
+      const result = await send({ _tag: "Hover", ref: args.ref });
+      return textResult(result, `Hovered ${args.ref}.`);
+    },
+  ),
+
+  tool(
+    "browser_select",
+    "Choose an option in a <select> dropdown identified by `ref` (from browser_snapshot). `value` matches either the option's value or its visible label. Requires user approval.",
+    {
+      ref: z.string().min(1),
+      value: z.string().describe("The option value or visible text to select."),
+    },
+    async (args) => {
+      const result = await send({ _tag: "Select", ref: args.ref, value: args.value });
+      return textResult(result, `Selected "${args.value}".`);
+    },
+  ),
+
+  tool(
+    "browser_press",
+    "Press a keyboard key — Enter, Tab, Escape, ArrowDown, Backspace, etc. Targets the element `ref` if given, otherwise whatever is currently focused. Good for submitting, dismissing dialogs, or keyboard navigation. Requires user approval.",
+    {
+      key: z
+        .string()
+        .min(1)
+        .describe("Key name, e.g. Enter, Tab, Escape, ArrowDown, PageDown, Backspace."),
+      ref: z.string().optional(),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "Press",
+        key: args.key,
+        ...(args.ref !== undefined ? { ref: args.ref } : {}),
+      });
+      return textResult(result, `Pressed ${args.key}.`);
+    },
+  ),
+
+  tool(
+    "browser_read",
+    "Read the visible text of the page (or of one element by `ref`). Use this — instead of a screenshot — to confirm content, read results, or verify a flow worked. Returns plain text, truncated if very long.",
+    { ref: z.string().optional() },
+    async (args) => {
+      const result = await send({
+        _tag: "Read",
+        ...(args.ref !== undefined ? { ref: args.ref } : {}),
+      });
+      if (!result.ok) {
+        return {
+          content: [{ type: "text" as const, text: result.error ?? "Could not read the page." }],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: "text" as const, text: result.text ?? "(no text)" }],
+      };
+    },
+  ),
+
+  tool(
+    "browser_history",
+    "Navigate the browser's own history: go back, go forward, or reload the current page. Waits for the page to settle.",
+    { action: z.enum(["back", "forward", "reload"]) },
+    async (args) => {
+      const result = await send({ _tag: "History", action: args.action });
+      return textResult(result, `Did ${args.action}.`);
+    },
+  ),
+
+  tool(
+    "browser_console",
+    "Return the page's recent console messages and uncaught JavaScript errors (captured since the last navigation). Use this to verify a page is healthy or to debug why something didn't work.",
+    {},
+    async () => {
+      const result = await send({ _tag: "Console" });
+      if (!result.ok) {
+        return {
+          content: [{ type: "text" as const, text: result.error ?? "Could not read the console." }],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: result.text && result.text.length > 0
+              ? result.text
+              : "(console is empty — no messages or errors since the last navigation)",
+          },
+        ],
+      };
+    },
+  ),
+
+  tool(
+    "browser_login",
+    "Fill and submit the saved TEST login for a site, using the dummy credentials the user configured in Settings → Browser. Pass the site's origin (e.g. https://app.example.com). You never see or handle the password — it's injected directly into the page. The user is always asked to approve. Navigate to the login page first. Returns whether a saved credential was found and submitted.",
+    {
+      origin: z
+        .string()
+        .min(1)
+        .describe(
+          "The site origin to log into, e.g. https://app.example.com. Must match a credential saved in Settings → Browser.",
+        ),
+    },
+    async (args) => {
+      const result = await send({ _tag: "Login", origin: args.origin });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: result.ok
+              ? (result.detail ?? `Submitted the saved login for ${args.origin}.`)
+              : (result.error ??
+                `No saved credential for ${args.origin}. Ask the user to add one in Settings → Browser.`),
+          },
+        ],
+        ...(result.ok ? {} : { isError: true }),
+      };
+    },
+  ),
+];

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -742,6 +742,23 @@ const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
   `mcp__${MEMOIZE_MCP_NAME}__find_references`,
   `mcp__${MEMOIZE_MCP_NAME}__read_chunk`,
   `mcp__${MEMOIZE_MCP_NAME}__list_module`,
+  // Agent browser — navigate / screenshot / snapshot / wait are read-only and
+  // fully visible to the user (the page loads in the on-screen webview,
+  // screenshots flash a shutter). Auto-allow like the index reads.
+  // `browser_click` and `browser_type` are deliberately absent: they mutate
+  // page state, so they fall through to the regular permission prompt.
+  `mcp__${MEMOIZE_MCP_NAME}__browser_navigate`,
+  `mcp__${MEMOIZE_MCP_NAME}__browser_screenshot`,
+  `mcp__${MEMOIZE_MCP_NAME}__browser_snapshot`,
+  `mcp__${MEMOIZE_MCP_NAME}__browser_wait`,
+  // Read-only / non-mutating browsing: scroll, hover, read text, console,
+  // and history (back/forward/reload — like navigate, which also auto-allows).
+  // `browser_select` and `browser_press` change page state, so they prompt.
+  `mcp__${MEMOIZE_MCP_NAME}__browser_scroll`,
+  `mcp__${MEMOIZE_MCP_NAME}__browser_hover`,
+  `mcp__${MEMOIZE_MCP_NAME}__browser_read`,
+  `mcp__${MEMOIZE_MCP_NAME}__browser_console`,
+  `mcp__${MEMOIZE_MCP_NAME}__browser_history`,
 ]);
 
 /**
@@ -821,6 +838,12 @@ const policyFor = (
   //    prompting. Always auto-allow.
   if (isAskUserQuestion(toolName)) {
     return { kind: "auto-allow" };
+  }
+  // 0b. Agent browser login submits saved (dummy) credentials into a page.
+  //     Always prompt, even in full-access mode — a login attempt should
+  //     never fire silently. Treated like a sensitive path.
+  if (toolName.endsWith("__browser_login")) {
+    return { kind: "prompt", forcePrompt: true };
   }
   // 1. Sensitive paths — checked before any auto-allow. Even YOLO mode prompts.
   if (toolName === "Read") {

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -9,6 +9,8 @@ import { Effect, Layer, Stream } from "effect";
 
 import { resolveCliPath } from "./availability.ts";
 import { loadOpencodeInventory } from "./drivers/opencode.ts";
+import { BrowserBridgeService } from "./services/browser-bridge-service.ts";
+import { CredentialsService } from "./services/credentials-service.ts";
 import { startProviderLogin } from "./services/login-service.ts";
 import { MessageStore } from "./services/message-store.ts";
 import { PermissionService } from "./services/permission-service.ts";
@@ -382,6 +384,60 @@ const PermissionRevokeDecision = MemoizeRpcs.toLayerHandler(
     Effect.flatMap(PermissionService, (svc) => svc.revokeDecision(requestId)),
 );
 
+// ---------------------------------------------------------------------------
+// browser.* — in-app agent browser bridge. The renderer's BrowserPane
+// subscribes to `browser.commands`, drives the `<webview>`, and posts the
+// outcome back via `browser.respond`, resolving the Deferred the MCP browser
+// tool is awaiting. Mirrors the permission.* request/decide pair.
+// ---------------------------------------------------------------------------
+
+const BrowserCommands = MemoizeRpcs.toLayerHandler("browser.commands", () =>
+  Stream.unwrap(
+    Effect.map(BrowserBridgeService, (svc) => svc.commands()),
+  ),
+);
+
+const BrowserRespond = MemoizeRpcs.toLayerHandler(
+  "browser.respond",
+  ({ result }) =>
+    Effect.flatMap(BrowserBridgeService, (svc) => svc.respond(result)),
+);
+
+// Browser credentials — DUMMY/TEST logins kept in the keychain. A keychain
+// failure is swallowed to a safe value (void / [] / null) rather than
+// surfacing a defect: a missing credential just means autofill no-ops.
+const BrowserSetCredential = MemoizeRpcs.toLayerHandler(
+  "browser.setCredential",
+  ({ origin, username, password }) =>
+    Effect.flatMap(CredentialsService, (svc) =>
+      svc.setBrowser(origin, username, password),
+    ).pipe(Effect.catchAll(() => Effect.void)),
+);
+
+const BrowserListCredentials = MemoizeRpcs.toLayerHandler(
+  "browser.listCredentials",
+  () =>
+    Effect.flatMap(CredentialsService, (svc) => svc.listBrowser()).pipe(
+      Effect.catchAll(() => Effect.succeed([])),
+    ),
+);
+
+const BrowserRemoveCredential = MemoizeRpcs.toLayerHandler(
+  "browser.removeCredential",
+  ({ origin }) =>
+    Effect.flatMap(CredentialsService, (svc) => svc.removeBrowser(origin)).pipe(
+      Effect.catchAll(() => Effect.void),
+    ),
+);
+
+const BrowserFillForOrigin = MemoizeRpcs.toLayerHandler(
+  "browser.fillForOrigin",
+  ({ origin }) =>
+    Effect.flatMap(CredentialsService, (svc) => svc.getBrowser(origin)).pipe(
+      Effect.catchAll(() => Effect.succeed(null)),
+    ),
+);
+
 export const ProviderHandlersLayer = Layer.mergeAll(
   Availability,
   SetCredential,
@@ -425,4 +481,10 @@ export const ProviderHandlersLayer = Layer.mergeAll(
   PermissionListPending,
   PermissionListDecisions,
   PermissionRevokeDecision,
+  BrowserCommands,
+  BrowserRespond,
+  BrowserSetCredential,
+  BrowserListCredentials,
+  BrowserRemoveCredential,
+  BrowserFillForOrigin,
 );

--- a/apps/server/src/provider/layers/browser-bridge-service.ts
+++ b/apps/server/src/provider/layers/browser-bridge-service.ts
@@ -1,0 +1,100 @@
+import { Deferred, Effect, Layer, PubSub, Ref, Stream } from "effect";
+
+import {
+  BrowserCommandNotFoundError,
+  BrowserCommandRequest,
+  BrowserCommandResult,
+  type BrowserCommand,
+  type SessionId,
+} from "@memoize/wire";
+
+import {
+  BrowserBridgeService,
+  type BrowserBridgeServiceShape,
+} from "../services/browser-bridge-service.ts";
+
+/**
+ * How long a single browser command may wait for the renderer before the
+ * bridge gives up and reports the webview as unavailable. The webview lives
+ * in the renderer — if the Browser pane isn't mounted (no project selected)
+ * or the renderer is wedged, the command would otherwise block the agent
+ * turn forever. 30s comfortably covers a real page load + screenshot.
+ */
+const COMMAND_TIMEOUT = "30 seconds";
+
+let commandCounter = 0;
+const nextCommandId = (): string => `bc_${Date.now()}_${++commandCounter}`;
+
+export const BrowserBridgeServiceLive = Layer.scoped(
+  BrowserBridgeService,
+  Effect.gen(function* () {
+    const pubsub = yield* PubSub.unbounded<BrowserCommandRequest>();
+    const pending = yield* Ref.make<
+      ReadonlyMap<string, Deferred.Deferred<BrowserCommandResult>>
+    >(new Map());
+
+    const forget = (id: string): Effect.Effect<void> =>
+      Ref.update(pending, (m) => {
+        const next = new Map(m);
+        next.delete(id);
+        return next;
+      });
+
+    const send: BrowserBridgeServiceShape["send"] = (
+      sessionId: SessionId,
+      command: BrowserCommand,
+    ) =>
+      Effect.gen(function* () {
+        const id = nextCommandId();
+        const req = BrowserCommandRequest.make({ id, sessionId, command });
+        const deferred = yield* Deferred.make<BrowserCommandResult>();
+        yield* Ref.update(pending, (m) => {
+          const next = new Map(m);
+          next.set(id, deferred);
+          return next;
+        });
+        yield* PubSub.publish(pubsub, req);
+        // Await the renderer's reply, but never longer than COMMAND_TIMEOUT.
+        // On timeout we synthesize a failure result rather than failing the
+        // effect, so the tool reports a clean error to the agent. `ensuring`
+        // guarantees the pending entry is cleared on every exit path.
+        const result = yield* Deferred.await(deferred).pipe(
+          Effect.timeoutTo({
+            duration: COMMAND_TIMEOUT,
+            onTimeout: () =>
+              BrowserCommandResult.make({
+                id,
+                ok: false,
+                error:
+                  "The in-app browser did not respond. Open the Browser tab in the right pane and try again.",
+              }),
+            onSuccess: (r: BrowserCommandResult) => r,
+          }),
+          Effect.ensuring(forget(id)),
+        );
+        return result;
+      });
+
+    const respond: BrowserBridgeServiceShape["respond"] = (result) =>
+      Effect.gen(function* () {
+        const map = yield* Ref.get(pending);
+        const deferred = map.get(result.id);
+        if (deferred === undefined) {
+          return yield* Effect.fail(
+            new BrowserCommandNotFoundError({ id: result.id }),
+          );
+        }
+        yield* Deferred.succeed(deferred, result);
+      });
+
+    const commands: BrowserBridgeServiceShape["commands"] = () =>
+      Stream.unwrapScoped(
+        Effect.gen(function* () {
+          const dequeue = yield* pubsub.subscribe;
+          return Stream.fromQueue(dequeue);
+        }),
+      );
+
+    return { send, respond, commands } as const;
+  }),
+);

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -16,6 +16,43 @@ const SERVICE_NAME = "memoize";
  */
 const accountFor = (providerId: ProviderId): string => `apiKey:${providerId}`;
 
+/**
+ * Browser credentials share the `memoize` keychain service but use a separate
+ * `browserCred:` prefix so they never collide with `apiKey:` entries. The
+ * origin is normalized (scheme + host[:port]) so `https://x.com/login` and
+ * `https://x.com/` resolve to the same saved credential.
+ */
+const BROWSER_PREFIX = "browserCred:";
+const browserAccountFor = (origin: string): string =>
+  `${BROWSER_PREFIX}${normalizeOrigin(origin)}`;
+
+const normalizeOrigin = (input: string): string => {
+  try {
+    return new URL(input).origin;
+  } catch {
+    // Not a full URL — best effort: strip any path/query and lowercase host.
+    return input.trim().replace(/\/.*$/, "").toLowerCase();
+  }
+};
+
+interface BrowserCred {
+  readonly username: string;
+  readonly password: string;
+}
+
+const parseBrowserCred = (raw: string | null): BrowserCred | null => {
+  if (raw === null) return null;
+  try {
+    const obj = JSON.parse(raw) as Partial<BrowserCred>;
+    if (typeof obj.username === "string" && typeof obj.password === "string") {
+      return { username: obj.username, password: obj.password };
+    }
+  } catch {
+    // Corrupt entry — treat as absent.
+  }
+  return null;
+};
+
 const KNOWN_PROVIDERS: ReadonlyArray<ProviderId> = [
   "claude",
   "codex",
@@ -65,6 +102,35 @@ export const CredentialsServiceLive = Layer.succeed(
             if (idx === -1 || account.slice(0, idx) !== "apiKey") continue;
             const id = account.slice(idx + 1);
             if (isKnownProvider(id) && !out.includes(id)) out.push(id);
+          }
+          return out;
+        }),
+      ),
+    setBrowser: (origin, username, password) =>
+      tryKeychain("*", () =>
+        keytar.setPassword(
+          SERVICE_NAME,
+          browserAccountFor(origin),
+          JSON.stringify({ username, password }),
+        ),
+      ),
+    getBrowser: (origin) =>
+      tryKeychain("*", () =>
+        keytar.getPassword(SERVICE_NAME, browserAccountFor(origin)),
+      ).pipe(Effect.map(parseBrowserCred)),
+    removeBrowser: (origin) =>
+      tryKeychain("*", () =>
+        keytar.deletePassword(SERVICE_NAME, browserAccountFor(origin)),
+      ).pipe(Effect.asVoid),
+    listBrowser: () =>
+      tryKeychain("*", () => keytar.findCredentials(SERVICE_NAME)).pipe(
+        Effect.map((entries) => {
+          const out: Array<{ origin: string; username: string }> = [];
+          for (const { account, password } of entries) {
+            if (!account.startsWith(BROWSER_PREFIX)) continue;
+            const origin = account.slice(BROWSER_PREFIX.length);
+            const cred = parseBrowserCred(password);
+            out.push({ origin, username: cred?.username ?? "" });
           }
           return out;
         }),

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -42,7 +42,9 @@ import {
 } from "../drivers/opencode.ts";
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { buildIndexTools } from "../../code-index/claude-tools.ts";
+import { buildBrowserTools } from "../drivers/browser-tools.ts";
 import { IndexRegistry } from "../../code-index/services/index-registry.ts";
+import { BrowserBridgeService } from "../services/browser-bridge-service.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
 import { PermissionService } from "../services/permission-service.ts";
 import { ProviderService } from "../services/provider-service.ts";
@@ -82,6 +84,7 @@ export const ProviderServiceLive = Layer.effect(
     const workspace = yield* WorkspaceService;
     const permissions = yield* PermissionService;
     const attachmentService = yield* AttachmentService;
+    const browserBridge = yield* BrowserBridgeService;
     const indexRegistry = yield* IndexRegistry;
     const runtime = yield* Effect.runtime<never>();
     const sessions = yield* Ref.make<Map<AgentSessionId, SessionEntry>>(
@@ -307,6 +310,15 @@ export const ProviderServiceLive = Layer.effect(
             // resolves it; Phase E adds a real git-checkout subscription.
             const indexHandle = yield* indexRegistry.getHandle(cwd, "HEAD");
             const indexTools = buildIndexTools(indexHandle);
+            // Browser tools drive the renderer's shared `<webview>` through
+            // the bridge. Bind `send` to this session id + the live runtime so
+            // the SDK's async tool handlers stay free of Effect wiring (same
+            // shape as `buildIndexTools` binding the workspace handle).
+            const browserTools = buildBrowserTools((command) =>
+              Runtime.runPromise(runtime)(
+                browserBridge.send(sessionId, command),
+              ),
+            );
 
             handle = yield* startClaudeSession(
               input,
@@ -317,7 +329,7 @@ export const ProviderServiceLive = Layer.effect(
               buildRequestPermission(input.folderId),
               runtimeModeGetter,
               resumeCursor,
-              indexTools,
+              [...indexTools, ...browserTools],
             ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else {
             // Same story as Claude: we don't ship the SDK's bundled native

--- a/apps/server/src/provider/services/browser-bridge-service.ts
+++ b/apps/server/src/provider/services/browser-bridge-service.ts
@@ -1,0 +1,44 @@
+import { Context, type Effect, type Stream } from "effect";
+
+import type {
+  BrowserCommand,
+  BrowserCommandNotFoundError,
+  BrowserCommandRequest,
+  BrowserCommandResult,
+  SessionId,
+} from "@memoize/wire";
+
+/**
+ * Bridge between the in-process browser MCP tools (which call `send` from
+ * inside the Claude SDK tool handler) and the renderer (which subscribes to
+ * `commands`, drives the `<webview>`, then calls `respond`).
+ *
+ * `send` blocks the tool until the renderer replies or a 30s safety timeout
+ * fires (a hidden/closed webview can never hang the agent turn). `respond`
+ * resolves whichever Deferred is keyed by `result.id`. `commands` is the
+ * server→renderer broadcast every BrowserPane consumes.
+ *
+ * Deliberately ephemeral — no SQLite. A browser command only matters while
+ * its agent turn is live; nothing survives a restart.
+ */
+export interface BrowserBridgeServiceShape {
+  /**
+   * Issue a command to the renderer and await its result. Never fails: a
+   * timeout (or absent webview) returns a `{ ok: false, error }` result so
+   * the tool can report it to the agent as a normal tool outcome.
+   */
+  readonly send: (
+    sessionId: SessionId,
+    command: BrowserCommand,
+  ) => Effect.Effect<BrowserCommandResult>;
+
+  readonly respond: (
+    result: BrowserCommandResult,
+  ) => Effect.Effect<void, BrowserCommandNotFoundError>;
+
+  readonly commands: () => Stream.Stream<BrowserCommandRequest>;
+}
+
+export class BrowserBridgeService extends Context.Tag(
+  "memoize/BrowserBridgeService",
+)<BrowserBridgeService, BrowserBridgeServiceShape>() {}

--- a/apps/server/src/provider/services/credentials-service.ts
+++ b/apps/server/src/provider/services/credentials-service.ts
@@ -27,6 +27,28 @@ export interface CredentialsServiceShape {
     ReadonlyArray<ProviderId>,
     CredentialsError
   >;
+
+  /**
+   * In-app agent browser credentials — DUMMY/TEST logins only. Keyed by web
+   * origin, namespaced `browserCred:<origin>` in the same keychain. Stored as
+   * `{ username, password }`. `listBrowser` deliberately drops the password so
+   * the settings UI only ever sees origin + username.
+   */
+  readonly setBrowser: (
+    origin: string,
+    username: string,
+    password: string,
+  ) => Effect.Effect<void, CredentialsError>;
+  readonly getBrowser: (
+    origin: string,
+  ) => Effect.Effect<{ username: string; password: string } | null, CredentialsError>;
+  readonly removeBrowser: (
+    origin: string,
+  ) => Effect.Effect<void, CredentialsError>;
+  readonly listBrowser: () => Effect.Effect<
+    ReadonlyArray<{ origin: string; username: string }>,
+    CredentialsError
+  >;
 }
 
 export class CredentialsService extends Context.Tag(

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -15,6 +15,7 @@ import { importWorkspacesJson } from "./persistence/import-workspaces.ts";
 import { MigrationsLive } from "./persistence/migrations.ts";
 import { NdjsonLoggerLive } from "./persistence/ndjson-logger.ts";
 import { SqliteLive } from "./persistence/sqlite.ts";
+import { BrowserBridgeServiceLive } from "./provider/layers/browser-bridge-service.ts";
 import { CredentialsServiceLive } from "./provider/layers/credentials-service.ts";
 import { MessageStoreLive } from "./provider/layers/message-store.ts";
 import { PermissionServiceLive } from "./provider/layers/permission-service.ts";
@@ -155,6 +156,13 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(MigratedSqlite),
   );
 
+  // BrowserBridge brokers between the in-process browser MCP tools (driver
+  // side) and the renderer's `<webview>` (RPC side). Ephemeral — no SQLite.
+  // Same instance is provided to both ProviderLayer (the driver publishes
+  // commands) and Handlers (the renderer subscribes + responds); Effect
+  // memoizes the layer by reference so they share one PubSub + pending map.
+  const BrowserBridgeLayer = BrowserBridgeServiceLive;
+
   // AttachmentService writes uploaded image bytes under userData and runs
   // the GC sweep that reaps orphaned blobs. Disk I/O comes from
   // NodeContext; persistence joins MigratedSqlite. Defined before
@@ -175,6 +183,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(WorkspaceLayer),
     Layer.provide(PermissionLayer),
     Layer.provide(AttachmentLayer),
+    Layer.provide(BrowserBridgeLayer),
     Layer.provide(IndexLayer),
     Layer.provide(NodeContext.layer),
   );
@@ -224,6 +233,9 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(MessageStoreLayer),
     Layer.provide(PermissionLayer),
     Layer.provide(AttachmentLayer),
+    Layer.provide(BrowserBridgeLayer),
+    // browser.* credential RPCs read/write the keychain directly.
+    Layer.provide(CredentialsServiceLive),
     Layer.provide(SkillBridgeLayer),
     Layer.provide(IndexLayer),
     Layer.provide(FolderPickerLayer),

--- a/packages/wire/src/browser.ts
+++ b/packages/wire/src/browser.ts
@@ -1,0 +1,222 @@
+import { Rpc } from "@effect/rpc";
+import { Schema } from "effect";
+
+import { SessionId } from "./session.ts";
+
+/**
+ * In-app agent browser bridge.
+ *
+ * MCP tools run in the server process; the `<webview>` lives in the renderer.
+ * So every agent browser action round-trips server → renderer → server,
+ * mirroring `permission.ts`: the server broadcasts a `BrowserCommandRequest`
+ * on `browser.commands`, the renderer drives the webview, and posts the
+ * outcome back via `browser.respond`, which resolves a server-side Deferred.
+ *
+ * The command union is intentionally small for Phase 1 (navigate + screenshot);
+ * interaction commands (snapshot/click/type/wait) and login land in later
+ * phases as new members — a wire change, never a stringly-typed addition.
+ */
+export const BrowserCommand = Schema.Union(
+  /** Load a URL into the shared in-app webview and wait for it to settle. */
+  Schema.TaggedStruct("Navigate", { url: Schema.String }),
+  /** Capture the visible viewport. The renderer returns a base64 PNG. */
+  Schema.TaggedStruct("Screenshot", {}),
+  /**
+   * Walk the page and return a compact list of interactive/visible elements,
+   * each tagged with a stable `ref` the agent then targets with Click/Type.
+   * Cheaper for the model than a screenshot and robust to scroll/DPI.
+   */
+  Schema.TaggedStruct("Snapshot", {}),
+  /** Click the element carrying this snapshot `ref`. */
+  Schema.TaggedStruct("Click", { ref: Schema.String }),
+  /**
+   * Type into the element with this `ref`. `submit` presses Enter afterward
+   * (e.g. to submit a search box / login form).
+   */
+  Schema.TaggedStruct("Type", {
+    ref: Schema.String,
+    text: Schema.String,
+    submit: Schema.optional(Schema.Boolean),
+  }),
+  /**
+   * Settle after navigation/AJAX. Either wait a fixed `ms`, or poll until a
+   * CSS `selector` appears (whichever is given; selector wins).
+   */
+  Schema.TaggedStruct("Wait", {
+    ms: Schema.optional(Schema.Number),
+    selector: Schema.optional(Schema.String),
+  }),
+  /**
+   * Scroll the page (or a `ref` into view). `direction` moves the viewport;
+   * `ref` (when given) scrolls that element to center instead.
+   */
+  Schema.TaggedStruct("Scroll", {
+    direction: Schema.optional(
+      Schema.Literal("up", "down", "top", "bottom"),
+    ),
+    ref: Schema.optional(Schema.String),
+  }),
+  /** Hover an element by `ref` (reveal menus / tooltips). */
+  Schema.TaggedStruct("Hover", { ref: Schema.String }),
+  /** Choose an option in a <select> by `ref`, matching value or visible label. */
+  Schema.TaggedStruct("Select", { ref: Schema.String, value: Schema.String }),
+  /**
+   * Press a key (Enter, Tab, Escape, ArrowDown, …) on the element `ref`, or on
+   * whatever is focused when `ref` is omitted.
+   */
+  Schema.TaggedStruct("Press", {
+    key: Schema.String,
+    ref: Schema.optional(Schema.String),
+  }),
+  /**
+   * Read the visible text of the page, or of one element when `ref` is given.
+   * Cheaper than a screenshot for confirming content / verifying a flow.
+   */
+  Schema.TaggedStruct("Read", { ref: Schema.optional(Schema.String) }),
+  /** Browser history / reload — back, forward, or reload the current page. */
+  Schema.TaggedStruct("History", {
+    action: Schema.Literal("back", "forward", "reload"),
+  }),
+  /** Return recent console messages + page errors captured since last load. */
+  Schema.TaggedStruct("Console", {}),
+  /**
+   * Autofill + submit the saved (DUMMY/TEST) credentials for this origin.
+   * SECURITY: the command carries ONLY the origin — never the password. The
+   * renderer pulls the secret out-of-band via `browser.fillForOrigin` and
+   * injects it into the page, so the password never enters the agent's tool
+   * args/results or the LLM context.
+   */
+  Schema.TaggedStruct("Login", { origin: Schema.String }),
+);
+export type BrowserCommand = typeof BrowserCommand.Type;
+
+/**
+ * Renderer-visible summary of a saved browser credential. Deliberately omits
+ * the password — the settings UI only ever sees the origin + username, mirroring
+ * the `hasApiKey` boolean exposure for provider API keys.
+ */
+export class BrowserCredentialSummary extends Schema.Class<BrowserCredentialSummary>(
+  "BrowserCredentialSummary",
+)({
+  origin: Schema.String,
+  username: Schema.String,
+}) {}
+
+/**
+ * The actual secret, returned ONLY to the trusted renderer executor when it
+ * handles a `Login` command. Never flows through the agent event stream, a
+ * tool result, or the command broadcast.
+ */
+export class BrowserCredentialSecret extends Schema.Class<BrowserCredentialSecret>(
+  "BrowserCredentialSecret",
+)({
+  username: Schema.String,
+  password: Schema.String,
+}) {}
+
+/**
+ * One outstanding command. `id` is the server-minted handle the renderer
+ * echoes back on `browser.respond`. `sessionId` is the agent session that
+ * issued it — the renderer uses it only for display/attribution today.
+ */
+export class BrowserCommandRequest extends Schema.Class<BrowserCommandRequest>(
+  "BrowserCommandRequest",
+)({
+  id: Schema.String,
+  sessionId: SessionId,
+  command: BrowserCommand,
+}) {}
+
+/**
+ * Renderer's reply for one command. `ok=false` carries a human-readable
+ * `error` the tool surfaces to the agent. Successful results fill the
+ * command-specific optional fields:
+ *   - Navigate   → `url`, `title`
+ *   - Screenshot → `screenshot` (base64 PNG, no data-URL prefix)
+ */
+export class BrowserCommandResult extends Schema.Class<BrowserCommandResult>(
+  "BrowserCommandResult",
+)({
+  id: Schema.String,
+  ok: Schema.Boolean,
+  error: Schema.optional(Schema.String),
+  url: Schema.optional(Schema.String),
+  title: Schema.optional(Schema.String),
+  screenshot: Schema.optional(Schema.String),
+  /** Snapshot → JSON array of `{ ref, role, name, value }`. */
+  snapshot: Schema.optional(Schema.String),
+  /** Click/Type/Scroll/… → short human-readable note for the agent. */
+  detail: Schema.optional(Schema.String),
+  /** Read → page/element text; Console → captured console + error log. */
+  text: Schema.optional(Schema.String),
+}) {}
+
+export class BrowserCommandNotFoundError extends Schema.TaggedError<BrowserCommandNotFoundError>()(
+  "BrowserCommandNotFoundError",
+  { id: Schema.String },
+) {}
+
+// ---------------------------------------------------------------------------
+// RPCs
+// ---------------------------------------------------------------------------
+
+/**
+ * Live stream of pending browser commands. The renderer's BrowserPane
+ * subscribes once (independent of which right-pane tab is active) and
+ * executes each against the webview. Broadcasting once and filtering on the
+ * client mirrors `permission.requests`.
+ */
+export const BrowserCommandsRpc = Rpc.make("browser.commands", {
+  payload: Schema.Struct({}),
+  success: BrowserCommandRequest,
+  stream: true,
+});
+
+/**
+ * Renderer posts the outcome of a command back here; the server resolves the
+ * Deferred the MCP tool handler is awaiting. Fails if the id is unknown
+ * (already resolved, timed out, or from a previous server run).
+ */
+export const BrowserRespondRpc = Rpc.make("browser.respond", {
+  payload: Schema.Struct({ result: BrowserCommandResult }),
+  success: Schema.Void,
+  error: BrowserCommandNotFoundError,
+});
+
+// ---------------------------------------------------------------------------
+// Browser credentials (DUMMY / TEST passwords only — see settings UI warning).
+// Stored in the OS keychain, namespaced by origin. Write-only from the UI's
+// perspective; the password is never returned to the settings UI, only to the
+// renderer's Login executor via `browser.fillForOrigin`.
+// ---------------------------------------------------------------------------
+
+/** Save (or overwrite) the dummy credential for an origin. */
+export const BrowserSetCredentialRpc = Rpc.make("browser.setCredential", {
+  payload: Schema.Struct({
+    origin: Schema.String,
+    username: Schema.String,
+    password: Schema.String,
+  }),
+  success: Schema.Void,
+});
+
+/** List saved credentials (origin + username only — never the password). */
+export const BrowserListCredentialsRpc = Rpc.make("browser.listCredentials", {
+  payload: Schema.Struct({}),
+  success: Schema.Array(BrowserCredentialSummary),
+});
+
+export const BrowserRemoveCredentialRpc = Rpc.make("browser.removeCredential", {
+  payload: Schema.Struct({ origin: Schema.String }),
+  success: Schema.Void,
+});
+
+/**
+ * Renderer-only: fetch the secret for an origin to inject into the page during
+ * a Login command. Returns null when nothing is saved. NEVER call this from any
+ * agent-facing path — the result is the cleartext dummy password.
+ */
+export const BrowserFillForOriginRpc = Rpc.make("browser.fillForOrigin", {
+  payload: Schema.Struct({ origin: Schema.String }),
+  success: Schema.NullOr(BrowserCredentialSecret),
+});

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./agent.ts";
 export * from "./attachment.ts";
+export * from "./browser.ts";
 export * from "./code-index.ts";
 export * from "./composer.ts";
 export * from "./fs.ts";

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -13,6 +13,14 @@ import {
 } from "./agent.ts";
 import { AttachmentTouchRpc, AttachmentUploadRpc } from "./attachment.ts";
 import {
+  BrowserCommandsRpc,
+  BrowserFillForOriginRpc,
+  BrowserListCredentialsRpc,
+  BrowserRemoveCredentialRpc,
+  BrowserRespondRpc,
+  BrowserSetCredentialRpc,
+} from "./browser.ts";
+import {
   IndexFindReferencesRpc,
   IndexListModuleRpc,
   IndexReadChunkRpc,
@@ -211,6 +219,12 @@ export const MemoizeRpcs = RpcGroup.make(
   PermissionListPendingRpc,
   PermissionListDecisionsRpc,
   PermissionRevokeDecisionRpc,
+  BrowserCommandsRpc,
+  BrowserRespondRpc,
+  BrowserSetCredentialRpc,
+  BrowserListCredentialsRpc,
+  BrowserRemoveCredentialRpc,
+  BrowserFillForOriginRpc,
   WorktreeCreateRpc,
   WorktreeListRpc,
   WorktreeGetRpc,

--- a/specs/0.05-MVP/features/agent-browser.md
+++ b/specs/0.05-MVP/features/agent-browser.md
@@ -1,0 +1,135 @@
+# Feature: In-App Agent Browser
+
+Let the agent drive memoize's existing on-screen browser — navigate, read the
+page, click, type, screenshot, and autofill dummy test logins — instead of
+spinning up a separate headless Chrome. Because it's the same `<webview>` the
+user is looking at, every action is visible: a camera **shutter flash** fires
+when the agent takes a screenshot.
+
+## Why this exists
+
+Agent-browser products (e.g. Vercel's) launch a hidden headless Chrome the user
+never sees. memoize already ships a real browser — the "Browser" tab in the
+right pane (`apps/renderer/src/components/browser-pane.tsx`). Reusing it means:
+
+- **No second browser process** — one Chromium, already on screen.
+- **Visible by default** — the user watches the agent work; screenshots flash a
+  shutter so "the agent just looked at the page" is legible.
+- **"Go and verify" flows** — the agent can navigate to a dev server, log in
+  with seeded test credentials, and confirm a change end-to-end.
+
+## Architecture (the one hard fact)
+
+> MCP tools run in the **server** process; the `<webview>` lives in the
+> **renderer**.
+
+So every browser tool round-trips **server → renderer → server**, cloned from
+`PermissionService`: the server broadcasts a `BrowserCommandRequest` on
+`browser.commands`, the renderer drives the webview, and replies on
+`browser.respond`, resolving a server-side `Deferred` (30s timeout backstop so a
+hidden/closed webview can't hang the agent turn).
+
+```
+Claude agent (server)
+  → MCP tool (apps/server/src/provider/drivers/browser-tools.ts)
+    → BrowserBridgeService.send(cmd)            [publish + await Deferred]
+      → browser.commands stream → renderer
+        → BrowserPane drives <webview>          [capturePage / executeJavaScript]
+        ← browser.respond → resolves Deferred
+    ← tool result (text or image block) → agent
+```
+
+Claude-only for v1 — the tools live in Claude's in-process MCP server
+(`createSdkMcpServer`). The bridge is provider-agnostic, so ACP providers
+(Grok/Gemini/Cursor) can be wired later without touching it.
+
+## Tools (all `mcp__memoize__browser_*`)
+
+| Tool | Does | Permission |
+|---|---|---|
+| `browser_navigate` | Load a URL, wait for it to settle | auto-allow |
+| `browser_screenshot` | Capture the viewport → image block + shutter flash | auto-allow |
+| `browser_snapshot` | Compact list of visible interactive elements, each with a stable `ref` | auto-allow |
+| `browser_read` | Read visible page text (or one `ref`), truncated | auto-allow |
+| `browser_scroll` | Scroll viewport (up/down/top/bottom) or a `ref` into view | auto-allow |
+| `browser_hover` | Hover a `ref` to reveal menus/tooltips | auto-allow |
+| `browser_console` | Recent console messages + page errors since last load | auto-allow |
+| `browser_history` | back / forward / reload | auto-allow |
+| `browser_wait` | Settle by `ms` or until a CSS `selector` appears | auto-allow |
+| `browser_click` | Click an element by `ref` | **prompts** |
+| `browser_type` | Type into an element by `ref`, optional submit | **prompts** |
+| `browser_select` | Choose a `<select>` option by `ref` | **prompts** |
+| `browser_press` | Press a key (Enter/Tab/Escape/Arrow…) on a `ref` or focus | **prompts** |
+| `browser_login` | Autofill + submit the saved dummy login for an origin | **always prompts** (even full-access) |
+
+Rule of thumb for permissions: read-only / navigational tools auto-allow; anything
+that mutates page state (`click`, `type`, `select`, `press`) prompts; `login`
+always prompts even in full-access mode.
+
+**Console capture** comes from the webview's `console-message` + `did-fail-load`
+events, buffered per page load (cleared on navigation). It catches `console.*`
+and load failures; uncaught-exception capture beyond that would need an injected
+error hook (follow-up).
+
+**Targeting** uses a DOM/accessibility snapshot (Playwright-style): `browser_snapshot`
+mints stable `data-mz-ref` ids on visible interactive elements; `click`/`type`
+act by `ref`, never by coordinates — robust to scroll, DPI, and responsive
+layout. Refs are regenerated per snapshot.
+
+## Credentials — dummy/test logins ONLY
+
+The credential feature exists for **seeded test logins** on dev/staging sites the
+agent verifies. The settings UI (Settings → Browser) shows a load-bearing
+warning: **never store a real or production password.**
+
+Defense in depth even so:
+- Passwords live in the **OS keychain** (`browserCred:<origin>`, reusing the
+  keytar pattern in `credentials-service.ts`).
+- The `Login` command carries **only the origin**. The renderer pulls the secret
+  out-of-band via `browser.fillForOrigin` (renderer-only RPC) and injects it
+  straight into the page's fields.
+- The password **never enters the LLM context** — not in tool args, tool
+  results, the agent event stream, or the command broadcast. `browser_login`'s
+  result is only `{ ok, detail }` with the password omitted.
+
+## Non-goals (v1)
+
+- Multi-provider (Claude only).
+- Full-page (scrolling) screenshots — viewport only.
+- Cross-origin iframe interaction (executeJavaScript can't reach them).
+- Persisting browser history across renderer reloads.
+- Concurrent sessions sharing the webview — last-command-wins; gate on the
+  active session if it becomes a problem.
+
+## Key files
+
+- Wire: `packages/wire/src/browser.ts` (commands, results, RPCs), registered in `rpc.ts`.
+- Server bridge: `apps/server/src/provider/{services,layers}/browser-bridge-service.ts`.
+- Tools: `apps/server/src/provider/drivers/browser-tools.ts`; registered + policy in `drivers/claude.ts`.
+- RPC handlers: `apps/server/src/provider/handlers.ts`; layer wiring in `runtime.ts`.
+- Credentials: `apps/server/src/provider/{services,layers}/credentials-service.ts` (`browserCred:` namespace).
+- Renderer executor + shutter: `apps/renderer/src/components/browser-pane.tsx`, `browser-shutter.tsx`.
+- Settings UI: `apps/renderer/src/components/settings-page.tsx` (Browser pane).
+- Timeline icons/labels: `apps/renderer/src/components/tool-row.tsx`.
+
+## Risks / verification notes
+
+- **capturePage on a hidden tab** can return empty — mitigated by force-showing
+  the Browser tab on every command + a paint delay before capture. Verify
+  empirically.
+- **Shutter z-order** — the overlay sits above the webview at `z-10`; in current
+  Electron `<webview>` composites in-page so this works, but confirm visually.
+- **MCP image tool results** — `browser_screenshot` returns an MCP `image`
+  content block; confirm Claude receives it as a visible image.
+
+## How to verify end-to-end
+
+1. **Navigate + screenshot**: ask Claude `"open https://example.com and take a
+   screenshot"`. Expect the right pane to switch to Browser, the page to load,
+   a shutter flash, and the agent's reply to reference the screenshot.
+2. **Interact**: point it at a local form; `"fill the email field with
+   test@test.com and submit"`; confirm with a follow-up `browser_snapshot`.
+3. **Auto-login**: add a dummy credential for a local dev app's origin in
+   Settings → Browser; prompt `"log in and verify the dashboard loads"`. Confirm
+   the approval prompt appears, the flow completes, and the password appears
+   nowhere in the session transcript.


### PR DESCRIPTION
## What

Adds an **in-app agent browser**: the agent drives memoize's existing on-screen Electron `<webview>` (the Browser tab) — navigate, read, scroll, click, type, screenshot, autofill dummy logins — instead of spinning up a separate headless Chrome. Because it's the same browser the user is looking at, every action is **visible**, and taking a screenshot fires a camera **shutter flash**.

## Architecture

MCP tools run in the **server**; the `<webview>` lives in the **renderer**. So every command round-trips **server → renderer → server** through a new `BrowserBridgeService` — a near-clone of `PermissionService` (PubSub + `Deferred` + `browser.commands`/`browser.respond` RPCs, 30s timeout backstop so a hidden webview can't hang the agent turn). Claude-only for v1; the bridge itself is provider-agnostic.

```
Claude agent (server) → MCP tool → BrowserBridgeService.send(cmd)
  → browser.commands stream → BrowserPane drives <webview> (capturePage / executeJavaScript)
  ← browser.respond → resolves Deferred → tool result (text or image block)
```

## Tools (14, `mcp__memoize__browser_*`)

`navigate, screenshot, snapshot, read, scroll, hover, console, history (back/forward/reload), wait, click, type, select, press, login`

- **snapshot** mints stable `data-mz-ref` ids on visible interactive elements; click/type/etc. target by ref (Playwright-style), not coordinates.
- **console** buffers `console-message` + `did-fail-load` per page load — lets the agent verify a page is healthy after an action.
- Permissions: read-only/navigational tools auto-allow; state-mutating ones (click/type/select/press) prompt; **login always prompts even in full-access**.

## Credentials — dummy/test logins only

For seeded logins on dev/staging sites the agent verifies. The Settings → Browser pane shows a load-bearing warning: **never store a real password.** Even so: kept in the **OS keychain** (`browserCred:<origin>`), the `Login` command carries **only the origin**, and the renderer pulls the secret out-of-band and injects it straight into the page — **the password never enters the LLM context** (not in tool args/results, the event stream, or the command broadcast).

## Verification status

Typechecks clean across wire, server, renderer, desktop. **Not yet runtime-verified in the Electron app** — three things to confirm live (detailed in the spec):
1. `capturePage` returns a real frame on the just-shown tab (mitigated by force-showing the Browser tab + paint delay).
2. The shutter overlay paints above the `<webview>`.
3. Claude receives the screenshot as a visible MCP image block.

Smoke test: ask Claude *"open https://example.com and take a screenshot"* → tab flips to Browser, page loads, shutter flashes, agent describes the page.

## Not included (would need CDP via `webContents.debugger`)

Network interception/HAR, tracing, profiler, React DevTools, device/geo emulation, multi-tab, annotated screenshots, `eval`, upload, pdf. Natural follow-up is a "CDP tier."

Spec: `specs/0.05-MVP/features/agent-browser.md`