### PR TITLE
[codex] Refine renderer color palette

### DIFF
--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -318,7 +318,7 @@ function PanelLauncher({
               key={kind}
               type="button"
               onClick={() => onAdd(kind)}
-              className="flex w-full items-center gap-3 rounded-lg bg-muted/20 px-3 py-3 text-left text-sm text-foreground/90 transition-colors hover:bg-muted/60"
+              className="flex w-full items-center gap-3 rounded-lg bg-card/80 px-3 py-3 text-left text-sm text-foreground/90 transition-colors hover:bg-card/60"
             >
               <HugeiconsIcon
                 icon={meta.icon}

--- a/apps/renderer/src/components/ui/shimmer-text.tsx
+++ b/apps/renderer/src/components/ui/shimmer-text.tsx
@@ -16,7 +16,7 @@ type ShimmerTone = "muted" | "lime";
 
 const TONE_STOPS: Record<ShimmerTone, GradientStop[]> = {
   muted: [{ position: 0.5, color: "oklch(0.97 0.004 260)" }],
-  lime: [{ position: 0.5, color: "oklch(0.94 0.2 122)" }],
+  lime: [{ position: 0.5, color: "hsl(72 98% 54%)" }],
 };
 
 type ShimmerTextProps = {

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -319,7 +319,7 @@ body,
   --secondary: hsl(72 4% 10%);
   --secondary-foreground: hsl(72 4% 92%);
 
-  --muted: hsl(72 4% 16%);
+  --muted: hsl(72 4% 10%);
   --muted-foreground: hsl(72 2% 64%);
 
   --accent: hsl(72 4% 13%);

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -282,82 +282,80 @@ body,
 }
 
 .dark {
-  /* Keep original surface values exactly as they were (no panel style changes) */
-  --background: oklch(0.2 0.004 260);
-  --foreground: oklch(0.955 0.004 260);
+  /* Espresso palette with a very subtle moss undertone. */
+  --lime: hsl(72 98% 54%);
+  --brand-highlight: hsl(72 98% 54%);
+  --brand-highlight-muted: hsl(73 96% 72%);
 
-  --bg-subtle: oklch(0.225 0.005 260);
-  --bg-elevated: oklch(0.275 0.006 260);
-  --bg-overlay: oklch(0.35 0.008 260);
-  --text-faint: oklch(0.58 0.006 260);
+  --background: hsl(72 5% 6%);
+  --foreground: hsl(72 4% 92%);
+
+  --bg-subtle: hsl(72 4% 10%);
+  --bg-elevated: hsl(72 4% 13%);
+  --bg-overlay: hsl(72 3% 22%);
+  --text-faint: hsl(72 3% 43%);
 
   /* Chip surface — kept darker than --card so pills read as inset on the
-     composer surface (card 0.225 vs chip 0.155 ≈ 0.07 lightness gap). */
-  --chip-bg: oklch(0.155 0.004 260);
+     composer surface while staying within the moss-neutral ramp. */
+  --chip-bg: hsl(72 4% 10%);
 
-  --card: oklch(0.225 0.005 260);
+  --card: hsl(72 4% 13%);
   --card-foreground: var(--foreground);
 
-  --popover: oklch(0.255 0.006 260);
-  --popover-foreground: var(--foreground);
+  --popover: hsl(72 4% 13%);
+  --popover-foreground: hsl(72 4% 92%);
 
-  /* Bright lime accent. Reused via --lime across primary/ring/sidebar/
-     glow utilities — change it here and everything follows. Hue/chroma
-     intentionally a touch off the obvious neon pin so it reads as ours. */
-  --lime: oklch(0.94 0.2 122);
+  /* Bright lime primary, with subdued moss neutrals around it. */
   --primary: var(--lime);
-  --primary-foreground: oklch(0.18 0.02 122);
+  --primary-foreground: hsl(72 82% 5%);
 
-  /* Accent palette for stateful surfaces (PR card, status pills). Inspired
-     by but softer than the obvious rgb(245,68,181)/rgb(42,189,101)/
-     rgb(17,179,231) trio — oklch lets us keep them perceptually balanced. */
-  --accent-pink: oklch(0.7 0.2 0);
-  --accent-green: oklch(0.74 0.16 150);
-  --accent-blue: oklch(0.74 0.13 230);
-  --accent-amber: oklch(0.82 0.16 80);
-  --accent-red: oklch(0.66 0.22 25);
-  --accent-zinc: oklch(0.74 0.01 260);
+  --accent-pink: hsl(339 96% 52%);
+  --accent-green: hsl(131 72% 59%);
+  --accent-blue: hsl(220 96% 68%);
+  --accent-amber: hsl(18 96% 62%);
+  --accent-red: hsl(0 91% 71%);
+  --accent-zinc: hsl(72 2% 63%);
 
-  --secondary: oklch(0.305 0.006 260);
-  --secondary-foreground: var(--foreground);
+  --secondary: hsl(72 4% 10%);
+  --secondary-foreground: hsl(72 4% 92%);
 
-  --muted: oklch(0.305 0.006 260);
-  --muted-foreground: oklch(0.72 0.006 260);
+  --muted: hsl(72 4% 16%);
+  --muted-foreground: hsl(72 2% 64%);
 
-  --accent: oklch(0.32 0.008 260);
-  --accent-foreground: var(--foreground);
+  --accent: hsl(72 4% 13%);
+  --accent-foreground: hsl(72 4% 92%);
 
-  --destructive: oklch(0.68 0.19 25);
-  --destructive-foreground: oklch(0.985 0.003 260);
+  --destructive: hsl(0 91% 71%);
+  --destructive-foreground: hsl(72 5% 6%);
 
-  --success: #26bd6c;
-  --success-foreground: oklch(0.18 0.004 260);
+  --success: hsl(131 72% 59%);
+  --success-foreground: hsl(130 66% 10%);
 
-  --warning: #f48e2f;
-  --warning-foreground: oklch(0.18 0.004 260);
+  --warning: hsl(360 15% 22%);
+  --warning-foreground: hsl(72 4% 92%);
 
-  --info: #4778f5;
-  --info-foreground: oklch(0.985 0.003 260);
+  --info: hsl(220 96% 68%);
+  --info-foreground: hsl(217 45% 14%);
 
-  --alert-error-bg: oklch(0.38 0.065 18);
-  --alert-warning-bg: oklch(0.39 0.055 70);
-  --alert-info-bg: oklch(0.39 0.045 240);
-  --alert-success-bg: oklch(0.39 0.052 150);
+  --alert-error-bg: hsl(360 15% 22%);
+  --alert-warning-bg: hsl(360 15% 22%);
+  --alert-info-bg: hsl(217 45% 18%);
+  --alert-success-bg: hsl(130 64% 11%);
 
-  --border: oklch(1 0 0 / 0.09);
-  --input: oklch(1 0 0 / 0.14);
+  --border: hsl(0 0% 100% / 0.1);
+  --input: hsl(0 0% 100% / 0.2);
   --ring: var(--lime);
 
-  --sidebar: oklch(0.22 0.004 260);
-  --sidebar-foreground: oklch(0.955 0.004 260);
+  --sidebar: hsl(72 4% 10%);
+  --sidebar-foreground: hsl(0 0% 100% / 0.9);
 
   --sidebar-primary: var(--lime);
-  --sidebar-primary-foreground: oklch(0.18 0.02 122);
+  --sidebar-primary-foreground: hsl(72 82% 5%);
 
-  --sidebar-accent: oklch(0.32 0.006 260);
-  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-accent: hsl(0 0% 100% / 0.05);
+  --sidebar-accent-foreground: hsl(0 0% 100% / 0.9);
 
-  --sidebar-border: oklch(1 0 0 / 0.09);
+  --sidebar-border: hsl(0 0% 100% / 0.1);
   --sidebar-ring: var(--lime);
 
   /* Subtle glass button tokens */
@@ -366,21 +364,20 @@ body,
   --color-white-3: #ffffff08;
 
   --chart-1: var(--lime);
-  --chart-2: #26bd6c;
-  --chart-3: #f48e2f;
-  --chart-4: #4778f5;
-  --chart-5: #e6483d;
+  --chart-2: hsl(131 72% 59%);
+  --chart-3: hsl(18 96% 62%);
+  --chart-4: hsl(220 96% 68%);
+  --chart-5: hsl(0 91% 71%);
 
-  /* Chat bubble + prose kept close to original for now */
-  --user-bubble: oklch(0.36 0.022 260);
-  --user-bubble-foreground: oklch(0.96 0.005 260);
-  --message-text: oklch(0.78 0.006 260);
-  --message-heading: oklch(0.88 0.006 260);
-  --message-code: oklch(0.84 0.085 122);
-  --message-code-bg: oklch(0.265 0.012 122);
-  --message-pre-bg: oklch(0.225 0.006 260);
-  --message-quote: oklch(0.66 0.008 260);
-  --message-rule: oklch(1 0 0 / 0.08);
+  --user-bubble: hsl(72 4% 13%);
+  --user-bubble-foreground: hsl(72 4% 92%);
+  --message-text: hsl(72 4% 90%);
+  --message-heading: hsl(72 4% 94%);
+  --message-code: hsl(72 90% 64%);
+  --message-code-bg: hsl(72 8% 12%);
+  --message-pre-bg: hsl(72 8% 12%);
+  --message-quote: hsl(72 2% 64%);
+  --message-rule: hsl(72 3% 22%);
 }
 @layer base {
   * {


### PR DESCRIPTION
## Summary
- refresh the renderer dark theme with a subtle moss-tinted HSL palette
- restore the lime primary accent and matching shimmer highlight
- tune muted/launcher surfaces so hover states read again

## Validation
- bun run --filter=renderer check-types
- bun run --filter=renderer build
