### PR TITLE
Terminal: fix pane overflow, GPU rendering, thin cursor

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -34,6 +34,7 @@
     "@memoize/wire": "*",
     "@pierre/diffs": "^1.1.22",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -219,7 +219,7 @@ export function RightPane() {
           <AddPanelMenu addable={addableKinds(panels)} onAdd={addPanel} />
         </div>
       ) : null}
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         {panels.length === 0 ? (
           <PanelLauncher addable={addableKinds(panels)} onAdd={addPanel} />
         ) : null}
@@ -230,7 +230,7 @@ export function RightPane() {
             <div
               key={panel.id}
               hidden={panel.id !== effectiveActiveId}
-              className="flex min-h-0 flex-1 flex-col"
+              className="flex min-h-0 min-w-0 flex-1 flex-col"
             >
               <PanelBody
                 panel={panel}
@@ -244,7 +244,10 @@ export function RightPane() {
             browser tab open or the sidebar collapsed — a command then calls
             revealPanel("browser") to surface it. Mounting it only on add
             would drop commands issued while it's closed. */}
-        <div hidden={!browserActive} className="flex min-h-0 flex-1 flex-col">
+        <div
+          hidden={!browserActive}
+          className="flex min-h-0 min-w-0 flex-1 flex-col"
+        >
           <BrowserPane />
         </div>
       </div>

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -110,5 +110,10 @@ export function PtyTerminal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [instanceId]);
 
-  return <div ref={containerRef} className="h-full w-full bg-background p-2" />;
+  return (
+    <div
+      ref={containerRef}
+      className="h-full w-full min-w-0 overflow-hidden bg-background p-2"
+    />
+  );
 }

--- a/apps/renderer/src/lib/terminal-registry.ts
+++ b/apps/renderer/src/lib/terminal-registry.ts
@@ -1,6 +1,7 @@
 import { Effect, Fiber, Stream } from "effect";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
 
 import type { PtyId } from "@memoize/wire";
 
@@ -70,13 +71,16 @@ function makeLive(
     fontFamily:
       '"SF Mono", "JetBrains Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
     fontSize: 13,
-    lineHeight: 1.3,
+    lineHeight: 1.2,
     cursorBlink: true,
+    // Thin bar cursor (not the chunky block) so it reads as a clean accent.
+    cursorStyle: "bar",
+    cursorInactiveStyle: "bar",
     convertEol: false,
-    // Transparent canvas so the parent pane's `bg-background` shows through.
-    allowTransparency: true,
     theme: {
-      background: "rgba(0, 0, 0, 0)",
+      // Solid background matching the pane: lets the WebGL renderer draw
+      // cleanly and skips the per-frame cost of a transparent canvas.
+      background: readToken(host, "--background", "#0b0b0c"),
       foreground: readToken(host, "--foreground", "#e6e6e6"),
       cursor: readToken(host, "--primary", "#e6e6e6"),
       cursorAccent: readToken(host, "--background", "#0b0b0c"),
@@ -87,6 +91,17 @@ function makeLive(
   const fit = new FitAddon();
   term.loadAddon(fit);
   term.open(host);
+
+  // GPU renderer — keeps up with fast PTY output where the default DOM
+  // renderer stalls and visibly drops/garbles characters. Falls back to the
+  // DOM renderer automatically if the GL context is lost or unavailable.
+  try {
+    const webgl = new WebglAddon();
+    webgl.onContextLoss(() => webgl.dispose());
+    term.loadAddon(webgl);
+  } catch {
+    // No WebGL context (rare) — DOM renderer stays active.
+  }
 
   const live: LiveTerminal = {
     term,

--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "@memoize/wire": "*",
         "@pierre/diffs": "^1.1.22",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1343,6 +1344,8 @@
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "http://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
+
+    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.18.0", "http://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w=="],
 
     "@xterm/xterm": ["@xterm/xterm@5.5.0", "http://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 


### PR DESCRIPTION
Fixes three terminal issues. **Overflow:** the xterm canvas was forcing the right pane wider than its slot, so prompt lines ran off the right edge — adding `min-w-0`/`overflow-hidden` down the panel flex chain lets FitAddon size to the real pane width and keeps content inside. **Stuck/garbled output:** xterm ran on the default DOM renderer over a transparent canvas, which stalled under fast PTY throughput — switched to the WebGL renderer (auto-fallback on context loss) with a solid background. **Cursor:** replaced the chunky lime block with a thin bar (active + inactive) and tightened line height to 1.2 for a cleaner grid. Adds the `@xterm/addon-webgl` dependency (lockfile edited surgically to avoid unrelated version bumps).