### PR TITLE
Fix false "Requires Claude Pro" gate for paid Claude logins

### DIFF
--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -656,10 +656,10 @@ const probeCodexAccount = (codexPath: string): Effect.Effect<AccountInfo> =>
 const CLAUDE_SUB_LABEL: Record<string, string> = {
   max: "Claude Max Subscription",
   pro: "Claude Pro Subscription",
-  // Claude Code agent usage requires a paid plan. Free / unknown tiers
-  // surface as "Requires …" so the renderer's existing subscription-gate
-  // rail (matches authLabel.includes("require")) disables the toggle and
-  // shows the Subscribe CTA, same as Grok/Cursor.
+  // Only an *explicitly* free tier surfaces as "Requires …" so the renderer's
+  // subscription-gate rail (matches authLabel.includes("require")) disables the
+  // toggle and shows the Subscribe CTA, same as Grok/Cursor. Unknown/missing
+  // tiers are NOT gated — see parseClaudeCredentials.
   free: "Requires Claude Pro",
 };
 
@@ -682,12 +682,18 @@ const parseClaudeCredentials = (raw: string): AccountInfo => {
   if (!oauth) return { authStatus: "authenticated" };
   const sub = oauth.subscriptionType?.toLowerCase();
   const email = oauth.emailAddress ?? oauth.email;
-  // Missing or unrecognised subscription tier → treat as needing Claude Pro,
-  // matching the explicit `free` branch in CLAUDE_SUB_LABEL.
+  // A present OAuth login already proves a paid Claude account — Claude Code
+  // agent usage is not available on the free tier. So only an *explicitly*
+  // recognised free tier surfaces the subscription gate; an unknown or missing
+  // subscriptionType is treated as a valid (non-blocking) login, with the
+  // runtime performing the real entitlement check. (Mirrors the Grok probe,
+  // which only blocks on a *confirmed* below-entitlement tier.) Defaulting
+  // unknown tiers to "Requires …" wrongly nagged Pro users — and anyone whose
+  // tier string we don't map — to subscribe despite an active subscription.
   const authLabel =
     sub && CLAUDE_SUB_LABEL[sub]
       ? CLAUDE_SUB_LABEL[sub]
-      : "Requires Claude Pro";
+      : "Claude subscription";
   return {
     authStatus: "authenticated",
     authType: "oauth",
@@ -900,6 +906,11 @@ export const grokAuthTestHelpers = {
   parseGrokAuthJson,
   extractTier,
   decodeJwtPayload,
+};
+
+// Exported for tests only. Not part of the public module surface.
+export const claudeAuthTestHelpers = {
+  parseClaudeCredentials,
 };
 
 // Grok stores OIDC credentials (JWT + email + tier claim) in `~/.grok/auth.json`

--- a/apps/server/test/availability.test.ts
+++ b/apps/server/test/availability.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   buildUpdateCommand,
+  claudeAuthTestHelpers,
   compareCliVersion,
   deriveLatestAdvisory,
   grokAuthTestHelpers,
@@ -13,6 +14,7 @@ import {
 
 const { parseGrokAuthJson, extractTier, decodeJwtPayload } =
   grokAuthTestHelpers;
+const { parseClaudeCredentials } = claudeAuthTestHelpers;
 
 describe("parseCliVersion", () => {
   it("pulls the first dotted triple out of labelled output", () => {
@@ -180,6 +182,66 @@ describe("grok auth probe — tier extraction & parseGrokAuthJson", () => {
   it("parseGrokAuthJson for empty entry still authenticated", () => {
     const info = parseGrokAuthJson(JSON.stringify({}));
     expect(info.authLabel).toBe("Grok");
+  });
+});
+
+describe("parseClaudeCredentials — subscription gating", () => {
+  const blob = (subscriptionType?: string, email = "user@anthropic.com") =>
+    JSON.stringify({
+      claudeAiOauth: {
+        ...(subscriptionType !== undefined ? { subscriptionType } : {}),
+        emailAddress: email,
+      },
+    });
+
+  it("labels a Pro plan without gating it", () => {
+    const info = parseClaudeCredentials(blob("pro"));
+    expect(info.authStatus).toBe("authenticated");
+    expect(info.authLabel).toBe("Claude Pro Subscription");
+    expect(info.authLabel?.toLowerCase()).not.toContain("require");
+    expect(info.authEmail).toBe("user@anthropic.com");
+  });
+
+  it("labels a Max plan without gating it", () => {
+    const info = parseClaudeCredentials(blob("max"));
+    expect(info.authLabel).toBe("Claude Max Subscription");
+    expect(info.authLabel?.toLowerCase()).not.toContain("require");
+  });
+
+  it("normalises tier casing before matching", () => {
+    expect(parseClaudeCredentials(blob("Pro")).authLabel).toBe(
+      "Claude Pro Subscription",
+    );
+  });
+
+  it("does NOT gate an unknown/unmapped tier (a paid login is still valid)", () => {
+    // Regression: a base Pro user whose tier string we don't map (or whose blob
+    // omits it) must not be told to subscribe — the OAuth login proves a paid
+    // account and the runtime does the real entitlement check.
+    const info = parseClaudeCredentials(blob("max_5x_20250101"));
+    expect(info.authStatus).toBe("authenticated");
+    expect(info.authLabel?.toLowerCase()).not.toContain("require");
+  });
+
+  it("does NOT gate when subscriptionType is missing", () => {
+    const info = parseClaudeCredentials(blob(undefined));
+    expect(info.authStatus).toBe("authenticated");
+    expect(info.authLabel?.toLowerCase()).not.toContain("require");
+  });
+
+  it("gates only an explicitly free tier", () => {
+    const info = parseClaudeCredentials(blob("free"));
+    expect(info.authLabel).toBe("Requires Claude Pro");
+    expect(info.authLabel?.toLowerCase()).toContain("require");
+  });
+
+  it("falls back to authenticated for non-JSON / OAuth-less blobs", () => {
+    expect(parseClaudeCredentials("{not json").authStatus).toBe(
+      "authenticated",
+    );
+    expect(parseClaudeCredentials(JSON.stringify({})).authStatus).toBe(
+      "authenticated",
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

Settings showed a "Requires Claude Pro" subscription gate (Subscribe CTA) for users who are already on a paid Claude plan — including base **Pro** users. They were wrongly told they need to subscribe despite an active subscription.

## Root cause

In `apps/server/src/provider/availability.ts`, `parseClaudeCredentials` mapped the OAuth `subscriptionType` to a label, but only the exact strings `"max"` and `"pro"` were recognized. **Any other value — an unmapped tier string or a missing field — defaulted to `"Requires Claude Pro"`.** The renderer's gate triggers on any `authLabel` containing `"require"`, so those users got the Subscribe CTA.

This is the opposite of the sibling Grok probe (`parseGrokAuthJson`), which only blocks on a *confirmed* below-entitlement tier and treats unknown tiers as non-blocking.

## Fix

- Unknown/missing `subscriptionType` now falls back to a non-blocking `"Claude subscription"` label instead of `"Requires Claude Pro"`. A present OAuth login already proves a paid Claude account (agent usage isn't available on free), so only an **explicitly** `free` tier surfaces the gate. The runtime still does the real entitlement check.
- Exported `parseClaudeCredentials` via a test-only helper (mirrors `grokAuthTestHelpers`).

## Tests

Added 7 cases for `parseClaudeCredentials`: Pro/Max labelled without gating, case-insensitive matching, **unknown tier not gated** (the regression), missing tier not gated, only explicit `free` gated, and non-JSON/OAuth-less fallback. All 45 tests in `availability.test.ts` pass.