### PR TITLE
Move plan Approve/Cancel into a pinned bar above the composer

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -83,6 +83,7 @@ import { parseComposerInput } from "../composer/segment-parser.ts";
 import { AnnotationTray } from "./composer/annotation-tray.tsx";
 import { ComposerChipOverlay } from "./composer/composer-chip-overlay.tsx";
 import { FileTagPopover } from "./composer/file-tag-popover.tsx";
+import { PlanApprovalTray } from "./composer/plan-approval-tray.tsx";
 import { ProjectPlanTray } from "./composer/project-plan-tray.tsx";
 import { QueueTray } from "./composer/queue-tray.tsx";
 import { TrayPill, trayPillActionClass } from "./composer/tray-pill.tsx";
@@ -755,6 +756,7 @@ export function ChatComposer({
           <Frame>
             {!isDraft ? (
               <div className="mb-1 overflow-hidden rounded-md border border-border/50 bg-muted/30 empty:hidden empty:mb-0">
+                <PlanApprovalTray sessionId={sessionId} />
                 {goalCapable && goal !== null ? (
                   <GoalBanner
                     goal={goal}

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -18,6 +18,7 @@ import type {
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { useMessagesStore } from "../store/messages.ts";
+import { usePermissionsStore } from "../store/permissions.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSkillsStore } from "../store/skills.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
@@ -48,6 +49,18 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   const inFlight = useMessagesStore(
     (s) => s.runningBySession[sessionId] === true,
   );
+  // While a plan sits awaiting approval the turn is technically still "running",
+  // but the agent is blocked on the user — show no spinner, since we're the ones
+  // waiting. The Approve/Cancel decision lives in the pinned PlanApprovalTray.
+  const awaitingPlanApproval = usePermissionsStore((s) => {
+    for (const req of Object.values(s.requestsById)) {
+      if (req.sessionId !== sessionId) continue;
+      if (req.kind._tag !== "Other") continue;
+      if (req.kind.tool !== "ExitPlanMode") continue;
+      return true;
+    }
+    return false;
+  });
   const error = useMessagesStore((s) => s.errorBySession[sessionId] ?? null);
   const clearError = useMessagesStore((s) => s.clearError);
   const hydrate = useMessagesStore((s) => s.hydrate);
@@ -321,7 +334,9 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
               </Fragment>
             );
           })}
-          {inFlight && <WorkingRow messages={messages} />}
+          {inFlight && !awaitingPlanApproval && (
+            <WorkingRow messages={messages} />
+          )}
         </div>
       )}
       {error !== null && (

--- a/apps/renderer/src/components/composer/plan-approval-tray.tsx
+++ b/apps/renderer/src/components/composer/plan-approval-tray.tsx
@@ -1,0 +1,61 @@
+import { CheckListIcon } from "@hugeicons-pro/core-bulk-rounded";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import type { SessionId } from "@memoize/wire";
+
+import { usePermissionsStore } from "../../store/permissions.ts";
+import { TrayPill } from "./tray-pill.tsx";
+
+/**
+ * Pinned "Review plan" bar docked above the composer. The proposed plan still
+ * renders inline in the chat scrollback (see `ExitPlanModeRow`); this tray only
+ * hoists the Approve / Cancel decision down to where the user's cursor already
+ * sits, so they don't have to scroll back up to act. Renders nothing unless an
+ * `ExitPlanMode` permission request is open for this session.
+ */
+export function PlanApprovalTray({ sessionId }: { sessionId: SessionId }) {
+  const pendingRequest = usePermissionsStore((s) => {
+    for (const req of Object.values(s.requestsById)) {
+      if (req.sessionId !== sessionId) continue;
+      if (req.kind._tag !== "Other") continue;
+      if (req.kind.tool !== "ExitPlanMode") continue;
+      return req;
+    }
+    return null;
+  });
+  const decide = usePermissionsStore((s) => s.decide);
+
+  if (pendingRequest === null) return null;
+
+  return (
+    <TrayPill
+      flush
+      className="bg-rose-500/10 hover:bg-rose-500/15"
+      icon={
+        <HugeiconsIcon icon={CheckListIcon} strokeWidth={2} className="size-3.5" />
+      }
+      title="Review plan"
+      subtitle="Approve to start building"
+      actions={
+        <>
+          <button
+            type="button"
+            onClick={() => void decide(pendingRequest.id, { _tag: "Deny" })}
+            className="rounded-md px-2.5 py-0.5 text-[12px] text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              void decide(pendingRequest.id, { _tag: "AllowOnce" })
+            }
+            className="rounded-md bg-foreground px-2.5 py-0.5 text-[12px] font-medium text-background hover:opacity-90"
+          >
+            Approve
+          </button>
+        </>
+      }
+    />
+  );
+}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -134,7 +134,6 @@ export function MessageRow({
           <ExitPlanModeRow
             input={message.content.input}
             result={resultsByItemId.get(message.content.itemId)}
-            sessionId={sessionId}
           />
         );
       }

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -20,15 +20,10 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
 
-import type {
-  SessionId,
-  UserQuestion,
-  UserQuestionAnswer,
-} from "@memoize/wire";
+import type { UserQuestion, UserQuestionAnswer } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 
-import { usePermissionsStore } from "../store/permissions.ts";
 import { CodeBlock } from "./code-block.tsx";
 import { FileBadge } from "./file-badge.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
@@ -1180,11 +1175,9 @@ const buildToolView = (
 export function ExitPlanModeRow({
   input,
   result,
-  sessionId,
 }: {
   input: unknown;
   result?: ToolResult;
-  sessionId?: SessionId;
 }) {
   const plan =
     typeof input === "object" && input !== null && "plan" in input
@@ -1200,25 +1193,12 @@ export function ExitPlanModeRow({
         ? "cancelled"
         : "approved";
 
-  // Find the open permission request for this session's ExitPlanMode.
-  // There should be at most one in-flight at a time.
-  const pendingRequest = usePermissionsStore((s) => {
-    if (sessionId === undefined) return null;
-    for (const req of Object.values(s.requestsById)) {
-      if (req.sessionId !== sessionId) continue;
-      if (req.kind._tag !== "Other") continue;
-      if (req.kind.tool !== "ExitPlanMode") continue;
-      return req;
-    }
-    return null;
-  });
-  const decide = usePermissionsStore((s) => s.decide);
-
-  // Pending plans need the Approve / Reject buttons visible inline so the
-  // user can act without an extra click — keep the full card layout.
-  // Resolved plans (approved / rejected) collapse into the same icon-row
-  // accordion the rest of the timeline uses, with the plan body behind the
-  // chevron and the status pill pinned to the body footer.
+  // Pending plans render the full body inline; the Approve / Cancel decision
+  // lives in the pinned `PlanApprovalTray` above the composer, where the user's
+  // cursor already sits — see composer/plan-approval-tray.tsx. Resolved plans
+  // (approved / rejected) collapse into the same icon-row accordion the rest of
+  // the timeline uses, with the plan body behind the chevron and the status pill
+  // pinned to the body footer.
   if (status === "pending") {
     return (
       <div className="px-4 py-2">
@@ -1233,26 +1213,6 @@ export function ExitPlanModeRow({
         ) : (
           <MarkdownBody>{plan}</MarkdownBody>
         )}
-        {pendingRequest !== null ? (
-          <div className="mt-4 flex items-center justify-end gap-2">
-            <button
-              type="button"
-              onClick={() => void decide(pendingRequest.id, { _tag: "Deny" })}
-              className="rounded-md px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() =>
-                void decide(pendingRequest.id, { _tag: "AllowOnce" })
-              }
-              className="rounded-md bg-foreground px-3 py-1 text-xs font-medium text-background hover:opacity-90"
-            >
-              Approve
-            </button>
-          </div>
-        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
## What

The proposed plan still renders inline in the chat scrollback, but its **Approve / Cancel** decision now lives in a compact, pinned bar above the composer — in the same tray stack as the queue and goal banners. Easier UX: the buttons sit where the cursor already is, instead of forcing a scroll back up to the plan card.

## Changes

- **New `composer/plan-approval-tray.tsx`** — `PlanApprovalTray` finds the open `ExitPlanMode` permission request for the session, returns `null` when none, and renders a flush `TrayPill` ("Review plan" / "Approve to start building") with **Cancel** (`Deny`) and **Approve** (`AllowOnce`) buttons. Rose-tinted surface ties it to plan mode.
- **`tool-row.tsx`** — `ExitPlanModeRow` pending branch keeps the plan header + markdown body but drops the inline buttons; removed the now-dead `pendingRequest`/`decide`/`sessionId` plumbing and unused imports.
- **`message-row.tsx`** — dropped the removed `sessionId` prop on the `ExitPlanModeRow` call.
- **`chat-composer.tsx`** — mounted `<PlanApprovalTray />` as the first item in the above-composer tray stack (above goal/plan/queue), inside the existing `!isDraft` guard. The container's `empty:hidden` keeps it invisible when nothing is pending.

## Verification

- `bun run check-types` ✅ and `bun run lint` ✅ clean.
- Manual desktop flow (Plan mode → agent proposes plan → bar appears → Approve/Cancel resolve → bar disappears) not yet exercised.