### PR TITLE
Isolate terminals & dock tabs per chat, keep shells running across switches

### DIFF
--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -13,6 +13,7 @@ import type { FolderId, WorktreeId } from "@memoize/wire";
 
 import { formatShortcut } from "../lib/shortcuts.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
+import { useChatsStore } from "../store/chats.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
@@ -22,6 +23,7 @@ import {
   useTerminalsStore,
 } from "../store/terminals.ts";
 import {
+  EMPTY_PANELS,
   type PanelInstance,
   type PanelKind,
   SINGLETON_PANEL_KINDS,
@@ -119,16 +121,23 @@ export function RightPane() {
       ? (s.byKey[prDetailsKey(selectedFolderId, worktreeId)] ?? null)
       : null,
   );
-  // Terminal tab titles are sourced from the active workspace's terminal
-  // list (slot → instance) so multiple terminal tabs read "zsh", "zsh 2".
+  // Dock layout + terminals are scoped to the selected sidebar chat, so each
+  // chat keeps its own open tabs and running shells.
+  const chatId = useChatsStore((s) => s.selectedChatId);
+  // Terminal tab titles are sourced from the chat's terminal list (slot →
+  // instance) so multiple terminal tabs read "zsh", "zsh 2".
   const termList = useTerminalsStore((s) =>
-    selectedFolderId
-      ? (s.byKey[terminalsKey(selectedFolderId, worktreeId)] ?? EMPTY_TERMINALS)
+    chatId
+      ? (s.byKey[terminalsKey(chatId)] ?? EMPTY_TERMINALS)
       : EMPTY_TERMINALS,
   );
 
-  const panels = useUiStore((s) => s.rightPanels);
-  const activeId = useUiStore((s) => s.activeRightPanelId);
+  const panels = useUiStore((s) =>
+    chatId ? (s.rightPanelsByChat[chatId] ?? EMPTY_PANELS) : EMPTY_PANELS,
+  );
+  const activeId = useUiStore((s) =>
+    chatId ? (s.activeRightPanelByChat[chatId] ?? null) : null,
+  );
   const addPanel = useUiStore((s) => s.addPanel);
   const closePanel = useUiStore((s) => s.closePanel);
   const setActive = useUiStore((s) => s.setActiveRightPanel);
@@ -140,13 +149,13 @@ export function RightPane() {
       ? activeId
       : (panels[0]?.id ?? null);
 
-  // Closing a terminal tab also drops its backing PTY instance for the
-  // active workspace (the store action is layout-only — it can't know the
-  // active key). `closePanel` then re-indexes remaining terminal slots, so
-  // panels and instances stay aligned.
+  // Closing a terminal tab also drops (and kills) its backing PTY instance
+  // for the chat (the store action is layout-only — it can't know the chat
+  // key). `closePanel` then re-indexes remaining terminal slots, so panels
+  // and instances stay aligned.
   const handleClose = (panel: PanelInstance) => {
-    if (panel.kind === "terminal" && selectedFolderId !== null) {
-      const key = terminalsKey(selectedFolderId, worktreeId);
+    if (panel.kind === "terminal" && chatId !== null) {
+      const key = terminalsKey(chatId);
       const inst = (useTerminalsStore.getState().byKey[key] ?? EMPTY_TERMINALS)[
         panel.slot
       ];

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -1,32 +1,23 @@
-import { HugeiconsIcon } from "@hugeicons/react";
-import { ComputerTerminal01Icon } from "@hugeicons-pro/core-bulk-rounded";
 import { type ReactNode, useEffect, useRef } from "react";
-import { Plus, X } from "lucide-react";
-import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import { Effect, Fiber, Stream } from "effect";
 
-import type { FolderId, PtyId, WorktreeId } from "@memoize/wire";
+import type { ChatId } from "@memoize/wire";
 
-import { getRpcClient } from "../lib/rpc-client.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
+import { useChatsStore } from "../store/chats.ts";
+import * as terminalRegistry from "../lib/terminal-registry.ts";
 import {
   EMPTY_TERMINALS,
   type TerminalInstance,
   terminalsKey,
   useTerminalsStore,
 } from "../store/terminals.ts";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 /**
- * Right-pane terminal host. Owns the per-workspace terminal list + active
- * selection (`useTerminalsStore`) and mounts a `PtyTerminal` for every
- * instance, toggling visibility with `hidden` so switching between terminals
- * preserves each one's xterm scrollback and PTY connection.
- *
- * Terminals are ephemeral: closing the renderer kills every PTY because the
- * `PtyTerminal` cleanup runs on unmount. Persistence across reloads is out
- * of scope.
+ * Right-pane terminal host. Each right-dock terminal tab carries a
+ * chat-relative `slot`; `TerminalSlotPane` resolves it against the active
+ * chat's terminal list and mounts one `PtyTerminal`. The xterm + PTY live in
+ * `terminal-registry.ts`, so unmounting (e.g. switching chats) detaches the
+ * DOM but leaves the shell running — re-selecting the chat reconnects.
  */
 function TerminalPlaceholder({ children }: { children: ReactNode }) {
   return (
@@ -38,13 +29,14 @@ function TerminalPlaceholder({ children }: { children: ReactNode }) {
 
 /**
  * Renders a single terminal for one right-dock tab. The tab carries a
- * workspace-relative `slot`; this resolves it to the active workspace's Nth
- * terminal instance (seeding via `ensureSlot`) and mounts one `PtyTerminal`.
- * Plain shell on every workspace — setup moved to the inline creating card
- * and Run to the top bar.
+ * chat-relative `slot`; this resolves it to the active chat's Nth terminal
+ * instance (seeding via `ensureSlot`) and mounts one `PtyTerminal`. The PTY's
+ * cwd is the active workspace root, but the terminal LIST is owned by the
+ * chat, so each chat keeps its own shells.
  */
 export function TerminalSlotPane({ slot }: { slot: number }) {
   const ctx = useActiveContext();
+  const chatId = useChatsStore((s) => s.selectedChatId);
   const ready = ctx.status === "ready" && !ctx.worktreePending;
 
   if (ctx.status === "loading") {
@@ -60,29 +52,22 @@ export function TerminalSlotPane({ slot }: { slot: number }) {
   if (ctx.worktreePending) {
     return <TerminalPlaceholder>Preparing worktree…</TerminalPlaceholder>;
   }
-  if (!ready) return null;
+  if (!ready || chatId === null) return null;
   return (
-    <PlainTerminalSlot
-      folderId={ctx.folderId}
-      worktreeId={ctx.worktreeId}
-      rootPath={ctx.rootPath}
-      slot={slot}
-    />
+    <PlainTerminalSlot chatId={chatId} rootPath={ctx.rootPath} slot={slot} />
   );
 }
 
 function PlainTerminalSlot({
-  folderId,
-  worktreeId,
+  chatId,
   rootPath,
   slot,
 }: {
-  folderId: FolderId;
-  worktreeId: WorktreeId | null;
+  chatId: ChatId;
   rootPath: string;
   slot: number;
 }) {
-  const key = terminalsKey(folderId, worktreeId);
+  const key = terminalsKey(chatId);
   const list = useTerminalsStore((s) => s.byKey[key] ?? EMPTY_TERMINALS);
   const ensureSlot = useTerminalsStore((s) => s.ensureSlot);
 
@@ -93,200 +78,22 @@ function PlainTerminalSlot({
   const inst = list[slot];
   if (inst === undefined) return null;
   return (
-    <PtyTerminal
-      folderId={folderId}
-      cwd={inst.cwd}
-      instanceId={inst.id}
-      command={inst.command}
-    />
+    <PtyTerminal cwd={inst.cwd} instanceId={inst.id} command={inst.command} />
   );
 }
 
-function TerminalWorkspace({
-  folderId,
-  worktreeId,
-  rootPath,
-  showFloatingAdd = false,
-}: {
-  folderId: FolderId;
-  worktreeId: WorktreeId | null;
-  rootPath: string;
-  showFloatingAdd?: boolean;
-}) {
-  const key = terminalsKey(folderId, worktreeId);
-  const list = useTerminalsStore((s) => s.byKey[key] ?? EMPTY_TERMINALS);
-  const activeId = useTerminalsStore((s) => s.activeByKey[key] ?? null);
-  const ensureSeed = useTerminalsStore((s) => s.ensureSeed);
-  const add = useTerminalsStore((s) => s.add);
-  const remove = useTerminalsStore((s) => s.remove);
-  const setActive = useTerminalsStore((s) => s.setActive);
-
-  const handleAdd = () => {
-    add(key, rootPath);
-  };
-  const handleClose = (id: string) => {
-    remove(key, id);
-    // If the user closed the last one, seed a fresh terminal so the pane
-    // is never empty — matches what a developer expects from a terminal
-    // dock: there's always a shell waiting.
-    if (list.length === 1) ensureSeed(key, rootPath);
-  };
-
-  useEffect(() => {
-    if (list.length === 0) ensureSeed(key, rootPath);
-  }, [key, list.length, ensureSeed, rootPath]);
-
-  // A single terminal gets the full pane — the list sidebar only earns its
-  // width once there's more than one shell to switch between. When it's
-  // hidden, a floating "+" (revealed on hover) keeps "add a terminal" within
-  // reach; adding a second one brings the sidebar back.
-  const single = list.length <= 1;
-
-  return (
-    <div className="group/terminal flex h-full min-h-0 w-full">
-      {single ? null : (
-        <TerminalList
-          instances={list}
-          activeId={activeId}
-          onAdd={handleAdd}
-          onSelect={(id) => setActive(key, id)}
-          onClose={handleClose}
-        />
-      )}
-      <div className="relative flex min-w-0 flex-1 flex-col bg-background">
-        {single && showFloatingAdd ? (
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <button
-                  type="button"
-                  onClick={handleAdd}
-                  className="absolute right-2 top-2 z-10 flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted/60 hover:text-foreground focus-visible:opacity-100 group-hover/terminal:opacity-100"
-                  aria-label="New terminal"
-                >
-                  <Plus className="size-3.5" strokeWidth={1.8} />
-                </button>
-              }
-            />
-            <TooltipPopup>New terminal</TooltipPopup>
-          </Tooltip>
-        ) : null}
-        {list.map((inst) => (
-          <div
-            key={inst.id}
-            hidden={inst.id !== activeId}
-            className="absolute inset-0 flex"
-          >
-            <PtyTerminal
-              folderId={folderId}
-              cwd={inst.cwd}
-              instanceId={inst.id}
-              command={inst.command}
-            />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function TerminalList({
-  instances,
-  activeId,
-  onAdd,
-  onSelect,
-  onClose,
-}: {
-  instances: ReadonlyArray<TerminalInstance>;
-  activeId: string | null;
-  onAdd: () => void;
-  onSelect: (id: string) => void;
-  onClose: (id: string) => void;
-}) {
-  const count = instances.length;
-  const label = count === 1 ? "1 Terminal" : `${count} Terminals`;
-  return (
-    <div className="flex w-44 shrink-0 flex-col border-r border-border bg-background/40">
-      <div className="flex h-7 shrink-0 items-center justify-between gap-1 border-b border-border/60 px-2 text-[11px] text-muted-foreground">
-        <span className="truncate">{label}</span>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                onClick={onAdd}
-                className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-                aria-label="New terminal"
-              >
-                <Plus className="size-3.5" strokeWidth={1.8} />
-              </button>
-            }
-          />
-          <TooltipPopup>New terminal</TooltipPopup>
-        </Tooltip>
-      </div>
-      <ul className="min-h-0 flex-1 overflow-y-auto py-1">
-        {instances.map((inst) => (
-          <li key={inst.id}>
-            <button
-              type="button"
-              onClick={() => onSelect(inst.id)}
-              className={`group flex w-full items-center gap-1.5 px-2 py-1 text-left text-[12px] transition-colors ${
-                inst.id === activeId
-                  ? "bg-muted text-foreground"
-                  : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-              }`}
-            >
-              <HugeiconsIcon icon={ComputerTerminal01Icon} className="size-3.5 shrink-0 opacity-70" />
-              <span className="flex-1 truncate">{inst.title}</span>
-              <span
-                role="button"
-                tabIndex={0}
-                aria-label={`Close ${inst.title}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClose(inst.id);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onClose(inst.id);
-                  }
-                }}
-                className="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-opacity hover:bg-background hover:text-foreground group-hover:opacity-100"
-              >
-                <X className="size-3" strokeWidth={1.8} />
-              </span>
-            </button>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-// xterm's canvas/webgl renderer takes literal color strings, not CSS vars,
-// so we resolve our shadcn tokens to computed rgb() strings via a probe span.
-// `getComputedStyle().color` always returns a normalized rgb()/rgba() the
-// renderer can parse, regardless of whether the var is defined in oklch().
-function readToken(el: HTMLElement, cssVar: string, fallback: string): string {
-  const probe = document.createElement("span");
-  probe.style.color = `var(${cssVar})`;
-  probe.style.display = "none";
-  el.appendChild(probe);
-  const computed = getComputedStyle(probe).color;
-  probe.remove();
-  return computed || fallback;
-}
-
+/**
+ * Thin host for one terminal instance. The xterm + PTY live in
+ * `terminal-registry.ts` keyed by `instanceId`; this just `attach`es the live
+ * entry into its container on mount and `detach`es (NOT disposes) on unmount,
+ * so the shell keeps running while its chat is in the background. The PTY is
+ * only torn down on explicit close — see `useTerminalsStore.remove`.
+ */
 export function PtyTerminal({
-  folderId,
   cwd,
   instanceId,
   command,
 }: {
-  folderId: FolderId;
   cwd: string;
   instanceId: string;
   command?: TerminalInstance["command"];
@@ -296,165 +103,12 @@ export function PtyTerminal({
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-
-    const term = new Terminal({
-      fontFamily:
-        '"SF Mono", "JetBrains Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
-      fontSize: 13,
-      lineHeight: 1.3,
-      cursorBlink: true,
-      convertEol: false,
-      // Transparent canvas so the parent pane's `bg-background` shows through.
-      // This keeps the terminal in sync with theme changes without re-mounting.
-      allowTransparency: true,
-      theme: {
-        background: "rgba(0, 0, 0, 0)",
-        foreground: readToken(container, "--foreground", "#e6e6e6"),
-        cursor: readToken(container, "--primary", "#e6e6e6"),
-        cursorAccent: readToken(container, "--background", "#0b0b0c"),
-        selectionBackground: readToken(container, "--accent", "#2c2c33"),
-        selectionForeground: readToken(container, "--accent-foreground", "#e6e6e6"),
-      },
-    });
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.open(container);
-
-    // Don't fit synchronously — the parent grid hasn't laid out yet on first
-    // render, so xterm's renderer has no dimensions and FitAddon throws
-    // "Cannot read properties of undefined (reading 'dimensions')". The
-    // ResizeObserver below fires once after observe with real measurements.
-    const safeFit = () => {
-      if (container.clientWidth === 0 || container.clientHeight === 0) return;
-      try {
-        fit.fit();
-      } catch {
-        // ignore — happens during teardown when the container is detached
-      }
-    };
-
-    let cancelled = false;
-    let ptyId: PtyId | null = null;
-    let dataDisposable: { dispose: () => void } | null = null;
-    let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
-    let resizeTimer: number | null = null;
-
-    const observer = new ResizeObserver(safeFit);
-    observer.observe(container);
-    window.requestAnimationFrame(safeFit);
-
-    void (async () => {
-      try {
-        const client = await getRpcClient();
-        if (cancelled) return;
-
-        const { ptyId: id } = await Effect.runPromise(
-          client.pty.open({
-            cwd,
-            cols: term.cols,
-            rows: term.rows,
-            command:
-              command === undefined
-                ? undefined
-                : {
-                    cmd: command.cmd,
-                    args: [...command.args],
-                    env: command.env,
-                  },
-          }),
-        );
-        if (cancelled) {
-          void Effect.runPromise(client.pty.close({ ptyId: id }));
-          return;
-        }
-        ptyId = id;
-        safeFit();
-        void Effect.runPromise(
-          client.pty.resize({ ptyId: id, cols: term.cols, rows: term.rows }),
-        ).catch(() => {
-          // ignore
-        });
-
-        // Pump output stream into xterm.
-        streamFiber = Effect.runFork(
-          Stream.runForEach(client.pty.output({ ptyId: id }), (event) =>
-            Effect.sync(() => {
-              if (event._tag === "data") {
-                term.write(event.bytes);
-              } else {
-                const note =
-                  event.exitCode === null
-                    ? "[process exited]"
-                    : `[process exited with code ${event.exitCode}]`;
-                term.write(`\r\n\x1b[38;5;244m${note}\x1b[0m\r\n`);
-              }
-            }),
-          ),
-        );
-
-        // Forward keystrokes to the pty.
-        dataDisposable = term.onData((data) => {
-          void Effect.runPromise(client.pty.write({ ptyId: id, data })).catch(
-            () => {
-              // pty exited; ignore
-            },
-          );
-        });
-
-        // Send debounced resizes.
-        const sendResize = () => {
-          if (ptyId === null) return;
-          void Effect.runPromise(
-            client.pty.resize({ ptyId, cols: term.cols, rows: term.rows }),
-          ).catch(() => {
-            // ignore
-          });
-        };
-        const onTermResize = term.onResize(() => {
-          if (resizeTimer !== null) window.clearTimeout(resizeTimer);
-          resizeTimer = window.setTimeout(sendResize, 100);
-        });
-        // Also tie the disposable cleanup chain.
-        const prevDispose = dataDisposable.dispose.bind(dataDisposable);
-        dataDisposable = {
-          dispose: () => {
-            prevDispose();
-            onTermResize.dispose();
-          },
-        };
-      } catch (err) {
-        if (cancelled) return;
-        // eslint-disable-next-line no-console
-        console.error("[memoize] failed to open pty:", err);
-        term.write(
-          "\r\n\x1b[38;5;203mfailed to open terminal — see devtools console\x1b[0m\r\n",
-        );
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      observer.disconnect();
-      dataDisposable?.dispose();
-      if (streamFiber !== null) {
-        void Effect.runPromise(Fiber.interrupt(streamFiber));
-      }
-      if (resizeTimer !== null) window.clearTimeout(resizeTimer);
-      if (ptyId !== null) {
-        const id = ptyId;
-        void getRpcClient().then((client) =>
-          Effect.runPromise(client.pty.close({ ptyId: id })).catch(() => {
-            // already closed
-          }),
-        );
-      }
-      term.dispose();
-    };
-    // Instance id is part of the deps so swapping instances re-opens cleanly.
+    terminalRegistry.attach(instanceId, container, { cwd, command });
+    return () => terminalRegistry.detach(instanceId);
+    // `cwd`/`command` only matter on first open; reconnects reuse the live
+    // entry, so the instance id is the sole identity that should re-run this.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [folderId, cwd, instanceId]);
+  }, [instanceId]);
 
-  return (
-    <div ref={containerRef} className="h-full w-full bg-background p-2" />
-  );
+  return <div ref={containerRef} className="h-full w-full bg-background p-2" />;
 }

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -1,6 +1,27 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Alert01Icon, ArrowDown01Icon, Copy01Icon, GitBranchIcon, GitMergeIcon, LinkSquare01Icon, Loading02Icon, MagicWand01Icon, PanelLeftCloseIcon, PanelLeftOpenIcon, PanelRightCloseIcon, PanelRightOpenIcon, PencilEdit01Icon, PlayIcon, Tick01Icon, Upload01Icon, Wrench01Icon } from "@hugeicons-pro/core-bulk-rounded";
-import { ArchiveArrowDownIcon, GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
+import {
+  Alert01Icon,
+  ArrowDown01Icon,
+  Copy01Icon,
+  GitBranchIcon,
+  GitMergeIcon,
+  LinkSquare01Icon,
+  Loading02Icon,
+  MagicWand01Icon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
+  PanelRightCloseIcon,
+  PanelRightOpenIcon,
+  PencilEdit01Icon,
+  PlayIcon,
+  Tick01Icon,
+  Upload01Icon,
+  Wrench01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import {
+  ArchiveArrowDownIcon,
+  GitPullRequestIcon,
+} from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
 import {
   type CSSProperties,
@@ -345,7 +366,10 @@ export function TopBarMain() {
               }
             >
               {rightSidebarOpen ? (
-                <HugeiconsIcon icon={PanelRightCloseIcon} className="size-3.5" />
+                <HugeiconsIcon
+                  icon={PanelRightCloseIcon}
+                  className="size-3.5"
+                />
               ) : (
                 <HugeiconsIcon icon={PanelRightOpenIcon} className="size-3.5" />
               )}
@@ -392,7 +416,10 @@ function BranchMenuButton({
         className="flex max-w-64 items-center gap-1 rounded-sm px-1.5 py-0.5 font-medium text-foreground outline-none hover:bg-foreground/5 data-[popup-open]:bg-foreground/5"
         aria-label="Switch branch"
       >
-        <HugeiconsIcon icon={GitBranchIcon} className="size-3.5 shrink-0 text-muted-foreground" />
+        <HugeiconsIcon
+          icon={GitBranchIcon}
+          className="size-3.5 shrink-0 text-muted-foreground"
+        />
         <span className="truncate" title={branchLabel}>
           {branchLabel}
         </span>
@@ -400,9 +427,15 @@ function BranchMenuButton({
           <span className="shrink-0 text-muted-foreground">· {dirtyFiles}</span>
         ) : null}
         {loading ? (
-          <HugeiconsIcon icon={Loading02Icon} className="size-3 animate-spin text-muted-foreground" />
+          <HugeiconsIcon
+            icon={Loading02Icon}
+            className="size-3 animate-spin text-muted-foreground"
+          />
         ) : (
-          <HugeiconsIcon icon={ArrowDown01Icon} className="size-3 text-muted-foreground" />
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            className="size-3 text-muted-foreground"
+          />
         )}
       </MenuTrigger>
       <MenuPopup align="center" className="min-w-64">
@@ -428,7 +461,10 @@ function BranchMenuButton({
               onClick={() => onSwitch(branch)}
               className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
             >
-              <HugeiconsIcon icon={Tick01Icon} className={`size-3.5 ${branch.current ? "opacity-100" : "opacity-0"}`} />
+              <HugeiconsIcon
+                icon={Tick01Icon}
+                className={`size-3.5 ${branch.current ? "opacity-100" : "opacity-0"}`}
+              />
               <span className="min-w-0 flex-1 truncate">{branch.name}</span>
               {branch.upstream !== null ? (
                 <span className="max-w-28 truncate text-[10px] text-muted-foreground">
@@ -620,7 +656,10 @@ function OpenInMenu({ rootPath }: { rootPath: string | null }) {
             >
               <span className="flex size-7 items-center justify-center border-r border-border/80">
                 {loading ? (
-                  <HugeiconsIcon icon={Loading02Icon} className="size-3.5 animate-spin" />
+                  <HugeiconsIcon
+                    icon={Loading02Icon}
+                    className="size-3.5 animate-spin"
+                  />
                 ) : primary !== undefined ? (
                   <OpenTargetIcon target={primary} />
                 ) : (
@@ -812,13 +851,15 @@ function RunButton() {
   if ((settings?.runScript?.trim().length ?? 0) === 0) return null;
 
   const worktreeId = ctx.worktreeId;
-  const projectId = ctx.folderId;
   const onRun = async () => {
+    // The Run button only renders for the active worktree, which belongs to
+    // the selected chat — so the run terminal lands in that chat's dock.
+    const chatId = useChatsStore.getState().selectedChatId;
+    if (chatId === null) return;
     const run = await startRun(worktreeId);
     if (run === null) return;
     openTerminalCommand({
-      folderId: projectId,
-      worktreeId,
+      chatId,
       cwd: run.cwd,
       title: "Run",
       command: { cmd: "/bin/zsh", args: ["-lc", run.script], env: run.env },
@@ -1129,7 +1170,13 @@ function DirectActionButton({
       ) : null}
       <GlassActionButton
         tone={tone}
-        icon={loading ? <HugeiconsIcon icon={Loading02Icon} className="animate-spin" /> : icon}
+        icon={
+          loading ? (
+            <HugeiconsIcon icon={Loading02Icon} className="animate-spin" />
+          ) : (
+            icon
+          )
+        }
         label={loading ? loadingLabel : label}
         disabled={disabled || loading}
         onClick={onClick}
@@ -1203,7 +1250,10 @@ function MergeButton({
               onClick={() => setMethod(m)}
               className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
             >
-              <HugeiconsIcon icon={Tick01Icon} className={`size-3.5 ${method === m ? "opacity-100" : "opacity-0"}`} />
+              <HugeiconsIcon
+                icon={Tick01Icon}
+                className={`size-3.5 ${method === m ? "opacity-100" : "opacity-0"}`}
+              />
               {MERGE_METHOD_LABEL[m]}
             </MenuItem>
           ))}
@@ -1295,7 +1345,11 @@ function AutoMergeToggle({
               }`}
               aria-pressed={enabled}
             >
-              {loading ? <HugeiconsIcon icon={Loading02Icon} className="animate-spin" /> : <HugeiconsIcon icon={MagicWand01Icon} />}
+              {loading ? (
+                <HugeiconsIcon icon={Loading02Icon} className="animate-spin" />
+              ) : (
+                <HugeiconsIcon icon={MagicWand01Icon} />
+              )}
               {enabled ? "Auto-merge on" : "Auto-merge"}
             </button>
           }
@@ -1371,7 +1425,13 @@ function FixActionsButton({
   return (
     <GlassActionButton
       tone="red"
-      icon={loading ? <HugeiconsIcon icon={Loading02Icon} className="animate-spin" /> : <HugeiconsIcon icon={Wrench01Icon} />}
+      icon={
+        loading ? (
+          <HugeiconsIcon icon={Loading02Icon} className="animate-spin" />
+        ) : (
+          <HugeiconsIcon icon={Wrench01Icon} />
+        )
+      }
       label={loading ? "Capturing…" : "Fix CI errors"}
       disabled={disabled || loading}
       onClick={onClick}

--- a/apps/renderer/src/lib/run-terminal.ts
+++ b/apps/renderer/src/lib/run-terminal.ts
@@ -1,4 +1,4 @@
-import type { FolderId, WorktreeId } from "@memoize/wire";
+import type { ChatId } from "@memoize/wire";
 
 import {
   type TerminalInstance,
@@ -9,26 +9,27 @@ import { useUiStore } from "../store/ui.ts";
 
 /**
  * Spawn a command-bound terminal (e.g. the project's Run script) and surface
- * it in the right dock: append the instance, open a terminal panel pinned to
- * that instance's exact list index, activate it, and open the sidebar.
+ * it in the owning chat's right dock: append the instance to that chat's
+ * terminal list, open a terminal panel pinned to the instance's exact list
+ * index, activate it, and open the sidebar.
  *
- * Pinning the panel to the command instance's real list index (rather than the
- * auto-computed "next terminal panel" slot) is what guarantees the new tab
- * shows the command output instead of a blank shell, regardless of how many
- * plain terminals are already open.
+ * Terminals are scoped per chat, so the caller passes the chat that should own
+ * the run (the active chat for the top-bar Run button, or the worktree's chat
+ * for auto-run after setup). Pinning the panel to the command instance's real
+ * list index (rather than the auto-computed "next terminal panel" slot) is what
+ * guarantees the new tab shows the command output instead of a blank shell.
  */
 export function openTerminalCommand(args: {
-  readonly folderId: FolderId;
-  readonly worktreeId: WorktreeId | null;
+  readonly chatId: ChatId;
   readonly cwd: string;
   readonly title: string;
   readonly command: NonNullable<TerminalInstance["command"]>;
 }): void {
-  const key = terminalsKey(args.folderId, args.worktreeId);
+  const key = terminalsKey(args.chatId);
   const index = useTerminalsStore
     .getState()
     .addCommand(key, args.cwd, args.title, args.command);
   const ui = useUiStore.getState();
-  ui.addTerminalPanelForSlot(index);
+  ui.addTerminalPanelForSlot(args.chatId, index);
   ui.setRightSidebarOpen(true);
 }

--- a/apps/renderer/src/lib/terminal-registry.ts
+++ b/apps/renderer/src/lib/terminal-registry.ts
@@ -1,0 +1,307 @@
+import { Effect, Fiber, Stream } from "effect";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+
+import type { PtyId } from "@memoize/wire";
+
+import { getRpcClient } from "./rpc-client.ts";
+import type { TerminalInstance } from "../store/terminals.ts";
+
+/**
+ * Persistent terminal registry. The xterm `Terminal` and its backing PTY live
+ * HERE — in a module-level map keyed by terminal-instance id — not inside the
+ * React component. `PtyTerminal` is a thin host that `attach()`es a live entry
+ * into its container on mount and `detach()`es (NOT disposes) on unmount.
+ *
+ * Why: the right dock mounts only the *active* chat's terminals. Before this
+ * registry, switching chats unmounted the previous chat's `PtyTerminal`, whose
+ * cleanup killed the PTY — so a running shell died the moment you looked at
+ * another chat. Now unmount only detaches the DOM; the process and its output
+ * stream keep running in the background, and re-selecting the chat reconnects
+ * to the same live shell.
+ *
+ * PTYs are torn down only on explicit close (`dispose`) or renderer unload
+ * (`disposeAll` via `pagehide`) — preserving the "PTYs die with the renderer,
+ * no rehydration across reloads" contract.
+ */
+type LiveTerminal = {
+  readonly term: Terminal;
+  readonly fit: FitAddon;
+  /** Dedicated wrapper that xterm renders into; moved between containers. */
+  readonly host: HTMLDivElement;
+  readonly observer: ResizeObserver;
+  ptyId: PtyId | null;
+  streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null;
+  disposables: { dispose: () => void } | null;
+  resizeTimer: number | null;
+  /** Set once `dispose()` runs so a late async PTY open closes itself. */
+  disposed: boolean;
+};
+
+const registry = new Map<string, LiveTerminal>();
+
+// xterm's canvas/webgl renderer takes literal color strings, not CSS vars, so
+// we resolve our shadcn tokens to computed rgb() strings via a probe span.
+// `getComputedStyle().color` always returns a normalized rgb()/rgba() the
+// renderer can parse, regardless of whether the var is defined in oklch().
+function readToken(el: HTMLElement, cssVar: string, fallback: string): string {
+  const probe = document.createElement("span");
+  probe.style.color = `var(${cssVar})`;
+  probe.style.display = "none";
+  el.appendChild(probe);
+  const computed = getComputedStyle(probe).color;
+  probe.remove();
+  return computed || fallback;
+}
+
+function makeLive(
+  instanceId: string,
+  container: HTMLElement,
+  opts: {
+    readonly cwd: string;
+    readonly command?: TerminalInstance["command"];
+  },
+): LiveTerminal {
+  const host = document.createElement("div");
+  host.className = "h-full w-full";
+  container.appendChild(host);
+
+  const term = new Terminal({
+    fontFamily:
+      '"SF Mono", "JetBrains Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
+    fontSize: 13,
+    lineHeight: 1.3,
+    cursorBlink: true,
+    convertEol: false,
+    // Transparent canvas so the parent pane's `bg-background` shows through.
+    allowTransparency: true,
+    theme: {
+      background: "rgba(0, 0, 0, 0)",
+      foreground: readToken(host, "--foreground", "#e6e6e6"),
+      cursor: readToken(host, "--primary", "#e6e6e6"),
+      cursorAccent: readToken(host, "--background", "#0b0b0c"),
+      selectionBackground: readToken(host, "--accent", "#2c2c33"),
+      selectionForeground: readToken(host, "--accent-foreground", "#e6e6e6"),
+    },
+  });
+  const fit = new FitAddon();
+  term.loadAddon(fit);
+  term.open(host);
+
+  const live: LiveTerminal = {
+    term,
+    fit,
+    host,
+    observer: new ResizeObserver(() => safeFit(live)),
+    ptyId: null,
+    streamFiber: null,
+    disposables: null,
+    resizeTimer: null,
+    disposed: false,
+  };
+
+  // Observe the host itself: when its container is `hidden` (background chat /
+  // inactive terminal tab) it measures 0×0 and `safeFit` no-ops; it fires
+  // again with real dimensions once shown.
+  live.observer.observe(host);
+  window.requestAnimationFrame(() => safeFit(live));
+
+  void openPty(live, opts);
+  return live;
+}
+
+// Don't fit when the container has no layout yet (first render, or hidden):
+// xterm's renderer has no dimensions and FitAddon throws "Cannot read
+// properties of undefined (reading 'dimensions')".
+function safeFit(live: LiveTerminal): void {
+  const { host } = live;
+  if (host.clientWidth === 0 || host.clientHeight === 0) return;
+  try {
+    live.fit.fit();
+  } catch {
+    // ignore — happens during teardown when the container is detached
+  }
+}
+
+async function openPty(
+  live: LiveTerminal,
+  opts: {
+    readonly cwd: string;
+    readonly command?: TerminalInstance["command"];
+  },
+): Promise<void> {
+  const { term } = live;
+  try {
+    const client = await getRpcClient();
+    if (live.disposed) return;
+
+    const { ptyId: id } = await Effect.runPromise(
+      client.pty.open({
+        cwd: opts.cwd,
+        cols: term.cols,
+        rows: term.rows,
+        command:
+          opts.command === undefined
+            ? undefined
+            : {
+                cmd: opts.command.cmd,
+                args: [...opts.command.args],
+                env: opts.command.env,
+              },
+      }),
+    );
+    if (live.disposed) {
+      void Effect.runPromise(client.pty.close({ ptyId: id }));
+      return;
+    }
+    live.ptyId = id;
+    safeFit(live);
+    void Effect.runPromise(
+      client.pty.resize({ ptyId: id, cols: term.cols, rows: term.rows }),
+    ).catch(() => {
+      // ignore
+    });
+
+    // Pump output stream into xterm. Stays alive while the chat is in the
+    // background so scrollback keeps filling.
+    live.streamFiber = Effect.runFork(
+      Stream.runForEach(client.pty.output({ ptyId: id }), (event) =>
+        Effect.sync(() => {
+          if (event._tag === "data") {
+            term.write(event.bytes);
+          } else {
+            const note =
+              event.exitCode === null
+                ? "[process exited]"
+                : `[process exited with code ${event.exitCode}]`;
+            term.write(`\r\n\x1b[38;5;244m${note}\x1b[0m\r\n`);
+          }
+        }),
+      ),
+    );
+
+    // Forward keystrokes to the pty.
+    const dataDisposable = term.onData((data) => {
+      void Effect.runPromise(client.pty.write({ ptyId: id, data })).catch(
+        () => {
+          // pty exited; ignore
+        },
+      );
+    });
+
+    // Send debounced resizes.
+    const sendResize = () => {
+      if (live.ptyId === null) return;
+      void Effect.runPromise(
+        client.pty.resize({
+          ptyId: live.ptyId,
+          cols: term.cols,
+          rows: term.rows,
+        }),
+      ).catch(() => {
+        // ignore
+      });
+    };
+    const onTermResize = term.onResize(() => {
+      if (live.resizeTimer !== null) window.clearTimeout(live.resizeTimer);
+      live.resizeTimer = window.setTimeout(sendResize, 100);
+    });
+    live.disposables = {
+      dispose: () => {
+        dataDisposable.dispose();
+        onTermResize.dispose();
+      },
+    };
+  } catch (err) {
+    if (live.disposed) return;
+    // eslint-disable-next-line no-console
+    console.error("[memoize] failed to open pty:", err);
+    term.write(
+      "\r\n\x1b[38;5;203mfailed to open terminal — see devtools console\x1b[0m\r\n",
+    );
+  }
+}
+
+/**
+ * Mount a terminal into `container`. Reuses the live entry for `instanceId`
+ * when one exists (reconnect — moves its DOM host into the new container, no
+ * new PTY); otherwise creates the xterm + PTY lazily.
+ */
+export function attach(
+  instanceId: string,
+  container: HTMLElement,
+  opts: {
+    readonly cwd: string;
+    readonly command?: TerminalInstance["command"];
+  },
+): void {
+  const existing = registry.get(instanceId);
+  if (existing !== undefined) {
+    if (existing.host.parentElement !== container) {
+      container.appendChild(existing.host);
+    }
+    existing.observer.observe(existing.host);
+    window.requestAnimationFrame(() => safeFit(existing));
+    return;
+  }
+  registry.set(instanceId, makeLive(instanceId, container, opts));
+}
+
+/**
+ * Unmount a terminal's DOM without killing it. The xterm, PTY, and output
+ * stream stay alive so a background chat's shell keeps running; re-selecting
+ * the chat re-`attach`es to the same live entry.
+ */
+export function detach(instanceId: string): void {
+  const live = registry.get(instanceId);
+  if (live === undefined) return;
+  live.observer.disconnect();
+  if (live.host.parentElement !== null) {
+    live.host.parentElement.removeChild(live.host);
+  }
+}
+
+/**
+ * Permanently tear down a terminal: interrupt its stream, close the PTY,
+ * dispose the xterm. Call only on explicit close (terminal tab closed, or its
+ * owning chat archived/deleted).
+ */
+export function dispose(instanceId: string): void {
+  const live = registry.get(instanceId);
+  if (live === undefined) return;
+  registry.delete(instanceId);
+  live.disposed = true;
+  live.observer.disconnect();
+  live.disposables?.dispose();
+  if (live.resizeTimer !== null) window.clearTimeout(live.resizeTimer);
+  if (live.streamFiber !== null) {
+    void Effect.runPromise(Fiber.interrupt(live.streamFiber));
+  }
+  if (live.ptyId !== null) {
+    const id = live.ptyId;
+    void getRpcClient().then((client) =>
+      Effect.runPromise(client.pty.close({ ptyId: id })).catch(() => {
+        // already closed
+      }),
+    );
+  }
+  if (live.host.parentElement !== null) {
+    live.host.parentElement.removeChild(live.host);
+  }
+  live.term.dispose();
+}
+
+/** Tear down every live terminal. Wired to renderer unload below. */
+export function disposeAll(): void {
+  for (const id of [...registry.keys()]) dispose(id);
+}
+
+// Preserve the "PTYs die with the renderer" contract: a full reload no longer
+// passes through any component unmount that closes the PTY, so close them here.
+// Guard on `addEventListener` too — the test runner stubs a bare `window`.
+if (
+  typeof window !== "undefined" &&
+  typeof window.addEventListener === "function"
+) {
+  window.addEventListener("pagehide", disposeAll);
+}

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -18,6 +18,7 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 import { formatError } from "../lib/format-error.ts";
 import { useMessagesStore } from "./messages.ts";
 import { useSessionsStore } from "./sessions.ts";
+import { useTerminalsStore } from "./terminals.ts";
 import { useUiStore } from "./ui.ts";
 import { useWorkspaceStore } from "./workspace.ts";
 import { useWorktreesStore } from "./worktrees.ts";
@@ -58,13 +59,10 @@ type ChatsState = {
       readonly permissionMode?: PermissionMode;
       readonly toolSearch?: boolean;
     },
-  ) => Promise<
-    | {
-        readonly chatId: ChatId;
-        readonly initialSessionId: SessionId;
-      }
-    | null
-  >;
+  ) => Promise<{
+    readonly chatId: ChatId;
+    readonly initialSessionId: SessionId;
+  } | null>;
   readonly rename: (chatId: ChatId, title: string) => Promise<void>;
   readonly setWorktree: (
     chatId: ChatId,
@@ -135,24 +133,22 @@ const ensureChangeStream = (projectId: FolderId): void => {
       Effect.flatMap(
         Effect.promise(() => getRpcClient()),
         (client) =>
-          Stream.runForEach(
-            client.chat.streamChanges({ projectId }),
-            (chat) =>
-              Effect.sync(() => {
-                useChatsStore.setState((s) => {
-                  const chats = s.chatsByProject[projectId];
-                  if (chats === undefined) return s;
-                  if (!chats.some((c) => c.id === chat.id)) return s;
-                  return {
-                    chatsByProject: {
-                      ...s.chatsByProject,
-                      [projectId]: chats.map((c) =>
-                        c.id === chat.id ? chat : c,
-                      ),
-                    },
-                  };
-                });
-              }),
+          Stream.runForEach(client.chat.streamChanges({ projectId }), (chat) =>
+            Effect.sync(() => {
+              useChatsStore.setState((s) => {
+                const chats = s.chatsByProject[projectId];
+                if (chats === undefined) return s;
+                if (!chats.some((c) => c.id === chat.id)) return s;
+                return {
+                  chatsByProject: {
+                    ...s.chatsByProject,
+                    [projectId]: chats.map((c) =>
+                      c.id === chat.id ? chat : c,
+                    ),
+                  },
+                };
+              });
+            }),
           ),
       ),
     ),
@@ -426,6 +422,10 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
               : s.selectedSessionId,
         };
       });
+      // Tear down the chat's terminals (closing their PTYs) and drop its dock
+      // layout so an archived chat leaks no shells or tab state.
+      useTerminalsStore.getState().disposeChat(chatId);
+      useUiStore.getState().clearChatPanels(chatId);
     } catch (err) {
       set({ error: formatError(err) });
     }
@@ -526,6 +526,10 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
               : s.selectedSessionId,
         };
       });
+      // Dispose the deleted chat's terminals (closing their PTYs) and drop its
+      // dock layout so nothing lingers after the chat is gone.
+      useTerminalsStore.getState().disposeChat(chatId);
+      useUiStore.getState().clearChatPanels(chatId);
     } catch (err) {
       set({ error: formatError(err) });
     }

--- a/apps/renderer/src/store/terminals.ts
+++ b/apps/renderer/src/store/terminals.ts
@@ -1,15 +1,19 @@
 import { create } from "zustand";
 
-import type { FolderId, WorktreeId } from "@memoize/wire";
+import type { ChatId } from "@memoize/wire";
+
+import * as terminalRegistry from "../lib/terminal-registry.ts";
 
 /**
- * Renderer-side terminal instances. The PTY itself lives on the server and
- * is opened lazily by the `PtyTerminal` component when its container mounts
- * — this store only tracks the list of slots the user wants to see and which
- * one is focused. PTYs die with the renderer (no rehydration across reloads).
+ * Renderer-side terminal instances. The xterm + PTY themselves live in
+ * `terminal-registry.ts` (kept alive across chat switches); this store only
+ * tracks the list of slots each chat wants to see and which one is focused.
+ * PTYs die with the renderer (no rehydration across reloads).
  *
- * Keyed by `(folderId, worktreeId)` so each workspace gets its own list and
- * switching projects/worktrees doesn't shuffle terminals between them.
+ * Keyed by `chatId` so each sidebar chat gets its own terminal list — opening
+ * a shell in one chat doesn't show up in (or get torn down by switching to)
+ * another. Closing a terminal, or its owning chat, disposes the backing PTY
+ * via the registry (`remove` / `disposeChat`).
  */
 export type TerminalInstance = {
   readonly id: string;
@@ -52,12 +56,15 @@ type TerminalsState = {
   ) => number;
   readonly remove: (key: string, id: string) => void;
   readonly setActive: (key: string, id: string) => void;
+  /**
+   * Dispose every terminal owned by a chat (closing each backing PTY) and drop
+   * the chat's list. Called when a chat is archived or deleted so its shells
+   * don't leak.
+   */
+  readonly disposeChat: (chatId: ChatId) => void;
 };
 
-export const terminalsKey = (
-  folderId: FolderId,
-  worktreeId: WorktreeId | null,
-): string => `${folderId}:${worktreeId ?? "main"}`;
+export const terminalsKey = (chatId: ChatId): string => chatId;
 
 const newId = (): string =>
   globalThis.crypto?.randomUUID?.() ??
@@ -143,6 +150,9 @@ export const useTerminalsStore = create<TerminalsState>((set) => ({
       const list = state.byKey[key] ?? [];
       const idx = list.findIndex((t) => t.id === id);
       if (idx === -1) return state;
+      // Component unmount no longer kills the PTY (it only detaches), so an
+      // explicit close has to tear the backing shell down here.
+      terminalRegistry.dispose(id);
       const next = list.filter((t) => t.id !== id);
       const wasActive = state.activeByKey[key] === id;
       // Pick the previous instance when closing the active one; if that
@@ -159,6 +169,16 @@ export const useTerminalsStore = create<TerminalsState>((set) => ({
     set((state) => ({
       activeByKey: { ...state.activeByKey, [key]: id },
     })),
+  disposeChat: (chatId) =>
+    set((state) => {
+      const key = terminalsKey(chatId);
+      const list = state.byKey[key];
+      if (list === undefined) return state;
+      for (const inst of list) terminalRegistry.dispose(inst.id);
+      const { [key]: _droppedList, ...byKey } = state.byKey;
+      const { [key]: _droppedActive, ...activeByKey } = state.activeByKey;
+      return { byKey, activeByKey };
+    }),
 }));
 
 export const EMPTY_TERMINALS: ReadonlyArray<TerminalInstance> = [];

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -1,6 +1,13 @@
 import { create } from "zustand";
 
-import type { CodeAnnotation, FolderId, WorktreeId } from "@memoize/wire";
+import type {
+  ChatId,
+  CodeAnnotation,
+  FolderId,
+  WorktreeId,
+} from "@memoize/wire";
+
+import { useChatsStore } from "./chats.ts";
 
 /**
  * Top-level renderer view. The settings page replaces the chat surface in the
@@ -57,12 +64,11 @@ export const SINGLETON_PANEL_KINDS: ReadonlySet<PanelKind> = new Set([
 
 /**
  * A panel tab in the right dock. `id` is a stable per-tab key used to
- * activate/close it. Terminal panels also carry a workspace-relative `slot`
- * (0-based) that resolves to the active workspace's Nth terminal instance at
- * render time — see `terminals.ts` `ensureSlot`. The dock layout is global
- * (one workbench arrangement); the four singletons are already context-aware
- * internally, and terminals stay correctly keyed by (folderId, worktreeId)
- * via the slot indirection.
+ * activate/close it. Terminal panels also carry a chat-relative `slot`
+ * (0-based) that resolves to the owning chat's Nth terminal instance at
+ * render time — see `terminals.ts` `ensureSlot`. The dock layout is per
+ * sidebar-chat (`rightPanelsByChat`), so each chat keeps its own set of open
+ * tabs and terminals; the singletons are context-aware internally.
  */
 export type PanelInstance =
   | { readonly id: string; readonly kind: "files" }
@@ -146,8 +152,9 @@ type UiState = {
   readonly leftSidebarPeek: boolean;
   readonly rightSidebarOpen: boolean;
   readonly isFullScreen: boolean;
-  readonly rightPanels: ReadonlyArray<PanelInstance>;
-  readonly activeRightPanelId: string | null;
+  /** Right-dock tab layout, scoped per sidebar-chat. */
+  readonly rightPanelsByChat: Record<string, ReadonlyArray<PanelInstance>>;
+  readonly activeRightPanelByChat: Record<string, string | null>;
   readonly revealedAnnotation: RevealedAnnotation | null;
   readonly setActiveMainTab: (tab: MainTab) => void;
   /** Open the Usage dashboard in the main pane at the given scope. */
@@ -172,15 +179,20 @@ type UiState = {
   /** Add a panel to the dock. Singletons that are already open are focused
    * instead of duplicated; terminals always append a new slot. */
   readonly addPanel: (kind: PanelKind) => void;
-  /** Add a terminal panel pinned to a SPECIFIC terminal-list slot (rather
-   * than the auto-computed next slot) and activate it. Used to surface a
-   * command terminal (e.g. Run) whose instance lives at a known list index. */
-  readonly addTerminalPanelForSlot: (slot: number) => void;
-  /** Remove a dock panel by id. Layout-only: callers that close a terminal
-   * panel must also drop its backing PTY instance (the active workspace key
-   * lives in the component layer). Re-indexes remaining terminal slots. */
+  /** Add a terminal panel to a SPECIFIC chat's dock, pinned to a known
+   * terminal-list slot (rather than the auto-computed next slot), and activate
+   * it. Used to surface a command terminal (e.g. Run) whose instance lives at a
+   * known list index — possibly in a chat that isn't currently selected. */
+  readonly addTerminalPanelForSlot: (chatId: ChatId, slot: number) => void;
+  /** Remove a dock panel by id from the active chat's layout. Layout-only:
+   * callers that close a terminal panel must also drop its backing PTY
+   * instance (`useTerminalsStore.remove`). Re-indexes remaining terminal
+   * slots. */
   readonly closePanel: (id: string) => void;
   readonly setActiveRightPanel: (id: string) => void;
+  /** Drop a chat's entire dock layout (on archive/delete). Terminal PTYs are
+   * disposed separately via `useTerminalsStore.disposeChat`. */
+  readonly clearChatPanels: (chatId: ChatId) => void;
   /** Open the sidebar and ensure a panel of `kind` is present + active.
    * Replaces the old `setRightSidebarOpen(true) + setActiveRightTab(kind)`
    * pairs. For terminals, focuses an existing one or adds a new slot. */
@@ -194,8 +206,8 @@ const newPanelId = (): string =>
   `p-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
 /** Renumber terminal panels' slots to stay contiguous (0..n-1) in tab order
- * after one is removed, so they keep mapping to the active workspace's
- * terminal list without gaps. */
+ * after one is removed, so they keep mapping to the owning chat's terminal
+ * list without gaps. */
 const reindexTerminalSlots = (
   panels: ReadonlyArray<PanelInstance>,
 ): ReadonlyArray<PanelInstance> => {
@@ -204,6 +216,28 @@ const reindexTerminalSlots = (
     p.kind === "terminal" ? { ...p, slot: next++ } : p,
   );
 };
+
+/** Stable empty reference so `rightPanelsByChat[chatId] ?? EMPTY_PANELS`
+ * doesn't churn selectors for chats with no dock layout yet. */
+export const EMPTY_PANELS: ReadonlyArray<PanelInstance> = [];
+
+/** The chat that owns the dock layout being mutated — always the selected
+ * one, since the dock only ever renders/edits the active chat. */
+const activeChatId = (): string | null =>
+  useChatsStore.getState().selectedChatId;
+
+const writePanels = (
+  state: UiState,
+  chatId: string,
+  panels: ReadonlyArray<PanelInstance>,
+  activeId: string | null,
+): Pick<UiState, "rightPanelsByChat" | "activeRightPanelByChat"> => ({
+  rightPanelsByChat: { ...state.rightPanelsByChat, [chatId]: panels },
+  activeRightPanelByChat: {
+    ...state.activeRightPanelByChat,
+    [chatId]: activeId,
+  },
+});
 
 export const useUiStore = create<UiState>((set, get) => ({
   view: "chat",
@@ -219,11 +253,12 @@ export const useUiStore = create<UiState>((set, get) => ({
   leftSidebarPeek: false,
   rightSidebarOpen: false,
   isFullScreen: false,
-  rightPanels: [],
-  activeRightPanelId: null,
+  rightPanelsByChat: {},
+  activeRightPanelByChat: {},
   revealedAnnotation: null,
   setActiveMainTab: (tab) => set({ activeMainTab: tab }),
-  openUsage: (scope) => set({ view: "chat", activeMainTab: "usage", usageScope: scope }),
+  openUsage: (scope) =>
+    set({ view: "chat", activeMainTab: "usage", usageScope: scope }),
   openFileInTab: (file) =>
     set({
       openFile:
@@ -242,59 +277,84 @@ export const useUiStore = create<UiState>((set, get) => ({
   // Opening the docked panel implicitly drops any peek state so the overlay
   // doesn't sit on top of the docked panel. Closing it also clears peek so a
   // stale hover doesn't immediately re-reveal the overlay.
-  setLeftSidebarOpen: (open) => set({ leftSidebarOpen: open, leftSidebarPeek: false }),
+  setLeftSidebarOpen: (open) =>
+    set({ leftSidebarOpen: open, leftSidebarPeek: false }),
   setLeftSidebarPeek: (peek) => set({ leftSidebarPeek: peek }),
   setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
   setFullScreen: (full) => set({ isFullScreen: full }),
   addPanel: (kind) =>
     set((s) => {
+      const chatId = activeChatId();
+      if (chatId === null) return s;
+      const panels = s.rightPanelsByChat[chatId] ?? EMPTY_PANELS;
       if (SINGLETON_PANEL_KINDS.has(kind)) {
-        const existing = s.rightPanels.find((p) => p.kind === kind);
+        const existing = panels.find((p) => p.kind === kind);
         if (existing !== undefined) {
-          return { activeRightPanelId: existing.id };
+          return {
+            activeRightPanelByChat: {
+              ...s.activeRightPanelByChat,
+              [chatId]: existing.id,
+            },
+          };
         }
         const panel = { id: newPanelId(), kind } as PanelInstance;
-        return {
-          rightPanels: [...s.rightPanels, panel],
-          activeRightPanelId: panel.id,
-        };
+        return writePanels(s, chatId, [...panels, panel], panel.id);
       }
       // terminal: append a new slot at the next contiguous index.
-      const slot = s.rightPanels.filter((p) => p.kind === "terminal").length;
+      const slot = panels.filter((p) => p.kind === "terminal").length;
       const panel: PanelInstance = { id: newPanelId(), kind: "terminal", slot };
-      return {
-        rightPanels: [...s.rightPanels, panel],
-        activeRightPanelId: panel.id,
-      };
+      return writePanels(s, chatId, [...panels, panel], panel.id);
     }),
-  addTerminalPanelForSlot: (slot) =>
+  addTerminalPanelForSlot: (chatId, slot) =>
     set((s) => {
+      const panels = s.rightPanelsByChat[chatId] ?? EMPTY_PANELS;
       const panel: PanelInstance = { id: newPanelId(), kind: "terminal", slot };
-      return {
-        rightPanels: [...s.rightPanels, panel],
-        activeRightPanelId: panel.id,
-      };
+      return writePanels(s, chatId, [...panels, panel], panel.id);
     }),
   closePanel: (id) =>
     set((s) => {
-      const idx = s.rightPanels.findIndex((p) => p.id === id);
+      const chatId = activeChatId();
+      if (chatId === null) return s;
+      const panels = s.rightPanelsByChat[chatId] ?? EMPTY_PANELS;
+      const idx = panels.findIndex((p) => p.id === id);
       if (idx === -1) return s;
-      const next = reindexTerminalSlots(
-        s.rightPanels.filter((p) => p.id !== id),
-      );
-      const wasActive = s.activeRightPanelId === id;
-      const activeRightPanelId = wasActive
+      const next = reindexTerminalSlots(panels.filter((p) => p.id !== id));
+      const wasActive = s.activeRightPanelByChat[chatId] === id;
+      const activeId = wasActive
         ? (next[Math.max(0, idx - 1)]?.id ?? next[0]?.id ?? null)
-        : s.activeRightPanelId;
-      return { rightPanels: next, activeRightPanelId };
+        : (s.activeRightPanelByChat[chatId] ?? null);
+      return writePanels(s, chatId, next, activeId);
     }),
-  setActiveRightPanel: (id) => set({ activeRightPanelId: id }),
+  setActiveRightPanel: (id) =>
+    set((s) => {
+      const chatId = activeChatId();
+      if (chatId === null) return s;
+      return {
+        activeRightPanelByChat: { ...s.activeRightPanelByChat, [chatId]: id },
+      };
+    }),
+  clearChatPanels: (chatId) =>
+    set((s) => {
+      const { [chatId]: _droppedPanels, ...rightPanelsByChat } =
+        s.rightPanelsByChat;
+      const { [chatId]: _droppedActive, ...activeRightPanelByChat } =
+        s.activeRightPanelByChat;
+      return { rightPanelsByChat, activeRightPanelByChat };
+    }),
   revealPanel: (kind) => {
     const s = get();
     if (!s.rightSidebarOpen) set({ rightSidebarOpen: true });
-    const existing = s.rightPanels.find((p) => p.kind === kind);
+    const chatId = activeChatId();
+    if (chatId === null) return;
+    const panels = s.rightPanelsByChat[chatId] ?? EMPTY_PANELS;
+    const existing = panels.find((p) => p.kind === kind);
     if (existing !== undefined) {
-      set({ activeRightPanelId: existing.id });
+      set((st) => ({
+        activeRightPanelByChat: {
+          ...st.activeRightPanelByChat,
+          [chatId]: existing.id,
+        },
+      }));
       return;
     }
     // No panel of this kind yet — add one (terminals add a fresh slot).

--- a/apps/renderer/src/store/worktrees.ts
+++ b/apps/renderer/src/store/worktrees.ts
@@ -11,6 +11,7 @@ import {
 import { toastManager } from "../components/ui/toast.tsx";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { openTerminalCommand } from "../lib/run-terminal.ts";
+import { useChatsStore } from "./chats.ts";
 import { useMessagesStore } from "./messages.ts";
 import { useRepositorySettingsStore } from "./repository-settings.ts";
 import { useSessionsStore } from "./sessions.ts";
@@ -80,11 +81,16 @@ const maybeAutoRun = async (projectId: FolderId, wt: Worktree) => {
     (await useRepositorySettingsStore.getState().refresh(projectId));
   if (settings?.autoRunAfterSetup !== true) return;
   if (wt.setupStatus !== "succeeded" && wt.setupStatus !== "skipped") return;
+  // Terminals are per chat — surface the auto-run in the chat that owns this
+  // worktree. Without one (none bound it), there's no dock to land it in.
+  const chat = (useChatsStore.getState().chatsByProject[projectId] ?? []).find(
+    (c) => c.worktreeId === wt.id,
+  );
+  if (chat === undefined) return;
   const run = await useWorktreesStore.getState().startRun(wt.id);
   if (run === null) return;
   openTerminalCommand({
-    folderId: projectId,
-    worktreeId: wt.id,
+    chatId: chat.id,
     cwd: run.cwd,
     title: "Run",
     command: { cmd: "/bin/zsh", args: ["-lc", run.script], env: run.env },


### PR DESCRIPTION
## Problem

Switching to another chat in the sidebar **killed a running terminal**, and the right-dock tab/terminal layout was shared across every chat. There was no per-chat isolation of "what tabs are open / how many terminals are running".

Three coupled root causes — fixing any one alone wasn't enough:

1. **Terminals were keyed by workspace** (`folderId + worktreeId`), not chat — so chats sharing a worktree shared shells.
2. **The right-dock tab layout was global** (`rightPanels` / `activeRightPanelId`) — every chat showed the same tabs.
3. **`PtyTerminal` killed its PTY on unmount** — so the single right pane re-rendering for a different chat terminated the shell.

## Fix

Isolation is scoped to the **sidebar chat** (confirmed direction: a chat's session-tabs share its dock/terminals, matching "chats own the worktree binding").

**New `apps/renderer/src/lib/terminal-registry.ts`** — a module-level registry that owns the xterm instance + PTY + output stream, keyed by terminal-instance id. The React component is now a thin host:
- `attach()` on mount — reconnects to the live shell (moves its DOM node in) or lazily spawns one.
- `detach()` on unmount — pulls the DOM out but **leaves the process + output stream running**, so a backgrounded chat's terminal keeps advancing.
- `dispose()` only on explicit close; a `pagehide` listener tears everything down on reload (preserves the old "PTYs die with the renderer" contract).

**Scoped per chat:**
- `terminals.ts` — keyed by `chatId`; `remove()` now disposes the PTY (unmount no longer does); added `disposeChat()`.
- `ui.ts` — `rightPanels`/`activeRightPanelId` → per-chat `rightPanelsByChat`/`activeRightPanelByChat`; panel actions resolve the active chat internally so call sites are unchanged; added `clearChatPanels()`.
- `right-pane.tsx` / `terminal-pane.tsx` — read the selected chat's panels + terminal list.
- `run-terminal.ts` + callers (`top-bar.tsx` Run, `worktrees.ts` auto-run) — the command terminal lands in the owning chat's dock.
- `chats.ts` — archiving/deleting a chat disposes its terminals and clears its dock layout (no leaks).

Also removed dead `TerminalWorkspace`/`TerminalList` code that still used the old 2-arg workspace key.

## Behavior note

A terminal in a **never-opened** background chat starts lazily on first view. Existing **running** terminals always survive chat switches — which is the actual bug being fixed.

## Verification

- `tsc --noEmit` clean; all 22 renderer tests pass; prettier clean.
- Manual: Chat A runs `top`/`ping`; switch to Chat B (independent, empty dock); return to A → process kept running with full scrollback. Closing a terminal tab kills only that shell; archiving a chat closes its PTYs.