### PR TITLE
[codex] Wire Hugeicons token into release install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           key: ${{ runner.os }}-electron-builder-${{ hashFiles('**/bun.lock') }}
 
       - name: Install
+        env:
+          # Required by .npmrc for @hugeicons-pro packages.
+          HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
         run: bun install --frozen-lockfile
 
       - name: Build


### PR DESCRIPTION
## Summary
- pass `secrets.HUGEICONS_TOKEN` into the release workflow install step
- lets `.npmrc` authenticate `@hugeicons-pro` packages during tag-driven releases

## Validation
- inspected `.npmrc` and release workflow token usage
- cancelled stuck v0.4.0 release run after it remained in `bun install`
