### PR TITLE
[codex] Hide Grok auth noise and group agent activity

### DIFF
--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -1,7 +1,7 @@
 import { ClipboardIcon, Robot01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { AgentItemId, Message, UserQuestionAnswer } from "@memoize/wire";
 
@@ -9,12 +9,15 @@ import { cn } from "~/lib/utils";
 
 import { CopyButton } from "./copy-button.tsx";
 import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import { ThreeDots } from "./ui/loaders";
 
 const MODEL_LABEL: Record<string, string> = {
   "claude-opus-4-7": "Opus 4.7",
   "claude-sonnet-4-6": "Sonnet 4.6",
   "claude-haiku-4-5": "Haiku 4.5",
 };
+
+const AGENT_ACTIVITY_WINDOW_MS = 10_000;
 
 const labelForModel = (model: string | undefined): string => {
   if (!model) return "inherit";
@@ -71,7 +74,6 @@ export function SubagentRow({
   // Auto-expand while running (no summary yet) so the user can watch the
   // sub-agent work. Once finished, collapse to a one-line meta summary.
   const [expanded, setExpanded] = useState<boolean>(summary === null);
-  const Chevron = expanded ? ChevronDown : ChevronRight;
 
   const trailingMeta = useMemo(() => {
     if (summary !== null) {
@@ -79,6 +81,25 @@ export function SubagentRow({
     }
     return labelForModel(modelRequested);
   }, [summary, modelRequested]);
+
+  const latestChildAt = useMemo(() => {
+    let latest = 0;
+    for (const child of children) {
+      latest = Math.max(latest, child.createdAt.getTime());
+    }
+    return latest;
+  }, [children]);
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (summary !== null) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [summary]);
+
+  const showActivityLoader =
+    summary === null &&
+    (latestChildAt === 0 || now - latestChildAt < AGENT_ACTIVITY_WINDOW_MS);
 
   void agentToolUseId; // reserved for future deeplink anchor
 
@@ -93,33 +114,33 @@ export function SubagentRow({
         )}
       >
         <div className="relative grid size-4 shrink-0 place-items-center">
-          <HugeiconsIcon
-            icon={Robot01Icon}
-            strokeWidth={2}
-            aria-hidden="true"
-            className={cn(
-              "col-start-1 row-start-1 size-3.5 text-muted-foreground transition-opacity duration-150 ease-out",
-              "group-hover:opacity-0 motion-reduce:transition-none",
-            )}
-          />
-          <Chevron
-            aria-hidden="true"
-            className={cn(
-              "col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
-              "group-hover:opacity-100 motion-reduce:transition-none",
-            )}
-          />
+          {showActivityLoader ? (
+            <ThreeDots
+              dotSize={2}
+              cellPadding={0.5}
+              speed={1.3}
+              className="text-muted-foreground"
+              aria-label="Agent running"
+            />
+          ) : (
+            <HugeiconsIcon
+              icon={Robot01Icon}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="size-3.5 text-muted-foreground"
+            />
+          )}
         </div>
         <span className="shrink-0 font-medium text-foreground/90">
           Agent · {agentName}
         </span>
         <span
           className={cn(
-            "min-w-0 flex-1 truncate text-muted-foreground",
+            "flex min-w-0 flex-1 items-center gap-1 truncate text-muted-foreground",
             summary?.isError && "text-red-300",
           )}
         >
-          {trailingMeta}
+          <span className="min-w-0 truncate">{trailingMeta}</span>
         </span>
       </button>
       {expanded ? (

--- a/apps/renderer/src/lib/group-messages.ts
+++ b/apps/renderer/src/lib/group-messages.ts
@@ -20,8 +20,18 @@ export type RenderGroup =
     };
 
 export const isAgentToolUse = (m: Message): boolean =>
-  m.content._tag === "tool_use" &&
-  (m.content.tool === "Agent" || m.content.tool === "Task");
+  (() => {
+    if (
+      m.content._tag !== "tool_use" ||
+      (m.content.tool !== "Agent" && m.content.tool !== "Task") ||
+      m.content.input === null ||
+      typeof m.content.input !== "object"
+    ) {
+      return false;
+    }
+    const input = m.content.input as Record<string, unknown>;
+    return typeof input.prompt === "string";
+  })();
 
 /**
  * Walk the message log once and produce a flat render order where each
@@ -70,10 +80,17 @@ export function groupMessages(
         c.input !== null && typeof c.input === "object"
           ? (c.input as Record<string, unknown>)
           : {};
+      const description =
+        typeof inputObj.description === "string" &&
+        inputObj.description.trim().length > 0 &&
+        inputObj.description !== "Task"
+          ? (inputObj.description as string)
+          : undefined;
       const subagentType =
         typeof inputObj.subagent_type === "string"
           ? (inputObj.subagent_type as string)
-          : "agent";
+          : undefined;
+      const agentName = description ?? subagentType ?? "agent";
       const modelRequested =
         typeof inputObj.model === "string"
           ? (inputObj.model as string)
@@ -100,7 +117,7 @@ export function groupMessages(
         kind: "subagent",
         parent: m,
         parentItemId: c.itemId,
-        agentName: subagentType,
+        agentName,
         prompt,
         modelRequested,
         children: childrenByParent.get(c.itemId) ?? [],

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -469,6 +469,9 @@ const buildCanonicalInput = (
 
   // Generic fallback — preserve whatever the provider sent so the renderer
   // can still render *something* even for tool names we don't recognize.
+  if (rawInput !== null) {
+    return rawInput;
+  }
   if (u["input"] !== undefined) return u["input"];
   if (u["arguments"] !== undefined) {
     const a = u["arguments"];
@@ -889,6 +892,152 @@ interface ToolCallState {
   toolName: string | null;
 }
 
+interface CollabAgentRun {
+  readonly parentItemId: AgentItemId;
+  readonly model: string;
+  readonly startedAt: number;
+  turnCount: number;
+  lastMessage: string;
+  summaryEmitted: boolean;
+}
+
+interface GrokCursorTaskRun {
+  readonly itemId: AgentItemId;
+  readonly description: string;
+  readonly prompt: string;
+  readonly model: string;
+  readonly startedAt: number;
+  readonly scoreText: string;
+  childEventCount: number;
+  lastActivityAt: number;
+  lastMessage: string;
+  summaryEmitted: boolean;
+}
+
+const recordFrom = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+
+const stringFrom = (
+  record: Record<string, unknown>,
+  key: string,
+): string | null => {
+  const v = record[key];
+  return typeof v === "string" && v.length > 0 ? v : null;
+};
+
+const collabAgentStateStatus = (value: unknown): string | null => {
+  const state = recordFrom(value);
+  if (state === null) return null;
+  const directType = stringFrom(state, "type");
+  if (directType !== null) return directType;
+  const status = state["status"];
+  if (typeof status === "string") return status;
+  if (status !== null && typeof status === "object") {
+    return stringFrom(status as Record<string, unknown>, "type");
+  }
+  return null;
+};
+
+const collabAgentStateMessage = (value: unknown): string | null => {
+  const state = recordFrom(value);
+  if (state === null) return null;
+  return stringFrom(state, "message");
+};
+
+const isTerminalCollabAgentStatus = (status: string | null): boolean =>
+  status === "completed" ||
+  status === "idle" ||
+  status === "notLoaded" ||
+  status === "errored" ||
+  status === "systemError" ||
+  status === "interrupted" ||
+  status === "shutdown";
+
+const grokCallPrefix = (itemId: string): string | null => {
+  const match = /^call-([0-9a-f-]{36})-composer_call_/i.exec(itemId);
+  return match?.[1] ?? null;
+};
+
+const isGrokCursorTaskInput = (input: unknown): input is Record<string, unknown> => {
+  const record = recordFrom(input);
+  if (record === null) return false;
+  return (
+    record["variant"] === "CursorTask" ||
+    typeof record["subagent_type"] === "string"
+  );
+};
+
+const grokTaskText = (input: Record<string, unknown>): {
+  readonly description: string;
+  readonly prompt: string;
+  readonly model: string;
+} => {
+  const description =
+    typeof input["description"] === "string" ? input["description"] : "agent";
+  const prompt = typeof input["prompt"] === "string" ? input["prompt"] : "";
+  const model = typeof input["model"] === "string" ? input["model"] : "inherit";
+  return { description, prompt, model };
+};
+
+const GROK_TASK_STOP_WORDS = new Set([
+  "about",
+  "after",
+  "again",
+  "available",
+  "check",
+  "code",
+  "current",
+  "files",
+  "from",
+  "into",
+  "local",
+  "return",
+  "status",
+  "task",
+  "tasks",
+  "that",
+  "this",
+  "with",
+  "work",
+]);
+
+const tokenizeForGrokTaskScore = (value: string): Set<string> => {
+  const out = new Set<string>();
+  for (const token of value.toLowerCase().match(/[a-z0-9][a-z0-9_-]{3,}/g) ?? []) {
+    if (!GROK_TASK_STOP_WORDS.has(token)) out.add(token);
+  }
+  return out;
+};
+
+const scoreGrokTaskMatch = (
+  task: GrokCursorTaskRun,
+  text: string,
+): number => {
+  const haystack = text.toLowerCase();
+  const description = task.description.toLowerCase();
+  let score = haystack.includes(description) ? 20 : 0;
+  const taskTokens = tokenizeForGrokTaskScore(task.scoreText);
+  const eventTokens = tokenizeForGrokTaskScore(text);
+  for (const token of eventTokens) {
+    if (taskTokens.has(token)) score += 1;
+  }
+  return score;
+};
+
+const appendStreamText = (buffer: string, text: string): string => {
+  if (
+    buffer.length > 0 &&
+    text.length > 0 &&
+    /[A-Za-z0-9]$/.test(buffer) &&
+    /^[A-Z][a-z]/.test(text)
+  ) {
+    return `${buffer} ${text}`;
+  }
+  return `${buffer}${text}`;
+};
+
 /**
  * Create a per-session translator. Stateful because:
  *   1. ACP's `agent_message_chunk` is a delta protocol — we buffer
@@ -910,14 +1059,23 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
   let thinkingItemId: AgentItemId | null = null;
 
   const toolStates = new Map<string, ToolCallState>();
+  const collabAgentsByThread = new Map<string, CollabAgentRun>();
+  const grokCursorTasks = new Map<AgentItemId, GrokCursorTaskRun>();
+  const grokCursorTaskOrder: AgentItemId[] = [];
+  const grokPrefixToTask = new Map<string, AgentItemId>();
+  const grokTaskLaunchPrefixes = new Set<string>();
+  let lastGrokCursorTextParentItemId: AgentItemId | undefined;
 
   const flushAssistant = (): ReadonlyArray<AgentEvent> => {
     if (assistantBuffer.length === 0) return [];
+    const parentItemId = grokCursorTextParentFor(assistantBuffer);
     const ev: AgentEvent = {
       _tag: "AssistantMessage",
       itemId: assistantItemId ?? nextItemId(),
       text: assistantBuffer,
+      parentItemId,
     };
+    noteGrokCursorTaskChild(parentItemId, assistantBuffer);
     trace(
       provider,
       `flush AssistantMessage itemId=${ev.itemId} len=${assistantBuffer.length} preview=${safePreview(assistantBuffer)}`,
@@ -929,12 +1087,15 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
 
   const flushThinking = (): ReadonlyArray<AgentEvent> => {
     if (thinkingBuffer.length === 0) return [];
+    const parentItemId = grokCursorTextParentFor(thinkingBuffer);
     const ev: AgentEvent = {
       _tag: "Thinking",
       itemId: thinkingItemId ?? nextItemId(),
       text: thinkingBuffer,
       redacted: false,
+      parentItemId,
     };
+    noteGrokCursorTaskChild(parentItemId);
     trace(
       provider,
       `flush Thinking itemId=${ev.itemId} len=${thinkingBuffer.length} preview=${safePreview(thinkingBuffer)}`,
@@ -970,23 +1131,204 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
     return s;
   };
 
+  const parentItemIdForThread = (threadId: unknown): AgentItemId | undefined =>
+    typeof threadId === "string"
+      ? collabAgentsByThread.get(threadId)?.parentItemId
+      : undefined;
+
+  const rememberCollabAgent = (
+    itemId: AgentItemId,
+    threadId: string,
+    model: string,
+  ): CollabAgentRun => {
+    let run = collabAgentsByThread.get(threadId);
+    if (run === undefined) {
+      run = {
+        parentItemId: itemId,
+        model,
+        startedAt: Date.now(),
+        turnCount: 0,
+        lastMessage: "",
+        summaryEmitted: false,
+      };
+      collabAgentsByThread.set(threadId, run);
+    }
+    return run;
+  };
+
+  const maybeFinishCollabAgent = (
+    itemId: AgentItemId,
+    run: CollabAgentRun,
+    state: unknown,
+  ): AgentEvent | null => {
+    const status = collabAgentStateStatus(state);
+    if (!isTerminalCollabAgentStatus(status) || run.summaryEmitted) return null;
+    run.summaryEmitted = true;
+    const message = collabAgentStateMessage(state) ?? run.lastMessage;
+    return {
+      _tag: "SubagentSummary",
+      itemId,
+      agentName: "agent",
+      model: run.model,
+      turns: run.turnCount,
+      durationMs: Date.now() - run.startedAt,
+      summary: message,
+      isError: status === "errored" || status === "interrupted",
+    };
+  };
+
+  const rememberGrokCursorTask = (
+    itemId: AgentItemId,
+    input: Record<string, unknown>,
+  ): void => {
+    if (provider !== "grok" || !isGrokCursorTaskInput(input)) return;
+    const current = grokCursorTasks.get(itemId);
+    const { description, prompt, model } = grokTaskText(input);
+    if (current !== undefined) {
+      current.lastMessage = current.lastMessage || description;
+      return;
+    }
+    grokCursorTasks.set(itemId, {
+      itemId,
+      description,
+      prompt,
+      model,
+      startedAt: Date.now(),
+      scoreText: `${description}\n${prompt}`,
+      childEventCount: 0,
+      lastActivityAt: Date.now(),
+      lastMessage: "",
+      summaryEmitted: false,
+    });
+    grokCursorTaskOrder.push(itemId);
+    const prefix = grokCallPrefix(itemId);
+    if (prefix !== null) grokTaskLaunchPrefixes.add(prefix);
+  };
+
+  const bestGrokCursorTaskForText = (text: string): GrokCursorTaskRun | null => {
+    if (provider !== "grok" || grokCursorTaskOrder.length === 0) return null;
+    let best: GrokCursorTaskRun | null = null;
+    let bestScore = 0;
+    for (const itemId of grokCursorTaskOrder) {
+      const task = grokCursorTasks.get(itemId);
+      if (task === undefined || task.summaryEmitted) continue;
+      const score = scoreGrokTaskMatch(task, text);
+      if (score > bestScore) {
+        best = task;
+        bestScore = score;
+      }
+    }
+    return bestScore > 0 ? best : null;
+  };
+
+  const grokCursorTextParentFor = (
+    text: string,
+  ): AgentItemId | undefined => {
+    if (provider !== "grok") return undefined;
+    const best = bestGrokCursorTaskForText(text);
+    if (best !== null) return best.itemId;
+    if (lastGrokCursorTextParentItemId === undefined) return undefined;
+    const task = grokCursorTasks.get(lastGrokCursorTextParentItemId);
+    return task !== undefined && !task.summaryEmitted ? task.itemId : undefined;
+  };
+
+  const parentGrokCursorTaskForTool = (
+    itemId: AgentItemId,
+    toolName: string,
+    update: Record<string, unknown>,
+    input: unknown,
+  ): AgentItemId | undefined => {
+    if (provider !== "grok" || grokCursorTaskOrder.length === 0) return undefined;
+    if (toolName === "Task" || toolName === "Agent") return undefined;
+    const prefix = grokCallPrefix(itemId);
+    if (prefix === null || grokTaskLaunchPrefixes.has(prefix)) return undefined;
+    const existing = grokPrefixToTask.get(prefix);
+    if (existing !== undefined) return existing;
+
+    const rawInput = recordFrom(update["rawInput"]);
+    const text = safeStringify({
+      title: update["title"],
+      kind: update["kind"],
+      rawInput,
+      input,
+    });
+    const task = bestGrokCursorTaskForText(text);
+    if (task === null) return undefined;
+    grokPrefixToTask.set(prefix, task.itemId);
+    return task.itemId;
+  };
+
+  const noteGrokCursorTaskChild = (
+    parentItemId: AgentItemId | undefined,
+    message?: string,
+  ): void => {
+    if (parentItemId === undefined) return;
+    const task = grokCursorTasks.get(parentItemId);
+    if (task === undefined) return;
+    if (!task.summaryEmitted) {
+      lastGrokCursorTextParentItemId = parentItemId;
+    }
+    task.childEventCount += 1;
+    task.lastActivityAt = Date.now();
+    if (message !== undefined && message.trim().length > 0) {
+      task.lastMessage = message.trim();
+    }
+  };
+
+  const finishGrokCursorTasks = (): ReadonlyArray<AgentEvent> => {
+    if (provider !== "grok") return [];
+    const events: AgentEvent[] = [];
+    for (const itemId of grokCursorTaskOrder) {
+      const task = grokCursorTasks.get(itemId);
+      if (task === undefined || task.summaryEmitted) continue;
+      task.summaryEmitted = true;
+      events.push({
+        _tag: "SubagentSummary",
+        itemId: task.itemId,
+        agentName: task.description,
+        model: task.model,
+        turns: task.childEventCount,
+        durationMs: Math.max(0, task.lastActivityAt - task.startedAt),
+        summary: task.lastMessage || "Completed.",
+        isError: false,
+      });
+    }
+    return events;
+  };
+
   const translateOne = (update: unknown): ReadonlyArray<AgentEvent> => {
     if (update === null || typeof update !== "object") return [];
     const u = update as Record<string, unknown>;
+    const wrappedItem = recordFrom(u["item"]);
     const kind =
       typeof u["sessionUpdate"] === "string"
         ? (u["sessionUpdate"] as string)
         : typeof u["type"] === "string"
           ? (u["type"] as string)
-          : null;
+          : typeof wrappedItem?.["type"] === "string"
+            ? (wrappedItem["type"] as string)
+            : typeof u["method"] === "string"
+              ? (u["method"] as string)
+              : null;
     if (kind === null) return [];
+
+    const shouldFlushBeforeEvent = !(
+      provider === "grok" &&
+      (kind === "tool_call_update" ||
+        kind === "tool_result" ||
+        kind === "tool_output" ||
+        kind === "function_call_output" ||
+        kind === "custom_tool_call_output" ||
+        kind === "tool_search_output")
+    );
 
     // 1. Thinking / reasoning delta — buffer (coalesce) exactly like assistant
     //    text. This is the fix for the "Thinking The user is asking if I can..."
     //    word-by-word explosion the user reported with Grok.
     if (isThinkingChunk(kind)) {
+      const flushed = flushAssistant();
       let text = asText(u["content"]);
-      if (text === null || text.length === 0) return [];
+      if (text === null || text.length === 0) return flushed;
       // Grok often starts its first thinking chunk by literally echoing the
       // user prompt ("The user says: \"...\" First, the user's query...").
       // We aggressively strip this meta-reasoning prefix so the Thinking row
@@ -1001,28 +1343,29 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
         }
       }
       if (thinkingItemId === null) thinkingItemId = nextItemId();
-      thinkingBuffer += text;
+      thinkingBuffer = appendStreamText(thinkingBuffer, text);
       trace(provider, `buffer thinking chunk len=${text.length} totalLen=${thinkingBuffer.length}`);
-      return [];
+      return flushed;
     }
 
     // 2. Assistant text delta — buffer, don't emit yet.
     if (isAssistantTextChunk(kind)) {
+      const flushed = flushThinking();
       const text =
         kind === "message"
           ? extractMessageText(u["content"])
           : asText(u["content"]);
-      if (text === null || text.length === 0) return [];
+      if (text === null || text.length === 0) return flushed;
       if (assistantItemId === null) assistantItemId = nextItemId();
-      assistantBuffer += text;
+      assistantBuffer = appendStreamText(assistantBuffer, text);
       trace(provider, `buffer message chunk len=${text.length} totalLen=${assistantBuffer.length}`);
-      return [];
+      return flushed;
     }
 
     // 3. Any other event: flush both pending thinking + assistant text first
     //    so the timeline order stays correct ("reasoning burst → next tool /
     //    final answer").
-    const flushed = flushPending();
+    const flushed = shouldFlushBeforeEvent ? flushPending() : [];
 
     const tail = ((): ReadonlyArray<AgentEvent> => {
       switch (kind) {
@@ -1060,6 +1403,15 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           const toolName = extractToolName(u);
           logUnknownToolIfNeeded(provider, u, toolName, "tool_call");
           const input = buildCanonicalInput(toolName, u);
+          if (input !== null && typeof input === "object") {
+            rememberGrokCursorTask(callId, input as Record<string, unknown>);
+          }
+          const parentItemId = parentGrokCursorTaskForTool(
+            callId,
+            toolName,
+            u,
+            input,
+          );
           const inputJson = safeStringify({ input });
           const state = getOrInitToolState(callId);
           // Pin the canonical tool name on first sight so later update
@@ -1078,6 +1430,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           }
           state.useEmitted = true;
           state.lastInputJson = inputJson;
+          noteGrokCursorTaskChild(parentItemId);
           trace(
             provider,
             `emit ToolUse id=${callId} tool=${toolName} input=${safePreview(input)}`,
@@ -1088,6 +1441,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
               itemId: callId,
               tool: toolName,
               input,
+              parentItemId,
             },
           ];
         }
@@ -1118,16 +1472,41 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           if (state.toolName === null) state.toolName = toolName;
           logUnknownToolIfNeeded(provider, u, toolName, "tool_call_update");
           const input = buildCanonicalInput(toolName, u);
+          if (input !== null && typeof input === "object") {
+            rememberGrokCursorTask(callId, input as Record<string, unknown>);
+          }
+          const parentItemId = parentGrokCursorTaskForTool(
+            callId,
+            toolName,
+            u,
+            input,
+          );
           const events: AgentEvent[] = [];
 
           // Re-emit ToolUse only when input changed substantively —
           // typically when a diff block first appears for an Edit. If the
           // input is identical to what we last emitted, skip.
           if (input !== null) {
+            if (
+              provider === "grok" &&
+              (toolName === "Task" || toolName === "Agent") &&
+              isGrokCursorTaskInput(input) &&
+              state.useEmitted &&
+              state.lastInputJson !== null &&
+              state.lastInputJson.includes('"prompt"') &&
+              !state.lastInputJson.includes('"description":"Task"')
+            ) {
+              trace(
+                provider,
+                `skip duplicate CursorTask update id=${callId} tool=${toolName}`,
+              );
+              return events;
+            }
             const inputJson = safeStringify({ input });
             if (state.lastInputJson !== inputJson) {
               state.lastInputJson = inputJson;
               state.useEmitted = true;
+              noteGrokCursorTaskChild(parentItemId);
               trace(
                 provider,
                 `emit ToolUse(update) id=${callId} tool=${toolName} input=${safePreview(input)}`,
@@ -1137,6 +1516,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
                 itemId: callId,
                 tool: toolName,
                 input,
+                parentItemId,
               });
             } else {
               trace(
@@ -1177,7 +1557,9 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
               itemId: callId,
               output,
               isError,
+              parentItemId,
             });
+            noteGrokCursorTaskChild(parentItemId);
           } else if (state.resultEmitted) {
             trace(
               provider,
@@ -1205,6 +1587,13 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           state.resultEmitted = true;
           const isError = u["isError"] === true || u["is_error"] === true;
           const output = extractOutput(u);
+          const parentItemId = parentGrokCursorTaskForTool(
+            callId,
+            state.toolName ?? extractToolName(u),
+            u,
+            u["input"] ?? u["arguments"] ?? null,
+          );
+          noteGrokCursorTaskChild(parentItemId);
           trace(
             provider,
             `emit ToolResult(${kind}) id=${callId} isError=${isError} output=${safePreview(output)}`,
@@ -1215,6 +1604,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
               itemId: callId,
               output,
               isError,
+              parentItemId,
             },
           ];
         }
@@ -1244,6 +1634,206 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           return [{ _tag: "Error", message }];
         }
 
+        case "agentMessage": {
+          const item = wrappedItem ?? u;
+          const parentItemId = parentItemIdForThread(u["threadId"]);
+          const text = stringFrom(item, "text");
+          if (parentItemId === undefined || text === null) return [];
+          const itemId = extractCallId(item);
+          const state = getOrInitToolState(itemId as string);
+          if (state.useEmitted) return [];
+          state.useEmitted = true;
+          const threadId = stringFrom(u, "threadId");
+          if (threadId !== null) {
+            const run = collabAgentsByThread.get(threadId);
+            if (run !== undefined) {
+              run.turnCount += 1;
+              run.lastMessage = text;
+            }
+          }
+          return [
+            {
+              _tag: "AssistantMessage",
+              itemId,
+              text,
+              parentItemId,
+            },
+          ];
+        }
+
+        case "reasoning": {
+          const item = wrappedItem ?? u;
+          const parentItemId = parentItemIdForThread(u["threadId"]);
+          if (parentItemId === undefined) return [];
+          const summary = Array.isArray(item["summary"])
+            ? (item["summary"] as unknown[]).filter(
+                (v): v is string => typeof v === "string",
+              )
+            : [];
+          const content = Array.isArray(item["content"])
+            ? (item["content"] as unknown[]).filter(
+                (v): v is string => typeof v === "string",
+              )
+            : [];
+          const text = [...summary, ...content].join("\n").trim();
+          if (text.length === 0) return [];
+          return [
+            {
+              _tag: "Thinking",
+              itemId: extractCallId(item),
+              text,
+              redacted: false,
+              parentItemId,
+            },
+          ];
+        }
+
+        case "commandExecution": {
+          const item = wrappedItem ?? u;
+          const parentItemId = parentItemIdForThread(u["threadId"]);
+          if (parentItemId === undefined) return [];
+          const itemId = extractCallId(item);
+          const command = stringFrom(item, "command") ?? "";
+          const cwd = stringFrom(item, "cwd");
+          const status = stringFrom(item, "status");
+          const output = stringFrom(item, "aggregatedOutput") ?? "";
+          const isTerminal =
+            status === "completed" ||
+            status === "failed" ||
+            item["exitCode"] !== null && item["exitCode"] !== undefined;
+          const state = getOrInitToolState(itemId as string);
+          const events: AgentEvent[] = [];
+          if (!state.useEmitted) {
+            state.useEmitted = true;
+            events.push({
+              _tag: "ToolUse",
+              itemId,
+              tool: "Bash",
+              input: { command, ...(cwd !== null ? { cwd } : {}) },
+              parentItemId,
+            });
+          }
+          if (isTerminal && !state.resultEmitted) {
+            state.resultEmitted = true;
+            events.push({
+              _tag: "ToolResult",
+              itemId,
+              output,
+              isError:
+                status === "failed" ||
+                (typeof item["exitCode"] === "number" && item["exitCode"] !== 0),
+              parentItemId,
+            });
+          }
+          return events;
+        }
+
+        case "fileChange": {
+          const item = wrappedItem ?? u;
+          const parentItemId = parentItemIdForThread(u["threadId"]);
+          if (parentItemId === undefined) return [];
+          const itemId = extractCallId(item);
+          const status = stringFrom(item, "status");
+          const state = getOrInitToolState(itemId as string);
+          const events: AgentEvent[] = [];
+          if (!state.useEmitted) {
+            state.useEmitted = true;
+            events.push({
+              _tag: "ToolUse",
+              itemId,
+              tool: "Edit",
+              input: { changes: item["changes"] ?? [] },
+              parentItemId,
+            });
+          }
+          if (
+            status !== null &&
+            status !== "pending" &&
+            status !== "inProgress" &&
+            !state.resultEmitted
+          ) {
+            state.resultEmitted = true;
+            events.push({
+              _tag: "ToolResult",
+              itemId,
+              output: { status, changes: item["changes"] ?? [] },
+              isError: status === "failed",
+              parentItemId,
+            });
+          }
+          return events;
+        }
+
+        case "mcpToolCall":
+        case "dynamicToolCall": {
+          const item = wrappedItem ?? u;
+          const parentItemId = parentItemIdForThread(u["threadId"]);
+          if (parentItemId === undefined) return [];
+          const itemId = extractCallId(item);
+          const status = stringFrom(item, "status");
+          const namespace = stringFrom(item, "namespace");
+          const server = stringFrom(item, "server");
+          const tool = stringFrom(item, "tool") ?? "Tool";
+          const toolName =
+            namespace !== null
+              ? `${namespace}__${tool}`
+              : server !== null
+                ? `${server}__${tool}`
+                : tool;
+          const state = getOrInitToolState(itemId as string);
+          const events: AgentEvent[] = [];
+          if (!state.useEmitted) {
+            state.useEmitted = true;
+            events.push({
+              _tag: "ToolUse",
+              itemId,
+              tool: toolName,
+              input: item["arguments"] ?? {},
+              parentItemId,
+            });
+          }
+          const terminal =
+            status === "completed" ||
+            status === "failed" ||
+            (item["success"] !== null && item["success"] !== undefined);
+          if (terminal && !state.resultEmitted) {
+            state.resultEmitted = true;
+            events.push({
+              _tag: "ToolResult",
+              itemId,
+              output: item["result"] ?? item["contentItems"] ?? item["error"] ?? null,
+              isError:
+                status === "failed" ||
+                item["success"] === false ||
+                (item["error"] !== null && item["error"] !== undefined),
+              parentItemId,
+            });
+          }
+          return events;
+        }
+
+        case "thread/status/changed":
+        case "thread/closed":
+        case "turn/completed": {
+          const threadId = stringFrom(u, "threadId");
+          if (threadId === null) return [];
+          const run = collabAgentsByThread.get(threadId);
+          if (run === undefined) return [];
+
+          const status =
+            kind === "thread/closed"
+              ? "shutdown"
+              : kind === "turn/completed"
+                ? "idle"
+                : collabAgentStateStatus(u["status"]);
+          if (!isTerminalCollabAgentStatus(status)) return [];
+          const summary = maybeFinishCollabAgent(run.parentItemId, run, {
+            status,
+            message: run.lastMessage,
+          });
+          return summary === null ? [] : [summary];
+        }
+
         case "available_commands_update":
         case "current_mode_update":
           return [];
@@ -1254,16 +1844,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
         // agent uses spawnAgent / sendInput / closeAgent etc. to orchestrate 10+
         // parallel sub-agents. We surface them as first-class ToolUse rows so the
         // swarm activity is visible immediately; richer SwarmRow UI comes later.
-        case "collabAgentToolCall":
-        case "item_started":
-        case "item_completed": {
+        case "collabAgentToolCall": {
           // The payload may be the collab item directly or wrapped: { item: ThreadItem, threadId, ... }
-          const maybeItem = (u as Record<string, unknown>)["item"];
-          const candidate = (maybeItem && typeof maybeItem === "object" ? maybeItem : u) as Record<string, unknown>;
+          const candidate = wrappedItem ?? u;
           if (candidate["type"] !== "collabAgentToolCall") {
-            // Not a collab item (some other item_started for plan / command etc.) — fall through
-            // but still avoid the generic "unknown" trace for item_* wrappers we don't care about.
-            if (kind === "item_started" || kind === "item_completed") return [];
             return [];
           }
 
@@ -1277,12 +1861,50 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           const prompt = typeof collab["prompt"] === "string" ? (collab["prompt"] as string) : null;
           const model = typeof collab["model"] === "string" ? (collab["model"] as string) : null;
           const agentsStates = (collab["agentsStates"] ?? {}) as Record<string, unknown>;
+          const parentItemId = parentItemIdForThread(collab["senderThreadId"]);
 
-          // Nice label for the tool row (SpawnAgent becomes "Spawn Agent", sendInput becomes "Collab Send Input")
-          const toolName =
-            tool === "spawnAgent"
-              ? "SpawnAgent"
-              : `Collab${tool.charAt(0).toUpperCase()}${tool.slice(1)}`;
+          if (tool === "spawnAgent") {
+            const input = {
+              subagent_type: "agent",
+              prompt: prompt ?? "",
+              ...(model !== null ? { model } : {}),
+              receiverThreadIds,
+            };
+            const state = getOrInitToolState(callId);
+            if (!state.useEmitted) {
+              state.useEmitted = true;
+              state.lastInputJson = JSON.stringify(input);
+              state.toolName = "Agent";
+              for (const threadId of receiverThreadIds) {
+                rememberCollabAgent(
+                  callId,
+                  threadId,
+                  model ?? "inherit",
+                );
+              }
+              const events: AgentEvent[] = [
+                {
+                  _tag: "ToolUse",
+                  itemId: callId,
+                  tool: "Agent",
+                  input,
+                  parentItemId,
+                },
+              ];
+              for (const threadId of receiverThreadIds) {
+                const run = collabAgentsByThread.get(threadId);
+                if (run === undefined) continue;
+                const summary = maybeFinishCollabAgent(
+                  run.parentItemId,
+                  run,
+                  agentsStates[threadId],
+                );
+                if (summary !== null) events.push(summary);
+              }
+              return events;
+            }
+            return [];
+          }
 
           const input: Record<string, unknown> = {
             tool,
@@ -1295,6 +1917,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
 
           const state = getOrInitToolState(callId);
           const isTerminal = status === "completed" || status === "failed";
+          const toolName = `Collab${tool.charAt(0).toUpperCase()}${tool.slice(1)}`;
 
           // Emit (or re-emit with richer input) on first sight and on terminal transitions
           // so the renderer row can show a final result panel with the ending agentsStates.
@@ -1311,6 +1934,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
                 itemId: callId,
                 tool: toolName,
                 input,
+                parentItemId,
               },
             ];
             if (isTerminal) {
@@ -1320,8 +1944,19 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
                 itemId: callId,
                 output: { status, agentsStates },
                 isError: status === "failed",
+                parentItemId,
               });
               state.resultEmitted = true;
+            }
+            for (const [threadId, agentState] of Object.entries(agentsStates)) {
+              const run = collabAgentsByThread.get(threadId);
+              if (run === undefined) continue;
+              const summary = maybeFinishCollabAgent(
+                run.parentItemId,
+                run,
+                agentState,
+              );
+              if (summary !== null) events.push(summary);
             }
             return events;
           }
@@ -1344,7 +1979,11 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
 
   return {
     translate: translateOne,
-    flush: flushPending,
+    flush: () => {
+      const pending = flushPending();
+      const finishedTasks = finishGrokCursorTasks();
+      return finishedTasks.length === 0 ? pending : [...pending, ...finishedTasks];
+    },
   };
 };
 

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 import * as readline from "node:readline";
 import { Effect, Mailbox, Stream } from "effect";
 
@@ -14,6 +16,7 @@ import {
 } from "@memoize/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import { isIgnorableGrokAuthNoise } from "./acp/grok-auth-noise.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
 import { handleFsRequest } from "./acp/fs.ts";
@@ -116,6 +119,23 @@ const grokDiag = (label: string, data?: unknown): void => {
     } catch {
       process.stderr.write(`${prefix}: (unserialisable)\n`);
     }
+  }
+};
+
+const appendGrokAcpLog = (
+  cwd: string,
+  entry: Record<string, unknown>,
+): void => {
+  try {
+    const dir = join(cwd, ".context");
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      join(dir, "grok-acp.log"),
+      `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`,
+      "utf8",
+    );
+  } catch {
+    // Best-effort local diagnostics only.
   }
 };
 
@@ -407,7 +427,13 @@ export const startGrokSession = (
         if (msg.method === "session/update") {
           const update = msg.params?.update;
           if (update !== undefined) {
-            for (const ev of translator.translate(update)) {
+            const translated = translator.translate(update);
+            appendGrokAcpLog(cwd, {
+              method: msg.method,
+              update,
+              events: translated,
+            });
+            for (const ev of translated) {
               events.unsafeOffer(ev);
             }
           }
@@ -427,7 +453,19 @@ export const startGrokSession = (
             );
           }
           if (msg.params !== undefined) {
-            for (const ev of translator.translate(msg.params)) {
+            const update = {
+              ...(msg.params !== null && typeof msg.params === "object"
+                ? (msg.params as Record<string, unknown>)
+                : { params: msg.params }),
+              method: msg.method,
+            };
+            const translated = translator.translate(update);
+            appendGrokAcpLog(cwd, {
+              method: msg.method,
+              params: msg.params,
+              events: translated,
+            });
+            for (const ev of translated) {
               events.unsafeOffer(ev);
             }
           }
@@ -599,10 +637,6 @@ export const startGrokSession = (
           return;
         }
 
-        dead = true;
-
-        const isCachedToken = authMethodUsed === "cached_token";
-
         // Always log the full diagnostic info (this is what we use for debugging).
         grokDiag("FATAL_AUTH_TRIGGERED", {
           chunkPreview: chunk.slice(0, 800),
@@ -610,26 +644,10 @@ export const startGrokSession = (
           currentPromptRpcId,
           inflightPending: pending.size,
           authMethodUsed,
-          isCachedToken,
         });
 
-        if (currentPromptRpcId !== null) {
-          rejectCurrentPrompt(GROK_AUTH_REQUIRED_MESSAGE);
-        }
-
         if (!closed) {
-          if (isCachedToken) {
-            // For local `grok login` users, the worker sometimes dies with this even
-            // when the session can continue. We suppress the noisy red error card
-            // so it doesn't spam the UI mid-turn. Full details are still in the logs.
-            grokDiag("Suppressed visible Error event for cached_token AuthorizationRequired (session may still continue)");
-          } else {
-            // Real/invalid/expired token cases — still show the hard error.
-            events.unsafeOffer({
-              _tag: "Error",
-              message: GROK_AUTH_REQUIRED_MESSAGE,
-            });
-          }
+          grokDiag("Ignored Grok AuthorizationRequired while keeping turn running");
         }
       }
     });
@@ -670,11 +688,12 @@ export const startGrokSession = (
       }
       pending.clear();
       if (!closed) {
-        // Park in idle and keep the mailbox alive — the next send() will
-        // transparently respawn the child + redo the handshake (see
-        // [[enqueuePrompt]]). The user no longer has to "close this chat
-        // and start a new one" after a single worker death.
-        events.unsafeOffer({ _tag: "Status", status: "idle" });
+        // Keep the mailbox alive — the next send() will transparently respawn
+        // the child + redo the handshake (see [[enqueuePrompt]]). Do not stop
+        // the visible turn for the known Grok AuthorizationRequired noise.
+        if (friendly === null) {
+          events.unsafeOffer({ _tag: "Status", status: "idle" });
+        }
         grokDiag("child closed — keeping mailbox alive for transparent respawn on next send", {
           friendly: friendly ?? null,
         });
@@ -809,11 +828,17 @@ export const startGrokSession = (
               const reason = cause instanceof Error ? cause.message : String(cause);
               grokDiag("respawn failed", { reason });
               if (!closed) {
-                events.unsafeOffer({
-                  _tag: "Error",
-                  message: `Grok respawn failed: ${reason}`,
-                });
-                events.unsafeOffer({ _tag: "Status", status: "idle" });
+                if (isIgnorableGrokAuthNoise(reason)) {
+                  grokDiag("Suppressed visible respawn auth-noise error", {
+                    reason,
+                  });
+                } else {
+                  events.unsafeOffer({
+                    _tag: "Error",
+                    message: `Grok respawn failed: ${reason}`,
+                  });
+                  events.unsafeOffer({ _tag: "Status", status: "idle" });
+                }
               }
               return;
             }
@@ -830,6 +855,7 @@ export const startGrokSession = (
             permissionMode: currentMode,
             model: input.model,
           });
+          let keepRunningAfterIgnoredAuthNoise = false;
           try {
             await request(
               "session/prompt",
@@ -860,7 +886,14 @@ export const startGrokSession = (
             }
             grokDiag("session/prompt failed", { reason });
             const isCancellation = /cancel|interrupt/i.test(reason);
-            if (!closed && !isCancellation) {
+            const isGrokAuthNoise = isIgnorableGrokAuthNoise(reason);
+            if (isGrokAuthNoise) {
+              keepRunningAfterIgnoredAuthNoise = true;
+              grokDiag("Suppressed visible session/prompt auth-noise error", {
+                reason,
+              });
+            }
+            if (!closed && !isCancellation && !isGrokAuthNoise) {
               events.unsafeOffer({
                 _tag: "Error",
                 message: reason,
@@ -873,7 +906,9 @@ export const startGrokSession = (
             // sitting unobserved in memory.
             if (!closed) {
               for (const ev of translator.flush()) events.unsafeOffer(ev);
-              events.unsafeOffer({ _tag: "Status", status: "idle" });
+              if (!keepRunningAfterIgnoredAuthNoise) {
+                events.unsafeOffer({ _tag: "Status", status: "idle" });
+              }
             }
           }
         })
@@ -914,6 +949,7 @@ export const startGrokSession = (
           // Force-reject the in-flight prompt so the inflight chain
           // unblocks even if grok's ACP doesn't honour `session/cancel`.
           rejectCurrentPrompt("Interrupted by user");
+          events.unsafeOffer({ _tag: "Status", status: "idle" });
         }),
       close: () =>
         Effect.gen(function* () {

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -40,6 +40,7 @@ import { WorktreeService } from "../../worktree/services/worktree-service.ts";
 import { NdjsonLogger } from "../../persistence/ndjson-logger.ts";
 import { PtyService } from "../../pty/services/pty-service.ts";
 import { RepositorySettingsService } from "../../repository-settings/services/repository-settings-service.ts";
+import { isIgnorableGrokAuthNoise } from "../drivers/acp/grok-auth-noise.ts";
 import {
   MessageStore,
   type CreateChatInput,
@@ -581,13 +582,6 @@ export const MessageStoreLive = Layer.scoped(
       }
     >();
 
-    /**
-     * Tracks consecutive times a Grok session died because the internal
-     * agent worker rejected the `cached_token` from `grok login`.
-     * Used to stop hammering restarts when local auth is having issues
-     * with the full coding agent.
-     */
-    const grokAuthWorkerDeathCount = new Map<SessionId, number>();
     const ndjsonAppend = (
       sessionId: SessionId,
       message: Message,
@@ -755,6 +749,7 @@ export const MessageStoreLive = Layer.scoped(
      */
     const startSubscription = (sessionId: SessionId): Effect.Effect<void> =>
       Effect.gen(function* () {
+        const session = yield* lookupSession(sessionId).pipe(Effect.orDie);
         const fiber = yield* Effect.forkDaemon(
           Stream.runForEach(provider.events(sessionId), (event) =>
             Effect.gen(function* () {
@@ -798,6 +793,13 @@ export const MessageStoreLive = Layer.scoped(
                   WHERE id = ${sessionId}
                 `.pipe(Effect.asVoid, Effect.orDie);
                 permissionModeBySession.set(sessionId, event.mode);
+                return;
+              }
+              if (
+                session.providerId === "grok" &&
+                event._tag === "Error" &&
+                isIgnorableGrokAuthNoise(event.message)
+              ) {
                 return;
               }
               const content = eventToContent(event);
@@ -2093,28 +2095,8 @@ export const MessageStoreLive = Layer.scoped(
             );
 
           if (looksLikeGrokAuthWorkerDeath) {
-            const count = (grokAuthWorkerDeathCount.get(sessionId) ?? 0) + 1;
-            grokAuthWorkerDeathCount.set(sessionId, count);
-
-            if (count >= 2) {
-              // Stop auto-restarting. The user is hitting the known
-              // local `grok login` + agent worker auth limitation.
-              const message =
-                `Grok's coding agent worker is repeatedly rejecting the session with AuthorizationRequired, even though your local login appears valid.\n\n` +
-                `This is a known current limitation when using \`grok login\` (cached_token) with the full agent.\n\n` +
-                `You can try:\n` +
-                `• Running \`grok login\` again\n` +
-                `• Temporarily setting an XAI API key in the Grok provider settings\n\n` +
-                `Further automatic restarts have been disabled for this session to avoid spam.`;
-              const persistedError = yield* persistMessage(sessionId, {
-                _tag: "error",
-                message,
-              });
-              yield* broadcastMessage(sessionId, persistedError);
-              yield* ndjsonAppend(sessionId, persistedError);
-              yield* setStatus(sessionId, "idle");
-              return;
-            }
+            yield* setStatus(sessionId, "running");
+            return;
           }
 
           console.log(
@@ -2160,6 +2142,7 @@ export const MessageStoreLive = Layer.scoped(
         yield* provider
           .interrupt(sessionId)
           .pipe(Effect.mapError(() => new SessionNotFoundError({ sessionId })));
+        yield* setStatus(sessionId, "idle");
       });
 
     const getSession: MessageStoreShape["getSession"] = (sessionId) =>

--- a/apps/server/test/grok-auth-noise.test.ts
+++ b/apps/server/test/grok-auth-noise.test.ts
@@ -9,6 +9,8 @@ describe("isIgnorableGrokAuthNoise", () => {
       "Auth(AuthorizationRequired)",
       "error: AUTHORIZATIONREQUIRED while refreshing token",
       "Grok authentication failed: AuthorizationRequired",
+      "Grok authentication failed (AuthorizationRequired). Run `grok login` again or verify that your account has SuperGrok or X Premium+.",
+      "Grok respawn failed: Grok authentication failed (AuthorizationRequired). Run `grok login` again or verify that your account has SuperGrok or X Premium+.",
       "worker quit with fatal auth error",
       "transport channel closed (auth refresh)",
     ];

--- a/apps/server/test/translate.test.ts
+++ b/apps/server/test/translate.test.ts
@@ -214,6 +214,14 @@ describe("createAcpTranslator — assistant + thinking coalescing", () => {
     expect(flushed.text).toBe("Hello world");
   });
 
+  it("repairs missing spaces between streamed sentence words", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({ sessionUpdate: "agent_message_chunk", content: "I'll" });
+    t.translate({ sessionUpdate: "agent_message_chunk", content: "Starting now" });
+    const flushed = only(t.flush(), "AssistantMessage");
+    expect(flushed.text).toBe("I'll Starting now");
+  });
+
   it("flushes buffered text before the next non-text event, preserving order", () => {
     const t = createAcpTranslator("grok");
     t.translate({ sessionUpdate: "agent_message_chunk", content: "intro" });
@@ -227,6 +235,30 @@ describe("createAcpTranslator — assistant + thinking coalescing", () => {
     expect((out[0] as Extract<AgentEvent, { _tag: "AssistantMessage" }>).text).toBe(
       "intro",
     );
+  });
+
+  it("does not split Grok streamed text around tool result updates", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({ sessionUpdate: "agent_message_chunk", content: "I'll" });
+
+    const result = only(
+      t.translate({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-stream",
+        status: "completed",
+        rawOutput: { type: "Bash", output: "ok" },
+      }),
+      "ToolResult",
+    );
+    expect(result.itemId).toBe("tc-stream");
+
+    t.translate({
+      sessionUpdate: "agent_message_chunk",
+      content: " keep this joined.",
+    });
+
+    const message = only(t.flush(), "AssistantMessage");
+    expect(message.text).toBe("I'll keep this joined.");
   });
 
   it("coalesces thinking chunks into one Thinking event", () => {
@@ -339,6 +371,266 @@ describe("createAcpTranslator — tool_call_update dedup & re-emit", () => {
 });
 
 describe("createAcpTranslator — per-provider quirks & errors", () => {
+  it("renders Grok collab spawnAgent as a grouped Agent run", () => {
+    const t = createAcpTranslator("grok");
+    const out = t.translate({
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-1",
+        tool: "spawnAgent",
+        status: "completed",
+        senderThreadId: "main",
+        receiverThreadIds: ["agent-thread-1"],
+        prompt: "Explore codebase architecture",
+        model: null,
+        reasoningEffort: null,
+        agentsStates: {
+          "agent-thread-1": { status: "running", message: null },
+        },
+      },
+      threadId: "main",
+      turnId: "turn-1",
+    });
+
+    const ev = only(out, "ToolUse");
+    expect(ev.itemId).toBe("spawn-1");
+    expect(ev.tool).toBe("Agent");
+    expect(ev.input).toEqual({
+      subagent_type: "agent",
+      prompt: "Explore codebase architecture",
+      receiverThreadIds: ["agent-thread-1"],
+    });
+  });
+
+  it("groups Grok/Cursor Task child tool batches under the subagent row", () => {
+    const t = createAcpTranslator("grok");
+    const taskId =
+      "call-e9325475-3790-4ba8-b6de-d31ccbe5f0bd-composer_call_RRQI1";
+    t.translate({
+      sessionUpdate: "tool_call",
+      toolCallId: taskId,
+      title: "Task",
+      rawInput: {
+        description: "Task",
+        subagent_type: "generalPurpose",
+        prompt: "Analyze the current state of the branch.",
+      },
+    });
+    const ev = only(
+      t.translate({
+        sessionUpdate: "tool_call_update",
+        toolCallId: taskId,
+        kind: "other",
+        title: "Audit recent branch work",
+        rawInput: {
+          variant: "CursorTask",
+          description: "Audit recent branch work",
+          prompt: "Analyze the current state of the branch.",
+          subagent_type: "generalPurpose",
+        },
+      }),
+      "ToolUse",
+    );
+
+    expect(ev.tool).toBe("Task");
+    expect(ev.input).toEqual({
+      variant: "CursorTask",
+      description: "Audit recent branch work",
+      prompt: "Analyze the current state of the branch.",
+      subagent_type: "generalPurpose",
+    });
+
+    const childUse = only(
+      t.translate({
+        sessionUpdate: "tool_call",
+        toolCallId:
+          "call-6bc3338e-60b3-42c6-b0f8-91cadd4694a7-composer_call_kLDxP",
+        title: "Shell",
+        rawInput: {
+          description: "Commits on branch vs main",
+          command: "git log origin/main..HEAD --oneline",
+        },
+      }),
+      "ToolUse",
+    );
+    expect(childUse.parentItemId).toBe(taskId);
+
+    const summary = only(t.flush(), "SubagentSummary");
+    expect(summary.itemId).toBe(taskId);
+    expect(summary.summary).toBe("Audit recent branch work");
+    expect(summary.isError).toBe(false);
+  });
+
+  it("nests Grok collab agent messages under the spawned Agent row", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-1",
+        tool: "spawnAgent",
+        status: "completed",
+        senderThreadId: "main",
+        receiverThreadIds: ["agent-thread-1"],
+        prompt: "Explore codebase architecture",
+        model: "grok-code-fast-1",
+        reasoningEffort: null,
+        agentsStates: {},
+      },
+      threadId: "main",
+      turnId: "turn-1",
+    });
+
+    const out = t.translate({
+      item: {
+        type: "agentMessage",
+        id: "msg-1",
+        text: "Found the server and renderer boundaries.",
+        phase: null,
+        memoryCitation: null,
+      },
+      threadId: "agent-thread-1",
+      turnId: "turn-2",
+    });
+
+    const ev = only(out, "AssistantMessage");
+    expect(ev.parentItemId).toBe("spawn-1");
+    expect(ev.text).toBe("Found the server and renderer boundaries.");
+  });
+
+  it("finishes Grok collab Agent rows from terminal agent state updates", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-1",
+        tool: "spawnAgent",
+        status: "completed",
+        senderThreadId: "main",
+        receiverThreadIds: ["agent-thread-1"],
+        prompt: "Explore codebase architecture",
+        model: "grok-code-fast-1",
+        reasoningEffort: null,
+        agentsStates: {},
+      },
+      threadId: "main",
+      turnId: "turn-1",
+    });
+    t.translate({
+      item: {
+        type: "agentMessage",
+        id: "msg-1",
+        text: "Architecture summary.",
+        phase: null,
+        memoryCitation: null,
+      },
+      threadId: "agent-thread-1",
+      turnId: "turn-2",
+    });
+
+    const out = t.translate({
+      item: {
+        type: "collabAgentToolCall",
+        id: "wait-1",
+        tool: "wait",
+        status: "completed",
+        senderThreadId: "main",
+        receiverThreadIds: ["agent-thread-1"],
+        prompt: null,
+        model: null,
+        reasoningEffort: null,
+        agentsStates: {
+          "agent-thread-1": {
+            status: "completed",
+            message: "Done exploring.",
+          },
+        },
+      },
+      threadId: "main",
+      turnId: "turn-1",
+    });
+
+    expect(tags(out)).toEqual(["ToolUse", "ToolResult", "SubagentSummary"]);
+    const summary = out[2] as Extract<AgentEvent, { _tag: "SubagentSummary" }>;
+    expect(summary.itemId).toBe("spawn-1");
+    expect(summary.summary).toBe("Done exploring.");
+    expect(summary.turns).toBe(1);
+  });
+
+  it("finishes Grok collab Agent rows from receiver thread idle status", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({
+      method: "item/started",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-1",
+        tool: "spawnAgent",
+        status: "completed",
+        senderThreadId: "main",
+        receiverThreadIds: ["agent-thread-1"],
+        prompt: "Explore renderer UI",
+        model: null,
+        reasoningEffort: null,
+        agentsStates: {},
+      },
+      threadId: "main",
+      turnId: "turn-1",
+    });
+    t.translate({
+      method: "item/completed",
+      item: {
+        type: "agentMessage",
+        id: "msg-1",
+        text: "Renderer UI is React.",
+        phase: null,
+        memoryCitation: null,
+      },
+      threadId: "agent-thread-1",
+      turnId: "turn-2",
+    });
+
+    const out = t.translate({
+      method: "thread/status/changed",
+      threadId: "agent-thread-1",
+      status: { type: "idle" },
+    });
+
+    const summary = only(out, "SubagentSummary");
+    expect(summary.itemId).toBe("spawn-1");
+    expect(summary.summary).toBe("Renderer UI is React.");
+    expect(summary.isError).toBe(false);
+  });
+
+  it("finishes Grok collab Agent rows from receiver thread close", () => {
+    const t = createAcpTranslator("grok");
+    t.translate({
+      method: "item/started",
+      item: {
+        type: "collabAgentToolCall",
+        id: "spawn-1",
+        tool: "spawnAgent",
+        status: "completed",
+        senderThreadId: "main",
+        receiverThreadIds: ["agent-thread-1"],
+        prompt: "Task",
+        model: null,
+        reasoningEffort: null,
+        agentsStates: {},
+      },
+      threadId: "main",
+      turnId: "turn-1",
+    });
+
+    const out = t.translate({
+      method: "thread/closed",
+      threadId: "agent-thread-1",
+    });
+
+    const summary = only(out, "SubagentSummary");
+    expect(summary.itemId).toBe("spawn-1");
+    expect(summary.summary).toBe("");
+    expect(summary.isError).toBe(false);
+  });
+
   it("skips Gemini's internal `think` tool call (surfaced via thinking chunks)", () => {
     expect(
       translateAcpSessionUpdate(


### PR DESCRIPTION
## Summary

- suppress transient Grok AuthorizationRequired/auth-noise failures from visible chat errors while keeping diagnostics in logs
- keep Grok sessions recoverable/running through auth-noise paths and reset sessions to idle on explicit interrupt
- group Grok/Cursor Task subagent activity so child tools/results render under the agent row instead of the main timeline
- improve subagent row labels/loaders and fix Grok stream chunk joining around tool result updates

## Root Cause

Grok emits subagent work as regular ACP `session/update` Task/tool batches rather than a clean terminal subagent lifecycle. The renderer was either surfacing auth-noise as provider errors or treating child tool batches as top-level activity, while result updates also forced streamed text buffers to flush into tiny fragments.

## Validation

- `bun test apps/server/test/translate.test.ts`
- `bun test apps/server/test/grok-auth-noise.test.ts`
- `bun test apps/server/test`
- `bun run --cwd apps/server check-types`
- `bun run --cwd apps/renderer check-types`
- replayed captured Grok ACP log: 3 task rows, 444 child events grouped, 0 tiny assistant fragments
