### PR TITLE
Fix Zuse mac updater identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1]
+
+### Fixed
+- Restored the macOS bundle identifier to `app.memoize.desktop` so existing memoize Alpha installs can accept Zuse Alpha updates in place through Squirrel.Mac. The app name and GitHub release feed stay Zuse, but the updater identity remains stable for compatibility.
+- Legacy memoize keychain credentials are now promoted into the Zuse keychain namespace after first successful fallback read.
+
 ## [0.8.0]
 
 ### Added

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,4 +1,7 @@
-appId: app.zuse.desktop
+# Keep the original bundle id so existing memoize Alpha installs can
+# auto-update in place through Squirrel.Mac. The visible app name and release
+# feed are Zuse, but macOS updater identity must remain stable.
+appId: app.memoize.desktop
 productName: Zuse Alpha
 copyright: © ${author}
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/server/src/persistence/db-path.ts
+++ b/apps/server/src/persistence/db-path.ts
@@ -1,14 +1,18 @@
-import { copyFile, stat } from "node:fs/promises";
+import { copyFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 export const ZUSE_SQLITE_FILENAME = "zuse.sqlite";
 const LEGACY_MEMOIZE_SQLITE_FILENAME = "memoize.sqlite";
+const MIGRATION_STATE_FILENAME = "zuse-migration-state.json";
 
 export const sqliteDbPath = (userData: string): string =>
   join(userData, ZUSE_SQLITE_FILENAME);
 
 export const legacySqliteDbPath = (userData: string): string =>
   join(userData, LEGACY_MEMOIZE_SQLITE_FILENAME);
+
+const migrationStatePath = (userData: string): string =>
+  join(userData, MIGRATION_STATE_FILENAME);
 
 const exists = async (path: string): Promise<boolean> => {
   try {
@@ -29,4 +33,17 @@ export const ensureSqliteRenameCompatibility = async (
   if (!(await exists(legacy))) return;
 
   await copyFile(legacy, current);
+  await writeFile(
+    migrationStatePath(userData),
+    `${JSON.stringify(
+      {
+        kind: "memoize-to-zuse-sqlite-copy",
+        from: LEGACY_MEMOIZE_SQLITE_FILENAME,
+        to: ZUSE_SQLITE_FILENAME,
+        migratedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+  );
 };

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -79,18 +79,25 @@ const tryKeychain = <A>(
       }),
   });
 
+const getPasswordWithLegacyPromotion = async (
+  account: string,
+): Promise<string | null> => {
+  const current = await keytar.getPassword(SERVICE_NAME, account);
+  if (current !== null) return current;
+
+  const legacy = await keytar.getPassword(LEGACY_SERVICE_NAME, account);
+  if (legacy !== null) {
+    await keytar.setPassword(SERVICE_NAME, account, legacy);
+  }
+  return legacy;
+};
+
 export const CredentialsServiceLive = Layer.succeed(
   CredentialsService,
   CredentialsService.of({
     get: (providerId) =>
       tryKeychain(providerId, () =>
-        keytar
-          .getPassword(SERVICE_NAME, accountFor(providerId))
-          .then(
-            (value) =>
-              value ??
-              keytar.getPassword(LEGACY_SERVICE_NAME, accountFor(providerId)),
-          ),
+        getPasswordWithLegacyPromotion(accountFor(providerId)),
       ),
     set: (providerId, apiKey) =>
       tryKeychain(providerId, () =>
@@ -130,16 +137,7 @@ export const CredentialsServiceLive = Layer.succeed(
       ),
     getBrowser: (origin) =>
       tryKeychain("*", () =>
-        keytar
-          .getPassword(SERVICE_NAME, browserAccountFor(origin))
-          .then(
-            (value) =>
-              value ??
-              keytar.getPassword(
-                LEGACY_SERVICE_NAME,
-                browserAccountFor(origin),
-              ),
-          ),
+        getPasswordWithLegacyPromotion(browserAccountFor(origin)),
       ).pipe(Effect.map(parseBrowserCred)),
     removeBrowser: (origin) =>
       tryKeychain("*", async () =>

--- a/apps/server/test/db-path.test.ts
+++ b/apps/server/test/db-path.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fsSync from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as Path from "node:path";
+
+import {
+  ensureSqliteRenameCompatibility,
+  sqliteDbPath,
+} from "../src/persistence/db-path.ts";
+
+describe("ensureSqliteRenameCompatibility", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(Path.join(os.tmpdir(), "zuse-db-path-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("copies memoize.sqlite to zuse.sqlite once and records the migration", async () => {
+    const legacyPath = Path.join(dir, "memoize.sqlite");
+    await fs.writeFile(legacyPath, "legacy-db");
+
+    await ensureSqliteRenameCompatibility(dir);
+
+    expect(await fs.readFile(sqliteDbPath(dir), "utf8")).toBe("legacy-db");
+
+    const state = JSON.parse(
+      await fs.readFile(Path.join(dir, "zuse-migration-state.json"), "utf8"),
+    ) as {
+      kind?: string;
+      from?: string;
+      to?: string;
+      migratedAt?: string;
+    };
+    expect(state.kind).toBe("memoize-to-zuse-sqlite-copy");
+    expect(state.from).toBe("memoize.sqlite");
+    expect(state.to).toBe("zuse.sqlite");
+    expect(typeof state.migratedAt).toBe("string");
+
+    await fs.writeFile(sqliteDbPath(dir), "current-db");
+    await ensureSqliteRenameCompatibility(dir);
+
+    expect(await fs.readFile(sqliteDbPath(dir), "utf8")).toBe("current-db");
+  });
+
+  it("does nothing when there is no legacy database", async () => {
+    await ensureSqliteRenameCompatibility(dir);
+
+    expect(fsSync.existsSync(sqliteDbPath(dir))).toBe(false);
+    expect(fsSync.existsSync(Path.join(dir, "zuse-migration-state.json"))).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.8.1",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Restored the macOS bundle identifier to `app.memoize.desktop` so existing memoize Alpha installs can accept Zuse Alpha updates in place through Squirrel.Mac. The app name and GitHub release feed stay Zuse, but the updater identity remains stable for compatibility.",
+          "Legacy memoize keychain credentials are now promoted into the Zuse keychain namespace after first successful fallback read."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.8.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- restore the macOS bundle identifier to `app.memoize.desktop` so existing memoize Alpha installs can update in place to Zuse Alpha through Squirrel.Mac
- bump desktop to `0.8.1` and add the 0.8.1 changelog entry
- keep the public app name and GitHub release feed as Zuse
- promote legacy `memoize` keychain credentials into the `zuse` keychain namespace after first fallback read
- record a JSON marker when copying `memoize.sqlite` to `zuse.sqlite`

## Root cause
Squirrel.Mac stages downloads under `~/Library/Caches/<bundle-id>.ShipIt/...`; the `.ShipIt` suffix is normal. The failure happened because old installs identify as `app.memoize.desktop`, but the 0.8.0 ZIP contained an app with `CFBundleIdentifier=app.zuse.desktop`. Squirrel could not find a matching update bundle and rejected it.

## Test
- `bun run --filter @zuse/server test`
- `bun run --filter @zuse/server check-types`
- `bun run --filter desktop check-types`
- `bun run --filter renderer check-types`
- `bun run build:desktop`
- inspected unsigned Electron Builder temp bundles: both `Zuse Alpha.app` Info.plist files report `CFBundleIdentifier=app.memoize.desktop`, `CFBundleName=Zuse Alpha`, `CFBundleDisplayName=Zuse Alpha`

Note: repo-wide `bun run check-types` currently fails in the web app on generated Fumadocs `collections/server` typings, unrelated to this hotfix.