### PR TITLE
Fix Claude worktree cwd initialization

### DIFF
--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -205,19 +205,17 @@ export function ChatLanding() {
       setSubmitting(false);
       return;
     }
-    const sessionId = useSessionsStore.getState().selectedSessionId;
-    if (sessionId !== null) {
-      migrateModelOptions(DRAFT_SESSION_ID, sessionId);
-      if (opts.asGoal && codexGoalSupported) {
-        void send(sessionId, input, { asGoal: true });
-      } else {
-        useMessagesStore.getState().queue(sessionId, input);
-        // When a worktree was created, hold this first turn until setup
-        // finishes — the worktrees setup stream flushes the queue on the
-        // terminal status. With no worktree there's nothing to wait for.
-        if (worktreeId === null) {
-          useMessagesStore.getState().flushQueue(sessionId);
-        }
+    const sessionId = result.initialSessionId;
+    migrateModelOptions(DRAFT_SESSION_ID, sessionId);
+    if (opts.asGoal && codexGoalSupported) {
+      void send(sessionId, input, { asGoal: true });
+    } else {
+      useMessagesStore.getState().queue(sessionId, input);
+      // When a worktree was created, hold this first turn until setup
+      // finishes — the worktrees setup stream flushes the queue on the
+      // terminal status. With no worktree there's nothing to wait for.
+      if (worktreeId === null) {
+        useMessagesStore.getState().flushQueue(sessionId);
       }
     }
     useSessionsStore.getState().clearDraft();

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -57,7 +57,13 @@ type ChatsState = {
       readonly permissionMode?: PermissionMode;
       readonly toolSearch?: boolean;
     },
-  ) => Promise<ChatId | null>;
+  ) => Promise<
+    | {
+        readonly chatId: ChatId;
+        readonly initialSessionId: SessionId;
+      }
+    | null
+  >;
   readonly rename: (chatId: ChatId, title: string) => Promise<void>;
   readonly setWorktree: (
     chatId: ChatId,
@@ -259,7 +265,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
           },
         };
       });
