### PR TITLE
[codex] Add chat state icons

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -4,6 +4,8 @@ import {
   ArchiveRestore,
   ChevronDown,
   ChevronRight,
+  CircleQuestionMark,
+  ClipboardCheck,
   Pencil,
   Settings,
   SquarePen,
@@ -25,6 +27,11 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Menu, MenuItem, MenuPopup } from "~/components/ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import {
+  deriveChatAttentionState,
+  type ChatAttentionState,
+  mergeChatAttentionStates,
+} from "~/lib/chat-attention-state";
 import { cn, formatCompactNumber } from "~/lib/utils";
 import { resolveAutoWorktreeId } from "../lib/auto-worktree.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
@@ -35,6 +42,10 @@ import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSettingsStore } from "../store/settings.ts";
+import {
+  useSidebarMessageStatusStore,
+  useSidebarMessageStatusSubscriptions,
+} from "../store/sidebar-message-status.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { BranchIcon, type BranchState } from "./branch-icon.tsx";
@@ -256,6 +267,7 @@ export function ProjectsSidebar() {
     return ids;
   }, [folders, sessionsByProject]);
   useSessionRunningSubscriptions(allSessionIds);
+  useSidebarMessageStatusSubscriptions(allSessionIds);
 
   const onToggleExpanded = (id: FolderId) =>
     setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
