### PR TITLE
Surface Claude auth failures as an in-app "Sign in to Claude" card

### DIFF
--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -4,6 +4,8 @@ import {
   ArrowRight01Icon,
   Copy01Icon,
   DashboardSpeedIcon,
+  Loading02Icon,
+  PlayIcon,
   RotateRight01Icon,
   Settings01Icon,
   Tick01Icon,
@@ -23,8 +25,18 @@ import type {
 } from "@memoize/wire";
 
 import { getFileIconUrl } from "~/lib/icons/material-icons";
+import {
+  openExternal,
+  useProviderLogin,
+} from "~/lib/use-provider-login";
 import { cn } from "~/lib/utils";
-import { useMessagesStore, type ChatError } from "~/store/messages";
+import {
+  classifyMessage,
+  lookupSessionProvider,
+  useMessagesStore,
+  type ChatError,
+} from "~/store/messages";
+import { useProvidersStore } from "~/store/providers";
 import { useUiStore } from "~/store/ui";
 
 import { CopyButton } from "./copy-button.tsx";
@@ -163,9 +175,17 @@ export function MessageRow({
     case "usage_limit":
       return null;
     case "error":
+      // Classify so an auth failure (expired OAuth / 401 / "Please run
+      // /login") gets the "Sign in to {provider}" headline + inline login
+      // button rather than a bare generic error.
       return (
         <ErrorBubble
-          error={{ kind: "generic", message: message.content.message }}
+          error={classifyMessage(
+            message.content.message,
+            sessionId !== undefined
+              ? lookupSessionProvider(sessionId)
+              : undefined,
+          )}
           sessionId={sessionId}
         />
       );
@@ -478,6 +498,157 @@ const PROVIDER_LABEL_FOR_ERROR: Record<ProviderId, string> = {
   opencode: "OpenCode",
 };
 
+// Providers with a real in-app `agent.startLogin` handler — for these we offer
+// the inline one-click sign-in directly in the auth error bubble instead of
+// only pointing the user at Settings.
+const PROVIDERS_WITH_LOGIN: ReadonlySet<ProviderId> = new Set<ProviderId>([
+  "cursor",
+  "claude",
+]);
+
+/**
+ * "Authentication required" card shown when a login-capable provider (Claude,
+ * Cursor) reports an auth failure. Reuses the shared `useProviderLogin` flow
+ * (open browser → wait for the OAuth callback → done): on success it re-probes
+ * availability and clears the bottom error.
+ *
+ * This card is a *persisted* message in scrollback, so it must not carry sticky
+ * per-instance UI: once the provider reports `authenticated` (whether via this
+ * card, another duplicate card, Settings, or the terminal) every auth card
+ * resolves to nothing. That's what kills the "stuck on Signed in. Resuming…"
+ * and the duplicate cards after a successful sign-in.
+ */
+function ProviderAuthCard({
+  providerId,
+  sessionId,
+  onOpenSettings,
+  onDismiss,
+}: {
+  providerId: ProviderId;
+  sessionId: SessionId | undefined;
+  onOpenSettings: () => void;
+  onDismiss?: () => void;
+}) {
+  const refreshProviders = useProvidersStore((s) => s.refresh);
+  const authStatus = useProvidersStore(
+    (s) => s.availability.find((a) => a.providerId === providerId)?.authStatus,
+  );
+  const clearError = useMessagesStore((s) => s.clearError);
+  const retry = useMessagesStore((s) => s.retry);
+  const { state, start, cancel } = useProviderLogin(providerId, {
+    onSuccess: () => {
+      // Re-probe first so the keychain write has landed and this card
+      // resolves (hides) before we resume — then re-send the pending message
+      // so the turn the user was blocked on actually runs. The server
+      // restarts the stale (unauthenticated) provider process on send, so it
+      // picks up the fresh credentials.
+      void (async () => {
+        await refreshProviders();
+        if (sessionId !== undefined) {
+          clearError(sessionId);
+          void retry(sessionId);
+        }
+      })();
+    },
+  });
+  const label = PROVIDER_LABEL_FOR_ERROR[providerId];
+
+  // Resolved — the provider is authenticated now, so this historical card has
+  // nothing left to do. Render nothing (no nag, no spinner, no duplicate).
+  if (authStatus === "authenticated") return null;
+
+  return (
+    <div className="px-4 py-2">
+      <div className="w-fit max-w-[80%] rounded-lg border border-border/60 bg-card px-3 py-2.5 text-xs text-foreground">
+        <div className="flex items-center justify-between gap-2">
+          <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+            <HugeiconsIcon
+              icon={AlertCircleIcon}
+              className="size-3.5 text-destructive"
+              aria-hidden
+            />
+            Authentication required
+          </span>
+          {onDismiss !== undefined && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+
+        {state.kind === "waiting" ? (
+          <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+            <HugeiconsIcon
+              icon={Loading02Icon}
+              className="size-3.5 animate-spin"
+              aria-hidden
+            />
+            <span>Waiting for browser sign-in…</span>
+            <button
+              type="button"
+              onClick={cancel}
+              className="rounded px-1 py-0.5 text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : state.kind === "success" ? (
+          <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+            <HugeiconsIcon
+              icon={Loading02Icon}
+              className="size-3.5 animate-spin"
+              aria-hidden
+            />
+            <span>Signed in. Finishing…</span>
+          </div>
+        ) : (
+          <>
+            <p className="mt-1 leading-relaxed text-muted-foreground">
+              To resolve, sign in to {label}. We&apos;ll validate the login
+              automatically.
+            </p>
+            {state.kind === "failed" && (
+              <p className="mt-1 text-[11px] text-destructive">{state.reason}</p>
+            )}
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              <Button
+                type="button"
+                size="xs"
+                variant="outline"
+                onClick={() => void start()}
+                className="gap-1.5"
+              >
+                <HugeiconsIcon icon={PlayIcon} className="size-3" aria-hidden />
+                {state.kind === "failed"
+                  ? `Try ${label} sign-in again`
+                  : `Sign in to ${label}`}
+              </Button>
+              <Button
+                type="button"
+                size="xs"
+                variant="ghost"
+                onClick={onOpenSettings}
+                className="gap-1"
+              >
+                <HugeiconsIcon
+                  icon={Settings01Icon}
+                  className="size-3"
+                  aria-hidden
+                />
+                Settings
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 const GEMINI_UPGRADE_COMMAND = "npm i -g @google/gemini-cli@latest";
 
 const isGeminiAcpUpgradeError = (text: string): boolean =>
@@ -627,6 +798,25 @@ export function ErrorBubble({
           )}
         </div>
       </div>
+    );
+  }
+
+  // Auth failure for a provider we can sign into in-app → the dedicated
+  // "Authentication required" card with the one-click OAuth button. Other
+  // providers (or auth errors without a provider) fall through to the generic
+  // bubble below with a "Open Provider Settings" link.
+  if (
+    error.kind === "auth" &&
+    error.providerId !== undefined &&
+    PROVIDERS_WITH_LOGIN.has(error.providerId)
+  ) {
+    return (
+      <ProviderAuthCard
+        providerId={error.providerId}
+        sessionId={sessionId}
+        onOpenSettings={onOpenSettings}
+        onDismiss={onDismiss}
+      />
     );
   }
 

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -14,12 +14,15 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   MODELS_BY_PROVIDER,
   type AgentAvailability,
-  type LoginEvent,
   type ProviderId,
   type ProviderUpdateEvent,
 } from "@memoize/wire";
 
 import { ApiKeyRow } from "~/components/api-key-row";
+import {
+  openExternal,
+  useProviderLogin,
+} from "~/lib/use-provider-login";
 import { ProviderIcon } from "~/components/provider-icons";
 import { Button } from "~/components/ui/button";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
@@ -245,8 +248,8 @@ export function ProviderCard({
           )}
           {availability?.cliInstalled &&
             availability.authStatus === "unauthenticated" &&
-            (providerId === "cursor" ? (
-              <CursorSignInRow />
+            (providerId === "cursor" || providerId === "claude" ? (
+              <ProviderSignInRow providerId={providerId} />
             ) : (
               <CodeRow label="Sign in" command={LOGIN_HINT[providerId]} />
             ))}
@@ -304,21 +307,6 @@ function ModelDefault({ providerId }: { providerId: ProviderId }) {
     </div>
   );
 }
-
-/**
- * Open a URL in the user's OS browser via the preload bridge (Electron's
- * `shell.openExternal`). Falls back to `window.open` for web/dev contexts.
- * We intentionally avoid an in-app webview here: a paid-checkout flow
- * needs the user's real browser session, password manager, and cookies.
- */
-const openExternal = (url: string) => {
-  const bridge = window.memoize?.app;
-  if (bridge !== undefined) {
-    bridge.openExternal(url);
-    return;
-  }
-  window.open(url, "_blank", "noopener,noreferrer");
-};
 
 /**
  * Subscription / plan notice for providers that gate behind a paid tier
@@ -404,79 +392,24 @@ function BlurredEmail({ email }: { email: string }) {
 }
 
 /**
- * One-click sign-in for Cursor. Click → subscribe to `agent.startLogin`,
- * which spawns `cursor-agent login` server-side and streams progress. The
+ * One-click sign-in row for providers with a real in-app login handler
+ * (`cursor`, `claude`). Click → subscribe to `agent.startLogin`, which spawns
+ * the provider's `login` subcommand server-side and streams progress. The
  * first `url` event opens the OAuth page in the OS browser; the terminal
- * `done` event triggers an availability refresh and (on success) collapses
- * the row. Cancel interrupts the stream, which closes the server-side
- * scope and SIGTERMs the child process.
+ * `done` event triggers an availability refresh and (on success) collapses the
+ * row. Cancel interrupts the stream, which closes the server-side scope and
+ * SIGTERMs the child process. The whole state machine lives in
+ * `useProviderLogin` so the inline auth ErrorBubble can reuse it verbatim.
  */
-function CursorSignInRow() {
+function ProviderSignInRow({ providerId }: { providerId: ProviderId }) {
   const refresh = useProvidersStore((s) => s.refresh);
-  const [state, setState] = useState<
-    | { kind: "idle" }
-    | { kind: "waiting"; url: string | null }
-    | { kind: "success" }
-    | { kind: "failed"; reason: string }
-  >({ kind: "idle" });
-  const fiberRef = useRef<Fiber.RuntimeFiber<unknown, unknown> | null>(null);
-
-  useEffect(
-    () => () => {
-      const fiber = fiberRef.current;
-      if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
+  const { state, start, cancel } = useProviderLogin(providerId, {
+    onSuccess: () => {
+      void refresh();
     },
-    [],
-  );
-
-  const cancel = () => {
-    const fiber = fiberRef.current;
-    if (fiber !== null) {
-      void Effect.runPromise(Fiber.interrupt(fiber));
-      fiberRef.current = null;
-    }
-    setState({ kind: "idle" });
-  };
-
-  const start = async () => {
-    setState({ kind: "waiting", url: null });
-    const client = await getRpcClient();
-    const fiber = Effect.runFork(
-      Stream.runForEach(
-        client.agent.startLogin({ providerId: "cursor" }),
-        (event: LoginEvent) =>
-          Effect.sync(() => {
-            if (event._tag === "url") {
-              openExternal(event.url);
-              setState({ kind: "waiting", url: event.url });
-            } else if (event._tag === "done") {
-              fiberRef.current = null;
-              if (event.ok) {
-                setState({ kind: "success" });
-                void refresh();
-              } else {
-                setState({
-                  kind: "failed",
-                  reason: event.reason ?? "Sign-in failed.",
-                });
-              }
-            }
-            // "log" events are diagnostic-only; ignored in the UI.
-          }),
-      ).pipe(
-        Effect.catchAll((err) =>
-          Effect.sync(() => {
-            fiberRef.current = null;
-            setState({
-              kind: "failed",
-              reason: err instanceof Error ? err.message : String(err),
-            });
-          }),
-        ),
-      ),
-    );
-    fiberRef.current = fiber;
-  };
+  });
+  const label = PROVIDER_LABEL[providerId];
+  const manualCommand = LOGIN_HINT[providerId];
 
   if (state.kind === "success") {
     return (
@@ -497,7 +430,7 @@ function CursorSignInRow() {
           />
           <span>
             {state.url === null
-              ? "Starting cursor-agent login…"
+              ? `Starting ${label} sign-in…`
               : "Waiting for browser sign-in…"}
           </span>
         </div>
@@ -558,7 +491,7 @@ function CursorSignInRow() {
             Try again
           </Button>
         </div>
-        <CodeRow label="Or run manually" command={LOGIN_HINT.cursor} />
+        <CodeRow label="Or run manually" command={manualCommand} />
       </div>
     );
   }
@@ -579,10 +512,10 @@ function CursorSignInRow() {
           }}
           className="h-7 px-3 text-[11px]"
         >
-          Sign in to Cursor
+          Sign in to {label}
         </Button>
         <span className="text-[10px] text-muted-foreground">
-          or run <code className="font-mono">$ {LOGIN_HINT.cursor}</code>
+          or run <code className="font-mono">$ {manualCommand}</code>
         </span>
       </div>
     </div>

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -80,9 +80,13 @@ export function WorktreeSetupCard() {
   const setupStatus = worktree?.setupStatus ?? null;
   const setupDone = setupStatus === "succeeded" || setupStatus === "skipped";
   const providerBooting = session?.status === "booting";
+  const providerErrored = session?.status === "error";
 
   // Visible while there's worktree/setup work left, OR while the provider CLI
   // is still booting (covers a worktree-less "new tab in this chat" too).
+  // Once the provider errors we stop occupying the screen with a fake
+  // "Starting…" spinner — the ErrorBubble below carries the failure + the
+  // inline "Sign in" CTA — so a worktree-less errored session hides the card.
   const visible = (hasWorktree && !setupDone) || providerBooting === true;
   if (!visible) return null;
 
@@ -91,7 +95,13 @@ export function WorktreeSetupCard() {
       ? (PROVIDER_LABEL[session.providerId] ?? session.providerId)
       : "agent";
   const providerState: StepState =
-    session === null ? "pending" : providerBooting ? "active" : "done";
+    session === null
+      ? "pending"
+      : providerBooting
+        ? "active"
+        : providerErrored
+          ? "failed"
+          : "done";
 
   return (
     <SetupCardView
@@ -210,7 +220,11 @@ export function SetupCardView({ data }: { data: SetupCardData }) {
           ) : null}
           <StepRow
             state={providerState}
-            label={`Starting ${providerLabel}`}
+            label={
+              providerState === "failed"
+                ? `${providerLabel} failed to start`
+                : `Starting ${providerLabel}`
+            }
           />
         </div>
         {setupOutput.trim().length > 0 ? (

--- a/apps/renderer/src/lib/use-provider-login.ts
+++ b/apps/renderer/src/lib/use-provider-login.ts
@@ -1,0 +1,111 @@
+import { Effect, Fiber, Stream } from "effect";
+import { useEffect, useRef, useState } from "react";
+
+import { type LoginEvent, type ProviderId } from "@memoize/wire";
+
+import { getRpcClient } from "./rpc-client";
+
+export type ProviderLoginState =
+  | { readonly kind: "idle" }
+  | { readonly kind: "waiting"; readonly url: string | null }
+  | { readonly kind: "success" }
+  | { readonly kind: "failed"; readonly reason: string };
+
+/**
+ * Open a URL in the user's OS browser via the preload bridge (Electron's
+ * `shell.openExternal`). Falls back to `window.open` for web/dev contexts.
+ * We intentionally avoid an in-app webview here: an OAuth flow needs the
+ * user's real browser session, password manager, and cookies.
+ */
+export const openExternal = (url: string): void => {
+  const bridge = window.memoize?.app;
+  if (bridge !== undefined) {
+    bridge.openExternal(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+};
+
+/**
+ * Shared one-click provider sign-in state machine. Subscribes to
+ * `agent.startLogin`, which spawns the provider's `login` subcommand
+ * server-side and streams progress. The first `url` event opens the OAuth page
+ * in the OS browser; the terminal `done` event resolves to success/failure.
+ * Cancel (or unmount) interrupts the stream, which closes the server-side
+ * scope and SIGTERMs the child process.
+ *
+ * Used by both the provider settings card and the inline auth ErrorBubble so
+ * the flow (and its copy) stays identical wherever a user signs in.
+ */
+export function useProviderLogin(
+  providerId: ProviderId,
+  opts?: { readonly onSuccess?: () => void },
+): {
+  readonly state: ProviderLoginState;
+  readonly start: () => Promise<void>;
+  readonly cancel: () => void;
+} {
+  const [state, setState] = useState<ProviderLoginState>({ kind: "idle" });
+  const fiberRef = useRef<Fiber.RuntimeFiber<unknown, unknown> | null>(null);
+  const onSuccessRef = useRef(opts?.onSuccess);
+  onSuccessRef.current = opts?.onSuccess;
+
+  useEffect(
+    () => () => {
+      const fiber = fiberRef.current;
+      if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
+    },
+    [],
+  );
+
+  const cancel = (): void => {
+    const fiber = fiberRef.current;
+    if (fiber !== null) {
+      void Effect.runPromise(Fiber.interrupt(fiber));
+      fiberRef.current = null;
+    }
+    setState({ kind: "idle" });
+  };
+
+  const start = async (): Promise<void> => {
+    setState({ kind: "waiting", url: null });
+    const client = await getRpcClient();
+    const fiber = Effect.runFork(
+      Stream.runForEach(
+        client.agent.startLogin({ providerId }),
+        (event: LoginEvent) =>
+          Effect.sync(() => {
+            if (event._tag === "url") {
+              openExternal(event.url);
+              setState({ kind: "waiting", url: event.url });
+            } else if (event._tag === "done") {
+              fiberRef.current = null;
+              if (event.ok) {
+                setState({ kind: "success" });
+                onSuccessRef.current?.();
+              } else {
+                setState({
+                  kind: "failed",
+                  reason: event.reason ?? "Sign-in failed.",
+                });
+              }
+            }
+            // "log" events are diagnostic-only; ignored in the UI.
+          }),
+      ).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            fiberRef.current = null;
+            setState({
+              kind: "failed",
+              reason: err instanceof Error ? err.message : String(err),
+            });
+          }),
+        ),
+      ),
+    );
+    fiberRef.current = fiber;
+  };
+
+  return { state, start, cancel };
+}

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -43,7 +43,7 @@ export type ChatError =
   | { readonly kind: "generic"; readonly message: string };
 
 const AUTH_PATTERN =
-  /\b401\b|\bunauthorized\b|expired token|invalid_grant|signed?\s?out|sign\s?in required|please log in|authorizationrequired|auth\(authorizationrequired\)|authentication failed/i;
+  /\b401\b|\bunauthorized\b|expired token|invalid_grant|signed?\s?out|sign\s?in required|please log in|please run \/login|not logged in|invalid authentication credentials|invalid api key|authorizationrequired|auth\(authorizationrequired\)|authentication failed/i;
 const NETWORK_PATTERN =
   /\b(network|fetch|econn|enotfound|etimedout|timeout|getaddrinfo)\b/i;
 
@@ -90,7 +90,7 @@ const readSessionModelOptions = (
   return Object.keys(out).length === 0 ? null : out;
 };
 
-const classifyMessage = (
+export const classifyMessage = (
   message: string,
   providerId?: ProviderId,
 ): ChatError => {
@@ -106,7 +106,7 @@ const classifyMessage = (
 const classifyError = (err: unknown, providerId?: ProviderId): ChatError =>
   classifyMessage(formatError(err), providerId);
 
-const lookupSessionProvider = (
+export const lookupSessionProvider = (
   sessionId: SessionId,
 ): ProviderId | undefined => {
   const buckets = useSessionsStore.getState().sessionsByProject;

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -277,6 +277,12 @@ interface TranslateState {
    * when the turn's `result` lands (which carries the real `contextWindow`).
    */
   lastContextUsedTokens: number | null;
+  /**
+   * Set once we've re-emitted an auth failure as an Error from a top-level
+   * assistant text block, so the turn's terminal `result` doesn't surface the
+   * same failure a second time.
+   */
+  emittedAuthError: boolean;
 }
 
 const newTranslateState = (): TranslateState => ({
@@ -287,6 +293,7 @@ const newTranslateState = (): TranslateState => ({
   askUserQuestionIds: new Set(),
   exitPlanModeIds: new Set(),
   lastContextUsedTokens: null,
+  emittedAuthError: false,
 });
 
 const isAgentToolUse = (block: { type?: string; name?: string }): boolean =>
@@ -423,6 +430,51 @@ const claudeRateLimitEvents = (
   ];
 };
 
+// When the `claude` CLI/SDK runs without valid credentials it does NOT throw —
+// it reports the failure as ordinary output ("Not logged in · Please run
+// /login", "Invalid API key", a 401 result). Left untranslated that renders as
+// a confusing assistant message the user can't act on. We sniff the signature
+// so it can be re-emitted as a structured `Error` event, which the renderer
+// turns into the "Authentication required → Sign in to Claude" card.
+const CLAUDE_AUTH_FAILURE_PATTERN =
+  /not logged in|please run \/login|\/login\b|invalid api key|invalid authentication credentials|\bunauthorized\b|oauth token (?:has )?expired|authentication_error|\b401\b/i;
+
+export const looksLikeClaudeAuthFailure = (text: string): boolean =>
+  CLAUDE_AUTH_FAILURE_PATTERN.test(text);
+
+/**
+ * Pull the human-readable error text out of a `result` message. The SDK splits
+ * results into a success shape (`result: string`, may still carry
+ * `is_error`/`api_error_status`) and an error shape (`errors: string[]`).
+ */
+export const claudeResultErrorText = (msg: SDKMessage): string | null => {
+  const m = msg as {
+    subtype?: string;
+    is_error?: boolean;
+    result?: unknown;
+    errors?: unknown;
+    api_error_status?: unknown;
+  };
+  const status =
+    typeof m.api_error_status === "number" ? m.api_error_status : null;
+  const isError =
+    m.is_error === true ||
+    (typeof m.subtype === "string" && m.subtype !== "success") ||
+    (status !== null && status >= 400);
+  if (!isError) return null;
+  const errors = Array.isArray(m.errors)
+    ? m.errors.filter((e): e is string => typeof e === "string")
+    : [];
+  const parts: string[] = [];
+  if (typeof m.result === "string" && m.result.trim().length > 0) {
+    parts.push(m.result.trim());
+  }
+  parts.push(...errors);
+  if (status !== null) parts.push(`API Error: ${status}`);
+  const text = parts.join("\n").trim();
+  return text.length > 0 ? text : "The agent run ended with an error.";
+};
+
 /**
  * Translate one SDKMessage into zero-or-more wire AgentEvents. Mostly
  * stateless, but the `state` carries thinking-delta accumulators across
@@ -484,6 +536,19 @@ const translate = (
       for (const block of content) {
         blockTypes.push(String((block as { type?: unknown }).type));
         if (block.type === "text" && typeof block.text === "string") {
+          // An unauthenticated `claude` surfaces "Not logged in · Please run
+          // /login" as a top-level assistant text block. Re-emit it as an
+          // Error so the renderer shows the sign-in card instead of a dead-end
+          // message. Only at the top level — a sub-agent quoting "/login" in
+          // its reasoning shouldn't trip this.
+          if (
+            parentItemId === undefined &&
+            looksLikeClaudeAuthFailure(block.text)
+          ) {
+            out.push({ _tag: "Error", message: block.text.trim() });
+            state.emittedAuthError = true;
+            continue;
+          }
           out.push({
             _tag: "AssistantMessage",
             itemId: nextItemId(),
@@ -830,11 +895,22 @@ const translate = (
           source: "Claude usage",
         });
       }
+      // Surface a failed result's text as an Error so it persists + renders
+      // (auth failures the SDK reports via the result rather than an assistant
+      // block land here). `state.emittedAuthError` dedupes against the
+      // assistant-block path above so we don't show the card twice.
+      const resultError = claudeResultErrorText(msg);
+      if (resultError !== null && !state.emittedAuthError) {
+        out.push({ _tag: "Error", message: resultError });
+      }
       out.push(
-        msg.subtype === "success"
+        msg.subtype === "success" && resultError === null
           ? { _tag: "Completed", reason: "ended" }
           : { _tag: "Completed", reason: "error" },
       );
+      // The result closes the top-level turn — reset the per-turn auth dedupe
+      // so a later turn that fails auth still surfaces its own card.
+      state.emittedAuthError = false;
     }
     return out;
   }

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -69,11 +69,11 @@ const Events = MemoizeRpcs.toLayerHandler("agent.events", ({ sessionId }) =>
 );
 
 // Renderer subscribes to this when the user clicks the "Sign in" button on a
-// provider card. Today only the cursor handler does real work — it spawns
-// `cursor-agent login`, extracts the OAuth URL, and streams progress back.
-// When the renderer unsubscribes (cancel, navigate away, IPC drop), the
-// stream's scope closes and the child process is SIGTERM'd by the service's
-// finalizer.
+// provider card or in an auth error bubble. `cursor` and `claude` have real
+// handlers — they spawn the provider's `login` subcommand, extract the OAuth
+// URL, and stream progress back. When the renderer unsubscribes (cancel,
+// navigate away, IPC drop), the stream's scope closes and the child process is
+// SIGTERM'd by the service's finalizer.
 const StartLogin = MemoizeRpcs.toLayerHandler(
   "agent.startLogin",
   ({ providerId }) => startProviderLogin(providerId),

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -491,6 +491,17 @@ const formatProviderFailure = (cause: unknown): string => {
   return String(cause);
 };
 
+// Auth failures (expired/missing OAuth, `401 Invalid authentication
+// credentials`, `Please run /login`) are not recoverable by re-spawning the
+// provider — restarting just hits the same 401, which is what left sessions
+// retrying forever and eventually surfacing an unrelated transient (e.g. a
+// Cloudflare 522). When the failure looks like auth we skip the restart and
+// surface the error so the renderer can show the inline "Sign in" button.
+const looksLikeAuthFailure = (reason: string): boolean =>
+  /\b401\b|\bunauthorized\b|invalid authentication credentials|please run \/login|please log ?in|invalid api key|authentication failed|authorizationrequired/i.test(
+    reason,
+  );
+
 export const MessageStoreLive = Layer.scoped(
   MessageStore,
   Effect.gen(function* () {
@@ -1138,6 +1149,16 @@ export const MessageStoreLive = Layer.scoped(
               const persisted = yield* persistMessage(sessionId, content);
               yield* broadcastMessage(sessionId, persisted);
               yield* ndjsonAppend(sessionId, persisted);
+              // A provider `Error` event terminates the turn but, unlike a
+              // `Completed`, carries no lifecycle reason of its own — so
+              // without this the session is left pinned at `running` and the
+              // composer / setup card spin forever (this is the "stuck on the
+              // loading screen" symptom for auth failures, which surface as a
+              // mid-stream Error with no trailing result message). Flip to
+              // `error` so the renderer shows the error bubble + login CTA.
+              if (event._tag === "Error") {
+                yield* setStatus(sessionId, "error");
+              }
             }),
           ).pipe(
             Effect.catchAllCause((cause) =>
@@ -1437,6 +1458,16 @@ export const MessageStoreLive = Layer.scoped(
                     yield* Effect.logWarning(
                       `[MessageStore] provider.start failed for session ${sessionId} (${input.providerId}): ${err.reason}`,
                     );
+                    // Persist the failure as an error message so the renderer
+                    // can render it (and classify auth failures into the inline
+                    // "Sign in" CTA) instead of leaving the session stuck on the
+                    // booting spinner with no explanation.
+                    const persistedError = yield* persistMessage(sessionId, {
+                      _tag: "error",
+                      message: err.reason,
+                    });
+                    yield* broadcastMessage(sessionId, persistedError);
+                    yield* ndjsonAppend(sessionId, persistedError);
                     yield* setStatus(sessionId, "error");
                   }),
                 ),
@@ -2787,6 +2818,21 @@ export const MessageStoreLive = Layer.scoped(
             (attachments ?? []).length
           })`,
         );
+        // If the session previously errored — typically an auth failure the
+        // user has since fixed by signing in — the in-memory provider process
+        // is stale: for Claude it was spawned without valid credentials and
+        // won't re-read the keychain on its own. Drop it (mirrors setModel's
+        // teardown) so the send below lazy-restarts a fresh process that picks
+        // up the new login, instead of silently re-pushing into the dead one.
+        const latestForSend = yield* lookupSession(sessionId).pipe(
+          Effect.orDie,
+        );
+        if (latestForSend.status === "error") {
+          yield* provider
+            .close(sessionId)
+            .pipe(Effect.catchAll(() => Effect.void));
+          yield* interruptProviderFiber(sessionId);
+        }
         const sendResult = yield* provider
           .send(sessionId, sendText, cleanAttachments, fileRefs, skillRefs)
           .pipe(
@@ -2810,6 +2856,23 @@ export const MessageStoreLive = Layer.scoped(
           if (looksLikeGrokAuthWorkerDeath) {
             yield* setStatus(sessionId, "running");
             return true;
+          }
+
+          // Auth failures aren't recoverable by restarting — re-spawning hits
+          // the same 401, which is the infinite-retry / stuck-loading bug.
+          // Persist the error so the renderer shows the "Sign in" CTA and stop.
+          if (looksLikeAuthFailure(sendResult.reason)) {
+            console.log(
+              `[message-store.sendMessage] provider.send failed with auth error for ${sessionId}; skipping restart`,
+            );
+            const persistedError = yield* persistMessage(sessionId, {
+              _tag: "error",
+              message: sendResult.reason,
+            });
+            yield* broadcastMessage(sessionId, persistedError);
+            yield* ndjsonAppend(sessionId, persistedError);
+            yield* setStatus(sessionId, "error");
+            return false;
           }
 
           console.log(

--- a/apps/server/src/provider/services/login-service.ts
+++ b/apps/server/src/provider/services/login-service.ts
@@ -12,18 +12,47 @@ import {
   type ProviderId,
 } from "@memoize/wire";
 
-// Cursor-agent's login command prints an OAuth URL to stdout (or to stderr
-// inside its TUI frame) and waits for the user to complete the flow in their
-// browser. We anchor on the cursor.com / cursor.sh / cursor.so hosts to avoid
-// matching install-instruction URLs the CLI may also print on startup.
-const CURSOR_URL_PATTERN =
-  /https?:\/\/[^\s]*cursor\.(?:com|sh|so)\/[^\s]*/i;
+// Each provider's interactive login command prints an OAuth URL to stdout (or
+// to stderr inside its TUI frame) and waits for the user to complete the flow
+// in their browser. We anchor each pattern on the provider's own hosts to
+// avoid matching install-instruction or doc URLs the CLI may also print on
+// startup.
+const CURSOR_URL_PATTERN = /https?:\/\/[^\s]*cursor\.(?:com|sh|so)\/[^\s]*/i;
+// `claude auth login` runs an OAuth 2.0 + PKCE flow against claude.ai with a
+// localhost callback server, so it auto-completes once the browser approves —
+// no code paste-back. The authorize URL lives on claude.ai / anthropic.com.
+const CLAUDE_URL_PATTERN =
+  /https?:\/\/[^\s]*(?:claude\.ai|(?:console\.)?anthropic\.com)\/[^\s]*/i;
 const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+interface LoginSpawnSpec {
+  readonly providerId: ProviderId;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly urlPattern: RegExp;
+}
+
+const LOGIN_SPECS: Partial<Record<ProviderId, LoginSpawnSpec>> = {
+  cursor: {
+    providerId: "cursor",
+    command: "cursor-agent",
+    args: ["login"],
+    urlPattern: CURSOR_URL_PATTERN,
+  },
+  claude: {
+    providerId: "claude",
+    command: "claude",
+    // `--claudeai` selects the Claude subscription OAuth (vs `--console` API
+    // billing), matching the default the interactive `/login` menu offers.
+    args: ["auth", "login", "--claudeai"],
+    urlPattern: CLAUDE_URL_PATTERN,
+  },
+};
 
 /**
  * Spawn a provider's interactive login subcommand and stream progress back
- * to the renderer. Today only `cursor` has a real handler — other providers
- * resolve to an immediate `{ kind: "done", ok: false, reason: … }`.
+ * to the renderer. Today `cursor` and `claude` have real handlers — other
+ * providers resolve to an immediate `{ kind: "done", ok: false, reason: … }`.
  *
  * Cancellation: the stream is wrapped in `Stream.unwrapScoped`, so when the
  * renderer unsubscribes (or the IPC drops), the scope closes and the
@@ -33,7 +62,8 @@ const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 export const startProviderLogin = (
   providerId: ProviderId,
 ): Stream.Stream<LoginEvent, AgentSessionStartError> => {
-  if (providerId !== "cursor") {
+  const spec = LOGIN_SPECS[providerId];
+  if (spec === undefined) {
     const event: LoginEvent = {
       _tag: "done",
       ok: false,
@@ -41,106 +71,109 @@ export const startProviderLogin = (
     };
     return Stream.succeed(event);
   }
-  return Stream.unwrapScoped(spawnCursorLogin);
+  return Stream.unwrapScoped(spawnLoginProcess(spec));
 };
 
-const spawnCursorLogin: Effect.Effect<
+const spawnLoginProcess = (
+  spec: LoginSpawnSpec,
+): Effect.Effect<
   Stream.Stream<LoginEvent>,
   AgentSessionStartError,
   Scope.Scope
-> = Effect.gen(function* () {
-  const mailbox = yield* Mailbox.make<LoginEvent>();
+> =>
+  Effect.gen(function* () {
+    const mailbox = yield* Mailbox.make<LoginEvent>();
 
-  // Spawn into the user's home dir — login doesn't touch the project tree
-  // and we don't want a project-local stale state to interfere.
-  let child: ChildProcessWithoutNullStreams;
-  try {
-    child = spawn("cursor-agent", ["login"], {
-      cwd: homedir(),
-      env: process.env,
-      stdio: ["pipe", "pipe", "pipe"],
+    // Spawn into the user's home dir — login doesn't touch the project tree
+    // and we don't want a project-local stale state to interfere.
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(spec.command, [...spec.args], {
+        cwd: homedir(),
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (cause) {
+      yield* mailbox.end;
+      return yield* Effect.fail(
+        new AgentSessionStartError({
+          providerId: spec.providerId,
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+      );
+    }
+
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+
+    let urlEmitted = false;
+    let exited = false;
+
+    const handleLine = (raw: string): void => {
+      const cleaned = raw.replace(ANSI_PATTERN, "").trim();
+      if (cleaned.length === 0) return;
+      mailbox.unsafeOffer({ _tag: "log", text: cleaned });
+      if (!urlEmitted) {
+        const m = cleaned.match(spec.urlPattern);
+        if (m !== null) {
+          urlEmitted = true;
+          mailbox.unsafeOffer({ _tag: "url", url: m[0] });
+        }
+      }
+    };
+
+    const rlOut = readline.createInterface({ input: child.stdout });
+    const rlErr = readline.createInterface({ input: child.stderr });
+    rlOut.on("line", handleLine);
+    rlErr.on("line", handleLine);
+
+    child.once("exit", (code, signal) => {
+      exited = true;
+      const ok = code === 0;
+      const reason = ok
+        ? undefined
+        : signal !== null
+          ? `${spec.command} login was terminated (${signal})`
+          : `${spec.command} login exited with code ${code ?? "?"}`;
+      mailbox.unsafeOffer({
+        _tag: "done",
+        ok,
+        ...(reason !== undefined ? { reason } : {}),
+      });
+      void mailbox.end.pipe(Effect.runPromise);
     });
-  } catch (cause) {
-    yield* mailbox.end;
-    return yield* Effect.fail(
-      new AgentSessionStartError({
-        providerId: "cursor",
-        reason: cause instanceof Error ? cause.message : String(cause),
+
+    child.once("error", (err) => {
+      exited = true;
+      mailbox.unsafeOffer({
+        _tag: "done",
+        ok: false,
+        reason: err.message,
+      });
+      void mailbox.end.pipe(Effect.runPromise);
+    });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        rlOut.close();
+        rlErr.close();
+        if (exited) return;
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          /* ignore */
+        }
+        setTimeout(() => {
+          if (!exited) {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              /* ignore */
+            }
+          }
+        }, 1_000);
       }),
     );
-  }
 
-  child.stdout.setEncoding("utf-8");
-  child.stderr.setEncoding("utf-8");
-
-  let urlEmitted = false;
-  let exited = false;
-
-  const handleLine = (raw: string): void => {
-    const cleaned = raw.replace(ANSI_PATTERN, "").trim();
-    if (cleaned.length === 0) return;
-    mailbox.unsafeOffer({ _tag: "log", text: cleaned });
-    if (!urlEmitted) {
-      const m = cleaned.match(CURSOR_URL_PATTERN);
-      if (m !== null) {
-        urlEmitted = true;
-        mailbox.unsafeOffer({ _tag: "url", url: m[0] });
-      }
-    }
-  };
-
-  const rlOut = readline.createInterface({ input: child.stdout });
-  const rlErr = readline.createInterface({ input: child.stderr });
-  rlOut.on("line", handleLine);
-  rlErr.on("line", handleLine);
-
-  child.once("exit", (code, signal) => {
-    exited = true;
-    const ok = code === 0;
-    const reason = ok
-      ? undefined
-      : signal !== null
-        ? `cursor-agent login was terminated (${signal})`
-        : `cursor-agent login exited with code ${code ?? "?"}`;
-    mailbox.unsafeOffer({
-      _tag: "done",
-      ok,
-      ...(reason !== undefined ? { reason } : {}),
-    });
-    void mailbox.end.pipe(Effect.runPromise);
+    return Mailbox.toStream(mailbox);
   });
-
-  child.once("error", (err) => {
-    exited = true;
-    mailbox.unsafeOffer({
-      _tag: "done",
-      ok: false,
-      reason: err.message,
-    });
-    void mailbox.end.pipe(Effect.runPromise);
-  });
-
-  yield* Effect.addFinalizer(() =>
-    Effect.sync(() => {
-      rlOut.close();
-      rlErr.close();
-      if (exited) return;
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        /* ignore */
-      }
-      setTimeout(() => {
-        if (!exited) {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            /* ignore */
-          }
-        }
-      }, 1_000);
-    }),
-  );
-
-  return Mailbox.toStream(mailbox);
-});

--- a/apps/server/test/claude-auth-detection.test.ts
+++ b/apps/server/test/claude-auth-detection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  claudeResultErrorText,
+  looksLikeClaudeAuthFailure,
+} from "../src/provider/drivers/claude.ts";
+
+// Regression coverage for the "stuck on a dead 'Not logged in' message"
+// report: an unauthenticated `claude` reports auth failures as plain output,
+// which we must recognise so the renderer can paint the sign-in card.
+describe("looksLikeClaudeAuthFailure", () => {
+  it("matches the CLI's not-logged-in output", () => {
+    expect(looksLikeClaudeAuthFailure("Not logged in · Please run /login")).toBe(
+      true,
+    );
+    expect(
+      looksLikeClaudeAuthFailure(
+        "Please run /login · API Error: 401 Invalid authentication credentials",
+      ),
+    ).toBe(true);
+    expect(looksLikeClaudeAuthFailure("Invalid API key · Fix external")).toBe(
+      true,
+    );
+  });
+
+  it("does not match ordinary assistant prose", () => {
+    expect(
+      looksLikeClaudeAuthFailure("I updated the login form component."),
+    ).toBe(false);
+    expect(looksLikeClaudeAuthFailure("All tests pass.")).toBe(false);
+  });
+});
+
+describe("claudeResultErrorText", () => {
+  it("returns null for a clean success result", () => {
+    expect(
+      claudeResultErrorText({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "done",
+      } as never),
+    ).toBeNull();
+  });
+
+  it("extracts the 401 from a success-shaped error result", () => {
+    const text = claudeResultErrorText({
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      result: "Please run /login",
+      api_error_status: 401,
+    } as never);
+    expect(text).not.toBeNull();
+    expect(text).toContain("Please run /login");
+    expect(text).toContain("401");
+  });
+
+  it("joins the errors[] of an error-subtype result", () => {
+    const text = claudeResultErrorText({
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      errors: ["Not logged in", "Please run /login"],
+    } as never);
+    expect(text).toBe("Not logged in\nPlease run /login");
+  });
+});


### PR DESCRIPTION
When the Claude CLI runs unauthenticated it reports "Not logged in · Please run /login" (or a 401) as ordinary output, so the driver dropped the signal and the session stuck on the loading spinner, retried forever, and eventually surfaced an unrelated Cloudflare 522. This PR detects that auth signature in the driver and re-emits it as a structured error, which the renderer turns into a compact "Authentication required" card with a **Sign in to Claude** button that runs the real `claude auth login` OAuth flow, validates automatically, and resumes the pending message. The card resolves (hides) once the provider reports authenticated, so it never sticks on "Resuming…" or duplicates after sign-in, and a send on an errored session now tears down the stale provider process so it re-spawns with the freshly-written credentials. The one-click login spawn is generalized (shared `useProviderLogin` hook, reused by the provider settings card), and `worktree-setup-card` now shows a failed rather than perpetually-spinning provider step on error. Adds `claude-auth-detection.test.ts`; typecheck and the full test suite pass.