### PR TITLE
Animated gradient shimmer for loading states

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -43,6 +43,7 @@
     "diff": "^9.0.0",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
+    "gradient-shimmer": "^0.1.1",
     "lucide-react": "^1.21.0",
     "material-icon-theme": "^5.30.0",
     "mermaid": "11.15.0",

--- a/apps/renderer/src/components/archived-chats-page.tsx
+++ b/apps/renderer/src/components/archived-chats-page.tsx
@@ -1,6 +1,9 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Search01Icon } from "@hugeicons-pro/core-bulk-rounded";
-import { ArchiveArrowUpIcon, ArchiveIcon } from "@hugeicons-pro/core-solid-rounded";
+import {
+  ArchiveArrowUpIcon,
+  ArchiveIcon,
+} from "@hugeicons-pro/core-solid-rounded";
 import { useEffect, useMemo, useState } from "react";
 import { Effect } from "effect";
 
@@ -10,6 +13,7 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { useUiStore } from "../store/ui.ts";
 import { Button } from "./ui/button.tsx";
+import { ShimmerText } from "./ui/shimmer-text.tsx";
 
 const formatDate = (date: Date): string =>
   date.toLocaleDateString(undefined, {
@@ -77,7 +81,10 @@ export function ArchivedChatsPage({
     <div className="flex min-h-0 flex-1 flex-col bg-background/55">
       <div className="border-b border-border/50 px-8 py-5">
         <div className="flex items-center gap-3">
-          <HugeiconsIcon icon={ArchiveIcon} className="size-5 text-muted-foreground" />
+          <HugeiconsIcon
+            icon={ArchiveIcon}
+            className="size-5 text-muted-foreground"
+          />
           <div className="min-w-0">
             <h1 className="truncate text-lg font-semibold text-foreground">
               Archived chats
@@ -88,7 +95,10 @@ export function ArchivedChatsPage({
           </div>
         </div>
         <label className="mt-5 flex h-9 max-w-xl items-center gap-2 rounded-md border border-border/70 bg-background px-3 text-sm">
-          <HugeiconsIcon icon={Search01Icon} className="size-4 shrink-0 text-muted-foreground" />
+          <HugeiconsIcon
+            icon={Search01Icon}
+            className="size-4 shrink-0 text-muted-foreground"
+          />
           <input
             value={query}
             onChange={(event) => setQuery(event.currentTarget.value)}
@@ -102,7 +112,7 @@ export function ArchivedChatsPage({
         {projectId === null ? (
           <EmptyState text="Select a repository to view archived chats." />
         ) : loading ? (
-          <EmptyState text="Loading archived chats..." />
+          <EmptyState text="Loading archived chats..." loading />
         ) : error !== null ? (
           <EmptyState text={error} />
         ) : filtered.length === 0 ? (
@@ -139,7 +149,10 @@ export function ArchivedChatsPage({
                   size="sm"
                   onClick={() => void onRestore(chat)}
                 >
-                  <HugeiconsIcon icon={ArchiveArrowUpIcon} className="size-3.5" />
+                  <HugeiconsIcon
+                    icon={ArchiveArrowUpIcon}
+                    className="size-3.5"
+                  />
                   Unarchive
                 </Button>
               </li>
@@ -151,10 +164,16 @@ export function ArchivedChatsPage({
   );
 }
 
-function EmptyState({ text }: { text: string }) {
+function EmptyState({
+  text,
+  loading = false,
+}: {
+  text: string;
+  loading?: boolean;
+}) {
   return (
     <div className="flex h-full min-h-64 items-center justify-center text-sm text-muted-foreground">
-      {text}
+      {loading ? <ShimmerText>{text}</ShimmerText> : text}
     </div>
   );
 }

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -25,9 +25,14 @@ import { useSkillsStore } from "../store/skills.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { FileChipProvider } from "./file-chip.tsx";
 import { WorktreeSetupCard } from "./worktree-setup-card.tsx";
-import { ErrorBubble, MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import {
+  ErrorBubble,
+  MessageRow,
+  type ToolResultRecord,
+} from "./message-row.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { TurnSummary } from "./turn-summary.tsx";
+import { ShimmerText } from "./ui/shimmer-text.tsx";
 import { Spinner } from "./ui/spinner";
 
 const NEAR_BOTTOM_PX = 80;
@@ -118,10 +123,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     // A message the user just sent always re-engages auto-scroll, even if
     // they had scrolled up to read older context.
     const last = messages[messages.length - 1];
-    if (
-      last?.content._tag === "user" ||
-      last?.content._tag === "user_rich"
-    ) {
+    if (last?.content._tag === "user" || last?.content._tag === "user_rich") {
       stickToBottomRef.current = true;
     }
     if (!stickToBottomRef.current) return;
@@ -199,158 +201,157 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     return map;
   }, [messages]);
 
-
   return (
     <FileChipProvider
       folderId={session?.projectId ?? null}
       worktreeId={session?.worktreeId ?? null}
     >
-    <div
-      ref={scrollRef}
-      onScroll={onScroll}
-      data-pane="chat"
-      tabIndex={-1}
-      className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto outline-none"
-    >
-      <WorktreeSetupCard />
-      {messages.length === 0 ? (
-        setupActive ? null : (
-          <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
-            <HugeiconsIcon
-              icon={Message01Icon}
-              className="size-10 opacity-40"
-            />
-            <div>
-              <p className="text-sm">{session?.title ?? "New chat"}</p>
-              <p className="mt-1 text-xs">
-                Type a message below to get started.
-              </p>
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        data-pane="chat"
+        tabIndex={-1}
+        className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto outline-none"
+      >
+        <WorktreeSetupCard />
+        {messages.length === 0 ? (
+          setupActive ? null : (
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+              <HugeiconsIcon
+                icon={Message01Icon}
+                className="size-10 opacity-40"
+              />
+              <div>
+                <p className="text-sm">{session?.title ?? "New chat"}</p>
+                <p className="mt-1 text-xs">
+                  Type a message below to get started.
+                </p>
+              </div>
             </div>
-          </div>
-        )
-      ) : (
-        <div className="flex flex-col py-2">
-          {turns.map((turn, idx) => {
-            const isLastTurn = idx === turns.length - 1;
-            const isLive = inFlight && isLastTurn;
-            const hasToolCalls = turn.body.some(
-              (m) => m.content._tag === "tool_use",
-            );
-            // Only collapse into a summary when there's a final assistant
-            // message worth showing as the body — otherwise a turn with
-            // just tool calls would lose its content behind the accordion.
-            const hasFinalText = turn.body.some(
-              (m) =>
-                m.content._tag === "assistant" &&
-                m.content.text.trim().length > 0,
-            );
-            const showSummary = !isLive && hasToolCalls && hasFinalText;
-            const turnKey = turn.user?.id ?? `turn-${idx}`;
-            // Within an open (non-collapsed) turn, group sub-agent rows
-            // under a SubagentRow wrapper. TurnSummary handles its own
-            // rendering for collapsed turns; sub-agents inside a collapsed
-            // turn render via TurnSummary's existing path.
-            const bodyGroups = groupMessages(turn.body);
-            // Hoist ExitPlanMode rows out of TurnSummary so the Plan card
-            // (and its resolved accordion) stays a top-level row in
-            // scrollback — it's a user-facing decision, not just another
-            // tool call to bury in the "N tool calls" rollup.
-            const planMessages = turn.body.filter(
-              (m) =>
-                m.content._tag === "tool_use" &&
-                m.content.tool === "ExitPlanMode",
-            );
-            const planItemIds = new Set(
-              planMessages.flatMap((m) =>
-                m.content._tag === "tool_use" ? [m.content.itemId] : [],
-              ),
-            );
-            const summaryBody =
-              planMessages.length === 0
-                ? turn.body
-                : turn.body.filter((m) => {
-                    if (
-                      m.content._tag === "tool_use" &&
-                      m.content.tool === "ExitPlanMode"
-                    ) {
-                      return false;
-                    }
-                    if (
-                      m.content._tag === "tool_result" &&
-                      planItemIds.has(m.content.itemId)
-                    ) {
-                      return false;
-                    }
-                    return true;
-                  });
-            return (
-              <Fragment key={turnKey}>
-                {turn.user !== null ? (
-                  <MessageRow
-                    message={turn.user}
-                    resultsByItemId={resultsByItemId}
-                    answersByItemId={answersByItemId}
-                    sessionId={sessionId}
-                  />
-                ) : null}
-                {showSummary ? (
-                  <>
-                    {planMessages.map((m) => (
-                      <MessageRow
-                        key={m.id}
-                        message={m}
-                        resultsByItemId={resultsByItemId}
-                        answersByItemId={answersByItemId}
-                        sessionId={sessionId}
-                      />
-                    ))}
-                    <TurnSummary
-                      body={summaryBody}
+          )
+        ) : (
+          <div className="flex flex-col py-2">
+            {turns.map((turn, idx) => {
+              const isLastTurn = idx === turns.length - 1;
+              const isLive = inFlight && isLastTurn;
+              const hasToolCalls = turn.body.some(
+                (m) => m.content._tag === "tool_use",
+              );
+              // Only collapse into a summary when there's a final assistant
+              // message worth showing as the body — otherwise a turn with
+              // just tool calls would lose its content behind the accordion.
+              const hasFinalText = turn.body.some(
+                (m) =>
+                  m.content._tag === "assistant" &&
+                  m.content.text.trim().length > 0,
+              );
+              const showSummary = !isLive && hasToolCalls && hasFinalText;
+              const turnKey = turn.user?.id ?? `turn-${idx}`;
+              // Within an open (non-collapsed) turn, group sub-agent rows
+              // under a SubagentRow wrapper. TurnSummary handles its own
+              // rendering for collapsed turns; sub-agents inside a collapsed
+              // turn render via TurnSummary's existing path.
+              const bodyGroups = groupMessages(turn.body);
+              // Hoist ExitPlanMode rows out of TurnSummary so the Plan card
+              // (and its resolved accordion) stays a top-level row in
+              // scrollback — it's a user-facing decision, not just another
+              // tool call to bury in the "N tool calls" rollup.
+              const planMessages = turn.body.filter(
+                (m) =>
+                  m.content._tag === "tool_use" &&
+                  m.content.tool === "ExitPlanMode",
+              );
+              const planItemIds = new Set(
+                planMessages.flatMap((m) =>
+                  m.content._tag === "tool_use" ? [m.content.itemId] : [],
+                ),
+              );
+              const summaryBody =
+                planMessages.length === 0
+                  ? turn.body
+                  : turn.body.filter((m) => {
+                      if (
+                        m.content._tag === "tool_use" &&
+                        m.content.tool === "ExitPlanMode"
+                      ) {
+                        return false;
+                      }
+                      if (
+                        m.content._tag === "tool_result" &&
+                        planItemIds.has(m.content.itemId)
+                      ) {
+                        return false;
+                      }
+                      return true;
+                    });
+              return (
+                <Fragment key={turnKey}>
+                  {turn.user !== null ? (
+                    <MessageRow
+                      message={turn.user}
                       resultsByItemId={resultsByItemId}
                       answersByItemId={answersByItemId}
+                      sessionId={sessionId}
                     />
-                  </>
-                ) : (
-                  bodyGroups.map((group) =>
-                    group.kind === "single" ? (
-                      <MessageRow
-                        key={group.message.id}
-                        message={group.message}
-                        resultsByItemId={resultsByItemId}
-                        answersByItemId={answersByItemId}
-                        sessionId={sessionId}
-                      />
-                    ) : (
-                      <SubagentRow
-                        key={group.parent.id}
-                        agentToolUseId={group.parentItemId}
-                        agentName={group.agentName}
-                        prompt={group.prompt}
-                        modelRequested={group.modelRequested}
-                        children={group.children}
-                        summary={group.summary}
+                  ) : null}
+                  {showSummary ? (
+                    <>
+                      {planMessages.map((m) => (
+                        <MessageRow
+                          key={m.id}
+                          message={m}
+                          resultsByItemId={resultsByItemId}
+                          answersByItemId={answersByItemId}
+                          sessionId={sessionId}
+                        />
+                      ))}
+                      <TurnSummary
+                        body={summaryBody}
                         resultsByItemId={resultsByItemId}
                         answersByItemId={answersByItemId}
                       />
-                    ),
-                  )
-                )}
-              </Fragment>
-            );
-          })}
-          {inFlight && !awaitingPlanApproval && (
-            <WorkingRow messages={messages} />
-          )}
-        </div>
-      )}
-      {error !== null && (
-        <ErrorBubble
-          error={error}
-          sessionId={sessionId}
-          onDismiss={() => clearError(sessionId)}
-        />
-      )}
-    </div>
+                    </>
+                  ) : (
+                    bodyGroups.map((group) =>
+                      group.kind === "single" ? (
+                        <MessageRow
+                          key={group.message.id}
+                          message={group.message}
+                          resultsByItemId={resultsByItemId}
+                          answersByItemId={answersByItemId}
+                          sessionId={sessionId}
+                        />
+                      ) : (
+                        <SubagentRow
+                          key={group.parent.id}
+                          agentToolUseId={group.parentItemId}
+                          agentName={group.agentName}
+                          prompt={group.prompt}
+                          modelRequested={group.modelRequested}
+                          children={group.children}
+                          summary={group.summary}
+                          resultsByItemId={resultsByItemId}
+                          answersByItemId={answersByItemId}
+                        />
+                      ),
+                    )
+                  )}
+                </Fragment>
+              );
+            })}
+            {inFlight && !awaitingPlanApproval && (
+              <WorkingRow messages={messages} />
+            )}
+          </div>
+        )}
+        {error !== null && (
+          <ErrorBubble
+            error={error}
+            sessionId={sessionId}
+            onDismiss={() => clearError(sessionId)}
+          />
+        )}
+      </div>
     </FileChipProvider>
   );
 }
@@ -388,7 +389,9 @@ function WorkingRow({ messages }: { messages: ReadonlyArray<Message> }) {
   return (
     <div className="flex items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground">
       <Spinner className="size-3" />
-      <span className="tabular-nums">{formatElapsed(elapsed)}</span>
+      <ShimmerText tone="lime" className="tabular-nums">
+        {formatElapsed(elapsed)}
+      </ShimmerText>
     </div>
   );
 }

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { CodeAnnotation, GitDiffResult } from "@memoize/wire";
 
 import { cn } from "~/lib/utils";
+import { ShimmerText } from "~/components/ui/shimmer-text";
 import { classifyGit } from "../lib/git-rpc.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { GitInitCta } from "./git-init-cta.tsx";
@@ -475,7 +476,11 @@ function CodeMirrorBody({
           }}
         />
       ) : null}
-      {state.status === "loading" && <Placeholder>Loading…</Placeholder>}
+      {state.status === "loading" && (
+        <Placeholder>
+          <ShimmerText>Loading…</ShimmerText>
+        </Placeholder>
+      )}
       {state.status === "binary" && (
         <Placeholder>
           Binary file ({state.size.toLocaleString()} bytes) — preview not
@@ -658,7 +663,11 @@ function DiffViewBody({
   }, [openFile.folderId, openFile.worktreeId, openFile.path, reload]);
 
   if (state.status === "loading") {
-    return <Placeholder>Loading diff…</Placeholder>;
+    return (
+      <Placeholder>
+        <ShimmerText>Loading diff…</ShimmerText>
+      </Placeholder>
+    );
   }
   if (state.status === "error") {
     if (state.noRepo) {

--- a/apps/renderer/src/components/index-progress-banner.tsx
+++ b/apps/renderer/src/components/index-progress-banner.tsx
@@ -5,6 +5,7 @@ import {
   ProgressIndicator,
   ProgressTrack,
 } from "~/components/ui/progress";
+import { ShimmerText } from "~/components/ui/shimmer-text";
 
 import { useIndexStore } from "../store/code-index.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
@@ -40,16 +41,21 @@ export function IndexProgressBanner() {
         {isError ? (
           <HugeiconsIcon icon={Alert01Icon} className="size-3.5" />
         ) : (
-          <HugeiconsIcon icon={Loading02Icon} className="size-3.5 animate-spin" />
+          <HugeiconsIcon
+            icon={Loading02Icon}
+            className="size-3.5 animate-spin"
+          />
         )}
       </span>
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <span className="text-foreground">
-          {isError
-            ? "Code index failed — agents will fall back to grep."
-            : total > 0
-              ? `Indexing ${processed}/${total}…`
-              : "Indexing…"}
+          {isError ? (
+            "Code index failed — agents will fall back to grep."
+          ) : (
+            <ShimmerText>
+              {total > 0 ? `Indexing ${processed}/${total}…` : "Indexing…"}
+            </ShimmerText>
+          )}
         </span>
         {!isError && total > 0 && (
           <Progress value={percent}>

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -25,10 +25,7 @@ import type {
 } from "@memoize/wire";
 
 import { getFileIconUrl } from "~/lib/icons/material-icons";
-import {
-  openExternal,
-  useProviderLogin,
-} from "~/lib/use-provider-login";
+import { openExternal, useProviderLogin } from "~/lib/use-provider-login";
 import { cn } from "~/lib/utils";
 import {
   classifyMessage,
@@ -50,6 +47,7 @@ import {
   UserInputRow,
 } from "./tool-row.tsx";
 import { Button } from "./ui/button.tsx";
+import { ShimmerText } from "./ui/shimmer-text.tsx";
 
 export interface ToolResultRecord {
   readonly output: unknown;
@@ -586,7 +584,7 @@ function ProviderAuthCard({
               className="size-3.5 animate-spin"
               aria-hidden
             />
-            <span>Waiting for browser sign-in…</span>
+            <ShimmerText as="span">Waiting for browser sign-in…</ShimmerText>
             <button
               type="button"
               onClick={cancel}
@@ -602,7 +600,7 @@ function ProviderAuthCard({
               className="size-3.5 animate-spin"
               aria-hidden
             />
-            <span>Signed in. Finishing…</span>
+            <ShimmerText as="span">Signed in. Finishing…</ShimmerText>
           </div>
         ) : (
           <>
@@ -611,7 +609,9 @@ function ProviderAuthCard({
               automatically.
             </p>
             {state.kind === "failed" && (
-              <p className="mt-1 text-[11px] text-destructive">{state.reason}</p>
+              <p className="mt-1 text-[11px] text-destructive">
+                {state.reason}
+              </p>
             )}
             <div className="mt-2 flex flex-wrap items-center gap-1.5">
               <Button

--- a/apps/renderer/src/components/permissions-inspector.tsx
+++ b/apps/renderer/src/components/permissions-inspector.tsx
@@ -18,6 +18,7 @@ import {
   DialogPopup,
   DialogTitle,
 } from "~/components/ui/dialog";
+import { ShimmerText } from "~/components/ui/shimmer-text";
 import { usePermissionsStore } from "../store/permissions.ts";
 
 const kindIcon = (kind: PermissionKind) => {
@@ -149,7 +150,9 @@ export function PermissionsInspector({
         </DialogHeader>
         <DialogPanel className="text-sm">
           {loading && decisions.length === 0 ? (
-            <p className="text-xs text-muted-foreground">Loading…</p>
+            <ShimmerText as="p" className="text-xs text-muted-foreground">
+              Loading…
+            </ShimmerText>
           ) : decisions.length === 0 ? (
             <p className="text-xs text-muted-foreground">
               No saved permission decisions for this project yet. They appear

--- a/apps/renderer/src/components/pr-pane.tsx
+++ b/apps/renderer/src/components/pr-pane.tsx
@@ -1,5 +1,11 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { CircleIcon, LinkSquare01Icon, Loading02Icon, MinusSignCircleIcon, Tick01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  CircleIcon,
+  LinkSquare01Icon,
+  Loading02Icon,
+  MinusSignCircleIcon,
+  Tick01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
 import { GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
 import { X } from "lucide-react";
 import { useEffect } from "react";
@@ -19,6 +25,7 @@ import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { GitInitCta } from "./git-init-cta.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
+import { ShimmerText } from "./ui/shimmer-text.tsx";
 
 const openExternal = (url: string) => {
   const bridge = window.memoize?.app;
@@ -99,13 +106,13 @@ export function PrPane({
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-3 py-3 text-xs">
       {!hasPr ? (
-        <NoPrState branch={status.branch} dirtyFiles={status.dirtyFiles} ahead={status.ahead} />
-      ) : (
-        <PrBody
-          pr={pr!}
-          details={details}
-          detailsLoading={detailsLoading}
+        <NoPrState
+          branch={status.branch}
+          dirtyFiles={status.dirtyFiles}
+          ahead={status.ahead}
         />
+      ) : (
+        <PrBody pr={pr!} details={details} detailsLoading={detailsLoading} />
       )}
     </div>
   );
@@ -139,7 +146,9 @@ function NoPrState({
         </Row>
         <Row label="Ahead of upstream">
           {ahead > 0 ? (
-            <Pill tone="sky">{ahead} commit{ahead === 1 ? "" : "s"}</Pill>
+            <Pill tone="sky">
+              {ahead} commit{ahead === 1 ? "" : "s"}
+            </Pill>
           ) : (
             <span className="text-muted-foreground">in sync</span>
           )}
@@ -186,7 +195,10 @@ function PrBody({
     <>
       <Section>
         <div className="flex items-start gap-2">
-          <HugeiconsIcon icon={GitPullRequestIcon} className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <HugeiconsIcon
+            icon={GitPullRequestIcon}
+            className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+          />
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <div className="flex items-baseline gap-2">
               {number !== null ? (
@@ -225,7 +237,9 @@ function PrBody({
       </Section>
 
       {detailsLoading && details === null ? (
-        <p className="text-muted-foreground">Loading PR details…</p>
+        <ShimmerText as="p" className="text-muted-foreground">
+          Loading PR details…
+        </ShimmerText>
       ) : details === null ? (
         <p className="text-amber-300/80">
           <code className="font-mono">gh</code> couldn't read PR details.
@@ -280,13 +294,23 @@ function PrBody({
           >
             {pr.isDraft ? (
               <Indicator
-                icon={<HugeiconsIcon icon={CircleIcon} className="size-4 text-zinc-400" />}
+                icon={
+                  <HugeiconsIcon
+                    icon={CircleIcon}
+                    className="size-4 text-zinc-400"
+                  />
+                }
                 title="Draft"
                 body="Mark the PR as ready for review to start running checks."
               />
             ) : orderedChecks.length === 0 ? (
               <Indicator
-                icon={<HugeiconsIcon icon={CircleIcon} className="size-4 text-muted-foreground" />}
+                icon={
+                  <HugeiconsIcon
+                    icon={CircleIcon}
+                    className="size-4 text-muted-foreground"
+                  />
+                }
                 title="No checks configured"
                 body="There aren't any required status checks on this branch."
               />
@@ -396,7 +420,10 @@ function CheckRunRow({ run }: { run: GitPrCheckRun }) {
         {run.name}
       </span>
       {run.url !== null ? (
-        <HugeiconsIcon icon={LinkSquare01Icon} className="size-3 shrink-0 text-muted-foreground" />
+        <HugeiconsIcon
+          icon={LinkSquare01Icon}
+          className="size-3 shrink-0 text-muted-foreground"
+        />
       ) : null}
     </div>
   );
@@ -419,13 +446,25 @@ function CheckRunRow({ run }: { run: GitPrCheckRun }) {
 function checkIcon(run: GitPrCheckRun) {
   if (run.status !== "completed") {
     if (run.status === "queued" || run.status === "pending") {
-      return <HugeiconsIcon icon={CircleIcon} className="size-4 text-muted-foreground" />;
+      return (
+        <HugeiconsIcon
+          icon={CircleIcon}
+          className="size-4 text-muted-foreground"
+        />
+      );
     }
-    return <HugeiconsIcon icon={Loading02Icon} className="size-4 animate-spin text-amber-300" />;
+    return (
+      <HugeiconsIcon
+        icon={Loading02Icon}
+        className="size-4 animate-spin text-amber-300"
+      />
+    );
   }
   switch (run.conclusion) {
     case "success":
-      return <HugeiconsIcon icon={Tick01Icon} className="size-3 text-emerald-400" />;
+      return (
+        <HugeiconsIcon icon={Tick01Icon} className="size-3 text-emerald-400" />
+      );
     case "failure":
     case "cancelled":
     case "timed_out":
@@ -433,9 +472,19 @@ function checkIcon(run: GitPrCheckRun) {
       return <X className="size-3 text-rose-300" strokeWidth={1.8} />;
     case "skipped":
     case "neutral":
-      return <HugeiconsIcon icon={MinusSignCircleIcon} className="size-3.5 text-muted-foreground" />;
+      return (
+        <HugeiconsIcon
+          icon={MinusSignCircleIcon}
+          className="size-3.5 text-muted-foreground"
+        />
+      );
     default:
-      return <HugeiconsIcon icon={CircleIcon} className="size-3.5 text-muted-foreground" />;
+      return (
+        <HugeiconsIcon
+          icon={CircleIcon}
+          className="size-3.5 text-muted-foreground"
+        />
+      );
   }
 }
 
@@ -473,13 +522,7 @@ function Row({
   );
 }
 
-function Pill({
-  tone,
-  children,
-}: {
-  tone: Tone;
-  children: React.ReactNode;
-}) {
+function Pill({ tone, children }: { tone: Tone; children: React.ReactNode }) {
   return (
     <span
       className={`flex items-center gap-1 rounded-sm px-1.5 py-0.5 font-mono text-[10px] ${softTone(tone)}`}

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -19,12 +19,10 @@ import {
 } from "@memoize/wire";
 
 import { ApiKeyRow } from "~/components/api-key-row";
-import {
-  openExternal,
-  useProviderLogin,
-} from "~/lib/use-provider-login";
+import { openExternal, useProviderLogin } from "~/lib/use-provider-login";
 import { ProviderIcon } from "~/components/provider-icons";
 import { Button } from "~/components/ui/button";
+import { ShimmerText } from "~/components/ui/shimmer-text";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { getRpcClient } from "~/lib/rpc-client";
 import { useProvidersStore } from "~/store/providers";
@@ -414,7 +412,7 @@ function ProviderSignInRow({ providerId }: { providerId: ProviderId }) {
   if (state.kind === "success") {
     return (
       <div className="flex items-center gap-2 rounded-md border border-emerald-400/30 bg-emerald-500/[0.06] px-3 py-2 text-[11px] text-emerald-200">
-        <span>Signed in. Refreshing…</span>
+        <ShimmerText as="span">Signed in. Refreshing…</ShimmerText>
       </div>
     );
   }
@@ -428,11 +426,11 @@ function ProviderSignInRow({ providerId }: { providerId: ProviderId }) {
             className="size-3.5 animate-spin"
             aria-hidden
           />
-          <span>
+          <ShimmerText as="span">
             {state.url === null
               ? `Starting ${label} sign-in…`
               : "Waiting for browser sign-in…"}
-          </span>
+          </ShimmerText>
         </div>
         <div className="flex items-center gap-2">
           {state.url !== null && (

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -5,6 +5,7 @@ import type { ChatId } from "@memoize/wire";
 import { useActiveContext } from "../store/active-workspace.ts";
 import { useChatsStore } from "../store/chats.ts";
 import * as terminalRegistry from "../lib/terminal-registry.ts";
+import { ShimmerText } from "./ui/shimmer-text.tsx";
 import {
   EMPTY_TERMINALS,
   type TerminalInstance,
@@ -40,7 +41,11 @@ export function TerminalSlotPane({ slot }: { slot: number }) {
   const ready = ctx.status === "ready" && !ctx.worktreePending;
 
   if (ctx.status === "loading") {
-    return <TerminalPlaceholder>Loading workspace…</TerminalPlaceholder>;
+    return (
+      <TerminalPlaceholder>
+        <ShimmerText>Loading workspace…</ShimmerText>
+      </TerminalPlaceholder>
+    );
   }
   if (ctx.status === "empty") {
     return (
@@ -50,7 +55,11 @@ export function TerminalSlotPane({ slot }: { slot: number }) {
     );
   }
   if (ctx.worktreePending) {
-    return <TerminalPlaceholder>Preparing worktree…</TerminalPlaceholder>;
+    return (
+      <TerminalPlaceholder>
+        <ShimmerText>Preparing worktree…</ShimmerText>
+      </TerminalPlaceholder>
+    );
   }
   if (!ready || chatId === null) return null;
   return (

--- a/apps/renderer/src/components/ui/shimmer-text.tsx
+++ b/apps/renderer/src/components/ui/shimmer-text.tsx
@@ -1,0 +1,72 @@
+import { GradientShimmer, type GradientStop } from "gradient-shimmer";
+import type React from "react";
+import { usePrefersReducedMotion } from "~/hooks/use-media-query";
+
+/**
+ * `muted` — a soft near-white highlight that brightens the text's own (usually
+ * muted) color; the default for plain loading/status text.
+ * `lime` — the theme lime accent, reserved for agent-activity text (Thinking,
+ * tool inline hints) so the eye reads "the agent is working".
+ *
+ * Only the highlight band is specified — `GradientShimmer`'s `baseColor`
+ * defaults to `currentColor`, so the sweep fades back into whatever color the
+ * call site already uses. That keeps each site's resting look unchanged.
+ */
+type ShimmerTone = "muted" | "lime";
+
+const TONE_STOPS: Record<ShimmerTone, GradientStop[]> = {
+  muted: [{ position: 0.5, color: "oklch(0.97 0.004 260)" }],
+  lime: [{ position: 0.5, color: "oklch(0.94 0.2 122)" }],
+};
+
+type ShimmerTextProps = {
+  /** Plain string only — the gradient sweeps over it. */
+  children: string;
+  tone?: ShimmerTone;
+  className?: string;
+  as?: React.ElementType;
+  style?: React.CSSProperties;
+};
+
+/**
+ * Animated gradient shimmer for pending/loading status text. Wraps the
+ * `gradient-shimmer` package with project-themed defaults so call sites stay a
+ * drop-in for a `<span>`. Use only while a state is actually pending; render
+ * plain text for done/error states.
+ *
+ * Under `prefers-reduced-motion` we render static text (not even the package's
+ * static gradient) so the resting color is identical to what it replaced.
+ */
+export function ShimmerText({
+  children,
+  tone = "muted",
+  className,
+  as: As = "span",
+  style,
+}: ShimmerTextProps): React.ReactElement {
+  const reduced = usePrefersReducedMotion();
+
+  if (reduced) {
+    return (
+      <As className={className} style={style}>
+        {children}
+      </As>
+    );
+  }
+
+  return (
+    <GradientShimmer
+      gradient={TONE_STOPS[tone]}
+      easing="smooth"
+      duration={1.5}
+      spread={5}
+      angle={105}
+      pauseBetween={350}
+      as={As}
+      className={className}
+      style={style}
+    >
+      {children}
+    </GradientShimmer>
+  );
+}

--- a/apps/renderer/src/components/update-banner.tsx
+++ b/apps/renderer/src/components/update-banner.tsx
@@ -1,5 +1,9 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Alert01Icon, CheckmarkCircle02Icon, CircleArrowUp01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  Alert01Icon,
+  CheckmarkCircle02Icon,
+  CircleArrowUp01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
@@ -7,6 +11,7 @@ import { X } from "lucide-react";
 import type { UpdateStatus } from "@memoize/wire";
 
 import { Button } from "~/components/ui/button";
+import { ShimmerText } from "~/components/ui/shimmer-text";
 import {
   Progress,
   ProgressIndicator,
@@ -116,7 +121,9 @@ export function UpdateBanner() {
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <span className="text-[13px] font-medium text-foreground">
             {status.kind === "available" && "Update available"}
-            {status.kind === "downloading" && "Downloading update…"}
+            {status.kind === "downloading" && (
+              <ShimmerText>Downloading update…</ShimmerText>
+            )}
             {status.kind === "ready" && "Update ready"}
             {status.kind === "error" && "Update failed"}
           </span>

--- a/apps/renderer/src/components/usage-dashboard.tsx
+++ b/apps/renderer/src/components/usage-dashboard.tsx
@@ -1,4 +1,11 @@
-import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Info, RefreshCw } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Info,
+  RefreshCw,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import type {
@@ -18,7 +25,14 @@ import {
   type TokenRow,
 } from "~/lib/format-usage.ts";
 import { Button } from "./ui/button.tsx";
-import { Frame, FrameFooter, FrameHeader, FramePanel, FrameTitle } from "./ui/frame.tsx";
+import { ShimmerText } from "./ui/shimmer-text.tsx";
+import {
+  Frame,
+  FrameFooter,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "./ui/frame.tsx";
 import {
   Table,
   TableBody,
@@ -29,7 +43,12 @@ import {
 } from "./ui/table.tsx";
 import { useUsageStore } from "../store/usage.ts";
 
-const BUCKETS: ReadonlyArray<UsageBucket> = ["daily", "weekly", "monthly", "session"];
+const BUCKETS: ReadonlyArray<UsageBucket> = [
+  "daily",
+  "weekly",
+  "monthly",
+  "session",
+];
 const PAGE_SIZE = 10;
 
 /** Token-type series used for the stacked chart, legend, and tooltip. */
@@ -40,10 +59,34 @@ const SERIES: ReadonlyArray<{
   readonly dot: string;
   readonly value: (r: TokenRow) => number;
 }> = [
-  { key: "input", label: "Input", bar: "bg-primary", dot: "bg-primary", value: (r) => r.inputTokens },
-  { key: "output", label: "Output", bar: "bg-primary/65", dot: "bg-primary/65", value: (r) => r.outputTokens },
-  { key: "cache", label: "Cache", bar: "bg-primary/35", dot: "bg-primary/35", value: cacheTokens },
-  { key: "reasoning", label: "Reasoning", bar: "bg-primary/20", dot: "bg-primary/20", value: (r) => r.reasoningTokens },
+  {
+    key: "input",
+    label: "Input",
+    bar: "bg-primary",
+    dot: "bg-primary",
+    value: (r) => r.inputTokens,
+  },
+  {
+    key: "output",
+    label: "Output",
+    bar: "bg-primary/65",
+    dot: "bg-primary/65",
+    value: (r) => r.outputTokens,
+  },
+  {
+    key: "cache",
+    label: "Cache",
+    bar: "bg-primary/35",
+    dot: "bg-primary/35",
+    value: cacheTokens,
+  },
+  {
+    key: "reasoning",
+    label: "Reasoning",
+    bar: "bg-primary/20",
+    dot: "bg-primary/20",
+    value: (r) => r.reasoningTokens,
+  },
 ];
 
 export function UsageDashboard({
@@ -92,7 +135,11 @@ export function UsageDashboard({
 
       {report === null ? (
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-          {loading ? "Loading usage…" : "No usage report loaded."}
+          {loading ? (
+            <ShimmerText>Loading usage…</ShimmerText>
+          ) : (
+            "No usage report loaded."
+          )}
         </div>
       ) : (
         <UsageReportView
@@ -117,7 +164,11 @@ function UsageReportView({
   const summary = report.summary;
   const metrics = useMemo(
     () => [
-      { label: "Total cost", value: formatUsd(summary.costUsd), hint: costHint(summary.costStatus) },
+      {
+        label: "Total cost",
+        value: formatUsd(summary.costUsd),
+        hint: costHint(summary.costStatus),
+      },
       {
         label: "Total tokens",
         value: formatTokens(totalTokens(summary)),
@@ -131,7 +182,10 @@ function UsageReportView({
       {
         label: "Cache",
         value: formatTokens(cacheTokens(summary)),
-        hint: summary.reasoningTokens > 0 ? `${formatTokens(summary.reasoningTokens)} reasoning` : undefined,
+        hint:
+          summary.reasoningTokens > 0
+            ? `${formatTokens(summary.reasoningTokens)} reasoning`
+            : undefined,
       },
     ],
     [summary],
@@ -156,7 +210,6 @@ function UsageReportView({
 
       <UsageChart groups={report.groups} bucket={bucket} onBucket={onBucket} />
 
-
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <Breakdown title="By source" rows={report.bySource} max={8} />
         <Breakdown title="By model" rows={report.byModel} max={12} />
@@ -167,7 +220,9 @@ function UsageReportView({
   );
 }
 
-function costHint(status: UsageReport["summary"]["costStatus"]): string | undefined {
+function costHint(
+  status: UsageReport["summary"]["costStatus"],
+): string | undefined {
   if (status === "partial") return "some models unpriced";
   if (status === "unknown") return "pricing unavailable";
   return undefined;
@@ -186,11 +241,18 @@ function Metric({
 }) {
   return (
     <div className={cn("p-4", divided && "sm:border-l sm:border-border/60")}>
-      <div className="text-[11px] font-medium text-muted-foreground">{label}</div>
-      <div className="mt-1.5 truncate text-2xl font-semibold tracking-tight tabular-nums" title={value}>
+      <div className="text-[11px] font-medium text-muted-foreground">
+        {label}
+      </div>
+      <div
+        className="mt-1.5 truncate text-2xl font-semibold tracking-tight tabular-nums"
+        title={value}
+      >
         {value}
       </div>
-      <div className="mt-1 h-3.5 text-[10px] text-muted-foreground">{hint ?? ""}</div>
+      <div className="mt-1 h-3.5 text-[10px] text-muted-foreground">
+        {hint ?? ""}
+      </div>
     </div>
   );
 }
@@ -211,7 +273,9 @@ function BucketSelector({
           onClick={() => onChange(b)}
           className={cn(
             "rounded px-2 py-1 text-[11px] capitalize transition-colors",
-            value === b ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground",
+            value === b
+              ? "bg-foreground text-background"
+              : "text-muted-foreground hover:text-foreground",
           )}
         >
           {b}
@@ -221,7 +285,13 @@ function BucketSelector({
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
     <section>
       <h2 className="mb-2 text-[12px] font-medium uppercase tracking-normal text-muted-foreground">
@@ -234,11 +304,17 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function SourceChip({ source }: { source: UsageSourceStatus }) {
   const active = source.detected && source.recordCount > 0;
-  const dotColor = active ? "bg-emerald-500" : source.detected ? "bg-amber-500" : "bg-muted-foreground/40";
+  const dotColor = active
+    ? "bg-emerald-500"
+    : source.detected
+      ? "bg-amber-500"
+      : "bg-muted-foreground/40";
   // Show the caveat (e.g. Memoize counts under the CLIs, Grok undercount) inline
   // so a low/zero number reads as "expected", not "broken".
   const hasNote = source.warning !== null && source.detected;
-  const title = source.warning ?? (source.detected ? `${source.recordCount} records` : "Not found");
+  const title =
+    source.warning ??
+    (source.detected ? `${source.recordCount} records` : "Not found");
   return (
     <div
       className={cn(
@@ -252,7 +328,9 @@ function SourceChip({ source }: { source: UsageSourceStatus }) {
       <span className="tabular-nums text-muted-foreground">
         {source.detected ? source.recordCount.toLocaleString() : "—"}
       </span>
-      {hasNote ? <Info className="size-3 text-muted-foreground/70" aria-label={title} /> : null}
+      {hasNote ? (
+        <Info className="size-3 text-muted-foreground/70" aria-label={title} />
+      ) : null}
     </div>
   );
 }
@@ -280,7 +358,10 @@ function UsageChart({
       <FramePanel>
         <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1">
           {SERIES.map((s) => (
-            <div key={s.key} className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            <div
+              key={s.key}
+              className="flex items-center gap-1.5 text-[10px] text-muted-foreground"
+            >
               <span className={cn("size-2 rounded-[2px]", s.dot)} />
               {s.label}
             </div>
@@ -294,7 +375,11 @@ function UsageChart({
         ) : (
           <div className="relative">
             {hovered !== null && visible[hovered] !== undefined ? (
-              <ChartTooltip group={visible[hovered]} index={hovered} count={visible.length} />
+              <ChartTooltip
+                group={visible[hovered]}
+                index={hovered}
+                count={visible.length}
+              />
             ) : null}
             <div className="flex h-44 items-end gap-[3px] border-b border-border/60">
               {visible.map((group, index) => (
@@ -302,7 +387,9 @@ function UsageChart({
                   key={group.key}
                   className="group flex h-full min-w-[3px] flex-1 cursor-default flex-col-reverse overflow-hidden rounded-t-[3px]"
                   onMouseEnter={() => setHovered(index)}
-                  onMouseLeave={() => setHovered((h) => (h === index ? null : h))}
+                  onMouseLeave={() =>
+                    setHovered((h) => (h === index ? null : h))
+                  }
                 >
                   {SERIES.map((s) => {
                     const value = s.value(group);
@@ -313,7 +400,9 @@ function UsageChart({
                         className={cn(
                           s.bar,
                           "transition-opacity",
-                          hovered !== null && hovered !== index ? "opacity-30" : "group-hover:brightness-110",
+                          hovered !== null && hovered !== index
+                            ? "opacity-30"
+                            : "group-hover:brightness-110",
                         )}
                         style={{ height: `${(value / peak) * 100}%` }}
                       />
@@ -333,7 +422,15 @@ function UsageChart({
   );
 }
 
-function ChartTooltip({ group, index, count }: { group: UsageGroup; index: number; count: number }) {
+function ChartTooltip({
+  group,
+  index,
+  count,
+}: {
+  group: UsageGroup;
+  index: number;
+  count: number;
+}) {
   const left = Math.min(Math.max(((index + 0.5) / count) * 100, 14), 86);
   return (
     <div
@@ -344,15 +441,22 @@ function ChartTooltip({ group, index, count }: { group: UsageGroup; index: numbe
         <span className="truncate text-[11px] font-medium" title={group.label}>
           {group.label}
         </span>
-        <span className="text-[11px] tabular-nums text-muted-foreground">{formatUsd(group.costUsd)}</span>
+        <span className="text-[11px] tabular-nums text-muted-foreground">
+          {formatUsd(group.costUsd)}
+        </span>
       </div>
       <div className="mb-1.5 flex items-center justify-between text-[11px]">
         <span className="text-muted-foreground">Total tokens</span>
-        <span className="font-medium tabular-nums">{formatTokens(totalTokens(group))}</span>
+        <span className="font-medium tabular-nums">
+          {formatTokens(totalTokens(group))}
+        </span>
       </div>
       <div className="space-y-1 border-t border-border/60 pt-1.5">
         {SERIES.filter((s) => s.value(group) > 0).map((s) => (
-          <div key={s.key} className="flex items-center justify-between text-[11px]">
+          <div
+            key={s.key}
+            className="flex items-center justify-between text-[11px]"
+          >
             <span className="flex items-center gap-1.5 text-muted-foreground">
               <span className={cn("size-1.5 rounded-full", s.dot)} />
               {s.label}
@@ -365,9 +469,21 @@ function ChartTooltip({ group, index, count }: { group: UsageGroup; index: numbe
   );
 }
 
-function Breakdown({ title, rows, max }: { title: string; rows: ReadonlyArray<UsageGroup>; max: number }) {
+function Breakdown({
+  title,
+  rows,
+  max,
+}: {
+  title: string;
+  rows: ReadonlyArray<UsageGroup>;
+  max: number;
+}) {
   const visible = useMemo(
-    () => rows.slice().sort((a, b) => totalTokens(b) - totalTokens(a)).slice(0, max),
+    () =>
+      rows
+        .slice()
+        .sort((a, b) => totalTokens(b) - totalTokens(a))
+        .slice(0, max),
     [rows, max],
   );
   const peak = Math.max(1, ...visible.map(totalTokens));
@@ -383,7 +499,10 @@ function Breakdown({ title, rows, max }: { title: string; rows: ReadonlyArray<Us
           <div className="p-3 text-sm text-muted-foreground">No data.</div>
         ) : (
           visible.map((row) => (
-            <div key={row.key} className="relative border-b border-border/50 last:border-0">
+            <div
+              key={row.key}
+              className="relative border-b border-border/50 last:border-0"
+            >
               <div
                 className="absolute inset-y-0 left-0 bg-primary/[0.10]"
                 style={{ width: `${(totalTokens(row) / peak) * 100}%` }}
@@ -399,7 +518,9 @@ function Breakdown({ title, rows, max }: { title: string; rows: ReadonlyArray<Us
                 </div>
                 <div className="ml-3 shrink-0 text-right text-[12px] tabular-nums">
                   <div>{formatTokens(totalTokens(row))}</div>
-                  <div className="text-[10px] text-muted-foreground">{formatUsd(row.costUsd)}</div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {formatUsd(row.costUsd)}
+                  </div>
                 </div>
               </div>
             </div>
@@ -417,7 +538,8 @@ function SessionsTable({ rows }: { rows: ReadonlyArray<UsageGroup> }) {
   const [pageIndex, setPageIndex] = useState(0);
 
   const sorted = useMemo(() => {
-    const value = (r: UsageGroup) => (sortKey === "cost" ? (r.costUsd ?? 0) : totalTokens(r));
+    const value = (r: UsageGroup) =>
+      sortKey === "cost" ? (r.costUsd ?? 0) : totalTokens(r);
     if (sortKey === "tokens") return rows;
     return rows.slice().sort((a, b) => value(b) - value(a));
   }, [rows, sortKey]);
@@ -435,7 +557,9 @@ function SessionsTable({ rows }: { rows: ReadonlyArray<UsageGroup> }) {
   if (rows.length === 0) {
     return (
       <Frame>
-        <FramePanel className="text-sm text-muted-foreground">No sessions found.</FramePanel>
+        <FramePanel className="text-sm text-muted-foreground">
+          No sessions found.
+        </FramePanel>
       </Frame>
     );
   }
@@ -452,8 +576,16 @@ function SessionsTable({ rows }: { rows: ReadonlyArray<UsageGroup> }) {
           <TableRow className="hover:bg-transparent">
             <TableHead className="w-[46%]">Session</TableHead>
             <TableHead className="w-[18%]">Sources</TableHead>
-            <SortableHead label="Tokens" active={sortKey === "tokens"} onClick={() => toggleSort("tokens")} />
-            <SortableHead label="Cost" active={sortKey === "cost"} onClick={() => toggleSort("cost")} />
+            <SortableHead
+              label="Tokens"
+              active={sortKey === "tokens"}
+              onClick={() => toggleSort("tokens")}
+            />
+            <SortableHead
+              label="Cost"
+              active={sortKey === "cost"}
+              onClick={() => toggleSort("cost")}
+            />
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -463,11 +595,19 @@ function SessionsTable({ rows }: { rows: ReadonlyArray<UsageGroup> }) {
                 <div className="truncate font-medium" title={row.label}>
                   {row.label}
                 </div>
-                <div className="truncate text-[10px] text-muted-foreground">{lastActive(row)}</div>
+                <div className="truncate text-[10px] text-muted-foreground">
+                  {lastActive(row)}
+                </div>
               </TableCell>
-              <TableCell className="truncate text-muted-foreground">{row.sourceIds.join(", ")}</TableCell>
-              <TableCell className="text-right tabular-nums">{formatTokens(totalTokens(row))}</TableCell>
-              <TableCell className="text-right tabular-nums">{formatUsd(row.costUsd)}</TableCell>
+              <TableCell className="truncate text-muted-foreground">
+                {row.sourceIds.join(", ")}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatTokens(totalTokens(row))}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatUsd(row.costUsd)}
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -476,7 +616,9 @@ function SessionsTable({ rows }: { rows: ReadonlyArray<UsageGroup> }) {
         <div className="flex items-center justify-between gap-2">
           <p className="text-[11px] text-muted-foreground">
             {start + 1}–{Math.min(start + PAGE_SIZE, sorted.length)} of{" "}
-            <strong className="font-medium text-foreground">{sorted.length.toLocaleString()}</strong>
+            <strong className="font-medium text-foreground">
+              {sorted.length.toLocaleString()}
+            </strong>
           </p>
           <div className="flex items-center gap-1">
             <Button
@@ -512,7 +654,15 @@ function lastActive(row: UsageGroup): string {
   return date === null ? "—" : `Last active ${date.toLocaleDateString()}`;
 }
 
-function SortableHead({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+function SortableHead({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
   return (
     <TableHead className="w-[18%] text-right">
       <button
@@ -521,7 +671,11 @@ function SortableHead({ label, active, onClick }: { label: string; active: boole
         className="ml-auto flex items-center gap-1 text-muted-foreground hover:text-foreground"
       >
         {label}
-        {active ? <ChevronDown className="size-3.5" /> : <ChevronUp className="size-3.5 opacity-30" />}
+        {active ? (
+          <ChevronDown className="size-3.5" />
+        ) : (
+          <ChevronUp className="size-3.5 opacity-30" />
+        )}
       </button>
     </TableHead>
   );

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -11,6 +11,7 @@ import { useWorkspaceStore } from "../store/workspace.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { PROVIDER_LABEL } from "./settings-page";
 import { Button } from "./ui/button.tsx";
+import { ShimmerText } from "./ui/shimmer-text.tsx";
 import { Spinner } from "./ui/spinner";
 
 type StepState = "pending" | "active" | "done" | "failed";
@@ -166,7 +167,13 @@ export function SetupCardView({ data }: { data: SetupCardData }) {
             className="size-4 shrink-0 text-muted-foreground"
           />
           <span className="flex-1 text-[13px] font-medium text-foreground/90">
-            Creating a worktree and running setup
+            {busy ? (
+              <ShimmerText tone="lime">
+                Creating a worktree and running setup
+              </ShimmerText>
+            ) : (
+              "Creating a worktree and running setup"
+            )}
           </span>
           {busy ? (
             <Spinner className="size-3.5 text-muted-foreground" />
@@ -273,7 +280,11 @@ function StepRow({ state, label }: { state: StepState; label: string }) {
               : "text-foreground/80"
         }
       >
-        {label}
+        {state === "active" ? (
+          <ShimmerText tone="lime">{label}</ShimmerText>
+        ) : (
+          label
+        )}
       </span>
     </div>
   );

--- a/apps/renderer/src/hooks/use-media-query.ts
+++ b/apps/renderer/src/hooks/use-media-query.ts
@@ -94,3 +94,8 @@ export function useMediaQuery(
 export function useIsMobile(): boolean {
   return useMediaQuery("max-md");
 }
+
+/** True when the user has requested reduced motion (OS-level setting). */
+export function usePrefersReducedMotion(): boolean {
+  return useMediaQuery("(prefers-reduced-motion: reduce)");
+}

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "diff": "^9.0.0",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
+        "gradient-shimmer": "^0.1.1",
         "lucide-react": "^1.21.0",
         "material-icon-theme": "^5.30.0",
         "mermaid": "11.15.0",
@@ -2027,6 +2028,8 @@
     "got": ["got@11.8.6", "http://registry.npmjs.org/got/-/got-11.8.6.tgz", { "dependencies": { "@sindresorhus/is": "^4.0.0", "@szmarczak/http-timer": "^4.0.5", "@types/cacheable-request": "^6.0.1", "@types/responselike": "^1.0.0", "cacheable-lookup": "^5.0.3", "cacheable-request": "^7.0.2", "decompress-response": "^6.0.0", "http2-wrapper": "^1.0.0-beta.5.2", "lowercase-keys": "^2.0.0", "p-cancelable": "^2.0.0", "responselike": "^2.0.0" } }, "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gradient-shimmer": ["gradient-shimmer@0.1.1", "", { "peerDependencies": { "react": ">=18" } }, "sha512-zSbJINOyDE04rxudOg0O30Vm/iozjln3f0/t5wgISzSoR0KDOhenEnmgWwX6kwxEsIidCMXu61QmLxa9zWVzwg=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 


### PR DESCRIPTION
Adds a `ShimmerText` wrapper around the `gradient-shimmer` package and applies it to pending loading/status surfaces — the worktree setup steps + header (lime), the agent "working" timer, and the terminal / indexing / file-editor / PR / usage / permissions / archived-chats loaders, the update banner, and provider auth sign-in status. A new `usePrefersReducedMotion()` hook renders plain static text when the OS reduce-motion setting is on, so nothing animates for those users. The workspace diff also carries pre-existing usage-dashboard enhancements (time-bucket navigation + pagination) and prettier formatting of the touched files. Type-checking and prettier pass; the dependency lives in the `renderer` workspace.