### PR TITLE
Fix sidebar spinner dropping for Codex/Grok chats on switch

### DIFF
--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -232,6 +232,16 @@ const handoffReleaseTimers = new Map<
 >();
 
 const stopLiveFiber = async () => {
+  // Clear the live marker FIRST, before any interrupt yields the event loop.
+  // The status fiber's `resetOnStreamEnd` + stale-status-event handler both
+  // guard on `liveSessionId === sessionId`. If a yield happens while this
+  // still points at the outgoing session — e.g. the awaited `goalFiber`
+  // interrupt below, which only exists for Codex/Grok — those handlers drain
+  // and wrongly clobber `runningBySession[sessionId]` to false, dropping the
+  // sidebar spinner for a backgrounded-but-still-running Codex/Grok chat the
+  // moment you switch away. Claude has no `goalFiber` and so never yielded
+  // here before this assignment, which is why the bug was Codex/Grok-only.
+  liveSessionId = null;
   const tasks: Array<Promise<unknown>> = [];
   if (liveFiber !== null) {
     tasks.push(Effect.runPromise(Fiber.interrupt(liveFiber)));
@@ -249,7 +259,6 @@ const stopLiveFiber = async () => {
     await Effect.runPromise(Fiber.interrupt(goalFiber));
     goalFiber = null;
   }
-  liveSessionId = null;
   await Promise.all(tasks);
   // We intentionally do NOT clear the prior session's `runningBySession`
   // entry here. The sidebar-root `useSessionRunningSubscriptions` hook


### PR DESCRIPTION
## Problem

When a Codex agent is running and you **switch to a different chat**, the running chat's **sidebar row loses its spinner and falls back to the plain branch icon**, even though the agent is still working. The chat you're actively viewing stays correct — only backgrounded rows lose it, and only for Codex (and, by the same mechanism, Grok). It is **not** goal-mode-specific.

## Root cause

`stopLiveFiber()` in `apps/renderer/src/store/messages.ts` cleared `liveSessionId = null` *after* the inline `await Effect.runPromise(Fiber.interrupt(goalFiber))`. The status fiber's interrupt is queued into `tasks` (not awaited yet), so that `goalFiber` await is the function's first event-loop yield — and `goalFiber` only exists for Codex/Grok sessions.

During that yield, `liveSessionId` still equaled the outgoing session, so the interrupting status fiber's `resetOnStreamEnd` and the stale-status-event handler — both guarded by `if (liveSessionId !== sessionId) return;` — *passed* and set `runningBySession[sessionId] = false`. The sidebar's `runningAttention` then read idle → rendered `BranchIcon` instead of the spinner. The sidebar-root `useSessionRunningSubscriptions` never restored `true` because Codex was mid-turn (no new `running` transition until the turn ends).

**Why Codex/Grok only, and why it isn't goal-mode-specific:** `goalFiber` is the only awaited interrupt in `stopLiveFiber`. Claude has no `goalFiber`, so `liveSessionId = null` ran synchronously before any yield → guards held → no clobber. And `goalFiber` is forked for *every* Codex/Grok session regardless of whether a goal is set, so it hit ordinary chats too.

This wasn't introduced by recent spinner work — the clobber window has been latent since Codex/Grok goal plumbing started forking `goalFiber` for all such sessions.

## Fix

Hoist `liveSessionId = null;` to the **top** of `stopLiveFiber()`, before any interrupt can yield. Once teardown begins the session is no longer "live," so the guards treat it as a background session and leave its running flag untouched (the sidebar-root subscription remains the source of truth). One-line move plus an explanatory comment.

## Verification

- `bun run check-types` passes (renderer).
- **Manual:** start a Codex chat, send a prompt so it's running, switch to another chat in the same project — the Codex row keeps its spinner for the whole turn and only clears when the turn finishes. Switching back and forth mid-turn stays stable.
- **Regressions:** Claude chats still keep their spinner across switches; a finished Codex turn still settles to idle in the sidebar; the active chat's in-chat working indicator is unaffected. Worth a spot-check on Grok.