### PR TITLE
Add agent completion sounds and permission diagnostics

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -92,6 +92,16 @@ let runtimeFiber: Fiber.RuntimeFiber<void, never> | null = null;
 const USER_APPLICATIONS_DIR = Path.join(homedir(), "Applications");
 const execFileAsync = promisify(execFile);
 
+const appendAppLog = (fileName: string, line: string): void => {
+  try {
+    const filePath = Path.join(app.getPath("userData"), "logs", fileName);
+    fsSync.mkdirSync(Path.dirname(filePath), { recursive: true });
+    fsSync.appendFileSync(filePath, `${line}\n`, "utf8");
+  } catch {
+    // Logging must never affect app behavior.
+  }
+};
+
 type OpenTargetDefinition = {
   readonly id: string;
   readonly label: string;
@@ -585,15 +595,24 @@ function createMainWindow() {
     ),
   );
 
+  // Persist renderer console output so UI-side races can be diagnosed from
+  // disk after the fact. In dev we also mirror it into the terminal.
+  mainWindow.webContents.on(
+    "console-message",
+    (_event, level, message, line, source) => {
+      const payload = JSON.stringify({
+        ts: new Date().toISOString(),
+        level,
+        message,
+        source,
+        line,
+      });
+      appendAppLog("renderer.log", payload);
+      if (isDevelopment) console.log(`[renderer] ${message}`);
+    },
+  );
+
   if (isDevelopment) {
-    // Mirror renderer console output into the dev terminal so we can see
-    // RPC smoke-test logs without having to open DevTools.
-    mainWindow.webContents.on(
-      "console-message",
-      (_event, _level, message, _line, _source) => {
-        console.log(`[renderer] ${message}`);
-      },
-    );
     void mainWindow.loadURL(DEV_SERVER_URL);
     mainWindow.webContents.openDevTools({ mode: "detach" });
   } else {

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -169,6 +169,18 @@ export function ChatComposer({ session }: { session: Session }) {
     return out;
   }, [requestsById, sessionId]);
   useEffect(() => {
+    console.info(
+      `[permission-ui] ${JSON.stringify({
+        ts: new Date().toISOString(),
+        event: "composer.pending_permissions_changed",
+        sessionId,
+        inFlight,
+        count: pendingPermissions.length,
+        requestIds: pendingPermissions.map((req) => req.id),
+      })}`,
+    );
+  }, [inFlight, pendingPermissions, sessionId]);
+  useEffect(() => {
     void hydratePermissions(sessionId);
   }, [sessionId, hydratePermissions]);
   // Reconcile permission requests whenever the running flag transitions
@@ -181,6 +193,37 @@ export function ChatComposer({ session }: { session: Session }) {
     void hydratePermissions(sessionId);
   }, [inFlight, sessionId, hydratePermissions]);
   const headPermission = pendingPermissions[0];
+  useEffect(() => {
+    if (!inFlight || headPermission !== undefined) return;
+    console.info(
+      `[permission-ui] ${JSON.stringify({
+        ts: new Date().toISOString(),
+        event: "composer.poll_pending_start",
+        sessionId,
+      })}`,
+    );
+    void hydratePermissions(sessionId);
+    const id = window.setInterval(() => {
+      console.info(
+        `[permission-ui] ${JSON.stringify({
+          ts: new Date().toISOString(),
+          event: "composer.poll_pending_tick",
+          sessionId,
+        })}`,
+      );
+      void hydratePermissions(sessionId);
+    }, 1_000);
+    return () => {
+      console.info(
+        `[permission-ui] ${JSON.stringify({
+          ts: new Date().toISOString(),
+          event: "composer.poll_pending_stop",
+          sessionId,
+        })}`,
+      );
+      window.clearInterval(id);
+    };
+  }, [inFlight, headPermission, sessionId, hydratePermissions]);
 
   const [hasText, setHasText] = useState(false);
   const [trigger, setTrigger] = useState<ActiveTrigger | null>(null);

