### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1]
+
+### Changed
+- [codex] Fix queue resume after stop (#172)
+- Base new worktrees on origin's default branch, not stale local HEAD (#171)
+- Persist composer drafts (#168)
+- Dock-style hover-reveal for the left sidebar (#170)
+
 ## [0.6.0]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "memoize Alpha",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "memoize desktop app",
   "private": true,
   "author": {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release memoize v0.6.1
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.6.1 after this PR lands.