### PR TITLE
Auto-name chat + branch from the first message

### DIFF
--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -20,6 +20,7 @@ import { Effect } from "effect";
 import { getRpcClient } from "../lib/rpc-client.ts";
 
 import {
+  type BranchNamingStyle,
   MODELS_BY_PROVIDER,
   type Folder,
   type FolderId,
@@ -502,11 +503,28 @@ function CredInput({
   );
 }
 
+const BRANCH_STYLE_ORDER: ReadonlyArray<BranchNamingStyle> = [
+  "username-slug",
+  "slug",
+  "feat-slug",
+];
+
+const BRANCH_STYLE_META: Record<
+  BranchNamingStyle,
+  { label: string; example: string }
+> = {
+  "username-slug": { label: "username/branch", example: "swarajbachu/dark-mode" },
+  slug: { label: "branch only", example: "dark-mode" },
+  "feat-slug": { label: "feat/branch", example: "feat/dark-mode" },
+};
+
 function GeneralPane() {
   const defaultRuntimeMode = useSettingsStore((s) => s.defaultRuntimeMode);
   const setDefaultRuntimeMode = useSettingsStore(
     (s) => s.setDefaultRuntimeMode,
   );
+  const branchNamingStyle = useSettingsStore((s) => s.branchNamingStyle);
+  const setBranchNamingStyle = useSettingsStore((s) => s.setBranchNamingStyle);
   const setOnboardingCompleted = useSettingsStore(
     (s) => s.setOnboardingCompleted,
   );
@@ -546,6 +564,40 @@ function GeneralPane() {
           </Select>
         }
         description="How the agent handles tool calls in new sessions. Each session can override this from its composer."
+      />
+
+      <SettingsFrame
+        title="Branch naming"
+        trailing={
+          <Select
+            value={branchNamingStyle}
+            onValueChange={(v) => setBranchNamingStyle(v as BranchNamingStyle)}
+            items={BRANCH_STYLE_ORDER.map((s) => ({
+              label: BRANCH_STYLE_META[s].label,
+              value: s,
+            }))}
+          >
+            <SelectTrigger size="sm" className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectPopup>
+              {BRANCH_STYLE_ORDER.map((style) => {
+                const m = BRANCH_STYLE_META[style];
+                return (
+                  <SelectItem key={style} value={style}>
+                    <div className="flex flex-col">
+                      <span>{m.label}</span>
+                      <span className="text-[10px] text-muted-foreground">
+                        {m.example}
+                      </span>
+                    </div>
+                  </SelectItem>
+                );
+              })}
+            </SelectPopup>
+          </Select>
+        }
+        description="When a new chat with its own worktree gets its first message, memoize summarizes it and renames the chat plus its git branch in this shape."
       />
 
       <SubagentsSection />

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -507,6 +507,7 @@ const BRANCH_STYLE_ORDER: ReadonlyArray<BranchNamingStyle> = [
   "username-slug",
   "slug",
   "feat-slug",
+  "custom",
 ];
 
 const BRANCH_STYLE_META: Record<
@@ -516,6 +517,7 @@ const BRANCH_STYLE_META: Record<
   "username-slug": { label: "username/branch", example: "swarajbachu/dark-mode" },
   slug: { label: "branch only", example: "dark-mode" },
   "feat-slug": { label: "feat/branch", example: "feat/dark-mode" },
+  custom: { label: "custom prefix", example: "prefix/dark-mode" },
 };
 
 function GeneralPane() {
@@ -525,10 +527,21 @@ function GeneralPane() {
   );
   const branchNamingStyle = useSettingsStore((s) => s.branchNamingStyle);
   const setBranchNamingStyle = useSettingsStore((s) => s.setBranchNamingStyle);
+  const branchNamingPrefix = useSettingsStore((s) => s.branchNamingPrefix);
+  const setBranchNamingPrefix = useSettingsStore(
+    (s) => s.setBranchNamingPrefix,
+  );
   const setOnboardingCompleted = useSettingsStore(
     (s) => s.setOnboardingCompleted,
   );
   const setView = useUiStore((s) => s.setView);
+
+  // Local mirror so typing is smooth; persist on blur to avoid an atomic
+  // settings-file write per keystroke.
+  const [prefixDraft, setPrefixDraft] = useState(branchNamingPrefix);
+  useEffect(() => {
+    setPrefixDraft(branchNamingPrefix);
+  }, [branchNamingPrefix]);
 
   return (
     <>
@@ -599,6 +612,28 @@ function GeneralPane() {
         }
         description="When a new chat with its own worktree gets its first message, memoize summarizes it and renames the chat plus its git branch in this shape."
       />
+
+      {branchNamingStyle === "custom" && (
+        <SettingsFrame
+          title="Custom prefix"
+          trailing={
+            <input
+              type="text"
+              value={prefixDraft}
+              placeholder="e.g. swaraj or team/wip"
+              spellCheck={false}
+              onChange={(e) => setPrefixDraft(e.target.value)}
+              onBlur={() => {
+                if (prefixDraft !== branchNamingPrefix) {
+                  setBranchNamingPrefix(prefixDraft);
+                }
+              }}
+              className="w-[220px] rounded-lg border border-border/50 bg-background px-3 py-1.5 text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 focus:border-border"
+            />
+          }
+          description="Slash-joined before the slug, e.g. prefix “swaraj” → swaraj/dark-mode. Letters, digits, slashes and dashes; leave empty for a bare slug."
+        />
+      )}
 
       <SubagentsSection />
 

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
 import type {
@@ -84,6 +84,48 @@ const findChatProject = (
   return null;
 };
 
+/**
+ * Live `chat.streamChanges` subscription per project — one long-lived fiber
+ * keyed by projectId. Carries server-side chat-row patches (notably the
+ * background auto-namer rewriting a new chat's title after its first
+ * message) so the sidebar updates without a manual refetch.
+ */
+const changeFibers = new Map<string, Fiber.RuntimeFiber<unknown, unknown>>();
+
+const ensureChangeStream = (projectId: FolderId): void => {
+  if (changeFibers.has(projectId)) return;
+  // Reserve the slot synchronously so concurrent hydrate() calls don't race
+  // two subscriptions onto the same project.
+  changeFibers.set(
+    projectId,
+    Effect.runFork(
+      Effect.flatMap(
+        Effect.promise(() => getRpcClient()),
+        (client) =>
+          Stream.runForEach(
+            client.chat.streamChanges({ projectId }),
+            (chat) =>
+              Effect.sync(() => {
+                useChatsStore.setState((s) => {
+                  const chats = s.chatsByProject[projectId];
+                  if (chats === undefined) return s;
+                  if (!chats.some((c) => c.id === chat.id)) return s;
+                  return {
+                    chatsByProject: {
+                      ...s.chatsByProject,
+                      [projectId]: chats.map((c) =>
+                        c.id === chat.id ? chat : c,
+                      ),
+                    },
+                  };
+                });
+              }),
+          ),
+      ),
+    ),
+  );
+};
+
 export const useChatsStore = create<ChatsState>((set, get) => ({
   chatsByProject: {},
   selectedChatId: null,
@@ -107,6 +149,9 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
         chatsByProject: { ...s.chatsByProject, [projectId]: chats },
         loadingByProject: { ...s.loadingByProject, [projectId]: false },
       }));
+      // Begin (or keep) the live change subscription now that the list is
+      // seeded — patches only land for chats already in the list.
+      ensureChangeStream(projectId);
     } catch (err) {
       set((s) => ({
         error: formatError(err),

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -2,6 +2,7 @@ import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
 import {
+  type BranchNamingStyle,
   defaultModelFor,
   type ProviderId,
   resolveModelSlug,
@@ -24,6 +25,7 @@ import { getRpcClient } from "../lib/rpc-client";
 
 const DEFAULT_PROVIDER: ProviderId = "claude";
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "approval-required";
+const DEFAULT_BRANCH_NAMING_STYLE: BranchNamingStyle = "username-slug";
 
 const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
   "claude",
@@ -59,6 +61,7 @@ const fallbackSnapshot = (): SettingsSlice => ({
   defaultAutoCreateWorktree: false,
   onboardingCompleted: false,
   providerEnabled: seedProviderEnabled(),
+  branchNamingStyle: DEFAULT_BRANCH_NAMING_STYLE,
 });
 
 const sliceFromFile = (file: SettingsFile): SettingsSlice => {
@@ -81,6 +84,7 @@ const sliceFromFile = (file: SettingsFile): SettingsSlice => {
       ...seedProviderEnabled(),
       ...file.providerEnabled,
     },
+    branchNamingStyle: file.branchNamingStyle,
   };
 };
 
@@ -91,6 +95,7 @@ interface SettingsSlice {
   readonly defaultAutoCreateWorktree: boolean;
   readonly onboardingCompleted: boolean;
   readonly providerEnabled: Record<ProviderId, boolean>;
+  readonly branchNamingStyle: BranchNamingStyle;
 }
 
 type SettingsState = SettingsSlice & {
@@ -113,6 +118,7 @@ type SettingsState = SettingsSlice & {
   readonly setDefaultAutoCreateWorktree: (value: boolean) => void;
   readonly setOnboardingCompleted: (value: boolean) => void;
   readonly setProviderEnabled: (providerId: ProviderId, value: boolean) => void;
+  readonly setBranchNamingStyle: (style: BranchNamingStyle) => void;
 };
 
 let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
@@ -250,6 +256,15 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const client = await getRpcClient();
       await Effect.runPromise(
         client.settings.update({ patch: { providerEnabled: next } }),
+      );
+    })();
+  },
+  setBranchNamingStyle: (style) => {
+    set({ branchNamingStyle: style });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({ patch: { branchNamingStyle: style } }),
       );
     })();
   },

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -62,6 +62,7 @@ const fallbackSnapshot = (): SettingsSlice => ({
   onboardingCompleted: false,
   providerEnabled: seedProviderEnabled(),
   branchNamingStyle: DEFAULT_BRANCH_NAMING_STYLE,
+  branchNamingPrefix: "",
 });
 
 const sliceFromFile = (file: SettingsFile): SettingsSlice => {
@@ -85,6 +86,7 @@ const sliceFromFile = (file: SettingsFile): SettingsSlice => {
       ...file.providerEnabled,
     },
     branchNamingStyle: file.branchNamingStyle,
+    branchNamingPrefix: file.branchNamingPrefix,
   };
 };
 
@@ -96,6 +98,7 @@ interface SettingsSlice {
   readonly onboardingCompleted: boolean;
   readonly providerEnabled: Record<ProviderId, boolean>;
   readonly branchNamingStyle: BranchNamingStyle;
+  readonly branchNamingPrefix: string;
 }
 
 type SettingsState = SettingsSlice & {
@@ -119,6 +122,7 @@ type SettingsState = SettingsSlice & {
   readonly setOnboardingCompleted: (value: boolean) => void;
   readonly setProviderEnabled: (providerId: ProviderId, value: boolean) => void;
   readonly setBranchNamingStyle: (style: BranchNamingStyle) => void;
+  readonly setBranchNamingPrefix: (prefix: string) => void;
 };
 
 let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
@@ -265,6 +269,15 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const client = await getRpcClient();
       await Effect.runPromise(
         client.settings.update({ patch: { branchNamingStyle: style } }),
+      );
+    })();
+  },
+  setBranchNamingPrefix: (prefix) => {
+    set({ branchNamingPrefix: prefix });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({ patch: { branchNamingPrefix: prefix } }),
       );
     })();
   },

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -5,6 +5,7 @@ import { FileSystem, Path } from "@effect/platform";
 import { Effect, Layer, PubSub, Ref, Stream } from "effect";
 
 import {
+  type BranchNamingStyle,
   defaultModelFor,
   type KeybindingRule,
   KeybindingsFile,
@@ -66,6 +67,7 @@ const freshSettings = (): SettingsFile =>
     onboardingCompleted: false,
     providerEnabled: seedProviderEnabled(),
     subagents: { enableForNewSessions: true, presets: {} },
+    branchNamingStyle: "username-slug",
   });
 
 const freshKeybindings = (): KeybindingsFile =>