--- a/apps/renderer/src/components/permission-card.tsx
+++ b/apps/renderer/src/components/permission-card.tsx
@@ -55,6 +55,20 @@ export function PermissionCard({
   const persistentDisabled = head.forcePrompt;
 
   useEffect(() => {
+    console.info(
+      `[permission-ui] ${JSON.stringify({
+        ts: new Date().toISOString(),
+        event: "card.visible",
+        requestId: head.id,
+        sessionId: head.sessionId,
+        kindTag: head.kind._tag,
+        queueSize,
+        forcePrompt: head.forcePrompt,
+      })}`,
+    );
+  }, [head.id, head.sessionId, head.kind._tag, head.forcePrompt, queueSize]);
+
+  useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -27,6 +27,7 @@ import { Menu, MenuItem, MenuPopup } from "~/components/ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { cn, formatCompactNumber } from "~/lib/utils";
 import { resolveAutoWorktreeId } from "../lib/auto-worktree.ts";
+import { noteSessionStatusForCompletionSound } from "../lib/completion-sounds.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useChatsStore } from "../store/chats.ts";
@@ -116,6 +117,7 @@ function useSessionRunningSubscriptions(sessionIds: ReadonlyArray<SessionId>) {
               client.session.streamStatus({ sessionId: id }),
               (event) =>
                 Effect.sync(() => {
+                  noteSessionStatusForCompletionSound(id, event.status);
                   useMessagesStore.setState((s) => ({
                     runningBySession: {
                       ...s.runningBySession,

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -12,6 +12,7 @@ import {
   Settings as SettingsIcon,
   Trash2,
   TriangleAlert,
+  Volume2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -21,6 +22,7 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 
 import {
   MODELS_BY_PROVIDER,
+  type CompletionSoundPreset,
   type Folder,
   type FolderId,
   type ProviderId,
@@ -32,6 +34,11 @@ import {
   useRelativeTimeTick,
 } from "~/lib/use-relative-time.ts";
 import { cn } from "~/lib/utils";
+import {
+  COMPLETION_SOUND_PRESETS,
+  playCompletionSound,
+  prepareCompletionSound,
+} from "../lib/completion-sounds.ts";
 import { DEFAULT_SUBAGENT_PRESETS } from "../lib/subagent-presets.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSettingsStore } from "../store/settings.ts";
@@ -507,6 +514,18 @@ function GeneralPane() {
   const setDefaultRuntimeMode = useSettingsStore(
     (s) => s.setDefaultRuntimeMode,
   );
+  const completionSoundEnabled = useSettingsStore(
+    (s) => s.completionSoundEnabled,
+  );
+  const setCompletionSoundEnabled = useSettingsStore(
+    (s) => s.setCompletionSoundEnabled,
+  );
+  const completionSoundPreset = useSettingsStore(
+    (s) => s.completionSoundPreset,
+  );
+  const setCompletionSoundPreset = useSettingsStore(
+    (s) => s.setCompletionSoundPreset,
+  );
   const setOnboardingCompleted = useSettingsStore(
     (s) => s.setOnboardingCompleted,
   );
@@ -547,6 +566,57 @@ function GeneralPane() {
         }
         description="How the agent handles tool calls in new sessions. Each session can override this from its composer."
       />
+
+      <SettingsFrame
+        title="Agent completion sound"
+        trailing={
+          <Switch
+            checked={completionSoundEnabled}
+            onCheckedChange={(value) => {
+              setCompletionSoundEnabled(value);
+              if (value) void prepareCompletionSound();
+            }}
+          />
+        }
+        description="Play a short sound when any agent turn finishes, including agents working in background chats."
+      >
+        <div className="flex items-center gap-2">
+          <Volume2 className="size-4 shrink-0 text-muted-foreground" />
+          <Select
+            value={completionSoundPreset}
+            onValueChange={(v) =>
+              setCompletionSoundPreset(v as CompletionSoundPreset)
+            }
+            items={COMPLETION_SOUND_PRESETS.map((preset) => ({
+              label: preset.label,
+              value: preset.value,
+            }))}
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-[160px]"
+              disabled={!completionSoundEnabled}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectPopup>
+              {COMPLETION_SOUND_PRESETS.map((preset) => (
+                <SelectItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+          <Button
+            variant="settings"
+            size="sm"
+            disabled={!completionSoundEnabled}
+            onClick={() => void playCompletionSound(completionSoundPreset)}
+          >
+            Preview
+          </Button>
+        </div>
+      </SettingsFrame>
 
       <SubagentsSection />
 

--- a/apps/renderer/src/lib/completion-sounds.ts
+++ b/apps/renderer/src/lib/completion-sounds.ts
@@ -1,0 +1,115 @@
+import type {
+  CompletionSoundPreset,
+  SessionId,
+  SessionStatus,
+} from "@memoize/wire";
+
+import { useSettingsStore } from "../store/settings.ts";
+
+export const COMPLETION_SOUND_PRESETS: ReadonlyArray<{
+  readonly value: CompletionSoundPreset;
+  readonly label: string;
+}> = [
+  { value: "chime", label: "Chime" },
+  { value: "soft", label: "Soft" },
+  { value: "pop", label: "Pop" },
+  { value: "bell", label: "Bell" },
+  { value: "rise", label: "Rise" },
+  { value: "bloom", label: "Bloom" },
+];
+
+let audioContext: AudioContext | null = null;
+const lastStatusBySession = new Map<SessionId, SessionStatus>();
+
+const getAudioContext = (): AudioContext | null => {
+  if (typeof window === "undefined") return null;
+  const AudioContextCtor = window.AudioContext;
+  if (AudioContextCtor === undefined) return null;
+  audioContext ??= new AudioContextCtor();
+  return audioContext;
+};
+
+const tone = (
+  ctx: AudioContext,
+  start: number,
+  frequency: number,
+  duration: number,
+  gain: number,
+  type: OscillatorType = "sine",
+) => {
+  const osc = ctx.createOscillator();
+  const envelope = ctx.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(frequency, start);
+  envelope.gain.setValueAtTime(0.0001, start);
+  envelope.gain.exponentialRampToValueAtTime(gain, start + 0.012);
+  envelope.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+  osc.connect(envelope);
+  envelope.connect(ctx.destination);
+  osc.start(start);
+  osc.stop(start + duration + 0.02);
+};
+
+export const playCompletionSound = async (
+  preset: CompletionSoundPreset,
+): Promise<void> => {
+  try {
+    const ctx = getAudioContext();
+    if (ctx === null) return;
+    if (ctx.state === "suspended") await ctx.resume();
+    const now = ctx.currentTime;
+    if (preset === "soft") {
+      tone(ctx, now, 523.25, 0.24, 0.048);
+      tone(ctx, now + 0.12, 659.25, 0.32, 0.04);
+      return;
+    }
+    if (preset === "pop") {
+      tone(ctx, now, 740, 0.12, 0.06, "triangle");
+      tone(ctx, now + 0.08, 987.77, 0.14, 0.034, "triangle");
+      return;
+    }
+    if (preset === "bell") {
+      tone(ctx, now, 880, 0.22, 0.052);
+      tone(ctx, now + 0.04, 1320, 0.42, 0.024);
+      return;
+    }
+    if (preset === "rise") {
+      tone(ctx, now, 440, 0.16, 0.04);
+      tone(ctx, now + 0.11, 554.37, 0.18, 0.044);
+      tone(ctx, now + 0.23, 659.25, 0.24, 0.04);
+      return;
+    }
+    if (preset === "bloom") {
+      tone(ctx, now, 392, 0.34, 0.034);
+      tone(ctx, now + 0.04, 493.88, 0.38, 0.035);
+      tone(ctx, now + 0.11, 659.25, 0.34, 0.032);
+      return;
+    }
+    tone(ctx, now, 587.33, 0.18, 0.055);
+    tone(ctx, now + 0.12, 783.99, 0.28, 0.046);
+  } catch {
+    // Audio can be blocked until a user gesture; completion sounds are best-effort.
+  }
+};
+
+export const prepareCompletionSound = async (): Promise<void> => {
+  try {
+    const ctx = getAudioContext();
+    if (ctx === null) return;
+    if (ctx.state === "suspended") await ctx.resume();
+  } catch {
+    // Best-effort unlock; preview/completion playback will retry later.
+  }
+};
+
+export const noteSessionStatusForCompletionSound = (
+  sessionId: SessionId,
+  status: SessionStatus,
+): void => {
+  const prev = lastStatusBySession.get(sessionId);
+  lastStatusBySession.set(sessionId, status);
+  if (prev !== "running" || status === "running") return;
+  const settings = useSettingsStore.getState();
+  if (!settings.completionSoundEnabled) return;
+  void playCompletionSound(settings.completionSoundPreset);
+};

--- a/apps/renderer/src/store/permissions.ts
+++ b/apps/renderer/src/store/permissions.ts
@@ -46,38 +46,71 @@ const formatError = (err: unknown): string => {
 
 let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 
+const logPermissionUi = (
+  event: string,
+  fields: Record<string, unknown> = {},
+): void => {
+  console.info(
+    `[permission-ui] ${JSON.stringify({
+      ts: new Date().toISOString(),
+      event,
+      ...fields,
+    })}`,
+  );
+};
+
 export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   requestsById: {},
   errorBySession: {},
   decisionsByProject: {},
   loadingDecisionsByProject: {},
   start: () => {
-    if (streamFiber !== null) return;
+    if (streamFiber !== null) {
+      logPermissionUi("stream.start_skipped_existing");
+      return;
+    }
+    logPermissionUi("stream.start");
     void (async () => {
       try {
         const client = await getRpcClient();
         streamFiber = Effect.runFork(
           Stream.runForEach(client.permission.requests({}), (req) =>
             Effect.sync(() => {
+              logPermissionUi("stream.request_received", {
+                requestId: req.id,
+                sessionId: req.sessionId,
+                kindTag: req.kind._tag,
+                requestedAt: req.requestedAt.toISOString(),
+              });
               set((s) => ({
                 requestsById: { ...s.requestsById, [req.id]: req },
               }));
             }),
           ),
         );
-      } catch {
+      } catch (err) {
+        logPermissionUi("stream.start_failed", { error: formatError(err) });
         // Boot-time stream failure is silent — `hydrate` is the safety net.
       }
     })();
   },
   hydrate: async (sessionId) => {
     try {
+      logPermissionUi("hydrate.start", { sessionId });
       const client = await getRpcClient();
       const pending = await Effect.runPromise(
         client.permission.listPending({ sessionId }),
       );
+      logPermissionUi("hydrate.result", {
+        sessionId,
+        count: pending.length,
+        requestIds: pending.map((req) => req.id),
+      });
       set((s) => {
         const next = { ...s.requestsById };
+        for (const [id, req] of Object.entries(next)) {
+          if (req.sessionId === sessionId) delete next[id];
+        }
         for (const req of pending) next[req.id] = req;
         return {
           requestsById: next,
@@ -85,6 +118,10 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
         };
       });
     } catch (err) {
+      logPermissionUi("hydrate.failed", {
+        sessionId,
+        error: formatError(err),
+      });
       set((s) => ({
         errorBySession: {
           ...s.errorBySession,
@@ -94,6 +131,12 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
     }
   },
   decide: async (requestId, decision) => {
+    const req = get().requestsById[requestId];
+    logPermissionUi("decide.start", {
+      requestId,
+      sessionId: req?.sessionId ?? null,
+      decision: decision._tag,
+    });
     set((s) => {
       const next = { ...s.requestsById };
       delete next[requestId];
@@ -104,7 +147,17 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
       await Effect.runPromise(
         client.permission.decide({ requestId, decision }),
       );
+      logPermissionUi("decide.success", {
+        requestId,
+        sessionId: req?.sessionId ?? null,
+        decision: decision._tag,
+      });
     } catch {
+      logPermissionUi("decide.failed", {
+        requestId,
+        sessionId: req?.sessionId ?? null,
+        decision: decision._tag,
+      });
       // The server drops the entry on success; a failed decide leaves it in
       // memory and we'll re-hydrate via listPending on the next session
       // mount. No noisy error UI for this case.
@@ -171,4 +224,3 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
     }
   },
 }));
-

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 
 import {
   defaultModelFor,
+  type CompletionSoundPreset,
   type ProviderId,
   resolveModelSlug,
   type RuntimeMode,
@@ -57,6 +58,8 @@ const fallbackSnapshot = (): SettingsSlice => ({
   defaultModelByProvider: seedModels(),
   defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
   defaultAutoCreateWorktree: false,
+  completionSoundEnabled: false,
+  completionSoundPreset: "chime",
   onboardingCompleted: false,
   providerEnabled: seedProviderEnabled(),
 });
@@ -76,6 +79,8 @@ const sliceFromFile = (file: SettingsFile): SettingsSlice => {
     defaultModelByProvider: models,
     defaultRuntimeMode: file.defaultRuntimeMode,
     defaultAutoCreateWorktree: file.defaultAutoCreateWorktree,
+    completionSoundEnabled: file.completionSoundEnabled,
+    completionSoundPreset: file.completionSoundPreset,
     onboardingCompleted: file.onboardingCompleted,
     providerEnabled: {
       ...seedProviderEnabled(),
@@ -89,6 +94,8 @@ interface SettingsSlice {
   readonly defaultModelByProvider: Record<ProviderId, string>;
   readonly defaultRuntimeMode: RuntimeMode;
   readonly defaultAutoCreateWorktree: boolean;
+  readonly completionSoundEnabled: boolean;
+  readonly completionSoundPreset: CompletionSoundPreset;
   readonly onboardingCompleted: boolean;
   readonly providerEnabled: Record<ProviderId, boolean>;
 }
@@ -111,6 +118,8 @@ type SettingsState = SettingsSlice & {
   ) => void;
   readonly setDefaultRuntimeMode: (mode: RuntimeMode) => void;
   readonly setDefaultAutoCreateWorktree: (value: boolean) => void;
+  readonly setCompletionSoundEnabled: (value: boolean) => void;
+  readonly setCompletionSoundPreset: (preset: CompletionSoundPreset) => void;
   readonly setOnboardingCompleted: (value: boolean) => void;
   readonly setProviderEnabled: (providerId: ProviderId, value: boolean) => void;
 };
@@ -231,6 +240,24 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         client.settings.update({
           patch: { defaultAutoCreateWorktree: value },
         }),
+      );
+    })();
+  },
+  setCompletionSoundEnabled: (value) => {
+    set({ completionSoundEnabled: value });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({ patch: { completionSoundEnabled: value } }),
+      );
+    })();
+  },
+  setCompletionSoundPreset: (preset) => {
+    set({ completionSoundPreset: preset });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({ patch: { completionSoundPreset: preset } }),
       );
     })();
   },

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -12,6 +12,7 @@ import {
   type ProviderId,
   resolveModelSlug,
   SettingsFile,
+  type CompletionSoundPreset,
   type SettingsPatch,
   type SubagentPresetState,
 } from "@memoize/wire";
@@ -64,6 +65,8 @@ const freshSettings = (): SettingsFile =>
     defaultRuntimeMode: "approval-required",
     defaultAutoCreateWorktree: false,
     onboardingCompleted: false,
+    completionSoundEnabled: false,
+    completionSoundPreset: "chime",
     providerEnabled: seedProviderEnabled(),
     subagents: { enableForNewSessions: true, presets: {} },
   });
@@ -88,6 +91,14 @@ const isRuntimeMode = (v: unknown): v is SettingsFile["defaultRuntimeMode"] =>
   v === "auto-accept-edits" ||
   v === "auto-accept-edits-and-bash" ||
   v === "full-access";
+
+const isCompletionSoundPreset = (v: unknown): v is CompletionSoundPreset =>
+  v === "chime" ||
+  v === "soft" ||
+  v === "pop" ||
+  v === "bell" ||
+  v === "rise" ||
+  v === "bloom";
 
 /**
  * Re-shape an arbitrary parsed JSON value onto a `SettingsFile`, falling
@@ -129,6 +140,17 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     typeof obj.onboardingCompleted === "boolean"
       ? obj.onboardingCompleted
       : base.onboardingCompleted;
+
+  const completionSoundEnabled =
+    typeof obj.completionSoundEnabled === "boolean"
+      ? obj.completionSoundEnabled
+      : base.completionSoundEnabled;
+
+  const completionSoundPreset = isCompletionSoundPreset(
+    obj.completionSoundPreset,
+  )
+    ? obj.completionSoundPreset
+    : base.completionSoundPreset;
 
   const providerEnabled: Record<ProviderId, boolean> = {
     ...base.providerEnabled,
@@ -177,6 +199,8 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     defaultRuntimeMode: runtime,
     defaultAutoCreateWorktree: autoWorktree,
     onboardingCompleted: onboarding,
+    completionSoundEnabled,
+    completionSoundPreset,
     providerEnabled,
     subagents,
   });
@@ -421,6 +445,10 @@ export const ConfigStoreServiceLive = Layer.scoped(
             patch.defaultAutoCreateWorktree ?? cur.defaultAutoCreateWorktree,
           onboardingCompleted:
             patch.onboardingCompleted ?? cur.onboardingCompleted,
+          completionSoundEnabled:
+            patch.completionSoundEnabled ?? cur.completionSoundEnabled,
+          completionSoundPreset:
+            patch.completionSoundPreset ?? cur.completionSoundPreset,
           providerEnabled: patch.providerEnabled ?? cur.providerEnabled,
           subagents: patch.subagents ?? cur.subagents,
         });
@@ -459,6 +487,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
             cur.defaultRuntimeMode === baseline.defaultRuntimeMode &&
             cur.defaultAutoCreateWorktree ===
               baseline.defaultAutoCreateWorktree &&
+            cur.completionSoundEnabled === baseline.completionSoundEnabled &&
+            cur.completionSoundPreset === baseline.completionSoundPreset &&
             cur.onboardingCompleted === false &&
             Object.keys(cur.subagents.presets).length === 0;
           if (!currentLooksFresh) return cur;
@@ -474,6 +504,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
           let providerEnabled: SettingsFile["providerEnabled"] =
             cur.providerEnabled;
           let subagents: SettingsFile["subagents"] = cur.subagents;
+          let completionSoundEnabled = cur.completionSoundEnabled;
+          let completionSoundPreset = cur.completionSoundPreset;
 
           if (
             payload.settingsV1Raw !== undefined &&
@@ -490,6 +522,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
               runtime = fromLs.defaultRuntimeMode;
               autoWorktree = fromLs.defaultAutoCreateWorktree;
               onboarding = fromLs.onboardingCompleted;
+              completionSoundEnabled = fromLs.completionSoundEnabled;
+              completionSoundPreset = fromLs.completionSoundPreset;
               providerEnabled = fromLs.providerEnabled;
             } catch {
               /* swallow — keep current values */
@@ -520,6 +554,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
             defaultRuntimeMode: runtime,
             defaultAutoCreateWorktree: autoWorktree,
             onboardingCompleted: onboarding,
+            completionSoundEnabled,
+            completionSoundPreset,
             providerEnabled,
             subagents,
           });

--- a/apps/server/src/provider/layers/permission-service.ts
+++ b/apps/server/src/provider/layers/permission-service.ts
@@ -1,5 +1,7 @@
 import { SqlClient } from "@effect/sql";
 import { Deferred, Effect, Layer, PubSub, Ref, Schema, Stream } from "effect";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 import {
   PermissionKind,
@@ -11,6 +13,7 @@ import {
   type SessionId,
 } from "@memoize/wire";
 
+import { AppPaths } from "../../app-paths.ts";
 import {
   PermissionService,
   type PermissionServiceShape,
@@ -101,10 +104,28 @@ export const PermissionServiceLive = Layer.scoped(
   PermissionService,
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
+    const paths = yield* AppPaths;
     const pubsub = yield* PubSub.unbounded<PermissionRequest>();
     const pending = yield* Ref.make<ReadonlyMap<string, PendingEntry>>(
       new Map(),
     );
+    const logPath = join(paths.userData, "logs", "permissions.log");
+
+    const log = (event: string, fields: Record<string, unknown> = {}): void => {
+      try {
+        mkdirSync(dirname(logPath), { recursive: true });
+        appendFileSync(
+          logPath,
+          `${JSON.stringify({
+            ts: new Date().toISOString(),
+            event,
+            ...fields,
+          })}\n`,
+        );
+      } catch {
+        // Permission logging must never affect permission handling.
+      }
+    };
 
     const findExistingAllow = (
       sessionId: SessionId,
@@ -174,6 +195,12 @@ export const PermissionServiceLive = Layer.scoped(
             kind,
           );
           if (allowed) {
+            log("request.auto_allowed", {
+              sessionId,
+              projectId: options.projectId,
+              kindTag: kind._tag,
+              kindKey: kindKey(kind),
+            });
             return { _tag: "AllowOnce" } as PermissionDecision;
           }
         }
@@ -195,10 +222,29 @@ export const PermissionServiceLive = Layer.scoped(
         yield* Ref.update(pending, (m) => {
           const next = new Map(m);
           next.set(id, { request: req, deferred });
+          log("request.pending_added", {
+            requestId: id,
+            sessionId,
+            projectId: options.projectId,
+            kindTag: kind._tag,
+            kindKey: kindKey(kind),
+            forcePrompt: req.forcePrompt,
+            pendingCount: next.size,
+          });
           return next;
         });
-        yield* PubSub.publish(pubsub, req);
+        const published = yield* PubSub.publish(pubsub, req);
+        log("request.published", {
+          requestId: id,
+          sessionId,
+          published,
+        });
         const decision = yield* Deferred.await(deferred);
+        log("request.resolved", {
+          requestId: id,
+          sessionId,
+          decision: decision._tag,
+        });
         return decision;
       });
 
@@ -207,6 +253,11 @@ export const PermissionServiceLive = Layer.scoped(
         const map = yield* Ref.get(pending);
         const entry = map.get(requestId);
         if (entry === undefined) {
+          log("decide.not_found", {
+            requestId,
+            decision: decision._tag,
+            pendingCount: map.size,
+          });
           return yield* Effect.fail(
             new PermissionRequestNotFoundError({ requestId }),
           );
@@ -216,6 +267,13 @@ export const PermissionServiceLive = Layer.scoped(
         yield* Ref.update(pending, (m) => {
           const next = new Map(m);
           next.delete(requestId);
+          log("decide.pending_removed", {
+            requestId,
+            sessionId: entry.request.sessionId,
+            decision: decision._tag,
+            projectId: projectId ?? null,
+            pendingCount: next.size,
+          });
           return next;
         });
         yield* Ref.update(projectByRequest, (m) => {
@@ -236,6 +294,11 @@ export const PermissionServiceLive = Layer.scoped(
         for (const entry of map.values()) {
           if (entry.request.sessionId === sessionId) out.push(entry.request);
         }
+        log("list_pending", {
+          sessionId,
+          count: out.length,
+          requestIds: out.map((req) => req.id),
+        });
         return out;
       });
 
@@ -243,7 +306,18 @@ export const PermissionServiceLive = Layer.scoped(
       Stream.unwrapScoped(
         Effect.gen(function* () {
           const dequeue = yield* pubsub.subscribe;
-          return Stream.fromQueue(dequeue);
+          const map = yield* Ref.get(pending);
+          const current = Array.from(map.values()).map(
+            (entry) => entry.request,
+          );
+          log("stream.subscribe", {
+            replayCount: current.length,
+            requestIds: current.map((req) => req.id),
+          });
+          return Stream.concat(
+            Stream.fromIterable(current),
+            Stream.fromQueue(dequeue),
+          );
         }),
       );
 

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -160,6 +160,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
   // user isn't re-prompted on resume.
   const PermissionLayer = PermissionServiceLive.pipe(
     Layer.provide(MigratedSqlite),
+    Layer.provide(AppPathsLayer),
   );
 
   // BrowserBridge brokers between the in-process browser MCP tools (driver

--- a/packages/wire/src/settings.ts
+++ b/packages/wire/src/settings.ts
@@ -15,6 +15,16 @@ export const SubagentPresetState = Schema.Struct({
 });
 export type SubagentPresetState = typeof SubagentPresetState.Type;
 
+export const CompletionSoundPreset = Schema.Literal(
+  "chime",
+  "soft",
+  "pop",
+  "bell",
+  "rise",
+  "bloom",
+);
+export type CompletionSoundPreset = typeof CompletionSoundPreset.Type;
+
 /**
  * Wire-shape of `settings.json`. Owned by the main process; rendered to and
  * mutated from the renderer over RPC. The renderer keeps a hot cache in a
@@ -34,6 +44,8 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
   defaultRuntimeMode: RuntimeMode,
   defaultAutoCreateWorktree: Schema.Boolean,
   onboardingCompleted: Schema.Boolean,
+  completionSoundEnabled: Schema.Boolean,
+  completionSoundPreset: CompletionSoundPreset,
   /**
    * Per-provider on/off toggle from the Providers settings card. Defaults
    * to `true` for every provider; flipping it to `false` filters the
@@ -66,6 +78,8 @@ export const SettingsPatch = Schema.Struct({
   defaultRuntimeMode: Schema.optional(RuntimeMode),
   defaultAutoCreateWorktree: Schema.optional(Schema.Boolean),
   onboardingCompleted: Schema.optional(Schema.Boolean),
+  completionSoundEnabled: Schema.optional(Schema.Boolean),
+  completionSoundPreset: Schema.optional(CompletionSoundPreset),
   providerEnabled: Schema.optional(
     Schema.Record({ key: ProviderId, value: Schema.Boolean }),
   ),

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -6,6 +6,7 @@ import {
   Chat,
   GitBranchInfo,
   Message,
+  SettingsFile,
   Session,
 } from "../src/index.ts";
 
@@ -217,6 +218,68 @@ describe("Chat round-trip", () => {
       createdAt: "2026-06-17T00:00:00.000Z",
       updatedAt: "2026-06-17T00:00:00.000Z",
     });
+  });
+});
+
+describe("SettingsFile round-trip", () => {
+  it("round-trips completion sound settings", () => {
+    roundTrip(SettingsFile, {
+      schemaVersion: 1,
+      defaultProviderId: "claude",
+      defaultModelByProvider: {
+        claude: "claude-opus-4-8",
+        codex: "gpt-5-codex",
+        grok: "grok-code-fast-1",
+        cursor: "cursor-agent",
+        gemini: "gemini-3-pro",
+        opencode: "sonnet",
+      },
+      defaultRuntimeMode: "approval-required",
+      defaultAutoCreateWorktree: false,
+      onboardingCompleted: true,
+      completionSoundEnabled: true,
+      completionSoundPreset: "bloom",
+      providerEnabled: {
+        claude: true,
+        codex: true,
+        grok: true,
+        cursor: true,
+        gemini: true,
+        opencode: true,
+      },
+      subagents: { enableForNewSessions: true, presets: {} },
+    });
+  });
+
+  it("rejects an unknown completion sound preset", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(SettingsFile)({
+        schemaVersion: 1,
+        defaultProviderId: "claude",
+        defaultModelByProvider: {
+          claude: "claude-opus-4-8",
+          codex: "gpt-5-codex",
+          grok: "grok-code-fast-1",
+          cursor: "cursor-agent",
+          gemini: "gemini-3-pro",
+          opencode: "sonnet",
+        },
+        defaultRuntimeMode: "approval-required",
+        defaultAutoCreateWorktree: false,
+        onboardingCompleted: true,
+        completionSoundEnabled: true,
+        completionSoundPreset: "airhorn",
+        providerEnabled: {
+          claude: true,
+          codex: true,
+          grok: true,
+          cursor: true,
+          gemini: true,
+          opencode: true,
+        },
+        subagents: { enableForNewSessions: true, presets: {} },
+      }),
+    ).toThrow();
   });
 });
 


### PR DESCRIPTION
Adds opt-in agent completion sounds with built-in Web Audio presets, persisted settings, a General settings control, and background-session completion detection.
Fixes permission prompts that could remain invisible while an agent was blocked by replaying pending requests, replacing stale hydrated state, and polling pending permissions during active turns.
Adds permission diagnostics to `<userData>/logs/permissions.log` and persists renderer console output to `<userData>/logs/renderer.log` for future repros.

Validation: `bun run check-types`, `bun test packages/wire/test/schema.test.ts`, and `bun test apps/server/test/message-store.test.ts`.
