### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0]
+
+### Changed
+- Add tokenmaxer onboarding and usage fixes (#166)
+- Add multi-source token usage dashboard (#164)
+- Drive the agent browser with real input + a rendered cursor (#165)
+- [codex] Show active task in project plan header (#160)
+- Make release skill available to Claude and Codex (#163)
+
 ## [0.5.0]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "memoize Alpha",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "memoize desktop app",
   "private": true,
   "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release memoize v0.6.0
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.6.0 after this PR lands.