### PR TITLE
[codex] Fix compact display lifecycle

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1637,16 +1637,99 @@ function ContextRing({ percent }: { percent: number | null }) {
   );
 }
 
+function StickMeter({
+  percent,
+  tone = "default",
+}: {
+  readonly percent: number | null;
+  readonly tone?: "default" | "warning";
+}) {
+  const segments = 38;
+  const clamped = percent === null ? 0 : Math.min(Math.max(percent, 0), 100);
+  const filled = percent === null ? 0 : Math.ceil((clamped / 100) * segments);
+  return (
+    <div
+      className="grid h-4 grid-cols-[repeat(38,minmax(0,1fr))] gap-0.5"
+      aria-hidden
+    >
+      {Array.from({ length: segments }, (_, index) => {
+        const active = index < filled;
+        return (
+          <div
+            key={index}
+            className={cn(
+              "rounded-[2px] transition-colors",
+              active
+                ? tone === "warning"
+                  ? "bg-amber-300/65"
+                  : "bg-primary/70"
+                : "bg-muted-foreground/16",
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
 function ContextStatusPopover({ session }: { session: Session }) {
   const messages = useMessagesStore(
     (s) => s.messagesBySession[session.id] ?? EMPTY_MESSAGES,
   );
 
   const latestContext = useMemo(() => {
+    let latestUsage: Extract<
+      Message["content"],
+      { _tag: "context_usage" }
+    > | null = null;
+    let latestUsageIndex = -1;
+    let latestCompact: Extract<
+      Message["content"],
+      { _tag: "context_compaction" }
+    > | null = null;
+    let latestCompactIndex = -1;
     for (let i = messages.length - 1; i >= 0; i--) {
       const content = messages[i]!.content;
       if (
         content._tag === "context_usage" &&
+        content.providerId === session.providerId
+      ) {
+        latestUsage = content;
+        latestUsageIndex = i;
+        break;
+      }
+    }
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const content = messages[i]!.content;
+      if (
+        content._tag === "context_compaction" &&
+        content.providerId === session.providerId &&
+        (content.status ?? "completed") === "completed" &&
+        content.afterTokens !== null
+      ) {
+        latestCompact = content;
+        latestCompactIndex = i;
+        break;
+      }
+    }
+    if (latestCompact !== null && latestCompactIndex > latestUsageIndex) {
+      return {
+        _tag: "context_usage" as const,
+        providerId: latestCompact.providerId,
+        usedTokens: latestCompact.afterTokens,
+        windowTokens: latestUsage?.windowTokens ?? null,
+        precision: "exact" as const,
+        source: "Context compaction",
+      };
+    }
+    return latestUsage;
+  }, [messages, session.providerId]);
+
+  const usageLimit = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const content = messages[i]!.content;
+      if (
+        content._tag === "usage_limit" &&
         content.providerId === session.providerId
       ) {
         return content;
@@ -1655,27 +1738,17 @@ function ContextStatusPopover({ session }: { session: Session }) {
     return null;
   }, [messages, session.providerId]);
 
-  const usageLimits = useMemo(
-    () =>
-      messages
-        .filter(
-          (m) =>
-            m.content._tag === "usage_limit" &&
-            m.content.providerId === session.providerId,
-        )
-        .slice(-2)
-        .map((m) => (m.content._tag === "usage_limit" ? m.content : null))
-        .filter((v): v is NonNullable<typeof v> => v !== null),
-    [messages, session.providerId],
-  );
-
-  // Real numbers only — but the context window itself is a real capacity we
-  // know from the model, so we show it from the first message and fill in
-  // the live bar once Claude/Codex report exact usage.
   const usedTokens = latestContext?.usedTokens ?? null;
+  const reportedWindowTokens = latestContext?.windowTokens ?? null;
+  const fallbackWindowTokens = selectedContextWindowTokens(
+    session.id,
+    session.providerId,
+    session.model,
+  );
   const windowTokens =
-    latestContext?.windowTokens ??
-    selectedContextWindowTokens(session.id, session.providerId, session.model);
+    usedTokens !== null
+      ? (reportedWindowTokens ?? fallbackWindowTokens)
+      : reportedWindowTokens;
 
   const percent =
     usedTokens !== null && windowTokens !== null && windowTokens > 0
@@ -1686,8 +1759,8 @@ function ContextStatusPopover({ session }: { session: Session }) {
       ? Math.max(0, windowTokens - usedTokens)
       : null;
 
-  const hasContext = usedTokens !== null || windowTokens !== null;
-  const hasLimits = usageLimits.length > 0;
+  const hasContext = usedTokens !== null && windowTokens !== null;
+  const hasLimits = usageLimit !== null;
   if (!hasContext && !hasLimits) return null;
 
   const high = percent !== null && percent >= 90;
@@ -1720,10 +1793,10 @@ function ContextStatusPopover({ session }: { session: Session }) {
         side="top"
         align="end"
         sideOffset={8}
-        className="w-[256px] overflow-hidden rounded-xl border-border bg-popover p-0 text-[13px] shadow-lg"
+        className="w-[300px] overflow-hidden rounded-xl border-border bg-popover p-0 text-[13px] shadow-lg"
       >
         {hasContext ? (
-          <div className="flex flex-col gap-2.5 p-3">
+          <div className="flex flex-col gap-3 p-3.5">
             <div className="flex items-baseline justify-between gap-3">
               <span className="font-medium text-foreground">Context</span>
               <span className="tabular-nums text-muted-foreground">
@@ -1732,22 +1805,19 @@ function ContextStatusPopover({ session }: { session: Session }) {
             </div>
             {percent !== null ? (
               <>
-                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                  <div
-                    className={cn(
-                      "h-full rounded-full transition-[width]",
-                      high ? "bg-amber-400" : "bg-foreground",
-                    )}
-                    style={{ width: `${Math.max(percent, 2)}%` }}
-                  />
-                </div>
+                <StickMeter
+                  percent={percent}
+                  tone={high ? "warning" : "default"}
+                />
                 <div className="flex items-center justify-between text-muted-foreground">
-                  <span className="tabular-nums">
-                    {percent.toFixed(1)}% used
-                  </span>
+                  <span>Window used</span>
+                  <span className="tabular-nums">{percent.toFixed(1)}%</span>
+                </div>
+                <div className="flex items-center justify-between text-muted-foreground/70">
+                  <span>Available</span>
                   {freeTokens !== null ? (
                     <span className="tabular-nums">
-                      {formatTokens(freeTokens)} free
+                      {formatTokens(freeTokens)}
                     </span>
                   ) : null}
                 </div>
@@ -1762,40 +1832,44 @@ function ContextStatusPopover({ session }: { session: Session }) {
         {hasLimits ? (
           <div
             className={cn(
-              "flex flex-col gap-2 p-3",
+              "flex flex-col gap-3 p-3.5",
               hasContext && "border-t border-border",
             )}
           >
-            <span className="font-medium text-foreground">Usage limits</span>
-            <div className="flex flex-col gap-1.5">
-              {usageLimits.map((limit, index) => {
-                const reset = resetLabel(limit.resetsAt);
-                const remaining =
-                  limit.usedPercent !== null
-                    ? `${Math.max(0, 100 - limit.usedPercent).toFixed(0)}% left`
-                    : "Active";
-                return (
-                  <div
-                    key={`${limit.label}-${index}`}
-                    className="flex flex-col gap-0.5"
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="truncate text-foreground">
-                        {limit.label}
-                      </span>
-                      <span className="shrink-0 tabular-nums text-muted-foreground">
-                        {remaining}
-                      </span>
-                    </div>
-                    {reset !== null ? (
-                      <span className="tabular-nums text-muted-foreground/50">
-                        resets {reset}
-                      </span>
-                    ) : null}
+            {(() => {
+              const limit = usageLimit!;
+              const reset = resetLabel(limit.resetsAt);
+              const used = limit.usedPercent;
+              const remaining =
+                used !== null
+                  ? `${Math.max(0, 100 - used).toFixed(0)}% left`
+                  : "Active";
+              const limitHigh = used !== null && used >= 80;
+              return (
+                <>
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="font-medium text-foreground">
+                      {limit.label}
+                    </span>
+                    <span className="shrink-0 tabular-nums text-muted-foreground">
+                      {remaining}
+                    </span>
                   </div>
-                );
-              })}
-            </div>
+                  {used !== null ? (
+                    <StickMeter
+                      percent={used}
+                      tone={limitHigh ? "warning" : "default"}
+                    />
+                  ) : null}
+                  <div className="flex items-center justify-between text-muted-foreground/70">
+                    <span>Reset</span>
+                    <span className="tabular-nums">
+                      {reset !== null ? reset : "unknown"}
+                    </span>
+                  </div>
+                </>
+              );
+            })()}
           </div>
         ) : null}
       </TooltipPopup>

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -1,5 +1,11 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { CircleArrowUp01Icon, Copy01Icon, LinkSquare01Icon, RotateRight01Icon, Tick01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  CircleArrowUp01Icon,
+  Copy01Icon,
+  LinkSquare01Icon,
+  Tick01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import { RefreshCw as RefreshIcon } from "lucide-react";
 import { useState } from "react";
 
 import type { ProviderId } from "@zuse/wire";
@@ -130,7 +136,9 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
           disabled={refreshing}
           className="gap-1.5 rounded-full text-[11px] text-muted-foreground"
         >
-          <HugeiconsIcon icon={RotateRight01Icon} className={`size-3 ${refreshing ? "animate-spin" : ""}`} />
+          <RefreshIcon
+            className={`size-3 ${refreshing ? "animate-spin" : ""}`}
+          />
           Recheck
         </Button>
       </div>

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -6,12 +6,12 @@ import {
   DashboardSpeedIcon,
   Loading02Icon,
   PlayIcon,
-  RotateRight01Icon,
   Settings01Icon,
   Tick01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useState } from "react";
+import { RefreshCw as RefreshIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 import type {
   AgentItemId,
   AttachmentRef,
@@ -74,6 +74,32 @@ const parseReconnectingStatus = (
   const maxAttempts = Number(match[2]);
   if (!Number.isFinite(attempt) || !Number.isFinite(maxAttempts)) return null;
   return { attempt, maxAttempts };
+};
+
+const formatDuration = (ms: number): string => {
+  const seconds = Math.max(0, ms) / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const min = Math.floor(seconds / 60);
+  const sec = seconds - min * 60;
+  return `${min}m, ${sec.toFixed(1)}s`;
+};
+
+const formatTokenCount = (tokens: number): string => tokens.toLocaleString();
+
+const formatCompactTokenDelta = (
+  beforeTokens: number | null,
+  afterTokens: number | null,
+): string | null => {
+  if (beforeTokens !== null && afterTokens !== null) {
+    return `${formatTokenCount(beforeTokens)} -> ${formatTokenCount(afterTokens)} tokens`;
+  }
+  if (beforeTokens !== null) {
+    return `${formatTokenCount(beforeTokens)} tokens before`;
+  }
+  if (afterTokens !== null) {
+    return `${formatTokenCount(afterTokens)} tokens after`;
+  }
+  return null;
 };
 
 /**
@@ -167,6 +193,16 @@ export function MessageRow({
       // The paired `user_question` row above renders the answer inline, so
       // the standalone answer row is suppressed.
       return null;
+    case "context_compaction":
+      return (
+        <CompactRow
+          beforeTokens={message.content.beforeTokens}
+          afterTokens={message.content.afterTokens}
+          startedAt={message.content.startedAt}
+          durationMs={message.content.durationMs}
+          status={message.content.status ?? "completed"}
+        />
+      );
     case "usage":
     case "context_usage":
     case "usage_limit":
@@ -197,6 +233,54 @@ export function MessageRow({
         </div>
       );
   }
+}
+
+function CompactRow({
+  beforeTokens,
+  afterTokens,
+  startedAt,
+  durationMs,
+  status,
+}: {
+  readonly beforeTokens: number | null;
+  readonly afterTokens: number | null;
+  readonly startedAt: number;
+  readonly durationMs: number;
+  readonly status: "in_progress" | "completed";
+}) {
+  const [now, setNow] = useState(() => Date.now());
+  const inProgress = status === "in_progress";
+  useEffect(() => {
+    if (!inProgress) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [inProgress]);
+  const elapsedMs = inProgress ? Math.max(0, now - startedAt) : durationMs;
+  const tokenDelta = formatCompactTokenDelta(beforeTokens, afterTokens);
+  const detail =
+    tokenDelta === null
+      ? formatDuration(elapsedMs)
+      : `${tokenDelta} · ${formatDuration(elapsedMs)}`;
+
+  return (
+    <div className="px-4 py-2 text-muted-foreground">
+      <div className="flex items-center gap-2">
+        <RefreshIcon
+          aria-hidden
+          className={cn(
+            "size-3.5 shrink-0 opacity-70",
+            inProgress && "animate-spin",
+          )}
+        />
+        <span className="text-sm font-medium text-foreground/90">
+          {inProgress ? "Compacting..." : "Chat compacted"}
+        </span>
+      </div>
+      <div className="mt-1 pl-5 text-[11px] tabular-nums text-muted-foreground/70">
+        {detail}
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -691,8 +775,8 @@ function GeminiUpgradeCard({ onDismiss }: { onDismiss?: () => void }) {
               Gemini CLI needs an upgrade
             </div>
             <p className="mt-1 leading-relaxed text-muted-foreground">
-              Your installed Gemini CLI does not support ACP mode yet, so
-              Zuse Alpha cannot start Gemini sessions until the CLI is updated.
+              Your installed Gemini CLI does not support ACP mode yet, so Zuse
+              Alpha cannot start Gemini sessions until the CLI is updated.
             </p>
             <div className="mt-3 flex flex-wrap items-center gap-2">
               <code className="rounded-md border border-border/60 bg-background/60 px-2 py-1 font-mono text-[11px] text-foreground">
@@ -884,11 +968,7 @@ export function ErrorBubble({
                   onClick={onRetry}
                   className="gap-1"
                 >
-                  <HugeiconsIcon
-                    icon={RotateRight01Icon}
-                    className="size-3"
-                    aria-hidden
-                  />
+                  <RefreshIcon className="size-3" aria-hidden />
                   Retry
                 </Button>
                 {error.kind === "auth" && (

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -9,14 +9,13 @@ import {
   GlobeIcon,
   KeyboardIcon,
   PackageIcon,
-  RotateRight01Icon,
   Settings01Icon,
   TaskDone01Icon,
   TestTubeIcon,
   Tick01Icon,
   VolumeHighIcon,
 } from "@hugeicons-pro/core-bulk-rounded";
-import { Plus } from "lucide-react";
+import { Plus, RefreshCw as RefreshIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { Effect } from "effect";
@@ -847,8 +846,7 @@ function ProvidersPane() {
               disabled={loading}
               aria-label="Refresh provider status"
             >
-              <HugeiconsIcon
-                icon={RotateRight01Icon}
+              <RefreshIcon
                 className={cn("size-3.5", loading && "animate-spin")}
                 aria-hidden
               />

--- a/apps/renderer/src/lib/group-messages.ts
+++ b/apps/renderer/src/lib/group-messages.ts
@@ -49,11 +49,18 @@ export function groupMessages(
 
   const childrenByParent = new Map<AgentItemId, Message[]>();
   const summariesByItemId = new Map<AgentItemId, Message>();
+  const completedCompactionItemIds = new Set<AgentItemId>();
   for (const m of messages) {
     const c = m.content;
     if (c._tag === "subagent_summary") {
       summariesByItemId.set(c.itemId, m);
       continue;
+    }
+    if (
+      c._tag === "context_compaction" &&
+      (c.status ?? "completed") === "completed"
+    ) {
+      completedCompactionItemIds.add(c.itemId);
     }
     if ("parentItemId" in c && c.parentItemId !== undefined) {
       const list = childrenByParent.get(c.parentItemId) ?? [];
@@ -73,6 +80,13 @@ export function groupMessages(
     const c = m.content;
     if (c._tag === "usage") continue;
     if (c._tag === "subagent_summary") continue;
+    if (
+      c._tag === "context_compaction" &&
+      c.status === "in_progress" &&
+      completedCompactionItemIds.has(c.itemId)
+    ) {
+      continue;
+    }
     if ("parentItemId" in c && c.parentItemId !== undefined) continue;
     if (c._tag === "tool_result" && agentItemIds.has(c.itemId)) continue;
     if (isAgentToolUse(m) && c._tag === "tool_use") {

--- a/apps/renderer/src/lib/plan-feedback-routing.ts
+++ b/apps/renderer/src/lib/plan-feedback-routing.ts
@@ -63,6 +63,7 @@ export const shouldSendPlanFeedbackNow = ({
       case "subagent_summary":
       case "usage":
       case "context_usage":
+      case "context_compaction":
       case "usage_limit":
       case "user_question_answer":
         continue;

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -20,9 +20,7 @@ import { useSessionsStore } from "./sessions.ts";
 
 let getMessagesRpcClient: typeof getRpcClient = getRpcClient;
 
-export const setMessagesRpcClientForTest = (
-  fn: typeof getRpcClient,
-): void => {
+export const setMessagesRpcClientForTest = (fn: typeof getRpcClient): void => {
   getMessagesRpcClient = fn;
 };
 
@@ -328,7 +326,13 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
   queuePausedBySession: {},
   goalBySession: {},
   hydrate: async (sessionId) => {
-    if (liveSessionId === sessionId && liveFiber !== null) return;
+    if (
+      liveSessionId === sessionId &&
+      liveFiber !== null &&
+      (get().messagesBySession[sessionId]?.length ?? 0) > 0
+    ) {
+      return;
+    }
     await stopLiveFiber();
     liveSessionId = sessionId;
     set((s) => ({
@@ -345,8 +349,9 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     }));
     try {
       const client = await getMessagesRpcClient();
-      liveFiber = Effect.runFork(
-        Stream.runForEach(client.messages.stream({ sessionId }), (message) =>
+      const messageProgram = Stream.runForEach(
+        client.messages.stream({ sessionId }),
+        (message) =>
           Effect.sync(() => {
             set((s) => {
               const current = s.messagesBySession[sessionId] ?? [];
@@ -398,8 +403,28 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
               };
             });
           }),
+      ).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            console.error("[messages] message stream errored", err);
+            set((s) => ({
+              errorBySession: {
+                ...s.errorBySession,
+                [sessionId]: classifyError(
+                  err,
+                  lookupSessionProvider(sessionId),
+                ),
+              },
+            }));
+          }),
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (liveSessionId === sessionId) liveFiber = null;
+          }),
         ),
       );
+      liveFiber = Effect.runFork(messageProgram);
       // Status mirror — keeps the composer's "running" indicator stable
       // across the whole tool-call loop. When a turn ends we also refresh
       // the project's PR state so freshly pushed branches recolor the

--- a/apps/renderer/test/messages-store.test.ts
+++ b/apps/renderer/test/messages-store.test.ts
@@ -1,12 +1,10 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Stream } from "effect";
 
 import { ComposerInput, QueuedMessage, type SessionId } from "@zuse/wire";
 
-const {
-  setMessagesRpcClientForTest,
-  useMessagesStore,
-} = await import("../src/store/messages.ts");
+const { setMessagesRpcClientForTest, useMessagesStore } =
+  await import("../src/store/messages.ts");
 
 const sessionId = "session-queue" as SessionId;
 const input = new ComposerInput({
@@ -26,38 +24,44 @@ const queued = QueuedMessage.make({
 });
 
 let interruptCalls = 0;
-let sendNowCalls: Array<{ readonly sessionId: SessionId; readonly queueId: string }> = [];
+let sendNowCalls: Array<{
+  readonly sessionId: SessionId;
+  readonly queueId: string;
+}> = [];
 let resumeCalls: Array<{ readonly sessionId: SessionId }> = [];
 let flushCalls: Array<{ readonly sessionId: SessionId }> = [];
+let rpcClientFactory: () => Awaited<
+  ReturnType<typeof import("../src/lib/rpc-client.ts").getRpcClient>
+>;
 
-setMessagesRpcClientForTest(
-  async () =>
-    ({
-      messages: {
-        interrupt: () =>
-          Effect.sync(() => {
-            interruptCalls += 1;
-          }),
-        "queue.sendNow": (payload: {
-          readonly sessionId: SessionId;
-          readonly queueId: string;
-        }) =>
-          Effect.sync(() => {
-            sendNowCalls.push(payload);
-          }),
-        "queue.resume": (payload: { readonly sessionId: SessionId }) =>
-          Effect.sync(() => {
-            resumeCalls.push(payload);
-          }),
-        "queue.flush": (payload: { readonly sessionId: SessionId }) =>
-          Effect.sync(() => {
-            flushCalls.push(payload);
-          }),
-      },
-    }) as Awaited<
-      ReturnType<typeof import("../src/lib/rpc-client.ts").getRpcClient>
-    >,
-);
+const makeQueueClient = () =>
+  ({
+    messages: {
+      interrupt: () =>
+        Effect.sync(() => {
+          interruptCalls += 1;
+        }),
+      "queue.sendNow": (payload: {
+        readonly sessionId: SessionId;
+        readonly queueId: string;
+      }) =>
+        Effect.sync(() => {
+          sendNowCalls.push(payload);
+        }),
+      "queue.resume": (payload: { readonly sessionId: SessionId }) =>
+        Effect.sync(() => {
+          resumeCalls.push(payload);
+        }),
+      "queue.flush": (payload: { readonly sessionId: SessionId }) =>
+        Effect.sync(() => {
+          flushCalls.push(payload);
+        }),
+    },
+  }) as Awaited<
+    ReturnType<typeof import("../src/lib/rpc-client.ts").getRpcClient>
+  >;
+
+setMessagesRpcClientForTest(async () => rpcClientFactory());
 
 describe("messages store queue actions", () => {
   beforeEach(() => {
@@ -65,6 +69,7 @@ describe("messages store queue actions", () => {
     sendNowCalls = [];
     resumeCalls = [];
     flushCalls = [];
+    rpcClientFactory = makeQueueClient;
     useMessagesStore.setState({
       messagesBySession: {},
       errorBySession: {},
@@ -106,5 +111,29 @@ describe("messages store queue actions", () => {
 
     expect(flushCalls).toEqual([{ sessionId }]);
     expect(useMessagesStore.getState().runningBySession[sessionId]).toBe(false);
+  });
+
+  it("reconnects the active transcript when it is still empty", async () => {
+    let streamCalls = 0;
+    rpcClientFactory = () =>
+      ({
+        messages: {
+          stream: () => {
+            streamCalls += 1;
+            return streamCalls === 1 ? Stream.never : Stream.empty;
+          },
+          "queue.stream": () => Stream.empty,
+        },
+        session: {
+          streamStatus: () => Stream.empty,
+        },
+      }) as Awaited<
+        ReturnType<typeof import("../src/lib/rpc-client.ts").getRpcClient>
+      >;
+
+    await useMessagesStore.getState().hydrate(sessionId);
+    await useMessagesStore.getState().hydrate(sessionId);
+
+    expect(streamCalls).toBe(2);
   });
 });

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -31,6 +31,13 @@ import {
   applyClaudeWorktreeEnv,
   claudeWorktreePrompt,
 } from "./claude-worktree-prompt.ts";
+import {
+  finishCompactEvent,
+  isCompactCommand,
+  startCompactEvent,
+  startCompactSnapshot,
+  type CompactSnapshot,
+} from "./compact.ts";
 
 /**
  * Live-only handle for one Claude SDK conversation. The orchestrator
@@ -277,6 +284,7 @@ interface TranslateState {
    * when the turn's `result` lands (which carries the real `contextWindow`).
    */
   lastContextUsedTokens: number | null;
+  pendingCompact: CompactSnapshot | null;
   /**
    * Set once we've re-emitted an auth failure as an Error from a top-level
    * assistant text block, so the turn's terminal `result` doesn't surface the
@@ -301,6 +309,7 @@ const newTranslateState = (): TranslateState => ({
   askUserQuestionIds: new Set(),
   exitPlanModeIds: new Set(),
   lastContextUsedTokens: null,
+  pendingCompact: null,
   emittedAuthError: false,
   interrupted: false,
 });
@@ -886,6 +895,8 @@ const translate = (
         const v = usage[key];
         return typeof v === "number" ? v : 0;
       };
+      const compactAfterTokens =
+        state.pendingCompact !== null ? num("output_tokens") : 0;
       out.push({
         _tag: "UsageDelta",
         parentItemId,
@@ -895,6 +906,9 @@ const translate = (
         cacheCreationTokens: num("cache_creation_input_tokens"),
         model: modelOnResult,
       });
+      if (state.pendingCompact !== null && compactAfterTokens > 0) {
+        state.lastContextUsedTokens = compactAfterTokens;
+      }
     }
     // The session-level `result` (no parent_tool_use_id) closes the turn.
     // A sub-agent's `result` does NOT close the parent's turn — the SDK
@@ -912,6 +926,17 @@ const translate = (
           precision: "exact",
           source: "Claude usage",
         });
+      }
+      if (state.pendingCompact !== null) {
+        out.push(
+          finishCompactEvent({
+            itemId: state.pendingCompact.itemId,
+            providerId: "claude",
+            snapshot: state.pendingCompact,
+            afterTokens: state.lastContextUsedTokens,
+          }),
+        );
+        state.pendingCompact = null;
       }
       // The user interrupted this turn. The SDK ends it with an
       // `error_during_execution` result, but that's a normal user action — emit
@@ -1729,11 +1754,25 @@ export const startClaudeSession = (
       events: Mailbox.toStream(events),
       send: (text, attachmentRefs) =>
         Effect.promise(async () => {
+          const compactCommand = isCompactCommand(text);
+          if (compactCommand) {
+            translateState.pendingCompact = startCompactSnapshot(
+              translateState.lastContextUsedTokens,
+            );
+            events.unsafeOffer(
+              startCompactEvent({
+                providerId: "claude",
+                snapshot: translateState.pendingCompact,
+              }),
+            );
+          }
           // Ultrathink is the only `effort` tier that's not forwarded to
           // the SDK as a knob — instead the literal word `"ultrathink"` is
           // prepended to the user's prompt. The session-level modelOptions
           // were captured at start() so we can apply the prefix here.
-          const promptText = applyUltrathinkPrefix(input.modelOptions, text);
+          const promptText = compactCommand
+            ? text.trim()
+            : applyUltrathinkPrefix(input.modelOptions, text);
           console.log(
             `[claude.send] sessionId=${sessionId} textLen=${promptText.length} attachments=${attachmentRefs?.length ?? 0}`,
           );

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -25,6 +25,13 @@ import {
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
 import { CodexAppServerClient } from "../codex-app-server-client.ts";
+import {
+  finishCompactEvent,
+  nextCompactItemId,
+  startCompactEvent,
+  startCompactSnapshot,
+  type CompactSnapshot,
+} from "./compact.ts";
 import type { ServerNotification } from "../codex-app-protocol/ServerNotification";
 import type { ServerRequest } from "../codex-app-protocol/ServerRequest";
 import type { SandboxPolicy } from "../codex-app-protocol/v2/SandboxPolicy";
@@ -502,6 +509,10 @@ const createCodexToolTranslationLogger = (
 export const translateCodexItem = (
   item: ThreadItem,
   phase: "started" | "completed",
+  contextCompaction?: CompactSnapshot & {
+    readonly afterTokens: number | null;
+    readonly durationMs?: number;
+  },
 ): ReadonlyArray<AgentEvent> => {
   switch (item.type) {
     case "agentMessage":
@@ -623,13 +634,17 @@ export const translateCodexItem = (
       ];
     case "contextCompaction":
       if (phase !== "completed") return [];
-      return [
-        {
-          _tag: "AssistantMessage",
-          itemId: item.id as AgentItemId,
-          text: "Conversation context compacted.",
-        },
-      ];
+      {
+        return [
+          finishCompactEvent({
+            itemId: contextCompaction?.itemId ?? (item.id as AgentItemId),
+            providerId: "codex",
+            snapshot: contextCompaction ?? null,
+            afterTokens: contextCompaction?.afterTokens ?? null,
+            durationMs: contextCompaction?.durationMs,
+          }),
+        ];
+      }
     default:
       return [];
   }
@@ -702,6 +717,8 @@ export const startCodexSession = (
     // does / does not advertise a fast tier. Only a definitive `false` blocks
     // the `serviceTier: "fast"` request in `runTurn`.
     let modelFastTier: boolean | null = null;
+    const latestContextTokensByThread = new Map<string, number>();
+    const pendingCompactionsByThread = new Map<string, CompactSnapshot>();
 
     type QuestionWaiter = {
       readonly questionIds: ReadonlyArray<string>;
@@ -961,10 +978,20 @@ export const startCodexSession = (
 
       switch (command) {
         case "compact":
-          await app.request("thread/compact/start", {
-            threadId: activeThreadId,
-          });
-          say("Compaction started.");
+          {
+            const threadId = activeThreadId;
+            const snapshot = startCompactSnapshot(
+              latestContextTokensByThread.get(threadId) ?? null,
+            );
+            pendingCompactionsByThread.set(threadId, snapshot);
+            emit(startCompactEvent({ providerId: "codex", snapshot }));
+            try {
+              await app.request("thread/compact/start", { threadId });
+            } catch (cause) {
+              pendingCompactionsByThread.delete(threadId);
+              throw cause;
+            }
+          }
           return true;
         case "fork": {
           const forked = await app.request<{ thread: { id: string } }>(
@@ -1128,6 +1155,16 @@ export const startCodexSession = (
     function translateNotification(
       notification: ServerNotification,
     ): ReadonlyArray<AgentEvent> {
+      if (
+        notification.method === "thread/tokenUsage/updated" &&
+        notification.params.threadId === activeThreadId
+      ) {
+        latestContextTokensByThread.set(
+          notification.params.threadId,
+          notification.params.tokenUsage.total.totalTokens,
+        );
+      }
+
       const statusEvents = translateCodexStatusNotification(
         notification,
         activeThreadId,
@@ -1185,9 +1222,34 @@ export const startCodexSession = (
         case "item/completed":
           if (notification.params.threadId !== activeThreadId) return [];
           {
+            const compactMetadata =
+              notification.params.item.type === "contextCompaction"
+                ? (() => {
+                    const threadId = notification.params.threadId;
+                    const started =
+                      pendingCompactionsByThread.get(threadId) ?? null;
+                    pendingCompactionsByThread.delete(threadId);
+                    const now = Date.now();
+                    const startedAt = started?.startedAt ?? now;
+                    const beforeTokens = started?.beforeTokens ?? null;
+                    const latestAfter =
+                      latestContextTokensByThread.get(threadId) ?? null;
+                    const afterTokens =
+                      latestAfter !== null && latestAfter !== beforeTokens
+                        ? latestAfter
+                        : null;
+                    return {
+                      itemId: started?.itemId ?? nextCompactItemId(),
+                      startedAt,
+                      beforeTokens,
+                      afterTokens,
+                    };
+                  })()
+                : undefined;
             const translated = translateCodexItem(
               notification.params.item,
               "completed",
+              compactMetadata,
             );
             toolTranslationLog.append(
               "completed",

--- a/apps/server/src/provider/drivers/compact.ts
+++ b/apps/server/src/provider/drivers/compact.ts
@@ -1,0 +1,71 @@
+import type { AgentEvent, AgentItemId, ProviderId } from "@zuse/wire";
+
+export interface CompactSnapshot {
+  readonly itemId: AgentItemId;
+  readonly startedAt: number;
+  readonly beforeTokens: number | null;
+}
+
+let compactCounter = 0;
+
+export const nextCompactItemId = (): AgentItemId =>
+  `compact_${Date.now()}_${++compactCounter}` as AgentItemId;
+
+export const isCompactCommand = (text: string): boolean =>
+  /^\/compact(?:\s|$)/.test(text.trim());
+
+export const startCompactSnapshot = (
+  beforeTokens: number | null,
+  itemId: AgentItemId = nextCompactItemId(),
+): CompactSnapshot => ({
+  itemId,
+  startedAt: Date.now(),
+  beforeTokens,
+});
+
+export const startCompactEvent = ({
+  providerId,
+  snapshot,
+}: {
+  readonly providerId: ProviderId;
+  readonly snapshot: CompactSnapshot;
+}): AgentEvent => ({
+  _tag: "ContextCompaction",
+  itemId: snapshot.itemId,
+  providerId,
+  startedAt: snapshot.startedAt,
+  durationMs: 0,
+  beforeTokens: snapshot.beforeTokens,
+  afterTokens: null,
+  status: "in_progress",
+});
+
+export const finishCompactEvent = ({
+  itemId,
+  providerId,
+  snapshot,
+  afterTokens,
+  durationMs,
+}: {
+  readonly itemId: AgentItemId;
+  readonly providerId: ProviderId;
+  readonly snapshot: CompactSnapshot | null;
+  readonly afterTokens: number | null;
+  readonly durationMs?: number;
+}): AgentEvent => {
+  const now = Date.now();
+  const startedAt = snapshot?.startedAt ?? now;
+  const beforeTokens = snapshot?.beforeTokens ?? null;
+  const exactAfterTokens =
+    afterTokens !== null && afterTokens !== beforeTokens ? afterTokens : null;
+  return {
+    _tag: "ContextCompaction",
+    itemId,
+    providerId,
+    startedAt,
+    durationMs: Math.max(0, durationMs ?? now - startedAt),
+    beforeTokens,
+    afterTokens: exactAfterTokens,
+    status: "completed",
+  };
+};

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -25,6 +25,12 @@ import { AttachmentService } from "../../attachment/services/attachment-service.
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
+import {
+  finishCompactEvent,
+  isCompactCommand,
+  startCompactEvent,
+  startCompactSnapshot,
+} from "./compact.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
 
 /**
@@ -994,19 +1000,31 @@ export const startCursorSession = (
     const enqueuePrompt = (text: string): void => {
       const sid = acpSessionId;
       if (sid === null) return;
+      const compactSnapshot = isCompactCommand(text)
+        ? startCompactSnapshot(null)
+        : null;
+      if (compactSnapshot !== null) {
+        events.unsafeOffer(
+          startCompactEvent({ providerId: "cursor", snapshot: compactSnapshot }),
+        );
+      }
+      const promptText = compactSnapshot !== null ? text.trim() : text;
       const n = ++promptCount;
       inflight = inflight
         .then(async () => {
           if (closed) return;
           firstChunkSeenForPrompt = false;
           const promptStart = Date.now();
-          log("prompt.send", `#${n} len=${text.length} mode=${currentMode}`);
+          log(
+            "prompt.send",
+            `#${n} len=${promptText.length} mode=${currentMode}`,
+          );
           try {
             await request(
               "session/prompt",
               {
                 sessionId: sid,
-                prompt: [{ type: "text", text }],
+                prompt: [{ type: "text", text: promptText }],
                 _meta: { permissionMode: currentMode },
               },
               5 * 60_000,
@@ -1015,6 +1033,16 @@ export const startCursorSession = (
               },
             );
             log("prompt.done", `#${n} ${Date.now() - promptStart}ms`);
+            if (compactSnapshot !== null && !closed) {
+              events.unsafeOffer(
+                finishCompactEvent({
+                  itemId: compactSnapshot.itemId,
+                  providerId: "cursor",
+                  snapshot: compactSnapshot,
+                  afterTokens: null,
+                }),
+              );
+            }
           } catch (cause) {
             const reason = cause instanceof Error ? cause.message : String(cause);
             log("prompt.fail", `#${n} ${Date.now() - promptStart}ms reason=${reason}`);

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -19,6 +19,12 @@ import {
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
+import {
+  finishCompactEvent,
+  isCompactCommand,
+  startCompactEvent,
+  startCompactSnapshot,
+} from "./compact.ts";
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
@@ -636,9 +642,20 @@ export const startGeminiSession = (
     const enqueuePrompt = (text: string): void => {
       const sid = acpSessionId;
       if (sid === null) return;
+      const compactSnapshot = isCompactCommand(text)
+        ? startCompactSnapshot(null)
+        : null;
+      if (compactSnapshot !== null) {
+        events.unsafeOffer(
+          startCompactEvent({ providerId: "gemini", snapshot: compactSnapshot }),
+        );
+      }
       // Plan-mode emulation: gemini ACP has no native read-only switch, so
       // prepend a developer-instructions block while plan mode is active.
-      const promptText = applyPlanModePrefix(currentMode, text);
+      const promptText =
+        compactSnapshot !== null
+          ? text.trim()
+          : applyPlanModePrefix(currentMode, text);
       inflight = inflight
         .then(async () => {
           if (closed) return;
@@ -665,6 +682,16 @@ export const startGeminiSession = (
             );
             if (GEMINI_RPC_TRACE) {
               process.stderr.write(`[gemini.prompt] completed\n`);
+            }
+            if (compactSnapshot !== null && !closed) {
+              events.unsafeOffer(
+                finishCompactEvent({
+                  itemId: compactSnapshot.itemId,
+                  providerId: "gemini",
+                  snapshot: compactSnapshot,
+                  afterTokens: null,
+                }),
+              );
             }
           } catch (cause) {
             const reason = cause instanceof Error ? cause.message : String(cause);

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -21,6 +21,12 @@ import { AttachmentService } from "../../attachment/services/attachment-service.
 import { isIgnorableGrokAuthNoise } from "./acp/grok-auth-noise.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
 import { applyPlanModePrefix } from "./planMode.ts";
+import {
+  finishCompactEvent,
+  isCompactCommand,
+  startCompactEvent,
+  startCompactSnapshot,
+} from "./compact.ts";
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
@@ -821,9 +827,20 @@ export const startGrokSession = (
     }
 
     const enqueuePrompt = (text: string): void => {
+      const compactSnapshot = isCompactCommand(text)
+        ? startCompactSnapshot(null)
+        : null;
+      if (compactSnapshot !== null) {
+        events.unsafeOffer(
+          startCompactEvent({ providerId: "grok", snapshot: compactSnapshot }),
+        );
+      }
       // Plan-mode emulation: grok ACP has no native read-only switch, so
       // prepend a developer-instructions block while plan mode is active.
-      const promptText = applyPlanModePrefix(currentMode, text);
+      const promptText =
+        compactSnapshot !== null
+          ? text.trim()
+          : applyPlanModePrefix(currentMode, text);
       inflight = inflight
         .then(async () => {
           if (closed) return;
@@ -897,6 +914,16 @@ export const startGrokSession = (
               process.stderr.write(`[grok.prompt] completed\n`);
             }
             grokDiag("session/prompt completed successfully");
+            if (compactSnapshot !== null && !closed) {
+              events.unsafeOffer(
+                finishCompactEvent({
+                  itemId: compactSnapshot.itemId,
+                  providerId: "grok",
+                  snapshot: compactSnapshot,
+                  afterTokens: null,
+                }),
+              );
+            }
           } catch (cause) {
             const reason = cause instanceof Error ? cause.message : String(cause);
             if (GROK_RPC_TRACE || GROK_DIAG) {

--- a/apps/server/src/provider/drivers/opencode.ts
+++ b/apps/server/src/provider/drivers/opencode.ts
@@ -28,6 +28,12 @@ import {
 } from "@opencode-ai/sdk";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
+import {
+  finishCompactEvent,
+  isCompactCommand,
+  startCompactEvent,
+  startCompactSnapshot,
+} from "./compact.ts";
 
 /**
  * Live handle for one OpenCode conversation. Mirrors the other driver
@@ -943,6 +949,18 @@ export const startOpencodeSession = (
     // === Prompt queue — serializes turns inside a single session. ===
     let inflight: Promise<void> = Promise.resolve();
     const enqueuePrompt = (text: string): void => {
+      const compactSnapshot = isCompactCommand(text)
+        ? startCompactSnapshot(null)
+        : null;
+      if (compactSnapshot !== null) {
+        events.unsafeOffer(
+          startCompactEvent({
+            providerId: "opencode",
+            snapshot: compactSnapshot,
+          }),
+        );
+      }
+      const promptText = compactSnapshot !== null ? text.trim() : text;
       inflight = inflight
         .then(async () => {
           if (closed) return;
@@ -973,10 +991,10 @@ export const startOpencodeSession = (
           const body = {
             agent,
             ...(modelField !== null ? { model: modelField } : {}),
-            parts: [{ type: "text" as const, text }],
+            parts: [{ type: "text" as const, text: promptText }],
           };
           dlog(
-            `prompt: agent=${agent} providerID=${providerID ?? "(default)"} modelID=${modelID ?? "(default)"} variant=${variantOpt ?? "(default)"} textLen=${text.length}`,
+            `prompt: agent=${agent} providerID=${providerID ?? "(default)"} modelID=${modelID ?? "(default)"} variant=${variantOpt ?? "(default)"} textLen=${promptText.length}`,
           );
           ddump(`  prompt.body`, body);
           try {
@@ -1037,6 +1055,16 @@ export const startOpencodeSession = (
             // prompt resolved before the SSE got there).
             for (const evt of flushDeltaState(deltaState)) {
               events.unsafeOffer(evt);
+            }
+            if (compactSnapshot !== null && !closed) {
+              events.unsafeOffer(
+                finishCompactEvent({
+                  itemId: compactSnapshot.itemId,
+                  providerId: "opencode",
+                  snapshot: compactSnapshot,
+                  afterTokens: null,
+                }),
+              );
             }
             events.unsafeOffer({ _tag: "Completed", reason: "ended" });
           } catch (cause) {

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -268,8 +268,17 @@ const chatFromRow = (row: ChatRow): Chat =>
     updatedAt: new Date(row.updated_at),
   });
 
+const normalizeMessageContent = (content: MessageContent): MessageContent => {
+  if (content._tag === "context_compaction" && content.status === undefined) {
+    return { ...content, status: "completed" };
+  }
+  return content;
+};
+
 const messageFromRow = (row: MessageRow): Message => {
-  const content = JSON.parse(row.content_json) as MessageContent;
+  const content = normalizeMessageContent(
+    JSON.parse(row.content_json) as MessageContent,
+  );
   return Message.make({
     id: MessageId.make(row.id),
     sessionId: SessionId.make(row.session_id),
@@ -305,6 +314,7 @@ const parentItemIdOfContent = (content: MessageContent): string | null => {
     case "user_question_answer":
       return content.parentItemId ?? null;
     case "context_usage":
+    case "context_compaction":
     case "usage_limit":
       return null;
     case "subagent_summary":
@@ -334,6 +344,7 @@ const roleForContent = (content: MessageContent): MessageRole => {
     case "interrupted":
     case "usage":
     case "context_usage":
+    case "context_compaction":
     case "usage_limit":
       return "system";
   }
@@ -406,6 +417,17 @@ const eventToContent = (event: AgentEvent): MessageContent | null => {
         windowTokens: event.windowTokens,
         precision: event.precision,
         source: event.source,
+      };
+    case "ContextCompaction":
+      return {
+        _tag: "context_compaction",
+        itemId: event.itemId,
+        providerId: event.providerId,
+        startedAt: event.startedAt,
+        durationMs: event.durationMs,
+        beforeTokens: event.beforeTokens,
+        afterTokens: event.afterTokens,
+        status: event.status,
       };
     case "UsageLimit":
       return {
@@ -1051,7 +1073,9 @@ export const MessageStoreLive = Layer.scoped(
         yield* broadcastQueue(sessionId);
       });
 
-    const clearQueuePauseIfEmpty = (sessionId: SessionId): Effect.Effect<void> =>
+    const clearQueuePauseIfEmpty = (
+      sessionId: SessionId,
+    ): Effect.Effect<void> =>
       Effect.gen(function* () {
         const queue = yield* listQueuedRows(sessionId);
         if (queue.length > 0 || !(yield* isQueuePaused(sessionId))) return;

--- a/apps/server/test/codex-translate.test.ts
+++ b/apps/server/test/codex-translate.test.ts
@@ -141,11 +141,39 @@ describe("translateCodexItem", () => {
     expect(ev.tool).toBe("mcp__zuse__browser_screenshot");
   });
 
-  it("renders context compaction as a compacted message", () => {
+  it("renders context compaction as a compact event with token counts", () => {
     const item: ThreadItem = { type: "contextCompaction", id: "compact1" };
 
-    const ev = only(translateCodexItem(item, "completed"), "AssistantMessage");
-    expect(ev.text).toBe("Conversation context compacted.");
+    const ev = only(
+      translateCodexItem(item, "completed", {
+        itemId: "compact1",
+        startedAt: 1_800_000_000,
+        durationMs: 37_000,
+        beforeTokens: 231_450,
+        afterTokens: 9_535,
+      }),
+      "ContextCompaction",
+    );
+    expect(ev.itemId).toBe("compact1");
+    expect(ev.providerId).toBe("codex");
+    expect(ev.startedAt).toBe(1_800_000_000);
+    expect(ev.durationMs).toBe(37_000);
+    expect(ev.beforeTokens).toBe(231_450);
+    expect(ev.afterTokens).toBe(9_535);
+    expect(ev.status).toBe("completed");
+  });
+
+  it("renders context compaction gracefully without token counts", () => {
+    const item: ThreadItem = { type: "contextCompaction", id: "compact1" };
+
+    const ev = only(
+      translateCodexItem(item, "completed"),
+      "ContextCompaction",
+    );
+    expect(ev.beforeTokens).toBeNull();
+    expect(ev.afterTokens).toBeNull();
+    expect(ev.status).toBe("completed");
+    expect(ev.durationMs).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -397,9 +397,7 @@ describe("MessageStore — chat & session lifecycle", () => {
 
       expect(result.chat.worktreeId).toBe(TEST_WORKTREE_ID);
       expect(result.initialSession.worktreeId).toBe(TEST_WORKTREE_ID);
-      expect(providerStartInputs.at(-1)?.cwdOverride).toBe(
-        TEST_WORKTREE_PATH,
-      );
+      expect(providerStartInputs.at(-1)?.cwdOverride).toBe(TEST_WORKTREE_PATH);
     });
   });
 
@@ -603,6 +601,55 @@ describe("MessageStore — chat & session lifecycle", () => {
       expect(user.at(-1)?.content).toMatchObject({
         _tag: "user",
         text: "hello there",
+      });
+    });
+  });
+
+  it("reads legacy context compaction rows without status", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "codex",
+            model: "gpt-5",
+          }),
+        ),
+      );
+      const id = initialSession.id;
+      const createdAt = "2026-06-30T07:22:00.000Z";
+      const legacyContent = JSON.stringify({
+        _tag: "context_compaction",
+        itemId: "compact_legacy",
+        providerId: "codex",
+        startedAt: 1_782_803_407_285,
+        durationMs: 31_110,
+        beforeTokens: null,
+        afterTokens: null,
+      });
+
+      await run(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`
+            INSERT INTO messages
+              (id, session_id, role, kind, content_json, created_at)
+            VALUES
+              (${"msg_legacy_compact"}, ${id}, ${"system"}, ${"context_compaction"}, ${legacyContent}, ${createdAt})
+          `;
+        }),
+      );
+
+      const messages = await run(
+        Effect.flatMap(store, (s) => s.listMessages(id)),
+      );
+      const compact = messages.find(
+        (message) => message.content._tag === "context_compaction",
+      );
+
+      expect(compact?.content).toMatchObject({
+        _tag: "context_compaction",
+        status: "completed",
       });
     });
   });
@@ -812,9 +859,7 @@ describe("MessageStore — chat & session lifecycle", () => {
         Effect.flatMap(store, (s) => s.listQueuedMessages(initialSession.id)),
       );
       expect(queue.paused).toBe(true);
-      expect(queue.items.map((item) => item.input.text)).toEqual([
-        "resume me",
-      ]);
+      expect(queue.items.map((item) => item.input.text)).toEqual(["resume me"]);
     });
   });
 

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -475,6 +475,16 @@ const ContextUsageEvent = Schema.TaggedStruct("ContextUsage", {
   source: Schema.optional(Schema.String),
 });
 
+const ContextCompactionEvent = Schema.TaggedStruct("ContextCompaction", {
+  itemId: AgentItemId,
+  providerId: ProviderId,
+  startedAt: Schema.Number,
+  durationMs: Schema.Number,
+  beforeTokens: Schema.NullOr(Schema.Number),
+  afterTokens: Schema.NullOr(Schema.Number),
+  status: Schema.Literal("in_progress", "completed"),
+});
+
 const UsageLimitEvent = Schema.TaggedStruct("UsageLimit", {
   providerId: ProviderId,
   label: Schema.String,
@@ -607,6 +617,7 @@ export const AgentEvent = Schema.Union(
   SubagentSummaryEvent,
   UsageDeltaEvent,
   ContextUsageEvent,
+  ContextCompactionEvent,
   UsageLimitEvent,
   SessionCursorEvent,
   UserQuestionEvent,

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -260,6 +260,18 @@ const ContextUsageContent = Schema.TaggedStruct("context_usage", {
   source: Schema.optional(Schema.String),
 });
 
+const ContextCompactionContent = Schema.TaggedStruct("context_compaction", {
+  itemId: AgentItemId,
+  providerId: ProviderId,
+  startedAt: Schema.Number,
+  durationMs: Schema.Number,
+  beforeTokens: Schema.NullOr(Schema.Number),
+  afterTokens: Schema.NullOr(Schema.Number),
+  status: Schema.optionalWith(Schema.Literal("in_progress", "completed"), {
+    default: () => "completed" as const,
+  }),
+});
+
 const UsageLimitContent = Schema.TaggedStruct("usage_limit", {
   providerId: ProviderId,
   label: Schema.String,
@@ -317,6 +329,7 @@ export const MessageContent = Schema.Union(
   SubagentSummaryContent,
   UsageContent,
   ContextUsageContent,
+  ContextCompactionContent,
   UsageLimitContent,
   UserQuestionContent,
   UserQuestionAnswerContent,

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -83,6 +83,19 @@ describe("AgentEvent round-trips", () => {
       },
     },
     {
+      name: "ContextCompaction",
+      encoded: {
+        _tag: "ContextCompaction",
+        itemId: "compact1",
+        providerId: "codex",
+        startedAt: 1_800_000_000,
+        durationMs: 37_000,
+        beforeTokens: 231_450,
+        afterTokens: 9_535,
+        status: "completed",
+      },
+    },
+    {
       name: "Completed",
       encoded: { _tag: "Completed", reason: "ended" },
     },
@@ -236,6 +249,23 @@ describe("Message round-trip", () => {
         itemId: "i1",
         tool: "Bash",
         input: { command: "ls" },
+      },
+    });
+  });
+
+  it("round-trips a context compaction message", () => {
+    roundTrip(Message, {
+      ...base,
+      role: "system" as const,
+      content: {
+        _tag: "context_compaction",
+        itemId: "compact1",
+        providerId: "codex",
+        startedAt: 1_800_000_000,
+        durationMs: 37_000,
+        beforeTokens: 231_450,
+        afterTokens: 9_535,
+        status: "completed",
       },
     });
   });


### PR DESCRIPTION
## Summary
- add a first-class context compaction event/content path and render compact rows instead of generic assistant text
- wire manual and provider-triggered compact lifecycle handling across Codex, Claude, Gemini, Grok, Cursor, and OpenCode
- clean up the context/usage popover with a single latest usage limit and compact segmented meters
- fix transcript hydration getting stuck on an empty active session and normalize legacy compact rows without `status`

## Root Cause
`/compact` and provider auto-compaction were not represented as a durable lifecycle event, so compact state was either invisible, rendered as generic assistant text, or failed on older persisted rows. The renderer also showed raw duplicate usage-limit events and could trust a stale empty message stream without replaying persisted chat history.

## Validation
- `bun test apps/server/test/codex-translate.test.ts packages/wire/test/schema.test.ts apps/renderer/test/messages-store.test.ts apps/server/test/message-store.test.ts`
- `bun run --filter renderer check-types`
- `bun run --filter @zuse/server check-types`
- `bun run --filter @zuse/wire check-types`
- `git diff --check`
