### PR TITLE
[codex] Add repo branch toolbar

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2,6 +2,7 @@ import { RpcSerialization } from "@effect/rpc";
 import {
   app,
   BrowserWindow,
+  clipboard,
   dialog,
   ipcMain,
   nativeTheme,
@@ -11,9 +12,12 @@ import {
 } from "electron";
 import { Effect, Fiber, Layer } from "effect";
 import fixPath from "fix-path";
+import { execFile, spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
+import { homedir } from "node:os";
 import * as Path from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 
 import { makeMainLayer } from "@memoize/server";
 
@@ -78,6 +82,263 @@ nativeTheme.themeSource = "dark";
 
 let mainWindow: BrowserWindow | null = null;
 let runtimeFiber: Fiber.RuntimeFiber<void, never> | null = null;
+const USER_APPLICATIONS_DIR = Path.join(homedir(), "Applications");
+const execFileAsync = promisify(execFile);
+
+type OpenTargetDefinition = {
+  readonly id: string;
+  readonly label: string;
+  readonly appName: string | null;
+  readonly appPaths: ReadonlyArray<string>;
+  readonly iconNames?: ReadonlyArray<string>;
+  readonly iconPaths?: ReadonlyArray<string>;
+};
+
+const OPEN_TARGETS: ReadonlyArray<OpenTargetDefinition> = [
+  {
+    id: "finder",
+    label: "Finder",
+    appName: null,
+    appPaths: ["/System/Library/CoreServices/Finder.app"],
+    iconNames: ["Finder"],
+    iconPaths: [
+      "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/FinderIcon.icns",
+    ],
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    appName: "Cursor",
+    appPaths: [
+      "/Applications/Cursor.app",
+      Path.join(USER_APPLICATIONS_DIR, "Cursor.app"),
+    ],
+    iconNames: ["Cursor"],
+  },
+  {
+    id: "vscode",
+    label: "VS Code",
+    appName: "Visual Studio Code",
+    appPaths: [
+      "/Applications/Visual Studio Code.app",
+      Path.join(USER_APPLICATIONS_DIR, "Visual Studio Code.app"),
+      "/Applications/Visual Studio Code - Insiders.app",
+      Path.join(USER_APPLICATIONS_DIR, "Visual Studio Code - Insiders.app"),
+    ],
+    iconNames: ["Code", "Visual Studio Code", "VSCode"],
+  },
+  {
+    id: "windsurf",
+    label: "Windsurf",
+    appName: "Windsurf",
+    appPaths: [
+      "/Applications/Windsurf.app",
+      Path.join(USER_APPLICATIONS_DIR, "Windsurf.app"),
+    ],
+    iconNames: ["Windsurf"],
+  },
+  {
+    id: "zed",
+    label: "Zed",
+    appName: "Zed",
+    appPaths: [
+      "/Applications/Zed.app",
+      Path.join(USER_APPLICATIONS_DIR, "Zed.app"),
+    ],
+    iconNames: ["Zed"],
+  },
+  {
+    id: "xcode",
+    label: "Xcode",
+    appName: "Xcode",
+    appPaths: [
+      "/Applications/Xcode.app",
+      Path.join(USER_APPLICATIONS_DIR, "Xcode.app"),
+    ],
+    iconNames: ["Xcode"],
+  },
+  {
+    id: "ghostty",
+    label: "Ghostty",
+    appName: "Ghostty",
+    appPaths: [
+      "/Applications/Ghostty.app",
+      Path.join(USER_APPLICATIONS_DIR, "Ghostty.app"),
+    ],
+    iconNames: ["Ghostty"],
+  },
+  {
+    id: "terminal",
+    label: "Terminal",
+    appName: "Terminal",
+    appPaths: ["/System/Applications/Utilities/Terminal.app"],
+    iconNames: ["Terminal"],
+  },
+  {
+    id: "antigravity",
+    label: "Antigravity",
+    appName: "Antigravity",
+    appPaths: [
+      "/Applications/Antigravity.app",
+      Path.join(USER_APPLICATIONS_DIR, "Antigravity.app"),
+    ],
+    iconNames: ["Antigravity"],
+  },
+];
+
+const openTargetById = new Map(
+  OPEN_TARGETS.map((target) => [target.id, target]),
+);
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const firstExistingPath = async (
+  paths: ReadonlyArray<string>,
+): Promise<string | null> => {
+  for (const candidate of paths) {
+    if (await pathExists(candidate)) return candidate;
+  }
+  return null;
+};
+
+const normalizeIconHint = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+const plistRawValue = async (
+  plistPath: string,
+  key: string,
+): Promise<string | null> => {
+  try {
+    const { stdout } = await execFileAsync(
+      "/usr/bin/plutil",
+      ["-extract", key, "raw", "-o", "-", plistPath],
+      { encoding: "utf8" },
+    );
+    const value = stdout.trim();
+    return value.length === 0 ? null : value;
+  } catch {
+    return null;
+  }
+};
+
+const iconFileNames = (iconName: string): ReadonlyArray<string> => {
+  const trimmed = iconName.trim();
+  if (trimmed.length === 0) return [];
+  return trimmed.toLowerCase().endsWith(".icns")
+    ? [trimmed]
+    : [trimmed, `${trimmed}.icns`];
+};
+
+const bundleDeclaredIconNames = async (
+  appPath: string,
+): Promise<ReadonlyArray<string>> => {
+  const plistPath = Path.join(appPath, "Contents", "Info.plist");
+  const names = await Promise.all([
+    plistRawValue(plistPath, "CFBundleIconFile"),
+    plistRawValue(plistPath, "CFBundleIconName"),
+  ]);
+  return names.flatMap((name) => (name === null ? [] : iconFileNames(name)));
+};
+
+const bundleIconPath = async (
+  target: OpenTargetDefinition,
+  appPath: string | null,
+): Promise<string | null> => {
+  const explicitIconPath = await firstExistingPath(target.iconPaths ?? []);
+  if (explicitIconPath !== null) return explicitIconPath;
+  if (appPath === null) return null;
+
+  const resourcesPath = Path.join(appPath, "Contents", "Resources");
+  const declaredIconNames = await bundleDeclaredIconNames(appPath);
+  const candidateIconNames = [
+    ...declaredIconNames,
+    ...(target.iconNames ?? []).flatMap(iconFileNames),
+  ];
+
+  for (const fileName of candidateIconNames) {
+    const candidate = Path.join(resourcesPath, fileName);
+    if (await pathExists(candidate)) return candidate;
+  }
+
+  let entries: ReadonlyArray<string>;
+  try {
+    entries = await fs.readdir(resourcesPath);
+  } catch {
+    return null;
+  }
+
+  const hints = [target.label, target.appName ?? "", target.id]
+    .filter((value) => value.length > 0)
+    .map(normalizeIconHint);
+  const genericIconNames = new Set(["document", "default", "file", "text"]);
+  const scored = entries
+    .filter((entry) => entry.toLowerCase().endsWith(".icns"))
+    .map((entry) => {
+      const baseName = normalizeIconHint(Path.basename(entry, ".icns"));
+      let score = 0;
+      if (hints.includes(baseName)) score += 100;
+      else if (
+        hints.some(
+          (hint) =>
+            hint.length > 0 &&
+            (baseName.includes(hint) || hint.includes(baseName)),
+        )
+      ) {
+        score += 80;
+      }
+      if (genericIconNames.has(baseName)) score -= 50;
+      return { entry, score };
+    })
+    .sort((left, right) => right.score - left.score);
+
+  const best = scored.find((item) => item.score > 0) ?? scored[0];
+  return best === undefined ? null : Path.join(resourcesPath, best.entry);
+};
+
+const appIconDataUrl = async (
+  target: OpenTargetDefinition,
+  appPath: string | null,
+): Promise<string | null> => {
+  const iconPath = await bundleIconPath(target, appPath);
+  if (iconPath === null) return null;
+  try {
+    const stat = await fs.stat(iconPath);
+    const cacheDir = Path.join(app.getPath("userData"), "open-target-icons");
+    await fs.mkdir(cacheDir, { recursive: true });
+    const cacheName = `${target.id}-${stat.size}-${Math.floor(stat.mtimeMs)}.png`;
+    const pngPath = Path.join(cacheDir, cacheName);
+    if (!(await pathExists(pngPath))) {
+      await execFileAsync(
+        "/usr/bin/sips",
+        ["-s", "format", "png", iconPath, "--out", pngPath],
+        { encoding: "utf8" },
+      );
+    }
+    const data = await fs.readFile(pngPath);
+    return `data:image/png;base64,${data.toString("base64")}`;
+  } catch {
+    return null;
+  }
+};
+
+const openWithApp = (appSpecifier: string, targetPath: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const child = spawn("open", ["-a", appSpecifier, targetPath], {
+      stdio: "ignore",
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`open exited with code ${code ?? "null"}`));
+    });
+  });
 
 // Electron's dialog is the only host-shell API the server reaches for. Wrap
 // it here so apps/server stays free of any UI-toolkit imports — see ADR 0007.
