### PR TITLE
Add tokenmaxer onboarding and usage fixes

### DIFF
--- a/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
+++ b/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
@@ -1,5 +1,8 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "~/components/ui/button";
@@ -9,14 +12,22 @@ import { useSettingsStore } from "../../store/settings.ts";
 import { useWorkspaceStore } from "../../store/workspace.ts";
 import { DefaultsStep } from "./steps/defaults.tsx";
 import { DoneStep } from "./steps/done.tsx";
+import { MaximizeStep } from "./steps/maximize.tsx";
 import { ProjectStep } from "./steps/project.tsx";
 import { ProviderStep } from "./steps/provider.tsx";
 import { WelcomeStep } from "./steps/welcome.tsx";
 
-type StepId = "welcome" | "provider" | "project" | "defaults" | "done";
+type StepId =
+  | "welcome"
+  | "maximize"
+  | "provider"
+  | "project"
+  | "defaults"
+  | "done";
 
 const STEPS: ReadonlyArray<StepId> = [
   "welcome",
+  "maximize",
   "provider",
   "project",
   "defaults",
@@ -83,10 +94,7 @@ export function OnboardingWizard() {
     <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden">
       {/* Ambient color: two soft radial blooms behind a heavy blur for that
           frosted-vibrancy feel. Sits behind the card, never interactive. */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10"
-      >
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute -top-32 -left-24 size-[28rem] rounded-full bg-[radial-gradient(circle_at_center,theme(colors.indigo.500/0.18),transparent_70%)] blur-3xl" />
         <div className="absolute -bottom-40 -right-20 size-[32rem] rounded-full bg-[radial-gradient(circle_at_center,theme(colors.fuchsia.500/0.14),transparent_70%)] blur-3xl" />
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,theme(colors.white/0.04),transparent_60%)]" />
@@ -101,6 +109,7 @@ export function OnboardingWizard() {
 
           <div className="min-h-[24rem] px-1 py-2">
             {stepId === "welcome" && <WelcomeStep />}
+            {stepId === "maximize" && <MaximizeStep />}
             {stepId === "provider" && <ProviderStep />}
             {stepId === "project" && <ProjectStep />}
             {stepId === "defaults" && <DefaultsStep />}

--- a/apps/renderer/src/components/onboarding/steps/defaults.tsx
+++ b/apps/renderer/src/components/onboarding/steps/defaults.tsx
@@ -85,13 +85,21 @@ export function DefaultsStep() {
           </div>
         </div>
 
-        <label className="flex cursor-pointer items-center gap-3 rounded-2xl bg-white/[0.025] px-3.5 py-3 transition-colors hover:bg-white/[0.05]">
-          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="text-[13px] font-medium leading-none text-foreground">
-              New worktree per chat
+        <label className="flex cursor-pointer items-start gap-3 rounded-2xl bg-white/[0.025] px-3.5 py-3 transition-colors hover:bg-white/[0.05]">
+          <span className="flex min-w-0 flex-1 flex-col gap-1">
+            <span className="flex items-center gap-2">
+              <span className="text-[13px] font-medium leading-none text-foreground">
+                New worktree per chat
+              </span>
+              <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-primary">
+                Recommended
+              </span>
             </span>
             <span className="text-[11px] leading-snug text-muted-foreground">
-              Each chat runs on its own branch under <code>~/.memoize/</code>.
+              A git worktree is a second checkout of your repo on its own branch.
+              Each chat gets one under <code>~/.memoize/</code>, so agents can run
+              in parallel without stepping on each other or your working tree.
+              You merge the branches you like.
             </span>
           </span>
           <Switch

--- a/apps/renderer/src/components/onboarding/steps/maximize.tsx
+++ b/apps/renderer/src/components/onboarding/steps/maximize.tsx
@@ -27,28 +27,6 @@ const MONTHLY_STACK = {
   ],
 } as const;
 
-const MONTHLY_CARDS: ReadonlyArray<{
-  readonly label: string;
-  readonly value: string;
-  readonly detail: string;
-}> = [
-  {
-    label: "You pay this month",
-    value: MONTHLY_STACK.subscriptionCost,
-    detail: "Claude Max + ChatGPT Pro",
-  },
-  {
-    label: "API value used this month",
-    value: "dynamic",
-    detail: "From your local agent logs",
-  },
-  {
-    label: "You can pull this month",
-    value: MONTHLY_STACK.apiValue,
-    detail: "API-equivalent monthly ceiling",
-  },
-];
-
 const currentMonthRange = () => {
   const now = new Date();
   const since = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -110,7 +88,7 @@ export function MaximizeStep() {
   const sourceLine = sources.length > 0 ? ` across ${sources.join(" · ")}` : "";
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-8">
       <StepHeader
         title="Maximize this month"
         subtitle="See the subscription bill, the API value you already used, and the value still available from the plans you pay for."
@@ -119,20 +97,10 @@ export function MaximizeStep() {
       {loading ? (
         <SpendSkeleton />
       ) : (
-        <div className="grid gap-3 sm:grid-cols-3">
-          {MONTHLY_CARDS.map((card) => (
-            <MonthlyCard
-              key={card.label}
-              label={card.label}
-              value={card.value === "dynamic" ? usedValue : card.value}
-              detail={card.detail}
-              accent={card.value === "dynamic"}
-            />
-          ))}
-        </div>
+        <MonthlySnapshot usedValue={usedValue} tokens={tokens} sourceLine={sourceLine} />
       )}
 
-      <div className="flex flex-col gap-3 rounded-2xl bg-white/[0.025] p-5">
+      <div className="flex flex-col gap-4 rounded-2xl bg-white/[0.025] p-5">
         <div className="flex items-start gap-3">
           <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary">
             <HugeiconsIcon
@@ -174,32 +142,70 @@ export function MaximizeStep() {
   );
 }
 
-function MonthlyCard({
+function MonthlySnapshot({
+  usedValue,
+  tokens,
+  sourceLine,
+}: {
+  usedValue: string;
+  tokens: number;
+  sourceLine: string;
+}) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_15rem]">
+      <div className="flex min-h-36 flex-col justify-between rounded-2xl border border-primary/10 bg-primary/[0.055] p-5">
+        <div className="flex flex-col gap-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-primary/80">
+            API value used this month
+          </span>
+          <span className="text-[12px] text-muted-foreground">
+            From your local agent logs
+          </span>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <span className="text-4xl font-semibold leading-none tracking-tight tabular-nums text-primary">
+            {usedValue}
+          </span>
+          <span className="text-[11px] leading-snug text-muted-foreground">
+            {tokens > 0 ? `${formatTokens(tokens)} tokens${sourceLine}` : "No usage found yet"}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid gap-3">
+        <CompactMetric
+          label="You pay"
+          value={MONTHLY_STACK.subscriptionCost}
+          detail="Claude Max + ChatGPT Pro"
+        />
+        <CompactMetric
+          label="Available ceiling"
+          value={MONTHLY_STACK.apiValue}
+          detail="API-equivalent monthly value"
+        />
+      </div>
+    </div>
+  );
+}
+
+function CompactMetric({
   label,
   value,
   detail,
-  accent,
 }: {
   label: string;
   value: string;
   detail: string;
-  accent?: boolean;
 }) {
   return (
-    <div className="flex min-h-32 flex-col justify-between rounded-2xl bg-white/[0.025] p-4">
-      <span className="text-[11px] font-medium leading-snug text-muted-foreground">
+    <div className="flex min-h-[4.5rem] flex-col justify-center gap-1 rounded-2xl bg-white/[0.025] px-4 py-3">
+      <span className="text-[11px] font-medium text-muted-foreground">
         {label}
       </span>
-      <span
-        className={
-          accent
-            ? "text-2xl font-semibold leading-tight tracking-tight tabular-nums text-primary"
-            : "text-2xl font-semibold leading-tight tracking-tight tabular-nums text-foreground"
-        }
-      >
+      <span className="text-xl font-semibold leading-tight tracking-tight tabular-nums text-foreground">
         {value}
       </span>
-      <span className="text-[11px] leading-snug text-muted-foreground">
+      <span className="text-[10px] leading-snug text-muted-foreground">
         {detail}
       </span>
     </div>
@@ -235,7 +241,7 @@ function PlanRow({
 
 function SpendSkeleton() {
   return (
-    <div className="flex flex-col gap-3 rounded-2xl bg-white/[0.025] p-5">
+    <div className="flex flex-col gap-4 rounded-2xl bg-white/[0.025] p-5">
       <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
         <HugeiconsIcon
           icon={Loading02Icon}
@@ -244,13 +250,22 @@ function SpendSkeleton() {
         />
         Scanning this month&apos;s local agent logs...
       </div>
-      <div className="grid gap-3 sm:grid-cols-3">
-        {[0, 1, 2].map((i) => (
-          <div key={i} className="flex flex-col gap-2">
-            <div className="h-3 w-20 animate-pulse rounded bg-white/[0.06]" />
-            <div className="h-8 w-24 animate-pulse rounded bg-white/[0.06]" />
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_15rem]">
+        <div className="flex h-36 flex-col justify-between rounded-2xl bg-white/[0.035] p-5">
+          <div className="h-3 w-40 animate-pulse rounded bg-white/[0.06]" />
+          <div className="space-y-2">
+            <div className="h-9 w-36 animate-pulse rounded bg-white/[0.06]" />
+            <div className="h-3 w-48 animate-pulse rounded bg-white/[0.06]" />
           </div>
-        ))}
+        </div>
+        <div className="grid gap-3">
+          {[0, 1].map((i) => (
+            <div key={i} className="flex flex-col justify-center gap-2 rounded-2xl bg-white/[0.025] px-4 py-3">
+              <div className="h-3 w-20 animate-pulse rounded bg-white/[0.06]" />
+              <div className="h-6 w-28 animate-pulse rounded bg-white/[0.06]" />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/apps/renderer/src/components/onboarding/steps/maximize.tsx
+++ b/apps/renderer/src/components/onboarding/steps/maximize.tsx
@@ -1,0 +1,257 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  CircleArrowUp01Icon,
+  Loading02Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import { Effect } from "effect";
+import { useEffect, useState } from "react";
+
+import type { UsageReport } from "@memoize/wire";
+
+import { formatTokens, formatUsd, totalTokens } from "~/lib/format-usage.ts";
+import { getRpcClient } from "../../../lib/rpc-client.ts";
+import { StepHeader } from "./shared.tsx";
+
+/**
+ * Monthly reference for the "token maxer" onboarding story. We do not know the
+ * user's exact plan yet, so this mirrors the board's default stack: Claude Max
+ * plus ChatGPT Pro. `apiValue` is API-equivalent monthly value heavy users can
+ * pull from those flat fees as of mid-2026, illustrative and not guaranteed.
+ */
+const MONTHLY_STACK = {
+  subscriptionCost: "$400",
+  apiValue: "$11,500 to $15,000",
+  plans: [
+    { name: "Claude Max", price: "$200/mo", potential: "$1,500 to $5,000/mo" },
+    { name: "ChatGPT Pro", price: "$200/mo", potential: "up to $10,000/mo" },
+  ],
+} as const;
+
+const MONTHLY_CARDS: ReadonlyArray<{
+  readonly label: string;
+  readonly value: string;
+  readonly detail: string;
+}> = [
+  {
+    label: "You pay this month",
+    value: MONTHLY_STACK.subscriptionCost,
+    detail: "Claude Max + ChatGPT Pro",
+  },
+  {
+    label: "API value used this month",
+    value: "dynamic",
+    detail: "From your local agent logs",
+  },
+  {
+    label: "You can pull this month",
+    value: MONTHLY_STACK.apiValue,
+    detail: "API-equivalent monthly ceiling",
+  },
+];
+
+const currentMonthRange = () => {
+  const now = new Date();
+  const since = new Date(now.getFullYear(), now.getMonth(), 1);
+  const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  const until = new Date(nextMonth.getTime() - 1);
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  return { since, until, timezone };
+};
+
+/**
+ * Onboarding hook step. Reads this month's global Tokenmaxer report (scanned
+ * from local CLI logs) and frames the whole monthly picture: what a user pays,
+ * what API-equivalent value they already used, and what the subscription stack
+ * can potentially produce.
+ */
+export function MaximizeStep() {
+  const [report, setReport] = useState<UsageReport | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    void getRpcClient()
+      .then((client) =>
+        Effect.runPromise(
+          client.usage.report({
+            bucket: "monthly",
+            ...currentMonthRange(),
+          }),
+        ),
+      )
+      .then((nextReport) => {
+        if (cancelled) return;
+        setReport(nextReport);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setReport(null);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const summary = report?.summary ?? null;
+  const tokens = summary !== null ? totalTokens(summary) : 0;
+  const hasSpend = summary !== null && tokens > 0;
+  const usedValue =
+    summary !== null && summary.costUsd !== null
+      ? formatUsd(summary.costUsd)
+      : "$0.00";
+  const sources =
+    report?.bySource
+      .filter((s) => totalTokens(s) > 0)
+      .map((s) => s.label)
+      .slice(0, 6) ?? [];
+  const sourceLine = sources.length > 0 ? ` across ${sources.join(" · ")}` : "";
+
+  return (
+    <div className="flex flex-col gap-6">
+      <StepHeader
+        title="Maximize this month"
+        subtitle="See the subscription bill, the API value you already used, and the value still available from the plans you pay for."
+      />
+
+      {loading ? (
+        <SpendSkeleton />
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-3">
+          {MONTHLY_CARDS.map((card) => (
+            <MonthlyCard
+              key={card.label}
+              label={card.label}
+              value={card.value === "dynamic" ? usedValue : card.value}
+              detail={card.detail}
+              accent={card.value === "dynamic"}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3 rounded-2xl bg-white/[0.025] p-5">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary">
+            <HugeiconsIcon
+              icon={CircleArrowUp01Icon}
+              className="size-4"
+              strokeWidth={1.75}
+            />
+          </span>
+          <div className="flex flex-col gap-1">
+            <span className="text-[14px] font-semibold text-foreground">
+              The gap is the opportunity
+            </span>
+            <p className="max-w-md text-[12px] leading-relaxed text-muted-foreground">
+              You pay a fixed monthly subscription. The more agents you run in
+              parallel, the more API-equivalent value you get from the same
+              bill.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col rounded-xl border border-white/[0.06] bg-black/10">
+          {MONTHLY_STACK.plans.map((p) => (
+            <PlanRow key={p.name} {...p} />
+          ))}
+        </div>
+
+        {hasSpend ? (
+          <p className="text-[10px] leading-snug text-muted-foreground/70">
+            This month: {formatTokens(tokens)} tokens{sourceLine}.
+          </p>
+        ) : (
+          <p className="text-[10px] leading-snug text-muted-foreground/70">
+            No local usage found for this month yet. Once you run agents, this
+            screen shows the API value you have already used.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MonthlyCard({
+  label,
+  value,
+  detail,
+  accent,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="flex min-h-32 flex-col justify-between rounded-2xl bg-white/[0.025] p-4">
+      <span className="text-[11px] font-medium leading-snug text-muted-foreground">
+        {label}
+      </span>
+      <span
+        className={
+          accent
+            ? "text-2xl font-semibold leading-tight tracking-tight tabular-nums text-primary"
+            : "text-2xl font-semibold leading-tight tracking-tight tabular-nums text-foreground"
+        }
+      >
+        {value}
+      </span>
+      <span className="text-[11px] leading-snug text-muted-foreground">
+        {detail}
+      </span>
+    </div>
+  );
+}
+
+function PlanRow({
+  name,
+  price,
+  potential,
+}: {
+  name: string;
+  price: string;
+  potential: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-white/[0.06] px-3 py-2.5 first:border-0">
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate text-[12px] font-medium text-foreground">
+          {name}
+        </span>
+        <span className="text-[11px] text-muted-foreground">{price}</span>
+      </span>
+      <span className="flex shrink-0 flex-col items-end">
+        <span className="text-[13px] font-semibold tabular-nums text-primary">
+          {potential}
+        </span>
+        <span className="text-[10px] text-muted-foreground">API value</span>
+      </span>
+    </div>
+  );
+}
+
+function SpendSkeleton() {
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl bg-white/[0.025] p-5">
+      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <HugeiconsIcon
+          icon={Loading02Icon}
+          className="size-3.5 animate-spin"
+          aria-hidden
+        />
+        Scanning this month&apos;s local agent logs...
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="flex flex-col gap-2">
+            <div className="h-3 w-20 animate-pulse rounded bg-white/[0.06]" />
+            <div className="h-8 w-24 animate-pulse rounded bg-white/[0.06]" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/project.tsx
+++ b/apps/renderer/src/components/onboarding/steps/project.tsx
@@ -27,7 +27,7 @@ export function ProjectStep() {
     <div className="flex flex-col gap-7">
       <StepHeader
         title="Add your first project"
-        subtitle="Any folder on your machine — we'll list it in the sidebar, no copies made."
+        subtitle="Any folder on your machine. We'll list it in the sidebar, no copies made."
       />
 
       {justAdded === null ? (
@@ -45,7 +45,7 @@ export function ProjectStep() {
               {busy ? "Opening picker…" : "Choose a folder"}
             </span>
             <span className="text-[11px] text-muted-foreground">
-              Click to browse — or drag one in
+              Click to browse, or drag one in
             </span>
           </span>
         </button>

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -286,8 +286,8 @@ function ProviderStatus({
   if (state.kind === "ready") {
     const label =
       state.via === "cli"
-        ? `${PROVIDER_LABEL[providerId]} CLI is logged in — you're all set.`
-        : `${PROVIDER_LABEL[providerId]} API key saved — you're all set.`;
+        ? `${PROVIDER_LABEL[providerId]} CLI is logged in. You're all set.`
+        : `${PROVIDER_LABEL[providerId]} API key saved. You're all set.`;
     return (
       <div className="flex items-center gap-2 rounded-full bg-emerald-400/[0.08] px-3 py-2 text-[12px] text-emerald-200/90">
         <HugeiconsIcon icon={Tick01Icon} className="size-3.5" strokeWidth={3} />
@@ -318,7 +318,7 @@ function ProviderStatus({
 
   const subline =
     state.kind === "signed-out"
-      ? "Already installed — just run the login command below."
+      ? "Already installed. Just run the login command below."
       : state.kind === "subscription"
         ? "Your CLI login was detected, but the required paid plan was not confirmed."
         : state.kind === "outdated"

--- a/apps/renderer/src/components/onboarding/steps/welcome.tsx
+++ b/apps/renderer/src/components/onboarding/steps/welcome.tsx
@@ -3,30 +3,27 @@ export function WelcomeStep() {
     <div className="flex h-full flex-col gap-10">
       <div className="flex flex-col gap-3">
         <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
-          Welcome
+          Welcome to memoize
         </span>
         <h1 className="text-4xl font-semibold leading-[1.05] tracking-tight text-foreground">
-          A calm home for
+          Every agent,
           <br />
-          parallel agents.
+          one workspace.
         </h1>
         <p className="max-w-md pt-1 text-[15px] leading-relaxed text-muted-foreground">
-          Run Claude or Codex on your repos — each chat in its own git worktree,
-          each agent on its own thread. We&apos;ll set things up in under a
-          minute.
+          Run Claude, Codex, Grok and more on your repos, side by side.
         </p>
       </div>
 
       <ul className="flex flex-col gap-0.5 text-sm">
         <Row title="No new logins">
-          We reuse your local CLI auth (claude, codex, gemini, grok, cursor).
-          Just pick your default and go — no API keys, no re-auth.
+          Reuses the CLI auth already on your Mac.
         </Row>
-        <Row title="One worktree per chat">
-          Experiments stay isolated, branches stay tidy.
+        <Row title="A worktree per chat">
+          Each agent runs on its own branch.
         </Row>
-        <Row title="Two quick picks">
-          Choose your default agent, add a project — you&apos;re in.
+        <Row title="Built for token maxers">
+          Run agents in parallel, get more from every plan.
         </Row>
       </ul>
     </div>

--- a/apps/renderer/src/components/usage-dashboard.tsx
+++ b/apps/renderer/src/components/usage-dashboard.tsx
@@ -75,7 +75,7 @@ export function UsageDashboard({
         </div>
         <button
           type="button"
-          onClick={() => void refresh(projectId)}
+          onClick={() => void refresh(projectId, { forceRefresh: true })}
           className="inline-flex size-7 items-center justify-center rounded-md border border-border text-muted-foreground hover:text-foreground"
           title="Refresh usage"
           aria-label="Refresh usage"
@@ -115,24 +115,27 @@ function UsageReportView({
   onBucket: (bucket: UsageBucket) => void;
 }) {
   const summary = report.summary;
-  const metrics = [
-    { label: "Total cost", value: formatUsd(summary.costUsd), hint: costHint(summary.costStatus) },
-    {
-      label: "Total tokens",
-      value: formatTokens(totalTokens(summary)),
-      hint: `${summary.recordCount.toLocaleString()} records`,
-    },
-    {
-      label: "Input / Output",
-      value: `${formatTokens(summary.inputTokens)} / ${formatTokens(summary.outputTokens)}`,
-      hint: undefined,
-    },
-    {
-      label: "Cache",
-      value: formatTokens(cacheTokens(summary)),
-      hint: summary.reasoningTokens > 0 ? `${formatTokens(summary.reasoningTokens)} reasoning` : undefined,
-    },
-  ];
+  const metrics = useMemo(
+    () => [
+      { label: "Total cost", value: formatUsd(summary.costUsd), hint: costHint(summary.costStatus) },
+      {
+        label: "Total tokens",
+        value: formatTokens(totalTokens(summary)),
+        hint: `${summary.recordCount.toLocaleString()} records`,
+      },
+      {
+        label: "Input / Output",
+        value: `${formatTokens(summary.inputTokens)} / ${formatTokens(summary.outputTokens)}`,
+        hint: undefined,
+      },
+      {
+        label: "Cache",
+        value: formatTokens(cacheTokens(summary)),
+        hint: summary.reasoningTokens > 0 ? `${formatTokens(summary.reasoningTokens)} reasoning` : undefined,
+      },
+    ],
+    [summary],
+  );
   return (
     <div className="min-h-0 flex-1 space-y-4 overflow-auto p-4">
       <Frame>
@@ -415,6 +418,7 @@ function SessionsTable({ rows }: { rows: ReadonlyArray<UsageGroup> }) {
 
   const sorted = useMemo(() => {
     const value = (r: UsageGroup) => (sortKey === "cost" ? (r.costUsd ?? 0) : totalTokens(r));
+    if (sortKey === "tokens") return rows;
     return rows.slice().sort((a, b) => value(b) - value(a));
   }, [rows, sortKey]);
 

--- a/apps/renderer/src/components/usage-dashboard.tsx
+++ b/apps/renderer/src/components/usage-dashboard.tsx
@@ -10,6 +10,13 @@ import type {
 } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
+import {
+  cacheTokens,
+  formatTokens,
+  formatUsd,
+  totalTokens,
+  type TokenRow,
+} from "~/lib/format-usage.ts";
 import { Button } from "./ui/button.tsx";
 import { Frame, FrameFooter, FrameHeader, FramePanel, FrameTitle } from "./ui/frame.tsx";
 import {
@@ -24,27 +31,6 @@ import { useUsageStore } from "../store/usage.ts";
 
 const BUCKETS: ReadonlyArray<UsageBucket> = ["daily", "weekly", "monthly", "session"];
 const PAGE_SIZE = 10;
-
-const formatTokens = (n: number): string => {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
-};
-
-const formatUsd = (n: number | null): string => (n === null ? "—" : `$${n.toFixed(2)}`);
-
-interface TokenRow {
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadTokens: number;
-  cacheCreationTokens: number;
-  reasoningTokens: number;
-}
-
-const totalTokens = (row: TokenRow): number =>
-  row.inputTokens + row.outputTokens + row.cacheReadTokens + row.cacheCreationTokens + row.reasoningTokens;
-
-const cacheTokens = (row: TokenRow): number => row.cacheReadTokens + row.cacheCreationTokens;
 
 /** Token-type series used for the stacked chart, legend, and tooltip. */
 const SERIES: ReadonlyArray<{

--- a/apps/renderer/src/lib/format-usage.ts
+++ b/apps/renderer/src/lib/format-usage.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared usage formatters. Used by the Tokenmaxer usage dashboard and the
+ * onboarding "Maximize" step so both render token/cost numbers identically.
+ */
+
+export interface TokenRow {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly reasoningTokens: number;
+}
+
+/** Compact token count, e.g. 1_234_567 → "1.2M", 1_234 → "1.2k". */
+export const formatTokens = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+};
+
+/** USD with two decimals, or a compact placeholder when cost is unavailable. */
+export const formatUsd = (n: number | null): string =>
+  n === null ? "N/A" : `$${n.toFixed(2)}`;
+
+/** Sum of every token type on a row. */
+export const totalTokens = (row: TokenRow): number =>
+  row.inputTokens +
+  row.outputTokens +
+  row.cacheReadTokens +
+  row.cacheCreationTokens +
+  row.reasoningTokens;
+
+/** Anthropic-style cache tokens (read + creation). */
+export const cacheTokens = (row: TokenRow): number =>
+  row.cacheReadTokens + row.cacheCreationTokens;

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -18,6 +18,7 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 import { formatError } from "../lib/format-error.ts";
 import { useMessagesStore } from "./messages.ts";
 import { useSessionsStore } from "./sessions.ts";
+import { useUiStore } from "./ui.ts";
 import { useWorkspaceStore } from "./workspace.ts";
 import { useWorktreesStore } from "./worktrees.ts";
 
@@ -545,6 +546,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
       return;
     }
     const projectId = findChatProject(get().chatsByProject, chatId);
+    useUiStore.getState().setActiveMainTab("chat");
     set((s) => ({
       selectedChatId: chatId,
       selectedChatByProject:

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -59,7 +59,7 @@ const fallbackSnapshot = (): SettingsSlice => ({
   defaultProviderId: DEFAULT_PROVIDER,
   defaultModelByProvider: seedModels(),
   defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
-  defaultAutoCreateWorktree: false,
+  defaultAutoCreateWorktree: true,
   completionSoundEnabled: false,
   completionSoundPreset: "chime",
   onboardingCompleted: false,

--- a/apps/renderer/src/store/usage.ts
+++ b/apps/renderer/src/store/usage.ts
@@ -5,12 +5,22 @@ import type { FolderId, UsageBucket, UsageReport } from "@memoize/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 
+let getUsageRpcClient: typeof getRpcClient = getRpcClient;
+
+export const setUsageRpcClientForTest = (fn: typeof getRpcClient): void => {
+  getUsageRpcClient = fn;
+};
+
 type UsageState = {
   readonly report: UsageReport | null;
   readonly loading: boolean;
   readonly error: string | null;
   readonly bucket: UsageBucket;
-  readonly refresh: (projectId: FolderId | null) => Promise<void>;
+  readonly requestId: number;
+  readonly refresh: (
+    projectId: FolderId | null,
+    opts?: { readonly forceRefresh?: boolean },
+  ) => Promise<void>;
   readonly setBucket: (bucket: UsageBucket, projectId: FolderId | null) => Promise<void>;
 };
 
@@ -19,19 +29,24 @@ export const useUsageStore = create<UsageState>((set, get) => ({
   loading: false,
   error: null,
   bucket: "daily",
-  refresh: async (projectId) => {
+  requestId: 0,
+  refresh: async (projectId, opts) => {
     const bucket = get().bucket;
-    set({ loading: true, error: null });
+    const requestId = get().requestId + 1;
+    set({ loading: true, error: null, requestId });
     try {
-      const client = await getRpcClient();
+      const client = await getUsageRpcClient();
       const report = await Effect.runPromise(
         client.usage.report({
           bucket,
           projectId: projectId ?? undefined,
+          forceRefresh: opts?.forceRefresh,
         }),
       );
+      if (get().requestId !== requestId) return;
       set({ report, loading: false });
     } catch (error) {
+      if (get().requestId !== requestId) return;
       set({
         loading: false,
         error: error instanceof Error ? error.message : String(error),

--- a/apps/renderer/test/chats-store.test.ts
+++ b/apps/renderer/test/chats-store.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import type { Chat, ChatId, FolderId, Session, SessionId } from "@memoize/wire";
+
+import { useChatsStore } from "../src/store/chats.ts";
+import { useSessionsStore } from "../src/store/sessions.ts";
+import { useUiStore } from "../src/store/ui.ts";
+import { useWorkspaceStore } from "../src/store/workspace.ts";
+
+const projectId = "proj-1" as FolderId;
+const chatId = "chat-1" as ChatId;
+const sessionId = "session-1" as SessionId;
+const now = new Date("2026-06-21T00:00:00.000Z");
+
+const chat: Chat = {
+  id: chatId,
+  projectId,
+  worktreeId: null,
+  title: "Lag fix",
+  activeSessionId: sessionId,
+  archivedAt: null,
+  lastMessageAt: null,
+  lastReadAt: now,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const session: Session = {
+  id: sessionId,
+  projectId,
+  title: "Main",
+  providerId: "codex",
+  model: "gpt-5.4",
+  status: "idle",
+  archivedAt: null,
+  cursor: null,
+  resumeStrategy: "none",
+  runtimeMode: "approval-required",
+  worktreeId: null,
+  chatId,
+  forkedFromSessionId: null,
+  forkedFromMessageId: null,
+  permissionMode: "default",
+  toolSearch: false,
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe("chats store selection", () => {
+  beforeEach(() => {
+    useUiStore.setState({ activeMainTab: "chat" });
+    useWorkspaceStore.setState({ selectedFolderId: projectId });
+    useSessionsStore.setState({
+      sessionsByProject: { [projectId]: [session] },
+      selectedSessionId: null,
+      selectedSessionByProject: {},
+    });
+    useChatsStore.setState({
+      chatsByProject: { [projectId]: [chat] },
+      selectedChatId: null,
+      selectedChatByProject: {},
+      error: null,
+    });
+  });
+
+  it("returns to the chat surface when selecting a chat from usage", () => {
+    useUiStore.setState({ activeMainTab: "usage" });
+
+    useChatsStore.getState().select(chatId);
+
+    expect(useUiStore.getState().activeMainTab).toBe("chat");
+    expect(useChatsStore.getState().selectedChatId).toBe(chatId);
+    expect(useSessionsStore.getState().selectedSessionId).toBe(sessionId);
+  });
+
+  it("does not force the chat surface when clearing selection", () => {
+    useUiStore.setState({ activeMainTab: "usage" });
+
+    useChatsStore.getState().select(null);
+
+    expect(useUiStore.getState().activeMainTab).toBe("usage");
+    expect(useChatsStore.getState().selectedChatId).toBeNull();
+    expect(useSessionsStore.getState().selectedSessionId).toBeNull();
+  });
+});

--- a/apps/renderer/test/usage-store.test.ts
+++ b/apps/renderer/test/usage-store.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+
+import type { UsageReport } from "@memoize/wire";
+
+let reportCalls: Array<{ readonly bucket?: string; readonly forceRefresh?: boolean }> = [];
+let pendingReports: Array<{
+  readonly resolve: (report: UsageReport) => void;
+  readonly reject: (error: unknown) => void;
+}> = [];
+
+const { setUsageRpcClientForTest, useUsageStore } = await import("../src/store/usage.ts");
+
+setUsageRpcClientForTest(
+  async () =>
+    ({
+    usage: {
+      report: (payload: { readonly bucket?: string; readonly forceRefresh?: boolean }) => {
+        reportCalls.push(payload);
+        return Effect.promise(
+          () =>
+            new Promise<UsageReport>((resolve, reject) => {
+              pendingReports.push({ resolve, reject });
+            }),
+        );
+      },
+    },
+  }) as Awaited<ReturnType<typeof import("../src/lib/rpc-client.ts").getRpcClient>>,
+);
+
+const makeReport = (recordCount: number): UsageReport =>
+  ({
+    bucket: "daily",
+    generatedAt: new Date("2026-06-21T00:00:00.000Z"),
+    summary: {
+      inputTokens: recordCount,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      reasoningTokens: 0,
+      costUsd: null,
+      costStatus: "unknown",
+      recordCount,
+      possibleDuplicateCount: 0,
+    },
+    groups: [],
+    bySource: [],
+    byModel: [],
+    bySession: [],
+    records: [],
+    sources: [],
+  }) as UsageReport;
+
+describe("usage store", () => {
+  beforeEach(() => {
+    reportCalls = [];
+    pendingReports = [];
+    useUsageStore.setState({
+      report: null,
+      loading: false,
+      error: null,
+      bucket: "daily",
+      requestId: 0,
+    });
+  });
+
+  it("keeps the newest usage response when older requests resolve later", async () => {
+    const first = useUsageStore.getState().refresh(null);
+    const second = useUsageStore.getState().refresh(null);
+    await Promise.resolve();
+
+    expect(pendingReports).toHaveLength(2);
+    pendingReports[1]!.resolve(makeReport(2));
+    await second;
+    expect(useUsageStore.getState().report?.summary.recordCount).toBe(2);
+
+    pendingReports[0]!.resolve(makeReport(1));
+    await first;
+    expect(useUsageStore.getState().report?.summary.recordCount).toBe(2);
+  });
+
+  it("passes forceRefresh only for explicit refreshes", async () => {
+    const request = useUsageStore.getState().refresh(null, { forceRefresh: true });
+    await Promise.resolve();
+
+    expect(reportCalls[0]?.forceRefresh).toBe(true);
+    pendingReports[0]!.resolve(makeReport(1));
+    await request;
+  });
+});

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -64,7 +64,9 @@ const freshSettings = (): SettingsFile =>
     defaultProviderId: "claude",
     defaultModelByProvider: seedModels(),
     defaultRuntimeMode: "approval-required",
-    defaultAutoCreateWorktree: false,
+    // Worktrees on by default: each new chat runs on its own branch so parallel
+    // agents stay isolated. Per-repo settings can still opt a repo out.
+    defaultAutoCreateWorktree: true,
     onboardingCompleted: false,
     completionSoundEnabled: false,
     completionSoundPreset: "chime",

--- a/apps/server/src/usage/handlers.ts
+++ b/apps/server/src/usage/handlers.ts
@@ -29,19 +29,57 @@ const sessionTokens = (s: {
 const PRICED_CACHE_TTL_MS = 60_000;
 
 let pricedCache: { readonly at: number; readonly value: PricedUsage } | null = null;
+let pricedInFlight: {
+  readonly forceRefresh: boolean;
+  readonly promise: Promise<PricedUsage>;
+} | null = null;
 
-const loadPricedUsageCached = (memoizeDbPath: string, cacheDir: string): Promise<PricedUsage> => {
-  const now = Date.now();
-  if (pricedCache !== null && now - pricedCache.at < PRICED_CACHE_TTL_MS) {
+export const resetUsageReportCacheForTest = (): void => {
+  pricedCache = null;
+  pricedInFlight = null;
+};
+
+export const loadPricedUsageCached = (
+  memoizeDbPath: string,
+  cacheDir: string,
+  opts: {
+    readonly forceRefresh?: boolean;
+    readonly load?: typeof loadPricedUsage;
+    readonly now?: () => number;
+  } = {},
+): Promise<PricedUsage> => {
+  const forceRefresh = opts.forceRefresh === true;
+  const now = (opts.now ?? Date.now)();
+  if (!forceRefresh && pricedCache !== null && now - pricedCache.at < PRICED_CACHE_TTL_MS) {
     return Promise.resolve(pricedCache.value);
   }
-  return loadPricedUsage({
+  if (pricedInFlight !== null && (!forceRefresh || pricedInFlight.forceRefresh)) {
+    return pricedInFlight.promise;
+  }
+  const load = opts.load ?? loadPricedUsage;
+  const promise = load({
     readOptions: { memoizeDbPath },
     pricing: { cacheDir },
   }).then((value) => {
-    pricedCache = { at: now, value };
+    pricedCache = { at: (opts.now ?? Date.now)(), value };
     return value;
+  }).finally(() => {
+    if (pricedInFlight?.promise === promise) {
+      pricedInFlight = null;
+    }
   });
+  pricedInFlight = { forceRefresh, promise };
+  return promise;
+};
+
+export const trimUsageReportForPayload = (report: ReturnType<typeof buildUsageReport>) => {
+  // The renderer never reads per-record rows, and the sessions table is
+  // paginated client-side — trim both so the RPC payload stays small.
+  const bySession = report.bySession
+    .slice()
+    .sort((a, b) => sessionTokens(b) - sessionTokens(a))
+    .slice(0, MAX_SESSIONS_IN_PAYLOAD);
+  return { ...report, records: [], bySession };
 };
 
 /**
@@ -64,7 +102,7 @@ const projectPathsFor = (projectId: FolderId | undefined) =>
 
 const UsageReport = MemoizeRpcs.toLayerHandler(
   "usage.report",
-  ({ bucket, sourceIds, since, until, timezone, projectId, includePossibleDuplicates }) =>
+  ({ bucket, sourceIds, since, until, timezone, projectId, includePossibleDuplicates, forceRefresh }) =>
     Effect.gen(function* () {
       const paths = yield* AppPaths;
       const projectPaths = yield* projectPathsFor(projectId).pipe(
@@ -74,6 +112,7 @@ const UsageReport = MemoizeRpcs.toLayerHandler(
         const { records, sources } = await loadPricedUsageCached(
           join(paths.userData, "memoize.sqlite"),
           join(paths.userData, "tokenmaxer"),
+          { forceRefresh },
         );
         const report = buildUsageReport({
           records,
@@ -89,13 +128,7 @@ const UsageReport = MemoizeRpcs.toLayerHandler(
             includePossibleDuplicates,
           },
         });
-        // The renderer never reads per-record rows, and the sessions table is
-        // paginated client-side — trim both so the RPC payload stays small.
-        const bySession = report.bySession
-          .slice()
-          .sort((a, b) => sessionTokens(b) - sessionTokens(a))
-          .slice(0, MAX_SESSIONS_IN_PAYLOAD);
-        return { ...report, records: [], bySession };
+        return trimUsageReportForPayload(report);
       }).pipe(Effect.orDie);
     }),
 );

--- a/apps/server/test/usage-cache.test.ts
+++ b/apps/server/test/usage-cache.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { buildUsageReport, makeUsageRecord, type PricedUsage } from "tokenmaxer";
+
+import {
+  loadPricedUsageCached,
+  resetUsageReportCacheForTest,
+  trimUsageReportForPayload,
+} from "../src/usage/handlers.ts";
+
+const emptyUsage = (id: string): PricedUsage => ({
+  records: [],
+  sources: [
+    {
+      id: "memoize",
+      label: `Memoize ${id}`,
+      detected: true,
+      recordCount: 0,
+      paths: [],
+      warning: null,
+    },
+  ],
+});
+
+describe("usage report cache", () => {
+  beforeEach(() => {
+    resetUsageReportCacheForTest();
+  });
+
+  it("coalesces concurrent cold loads", async () => {
+    let calls = 0;
+    let resolveLoad: ((value: PricedUsage) => void) | null = null;
+    const load = () => {
+      calls += 1;
+      return new Promise<PricedUsage>((resolve) => {
+        resolveLoad = resolve;
+      });
+    };
+
+    const first = loadPricedUsageCached("/tmp/memoize.sqlite", "/tmp/tokenmaxer", { load });
+    const second = loadPricedUsageCached("/tmp/memoize.sqlite", "/tmp/tokenmaxer", { load });
+
+    expect(calls).toBe(1);
+    resolveLoad?.(emptyUsage("cold"));
+    expect(await first).toBe(await second);
+  });
+
+  it("uses fresh cached data unless forceRefresh is set", async () => {
+    let calls = 0;
+    const load = () => Promise.resolve(emptyUsage(String(++calls)));
+    let now = 1_000;
+
+    const first = await loadPricedUsageCached("/tmp/memoize.sqlite", "/tmp/tokenmaxer", {
+      load,
+      now: () => now,
+    });
+    now += 1;
+    const cached = await loadPricedUsageCached("/tmp/memoize.sqlite", "/tmp/tokenmaxer", {
+      load,
+      now: () => now,
+    });
+    const refreshed = await loadPricedUsageCached("/tmp/memoize.sqlite", "/tmp/tokenmaxer", {
+      forceRefresh: true,
+      load,
+      now: () => now,
+    });
+
+    expect(calls).toBe(2);
+    expect(cached).toBe(first);
+    expect(refreshed).not.toBe(first);
+  });
+
+  it("trims raw records and caps sessions by token volume", () => {
+    const records = Array.from({ length: 300 }, (_, index) =>
+      makeUsageRecord({
+        sourceId: "memoize",
+        sourceLabel: "Memoize",
+        providerId: "codex",
+        model: "gpt-5.4",
+        sessionId: `session-${index}`,
+        startedAt: new Date(1_800_000_000_000 + index),
+        counts: { inputTokens: index + 1, outputTokens: 0 },
+        provenance: `fixture-${index}`,
+      }),
+    );
+    const report = buildUsageReport({
+      records,
+      sources: [],
+      bucket: "session",
+      filters: { includePossibleDuplicates: true },
+    });
+
+    const trimmed = trimUsageReportForPayload(report);
+
+    expect(trimmed.records).toEqual([]);
+    expect(trimmed.bySession).toHaveLength(250);
+    expect(trimmed.bySession[0]?.key).toBe("session-299");
+    expect(trimmed.bySession.at(-1)?.key).toBe("session-50");
+  });
+});

--- a/apps/web/content/blog/know-your-token-spend.mdx
+++ b/apps/web/content/blog/know-your-token-spend.mdx
@@ -1,0 +1,108 @@
+---
+title: "Know your token spend"
+description: "Tokenmaxer reads your agent CLI logs and unifies token counts and dollar cost by day, source, model, and session. All of it stays on your Mac."
+date: "2026-06-21"
+timeToRead: "6 min read"
+authorName: "memoize team"
+authorRole: "Product notes"
+authorAvatar: "/app-icon.png"
+previewImage: "/assets/blog-preview-local-clean.svg"
+labels:
+  [
+    { name: "Token maxing", hex: "#84CC16" },
+    { name: "Local-first", hex: "#4ADE80" },
+  ]
+---
+
+# Know your token spend
+
+Most developers running coding agents have no idea how many tokens they burned last week. The usage exists, the dollars are real, but the number is invisible. It is scattered across Claude Code, Codex, OpenCode, Amp, Grok, and whatever else is installed, each writing its own logs in its own format, in its own corner of the disk.
+
+memoize is a tool for token maxers. The first step to maxing anything is being able to see it. So memoize ships Tokenmaxer: a local dashboard that reads the logs your agent CLIs already write and turns them into one honest picture of what you actually run.
+
+---
+
+## The problem: spend you can't see
+
+When usage is invisible, you make bad decisions in both directions.
+
+- You under-use a plan you already pay for, treating every agent run as if it costs something out of pocket, when the subscription is flat and the marginal run is effectively free.
+- You over-use without noticing, racking up cost on a metered key because nothing in the workflow ever shows you the running total.
+
+Neither is a knowledge problem you can fix by guessing. The data is there. It is just trapped in per-tool logs that no one reads. Each CLI knows what it sent and received, but no tool sits above all of them to add it up. So the question "how much did I spend on agents this month, and where did it go" has no answer on most machines.
+
+---
+
+## What Tokenmaxer does
+
+Tokenmaxer scans the local logs of your installed agent CLIs and aggregates them into one view. It reads from the sources you already have on disk:
+
+- Claude Code
+- Codex
+- OpenCode
+- Amp
+- Grok
+- and memoize's own sessions
+
+It parses the session records each tool leaves behind, pulls out the token counts, and rolls them up by day, week, and month. Then it slices the same totals by source, by model, and by session, so the same spend can be read from whichever angle answers your question.
+
+Nothing about this requires a new account, a billing export, or a provider dashboard. The logs are already being written every time you run an agent. Tokenmaxer just reads them.
+
+---
+
+## What the numbers actually mean
+
+A token count is not one number. Modern agents move several kinds of tokens, and they do not cost the same, so it matters which is which.
+
+- **Input tokens** are what you send to the model: your prompt, the files in context, the conversation so far. On a large repo with lots of context, input often dominates.
+- **Output tokens** are what the model writes back: the code, the explanations, the tool calls. These are usually priced higher per token than input.
+- **Cache tokens** are input that the provider served from a cache instead of processing fresh. Cache reads are cheaper than full input, which is why a long session that keeps referencing the same context can be far less expensive than the raw input count suggests.
+- **Reasoning tokens** are the hidden thinking some models generate before answering. You do not see them in the reply, but they are real output and they are billed.
+
+Tokenmaxer keeps these separate because lumping them together hides the story. A session that looks expensive by total tokens might be mostly cache reads. A session that looks cheap might be quietly heavy on reasoning. Seeing the split is how you learn which of your habits are actually costly.
+
+### Cost is an estimate, and it says so
+
+Tokenmaxer estimates dollar cost from public pricing tables for each model. That is the honest way to do it without a billing API: take the token counts you actually ran and multiply by the published per-token rates.
+
+Because pricing comes from public tables, the cost is an estimate, not your invoice. When a model is not in the pricing table — a new release, a preview, a local or self-hosted model with no public rate — Tokenmaxer does not invent a number. It marks the cost as **partial** or **unknown** rather than guessing. You will still see the token counts for that model; the dollar figure is just flagged as something it could not price. We would rather show you a clear gap than a confident wrong number.
+
+---
+
+## Reading the breakdowns
+
+The same totals are useful in different shapes depending on what you are trying to learn.
+
+**By source** answers "which tool is eating my budget." If most of your spend is in one CLI, that is where optimization pays off. It also surfaces the tools you forgot you were running. A background agent that quietly logs a lot of tokens is easy to miss until the by-source view puts it at the top.
+
+**By model** answers "what am I paying the premium for." Heavy use of a top-tier model on small tasks is one of the most common ways to overspend without feeling it. The by-model view makes that obvious: you can see the share of cost going to the expensive model versus the fast, cheap one, and decide whether the split matches the work.
+
+**By session** answers "what did this specific piece of work cost." This is where token spend stops being abstract. A single refactor, a debugging marathon, a long planning conversation — each has a token and dollar weight. Once you can see that a certain kind of session reliably runs up the count, you can change how you approach it: tighten the context you load, lean on a cheaper model for exploration, or split the work across sessions.
+
+**By day, week, and month** answers "is my usage trending up, and does it line up with the plan I'm on." A flat subscription with rising usage is a sign you are extracting more value. A metered key with rising usage is a signal to look before the bill does.
+
+---
+
+## Local by default
+
+Tokenmaxer is built on the same principle as the rest of memoize: it runs on your Mac, and your data stays there.
+
+Reading token usage could easily have been a cloud feature. Upload the logs, crunch them on a server, render a dashboard. That is the normal shape for analytics, and it is exactly the shape we did not want for a tool that reads your coding history.
+
+So Tokenmaxer reads the CLI logs on disk and aggregates them on your machine. Nothing is uploaded. Your prompts are not sent anywhere to be counted. The session contents — which are full of your code, your file paths, your internal context — never leave the Mac just so a number can be totaled. The logs were already there; Tokenmaxer simply reads them where they sit.
+
+This matters more than it might for a usage dashboard, because agent logs are unusually sensitive. They contain fragments of source, command output, file names, and the shape of what you are building. A token counter has no business shipping that off the machine. Local-first is not a slogan we apply selectively; it applies to the analytics too.
+
+---
+
+## From visibility to a habit
+
+The point of seeing your spend is not anxiety. It is leverage.
+
+Once the numbers are in front of you, a pattern usually emerges within a few days. You notice that one tool dominates, or that a premium model is doing work a cheaper one could handle, or that your flat plan has tons of headroom you have never touched. Each of those observations turns into a small change in behavior, and the changes compound.
+
+The most common shift is in the direction people expect least: developers start using their agents *more*, not less. When the dashboard shows that a subscription is being run at a fraction of its ceiling, the rational move is to put it to work. Run a second agent in parallel on the same repo. Spin up an exploration session alongside the implementation session instead of waiting. Hand a review pass to a different model while the first one keeps building. The plan is already paid for; the unused capacity is just sitting there.
+
+That is what token maxing actually means. It is not spending more for its own sake. It is making sure the subscriptions you already pay for are doing the maximum amount of useful work, and making sure the metered spend is going where it earns its cost. You cannot do either while the number is invisible.
+
+Tokenmaxer makes the number visible, keeps it local, and tells you honestly when it cannot price something. From there, the habit follows on its own: check the dashboard, see where the tokens went, and squeeze a little more leverage out of the same plans every week.

--- a/apps/web/content/blog/token-maxing-your-subscriptions.mdx
+++ b/apps/web/content/blog/token-maxing-your-subscriptions.mdx
@@ -1,0 +1,95 @@
+---
+title: "Token maxing your AI coding subscriptions"
+description: "You already pay a flat fee for Claude, Codex, and the rest. Running one agent at a time leaves most of that included usage on the table."
+date: "2026-06-21"
+timeToRead: "6 min read"
+authorName: "memoize team"
+authorRole: "Product notes"
+authorAvatar: "/app-icon.png"
+previewImage: "/assets/blog-preview-agents-clean.svg"
+labels:
+  [
+    { name: "Token maxing", hex: "#84CC16" },
+    { name: "Guide", hex: "#38BDF8" },
+  ]
+---
+
+# Token maxing your AI coding subscriptions
+
+Most developers now pay for at least one AI coding plan, and many pay for several. A monthly plan for Claude Code, another for Codex, maybe a SuperGrok or a Cursor seat on top. The bill is flat. The same amount leaves your account whether you use the agent twice on a quiet Tuesday or run it hard all month.
+
+Here is the part most people miss: a flat fee rewards volume. The included usage in your plan is a budget, not a meter. If you only ever run one agent at a time, you spend a small fraction of that budget and pay full price for it anyway. Token maxing is the practice of using more of what you already bought.
+
+memoize is built for exactly this. It wraps every coding agent CLI in one project-aware workspace, gives each chat its own git worktree, and tracks your spend locally so you can see your leverage. This post is about how to use that to get multiples more work out of the subscriptions you already have.
+
+---
+
+## Flat-rate plans reward parallelism
+
+A subscription priced per month is fundamentally different from one priced per token. With pay-as-you-go API billing, running two agents costs twice as much as running one. There is no leverage to find; cost scales with work. A flat monthly plan inverts that. The fee is fixed, so the question changes from "what can I afford" to "how much of my included usage am I actually using."
+
+Run a single agent serially and the answer is usually "not much." You prompt, you wait, you read the diff, you prompt again. During every one of those waits, your plan's capacity sits idle. The model is not working. The clock is not buying you anything. You are paying for a lane and driving one car down it.
+
+The fix is not to upgrade to a bigger plan. It is to put more cars in the lane you already pay for. If three agents are working while you review the output of a fourth, the same flat fee is now doing four streams of work in the time it used to do one. Nothing about the bill changed. The throughput did.
+
+---
+
+## Three to six agents, same monthly fee
+
+The practical move is to run several agents side by side instead of one after another. memoize is designed so this feels normal rather than chaotic. Open a chat, pick a provider, start a task. Open another chat, pick a provider, start a different task. Each chat is its own unit of work with its own timeline.
+
+What does that buy you in a real session?
+
+- **Parallel tasks.** One agent fixes a flaky test, another updates docs, a third drafts a migration. Three independent jobs finish in the time one used to take.
+- **Competing attempts.** Ask two agents the same prompt and keep the better diff. The cost of a second opinion is close to zero when both are inside a plan you already pay for.
+- **Long plus short.** Let a slow refactor run in one chat while you knock out quick fixes in others. The long task no longer blocks everything behind it.
+
+The multiplier here is real but bounded by your attention, not your wallet. You are the reviewer, and you can only steer so many sessions at once. Most developers find three to six concurrent agents is the sweet spot: enough to keep capacity busy, few enough to still review every diff with care. The constraint moved from cost to focus, which is a much better constraint to have.
+
+---
+
+## Worktrees keep parallel work from colliding
+
+Running several agents against one repo only works if they cannot clobber each other. That is what git worktrees handle, and memoize creates one per chat automatically. Each chat gets its own branch and its own working directory while sharing the repository's object store, so agents edit in isolation and you review each change on its own branch.
+
+We have written about the mechanics of worktrees elsewhere, so the short version here is what they mean for token maxing: isolation is the thing that makes parallelism safe enough to actually do. Without it, every additional agent raises the odds of a stale read or a build collision, and the safe move is to fall back to one-at-a-time. With it, adding another agent just adds another branch with a clear owner. Parallelism stops being risky, which is the whole point, because the leverage only exists if you are comfortable running many agents at once.
+
+When an attempt does not pan out, you discard the worktree and your main checkout never noticed. When two attempts both look good, you compare the branches and land the one you prefer. Cheap to try, cheap to throw away, easy to review: that is what turns "I could run more agents" into "I do run more agents."
+
+---
+
+## Mix providers to dodge per-provider limits
+
+Each plan has its own included usage and its own rate limits. If you push a single provider hard enough, you will eventually hit a ceiling and stall. Spreading work across providers is both a throughput trick and a resilience one.
+
+Because memoize speaks each CLI's native protocol under one surface, the provider is just a choice you make per chat. So you can run Claude Code in two chats, Codex in two more, and Grok in another, all against the same project. Five agents working, five different usage budgets being drawn down, and no single provider getting throttled because you concentrated everything on it.
+
+This also lets you match the agent to the task while you are at it. A model with a huge context window can hold the whole repo while it investigates. A faster provider can churn through a tight test-fix loop. A different one can do the review pass. You are not just dodging limits; you are spending each plan's included usage on the work it is best at. The mix is the point. Provider variety stops being a tab-management headache and becomes a way to keep more lanes open at once.
+
+A practical note: keep an eye on which provider is carrying the load. If one plan is doing all the work and another sits untouched, you are leaving usage on the table on the idle plan and inviting limits on the busy one. Rebalancing is as simple as pointing the next chat at the quieter provider.
+
+---
+
+## Tokenmaxer: see exactly what you spent
+
+You cannot maximize what you cannot measure. memoize includes a local token dashboard we call Tokenmaxer that reads usage across the providers you run and shows it in one place. It is on your machine, not a provider portal you have to log into five separate times.
+
+The dashboard answers the questions that actually tell you whether token maxing is working:
+
+- How many tokens did this project consume this week, and across which providers?
+- Which agent did the heavy lifting, and which plan is barely touched?
+- How does a parallel session compare to a serial one for the same kind of work?
+
+The reason this matters is leverage made visible. When you can see that a flat monthly plan moved through a large pile of included usage in a week, you know the fee is pulling its weight. When you see one provider sitting near idle, you know there is free capacity to redirect. The number on the dashboard is the gap between what you pay for and what you actually use, and watching it climb is the whole game.
+
+There is a discipline angle too. Seeing real usage keeps you honest about where the work is going. If a single chat is burning far more than its results justify, that is a signal to switch providers, tighten the prompt, or kill the session. Measurement is what turns "run more agents" from a vague intention into something you can tune.
+
+---
+
+## The shift in mindset
+
+Token maxing is not about being wasteful or spinning up agents for the sake of it. It is about noticing that you already bought capacity and then arranging your workflow so that capacity is busy instead of idle. Flat-rate plans make idle capacity the default; parallelism makes it the exception.
+
+The pieces fit together. Several agents side by side put more of your plan to work at once. Worktrees keep those agents from stepping on each other so parallel work stays reviewable. Mixing providers spreads the load so no single plan throttles you. And Tokenmaxer shows you the result, so you can see that the same monthly fee is now doing several times the work.
+
+You are still the editor. The agents produce candidates; you decide what lands. But the version of that job where one agent works while three plans sit idle was always leaving value on the table. memoize is the workspace that lets you use what you already pay for.

--- a/packages/wire/src/usage.ts
+++ b/packages/wire/src/usage.ts
@@ -104,6 +104,7 @@ export const UsageReportRpc = Rpc.make("usage.report", {
     timezone: Schema.optional(Schema.String),
     projectId: Schema.optional(FolderId),
     includePossibleDuplicates: Schema.optional(Schema.Boolean),
+    forceRefresh: Schema.optional(Schema.Boolean),
   }),
   success: UsageReport,
 });


### PR DESCRIPTION
Adds tokenmaxer-focused onboarding updates, including a new maximize step, refreshed copy, and auto-worktree defaults.

Improves usage reporting with shared formatting helpers, force refresh, stale response protection, server-side cache coalescing, and trimmed payloads.

Fixes chat selection from the Usage dashboard so selecting a chat returns to the chat surface.

Adds token spend blog posts and tests for chat selection, usage store staleness, cache coalescing, force refresh, and payload trimming; validated with `bun test apps/renderer/test`, `bun test apps/server/test`, `bun test packages/tokenmaxer/test`, and `bun run check-types`.