### PR TITLE
[codex] Polish markdown rendering

### DIFF
--- a/apps/renderer/src/components/code-block.tsx
+++ b/apps/renderer/src/components/code-block.tsx
@@ -2,14 +2,81 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   createHighlighter,
   type BundledLanguage,
-  type BundledTheme,
   type Highlighter,
+  type ThemeRegistration,
 } from "shiki";
 
 import { cn } from "~/lib/utils";
+import { CopyButton } from "./copy-button.tsx";
 import { FileIcon } from "./file-icon.tsx";
 
-const THEME: BundledTheme = "github-dark-dimmed";
+const THEME = "memoize-dark" as const;
+
+const MEMOIZE_SHIKI_THEME: ThemeRegistration = {
+  name: THEME,
+  type: "dark",
+  colors: {
+    "editor.background": "#00000000",
+    "editor.foreground": "#e4e4e7",
+    "editorLineNumber.foreground": "#71717a",
+    "editor.selectionBackground": "#a855f72e",
+  },
+  tokenColors: [
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: { foreground: "#71717a", fontStyle: "italic" },
+    },
+    {
+      scope: ["keyword", "storage", "storage.type", "constant.language"],
+      settings: { foreground: "#c084fc" },
+    },
+    {
+      scope: ["string", "constant.character", "markup.inline.raw.string"],
+      settings: { foreground: "#86efac" },
+    },
+    {
+      scope: ["constant.numeric", "constant.language.boolean"],
+      settings: { foreground: "#fbbf24" },
+    },
+    {
+      scope: ["entity.name.function", "support.function", "variable.function"],
+      settings: { foreground: "#7dd3fc" },
+    },
+    {
+      scope: [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class",
+      ],
+      settings: { foreground: "#67e8f9" },
+    },
+    {
+      scope: ["entity.other.attribute-name", "variable.parameter"],
+      settings: { foreground: "#fda4af" },
+    },
+    {
+      scope: ["entity.name.tag", "support.class.component"],
+      settings: { foreground: "#f87171" },
+    },
+    {
+      scope: ["punctuation", "meta.brace", "keyword.operator"],
+      settings: { foreground: "#a1a1aa" },
+    },
+    {
+      scope: ["markup.heading", "entity.name.section"],
+      settings: { foreground: "#fafafa", fontStyle: "bold" },
+    },
+    {
+      scope: ["markup.link", "string.other.link"],
+      settings: { foreground: "#7dd3fc", fontStyle: "underline" },
+    },
+    {
+      scope: ["invalid", "invalid.illegal"],
+      settings: { foreground: "#f87171" },
+    },
+  ],
+};
 
 /** Languages we eagerly load on highlighter init. Anything outside this set
  *  renders as plain text — Shiki throws if asked to highlight an unloaded
@@ -80,6 +147,42 @@ const langForExtension = (ext: string): BundledLanguage | null => {
   }
 };
 
+const LANG_ALIASES: Readonly<Record<string, BundledLanguage>> = {
+  cjs: "js",
+  mjs: "js",
+  javascript: "js",
+  jsx: "jsx",
+  mdx: "md",
+  markdown: "md",
+  py: "python",
+  python3: "python",
+  rs: "rust",
+  rust: "rust",
+  shell: "bash",
+  shellscript: "bash",
+  sh: "bash",
+  zsh: "bash",
+  typescript: "ts",
+  yml: "yaml",
+};
+
+const langForLanguage = (
+  language: string | undefined,
+): BundledLanguage | null => {
+  if (language === undefined) return null;
+  const normalized = language
+    .trim()
+    .toLowerCase()
+    .replace(/^language-/, "");
+  if (normalized.length === 0) return null;
+  const aliased = LANG_ALIASES[normalized];
+  if (aliased !== undefined) return aliased;
+  if (LANGS.includes(normalized as BundledLanguage)) {
+    return normalized as BundledLanguage;
+  }
+  return langForExtension(normalized);
+};
+
 const langForFilename = (filename: string): BundledLanguage | null => {
   const slash = filename.lastIndexOf("/");
   const base = slash === -1 ? filename : filename.slice(slash + 1);
@@ -100,7 +203,7 @@ const basename = (p: string): string => {
 let highlighterPromise: Promise<Highlighter> | null = null;
 const getHighlighter = (): Promise<Highlighter> => {
   highlighterPromise ??= createHighlighter({
-    themes: [THEME],
+    themes: [MEMOIZE_SHIKI_THEME],
     langs: [...LANGS],
   });
   return highlighterPromise;
@@ -114,6 +217,8 @@ const MAX_HIGHLIGHT_BYTES = 200_000;
 interface Props {
   readonly filename: string;
   readonly text: string;
+  readonly language?: string;
+  readonly title?: string;
   readonly maxHeight?: number;
   readonly isError?: boolean;
 }
@@ -128,10 +233,15 @@ interface Props {
 export function CodeBlock({
   filename,
   text,
+  language,
+  title,
   maxHeight = 420,
   isError = false,
 }: Props) {
-  const lang = useMemo(() => langForFilename(filename), [filename]);
+  const lang = useMemo(
+    () => langForLanguage(language) ?? langForFilename(filename),
+    [filename, language],
+  );
   const safeText = useMemo(
     () =>
       text.length > MAX_HIGHLIGHT_BYTES
@@ -176,7 +286,7 @@ export function CodeBlock({
     };
   }, [safeText, lang]);
 
-  const name = basename(filename);
+  const name = title ?? basename(filename);
   const lineCount = safeText.length === 0 ? 0 : safeText.split("\n").length;
 
   return (
@@ -192,15 +302,22 @@ export function CodeBlock({
           kind="file"
           className="inline-flex size-3.5 shrink-0 items-center justify-center"
         />
-        <span className="truncate font-mono text-foreground/80">{name}</span>
-        <span className="ml-auto tabular-nums opacity-70">
+        <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">
+          {name}
+        </span>
+        <CopyButton
+          text={text}
+          label={`Copy ${name}`}
+          className="size-5 rounded text-muted-foreground/60 hover:bg-muted/60"
+        />
+        <span className="tabular-nums opacity-70">
           {lineCount} {lineCount === 1 ? "line" : "lines"}
         </span>
       </div>
       <div
         ref={hostRef}
         className={cn(
-          "code-block-scroll overflow-auto bg-zinc-900/70 text-[12px] leading-[1.3]",
+          "code-block-scroll overflow-auto bg-message-pre-bg text-[12px] leading-[1.3]",
           isError ? "bg-alert-error-bg/40" : undefined,
         )}
         style={{ maxHeight }}

--- a/apps/renderer/src/components/copy-button.tsx
+++ b/apps/renderer/src/components/copy-button.tsx
@@ -1,0 +1,45 @@
+import { Check, Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { cn } from "~/lib/utils";
+
+export function CopyButton({
+  text,
+  label = "Copy",
+  className,
+}: {
+  readonly text: string;
+  readonly label?: string;
+  readonly className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(id);
+  }, [copied]);
+
+  const onCopy = () => {
+    void navigator.clipboard?.writeText(text).then(() => setCopied(true));
+  };
+
+  const Icon = copied ? Check : Copy;
+  const title = copied ? "Copied" : label;
+
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      aria-label={title}
+      title={title}
+      className={cn(
+        "inline-grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground/70 outline-none",
+        "hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    >
+      <Icon className="size-3.5" aria-hidden="true" />
+    </button>
+  );
+}

--- a/apps/renderer/src/components/markdown-body.tsx
+++ b/apps/renderer/src/components/markdown-body.tsx
@@ -1,5 +1,33 @@
+import { isValidElement, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+import { cn } from "~/lib/utils";
+
+import { CodeBlock } from "./code-block.tsx";
+
+const languageFromClassName = (className: unknown): string | undefined => {
+  if (typeof className !== "string") return undefined;
+  const match = /(?:^|\s)language-([^\s]+)/.exec(className);
+  return match?.[1];
+};
+
+const textFromReactNode = (node: ReactNode): string => {
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") {
+    return String(node);
+  }
+  if (Array.isArray(node)) return node.map(textFromReactNode).join("");
+  return "";
+};
+
+const codeChildFromPre = (node: ReactNode): ReactNode => {
+  if (isValidElement(node) && node.type === "code") return node;
+  if (Array.isArray(node)) {
+    return node.find((child) => isValidElement(child) && child.type === "code");
+  }
+  return undefined;
+};
 
 /**
  * Shared markdown surface for PR descriptions, comments, review bodies, and
@@ -13,9 +41,15 @@ import remarkGfm from "remark-gfm";
  * browser. Non-http schemes (e.g. `memoize://attachments/...`) are left to
  * their own handlers.
  */
