### PR TITLE
Cap turn-summary file chips with collapsible +N more toggle

### DIFF
--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -80,6 +80,7 @@ const findFinalAssistant = (body: ReadonlyArray<Message>): Message | null => {
 };
 
 const MAX_PREVIEW_ICONS = 5;
+const MAX_FILE_CHIPS = 4;
 
 /**
  * Inline summary of a completed turn. The header (chevron + counts + tool
@@ -97,6 +98,7 @@ export function TurnSummary({
   answersByItemId?: ReadonlyMap<AgentItemId, ReadonlyArray<UserQuestionAnswer>>;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [filesExpanded, setFilesExpanded] = useState(false);
 
   const toolUses = useMemo(
     () => body.filter((m) => m.content._tag === "tool_use"),
@@ -153,6 +155,22 @@ export function TurnSummary({
     : "text-muted-foreground";
 
   const overflowCount = previewIcons.length - MAX_PREVIEW_ICONS;
+
+  const hasFileOverflow = fileStats.length > MAX_FILE_CHIPS;
+  const visibleFileStats =
+    hasFileOverflow && !filesExpanded
+      ? fileStats.slice(0, MAX_FILE_CHIPS)
+      : fileStats;
+  const hiddenFileStats = hasFileOverflow
+    ? fileStats.slice(MAX_FILE_CHIPS)
+    : [];
+  const hiddenTotals = hiddenFileStats.reduce(
+    (acc, f) => ({
+      added: acc.added + f.added,
+      removed: acc.removed + f.removed,
+    }),
+    { added: 0, removed: 0 },
+  );
 
   return (
     <div className="flex flex-col">
@@ -257,7 +275,7 @@ export function TurnSummary({
             className="size-5 rounded opacity-70 hover:opacity-100"
           />
         ) : null}
-        {fileStats.map((f) => (
+        {visibleFileStats.map((f) => (
           <FileBadge
             key={f.path}
             path={f.path}
@@ -265,6 +283,37 @@ export function TurnSummary({
             diffStats={{ added: f.added, removed: f.removed }}
           />
         ))}
+        {hasFileOverflow ? (
+          <button
+            type="button"
+            onClick={() => setFilesExpanded((e) => !e)}
+            className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+          >
+            <HugeiconsIcon
+              icon={filesExpanded ? ArrowDown01Icon : ArrowRight01Icon}
+              className="size-3.5 shrink-0 opacity-70"
+            />
+            {filesExpanded ? (
+              <span>Show less</span>
+            ) : (
+              <>
+                <span className="tabular-nums">
+                  +{hiddenFileStats.length} more
+                </span>
+                {hiddenTotals.added > 0 ? (
+                  <span className="font-mono tabular-nums text-emerald-400">
+                    +{hiddenTotals.added}
+                  </span>
+                ) : null}
+                {hiddenTotals.removed > 0 ? (
+                  <span className="font-mono tabular-nums text-red-400">
+                    -{hiddenTotals.removed}
+                  </span>
+                ) : null}
+              </>
+            )}
+          </button>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

The turn footer previously rendered **one chip per changed file** with no limit, so turns touching many files (~15 in practice) wrapped into a tall block of pills that dominated the message.

This caps the inline chips at **4** and folds the rest behind a collapsible toggle:

- **≤4 files** → all chips show, no toggle (unchanged).
- **>4 files** → first 4 chips, then a `▸ +N more  +123 −45` button — the count of hidden files plus an aggregate `+added −removed` rollup of just those hidden files, styled to match the chips (emerald/red, `tabular-nums`).
- Clicking expands the remaining chips in place; the toggle flips to `▾ Show less`, and clicking again collapses.

Mechanics mirror the existing `MAX_PREVIEW_ICONS` / `+N` idiom already in this file: a new `MAX_FILE_CHIPS = 4` constant, a `filesExpanded` state, and plain conditional slicing (the footer isn't virtualized, so no motion needed). `FileChip`/`FileBadge` and click-to-diff are untouched.

Out of scope: the full "Edited N files / Undo / Review" bar — that's from another product and we have no undo/review wiring here.

## Verify

- `bun run check-types` and prettier pass.
- `bun run dev:desktop`, open a turn editing >4 files: footer shows 4 chips + `+N more`; clicking expands to all + `Show less`; clicking collapses. A turn editing ≤4 files shows all chips with no toggle.