### PR TITLE
Unify composer + bubble pill styling

### DIFF
--- a/apps/renderer/src/components/file-chip.tsx
+++ b/apps/renderer/src/components/file-chip.tsx
@@ -114,7 +114,7 @@ export function AnnotationFileChip({
   return (
     <span
       className={cn(
-        "inline-flex max-w-full shrink-0 items-center gap-1.5 rounded-[0.375rem] border border-border/45 bg-[color-mix(in_oklch,var(--bg-elevated)_34%,var(--background))] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]",
+        "inline-flex max-w-full shrink-0 items-center gap-1.5 rounded-[0.375rem] border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]",
         className,
       )}
       title={`${annotation.relPath}:${range}`}
@@ -243,9 +243,9 @@ export function FileChip({
             onClick={canOpen ? onChipClick : undefined}
             onKeyDown={canOpen ? onKeyDown : undefined}
             className={cn(
-              "inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[color-mix(in_oklch,var(--bg-elevated)_34%,var(--background))] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)] transition-[background-color,color,box-shadow]",
+              "inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)] transition-[background-color,color,box-shadow]",
               canOpen
-                ? "cursor-pointer hover:bg-[color-mix(in_oklch,var(--bg-elevated)_48%,var(--background))] hover:text-foreground hover:shadow-[inset_0_1px_0_color-mix(in_oklch,white_6%,transparent),0_2px_5px_color-mix(in_oklch,black_24%,transparent)]"
+                ? "cursor-pointer hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground hover:shadow-[inset_0_1px_0_color-mix(in_oklch,white_6%,transparent),0_2px_5px_color-mix(in_oklch,black_24%,transparent)]"
                 : "cursor-default",
               className,
             )}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -273,7 +273,7 @@ function UserBubble({
               const iconUrl = isImage ? null : getFileIconUrl(a.originalName);
               const src = `memoize://attachments/${a.id}`;
               const className =
-                "inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted/60";
+                "inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)] hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground";
               const inner = (
                 <>
                   {isImage ? (
@@ -331,7 +331,7 @@ function UserBubble({
             {(skillRefs ?? []).map((s) => (
               <span
                 key={s.name}
-                className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs text-muted-foreground"
+                className="inline-flex items-center rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]"
               >
                 /{s.name}
               </span>

--- a/apps/renderer/src/lib/codemirror/composer-chips.ts
+++ b/apps/renderer/src/lib/codemirror/composer-chips.ts
@@ -11,10 +11,6 @@ import {
   EditorView,
   WidgetType,
 } from "@codemirror/view";
-import { SparklesIcon } from "@hugeicons-pro/core-bulk-rounded";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { renderToStaticMarkup } from "react-dom/server";
-import { createElement } from "react";
 
 import {
   getFileIconUrl,
@@ -149,15 +145,22 @@ class ChipWidget extends WidgetType {
       span.dataset.skillScope = this.meta.scope;
     }
 
-    const icon = document.createElement("span");
-    icon.className = "fz-chip-icon";
-    icon.appendChild(buildIconNode(this.meta));
-
     const label = document.createElement("span");
     label.className = "fz-chip-label";
-    label.textContent = chipLabel(this.meta);
 
-    span.append(icon, label);
+    if (this.meta.kind === "skill") {
+      // Skill chips render as `/name` text only — no leading icon. The
+      // monospace `/` cues the slash-command origin without an emoji-like
+      // sparkles glyph.
+      label.textContent = `/${chipLabel(this.meta)}`;
+      span.append(label);
+    } else {
+      const icon = document.createElement("span");
+      icon.className = "fz-chip-icon";
+      icon.appendChild(buildIconNode(this.meta));
+      label.textContent = chipLabel(this.meta);
+      span.append(icon, label);
+    }
     return span;
   }
   ignoreEvent(): boolean {
@@ -226,16 +229,6 @@ const buildIconNode = (meta: ChipMeta): Node => {
       img.className = "fz-chip-iconimg";
       return img;
     }
-  }
-  if (meta.kind === "skill") {
-    // Hugeicons icons render as SVG via React; for our DOM widget we inline the
-    // sparkles icon via renderToStaticMarkup once and reuse the markup.
-    const wrap = document.createElement("span");
-    wrap.className = "fz-chip-iconsvg";
-    wrap.innerHTML = renderToStaticMarkup(
-      createElement(HugeiconsIcon, { icon: SparklesIcon, size: 12 }),
-    );
-    return wrap;
   }
   // Fallback — should be unreachable.
   return document.createElement("span");

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -215,6 +215,10 @@ body,
   --bg-overlay: oklch(0.91 0.006 70);
   --text-faint: oklch(0.62 0.012 70);
 
+  /* Chip surface — sits on top of cards/bubbles, must stay visibly darker than
+     --card so the pill reads as inset against the composer card. */
+  --chip-bg: oklch(0.94 0.005 70);
+
   --card: oklch(1 0 0);
   --card-foreground: var(--foreground);
   --popover: oklch(1 0 0);
@@ -286,6 +290,10 @@ body,
   --bg-elevated: oklch(0.275 0.006 260);
   --bg-overlay: oklch(0.35 0.008 260);
   --text-faint: oklch(0.58 0.006 260);
+
+  /* Chip surface — kept darker than --card so pills read as inset on the
+     composer surface (card 0.225 vs chip 0.155 ≈ 0.07 lightness gap). */
+  --chip-bg: oklch(0.155 0.004 260);
 
   --card: oklch(0.225 0.005 260);
   --card-foreground: var(--foreground);
@@ -756,11 +764,7 @@ body,
     margin: 0 0.15rem;
     border: 1px solid color-mix(in srgb, var(--border), transparent 55%);
     border-radius: 0.375rem;
-    background-color: color-mix(
-      in oklch,
-      var(--bg-elevated) 34%,
-      var(--background)
-    );
+    background-color: var(--chip-bg);
     box-shadow:
       0 1px 0 color-mix(in oklch, white 4%, transparent) inset,
       0 1px 2px color-mix(in oklch, black 22%, transparent);
@@ -778,22 +782,13 @@ body,
     width: 1.4em;
     height: 1.4em;
     border-radius: 0.25rem;
-    background-color: color-mix(
-      in oklch,
-      var(--bg-elevated) 52%,
-      var(--background)
-    );
+    background-color: color-mix(in oklch, var(--chip-bg) 60%, var(--foreground) 6%);
     flex-shrink: 0;
   }
   .fz-chip-iconimg {
     width: 1em;
     height: 1em;
     object-fit: contain;
-  }
-  .fz-chip-iconsvg {
-    display: inline-flex;
-    align-items: center;
-    color: var(--muted-foreground);
   }
   .fz-chip-thumb {
     width: 1.4em;
@@ -807,25 +802,12 @@ body,
   .fz-chip-label {
     color: var(--foreground);
   }
-  /* Skill chips read as a different category from file chips — accent
-     border + tint. */
-  .fz-chip[data-kind="skill"] {
-    border-color: color-mix(in srgb, var(--accent), transparent 24%);
-    background-color: color-mix(in oklch, var(--accent) 52%, var(--background));
-  }
-  .fz-chip[data-kind="skill"] .fz-chip-iconsvg {
-    color: var(--accent-foreground);
-  }
   .fz-chip[data-kind="file"] {
     cursor: pointer;
   }
   .fz-chip[data-kind="file"]:hover,
   .fz-chip[data-kind="image"]:hover {
-    background-color: color-mix(
-      in oklch,
-      var(--bg-elevated) 48%,
-      var(--background)
-    );
+    background-color: color-mix(in oklch, var(--chip-bg) 80%, var(--foreground) 4%);
     box-shadow:
       0 1px 0 color-mix(in oklch, white 6%, transparent) inset,
       0 2px 5px color-mix(in oklch, black 24%, transparent);


### PR DESCRIPTION
## Summary
- Adds a per-theme `--chip-bg` token so file, image (screenshot), and skill pills share the same inset look against both the composer card and the user bubble — previously the composer card and chip both sat at ~0.225 lightness in dark mode, so chips disappeared into the surface.
- Drops the sparkles icon and accent tint on skill chips; all composer chips now render with a uniform muted pill.
- Aligns the attachment and skill pills inside the rendered chat bubble (`message-row.tsx`) with the canonical `FileChip` look.

## Test plan
- [ ] Open a chat, attach a screenshot, type `/skill` — confirm screenshot, skill, and `@file` pills all look identical in the composer.
- [ ] Send the message and confirm the same three pill types match in the user bubble.
- [ ] Toggle light theme and confirm pills still read as inset against the surface.