### PR TITLE
fix(renderer): reliably deliver permission prompts mid-turn

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -180,6 +180,22 @@ export function ChatComposer({ session }: { session: Session }) {
     if (inFlight) return;
     void hydratePermissions(sessionId);
   }, [inFlight, sessionId, hydratePermissions]);
+  // Deterministic fallback delivery. The reconcile hydrate above is gated off
+  // while a turn is in flight, yet that's exactly when the agent blocks on a
+  // permission request. If the live `permission.requests` stream ever drops
+  // the request (subscribe race / stream death), the card would never appear
+  // and the agent hangs invisibly. Poll `listPending` (the server's durable
+  // truth) while running so the card always surfaces within ~2s. Idempotent —
+  // `requestsById` is keyed by id, so it's a no-op merge when the stream is
+  // healthy. The interval is cleared the instant the turn ends or the session
+  // changes.
+  useEffect(() => {
+    if (!inFlight) return;
+    const id = window.setInterval(() => {
+      void hydratePermissions(sessionId);
+    }, 2000);
+    return () => window.clearInterval(id);
+  }, [inFlight, sessionId, hydratePermissions]);
   const headPermission = pendingPermissions[0];
 
   const [hasText, setHasText] = useState(false);

--- a/apps/renderer/src/store/permissions.ts
+++ b/apps/renderer/src/store/permissions.ts
@@ -1,4 +1,4 @@
-import { Effect, Fiber, Stream } from "effect";
+import { Effect, Fiber, Schedule, Stream } from "effect";
 import { create } from "zustand";
 
 import type {
@@ -45,6 +45,18 @@ const formatError = (err: unknown): string => {
 };
 
 let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
+// Real guard against double-subscribe. `streamFiber` is only a handle —
+// it must never be used as the latch, since the previous design left it
+// non-null after the stream died and wedged `start()` into a permanent
+// no-op (live delivery dead until full reload).
+let started = false;
+
+// Ids of requests the user just decided. `decide()` removes them optimistically
+// and the server drops them from `pending` synchronously, but a `listPending`
+// poll (or a late stream echo) already in flight can race ahead and re-add the
+// decided request for one cycle. Suppress those ids on both ingest paths until
+// the in-flight reads drain.
+const decidedRecently = new Set<string>();
 
 export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   requestsById: {},
@@ -52,22 +64,54 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   decisionsByProject: {},
   loadingDecisionsByProject: {},
   start: () => {
-    if (streamFiber !== null) return;
+    if (started) return;
+    started = true;
     void (async () => {
+      let client: Awaited<ReturnType<typeof getRpcClient>>;
       try {
-        const client = await getRpcClient();
-        streamFiber = Effect.runFork(
-          Stream.runForEach(client.permission.requests({}), (req) =>
-            Effect.sync(() => {
-              set((s) => ({
-                requestsById: { ...s.requestsById, [req.id]: req },
-              }));
-            }),
-          ),
-        );
+        client = await getRpcClient();
       } catch {
-        // Boot-time stream failure is silent — `hydrate` is the safety net.
+        // Couldn't get the client at all — allow a later retry.
+        started = false;
+        return;
       }
+      // The server stream has no replay, so a request published during the
+      // window before our subscription is live only lives in `listPending`.
+      // Re-hydrate every session we already know about on each (re)subscribe
+      // to pull those back. No-op on first boot (empty map).
+      const rehydrateKnownSessions = Effect.sync(() => {
+        const seen = new Set<SessionId>();
+        for (const req of Object.values(get().requestsById)) {
+          if (seen.has(req.sessionId)) continue;
+          seen.add(req.sessionId);
+          void get().hydrate(req.sessionId);
+        }
+      });
+      const subscribe = Stream.runForEach(
+        client.permission.requests({}),
+        (req) =>
+          Effect.sync(() => {
+            if (decidedRecently.has(req.id)) return;
+            set((s) => ({
+              requestsById: { ...s.requestsById, [req.id]: req },
+            }));
+          }),
+      );
+      // Self-healing: re-establish after any completion/error with bounded
+      // backoff. Without this the stream dies once (server restart, dev HMR,
+      // scope close) and live delivery never recovers. Mirrors the
+      // `statusFiber` reset idiom in store/messages.ts.
+      const program = Effect.zipRight(rehydrateKnownSessions, subscribe).pipe(
+        Effect.catchAll(() => Effect.void),
+        Effect.repeat(Schedule.spaced("2 seconds")),
+        Effect.ensuring(
+          Effect.sync(() => {
+            streamFiber = null;
+            started = false;
+          }),
+        ),
+      );
+      streamFiber = Effect.runFork(program);
     })();
   },
   hydrate: async (sessionId) => {
@@ -78,7 +122,10 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
       );
       set((s) => {
         const next = { ...s.requestsById };
-        for (const req of pending) next[req.id] = req;
+        for (const req of pending) {
+          if (decidedRecently.has(req.id)) continue;
+          next[req.id] = req;
+        }
         return {
           requestsById: next,
           errorBySession: { ...s.errorBySession, [sessionId]: null },
@@ -94,6 +141,9 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
     }
   },
   decide: async (requestId, decision) => {
+    decidedRecently.add(requestId);
+    // Long enough to outlast any in-flight `listPending` poll / stream echo.
+    window.setTimeout(() => decidedRecently.delete(requestId), 5000);
     set((s) => {
       const next = { ...s.requestsById };
       delete next[requestId];


### PR DESCRIPTION
## Problem

When Claude requested permission to run a tool, the permission card **sometimes never appeared** and the agent silently hung — the server driver blocks awaiting a decision the user is never shown, so the composer just looks idle.

Root cause: during a running turn the **only** live delivery path to the UI was a single boot-time subscription to `permission.requests`, and it was fragile in three ways:

1. **No retry/reset** — `start()` latched a module-level `streamFiber` and never reset it; once the stream completed/errored (server restart, dev HMR, scope close) `start()` became a permanent no-op and live delivery was dead until a full reload.
2. **No replay** — the server `PubSub` only delivers messages published *after* a subscriber attaches, so a request racing the (re)subscribe was lost.
3. **No fallback mid-turn** — the reconcile `hydrate` is gated `if (inFlight) return`, but `inFlight` stays `true` the entire time the agent is blocked on the prompt, so the safety net could never fire exactly when needed.

## Fix (renderer-only; the server `pending` Ref is already durable truth)

- **Self-healing stream** (`store/permissions.ts`): guard on a `started` flag instead of the fiber handle, re-establish on completion/error with bounded backoff via `Effect.repeat(Schedule.spaced("2 seconds"))`, reset the latch on end with `Effect.ensuring` (mirrors the `statusFiber` idiom in `store/messages.ts`), and re-hydrate known sessions on every (re)subscribe to close the no-replay race.
- **In-flight poll** (`components/chat-composer.tsx`): poll `listPending` every 2s while a turn is running so the card always surfaces within ~2s even if the stream drops. Idempotent (`requestsById` is keyed by id); the interval clears the moment the turn ends or the session changes.
- **`decidedRecently` guard**: a short-lived id-set so an in-flight poll / late stream echo can't re-add a just-decided request.

No server changes.

## Verification

- Healthy path: prompt still appears instantly; the 2s poll is a no-op idempotent merge.
- Failure path: with the agent blocked on a prompt, kill/restart the server (or trigger HMR) — before, the card never appeared and the agent hung until reload; after, the card appears within ~2s, and once the server is back a fresh prompt appears sub-second again (stream re-subscribed).
- `bun run check-types` passes (renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)