### PR TITLE
[codex] Remove competitor mentions

### DIFF
--- a/apps/renderer/src/components/file-tree.tsx
+++ b/apps/renderer/src/components/file-tree.tsx
@@ -756,7 +756,7 @@ function FileTreeContextMenu({
         {entry?.kind === "file" && (
           <MenuItem onClick={() => onOpenInEditor(entry)}>
             <HugeiconsIcon icon={PencilEdit01Icon} className="size-4" />
-            Open in Conductor editor
+            Open in editor
           </MenuItem>
         )}
         {entry !== null && (

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -180,13 +180,13 @@ export const selectCliPathCandidate = (
   if (candidates.length === 0) return null;
   if (cliBinary !== "codex") return candidates[0]!;
 
-  // Conductor can prepend its managed Codex shim to PATH for app internals.
+  // Some environments can prepend a managed Codex shim to PATH for internals.
   // Provider settings should report the user's real Codex install, not that
   // managed binary.
   return (
     candidates.find(
       (candidate) =>
-        !isConductorManagedCodexPath(normalizeCommandPath(candidate)),
+        !isManagedCodexShimPath(normalizeCommandPath(candidate)),
     ) ?? null
   );
 };
@@ -436,7 +436,7 @@ const isHomebrewPath = (p: string): boolean =>
   p.startsWith("/opt/homebrew/bin/") ||
   p.startsWith("/usr/local/bin/");
 
-const isConductorManagedCodexPath = (p: string): boolean =>
+const isManagedCodexShimPath = (p: string): boolean =>
   p.endsWith("/application support/com.conductor.app/bin/codex") ||
   (p.includes("/application support/com.conductor.app/agent-binaries/codex/") &&
     p.endsWith("/codex"));

--- a/apps/server/test/availability.test.ts
+++ b/apps/server/test/availability.test.ts
@@ -275,7 +275,7 @@ describe("deriveLatestAdvisory — update-available verdict", () => {
 });
 
 describe("selectCliPathCandidate", () => {
-  it("prefers a user Codex install over Conductor's managed Codex shim", () => {
+  it("prefers a user Codex install over a managed Codex shim", () => {
     expect(
       selectCliPathCandidate("codex", [
         "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
@@ -284,7 +284,7 @@ describe("selectCliPathCandidate", () => {
     ).toBe("/Users/me/.nvm/versions/node/v23.10.0/bin/codex");
   });
 
-  it("does not select Conductor's managed Codex when it is the only candidate", () => {
+  it("does not select a managed Codex shim when it is the only candidate", () => {
     expect(
       selectCliPathCandidate("codex", [
         "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
@@ -303,7 +303,7 @@ describe("selectCliPathCandidate", () => {
 });
 
 describe("buildUpdateCommand — install-method detection", () => {
-  it("does not offer an updater for Conductor's managed standalone Codex", () => {
+  it("does not offer an updater for a managed standalone Codex shim", () => {
     expect(
       buildUpdateCommand("codex", [
         "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",


### PR DESCRIPTION
## Summary
- remove the Conductor brand mention from the file-tree context menu copy
- rename managed Codex shim helper/test wording to avoid naming Conductor in code descriptions
- preserve required com.conductor.app path literals used for shim detection

## Validation
- bun test apps/server/test/availability.test.ts
- bun run --cwd apps/server check-types
- bun run --cwd apps/renderer check-types