### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0]
+
+### Changed
+- [codex] Fix dirty worktree removal feedback (#222)
+- [codex] Remove competitor mentions (#227)
+- [codex] Show approve bar for emulated plan mode (#226)
+- Clean up stale memoize branding (#225)
+- [codex] fix codex context status accounting (#224)
+- [codex] Fix stale wire package imports (#223)
+- [codex] Polish streaming chat motion (#221)
+- feat(auth): WorkOS AuthKit login (PKCE, keychain, optional) (#219)
+- [codex] Add Claude Fable 5 support (#220)
+- Add diagnostics bundle export (#206)
+- [codex] Refine renderer color palette (#216)
+- [codex] Float chat scroll controls (#217)
+- [codex] clean model picker (#215)
+- Fix messages not appearing until chat re-open (hydrate race) (#210)
+
 ## [0.8.3]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "0.9.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "[codex] Fix dirty worktree removal feedback (#222)",
+          "[codex] Remove competitor mentions (#227)",
+          "[codex] Show approve bar for emulated plan mode (#226)",
+          "Clean up stale memoize branding (#225)",
+          "[codex] fix codex context status accounting (#224)",
+          "[codex] Fix stale wire package imports (#223)",
+          "[codex] Polish streaming chat motion (#221)",
+          "feat(auth): WorkOS AuthKit login (PKCE, keychain, optional) (#219)",
+          "[codex] Add Claude Fable 5 support (#220)",
+          "Add diagnostics bundle export (#206)",
+          "[codex] Refine renderer color palette (#216)",
+          "[codex] Float chat scroll controls (#217)",
+          "[codex] clean model picker (#215)",
+          "Fix messages not appearing until chat re-open (hydrate race) (#210)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.8.3",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release Zuse v0.9.0
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.9.0 after this PR lands.