### PR TITLE
Fix Zuse legacy data migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2]
+
+### Fixed
+- Zuse now migrates data from legacy sibling Application Support folders such as `memoize Alpha` and `memoize` when the new `Zuse Alpha` database is still empty. The empty Zuse database is backed up before the legacy database is copied forward.
+
 ## [0.8.1]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/server/src/persistence/db-path.ts
+++ b/apps/server/src/persistence/db-path.ts
@@ -1,9 +1,16 @@
-import { copyFile, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { copyFile, rename, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 
 export const ZUSE_SQLITE_FILENAME = "zuse.sqlite";
 const LEGACY_MEMOIZE_SQLITE_FILENAME = "memoize.sqlite";
 const MIGRATION_STATE_FILENAME = "zuse-migration-state.json";
+const LEGACY_USER_DATA_DIR_NAMES = [
+  "memoize Alpha",
+  "memoize",
+  "memoize Alpha (Dev)",
+  "memoize (Dev)",
+] as const;
+const EMPTY_SQLITE_MAX_BYTES = 64 * 1024;
 
 export const sqliteDbPath = (userData: string): string =>
   join(userData, ZUSE_SQLITE_FILENAME);
@@ -23,27 +30,102 @@ const exists = async (path: string): Promise<boolean> => {
   }
 };
 
-export const ensureSqliteRenameCompatibility = async (
+const legacySiblingDbCandidates = async (
   userData: string,
+): Promise<ReadonlyArray<string>> => {
+  const appSupportDir = dirname(userData);
+  const currentDirName = basename(userData);
+  const candidates: string[] = [];
+  for (const name of LEGACY_USER_DATA_DIR_NAMES) {
+    if (name === currentDirName) continue;
+    const candidate = join(appSupportDir, name, LEGACY_MEMOIZE_SQLITE_FILENAME);
+    if (await exists(candidate)) candidates.push(candidate);
+  }
+  return candidates;
+};
+
+const newestNonEmptyLegacyDb = async (
+  userData: string,
+): Promise<string | null> => {
+  const candidates = await legacySiblingDbCandidates(userData);
+  const withStats = await Promise.all(
+    candidates.map(async (path) => ({
+      path,
+      stats: await stat(path),
+    })),
+  );
+  const nonEmpty = withStats
+    .filter((candidate) => candidate.stats.size > EMPTY_SQLITE_MAX_BYTES)
+    .sort((a, b) => {
+      const sizeDiff = b.stats.size - a.stats.size;
+      if (sizeDiff !== 0) return sizeDiff;
+      return b.stats.mtimeMs - a.stats.mtimeMs;
+    });
+  return nonEmpty[0]?.path ?? null;
+};
+
+const copyLegacyDb = async (
+  userData: string,
+  legacy: string,
+  current: string,
+  kind: string,
 ): Promise<void> => {
-  const current = sqliteDbPath(userData);
-  if (await exists(current)) return;
-
-  const legacy = legacySqliteDbPath(userData);
-  if (!(await exists(legacy))) return;
-
   await copyFile(legacy, current);
   await writeFile(
     migrationStatePath(userData),
     `${JSON.stringify(
       {
-        kind: "memoize-to-zuse-sqlite-copy",
-        from: LEGACY_MEMOIZE_SQLITE_FILENAME,
-        to: ZUSE_SQLITE_FILENAME,
+        kind,
+        from: legacy,
+        to: current,
         migratedAt: new Date().toISOString(),
       },
       null,
       2,
     )}\n`,
+  );
+};
+
+export const ensureSqliteRenameCompatibility = async (
+  userData: string,
+): Promise<void> => {
+  const current = sqliteDbPath(userData);
+  if (await exists(current)) {
+    const currentStats = await stat(current);
+    if (currentStats.size > EMPTY_SQLITE_MAX_BYTES) return;
+
+    const legacySibling = await newestNonEmptyLegacyDb(userData);
+    if (legacySibling === null) return;
+
+    const backup = `${current}.empty-before-zuse-migration-${Date.now()}`;
+    await rename(current, backup);
+    await copyLegacyDb(
+      userData,
+      legacySibling,
+      current,
+      "memoize-app-support-to-zuse-sqlite-copy",
+    );
+    return;
+  }
+
+  const legacy = legacySqliteDbPath(userData);
+  if (await exists(legacy)) {
+    await copyLegacyDb(
+      userData,
+      legacy,
+      current,
+      "memoize-to-zuse-sqlite-copy",
+    );
+    return;
+  }
+
+  const legacySibling = await newestNonEmptyLegacyDb(userData);
+  if (legacySibling === null) return;
+
+  await copyLegacyDb(
+    userData,
+    legacySibling,
+    current,
+    "memoize-app-support-to-zuse-sqlite-copy",
   );
 };

--- a/apps/server/test/db-path.test.ts
+++ b/apps/server/test/db-path.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Database } from "bun:sqlite";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -8,6 +9,43 @@ import {
   ensureSqliteRenameCompatibility,
   sqliteDbPath,
 } from "../src/persistence/db-path.ts";
+
+const createProjectsDb = (path: string, projectCount: number): void => {
+  const db = new Database(path);
+  try {
+    db.exec(`
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        name TEXT NOT NULL,
+        default_model TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+    const insert = db.prepare(
+      "INSERT INTO projects (id, path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    for (let i = 0; i < projectCount; i += 1) {
+      insert.run(
+        `p${i}`,
+        `/tmp/project-${i}`,
+        `Project ${i}`,
+        "2026-06-30T00:00:00.000Z",
+        "2026-06-30T00:00:00.000Z",
+      );
+    }
+    if (projectCount > 0) {
+      db.exec("CREATE TABLE migration_padding (content TEXT NOT NULL)");
+      db.prepare("INSERT INTO migration_padding (content) VALUES (?)").run(
+        "x".repeat(80 * 1024),
+      );
+    }
+    db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+  } finally {
+    db.close();
+  }
+};
 
 describe("ensureSqliteRenameCompatibility", () => {
   let dir: string;
@@ -37,14 +75,60 @@ describe("ensureSqliteRenameCompatibility", () => {
       migratedAt?: string;
     };
     expect(state.kind).toBe("memoize-to-zuse-sqlite-copy");
-    expect(state.from).toBe("memoize.sqlite");
-    expect(state.to).toBe("zuse.sqlite");
+    expect(state.from).toBe(legacyPath);
+    expect(state.to).toBe(sqliteDbPath(dir));
     expect(typeof state.migratedAt).toBe("string");
 
     await fs.writeFile(sqliteDbPath(dir), "current-db");
     await ensureSqliteRenameCompatibility(dir);
 
     expect(await fs.readFile(sqliteDbPath(dir), "utf8")).toBe("current-db");
+  });
+
+  it("replaces an empty Zuse db from a non-empty legacy app support db", async () => {
+    const appSupport = await fs.mkdtemp(
+      Path.join(os.tmpdir(), "zuse-app-support-"),
+    );
+    const zuseDir = Path.join(appSupport, "Zuse Alpha");
+    const legacyDir = Path.join(appSupport, "memoize Alpha");
+    await fs.mkdir(zuseDir, { recursive: true });
+    await fs.mkdir(legacyDir, { recursive: true });
+
+    try {
+      const current = sqliteDbPath(zuseDir);
+      const legacy = Path.join(legacyDir, "memoize.sqlite");
+      createProjectsDb(current, 0);
+      createProjectsDb(legacy, 1);
+
+      await ensureSqliteRenameCompatibility(zuseDir);
+
+      const migrated = new Database(current, { readonly: true });
+      try {
+        const row = migrated
+          .query("SELECT count(*) AS count FROM projects")
+          .get() as { count: number };
+        expect(row.count).toBe(1);
+      } finally {
+        migrated.close();
+      }
+
+      const state = JSON.parse(
+        await fs.readFile(
+          Path.join(zuseDir, "zuse-migration-state.json"),
+          "utf8",
+        ),
+      ) as { kind?: string; from?: string; to?: string };
+      expect(state.kind).toBe("memoize-app-support-to-zuse-sqlite-copy");
+      expect(state.from).toBe(legacy);
+      expect(state.to).toBe(current);
+
+      const backups = (await fs.readdir(zuseDir)).filter((name) =>
+        name.startsWith("zuse.sqlite.empty-before-zuse-migration-"),
+      );
+      expect(backups).toHaveLength(1);
+    } finally {
+      await fs.rm(appSupport, { recursive: true, force: true });
+    }
   });
 
   it("does nothing when there is no legacy database", async () => {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.8.2",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Zuse now migrates data from legacy sibling Application Support folders such as `memoize Alpha` and `memoize` when the new `Zuse Alpha` database is still empty. The empty Zuse database is backed up before the legacy database is copied forward."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.8.1",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- bump desktop release metadata to `0.8.2`
- migrate from legacy sibling Application Support folders like `memoize Alpha/memoize.sqlite` and `memoize/memoize.sqlite` when the new `Zuse Alpha/zuse.sqlite` database is still empty
- back up the tiny empty Zuse database before copying legacy data forward
- record the migration source and destination in `zuse-migration-state.json`
- add a focused migration test for the exact empty-Zuse/non-empty-memoize case

## Root cause
The previous migration only looked for `memoize.sqlite` inside the current Zuse userData folder. In practice, the renamed app created `~/Library/Application Support/Zuse Alpha/zuse.sqlite`, while existing user data stayed in sibling folders like `~/Library/Application Support/memoize Alpha/memoize.sqlite`. That left users on an empty project list after launch.

## Local evidence
- `~/Library/Application Support/Zuse Alpha/zuse.sqlite`: 0 projects
- `~/Library/Application Support/memoize Alpha/memoize.sqlite`: 6 projects

## Test
- `bun run --filter @zuse/server test -- test/db-path.test.ts`
- `bun run --filter @zuse/server check-types`
- `bun run build:desktop`