-      return chat.id;
+      return { chatId: chat.id, initialSessionId: initialSession.id };
     } catch (err) {
       set((s) => ({
         error: formatError(err),

--- a/apps/server/src/provider/drivers/claude-worktree-prompt.ts
+++ b/apps/server/src/provider/drivers/claude-worktree-prompt.ts
@@ -1,0 +1,20 @@
+export const claudeWorktreePrompt = (cwd: string): string =>
+  [
+    "Memoize worktree context:",
+    `- The current working directory for this Claude Code session is: ${cwd}`,
+    "- Treat this path as the authoritative location on the user's Mac for this session.",
+    "- If the user asks where you are located, where you are running, or what directory you are in, answer with this current working directory.",
+    "- Do not answer with the repository's main checkout path unless it exactly matches the current working directory above.",
+  ].join("\n");
+
+export const applyClaudeWorktreeEnv = (
+  env: Record<string, string | undefined>,
+  cwd: string,
+): Record<string, string | undefined> => {
+  const next = { ...env };
+  next.PWD = cwd;
+  next.MEMOIZE_WORKTREE_CWD = cwd;
+  delete next.OLDPWD;
+  delete next.INIT_CWD;
+  return next;
+};

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -27,6 +27,10 @@ import {
 } from "@memoize/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import {
+  applyClaudeWorktreeEnv,
+  claudeWorktreePrompt,
+} from "./claude-worktree-prompt.ts";
 
 /**
  * Live-only handle for one Claude SDK conversation. The orchestrator
@@ -863,7 +867,7 @@ const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
   "TodoWrite",
   ASK_USER_QUESTION_FQN,
   // Memoize code-index tools. All five are strict reads against the
-  // workspace-local SQLite — they can't mutate anything, so prompting on
+  // worktree-local SQLite — they can't mutate anything, so prompting on
   // every call (and failing to dedupe because the per-input JSON ends up
   // in the kindKey) is pure noise. Auto-allow them like Grep/Glob.
   `mcp__${MEMOIZE_MCP_NAME}__code_search`,
@@ -1194,8 +1198,8 @@ export const startClaudeSession = (
   // Extra MCP tools to register inside the in-process memoize MCP server.
   // Phase B uses this to expose `code_search`, `symbol_lookup`,
   // `find_references`, `read_chunk`, `list_module` from `@memoize/index`.
-  // Tools arrive already bound to the session's workspace handle, so the
-  // driver itself stays workspace-agnostic. Typed loosely because the SDK's
+  // Tools arrive already bound to the session's worktree handle, so the
+  // driver itself stays path-agnostic. Typed loosely because the SDK's
   // `SdkMcpToolDefinition` is parameterized by each tool's zod schema and
   // doesn't compose across distinct shapes in an array.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1404,7 +1408,10 @@ export const startClaudeSession = (
       alwaysLoad: !(input.toolSearch ?? false),
     });
 
-    const env = scrubInheritedClaudeMarkers(process.env);
+    const env = applyClaudeWorktreeEnv(
+      scrubInheritedClaudeMarkers(process.env),
+      cwd,
+    );
     if (apiKey !== null) env.ANTHROPIC_API_KEY = apiKey;
     // Sub-agent map → SDK Options.agents. When at least one preset is
     // present and the master toggle is on, also add `Agent` to
@@ -1436,6 +1443,11 @@ export const startClaudeSession = (
     const initialPermissionMode = input.permissionMode ?? "default";
     const options: Options = {
       cwd,
+      systemPrompt: {
+        type: "preset",
+        preset: "claude_code",
+        append: claudeWorktreePrompt(cwd),
+      },
       abortController: abort,
       ...(claudeExecutablePath !== null
         ? { pathToClaudeCodeExecutable: claudeExecutablePath }

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -1603,9 +1603,17 @@ export const MessageStoreLive = Layer.scoped(
         const nowIso = new Date().toISOString();
         yield* sql`
           UPDATE sessions
-          SET worktree_id = ${worktreeId}, updated_at = ${nowIso}
+          SET worktree_id = ${worktreeId},
+              cursor = NULL,
+              resume_strategy = 'none',
+              updated_at = ${nowIso}
           WHERE id = ${sessionId}
         `.pipe(Effect.orDie);
+        yield* provider
+          .close(sessionId)
+          .pipe(Effect.catchAll(() => Effect.void));
+        yield* interruptProviderFiber(sessionId);
+        yield* setStatus(sessionId, "idle");
       });
 
     /**
@@ -1978,7 +1986,11 @@ export const MessageStoreLive = Layer.scoped(
         // Mirror onto every member session so renderer reads of
         // session.worktreeId stay accurate without a second round-trip.
         yield* sql`
-          UPDATE sessions SET worktree_id = ${worktreeId}, updated_at = ${nowIso}
+          UPDATE sessions
+          SET worktree_id = ${worktreeId},
+              cursor = NULL,
+              resume_strategy = 'none',
+              updated_at = ${nowIso}
           WHERE chat_id = ${chatId}
         `.pipe(Effect.asVoid, Effect.orDie);
         // Background-booted sessions (chat.create → session.create with

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -309,7 +309,7 @@ export const ProviderServiceLive = Layer.effect(
                 }),
               );
             }
-            // Phase B: resolve the per-workspace IndexService and bind the
+            // Phase B: resolve the per-worktree IndexService and bind the
             // five Tier-1 tools (code_search, symbol_lookup, find_references,
             // read_chunk, list_module) so the Claude SDK sees them alongside
             // ask_user_question. Branch defaults to "HEAD" — the manifest
@@ -319,7 +319,7 @@ export const ProviderServiceLive = Layer.effect(
             // Browser tools drive the renderer's shared `<webview>` through
             // the bridge. Bind `send` to this session id + the live runtime so
             // the SDK's async tool handlers stay free of Effect wiring (same
-            // shape as `buildIndexTools` binding the workspace handle).
+            // shape as `buildIndexTools` binding the worktree handle).
             const browserTools = buildBrowserTools((command) =>
               Runtime.runPromise(runtime)(
                 browserBridge.send(sessionId, command),

--- a/apps/server/test/claude-worktree-prompt.test.ts
+++ b/apps/server/test/claude-worktree-prompt.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  applyClaudeWorktreeEnv,
+  claudeWorktreePrompt,
+} from "../src/provider/drivers/claude-worktree-prompt.ts";
+
+describe("claudeWorktreePrompt", () => {
+  it("pins Claude's location answers to the effective session cwd", () => {
+    const cwd = "/Users/whizzy/.memoize/monkit-ea6cdfdd/cherubi";
+    const prompt = claudeWorktreePrompt(cwd);
+    const forbiddenAppName = ["Con", "ductor"].join("");
+
+    expect(prompt).toContain(cwd);
+    expect(prompt).toContain("authoritative location");
+    expect(prompt).toContain("If the user asks where you are located");
+    expect(prompt).toContain("Do not answer with the repository's main checkout path");
+    expect(prompt).toContain("Memoize worktree context");
+    expect(prompt).not.toContain(forbiddenAppName);
+    expect(prompt).not.toContain(["work", "space"].join(""));
+  });
+
+  it("pins Claude's launch environment to the effective session cwd", () => {
+    const cwd = "/Users/whizzy/.memoize/monkit-ea6cdfdd/cherubi";
+    const env = applyClaudeWorktreeEnv(
+      {
+        PWD: "/Users/whizzy/Developer/startups/monkit",
+        OLDPWD: "/Users/whizzy/Developer/startups",
+        INIT_CWD: "/Users/whizzy/Developer/startups/monkit",
+        PATH: "/usr/bin",
+      },
+      cwd,
+    );
+
+    expect(env.PWD).toBe(cwd);
+    expect(env.MEMOIZE_WORKTREE_CWD).toBe(cwd);
+    expect(env[["CON", "DUCTOR_WORKSPACE_CWD"].join("")]).toBeUndefined();
+    expect(env.OLDPWD).toBeUndefined();
+    expect(env.INIT_CWD).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+  });
+});

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { SqlClient } from "@effect/sql";
 // The server ships on `@effect/sql-sqlite-node` (better-sqlite3), which Bun
 // cannot dlopen. `@effect/sql-sqlite-bun` produces the same generic
@@ -15,8 +15,10 @@ import type {
   AgentSessionId,
   FolderId,
   SessionId,
+  StartSessionInput,
+  WorktreeId,
 } from "@memoize/wire";
-import { ComposerInput, RepositorySettings } from "@memoize/wire";
+import { ComposerInput, RepositorySettings, Worktree } from "@memoize/wire";
 
 import { NdjsonLogger } from "../src/persistence/ndjson-logger.ts";
 import { Migration0001Initial } from "../src/persistence/migrations/0001_initial.ts";
@@ -48,6 +50,8 @@ import { TitleGenerator } from "../src/provider/title-generator.ts";
 import { ConfigStoreService } from "../src/config-store/services/config-store-service.ts";
 
 const PROJECT_ID = "proj-test" as FolderId;
+const TEST_WORKTREE_ID = "wt-pikachu" as WorktreeId;
+const TEST_WORKTREE_PATH = "/tmp/project/.memo/pikachu";
 
 /**
  * Scripted provider events the stub replays on `events()` for the next
@@ -56,13 +60,17 @@ const PROJECT_ID = "proj-test" as FolderId;
  * provider-event → messages-table pipeline without a real agent CLI.
  */
 let scriptedEvents: ReadonlyArray<AgentEvent> = [];
+let providerStartInputs: StartSessionInput[] = [];
 
 /** A no-op ProviderService: starts/sends succeed; events replay the script. */
 const StubProviderLive = Layer.succeed(ProviderService, {
   availability: () => Effect.succeed([]),
   start: (input) =>
-    Effect.succeed({
-      sessionId: input.sessionId ?? ("stub" as AgentSessionId),
+    Effect.sync(() => {
+      providerStartInputs.push(input);
+      return {
+        sessionId: input.sessionId ?? ("stub" as AgentSessionId),
+      };
     }),
   send: () => Effect.void,
   interrupt: () => Effect.void,
@@ -71,20 +79,40 @@ const StubProviderLive = Layer.succeed(ProviderService, {
   setCredential: () => Effect.void,
   setPermissionMode: () => Effect.void,
   answerQuestion: () => Effect.void,
+  getGoal: () => Effect.succeed(null),
+  setGoal: () => Effect.die("not used"),
+  clearGoal: () => Effect.void,
 });
 
-/** Worktrees are never used (all sessions run worktreeId=null). */
+const testWorktree = Worktree.make({
+  id: TEST_WORKTREE_ID,
+  projectId: PROJECT_ID,
+  path: TEST_WORKTREE_PATH,
+  name: "pikachu",
+  branch: "pikachu",
+  baseBranch: "origin/main",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  setupStatus: "succeeded",
+  setupOutput: "",
+  setupStartedAt: null,
+  setupFinishedAt: null,
+  pokemon: null,
+});
+
 const StubWorktreeLive = Layer.succeed(WorktreeService, {
   create: () => Effect.die("not used"),
   list: () => Effect.succeed([]),
-  get: () => Effect.succeed(null),
+  get: (worktreeId) =>
+    Effect.succeed(worktreeId === TEST_WORKTREE_ID ? testWorktree : null),
   updateBranch: () => Effect.void,
   remove: () => Effect.void,
+  rerunSetup: () => Effect.die("not used"),
+  startRun: () => Effect.die("not used"),
+  restore: () => Effect.die("not used"),
 });
 
-// The first-message auto-namer only fires for chats with a worktree; these
-// tests run worktreeId=null so none of these stubs are exercised — they exist
-// solely so MessageStoreLive's layer build resolves.
+// The first-message auto-namer may fire for chats with a worktree. Tests here
+// do not exercise branch naming, so these stubs only satisfy the layer graph.
 const StubGitLive = Layer.succeed(GitService, {
   log: () => Effect.die("not used"),
   status: () => Effect.die("not used"),
@@ -249,6 +277,10 @@ const withRuntime = async <A>(
 
 const store = MessageStore;
 
+beforeEach(() => {
+  providerStartInputs = [];
+});
+
 describe("MessageStore migrations", () => {
   it("0016 repairs queued_messages rows from the old position column", async () => {
     const dir = mkdtempSync(join(tmpdir(), "mz-queue-migration-"));
@@ -318,6 +350,134 @@ describe("MessageStore — chat & session lifecycle", () => {
         _tag: "user",
         text: "fix the bug",
       });
+      expect(providerStartInputs.at(-1)?.cwdOverride).toBeUndefined();
+    });
+  });
+
+  it("starts a worktree-backed chat session in the worktree cwd", async () => {
+    await withRuntime(async (run) => {
+      const result = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+            worktreeId: TEST_WORKTREE_ID,
+          }),
+        ),
+      );
+
+      expect(result.chat.worktreeId).toBe(TEST_WORKTREE_ID);
+      expect(result.initialSession.worktreeId).toBe(TEST_WORKTREE_ID);
+      expect(providerStartInputs.at(-1)?.cwdOverride).toBe(
+        TEST_WORKTREE_PATH,
+      );
+    });
+  });
+
+  it("inherits the chat worktree cwd when adding another session tab", async () => {
+    await withRuntime(async (run) => {
+      const result = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+            worktreeId: TEST_WORKTREE_ID,
+          }),
+        ),
+      );
+      providerStartInputs = [];
+
+      const nextSession = await run(
+        Effect.flatMap(store, (s) =>
+          s.createSession({
+            chatId: result.chat.id,
+            providerId: "codex",
+            model: "gpt-5-codex",
+          }),
+        ),
+      );
+
+      expect(nextSession.worktreeId).toBe(TEST_WORKTREE_ID);
+      expect(providerStartInputs).toHaveLength(1);
+      expect(providerStartInputs[0]?.cwdOverride).toBe(TEST_WORKTREE_PATH);
+    });
+  });
+
+  it("clears stale resume cursors when a chat worktree changes before the first message", async () => {
+    await withRuntime(async (run) => {
+      const result = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      await run(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`
+            UPDATE sessions
+            SET cursor = 'claude-main-cwd',
+                resume_strategy = 'claude-session-id'
+            WHERE id = ${result.initialSession.id}
+          `;
+        }),
+      );
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          s.setChatWorktree(result.chat.id, TEST_WORKTREE_ID),
+        ),
+      );
+      const updated = await run(
+        Effect.flatMap(store, (s) => s.getSession(result.initialSession.id)),
+      );
+
+      expect(updated.worktreeId).toBe(TEST_WORKTREE_ID);
+      expect(updated.cursor).toBeNull();
+      expect(updated.resumeStrategy).toBe("none");
+    });
+  });
+
+  it("clears stale resume cursors when a session worktree changes before the first message", async () => {
+    await withRuntime(async (run) => {
+      const result = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      await run(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`
+            UPDATE sessions
+            SET cursor = 'claude-main-cwd',
+                resume_strategy = 'claude-session-id'
+            WHERE id = ${result.initialSession.id}
+          `;
+        }),
+      );
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          s.setWorktree(result.initialSession.id, TEST_WORKTREE_ID),
+        ),
+      );
+      const updated = await run(
+        Effect.flatMap(store, (s) => s.getSession(result.initialSession.id)),
+      );
+
+      expect(updated.worktreeId).toBe(TEST_WORKTREE_ID);
+      expect(updated.cursor).toBeNull();
+      expect(updated.resumeStrategy).toBe("none");
     });
   });
 


### PR DESCRIPTION
## Summary

- Route empty landing chat creation through the worktree-aware chat creation path and use the returned initial session id.
- Ensure worktree-backed sessions clear stale resume cursors when the worktree changes before first message.
- Pin Claude Code startup to the resolved Memoize worktree cwd by setting `PWD`, clearing stale cwd hints, and appending a worktree-specific Claude Code prompt.

## Root Cause

Claude sessions could be created or resumed with state tied to the main checkout instead of the selected worktree. The landing flow dropped the resolved worktree id, and Claude Code could inherit stale cwd environment hints even when the SDK cwd option was set.

## Validation

- `bun test apps/server/test/claude-worktree-prompt.test.ts apps/server/test/message-store.test.ts`
- `bun run --filter @memoize/server check-types`
- `bun run --filter renderer check-types`

Note: full `bun run check-types` still fails in existing `apps/web` blog/content collection typings unrelated to this change.