-export function MarkdownBody({ children }: { children: string }) {
+export function MarkdownBody({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
   return (
-    <div className="fz-prose">
+    <div className={cn("fz-prose", className)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
@@ -27,12 +61,41 @@ export function MarkdownBody({ children }: { children: string }) {
                 if (typeof href !== "string") return;
                 if (!/^https?:\/\//i.test(href)) return;
                 e.preventDefault();
-                window.memoize?.app.openExternal(href);
+                window.memoize?.app?.openExternal(href);
               }}
             >
               {children}
             </a>
           ),
+          pre: ({ children }) => {
+            const codeChild = codeChildFromPre(children);
+            if (!isValidElement(codeChild)) {
+              return <pre>{children}</pre>;
+            }
+
+            const codeProps = codeChild.props as {
+              className?: string;
+              children?: ReactNode;
+            };
+            const language = languageFromClassName(codeProps.className);
+            const text = textFromReactNode(codeProps.children).replace(
+              /\n$/,
+              "",
+            );
+            const filename =
+              language === undefined ? "snippet.txt" : `snippet.${language}`;
+
+            return (
+              <div className="markdown-code-block">
+                <CodeBlock
+                  filename={filename}
+                  language={language}
+                  text={text}
+                  maxHeight={360}
+                />
+              </div>
+            );
+          },
         }}
       >
         {children}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -25,6 +25,7 @@ import { cn } from "~/lib/utils";
 import { useMessagesStore, type ChatError } from "~/store/messages";
 import { useUiStore } from "~/store/ui";
 
+import { CopyButton } from "./copy-button.tsx";
 import { FileChip } from "./file-chip.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
 import {
@@ -81,7 +82,12 @@ export function MessageRow({
         />
       );
     case "assistant":
-      return <AssistantBubble text={message.content.text} />;
+      return (
+        <AssistantBubble
+          text={message.content.text}
+          createdAt={message.createdAt}
+        />
+      );
     case "thinking":
       return (
         <ThinkingRow
@@ -170,6 +176,12 @@ const stripChipTokens = (
   return out.replace(/[ \t]{2,}/g, " ").trim();
 };
 
+const formatMessageTime = (date: Date): string =>
+  date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
 function UserBubble({
   text,
   attachments,
@@ -191,8 +203,13 @@ function UserBubble({
   const truncate = (name: string): string =>
     name.length > 28 ? `${name.slice(0, 25)}...` : name;
   return (
-    <div className="flex justify-end px-4 py-2">
-      <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 text-sm text-user-bubble-foreground">
+    <div className="group/message flex justify-end px-4 py-2">
+      <div className="relative max-w-[80%] rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 pr-9 text-sm text-user-bubble-foreground">
+        <CopyButton
+          text={display || text}
+          label="Copy message"
+          className="absolute right-2 top-1.5 size-5 text-user-bubble-foreground/50 opacity-60 hover:bg-background/10 hover:text-user-bubble-foreground hover:opacity-100 focus-visible:opacity-100"
+        />
         {hasChips ? (
           <div className="mb-1.5 flex flex-wrap items-center gap-1.5">
             {(attachments ?? []).map((a) => {
@@ -273,11 +290,27 @@ function UserBubble({
   );
 }
 
-function AssistantBubble({ text }: { text: string }) {
+function AssistantBubble({
+  text,
+  createdAt,
+}: {
+  text: string;
+  createdAt?: Date;
+}) {
   return (
     <div className="px-4 py-2">
       <div className="max-w-[88%]">
         <MarkdownBody>{text}</MarkdownBody>
+        <div className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          {createdAt !== undefined ? (
+            <span className="tabular-nums">{formatMessageTime(createdAt)}</span>
+          ) : null}
+          <CopyButton
+            text={text}
+            label="Copy message"
+            className="size-5 rounded opacity-70 hover:opacity-100"
+          />
+        </div>
       </div>
     </div>
   );
@@ -389,11 +422,7 @@ const isGeminiAcpUpgradeError = (text: string): boolean =>
     text,
   );
 
-function GeminiUpgradeCard({
-  onDismiss,
-}: {
-  onDismiss?: () => void;
-}) {
+function GeminiUpgradeCard({ onDismiss }: { onDismiss?: () => void }) {
   const [copied, setCopied] = useState(false);
   const copyCommand = () => {
     void navigator.clipboard.writeText(GEMINI_UPGRADE_COMMAND).then(() => {
@@ -512,7 +541,9 @@ export function ErrorBubble({
   const headline =
     error.kind === "auth"
       ? `Sign in to ${
-          error.providerId ? PROVIDER_LABEL_FOR_ERROR[error.providerId] : "your provider"
+          error.providerId
+            ? PROVIDER_LABEL_FOR_ERROR[error.providerId]
+            : "your provider"
         }`
       : error.kind === "network"
         ? "Connection lost"
@@ -546,7 +577,9 @@ export function ErrorBubble({
             {headline !== null ? (
               <span className="font-medium text-foreground">{headline}</span>
             ) : (
-              <span className="font-medium text-foreground">Provider error</span>
+              <span className="font-medium text-foreground">
+                Provider error
+              </span>
             )}
             <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
               {error.message || "(empty)"}

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -1,19 +1,13 @@
-import {
-  ClipboardIcon,
-  Robot01Icon,
-} from "@hugeicons/core-free-icons";
+import { ClipboardIcon, Robot01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type {
-  AgentItemId,
-  Message,
-  UserQuestionAnswer,
-} from "@memoize/wire";
+import type { AgentItemId, Message, UserQuestionAnswer } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 
+import { CopyButton } from "./copy-button.tsx";
 import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
 
 const MODEL_LABEL: Record<string, string> = {
@@ -190,9 +184,16 @@ function PromptRow({ text }: { text: string }) {
       </button>
       {expanded ? (
         <div className="ml-7 mt-1 max-w-2xl border-l border-border/60 pl-3 pr-1">
-          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px] text-foreground/80">
-            {text || "(empty)"}
-          </pre>
+          <div className="group/prompt relative">
+            <CopyButton
+              text={text}
+              label="Copy prompt"
+              className="absolute right-1.5 top-1.5 opacity-60 hover:opacity-100 focus-visible:opacity-100"
+            />
+            <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded border border-message-rule bg-message-pre-bg px-3 py-2 pr-9 font-mono text-[11px] text-foreground/80">
+              {text || "(empty)"}
+            </pre>
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -18,8 +18,6 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 
 import type {
   SessionId,
@@ -93,10 +91,19 @@ export const iconForTool = (tool: string): IconHandle => {
       // wired an exact case for yet. "list dir", "read file", "run shell"
       // etc. will now get a reasonable icon instead of the generic wrench.
       const t = tool.toLowerCase();
-      if (t.includes("dir") || t.includes("folder") || t.includes("list")) return Folder01Icon;
-      if (t.includes("file") || t.includes("read") || t.includes("write")) return File01Icon;
-      if (t.includes("bash") || t.includes("shell") || t.includes("cmd") || t.includes("exec")) return TerminalIcon;
-      if (t.includes("search") || t.includes("grep") || t.includes("glob")) return SearchIcon;
+      if (t.includes("dir") || t.includes("folder") || t.includes("list"))
+        return Folder01Icon;
+      if (t.includes("file") || t.includes("read") || t.includes("write"))
+        return File01Icon;
+      if (
+        t.includes("bash") ||
+        t.includes("shell") ||
+        t.includes("cmd") ||
+        t.includes("exec")
+      )
+        return TerminalIcon;
+      if (t.includes("search") || t.includes("grep") || t.includes("glob"))
+        return SearchIcon;
       if (t.includes("web") || t.includes("http")) return GlobeIcon;
       return Wrench01Icon;
     }
@@ -195,9 +202,7 @@ function InlineCodeChip({ value }: { value: string }) {
 
 function InlineTextHint({ value }: { value: string }) {
   return (
-    <span className="ml-1 truncate text-muted-foreground italic">
-      {value}
-    </span>
+    <span className="ml-1 truncate text-muted-foreground italic">{value}</span>
   );
 }
 
@@ -213,10 +218,10 @@ function TerminalBlock({
   return (
     <div
       className={cn(
-        "rounded px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
+        "overflow-x-auto rounded border px-3 py-2 font-mono text-[11px] leading-relaxed",
         isError
-          ? "bg-alert-error-bg"
-          : "bg-zinc-900/70",
+          ? "border-alert-error-bg bg-alert-error-bg"
+          : "border-message-rule bg-message-pre-bg",
       )}
     >
       {command !== undefined ? (
@@ -286,7 +291,7 @@ function DirTreeBlock({ text }: { text: string }) {
     );
   }
   return (
-    <pre className="overflow-x-auto rounded bg-zinc-900/70 px-3 py-2 font-mono text-[11px] leading-relaxed">
+    <pre className="overflow-x-auto rounded border border-message-rule bg-message-pre-bg px-3 py-2 font-mono text-[11px] leading-relaxed">
       {lines.map((line, i) => {
         const isDir = line.trimEnd().endsWith("/");
         return (
@@ -321,7 +326,7 @@ function GrepGroupsBlock({
         <div key={i} className="space-y-0.5">
           <FileBadge path={g.path} />
           {g.matches.length > 0 ? (
-            <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded bg-zinc-900/70 px-3 py-1.5 font-mono text-[11px] text-foreground/80">
+            <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded border border-message-rule bg-message-pre-bg px-3 py-1.5 font-mono text-[11px] text-foreground/80">
               {g.matches.join("\n")}
             </pre>
           ) : null}
@@ -332,27 +337,17 @@ function GrepGroupsBlock({
 }
 
 function MarkdownBlock({ text }: { text: string }) {
-  return (
-    <div className="prose prose-invert prose-sm max-w-none break-words text-[12px] [&>:first-child]:mt-0 [&>:last-child]:mb-0 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_pre>code]:bg-transparent [&_pre>code]:p-0">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
-    </div>
-  );
+  return <MarkdownBody className="text-[12px]">{text}</MarkdownBody>;
 }
 
-function PreBlock({
-  text,
-  isError,
-}: {
-  text: string;
-  isError?: boolean;
-}) {
+function PreBlock({ text, isError }: { text: string; isError?: boolean }) {
   return (
     <pre
       className={cn(
-        "overflow-x-auto whitespace-pre-wrap break-words rounded px-3 py-2 font-mono text-[11px] text-foreground/80",
+        "overflow-x-auto whitespace-pre-wrap break-words rounded border px-3 py-2 font-mono text-[11px] text-foreground/80",
         isError
-          ? "bg-alert-error-bg"
-          : "bg-zinc-900/70",
+          ? "border-alert-error-bg bg-alert-error-bg"
+          : "border-message-rule bg-message-pre-bg",
       )}
     >
       {text || "(empty)"}
@@ -367,7 +362,10 @@ function PreBlock({
 const splitLines = (s: string): ReadonlyArray<string> => {
   const trimmed = s.trim();
   if (trimmed.length === 0) return [];
-  return trimmed.split("\n").map((line) => line.trim()).filter((l) => l.length > 0);
+  return trimmed
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((l) => l.length > 0);
 };
 
 // Grep / Glob results are usually one path per line, sometimes followed
@@ -515,9 +513,10 @@ const buildToolView = (
         icon: TerminalIcon,
         label: desc ?? "Bash",
         trailing:
-          cmd !== null ? <InlineCodeChip value={truncate(cmd, 120)} /> : undefined,
-        inputPanel:
-          cmd !== null ? <TerminalBlock command={cmd} /> : undefined,
+          cmd !== null ? (
+            <InlineCodeChip value={truncate(cmd, 120)} />
+          ) : undefined,
+        inputPanel: cmd !== null ? <TerminalBlock command={cmd} /> : undefined,
         resultPanel: (result) => (
           <TerminalBlock
             output={toResultText(result.output) || "(no output)"}
@@ -525,9 +524,7 @@ const buildToolView = (
           />
         ),
         fallbackBody:
-          cmd === null ? (
-            <PreBlock text={stringifyJson(input)} />
-          ) : undefined,
+          cmd === null ? <PreBlock text={stringifyJson(input)} /> : undefined,
       };
     }
 
@@ -574,11 +571,7 @@ const buildToolView = (
             );
           }
           return (
-            <CodeBlock
-              filename={path}
-              text={text}
-              isError={result.isError}
-            />
+            <CodeBlock filename={path} text={text} isError={result.isError} />
           );
         },
       };
@@ -666,11 +659,13 @@ const buildToolView = (
           pattern !== null ? (
             <div className="text-[11px] text-muted-foreground space-y-0.5">
               <div>
-                pattern <span className="font-mono text-foreground/90">{pattern}</span>
+                pattern{" "}
+                <span className="font-mono text-foreground/90">{pattern}</span>
               </div>
               {where !== null ? (
                 <div>
-                  scope <span className="font-mono text-foreground/90">{where}</span>
+                  scope{" "}
+                  <span className="font-mono text-foreground/90">{where}</span>
                 </div>
               ) : null}
             </div>
@@ -833,10 +828,7 @@ const buildToolView = (
             );
           }
           return (
-            <PreBlock
-              text={truncate(text, 4000)}
-              isError={result.isError}
-            />
+            <PreBlock text={truncate(text, 4000)} isError={result.isError} />
           );
         },
       };
@@ -858,7 +850,8 @@ const buildToolView = (
                 if (t === null || typeof t !== "object")
                   return <li key={i}>{stringifyJson(t)}</li>;
                 const r = t as Record<string, unknown>;
-                const content = asString(r.content) ?? asString(r.activeForm) ?? "";
+                const content =
+                  asString(r.content) ?? asString(r.activeForm) ?? "";
                 const status = asString(r.status) ?? "";
                 return (
                   <li key={i} className="font-mono">
@@ -897,7 +890,9 @@ const buildToolView = (
             )}
             {promptText && (
               <div className="rounded border bg-muted/30 p-1.5 font-mono text-[11px] leading-snug">
-                {promptText.length > 280 ? promptText.slice(0, 277) + "…" : promptText}
+                {promptText.length > 280
+                  ? promptText.slice(0, 277) + "…"
+                  : promptText}
               </div>
             )}
             {receivers.length > 0 && (
@@ -915,7 +910,9 @@ const buildToolView = (
         ),
         resultPanel: (result) => (
           <PreBlock
-            text={toResultText(result.output) || stringifyJson(obj.agentsStates)}
+            text={
+              toResultText(result.output) || stringifyJson(obj.agentsStates)
+            }
             isError={result.isError}
           />
         ),
@@ -962,7 +959,10 @@ const buildToolView = (
         label: "Read page",
         trailing: <InlineTextHint value="elements" />,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -974,7 +974,10 @@ const buildToolView = (
         label: "Click",
         trailing: ref !== null ? <InlineTextHint value={ref} /> : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -989,7 +992,10 @@ const buildToolView = (
             <InlineTextHint value={truncate(typed, 48)} />
           ) : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1029,9 +1035,14 @@ const buildToolView = (
         icon: BrowserIcon,
         label: "Select",
         trailing:
-          value !== null ? <InlineTextHint value={truncate(value, 40)} /> : undefined,
+          value !== null ? (
+            <InlineTextHint value={truncate(value, 40)} />
+          ) : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1050,7 +1061,10 @@ const buildToolView = (
         icon: File01Icon,
         label: "Read page",
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1073,7 +1087,10 @@ const buildToolView = (
         icon: TerminalIcon,
         label: "Console",
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1088,7 +1105,10 @@ const buildToolView = (
             <InlineTextHint value={truncate(origin, 48)} />
           ) : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1192,9 +1212,7 @@ export function ExitPlanModeRow({
           <div className="mt-4 flex items-center justify-end gap-2">
             <button
               type="button"
-              onClick={() =>
-                void decide(pendingRequest.id, { _tag: "Deny" })
-              }
+              onClick={() => void decide(pendingRequest.id, { _tag: "Deny" })}
               className="rounded-md px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
             >
               Cancel
@@ -1218,9 +1236,7 @@ export function ExitPlanModeRow({
   const body = (
     <>
       {plan === null ? (
-        <p className="text-sm italic text-muted-foreground">
-          (No plan body.)
-        </p>
+        <p className="text-sm italic text-muted-foreground">(No plan body.)</p>
       ) : (
         <MarkdownBody>{plan}</MarkdownBody>
       )}
@@ -1474,10 +1490,10 @@ export function ThinkingRow({
     </p>
   ) : isEmpty ? (
     <p className="whitespace-pre-wrap text-[11px] italic leading-relaxed text-muted-foreground/70">
-      The model produced a thinking block (the SDK forwarded its signed
-      receipt) but the underlying text was filtered out by Anthropic's
-      agent SDK before it reached us. We can&apos;t expose the actual
-      thoughts without bypassing the official SDK.
+      The model produced a thinking block (the SDK forwarded its signed receipt)
+      but the underlying text was filtered out by Anthropic's agent SDK before
+      it reached us. We can&apos;t expose the actual thoughts without bypassing
+      the official SDK.
     </p>
   ) : (
     <MarkdownBlock text={text} />

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -1,24 +1,17 @@
-import {
-  BubbleChatIcon,
-  Wrench01Icon,
-} from "@hugeicons/core-free-icons";
+import { BubbleChatIcon, Wrench01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 
-import type {
-  AgentItemId,
-  Message,
-  UserQuestionAnswer,
-} from "@memoize/wire";
+import type { AgentItemId, Message, UserQuestionAnswer } from "@memoize/wire";
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { cn } from "~/lib/utils";
 
+import { CopyButton } from "./copy-button.tsx";
 import { FileBadge } from "./file-badge.tsx";
 import { diffStats, extractEdits } from "./inline-diff.tsx";
+import { MarkdownBody } from "./markdown-body.tsx";
 import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { iconForTool } from "./tool-row.tsx";
@@ -56,9 +49,7 @@ const aggregateFileStats = (body: ReadonlyArray<Message>): FileStat[] => {
   return Array.from(map.entries()).map(([path, s]) => ({ path, ...s }));
 };
 
-const findFinalAssistant = (
-  body: ReadonlyArray<Message>,
-): Message | null => {
+const findFinalAssistant = (body: ReadonlyArray<Message>): Message | null => {
   for (let i = body.length - 1; i >= 0; i--) {
     const m = body[i]!;
     if (m.content._tag === "assistant") return m;
@@ -81,10 +72,7 @@ export function TurnSummary({
 }: {
   body: ReadonlyArray<Message>;
   resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
-  answersByItemId?: ReadonlyMap<
-    AgentItemId,
-    ReadonlyArray<UserQuestionAnswer>
-  >;
+  answersByItemId?: ReadonlyMap<AgentItemId, ReadonlyArray<UserQuestionAnswer>>;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -95,8 +83,7 @@ export function TurnSummary({
   const messageCount = useMemo(
     () =>
       body.filter(
-        (m) =>
-          m.content._tag === "thinking" || m.content._tag === "assistant",
+        (m) => m.content._tag === "thinking" || m.content._tag === "assistant",
       ).length,
     [body],
   );
@@ -221,12 +208,11 @@ export function TurnSummary({
         </div>
       ) : null}
 
-      {finalAssistant !== null && finalAssistant.content._tag === "assistant" ? (
+      {finalAssistant !== null &&
+      finalAssistant.content._tag === "assistant" ? (
         <div className="px-4 py-2">
-          <div className="fz-prose max-w-[88%]">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {finalAssistant.content.text}
-            </ReactMarkdown>
+          <div className="max-w-[88%]">
+            <MarkdownBody>{finalAssistant.content.text}</MarkdownBody>
           </div>
         </div>
       ) : null}
@@ -238,6 +224,14 @@ export function TurnSummary({
         )}
       >
         <span className="tabular-nums">{formatElapsed(duration)}</span>
+        {finalAssistant !== null &&
+        finalAssistant.content._tag === "assistant" ? (
+          <CopyButton
+            text={finalAssistant.content.text}
+            label="Copy message"
+            className="size-5 rounded opacity-70 hover:opacity-100"
+          />
+        ) : null}
         {fileStats.map((f) => (
           <span key={f.path} className="flex items-center gap-1.5 tabular-nums">
             <FileBadge path={f.path} />

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -272,9 +272,9 @@ body,
   --user-bubble-foreground: oklch(0.22 0.01 260);
   --message-text: oklch(0.28 0.008 260);
   --message-heading: oklch(0.18 0.01 260);
-  --message-code: oklch(0.42 0.05 30);
-  --message-code-bg: oklch(0.95 0.006 260);
-  --message-pre-bg: oklch(0.97 0.005 260);
+  --message-code: oklch(0.36 0.065 122);
+  --message-code-bg: oklch(0.945 0.012 122);
+  --message-pre-bg: oklch(0.965 0.004 260);
   --message-quote: oklch(0.46 0.01 260);
   --message-rule: oklch(0.88 0.005 260);
 }
@@ -370,9 +370,9 @@ body,
   --user-bubble-foreground: oklch(0.96 0.005 260);
   --message-text: oklch(0.78 0.006 260);
   --message-heading: oklch(0.88 0.006 260);
-  --message-code: oklch(0.82 0.04 60);
-  --message-code-bg: oklch(0.28 0.008 260);
-  --message-pre-bg: oklch(0.235 0.006 260);
+  --message-code: oklch(0.84 0.085 122);
+  --message-code-bg: oklch(0.265 0.012 122);
+  --message-pre-bg: oklch(0.225 0.006 260);
   --message-quote: oklch(0.66 0.008 260);
   --message-rule: oklch(1 0 0 / 0.08);
 }
@@ -430,18 +430,36 @@ body,
     --diffs-modified-light: oklch(0.7 0.13 80);
     --diffs-modified-dark: oklch(0.82 0.11 82);
 
-    --diffs-bg-addition-override:
-      color-mix(in oklab, var(--diffs-added-dark) 10%, var(--background));
-    --diffs-bg-addition-emphasis-override:
-      color-mix(in oklab, var(--diffs-added-dark) 20%, var(--background));
-    --diffs-bg-addition-number-override:
-      color-mix(in oklab, var(--diffs-added-dark) 14%, var(--bg-subtle));
-    --diffs-bg-deletion-override:
-      color-mix(in oklab, var(--diffs-deleted-dark) 10%, var(--background));
-    --diffs-bg-deletion-emphasis-override:
-      color-mix(in oklab, var(--diffs-deleted-dark) 20%, var(--background));
-    --diffs-bg-deletion-number-override:
-      color-mix(in oklab, var(--diffs-deleted-dark) 14%, var(--bg-subtle));
+    --diffs-bg-addition-override: color-mix(
+      in oklab,
+      var(--diffs-added-dark) 10%,
+      var(--background)
+    );
+    --diffs-bg-addition-emphasis-override: color-mix(
+      in oklab,
+      var(--diffs-added-dark) 20%,
+      var(--background)
+    );
+    --diffs-bg-addition-number-override: color-mix(
+      in oklab,
+      var(--diffs-added-dark) 14%,
+      var(--bg-subtle)
+    );
+    --diffs-bg-deletion-override: color-mix(
+      in oklab,
+      var(--diffs-deleted-dark) 10%,
+      var(--background)
+    );
+    --diffs-bg-deletion-emphasis-override: color-mix(
+      in oklab,
+      var(--diffs-deleted-dark) 20%,
+      var(--background)
+    );
+    --diffs-bg-deletion-number-override: color-mix(
+      in oklab,
+      var(--diffs-deleted-dark) 14%,
+      var(--bg-subtle)
+    );
 
     /* Typography — same monospace token as the rest of the app, slightly
        smaller than Pierre's default so a diff doesn't dwarf the chat. */
@@ -459,7 +477,7 @@ body,
   .fz-prose {
     color: var(--message-text);
     font-size: 0.9rem;
-    line-height: 1.65;
+    line-height: 1.62;
     word-break: break-word;
   }
   .fz-prose > :first-child {
@@ -480,8 +498,8 @@ body,
     color: var(--message-heading);
     font-weight: 600;
     line-height: 1.3;
-    letter-spacing: -0.01em;
-    margin: 1.4em 0 0.5em;
+    letter-spacing: 0;
+    margin: 1.35em 0 0.45em;
   }
   .fz-prose h1 {
     font-size: 1.4em;
@@ -502,13 +520,14 @@ body,
     font-weight: 600;
   }
   .fz-prose a {
-    color: var(--info);
+    color: color-mix(in oklch, var(--info) 78%, var(--foreground));
     text-decoration: underline;
-    text-decoration-color: color-mix(in srgb, var(--info), transparent 60%);
+    text-decoration-color: color-mix(in oklch, var(--info) 36%, transparent);
     text-underline-offset: 0.2em;
   }
   .fz-prose a:hover {
-    text-decoration-color: var(--info);
+    color: color-mix(in oklch, var(--info) 88%, var(--foreground));
+    text-decoration-color: color-mix(in oklch, var(--info) 68%, transparent);
   }
   .fz-prose ul,
   .fz-prose ol {
@@ -523,8 +542,9 @@ body,
   }
   .fz-prose blockquote {
     margin: 0.8em 0;
-    padding: 0.1em 0 0.1em 0.9em;
-    border-left: 2px solid var(--message-rule);
+    padding: 0.2em 0 0.2em 0.9em;
+    border-left: 2px solid
+      color-mix(in oklch, var(--primary) 36%, var(--message-rule));
     color: var(--message-quote);
     font-style: normal;
   }
@@ -537,12 +557,21 @@ body,
     font-family: var(--font-mono);
     font-size: 0.86em;
     color: var(--message-code);
-    background-color: var(--message-code-bg);
-    padding: 0.1em 0.35em;
+    background-color: color-mix(
+      in oklch,
+      var(--message-code-bg) 84%,
+      var(--background)
+    );
+    border: 1px solid color-mix(in oklch, var(--message-rule) 72%, transparent);
+    padding: 0.08em 0.34em;
     border-radius: 0.3rem;
   }
   .fz-prose pre {
-    background-color: var(--message-pre-bg);
+    background-color: color-mix(
+      in oklch,
+      var(--message-pre-bg) 90%,
+      var(--background)
+    );
     border: 1px solid var(--message-rule);
     border-radius: 0.5rem;
     padding: 0.85em 1em;
@@ -554,6 +583,20 @@ body,
   .fz-prose pre code {
     color: var(--message-text);
     background: transparent;
+    border: 0;
+    padding: 0;
+    font-size: inherit;
+  }
+  .fz-prose .markdown-code-block {
+    margin: 0.9em 0;
+  }
+  .fz-prose .markdown-code-block code,
+  .fz-prose .markdown-code-block pre code,
+  .fz-prose .code-block-shiki code {
+    color: inherit;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
     padding: 0;
     font-size: inherit;
   }
@@ -573,9 +616,9 @@ body,
     color: var(--message-heading);
     font-weight: 600;
     background-color: color-mix(
-      in srgb,
-      var(--message-pre-bg),
-      transparent 40%
+      in oklch,
+      var(--message-pre-bg) 72%,
+      var(--background)
     );
   }
 }
@@ -766,7 +809,13 @@ body,
     margin: 0;
     padding: 6px 0;
     background: transparent !important;
-    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-family: var(
+      --font-mono,
+      ui-monospace,
+      SFMono-Regular,
+      Menlo,
+      monospace
+    );
     font-size: 12px;
     line-height: 1.3;
     counter-reset: line;
@@ -787,7 +836,8 @@ body,
     width: 2em;
     margin-right: 0.6em;
     text-align: right;
-    color: rgba(255, 255, 255, 0.25);
+    color: var(--text-faint);
+    opacity: 0.58;
     user-select: none;
   }
   /* Scrollbar polish — match xterm-viewport style. */


### PR DESCRIPTION
## Summary
- retheme markdown prose and fenced code blocks to use Memoize renderer tokens instead of stock prose/Shiki styling
- route markdown fences through the shared `CodeBlock` renderer with a custom Memoize Shiki theme
- add reusable copy affordances for code blocks, prompts, user messages, and agent messages, with agent-message copy controls placed beside the time/footer metadata

## Impact
- Assistant, PR, plan, and tool markdown now share a more consistent app-native visual treatment.
- Code blocks have consistent chrome, syntax colors, scrolling, line counts, and copy behavior.
- Agent and prompt text can be copied without selecting text manually.

## Validation
- `bun run --filter=renderer build` passes
- `git diff --check` passes
- `bun run --filter=renderer check-types` still fails on pre-existing unrelated `OpenFile` / `file-editor` type errors in `app.tsx`, `file-tree.tsx`, and `file-editor.tsx`
