### PR TITLE
Render inline chat Edit diffs with @pierre/diffs library

### DIFF
--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -2,7 +2,6 @@ import { PatchDiff } from "@pierre/diffs/react";
 import { createPatch, structuredPatch } from "diff";
 import { useMemo } from "react";
 
-import { cn } from "~/lib/utils";
 import { FileIcon } from "./file-icon.tsx";
 
 const UNIFIED_DIFF_OPTIONS = { diffStyle: "unified" } as const;
@@ -74,13 +73,6 @@ export const extractEdits = (
 
   return [];
 };
-
-interface DiffLine {
-  readonly kind: "context" | "add" | "del" | "hunk";
-  readonly text: string;
-  readonly oldLine: number | null;
-  readonly newLine: number | null;
-}
 
 /**
  * Total +/- line counts across a set of edits, without rendering the diff.
@@ -167,160 +159,13 @@ export const patchStats = (
   return { added, removed };
 };
 
-const buildDiff = (edit: FileEdit): ReadonlyArray<DiffLine> => {
-  const patch = structuredPatch(
-    edit.path,
-    edit.path,
-    edit.oldText,
-    edit.newText,
-    "",
-    "",
-    { context: 3 },
-  );
-  const lines: DiffLine[] = [];
-  for (const hunk of patch.hunks) {
-    lines.push({
-      kind: "hunk",
-      text: `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`,
-      oldLine: null,
-      newLine: null,
-    });
-    let oldLn = hunk.oldStart;
-    let newLn = hunk.newStart;
-    for (const raw of hunk.lines) {
-      const marker = raw.charAt(0);
-      const text = raw.slice(1);
-      if (marker === "+") {
-        lines.push({ kind: "add", text, oldLine: null, newLine: newLn });
-        newLn += 1;
-      } else if (marker === "-") {
-        lines.push({ kind: "del", text, oldLine: oldLn, newLine: null });
-        oldLn += 1;
-      } else {
-        lines.push({ kind: "context", text, oldLine: oldLn, newLine: newLn });
-        oldLn += 1;
-        newLn += 1;
-      }
-    }
-  }
-  return lines;
-};
-
 /**
- * Render a `FileEdit` as a unified diff using `@pierre/diffs` — gets us
- * line numbers, hunk separators, syntax-aware tinting, and a polished
- * scrolling layout for free. We feed it a unified-diff text string built
- * from the Edit/Write/MultiEdit tool input.
+ * Build a unified-diff text string from a `FileEdit`, suitable for feeding to
+ * `@pierre/diffs` `PatchDiff`. For a `create` with empty old text we still pass
+ * `""` as the old file so the line numbers + additions render.
  */
