### PR TITLE
Auto-symlink nested env files (monorepo + Cloudflare) into new worktrees

### DIFF
--- a/apps/server/src/worktree/layers/env-files.ts
+++ b/apps/server/src/worktree/layers/env-files.ts
@@ -1,0 +1,98 @@
+import * as fsSync from "node:fs";
+import * as fs from "node:fs/promises";
+import * as Path from "node:path";
+
+/**
+ * Directories that never hold app env files and/or are huge — pruned from the
+ * recursive walk so it stays fast even on large monorepos.
+ */
+const PRUNED_DIRS = new Set<string>([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  ".cache",
+  "coverage",
+  "vendor",
+  "target",
+  ".memoize",
+]);
+
+/**
+ * Template/sample env files that carry no secrets and are meant to be committed.
+ * They're tracked (so already materialized in the worktree checkout) and pointless
+ * to link — excluding them keeps the setup output clean.
+ */
+const TEMPLATE_SUFFIXES = [".example", ".sample", ".template", ".dist"] as const;
+
+/** Safety backstop against pathological trees; real env files sit 1-3 levels deep. */
+const MAX_DEPTH = 6;
+
+/**
+ * True for secret env files we want to bring into a worktree:
+ * - `.env`, `.env.*` (e.g. `.env.local`, `.env.production`)
+ * - `.dev.vars`, `.dev.vars.*` (Cloudflare Wrangler)
+ *
+ * False for template/sample variants (`.env.example`, `.env.sample`, …) and for
+ * unrelated files like `.envrc` or a bare `env`.
+ */
+export const isEnvFileName = (name: string): boolean => {
+  const isEnv = name === ".env" || name.startsWith(".env.");
+  const isDevVars = name === ".dev.vars" || name.startsWith(".dev.vars.");
+  if (!isEnv && !isDevVars) return false;
+  return !TEMPLATE_SUFFIXES.some((suffix) => name.endsWith(suffix));
+};
+
+/**
+ * Recursively discover env files anywhere under `repoPath` and symlink each into
+ * `worktreePath` at the same relative location, so the worktree's env file *is* the
+ * repo's env file (one source of truth, no drift) — mirroring how `node_modules` is
+ * symlinked. Existing targets are left untouched (non-clobber). Returns a
+ * human-readable summary streamed to the worktree setup UI.
+ */
+export const linkEnvFiles = async (
+  repoPath: string,
+  worktreePath: string,
+): Promise<string> => {
+  let output = "";
+
+  const walk = async (relDir: string, depth: number): Promise<void> => {
+    const absDir = relDir === "" ? repoPath : Path.join(repoPath, relDir);
+    let entries: fsSync.Dirent[];
+    try {
+      entries = await fs.readdir(absDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const rel = relDir === "" ? entry.name : Path.join(relDir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (depth >= MAX_DEPTH) continue;
+        if (PRUNED_DIRS.has(entry.name)) continue;
+        // Stay inside this repo: skip submodules / nested repos / stray worktrees.
+        if (fsSync.existsSync(Path.join(repoPath, rel, ".git"))) continue;
+        await walk(rel, depth + 1);
+        continue;
+      }
+
+      // Link regular files and symlinked files only (matches node_modules guard).
+      if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+      if (!isEnvFileName(entry.name)) continue;
+
+      const source = Path.join(repoPath, rel);
+      const target = Path.join(worktreePath, rel);
+      if (fsSync.existsSync(target)) continue;
+
+      await fs.mkdir(Path.dirname(target), { recursive: true });
+      await fs.symlink(source, target, "file");
+      output += `linked ${rel} -> ${source}\n`;
+    }
+  };
+
+  await walk("", 0);
+  return output;
+};

--- a/apps/server/src/worktree/layers/worktree-service.ts
+++ b/apps/server/src/worktree/layers/worktree-service.ts
@@ -37,6 +37,7 @@ import {
   WorktreeService,
   type WorktreeRestoreSnapshot,
 } from "../services/worktree-service.ts";
+import { linkEnvFiles } from "./env-files.ts";
 
 interface WorktreeRow {
   readonly id: string;
@@ -218,16 +219,7 @@ const prepareLocalFiles = async (
     }
   }
 
-  for (const entry of await fs.readdir(repoPath)) {
-    if (!entry.startsWith(".env")) continue;
-    const source = Path.join(repoPath, entry);
-    const target = Path.join(worktreePath, entry);
-    if (fsSync.existsSync(target)) continue;
-    const stat = await fs.lstat(source);
-    if (!stat.isFile() && !stat.isSymbolicLink()) continue;
-    await fs.copyFile(source, target);
-    output += `copied ${entry}\n`;
-  }
+  output += await linkEnvFiles(repoPath, worktreePath);
 
   return output;
 };

