### PR TITLE
[codex] Fix Claude result error classification

### DIFF
--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -443,9 +443,10 @@ export const looksLikeClaudeAuthFailure = (text: string): boolean =>
   CLAUDE_AUTH_FAILURE_PATTERN.test(text);
 
 /**
- * Pull the human-readable error text out of a `result` message. The SDK splits
- * results into a success shape (`result: string`, may still carry
- * `is_error`/`api_error_status`) and an error shape (`errors: string[]`).
+ * Pull the human-readable error text out of a `result` message. Treat only
+ * explicit failure signals as provider errors. Claude can return assistant
+ * prose in `result` even when `subtype` is not exactly `"success"`; rendering
+ * that prose as an Error creates a bogus "Provider error" bubble.
  */
 export const claudeResultErrorText = (msg: SDKMessage): string | null => {
   const m = msg as {
@@ -457,14 +458,22 @@ export const claudeResultErrorText = (msg: SDKMessage): string | null => {
   };
   const status =
     typeof m.api_error_status === "number" ? m.api_error_status : null;
-  const isError =
-    m.is_error === true ||
-    (typeof m.subtype === "string" && m.subtype !== "success") ||
-    (status !== null && status >= 400);
-  if (!isError) return null;
   const errors = Array.isArray(m.errors)
     ? m.errors.filter((e): e is string => typeof e === "string")
     : [];
+  const isError =
+    m.is_error === true ||
+    errors.length > 0 ||
+    (status !== null && status >= 400);
+  if (!isError) {
+    const subtype = typeof m.subtype === "string" ? m.subtype : "";
+    const hasResult =
+      typeof m.result === "string" && m.result.trim().length > 0;
+    if (subtype.startsWith("error") && !hasResult) {
+      return "The agent run ended with an error.";
+    }
+    return null;
+  }
   const parts: string[] = [];
   if (typeof m.result === "string" && m.result.trim().length > 0) {
     parts.push(m.result.trim());
@@ -904,7 +913,7 @@ const translate = (
         out.push({ _tag: "Error", message: resultError });
       }
       out.push(
-        msg.subtype === "success" && resultError === null
+        resultError === null
           ? { _tag: "Completed", reason: "ended" }
           : { _tag: "Completed", reason: "error" },
       );

--- a/apps/server/test/claude-auth-detection.test.ts
+++ b/apps/server/test/claude-auth-detection.test.ts
@@ -65,4 +65,24 @@ describe("claudeResultErrorText", () => {
     } as never);
     expect(text).toBe("Not logged in\nPlease run /login");
   });
+
+  it("does not treat answer text on a non-success subtype as a provider error", () => {
+    expect(
+      claudeResultErrorText({
+        type: "result",
+        subtype: "error_during_execution",
+        result:
+          "Two good questions, and the first one has an important gotcha.",
+      } as never),
+    ).toBeNull();
+  });
+
+  it("keeps a generic error for an error subtype with no answer text", () => {
+    expect(
+      claudeResultErrorText({
+        type: "result",
+        subtype: "error_during_execution",
+      } as never),
+    ).toBe("The agent run ended with an error.");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a Claude provider regression where useful assistant prose in a Claude SDK `result` payload could be persisted as a provider error and rendered under the generic “Provider error” banner.

## Root Cause

The Claude result classifier treated any `result` message whose `subtype` was not exactly `success` as an error. Recent Claude runs can still include normal assistant answer text in `result` even when the subtype is non-success-shaped, which caused valid answers to be stored as error rows.

## Changes

- Classify Claude result messages as provider errors only when explicit failure signals are present: `is_error`, `errors[]`, or `api_error_status >= 400`.
- Preserve a generic provider error for empty error-subtype results.
- Treat non-success result payloads with answer text and no explicit error fields as completed turns.
- Add regression tests for the misclassified-answer case and the empty-error case.

## Validation

- `bun test apps/server/test/claude-auth-detection.test.ts`
- `bun run --cwd apps/server check-types`