### PR TITLE
[codex] add unit tests

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,7 +18,8 @@
     }
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.126",
@@ -39,6 +40,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@effect/sql-sqlite-bun": "0.52.0",
     "@repo/typescript-config": "*",
     "@types/node": "catalog:",
     "typescript": "catalog:"

--- a/apps/server/test/availability.test.ts
+++ b/apps/server/test/availability.test.ts
@@ -1,8 +1,70 @@
 import { describe, expect, it } from "bun:test";
 
-import { grokAuthTestHelpers } from "./availability.ts";
+import {
+  compareCliVersion,
+  grokAuthTestHelpers,
+  MIN_CODEX_CLI_VERSION,
+  parseCliVersion,
+} from "../src/provider/availability.ts";
 
 const { parseGrokAuthJson, extractTier, decodeJwtPayload } = grokAuthTestHelpers;
+
+describe("parseCliVersion", () => {
+  it("pulls the first dotted triple out of labelled output", () => {
+    expect(parseCliVersion("codex-cli 0.27.0")).toMatchObject({
+      major: 0,
+      minor: 27,
+      patch: 0,
+    });
+    expect(parseCliVersion("1.0.123 (Claude Code)")).toMatchObject({
+      major: 1,
+      minor: 0,
+      patch: 123,
+    });
+  });
+
+  it("ignores pre-release suffixes when extracting the baseline triple", () => {
+    expect(parseCliVersion("2.5.9-beta.3")).toMatchObject({
+      major: 2,
+      minor: 5,
+      patch: 9,
+    });
+  });
+
+  it("retains the trimmed raw string", () => {
+    expect(parseCliVersion("  0.128.0  ")?.raw).toBe("0.128.0");
+  });
+
+  it("returns null for output without a version triple", () => {
+    expect(parseCliVersion("no version here")).toBe(null);
+    expect(parseCliVersion("1.2")).toBe(null); // only a pair, not a triple
+    expect(parseCliVersion("")).toBe(null);
+  });
+});
+
+describe("compareCliVersion", () => {
+  const v = (major: number, minor: number, patch: number) => ({
+    major,
+    minor,
+    patch,
+    raw: `${major}.${minor}.${patch}`,
+  });
+
+  it("orders by major, then minor, then patch", () => {
+    expect(compareCliVersion(v(1, 0, 0), v(0, 9, 9))).toBeGreaterThan(0);
+    expect(compareCliVersion(v(0, 128, 0), v(0, 127, 9))).toBeGreaterThan(0);
+    expect(compareCliVersion(v(0, 27, 1), v(0, 27, 2))).toBeLessThan(0);
+  });
+
+  it("returns 0 for equal versions", () => {
+    expect(compareCliVersion(v(0, 128, 0), v(0, 128, 0))).toBe(0);
+  });
+
+  it("detects an older-than-minimum codex CLI", () => {
+    const old = parseCliVersion("codex-cli 0.27.0")!;
+    expect(compareCliVersion(old, MIN_CODEX_CLI_VERSION)).toBeLessThan(0);
+  });
+});
 
 describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
   it("decodeJwtPayload handles a real-ish JWT payload", () => {

--- a/apps/server/test/fs.test.ts
+++ b/apps/server/test/fs.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+import { ensureUnderCwd, isUnderCwd } from "../src/provider/drivers/acp/fs.ts";
+
+const cwd = "/work/repo";
+
+describe("isUnderCwd", () => {
+  it("accepts the cwd itself and nested paths", () => {
+    expect(isUnderCwd("/work/repo", cwd)).toBe(true);
+    expect(isUnderCwd("/work/repo/src/a.ts", cwd)).toBe(true);
+    expect(isUnderCwd("/work/repo/deep/nested/file", cwd)).toBe(true);
+  });
+
+  it("rejects parent traversal that escapes the cwd", () => {
+    expect(isUnderCwd("/work/repo/../secret", cwd)).toBe(false);
+    expect(isUnderCwd("/work/repo/../../etc/passwd", cwd)).toBe(false);
+  });
+
+  it("rejects sibling directories with a shared prefix", () => {
+    // `/work/repo-evil` shares the `/work/repo` string prefix but is NOT under cwd.
+    expect(isUnderCwd("/work/repo-evil/file", cwd)).toBe(false);
+  });
+
+  it("rejects unrelated absolute paths", () => {
+    expect(isUnderCwd("/etc/passwd", cwd)).toBe(false);
+  });
+
+  it("resolves relative paths against process cwd before comparing", () => {
+    // A traversal that normalizes back under cwd is accepted.
+    expect(isUnderCwd("/work/repo/src/../src/a.ts", cwd)).toBe(true);
+  });
+});
+
+describe("ensureUnderCwd", () => {
+  it("returns the resolved absolute path for in-workspace targets", () => {
+    expect(ensureUnderCwd("/work/repo/src/a.ts", cwd)).toBe(
+      path.resolve("/work/repo/src/a.ts"),
+    );
+  });
+
+  it("throws when the path escapes the workspace", () => {
+    expect(() => ensureUnderCwd("/work/repo/../secret", cwd)).toThrow(
+      /escapes workspace/,
+    );
+    expect(() => ensureUnderCwd("/etc/passwd", cwd)).toThrow(
+      /escapes workspace/,
+    );
+  });
+});

--- a/apps/server/test/grok-auth-noise.test.ts
+++ b/apps/server/test/grok-auth-noise.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+
+import { isIgnorableGrokAuthNoise } from "../src/provider/drivers/acp/grok-auth-noise.ts";
+
+describe("isIgnorableGrokAuthNoise", () => {
+  it("ignores transient AuthorizationRequired chatter (case-insensitive)", () => {
+    const noisy = [
+      "AuthorizationRequired",
+      "Auth(AuthorizationRequired)",
+      "error: AUTHORIZATIONREQUIRED while refreshing token",
+      "Grok authentication failed: AuthorizationRequired",
+      "worker quit with fatal auth error",
+      "transport channel closed (auth refresh)",
+    ];
+    for (const line of noisy) {
+      expect(isIgnorableGrokAuthNoise(line)).toBe(true);
+    }
+  });
+
+  it("does not ignore real errors", () => {
+    const real = [
+      "SyntaxError: unexpected token",
+      "ENOENT: no such file or directory",
+      "grok authentication failed", // missing the AuthorizationRequired co-signal
+      "worker quit with fatal segfault", // fatal but not auth
+      "transport channel closed", // closed but not auth
+      "",
+    ];
+    for (const line of real) {
+      expect(isIgnorableGrokAuthNoise(line)).toBe(false);
+    }
+  });
+});

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from "bun:test";
+import { SqlClient } from "@effect/sql";
+// The server ships on `@effect/sql-sqlite-node` (better-sqlite3), which Bun
+// cannot dlopen. `@effect/sql-sqlite-bun` produces the same generic
+// `SqlClient` tag on top of the built-in `bun:sqlite`, so MessageStoreLive
+// runs unchanged under `bun test`. Test-only — the app keeps the node client.
+import { SqliteClient } from "@effect/sql-sqlite-bun";
+import { Effect, Layer, ManagedRuntime, Schedule, Stream } from "effect";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type {
+  AgentEvent,
+  AgentSessionId,
+  FolderId,
+  SessionId,
+} from "@memoize/wire";
+
+import { NdjsonLogger } from "../src/persistence/ndjson-logger.ts";
+import { Migration0001Initial } from "../src/persistence/migrations/0001_initial.ts";
+import { Migration0002Permissions } from "../src/persistence/migrations/0002_permissions.ts";
+import { Migration0003ResumeAndExport } from "../src/persistence/migrations/0003_resume_and_export.ts";
+import { Migration0004PermissionScope } from "../src/persistence/migrations/0004_permission_scope.ts";
+import { Migration0005RuntimeMode } from "../src/persistence/migrations/0005_runtime_mode.ts";
+import { Migration0006Attachments } from "../src/persistence/migrations/0006_attachments.ts";
+import { Migration0007Subagents } from "../src/persistence/migrations/0007_subagents.ts";
+import { Migration0008WorktreesAndRepoSettings } from "../src/persistence/migrations/0008_worktrees_and_repo_settings.ts";
+import { Migration0009PermissionModeAndToolSearch } from "../src/persistence/migrations/0009_permission_mode_and_tool_search.ts";
+import { Migration0010NestedSessions } from "../src/persistence/migrations/0010_nested_sessions.ts";
+import { Migration0011ChatsTable } from "../src/persistence/migrations/0011_chats_table.ts";
+import { Migration0012ChatIdNotNull } from "../src/persistence/migrations/0012_chat_id_not_null.ts";
+import { WorktreeService } from "../src/worktree/services/worktree-service.ts";
+import { MessageStore } from "../src/provider/services/message-store.ts";
+import { ProviderService } from "../src/provider/services/provider-service.ts";
+import { MessageStoreLive } from "../src/provider/layers/message-store.ts";
+
+const PROJECT_ID = "proj-test" as FolderId;
+
+/**
+ * Scripted provider events the stub replays on `events()` for the next
+ * created session. The MessageStore boot path subscribes to this stream and
+ * persists each renderable event — letting us assert the full
+ * provider-event → messages-table pipeline without a real agent CLI.
+ */
+let scriptedEvents: ReadonlyArray<AgentEvent> = [];
+
+/** A no-op ProviderService: starts/sends succeed; events replay the script. */
+const StubProviderLive = Layer.succeed(ProviderService, {
+  availability: () => Effect.succeed([]),
+  start: (input) =>
+    Effect.succeed({ sessionId: input.sessionId ?? ("stub" as AgentSessionId) }),
+  send: () => Effect.void,
+  interrupt: () => Effect.void,
+  close: () => Effect.void,
+  events: () => Stream.fromIterable(scriptedEvents),
+  setCredential: () => Effect.void,
+  setPermissionMode: () => Effect.void,
+  answerQuestion: () => Effect.void,
+});
+
+/** Worktrees are never used (all sessions run worktreeId=null). */
+const StubWorktreeLive = Layer.succeed(WorktreeService, {
+  create: () => Effect.die("not used"),
+  list: () => Effect.succeed([]),
+  get: () => Effect.succeed(null),
+  remove: () => Effect.void,
+});
+
+/** NdjsonLogger writes audit lines; in tests we swallow them. */
+const StubNdjsonLive = Layer.succeed(NdjsonLogger, {
+  append: () => Effect.void,
+  close: () => Effect.void,
+});
+
+// Run every numbered migration in order against the generic SqlClient. We run
+// them directly instead of via the node `SqliteMigrator` so the schema builds
+// on top of the bun client too — a fresh test DB needs no migration tracking.
+const runAllMigrations = Effect.all(
+  [
+    Migration0001Initial,
+    Migration0002Permissions,
+    Migration0003ResumeAndExport,
+    Migration0004PermissionScope,
+    Migration0005RuntimeMode,
+    Migration0006Attachments,
+    Migration0007Subagents,
+    Migration0008WorktreesAndRepoSettings,
+    Migration0009PermissionModeAndToolSearch,
+    Migration0010NestedSessions,
+    Migration0011ChatsTable,
+    Migration0012ChatIdNotNull,
+  ],
+  { discard: true },
+);
+
+const makeRuntime = (dbPath: string) => {
+  const SqlLive = SqliteClient.layer({ filename: dbPath });
+  // Run migrations during layer build, and re-export SqlClient downstream.
+  const Migrated = Layer.effectDiscard(runAllMigrations).pipe(
+    Layer.provideMerge(SqlLive),
+  );
+  const TestLayer = MessageStoreLive.pipe(
+    Layer.provide(StubProviderLive),
+    Layer.provide(StubWorktreeLive),
+    Layer.provide(StubNdjsonLive),
+    // provideMerge (not provide) so SqlClient stays in the runtime context —
+    // the test seeds the `projects` row through it directly.
+    Layer.provideMerge(Migrated),
+  );
+  return ManagedRuntime.make(TestLayer);
+};
+
+const withRuntime = async <A>(
+  fn: (run: <X>(eff: Effect.Effect<X, unknown, MessageStore | SqlClient.SqlClient>) => Promise<X>) => Promise<A>,
+): Promise<A> => {
+  const dir = mkdtempSync(join(tmpdir(), "mz-msgstore-"));
+  const dbPath = join(dir, "test.sqlite");
+  const runtime = makeRuntime(dbPath);
+  const run = <X>(eff: Effect.Effect<X, unknown, MessageStore | SqlClient.SqlClient>): Promise<X> =>
+    runtime.runPromise(eff as Effect.Effect<X, unknown, never>);
+  try {
+    // Seed the project row through the runtime's own SqlClient.
+    await run(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const now = new Date().toISOString();
+        yield* sql`
+          INSERT INTO projects (id, path, name, created_at, updated_at)
+          VALUES (${PROJECT_ID}, ${"/tmp/project"}, ${"Test"}, ${now}, ${now})
+        `;
+      }),
+    );
+    return await fn(run);
+  } finally {
+    await runtime.dispose();
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+const store = MessageStore;
+
+describe("MessageStore — chat & session lifecycle", () => {
+  it("createChat persists a chat, an initial session, and the user message", async () => {
+    await withRuntime(async (run) => {
+      const result = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+            initialPrompt: "fix the bug",
+          }),
+        ),
+      );
+
+      expect(result.chat.projectId).toBe(PROJECT_ID);
+      expect(result.initialSession.providerId).toBe("claude");
+      expect(result.initialSession.chatId).toBe(result.chat.id);
+      // hasInitial → session boots straight into "running".
+      expect(result.initialSession.status).toBe("running");
+      expect(result.initialMessage?.role).toBe("user");
+      expect(result.initialMessage?.content).toMatchObject({
+        _tag: "user",
+        text: "fix the bug",
+      });
+    });
+  });
+
+  it("listSessions and getSession read the persisted row back", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "grok",
+            model: "grok-code",
+          }),
+        ),
+      );
+
+      const listed = await run(
+        Effect.flatMap(store, (s) => s.listSessions(PROJECT_ID, false)),
+      );
+      expect(listed.map((x) => x.id)).toContain(initialSession.id);
+
+      const got = await run(
+        Effect.flatMap(store, (s) => s.getSession(initialSession.id)),
+      );
+      expect(got.id).toBe(initialSession.id);
+      expect(got.providerId).toBe("grok");
+    });
+  });
+
+  it("getSession fails with SessionNotFoundError for an unknown id", async () => {
+    await withRuntime(async (run) => {
+      const exit = await run(
+        Effect.flatMap(store, (s) =>
+          s.getSession("does-not-exist" as SessionId),
+        ).pipe(Effect.either),
+      );
+      expect(exit._tag).toBe("Left");
+      if (exit._tag === "Left") {
+        expect((exit.left as { _tag: string })._tag).toBe(
+          "SessionNotFoundError",
+        );
+      }
+    });
+  });
+
+  it("renameSession, setRuntimeMode and setPermissionMode persist", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const id = initialSession.id;
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          Effect.all([
+            s.renameSession(id, "Renamed"),
+            s.setRuntimeMode(id, "full-access"),
+            s.setPermissionMode(id, "plan"),
+          ]),
+        ),
+      );
+
+      const got = await run(Effect.flatMap(store, (s) => s.getSession(id)));
+      expect(got.title).toBe("Renamed");
+      expect(got.runtimeMode).toBe("full-access");
+      expect(got.permissionMode).toBe("plan");
+    });
+  });
+
+  it("sendMessage appends a user message to the log", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const id = initialSession.id;
+
+      await run(Effect.flatMap(store, (s) => s.sendMessage(id, "hello there")));
+
+      const messages = await run(
+        Effect.flatMap(store, (s) => s.listMessages(id)),
+      );
+      const user = messages.filter((m) => m.role === "user");
+      expect(user.length).toBeGreaterThanOrEqual(1);
+      expect(user.at(-1)?.content).toMatchObject({
+        _tag: "user",
+        text: "hello there",
+      });
+    });
+  });
+
+  it("archiveSession hides the row unless includeArchived is set", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const id = initialSession.id;
+
+      await run(Effect.flatMap(store, (s) => s.archiveSession(id)));
+
+      const active = await run(
+        Effect.flatMap(store, (s) => s.listSessions(PROJECT_ID, false)),
+      );
+      expect(active.map((x) => x.id)).not.toContain(id);
+
+      const all = await run(
+        Effect.flatMap(store, (s) => s.listSessions(PROJECT_ID, true)),
+      );
+      expect(all.map((x) => x.id)).toContain(id);
+    });
+  });
+});
+
+describe("MessageStore — provider event persistence", () => {
+  it("persists a scripted AssistantMessage event as an assistant message", async () => {
+    scriptedEvents = [
+      { _tag: "AssistantMessage", itemId: "i_a1" as never, text: "all done" },
+      { _tag: "Completed", reason: "ended" },
+    ];
+    try {
+      await withRuntime(async (run) => {
+        const { initialSession } = await run(
+          Effect.flatMap(store, (s) =>
+            s.createChat({
+              projectId: PROJECT_ID,
+              providerId: "claude",
+              model: "claude-opus-4-8",
+              initialPrompt: "go",
+            }),
+          ),
+        );
+        const id = initialSession.id;
+
+        // The event pump is a forked daemon — poll until the assistant row
+        // lands (or give up after a bounded number of tries).
+        const findAssistant = Effect.flatMap(store, (s) =>
+          s.listMessages(id),
+        ).pipe(
+          Effect.map((msgs) => msgs.find((m) => m.role === "assistant")),
+          Effect.flatMap((found) =>
+            found !== undefined
+              ? Effect.succeed(found)
+              : Effect.fail("not yet" as const),
+          ),
+          Effect.retry(
+            Schedule.spaced("10 millis").pipe(
+              Schedule.intersect(Schedule.recurs(100)),
+            ),
+          ),
+          Effect.either,
+        );
+
+        const assistant = await run(findAssistant);
+        expect(assistant._tag).toBe("Right");
+        if (assistant._tag === "Right") {
+          expect(assistant.right.content).toMatchObject({
+            _tag: "assistant",
+            text: "all done",
+          });
+        }
+      });
+    } finally {
+      scriptedEvents = [];
+    }
+  });
+});

