### PR TITLE
[codex] Refine Claude Ultracode UI

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -105,6 +105,7 @@ const MAX_ATTACHMENTS_PER_TURN = 20;
 
 export function ChatComposer({ session }: { session: Session }) {
   const sessionId: SessionId = session.id;
+  const [reasoningLevel, setReasoningLevel] = useState<string | null>(null);
   const inFlight = useMessagesStore(
     (s) => s.runningBySession[sessionId] === true,
   );
@@ -548,6 +549,7 @@ export function ChatComposer({ session }: { session: Session }) {
   };
 
   const inPlanMode = session.permissionMode === "plan";
+  const inUltracodeMode = reasoningLevel === "ultracode";
   // Keep the editor mounted at all times. Permissions / questions render as
   // a sibling above it, and we hide the editor block with `display: none`
   // while a card is up. Unmounting the editor branch detaches the CodeMirror
@@ -591,7 +593,9 @@ export function ChatComposer({ session }: { session: Session }) {
                 "rounded-xl min-h-30 transition-colors",
                 inPlanMode
                   ? "border-2 border-dashed border-rose-300/60 dark:border-rose-300/40"
-                  : "border-border/50",
+                  : inUltracodeMode
+                    ? "border-2 border-transparent [background:linear-gradient(var(--color-card),var(--color-card))_padding-box,linear-gradient(90deg,#fb7185,#f97316,#facc15,#22c55e,#06b6d4,#8b5cf6,#d946ef)_border-box]"
+                    : "border-border/50",
               )}
               onDragEnter={onDragEnter}
               onDragOver={onDragOver}
