### PR TITLE
[codex] Add Vercel web-only ignore config

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+}


### PR DESCRIPTION
## Summary
- add an `apps/web/vercel.json` ignore command for the Vercel web project
- skip Vercel builds when the diff has no changes under the configured `apps/web` root

## Validation
- `bun -e "JSON.parse(await Bun.file('apps/web/vercel.json').text()); console.log('valid json')"`
- `git diff --quiet HEAD^ HEAD -- .` from `apps/web` was checked before commit for the skip-build path on the previous commit comparison
