### PR TITLE
[codex] Add worktree setup scripts

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "node scripts/conductor-setup.mjs"
+run = "PORT=${CONDUCTOR_PORT:-5733} MEMOIZE_USER_DATA_DIR=\"$PWD/.context/user-data\" bun run dev:desktop"
+run_mode = "concurrent"

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.env.local
+.env.*.local

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -13,6 +13,7 @@ import {
 import { Effect, Fiber, Layer } from "effect";
 import fixPath from "fix-path";
 import { execFile, spawn } from "node:child_process";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import { homedir } from "node:os";
 import * as Path from "node:path";
@@ -72,6 +73,12 @@ const isDevelopment = Boolean(DEV_SERVER_URL);
 const APP_NAME = isDevelopment ? "memoize Alpha (Dev)" : "memoize Alpha";
 
 app.setName(APP_NAME);
+
+const MEMOIZE_USER_DATA_DIR = process.env.MEMOIZE_USER_DATA_DIR?.trim();
+if (MEMOIZE_USER_DATA_DIR) {
+  fsSync.mkdirSync(MEMOIZE_USER_DATA_DIR, { recursive: true });
+  app.setPath("userData", MEMOIZE_USER_DATA_DIR);
+}
 
 // Lock the app to macOS's dark appearance so the sidebar vibrancy material
 // always renders in its dark variant. Without this, vibrancy follows the

--- a/apps/renderer/src/components/chat-creating-panel.tsx
+++ b/apps/renderer/src/components/chat-creating-panel.tsx
@@ -77,6 +77,12 @@ export function ChatCreatingPanel({
           </>
         ),
       });
