### PR TITLE
Plans as annotatable HTML artifacts (opt-in)

### DIFF
--- a/apps/renderer/src/components/annotation/annotation-navigation.ts
+++ b/apps/renderer/src/components/annotation/annotation-navigation.ts
@@ -1,6 +1,11 @@
 import { useCallback } from "react";
 
-import type { CodeAnnotation, FolderId, WorktreeId } from "@memoize/wire";
+import {
+  isElementAnnotation,
+  type Annotation,
+  type FolderId,
+  type WorktreeId,
+} from "@memoize/wire";
 
 import { useUiStore } from "~/store/ui";
 import { useWorkspaceStore } from "~/store/workspace";
@@ -15,7 +20,7 @@ const basename = (p: string): string => {
 export const useRevealAnnotation = (opts?: {
   readonly folderId?: FolderId | null;
   readonly worktreeId?: WorktreeId | null;
-}): ((annotation: CodeAnnotation) => void) => {
+}): ((annotation: Annotation) => void) => {
   const context = useFileChipContext();
   const folderId = opts?.folderId ?? context.folderId;
   const worktreeId = opts?.worktreeId ?? context.worktreeId;
@@ -32,7 +37,11 @@ export const useRevealAnnotation = (opts?: {
   });
 
   return useCallback(
-    (annotation: CodeAnnotation) => {
+    (annotation: Annotation) => {
+      // Element annotations live inside a rendered HTML artifact in the chat,
+      // not a file — there's nothing to open in the editor. (Scrolling the
+      // chat back to the source artifact is a future enhancement.)
+      if (isElementAnnotation(annotation)) return;
       const rootPath = worktreePath ?? folderPath;
       const resolvedAbs =
         annotation.absPath ||

--- a/apps/renderer/src/components/annotation/use-add-annotation.ts
+++ b/apps/renderer/src/components/annotation/use-add-annotation.ts
@@ -1,24 +1,24 @@
 import { useCallback } from "react";
 
-import type { CodeAnnotation } from "@memoize/wire";
+import type { Annotation, NewAnnotation } from "@memoize/wire";
 
 import { useAnnotationsStore } from "../../store/annotations.ts";
 import { useSessionsStore } from "../../store/sessions.ts";
-import type { AnnotationDraft } from "./annotate-overlay.tsx";
 
 /**
- * Returns a stable callback that drops a finished annotation into the focused
- * chat's draft list. The file editor and diff view live in a different pane
- * from the composer, so the target session is resolved from
+ * Returns a stable callback that drops a finished annotation — a code region
+ * (file editor / diff view) or an HTML element/text pick (embedded artifact) —
+ * into the focused chat's draft list. The annotation surfaces live in a
+ * different pane from the composer, so the target session is resolved from
  * `selectedSessionId` at confirm time. Returns the stored annotation, or
  * `null` when there is no active chat to attach to.
  */
 export const useAddAnnotation = (): ((
-  draft: AnnotationDraft,
-) => CodeAnnotation | null) =>
-  useCallback((draft: AnnotationDraft): CodeAnnotation | null => {
+  draft: NewAnnotation,
+) => Annotation | null) =>
+  useCallback((draft: NewAnnotation): Annotation | null => {
     const sessionId = useSessionsStore.getState().selectedSessionId;
     if (sessionId === null) return null;
     const id = useAnnotationsStore.getState().add(sessionId, draft);
-    return { ...draft, id };
+    return { ...draft, id } as Annotation;
   }, []);

--- a/apps/renderer/src/components/artifact/annotatable.tsx
+++ b/apps/renderer/src/components/artifact/annotatable.tsx
@@ -1,0 +1,265 @@
+import {
+  BubbleChatIcon,
+  CheckListIcon,
+  Tick01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { X } from "lucide-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import { cn } from "~/lib/utils";
+
+import { useAddAnnotation } from "../annotation/use-add-annotation.ts";
+
+interface PendingPick {
+  readonly selector: string;
+  readonly label: string;
+  readonly text?: string;
+  readonly x: number;
+  readonly y: number;
+}
+
+/** Build a best-effort unique CSS selector for `el` within `root`. */
+const selectorWithin = (root: HTMLElement, el: HTMLElement): string => {
+  if (el === root) return "body";
+  const parts: string[] = [];
+  let node: HTMLElement | null = el;
+  while (node !== null && node !== root && node.nodeType === 1) {
+    if (node.id !== "") {
+      parts.unshift(`#${CSS.escape(node.id)}`);
+      break;
+    }
+    let tag = node.tagName.toLowerCase();
+    const parent: HTMLElement | null = node.parentElement;
+    if (parent !== null) {
+      const tagName = node.tagName;
+      const same = Array.from(parent.children).filter(
+        (c) => c.tagName === tagName,
+      );
+      if (same.length > 1) tag += `:nth-of-type(${same.indexOf(node) + 1})`;
+    }
+    parts.unshift(tag);
+    node = node.parentElement;
+  }
+  return parts.length > 0 ? parts.join(" > ") : "body";
+};
+
+/** Human label: tag + a slice of the element's visible text. */
+const labelFor = (el: HTMLElement): string => {
+  const text = (el.innerText || el.textContent || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 48);
+  const tag = el.tagName.toLowerCase();
+  return text.length > 0 ? `${tag} "${text}"` : tag;
+};
+
+/**
+ * Wraps rendered content (a plan, rendered via the app's own MarkdownBody so it
+ * matches the chat's look and flows to full height) and makes it annotatable.
+ * Toggling Annotate turns the content into a click/select target: clicking an
+ * element or selecting text pins a comment that drops into the same composer
+ * tray as code annotations and travels to the agent on the next turn.
+ *
+ * In-DOM (no iframe) on purpose — plans are app-rendered markdown, so real React
+ * event handling + the app's theme beat a sandboxed white box. The iframe
+ * `HtmlArtifact` stays for genuine agent-authored HTML, where isolation matters.
+ */
+export function AnnotatableArtifact({
+  sourceRef,
+  title = "Plan",
+  children,
+}: {
+  readonly sourceRef: string;
+  readonly title?: string;
+  readonly children: ReactNode;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [annotate, setAnnotate] = useState(false);
+  const [pending, setPending] = useState<PendingPick | null>(null);
+  const [comment, setComment] = useState("");
+  const addAnnotation = useAddAnnotation();
+
+  useEffect(() => {
+    if (pending !== null) textareaRef.current?.focus();
+  }, [pending]);
+
+  useEffect(() => {
+    if (!annotate) setPending(null);
+  }, [annotate]);
+
+  const pickFromEvent = (
+    target: HTMLElement,
+    clientX: number,
+    clientY: number,
+    text?: string,
+  ) => {
+    const root = containerRef.current;
+    if (root === null || !root.contains(target)) return;
+    setComment("");
+    setPending({
+      selector: selectorWithin(root, target),
+      label: labelFor(target),
+      ...(text !== undefined ? { text } : {}),
+      x: clientX,
+      y: clientY,
+    });
+  };
+
+  const onClickCapture = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!annotate) return;
+    // A drag-select ends in a click too; let the text path own that case.
+    if (String(window.getSelection() ?? "").trim().length > 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    pickFromEvent(e.target as HTMLElement, e.clientX, e.clientY);
+  };
+
+  const onMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!annotate) return;
+    const sel = window.getSelection();
+    const text = sel !== null ? sel.toString().replace(/\s+/g, " ").trim() : "";
+    if (text.length === 0) return;
+    const anchor = sel?.anchorNode ?? null;
+    const el =
+      anchor !== null && anchor.nodeType === 3
+        ? anchor.parentElement
+        : (anchor as HTMLElement | null);
+    if (el === null) return;
+    pickFromEvent(el, e.clientX, e.clientY, text.slice(0, 200));
+  };
+
+  const confirm = () => {
+    if (pending === null) return;
+    const trimmed = comment.trim();
+    if (trimmed.length === 0) {
+      setPending(null);
+      return;
+    }
+    addAnnotation({
+      _tag: "element",
+      sourceRef,
+      selector: pending.selector,
+      label: pending.label,
+      ...(pending.text !== undefined ? { text: pending.text } : {}),
+      comment: trimmed,
+    });
+    setPending(null);
+    setComment("");
+  };
+
+  const popupStyle =
+    pending === null
+      ? undefined
+      : ({
+          top: Math.min(pending.y + 8, window.innerHeight - 180),
+          left: Math.min(Math.max(8, pending.x), window.innerWidth - 312),
+          width: 300,
+        } as const);
+
+  return (
+    <div className="my-1 overflow-hidden rounded-lg border border-border/50 bg-card/40">
+      {annotate ? (
+        <style>{`.mz-annotating, .mz-annotating *{cursor:crosshair!important}.mz-annotating *:hover{outline:2px solid #84cc16;outline-offset:2px;border-radius:3px}`}</style>
+      ) : null}
+      <div className="flex items-center gap-2 border-b border-border/40 bg-muted/15 px-3 py-1.5">
+        <HugeiconsIcon
+          icon={CheckListIcon}
+          className="size-3.5 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <span className="text-xs font-medium text-muted-foreground">
+          {title}
+        </span>
+        <button
+          type="button"
+          onClick={() => setAnnotate((v) => !v)}
+          aria-pressed={annotate}
+          className={cn(
+            "ml-auto flex h-6 items-center gap-1 rounded-md px-2 text-xs font-medium",
+            annotate
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : "text-muted-foreground hover:bg-background hover:text-foreground",
+          )}
+        >
+          <HugeiconsIcon icon={BubbleChatIcon} className="size-3.5" />
+          Annotate
+        </button>
+      </div>
+
+      <div
+        ref={containerRef}
+        onClickCapture={onClickCapture}
+        onMouseUp={onMouseUp}
+        className={cn("px-3 py-2", annotate && "mz-annotating")}
+      >
+        {children}
+      </div>
+
+      {annotate ? (
+        <div className="border-t border-border/40 bg-muted/10 px-3 py-1 text-[11px] text-muted-foreground">
+          Click any element or select text above to leave a comment for the
+          agent.
+        </div>
+      ) : null}
+
+      {pending !== null && popupStyle !== undefined ? (
+        <div
+          className="fixed z-50"
+          style={popupStyle}
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          <div className="w-full rounded-lg border border-border/70 bg-popover p-2 shadow-lg">
+            <div className="mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+              <HugeiconsIcon icon={BubbleChatIcon} className="size-3.5" />
+              <span className="min-w-0 truncate font-medium text-foreground">
+                {pending.text !== undefined
+                  ? `"${pending.text.slice(0, 32)}"`
+                  : pending.label}
+              </span>
+            </div>
+            <textarea
+              ref={textareaRef}
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              onMouseDown={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setPending(null);
+                } else if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  confirm();
+                }
+              }}
+              rows={2}
+              placeholder="Add a comment…"
+              className="max-h-32 min-h-14 w-full resize-y rounded-md bg-background/80 px-2 py-1.5 text-xs leading-relaxed text-foreground outline-none ring-0 placeholder:text-muted-foreground/70 focus:bg-background"
+            />
+            <div className="mt-1.5 flex items-center justify-end gap-1">
+              <button
+                type="button"
+                onClick={() => setPending(null)}
+                className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground"
+                aria-label="Cancel annotation"
+              >
+                <X className="size-3.5" strokeWidth={1.8} />
+              </button>
+              <button
+                type="button"
+                onClick={confirm}
+                disabled={comment.trim().length === 0}
+                className="flex h-6 items-center gap-1 rounded-md bg-primary px-2 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
+                aria-label="Add annotation"
+              >
+                <HugeiconsIcon icon={Tick01Icon} className="size-3.5" />
+                Add
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/artifact/html-artifact.tsx
+++ b/apps/renderer/src/components/artifact/html-artifact.tsx
@@ -1,0 +1,339 @@
+import {
+  BubbleChatIcon,
+  Copy01Icon,
+  CursorMagicSelection02Icon,
+  Tick01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "~/lib/utils";
+
+import { useAddAnnotation } from "../annotation/use-add-annotation.ts";
+
+/**
+ * A selection reported by the in-iframe annotate script. `rect` is in the
+ * iframe's own viewport coordinates; the parent adds the iframe's on-screen
+ * offset to place the comment popup. `text` is present only for text-range
+ * selections (vs whole-element picks).
+ */
+interface PendingPick {
+  readonly selector: string;
+  readonly label: string;
+  readonly text?: string;
+  readonly rect: { left: number; top: number; bottom: number };
+}
+
+const MAX_HEIGHT = 820;
+
+/**
+ * Page-side script injected into the sandboxed artifact iframe. Runs in an
+ * opaque origin (sandbox is `allow-scripts` only — no `allow-same-origin`), so
+ * it can read its own DOM and `postMessage` the parent but can't touch the
+ * app. Responsibilities: report content height for auto-sizing, and — while
+ * annotate mode is on — highlight the hovered element and post the clicked
+ * element / selected text back to the host.
+ *
+ * Kept as a hand-written string (no template literals) so it concatenates
+ * cleanly onto arbitrary agent HTML. The closing tag is split at the very end
+ * so this source file never contains a literal `</script>`.
+ */
+const INJECT = [
+  "<script>(function(){",
+  "var mode=false,hl=null,prevOutline='';",
+  "function clearHl(){if(hl){hl.style.outline=prevOutline;hl=null;}}",
+  "function sel(el){",
+  "  if(!el||el.nodeType!==1||el===document.body||el===document.documentElement)return 'body';",
+  "  if(el.id)return '#'+CSS.escape(el.id);",
+  "  var parts=[],node=el;",
+  "  while(node&&node.nodeType===1&&node!==document.body){",
+  "    var tag=node.tagName.toLowerCase(),p=node.parentNode;",
+  "    if(node.id){parts.unshift('#'+CSS.escape(node.id));break;}",
+  "    if(p){var same=Array.prototype.filter.call(p.children,function(c){return c.tagName===node.tagName;});",
+  "      if(same.length>1)tag+=':nth-of-type('+(same.indexOf(node)+1)+')';}",
+  "    parts.unshift(tag);node=p;}",
+  "  return parts.join(' > ');",
+  "}",
+  "function label(el){",
+  "  if(!el||el.nodeType!==1)return 'text';",
+  "  var t=(el.innerText||el.textContent||'').replace(/\\s+/g,' ').trim().slice(0,40);",
+  "  var tag=el.tagName.toLowerCase();return t?tag+' \"'+t+'\"':tag;",
+  "}",
+  "function reportH(){try{parent.postMessage({type:'mz-height',value:document.documentElement.scrollHeight},'*');}catch(e){}}",
+  "window.addEventListener('message',function(e){var d=e.data;if(d&&d.type==='mz-mode'){mode=!!d.on;clearHl();document.body.style.cursor=mode?'crosshair':'';}});",
+  "document.addEventListener('mouseover',function(e){if(!mode)return;clearHl();hl=e.target;prevOutline=hl.style.outline;hl.style.outline='2px solid #84cc16';hl.style.outlineOffset='1px';},true);",
+  "document.addEventListener('mouseout',function(){if(mode)clearHl();},true);",
+  "document.addEventListener('click',function(e){",
+  "  if(!mode)return;e.preventDefault();e.stopPropagation();",
+  "  if(window.getSelection&&String(window.getSelection()).trim())return;",
+  "  var el=e.target,r=el.getBoundingClientRect();",
+  "  parent.postMessage({type:'mz-pick',selector:sel(el),label:label(el),rect:{left:r.left,top:r.top,bottom:r.bottom}},'*');",
+  "},true);",
+  "document.addEventListener('mouseup',function(){",
+  "  if(!mode)return;var s=window.getSelection();var txt=s?s.toString().replace(/\\s+/g,' ').trim():'';",
+  "  if(!txt)return;var n=s.anchorNode;n=n&&n.nodeType===3?n.parentElement:n;",
+  "  var r=s.getRangeAt(0).getBoundingClientRect();",
+  "  parent.postMessage({type:'mz-text',text:txt.slice(0,200),selector:sel(n),label:label(n),rect:{left:r.left,top:r.top,bottom:r.bottom}},'*');",
+  "});",
+  // Re-report after late reflow too — CDN runtimes (Tailwind browser, Mermaid)
+  // restyle the DOM well after first paint, which changes the content height.
+  "window.addEventListener('load',reportH);[50,400,1000,2000].forEach(function(t){setTimeout(reportH,t);});",
+  "try{new ResizeObserver(reportH).observe(document.documentElement);}catch(e){}",
+  "})();",
+].join("\n") + "</scr" + "ipt>";
+
+/**
+ * Embedded, annotatable HTML artifact — the rendered-HTML analogue of the code
+ * annotation flow. Renders agent-produced HTML (a plan body or a fenced `html`
+ * block) in a sandboxed iframe. Toggling "Annotate" lets the user click an
+ * element or select text inside the rendered preview and pin a comment; the
+ * annotation drops into the same per-session tray above the composer and
+ * serialises into the next prompt, so the agent can revise the exact node it
+ * produced.
+ */
+export function HtmlArtifact({
+  source,
+  sourceRef,
+}: {
+  readonly source: string;
+  readonly sourceRef: string;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [height, setHeight] = useState(120);
+  const [annotateMode, setAnnotateMode] = useState(false);
+  const [pending, setPending] = useState<PendingPick | null>(null);
+  const [comment, setComment] = useState("");
+  const [copied, setCopied] = useState(false);
+  const addAnnotation = useAddAnnotation();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const srcDoc = source + INJECT;
+
+  // Listen for the iframe's height + selection messages. Filter by the
+  // iframe's own contentWindow — the sandbox gives it an opaque ("null")
+  // origin, so we identify it by window identity rather than `event.origin`.
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const d = e.data as
+        | { type: "mz-height"; value: number }
+        | { type: "mz-pick" | "mz-text"; selector: string; label: string; text?: string; rect: PendingPick["rect"] }
+        | undefined;
+      if (d === undefined || typeof d !== "object") return;
+      if (d.type === "mz-height") {
+        setHeight(Math.min(MAX_HEIGHT, Math.max(60, Math.ceil(d.value) + 2)));
+        return;
+      }
+      if (d.type === "mz-pick" || d.type === "mz-text") {
+        setComment("");
+        setPending({
+          selector: d.selector,
+          label: d.label,
+          text: d.type === "mz-text" ? d.text : undefined,
+          rect: d.rect,
+        });
+      }
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  // Push the current annotate mode into the iframe (on toggle + after load).
+  const postMode = (on: boolean) => {
+    iframeRef.current?.contentWindow?.postMessage({ type: "mz-mode", on }, "*");
+  };
+  useEffect(() => {
+    postMode(annotateMode);
+    if (!annotateMode) setPending(null);
+  }, [annotateMode]);
+
+  useEffect(() => {
+    if (pending !== null) textareaRef.current?.focus();
+  }, [pending]);
+
+  const confirm = () => {
+    if (pending === null) return;
+    const trimmed = comment.trim();
+    if (trimmed.length === 0) {
+      setPending(null);
+      return;
+    }
+    addAnnotation({
+      _tag: "element",
+      sourceRef,
+      selector: pending.selector,
+      label: pending.label,
+      ...(pending.text !== undefined ? { text: pending.text } : {}),
+      comment: trimmed,
+    });
+    setPending(null);
+    setComment("");
+  };
+
+  const copyHtml = () => {
+    void navigator.clipboard?.writeText(source).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    });
+  };
+
+  // Place the comment popup just below the selected node, in client coords.
+  const popupStyle = (() => {
+    if (pending === null) return undefined;
+    const frame = iframeRef.current?.getBoundingClientRect();
+    if (frame === undefined) return undefined;
+    const top = Math.min(
+      frame.top + Math.min(pending.rect.bottom, MAX_HEIGHT) + 6,
+      window.innerHeight - 180,
+    );
+    const left = Math.min(
+      Math.max(8, frame.left + pending.rect.left),
+      window.innerWidth - 320,
+    );
+    return { top, left, width: 300 } as const;
+  })();
+
+  return (
+    <div className="markdown-html-artifact my-2 overflow-hidden rounded-lg border border-border/60 bg-card/60">
+      <div className="flex items-center gap-2 border-b border-border/40 bg-muted/20 px-2.5 py-1.5">
+        <HugeiconsIcon
+          icon={CursorMagicSelection02Icon}
+          className="size-3.5 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <span className="text-xs font-medium text-muted-foreground">
+          Preview
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setAnnotateMode((v) => !v)}
+            aria-pressed={annotateMode}
+            className={cn(
+              "flex h-6 items-center gap-1 rounded-md px-2 text-xs font-medium",
+              annotateMode
+                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                : "text-muted-foreground hover:bg-background hover:text-foreground",
+            )}
+          >
+            <HugeiconsIcon icon={BubbleChatIcon} className="size-3.5" />
+            Annotate
+          </button>
+          <button
+            type="button"
+            onClick={copyHtml}
+            className="flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground"
+            aria-label="Copy HTML"
+          >
+            <HugeiconsIcon
+              icon={copied ? Tick01Icon : Copy01Icon}
+              className="size-3.5"
+            />
+          </button>
+        </div>
+      </div>
+      <iframe
+        ref={iframeRef}
+        title="HTML artifact"
+        sandbox="allow-scripts"
+        srcDoc={srcDoc}
+        onLoad={() => postMode(annotateMode)}
+        style={{ height }}
+        className="w-full bg-[#0d0d12]"
+      />
+      {annotateMode ? (
+        <div className="border-t border-border/40 bg-muted/10 px-2.5 py-1 text-[11px] text-muted-foreground">
+          Click an element or select text in the preview to annotate it.
+        </div>
+      ) : null}
+
+      {pending !== null && popupStyle !== undefined ? (
+        <div
+          className="fixed z-50"
+          style={popupStyle}
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          <div className="w-full rounded-lg border border-border/70 bg-popover p-2 shadow-lg">
+            <div className="mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+              <HugeiconsIcon icon={BubbleChatIcon} className="size-3.5" />
+              <span className="min-w-0 truncate font-medium text-foreground">
+                {pending.text !== undefined
+                  ? `"${pending.text.slice(0, 32)}"`
+                  : pending.label}
+              </span>
+            </div>
+            <textarea
+              ref={textareaRef}
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              onMouseDown={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setPending(null);
+                } else if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  confirm();
+                }
+              }}
+              rows={2}
+              placeholder="Add a comment…"
+              className="max-h-32 min-h-14 w-full resize-y rounded-md bg-background/80 px-2 py-1.5 text-xs leading-relaxed text-foreground outline-none ring-0 placeholder:text-muted-foreground/70 focus:bg-background"
+            />
+            <div className="mt-1.5 flex items-center justify-end gap-1">
+              <button
+                type="button"
+                onClick={() => setPending(null)}
+                className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground"
+                aria-label="Cancel annotation"
+              >
+                <X className="size-3.5" strokeWidth={1.8} />
+              </button>
+              <button
+                type="button"
+                onClick={confirm}
+                disabled={comment.trim().length === 0}
+                className="flex h-6 items-center gap-1 rounded-md bg-primary px-2 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
+                aria-label="Add annotation"
+              >
+                <HugeiconsIcon icon={Tick01Icon} className="size-3.5" />
+                Add
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Heuristic: does this string look like a full HTML document we should render
+ * as an artifact (vs markdown)? Conservative — only fires on an explicit
+ * doctype / `<html>` / `<body>` root so ordinary prose with stray angle
+ * brackets keeps rendering as markdown.
+ */
+export const looksLikeHtmlDocument = (s: string): boolean => {
+  const head = s.trimStart().slice(0, 200).toLowerCase();
+  return (
+    head.startsWith("<!doctype html") ||
+    head.startsWith("<html") ||
+    head.startsWith("<body")
+  );
+};
+
+/**
+ * Pull a renderable HTML document out of a plan/message body, or `null` if it
+ * isn't HTML. Handles both a raw document and a single ```html fenced block
+ * (the model may emit either), so a fenced plan renders as an artifact rather
+ * than an ugly raw-HTML code block.
+ */
+export const extractHtmlDoc = (s: string): string | null => {
+  const t = s.trim();
+  if (looksLikeHtmlDocument(t)) return t;
+  const fence = t.match(/```html\s*\n([\s\S]*?)```/i);
+  const inner = fence?.[1];
+  if (inner !== undefined && looksLikeHtmlDocument(inner)) return inner.trim();
+  return null;
+};

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -753,16 +753,14 @@ export function ChatComposer({
         aria-hidden={showCard || undefined}
       >
         <div className="mx-auto">
-          {!isDraft ? (
-            <AnnotationTray
-              sessionId={sessionId}
-              folderId={session.projectId}
-              worktreeId={session.worktreeId}
-            />
-          ) : null}
           <Frame>
             {!isDraft ? (
               <div className="mb-1 overflow-hidden rounded-md border border-border/50 bg-muted/30 empty:hidden empty:mb-0">
+                <AnnotationTray
+                  sessionId={sessionId}
+                  folderId={session.projectId}
+                  worktreeId={session.worktreeId}
+                />
                 <PlanApprovalTray sessionId={sessionId} />
                 {goalCapable && goal !== null ? (
                   <GoalBanner

--- a/apps/renderer/src/components/composer/annotation-tray.tsx
+++ b/apps/renderer/src/components/composer/annotation-tray.tsx
@@ -1,32 +1,47 @@
 import {
   ArrowDown01Icon,
   BubbleChatIcon,
-  PencilEdit01Icon,
-  Tick01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { X } from "lucide-react";
 import { useState } from "react";
 
-import type {
-  CodeAnnotation,
-  FolderId,
-  SessionId,
-  WorktreeId,
+import {
+  isElementAnnotation,
+  type Annotation,
+  type FolderId,
+  type SessionId,
+  type WorktreeId,
 } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 
 import { useAnnotationsStore } from "../../store/annotations.ts";
 import { useRevealAnnotation } from "../annotation/annotation-navigation.ts";
-import { AnnotationFileChip } from "../file-chip.tsx";
 
-const EMPTY: ReadonlyArray<CodeAnnotation> = [];
+const EMPTY: ReadonlyArray<Annotation> = [];
+
+const basename = (p: string): string => {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+};
+
+/** Short, single-line source label for an annotation row. */
+const shortLabel = (a: Annotation): string => {
+  if (isElementAnnotation(a)) {
+    if (a.text !== undefined && a.text.length > 0) return `“${a.text}”`;
+    return a.label;
+  }
+  const range =
+    a.startLine === a.endLine ? `${a.startLine}` : `${a.startLine}-${a.endLine}`;
+  return `${basename(a.relPath)}:${range}`;
+};
 
 /**
- * Stacked code annotations docked above the composer. Draft annotations can be
- * opened in the editor, edited in-place, removed individually, or cleared as a
- * group before submit.
+ * Compact stacked annotations docked in the composer tray box. One row per
+ * comment: the note on the left, its source target on the right, edit/remove on
+ * hover. Collapsible; the whole list drains into the next submit (or the plan
+ * Approve / Cancel).
  */
 export function AnnotationTray({
   sessionId,
@@ -51,29 +66,29 @@ export function AnnotationTray({
   if (annotations.length === 0) return null;
 
   return (
-    <div className="mb-2 overflow-hidden rounded-lg border border-border/50 bg-card/80 shadow-sm">
-      <div className="flex w-full items-center gap-2 border-b border-border/40 bg-muted/20 px-2.5 py-1.5">
+    <div className="border-b border-border/40 bg-card/20">
+      <div className="flex w-full items-center gap-1.5 px-2 py-1">
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
-          className="flex min-h-7 flex-1 items-center gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          className="flex min-h-5 flex-1 items-center gap-1.5 text-left"
         >
           <HugeiconsIcon
             icon={BubbleChatIcon}
-            className="size-3.5 shrink-0 text-muted-foreground"
+            className="size-3 shrink-0 text-muted-foreground"
             aria-hidden="true"
           />
-          <span className="text-xs font-semibold text-foreground">
+          <span className="text-[11px] font-medium text-foreground">
             Annotations
           </span>
-          <span className="rounded border border-border/50 bg-background/70 px-1.5 py-px text-[10px] font-medium tabular-nums text-muted-foreground">
+          <span className="rounded bg-muted/60 px-1 text-[9px] font-medium tabular-nums text-muted-foreground">
             {annotations.length}
           </span>
           <HugeiconsIcon
             icon={ArrowDown01Icon}
             className={cn(
-              "ml-auto size-4 shrink-0 text-muted-foreground transition-transform",
+              "ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform",
               expanded ? "rotate-180" : "",
             )}
             aria-hidden="true"
@@ -82,73 +97,39 @@ export function AnnotationTray({
         <button
           type="button"
           onClick={() => clear(sessionId)}
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-          aria-label="Clear all annotations"
+          className="shrink-0 rounded px-1 text-[10px] text-muted-foreground hover:text-foreground"
         >
-          <X className="size-3.5" strokeWidth={1.8} />
+          Clear
         </button>
       </div>
       {expanded ? (
-        <ul className="max-h-64 space-y-px overflow-y-auto p-1">
-          {annotations.map((a, i) => (
+        <ul className="max-h-36 overflow-y-auto px-1 pb-1">
+          {annotations.map((a) => (
             <li
               key={a.id}
-              className="group/annotation flex items-stretch gap-1.5 rounded-md"
+              className="group/a flex items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-muted/40"
             >
-              <div className="flex min-w-0 flex-1 items-start gap-2 rounded-md px-2 py-1.5 hover:bg-muted/55">
-                <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-primary/10 text-[11px] font-semibold tabular-nums text-primary">
-                  {i + 1}
-                </span>
-                <span className="grid min-w-0 flex-1 gap-1">
-                  <button
-                    type="button"
-                    onClick={() => revealAnnotation(a)}
-                    className="min-w-0 justify-self-start rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                    title="Open annotation"
-                  >
-                    <AnnotationFileChip annotation={a} />
-                  </button>
-                  {editingId === a.id ? (
-                    <textarea
-                      value={editText}
-                      onChange={(e) => setEditText(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Escape") {
-                          e.preventDefault();
-                          setEditingId(null);
-                        } else if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                          updateComment(sessionId, a.id, editText);
-                          setEditingId(null);
-                        }
-                      }}
-                      rows={2}
-                      className="max-h-24 min-h-12 w-full resize-y rounded-md bg-background/70 px-2 py-1.5 text-sm leading-snug text-foreground outline-none ring-1 ring-border/50 focus:ring-ring/50"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => revealAnnotation(a)}
-                      className="min-w-0 truncate rounded text-left text-sm leading-snug text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                    >
-                      {a.comment}
-                    </button>
-                  )}
-                </span>
-              </div>
               {editingId === a.id ? (
-                <button
-                  type="button"
-                  onClick={() => {
+                <input
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                  onBlur={() => {
                     updateComment(sessionId, a.id, editText);
                     setEditingId(null);
                   }}
-                  className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                  aria-label="Save annotation"
-                >
-                  <HugeiconsIcon icon={Tick01Icon} className="size-3.5" />
-                </button>
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      e.preventDefault();
+                      setEditingId(null);
+                    } else if (e.key === "Enter") {
+                      e.preventDefault();
+                      updateComment(sessionId, a.id, editText);
+                      setEditingId(null);
+                    }
+                  }}
+                  className="min-w-0 flex-1 rounded bg-background/80 px-1.5 py-0.5 text-xs text-foreground outline-none ring-1 ring-border/50"
+                  autoFocus
+                />
               ) : (
                 <button
                   type="button"
@@ -156,19 +137,27 @@ export function AnnotationTray({
                     setEditingId(a.id);
                     setEditText(a.comment);
                   }}
-                  className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 group-hover/annotation:opacity-100"
-                  aria-label="Edit annotation"
+                  className="min-w-0 flex-1 truncate text-left text-xs leading-5 text-foreground"
+                  title="Edit comment"
                 >
-                  <HugeiconsIcon icon={PencilEdit01Icon} className="size-3.5" />
+                  {a.comment}
                 </button>
               )}
               <button
                 type="button"
+                onClick={() => revealAnnotation(a)}
+                className="max-w-[42%] shrink-0 truncate text-right font-mono text-[10px] text-muted-foreground/80 hover:text-foreground"
+                title={shortLabel(a)}
+              >
+                {shortLabel(a)}
+              </button>
+              <button
+                type="button"
                 onClick={() => remove(sessionId, a.id)}
-                className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 group-hover/annotation:opacity-100"
+                className="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 hover:text-foreground group-hover/a:opacity-100"
                 aria-label="Remove annotation"
               >
-                <X className="size-3.5" strokeWidth={1.8} />
+                <X className="size-3" strokeWidth={2} />
               </button>
             </li>
           ))}

--- a/apps/renderer/src/components/composer/plan-approval-tray.tsx
+++ b/apps/renderer/src/components/composer/plan-approval-tray.tsx
@@ -1,16 +1,23 @@
 import { CheckListIcon } from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
 
-import type { SessionId } from "@memoize/wire";
+import { ComposerInput, type SessionId } from "@memoize/wire";
 
+import {
+  annotationsForSession,
+  useAnnotationsStore,
+} from "../../store/annotations.ts";
+import { useMessagesStore } from "../../store/messages.ts";
 import { usePermissionsStore } from "../../store/permissions.ts";
 import { TrayPill } from "./tray-pill.tsx";
 
 /**
  * Pinned "Review plan" bar docked above the composer. The proposed plan still
- * renders inline in the chat scrollback (see `ExitPlanModeRow`); this tray only
+ * renders inline in the chat scrollback (see `ExitPlanModeRow`); this tray
  * hoists the Approve / Cancel decision down to where the user's cursor already
- * sits, so they don't have to scroll back up to act. Renders nothing unless an
+ * sits. If the user left annotations on the plan, the decision also DELIVERS
+ * them: they're sent as a message (so they land in the chat and reach the
+ * agent) before the plan is approved or cancelled. Renders nothing unless an
  * `ExitPlanMode` permission request is open for this session.
  */
 export function PlanApprovalTray({ sessionId }: { sessionId: SessionId }) {
@@ -24,35 +31,71 @@ export function PlanApprovalTray({ sessionId }: { sessionId: SessionId }) {
     return null;
   });
   const decide = usePermissionsStore((s) => s.decide);
+  const send = useMessagesStore((s) => s.send);
+  const annCount = useAnnotationsStore(
+    (s) => (s.bySession[sessionId] ?? []).length,
+  );
 
   if (pendingRequest === null) return null;
+
+  // Drain any pending annotations into a message so the user's comments land in
+  // the chat and reach the agent. Fire it before the decision so the feedback
+  // is registered alongside the plan response.
+  const flushAnnotations = () => {
+    const annotations = annotationsForSession(sessionId);
+    if (annotations.length === 0) return;
+    useAnnotationsStore.getState().clear(sessionId);
+    void send(
+      sessionId,
+      ComposerInput.make({
+        text: "",
+        attachments: [],
+        fileRefs: [],
+        skillRefs: [],
+        annotations,
+      }),
+    );
+  };
+
+  const decideWith = (decision: "AllowOnce" | "Deny") => {
+    flushAnnotations();
+    void decide(pendingRequest.id, { _tag: decision });
+  };
+
+  const hasComments = annCount > 0;
 
   return (
     <TrayPill
       flush
       className="bg-rose-500/10 hover:bg-rose-500/15"
       icon={
-        <HugeiconsIcon icon={CheckListIcon} strokeWidth={2} className="size-3.5" />
+        <HugeiconsIcon
+          icon={CheckListIcon}
+          strokeWidth={2}
+          className="size-3.5"
+        />
       }
       title="Review plan"
-      subtitle="Approve to start building"
+      subtitle={
+        hasComments
+          ? `${annCount} comment${annCount > 1 ? "s" : ""} will be sent`
+          : "Approve to start building"
+      }
       actions={
         <>
           <button
             type="button"
-            onClick={() => void decide(pendingRequest.id, { _tag: "Deny" })}
+            onClick={() => decideWith("Deny")}
             className="rounded-md px-2.5 py-0.5 text-[12px] text-muted-foreground hover:bg-muted/60 hover:text-foreground"
           >
-            Cancel
+            {hasComments ? "Send & cancel" : "Cancel"}
           </button>
           <button
             type="button"
-            onClick={() =>
-              void decide(pendingRequest.id, { _tag: "AllowOnce" })
-            }
+            onClick={() => decideWith("AllowOnce")}
             className="rounded-md bg-foreground px-2.5 py-0.5 text-[12px] font-medium text-background hover:opacity-90"
           >
-            Approve
+            {hasComments ? "Send & approve" : "Approve"}
           </button>
         </>
       }

--- a/apps/renderer/src/components/file-chip.tsx
+++ b/apps/renderer/src/components/file-chip.tsx
@@ -1,6 +1,14 @@
 import { createContext, useContext } from "react";
 
-import type { CodeAnnotation, FolderId, WorktreeId } from "@memoize/wire";
+import {
+  isElementAnnotation,
+  type Annotation,
+  type CodeAnnotation,
+  type FolderId,
+  type WorktreeId,
+} from "@memoize/wire";
+import { CursorMagicSelection02Icon } from "@hugeicons-pro/core-bulk-rounded";
+import { HugeiconsIcon } from "@hugeicons/react";
 
 import { cn } from "~/lib/utils";
 import { useUiStore, type FileView } from "~/store/ui";
@@ -105,9 +113,33 @@ export function AnnotationFileChip({
   annotation,
   className,
 }: {
-  readonly annotation: CodeAnnotation;
+  readonly annotation: Annotation;
   readonly className?: string;
 }) {
+  // Element annotations target a node in a rendered HTML artifact — there is no
+  // file to name, so the chip shows the picker icon + the element's human label.
+  if (isElementAnnotation(annotation)) {
+    return (
+      <span
+        className={cn(
+          "inline-flex max-w-full shrink-0 items-center gap-1.5 rounded-[0.375rem] border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]",
+          className,
+        )}
+        title={annotation.selector}
+      >
+        <HugeiconsIcon
+          icon={CursorMagicSelection02Icon}
+          className="size-3.5 shrink-0 text-muted-foreground"
+        />
+        <span className="min-w-0 truncate">
+          {annotation.text !== undefined && annotation.text.length > 0
+            ? `"${annotation.text}"`
+            : annotation.label}
+        </span>
+      </span>
+    );
+  }
+
   const name = basename(annotation.relPath);
   const range = annotationRangeLabel(annotation);
 

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -2,7 +2,11 @@ import { PatchDiff } from "@pierre/diffs/react";
 import { Effect } from "effect";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { CodeAnnotation, GitDiffResult } from "@memoize/wire";
+import {
+  isCodeAnnotation,
+  type Annotation,
+  type GitDiffResult,
+} from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
 import { classifyGit } from "../lib/git-rpc.ts";
@@ -136,7 +140,7 @@ type EditableFile = Extract<OpenFile, { kind: "text" | "external" }>;
 // `[]` literal from a zustand/`useSyncExternalStore` selector fails React's
 // snapshot identity check every render → "getSnapshot should be cached" and
 // an infinite update loop. One shared constant keeps the reference stable.
-const EMPTY_ANNOTATIONS: ReadonlyArray<CodeAnnotation> = [];
+const EMPTY_ANNOTATIONS: ReadonlyArray<Annotation> = [];
 
 function CodeMirrorBody({
   openFile,
@@ -188,6 +192,7 @@ function CodeMirrorBody({
   const visibleAnnotations = useMemo(
     () =>
       draftAnnotations
+        .filter(isCodeAnnotation)
         .filter(
           (a) =>
             a.relPath === annotationPath || a.absPath === annotationAbsPath,
@@ -460,7 +465,7 @@ function CodeMirrorBody({
           onCardOpenChange={setCardOpen}
           onConfirm={(draft) => {
             const created = addAnnotation(draft);
-            if (created !== null) {
+            if (created !== null && isCodeAnnotation(created)) {
               useUiStore.getState().revealAnnotation(created);
             }
             // Collapse the selection so the affordance dismisses itself.

--- a/apps/renderer/src/components/markdown-body.tsx
+++ b/apps/renderer/src/components/markdown-body.tsx
@@ -19,10 +19,12 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "~/lib/utils";
+import { useSettingsStore } from "~/store/settings";
 import { useUiStore } from "~/store/ui";
 import { useWorkspaceStore } from "~/store/workspace";
 import { useWorktreesStore } from "~/store/worktrees";
 
+import { HtmlArtifact } from "./artifact/html-artifact.tsx";
 import { CodeBlock } from "./code-block.tsx";
 import { resolveFileOpenTarget, useFileChipContext } from "./file-chip.tsx";
 import {
@@ -393,11 +395,22 @@ function MermaidDiagram({ source }: { source: string }) {
 export function MarkdownBody({
   children,
   className,
+  htmlArtifactRef,
 }: {
   children: string;
   className?: string;
+  /**
+   * When set, fenced ```html blocks render as interactive, annotatable
+   * `HtmlArtifact`s (rather than static code blocks) and tag their annotations
+   * with this id (the source message / plan). Only chat surfaces pass it; PR
+   * descriptions / comments keep rendering html as plain code.
+   */
+  htmlArtifactRef?: string;
 }) {
   const { folderId, worktreeId } = useFileChipContext();
+  const planArtifactsEnabled = useSettingsStore(
+    (s) => s.planArtifactsEnabled,
+  );
   const openFileInTab = useUiStore((s) => s.openFileInTab);
   const folderPath = useWorkspaceStore((s) => {
     if (folderId === null) return null;
@@ -465,6 +478,16 @@ export function MarkdownBody({
             );
             if (language?.toLowerCase() === "mermaid") {
               return <MermaidDiagram source={text} />;
+            }
+
+            if (
+              planArtifactsEnabled &&
+              htmlArtifactRef !== undefined &&
+              language?.toLowerCase() === "html"
+            ) {
+              return (
+                <HtmlArtifact source={text} sourceRef={htmlArtifactRef} />
+              );
             }
 
             const filename =

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -14,8 +14,8 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
 import type {
   AgentItemId,
+  Annotation,
   AttachmentRef,
-  CodeAnnotation,
   FileRef,
   Message,
   ProviderId,
@@ -119,6 +119,7 @@ export function MessageRow({
         <AssistantBubble
           text={message.content.text}
           createdAt={message.createdAt}
+          sourceRef={message.id}
         />
       );
     case "thinking":
@@ -133,6 +134,7 @@ export function MessageRow({
         return (
           <ExitPlanModeRow
             input={message.content.input}
+            itemId={message.content.itemId}
             result={resultsByItemId.get(message.content.itemId)}
           />
         );
@@ -239,7 +241,7 @@ function UserBubble({
   attachments?: ReadonlyArray<AttachmentRef>;
   fileRefs?: ReadonlyArray<FileRef>;
   skillRefs?: ReadonlyArray<SkillRef>;
-  annotations?: ReadonlyArray<CodeAnnotation>;
+  annotations?: ReadonlyArray<Annotation>;
   goal?: boolean;
 }) {
   const hasAnnotations = annotations !== undefined && annotations.length > 0;
@@ -374,14 +376,16 @@ function UserBubble({
 function AssistantBubble({
   text,
   createdAt,
+  sourceRef,
 }: {
   text: string;
   createdAt?: Date;
+  sourceRef?: string;
 }) {
   return (
     <div className="px-4 py-2">
       <div className="max-w-[88%]">
-        <MarkdownBody>{text}</MarkdownBody>
+        <MarkdownBody htmlArtifactRef={sourceRef}>{text}</MarkdownBody>
         <div className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
           {createdAt !== undefined ? (
             <span className="tabular-nums">{formatMessageTime(createdAt)}</span>

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -576,6 +576,12 @@ function GeneralPane() {
   const setOnboardingCompleted = useSettingsStore(
     (s) => s.setOnboardingCompleted,
   );
+  const planArtifactsEnabled = useSettingsStore(
+    (s) => s.planArtifactsEnabled,
+  );
+  const setPlanArtifactsEnabled = useSettingsStore(
+    (s) => s.setPlanArtifactsEnabled,
+  );
   const setView = useUiStore((s) => s.setView);
 
   // Local mirror so typing is smooth; persist on blur to avoid an atomic
@@ -683,6 +689,22 @@ function GeneralPane() {
             </Button>
           </div>
         </SettingsRow>
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Experimental"
+        description="Newer features still being polished. Toggle on to try them."
+      >
+        <SettingsRow
+          title="Plan artifacts"
+          description="Render plans as embedded, annotatable HTML artifacts. Plan mode asks the agent for a visual HTML plan you can click element-by-element to leave inline feedback before approving. When off, plans render as plain markdown. Applies to new chats."
+          action={
+            <Switch
+              checked={planArtifactsEnabled}
+              onCheckedChange={setPlanArtifactsEnabled}
+            />
+          }
+        />
       </SettingsGroup>
 
       <SettingsGroup

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -23,9 +23,12 @@ import { useState } from "react";
 import type { UserQuestion, UserQuestionAnswer } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
+import { useSettingsStore } from "../store/settings.ts";
 
 import { CodeBlock } from "./code-block.tsx";
 import { FileBadge } from "./file-badge.tsx";
+import { AnnotatableArtifact } from "./artifact/annotatable.tsx";
+import { HtmlArtifact, extractHtmlDoc } from "./artifact/html-artifact.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
 import {
   diffStats,
@@ -1174,17 +1177,43 @@ const buildToolView = (
  */
 export function ExitPlanModeRow({
   input,
+  itemId,
   result,
 }: {
   input: unknown;
+  itemId?: string;
   result?: ToolResult;
 }) {
+  const planArtifactsEnabled = useSettingsStore(
+    (s) => s.planArtifactsEnabled,
+  );
   const plan =
     typeof input === "object" && input !== null && "plan" in input
       ? typeof (input as { plan?: unknown }).plan === "string"
         ? ((input as { plan: string }).plan as string)
         : null
       : null;
+
+  // Plan artifacts are opt-in (Settings → General). When off, plans render as
+  // plain markdown — memoize's original behaviour, no artifact, no annotate.
+  // When on: a genuine HTML-document plan goes in the isolated iframe; a
+  // markdown plan renders with the app's own MarkdownBody wrapped so any
+  // heading/step/element is clickable to leave inline feedback before approving.
+  // (`itemId` is the annotation source ref; absent only in odd replays.)
+  const renderPlan = (body: string): React.ReactNode => {
+    if (!planArtifactsEnabled || itemId === undefined) {
+      return <MarkdownBody>{body}</MarkdownBody>;
+    }
+    const html = extractHtmlDoc(body);
+    if (html !== null) {
+      return <HtmlArtifact source={html} sourceRef={itemId} />;
+    }
+    return (
+      <AnnotatableArtifact sourceRef={itemId}>
+        <MarkdownBody>{body}</MarkdownBody>
+      </AnnotatableArtifact>
+    );
+  };
 
   const status: "pending" | "approved" | "cancelled" =
     result === undefined
@@ -1211,7 +1240,7 @@ export function ExitPlanModeRow({
             (No plan body.)
           </p>
         ) : (
-          <MarkdownBody>{plan}</MarkdownBody>
+          renderPlan(plan)
         )}
       </div>
     );
@@ -1223,7 +1252,7 @@ export function ExitPlanModeRow({
       {plan === null ? (
         <p className="text-sm italic text-muted-foreground">(No plan body.)</p>
       ) : (
-        <MarkdownBody>{plan}</MarkdownBody>
+        renderPlan(plan)
       )}
       <div className="mt-3 flex items-center justify-end text-[11px] text-muted-foreground">
         <span

--- a/apps/renderer/src/store/annotations.ts
+++ b/apps/renderer/src/store/annotations.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-import type { CodeAnnotation, SessionId } from "@memoize/wire";
+import type { Annotation, NewAnnotation, SessionId } from "@memoize/wire";
 
 /**
  * Draft code annotations, keyed by chat session. The user selects code in the
@@ -14,7 +14,7 @@ import type { CodeAnnotation, SessionId } from "@memoize/wire";
  */
 const STORAGE_KEY = "memoize.annotations.v1";
 
-type Persisted = Record<string, ReadonlyArray<CodeAnnotation>>;
+type Persisted = Record<string, ReadonlyArray<Annotation>>;
 
 const load = (): Persisted => {
   try {
@@ -50,7 +50,7 @@ type AnnotationsState = {
   /** Append an annotation; `id` is generated here. Returns the new id. */
   readonly add: (
     sessionId: SessionId,
-    annotation: Omit<CodeAnnotation, "id">,
+    annotation: NewAnnotation,
   ) => string;
   readonly remove: (sessionId: SessionId, id: string) => void;
   readonly updateComment: (
@@ -65,7 +65,7 @@ export const useAnnotationsStore = create<AnnotationsState>((set, get) => ({
   bySession: load(),
   add: (sessionId, annotation) => {
     const id = newId();
-    const entry: CodeAnnotation = { ...annotation, id };
+    const entry = { ...annotation, id } as Annotation;
     const current = get().bySession[sessionId] ?? [];
     const bySession = { ...get().bySession, [sessionId]: [...current, entry] };
     set({ bySession });
@@ -106,5 +106,5 @@ export const useAnnotationsStore = create<AnnotationsState>((set, get) => ({
 /** Snapshot read for non-reactive callers (e.g. the submit handler). */
 export const annotationsForSession = (
   sessionId: SessionId,
-): ReadonlyArray<CodeAnnotation> =>
+): ReadonlyArray<Annotation> =>
   useAnnotationsStore.getState().bySession[sessionId] ?? [];

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -66,6 +66,7 @@ const fallbackSnapshot = (): SettingsSlice => ({
   providerEnabled: seedProviderEnabled(),
   branchNamingStyle: DEFAULT_BRANCH_NAMING_STYLE,
   branchNamingPrefix: "",
+  planArtifactsEnabled: false,
 });
 
 const sliceFromFile = (file: SettingsFile): SettingsSlice => {
@@ -92,6 +93,7 @@ const sliceFromFile = (file: SettingsFile): SettingsSlice => {
     },
     branchNamingStyle: file.branchNamingStyle,
     branchNamingPrefix: file.branchNamingPrefix,
+    planArtifactsEnabled: file.planArtifactsEnabled,
   };
 };
 
@@ -106,6 +108,7 @@ interface SettingsSlice {
   readonly providerEnabled: Record<ProviderId, boolean>;
   readonly branchNamingStyle: BranchNamingStyle;
   readonly branchNamingPrefix: string;
+  readonly planArtifactsEnabled: boolean;
 }
 
 type SettingsState = SettingsSlice & {
@@ -132,6 +135,7 @@ type SettingsState = SettingsSlice & {
   readonly setProviderEnabled: (providerId: ProviderId, value: boolean) => void;
   readonly setBranchNamingStyle: (style: BranchNamingStyle) => void;
   readonly setBranchNamingPrefix: (prefix: string) => void;
+  readonly setPlanArtifactsEnabled: (value: boolean) => void;
 };
 
 let streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
@@ -305,6 +309,15 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const client = await getRpcClient();
       await Effect.runPromise(
         client.settings.update({ patch: { branchNamingPrefix: prefix } }),
+      );
+    })();
+  },
+  setPlanArtifactsEnabled: (value) => {
+    set({ planArtifactsEnabled: value });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({ patch: { planArtifactsEnabled: value } }),
       );
     })();
   },

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -74,6 +74,7 @@ const freshSettings = (): SettingsFile =>
     subagents: { enableForNewSessions: true, presets: {} },
     branchNamingStyle: "username-slug",
     branchNamingPrefix: "",
+    planArtifactsEnabled: false,
   });
 
 const freshKeybindings = (): KeybindingsFile =>
@@ -212,6 +213,11 @@ const coerceSettings = (raw: unknown): SettingsFile => {
       ? obj.branchNamingPrefix
       : base.branchNamingPrefix;
 
+  const planArtifactsEnabled =
+    typeof obj.planArtifactsEnabled === "boolean"
+      ? obj.planArtifactsEnabled
+      : base.planArtifactsEnabled;
+
   return SettingsFile.make({
     schemaVersion: 1,
     defaultProviderId: provider,
@@ -225,6 +231,7 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     subagents,
     branchNamingStyle,
     branchNamingPrefix,
+    planArtifactsEnabled,
   });
 };
 
@@ -477,6 +484,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
             patch.branchNamingStyle ?? cur.branchNamingStyle,
           branchNamingPrefix:
             patch.branchNamingPrefix ?? cur.branchNamingPrefix,
+          planArtifactsEnabled:
+            patch.planArtifactsEnabled ?? cur.planArtifactsEnabled,
         });
         const serialized = serialize(next);
         yield* writeAtomically(settingsPath, serialized);
@@ -586,6 +595,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
             subagents,
             branchNamingStyle: cur.branchNamingStyle,
             branchNamingPrefix: cur.branchNamingPrefix,
+            planArtifactsEnabled: cur.planArtifactsEnabled,
           });
 
           const serialized = serialize(merged);

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -31,6 +31,7 @@ import {
   applyClaudeWorktreeEnv,
   claudeWorktreePrompt,
 } from "./claude-worktree-prompt.ts";
+import { PLAN_MODE_HTML_INSTRUCTIONS } from "./planMode.ts";
 
 /**
  * Live-only handle for one Claude SDK conversation. The orchestrator
@@ -1556,7 +1557,9 @@ export const startClaudeSession = (
         "Phase 1 — Explore. Use only read-only tools (Read, Glob, Grep).",
         "Phase 2 — Track. Maintain a TodoWrite list as you discover work; keep it crisp.",
         `Phase 3 — Ask. When a real fork in the road exists (which library, which scope, which approach), call ${ASK_USER_QUESTION_FQN} with the choices instead of guessing.`,
-        "Phase 4 — Propose. Call ExitPlanMode with a concise plan: what changes, where, and how to verify.",
+        "Phase 4 — Propose. Call ExitPlanMode with a plan covering what changes, where, and how to verify.",
+        // Visual-HTML plan formatting only when the plan-artifacts setting is on.
+        ...(input.planHtml === true ? [PLAN_MODE_HTML_INSTRUCTIONS] : []),
       ].join("\n"),
       // Reasoning effort: mapped from FE picker via `input.modelOptions
       // .effort` (or legacy `reasoning`). The per-model descriptor in

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -885,7 +885,11 @@ export const startCodexSession = (
       // Plan-mode emulation: Codex has no native "plan" runtime mode, so
       // prepend a developer-instructions block while plan mode is active.
       // The sandbox policy still gates writes, so this is belt-and-braces.
-      const promptText = applyPlanModePrefix(currentMode, text);
+      const promptText = applyPlanModePrefix(
+        currentMode,
+        text,
+        input.planHtml ?? false,
+      );
       // Reasoning effort: forwarded from FE picker via
       // `input.modelOptions.reasoning`. Pass through low/medium/high
       // directly — Codex accepts the same literal set we use in wire's

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -638,7 +638,11 @@ export const startGeminiSession = (
       if (sid === null) return;
       // Plan-mode emulation: gemini ACP has no native read-only switch, so
       // prepend a developer-instructions block while plan mode is active.
-      const promptText = applyPlanModePrefix(currentMode, text);
+      const promptText = applyPlanModePrefix(
+        currentMode,
+        text,
+        input.planHtml ?? false,
+      );
       inflight = inflight
         .then(async () => {
           if (closed) return;

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -823,7 +823,11 @@ export const startGrokSession = (
     const enqueuePrompt = (text: string): void => {
       // Plan-mode emulation: grok ACP has no native read-only switch, so
       // prepend a developer-instructions block while plan mode is active.
-      const promptText = applyPlanModePrefix(currentMode, text);
+      const promptText = applyPlanModePrefix(
+        currentMode,
+        text,
+        input.planHtml ?? false,
+      );
       inflight = inflight
         .then(async () => {
           if (closed) return;

--- a/apps/server/src/provider/drivers/planMode.ts
+++ b/apps/server/src/provider/drivers/planMode.ts
@@ -11,7 +11,7 @@ import type { PermissionMode } from "@memoize/wire";
  * `RuntimeMode: "approval-required"` as the safety net for any tool call
  * that wants to mutate state.
  */
-export const PLAN_MODE_INSTRUCTIONS =
+const PLAN_MODE_READONLY =
   "PLAN MODE — you are in read-only planning mode. Investigate the " +
   "codebase, ask clarifying questions if needed, then propose a concrete " +
   "plan. DO NOT modify files, run mutating commands, or invoke any tool " +
@@ -20,13 +20,69 @@ export const PLAN_MODE_INSTRUCTIONS =
   "exiting plan mode.";
 
 /**
+ * Plan formatting: emit the plan as a rich, VISUAL self-contained HTML document
+ * (rendered as an embedded, annotatable artifact the user can click to leave
+ * inline feedback). Used by every provider in plan mode. Designed to look great
+ * embedded in a DARK app, and to be skimmable — colour, hierarchy, and grouping
+ * carry meaning so the user understands the plan at a glance, not a wall of text.
+ */
+export const PLAN_MODE_HTML_INSTRUCTIONS = [
+  "Present the FINAL plan as a SINGLE, SELF-CONTAINED, VISUALLY RICH HTML",
+  "DOCUMENT — a review surface the user skims in seconds, NOT a wall of text",
+  "and NOT plain markdown. If you have an ExitPlanMode tool, put the whole",
+  "document in its `plan` field; otherwise emit exactly ONE ```html fenced",
+  "block. It renders embedded in a DARK app, in a sandbox that allows scripts",
+  "and network, and the user clicks elements / selects text to annotate them.",
+  "",
+  "DESIGN DIRECTION — pick in this strict priority: (1) if the user named a look",
+  "or design system, use it; (2) else if the plan is about a specific app or",
+  "codebase, MATCH that project's own design system — its Tailwind/theme config,",
+  "CSS variables / design tokens, component library, or brand — so the plan",
+  "looks like it belongs to the product; (3) else use the polished dark system",
+  "below. State which you used in one short comment.",
+  "",
+  "You MAY (and for components/diagrams SHOULD) load a CDN — it works here:",
+  "Tailwind v4 browser runtime + DaisyUI v5 for polished components, and Mermaid",
+  "for any flow / architecture / state / sequence diagram (never hand-build",
+  "boxes-and-arrows from divs). If you don't use a CDN, hand-write inline CSS to",
+  "the SAME quality bar — the result must never look default-browser plain.",
+  "",
+  "DEFAULT DARK SYSTEM (when hand-writing CSS): page bg #0d0d12; cards #16161d",
+  "with 1px #262630 borders, ~12px radius, and a soft shadow; text #e7e7ea,",
+  "muted #9b9ba6; accents that MEAN things — lime #84cc16, sky #38bdf8, amber",
+  "#fbbf24, rose #fb7185, violet #a78bfa. System font stack, a real type scale",
+  "(≈24/17/14/12px), generous spacing (16–24px). A header band (plan title +",
+  "one-line summary, optional gradient accent) sets the tone.",
+  "",
+  "STRUCTURE so hierarchy is obvious at a glance:",
+  "- Group work into titled CARDS / sections (Goal, Changes per file or area,",
+  "  Verification, Risks). Use a responsive card grid where it helps.",
+  "- Number each step with a badge; tag items with COLOUR-CODED pills (e.g.",
+  "  New=lime, Edit=sky, Delete=rose; or risk High/Med/Low).",
+  "- Use TABLES for dense comparisons (option A vs B, current vs target) and",
+  "  callout boxes for risks/notes. Every element keeps readable visible TEXT.",
+  "",
+  "ROBUSTNESS: self-contained (no local assets; CDN-only externals), no looping",
+  "animations. Prevent horizontal overflow at EVERY nesting level — give",
+  "grid/flex children `minmax(0,1fr)` tracks and `min-width:0`, and wrap or",
+  "truncate long unbreakable text (paths, ids, monospace). Make it intentional",
+  "and genuinely polished.",
+].join("\n");
+
+export const PLAN_MODE_INSTRUCTIONS = `${PLAN_MODE_READONLY}\n\n${PLAN_MODE_HTML_INSTRUCTIONS}`;
+
+/**
  * Wrap a user-supplied prompt with the plan-mode developer-instructions
- * prefix iff plan mode is active. No-op for `default` / `acceptEdits`.
+ * prefix iff plan mode is active. No-op for `default` / `acceptEdits`. For
+ * providers that emulate plan mode via the prompt (no runtime read-only switch).
  */
 export const applyPlanModePrefix = (
   permissionMode: PermissionMode,
   text: string,
-): string =>
-  permissionMode === "plan"
-    ? `${PLAN_MODE_INSTRUCTIONS}\n\n---\n\n${text}`
-    : text;
+  /** Include the visual-HTML formatting guidance (the plan-artifacts flag). */
+  includeHtml = false,
+): string => {
+  if (permissionMode !== "plan") return text;
+  const prefix = includeHtml ? PLAN_MODE_INSTRUCTIONS : PLAN_MODE_READONLY;
+  return `${prefix}\n\n---\n\n${text}`;
+};

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -20,9 +20,10 @@ import {
   type AgentDefinition,
   type AgentEvent,
   AgentSessionNotFoundError,
+  type Annotation,
   type AttachmentRef,
-  type CodeAnnotation,
   type FileRef,
+  isElementAnnotation,
   type FolderId,
   GoalUnsupportedError,
   type MessageContent,
@@ -442,22 +443,30 @@ const titleFromInitial = (prompt: string | undefined): string => {
 };
 
 /**
- * Render stacked code annotations into the numbered list the model receives.
- * Each entry is `path:lineRange — comment`; the agent's cwd is the workspace
- * root, so the relative path resolves when it reads the file. Pure string fn —
- * no I/O.
+ * Render stacked annotations into the numbered list the model receives. Code
+ * entries are `path:lineRange — comment` (the agent's cwd is the workspace
+ * root, so the relative path resolves when it reads the file). Element entries
+ * point at a node in the HTML artifact the agent itself produced, by selector +
+ * human label, so it can map the comment back. Pure string fn — no I/O.
  */
 const serializeAnnotations = (
-  annotations: ReadonlyArray<CodeAnnotation>,
+  annotations: ReadonlyArray<Annotation>,
 ): string => {
   const lines = annotations.map((a, i) => {
+    if (isElementAnnotation(a)) {
+      const where =
+        a.text !== undefined && a.text.length > 0
+          ? `text "${a.text}"`
+          : a.label;
+      return `${i + 1}. [rendered UI] ${where} (selector: ${a.selector}) — ${a.comment}`;
+    }
     const range =
       a.startLine === a.endLine
         ? `${a.startLine}`
         : `${a.startLine}-${a.endLine}`;
     return `${i + 1}. ${a.relPath}:${range} — ${a.comment}`;
   });
-  return ["Code annotations:", ...lines].join("\n");
+  return ["Annotations:", ...lines].join("\n");
 };
 
 const formatProviderFailure = (cause: unknown): string => {
@@ -2687,7 +2696,7 @@ export const MessageStoreLive = Layer.scoped(
       attachments?: ReadonlyArray<AttachmentRef>,
       fileRefs?: ReadonlyArray<FileRef>,
       skillRefs?: ReadonlyArray<SkillRef>,
-      annotations?: ReadonlyArray<CodeAnnotation>,
+      annotations?: ReadonlyArray<Annotation>,
       asGoal?: boolean,
     ): Effect.Effect<boolean, SessionNotFoundError> =>
       Effect.gen(function* () {

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -39,6 +39,7 @@ import {
   type OpencodeSessionHandle,
 } from "../drivers/opencode.ts";
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import { ConfigStoreService } from "../../config-store/services/config-store-service.ts";
 import { buildIndexTools } from "../../code-index/claude-tools.ts";
 import { buildBrowserTools } from "../drivers/browser-tools.ts";
 import { IndexRegistry } from "../../code-index/services/index-registry.ts";
@@ -91,6 +92,7 @@ export const ProviderServiceLive = Layer.effect(
     const attachmentService = yield* AttachmentService;
     const browserBridge = yield* BrowserBridgeService;
     const indexRegistry = yield* IndexRegistry;
+    const configStore = yield* ConfigStoreService;
     const runtime = yield* Effect.runtime<never>();
     const sessions = yield* Ref.make<Map<AgentSessionId, SessionEntry>>(
       new Map(),
@@ -188,6 +190,15 @@ export const ProviderServiceLive = Layer.effect(
             .get(input.providerId)
             .pipe(Effect.catchAll(() => Effect.succeed<string | null>(null)));
           const sessionId = input.sessionId ?? nextSessionId();
+          // Capture the plan-artifacts setting at session start so plan mode
+          // knows whether to ask the agent for a rich HTML plan. Threaded to
+          // every driver via `planInput.planHtml`; drivers that don't emulate
+          // plan mode simply ignore it.
+          const settings = yield* configStore.getSettings();
+          const planInput = {
+            ...input,
+            planHtml: settings.planArtifactsEnabled,
+          };
           let handle: SessionHandle;
           if (input.providerId === "gemini") {
             // Same story as Grok: hand the driver the user's installed
@@ -206,7 +217,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startGeminiSession(
-              input,
+              planInput,
               cwd,
               apiKey,
               geminiPath,
@@ -233,7 +244,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startGrokSession(
-              input,
+              planInput,
               cwd,
               apiKey,
               grokPath,
@@ -260,7 +271,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startOpencodeSession(
-              input,
+              planInput,
               cwd,
               apiKey,
               opencodePath,
@@ -288,7 +299,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startCursorSession(
-              input,
+              planInput,
               cwd,
               apiKey,
               cursorPath,
@@ -334,7 +345,7 @@ export const ProviderServiceLive = Layer.effect(
             );
 
             handle = yield* startClaudeSession(
-              input,
+              planInput,
               cwd,
               apiKey,
               claudePath,
@@ -373,7 +384,7 @@ export const ProviderServiceLive = Layer.effect(
             // either the banner before sending or the friendly error after,
             // never the cryptic SDK trace.
             handle = yield* startCodexSession(
-              input,
+              planInput,
               cwd,
               apiKey,
               codexPath,

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -13,7 +13,7 @@ import type {
   ChatId,
   ChatNotFoundError,
   ChatUnarchiveResult,
-  CodeAnnotation,
+  Annotation,
   ComposerInput,
   FileRef,
   FolderId,
@@ -349,7 +349,7 @@ export interface MessageStoreShape {
     attachments?: ReadonlyArray<AttachmentRef>,
     fileRefs?: ReadonlyArray<FileRef>,
     skillRefs?: ReadonlyArray<SkillRef>,
-    annotations?: ReadonlyArray<CodeAnnotation>,
+    annotations?: ReadonlyArray<Annotation>,
     asGoal?: boolean,
   ) => Effect.Effect<void, SessionNotFoundError>;
 

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -201,6 +201,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(AttachmentLayer),
     Layer.provide(BrowserBridgeLayer),
     Layer.provide(IndexLayer),
+    Layer.provide(ConfigStoreLayer),
     Layer.provide(NodeContext.layer),
   );
 

--- a/apps/server/test/planMode.test.ts
+++ b/apps/server/test/planMode.test.ts
@@ -2,26 +2,38 @@ import { describe, expect, it } from "bun:test";
 
 import type { PermissionMode } from "@memoize/wire";
 
-import { applyPlanModePrefix, PLAN_MODE_INSTRUCTIONS } from "../src/provider/drivers/planMode.ts";
+import {
+  applyPlanModePrefix,
+  PLAN_MODE_HTML_INSTRUCTIONS,
+  PLAN_MODE_INSTRUCTIONS,
+} from "../src/provider/drivers/planMode.ts";
 
 describe("applyPlanModePrefix", () => {
-  it("prepends the plan-mode instructions when plan mode is active", () => {
-    const out = applyPlanModePrefix("plan", "fix the bug");
+  it("prepends the full instructions (incl. HTML) when plan-artifacts is on", () => {
+    const out = applyPlanModePrefix("plan", "fix the bug", true);
     expect(out).toBe(`${PLAN_MODE_INSTRUCTIONS}\n\n---\n\nfix the bug`);
-    expect(out.startsWith(PLAN_MODE_INSTRUCTIONS)).toBe(true);
+    expect(out.endsWith("fix the bug")).toBe(true);
+  });
+
+  it("omits the HTML formatting when plan-artifacts is off (default)", () => {
+    const out = applyPlanModePrefix("plan", "fix the bug");
+    expect(out.startsWith("PLAN MODE")).toBe(true);
+    expect(out.includes(PLAN_MODE_HTML_INSTRUCTIONS)).toBe(false);
     expect(out.endsWith("fix the bug")).toBe(true);
   });
 
   it("passes the prompt through unchanged outside plan mode", () => {
     const modes: ReadonlyArray<PermissionMode> = ["default", "acceptEdits"];
     for (const mode of modes) {
-      expect(applyPlanModePrefix(mode, "fix the bug")).toBe("fix the bug");
+      expect(applyPlanModePrefix(mode, "fix the bug", true)).toBe(
+        "fix the bug",
+      );
     }
   });
 
   it("preserves an empty prompt", () => {
     expect(applyPlanModePrefix("default", "")).toBe("");
-    expect(applyPlanModePrefix("plan", "")).toBe(
+    expect(applyPlanModePrefix("plan", "", true)).toBe(
       `${PLAN_MODE_INSTRUCTIONS}\n\n---\n\n`,
     );
   });

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -690,6 +690,14 @@ export const StartSessionInput = Schema.Struct({
   modelOptions: Schema.optional(
     Schema.Record({ key: Schema.String, value: Schema.String }),
   ),
+  /**
+   * Opt-in (mirrors `SettingsFile.planArtifactsEnabled`): when true, plan mode
+   * instructs the agent to present its plan as a rich, self-contained HTML
+   * document so the renderer can show it as an embedded, annotatable artifact.
+   * When false/omitted, the plan-mode prompt stays plain. Set once at session
+   * start by `ProviderService` from the current setting.
+   */
+  planHtml: Schema.optional(Schema.Boolean),
 });
 export type StartSessionInput = typeof StartSessionInput.Type;
 

--- a/packages/wire/src/composer.ts
+++ b/packages/wire/src/composer.ts
@@ -69,6 +69,56 @@ export const CodeAnnotation = Schema.Struct({
 export type CodeAnnotation = typeof CodeAnnotation.Type;
 
 /**
+ * A pinned element or text region inside an embedded HTML artifact (a plan or a
+ * fenced `html` block rendered inline in chat). The rendered-HTML analogue of
+ * `CodeAnnotation`: the user clicks an element or selects text in the preview
+ * and pins a comment; it stacks in the same tray and serialises into the same
+ * prompt. No HTML crosses the wire — `selector` + `label` pinpoint the element
+ * inside the document the agent itself produced, so it can map the comment back.
+ */
+export const ElementAnnotation = Schema.Struct({
+  _tag: Schema.Literal("element"),
+  /** Client-generated v4 UUID — list keys + removal. */
+  id: Schema.String,
+  /** Id of the source message / plan whose rendered artifact this targets. */
+  sourceRef: Schema.String,
+  /** Best-effort unique CSS selector within the artifact root. */
+  selector: Schema.String,
+  /** Human label: tag + trimmed text, e.g. `button "Get started"`. */
+  label: Schema.String,
+  /** Present when the user annotated a text selection rather than an element. */
+  text: Schema.optional(Schema.String),
+  comment: Schema.String,
+});
+export type ElementAnnotation = typeof ElementAnnotation.Type;
+
+/**
+ * Either kind of pinned annotation. Decode tries `ElementAnnotation` first (it
+ * requires `_tag: "element"`); anything without that tag falls back to the
+ * untagged `CodeAnnotation`, so annotations persisted before HTML artifacts
+ * existed still decode.
+ */
+export const Annotation = Schema.Union(ElementAnnotation, CodeAnnotation);
+export type Annotation = typeof Annotation.Type;
+
+/**
+ * An annotation before the store mints its `id`. Spelled as an explicit
+ * (distributive) union because `Omit<Annotation, "id">` over a union collapses
+ * to only the shared keys, dropping each variant's distinct fields.
+ */
+export type NewAnnotation =
+  | Omit<CodeAnnotation, "id">
+  | Omit<ElementAnnotation, "id">;
+
+/** Narrow an `Annotation` to the HTML-artifact element/text variant. */
+export const isElementAnnotation = (a: Annotation): a is ElementAnnotation =>
+  "_tag" in a;
+
+/** Narrow an `Annotation` to the code-region variant. */
+export const isCodeAnnotation = (a: Annotation): a is CodeAnnotation =>
+  !("_tag" in a);
+
+/**
  * The full payload of a single composer submission. `text` is the editor
  * document with `@` / `/` tokens preserved as plain text; the typed arrays
  * give the server enough metadata to expand each segment without re-parsing.
@@ -79,7 +129,7 @@ export class ComposerInput extends Schema.Class<ComposerInput>("ComposerInput")(
     attachments: Schema.Array(AttachmentRef),
     fileRefs: Schema.Array(FileRef),
     skillRefs: Schema.Array(SkillRef),
-    annotations: Schema.optionalWith(Schema.Array(CodeAnnotation), {
+    annotations: Schema.optionalWith(Schema.Array(Annotation), {
       default: () => [],
     }),
   },

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -10,8 +10,8 @@ import {
   UserQuestion,
 } from "./agent.ts";
 import {
+  Annotation,
   AttachmentRef,
-  CodeAnnotation,
   ComposerInput,
   FileRef,
   SkillRef,
@@ -173,7 +173,7 @@ const UserRichContent = Schema.TaggedStruct("user_rich", {
   skillRefs: Schema.Array(SkillRef),
   // Additive + back-compat: rows persisted before code annotations existed
   // decode with an empty list rather than failing.
-  annotations: Schema.optionalWith(Schema.Array(CodeAnnotation), {
+  annotations: Schema.optionalWith(Schema.Array(Annotation), {
     default: () => [],
   }),
   goal: Schema.optional(Schema.Boolean),

--- a/packages/wire/src/settings.ts
+++ b/packages/wire/src/settings.ts
@@ -90,6 +90,13 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
    * Empty falls back to a bare slug.
    */
   branchNamingPrefix: Schema.String,
+  /**
+   * Opt-in: render plans as embedded, annotatable HTML artifacts. When on,
+   * plan mode instructs the agent to emit a visual HTML plan and the renderer
+   * shows it as a clickable artifact; when off, plans render as plain markdown.
+   * Defaults off.
+   */
+  planArtifactsEnabled: Schema.Boolean,
 }) {}
 
 /**
@@ -122,6 +129,7 @@ export const SettingsPatch = Schema.Struct({
   ),
   branchNamingStyle: Schema.optional(BranchNamingStyle),
   branchNamingPrefix: Schema.optional(Schema.String),
+  planArtifactsEnabled: Schema.optional(Schema.Boolean),
 });
 export type SettingsPatch = typeof SettingsPatch.Type;
 

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -381,6 +381,7 @@ describe("SettingsFile round-trip", () => {
       subagents: { enableForNewSessions: true, presets: {} },
       branchNamingStyle: "username-slug",
       branchNamingPrefix: "",
+      planArtifactsEnabled: true,
     });
   });
 
@@ -413,6 +414,7 @@ describe("SettingsFile round-trip", () => {
         subagents: { enableForNewSessions: true, presets: {} },
         branchNamingStyle: "username-slug",
         branchNamingPrefix: "",
+        planArtifactsEnabled: false,
       }),
     ).toThrow();
   });


### PR DESCRIPTION
Renders agent plans (and fenced ```html blocks) as embedded, sandboxed HTML artifacts in chat: users toggle **Annotate** to click elements or select text and pin comments that stack in the composer tray and travel back to the agent on the next send or via the plan **Approve/Cancel** buttons. Plan mode now instructs every provider (Claude, Codex, Grok, Gemini) to emit a rich, visual HTML plan, and element/text annotations are serialized into the prompt. Adds an `Annotation` wire union (code + element) threaded through the composer, message store, and serialization, and compacts the annotation tray into the composer tray box. The whole feature is gated behind a new **Settings → General → Plan artifacts** toggle (`planArtifactsEnabled`), off by default. Also updates the planMode and schema tests for the new types.