### PR TITLE
Add context window & usage-limit status popover

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1705,19 +1705,21 @@ function ContextStatusPopover({ session }: { session: Session }) {
                 return (
                   <div
                     key={`${limit.label}-${index}`}
-                    className="flex items-center justify-between gap-3 text-muted-foreground"
+                    className="flex flex-col gap-0.5"
                   >
-                    <span className="truncate text-foreground">
-                      {limit.label}
-                    </span>
-                    <span className="flex shrink-0 items-center gap-2 tabular-nums">
-                      <span>{remaining}</span>
-                      {reset !== null ? (
-                        <span className="text-muted-foreground/50">
-                          resets {reset}
-                        </span>
-                      ) : null}
-                    </span>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="truncate text-foreground">
+                        {limit.label}
+                      </span>
+                      <span className="shrink-0 tabular-nums text-muted-foreground">
+                        {remaining}
+                      </span>
+                    </div>
+                    {reset !== null ? (
+                      <span className="tabular-nums text-muted-foreground/50">
+                        resets {reset}
+                      </span>
+                    ) : null}
                   </div>
                 );
               })}

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -72,7 +72,7 @@ import {
 } from "../store/annotations.ts";
 import { useAttachmentsStore } from "../store/attachments.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
-import { cn } from "~/lib/utils";
+import { cn, formatCompactNumber } from "~/lib/utils";
 import {
   matchBuiltin,
   type BuiltinCommand,
@@ -866,6 +866,7 @@ export function ChatComposer({ session }: { session: Session }) {
                   sessionId={sessionId}
                   current={session.runtimeMode}
                 />
+                <ContextStatusPopover session={session} />
                 <SessionTimer sessionId={sessionId} inFlight={inFlight} />
                 {inFlight ? (
                   <Tooltip>
@@ -1484,6 +1485,243 @@ function ReasoningPicker({
         </MenuGroup>
       </MenuPopup>
     </Menu>
+  );
+}
+
+const contextWindowTokensFromId = (id: string | undefined): number | null => {
+  switch (id?.toLowerCase()) {
+    case "200k":
+      return 200_000;
+    case "1m":
+      return 1_000_000;
+    default:
+      return null;
+  }
+};
+
+const descriptorContextWindowTokens = (
+  providerId: ProviderId,
+  model: string,
+): number | null => {
+  const descriptor = findModelDescriptor(providerId, model);
+  const contextDescriptor = descriptor?.optionDescriptors?.find(
+    (d): d is SelectOptionDescriptor =>
+      d.kind === "select" && d.id === "contextWindow",
+  );
+  return contextWindowTokensFromId(contextDescriptor?.defaultId);
+};
+
+/**
+ * Best-known context window for a session before Claude/Codex report the
+ * exact number — the user's selected window if any, else the model's
+ * default. This is a real capacity (not a fabricated usage figure), so the
+ * control can stay visible from the first message.
+ */
+const selectedContextWindowTokens = (
+  sessionId: SessionId,
+  providerId: ProviderId,
+  model: string,
+): number | null => {
+  if (typeof window === "undefined") {
+    return descriptorContextWindowTokens(providerId, model);
+  }
+  const stored = window.sessionStorage.getItem(
+    `memoize.modelOptions.${sessionId}.contextWindow`,
+  );
+  return (
+    contextWindowTokensFromId(stored ?? undefined) ??
+    descriptorContextWindowTokens(providerId, model)
+  );
+};
+
+const formatTokens = (value: number): string => {
+  const formatted = formatCompactNumber(value);
+  return formatted.endsWith("m") || formatted.endsWith("k")
+    ? formatted
+    : `${formatted}`;
+};
+
+const resetLabel = (date: Date | null): string | null => {
+  if (date === null) return null;
+  const now = new Date();
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (sameDay) {
+    return new Intl.DateTimeFormat([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(date);
+  }
+  return new Intl.DateTimeFormat([], {
+    day: "numeric",
+    month: "short",
+  }).format(date);
+};
+
+function ContextStatusPopover({ session }: { session: Session }) {
+  const messages = useMessagesStore(
+    (s) => s.messagesBySession[session.id] ?? EMPTY_MESSAGES,
+  );
+
+  const latestContext = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const content = messages[i]!.content;
+      if (
+        content._tag === "context_usage" &&
+        content.providerId === session.providerId
+      ) {
+        return content;
+      }
+    }
+    return null;
+  }, [messages, session.providerId]);
+
+  const usageLimits = useMemo(
+    () =>
+      messages
+        .filter(
+          (m) =>
+            m.content._tag === "usage_limit" &&
+            m.content.providerId === session.providerId,
+        )
+        .slice(-2)
+        .map((m) => (m.content._tag === "usage_limit" ? m.content : null))
+        .filter((v): v is NonNullable<typeof v> => v !== null),
+    [messages, session.providerId],
+  );
+
+  // Real numbers only — but the context window itself is a real capacity we
+  // know from the model, so we show it from the first message and fill in
+  // the live bar once Claude/Codex report exact usage.
+  const usedTokens = latestContext?.usedTokens ?? null;
+  const windowTokens =
+    latestContext?.windowTokens ??
+    selectedContextWindowTokens(session.id, session.providerId, session.model);
+
+  const percent =
+    usedTokens !== null && windowTokens !== null && windowTokens > 0
+      ? Math.min(100, (usedTokens / windowTokens) * 100)
+      : null;
+  const freeTokens =
+    usedTokens !== null && windowTokens !== null
+      ? Math.max(0, windowTokens - usedTokens)
+      : null;
+
+  const hasContext = usedTokens !== null || windowTokens !== null;
+  const hasLimits = usageLimits.length > 0;
+  if (!hasContext && !hasLimits) return null;
+
+  const high = percent !== null && percent >= 90;
+  const headerValue =
+    usedTokens !== null && windowTokens !== null
+      ? `${formatTokens(usedTokens)} / ${formatTokens(windowTokens)}`
+      : windowTokens !== null
+        ? formatTokens(windowTokens)
+        : formatTokens(usedTokens!);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            className={cn(
+              "flex h-6 items-center justify-center rounded-md px-2 transition-colors hover:bg-muted/60",
+              high
+                ? "text-amber-400 hover:text-amber-300"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            aria-label="Context and usage status"
+          >
+            <HugeiconsIcon icon={DashboardSpeedIcon} className="size-3.5" />
+          </button>
+        }
+      />
+      <TooltipPopup
+        side="top"
+        align="end"
+        sideOffset={8}
+        className="w-[256px] overflow-hidden rounded-xl border-border bg-popover p-0 text-[13px] shadow-lg"
+      >
+        {hasContext ? (
+          <div className="flex flex-col gap-2.5 p-3">
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="font-medium text-foreground">Context</span>
+              <span className="tabular-nums text-muted-foreground">
+                {headerValue}
+              </span>
+            </div>
+            {percent !== null ? (
+              <>
+                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className={cn(
+                      "h-full rounded-full transition-[width]",
+                      high ? "bg-amber-400" : "bg-foreground",
+                    )}
+                    style={{ width: `${Math.max(percent, 2)}%` }}
+                  />
+                </div>
+                <div className="flex items-center justify-between text-muted-foreground">
+                  <span className="tabular-nums">
+                    {percent.toFixed(1)}% used
+                  </span>
+                  {freeTokens !== null ? (
+                    <span className="tabular-nums">
+                      {formatTokens(freeTokens)} free
+                    </span>
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <div className="text-muted-foreground/70">
+                Usage appears after the first response
+              </div>
+            )}
+          </div>
+        ) : null}
+        {hasLimits ? (
+          <div
+            className={cn(
+              "flex flex-col gap-2 p-3",
+              hasContext && "border-t border-border",
+            )}
+          >
+            <span className="font-medium text-foreground">Usage limits</span>
+            <div className="flex flex-col gap-1.5">
+              {usageLimits.map((limit, index) => {
+                const reset = resetLabel(limit.resetsAt);
+                const remaining =
+                  limit.usedPercent !== null
+                    ? `${Math.max(0, 100 - limit.usedPercent).toFixed(0)}% left`
+                    : "Active";
+                return (
+                  <div
+                    key={`${limit.label}-${index}`}
+                    className="flex items-center justify-between gap-3 text-muted-foreground"
+                  >
+                    <span className="truncate text-foreground">
+                      {limit.label}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2 tabular-nums">
+                      <span>{remaining}</span>
+                      {reset !== null ? (
+                        <span className="text-muted-foreground/50">
+                          resets {reset}
+                        </span>
+                      ) : null}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+      </TooltipPopup>
+    </Tooltip>
   );
 }
 

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1541,8 +1541,10 @@ const formatTokens = (value: number): string => {
     : `${formatted}`;
 };
 
-const resetLabel = (date: Date | null): string | null => {
-  if (date === null) return null;
+const resetLabel = (iso: string | null): string | null => {
+  if (iso === null) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
   const now = new Date();
   const sameDay =
     date.getFullYear() === now.getFullYear() &&

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1550,17 +1550,19 @@ const resetLabel = (iso: string | null): string | null => {
     date.getFullYear() === now.getFullYear() &&
     date.getMonth() === now.getMonth() &&
     date.getDate() === now.getDate();
-  if (sameDay) {
-    return new Intl.DateTimeFormat([], {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    }).format(date);
-  }
-  return new Intl.DateTimeFormat([], {
+  const time = new Intl.DateTimeFormat([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+  // Same day → just the time; otherwise prefix the day so "resets 20 Jun
+  // 08:00" still tells you when, not only which day.
+  if (sameDay) return time;
+  const day = new Intl.DateTimeFormat([], {
     day: "numeric",
     month: "short",
   }).format(date);
+  return `${day} ${time}`;
 };
 
 function ContextStatusPopover({ session }: { session: Session }) {

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1565,6 +1565,43 @@ const resetLabel = (iso: string | null): string | null => {
   return `${day} ${time}`;
 };
 
+/**
+ * Mini donut gauge for the composer status trigger. The faint track is the
+ * full window; the bright arc fills clockwise from the top with the percent
+ * of context used. `percent === null` (no usage reported yet) shows just the
+ * track. Inherits `currentColor`, so it turns amber when the button does.
+ */
+function ContextRing({ percent }: { percent: number | null }) {
+  const r = 6;
+  const circumference = 2 * Math.PI * r;
+  const clamped = Math.min(Math.max(percent ?? 0, 0), 100);
+  return (
+    <svg viewBox="0 0 16 16" fill="none" className="size-3.5 -rotate-90">
+      <circle
+        cx="8"
+        cy="8"
+        r={r}
+        stroke="currentColor"
+        strokeWidth="2"
+        className="opacity-25"
+      />
+      {percent !== null ? (
+        <circle
+          cx="8"
+          cy="8"
+          r={r}
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={circumference * (1 - clamped / 100)}
+          className="transition-[stroke-dashoffset]"
+        />
+      ) : null}
+    </svg>
+  );
+}
+
 function ContextStatusPopover({ session }: { session: Session }) {
   const messages = useMessagesStore(
     (s) => s.messagesBySession[session.id] ?? EMPTY_MESSAGES,
@@ -1640,7 +1677,7 @@ function ContextStatusPopover({ session }: { session: Session }) {
             )}
             aria-label="Context and usage status"
           >
-            <HugeiconsIcon icon={DashboardSpeedIcon} className="size-3.5" />
+            <ContextRing percent={percent} />
           </button>
         }
       />

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -2,7 +2,7 @@ import { PatchDiff } from "@pierre/diffs/react";
 import { Effect } from "effect";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { GitDiffResult } from "@memoize/wire";
+import type { CodeAnnotation, GitDiffResult } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 import { classifyGit } from "../lib/git-rpc.ts";
@@ -132,6 +132,12 @@ function ImageBody({ src, name }: { src: string; name: string }) {
 
 type EditableFile = Extract<OpenFile, { kind: "text" | "external" }>;
 
+// Stable empty reference for the annotations selector. Returning a fresh
+// `[]` literal from a zustand/`useSyncExternalStore` selector fails React's
+// snapshot identity check every render → "getSnapshot should be cached" and
+// an infinite update loop. One shared constant keeps the reference stable.
+const EMPTY_ANNOTATIONS: ReadonlyArray<CodeAnnotation> = [];
+
 function CodeMirrorBody({
   openFile,
   hidden,
@@ -152,7 +158,9 @@ function CodeMirrorBody({
   const revealedAnnotation = useUiStore((s) => s.revealedAnnotation);
   const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
   const draftAnnotations = useAnnotationsStore((s) =>
-    selectedSessionId === null ? [] : (s.bySession[selectedSessionId] ?? []),
+    selectedSessionId === null
+      ? EMPTY_ANNOTATIONS
+      : (s.bySession[selectedSessionId] ?? EMPTY_ANNOTATIONS),
   );
   const selectedSessionIdRef = useRef(selectedSessionId);
   selectedSessionIdRef.current = selectedSessionId;

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -388,6 +388,18 @@ function CodeMirrorBody({
     };
   }, [openFile, reloadCount, setFileDirty]);
 
+  // The editor is created once (mount effect) while its container is still
+  // hidden — during the initial file read, and whenever the tab opens in
+  // diff view. CodeMirror constructed inside a `display:none` subtree
+  // measures zero height and paints nothing; its ResizeObserver doesn't
+  // reliably fire on the later none→visible transition. Force a re-measure
+  // once the editor is both visible and populated so the content shows.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (view === null || hidden || state.status !== "text") return;
+    view.requestMeasure();
+  }, [hidden, state.status]);
+
   useEffect(() => {
     const view = viewRef.current;
     if (view === null || state.status !== "text") return;

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -158,6 +158,10 @@ export function MessageRow({
       // The paired `user_question` row above renders the answer inline, so
       // the standalone answer row is suppressed.
       return null;
+    case "usage":
+    case "context_usage":
+    case "usage_limit":
+      return null;
     case "error":
       return (
         <ErrorBubble

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -210,7 +210,6 @@ const scrubInheritedClaudeMarkers = (
   return next;
 };
 
-
 /**
  * Per-turn accumulator for thinking_delta / redacted_thinking blocks. The
  * SDK delivers raw `content_block_*` events when `includePartialMessages`
@@ -266,6 +265,14 @@ interface TranslateState {
    * persists the new mode and the chip auto-untoggles.
    */
   exitPlanModeIds: Set<string>;
+  /**
+   * Tokens occupying the context window after the most recent top-level
+   * assistant turn (`input + cache_read + cache_creation + output`). The
+   * per-request `usage` on an assistant message is the truest snapshot of
+   * current context fill; we stash it here and emit an exact `ContextUsage`
+   * when the turn's `result` lands (which carries the real `contextWindow`).
+   */
+  lastContextUsedTokens: number | null;
 }
 
 const newTranslateState = (): TranslateState => ({
@@ -275,10 +282,12 @@ const newTranslateState = (): TranslateState => ({
   latestParentItemId: undefined,
   askUserQuestionIds: new Set(),
   exitPlanModeIds: new Set(),
+  lastContextUsedTokens: null,
 });
 
 const isAgentToolUse = (block: { type?: string; name?: string }): boolean =>
-  block.type === "tool_use" && (block.name === "Agent" || block.name === "Task");
+  block.type === "tool_use" &&
+  (block.name === "Agent" || block.name === "Task");
 
 const extractTextFromContent = (content: unknown): string => {
   if (typeof content === "string") return content;
@@ -324,6 +333,91 @@ const summarize = (value: unknown, max = 200): string => {
 };
 
 /**
+ * Pull the real context-window size out of a `result` message's
+ * `modelUsage` map. Prefers the model that produced the result; falls back
+ * to the largest window present (sub-agents on smaller models can pollute
+ * the map). Returns `null` when the SDK omits it.
+ */
+const contextWindowFromModelUsage = (
+  msg: SDKMessage,
+  model: string,
+): number | null => {
+  const modelUsage = (
+    msg as { modelUsage?: Record<string, { contextWindow?: unknown }> }
+  ).modelUsage;
+  if (modelUsage === undefined) return null;
+  const windowOf = (entry: { contextWindow?: unknown } | undefined) =>
+    typeof entry?.contextWindow === "number" && entry.contextWindow > 0
+      ? entry.contextWindow
+      : null;
+  const exact = windowOf(modelUsage[model]);
+  if (exact !== null) return exact;
+  let max: number | null = null;
+  for (const entry of Object.values(modelUsage)) {
+    const w = windowOf(entry);
+    if (w !== null && (max === null || w > max)) max = w;
+  }
+  return max;
+};
+
+interface ClaudeRateLimitInfo {
+  readonly status?: string;
+  readonly resetsAt?: number;
+  readonly rateLimitType?: string;
+  readonly utilization?: number;
+}
+
+const CLAUDE_LIMIT_LABELS: Record<string, string> = {
+  five_hour: "5-hour limit",
+  seven_day: "Weekly limit",
+  seven_day_opus: "Weekly limit (Opus)",
+  seven_day_sonnet: "Weekly limit (Sonnet)",
+  overage: "Overage",
+};
+
+const CLAUDE_LIMIT_WINDOW_MINUTES: Record<string, number> = {
+  five_hour: 5 * 60,
+  seven_day: 7 * 24 * 60,
+  seven_day_opus: 7 * 24 * 60,
+  seven_day_sonnet: 7 * 24 * 60,
+};
+
+/**
+ * Map a subscription `rate_limit_event` into a `UsageLimit` event. Only
+ * fires for claude.ai subscription sessions; API-key sessions never emit
+ * it. `utilization` arrives as a 0–1 fraction or a 0–100 percent depending
+ * on SDK version, so normalise defensively.
+ */
+const claudeRateLimitEvents = (
+  info: ClaudeRateLimitInfo,
+): ReadonlyArray<AgentEvent> => {
+  const type = info.rateLimitType;
+  if (type === undefined) return [];
+  const utilization =
+    typeof info.utilization === "number" ? info.utilization : null;
+  const usedPercent =
+    utilization === null
+      ? null
+      : utilization <= 1
+        ? utilization * 100
+        : utilization;
+  const resetsAt =
+    typeof info.resetsAt === "number" && Number.isFinite(info.resetsAt)
+      ? new Date(info.resetsAt > 1e12 ? info.resetsAt : info.resetsAt * 1000)
+      : null;
+  return [
+    {
+      _tag: "UsageLimit",
+      providerId: "claude",
+      label: CLAUDE_LIMIT_LABELS[type] ?? "Usage limit",
+      usedPercent,
+      resetsAt,
+      windowMinutes: CLAUDE_LIMIT_WINDOW_MINUTES[type] ?? null,
+    },
+  ];
+};
+
+/**
  * Translate one SDKMessage into zero-or-more wire AgentEvents. Mostly
  * stateless, but the `state` carries thinking-delta accumulators across
  * `stream_event` messages so we can emit one Thinking event per content
@@ -360,6 +454,23 @@ const translate = (
     if (parentItemId !== undefined) {
       const pending = state.pendingAgents.get(parentItemId);
       if (pending !== undefined) pending.turnCount += 1;
+    } else {
+      // Top-level turn: snapshot how full the context window is. The
+      // per-request `usage` is what was actually sent to (input + cache)
+      // plus generated this request (output) — i.e. the live occupancy.
+      const usage = (msg.message as { usage?: Record<string, unknown> }).usage;
+      if (usage !== undefined) {
+        const tok = (key: string): number => {
+          const v = usage[key];
+          return typeof v === "number" ? v : 0;
+        };
+        const used =
+          tok("input_tokens") +
+          tok("cache_read_input_tokens") +
+          tok("cache_creation_input_tokens") +
+          tok("output_tokens");
+        if (used > 0) state.lastContextUsedTokens = used;
+      }
     }
     if (Array.isArray(content)) {
       for (const block of content) {
@@ -516,8 +627,7 @@ const translate = (
       }
       const acc = state.thinkingByIndex.get(index);
       if (delta.type === "thinking_delta") {
-        const chunk =
-          typeof delta.thinking === "string" ? delta.thinking : "";
+        const chunk = typeof delta.thinking === "string" ? delta.thinking : "";
         tlog("stream_event.thinking_delta", {
           index,
           chunkLen: chunk.length,
@@ -527,8 +637,7 @@ const translate = (
         if (acc !== undefined) acc.text += chunk;
       } else if (delta.type === "signature_delta") {
         // signatures confirm thinking happened even when text is empty
-        const sig =
-          typeof delta.signature === "string" ? delta.signature : "";
+        const sig = typeof delta.signature === "string" ? delta.signature : "";
         tlog("stream_event.signature_delta", { index, sigLen: sig.length });
         if (acc !== undefined) acc.signatureLength += sig.length;
       } else if (
@@ -615,10 +724,8 @@ const translate = (
           // fall back to a fresh id only if the SDK omits it (shouldn't
           // happen for valid tool_result blocks).
           const id =
-            typeof (block as { tool_use_id?: unknown }).tool_use_id ===
-            "string"
-              ? ((block as { tool_use_id: string })
-                  .tool_use_id as AgentItemId)
+            typeof (block as { tool_use_id?: unknown }).tool_use_id === "string"
+              ? ((block as { tool_use_id: string }).tool_use_id as AgentItemId)
               : nextItemId();
           // Suppress tool_result rows for AskUserQuestion — the answer is
           // already persisted as a `user_question_answer` row via
@@ -681,7 +788,7 @@ const translate = (
       | undefined;
     const modelOnResult =
       typeof (msg as unknown as { model?: unknown }).model === "string"
-        ? ((msg as unknown as { model: string }).model)
+        ? (msg as unknown as { model: string }).model
         : "unknown";
     if (usage !== undefined) {
       const num = (key: string): number => {
@@ -702,6 +809,19 @@ const translate = (
     // A sub-agent's `result` does NOT close the parent's turn — the SDK
     // continues running until the parent emits its own top-level result.
     if (parentItemId === undefined) {
+      // Emit the exact context occupancy for the turn. The real window
+      // comes from `modelUsage[model].contextWindow`; the used tokens are
+      // the snapshot stashed from the last top-level assistant message.
+      if (state.lastContextUsedTokens !== null) {
+        out.push({
+          _tag: "ContextUsage",
+          providerId: "claude",
+          usedTokens: state.lastContextUsedTokens,
+          windowTokens: contextWindowFromModelUsage(msg, modelOnResult),
+          precision: "exact",
+          source: "Claude usage",
+        });
+      }
       out.push(
         msg.subtype === "success"
           ? { _tag: "Completed", reason: "ended" }
@@ -709,6 +829,11 @@ const translate = (
       );
     }
     return out;
+  }
+  if ((msg as { type?: unknown }).type === "rate_limit_event") {
+    const info = (msg as { rate_limit_info?: ClaudeRateLimitInfo })
+      .rate_limit_info;
+    return info === undefined ? [] : claudeRateLimitEvents(info);
   }
   return [];
 };
@@ -856,9 +981,8 @@ const policyFor = (
   }
   // 1. Sensitive paths — checked before any auto-allow. Even YOLO mode prompts.
   if (toolName === "Read") {
-    const path = typeof toolInput.file_path === "string"
-      ? toolInput.file_path
-      : "";
+    const path =
+      typeof toolInput.file_path === "string" ? toolInput.file_path : "";
     if (path.length > 0 && isSensitivePath(path)) {
       return { kind: "prompt", forcePrompt: true };
     }
@@ -909,9 +1033,10 @@ const kindForTool = (
 ): PermissionKind => {
   switch (toolName) {
     case "Bash": {
-      const command = typeof toolInput.command === "string"
-        ? toolInput.command
-        : JSON.stringify(toolInput);
+      const command =
+        typeof toolInput.command === "string"
+          ? toolInput.command
+          : JSON.stringify(toolInput);
       return { _tag: "Bash", command };
     }
     case "Edit":
@@ -1071,7 +1196,11 @@ export const startClaudeSession = (
   // doesn't compose across distinct shapes in an array.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extraTools: ReadonlyArray<any> = [],
-): Effect.Effect<ClaudeSessionHandle, AgentSessionStartError, AttachmentService> =>
+): Effect.Effect<
+  ClaudeSessionHandle,
+  AgentSessionStartError,
+  AttachmentService
+> =>
   Effect.gen(function* () {
     const attachments = yield* AttachmentService;
     const events = yield* Mailbox.make<AgentEvent>();
@@ -1222,11 +1351,12 @@ export const startClaudeSession = (
           questions: userQuestions,
           parentItemId: translateState.latestParentItemId,
         });
-        const answers = await new Promise<
-          ReadonlyArray<UserQuestionAnswer> | null
-        >((resolve) => {
-          pendingQuestions.set(itemId, resolve);
-        });
+        const answers =
+          await new Promise<ReadonlyArray<UserQuestionAnswer> | null>(
+            (resolve) => {
+              pendingQuestions.set(itemId, resolve);
+            },
+          );
         if (answers === null) {
           return {
             content: [
@@ -1487,7 +1617,11 @@ export const startClaudeSession = (
                 ...attachmentBlocks.map((b) =>
                   b.type === "text"
                     ? { type: "text", textLen: b.text.length }
-                    : { type: b.type, media_type: b.source.media_type, base64Len: b.source.data.length },
+                    : {
+                        type: b.type,
+                        media_type: b.source.media_type,
+                        base64Len: b.source.data.length,
+                      },
                 ),
                 { type: "text", textLen: promptText.length },
               ],

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -403,7 +403,9 @@ const claudeRateLimitEvents = (
         : utilization;
   const resetsAt =
     typeof info.resetsAt === "number" && Number.isFinite(info.resetsAt)
-      ? new Date(info.resetsAt > 1e12 ? info.resetsAt : info.resetsAt * 1000)
+      ? new Date(
+          info.resetsAt > 1e12 ? info.resetsAt : info.resetsAt * 1000,
+        ).toISOString()
       : null;
   return [
     {
@@ -458,7 +460,9 @@ const translate = (
       // Top-level turn: snapshot how full the context window is. The
       // per-request `usage` is what was actually sent to (input + cache)
       // plus generated this request (output) — i.e. the live occupancy.
-      const usage = (msg.message as { usage?: Record<string, unknown> }).usage;
+      const usage = (msg.message as { usage?: unknown }).usage as
+        | Record<string, unknown>
+        | undefined;
       if (usage !== undefined) {
         const tok = (key: string): number => {
           const v = usage[key];

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -396,9 +396,11 @@ const decisionToCodex = (
       ? "accept"
       : "decline";
 
-const codexResetDate = (value: number | null): Date | null => {
+const codexResetDate = (value: number | null): string | null => {
   if (value === null || !Number.isFinite(value)) return null;
-  return new Date(value > 1_000_000_000_000 ? value : value * 1000);
+  return new Date(
+    value > 1_000_000_000_000 ? value : value * 1000,
+  ).toISOString();
 };
 
 const codexLimitLabel = (value: string | null): string =>
@@ -608,7 +610,8 @@ export const translateCodexStatusNotification = (
           _tag: "ContextUsage",
           providerId: "codex",
           usedTokens: notification.params.tokenUsage.total.totalTokens,
-          windowTokens: notification.params.tokenUsage.modelContextWindow ?? null,
+          windowTokens:
+            notification.params.tokenUsage.modelContextWindow ?? null,
           precision: "exact",
           source: "Codex app-server",
         },

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -396,6 +396,14 @@ const decisionToCodex = (
       ? "accept"
       : "decline";
 
+const codexResetDate = (value: number | null): Date | null => {
+  if (value === null || !Number.isFinite(value)) return null;
+  return new Date(value > 1_000_000_000_000 ? value : value * 1000);
+};
+
+const codexLimitLabel = (value: string | null): string =>
+  value !== null && value.trim().length > 0 ? value.trim() : "Codex usage";
+
 interface CodexToolTranslationLogger {
   readonly path: string;
   readonly append: (
@@ -585,6 +593,43 @@ export const translateCodexItem = (
       ];
     default:
       return [];
+  }
+};
+
+export const translateCodexStatusNotification = (
+  notification: ServerNotification,
+  activeThreadId: string | null,
+): ReadonlyArray<AgentEvent> | null => {
+  switch (notification.method) {
+    case "thread/tokenUsage/updated":
+      if (notification.params.threadId !== activeThreadId) return [];
+      return [
+        {
+          _tag: "ContextUsage",
+          providerId: "codex",
+          usedTokens: notification.params.tokenUsage.total.totalTokens,
+          windowTokens: notification.params.tokenUsage.modelContextWindow ?? null,
+          precision: "exact",
+          source: "Codex app-server",
+        },
+      ];
+    case "account/rateLimits/updated": {
+      const limits = notification.params.rateLimits;
+      const primary = limits.primary;
+      if (primary === null) return [];
+      return [
+        {
+          _tag: "UsageLimit",
+          providerId: "codex",
+          label: codexLimitLabel(limits.limitName),
+          usedPercent: primary.usedPercent,
+          resetsAt: codexResetDate(primary.resetsAt),
+          windowMinutes: primary.windowDurationMins,
+        },
+      ];
+    }
+    default:
+      return null;
   }
 };
 
@@ -1011,6 +1056,12 @@ export const startCodexSession = (
     function translateNotification(
       notification: ServerNotification,
     ): ReadonlyArray<AgentEvent> {
+      const statusEvents = translateCodexStatusNotification(
+        notification,
+        activeThreadId,
+      );
+      if (statusEvents !== null) return statusEvents;
+
       switch (notification.method) {
         case "thread/started":
           activeThreadId = notification.params.thread.id;

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -303,6 +303,9 @@ const parentItemIdOfContent = (content: MessageContent): string | null => {
     case "user_question":
     case "user_question_answer":
       return content.parentItemId ?? null;
+    case "context_usage":
+    case "usage_limit":
+      return null;
     case "subagent_summary":
       // The summary row IS the wrapper; it sits at the top level next to
       // its `Agent` tool_use. No parent.
@@ -328,6 +331,8 @@ const roleForContent = (content: MessageContent): MessageRole => {
       return "tool";
     case "error":
     case "usage":
+    case "context_usage":
+    case "usage_limit":
       return "system";
   }
 };
@@ -390,6 +395,24 @@ const eventToContent = (event: AgentEvent): MessageContent | null => {
         cacheReadTokens: event.cacheReadTokens,
         cacheCreationTokens: event.cacheCreationTokens,
         model: event.model,
+      };
+    case "ContextUsage":
+      return {
+        _tag: "context_usage",
+        providerId: event.providerId,
+        usedTokens: event.usedTokens,
+        windowTokens: event.windowTokens,
+        precision: event.precision,
+        source: event.source,
+      };
+    case "UsageLimit":
+      return {
+        _tag: "usage_limit",
+        providerId: event.providerId,
+        label: event.label,
+        usedPercent: event.usedPercent,
+        resetsAt: event.resetsAt,
+        windowMinutes: event.windowMinutes,
       };
     case "Error":
       return { _tag: "error", message: event.message };

--- a/apps/server/test/codex-translate.test.ts
+++ b/apps/server/test/codex-translate.test.ts
@@ -7,6 +7,7 @@ import type { ThreadItem } from "../src/provider/codex-app-protocol/v2/ThreadIte
 import {
   codexWritableRootsForCwd,
   translateCodexItem,
+  translateCodexStatusNotification,
 } from "../src/provider/drivers/codex.ts";
 
 const tags = (events: ReadonlyArray<AgentEvent>): string[] =>
@@ -138,6 +139,86 @@ describe("translateCodexItem", () => {
 
     const ev = only(translateCodexItem(item, "started"), "ToolUse");
     expect(ev.tool).toBe("mcp__memoize__browser_screenshot");
+  });
+
+  it("renders context compaction as a compacted message", () => {
+    const item: ThreadItem = { type: "contextCompaction", id: "compact1" };
+
+    const ev = only(translateCodexItem(item, "completed"), "AssistantMessage");
+    expect(ev.text).toBe("Conversation context compacted.");
+  });
+});
+
+describe("translateCodexStatusNotification", () => {
+  it("maps token usage notifications to exact context usage", () => {
+    const ev = only(
+      translateCodexStatusNotification(
+        {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread1",
+            turnId: "turn1",
+            tokenUsage: {
+              total: {
+                totalTokens: 231_700,
+                inputTokens: 220_000,
+                cachedInputTokens: 0,
+                outputTokens: 10_000,
+                reasoningOutputTokens: 1_700,
+              },
+              last: {
+                totalTokens: 1_000,
+                inputTokens: 800,
+                cachedInputTokens: 0,
+                outputTokens: 200,
+                reasoningOutputTokens: 0,
+              },
+              modelContextWindow: 258_400,
+            },
+          },
+        },
+        "thread1",
+      ) ?? [],
+      "ContextUsage",
+    );
+
+    expect(ev.providerId).toBe("codex");
+    expect(ev.usedTokens).toBe(231_700);
+    expect(ev.windowTokens).toBe(258_400);
+    expect(ev.precision).toBe("exact");
+  });
+
+  it("maps account rate-limit notifications to usage limits", () => {
+    const ev = only(
+      translateCodexStatusNotification(
+        {
+          method: "account/rateLimits/updated",
+          params: {
+            rateLimits: {
+              limitId: "primary",
+              limitName: "Codex weekly",
+              primary: {
+                usedPercent: 42,
+                windowDurationMins: 10_080,
+                resetsAt: 1_800_000_000,
+              },
+              secondary: null,
+              credits: null,
+              planType: null,
+              rateLimitReachedType: null,
+            },
+          },
+        },
+        "thread1",
+      ) ?? [],
+      "UsageLimit",
+    );
+
+    expect(ev.providerId).toBe("codex");
+    expect(ev.label).toBe("Codex weekly");
+    expect(ev.usedPercent).toBe(42);
+    expect(ev.windowMinutes).toBe(10_080);
+    expect(ev.resetsAt?.toISOString()).toBe("2027-01-15T08:00:00.000Z");
   });
 });
 

--- a/apps/server/test/codex-translate.test.ts
+++ b/apps/server/test/codex-translate.test.ts
@@ -66,13 +66,13 @@ describe("translateCodexItem", () => {
           path: "/repo/package.json",
         },
       ],
-      aggregatedOutput: "{\n  \"name\": \"desktop\"\n}\n",
+      aggregatedOutput: '{\n  "name": "desktop"\n}\n',
       exitCode: 0,
       durationMs: 12,
     };
 
     const ev = only(translateCodexItem(item, "completed"), "ToolResult");
-    expect(ev.output).toBe("{\n  \"name\": \"desktop\"\n}\n");
+    expect(ev.output).toBe('{\n  "name": "desktop"\n}\n');
   });
 
   it("falls back to Bash for ordinary command execution", () => {
@@ -218,7 +218,7 @@ describe("translateCodexStatusNotification", () => {
     expect(ev.label).toBe("Codex weekly");
     expect(ev.usedPercent).toBe(42);
     expect(ev.windowMinutes).toBe(10_080);
-    expect(ev.resetsAt?.toISOString()).toBe("2027-01-15T08:00:00.000Z");
+    expect(ev.resetsAt).toBe("2027-01-15T08:00:00.000Z");
   });
 });
 

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -455,7 +455,10 @@ const UsageLimitEvent = Schema.TaggedStruct("UsageLimit", {
   providerId: ProviderId,
   label: Schema.String,
   usedPercent: Schema.NullOr(Schema.Number),
-  resetsAt: Schema.NullOr(Schema.DateFromString),
+  // ISO-8601 string, not a `Date` schema: the value crosses IPC and the
+  // persistence layer as JSON, and a `DateFromString` transform trips the
+  // struct constructor (which validates against the decoded `Date` side).
+  resetsAt: Schema.NullOr(Schema.String),
   windowMinutes: Schema.NullOr(Schema.Number),
 });
 

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -436,6 +436,29 @@ const UsageDeltaEvent = Schema.TaggedStruct("UsageDelta", {
   model: Schema.String,
 });
 
+export const ContextUsagePrecision = Schema.Literal(
+  "exact",
+  "estimated",
+  "capacity-only",
+);
+export type ContextUsagePrecision = typeof ContextUsagePrecision.Type;
+
+const ContextUsageEvent = Schema.TaggedStruct("ContextUsage", {
+  providerId: ProviderId,
+  usedTokens: Schema.NullOr(Schema.Number),
+  windowTokens: Schema.NullOr(Schema.Number),
+  precision: ContextUsagePrecision,
+  source: Schema.optional(Schema.String),
+});
+
+const UsageLimitEvent = Schema.TaggedStruct("UsageLimit", {
+  providerId: ProviderId,
+  label: Schema.String,
+  usedPercent: Schema.NullOr(Schema.Number),
+  resetsAt: Schema.NullOr(Schema.DateFromString),
+  windowMinutes: Schema.NullOr(Schema.Number),
+});
+
 const CompletedEvent = Schema.TaggedStruct("Completed", {
   reason: Schema.Literal("ended", "interrupted", "error"),
 });
@@ -547,6 +570,8 @@ export const AgentEvent = Schema.Union(
   PermissionRequestEvent,
   SubagentSummaryEvent,
   UsageDeltaEvent,
+  ContextUsageEvent,
+  UsageLimitEvent,
   SessionCursorEvent,
   UserQuestionEvent,
   PermissionModeChangedEvent,
@@ -735,6 +760,17 @@ const claudeContextWindowDescriptor = (): SelectOptionDescriptor => ({
     { id: "1m", label: "1M" },
   ],
   defaultId: "1m",
+});
+
+const staticContextWindowDescriptor = (
+  id: string,
+  label: string,
+): SelectOptionDescriptor => ({
+  kind: "select",
+  id: "contextWindow",
+  label: "Context Window",
+  options: [{ id, label }],
+  defaultId: id,
 });
 
 export const MODELS_BY_PROVIDER: Record<
@@ -960,8 +996,18 @@ export const MODELS_BY_PROVIDER: Record<
     { id: "composer-2.5", label: "Composer 2.5", supportsPlanMode: true },
     { id: "gpt-5.5", label: "GPT-5.5", supportsPlanMode: true },
     { id: "gpt-5.3-codex", label: "Codex 5.3", supportsPlanMode: true },
-    { id: "claude-sonnet-4-6", label: "Sonnet 4.6", supportsPlanMode: true },
-    { id: "claude-opus-4-7", label: "Opus 4.7", supportsPlanMode: true },
+    {
+      id: "claude-sonnet-4-6",
+      label: "Sonnet 4.6",
+      optionDescriptors: [staticContextWindowDescriptor("1m", "1M")],
+      supportsPlanMode: true,
+    },
+    {
+      id: "claude-opus-4-7",
+      label: "Opus 4.7",
+      optionDescriptors: [staticContextWindowDescriptor("1m", "1M")],
+      supportsPlanMode: true,
+    },
     { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro", supportsPlanMode: true },
   ],
   // OpenCode is a meta-provider: it spawns a local `opencode serve` and

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -256,7 +256,9 @@ const UsageLimitContent = Schema.TaggedStruct("usage_limit", {
   providerId: ProviderId,
   label: Schema.String,
   usedPercent: Schema.NullOr(Schema.Number),
-  resetsAt: Schema.NullOr(Schema.DateFromString),
+  // ISO-8601 string — see `UsageLimitEvent` in agent.ts for why this isn't
+  // a `Date` schema (constructor validates against the decoded `Date`).
+  resetsAt: Schema.NullOr(Schema.String),
   windowMinutes: Schema.NullOr(Schema.Number),
 });
 

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -3,6 +3,7 @@ import { Schema } from "effect";
 
 import {
   AgentDefinition,
+  ContextUsagePrecision,
   PermissionMode,
   ProviderId,
   RuntimeMode,
@@ -243,6 +244,22 @@ const UsageContent = Schema.TaggedStruct("usage", {
   model: Schema.String,
 });
 
+const ContextUsageContent = Schema.TaggedStruct("context_usage", {
+  providerId: ProviderId,
+  usedTokens: Schema.NullOr(Schema.Number),
+  windowTokens: Schema.NullOr(Schema.Number),
+  precision: ContextUsagePrecision,
+  source: Schema.optional(Schema.String),
+});
+
+const UsageLimitContent = Schema.TaggedStruct("usage_limit", {
+  providerId: ProviderId,
+  label: Schema.String,
+  usedPercent: Schema.NullOr(Schema.Number),
+  resetsAt: Schema.NullOr(Schema.DateFromString),
+  windowMinutes: Schema.NullOr(Schema.Number),
+});
+
 /**
  * Persisted form of a `UserQuestion` event. `itemId` is the SDK's
  * `tool_use.id` for the AskUserQuestion call; the paired
@@ -288,6 +305,8 @@ export const MessageContent = Schema.Union(
   ErrorContent,
   SubagentSummaryContent,
   UsageContent,
+  ContextUsageContent,
+  UsageLimitContent,
   UserQuestionContent,
   UserQuestionAnswerContent,
 );


### PR DESCRIPTION
## What

Adds a composer status popover that surfaces **live context-window usage** and **subscription usage limits**, using exact numbers reported by the providers rather than renderer-side estimates.

![context popover](https://github.com/user-attachments/assets/placeholder)

## Where the data comes from

The per-category breakdown (Free space / MCP tools / Messages / Skills …) shown in Claude Code's native `/context` is computed internally by the TUI and is **not** exposed over the Agent SDK — only aggregate totals are. So this surfaces the honest totals:

- **Claude** — exact context occupancy from each top-level assistant message's `usage` (`input + cache_read + cache_creation + output`), paired with the real window from `modelUsage[model].contextWindow`. Subscription `rate_limit_event`s map to usage limits.
- **Codex** — `ContextUsage` / `UsageLimit` from the app-server's token + rate-limit notifications.

## Changes

- **wire** — new `ContextUsage` / `UsageLimit` agent events and persisted message content.
- **claude driver** — emit exact `ContextUsage` on turn end; map `rate_limit_event` → `UsageLimit`.
- **codex driver** — emit `ContextUsage` / `UsageLimit` from notifications.
- **renderer** — `ContextStatusPopover`:
  - Shows the real **window capacity** from the first message, fills in the live bar + `% used` / `free` once exact usage lands.
  - Hides cleanly when there's nothing real to show; never hides just because one number is missing.
  - `usage` / `context_usage` / `usage_limit` rows are non-rendering in the message list.

## Testing

- `bun run check-types` — passes (pre-existing `web`/blog errors unrelated).
- `bun run test --filter=@memoize/server` — 116 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)