### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0]
+
+### Added
+- Live file tree updates now track disk changes and support create/delete flows with confirmation dialogs. (#204)
+- New worktrees can auto-symlink nested environment files for monorepos and Cloudflare projects. (#201)
+
 ### Changed
-- memoize Alpha is now Zuse Alpha. The app now uses the Zuse bundle identifier (`app.zuse.desktop`), GitHub release feed, package names, worktree paths, protocol links, keychain service, and SQLite paths. Existing data and legacy `memoize://` links remain readable where possible, but this is a full technical identity move to Zuse rather than an updater-compatible in-place rename.
+- memoize Alpha is now Zuse Alpha. The app now uses the Zuse bundle identifier (`app.zuse.desktop`), GitHub release feed, package names, worktree paths, protocol links, keychain service, and SQLite paths. Existing data and legacy `memoize://` links remain readable where possible, but this is a full technical identity move to Zuse rather than an updater-compatible in-place rename. (#207)
+- Removed remaining legacy source references from user-facing copy and project metadata. (#198)
+- Loading states now use animated gradient shimmer polish. (#200)
+
+### Fixed
+- Force-archiving can remove a chat even when its worktree is dirty. (#197)
+- Plan feedback routing now reaches the correct agent turn. (#205)
+- Claude interruptions now render as an interrupted badge instead of a hard error. (#202)
 
 ## [0.7.1]
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,11 +1,28 @@
 [
   {
-    "version": "Unreleased",
+    "version": "0.8.0",
     "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Live file tree updates now track disk changes and support create/delete flows with confirmation dialogs. (#204)",
+          "New worktrees can auto-symlink nested environment files for monorepos and Cloudflare projects. (#201)"
+        ]
+      },
       {
         "title": "Changed",
         "items": [
-          "memoize Alpha is now Zuse Alpha. The app now uses the Zuse bundle identifier (`app.zuse.desktop`), GitHub release feed, package names, worktree paths, protocol links, keychain service, and SQLite paths. Existing data and legacy `memoize://` links remain readable where possible, but this is a full technical identity move to Zuse rather than an updater-compatible in-place rename."
+          "memoize Alpha is now Zuse Alpha. The app now uses the Zuse bundle identifier (`app.zuse.desktop`), GitHub release feed, package names, worktree paths, protocol links, keychain service, and SQLite paths. Existing data and legacy `memoize://` links remain readable where possible, but this is a full technical identity move to Zuse rather than an updater-compatible in-place rename. (#207)",
+          "Removed remaining legacy source references from user-facing copy and project metadata. (#198)",
+          "Loading states now use animated gradient shimmer polish. (#200)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Force-archiving can remove a chat even when its worktree is dirty. (#197)",
+          "Plan feedback routing now reaches the correct agent turn. (#205)",
+          "Claude interruptions now render as an interrupted badge instead of a hard error. (#202)"
         ]
       }
     ]

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- bump Zuse Alpha desktop version to 0.8.0
- add the 0.8.0 changelog entry for the Zuse rebrand and recent app fixes
- regenerate the website changelog JSON

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.8.0 after this PR lands.