@@ -395,16 +407,31 @@ function ProjectGroup({
     [chats],
   );
 
-  // Surface a busy hint on the collapsed project header when any session
-  // inside any of this project's live chats is running.
+  // Surface the highest-priority attention hint on the collapsed project
+  // header when any session inside this project needs attention.
   const liveSessionIds = useMemo(
     () => projectSessions.filter((s) => s.archivedAt === null).map((s) => s.id),
     [projectSessions],
   );
-  const anyRunning = useMessagesStore((s) =>
-    liveSessionIds.some((id) => s.runningBySession[id] === true),
+  const headerRunning = useMessagesStore((s) =>
+    mergeChatAttentionStates(
+      liveSessionIds.map((id) =>
+        s.runningBySession[id] === true ? "running" : "idle",
+      ),
+    ),
   );
-  const showHeaderBusy = anyRunning && !isExpanded;
+  const headerMessageAttention = useSidebarMessageStatusStore((s) =>
+    mergeChatAttentionStates(
+      liveSessionIds.map((id) =>
+        deriveChatAttentionState(s.messagesBySession[id] ?? [], false),
+      ),
+    ),
+  );
+  const headerAttention = mergeChatAttentionStates([
+    headerRunning,
+    headerMessageAttention,
+  ]);
+  const showHeaderAttention = headerAttention !== "idle" && !isExpanded;
 
   const Chevron = isExpanded ? ChevronDown : ChevronRight;
 
@@ -439,7 +466,7 @@ function ProjectGroup({
               className={cn(
                 "col-start-1 row-start-1 size-5 rounded transition-opacity duration-150 ease-out",
                 "group-hover:opacity-0 motion-reduce:transition-none",
-                showHeaderBusy && "opacity-0",
+                showHeaderAttention && "opacity-0",
               )}
             >
               {avatarUrl !== null && (
@@ -449,22 +476,15 @@ function ProjectGroup({
                 {fallbackText}
               </AvatarFallback>
             </Avatar>
-            {showHeaderBusy && (
-              <span
+            {showHeaderAttention && (
+              <ChatAttentionIcon
+                state={headerAttention}
                 className={cn(
-                  "col-start-1 row-start-1 inline-flex size-3.5 items-center justify-center text-foreground transition-opacity duration-150 ease-out",
+                  "col-start-1 row-start-1 transition-opacity duration-150 ease-out",
                   "group-hover:opacity-0 motion-reduce:transition-none",
                 )}
-                aria-label="Agent is working in a session"
-                title="Agent is working in a session"
-              >
-                <Beacon
-                  dotSize={3}
-                  cellPadding={0.75}
-                  speed={1.8}
-                  color="currentColor"
-                />
-              </span>
+                context="project"
+              />
             )}
             <Chevron
               aria-hidden="true"
@@ -711,12 +731,24 @@ function ChatRow({ chat }: { chat: Chat }) {
     [sessionsByProject, chat.projectId, chat.id],
   );
 
-  const isRunning = useMessagesStore((s) => {
-    for (const id of sessionIds) {
-      if (s.runningBySession[id] === true) return true;
-    }
-    return false;
-  });
+  const runningAttention = useMessagesStore((s) =>
+    mergeChatAttentionStates(
+      sessionIds.map((id) =>
+        s.runningBySession[id] === true ? "running" : "idle",
+      ),
+    ),
+  );
+  const messageAttention = useSidebarMessageStatusStore((s) =>
+    mergeChatAttentionStates(
+      sessionIds.map((id) =>
+        deriveChatAttentionState(s.messagesBySession[id] ?? [], false),
+      ),
+    ),
+  );
+  const attentionState = mergeChatAttentionStates([
+    runningAttention,
+    messageAttention,
+  ]);
 
   // Highlight this row when its own chat is selected, OR when the active
   // session (any tab inside this chat) lives in it. Covers the transient
@@ -796,22 +828,12 @@ function ChatRow({ chat }: { chat: Chat }) {
         )}
         title={chat.title}
       >
-        {isRunning ? (
-          <span
-            className={cn(
-              "ml-3 inline-flex size-3.5 shrink-0 items-center justify-center",
-              isSelected ? "text-sidebar-accent-foreground" : "text-foreground",
-            )}
-            aria-label="Agent is working"
-            title="Agent is working"
-          >
-            <Beacon
-              dotSize={3}
-              cellPadding={0.75}
-              speed={1.8}
-              color="currentColor"
-            />
-          </span>
+        {attentionState !== "idle" ? (
+          <ChatAttentionIcon
+            state={attentionState}
+            selected={isSelected}
+            className="ml-3"
+          />
         ) : (
           <BranchIcon
             state={branchState}
@@ -890,5 +912,64 @@ function ChatRow({ chat }: { chat: Chat }) {
         </MenuPopup>
       </Menu>
     </>
+  );
+}
+
+function ChatAttentionIcon({
+  state,
+  selected = false,
+  className,
+  context = "chat",
+}: {
+  state: ChatAttentionState;
+  selected?: boolean;
+  className?: string;
+  context?: "chat" | "project";
+}) {
+  if (state === "idle") return null;
+
+  const color = selected
+    ? "text-sidebar-accent-foreground"
+    : state === "question"
+      ? "text-amber-300"
+      : state === "planReady"
+        ? "text-emerald-300"
+        : "text-foreground";
+  const label =
+    state === "question"
+      ? context === "project"
+        ? "A chat is waiting for your answer"
+        : "Waiting for your answer"
+      : state === "planReady"
+        ? context === "project"
+          ? "A chat has a plan ready to approve"
+          : "Plan ready to approve"
+        : context === "project"
+          ? "Agent is working in a session"
+          : "Agent is working";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex size-3.5 shrink-0 items-center justify-center",
+        color,
+        className,
+      )}
+      aria-label={label}
+      title={label}
+    >
+      {state === "running" ? (
+        <Beacon
+          dotSize={3}
+          cellPadding={0.75}
+          speed={1.8}
+          color="currentColor"
+        />
+      ) : state === "question" ? (
+        <CircleQuestionMark className="size-3.5" />
+      ) : (
+        <ClipboardCheck className="size-3.5" />
+      )}
+    </span>
   );
 }

--- a/apps/renderer/src/lib/chat-attention-state.ts
+++ b/apps/renderer/src/lib/chat-attention-state.ts
@@ -1,0 +1,58 @@
+import type { Message } from "@memoize/wire";
+
+export type ChatAttentionState = "idle" | "running" | "planReady" | "question";
+
+const priority: Record<ChatAttentionState, number> = {
+  idle: 0,
+  running: 1,
+  planReady: 2,
+  question: 3,
+};
+
+const itemIdOf = (value: unknown): string | null =>
+  typeof value === "string" && value.length > 0 ? value : null;
+
+export const mergeChatAttentionStates = (
+  states: ReadonlyArray<ChatAttentionState>,
+): ChatAttentionState =>
+  states.reduce<ChatAttentionState>(
+    (best, next) => (priority[next] > priority[best] ? next : best),
+    "idle",
+  );
+
+export const deriveChatAttentionState = (
+  messages: ReadonlyArray<Pick<Message, "content">>,
+  running: boolean,
+): ChatAttentionState => {
+  const answeredQuestions = new Set<string>();
+  const completedTools = new Set<string>();
+
+  for (const message of messages) {
+    const content = message.content;
+    if (content._tag === "user_question_answer") {
+      const itemId = itemIdOf(content.itemId);
+      if (itemId !== null) answeredQuestions.add(itemId);
+    }
+    if (content._tag === "tool_result") {
+      const itemId = itemIdOf(content.itemId);
+      if (itemId !== null) completedTools.add(itemId);
+    }
+  }
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i]!.content;
+    if (content._tag !== "user_question") continue;
+    const itemId = itemIdOf(content.itemId);
+    if (itemId !== null && !answeredQuestions.has(itemId)) return "question";
+  }
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i]!.content;
+    if (content._tag !== "tool_use") continue;
+    if (content.tool !== "ExitPlanMode") continue;
+    const itemId = itemIdOf(content.itemId);
+    if (itemId !== null && !completedTools.has(itemId)) return "planReady";
+  }
+
+  return running ? "running" : "idle";
+};

--- a/apps/renderer/src/store/sidebar-message-status.ts
+++ b/apps/renderer/src/store/sidebar-message-status.ts
@@ -1,0 +1,91 @@
+import { Effect, Fiber, Stream } from "effect";
+import { useEffect, useRef } from "react";
+import { create } from "zustand";
+
+import type { Message, SessionId } from "@memoize/wire";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
+
+type SidebarMessageStatusState = {
+  readonly messagesBySession: Record<string, ReadonlyArray<Message>>;
+};
+
+export const useSidebarMessageStatusStore =
+  create<SidebarMessageStatusState>(() => ({
+    messagesBySession: {},
+  }));
+
+export function useSidebarMessageStatusSubscriptions(
+  sessionIds: ReadonlyArray<SessionId>,
+) {
+  const fibersRef = useRef<
+    Map<SessionId, Fiber.RuntimeFiber<unknown, unknown>>
+  >(new Map());
+  const idsKey = sessionIds.join(",");
+
+  useEffect(() => {
+    const tracked = fibersRef.current;
+    const incoming = new Set(sessionIds);
+    const toAdd = sessionIds.filter((id) => !tracked.has(id));
+    const toRemove = Array.from(tracked.keys()).filter(
+      (id) => !incoming.has(id),
+    );
+
+    for (const id of toRemove) {
+      const fiber = tracked.get(id);
+      tracked.delete(id);
+      if (fiber !== undefined) {
+        void Effect.runPromise(Fiber.interrupt(fiber)).catch(() => {});
+      }
+    }
+
+    if (toAdd.length === 0) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const client = await getRpcClient();
+        if (cancelled) return;
+        for (const id of toAdd) {
+          if (tracked.has(id)) continue;
+          const fiber = Effect.runFork(
+            Stream.runForEach(
+              client.messages.stream({ sessionId: id }),
+              (message) =>
+                Effect.sync(() => {
+                  useSidebarMessageStatusStore.setState((s) => {
+                    const current = s.messagesBySession[id] ?? [];
+                    if (current.some((row) => row.id === message.id)) return s;
+                    return {
+                      messagesBySession: {
+                        ...s.messagesBySession,
+                        [id]: [...current, message],
+                      },
+                    };
+                  });
+                }),
+            ),
+          );
+          tracked.set(id, fiber);
+        }
+      } catch {
+        // Best-effort sidebar signal; the active chat surface remains canonical.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey]);
+
+  useEffect(() => {
+    return () => {
+      const tracked = fibersRef.current;
+      for (const fiber of tracked.values()) {
+        void Effect.runPromise(Fiber.interrupt(fiber)).catch(() => {});
+      }
+      tracked.clear();
+    };
+  }, []);
+}

--- a/apps/renderer/test/chat-attention-state.test.ts
+++ b/apps/renderer/test/chat-attention-state.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  deriveChatAttentionState,
+  mergeChatAttentionStates,
+} from "../src/lib/chat-attention-state.ts";
+
+type TestMessage = Parameters<typeof deriveChatAttentionState>[0][number];
+
+const question = (itemId: string): TestMessage => ({
+  content: {
+    _tag: "user_question",
+    itemId: itemId as never,
+    questions: [{ question: "Pick one", options: ["A"] }],
+  },
+});
+
+const questionAnswer = (itemId: string): TestMessage => ({
+  content: {
+    _tag: "user_question_answer",
+    itemId: itemId as never,
+    answers: [{ questionIndex: 0, selected: [0] }],
+  },
+});
+
+const exitPlan = (itemId: string): TestMessage => ({
+  content: {
+    _tag: "tool_use",
+    itemId: itemId as never,
+    tool: "ExitPlanMode",
+    input: { plan: "Do the work" },
+  },
+});
+
+const toolResult = (itemId: string): TestMessage => ({
+  content: {
+    _tag: "tool_result",
+    itemId: itemId as never,
+    output: "ok",
+    isError: false,
+  },
+});
+
+describe("deriveChatAttentionState", () => {
+  it("returns idle with no messages and not running", () => {
+    expect(deriveChatAttentionState([], false)).toBe("idle");
+  });
+
+  it("returns running when only running is true", () => {
+    expect(deriveChatAttentionState([], true)).toBe("running");
+  });
+
+  it("prioritizes an unanswered question over running", () => {
+    expect(deriveChatAttentionState([question("q1")], true)).toBe("question");
+  });
+
+  it("clears question state once answered", () => {
+    expect(
+      deriveChatAttentionState([question("q1"), questionAnswer("q1")], false),
+    ).toBe("idle");
+  });
+
+  it("prioritizes a pending ExitPlanMode plan over running", () => {
+    expect(deriveChatAttentionState([exitPlan("p1")], true)).toBe(
+      "planReady",
+    );
+  });
+
+  it("clears plan-ready state once ExitPlanMode has a result", () => {
+    expect(
+      deriveChatAttentionState([exitPlan("p1"), toolResult("p1")], false),
+    ).toBe("idle");
+  });
+
+  it("prioritizes question over plan when both are pending", () => {
+    expect(deriveChatAttentionState([exitPlan("p1"), question("q1")], true)).toBe(
+      "question",
+    );
+  });
+});
+
+describe("mergeChatAttentionStates", () => {
+  it("returns the highest-priority state", () => {
+    expect(mergeChatAttentionStates(["idle", "running", "planReady"])).toBe(
+      "planReady",
+    );
+  });
+});


### PR DESCRIPTION
Adds sidebar attention states for chats that are running, waiting on a user question, or have a plan ready to approve.

Chat rows now show the highest-priority state, while collapsed project headers roll up attention from non-archived sessions.

The renderer keeps this state in a sidebar-only passive message stream so it does not disturb active chat hydration, and includes unit coverage for the priority rules.

Validated with `bun run check-types` and `bun run test`.