### PR TITLE
[codex] Polish streaming chat motion

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -112,6 +112,7 @@ import {
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { useMessagesStore } from "../store/messages.ts";
+import { useChatMotionStore } from "../store/chat-motion.ts";
 import { useOpencodeInventory } from "../store/opencode-inventory.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSettingsStore } from "../store/settings.ts";
@@ -126,6 +127,17 @@ import { ProviderIcon } from "./provider-icons.tsx";
 const MIN_HEIGHT = 56;
 const MAX_HEIGHT = 240;
 const MAX_ATTACHMENTS_PER_TURN = 20;
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const motionSnippet = (text: string): string => {
+  const trimmed = text.replace(/\s+/g, " ").trim();
+  if (trimmed.length === 0) return "Message sent";
+  return trimmed.length > 120 ? `${trimmed.slice(0, 117)}...` : trimmed;
+};
 
 export function ChatComposer({
   session,
@@ -315,6 +327,7 @@ export function ChatComposer({
   const [isDragging, setIsDragging] = useState(false);
   const editorHostRef = useRef<HTMLDivElement | null>(null);
   const editorViewRef = useRef<EditorView | null>(null);
+  const composerCardRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
   const uploadOne = useAttachmentsStore((s) => s.uploadOne);
@@ -338,6 +351,7 @@ export function ChatComposer({
   const revealPanel = useUiStore((s) => s.revealPanel);
   const setView = useUiStore((s) => s.setView);
   const setSettingsSection = useUiStore((s) => s.setSettingsSection);
+  const startSendMotion = useChatMotionStore((s) => s.startSend);
   const workspaceRoot = useActiveWorkspaceRoot(session.projectId);
   const annotationCount = useAnnotationsStore(
     (s) => (s.bySession[sessionId] ?? []).length,
@@ -693,6 +707,31 @@ export function ChatComposer({
             annotations,
           })
         : parsed;
+    const route =
+      onDraftSubmit === undefined
+        ? chooseComposerSubmitRoute({
+            sendPlanFeedbackNow,
+            goalSendMode,
+            shouldQueue: inFlight || holdForSetup,
+          })
+        : null;
+    const sourceRect = composerCardRef.current?.getBoundingClientRect() ?? null;
+    if (
+      route !== null &&
+      route !== "queue" &&
+      sourceRect !== null &&
+      !prefersReducedMotion()
+    ) {
+      startSendMotion(sessionId, {
+        text: motionSnippet(input.text),
+        sourceRect: {
+          left: sourceRect.left,
+          top: sourceRect.top,
+          width: sourceRect.width,
+          height: sourceRect.height,
+        },
+      });
+    }
     clearComposer(view);
     clearComposerDraft(draftKey);
     setGoalSendMode(false);
@@ -705,13 +744,7 @@ export function ChatComposer({
       onDraftSubmit(input, { asGoal: goalSendMode });
       return true;
     }
-    switch (
-      chooseComposerSubmitRoute({
-        sendPlanFeedbackNow,
-        goalSendMode,
-        shouldQueue: inFlight || holdForSetup,
-      })
-    ) {
+    switch (route) {
       case "planFeedback":
         void (async () => {
           if (pendingPlanApprovalRequest !== null) {
@@ -828,6 +861,7 @@ export function ChatComposer({
               </div>
             ) : null}
             <Card
+              ref={composerCardRef}
               className={cn(
                 "min-h-30 rounded-lg transition-colors",
                 goalSendMode

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -1,16 +1,7 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import {
-  ArrowDown01Icon,
-  Message01Icon,
-} from "@hugeicons-pro/core-bulk-rounded";
-import {
-  Fragment,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { Message01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import { Fragment, useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
 
 import type {
   AgentItemId,
@@ -20,8 +11,10 @@ import type {
 } from "@zuse/wire";
 
 import { groupMessages } from "../lib/group-messages.ts";
+import { useChatScroll } from "../lib/use-chat-scroll.ts";
 import { useRegisterPane } from "../store/pane-focus.ts";
 import { teardownLiveStreams, useMessagesStore } from "../store/messages.ts";
+import { useChatMotionStore } from "../store/chat-motion.ts";
 import { usePermissionsStore } from "../store/permissions.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSkillsStore } from "../store/skills.ts";
@@ -33,25 +26,36 @@ import {
   MessageRow,
   type ToolResultRecord,
 } from "./message-row.tsx";
+import { JumpToLatestPill } from "./jump-to-latest-pill.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { TurnSummary } from "./turn-summary.tsx";
 import { NextUnreadButton } from "./next-unread-button.tsx";
-import { Button } from "./ui/button";
 import { ShimmerText } from "./ui/shimmer-text.tsx";
 import { Spinner } from "./ui/spinner";
-
-const NEAR_BOTTOM_PX = 80;
 
 // Stable empty-array reference for the selector below. Returning a fresh
 // `[]` from a Zustand selector each call breaks `useSyncExternalStore`'s
 // snapshot-equality check and triggers an infinite re-render loop.
 const EMPTY_MESSAGES: ReadonlyArray<Message> = [];
 
+const isUserMessage = (m: Message | undefined): boolean =>
+  m !== undefined &&
+  (m.content._tag === "user" || m.content._tag === "user_rich");
+
+type SendFlight = {
+  readonly id: string;
+  readonly text: string;
+  readonly style: CSSProperties & {
+    readonly "--chat-send-x": string;
+    readonly "--chat-send-y": string;
+  };
+};
+
 /**
  * Read-only timeline of one session. Subscribes to `messages.stream` via the
  * messages store on mount / session-change; the store owns the live fiber.
- * Auto-scrolls to bottom on new messages unless the user has scrolled up out
- * of the "near-bottom" band.
+ * Scroll behavior is owned by `useChatScroll`: it anchors each new turn near
+ * the top and follows the live edge only while the reader is there.
  */
 export function ChatView({ sessionId }: { sessionId: SessionId }) {
   const messages = useMessagesStore(
@@ -105,10 +109,22 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   });
   const setupActive = worktreeSetupActive || session?.status === "booting";
 
-  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const {
+    scrollRef,
+    contentRef,
+    sentinelRef,
+    spacerRef,
+    spacerHeight,
+    showPill,
+    streaming,
+    jumpToLatest,
+  } = useChatScroll({ sessionId, messages, inFlight });
+  const pendingSendMotion = useChatMotionStore(
+    (s) => s.pendingBySession[sessionId as string] ?? null,
+  );
+  const consumeSendMotion = useChatMotionStore((s) => s.consumeSend);
+  const [sendFlight, setSendFlight] = useState<SendFlight | null>(null);
   useRegisterPane("chat", scrollRef);
-  const stickToBottomRef = useRef(true);
-  const [isNearBottom, setIsNearBottom] = useState(true);
 
   useEffect(() => {
     void hydrate(sessionId);
@@ -124,40 +140,54 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     };
   }, [sessionId, hydrate, hydrateSkills]);
 
-  // Track whether the user is near the bottom of the timeline; if they
-  // scroll up, we stop auto-scrolling so reading older context isn't
-  // disrupted by streaming new replies.
-  const onScroll = () => {
-    const el = scrollRef.current;
-    if (el === null) return;
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const nextIsNearBottom = distance < NEAR_BOTTOM_PX;
-    stickToBottomRef.current = nextIsNearBottom;
-    setIsNearBottom(nextIsNearBottom);
-  };
-
-  const scrollToBottom = () => {
-    const el = scrollRef.current;
-    if (el === null) return;
-    stickToBottomRef.current = true;
-    setIsNearBottom(true);
-    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-  };
-
-  useLayoutEffect(() => {
-    // A message the user just sent always re-engages auto-scroll, even if
-    // they had scrolled up to read older context.
-    const last = messages[messages.length - 1];
-    if (last?.content._tag === "user" || last?.content._tag === "user_rich") {
-      stickToBottomRef.current = true;
-      setIsNearBottom(true);
+  useEffect(() => {
+    if (pendingSendMotion === null) return;
+    let latestUser: Message | null = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const candidate = messages[i]!;
+      if (isUserMessage(candidate)) {
+        latestUser = candidate;
+        break;
+      }
     }
-    if (!stickToBottomRef.current) return;
-    const el = scrollRef.current;
-    if (el === null) return;
-    el.scrollTop = el.scrollHeight;
-    setIsNearBottom(true);
-  }, [messages.length]);
+    if (latestUser === null) return;
+    if (latestUser.createdAt.getTime() + 1_000 < pendingSendMotion.createdAt) {
+      return;
+    }
+
+    const content = contentRef.current;
+    if (content === null) return;
+    const anchor = content.querySelector<HTMLElement>(
+      `[data-user-anchor="${CSS.escape(String(latestUser.id))}"]`,
+    );
+    if (anchor === null) return;
+    const bubble =
+      anchor.querySelector<HTMLElement>("[data-chat-user-bubble]") ?? anchor;
+    const target = bubble.getBoundingClientRect();
+    const source = pendingSendMotion.sourceRect;
+    const fromLeft = source.left + 12;
+    const fromTop = source.top + 8;
+    setSendFlight({
+      id: pendingSendMotion.id,
+      text: pendingSendMotion.text,
+      style: {
+        left: fromLeft,
+        top: fromTop,
+        maxWidth: Math.max(160, Math.min(source.width - 24, 420)),
+        "--chat-send-x": `${target.left - fromLeft}px`,
+        "--chat-send-y": `${target.top - fromTop}px`,
+      },
+    });
+    consumeSendMotion(sessionId, pendingSendMotion.id);
+    const timeout = window.setTimeout(() => setSendFlight(null), 260);
+    return () => window.clearTimeout(timeout);
+  }, [
+    contentRef,
+    consumeSendMotion,
+    messages,
+    pendingSendMotion,
+    sessionId,
+  ]);
 
   // Pair tool_result rows back to their originating tool_use by AgentItemId.
   // The driver assigns the SDK's tool_use id to both events, so each
@@ -236,7 +266,6 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       <div className="relative flex min-h-0 flex-1">
         <div
           ref={scrollRef}
-          onScroll={onScroll}
           data-pane="chat"
           tabIndex={-1}
           className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto outline-none"
@@ -258,7 +287,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
               </div>
             )
           ) : (
-            <div className="flex flex-col py-2">
+            <div ref={contentRef} className="flex flex-col py-2">
               {turns.map((turn, idx) => {
                 const isLastTurn = idx === turns.length - 1;
                 const isLive = inFlight && isLastTurn;
@@ -315,52 +344,68 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                 return (
                   <Fragment key={turnKey}>
                     {turn.user !== null ? (
-                      <MessageRow
-                        message={turn.user}
-                        resultsByItemId={resultsByItemId}
-                        answersByItemId={answersByItemId}
-                        sessionId={sessionId}
-                      />
+                      <div
+                        data-user-anchor={turn.user.id}
+                        className="chat-row-enter chat-row-enter-user scroll-mt-6"
+                      >
+                        <MessageRow
+                          message={turn.user}
+                          resultsByItemId={resultsByItemId}
+                          answersByItemId={answersByItemId}
+                          sessionId={sessionId}
+                        />
+                      </div>
                     ) : null}
                     {showSummary ? (
                       <>
                         {planMessages.map((m) => (
-                          <MessageRow
-                            key={m.id}
-                            message={m}
+                          <div key={m.id} className="chat-row-enter">
+                            <MessageRow
+                              message={m}
+                              resultsByItemId={resultsByItemId}
+                              answersByItemId={answersByItemId}
+                              sessionId={sessionId}
+                            />
+                          </div>
+                        ))}
+                        <div className="chat-row-enter">
+                          <TurnSummary
+                            body={summaryBody}
                             resultsByItemId={resultsByItemId}
                             answersByItemId={answersByItemId}
-                            sessionId={sessionId}
                           />
-                        ))}
-                        <TurnSummary
-                          body={summaryBody}
-                          resultsByItemId={resultsByItemId}
-                          answersByItemId={answersByItemId}
-                        />
+                        </div>
                       </>
                     ) : (
                       bodyGroups.map((group) =>
                         group.kind === "single" ? (
-                          <MessageRow
+                          <div
                             key={group.message.id}
-                            message={group.message}
-                            resultsByItemId={resultsByItemId}
-                            answersByItemId={answersByItemId}
-                            sessionId={sessionId}
-                          />
+                            className="chat-row-enter"
+                          >
+                            <MessageRow
+                              message={group.message}
+                              resultsByItemId={resultsByItemId}
+                              answersByItemId={answersByItemId}
+                              sessionId={sessionId}
+                            />
+                          </div>
                         ) : (
-                          <SubagentRow
+                          <div
                             key={group.parent.id}
-                            agentToolUseId={group.parentItemId}
-                            agentName={group.agentName}
-                            prompt={group.prompt}
-                            modelRequested={group.modelRequested}
-                            children={group.children}
-                            summary={group.summary}
-                            resultsByItemId={resultsByItemId}
-                            answersByItemId={answersByItemId}
-                          />
+                            className="chat-row-enter"
+                          >
+                            <SubagentRow
+                              agentToolUseId={group.parentItemId}
+                              agentName={group.agentName}
+                              prompt={group.prompt}
+                              modelRequested={group.modelRequested}
+                              children={group.children}
+                              summary={group.summary}
+                              resultsByItemId={resultsByItemId}
+                              answersByItemId={answersByItemId}
+                            />
+                          </div>
                         ),
                       )
                     )}
@@ -379,22 +424,32 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
               onDismiss={() => clearError(sessionId)}
             />
           )}
+          {/* Live-edge sentinel — must be the last child so it sits at the very
+          bottom of the real content (before the spacer). */}
+          <div ref={sentinelRef} aria-hidden className="h-px w-full shrink-0" />
+          {/* Dynamic spacer: lets a freshly-sent turn be read from the top while
+          its answer streams into the space below. */}
+          <div
+            ref={spacerRef}
+            aria-hidden
+            className="shrink-0"
+            style={{ height: spacerHeight }}
+          />
         </div>
-        {!isNearBottom && (
-          <div className="pointer-events-none absolute bottom-3 left-3 z-20">
-            <Button
-              variant="outline"
-              size="xs"
-              className="pointer-events-auto text-muted-foreground shadow-md"
-              onClick={scrollToBottom}
-              title="Scroll to bottom"
-              aria-label="Scroll to bottom"
-            >
-              <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5" />
-              Scroll to bottom
-            </Button>
+        <JumpToLatestPill
+          visible={showPill}
+          streaming={streaming}
+          onClick={jumpToLatest}
+        />
+        {sendFlight !== null ? (
+          <div
+            key={sendFlight.id}
+            className="chat-send-flight fixed z-50 truncate rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 text-sm text-user-bubble-foreground shadow-lg/20"
+            style={sendFlight.style}
+          >
+            {sendFlight.text}
           </div>
-        )}
+        ) : null}
         <div className="pointer-events-none absolute right-3 bottom-3 z-20 flex items-center gap-2">
           <NextUnreadButton />
         </div>

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -1,0 +1,59 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowDown01Icon } from "@hugeicons-pro/core-bulk-rounded";
+
+import { cn } from "~/lib/utils";
+
+/**
+ * Floating "Jump to latest" affordance, pinned to the bottom-center of the
+ * chat pane. Appears once the reader has scrolled away from the live edge
+ * (principle 9); while a response is still streaming out of view it shows a
+ * pulsing activity dot (principle 8). Fades/slides in with a CSS transition
+ * that respects `prefers-reduced-motion`.
+ */
+export function JumpToLatestPill({
+  visible,
+  streaming,
+  onClick,
+}: {
+  visible: boolean;
+  streaming: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-x-0 bottom-3 z-10 flex justify-center",
+        "transition-all duration-150 ease-out motion-reduce:transition-none",
+        visible
+          ? "translate-y-0 opacity-100"
+          : "pointer-events-none translate-y-1 opacity-0",
+      )}
+      aria-hidden={!visible}
+    >
+      <button
+        type="button"
+        tabIndex={visible ? 0 : -1}
+        onClick={onClick}
+        aria-label="Jump to latest"
+        className={cn(
+          "pointer-events-auto inline-flex items-center gap-1.5 rounded-full",
+          "border border-border/60 bg-popover/95 px-3 py-1.5 text-xs text-muted-foreground",
+          "shadow-[0_2px_8px_color-mix(in_oklch,black_28%,transparent)] backdrop-blur",
+          "hover:text-foreground hover:bg-popover",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          !visible && "pointer-events-none",
+        )}
+      >
+        {streaming ? (
+          <span
+            className="size-1.5 rounded-full bg-current motion-safe:animate-pulse"
+            aria-hidden
+          />
+        ) : (
+          <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5" />
+        )}
+        <span>{streaming ? "Streaming…" : "Jump to latest"}</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -347,7 +347,10 @@ function UserBubble({
     name.length > 28 ? `${name.slice(0, 25)}...` : name;
   return (
     <div className="group/message flex justify-end px-4 py-2">
-      <div className="relative max-w-[80%] rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 pr-9 text-sm text-user-bubble-foreground">
+      <div
+        data-chat-user-bubble
+        className="relative max-w-[80%] rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 pr-9 text-sm text-user-bubble-foreground"
+      >
         <CopyButton
           text={display || text}
           label="Copy message"

--- a/apps/renderer/src/lib/use-chat-scroll.ts
+++ b/apps/renderer/src/lib/use-chat-scroll.ts
@@ -1,0 +1,318 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import type { RefObject } from "react";
+
+import type { Message, SessionId } from "@zuse/wire";
+
+// How far below the top of the viewport a freshly-sent user message lands, so
+// the tail of the previous turn stays visible above it (principle 6).
+const TOP_GAP = 24;
+// The sentinel counts as "at the live edge" while it sits within this many px
+// of the bottom of the scroll viewport.
+const LIVE_EDGE_BAND_PX = 80;
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const isUserMessage = (m: Message | undefined): boolean =>
+  m !== undefined &&
+  (m.content._tag === "user" || m.content._tag === "user_rich");
+
+export interface ChatScroll {
+  /** The scrollable viewport. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+  /** Wraps every turn; observed for size changes. */
+  contentRef: RefObject<HTMLDivElement | null>;
+  /** Zero-height marker after the last real message; drives live-edge detection. */
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  /** Dynamic bottom spacer that lets a short answer be read from the top. */
+  spacerRef: RefObject<HTMLDivElement | null>;
+  spacerHeight: number;
+  /** Show the "Jump to latest" pill (reader has scrolled away from the edge). */
+  showPill: boolean;
+  /** A response is streaming out of view (drives the pill's activity dot). */
+  streaming: boolean;
+  jumpToLatest: () => void;
+}
+
+/**
+ * Scroll controller for the streaming chat timeline. Honors the "great
+ * streaming chat" principles: never moves the reader against their intent
+ * (1-3), anchors each new turn near the top so the answer streams into the
+ * space below (4-7), surfaces offscreen activity (8), offers a jump-to-latest
+ * affordance (9), preserves position across layout shifts (12), and never lets
+ * an interruption / error steal scroll position (13).
+ *
+ * Live-edge detection uses an IntersectionObserver on a bottom sentinel rather
+ * than scroll math, so it stays correct even while the dynamic spacer is
+ * present. "Following" (stick-to-bottom) is mirrored in a ref so event handlers
+ * and layout effects read the latest value synchronously.
+ */
+export function useChatScroll(opts: {
+  sessionId: SessionId;
+  messages: ReadonlyArray<Message>;
+  inFlight: boolean;
+}): ChatScroll {
+  const { sessionId, messages, inFlight } = opts;
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const spacerRef = useRef<HTMLDivElement | null>(null);
+
+  // `following` = stick-to-bottom engaged. Ref mirror for synchronous reads.
+  const followingRef = useRef(true);
+  const [, setFollowingState] = useState(true);
+  const setFollowing = useCallback((v: boolean) => {
+    if (followingRef.current === v) return;
+    followingRef.current = v;
+    setFollowingState(v);
+  }, []);
+
+  const [atLiveEdge, setAtLiveEdge] = useState(true);
+  const [spacerHeight, setSpacerHeight] = useState(0);
+  const setSpacer = useCallback((px: number) => {
+    setSpacerHeight((prev) => (prev === px ? prev : px));
+  }, []);
+
+  // Bookkeeping refs (synchronous; safe to read inside effects/handlers).
+  const prevSessionRef = useRef<SessionId>(sessionId);
+  const didInitialScrollRef = useRef(false);
+  const lastAnchoredUserIdRef = useRef<Message["id"] | null>(null);
+  // True while a freshly-sent turn is top-anchored (drives spacer sizing).
+  const anchorModeRef = useRef(false);
+  // Guards our own scroll writes from being mis-read as user intent.
+  const programmaticRef = useRef(false);
+
+  const markProgrammatic = useCallback(() => {
+    programmaticRef.current = true;
+    // Clear after the resulting scroll event has fired (two frames is plenty
+    // for an instant scroll; smooth scrolls only move downward, which the
+    // intent listener ignores anyway).
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        programmaticRef.current = false;
+      });
+    });
+  }, []);
+
+  // Size the spacer so the anchored user message can sit TOP_GAP from the top
+  // even when the answer is shorter than the viewport. Shrinks to 0 as the
+  // answer grows past the available space.
+  const recomputeSpacer = useCallback(() => {
+    const el = scrollRef.current;
+    const content = contentRef.current;
+    const id = lastAnchoredUserIdRef.current;
+    if (
+      el === null ||
+      content === null ||
+      !anchorModeRef.current ||
+      id === null
+    )
+      return;
+    const anchor = content.querySelector<HTMLElement>(
+      `[data-user-anchor="${CSS.escape(String(id))}"]`,
+    );
+    if (anchor === null) return;
+    const anchorTop =
+      anchor.getBoundingClientRect().top - content.getBoundingClientRect().top;
+    const belowAnchor = content.offsetHeight - anchorTop;
+    setSpacer(Math.max(0, el.clientHeight - TOP_GAP - belowAnchor));
+  }, [setSpacer]);
+
+  const jumpToLatest = useCallback(() => {
+    anchorModeRef.current = false;
+    setSpacer(0);
+    setFollowing(true);
+    // Collapse the spacer on this paint, then scroll to the true bottom.
+    requestAnimationFrame(() => {
+      const el = scrollRef.current;
+      if (el === null) return;
+      markProgrammatic();
+      el.scrollTo({
+        top: el.scrollHeight,
+        behavior: prefersReducedMotion() ? "auto" : "smooth",
+      });
+    });
+  }, [markProgrammatic, setFollowing, setSpacer]);
+
+  // --- Live-edge detection + re-engage (IntersectionObserver on sentinel) ---
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = sentinelRef.current;
+    if (root === null || sentinel === null) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (entry === undefined) return;
+        const edge = entry.isIntersecting;
+        setAtLiveEdge(edge);
+        // Reaching the edge via a user scroll resumes following. Our own
+        // programmatic scrolls (jump-to-latest, pin) are guarded out.
+        if (edge && !programmaticRef.current) {
+          anchorModeRef.current = false;
+          setSpacer(0);
+          setFollowing(true);
+        }
+      },
+      { root, rootMargin: `0px 0px ${LIVE_EDGE_BAND_PX}px 0px`, threshold: 0 },
+    );
+    io.observe(sentinel);
+    return () => io.disconnect();
+  }, [sessionId, setFollowing, setSpacer]);
+
+  // --- Disengage on a genuine upward user scroll ---
+  // A user scroll-up decreases scrollTop; content growth does not, so this
+  // never fires from streaming or from our own pinning (which is guarded).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el === null) return;
+    let lastTop = el.scrollTop;
+    const onScroll = () => {
+      const cur = el.scrollTop;
+      const delta = cur - lastTop;
+      lastTop = cur;
+      if (programmaticRef.current || delta >= -2) return;
+      const sentinel = sentinelRef.current;
+      if (sentinel === null) {
+        setFollowing(false);
+        return;
+      }
+      const dist =
+        sentinel.getBoundingClientRect().bottom -
+        el.getBoundingClientRect().bottom;
+      if (dist > LIVE_EDGE_BAND_PX) setFollowing(false);
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [sessionId, setFollowing]);
+
+  // --- Selecting text inside the transcript is reading intent (principle 3) ---
+  useEffect(() => {
+    const onSelect = () => {
+      const sel = document.getSelection();
+      if (sel === null || sel.isCollapsed || sel.rangeCount === 0) return;
+      const el = scrollRef.current;
+      const node = sel.anchorNode;
+      if (el !== null && node !== null && el.contains(node))
+        setFollowing(false);
+    };
+    document.addEventListener("selectionchange", onSelect);
+    return () => document.removeEventListener("selectionchange", onSelect);
+  }, [setFollowing]);
+
+  // --- Keep position across layout shifts (images, code, markdown expanding) ---
+  // While following, re-pin to the bottom; while anchored, resize the spacer.
+  // (Reading position when not following is preserved by Chromium's native
+  // `overflow-anchor`, which we never disable.)
+  useEffect(() => {
+    const content = contentRef.current;
+    const el = scrollRef.current;
+    if (content === null || el === null) return;
+    const ro = new ResizeObserver(() => {
+      if (followingRef.current) {
+        markProgrammatic();
+        el.scrollTop = el.scrollHeight;
+      } else if (anchorModeRef.current) {
+        recomputeSpacer();
+      }
+    });
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [sessionId, markProgrammatic, recomputeSpacer]);
+
+  // --- React to new messages: initial land, new-turn anchor, follow-pin ---
+  useLayoutEffect(() => {
+    // Session switch: reset to a fresh "follow + land at bottom" state.
+    if (prevSessionRef.current !== sessionId) {
+      prevSessionRef.current = sessionId;
+      followingRef.current = true;
+      setFollowingState(true);
+      didInitialScrollRef.current = false;
+      anchorModeRef.current = false;
+      lastAnchoredUserIdRef.current = null;
+      setSpacer(0);
+      setAtLiveEdge(true);
+    }
+
+    const el = scrollRef.current;
+    const content = contentRef.current;
+    if (el === null) return;
+
+    if (messages.length === 0) {
+      didInitialScrollRef.current = true;
+      return;
+    }
+    const last = messages[messages.length - 1]!;
+
+    // First paint of a (possibly backfilled) transcript: land at the bottom
+    // and record the newest user id so history never triggers a top-anchor.
+    if (!didInitialScrollRef.current) {
+      didInitialScrollRef.current = true;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (isUserMessage(messages[i])) {
+          lastAnchoredUserIdRef.current = messages[i]!.id;
+          break;
+        }
+      }
+      markProgrammatic();
+      el.scrollTop = el.scrollHeight;
+      return;
+    }
+
+    // A brand-new user turn: anchor it near the top, open space below for the
+    // answer, and stop following so the reader stays at the top of the answer.
+    if (isUserMessage(last) && last.id !== lastAnchoredUserIdRef.current) {
+      lastAnchoredUserIdRef.current = last.id;
+      anchorModeRef.current = true;
+      followingRef.current = false;
+      setFollowingState(false);
+      if (content !== null) {
+        const anchor = content.querySelector<HTMLElement>(
+          `[data-user-anchor="${CSS.escape(String(last.id))}"]`,
+        );
+        if (anchor !== null) {
+          const anchorTop =
+            anchor.getBoundingClientRect().top -
+            content.getBoundingClientRect().top;
+          const belowAnchor = content.offsetHeight - anchorTop;
+          const next = Math.max(0, el.clientHeight - TOP_GAP - belowAnchor);
+          // Apply synchronously so scrollIntoView has room to reach the top.
+          if (spacerRef.current !== null)
+            spacerRef.current.style.height = `${next}px`;
+          setSpacer(next);
+          markProgrammatic();
+          anchor.scrollIntoView({ block: "start", behavior: "auto" });
+        }
+      }
+      return;
+    }
+
+    // Streamed rows (assistant / thinking / tool): pin to bottom only while
+    // following; otherwise let them arrive offscreen without moving the reader.
+    if (followingRef.current) {
+      markProgrammatic();
+      el.scrollTop = el.scrollHeight;
+    } else if (anchorModeRef.current) {
+      recomputeSpacer();
+    }
+  }, [sessionId, messages, markProgrammatic, recomputeSpacer, setSpacer]);
+
+  return {
+    scrollRef,
+    contentRef,
+    sentinelRef,
+    spacerRef,
+    spacerHeight,
+    showPill: !atLiveEdge && messages.length > 0,
+    streaming: inFlight && !atLiveEdge,
+    jumpToLatest,
+  };
+}

--- a/apps/renderer/src/store/chat-motion.ts
+++ b/apps/renderer/src/store/chat-motion.ts
@@ -1,0 +1,53 @@
+import type { SessionId } from "@zuse/wire";
+import { create } from "zustand";
+
+type RectSnapshot = {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+export type ChatSendMotion = {
+  readonly id: string;
+  readonly sessionId: SessionId;
+  readonly text: string;
+  readonly sourceRect: RectSnapshot;
+  readonly createdAt: number;
+};
+
+type ChatMotionState = {
+  readonly pendingBySession: Record<string, ChatSendMotion>;
+  readonly startSend: (
+    sessionId: SessionId,
+    input: {
+      readonly text: string;
+      readonly sourceRect: RectSnapshot;
+    },
+  ) => void;
+  readonly consumeSend: (sessionId: SessionId, id: string) => void;
+};
+
+export const useChatMotionStore = create<ChatMotionState>((set) => ({
+  pendingBySession: {},
+  startSend: (sessionId, input) =>
+    set((s) => ({
+      pendingBySession: {
+        ...s.pendingBySession,
+        [sessionId as string]: {
+          id: crypto.randomUUID(),
+          sessionId,
+          text: input.text,
+          sourceRect: input.sourceRect,
+          createdAt: Date.now(),
+        },
+      },
+    })),
+  consumeSend: (sessionId, id) =>
+    set((s) => {
+      const key = sessionId as string;
+      if (s.pendingBySession[key]?.id !== id) return s;
+      const { [key]: _consumed, ...pendingBySession } = s.pendingBySession;
+      return { pendingBySession };
+    }),
+}));

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -25,6 +25,69 @@ body,
   border-radius: 4px;
 }
 
+.chat-row-enter {
+  animation: chat-row-enter 150ms cubic-bezier(0.215, 0.61, 0.355, 1) both;
+  will-change: transform, opacity;
+}
+
+.chat-row-enter-user {
+  animation-duration: 210ms;
+}
+
+.chat-send-flight {
+  animation: chat-send-flight 220ms cubic-bezier(0.215, 0.61, 0.355, 1) both;
+  pointer-events: none;
+  transform-origin: top left;
+  will-change: transform, opacity;
+}
+
+@keyframes chat-row-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 5px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes chat-send-flight {
+  0% {
+    opacity: 0.82;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  70% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--chat-send-x), var(--chat-send-y), 0)
+      scale(0.96);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-row-enter {
+    animation: chat-row-enter-reduced 80ms ease-out both;
+    will-change: opacity;
+  }
+
+  .chat-send-flight {
+    animation: none;
+    display: none;
+  }
+
+  @keyframes chat-row-enter-reduced {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;
   --animate-caret-blink: 1s ease-out infinite caret-blink;


### PR DESCRIPTION
## Summary
- adds top-anchored streaming chat scroll behavior with a jump-to-latest affordance
- adds a subtle send handoff animation from the composer to the new user bubble
- adds restrained row entrance motion with reduced-motion handling

## Impact
This improves chat readability while responses stream and adds a small visual confirmation when a sent message moves into the transcript. Queued messages are not animated as transcript sends, preserving the existing queue behavior.

## Validation
- bun --filter renderer check-types
- bun --filter renderer build
- Vite renderer HTTP smoke check at http://127.0.0.1:5733/