### PR TITLE
[codex] add light and system appearance support

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -64,14 +64,26 @@ function tcpReady(host, port, timeoutMs = 500) {
   });
 }
 
-async function waitForResources({ timeoutMs = 120_000, intervalMs = 100 } = {}) {
+async function waitForResources({
+  timeoutMs = 120_000,
+  intervalMs = 100,
+} = {}) {
+  console.log(
+    `[desktop:electron] waiting for ${devServerUrl} and ${requiredFiles.join(", ")}`,
+  );
   const startedAt = Date.now();
   while (true) {
     const filesReady = await Promise.all(
       requiredFiles.map((rel) => fileExists(resolve(desktopDir, rel))),
     ).then((results) => results.every(Boolean));
-    const portReady = await tcpReady(devServer.hostname || "127.0.0.1", devPort);
-    if (filesReady && portReady) return;
+    const portReady = await tcpReady(
+      devServer.hostname || "127.0.0.1",
+      devPort,
+    );
+    if (filesReady && portReady) {
+      console.log("[desktop:electron] resources ready");
+      return;
+    }
     if (Date.now() - startedAt >= timeoutMs) {
       throw new Error(
         `Timed out waiting for dev resources (port ${devPort}, files ${requiredFiles.join(", ")})`,
@@ -90,6 +102,7 @@ function startApp() {
   if (shuttingDown || currentApp !== null) return;
 
   const electronPath = require("electron");
+  console.log(`[desktop:electron] launching ${electronPath}`);
   const app = spawn(electronPath, [".", "--memoize-dev"], {
     cwd: desktopDir,
     // Pass the resolved dev URL through explicitly so main.ts sees it even
@@ -99,12 +112,16 @@ function startApp() {
   });
   currentApp = app;
 
-  app.once("error", () => {
+  app.once("error", (error) => {
+    console.error("[desktop:electron] failed to launch", error);
     if (currentApp === app) currentApp = null;
     if (!shuttingDown) scheduleRestart();
   });
 
   app.once("exit", (code, signal) => {
+    console.log(
+      `[desktop:electron] exited (code=${code ?? "null"} signal=${signal ?? "null"})`,
+    );
     if (currentApp === app) currentApp = null;
     const abnormal = signal !== null || code !== 0;
     if (!shuttingDown && !expectedExits.has(app) && abnormal) scheduleRestart();
@@ -152,9 +169,14 @@ function scheduleRestart() {
 
 function startWatcher() {
   const watchedFiles = new Set(["main.cjs", "preload.cjs"]);
-  return watch(join(desktopDir, "dist-electron"), { persistent: true }, (_event, filename) => {
-    if (typeof filename === "string" && watchedFiles.has(filename)) scheduleRestart();
-  });
+  return watch(
+    join(desktopDir, "dist-electron"),
+    { persistent: true },
+    (_event, filename) => {
+      if (typeof filename === "string" && watchedFiles.has(filename))
+        scheduleRestart();
+    },
+  );
 }
 
 async function shutdown(code) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -170,9 +170,34 @@ const startAuthLoopback = (): void => {
   authLoopbackServer = server;
 };
 
+const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL?.trim() || "";
+const isDevelopment = Boolean(DEV_SERVER_URL);
+
+const APP_NAME = isDevelopment ? "Zuse Alpha (Dev)" : "Zuse Alpha";
+const DEV_ICON_PATH = Path.resolve(__dirname, "..", "build", "icon.png");
+
+app.setName(APP_NAME);
+if (
+  isDevelopment &&
+  process.platform === "darwin" &&
+  fsSync.existsSync(DEV_ICON_PATH)
+) {
+  app.dock?.setIcon(DEV_ICON_PATH);
+}
+
+const ZUSE_USER_DATA_DIR =
+  process.env.ZUSE_USER_DATA_DIR?.trim() ||
+  process.env.MEMOIZE_USER_DATA_DIR?.trim();
+if (ZUSE_USER_DATA_DIR) {
+  fsSync.mkdirSync(ZUSE_USER_DATA_DIR, { recursive: true });
+  app.setPath("userData", ZUSE_USER_DATA_DIR);
+}
+
 // Single-instance lock: required so a deep link launched while the app is
 // already running routes through `second-instance` (Win/Linux) rather than
-// spawning a second copy. macOS delivers via `open-url` regardless.
+// spawning a second copy. macOS delivers via `open-url` regardless. App name
+// and userData must be set first so dev workspaces don't collide with the
+// packaged app or with each other.
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
 if (!gotSingleInstanceLock) {
   app.quit();
@@ -184,27 +209,14 @@ app.on("open-url", (event, url) => {
   handleAuthCallback(url);
 });
 
-const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL?.trim() || "";
-const isDevelopment = Boolean(DEV_SERVER_URL);
-
-const APP_NAME = isDevelopment ? "Zuse Alpha (Dev)" : "Zuse Alpha";
-
-app.setName(APP_NAME);
-
-const ZUSE_USER_DATA_DIR =
-  process.env.ZUSE_USER_DATA_DIR?.trim() ||
-  process.env.MEMOIZE_USER_DATA_DIR?.trim();
-if (ZUSE_USER_DATA_DIR) {
-  fsSync.mkdirSync(ZUSE_USER_DATA_DIR, { recursive: true });
-  app.setPath("userData", ZUSE_USER_DATA_DIR);
-}
-
-// Lock the app to macOS's dark appearance so the sidebar vibrancy material
-// always renders in its dark variant. Without this, vibrancy follows the
-// user's system theme — on a light-mode Mac the bright material lets the
-// desktop wallpaper bleed through and washes out the (hardcoded-dark)
-// renderer UI.
+// Start dark to preserve the historical launch appearance. The renderer sends
+// the persisted Light / Dark / System preference after settings hydrate.
 nativeTheme.themeSource = "dark";
+
+ipcMain.on("window:setAppearanceMode", (_event, value: unknown) => {
+  if (value !== "system" && value !== "light" && value !== "dark") return;
+  nativeTheme.themeSource = value;
+});
 
 let mainWindow: BrowserWindow | null = null;
 let runtimeFiber: Fiber.RuntimeFiber<void, never> | null = null;
@@ -550,6 +562,7 @@ function createMainWindow() {
           backgroundColor: "#00000000",
         }
       : { backgroundColor: "#0b0b0c" }),
+    ...(fsSync.existsSync(DEV_ICON_PATH) ? { icon: DEV_ICON_PATH } : {}),
     titleBarStyle: isMac ? "hiddenInset" : "default",
     title: APP_NAME,
     webPreferences: {
@@ -924,7 +937,7 @@ function createMainWindow() {
 
   if (isDevelopment) {
     void mainWindow.loadURL(DEV_SERVER_URL);
-    mainWindow.webContents.openDevTools({ mode: "detach" });
+    mainWindow.webContents.openDevTools({ mode: "right" });
   } else {
     // In dev `dist-electron/main.cjs` lives at apps/desktop/dist-electron/
     // and the renderer is two levels up at apps/renderer/dist. In the

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -39,6 +39,9 @@ const bridge = {
         ipcRenderer.off("window:fullscreen", wrapped);
       };
     },
+    setAppearanceMode: (mode: "system" | "light" | "dark") => {
+      ipcRenderer.send("window:setAppearanceMode", mode);
+    },
   },
   browser: {
     /**

--- a/apps/renderer/index.html
+++ b/apps/renderer/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -35,6 +35,7 @@ import { UsageDashboard } from "./components/usage-dashboard.tsx";
 import { useKeybindingDispatch } from "./hooks/use-keybinding-dispatch.ts";
 import { useMenuShortcuts } from "./hooks/use-menu-shortcuts.ts";
 import { getRpcClient } from "./lib/rpc-client.ts";
+import { AppearanceController } from "./lib/appearance.tsx";
 import { useAuthStore } from "./store/auth.ts";
 import { useKeybindingsStore } from "./store/keybindings.ts";
 import { usePermissionsStore } from "./store/permissions.ts";
@@ -225,7 +226,8 @@ export function App() {
   if (!onboardingCompleted) {
     return (
       <TooltipProvider>
-        <div className="dark relative flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background text-foreground">
+        <AppearanceController />
+        <div className="relative flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background text-foreground">
           <OnboardingWizard />
         </div>
       </TooltipProvider>
@@ -235,7 +237,8 @@ export function App() {
   if (view === "settings") {
     return (
       <TooltipProvider>
-        <div className="dark flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background text-foreground">
+        <AppearanceController />
+        <div className="flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden bg-background text-foreground">
           <SettingsPage />
         </div>
       </TooltipProvider>
@@ -244,6 +247,7 @@ export function App() {
 
   return (
     <TooltipProvider>
+      <AppearanceController />
       <MainShell />
     </TooltipProvider>
   );
@@ -357,7 +361,7 @@ function MainShell() {
   useAnimatedPanelCollapse(rightPanelRef, rightSidebarOpen, 22, rightAnimating);
 
   return (
-    <div className="dark flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden text-foreground">
+    <div className="flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden text-foreground">
       <Group
         id={PANEL_GROUP_ID}
         orientation="horizontal"

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1136,7 +1136,7 @@ function FastModeToggle({ sessionId }: { sessionId: SessionId }) {
             className={cn(
               "flex h-6 items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
               enabled
-                ? "bg-amber-300/15 text-amber-200 dark:text-amber-200 hover:bg-amber-300/25"
+                ? "bg-amber-400/20 text-amber-700 hover:bg-amber-400/30 dark:bg-amber-300/15 dark:text-amber-200 dark:hover:bg-amber-300/25"
                 : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
             )}
           >
@@ -1188,7 +1188,7 @@ function PlanModeToggle({
             className={cn(
               "flex h-6 items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
               isPlan
-                ? "bg-rose-300/15 text-rose-200 dark:text-rose-200 hover:bg-rose-300/25"
+                ? "bg-rose-400/20 text-rose-700 hover:bg-rose-400/30 dark:bg-rose-300/15 dark:text-rose-200 dark:hover:bg-rose-300/25"
                 : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
             )}
           >
@@ -1226,9 +1226,9 @@ function GoalModeToggle({
             className={cn(
               "flex h-6 items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
               active
-                ? "bg-amber-300/15 text-amber-200 hover:bg-amber-300/25"
+                ? "bg-amber-400/20 text-amber-700 hover:bg-amber-400/30 dark:bg-amber-300/15 dark:text-amber-200 dark:hover:bg-amber-300/25"
                 : hasGoal
-                  ? "text-amber-200 hover:bg-muted/60"
+                  ? "text-amber-700 hover:bg-muted/60 dark:text-amber-200"
                   : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
             )}
           >

--- a/apps/renderer/src/components/code-block.tsx
+++ b/apps/renderer/src/components/code-block.tsx
@@ -7,13 +7,15 @@ import {
 } from "shiki";
 
 import { cn } from "~/lib/utils";
+import { useResolvedAppearance } from "~/lib/appearance.tsx";
 import { CopyButton } from "./copy-button.tsx";
 import { FileIcon } from "./file-icon.tsx";
 
-const THEME = "memoize-dark" as const;
+const DARK_THEME = "memoize-dark" as const;
+const LIGHT_THEME = "memoize-light" as const;
 
-const MEMOIZE_SHIKI_THEME: ThemeRegistration = {
-  name: THEME,
+const MEMOIZE_DARK_SHIKI_THEME: ThemeRegistration = {
+  name: DARK_THEME,
   type: "dark",
   colors: {
     "editor.background": "#00000000",
@@ -74,6 +76,76 @@ const MEMOIZE_SHIKI_THEME: ThemeRegistration = {
     {
       scope: ["invalid", "invalid.illegal"],
       settings: { foreground: "#f87171" },
+    },
+  ],
+};
+
+const MEMOIZE_LIGHT_SHIKI_THEME: ThemeRegistration = {
+  name: LIGHT_THEME,
+  type: "light",
+  colors: {
+    "editor.background": "#00000000",
+    "editor.foreground": "var(--foreground)",
+    "editorLineNumber.foreground": "var(--muted-foreground)",
+    "editor.selectionBackground":
+      "color-mix(in oklab, var(--primary) 22%, transparent)",
+  },
+  tokenColors: [
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: { foreground: "var(--muted-foreground)", fontStyle: "italic" },
+    },
+    {
+      scope: ["keyword", "storage", "storage.type", "constant.language"],
+      settings: { foreground: "var(--syntax-keyword)" },
+    },
+    {
+      scope: ["string", "constant.character", "markup.inline.raw.string"],
+      settings: { foreground: "var(--syntax-string)" },
+    },
+    {
+      scope: ["constant.numeric", "constant.language.boolean"],
+      settings: { foreground: "var(--syntax-number)" },
+    },
+    {
+      scope: ["entity.name.function", "support.function", "variable.function"],
+      settings: { foreground: "var(--syntax-function)" },
+    },
+    {
+      scope: [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class",
+      ],
+      settings: { foreground: "var(--syntax-type)" },
+    },
+    {
+      scope: ["entity.other.attribute-name", "variable.parameter"],
+      settings: { foreground: "var(--syntax-attribute)" },
+    },
+    {
+      scope: ["entity.name.tag", "support.class.component"],
+      settings: { foreground: "var(--syntax-tag)" },
+    },
+    {
+      scope: ["punctuation", "meta.brace", "keyword.operator"],
+      settings: { foreground: "var(--muted-foreground)" },
+    },
+    {
+      scope: ["markup.heading", "entity.name.section"],
+      settings: { foreground: "var(--message-heading)", fontStyle: "bold" },
+    },
+    {
+      scope: ["markup.link", "string.other.link"],
+      settings: {
+        foreground: "var(--syntax-function)",
+        fontStyle: "underline",
+      },
+    },
+    {
+      scope: ["invalid", "invalid.illegal"],
+      settings: { foreground: "var(--destructive)" },
     },
   ],
 };
@@ -203,7 +275,7 @@ const basename = (p: string): string => {
 let highlighterPromise: Promise<Highlighter> | null = null;
 const getHighlighter = (): Promise<Highlighter> => {
   highlighterPromise ??= createHighlighter({
-    themes: [MEMOIZE_SHIKI_THEME],
+    themes: [MEMOIZE_DARK_SHIKI_THEME, MEMOIZE_LIGHT_SHIKI_THEME],
     langs: [...LANGS],
   });
   return highlighterPromise;
@@ -238,6 +310,8 @@ export function CodeBlock({
   maxHeight = 420,
   isError = false,
 }: Props) {
+  const resolvedAppearance = useResolvedAppearance();
+  const theme = resolvedAppearance === "dark" ? DARK_THEME : LIGHT_THEME;
   const lang = useMemo(
     () => langForLanguage(language) ?? langForFilename(filename),
     [filename, language],
@@ -266,7 +340,7 @@ export function CodeBlock({
         if (cancelled) return;
         const out = hl.codeToHtml(safeText, {
           lang,
-          theme: THEME,
+          theme,
           transformers: [
             {
               line(node, line) {
@@ -284,7 +358,7 @@ export function CodeBlock({
     return () => {
       cancelled = true;
     };
-  }, [safeText, lang]);
+  }, [safeText, lang, theme]);
 
   const name = title ?? basename(filename);
   const lineCount = safeText.length === 0 ? 0 : safeText.split("\n").length;

--- a/apps/renderer/src/components/file-chip.tsx
+++ b/apps/renderer/src/components/file-chip.tsx
@@ -114,7 +114,7 @@ export function AnnotationFileChip({
   return (
     <span
       className={cn(
-        "inline-flex max-w-full shrink-0 items-center gap-1.5 rounded-[0.375rem] border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]",
+        "inline-flex max-w-full shrink-0 items-center gap-1.5 rounded-[0.375rem] border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]",
         className,
       )}
       title={`${annotation.relPath}:${range}`}
@@ -243,9 +243,9 @@ export function FileChip({
             onClick={canOpen ? onChipClick : undefined}
             onKeyDown={canOpen ? onKeyDown : undefined}
             className={cn(
-              "inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)] transition-[background-color,color,box-shadow]",
+              "inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 transition-[background-color,color,box-shadow] dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]",
               canOpen
-                ? "cursor-pointer hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground hover:shadow-[inset_0_1px_0_color-mix(in_oklch,white_6%,transparent),0_2px_5px_color-mix(in_oklch,black_24%,transparent)]"
+                ? "cursor-pointer hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground dark:hover:shadow-[inset_0_1px_0_color-mix(in_oklch,white_6%,transparent),0_2px_5px_color-mix(in_oklch,black_24%,transparent)]"
                 : "cursor-default",
               className,
             )}

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -38,7 +38,7 @@ export function JumpToLatestPill({
         className={cn(
           "pointer-events-auto inline-flex items-center gap-1.5 rounded-full",
           "border border-border/60 bg-popover/95 px-3 py-1.5 text-xs text-muted-foreground",
-          "shadow-[0_2px_8px_color-mix(in_oklch,black_28%,transparent)] backdrop-blur",
+          "backdrop-blur dark:shadow-[0_2px_8px_color-mix(in_oklch,black_28%,transparent)]",
           "hover:text-foreground hover:bg-popover",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           !visible && "pointer-events-none",

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -387,7 +387,7 @@ function UserBubble({
               const iconUrl = isImage ? null : getFileIconUrl(a.originalName);
               const src = `zuse://attachments/${a.id}`;
               const className =
-                "inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)] hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground";
+                "inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]";
               const inner = (
                 <>
                   {isImage ? (
@@ -445,7 +445,7 @@ function UserBubble({
             {(skillRefs ?? []).map((s) => (
               <span
                 key={s.name}
-                className="inline-flex items-center rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]"
+                className="inline-flex items-center rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]"
               >
                 /{s.name}
               </span>
@@ -839,7 +839,7 @@ export function ErrorBubble({
   if (rateLimit !== null) {
     return (
       <div className="px-4 py-1.5">
-        <div className="inline-flex max-w-[88%] items-center gap-2 rounded-md border border-border/45 bg-[color-mix(in_oklch,var(--bg-elevated)_34%,var(--background))] px-2.5 py-1.5 text-xs text-foreground shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]">
+        <div className="inline-flex max-w-[88%] items-center gap-2 rounded-md border border-border/45 bg-[color-mix(in_oklch,var(--bg-elevated)_34%,var(--background))] px-2.5 py-1.5 text-xs text-foreground dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]">
           <span className="font-medium">Limit reached</span>
           <span className="text-muted-foreground">
             {formatResetDetail(rateLimit)}
@@ -864,7 +864,7 @@ export function ErrorBubble({
     const isFinalAttempt = reconnecting.attempt >= reconnecting.maxAttempts;
     return (
       <div className="px-4 py-1.5">
-        <div className="inline-flex max-w-[88%] items-center gap-2 rounded-md border border-border/45 bg-[color-mix(in_oklch,var(--bg-elevated)_34%,var(--background))] px-2.5 py-1.5 text-xs text-foreground shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]">
+        <div className="inline-flex max-w-[88%] items-center gap-2 rounded-md border border-border/45 bg-[color-mix(in_oklch,var(--bg-elevated)_34%,var(--background))] px-2.5 py-1.5 text-xs text-foreground dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]">
           <span className="font-medium">Reconnecting</span>
           <span className="font-mono text-muted-foreground">
             {reconnecting.attempt}/{reconnecting.maxAttempts}

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -673,7 +673,7 @@ function ProviderSectionHeader({
         {PROVIDER_LABEL[providerId]}
       </span>
       {current && (
-        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22">
+        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22 dark:text-primary">
           Current
         </span>
       )}
@@ -767,7 +767,7 @@ function ModelRow({
       </span>
       <span className="flex-1" />
       {entry.badgeLabel !== undefined && (
-        <span className="shrink-0 rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22">
+        <span className="shrink-0 rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22 dark:text-primary">
           {entry.badgeLabel}
         </span>
       )}
@@ -791,7 +791,7 @@ function ModelRow({
         </span>
       )}
       {showNowBadge && isActive && (
-        <span className="rounded-[0.25rem] border border-primary/65 bg-primary/40 px-1.5 py-px font-semibold text-[9px] text-primary uppercase tracking-wide dark:border-primary/55 dark:bg-primary/28">
+        <span className="rounded-[0.25rem] border border-primary/65 bg-primary/40 px-1.5 py-px font-semibold text-[9px] text-primary-foreground uppercase tracking-wide dark:border-primary/55 dark:bg-primary/28 dark:text-primary">
           now
         </span>
       )}

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -673,7 +673,7 @@ function ProviderSectionHeader({
         {PROVIDER_LABEL[providerId]}
       </span>
       {current && (
-        <span className="rounded bg-primary/15 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
+        <span className="rounded-full border border-primary/25 bg-primary/8 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
           Current
         </span>
       )}
@@ -753,7 +753,7 @@ function ModelRow({
           {entry.contextWindowLabel !== undefined && (
             <span
               title={`${entry.contextWindowLabel} context window`}
-              className="shrink-0 rounded bg-muted/70 px-1 py-px text-[10px] font-medium text-muted-foreground"
+              className="shrink-0 rounded-full border border-border/50 bg-muted/45 px-1.5 py-px text-[10px] font-medium text-muted-foreground"
             >
               {entry.contextWindowLabel}
             </span>
@@ -767,7 +767,7 @@ function ModelRow({
       </span>
       <span className="flex-1" />
       {entry.badgeLabel !== undefined && (
-        <span className="shrink-0 rounded bg-primary/15 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
+        <span className="shrink-0 rounded-full border border-primary/25 bg-primary/8 px-2 py-0.5 text-[9px] font-semibold text-primary uppercase tracking-[0.08em]">
           {entry.badgeLabel}
         </span>
       )}
@@ -791,12 +791,12 @@ function ModelRow({
         </span>
       )}
       {showNowBadge && isActive && (
-        <span className="rounded bg-primary px-1.5 py-px font-medium text-[9px] text-primary-foreground uppercase tracking-wider">
+        <span className="rounded-full border border-primary/35 bg-primary/15 px-1.5 py-px font-semibold text-[9px] text-primary uppercase tracking-[0.08em]">
           now
         </span>
       )}
       {shortcut !== undefined && shortcut !== null && (
-        <kbd className="ml-0.5 rounded bg-muted/70 px-1 py-px font-medium text-[10px] text-muted-foreground tabular-nums">
+        <kbd className="ml-0.5 flex h-5 min-w-5 items-center justify-center rounded-full border border-border/45 bg-muted/45 px-1 font-medium text-[10px] text-muted-foreground tabular-nums">
           {shortcut}
         </kbd>
       )}

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -673,7 +673,7 @@ function ProviderSectionHeader({
         {PROVIDER_LABEL[providerId]}
       </span>
       {current && (
-        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22 dark:text-primary">
+        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-0 dark:bg-primary/15 dark:text-primary">
           Current
         </span>
       )}
@@ -753,7 +753,7 @@ function ModelRow({
           {entry.contextWindowLabel !== undefined && (
             <span
               title={`${entry.contextWindowLabel} context window`}
-              className="shrink-0 rounded-[0.25rem] border border-border/70 bg-muted px-1.5 py-px text-[10px] font-medium text-foreground/70"
+              className="shrink-0 rounded-[0.25rem] border border-border/70 bg-muted px-1.5 py-px text-[10px] font-medium text-foreground/70 dark:border-0 dark:bg-muted/70 dark:px-1 dark:text-muted-foreground"
             >
               {entry.contextWindowLabel}
             </span>
@@ -767,7 +767,7 @@ function ModelRow({
       </span>
       <span className="flex-1" />
       {entry.badgeLabel !== undefined && (
-        <span className="shrink-0 rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22 dark:text-primary">
+        <span className="shrink-0 rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-0 dark:bg-primary/15 dark:text-primary">
           {entry.badgeLabel}
         </span>
       )}
@@ -791,12 +791,12 @@ function ModelRow({
         </span>
       )}
       {showNowBadge && isActive && (
-        <span className="rounded-[0.25rem] border border-primary/65 bg-primary/40 px-1.5 py-px font-semibold text-[9px] text-primary-foreground uppercase tracking-wide dark:border-primary/55 dark:bg-primary/28 dark:text-primary">
+        <span className="rounded-[0.25rem] border border-primary/65 bg-primary/40 px-1.5 py-px font-semibold text-[9px] text-primary-foreground uppercase tracking-wide dark:border-0 dark:bg-primary dark:font-medium dark:text-primary-foreground dark:tracking-wider">
           now
         </span>
       )}
       {shortcut !== undefined && shortcut !== null && (
-        <kbd className="ml-0.5 flex h-5 min-w-5 items-center justify-center rounded-[0.25rem] border border-border/70 bg-muted px-1 font-medium text-[10px] text-foreground/70 tabular-nums">
+        <kbd className="ml-0.5 flex h-5 min-w-5 items-center justify-center rounded-[0.25rem] border border-border/70 bg-muted px-1 font-medium text-[10px] text-foreground/70 tabular-nums dark:h-auto dark:min-w-0 dark:border-0 dark:bg-muted/70 dark:text-muted-foreground">
           {shortcut}
         </kbd>
       )}

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -673,7 +673,7 @@ function ProviderSectionHeader({
         {PROVIDER_LABEL[providerId]}
       </span>
       {current && (
-        <span className="rounded-full border border-primary/25 bg-primary/8 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
+        <span className="rounded-[0.25rem] border border-primary/45 bg-primary/22 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
           Current
         </span>
       )}
@@ -753,7 +753,7 @@ function ModelRow({
           {entry.contextWindowLabel !== undefined && (
             <span
               title={`${entry.contextWindowLabel} context window`}
-              className="shrink-0 rounded-full border border-border/50 bg-muted/45 px-1.5 py-px text-[10px] font-medium text-muted-foreground"
+              className="shrink-0 rounded-[0.25rem] border border-border/70 bg-muted px-1.5 py-px text-[10px] font-medium text-foreground/70"
             >
               {entry.contextWindowLabel}
             </span>
@@ -767,7 +767,7 @@ function ModelRow({
       </span>
       <span className="flex-1" />
       {entry.badgeLabel !== undefined && (
-        <span className="shrink-0 rounded-full border border-primary/25 bg-primary/8 px-2 py-0.5 text-[9px] font-semibold text-primary uppercase tracking-[0.08em]">
+        <span className="shrink-0 rounded-[0.25rem] border border-primary/45 bg-primary/22 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
           {entry.badgeLabel}
         </span>
       )}
@@ -791,12 +791,12 @@ function ModelRow({
         </span>
       )}
       {showNowBadge && isActive && (
-        <span className="rounded-full border border-primary/35 bg-primary/15 px-1.5 py-px font-semibold text-[9px] text-primary uppercase tracking-[0.08em]">
+        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/28 px-1.5 py-px font-semibold text-[9px] text-primary uppercase tracking-wide">
           now
         </span>
       )}
       {shortcut !== undefined && shortcut !== null && (
-        <kbd className="ml-0.5 flex h-5 min-w-5 items-center justify-center rounded-full border border-border/45 bg-muted/45 px-1 font-medium text-[10px] text-muted-foreground tabular-nums">
+        <kbd className="ml-0.5 flex h-5 min-w-5 items-center justify-center rounded-[0.25rem] border border-border/70 bg-muted px-1 font-medium text-[10px] text-foreground/70 tabular-nums">
           {shortcut}
         </kbd>
       )}

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -673,7 +673,7 @@ function ProviderSectionHeader({
         {PROVIDER_LABEL[providerId]}
       </span>
       {current && (
-        <span className="rounded-[0.25rem] border border-primary/45 bg-primary/22 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
+        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22">
           Current
         </span>
       )}
@@ -767,7 +767,7 @@ function ModelRow({
       </span>
       <span className="flex-1" />
       {entry.badgeLabel !== undefined && (
-        <span className="shrink-0 rounded-[0.25rem] border border-primary/45 bg-primary/22 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide">
+        <span className="shrink-0 rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary uppercase tracking-wide dark:border-primary/45 dark:bg-primary/22">
           {entry.badgeLabel}
         </span>
       )}
@@ -791,7 +791,7 @@ function ModelRow({
         </span>
       )}
       {showNowBadge && isActive && (
-        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/28 px-1.5 py-px font-semibold text-[9px] text-primary uppercase tracking-wide">
+        <span className="rounded-[0.25rem] border border-primary/65 bg-primary/40 px-1.5 py-px font-semibold text-[9px] text-primary uppercase tracking-wide dark:border-primary/55 dark:bg-primary/28">
           now
         </span>
       )}

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -673,7 +673,7 @@ function ProviderSectionHeader({
         {PROVIDER_LABEL[providerId]}
       </span>
       {current && (
-        <span className="rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-0 dark:bg-primary/15 dark:text-primary">
+        <span className="rounded-[0.25rem] bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:bg-primary/15 dark:text-primary">
           Current
         </span>
       )}
@@ -753,7 +753,7 @@ function ModelRow({
           {entry.contextWindowLabel !== undefined && (
             <span
               title={`${entry.contextWindowLabel} context window`}
-              className="shrink-0 rounded-[0.25rem] border border-border/70 bg-muted px-1.5 py-px text-[10px] font-medium text-foreground/70 dark:border-0 dark:bg-muted/70 dark:px-1 dark:text-muted-foreground"
+              className="shrink-0 rounded-[0.25rem] bg-muted px-1.5 py-px text-[10px] font-medium text-foreground/70 dark:bg-muted/70 dark:px-1 dark:text-muted-foreground"
             >
               {entry.contextWindowLabel}
             </span>
@@ -767,7 +767,7 @@ function ModelRow({
       </span>
       <span className="flex-1" />
       {entry.badgeLabel !== undefined && (
-        <span className="shrink-0 rounded-[0.25rem] border border-primary/55 bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:border-0 dark:bg-primary/15 dark:text-primary">
+        <span className="shrink-0 rounded-[0.25rem] bg-primary/35 px-1.5 py-px text-[9px] font-semibold text-primary-foreground uppercase tracking-wide dark:bg-primary/15 dark:text-primary">
           {entry.badgeLabel}
         </span>
       )}
@@ -791,12 +791,12 @@ function ModelRow({
         </span>
       )}
       {showNowBadge && isActive && (
-        <span className="rounded-[0.25rem] border border-primary/65 bg-primary/40 px-1.5 py-px font-semibold text-[9px] text-primary-foreground uppercase tracking-wide dark:border-0 dark:bg-primary dark:font-medium dark:text-primary-foreground dark:tracking-wider">
+        <span className="rounded-[0.25rem] bg-primary/40 px-1.5 py-px font-semibold text-[9px] text-primary-foreground uppercase tracking-wide dark:bg-primary dark:font-medium dark:text-primary-foreground dark:tracking-wider">
           now
         </span>
       )}
       {shortcut !== undefined && shortcut !== null && (
-        <kbd className="ml-0.5 flex h-5 min-w-5 items-center justify-center rounded-[0.25rem] border border-border/70 bg-muted px-1 font-medium text-[10px] text-foreground/70 tabular-nums dark:h-auto dark:min-w-0 dark:border-0 dark:bg-muted/70 dark:text-muted-foreground">
+        <kbd className="ml-0.5 flex h-5 min-w-5 items-center justify-center rounded-[0.25rem] bg-muted px-1 font-medium text-[10px] text-foreground/70 tabular-nums dark:h-auto dark:min-w-0 dark:bg-muted/70 dark:text-muted-foreground">
           {shortcut}
         </kbd>
       )}

--- a/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
+++ b/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
@@ -10,6 +10,7 @@ import { cn } from "~/lib/utils";
 import { useProvidersStore } from "../../store/providers.ts";
 import { useSettingsStore } from "../../store/settings.ts";
 import { useWorkspaceStore } from "../../store/workspace.ts";
+import { AppearanceStep } from "./steps/appearance.tsx";
 import { DefaultsStep } from "./steps/defaults.tsx";
 import { DoneStep } from "./steps/done.tsx";
 import { MaximizeStep } from "./steps/maximize.tsx";
@@ -24,6 +25,7 @@ type StepId =
   | "maximize"
   | "provider"
   | "project"
+  | "appearance"
   | "defaults"
   | "done";
 
@@ -32,6 +34,7 @@ const STEPS: ReadonlyArray<StepId> = [
   "maximize",
   "provider",
   "project",
+  "appearance",
   "defaults",
   "signin",
   "done",
@@ -117,6 +120,7 @@ export function OnboardingWizard() {
             {stepId === "maximize" && <MaximizeStep />}
             {stepId === "provider" && <ProviderStep />}
             {stepId === "project" && <ProjectStep />}
+            {stepId === "appearance" && <AppearanceStep />}
             {stepId === "defaults" && <DefaultsStep />}
             {stepId === "done" && <DoneStep onFinish={finish} />}
           </div>

--- a/apps/renderer/src/components/onboarding/steps/appearance.tsx
+++ b/apps/renderer/src/components/onboarding/steps/appearance.tsx
@@ -1,0 +1,97 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ComputerIcon,
+  Moon02Icon,
+  Sun03Icon,
+  Tick01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import type { AppearanceMode } from "@zuse/wire";
+
+import { cn } from "~/lib/utils";
+import { useSettingsStore } from "../../../store/settings.ts";
+import { StepHeader } from "./shared.tsx";
+
+const APPEARANCE_OPTIONS: ReadonlyArray<{
+  readonly value: AppearanceMode;
+  readonly label: string;
+  readonly description: string;
+  readonly Icon: typeof ComputerIcon;
+}> = [
+  {
+    value: "system",
+    label: "System",
+    description: "Match your Mac automatically.",
+    Icon: ComputerIcon,
+  },
+  {
+    value: "light",
+    label: "Light",
+    description: "Use the brighter interface.",
+    Icon: Sun03Icon,
+  },
+  {
+    value: "dark",
+    label: "Dark",
+    description: "Keep the classic dark interface.",
+    Icon: Moon02Icon,
+  },
+];
+
+export function AppearanceStep() {
+  const appearanceMode = useSettingsStore((s) => s.appearanceMode);
+  const setAppearanceMode = useSettingsStore((s) => s.setAppearanceMode);
+
+  return (
+    <div className="flex flex-col gap-7">
+      <StepHeader
+        title="Choose your appearance"
+        subtitle="Pick a starting look. You can change this later in Settings."
+      />
+
+      <div className="grid gap-2">
+        {APPEARANCE_OPTIONS.map((option) => {
+          const active = option.value === appearanceMode;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={active}
+              onClick={() => setAppearanceMode(option.value)}
+              className={cn(
+                "group flex items-center gap-3 rounded-2xl px-3.5 py-3 text-left transition-all",
+                active
+                  ? "bg-accent text-accent-foreground"
+                  : "bg-muted/60 hover:bg-muted",
+              )}
+            >
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-background/70 text-foreground">
+                <HugeiconsIcon
+                  icon={option.Icon}
+                  className="size-4"
+                  strokeWidth={1.75}
+                />
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col gap-1">
+                <span className="text-[13px] font-medium leading-none text-foreground">
+                  {option.label}
+                </span>
+                <span className="text-[11px] leading-snug text-muted-foreground">
+                  {option.description}
+                </span>
+              </span>
+              {active && (
+                <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-foreground text-background">
+                  <HugeiconsIcon
+                    icon={Tick01Icon}
+                    className="size-2.5"
+                    strokeWidth={3.5}
+                  />
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/defaults.tsx
+++ b/apps/renderer/src/components/onboarding/steps/defaults.tsx
@@ -1,8 +1,6 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Tick01Icon } from "@hugeicons-pro/core-bulk-rounded";
-import {
-  ModelSelect,
-} from "~/components/settings-page";
+import { ModelSelect } from "~/components/settings-page";
 import { MODE_META, MODES_ORDER } from "~/components/runtime-mode-meta";
 import { Switch } from "~/components/ui/switch";
 import { cn } from "~/lib/utils";
@@ -59,12 +57,16 @@ export function DefaultsStep() {
                   className={cn(
                     "group flex items-center gap-3 rounded-2xl px-3.5 py-2.5 text-left transition-all",
                     active
-                      ? "bg-white/[0.08]"
-                      : "bg-white/[0.025] hover:bg-white/[0.05]",
+                      ? "bg-accent text-accent-foreground"
+                      : "bg-muted/60 hover:bg-muted",
                   )}
                 >
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-xl bg-white/[0.06] text-foreground">
-                    <HugeiconsIcon icon={m.Icon} className="size-3.5" strokeWidth={1.75} />
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-xl bg-background/70 text-foreground">
+                    <HugeiconsIcon
+                      icon={m.Icon}
+                      className="size-3.5"
+                      strokeWidth={1.75}
+                    />
                   </span>
                   <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                     <span className="text-[13px] font-medium leading-none text-foreground">
@@ -76,7 +78,11 @@ export function DefaultsStep() {
                   </span>
                   {active && (
                     <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-foreground text-background">
-                      <HugeiconsIcon icon={Tick01Icon} className="size-2.5" strokeWidth={3.5} />
+                      <HugeiconsIcon
+                        icon={Tick01Icon}
+                        className="size-2.5"
+                        strokeWidth={3.5}
+                      />
                     </span>
                   )}
                 </button>
@@ -85,7 +91,7 @@ export function DefaultsStep() {
           </div>
         </div>
 
-        <label className="flex cursor-pointer items-start gap-3 rounded-2xl bg-white/[0.025] px-3.5 py-3 transition-colors hover:bg-white/[0.05]">
+        <label className="flex cursor-pointer items-start gap-3 rounded-2xl bg-muted/60 px-3.5 py-3 transition-colors hover:bg-muted">
           <span className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="flex items-center gap-2">
               <span className="text-[13px] font-medium leading-none text-foreground">
@@ -96,10 +102,10 @@ export function DefaultsStep() {
               </span>
             </span>
             <span className="text-[11px] leading-snug text-muted-foreground">
-              A git worktree is a second checkout of your repo on its own branch.
-              Each chat gets one under <code>~/.zuse/</code>, so agents can run
-              in parallel without stepping on each other or your working tree.
-              You merge the branches you like.
+              A git worktree is a second checkout of your repo on its own
+              branch. Each chat gets one under <code>~/.zuse/</code>, so agents
+              can run in parallel without stepping on each other or your working
+              tree. You merge the branches you like.
             </span>
           </span>
           <Switch

--- a/apps/renderer/src/components/onboarding/steps/maximize.tsx
+++ b/apps/renderer/src/components/onboarding/steps/maximize.tsx
@@ -97,10 +97,14 @@ export function MaximizeStep() {
       {loading ? (
         <SpendSkeleton />
       ) : (
-        <MonthlySnapshot usedValue={usedValue} tokens={tokens} sourceLine={sourceLine} />
+        <MonthlySnapshot
+          usedValue={usedValue}
+          tokens={tokens}
+          sourceLine={sourceLine}
+        />
       )}
 
-      <div className="flex flex-col gap-4 rounded-2xl bg-white/[0.025] p-5">
+      <div className="flex flex-col gap-4 rounded-2xl bg-muted/50 p-5">
         <div className="flex items-start gap-3">
           <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary">
             <HugeiconsIcon
@@ -121,7 +125,7 @@ export function MaximizeStep() {
           </div>
         </div>
 
-        <div className="flex flex-col rounded-xl border border-white/[0.06] bg-black/10">
+        <div className="flex flex-col rounded-xl border border-border/60 bg-background/60">
           {MONTHLY_STACK.plans.map((p) => (
             <PlanRow key={p.name} {...p} />
           ))}
@@ -167,7 +171,9 @@ function MonthlySnapshot({
             {usedValue}
           </span>
           <span className="text-[11px] leading-snug text-muted-foreground">
-            {tokens > 0 ? `${formatTokens(tokens)} tokens${sourceLine}` : "No usage found yet"}
+            {tokens > 0
+              ? `${formatTokens(tokens)} tokens${sourceLine}`
+              : "No usage found yet"}
           </span>
         </div>
       </div>
@@ -198,7 +204,7 @@ function CompactMetric({
   detail: string;
 }) {
   return (
-    <div className="flex min-h-[4.5rem] flex-col justify-center gap-1 rounded-2xl bg-white/[0.025] px-4 py-3">
+    <div className="flex min-h-[4.5rem] flex-col justify-center gap-1 rounded-2xl bg-muted/50 px-4 py-3">
       <span className="text-[11px] font-medium text-muted-foreground">
         {label}
       </span>
@@ -222,7 +228,7 @@ function PlanRow({
   potential: string;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 border-t border-white/[0.06] px-3 py-2.5 first:border-0">
+    <div className="flex items-center justify-between gap-3 border-t border-border/60 px-3 py-2.5 first:border-0">
       <span className="flex min-w-0 flex-col">
         <span className="truncate text-[12px] font-medium text-foreground">
           {name}
@@ -241,7 +247,7 @@ function PlanRow({
 
 function SpendSkeleton() {
   return (
-    <div className="flex flex-col gap-4 rounded-2xl bg-white/[0.025] p-5">
+    <div className="flex flex-col gap-4 rounded-2xl bg-muted/50 p-5">
       <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
         <HugeiconsIcon
           icon={Loading02Icon}
@@ -251,18 +257,21 @@ function SpendSkeleton() {
         Scanning this month&apos;s local agent logs...
       </div>
       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_15rem]">
-        <div className="flex h-36 flex-col justify-between rounded-2xl bg-white/[0.035] p-5">
-          <div className="h-3 w-40 animate-pulse rounded bg-white/[0.06]" />
+        <div className="flex h-36 flex-col justify-between rounded-2xl bg-background/60 p-5">
+          <div className="h-3 w-40 animate-pulse rounded bg-muted" />
           <div className="space-y-2">
-            <div className="h-9 w-36 animate-pulse rounded bg-white/[0.06]" />
-            <div className="h-3 w-48 animate-pulse rounded bg-white/[0.06]" />
+            <div className="h-9 w-36 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-48 animate-pulse rounded bg-muted" />
           </div>
         </div>
         <div className="grid gap-3">
           {[0, 1].map((i) => (
-            <div key={i} className="flex flex-col justify-center gap-2 rounded-2xl bg-white/[0.025] px-4 py-3">
-              <div className="h-3 w-20 animate-pulse rounded bg-white/[0.06]" />
-              <div className="h-6 w-28 animate-pulse rounded bg-white/[0.06]" />
+            <div
+              key={i}
+              className="flex flex-col justify-center gap-2 rounded-2xl bg-background/60 px-4 py-3"
+            >
+              <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+              <div className="h-6 w-28 animate-pulse rounded bg-muted" />
             </div>
           ))}
         </div>

--- a/apps/renderer/src/components/onboarding/steps/project.tsx
+++ b/apps/renderer/src/components/onboarding/steps/project.tsx
@@ -1,5 +1,9 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Folder01Icon, FolderAddIcon, Tick01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  Folder01Icon,
+  FolderAddIcon,
+  Tick01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
 import { useState } from "react";
 
 import { Button } from "~/components/ui/button";
@@ -35,9 +39,9 @@ export function ProjectStep() {
           type="button"
           onClick={() => void pick()}
           disabled={busy}
-          className="group flex flex-col items-center justify-center gap-4 rounded-2xl bg-white/[0.025] px-6 py-12 text-center transition-all hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-60"
+          className="group flex flex-col items-center justify-center gap-4 rounded-2xl bg-muted/60 px-6 py-12 text-center transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
         >
-          <span className="flex size-12 items-center justify-center rounded-2xl bg-white/[0.06] text-foreground transition-transform group-hover:scale-105">
+          <span className="flex size-12 items-center justify-center rounded-2xl bg-background/70 text-foreground transition-transform group-hover:scale-105">
             <HugeiconsIcon icon={FolderAddIcon} className="size-5" />
           </span>
           <span className="flex flex-col gap-1">
@@ -51,8 +55,8 @@ export function ProjectStep() {
         </button>
       ) : (
         <div className="flex flex-col gap-3">
-          <div className="flex items-center gap-3 rounded-2xl bg-emerald-400/[0.06] px-4 py-3.5">
-            <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white/[0.08] text-foreground">
+          <div className="flex items-center gap-3 rounded-2xl bg-alert-success-bg px-4 py-3.5">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-background/70 text-foreground">
               <HugeiconsIcon icon={Folder01Icon} className="size-4" />
             </span>
             <div className="flex min-w-0 flex-1 flex-col">
@@ -63,7 +67,7 @@ export function ProjectStep() {
                 {justAdded.path}
               </span>
             </div>
-            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-emerald-400/20 text-emerald-300">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-success/20 text-success">
               <HugeiconsIcon icon={Tick01Icon} className="size-3" />
             </span>
           </div>

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -32,13 +32,12 @@ const SUBSCRIPTION_INFO: Partial<
 
 const openExternal = (url: string): void => {
   if (typeof window === "undefined") return;
-  const bridge = (
-    window as unknown as {
-      zuse?: { app?: { openExternal?: (u: string) => void } };
-      memoize?: { app?: { openExternal?: (u: string) => void } };
-    }
-  );
-  const open = bridge.zuse?.app?.openExternal ?? bridge.memoize?.app?.openExternal;
+  const bridge = window as unknown as {
+    zuse?: { app?: { openExternal?: (u: string) => void } };
+    memoize?: { app?: { openExternal?: (u: string) => void } };
+  };
+  const open =
+    bridge.zuse?.app?.openExternal ?? bridge.memoize?.app?.openExternal;
   if (typeof open === "function") {
     open(url);
     return;
@@ -185,11 +184,11 @@ function ProviderCard({
         // information density.
         "group relative flex items-center gap-3 overflow-hidden rounded-xl p-2.5 text-left transition-all",
         active
-          ? "bg-white/[0.08] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-          : "bg-white/[0.025] hover:bg-white/[0.05]",
+          ? "bg-accent text-accent-foreground"
+          : "bg-muted/60 hover:bg-muted",
       )}
     >
-      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] text-foreground">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-background/70 text-foreground">
         <ProviderIcon providerId={providerId} className="size-4" />
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -291,7 +290,7 @@ function ProviderStatus({
         ? `${PROVIDER_LABEL[providerId]} CLI is logged in. You're all set.`
         : `${PROVIDER_LABEL[providerId]} API key saved. You're all set.`;
     return (
-      <div className="flex items-center gap-2 rounded-full bg-emerald-400/[0.08] px-3 py-2 text-[12px] text-emerald-200/90">
+      <div className="flex items-center gap-2 rounded-full bg-alert-success-bg px-3 py-2 text-[12px] text-success">
         <HugeiconsIcon icon={Tick01Icon} className="size-3.5" strokeWidth={3} />
         <span className="leading-none">{label}</span>
       </div>
@@ -301,7 +300,7 @@ function ProviderStatus({
   // Loading: a single quiet line, no big card.
   if (state.kind === "loading") {
     return (
-      <div className="flex items-center gap-2 rounded-full bg-white/[0.025] px-3 py-2 text-[12px] text-muted-foreground">
+      <div className="flex items-center gap-2 rounded-full bg-muted/60 px-3 py-2 text-[12px] text-muted-foreground">
         <span className="size-1.5 animate-pulse rounded-full bg-muted-foreground/60" />
         Checking {PROVIDER_LABEL[providerId]}…
       </div>
@@ -384,8 +383,8 @@ function SubscriptionNotice({
   url: string;
 }) {
   return (
-    <div className="flex flex-col gap-1.5 rounded-xl border border-violet-400/25 bg-violet-500/[0.08] px-3 py-2.5">
-      <span className="text-[11px] font-medium text-violet-200">
+    <div className="flex flex-col gap-1.5 rounded-xl border border-violet-500/25 bg-violet-500/[0.08] px-3 py-2.5">
+      <span className="text-[11px] font-medium text-violet-700 dark:text-violet-200">
         Requires {plan} subscription
       </span>
       <p className="text-[11px] leading-snug text-muted-foreground">
@@ -398,7 +397,7 @@ function SubscriptionNotice({
           size="xs"
           variant="ghost"
           onClick={() => openExternal(url)}
-          className="gap-1.5 rounded-full bg-violet-500/15 px-2.5 text-[11px] text-violet-200 hover:bg-violet-500/25 hover:text-violet-100"
+          className="gap-1.5 rounded-full bg-violet-500/15 px-2.5 text-[11px] text-violet-700 hover:bg-violet-500/25 hover:text-violet-800 dark:text-violet-200 dark:hover:text-violet-100"
         >
           <HugeiconsIcon icon={LinkSquare01Icon} className="size-3" />
           Subscribe to {plan}
@@ -416,7 +415,7 @@ function CodeRow({
   onRecheck: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-xl bg-black/30 px-3 py-2 font-mono text-[12px]">
+    <div className="flex items-center justify-between gap-3 rounded-xl bg-muted px-3 py-2 font-mono text-[12px]">
       <code className="truncate text-foreground/90">$ {command}</code>
       <Button
         size="xs"
@@ -438,38 +437,38 @@ function StatusPill({ state }: { state: ProviderState }) {
     loading: {
       label: "Checking",
       dot: "bg-muted-foreground/50",
-      bg: "bg-white/[0.04]",
+      bg: "bg-muted/70",
       text: "text-muted-foreground",
     },
     missing: {
       label: "Not installed",
       dot: "bg-rose-400",
       bg: "bg-rose-400/12",
-      text: "text-rose-300",
+      text: "text-rose-700 dark:text-rose-300",
     },
     outdated: {
       label: "Update",
       dot: "bg-amber-400",
       bg: "bg-amber-400/12",
-      text: "text-amber-300",
+      text: "text-amber-700 dark:text-amber-300",
     },
     "signed-out": {
       label: "Sign in",
       dot: "bg-amber-400",
       bg: "bg-amber-400/12",
-      text: "text-amber-300",
+      text: "text-amber-700 dark:text-amber-300",
     },
     subscription: {
       label: "Subscribe",
       dot: "bg-amber-400",
       bg: "bg-amber-400/12",
-      text: "text-amber-300",
+      text: "text-amber-700 dark:text-amber-300",
     },
     ready: {
       label: "Connected",
       dot: "bg-emerald-400",
       bg: "bg-emerald-400/12",
-      text: "text-emerald-300",
+      text: "text-emerald-700 dark:text-emerald-300",
     },
   };
   const s = map[state.kind];
@@ -519,7 +518,7 @@ function ApiKeyRow({ providerId }: { providerId: ProviderId }) {
             value={value}
             onChange={(e) => setValue(e.target.value)}
             disabled={busy}
-            className="h-9 rounded-xl border-0 bg-white/[0.04]"
+            className="h-9 rounded-xl border-0 bg-muted/70"
           />
           <button
             type="button"

--- a/apps/renderer/src/components/onboarding/steps/signin.tsx
+++ b/apps/renderer/src/components/onboarding/steps/signin.tsx
@@ -20,9 +20,9 @@ export function SigninStep() {
         subtitle="Sign in with WorkOS to sync this Mac with future remote agents and mobile controls. You can skip it for now and connect later from Settings."
       />
 
-      <div className="grid gap-4 rounded-xl border border-white/8 bg-white/[0.035] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] sm:grid-cols-[1fr_auto] sm:items-center">
+      <div className="grid gap-4 rounded-xl border border-border/60 bg-muted/50 p-4 sm:grid-cols-[1fr_auto] sm:items-center">
         <div className="flex min-w-0 items-start gap-3">
-          <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white/[0.07] text-foreground">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-background/70 text-foreground">
             <HugeiconsIcon
               icon={isSignedIn ? Tick01Icon : UserCircleIcon}
               className="size-5"
@@ -42,7 +42,7 @@ export function SigninStep() {
         </div>
 
         {isSignedIn ? (
-          <span className="inline-flex h-9 items-center justify-center rounded-lg border border-emerald-400/20 bg-emerald-400/[0.08] px-3 text-[12px] font-medium text-emerald-200">
+          <span className="inline-flex h-9 items-center justify-center rounded-lg border border-success/20 bg-alert-success-bg px-3 text-[12px] font-medium text-success">
             Signed in
           </span>
         ) : (
@@ -99,7 +99,7 @@ function Hint({
   children: React.ReactNode;
 }) {
   return (
-    <div className="rounded-lg bg-white/[0.025] px-3 py-2.5">
+    <div className="rounded-lg bg-muted/50 px-3 py-2.5">
       <div className="font-medium text-foreground">{title}</div>
       <div className="mt-0.5 leading-snug">{children}</div>
     </div>

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -24,6 +24,7 @@ import { Effect } from "effect";
 import { getRpcClient } from "../lib/rpc-client.ts";
 
 import {
+  type AppearanceMode,
   type BranchNamingStyle,
   MODELS_BY_PROVIDER,
   type CompletionSoundPreset,
@@ -563,7 +564,7 @@ function BrowserSettingsPane() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-start gap-2 rounded-xl border border-amber-400/30 bg-amber-400/10 px-3 py-2.5 text-[12px] leading-relaxed text-amber-200">
+      <div className="flex items-start gap-2 rounded-xl border border-warning/30 bg-alert-warning-bg px-3 py-2.5 text-[12px] leading-relaxed text-warning-foreground">
         <HugeiconsIcon icon={Alert01Icon} className="mt-0.5 size-4 shrink-0" />
         <span>
           <strong className="font-semibold">Dummy / test logins only.</strong>{" "}
@@ -688,7 +689,18 @@ const BRANCH_STYLE_META: Record<
   custom: { label: "custom prefix", example: "prefix/dark-mode" },
 };
 
+const APPEARANCE_OPTIONS: ReadonlyArray<{
+  readonly value: AppearanceMode;
+  readonly label: string;
+}> = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
+
 function GeneralPane() {
+  const appearanceMode = useSettingsStore((s) => s.appearanceMode);
+  const setAppearanceMode = useSettingsStore((s) => s.setAppearanceMode);
   const defaultRuntimeMode = useSettingsStore((s) => s.defaultRuntimeMode);
   const setDefaultRuntimeMode = useSettingsStore(
     (s) => s.setDefaultRuntimeMode,
@@ -808,6 +820,39 @@ function GeneralPane() {
             }
           />
         )}
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Appearance"
+        description="Choose the app theme, or follow your system setting."
+      >
+        <SettingsRow
+          title="Theme"
+          description="Choose the app theme, or follow your system setting."
+          action={
+            <div className="inline-flex rounded-lg border border-border/60 bg-muted p-0.5">
+              {APPEARANCE_OPTIONS.map((option) => {
+                const active = option.value === appearanceMode;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setAppearanceMode(option.value)}
+                    className={cn(
+                      "h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
+                      active
+                        ? "bg-background text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          }
+        />
       </SettingsGroup>
 
       <SettingsGroup
@@ -1787,7 +1832,7 @@ export function OverrideField({
             className={cn(
               "rounded px-2.5 py-1 transition-colors",
               !isOverridden
-                ? "bg-background text-foreground shadow-sm"
+                ? "bg-background text-foreground"
                 : "text-muted-foreground hover:text-foreground",
             )}
           >
@@ -1799,7 +1844,7 @@ export function OverrideField({
             className={cn(
               "rounded px-2.5 py-1 transition-colors",
               isOverridden
-                ? "bg-background text-foreground shadow-sm"
+                ? "bg-background text-foreground"
                 : "text-muted-foreground",
             )}
           >

--- a/apps/renderer/src/components/ui/card.tsx
+++ b/apps/renderer/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ export function Card({
 }: useRender.ComponentProps<"div">): React.ReactElement {
   const defaultProps = {
     className: cn(
-      "relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/5%)]",
+      "relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] dark:shadow-xs/5 dark:before:shadow-[0_-1px_--theme(--color-white/5%)]",
       className,
     ),
     "data-slot": "card",
@@ -32,7 +32,7 @@ export function CardFrame({
 }: useRender.ComponentProps<"div">): React.ReactElement {
   const defaultProps = {
     className: cn(
-      "relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground shadow-xs/5 [--clip-bottom:-1rem] [--clip-top:-1rem] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:bg-muted/72 before:shadow-[0_1px_--theme(--color-black/4%)] has-data-[slot=table-container]:overflow-hidden *:data-[slot=card]:-m-px *:data-[slot=table-container]:-m-px *:data-[slot=table-container]:w-[calc(100%+2px)] *:not-first:data-[slot=card]:rounded-t-md *:not-last:data-[slot=card]:rounded-b-md *:data-[slot=card]:bg-clip-padding *:data-[slot=card]:shadow-none *:data-[slot=card]:before:hidden *:not-first:data-[slot=card]:before:rounded-t-[calc(var(--radius-md)-1px)] *:not-last:data-[slot=card]:before:rounded-b-[calc(var(--radius-md)-1px)] dark:before:shadow-[0_-1px_--theme(--color-white/5%)] *:data-[slot=card]:[clip-path:inset(var(--clip-top)_1px_var(--clip-bottom)_1px_round_calc(var(--radius-lg)-1px))] *:data-[slot=card]:last:[--clip-bottom:1px] *:data-[slot=card]:first:[--clip-top:1px]",
+      "relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground [--clip-bottom:-1rem] [--clip-top:-1rem] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:bg-muted/72 has-data-[slot=table-container]:overflow-hidden *:data-[slot=card]:-m-px *:data-[slot=table-container]:-m-px *:data-[slot=table-container]:w-[calc(100%+2px)] *:not-first:data-[slot=card]:rounded-t-md *:not-last:data-[slot=card]:rounded-b-md *:data-[slot=card]:bg-clip-padding *:data-[slot=card]:shadow-none *:data-[slot=card]:before:hidden *:not-first:data-[slot=card]:before:rounded-t-[calc(var(--radius-md)-1px)] *:not-last:data-[slot=card]:before:rounded-b-[calc(var(--radius-md)-1px)] dark:shadow-xs/5 dark:before:shadow-[0_-1px_--theme(--color-white/5%)] *:data-[slot=card]:[clip-path:inset(var(--clip-top)_1px_var(--clip-bottom)_1px_round_calc(var(--radius-lg)-1px))] *:data-[slot=card]:last:[--clip-bottom:1px] *:data-[slot=card]:first:[--clip-top:1px]",
       className,
     ),
     "data-slot": "card-frame",

--- a/apps/renderer/src/components/ui/frame.tsx
+++ b/apps/renderer/src/components/ui/frame.tsx
@@ -25,7 +25,7 @@ export function FramePanel({
   return (
     <div
       className={cn(
-        "relative rounded-md border border-border/70 bg-background bg-clip-padding p-5 shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/5%)]",
+        "relative rounded-md border border-border/70 bg-background bg-clip-padding p-5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] dark:shadow-xs/5 dark:before:shadow-[0_-1px_--theme(--color-white/5%)]",
         className,
       )}
       data-slot="frame-panel"

--- a/apps/renderer/src/lib/appearance.tsx
+++ b/apps/renderer/src/lib/appearance.tsx
@@ -1,0 +1,67 @@
+import { useLayoutEffect, useMemo, useSyncExternalStore } from "react";
+import type { AppearanceMode } from "@zuse/wire";
+
+import { useSettingsStore } from "../store/settings.ts";
+
+export type ResolvedAppearance = "light" | "dark";
+
+const subscribeSystemAppearance = (onStoreChange: () => void): (() => void) => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return () => {};
+  }
+  const media = window.matchMedia("(prefers-color-scheme: dark)");
+  media.addEventListener("change", onStoreChange);
+  return () => media.removeEventListener("change", onStoreChange);
+};
+
+const getSystemAppearance = (): ResolvedAppearance => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return "dark";
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+};
+
+export const resolveAppearance = (
+  mode: AppearanceMode,
+  systemAppearance: ResolvedAppearance,
+): ResolvedAppearance => (mode === "system" ? systemAppearance : mode);
+
+export function useResolvedAppearance(): ResolvedAppearance {
+  const appearanceMode = useSettingsStore((s) => s.appearanceMode);
+  const systemAppearance = useSyncExternalStore(
+    subscribeSystemAppearance,
+    getSystemAppearance,
+    (): ResolvedAppearance => "dark",
+  );
+  return useMemo(
+    () => resolveAppearance(appearanceMode, systemAppearance),
+    [appearanceMode, systemAppearance],
+  );
+}
+
+export function AppearanceController() {
+  const appearanceMode = useSettingsStore((s) => s.appearanceMode);
+  const resolvedAppearance = useResolvedAppearance();
+
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", resolvedAppearance === "dark");
+    root.style.colorScheme = resolvedAppearance;
+    window.zuse?.window?.setAppearanceMode?.(appearanceMode);
+    window.dispatchEvent(
+      new CustomEvent("zuse:appearance-change", {
+        detail: { mode: appearanceMode, resolved: resolvedAppearance },
+      }),
+    );
+  }, [appearanceMode, resolvedAppearance]);
+
+  return null;
+}

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -16,6 +16,7 @@ export interface WindowBridge {
   readonly onFullScreenChange: (
     handler: (fullscreen: boolean) => void,
   ) => () => void;
+  readonly setAppearanceMode?: (mode: "system" | "light" | "dark") => void;
 }
 
 export interface AppBridge {

--- a/apps/renderer/src/lib/codemirror/composer-theme.ts
+++ b/apps/renderer/src/lib/codemirror/composer-theme.ts
@@ -36,7 +36,7 @@ export const composerTheme: Extension = EditorView.theme(
     },
     "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
       {
-        backgroundColor: "rgba(168, 85, 247, 0.18)",
+        backgroundColor: "color-mix(in oklab, var(--primary) 22%, transparent)",
       },
   },
   { dark: true },

--- a/apps/renderer/src/lib/codemirror/theme.ts
+++ b/apps/renderer/src/lib/codemirror/theme.ts
@@ -1,45 +1,41 @@
-import {
-  HighlightStyle,
-  syntaxHighlighting,
-} from "@codemirror/language";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { tags as t } from "@lezer/highlight";
 
-// Palette aligned with the rest of memoize's chrome (zinc-950 surface,
-// zinc-400/500 muted-foreground). Syntax accents are deliberately desaturated
-// so the editor reads as part of the chat IDE rather than a separate VS Code.
+// Palette aligned with app CSS variables so appearance changes update existing
+// editor instances without remounting CodeMirror.
 const PALETTE = {
   bg: "transparent",
-  fg: "#e4e4e7", // zinc-200
-  mutedFg: "#71717a", // zinc-500
-  faintBorder: "rgba(255,255,255,0.06)",
-  selection: "rgba(168, 85, 247, 0.18)", // soft violet, matches accent
-  cursor: "#e4e4e7",
-  activeLine: "rgba(255,255,255,0.025)",
-  activeLineGutter: "rgba(255,255,255,0.04)",
-  matchingBracket: "rgba(168, 85, 247, 0.25)",
+  fg: "var(--foreground)",
+  mutedFg: "var(--muted-foreground)",
+  faintBorder: "var(--border)",
+  selection: "color-mix(in oklab, var(--primary) 22%, transparent)",
+  cursor: "var(--foreground)",
+  activeLine: "color-mix(in oklab, var(--foreground) 4%, transparent)",
+  activeLineGutter: "color-mix(in oklab, var(--foreground) 6%, transparent)",
+  matchingBracket: "color-mix(in oklab, var(--primary) 26%, transparent)",
 
   // Syntax
-  keyword: "#c084fc", // violet-400
-  control: "#c084fc",
-  string: "#86efac", // green-300
-  number: "#fbbf24", // amber-400
-  bool: "#fbbf24",
-  function: "#7dd3fc", // sky-300
-  variable: "#e4e4e7",
-  property: "#e4e4e7",
-  type: "#67e8f9", // cyan-300
-  className: "#67e8f9",
-  attribute: "#fda4af", // rose-300
-  tag: "#f87171", // red-400
-  punctuation: "#a1a1aa", // zinc-400
-  comment: "#71717a", // zinc-500
-  meta: "#a1a1aa",
-  operator: "#a1a1aa",
-  link: "#7dd3fc",
-  heading: "#fafafa",
-  invalid: "#f87171",
+  keyword: "var(--syntax-keyword)",
+  control: "var(--syntax-keyword)",
+  string: "var(--syntax-string)",
+  number: "var(--syntax-number)",
+  bool: "var(--syntax-number)",
+  function: "var(--syntax-function)",
+  variable: "var(--foreground)",
+  property: "var(--foreground)",
+  type: "var(--syntax-type)",
+  className: "var(--syntax-type)",
+  attribute: "var(--syntax-attribute)",
+  tag: "var(--syntax-tag)",
+  punctuation: "var(--muted-foreground)",
+  comment: "var(--muted-foreground)",
+  meta: "var(--muted-foreground)",
+  operator: "var(--muted-foreground)",
+  link: "var(--syntax-function)",
+  heading: "var(--message-heading)",
+  invalid: "var(--destructive)",
 };
 
 const editorTheme = EditorView.theme(
@@ -97,13 +93,13 @@ const editorTheme = EditorView.theme(
       color: PALETTE.invalid,
     },
     ".cm-tooltip": {
-      backgroundColor: "#18181b", // zinc-900
+      backgroundColor: "var(--popover)",
       color: PALETTE.fg,
       border: `1px solid ${PALETTE.faintBorder}`,
       borderRadius: "6px",
     },
     ".cm-panels": {
-      backgroundColor: "#18181b",
+      backgroundColor: "var(--popover)",
       color: PALETTE.fg,
     },
     ".cm-panels.cm-panels-bottom": {
@@ -159,7 +155,14 @@ const highlightStyle = HighlightStyle.define([
   { tag: t.angleBracket, color: PALETTE.punctuation },
 
   {
-    tag: [t.punctuation, t.separator, t.bracket, t.paren, t.brace, t.squareBracket],
+    tag: [
+      t.punctuation,
+      t.separator,
+      t.bracket,
+      t.paren,
+      t.brace,
+      t.squareBracket,
+    ],
     color: PALETTE.punctuation,
   },
   { tag: t.operator, color: PALETTE.operator },

--- a/apps/renderer/src/lib/terminal-registry.ts
+++ b/apps/renderer/src/lib/terminal-registry.ts
@@ -31,6 +31,7 @@ type LiveTerminal = {
   /** Dedicated wrapper that xterm renders into; moved between containers. */
   readonly host: HTMLDivElement;
   readonly observer: ResizeObserver;
+  readonly refreshTheme: () => void;
   ptyId: PtyId | null;
   streamFiber: Fiber.RuntimeFiber<unknown, unknown> | null;
   disposables: { dispose: () => void } | null;
@@ -55,6 +56,21 @@ function readToken(el: HTMLElement, cssVar: string, fallback: string): string {
   return computed || fallback;
 }
 
+function readTerminalTheme(
+  host: HTMLElement,
+): NonNullable<Terminal["options"]["theme"]> {
+  return {
+    // Solid background matching the pane: lets the WebGL renderer draw
+    // cleanly and skips the per-frame cost of a transparent canvas.
+    background: readToken(host, "--background", "#0b0b0c"),
+    foreground: readToken(host, "--foreground", "#e6e6e6"),
+    cursor: readToken(host, "--primary", "#e6e6e6"),
+    cursorAccent: readToken(host, "--background", "#0b0b0c"),
+    selectionBackground: readToken(host, "--accent", "#2c2c33"),
+    selectionForeground: readToken(host, "--accent-foreground", "#e6e6e6"),
+  };
+}
+
 function makeLive(
   instanceId: string,
   container: HTMLElement,
@@ -77,16 +93,7 @@ function makeLive(
     cursorStyle: "bar",
     cursorInactiveStyle: "bar",
     convertEol: false,
-    theme: {
-      // Solid background matching the pane: lets the WebGL renderer draw
-      // cleanly and skips the per-frame cost of a transparent canvas.
-      background: readToken(host, "--background", "#0b0b0c"),
-      foreground: readToken(host, "--foreground", "#e6e6e6"),
-      cursor: readToken(host, "--primary", "#e6e6e6"),
-      cursorAccent: readToken(host, "--background", "#0b0b0c"),
-      selectionBackground: readToken(host, "--accent", "#2c2c33"),
-      selectionForeground: readToken(host, "--accent-foreground", "#e6e6e6"),
-    },
+    theme: readTerminalTheme(host),
   });
   const fit = new FitAddon();
   term.loadAddon(fit);
@@ -108,6 +115,9 @@ function makeLive(
     fit,
     host,
     observer: new ResizeObserver(() => safeFit(live)),
+    refreshTheme: () => {
+      term.options.theme = readTerminalTheme(host);
+    },
     ptyId: null,
     streamFiber: null,
     disposables: null,
@@ -119,6 +129,7 @@ function makeLive(
   // inactive terminal tab) it measures 0×0 and `safeFit` no-ops; it fires
   // again with real dimensions once shown.
   live.observer.observe(host);
+  window.addEventListener("zuse:appearance-change", live.refreshTheme);
   window.requestAnimationFrame(() => safeFit(live));
 
   void openPty(live, opts);
@@ -287,6 +298,7 @@ export function dispose(instanceId: string): void {
   registry.delete(instanceId);
   live.disposed = true;
   live.observer.disconnect();
+  window.removeEventListener("zuse:appearance-change", live.refreshTheme);
   live.disposables?.dispose();
   if (live.resizeTimer !== null) window.clearTimeout(live.resizeTimer);
   if (live.streamFiber !== null) {

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -2,6 +2,7 @@ import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
 import {
+  type AppearanceMode,
   type BranchNamingStyle,
   defaultModelEnabledByProvider,
   defaultModelFor,
@@ -80,6 +81,7 @@ const fallbackSnapshot = (): SettingsSlice => ({
   defaultAutoCreateWorktree: true,
   completionSoundEnabled: false,
   completionSoundPreset: "chime",
+  appearanceMode: "dark",
   onboardingCompleted: false,
   providerEnabled: seedProviderEnabled(),
   modelEnabledByProvider: seedModelEnabledByProvider(),
@@ -104,6 +106,7 @@ const sliceFromFile = (file: SettingsFile): SettingsSlice => {
     defaultAutoCreateWorktree: file.defaultAutoCreateWorktree,
     completionSoundEnabled: file.completionSoundEnabled,
     completionSoundPreset: file.completionSoundPreset,
+    appearanceMode: file.appearanceMode,
     onboardingCompleted: file.onboardingCompleted,
     providerEnabled: {
       ...seedProviderEnabled(),
@@ -122,6 +125,7 @@ interface SettingsSlice {
   readonly defaultAutoCreateWorktree: boolean;
   readonly completionSoundEnabled: boolean;
   readonly completionSoundPreset: CompletionSoundPreset;
+  readonly appearanceMode: AppearanceMode;
   readonly onboardingCompleted: boolean;
   readonly providerEnabled: Record<ProviderId, boolean>;
   readonly modelEnabledByProvider: ModelEnabledByProvider;
@@ -149,6 +153,7 @@ type SettingsState = SettingsSlice & {
   readonly setDefaultAutoCreateWorktree: (value: boolean) => void;
   readonly setCompletionSoundEnabled: (value: boolean) => void;
   readonly setCompletionSoundPreset: (preset: CompletionSoundPreset) => void;
+  readonly setAppearanceMode: (mode: AppearanceMode) => void;
   readonly setOnboardingCompleted: (value: boolean) => void;
   readonly setProviderEnabled: (providerId: ProviderId, value: boolean) => void;
   readonly setModelEnabled: (
@@ -294,6 +299,15 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const client = await getRpcClient();
       await Effect.runPromise(
         client.settings.update({ patch: { completionSoundPreset: preset } }),
+      );
+    })();
+  },
+  setAppearanceMode: (mode) => {
+    set({ appearanceMode: mode });
+    void (async () => {
+      const client = await getRpcClient();
+      await Effect.runPromise(
+        client.settings.update({ patch: { appearanceMode: mode } }),
       );
     })();
   },

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -265,83 +265,100 @@ body,
 }
 
 /* ---------- Light theme ---------- */
-/* Warm stone neutrals (hue 70). Subtle warmth, no cool blue cast. Light
-   mode exists for parity / future toggle but we ship dark-by-default. */
+/* Same moss/lime identity as dark mode, lifted onto a quiet paper surface.
+   Primary stays chartreuse instead of becoming a generic blue/gray light UI. */
 :root {
   --radius: 0.5rem;
+  --lime: hsl(72 92% 48%);
+  --brand-highlight: hsl(72 92% 48%);
+  --brand-highlight-muted: hsl(74 70% 58%);
 
-  --background: oklch(0.99 0.003 75);
-  --foreground: oklch(0.18 0.008 70);
+  --background: hsl(76 12% 98%);
+  --foreground: hsl(72 18% 9%);
 
-  --bg-subtle: oklch(0.975 0.004 75);
-  --bg-elevated: oklch(0.955 0.005 70);
-  --bg-overlay: oklch(0.91 0.006 70);
-  --text-faint: oklch(0.62 0.012 70);
+  --bg-subtle: hsl(76 10% 95%);
+  --bg-elevated: hsl(74 10% 92%);
+  --bg-overlay: hsl(72 8% 84%);
+  --text-faint: hsl(72 6% 46%);
 
   /* Chip surface — sits on top of cards/bubbles, must stay visibly darker than
      --card so the pill reads as inset against the composer card. */
-  --chip-bg: oklch(0.94 0.005 70);
+  --chip-bg: hsl(74 10% 91%);
 
-  --card: oklch(1 0 0);
+  --card: hsl(72 22% 99%);
   --card-foreground: var(--foreground);
-  --popover: oklch(1 0 0);
+  --popover: hsl(72 22% 99%);
   --popover-foreground: var(--foreground);
 
-  --primary: oklch(0.62 0.18 102);
-  --primary-foreground: oklch(0.985 0.003 102);
-  --secondary: oklch(0.955 0.005 70);
+  --primary: var(--lime);
+  --primary-foreground: hsl(72 82% 6%);
+
+  --accent-pink: hsl(339 84% 48%);
+  --accent-green: hsl(131 52% 42%);
+  --accent-blue: hsl(220 76% 54%);
+  --accent-amber: hsl(18 86% 52%);
+  --accent-red: hsl(0 74% 56%);
+  --accent-zinc: hsl(72 4% 42%);
+
+  --secondary: hsl(74 10% 93%);
   --secondary-foreground: var(--foreground);
-  --muted: oklch(0.955 0.005 70);
-  --muted-foreground: oklch(0.52 0.012 70);
-  --accent: oklch(0.94 0.03 102);
-  --accent-foreground: oklch(0.24 0.06 102);
+  --muted: hsl(74 10% 93%);
+  --muted-foreground: hsl(72 6% 39%);
+  --accent: hsl(74 18% 90%);
+  --accent-foreground: hsl(72 34% 14%);
 
-  --destructive: oklch(0.585 0.22 27);
-  --destructive-foreground: oklch(0.985 0.003 75);
-  --success: oklch(0.66 0.15 150);
-  --success-foreground: oklch(0.985 0.003 75);
-  --warning: oklch(0.78 0.16 75);
-  --warning-foreground: oklch(0.24 0.008 70);
-  --info: oklch(0.62 0.16 245);
-  --info-foreground: oklch(0.985 0.003 75);
+  --destructive: hsl(0 74% 50%);
+  --destructive-foreground: hsl(72 22% 99%);
+  --success: hsl(131 52% 42%);
+  --success-foreground: hsl(72 22% 99%);
+  --warning: hsl(42 84% 47%);
+  --warning-foreground: hsl(72 18% 9%);
+  --info: hsl(220 76% 54%);
+  --info-foreground: hsl(72 22% 99%);
 
-  /* Light-mode alert surfaces — soft warm tints, light enough to keep dark
-     foreground text legible. */
-  --alert-error-bg: oklch(0.95 0.035 25);
-  --alert-warning-bg: oklch(0.95 0.04 80);
-  --alert-info-bg: oklch(0.95 0.035 240);
-  --alert-success-bg: oklch(0.95 0.04 150);
+  --alert-error-bg: hsl(0 72% 95%);
+  --alert-warning-bg: hsl(42 80% 92%);
+  --alert-info-bg: hsl(220 72% 94%);
+  --alert-success-bg: hsl(131 46% 92%);
 
-  --border: oklch(0.9 0.006 70);
-  --input: oklch(0.9 0.006 70);
-  --ring: oklch(0.62 0.012 70);
+  --border: hsl(72 10% 84%);
+  --input: hsl(72 10% 84%);
+  --ring: var(--lime);
 
-  --sidebar: oklch(0.975 0.004 75);
-  --sidebar-foreground: oklch(0.18 0.008 70);
-  --sidebar-primary: oklch(0.24 0.008 70);
-  --sidebar-primary-foreground: oklch(0.985 0.003 75);
-  --sidebar-accent: oklch(0.955 0.005 70);
-  --sidebar-accent-foreground: oklch(0.24 0.008 70);
-  --sidebar-border: oklch(0.9 0.006 70);
-  --sidebar-ring: oklch(0.62 0.012 70);
+  --sidebar: hsl(76 10% 95%);
+  --sidebar-foreground: hsl(72 18% 12%);
+  --sidebar-primary: var(--lime);
+  --sidebar-primary-foreground: hsl(72 82% 6%);
+  --sidebar-accent: hsl(74 16% 89%);
+  --sidebar-accent-foreground: hsl(72 24% 13%);
+  --sidebar-border: hsl(72 10% 82%);
+  --sidebar-ring: var(--lime);
 
-  --chart-1: oklch(0.646 0.222 41.1);
-  --chart-2: oklch(0.6 0.118 184.7);
-  --chart-3: oklch(0.398 0.07 227.4);
-  --chart-4: oklch(0.828 0.189 84.4);
-  --chart-5: oklch(0.769 0.188 70.1);
+  --chart-1: var(--lime);
+  --chart-2: hsl(131 52% 42%);
+  --chart-3: hsl(18 86% 52%);
+  --chart-4: hsl(220 76% 54%);
+  --chart-5: hsl(0 74% 56%);
 
   /* Chat bubble + prose. Independent of `primary` so we can keep button
      primary punchy without bleaching message text. */
-  --user-bubble: oklch(0.93 0.012 260);
-  --user-bubble-foreground: oklch(0.22 0.01 260);
-  --message-text: oklch(0.28 0.008 260);
-  --message-heading: oklch(0.18 0.01 260);
-  --message-code: oklch(0.36 0.065 122);
-  --message-code-bg: oklch(0.945 0.012 122);
-  --message-pre-bg: oklch(0.965 0.004 260);
-  --message-quote: oklch(0.46 0.01 260);
-  --message-rule: oklch(0.88 0.005 260);
+  --user-bubble: hsl(74 18% 90%);
+  --user-bubble-foreground: hsl(72 28% 12%);
+  --message-text: hsl(72 14% 18%);
+  --message-heading: hsl(72 18% 9%);
+  --message-code: hsl(72 80% 28%);
+  --message-code-bg: hsl(74 18% 91%);
+  --message-pre-bg: hsl(74 10% 93%);
+  --message-quote: hsl(72 6% 40%);
+  --message-rule: hsl(72 10% 84%);
+
+  --syntax-keyword: hsl(276 66% 42%);
+  --syntax-string: hsl(131 48% 34%);
+  --syntax-number: hsl(38 82% 38%);
+  --syntax-function: hsl(220 70% 44%);
+  --syntax-type: hsl(190 68% 34%);
+  --syntax-attribute: hsl(339 70% 43%);
+  --syntax-tag: hsl(0 70% 45%);
 }
 
 .dark {
@@ -441,8 +458,24 @@ body,
   --message-pre-bg: hsl(72 8% 12%);
   --message-quote: hsl(72 2% 64%);
   --message-rule: hsl(72 3% 22%);
+
+  --syntax-keyword: #c084fc;
+  --syntax-string: #86efac;
+  --syntax-number: #fbbf24;
+  --syntax-function: #7dd3fc;
+  --syntax-type: #67e8f9;
+  --syntax-attribute: #fda4af;
+  --syntax-tag: #f87171;
 }
 @layer base {
+  html:not(.dark) *,
+  html:not(.dark) *::before,
+  html:not(.dark) *::after {
+    --tw-shadow: 0 0 #0000 !important;
+    --tw-shadow-colored: 0 0 #0000 !important;
+    --tw-inset-shadow: 0 0 #0000 !important;
+  }
+
   * {
     @apply border-border outline-ring/50;
   }
@@ -623,17 +656,21 @@ body,
     font-family: var(--font-mono);
     font-size: 0.86em;
     color: color-mix(in oklch, var(--foreground) 90%, transparent);
+    background-color: var(--message-code-bg);
+    border: 1px solid color-mix(in oklch, var(--border) 45%, transparent);
+    box-shadow: none;
+    padding: 0.08em 0.34em;
+    border-radius: 0.3rem;
+  }
+  .dark .fz-prose code {
     background-color: color-mix(
       in oklch,
       var(--bg-elevated) 34%,
       var(--background)
     );
-    border: 1px solid color-mix(in oklch, var(--border) 45%, transparent);
     box-shadow:
       inset 0 1px 0 color-mix(in oklch, white 4%, transparent),
       0 1px 2px color-mix(in oklch, black 22%, transparent);
-    padding: 0.08em 0.34em;
-    border-radius: 0.3rem;
   }
   .fz-prose pre {
     background-color: color-mix(
@@ -712,7 +749,7 @@ body,
     min-width: 0;
     flex: 1;
     flex-direction: column;
-    background-color: #09090b;
+    background-color: var(--message-pre-bg);
   }
   .markdown-mermaid-shell-inline {
     height: min(58vh, 520px);
@@ -731,10 +768,10 @@ body,
     align-items: center;
     gap: 0.2rem;
     padding: 0.15rem;
-    border: 1px solid #3f3f46;
+    border: 1px solid var(--message-rule);
     border-radius: 0.55rem;
-    background-color: #18181b;
-    box-shadow: 0 10px 28px rgb(0 0 0 / 0.28);
+    background-color: var(--popover);
+    box-shadow: none;
   }
   .markdown-mermaid-viewer {
     position: relative;
@@ -743,7 +780,7 @@ body,
     flex: 1;
     place-items: center;
     overflow: auto;
-    background-color: #09090b;
+    background-color: var(--message-pre-bg);
     cursor: grab;
     touch-action: none;
     user-select: none;
@@ -755,7 +792,7 @@ body,
     min-width: max-content;
     padding: 2rem;
     border-radius: 0.7rem;
-    background-color: #09090b;
+    background-color: var(--message-pre-bg);
     zoom: var(--markdown-mermaid-scale);
   }
   .markdown-mermaid-viewer-canvas .markdown-mermaid-svg {
@@ -774,9 +811,23 @@ body,
     justify-content: center;
     width: 1.75rem;
     height: 1.75rem;
-    border: 1px solid #3f3f46;
+    border: 1px solid var(--message-rule);
     border-radius: 0.45rem;
     color: var(--text-muted);
+    background-color: var(--popover);
+  }
+  .dark .markdown-mermaid-shell,
+  .dark .markdown-mermaid-viewer,
+  .dark .markdown-mermaid-viewer-canvas {
+    background-color: #09090b;
+  }
+  .dark .markdown-mermaid-viewer-controls {
+    border-color: #3f3f46;
+    background-color: #18181b;
+    box-shadow: 0 10px 28px rgb(0 0 0 / 0.28);
+  }
+  .dark .markdown-mermaid-pan-hint {
+    border-color: #3f3f46;
     background-color: #18181b;
   }
   .fz-prose .markdown-code-block code,
@@ -825,9 +876,7 @@ body,
     border: 1px solid color-mix(in srgb, var(--border), transparent 55%);
     border-radius: 0.375rem;
     background-color: var(--chip-bg);
-    box-shadow:
-      0 1px 0 color-mix(in oklch, white 4%, transparent) inset,
-      0 1px 2px color-mix(in oklch, black 22%, transparent);
+    box-shadow: none;
     color: var(--foreground);
     font-size: 0.85em;
     line-height: 1.1;
@@ -842,7 +891,11 @@ body,
     width: 1.4em;
     height: 1.4em;
     border-radius: 0.25rem;
-    background-color: color-mix(in oklch, var(--chip-bg) 60%, var(--foreground) 6%);
+    background-color: color-mix(
+      in oklch,
+      var(--chip-bg) 60%,
+      var(--foreground) 6%
+    );
     flex-shrink: 0;
   }
   .fz-chip-iconimg {
@@ -867,7 +920,20 @@ body,
   }
   .fz-chip[data-kind="file"]:hover,
   .fz-chip[data-kind="image"]:hover {
-    background-color: color-mix(in oklch, var(--chip-bg) 80%, var(--foreground) 4%);
+    background-color: color-mix(
+      in oklch,
+      var(--chip-bg) 80%,
+      var(--foreground) 4%
+    );
+    box-shadow: none;
+  }
+  .dark .fz-chip {
+    box-shadow:
+      0 1px 0 color-mix(in oklch, white 4%, transparent) inset,
+      0 1px 2px color-mix(in oklch, black 22%, transparent);
+  }
+  .dark .fz-chip[data-kind="file"]:hover,
+  .dark .fz-chip[data-kind="image"]:hover {
     box-shadow:
       0 1px 0 color-mix(in oklch, white 6%, transparent) inset,
       0 2px 5px color-mix(in oklch, black 24%, transparent);
@@ -887,23 +953,15 @@ body,
 @layer components {
   .neon-lime {
     color: var(--lime);
-    text-shadow:
-      0 0 4px color-mix(in oklch, var(--lime) 25%, transparent),
-      0 0 12px color-mix(in oklch, var(--lime) 15%, transparent);
+    text-shadow: none;
   }
 
   .shadow-lime-glow {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 20%, transparent),
-      0 0 10px color-mix(in oklch, var(--lime) 25%, transparent),
-      0 0 24px color-mix(in oklch, var(--lime) 15%, transparent);
+    box-shadow: 0 0 0 1px color-mix(in oklch, var(--lime) 24%, transparent);
   }
 
   .shadow-lime-glow-strong {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent),
-      0 0 14px color-mix(in oklch, var(--lime) 36%, transparent),
-      0 0 32px color-mix(in oklch, var(--lime) 24%, transparent);
+    box-shadow: 0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent);
   }
 
   /* Embodied primary button */
@@ -914,28 +972,19 @@ body,
       background-color 120ms ease;
   }
   .btn-lime-embodied:hover:not(:disabled):not([data-loading]) {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 25%, transparent),
-      0 0 12px color-mix(in oklch, var(--lime) 32%, transparent),
-      var(--tw-shadow, 0 0 #0000);
+    box-shadow: var(--tw-shadow, 0 0 #0000);
     transform: translateY(-0.5px);
   }
   .btn-lime-embodied:active:not(:disabled):not([data-loading]),
   .btn-lime-embodied[data-pressed]:not(:disabled):not([data-loading]) {
     transform: translateY(0.5px) scale(0.985);
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 15%, transparent),
-      0 0 6px color-mix(in oklch, var(--lime) 20%, transparent),
-      var(--tw-shadow, 0 0 #0000);
+    box-shadow: var(--tw-shadow, 0 0 #0000);
   }
 
   /* Framed card polish — ensure inner FramePanels get the full layered
      bevel treatment when nested inside the main shell Frames. */
   [data-slot="frame"] [data-slot="card"] {
-    box-shadow:
-      0 1px 0 oklch(1 0 0 / 0.035) inset,
-      0 -1px 0 oklch(0 0 0 / 0.25) inset,
-      var(--tw-shadow, 0 0 #0000);
+    box-shadow: var(--tw-shadow, 0 0 #0000);
   }
 
   /* Tinted glass surfaces (PR card states, status buttons). Reads --tone
@@ -945,11 +994,8 @@ body,
      never duplicate per-tone classes. */
   .glass-tone {
     background-color: color-mix(in oklch, var(--tone) 14%, transparent);
-    color: color-mix(in oklch, var(--tone) 88%, white);
-    box-shadow:
-      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.04),
-      inset 0 1px 0 0 color-mix(in oklch, var(--tone) 24%, transparent),
-      inset 0 2px 3px 0 color-mix(in oklch, var(--tone) 14%, transparent);
+    color: color-mix(in oklch, var(--tone) 64%, var(--foreground));
+    box-shadow: none;
     backdrop-filter: blur(12px);
   }
   .glass-tone:hover:not(:disabled) {
@@ -963,9 +1009,7 @@ body,
   .glass-neutral {
     background-color: var(--color-neutral-primary-reverted-5);
     color: var(--foreground);
-    box-shadow:
-      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.03),
-      inset 0 2px 3px 0 rgba(255, 255, 255, 0.03);
+    box-shadow: none;
     backdrop-filter: blur(12px);
   }
   .glass-neutral:hover:not(:disabled) {
@@ -973,6 +1017,62 @@ body,
   }
   .glass-neutral:active:not(:disabled) {
     background-color: rgba(255, 255, 255, 0.16);
+  }
+
+  .dark .neon-lime {
+    text-shadow:
+      0 0 4px color-mix(in oklch, var(--lime) 25%, transparent),
+      0 0 12px color-mix(in oklch, var(--lime) 15%, transparent);
+  }
+
+  .dark .shadow-lime-glow {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 20%, transparent),
+      0 0 10px color-mix(in oklch, var(--lime) 25%, transparent),
+      0 0 24px color-mix(in oklch, var(--lime) 15%, transparent);
+  }
+
+  .dark .shadow-lime-glow-strong {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent),
+      0 0 14px color-mix(in oklch, var(--lime) 36%, transparent),
+      0 0 32px color-mix(in oklch, var(--lime) 24%, transparent);
+  }
+
+  .dark .btn-lime-embodied:hover:not(:disabled):not([data-loading]) {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 25%, transparent),
+      0 0 12px color-mix(in oklch, var(--lime) 32%, transparent),
+      var(--tw-shadow, 0 0 #0000);
+  }
+
+  .dark .btn-lime-embodied:active:not(:disabled):not([data-loading]),
+  .dark .btn-lime-embodied[data-pressed]:not(:disabled):not([data-loading]) {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--lime) 15%, transparent),
+      0 0 6px color-mix(in oklch, var(--lime) 20%, transparent),
+      var(--tw-shadow, 0 0 #0000);
+  }
+
+  .dark [data-slot="frame"] [data-slot="card"] {
+    box-shadow:
+      0 1px 0 oklch(1 0 0 / 0.035) inset,
+      0 -1px 0 oklch(0 0 0 / 0.25) inset,
+      var(--tw-shadow, 0 0 #0000);
+  }
+
+  .dark .glass-tone {
+    color: color-mix(in oklch, var(--tone) 88%, white);
+    box-shadow:
+      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.04),
+      inset 0 1px 0 0 color-mix(in oklch, var(--tone) 24%, transparent),
+      inset 0 2px 3px 0 color-mix(in oklch, var(--tone) 14%, transparent);
+  }
+
+  .dark .glass-neutral {
+    box-shadow:
+      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.03),
+      inset 0 2px 3px 0 rgba(255, 255, 255, 0.03);
   }
 }
 

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -5,7 +5,9 @@ import { FileSystem, Path } from "@effect/platform";
 import { Effect, Layer, PubSub, Ref, Stream } from "effect";
 
 import {
+  type AppearanceMode,
   type BranchNamingStyle,
+  type CompletionSoundPreset,
   defaultModelEnabledByProvider,
   defaultModelFor,
   type KeybindingRule,
@@ -15,7 +17,6 @@ import {
   type ProviderId,
   resolveModelSlug,
   SettingsFile,
-  type CompletionSoundPreset,
   type SettingsPatch,
   type SubagentPresetState,
 } from "@zuse/wire";
@@ -72,6 +73,7 @@ const freshSettings = (): SettingsFile =>
     // agents stay isolated. Per-repo settings can still opt a repo out.
     defaultAutoCreateWorktree: true,
     onboardingCompleted: false,
+    appearanceMode: "dark",
     completionSoundEnabled: false,
     completionSoundPreset: "chime",
     providerEnabled: seedProviderEnabled(),
@@ -110,6 +112,9 @@ const isCompletionSoundPreset = (v: unknown): v is CompletionSoundPreset =>
   v === "bell" ||
   v === "rise" ||
   v === "bloom";
+
+const isAppearanceMode = (v: unknown): v is AppearanceMode =>
+  v === "system" || v === "light" || v === "dark";
 
 const isBranchNamingStyle = (v: unknown): v is BranchNamingStyle =>
   v === "username-slug" || v === "slug" || v === "feat-slug" || v === "custom";
@@ -154,6 +159,10 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     typeof obj.onboardingCompleted === "boolean"
       ? obj.onboardingCompleted
       : base.onboardingCompleted;
+
+  const appearanceMode = isAppearanceMode(obj.appearanceMode)
+    ? obj.appearanceMode
+    : base.appearanceMode;
 
   const completionSoundEnabled =
     typeof obj.completionSoundEnabled === "boolean"
@@ -241,6 +250,7 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     defaultRuntimeMode: runtime,
     defaultAutoCreateWorktree: autoWorktree,
     onboardingCompleted: onboarding,
+    appearanceMode,
     completionSoundEnabled,
     completionSoundPreset,
     providerEnabled,
@@ -487,6 +497,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
             patch.defaultAutoCreateWorktree ?? cur.defaultAutoCreateWorktree,
           onboardingCompleted:
             patch.onboardingCompleted ?? cur.onboardingCompleted,
+          appearanceMode: patch.appearanceMode ?? cur.appearanceMode,
           completionSoundEnabled:
             patch.completionSoundEnabled ?? cur.completionSoundEnabled,
           completionSoundPreset:
@@ -536,6 +547,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
               baseline.defaultAutoCreateWorktree &&
             cur.completionSoundEnabled === baseline.completionSoundEnabled &&
             cur.completionSoundPreset === baseline.completionSoundPreset &&
+            cur.appearanceMode === baseline.appearanceMode &&
             cur.onboardingCompleted === false &&
             Object.keys(cur.subagents.presets).length === 0;
           if (!currentLooksFresh) return cur;
@@ -548,6 +560,8 @@ export const ConfigStoreServiceLive = Layer.scoped(
             cur.defaultRuntimeMode;
           let autoWorktree: boolean = cur.defaultAutoCreateWorktree;
           let onboarding: boolean = cur.onboardingCompleted;
+          let appearanceMode: SettingsFile["appearanceMode"] =
+            cur.appearanceMode;
           let providerEnabled: SettingsFile["providerEnabled"] =
             cur.providerEnabled;
           let modelEnabledByProvider: SettingsFile["modelEnabledByProvider"] =
@@ -571,6 +585,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
               runtime = fromLs.defaultRuntimeMode;
               autoWorktree = fromLs.defaultAutoCreateWorktree;
               onboarding = fromLs.onboardingCompleted;
+              appearanceMode = fromLs.appearanceMode;
               completionSoundEnabled = fromLs.completionSoundEnabled;
               completionSoundPreset = fromLs.completionSoundPreset;
               providerEnabled = fromLs.providerEnabled;
@@ -604,6 +619,7 @@ export const ConfigStoreServiceLive = Layer.scoped(
             defaultRuntimeMode: runtime,
             defaultAutoCreateWorktree: autoWorktree,
             onboardingCompleted: onboarding,
+            appearanceMode,
             completionSoundEnabled,
             completionSoundPreset,
             providerEnabled,

--- a/apps/server/test/config-store.test.ts
+++ b/apps/server/test/config-store.test.ts
@@ -20,12 +20,11 @@ describe("config-store settings coercion", () => {
   it("seeds missing model visibility from catalog defaults", () => {
     const settings = coerceSettings({});
 
+    expect(settings.appearanceMode).toBe("dark");
     expect(settings.modelEnabledByProvider.claude["claude-sonnet-5"]).toBe(
       true,
     );
-    expect(settings.modelEnabledByProvider.claude["claude-fable-5"]).toBe(
-      true,
-    );
+    expect(settings.modelEnabledByProvider.claude["claude-fable-5"]).toBe(true);
     expect(settings.modelEnabledByProvider.claude["claude-sonnet-4-6"]).toBe(
       false,
     );
@@ -45,5 +44,17 @@ describe("config-store settings coercion", () => {
 
     expect(settings.modelEnabledByProvider.codex["gpt-5.3-codex"]).toBe(true);
     expect(settings.modelEnabledByProvider.codex["not-real"]).toBeUndefined();
+  });
+
+  it("preserves valid appearance modes and drops invalid ones", () => {
+    expect(coerceSettings({ appearanceMode: "system" }).appearanceMode).toBe(
+      "system",
+    );
+    expect(coerceSettings({ appearanceMode: "light" }).appearanceMode).toBe(
+      "light",
+    );
+    expect(coerceSettings({ appearanceMode: "sepia" }).appearanceMode).toBe(
+      "dark",
+    );
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "turbo run build",
     "build:desktop": "turbo run build --filter=renderer --filter=desktop",
-    "dev": "turbo run dev --filter=renderer --filter=desktop",
+    "dev": "node scripts/dev.mjs",
+    "dev:turbo": "turbo run dev --filter=renderer --filter=desktop",
     "dev:desktop": "node scripts/dev.mjs",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/packages/wire/src/settings.ts
+++ b/packages/wire/src/settings.ts
@@ -25,6 +25,9 @@ export const CompletionSoundPreset = Schema.Literal(
 );
 export type CompletionSoundPreset = typeof CompletionSoundPreset.Type;
 
+export const AppearanceMode = Schema.Literal("system", "light", "dark");
+export type AppearanceMode = typeof AppearanceMode.Type;
+
 /**
  * How the auto-namer (PR: "auto-name chat + branch after first message")
  * shapes a worktree's git branch once it has an LLM-derived title slug.
@@ -61,6 +64,7 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
   defaultRuntimeMode: RuntimeMode,
   defaultAutoCreateWorktree: Schema.Boolean,
   onboardingCompleted: Schema.Boolean,
+  appearanceMode: AppearanceMode,
   completionSoundEnabled: Schema.Boolean,
   completionSoundPreset: CompletionSoundPreset,
   /**
@@ -114,6 +118,7 @@ export const SettingsPatch = Schema.Struct({
   defaultRuntimeMode: Schema.optional(RuntimeMode),
   defaultAutoCreateWorktree: Schema.optional(Schema.Boolean),
   onboardingCompleted: Schema.optional(Schema.Boolean),
+  appearanceMode: Schema.optional(AppearanceMode),
   completionSoundEnabled: Schema.optional(Schema.Boolean),
   completionSoundPreset: Schema.optional(CompletionSoundPreset),
   providerEnabled: Schema.optional(

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -404,6 +404,7 @@ describe("SettingsFile round-trip", () => {
       defaultRuntimeMode: "approval-required",
       defaultAutoCreateWorktree: false,
       onboardingCompleted: true,
+      appearanceMode: "system",
       completionSoundEnabled: true,
       completionSoundPreset: "bloom",
       providerEnabled: {
@@ -443,8 +444,44 @@ describe("SettingsFile round-trip", () => {
         defaultRuntimeMode: "approval-required",
         defaultAutoCreateWorktree: false,
         onboardingCompleted: true,
+        appearanceMode: "dark",
         completionSoundEnabled: true,
         completionSoundPreset: "airhorn",
+        providerEnabled: {
+          claude: true,
+          codex: true,
+          grok: true,
+          cursor: true,
+          gemini: true,
+          opencode: true,
+        },
+        modelEnabledByProvider: defaultModelEnabledByProvider(),
+        subagents: { enableForNewSessions: true, presets: {} },
+        branchNamingStyle: "username-slug",
+        branchNamingPrefix: "",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown appearance mode", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(SettingsFile)({
+        schemaVersion: 1,
+        defaultProviderId: "claude",
+        defaultModelByProvider: {
+          claude: "claude-opus-4-8",
+          codex: "gpt-5-codex",
+          grok: "grok-code-fast-1",
+          cursor: "cursor-agent",
+          gemini: "gemini-3-pro",
+          opencode: "sonnet",
+        },
+        defaultRuntimeMode: "approval-required",
+        defaultAutoCreateWorktree: false,
+        onboardingCompleted: true,
+        appearanceMode: "sepia",
+        completionSoundEnabled: true,
+        completionSoundPreset: "chime",
         providerEnabled: {
           claude: true,
           codex: true,

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,8 +1,10 @@
-// Root dev orchestrator for the desktop app: starts the Vite renderer on a
-// fixed port, then starts the desktop package (which runs tsdown in watch mode
-// and spawns Electron once the dev server + main/preload bundles are ready).
+// Root dev orchestrator for the desktop app: starts the Vite renderer, the
+// desktop bundle watcher, and Electron as separate visible processes. Keeping
+// these as top-level children avoids nested Turbo/Bun task UIs hiding the
+// Electron launcher while only showing the bundle watcher.
 
 import { spawn } from "node:child_process";
+import { rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -12,6 +14,15 @@ const repoRoot = resolve(__dirname, "..");
 const RENDERER_PORT = Number(process.env.PORT ?? 5733);
 const RENDERER_HOST = process.env.HOST?.trim() || "localhost";
 const DEV_SERVER_URL = `http://${RENDERER_HOST}:${RENDERER_PORT}`;
+
+// Force Electron to wait for the bundle produced by this dev run. Otherwise a
+// stale dist-electron from a previous build can launch immediately, then the
+// watch build writes fresh bundles and triggers a restart, briefly creating two
+// Electron dock icons.
+rmSync(resolve(repoRoot, "apps", "desktop", "dist-electron"), {
+  recursive: true,
+  force: true,
+});
 
 const children = [];
 let shuttingDown = false;
@@ -24,7 +35,9 @@ function run(name, command, args, extraEnv = {}) {
   });
   child.once("exit", (code, signal) => {
     if (shuttingDown) return;
-    console.error(`[${name}] exited (code=${code ?? "null"} signal=${signal ?? "null"})`);
+    console.error(
+      `[${name}] exited (code=${code ?? "null"} signal=${signal ?? "null"})`,
+    );
     void shutdown(code ?? 1);
   });
   children.push({ name, child });
@@ -46,7 +59,8 @@ run("renderer", "bun", ["run", "--filter", "renderer", "dev"], {
   PORT: String(RENDERER_PORT),
   HOST: RENDERER_HOST,
 });
-run("desktop", "bun", ["run", "--filter", "desktop", "dev"], {
+run("desktop:bundle", "bun", ["run", "--filter", "desktop", "dev:bundle"]);
+run("desktop:electron", "bun", ["run", "--filter", "desktop", "dev:electron"], {
   VITE_DEV_SERVER_URL: DEV_SERVER_URL,
 });
 


### PR DESCRIPTION
## Summary
- add persisted `appearanceMode` support with `system`, `light`, and `dark` modes across wire settings, config store coercion, and renderer settings store
- add renderer/native theme controllers so the DOM, Electron `nativeTheme`, CodeMirror, Shiki code blocks, and xterm terminals follow the resolved appearance
- add Settings and onboarding appearance controls, with onboarding split into a dedicated appearance step
- clean up light-mode tokens and theme-sensitive surfaces, including markdown/code shadows and onboarding/settings/composer surfaces
- fix `bun dev` desktop startup visibility by running renderer, desktop bundle, and Electron as top-level dev processes

## Why
Existing users should keep the historical dark behavior, while new users can choose System/Light/Dark during onboarding. The app also needed native macOS appearance updates and light-mode surfaces that match the existing lime/moss dark identity without heavy shadow artifacts.

## Validation
- `bun run check-types`
- `bun test packages/wire/test/schema.test.ts apps/server/test/config-store.test.ts apps/renderer/test`
- `bun run --filter renderer build`

Renderer build still emits the existing Hugeicons Rollup annotation warnings and chunk-size warning, but exits successfully.