@@ -93,11 +354,7 @@ const folderPicker = {
     Effect.promise(() =>
       dialog.showOpenDialog({
         defaultPath: app.getPath("home"),
-        properties: [
-          "openDirectory",
-          "createDirectory",
-          "showHiddenFiles",
-        ],
+        properties: ["openDirectory", "createDirectory", "showHiddenFiles"],
       }),
     ).pipe(
       Effect.map((result) =>
@@ -151,10 +408,7 @@ function createMainWindow() {
   // toggle — a fresh boot in fullscreen still gets the initial value.
   const sendFullScreenState = () => {
     if (mainWindow === null) return;
-    mainWindow.webContents.send(
-      "window:fullscreen",
-      mainWindow.isFullScreen(),
-    );
+    mainWindow.webContents.send("window:fullscreen", mainWindow.isFullScreen());
   };
   mainWindow.on("enter-full-screen", sendFullScreenState);
   mainWindow.on("leave-full-screen", sendFullScreenState);
@@ -181,6 +435,58 @@ function createMainWindow() {
 
   ipcMain.on("app:openExternal", (_event, rawUrl: unknown) => {
     openHttpExternal(rawUrl);
+  });
+
+  ipcMain.handle("app:listOpenTargets", async (_event, rawPath: unknown) => {
+    if (typeof rawPath !== "string" || rawPath.length === 0) return [];
+    const existingPath = await pathExists(rawPath);
+    if (!existingPath) return [];
+
+    return Promise.all(
+      OPEN_TARGETS.map(async (target) => {
+        const appPath = await firstExistingPath(target.appPaths);
+        const alwaysAvailable =
+          target.id === "finder" || target.id === "terminal";
+        const iconDataUrl = await appIconDataUrl(target, appPath);
+        const available = alwaysAvailable || appPath !== null;
+        return {
+          id: target.id,
+          label: target.label,
+          available,
+          iconDataUrl,
+        };
+      }),
+    );
+  });
+
+  ipcMain.handle(
+    "app:openPathInApp",
+    async (_event, rawPath: unknown, rawAppId: unknown) => {
+      if (typeof rawPath !== "string" || typeof rawAppId !== "string") return;
+      if (!(await pathExists(rawPath))) return;
+      const target = openTargetById.get(rawAppId);
+      if (target === undefined) return;
+      if (target.id === "finder") {
+        shell.showItemInFolder(rawPath);
+        return;
+      }
+      const appPath = await firstExistingPath(target.appPaths);
+      const appSpecifier = appPath ?? target.appName;
+      if (appSpecifier === null) return;
+      await openWithApp(appSpecifier, rawPath);
+    },
+  );
+
+  ipcMain.handle("app:revealPath", async (_event, rawPath: unknown) => {
+    if (typeof rawPath !== "string") return;
+    if (!(await pathExists(rawPath))) return;
+    shell.showItemInFolder(rawPath);
+  });
+
+  ipcMain.handle("app:copyPath", async (_event, rawPath: unknown) => {
+    if (typeof rawPath !== "string") return;
+    if (!(await pathExists(rawPath))) return;
+    clipboard.writeText(rawPath);
   });
 
   // Markdown links rendered by react-markdown have no `target="_blank"`, so a
@@ -248,9 +554,9 @@ function createMainWindow() {
   // Boot the Effect runtime once the window's webContents exists. The RPC
   // server protocol is bound to this webContents, so a window restart means
   // a fresh runtime — the only Effect.runFork in the main process.
-  const serverProtocol = electronServerProtocolLayer(mainWindow.webContents).pipe(
-    Layer.provide(RpcSerialization.layerJson),
-  );
+  const serverProtocol = electronServerProtocolLayer(
+    mainWindow.webContents,
+  ).pipe(Layer.provide(RpcSerialization.layerJson));
 
   runtimeFiber = Effect.runFork(
     Layer.launch(
@@ -290,7 +596,13 @@ function createMainWindow() {
     // <app>/Contents/Resources/app/renderer/dist (see
     // apps/desktop/electron-builder.yml).
     const rendererIndex = app.isPackaged
-      ? Path.join(process.resourcesPath, "app", "renderer", "dist", "index.html")
+      ? Path.join(
+          process.resourcesPath,
+          "app",
+          "renderer",
+          "dist",
+          "index.html",
+        )
       : Path.resolve(__dirname, "..", "..", "renderer", "dist", "index.html");
     void mainWindow.loadFile(rendererIndex);
   }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -44,6 +44,21 @@ const bridge = {
     openExternal: (url: string) => {
       ipcRenderer.send("app:openExternal", url);
     },
+    listOpenTargets: (path: string) =>
+      ipcRenderer.invoke("app:listOpenTargets", path) as Promise<
+        ReadonlyArray<{
+          readonly id: string;
+          readonly label: string;
+          readonly available: boolean;
+          readonly iconDataUrl?: string | null;
+        }>
+      >,
+    openPathInApp: (path: string, appId: string) =>
+      ipcRenderer.invoke("app:openPathInApp", path, appId) as Promise<void>,
+    revealPath: (path: string) =>
+      ipcRenderer.invoke("app:revealPath", path) as Promise<void>,
+    copyPath: (path: string) =>
+      ipcRenderer.invoke("app:copyPath", path) as Promise<void>,
   },
   updates: {
     onStatus: (handler: (status: UpdateStatus) => void) => {

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import { ArrowLeft, ArrowRight, RotateCw, Star } from "lucide-react";
 import { Effect, Fiber, Stream } from "effect";
 
-import { BrowserCommandResult, type BrowserCommandRequest } from "@memoize/wire";
+import {
+  BrowserCommandResult,
+  type BrowserCommandRequest,
+} from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useUiStore } from "../store/ui.ts";
@@ -226,9 +229,7 @@ export function BrowserPane() {
           disabled={url === ""}
           ariaLabel={isLoading ? "Stop" : "Reload"}
         >
-          <RotateCw
-            className={`size-3.5 ${isLoading ? "animate-spin" : ""}`}
-          />
+          <RotateCw className={`size-3.5 ${isLoading ? "animate-spin" : ""}`} />
         </ToolbarButton>
         <ToolbarButton
           onClick={() => {
@@ -257,7 +258,7 @@ export function BrowserPane() {
         <webview
           ref={webviewRef as unknown as React.RefObject<HTMLElement>}
           src={url === "" ? "about:blank" : url}
-          allowpopups={true}
+          allowpopups="true"
           style={{
             display: url === "" ? "none" : "flex",
             width: "100%",
@@ -316,9 +317,13 @@ async function runBrowserCommand(
         await delay(180);
         const image = await wv.capturePage();
         if (image.isEmpty()) {
-          return fail("Screenshot came back empty — the page may still be loading.");
+          return fail(
+            "Screenshot came back empty — the page may still be loading.",
+          );
         }
-        const base64 = image.toDataURL().replace(/^data:image\/png;base64,/, "");
+        const base64 = image
+          .toDataURL()
+          .replace(/^data:image\/png;base64,/, "");
         hooks.flashShutter();
         return BrowserCommandResult.make({
           id: req.id,
@@ -356,7 +361,10 @@ async function runBrowserCommand(
         return resultFromJs(req.id, res, `Typed into ${command.ref}.`);
       }
       case "Wait": {
-        if (typeof command.selector === "string" && command.selector.length > 0) {
+        if (
+          typeof command.selector === "string" &&
+          command.selector.length > 0
+        ) {
           const res = await runJsObject(
             wv,
             `(async () => { const sel = ${JSON.stringify(command.selector)}; const deadline = Date.now() + 10000; while (Date.now() < deadline) { if (document.querySelector(sel)) return JSON.stringify({ ok:true, detail:'Element appeared: ' + sel }); await new Promise(r => setTimeout(r, 150)); } return JSON.stringify({ ok:false, error:'Timed out (10s) waiting for ' + sel }); })()`,
@@ -406,9 +414,9 @@ async function runBrowserCommand(
       case "Press": {
         const refClause =
           typeof command.ref === "string" && command.ref.length > 0
-            ? (isValidRef(command.ref)
-                ? `document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]')`
-                : null)
+            ? isValidRef(command.ref)
+              ? `document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]')`
+              : null
             : `(document.activeElement || document.body)`;
         if (refClause === null) return fail("Invalid element ref.");
         const res = await runJsObject(
@@ -420,9 +428,9 @@ async function runBrowserCommand(
       case "Read": {
         const refExpr =
           typeof command.ref === "string" && command.ref.length > 0
-            ? (isValidRef(command.ref)
-                ? `document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]')`
-                : null)
+            ? isValidRef(command.ref)
+              ? `document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]')`
+              : null
             : `document.body`;
         if (refExpr === null) return fail("Invalid element ref.");
         const raw = await wv.executeJavaScript(
@@ -643,8 +651,9 @@ function resolveUrl(input: string): string | null {
   const trimmed = input.trim();
   if (trimmed === "") return null;
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
-  const isLocal =
-    /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:|\/|$)/i.test(trimmed);
+  const isLocal = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:|\/|$)/i.test(
+    trimmed,
+  );
   return `${isLocal ? "http" : "https"}://${trimmed}`;
 }
 

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -2,6 +2,9 @@ import {
   Archive,
   Check,
   ChevronDown,
+  Copy,
+  Edit3,
+  ExternalLink,
   GitBranch,
   GitMerge,
   GitPullRequestArrow,
@@ -16,16 +19,25 @@ import {
   Wrench,
 } from "lucide-react";
 import { Effect } from "effect";
-import { type CSSProperties, type ReactNode, useEffect, useState } from "react";
+import {
+  type CSSProperties,
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   ComposerInput,
   type FolderId,
+  type GitBranchInfo,
   type GitMergeMethod,
   type WorktreeId,
 } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
+import type { OpenTarget } from "../lib/bridge.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
 import {
   GlassActionButton,
@@ -41,7 +53,27 @@ import { useMessagesStore } from "../store/messages.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu.tsx";
+import { useWorkspaceStore } from "../store/workspace.ts";
+import { Button } from "./ui/button.tsx";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog.tsx";
+import { Input } from "./ui/input.tsx";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuSeparator,
+  MenuShortcut,
+  MenuTrigger,
+} from "./ui/menu.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 /**
@@ -128,6 +160,14 @@ export function TopBarMain() {
   const rightSidebarOpen = useUiStore((s) => s.rightSidebarOpen);
   const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
   const isFullScreen = useUiStore((s) => s.isFullScreen);
+  const folder = useWorkspaceStore((s) =>
+    folderId ? (s.folders.find((f) => f.id === folderId) ?? null) : null,
+  );
+  const [originLabel, setOriginLabel] = useState<string | null>(null);
+  const [branches, setBranches] = useState<ReadonlyArray<GitBranchInfo>>([]);
+  const [branchesLoading, setBranchesLoading] = useState(false);
+  const [branchError, setBranchError] = useState<string | null>(null);
+  const [renameOpen, setRenameOpen] = useState(false);
 
   // Poll both `git status` (branch / dirty / ahead) and the PR state (CI
   // rollup, mergeable, auto-merge) on the same 5s tick so the top-bar PR
@@ -148,6 +188,7 @@ export function TopBarMain() {
   // until the first refresh lands — which is the correct behavior. No
   // stale-branch flash during the swap.
   const branchLabel = status?.branch ?? null;
+  const repoLabel = originLabel ?? folder?.name ?? "No repository";
   const showLeftToggle = !leftSidebarOpen;
   // When the left panel is open its own header carries the traffic-light
   // gutter, so this section starts flush. When it's collapsed we slide the
@@ -155,6 +196,85 @@ export function TopBarMain() {
   // for the macOS controls. Native fullscreen hides those controls, so we
   // skip the reserve.
   const leftPad = showLeftToggle ? (isFullScreen ? "pl-2" : "pl-20") : "pl-2";
+
+  useEffect(() => {
+    if (folderId === null) {
+      setOriginLabel(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const client = await getRpcClient();
+        const origin = await Effect.runPromise(client.git.origin({ folderId }));
+        if (cancelled) return;
+        setOriginLabel(
+          origin !== null ? `${origin.owner}/${origin.repo}` : null,
+        );
+      } catch {
+        if (!cancelled) setOriginLabel(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [folderId]);
+
+  const refreshBranches = async (): Promise<void> => {
+    if (folderId === null) return;
+    setBranchesLoading(true);
+    setBranchError(null);
+    try {
+      const client = await getRpcClient();
+      const list = await Effect.runPromise(
+        client.git.branches({ folderId, worktreeId }),
+      );
+      setBranches(list);
+    } catch (err) {
+      setBranchError(errorMessage(err));
+    } finally {
+      setBranchesLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshBranches();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folderId, worktreeId, branchLabel]);
+
+  const switchToBranch = async (branch: GitBranchInfo): Promise<void> => {
+    if (folderId === null || branch.current) return;
+    if (
+      status !== null &&
+      status.dirtyFiles > 0 &&
+      !window.confirm(
+        `Switch branches with ${status.dirtyFiles} uncommitted change${
+          status.dirtyFiles === 1 ? "" : "s"
+        }? Git may refuse if the changes conflict.`,
+      )
+    ) {
+      return;
+    }
+    setBranchesLoading(true);
+    setBranchError(null);
+    try {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.git.switchBranch({
+          folderId,
+          worktreeId,
+          branch: branch.name,
+          remote: branch.remote,
+        }),
+      );
+      refreshAfterAction(folderId, worktreeId);
+      await refreshBranches();
+    } catch (err) {
+      setBranchError(errorMessage(err));
+    } finally {
+      setBranchesLoading(false);
+    }
+  };
 
   return (
     <header className={`${SECTION_CLASS} ${leftPad} pr-1`}>
@@ -180,24 +300,45 @@ export function TopBarMain() {
           </TooltipPopup>
         </Tooltip>
       ) : null}
-      <div
-        className={`flex min-w-0 flex-1 items-center gap-1.5 ${ACTION_CLASS}`}
-      >
-        {branchLabel ? (
-          <>
-            <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="truncate font-medium" title={branchLabel}>
-              {branchLabel}
-            </span>
-            {status && status.dirtyFiles > 0 ? (
-              <span className="shrink-0 text-muted-foreground">
-                · {status.dirtyFiles} change
-                {status.dirtyFiles === 1 ? "" : "s"}
-              </span>
-            ) : null}
-          </>
-        ) : null}
+      <div className={`flex min-w-0 flex-1 items-center ${ACTION_CLASS}`}>
+        <div className="flex min-w-0 max-w-[min(620px,100%)] items-center gap-1.5 text-xs">
+          <span
+            className="truncate font-medium text-foreground"
+            title={repoLabel}
+          >
+            {repoLabel}
+          </span>
+          {branchLabel ? (
+            <>
+              <span className="shrink-0 text-muted-foreground/70">/</span>
+              <BranchMenuButton
+                branchLabel={branchLabel}
+                branches={branches}
+                dirtyFiles={status?.dirtyFiles ?? 0}
+                error={branchError}
+                loading={branchesLoading}
+                onOpen={() => void refreshBranches()}
+                onRename={() => setRenameOpen(true)}
+                onSwitch={(branch) => void switchToBranch(branch)}
+              />
+            </>
+          ) : null}
+        </div>
       </div>
+      {folderId !== null && branchLabel !== null ? (
+        <RenameBranchDialog
+          branchLabel={branchLabel}
+          folderId={folderId}
+          open={renameOpen}
+          onOpenChange={setRenameOpen}
+          onRenamed={async () => {
+            refreshAfterAction(folderId, worktreeId);
+            await refreshBranches();
+          }}
+          worktreeId={worktreeId}
+        />
+      ) : null}
+      <OpenInMenu rootPath={ctx.status === "ready" ? ctx.rootPath : null} />
       <Tooltip>
         <TooltipTrigger
           render={
@@ -226,6 +367,319 @@ export function TopBarMain() {
       </Tooltip>
     </header>
   );
+}
+
+function BranchMenuButton({
+  branchLabel,
+  branches,
+  dirtyFiles,
+  error,
+  loading,
+  onOpen,
+  onRename,
+  onSwitch,
+}: {
+  branchLabel: string;
+  branches: ReadonlyArray<GitBranchInfo>;
+  dirtyFiles: number;
+  error: string | null;
+  loading: boolean;
+  onOpen: () => void;
+  onRename: () => void;
+  onSwitch: (branch: GitBranchInfo) => void;
+}) {
+  const localBranches = branches.filter((b) => b.kind === "local");
+  const remoteBranches = branches.filter((b) => b.kind === "remote");
+
+  return (
+    <Menu>
+      <MenuTrigger
+        onClick={onOpen}
+        className="flex max-w-64 items-center gap-1 rounded-sm px-1.5 py-0.5 font-medium text-foreground outline-none hover:bg-foreground/5 data-[popup-open]:bg-foreground/5"
+        aria-label="Switch branch"
+      >
+        <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="truncate" title={branchLabel}>
+          {branchLabel}
+        </span>
+        {dirtyFiles > 0 ? (
+          <span className="shrink-0 text-muted-foreground">· {dirtyFiles}</span>
+        ) : null}
+        {loading ? (
+          <Loader2 className="size-3 animate-spin text-muted-foreground" />
+        ) : (
+          <ChevronDown className="size-3 text-muted-foreground" />
+        )}
+      </MenuTrigger>
+      <MenuPopup align="center" className="min-w-64">
+        {error !== null ? (
+          <div className="max-w-72 px-2 py-1.5 text-[11px] leading-snug text-[var(--accent-red)]">
+            {error}
+          </div>
+        ) : null}
+        <MenuItem
+          onClick={onRename}
+          className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+        >
+          <Edit3 className="size-3.5" />
+          Rename current branch…
+        </MenuItem>
+        <MenuSeparator />
+        <MenuSectionLabel>Local branches</MenuSectionLabel>
+        {localBranches.length > 0 ? (
+          localBranches.map((branch) => (
+            <MenuItem
+              key={`local:${branch.name}`}
+              disabled={branch.current || loading}
+              onClick={() => onSwitch(branch)}
+              className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+            >
+              <Check
+                className={`size-3.5 ${branch.current ? "opacity-100" : "opacity-0"}`}
+              />
+              <span className="min-w-0 flex-1 truncate">{branch.name}</span>
+              {branch.upstream !== null ? (
+                <span className="max-w-28 truncate text-[10px] text-muted-foreground">
+                  {branch.upstream}
+                </span>
+              ) : null}
+            </MenuItem>
+          ))
+        ) : (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">
+            No local branches
+          </div>
+        )}
+        {remoteBranches.length > 0 ? (
+          <>
+            <MenuSeparator />
+            <MenuSectionLabel>Remote branches</MenuSectionLabel>
+            {remoteBranches.map((branch) => (
+              <MenuItem
+                key={`remote:${branch.remote ?? branch.name}`}
+                disabled={loading}
+                onClick={() => onSwitch(branch)}
+                className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+              >
+                <GitBranch className="size-3.5" />
+                <span className="min-w-0 flex-1 truncate">{branch.name}</span>
+                {branch.remote !== null ? (
+                  <span className="max-w-28 truncate text-[10px] text-muted-foreground">
+                    {branch.remote}
+                  </span>
+                ) : null}
+              </MenuItem>
+            ))}
+          </>
+        ) : null}
+      </MenuPopup>
+    </Menu>
+  );
+}
+
+function MenuSectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">
+      {children}
+    </div>
+  );
+}
+
+function RenameBranchDialog({
+  branchLabel,
+  folderId,
+  open,
+  onOpenChange,
+  onRenamed,
+  worktreeId,
+}: {
+  branchLabel: string;
+  folderId: FolderId;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRenamed: () => Promise<void>;
+  worktreeId: WorktreeId | null;
+}) {
+  const [value, setValue] = useState(branchLabel);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setValue(branchLabel);
+    setError(null);
+  }, [branchLabel, open]);
+
+  const submit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    const next = value.trim();
+    if (next.length === 0) {
+      setError("Branch name cannot be empty.");
+      return;
+    }
+    if (/\s/.test(next)) {
+      setError("Branch name cannot contain spaces.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.git.renameBranch({ folderId, worktreeId, name: next }),
+      );
+      await onRenamed();
+      onOpenChange(false);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Rename branch</DialogTitle>
+          <DialogDescription>
+            Rename the current local branch in this workspace.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="contents" onSubmit={(event) => void submit(event)}>
+          <DialogPanel className="flex flex-col gap-3">
+            <Input
+              autoFocus
+              value={value}
+              onChange={(event) => setValue(event.currentTarget.value)}
+              aria-label="Branch name"
+            />
+            {error !== null ? (
+              <p className="text-[11px] leading-snug text-[var(--accent-red)]">
+                {error}
+              </p>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <DialogClose type="button" disabled={loading}>
+              Cancel
+            </DialogClose>
+            <Button type="submit" disabled={loading} loading={loading}>
+              Rename
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+function OpenInMenu({ rootPath }: { rootPath: string | null }) {
+  const [targets, setTargets] = useState<ReadonlyArray<OpenTarget>>([]);
+  const [loading, setLoading] = useState(false);
+  const availableTargets = useMemo(
+    () => targets.filter((target) => target.available),
+    [targets],
+  );
+  const primary = availableTargets.find((target) => target.id === "finder");
+
+  const refreshTargets = async (): Promise<void> => {
+    if (rootPath === null) return;
+    const bridge = window.memoize?.app;
+    if (bridge?.listOpenTargets === undefined) return;
+    setLoading(true);
+    try {
+      setTargets(await bridge.listOpenTargets(rootPath));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshTargets();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootPath]);
+
+  const openTarget = async (target: OpenTarget): Promise<void> => {
+    if (rootPath === null) return;
+    const bridge = window.memoize?.app;
+    if (target.id === "finder") {
+      await bridge?.revealPath?.(rootPath);
+      return;
+    }
+    await bridge?.openPathInApp?.(rootPath, target.id);
+  };
+
+  const copyPath = async (): Promise<void> => {
+    if (rootPath === null) return;
+    await window.memoize?.app?.copyPath?.(rootPath);
+  };
+
+  return (
+    <Menu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              disabled={rootPath === null}
+              onClick={() => void refreshTargets()}
+              className={`${ACTION_CLASS} flex h-7 items-center overflow-hidden rounded-md border border-border/80 text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground disabled:pointer-events-none disabled:opacity-50`}
+              aria-label="Open workspace in app"
+            >
+              <span className="flex size-7 items-center justify-center border-r border-border/80">
+                {loading ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : primary !== undefined ? (
+                  <OpenTargetIcon target={primary} />
+                ) : (
+                  <ExternalLink className="size-3.5" />
+                )}
+              </span>
+              <span className="flex size-7 items-center justify-center">
+                <ChevronDown className="size-3.5" />
+              </span>
+            </MenuTrigger>
+          }
+        />
+        <TooltipPopup>Open in…</TooltipPopup>
+      </Tooltip>
+      <MenuPopup align="end" className="min-w-56">
+        {availableTargets.map((target, index) => (
+          <MenuItem
+            key={target.id}
+            onClick={() => void openTarget(target)}
+            className="flex w-full items-center gap-3 rounded px-2 py-1.5 text-sm hover:bg-sidebar-accent"
+          >
+            <OpenTargetIcon target={target} />
+            <span className="min-w-0 flex-1 truncate">{target.label}</span>
+            <MenuShortcut>{index + 1}</MenuShortcut>
+          </MenuItem>
+        ))}
+        <MenuSeparator />
+        <MenuItem
+          onClick={() => void copyPath()}
+          className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-sm hover:bg-sidebar-accent"
+        >
+          <Copy className="size-4" />
+          <span className="min-w-0 flex-1 truncate">Copy path</span>
+          <MenuShortcut>⌘⇧C</MenuShortcut>
+        </MenuItem>
+      </MenuPopup>
+    </Menu>
+  );
+}
+
+function OpenTargetIcon({ target }: { target: OpenTarget }) {
+  if (target.iconDataUrl !== null && target.iconDataUrl !== undefined) {
+    return (
+      <img
+        alt=""
+        src={target.iconDataUrl}
+        className="size-5 shrink-0 rounded-[4px]"
+      />
+    );
+  }
+  return <span className="size-5 shrink-0" />;
 }
 
 type OpenPrWorkflow = {

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -20,6 +20,19 @@ export interface WindowBridge {
 
 export interface AppBridge {
   readonly openExternal: (url: string) => void;
+  readonly listOpenTargets?: (
+    path: string,
+  ) => Promise<ReadonlyArray<OpenTarget>>;
+  readonly openPathInApp?: (path: string, appId: string) => Promise<void>;
+  readonly revealPath?: (path: string) => Promise<void>;
+  readonly copyPath?: (path: string) => Promise<void>;
+}
+
+export interface OpenTarget {
+  readonly id: string;
+  readonly label: string;
+  readonly available: boolean;
+  readonly iconDataUrl?: string | null;
 }
 
 export interface UpdatesBridge {

--- a/apps/server/src/git/handlers.ts
+++ b/apps/server/src/git/handlers.ts
@@ -15,6 +15,30 @@ const Status = MemoizeRpcs.toLayerHandler(
     ),
 );
 
+const Branches = MemoizeRpcs.toLayerHandler(
+  "git.branches",
+  ({ folderId, worktreeId }) =>
+    Effect.flatMap(GitService, (svc) =>
+      svc.branches(folderId, worktreeId ?? null),
+    ),
+);
+
+const SwitchBranch = MemoizeRpcs.toLayerHandler(
+  "git.switchBranch",
+  ({ folderId, worktreeId, branch, remote }) =>
+    Effect.flatMap(GitService, (svc) =>
+      svc.switchBranch(folderId, branch, remote ?? null, worktreeId ?? null),
+    ),
+);
+
+const RenameBranch = MemoizeRpcs.toLayerHandler(
+  "git.renameBranch",
+  ({ folderId, worktreeId, name }) =>
+    Effect.flatMap(GitService, (svc) =>
+      svc.renameBranch(folderId, name, worktreeId ?? null),
+    ),
+);
+
 const HeadChanged = MemoizeRpcs.toLayerHandler(
   "git.headChanged",
   ({ folderId }) =>
@@ -104,6 +128,9 @@ const FixFailingChecks = MemoizeRpcs.toLayerHandler(
 export const GitHandlersLayer = Layer.mergeAll(
   Log,
   Status,
+  Branches,
+  SwitchBranch,
+  RenameBranch,
   HeadChanged,
   Origin,
   PrState,

--- a/apps/server/src/git/layers/git-service.ts
+++ b/apps/server/src/git/layers/git-service.ts
@@ -11,6 +11,7 @@ import {
 } from "effect";
 
 import {
+  GitBranchInfo,
   GitChange,
   GitCommandError,
   GitCommit,
@@ -114,6 +115,53 @@ const parseStatusOutput = (out: string): GitStatusSummary => {
   }
 
   return GitStatusSummary.make({ branch, ahead, behind, dirtyFiles });
+};
+
+const parseBranchRows = (
+  localOut: string,
+  remoteOut: string,
+): ReadonlyArray<GitBranchInfo> => {
+  const sep = "\0";
+  const locals = new Set<string>();
+  const result: GitBranchInfo[] = [];
+
+  for (const line of localOut.split("\n")) {
+    if (line.length === 0) continue;
+    const [name, head, upstream] = line.split(sep);
+    if (name === undefined || name.length === 0) continue;
+    locals.add(name);
+    result.push(
+      GitBranchInfo.make({
+        name,
+        current: head === "*",
+        remote: null,
+        upstream: upstream && upstream.length > 0 ? upstream : null,
+        kind: "local",
+      }),
+    );
+  }
+
+  for (const line of remoteOut.split("\n")) {
+    if (line.length === 0) continue;
+    const [remoteName, head] = line.split(sep);
+    if (remoteName === undefined || remoteName.length === 0) continue;
+    if (remoteName.endsWith("/HEAD")) continue;
+    const slash = remoteName.indexOf("/");
+    if (slash <= 0 || slash === remoteName.length - 1) continue;
+    const branchName = remoteName.slice(slash + 1);
+    if (locals.has(branchName)) continue;
+    result.push(
+      GitBranchInfo.make({
+        name: branchName,
+        current: head === "*",
+        remote: remoteName,
+        upstream: null,
+        kind: "remote",
+      }),
+    );
+  }
+
+  return result;
 };
 
 // Map a single porcelain-v2 status code (per `git status --porcelain=v2`):
@@ -465,6 +513,98 @@ export const GitServiceLive = Layer.effect(
         run(folderId, cwd, ["status", "--porcelain=v2", "--branch"]).pipe(
           Effect.map(parseStatusOutput),
         ),
+      );
+
+    const branches: GitService["Type"]["branches"] = (folderId, worktreeId) =>
+      Effect.flatMap(resolvePathForWorktree(folderId, worktreeId), (cwd) =>
+        Effect.gen(function* () {
+          const format = "%(refname:short)%00%(HEAD)%00%(upstream:short)";
+          const localOut = yield* run(folderId, cwd, [
+            "branch",
+            "--format",
+            format,
+          ]);
+          const remoteOut = yield* run(folderId, cwd, [
+            "branch",
+            "-r",
+            "--format",
+            format,
+          ]).pipe(Effect.catchTag("GitCommandError", () => Effect.succeed("")));
+          return parseBranchRows(localOut, remoteOut);
+        }),
+      );
+
+    const switchBranch: GitService["Type"]["switchBranch"] = (
+      folderId,
+      branch,
+      remote,
+      worktreeId,
+    ) =>
+      Effect.flatMap(resolvePathForWorktree(folderId, worktreeId), (cwd) =>
+        Effect.gen(function* () {
+          const target = branch.trim();
+          if (target.length === 0) {
+            return yield* Effect.fail(
+              new GitCommandError({
+                folderId,
+                reason: "Branch name cannot be empty.",
+              }),
+            );
+          }
+          const remoteTarget = remote?.trim() ?? "";
+          if (remoteTarget.length > 0) {
+            yield* run(folderId, cwd, ["switch", "--track", remoteTarget]);
+          } else {
+            yield* run(folderId, cwd, ["switch", target]);
+          }
+          const out = yield* run(folderId, cwd, [
+            "status",
+            "--porcelain=v2",
+            "--branch",
+          ]);
+          return parseStatusOutput(out);
+        }),
+      );
+
+    const renameBranch: GitService["Type"]["renameBranch"] = (
+      folderId,
+      name,
+      worktreeId,
+    ) =>
+      Effect.flatMap(resolvePathForWorktree(folderId, worktreeId), (cwd) =>
+        Effect.gen(function* () {
+          const next = name.trim();
+          if (next.length === 0) {
+            return yield* Effect.fail(
+              new GitCommandError({
+                folderId,
+                reason: "Branch name cannot be empty.",
+              }),
+            );
+          }
+          const current = (yield* run(folderId, cwd, [
+            "branch",
+            "--show-current",
+          ])).trim();
+          if (current.length === 0) {
+            return yield* Effect.fail(
+              new GitCommandError({
+                folderId,
+                reason: "Cannot rename a detached HEAD.",
+              }),
+            );
+          }
+          yield* run(folderId, cwd, ["check-ref-format", "--branch", next]);
+          if (current !== next) {
+            yield* run(folderId, cwd, ["branch", "-m", current, next]);
+          }
+          const out = yield* run(folderId, cwd, [
+            "status",
+            "--porcelain=v2",
+            "--branch",
+          ]);
+          return parseStatusOutput(out);
+        }),
       );
 
     const headSha = (folderId: FolderId) =>
@@ -1288,6 +1428,9 @@ export const GitServiceLive = Layer.effect(
     return {
       log,
       status,
+      branches,
+      switchBranch,
+      renameBranch,
       subscribeHeadChanges,
       origin,
       prState,

--- a/apps/server/src/git/services/git-service.ts
+++ b/apps/server/src/git/services/git-service.ts
@@ -4,6 +4,7 @@ import {
   type FolderId,
   type GitChange,
   type GitCommandError,
+  type GitBranchInfo,
   type GitCommit,
   type GitDiffResult,
   type GitFailingChecksArtifact,
@@ -31,6 +32,21 @@ export interface GitServiceShape {
   ) => Effect.Effect<ReadonlyArray<GitCommit>, GitFailure>;
   readonly status: (
     folderId: FolderId,
+    worktreeId?: WorktreeId | null,
+  ) => Effect.Effect<GitStatusSummary, GitFailure>;
+  readonly branches: (
+    folderId: FolderId,
+    worktreeId?: WorktreeId | null,
+  ) => Effect.Effect<ReadonlyArray<GitBranchInfo>, GitFailure>;
+  readonly switchBranch: (
+    folderId: FolderId,
+    branch: string,
+    remote?: string | null,
+    worktreeId?: WorktreeId | null,
+  ) => Effect.Effect<GitStatusSummary, GitFailure>;
+  readonly renameBranch: (
+    folderId: FolderId,
+    name: string,
     worktreeId?: WorktreeId | null,
   ) => Effect.Effect<GitStatusSummary, GitFailure>;
   readonly subscribeHeadChanges: (

--- a/packages/wire/src/git.ts
+++ b/packages/wire/src/git.ts
@@ -21,6 +21,19 @@ export class GitStatusSummary extends Schema.Class<GitStatusSummary>(
   dirtyFiles: Schema.Number,
 }) {}
 
+export const GitBranchKind = Schema.Literal("local", "remote");
+export type GitBranchKind = typeof GitBranchKind.Type;
+
+export class GitBranchInfo extends Schema.Class<GitBranchInfo>("GitBranchInfo")(
+  {
+    name: Schema.String,
+    current: Schema.Boolean,
+    remote: Schema.NullOr(Schema.String),
+    upstream: Schema.NullOr(Schema.String),
+    kind: GitBranchKind,
+  },
+) {}
+
 export class GitNotARepoError extends Schema.TaggedError<GitNotARepoError>()(
   "GitNotARepoError",
   { folderId: FolderId },
@@ -62,6 +75,36 @@ export const GitStatusRpc = Rpc.make("git.status", {
      * dirty/ahead counts reflect the worktree, not the main checkout.
      */
     worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
+  }),
+  success: GitStatusSummary,
+  error: GitErrors,
+});
+
+export const GitBranchesRpc = Rpc.make("git.branches", {
+  payload: Schema.Struct({
+    folderId: FolderId,
+    worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
+  }),
+  success: Schema.Array(GitBranchInfo),
+  error: GitErrors,
+});
+
+export const GitSwitchBranchRpc = Rpc.make("git.switchBranch", {
+  payload: Schema.Struct({
+    folderId: FolderId,
+    worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
+    branch: Schema.String,
+    remote: Schema.optional(Schema.NullOr(Schema.String)),
+  }),
+  success: GitStatusSummary,
+  error: GitErrors,
+});
+
+export const GitRenameBranchRpc = Rpc.make("git.renameBranch", {
+  payload: Schema.Struct({
+    folderId: FolderId,
+    worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
+    name: Schema.String,
   }),
   success: GitStatusSummary,
   error: GitErrors,

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -39,6 +39,7 @@ import {
   FsWriteFileRpc,
 } from "./fs.ts";
 import {
+  GitBranchesRpc,
   GitChangesRpc,
   GitCommitRpc,
   GitDiffRpc,
@@ -52,7 +53,9 @@ import {
   GitPrDetailsRpc,
   GitPrStateRpc,
   GitPushRpc,
+  GitRenameBranchRpc,
   GitStatusRpc,
+  GitSwitchBranchRpc,
 } from "./git.ts";
 import {
   PermissionDecideRpc,
@@ -161,6 +164,9 @@ export const MemoizeRpcs = RpcGroup.make(
   PtyOutputRpc,
   GitLogRpc,
   GitStatusRpc,
+  GitBranchesRpc,
+  GitSwitchBranchRpc,
+  GitRenameBranchRpc,
   GitHeadChangedRpc,
   GitOriginRpc,
   GitPrStateRpc,

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { Schema } from "effect";
 
-import { AgentEvent, Chat, Message, Session } from "../src/index.ts";
+import {
+  AgentEvent,
+  Chat,
+  GitBranchInfo,
+  Message,
+  Session,
+} from "../src/index.ts";
 
 /**
  * These guard the renderer↔server wire contract: every payload that crosses
@@ -20,7 +26,12 @@ describe("AgentEvent round-trips", () => {
   const cases: ReadonlyArray<{ name: string; encoded: unknown }> = [
     {
       name: "Started",
-      encoded: { _tag: "Started", sessionId: "s1", providerId: "claude", mode: "sdk" },
+      encoded: {
+        _tag: "Started",
+        sessionId: "s1",
+        providerId: "claude",
+        mode: "sdk",
+      },
     },
     {
       name: "Status",
@@ -45,7 +56,12 @@ describe("AgentEvent round-trips", () => {
     },
     {
       name: "ToolResult",
-      encoded: { _tag: "ToolResult", itemId: "i4", output: "done", isError: false },
+      encoded: {
+        _tag: "ToolResult",
+        itemId: "i4",
+        output: "done",
+        isError: false,
+      },
     },
     {
       name: "Error",
@@ -75,7 +91,9 @@ describe("AgentEvent round-trips", () => {
   }
 
   it("rejects an event with no _tag", () => {
-    expect(() => Schema.decodeUnknownSync(AgentEvent)({ text: "no tag" })).toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(AgentEvent)({ text: "no tag" }),
+    ).toThrow();
   });
 
   it("rejects an unknown _tag", () => {
@@ -86,13 +104,20 @@ describe("AgentEvent round-trips", () => {
 
   it("rejects a known event missing a required field", () => {
     expect(() =>
-      Schema.decodeUnknownSync(AgentEvent)({ _tag: "ToolResult", itemId: "i", output: "o" }),
+      Schema.decodeUnknownSync(AgentEvent)({
+        _tag: "ToolResult",
+        itemId: "i",
+        output: "o",
+      }),
     ).toThrow(); // isError missing
   });
 
   it("rejects an invalid enum literal", () => {
     expect(() =>
-      Schema.decodeUnknownSync(AgentEvent)({ _tag: "Status", status: "spinning" }),
+      Schema.decodeUnknownSync(AgentEvent)({
+        _tag: "Status",
+        status: "spinning",
+      }),
     ).toThrow();
   });
 });
@@ -191,6 +216,28 @@ describe("Chat round-trip", () => {
       archivedAt: null,
       createdAt: "2026-06-17T00:00:00.000Z",
       updatedAt: "2026-06-17T00:00:00.000Z",
+    });
+  });
+});
+
+describe("Git branch round-trip", () => {
+  it("round-trips a local branch", () => {
+    roundTrip(GitBranchInfo, {
+      name: "feature/top-bar",
+      current: true,
+      remote: null,
+      upstream: "origin/feature/top-bar",
+      kind: "local" as const,
+    });
+  });
+
+  it("round-trips a remote-only branch", () => {
+    roundTrip(GitBranchInfo, {
+      name: "main",
+      current: false,
+      remote: "origin/main",
+      upstream: null,
+      kind: "remote" as const,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a centered repo/branch control to the top bar
- add branch listing, switching, dirty-switch confirmation, and current-branch rename RPCs
- add an Open In menu with Finder/Terminal/editor targets and real macOS app icon resolution

## Validation
- bun run check-types --filter=@memoize/wire --filter=@memoize/server --filter=desktop
- bun run build:desktop
- bun run --filter=@memoize/wire test
- git diff --check