--- a/apps/server/test/planMode.test.ts
+++ b/apps/server/test/planMode.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+
+import type { PermissionMode } from "@memoize/wire";
+
+import { applyPlanModePrefix, PLAN_MODE_INSTRUCTIONS } from "../src/provider/drivers/planMode.ts";
+
+describe("applyPlanModePrefix", () => {
+  it("prepends the plan-mode instructions when plan mode is active", () => {
+    const out = applyPlanModePrefix("plan", "fix the bug");
+    expect(out).toBe(`${PLAN_MODE_INSTRUCTIONS}\n\n---\n\nfix the bug`);
+    expect(out.startsWith(PLAN_MODE_INSTRUCTIONS)).toBe(true);
+    expect(out.endsWith("fix the bug")).toBe(true);
+  });
+
+  it("passes the prompt through unchanged outside plan mode", () => {
+    const modes: ReadonlyArray<PermissionMode> = ["default", "acceptEdits"];
+    for (const mode of modes) {
+      expect(applyPlanModePrefix(mode, "fix the bug")).toBe("fix the bug");
+    }
+  });
+
+  it("preserves an empty prompt", () => {
+    expect(applyPlanModePrefix("default", "")).toBe("");
+    expect(applyPlanModePrefix("plan", "")).toBe(
+      `${PLAN_MODE_INSTRUCTIONS}\n\n---\n\n`,
+    );
+  });
+});

