### PR TITLE
[codex] fix Codex tool translation

### DIFF
--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -329,57 +329,6 @@ const basename = (p: string): string => {
   return i === -1 ? p : p.slice(i + 1);
 };
 
-const parseUnifiedPatch = (patchText: string): ReadonlyArray<DiffLine> => {
-  const lines: DiffLine[] = [];
-  let oldLn = 0;
-  let newLn = 0;
-  let inHunk = false;
-
-  for (const raw of patchText.split("\n")) {
-    const hunk = raw.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-    if (hunk !== null) {
-      oldLn = Number(hunk[1]);
-      newLn = Number(hunk[2]);
-      inHunk = true;
-      lines.push({
-        kind: "hunk",
-        text: raw,
-        oldLine: null,
-        newLine: null,
-      });
-      continue;
-    }
-    if (!inHunk) continue;
-    if (raw.startsWith("\\ No newline")) continue;
-    if (raw.startsWith("+") && !raw.startsWith("+++")) {
-      lines.push({
-        kind: "add",
-        text: raw.slice(1),
-        oldLine: null,
-        newLine: newLn,
-      });
-      newLn += 1;
-      continue;
-    }
-    if (raw.startsWith("-") && !raw.startsWith("---")) {
-      lines.push({
-        kind: "del",
-        text: raw.slice(1),
-        oldLine: oldLn,
-        newLine: null,
-      });
-      oldLn += 1;
-      continue;
-    }
-    const text = raw.startsWith(" ") ? raw.slice(1) : raw;
-    lines.push({ kind: "context", text, oldLine: oldLn, newLine: newLn });
-    oldLn += 1;
-    newLn += 1;
-  }
-
-  return lines;
-};
-
 export function UnifiedPatchDiff({
   path,
   patch,
@@ -391,8 +340,7 @@ export function UnifiedPatchDiff({
   kind?: string;
   showHeader?: boolean;
 }) {
-  const lines = useMemo(() => parseUnifiedPatch(patch), [patch]);
-  if (lines.length === 0) {
+  if (patch.trim().length === 0) {
     return (
       <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
         (no textual change)
@@ -416,12 +364,10 @@ export function UnifiedPatchDiff({
       ) : null}
 
       <div
-        className="code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
+        className="fz-diff code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
         style={{ maxHeight: 420 }}
       >
-        {lines.map((line, idx) => (
-          <EditDiffRow key={idx} line={line} />
-        ))}
+        <PatchDiff patch={patch} disableWorkerPool />
       </div>
     </div>
   );

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -12,6 +12,12 @@ export interface FileEdit {
   readonly mode: "edit" | "create";
 }
 
+export interface PatchEntry {
+  readonly file_path: string;
+  readonly kind?: string;
+  readonly patch: string;
+}
+
 /**
  * Best-effort extraction of a `(path, old, new)` triple from a Claude
  * `Edit` / `Write` / `MultiEdit` tool input. Tools we can't parse fall back
@@ -104,6 +110,56 @@ export const diffStats = (
         if (m === "+") added += 1;
         else if (m === "-") removed += 1;
       }
+    }
+  }
+  return { added, removed };
+};
+
+export const extractPatchEntries = (
+  input: unknown,
+): ReadonlyArray<PatchEntry> => {
+  if (input === null || typeof input !== "object") return [];
+  const obj = input as Record<string, unknown>;
+  const patches = Array.isArray(obj.patches) ? obj.patches : null;
+  if (patches !== null) {
+    return patches
+      .map((raw): PatchEntry | null => {
+        if (raw === null || typeof raw !== "object") return null;
+        const patch = raw as Record<string, unknown>;
+        const filePath =
+          typeof patch.file_path === "string" ? patch.file_path : null;
+        const text = typeof patch.patch === "string" ? patch.patch : null;
+        if (filePath === null || text === null) return null;
+        return {
+          file_path: filePath,
+          kind: typeof patch.kind === "string" ? patch.kind : undefined,
+          patch: text,
+        };
+      })
+      .filter((entry): entry is PatchEntry => entry !== null);
+  }
+  const path = typeof obj.file_path === "string" ? obj.file_path : null;
+  const patch = typeof obj.patch === "string" ? obj.patch : null;
+  if (path === null || patch === null) return [];
+  return [
+    {
+      file_path: path,
+      kind: typeof obj.kind === "string" ? obj.kind : undefined,
+      patch,
+    },
+  ];
+};
+
+export const patchStats = (
+  patches: ReadonlyArray<PatchEntry>,
+): { added: number; removed: number } => {
+  let added = 0;
+  let removed = 0;
+  for (const patch of patches) {
+    for (const line of patch.patch.split("\n")) {
+      if (line.startsWith("+++") || line.startsWith("---")) continue;
+      if (line.startsWith("+")) added += 1;
+      else if (line.startsWith("-")) removed += 1;
     }
   }
   return { added, removed };

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -5,6 +5,8 @@ import { useMemo } from "react";
 import { cn } from "~/lib/utils";
 import { FileIcon } from "./file-icon.tsx";
 
+const UNIFIED_DIFF_OPTIONS = { diffStyle: "unified" } as const;
+
 export interface FileEdit {
   readonly path: string;
   readonly oldText: string;
@@ -239,7 +241,11 @@ export function DiffBody({
           {edit.mode === "create" ? "create" : "edit"} · {edit.path}
         </div>
       ) : null}
-      <PatchDiff patch={patchText} disableWorkerPool />
+      <PatchDiff
+        patch={patchText}
+        options={UNIFIED_DIFF_OPTIONS}
+        disableWorkerPool
+      />
     </div>
   );
 }
@@ -329,6 +335,22 @@ const basename = (p: string): string => {
   return i === -1 ? p : p.slice(i + 1);
 };
 
+const normalizePatchForDiffViewer = (path: string, patch: string): string => {
+  const trimmed = patch.trimStart();
+  if (trimmed.startsWith("diff --git") || trimmed.startsWith("--- ")) {
+    return patch;
+  }
+  if (!trimmed.startsWith("@@")) return patch;
+  const displayPath = path.length > 0 ? path : "file";
+  const body = patch.endsWith("\n") ? patch : `${patch}\n`;
+  return [
+    `diff --git a/${displayPath} b/${displayPath}`,
+    `--- a/${displayPath}`,
+    `+++ b/${displayPath}`,
+    body,
+  ].join("\n");
+};
+
 export function UnifiedPatchDiff({
   path,
   patch,
@@ -349,6 +371,7 @@ export function UnifiedPatchDiff({
   }
 
   const name = basename(path);
+  const normalizedPatch = normalizePatchForDiffViewer(path, patch);
   return (
     <div className="overflow-hidden rounded-md border border-border/60">
       {showHeader ? (
@@ -367,7 +390,11 @@ export function UnifiedPatchDiff({
         className="fz-diff code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
         style={{ maxHeight: 420 }}
       >
-        <PatchDiff patch={patch} disableWorkerPool />
+        <PatchDiff
+          patch={normalizedPatch}
+          options={UNIFIED_DIFF_OPTIONS}
+          disableWorkerPool
+        />
       </div>
     </div>
   );

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -273,6 +273,104 @@ const basename = (p: string): string => {
   return i === -1 ? p : p.slice(i + 1);
 };
 
+const parseUnifiedPatch = (patchText: string): ReadonlyArray<DiffLine> => {
+  const lines: DiffLine[] = [];
+  let oldLn = 0;
+  let newLn = 0;
+  let inHunk = false;
+
+  for (const raw of patchText.split("\n")) {
+    const hunk = raw.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunk !== null) {
+      oldLn = Number(hunk[1]);
+      newLn = Number(hunk[2]);
+      inHunk = true;
+      lines.push({
+        kind: "hunk",
+        text: raw,
+        oldLine: null,
+        newLine: null,
+      });
+      continue;
+    }
+    if (!inHunk) continue;
+    if (raw.startsWith("\\ No newline")) continue;
+    if (raw.startsWith("+") && !raw.startsWith("+++")) {
+      lines.push({
+        kind: "add",
+        text: raw.slice(1),
+        oldLine: null,
+        newLine: newLn,
+      });
+      newLn += 1;
+      continue;
+    }
+    if (raw.startsWith("-") && !raw.startsWith("---")) {
+      lines.push({
+        kind: "del",
+        text: raw.slice(1),
+        oldLine: oldLn,
+        newLine: null,
+      });
+      oldLn += 1;
+      continue;
+    }
+    const text = raw.startsWith(" ") ? raw.slice(1) : raw;
+    lines.push({ kind: "context", text, oldLine: oldLn, newLine: newLn });
+    oldLn += 1;
+    newLn += 1;
+  }
+
+  return lines;
+};
+
+export function UnifiedPatchDiff({
+  path,
+  patch,
+  kind = "edit",
+  showHeader = false,
+}: {
+  path: string;
+  patch: string;
+  kind?: string;
+  showHeader?: boolean;
+}) {
+  const lines = useMemo(() => parseUnifiedPatch(patch), [patch]);
+  if (lines.length === 0) {
+    return (
+      <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+        (no textual change)
+      </div>
+    );
+  }
+
+  const name = basename(path);
+  return (
+    <div className="overflow-hidden rounded-md border border-border/60">
+      {showHeader ? (
+        <div className="flex items-center gap-2 border-b border-border/40 bg-muted/30 px-2 py-1 text-[11px] text-muted-foreground">
+          <FileIcon
+            name={name}
+            kind="file"
+            className="inline-flex size-3.5 shrink-0"
+          />
+          <span className="truncate font-mono text-foreground/80">{name}</span>
+          <span className="text-muted-foreground">{kind}</span>
+        </div>
+      ) : null}
+
+      <div
+        className="code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
+        style={{ maxHeight: 420 }}
+      >
+        {lines.map((line, idx) => (
+          <EditDiffRow key={idx} line={line} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function EditDiff({
   edit,
   showHeader = false,

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -37,7 +37,9 @@ import {
   diffStats,
   EditDiff,
   extractEdits,
+  extractPatchEntries,
   type FileEdit,
+  patchStats,
   UnifiedPatchDiff,
 } from "./inline-diff.tsx";
 
@@ -383,12 +385,6 @@ interface GrepGroup {
   readonly matches: ReadonlyArray<string>;
 }
 
-interface PatchEntry {
-  readonly file_path: string;
-  readonly kind?: string;
-  readonly patch: string;
-}
-
 /**
  * Parse grep output into per-file groups. A flush-left line is a file path;
  * indented lines are matches under the current file. Plain path-per-line
@@ -411,54 +407,6 @@ const parseGrepGroups = (output: string): ReadonlyArray<GrepGroup> => {
     groups.push(current);
   }
   return groups;
-};
-
-const extractPatchEntries = (input: unknown): ReadonlyArray<PatchEntry> => {
-  if (input === null || typeof input !== "object") return [];
-  const obj = input as Record<string, unknown>;
-  const patches = Array.isArray(obj.patches) ? obj.patches : null;
-  if (patches !== null) {
-    return patches
-      .map((raw): PatchEntry | null => {
-        if (raw === null || typeof raw !== "object") return null;
-        const patch = raw as Record<string, unknown>;
-        const filePath =
-          typeof patch.file_path === "string" ? patch.file_path : null;
-        const text = typeof patch.patch === "string" ? patch.patch : null;
-        if (filePath === null || text === null) return null;
-        return {
-          file_path: filePath,
-          kind: typeof patch.kind === "string" ? patch.kind : undefined,
-          patch: text,
-        };
-      })
-      .filter((entry): entry is PatchEntry => entry !== null);
-  }
-  const path = typeof obj.file_path === "string" ? obj.file_path : null;
-  const patch = typeof obj.patch === "string" ? obj.patch : null;
-  if (path === null || patch === null) return [];
-  return [
-    {
-      file_path: path,
-      kind: typeof obj.kind === "string" ? obj.kind : undefined,
-      patch,
-    },
-  ];
-};
-
-const patchStats = (
-  patches: ReadonlyArray<PatchEntry>,
-): { added: number; removed: number } => {
-  let added = 0;
-  let removed = 0;
-  for (const patch of patches) {
-    for (const line of patch.patch.split("\n")) {
-      if (line.startsWith("+++") || line.startsWith("---")) continue;
-      if (line.startsWith("+")) added += 1;
-      else if (line.startsWith("-")) removed += 1;
-    }
-  }
-  return { added, removed };
 };
 
 // Count the leaf files in a `list_dir` tree (lines that aren't directories).

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -93,10 +93,19 @@ export const iconForTool = (tool: string): IconHandle => {
       // wired an exact case for yet. "list dir", "read file", "run shell"
       // etc. will now get a reasonable icon instead of the generic wrench.
       const t = tool.toLowerCase();
-      if (t.includes("dir") || t.includes("folder") || t.includes("list")) return Folder01Icon;
-      if (t.includes("file") || t.includes("read") || t.includes("write")) return File01Icon;
-      if (t.includes("bash") || t.includes("shell") || t.includes("cmd") || t.includes("exec")) return TerminalIcon;
-      if (t.includes("search") || t.includes("grep") || t.includes("glob")) return SearchIcon;
+      if (t.includes("dir") || t.includes("folder") || t.includes("list"))
+        return Folder01Icon;
+      if (t.includes("file") || t.includes("read") || t.includes("write"))
+        return File01Icon;
+      if (
+        t.includes("bash") ||
+        t.includes("shell") ||
+        t.includes("cmd") ||
+        t.includes("exec")
+      )
+        return TerminalIcon;
+      if (t.includes("search") || t.includes("grep") || t.includes("glob"))
+        return SearchIcon;
       if (t.includes("web") || t.includes("http")) return GlobeIcon;
       return Wrench01Icon;
     }
@@ -195,9 +204,7 @@ function InlineCodeChip({ value }: { value: string }) {
 
 function InlineTextHint({ value }: { value: string }) {
   return (
-    <span className="ml-1 truncate text-muted-foreground italic">
-      {value}
-    </span>
+    <span className="ml-1 truncate text-muted-foreground italic">{value}</span>
   );
 }
 
@@ -214,9 +221,7 @@ function TerminalBlock({
     <div
       className={cn(
         "rounded px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto",
-        isError
-          ? "bg-alert-error-bg"
-          : "bg-zinc-900/70",
+        isError ? "bg-alert-error-bg" : "bg-zinc-900/70",
       )}
     >
       {command !== undefined ? (
@@ -339,20 +344,12 @@ function MarkdownBlock({ text }: { text: string }) {
   );
 }
 
-function PreBlock({
-  text,
-  isError,
-}: {
-  text: string;
-  isError?: boolean;
-}) {
+function PreBlock({ text, isError }: { text: string; isError?: boolean }) {
   return (
     <pre
       className={cn(
         "overflow-x-auto whitespace-pre-wrap break-words rounded px-3 py-2 font-mono text-[11px] text-foreground/80",
-        isError
-          ? "bg-alert-error-bg"
-          : "bg-zinc-900/70",
+        isError ? "bg-alert-error-bg" : "bg-zinc-900/70",
       )}
     >
       {text || "(empty)"}
@@ -367,7 +364,10 @@ function PreBlock({
 const splitLines = (s: string): ReadonlyArray<string> => {
   const trimmed = s.trim();
   if (trimmed.length === 0) return [];
-  return trimmed.split("\n").map((line) => line.trim()).filter((l) => l.length > 0);
+  return trimmed
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((l) => l.length > 0);
 };
 
 // Grep / Glob results are usually one path per line, sometimes followed
@@ -380,6 +380,12 @@ const parseFileList = (output: string): ReadonlyArray<string> => {
 interface GrepGroup {
   readonly path: string;
   readonly matches: ReadonlyArray<string>;
+}
+
+interface PatchEntry {
+  readonly file_path: string;
+  readonly kind?: string;
+  readonly patch: string;
 }
 
 /**
@@ -404,6 +410,39 @@ const parseGrepGroups = (output: string): ReadonlyArray<GrepGroup> => {
     groups.push(current);
   }
   return groups;
+};
+
+const extractPatchEntries = (input: unknown): ReadonlyArray<PatchEntry> => {
+  if (input === null || typeof input !== "object") return [];
+  const obj = input as Record<string, unknown>;
+  const patches = Array.isArray(obj.patches) ? obj.patches : null;
+  if (patches !== null) {
+    return patches
+      .map((raw): PatchEntry | null => {
+        if (raw === null || typeof raw !== "object") return null;
+        const patch = raw as Record<string, unknown>;
+        const filePath =
+          typeof patch.file_path === "string" ? patch.file_path : null;
+        const text = typeof patch.patch === "string" ? patch.patch : null;
+        if (filePath === null || text === null) return null;
+        return {
+          file_path: filePath,
+          kind: typeof patch.kind === "string" ? patch.kind : undefined,
+          patch: text,
+        };
+      })
+      .filter((entry): entry is PatchEntry => entry !== null);
+  }
+  const path = typeof obj.file_path === "string" ? obj.file_path : null;
+  const patch = typeof obj.patch === "string" ? obj.patch : null;
+  if (path === null || patch === null) return [];
+  return [
+    {
+      file_path: path,
+      kind: typeof obj.kind === "string" ? obj.kind : undefined,
+      patch,
+    },
+  ];
 };
 
 // Count the leaf files in a `list_dir` tree (lines that aren't directories).
@@ -515,9 +554,10 @@ const buildToolView = (
         icon: TerminalIcon,
         label: desc ?? "Bash",
         trailing:
-          cmd !== null ? <InlineCodeChip value={truncate(cmd, 120)} /> : undefined,
-        inputPanel:
-          cmd !== null ? <TerminalBlock command={cmd} /> : undefined,
+          cmd !== null ? (
+            <InlineCodeChip value={truncate(cmd, 120)} />
+          ) : undefined,
+        inputPanel: cmd !== null ? <TerminalBlock command={cmd} /> : undefined,
         resultPanel: (result) => (
           <TerminalBlock
             output={toResultText(result.output) || "(no output)"}
@@ -525,9 +565,7 @@ const buildToolView = (
           />
         ),
         fallbackBody:
-          cmd === null ? (
-            <PreBlock text={stringifyJson(input)} />
-          ) : undefined,
+          cmd === null ? <PreBlock text={stringifyJson(input)} /> : undefined,
       };
     }
 
@@ -574,11 +612,7 @@ const buildToolView = (
             );
           }
           return (
-            <CodeBlock
-              filename={path}
-              text={text}
-              isError={result.isError}
-            />
+            <CodeBlock filename={path} text={text} isError={result.isError} />
           );
         },
       };
@@ -589,11 +623,12 @@ const buildToolView = (
     case "MultiEdit": {
       const path = asString(obj.file_path);
       const edits = extractEdits(tool, input);
+      const patches = extractPatchEntries(input);
       const label =
         tool === "Write"
           ? "Write"
           : tool === "MultiEdit"
-            ? `MultiEdit (${edits.length})`
+            ? `MultiEdit (${edits.length || patches.length})`
             : "Edit";
       const stats = edits.length > 0 ? diffStats(edits) : null;
       return {
@@ -620,6 +655,22 @@ const buildToolView = (
                   edit={edit as FileEdit}
                   showHeader={edits.length > 1}
                 />
+              ))}
+            </div>
+          ) : patches.length > 0 ? (
+            <div className="space-y-2">
+              {patches.map((patch, i) => (
+                <div key={i} className="space-y-1">
+                  <div className="flex items-center gap-2 text-[11px]">
+                    <FileBadge path={patch.file_path} view="diff" />
+                    {patch.kind !== undefined ? (
+                      <span className="text-muted-foreground">
+                        {patch.kind}
+                      </span>
+                    ) : null}
+                  </div>
+                  <PreBlock text={patch.patch} />
+                </div>
               ))}
             </div>
           ) : (
@@ -666,11 +717,13 @@ const buildToolView = (
           pattern !== null ? (
             <div className="text-[11px] text-muted-foreground space-y-0.5">
               <div>
-                pattern <span className="font-mono text-foreground/90">{pattern}</span>
+                pattern{" "}
+                <span className="font-mono text-foreground/90">{pattern}</span>
               </div>
               {where !== null ? (
                 <div>
-                  scope <span className="font-mono text-foreground/90">{where}</span>
+                  scope{" "}
+                  <span className="font-mono text-foreground/90">{where}</span>
                 </div>
               ) : null}
             </div>
@@ -833,10 +886,7 @@ const buildToolView = (
             );
           }
           return (
-            <PreBlock
-              text={truncate(text, 4000)}
-              isError={result.isError}
-            />
+            <PreBlock text={truncate(text, 4000)} isError={result.isError} />
           );
         },
       };
@@ -858,7 +908,8 @@ const buildToolView = (
                 if (t === null || typeof t !== "object")
                   return <li key={i}>{stringifyJson(t)}</li>;
                 const r = t as Record<string, unknown>;
-                const content = asString(r.content) ?? asString(r.activeForm) ?? "";
+                const content =
+                  asString(r.content) ?? asString(r.activeForm) ?? "";
                 const status = asString(r.status) ?? "";
                 return (
                   <li key={i} className="font-mono">
@@ -897,7 +948,9 @@ const buildToolView = (
             )}
             {promptText && (
               <div className="rounded border bg-muted/30 p-1.5 font-mono text-[11px] leading-snug">
-                {promptText.length > 280 ? promptText.slice(0, 277) + "…" : promptText}
+                {promptText.length > 280
+                  ? promptText.slice(0, 277) + "…"
+                  : promptText}
               </div>
             )}
             {receivers.length > 0 && (
@@ -915,7 +968,9 @@ const buildToolView = (
         ),
         resultPanel: (result) => (
           <PreBlock
-            text={toResultText(result.output) || stringifyJson(obj.agentsStates)}
+            text={
+              toResultText(result.output) || stringifyJson(obj.agentsStates)
+            }
             isError={result.isError}
           />
         ),
@@ -962,7 +1017,10 @@ const buildToolView = (
         label: "Read page",
         trailing: <InlineTextHint value="elements" />,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -974,7 +1032,10 @@ const buildToolView = (
         label: "Click",
         trailing: ref !== null ? <InlineTextHint value={ref} /> : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -989,7 +1050,10 @@ const buildToolView = (
             <InlineTextHint value={truncate(typed, 48)} />
           ) : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1029,9 +1093,14 @@ const buildToolView = (
         icon: BrowserIcon,
         label: "Select",
         trailing:
-          value !== null ? <InlineTextHint value={truncate(value, 40)} /> : undefined,
+          value !== null ? (
+            <InlineTextHint value={truncate(value, 40)} />
+          ) : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1050,7 +1119,10 @@ const buildToolView = (
         icon: File01Icon,
         label: "Read page",
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1073,7 +1145,10 @@ const buildToolView = (
         icon: TerminalIcon,
         label: "Console",
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1088,7 +1163,10 @@ const buildToolView = (
             <InlineTextHint value={truncate(origin, 48)} />
           ) : undefined,
         resultPanel: (result) => (
-          <PreBlock text={toResultText(result.output)} isError={result.isError} />
+          <PreBlock
+            text={toResultText(result.output)}
+            isError={result.isError}
+          />
         ),
       };
     }
@@ -1192,9 +1270,7 @@ export function ExitPlanModeRow({
           <div className="mt-4 flex items-center justify-end gap-2">
             <button
               type="button"
-              onClick={() =>
-                void decide(pendingRequest.id, { _tag: "Deny" })
-              }
+              onClick={() => void decide(pendingRequest.id, { _tag: "Deny" })}
               className="rounded-md px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
             >
               Cancel
@@ -1218,9 +1294,7 @@ export function ExitPlanModeRow({
   const body = (
     <>
       {plan === null ? (
-        <p className="text-sm italic text-muted-foreground">
-          (No plan body.)
-        </p>
+        <p className="text-sm italic text-muted-foreground">(No plan body.)</p>
       ) : (
         <MarkdownBody>{plan}</MarkdownBody>
       )}
@@ -1474,10 +1548,10 @@ export function ThinkingRow({
     </p>
   ) : isEmpty ? (
     <p className="whitespace-pre-wrap text-[11px] italic leading-relaxed text-muted-foreground/70">
-      The model produced a thinking block (the SDK forwarded its signed
-      receipt) but the underlying text was filtered out by Anthropic's
-      agent SDK before it reached us. We can&apos;t expose the actual
-      thoughts without bypassing the official SDK.
+      The model produced a thinking block (the SDK forwarded its signed receipt)
+      but the underlying text was filtered out by Anthropic's agent SDK before
+      it reached us. We can&apos;t expose the actual thoughts without bypassing
+      the official SDK.
     </p>
   ) : (
     <MarkdownBlock text={text} />

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -38,6 +38,7 @@ import {
   EditDiff,
   extractEdits,
   type FileEdit,
+  UnifiedPatchDiff,
 } from "./inline-diff.tsx";
 
 type IconHandle = Parameters<typeof HugeiconsIcon>[0]["icon"];
@@ -670,17 +671,13 @@ const buildToolView = (
           patches.length > 0 ? (
             <div className="space-y-2">
               {patches.map((patch, i) => (
-                <div key={i} className="space-y-1">
-                  <div className="flex items-center gap-2 text-[11px]">
-                    <FileBadge path={patch.file_path} view="diff" />
-                    {patch.kind !== undefined ? (
-                      <span className="text-muted-foreground">
-                        {patch.kind}
-                      </span>
-                    ) : null}
-                  </div>
-                  <PreBlock text={patch.patch} />
-                </div>
+                <UnifiedPatchDiff
+                  key={i}
+                  path={patch.file_path}
+                  patch={patch.patch}
+                  kind={patch.kind}
+                  showHeader={patches.length > 1}
+                />
               ))}
             </div>
           ) : edits.length > 0 ? (

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -445,6 +445,21 @@ const extractPatchEntries = (input: unknown): ReadonlyArray<PatchEntry> => {
   ];
 };
 
+const patchStats = (
+  patches: ReadonlyArray<PatchEntry>,
+): { added: number; removed: number } => {
+  let added = 0;
+  let removed = 0;
+  for (const patch of patches) {
+    for (const line of patch.patch.split("\n")) {
+      if (line.startsWith("+++") || line.startsWith("---")) continue;
+      if (line.startsWith("+")) added += 1;
+      else if (line.startsWith("-")) removed += 1;
+    }
+  }
+  return { added, removed };
+};
+
 // Count the leaf files in a `list_dir` tree (lines that aren't directories).
 const countTreeFiles = (tree: string): number =>
   splitLines(tree).filter((l) => !l.endsWith("/")).length;
@@ -622,15 +637,20 @@ const buildToolView = (
     case "Write":
     case "MultiEdit": {
       const path = asString(obj.file_path);
-      const edits = extractEdits(tool, input);
       const patches = extractPatchEntries(input);
+      const edits = patches.length > 0 ? [] : extractEdits(tool, input);
       const label =
         tool === "Write"
           ? "Write"
           : tool === "MultiEdit"
             ? `MultiEdit (${edits.length || patches.length})`
             : "Edit";
-      const stats = edits.length > 0 ? diffStats(edits) : null;
+      const stats =
+        patches.length > 0
+          ? patchStats(patches)
+          : edits.length > 0
+            ? diffStats(edits)
+            : null;
       return {
         icon: PencilEdit01Icon,
         label,
@@ -647,17 +667,7 @@ const buildToolView = (
             </span>
           ) : undefined,
         fallbackBody:
-          edits.length > 0 ? (
-            <div className="space-y-px">
-              {edits.map((edit, i) => (
-                <EditDiff
-                  key={i}
-                  edit={edit as FileEdit}
-                  showHeader={edits.length > 1}
-                />
-              ))}
-            </div>
-          ) : patches.length > 0 ? (
+          patches.length > 0 ? (
             <div className="space-y-2">
               {patches.map((patch, i) => (
                 <div key={i} className="space-y-1">
@@ -671,6 +681,16 @@ const buildToolView = (
                   </div>
                   <PreBlock text={patch.patch} />
                 </div>
+              ))}
+            </div>
+          ) : edits.length > 0 ? (
+            <div className="space-y-px">
+              {edits.map((edit, i) => (
+                <EditDiff
+                  key={i}
+                  edit={edit as FileEdit}
+                  showHeader={edits.length > 1}
+                />
               ))}
             </div>
           ) : (

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -18,7 +18,12 @@ import { groupMessages } from "../lib/group-messages.ts";
 import { cn } from "~/lib/utils";
 
 import { FileBadge } from "./file-badge.tsx";
-import { diffStats, extractEdits } from "./inline-diff.tsx";
+import {
+  diffStats,
+  extractEdits,
+  extractPatchEntries,
+  patchStats,
+} from "./inline-diff.tsx";
 import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { iconForTool } from "./tool-row.tsx";
@@ -39,19 +44,32 @@ interface FileStat {
 
 const aggregateFileStats = (body: ReadonlyArray<Message>): FileStat[] => {
   const map = new Map<string, { added: number; removed: number }>();
-  for (const m of body) {
-    if (m.content._tag !== "tool_use") continue;
-    const tool = m.content.tool;
-    if (tool !== "Edit" && tool !== "Write" && tool !== "MultiEdit") continue;
-    const edits = extractEdits(tool, m.content.input);
-    if (edits.length === 0) continue;
-    const stats = diffStats(edits);
-    const path = edits[0]!.path;
+  const addStats = (
+    path: string,
+    stats: { added: number; removed: number },
+  ) => {
     const prev = map.get(path) ?? { added: 0, removed: 0 };
     map.set(path, {
       added: prev.added + stats.added,
       removed: prev.removed + stats.removed,
     });
+  };
+  for (const m of body) {
+    if (m.content._tag !== "tool_use") continue;
+    const tool = m.content.tool;
+    if (tool !== "Edit" && tool !== "Write" && tool !== "MultiEdit") continue;
+    const patches = extractPatchEntries(m.content.input);
+    if (patches.length > 0) {
+      for (const patch of patches) {
+        addStats(patch.file_path, patchStats([patch]));
+      }
+      continue;
+    }
+    const edits = extractEdits(tool, m.content.input);
+    if (edits.length === 0) continue;
+    const stats = diffStats(edits);
+    const path = edits[0]!.path;
+    addStats(path, stats);
   }
   return Array.from(map.entries()).map(([path, s]) => ({ path, ...s }));
 };

--- a/apps/renderer/src/composer/builtin-commands.ts
+++ b/apps/renderer/src/composer/builtin-commands.ts
@@ -81,6 +81,8 @@ const COMMANDS: readonly BuiltinCommand[] = [
   { name: "experimental", description: "List Codex experimental features.", kind: "forward", appliesTo: "codex" },
   { name: "status", description: "Show Codex thread status.", kind: "forward", appliesTo: "codex" },
   { name: "debug-config", description: "Show Codex config details.", kind: "forward", appliesTo: "codex" },
+  { name: "tool-log", description: "Show the Codex tool translation log path.", kind: "forward", appliesTo: "codex" },
+  { name: "debug-tools", description: "Show the Codex tool translation log path.", kind: "forward", appliesTo: "codex" },
   { name: "statusline", description: "Configure statusline fields.", kind: "client", appliesTo: "codex" },
   { name: "title", description: "Configure terminal title fields.", kind: "client", appliesTo: "codex" },
   { name: "ps", description: "Check background Codex processes.", kind: "forward", appliesTo: "codex" },

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -1,4 +1,7 @@
 import { Effect, Mailbox, Stream } from "effect";
+import { execFileSync } from "node:child_process";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 
 import {
   AgentSessionStartError,
@@ -43,13 +46,56 @@ const toSandboxMode = (
 ): "read-only" | "workspace-write" =>
   mode === "plan" ? "read-only" : "workspace-write";
 
+const dedupe = (paths: ReadonlyArray<string>): ReadonlyArray<string> => [
+  ...new Set(paths),
+];
+
+const gitRevParsePaths = (
+  cwd: string,
+  args: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+  try {
+    return execFileSync("git", ["rev-parse", ...args], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } catch {
+    return [];
+  }
+};
+
+export const codexWritableRootsForCwd = (
+  cwd: string,
+): ReadonlyArray<string> => {
+  const gitPaths = gitRevParsePaths(cwd, [
+    "--path-format=absolute",
+    "--git-dir",
+    "--git-common-dir",
+  ]);
+  const fallbackGitPaths =
+    gitPaths.length > 0
+      ? []
+      : gitRevParsePaths(cwd, ["--git-dir", "--git-common-dir"]);
+  return dedupe([
+    cwd,
+    ...gitPaths,
+    ...fallbackGitPaths.map((path) =>
+      isAbsolute(path) ? path : resolve(cwd, path),
+    ),
+  ]);
+};
+
 const toSandboxPolicy = (mode: PermissionMode, cwd: string): SandboxPolicy =>
   mode === "plan"
     ? { type: "readOnly", networkAccess: false }
     : {
         type: "workspaceWrite",
-        writableRoots: [cwd],
-        networkAccess: false,
+        writableRoots: [...codexWritableRootsForCwd(cwd)],
+        networkAccess: true,
         excludeTmpdirEnvVar: false,
         excludeSlashTmp: false,
       };
@@ -80,6 +126,218 @@ const firstLine = (text: string): string => text.split("\n", 1)[0] ?? "";
 const asText = (value: unknown): string =>
   typeof value === "string" ? value : JSON.stringify(value, null, 2);
 
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+
+const asString = (value: unknown): string | null =>
+  typeof value === "string" && value.length > 0 ? value : null;
+
+const toolIdentifierPart = (value: string): string =>
+  value.replace(/[^A-Za-z0-9_]/g, "_");
+
+const toMcpToolName = (server: string, tool: string): string =>
+  `mcp__${toolIdentifierPart(server)}__${toolIdentifierPart(tool)}`;
+
+const dynamicToolName = (namespace: string | null, tool: string): string =>
+  namespace !== null ? `${namespace}.${tool}` : tool;
+
+const niceToolLabel = (raw: string): string =>
+  raw
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_\-.\/]+/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ") || "Tool";
+
+const firstTextBlock = (value: unknown): string | null => {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return null;
+  const parts: string[] = [];
+  for (const item of value) {
+    if (item === null || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    if (typeof record["text"] === "string") {
+      parts.push(record["text"] as string);
+      continue;
+    }
+    const inner = record["content"];
+    if (inner !== null && typeof inner === "object") {
+      const text = (inner as Record<string, unknown>)["text"];
+      if (typeof text === "string") parts.push(text);
+    }
+  }
+  return parts.length > 0 ? parts.join("") : null;
+};
+
+const dynamicOutputText = (items: unknown): unknown => {
+  if (!Array.isArray(items)) return items ?? null;
+  const text = items
+    .map((item) =>
+      item !== null &&
+      typeof item === "object" &&
+      (item as Record<string, unknown>)["type"] === "inputText" &&
+      typeof (item as Record<string, unknown>)["text"] === "string"
+        ? ((item as Record<string, unknown>)["text"] as string)
+        : null,
+    )
+    .filter((item): item is string => item !== null)
+    .join("");
+  return text.length > 0 ? text : items;
+};
+
+const webSearchQueryFromAction = (
+  item: Extract<ThreadItem, { type: "webSearch" }>,
+): string => {
+  const action = item.action;
+  if (action?.type === "search") {
+    return (
+      action.query ?? action.queries?.filter(Boolean).join(", ") ?? item.query
+    );
+  }
+  if (action?.type === "openPage") return action.url ?? item.query;
+  if (action?.type === "findInPage")
+    return action.pattern ?? action.url ?? item.query;
+  return item.query;
+};
+
+const codexCommandToolUse = (
+  item: Extract<ThreadItem, { type: "commandExecution" }>,
+): Extract<AgentEvent, { _tag: "ToolUse" }> => {
+  const action =
+    item.commandActions.length === 1 ? item.commandActions[0] : null;
+  if (action?.type === "read") {
+    return {
+      _tag: "ToolUse",
+      itemId: item.id as AgentItemId,
+      tool: "Read",
+      input: { file_path: action.path },
+    };
+  }
+  if (action?.type === "listFiles") {
+    return {
+      _tag: "ToolUse",
+      itemId: item.id as AgentItemId,
+      tool: "ListDir",
+      input: { path: action.path ?? item.cwd },
+    };
+  }
+  if (action?.type === "search") {
+    const input: Record<string, unknown> = {
+      pattern: action.query ?? action.command,
+    };
+    if (action.path !== null) input["path"] = action.path;
+    return {
+      _tag: "ToolUse",
+      itemId: item.id as AgentItemId,
+      tool: "Grep",
+      input,
+    };
+  }
+  return {
+    _tag: "ToolUse",
+    itemId: item.id as AgentItemId,
+    tool: "Bash",
+    input: {
+      command: item.command,
+      cwd: item.cwd,
+      description: firstLine(item.command),
+    },
+  };
+};
+
+const codexCommandResultOutput = (
+  item: Extract<ThreadItem, { type: "commandExecution" }>,
+): string => {
+  const output = item.aggregatedOutput ?? "";
+  if (output.length > 0 || item.exitCode === 0 || item.exitCode === null) {
+    return output;
+  }
+  return `Command exited with code ${item.exitCode}.`;
+};
+
+const codexFileChangeInput = (
+  item: Extract<ThreadItem, { type: "fileChange" }>,
+): { tool: "Edit" | "MultiEdit"; input: Record<string, unknown> } => {
+  const patches = item.changes.map((change) => ({
+    file_path: change.path,
+    kind: change.kind.type,
+    patch: change.diff,
+    move_path:
+      change.kind.type === "update" ? change.kind.move_path : undefined,
+  }));
+  if (patches.length === 1) {
+    const patch = patches[0]!;
+    return {
+      tool: "Edit",
+      input: {
+        file_path: patch.file_path,
+        kind: patch.kind,
+        patch: patch.patch,
+        ...(patch.move_path !== undefined
+          ? { move_path: patch.move_path }
+          : {}),
+      },
+    };
+  }
+  return {
+    tool: "MultiEdit",
+    input: {
+      file_path: patches.map((patch) => patch.file_path).join(", "),
+      patches,
+    },
+  };
+};
+
+const normalizeDynamicToolUse = (
+  item: Extract<ThreadItem, { type: "dynamicToolCall" }>,
+): { tool: string; input: unknown } => {
+  const rawName = dynamicToolName(item.namespace, item.tool);
+  const input = asRecord(item.arguments);
+  switch (rawName) {
+    case "functions.exec_command":
+    case "exec_command": {
+      const command = asString(input["cmd"]) ?? asString(input["command"]);
+      if (command !== null) {
+        return {
+          tool: "Bash",
+          input: {
+            command,
+            ...(asString(input["workdir"]) !== null
+              ? { cwd: asString(input["workdir"]) }
+              : {}),
+          },
+        };
+      }
+      break;
+    }
+    case "functions.apply_patch":
+    case "apply_patch": {
+      return {
+        tool: "Edit",
+        input: { file_path: "(patch)", patch: item.arguments },
+      };
+    }
+    case "web.run": {
+      const searches = Array.isArray(input["search_query"])
+        ? (input["search_query"] as unknown[])
+        : Array.isArray(input["image_query"])
+          ? (input["image_query"] as unknown[])
+          : [];
+      const first = searches[0];
+      const query =
+        first !== null && typeof first === "object"
+          ? asString((first as Record<string, unknown>)["q"])
+          : null;
+      if (query !== null) return { tool: "WebSearch", input: { query } };
+      break;
+    }
+  }
+  return { tool: niceToolLabel(rawName), input: item.arguments };
+};
+
 const decisionToCodex = (
   decision: PermissionDecision,
 ): "accept" | "acceptForSession" | "decline" =>
@@ -89,17 +347,77 @@ const decisionToCodex = (
       ? "accept"
       : "decline";
 
-const translateItem = (
+interface CodexToolTranslationLogger {
+  readonly path: string;
+  readonly append: (
+    phase: "started" | "completed",
+    item: ThreadItem,
+    events: ReadonlyArray<AgentEvent>,
+  ) => void;
+}
+
+const createCodexToolTranslationLogger = (
+  cwd: string,
+  sessionId: AgentSessionId,
+): CodexToolTranslationLogger => {
+  const dir = join(cwd, ".context");
+  const path = join(dir, `codex-tools.${sessionId}.ndjson`);
+  const safeJson = (value: unknown): string => {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return JSON.stringify("(unserializable)");
+    }
+  };
+  return {
+    path,
+    append: (phase, item, events) => {
+      if (
+        events.length === 0 ||
+        (item.type !== "commandExecution" &&
+          item.type !== "fileChange" &&
+          item.type !== "mcpToolCall" &&
+          item.type !== "dynamicToolCall" &&
+          item.type !== "webSearch")
+      ) {
+        return;
+      }
+      try {
+        mkdirSync(dir, { recursive: true });
+        appendFileSync(
+          path,
+          `${safeJson({
+            ts: new Date().toISOString(),
+            provider: "codex",
+            phase,
+            itemType: item.type,
+            itemId: "id" in item ? item.id : null,
+            raw: item,
+            events,
+          })}\n`,
+        );
+      } catch {
+        // Best-effort debug log: never disrupt the agent loop.
+      }
+    },
+  };
+};
+
+export const translateCodexItem = (
   item: ThreadItem,
   phase: "started" | "completed",
 ): ReadonlyArray<AgentEvent> => {
   switch (item.type) {
     case "agentMessage":
       if (phase !== "completed") return [];
-      return [{ _tag: "AssistantMessage", itemId: nextItemId(), text: item.text }];
+      return [
+        { _tag: "AssistantMessage", itemId: nextItemId(), text: item.text },
+      ];
     case "plan":
       if (phase !== "completed") return [];
-      return [{ _tag: "AssistantMessage", itemId: nextItemId(), text: item.text }];
+      return [
+        { _tag: "AssistantMessage", itemId: nextItemId(), text: item.text },
+      ];
     case "reasoning": {
       if (phase !== "completed") return [];
       const text = [...item.summary, ...item.content].join("\n").trim();
@@ -109,40 +427,33 @@ const translateItem = (
     }
     case "commandExecution":
       if (phase === "started") {
-        return [
-          {
-            _tag: "ToolUse",
-            itemId: item.id as AgentItemId,
-            tool: "command_execution",
-            input: { command: item.command, cwd: item.cwd },
-          },
-        ];
+        return [codexCommandToolUse(item)];
       }
       return [
         {
           _tag: "ToolResult",
           itemId: item.id as AgentItemId,
-          output: {
-            command: item.command,
-            exit_code: item.exitCode,
-            output: item.aggregatedOutput ?? "",
-          },
+          output: codexCommandResultOutput(item),
           isError: item.status === "failed",
         },
       ];
     case "fileChange":
       if (phase !== "completed") return [];
+      const fileChange = codexFileChangeInput(item);
       return [
         {
           _tag: "ToolUse",
           itemId: item.id as AgentItemId,
-          tool: "file_change",
-          input: { changes: item.changes },
+          tool: fileChange.tool,
+          input: fileChange.input,
         },
         {
           _tag: "ToolResult",
           itemId: item.id as AgentItemId,
-          output: { changes: item.changes, status: item.status },
+          output:
+            item.status === "completed"
+              ? `Applied ${item.changes.length} file change${item.changes.length === 1 ? "" : "s"}.`
+              : { changes: item.changes, status: item.status },
           isError: item.status === "failed",
         },
       ];
@@ -152,7 +463,7 @@ const translateItem = (
           {
             _tag: "ToolUse",
             itemId: item.id as AgentItemId,
-            tool: `${item.server}/${item.tool}`,
+            tool: toMcpToolName(item.server, item.tool),
             input: item.arguments,
           },
         ];
@@ -161,21 +472,22 @@ const translateItem = (
         {
           _tag: "ToolResult",
           itemId: item.id as AgentItemId,
-          output: item.result ?? item.error ?? null,
+          output:
+            item.result !== null
+              ? (firstTextBlock(item.result.content) ?? item.result.content)
+              : (item.error ?? null),
           isError: item.status === "failed",
         },
       ];
     case "dynamicToolCall":
       if (phase === "started") {
+        const toolUse = normalizeDynamicToolUse(item);
         return [
           {
             _tag: "ToolUse",
             itemId: item.id as AgentItemId,
-            tool:
-              item.namespace !== null
-                ? `${item.namespace}/${item.tool}`
-                : item.tool,
-            input: item.arguments,
+            tool: toolUse.tool,
+            input: toolUse.input,
           },
         ];
       }
@@ -183,7 +495,7 @@ const translateItem = (
         {
           _tag: "ToolResult",
           itemId: item.id as AgentItemId,
-          output: item.contentItems ?? null,
+          output: dynamicOutputText(item.contentItems),
           isError: item.success === false,
         },
       ];
@@ -197,7 +509,7 @@ const translateItem = (
           _tag: "ToolUse",
           itemId: item.id as AgentItemId,
           tool: "WebSearch",
-          input: { query: item.query, action: item.action },
+          input: { query: webSearchQueryFromAction(item), action: item.action },
         },
       ];
     case "enteredReviewMode":
@@ -235,10 +547,15 @@ export const startCodexSession = (
   sessionId: AgentSessionId,
   requestPermission: RequestPermission,
   resumeCursor: string | null = null,
-): Effect.Effect<CodexSessionHandle, AgentSessionStartError, AttachmentService> =>
+): Effect.Effect<
+  CodexSessionHandle,
+  AgentSessionStartError,
+  AttachmentService
+> =>
   Effect.gen(function* () {
     const attachments = yield* AttachmentService;
     const events = yield* Mailbox.make<AgentEvent>();
+    const toolTranslationLog = createCodexToolTranslationLogger(cwd, sessionId);
     let currentMode: PermissionMode = input.permissionMode ?? "default";
     let activeThreadId = resumeCursor;
     let currentTurnId: string | null = null;
@@ -261,13 +578,16 @@ export const startCodexSession = (
         CodexAppServerClient.start({
           codexPath,
           onNotification: (notification) => {
-            for (const event of translateNotification(notification)) emit(event);
+            for (const event of translateNotification(notification))
+              emit(event);
           },
           onServerRequest: (request, respond) => {
-            void handleServerRequest(request).then(respond).catch((cause) => {
-              console.warn("[codex-app-server] request failed", cause);
-              respond(defaultServerRequestResponse(request));
-            });
+            void handleServerRequest(request)
+              .then(respond)
+              .catch((cause) => {
+                console.warn("[codex-app-server] request failed", cause);
+                respond(defaultServerRequestResponse(request));
+              });
           },
         }),
       catch: (cause) =>
@@ -281,7 +601,9 @@ export const startCodexSession = (
       // app-server uses the same CLI auth stack as the TUI. The key is still
       // accepted by the legacy SDK path, but app-server currently reads auth
       // from the user's Codex home; keep a visible note for future debugging.
-      console.warn("[codex] API key credential present; app-server uses Codex CLI auth");
+      console.warn(
+        "[codex] API key credential present; app-server uses Codex CLI auth",
+      );
     }
 
     const commonThreadParams = {
@@ -348,7 +670,11 @@ export const startCodexSession = (
     const findSkillPath = async (name: string): Promise<string | null> => {
       const response = await app.request<{
         data: ReadonlyArray<{
-          skills: ReadonlyArray<{ name: string; path: string; enabled: boolean }>;
+          skills: ReadonlyArray<{
+            name: string;
+            path: string;
+            enabled: boolean;
+          }>;
         }>;
       }>("skills/list", { cwds: [cwd], forceReload: false });
       for (const entry of response.data) {
@@ -413,7 +739,14 @@ export const startCodexSession = (
           : null;
       const turn = await app.request<{ turn: { id: string } }>("turn/start", {
         threadId: activeThreadId,
-        input: [...(await buildUserInput(promptText, attachmentRefs, fileRefs, skillRefs))],
+        input: [
+          ...(await buildUserInput(
+            promptText,
+            attachmentRefs,
+            fileRefs,
+            skillRefs,
+          )),
+        ],
         cwd,
         approvalPolicy: "never",
         sandboxPolicy: toSandboxPolicy(currentMode, cwd),
@@ -451,7 +784,9 @@ export const startCodexSession = (
 
       switch (command) {
         case "compact":
-          await app.request("thread/compact/start", { threadId: activeThreadId });
+          await app.request("thread/compact/start", {
+            threadId: activeThreadId,
+          });
           say("Compaction started.");
           return true;
         case "fork": {
@@ -477,7 +812,9 @@ export const startCodexSession = (
             threadId: activeThreadId,
             numTurns: 1,
           });
-          say("Rolled back the last Codex turn. Local file changes are not reverted by Codex app-server rollback.");
+          say(
+            "Rolled back the last Codex turn. Local file changes are not reverted by Codex app-server rollback.",
+          );
           return true;
         case "review":
           emit({ _tag: "Status", status: "running" });
@@ -492,7 +829,12 @@ export const startCodexSession = (
           return true;
         case "status": {
           const status = await app.request<{
-            thread: { id: string; status: string; modelProvider: string; cwd: string };
+            thread: {
+              id: string;
+              status: string;
+              modelProvider: string;
+              cwd: string;
+            };
           }>("thread/read", { threadId: activeThreadId, includeTurns: false });
           say(
             `Codex thread ${status.thread.id}\nstatus: ${status.thread.status}\nprovider: ${status.thread.modelProvider}\ncwd: ${status.thread.cwd}`,
@@ -500,7 +842,11 @@ export const startCodexSession = (
           return true;
         }
         case "diff":
-          say(latestDiff.length > 0 ? latestDiff : "No Codex turn diff is available yet.");
+          say(
+            latestDiff.length > 0
+              ? latestDiff
+              : "No Codex turn diff is available yet.",
+          );
           return true;
         case "mcp": {
           const result = await app.request("mcpServerStatus/list", {});
@@ -527,18 +873,22 @@ export const startCodexSession = (
           say(`Codex config:\n${asText(result)}`);
           return true;
         }
+        case "tool-log":
+        case "debug-tools":
+          say(`Codex tool translation log:\n${toolTranslationLog.path}`);
+          return true;
         case "permissions":
-          say("Codex approval policy is managed by this app. Current embedded policy: never.");
+          say(
+            "Codex approval policy is managed by this app. Current embedded policy: never.",
+          );
           return true;
         case "approval":
-          say("Codex embedded approval policy is currently fixed at never; permission prompts are bridged through this app when app-server requests them.");
+          say(
+            "Codex embedded approval policy is currently fixed at never; permission prompts are bridged through this app when app-server requests them.",
+          );
           return true;
         case "sandbox":
-          if (
-            args === "read-only" ||
-            args === "plan" ||
-            args === "readonly"
-          ) {
+          if (args === "read-only" || args === "plan" || args === "readonly") {
             currentMode = "plan";
             emit({ _tag: "PermissionModeChanged", mode: "plan" });
             say("Codex sandbox set to read-only.");
@@ -626,12 +976,36 @@ export const startCodexSession = (
           return [];
         case "item/started":
           if (notification.params.threadId !== activeThreadId) return [];
-          return translateItem(notification.params.item, "started");
+          {
+            const translated = translateCodexItem(
+              notification.params.item,
+              "started",
+            );
+            toolTranslationLog.append(
+              "started",
+              notification.params.item,
+              translated,
+            );
+            return translated;
+          }
         case "item/completed":
           if (notification.params.threadId !== activeThreadId) return [];
-          return translateItem(notification.params.item, "completed");
+          {
+            const translated = translateCodexItem(
+              notification.params.item,
+              "completed",
+            );
+            toolTranslationLog.append(
+              "completed",
+              notification.params.item,
+              translated,
+            );
+            return translated;
+          }
         case "error":
-          return [{ _tag: "Error", message: notification.params.error.message }];
+          return [
+            { _tag: "Error", message: notification.params.error.message },
+          ];
         default:
           return [];
       }
@@ -714,7 +1088,8 @@ export const startCodexSession = (
             },
           );
           const waiter = questionWaiters.get(p.itemId);
-          const questionIds = waiter?.questionIds ?? p.questions.map((q) => q.id);
+          const questionIds =
+            waiter?.questionIds ?? p.questions.map((q) => q.id);
           const out: Record<string, { answers: string[] }> = {};
           for (const answer of answers) {
             const question = p.questions[answer.questionIndex];

--- a/apps/server/test/codex-translate.test.ts
+++ b/apps/server/test/codex-translate.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+
+import type { AgentEvent } from "@memoize/wire";
+
+import type { ThreadItem } from "../src/provider/codex-app-protocol/v2/ThreadItem.ts";
+import {
+  codexWritableRootsForCwd,
+  translateCodexItem,
+} from "../src/provider/drivers/codex.ts";
+
+const tags = (events: ReadonlyArray<AgentEvent>): string[] =>
+  events.map((event) => event._tag);
+
+const only = <T extends AgentEvent["_tag"]>(
+  events: ReadonlyArray<AgentEvent>,
+  tag: T,
+): Extract<AgentEvent, { _tag: T }> => {
+  expect(tags(events)).toEqual([tag]);
+  return events[0] as Extract<AgentEvent, { _tag: T }>;
+};
+
+describe("translateCodexItem", () => {
+  it("maps a parsed read command to the canonical Read row", () => {
+    const item: ThreadItem = {
+      type: "commandExecution",
+      id: "cmd1",
+      command: "sed -n '1,20p' apps/server/src/index.ts",
+      cwd: "/repo",
+      processId: null,
+      source: "agent",
+      status: "inProgress",
+      commandActions: [
+        {
+          type: "read",
+          command: "sed -n '1,20p' apps/server/src/index.ts",
+          name: "sed",
+          path: "/repo/apps/server/src/index.ts",
+        },
+      ],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    };
+
+    const ev = only(translateCodexItem(item, "started"), "ToolUse");
+    expect(ev.tool).toBe("Read");
+    expect(ev.input).toEqual({ file_path: "/repo/apps/server/src/index.ts" });
+  });
+
+  it("returns raw command output for a completed canonical Read", () => {
+    const item: ThreadItem = {
+      type: "commandExecution",
+      id: "cmd1",
+      command: "/bin/zsh -lc \"sed -n '1,220p' package.json\"",
+      cwd: "/repo",
+      processId: null,
+      source: "agent",
+      status: "completed",
+      commandActions: [
+        {
+          type: "read",
+          command: "sed -n '1,220p' package.json",
+          name: "sed",
+          path: "/repo/package.json",
+        },
+      ],
+      aggregatedOutput: "{\n  \"name\": \"desktop\"\n}\n",
+      exitCode: 0,
+      durationMs: 12,
+    };
+
+    const ev = only(translateCodexItem(item, "completed"), "ToolResult");
+    expect(ev.output).toBe("{\n  \"name\": \"desktop\"\n}\n");
+  });
+
+  it("falls back to Bash for ordinary command execution", () => {
+    const item: ThreadItem = {
+      type: "commandExecution",
+      id: "cmd2",
+      command: "bun test apps/server/test/translate.test.ts",
+      cwd: "/repo",
+      processId: null,
+      source: "agent",
+      status: "inProgress",
+      commandActions: [],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    };
+
+    const ev = only(translateCodexItem(item, "started"), "ToolUse");
+    expect(ev.tool).toBe("Bash");
+    expect(ev.input).toMatchObject({
+      command: "bun test apps/server/test/translate.test.ts",
+      cwd: "/repo",
+    });
+  });
+
+  it("renders Codex file changes as patch-backed edit rows", () => {
+    const item: ThreadItem = {
+      type: "fileChange",
+      id: "patch1",
+      status: "completed",
+      changes: [
+        {
+          path: "apps/server/src/provider/drivers/codex.ts",
+          kind: { type: "update", move_path: null },
+          diff: "@@ -1 +1 @@\n-old\n+new",
+        },
+      ],
+    };
+
+    const out = translateCodexItem(item, "completed");
+    expect(tags(out)).toEqual(["ToolUse", "ToolResult"]);
+    const use = out[0] as Extract<AgentEvent, { _tag: "ToolUse" }>;
+    expect(use.tool).toBe("Edit");
+    expect(use.input).toEqual({
+      file_path: "apps/server/src/provider/drivers/codex.ts",
+      kind: "update",
+      patch: "@@ -1 +1 @@\n-old\n+new",
+      move_path: null,
+    });
+  });
+
+  it("normalizes MCP tool names to Claude-style names", () => {
+    const item: ThreadItem = {
+      type: "mcpToolCall",
+      id: "mcp1",
+      server: "memoize",
+      tool: "browser_screenshot",
+      status: "inProgress",
+      arguments: {},
+      result: null,
+      error: null,
+      durationMs: null,
+    };
+
+    const ev = only(translateCodexItem(item, "started"), "ToolUse");
+    expect(ev.tool).toBe("mcp__memoize__browser_screenshot");
+  });
+});
+
+describe("codexWritableRootsForCwd", () => {
+  it("includes the real Git metadata dirs for worktree-safe git operations", () => {
+    const cwd = process.cwd();
+    const gitDirs = execFileSync(
+      "git",
+      ["rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"],
+      { cwd, encoding: "utf8" },
+    )
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    expect(codexWritableRootsForCwd(cwd)).toEqual(
+      expect.arrayContaining([cwd, ...gitDirs]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize Codex app-server tool items into the same canonical tool names the renderer already handles (`Read`, `Bash`, `Grep`, `ListDir`, `Edit`, `MultiEdit`, `WebSearch`, and Claude-style MCP names).
- Render Codex file changes as patch-backed edit rows and expose `/tool-log` / `/debug-tools` for per-session translation logs in `.context`.
- Fix Codex worktree sandboxes by granting writable access to the real Git metadata dirs and enabling network access for workspace-write sessions so Git sync commands can run.
- Return raw command output for completed Codex command executions so `Read` rows show file contents instead of a `{ command, exit_code, output }` JSON envelope.

## Why

Codex tool events were reaching the UI with provider-specific names and result envelopes. That made read/file/search operations look like generic command output or raw JSON instead of the cleaner Claude/Grok-style rows. In worktree sessions, Codex also lacked access to the external Git metadata paths required by normal Git operations.

## Validation

- `bun test apps/server/test/codex-translate.test.ts apps/server/test/translate.test.ts`
- `bun run --filter @memoize/server check-types`
- `bun run --filter @memoize/server test`

Note: `bun run --filter renderer check-types` still fails on existing unrelated type errors in `app.tsx`, `file-editor.tsx`, `file-tree.tsx`, and `markdown-body.tsx`.
