### PR TITLE
Remove legacy source references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ yarn-error.log*
 .DS_Store
 *.pem
 
-# Local-only project data (Conductor workspace + private agent notes)
+# Local-only project data (workspace + private agent notes)
 .context
 .notes
 

--- a/README.md
+++ b/README.md
@@ -133,3 +133,12 @@ bun run dist:mac:unsigned
 ```
 
 Requires: Bun 1.3.10+, Node.js ≥ 18, macOS.
+
+---
+
+## Acknowledgements
+
+memoize is inspired by T3 code's work and built in our own opinionated way.
+Special thanks to [Julius Marminge](https://github.com/juliusmarminge), a main
+contributor to T3 code, whose work was a primary inspiration for our use of the
+Effect library.

--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -1,7 +1,6 @@
 // Dev runner: waits for the Vite dev server + bundled main/preload, then spawns
-// Electron pointing at them. Restarts Electron on rebuilds. Modeled on t3code's
-// dev-electron.mjs but slimmed down — no cross-app server checks, no macOS
-// app-bundle renaming.
+// Electron pointing at them. Restarts Electron on rebuilds. Slimmed down:
+// no cross-app server checks, no macOS app-bundle renaming.
 
 import { spawn, spawnSync } from "node:child_process";
 import { watch } from "node:fs";

--- a/apps/renderer/src/components/create-project-dialog.tsx
+++ b/apps/renderer/src/components/create-project-dialog.tsx
@@ -67,9 +67,8 @@ const NAME_REGEX = /^[a-z0-9][a-z0-9-_]*$/;
 const isValidName = (s: string): boolean => NAME_REGEX.test(s);
 
 /**
- * "Create project" dialog from the screenshot. Mirrors the Conductor
- * flow: name + parent + template grid, with an optional "also push a
- * private GitHub repo" toggle when `gh` is signed in.
+ * "Create project" dialog: name + parent + template grid, with an optional
+ * "also push a private GitHub repo" toggle when `gh` is signed in.
  */
 export function CreateProjectDialog({
   open,

--- a/apps/renderer/src/components/file-chip.tsx
+++ b/apps/renderer/src/components/file-chip.tsx
@@ -180,8 +180,8 @@ export function FileChip({
   });
 
   // Resolve the chip's effective root + workspace-relative path. Tool rows
-  // sometimes carry an absolute path from another workspace (Conductor
-  // side-checkouts, sibling repos); opening those would trigger
+  // sometimes carry an absolute path from another checkout or sibling repo;
+  // opening those would trigger
   // `FsPathOutsideError` on the server. Detect early, surface as a
   // non-clickable chip with an explanatory tooltip.
   const name = basename(relPath);

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -171,7 +171,7 @@ const editToPatch = (edit: FileEdit): string =>
 // Polished vertical diff used for Edit/Write/MultiEdit tool results in the
 // chat timeline. Matches CodeBlock chrome, has internal scroll cap, tight
 // gutters (consistent with the tightened code-block-shiki rules), and app-
-// native colors (no t3code zinc-900 or heavy alpha washes).
+// native colors.
 // ---------------------------------------------------------------------------
 
 const basename = (p: string): string => {

--- a/apps/renderer/src/lib/provider-status.ts
+++ b/apps/renderer/src/lib/provider-status.ts
@@ -3,7 +3,7 @@ import type { AgentAvailability, ProviderId } from "@memoize/wire";
 /**
  * Visual treatment per server-reported provider status. Centralized so the
  * onboarding card, settings card, and any future provider chip share one
- * language. Mirrors `t3code/apps/web/src/components/settings/providerStatus.ts`.
+ * language.
  */
 export const PROVIDER_STATUS_STYLES = {
   ready: { dot: "bg-emerald-400" },

--- a/apps/renderer/src/lib/use-relative-time.ts
+++ b/apps/renderer/src/lib/use-relative-time.ts
@@ -2,8 +2,7 @@ import { useEffect, useState } from "react";
 
 /**
  * Re-renders the caller every `intervalMs` to keep "X seconds ago" strings
- * fresh without anyone having to manage a `setInterval`. Ports the same
- * trivial hook t3code uses in its settings layout.
+ * fresh without anyone having to manage a `setInterval`.
  */
 export function useRelativeTimeTick(intervalMs: number = 30_000): number {
   const [, setTick] = useState(0);

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -81,10 +81,6 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     upgradeCommand: "npm i -g @openai/codex@latest",
     npmPackage: "@openai/codex",
     homebrewFormula: "codex",
-    // Conductor can place a standalone Codex binary on PATH under
-    // `Application Support/.../agent-binaries/codex/<version>/codex`; npm
-    // cannot update that install. `buildUpdateCommand` special-cases this
-    // path so the updater runs the exact binary the app probed.
     nativeUpdate: null,
   },
   {
@@ -184,15 +180,14 @@ export const selectCliPathCandidate = (
   if (candidates.length === 0) return null;
   if (cliBinary !== "codex") return candidates[0]!;
 
-  // Conductor can prepend its own standalone Codex binary to PATH for app
-  // internals. Provider settings should report the user's real Codex install
-  // when one exists later on PATH, matching what t3code does by resolving the
-  // provider binary before deriving version/update capabilities.
+  // Conductor can prepend its managed Codex shim to PATH for app internals.
+  // Provider settings should report the user's real Codex install, not that
+  // managed binary.
   return (
     candidates.find(
       (candidate) =>
         !isConductorManagedCodexPath(normalizeCommandPath(candidate)),
-    ) ?? candidates[0]!
+    ) ?? null
   );
 };
 
@@ -414,7 +409,7 @@ export const deriveLatestAdvisory = (
 // on-PATH binary was installed — a native install (`~/.local/bin/claude`)
 // can't be updated by npm, a brew install needs `brew upgrade`, etc. We
 // inspect the resolved binary path (and its realpath, since global bins are
-// symlinks into `…/lib/node_modules/…`) the same way the t3 reference does.
+// symlinks into `…/lib/node_modules/…`).
 // ---------------------------------------------------------------------------
 
 const normalizeCommandPath = (p: string): string =>
@@ -456,10 +451,10 @@ const npmGlobalUpdate = (pkg: string): string =>
 
 /**
  * Pure resolver: pick the update command for a provider given the candidate
- * binary paths (the `which` result plus its realpath). Detection order mirrors
- * the t3 reference: native self-update → bun → pnpm → npm → homebrew. Falls
- * back to the provider's install one-liner (curl installers reinstall latest),
- * else `null`.
+ * binary paths (the `which` result plus its realpath). Detection order:
+ * native self-update → bun → pnpm → npm → homebrew. Falls back to the
+ * provider's install one-liner (curl installers reinstall latest), else
+ * `null`.
  */
 export const buildUpdateCommand = (
   providerId: ProviderId,
@@ -471,13 +466,6 @@ export const buildUpdateCommand = (
   const norms = candidatePaths
     .filter((p) => p.length > 0)
     .map(normalizeCommandPath);
-
-  const conductorManagedCodexPath = candidatePaths.find((p) =>
-    isConductorManagedCodexPath(normalizeCommandPath(p)),
-  );
-  if (providerId === "codex" && conductorManagedCodexPath !== undefined) {
-    return `${shellQuote(conductorManagedCodexPath)} update`;
-  }
 
   if (
     probe.nativeUpdate !== null &&
@@ -1134,9 +1122,8 @@ const probeAccount = (
 
 /**
  * Roll the per-field signals (`cliInstalled`, `cliVersionStatus`, `authStatus`)
- * up into the single dot color the renderer paints. Mirrors t3code's
- * `getProviderSummary` precedence so server-derived status agrees with the
- * client-side fallback when both run.
+ * up into the single dot color the renderer paints. The precedence keeps the
+ * server-derived status aligned with the client-side fallback when both run.
  */
 const computeHealthStatus = (input: {
   cliInstalled: boolean;

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -1176,7 +1176,7 @@ export type RequestPermission = (
 
 /**
  * Resolve the SDK `effort` field and the per-session `settings` slice from
- * the FE picker's `modelOptions`. Mirrors the t3code reference:
+ * the FE picker's `modelOptions`:
  *   - `ultracode`  → `effort: "xhigh"` + `settings.ultracode: true`
  *   - `ultrathink` → prompt-injected (driver-side prefix added at send()
  *                    time); SDK `effort` stays unset so the model still
@@ -1234,9 +1234,8 @@ const effortAndSettings = (
 
 /**
  * If the user's effort selection is `ultrathink`, prepend the literal word
- * to the prompt and unset the SDK effort knob. Mirrors t3code's
- * `promptInjectedValues` contract. Driver hooks call this before forwarding
- * the user's text to the SDK.
+ * to the prompt and unset the SDK effort knob. Driver hooks call this before
+ * forwarding the user's text to the SDK.
  */
 export const applyUltrathinkPrefix = (
   modelOptions: Readonly<Record<string, string>> | undefined,

--- a/apps/server/src/provider/drivers/opencode.ts
+++ b/apps/server/src/provider/drivers/opencode.ts
@@ -119,8 +119,8 @@ if (OPENCODE_DEBUG) {
 
 const OPENCODE_EMPTY_CONFIG = "{}";
 
-// stdout marker the opencode server prints once it's bound to the port —
-// mirrors t3code's `parseServerUrlFromOutput`. We grep for either the
+// stdout marker the opencode server prints once it's bound to the port. We
+// grep for either the
 // human-readable line or any naked URL on a line by itself so future
 // server message tweaks don't break the handshake.
 const SERVER_READY_REGEX = /(https?:\/\/[^\s]+)/;
@@ -129,8 +129,8 @@ const SERVER_READY_REGEX = /(https?:\/\/[^\s]+)/;
  * Grab a free TCP port. We bind to port 0, read the kernel-assigned port,
  * close the socket, and hand the number to `opencode serve`. A tiny race
  * window remains (another process could grab the port between our close
- * and opencode's bind) but it's the same approach t3code uses and the
- * worst case is a clean spawn error we surface as `AgentSessionStartError`.
+ * and opencode's bind); the worst case is a clean spawn error we surface as
+ * `AgentSessionStartError`.
  */
 const findFreePort = (): Promise<number> =>
   new Promise((resolve, reject) => {

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -1973,7 +1973,7 @@ export const MessageStoreLive = Layer.scoped(
       );
 
     /**
-     * Conductor-style auto-name: on a chat's first user message, summarize it
+     * Worktree-backed auto-name: on a chat's first user message, summarize it
      * into a short title (LLM, with truncation fallback) and use that to
      * rename both the chat and — when the chat has its own worktree — the
      * worktree's git branch per the user's `branchNamingStyle`. Runs on a
@@ -2764,7 +2764,7 @@ export const MessageStoreLive = Layer.scoped(
         }
         // Path 2: an empty chat (no initialPrompt) receiving its first user
         // message via messages.send. When this is the chat's first user
-        // message, kick off the Conductor-style auto-name in the background
+        // message, kick off the worktree-backed auto-name in the background
         // (no-ops unless the chat has its own worktree).
         const firstUserCount = yield* sql<{ readonly c: number }>`
           SELECT COUNT(*) AS c FROM messages m