--- a/apps/server/test/env-files.test.ts
+++ b/apps/server/test/env-files.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fsSync from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as Path from "node:path";
+
+import { isEnvFileName, linkEnvFiles } from "../src/worktree/layers/env-files.ts";
+
+describe("isEnvFileName", () => {
+  const cases: ReadonlyArray<readonly [string, boolean]> = [
+    [".env", true],
+    [".env.local", true],
+    [".env.production", true],
+    [".dev.vars", true],
+    [".dev.vars.prod", true],
+    [".env.example", false],
+    [".env.sample", false],
+    [".env.template", false],
+    [".env.dist", false],
+    [".envrc", false],
+    ["env", false],
+    ["package.json", false],
+  ];
+  for (const [name, expected] of cases) {
+    it(`${name} -> ${expected}`, () => {
+      expect(isEnvFileName(name)).toBe(expected);
+    });
+  }
+});
+
+describe("linkEnvFiles", () => {
+  let repo: string;
+  let worktree: string;
+
+  const write = async (root: string, rel: string, content: string) => {
+    const abs = Path.join(root, rel);
+    await fs.mkdir(Path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  };
+
+  beforeEach(async () => {
+    const base = await fs.mkdtemp(Path.join(os.tmpdir(), "env-files-"));
+    repo = Path.join(base, "repo");
+    worktree = Path.join(base, "worktree");
+    await fs.mkdir(repo, { recursive: true });
+    await fs.mkdir(worktree, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(Path.dirname(repo), { recursive: true, force: true });
+  });
+
+  it("symlinks root, nested, and Cloudflare env files; skips templates and pruned dirs", async () => {
+    await write(repo, ".env", "ROOT=1");
+    await write(repo, ".env.local", "ROOT_LOCAL=1");
+    await write(repo, "apps/web/.env.production", "WEB=1");
+    await write(repo, "apps/api/.dev.vars", "API=1");
+    await write(repo, ".env.example", "EXAMPLE=1");
+    await write(repo, "node_modules/.env", "DEP=1");
+
+    const output = await linkEnvFiles(repo, worktree);
+
+    const expectLinked = async (rel: string, expectedContent: string) => {
+      const target = Path.join(worktree, rel);
+      const stat = await fs.lstat(target);
+      expect(stat.isSymbolicLink()).toBe(true);
+      expect(await fs.readlink(target)).toBe(Path.join(repo, rel));
+      expect(await fs.readFile(target, "utf8")).toBe(expectedContent);
+    };
+
+    await expectLinked(".env", "ROOT=1");
+    await expectLinked(".env.local", "ROOT_LOCAL=1");
+    await expectLinked("apps/web/.env.production", "WEB=1");
+    await expectLinked("apps/api/.dev.vars", "API=1");
+
+    expect(fsSync.existsSync(Path.join(worktree, ".env.example"))).toBe(false);
+    expect(fsSync.existsSync(Path.join(worktree, "node_modules"))).toBe(false);
+
+    expect(output).toContain("linked .env ");
+    expect(output).toContain("linked apps/web/.env.production ");
+    expect(output).toContain("linked apps/api/.dev.vars ");
+  });
+
+  it("reflects edits to the source through the symlink (one source of truth)", async () => {
+    await write(repo, ".env", "V=1");
+    await linkEnvFiles(repo, worktree);
+    await fs.writeFile(Path.join(repo, ".env"), "V=2");
+    expect(await fs.readFile(Path.join(worktree, ".env"), "utf8")).toBe("V=2");
+  });
+
+  it("leaves an existing target untouched (non-clobber)", async () => {
+    await write(repo, ".env", "FROM_REPO=1");
+    await write(worktree, ".env", "ALREADY_HERE=1");
+
+    await linkEnvFiles(repo, worktree);
+
+    const stat = await fs.lstat(Path.join(worktree, ".env"));
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(await fs.readFile(Path.join(worktree, ".env"), "utf8")).toBe(
+      "ALREADY_HERE=1",
+    );
+  });
+
+  it("does not descend into nested repos / submodules", async () => {
+    await write(repo, "vendored/.git", "gitdir: ../.git/modules/vendored");
+    await write(repo, "vendored/.env", "NESTED=1");
+
+    await linkEnvFiles(repo, worktree);
+
+    expect(fsSync.existsSync(Path.join(worktree, "vendored/.env"))).toBe(false);
+  });
+});


### PR DESCRIPTION
When a new worktree is created, env files are now discovered recursively anywhere in the repo and symlinked into the worktree at the same relative path, replacing the old root-only copy. This covers monorepo subdirectories (e.g. `apps/web/.env.local`) and Cloudflare Wrangler `.dev.vars` files, while excluding committed template variants (`.env.example`, etc.). The walk prunes heavy/irrelevant directories (`node_modules`, `.git`, `dist`, `.next`, …), skips nested repos/submodules, caps depth, and never clobbers existing files. Symlinking (matching how `node_modules` is already linked) gives a single source of truth so secrets never drift across worktrees. Adds `apps/server/src/worktree/layers/env-files.ts` with 16 unit tests; full server suite passes and typecheck is clean.