### PR TITLE
[codex] Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0]
+
+### Added
+- Worktree setup scripts can now run per project/worktree, giving agents a first-class way to prepare dependencies and local environment before starting work. (#126)
+- Mermaid diagrams render directly in markdown responses. (#128)
+- Chat titles and worktree branches can be generated from the first user message, making new agent runs easier to scan and easier to identify in git. (#129)
+- GPT-5.5 Codex is available in the Codex model picker. (#130)
+- Chat rows now include state icons for faster scanning across idle, running, and attention-needed sessions. (#132)
+- Agent completion sounds and deeper permission diagnostics make long-running work and blocked permission flows easier to notice and debug. (#133)
+- Agent message queue persistence keeps queued follow-up messages across renderer/server restarts and improves queue handling for multi-message agent workflows. (#136)
+- Chats now track read/unread state, with Next unread navigation for moving through updated sessions quickly. (#137)
+- Pokémon worktree Pokédex gives the new Pokémon-named worktree system a dedicated browsing surface. (#140)
+- Code annotations composer adds a richer composer path for referencing and annotating source code while prompting agents. (#141)
+- Public Memoize landing site. (#142)
+
+### Changed
+- Grok auth noise is hidden more aggressively and agent activity is grouped for a cleaner timeline. (#127)
+- Claude Ultracode UI is refined so the new model/provider controls fit the rest of the provider experience. (#131)
+- Loaders were standardized around a smoother circle/comet treatment. (#135)
+- Renderer iconography moved from Lucide to Hugeicons Pro, with real provider logos replacing generic marks. (#138)
+- Changes tab cleanup improves file selection, revert flows, conflict handling, and sidebar diff stats. (#139)
+- Renderer surfaces were cleaned up across the app for a tighter, more consistent desktop UI. (#143)
+- Renderer icons were polished after the Hugeicons migration. (#144)
+- Settings UI was cleaned up for a clearer, denser configuration experience. (#145)
+
+### Fixed
+- Permission prompts are now delivered reliably mid-turn, preventing stuck or missed approval flows while an agent is running. (#134)
+
 ## [0.3.3]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "memoize Alpha",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "memoize desktop app",
   "private": true,
   "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- bump the desktop app release version from 0.3.3 to 0.4.0
- add the 0.4.0 changelog covering PRs #126 through #145
- update the Bun lockfile workspace metadata for the desktop package

## Validation
- parsed apps/desktop/package.json and confirmed version 0.4.0
- ran `bun install --lockfile-only --frozen-lockfile`