--- a/apps/server/test/policy.test.ts
+++ b/apps/server/test/policy.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+
+import type { PermissionMode, RuntimeMode } from "@memoize/wire";
+
+import {
+  getBashPolicy,
+  getFsPolicy,
+  isSensitivePath,
+  SENSITIVE_PATTERNS,
+} from "../src/provider/policy.ts";
+
+const RUNTIME_MODES: ReadonlyArray<RuntimeMode> = [
+  "approval-required",
+  "auto-accept-edits",
+  "auto-accept-edits-and-bash",
+  "full-access",
+];
+
+describe("isSensitivePath", () => {
+  it("matches dotfiles and credential-bearing paths anywhere in the string", () => {
+    const sensitive = [
+      "/repo/.env",
+      "/repo/.env.local",
+      "~/.aws/credentials",
+      "/home/u/.ssh/id_rsa",
+      "/home/u/.ssh/id_ed25519.pub",
+      "/secrets/credentials.json",
+      "credentials",
+      "/certs/server.pem",
+      "/certs/server.key",
+      "/certs/bundle.p12",
+      "/certs/bundle.pfx",
+      "/home/u/.netrc",
+      "/home/u/.pgpass",
+    ];
+    for (const p of sensitive) {
+      expect(isSensitivePath(p)).toBe(true);
+    }
+  });
+
+  it("does not match ordinary source paths", () => {
+    const safe = [
+      "/repo/src/index.ts",
+      "/repo/environment.ts", // not `.env`
+      "/repo/README.md",
+      "/repo/package.json",
+      "/repo/.envrc.example.ts", // `.env` not followed by `.` or end
+      "",
+    ];
+    for (const p of safe) {
+      expect(isSensitivePath(p)).toBe(false);
+    }
+  });
+
+  it("SENSITIVE_PATTERNS is non-empty and drives isSensitivePath", () => {
+    expect(SENSITIVE_PATTERNS.length).toBeGreaterThan(0);
+    expect(SENSITIVE_PATTERNS.some((re) => re.test("/repo/.env"))).toBe(true);
+  });
+});
+
+describe("getFsPolicy", () => {
+  it("forces a prompt on sensitive paths under every runtime mode", () => {
+    for (const mode of RUNTIME_MODES) {
+      const policy = getFsPolicy("write", "/repo/.env", mode);
+      expect(policy).toEqual({ kind: "prompt", forcePrompt: true });
+    }
+  });
+
+  it("auto-allows reads regardless of runtime mode (non-sensitive)", () => {
+    for (const mode of RUNTIME_MODES) {
+      expect(getFsPolicy("read", "/repo/src/a.ts", mode)).toEqual({
+        kind: "auto-allow",
+      });
+    }
+  });
+
+  it("reads of sensitive paths still prompt", () => {
+    expect(getFsPolicy("read", "/repo/.env", "full-access")).toEqual({
+      kind: "prompt",
+      forcePrompt: true,
+    });
+  });
+
+  it("plan mode forces a prompt for mutations even under full-access", () => {
+    const policy = getFsPolicy(
+      "write",
+      "/repo/src/a.ts",
+      "full-access",
+      "plan",
+    );
+    expect(policy).toEqual({ kind: "prompt", forcePrompt: true });
+  });
+
+  it("auto-accept-edits auto-allows non-sensitive mutations", () => {
+    for (const op of ["write", "create", "delete", "move"] as const) {
+      expect(getFsPolicy(op, "/repo/src/a.ts", "auto-accept-edits")).toEqual({
+        kind: "auto-allow",
+      });
+    }
+  });
+
+  it("full-access auto-allows surviving (non-sensitive) mutations", () => {
+    expect(getFsPolicy("write", "/repo/src/a.ts", "full-access")).toEqual({
+      kind: "auto-allow",
+    });
+  });
+
+  it("approval-required prompts (non-force) for non-sensitive mutations", () => {
+    expect(getFsPolicy("write", "/repo/src/a.ts", "approval-required")).toEqual({
+      kind: "prompt",
+      forcePrompt: false,
+    });
+  });
+});
+
+describe("getBashPolicy", () => {
+  it("plan mode always forces a prompt", () => {
+    for (const mode of RUNTIME_MODES) {
+      expect(getBashPolicy("rm -rf /", mode, "plan")).toEqual({
+        kind: "prompt",
+        forcePrompt: true,
+      });
+    }
+  });
+
+  it("full-access auto-allows commands", () => {
+    expect(getBashPolicy("ls", "full-access")).toEqual({ kind: "auto-allow" });
+  });
+
+  it("auto-accept-edits still prompts for bash (only file edits are auto-accepted)", () => {
+    expect(getBashPolicy("ls", "auto-accept-edits")).toEqual({
+      kind: "prompt",
+      forcePrompt: false,
+    });
+  });
+
+  it("approval-required prompts (non-force)", () => {
+    expect(getBashPolicy("ls", "approval-required")).toEqual({
+      kind: "prompt",
+      forcePrompt: false,
+    });
+  });
+
+  it("plan mode wins over full-access", () => {
+    const mode: RuntimeMode = "full-access";
+    const perm: PermissionMode = "plan";
+    expect(getBashPolicy("ls", mode, perm)).toEqual({
+      kind: "prompt",
+      forcePrompt: true,
+    });
+  });
+});