-export function DiffBody({
-  edit,
-  showHeader,
-}: {
-  edit: FileEdit;
-  showHeader: boolean;
-}) {
-  const patchText = useMemo(() => {
-    if (edit.mode === "create" && edit.oldText === "") {
-      // `createPatch("", file, "", text)` produces an empty header diff —
-      // fake an old-file/new-file pair so the line numbers + adds appear.
-      return createPatch(edit.path, "", edit.newText, "", "") ?? "";
-    }
-    return createPatch(edit.path, edit.oldText, edit.newText, "", "") ?? "";
-  }, [edit]);
-  if (patchText.trim().length === 0 || edit.oldText === edit.newText) {
-    return (
-      <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
-        (no textual change)
-      </div>
-    );
-  }
-  return (
-    <div className="fz-diff overflow-x-auto text-[11px]">
-      {showHeader ? (
-        <div className="border-b border-border/40 bg-muted/40 px-2 py-1 font-mono text-muted-foreground">
-          {edit.mode === "create" ? "create" : "edit"} · {edit.path}
-        </div>
-      ) : null}
-      <PatchDiff
-        patch={patchText}
-        options={UNIFIED_DIFF_OPTIONS}
-        disableWorkerPool
-      />
-    </div>
-  );
-}
-
-/**
- * Fallback renderer kept for any caller that wants the bare row-by-row
- * markup without the @pierre/diffs runtime (e.g. unit tests / minimal
- * snapshots). Currently unused at runtime but exported so future surfaces
- * can opt in.
- */
-export function DiffBodyPlain({
-  edit,
-  showHeader,
-}: {
-  edit: FileEdit;
-  showHeader: boolean;
-}) {
-  const lines = useMemo(() => buildDiff(edit), [edit]);
-  if (lines.length === 0) {
-    return (
-      <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
-        (no textual change)
-      </div>
-    );
-  }
-  return (
-    <div className="overflow-x-auto font-mono text-[11px]">
-      {showHeader ? (
-        <div className="bg-zinc-900/40 px-2 py-1 text-muted-foreground">
-          {edit.mode === "create" ? "create" : "edit"} · {edit.path}
-        </div>
-      ) : null}
-      {lines.map((line, idx) => (
-        <DiffRow key={idx} line={line} />
-      ))}
-    </div>
-  );
-}
-
-function DiffRow({ line }: { line: DiffLine }) {
-  if (line.kind === "hunk") {
-    return (
-      <div className="bg-sky-500/10 px-2 py-0.5 text-sky-200">{line.text}</div>
-    );
-  }
-  const bg =
-    line.kind === "add"
-      ? "bg-emerald-500/10"
-      : line.kind === "del"
-        ? "bg-red-500/10"
-        : "";
-  const marker = line.kind === "add" ? "+" : line.kind === "del" ? "-" : " ";
-  const markerColor =
-    line.kind === "add"
-      ? "text-emerald-400"
-      : line.kind === "del"
-        ? "text-red-400"
-        : "text-muted-foreground";
-  return (
-    <div className={`flex gap-2 px-2 ${bg}`}>
-      <span className="w-8 shrink-0 select-none text-right text-muted-foreground">
-        {line.oldLine ?? ""}
-      </span>
-      <span className="w-8 shrink-0 select-none text-right text-muted-foreground">
-        {line.newLine ?? ""}
-      </span>
-      <span className={`w-3 shrink-0 select-none ${markerColor}`}>
-        {marker}
-      </span>
-      <span className="whitespace-pre-wrap break-words">
-        {line.text === "" ? " " : line.text}
-      </span>
-    </div>
-  );
-}
+const editToPatch = (edit: FileEdit): string =>
+  createPatch(edit.path, edit.oldText, edit.newText, "", "") ?? "";
 
 // ---------------------------------------------------------------------------
 // Polished vertical diff used for Edit/Write/MultiEdit tool results in the
@@ -399,6 +244,15 @@ export function UnifiedPatchDiff({
   );
 }
 
