### PR TITLE
Auto-scroll on send and cap tool box height

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -100,6 +100,15 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   };
 
   useLayoutEffect(() => {
+    // A message the user just sent always re-engages auto-scroll, even if
+    // they had scrolled up to read older context.
+    const last = messages[messages.length - 1];
+    if (
+      last?.content._tag === "user" ||
+      last?.content._tag === "user_rich"
+    ) {
+      stickToBottomRef.current = true;
+    }
     if (!stickToBottomRef.current) return;
     const el = scrollRef.current;
     if (el === null) return;

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -471,7 +471,7 @@ function ExpandableIconRow({
         ) : null}
       </button>
       {expanded && hasContent ? (
-        <div className="ml-6 mt-1 max-w-2xl space-y-2 overflow-hidden border-l border-border/60 pl-2 pr-1">
+        <div className="ml-6 mt-1 max-h-96 max-w-2xl space-y-2 overflow-y-auto border-l border-border/60 pl-2 pr-1">
           {body}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- Re-engage auto-scroll-to-bottom whenever the user sends a new message, even if they had scrolled up to read older context. Streaming replies still respect the user's scroll position.
- Cap the expanded tool box body at a max height (`max-h-96`) with internal vertical scroll instead of growing unbounded.

## Changes
- `apps/renderer/src/components/chat-view.tsx`: force stick-to-bottom when the newest message is a `user`/`user_rich` message.
- `apps/renderer/src/components/tool-row.tsx`: `overflow-hidden` → `max-h-96 ... overflow-y-auto` on the expanded tool body.