### PR TITLE
Cap collapsed tool row width

### DIFF
--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -437,7 +437,7 @@ function ExpandableIconRow({
         type="button"
         onClick={() => hasContent && setExpanded((e) => !e)}
         className={cn(
-          "group flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs",
+          "group flex w-full max-w-2xl items-center gap-2 rounded px-1.5 py-0.5 text-left text-xs",
           hasContent ? "hover:bg-muted/40 cursor-pointer" : "cursor-default",
         )}
       >


### PR DESCRIPTION
## Summary
- Collapsed tool rows previously stretched to the full chat width, so the trailing hint ran much further than the expanded body (which is already capped at `max-w-2xl`).
- Adds `max-w-2xl` to the `ExpandableIconRow` button so the collapsed row aligns with its expanded body even when the sidebar is closed.

## Test plan
- [ ] Sidebar closed: collapsed Bash/Read/etc. rows truncate at the same width as their expanded panels.
- [ ] Sidebar open: layout unchanged.
- [ ] Expanding a row still reveals the full content body.