### PR TITLE
Fix migrated Zuse empty database detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3]
+
+### Fixed
+- Zuse data migration now checks the actual project count before deciding whether the new `Zuse Alpha` database is empty. This recovers users who already launched Zuse once and have a migrated schema with no projects.
+
 ## [0.8.2]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/server/src/persistence/db-path.ts
+++ b/apps/server/src/persistence/db-path.ts
@@ -1,5 +1,8 @@
+import { execFile } from "node:child_process";
 import { copyFile, rename, stat, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { basename, dirname, join } from "node:path";
+import { promisify } from "node:util";
 
 export const ZUSE_SQLITE_FILENAME = "zuse.sqlite";
 const LEGACY_MEMOIZE_SQLITE_FILENAME = "memoize.sqlite";
@@ -11,6 +14,22 @@ const LEGACY_USER_DATA_DIR_NAMES = [
   "memoize (Dev)",
 ] as const;
 const EMPTY_SQLITE_MAX_BYTES = 64 * 1024;
+const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
+
+type SqliteRow = Record<string, unknown>;
+type SqliteStatement = {
+  readonly get: () => SqliteRow | undefined;
+};
+type SqliteDatabase = {
+  readonly prepare: (sql: string) => SqliteStatement;
+  readonly close: () => void;
+};
+type SqliteDatabaseConstructor = new (
+  path: string,
+  options: { readonly readonly: boolean; readonly fileMustExist: boolean },
+) => SqliteDatabase;
+const Database = require("better-sqlite3") as SqliteDatabaseConstructor;
 
 export const sqliteDbPath = (userData: string): string =>
   join(userData, ZUSE_SQLITE_FILENAME);
@@ -28,6 +47,57 @@ const exists = async (path: string): Promise<boolean> => {
   } catch {
     return false;
   }
+};
+
+const projectCount = (path: string): number | null => {
+  try {
+    const db = new Database(path, { readonly: true, fileMustExist: true });
+    try {
+      const hasProjects = db
+        .prepare(
+          "SELECT count(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'projects'",
+        )
+        .get();
+      if (typeof hasProjects?.count !== "number" || !hasProjects.count) {
+        return 0;
+      }
+
+      const projects = db
+        .prepare("SELECT count(*) AS count FROM projects")
+        .get();
+      return typeof projects?.count === "number" ? projects.count : 0;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+};
+
+const projectCountViaSqliteCli = async (path: string): Promise<number | null> => {
+  try {
+    const { stdout } = await execFileAsync(
+      "/usr/bin/sqlite3",
+      [
+        path,
+        "SELECT CASE WHEN EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'projects') THEN (SELECT count(*) FROM projects) ELSE 0 END;",
+      ],
+      { timeout: 2_000 },
+    );
+    const count = Number(stdout.trim());
+    return Number.isFinite(count) ? count : null;
+  } catch {
+    return null;
+  }
+};
+
+const detectedProjectCount = async (path: string): Promise<number | null> =>
+  projectCount(path) ?? (await projectCountViaSqliteCli(path));
+
+const looksEmpty = async (path: string): Promise<boolean> => {
+  const projects = await detectedProjectCount(path);
+  if (projects !== null) return projects === 0;
+  return (await stat(path)).size <= EMPTY_SQLITE_MAX_BYTES;
 };
 
 const legacySiblingDbCandidates = async (
@@ -51,12 +121,19 @@ const newestNonEmptyLegacyDb = async (
   const withStats = await Promise.all(
     candidates.map(async (path) => ({
       path,
+      projects: await detectedProjectCount(path),
       stats: await stat(path),
     })),
   );
   const nonEmpty = withStats
-    .filter((candidate) => candidate.stats.size > EMPTY_SQLITE_MAX_BYTES)
+    .filter((candidate) =>
+      candidate.projects !== null
+        ? candidate.projects > 0
+        : candidate.stats.size > EMPTY_SQLITE_MAX_BYTES,
+    )
     .sort((a, b) => {
+      const projectDiff = (b.projects ?? 0) - (a.projects ?? 0);
+      if (projectDiff !== 0) return projectDiff;
       const sizeDiff = b.stats.size - a.stats.size;
       if (sizeDiff !== 0) return sizeDiff;
       return b.stats.mtimeMs - a.stats.mtimeMs;
@@ -91,8 +168,7 @@ export const ensureSqliteRenameCompatibility = async (
 ): Promise<void> => {
   const current = sqliteDbPath(userData);
   if (await exists(current)) {
-    const currentStats = await stat(current);
-    if (currentStats.size > EMPTY_SQLITE_MAX_BYTES) return;
+    if (!(await looksEmpty(current))) return;
 
     const legacySibling = await newestNonEmptyLegacyDb(userData);
     if (legacySibling === null) return;

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.8.3",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Zuse data migration now checks the actual project count before deciding whether the new `Zuse Alpha` database is empty. This recovers users who already launched Zuse once and have a migrated schema with no projects."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.8.2",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- bump desktop release metadata to `0.8.3`
- detect whether an existing Zuse database is empty by checking its actual project count, not just file size
- fall back to macOS `sqlite3` when `better-sqlite3` cannot load in local/test runtimes
- keep backing up the empty Zuse database before copying legacy memoize data forward

## Root cause
A user can launch Zuse once before migration succeeds. That creates a valid migrated `Zuse Alpha/zuse.sqlite` schema with zero projects, and the file grows beyond the previous tiny-file threshold. The `0.8.2` migration would then treat that empty-but-migrated DB as real data and skip copying `memoize Alpha/memoize.sqlite`.

## Local production verification
- Before: `~/Library/Application Support/Zuse Alpha/zuse.sqlite` had 0 projects
- Legacy source: `~/Library/Application Support/memoize Alpha/memoize.sqlite` had 6 projects
- Ran the corrected migration against the real production folder
- After: `~/Library/Application Support/Zuse Alpha/zuse.sqlite` has 6 projects
- Empty Zuse DB backup was created as `zuse.sqlite.empty-before-zuse-migration-*`

## Test
- `bun run --filter @zuse/server test -- test/db-path.test.ts`
- `bun run --filter @zuse/server check-types`
- `bun run build:desktop`