### PR TITLE
Make right sidebar a customizable panel dock

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -404,7 +404,12 @@ function MainShell() {
           collapsible
           collapsedSize="0%"
           panelRef={rightPanelRef}
-          onResize={(size) => {
+          onResize={(size, _id, prev) => {
+            // Ignore the initial mount call (prev === undefined). The right
+            // dock defaults to closed (`rightSidebarOpen: false`); the
+            // persisted/default panel width would otherwise fire here and
+            // flip the sidebar open before the collapse effect runs.
+            if (prev === undefined) return;
             const open = size.asPercentage > 0;
             if (open !== rightSidebarOpen) setRightSidebarOpen(open);
           }}

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -135,10 +135,10 @@ export function BrowserPane() {
     const executeBrowserCommand = async (
       req: BrowserCommandRequest,
     ): Promise<void> => {
-      // Always surface the action: force the Browser tab visible. This also
-      // un-hides the webview so `capturePage` works (it returns an empty
-      // image for a `display:none` element).
-      useUiStore.getState().setActiveRightTab("browser");
+      // Always surface the action: open the sidebar and force the Browser
+      // panel visible+active. This also un-hides the webview so `capturePage`
+      // works (it returns an empty image for a `display:none` element).
+      useUiStore.getState().revealPanel("browser");
       const wv = webviewRef.current as WebviewElement | null;
       const result = await runBrowserCommand(req, wv, {
         setUrl,

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -289,8 +289,7 @@ export function ChatComposer({ session }: { session: Session }) {
   const setModel = useSessionsStore((s) => s.setModel);
   const setRuntimeMode = useSessionsStore((s) => s.setRuntimeMode);
   const setPermissionMode = useSessionsStore((s) => s.setPermissionMode);
-  const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
-  const setActiveRightTab = useUiStore((s) => s.setActiveRightTab);
+  const revealPanel = useUiStore((s) => s.revealPanel);
   const setView = useUiStore((s) => s.setView);
   const setSettingsSection = useUiStore((s) => s.setSettingsSection);
   const workspaceRoot = useActiveWorkspaceRoot(session.projectId);
@@ -431,8 +430,7 @@ export function ChatComposer({ session }: { session: Session }) {
         }
         break;
       case "diff":
-        setRightSidebarOpen(true);
-        setActiveRightTab("changes");
+        revealPanel("changes");
         break;
       case "copy": {
         const latest = [...(sessionMessages ?? [])]

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -1,12 +1,32 @@
-import { Folder01Icon, GitBranchIcon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  ComputerTerminal01Icon,
+  Folder01Icon,
+  GitBranchIcon,
+  GitCompareIcon,
+  GlobeIcon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import { GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { Plus, X } from "lucide-react";
+
+import type { FolderId, WorktreeId } from "@memoize/wire";
 
 import { formatShortcut } from "../lib/shortcuts.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
-import { useUiStore } from "../store/ui.ts";
+import {
+  EMPTY_TERMINALS,
+  terminalsKey,
+  useTerminalsStore,
+} from "../store/terminals.ts";
+import {
+  type PanelInstance,
+  type PanelKind,
+  SINGLETON_PANEL_KINDS,
+  useUiStore,
+} from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { BrowserPane } from "./browser-pane.tsx";
@@ -14,15 +34,70 @@ import { DiffPane } from "./diff-pane.tsx";
 import { FileTree } from "./file-tree.tsx";
 import { PrPane } from "./pr-pane.tsx";
 import { PokemonRarityText, PokemonSprite } from "./pokemon.tsx";
-import { RightPaneHeader } from "./right-pane-header.tsx";
-import { TerminalPane } from "./terminal-pane.tsx";
+import { TerminalSlotPane } from "./terminal-pane.tsx";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuShortcut,
+  MenuTrigger,
+} from "./ui/menu.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 /**
- * Right-pane shell with four tabs: file tree, terminal, changes
- * (working-tree + commit composer), and PR detail. All children mount once
- * and stay mounted (`hidden` toggling) so switching tabs preserves terminal
- * scrollback, file-tree expansion, and any in-flight PR fetch.
+ * Metadata for each addable panel kind: launcher/tab label, icon, and the
+ * keyboard shortcut to surface (only Terminal has one today).
+ */
+const PANEL_META: Record<
+  PanelKind,
+  {
+    readonly label: string;
+    readonly icon: Parameters<typeof HugeiconsIcon>[0]["icon"];
+    readonly shortcut?: string;
+  }
+> = {
+  files: { label: "Files", icon: Folder01Icon },
+  terminal: {
+    label: "Terminal",
+    icon: ComputerTerminal01Icon,
+    shortcut: formatShortcut("toggle-terminal"),
+  },
+  changes: { label: "Changes", icon: GitCompareIcon },
+  pr: { label: "PR", icon: GitPullRequestIcon },
+  browser: { label: "Browser", icon: GlobeIcon },
+};
+
+/** Display order shared by the launcher and the "+" menu. */
+const PANEL_ORDER: ReadonlyArray<PanelKind> = [
+  "files",
+  "terminal",
+  "changes",
+  "pr",
+  "browser",
+];
+
+/**
+ * Kinds the user can still add: every kind, minus singletons that are
+ * already open. Terminal is always offered (multi-instance).
+ */
+function addableKinds(
+  panels: ReadonlyArray<PanelInstance>,
+): ReadonlyArray<PanelKind> {
+  const openSingletons = new Set(
+    panels.filter((p) => SINGLETON_PANEL_KINDS.has(p.kind)).map((p) => p.kind),
+  );
+  return PANEL_ORDER.filter(
+    (k) => k === "terminal" || !openSingletons.has(k),
+  );
+}
+
+/**
+ * Right-pane dock. The panel set is user-managed: nothing is shown until the
+ * user adds a panel from the launcher (empty state) or the trailing "+" menu.
+ * Terminal can be added multiple times (each its own tab); Files / Changes /
+ * PR / Browser are singletons. All open panels mount once and stay mounted
+ * (`hidden` toggling) so switching tabs preserves terminal scrollback,
+ * file-tree expansion, the browser webview, and any in-flight PR fetch.
  */
 export function RightPane() {
   const ctx = useActiveContext();
@@ -47,79 +122,293 @@ export function RightPane() {
       ? (s.byKey[prDetailsKey(selectedFolderId, worktreeId)] ?? null)
       : null,
   );
-  const tab = useUiStore((s) => s.activeRightTab);
-  const setTab = useUiStore((s) => s.setActiveRightTab);
+  // Terminal tab titles are sourced from the active workspace's terminal
+  // list (slot → instance) so multiple terminal tabs read "zsh", "zsh 2".
+  const termList = useTerminalsStore((s) =>
+    selectedFolderId
+      ? (s.byKey[terminalsKey(selectedFolderId, worktreeId)] ?? EMPTY_TERMINALS)
+      : EMPTY_TERMINALS,
+  );
+
+  const panels = useUiStore((s) => s.rightPanels);
+  const activeId = useUiStore((s) => s.activeRightPanelId);
+  const addPanel = useUiStore((s) => s.addPanel);
+  const closePanel = useUiStore((s) => s.closePanel);
+  const setActive = useUiStore((s) => s.setActiveRightPanel);
+
+  // Defensive: if the stored active id ever points at a closed panel, fall
+  // back to the first one so exactly one panel body is visible.
+  const effectiveActiveId =
+    activeId !== null && panels.some((p) => p.id === activeId)
+      ? activeId
+      : (panels[0]?.id ?? null);
+
+  // Closing a terminal tab also drops its backing PTY instance for the
+  // active workspace (the store action is layout-only — it can't know the
+  // active key). `closePanel` then re-indexes remaining terminal slots, so
+  // panels and instances stay aligned.
+  const handleClose = (panel: PanelInstance) => {
+    if (panel.kind === "terminal" && selectedFolderId !== null) {
+      const key = terminalsKey(selectedFolderId, worktreeId);
+      const inst = (
+        useTerminalsStore.getState().byKey[key] ?? EMPTY_TERMINALS
+      )[panel.slot];
+      if (inst !== undefined) {
+        useTerminalsStore.getState().remove(key, inst.id);
+      }
+    }
+    closePanel(panel.id);
+  };
+
+  const tabLabel = (panel: PanelInstance): string =>
+    panel.kind === "terminal"
+      ? (termList[panel.slot]?.title ?? PANEL_META.terminal.label)
+      : PANEL_META[panel.kind].label;
+
+  const tabBadge = (panel: PanelInstance): React.ReactNode => {
+    if (panel.kind === "changes") {
+      return renderChangesBadge(status?.dirtyFiles ?? 0);
+    }
+    if (panel.kind === "pr") return renderPrBadge(pr, details);
+    return null;
+  };
+
+  if (selected === null) {
+    return (
+      <aside className="flex h-full min-h-0 w-full flex-col">
+        <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+          No project selected.
+        </p>
+      </aside>
+    );
+  }
+
+  const activePanel = panels.find((p) => p.id === effectiveActiveId) ?? null;
+  const browserActive = activePanel?.kind === "browser";
 
   return (
     <aside className="flex h-full min-h-0 w-full flex-col">
-      {selected ? <RightPaneHeader projectName={selected.name} /> : null}
-      <div className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border px-1 text-xs">
-        <TabButton
-          active={tab === "files"}
-          onClick={() => setTab("files")}
-          label="Files"
-          tooltip="Browse project files"
-        />
-        <TabButton
-          active={tab === "terminal"}
-          onClick={() => setTab("terminal")}
-          label="Terminal"
-          tooltip="Open a terminal in the project root"
-          shortcut={formatShortcut("toggle-terminal")}
-        />
-        <TabButton
-          active={tab === "changes"}
-          onClick={() => setTab("changes")}
-          label="Changes"
-          tooltip="Working-tree changes + commit"
-          badge={renderChangesBadge(status?.dirtyFiles ?? 0)}
-        />
-        <TabButton
-          active={tab === "pr"}
-          onClick={() => setTab("pr")}
-          label="PR"
-          tooltip="Pull request title, reviews, comments, and CI"
-          badge={renderPrBadge(pr, details)}
-        />
-        <TabButton
-          active={tab === "browser"}
-          onClick={() => setTab("browser")}
-          label="Browser"
-          tooltip="In-app browser for dev servers and references"
-        />
-      </div>
+      {panels.length > 0 ? (
+        <div className="flex h-9 shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border px-1 text-xs">
+          {panels.map((panel) => (
+            <PanelTab
+              key={panel.id}
+              active={panel.id === effectiveActiveId}
+              icon={PANEL_META[panel.kind].icon}
+              label={tabLabel(panel)}
+              badge={tabBadge(panel)}
+              onSelect={() => setActive(panel.id)}
+              onClose={() => handleClose(panel)}
+            />
+          ))}
+          <AddPanelMenu addable={addableKinds(panels)} onAdd={addPanel} />
+        </div>
+      ) : null}
       <div className="flex min-h-0 flex-1 flex-col">
-        {selected === null ? (
-          <p className="px-3 py-6 text-center text-xs text-muted-foreground">
-            No project selected.
-          </p>
-        ) : (
-          <>
+        {panels.length === 0 ? (
+          <PanelLauncher addable={addableKinds(panels)} onAdd={addPanel} />
+        ) : null}
+        {/* Non-browser panels: mount on add, kept mounted while open. */}
+        {panels
+          .filter((panel) => panel.kind !== "browser")
+          .map((panel) => (
             <div
-              hidden={tab !== "files"}
+              key={panel.id}
+              hidden={panel.id !== effectiveActiveId}
               className="flex min-h-0 flex-1 flex-col"
             >
-              <ActiveWorkspaceChip />
-              <div className="min-h-0 flex-1 overflow-y-auto">
-                <FileTree key={selected.id} folderId={selected.id} />
-              </div>
+              <PanelBody
+                panel={panel}
+                folderId={selected.id}
+                worktreeId={worktreeId}
+              />
             </div>
-            <div hidden={tab !== "terminal"} className="min-h-0 flex-1">
-              <TerminalPane />
-            </div>
-            <div hidden={tab !== "changes"} className="min-h-0 flex-1">
-              <DiffPane folderId={selected.id} worktreeId={worktreeId} />
-            </div>
-            <div hidden={tab !== "pr"} className="min-h-0 flex-1">
-              <PrPane folderId={selected.id} worktreeId={worktreeId} />
-            </div>
-            <div hidden={tab !== "browser"} className="min-h-0 flex-1">
-              <BrowserPane />
-            </div>
-          </>
-        )}
+          ))}
+        {/* Browser is always mounted (display:none when not the active tab)
+            so the agent `browser.commands` stream stays alive even with no
+            browser tab open or the sidebar collapsed — a command then calls
+            revealPanel("browser") to surface it. Mounting it only on add
+            would drop commands issued while it's closed. */}
+        <div hidden={!browserActive} className="flex min-h-0 flex-1 flex-col">
+          <BrowserPane />
+        </div>
       </div>
     </aside>
+  );
+}
+
+function PanelBody({
+  panel,
+  folderId,
+  worktreeId,
+}: {
+  panel: PanelInstance;
+  folderId: FolderId;
+  worktreeId: WorktreeId | null;
+}) {
+  switch (panel.kind) {
+    case "files":
+      return (
+        <>
+          <ActiveWorkspaceChip />
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <FileTree key={folderId} folderId={folderId} />
+          </div>
+        </>
+      );
+    case "terminal":
+      return <TerminalSlotPane slot={panel.slot} />;
+    case "changes":
+      return <DiffPane folderId={folderId} worktreeId={worktreeId} />;
+    case "pr":
+      return <PrPane folderId={folderId} worktreeId={worktreeId} />;
+    case "browser":
+      // Browser is rendered once, always-mounted, by RightPane (so the agent
+      // command stream survives close/collapse) — never via this map.
+      return null;
+  }
+}
+
+/**
+ * Empty-state launcher: a vertically-centered list of every addable panel as
+ * a large row (icon + label + shortcut). Shown when the sidebar is open but
+ * no panels have been added yet.
+ */
+function PanelLauncher({
+  addable,
+  onAdd,
+}: {
+  addable: ReadonlyArray<PanelKind>;
+  onAdd: (kind: PanelKind) => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-3">
+      <div className="flex w-full max-w-md flex-col gap-1.5">
+        {addable.map((kind) => {
+          const meta = PANEL_META[kind];
+          return (
+            <button
+              key={kind}
+              type="button"
+              onClick={() => onAdd(kind)}
+              className="flex w-full items-center gap-3 rounded-lg bg-muted/20 px-3 py-3 text-left text-sm text-foreground/90 transition-colors hover:bg-muted/60"
+            >
+              <HugeiconsIcon
+                icon={meta.icon}
+                className="size-4 shrink-0 text-muted-foreground"
+              />
+              <span className="flex-1 truncate">{meta.label}</span>
+              {meta.shortcut !== undefined && meta.shortcut !== "" ? (
+                <kbd className="font-sans text-[11px] text-muted-foreground/70">
+                  {meta.shortcut}
+                </kbd>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Trailing "+" in the tab strip. Lists the kinds the user can still add. */
+function AddPanelMenu({
+  addable,
+  onAdd,
+}: {
+  addable: ReadonlyArray<PanelKind>;
+  onAdd: (kind: PanelKind) => void;
+}) {
+  if (addable.length === 0) return null;
+  return (
+    <Menu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground data-[popup-open]:bg-muted/60"
+              aria-label="Add panel"
+            >
+              <Plus className="size-3.5" strokeWidth={1.8} />
+            </MenuTrigger>
+          }
+        />
+        <TooltipPopup>Add panel</TooltipPopup>
+      </Tooltip>
+      <MenuPopup align="end" className="min-w-44 p-1">
+        {addable.map((kind) => {
+          const meta = PANEL_META[kind];
+          return (
+            <MenuItem
+              key={kind}
+              onClick={() => onAdd(kind)}
+              className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-sm hover:bg-sidebar-accent"
+            >
+              <HugeiconsIcon icon={meta.icon} className="size-3.5 opacity-80" />
+              <span className="min-w-0 flex-1 truncate">{meta.label}</span>
+              {meta.shortcut !== undefined && meta.shortcut !== "" ? (
+                <MenuShortcut>{meta.shortcut}</MenuShortcut>
+              ) : null}
+            </MenuItem>
+          );
+        })}
+      </MenuPopup>
+    </Menu>
+  );
+}
+
+function PanelTab({
+  active,
+  icon,
+  label,
+  badge,
+  onSelect,
+  onClose,
+}: {
+  active: boolean;
+  icon: Parameters<typeof HugeiconsIcon>[0]["icon"];
+  label: string;
+  badge?: React.ReactNode;
+  onSelect: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className={`group flex shrink-0 items-center gap-1 rounded px-1.5 py-1 text-[11px] transition-colors ${
+        active
+          ? "bg-muted text-foreground"
+          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex max-w-36 items-center gap-1.5"
+      >
+        <HugeiconsIcon icon={icon} className="size-3.5 shrink-0 opacity-80" />
+        <span className="truncate">{label}</span>
+        {badge}
+      </button>
+      <span
+        role="button"
+        tabIndex={0}
+        aria-label={`Close ${label}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onClose();
+          }
+        }}
+        className="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-opacity hover:bg-background hover:text-foreground group-hover:opacity-100"
+      >
+        <X className="size-3" strokeWidth={1.8} />
+      </span>
+    </div>
   );
 }
 
@@ -229,52 +518,5 @@ function renderPrBadge(
     <span className="flex min-w-[1rem] items-center justify-center rounded-full bg-muted px-1 font-mono text-[10px] text-foreground">
       {count}
     </span>
-  );
-}
-
-function TabButton({
-  active,
-  onClick,
-  label,
-  tooltip,
-  badge,
-  shortcut,
-}: {
-  active: boolean;
-  onClick: () => void;
-  label: string;
-  tooltip: string;
-  badge?: React.ReactNode;
-  shortcut?: string;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <button
-            type="button"
-            onClick={onClick}
-            className={`flex items-center gap-1.5 rounded px-2 py-1 text-[11px] transition-colors ${
-              active
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            }`}
-          >
-            {label}
-            {badge}
-          </button>
-        }
-      />
-      <TooltipPopup>
-        {shortcut !== undefined && shortcut !== "" ? (
-          <span className="inline-flex items-baseline gap-2 whitespace-nowrap">
-            <span>{tooltip}</span>
-            <kbd className="font-sans text-muted-foreground/80">{shortcut}</kbd>
-          </span>
-        ) : (
-          tooltip
-        )}
-      </TooltipPopup>
-    </Tooltip>
   );
 }

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -75,6 +75,86 @@ export function TerminalPane() {
   );
 }
 
+function TerminalPlaceholder({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-background text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Renders a single terminal for one right-dock tab. The tab carries a
+ * workspace-relative `slot`; this resolves it to the active workspace's Nth
+ * terminal instance (seeding via `ensureSlot`) and mounts one `PtyTerminal`.
+ *
+ * Transitional: on a worktree, slot 0 hosts `WorktreeTerminalPane` so its
+ * Setup/Run/Terminal sub-tabs stay reachable exactly once; extra terminal
+ * tabs (slot ≥ 1) are plain shells. The setup-flow redesign will move setup
+ * out of here and this branch goes away.
+ */
+export function TerminalSlotPane({ slot }: { slot: number }) {
+  const ctx = useActiveContext();
+  const ready = ctx.status === "ready" && !ctx.worktreePending;
+
+  if (ctx.status === "loading") {
+    return <TerminalPlaceholder>Loading workspace…</TerminalPlaceholder>;
+  }
+  if (ctx.status === "empty") {
+    return (
+      <TerminalPlaceholder>
+        No folder selected. Add or pick a folder on the left.
+      </TerminalPlaceholder>
+    );
+  }
+  if (ctx.worktreePending) {
+    return <TerminalPlaceholder>Preparing worktree…</TerminalPlaceholder>;
+  }
+  if (!ready) return null;
+  if (ctx.worktreeId !== null && slot === 0) {
+    return <WorktreeTerminalPane ctx={ctx} worktreeId={ctx.worktreeId} />;
+  }
+  return (
+    <PlainTerminalSlot
+      folderId={ctx.folderId}
+      worktreeId={ctx.worktreeId}
+      rootPath={ctx.rootPath}
+      slot={slot}
+    />
+  );
+}
+
+function PlainTerminalSlot({
+  folderId,
+  worktreeId,
+  rootPath,
+  slot,
+}: {
+  folderId: FolderId;
+  worktreeId: WorktreeId | null;
+  rootPath: string;
+  slot: number;
+}) {
+  const key = terminalsKey(folderId, worktreeId);
+  const list = useTerminalsStore((s) => s.byKey[key] ?? EMPTY_TERMINALS);
+  const ensureSlot = useTerminalsStore((s) => s.ensureSlot);
+
+  useEffect(() => {
+    if (list.length <= slot) ensureSlot(key, slot, rootPath);
+  }, [key, list.length, slot, ensureSlot, rootPath]);
+
+  const inst = list[slot];
+  if (inst === undefined) return null;
+  return (
+    <PtyTerminal
+      folderId={folderId}
+      cwd={inst.cwd}
+      instanceId={inst.id}
+      command={inst.command}
+    />
+  );
+}
+
 function TerminalWorkspace({
   folderId,
   worktreeId,
@@ -450,7 +530,7 @@ function readToken(el: HTMLElement, cssVar: string, fallback: string): string {
   return computed || fallback;
 }
 
-function PtyTerminal({
+export function PtyTerminal({
   folderId,
   cwd,
   instanceId,

--- a/apps/renderer/src/lib/commands.ts
+++ b/apps/renderer/src/lib/commands.ts
@@ -48,13 +48,9 @@ const HANDLERS: Record<Command, () => void> = {
     ui.setRightSidebarOpen(!ui.rightSidebarOpen);
   },
   "toggle-terminal": () => {
-    const ui = useUiStore.getState();
-    if (!ui.rightSidebarOpen) ui.setRightSidebarOpen(true);
-    ui.setActiveRightTab(
-      ui.activeRightTab === "terminal" && ui.rightSidebarOpen
-        ? "files"
-        : "terminal",
-    );
+    // Open the sidebar (if closed) and reveal a terminal panel — focus an
+    // existing one or add a fresh terminal tab.
+    useUiStore.getState().revealPanel("terminal");
   },
   "focus-composer": () => {
     useComposerBridge.getState().focus?.();

--- a/apps/renderer/src/store/terminals.ts
+++ b/apps/renderer/src/store/terminals.ts
@@ -26,6 +26,18 @@ type TerminalsState = {
   readonly byKey: Readonly<Record<string, ReadonlyArray<TerminalInstance>>>;
   readonly activeByKey: Readonly<Record<string, string | null>>;
   readonly ensureSeed: (key: string, cwd: string) => void;
+  /**
+   * Resolve a 0-based slot index to a terminal instance for `key`, appending
+   * fresh instances until the list is long enough. Used by the right-dock
+   * terminal tabs, which carry a workspace-relative `slot` rather than a
+   * pinned instance id (see `ui.ts` PanelInstance). Returns the instance at
+   * `slot`.
+   */
+  readonly ensureSlot: (
+    key: string,
+    slot: number,
+    cwd: string,
+  ) => TerminalInstance;
   readonly add: (key: string, cwd: string) => string;
   readonly addCommand: (
     key: string,
@@ -70,6 +82,31 @@ export const useTerminalsStore = create<TerminalsState>((set) => ({
         activeByKey: { ...state.activeByKey, [key]: instance.id },
       };
     }),
+  ensureSlot: (key, slot, cwd) => {
+    let result: TerminalInstance | undefined;
+    set((state) => {
+      const list = state.byKey[key] ?? [];
+      if (list.length > slot) {
+        result = list[slot];
+        return state;
+      }
+      const next = [...list];
+      while (next.length <= slot) {
+        next.push({ id: newId(), title: nextTitle(next), cwd });
+      }
+      const instance = next[slot] as TerminalInstance;
+      result = instance;
+      // Only claim focus when the key has none yet — the dock renders each
+      // slot independently, so `activeByKey` is only meaningful to the
+      // worktree `TerminalWorkspace` list path.
+      const active = state.activeByKey[key] ?? instance.id;
+      return {
+        byKey: { ...state.byKey, [key]: next },
+        activeByKey: { ...state.activeByKey, [key]: active },
+      };
+    });
+    return result as TerminalInstance;
+  },
   add: (key, cwd) => {
     const id = newId();
     set((state) => {

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -31,10 +31,38 @@ export type SettingsSection =
 export type MainTab = "chat" | "file" | "archives";
 
 /**
- * Tabs in the right-hand workspace pane. Lifted from `RightPane`'s local
- * state so the native menu (Cmd+J → Toggle Terminal) can drive it.
+ * Panel kinds the right-hand dock can host. The dock is user-managed: panels
+ * are added from a launcher / "+" menu and closed individually, rather than
+ * being a fixed tab set.
  */
-export type RightTab = "files" | "terminal" | "changes" | "pr" | "browser";
+export type PanelKind = "files" | "terminal" | "changes" | "pr" | "browser";
+
+/**
+ * Kinds that may have at most one open instance. Terminal is the only
+ * multi-instance kind — each terminal is its own dock tab.
+ */
+export const SINGLETON_PANEL_KINDS: ReadonlySet<PanelKind> = new Set([
+  "files",
+  "changes",
+  "pr",
+  "browser",
+]);
+
+/**
+ * A panel tab in the right dock. `id` is a stable per-tab key used to
+ * activate/close it. Terminal panels also carry a workspace-relative `slot`
+ * (0-based) that resolves to the active workspace's Nth terminal instance at
+ * render time — see `terminals.ts` `ensureSlot`. The dock layout is global
+ * (one workbench arrangement); the four singletons are already context-aware
+ * internally, and terminals stay correctly keyed by (folderId, worktreeId)
+ * via the slot indirection.
+ */
+export type PanelInstance =
+  | { readonly id: string; readonly kind: "files" }
+  | { readonly id: string; readonly kind: "changes" }
+  | { readonly id: string; readonly kind: "pr" }
+  | { readonly id: string; readonly kind: "browser" }
+  | { readonly id: string; readonly kind: "terminal"; readonly slot: number };
 
 /**
  * Which body the file viewer is showing. `edit` is the CodeMirror editor;
@@ -104,7 +132,8 @@ type UiState = {
   readonly leftSidebarOpen: boolean;
   readonly rightSidebarOpen: boolean;
   readonly isFullScreen: boolean;
-  readonly activeRightTab: RightTab;
+  readonly rightPanels: ReadonlyArray<PanelInstance>;
+  readonly activeRightPanelId: string | null;
   readonly revealedAnnotation: RevealedAnnotation | null;
   readonly setActiveMainTab: (tab: MainTab) => void;
   readonly openFileInTab: (
@@ -123,12 +152,39 @@ type UiState = {
   readonly setLeftSidebarOpen: (open: boolean) => void;
   readonly setRightSidebarOpen: (open: boolean) => void;
   readonly setFullScreen: (full: boolean) => void;
-  readonly setActiveRightTab: (tab: RightTab) => void;
+  /** Add a panel to the dock. Singletons that are already open are focused
+   * instead of duplicated; terminals always append a new slot. */
+  readonly addPanel: (kind: PanelKind) => void;
+  /** Remove a dock panel by id. Layout-only: callers that close a terminal
+   * panel must also drop its backing PTY instance (the active workspace key
+   * lives in the component layer). Re-indexes remaining terminal slots. */
+  readonly closePanel: (id: string) => void;
+  readonly setActiveRightPanel: (id: string) => void;
+  /** Open the sidebar and ensure a panel of `kind` is present + active.
+   * Replaces the old `setRightSidebarOpen(true) + setActiveRightTab(kind)`
+   * pairs. For terminals, focuses an existing one or adds a new slot. */
+  readonly revealPanel: (kind: PanelKind) => void;
   readonly revealAnnotation: (annotation: CodeAnnotation) => void;
   readonly clearRevealedAnnotation: () => void;
 };
 
-export const useUiStore = create<UiState>((set) => ({
+const newPanelId = (): string =>
+  globalThis.crypto?.randomUUID?.() ??
+  `p-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+/** Renumber terminal panels' slots to stay contiguous (0..n-1) in tab order
+ * after one is removed, so they keep mapping to the active workspace's
+ * terminal list without gaps. */
+const reindexTerminalSlots = (
+  panels: ReadonlyArray<PanelInstance>,
+): ReadonlyArray<PanelInstance> => {
+  let next = 0;
+  return panels.map((p) =>
+    p.kind === "terminal" ? { ...p, slot: next++ } : p,
+  );
+};
+
+export const useUiStore = create<UiState>((set, get) => ({
   view: "chat",
   setView: (view) => set({ view }),
   settingsSection: { kind: "general" },
@@ -138,9 +194,10 @@ export const useUiStore = create<UiState>((set) => ({
   fileDirty: false,
   autosave: false,
   leftSidebarOpen: true,
-  rightSidebarOpen: true,
+  rightSidebarOpen: false,
   isFullScreen: false,
-  activeRightTab: "files",
+  rightPanels: [],
+  activeRightPanelId: null,
   revealedAnnotation: null,
   setActiveMainTab: (tab) => set({ activeMainTab: tab }),
   openFileInTab: (file) =>
@@ -161,7 +218,52 @@ export const useUiStore = create<UiState>((set) => ({
   setLeftSidebarOpen: (open) => set({ leftSidebarOpen: open }),
   setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
   setFullScreen: (full) => set({ isFullScreen: full }),
-  setActiveRightTab: (tab) => set({ activeRightTab: tab }),
+  addPanel: (kind) =>
+    set((s) => {
+      if (SINGLETON_PANEL_KINDS.has(kind)) {
+        const existing = s.rightPanels.find((p) => p.kind === kind);
+        if (existing !== undefined) {
+          return { activeRightPanelId: existing.id };
+        }
+        const panel = { id: newPanelId(), kind } as PanelInstance;
+        return {
+          rightPanels: [...s.rightPanels, panel],
+          activeRightPanelId: panel.id,
+        };
+      }
+      // terminal: append a new slot at the next contiguous index.
+      const slot = s.rightPanels.filter((p) => p.kind === "terminal").length;
+      const panel: PanelInstance = { id: newPanelId(), kind: "terminal", slot };
+      return {
+        rightPanels: [...s.rightPanels, panel],
+        activeRightPanelId: panel.id,
+      };
+    }),
+  closePanel: (id) =>
+    set((s) => {
+      const idx = s.rightPanels.findIndex((p) => p.id === id);
+      if (idx === -1) return s;
+      const next = reindexTerminalSlots(
+        s.rightPanels.filter((p) => p.id !== id),
+      );
+      const wasActive = s.activeRightPanelId === id;
+      const activeRightPanelId = wasActive
+        ? (next[Math.max(0, idx - 1)]?.id ?? next[0]?.id ?? null)
+        : s.activeRightPanelId;
+      return { rightPanels: next, activeRightPanelId };
+    }),
+  setActiveRightPanel: (id) => set({ activeRightPanelId: id }),
+  revealPanel: (kind) => {
+    const s = get();
+    if (!s.rightSidebarOpen) set({ rightSidebarOpen: true });
+    const existing = s.rightPanels.find((p) => p.kind === kind);
+    if (existing !== undefined) {
+      set({ activeRightPanelId: existing.id });
+      return;
+    }
+    // No panel of this kind yet — add one (terminals add a fresh slot).
+    s.addPanel(kind);
+  },
   revealAnnotation: (annotation) =>
     set((s) => ({
       revealedAnnotation: {


### PR DESCRIPTION
Converts the fixed 5-tab right pane into a user-managed dock that is hidden by default (full-screen chat) and opened via the existing top-bar toggle. When open with no panels it shows a launcher listing every panel option, and a trailing "+" menu adds more — Terminal is multi-instance (each its own tab) while Files/Changes/PR/Browser are singletons. State moves from `activeRightTab` to a `rightPanels`/`activeRightPanelId` model in `ui.ts` (with `addPanel`/`closePanel`/`revealPanel`), terminals resolve a workspace-relative slot via a new `ensureSlot`, and `/diff`, the agent browser, and `toggle-terminal` now route through `revealPanel`. `BrowserPane` stays always-mounted so the agent browser command stream survives a closed dock, and `app.tsx` ignores the initial panel `onResize` so the default-closed sidebar isn't flipped open on mount. Renderer-only — no server, wire, schema, or persistence changes; behavior changes, so it's worth a manual smoke-test rather than treating it as a pure visual tweak.