### PR TITLE
[codex] Fix stale wire package imports

### DIFF
--- a/apps/renderer/src/hooks/use-auth.ts
+++ b/apps/renderer/src/hooks/use-auth.ts
@@ -1,4 +1,4 @@
-import type { AuthUser } from "@memoize/wire";
+import type { AuthUser } from "@zuse/wire";
 
 import { useAuthStore } from "../store/auth.ts";
 

--- a/apps/renderer/src/store/auth.ts
+++ b/apps/renderer/src/store/auth.ts
@@ -1,7 +1,7 @@
 import { Effect, Fiber, Schedule, Stream } from "effect";
 import { create } from "zustand";
 
-import type { AuthState } from "@memoize/wire";
+import type { AuthState } from "@zuse/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 

--- a/apps/server/src/auth/errors.ts
+++ b/apps/server/src/auth/errors.ts
@@ -2,7 +2,7 @@ import { Data } from "effect";
 
 /**
  * Server-internal auth errors. Wire-facing errors (`AuthFlowError`,
- * `AuthCancelledError`) live in `@memoize/wire`'s `auth.ts`. `getAccessToken`
+ * `AuthCancelledError`) live in `@zuse/wire`'s `auth.ts`. `getAccessToken`
  * — the internal seam future cloud/mobile callers use — fails with
  * `AuthTokenError`; everything renderer-facing is mapped to a wire error by
  * the AuthService before it surfaces.

--- a/apps/server/src/auth/handlers.ts
+++ b/apps/server/src/auth/handlers.ts
@@ -1,4 +1,4 @@
-import { MemoizeRpcs } from "@memoize/wire";
+import { MemoizeRpcs } from "@zuse/wire";
 import { Effect, Layer, Stream } from "effect";
 
 import { AuthService } from "./services/auth-service.ts";

--- a/apps/server/src/auth/layers/auth-service.ts
+++ b/apps/server/src/auth/layers/auth-service.ts
@@ -6,7 +6,7 @@ import {
   AuthSession,
   AuthState,
   AuthUser,
-} from "@memoize/wire";
+} from "@zuse/wire";
 
 import { CredentialsService } from "../../provider/services/credentials-service.ts";
 import { AuthTokenError } from "../errors.ts";

--- a/apps/server/src/auth/services/auth-service.ts
+++ b/apps/server/src/auth/services/auth-service.ts
@@ -4,7 +4,7 @@ import type {
   AuthCancelledError,
   AuthFlowError,
   AuthState,
-} from "@memoize/wire";
+} from "@zuse/wire";
 
 import type { AuthTokenError } from "../errors.ts";
 

--- a/apps/server/src/diagnostics/handlers.ts
+++ b/apps/server/src/diagnostics/handlers.ts
@@ -1,4 +1,4 @@
-import { MemoizeRpcs } from "@memoize/wire";
+import { MemoizeRpcs } from "@zuse/wire";
 import { Effect, Layer } from "effect";
 
 import { DiagnosticsService } from "./services/diagnostics-service.ts";

--- a/apps/server/src/diagnostics/layers/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/layers/diagnostics-service.ts
@@ -17,7 +17,7 @@ import {
   DiagnosticsExportError,
   DiagnosticsExportResult,
   type AgentAvailability,
-} from "@memoize/wire";
+} from "@zuse/wire";
 
 import packageJson from "../../../package.json" with { type: "json" };
 import { AppPaths } from "../../app-paths.ts";

--- a/apps/server/src/diagnostics/services/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/services/diagnostics-service.ts
@@ -3,7 +3,7 @@ import { Context, type Effect } from "effect";
 import type {
   DiagnosticsExportError,
   DiagnosticsExportResult,
-} from "@memoize/wire";
+} from "@zuse/wire";
 
 export interface DiagnosticsServiceShape {
   readonly exportBundle: () => Effect.Effect<


### PR DESCRIPTION
## Summary

Fixes the packaged Electron startup crash caused by stale `@memoize/wire` imports after the wire package was renamed to `@zuse/wire`.

## Root Cause

A few auth and diagnostics files still imported `@memoize/wire`. The package no longer exists in this repo, so the desktop bundle emitted `require("@memoize/wire")` and crashed at runtime with `Cannot find module '@memoize/wire'`.

The stale imports were introduced by:
- PR #219 / `d6b8540` for auth
- PR #206 / `8fe44d8` for diagnostics

## Changes

- Replaced remaining `@memoize/wire` imports with `@zuse/wire`.
- Updated the stale auth comment to reference `@zuse/wire`.
- Did not add a compatibility alias or dependency.

## Validation

- `rg -n "@memoize/wire|memoize/wire" apps packages apps/desktop/dist-electron` returns no matches.
- `bun run build:desktop` succeeds.
- Rebuilt `apps/desktop/dist-electron/main.cjs` no longer contains `require("@memoize/wire")`.
- `bun run check-types` succeeds.