@@ -88,6 +90,9 @@ const isRuntimeMode = (v: unknown): v is SettingsFile["defaultRuntimeMode"] =>
   v === "auto-accept-edits" ||
   v === "auto-accept-edits-and-bash" ||
   v === "full-access";
+
+const isBranchNamingStyle = (v: unknown): v is BranchNamingStyle =>
+  v === "username-slug" || v === "slug" || v === "feat-slug";
 
 /**
  * Re-shape an arbitrary parsed JSON value onto a `SettingsFile`, falling
@@ -170,6 +175,10 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     subagents = { enableForNewSessions: enable, presets };
   }
 
+  const branchNamingStyle = isBranchNamingStyle(obj.branchNamingStyle)
+    ? obj.branchNamingStyle
+    : base.branchNamingStyle;
+
   return SettingsFile.make({
     schemaVersion: 1,
     defaultProviderId: provider,
@@ -179,6 +188,7 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     onboardingCompleted: onboarding,
     providerEnabled,
     subagents,
+    branchNamingStyle,
   });
 };
 
@@ -423,6 +433,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
             patch.onboardingCompleted ?? cur.onboardingCompleted,
           providerEnabled: patch.providerEnabled ?? cur.providerEnabled,
           subagents: patch.subagents ?? cur.subagents,
+          branchNamingStyle:
+            patch.branchNamingStyle ?? cur.branchNamingStyle,
         });
         const serialized = serialize(next);
         yield* writeAtomically(settingsPath, serialized);
@@ -522,6 +534,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
             onboardingCompleted: onboarding,
             providerEnabled,
             subagents,
+            branchNamingStyle: cur.branchNamingStyle,
           });
 
           const serialized = serialize(merged);

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -68,6 +68,7 @@ const freshSettings = (): SettingsFile =>
     providerEnabled: seedProviderEnabled(),
     subagents: { enableForNewSessions: true, presets: {} },
     branchNamingStyle: "username-slug",
+    branchNamingPrefix: "",
   });
 
 const freshKeybindings = (): KeybindingsFile =>
@@ -92,7 +93,10 @@ const isRuntimeMode = (v: unknown): v is SettingsFile["defaultRuntimeMode"] =>
   v === "full-access";
 
 const isBranchNamingStyle = (v: unknown): v is BranchNamingStyle =>
-  v === "username-slug" || v === "slug" || v === "feat-slug";
+  v === "username-slug" ||
+  v === "slug" ||
+  v === "feat-slug" ||
+  v === "custom";
 
 /**
  * Re-shape an arbitrary parsed JSON value onto a `SettingsFile`, falling
@@ -179,6 +183,11 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     ? obj.branchNamingStyle
     : base.branchNamingStyle;
 
+  const branchNamingPrefix =
+    typeof obj.branchNamingPrefix === "string"
+      ? obj.branchNamingPrefix
+      : base.branchNamingPrefix;
+
   return SettingsFile.make({
     schemaVersion: 1,
     defaultProviderId: provider,
@@ -189,6 +198,7 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     providerEnabled,
     subagents,
     branchNamingStyle,
+    branchNamingPrefix,
   });
 };
 
@@ -435,6 +445,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
           subagents: patch.subagents ?? cur.subagents,
           branchNamingStyle:
             patch.branchNamingStyle ?? cur.branchNamingStyle,
+          branchNamingPrefix:
+            patch.branchNamingPrefix ?? cur.branchNamingPrefix,
         });
         const serialized = serialize(next);
         yield* writeAtomically(settingsPath, serialized);
@@ -535,6 +547,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
             providerEnabled,
             subagents,
             branchNamingStyle: cur.branchNamingStyle,
+            branchNamingPrefix: cur.branchNamingPrefix,
           });
 
           const serialized = serialize(merged);

--- a/apps/server/src/git/handlers.ts
+++ b/apps/server/src/git/handlers.ts
@@ -39,6 +39,12 @@ const RenameBranch = MemoizeRpcs.toLayerHandler(
     ),
 );
 
+const UserName = MemoizeRpcs.toLayerHandler("git.userName", ({ folderId }) =>
+  Effect.flatMap(GitService, (svc) =>
+    svc.getUserName(folderId).pipe(Effect.map((userName) => ({ userName }))),
+  ),
+);
+
 const HeadChanged = MemoizeRpcs.toLayerHandler(
   "git.headChanged",
   ({ folderId }) =>
@@ -131,6 +137,7 @@ export const GitHandlersLayer = Layer.mergeAll(
   Branches,
   SwitchBranch,
   RenameBranch,
+  UserName,
   HeadChanged,
   Origin,
   PrState,

--- a/apps/server/src/git/layers/git-service.ts
+++ b/apps/server/src/git/layers/git-service.ts
@@ -607,6 +607,17 @@ export const GitServiceLive = Layer.effect(
         }),
       );
 
+    // `git config user.name` exits non-zero (code 1) when the key is unset.
+    // We don't want that to read as a hard failure — an empty author name is
+    // a legitimate state — so a GitCommandError collapses to "".
+    const getUserName: GitService["Type"]["getUserName"] = (folderId) =>
+      Effect.flatMap(resolvePath(folderId), (cwd) =>
+        run(folderId, cwd, ["config", "user.name"]).pipe(
+          Effect.map((s) => s.trim()),
+          Effect.catchTag("GitCommandError", () => Effect.succeed("")),
+        ),
+      );
+
     const headSha = (folderId: FolderId) =>
       Effect.flatMap(resolvePath(folderId), (cwd) =>
         run(folderId, cwd, ["rev-parse", "HEAD"]).pipe(
@@ -1431,6 +1442,7 @@ export const GitServiceLive = Layer.effect(
       branches,
       switchBranch,
       renameBranch,
+      getUserName,
       subscribeHeadChanges,
       origin,
       prState,

--- a/apps/server/src/git/services/git-service.ts
+++ b/apps/server/src/git/services/git-service.ts
@@ -49,6 +49,13 @@ export interface GitServiceShape {
     name: string,
     worktreeId?: WorktreeId | null,
   ) => Effect.Effect<GitStatusSummary, GitFailure>;
+  /**
+   * `git config user.name`, trimmed (empty string when unset). Feeds the
+   * auto-namer's `username/<slug>` branch convention.
+   */
+  readonly getUserName: (
+    folderId: FolderId,
+  ) => Effect.Effect<string, GitFailure>;
   readonly subscribeHeadChanges: (
     folderId: FolderId,
   ) => Stream.Stream<{ readonly sha: string }, GitFailure>;

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -192,6 +192,14 @@ const ChatRename = MemoizeRpcs.toLayerHandler(
     Effect.flatMap(MessageStore, (svc) => svc.renameChat(chatId, title)),
 );
 
