### PR TITLE
[codex] clean model picker

### DIFF
--- a/apps/renderer/src/components/cost-footer.tsx
+++ b/apps/renderer/src/components/cost-footer.tsx
@@ -12,13 +12,13 @@ import { useMessagesStore } from "../store/messages.ts";
 const EMPTY: ReadonlyArray<Message> = [];
 
 const MODEL_LABEL: Record<string, string> = {
+  "claude-sonnet-5": "Sonnet",
   "claude-opus-4-7": "Opus",
   "claude-sonnet-4-6": "Sonnet",
   "claude-haiku-4-5": "Haiku",
 };
 
-const labelForModel = (model: string): string =>
-  MODEL_LABEL[model] ?? model;
+const labelForModel = (model: string): string => MODEL_LABEL[model] ?? model;
 
 const formatTokens = (n: number): string => {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -47,7 +47,12 @@ const newBucket = (): UsageBucket => ({
 
 const addBucket = (
   acc: UsageBucket,
-  delta: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number },
+  delta: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  },
 ): void => {
   acc.inputTokens += delta.inputTokens;
   acc.outputTokens += delta.outputTokens;

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -26,6 +26,7 @@ import type {
 import {
   MODELS_BY_PROVIDER,
   findModelDescriptor,
+  isModelVisible,
   type Message,
   type SelectOptionDescriptor,
 } from "@zuse/wire";
@@ -102,6 +103,9 @@ export function ModelPicker(props: ModelPickerProps) {
     (s) => s.defaultModelByProvider,
   );
   const providerEnabled = useSettingsStore((s) => s.providerEnabled);
+  const modelEnabledByProvider = useSettingsStore(
+    (s) => s.modelEnabledByProvider,
+  );
 
   const providerId = isDefault ? defaultProviderId : props.providerId;
   const currentModel = isDefault
@@ -203,6 +207,9 @@ export function ModelPicker(props: ModelPickerProps) {
     const out: ModelPickerEntry[] = [];
     for (const pid of pickableProviders) {
       for (const m of modelsForProvider(pid)) {
+        const visible = isModelVisible(pid, m.id, modelEnabledByProvider);
+        const selectedHidden = pid === providerId && m.id === currentModel;
+        if (!visible && !selectedHidden) continue;
         const descriptor = findModelDescriptor(pid, m.id);
         const ctxDescriptor = descriptor?.optionDescriptors?.find(
           (d): d is SelectOptionDescriptor =>
@@ -226,7 +233,13 @@ export function ModelPicker(props: ModelPickerProps) {
       }
     }
     return out;
-  }, [pickableProviders, modelsForProvider]);
+  }, [
+    pickableProviders,
+    modelsForProvider,
+    modelEnabledByProvider,
+    providerId,
+    currentModel,
+  ]);
 
   const countByProvider = useMemo(() => {
     const map = new globalThis.Map<ProviderId, number>();
@@ -258,10 +271,15 @@ export function ModelPicker(props: ModelPickerProps) {
         (m) => m.providerId === r.providerId && m.modelId === r.modelId,
       );
       if (match === undefined) continue;
+      if (
+        !isModelVisible(match.providerId, match.modelId, modelEnabledByProvider)
+      ) {
+        continue;
+      }
       out.push({ ...match, count: r.count });
     }
     return out;
-  }, [events, scope, allModels]);
+  }, [events, scope, allModels, modelEnabledByProvider]);
 
   const accordionGroups = useMemo(() => {
     if (scope !== "all" || query.trim() !== "") return [];
@@ -506,7 +524,7 @@ export function ModelPicker(props: ModelPickerProps) {
 
               {inAccordionView ? (
                 <>
-                  <SectionLabel title={`all ${totalCount} by provider`} />
+                  <SectionLabel title="Models" />
                   {accordionGroups.map((g) => {
                     const expanded = expandedGroup === g.providerId;
                     return (
@@ -517,7 +535,7 @@ export function ModelPicker(props: ModelPickerProps) {
                             setExpandedGroup(expanded ? null : g.providerId)
                           }
                           aria-expanded={expanded}
-                          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/60"
+                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted/60"
                         >
                           <span className="flex size-3 items-center justify-center text-muted-foreground">
                             {expanded ? (
@@ -534,17 +552,17 @@ export function ModelPicker(props: ModelPickerProps) {
                           </span>
                           <ProviderIcon
                             providerId={g.providerId}
-                            className="size-3.5"
+                            className="size-4"
                           />
                           <span className="flex-1 font-medium">
                             {PROVIDER_LABEL[g.providerId]}
                           </span>
-                          <span className="text-muted-foreground text-xs">
-                            {g.models.length}
+                          <span className="text-muted-foreground text-[11px] tabular-nums">
+                            {g.models.length} shown
                           </span>
                         </button>
                         {expanded && (
-                          <div className="ml-3 border-l border-border/60 pl-2">
+                          <div className="ml-3 border-l border-border/60 pl-2 pb-1">
                             {g.models.map((m) => (
                               <ModelRow
                                 key={`${m.providerId}-${m.modelId}`}
@@ -736,6 +754,13 @@ function ModelRow({
           icon={ArrowUpRight01Icon}
           className="size-3 text-muted-foreground/70"
           aria-label="Open in new tab"
+        />
+      )}
+      {isActive && (
+        <HugeiconsIcon
+          icon={Tick01Icon}
+          className="size-3.5 shrink-0 text-primary"
+          aria-label="Selected"
         />
       )}
       {countSuffix !== undefined && (

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -1,20 +1,11 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowDown01Icon,
-  ArrowRight01Icon,
   ArrowUpRight01Icon,
   Search01Icon,
   Tick01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   AgentAvailability,
@@ -57,12 +48,12 @@ const PROVIDER_LABEL: Record<ProviderId, string> = {
 };
 
 const PROVIDER_CHIP_LABEL: Record<ProviderId, string> = {
-  claude: "claude",
-  codex: "codex",
-  grok: "grok",
-  cursor: "cursor",
-  gemini: "gemini",
-  opencode: "oc",
+  claude: "Claude",
+  codex: "Codex",
+  grok: "Grok",
+  cursor: "Cursor",
+  gemini: "Gemini",
+  opencode: "OpenCode",
 };
 
 interface ModelPickerEntry {
@@ -144,9 +135,6 @@ export function ModelPicker(props: ModelPickerProps) {
   const [query, setQuery] = useState("");
   const [scope, setScope] = useState<Scope>("all");
   const [events, setEvents] = useState<ModelPickerEvent[]>([]);
-  const [expandedGroup, setExpandedGroup] = useState<ProviderId | null>(
-    providerId,
-  );
   // Inline feedback for failed picks. The session-mode handlers
   // (createSession / setSessionProvider / setSessionModel) used to fire-
   // and-forget, so a failed switch (cursor-agent not installed, ACP
@@ -168,11 +156,10 @@ export function ModelPicker(props: ModelPickerProps) {
       setQuery("");
       setEvents(readModelPickerEvents());
       setScope("all");
-      setExpandedGroup(providerId);
       setPickError(null);
       setPicking(false);
     }
-  }, [open, providerId]);
+  }, [open]);
 
   const modelsForProvider = useCallback(
     (pid: ProviderId): ReadonlyArray<{ id: string; label: string }> => {
@@ -281,8 +268,8 @@ export function ModelPicker(props: ModelPickerProps) {
     return out;
   }, [events, scope, allModels, modelEnabledByProvider]);
 
-  const accordionGroups = useMemo(() => {
-    if (scope !== "all" || query.trim() !== "") return [];
+  const modelGroups = useMemo(() => {
+    if (scope !== "all") return [];
     const order: ProviderId[] = [
       providerId,
       ...pickableProviders.filter((p) => p !== providerId),
@@ -293,7 +280,7 @@ export function ModelPicker(props: ModelPickerProps) {
         models: allModels.filter((m) => m.providerId === pid),
       }))
       .filter((g) => g.models.length > 0);
-  }, [scope, query, allModels, pickableProviders, providerId]);
+  }, [scope, allModels, pickableProviders, providerId]);
 
   const handlePick = async (pid: ProviderId, modelId: string) => {
     if (isDefault) {
@@ -354,9 +341,9 @@ export function ModelPicker(props: ModelPickerProps) {
   const showEmpty =
     flatMatches.length === 0 &&
     scopedRecents.length === 0 &&
-    accordionGroups.length === 0;
+    modelGroups.length === 0;
 
-  const inAccordionView = scope === "all" && query.trim() === "";
+  const inGroupedView = scope === "all" && query.trim() === "";
 
   const shortcutTargets = useMemo<ModelPickerEntry[]>(() => {
     const out: ModelPickerEntry[] = [];
@@ -367,20 +354,13 @@ export function ModelPicker(props: ModelPickerProps) {
         label: r.label,
       });
     }
-    if (inAccordionView) {
-      const group = accordionGroups.find((g) => g.providerId === expandedGroup);
-      if (group !== undefined) out.push(...group.models);
+    if (inGroupedView) {
+      for (const group of modelGroups) out.push(...group.models);
     } else {
       out.push(...flatMatches);
     }
     return out;
-  }, [
-    scopedRecents,
-    inAccordionView,
-    accordionGroups,
-    expandedGroup,
-    flatMatches,
-  ]);
+  }, [scopedRecents, inGroupedView, modelGroups, flatMatches]);
 
   // STABLE REFS — this is the fix so shortcuts actually work while the
   // composer editor is focused and causing re-renders.
@@ -438,173 +418,150 @@ export function ModelPicker(props: ModelPickerProps) {
         >
           <PopoverPrimitive.Popup
             ref={popupRef}
-            className="flex max-h-[480px] w-[320px] flex-col overflow-hidden rounded-lg border border-border/70 bg-popover text-popover-foreground shadow-lg/10 outline-none"
+            className="flex max-h-[540px] w-[430px] overflow-hidden rounded-xl border border-border/70 bg-popover text-popover-foreground shadow-xl/15 outline-none"
           >
-            <div className="flex flex-col gap-1.5 p-2.5">
-              <SearchField
-                value={query}
-                onChange={setQuery}
-                totalCount={totalCount}
-                scope={scope}
+            <div
+              role="tablist"
+              aria-label="Model provider"
+              className="flex w-11 shrink-0 flex-col items-center gap-1 border-r border-border/50 bg-muted/20 p-1.5"
+            >
+              <ProviderSidebarItem
+                active={scope === "all"}
+                onClick={() => setScope("all")}
+                label="All models"
+                count={totalCount}
               />
-              <div className="flex flex-wrap gap-1 px-0.5 pt-1">
-                <ChipButton
-                  active={scope === "all"}
-                  onClick={() => setScope("all")}
-                >
-                  <span>all</span>
-                  <ChipCount>{totalCount}</ChipCount>
-                </ChipButton>
-                {pickableProviders.map((pid) => {
-                  const live = pid === "opencode" && opencodeInventory !== null;
-                  return (
-                    <ChipButton
-                      key={pid}
-                      active={scope === pid}
-                      onClick={() => setScope(pid)}
-                    >
-                      <span>{PROVIDER_CHIP_LABEL[pid]}</span>
-                      <ChipCount>{countByProvider.get(pid) ?? 0}</ChipCount>
-                      {live && (
-                        <span
-                          className="size-1.5 rounded-full bg-primary"
-                          title="Live from local daemon"
-                        />
-                      )}
-                    </ChipButton>
-                  );
-                })}
-              </div>
+              {pickableProviders.map((pid) => {
+                const live = pid === "opencode" && opencodeInventory !== null;
+                return (
+                  <ProviderSidebarItem
+                    key={pid}
+                    active={scope === pid}
+                    onClick={() => setScope(pid)}
+                    providerId={pid}
+                    label={PROVIDER_CHIP_LABEL[pid]}
+                    count={countByProvider.get(pid) ?? 0}
+                    live={live}
+                  />
+                );
+              })}
             </div>
 
-            {pickError !== null && (
-              <div className="mx-2.5 mb-1.5 flex items-start gap-2 rounded-md border border-rose-400/30 bg-rose-500/[0.08] px-2.5 py-2 text-[11px] text-rose-200">
-                <span className="mt-px shrink-0">⚠</span>
-                <span className="leading-snug">{pickError}</span>
+            <div className="flex min-w-0 flex-1 flex-col">
+              <div className="border-b border-border/50 p-2.5">
+                <SearchField
+                  value={query}
+                  onChange={setQuery}
+                  totalCount={totalCount}
+                  scope={scope}
+                />
               </div>
-            )}
 
-            <div
-              className={cn(
-                "flex-1 overflow-y-auto px-2 pb-2",
-                picking && "pointer-events-none opacity-60",
-              )}
-            >
-              {showEmpty && (
-                <div className="px-3 py-6 text-center text-muted-foreground text-xs">
-                  No models match.
+              {pickError !== null && (
+                <div className="mx-2.5 mt-2 flex items-start gap-2 rounded-md border border-rose-400/30 bg-rose-500/[0.08] px-2.5 py-2 text-[11px] text-rose-200">
+                  <span className="mt-px shrink-0">⚠</span>
+                  <span className="leading-snug">{pickError}</span>
                 </div>
               )}
 
-              {scopedRecents.length > 0 && (
-                <>
-                  <SectionLabel
-                    title={
-                      scope === "all"
-                        ? "recents"
-                        : `recents in ${PROVIDER_CHIP_LABEL[scope]}`
-                    }
-                    meta="last 30 days"
-                  />
-                  {scopedRecents.map((m) => (
-                    <ModelRow
-                      key={`recent-${m.providerId}-${m.modelId}`}
-                      entry={m}
-                      currentProviderId={providerId}
-                      currentModelId={currentModel}
-                      isFresh={isFresh}
-                      onSelect={handlePick}
-                      countSuffix={`${m.count}×`}
-                      showNowBadge
-                      shortcut={shortcutFor(m.providerId, m.modelId)}
-                    />
-                  ))}
-                </>
-              )}
+              <div
+                className={cn(
+                  "min-h-0 flex-1 overflow-y-auto px-2.5 pb-2.5",
+                  picking && "pointer-events-none opacity-60",
+                )}
+              >
+                {showEmpty && (
+                  <div className="px-3 py-6 text-center text-muted-foreground text-xs">
+                    No models match.
+                  </div>
+                )}
 
-              {inAccordionView ? (
-                <>
-                  <SectionLabel title="Models" />
-                  {accordionGroups.map((g) => {
-                    const expanded = expandedGroup === g.providerId;
-                    return (
-                      <div key={g.providerId}>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setExpandedGroup(expanded ? null : g.providerId)
-                          }
-                          aria-expanded={expanded}
-                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted/60"
-                        >
-                          <span className="flex size-3 items-center justify-center text-muted-foreground">
-                            {expanded ? (
-                              <HugeiconsIcon
-                                icon={ArrowDown01Icon}
-                                className="size-3"
-                              />
-                            ) : (
-                              <HugeiconsIcon
-                                icon={ArrowRight01Icon}
-                                className="size-3"
-                              />
-                            )}
-                          </span>
-                          <ProviderIcon
-                            providerId={g.providerId}
-                            className="size-4"
-                          />
-                          <span className="flex-1 font-medium">
-                            {PROVIDER_LABEL[g.providerId]}
-                          </span>
-                          <span className="text-muted-foreground text-[11px] tabular-nums">
-                            {g.models.length} shown
-                          </span>
-                        </button>
-                        {expanded && (
-                          <div className="ml-3 border-l border-border/60 pl-2 pb-1">
-                            {g.models.map((m) => (
-                              <ModelRow
-                                key={`${m.providerId}-${m.modelId}`}
-                                entry={m}
-                                currentProviderId={providerId}
-                                currentModelId={currentModel}
-                                isFresh={isFresh}
-                                onSelect={handlePick}
-                                dense
-                                shortcut={shortcutFor(m.providerId, m.modelId)}
-                              />
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </>
-              ) : (
-                flatMatches.length > 0 && (
+                {scopedRecents.length > 0 && (
                   <>
                     <SectionLabel
                       title={
                         scope === "all"
-                          ? `${flatMatches.length} match${flatMatches.length === 1 ? "" : "es"}`
-                          : `all ${flatMatches.length} models`
+                          ? "recents"
+                          : `recents in ${PROVIDER_CHIP_LABEL[scope]}`
                       }
+                      meta="last 30 days"
                     />
-                    {flatMatches.map((m) => (
-                      <ModelRow
-                        key={`${m.providerId}-${m.modelId}`}
-                        entry={m}
-                        currentProviderId={providerId}
-                        currentModelId={currentModel}
-                        isFresh={isFresh}
-                        onSelect={handlePick}
-                        shortcut={shortcutFor(m.providerId, m.modelId)}
-                      />
+                    <div className="flex flex-col gap-0.5">
+                      {scopedRecents.map((m) => (
+                        <ModelRow
+                          key={`recent-${m.providerId}-${m.modelId}`}
+                          entry={m}
+                          currentProviderId={providerId}
+                          currentModelId={currentModel}
+                          isFresh={isFresh}
+                          onSelect={handlePick}
+                          countSuffix={`${m.count}×`}
+                          showNowBadge
+                          shortcut={shortcutFor(m.providerId, m.modelId)}
+                          showProvider
+                        />
+                      ))}
+                    </div>
+                  </>
+                )}
+
+                {inGroupedView ? (
+                  <>
+                    <SectionLabel title="Models" />
+                    {modelGroups.map((g) => (
+                      <div
+                        key={g.providerId}
+                        className="border-t border-border/50 py-2 first:border-t-0 first:pt-0"
+                      >
+                        <ProviderSectionHeader
+                          providerId={g.providerId}
+                          count={g.models.length}
+                          current={g.providerId === providerId}
+                        />
+                        <div className="flex flex-col gap-0.5">
+                          {g.models.map((m) => (
+                            <ModelRow
+                              key={`${m.providerId}-${m.modelId}`}
+                              entry={m}
+                              currentProviderId={providerId}
+                              currentModelId={currentModel}
+                              isFresh={isFresh}
+                              onSelect={handlePick}
+                              shortcut={shortcutFor(m.providerId, m.modelId)}
+                            />
+                          ))}
+                        </div>
+                      </div>
                     ))}
                   </>
-                )
-              )}
+                ) : (
+                  flatMatches.length > 0 && (
+                    <>
+                      <SectionLabel
+                        title={
+                          scope === "all"
+                            ? `${flatMatches.length} match${flatMatches.length === 1 ? "" : "es"}`
+                            : `${flatMatches.length} model${flatMatches.length === 1 ? "" : "s"}`
+                        }
+                      />
+                      <div className="flex flex-col gap-0.5">
+                        {flatMatches.map((m) => (
+                          <ModelRow
+                            key={`${m.providerId}-${m.modelId}`}
+                            entry={m}
+                            currentProviderId={providerId}
+                            currentModelId={currentModel}
+                            isFresh={isFresh}
+                            onSelect={handlePick}
+                            shortcut={shortcutFor(m.providerId, m.modelId)}
+                            showProvider={scope === "all"}
+                          />
+                        ))}
+                      </div>
+                    </>
+                  )
+                )}
+              </div>
             </div>
           </PopoverPrimitive.Popup>
         </PopoverPrimitive.Positioner>
@@ -626,10 +583,10 @@ function SearchField({
 }) {
   const placeholder =
     scope === "all"
-      ? `filter ${totalCount} models…`
+      ? `Search ${totalCount} models`
       : `in ${PROVIDER_CHIP_LABEL[scope]}…`;
   return (
-    <div className="flex items-center gap-2 rounded-lg border bg-background px-2.5 py-1.5 focus-within:border-foreground/60 focus-within:ring-2 focus-within:ring-primary/30">
+    <div className="flex min-h-10 items-center gap-2 rounded-lg border bg-background px-3 focus-within:border-foreground/60 focus-within:ring-2 focus-within:ring-primary/30">
       <HugeiconsIcon
         icon={Search01Icon}
         className="size-3.5 text-muted-foreground"
@@ -640,41 +597,81 @@ function SearchField({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         autoFocus
-        className="flex-1 bg-transparent text-foreground text-sm outline-none placeholder:text-muted-foreground/70"
+        className="min-w-0 flex-1 bg-transparent text-foreground text-sm outline-none placeholder:text-muted-foreground/70"
       />
     </div>
   );
 }
 
-function ChipButton({
+function ProviderSidebarItem({
   active,
   onClick,
-  children,
+  label,
+  providerId,
+  live = false,
 }: {
   active: boolean;
   onClick: () => void;
-  children: ReactNode;
+  label: string;
+  count: number;
+  providerId?: ProviderId;
+  live?: boolean;
 }) {
+  const title = `${label} models`;
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-pressed={active}
+      role="tab"
+      aria-selected={active}
+      aria-label={title}
+      title={title}
       className={cn(
-        "flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-[11px] transition-colors",
+        "relative flex size-8 shrink-0 items-center justify-center rounded-md text-[11px] transition-colors",
         active
-          ? "border-primary bg-primary text-primary-foreground"
-          : "border-border bg-background text-foreground hover:bg-muted/60",
+          ? "bg-primary/12 text-foreground ring-1 ring-primary/20"
+          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
       )}
     >
-      {children}
+      {providerId !== undefined ? (
+        <ProviderIcon providerId={providerId} className="size-3.5 shrink-0" />
+      ) : (
+        <span className="font-semibold">All</span>
+      )}
+      {live && (
+        <span
+          className="absolute right-1 bottom-1 size-1.5 rounded-full bg-primary"
+          title="Live from local daemon"
+        />
+      )}
     </button>
   );
 }
 
-function ChipCount({ children }: { children: ReactNode }) {
+function ProviderSectionHeader({
+  providerId,
+  count,
+  current,
+}: {
+  providerId: ProviderId;
+  count: number;
+  current: boolean;
+}) {
   return (
-    <span className="text-[10px] opacity-60 tabular-nums">{children}</span>
+    <div className="flex items-center gap-2 px-2 pt-1.5 pb-1 text-xs">
+      <ProviderIcon providerId={providerId} className="size-3.5" />
+      <span className="font-medium text-foreground">
+        {PROVIDER_LABEL[providerId]}
+      </span>
+      {current && (
+        <span className="rounded bg-primary/15 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
+          Current
+        </span>
+      )}
+      <span className="ml-auto text-[10px] text-muted-foreground tabular-nums">
+        {count}
+      </span>
+    </div>
   );
 }
 
@@ -701,6 +698,7 @@ function ModelRow({
   countSuffix,
   showNowBadge = false,
   shortcut,
+  showProvider = false,
 }: {
   entry: ModelPickerEntry;
   currentProviderId: ProviderId;
@@ -711,6 +709,7 @@ function ModelRow({
   countSuffix?: string;
   showNowBadge?: boolean;
   shortcut?: number | null;
+  showProvider?: boolean;
 }) {
   const isActive =
     entry.providerId === currentProviderId && entry.modelId === currentModelId;
@@ -723,10 +722,10 @@ function ModelRow({
       aria-current={isActive || undefined}
       title={opensNewTab ? "Open in new tab" : undefined}
       className={cn(
-        "group relative flex w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors",
+        "group relative flex min-h-10 w-full items-center gap-2 rounded-md px-2.5 text-left text-sm transition-colors",
         dense ? "py-1" : "py-1.5",
         isActive
-          ? "bg-primary/12 text-foreground"
+          ? "bg-primary/12 text-foreground ring-1 ring-primary/20"
           : "text-foreground hover:bg-muted/60",
       )}
     >
@@ -736,18 +735,27 @@ function ModelRow({
       {!dense && (
         <ProviderIcon
           providerId={entry.providerId}
-          className="size-3.5 shrink-0 text-muted-foreground"
+          className="size-4 shrink-0 text-muted-foreground"
         />
       )}
-      <span className="truncate">{entry.label}</span>
-      {entry.contextWindowLabel !== undefined && (
-        <span
-          title={`${entry.contextWindowLabel} context window`}
-          className="rounded bg-muted/70 px-1 py-px text-[10px] font-medium text-muted-foreground"
-        >
-          {entry.contextWindowLabel}
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate font-medium">{entry.label}</span>
+          {entry.contextWindowLabel !== undefined && (
+            <span
+              title={`${entry.contextWindowLabel} context window`}
+              className="shrink-0 rounded bg-muted/70 px-1 py-px text-[10px] font-medium text-muted-foreground"
+            >
+              {entry.contextWindowLabel}
+            </span>
+          )}
         </span>
-      )}
+        {showProvider && (
+          <span className="truncate text-[11px] text-muted-foreground">
+            {PROVIDER_LABEL[entry.providerId]}
+          </span>
+        )}
+      </span>
       <span className="flex-1" />
       {opensNewTab && (
         <HugeiconsIcon

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -1,7 +1,6 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowDown01Icon,
-  ArrowRight01Icon,
   ArrowUpRight01Icon,
   Search01Icon,
   Tick01Icon,
@@ -144,9 +143,6 @@ export function ModelPicker(props: ModelPickerProps) {
   const [query, setQuery] = useState("");
   const [scope, setScope] = useState<Scope>("all");
   const [events, setEvents] = useState<ModelPickerEvent[]>([]);
-  const [expandedGroup, setExpandedGroup] = useState<ProviderId | null>(
-    providerId,
-  );
   // Inline feedback for failed picks. The session-mode handlers
   // (createSession / setSessionProvider / setSessionModel) used to fire-
   // and-forget, so a failed switch (cursor-agent not installed, ACP
@@ -168,11 +164,10 @@ export function ModelPicker(props: ModelPickerProps) {
       setQuery("");
       setEvents(readModelPickerEvents());
       setScope("all");
-      setExpandedGroup(providerId);
       setPickError(null);
       setPicking(false);
     }
-  }, [open, providerId]);
+  }, [open]);
 
   const modelsForProvider = useCallback(
     (pid: ProviderId): ReadonlyArray<{ id: string; label: string }> => {
@@ -368,19 +363,12 @@ export function ModelPicker(props: ModelPickerProps) {
       });
     }
     if (inAccordionView) {
-      const group = accordionGroups.find((g) => g.providerId === expandedGroup);
-      if (group !== undefined) out.push(...group.models);
+      for (const group of accordionGroups) out.push(...group.models);
     } else {
       out.push(...flatMatches);
     }
     return out;
-  }, [
-    scopedRecents,
-    inAccordionView,
-    accordionGroups,
-    expandedGroup,
-    flatMatches,
-  ]);
+  }, [scopedRecents, inAccordionView, accordionGroups, flatMatches]);
 
   // STABLE REFS — this is the fix so shortcuts actually work while the
   // composer editor is focused and causing re-renders.
@@ -525,61 +513,36 @@ export function ModelPicker(props: ModelPickerProps) {
               {inAccordionView ? (
                 <>
                   <SectionLabel title="Models" />
-                  {accordionGroups.map((g) => {
-                    const expanded = expandedGroup === g.providerId;
-                    return (
-                      <div key={g.providerId}>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setExpandedGroup(expanded ? null : g.providerId)
-                          }
-                          aria-expanded={expanded}
-                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted/60"
-                        >
-                          <span className="flex size-3 items-center justify-center text-muted-foreground">
-                            {expanded ? (
-                              <HugeiconsIcon
-                                icon={ArrowDown01Icon}
-                                className="size-3"
-                              />
-                            ) : (
-                              <HugeiconsIcon
-                                icon={ArrowRight01Icon}
-                                className="size-3"
-                              />
-                            )}
-                          </span>
-                          <ProviderIcon
-                            providerId={g.providerId}
-                            className="size-4"
-                          />
-                          <span className="flex-1 font-medium">
-                            {PROVIDER_LABEL[g.providerId]}
-                          </span>
-                          <span className="text-muted-foreground text-[11px] tabular-nums">
-                            {g.models.length} shown
-                          </span>
-                        </button>
-                        {expanded && (
-                          <div className="ml-3 border-l border-border/60 pl-2 pb-1">
-                            {g.models.map((m) => (
-                              <ModelRow
-                                key={`${m.providerId}-${m.modelId}`}
-                                entry={m}
-                                currentProviderId={providerId}
-                                currentModelId={currentModel}
-                                isFresh={isFresh}
-                                onSelect={handlePick}
-                                dense
-                                shortcut={shortcutFor(m.providerId, m.modelId)}
-                              />
-                            ))}
-                          </div>
-                        )}
+                  {accordionGroups.map((g) => (
+                    <div key={g.providerId} className="pb-1">
+                      <div className="flex w-full items-center gap-2 px-2 py-2 text-left text-sm">
+                        <ProviderIcon
+                          providerId={g.providerId}
+                          className="size-4"
+                        />
+                        <span className="flex-1 font-medium">
+                          {PROVIDER_LABEL[g.providerId]}
+                        </span>
+                        <span className="text-muted-foreground text-[11px] tabular-nums">
+                          {g.models.length} shown
+                        </span>
                       </div>
-                    );
-                  })}
+                      <div className="ml-3 border-l border-border/60 pl-2 pb-1">
+                        {g.models.map((m) => (
+                          <ModelRow
+                            key={`${m.providerId}-${m.modelId}`}
+                            entry={m}
+                            currentProviderId={providerId}
+                            currentModelId={currentModel}
+                            isFresh={isFresh}
+                            onSelect={handlePick}
+                            dense
+                            shortcut={shortcutFor(m.providerId, m.modelId)}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
                 </>
               ) : (
                 flatMatches.length > 0 && (

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -1,6 +1,7 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowDown01Icon,
+  ArrowRight01Icon,
   ArrowUpRight01Icon,
   Search01Icon,
   Tick01Icon,
@@ -143,6 +144,9 @@ export function ModelPicker(props: ModelPickerProps) {
   const [query, setQuery] = useState("");
   const [scope, setScope] = useState<Scope>("all");
   const [events, setEvents] = useState<ModelPickerEvent[]>([]);
+  const [expandedGroup, setExpandedGroup] = useState<ProviderId | null>(
+    providerId,
+  );
   // Inline feedback for failed picks. The session-mode handlers
   // (createSession / setSessionProvider / setSessionModel) used to fire-
   // and-forget, so a failed switch (cursor-agent not installed, ACP
@@ -164,10 +168,11 @@ export function ModelPicker(props: ModelPickerProps) {
       setQuery("");
       setEvents(readModelPickerEvents());
       setScope("all");
+      setExpandedGroup(providerId);
       setPickError(null);
       setPicking(false);
     }
-  }, [open]);
+  }, [open, providerId]);
 
   const modelsForProvider = useCallback(
     (pid: ProviderId): ReadonlyArray<{ id: string; label: string }> => {
@@ -363,12 +368,19 @@ export function ModelPicker(props: ModelPickerProps) {
       });
     }
     if (inAccordionView) {
-      for (const group of accordionGroups) out.push(...group.models);
+      const group = accordionGroups.find((g) => g.providerId === expandedGroup);
+      if (group !== undefined) out.push(...group.models);
     } else {
       out.push(...flatMatches);
     }
     return out;
-  }, [scopedRecents, inAccordionView, accordionGroups, flatMatches]);
+  }, [
+    scopedRecents,
+    inAccordionView,
+    accordionGroups,
+    expandedGroup,
+    flatMatches,
+  ]);
 
   // STABLE REFS — this is the fix so shortcuts actually work while the
   // composer editor is focused and causing re-renders.
@@ -513,36 +525,61 @@ export function ModelPicker(props: ModelPickerProps) {
               {inAccordionView ? (
                 <>
                   <SectionLabel title="Models" />
-                  {accordionGroups.map((g) => (
-                    <div key={g.providerId} className="pb-1">
-                      <div className="flex w-full items-center gap-2 px-2 py-2 text-left text-sm">
-                        <ProviderIcon
-                          providerId={g.providerId}
-                          className="size-4"
-                        />
-                        <span className="flex-1 font-medium">
-                          {PROVIDER_LABEL[g.providerId]}
-                        </span>
-                        <span className="text-muted-foreground text-[11px] tabular-nums">
-                          {g.models.length} shown
-                        </span>
-                      </div>
-                      <div className="ml-3 border-l border-border/60 pl-2 pb-1">
-                        {g.models.map((m) => (
-                          <ModelRow
-                            key={`${m.providerId}-${m.modelId}`}
-                            entry={m}
-                            currentProviderId={providerId}
-                            currentModelId={currentModel}
-                            isFresh={isFresh}
-                            onSelect={handlePick}
-                            dense
-                            shortcut={shortcutFor(m.providerId, m.modelId)}
+                  {accordionGroups.map((g) => {
+                    const expanded = expandedGroup === g.providerId;
+                    return (
+                      <div key={g.providerId}>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedGroup(expanded ? null : g.providerId)
+                          }
+                          aria-expanded={expanded}
+                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted/60"
+                        >
+                          <span className="flex size-3 items-center justify-center text-muted-foreground">
+                            {expanded ? (
+                              <HugeiconsIcon
+                                icon={ArrowDown01Icon}
+                                className="size-3"
+                              />
+                            ) : (
+                              <HugeiconsIcon
+                                icon={ArrowRight01Icon}
+                                className="size-3"
+                              />
+                            )}
+                          </span>
+                          <ProviderIcon
+                            providerId={g.providerId}
+                            className="size-4"
                           />
-                        ))}
+                          <span className="flex-1 font-medium">
+                            {PROVIDER_LABEL[g.providerId]}
+                          </span>
+                          <span className="text-muted-foreground text-[11px] tabular-nums">
+                            {g.models.length} shown
+                          </span>
+                        </button>
+                        {expanded && (
+                          <div className="ml-3 border-l border-border/60 pl-2 pb-1">
+                            {g.models.map((m) => (
+                              <ModelRow
+                                key={`${m.providerId}-${m.modelId}`}
+                                entry={m}
+                                currentProviderId={providerId}
+                                currentModelId={currentModel}
+                                isFresh={isFresh}
+                                onSelect={handlePick}
+                                dense
+                                shortcut={shortcutFor(m.providerId, m.modelId)}
+                              />
+                            ))}
+                          </div>
+                        )}
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </>
               ) : (
                 flatMatches.length > 0 && (

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -16,6 +16,7 @@ import {
   type AgentAvailability,
   type ProviderId,
   type ProviderUpdateEvent,
+  visibleModelsForProvider,
 } from "@zuse/wire";
 
 import { ApiKeyRow } from "~/components/api-key-row";
@@ -257,6 +258,7 @@ export function ProviderCard({
           />
 
           <ModelDefault providerId={providerId} />
+          <ModelVisibilitySettings providerId={providerId} />
 
           <div className="flex flex-col gap-1.5">
             <span className="text-[11px] font-medium text-muted-foreground">
@@ -275,7 +277,12 @@ function ModelDefault({ providerId }: { providerId: ProviderId }) {
     (s) => s.defaultModelByProvider[providerId] ?? "",
   );
   const setDefaultModel = useSettingsStore((s) => s.setDefaultModel);
-  const models = MODELS_BY_PROVIDER[providerId] ?? [];
+  const modelEnabledByProvider = useSettingsStore(
+    (s) => s.modelEnabledByProvider,
+  );
+  const models = visibleModelsForProvider(providerId, modelEnabledByProvider, {
+    includeModelId: value,
+  });
   const items = useMemo(
     () => models.map((m) => ({ value: m.id, label: m.label })),
     [models],
@@ -302,6 +309,67 @@ function ModelDefault({ providerId }: { providerId: ProviderId }) {
           ))}
         </SelectPopup>
       </Select>
+    </div>
+  );
+}
+
+function ModelVisibilitySettings({ providerId }: { providerId: ProviderId }) {
+  const modelEnabledByProvider = useSettingsStore(
+    (s) => s.modelEnabledByProvider,
+  );
+  const setModelEnabled = useSettingsStore((s) => s.setModelEnabled);
+  const models = MODELS_BY_PROVIDER[providerId] ?? [];
+  if (models.length <= 1) return null;
+
+  const visibleCount = models.filter(
+    (m) => modelEnabledByProvider[providerId]?.[m.id] !== false,
+  ).length;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="text-[11px] font-medium text-muted-foreground">
+          Models
+        </span>
+        <span className="text-[10px] text-muted-foreground/70">
+          {visibleCount} shown
+        </span>
+      </div>
+      <div className="overflow-hidden rounded-md border border-border/50 bg-background/45">
+        {models.map((model) => {
+          const checked =
+            modelEnabledByProvider[providerId]?.[model.id] !== false;
+          const onlyVisible = checked && visibleCount <= 1;
+          return (
+            <div
+              key={model.id}
+              className="flex min-h-9 items-center gap-2 border-b border-border/40 px-2.5 py-1.5 last:border-b-0"
+            >
+              <span className="min-w-0 flex-1 truncate text-xs text-foreground">
+                {model.label}
+              </span>
+              {model.defaultVisible === false && (
+                <span className="rounded bg-muted/70 px-1.5 py-px text-[9px] font-medium text-muted-foreground uppercase tracking-wide">
+                  older
+                </span>
+              )}
+              <Switch
+                checked={checked}
+                disabled={onlyVisible}
+                onCheckedChange={(next) =>
+                  setModelEnabled(providerId, model.id, next)
+                }
+                aria-label={`${checked ? "Hide" : "Show"} ${model.label}`}
+                title={
+                  onlyVisible
+                    ? "At least one model must stay visible"
+                    : undefined
+                }
+              />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -1,7 +1,6 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   AlertCircleIcon,
-  ArrowDown01Icon,
   CircleArrowUp01Icon,
   Copy01Icon,
   LinkSquare01Icon,
@@ -97,7 +96,6 @@ export function ProviderCard({
   availability: AgentAvailability | undefined;
   loading: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
   const subscription = SUBSCRIPTION_INFO[providerId];
   const persistedEnabled =
     useSettingsStore((s) => s.providerEnabled[providerId]) ?? true;
@@ -157,11 +155,7 @@ export function ProviderCard({
         !enabled && !unmetSubscriptionRequirement && "opacity-70",
       )}
     >
-      <button
-        type="button"
-        onClick={() => setExpanded((e) => !e)}
-        className="flex w-full items-center gap-3 px-3.5 py-3 text-left group-first:rounded-t-xl group-last:rounded-b-xl transition-colors hover:bg-muted/40"
-      >
+      <div className="flex w-full items-center gap-3 px-3.5 py-3 text-left group-first:rounded-t-xl">
         <span className="flex size-7 shrink-0 items-center justify-center">
           <ProviderIcon providerId={providerId} className="size-5" />
         </span>
@@ -217,57 +211,44 @@ export function ProviderCard({
               : undefined
           }
         />
-        <HugeiconsIcon
-          icon={ArrowDown01Icon}
-          className={cn(
-            "size-4 shrink-0 text-muted-foreground transition-transform",
-            expanded && "rotate-180",
-          )}
-          aria-hidden
-        />
-      </button>
+      </div>
 
-      {expanded && (
-        <div
-          className={cn(
-            "flex flex-col gap-4 border-t border-border/40 px-3.5 py-3 text-xs",
-            !enabled && "pointer-events-none",
-          )}
-        >
-          {showUpgrade && (
-            <CodeRow
-              label="Update CLI"
-              command={
-                availability?.cliUpgradeCommand ?? INSTALL_HINT[providerId]
-              }
-            />
-          )}
-          {availability !== undefined && !availability.cliInstalled && (
-            <CodeRow label="Install" command={INSTALL_HINT[providerId]} />
-          )}
-          {availability?.cliInstalled &&
-            availability.authStatus === "unauthenticated" &&
-            (providerId === "cursor" || providerId === "claude" ? (
-              <ProviderSignInRow providerId={providerId} />
-            ) : (
-              <CodeRow label="Sign in" command={LOGIN_HINT[providerId]} />
-            ))}
-          <SubscriptionRow
-            providerId={providerId}
-            availability={availability}
+      <div
+        className={cn(
+          "flex flex-col gap-4 border-t border-border/40 px-3.5 py-3 text-xs",
+          !enabled && "pointer-events-none",
+        )}
+      >
+        {showUpgrade && (
+          <CodeRow
+            label="Update CLI"
+            command={
+              availability?.cliUpgradeCommand ?? INSTALL_HINT[providerId]
+            }
           />
+        )}
+        {availability !== undefined && !availability.cliInstalled && (
+          <CodeRow label="Install" command={INSTALL_HINT[providerId]} />
+        )}
+        {availability?.cliInstalled &&
+          availability.authStatus === "unauthenticated" &&
+          (providerId === "cursor" || providerId === "claude" ? (
+            <ProviderSignInRow providerId={providerId} />
+          ) : (
+            <CodeRow label="Sign in" command={LOGIN_HINT[providerId]} />
+          ))}
+        <SubscriptionRow providerId={providerId} availability={availability} />
 
-          <ModelDefault providerId={providerId} />
-          <ModelVisibilitySettings providerId={providerId} />
+        <ModelDefault providerId={providerId} />
+        <ModelVisibilitySettings providerId={providerId} />
 
-          <div className="flex flex-col gap-1.5">
-            <span className="text-[11px] font-medium text-muted-foreground">
-              API key (optional)
-            </span>
-            <ApiKeyRow providerId={providerId} />
-          </div>
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">
+            API key (optional)
+          </span>
+          <ApiKeyRow providerId={providerId} />
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -813,6 +813,8 @@ function ProvidersPane() {
     "cursor",
     "opencode",
   ];
+  const [selectedProvider, setSelectedProvider] =
+    useState<ProviderId>("claude");
   const availabilityById = useMemo(() => {
     const map = new Map<ProviderId, (typeof availability)[number]>();
     for (const a of availability) map.set(a.providerId, a);
@@ -854,18 +856,47 @@ function ProvidersPane() {
             </Button>
           </div>
         </FrameHeader>
-        <Card>
-          <div className="flex flex-col divide-y divide-border/40">
-            {providers.map((pid) => (
-              <ProviderCard
-                key={pid}
-                providerId={pid}
-                availability={availabilityById.get(pid)}
-                loading={loading}
-              />
-            ))}
+        <div className="flex flex-col gap-2 px-2 pb-2">
+          <div
+            role="tablist"
+            aria-label="Provider settings"
+            className="flex min-w-0 gap-1 overflow-x-auto border-b border-border/50"
+          >
+            {providers.map((pid) => {
+              const selected = selectedProvider === pid;
+              return (
+                <button
+                  key={pid}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  onClick={() => setSelectedProvider(pid)}
+                  className={cn(
+                    "flex min-h-9 shrink-0 items-center gap-2 border-b px-2.5 text-sm transition-colors",
+                    selected
+                      ? "border-primary text-foreground"
+                      : "border-transparent text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <ProviderIcon providerId={pid} className="size-3.5" />
+                  <span>{PROVIDER_LABEL[pid]}</span>
+                  {pid === "opencode" && (
+                    <span className="rounded border border-border/60 bg-muted/70 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      New
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
-        </Card>
+          <Card>
+            <ProviderCard
+              providerId={selectedProvider}
+              availability={availabilityById.get(selectedProvider)}
+              loading={loading}
+            />
+          </Card>
+        </div>
         <FrameFooter className="px-2 py-1 w-full">
           <p className="text-xs leading-relaxed text-muted-foreground">
             Zuse Alpha uses your existing CLI credentials — Claude Code, Codex,

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -30,6 +30,7 @@ import {
   type FolderId,
   type ProviderId,
   type RuntimeMode,
+  visibleModelsForProvider,
 } from "@zuse/wire";
 
 import {
@@ -953,8 +954,14 @@ function SubagentsSection() {
   const presets = useSubagentsStore((s) => s.presets);
   const setPresetEnabled = useSubagentsStore((s) => s.setPresetEnabled);
   const setPresetOverride = useSubagentsStore((s) => s.setPresetOverride);
+  const modelEnabledByProvider = useSettingsStore(
+    (s) => s.modelEnabledByProvider,
+  );
 
-  const claudeModels = MODELS_BY_PROVIDER.claude;
+  const claudeModels = visibleModelsForProvider(
+    "claude",
+    modelEnabledByProvider,
+  );
 
   return (
     <Frame>
@@ -1572,7 +1579,12 @@ export function ModelSelect({
   value: string | null;
   onChange: (model: string) => void;
 }) {
-  const models = MODELS_BY_PROVIDER[providerId] ?? [];
+  const modelEnabledByProvider = useSettingsStore(
+    (s) => s.modelEnabledByProvider,
+  );
+  const models = visibleModelsForProvider(providerId, modelEnabledByProvider, {
+    includeModelId: value,
+  });
   const normalizedValue =
     value !== null &&
     (models.some((m) => m.id === value) || models.length === 0)
@@ -1620,6 +1632,8 @@ export function ensureValidDefaultsForRuntime(
     : ready[0]!;
   const model =
     settings.defaultModelByProvider[provider] ??
+    visibleModelsForProvider(provider, settings.modelEnabledByProvider)[0]
+      ?.id ??
     MODELS_BY_PROVIDER[provider][0]!.id;
   return {
     providerId: provider,

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -7,6 +7,7 @@ import {
   MODELS_BY_PROVIDER,
   type FolderId,
   type ProviderId,
+  visibleModelsForProvider,
 } from "@zuse/wire";
 
 import { useRepositorySettingsStore } from "../store/repository-settings.ts";
@@ -165,6 +166,9 @@ function ProviderOverrideSection({
     (s) => s.defaultModelByProvider,
   );
   const providerEnabled = useSettingsStore((s) => s.providerEnabled);
+  const modelEnabledByProvider = useSettingsStore(
+    (s) => s.modelEnabledByProvider,
+  );
   const effectiveProvider: ProviderId = defaultProviderId ?? globalProviderId;
   const globalModel = globalModelByProvider[globalProviderId];
   const globalModelLabel =
@@ -186,7 +190,9 @@ function ProviderOverrideSection({
   });
 
   const firstModelFor = (pid: ProviderId): string | null =>
-    MODELS_BY_PROVIDER[pid]?.[0]?.id ?? null;
+    visibleModelsForProvider(pid, modelEnabledByProvider)[0]?.id ??
+    MODELS_BY_PROVIDER[pid]?.[0]?.id ??
+    null;
 
   const onToggle = (next: boolean) => {
     if (next) {
@@ -231,7 +237,14 @@ function ProviderOverrideSection({
         >
           {availableProviders.map((pid) => {
             const selected = effectiveProvider === pid;
-            const models = MODELS_BY_PROVIDER[pid] ?? [];
+            const models = visibleModelsForProvider(
+              pid,
+              modelEnabledByProvider,
+              {
+                includeModelId:
+                  selected && selectedModel !== null ? selectedModel : null,
+              },
+            );
             return (
               <div
                 key={pid}
@@ -335,7 +348,10 @@ function RuntimeModeOverrideSection({
                 onClick={() => onChange(mode)}
                 className="group flex w-full items-start gap-3 border-b border-border/40 px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-muted/40"
               >
-                <HugeiconsIcon icon={m.Icon} className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <HugeiconsIcon
+                  icon={m.Icon}
+                  className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                />
                 <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                   <span className="text-sm font-medium text-foreground">
                     {m.label}
@@ -446,8 +462,8 @@ function WorktreeSection({
       <div className="flex flex-col">
         {sorted.length === 0 ? (
           <p className="px-4 py-8 text-center text-xs text-muted-foreground">
-            No worktrees yet. Zuse Alpha creates one for you when you start a new
-            chat.
+            No worktrees yet. Zuse Alpha creates one for you when you start a
+            new chat.
           </p>
         ) : (
           <ul className="flex flex-col divide-y divide-border/40">
@@ -456,11 +472,11 @@ function WorktreeSection({
                 key={wt.id}
                 className="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/20"
               >
-                <HugeiconsIcon icon={GitBranchIcon} className="size-4 shrink-0 text-muted-foreground" />
-                <div
-                  className="flex min-w-0 flex-col gap-0.5"
-                  title={wt.path}
-                >
+                <HugeiconsIcon
+                  icon={GitBranchIcon}
+                  className="size-4 shrink-0 text-muted-foreground"
+                />
+                <div className="flex min-w-0 flex-col gap-0.5" title={wt.path}>
                   <span className="truncate text-sm font-medium text-foreground">
                     {wt.name}
                   </span>

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -1,4 +1,9 @@
-import { ArrowDown01Icon, ArrowRight01Icon, ClipboardIcon, Robot01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  ClipboardIcon,
+  Robot01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -12,6 +17,7 @@ import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
 import { Spinner } from "./ui/spinner";
 
 const MODEL_LABEL: Record<string, string> = {
+  "claude-sonnet-5": "Sonnet 5",
   "claude-opus-4-7": "Opus 4.7",
   "claude-sonnet-4-6": "Sonnet 4.6",
   "claude-haiku-4-5": "Haiku 4.5",
@@ -115,7 +121,10 @@ export function SubagentRow({
       >
         <div className="relative grid size-4 shrink-0 place-items-center">
           {showActivityLoader ? (
-            <Spinner className="size-3.5 text-muted-foreground" aria-label="Agent running" />
+            <Spinner
+              className="size-3.5 text-muted-foreground"
+              aria-label="Agent running"
+            />
           ) : (
             <HugeiconsIcon
               icon={Robot01Icon}

--- a/apps/renderer/src/lib/subagent-presets.ts
+++ b/apps/renderer/src/lib/subagent-presets.ts
@@ -24,7 +24,8 @@ export const DEFAULT_SUBAGENT_PRESETS: ReadonlyArray<SubagentPreset> = [
   {
     name: "research",
     displayName: "Research",
-    summary: "Read-only codebase exploration. Find files, understand patterns, list usages.",
+    summary:
+      "Read-only codebase exploration. Find files, understand patterns, list usages.",
     definition: {
       description:
         "Read-only codebase exploration. Use when you need to find files, " +
@@ -63,7 +64,7 @@ export const DEFAULT_SUBAGENT_PRESETS: ReadonlyArray<SubagentPreset> = [
         "Don't refactor adjacent code, don't add comments, don't 'improve' " +
         "anything that isn't part of the requested change.",
       tools: ["Read", "Edit", "Write", "Glob"],
-      model: "claude-sonnet-4-6",
+      model: "claude-sonnet-5",
       maxTurns: 40,
     },
   },

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -3,8 +3,10 @@ import { create } from "zustand";
 
 import {
   type BranchNamingStyle,
+  defaultModelEnabledByProvider,
   defaultModelFor,
   type CompletionSoundPreset,
+  type ModelEnabledByProvider,
   type ProviderId,
   resolveModelSlug,
   type RuntimeMode,
@@ -52,6 +54,22 @@ const seedProviderEnabled = (): Record<ProviderId, boolean> => {
   return out;
 };
 
+const seedModelEnabledByProvider = defaultModelEnabledByProvider;
+
+const mergeModelEnabled = (
+  input: Partial<Record<ProviderId, Partial<Record<string, boolean>>>>,
+): ModelEnabledByProvider => {
+  const base = seedModelEnabledByProvider();
+  for (const id of PROVIDER_IDS) {
+    const providerFlags = input[id];
+    if (providerFlags === undefined) continue;
+    for (const [modelId, value] of Object.entries(providerFlags)) {
+      if (typeof value === "boolean") base[id][modelId] = value;
+    }
+  }
+  return base;
+};
+
 const OLD_SETTINGS_KEY = "memoize.settings.v1";
 const OLD_SUBAGENTS_KEY = "memoize.subagents";
 
@@ -64,6 +82,7 @@ const fallbackSnapshot = (): SettingsSlice => ({
   completionSoundPreset: "chime",
   onboardingCompleted: false,
   providerEnabled: seedProviderEnabled(),
+  modelEnabledByProvider: seedModelEnabledByProvider(),
   branchNamingStyle: DEFAULT_BRANCH_NAMING_STYLE,
   branchNamingPrefix: "",
 });
@@ -90,6 +109,7 @@ const sliceFromFile = (file: SettingsFile): SettingsSlice => {
       ...seedProviderEnabled(),
       ...file.providerEnabled,
     },
+    modelEnabledByProvider: mergeModelEnabled(file.modelEnabledByProvider),
     branchNamingStyle: file.branchNamingStyle,
     branchNamingPrefix: file.branchNamingPrefix,
   };
@@ -104,6 +124,7 @@ interface SettingsSlice {
   readonly completionSoundPreset: CompletionSoundPreset;
   readonly onboardingCompleted: boolean;
   readonly providerEnabled: Record<ProviderId, boolean>;
+  readonly modelEnabledByProvider: ModelEnabledByProvider;
   readonly branchNamingStyle: BranchNamingStyle;
   readonly branchNamingPrefix: string;
 }
@@ -130,6 +151,11 @@ type SettingsState = SettingsSlice & {
   readonly setCompletionSoundPreset: (preset: CompletionSoundPreset) => void;
   readonly setOnboardingCompleted: (value: boolean) => void;
   readonly setProviderEnabled: (providerId: ProviderId, value: boolean) => void;
+  readonly setModelEnabled: (
+    providerId: ProviderId,
+    modelId: string,
+    value: boolean,
+  ) => void;
   readonly setBranchNamingStyle: (style: BranchNamingStyle) => void;
   readonly setBranchNamingPrefix: (prefix: string) => void;
 };
@@ -287,6 +313,23 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const client = await getRpcClient();
       await Effect.runPromise(
         client.settings.update({ patch: { providerEnabled: next } }),
+      );
+    })();
+  },
+  setModelEnabled: (providerId, modelId, value) => {
+    const current = get().modelEnabledByProvider;
+    const next: ModelEnabledByProvider = {
+      ...current,
+      [providerId]: {
+        ...current[providerId],
+        [modelId]: value,
+      },
+    };
+    set({ modelEnabledByProvider: next });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({ patch: { modelEnabledByProvider: next } }),
       );
     })();
   },

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -6,9 +6,11 @@ import { Effect, Layer, PubSub, Ref, Stream } from "effect";
 
 import {
   type BranchNamingStyle,
+  defaultModelEnabledByProvider,
   defaultModelFor,
   type KeybindingRule,
   KeybindingsFile,
+  MODELS_BY_PROVIDER,
   MAX_KEYBINDING_RULES,
   type ProviderId,
   resolveModelSlug,
@@ -58,6 +60,8 @@ const seedProviderEnabled = (): Record<ProviderId, boolean> => {
   return out;
 };
 
+const seedModelEnabledByProvider = defaultModelEnabledByProvider;
+
 const freshSettings = (): SettingsFile =>
   SettingsFile.make({
     schemaVersion: 1,
@@ -71,6 +75,7 @@ const freshSettings = (): SettingsFile =>
     completionSoundEnabled: false,
     completionSoundPreset: "chime",
     providerEnabled: seedProviderEnabled(),
+    modelEnabledByProvider: seedModelEnabledByProvider(),
     subagents: { enableForNewSessions: true, presets: {} },
     branchNamingStyle: "username-slug",
     branchNamingPrefix: "",
@@ -89,7 +94,8 @@ const isProviderId = (v: unknown): v is ProviderId =>
   v === "codex" ||
   v === "grok" ||
   v === "cursor" ||
-  v === "gemini";
+  v === "gemini" ||
+  v === "opencode";
 
 const isRuntimeMode = (v: unknown): v is SettingsFile["defaultRuntimeMode"] =>
   v === "approval-required" ||
@@ -106,10 +112,7 @@ const isCompletionSoundPreset = (v: unknown): v is CompletionSoundPreset =>
   v === "bloom";
 
 const isBranchNamingStyle = (v: unknown): v is BranchNamingStyle =>
-  v === "username-slug" ||
-  v === "slug" ||
-  v === "feat-slug" ||
-  v === "custom";
+  v === "username-slug" || v === "slug" || v === "feat-slug" || v === "custom";
 
 /**
  * Re-shape an arbitrary parsed JSON value onto a `SettingsFile`, falling
@@ -166,14 +169,33 @@ const coerceSettings = (raw: unknown): SettingsFile => {
   const providerEnabled: Record<ProviderId, boolean> = {
     ...base.providerEnabled,
   };
-  if (
-    typeof obj.providerEnabled === "object" &&
-    obj.providerEnabled !== null
-  ) {
+  if (typeof obj.providerEnabled === "object" && obj.providerEnabled !== null) {
     const flags = obj.providerEnabled as Record<string, unknown>;
     for (const id of PROVIDER_IDS) {
       const v = flags[id];
       if (typeof v === "boolean") providerEnabled[id] = v;
+    }
+  }
+
+  const modelEnabledByProvider = seedModelEnabledByProvider();
+  if (
+    typeof obj.modelEnabledByProvider === "object" &&
+    obj.modelEnabledByProvider !== null
+  ) {
+    const byProvider = obj.modelEnabledByProvider as Record<string, unknown>;
+    for (const id of PROVIDER_IDS) {
+      const providerModels = byProvider[id];
+      if (typeof providerModels !== "object" || providerModels === null) {
+        continue;
+      }
+      const flags = providerModels as Record<string, unknown>;
+      const knownModelIds = new Set(MODELS_BY_PROVIDER[id].map((m) => m.id));
+      for (const [modelId, value] of Object.entries(flags)) {
+        if (!knownModelIds.has(modelId)) continue;
+        if (typeof value === "boolean") {
+          modelEnabledByProvider[id][modelId] = value;
+        }
+      }
     }
   }
 
@@ -222,6 +244,7 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     completionSoundEnabled,
     completionSoundPreset,
     providerEnabled,
+    modelEnabledByProvider,
     subagents,
     branchNamingStyle,
     branchNamingPrefix,
@@ -249,6 +272,10 @@ const coerceKeybindings = (raw: unknown): KeybindingsFile => {
   return KeybindingsFile.make({ schemaVersion: 1, rules });
 };
 
+export const configStoreTestHelpers = {
+  coerceSettings,
+};
+
 /* ────────────────────────── Service implementation ──────────────────────────── */
 
 export const ConfigStoreServiceLive = Layer.scoped(
@@ -267,9 +294,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
      * Read a JSON file from disk, returning the parsed object or `null` if
      * the file doesn't exist / is malformed. Other I/O failures bubble out.
      */
-    const readJsonOrNull = (
-      absPath: string,
-    ): Effect.Effect<unknown | null> =>
+    const readJsonOrNull = (absPath: string): Effect.Effect<unknown | null> =>
       Effect.gen(function* () {
         const exists = yield* fs.exists(absPath).pipe(Effect.orDie);
         if (!exists) return null;
@@ -287,9 +312,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
     // would otherwise both pick the same `<path>.tmp` and the second
     // rename ENOENTs because the first already renamed the tmp away.
     const writeLocks = new Map<string, Effect.Semaphore>();
-    const lockFor = (
-      absPath: string,
-    ): Effect.Effect<Effect.Semaphore> =>
+    const lockFor = (absPath: string): Effect.Effect<Effect.Semaphore> =>
       Effect.gen(function* () {
         const existing = writeLocks.get(absPath);
         if (existing) return existing;
@@ -450,15 +473,12 @@ export const ConfigStoreServiceLive = Layer.scoped(
     const getSettings: ConfigStoreServiceShape["getSettings"] = () =>
       Ref.get(settingsRef);
 
-    const updateSettings: ConfigStoreServiceShape["updateSettings"] = (
-      patch,
-    ) =>
+    const updateSettings: ConfigStoreServiceShape["updateSettings"] = (patch) =>
       Effect.gen(function* () {
         const cur = yield* Ref.get(settingsRef);
         const next: SettingsFile = SettingsFile.make({
           schemaVersion: 1,
-          defaultProviderId:
-            patch.defaultProviderId ?? cur.defaultProviderId,
+          defaultProviderId: patch.defaultProviderId ?? cur.defaultProviderId,
           defaultModelByProvider:
             patch.defaultModelByProvider ?? cur.defaultModelByProvider,
           defaultRuntimeMode:
@@ -472,9 +492,10 @@ export const ConfigStoreServiceLive = Layer.scoped(
           completionSoundPreset:
             patch.completionSoundPreset ?? cur.completionSoundPreset,
           providerEnabled: patch.providerEnabled ?? cur.providerEnabled,
+          modelEnabledByProvider:
+            patch.modelEnabledByProvider ?? cur.modelEnabledByProvider,
           subagents: patch.subagents ?? cur.subagents,
-          branchNamingStyle:
-            patch.branchNamingStyle ?? cur.branchNamingStyle,
+          branchNamingStyle: patch.branchNamingStyle ?? cur.branchNamingStyle,
           branchNamingPrefix:
             patch.branchNamingPrefix ?? cur.branchNamingPrefix,
         });
@@ -529,6 +550,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
           let onboarding: boolean = cur.onboardingCompleted;
           let providerEnabled: SettingsFile["providerEnabled"] =
             cur.providerEnabled;
+          let modelEnabledByProvider: SettingsFile["modelEnabledByProvider"] =
+            cur.modelEnabledByProvider;
           let subagents: SettingsFile["subagents"] = cur.subagents;
           let completionSoundEnabled = cur.completionSoundEnabled;
           let completionSoundPreset = cur.completionSoundPreset;
@@ -551,6 +574,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
               completionSoundEnabled = fromLs.completionSoundEnabled;
               completionSoundPreset = fromLs.completionSoundPreset;
               providerEnabled = fromLs.providerEnabled;
+              modelEnabledByProvider = fromLs.modelEnabledByProvider;
             } catch {
               /* swallow — keep current values */
             }
@@ -583,6 +607,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
             completionSoundEnabled,
             completionSoundPreset,
             providerEnabled,
+            modelEnabledByProvider,
             subagents,
             branchNamingStyle: cur.branchNamingStyle,
             branchNamingPrefix: cur.branchNamingPrefix,

--- a/apps/server/test/config-store.test.ts
+++ b/apps/server/test/config-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+
+import { configStoreTestHelpers } from "../src/config-store/layers/config-store-service.ts";
+
+const { coerceSettings } = configStoreTestHelpers;
+
+describe("config-store settings coercion", () => {
+  it("preserves opencode as a valid default provider", () => {
+    const settings = coerceSettings({
+      defaultProviderId: "opencode",
+      defaultModelByProvider: {
+        opencode: "openai/gpt-5",
+      },
+    });
+
+    expect(settings.defaultProviderId).toBe("opencode");
+    expect(settings.defaultModelByProvider.opencode).toBe("openai/gpt-5");
+  });
+
+  it("seeds missing model visibility from catalog defaults", () => {
+    const settings = coerceSettings({});
+
+    expect(settings.modelEnabledByProvider.claude["claude-sonnet-5"]).toBe(
+      true,
+    );
+    expect(settings.modelEnabledByProvider.claude["claude-sonnet-4-6"]).toBe(
+      false,
+    );
+    expect(settings.modelEnabledByProvider.codex["gpt-5.5"]).toBe(true);
+    expect(settings.modelEnabledByProvider.codex["gpt-5.3-codex"]).toBe(false);
+  });
+
+  it("keeps valid model visibility overrides and drops unknown model ids", () => {
+    const settings = coerceSettings({
+      modelEnabledByProvider: {
+        codex: {
+          "gpt-5.3-codex": true,
+          "not-real": true,
+        },
+      },
+    });
+
+    expect(settings.modelEnabledByProvider.codex["gpt-5.3-codex"]).toBe(true);
+    expect(settings.modelEnabledByProvider.codex["not-real"]).toBeUndefined();
+  });
+});

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -733,6 +733,11 @@ export type StartSessionInput = typeof StartSessionInput.Type;
 export interface ModelOption {
   readonly id: string;
   readonly label: string;
+  /**
+   * Whether this model appears in normal picker/default selectors before the
+   * user opts it back in from provider settings. Omitted means visible.
+   */
+  readonly defaultVisible?: boolean;
   readonly optionDescriptors?: ReadonlyArray<OptionDescriptor>;
   readonly supportsPlanMode?: boolean;
   readonly supportsWebSearch?: "native" | "queryOnly";
@@ -826,10 +831,29 @@ export const MODELS_BY_PROVIDER: Record<
   ProviderId,
   ReadonlyArray<ModelOption>
 > = {
-  // Claude 4.x catalog (May 2026). Effort tiers and per-model knobs match
+  // Claude catalog. Effort tiers and per-model knobs match
   // the published Claude Agent SDK contract. Ordering = newest first so the
-  // picker accordion expands Opus 4.8 by default.
+  // picker accordion opens on the latest recommended model by default.
   claude: [
+    {
+      id: "claude-sonnet-5",
+      label: "Sonnet 5",
+      optionDescriptors: [
+        claudeEffortDescriptor({
+          options: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "max", label: "Max" },
+            { id: "ultracode", label: "Ultracode" },
+          ],
+          defaultId: "high",
+        }),
+        claudeContextWindowDescriptor(),
+      ],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
     {
       id: "claude-opus-4-8",
       label: "Opus 4.8",
@@ -895,6 +919,7 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "claude-sonnet-4-6",
       label: "Sonnet 4.6",
+      defaultVisible: false,
       optionDescriptors: [
         claudeEffortDescriptor({
           options: [
@@ -921,6 +946,17 @@ export const MODELS_BY_PROVIDER: Record<
   ],
   codex: [
     {
+      id: "gpt-5.5",
+      label: "GPT-5.5",
+      // Fast tier supported — see gpt-5.4 note above.
+      optionDescriptors: [
+        reasoningSelectDescriptor("medium"),
+        booleanDescriptor("fastMode", "Fast"),
+      ],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
       id: "gpt-5.4",
       label: "GPT-5.4",
       // `fastMode` → `serviceTier: "fast"`. OpenAI only offers the fast tier on
@@ -942,19 +978,9 @@ export const MODELS_BY_PROVIDER: Record<
       supportsWebSearch: "native",
     },
     {
-      id: "gpt-5.5",
-      label: "GPT-5.5",
-      // Fast tier supported — see gpt-5.4 note above.
-      optionDescriptors: [
-        reasoningSelectDescriptor("medium"),
-        booleanDescriptor("fastMode", "Fast"),
-      ],
-      supportsPlanMode: true,
-      supportsWebSearch: "native",
-    },
-    {
       id: "gpt-5.3-codex",
       label: "GPT-5.3 Codex",
+      defaultVisible: false,
       optionDescriptors: [reasoningSelectDescriptor("medium")],
       supportsPlanMode: true,
       supportsWebSearch: "native",
@@ -962,6 +988,7 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "gpt-5.3-codex-spark",
       label: "GPT-5.3 Codex Spark",
+      defaultVisible: false,
       optionDescriptors: [reasoningSelectDescriptor("medium")],
       supportsPlanMode: true,
       supportsWebSearch: "native",
@@ -989,6 +1016,7 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "grok-4",
       label: "Grok 4",
+      defaultVisible: false,
       supportsPlanMode: true,
       supportsWebSearch: "queryOnly",
     },
@@ -1001,6 +1029,7 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "grok-code-fast-1",
       label: "Grok Code Fast",
+      defaultVisible: false,
       supportsPlanMode: true,
       supportsWebSearch: "queryOnly",
     },
@@ -1026,12 +1055,14 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "gemini-2.5-pro",
       label: "Gemini 2.5 Pro",
+      defaultVisible: false,
       supportsPlanMode: true,
       supportsWebSearch: "queryOnly",
     },
     {
       id: "gemini-2.5-flash",
       label: "Gemini 2.5 Flash",
+      defaultVisible: false,
       supportsPlanMode: true,
       supportsWebSearch: "queryOnly",
     },
@@ -1053,7 +1084,12 @@ export const MODELS_BY_PROVIDER: Record<
     { id: "composer-2", label: "Composer 2", supportsPlanMode: true },
     { id: "composer-2.5", label: "Composer 2.5", supportsPlanMode: true },
     { id: "gpt-5.5", label: "GPT-5.5", supportsPlanMode: true },
-    { id: "gpt-5.3-codex", label: "Codex 5.3", supportsPlanMode: true },
+    {
+      id: "gpt-5.3-codex",
+      label: "Codex 5.3",
+      defaultVisible: false,
+      supportsPlanMode: true,
+    },
     {
       id: "claude-sonnet-4-6",
       label: "Sonnet 4.6",
@@ -1063,10 +1099,16 @@ export const MODELS_BY_PROVIDER: Record<
     {
       id: "claude-opus-4-7",
       label: "Opus 4.7",
+      defaultVisible: false,
       optionDescriptors: [staticContextWindowDescriptor("1m", "1M")],
       supportsPlanMode: true,
     },
-    { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro", supportsPlanMode: true },
+    {
+      id: "gemini-3.1-pro",
+      label: "Gemini 3.1 Pro",
+      defaultVisible: false,
+      supportsPlanMode: true,
+    },
   ],
   // OpenCode is a meta-provider: it spawns a local `opencode serve` and
   // forwards prompts to whichever underlying provider (anthropic, openai,
@@ -1101,7 +1143,53 @@ export const MODELS_BY_PROVIDER: Record<
 };
 
 export const defaultModelFor = (providerId: ProviderId): string =>
-  MODELS_BY_PROVIDER[providerId][0]!.id;
+  (MODELS_BY_PROVIDER[providerId].find((m) => m.defaultVisible !== false) ??
+    MODELS_BY_PROVIDER[providerId][0]!)!.id;
+
+export type ModelEnabledByProvider = Record<
+  ProviderId,
+  Record<string, boolean>
+>;
+
+export const defaultModelEnabledByProvider = (): ModelEnabledByProvider => {
+  const out = {} as ModelEnabledByProvider;
+  for (const providerId of Object.keys(MODELS_BY_PROVIDER) as ProviderId[]) {
+    out[providerId] = {};
+    for (const model of MODELS_BY_PROVIDER[providerId]) {
+      out[providerId][model.id] = model.defaultVisible !== false;
+    }
+  }
+  return out;
+};
+
+export const isModelVisible = (
+  providerId: ProviderId,
+  modelId: string,
+  modelEnabledByProvider?: Partial<
+    Record<ProviderId, Partial<Record<string, boolean>>>
+  >,
+): boolean => {
+  const override = modelEnabledByProvider?.[providerId]?.[modelId];
+  if (typeof override === "boolean") return override;
+  const descriptor = findModelDescriptor(providerId, modelId);
+  if (descriptor === undefined) return true;
+  return descriptor.defaultVisible !== false;
+};
+
+export const visibleModelsForProvider = (
+  providerId: ProviderId,
+  modelEnabledByProvider?: Partial<
+    Record<ProviderId, Partial<Record<string, boolean>>>
+  >,
+  options?: { readonly includeModelId?: string | null },
+): ReadonlyArray<ModelOption> => {
+  const includeModelId = options?.includeModelId ?? null;
+  return MODELS_BY_PROVIDER[providerId].filter(
+    (model) =>
+      isModelVisible(providerId, model.id, modelEnabledByProvider) ||
+      model.id === includeModelId,
+  );
+};
 
 /**
  * Look up a model's descriptor by `(providerId, modelId)`. Returns
@@ -1136,7 +1224,9 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<
     "claude-opus-4.7": "claude-opus-4-7",
     "opus-4.6": "claude-opus-4-6",
     "claude-opus-4.6": "claude-opus-4-6",
-    sonnet: "claude-sonnet-4-6",
+    sonnet: "claude-sonnet-5",
+    "sonnet-5": "claude-sonnet-5",
+    "claude-sonnet-5": "claude-sonnet-5",
     "sonnet-4.6": "claude-sonnet-4-6",
     "claude-sonnet-4.6": "claude-sonnet-4-6",
     haiku: "claude-haiku-4-5",
@@ -1144,8 +1234,8 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<
     "claude-haiku-4.5": "claude-haiku-4-5",
   },
   codex: {
-    "gpt-5-codex": "gpt-5.4",
-    "gpt-5": "gpt-5.4",
+    "gpt-5-codex": "gpt-5.5",
+    "gpt-5": "gpt-5.5",
   },
   grok: {},
   gemini: {
@@ -1227,6 +1317,12 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     output: 25,
     cacheRead: 0.5,
     cacheCreate: 6.25,
+  },
+  "claude-sonnet-5": {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheCreate: 3.75,
   },
   "claude-sonnet-4-6": {
     input: 3,

--- a/packages/wire/src/settings.ts
+++ b/packages/wire/src/settings.ts
@@ -72,6 +72,14 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
     key: ProviderId,
     value: Schema.Boolean,
   }),
+  /**
+   * Per-model visibility toggles from provider settings. Missing entries are
+   * filled from each model's catalog `defaultVisible` flag by config-store.
+   */
+  modelEnabledByProvider: Schema.Record({
+    key: ProviderId,
+    value: Schema.Record({ key: Schema.String, value: Schema.Boolean }),
+  }),
   subagents: Schema.Struct({
     enableForNewSessions: Schema.Boolean,
     presets: Schema.Record({
@@ -110,6 +118,12 @@ export const SettingsPatch = Schema.Struct({
   completionSoundPreset: Schema.optional(CompletionSoundPreset),
   providerEnabled: Schema.optional(
     Schema.Record({ key: ProviderId, value: Schema.Boolean }),
+  ),
+  modelEnabledByProvider: Schema.optional(
+    Schema.Record({
+      key: ProviderId,
+      value: Schema.Record({ key: Schema.String, value: Schema.Boolean }),
+    }),
   ),
   subagents: Schema.optional(
     Schema.Struct({

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -5,11 +5,15 @@ import {
   AgentEvent,
   Chat,
   ComposerInput,
+  defaultModelEnabledByProvider,
+  defaultModelFor,
   GitBranchInfo,
+  isModelVisible,
   Message,
   PokemonPokedexEntry,
   SettingsFile,
   Session,
+  visibleModelsForProvider,
   Worktree,
 } from "../src/index.ts";
 
@@ -408,6 +412,13 @@ describe("SettingsFile round-trip", () => {
         gemini: true,
         opencode: true,
       },
+      modelEnabledByProvider: {
+        ...defaultModelEnabledByProvider(),
+        codex: {
+          ...defaultModelEnabledByProvider().codex,
+          "gpt-5.3-codex": true,
+        },
+      },
       subagents: { enableForNewSessions: true, presets: {} },
       branchNamingStyle: "username-slug",
       branchNamingPrefix: "",
@@ -440,11 +451,49 @@ describe("SettingsFile round-trip", () => {
           gemini: true,
           opencode: true,
         },
+        modelEnabledByProvider: defaultModelEnabledByProvider(),
         subagents: { enableForNewSessions: true, presets: {} },
         branchNamingStyle: "username-slug",
         branchNamingPrefix: "",
       }),
     ).toThrow();
+  });
+});
+
+describe("model visibility helpers", () => {
+  it("uses Sonnet 5 as the default visible Claude model", () => {
+    expect(defaultModelFor("claude")).toBe("claude-sonnet-5");
+    expect(isModelVisible("claude", "claude-sonnet-5")).toBe(true);
+    expect(isModelVisible("claude", "claude-sonnet-4-6")).toBe(false);
+  });
+
+  it("filters hidden models unless they are explicitly enabled", () => {
+    expect(isModelVisible("codex", "gpt-5.3-codex")).toBe(false);
+    expect(
+      visibleModelsForProvider("codex").some(
+        (model) => model.id === "gpt-5.3-codex",
+      ),
+    ).toBe(false);
+
+    const overrides = defaultModelEnabledByProvider();
+    overrides.codex["gpt-5.3-codex"] = true;
+
+    expect(isModelVisible("codex", "gpt-5.3-codex", overrides)).toBe(true);
+    expect(
+      visibleModelsForProvider("codex", overrides).some(
+        (model) => model.id === "gpt-5.3-codex",
+      ),
+    ).toBe(true);
+  });
+
+  it("can include a hidden selected model without making all hidden models visible", () => {
+    const models = visibleModelsForProvider("codex", undefined, {
+      includeModelId: "gpt-5.3-codex",
+    });
+    expect(models.some((model) => model.id === "gpt-5.3-codex")).toBe(true);
+    expect(models.some((model) => model.id === "gpt-5.3-codex-spark")).toBe(
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds settings-backed curated model visibility so older/noisy models stay available but are hidden from normal pickers by default.
- Cleans up the model picker and provider settings model controls, including hidden-model toggles and recents filtering.
- Adds Claude Sonnet 5 as the default visible Claude model and moves Sonnet-based defaults/labels forward.

## Impact

Users see a shorter, newer model list by default, with GPT-5.5 ordered above GPT-5.4 and Sonnet 5 available as the recommended Claude choice. Older models can be turned back on from provider settings without breaking persisted settings.

## Validation

- `bun test packages/wire/test/schema.test.ts apps/server/test/config-store.test.ts`
- `bunx turbo run check-types --filter=@zuse/wire --filter=@zuse/server --filter=renderer`
- `git diff --check`

Note: full `bun run check-types` is blocked by existing unrelated `apps/web` blog/source typing errors around `collections/server` and blog metadata fields.
