### PR TITLE
[codex] Increase release build heap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build
+        env:
+          # Renderer bundling pulls in the Hugeicons Pro ESM package and can
+          # exceed Node's default ~2GB heap on the macOS release runner.
+          NODE_OPTIONS: --max-old-space-size=6144
         run: bun run build
 
       - name: Package + sign + notarize + publish


### PR DESCRIPTION
## Summary
- set `NODE_OPTIONS=--max-old-space-size=6144` for the release workflow build step
- prevents the renderer bundle from exhausting Node's default heap after the Hugeicons migration

## Validation
- inspected failed v0.4.0 release logs: renderer build reached JS heap OOM after transforming 18,456 modules
