### PR TITLE
[codex] Show approve bar for emulated plan mode

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -80,6 +80,7 @@ import { cn, formatCompactNumber } from "~/lib/utils";
 import {
   chooseComposerSubmitRoute,
   findPendingPlanApprovalRequest,
+  hasEmulatedPlanAwaitingAction,
   shouldSendPlanFeedbackNow,
 } from "~/lib/plan-feedback-routing";
 import {
@@ -90,7 +91,10 @@ import { parseComposerInput } from "../composer/segment-parser.ts";
 import { AnnotationTray } from "./composer/annotation-tray.tsx";
 import { ComposerChipOverlay } from "./composer/composer-chip-overlay.tsx";
 import { FileTagPopover } from "./composer/file-tag-popover.tsx";
-import { PlanApprovalTray } from "./composer/plan-approval-tray.tsx";
+import {
+  EMULATED_PLAN_APPROVAL_PROMPT,
+  PlanApprovalTray,
+} from "./composer/plan-approval-tray.tsx";
 import { ProjectPlanTray } from "./composer/project-plan-tray.tsx";
 import { QueueTray } from "./composer/queue-tray.tsx";
 import { TrayPill, trayPillActionClass } from "./composer/tray-pill.tsx";
@@ -263,6 +267,15 @@ export function ChatComposer({
   const sendPlanFeedbackNow = useMemo(
     () =>
       shouldSendPlanFeedbackNow({
+        permissionMode: session.permissionMode,
+        messages: sessionMessages ?? [],
+        pendingPlanApprovalRequest,
+      }),
+    [pendingPlanApprovalRequest, session.permissionMode, sessionMessages],
+  );
+  const emulatedPlanReady = useMemo(
+    () =>
+      hasEmulatedPlanAwaitingAction({
         permissionMode: session.permissionMode,
         messages: sessionMessages ?? [],
         pendingPlanApprovalRequest,
@@ -790,6 +803,15 @@ export function ChatComposer({
   };
 
   const inPlanMode = session.permissionMode === "plan";
+  const approveEmulatedPlan = () => {
+    void (async () => {
+      await setPermissionMode(sessionId, "default");
+      await send(sessionId, EMULATED_PLAN_APPROVAL_PROMPT);
+    })();
+  };
+  const cancelEmulatedPlan = () => {
+    void setPermissionMode(sessionId, "default");
+  };
   const inUltracodeMode = reasoningLevel === "ultracode";
   // Keep the editor mounted at all times. Permissions / questions render as
   // a sibling above it, and we hide the editor block with `display: none`
@@ -837,7 +859,12 @@ export function ChatComposer({
           <Frame>
             {!isDraft ? (
               <div className="mb-1 overflow-hidden rounded-md border border-border/50 bg-muted/30 empty:hidden empty:mb-0">
-                <PlanApprovalTray sessionId={sessionId} />
+                <PlanApprovalTray
+                  sessionId={sessionId}
+                  emulatedPlanReady={emulatedPlanReady}
+                  onApproveEmulatedPlan={approveEmulatedPlan}
+                  onCancelEmulatedPlan={cancelEmulatedPlan}
+                />
                 {goalCapable && goal !== null ? (
                   <GoalBanner
                     goal={goal}

--- a/apps/renderer/src/components/composer/plan-approval-tray.tsx
+++ b/apps/renderer/src/components/composer/plan-approval-tray.tsx
@@ -6,14 +6,29 @@ import type { SessionId } from "@zuse/wire";
 import { usePermissionsStore } from "../../store/permissions.ts";
 import { TrayPill } from "./tray-pill.tsx";
 
+export const EMULATED_PLAN_APPROVAL_PROMPT =
+  "Implement the proposed plan now. Make the code changes.";
+
 /**
  * Pinned "Review plan" bar docked above the composer. The proposed plan still
  * renders inline in the chat scrollback (see `ExitPlanModeRow`); this tray only
  * hoists the Approve / Cancel decision down to where the user's cursor already
  * sits, so they don't have to scroll back up to act. Renders nothing unless an
- * `ExitPlanMode` permission request is open for this session.
+ * `ExitPlanMode` permission request is open for this session, or an emulated
+ * plan-mode provider has produced an assistant plan and is waiting for the
+ * user to continue.
  */
-export function PlanApprovalTray({ sessionId }: { sessionId: SessionId }) {
+export function PlanApprovalTray({
+  sessionId,
+  emulatedPlanReady = false,
+  onApproveEmulatedPlan,
+  onCancelEmulatedPlan,
+}: {
+  sessionId: SessionId;
+  emulatedPlanReady?: boolean;
+  onApproveEmulatedPlan?: () => void;
+  onCancelEmulatedPlan?: () => void;
+}) {
   const pendingRequest = usePermissionsStore((s) => {
     for (const req of Object.values(s.requestsById)) {
       if (req.sessionId !== sessionId) continue;
@@ -25,14 +40,19 @@ export function PlanApprovalTray({ sessionId }: { sessionId: SessionId }) {
   });
   const decide = usePermissionsStore((s) => s.decide);
 
-  if (pendingRequest === null) return null;
+  if (pendingRequest === null && !emulatedPlanReady) return null;
+  const isPermissionBacked = pendingRequest !== null;
 
   return (
     <TrayPill
       flush
       className="bg-rose-500/10 hover:bg-rose-500/15"
       icon={
-        <HugeiconsIcon icon={CheckListIcon} strokeWidth={2} className="size-3.5" />
+        <HugeiconsIcon
+          icon={CheckListIcon}
+          strokeWidth={2}
+          className="size-3.5"
+        />
       }
       title="Review plan"
       subtitle="Approve to start building"
@@ -40,15 +60,28 @@ export function PlanApprovalTray({ sessionId }: { sessionId: SessionId }) {
         <>
           <button
             type="button"
-            onClick={() => void decide(pendingRequest.id, { _tag: "Deny" })}
+            onClick={() => {
+              if (pendingRequest !== null) {
+                void decide(pendingRequest.id, { _tag: "Deny" });
+                return;
+              }
+              onCancelEmulatedPlan?.();
+            }}
             className="rounded-md px-2.5 py-0.5 text-[12px] text-muted-foreground hover:bg-muted/60 hover:text-foreground"
           >
             Cancel
           </button>
           <button
             type="button"
-            onClick={() =>
-              void decide(pendingRequest.id, { _tag: "AllowOnce" })
+            onClick={() => {
+              if (pendingRequest !== null) {
+                void decide(pendingRequest.id, { _tag: "AllowOnce" });
+                return;
+              }
+              onApproveEmulatedPlan?.();
+            }}
+            disabled={
+              !isPermissionBacked && onApproveEmulatedPlan === undefined
             }
             className="rounded-md bg-foreground px-2.5 py-0.5 text-[12px] font-medium text-background hover:opacity-90"
           >

--- a/apps/renderer/src/lib/plan-feedback-routing.ts
+++ b/apps/renderer/src/lib/plan-feedback-routing.ts
@@ -73,6 +73,22 @@ export const shouldSendPlanFeedbackNow = ({
   return false;
 };
 
+export const hasEmulatedPlanAwaitingAction = ({
+  permissionMode,
+  messages,
+  pendingPlanApprovalRequest,
+}: {
+  readonly permissionMode: PermissionMode;
+  readonly messages: ReadonlyArray<Pick<Message, "content">>;
+  readonly pendingPlanApprovalRequest: PermissionRequest | null;
+}): boolean =>
+  pendingPlanApprovalRequest === null &&
+  shouldSendPlanFeedbackNow({
+    permissionMode,
+    messages,
+    pendingPlanApprovalRequest,
+  });
+
 export type ComposerSubmitRoute = "planFeedback" | "goal" | "queue" | "send";
 
 export const chooseComposerSubmitRoute = ({

--- a/apps/renderer/test/plan-feedback-routing.test.ts
+++ b/apps/renderer/test/plan-feedback-routing.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   chooseComposerSubmitRoute,
   findPendingPlanApprovalRequest,
+  hasEmulatedPlanAwaitingAction,
   shouldSendPlanFeedbackNow,
 } from "../src/lib/plan-feedback-routing.ts";
 
@@ -72,6 +73,26 @@ describe("plan feedback routing", () => {
         pendingPlanApprovalRequest: null,
       }),
     ).toBe(true);
+  });
+
+  it("marks emulated provider plans as awaiting an explicit action", () => {
+    expect(
+      hasEmulatedPlanAwaitingAction({
+        permissionMode: "plan",
+        messages: [user(), assistant()],
+        pendingPlanApprovalRequest: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not use the emulated approval state for native plan permission requests", () => {
+    expect(
+      hasEmulatedPlanAwaitingAction({
+        permissionMode: "plan",
+        messages: [user(), toolUse("ExitPlanMode")],
+        pendingPlanApprovalRequest: exitPlanRequest,
+      }),
+    ).toBe(false);
   });
 
   it("keeps normal running turns on the queue path before an assistant response", () => {


### PR DESCRIPTION
## Summary

Adds an explicit Review plan bar for Codex and other emulated plan-mode providers after they produce an assistant plan without a native `ExitPlanMode` permission request.

## Why

Claude plan mode exposes a real permission request, so Zuse could already show Approve/Cancel. Codex plan mode is emulated with prompt instructions, so the existing tray never rendered and users were left with no visible approve button.

## Changes

- Detect emulated plan-mode sessions that have produced an assistant plan and are waiting for user action.
- Reuse the existing pinned plan approval tray for that state.
- Wire Approve to exit plan mode and send the implementation confirmation.
- Wire Cancel to exit plan mode without sending.
- Keep native Claude `ExitPlanMode` permission-request behavior unchanged.

## Validation

- `bun test apps/renderer/test/plan-feedback-routing.test.ts`
- `bun run --cwd apps/renderer check-types`
- `bun run build:desktop`
