### PR TITLE
Auto-publish releases instead of drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: release
 
 # Tag-driven release. Push `v0.1.0` (or any `v*` tag) to trigger a build,
-# notarize, and publish to a draft GitHub Release. Promote the draft to
-# public when the artifacts have been smoke-tested.
+# notarize, and publish a public GitHub Release (auto-published, no draft).
 on:
   push:
     tags:

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -88,15 +88,14 @@ dmg:
       path: /Applications
 
 # electron-updater consumes latest-mac.yml from the GitHub Release
-# associated with this repo. Note: with `releaseType: draft`, the release
-# workflow uploads the .dmg + latest-mac.yml as a *draft* release. Drafts
-# are invisible to unauthenticated readers, so electron-updater (in the
-# in-the-wild app) cannot see the new version until you flip the release
-# from "Draft" to "Published" in the GitHub Releases UI. This is the QA
-# gate — change to `releaseType: release` if you'd rather every tag push
-# go live immediately with no manual promotion step.
+# associated with this repo. With `releaseType: release`, the release
+# workflow uploads the .dmg + latest-mac.yml as a *published* release, so
+# every tag push goes live immediately and electron-updater (in the
+# in-the-wild app) can see the new version with no manual promotion step.
+# Switch back to `releaseType: draft` if you'd rather gate each release
+# behind a manual "Draft" -> "Published" flip in the GitHub Releases UI.
 publish:
   provider: github
   owner: swarajbachu
   repo: memoize
-  releaseType: draft
+  releaseType: release


### PR DESCRIPTION
## What

Flip the release pipeline from publishing to a **draft** GitHub Release to **auto-publishing** a public release on every `v*` tag push.

## Why

Previously each tagged release landed as a draft, requiring a manual "Draft → Published" flip in the GitHub Releases UI before `electron-updater` could see the new version. This removes that manual gate so tag pushes go live immediately.

## Changes

- `apps/desktop/electron-builder.yml`: `releaseType: draft` → `releaseType: release` (this is what actually controlled the draft behavior, not the workflow YAML).
- Updated explanatory comments in `electron-builder.yml` and `.github/workflows/release.yml`.

To restore the manual QA gate, flip `releaseType` back to `draft`.