### PR TITLE
[codex] Allow X Premium+ Grok access

### DIFF
--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -20,7 +20,7 @@ import { StepHeader } from "./shared.tsx";
 const SUBSCRIPTION_INFO: Partial<
   Record<ProviderId, { readonly plan: string; readonly url: string }>
 > = {
-  grok: { plan: "SuperGrok Heavy", url: "https://grok.com/#subscribe" },
+  grok: { plan: "SuperGrok or X Premium+", url: "https://x.ai/cli" },
   cursor: { plan: "Cursor Pro", url: "https://cursor.com/pricing" },
 };
 
@@ -59,7 +59,7 @@ type ProviderState =
   | { readonly kind: "missing" } // CLI not installed
   | { readonly kind: "outdated"; readonly current: string; readonly required: string; readonly command: string | null } // installed but below SDK floor
   | { readonly kind: "signed-out" } // CLI installed, not logged in, no API key
-  | { readonly kind: "subscription"; readonly plan: string } // logged in but missing required paid plan (e.g. SuperGrok Heavy)
+  | { readonly kind: "subscription"; readonly plan: string } // logged in but missing required paid plan (e.g. SuperGrok or X Premium+)
   | { readonly kind: "ready"; readonly via: "cli" | "key" };
 
 function deriveState(
@@ -85,7 +85,7 @@ function deriveState(
   }
 
   // For subscription-gated providers (grok, cursor), the server-side probe
-  // (parseGrokAuthJson etc.) sets authLabel to "Requires SuperGrok Heavy"
+  // (parseGrokAuthJson etc.) sets authLabel to "Requires SuperGrok or X Premium+"
   // (or equivalent) when the JWT tier is insufficient, even if cliLoggedIn
   // is true. We surface this as a distinct state so onboarding no longer
   // lies to paying users who already have the plan.

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -60,14 +60,14 @@ const LOGIN_HINT: Record<ProviderId, string> = {
 /**
  * Providers that have a known paid-plan requirement for full agent usage.
  * For Grok we now decode the `tier` claim from `~/.grok/auth.json` JWT:
- *   - tier >= 5 → authLabel = "SuperGrok Heavy" (positive, shows plan, toggle works)
- *   - lower / unknown → authLabel = "Requires SuperGrok Heavy" → violet nag + disabled
+ *   - tier >= 4 → authLabel = "Grok subscription" (positive, shows plan, toggle works)
+ *   - lower / unknown → authLabel = "Requires SuperGrok or X Premium+" → violet nag + disabled
  * The frontend only forces the subscription alarm/disable when the label contains "Requires".
  */
 const SUBSCRIPTION_INFO: Partial<
   Record<ProviderId, { readonly plan: string; readonly url: string }>
 > = {
-  grok: { plan: "SuperGrok Heavy", url: "https://grok.com/#subscribe" },
+  grok: { plan: "SuperGrok or X Premium+", url: "https://x.ai/cli" },
   cursor: { plan: "Cursor Pro", url: "https://cursor.com/pricing" },
   claude: {
     plan: "Claude Pro",
@@ -289,7 +289,7 @@ const openExternal = (url: string) => {
 
 /**
  * Subscription / plan notice for providers that gate behind a paid tier
- * (Grok → SuperGrok Heavy, Cursor → Cursor Pro).
+ * (Grok → SuperGrok or X Premium+, Cursor → Cursor Pro).
  *
  * - If the server probe reports an unmet requirement (authLabel contains
  *   "Requires"), we show the strong violet alarm box + Subscribe CTA.

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -684,9 +684,8 @@ function ProvidersPane() {
             .filter((pid) => {
               // Hide providers the user has toggled off. Cursor is still
               // excluded because it has an unconditional subscription gate.
-              // Grok is allowed once the user has a real login (the probe
-              // now surfaces email from auth.json and does not force a
-              // "Requires..." label).
+              // Grok is allowed once the probe confirms a usable paid tier,
+              // including X Premium+.
               if (providerEnabled[pid] === false) return false;
               if (pid === "cursor") return false;
               return true;

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -120,14 +120,13 @@ function ProviderOverrideSection({
   const isOverridden = defaultProviderId !== null || defaultModel !== null;
 
   // Mirror the global "Default agent" filter: skip providers the user
-  // toggled off, and skip the subscription-gated ones (Grok → SuperGrok
-  // Heavy, Cursor → Cursor Pro) so we don't let the user pick something
-  // that can't actually launch a session.
+  // toggled off. Cursor is still excluded because its CLI does not expose
+  // enough plan information for us to distinguish signed-in from usable.
   const availableProviders = (
     ["claude", "codex", "grok", "gemini", "cursor", "opencode"] as const
   ).filter((pid) => {
     if (providerEnabled[pid] === false) return false;
-    if (pid === "grok" || pid === "cursor") return false;
+    if (pid === "cursor") return false;
     return true;
   });
 

--- a/apps/renderer/src/lib/provider-status.ts
+++ b/apps/renderer/src/lib/provider-status.ts
@@ -11,7 +11,7 @@ export const PROVIDER_STATUS_STYLES = {
   error: { dot: "bg-rose-400" },
   disabled: { dot: "bg-muted-foreground/40" },
   loading: { dot: "bg-muted-foreground/40 animate-pulse" },
-  // Subscription-gated providers (Grok → SuperGrok Heavy) — distinct from
+  // Subscription-gated providers (Grok → SuperGrok or X Premium+) — distinct from
   // amber "sign in required" because the user already signed in; their
   // plan is what's missing.
   subscription: { dot: "bg-violet-400" },

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -400,11 +400,12 @@ interface GrokAuthEntry {
 }
 
 /**
- * Minimum `tier` value from the xAI OIDC JWT that includes SuperGrok Heavy
- * (the plan required for full Grok coding agent / `grok agent stdio` access).
- * Lower tiers will be treated as "requires subscription" (disabled + nag).
+ * Minimum `tier` value from the xAI OIDC JWT that includes Grok Build CLI
+ * access. xAI now exposes Grok Build to SuperGrok and X Premium+ subscribers;
+ * locally-observed X Premium+ tokens carry tier 4, while older SuperGrok Heavy
+ * tokens carried tier 5+.
  */
-const MIN_SUPERGROK_HEAVY_TIER = 5;
+const MIN_GROK_BUILD_TIER = 4;
 
 /** Base64url decode + parse a JWT payload (no signature verification). */
 const decodeJwtPayload = (jwt: string): Record<string, unknown> | null => {
@@ -511,10 +512,10 @@ const parseGrokAuthJson = (raw: string): AccountInfo => {
         );
       }
       if (typeof tierFound === "number") {
-        if (tierFound >= MIN_SUPERGROK_HEAVY_TIER) {
-          authLabel = "SuperGrok Heavy";
+        if (tierFound >= MIN_GROK_BUILD_TIER) {
+          authLabel = "Grok subscription";
         } else {
-          authLabel = "Requires SuperGrok Heavy";
+          authLabel = "Requires SuperGrok or X Premium+";
         }
       }
       // else: we have a token but no usable tier claim → non-blocking "Grok"
@@ -553,8 +554,8 @@ export const grokAuthTestHelpers = {
 // after `grok login`. We parse the JWT to read the `tier` claim and decide the
 // plan status (best-effort only — the ACP binary is the source of truth):
 //
-// - tier >= 5 → "SuperGrok Heavy"   (nice label, toggle enabled)
-// - tier < 5  → "Requires SuperGrok Heavy" (violet nag + disabled)
+// - tier >= 4 → "Grok subscription"   (nice label, toggle enabled)
+// - tier < 4  → "Requires SuperGrok or X Premium+" (violet nag + disabled)
 // - token present but tier unreadable / missing / new shape → "Grok" (non-blocking)
 //   The runtime will surface the precise AuthorizationRequired if the account
 //   truly lacks the agent entitlement.

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -100,7 +100,7 @@ const GROK_DIAG = process.env.MEMOIZE_DEBUG_GROK === "1" || process.env.MEMOIZE_
 // the slightly longer "Your cached login may have expired...") never diverge.
 export const GROK_AUTH_REQUIRED_MESSAGE =
   "Grok authentication failed (AuthorizationRequired). " +
-  "Run `grok login` again or verify that your account has the SuperGrok Heavy plan. " +
+  "Run `grok login` again or verify that your account has SuperGrok or X Premium+. " +
   "If the problem persists after logging in, check your plan at https://x.ai/.";
 
 /** Always-on diagnostic helper. Use for anything that helps root-cause "it stops". */
@@ -121,7 +121,7 @@ const grokDiag = (label: string, data?: unknown): void => {
 
 /**
  * Detect fatal authorization failures from the grok agent's own stderr.
- * When the cached token is missing/expired/insufficient (SuperGrok Heavy
+ * When the cached token is missing/expired/insufficient (Grok paid tier
  * tier required), the agent prints:
  *   "worker quit with fatal: Transport channel closed, when Auth(AuthorizationRequired)"
  * and dies. We watch for this in real time so we can fail the in-flight
@@ -301,7 +301,7 @@ export const startGrokSession = (
     let spawnedAt = 0;
     /** Re-spawn the grok child and re-run the ACP handshake. Used both for
      *  the initial start() path and for transparent recovery after the
-     *  worker dies (auth refresh races, the SuperGrok Heavy worker quitting
+     *  worker dies (auth refresh races, the Grok worker quitting
      *  mid-session, etc). On success: child/rl/acpSessionId/authMethodUsed
      *  are populated, dead=false, listeners attached. On failure the
      *  returned promise rejects and the caller decides whether to surface

--- a/apps/server/test/availability.test.ts
+++ b/apps/server/test/availability.test.ts
@@ -89,20 +89,20 @@ describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
     expect(extractTier({ a: { b: { weird_tier: "8" } } })).toBe(8);
   });
 
-  it("parseGrokAuthJson returns SuperGrok Heavy for tier >= 5", () => {
+  it("parseGrokAuthJson accepts X Premium+ / SuperGrok tiers", () => {
     const raw = JSON.stringify({
       "user@x.ai": {
-        key: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0aWVyIjo3LCJlbWFpbCI6InVzZXJAeC5haSJ9.sig",
+        key: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0aWVyIjo0LCJlbWFpbCI6InVzZXJAeC5haSJ9.sig",
         email: "user@x.ai",
       },
     });
     const info = parseGrokAuthJson(raw);
     expect(info.authStatus).toBe("authenticated");
-    expect(info.authLabel).toBe("SuperGrok Heavy");
+    expect(info.authLabel).toBe("Grok subscription");
     expect(info.authEmail).toBe("user@x.ai");
   });
 
-  it("parseGrokAuthJson returns Requires... only for confirmed low tier", () => {
+  it("parseGrokAuthJson returns Requires... only for confirmed below-entitlement tier", () => {
     const raw = JSON.stringify({
       "free@x.ai": {
         key: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0aWVyIjozLCJlbWFpbCI6ImZyZWVAeC5haSJ9.sig",
@@ -110,7 +110,7 @@ describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
       },
     });
     const info = parseGrokAuthJson(raw);
-    expect(info.authLabel).toBe("Requires SuperGrok Heavy");
+    expect(info.authLabel).toBe("Requires SuperGrok or X Premium+");
   });
 
   it("parseGrokAuthJson is non-blocking (Grok label) when token present but no usable tier", () => {
@@ -134,7 +134,7 @@ describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
         email: "u@x.ai",
       },
     });
-    expect(parseGrokAuthJson(raw).authLabel).toBe("SuperGrok Heavy");
+    expect(parseGrokAuthJson(raw).authLabel).toBe("Grok subscription");
   });
 
   it("parseGrokAuthJson for unparseable file still returns authenticated (non-blocking)", () => {

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -828,15 +828,20 @@ export const MODELS_BY_PROVIDER: Record<ProviderId, ReadonlyArray<ModelOption>> 
   ],
   // Seed list — Grok CLI's `-m` flag accepts any model id it knows, so a
   // custom slug typed by the user still works; this list is just what the
-  // picker shows by default. `grok-build` is the only model free-tier
-  // accounts can run (verified via `grok models`); the rest unlock with a
-  // SuperGrok subscription. Passing a slug the account can't access yields
+  // picker shows by default. `grok-build` unlocks with a paid Grok entitlement
+  // such as SuperGrok or X Premium+. Passing a slug the account can't access yields
   // a clean 403 surfaced through grok's streaming-json `type: "error"`
   // envelope, so no client-side validation needed.
   grok: [
     {
       id: "grok-build",
       label: "Grok Build",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
+      id: "grok-composer-2.5-fast",
+      label: "Grok Composer 2.5 Fast",
       supportsPlanMode: true,
       supportsWebSearch: "queryOnly",
     },


### PR DESCRIPTION
## Summary

- Treat Grok auth tokens with tier 4 as eligible so X Premium+ accounts are not blocked by the old SuperGrok Heavy-only heuristic.
- Update Grok subscription copy across settings, onboarding, provider status, and runtime auth errors to say SuperGrok or X Premium+.
- Allow Grok in repository provider overrides and add the current CLI-reported `grok-composer-2.5-fast` model to the seeded picker list.

## Why

xAI now exposes Grok Build/CLI access to SuperGrok and X Premium+ subscribers. The previous local probe only accepted tier 5+ and labelled tier 4 as requiring SuperGrok Heavy, which incorrectly disabled valid X Premium+ accounts.

## Validation

- `grok models` reports the local account is logged in and has `grok-build` plus `grok-composer-2.5-fast` available.
- `bun test apps/server/test/availability.test.ts`
- `bun run --filter @memoize/wire check-types`
- `bun run --filter @memoize/server check-types`

Full `bun run check-types` still fails on existing renderer errors unrelated to this change: `src/app.tsx`, `src/components/file-editor.tsx`, `src/components/file-tree.tsx`, and `src/components/markdown-body.tsx`.