### PR TITLE
Allow force-archiving a chat with a dirty worktree

### DIFF
--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -41,7 +41,11 @@ import { cn, formatCompactNumber } from "~/lib/utils";
 import { noteSessionStatusForCompletionSound } from "../lib/completion-sounds.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
-import { isChatUnread, useChatsStore } from "../store/chats.ts";
+import {
+  archiveChatWithConfirm,
+  isChatUnread,
+  useChatsStore,
+} from "../store/chats.ts";
 import { usePermissionsStore } from "../store/permissions.ts";
 import { gitDiffStatKey, useGitDiffStatStore } from "../store/git-diff-stat.ts";
 import { useMessagesStore } from "../store/messages.ts";
@@ -806,7 +810,6 @@ function ChatRow({ chat }: { chat: Chat }) {
 
   const selectChat = useChatsStore((s) => s.select);
   const renameChat = useChatsStore((s) => s.rename);
-  const archiveChat = useChatsStore((s) => s.archive);
   const unarchiveChat = useChatsStore((s) => s.unarchive);
   const removeChat = useChatsStore((s) => s.remove);
 
@@ -1006,7 +1009,9 @@ function ChatRow({ chat }: { chat: Chat }) {
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              void (isArchived ? unarchiveChat(chat.id) : archiveChat(chat.id));
+              void (isArchived
+                ? unarchiveChat(chat.id)
+                : archiveChatWithConfirm(chat.id));
             }}
             className="hidden items-center rounded p-0.5 text-muted-foreground transition-opacity duration-150 ease-out hover:text-sidebar-accent-foreground group-hover:flex motion-reduce:transition-none"
             aria-label={`${primaryActionLabel} ${chat.title}`}
@@ -1040,7 +1045,7 @@ function ChatRow({ chat }: { chat: Chat }) {
             </MenuItem>
           ) : (
             <MenuItem
-              onClick={() => void archiveChat(chat.id)}
+              onClick={() => void archiveChatWithConfirm(chat.id)}
               className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
             >
               <HugeiconsIcon icon={ArchiveArrowDownIcon} className="size-3.5" />

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -51,7 +51,7 @@ import {
 } from "./glass-action.tsx";
 import { TooltipShortcut } from "./projects-sidebar.tsx";
 import { useActiveContext } from "../store/active-workspace.ts";
-import { useChatsStore } from "../store/chats.ts";
+import { archiveChatWithConfirm, useChatsStore } from "../store/chats.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { useMergePrefs } from "../store/merge-prefs.ts";
 import { useMessagesStore } from "../store/messages.ts";
@@ -888,7 +888,6 @@ export function TopBarRight() {
   );
   const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
   const selectedChatId = useChatsStore((s) => s.selectedChatId);
-  const archiveChat = useChatsStore((s) => s.archive);
   const setActiveMainTab = useUiStore((s) => s.setActiveMainTab);
 
   // Auto-submit a new chat message to the active session (no manual Send).
@@ -968,7 +967,7 @@ export function TopBarRight() {
             icon={<HugeiconsIcon icon={ArchiveArrowDownIcon} />}
             label="Archive chat"
             loadingLabel="Archiving…"
-            run={() => archiveChat(selectedChatId)}
+            run={() => archiveChatWithConfirm(selectedChatId)}
           />
         ) : null}
         {workflow.kind === "open-pr" && workflow.mergeable === "conflicting" ? (

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -72,7 +72,13 @@ type ChatsState = {
     chatId: ChatId,
     sessionId: SessionId,
   ) => Promise<void>;
-  readonly archive: (chatId: ChatId) => Promise<void>;
+  readonly archive: (
+    chatId: ChatId,
+    force?: boolean,
+  ) => Promise<
+    | { readonly ok: true }
+    | { readonly ok: false; readonly dirty: boolean; readonly reason: string }
+  >;
   readonly unarchive: (chatId: ChatId) => Promise<void>;
   readonly remove: (chatId: ChatId) => Promise<void>;
   readonly select: (chatId: ChatId | null) => void;
@@ -368,11 +374,13 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
       set({ error: formatError(err) });
     }
   },
-  archive: async (chatId) => {
+  archive: async (chatId, force = false) => {
     set({ error: null });
     try {
       const client = await getRpcClient();
-      const result = await Effect.runPromise(client.chat.archive({ chatId }));
+      const result = await Effect.runPromise(
+        client.chat.archive({ chatId, force }),
+      );
       const projectId = findChatProject(get().chatsByProject, chatId);
       if (projectId !== null) {
         set((s) => {
@@ -426,8 +434,19 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
       // layout so an archived chat leaks no shells or tab state.
       useTerminalsStore.getState().disposeChat(chatId);
       useUiStore.getState().clearChatPanels(chatId);
+      return { ok: true } as const;
     } catch (err) {
-      set({ error: formatError(err) });
+      const reason = formatError(err);
+      // A dirty worktree blocks removal; the caller can re-issue with
+      // `force: true` after confirming the discard with the user.
+      const dirty =
+        !force &&
+        (reason.includes("WorktreeDirtyError") ||
+          reason.toLowerCase().includes("dirty"));
+      // Keep the dirty case out of the global error banner — the caller owns
+      // the confirm-and-retry flow. Surface every other failure as before.
+      set({ error: dirty ? null : reason });
+      return { ok: false, dirty, reason } as const;
     }
   },
   unarchive: async (chatId) => {
@@ -657,6 +676,26 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
     void get().hydrate(projectId);
   },
 }));
+
+/**
+ * Archive a chat, surfacing the dirty-worktree case as a confirm prompt.
+ * Mirrors the settings page's force-remove flow: when the chat's worktree has
+ * uncommitted/untracked changes, ask the user to confirm discarding them, then
+ * retry with `force: true`. Resolves quietly when the user declines; throws on
+ * any other failure so button-level error UI can surface it.
+ */
+export async function archiveChatWithConfirm(chatId: ChatId): Promise<void> {
+  const { archive } = useChatsStore.getState();
+  const first = await archive(chatId);
+  if (first.ok) return;
+  if (!first.dirty) throw new Error(first.reason);
+  const confirmed = window.confirm(
+    "This chat's worktree has uncommitted changes. Discard them and archive anyway?",
+  );
+  if (!confirmed) return;
+  const forced = await archive(chatId, true);
+  if (!forced.ok) throw new Error(forced.reason);
+}
 
 // Mirror `selectedChatId` from the active project's slot — same pattern
 // as `useSessionsStore` so switching projects swaps the active chat too.

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -220,8 +220,12 @@ const ChatSetActiveSession = MemoizeRpcs.toLayerHandler(
     ),
 );
 
