### PR TITLE
Dock-style hover-reveal for the left sidebar

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -24,6 +24,10 @@ import { ProjectsSidebar } from "./components/projects-sidebar";
 import { ProviderUpdatesToast } from "./components/provider-updates-toast.tsx";
 import { RightPane } from "./components/right-pane";
 import { SettingsPage } from "./components/settings-page";
+import {
+  SidebarPeekOverlay,
+  SidebarPeekTrigger,
+} from "./components/sidebar-peek.tsx";
 import { TopBarLeft, TopBarMain, TopBarRight } from "./components/top-bar.tsx";
 import { UpdateBanner } from "./components/update-banner.tsx";
 import { UsageDashboard } from "./components/usage-dashboard.tsx";
@@ -385,6 +389,8 @@ function MainShell() {
           </div>
         </Panel>
       </Group>
+      <SidebarPeekTrigger />
+      <SidebarPeekOverlay />
     </div>
   );
 }

--- a/apps/renderer/src/components/sidebar-peek.tsx
+++ b/apps/renderer/src/components/sidebar-peek.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from "react";
+
+import { useUiStore } from "../store/ui.ts";
+import { ProjectsSidebar } from "./projects-sidebar.tsx";
+import { TopBarLeft } from "./top-bar.tsx";
+
+/**
+ * macOS Dock-style auto-reveal for the left sidebar. Two pieces:
+ *
+ *   - `<SidebarPeekTrigger />`: a thin invisible strip pinned to the left
+ *     edge of the window. Only mounted when the docked panel is collapsed.
+ *     Hovering it flips `leftSidebarPeek` → true.
+ *
+ *   - `<SidebarPeekOverlay />`: the floating sidebar itself. Position-fixed
+ *     above the main content (does NOT shift the chat), slides in from the
+ *     left, and auto-hides ~250ms after the cursor leaves it. Re-uses the
+ *     same `<TopBarLeft />` + `<ProjectsSidebar />` as the docked panel so
+ *     behavior and state stay in lockstep.
+ */
+
+const TRIGGER_WIDTH_PX = 4;
+const OVERLAY_WIDTH_PX = 280;
+const CLOSE_DELAY_MS = 250;
+
+export function SidebarPeekTrigger() {
+  const docked = useUiStore((s) => s.leftSidebarOpen);
+  const setPeek = useUiStore((s) => s.setLeftSidebarPeek);
+
+  if (docked) return null;
+
+  return (
+    <div
+      aria-hidden
+      onMouseEnter={() => setPeek(true)}
+      className="fixed inset-y-0 left-0 z-40"
+      style={{ width: TRIGGER_WIDTH_PX }}
+    />
+  );
+}
+
+export function SidebarPeekOverlay() {
+  const docked = useUiStore((s) => s.leftSidebarOpen);
+  const peek = useUiStore((s) => s.leftSidebarPeek);
+  const setPeek = useUiStore((s) => s.setLeftSidebarPeek);
+  const closeTimer = useRef<number | null>(null);
+
+  // Clear any pending close timer if the docked panel opens (keyboard
+  // shortcut, header button) — the overlay would otherwise try to flip
+  // peek=false after the panel was already opened.
+  useEffect(() => {
+    if (docked && closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, [docked]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current !== null) {
+        window.clearTimeout(closeTimer.current);
+      }
+    };
+  }, []);
+
+  if (docked) return null;
+
+  const cancelClose = () => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+
+  const scheduleClose = () => {
+    cancelClose();
+    closeTimer.current = window.setTimeout(() => {
+      closeTimer.current = null;
+      setPeek(false);
+    }, CLOSE_DELAY_MS);
+  };
+
+  return (
+    <div
+      onMouseEnter={cancelClose}
+      onMouseLeave={scheduleClose}
+      className={`fixed inset-y-0 left-0 z-50 flex flex-col bg-background/95 shadow-2xl shadow-black/40 backdrop-blur-xl transition-transform duration-200 ease-out ${
+        peek ? "translate-x-0" : "-translate-x-full"
+      }`}
+      style={{ width: OVERLAY_WIDTH_PX }}
+    >
+      <TopBarLeft />
+      <div className="flex min-h-0 flex-1 flex-col">
+        <ProjectsSidebar />
+      </div>
+    </div>
+  );
+}

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -138,6 +138,12 @@ type UiState = {
   // this to true and a debounced save kicks in inside FileEditor.
   readonly autosave: boolean;
   readonly leftSidebarOpen: boolean;
+  /**
+   * Transient overlay-reveal of the left sidebar when the docked panel is
+   * collapsed. Triggered by hovering the left edge of the window
+   * (macOS Dock-style auto-reveal). Resets on reload — never persisted.
+   */
+  readonly leftSidebarPeek: boolean;
   readonly rightSidebarOpen: boolean;
   readonly isFullScreen: boolean;
   readonly rightPanels: ReadonlyArray<PanelInstance>;
@@ -160,6 +166,7 @@ type UiState = {
   readonly closeFileTab: () => void;
   readonly setFileDirty: (dirty: boolean) => void;
   readonly setLeftSidebarOpen: (open: boolean) => void;
+  readonly setLeftSidebarPeek: (peek: boolean) => void;
   readonly setRightSidebarOpen: (open: boolean) => void;
   readonly setFullScreen: (full: boolean) => void;
   /** Add a panel to the dock. Singletons that are already open are focused
@@ -209,6 +216,7 @@ export const useUiStore = create<UiState>((set, get) => ({
   fileDirty: false,
   autosave: false,
   leftSidebarOpen: true,
+  leftSidebarPeek: false,
   rightSidebarOpen: false,
   isFullScreen: false,
   rightPanels: [],
@@ -231,7 +239,11 @@ export const useUiStore = create<UiState>((set, get) => ({
   closeFileTab: () =>
     set({ openFile: null, activeMainTab: "chat", fileDirty: false }),
   setFileDirty: (dirty) => set({ fileDirty: dirty }),
-  setLeftSidebarOpen: (open) => set({ leftSidebarOpen: open }),
+  // Opening the docked panel implicitly drops any peek state so the overlay
+  // doesn't sit on top of the docked panel. Closing it also clears peek so a
+  // stale hover doesn't immediately re-reveal the overlay.
+  setLeftSidebarOpen: (open) => set({ leftSidebarOpen: open, leftSidebarPeek: false }),
+  setLeftSidebarPeek: (peek) => set({ leftSidebarPeek: peek }),
   setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
   setFullScreen: (full) => set({ isFullScreen: full }),
   addPanel: (kind) =>

--- a/apps/renderer/vite.config.ts
+++ b/apps/renderer/vite.config.ts
@@ -1,11 +1,27 @@
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, searchForWorkspaceRoot } from "vite";
 
 const port = Number(process.env.PORT ?? 5733);
 const host = process.env.HOST?.trim() || "localhost";
+
+// In Memoize worktrees, the renderer's node_modules links out to a Bun
+// central store at a sibling path (e.g. `~/Developer/<main checkout>/
+// node_modules/.bun/...`), which sits OUTSIDE the workspace root. Vite's
+// default `fs.allow` doesn't see it and refuses to serve font files. We
+// resolve a known font package at config-load time and walk up to the
+// store root so every hoisted dep gets allowed too.
+const require = createRequire(import.meta.url);
+const fontPkgPath = require.resolve("@fontsource-variable/inter/package.json");
+// .../node_modules/.bun/@fontsource-variable+inter@X.Y.Z/node_modules/@fontsource-variable/inter/package.json
+//                  ^^^^ walk up 5 dirs to reach `node_modules/.bun/`
+const bunStoreRoot = dirname(
+  dirname(dirname(dirname(dirname(fontPkgPath)))),
+);
 
 export default defineConfig({
   // Relative base so file:// loads work in the packaged Electron build.
@@ -20,6 +36,9 @@ export default defineConfig({
     host,
     port,
     strictPort: true,
+    fs: {
+      allow: [searchForWorkspaceRoot(process.cwd()), bunStoreRoot],
+    },
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary

- New `<SidebarPeekTrigger />` + `<SidebarPeekOverlay />` in `apps/renderer/src/components/sidebar-peek.tsx`. When the projects panel is collapsed, sweeping the cursor to the left edge slides the sidebar in as a floating overlay (macOS Dock auto-hide pattern). The overlay sits above the chat without shifting it, and auto-hides ~250ms after the cursor leaves.
- Transient `leftSidebarPeek` flag in `store/ui.ts` gates the overlay. `setLeftSidebarOpen` now also clears peek so the overlay never stacks on top of the docked panel when the user opens it via the chevron / Cmd+\\.
- `vite.config.ts`: extended `server.fs.allow` to include the resolved Bun central store so font files (Inter / Geist Mono) load in Memoize worktree setups where `node_modules` links out to a sibling checkout.

## Test plan

- [ ] Collapse the projects panel via the chevron — cursor to the left edge should pop the sidebar over the chat, chat does not shift.
- [ ] Move cursor into the overlay, click around — stays open.
- [ ] Move cursor right out of the overlay — slides back ~250ms later.
- [ ] Open the sidebar via Cmd+\\ — overlay/trigger disappear, normal docked behavior restored.
- [ ] Resize the chat / right pane while overlay hidden — separator drag still works (trigger zone is only 4px).
- [ ] Restart the app — sidebar state restored, peek state always starts collapsed.
- [ ] `bun dev` serves Inter/Geist Mono fonts without `fs.allow` errors in a Memoize worktree.