+const ChatStreamChanges = MemoizeRpcs.toLayerHandler(
+  "chat.streamChanges",
+  ({ projectId }) =>
+    Stream.unwrap(
+      Effect.map(MessageStore, (svc) => svc.streamChatChanges(projectId)),
+    ),
+);
+
 const ChatSetWorktree = MemoizeRpcs.toLayerHandler(
   "chat.setWorktree",
   ({ chatId, worktreeId }) =>
@@ -472,6 +480,7 @@ export const ProviderHandlersLayer = Layer.mergeAll(
   ChatGet,
   ChatCreate,
   ChatRename,
+  ChatStreamChanges,
   ChatSetWorktree,
   ChatSetActiveSession,
   ChatArchive,

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -1655,6 +1655,7 @@ export const MessageStoreLive = Layer.scoped(
           title,
           username,
           settings.branchNamingStyle,
+          settings.branchNamingPrefix,
         );
         // Rename the git branch, then mirror it onto the worktree row so the
         // DB and git agree. updateBranch only runs if the rename succeeded.

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -37,9 +37,12 @@ import {
 
 import { WorktreeService } from "../../worktree/services/worktree-service.ts";
 
+import { ConfigStoreService } from "../../config-store/services/config-store-service.ts";
+import { GitService } from "../../git/services/git-service.ts";
 import { NdjsonLogger } from "../../persistence/ndjson-logger.ts";
 import { PtyService } from "../../pty/services/pty-service.ts";
 import { RepositorySettingsService } from "../../repository-settings/services/repository-settings-service.ts";
+import { TitleGenerator, formatBranchName } from "../title-generator.ts";
 import {
   MessageStore,
   type CreateChatInput,
@@ -422,6 +425,9 @@ export const MessageStoreLive = Layer.scoped(
     const worktrees = yield* WorktreeService;
     const repositorySettings = yield* RepositorySettingsService;
     const ptys = yield* PtyService;
+    const git = yield* GitService;
+    const titleGen = yield* TitleGenerator;
+    const configStore = yield* ConfigStoreService;
 
     const chatColumns = yield* sql<{ readonly name: string }>`
       PRAGMA table_info(chats)
@@ -628,6 +634,22 @@ export const MessageStoreLive = Layer.scoped(
     const statusPubsubs = yield* Ref.make<
       ReadonlyMap<SessionId, PubSub.PubSub<StatusEvent>>
     >(new Map());
+
+    // Single hub for chat-row changes (title / worktree binding). Unlike the
+    // per-session message/status pubsubs, chats are few and updates rare, so
+    // one project-filtered hub keeps it simple. The renderer already holds
+    // the chat list via `chat.list`; this stream only carries live patches
+    // (e.g. the background auto-namer rewriting a title), so there's no
+    // backfill on subscribe.
+    const chatChangesHub = yield* PubSub.unbounded<Chat>();
+    const broadcastChat = (chat: Chat): Effect.Effect<void> =>
+      PubSub.publish(chatChangesHub, chat).pipe(Effect.asVoid);
+
+    // Chats whose first-message auto-name is in flight, so a second message
+    // arriving mid-rename can't kick off a duplicate pass. One-shot per chat
+    // per process — entries are never removed because the triggering hooks
+    // only fire on the first user message anyway.
+    const autoNamingChats = new Set<string>();
 
     const getOrMakePubsub = (sessionId: SessionId) =>
       Effect.gen(function* () {
@@ -1538,6 +1560,16 @@ export const MessageStoreLive = Layer.scoped(
               ),
             )
           : null;
+        // Path 1: the chat was created WITH its first message (the common
+        // composer flow). Kick off the background auto-name now — it no-ops
+        // unless the chat has its own worktree.
+        if (
+          hasInitial &&
+          chat.worktreeId !== null &&
+          input.initialPrompt !== undefined
+        ) {
+          yield* forkAutoName(chat.id, initialSession.id, input.initialPrompt);
+        }
         return { chat, initialSession, initialMessage };
       });
 
@@ -1549,7 +1581,99 @@ export const MessageStoreLive = Layer.scoped(
           UPDATE chats SET title = ${title}, updated_at = ${nowIso}
           WHERE id = ${chatId}
         `.pipe(Effect.asVoid, Effect.orDie);
+        // Push the new title to any renderer subscribed via
+        // `chat.streamChanges` so the sidebar updates without a refetch.
+        const updated = yield* lookupChat(chatId);
+        yield* broadcastChat(updated);
       });
+
+    const streamChatChanges: MessageStoreShape["streamChatChanges"] = (
+      projectId,
+    ) =>
+      Stream.unwrapScoped(
+        Effect.gen(function* () {
+          const sub = yield* chatChangesHub.subscribe;
+          return Stream.fromQueue(sub).pipe(
+            Stream.filter((chat) => chat.projectId === projectId),
+          );
+        }),
+      );
+
+    /**
+     * Conductor-style auto-name: on a chat's first user message, summarize it
+     * into a short title (LLM, with truncation fallback) and use that to
+     * rename both the chat and — when the chat has its own worktree — the
+     * worktree's git branch per the user's `branchNamingStyle`. Runs on a
+     * background fiber so the agent's first reply is never delayed; swallows
+     * every failure so a flaky title call can't wedge the session.
+     *
+     * Only chats WITH a worktree are renamed (a bare main-checkout chat keeps
+     * the cheap first-line title set elsewhere).
+     */
+    const autoNameChat = (
+      chatId: ChatId,
+      sessionId: SessionId,
+      firstText: string,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (autoNamingChats.has(chatId)) return;
+        autoNamingChats.add(chatId);
+        const chat = yield* lookupChat(chatId).pipe(
+          Effect.catchAll(() => Effect.succeed(null)),
+        );
+        if (chat === null || chat.worktreeId === null) return;
+        const worktreeId = chat.worktreeId;
+        const wt = yield* worktrees.get(worktreeId);
+        if (wt === null) return;
+
+        // Name the chat with the SAME provider/model the session uses, so a
+        // user without Claude auth (e.g. Grok-only) still gets an LLM title.
+        const session = yield* lookupSession(sessionId).pipe(
+          Effect.catchAll(() => Effect.succeed(null)),
+        );
+        if (session === null) return;
+        const title = yield* titleGen.generate({
+          folderId: chat.projectId,
+          providerId: session.providerId,
+          model: session.model,
+          firstMessage: firstText,
+        });
+        if (title.length === 0 || title === "New chat") return;
+
+        // Title first — cheap, and the user sees the sidebar update even if
+        // the branch rename below is skipped or fails.
+        yield* renameChat(chatId, title);
+        yield* sql`
+          UPDATE sessions SET title = ${title} WHERE id = ${sessionId}
+        `.pipe(Effect.ignoreLogged);
+
+        const settings = yield* configStore.getSettings();
+        const username = yield* git
+          .getUserName(chat.projectId)
+          .pipe(Effect.catchAll(() => Effect.succeed("")));
+        const branch = formatBranchName(
+          title,
+          username,
+          settings.branchNamingStyle,
+        );
+        // Rename the git branch, then mirror it onto the worktree row so the
+        // DB and git agree. updateBranch only runs if the rename succeeded.
+        yield* git
+          .renameBranch(chat.projectId, branch, worktreeId)
+          .pipe(
+            Effect.flatMap(() => worktrees.updateBranch(worktreeId, branch)),
+            Effect.catchAll(() => Effect.void),
+          );
+      }).pipe(Effect.catchAllCause(() => Effect.void));
+
+    const forkAutoName = (
+      chatId: ChatId,
+      sessionId: SessionId,
+      firstText: string,
+    ): Effect.Effect<void> =>
+      Effect.forkDaemon(autoNameChat(chatId, sessionId, firstText)).pipe(
+        Effect.asVoid,
+      );
 
     /**
      * Worktrees are immutable past the first user message in any of the
@@ -2053,8 +2177,8 @@ export const MessageStoreLive = Layer.scoped(
         }
         yield* broadcastMessage(sessionId, persisted);
         // Auto-title: if the session is still on its placeholder title, derive
-        // one from the user's first real message. Cheaper and more accurate
-        // than a separate LLM summarization step.
+        // a cheap first-line title immediately so the tab never reads
+        // "New chat" while the richer LLM pass (below) runs.
         if (session.title === "New chat") {
           const derived = titleFromInitial(text);
           if (derived !== "New chat") {
@@ -2063,6 +2187,21 @@ export const MessageStoreLive = Layer.scoped(
               WHERE id = ${sessionId} AND title = 'New chat'
             `.pipe(Effect.orDie);
           }
+        }
+        // Path 2: an empty chat (no initialPrompt) receiving its first user
+        // message via messages.send. When this is the chat's first user
+        // message, kick off the Conductor-style auto-name in the background
+        // (no-ops unless the chat has its own worktree).
+        const firstUserCount = yield* sql<{ readonly c: number }>`
+          SELECT COUNT(*) AS c FROM messages m
+          INNER JOIN sessions s ON s.id = m.session_id
+          WHERE s.chat_id = ${session.chatId} AND m.role = 'user'
+        `.pipe(
+          Effect.map((rows) => rows[0]?.c ?? 0),
+          Effect.catchAll(() => Effect.succeed(0)),
+        );
+        if (firstUserCount === 1 && text.trim().length > 0) {
+          yield* forkAutoName(session.chatId, sessionId, text);
         }
         // First attempt: push into the existing provider session. If that
         // session is gone (provider dropped it across an app restart) start
@@ -2183,6 +2322,7 @@ export const MessageStoreLive = Layer.scoped(
       getChat,
       createChat,
       renameChat,
+      streamChatChanges,
       setChatWorktree,
       setChatActiveSession,
       archiveChat,

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -229,6 +229,16 @@ export interface MessageStoreShape {
   ) => Effect.Effect<void, ChatNotFoundError>;
 
   /**
+   * Live feed of chat-row changes (title / worktree) for one project. Emits
+   * only live patches — no backfill — so the renderer keeps its `chat.list`
+   * snapshot and applies updates (e.g. the background auto-namer rewriting a
+   * title) on top. Never fails.
+   */
+  readonly streamChatChanges: (
+    projectId: FolderId,
+  ) => Stream.Stream<Chat>;
+
+  /**
    * Update the chat's worktree. Allowed only when no session in the chat
    * has any user message yet. Mirrors the new value onto every member
    * session's `worktreeId` in the same transaction.

--- a/apps/server/src/provider/title-generator.ts
+++ b/apps/server/src/provider/title-generator.ts
@@ -75,14 +75,31 @@ export const usernameHandle = (username: string): string =>
   username.toLowerCase().replace(/[^a-z0-9]/g, "");
 
 /**
- * Build the new branch name from an LLM title, the (raw) git user name, and
- * the user's chosen style. When the username is unknown, `username-slug`
- * gracefully degrades to a bare slug rather than emitting a leading slash.
+ * Normalize a user-supplied branch prefix into a valid, slash-delimited ref
+ * fragment: lowercase, keep `[a-z0-9/_-]`, collapse repeats, trim stray
+ * leading/trailing separators. Empty when nothing usable remains.
+ */
+export const sanitizePrefix = (prefix: string): string =>
+  prefix
+    .toLowerCase()
+    .replace(/[^a-z0-9/_-]+/g, "-")
+    .replace(/\/{2,}/g, "/")
+    .replace(/-+/g, "-")
+    .replace(/^[-/]+|[-/]+$/g, "")
+    .slice(0, 40)
+    .replace(/[-/]+$/g, "");
+
+/**
+ * Build the new branch name from an LLM title, the (raw) git user name, the
+ * chosen style, and (for `custom`) a user-defined prefix. `username-slug` and
+ * `custom` gracefully degrade to a bare slug when their prefix is empty,
+ * rather than emitting a leading slash.
  */
 export const formatBranchName = (
   title: string,
   username: string,
   style: BranchNamingStyle,
+  customPrefix: string,
 ): string => {
   const slug = slugify(title);
   switch (style) {
@@ -93,6 +110,10 @@ export const formatBranchName = (
     case "username-slug": {
       const handle = usernameHandle(username);
       return handle.length === 0 ? slug : `${handle}/${slug}`;
+    }
+    case "custom": {
+      const prefix = sanitizePrefix(customPrefix);
+      return prefix.length === 0 ? slug : `${prefix}/${slug}`;
     }
   }
 };

--- a/apps/server/src/provider/title-generator.ts
+++ b/apps/server/src/provider/title-generator.ts
@@ -1,0 +1,192 @@
+import { Context, Effect, Layer, Option, Stream } from "effect";
+import * as os from "node:os";
+
+import {
+  AgentSessionId,
+  type BranchNamingStyle,
+  type FolderId,
+  type ProviderId,
+  type RuntimeMode,
+} from "@memoize/wire";
+
+import { ProviderService } from "./services/provider-service.ts";
+
+/** Hard ceiling on the one-shot turn; on timeout we fall back to truncation. */
+const TITLE_TIMEOUT_MS = 25_000;
+
+const PROMPT_PREFIX = [
+  "Summarize the following coding task as a SHORT title of 3 to 5 words in Title Case.",
+  "Reply with ONLY the title — no quotes, no punctuation, no preamble, no explanation.",
+  "Do NOT use any tools, do NOT read or write files, do NOT run commands. Just output the title text.",
+  "",
+  "Task:",
+  "",
+].join("\n");
+
+/* ──────────────────────────── pure helpers ──────────────────────────── */
+
+/**
+ * First-line truncation fallback — identical in spirit to the message-store
+ * helper of the same shape. Used whenever the model call is unavailable
+ * (offline, provider not installed) or returns nothing usable, so a chat is
+ * never left on its "New chat" placeholder.
+ */
+export const fallbackTitle = (firstMessage: string): string => {
+  const firstLine = firstMessage.trim().split("\n")[0] ?? "";
+  const truncated = firstLine.slice(0, 60).trim();
+  return truncated.length > 0 ? truncated : "New chat";
+};
+
+/** Strip the model's stray quoting / punctuation and clamp to one tidy line. */
+const cleanTitle = (raw: string): string => {
+  const firstLine = raw.trim().split("\n")[0] ?? "";
+  return firstLine
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/[.!,;:]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 60)
+    .trim();
+};
+
+/**
+ * Lowercase kebab slug safe for a git ref segment: only `[a-z0-9-]`, no
+ * leading/trailing/triple dashes, length-capped. Empty input yields
+ * `"session"` so we never produce an invalid (empty) ref.
+ */
+export const slugify = (text: string): string => {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 40)
+    .replace(/-$/g, "");
+  return slug.length > 0 ? slug : "session";
+};
+
+/**
+ * Collapse a git `user.name` into a branch-prefix handle: lowercase, all
+ * non-alphanumerics dropped (not dashed) so `"Swaraj Bachu"` becomes
+ * `swarajbachu` — matching the GitHub-style `username/branch` convention.
+ * Empty when nothing usable remains.
+ */
+export const usernameHandle = (username: string): string =>
+  username.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/**
+ * Build the new branch name from an LLM title, the (raw) git user name, and
+ * the user's chosen style. When the username is unknown, `username-slug`
+ * gracefully degrades to a bare slug rather than emitting a leading slash.
+ */
+export const formatBranchName = (
+  title: string,
+  username: string,
+  style: BranchNamingStyle,
+): string => {
+  const slug = slugify(title);
+  switch (style) {
+    case "slug":
+      return slug;
+    case "feat-slug":
+      return `feat/${slug}`;
+    case "username-slug": {
+      const handle = usernameHandle(username);
+      return handle.length === 0 ? slug : `${handle}/${slug}`;
+    }
+  }
+};
+
+/* ───────────────────────────── service ──────────────────────────────── */
+
+export interface GenerateTitleInput {
+  /** Project the chat belongs to (resolves provider auth + default cwd). */
+  readonly folderId: FolderId;
+  /** The chat's chosen provider — the title runs on THIS agent, never a
+   *  hardcoded one, so a Grok/Codex-only user uses their own auth. */
+  readonly providerId: ProviderId;
+  /** The chat's chosen model. */
+  readonly model: string;
+  /** The user's first message. */
+  readonly firstMessage: string;
+}
+
+export interface TitleGeneratorShape {
+  /**
+   * Summarize a chat's first message into a short title by running a single,
+   * throwaway turn through the chat's OWN provider (so it reuses whatever
+   * auth that provider has). Never fails: any error / timeout / empty
+   * response collapses to the first-line truncation fallback.
+   */
+  readonly generate: (input: GenerateTitleInput) => Effect.Effect<string>;
+}
+
+export class TitleGenerator extends Context.Tag("memoize/TitleGenerator")<
+  TitleGenerator,
+  TitleGeneratorShape
+>() {}
+
+export const TitleGeneratorLive = Layer.effect(
+  TitleGenerator,
+  Effect.gen(function* () {
+    const provider = yield* ProviderService;
+    // Run the throwaway session in a scratch dir, not the worktree: the title
+    // only needs the message text (it's in the prompt), so an empty cwd means
+    // the agent can't read/edit the repo even if it ignores the no-tools
+    // instruction. Paired with a full-access runtime mode below so the turn
+    // never raises a permission toast the user would see for a hidden session.
+    const scratchCwd = os.tmpdir();
+    const runtimeMode: RuntimeMode = "full-access";
+
+    const generate: TitleGeneratorShape["generate"] = (input) =>
+      Effect.gen(function* () {
+        const fallback = fallbackTitle(input.firstMessage);
+        const sid = AgentSessionId.make(`title-${crypto.randomUUID()}`);
+        const prompt = `${PROMPT_PREFIX}${input.firstMessage.slice(0, 2000)}`;
+
+        const text = yield* Effect.gen(function* () {
+          yield* provider.start(
+            {
+              folderId: input.folderId,
+              providerId: input.providerId,
+              mode: "sdk",
+              sessionId: sid,
+              initialPrompt: prompt,
+              model: input.model,
+              cwdOverride: scratchCwd,
+              permissionMode: "default",
+            },
+            null,
+            () => runtimeMode,
+          );
+          // First non-empty assistant chunk is the title; we don't need the
+          // rest of the turn.
+          const head = yield* provider.events(sid).pipe(
+            Stream.filterMap((event) =>
+              event._tag === "AssistantMessage" &&
+              event.text.trim().length > 0
+                ? Option.some(event.text)
+                : Option.none(),
+            ),
+            Stream.take(1),
+            Stream.runHead,
+          );
+          return Option.getOrElse(head, () => "");
+        }).pipe(
+          // Always tear the throwaway session down — on success, timeout, or
+          // failure — so we never leak a CLI/SDK process.
+          Effect.ensuring(
+            provider.close(sid).pipe(Effect.catchAll(() => Effect.void)),
+          ),
+          Effect.timeoutOption(`${TITLE_TIMEOUT_MS} millis`),
+          Effect.map((maybe) => Option.getOrElse(maybe, () => "")),
+          Effect.catchAll(() => Effect.succeed("")),
+        );
+
+        const cleaned = cleanTitle(text);
+        return cleaned.length > 0 ? cleaned : fallback;
+      });
+
+    return { generate } satisfies TitleGeneratorShape;
+  }),
+);

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -20,6 +20,7 @@ import { CredentialsServiceLive } from "./provider/layers/credentials-service.ts
 import { MessageStoreLive } from "./provider/layers/message-store.ts";
 import { PermissionServiceLive } from "./provider/layers/permission-service.ts";
 import { ProviderServiceLive } from "./provider/layers/provider-service.ts";
+import { TitleGeneratorLive } from "./provider/title-generator.ts";
 import { PtyServiceLive } from "./pty/layers/pty-service.ts";
 import { SkillBridgeLive } from "./skill/layers/skill-bridge.ts";
 import { SkillDiscoveryServiceLive } from "./skill/layers/skill-discovery.ts";
@@ -202,11 +203,24 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
   // messages tables. The chat-MVP RPC surface (session.* / messages.*) talks
   // through this; legacy agent.* handlers stay bound to ProviderService for
   // low-level testing.
+  // TitleGenerator names a chat from its first message by running one
+  // throwaway turn through the chat's OWN provider (via ProviderService), so
+  // it reuses whatever auth that provider has — a Grok-only user is never
+  // forced onto Claude.
+  const TitleGeneratorLayer = TitleGeneratorLive.pipe(
+    Layer.provide(ProviderLayer),
+  );
+
   const MessageStoreLayer = MessageStoreLive.pipe(
     Layer.provide(ProviderLayer),
     Layer.provide(WorktreeLayer),
     Layer.provide(RepositorySettingsLayer),
     Layer.provide(PtyLayer),
+    // GitService + ConfigStore + TitleGenerator back the first-message
+    // auto-namer (rename chat + branch); see message-store `autoNameChat`.
+    Layer.provide(GitLayer),
+    Layer.provide(ConfigStoreLayer),
+    Layer.provide(TitleGeneratorLayer),
     Layer.provide(MigratedSqlite),
     Layer.provide(NdjsonLoggerLayer),
   );

--- a/apps/server/src/worktree/layers/worktree-service.ts
+++ b/apps/server/src/worktree/layers/worktree-service.ts
@@ -117,6 +117,14 @@ export const WorktreeServiceLive = Layer.effect(
         return rows.length > 0 ? rowToWorktree(rows[0]!) : null;
       });
 
