### PR TITLE
Persist composer drafts

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -316,7 +316,10 @@ function MainShell() {
                   <CostFooter sessionId={selectedSessionId} />
                   <CliUpgradeBanner providerId={selectedSession.providerId} />
                   <NextUnreadButton />
-                  <ChatComposer session={selectedSession} />
+                  <ChatComposer
+                    key={selectedSession.id}
+                    session={selectedSession}
+                  />
                 </>
               ) : (
                 <ChatLanding />

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -56,12 +56,14 @@ import {
   createComposerView,
   reconfigureComposerKeymap,
   replaceWithChip,
+  restoreComposerChips,
   setComposerDoc,
   type ActiveTrigger,
 } from "~/lib/codemirror/composer";
 import { useKeybindingsStore } from "../store/keybindings";
 import {
   addChipEffect,
+  allChips,
   clearChipsEffect,
   updateImageChipEffect,
 } from "~/lib/codemirror/composer-chips";
@@ -72,6 +74,10 @@ import {
 } from "../store/annotations.ts";
 import { useAttachmentsStore } from "../store/attachments.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
+import {
+  composerDraftKeyForSession,
+  useComposerDraftsStore,
+} from "../store/composer-drafts.ts";
 import { cn, formatCompactNumber } from "~/lib/utils";
 import {
   matchBuiltin,
@@ -122,8 +128,10 @@ const MAX_ATTACHMENTS_PER_TURN = 20;
 export function ChatComposer({
   session,
   onDraftSubmit,
+  composerDraftKey,
 }: {
   session: Session;
+  composerDraftKey?: string;
   /**
    * When set, the composer runs in "draft" mode for the new-chat landing:
    * `session` is a synthetic draft (see `sessions.beginDraft`) with no real
@@ -137,6 +145,7 @@ export function ChatComposer({
   onDraftSubmit?: (input: ComposerInput, opts: { asGoal: boolean }) => void;
 }) {
   const sessionId: SessionId = session.id;
+  const draftKey = composerDraftKey ?? composerDraftKeyForSession(sessionId);
   const isDraft = onDraftSubmit !== undefined;
   const [reasoningLevel, setReasoningLevel] = useState<string | null>(null);
   const inFlight = useMessagesStore(
@@ -171,6 +180,8 @@ export function ChatComposer({
   const queue = useMessagesStore((s) => s.queue);
   const setGoal = useMessagesStore((s) => s.setGoal);
   const clearGoal = useMessagesStore((s) => s.clearGoal);
+  const saveComposerDraft = useComposerDraftsStore((s) => s.save);
+  const clearComposerDraft = useComposerDraftsStore((s) => s.clear);
 
   // Pending AskUserQuestion takes over the composer slot — that's where
   // the user types anyway, and floating it inline above the chat
@@ -311,16 +322,26 @@ export function ChatComposer({
   // even with an empty text box.
   const canSend = hasText || annotationCount > 0;
 
-  // Mount the CodeMirror view once per ChatComposer instance. Switching
-  // sessions remounts the component (`session.id` is the chat-view key),
-  // so we don't have to swap docs in-place here.
+  // Mount the CodeMirror view once per ChatComposer instance. The parent keys
+  // live chat composers by session id, and the landing keys them by project id,
+  // so the initial snapshot below is the right one for the lifetime of this
+  // editor view.
   useEffect(() => {
     const host = editorHostRef.current;
     if (host === null) return;
+    const initialSnapshot =
+      useComposerDraftsStore.getState().draftsByKey[draftKey] ?? null;
+    const persistSnapshot = (state: EditorView["state"]) => {
+      saveComposerDraft(draftKey, {
+        doc: state.doc.toString(),
+        chips: allChips(state),
+      });
+    };
 
     const callbacks = {
       onSubmit: () => submitRef.current(),
       onChange: (doc: string) => setHasText(doc.trim().length > 0),
+      onSnapshotChange: persistSnapshot,
       onTrigger: (t: ActiveTrigger | null) => setTrigger(t),
       onFilesDropped: (files: ReadonlyArray<File>) =>
         filesDroppedRef.current(files),
@@ -328,10 +349,15 @@ export function ChatComposer({
     };
     const view = createComposerView({
       parent: host,
+      initialDoc: initialSnapshot?.doc ?? "",
       placeholderText:
         "Ask to make changes at the @ mentioned files or run slash commands, shift enter for next line.",
       callbacks,
     });
+    if (initialSnapshot !== null) {
+      restoreComposerChips(view, initialSnapshot.chips);
+      setHasText(view.state.doc.toString().trim().length > 0);
+    }
     editorViewRef.current = view;
     view.focus();
 
@@ -382,7 +408,7 @@ export function ChatComposer({
       view.destroy();
       editorViewRef.current = null;
     };
-  }, []);
+  }, [draftKey, saveComposerDraft]);
 
   // Picker-triggered session changes (model / provider) can shift the
   // composer's surrounding layout — chip icon swap, CliUpgradeBanner
@@ -621,6 +647,7 @@ export function ChatComposer({
     const builtin = matchBuiltin(docText, session.providerId);
     if (builtin !== null) {
       clearComposer(view);
+      clearComposerDraft(draftKey);
       dispatchBuiltin(builtin);
       return true;
     }
@@ -637,6 +664,7 @@ export function ChatComposer({
           })
         : parsed;
     clearComposer(view);
+    clearComposerDraft(draftKey);
     setGoalSendMode(false);
     // Drain the tray: the annotations now live on `input` (carried into the
     // queue too, so a mid-turn submit flushes them intact).

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -33,6 +33,7 @@ import { DRAFT_SESSION_ID, useSessionsStore } from "~/store/sessions";
 import { useSettingsStore } from "~/store/settings";
 import { useWorkspaceStore } from "~/store/workspace";
 import { EMPTY_WORKTREES, useWorktreesStore } from "~/store/worktrees";
+import { composerDraftKeyForLanding } from "~/store/composer-drafts";
 import { ChatComposer } from "./chat-composer.tsx";
 import { PROVIDER_LABEL } from "./settings-page";
 import { SetupCardView } from "./worktree-setup-card.tsx";
@@ -284,6 +285,7 @@ export function ChatLanding() {
           <ChatComposer
             key={selectedFolderId ?? "none"}
             session={draftSession}
+            composerDraftKey={composerDraftKeyForLanding(selectedFolderId)}
             onDraftSubmit={(input, opts) => void handleDraftSubmit(input, opts)}
           />
         ) : (

--- a/apps/renderer/src/lib/codemirror/composer-chips.ts
+++ b/apps/renderer/src/lib/codemirror/composer-chips.ts
@@ -77,6 +77,11 @@ export const updateImageChipEffect = StateEffect.define<{
   readonly meta: ChipMeta;
 }>();
 
+export const isChipEffect = (effect: StateEffect<unknown>): boolean =>
+  effect.is(addChipEffect) ||
+  effect.is(clearChipsEffect) ||
+  effect.is(updateImageChipEffect);
+
 /**
  * Holds the current chip set. Decoration ranges are derived; this field
  * is the source of truth that survives transactions.

--- a/apps/renderer/src/lib/codemirror/composer.ts
+++ b/apps/renderer/src/lib/codemirror/composer.ts
@@ -7,7 +7,13 @@ import {
   type KeyBinding,
 } from "@codemirror/view";
 
-import { addChipEffect, chipExtensions, type ChipMeta } from "./composer-chips.ts";
+import {
+  addChipEffect,
+  chipExtensions,
+  isChipEffect,
+  type ChipMeta,
+  type ChipRange,
+} from "./composer-chips.ts";
 import { buildComposerKeymap, composerKeymap } from "./composer-keymap.ts";
 import { composerTheme } from "./composer-theme.ts";
 import {
@@ -31,6 +37,7 @@ export type ComposerCallbacks = {
    */
   readonly onSubmit: () => boolean;
   readonly onChange: (doc: string) => void;
+  readonly onSnapshotChange?: (state: EditorState) => void;
   readonly onTrigger: (trigger: ActiveTrigger | null) => void;
   /**
    * Called when one or more files are dropped onto the editor surface.
@@ -89,6 +96,13 @@ export const createComposerView = ({
     ]),
     EditorView.updateListener.of((u) => {
       if (u.docChanged) callbacks.onChange(u.state.doc.toString());
+      if (
+        callbacks.onSnapshotChange !== undefined &&
+        (u.docChanged ||
+          u.transactions.some((tr) => tr.effects.some(isChipEffect)))
+      ) {
+        callbacks.onSnapshotChange(u.state);
+      }
     }),
     // File drops: CodeMirror's default handler tries to paste the dropped
     // payload as text. For image drops that turns into a `file://...`
@@ -160,6 +174,18 @@ export const setComposerDoc = (view: EditorView, doc: string): void => {
 
 export const composerDoc = (view: EditorView): string =>
   view.state.doc.toString();
+
+export const restoreComposerChips = (
+  view: EditorView,
+  chips: readonly ChipRange[],
+): void => {
+  if (chips.length === 0) return;
+  view.dispatch({
+    effects: chips
+      .filter((chip) => chip.from >= 0 && chip.to <= view.state.doc.length)
+      .map((chip) => addChipEffect.of(chip)),
+  });
+};
 
 /**
  * Replace `[from, to)` in the document with `tokenText` and register a chip

--- a/apps/renderer/src/store/composer-drafts.ts
+++ b/apps/renderer/src/store/composer-drafts.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+
+import type { FolderId, SessionId } from "@memoize/wire";
+
+import type { ChipRange } from "../lib/codemirror/composer-chips.ts";
+
+export type ComposerDraftSnapshot = {
+  readonly doc: string;
+  readonly chips: readonly ChipRange[];
+};
+
+type ComposerDraftsState = {
+  readonly draftsByKey: Record<string, ComposerDraftSnapshot>;
+  readonly save: (key: string, snapshot: ComposerDraftSnapshot) => void;
+  readonly clear: (key: string) => void;
+};
+
+const isEmptySnapshot = (snapshot: ComposerDraftSnapshot): boolean =>
+  snapshot.doc.length === 0 && snapshot.chips.length === 0;
+
+export const composerDraftKeyForSession = (sessionId: SessionId): string =>
+  `session:${sessionId}`;
+
+export const composerDraftKeyForLanding = (
+  folderId: FolderId | null,
+): string => `landing:${folderId ?? "none"}`;
+
+export const useComposerDraftsStore = create<ComposerDraftsState>((set) => ({
+  draftsByKey: {},
+  save: (key, snapshot) =>
+    set((state) => {
+      const next = { ...state.draftsByKey };
+      if (isEmptySnapshot(snapshot)) {
+        delete next[key];
+      } else {
+        next[key] = {
+          doc: snapshot.doc,
+          chips: snapshot.chips.map((chip) => ({ ...chip })),
+        };
+      }
+      return { draftsByKey: next };
+    }),
+  clear: (key) =>
+    set((state) => {
+      if (state.draftsByKey[key] === undefined) return state;
+      const next = { ...state.draftsByKey };
+      delete next[key];
+      return { draftsByKey: next };
+    }),
+}));

--- a/apps/renderer/test/composer-drafts-store.test.ts
+++ b/apps/renderer/test/composer-drafts-store.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import type { SessionId } from "@memoize/wire";
+
+import type { ChipRange } from "../src/lib/codemirror/composer-chips.ts";
+import {
+  composerDraftKeyForSession,
+  useComposerDraftsStore,
+} from "../src/store/composer-drafts.ts";
+
+const firstKey = composerDraftKeyForSession("sess1" as SessionId);
+const secondKey = composerDraftKeyForSession("sess2" as SessionId);
+
+describe("composer drafts store", () => {
+  beforeEach(() => {
+    useComposerDraftsStore.setState({ draftsByKey: {} });
+  });
+
+  it("saves independent drafts by key", () => {
+    useComposerDraftsStore.getState().save(firstKey, {
+      doc: "draft one",
+      chips: [],
+    });
+    useComposerDraftsStore.getState().save(secondKey, {
+      doc: "draft two",
+      chips: [],
+    });
+
+    expect(useComposerDraftsStore.getState().draftsByKey[firstKey]?.doc).toBe(
+      "draft one",
+    );
+    expect(useComposerDraftsStore.getState().draftsByKey[secondKey]?.doc).toBe(
+      "draft two",
+    );
+  });
+
+  it("clears one draft without affecting another", () => {
+    useComposerDraftsStore.getState().save(firstKey, {
+      doc: "draft one",
+      chips: [],
+    });
+    useComposerDraftsStore.getState().save(secondKey, {
+      doc: "draft two",
+      chips: [],
+    });
+
+    useComposerDraftsStore.getState().clear(firstKey);
+
+    expect(useComposerDraftsStore.getState().draftsByKey[firstKey]).toBe(
+      undefined,
+    );
+    expect(useComposerDraftsStore.getState().draftsByKey[secondKey]?.doc).toBe(
+      "draft two",
+    );
+  });
+
+  it("preserves chip metadata in the saved snapshot", () => {
+    const chips: ChipRange[] = [
+      {
+        from: 0,
+        to: 12,
+        meta: {
+          kind: "file",
+          relPath: "src/app.tsx",
+          absPath: "/repo/src/app.tsx",
+          entryKind: "file",
+        },
+      },
+      {
+        from: 13,
+        to: 26,
+        meta: {
+          kind: "skill",
+          name: "review",
+          scope: "project",
+        },
+      },
+    ];
+
+    useComposerDraftsStore.getState().save(firstKey, {
+      doc: "@src/app.tsx /review",
+      chips,
+    });
+
+    expect(useComposerDraftsStore.getState().draftsByKey[firstKey]?.chips).toEqual(
+      chips,
+    );
+  });
+
+  it("removes empty snapshots", () => {
+    useComposerDraftsStore.getState().save(firstKey, {
+      doc: "draft",
+      chips: [],
+    });
+
+    useComposerDraftsStore.getState().save(firstKey, {
+      doc: "",
+      chips: [],
+    });
+
+    expect(useComposerDraftsStore.getState().draftsByKey[firstKey]).toBe(
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
Adds in-window composer draft memory so unsent text and chips survive switching chats, returning to the landing composer, and reopening new-chat surfaces. The fix snapshots CodeMirror document text plus chip metadata in a renderer-only Zustand store keyed by session or landing project, then restores that snapshot when the composer remounts. Drafts are cleared on submit or explicit clear so sent messages are not duplicated. Validated with renderer Bun tests and renderer typecheck.