### PR TITLE
Refresh git status from fs.watch instead of polling every 5s

### DIFF
--- a/apps/renderer/src/components/diff-pane.tsx
+++ b/apps/renderer/src/components/diff-pane.tsx
@@ -90,14 +90,15 @@ export function DiffPane({
   // Paths the user has unchecked for the next commit (see `committable` below).
   const [excluded, setExcluded] = useState<Set<string>>(() => new Set());
 
-  // Poll the working tree on the same 5s cadence the top bar uses for
-  // `git status`, so the Changes tab stays in sync with the dirty-count badge.
+  // Live updates come from the `git.worktreeChanged` stream that the
+  // top bar opens (it drives both stores). The 30s tick is just a
+  // backstop in case the watcher misses an event or the stream dropped.
   useEffect(() => {
     if (folderId === null) return;
     void refreshChanges(folderId, worktreeId);
     const id = window.setInterval(
       () => void refreshChanges(folderId, worktreeId),
-      5000,
+      30000,
     );
     return () => window.clearInterval(id);
   }, [folderId, worktreeId, refreshChanges]);

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -1,7 +1,7 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Alert01Icon, ArrowDown01Icon, Copy01Icon, GitBranchIcon, GitMergeIcon, LinkSquare01Icon, Loading02Icon, MagicWand01Icon, PanelLeftCloseIcon, PanelLeftOpenIcon, PanelRightCloseIcon, PanelRightOpenIcon, PencilEdit01Icon, PlayIcon, Tick01Icon, Upload01Icon, Wrench01Icon } from "@hugeicons-pro/core-bulk-rounded";
 import { ArchiveArrowDownIcon, GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
-import { Effect } from "effect";
+import { Effect, Fiber, Stream } from "effect";
 import {
   type CSSProperties,
   type FormEvent,
@@ -31,6 +31,7 @@ import {
 import { TooltipShortcut } from "./projects-sidebar.tsx";
 import { useActiveContext } from "../store/active-workspace.ts";
 import { useChatsStore } from "../store/chats.ts";
+import { useGitChangesStore } from "../store/git-changes.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { useMergePrefs } from "../store/merge-prefs.ts";
 import { useMessagesStore } from "../store/messages.ts";
@@ -159,18 +160,43 @@ export function TopBarMain() {
   const [branchError, setBranchError] = useState<string | null>(null);
   const [renameOpen, setRenameOpen] = useState(false);
 
-  // Poll both `git status` (branch / dirty / ahead) and the PR state (CI
-  // rollup, mergeable, auto-merge) on the same 5s tick so the top-bar PR
-  // cluster shows live "N checks running" without the PR pane being open.
+  // Working-tree changes drive `git status` + the Changes tab via a
+  // server-pushed `git.worktreeChanged` stream — sub-second updates on
+  // any edit, internal or external. PR state still needs a polling tick
+  // (it's GitHub state, not local FS). We poll on a 30s backstop too,
+  // for filesystems where `fs.watch` is unreliable (network mounts,
+  // FUSE) and to recover if the stream silently drops.
   useEffect(() => {
     if (folderId === null) return;
-    const tick = () => {
+    let cancelled = false;
+    const refreshLocal = () => {
       void refresh(folderId, worktreeId);
+      void useGitChangesStore.getState().refresh(folderId, worktreeId);
+    };
+    const tick = () => {
+      refreshLocal();
       void refreshPr(folderId, worktreeId);
     };
     tick();
-    const id = window.setInterval(tick, 5000);
-    return () => window.clearInterval(id);
+    const id = window.setInterval(tick, 30000);
+    let fiber: Fiber.RuntimeFiber<void, unknown> | null = null;
+    void (async () => {
+      const client = await getRpcClient();
+      if (cancelled) return;
+      fiber = Effect.runFork(
+        Stream.runForEach(
+          client.git.worktreeChanged({ folderId, worktreeId }),
+          () => Effect.sync(refreshLocal),
+        ).pipe(Effect.catchAll(() => Effect.void)),
+      );
+    })();
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+      if (fiber !== null) {
+        void Effect.runPromise(Fiber.interrupt(fiber)).catch(() => {});
+      }
+    };
   }, [folderId, refresh, refreshPr, worktreeId]);
 
   // After a worktree/project switch the status row in `byKey` is keyed by

--- a/apps/renderer/src/store/git-changes.ts
+++ b/apps/renderer/src/store/git-changes.ts
@@ -13,7 +13,8 @@ import { usePrStateStore } from "./pr-state.ts";
 /**
  * Per-`(folder, worktree)` list of working-tree changes parsed from
  * `git status --porcelain=v2`. Backs the Changes tab's "tracked / untracked"
- * sections. Polled on the same 5s cadence the top bar uses for `git.status`.
+ * sections. Refresh is driven by the server's `git.worktreeChanged` stream
+ * (top-bar opens the subscription) with a 30s poll as a backstop.
  */
 type ChangesMap = Record<string, ReadonlyArray<GitChange>>;
 

--- a/apps/renderer/src/store/git-status.ts
+++ b/apps/renderer/src/store/git-status.ts
@@ -7,9 +7,10 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 
 /**
  * `git status` summary used by the top bar to decide which workflow button
- * to surface (Commit & push / Create PR / View PR). Polled every 5 s while
- * a folder is selected — `git status` is cheap and the latency budget is
- * "user perceives the right button shortly after they touch a file."
+ * to surface (Commit & push / Create PR / View PR). Refresh is driven by
+ * the server's `git.worktreeChanged` stream (sub-second after any FS
+ * change) with a 30s poll as a backstop for filesystems where `fs.watch`
+ * is unreliable. The subscription is opened in `top-bar.tsx`.
  *
  * Keyed by `(folderId, worktreeId)` because a session running in a worktree
  * has its own branch + dirty state that differs from the main checkout.

--- a/apps/server/src/git/handlers.ts
+++ b/apps/server/src/git/handlers.ts
@@ -53,6 +53,16 @@ const HeadChanged = MemoizeRpcs.toLayerHandler(
     ),
 );
 
+const WorktreeChanged = MemoizeRpcs.toLayerHandler(
+  "git.worktreeChanged",
+  ({ folderId, worktreeId }) =>
+    Stream.unwrap(
+      Effect.map(GitService, (svc) =>
+        svc.subscribeWorktreeChanges(folderId, worktreeId ?? null),
+      ),
+    ),
+);
+
 const Origin = MemoizeRpcs.toLayerHandler("git.origin", ({ folderId }) =>
   Effect.flatMap(GitService, (svc) => svc.origin(folderId)),
 );
@@ -163,6 +173,7 @@ export const GitHandlersLayer = Layer.mergeAll(
   RenameBranch,
   UserName,
   HeadChanged,
+  WorktreeChanged,
   Origin,
   PrState,
   PrDetails,

--- a/apps/server/src/git/layers/git-service.ts
+++ b/apps/server/src/git/layers/git-service.ts
@@ -9,6 +9,10 @@ import {
   Schedule,
   Stream,
 } from "effect";
+import { type FSWatcher, watch as fsWatch } from "node:fs";
+import { join as pathJoin } from "node:path";
+
+import { startWatcher } from "../../code-index/watcher.ts";
 
 import {
   GitBranchInfo,
@@ -1583,6 +1587,57 @@ export const GitServiceLive = Layer.effect(
         }),
       );
 
+    // Push-based "the working tree (or .git/index) changed" stream.
+    // Drives the renderer's git-status / git-changes stores so the dirty
+    // badge updates within the watcher debounce (~120ms) instead of
+    // waiting for the polling backstop. The recursive watcher handles
+    // file edits from anywhere — the user's editor, an agent's `Edit`
+    // tool, an external CLI. The targeted `.git/index` watcher catches
+    // `git add` / `git rm` from an outside terminal without us needing
+    // to invert the watcher's ignore set.
+    const subscribeWorktreeChanges: GitService["Type"]["subscribeWorktreeChanges"] =
+      (folderId, worktreeId) =>
+        Stream.unwrapScoped(
+          Effect.gen(function* () {
+            const cwd = yield* resolvePathForWorktree(folderId, worktreeId);
+            const mailbox = yield* Mailbox.make<
+              Record<string, never>,
+              GitFailure
+            >();
+
+            const offer = () => {
+              mailbox.unsafeOffer({});
+            };
+
+            const wt = yield* startWatcher(cwd, offer);
+
+            // .git/index may not exist yet (no commits, or `git init`
+            // hasn't run). The watch() will throw ENOENT; swallow it so
+            // we degrade to "working-tree-only" rather than killing the
+            // subscription. If the user later runs `git init`, the
+            // working-tree watcher will fire on the new `.git/` dir
+            // creation and the renderer's refresh picks up the index.
+            let indexHandle: FSWatcher | null = null;
+            try {
+              indexHandle = fsWatch(pathJoin(cwd, ".git", "index"), offer);
+              indexHandle.on("error", () => {
+                /* best-effort; working-tree watcher carries the load */
+              });
+            } catch {
+              indexHandle = null;
+            }
+
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => {
+                wt.stop();
+                indexHandle?.close();
+              }),
+            );
+
+            return Mailbox.toStream(mailbox);
+          }),
+        );
+
     return {
       log,
       status,
@@ -1591,6 +1646,7 @@ export const GitServiceLive = Layer.effect(
       renameBranch,
       getUserName,
       subscribeHeadChanges,
+      subscribeWorktreeChanges,
       origin,
       prState,
       prDetails,

--- a/apps/server/src/git/services/git-service.ts
+++ b/apps/server/src/git/services/git-service.ts
@@ -60,6 +60,17 @@ export interface GitServiceShape {
   readonly subscribeHeadChanges: (
     folderId: FolderId,
   ) => Stream.Stream<{ readonly sha: string }, GitFailure>;
+  /**
+   * Push-based notification that the working tree (or `.git/index`) for the
+   * given `(folder, worktree)` changed. The empty payload is deliberate — the
+   * subscriber re-fetches whatever git query it cares about. Server-side
+   * debounce coalesces bursts (save-on-build, `git checkout` touching many
+   * files) into one event.
+   */
+  readonly subscribeWorktreeChanges: (
+    folderId: FolderId,
+    worktreeId?: WorktreeId | null,
+  ) => Stream.Stream<Record<string, never>, GitFailure>;
   readonly origin: (
     folderId: FolderId,
   ) => Effect.Effect<GitOriginInfo | null, GitFailure>;

--- a/packages/wire/src/git.ts
+++ b/packages/wire/src/git.ts
@@ -128,6 +128,23 @@ export const GitHeadChangedRpc = Rpc.make("git.headChanged", {
   stream: true,
 });
 
+/**
+ * Push-based notification that the working tree (or `.git/index`) for a
+ * `(folder, worktree)` likely changed and consumers should re-fetch
+ * `git.status` / `git.changes`. The payload is empty — the subscriber's
+ * job is to re-run whichever query it cares about. Debounced server-side
+ * so a save-on-build that touches many files becomes one event.
+ */
+export const GitWorktreeChangedRpc = Rpc.make("git.worktreeChanged", {
+  payload: Schema.Struct({
+    folderId: FolderId,
+    worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
+  }),
+  success: Schema.Struct({}),
+  error: GitErrors,
+  stream: true,
+});
+
 export class GitOriginInfo extends Schema.Class<GitOriginInfo>("GitOriginInfo")(
   {
     host: Schema.String,

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -60,6 +60,7 @@ import {
   GitStatusRpc,
   GitSwitchBranchRpc,
   GitUserNameRpc,
+  GitWorktreeChangedRpc,
 } from "./git.ts";
 import {
   PermissionDecideRpc,
@@ -193,6 +194,7 @@ export const MemoizeRpcs = RpcGroup.make(
   GitRenameBranchRpc,
   GitUserNameRpc,
   GitHeadChangedRpc,
+  GitWorktreeChangedRpc,
   GitOriginRpc,
   GitPrStateRpc,
   GitPrDetailsRpc,


### PR DESCRIPTION
## Summary
- Top bar's dirty badge and the Changes tab were polling `git status`/`git changes` every 5s with no FS watcher, so edits could take up to 5 seconds to appear.
- Added a server-pushed `git.worktreeChanged` stream backed by a recursive `fs.watch` on the working tree (reuses the 120 ms-debounced watcher from `code-index/watcher.ts`) plus a targeted watch on `.git/index` so `git add` / `git rm` from an external terminal triggers the same refresh.
- Renderer opens the subscription in `top-bar.tsx` and refreshes both stores per event; both polls drop from 5s → 30s as a backstop for filesystems where `fs.watch` is unreliable.

## Test plan
- [x] `bun run check-types` — 9 packages clean
- [x] `bun test` — 223 / 223 pass
- [ ] Manual: open a project, edit a file in an external editor, confirm dirty badge updates in <500 ms
- [ ] Manual: run `git add .` from a terminal in the project root, confirm staged count updates without waiting for the 30s backstop
- [ ] Manual: switch projects + close the app, confirm watchers tear down (no leaked `fs.watch` handles)