### PR TITLE
[codex] Add Claude Fable 5 support

### DIFF
--- a/apps/renderer/src/components/cost-footer.tsx
+++ b/apps/renderer/src/components/cost-footer.tsx
@@ -13,6 +13,7 @@ const EMPTY: ReadonlyArray<Message> = [];
 
 const MODEL_LABEL: Record<string, string> = {
   "claude-sonnet-5": "Sonnet",
+  "claude-fable-5": "Fable",
   "claude-opus-4-7": "Opus",
   "claude-sonnet-4-6": "Sonnet",
   "claude-haiku-4-5": "Haiku",

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -19,6 +19,7 @@ import {
   findModelDescriptor,
   isModelVisible,
   type Message,
+  type ModelOption,
   type SelectOptionDescriptor,
 } from "@zuse/wire";
 
@@ -60,6 +61,7 @@ interface ModelPickerEntry {
   providerId: ProviderId;
   modelId: string;
   label: string;
+  badgeLabel?: string;
   /**
    * When set, render a small context-window pill on this row. We only show
    * a pill when the model's `contextWindow` descriptor defaults to `"1m"`
@@ -162,7 +164,9 @@ export function ModelPicker(props: ModelPickerProps) {
   }, [open]);
 
   const modelsForProvider = useCallback(
-    (pid: ProviderId): ReadonlyArray<{ id: string; label: string }> => {
+    (
+      pid: ProviderId,
+    ): ReadonlyArray<Pick<ModelOption, "id" | "label" | "badgeLabel">> => {
       if (pid !== "opencode" || opencodeInventory === null) {
         return MODELS_BY_PROVIDER[pid] ?? [];
       }
@@ -215,6 +219,7 @@ export function ModelPicker(props: ModelPickerProps) {
           providerId: pid,
           modelId: m.id,
           label: m.label,
+          ...(m.badgeLabel !== undefined ? { badgeLabel: m.badgeLabel } : {}),
           ...(contextWindowLabel !== undefined ? { contextWindowLabel } : {}),
         });
       }
@@ -352,6 +357,10 @@ export function ModelPicker(props: ModelPickerProps) {
         providerId: r.providerId,
         modelId: r.modelId,
         label: r.label,
+        ...(r.badgeLabel !== undefined ? { badgeLabel: r.badgeLabel } : {}),
+        ...(r.contextWindowLabel !== undefined
+          ? { contextWindowLabel: r.contextWindowLabel }
+          : {}),
       });
     }
     if (inGroupedView) {
@@ -757,6 +766,11 @@ function ModelRow({
         )}
       </span>
       <span className="flex-1" />
+      {entry.badgeLabel !== undefined && (
+        <span className="shrink-0 rounded bg-primary/15 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
+          {entry.badgeLabel}
+        </span>
+      )}
       {opensNewTab && (
         <HugeiconsIcon
           icon={ArrowUpRight01Icon}

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -18,6 +18,7 @@ import { Spinner } from "./ui/spinner";
 
 const MODEL_LABEL: Record<string, string> = {
   "claude-sonnet-5": "Sonnet 5",
+  "claude-fable-5": "Fable 5",
   "claude-opus-4-7": "Opus 4.7",
   "claude-sonnet-4-6": "Sonnet 4.6",
   "claude-haiku-4-5": "Haiku 4.5",

--- a/apps/server/test/config-store.test.ts
+++ b/apps/server/test/config-store.test.ts
@@ -23,6 +23,9 @@ describe("config-store settings coercion", () => {
     expect(settings.modelEnabledByProvider.claude["claude-sonnet-5"]).toBe(
       true,
     );
+    expect(settings.modelEnabledByProvider.claude["claude-fable-5"]).toBe(
+      true,
+    );
     expect(settings.modelEnabledByProvider.claude["claude-sonnet-4-6"]).toBe(
       false,
     );

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -734,6 +734,15 @@ export interface ModelOption {
   readonly id: string;
   readonly label: string;
   /**
+   * Optional small picker badge for launch/newness callouts.
+   */
+  readonly badgeLabel?: string;
+  /**
+   * Preferred default for this provider. When omitted, the first visible model
+   * remains the fallback default.
+   */
+  readonly defaultModel?: boolean;
+  /**
    * Whether this model appears in normal picker/default selectors before the
    * user opts it back in from provider settings. Omitted means visible.
    */
@@ -836,8 +845,32 @@ export const MODELS_BY_PROVIDER: Record<
   // picker accordion opens on the latest recommended model by default.
   claude: [
     {
+      id: "claude-fable-5",
+      label: "Fable 5",
+      badgeLabel: "Available now",
+      optionDescriptors: [
+        claudeEffortDescriptor({
+          options: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "xhigh", label: "Extra High" },
+            { id: "max", label: "Max" },
+            { id: "ultracode", label: "Ultracode" },
+          ],
+          defaultId: "high",
+        }),
+        booleanDescriptor("fastMode", "Fast Mode"),
+        claudeContextWindowDescriptor(),
+      ],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
       id: "claude-sonnet-5",
       label: "Sonnet 5",
+      badgeLabel: "New",
+      defaultModel: true,
       optionDescriptors: [
         claudeEffortDescriptor({
           options: [
@@ -1143,7 +1176,10 @@ export const MODELS_BY_PROVIDER: Record<
 };
 
 export const defaultModelFor = (providerId: ProviderId): string =>
-  (MODELS_BY_PROVIDER[providerId].find((m) => m.defaultVisible !== false) ??
+  (MODELS_BY_PROVIDER[providerId].find(
+    (m) => m.defaultModel === true && m.defaultVisible !== false,
+  ) ??
+    MODELS_BY_PROVIDER[providerId].find((m) => m.defaultVisible !== false) ??
     MODELS_BY_PROVIDER[providerId][0]!)!.id;
 
 export type ModelEnabledByProvider = Record<
@@ -1224,6 +1260,9 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<
     "claude-opus-4.7": "claude-opus-4-7",
     "opus-4.6": "claude-opus-4-6",
     "claude-opus-4.6": "claude-opus-4-6",
+    fable: "claude-fable-5",
+    "fable-5": "claude-fable-5",
+    "claude-fable-5": "claude-fable-5",
     sonnet: "claude-sonnet-5",
     "sonnet-5": "claude-sonnet-5",
     "claude-sonnet-5": "claude-sonnet-5",
@@ -1317,6 +1356,12 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     output: 25,
     cacheRead: 0.5,
     cacheCreate: 6.25,
+  },
+  "claude-fable-5": {
+    input: 10,
+    output: 50,
+    cacheRead: 1,
+    cacheCreate: 12.5,
   },
   "claude-sonnet-5": {
     input: 3,

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -10,7 +10,9 @@ import {
   GitBranchInfo,
   isModelVisible,
   Message,
+  MODELS_BY_PROVIDER,
   PokemonPokedexEntry,
+  resolveModelSlug,
   SettingsFile,
   Session,
   visibleModelsForProvider,
@@ -463,7 +465,18 @@ describe("SettingsFile round-trip", () => {
 describe("model visibility helpers", () => {
   it("uses Sonnet 5 as the default visible Claude model", () => {
     expect(defaultModelFor("claude")).toBe("claude-sonnet-5");
+    expect(visibleModelsForProvider("claude")[0]?.id).toBe("claude-fable-5");
     expect(isModelVisible("claude", "claude-sonnet-5")).toBe(true);
+    expect(isModelVisible("claude", "claude-fable-5")).toBe(true);
+    expect(resolveModelSlug("claude", "fable")).toBe("claude-fable-5");
+    expect(
+      MODELS_BY_PROVIDER.claude.find((m) => m.id === "claude-sonnet-5")
+        ?.badgeLabel,
+    ).toBe("New");
+    expect(
+      MODELS_BY_PROVIDER.claude.find((m) => m.id === "claude-fable-5")
+        ?.badgeLabel,
+    ).toBe("Available now");
     expect(isModelVisible("claude", "claude-sonnet-4-6")).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- add Claude Fable 5 to the shared Claude model catalog with the confirmed `claude-fable-5` slug
- surface Fable 5 at the top of the model picker while keeping Sonnet 5 as the default
- add picker badges for Sonnet 5 (`NEW`) and Fable 5 (`AVAILABLE NOW`), plus Fable pricing, aliases, and label-map coverage

## Validation

- `bun run check-types` in `packages/wire`
- `bun run check-types` in `apps/renderer`
- `bun test packages/wire/test/schema.test.ts`
- `bun test apps/server/test/config-store.test.ts`
- `bun test` in `packages/wire`
- `bun test` in `apps/server`
- `bun test` in `apps/renderer`
- `git diff --check`
