### PR TITLE
Render sub-agent summary as markdown

### DIFF
--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -7,6 +7,7 @@ import type { AgentItemId, Message, UserQuestionAnswer } from "@memoize/wire";
 import { cn } from "~/lib/utils";
 
 import { CopyButton } from "./copy-button.tsx";
+import { MarkdownBody } from "./markdown-body.tsx";
 import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
 import { Spinner } from "./ui/spinner";
 
@@ -150,8 +151,8 @@ export function SubagentRow({
             ))}
           </div>
           {summary !== null && summary.text.length > 0 ? (
-            <div className="px-4 py-1 text-xs text-foreground/80">
-              {summary.text}
+            <div className="px-4 py-1">
+              <MarkdownBody className="text-xs">{summary.text}</MarkdownBody>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Problem

A finished sub-agent's final summary showed as **raw markdown source** — literal `###`, `**`, backticks, and `|` tables — collapsed into a single flowing paragraph instead of formatted output.

## Root cause

`subagent-row.tsx` rendered `summary.text` into a plain `<div>`. `summary.text` is markdown (from the `subagent_summary` wire content), but a normal `<div>` collapses the source newlines and renders the syntax literally. Every other chat surface — assistant bubbles, turn summaries, the `Task` tool reply — routes through `MarkdownBody`; the sub-agent summary was the one that didn't.

## Fix

Route the summary through `MarkdownBody` (reusing the shared `fz-prose` typography + code-block/table/mermaid handling), keeping the small text size.

## Verify

- Expand a turn containing a sub-agent run.
- Confirm the summary renders headings, bold, code blocks, and pipe tables as formatted markdown (no literal `###` / `**` / `|`).
- Plain-text summaries still render normally.