### PR TITLE
[codex] Fix website changelog publishing

### DIFF
--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -1,8 +1,6 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-
 import { Container } from "@/components/container";
 import { Header } from "@/components/header";
+import changelogData from "@/content/changelog.json";
 import { getSEO } from "@/lib/seo";
 
 export const metadata = getSEO({
@@ -21,45 +19,8 @@ type ChangeRelease = {
   sections: ChangeSection[];
 };
 
-async function getChangelog(): Promise<ChangeRelease[]> {
-  const changelogPath = path.join(process.cwd(), "..", "..", "CHANGELOG.md");
-  const source = await readFile(changelogPath, "utf8");
-  const releases: ChangeRelease[] = [];
-  let currentRelease: ChangeRelease | null = null;
-  let currentSection: ChangeSection | null = null;
-
-  for (const line of source.split(/\r?\n/)) {
-    const releaseMatch = line.match(/^## \[([^\]]+)\]/);
-    if (releaseMatch) {
-      if (currentRelease) releases.push(currentRelease);
-      currentRelease = { version: releaseMatch[1] ?? "", sections: [] };
-      currentSection = null;
-      continue;
-    }
-
-    const sectionMatch = line.match(/^### (.+)$/);
-    if (sectionMatch && currentRelease) {
-      currentSection = { title: sectionMatch[1] ?? "", items: [] };
-      currentRelease.sections.push(currentSection);
-      continue;
-    }
-
-    if (line.startsWith("- ") && currentSection) {
-      currentSection.items.push(line.slice(2));
-    }
-  }
-
-  if (currentRelease) releases.push(currentRelease);
-
-  return releases.filter(
-    (release) =>
-      release.version !== "Unreleased" &&
-      release.sections.some((section) => section.items.length > 0),
-  );
-}
-
 export default async function ChangelogPage() {
-  const releases = await getChangelog();
+  const releases = changelogData as ChangeRelease[];
 
   return (
     <section className="w-full">

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,0 +1,388 @@
+[
+  {
+    "version": "0.7.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Surface supervised-mode permission prompts in sidebar and tabs (#184)",
+          "Render inline chat Edit diffs with @pierre/diffs library (#183)",
+          "Auto-scroll on send and cap tool box height (#182)",
+          "Fix false \"Requires Claude Pro\" gate for paid Claude logins (#179)",
+          "Add goal mode support for the Grok provider (#181)",
+          "Surface Claude auth failures as an in-app \"Sign in to Claude\" card (#180)",
+          "Compact composer trays into a unified pill stack (#178)",
+          "Cap collapsed tool row width (#176)",
+          "Unify composer + bubble pill styling (#175)",
+          "Auto-publish releases instead of drafts (#174)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.6.1",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "[codex] Fix queue resume after stop (#172)",
+          "Base new worktrees on origin's default branch, not stale local HEAD (#171)",
+          "Persist composer drafts (#168)",
+          "Dock-style hover-reveal for the left sidebar (#170)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.6.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Add tokenmaxer onboarding and usage fixes (#166)",
+          "Add multi-source token usage dashboard (#164)",
+          "Drive the agent browser with real input + a rendered cursor (#165)",
+          "[codex] Show active task in project plan header (#160)",
+          "Make release skill available to Claude and Codex (#163)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.5.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Worktree setup now streams live progress in the app, with a dedicated setup card and the Run action moved into the top bar for faster project startup. (#159)",
+          "The right sidebar can be customized as a panel dock, making terminal, browser, files, and supporting tools easier to arrange per workflow. (#156)",
+          "Codex goal mode is supported in chat sessions, giving agents a persistent objective and visible goal state during longer work. (#151)",
+          "Context window and usage-limit status popovers expose model usage and limit state without digging through raw provider output. (#154)",
+          "The website now has a direct download route for the latest signed macOS build. (#150)",
+          "Codex feature controls are gated by CLI capability, with fast mode surfaced only when the installed CLI can support it. (#158)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Worktree creation is faster, Pokemon chips are cleaner, and rare unlocks now appear as toasts instead of taking over the chip UI. (#157)",
+          "Code annotation composition and navigation are more polished, including clearer tray behavior and source reveal handling. (#153)",
+          "Loading states now use a simpler solid spinner treatment instead of the previous dotted loader set. (#155)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Claude sessions now initialize with the correct worktree current working directory, so prompts run in the intended workspace. (#161)",
+          "Project Plan tray parsing supports newer TaskCreate and TaskUpdate tool event shapes. (#152)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.4.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Worktree setup scripts can now run per project/worktree, giving agents a first-class way to prepare dependencies and local environment before starting work. (#126)",
+          "Mermaid diagrams render directly in markdown responses. (#128)",
+          "Chat titles and worktree branches can be generated from the first user message, making new agent runs easier to scan and easier to identify in git. (#129)",
+          "GPT-5.5 Codex is available in the Codex model picker. (#130)",
+          "Chat rows now include state icons for faster scanning across idle, running, and attention-needed sessions. (#132)",
+          "Agent completion sounds and deeper permission diagnostics make long-running work and blocked permission flows easier to notice and debug. (#133)",
+          "Agent message queue persistence keeps queued follow-up messages across renderer/server restarts and improves queue handling for multi-message agent workflows. (#136)",
+          "Chats now track read/unread state, with Next unread navigation for moving through updated sessions quickly. (#137)",
+          "Pokémon worktree Pokédex gives the new Pokémon-named worktree system a dedicated browsing surface. (#140)",
+          "Code annotations composer adds a richer composer path for referencing and annotating source code while prompting agents. (#141)",
+          "Public Memoize landing site. (#142)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Grok auth noise is hidden more aggressively and agent activity is grouped for a cleaner timeline. (#127)",
+          "Claude Ultracode UI is refined so the new model/provider controls fit the rest of the provider experience. (#131)",
+          "Loaders were standardized around a smoother circle/comet treatment. (#135)",
+          "Renderer iconography moved from Lucide to Hugeicons Pro, with real provider logos replacing generic marks. (#138)",
+          "Changes tab cleanup improves file selection, revert flows, conflict handling, and sidebar diff stats. (#139)",
+          "Renderer surfaces were cleaned up across the app for a tighter, more consistent desktop UI. (#143)",
+          "Renderer icons were polished after the Hugeicons migration. (#144)",
+          "Settings UI was cleaned up for a clearer, denser configuration experience. (#145)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Permission prompts are now delivered reliably mid-turn, preventing stuck or missed approval flows while an agent is running. (#134)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.3.3",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Claude provider updates: Opus 4.8 and Ultracode model options, plus plan mode now always routes edits through prompts. (#111)",
+          "ACP agents (Grok, Gemini, Cursor) can execute real terminal/output commands instead of rendering terminal requests as inert tool calls. (#112)",
+          "In-app agent browser control drives the existing Electron webview, so agents can navigate and inspect pages without opening a separate browser surface. (#117)",
+          "Top bar can now show live CI state and offers direct merge / auto-merge actions. (#113)",
+          "Provider cards surface available CLI updates for supported providers. (#114)",
+          "Claude fast mode toggle for faster lower-latency Claude sessions. (#119)",
+          "Archive cleanup scripts and related repository cleanup controls. (#120)",
+          "Repository branch toolbar for faster branch/context switching. (#124)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Markdown rendering is more polished and consistent in chat output. (#121)",
+          "Grok access detection now accepts X Premium+ / SuperGrok entitlements. (#122)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Grok sessions no longer abort mid-turn when the ACP child surfaces transient `AuthorizationRequired` noise inside `session/update` error frames while the turn is still completing normally. The shared ACP translator now filters that frame on the grok channel so in-flight prompts aren't rejected and the session doesn't flip to idle prematurely.",
+          "New chats run inside their selected worktree and create branches from a fresh `origin` base. (#115)",
+          "Codex tool translation handles the current tool event shape correctly. (#123)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.3.2",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Three-way \"add project\" menu (Open project / Open GitHub project / Quick start) with clone and create-project dialogs — templates Empty / Next.js / Turborepo and an optional private GitHub repo on create (gh-authed). (#104)",
+          "Project Plan tray docked above the composer: surfaces the agent's TodoWrite task list as a collapsible panel with an \"X of Y Done\" count and per-item status icons, reading the list from either the Claude (`tool_use` input) or Grok (`tool_result` output) shape. (#107)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Git-not-a-repo handling: a new `git.init` RPC and a shared \"Initialize Git repository\" CTA replace the raw error payload across the Changes, PR, and Diff tabs; the failure is classified inside the Effect (typed `GitNotARepoError`) so the CTA fires reliably, and the Diff view re-fetches immediately after an in-place init. (#104, #105)",
+          "A lone terminal now spans the full pane width; the terminal-list sidebar appears only once there are 2+ shells, with a floating hover-revealed `+` to add more. (#104)",
+          "Grok native tool results (`list_dir` / `grep` / `read` / `edit`) now render as clean rows — directory tree, grouped grep matches, file contents, and real diffs — instead of raw JSON envelopes or byte-array char codes. (#106)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Auto-update on macOS was stranded: `electron-updater` (Squirrel.Mac) needs a ZIP of the `.app`, but releases only shipped a DMG. Each release now ships a `zip/universal` target alongside the DMG, so auto-update works from 0.3.2 onward. (#108)",
+          "External (http/https) links now open in the system browser instead of hijacking the app window or spawning an in-app Chromium window; the Vite dev origin is whitelisted so HMR is unaffected. (#108)",
+          "Create-project dialog no longer crashes — the base-ui Checkbox hook error is gone, replaced with a native checkbox. (#105)",
+          "Files outside the project folder can be opened, edited, and saved via dedicated external-file RPCs, with clickable out-of-workspace file chips. (#105)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.3.1",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Multi-terminal sub-sidebar in the right pane: the Terminal tab now lists every terminal for the workspace with a `+` to spawn more, click-to-switch, and hover-X to close. All instances stay mounted so xterm scrollback and PTY connections survive switches, and closing the last terminal re-seeds a fresh one. (#95)",
+          "In-app Browser tab driven by an Electron `<webview>` with back/forward/refresh and a URL bar, sandboxed in its own process. Bare hosts default to `https://`, except `localhost`/`127.0.0.1` which default to `http://` for dev servers. (#95)",
+          "Standalone MCP server now wires up the full hybrid `code_search` pipeline (symbol + BM25 + vector + RRF + rerank) instead of the symbol-only stub, shared with `IndexService` via a single `search()` module. `index_status` reports populated blob/chunk/symbol/ref counts, and a new `reindex` tool exposes a full pass to agents. (#97)",
+          "ACP file-system handlers for `create_directory`, `delete_file`, and `move_file`, plus method aliases (`writeTextFile`, `mkdir`, `unlink`, `rename`, …) and flexible write payloads (`dataBase64` / `content` / `text` / `data`). (#98)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Creating a new chat session no longer freezes the UI for ~60s. The `+` on the tab strip now opens an instant tab backed by a loading panel while the provider CLI boots on a background daemon; sessions start in a `booting` state and flip to `idle`/`running` (or `error`) once the handshake completes. (#99)",
+          "Single source of truth for sensitive-path detection and FS-operation policy (read / write / create / delete / move), honoring runtime and permission modes, with every ACP mutation routed through it. (#98)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Grok agent reliability: a 4s startup grace window swallows transient `Auth(AuthorizationRequired)` stderr during cached-token refresh so the first message no longer shows a red error card; the worker now transparently respawns on death instead of asking you to close the chat; and MCP-style tool output is flattened so `read_file` results render as code instead of raw JSON. (#101)",
+          "Cursor driver: `cursor-agent` is prewarmed at boot (time-to-first-token 18s → 5.8s), the model picker uses ACP-valid slugs with aliases for old persisted settings, `session/load` resumes sessions (falling back to `session/new`), and tool-call frames are logged to `~/.cache/memoize/cursor.log` with arguments and tool names preserved across updates. (#96)",
+          "UX cluster: external links now open in the system browser instead of inside the app, switching a chat's worktree restarts member sessions in the new cwd, out-of-workspace file chips are flagged non-clickable with a tooltip, image attachments open inline in a tab, and Cmd+W closes the active file tab before falling through to archiving the chat tab. (#102)",
+          "Auto-acknowledge `ask_user_question` and `_x.ai` / `_google` namespaced ACP methods in the grok, gemini, and cursor drivers so interactive prompts no longer hang the agent turn. (#98)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.3.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "**App renamed to \"memoize Alpha\"** to signal that this build is pre-1.0 and may contain bugs. The bundle identifier (`app.memoize.desktop`) is unchanged, so existing installs auto-update to the renamed app in place. Dock title, About panel, and macOS app menu now read \"memoize Alpha\"; the in-app brand and CLI / URL scheme stay as `memoize`."
+        ]
+      },
+      {
+        "title": "Added",
+        "items": [
+          "Full-pane diff view in the file viewer with a Diff / Edit toggle, so reviewing a tool's edits no longer requires scrolling between two side-by-side columns. (#93)",
+          "Worktree UX overhaul: new worktrees are created outside the repo root (no more accidental nesting in `git status`), get Pokémon-themed names instead of UUIDs, and the new-chat panel opens instantly instead of waiting for the worktree to materialize. (#92)",
+          "Local code index (MVP 0.04) — phases A–F land together with auto-reindex on file change, giving the agent a fast structural view of the repo without re-walking the tree on every query. (#86)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Renderer now has a single source of truth for the active directory and branch, replacing the previous fan-out of duplicated state across panels. (#91)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Grok agent reliability on local login — the driver now uses the cached OAuth token instead of re-prompting on every session start. (#78)",
+          "Cursor driver: ACP now fails fast on auth errors instead of silently retrying, OAuth flow is wired end-to-end, the model list is refreshed on each session, and provider errors surface in the UI instead of being swallowed. (#90)",
+          "Settings writes occasionally raised `ENOENT` mid-rename when two writes raced. Writes through the config store are now serialized. (#89)",
+          "Provider boot crashes: codex no longer crashes when spawned without a TTY, missing cursor binaries surface a clear error, and claude/opencode gate correctly on availability. (#88)",
+          "Onboarding provider step tightened — copy now makes it clear that you pick a provider and go; no extra setup required. (#87)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.2.1",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "\"Check for Updates…\" menu item that reflects all 7 `electron-updater` states (idle / checking / available / downloading / ready / error / not-available), giving users a way back into the update flow after dismissing the toast. Sits in the macOS app menu and the top of Help on Windows/Linux. About panel gets version + copyright; Help menu gains \"View Changelog\" and \"Report an Issue\"; DevTools / Force Reload move into a `Developer ▸` submenu that only appears in dev builds. (#84)",
+          "One-click Cursor sign-in. New `agent.startLogin` streaming RPC spawns `cursor-agent login`, extracts the OAuth URL, and emits `LoginEvent`s; the renderer card replaces the old copy-and-run flow with a button that opens the URL via `shell.openExternal`, shows progress, and refreshes availability on success. (#83)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Auto-update downloads that stalled mid-way were silent — `electron-updater` fires no \"stuck\" event. Added a 60s download-stall watchdog with one-shot auto-retry that then surfaces a retryable `error` state; the update banner now renders the `error` state with a \"Try again\" button and un-dismisses itself when status flips to error. (#84)",
+          "Cursor authentication detection was trusting the existence of `~/.local/share/cursor-agent/` as proof of login, but that directory is created on install and just holds the CLI bundle — so every fresh install was flagged as signed in. Now probes `cursor-agent status` and parses the output. The blanket \"Requires Cursor Pro\" badge was dropped since the CLI has no whoami; the ACP server enforces the real plan check at session start. ACP auth waterfall in the cursor driver now throws a clear \"not signed in\" error instead of silently retrying `cursor_login` and timing out. (#83)",
+          "Folder picker hid every dotfile directory (`~/.claude`, `~/.config`, `~/.ssh`, …) on macOS because the Electron open dialog was missing `showHiddenFiles`, making any folder under a hidden parent unreachable. The picker also now defaults to the user's home directory instead of the process cwd, so it opens somewhere useful on first launch. (#82)",
+          "Broken `github.com/forkzero/memoize` repository URL in the native menu. (#84)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.2.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "xAI Grok provider via the Agent Client Protocol (ACP). Picker exposes Grok models alongside Claude/Codex; sessions stream through the shared ACP transport with the same permission/tool plumbing as the other ACP providers. (#64)",
+          "Gemini CLI provider. Adds Google's `gemini` CLI as a first-class driver; ACP v2 response types and tool-call normalization land in the same pass so tool results render correctly in the timeline. (#67)",
+          "Cursor Agent provider via ACP. (#69)",
+          "opencode provider with dynamic model inventory + variants. Models are fetched at runtime from the opencode catalog instead of being hardcoded, and the picker surfaces per-model variants. (#75)",
+          "Canonical tool translator for opencode. Provider-specific tool shapes are mapped to memoize's canonical schema, `ToolUse` events are deduplicated, and stale user-echo messages are dropped from the stream so the timeline matches what other providers produce. (#77)",
+          "User-editable keybindings backed by an on-disk config store. Settings → Keyboard shortcuts now writes through to a JSON config file; rebinds persist across launches and survive app upgrades. (#71)",
+          "Unified ACP translator + per-model capabilities + reliable interrupt. All ACP-based providers (Grok, Gemini, Cursor, opencode) share a single translator that normalizes streamed events into canonical timeline items; per-model capability metadata gates features like images/tools at the picker; interrupt now reliably halts in-flight ACP turns instead of leaving zombie streams. (#72)",
+          "Rich model picker: search, recents, provider chips, collapsible accordion sections, and stable `Cmd+1`–`Cmd+9` shortcuts that always map to the same top-pinned slots regardless of filter state. (#80)",
+          "Loading affordances during chat create + per-tab streaming. Creating a new chat now shows immediate feedback while the session boots, and streaming state is tracked per-tab so background tabs keep streaming while the foreground tab is interactive. (#66)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Settings redesigned with a minimal frame and a lime accent. Rows are tighter, section headers are quieter, and the new primary color flows through buttons, focus rings, and toggle states. (#73)",
+          "Top bar gains glass workflow buttons and inline \"Fix\" actions when CI is failing — the buttons read the latest run status and offer a one-click flow to push a fix branch. (#74)",
+          "README rewritten end-to-end as a full memoize project overview (what it is, providers, install, contributing). (#76)",
+          "UI polish pass: empty-state model picker matches the populated state, and Read/Edit tool result visuals now render diffs and file context in line with the rest of the timeline. (#79)",
+          "Provider diffs cleaned up in the renderer so per-provider streams normalize into the shared timeline without provider-specific branches in UI code. (#68)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Sessions with NULL `chat_id` rows (left over from the 0.1.4 chats migration on some installs) are healed on startup and the column is now `NOT NULL` at the schema level, so the nested-tab UX can't fall back into a broken state. (#70)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.1.4",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Native macOS menu bar with keyboard shortcuts: new chat (⌘N), open project (⌘O), settings (⌘,), toggle sidebars (⌘B / ⌘⌥B), toggle terminal (⌘J), focus composer (⌘L). Bindings are listed in Settings → Keyboard shortcuts (single source of truth in `lib/shortcuts.ts`) and surfaced inline on the relevant button tooltips. (#59)",
+          "In-app update toast. Drives `electron-updater` manually instead of `checkForUpdatesAndNotify`; the bottom-right toast offers Later / Install on quit / Update now, downloads only after the user picks, and auto-installs once the download lands. Lifecycle events flow through a new `window.memoize.updates` bridge and shared `UpdateStatus` in `@memoize/wire`. (#61)",
+          "Cross-provider switching on fresh chats. `ModelPicker` lets you pick a model from the other provider as long as the chat has no user message yet; a new `session.setProvider` RPC mirrors `setWorktree`'s fresh-session gate. The teardown path was split so `setModel` / `setProvider` / `resumeSession` only interrupt the provider event-pump fiber, keeping the renderer's `messages.stream` and `session.streamStatus` subscriptions alive across the swap. (#60)",
+          "Codex app-server slash commands. (#62)",
+          "Nested-tab chat UX. Sidebar rows become \"chats\" (a new container table); the tab strip in the main pane shows that chat's sessions as peer tabs, \"+\" adds a session to the active chat, and ⌘W closes the active tab via Electron menu → IPC and archives the session (auto-spawning a fresh one if it was the last). Migration 0011 backfills one chat per existing top-level session and rehomes v3 children. Adds `forked_from_session_id` / `forked_from_message_id` columns for a future fork-from-message feature. (#63)",
+          "Codex session resume. The driver captures the codex thread id from `thread.started` and persists it as the session's resume cursor; `Codex.resumeThread(id, opts)` reattaches on next start. Codex doesn't replay prior items on resume — the renderer's persisted timeline remains the source of truth for what came before. Wire schema gained a `\"codex-thread-id\"` resume strategy alongside the existing `\"claude-session-id\"`. (#57)",
+          "Codex image attachments. Image refs (`png`, `jpeg`, `gif`, `webp`) attached to a turn are forwarded to `runStreamed` as `local_image` items pointing at the on-disk blob; non-image refs are dropped with a warn. `AttachmentService` gained a `readPath` method so the driver can hand the SDK a file path instead of re-encoding bytes. (#57)",
+          "Codex plan mode. The chat-header chip flipped the wire but the codex driver was hardcoded to read-only — now `plan` → codex `sandboxMode: \"read-only\"` and `default` / `acceptEdits` → `workspace-write`. Live toggle is implemented as `codex.resumeThread(currentId, newOptions)` since the SDK has no live sandbox-update API; the rebuild is chained onto the per-thread send queue so a toggle mid-turn doesn't race an in-flight `runStreamed`. (#57)",
+          "Codex CLI upgrade banner. Provider availability probe now reports `cliVersionStatus` (\"ok\" | \"outdated\" | \"unknown\") plus a per-provider upgrade command; an inline banner above the composer prompts the user to upgrade when the installed codex CLI is below the SDK's pinned floor (currently 0.128.0). (#57)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Cleaner alert surfaces across `Alert`, `ErrorBubble`, `ToolErrorRow`, `CliUpgradeBanner`, `FileEditor` conflict banner, `TerminalBlock` / `PreBlock` errors, and `ErrorPill`. New dedicated tokens (`--alert-error-bg`, `--alert-warning-bg`, `--alert-info-bg`, `--alert-success-bg`) replace the loud red/yellow/amber borders + washes with soft warm-tinted card surfaces. (#58)",
+          "Tooltip popups restyled with a frosted-glass look (translucent fill + backdrop blur). (#59)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Codex CLI 0.130+ rejected `gpt-5-codex` (and bare `gpt-5`) for ChatGPT-account users; sessions died at start with a 400. Picker now uses current codex model names (`gpt-5.4` default, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`) and `resolveModelSlug` aliases stale slugs through to `gpt-5.4` at both renderer load and codex driver boundaries, so an in-flight resume can't punch the bad slug through. (#58)",
+          "Codex turn end no longer left the renderer composer stuck in \"loading\". `turn.completed` / `turn.failed` and the `runTurn` catch now emit `Status: idle`. (#57)",
+          "Codex sessions on older `codex` CLIs failed with \"Codex Exec exited with code 2: error: unexpected argument '--experimental-json' found\". codex-sdk@0.128 hard-codes that flag; pre-0.128 binaries reject it. The server now probes `codex --version` before starting and the renderer's `CliUpgradeBanner` surfaces a friendly upgrade card; if the user sends anyway, the SDK trace is intercepted and replaced with a single-sentence chat error. (#57)"
+        ]
+      },
+      {
+        "title": "Known limitations (Codex SDK 0.128)",
+        "items": [
+          "No interactive permission prompts on Codex. The SDK exposes `approvalPolicy` as static config but no JS callback to bridge approvals into memoize's toast, so codex sessions stay on `approvalPolicy: \"never\"` regardless of mode. Plan-mode (read-only) is the only user-facing lever; default/acceptEdits both run with full workspace-write and no prompts.",
+          "No cross-provider sub-agents on Codex. `input.agents` is still ignored — Codex SDK has no `mcpServers` config, so the cross-provider bridge sketched in `specs/sub-agents/decisions/0012-codex-bridge-via-mcp.md` lands as a follow-up PR."
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.1.2",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Packaged macOS app failed to start Codex sessions with \"Unable to locate Codex CLI binaries. Ensure @openai/codex is installed with optional dependencies.\" Same shape as the 0.1.1 Claude fix: we don't ship the SDK's bundled native CLI, so the SDK now receives `codexPathOverride` pointing at the user's installed `codex` binary (`which codex`, with the same `fix-path`-expanded PATH). Surfaces a clean \"Codex CLI not found on PATH\" message when the binary genuinely isn't installed."
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.1.1",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Packaged macOS app could not start new Claude sessions (\"Native CLI binary for darwin-arm64 not found\"). GUI-launched apps inherit a minimal PATH, so `which claude` never found the user's installed Claude Code binary and the SDK fell back to a bundled native CLI we don't ship. The main process now expands PATH from the user's login shell (via `fix-path`) before the runtime boots, and the server fails with a clear \"Claude Code CLI not found on PATH\" message when the binary genuinely isn't installed."
+        ]
+      }
+    ]
+  },
+  {
+    "version": "0.1.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "First public macOS build: signed + notarized universal `.dmg` (Apple Silicon + Intel) distributed via GitHub Releases.",
+          "In-app auto-update via `electron-updater` against the GitHub Releases feed.",
+          "Tag-driven CI release workflow (`v*` tags publish a draft release with the `.dmg`, `latest-mac.yml`, and blockmap)."
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Locked the macOS app to the dark appearance variant so vibrancy no longer follows the user's system theme — fixes the \"faded UI on a light-mode Mac\" look.",
+          "Rebranded from `forkzero` to `memoize` (app name, custom protocol scheme, package names)."
+        ]
+      }
+    ]
+  }
+]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3001",
-    "build": "next build",
+    "dev": "node ../../scripts/generate-website-changelog.mjs && next dev --port 3001",
+    "build": "node ../../scripts/generate-website-changelog.mjs && next build",
     "start": "next start --port 3001",
     "lint": "eslint",
     "check-types": "tsc --noEmit"

--- a/scripts/generate-website-changelog.mjs
+++ b/scripts/generate-website-changelog.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const changelogPath = join(root, "CHANGELOG.md");
+const outputPath = join(root, "apps/web/content/changelog.json");
+
+function parseChangelog(source) {
+  const releases = [];
+  let currentRelease = null;
+  let currentSection = null;
+
+  for (const line of source.split(/\r?\n/)) {
+    const releaseMatch = line.match(/^## \[([^\]]+)\]/);
+    if (releaseMatch) {
+      if (currentRelease) releases.push(currentRelease);
+      currentRelease = { version: releaseMatch[1] ?? "", sections: [] };
+      currentSection = null;
+      continue;
+    }
+
+    const sectionMatch = line.match(/^### (.+)$/);
+    if (sectionMatch && currentRelease) {
+      currentSection = { title: sectionMatch[1] ?? "", items: [] };
+      currentRelease.sections.push(currentSection);
+      continue;
+    }
+
+    if (line.startsWith("- ") && currentSection) {
+      currentSection.items.push(line.slice(2));
+    }
+  }
+
+  if (currentRelease) releases.push(currentRelease);
+
+  return releases.filter(
+    (release) =>
+      release.version !== "Unreleased" &&
+      release.sections.some((section) => section.items.length > 0),
+  );
+}
+
+const releases = parseChangelog(readFileSync(changelogPath, "utf8"));
+writeFileSync(outputPath, `${JSON.stringify(releases, null, 2)}\n`);
+console.log(`Wrote ${releases.length} changelog releases to ${outputPath}`);

--- a/scripts/release-new-version.mjs
+++ b/scripts/release-new-version.mjs
@@ -149,6 +149,7 @@ if (!changelog.includes(`## [${nextVersion}]`)) {
   );
 }
 
+run("node", ["scripts/generate-website-changelog.mjs"]);
 run("bun", ["run", "check-types"]);
 run("git", ["add", "CHANGELOG.md", "apps/desktop/package.json", "bun.lock", "apps/web", "scripts/release-new-version.mjs", ".codex/skills/release-new-version"]);
 run("git", ["commit", "-m", `Release v${nextVersion}`]);

--- a/scripts/sync-github-release-notes.mjs
+++ b/scripts/sync-github-release-notes.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const dryRun = process.argv.includes("--dry-run");
+const all = process.argv.includes("--all");
+const explicitTag = readArg("--tag") ?? process.env.GITHUB_REF_NAME;
+const explicitRepo = readArg("--repo") ?? process.env.GITHUB_REPOSITORY;
+
+function readArg(name) {
+  const prefix = `${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: options.stdio ?? "pipe",
+  });
+}
+
+function normalizeTag(tag) {
+  if (!tag) return undefined;
+  return tag.startsWith("refs/tags/") ? tag.slice("refs/tags/".length) : tag;
+}
+
+function versionFromTag(tag) {
+  const normalized = normalizeTag(tag);
+  const match = normalized?.match(/^v?(\d+\.\d+\.\d+)$/);
+  if (!match) {
+    throw new Error(`Expected a semver tag like v0.7.0, got ${tag}`);
+  }
+  return match[1];
+}
+
+function changelogVersions(source) {
+  return [...source.matchAll(/^## \[([^\]]+)\]/gm)]
+    .map((match) => match[1])
+    .filter((version) => version && version !== "Unreleased");
+}
+
+function extractChangelogSection(source, version) {
+  const lines = source.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `## [${version}]`);
+  if (start < 0) {
+    throw new Error(`CHANGELOG.md does not contain release notes for ${version}`);
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && line.startsWith("## ["),
+  );
+  const section = lines
+    .slice(start + 1, end < 0 ? undefined : end)
+    .join("\n")
+    .trim();
+  if (!section) {
+    throw new Error(`CHANGELOG.md does not contain release notes for ${version}`);
+  }
+  return section;
+}
+
+function repoSlug() {
+  if (explicitRepo) return explicitRepo;
+
+  const remote = git(["config", "--get", "remote.origin.url"]);
+  const match =
+    remote.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/) ??
+    remote.match(/^git@github\.com:([^/]+\/[^/.]+)(?:\.git)?$/);
+  if (!match?.[1]) {
+    throw new Error(
+      "Could not infer GitHub repository. Pass --repo=owner/name or set GITHUB_REPOSITORY.",
+    );
+  }
+  return match[1];
+}
+
+function versionTags() {
+  return git(["tag", "--list", "v*", "--sort=version:refname"])
+    .split("\n")
+    .filter(Boolean);
+}
+
+function previousTagFor(tag) {
+  const tags = versionTags();
+  const index = tags.indexOf(tag);
+  if (index <= 0) return undefined;
+  return tags[index - 1];
+}
+
+function renderReleaseBody({ repo, tag, version, section }) {
+  const previousTag = previousTagFor(tag);
+  const lines = [`## What's new in ${version}`, "", section];
+
+  if (previousTag) {
+    lines.push(
+      "",
+      "---",
+      `**Full Changelog:** https://github.com/${repo}/compare/${previousTag}...${tag}`,
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function releaseBodyForTag(tag, source, repo) {
+  const version = versionFromTag(tag);
+  return renderReleaseBody({
+    repo,
+    tag,
+    version,
+    section: extractChangelogSection(source, version),
+  });
+}
+
+function updateRelease({ tag, body }) {
+  if (dryRun) {
+    console.log(`\n=== ${tag} ===\n${body}`);
+    return;
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), "memoize-release-notes-"));
+  const notesFile = join(dir, `${tag}.md`);
+  try {
+    writeFileSync(notesFile, body);
+    run("gh", ["release", "edit", tag, "--notes-file", notesFile], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+const tag = normalizeTag(explicitTag);
+if (!all && !tag) {
+  throw new Error("Pass --tag=vX.Y.Z, set GITHUB_REF_NAME, or use --all.");
+}
+
+const source = await readFile(join(root, "CHANGELOG.md"), "utf8");
+const repo = repoSlug();
+const tags = all
+  ? changelogVersions(source)
+      .map((version) => `v${version}`)
+      .reverse()
+  : [tag];
+
+for (const releaseTag of tags) {
+  const body = await releaseBodyForTag(releaseTag, source, repo);
+  updateRelease({ tag: releaseTag, body });
+}


### PR DESCRIPTION
## Summary
- generate deploy-safe website changelog data from root CHANGELOG.md
- render /changelog from checked-in JSON instead of reading ../../CHANGELOG.md at runtime
- add release-note sync helpers for website changelog generation and GitHub Release body backfills

## Root Cause
The website changelog route read CHANGELOG.md through process.cwd() at runtime. In deployment, the web app may not have the monorepo root file at that relative path, so the route could miss release entries even though CHANGELOG.md was populated.

## Notes
- .github/workflows/release.yml is intentionally unchanged; the local workflow edit was reverted before this PR.
- Existing dirty bun.lock changes were not included.

## Validation
- node --check scripts/generate-website-changelog.mjs
- node --check scripts/sync-github-release-notes.mjs
- node scripts/generate-website-changelog.mjs wrote 15 releases
- curl http://localhost:3001/changelog showed 0.7.0, 0.3.2, and release-note text

## Known Existing Failure
- bun run --cwd apps/web check-types still fails in existing blog/Fumadocs typing: missing collections/server and blog metadata fields such as date, timeToRead, previewImage.
