### PR TITLE
Make release skill available to Claude and Codex

### DIFF
--- a/.claude/commands/release-new-version.md
+++ b/.claude/commands/release-new-version.md
@@ -1,0 +1,11 @@
+Release a new memoize version.
+
+Use the `release-new-version` skill from this repository.
+
+If the user provided arguments, pass them through to `scripts/release-new-version.mjs` where appropriate:
+- `major` -> `--kind=major`
+- `minor` -> `--kind=minor`
+- `patch` -> `--kind=patch`
+- a semver version like `0.5.1` -> `--version=0.5.1`
+
+Follow the skill workflow exactly: inspect git state, pull `origin/main`, infer or ask for the bump level, update changelog/package metadata, verify, commit, push, and create the PR.

--- a/.claude/skills/release-new-version/SKILL.md
+++ b/.claude/skills/release-new-version/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: release-new-version
+description: Release a new memoize version from this repository. Use when the user asks to release, bump versions, add changelogs, update the website changelog, create a release PR, or run the "Release New Version" slash command.
+---
+
+# Release New Version
+
+Run this skill from the memoize repository root.
+
+## Workflow
+
+1. Inspect `git status --short --branch`. If the working tree is dirty, explain that release automation needs a clean tree unless the user explicitly wants those changes included.
+2. Pull the latest base with `git fetch --prune origin` and `git pull --ff-only origin main`.
+3. Compare commits since the current `apps/desktop/package.json` version tag, e.g. `git log --pretty=format:%s v0.5.0..HEAD`.
+4. Decide the version bump:
+   - major: several breaking or migration-heavy changes.
+   - minor: multiple user-visible features or workflow changes.
+   - patch: fixes, polish, or small internal changes.
+   - If the signal is mixed or ambiguous, ask the user for `major`, `minor`, `patch`, or an explicit semver version.
+5. Run the helper script:
+
+```bash
+node scripts/release-new-version.mjs --yes
+```
+
+Use `--kind=major`, `--kind=minor`, `--kind=patch`, or `--version=x.y.z` when the user gave a specific choice.
+
+## What The Script Does
+
+- Pulls from `origin/main`.
+- Updates `apps/desktop/package.json` and `bun.lock`.
+- Adds a new `CHANGELOG.md` entry when one is missing.
+- Stages changelog, package metadata, the website changelog page, and this skill.
+- Runs `bun run check-types`.
+- Commits the release changes.
+- Pushes the branch.
+- Creates a GitHub PR against `main`.
+
+## After The PR Lands
+
+The repository release workflow is tag-driven. Create and push `vX.Y.Z` from `main` after merge to build, notarize, and publish the draft GitHub Release:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```

--- a/.codex/commands/release-new-version.md
+++ b/.codex/commands/release-new-version.md
@@ -1,0 +1,11 @@
+Release a new memoize version.
+
+Use the `release-new-version` skill from this repository.
+
+If the user provided arguments, pass them through to `scripts/release-new-version.mjs` where appropriate:
+- `major` -> `--kind=major`
+- `minor` -> `--kind=minor`
+- `patch` -> `--kind=patch`
+- a semver version like `0.5.1` -> `--version=0.5.1`
+
+Follow the skill workflow exactly: inspect git state, pull `origin/main`, infer or ask for the bump level, update changelog/package metadata, verify, commit, push, and create the PR.


### PR DESCRIPTION
## Summary
- add a repo-local Claude skill for release-new-version
- add Claude and Codex slash-command wrappers for /release-new-version
- keep the command pointed at the shared release helper script

## Verification
- git diff --check
- installed local copies under ~/.claude and ~/.codex for immediate use