### PR TITLE
Show "Interrupted by user" badge instead of error on Claude interrupt

### DIFF
--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -188,6 +188,16 @@ export function MessageRow({
           sessionId={sessionId}
         />
       );
+    case "interrupted":
+      // The user stopped the turn — a normal action, so render a small muted
+      // badge rather than an error bubble.
+      return (
+        <div className="flex justify-center py-1">
+          <span className="rounded-full bg-muted/50 px-2.5 py-0.5 text-[11px] text-muted-foreground">
+            Interrupted by user
+          </span>
+        </div>
+      );
   }
 }
 

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -283,6 +283,14 @@ interface TranslateState {
    * same failure a second time.
    */
   emittedAuthError: boolean;
+  /**
+   * Set when the user interrupts the running turn (`handle.interrupt`). The SDK
+   * ends an interrupted turn with an `error_during_execution` result, which
+   * would otherwise surface as a bogus error bubble; while this flag is set the
+   * translator emits an `Interrupted` event + `Completed reason:"interrupted"`
+   * instead. Reset per turn once consumed.
+   */
+  interrupted: boolean;
 }
 
 const newTranslateState = (): TranslateState => ({
@@ -294,6 +302,7 @@ const newTranslateState = (): TranslateState => ({
   exitPlanModeIds: new Set(),
   lastContextUsedTokens: null,
   emittedAuthError: false,
+  interrupted: false,
 });
 
 const isAgentToolUse = (block: { type?: string; name?: string }): boolean =>
@@ -903,6 +912,17 @@ const translate = (
           precision: "exact",
           source: "Claude usage",
         });
+      }
+      // The user interrupted this turn. The SDK ends it with an
+      // `error_during_execution` result, but that's a normal user action — emit
+      // a muted `Interrupted` badge + non-error completion instead of an Error
+      // bubble, and skip the failed-result handling below.
+      if (state.interrupted) {
+        out.push({ _tag: "Interrupted" });
+        out.push({ _tag: "Completed", reason: "interrupted" });
+        state.interrupted = false;
+        state.emittedAuthError = false;
+        return out;
       }
       // Surface a failed result's text as an Error so it persists + renders
       // (auth failures the SDK reports via the result rather than an assistant
@@ -1684,6 +1704,16 @@ export const startClaudeSession = (
     }).pipe(
       Effect.catchAll((cause) =>
         Effect.sync(() => {
+          // If the SDK threw out of the `for await` because the user
+          // interrupted (rather than yielding an `error_during_execution`
+          // result), surface the muted interrupted badge, not an error. Emit a
+          // non-error completion too so the turn isn't left pinned at running.
+          if (translateState.interrupted) {
+            translateState.interrupted = false;
+            events.unsafeOffer({ _tag: "Interrupted" });
+            events.unsafeOffer({ _tag: "Completed", reason: "interrupted" });
+            return;
+          }
           events.unsafeOffer({
             _tag: "Error",
             message: cause instanceof Error ? cause.message : String(cause),
@@ -1732,10 +1762,20 @@ export const startClaudeSession = (
           );
         }),
       interrupt: () =>
-        Effect.tryPromise({
-          try: () => q.interrupt(),
-          catch: (cause) => cause,
-        }).pipe(Effect.catchAll(() => Effect.void)),
+        Effect.sync(() => {
+          // Mark the turn as interrupted so the terminal `result`
+          // (`error_during_execution`) is translated into an `Interrupted`
+          // badge instead of an error bubble.
+          translateState.interrupted = true;
+        }).pipe(
+          Effect.zipRight(
+            Effect.tryPromise({
+              try: () => q.interrupt(),
+              catch: (cause) => cause,
+            }),
+          ),
+          Effect.catchAll(() => Effect.void),
+        ),
       close: () =>
         Effect.sync(() => {
           // Unblock any in-flight AskUserQuestion calls so the SDK turn

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -331,6 +331,7 @@ const roleForContent = (content: MessageContent): MessageRole => {
     case "tool_result":
       return "tool";
     case "error":
+    case "interrupted":
     case "usage":
     case "context_usage":
     case "usage_limit":
@@ -417,6 +418,8 @@ const eventToContent = (event: AgentEvent): MessageContent | null => {
       };
     case "Error":
       return { _tag: "error", message: event.message };
+    case "Interrupted":
+      return { _tag: "interrupted" };
     case "UserQuestion":
       return {
         _tag: "user_question",

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -490,6 +490,16 @@ const CompletedEvent = Schema.TaggedStruct("Completed", {
   reason: Schema.Literal("ended", "interrupted", "error"),
 });
 
+/**
+ * Emitted when the user interrupts a running turn. Unlike `Error`, this is a
+ * normal user action — the renderer shows a muted "Interrupted by user" badge
+ * (no red error bubble) and the session stays out of the error state. Drivers
+ * emit this in place of `Error` when they know the turn ended because of an
+ * explicit interrupt (see the Claude driver, which otherwise surfaces the
+ * SDK's `error_during_execution` result as a bogus error).
+ */
+const InterruptedEvent = Schema.TaggedStruct("Interrupted", {});
+
 const ErrorEvent = Schema.TaggedStruct("Error", {
   message: Schema.String,
   /**
@@ -604,6 +614,7 @@ export const AgentEvent = Schema.Union(
   GoalUpdatedEvent,
   GoalClearedEvent,
   CompletedEvent,
+  InterruptedEvent,
   ErrorEvent,
 );
 export type AgentEvent = typeof AgentEvent.Type;

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -216,6 +216,14 @@ const ErrorContent = Schema.TaggedStruct("error", {
 });
 
 /**
+ * Persisted marker for a turn the user explicitly interrupted. Rendered as a
+ * small muted "Interrupted by user" badge — distinct from `error`, which is a
+ * real failure. Carries no fields; its presence in the message list is the
+ * whole signal.
+ */
+const InterruptedContent = Schema.TaggedStruct("interrupted", {});
+
+/**
  * Closing summary persisted for a sub-agent run. Mirrors the streaming
  * `SubagentSummaryEvent` so resume parity holds: the wrapper-row footer
  * reads `summary` / `turns` / `durationMs` from this row when collapsed.
@@ -305,6 +313,7 @@ export const MessageContent = Schema.Union(
   ToolUseContent,
   ToolResultContent,
   ErrorContent,
+  InterruptedContent,
   SubagentSummaryContent,
   UsageContent,
   ContextUsageContent,


### PR DESCRIPTION
Interrupting a Claude turn previously surfaced a red "The agent run ended with an error" bubble and flipped the session into an error state, because the SDK ends an interrupted turn with an `error_during_execution` result that the driver misclassified as a real failure. This adds an additive `Interrupted` agent event and `interrupted` message content; the Claude driver now tracks the user interrupt and emits that event plus a non-error completion instead of an `Error`, matching how the Codex and Grok drivers already handle interrupts. The renderer renders it as a small muted "Interrupted by user" badge, and the server maps it to a system-role row that never sets the session to `error`. The interrupt flag is per-turn and only set by the Claude driver, so genuine errors (auth/network) and the other providers are unaffected, and the badge persists across reload/resume. Type checks pass across all packages.