### PR TITLE
[codex] Add markdown and HTML preview tab

### DIFF
--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -22,7 +22,12 @@ import { useActiveWorkspaceRoot } from "../store/active-workspace.ts";
 import { useAnnotationsStore } from "../store/annotations.ts";
 import { useKeybindingsStore } from "../store/keybindings.ts";
 import { useSessionsStore } from "../store/sessions.ts";
-import { useUiStore, type FileView, type OpenFile } from "../store/ui.ts";
+import {
+  isPreviewableFileName,
+  useUiStore,
+  type FileView,
+  type OpenFile,
+} from "../store/ui.ts";
 import {
   ANNOTATION_WIDGET_DELETE,
   ANNOTATION_WIDGET_SAVE,
@@ -35,12 +40,21 @@ import {
 } from "../lib/codemirror/annotation-selection.ts";
 import { AnnotateOverlay } from "./annotation/annotate-overlay.tsx";
 import { useAddAnnotation } from "./annotation/use-add-annotation.ts";
+import { MarkdownBody } from "./markdown-body.tsx";
 
 import type { EditorView } from "@codemirror/view";
 
 type EditorState =
   | { status: "loading" }
   | { status: "text"; size: number }
+  | { status: "binary"; size: number }
+  | { status: "error"; reason: string };
+
+type PreviewKind = "markdown" | "html";
+
+type PreviewState =
+  | { status: "loading" }
+  | { status: "ready"; kind: PreviewKind; content: string; baseHref: string }
   | { status: "binary"; size: number }
   | { status: "error"; reason: string };
 
@@ -68,6 +82,53 @@ const tagOf = (err: unknown): string | null =>
     ? String((err as { _tag: unknown })._tag)
     : null;
 
+const previewKindForFile = (name: string): PreviewKind | null => {
+  const lower = name.toLowerCase();
+  if (lower.endsWith(".html") || lower.endsWith(".htm")) return "html";
+  if (
+    lower.endsWith(".md") ||
+    lower.endsWith(".markdown") ||
+    lower.endsWith(".mdown") ||
+    lower.endsWith(".mkd")
+  ) {
+    return "markdown";
+  }
+  return null;
+};
+
+const dirname = (path: string): string => {
+  const idx = path.lastIndexOf("/");
+  if (idx === -1) return "";
+  if (idx === 0) return "/";
+  return path.slice(0, idx);
+};
+
+const joinPath = (base: string, rel: string): string =>
+  base.endsWith("/") ? `${base}${rel}` : `${base}/${rel}`;
+
+const fileUrlForDirectory = (dir: string): string => {
+  const normalized = dir.endsWith("/") ? dir : `${dir}/`;
+  const segments = normalized.split("/").map((segment) =>
+    segment === "" ? "" : encodeURIComponent(segment),
+  );
+  return `file://${segments.join("/")}`;
+};
+
+const escapeHtmlAttribute = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const htmlWithBaseHref = (html: string, baseHref: string): string => {
+  const base = `<base href="${escapeHtmlAttribute(baseHref)}">`;
+  if (/<head(?:\s[^>]*)?>/i.test(html)) {
+    return html.replace(/<head(?:\s[^>]*)?>/i, (match) => `${match}${base}`);
+  }
+  return `${base}${html}`;
+};
+
 /**
  * Top-level shell for the file tab in the main pane. Renders a Toolbar with
  * the Diff | Edit segmented control and delegates the body to either a
@@ -87,14 +148,24 @@ export function FileEditor() {
     return <ImageBody src={openFile.src} name={openFile.name} />;
   }
 
-  const view = openFile.view;
-  // External files have no git/folder context, so they're edit-only — no diff.
+  const canPreview = isPreviewableFileName(openFile.name);
+  // External files have no git/folder context, so they're edit/preview only.
   const isExternal = openFile.kind === "external";
+  const view =
+    (openFile.view === "preview" && !canPreview) ||
+    (openFile.view === "diff" && isExternal)
+      ? "edit"
+      : openFile.view;
   const path = isExternal ? openFile.absPath : openFile.path;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <Toolbar path={path} view={view} showViewToggle={!isExternal} />
+      <Toolbar
+        path={path}
+        view={view}
+        showDiff={!isExternal}
+        showPreview={canPreview}
+      />
       <CodeMirrorBody
         openFile={openFile}
         hidden={view !== "edit"}
@@ -103,6 +174,7 @@ export function FileEditor() {
       {openFile.kind === "text" && view === "diff" ? (
         <DiffViewBody openFile={openFile} />
       ) : null}
+      {view === "preview" ? <PreviewViewBody openFile={openFile} /> : null}
     </div>
   );
 }
@@ -731,6 +803,116 @@ function DiffViewBody({
 }
 
 // ---------------------------------------------------------------------------
+// Preview body — reads the saved file from disk and renders markdown / HTML.
+// This deliberately ignores unsaved CodeMirror edits until the user saves.
+// ---------------------------------------------------------------------------
+
+function PreviewViewBody({ openFile }: { openFile: EditableFile }) {
+  const [state, setState] = useState<PreviewState>({ status: "loading" });
+  const workspaceRoot = useActiveWorkspaceRoot(
+    openFile.kind === "text" ? openFile.folderId : null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+
+    void (async () => {
+      try {
+        const kind = previewKindForFile(openFile.name);
+        if (kind === null) {
+          setState({
+            status: "error",
+            reason: "Preview is only available for markdown and HTML files.",
+          });
+          return;
+        }
+
+        const client = await getRpcClient();
+        const result =
+          openFile.kind === "external"
+            ? await Effect.runPromise(
+                client.fs.readExternalFile({ path: openFile.absPath }),
+              )
+            : await Effect.runPromise(
+                client.fs.readFile({
+                  folderId: openFile.folderId,
+                  path: openFile.path,
+                  worktreeId: openFile.worktreeId,
+                }),
+              );
+        if (cancelled) return;
+        if (result.kind === "binary") {
+          setState({ status: "binary", size: result.size });
+          return;
+        }
+
+        const fileDir =
+          openFile.kind === "external"
+            ? dirname(openFile.absPath)
+            : workspaceRoot !== null
+              ? joinPath(workspaceRoot, dirname(openFile.path))
+              : dirname(openFile.path);
+        setState({
+          status: "ready",
+          kind,
+          content: result.content,
+          baseHref: fileUrlForDirectory(fileDir),
+        });
+      } catch (err) {
+        if (!cancelled) {
+          setState({ status: "error", reason: formatError(err) });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [openFile, workspaceRoot]);
+
+  if (state.status === "loading") {
+    return (
+      <Placeholder>
+        <ShimmerText>Loading preview…</ShimmerText>
+      </Placeholder>
+    );
+  }
+  if (state.status === "binary") {
+    return (
+      <Placeholder>
+        Binary file ({state.size.toLocaleString()} bytes) — preview not
+        supported.
+      </Placeholder>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <Placeholder>
+        <span className="text-destructive">{state.reason}</span>
+      </Placeholder>
+    );
+  }
+
+  if (state.kind === "markdown") {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto px-8 py-6">
+        <MarkdownBody className="mx-auto max-w-3xl" children={state.content} />
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      title={`${openFile.name} preview`}
+      sandbox=""
+      srcDoc={htmlWithBaseHref(state.content, state.baseHref)}
+      className="min-h-0 flex-1 border-0 bg-white"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Toolbar — path + dirty/saving on the left, Diff/Edit segmented toggle on
 // the right. The saving indicator lives inside CodeMirrorBody so it tracks
 // the actual save call; the toolbar just shows path + dirty + the toggle.
@@ -739,11 +921,13 @@ function DiffViewBody({
 function Toolbar({
   path,
   view,
-  showViewToggle = true,
+  showDiff,
+  showPreview,
 }: {
   path: string;
   view: FileView;
-  showViewToggle?: boolean;
+  showDiff: boolean;
+  showPreview: boolean;
 }) {
   const dirty = useUiStore((s) => s.fileDirty);
   const setOpenFileView = useUiStore((s) => s.setOpenFileView);
@@ -761,8 +945,13 @@ function Toolbar({
         {view === "edit" ? (
           <span className="opacity-60">⌘S to save</span>
         ) : null}
-        {showViewToggle ? (
-          <ViewToggle value={view} onChange={setOpenFileView} />
+        {showDiff || showPreview ? (
+          <ViewToggle
+            value={view}
+            onChange={setOpenFileView}
+            showDiff={showDiff}
+            showPreview={showPreview}
+          />
         ) : null}
       </span>
     </div>
@@ -772,25 +961,38 @@ function Toolbar({
 function ViewToggle({
   value,
   onChange,
+  showDiff,
+  showPreview,
 }: {
   value: FileView;
   onChange: (v: FileView) => void;
+  showDiff: boolean;
+  showPreview: boolean;
 }) {
   return (
     <div
       role="tablist"
       className="flex items-center gap-px rounded-sm border border-border bg-background/60 p-px"
     >
-      <ToggleButton
-        active={value === "diff"}
-        onClick={() => onChange("diff")}
-        label="Diff"
-      />
+      {showDiff ? (
+        <ToggleButton
+          active={value === "diff"}
+          onClick={() => onChange("diff")}
+          label="Diff"
+        />
+      ) : null}
       <ToggleButton
         active={value === "edit"}
         onClick={() => onChange("edit")}
         label="Edit"
       />
+      {showPreview ? (
+        <ToggleButton
+          active={value === "preview"}
+          onClick={() => onChange("preview")}
+          label="Preview"
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -80,11 +80,36 @@ export type PanelInstance =
 
 /**
  * Which body the file viewer is showing. `edit` is the CodeMirror editor;
- * `diff` is the side-by-side patch view (working tree vs HEAD) — wired up
- * for clicks from the Changes panel and from Edit/Write/MultiEdit tool
- * rows. Toggled in the toolbar; defaults set per entry point.
+ * `diff` is the side-by-side patch view (working tree vs HEAD); `preview`
+ * renders saved markdown / HTML files. Toggled in the toolbar; defaults set
+ * per entry point.
  */
-export type FileView = "edit" | "diff";
+export type FileView = "edit" | "diff" | "preview";
+
+const PREVIEWABLE_EXTENSIONS = new Set([
+  ".htm",
+  ".html",
+  ".markdown",
+  ".md",
+  ".mdown",
+  ".mkd",
+]);
+
+export const isPreviewableFileName = (name: string): boolean => {
+  const lower = name.toLowerCase();
+  const dot = lower.lastIndexOf(".");
+  if (dot === -1) return false;
+  return PREVIEWABLE_EXTENSIONS.has(lower.slice(dot));
+};
+
+const coerceFileView = (
+  file: { readonly kind: "text" | "external"; readonly name: string },
+  view: FileView,
+): FileView => {
+  if (file.kind === "external" && view === "diff") return "edit";
+  if (view === "preview" && !isPreviewableFileName(file.name)) return "edit";
+  return view;
+};
 
 /**
  * Discriminated by `kind`. `text` is the project-root-relative path the file
@@ -116,7 +141,8 @@ export type OpenFile =
        * A file outside any project folder (e.g. a plan or markdown file the
        * agent wrote elsewhere on disk). Read/written by absolute path via the
        * `fs.*ExternalFile` RPCs, which deliberately skip the workspace
-       * sandbox. Edit-only — there's no git/folder context for a diff.
+       * sandbox. External files are edit/preview only — there's no git/folder
+       * context for a diff.
        */
       readonly kind: "external";
       readonly absPath: string;
@@ -268,14 +294,26 @@ export const useUiStore = create<UiState>((set, get) => ({
   openFileInTab: (file) =>
     set({
       openFile:
-        file.kind === "image" ? file : { ...file, view: file.view ?? "edit" },
+        file.kind === "image"
+          ? file
+          : {
+              ...file,
+              view: coerceFileView(file, file.view ?? "edit"),
+            },
       activeMainTab: "file",
       fileDirty: false,
     }),
   setOpenFileView: (view) =>
     set((s) => {
-      if (s.openFile === null || s.openFile.kind !== "text") return s;
-      return { openFile: { ...s.openFile, view } };
+      if (
+        s.openFile === null ||
+        (s.openFile.kind !== "text" && s.openFile.kind !== "external")
+      ) {
+        return s;
+      }
+      return {
+        openFile: { ...s.openFile, view: coerceFileView(s.openFile, view) },
+      };
     }),
   closeFileTab: () =>
     set({ openFile: null, activeMainTab: "chat", fileDirty: false }),


### PR DESCRIPTION
## Summary

Adds a Preview tab to the file viewer for markdown and HTML files.

## Changes

- Extends the renderer file view state with a `preview` mode.
- Shows Preview only for markdown and HTML-like files.
- Keeps external files edit/preview-only while preserving workspace diff/edit behavior.
- Renders markdown through the existing `MarkdownBody` component.
- Renders HTML in a sandboxed iframe from saved disk content, with a file-directory `<base>` for relative assets.

## Validation

- `bun --filter renderer check-types`
- `git diff --check -- apps/renderer/src/store/ui.ts apps/renderer/src/components/file-editor.tsx`
