### PR TITLE
Add goal mode support for the Grok provider

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -275,11 +275,19 @@ export function ChatComposer({
 
   const [hasText, setHasText] = useState(false);
   const [goalSendMode, setGoalSendMode] = useState(false);
-  // Version-gated Codex features the installed CLI supports (from the
-  // availability probe). Drives whether goal/fast controls render at all.
-  const codexCapabilities = useProvidersStore((s) =>
+  // Provider features the installed CLI supports (from the availability
+  // probe). Drives whether goal/fast controls render at all. Codex resolves
+  // these from its CLI version; Grok advertises `goalMode` unconditionally.
+  const capabilities = useProvidersStore((s) =>
     s.capabilitiesFor(session.providerId),
   );
+  // Goal mode is supported by Codex (native `thread/goal/*`, version-gated via
+  // the `goalMode` capability) and Grok (native `/goal`, forwarded by the
+  // driver). Grok has no version floor, so it's always goal-capable and
+  // doesn't depend on the availability probe.
+  const goalCapable =
+    session.providerId === "grok" ||
+    (session.providerId === "codex" && capabilities.includes("goalMode"));
   const [trigger, setTrigger] = useState<ActiveTrigger | null>(null);
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -747,7 +755,7 @@ export function ChatComposer({
           <Frame>
             {!isDraft ? (
               <div className="mb-1 overflow-hidden rounded-md border border-border/50 bg-muted/30 empty:hidden empty:mb-0">
-                {session.providerId === "codex" && goal !== null ? (
+                {goalCapable && goal !== null ? (
                   <GoalBanner
                     goal={goal}
                     inPlanMode={inPlanMode}
@@ -894,11 +902,10 @@ export function ChatComposer({
                   // `fastMode` descriptor and isn't version-gated, so only
                   // filter when the provider gates it.
                   (session.providerId !== "codex" ||
-                    codexCapabilities.includes("fastMode")) && (
+                    capabilities.includes("fastMode")) && (
                     <FastModeToggle sessionId={sessionId} />
                   )}
-                {session.providerId === "codex" &&
-                codexCapabilities.includes("goalMode") ? (
+                {goalCapable ? (
                   <GoalModeToggle
                     active={goalSendMode}
                     hasGoal={goal !== null}

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -80,13 +80,16 @@ export function ChatLanding() {
   const addFolder = useWorkspaceStore((s) => s.add);
 
   const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
-  // Goal mode is only offered when the installed Codex CLI is new enough
-  // (version-gated capability from the availability probe).
-  const codexCapabilities = useProvidersStore((s) =>
-    s.capabilitiesFor("codex"),
+  // Goal mode is offered for Codex (version-gated `goalMode` capability) and
+  // Grok (native `/goal`, advertised unconditionally) — both surface the
+  // capability via the availability probe.
+  const defaultProviderCapabilities = useProvidersStore((s) =>
+    s.capabilitiesFor(defaultProviderId),
   );
-  const codexGoalSupported =
-    defaultProviderId === "codex" && codexCapabilities.includes("goalMode");
+  const goalSupported =
+    defaultProviderId === "grok" ||
+    (defaultProviderId === "codex" &&
+      defaultProviderCapabilities.includes("goalMode"));
   const defaultModelByProvider = useSettingsStore(
     (s) => s.defaultModelByProvider,
   );
@@ -208,7 +211,7 @@ export function ChatLanding() {
     }
     const sessionId = result.initialSessionId;
     migrateModelOptions(DRAFT_SESSION_ID, sessionId);
-    if (opts.asGoal && codexGoalSupported) {
+    if (opts.asGoal && goalSupported) {
       void send(sessionId, input, { asGoal: true });
     } else {
       useMessagesStore.getState().queue(sessionId, input);

--- a/apps/renderer/src/composer/builtin-commands.ts
+++ b/apps/renderer/src/composer/builtin-commands.ts
@@ -70,9 +70,15 @@ const COMMANDS: readonly BuiltinCommand[] = [
   },
   {
     name: "goal",
-    description: "Send the next message as a Codex goal.",
+    description: "Send the next message as a goal.",
     kind: "client",
     appliesTo: "codex",
+  },
+  {
+    name: "goal",
+    description: "Send the next message as a goal.",
+    kind: "client",
+    appliesTo: "grok",
   },
   {
     name: "help",

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -493,7 +493,8 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
             }),
         ),
       );
-      if (lookupSessionProvider(sessionId) === "codex") {
+      const goalProvider = lookupSessionProvider(sessionId);
+      if (goalProvider === "codex" || goalProvider === "grok") {
         goalFiber = Effect.runFork(
           Stream.runForEach(
             (client as unknown as GoalRpcClient).session["goal.stream"]({
@@ -529,12 +530,17 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     // Optimistic — flip running to true before the server status arrives so
     // the composer's Send→Interrupt swap doesn't flash through "idle" while
     // the RPC round-trip happens.
+    // Codex goal sends don't run a turn immediately (Codex drives its own
+    // status via native goal notifications), so we skip the optimistic flip
+    // there. Grok runs goal mode by forwarding `/goal` as a real prompt turn,
+    // so it should show the running indicator like any normal send.
+    const skipOptimisticRunning =
+      opts?.asGoal === true && lookupSessionProvider(sessionId) === "codex";
     set((s) => ({
       errorBySession: { ...s.errorBySession, [sessionId]: null },
-      runningBySession:
-        opts?.asGoal === true
-          ? s.runningBySession
-          : { ...s.runningBySession, [sessionId]: true },
+      runningBySession: skipOptimisticRunning
+        ? s.runningBySession
+        : { ...s.runningBySession, [sessionId]: true },
     }));
     try {
       const client = await getMessagesRpcClient();

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -1197,11 +1197,16 @@ const probeOne = (
     }
 
     // Version-gated features the installed CLI supports (pre-session UI gate).
-    // Only Codex declares gated features today; others resolve to `[]`.
+    // Codex resolves its set from the CLI version; Grok ships a single
+    // curl-installed channel with no version floor, so we advertise its
+    // `goalMode` (native `/goal`, forwarded as a slash command by the driver)
+    // unconditionally. Other providers resolve to `[]`.
     const capabilities =
       probe.providerId === "codex"
         ? resolveCodexCapabilities(parsedVersion)
-        : [];
+        : probe.providerId === "grok"
+          ? ["goalMode"]
+          : [];
 
     // Informational "update available" layer — independent of the SDK floor.
     // Only providers with a registry package are checked; the rest report

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -6,12 +6,14 @@ import { Effect, Mailbox, Stream } from "effect";
 
 import {
   AgentSessionStartError,
+  ThreadGoal,
   type AgentEvent,
   type AgentItemId,
   type AgentSessionId,
   type AttachmentRef,
   type PermissionMode,
   type StartSessionInput,
+  type ThreadGoalSetInput,
   type UserQuestionAnswer,
 } from "@memoize/wire";
 
@@ -58,6 +60,17 @@ export interface GrokSessionHandle {
     itemId: AgentItemId,
     answers: ReadonlyArray<UserQuestionAnswer>,
   ) => Effect.Effect<void>;
+  /**
+   * Goal mode. Grok exposes `/goal` as a native slash command but ACP has no
+   * structured `thread/goal/*` round-trip (unlike Codex). So goal state is
+   * kept driver-local and the objective is forwarded to Grok's native `/goal`
+   * command as prompt text — the same emulation shape as plan mode
+   * (`applyPlanModePrefix`). `tokensUsed`/`timeUsedSeconds` are best-effort
+   * (Grok does not report them back over ACP).
+   */
+  readonly getGoal: () => Effect.Effect<ThreadGoal | null>;
+  readonly setGoal: (goal: ThreadGoalSetInput) => Effect.Effect<ThreadGoal>;
+  readonly clearGoal: () => Effect.Effect<void>;
 }
 
 
@@ -283,6 +296,10 @@ export const startGrokSession = (
     let acpSessionId: string | null = null;
     let nextRpcId = 1;
     let closed = false;
+    /** Driver-local goal state. Grok has no `thread/goal/*` ACP surface, so we
+     *  track the goal here and forward the objective via the native `/goal`
+     *  slash command. See the goal methods on the handle below. */
+    let currentGoal: ThreadGoal | null = null;
     /** True once the ACP child has exited (fatal auth, crash, or normal end).
      *  Further send() calls fail fast with a clear "session ended — start a new chat" message
      *  instead of queuing doomed RPCs that will 5-minute timeout.
@@ -856,6 +873,7 @@ export const startGrokSession = (
             model: input.model,
           });
           let keepRunningAfterIgnoredAuthNoise = false;
+          let turnWasCancelled = false;
           try {
             await request(
               "session/prompt",
@@ -886,6 +904,7 @@ export const startGrokSession = (
             }
             grokDiag("session/prompt failed", { reason });
             const isCancellation = /cancel|interrupt/i.test(reason);
+            if (isCancellation) turnWasCancelled = true;
             const isGrokAuthNoise = isIgnorableGrokAuthNoise(reason);
             if (isGrokAuthNoise) {
               keepRunningAfterIgnoredAuthNoise = true;
@@ -908,6 +927,26 @@ export const startGrokSession = (
               for (const ev of translator.flush()) events.unsafeOffer(ev);
               if (!keepRunningAfterIgnoredAuthNoise) {
                 events.unsafeOffer({ _tag: "Status", status: "idle" });
+                // A Grok goal runs as a single forwarded `/goal` turn that
+                // loops internally (plan → implement → verify → summarize)
+                // and self-terminates. Grok exposes no structured goal-status
+                // feed over ACP, so we infer the goal's end from the turn
+                // ending: a normal finish marks it "complete"; a user
+                // interrupt marks it "paused" (resumable) — either way the
+                // banner stops hanging on "Pursuing goal" forever.
+                if (currentGoal !== null && currentGoal.status === "active") {
+                  currentGoal = ThreadGoal.make({
+                    threadId: currentGoal.threadId,
+                    objective: currentGoal.objective,
+                    status: turnWasCancelled ? "paused" : "complete",
+                    tokenBudget: currentGoal.tokenBudget,
+                    tokensUsed: currentGoal.tokensUsed,
+                    timeUsedSeconds: currentGoal.timeUsedSeconds,
+                    createdAt: currentGoal.createdAt,
+                    updatedAt: Date.now(),
+                  });
+                  events.unsafeOffer({ _tag: "GoalUpdated", goal: currentGoal });
+                }
               }
             }
           }
@@ -975,6 +1014,50 @@ export const startGrokSession = (
           events.unsafeOffer({ _tag: "PermissionModeChanged", mode });
         }),
       answerQuestion: () => Effect.void,
+      getGoal: () => Effect.sync(() => currentGoal),
+      setGoal: (goalInput) =>
+        Effect.sync(() => {
+          const now = Date.now();
+          const objective = (
+            goalInput.objective ?? currentGoal?.objective ?? ""
+          ).trim();
+          const status = goalInput.status ?? currentGoal?.status ?? "active";
+          const wasActiveWithObjective =
+            currentGoal?.status === "active" &&
+            (currentGoal?.objective.trim() ?? "") === objective;
+          const goal = ThreadGoal.make({
+            threadId: acpSessionId ?? "",
+            objective,
+            status,
+            tokenBudget:
+              goalInput.tokenBudget !== undefined
+                ? goalInput.tokenBudget
+                : (currentGoal?.tokenBudget ?? null),
+            // Grok doesn't report goal accounting back over ACP — best-effort 0.
+            tokensUsed: currentGoal?.tokensUsed ?? 0,
+            timeUsedSeconds: currentGoal?.timeUsedSeconds ?? 0,
+            createdAt: currentGoal?.createdAt ?? now,
+            updatedAt: now,
+          });
+          currentGoal = goal;
+          // Only fire the native `/goal` command when a goal newly becomes
+          // active with an objective — status-only changes (pause/resume) just
+          // update local state so we don't re-launch Grok's run.
+          if (
+            status === "active" &&
+            objective.length > 0 &&
+            !wasActiveWithObjective
+          ) {
+            enqueuePrompt(`/goal ${objective}`);
+          }
+          events.unsafeOffer({ _tag: "GoalUpdated", goal });
+          return goal;
+        }),
+      clearGoal: () =>
+        Effect.sync(() => {
+          currentGoal = null;
+          events.unsafeOffer({ _tag: "GoalCleared" });
+        }),
     };
     return handle;
   });

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -2387,12 +2387,17 @@ export const MessageStoreLive = Layer.scoped(
         }),
       );
 
-    const ensureCodexGoalSession = (
+    // Providers that support goal mode. Codex backs it with `thread/goal/*`
+    // RPCs; Grok forwards to its native `/goal` slash command with
+    // driver-local state. Both go through `setGoalWithLiveProvider` →
+    // `provider.setGoal`, which routes to the right handle.
+    const goalCapableProviders = new Set<ProviderId>(["codex", "grok"]);
+    const ensureGoalSession = (
       sessionId: SessionId,
     ): Effect.Effect<Session, SessionNotFoundError | GoalUnsupportedError> =>
       Effect.gen(function* () {
         const session = yield* lookupSession(sessionId);
-        if (session.providerId !== "codex") {
+        if (!goalCapableProviders.has(session.providerId)) {
           return yield* Effect.fail(
             new GoalUnsupportedError({ providerId: session.providerId }),
           );
@@ -2495,7 +2500,7 @@ export const MessageStoreLive = Layer.scoped(
 
     const getGoal: MessageStoreShape["getGoal"] = (sessionId) =>
       Effect.gen(function* () {
-        yield* ensureCodexGoalSession(sessionId);
+        yield* ensureGoalSession(sessionId);
         const goal = yield* provider
           .getGoal(sessionId)
           .pipe(
@@ -2510,7 +2515,7 @@ export const MessageStoreLive = Layer.scoped(
 
     const setGoal: MessageStoreShape["setGoal"] = (sessionId, goalInput) =>
       Effect.gen(function* () {
-        const session = yield* ensureCodexGoalSession(sessionId);
+        const session = yield* ensureGoalSession(sessionId);
         const goal = yield* setGoalWithLiveProvider(session, goalInput);
         yield* publishGoal(sessionId, goal);
         return goal;
@@ -2518,7 +2523,7 @@ export const MessageStoreLive = Layer.scoped(
 
     const clearGoal: MessageStoreShape["clearGoal"] = (sessionId) =>
       Effect.gen(function* () {
-        yield* ensureCodexGoalSession(sessionId);
+        yield* ensureGoalSession(sessionId);
         yield* provider
           .clearGoal(sessionId)
           .pipe(
@@ -2533,7 +2538,7 @@ export const MessageStoreLive = Layer.scoped(
     const streamGoal: MessageStoreShape["streamGoal"] = (sessionId) =>
       Stream.unwrapScoped(
         Effect.gen(function* () {
-          yield* ensureCodexGoalSession(sessionId);
+          yield* ensureGoalSession(sessionId);
           const pubsub = yield* getOrMakeGoalPubsub(sessionId);
           const dequeue = yield* pubsub.subscribe;
           const cached = goalsBySession.get(sessionId);
@@ -2687,7 +2692,7 @@ export const MessageStoreLive = Layer.scoped(
     ): Effect.Effect<boolean, SessionNotFoundError> =>
       Effect.gen(function* () {
         const session = yield* lookupSession(sessionId);
-        if (asGoal !== true && session.providerId === "codex") {
+        if (asGoal !== true && goalCapableProviders.has(session.providerId)) {
           const goal = goalsBySession.get(sessionId);
           const trimmed = text.trim();
           if (
@@ -2775,11 +2780,11 @@ export const MessageStoreLive = Layer.scoped(
         if (asGoal === true) {
           const objective = text.trim();
           if (objective.length === 0) return false;
-          if (session.providerId !== "codex") {
+          if (!goalCapableProviders.has(session.providerId)) {
             const persistedError = yield* persistMessage(sessionId, {
               _tag: "error",
               message:
-                "Goal mode is currently only supported for Codex sessions.",
+                "Goal mode is currently only supported for Codex and Grok sessions.",
             });
             yield* broadcastMessage(sessionId, persistedError);
             yield* ndjsonAppend(sessionId, persistedError);
@@ -2793,8 +2798,8 @@ export const MessageStoreLive = Layer.scoped(
               Effect.gen(function* () {
                 const message =
                   err._tag === "SessionStartError"
-                    ? `Goal mode could not start Codex: ${err.reason}`
-                    : "Goal mode could not start Codex for this session.";
+                    ? `Goal mode could not start ${session.providerId}: ${err.reason}`
+                    : `Goal mode could not start ${session.providerId} for this session.`;
                 const persistedError = yield* persistMessage(sessionId, {
                   _tag: "error",
                   message,
@@ -2808,6 +2813,13 @@ export const MessageStoreLive = Layer.scoped(
           );
           if (goal === null) return false;
           yield* publishGoal(sessionId, goal);
+          // Grok runs goal mode by forwarding `/goal` as a real prompt turn,
+          // so reflect the running turn the way a normal send does — the
+          // driver emits `Status: idle` when the goal run finishes. Codex
+          // drives its own status via native goal notifications, so leave it.
+          if (session.providerId === "grok") {
+            yield* setStatus(sessionId, "running");
+          }
           return true;
         }
         // First attempt: push into the existing provider session. If that

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -64,6 +64,13 @@ type SessionHandle =
   | GeminiSessionHandle
   | CursorSessionHandle
   | OpencodeSessionHandle;
+
+/**
+ * Handles that expose goal mode. Codex backs it with `thread/goal/*` RPCs;
+ * Grok forwards to its native `/goal` slash command with driver-local state.
+ * Both share the same method shape so the goal routes treat them uniformly.
+ */
+type GoalCapableHandle = CodexSessionHandle | GrokSessionHandle;
 type SessionEntry = {
   readonly providerId: ProviderId;
   readonly handle: SessionHandle;
@@ -416,20 +423,20 @@ export const ProviderServiceLive = Layer.effect(
         ),
       getGoal: (sessionId) =>
         Effect.flatMap(lookup(sessionId), ({ providerId, handle }) =>
-          providerId === "codex"
-            ? (handle as CodexSessionHandle).getGoal()
+          providerId === "codex" || providerId === "grok"
+            ? (handle as GoalCapableHandle).getGoal()
             : Effect.fail(new AgentSessionNotFoundError({ sessionId })),
         ),
       setGoal: (sessionId, goal: ThreadGoalSetInput) =>
         Effect.flatMap(lookup(sessionId), ({ providerId, handle }) =>
-          providerId === "codex"
-            ? (handle as CodexSessionHandle).setGoal(goal)
+          providerId === "codex" || providerId === "grok"
+            ? (handle as GoalCapableHandle).setGoal(goal)
             : Effect.fail(new AgentSessionNotFoundError({ sessionId })),
         ),
       clearGoal: (sessionId) =>
         Effect.flatMap(lookup(sessionId), ({ providerId, handle }) =>
-          providerId === "codex"
-            ? (handle as CodexSessionHandle).clearGoal()
+          providerId === "codex" || providerId === "grok"
+            ? (handle as GoalCapableHandle).clearGoal()
             : Effect.fail(new AgentSessionNotFoundError({ sessionId })),
         ),
     };


### PR DESCRIPTION
Extends the existing (Codex-only) goal mode to the Grok provider so `/goal` and the goal toggle/banner work for Grok sessions. Because Grok speaks ACP and exposes no structured `thread/goal/*` surface, the driver mirrors the goal wiring with driver-local state: `setGoal` forwards the objective to Grok's native `/goal` slash command, emits `GoalUpdated`, and infers the goal's end from the turn boundary (`complete` on normal finish, `paused` on user interrupt). Server-side, the `goalMode` capability is advertised for Grok and the goal RPCs + `asGoal` send path now route to grok alongside codex; the running status is set for the forwarded goal turn so the loading indicator behaves like a normal send. Renderer-side, the composer goal toggle/banner and the `goal.stream` subscription are un-gated for Grok (always-on, since Grok has no version floor). Codex's goal behavior is unchanged.