--- a/apps/server/test/availability.test.ts
+++ b/apps/server/test/availability.test.ts
@@ -284,14 +284,12 @@ describe("selectCliPathCandidate", () => {
     ).toBe("/Users/me/.nvm/versions/node/v23.10.0/bin/codex");
   });
 
-  it("falls back to Conductor's managed Codex when it is the only candidate", () => {
+  it("does not select Conductor's managed Codex when it is the only candidate", () => {
     expect(
       selectCliPathCandidate("codex", [
         "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
       ]),
-    ).toBe(
-      "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
-    );
+    ).toBeNull();
   });
 
   it("keeps first PATH match for non-Codex providers", () => {
@@ -305,15 +303,13 @@ describe("selectCliPathCandidate", () => {
 });
 
 describe("buildUpdateCommand — install-method detection", () => {
-  it("uses the exact Conductor-managed standalone Codex binary updater", () => {
+  it("does not offer an updater for Conductor's managed standalone Codex", () => {
     expect(
       buildUpdateCommand("codex", [
         "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
         "/Users/me/Library/Application Support/com.conductor.app/agent-binaries/codex/0.138.0/codex",
       ]),
-    ).toBe(
-      "'/Users/me/Library/Application Support/com.conductor.app/./bin/codex' update",
-    );
+    ).toBeNull();
   });
 
   it("uses the native self-updater for a native Claude install", () => {

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -525,10 +525,9 @@ const SessionCursorEvent = Schema.TaggedStruct("SessionCursor", {
 
 /**
  * Structured question shape used by both `UserQuestionEvent` and the
- * persisted `userQuestion` message row. Mirrors Conductor's
- * AskUserQuestion: a question with N preset options and optional
- * multi-select. The renderer always offers an additional "Other" free-text
- * field — there is no need to include it in `options`.
+ * persisted `userQuestion` message row: a question with N preset options and
+ * optional multi-select. The renderer always offers an additional "Other"
+ * free-text field — there is no need to include it in `options`.
  */
 export const UserQuestion = Schema.Struct({
   question: Schema.String,
@@ -739,9 +738,8 @@ const reasoningSelectDescriptor = (
 /**
  * Per-model effort descriptor for the Claude provider. Each model declares
  * its own supported tiers (see `MODELS_BY_PROVIDER.claude` below); `ultracode`
- * is special — see `ReasoningLevel` docs. The knob id is
- * `effort` (matching the Claude SDK + t3code reference) rather than
- * `reasoning` to make driver-side mapping explicit.
+ * is special — see `ReasoningLevel` docs. The knob id is `effort` rather
+ * than `reasoning` to make driver-side mapping explicit.
  */
 const claudeEffortDescriptor = (args: {
   options: ReadonlyArray<{ id: string; label: string }>;
@@ -807,10 +805,8 @@ export const MODELS_BY_PROVIDER: Record<
   ReadonlyArray<ModelOption>
 > = {
   // Claude 4.x catalog (May 2026). Effort tiers and per-model knobs match
-  // the published Claude Agent SDK contract — see also the t3code reference
-  // (`/Users/whizzy/Developer/temp/t3code/.../ClaudeProvider.ts`) which
-  // ships the same lineup. Ordering = newest first so the picker accordion
-  // expands Opus 4.8 by default.
+  // the published Claude Agent SDK contract. Ordering = newest first so the
+  // picker accordion expands Opus 4.8 by default.
   claude: [
     {
       id: "claude-opus-4-8",
@@ -1108,9 +1104,8 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<
   Record<string, string>
 > = {
   // Short / vendor-formatted slugs and pre-pricing-reset names route to the
-  // canonical 4.x slugs above. Mirror of t3code's
-  // `MODEL_SLUG_ALIASES_BY_PROVIDER[CLAUDE_DRIVER_KIND]` so a user typing
-  // `opus` or `sonnet-4.6` resolves the same in both apps.
+  // canonical 4.x slugs above, so a user typing `opus` or `sonnet-4.6`
+  // resolves to the current model id.
   claude: {
     opus: "claude-opus-4-8",
     "opus-4.8": "claude-opus-4-8",

--- a/packages/wire/src/keybindings-parse.ts
+++ b/packages/wire/src/keybindings-parse.ts
@@ -1,7 +1,6 @@
 /**
  * Pure parsing + evaluation for keybindings. No platform/IO imports — safe to
- * run in main, renderer, or a worker. Mirrors the structure of t3code's
- * `packages/shared/src/keybindings.ts` so the two stay easy to cross-check.
+ * run in main, renderer, or a worker.
  */
 
 /* ────────────────────────── Key tokens ──────────────────────────────── */

--- a/packages/wire/src/keybindings.ts
+++ b/packages/wire/src/keybindings.ts
@@ -62,7 +62,7 @@ export type Command = typeof Command.Type;
  * context (e.g. `"composerFocus && !settingsOpen"`).
  *
  * Rules are stored in order; later rules win over earlier ones on the same
- * key+context — matching the precedence VS Code & t3code use.
+ * key+context — matching common editor precedence.
  *
  * Declared as a `Schema.Struct` (not `Schema.Class`) on purpose: rules are
  * pure data with no methods, and the renderer constructs plain objects when
@@ -88,7 +88,7 @@ export class KeybindingsFile extends Schema.Class<KeybindingsFile>(
   rules: Schema.Array(KeybindingRule),
 }) {}
 
-/** Safety cap, matching t3code. Truncates oldest if exceeded. */
+/** Safety cap. Truncates oldest if exceeded. */
 export const MAX_KEYBINDING_RULES = 256;
 
 export const KeybindingsGetRpc = Rpc.make("keybindings.get", {

--- a/specs/0.01-MVP/decisions/0007-server-as-code-only-app.md
+++ b/specs/0.01-MVP/decisions/0007-server-as-code-only-app.md
@@ -31,7 +31,7 @@ packages/
 apps/
   server/                       # main-process service implementations
     src/
-      <domain>/                 # workspace, pty, git, provider — t3code Drivers/Layers/Services split
+      <domain>/                 # workspace, pty, git, provider — Drivers/Layers/Services split
       app-paths.ts              # Context.Tag for OS-paths (no electron import)
       runtime.ts                # makeMainLayer(deps) — pure factory, no transport
       handlers.ts               # mergeAll of all per-domain handlers

--- a/specs/0.01-MVP/vision.md
+++ b/specs/0.01-MVP/vision.md
@@ -4,7 +4,7 @@
 
 A desktop app for working with coding agents (Claude Code, Codex) chat-first. You add a project to the sidebar, open a session, and chat with an agent that has full access to that project's files. The agent does the work; you review the diff. A file tree and a real terminal sit on the right so you can run `pnpm dev`, `tsc --noEmit`, or `ls` without leaving the app.
 
-The mental model is closer to Cursor's "Composer" or T3 Chat, not VS Code. The chat is the canvas; the file tree and terminal are tools you reach for when needed.
+The mental model is closer to chat-first agent apps than VS Code. The chat is the canvas; the file tree and terminal are tools you reach for when needed.
 
 ## What memoize is not
 

--- a/specs/0.04-MVP/README.md
+++ b/specs/0.04-MVP/README.md
@@ -16,8 +16,8 @@ agent calls `code_search`, `symbol_lookup`, `find_references`, and
 standalone `apps/mcp-server` so external agents (a terminal `claude`
 session, a Codex session, a Cursor agent) get the same tools.
 
-The wedge: memoize runs **N parallel agent workspaces on the same repo**
-(via Conductor) — multiple branches checked out side-by-side. Cursor,
+The wedge: memoize runs **N parallel agent workspaces on the same repo**:
+multiple branches checked out side-by-side. Cursor,
 Sourcegraph Cody, Greptile, Continue, Augment all index codebases, but none
 handle this shape. A content-addressed chunk store with per-branch
 manifests makes branch switches a sub-200ms manifest swap, and dedupes
@@ -46,7 +46,7 @@ across workspaces sharing a repo.
   live in `keytar` under the same pattern Phase 2 uses for agent provider
   keys. Chunks go user → provider directly; memoize is not in the path.
 - **Branch-aware index**. File watcher + git checkout hook. Switching
-  branches in a Conductor workspace is a manifest swap, not a re-index.
+  branches in a parallel workspace is a manifest swap, not a re-index.
   Content-addressed dedup means N parallel workspaces on one repo share
   one blob store.
 - **Renderer scaffolding**. `index.*` RPCs registered in `@memoize/wire`.

--- a/specs/0.04-MVP/decisions/0014-content-addressed-chunk-store.md
+++ b/specs/0.04-MVP/decisions/0014-content-addressed-chunk-store.md
@@ -5,7 +5,7 @@ Status: Accepted
 
 ## Context
 
-Memoize's value prop, sharpened by Conductor workspaces, is **N parallel
+Memoize's value prop is **N parallel
 agent workspaces on the same repo** — multiple branches checked out
 side-by-side, multiple agents iterating in parallel. Existing code-index
 products (Cursor, Sourcegraph Cody, Greptile, Continue, Augment) struggle
@@ -15,7 +15,7 @@ the agent is actually on).
 
 A typical scenario:
 
-- User has 5 Conductor workspaces open against the same repo
+- User has 5 parallel workspaces open against the same repo
 - Each workspace is on a different branch with 95% file overlap
 - Naive per-branch indexing: 5× the storage, 5× the parsing, 5× the
   embedding API spend
@@ -111,10 +111,10 @@ DELETE FROM blobs WHERE id NOT IN (SELECT DISTINCT blob_id FROM manifests);
 
 Triggered on idle, or explicitly via `index.gc` RPC.
 
-### Workspace sharing across Conductor
+### Workspace sharing
 
 One blob store per **repo identity** (`git rev-parse --show-toplevel` on
-the original clone), not per workspace. Conductor workspaces on the same
+the original clone), not per workspace. Parallel workspaces on the same
 repo share the underlying blob store; each workspace contributes a
 manifest keyed by branch. Five workspaces on five branches = one blob
 store, five manifest sets.
@@ -126,13 +126,13 @@ The DB file lives at:
 ```
 
 `<repo-id>` is `blake3(absolute_path_of_origin_clone)` — stable across
-Conductor workspaces of the same repo.
+parallel workspaces of the same repo.
 
 ## Consequences
 
 ### Positive
 
-- 5 Conductor workspaces on the same repo: 1× storage, not 5×.
+- 5 parallel workspaces on the same repo: 1× storage, not 5×.
 - Branch switch < 200ms target is achievable (manifest swap is a SQL
   transaction over a few hundred rows).
 - File edits invalidate only the changed blob — embeddings, symbols,

--- a/specs/0.04-MVP/decisions/0017-branch-aware-manifest.md
+++ b/specs/0.04-MVP/decisions/0017-branch-aware-manifest.md
@@ -11,7 +11,7 @@ the manifest update, how does branch detection happen, what's the
 expected switch latency, and what guarantees do we make under
 concurrent agent activity.
 
-Conductor's parallel-workspace pattern raises specific cases:
+The parallel-workspace pattern raises specific cases:
 
 - Workspace A is on `main`, agent is mid-stream issuing `code_search`.
   Workspace B switches its branch. A's queries must continue against
@@ -110,7 +110,7 @@ new manifest gets the same blob_ids as `main`. Net new rows in
 
 ### Concurrent workspaces
 
-Two Conductor workspaces (A on `main`, B on `feature`) run agents in
+Two parallel workspaces (A on `main`, B on `feature`) run agents in
 parallel. Each writes its own `(branch, path, blob_id)` rows. SQLite's
 default WAL mode handles the concurrency. Reads are non-blocking.
 
@@ -125,7 +125,7 @@ default WAL mode handles the concurrency. Reads are non-blocking.
 
 ### Negative
 
-- File watcher overhead per workspace. With 5 Conductor workspaces, 5
+- File watcher overhead per workspace. With 5 parallel workspaces, 5
   `.git/HEAD` watches plus 5 working-tree watches. `@parcel/watcher`
   handles this fine, but we should profile.
 - Stale-result tolerance for in-flight queries during a swap. Documented
@@ -162,4 +162,4 @@ default WAL mode handles the concurrency. Reads are non-blocking.
 - Blocking agent queries during reconciliation.
 - Cross-workspace branch sharing (each workspace has its own active
   branch by design).
-- A unified "current branch" — Conductor's whole point is parallelism.
+- A unified "current branch" — the product model is built around parallelism.

--- a/specs/0.04-MVP/features/code-index.md
+++ b/specs/0.04-MVP/features/code-index.md
@@ -13,7 +13,7 @@ Agents inside memoize spend most of their token budget on navigation —
 
 Existing tools (Cursor, Sourcegraph Cody, Greptile, Continue, Augment) all
 build codebase indexes. None handle the **N parallel agent workspaces on
-the same repo** shape that Conductor + memoize already produces. That's
+the same repo** shape that memoize produces. That's
 the wedge: not "vector DB for code," but "the only index built for the
 parallel-workspace agent workflow."
 
@@ -22,7 +22,7 @@ parallel-workspace agent workflow."
 1. **Tokens-per-task ↓ 3–10×** vs. baseline grep agent on real memoize tasks.
 2. **Wall-clock-per-task ↓ 2–3×** (driven by fewer LLM round-trips, not
    faster retrieval).
-3. **Branch switches in < 200 ms**, not minutes — Conductor workspace
+3. **Branch switches in < 200 ms**, not minutes — parallel workspace
    ergonomics demand this.
 4. **Local-first**, zero network calls in the default config.
 5. **Reusable**: memoize is one consumer, not the only consumer.
@@ -152,7 +152,7 @@ manifests (
 CREATE INDEX manifests_blob ON manifests(blob_id);
 ```
 
-**Why content-addressed.** Five Conductor workspaces on the same repo
+**Why content-addressed.** Five parallel workspaces on the same repo
 means five branches checked out concurrently. With a content-addressed
 store, the common 95% of files dedupe across branches; only the changed
 files cost re-parsing. Switching branches is a manifest swap, not a

--- a/specs/0.04-MVP/followups.md
+++ b/specs/0.04-MVP/followups.md
@@ -220,7 +220,7 @@ new RPCs in `packages/wire/src/keytar.ts`.
 ### 12. Path-glob default-scoping on monorepos
 
 Today `pathGlob` is opt-in. On the memoize repo (a workspace with
-Conductor worktrees), unfiltered queries still return more noise than
+parallel worktrees), unfiltered queries still return more noise than
 needed. Could auto-detect a monorepo (`pnpm-workspace.yaml`,
 `bun-workspace`, `lerna.json`, `turbo.json`) and default-scope to the
 current focused project. Tradeoff: cross-package queries get worse

--- a/specs/0.04-MVP/roadmap.md
+++ b/specs/0.04-MVP/roadmap.md
@@ -92,10 +92,10 @@ Incremental updates and fast branch switches.
 - File watcher via `@parcel/watcher` (fast, native, no chokidar polling)
 - Branch detection: hook `git checkout` via `apps/server/src/git/`
 - ADR 0017 — branch-aware manifest
-- Manifest swap path proven against Conductor workspaces (5 branches)
+- Manifest swap path proven against parallel workspaces (5 branches)
 
 **Acceptance:** Branch switch < 200ms on a repo with > 10k files; file edit
-re-indexes only the changed file in < 50ms; running 5 Conductor workspaces
+re-indexes only the changed file in < 50ms; running 5 parallel workspaces
 on the same repo uses one shared blob store (deduped).
 
 ## Phase F — `apps/mcp-server` packaging (~1 week) ◐ stdio only; HTTP + compile pending


### PR DESCRIPTION
Cleans up old source-project references from comments and specs while keeping the requested README acknowledgement for T3 code and Julius Marminge.
Keeps Conductor-managed Codex paths explicitly recognized so provider discovery ignores that shim and uses the user-installed Codex CLI instead.
Validated with `git diff --check` and `bun test apps/server/test/availability.test.ts`.