+    const updateBranch: WorktreeService["Type"]["updateBranch"] = (
+      worktreeId,
+      branch,
+    ) =>
+      sql`
+        UPDATE worktrees SET branch = ${branch} WHERE id = ${worktreeId}
+      `.pipe(Effect.asVoid, Effect.orDie);
+
     const create: WorktreeService["Type"]["create"] = (projectId) =>
       Effect.gen(function* () {
         const folder = yield* workspace.findById(projectId);
@@ -400,6 +408,6 @@ export const WorktreeServiceLive = Layer.effect(
         });
       });
 
-    return { create, list, get, remove, restore } as const;
+    return { create, list, get, updateBranch, remove, restore } as const;
   }),
 );

--- a/apps/server/src/worktree/services/worktree-service.ts
+++ b/apps/server/src/worktree/services/worktree-service.ts
@@ -28,6 +28,17 @@ export interface WorktreeServiceShape {
     projectId: FolderId,
   ) => Effect.Effect<ReadonlyArray<Worktree>>;
   readonly get: (worktreeId: WorktreeId) => Effect.Effect<Worktree | null>;
+  /**
+   * Update the stored `branch` for a worktree row so it tracks a `git branch
+   * -m` performed elsewhere (the auto-namer renames the branch via
+   * `GitService`, then calls this to keep the DB in lockstep). The on-disk
+   * directory and `name` are left untouched — only the branch label moves.
+   * No-op when the worktree row is absent.
+   */
+  readonly updateBranch: (
+    worktreeId: WorktreeId,
+    branch: string,
+  ) => Effect.Effect<void>;
   readonly remove: (
     worktreeId: WorktreeId,
     force: boolean,

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -37,6 +37,9 @@ import { ProviderService } from "../src/provider/services/provider-service.ts";
 import { MessageStoreLive } from "../src/provider/layers/message-store.ts";
 import { PtyService } from "../src/pty/services/pty-service.ts";
 import { RepositorySettingsService } from "../src/repository-settings/services/repository-settings-service.ts";
+import { GitService } from "../src/git/services/git-service.ts";
+import { TitleGenerator } from "../src/provider/title-generator.ts";
+import { ConfigStoreService } from "../src/config-store/services/config-store-service.ts";
 
 const PROJECT_ID = "proj-test" as FolderId;
 
@@ -69,7 +72,46 @@ const StubWorktreeLive = Layer.succeed(WorktreeService, {
   create: () => Effect.die("not used"),
   list: () => Effect.succeed([]),
   get: () => Effect.succeed(null),
+  updateBranch: () => Effect.void,
   remove: () => Effect.void,
+});
+
+// The first-message auto-namer only fires for chats with a worktree; these
+// tests run worktreeId=null so none of these stubs are exercised — they exist
+// solely so MessageStoreLive's layer build resolves.
+const StubGitLive = Layer.succeed(GitService, {
+  log: () => Effect.die("not used"),
+  status: () => Effect.die("not used"),
+  branches: () => Effect.die("not used"),
+  switchBranch: () => Effect.die("not used"),
+  renameBranch: () => Effect.die("not used"),
+  getUserName: () => Effect.succeed(""),
+  subscribeHeadChanges: () => Stream.die("not used"),
+  origin: () => Effect.die("not used"),
+  prState: () => Effect.die("not used"),
+  prDetails: () => Effect.die("not used"),
+  changes: () => Effect.die("not used"),
+  diff: () => Effect.die("not used"),
+  commit: () => Effect.die("not used"),
+  push: () => Effect.die("not used"),
+  mergePr: () => Effect.die("not used"),
+  markReady: () => Effect.die("not used"),
+  init: () => Effect.die("not used"),
+  fixFailingChecks: () => Effect.die("not used"),
+});
+
+const StubTitleGeneratorLive = Layer.succeed(TitleGenerator, {
+  generate: () => Effect.die("not used"),
+});
+
+const StubConfigStoreLive = Layer.succeed(ConfigStoreService, {
+  getSettings: () => Effect.die("not used"),
+  updateSettings: () => Effect.die("not used"),
+  settingsChanges: () => Stream.die("not used"),
+  migrateLocalStorage: () => Effect.die("not used"),
+  getKeybindings: () => Effect.die("not used"),
+  replaceKeybindings: () => Effect.die("not used"),
+  keybindingsChanges: () => Stream.die("not used"),
 });
 
 /** Chat archive cleanup is out of scope for MessageStore persistence tests. */
@@ -151,6 +193,9 @@ const makeRuntime = (dbPath: string) => {
     Layer.provide(StubRepositorySettingsLive),
     Layer.provide(StubPtyLive),
     Layer.provide(StubNdjsonLive),
+    Layer.provide(StubGitLive),
+    Layer.provide(StubTitleGeneratorLive),
+    Layer.provide(StubConfigStoreLive),
     // provideMerge (not provide) so SqlClient stays in the runtime context —
     // the test seeds the `projects` row through it directly.
     Layer.provideMerge(Migrated),

--- a/packages/wire/src/git.ts
+++ b/packages/wire/src/git.ts
@@ -110,6 +110,17 @@ export const GitRenameBranchRpc = Rpc.make("git.renameBranch", {
   error: GitErrors,
 });
 
+/**
+ * `git config user.name` for the folder, trimmed. Returns an empty string
+ * when unset. Used by the auto-namer to build `username/<slug>` branch names
+ * (the name is slugified before use).
+ */
+export const GitUserNameRpc = Rpc.make("git.userName", {
+  payload: Schema.Struct({ folderId: FolderId }),
+  success: Schema.Struct({ userName: Schema.String }),
+  error: GitErrors,
+});
+
 export const GitHeadChangedRpc = Rpc.make("git.headChanged", {
   payload: Schema.Struct({ folderId: FolderId }),
   success: Schema.Struct({ sha: Schema.String }),

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -56,6 +56,7 @@ import {
   GitRenameBranchRpc,
   GitStatusRpc,
   GitSwitchBranchRpc,
+  GitUserNameRpc,
 } from "./git.ts";
 import {
   PermissionDecideRpc,
@@ -94,6 +95,7 @@ import {
   ChatGetRpc,
   ChatListRpc,
   ChatRenameRpc,
+  ChatStreamChangesRpc,
   ChatSetActiveSessionRpc,
   ChatSetWorktreeRpc,
   ChatUnarchiveRpc,
@@ -167,6 +169,7 @@ export const MemoizeRpcs = RpcGroup.make(
   GitBranchesRpc,
   GitSwitchBranchRpc,
   GitRenameBranchRpc,
+  GitUserNameRpc,
   GitHeadChangedRpc,
   GitOriginRpc,
   GitPrStateRpc,
@@ -198,6 +201,7 @@ export const MemoizeRpcs = RpcGroup.make(
   ChatGetRpc,
   ChatCreateRpc,
   ChatRenameRpc,
+  ChatStreamChangesRpc,
   ChatSetWorktreeRpc,
   ChatSetActiveSessionRpc,
   ChatArchiveRpc,

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -573,6 +573,18 @@ export const ChatRenameRpc = Rpc.make("chat.rename", {
 });
 
 /**
+ * Live feed of chat-row changes (title / worktree binding) for one project.
+ * Carries only live patches — no backfill — so the renderer keeps its
+ * `chat.list` snapshot and patches it as updates arrive (e.g. the background
+ * auto-namer rewriting a new chat's title after its first message).
+ */
+export const ChatStreamChangesRpc = Rpc.make("chat.streamChanges", {
+  payload: Schema.Struct({ projectId: FolderId }),
+  success: Chat,
+  stream: true,
+});
+
+/**
  * Change the chat's worktree. Allowed only when no session in the chat has
  * any user message yet — fails with `ChatAlreadyStartedError` otherwise.
  * Updates `chat.worktreeId` AND mirrors the change onto every member

--- a/packages/wire/src/settings.ts
+++ b/packages/wire/src/settings.ts
@@ -21,12 +21,14 @@ export type SubagentPresetState = typeof SubagentPresetState.Type;
  *   - `username-slug` → `<git-user>/<slug>` (e.g. `swarajbachu/dark-mode`)
  *   - `slug`          → `<slug>`            (e.g. `dark-mode`)
  *   - `feat-slug`     → `feat/<slug>`       (e.g. `feat/dark-mode`)
+ *   - `custom`        → `<branchNamingPrefix>/<slug>` (user-defined prefix)
  * Default is `username-slug`, mirroring the convention most teams use.
  */
 export const BranchNamingStyle = Schema.Literal(
   "username-slug",
   "slug",
   "feat-slug",
+  "custom",
 );
 export type BranchNamingStyle = typeof BranchNamingStyle.Type;
 
@@ -70,6 +72,12 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
    * worktree branch from the first message. See {@link BranchNamingStyle}.
    */
   branchNamingStyle: BranchNamingStyle,
+  /**
+   * User-defined prefix used only when `branchNamingStyle === "custom"`,
+   * slash-joined before the slug (e.g. prefix `wip` → `wip/dark-mode`).
+   * Empty falls back to a bare slug.
+   */
+  branchNamingPrefix: Schema.String,
 }) {}
 
 /**
@@ -99,6 +107,7 @@ export const SettingsPatch = Schema.Struct({
     }),
   ),
   branchNamingStyle: Schema.optional(BranchNamingStyle),
+  branchNamingPrefix: Schema.optional(Schema.String),
 });
 export type SettingsPatch = typeof SettingsPatch.Type;
 

--- a/packages/wire/src/settings.ts
+++ b/packages/wire/src/settings.ts
@@ -16,6 +16,21 @@ export const SubagentPresetState = Schema.Struct({
 export type SubagentPresetState = typeof SubagentPresetState.Type;
 
 /**
+ * How the auto-namer (PR: "auto-name chat + branch after first message")
+ * shapes a worktree's git branch once it has an LLM-derived title slug.
+ *   - `username-slug` → `<git-user>/<slug>` (e.g. `swarajbachu/dark-mode`)
+ *   - `slug`          → `<slug>`            (e.g. `dark-mode`)
+ *   - `feat-slug`     → `feat/<slug>`       (e.g. `feat/dark-mode`)
+ * Default is `username-slug`, mirroring the convention most teams use.
+ */
+export const BranchNamingStyle = Schema.Literal(
+  "username-slug",
+  "slug",
+  "feat-slug",
+);
+export type BranchNamingStyle = typeof BranchNamingStyle.Type;
+
+/**
  * Wire-shape of `settings.json`. Owned by the main process; rendered to and
  * mutated from the renderer over RPC. The renderer keeps a hot cache in a
  * Zustand store that subscribes to `settings.stream`.
@@ -50,6 +65,11 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
       value: SubagentPresetState,
     }),
   }),
+  /**
+   * Branch-name shape the auto-namer uses when it renames a new chat's
+   * worktree branch from the first message. See {@link BranchNamingStyle}.
+   */
+  branchNamingStyle: BranchNamingStyle,
 }) {}
 
 /**
@@ -78,6 +98,7 @@ export const SettingsPatch = Schema.Struct({
       }),
     }),
   ),
+  branchNamingStyle: Schema.optional(BranchNamingStyle),
 });
 export type SettingsPatch = typeof SettingsPatch.Type;
 


### PR DESCRIPTION
When a new chat that has its own worktree receives its first message, memoize now summarizes it into a short title and renames both the chat and the worktree's git branch in the background, so the agent's first reply is never delayed. The title is generated by running one throwaway turn through the chat's own provider/model (Claude, Grok, Codex, etc.), so a user without Claude auth still gets an LLM title; it runs in a temp dir with a first-line truncation fallback on any error or timeout. A new `branchNamingStyle` setting (default `username/branch`, also `branch` and `feat/branch`) picks the branch shape, exposed via a picker in General settings. Supporting plumbing: a `git.userName` RPC, `WorktreeService.updateBranch` to keep the DB and git in sync after the rename, and a `chat.streamChanges` stream so the sidebar title updates live without a refetch. Verified with `bun run check-types`, `bun run test` (95 pass), and `bun run lint`.