-const ChatArchive = MemoizeRpcs.toLayerHandler("chat.archive", ({ chatId }) =>
-  Effect.flatMap(MessageStore, (svc) => svc.archiveChat(chatId)),
+const ChatArchive = MemoizeRpcs.toLayerHandler(
+  "chat.archive",
+  ({ chatId, force }) =>
+    Effect.flatMap(MessageStore, (svc) =>
+      svc.archiveChat(chatId, force ?? false),
+    ),
 );
 
 const ChatUnarchive = MemoizeRpcs.toLayerHandler(

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -2122,7 +2122,7 @@ export const MessageStoreLive = Layer.scoped(
         `.pipe(Effect.asVoid, Effect.orDie);
       });
 
-    const archiveChat: MessageStoreShape["archiveChat"] = (chatId) =>
+    const archiveChat: MessageStoreShape["archiveChat"] = (chatId, force) =>
       Effect.gen(function* () {
         const chat = yield* lookupChat(chatId);
         if (chat.archivedAt !== null) {
@@ -2188,7 +2188,7 @@ export const MessageStoreLive = Layer.scoped(
         }
 
         if (worktree !== null && settings.archiveRemoveWorktree) {
-          yield* worktrees.remove(worktree.id, false).pipe(
+          yield* worktrees.remove(worktree.id, force).pipe(
             Effect.mapError(
               (err) =>
                 new ChatArchiveWorktreeError({

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -273,6 +273,7 @@ export interface MessageStoreShape {
 
   readonly archiveChat: (
     chatId: ChatId,
+    force: boolean,
   ) => Effect.Effect<
     ChatArchiveResult,
     | ChatNotFoundError

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -715,7 +715,15 @@ export const ChatSetActiveSessionRpc = Rpc.make("chat.setActiveSession", {
 });
 
 export const ChatArchiveRpc = Rpc.make("chat.archive", {
-  payload: Schema.Struct({ chatId: ChatId }),
+  payload: Schema.Struct({
+    chatId: ChatId,
+    /**
+     * Force-remove the chat's worktree even when it has uncommitted or
+     * untracked changes. Callers pass `true` after confirming the discard
+     * with the user (mirrors `worktree.remove`'s `force`).
+     */
+    force: Schema.optional(Schema.Boolean),
+  }),
   success: ChatArchiveResult,
   error: ChatArchiveErrors,
 });


### PR DESCRIPTION
## Problem

Archiving a chat fails hard when its worktree has uncommitted/untracked files. The error surfaced to the user is `{ chatId, reason: "WorktreeDirtyError" }`, and the entire archive aborts with no recovery path.

### Root cause

`apps/server/src/provider/layers/message-store.ts` hardcoded a **non-force** worktree removal during archive:

```ts
yield* worktrees.remove(worktree.id, false) // force = false, hardcoded
```

`git worktree remove` (no `--force`) refuses a dirty worktree → the service raises `WorktreeDirtyError` → mapped to `ChatArchiveWorktreeError` → the whole `chat.archive` RPC aborts before `archived_at` is set. The renderer just dumped the error string — no way to proceed.

The **settings page** already had a force-remove flow; the chat-archive path had no equivalent.

## Fix

Thread a `force` flag through the archive path and, in the renderer, confirm-and-retry on a dirty worktree — mirroring the existing settings-page force-remove UX.

### Server
- `packages/wire/src/session.ts` — add optional `force` to `ChatArchiveRpc` payload.
- `apps/server/src/provider/handlers.ts` — pass `force ?? false` into `archiveChat`.
- `apps/server/src/provider/{services,layers}/message-store.ts` — `archiveChat(chatId, force)`; forward `force` to `worktrees.remove(worktree.id, force)`.

### Renderer
- `apps/renderer/src/store/chats.ts` — `archive(chatId, force?)` returns `{ ok } | { ok:false, dirty, reason }` instead of swallowing into the global error banner; keeps the dirty case off the banner so the caller owns the retry. New exported `archiveChatWithConfirm(chatId)` helper: archive → on dirty, `window.confirm` to discard → retry with `force: true`.
- `apps/renderer/src/components/top-bar.tsx` and `projects-sidebar.tsx` (all archive trigger sites) — call `archiveChatWithConfirm`.

## Verification
- `bun run check-types` — passes (all packages)
- `bun run test` — 147 pass, 0 fail
- `bun run lint` — clean
- Manual: dirty worktree → confirm prompt → force archives cleanly, branch preserved; clean worktree → archives with no prompt (no regression).