### PR TITLE
Release v0.5.0

### DIFF
--- a/.codex/skills/release-new-version/SKILL.md
+++ b/.codex/skills/release-new-version/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: release-new-version
+description: Release a new memoize version from this repository. Use when the user asks to release, bump versions, add changelogs, update the website changelog, create a release PR, or run the "Release New Version" slash command.
+---
+
+# Release New Version
+
+Run this skill from the memoize repository root.
+
+## Workflow
+
+1. Inspect `git status --short --branch`. If the working tree is dirty, explain that release automation needs a clean tree unless the user explicitly wants those changes included.
+2. Pull the latest base with `git fetch --prune origin` and `git pull --ff-only origin main`.
+3. Compare commits since the current `apps/desktop/package.json` version tag, e.g. `git log --pretty=format:%s v0.5.0..HEAD`.
+4. Decide the version bump:
+   - major: several breaking or migration-heavy changes.
+   - minor: multiple user-visible features or workflow changes.
+   - patch: fixes, polish, or small internal changes.
+   - If the signal is mixed or ambiguous, ask the user for `major`, `minor`, `patch`, or an explicit semver version.
+5. Run the helper script:
+
+```bash
+node scripts/release-new-version.mjs --yes
+```
+
+Use `--kind=major`, `--kind=minor`, `--kind=patch`, or `--version=x.y.z` when the user gave a specific choice.
+
+## What The Script Does
+
+- Pulls from `origin/main`.
+- Updates `apps/desktop/package.json` and `bun.lock`.
+- Adds a new `CHANGELOG.md` entry when one is missing.
+- Stages changelog, package metadata, the website changelog page, and this skill.
+- Runs `bun run check-types`.
+- Commits the release changes.
+- Pushes the branch.
+- Creates a GitHub PR against `main`.
+
+## After The PR Lands
+
+The repository release workflow is tag-driven. Create and push `vX.Y.Z` from `main` after merge to build, notarize, and publish the draft GitHub Release:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0]
+
+### Added
+- Worktree setup now streams live progress in the app, with a dedicated setup card and the Run action moved into the top bar for faster project startup. (#159)
+- The right sidebar can be customized as a panel dock, making terminal, browser, files, and supporting tools easier to arrange per workflow. (#156)
+- Codex goal mode is supported in chat sessions, giving agents a persistent objective and visible goal state during longer work. (#151)
+- Context window and usage-limit status popovers expose model usage and limit state without digging through raw provider output. (#154)
+- The website now has a direct download route for the latest signed macOS build. (#150)
+- Codex feature controls are gated by CLI capability, with fast mode surfaced only when the installed CLI can support it. (#158)
+
+### Changed
+- Worktree creation is faster, Pokemon chips are cleaner, and rare unlocks now appear as toasts instead of taking over the chip UI. (#157)
+- Code annotation composition and navigation are more polished, including clearer tray behavior and source reveal handling. (#153)
+- Loading states now use a simpler solid spinner treatment instead of the previous dotted loader set. (#155)
+
+### Fixed
+- Claude sessions now initialize with the correct worktree current working directory, so prompts run in the intended workspace. (#161)
+- Project Plan tray parsing supports newer TaskCreate and TaskUpdate tool event shapes. (#152)
+
 ## [0.4.0]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "memoize Alpha",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "memoize desktop app",
   "private": true,
   "author": {

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -1,0 +1,111 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { Container } from "@/components/container";
+import { Header } from "@/components/header";
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+  title: "Change Log",
+  description: "All notable memoize product changes, grouped by release.",
+  path: "/changelog",
+});
+
+type ChangeSection = {
+  title: string;
+  items: string[];
+};
+
+type ChangeRelease = {
+  version: string;
+  sections: ChangeSection[];
+};
+
+async function getChangelog(): Promise<ChangeRelease[]> {
+  const changelogPath = path.join(process.cwd(), "..", "..", "CHANGELOG.md");
+  const source = await readFile(changelogPath, "utf8");
+  const releases: ChangeRelease[] = [];
+  let currentRelease: ChangeRelease | null = null;
+  let currentSection: ChangeSection | null = null;
+
+  for (const line of source.split(/\r?\n/)) {
+    const releaseMatch = line.match(/^## \[([^\]]+)\]/);
+    if (releaseMatch) {
+      if (currentRelease) releases.push(currentRelease);
+      currentRelease = { version: releaseMatch[1] ?? "", sections: [] };
+      currentSection = null;
+      continue;
+    }
+
+    const sectionMatch = line.match(/^### (.+)$/);
+    if (sectionMatch && currentRelease) {
+      currentSection = { title: sectionMatch[1] ?? "", items: [] };
+      currentRelease.sections.push(currentSection);
+      continue;
+    }
+
+    if (line.startsWith("- ") && currentSection) {
+      currentSection.items.push(line.slice(2));
+    }
+  }
+
+  if (currentRelease) releases.push(currentRelease);
+
+  return releases.filter(
+    (release) =>
+      release.version !== "Unreleased" &&
+      release.sections.some((section) => section.items.length > 0),
+  );
+}
+
+export default async function ChangelogPage() {
+  const releases = await getChangelog();
+
+  return (
+    <section className="w-full">
+      <Container className="flex flex-col gap-12 pt-30 pb-24">
+        <div className="flex max-w-3xl flex-col gap-5">
+          <Header>Change Log</Header>
+          <p className="text-muted-foreground text-lg leading-8">
+            Product updates, fixes, and release notes for memoize.
+          </p>
+        </div>
+
+        <div className="grid gap-8">
+          {releases.map((release) => (
+            <article
+              key={release.version}
+              className="border-natural-white/10 bg-natural-white/5 rounded-2xl border p-6 shadow-card-lg md:p-8"
+            >
+              <div className="flex flex-col gap-8 md:grid md:grid-cols-[160px_1fr]">
+                <h2 className="text-heading font-mono text-2xl font-semibold">
+                  {release.version}
+                </h2>
+                <div className="grid gap-8">
+                  {release.sections.map((section) => (
+                    <section key={`${release.version}-${section.title}`}>
+                      <h3 className="text-natural-white text-sm font-semibold tracking-wide uppercase">
+                        {section.title}
+                      </h3>
+                      <ul className="mt-4 grid gap-3">
+                        {section.items.map((item) => (
+                          <li
+                            key={item}
+                            className="text-muted-foreground flex gap-3 text-sm leading-6"
+                          >
+                            <span className="bg-primary mt-2 size-1.5 shrink-0 rounded-full" />
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ))}
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/components/footer/index.tsx
+++ b/apps/web/components/footer/index.tsx
@@ -19,7 +19,7 @@ const data = {
     { label: "Compare", href: "/#compare" },
     { label: "FAQ", href: "/#faq" },
     { label: "Download", href: DOWNLOAD_URL },
-    { label: "Changelog", href: "/blog" },
+    { label: "Change Log", href: "/changelog" },
   ],
   Agents: [
     { label: "Claude Code", href: "/#features" },
@@ -30,6 +30,7 @@ const data = {
   ],
   Resources: [
     { label: "Blog", href: "/blog" },
+    { label: "Change Log", href: "/changelog" },
     { label: "GitHub", href: GITHUB_URL },
     { label: "Releases", href: `${GITHUB_URL}/releases` },
     { label: "Issues", href: `${GITHUB_URL}/issues` },

--- a/apps/web/components/navbar.tsx
+++ b/apps/web/components/navbar.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 const navItems = [
   { label: "Features", href: "/#features" },
   { label: "Compare", href: "/#compare" },
+  { label: "Change Log", href: "/changelog" },
   { label: "Blog", href: "/blog" },
 ];
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/scripts/release-new-version.mjs
+++ b/scripts/release-new-version.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const dryRun = process.argv.includes("--dry-run");
+const explicitVersion = readArg("--version");
+const releaseKind = readArg("--kind");
+const yes = process.argv.includes("--yes");
+
+function readArg(name) {
+  const prefix = `${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function run(command, args) {
+  const rendered = [command, ...args].join(" ");
+  if (dryRun) {
+    console.log(`[dry-run] ${rendered}`);
+    return "";
+  }
+  return execFileSync(command, args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: "inherit",
+  });
+}
+
+function currentBranch() {
+  return git(["branch", "--show-current"]);
+}
+
+function parseVersion(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) throw new Error(`Expected semver version, got ${version}`);
+  return match.slice(1).map(Number);
+}
+
+function bumpVersion(version, kind) {
+  const [major, minor, patch] = parseVersion(version);
+  if (kind === "major") return `${major + 1}.0.0`;
+  if (kind === "minor") return `${major}.${minor + 1}.0`;
+  if (kind === "patch") return `${major}.${minor}.${patch + 1}`;
+  throw new Error(`Unknown release kind: ${kind}`);
+}
+
+function inferKind(messages) {
+  const breaking = messages.filter((message) =>
+    /\b(breaking|rename|remove|drop|migration|major)\b/i.test(message),
+  );
+  const features = messages.filter((message) =>
+    /\b(add|adds|added|support|new|stream|gate|custom|mode|feature)\b/i.test(
+      message,
+    ),
+  );
+  const fixes = messages.filter((message) =>
+    /\b(fix|fixed|patch|bug|crash|correct)\b/i.test(message),
+  );
+
+  if (breaking.length >= 2) return { kind: "minor", confidence: "low" };
+  if (features.length >= 2) return { kind: "minor", confidence: "high" };
+  if (fixes.length > 0 && features.length === 0) {
+    return { kind: "patch", confidence: "high" };
+  }
+  return { kind: "patch", confidence: "low" };
+}
+
+function updateJsonVersion(relativePath, nextVersion) {
+  const file = join(root, relativePath);
+  const json = JSON.parse(readFileSync(file, "utf8"));
+  json.version = nextVersion;
+  writeFileSync(file, `${JSON.stringify(json, null, 2)}\n`);
+}
+
+function replaceInFile(relativePath, before, after) {
+  const file = join(root, relativePath);
+  const source = readFileSync(file, "utf8");
+  if (!source.includes(before)) {
+    throw new Error(`${relativePath} did not contain expected text: ${before}`);
+  }
+  writeFileSync(file, source.replace(before, after));
+}
+
+function releaseNotes(version, commits) {
+  const lines = commits.map((commit) => `- ${commit}`);
+  return `## [${version}]\n\n### Changed\n${lines.join("\n")}\n\n`;
+}
+
+const status = git(["status", "--porcelain"]);
+if (status) {
+  throw new Error("Working tree is dirty. Commit, stash, or discard changes first.");
+}
+
+run("git", ["fetch", "--prune", "origin"]);
+run("git", ["pull", "--ff-only", "origin", "main"]);
+
+const desktopPkg = JSON.parse(
+  readFileSync(join(root, "apps/desktop/package.json"), "utf8"),
+);
+const currentVersion = desktopPkg.version;
+const latestTag = `v${currentVersion}`;
+const log = git(["log", "--pretty=format:%s", `${latestTag}..HEAD`]);
+const commits = log.split("\n").filter(Boolean);
+
+if (commits.length === 0 && !explicitVersion) {
+  throw new Error(`No commits found after ${latestTag}.`);
+}
+
+const inferred = inferKind(commits);
+if (!explicitVersion && inferred.confidence === "low" && !releaseKind && !yes) {
+  throw new Error(
+    `Release kind is ambiguous. Re-run with --kind=major, --kind=minor, --kind=patch, or --version=x.y.z.\n` +
+      `Inferred ${inferred.kind} from ${commits.length} commits.`,
+  );
+}
+
+const nextVersion =
+  explicitVersion ?? bumpVersion(currentVersion, releaseKind ?? inferred.kind);
+
+if (currentBranch() === "main") {
+  run("git", ["checkout", "-b", `release-v${nextVersion}`]);
+}
+
+updateJsonVersion("apps/desktop/package.json", nextVersion);
+replaceInFile(
+  "bun.lock",
+  `"apps/desktop": {\n      "name": "desktop",\n      "version": "${currentVersion}",`,
+  `"apps/desktop": {\n      "name": "desktop",\n      "version": "${nextVersion}",`,
+);
+
+const changelog = readFileSync(join(root, "CHANGELOG.md"), "utf8");
+if (!changelog.includes(`## [${nextVersion}]`)) {
+  writeFileSync(
+    join(root, "CHANGELOG.md"),
+    changelog.replace("## [Unreleased]\n\n", `## [Unreleased]\n\n${releaseNotes(nextVersion, commits)}`),
+  );
+}
+
+run("bun", ["run", "check-types"]);
+run("git", ["add", "CHANGELOG.md", "apps/desktop/package.json", "bun.lock", "apps/web", "scripts/release-new-version.mjs", ".codex/skills/release-new-version"]);
+run("git", ["commit", "-m", `Release v${nextVersion}`]);
+run("git", ["push", "-u", "origin", "HEAD"]);
+
+const prBody = `## Summary
+- release memoize v${nextVersion}
+- update CHANGELOG.md and package metadata
+- keep the website Change Log page rendering release notes from CHANGELOG.md
+
+## Test
+- bun run check-types
+
+Release artifacts are produced by pushing tag v${nextVersion} after this PR lands.`;
+
+run("gh", [
+  "pr",
+  "create",
+  "--base",
+  "main",
+  "--fill",
+  "--title",
+  `Release v${nextVersion}`,
+  "--body",
+  prBody,
+]);
+
+console.log(`Prepared release PR for v${nextVersion}.`);


### PR DESCRIPTION
## Summary
- bump memoize desktop release metadata to v0.5.0
- add v0.5.0 release notes to CHANGELOG.md
- add a /changelog web page that renders release notes from CHANGELOG.md
- add a local Release New Version skill and helper script for future release PRs

## Verification
- bun run check-types
- bun run test
- bun run build (apps/web)
- curl http://localhost:3001/changelog and confirmed the 0.5.0 release renders

## Release
After this PR lands, push tag v0.5.0 from main to trigger the existing release workflow.