### PR TITLE
Gate Codex features by CLI version; add fast mode

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -264,6 +264,11 @@ export function ChatComposer({ session }: { session: Session }) {
 
   const [hasText, setHasText] = useState(false);
   const [goalSendMode, setGoalSendMode] = useState(false);
+  // Version-gated Codex features the installed CLI supports (from the
+  // availability probe). Drives whether goal/fast controls render at all.
+  const codexCapabilities = useProvidersStore((s) =>
+    s.capabilitiesFor(session.providerId),
+  );
   const [trigger, setTrigger] = useState<ActiveTrigger | null>(null);
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -840,8 +845,17 @@ export function ChatComposer({ session }: { session: Session }) {
                 )?.optionDescriptors?.some(
                   (d): d is BooleanOptionDescriptor =>
                     d.kind === "boolean" && d.id === "fastMode",
-                ) === true && <FastModeToggle sessionId={sessionId} />}
-                {session.providerId === "codex" ? (
+                ) === true &&
+                  // For Codex, the fast tier also requires a new-enough CLI
+                  // (the `fastMode` capability). Claude declares its own
+                  // `fastMode` descriptor and isn't version-gated, so only
+                  // filter when the provider gates it.
+                  (session.providerId !== "codex" ||
+                    codexCapabilities.includes("fastMode")) && (
+                    <FastModeToggle sessionId={sessionId} />
+                  )}
+                {session.providerId === "codex" &&
+                codexCapabilities.includes("goalMode") ? (
                   <GoalModeToggle
                     active={goalSendMode}
                     hasGoal={goal !== null}

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -27,6 +27,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
 import { useChatsStore } from "~/store/chats";
 import { useMessagesStore } from "~/store/messages";
+import { useProvidersStore } from "~/store/providers";
 import { useSessionsStore } from "~/store/sessions";
 import { useSettingsStore } from "~/store/settings";
 import { useWorkspaceStore } from "~/store/workspace";
@@ -67,6 +68,14 @@ export function ChatLanding() {
   const addFolder = useWorkspaceStore((s) => s.add);
 
   const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
+  // Goal mode is only offered when the installed Codex CLI is new enough
+  // (version-gated capability from the availability probe). No live session
+  // exists here, so this is the only gate the landing screen can apply.
+  const codexCapabilities = useProvidersStore((s) =>
+    s.capabilitiesFor("codex"),
+  );
+  const codexGoalSupported =
+    defaultProviderId === "codex" && codexCapabilities.includes("goalMode");
   const defaultModelByProvider = useSettingsStore(
     (s) => s.defaultModelByProvider,
   );
@@ -144,7 +153,7 @@ export function ChatLanding() {
         fileRefs: [],
         skillRefs: [],
       });
-      if (goalSendMode && defaultProviderId === "codex") {
+      if (goalSendMode && codexGoalSupported) {
         void send(sessionId, input, { asGoal: true });
       } else {
         useMessagesStore.getState().queue(sessionId, input);
@@ -205,7 +214,7 @@ export function ChatLanding() {
               <Card
                 className={cn(
                   "rounded-xl border-border/50",
-                  goalSendMode && defaultProviderId === "codex"
+                  goalSendMode && codexGoalSupported
                     ? "border-amber-400/55 shadow-[0_0_0_1px_rgba(251,191,36,0.22)]"
                     : undefined,
                 )}
@@ -234,7 +243,7 @@ export function ChatLanding() {
                   />
                   <div className="flex items-center justify-between">
                     <div>
-                      {defaultProviderId === "codex" ? (
+                      {codexGoalSupported ? (
                         <Tooltip>
                           <TooltipTrigger
                             render={

--- a/apps/renderer/src/store/providers.ts
+++ b/apps/renderer/src/store/providers.ts
@@ -6,6 +6,11 @@ import type { AgentAvailability, ProviderId } from "@memoize/wire";
 import { formatError } from "../lib/format-error.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 
+// Stable reference for the "no capabilities" case so the `capabilitiesFor`
+// selector doesn't return a fresh array each call (which would churn zustand
+// subscribers on every unrelated store update).
+const EMPTY_CAPABILITIES: ReadonlyArray<string> = [];
+
 /**
  * Renderer-side cache of provider availability + the credentials sheet
  * controller. Replaces the per-session state that used to live in
@@ -18,6 +23,13 @@ type ProvidersState = {
   readonly credentialsOpen: boolean;
   readonly refresh: () => Promise<void>;
   readonly setCredentialsOpen: (open: boolean) => void;
+  /**
+   * Version-gated features the installed CLI supports for `providerId` (the
+   * `capabilities` list from the availability probe). `[]` when the provider
+   * isn't probed yet or declares no gated features. Used to show/hide feature
+   * controls (e.g. Codex goal/fast toggles) before a session exists.
+   */
+  readonly capabilitiesFor: (providerId: ProviderId) => ReadonlyArray<string>;
   readonly setCredential: (
     providerId: ProviderId,
     apiKey: string,
@@ -40,6 +52,9 @@ export const useProvidersStore = create<ProvidersState>((set, get) => ({
     }
   },
   setCredentialsOpen: (open) => set({ credentialsOpen: open }),
+  capabilitiesFor: (providerId) =>
+    get().availability.find((a) => a.providerId === providerId)?.capabilities ??
+    EMPTY_CAPABILITIES,
   setCredential: async (providerId, apiKey) => {
     try {
       const client = await getRpcClient();

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   AgentAvailability,
   type CliVersionStatus,
+  type CodexFeature,
   type LatestVersionStatus,
   type ProviderAuthStatus,
   type ProviderHealthStatus,
@@ -205,12 +206,17 @@ export const resolveCliPath = (
   cliBinary: string,
 ): Effect.Effect<string | null, never, CommandExecutor.CommandExecutor> =>
   Effect.gen(function* () {
-    const result = yield* runCapture(Command.make("which", "-a", cliBinary)).pipe(
+    const result = yield* runCapture(
+      Command.make("which", "-a", cliBinary),
+    ).pipe(
       Effect.timeoutOption(PROBE_TIMEOUT),
       Effect.catchAll(() => Effect.succeedNone),
     );
     if (result._tag !== "Some" || result.value.exitCode !== 0) return null;
-    return selectCliPathCandidate(cliBinary, splitCommandPaths(result.value.stdout));
+    return selectCliPathCandidate(
+      cliBinary,
+      splitCommandPaths(result.value.stdout),
+    );
   });
 
 export interface CliVersion {
@@ -230,6 +236,49 @@ export const MIN_CODEX_CLI_VERSION: CliVersion = {
   patch: 0,
   raw: "0.128.0",
 };
+
+// Per-feature minimum Codex CLI version. This is the *pre-session* gate: the
+// renderer reads the resolved `capabilities` list off `AgentAvailability` to
+// show/hide a feature's control before any session exists. Each entry is one
+// `CodexFeature`. Adding a feature is additive — add it here and to the wire
+// `CodexFeature` literal, then gate the UI on the capability.
+//
+// Note for `fastMode`: the live `model/list` `serviceTiers` (emitted by the
+// driver as a `Capabilities` event) are the authoritative per-model gate, so
+// this floor only governs when the toggle first becomes visible — an
+// approximate value is safe.
+export const CODEX_FEATURE_FLOORS: ReadonlyArray<{
+  readonly feature: CodexFeature;
+  readonly min: CliVersion;
+}> = [
+  // Goal mode uses the `thread/goal/*` RPCs, which exist as of our SDK floor
+  // (0.128). Pinned at the floor so it's effectively always-on whenever Codex
+  // is new enough to run at all.
+  {
+    feature: "goalMode",
+    min: { major: 0, minor: 128, patch: 0, raw: "0.128.0" },
+  },
+  // Fast mode (`serviceTier: "fast"`) landed in a later release. TODO: confirm
+  // the exact CLI version; the runtime `serviceTiers` check is the real gate.
+  {
+    feature: "fastMode",
+    min: { major: 0, minor: 145, patch: 0, raw: "0.145.0" },
+  },
+];
+
+/**
+ * Resolve the version-gated features a Codex CLI of `parsed` version supports.
+ * Empty when the version couldn't be parsed (caller treats unknown versions as
+ * "no extra capabilities" — the renderer falls back to hiding gated controls).
+ */
+export const resolveCodexCapabilities = (
+  parsed: CliVersion | null,
+): ReadonlyArray<CodexFeature> =>
+  parsed === null
+    ? []
+    : CODEX_FEATURE_FLOORS.filter(
+        ({ min }) => compareCliVersion(parsed, min) >= 0,
+      ).map(({ feature }) => feature);
 
 // `codex --version` prints `codex-cli 0.27.0`; `claude --version` prints
 // `1.0.123 (Claude Code)`. Pull the first dotted triple we can find; ignore
@@ -1130,22 +1179,29 @@ const probeOne = (
     // doesn't need its own parser. `unknown` covers both "no min tracked for
     // this provider" and "we tried to parse and failed" — both are
     // "let them try" cases as far as the upgrade card is concerned.
+    const parsedVersion =
+      cliVersion !== undefined ? parseCliVersion(cliVersion) : null;
     let cliVersionStatus: CliVersionStatus = "unknown";
     let cliVersionMinRequired: string | undefined;
     let cliUpgradeCommand: string | undefined;
     if (probe.minVersion !== null) {
       cliVersionMinRequired = probe.minVersion.raw;
       cliUpgradeCommand = probe.upgradeCommand ?? undefined;
-      const parsed =
-        cliVersion !== undefined ? parseCliVersion(cliVersion) : null;
-      if (parsed === null) {
+      if (parsedVersion === null) {
         cliVersionStatus = "unknown";
-      } else if (compareCliVersion(parsed, probe.minVersion) < 0) {
+      } else if (compareCliVersion(parsedVersion, probe.minVersion) < 0) {
         cliVersionStatus = "outdated";
       } else {
         cliVersionStatus = "ok";
       }
     }
+
+    // Version-gated features the installed CLI supports (pre-session UI gate).
+    // Only Codex declares gated features today; others resolve to `[]`.
+    const capabilities =
+      probe.providerId === "codex"
+        ? resolveCodexCapabilities(parsedVersion)
+        : [];
 
     // Informational "update available" layer — independent of the SDK floor.
     // Only providers with a registry package are checked; the rest report
@@ -1195,6 +1251,7 @@ const probeOne = (
       cliVersionStatus,
       cliVersionMinRequired,
       cliUpgradeCommand,
+      capabilities,
       latestVersion,
       latestVersionStatus,
       updateCommand,

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -28,6 +28,8 @@ import { CodexAppServerClient } from "../codex-app-server-client.ts";
 import type { ServerNotification } from "../codex-app-protocol/ServerNotification";
 import type { ServerRequest } from "../codex-app-protocol/ServerRequest";
 import type { SandboxPolicy } from "../codex-app-protocol/v2/SandboxPolicy";
+import type { Model } from "../codex-app-protocol/v2/Model";
+import type { ModelListResponse } from "../codex-app-protocol/v2/ModelListResponse";
 import type { ThreadGoal as CodexThreadGoal } from "../codex-app-protocol/v2/ThreadGoal";
 import type { ThreadItem } from "../codex-app-protocol/v2/ThreadItem";
 import type { UserInput } from "../codex-app-protocol/v2/UserInput";
@@ -181,6 +183,38 @@ const goalFromResponse = (value: unknown): CodexThreadGoal | null => {
     return nested as CodexThreadGoal;
   }
   return value as CodexThreadGoal;
+};
+
+/**
+ * Whether a model advertises a "fast" service tier. Codex exposes speed tiers
+ * via `serviceTiers` (current) and `additionalSpeedTiers` (deprecated); we
+ * match either id/name containing "fast" so we stay robust to label changes.
+ */
+const modelAdvertisesFastTier = (model: Model): boolean =>
+  [
+    ...model.serviceTiers.flatMap((tier) => [tier.id, tier.name]),
+    ...model.additionalSpeedTiers,
+  ].some((label) => label.toLowerCase().includes("fast"));
+
+/**
+ * Whether the model a session resolved to advertises a fast service tier,
+ * from the live `model/list`. Returns `null` when the model isn't in the
+ * catalog (unknown — caller should trust the pre-session FE gate rather than
+ * block). The version floor + static model catalog gate the FE *control*; this
+ * is the authoritative per-model confirmation enforced at turn time.
+ */
+const probeModelFastTier = async (
+  app: CodexAppServerClient,
+  activeModel: string | null,
+): Promise<boolean | null> => {
+  const response = await app.request<ModelListResponse>("model/list", {
+    includeHidden: true,
+  });
+  const model =
+    response.data.find(
+      (entry) => entry.id === activeModel || entry.model === activeModel,
+    ) ?? response.data.find((entry) => entry.isDefault);
+  return model === undefined ? null : modelAdvertisesFastTier(model);
 };
 
 const toolIdentifierPart = (value: string): string =>
@@ -611,6 +645,12 @@ export const startCodexSession = (
     let latestDiff = "";
     let closed = false;
     let pending: Promise<void> = Promise.resolve();
+    // Runtime fast-tier gate for the model this session resolved to, from the
+    // live `model/list` `serviceTiers`. `null` = unknown (probe not done /
+    // failed) → trust the FE gate; `true`/`false` = the model definitively
+    // does / does not advertise a fast tier. Only a definitive `false` blocks
+    // the `serviceTier: "fast"` request in `runTurn`.
+    let modelFastTier: boolean | null = null;
 
     type QuestionWaiter = {
       readonly questionIds: ReadonlyArray<string>;
@@ -695,6 +735,16 @@ export const startCodexSession = (
         }
       } catch (cause) {
         console.warn("[codex] goal hydration failed", cause);
+      }
+      // Runtime fast-mode confirmation: the version floor (AgentAvailability
+      // `capabilities`) + the static model catalog decide whether the FE
+      // *shows* the fast toggle; the live `model/list` `serviceTiers` are the
+      // authoritative per-model gate enforced at turn time (see `runTurn`).
+      // Best-effort — a failure leaves `modelFastTier` null (trust the FE).
+      try {
+        modelFastTier = await probeModelFastTier(app, input.model ?? null);
+      } catch (cause) {
+        console.warn("[codex] fast-tier probe failed", cause);
       }
     };
 
@@ -797,6 +847,21 @@ export const startCodexSession = (
         reasoning === "low" || reasoning === "medium" || reasoning === "high"
           ? reasoning
           : null;
+      // Fast mode: the `fastMode` per-model boolean knob maps onto Codex's
+      // `serviceTier: "fast"` (the 1.5× speed tier). The FE only shows the
+      // toggle when the CLI version + static model catalog allow it; the live
+      // `model/list` `serviceTiers` are the authoritative per-model gate, so we
+      // drop the field (and tell the user) when the resolved model definitively
+      // lacks a fast tier. `modelFastTier === null` (unknown) trusts the FE.
+      const fastModeRequested = input.modelOptions?.["fastMode"] === "true";
+      const fastMode = fastModeRequested && modelFastTier !== false;
+      if (fastModeRequested && modelFastTier === false) {
+        emit({
+          _tag: "AssistantMessage",
+          itemId: nextItemId(),
+          text: "Fast mode isn't available for this model — running at the standard tier.",
+        });
+      }
       const turn = await app.request<{ turn: { id: string } }>("turn/start", {
         threadId: activeThreadId,
         input: [
@@ -812,6 +877,7 @@ export const startCodexSession = (
         sandboxPolicy: toSandboxPolicy(currentMode, cwd),
         model: input.model ?? null,
         ...(effort !== null ? { effort } : {}),
+        ...(fastMode ? { serviceTier: "fast" } : {}),
       });
       currentTurnId = turn.turn.id;
     };

--- a/apps/server/test/availability.test.ts
+++ b/apps/server/test/availability.test.ts
@@ -7,6 +7,7 @@ import {
   grokAuthTestHelpers,
   MIN_CODEX_CLI_VERSION,
   parseCliVersion,
+  resolveCodexCapabilities,
   selectCliPathCandidate,
 } from "../src/provider/availability.ts";
 
@@ -67,6 +68,35 @@ describe("compareCliVersion", () => {
   it("detects an older-than-minimum codex CLI", () => {
     const old = parseCliVersion("codex-cli 0.27.0")!;
     expect(compareCliVersion(old, MIN_CODEX_CLI_VERSION)).toBeLessThan(0);
+  });
+});
+
+describe("resolveCodexCapabilities — version-gated feature floors", () => {
+  it("returns no capabilities for an unparseable / null version", () => {
+    expect(resolveCodexCapabilities(null)).toEqual([]);
+  });
+
+  it("enables only goalMode at the SDK floor but below the fast floor", () => {
+    // 0.128.0 meets goalMode's 0.128.0 floor but is below fastMode's floor.
+    expect(resolveCodexCapabilities(parseCliVersion("0.128.0"))).toEqual([
+      "goalMode",
+    ]);
+  });
+
+  it("enables no gated features below every floor", () => {
+    expect(resolveCodexCapabilities(parseCliVersion("0.27.0"))).toEqual([]);
+  });
+
+  it("enables both goalMode and fastMode once the fast floor is met", () => {
+    const caps = resolveCodexCapabilities(parseCliVersion("0.145.0"));
+    expect(caps).toContain("goalMode");
+    expect(caps).toContain("fastMode");
+  });
+
+  it("keeps fastMode enabled for versions above the floor", () => {
+    expect(resolveCodexCapabilities(parseCliVersion("0.200.3"))).toContain(
+      "fastMode",
+    );
   });
 });
 
@@ -197,7 +227,9 @@ describe("selectCliPathCandidate", () => {
       selectCliPathCandidate("codex", [
         "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
       ]),
-    ).toBe("/Users/me/Library/Application Support/com.conductor.app/./bin/codex");
+    ).toBe(
+      "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
+    );
   });
 
   it("keeps first PATH match for non-Codex providers", () => {

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -155,6 +155,20 @@ export const CliVersionStatus = Schema.Literal("ok", "outdated", "unknown");
 export type CliVersionStatus = typeof CliVersionStatus.Type;
 
 /**
+ * Version-gated Codex features. The installed Codex CLI only speaks these on
+ * recent releases, so we surface support as a capability list on
+ * {@link AgentAvailability} (computed from `cliVersion` against per-feature
+ * floors in `availability.ts`) and the renderer shows/hides the matching
+ * control. Adding a feature here is additive — pair it with a floor in
+ * `CODEX_FEATURE_FLOORS` and a UI gate.
+ *
+ *   - `goalMode` — `thread/goal/*` RPCs (the goal banner + `/goal`).
+ *   - `fastMode` — `serviceTier: "fast"` on `turn/start` (1.5× speed tier).
+ */
+export const CodexFeature = Schema.Literal("goalMode", "fastMode");
+export type CodexFeature = typeof CodexFeature.Type;
+
+/**
  * Per-provider verdict on whether a *newer published release* exists, distinct
  * from {@link CliVersionStatus} (which is the blocking SDK floor). This layer
  * is purely informational — it powers the "update available" hover affordance
@@ -234,6 +248,16 @@ export const AgentAvailability = Schema.Struct({
    * tandem with `cliVersionStatus`; rendered inside the upgrade card.
    */
   cliVersionMinRequired: Schema.optional(Schema.String),
+  /**
+   * Version-gated features the *installed CLI* supports, computed by comparing
+   * `cliVersion` against per-feature floors (see `CODEX_FEATURE_FLOORS` in
+   * availability.ts). Values are {@link CodexFeature} ids. Empty/omitted when
+   * the version is unknown or no features are gated for this provider. The
+   * renderer reads this to show/hide feature controls *before* a session
+   * exists (the live `model/list` `serviceTiers` refine it per-model once a
+   * session is connected — see the `Capabilities` event).
+   */
+  capabilities: Schema.optional(Schema.Array(Schema.String)),
   /**
    * One-line shell command we recommend the user run to fix an outdated
    * CLI. Co-located with the version probe so renderer doesn't need its
@@ -707,11 +731,13 @@ const claudeEffortDescriptor = (args: {
 });
 
 /**
- * Boolean descriptor for Claude's per-model toggles. `fastMode` halves the
- * token cost and roughly doubles throughput at the cost of some quality;
- * `thinking` enables Haiku 4.5's always-on adaptive thinking.
+ * Boolean descriptor for a per-model toggle. Used by Claude (`fastMode` halves
+ * the token cost and roughly doubles throughput at the cost of some quality;
+ * `thinking` enables Haiku 4.5's always-on adaptive thinking) and by Codex
+ * (`fastMode` → `serviceTier: "fast"`, the 1.5× speed tier on the latest
+ * models). The driver keys behavior off the descriptor `id`.
  */
-const claudeBooleanDescriptor = (
+const booleanDescriptor = (
   id: string,
   label: string,
 ): BooleanOptionDescriptor => ({
@@ -762,7 +788,7 @@ export const MODELS_BY_PROVIDER: Record<
           ],
           defaultId: "high",
         }),
-        claudeBooleanDescriptor("fastMode", "Fast Mode"),
+        booleanDescriptor("fastMode", "Fast Mode"),
         claudeContextWindowDescriptor(),
       ],
       supportsPlanMode: true,
@@ -783,7 +809,7 @@ export const MODELS_BY_PROVIDER: Record<
           ],
           defaultId: "xhigh",
         }),
-        claudeBooleanDescriptor("fastMode", "Fast Mode"),
+        booleanDescriptor("fastMode", "Fast Mode"),
         claudeContextWindowDescriptor(),
       ],
       supportsPlanMode: true,
@@ -803,7 +829,7 @@ export const MODELS_BY_PROVIDER: Record<
           ],
           defaultId: "high",
         }),
-        claudeBooleanDescriptor("fastMode", "Fast Mode"),
+        booleanDescriptor("fastMode", "Fast Mode"),
         claudeContextWindowDescriptor(),
       ],
       supportsPlanMode: true,
@@ -831,7 +857,7 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "claude-haiku-4-5",
       label: "Haiku 4.5",
-      optionDescriptors: [claudeBooleanDescriptor("thinking", "Thinking")],
+      optionDescriptors: [booleanDescriptor("thinking", "Thinking")],
       supportsPlanMode: true,
       supportsWebSearch: "native",
     },
@@ -840,7 +866,14 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "gpt-5.4",
       label: "GPT-5.4",
-      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      // `fastMode` → `serviceTier: "fast"`. OpenAI only offers the fast tier on
+      // the latest models (GPT-5.4 / GPT-5.5); older Codex CLIs don't accept
+      // the field, so the toggle is additionally gated on the `fastMode`
+      // capability (CLI version) + the live model's `serviceTiers`.
+      optionDescriptors: [
+        reasoningSelectDescriptor("medium"),
+        booleanDescriptor("fastMode", "Fast"),
+      ],
       supportsPlanMode: true,
       supportsWebSearch: "native",
     },
@@ -854,7 +887,11 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "gpt-5.5",
       label: "GPT-5.5",
-      optionDescriptors: [reasoningSelectDescriptor("medium")],
+      // Fast tier supported — see gpt-5.4 note above.
+      optionDescriptors: [
+        reasoningSelectDescriptor("medium"),
+        booleanDescriptor("fastMode", "Fast"),
+      ],
       supportsPlanMode: true,
       supportsWebSearch: "native",
     },


### PR DESCRIPTION
Adds a version-gated feature-capability layer for Codex so features can be released based on the user's installed CLI version. A `CODEX_FEATURE_FLOORS` registry maps each feature to a minimum version; the availability probe resolves a `capabilities` list on `AgentAvailability`, and the renderer hides the goal and fast-mode controls (in both the composer and landing screen) when the installed Codex is too old. Fast mode is new — it sends `serviceTier: "fast"` on the latest models (GPT-5.4/5.5, default off), with the live `model/list` `serviceTiers` as the authoritative turn-time gate that downgrades gracefully when a model lacks the fast tier. Goal mode is now version-gated rather than shown for every Codex session. Includes unit tests for floor resolution; `check-types`, the full server test suite, and lint all pass.