@@ -689,6 +693,7 @@ export function ChatComposer({ session }: { session: Session }) {
                   sessionId={sessionId}
                   providerId={session.providerId}
                   model={session.model}
+                  onLevelChange={setReasoningLevel}
                 />
                 {findModelDescriptor(session.providerId, session.model)
                   ?.optionDescriptors?.some(
@@ -953,10 +958,12 @@ function ReasoningPicker({
   sessionId,
   providerId,
   model,
+  onLevelChange,
 }: {
   sessionId: SessionId;
   providerId: ProviderId;
   model: string;
+  onLevelChange?: (level: string | null) => void;
 }) {
   const opencodeInventory = useOpencodeInventory((s) => s.inventory);
 
@@ -964,7 +971,7 @@ function ReasoningPicker({
   // inventory (`provider.list()` → `model.variants`). For other providers
   // it's the static reasoning/effort descriptor curated in
   // `MODELS_BY_PROVIDER`. Claude's descriptor is keyed `effort` (with
-  // tiers up through ultracode/ultrathink); everything else uses
+  // tiers up through ultracode); everything else uses
   // `reasoning`.
   const resolved = useMemo((): {
     label: string;
@@ -1019,6 +1026,14 @@ function ReasoningPicker({
     if (legacy !== null && legacy.length > 0) return legacy;
     return defaultId;
   });
+
+  useEffect(() => {
+    if (resolved === null || !resolved.options.some((o) => o.id === level)) {
+      onLevelChange?.(null);
+      return;
+    }
+    onLevelChange?.(level);
+  }, [level, onLevelChange, resolved]);
 
   if (resolved === null) return null;
 

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -3,7 +3,6 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
-  Info,
   Search as SearchIcon,
 } from "lucide-react";
 import {
@@ -72,8 +71,6 @@ interface ModelPickerEntry {
   providerId: ProviderId;
   modelId: string;
   label: string;
-  /** When true, render the rainbow Ultracode chip on this row. */
-  ultracode?: boolean;
   /**
    * When set, render a small context-window pill on this row. We only show
    * a pill when the model's `contextWindow` descriptor defaults to `"1m"`
@@ -229,7 +226,6 @@ export function ModelPicker(props: ModelPickerProps) {
           providerId: pid,
           modelId: m.id,
           label: m.label,
-          ultracode: descriptor?.ultracode?.available === true,
           ...(contextWindowLabel !== undefined ? { contextWindowLabel } : {}),
         });
       }
@@ -288,19 +284,6 @@ export function ModelPicker(props: ModelPickerProps) {
       .filter((g) => g.models.length > 0);
   }, [scope, query, allModels, pickableProviders, providerId]);
 
-  // When the user picks an Ultracode-eligible model (today: Opus 4.8), seed
-  // the per-session `effort` to `"ultracode"` so the rainbow chip lights up
-  // out of the box. Skipped if the user has already picked an effort for
-  // this session — their explicit choice wins.
-  const seedUltracodeDefault = (sessionId: SessionId, modelId: string) => {
-    if (typeof window === "undefined") return;
-    const descriptor = findModelDescriptor("claude", modelId);
-    if (descriptor?.ultracode?.available !== true) return;
-    const key = `memoize.modelOptions.${sessionId}.effort`;
-    if (window.sessionStorage.getItem(key) !== null) return;
-    window.sessionStorage.setItem(key, "ultracode");
-  };
-
   const handlePick = async (pid: ProviderId, modelId: string) => {
     if (isDefault) {
       setDefaultProviderAndModel(pid, modelId);
@@ -344,7 +327,6 @@ export function ModelPicker(props: ModelPickerProps) {
           return;
         }
       }
-      seedUltracodeDefault(sessionId, modelId);
       pushModelPickerEvent({ providerId: pid, modelId });
       setOpen(false);
     } finally {
@@ -738,15 +720,6 @@ function ModelRow({
         />
       )}
       <span className="truncate">{entry.label}</span>
-      {entry.ultracode === true && (
-        <span
-          title="Ultracode — max reasoning + automatic workflow orchestration."
-          className="flex items-center gap-0.5 rounded-md bg-gradient-to-r from-rose-400 via-amber-300 via-emerald-400 via-sky-400 to-violet-400 px-1.5 py-px text-[10px] font-medium text-white shadow-sm/10"
-        >
-          Ultracode
-          <Info className="size-2.5 opacity-80" aria-hidden />
-        </span>
-      )}
       {entry.contextWindowLabel !== undefined && (
         <span
           title={`${entry.contextWindowLabel} context window`}

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -43,7 +43,7 @@ const NETWORK_PATTERN =
  *
  * Multiple keys are supported — the Claude provider uses `effort` for
  * its reasoning tier (with values `low | medium | high | xhigh | max |
- * ultracode | ultrathink`), `fastMode` / `thinking` booleans, and
+ * ultracode`), `fastMode` / `thinking` booleans, and
  * `contextWindow` (`200k | 1m`). Non-Claude providers use `reasoning`.
  * Returns `null` when nothing has been set so the RPC payload stays
  * clean (drivers default to model presets).

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -86,8 +86,6 @@ export const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
  *   - Claude → `maxThinkingTokens` (low=5k, medium=15k, high=60k) + SDK
  *     `effort` enum (low/medium/high/xhigh/max). `ultracode` is a Claude
  *     Code preset that normalizes to `xhigh` + `settings.ultracode: true`.
- *     `ultrathink` is prompt-injected (the literal word is prepended to the
- *     user prompt); SDK `effort` stays unset.
  *   - Codex → `reasoning_effort` enum (low/medium/high pass through; higher
  *     tiers fall back to `high`).
  *   - Gemini Pro → `thinkingConfig.thinkingBudget` (low=4k, medium=16k, high=32k)
@@ -102,7 +100,6 @@ export const ReasoningLevel = Schema.Literal(
   "xhigh",
   "max",
   "ultracode",
-  "ultrathink",
 );
 export type ReasoningLevel = typeof ReasoningLevel.Type;
 
@@ -122,9 +119,8 @@ export const SelectOptionDescriptor = Schema.Struct({
   /**
    * Option ids in this list are *prompt-injected* rather than forwarded to
    * the SDK as a knob value. The driver prepends the option id (e.g. the
-   * literal word `"ultrathink"`) to the user prompt and unsets the
-   * underlying SDK field. Used by Claude's `effort` descriptor for the
-   * `ultrathink` tier.
+   * literal word for a prompt-only mode) to the user prompt and unsets the
+   * underlying SDK field.
    */
   promptInjectedValues: Schema.optional(Schema.Array(Schema.String)),
 });
@@ -639,15 +635,6 @@ export interface ModelOption {
   readonly optionDescriptors?: ReadonlyArray<OptionDescriptor>;
   readonly supportsPlanMode?: boolean;
   readonly supportsWebSearch?: "native" | "queryOnly";
-  /**
-   * When set, the renderer renders a rainbow "Ultracode" chip + info icon on
-   * this model's picker row, and the composer footer surfaces an Ultracode
-   * toggle pill. Server-side, picking this model defaults
-   * `modelOptions.effort = "ultracode"`, which the Claude driver normalizes
-   * to `effort: "xhigh"` + `settings.ultracode: true` on the SDK options.
-   * Today only Opus 4.8 advertises this.
-   */
-  readonly ultracode?: { readonly available: true };
 }
 
 /**
@@ -672,7 +659,7 @@ const reasoningSelectDescriptor = (
 /**
  * Per-model effort descriptor for the Claude provider. Each model declares
  * its own supported tiers (see `MODELS_BY_PROVIDER.claude` below); `ultracode`
- * and `ultrathink` are special — see `ReasoningLevel` docs. The knob id is
+ * is special — see `ReasoningLevel` docs. The knob id is
  * `effort` (matching the Claude SDK + t3code reference) rather than
  * `reasoning` to make driver-side mapping explicit.
  */
@@ -744,17 +731,14 @@ export const MODELS_BY_PROVIDER: Record<
             { id: "xhigh", label: "Extra High" },
             { id: "max", label: "Max" },
             { id: "ultracode", label: "Ultracode" },
-            { id: "ultrathink", label: "Ultrathink" },
           ],
           defaultId: "high",
-          promptInjectedValues: ["ultrathink"],
         }),
         claudeBooleanDescriptor("fastMode", "Fast Mode"),
         claudeContextWindowDescriptor(),
       ],
       supportsPlanMode: true,
       supportsWebSearch: "native",
-      ultracode: { available: true },
     },
     {
       id: "claude-opus-4-7",
@@ -767,10 +751,9 @@ export const MODELS_BY_PROVIDER: Record<
             { id: "high", label: "High" },
             { id: "xhigh", label: "Extra High" },
             { id: "max", label: "Max" },
-            { id: "ultrathink", label: "Ultrathink" },
+            { id: "ultracode", label: "Ultracode" },
           ],
           defaultId: "xhigh",
-          promptInjectedValues: ["ultrathink"],
         }),
         claudeBooleanDescriptor("fastMode", "Fast Mode"),
         claudeContextWindowDescriptor(),
