### PR TITLE
[codex] Add renderer toast notifications

### DIFF
--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -40,6 +40,7 @@ import {
   MenuTrigger,
 } from "~/components/ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { toastManager } from "~/components/ui/toast.tsx";
 import { useAuth } from "~/hooks/use-auth.ts";
 import {
   deriveChatAttentionState,
@@ -73,12 +74,56 @@ import { BranchIcon, type BranchState } from "./branch-icon.tsx";
 import { ProjectAddMenu } from "./project-add-menu.tsx";
 import { Spinner } from "./ui/spinner";
 
+const sidebarErrorToastCache = {
+  chats: null as string | null,
+  sessions: null as string | null,
+  workspace: null as string | null,
+};
+
 const initialsOf = (name: string): string => {
   const parts = name.split(/[-_.\s]+/).filter(Boolean);
   const letters =
     parts.length >= 2 ? parts[0]![0]! + parts[1]![0]! : name.slice(0, 2);
   return letters.toUpperCase();
 };
+
+function showSidebarErrorToast(
+  source: keyof typeof sidebarErrorToastCache,
+  title: string,
+  message: string | null,
+): void {
+  if (message === null) {
+    sidebarErrorToastCache[source] = null;
+    return;
+  }
+  if (sidebarErrorToastCache[source] === message) return;
+  sidebarErrorToastCache[source] = message;
+  toastManager.add({
+    type: "error",
+    title,
+    description: message,
+  });
+}
+
+function SidebarErrorToasts(): null {
+  const workspaceError = useWorkspaceStore((s) => s.error);
+  const chatsError = useChatsStore((s) => s.error);
+  const sessionsError = useSessionsStore((s) => s.error);
+
+  useEffect(() => {
+    showSidebarErrorToast("workspace", "Project error", workspaceError);
+  }, [workspaceError]);
+
+  useEffect(() => {
+    showSidebarErrorToast("chats", "Chats error", chatsError);
+  }, [chatsError]);
+
+  useEffect(() => {
+    showSidebarErrorToast("sessions", "Sessions error", sessionsError);
+  }, [sessionsError]);
+
+  return null;
+}
 
 // GitHub serves owner/org avatars at this path; works for users and orgs alike.
 // Returns null for non-GitHub remotes so the caller falls back to initials.
@@ -226,7 +271,6 @@ export function ProjectsSidebar() {
   useRegisterPane("sidebar", paneRef);
   const folders = useWorkspaceStore((s) => s.folders);
   const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
-  const error = useWorkspaceStore((s) => s.error);
   const loading = useWorkspaceStore((s) => s.loading);
   const load = useWorkspaceStore((s) => s.load);
   const remove = useWorkspaceStore((s) => s.remove);
@@ -234,10 +278,8 @@ export function ProjectsSidebar() {
 
   const sessionsByProject = useSessionsStore((s) => s.sessionsByProject);
   const hydrateSessions = useSessionsStore((s) => s.hydrate);
-  const sessionsError = useSessionsStore((s) => s.error);
 
   const chatsByProject = useChatsStore((s) => s.chatsByProject);
-  const chatsError = useChatsStore((s) => s.error);
   const hydrateChats = useChatsStore((s) => s.hydrate);
 
   const [origins, setOrigins] = useState<Record<string, GitOriginInfo | null>>(
@@ -349,12 +391,7 @@ export function ProjectsSidebar() {
         <span>Projects</span>
         <ProjectAddMenu />
       </div>
-
-      {(error ?? chatsError ?? sessionsError) !== null && (
-        <p className="mx-3 mb-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200">
-          {error ?? chatsError ?? sessionsError}
-        </p>
-      )}
+      <SidebarErrorToasts />
 
       <ul className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2">
         {folders.length === 0 && !loading && (

--- a/apps/renderer/src/components/settings/developer-pane.tsx
+++ b/apps/renderer/src/components/settings/developer-pane.tsx
@@ -1,5 +1,13 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Alert01Icon, GitMergeIcon, Upload01Icon, Wrench01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  Alert01Icon,
+  GitMergeIcon,
+  InformationCircleIcon,
+  Loading02Icon,
+  TaskDone01Icon,
+  Upload01Icon,
+  Wrench01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
 import { GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
 import {
   GlassActionButton,
@@ -8,6 +16,7 @@ import {
   GLASS_TONE_VARS,
   type GlassTone,
 } from "../glass-action.tsx";
+import { toastManager } from "../ui/toast.tsx";
 
 /**
  * Dev-only visual playground. Renders the accent palette + every state of
@@ -19,6 +28,7 @@ export function DeveloperPane(): React.ReactElement {
   return (
     <div className="flex flex-col gap-10">
       <PaletteSection />
+      <ToastPlaygroundSection />
       <WorkflowStatesSection />
     </div>
   );
@@ -138,6 +148,91 @@ const WORKFLOW_DEMOS: ReadonlyArray<WorkflowDemo> = [
 ];
 
 function noop(): void {}
+
+function ToastPlaygroundSection(): React.ReactElement {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-xs font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+        Toast playground
+      </h2>
+      <div className="grid gap-2 rounded-lg border border-border/60 bg-muted p-3 sm:grid-cols-2">
+        <GlassActionButton
+          tone="green"
+          icon={<HugeiconsIcon icon={GitMergeIcon} />}
+          label="PR merged"
+          onClick={() =>
+            toastManager.add({
+              type: "success",
+              title: "Pull request #142 merged",
+              description: "toast-system into main",
+            })
+          }
+        />
+        <GlassActionButton
+          tone="zinc"
+          icon={<HugeiconsIcon icon={InformationCircleIcon} />}
+          label="PR closed"
+          onClick={() =>
+            toastManager.add({
+              type: "info",
+              title: "Pull request #142 closed",
+              description: "toast-system into main",
+            })
+          }
+        />
+        <GlassActionButton
+          tone="red"
+          icon={<HugeiconsIcon icon={Alert01Icon} />}
+          label="Sidebar error"
+          onClick={() =>
+            toastManager.add({
+              type: "error",
+              title: "Project error",
+              description: "Could not load projects from the local workspace.",
+            })
+          }
+        />
+        <GlassActionButton
+          tone="red"
+          icon={<HugeiconsIcon icon={Alert01Icon} />}
+          label="Action failed"
+          onClick={() =>
+            toastManager.add({
+              type: "error",
+              title: "Merge failed",
+              description:
+                "GitHub rejected the merge because required checks are still running.",
+            })
+          }
+        />
+        <GlassActionButton
+          tone="pink"
+          icon={<HugeiconsIcon icon={Loading02Icon} />}
+          label="Loading"
+          onClick={() =>
+            toastManager.add({
+              type: "loading",
+              title: "Removing dirty worktree...",
+              description: "Discarding local changes and deleting the checkout.",
+            })
+          }
+        />
+        <GlassActionButton
+          tone="green"
+          icon={<HugeiconsIcon icon={TaskDone01Icon} />}
+          label="Success"
+          onClick={() =>
+            toastManager.add({
+              type: "success",
+              title: "Worktree removed",
+              description: "The dirty checkout was discarded and archived.",
+            })
+          }
+        />
+      </div>
+    </section>
+  );
+}
 
 function WorkflowStatesSection(): React.ReactElement {
   return (

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -66,6 +66,7 @@ import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { useWorktreesStore } from "../store/worktrees.ts";
 import { Button } from "./ui/button.tsx";
+import { toastManager } from "./ui/toast.tsx";
 import {
   Dialog,
   DialogClose,
@@ -1128,9 +1129,8 @@ function CiStatus({ workflow }: { workflow: OpenPrWorkflow }) {
 
 /**
  * GlassActionButton wrapper for direct (non-agent) git/gh actions. Shows a
- * spinner while the RPC is in flight and, on failure, a red warning affordance
- * whose tooltip carries gh's verbatim error (click to dismiss). The user can
- * retry once it clears.
+ * spinner while the RPC is in flight and reports failures through the global
+ * toast surface. The user can retry once loading clears.
  */
 function DirectActionButton({
   tone,
@@ -1150,55 +1150,38 @@ function DirectActionButton({
   onSuccess?: () => void;
 }) {
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const onClick = async () => {
     if (loading) return;
     setLoading(true);
-    setError(null);
     try {
       await run();
       onSuccess?.();
     } catch (err) {
-      setError(errorMessage(err));
+      toastManager.add({
+        type: "error",
+        title: `${label} failed`,
+        description: errorMessage(err),
+      });
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="flex items-center gap-1">
-      {error !== null ? (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                onClick={() => setError(null)}
-                className="flex size-6 items-center justify-center rounded-sm text-[var(--accent-red)] hover:bg-foreground/5"
-                aria-label="Action failed — dismiss"
-              >
-                <HugeiconsIcon icon={Alert01Icon} className="size-3.5" />
-              </button>
-            }
-          />
-          <TooltipPopup className="max-w-xs">{error}</TooltipPopup>
-        </Tooltip>
-      ) : null}
-      <GlassActionButton
-        tone={tone}
-        icon={
-          loading ? (
-            <HugeiconsIcon icon={Loading02Icon} className="animate-spin" />
-          ) : (
-            icon
-          )
-        }
-        label={loading ? loadingLabel : label}
-        disabled={disabled || loading}
-        onClick={onClick}
-      />
-    </div>
+    <GlassActionButton
+      tone={tone}
+      icon={
+        loading ? (
+          <HugeiconsIcon icon={Loading02Icon} className="animate-spin" />
+        ) : (
+          icon
+        )
+      }
+      label={loading ? loadingLabel : label}
+      disabled={disabled || loading}
+      onClick={onClick}
+    />
   );
 }
 
@@ -1299,12 +1282,10 @@ function AutoMergeToggle({
   const method = useMergePrefs((s) => s.method);
   const deleteBranch = useMergePrefs((s) => s.deleteBranch);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const toggle = async () => {
     if (loading) return;
     setLoading(true);
-    setError(null);
     try {
       const client = await getRpcClient();
       await Effect.runPromise(
@@ -1318,7 +1299,11 @@ function AutoMergeToggle({
       );
       refreshAfterAction(folderId, worktreeId);
     } catch (err) {
-      setError(errorMessage(err));
+      toastManager.add({
+        type: "error",
+        title: "Auto-merge failed",
+        description: errorMessage(err),
+      });
     } finally {
       setLoading(false);
     }
@@ -1330,23 +1315,6 @@ function AutoMergeToggle({
 
   return (
     <div className="flex items-center gap-1">
-      {error !== null ? (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                onClick={() => setError(null)}
-                className="flex size-6 items-center justify-center rounded-sm text-[var(--accent-red)] hover:bg-foreground/5"
-                aria-label="Auto-merge failed — dismiss"
-              >
-                <HugeiconsIcon icon={Alert01Icon} className="size-3.5" />
-              </button>
-            }
-          />
-          <TooltipPopup className="max-w-xs">{error}</TooltipPopup>
-        </Tooltip>
-      ) : null}
       <Tooltip>
         <TooltipTrigger
           render={

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -5,6 +5,7 @@ import "@xterm/xterm/css/xterm.css";
 import "./styles.css";
 
 import { App } from "./app";
+import { ToastProvider } from "./components/ui/toast.tsx";
 
 if (import.meta.env.DEV) {
   void import("./lib/update-demo.ts").then((m) => m.installUpdateDemo());
@@ -15,6 +16,8 @@ if (!root) throw new Error("#root missing in index.html");
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </React.StrictMode>,
 );

--- a/apps/renderer/src/store/pr-state.ts
+++ b/apps/renderer/src/store/pr-state.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 
 import type { FolderId, GitPrInfo, WorktreeId } from "@zuse/wire";
 
+import { toastManager } from "../components/ui/toast.tsx";
 import { getRpcClient } from "../lib/rpc-client.ts";
 
 /**
@@ -50,6 +51,42 @@ const fetchPrState = async (
   }
 };
 
+const prLabel = (info: GitPrInfo): string =>
+  info.number === null ? "Pull request" : `Pull request #${info.number}`;
+
+const prDescription = (info: GitPrInfo): string => {
+  if (info.branch !== null && info.baseBranch !== null) {
+    return `${info.branch} into ${info.baseBranch}`;
+  }
+  if (info.branch !== null) return info.branch;
+  return "";
+};
+
+const notifyPrStateTransition = (
+  previous: GitPrInfo | undefined,
+  next: GitPrInfo,
+): void => {
+  if (previous === undefined) return;
+  if (previous.state !== "open" || next.state === previous.state) return;
+
+  if (next.state === "merged") {
+    toastManager.add({
+      type: "success",
+      title: `${prLabel(next)} merged`,
+      description: prDescription(next),
+    });
+    return;
+  }
+
+  if (next.state === "closed") {
+    toastManager.add({
+      type: "info",
+      title: `${prLabel(next)} closed`,
+      description: prDescription(next),
+    });
+  }
+};
+
 export const usePrStateStore = create<PrState>((set, get) => ({
   byKey: {},
   hydrate: async (folderId, worktreeId) => {
@@ -63,6 +100,9 @@ export const usePrStateStore = create<PrState>((set, get) => ({
     const info = await fetchPrState(folderId, worktreeId);
     if (info === null) return;
     const key = prStateKey(folderId, worktreeId);
-    set((s) => ({ byKey: { ...s.byKey, [key]: info } }));
+    set((s) => {
+      notifyPrStateTransition(s.byKey[key], info);
+      return { byKey: { ...s.byKey, [key]: info } };
+    });
   },
 }));


### PR DESCRIPTION
## Summary

Adds a visible app-wide toast surface for renderer notifications and routes PR/sidebar feedback through it.

## Changes

- Mounts the existing Base UI `ToastProvider` globally so `toastManager.add(...)` calls render across the app.
- Replaces persistent project-sidebar inline errors with deduped error toasts for workspace, chat, and session store failures.
- Adds PR state transition toasts for `open -> merged` and `open -> closed`, covering direct merge and auto-merge completion after refresh.
- Moves direct git/PR action failures from inline top-bar alert icons to global error toasts.
- Adds a DEV-only Settings -> Developer toast playground for manually testing PR, error, loading, and success toast variants.

## Validation

- `bun run --filter renderer check-types`
- `bun run --filter renderer test`
- `git diff --check`
