### PR TITLE
Add diagnostics bundle export

### DIFF
--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -24,6 +24,7 @@ export type MenuCommand =
   | "new-chat"
   | "open-project"
   | "settings"
+  | "export-diagnostics"
   | "close-tab"
   | "toggle-left-sidebar"
   | "toggle-right-sidebar"
@@ -49,6 +50,7 @@ export const DEFAULT_MENU_ACCELERATORS: MenuAccelerators = {
   "new-chat": "CmdOrCtrl+N",
   "open-project": "CmdOrCtrl+O",
   settings: "CmdOrCtrl+,",
+  "export-diagnostics": null,
   "close-tab": "CmdOrCtrl+W",
   "toggle-left-sidebar": "CmdOrCtrl+B",
   "toggle-right-sidebar": "CmdOrCtrl+Alt+B",
@@ -65,9 +67,7 @@ const GITHUB_ISSUE_NEW_URL = `${GITHUB_REPO_URL}/issues/new`;
  * updater status. Label + enabled + click target all flip together so the
  * menu is a complete fallback path even when the in-app toast is missing.
  */
-function buildUpdateMenuItem(
-  status: UpdateStatus,
-): MenuItemConstructorOptions {
+function buildUpdateMenuItem(status: UpdateStatus): MenuItemConstructorOptions {
   switch (status.kind) {
     case "checking":
       return { label: "Checking for Updates…", enabled: false };
@@ -127,13 +127,11 @@ export function installAppMenu(
   const isMac = process.platform === "darwin";
   const isDev = !app.isPackaged;
 
-  const sendAction =
-    (action: Exclude<MenuCommand, "close-tab">) =>
-    () => {
-      const win = getWindow();
-      if (win === null) return;
-      win.webContents.send("menu:action", action);
-    };
+  const sendAction = (action: Exclude<MenuCommand, "close-tab">) => () => {
+    const win = getWindow();
+    if (win === null) return;
+    win.webContents.send("menu:action", action);
+  };
 
   const sendCloseTab = () => {
     const win = getWindow();
@@ -278,6 +276,10 @@ export function installAppMenu(
         click: () => {
           void shell.openExternal(GITHUB_ISSUE_NEW_URL);
         },
+      },
+      {
+        label: "Export Diagnostics…",
+        click: sendAction("export-diagnostics"),
       },
       { type: "separator" },
       {

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -4,6 +4,7 @@ import {
   Alert01Icon,
   ArrowLeft01Icon,
   Delete02Icon,
+  DocumentAttachmentIcon,
   Folder01Icon,
   GitBranchIcon,
   GlobeIcon,
@@ -114,6 +115,12 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
     label: "Browser",
     Icon: GlobeIcon,
     section: { kind: "browser" },
+  },
+  {
+    id: "diagnostics",
+    label: "Diagnostics",
+    Icon: DocumentAttachmentIcon,
+    section: { kind: "diagnostics" },
   },
   {
     id: "shortcuts",
@@ -316,6 +323,12 @@ function SectionTitle({
         subtitle: "Dummy test logins the agent browser can autofill.",
       };
     }
+    if (section.kind === "diagnostics") {
+      return {
+        title: "Diagnostics",
+        subtitle: "Export a redacted support bundle for debugging user issues.",
+      };
+    }
     if (section.kind === "shortcuts") {
       return {
         title: "Keyboard shortcuts",
@@ -361,9 +374,132 @@ function Pane({ section }: { section: SettingsSection }) {
   if (section.kind === "workspace") return <WorkspacePane />;
   if (section.kind === "pokedex") return <PokedexPane />;
   if (section.kind === "browser") return <BrowserSettingsPane />;
+  if (section.kind === "diagnostics") return <DiagnosticsPane />;
   if (section.kind === "shortcuts") return <KeybindingsPane />;
   if (section.kind === "developer") return <DeveloperPane />;
   return <RepositorySettings projectId={section.projectId} />;
+}
+
+function DiagnosticsPane() {
+  const [isExporting, setIsExporting] = useState(false);
+  const [lastExport, setLastExport] = useState<{
+    diagnosticId: string;
+    bundlePath: string;
+    summary: string;
+    agentPrompt: string;
+    included: ReadonlyArray<string>;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<"summary" | "prompt" | null>(null);
+
+  const copyText = async (kind: "summary" | "prompt", text: string) => {
+    await navigator.clipboard?.writeText(text);
+    setCopied(kind);
+    window.setTimeout(() => {
+      setCopied((current) => (current === kind ? null : current));
+    }, 1400);
+  };
+
+  const exportDiagnostics = async () => {
+    setIsExporting(true);
+    setError(null);
+    try {
+      const client = await getRpcClient();
+      const result = await Effect.runPromise(client.diagnostics.export({}));
+      setLastExport({
+        diagnosticId: result.diagnosticId,
+        bundlePath: result.bundlePath,
+        summary: result.summary,
+        agentPrompt: result.agentPrompt,
+        included: result.included,
+      });
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Could not export diagnostics bundle.",
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SettingsGroup
+        title="Support bundle"
+        description="Creates a local redacted diagnostics file plus agent-readable artifacts. Raw prompts and full transcripts are not included by default."
+      >
+        <SettingsRow
+          title="Included by default"
+          description="Manifest, trace summary, recent errors, environment, provider status, and redacted session-event previews."
+          action={
+            <Button
+              size="sm"
+              onClick={() => void exportDiagnostics()}
+              disabled={isExporting}
+            >
+              <HugeiconsIcon
+                icon={DocumentAttachmentIcon}
+                className="size-3.5"
+              />
+              {isExporting ? "Exporting..." : "Export diagnostics"}
+            </Button>
+          }
+        />
+        {lastExport && (
+          <SettingsRow
+            title={`Last export: ${lastExport.diagnosticId}`}
+            description={lastExport.bundlePath}
+          >
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="settings"
+                size="sm"
+                onClick={() => void copyText("summary", lastExport.summary)}
+              >
+                {copied === "summary" ? "Copied" : "Copy summary"}
+              </Button>
+              <Button
+                variant="settings"
+                size="sm"
+                onClick={() => void copyText("prompt", lastExport.agentPrompt)}
+              >
+                {copied === "prompt" ? "Copied" : "Copy agent prompt"}
+              </Button>
+            </div>
+            <div className="mt-3 rounded-lg border border-border/40 bg-background/60 p-3">
+              <div className="mb-2 text-xs font-medium text-muted-foreground">
+                Bundle contents
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {lastExport.included.map((item) => (
+                  <span
+                    key={item}
+                    className="rounded bg-muted px-2 py-0.5 font-mono text-[11px] text-muted-foreground"
+                  >
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </SettingsRow>
+        )}
+        {error && (
+          <SettingsRow
+            icon={Alert01Icon}
+            title="Export failed"
+            description={error}
+          />
+        )}
+      </SettingsGroup>
+
+      <SettingsFrame
+        title="Agent intake"
+        description="After a user sends the exported JSON file, run bun run diagnostics:inspect path/to/memoize-diagnostics.json in a repo workspace. The script writes .context/diagnostics/<id>/REPORT.md for an agent to inspect."
+      />
+    </div>
+  );
 }
 
 interface BrowserCredRow {

--- a/apps/renderer/src/hooks/use-menu-shortcuts.ts
+++ b/apps/renderer/src/hooks/use-menu-shortcuts.ts
@@ -4,6 +4,7 @@ import type { Command } from "@memoize/wire";
 
 import type { MenuAction } from "../lib/bridge";
 import { dispatchCommand } from "../lib/commands";
+import { useUiStore } from "../store/ui";
 
 /**
  * Subscribe to native Application Menu clicks emitted by the main process
@@ -20,6 +21,12 @@ export function useMenuShortcuts(): void {
     if (menu === undefined) return;
 
     const handle = (action: MenuAction) => {
+      if (action === "export-diagnostics") {
+        const ui = useUiStore.getState();
+        ui.setSettingsSection({ kind: "diagnostics" });
+        ui.setView("settings");
+        return;
+      }
       dispatchCommand(action as Command);
     };
 

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -53,6 +53,7 @@ export type MenuAction =
   | "new-chat"
   | "open-project"
   | "settings"
+  | "export-diagnostics"
   | "toggle-left-sidebar"
   | "toggle-right-sidebar"
   | "toggle-terminal"

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -26,6 +26,7 @@ export type SettingsSection =
   | { readonly kind: "workspace" }
   | { readonly kind: "pokedex" }
   | { readonly kind: "browser" }
+  | { readonly kind: "diagnostics" }
   | { readonly kind: "shortcuts" }
   | { readonly kind: "developer" }
   | { readonly kind: "repository"; readonly projectId: FolderId };

--- a/apps/server/src/diagnostics/handlers.ts
+++ b/apps/server/src/diagnostics/handlers.ts
@@ -1,0 +1,10 @@
+import { MemoizeRpcs } from "@memoize/wire";
+import { Effect, Layer } from "effect";
+
+import { DiagnosticsService } from "./services/diagnostics-service.ts";
+
+const ExportBundle = MemoizeRpcs.toLayerHandler("diagnostics.export", () =>
+  Effect.flatMap(DiagnosticsService, (svc) => svc.exportBundle()),
+);
+
+export const DiagnosticsHandlersLayer = Layer.mergeAll(ExportBundle);

--- a/apps/server/src/diagnostics/layers/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/layers/diagnostics-service.ts
@@ -1,0 +1,382 @@
+import { SqlClient } from "@effect/sql";
+import { Effect, Layer } from "effect";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { arch, platform, release } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import {
+  DiagnosticsExportError,
+  DiagnosticsExportResult,
+  type AgentAvailability,
+} from "@memoize/wire";
+
+import packageJson from "../../../package.json" with { type: "json" };
+import { AppPaths } from "../../app-paths.ts";
+import { ProviderService } from "../../provider/services/provider-service.ts";
+import { DiagnosticsService } from "../services/diagnostics-service.ts";
+
+const MAX_RECENT_ERRORS = 20;
+const MAX_SESSION_EVENTS = 8;
+const MAX_REDACTED_EVENTS_PER_FILE = 200;
+const MAX_TEXT_PREVIEW = 240;
+
+interface RecentErrorRow {
+  readonly message_id: string;
+  readonly session_id: string;
+  readonly chat_id: string | null;
+  readonly project_id: string;
+  readonly provider_id: string;
+  readonly model: string;
+  readonly kind: string;
+  readonly content_json: string;
+  readonly created_at: string;
+}
+
+interface SessionEventFile {
+  readonly sessionId: string;
+  readonly projectId: string;
+  readonly sourcePath: string;
+  readonly eventCount: number;
+  readonly truncated: boolean;
+  readonly events: ReadonlyArray<unknown>;
+}
+
+type BundleArtifactName =
+  | "manifest"
+  | "trace-summary"
+  | "recent-errors"
+  | "environment"
+  | "provider-status"
+  | "redacted-session-events";
+
+function safeIsoForFile(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, "-");
+}
+
+function truncate(value: string): string {
+  return value.length <= MAX_TEXT_PREVIEW
+    ? value
+    : `${value.slice(0, MAX_TEXT_PREVIEW)}...`;
+}
+
+function summarizeUnknown(value: unknown): unknown {
+  if (typeof value === "string") {
+    return {
+      redacted: true,
+      length: value.length,
+      preview: truncate(value),
+    };
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map(summarizeUnknown);
+  }
+  if (typeof value === "object" && value !== null) {
+    const entries = Object.entries(value as Record<string, unknown>).map(
+      ([key, entry]) => {
+        if (
+          key.toLowerCase().includes("text") ||
+          key.toLowerCase().includes("prompt") ||
+          key.toLowerCase().includes("output") ||
+          key.toLowerCase().includes("summary")
+        ) {
+          return [key, summarizeUnknown(entry)] as const;
+        }
+        return [key, summarizeUnknown(entry)] as const;
+      },
+    );
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+function readErrorMessage(contentJson: string): string {
+  try {
+    const parsed = JSON.parse(contentJson) as unknown;
+    if (typeof parsed === "object" && parsed !== null && "message" in parsed) {
+      const message = (parsed as { readonly message?: unknown }).message;
+      return typeof message === "string"
+        ? truncate(message)
+        : "Error message unavailable";
+    }
+    return truncate(JSON.stringify(summarizeUnknown(parsed)));
+  } catch {
+    return "Could not parse persisted error content.";
+  }
+}
+
+function listSessionEventFiles(
+  userData: string,
+): ReadonlyArray<{ projectId: string; path: string }> {
+  const root = join(userData, "sessions");
+  if (!existsSync(root)) return [];
+  const files: Array<{ projectId: string; path: string; mtimeMs: number }> = [];
+  for (const projectId of readdirSync(root)) {
+    const projectDir = join(root, projectId);
+    if (!statSync(projectDir).isDirectory()) continue;
+    for (const entry of readdirSync(projectDir)) {
+      if (!entry.endsWith(".events.ndjson")) continue;
+      const path = join(projectDir, entry);
+      const stat = statSync(path);
+      files.push({ projectId, path, mtimeMs: stat.mtimeMs });
+    }
+  }
+  return [...files]
+    .sort((left, right) => right.mtimeMs - left.mtimeMs)
+    .slice(0, MAX_SESSION_EVENTS)
+    .map(({ projectId, path }) => ({ projectId, path }));
+}
+
+function redactSessionEventFile(input: {
+  readonly projectId: string;
+  readonly path: string;
+}): SessionEventFile {
+  const text = readFileSync(input.path, "utf8");
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const events = lines.slice(-MAX_REDACTED_EVENTS_PER_FILE).flatMap((line) => {
+    try {
+      return [summarizeUnknown(JSON.parse(line) as unknown)];
+    } catch {
+      return [{ parseError: true, bytes: Buffer.byteLength(line) }];
+    }
+  });
+  const fileName = basename(input.path);
+  const sessionId = fileName.replace(/\.events\.ndjson$/, "");
+  return {
+    projectId: input.projectId,
+    sessionId,
+    sourcePath: input.path,
+    eventCount: lines.length,
+    truncated: lines.length > MAX_REDACTED_EVENTS_PER_FILE,
+    events,
+  };
+}
+
+function summarizeProvider(provider: AgentAvailability) {
+  return {
+    providerId: provider.providerId,
+    displayName: provider.displayName,
+    cliInstalled: provider.cliInstalled,
+    cliVersion: provider.cliVersion,
+    cliLoggedIn: provider.cliLoggedIn,
+    hasApiKey: provider.hasApiKey,
+    cliVersionStatus: provider.cliVersionStatus,
+    latestVersionStatus: provider.latestVersionStatus,
+    authStatus: provider.authStatus,
+    authType: provider.authType,
+    status: provider.status,
+    statusMessage: provider.statusMessage,
+    lastCheckedAt: provider.lastCheckedAt,
+  };
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function buildSummary(input: {
+  readonly diagnosticId: string;
+  readonly bundlePath: string;
+  readonly latestFailures: ReadonlyArray<{
+    readonly span: string;
+    readonly message: string;
+  }>;
+  readonly providerCount: number;
+}): string {
+  const topFailure = input.latestFailures[0];
+  return [
+    `Diagnostic ID: ${input.diagnosticId}`,
+    `Bundle: ${input.bundlePath}`,
+    `Latest failure: ${topFailure ? `${topFailure.span} - ${topFailure.message}` : "none found"}`,
+    `Providers captured: ${input.providerCount}`,
+  ].join("\n");
+}
+
+export const DiagnosticsServiceLive = Layer.effect(
+  DiagnosticsService,
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const paths = yield* AppPaths;
+    const providerService = yield* ProviderService;
+
+    const exportBundle = () =>
+      Effect.gen(function* () {
+        const createdAt = new Date();
+        const diagnosticId = `diag_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+        const bundleDir = join(paths.userData, "diagnostics", diagnosticId);
+        yield* Effect.try(() => mkdirSync(bundleDir, { recursive: true }));
+
+        const recentErrorRows = yield* sql<RecentErrorRow>`
+            SELECT
+              m.id AS message_id,
+              m.session_id,
+              s.chat_id,
+              s.project_id,
+              s.provider_id,
+              s.model,
+              m.kind,
+              m.content_json,
+              m.created_at
+            FROM messages m
+            INNER JOIN sessions s ON s.id = m.session_id
+            WHERE m.kind = 'error'
+            ORDER BY m.created_at DESC
+            LIMIT ${MAX_RECENT_ERRORS}
+          `;
+
+        const providers = yield* providerService
+          .availability()
+          .pipe(Effect.orElseSucceed(() => []));
+
+        const latestFailures = recentErrorRows.map((row) => ({
+          traceId: null,
+          span: `message.${row.kind}`,
+          message: readErrorMessage(row.content_json),
+          chatId: row.chat_id,
+          sessionId: row.session_id,
+          providerId: row.provider_id,
+          model: row.model,
+          occurredAt: row.created_at,
+        }));
+
+        const commonFailureMap = new Map<
+          string,
+          { span: string; count: number; errorTag: string }
+        >();
+        for (const failure of latestFailures) {
+          const key = `${failure.span}:${failure.message}`;
+          const existing = commonFailureMap.get(key);
+          commonFailureMap.set(key, {
+            span: failure.span,
+            count: (existing?.count ?? 0) + 1,
+            errorTag: failure.message,
+          });
+        }
+
+        const traceSummary = {
+          latestFailures,
+          slowestSpans: [],
+          commonFailures: [...commonFailureMap.values()].sort(
+            (left, right) => right.count - left.count,
+          ),
+        };
+        const recentErrors = {
+          errors: latestFailures,
+        };
+        const environment = {
+          app: "memoize",
+          version: packageJson.version,
+          createdAt: createdAt.toISOString(),
+          platform: platform(),
+          arch: arch(),
+          osRelease: release(),
+          node: process.version,
+        };
+        const providerStatus = {
+          providers: providers.map(summarizeProvider),
+        };
+        const sessionEvents = yield* Effect.try(() => ({
+          files: listSessionEventFiles(paths.userData).map(
+            redactSessionEventFile,
+          ),
+        }));
+        const included: BundleArtifactName[] = [
+          "manifest",
+          "trace-summary",
+          "recent-errors",
+          "environment",
+          "provider-status",
+          "redacted-session-events",
+        ];
+        const manifest = {
+          app: "memoize",
+          version: packageJson.version,
+          createdAt: createdAt.toISOString(),
+          platform: `${platform()}-${arch()}`,
+          diagnosticId,
+          included,
+          redaction: {
+            default:
+              "text fields are summarized with length and short previews",
+            rawPromptsIncluded: false,
+            rawTranscriptsIncluded: false,
+          },
+        };
+
+        yield* Effect.try(() => {
+          writeJson(join(bundleDir, "manifest.json"), manifest);
+          writeJson(join(bundleDir, "trace-summary.json"), traceSummary);
+          writeJson(join(bundleDir, "recent-errors.json"), recentErrors);
+          writeJson(join(bundleDir, "environment.json"), environment);
+          writeJson(join(bundleDir, "provider-status.json"), providerStatus);
+          writeJson(
+            join(bundleDir, "session-events-redacted.json"),
+            sessionEvents,
+          );
+        });
+
+        const bundlePath = join(
+          paths.userData,
+          "diagnostics",
+          `memoize-diagnostics-${safeIsoForFile(createdAt)}-${diagnosticId}.json`,
+        );
+        const bundle = {
+          manifest,
+          artifacts: {
+            "trace-summary": traceSummary,
+            "recent-errors": recentErrors,
+            environment,
+            "provider-status": providerStatus,
+            "redacted-session-events": sessionEvents,
+          },
+        };
+        yield* Effect.try(() => {
+          writeJson(bundlePath, bundle);
+          copyFileSync(bundlePath, join(bundleDir, basename(bundlePath)));
+        });
+
+        const summary = buildSummary({
+          diagnosticId,
+          bundlePath,
+          latestFailures,
+          providerCount: providers.length,
+        });
+        const agentPrompt = [
+          `A user exported diagnostics for memoize issue ${diagnosticId}.`,
+          `Inspect .context/diagnostics/${diagnosticId}.`,
+          "Start with REPORT.md, then use trace-summary.json and the raw bundle files.",
+          "Find the root cause and propose or implement a fix.",
+          "Do not include sensitive user content in the final summary.",
+        ].join("\n");
+
+        return DiagnosticsExportResult.make({
+          diagnosticId,
+          createdAt,
+          bundlePath,
+          summary,
+          agentPrompt,
+          included,
+        });
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new DiagnosticsExportError({
+              reason:
+                cause instanceof Error
+                  ? cause.message
+                  : "Failed to export diagnostics.",
+            }),
+        ),
+      );
+
+    return { exportBundle } as const;
+  }),
+);

--- a/apps/server/src/diagnostics/services/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/services/diagnostics-service.ts
@@ -1,0 +1,17 @@
+import { Context, type Effect } from "effect";
+
+import type {
+  DiagnosticsExportError,
+  DiagnosticsExportResult,
+} from "@memoize/wire";
+
+export interface DiagnosticsServiceShape {
+  readonly exportBundle: () => Effect.Effect<
+    DiagnosticsExportResult,
+    DiagnosticsExportError
+  >;
+}
+
+export class DiagnosticsService extends Context.Tag(
+  "memoize/DiagnosticsService",
+)<DiagnosticsService, DiagnosticsServiceShape>() {}

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -3,6 +3,7 @@ import { Layer } from "effect";
 import { AttachmentHandlersLayer } from "./attachment/handlers.ts";
 import { CodeIndexHandlersLayer } from "./code-index/handlers.ts";
 import { ConfigStoreHandlersLayer } from "./config-store/handlers.ts";
+import { DiagnosticsHandlersLayer } from "./diagnostics/handlers.ts";
 import { FsHandlersLayer } from "./fs/handlers.ts";
 import { GitHandlersLayer } from "./git/handlers.ts";
 import { PingHandlersLayer } from "./ping/handlers.ts";
@@ -36,4 +37,5 @@ export const HandlersLayer = Layer.mergeAll(
   CodeIndexHandlersLayer,
   PokemonHandlersLayer,
   UsageHandlersLayer,
+  DiagnosticsHandlersLayer,
 );

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -8,6 +8,7 @@ import { AppPaths } from "./app-paths.ts";
 import { AttachmentServiceLive } from "./attachment/layers/attachment-service.ts";
 import { IndexRegistryLive } from "./code-index/layers/index-registry.ts";
 import { ConfigStoreServiceLive } from "./config-store/layers/config-store-service.ts";
+import { DiagnosticsServiceLive } from "./diagnostics/layers/diagnostics-service.ts";
 import { FsServiceLive } from "./fs/layers/fs-service.ts";
 import { GitServiceLive } from "./git/layers/git-service.ts";
 import { HandlersLayer } from "./handlers.ts";
@@ -235,6 +236,12 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(NdjsonLoggerLayer),
   );
 
+  const DiagnosticsLayer = DiagnosticsServiceLive.pipe(
+    Layer.provide(MigratedSqlite),
+    Layer.provide(AppPathsLayer),
+    Layer.provide(ProviderLayer),
+  );
+
   // SkillBridge surfaces the user's per-provider skill library to the
   // composer's slash popover. Discovery walks disk; the bridge caches per
   // (provider, projectCwd) and re-emits on watcher fire so editing a
@@ -253,27 +260,32 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     NodeContext.layer,
   );
 
-  const Handlers = HandlersLayer.pipe(
-    Layer.provide(WorkspaceLayer),
-    Layer.provide(PtyLayer),
-    Layer.provide(GitLayer),
-    Layer.provide(WorktreeLayer),
-    Layer.provide(RepositorySettingsLayer),
-    Layer.provide(PokemonLayer),
-    Layer.provide(ConfigStoreLayer),
-    Layer.provide(FsLayer),
-    Layer.provide(FileSearchLayer),
-    Layer.provide(ProjectScaffoldLayer),
-    Layer.provide(ProviderLayer),
-    Layer.provide(MessageStoreLayer),
-    Layer.provide(PermissionLayer),
-    Layer.provide(AttachmentLayer),
-    Layer.provide(BrowserBridgeLayer),
+  const HandlerDomainLayer = Layer.mergeAll(
+    WorkspaceLayer,
+    PtyLayer,
+    GitLayer,
+    WorktreeLayer,
+    RepositorySettingsLayer,
+    PokemonLayer,
+    ConfigStoreLayer,
+    FsLayer,
+    FileSearchLayer,
+    ProjectScaffoldLayer,
+    ProviderLayer,
+    MessageStoreLayer,
+    PermissionLayer,
+    AttachmentLayer,
+    BrowserBridgeLayer,
     // browser.* credential RPCs read/write the keychain directly.
-    Layer.provide(CredentialsServiceLive),
-    Layer.provide(SkillBridgeLayer),
-    Layer.provide(IndexLayer),
-    Layer.provide(FolderPickerLayer),
+    CredentialsServiceLive,
+    SkillBridgeLayer,
+    IndexLayer,
+    DiagnosticsLayer,
+    FolderPickerLayer,
+  );
+
+  const Handlers = HandlersLayer.pipe(
+    Layer.provide(HandlerDomainLayer),
     // `agent.opencodeInventory` calls `resolveCliPath("opencode")` directly
     // (it spins up a short-lived `opencode serve` to read the user's
     // connected providers + agents). That uses `CommandExecutor` from

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",
     "test": "turbo run test",
+    "diagnostics:inspect": "node scripts/diagnostics-inspect.mjs",
     "rebuild:pty": "cd apps/desktop && electron-rebuild -f -w node-pty",
     "dist:mac": "bun run build:desktop && cd apps/desktop && bun run dist:mac",
     "dist:mac:unsigned": "bun run build:desktop && cd apps/desktop && bun run dist:mac:unsigned"

--- a/packages/wire/src/diagnostics.ts
+++ b/packages/wire/src/diagnostics.ts
@@ -1,0 +1,35 @@
+import { Rpc } from "@effect/rpc";
+import { Schema } from "effect";
+
+const DiagnosticArtifactName = Schema.Literal(
+  "manifest",
+  "trace-summary",
+  "recent-errors",
+  "environment",
+  "provider-status",
+  "redacted-session-events",
+);
+
+export class DiagnosticsExportResult extends Schema.Class<DiagnosticsExportResult>(
+  "DiagnosticsExportResult",
+)({
+  diagnosticId: Schema.String,
+  createdAt: Schema.DateFromString,
+  bundlePath: Schema.String,
+  summary: Schema.String,
+  agentPrompt: Schema.String,
+  included: Schema.Array(DiagnosticArtifactName),
+}) {}
+
+export class DiagnosticsExportError extends Schema.TaggedError<DiagnosticsExportError>()(
+  "DiagnosticsExportError",
+  {
+    reason: Schema.String,
+  },
+) {}
+
+export const DiagnosticsExportRpc = Rpc.make("diagnostics.export", {
+  payload: Schema.Struct({}),
+  success: DiagnosticsExportResult,
+  error: DiagnosticsExportError,
+});

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -3,6 +3,7 @@ export * from "./attachment.ts";
 export * from "./browser.ts";
 export * from "./code-index.ts";
 export * from "./composer.ts";
+export * from "./diagnostics.ts";
 export * from "./fs.ts";
 export * from "./git.ts";
 export * from "./ids.ts";

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -38,6 +38,7 @@ import {
   FsWriteExternalFileRpc,
   FsWriteFileRpc,
 } from "./fs.ts";
+import { DiagnosticsExportRpc } from "./diagnostics.ts";
 import {
   GitBranchesRpc,
   GitChangesRpc,
@@ -296,6 +297,7 @@ export const MemoizeRpcs = RpcGroup.make(
   SettingsStreamRpc,
   SettingsMigrateLocalStorageRpc,
   UsageReportRpc,
+  DiagnosticsExportRpc,
   KeybindingsGetRpc,
   KeybindingsReplaceRpc,
   KeybindingsStreamRpc,

--- a/scripts/diagnostics-inspect.mjs
+++ b/scripts/diagnostics-inspect.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+function usage() {
+  return "Usage: bun run diagnostics:inspect <memoize-diagnostics.json>";
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function getDiagnosticId(bundle, inputPath) {
+  const id = bundle?.manifest?.diagnosticId;
+  if (typeof id === "string" && id.length > 0) return id;
+  return basename(inputPath).replace(/[^A-Za-z0-9._-]+/g, "-");
+}
+
+function likelyIssue(traceSummary) {
+  const first = traceSummary?.latestFailures?.[0];
+  if (!first) {
+    return "No recent persisted error messages were found in this diagnostics bundle.";
+  }
+  const span = typeof first.span === "string" ? first.span : "unknown span";
+  const message =
+    typeof first.message === "string"
+      ? first.message
+      : "No error message was captured.";
+  return `${span}: ${message}`;
+}
+
+function relevantHints(traceSummary) {
+  const failures = Array.isArray(traceSummary?.latestFailures)
+    ? traceSummary.latestFailures
+    : [];
+  const providerIds = new Set(
+    failures
+      .map((failure) => failure?.providerId)
+      .filter(
+        (providerId) => typeof providerId === "string" && providerId.length > 0,
+      ),
+  );
+  const spans = new Set(
+    failures
+      .map((failure) => failure?.span)
+      .filter((span) => typeof span === "string" && span.length > 0),
+  );
+
+  const hints = new Set([
+    "apps/server/src/provider/",
+    "apps/server/src/provider/layers/message-store.ts",
+    "apps/renderer/src/components/",
+  ]);
+  for (const providerId of providerIds) {
+    hints.add(`apps/server/src/provider/drivers/${providerId}.ts`);
+  }
+  if ([...spans].some((span) => span.includes("message"))) {
+    hints.add("packages/wire/src/session.ts");
+  }
+  return [...hints];
+}
+
+function buildReport({ diagnosticId, bundlePath, bundle }) {
+  const traceSummary = bundle.artifacts?.["trace-summary"] ?? {};
+  const recentErrors = bundle.artifacts?.["recent-errors"] ?? {};
+  const providerStatus = bundle.artifacts?.["provider-status"] ?? {};
+  const environment = bundle.artifacts?.environment ?? {};
+  const latestFailures = Array.isArray(traceSummary.latestFailures)
+    ? traceSummary.latestFailures
+    : [];
+  const firstTraceId =
+    latestFailures.find((failure) => failure?.traceId)?.traceId ??
+    "not captured";
+
+  const lines = [
+    "# Diagnostic Report",
+    "",
+    `Diagnostic ID: ${diagnosticId}`,
+    `Source bundle: ${bundlePath}`,
+    "",
+    "## Likely Issue",
+    "",
+    likelyIssue(traceSummary),
+    "",
+    "## Relevant Trace",
+    "",
+    String(firstTraceId),
+    "",
+    "## Recent Failures",
+    "",
+  ];
+
+  if (latestFailures.length === 0) {
+    lines.push("No recent failures found.", "");
+  } else {
+    for (const failure of latestFailures.slice(0, 8)) {
+      lines.push(
+        `- ${failure.occurredAt ?? "unknown time"} · ${failure.span ?? "unknown span"} · ${failure.message ?? "no message"} · session=${failure.sessionId ?? "unknown"}`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## Provider Status", "");
+  const providers = Array.isArray(providerStatus.providers)
+    ? providerStatus.providers
+    : [];
+  if (providers.length === 0) {
+    lines.push("No provider status captured.", "");
+  } else {
+    for (const provider of providers) {
+      lines.push(
+        `- ${provider.providerId}: status=${provider.status ?? "unknown"}, cliInstalled=${provider.cliInstalled}, auth=${provider.authStatus ?? "unknown"}, version=${provider.cliVersion ?? "unknown"}`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## Environment", "");
+  lines.push(
+    `- app=${environment.app ?? "unknown"} version=${environment.version ?? "unknown"} platform=${environment.platform ?? "unknown"} arch=${environment.arch ?? "unknown"} node=${environment.node ?? "unknown"}`,
+    "",
+  );
+
+  lines.push("## Relevant Files To Inspect", "");
+  for (const hint of relevantHints(traceSummary)) {
+    lines.push(`- ${hint}`);
+  }
+  lines.push(
+    "",
+    "## Agent Prompt",
+    "",
+    `Debug this user issue using .context/diagnostics/${diagnosticId}/REPORT.md and the raw bundle files.`,
+    "Find the root cause and propose or implement a fix. Do not include sensitive user content in the final summary.",
+    "",
+  );
+
+  if (Array.isArray(recentErrors.errors) && recentErrors.errors.length > 0) {
+    lines.push("## Raw Error Summary", "");
+    for (const error of recentErrors.errors.slice(0, 12)) {
+      lines.push(`- ${error.message ?? "no message"}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+const input = process.argv[2];
+if (!input) {
+  console.error(usage());
+  process.exit(2);
+}
+
+const bundlePath = resolve(input);
+const bundle = readJson(bundlePath);
+const diagnosticId = getDiagnosticId(bundle, bundlePath);
+const outputDir = resolve(".context", "diagnostics", diagnosticId);
+mkdirSync(outputDir, { recursive: true });
+
+writeJson(join(outputDir, "manifest.json"), bundle.manifest ?? {});
+for (const [name, artifact] of Object.entries(bundle.artifacts ?? {})) {
+  writeJson(join(outputDir, `${name}.json`), artifact);
+}
+writeJson(join(outputDir, basename(bundlePath)), bundle);
+
+const report = buildReport({ diagnosticId, bundlePath, bundle });
+writeFileSync(join(outputDir, "REPORT.md"), report, "utf8");
+
+console.log(`Diagnostic ID: ${diagnosticId}`);
+console.log(`Output: ${outputDir}`);
+console.log("");
+console.log(likelyIssue(bundle.artifacts?.["trace-summary"] ?? {}));


### PR DESCRIPTION
Adds a redacted diagnostics export flow so users can generate a local support bundle from Settings or Help -> Export Diagnostics.
The bundle captures manifest, recent errors, provider status, environment data, and redacted session event previews, plus copyable summary and agent prompt text.
Adds `bun run diagnostics:inspect` to unpack a bundle into `.context/diagnostics/<id>/REPORT.md` for agent-driven debugging.
Validated with wire, server, renderer, and desktop type checks plus a diagnostics inspector smoke test.