@@ -788,10 +771,9 @@ export const MODELS_BY_PROVIDER: Record<
             { id: "medium", label: "Medium" },
             { id: "high", label: "High" },
             { id: "max", label: "Max" },
-            { id: "ultrathink", label: "Ultrathink" },
+            { id: "ultracode", label: "Ultracode" },
           ],
           defaultId: "high",
-          promptInjectedValues: ["ultrathink"],
         }),
         claudeBooleanDescriptor("fastMode", "Fast Mode"),
         claudeContextWindowDescriptor(),
@@ -809,10 +791,9 @@ export const MODELS_BY_PROVIDER: Record<
             { id: "medium", label: "Medium" },
             { id: "high", label: "High" },
             { id: "max", label: "Max" },
-            { id: "ultrathink", label: "Ultrathink" },
+            { id: "ultracode", label: "Ultracode" },
           ],
           defaultId: "high",
-          promptInjectedValues: ["ultrathink"],
         }),
         claudeContextWindowDescriptor(),
       ],


### PR DESCRIPTION
## Summary
- remove the Ultracode badge from Claude model picker rows
- keep Ultracode as a reasoning selector mode and add a rainbow composer border when active
- remove Ultrathink from the renderer/wire-facing Claude effort options

## Validation
- bun run --filter=renderer check-types
- bun run check-types