--- a/apps/server/test/translate.test.ts
+++ b/apps/server/test/translate.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "bun:test";
+
+import type { AgentEvent } from "@memoize/wire";
+
+import {
+  createAcpTranslator,
+  translateAcpSessionUpdate,
+} from "../src/provider/drivers/acp/translate.ts";
+
+// Narrowing helpers — the translator returns the AgentEvent union; tests below
+// assert on concrete variants, so pull the tag out and cast for convenience.
+const tags = (events: ReadonlyArray<AgentEvent>): string[] =>
+  events.map((e) => e._tag);
+
+const only = <T extends AgentEvent["_tag"]>(
+  events: ReadonlyArray<AgentEvent>,
+  tag: T,
+): Extract<AgentEvent, { _tag: T }> => {
+  expect(tags(events)).toEqual([tag]);
+  return events[0] as Extract<AgentEvent, { _tag: T }>;
+};
+
+describe("translateAcpSessionUpdate — tool-call normalization", () => {
+  it("maps Grok read_file → canonical Read with file_path", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_call",
+          kind: "read_file",
+          toolCallId: "tc1",
+          locations: [{ path: "/repo/a.ts" }],
+        },
+        "grok",
+      ),
+      "ToolUse",
+    );
+    expect(ev).toEqual({
+      _tag: "ToolUse",
+      itemId: "tc1",
+      tool: "Read",
+      input: { file_path: "/repo/a.ts" },
+    });
+  });
+
+  it("recovers a Grok SearchReplace envelope into a canonical Edit", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_call",
+          kind: "search_replace",
+          toolCallId: "tc2",
+          content: [
+            {
+              type: "SearchReplace",
+              EditsApplied: {
+                absolute_path: "/repo/a.ts",
+                old_string: "foo",
+                new_string: "bar",
+              },
+            },
+          ],
+        },
+        "grok",
+      ),
+      "ToolUse",
+    );
+    expect(ev.tool).toBe("Edit");
+    expect(ev.input).toEqual({
+      file_path: "/repo/a.ts",
+      old_string: "foo",
+      new_string: "bar",
+    });
+  });
+
+  it("maps a Gemini diff block → canonical Edit", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_call",
+          kind: "edit",
+          toolCallId: "tc3",
+          content: [
+            { type: "diff", path: "/repo/b.ts", oldText: "a", newText: "b" },
+          ],
+        },
+        "gemini",
+      ),
+      "ToolUse",
+    );
+    expect(ev.tool).toBe("Edit");
+    expect(ev.input).toEqual({
+      file_path: "/repo/b.ts",
+      old_string: "a",
+      new_string: "b",
+    });
+  });
+
+  it("maps a Bash command and folds title into description", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_call",
+          kind: "bash",
+          toolCallId: "tc4",
+          command: "ls -la",
+          title: "List files",
+        },
+        "grok",
+      ),
+      "ToolUse",
+    );
+    expect(ev.tool).toBe("Bash");
+    expect(ev.input).toEqual({ command: "ls -la", description: "List files" });
+  });
+
+  it("normalizes unknown tool kinds into a Title Case label", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        { sessionUpdate: "tool_call", kind: "list_dir", toolCallId: "tc5" },
+        "grok",
+      ),
+      "ToolUse",
+    );
+    expect(ev.tool).toBe("ListDir");
+  });
+
+  it("uses the call id from any of the accepted id fields", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        { sessionUpdate: "tool_call", kind: "read", call_id: "snake_id" },
+        "grok",
+      ),
+      "ToolUse",
+    );
+    expect(ev.itemId).toBe("snake_id");
+  });
+});
+
+describe("translateAcpSessionUpdate — result normalization", () => {
+  it("decodes Grok byte-array stdout into UTF-8 text", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_result",
+          toolCallId: "g1",
+          output: { stdout: [72, 105], stderr: [] }, // "Hi"
+        },
+        "grok",
+      ),
+      "ToolResult",
+    );
+    expect(ev.output).toBe("Hi");
+    expect(ev.isError).toBe(false);
+  });
+
+  it("strips Grok N→ line markers from FileContent results", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_result",
+          toolCallId: "r1",
+          output: { type: "ReadFile", FileContent: { content: "1→hello\n2→world" } },
+        },
+        "grok",
+      ),
+      "ToolResult",
+    );
+    expect(ev.output).toBe("hello\nworld");
+  });
+
+  it("flattens nested MCP content blocks to a plain string", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_result",
+          toolCallId: "m1",
+          content: [{ type: "content", content: { type: "text", text: "body" } }],
+        },
+        "grok",
+      ),
+      "ToolResult",
+    );
+    expect(ev.output).toBe("body");
+  });
+
+  it("maps is_error / failed status onto isError", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        {
+          sessionUpdate: "tool_result",
+          toolCallId: "e1",
+          is_error: true,
+          output: "boom",
+        },
+        "grok",
+      ),
+      "ToolResult",
+    );
+    expect(ev.isError).toBe(true);
+    expect(ev.output).toBe("boom");
+  });
+});
+
+describe("createAcpTranslator — assistant + thinking coalescing", () => {
+  it("buffers agent_message_chunk deltas and flushes one AssistantMessage", () => {
+    const t = createAcpTranslator("grok");
+    expect(t.translate({ sessionUpdate: "agent_message_chunk", content: "Hello " })).toEqual(
+      [],
+    );
+    expect(t.translate({ sessionUpdate: "agent_message_chunk", content: "world" })).toEqual(
+      [],
+    );
+    const flushed = only(t.flush(), "AssistantMessage");
+    expect(flushed.text).toBe("Hello world");
+  });
+
+  it("flushes buffered text before the next non-text event, preserving order", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({ sessionUpdate: "agent_message_chunk", content: "intro" });
+    const out = t.translate({
+      sessionUpdate: "tool_call",
+      kind: "read",
+      toolCallId: "x1",
+      locations: [{ path: "/a.ts" }],
+    });
+    expect(tags(out)).toEqual(["AssistantMessage", "ToolUse"]);
+    expect((out[0] as Extract<AgentEvent, { _tag: "AssistantMessage" }>).text).toBe(
+      "intro",
+    );
+  });
+
+  it("coalesces thinking chunks into one Thinking event", () => {
+    const t = createAcpTranslator("gemini");
+    expect(t.translate({ sessionUpdate: "agent_thought_chunk", content: "think " })).toEqual(
+      [],
+    );
+    expect(t.translate({ sessionUpdate: "agent_thought_chunk", content: "more" })).toEqual(
+      [],
+    );
+    const ev = only(t.flush(), "Thinking");
+    expect(ev.text).toBe("think more");
+    expect(ev.redacted).toBe(false);
+  });
+
+  it("strips Grok's echoed-prompt prefix from the first thinking chunk", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({
+      sessionUpdate: "agent_thought_chunk",
+      content: 'The user says: "do X" Now I need to plan the real approach here',
+    });
+    const ev = only(t.flush(), "Thinking");
+    expect(ev.text).not.toContain("The user says");
+    expect(ev.text).toContain("Now I need to plan");
+  });
+});
+
+describe("createAcpTranslator — tool_call_update dedup & re-emit", () => {
+  it("skips a tool_call_update whose input is unchanged", () => {
+    const t = createAcpTranslator("cursor");
+    const first = t.translate({
+      sessionUpdate: "tool_call",
+      kind: "read",
+      toolCallId: "d1",
+      locations: [{ path: "/a.ts" }],
+    });
+    expect(tags(first)).toEqual(["ToolUse"]);
+    // Same locations, no content, no terminal status → nothing new to emit.
+    const second = t.translate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "d1",
+      locations: [{ path: "/a.ts" }],
+    });
+    expect(second).toEqual([]);
+  });
+
+  it("re-emits ToolUse when a diff first appears on an Edit update", () => {
+    const t = createAcpTranslator("cursor");
+    t.translate({
+      sessionUpdate: "tool_call",
+      kind: "edit",
+      toolCallId: "e1",
+      locations: [{ path: "/c.ts" }],
+    });
+    const update = t.translate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "e1",
+      content: [{ type: "diff", path: "/c.ts", oldText: "x", newText: "y" }],
+    });
+    const ev = only(update, "ToolUse");
+    expect(ev.tool).toBe("Edit");
+    expect(ev.input).toEqual({
+      file_path: "/c.ts",
+      old_string: "x",
+      new_string: "y",
+    });
+  });
+
+  it("remembers the tool name across update frames that omit kind (Cursor)", () => {
+    const t = createAcpTranslator("cursor");
+    t.translate({
+      sessionUpdate: "tool_call",
+      kind: "read",
+      toolCallId: "c1",
+      rawInput: { path: "/repo/x.ts" },
+    });
+    const result = t.translate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "c1",
+      status: "completed",
+      content: [{ type: "content", content: { type: "text", text: "file body" } }],
+    });
+    const ev = only(result, "ToolResult");
+    expect(ev.output).toBe("file body");
+    expect(ev.isError).toBe(false);
+  });
+
+  it("emits ToolResult once when status flips to completed even without content", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({
+      sessionUpdate: "tool_call",
+      kind: "bash",
+      toolCallId: "b1",
+      command: "true",
+    });
+    const done = t.translate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "completed",
+    });
+    expect(tags(done)).toEqual(["ToolResult"]);
+    // A late duplicate terminal update must not stack a second result row.
+    const late = t.translate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "b1",
+      status: "completed",
+    });
+    expect(late).toEqual([]);
+  });
+});
+
+describe("createAcpTranslator — per-provider quirks & errors", () => {
+  it("skips Gemini's internal `think` tool call (surfaced via thinking chunks)", () => {
+    expect(
+      translateAcpSessionUpdate(
+        { sessionUpdate: "tool_call", kind: "think", toolCallId: "t1" },
+        "gemini",
+      ),
+    ).toEqual([]);
+  });
+
+  it("ignores transient Grok auth-noise error frames", () => {
+    expect(
+      translateAcpSessionUpdate(
+        { sessionUpdate: "error", message: "Auth(AuthorizationRequired)" },
+        "grok",
+      ),
+    ).toEqual([]);
+  });
+
+  it("surfaces a real error frame as an Error event", () => {
+    const ev = only(
+      translateAcpSessionUpdate(
+        { sessionUpdate: "error", message: "disk full" },
+        "gemini",
+      ),
+      "Error",
+    );
+    expect(ev.message).toBe("disk full");
+  });
+
+  it("returns no events for unknown / ignored update kinds", () => {
+    expect(
+      translateAcpSessionUpdate({ sessionUpdate: "current_mode_update" }, "cursor"),
+    ).toEqual([]);
+    expect(translateAcpSessionUpdate(null, "grok")).toEqual([]);
+    expect(translateAcpSessionUpdate({ noKindHere: true }, "grok")).toEqual([]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -160,6 +160,7 @@
         "zod": "^4.0.0",
       },
       "devDependencies": {
+        "@effect/sql-sqlite-bun": "0.52.0",
         "@repo/typescript-config": "*",
         "@types/node": "catalog:",
         "typescript": "catalog:",
@@ -412,6 +413,8 @@
     "@effect/rpc": ["@effect/rpc@0.75.1", "http://registry.npmjs.org/@effect/rpc/-/rpc-0.75.1.tgz", { "dependencies": { "msgpackr": "^1.11.10" }, "peerDependencies": { "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg=="],
 
     "@effect/sql": ["@effect/sql@0.51.1", "http://registry.npmjs.org/@effect/sql/-/sql-0.51.1.tgz", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA=="],
+
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@0.52.0", "", { "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-iqQ7SvSNxq0HLjKW5IQ29FsCTzOD1CuX1wuBEuPLLgPCvuEykEHLn4zDrs2qJ+O3CBEUm4kiCy29tmfHE7uAdw=="],
 
     "@effect/sql-sqlite-node": ["@effect/sql-sqlite-node@0.52.0", "http://registry.npmjs.org/@effect/sql-sqlite-node/-/sql-sqlite-node-0.52.0.tgz", { "dependencies": { "better-sqlite3": "^12.6.2" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-yijDbly4MwxAPebvd2ZBI62qDpGdXKL96drMzflXDnjEh2JiVr/xVyy1VB0JsVxqw8IJ9TUIgOvAJWQ88oVMXA=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",
+    "test": "turbo run test",
     "rebuild:pty": "cd apps/desktop && electron-rebuild -f -w node-pty",
     "dist:mac": "bun run build:desktop && cd apps/desktop && bun run dist:mac",
     "dist:mac:unsigned": "bun run build:desktop && cd apps/desktop && bun run dist:mac:unsigned"

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -13,7 +13,8 @@
     }
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@effect/rpc": "catalog:",

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+import { Schema } from "effect";
+
+import { AgentEvent, Chat, Message, Session } from "../src/index.ts";
+
+/**
+ * These guard the renderer↔server wire contract: every payload that crosses
+ * the RPC boundary is encoded to plain JSON on one side and decoded on the
+ * other. A round-trip (decode∘encode) that isn't the identity, or a schema
+ * that silently accepts malformed input, is a contract break.
+ */
+
+const roundTrip = <A, I>(schema: Schema.Schema<A, I>, encoded: I): void => {
+  const decoded = Schema.decodeUnknownSync(schema)(encoded);
+  const reEncoded = Schema.encodeSync(schema)(decoded);
+  expect(reEncoded).toEqual(encoded);
+};
+
+describe("AgentEvent round-trips", () => {
+  const cases: ReadonlyArray<{ name: string; encoded: unknown }> = [
+    {
+      name: "Started",
+      encoded: { _tag: "Started", sessionId: "s1", providerId: "claude", mode: "sdk" },
+    },
+    {
+      name: "Status",
+      encoded: { _tag: "Status", status: "running" },
+    },
+    {
+      name: "AssistantMessage",
+      encoded: { _tag: "AssistantMessage", itemId: "i1", text: "hello" },
+    },
+    {
+      name: "Thinking",
+      encoded: { _tag: "Thinking", itemId: "i2", text: "hmm", redacted: false },
+    },
+    {
+      name: "ToolUse (unknown input survives)",
+      encoded: {
+        _tag: "ToolUse",
+        itemId: "i3",
+        tool: "Edit",
+        input: { file_path: "/a.ts", old_string: "x", new_string: "y" },
+      },
+    },
+    {
+      name: "ToolResult",
+      encoded: { _tag: "ToolResult", itemId: "i4", output: "done", isError: false },
+    },
+    {
+      name: "Error",
+      encoded: { _tag: "Error", message: "boom" },
+    },
+    {
+      name: "UsageDelta",
+      encoded: {
+        _tag: "UsageDelta",
+        inputTokens: 10,
+        outputTokens: 20,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        model: "claude-opus-4-8",
+      },
+    },
+    {
+      name: "Completed",
+      encoded: { _tag: "Completed", reason: "ended" },
+    },
+  ];
+
+  for (const c of cases) {
+    it(`round-trips ${c.name}`, () => {
+      roundTrip(AgentEvent, c.encoded as never);
+    });
+  }
+
+  it("rejects an event with no _tag", () => {
+    expect(() => Schema.decodeUnknownSync(AgentEvent)({ text: "no tag" })).toThrow();
+  });
+
+  it("rejects an unknown _tag", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(AgentEvent)({ _tag: "Nonsense" }),
+    ).toThrow();
+  });
+
+  it("rejects a known event missing a required field", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(AgentEvent)({ _tag: "ToolResult", itemId: "i", output: "o" }),
+    ).toThrow(); // isError missing
+  });
+
+  it("rejects an invalid enum literal", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(AgentEvent)({ _tag: "Status", status: "spinning" }),
+    ).toThrow();
+  });
+});
+
+describe("Session round-trip", () => {
+  const encoded = {
+    id: "sess1",
+    projectId: "proj1",
+    title: "My session",
+    providerId: "claude",
+    model: "claude-opus-4-8",
+    status: "idle" as const,
+    archivedAt: null,
+    cursor: null,
+    resumeStrategy: "none" as const,
+    runtimeMode: "approval-required" as const,
+    worktreeId: null,
+    chatId: "chat1",
+    forkedFromSessionId: null,
+    forkedFromMessageId: null,
+    permissionMode: "default" as const,
+    toolSearch: false,
+    createdAt: "2026-06-17T00:00:00.000Z",
+    updatedAt: "2026-06-17T00:00:00.000Z",
+  };
+
+  it("decodes dates and re-encodes them as ISO strings", () => {
+    const session = Schema.decodeUnknownSync(Session)(encoded);
+    expect(session.createdAt).toBeInstanceOf(Date);
+    expect(Schema.encodeSync(Session)(session)).toEqual(encoded);
+  });
+
+  it("round-trips an archived session", () => {
+    roundTrip(Session, {
+      ...encoded,
+      archivedAt: "2026-06-17T12:00:00.000Z",
+      cursor: "claude-session-abc",
+      resumeStrategy: "claude-session-id" as const,
+    });
+  });
+
+  it("rejects an unknown status literal", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(Session)({ ...encoded, status: "zombie" }),
+    ).toThrow();
+  });
+});
+
+describe("Message round-trip", () => {
+  const base = {
+    id: "msg1",
+    sessionId: "sess1",
+    createdAt: "2026-06-17T00:00:00.000Z",
+  };
+
+  it("round-trips a user message", () => {
+    roundTrip(Message, {
+      ...base,
+      role: "user" as const,
+      content: { _tag: "user", text: "hi" },
+    });
+  });
+
+  it("round-trips a tool_use message with unknown input", () => {
+    roundTrip(Message, {
+      ...base,
+      role: "assistant" as const,
+      content: {
+        _tag: "tool_use",
+        itemId: "i1",
+        tool: "Bash",
+        input: { command: "ls" },
+      },
+    });
+  });
+
+  it("rejects an unknown content _tag", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(Message)({
+        ...base,
+        role: "user",
+        content: { _tag: "telepathy", text: "hi" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Chat round-trip", () => {
+  it("round-trips a chat row", () => {
+    roundTrip(Chat, {
+      id: "chat1",
+      projectId: "proj1",
+      worktreeId: null,
+      title: "Chat",
+      activeSessionId: "sess1",
+      archivedAt: null,
+      createdAt: "2026-06-17T00:00:00.000Z",
+      updatedAt: "2026-06-17T00:00:00.000Z",
+    });
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,10 @@
     "check-types": {
       "dependsOn": ["^check-types"]
     },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary
- add Bun test scripts for the server and wire packages and wire them into the root turbo test task
- move and expand provider availability tests with CLI version parsing coverage
- add server unit tests for filesystem containment, Grok auth noise filtering, message store persistence, plan mode prefixing, policy decisions, and ACP translation
- add wire schema round-trip and validation coverage

## Validation
- bun run test