### PR TITLE
[codex] Add GPT-5.5 Codex model

### DIFF
--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -843,6 +843,13 @@ export const MODELS_BY_PROVIDER: Record<
       supportsWebSearch: "native",
     },
     {
+      id: "gpt-5.5",
+      label: "GPT-5.5",
+      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
       id: "gpt-5.3-codex",
       label: "GPT-5.3 Codex",
       optionDescriptors: [reasoningSelectDescriptor("medium")],


### PR DESCRIPTION
## Summary
- Add `gpt-5.5` to the Codex model list.

## Validation
- `bun run --filter @memoize/wire check-types`