### PR TITLE
Fix messages not appearing until chat re-open (hydrate race)

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -18,7 +18,7 @@ import type {
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { useRegisterPane } from "../store/pane-focus.ts";
-import { useMessagesStore } from "../store/messages.ts";
+import { teardownLiveStreams, useMessagesStore } from "../store/messages.ts";
 import { usePermissionsStore } from "../store/permissions.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSkillsStore } from "../store/skills.ts";
@@ -107,6 +107,15 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   useEffect(() => {
     void hydrate(sessionId);
     void hydrateSkills(sessionId);
+    // Tear down the live message fibers on unmount / session change. Without
+    // this, the previous session's stream lingered until the next hydrate
+    // tore it down, and a hydrate caught mid-await could install orphaned
+    // fibers after the view was gone. `teardownLiveStreams` bumps the hydrate
+    // epoch so any in-flight hydrate bails. The next hydrate re-subscribes;
+    // `messagesBySession` is preserved, so there's no empty-state flash.
+    return () => {
+      void teardownLiveStreams();
+    };
   }, [sessionId, hydrate, hydrateSkills]);
 
   // Track whether the user is near the bottom of the timeline; if they

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -3,7 +3,9 @@ import { create } from "zustand";
 
 import {
   ComposerInput,
-  type Message,
+  Message,
+  MessageId,
+  type MessageContent,
   type ProviderId,
   type QueuedMessage,
   type SessionStatus,
@@ -220,6 +222,22 @@ let statusFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 let queueFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 let goalFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
 let liveSessionId: SessionId | null = null;
+// Monotonic token guarding `hydrate` against re-entrancy. `hydrate` mutates the
+// module-global fibers + `liveSessionId` across two `await` points, so two
+// overlapping calls (rapid tab switches, or React's mount→cleanup→mount) used
+// to interleave and leave `liveFiber`/`liveSessionId` pointing at a session
+// other than the one on screen — the active session then had no live stream, so
+// freshly-sent / streamed messages never landed until a re-open re-ran the
+// backfill. Each call captures the epoch on entry and bails after every await
+// once a newer call (or `teardownLiveStreams`) has superseded it, so only the
+// latest (rendered) session ever installs fibers.
+let hydrateEpoch = 0;
+// Message ids we minted optimistically in `send()`. When the server echoes the
+// same row back over the live stream (same id, because the renderer passes the
+// id as `clientMessageId`), we replace the optimistic row in place with the
+// canonical server message instead of skipping it, so server-side fixups
+// (stripped `pending-` attachments, server `createdAt`) win.
+const optimisticIds = new Set<MessageId>();
 const handoffRunningSessions = new Set<SessionId>();
 const lastStatusBySession = new Map<SessionId, SessionStatus>();
 const statusWaiters = new Map<
@@ -266,6 +284,17 @@ const stopLiveFiber = async () => {
   // live truth even after switching away. Wiping it would make the
   // previous session's busy indicator disappear in the sidebar until
   // the next transition event.
+};
+
+/**
+ * Tear down the single live message stream — called from the `ChatView`
+ * effect cleanup on unmount / session change. Bumps `hydrateEpoch` first so a
+ * `hydrate` still awaiting its RPC client can't resume and fork orphaned
+ * fibers after the view is gone, then interrupts the live fibers.
+ */
+export const teardownLiveStreams = async (): Promise<void> => {
+  hydrateEpoch++;
+  await stopLiveFiber();
 };
 
 /**
@@ -338,8 +367,11 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
   goalBySession: {},
   hydrate: async (sessionId) => {
     if (liveSessionId === sessionId && liveFiber !== null) return;
+    const myEpoch = ++hydrateEpoch;
     await stopLiveFiber();
-    liveSessionId = sessionId;
+    // A newer hydrate (or a teardown) started while we were tearing down — let
+    // it win rather than installing fibers for a session no longer on screen.
+    if (myEpoch !== hydrateEpoch) return;
     set((s) => ({
       // Preserve any pre-seeded messages (e.g. the initial user message
       // that `chats.create` stuffed in optimistically) so the chat view
@@ -354,11 +386,34 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     }));
     try {
       const client = await getMessagesRpcClient();
+      // Superseded while awaiting the client — don't install stale fibers.
+      if (myEpoch !== hydrateEpoch) return;
+      // Set the live target + fork the fibers together (winner-only,
+      // synchronously) so `liveSessionId` and the forked subscriptions can
+      // never disagree. The `resetOnStreamEnd` / status guards below read
+      // `liveSessionId`, so it must be correct before the fibers run.
+      liveSessionId = sessionId;
       liveFiber = Effect.runFork(
         Stream.runForEach(client.messages.stream({ sessionId }), (message) =>
           Effect.sync(() => {
             set((s) => {
               const current = s.messagesBySession[sessionId] ?? [];
+              // The server echo of a message we inserted optimistically (same
+              // id, passed as `clientMessageId` on send) — swap our placeholder
+              // row for the canonical server row in place rather than skipping,
+              // so server fixups (stripped `pending-` attachments, server
+              // `createdAt`) take effect without a duplicate.
+              if (optimisticIds.has(message.id)) {
+                optimisticIds.delete(message.id);
+                return {
+                  messagesBySession: {
+                    ...s.messagesBySession,
+                    [sessionId]: current.map((m) =>
+                      m.id === message.id ? message : m,
+                    ),
+                  },
+                };
+              }
               if (current.some((m) => m.id === message.id)) return s;
               const next = [...current, message];
               // Auto-untoggle plan mode when the SDK runs ExitPlanMode
@@ -545,11 +600,55 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     // so it should show the running indicator like any normal send.
     const skipOptimisticRunning =
       opts?.asGoal === true && lookupSessionProvider(sessionId) === "codex";
+    // Optimistic message insert — show the user's turn instantly instead of
+    // waiting for the server echo on the live stream. We mint the id here and
+    // pass it as `clientMessageId` so the server persists the row under the
+    // same id; the echo then dedupes against this row (and upgrades it to the
+    // canonical server version in place — see the stream handler).
+    const asGoal = opts?.asGoal === true;
+    const optimisticContent: MessageContent =
+      typeof input === "string"
+        ? { _tag: "user", text: input, goal: asGoal }
+        : (() => {
+            const annotations = input.annotations ?? [];
+            const hasRich =
+              input.attachments.length > 0 ||
+              input.fileRefs.length > 0 ||
+              input.skillRefs.length > 0 ||
+              annotations.length > 0;
+            return hasRich
+              ? {
+                  _tag: "user_rich",
+                  text: input.text,
+                  attachments: input.attachments,
+                  fileRefs: input.fileRefs,
+                  skillRefs: input.skillRefs,
+                  annotations,
+                  goal: asGoal,
+                }
+              : { _tag: "user", text: input.text, goal: asGoal };
+          })();
+    const messageId = MessageId.make(crypto.randomUUID());
+    const optimisticMessage = Message.make({
+      id: messageId,
+      sessionId,
+      role: "user",
+      content: optimisticContent,
+      createdAt: new Date(),
+    });
+    optimisticIds.add(messageId);
     set((s) => ({
       errorBySession: { ...s.errorBySession, [sessionId]: null },
       runningBySession: skipOptimisticRunning
         ? s.runningBySession
         : { ...s.runningBySession, [sessionId]: true },
+      messagesBySession: {
+        ...s.messagesBySession,
+        [sessionId]: [
+          ...(s.messagesBySession[sessionId] ?? []),
+          optimisticMessage,
+        ],
+      },
     }));
     try {
       const client = await getMessagesRpcClient();
@@ -564,12 +663,14 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
               sessionId,
               text: input,
               asGoal: opts?.asGoal,
+              clientMessageId: messageId,
               ...(modelOptions !== null ? { modelOptions } : {}),
             }
           : {
               sessionId,
               input,
               asGoal: opts?.asGoal,
+              clientMessageId: messageId,
               ...(modelOptions !== null ? { modelOptions } : {}),
             };
       await Effect.runPromise(client.messages.send(payload));
@@ -578,12 +679,20 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
       // Reset the optimistic running flag — otherwise a failed send leaves
       // the composer stuck on Interrupt with no path back to Send (the
       // status stream won't emit "idle" if the server never saw the turn).
+      // Also drop the optimistic message row so a failed send leaves no ghost.
+      optimisticIds.delete(messageId);
       set((s) => ({
         errorBySession: {
           ...s.errorBySession,
           [sessionId]: classifyError(err, lookupSessionProvider(sessionId)),
         },
         runningBySession: { ...s.runningBySession, [sessionId]: false },
+        messagesBySession: {
+          ...s.messagesBySession,
+          [sessionId]: (s.messagesBySession[sessionId] ?? []).filter(
+            (m) => m.id !== messageId,
+          ),
+        },
       }));
     }
   },

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -366,7 +366,7 @@ const SessionGoalStream = MemoizeRpcs.toLayerHandler(
 
 const MessagesSend = MemoizeRpcs.toLayerHandler(
   "messages.send",
-  ({ sessionId, text, input, asGoal }) => {
+  ({ sessionId, text, input, asGoal, clientMessageId }) => {
     console.log(
       `[rpc.messages.send] sessionId=${sessionId} hasInput=${input !== undefined} attachments=${
         input?.attachments?.length ?? 0
@@ -388,6 +388,7 @@ const MessagesSend = MemoizeRpcs.toLayerHandler(
         input?.skillRefs,
         input?.annotations,
         asGoal,
+        clientMessageId,
       ),
     );
   },

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -879,9 +879,14 @@ export const MessageStoreLive = Layer.scoped(
     const persistMessage = (
       sessionId: SessionId,
       content: MessageContent,
+      idOverride?: MessageId,
     ): Effect.Effect<Message> =>
       Effect.gen(function* () {
-        const id = MessageId.make(crypto.randomUUID());
+        // `idOverride` is the renderer-minted `clientMessageId` for an
+        // optimistic user message — reuse it so the live-stream echo carries
+        // the same id the renderer already inserted. All other persists
+        // (assistant/tool/error/goal) omit it and get a fresh server id.
+        const id = idOverride ?? MessageId.make(crypto.randomUUID());
         const role = roleForContent(content);
         const now = new Date();
         const nowIso = now.toISOString();
@@ -2692,6 +2697,7 @@ export const MessageStoreLive = Layer.scoped(
       skillRefs?: ReadonlyArray<SkillRef>,
       annotations?: ReadonlyArray<CodeAnnotation>,
       asGoal?: boolean,
+      clientMessageId?: MessageId,
     ): Effect.Effect<boolean, SessionNotFoundError> =>
       Effect.gen(function* () {
         const session = yield* lookupSession(sessionId);
@@ -2742,7 +2748,11 @@ export const MessageStoreLive = Layer.scoped(
           annotationList.length > 0
             ? `${serializeAnnotations(annotationList)}\n\n${text}`.trim()
             : text;
-        const persisted = yield* persistMessage(sessionId, content);
+        const persisted = yield* persistMessage(
+          sessionId,
+          content,
+          clientMessageId,
+        );
         // Pin the attachments so the GC sweep treats them as referenced —
         // a separate row per (message, attachment) keeps the existing
         // GC join intact.
@@ -2934,6 +2944,7 @@ export const MessageStoreLive = Layer.scoped(
       skillRefs,
       annotations,
       asGoal,
+      clientMessageId,
     ) =>
       Effect.gen(function* () {
         yield* submitUserMessage(
@@ -2944,6 +2955,7 @@ export const MessageStoreLive = Layer.scoped(
           skillRefs,
           annotations,
           asGoal,
+          clientMessageId,
         );
       });
 

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -19,6 +19,7 @@ import type {
   FolderId,
   GoalUnsupportedError,
   Message,
+  MessageId,
   PermissionMode,
   ProviderId,
   QueueState,
@@ -352,6 +353,7 @@ export interface MessageStoreShape {
     skillRefs?: ReadonlyArray<SkillRef>,
     annotations?: ReadonlyArray<CodeAnnotation>,
     asGoal?: boolean,
+    clientMessageId?: MessageId,
   ) => Effect.Effect<void, SessionNotFoundError>;
 
   readonly interruptSession: (

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -18,7 +18,12 @@ import type {
   StartSessionInput,
   WorktreeId,
 } from "@zuse/wire";
-import { ComposerInput, RepositorySettings, Worktree } from "@zuse/wire";
+import {
+  ComposerInput,
+  MessageId,
+  RepositorySettings,
+  Worktree,
+} from "@zuse/wire";
 
 import { NdjsonLogger } from "../src/persistence/ndjson-logger.ts";
 import { Migration0001Initial } from "../src/persistence/migrations/0001_initial.ts";
@@ -604,6 +609,45 @@ describe("MessageStore — chat & session lifecycle", () => {
         _tag: "user",
         text: "hello there",
       });
+    });
+  });
+
+  it("sendMessage persists the user row under a supplied clientMessageId", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const id = initialSession.id;
+      const clientId = MessageId.make(`m_client_${Date.now()}`);
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          s.sendMessage(
+            id,
+            "with a client id",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            clientId,
+          ),
+        ),
+      );
+
+      const messages = await run(
+        Effect.flatMap(store, (s) => s.listMessages(id)),
+      );
+      const user = messages.filter((m) => m.role === "user");
+      // The row the renderer inserted optimistically and the persisted/echoed
+      // row share the id, so the live stream dedupes against it.
+      expect(user.some((m) => m.id === clientId)).toBe(true);
     });
   });
 

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -784,6 +784,12 @@ export const MessagesSendRpc = Rpc.make("messages.send", {
     text: Schema.optional(Schema.String),
     input: Schema.optional(ComposerInput),
     asGoal: Schema.optional(Schema.Boolean),
+    // Optional renderer-minted id for the user message. When present the
+    // server persists the row under this id instead of generating one, so the
+    // renderer can insert the message optimistically and have the live-stream
+    // echo dedupe against it. Omitted by non-interactive callers (queue
+    // flush), which keep server-generated ids.
+    clientMessageId: Schema.optional(MessageId),
   }),
   success: Schema.Void,
   error: SessionNotFoundError,


### PR DESCRIPTION
## Problem

After sending a message it sometimes doesn't render in the chat; switching to another chat and back makes it appear. Streamed assistant messages are intermittently affected too.

**Root cause:** the renderer keeps exactly one live message stream, tracked by module globals (`liveFiber`/`liveSessionId`) that `hydrate()` mutates across **two `await` points** with no mutual exclusion, and the `ChatView` effect had **no cleanup**. Two overlapping `hydrate` calls (rapid tab switches, or React mount→cleanup→mount) interleave and leave the on-screen session wired to the *wrong* fiber — or to *no* fiber while the top guard refuses to repair it. The active session then has no live stream, so echoed/streamed messages land nowhere until navigating away and back re-runs the server backfill. It's self-masking for the user's own message because `send()` did no optimistic insert — the message was only visible via the very echo the race drops.

## Fix

1. **Epoch guard in `hydrate()`** (root cause) — a monotonic `hydrateEpoch` captured on entry; the call bails after every `await` once superseded, and sets `liveSessionId` + forks the subscriptions together (winner-only) so they can never disagree.
2. **ChatView cleanup** — `teardownLiveStreams()` interrupts the live fibers on unmount/session change and **bumps the epoch first**, so a `hydrate` caught mid-`await` can't fork orphaned fibers after the view is gone.
3. **Optimistic send via client-generated id** — `send()` mints the `MessageId`, inserts the user's message instantly, and passes it as `clientMessageId`. The server persists the user row under that id (`persistMessage` `idOverride`), so the live echo shares it: the existing id-dedupe suppresses the echo and the stream handler upgrades the optimistic row to the canonical server row in place. Failed sends drop the optimistic row; queue-flush sends keep server-generated ids.

## Files

- `apps/renderer/src/store/messages.ts` — epoch guard, `teardownLiveStreams`, optimistic insert + in-place echo dedupe + error cleanup
- `apps/renderer/src/components/chat-view.tsx` — effect cleanup
- `packages/wire/src/session.ts` — `clientMessageId` on the send payload
- `apps/server/.../message-store.ts` + `services/message-store.ts` + `handlers.ts` — thread `clientMessageId` to the user-message persist

## Verification

- `bun run check-types` → 9/9 pass
- renderer build → green (`@zuse/server`/`@zuse/wire` are TS-source, type-checked only)
- renderer store tests 3/3; server message-store tests 20/20 (incl. a new test proving `sendMessage` persists the user row under a supplied `clientMessageId`)

**Manual checks still recommended** (real app run): rapid A→B→A then send in A appears immediately; normal send shows instantly with no duplicate; long streaming reply while tabbing lands in the right chat; forced send failure removes the optimistic bubble; Codex/Grok goal send behaves as before.

## Note (out of scope)

`modelOptions` is passed by the renderer's `send()` but isn't in the `MessagesSendRpc` payload schema, so Effect silently strips it on encode — the reasoning-picker selection may not be reaching the server today. Pre-existing; flagging for a separate look.