### PR TITLE
Add direct landing page download

### DIFF
--- a/apps/web/app/download/route.ts
+++ b/apps/web/app/download/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { GITHUB_URL } from "@/lib/site";
+
+const RELEASE_API_URL =
+  "https://api.github.com/repos/swarajbachu/memoize/releases/latest";
+
+type GitHubReleaseAsset = {
+  name?: unknown;
+  browser_download_url?: unknown;
+};
+
+type GitHubRelease = {
+  assets?: unknown;
+};
+
+const FALLBACK_URL = `${GITHUB_URL}/releases`;
+
+export async function GET() {
+  try {
+    const response = await fetch(RELEASE_API_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+      next: { revalidate: 300 },
+    });
+
+    if (!response.ok) {
+      return NextResponse.redirect(FALLBACK_URL);
+    }
+
+    const release = (await response.json()) as GitHubRelease;
+    const assets = Array.isArray(release.assets) ? release.assets : [];
+    const dmg = assets.find((asset): asset is GitHubReleaseAsset => {
+      if (asset === null || typeof asset !== "object") return false;
+
+      const { name, browser_download_url } = asset as GitHubReleaseAsset;
+      return (
+        typeof name === "string" &&
+        typeof browser_download_url === "string" &&
+        name.endsWith(".dmg") &&
+        !name.endsWith(".dmg.blockmap")
+      );
+    });
+
+    if (typeof dmg?.browser_download_url === "string") {
+      return NextResponse.redirect(dmg.browser_download_url);
+    }
+  } catch {
+    // Fall through to the public releases page.
+  }
+
+  return NextResponse.redirect(FALLBACK_URL);
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,6 +2,7 @@ import { getSEO } from "@/lib/seo";
 import { AboutSection } from "@/components/about";
 import { BentoOne } from "@/components/bento-one";
 import { Comparison } from "@/components/comparison";
+import { DownloadShortcut } from "@/components/download-shortcut";
 import { FAQ } from "@/components/faq";
 import { Hero } from "@/components/hero";
 import { LogoCloud } from "@/components/logo-cloud";
@@ -17,6 +18,7 @@ export const metadata = getSEO({
 export default function Home() {
   return (
     <section className="flex max-w-screen overflow-x-hidden flex-col items-center justify-center">
+      <DownloadShortcut />
       <Hero />
       <LogoCloud />
       <BentoOne />

--- a/apps/web/components/download-shortcut.tsx
+++ b/apps/web/components/download-shortcut.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { DOWNLOAD_URL } from "@/lib/site";
+
+const isEditableTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return false;
+
+  const tagName = target.tagName.toLowerCase();
+  return (
+    tagName === "input" ||
+    tagName === "textarea" ||
+    tagName === "select" ||
+    target.isContentEditable
+  );
+};
+
+export const DownloadShortcut = () => {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.shiftKey ||
+        event.key.toLowerCase() !== "d" ||
+        isEditableTarget(event.target)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      window.location.assign(DOWNLOAD_URL);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  return null;
+};

--- a/apps/web/components/footer/index.tsx
+++ b/apps/web/components/footer/index.tsx
@@ -89,8 +89,6 @@ export const Footer = () => {
                 </div>
                 <Link
                   href={DOWNLOAD_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
                   aria-label="Download memoize for Mac"
                   className="bg-primary text-primary-foreground shadow-card-md inline-flex size-12 items-center justify-center rounded-xl"
                 >

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -1,14 +1,12 @@
 // Central place for memoize's brand constants and outbound links so we only
-// edit them once. Swap DOWNLOAD_URL to the direct signed .dmg asset once a
-// release exists.
+// edit them once.
 
 export const SITE_NAME = "memoize";
 
 export const GITHUB_URL = "https://github.com/swarajbachu/memoize";
 
-// Points at the latest GitHub release for now. Replace with the direct
-// `.dmg` download URL when a signed build is published.
-export const DOWNLOAD_URL = `${GITHUB_URL}/releases/latest`;
+// Stable site route that redirects to the latest signed `.dmg`.
+export const DOWNLOAD_URL = "/download";
 
 export const TAGLINE =
   "Token max every coding agent from one local Mac workspace.";


### PR DESCRIPTION
Updates the landing page download flow so CTA links use a stable /download route that redirects to the latest public DMG instead of the GitHub releases page. Adds a plain D keyboard shortcut on the landing page that triggers the same download while ignoring editable fields and modifier-key combos. Also keeps the footer download icon in the same tab now that the link is an internal redirect. Validation: bun run --filter web lint passes; /download locally returned a 307 to the current v0.4.0 DMG. Typecheck/build are still blocked by existing unrelated blog/Fumadocs issues around collections/server and blog page data types.