### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3]
+
 ### Fixed
 - Grok sessions no longer abort mid-turn when the ACP child surfaces transient `AuthorizationRequired` noise inside `session/update` error frames while the turn is still completing normally. The shared ACP translator now filters that frame on the grok channel so in-flight prompts aren't rejected and the session doesn't flip to idle prematurely.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.3]
 
+### Added
+- Claude provider updates: Opus 4.8 and Ultracode model options, plus plan mode now always routes edits through prompts. (#111)
+- ACP agents (Grok, Gemini, Cursor) can execute real terminal/output commands instead of rendering terminal requests as inert tool calls. (#112)
+- In-app agent browser control drives the existing Electron webview, so agents can navigate and inspect pages without opening a separate browser surface. (#117)
+- Top bar can now show live CI state and offers direct merge / auto-merge actions. (#113)
+- Provider cards surface available CLI updates for supported providers. (#114)
+- Claude fast mode toggle for faster lower-latency Claude sessions. (#119)
+- Archive cleanup scripts and related repository cleanup controls. (#120)
+- Repository branch toolbar for faster branch/context switching. (#124)
+
+### Changed
+- Markdown rendering is more polished and consistent in chat output. (#121)
+- Grok access detection now accepts X Premium+ / SuperGrok entitlements. (#122)
+
 ### Fixed
 - Grok sessions no longer abort mid-turn when the ACP child surfaces transient `AuthorizationRequired` noise inside `session/update` error frames while the turn is still completing normally. The shared ACP translator now filters that frame on the grok channel so in-flight prompts aren't rejected and the session doesn't flip to idle prematurely.
+- New chats run inside their selected worktree and create branches from a fresh `origin` base. (#115)
+- Codex tool translation handles the current tool event shape correctly. (#123)
 
 ## [0.3.2]
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "memoize Alpha",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "memoize desktop app",
   "private": true,
   "author": {

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -214,6 +214,7 @@ function MainShell() {
   // under the new project's root anyway.
   useEffect(() => {
     if (openFile === null) return;
+    if (openFile.kind !== "text") return;
     if (selectedFolderId !== null && openFile.folderId === selectedFolderId) {
       return;
     }

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -258,7 +258,7 @@ export function BrowserPane() {
         <webview
           ref={webviewRef as unknown as React.RefObject<HTMLElement>}
           src={url === "" ? "about:blank" : url}
-          allowpopups="true"
+          allowpopups={true}
           style={{
             display: url === "" ? "none" : "flex",
             width: "100%",

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -15,11 +15,7 @@ import {
 } from "../lib/codemirror/setup.ts";
 import { languageForFile } from "../lib/codemirror/languages.ts";
 import { useKeybindingsStore } from "../store/keybindings.ts";
-import {
-  useUiStore,
-  type FileView,
-  type OpenFile,
-} from "../store/ui.ts";
+import { useUiStore, type FileView, type OpenFile } from "../store/ui.ts";
 
 import type { EditorView } from "@codemirror/view";
 
@@ -35,7 +31,7 @@ const formatError = (err: unknown): string => {
     if (tag === "FsPathOutsideError") {
       const p =
         "path" in (err as Record<string, unknown>)
-          ? String((err as { path: unknown }).path)
+          ? String((err as unknown as { path: unknown }).path)
           : null;
       return p === null
         ? "This file is outside the current project."

--- a/apps/renderer/src/components/file-tree.tsx
+++ b/apps/renderer/src/components/file-tree.tsx
@@ -13,11 +13,7 @@ import { useComposerBridge } from "../store/composer-bridge.ts";
 import { useUiStore } from "../store/ui.ts";
 import { FileIcon } from "./file-icon.tsx";
 import { Skeleton } from "./ui/skeleton.tsx";
-import {
-  Tooltip,
-  TooltipPopup,
-  TooltipTrigger,
-} from "./ui/tooltip.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 type DirState =
   | { status: "loading" }
@@ -118,7 +114,9 @@ export function FileTree({ folderId }: { folderId: FolderId }) {
 
   const openFileInTab = useUiStore((s) => s.openFileInTab);
   const setActiveMainTab = useUiStore((s) => s.setActiveMainTab);
-  const activePath = useUiStore((s) => s.openFile?.path ?? null);
+  const activePath = useUiStore((s) =>
+    s.openFile?.kind === "text" ? s.openFile.path : null,
+  );
 
   const onActivate = useCallback(
     (entry: FsEntry) => {
@@ -278,7 +276,9 @@ const TreeNode = memo(
             {isDir ? (
               <Chevron
                 className={`size-3.5 text-muted-foreground transition-opacity ${
-                  isOpen ? "opacity-100" : "opacity-0 group-hover/row:opacity-100"
+                  isOpen
+                    ? "opacity-100"
+                    : "opacity-0 group-hover/row:opacity-100"
                 }`}
               />
             ) : (
@@ -325,8 +325,7 @@ const TreeNode = memo(
     // Open: subtree may have changed. Map identity is the conservative check
     // — we only get a new ref when something actually mutated.
     return (
-      prev.expanded === next.expanded &&
-      prev.childStates === next.childStates
+      prev.expanded === next.expanded && prev.childStates === next.childStates
     );
   },
 );

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -16,6 +16,7 @@ import type {
   FolderId,
   SessionId,
 } from "@memoize/wire";
+import { RepositorySettings } from "@memoize/wire";
 
 import { NdjsonLogger } from "../src/persistence/ndjson-logger.ts";
 import { Migration0001Initial } from "../src/persistence/migrations/0001_initial.ts";
@@ -34,6 +35,8 @@ import { WorktreeService } from "../src/worktree/services/worktree-service.ts";
 import { MessageStore } from "../src/provider/services/message-store.ts";
 import { ProviderService } from "../src/provider/services/provider-service.ts";
 import { MessageStoreLive } from "../src/provider/layers/message-store.ts";
+import { PtyService } from "../src/pty/services/pty-service.ts";
+import { RepositorySettingsService } from "../src/repository-settings/services/repository-settings-service.ts";
 
 const PROJECT_ID = "proj-test" as FolderId;
 
@@ -49,7 +52,9 @@ let scriptedEvents: ReadonlyArray<AgentEvent> = [];
 const StubProviderLive = Layer.succeed(ProviderService, {
   availability: () => Effect.succeed([]),
   start: (input) =>
-    Effect.succeed({ sessionId: input.sessionId ?? ("stub" as AgentSessionId) }),
+    Effect.succeed({
+      sessionId: input.sessionId ?? ("stub" as AgentSessionId),
+    }),
   send: () => Effect.void,
   interrupt: () => Effect.void,
   close: () => Effect.void,
@@ -65,6 +70,46 @@ const StubWorktreeLive = Layer.succeed(WorktreeService, {
   list: () => Effect.succeed([]),
   get: () => Effect.succeed(null),
   remove: () => Effect.void,
+});
+
+/** Chat archive cleanup is out of scope for MessageStore persistence tests. */
+const StubRepositorySettingsLive = Layer.succeed(RepositorySettingsService, {
+  get: (projectId) =>
+    Effect.succeed(
+      RepositorySettings.make({
+        projectId,
+        defaultProviderId: null,
+        defaultModel: null,
+        defaultRuntimeMode: null,
+        autoCreateWorktree: false,
+        worktreeBaseDir: null,
+        archiveCleanupScript: null,
+        archiveRemoveWorktree: false,
+      }),
+    ),
+  update: (projectId, patch) =>
+    Effect.succeed(
+      RepositorySettings.make({
+        projectId,
+        defaultProviderId: patch.defaultProviderId ?? null,
+        defaultModel: patch.defaultModel ?? null,
+        defaultRuntimeMode: patch.defaultRuntimeMode ?? null,
+        autoCreateWorktree: patch.autoCreateWorktree ?? false,
+        worktreeBaseDir: patch.worktreeBaseDir ?? null,
+        archiveCleanupScript: patch.archiveCleanupScript ?? null,
+        archiveRemoveWorktree: patch.archiveRemoveWorktree ?? false,
+      }),
+    ),
+});
+
+/** PTYs are only touched during worktree cleanup; these tests use no worktrees. */
+const StubPtyLive = Layer.succeed(PtyService, {
+  open: () => Effect.die("not used"),
+  write: () => Effect.die("not used"),
+  resize: () => Effect.die("not used"),
+  close: () => Effect.die("not used"),
+  closeByCwdPrefix: () => Effect.void,
+  subscribe: () => Stream.die("not used"),
 });
 
 /** NdjsonLogger writes audit lines; in tests we swallow them. */
@@ -103,6 +148,8 @@ const makeRuntime = (dbPath: string) => {
   const TestLayer = MessageStoreLive.pipe(
     Layer.provide(StubProviderLive),
     Layer.provide(StubWorktreeLive),
+    Layer.provide(StubRepositorySettingsLive),
+    Layer.provide(StubPtyLive),
     Layer.provide(StubNdjsonLive),
     // provideMerge (not provide) so SqlClient stays in the runtime context —
     // the test seeds the `projects` row through it directly.
@@ -112,13 +159,18 @@ const makeRuntime = (dbPath: string) => {
 };
 
 const withRuntime = async <A>(
-  fn: (run: <X>(eff: Effect.Effect<X, unknown, MessageStore | SqlClient.SqlClient>) => Promise<X>) => Promise<A>,
+  fn: (
+    run: <X>(
+      eff: Effect.Effect<X, unknown, MessageStore | SqlClient.SqlClient>,
+    ) => Promise<X>,
+  ) => Promise<A>,
 ): Promise<A> => {
   const dir = mkdtempSync(join(tmpdir(), "mz-msgstore-"));
   const dbPath = join(dir, "test.sqlite");
   const runtime = makeRuntime(dbPath);
-  const run = <X>(eff: Effect.Effect<X, unknown, MessageStore | SqlClient.SqlClient>): Promise<X> =>
-    runtime.runPromise(eff as Effect.Effect<X, unknown, never>);
+  const run = <X>(
+    eff: Effect.Effect<X, unknown, MessageStore | SqlClient.SqlClient>,
+  ): Promise<X> => runtime.runPromise(eff as Effect.Effect<X, unknown, never>);
   try {
     // Seed the project row through the runtime's own SqlClient.
     await run(

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- bump desktop app version to 0.3.3
- expand the 0.3.3 changelog with the user-facing changes from PRs #110-#124
- fix current type/test blockers so the release branch passes checks

## Highlights
- Claude model/mode updates, provider update advisories, fast mode, archive cleanup, and branch toolbar
- real terminal/output execution for ACP agents and in-app browser control
- live CI / merge actions in the top bar
- Grok auth/access fixes, worktree chat fix, Codex tool translation fix, markdown polish

## Verification
- bun run check-types
- bun run lint
- bun run test
- bun run build