+      out.push({
+        id: "setup",
+        icon: SparklesIcon,
+        hold: 1800,
+        render: () => <>Running setup script</>,
+      });
     }
     out.push({
       id: "provider",

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -93,16 +93,35 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
         projectName={folder.name}
       />
 
+      <ScriptsSection
+        setupScript={settings.setupScript}
+        runScript={settings.runScript}
+        archiveScript={settings.archiveCleanupScript}
+        autoRunAfterSetup={settings.autoRunAfterSetup}
+        environmentVariables={settings.environmentVariables}
+        onSetupScriptChange={(value) =>
+          void update(projectId, { setupScript: value })
+        }
+        onRunScriptChange={(value) =>
+          void update(projectId, { runScript: value })
+        }
+        onArchiveScriptChange={(value) =>
+          void update(projectId, { archiveCleanupScript: value })
+        }
+        onAutoRunAfterSetupChange={(value) =>
+          void update(projectId, { autoRunAfterSetup: value })
+        }
+        onEnvironmentVariablesChange={(value) =>
+          void update(projectId, { environmentVariables: value })
+        }
+      />
+
       <WorktreeSection
         projectId={projectId}
         autoCreate={settings.autoCreateWorktree}
-        archiveCleanupScript={settings.archiveCleanupScript}
         archiveRemoveWorktree={settings.archiveRemoveWorktree}
         onAutoCreateChange={(value) =>
           void update(projectId, { autoCreateWorktree: value })
-        }
-        onArchiveCleanupScriptChange={(value) =>
-          void update(projectId, { archiveCleanupScript: value })
         }
         onArchiveRemoveWorktreeChange={(value) =>
           void update(projectId, { archiveRemoveWorktree: value })
@@ -327,18 +346,14 @@ function RuntimeModeOverrideSection({
 function WorktreeSection({
   projectId,
   autoCreate,
-  archiveCleanupScript,
   archiveRemoveWorktree,
   onAutoCreateChange,
-  onArchiveCleanupScriptChange,
   onArchiveRemoveWorktreeChange,
 }: {
   projectId: FolderId;
   autoCreate: boolean;
-  archiveCleanupScript: string | null;
   archiveRemoveWorktree: boolean;
   onAutoCreateChange: (v: boolean) => void;
-  onArchiveCleanupScriptChange: (v: string | null) => void;
   onArchiveRemoveWorktreeChange: (v: boolean) => void;
 }) {
   const worktrees = useWorktreesStore(
@@ -392,12 +407,15 @@ function WorktreeSection({
         }
         description={`When on, the composer's workspace picker pre-selects a fresh worktree. You can still flip back to "Current checkout" before sending the first message.`}
       />
-
-      <ArchiveCleanupSection
-        script={archiveCleanupScript}
-        removeWorktree={archiveRemoveWorktree}
-        onScriptChange={onArchiveCleanupScriptChange}
-        onRemoveWorktreeChange={onArchiveRemoveWorktreeChange}
+      <SettingsFrame
+        title="Remove worktree on archive"
+        trailing={
+          <Switch
+            checked={archiveRemoveWorktree}
+            onCheckedChange={onArchiveRemoveWorktreeChange}
+          />
+        }
+        description="After the archive script succeeds, remove the checkout from disk while preserving the branch."
       />
 
       <Frame>
@@ -493,64 +511,162 @@ function WorktreeSection({
   );
 }
 
-function ArchiveCleanupSection({
-  script,
-  removeWorktree,
-  onScriptChange,
-  onRemoveWorktreeChange,
+function ScriptsSection({
+  setupScript,
+  runScript,
+  archiveScript,
+  autoRunAfterSetup,
+  environmentVariables,
+  onSetupScriptChange,
+  onRunScriptChange,
+  onArchiveScriptChange,
+  onAutoRunAfterSetupChange,
+  onEnvironmentVariablesChange,
 }: {
-  script: string | null;
-  removeWorktree: boolean;
-  onScriptChange: (v: string | null) => void;
-  onRemoveWorktreeChange: (v: boolean) => void;
+  setupScript: string | null;
+  runScript: string | null;
+  archiveScript: string | null;
+  autoRunAfterSetup: boolean;
+  environmentVariables: Readonly<Record<string, string>>;
+  onSetupScriptChange: (v: string | null) => void;
+  onRunScriptChange: (v: string | null) => void;
+  onArchiveScriptChange: (v: string | null) => void;
+  onAutoRunAfterSetupChange: (v: boolean) => void;
+  onEnvironmentVariablesChange: (v: Record<string, string>) => void;
 }) {
-  const [draft, setDraft] = useState(script ?? "");
-
-  useEffect(() => {
-    setDraft(script ?? "");
-  }, [script]);
-
-  const persist = () => {
-    const next = draft.trim().length === 0 ? null : draft;
-    if ((script ?? "") === (next ?? "")) return;
-    onScriptChange(next);
+  const envText = Object.entries(environmentVariables)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  const [envDraft, setEnvDraft] = useState(envText);
+  useEffect(() => setEnvDraft(envText), [envText]);
+  const persistEnv = () => {
+    const next: Record<string, string> = {};
+    for (const line of envDraft.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+      const idx = trimmed.indexOf("=");
+      if (idx <= 0) continue;
+      next[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+    }
+    onEnvironmentVariablesChange(next);
   };
 
   return (
     <Frame>
-      <FrameHeader className="flex flex-row items-center justify-between px-2 py-2 w-full">
-        <div className="flex min-w-0 flex-col">
-          <p className="text-sm font-semibold text-foreground">
-            Archive cleanup
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Runs only for chats bound to a worktree.
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <span className="text-xs text-muted-foreground">Remove worktree</span>
+      <FrameHeader className="flex flex-col items-start gap-1 px-2 py-2 w-full">
+        <p className="text-lg font-semibold text-foreground">Scripts</p>
+        <p className="text-xs text-muted-foreground">
+          Commands that run when worktrees are set up, run, or archived.
+        </p>
+      </FrameHeader>
+      <Card className="divide-y divide-border/50 p-0">
+        <ScriptEditor
+          title="Setup script"
+          description="Runs when a new worktree is created"
+          value={setupScript}
+          placeholder="bun i"
+          onChange={onSetupScriptChange}
+        />
+        <ScriptEditor
+          title="Run script"
+          description="Runs when you click Run"
+          value={runScript}
+          placeholder="bun run dev"
+          onChange={onRunScriptChange}
+        />
+        <div className="flex items-center justify-between gap-4 px-4 py-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">
+              Auto-run after setup
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Start this repository's run script automatically after setup.
+            </p>
+          </div>
           <Switch
-            checked={removeWorktree}
-            onCheckedChange={onRemoveWorktreeChange}
+            checked={autoRunAfterSetup}
+            onCheckedChange={onAutoRunAfterSetupChange}
           />
         </div>
-      </FrameHeader>
-      <Card className="p-3">
+        <ScriptEditor
+          title="Archive script"
+          description="Runs before a worktree-backed chat is archived"
+          value={archiveScript}
+          placeholder={'rm -rf node_modules .next\npkill -f "next dev" || true'}
+          onChange={onArchiveScriptChange}
+        />
+        <div className="px-4 py-4">
+          <div className="mb-2">
+            <p className="text-sm font-medium text-foreground">
+              Environment variables
+            </p>
+            <p className="text-xs text-muted-foreground">
+              KEY=value pairs passed to setup, run, and archive scripts.
+            </p>
+          </div>
+          <Textarea
+            value={envDraft}
+            onChange={(event) => setEnvDraft(event.currentTarget.value)}
+            onBlur={persistEnv}
+            spellCheck={false}
+            placeholder="MEMOIZE_PORT=5733"
+            className="min-h-20 resize-y font-mono text-xs"
+          />
+        </div>
+      </Card>
+      <FrameFooter className="px-2 py-1 w-full">
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Want to share scripts with your team? Create a{" "}
+          <span className="font-mono">.memoize/settings.toml</span> file.
+        </p>
+      </FrameFooter>
+    </Frame>
+  );
+}
+
+function ScriptEditor({
+  title,
+  description,
+  value,
+  placeholder,
+  onChange,
+}: {
+  title: string;
+  description: string;
+  value: string | null;
+  placeholder: string;
+  onChange: (v: string | null) => void;
+}) {
+  const [draft, setDraft] = useState(value ?? "");
+  useEffect(() => setDraft(value ?? ""), [value]);
+  const persist = () => {
+    const next = draft.trim().length === 0 ? null : draft;
+    if ((value ?? "") !== (next ?? "")) onChange(next);
+  };
+  const lines = Math.max(1, draft.split(/\r?\n/).length);
+  return (
+    <div className="px-4 py-4">
+      <div className="mb-2">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <div className="grid grid-cols-[3rem_1fr] overflow-hidden rounded-md border border-border bg-muted/20">
+        <div className="select-none border-r border-border/60 bg-background/40 py-2 text-right font-mono text-xs leading-5 text-muted-foreground">
+          {Array.from({ length: lines }, (_, idx) => (
+            <div key={idx} className="pr-3">
+              {idx + 1}
+            </div>
+          ))}
+        </div>
         <Textarea
           value={draft}
           onChange={(event) => setDraft(event.currentTarget.value)}
           onBlur={persist}
           spellCheck={false}
-          placeholder={'rm -rf node_modules .next\npkill -f "next dev" || true'}
-          className="min-h-28 resize-y font-mono text-xs"
+          placeholder={placeholder}
+          className="min-h-16 resize-y border-0 bg-transparent font-mono text-xs shadow-none focus-visible:ring-0"
         />
-      </Card>
-      <FrameFooter className="px-2 py-1 w-full">
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          Memoize runs this with <span className="font-mono">zsh -lc</span> from
-          the worktree. A non-zero exit keeps the chat unarchived.
-        </p>
-      </FrameFooter>
-    </Frame>
+      </div>
+    </div>
   );
 }

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -1,19 +1,22 @@
-import { useEffect, useRef } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Effect, Fiber, Stream } from "effect";
-import { Plus, SquareTerminal, X } from "lucide-react";
+import { Loader2, Play, Plus, RefreshCw, SquareTerminal, X } from "lucide-react";
 
-import type { FolderId, PtyId } from "@memoize/wire";
+import type { FolderId, PtyId, Worktree, WorktreeId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
-import { useActiveContext } from "../store/active-workspace.ts";
+import { type ActiveContext, useActiveContext } from "../store/active-workspace.ts";
+import { useRepositorySettingsStore } from "../store/repository-settings.ts";
 import {
   EMPTY_TERMINALS,
   type TerminalInstance,
   terminalsKey,
   useTerminalsStore,
 } from "../store/terminals.ts";
+import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
+import { Button } from "./ui/button.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 /**
@@ -29,26 +32,6 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 export function TerminalPane() {
   const ctx = useActiveContext();
   const ready = ctx.status === "ready" && !ctx.worktreePending;
-  const key = ready ? terminalsKey(ctx.folderId, ctx.worktreeId) : null;
-  const list = useTerminalsStore((s) =>
-    key === null ? EMPTY_TERMINALS : s.byKey[key] ?? EMPTY_TERMINALS,
-  );
-  const activeId = useTerminalsStore((s) =>
-    key === null ? null : s.activeByKey[key] ?? null,
-  );
-  const ensureSeed = useTerminalsStore((s) => s.ensureSeed);
-  const add = useTerminalsStore((s) => s.add);
-  const remove = useTerminalsStore((s) => s.remove);
-  const setActive = useTerminalsStore((s) => s.setActive);
-
-  // Seed a first terminal whenever we land on a workspace with an empty
-  // list. Done in an effect (not render) so we don't call set() during
-  // another component's render.
-  const seedCwd = ctx.status === "ready" ? ctx.rootPath : null;
-  useEffect(() => {
-    if (key === null || !ready || seedCwd === null) return;
-    if (list.length === 0) ensureSeed(key, seedCwd);
-  }, [key, ready, list.length, ensureSeed, seedCwd]);
 
   if (ctx.status === "loading") {
     return (
@@ -74,18 +57,54 @@ export function TerminalPane() {
       </div>
     );
   }
-  if (key === null) return null;
+  if (!ready) return null;
+  if (ctx.worktreeId !== null) {
+    return <WorktreeTerminalPane ctx={ctx} worktreeId={ctx.worktreeId} />;
+  }
+
+  return (
+    <TerminalWorkspace
+      folderId={ctx.folderId}
+      worktreeId={ctx.worktreeId}
+      rootPath={ctx.rootPath}
+      showFloatingAdd
+    />
+  );
+}
+
+function TerminalWorkspace({
+  folderId,
+  worktreeId,
+  rootPath,
+  showFloatingAdd = false,
+}: {
+  folderId: FolderId;
+  worktreeId: WorktreeId | null;
+  rootPath: string;
+  showFloatingAdd?: boolean;
+}) {
+  const key = terminalsKey(folderId, worktreeId);
+  const list = useTerminalsStore((s) => s.byKey[key] ?? EMPTY_TERMINALS);
+  const activeId = useTerminalsStore((s) => s.activeByKey[key] ?? null);
+  const ensureSeed = useTerminalsStore((s) => s.ensureSeed);
+  const add = useTerminalsStore((s) => s.add);
+  const remove = useTerminalsStore((s) => s.remove);
+  const setActive = useTerminalsStore((s) => s.setActive);
 
   const handleAdd = () => {
-    add(key, ctx.rootPath);
+    add(key, rootPath);
   };
   const handleClose = (id: string) => {
     remove(key, id);
     // If the user closed the last one, seed a fresh terminal so the pane
     // is never empty — matches what a developer expects from a terminal
     // dock: there's always a shell waiting.
-    if (list.length === 1) ensureSeed(key, ctx.rootPath);
+    if (list.length === 1) ensureSeed(key, rootPath);
   };
+
+  useEffect(() => {
+    if (list.length === 0) ensureSeed(key, rootPath);
+  }, [key, list.length, ensureSeed, rootPath]);
 
   // A single terminal gets the full pane — the list sidebar only earns its
   // width once there's more than one shell to switch between. When it's
@@ -105,7 +124,7 @@ export function TerminalPane() {
         />
       )}
       <div className="relative flex min-w-0 flex-1 flex-col bg-background">
-        {single ? (
+        {single && showFloatingAdd ? (
           <Tooltip>
             <TooltipTrigger
               render={
@@ -129,13 +148,211 @@ export function TerminalPane() {
             className="absolute inset-0 flex"
           >
             <PtyTerminal
-              folderId={ctx.folderId}
+              folderId={folderId}
               cwd={inst.cwd}
               instanceId={inst.id}
+              command={inst.command}
             />
           </div>
         ))}
       </div>
+    </div>
+  );
+}
+
+function WorktreeTerminalPane({
+  ctx,
+  worktreeId,
+}: {
+  ctx: Extract<ActiveContext, { status: "ready" }>;
+  worktreeId: WorktreeId;
+}) {
+  const [tab, setTab] = useState<"setup" | "run" | "terminal">("setup");
+  const worktree = useWorktreesStore((s) => {
+    const list = s.byProject[ctx.folderId] ?? EMPTY_WORKTREES;
+    return list.find((w) => w.id === worktreeId) ?? null;
+  });
+  const setupPending = useWorktreesStore((s) => s.setupPending.has(worktreeId));
+  const rerunSetup = useWorktreesStore((s) => s.rerunSetup);
+  const startRun = useWorktreesStore((s) => s.startRun);
+  const addTerminal = useTerminalsStore((s) => s.add);
+  const addCommand = useTerminalsStore((s) => s.addCommand);
+  const refreshSettings = useRepositorySettingsStore((s) => s.refresh);
+  const settings = useRepositorySettingsStore(
+    (s) => s.byProject[ctx.folderId] ?? null,
+  );
+
+  useEffect(() => {
+    if (settings === null) void refreshSettings(ctx.folderId);
+  }, [ctx.folderId, refreshSettings, settings]);
+
+  const onRun = async () => {
+    const run = await startRun(worktreeId);
+    if (run === null) return;
+    addCommand(terminalsKey(ctx.folderId, worktreeId), run.cwd, "Run", {
+      cmd: "/bin/zsh",
+      args: ["-lc", run.script],
+      env: run.env,
+    });
+    setTab("run");
+  };
+
+  const onRerunSetup = async () => {
+    if (setupPending || worktree?.setupStatus === "running") return;
+    const wt = await rerunSetup(ctx.folderId, worktreeId);
+    if (wt?.setupStatus === "succeeded" && settings?.autoRunAfterSetup) {
+      await onRun();
+    }
+  };
+
+  const onAddTerminal = () => {
+    addTerminal(terminalsKey(ctx.folderId, worktreeId), ctx.rootPath);
+    setTab("terminal");
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex h-10 shrink-0 items-center border-b border-border bg-background text-sm">
+        <TabButton active={tab === "setup"} onClick={() => setTab("setup")}>
+          {(setupPending || worktree?.setupStatus === "running") && (
+            <Loader2 className="size-3.5 animate-spin" />
+          )}
+          Setup
+        </TabButton>
+        <TabButton active={tab === "run"} onClick={() => setTab("run")}>
+          Run
+        </TabButton>
+        <TabButton active={tab === "terminal"} onClick={() => setTab("terminal")}>
+          Terminal
+        </TabButton>
+        <button
+          type="button"
+          onClick={onAddTerminal}
+          className="ml-1 flex h-full w-10 items-center justify-center text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          aria-label="New terminal"
+          title="New terminal"
+        >
+          <Plus className="size-4" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1">
+        {tab === "setup" ? (
+          <SetupOutput
+            worktree={worktree}
+            running={setupPending || worktree?.setupStatus === "running"}
+            onRerunSetup={onRerunSetup}
+          />
+        ) : tab === "run" ? (
+          <RunPane ctx={ctx} worktreeId={worktreeId} onRun={onRun} />
+        ) : (
+          <TerminalWorkspace
+            folderId={ctx.folderId}
+            worktreeId={worktreeId}
+            rootPath={ctx.rootPath}
+            showFloatingAdd={false}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex h-full items-center gap-1.5 border-b-2 px-4 text-[13px] transition-colors ${
+        active
+          ? "border-foreground text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SetupOutput({
+  worktree,
+  running,
+  onRerunSetup,
+}: {
+  worktree: Worktree | null;
+  running: boolean;
+  onRerunSetup: () => void;
+}) {
+  const output =
+    running && (worktree === null || worktree.setupOutput.trim().length === 0)
+      ? "Running setup..."
+      : worktree === null
+      ? "Loading setup state..."
+      : worktree.setupOutput.trim().length > 0
+        ? worktree.setupOutput
+        : `Setup ${worktree.setupStatus}`;
+  return (
+    <div className="relative h-full bg-background">
+      {running && (
+        <div className="absolute left-4 top-3 z-10 flex items-center gap-2 rounded border border-border bg-background/90 px-2.5 py-1.5 text-xs text-muted-foreground shadow-sm">
+          <Loader2 className="size-3.5 animate-spin" />
+          Running setup
+        </div>
+      )}
+      <pre className="h-full overflow-auto p-4 font-mono text-sm leading-6 text-foreground whitespace-pre-wrap">
+        {output}
+      </pre>
+      <Button
+        variant="settings"
+        size="sm"
+        onClick={onRerunSetup}
+        disabled={running}
+        className="absolute bottom-3 right-3 gap-2"
+      >
+        {running ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : (
+          <RefreshCw className="size-3.5" />
+        )}
+        {running ? "Running..." : "Rerun setup"}
+      </Button>
+    </div>
+  );
+}
+
+function RunPane({
+  ctx,
+  worktreeId,
+  onRun,
+}: {
+  ctx: Extract<ActiveContext, { status: "ready" }>;
+  worktreeId: WorktreeId;
+  onRun: () => void;
+}) {
+  return (
+    <div className="relative h-full">
+      <TerminalWorkspace
+        folderId={ctx.folderId}
+        worktreeId={worktreeId}
+        rootPath={ctx.rootPath}
+        showFloatingAdd={false}
+      />
+      <Button
+        variant="settings"
+        size="sm"
+        onClick={onRun}
+        className="absolute right-3 top-3 z-10 gap-2"
+      >
+        <Play className="size-3.5" />
+        Run
+      </Button>
     </div>
   );
 }
@@ -234,10 +451,12 @@ function PtyTerminal({
   folderId,
   cwd,
   instanceId,
+  command,
 }: {
   folderId: FolderId;
   cwd: string;
   instanceId: string;
+  command?: TerminalInstance["command"];
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -289,6 +508,7 @@ function PtyTerminal({
 
     const observer = new ResizeObserver(safeFit);
     observer.observe(container);
+    window.requestAnimationFrame(safeFit);
 
     void (async () => {
       try {
@@ -300,6 +520,14 @@ function PtyTerminal({
             cwd,
             cols: term.cols,
             rows: term.rows,
+            command:
+              command === undefined
+                ? undefined
+                : {
+                    cmd: command.cmd,
+                    args: [...command.args],
+                    env: command.env,
+                  },
           }),
         );
         if (cancelled) {
@@ -307,6 +535,12 @@ function PtyTerminal({
           return;
         }
         ptyId = id;
+        safeFit();
+        void Effect.runPromise(
+          client.pty.resize({ ptyId: id, cols: term.cols, rows: term.rows }),
+        ).catch(() => {
+          // ignore
+        });
 
         // Pump output stream into xterm.
         streamFiber = Effect.runFork(

--- a/apps/renderer/src/store/terminals.ts
+++ b/apps/renderer/src/store/terminals.ts
@@ -15,6 +15,11 @@ export type TerminalInstance = {
   readonly id: string;
   readonly title: string;
   readonly cwd: string;
+  readonly command?: {
+    readonly cmd: string;
+    readonly args: ReadonlyArray<string>;
+    readonly env?: Readonly<Record<string, string>>;
+  };
 };
 
 type TerminalsState = {
@@ -22,6 +27,12 @@ type TerminalsState = {
   readonly activeByKey: Readonly<Record<string, string | null>>;
   readonly ensureSeed: (key: string, cwd: string) => void;
   readonly add: (key: string, cwd: string) => string;
+  readonly addCommand: (
+    key: string,
+    cwd: string,
+    title: string,
+    command: TerminalInstance["command"],
+  ) => string;
   readonly remove: (key: string, id: string) => void;
   readonly setActive: (key: string, id: string) => void;
 };
@@ -64,6 +75,18 @@ export const useTerminalsStore = create<TerminalsState>((set) => ({
     set((state) => {
       const list = state.byKey[key] ?? [];
       const instance: TerminalInstance = { id, title: nextTitle(list), cwd };
+      return {
+        byKey: { ...state.byKey, [key]: [...list, instance] },
+        activeByKey: { ...state.activeByKey, [key]: id },
+      };
+    });
+    return id;
+  },
+  addCommand: (key, cwd, title, command) => {
+    const id = newId();
+    set((state) => {
+      const list = state.byKey[key] ?? [];
+      const instance: TerminalInstance = { id, title, cwd, command };
       return {
         byKey: { ...state.byKey, [key]: [...list, instance] },
         activeByKey: { ...state.activeByKey, [key]: id },

--- a/apps/renderer/src/store/worktrees.ts
+++ b/apps/renderer/src/store/worktrees.ts
@@ -4,6 +4,8 @@ import { create } from "zustand";
 import type { FolderId, Worktree, WorktreeId } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { useRepositorySettingsStore } from "./repository-settings.ts";
+import { terminalsKey, useTerminalsStore } from "./terminals.ts";
 
 type WorktreesByProject = Readonly<Record<string, ReadonlyArray<Worktree>>>;
 
@@ -18,9 +20,22 @@ export const EMPTY_WORKTREES: ReadonlyArray<Worktree> = Object.freeze([]);
 type WorktreesState = {
   readonly byProject: WorktreesByProject;
   readonly loading: ReadonlySet<FolderId>;
+  readonly creatingSetupByProject: ReadonlySet<FolderId>;
+  readonly setupPending: ReadonlySet<WorktreeId>;
   readonly error: string | null;
   readonly refresh: (projectId: FolderId) => Promise<void>;
   readonly create: (projectId: FolderId) => Promise<Worktree | null>;
+  readonly rerunSetup: (
+    projectId: FolderId,
+    worktreeId: WorktreeId,
+  ) => Promise<Worktree | null>;
+  readonly startRun: (
+    worktreeId: WorktreeId,
+  ) => Promise<{
+    readonly cwd: string;
+    readonly script: string;
+    readonly env: Record<string, string>;
+  } | null>;
   readonly remove: (
     projectId: FolderId,
     worktreeId: WorktreeId,
@@ -36,9 +51,27 @@ const formatError = (err: unknown): string => {
   return String(err);
 };
 
+const maybeAutoRun = async (projectId: FolderId, wt: Worktree) => {
+  const settings =
+    useRepositorySettingsStore.getState().byProject[projectId] ??
+    (await useRepositorySettingsStore.getState().refresh(projectId));
+  if (settings?.autoRunAfterSetup !== true) return;
+  if (wt.setupStatus !== "succeeded" && wt.setupStatus !== "skipped") return;
+  const run = await useWorktreesStore.getState().startRun(wt.id);
+  if (run === null) return;
+  useTerminalsStore.getState().addCommand(
+    terminalsKey(projectId, wt.id),
+    run.cwd,
+    "Run",
+    { cmd: "/bin/zsh", args: ["-lc", run.script], env: run.env },
+  );
+};
+
 export const useWorktreesStore = create<WorktreesState>((set, get) => ({
   byProject: {},
   loading: new Set(),
+  creatingSetupByProject: new Set(),
+  setupPending: new Set(),
   error: null,
   refresh: async (projectId) => {
     set((s) => {
@@ -72,6 +105,11 @@ export const useWorktreesStore = create<WorktreesState>((set, get) => ({
     }
   },
   create: async (projectId) => {
+    set((s) => {
+      const next = new Set(s.creatingSetupByProject);
+      next.add(projectId);
+      return { creatingSetupByProject: next };
+    });
     try {
       const client = await getRpcClient();
       const wt = await Effect.runPromise(
@@ -81,10 +119,67 @@ export const useWorktreesStore = create<WorktreesState>((set, get) => ({
         const existing = s.byProject[projectId] ?? [];
         return {
           byProject: { ...s.byProject, [projectId]: [wt, ...existing] },
+          creatingSetupByProject: (() => {
+            const next = new Set(s.creatingSetupByProject);
+            next.delete(projectId);
+            return next;
+          })(),
+          error: null,
+        };
+      });
+      void maybeAutoRun(projectId, wt);
+      return wt;
+    } catch (err) {
+      set((s) => {
+        const next = new Set(s.creatingSetupByProject);
+        next.delete(projectId);
+        return { creatingSetupByProject: next, error: formatError(err) };
+      });
+      return null;
+    }
+  },
+  rerunSetup: async (projectId, worktreeId) => {
+    set((s) => {
+      const next = new Set(s.setupPending);
+      next.add(worktreeId);
+      return { setupPending: next };
+    });
+    try {
+      const client = await getRpcClient();
+      const wt = await Effect.runPromise(
+        client.worktree.rerunSetup({ worktreeId }),
+      );
+      set((s) => {
+        const list = s.byProject[projectId] ?? [];
+        return {
+          byProject: {
+            ...s.byProject,
+            [projectId]: list.map((existing) =>
+              existing.id === wt.id ? wt : existing,
+            ),
+          },
+          setupPending: (() => {
+            const next = new Set(s.setupPending);
+            next.delete(worktreeId);
+            return next;
+          })(),
           error: null,
         };
       });
       return wt;
+    } catch (err) {
+      set((s) => {
+        const next = new Set(s.setupPending);
+        next.delete(worktreeId);
+        return { setupPending: next, error: formatError(err) };
+      });
+      return null;
+    }
+  },
+  startRun: async (worktreeId) => {
+    try {
+      const client = await getRpcClient();
+      return await Effect.runPromise(client.worktree.startRun({ worktreeId }));
     } catch (err) {
       set({ error: formatError(err) });
       return null;

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -13,6 +13,7 @@ import { Migration0010NestedSessions } from "./migrations/0010_nested_sessions.t
 import { Migration0011ChatsTable } from "./migrations/0011_chats_table.ts";
 import { Migration0012ChatIdNotNull } from "./migrations/0012_chat_id_not_null.ts";
 import { Migration0013ArchiveCleanup } from "./migrations/0013_archive_cleanup.ts";
+import { Migration0014ScriptsAndSetup } from "./migrations/0014_scripts_and_setup.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -38,5 +39,6 @@ export const MigrationsLive = SqliteMigrator.layer({
     "0011_chats_table": Migration0011ChatsTable,
     "0012_chat_id_not_null": Migration0012ChatIdNotNull,
     "0013_archive_cleanup": Migration0013ArchiveCleanup,
+    "0014_scripts_and_setup": Migration0014ScriptsAndSetup,
   }),
 });

--- a/apps/server/src/persistence/migrations/0014_scripts_and_setup.ts
+++ b/apps/server/src/persistence/migrations/0014_scripts_and_setup.ts
@@ -1,0 +1,56 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+export const Migration0014ScriptsAndSetup = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const repositoryColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(repository_settings)
+  `;
+  const hasRepositoryColumn = (name: string): boolean =>
+    repositoryColumns.some((column) => column.name === name);
+
+  if (!hasRepositoryColumn("setup_script")) {
+    yield* sql`ALTER TABLE repository_settings ADD COLUMN setup_script TEXT`;
+  }
+  if (!hasRepositoryColumn("run_script")) {
+    yield* sql`ALTER TABLE repository_settings ADD COLUMN run_script TEXT`;
+  }
+  if (!hasRepositoryColumn("auto_run_after_setup")) {
+    yield* sql`
+      ALTER TABLE repository_settings
+        ADD COLUMN auto_run_after_setup INTEGER NOT NULL DEFAULT 0
+    `;
+  }
+  if (!hasRepositoryColumn("environment_variables_json")) {
+    yield* sql`
+      ALTER TABLE repository_settings
+        ADD COLUMN environment_variables_json TEXT
+    `;
+  }
+
+  const worktreeColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(worktrees)
+  `;
+  const hasWorktreeColumn = (name: string): boolean =>
+    worktreeColumns.some((column) => column.name === name);
+
+  if (!hasWorktreeColumn("setup_status")) {
+    yield* sql`
+      ALTER TABLE worktrees
+        ADD COLUMN setup_status TEXT NOT NULL DEFAULT 'pending'
+    `;
+  }
+  if (!hasWorktreeColumn("setup_output")) {
+    yield* sql`
+      ALTER TABLE worktrees
+        ADD COLUMN setup_output TEXT NOT NULL DEFAULT ''
+    `;
+  }
+  if (!hasWorktreeColumn("setup_started_at")) {
+    yield* sql`ALTER TABLE worktrees ADD COLUMN setup_started_at TEXT`;
+  }
+  if (!hasWorktreeColumn("setup_finished_at")) {
+    yield* sql`ALTER TABLE worktrees ADD COLUMN setup_finished_at TEXT`;
+  }
+});

--- a/apps/server/src/pty/layers/pty-service.ts
+++ b/apps/server/src/pty/layers/pty-service.ts
@@ -51,6 +51,7 @@ export const PtyServiceLive = Layer.effect(
               cwd,
               env: {
                 ...(process.env as Record<string, string>),
+                ...(command?.env ?? {}),
                 TERM: "xterm-256color",
               },
             }),

--- a/apps/server/src/repository-settings/layers/repository-settings-service.ts
+++ b/apps/server/src/repository-settings/layers/repository-settings-service.ts
@@ -1,5 +1,7 @@
 import { SqlClient } from "@effect/sql";
 import { Effect, Layer } from "effect";
+import * as fsSync from "node:fs";
+import * as Path from "node:path";
 
 import {
   type FolderId,
@@ -19,6 +21,10 @@ interface Row {
   readonly worktree_base_dir: string | null;
   readonly archive_cleanup_script: string | null;
   readonly archive_remove_worktree: number;
+  readonly setup_script: string | null;
+  readonly run_script: string | null;
+  readonly auto_run_after_setup: number;
+  readonly environment_variables_json: string | null;
 }
 
 const isProviderId = (v: unknown): v is ProviderId =>
@@ -30,9 +36,95 @@ const isRuntimeMode = (v: unknown): v is RuntimeMode =>
   v === "auto-accept-edits-and-bash" ||
   v === "full-access";
 
+interface RepoFileSettings {
+  readonly setupScript: string | null;
+  readonly runScript: string | null;
+  readonly archiveScript: string | null;
+  readonly autoRunAfterSetup: boolean;
+  readonly environmentVariables: Record<string, string>;
+}
+
+const emptyRepoFileSettings = (): RepoFileSettings => ({
+  setupScript: null,
+  runScript: null,
+  archiveScript: null,
+  autoRunAfterSetup: false,
+  environmentVariables: {},
+});
+
+const cleanScript = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? value! : null;
+};
+
+const parseEnvJson = (value: string | null): Record<string, string> => {
+  if (value === null || value.trim().length === 0) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const out: Record<string, string> = {};
+    for (const [key, val] of Object.entries(parsed)) {
+      if (typeof val === "string") out[key] = val;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+};
+
+const parseTomlString = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+};
+
+const parseRepoFileSettings = (repoPath: string): RepoFileSettings => {
+  const filePath = Path.join(repoPath, ".memoize", "settings.toml");
+  if (!fsSync.existsSync(filePath)) return emptyRepoFileSettings();
+  const settings = emptyRepoFileSettings();
+  let section = "";
+  for (const line of fsSync.readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      section = sectionMatch[1] ?? "";
+      continue;
+    }
+    const match = trimmed.match(/^([A-Za-z0-9_.-]+)\s*=\s*(.+)$/);
+    if (!match) continue;
+    const key = match[1]!;
+    const value = match[2]!;
+    if (section === "scripts") {
+      if (key === "setup") {
+        (settings as { setupScript: string | null }).setupScript =
+          parseTomlString(value);
+      } else if (key === "run") {
+        (settings as { runScript: string | null }).runScript =
+          parseTomlString(value);
+      } else if (key === "archive") {
+        (settings as { archiveScript: string | null }).archiveScript =
+          parseTomlString(value);
+      } else if (key === "auto_run_after_setup") {
+        (settings as { autoRunAfterSetup: boolean }).autoRunAfterSetup =
+          value.trim() === "true";
+      }
+    } else if (section === "environment_variables") {
+      settings.environmentVariables[key] = parseTomlString(value);
+    }
+  }
+  return settings;
+};
+
 const rowToSettings = (
   projectId: FolderId,
   row: Row | null,
+  repoFile: RepoFileSettings,
 ): RepositorySettings =>
   RepositorySettings.make({
     projectId,
@@ -45,8 +137,17 @@ const rowToSettings = (
       : null,
     autoCreateWorktree: (row?.auto_create_worktree ?? 0) === 1,
     worktreeBaseDir: row?.worktree_base_dir ?? null,
-    archiveCleanupScript: row?.archive_cleanup_script ?? null,
+    archiveCleanupScript:
+      cleanScript(row?.archive_cleanup_script) ?? repoFile.archiveScript,
     archiveRemoveWorktree: (row?.archive_remove_worktree ?? 0) === 1,
+    setupScript: cleanScript(row?.setup_script) ?? repoFile.setupScript,
+    runScript: cleanScript(row?.run_script) ?? repoFile.runScript,
+    autoRunAfterSetup:
+      row?.auto_run_after_setup === 1 || repoFile.autoRunAfterSetup,
+    environmentVariables: {
+      ...repoFile.environmentVariables,
+      ...parseEnvJson(row?.environment_variables_json ?? null),
+    },
   });
 
 export const RepositorySettingsServiceLive = Layer.effect(
@@ -71,18 +172,55 @@ export const RepositorySettingsServiceLive = Layer.effect(
           ADD COLUMN archive_remove_worktree INTEGER NOT NULL DEFAULT 0
       `.pipe(Effect.orDie);
     }
+    if (!hasColumn("setup_script")) {
+      yield* sql`
+        ALTER TABLE repository_settings
+          ADD COLUMN setup_script TEXT
+      `.pipe(Effect.orDie);
+    }
+    if (!hasColumn("run_script")) {
+      yield* sql`
+        ALTER TABLE repository_settings
+          ADD COLUMN run_script TEXT
+      `.pipe(Effect.orDie);
+    }
+    if (!hasColumn("auto_run_after_setup")) {
+      yield* sql`
+        ALTER TABLE repository_settings
+          ADD COLUMN auto_run_after_setup INTEGER NOT NULL DEFAULT 0
+      `.pipe(Effect.orDie);
+    }
+    if (!hasColumn("environment_variables_json")) {
+      yield* sql`
+        ALTER TABLE repository_settings
+          ADD COLUMN environment_variables_json TEXT
+      `.pipe(Effect.orDie);
+    }
+
+    const projectPath = (projectId: FolderId) =>
+      Effect.gen(function* () {
+        const rows = yield* sql<{ readonly path: string }>`
+          SELECT path FROM projects WHERE id = ${projectId} LIMIT 1
+        `.pipe(Effect.orDie);
+        return rows[0]?.path ?? null;
+      });
 
     const get: RepositorySettingsService["Type"]["get"] = (projectId) =>
       Effect.gen(function* () {
+        const path = yield* projectPath(projectId);
+        const repoFile =
+          path === null ? emptyRepoFileSettings() : parseRepoFileSettings(path);
         const rows = yield* sql<Row>`
           SELECT project_id, default_provider_id, default_model,
                  default_runtime_mode, auto_create_worktree, worktree_base_dir,
-                 archive_cleanup_script, archive_remove_worktree
+                 archive_cleanup_script, archive_remove_worktree,
+                 setup_script, run_script, auto_run_after_setup,
+                 environment_variables_json
           FROM repository_settings
           WHERE project_id = ${projectId}
           LIMIT 1
         `.pipe(Effect.orDie);
-        return rowToSettings(projectId, rows[0] ?? null);
+        return rowToSettings(projectId, rows[0] ?? null, repoFile);
       });
 
     const update: RepositorySettingsService["Type"]["update"] = (
@@ -119,18 +257,31 @@ export const RepositorySettingsServiceLive = Layer.effect(
               : current.archiveCleanupScript,
           archiveRemoveWorktree:
             patch.archiveRemoveWorktree ?? current.archiveRemoveWorktree,
+          setupScript:
+            "setupScript" in patch ? cleanScript(patch.setupScript) : current.setupScript,
+          runScript:
+            "runScript" in patch ? cleanScript(patch.runScript) : current.runScript,
+          autoRunAfterSetup:
+            patch.autoRunAfterSetup ?? current.autoRunAfterSetup,
+          environmentVariables:
+            patch.environmentVariables ?? current.environmentVariables,
         });
 
         yield* sql`
           INSERT INTO repository_settings
             (project_id, default_provider_id, default_model,
              default_runtime_mode, auto_create_worktree, worktree_base_dir,
-             archive_cleanup_script, archive_remove_worktree)
+             archive_cleanup_script, archive_remove_worktree,
+             setup_script, run_script, auto_run_after_setup,
+             environment_variables_json)
           VALUES
             (${projectId}, ${next.defaultProviderId}, ${next.defaultModel},
              ${next.defaultRuntimeMode}, ${next.autoCreateWorktree ? 1 : 0},
              ${next.worktreeBaseDir}, ${next.archiveCleanupScript},
-             ${next.archiveRemoveWorktree ? 1 : 0})
+             ${next.archiveRemoveWorktree ? 1 : 0},
+             ${next.setupScript}, ${next.runScript},
+             ${next.autoRunAfterSetup ? 1 : 0},
+             ${JSON.stringify(next.environmentVariables)})
           ON CONFLICT(project_id) DO UPDATE SET
             default_provider_id = excluded.default_provider_id,
             default_model = excluded.default_model,
@@ -138,7 +289,11 @@ export const RepositorySettingsServiceLive = Layer.effect(
             auto_create_worktree = excluded.auto_create_worktree,
             worktree_base_dir = excluded.worktree_base_dir,
             archive_cleanup_script = excluded.archive_cleanup_script,
-            archive_remove_worktree = excluded.archive_remove_worktree
+            archive_remove_worktree = excluded.archive_remove_worktree,
+            setup_script = excluded.setup_script,
+            run_script = excluded.run_script,
+            auto_run_after_setup = excluded.auto_run_after_setup,
+            environment_variables_json = excluded.environment_variables_json
         `.pipe(Effect.orDie);
 
         return next;

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -95,10 +95,16 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(NodeContext.layer),
   );
 
+  // Per-repo settings overrides on top of the global defaults.
+  const RepositorySettingsLayer = RepositorySettingsServiceLive.pipe(
+    Layer.provide(MigratedSqlite),
+  );
+
   // WorktreeService manages memoize-owned `git worktree` checkouts. Same
   // shape as GitLayer + the SqlClient for persisting the rows.
   const WorktreeLayer = WorktreeServiceLive.pipe(
     Layer.provide(WorkspaceLayer),
+    Layer.provide(RepositorySettingsLayer),
     Layer.provide(MigratedSqlite),
     Layer.provide(NodeContext.layer),
   );
@@ -110,11 +116,6 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(WorkspaceLayer),
     Layer.provide(WorktreeLayer),
     Layer.provide(NodeContext.layer),
-  );
-
-  // Per-repo settings overrides on top of the global defaults.
-  const RepositorySettingsLayer = RepositorySettingsServiceLive.pipe(
-    Layer.provide(MigratedSqlite),
   );
 
   const PtyLayer = PtyServiceLive;

--- a/apps/server/src/worktree/handlers.ts
+++ b/apps/server/src/worktree/handlers.ts
@@ -17,10 +17,29 @@ const Get = MemoizeRpcs.toLayerHandler("worktree.get", ({ worktreeId }) =>
   Effect.flatMap(WorktreeService, (svc) => svc.get(worktreeId)),
 );
 
+const RerunSetup = MemoizeRpcs.toLayerHandler(
+  "worktree.rerunSetup",
+  ({ worktreeId }) =>
+    Effect.flatMap(WorktreeService, (svc) => svc.rerunSetup(worktreeId)),
+);
+
+const StartRun = MemoizeRpcs.toLayerHandler(
+  "worktree.startRun",
+  ({ worktreeId }) =>
+    Effect.flatMap(WorktreeService, (svc) => svc.startRun(worktreeId)),
+);
+
 const Remove = MemoizeRpcs.toLayerHandler(
   "worktree.remove",
   ({ worktreeId, force }) =>
     Effect.flatMap(WorktreeService, (svc) => svc.remove(worktreeId, force ?? false)),
 );
 
-export const WorktreeHandlersLayer = Layer.mergeAll(Create, List, Get, Remove);
+export const WorktreeHandlersLayer = Layer.mergeAll(
+  Create,
+  List,
+  Get,
+  RerunSetup,
+  StartRun,
+  Remove,
+);

--- a/apps/server/src/worktree/layers/worktree-service.ts
+++ b/apps/server/src/worktree/layers/worktree-service.ts
@@ -1,6 +1,9 @@
 import { Command, CommandExecutor, FileSystem } from "@effect/platform";
 import { SqlClient } from "@effect/sql";
 import { Effect, Layer, Stream } from "effect";
+import { spawn } from "node:child_process";
+import * as fsSync from "node:fs";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as Path from "node:path";
 
@@ -12,8 +15,11 @@ import {
   WorktreeId,
   WorktreeNotFoundError,
   WorktreeRemoveError,
+  WorktreeSetupError,
+  type WorktreeSetupStatus,
 } from "@memoize/wire";
 
+import { RepositorySettingsService } from "../../repository-settings/services/repository-settings-service.ts";
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
 import { generateCoolName } from "../cool-name.ts";
 import {
@@ -29,7 +35,18 @@ interface WorktreeRow {
   readonly branch: string;
   readonly base_branch: string;
   readonly created_at: string;
+  readonly setup_status: string;
+  readonly setup_output: string;
+  readonly setup_started_at: string | null;
+  readonly setup_finished_at: string | null;
 }
+
+const isSetupStatus = (value: string): value is WorktreeSetupStatus =>
+  value === "pending" ||
+  value === "running" ||
+  value === "succeeded" ||
+  value === "failed" ||
+  value === "skipped";
 
 const rowToWorktree = (row: WorktreeRow): Worktree =>
   Worktree.make({
@@ -40,15 +57,206 @@ const rowToWorktree = (row: WorktreeRow): Worktree =>
     branch: row.branch,
     baseBranch: row.base_branch,
     createdAt: new Date(row.created_at),
+    setupStatus: isSetupStatus(row.setup_status) ? row.setup_status : "pending",
+    setupOutput: row.setup_output,
+    setupStartedAt:
+      row.setup_started_at === null ? null : new Date(row.setup_started_at),
+    setupFinishedAt:
+      row.setup_finished_at === null ? null : new Date(row.setup_finished_at),
+  });
+
+const SETUP_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_SETUP_OUTPUT = 80_000;
+const LOCKFILES = [
+  "bun.lock",
+  "bun.lockb",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+] as const;
+
+const truncateOutput = (value: string): string =>
+  value.length <= MAX_SETUP_OUTPUT
+    ? value
+    : value.slice(value.length - MAX_SETUP_OUTPUT);
+
+const readIfExists = async (path: string): Promise<Buffer | null> => {
+  try {
+    return await fs.readFile(path);
+  } catch (err) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      err.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw err;
+  }
+};
+
+const matchingLockfile = async (
+  repoPath: string,
+  worktreePath: string,
+): Promise<boolean> => {
+  for (const lockfile of LOCKFILES) {
+    const source = await readIfExists(Path.join(repoPath, lockfile));
+    const target = await readIfExists(Path.join(worktreePath, lockfile));
+    if (source !== null || target !== null) {
+      return (
+        source !== null &&
+        target !== null &&
+        source.length === target.length &&
+        source.equals(target)
+      );
+    }
+  }
+  return false;
+};
+
+const isEmptyDirectory = async (path: string): Promise<boolean> => {
+  try {
+    const entries = await fs.readdir(path);
+    return entries.length === 0;
+  } catch {
+    return false;
+  }
+};
+
+const prepareLocalFiles = async (
+  repoPath: string,
+  worktreePath: string,
+): Promise<string> => {
+  let output = "";
+
+  const sourceNodeModules = Path.join(repoPath, "node_modules");
+  const targetNodeModules = Path.join(worktreePath, "node_modules");
+  if (
+    fsSync.existsSync(sourceNodeModules) &&
+    (await matchingLockfile(repoPath, worktreePath))
+  ) {
+    let canLink = false;
+    try {
+      const stat = await fs.lstat(targetNodeModules);
+      if (stat.isSymbolicLink()) {
+        output += "node_modules already symlinked\n";
+      } else if (stat.isDirectory() && (await isEmptyDirectory(targetNodeModules))) {
+        await fs.rmdir(targetNodeModules);
+        canLink = true;
+      } else {
+        output += "node_modules exists; leaving it untouched\n";
+      }
+    } catch (err) {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        err.code === "ENOENT"
+      ) {
+        canLink = true;
+      } else {
+        throw err;
+      }
+    }
+    if (canLink) {
+      await fs.symlink(sourceNodeModules, targetNodeModules, "dir");
+      output += `linked node_modules -> ${sourceNodeModules}\n`;
+    }
+  }
+
+  for (const entry of await fs.readdir(repoPath)) {
+    if (!entry.startsWith(".env")) continue;
+    const source = Path.join(repoPath, entry);
+    const target = Path.join(worktreePath, entry);
+    if (fsSync.existsSync(target)) continue;
+    const stat = await fs.lstat(source);
+    if (!stat.isFile() && !stat.isSymbolicLink()) continue;
+    await fs.copyFile(source, target);
+    output += `copied ${entry}\n`;
+  }
+
+  return output;
+};
+
+const runShellScript = ({
+  script,
+  cwd,
+  env,
+}: {
+  readonly script: string;
+  readonly cwd: string;
+  readonly env: Readonly<Record<string, string>>;
+}): Promise<{ readonly exitCode: number | null; readonly output: string }> =>
+  new Promise((resolve, reject) => {
+    let output = "";
+    let timedOut = false;
+    const child = spawn("/bin/zsh", ["-lc", script], {
+      cwd,
+      env: { ...(process.env as Record<string, string>), ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const append = (chunk: unknown) => {
+      output = truncateOutput(output + String(chunk));
+    };
+    child.stdout?.on("data", append);
+    child.stderr?.on("data", append);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already exited
+      }
+    }, SETUP_TIMEOUT_MS);
+    child.on("error", reject);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: timedOut ? 124 : code,
+        output: truncateOutput(output),
+      });
+    });
   });
 
 export const WorktreeServiceLive = Layer.effect(
   WorktreeService,
   Effect.gen(function* () {
     const workspace = yield* WorkspaceService;
+    const repositorySettings = yield* RepositorySettingsService;
     const executor = yield* CommandExecutor.CommandExecutor;
     const fs = yield* FileSystem.FileSystem;
     const sql = yield* SqlClient.SqlClient;
+
+    const worktreeColumns = yield* sql<{ readonly name: string }>`
+      PRAGMA table_info(worktrees)
+    `.pipe(Effect.orDie);
+    const hasWorktreeColumn = (name: string): boolean =>
+      worktreeColumns.some((column) => column.name === name);
+    if (!hasWorktreeColumn("setup_status")) {
+      yield* sql`
+        ALTER TABLE worktrees
+          ADD COLUMN setup_status TEXT NOT NULL DEFAULT 'pending'
+      `.pipe(Effect.orDie);
+    }
+    if (!hasWorktreeColumn("setup_output")) {
+      yield* sql`
+        ALTER TABLE worktrees
+          ADD COLUMN setup_output TEXT NOT NULL DEFAULT ''
+      `.pipe(Effect.orDie);
+    }
+    if (!hasWorktreeColumn("setup_started_at")) {
+      yield* sql`
+        ALTER TABLE worktrees
+          ADD COLUMN setup_started_at TEXT
+      `.pipe(Effect.orDie);
+    }
+    if (!hasWorktreeColumn("setup_finished_at")) {
+      yield* sql`
+        ALTER TABLE worktrees
+          ADD COLUMN setup_finished_at TEXT
+      `.pipe(Effect.orDie);
+    }
 
     const collectText = (
       s: Stream.Stream<
@@ -98,7 +306,8 @@ export const WorktreeServiceLive = Layer.effect(
     const list: WorktreeService["Type"]["list"] = (projectId) =>
       Effect.gen(function* () {
         const rows = yield* sql<WorktreeRow>`
-          SELECT id, project_id, path, name, branch, base_branch, created_at
+          SELECT id, project_id, path, name, branch, base_branch, created_at,
+                 setup_status, setup_output, setup_started_at, setup_finished_at
           FROM worktrees
           WHERE project_id = ${projectId}
           ORDER BY created_at DESC
@@ -109,7 +318,8 @@ export const WorktreeServiceLive = Layer.effect(
     const get: WorktreeService["Type"]["get"] = (worktreeId) =>
       Effect.gen(function* () {
         const rows = yield* sql<WorktreeRow>`
-          SELECT id, project_id, path, name, branch, base_branch, created_at
+          SELECT id, project_id, path, name, branch, base_branch, created_at,
+                 setup_status, setup_output, setup_started_at, setup_finished_at
           FROM worktrees
           WHERE id = ${worktreeId}
           LIMIT 1
@@ -256,19 +466,16 @@ export const WorktreeServiceLive = Layer.effect(
           const nowIso = now.toISOString();
           yield* sql`
             INSERT INTO worktrees
-              (id, project_id, path, name, branch, base_branch, created_at)
+              (id, project_id, path, name, branch, base_branch, created_at,
+               setup_status, setup_output)
             VALUES
-              (${id}, ${projectId}, ${target}, ${name}, ${branch}, ${baseBranch}, ${nowIso})
+              (${id}, ${projectId}, ${target}, ${name}, ${branch}, ${baseBranch}, ${nowIso},
+               'pending', '')
           `.pipe(Effect.orDie);
-          return Worktree.make({
-            id,
-            projectId,
-            path: target,
-            name,
-            branch,
-            baseBranch,
-            createdAt: now,
-          });
+          const prepared = yield* runSetupFor(id).pipe(
+            Effect.catchAll(() => get(id).pipe(Effect.map((wt) => wt!))),
+          );
+          return prepared;
         }
         return yield* Effect.fail(
           new WorktreeCreateError({
@@ -382,11 +589,12 @@ export const WorktreeServiceLive = Layer.effect(
         const createdAtIso = snapshot.createdAt.toISOString();
         yield* sql`
           INSERT INTO worktrees
-            (id, project_id, path, name, branch, base_branch, created_at)
+            (id, project_id, path, name, branch, base_branch, created_at,
+             setup_status, setup_output)
           VALUES
             (${snapshot.id}, ${snapshot.projectId}, ${snapshot.path},
              ${snapshot.name}, ${snapshot.branch}, ${snapshot.baseBranch},
-             ${createdAtIso})
+             ${createdAtIso}, 'skipped', '')
         `.pipe(Effect.orDie);
 
         return Worktree.make({
@@ -397,9 +605,128 @@ export const WorktreeServiceLive = Layer.effect(
           branch: snapshot.branch,
           baseBranch: snapshot.baseBranch,
           createdAt: snapshot.createdAt,
+          setupStatus: "skipped",
+          setupOutput: "",
+          setupStartedAt: null,
+          setupFinishedAt: null,
         });
       });
 
-    return { create, list, get, remove, restore } as const;
+    const setupEnv = (
+      repoPath: string,
+      worktree: Worktree,
+      env: Readonly<Record<string, string>>,
+    ): Record<string, string> => ({
+      ...env,
+      MEMOIZE_ROOT_PATH: repoPath,
+      MEMOIZE_WORKTREE_PATH: worktree.path,
+      MEMOIZE_WORKTREE_ID: worktree.id,
+      MEMOIZE_PORT: process.env.MEMOIZE_PORT ?? process.env.PORT ?? "",
+    });
+
+    function runSetupFor(
+      worktreeId: WorktreeId,
+    ): Effect.Effect<Worktree, WorktreeNotFoundError | WorktreeSetupError> {
+      return Effect.gen(function* () {
+        const worktree = yield* get(worktreeId);
+        if (worktree === null) {
+          return yield* Effect.fail(new WorktreeNotFoundError({ worktreeId }));
+        }
+        const folder = yield* workspace.findById(worktree.projectId);
+        if (folder === null) {
+          return yield* Effect.fail(
+            new WorktreeSetupError({ worktreeId, reason: "project not found" }),
+          );
+        }
+        const settings = yield* repositorySettings.get(worktree.projectId);
+        const script = settings.setupScript?.trim() ?? "";
+        const startedAt = new Date().toISOString();
+        yield* sql`
+          UPDATE worktrees
+          SET setup_status = 'running',
+              setup_output = '',
+              setup_started_at = ${startedAt},
+              setup_finished_at = NULL
+          WHERE id = ${worktreeId}
+        `.pipe(Effect.orDie);
+
+        const prep = yield* Effect.tryPromise({
+          try: () => prepareLocalFiles(folder.path, worktree.path),
+          catch: (err) =>
+            new WorktreeSetupError({
+              worktreeId,
+              reason: err instanceof Error ? err.message : String(err),
+            }),
+        });
+
+        if (script.length === 0) {
+          const finishedAt = new Date().toISOString();
+          yield* sql`
+            UPDATE worktrees
+            SET setup_status = 'skipped',
+                setup_output = ${prep},
+                setup_finished_at = ${finishedAt}
+            WHERE id = ${worktreeId}
+          `.pipe(Effect.orDie);
+          return (yield* get(worktreeId))!;
+        }
+
+        const result = yield* Effect.tryPromise({
+          try: () =>
+            runShellScript({
+              script,
+              cwd: worktree.path,
+              env: setupEnv(folder.path, worktree, settings.environmentVariables),
+            }),
+          catch: (err) =>
+            new WorktreeSetupError({
+              worktreeId,
+              reason: err instanceof Error ? err.message : String(err),
+            }),
+        });
+        const finishedAt = new Date().toISOString();
+        const status = result.exitCode === 0 ? "succeeded" : "failed";
+        const output = truncateOutput(`${prep}${result.output}`);
+        yield* sql`
+          UPDATE worktrees
+          SET setup_status = ${status},
+              setup_output = ${output},
+              setup_finished_at = ${finishedAt}
+          WHERE id = ${worktreeId}
+        `.pipe(Effect.orDie);
+        return (yield* get(worktreeId))!;
+      });
+    }
+
+    const rerunSetup: WorktreeService["Type"]["rerunSetup"] = (worktreeId) =>
+      runSetupFor(worktreeId);
+
+    const startRun: WorktreeService["Type"]["startRun"] = (worktreeId) =>
+      Effect.gen(function* () {
+        const worktree = yield* get(worktreeId);
+        if (worktree === null) {
+          return yield* Effect.fail(new WorktreeNotFoundError({ worktreeId }));
+        }
+        const folder = yield* workspace.findById(worktree.projectId);
+        if (folder === null) {
+          return yield* Effect.fail(
+            new WorktreeSetupError({ worktreeId, reason: "project not found" }),
+          );
+        }
+        const settings = yield* repositorySettings.get(worktree.projectId);
+        const script = settings.runScript?.trim() ?? "";
+        if (script.length === 0) {
+          return yield* Effect.fail(
+            new WorktreeSetupError({ worktreeId, reason: "run script is empty" }),
+          );
+        }
+        return {
+          cwd: worktree.path,
+          script,
+          env: setupEnv(folder.path, worktree, settings.environmentVariables),
+        };
+      });
+
+    return { create, list, get, remove, restore, rerunSetup, startRun } as const;
   }),
 );

--- a/apps/server/src/worktree/services/worktree-service.ts
+++ b/apps/server/src/worktree/services/worktree-service.ts
@@ -8,6 +8,7 @@ import {
   type WorktreeId,
   type WorktreeNotFoundError,
   type WorktreeRemoveError,
+  type WorktreeSetupError,
 } from "@memoize/wire";
 
 export interface WorktreeRestoreSnapshot {
@@ -34,6 +35,22 @@ export interface WorktreeServiceShape {
   ) => Effect.Effect<
     void,
     WorktreeNotFoundError | WorktreeDirtyError | WorktreeRemoveError
+  >;
+  readonly rerunSetup: (
+    worktreeId: WorktreeId,
+  ) => Effect.Effect<
+    Worktree,
+    WorktreeNotFoundError | WorktreeSetupError | WorktreeRemoveError
+  >;
+  readonly startRun: (
+    worktreeId: WorktreeId,
+  ) => Effect.Effect<
+    {
+      readonly cwd: string;
+      readonly script: string;
+      readonly env: Record<string, string>;
+    },
+    WorktreeNotFoundError | WorktreeSetupError
   >;
   readonly restore: (
     snapshot: WorktreeRestoreSnapshot,

--- a/packages/wire/src/pty.ts
+++ b/packages/wire/src/pty.ts
@@ -37,6 +37,9 @@ export class PtySpawnError extends Schema.TaggedError<PtySpawnError>()(
 export const PtyCommand = Schema.Struct({
   cmd: Schema.String,
   args: Schema.Array(Schema.String),
+  env: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
 });
 export type PtyCommand = typeof PtyCommand.Type;
 

--- a/packages/wire/src/repository-settings.ts
+++ b/packages/wire/src/repository-settings.ts
@@ -39,6 +39,13 @@ export class RepositorySettings extends Schema.Class<RepositorySettings>(
    * the checkout from the archived metadata.
    */
   archiveRemoveWorktree: Schema.Boolean,
+  setupScript: Schema.NullOr(Schema.String),
+  runScript: Schema.NullOr(Schema.String),
+  autoRunAfterSetup: Schema.Boolean,
+  environmentVariables: Schema.Record({
+    key: Schema.String,
+    value: Schema.String,
+  }),
 }) {}
 
 /**
@@ -54,6 +61,12 @@ export const RepositorySettingsPatch = Schema.Struct({
   worktreeBaseDir: Schema.optional(Schema.NullOr(Schema.String)),
   archiveCleanupScript: Schema.optional(Schema.NullOr(Schema.String)),
   archiveRemoveWorktree: Schema.optional(Schema.Boolean),
+  setupScript: Schema.optional(Schema.NullOr(Schema.String)),
+  runScript: Schema.optional(Schema.NullOr(Schema.String)),
+  autoRunAfterSetup: Schema.optional(Schema.Boolean),
+  environmentVariables: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
 });
 export type RepositorySettingsPatch = typeof RepositorySettingsPatch.Type;
 

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -136,6 +136,8 @@ import {
   WorktreeGetRpc,
   WorktreeListRpc,
   WorktreeRemoveRpc,
+  WorktreeRerunSetupRpc,
+  WorktreeStartRunRpc,
 } from "./worktree.ts";
 
 /**
@@ -240,6 +242,8 @@ export const MemoizeRpcs = RpcGroup.make(
   WorktreeCreateRpc,
   WorktreeListRpc,
   WorktreeGetRpc,
+  WorktreeRerunSetupRpc,
+  WorktreeStartRunRpc,
   WorktreeRemoveRpc,
   RepositorySettingsGetRpc,
   RepositorySettingsUpdateRpc,

--- a/packages/wire/src/worktree.ts
+++ b/packages/wire/src/worktree.ts
@@ -3,6 +3,15 @@ import { Schema } from "effect";
 
 import { FolderId, WorktreeId } from "./ids.ts";
 
+export const WorktreeSetupStatus = Schema.Literal(
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+  "skipped",
+);
+export type WorktreeSetupStatus = typeof WorktreeSetupStatus.Type;
+
 /**
  * A git worktree owned by memoize. Lives at
  * `~/.memoize/<repo-name>-<projectId-short>/<name>/` so it stays out of the
@@ -18,6 +27,10 @@ export class Worktree extends Schema.Class<Worktree>("Worktree")({
   branch: Schema.String,
   baseBranch: Schema.String,
   createdAt: Schema.DateFromString,
+  setupStatus: WorktreeSetupStatus,
+  setupOutput: Schema.String,
+  setupStartedAt: Schema.NullOr(Schema.DateFromString),
+  setupFinishedAt: Schema.NullOr(Schema.DateFromString),
 }) {}
 
 export class WorktreeNotFoundError extends Schema.TaggedError<WorktreeNotFoundError>()(
@@ -40,11 +53,17 @@ export class WorktreeDirtyError extends Schema.TaggedError<WorktreeDirtyError>()
   { worktreeId: WorktreeId },
 ) {}
 
+export class WorktreeSetupError extends Schema.TaggedError<WorktreeSetupError>()(
+  "WorktreeSetupError",
+  { worktreeId: WorktreeId, reason: Schema.String },
+) {}
+
 const WorktreeErrors = Schema.Union(
   WorktreeCreateError,
   WorktreeRemoveError,
   WorktreeNotFoundError,
   WorktreeDirtyError,
+  WorktreeSetupError,
 );
 
 export const WorktreeCreateRpc = Rpc.make("worktree.create", {
@@ -61,6 +80,22 @@ export const WorktreeListRpc = Rpc.make("worktree.list", {
 export const WorktreeGetRpc = Rpc.make("worktree.get", {
   payload: Schema.Struct({ worktreeId: WorktreeId }),
   success: Schema.NullOr(Worktree),
+});
+
+export const WorktreeRerunSetupRpc = Rpc.make("worktree.rerunSetup", {
+  payload: Schema.Struct({ worktreeId: WorktreeId }),
+  success: Worktree,
+  error: WorktreeErrors,
+});
+
+export const WorktreeStartRunRpc = Rpc.make("worktree.startRun", {
+  payload: Schema.Struct({ worktreeId: WorktreeId }),
+  success: Schema.Struct({
+    cwd: Schema.String,
+    script: Schema.String,
+    env: Schema.Record({ key: Schema.String, value: Schema.String }),
+  }),
+  error: WorktreeErrors,
 });
 
 /**

--- a/scripts/conductor-setup.mjs
+++ b/scripts/conductor-setup.mjs
@@ -1,0 +1,68 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, lstatSync, readdirSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+
+const workspaceRoot = process.cwd();
+const commonDir = execFileSync("git", [
+  "rev-parse",
+  "--path-format=absolute",
+  "--git-common-dir",
+], { cwd: workspaceRoot, encoding: "utf8" }).trim();
+const repoRoot = join(commonDir, "..");
+
+const lockfiles = [
+  "bun.lock",
+  "bun.lockb",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+];
+
+function sameFile(a, b) {
+  if (!existsSync(a) || !existsSync(b)) return false;
+  const left = readFileSync(a);
+  const right = readFileSync(b);
+  return left.length === right.length && left.equals(right);
+}
+
+function lockfilesMatch() {
+  for (const lockfile of lockfiles) {
+    const source = join(repoRoot, lockfile);
+    const target = join(workspaceRoot, lockfile);
+    if (existsSync(source) || existsSync(target)) return sameFile(source, target);
+  }
+  return false;
+}
+
+function isEmptyDir(path) {
+  try {
+    return lstatSync(path).isDirectory() && readdirSync(path).length === 0;
+  } catch {
+    return false;
+  }
+}
+
+const sourceNodeModules = join(repoRoot, "node_modules");
+const targetNodeModules = join(workspaceRoot, "node_modules");
+
+if (existsSync(sourceNodeModules) && lockfilesMatch()) {
+  let canLink = false;
+  if (!existsSync(targetNodeModules)) {
+    canLink = true;
+  } else if (lstatSync(targetNodeModules).isSymbolicLink()) {
+    console.log("node_modules already symlinked");
+  } else if (isEmptyDir(targetNodeModules)) {
+    rmSync(targetNodeModules, { recursive: false });
+    canLink = true;
+  } else {
+    console.log("node_modules exists; leaving it untouched");
+  }
+
+  if (canLink) {
+    symlinkSync(sourceNodeModules, targetNodeModules, "dir");
+    console.log(`linked node_modules -> ${sourceNodeModules}`);
+  }
+} else {
+  console.log("node_modules not linked; running bun install");
+  execFileSync("bun", ["install"], { cwd: workspaceRoot, stdio: "inherit" });
+}


### PR DESCRIPTION
Adds Conductor-style setup, run, archive, environment, and auto-run settings for worktree-backed chats.

Worktree creation now records setup state/output, prepares local env/dependency files, exposes rerun/start-run RPCs, and shows setup/run/terminal tabs with loading states.

The repo also gets Conductor setup defaults, a .worktreeinclude, isolated dev user data support, and lockfile-safe node_modules symlinking.

Validated with `bun run check-types`, `bun run test`, and `bun run lint`.