+/**
+ * Render a `FileEdit` (an `Edit` / `Write` / `MultiEdit` tool input) as a
+ * unified diff through `@pierre/diffs` `PatchDiff` — the same library the
+ * file-editor diff tab and `UnifiedPatchDiff` use — so the inline chat diff
+ * inherits the app's themed lime-add / rose-delete colors, syntax tinting, and
+ * proper gutters (via the `.fz-diff` overrides in styles.css) instead of the
+ * old hand-rolled rows. Wrapped in a bordered card with a filename + `+N`/`-N`
+ * stats header and an internal scroll cap.
+ */
 export function EditDiff({
   edit,
   showHeader = false,
@@ -406,8 +260,8 @@ export function EditDiff({
   edit: FileEdit;
   showHeader?: boolean;
 }) {
-  const lines = useMemo(() => buildDiff(edit), [edit]);
-  if (lines.length === 0) {
+  const patchText = useMemo(() => editToPatch(edit), [edit]);
+  if (patchText.trim().length === 0 || edit.oldText === edit.newText) {
     return (
       <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
         (no textual change)
@@ -440,60 +294,15 @@ export function EditDiff({
       ) : null}
 
       <div
-        className="code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
+        className="fz-diff code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
         style={{ maxHeight: 420 }}
       >
-        {lines.map((line, idx) => (
-          <EditDiffRow key={idx} line={line} />
-        ))}
+        <PatchDiff
+          patch={patchText}
+          options={UNIFIED_DIFF_OPTIONS}
+          disableWorkerPool
+        />
       </div>
-    </div>
-  );
-}
-
-function EditDiffRow({ line }: { line: DiffLine }) {
-  if (line.kind === "hunk") {
-    return (
-      <div className="bg-sky-500/10 px-2 py-0.5 text-[10px] text-sky-300/80 font-mono tabular-nums">
-        {line.text}
-      </div>
-    );
-  }
-
-  const isAdd = line.kind === "add";
-  const isDel = line.kind === "del";
-
-  const bg = isAdd ? "bg-emerald-500/10" : isDel ? "bg-red-500/10" : "";
-  const bar = isAdd
-    ? "bg-emerald-400"
-    : isDel
-      ? "bg-red-400"
-      : "bg-transparent";
-  const marker = isAdd ? "+" : isDel ? "-" : " ";
-  const markerColor = isAdd
-    ? "text-emerald-400"
-    : isDel
-      ? "text-red-400"
-      : "text-muted-foreground/70";
-
-  // Two-column gutter (old | new) to match classic unified diff feel while
-  // staying compact. Widths chosen to align with the 2em tightened shiki
-  // line-number gutter used by CodeBlock.
-  return (
-    <div className={`flex items-start gap-0 ${bg}`}>
-      <div className={`w-0.5 shrink-0 self-stretch ${bar}`} />
-      <span className="w-7 shrink-0 select-none text-right pr-1 text-muted-foreground/60 tabular-nums">
-        {line.oldLine ?? ""}
-      </span>
-      <span className="w-7 shrink-0 select-none text-right pr-1 text-muted-foreground/60 tabular-nums">
-        {line.newLine ?? ""}
-      </span>
-      <span className={`w-3 shrink-0 select-none text-center ${markerColor}`}>
-        {marker}
-      </span>
-      <span className="flex-1 whitespace-pre font-mono text-foreground/90">
-        {line.text === "" ? " " : line.text}
-      </span>
     </div>
   );
 }


### PR DESCRIPTION
## What

Inline `Edit` / `Write` / `MultiEdit` tool diffs in the **chat timeline** were rendered by a hand-rolled component (`buildDiff` + `EditDiffRow`): two line-number gutters, a `+/-` marker column, a raw `@@ -1,1 +1,1 @@` row, stray `No newline at end of file` context lines, and raw `emerald`/`red` washes that read as a separate widget.

Everywhere else — the file-editor diff tab and the Codex/Grok `UnifiedPatchDiff` path — already renders through the `@pierre/diffs` `PatchDiff` library wrapped in `.fz-diff` (app-themed lime-add / rose-delete, syntax tinting, proper gutters). The Claude edit path was the only one not using it.

## Changes

`apps/renderer/src/components/inline-diff.tsx`:
- **`EditDiff`** now builds a unified-diff string with `createPatch` and renders it through `<PatchDiff>` inside a `.fz-diff` wrapper, so the inline chat diff inherits the app's themed colors, syntax tinting, and clean gutters. The bordered card chrome (filename + `+N`/`-N` stats header, `maxHeight: 420` scroll cap) is preserved.
- Removed the now-dead hand-rolled machinery: `EditDiffRow`, `buildDiff`, the `DiffLine` interface, and the unused `DiffBody` / `DiffBodyPlain` / `DiffRow` renderers. Added a small `editToPatch` helper.
- Dropped a stale unused `cn` import.

No change needed in `tool-row.tsx` — it already calls `<EditDiff>` for the Claude edit path; only the internals changed.

## Verify

- `pnpm -C apps/renderer check-types` passes clean.
- No tests referenced the removed symbols.
- Manual: trigger an `Edit` / `Write` in a chat session and expand the tool row — the diff now matches the file-editor diff tab (themed lime/rose, syntax tinting, single clean gutter, no stray `@@` / `No newline` artifact rows).