### PR TITLE
[codex] Fix plan feedback routing

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -77,6 +77,11 @@ import {
 } from "../store/composer-drafts.ts";
 import { cn, formatCompactNumber } from "~/lib/utils";
 import {
+  chooseComposerSubmitRoute,
+  findPendingPlanApprovalRequest,
+  shouldSendPlanFeedbackNow,
+} from "~/lib/plan-feedback-routing";
+import {
   matchBuiltin,
   type BuiltinCommand,
 } from "../composer/builtin-commands.ts";
@@ -223,6 +228,7 @@ export function ChatComposer({
   // because the agent is already mid-tool-call.
   const requestsById = usePermissionsStore((s) => s.requestsById);
   const hydratePermissions = usePermissionsStore((s) => s.hydrate);
+  const decidePermission = usePermissionsStore((s) => s.decide);
   const pendingPermissions = useMemo(() => {
     const out: PermissionRequest[] = [];
     for (const req of Object.values(requestsById)) {
@@ -236,6 +242,20 @@ export function ChatComposer({
     out.sort((a, b) => a.requestedAt.getTime() - b.requestedAt.getTime());
     return out;
   }, [requestsById, sessionId]);
+  const pendingPlanApprovalRequest = useMemo(
+    () =>
+      findPendingPlanApprovalRequest(Object.values(requestsById), sessionId),
+    [requestsById, sessionId],
+  );
+  const sendPlanFeedbackNow = useMemo(
+    () =>
+      shouldSendPlanFeedbackNow({
+        permissionMode: session.permissionMode,
+        messages: sessionMessages ?? [],
+        pendingPlanApprovalRequest,
+      }),
+    [pendingPlanApprovalRequest, session.permissionMode, sessionMessages],
+  );
   useEffect(() => {
     if (isDraft) return;
     void hydratePermissions(sessionId);
@@ -685,15 +705,35 @@ export function ChatComposer({
       onDraftSubmit(input, { asGoal: goalSendMode });
       return true;
     }
-    if (goalSendMode) {
-      void send(sessionId, input, { asGoal: true });
-    } else if (inFlight || holdForSetup) {
-      // Mid-turn submit — or a submit while the worktree/provider is still
-      // coming up — becomes a queue chip; auto-flushed when the turn ends,
-      // setup completes, or steered manually.
-      queue(sessionId, input);
-    } else {
-      void send(sessionId, input);
+    switch (
+      chooseComposerSubmitRoute({
+        sendPlanFeedbackNow,
+        goalSendMode,
+        shouldQueue: inFlight || holdForSetup,
+      })
+    ) {
+      case "planFeedback":
+        void (async () => {
+          if (pendingPlanApprovalRequest !== null) {
+            await decidePermission(pendingPlanApprovalRequest.id, {
+              _tag: "Deny",
+            });
+          }
+          await send(sessionId, input);
+        })();
+        break;
+      case "goal":
+        void send(sessionId, input, { asGoal: true });
+        break;
+      case "queue":
+        // Mid-turn submit — or a submit while the worktree/provider is still
+        // coming up — becomes a queue chip; auto-flushed when the turn ends,
+        // setup completes, or steered manually.
+        queue(sessionId, input);
+        break;
+      case "send":
+        void send(sessionId, input);
+        break;
     }
     return true;
   };

--- a/apps/renderer/src/lib/plan-feedback-routing.ts
+++ b/apps/renderer/src/lib/plan-feedback-routing.ts
@@ -1,0 +1,90 @@
+import type {
+  Message,
+  PermissionMode,
+  PermissionRequest,
+  SessionId,
+} from "@memoize/wire";
+
+export const isPlanApprovalRequest = (
+  req: PermissionRequest,
+  sessionId: SessionId,
+): boolean =>
+  req.sessionId === sessionId &&
+  req.kind._tag === "Other" &&
+  req.kind.tool === "ExitPlanMode";
+
+export const findPendingPlanApprovalRequest = (
+  requests: ReadonlyArray<PermissionRequest>,
+  sessionId: SessionId,
+): PermissionRequest | null => {
+  for (const req of requests) {
+    if (isPlanApprovalRequest(req, sessionId)) return req;
+  }
+  return null;
+};
+
+/**
+ * True when typed composer text should be treated as feedback on a proposed
+ * plan instead of a mid-turn queue item.
+ *
+ * Claude exposes this as an ExitPlanMode permission request. Providers with
+ * emulated plan mode do not have that tool, so use the transcript shape:
+ * while the session is still in plan mode, an assistant answer after the last
+ * user message means the agent has produced the plan and is waiting for
+ * feedback. If the latest turn is still only the user's prompt or a tool call,
+ * the agent is still working and normal queueing should apply.
+ */
+export const shouldSendPlanFeedbackNow = ({
+  permissionMode,
+  messages,
+  pendingPlanApprovalRequest,
+}: {
+  readonly permissionMode: PermissionMode;
+  readonly messages: ReadonlyArray<Pick<Message, "content">>;
+  readonly pendingPlanApprovalRequest: PermissionRequest | null;
+}): boolean => {
+  if (pendingPlanApprovalRequest !== null) return true;
+  if (permissionMode !== "plan") return false;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i]!.content;
+    switch (content._tag) {
+      case "assistant":
+        return content.text.trim().length > 0;
+      case "user":
+      case "user_rich":
+      case "tool_use":
+      case "error":
+      case "interrupted":
+      case "user_question":
+        return false;
+      case "tool_result":
+      case "thinking":
+      case "subagent_summary":
+      case "usage":
+      case "context_usage":
+      case "usage_limit":
+      case "user_question_answer":
+        continue;
+    }
+  }
+
+  return false;
+};
+
+export type ComposerSubmitRoute = "planFeedback" | "goal" | "queue" | "send";
+
+export const chooseComposerSubmitRoute = ({
+  sendPlanFeedbackNow,
+  goalSendMode,
+  shouldQueue,
+}: {
+  readonly sendPlanFeedbackNow: boolean;
+  readonly goalSendMode: boolean;
+  readonly shouldQueue: boolean;
+}): ComposerSubmitRoute => {
+  if (sendPlanFeedbackNow) return "planFeedback";
+  if (goalSendMode) return "goal";
+  if (shouldQueue) return "queue";
+  return "send";
+};

--- a/apps/renderer/test/plan-feedback-routing.test.ts
+++ b/apps/renderer/test/plan-feedback-routing.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  PermissionRequest,
+  type Message,
+  type SessionId,
+} from "@memoize/wire";
+
+import {
+  chooseComposerSubmitRoute,
+  findPendingPlanApprovalRequest,
+  shouldSendPlanFeedbackNow,
+} from "../src/lib/plan-feedback-routing.ts";
+
+type TestMessage = Pick<Message, "content">;
+
+const sessionId = "session-plan" as SessionId;
+
+const user = (text = "make a plan"): TestMessage => ({
+  content: { _tag: "user", text },
+});
+
+const assistant = (
+  text = "<proposed_plan>\nDo it\n</proposed_plan>",
+): TestMessage => ({
+  content: { _tag: "assistant", text },
+});
+
+const toolUse = (tool = "Read"): TestMessage => ({
+  content: {
+    _tag: "tool_use",
+    itemId: "tool_1" as never,
+    tool,
+    input: {},
+  },
+});
+
+const exitPlanRequest = PermissionRequest.make({
+  id: "perm_plan",
+  sessionId,
+  kind: {
+    _tag: "Other",
+    tool: "ExitPlanMode",
+    summary: "Approve plan",
+  },
+  requestedAt: new Date("2026-06-28T00:00:00.000Z"),
+  forcePrompt: true,
+});
+
+describe("plan feedback routing", () => {
+  it("detects a pending ExitPlanMode approval request", () => {
+    expect(findPendingPlanApprovalRequest([exitPlanRequest], sessionId)).toBe(
+      exitPlanRequest,
+    );
+  });
+
+  it("routes Claude-style pending plan approval feedback to send now", () => {
+    expect(
+      shouldSendPlanFeedbackNow({
+        permissionMode: "plan",
+        messages: [user(), toolUse("ExitPlanMode")],
+        pendingPlanApprovalRequest: exitPlanRequest,
+      }),
+    ).toBe(true);
+  });
+
+  it("routes emulated provider plan feedback to send now after an assistant plan", () => {
+    expect(
+      shouldSendPlanFeedbackNow({
+        permissionMode: "plan",
+        messages: [user(), assistant()],
+        pendingPlanApprovalRequest: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps normal running turns on the queue path before an assistant response", () => {
+    expect(
+      shouldSendPlanFeedbackNow({
+        permissionMode: "default",
+        messages: [user()],
+        pendingPlanApprovalRequest: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSendPlanFeedbackNow({
+        permissionMode: "plan",
+        messages: [user()],
+        pendingPlanApprovalRequest: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps setup or active tool work on the queue path", () => {
+    expect(
+      shouldSendPlanFeedbackNow({
+        permissionMode: "plan",
+        messages: [user(), toolUse("Read")],
+        pendingPlanApprovalRequest: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("routes plan feedback before goal mode or queueing", () => {
+    expect(
+      chooseComposerSubmitRoute({
+        sendPlanFeedbackNow: true,
+        goalSendMode: true,
+        shouldQueue: true,
+      }),
+    ).toBe("planFeedback");
+  });
+
+  it("preserves normal goal, queue, and send routing otherwise", () => {
+    expect(
+      chooseComposerSubmitRoute({
+        sendPlanFeedbackNow: false,
+        goalSendMode: true,
+        shouldQueue: true,
+      }),
+    ).toBe("goal");
+    expect(
+      chooseComposerSubmitRoute({
+        sendPlanFeedbackNow: false,
+        goalSendMode: false,
+        shouldQueue: true,
+      }),
+    ).toBe("queue");
+    expect(
+      chooseComposerSubmitRoute({
+        sendPlanFeedbackNow: false,
+        goalSendMode: false,
+        shouldQueue: false,
+      }),
+    ).toBe("send");
+  });
+});


### PR DESCRIPTION
## Summary
- route typed plan feedback directly instead of adding it to the message queue
- deny pending `ExitPlanMode` approvals before sending the feedback comment
- support emulated plan mode for non-Claude providers by detecting assistant plan responses while still in plan mode

## Validation
- `bun test apps/renderer/test`
- `bun run --filter renderer check-types`
