### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1]
+
+### Changed
+- [codex] Fix Claude result error classification (#195)
+- [codex] Fix website changelog publishing (#194)
+- [codex] Optimize Pokédex page (#193)
+- Terminal: fix pane overflow, GPU rendering, thin cursor (#192)
+- Add app-wide motion system to the renderer (#188)
+- Keyboard navigation: tabs, chats, panels, panes + Cmd+K chat switcher (#191)
+- Isolate terminals & dock tabs per chat, keep shells running across switches (#190)
+- Cap turn-summary file chips with collapsible +N more toggle (#189)
+- Render sub-agent summary as markdown (#187)
+- Move plan Approve/Cancel into a pinned bar above the composer (#186)
+
 ## [0.7.0]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "memoize Alpha",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "memoize desktop app",
   "private": true,
   "author": {

--- a/apps/renderer/src/components/ui/otp-field.tsx
+++ b/apps/renderer/src/components/ui/otp-field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { OTPFieldPreview as OTPFieldPrimitive } from "@base-ui/react/otp-field";
+import { OTPField as OTPFieldPrimitive } from "@base-ui/react/otp-field";
 import type * as React from "react";
 import { cn } from "~/lib/utils";
 import { Separator } from "~/components/ui/separator";

--- a/apps/renderer/src/lib/commands.ts
+++ b/apps/renderer/src/lib/commands.ts
@@ -97,10 +97,13 @@ function stepChat(delta: 1 | -1): void {
  *  right sidebar first if it's collapsed. */
 function stepPanel(delta: 1 | -1): void {
   const ui = useUiStore.getState();
-  const panels = ui.rightPanels;
+  const chatId = currentChatId();
+  if (chatId === null) return;
+  const panels = ui.rightPanelsByChat[chatId] ?? [];
   if (panels.length === 0) return;
   if (!ui.rightSidebarOpen) ui.setRightSidebarOpen(true);
-  const idx = panels.findIndex((p) => p.id === ui.activeRightPanelId);
+  const activeId = ui.activeRightPanelByChat[chatId] ?? null;
+  const idx = panels.findIndex((p) => p.id === activeId);
   const base = idx === -1 ? 0 : idx;
   const next = (base + delta + panels.length) % panels.length;
   ui.setActiveRightPanel(panels[next]!.id);

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,25 @@
 [
   {
+    "version": "0.7.1",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "[codex] Fix Claude result error classification (#195)",
+          "[codex] Fix website changelog publishing (#194)",
+          "[codex] Optimize Pokédex page (#193)",
+          "Terminal: fix pane overflow, GPU rendering, thin cursor (#192)",
+          "Add app-wide motion system to the renderer (#188)",
+          "Keyboard navigation: tabs, chats, panels, panes + Cmd+K chat switcher (#191)",
+          "Isolate terminals & dock tabs per chat, keep shells running across switches (#190)",
+          "Cap turn-summary file chips with collapsible +N more toggle (#189)",
+          "Render sub-agent summary as markdown (#187)",
+          "Move plan Approve/Cancel into a pinned bar above the composer (#186)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.7.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release memoize v0.7.1
- update CHANGELOG.md, apps/desktop package metadata, bun.lock, and website changelog JSON
- include the Claude result error classification fix in the release notes
- fix two renderer typecheck issues required for the release check to pass

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.7.1 after this PR lands.