### PR TITLE
[codex] add agent browser v2

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -53,9 +53,14 @@ extraResources:
 # Native bindings can't load from inside an asar; they need to live as
 # real files on disk. electron-builder writes these to app.asar.unpacked/
 # and the loader transparently rewrites the path.
+# browser-mcp-child.cjs is spawned by bun (Grok's zuse-browser MCP server) —
+# an external process that can't read inside the asar, so it must be unpacked
+# too; browser-mcp-bridge.ts rewrites app.asar → app.asar.unpacked when
+# resolving it.
 asar: true
 asarUnpack:
   - "**/*.node"
+  - "dist-electron/browser-mcp-child.cjs"
   - "node_modules/better-sqlite3/**"
   - "node_modules/node-pty/**"
   - "node_modules/keytar/**"

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -10,6 +10,7 @@ import {
   protocol,
   shell,
   webContents as webContentsModule,
+  type WebContents,
 } from "electron";
 import { Effect, Fiber, Layer } from "effect";
 import fixPath from "fix-path";
@@ -687,11 +688,47 @@ function createMainWindow() {
   // Track which webContentsIds we've attached to so registerWebview is
   // idempotent (the renderer fires it on every `dom-ready`, including reloads).
   const attachedWebContents = new Set<number>();
+  // Event taps (debugger message listener + webContents listeners) survive a
+  // debugger detach/re-attach cycle, so they install once per webContents —
+  // re-installing on every crash-recovery attach would double every buffered
+  // page error and unload-allow.
+  const tappedWebContents = new Set<number>();
+
+  // Per-webview observability buffers, fed by CDP events below. Network keeps
+  // insertion order (Map) so "recent requests" reads oldest→newest; both are
+  // cleared on every main-frame load start so the agent's `browser_network` /
+  // `browser_console` reads describe the current page, mirroring the
+  // renderer's own console ring buffer.
+  type NetworkEntry = {
+    id: string;
+    method: string;
+    url: string;
+    resourceType?: string;
+    status?: number;
+    mimeType?: string;
+    responseHeaders?: Record<string, string>;
+    failed?: string;
+  };
+  const NETWORK_LOG_CAP = 300;
+  const PAGE_ERROR_CAP = 100;
+  const browserNetworkLog = new Map<number, Map<string, NetworkEntry>>();
+  const browserPageErrors = new Map<number, string[]>();
+  const browserPendingDialog = new Map<
+    number,
+    { type: string; message: string; defaultPrompt?: string }
+  >();
+
+  const dropBrowserBuffers = (id: number): void => {
+    browserNetworkLog.delete(id);
+    browserPageErrors.delete(id);
+    browserPendingDialog.delete(id);
+  };
 
   const detachDebugger = (id: number): void => {
     const wc = webContentsModule.fromId(id);
     if (wc === undefined || wc.isDestroyed()) {
       attachedWebContents.delete(id);
+      dropBrowserBuffers(id);
       return;
     }
     try {
@@ -700,6 +737,121 @@ function createMainWindow() {
       // Detach failures are non-fatal — the webContents may be tearing down.
     }
     attachedWebContents.delete(id);
+    dropBrowserBuffers(id);
+  };
+
+  /**
+   * Route CDP events into the per-webview buffers. Registered once per
+   * attach; Electron drops the listener with the webContents.
+   */
+  const installCdpEventTaps = (id: number, wc: WebContents): void => {
+    wc.debugger.on("message", (_event, method, rawParams) => {
+      const params = (rawParams ?? {}) as Record<string, any>;
+      switch (method) {
+        case "Network.requestWillBeSent": {
+          const log =
+            browserNetworkLog.get(id) ??
+            browserNetworkLog.set(id, new Map()).get(id)!;
+          log.set(String(params.requestId), {
+            id: String(params.requestId),
+            method: String(params.request?.method ?? "GET"),
+            url: String(params.request?.url ?? ""),
+            resourceType:
+              typeof params.type === "string" ? params.type : undefined,
+          });
+          if (log.size > NETWORK_LOG_CAP) {
+            const oldest = log.keys().next().value;
+            if (oldest !== undefined) log.delete(oldest);
+          }
+          return;
+        }
+        case "Network.responseReceived": {
+          const entry = browserNetworkLog
+            .get(id)
+            ?.get(String(params.requestId));
+          if (entry === undefined) return;
+          entry.status = Number(params.response?.status ?? 0);
+          entry.mimeType =
+            typeof params.response?.mimeType === "string"
+              ? params.response.mimeType
+              : undefined;
+          const headers = params.response?.headers;
+          if (headers !== null && typeof headers === "object") {
+            entry.responseHeaders = headers as Record<string, string>;
+          }
+          return;
+        }
+        case "Network.loadingFailed": {
+          const entry = browserNetworkLog
+            .get(id)
+            ?.get(String(params.requestId));
+          if (entry !== undefined) {
+            entry.failed = String(params.errorText ?? "failed");
+          }
+          return;
+        }
+        case "Runtime.exceptionThrown": {
+          const details = params.exceptionDetails as
+            | Record<string, any>
+            | undefined;
+          const description =
+            details?.exception?.description ??
+            details?.text ??
+            "Uncaught exception";
+          const where =
+            typeof details?.url === "string" && details.url.length > 0
+              ? ` (${details.url}:${details.lineNumber ?? 0})`
+              : "";
+          const errors = browserPageErrors.get(id) ?? [];
+          errors.push(
+            `[uncaught] ${String(description).slice(0, 500)}${where}`,
+          );
+          if (errors.length > PAGE_ERROR_CAP) {
+            errors.splice(0, errors.length - PAGE_ERROR_CAP);
+          }
+          browserPageErrors.set(id, errors);
+          return;
+        }
+        case "Page.javascriptDialogOpening": {
+          browserPendingDialog.set(id, {
+            type: String(params.type ?? "alert"),
+            message: String(params.message ?? ""),
+            defaultPrompt:
+              typeof params.defaultPrompt === "string"
+                ? params.defaultPrompt
+                : undefined,
+          });
+          return;
+        }
+        case "Page.javascriptDialogClosed": {
+          browserPendingDialog.delete(id);
+          return;
+        }
+        default:
+          return;
+      }
+    });
+  };
+
+  /**
+   * Turn on the CDP domains the v2 tools read from. Best-effort per domain —
+   * a domain that fails to enable (older Chromium, experimental surface)
+   * degrades that one capability, not the whole browser.
+   */
+  const enableCdpDomains = async (wc: WebContents): Promise<void> => {
+    for (const method of [
+      "Network.enable",
+      "Runtime.enable",
+      "Page.enable",
+      "DOM.enable",
+      "Accessibility.enable",
+    ]) {
+      try {
+        await wc.debugger.sendCommand(method);
+      } catch (err) {
+        console.error(`[zuse] CDP ${method} failed`, err);
+      }
+    }
   };
 
   ipcMain.handle("browser:registerWebview", async (_event, rawId: unknown) => {
@@ -711,15 +863,35 @@ function createMainWindow() {
       // Protocol 1.3 is the stable baseline that ships with every modern
       // Chromium; older revisions don't accept `Input.dispatchMouseEvent`
       // payload fields we rely on (`pointerType`, `tangentialPressure`).
+      // Experimental domains (Accessibility) still work — the attached
+      // debugger speaks the running Chromium's full protocol.
       wc.debugger.attach("1.3");
       attachedWebContents.add(rawId);
-      // Auto-cleanup when the webContents goes away (window close, webview
-      // teardown, full crash). Without this, a `Another debugger is already
-      // attached` error fires on the next register-after-reload.
-      wc.once("destroyed", () => {
-        attachedWebContents.delete(rawId);
-      });
-      wc.on("render-process-gone", () => detachDebugger(rawId));
+      if (!tappedWebContents.has(rawId)) {
+        tappedWebContents.add(rawId);
+        installCdpEventTaps(rawId, wc);
+        // Fresh page → the previous page's requests/errors are stale.
+        wc.on("did-start-loading", () => {
+          browserNetworkLog.get(rawId)?.clear();
+          browserPageErrors.get(rawId)?.splice(0);
+        });
+        // A page's beforeunload handler must not wedge agent navigation — the
+        // user watched the agent ask for the navigation, so always let it
+        // proceed (this is what a user clicking "Leave" would do).
+        wc.on("will-prevent-unload", (event) => {
+          event.preventDefault();
+        });
+        // Auto-cleanup when the webContents goes away (window close, webview
+        // teardown, full crash). Without this, a `Another debugger is already
+        // attached` error fires on the next register-after-reload.
+        wc.once("destroyed", () => {
+          attachedWebContents.delete(rawId);
+          tappedWebContents.delete(rawId);
+          dropBrowserBuffers(rawId);
+        });
+        wc.on("render-process-gone", () => detachDebugger(rawId));
+      }
+      await enableCdpDomains(wc);
       return true;
     } catch (err) {
       // The only expected failure here is "already attached by DevTools" —
@@ -727,6 +899,122 @@ function createMainWindow() {
       console.error("[zuse] failed to attach CDP debugger", err);
       return false;
     }
+  });
+
+  /**
+   * Allowlisted CDP passthrough for the agent-browser renderer. The renderer
+   * already holds `executeJavaScript` on the same webview, so this grants no
+   * new page-level power — the list just keeps the seam from becoming a
+   * generic protocol proxy (no Target.*, no Browser.*, no Input.* — input
+   * stays on the dedicated `browser:dispatchInput` path).
+   */
+  const CDP_ALLOWED_METHODS = new Set([
+    "Accessibility.getFullAXTree",
+    "DOM.getDocument",
+    "DOM.scrollIntoViewIfNeeded",
+    "DOM.getContentQuads",
+    "DOM.resolveNode",
+    "Runtime.callFunctionOn",
+    "Page.captureScreenshot",
+    "Page.handleJavaScriptDialog",
+  ]);
+
+  ipcMain.handle(
+    "browser:cdpCommand",
+    async (_event, rawId: unknown, rawMethod: unknown, rawParams: unknown) => {
+      if (typeof rawId !== "number" || !Number.isInteger(rawId)) {
+        return { ok: false as const, error: "bad webContents id" };
+      }
+      if (
+        typeof rawMethod !== "string" ||
+        !CDP_ALLOWED_METHODS.has(rawMethod)
+      ) {
+        return {
+          ok: false as const,
+          error: `method not allowed: ${String(rawMethod)}`,
+        };
+      }
+      const wc = webContentsModule.fromId(rawId);
+      if (wc === undefined || wc.isDestroyed() || !wc.debugger.isAttached()) {
+        return { ok: false as const, error: "debugger not attached" };
+      }
+      try {
+        const result = await wc.debugger.sendCommand(
+          rawMethod,
+          rawParams !== null && typeof rawParams === "object"
+            ? (rawParams as Record<string, unknown>)
+            : {},
+        );
+        // Dialog resolution isn't always reported back via
+        // javascriptDialogClosed on every Chromium; clear eagerly.
+        if (rawMethod === "Page.handleJavaScriptDialog") {
+          browserPendingDialog.delete(rawId);
+        }
+        return { ok: true as const, result };
+      } catch (err) {
+        return {
+          ok: false as const,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    "browser:getNetwork",
+    async (_event, rawId: unknown, rawQuery: unknown) => {
+      if (typeof rawId !== "number" || !Number.isInteger(rawId)) return null;
+      const log = browserNetworkLog.get(rawId);
+      if (log === undefined) return { requests: [] };
+      const query = (rawQuery ?? {}) as { filter?: unknown; id?: unknown };
+      if (typeof query.id === "string" && query.id.length > 0) {
+        const entry = log.get(query.id);
+        if (entry === undefined) return null;
+        // Body comes straight from the CDP buffer; truncated so one XHR
+        // can't blow up the agent's context.
+        let body: string | undefined;
+        let bodyBase64 = false;
+        const wc = webContentsModule.fromId(rawId);
+        if (wc !== undefined && !wc.isDestroyed() && wc.debugger.isAttached()) {
+          try {
+            const res = (await wc.debugger.sendCommand(
+              "Network.getResponseBody",
+              { requestId: entry.id },
+            )) as { body?: string; base64Encoded?: boolean };
+            bodyBase64 = res.base64Encoded === true;
+            body =
+              typeof res.body === "string"
+                ? res.body.slice(0, 4000)
+                : undefined;
+          } catch {
+            // Body may be gone (evicted, streamed, or a non-buffered type) —
+            // detail without a body is still useful.
+          }
+        }
+        return { detail: { ...entry, body, bodyBase64 } };
+      }
+      const filter =
+        typeof query.filter === "string" && query.filter.length > 0
+          ? query.filter.toLowerCase()
+          : null;
+      const requests = [...log.values()]
+        .filter(
+          (entry) =>
+            filter === null || entry.url.toLowerCase().includes(filter),
+        )
+        .map(({ responseHeaders: _headers, ...summary }) => summary);
+      return { requests };
+    },
+  );
+
+  ipcMain.handle("browser:getPageErrors", async (_event, rawId: unknown) => {
+    if (typeof rawId !== "number" || !Number.isInteger(rawId)) return [];
+    return [...(browserPageErrors.get(rawId) ?? [])];
+  });
+
+  ipcMain.handle("browser:getDialogState", async (_event, rawId: unknown) => {
+    if (typeof rawId !== "number" || !Number.isInteger(rawId)) return null;
+    return browserPendingDialog.get(rawId) ?? null;
   });
 
   ipcMain.handle(

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -67,6 +67,37 @@ const bridge = {
         webContentsId,
         action,
       ) as Promise<boolean>,
+    /**
+     * Allowlisted CDP passthrough (Accessibility/DOM/Runtime/Page) for the
+     * v2 agent-browser tools — a11y snapshots, ref → coordinate resolution,
+     * full-page capture, dialog handling. Main rejects anything off-list.
+     */
+    cdpCommand: (webContentsId: number, method: string, params?: unknown) =>
+      ipcRenderer.invoke(
+        "browser:cdpCommand",
+        webContentsId,
+        method,
+        params ?? {},
+      ) as Promise<{ ok: boolean; result?: unknown; error?: string }>,
+    /** Network requests captured since the last load (buffered in main). */
+    getNetwork: (webContentsId: number, query?: unknown) =>
+      ipcRenderer.invoke(
+        "browser:getNetwork",
+        webContentsId,
+        query ?? {},
+      ) as Promise<unknown>,
+    /** Uncaught page exceptions captured via CDP since the last load. */
+    getPageErrors: (webContentsId: number) =>
+      ipcRenderer.invoke("browser:getPageErrors", webContentsId) as Promise<
+        string[]
+      >,
+    /** The currently open JS dialog (alert/confirm/prompt), if any. */
+    getDialogState: (webContentsId: number) =>
+      ipcRenderer.invoke("browser:getDialogState", webContentsId) as Promise<{
+        type: string;
+        message: string;
+        defaultPrompt?: string;
+      } | null>,
   },
   app: {
     openExternal: (url: string) => {

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -89,4 +89,21 @@ export default defineConfig([
     ...shared,
     entry: ["src/preload.ts"],
   },
+  {
+    ...shared,
+    // The zuse-browser MCP child that ACP providers (Grok) spawn via bun to
+    // reach the in-app browser. It runs OUTSIDE Electron — and, packaged,
+    // outside the asar — so it can't resolve node_modules at runtime: bundle
+    // every dependency in (the runtime graph is just @modelcontextprotocol/sdk
+    // plus node builtins; the @zuse imports are type-only). The bridge resolves
+    // this artifact next to the main bundle (browser-mcp-bridge.ts).
+    entry: {
+      "browser-mcp-child":
+        "../server/src/provider/drivers/acp/browser-mcp-child.ts",
+    },
+    deps: {
+      alwaysBundle: ["@zuse/wire", "@zuse/server", "@modelcontextprotocol/sdk"],
+    },
+    external: [],
+  },
 ]);

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -4,12 +4,13 @@ import { useEffect, useRef, useState } from "react";
 import { Effect, Fiber, Stream } from "effect";
 import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 
-import {
-  BrowserCommandResult,
-  type BrowserCommandRequest,
-} from "@zuse/wire";
+import { BrowserCommandResult, type BrowserCommandRequest } from "@zuse/wire";
 
-import type { BrowserInputAction } from "../lib/bridge.ts";
+import type {
+  BrowserInputAction,
+  CdpCommandOutcome,
+  NetworkQueryResult,
+} from "../lib/bridge.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useUiStore } from "../store/ui.ts";
 import { AgentCursor, type AgentCursorIntent } from "./agent-cursor.tsx";
@@ -48,6 +49,12 @@ export function BrowserPane() {
   // Ring buffer of console messages + page errors, captured per page load so
   // `browser_console` can report them to the agent. Cleared on navigation.
   const consoleBufferRef = useRef<string[]>([]);
+  // Which snapshot minted the refs the agent is currently holding, and (for
+  // the CDP a11y path) the ref → backendNodeId map actions resolve through.
+  // DOM-mode refs live in the page itself as `data-mz-ref` attributes, so the
+  // map stays empty there. Reset on navigation — stale refs must fail with
+  // "re-snapshot" rather than land on the wrong node of a new page.
+  const refStoreRef = useRef<RefStore>({ mode: "dom", map: new Map() });
   // The embedded webview's webContents id — handed to main once we see
   // `dom-ready` so main can attach Chrome DevTools Protocol and dispatch real
   // input events. `null` until the first dom-ready; null disables CDP paths
@@ -101,12 +108,15 @@ export function BrowserPane() {
       // and hit `Browser input bridge is not ready`. Only set it back after
       // main confirms the debugger attached.
       webContentsIdRef.current = null;
-      void browserBridge.registerWebview(id).then((ok) => {
-        if (ok) webContentsIdRef.current = id;
-      }).catch(() => {
-        // Attach failure is non-fatal — leave id null and CDP-using tools
-        // fall back to the synthetic path with a clean cursor animation.
-      });
+      void browserBridge
+        .registerWebview(id)
+        .then((ok) => {
+          if (ok) webContentsIdRef.current = id;
+        })
+        .catch(() => {
+          // Attach failure is non-fatal — leave id null and CDP-using tools
+          // fall back to the synthetic path with a clean cursor animation.
+        });
     };
     const onDidNavigate = (e: Event) => {
       const ev = e as Event & { url?: string };
@@ -118,8 +128,9 @@ export function BrowserPane() {
     };
     const onStart = () => {
       setIsLoading(true);
-      // Fresh page — drop the previous page's console history.
+      // Fresh page — drop the previous page's console history and refs.
       consoleBufferRef.current = [];
+      refStoreRef.current = { mode: "dom", map: new Map() };
     };
     const onStop = () => {
       setIsLoading(false);
@@ -216,6 +227,10 @@ export function BrowserPane() {
           });
         },
         getWebContentsId: () => webContentsIdRef.current,
+        getRefStore: () => refStoreRef.current,
+        setRefStore: (store) => {
+          refStoreRef.current = store;
+        },
       });
       try {
         const client = await getRpcClient();
@@ -376,6 +391,10 @@ async function runBrowserCommand(
      * available (non-Electron build of the renderer).
      */
     getWebContentsId: () => number | null;
+    /** Current snapshot ref store (mode + ref → backendNodeId map). */
+    getRefStore: () => RefStore;
+    /** Replace the ref store after a fresh snapshot. */
+    setRefStore: (store: RefStore) => void;
   },
 ): Promise<BrowserCommandResult> {
   const fail = (error: string) =>
@@ -407,6 +426,29 @@ async function runBrowserCommand(
         // The tab was just made visible; give the compositor a beat to paint
         // before capturing, otherwise the frame can come back blank.
         await delay(180);
+        // Full-page goes through CDP (captures beyond the viewport); without
+        // the debugger we degrade to the viewport capture below rather than
+        // failing — a partial screenshot beats none.
+        if (command.fullPage === true) {
+          const wcId = hooks.getWebContentsId();
+          if (wcId !== null) {
+            const shot = await cdpCall(wcId, "Page.captureScreenshot", {
+              format: "png",
+              captureBeyondViewport: true,
+            });
+            const data = (shot as { data?: unknown } | null)?.data;
+            if (typeof data === "string" && data.length > 0) {
+              hooks.flashShutter();
+              return BrowserCommandResult.make({
+                id: req.id,
+                ok: true,
+                url: current,
+                title: safeCall(() => wv.getTitle(), ""),
+                screenshot: data,
+              });
+            }
+          }
+        }
         const image = await wv.capturePage();
         if (image.isEmpty()) {
           return fail(
@@ -426,7 +468,26 @@ async function runBrowserCommand(
         });
       }
       case "Snapshot": {
+        // Prefer the a11y tree over CDP: full-document coverage, roles and
+        // states the DOM walk can't see, and ~an order of magnitude cheaper
+        // for the model than a screenshot. Any failure (debugger detached,
+        // experimental domain missing) falls back to the v1 DOM walk.
+        const wcId = hooks.getWebContentsId();
+        if (wcId !== null) {
+          const built = await buildA11ySnapshot(wcId);
+          if (built !== null) {
+            hooks.setRefStore({ mode: "cdp", map: built.map });
+            return BrowserCommandResult.make({
+              id: req.id,
+              ok: true,
+              url: safeCall(() => wv.getURL(), ""),
+              title: safeCall(() => wv.getTitle(), ""),
+              snapshot: built.text,
+            });
+          }
+        }
         const raw = await wv.executeJavaScript(SNAPSHOT_JS);
+        hooks.setRefStore({ mode: "dom", map: new Map() });
         return BrowserCommandResult.make({
           id: req.id,
           ok: true,
@@ -437,37 +498,36 @@ async function runBrowserCommand(
       }
       case "Click": {
         if (!isValidRef(command.ref)) return fail("Invalid element ref.");
-        const target = await resolveRefRect(wv, command.ref);
-        if (target === null) {
-          return fail(
-            "No element with that ref — re-snapshot the page first.",
-          );
-        }
         const wcId = hooks.getWebContentsId();
+        const store = hooks.getRefStore();
+        const target = await resolveRefTarget(wv, wcId, store, command.ref);
+        if (target === null) {
+          return fail("No element with that ref — re-snapshot the page first.");
+        }
         // Without CDP attached (preload bridge missing, attach failed) we
         // can't deliver real input. Fall back to the synthetic click so the
         // agent still makes progress — the cursor animation still runs so
         // the user sees *where* the click landed.
         hooks.moveCursor(target.cx, target.cy, { click: true });
-        if (wcId === null) {
-          await wv.executeJavaScript(
-            `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (el) el.click(); })()`,
+        const delivered =
+          wcId !== null &&
+          (await dispatchClickViaCdp(wcId, target.cx, target.cy));
+        if (!delivered) {
+          if (wcId === null) await delay(CURSOR_GLIDE_MS + 20);
+          const res = await callOnRefElement(
+            wv,
+            wcId,
+            store,
+            command.ref,
+            CLICK_FN,
+            [],
           );
-          await delay(CURSOR_GLIDE_MS + 20);
-          return BrowserCommandResult.make({
-            id: req.id,
-            ok: true,
-            detail: `Clicked ${target.label} (no-CDP fallback).`,
-          });
-        }
-        const ok = await dispatchClickViaCdp(wcId, target.cx, target.cy);
-        if (!ok) {
-          // Debugger detached mid-action (webview reload, crash). Fall through
-          // to synthetic so the agent still makes progress — the cursor pulse
-          // already fired so the user sees *where* the click landed.
-          await wv.executeJavaScript(
-            `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (el) el.click(); })()`,
-          );
+          if (res === null || !res.ok) {
+            return fail(
+              res?.error ??
+                "The click could not be delivered — re-snapshot and retry.",
+            );
+          }
         }
         return BrowserCommandResult.make({
           id: req.id,
@@ -478,49 +538,63 @@ async function runBrowserCommand(
       case "Type": {
         if (!isValidRef(command.ref)) return fail("Invalid element ref.");
         const submit = command.submit === true;
-        const target = await resolveRefRect(wv, command.ref);
+        const wcId = hooks.getWebContentsId();
+        const store = hooks.getRefStore();
+        const target = await resolveRefTarget(wv, wcId, store, command.ref);
         if (target === null) {
           return fail("No element with that ref — re-snapshot first.");
         }
         // Glide the cursor to the field with a click pulse — visually frames
         // the field activation. Real focus happens via CDP click (or .focus()
         // when CDP isn't available) so the input shows its native focus ring.
-        const wcId = hooks.getWebContentsId();
         hooks.moveCursor(target.cx, target.cy, { click: true });
         if (wcId !== null) {
           await dispatchClickViaCdp(wcId, target.cx, target.cy);
         }
-        // The value-setter via the prototype descriptor bypasses React's
-        // value tracker — without it, React thinks the controlled value
-        // didn't change and the next render reverts the input. This is the
-        // industry-standard "type into a React input" approach (used by
-        // Testing Library's `userEvent` and Puppeteer fallbacks); switching
-        // to CDP's `Input.insertText` here would regress on common SPA
-        // login forms. We keep the JS path on purpose; the real click above
-        // already gave the field a true focus event.
-        const res = await runJsObject(
+        // FILL_FIELD_FN keeps v1's prototype-descriptor value setter: it
+        // bypasses React's value tracker — without it, React thinks the
+        // controlled value didn't change and the next render reverts the
+        // input. Switching to CDP's `Input.insertText` here would regress on
+        // common SPA login forms; the real click above already gave the
+        // field a true focus event.
+        const res = await callOnRefElement(
           wv,
-          `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot first.' }); el.focus(); const v = ${JSON.stringify(command.text)}; const tag = el.tagName; if (tag === 'INPUT' || tag === 'TEXTAREA') { const proto = tag === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype; const d = Object.getOwnPropertyDescriptor(proto, 'value'); if (d && d.set) d.set.call(el, v); else el.value = v; } else { el.textContent = v; } el.dispatchEvent(new Event('input', { bubbles:true })); el.dispatchEvent(new Event('change', { bubbles:true })); return JSON.stringify({ ok:true, detail:'Typed into ' + ((el.getAttribute('name')||el.getAttribute('aria-label')||el.tagName)||'') }); })()`,
+          wcId,
+          store,
+          command.ref,
+          FILL_FIELD_FN,
+          [command.text],
         );
         if (submit) {
           if (wcId !== null) {
             await dispatchKeyTap(wcId, "Enter");
           } else {
-            await wv.executeJavaScript(
-              `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return; const o = { key:'Enter', keyCode:13, which:13, bubbles:true }; el.dispatchEvent(new KeyboardEvent('keydown', o)); el.dispatchEvent(new KeyboardEvent('keyup', o)); const f = el.form; if (f && typeof f.requestSubmit === 'function') { try { f.requestSubmit(); } catch (e) {} } })()`,
-            );
+            await callOnRefElement(wv, wcId, store, command.ref, ENTER_FN, []);
           }
         }
         return resultFromJs(req.id, res, `Typed into ${command.ref}.`);
       }
       case "Wait": {
+        // Bounded below the bridge's 30s deadline so a hopeless wait comes
+        // back as a clean tool error instead of a bridge timeout.
+        const timeoutMs = Math.min(
+          Math.max(command.timeoutMs ?? 10000, 100),
+          25000,
+        );
         if (
           typeof command.selector === "string" &&
           command.selector.length > 0
         ) {
           const res = await runJsObject(
             wv,
-            `(async () => { const sel = ${JSON.stringify(command.selector)}; const deadline = Date.now() + 10000; while (Date.now() < deadline) { if (document.querySelector(sel)) return JSON.stringify({ ok:true, detail:'Element appeared: ' + sel }); await new Promise(r => setTimeout(r, 150)); } return JSON.stringify({ ok:false, error:'Timed out (10s) waiting for ' + sel }); })()`,
+            `(async () => { const sel = ${JSON.stringify(command.selector)}; const deadline = Date.now() + ${timeoutMs}; while (Date.now() < deadline) { if (document.querySelector(sel)) return JSON.stringify({ ok:true, detail:'Element appeared: ' + sel }); await new Promise(r => setTimeout(r, 150)); } return JSON.stringify({ ok:false, error:'Timed out (${timeoutMs}ms) waiting for ' + sel }); })()`,
+          );
+          return resultFromJs(req.id, res, "Done waiting.");
+        }
+        if (typeof command.text === "string" && command.text.length > 0) {
+          const res = await runJsObject(
+            wv,
+            `(async () => { const want = ${JSON.stringify(command.text)}; const deadline = Date.now() + ${timeoutMs}; while (Date.now() < deadline) { if ((document.body?.innerText || '').includes(want)) return JSON.stringify({ ok:true, detail:'Text appeared: "' + want + '"' }); await new Promise(r => setTimeout(r, 150)); } return JSON.stringify({ ok:false, error:'Timed out (${timeoutMs}ms) waiting for text "' + want + '"' }); })()`,
           );
           return resultFromJs(req.id, res, "Done waiting.");
         }
@@ -535,17 +609,23 @@ async function runBrowserCommand(
       case "Scroll": {
         if (typeof command.ref === "string" && command.ref.length > 0) {
           if (!isValidRef(command.ref)) return fail("Invalid element ref.");
+          const wcId = hooks.getWebContentsId();
+          const store = hooks.getRefStore();
           // Use a JS-driven rAF animation instead of `scrollIntoView({behavior:
           // 'smooth'})` — native smooth scroll varies wildly across pages (some
           // override `scroll-behavior`, some cut the animation short on tiny
           // deltas) and feels choppy. We control duration + easing here so the
           // glide looks the same regardless of the page.
-          const res = await runJsObject(
+          const res = await callOnRefElement(
             wv,
-            buildSmoothScrollRefJs(command.ref),
+            wcId,
+            store,
+            command.ref,
+            SMOOTH_SCROLL_REF_FN,
+            [],
           );
           await delay(SMOOTH_SCROLL_MS + 60);
-          const after = await resolveRefRect(wv, command.ref);
+          const after = await resolveRefTarget(wv, wcId, store, command.ref);
           if (after !== null) hooks.moveCursor(after.cx, after.cy);
           return resultFromJs(req.id, res, "Scrolled into view.");
         }
@@ -561,12 +641,13 @@ async function runBrowserCommand(
       }
       case "Hover": {
         if (!isValidRef(command.ref)) return fail("Invalid element ref.");
-        const target = await resolveRefRect(wv, command.ref);
+        const wcId = hooks.getWebContentsId();
+        const store = hooks.getRefStore();
+        const target = await resolveRefTarget(wv, wcId, store, command.ref);
         if (target === null) {
           return fail("No element with that ref — re-snapshot first.");
         }
         hooks.moveCursor(target.cx, target.cy);
-        const wcId = hooks.getWebContentsId();
         if (wcId !== null) {
           // Real `mouseMove` triggers Chromium's hit-testing, which is what
           // makes :hover styles and hover-only menus actually open. Synthetic
@@ -577,9 +658,7 @@ async function runBrowserCommand(
             y: target.cy,
           });
         } else {
-          await wv.executeJavaScript(
-            `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return; const r = el.getBoundingClientRect(); const o = { bubbles:true, clientX: r.left + r.width/2, clientY: r.top + r.height/2 }; for (const t of ['pointerover','mouseover','mouseenter','mousemove']) el.dispatchEvent(new MouseEvent(t, o)); })()`,
-          );
+          await callOnRefElement(wv, wcId, store, command.ref, HOVER_FN, []);
         }
         await delay(CURSOR_GLIDE_MS + 20);
         return BrowserCommandResult.make({
@@ -590,14 +669,19 @@ async function runBrowserCommand(
       }
       case "Select": {
         if (!isValidRef(command.ref)) return fail("Invalid element ref.");
-        const res = await runJsObject(
+        const res = await callOnRefElement(
           wv,
-          `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot first.' }); if (el.tagName !== 'SELECT') return JSON.stringify({ ok:false, error:'That ref is not a <select> dropdown.' }); const want = ${JSON.stringify(command.value)}; const opt = Array.from(el.options).find((o) => o.value === want || (o.textContent||'').trim() === want); if (!opt) return JSON.stringify({ ok:false, error:'No option matching "' + want + '".' }); el.value = opt.value; el.dispatchEvent(new Event('input', { bubbles:true })); el.dispatchEvent(new Event('change', { bubbles:true })); return JSON.stringify({ ok:true, detail:'Selected ' + (opt.textContent||opt.value) }); })()`,
+          hooks.getWebContentsId(),
+          hooks.getRefStore(),
+          command.ref,
+          SELECT_OPTION_FN,
+          [command.value],
         );
         return resultFromJs(req.id, res, `Selected ${command.value}.`);
       }
       case "Press": {
         const wcId = hooks.getWebContentsId();
+        const store = hooks.getRefStore();
         const hasRef =
           typeof command.ref === "string" && command.ref.length > 0;
         if (hasRef && !isValidRef(command.ref as string)) {
@@ -607,7 +691,12 @@ async function runBrowserCommand(
         // element). With CDP we do a real click → cursor moves to it; without
         // CDP we just call `.focus()` via JS.
         if (hasRef) {
-          const target = await resolveRefRect(wv, command.ref as string);
+          const target = await resolveRefTarget(
+            wv,
+            wcId,
+            store,
+            command.ref as string,
+          );
           if (target === null) {
             return fail("No element with that ref — re-snapshot first.");
           }
@@ -615,8 +704,13 @@ async function runBrowserCommand(
           if (wcId !== null) {
             await dispatchClickViaCdp(wcId, target.cx, target.cy);
           } else {
-            await wv.executeJavaScript(
-              `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(command.ref as string)}]'); if (el && typeof el.focus === 'function') el.focus(); })()`,
+            await callOnRefElement(
+              wv,
+              wcId,
+              store,
+              command.ref as string,
+              FOCUS_FN,
+              [],
             );
             await delay(CURSOR_GLIDE_MS + 20);
           }
@@ -635,15 +729,32 @@ async function runBrowserCommand(
         });
       }
       case "Read": {
-        const refExpr =
-          typeof command.ref === "string" && command.ref.length > 0
-            ? isValidRef(command.ref)
-              ? `document.querySelector('[data-mz-ref=${JSON.stringify(command.ref)}]')`
-              : null
-            : `document.body`;
-        if (refExpr === null) return fail("Invalid element ref.");
+        if (typeof command.ref === "string" && command.ref.length > 0) {
+          if (!isValidRef(command.ref)) return fail("Invalid element ref.");
+          const res = await callOnRefElement(
+            wv,
+            hooks.getWebContentsId(),
+            hooks.getRefStore(),
+            command.ref,
+            READ_TEXT_FN,
+            [],
+          );
+          if (res === null || !res.ok) {
+            return fail(res?.error ?? "Could not read that element.");
+          }
+          return BrowserCommandResult.make({
+            id: req.id,
+            ok: true,
+            url: safeCall(() => wv.getURL(), ""),
+            title: safeCall(() => wv.getTitle(), ""),
+            text:
+              typeof res.text === "string" && res.text.length > 0
+                ? res.text
+                : "(no visible text)",
+          });
+        }
         const raw = await wv.executeJavaScript(
-          `(() => { const el = ${refExpr}; if (!el) return ''; return (el.innerText || el.textContent || '').replace(/\\n{3,}/g, '\\n\\n').trim().slice(0, 8000); })()`,
+          `(() => { const el = document.body; if (!el) return ''; return (el.innerText || el.textContent || '').replace(/\\n{3,}/g, '\\n\\n').trim().slice(0, 8000); })()`,
         );
         const text = typeof raw === "string" ? raw : "";
         return BrowserCommandResult.make({
@@ -678,11 +789,179 @@ async function runBrowserCommand(
         });
       }
       case "Console": {
-        const log = hooks.readConsole();
+        // Three sources merged: the webview's console-message events (v1),
+        // uncaught exceptions captured via CDP in main (v2), and — because a
+        // blocked page is the most confusing failure mode — a note when a JS
+        // dialog is sitting open.
+        const parts = [hooks.readConsole()];
+        const wcId = hooks.getWebContentsId();
+        const bridge = window.zuse?.browser;
+        if (wcId !== null && bridge?.getPageErrors !== undefined) {
+          const errors = await bridge.getPageErrors(wcId).catch(() => []);
+          if (errors.length > 0) parts.push(errors.join("\n"));
+        }
+        if (wcId !== null && bridge?.getDialogState !== undefined) {
+          const dialog = await bridge.getDialogState(wcId).catch(() => null);
+          if (dialog !== null) {
+            parts.push(
+              `[dialog open] ${dialog.type}: "${dialog.message}" — the page is blocked until browser_dialog resolves it.`,
+            );
+          }
+        }
         return BrowserCommandResult.make({
           id: req.id,
           ok: true,
-          text: log,
+          text: parts.filter((p) => p.length > 0).join("\n"),
+        });
+      }
+      case "FillForm": {
+        if (command.fields.length === 0) {
+          return fail("No fields given — pass at least one { ref, value }.");
+        }
+        const wcId = hooks.getWebContentsId();
+        const store = hooks.getRefStore();
+        const filled: string[] = [];
+        for (const field of command.fields) {
+          if (!isValidRef(field.ref)) {
+            return fail(`Invalid element ref: ${field.ref}`);
+          }
+          const target = await resolveRefTarget(wv, wcId, store, field.ref);
+          if (target === null) {
+            return fail(
+              `No element for ref ${field.ref} — re-snapshot first. Already filled: ${
+                filled.length > 0 ? filled.join(", ") : "none"
+              }.`,
+            );
+          }
+          // Glide (no click pulse) so the user can follow field to field.
+          hooks.moveCursor(target.cx, target.cy);
+          const res = await callOnRefElement(
+            wv,
+            wcId,
+            store,
+            field.ref,
+            FILL_FIELD_FN,
+            [field.value],
+          );
+          if (res === null || !res.ok) {
+            return fail(
+              `${res?.error ?? `Could not fill ${field.ref}.`} Already filled: ${
+                filled.length > 0 ? filled.join(", ") : "none"
+              }.`,
+            );
+          }
+          filled.push(target.label.length > 0 ? target.label : field.ref);
+          await delay(120);
+        }
+        if (command.submit === true) {
+          const lastRef = command.fields[command.fields.length - 1]!.ref;
+          if (wcId !== null) {
+            await dispatchKeyTap(wcId, "Enter");
+          } else {
+            await callOnRefElement(wv, wcId, store, lastRef, ENTER_FN, []);
+          }
+        }
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          detail: `Filled ${filled.length} field${filled.length === 1 ? "" : "s"} (${filled.join(", ")})${command.submit === true ? " and submitted" : ""}.`,
+        });
+      }
+      case "Network": {
+        const wcId = hooks.getWebContentsId();
+        const bridge = window.zuse?.browser;
+        if (wcId === null || bridge?.getNetwork === undefined) {
+          return fail(
+            "Network capture is unavailable — the browser's debugger is not attached.",
+          );
+        }
+        const res: NetworkQueryResult = await bridge
+          .getNetwork(wcId, {
+            ...(command.filter !== undefined ? { filter: command.filter } : {}),
+            ...(command.id !== undefined ? { id: command.id } : {}),
+          })
+          .catch(() => null);
+        if (res === null) {
+          return fail(
+            command.id !== undefined
+              ? `No captured request with id ${command.id} — list requests first (they reset on navigation).`
+              : "No network activity captured yet.",
+          );
+        }
+        if ("detail" in res) {
+          const d = res.detail;
+          const lines = [
+            `${d.method} ${d.url}`,
+            `status: ${d.failed !== undefined ? `FAILED (${d.failed})` : (d.status ?? "(pending)")}  type: ${d.resourceType ?? "?"}  mime: ${d.mimeType ?? "?"}`,
+          ];
+          const headers = Object.entries(d.responseHeaders ?? {}).slice(0, 30);
+          if (headers.length > 0) {
+            lines.push(
+              "response headers:",
+              ...headers.map(([k, v]) => `  ${k}: ${String(v).slice(0, 200)}`),
+            );
+          }
+          if (typeof d.body === "string" && d.body.length > 0) {
+            lines.push(
+              d.bodyBase64 === true
+                ? "body: (binary, base64 — omitted)"
+                : `body (truncated to 4000 chars):\n${d.body}`,
+            );
+          }
+          return BrowserCommandResult.make({
+            id: req.id,
+            ok: true,
+            text: lines.join("\n"),
+          });
+        }
+        const rows = res.requests
+          .slice(-200)
+          .map(
+            (r) =>
+              `${r.method} ${r.failed !== undefined ? `FAIL(${r.failed})` : (r.status ?? "…")} ${r.resourceType ?? ""} ${r.url.slice(0, 300)}  [id=${r.id}]`,
+          );
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          text:
+            rows.length > 0
+              ? rows.join("\n")
+              : "(no requests captured since the last page load)",
+        });
+      }
+      case "Dialog": {
+        const wcId = hooks.getWebContentsId();
+        const bridge = window.zuse?.browser;
+        if (
+          wcId === null ||
+          bridge?.getDialogState === undefined ||
+          bridge?.cdpCommand === undefined
+        ) {
+          return fail(
+            "Dialog handling is unavailable — the browser's debugger is not attached.",
+          );
+        }
+        const pending = await bridge.getDialogState(wcId).catch(() => null);
+        if (pending === null) {
+          return fail("No JavaScript dialog is open.");
+        }
+        const out = await bridge.cdpCommand(
+          wcId,
+          "Page.handleJavaScriptDialog",
+          {
+            accept: command.action === "accept",
+            ...(command.promptText !== undefined
+              ? { promptText: command.promptText }
+              : {}),
+          },
+        );
+        if (!out.ok) {
+          return fail(out.error ?? "Could not resolve the dialog.");
+        }
+        return BrowserCommandResult.make({
+          id: req.id,
+          ok: true,
+          detail: `${command.action === "accept" ? "Accepted" : "Dismissed"} the ${pending.type}: "${pending.message.slice(0, 200)}".`,
         });
       }
       case "Login": {
@@ -713,6 +992,159 @@ async function runBrowserCommand(
 // Snapshot refs are minted as `e<number>` — validate before string-injecting
 // into a querySelector so a crafted ref can't break out of the selector.
 const isValidRef = (ref: string): boolean => /^e\d+$/.test(ref);
+
+/**
+ * Which snapshot mode minted the refs the agent currently holds. `cdp` refs
+ * resolve through backendNodeIds (a11y tree); `dom` refs live in the page as
+ * `data-mz-ref` attributes (v1 fallback). A store from one page never
+ * survives navigation — see the `did-start-loading` reset.
+ */
+type RefStore = {
+  mode: "dom" | "cdp";
+  map: Map<string, { backendNodeId: number; label: string }>;
+};
+
+/**
+ * One allowlisted CDP call through the preload bridge. Returns the raw CDP
+ * result object, or null on any failure (bridge absent, method rejected,
+ * debugger detached) — callers treat null as "fall back or fail soft".
+ */
+async function cdpCall(
+  webContentsId: number,
+  method: string,
+  params?: unknown,
+): Promise<unknown | null> {
+  const fn = window.zuse?.browser?.cdpCommand;
+  if (fn === undefined) return null;
+  try {
+    const out: CdpCommandOutcome = await fn(webContentsId, method, params);
+    return out.ok ? (out.result ?? {}) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a snapshot ref to webview-relative CSS-pixel center coords + label,
+ * scrolling the element into view first (so a click can't miss because the
+ * page moved between snapshot and action). CDP mode goes backendNodeId →
+ * `DOM.scrollIntoViewIfNeeded` → `DOM.getContentQuads`; DOM mode keeps the
+ * v1 querySelector path. Null → ref is stale, tell the agent to re-snapshot.
+ */
+async function resolveRefTarget(
+  wv: WebviewElement,
+  webContentsId: number | null,
+  store: RefStore,
+  ref: string,
+): Promise<{ cx: number; cy: number; label: string } | null> {
+  if (store.mode === "cdp") {
+    const entry = store.map.get(ref);
+    if (entry === undefined || webContentsId === null) return null;
+    await cdpCall(webContentsId, "DOM.scrollIntoViewIfNeeded", {
+      backendNodeId: entry.backendNodeId,
+    });
+    const res = await cdpCall(webContentsId, "DOM.getContentQuads", {
+      backendNodeId: entry.backendNodeId,
+    });
+    const quads = (res as { quads?: unknown } | null)?.quads;
+    if (!Array.isArray(quads) || quads.length === 0) return null;
+    const q = quads[0] as number[];
+    if (!Array.isArray(q) || q.length < 8) return null;
+    const cx = (q[0]! + q[2]! + q[4]! + q[6]!) / 4;
+    const cy = (q[1]! + q[3]! + q[5]! + q[7]!) / 4;
+    if (!Number.isFinite(cx) || !Number.isFinite(cy)) return null;
+    return { cx, cy, label: entry.label };
+  }
+  return resolveRefRect(wv, ref);
+}
+
+/**
+ * Run one of the `*_FN` page functions against a ref's element, whichever
+ * mode minted the ref. CDP mode: `DOM.resolveNode` → `Runtime.callFunctionOn`
+ * with the element as `this` (works for a11y refs that have no DOM marker).
+ * DOM mode: the same function source is applied to the `data-mz-ref` element
+ * via `executeJavaScript`. Both return the function's `{ ok, ... }` object.
+ */
+async function callOnRefElement(
+  wv: WebviewElement,
+  webContentsId: number | null,
+  store: RefStore,
+  ref: string,
+  fnDecl: string,
+  args: ReadonlyArray<string | number | boolean>,
+): Promise<{
+  ok: boolean;
+  error?: string;
+  detail?: string;
+  text?: string;
+} | null> {
+  if (store.mode === "cdp") {
+    const entry = store.map.get(ref);
+    if (entry === undefined || webContentsId === null) {
+      return {
+        ok: false,
+        error: "No element with that ref — re-snapshot the page first.",
+      };
+    }
+    const resolved = await cdpCall(webContentsId, "DOM.resolveNode", {
+      backendNodeId: entry.backendNodeId,
+    });
+    const objectId = (resolved as { object?: { objectId?: unknown } } | null)
+      ?.object?.objectId;
+    if (typeof objectId !== "string") {
+      return {
+        ok: false,
+        error: "That element is gone — re-snapshot the page first.",
+      };
+    }
+    const call = await cdpCall(webContentsId, "Runtime.callFunctionOn", {
+      objectId,
+      functionDeclaration: fnDecl,
+      returnByValue: true,
+      arguments: args.map((value) => ({ value })),
+    });
+    const value = (call as { result?: { value?: unknown } } | null)?.result
+      ?.value;
+    return value !== null && typeof value === "object"
+      ? (value as {
+          ok: boolean;
+          error?: string;
+          detail?: string;
+          text?: string;
+        })
+      : { ok: false, error: "The page did not respond to the action." };
+  }
+  return runJsObject(
+    wv,
+    `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot the page first.' }); return JSON.stringify((${fnDecl}).apply(el, ${JSON.stringify(args)})); })()`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page functions shared by both ref modes. Each runs with the target element
+// as `this` and returns a plain `{ ok, error?, detail?, text? }` object —
+// callOnRefElement handles the mode-specific delivery and serialization.
+// ---------------------------------------------------------------------------
+
+const CLICK_FN = `function () { this.click(); return { ok: true }; }`;
+
+const FOCUS_FN = `function () { if (typeof this.focus === 'function') this.focus(); return { ok: true }; }`;
+
+const HOVER_FN = `function () { const el = this; const r = el.getBoundingClientRect(); const o = { bubbles: true, clientX: r.left + r.width / 2, clientY: r.top + r.height / 2 }; for (const t of ['pointerover', 'mouseover', 'mouseenter', 'mousemove']) el.dispatchEvent(new MouseEvent(t, o)); return { ok: true }; }`;
+
+const READ_TEXT_FN = `function () { const el = this; return { ok: true, text: (el.innerText || el.textContent || '').replace(/\\n{3,}/g, '\\n\\n').trim().slice(0, 8000) }; }`;
+
+/**
+ * Fill an input/textarea/select/contenteditable. Keeps v1's prototype-
+ * descriptor value setter (bypasses React's value tracker so controlled
+ * inputs don't revert on the next render) and folds in <select> matching so
+ * FillForm can hit mixed forms with one function.
+ */
+const FILL_FIELD_FN = `function (v) { const el = this; el.focus(); const tag = el.tagName; if (tag === 'SELECT') { const opt = Array.from(el.options).find((o) => o.value === v || (o.textContent || '').trim() === v); if (!opt) return { ok: false, error: 'No option matching "' + v + '".' }; el.value = opt.value; } else if (tag === 'INPUT' || tag === 'TEXTAREA') { const proto = tag === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype; const d = Object.getOwnPropertyDescriptor(proto, 'value'); if (d && d.set) d.set.call(el, v); else el.value = v; } else { el.textContent = v; } el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); return { ok: true, detail: 'Filled ' + ((el.getAttribute('name') || el.getAttribute('aria-label') || el.tagName) || '') }; }`;
+
+const SELECT_OPTION_FN = `function (v) { const el = this; if (el.tagName !== 'SELECT') return { ok: false, error: 'That ref is not a <select> dropdown.' }; const opt = Array.from(el.options).find((o) => o.value === v || (o.textContent || '').trim() === v); if (!opt) return { ok: false, error: 'No option matching "' + v + '".' }; el.value = opt.value; el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); return { ok: true, detail: 'Selected ' + (opt.textContent || opt.value) }; }`;
+
+const ENTER_FN = `function () { const el = this; const o = { key: 'Enter', keyCode: 13, which: 13, bubbles: true }; el.dispatchEvent(new KeyboardEvent('keydown', o)); el.dispatchEvent(new KeyboardEvent('keyup', o)); const f = el.form; if (f && typeof f.requestSubmit === 'function') { try { f.requestSubmit(); } catch (e) {} } return { ok: true }; }`;
 
 /**
  * Resolve a snapshot ref to webview-relative pixel coords + a short label.
@@ -814,7 +1246,10 @@ async function dispatchClickViaCdp(
  * a real `input` event in `<textarea>`/contenteditable; non-printable keys
  * (Enter, arrows) leave `text` blank, mirroring Chromium's own handling.
  */
-async function dispatchKeyTap(webContentsId: number, key: string): Promise<void> {
+async function dispatchKeyTap(
+  webContentsId: number,
+  key: string,
+): Promise<void> {
   const isPrintable = key.length === 1;
   const payload: BrowserInputAction = {
     type: "keyDown",
@@ -828,15 +1263,32 @@ async function dispatchKeyTap(webContentsId: number, key: string): Promise<void>
   });
 }
 
+/**
+ * Center the element in the viewport with the same rAF glide as directional
+ * scroll. Self-contained (returns `{ ok }` on every path — the early-exit
+ * for tiny deltas must not fall through to `undefined`).
+ */
+const SMOOTH_SCROLL_REF_FN = `function () { const el = this; const r = el.getBoundingClientRect(); const targetY = Math.max(0, window.scrollY + r.top - (window.innerHeight - r.height) / 2); const start = window.scrollY; const dist = targetY - start; if (Math.abs(dist) < 2) { window.scrollTo(0, targetY); return { ok: true, detail: 'Already in view.' }; } const dur = ${SMOOTH_SCROLL_MS}; const t0 = performance.now(); const ease = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2); function step(now) { const p = Math.min(1, (now - t0) / dur); window.scrollTo(0, start + dist * ease(p)); if (p < 1) requestAnimationFrame(step); } requestAnimationFrame(step); return { ok: true, detail: 'Scrolled element into view.' }; }`;
+
 /** Run page JS that returns a JSON string and parse it; null on any failure. */
 async function runJsObject(
   wv: WebviewElement,
   code: string,
-): Promise<{ ok: boolean; error?: string; detail?: string } | null> {
+): Promise<{
+  ok: boolean;
+  error?: string;
+  detail?: string;
+  text?: string;
+} | null> {
   const raw = await wv.executeJavaScript(code);
   if (typeof raw !== "string") return null;
   try {
-    return JSON.parse(raw) as { ok: boolean; error?: string; detail?: string };
+    return JSON.parse(raw) as {
+      ok: boolean;
+      error?: string;
+      detail?: string;
+      text?: string;
+    };
   } catch {
     return null;
   }
@@ -861,10 +1313,219 @@ const resultFromJs = (
           : { error: res.error ?? "Action failed." }),
       });
 
+// ---------------------------------------------------------------------------
+// Accessibility-tree snapshot (v2). Fetches the full AX tree over CDP and
+// renders the Playwright-style compact text the whole industry converged on:
+// one line per meaningful node, interactive elements carrying `ref=eN`.
+// ---------------------------------------------------------------------------
+
+type AxValue = { value?: unknown };
+type AxNode = {
+  nodeId: string;
+  ignored?: boolean;
+  role?: AxValue;
+  name?: AxValue;
+  value?: AxValue;
+  properties?: Array<{ name?: string; value?: AxValue }>;
+  childIds?: string[];
+  backendDOMNodeId?: number;
+  parentId?: string;
+};
+
+/** Roles the agent can act on — these get a `ref` (needs a backing DOM node). */
+const INTERACTIVE_ROLES = new Set([
+  "link",
+  "button",
+  "textbox",
+  "searchbox",
+  "textfield",
+  "textfieldwithcombobox",
+  "checkbox",
+  "radio",
+  "combobox",
+  "listbox",
+  "option",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "tab",
+  "switch",
+  "slider",
+  "spinbutton",
+  "togglebutton",
+  "popupbutton",
+  "menubutton",
+  "disclosuretriangle",
+]);
+
+/** Structural roles worth a line for context even without interactivity. */
+const STRUCTURAL_ROLES = new Set([
+  "heading",
+  "banner",
+  "navigation",
+  "main",
+  "contentinfo",
+  "form",
+  "search",
+  "region",
+  "complementary",
+  "article",
+  "list",
+  "listitem",
+  "descriptionlist",
+  "table",
+  "row",
+  "cell",
+  "gridcell",
+  "columnheader",
+  "rowheader",
+  "image",
+  "img",
+  "figure",
+  "dialog",
+  "alertdialog",
+  "alert",
+  "status",
+  "tabpanel",
+  "tablist",
+  "menu",
+  "menubar",
+  "toolbar",
+  "tree",
+  "treeitem",
+]);
+
+const SNAPSHOT_MAX_LINES = 800;
+const SNAPSHOT_MAX_CHARS = 20000;
+
 /**
- * Page-side DOM snapshot. Clears stale refs, then tags every visible
- * interactive element with a fresh `data-mz-ref` and returns a compact JSON
- * array `[{ ref, role, name, value, tag }]` for the agent to target.
+ * Fetch `Accessibility.getFullAXTree` and render the pruned text tree +
+ * ref map. Null on any failure (domain unavailable, empty tree) so the
+ * caller can fall back to the v1 DOM snapshot. The `DOM.getDocument` call
+ * warms the DOM agent so later backendNodeId lookups resolve reliably.
+ */
+async function buildA11ySnapshot(webContentsId: number): Promise<{
+  text: string;
+  map: Map<string, { backendNodeId: number; label: string }>;
+} | null> {
+  await cdpCall(webContentsId, "DOM.getDocument", { depth: 0 });
+  const res = await cdpCall(webContentsId, "Accessibility.getFullAXTree", {});
+  const nodes = (res as { nodes?: unknown } | null)?.nodes;
+  if (!Array.isArray(nodes) || nodes.length === 0) return null;
+  const byId = new Map<string, AxNode>();
+  for (const raw of nodes as AxNode[]) {
+    if (typeof raw?.nodeId === "string") byId.set(raw.nodeId, raw);
+  }
+  const root =
+    (nodes as AxNode[]).find((n) => n.parentId === undefined) ??
+    (nodes as AxNode[])[0]!;
+
+  const map = new Map<string, { backendNodeId: number; label: string }>();
+  const lines: string[] = [];
+  let chars = 0;
+  let skipped = 0;
+  let refCounter = 0;
+
+  const prop = (node: AxNode, name: string): unknown =>
+    node.properties?.find((p) => p.name === name)?.value?.value;
+
+  const emitLine = (line: string): boolean => {
+    if (lines.length >= SNAPSHOT_MAX_LINES || chars >= SNAPSHOT_MAX_CHARS) {
+      skipped += 1;
+      return false;
+    }
+    lines.push(line);
+    chars += line.length + 1;
+    return true;
+  };
+
+  const walk = (node: AxNode, depth: number, parentName: string): void => {
+    let nextDepth = depth;
+    let nextParentName = parentName;
+    if (node.ignored !== true) {
+      const role = String(node.role?.value ?? "");
+      const lrole = role.toLowerCase();
+      const name = String(node.name?.value ?? "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 80);
+      const interactive =
+        INTERACTIVE_ROLES.has(lrole) &&
+        typeof node.backendDOMNodeId === "number";
+      const isText = lrole === "statictext" || lrole === "text";
+      const structural = STRUCTURAL_ROLES.has(lrole);
+      // Emit: everything actionable; structure with a name (or a heading —
+      // its text is its name); text that isn't just repeating its parent's
+      // label. Nameless generic containers are flattened away.
+      const emit = interactive
+        ? true
+        : isText
+          ? name.length > 0 && name !== parentName
+          : structural && (name.length > 0 || lrole === "heading");
+      if (emit) {
+        const parts: string[] = [`${"  ".repeat(Math.min(depth, 10))}- `];
+        if (isText) {
+          parts.push(`text "${name}"`);
+        } else {
+          parts.push(lrole);
+          if (name.length > 0) parts.push(` "${name}"`);
+        }
+        if (interactive) {
+          refCounter += 1;
+          const ref = `e${refCounter}`;
+          map.set(ref, {
+            backendNodeId: node.backendDOMNodeId!,
+            label: name.length > 0 ? name : lrole,
+          });
+          parts.push(` [ref=${ref}]`);
+        }
+        const value = String(node.value?.value ?? "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 60);
+        if (value.length > 0 && !isText) parts.push(` [value="${value}"]`);
+        const level = prop(node, "level");
+        if (lrole === "heading" && typeof level === "number") {
+          parts.push(` [level=${level}]`);
+        }
+        for (const flag of [
+          "disabled",
+          "checked",
+          "expanded",
+          "selected",
+          "required",
+        ]) {
+          const v = prop(node, flag);
+          if (v === true || v === "true" || v === "mixed")
+            parts.push(` [${flag}]`);
+        }
+        if (emitLine(parts.join(""))) {
+          nextDepth = depth + 1;
+          nextParentName = name.length > 0 ? name : parentName;
+        }
+      }
+    }
+    for (const childId of node.childIds ?? []) {
+      const child = byId.get(childId);
+      if (child !== undefined) walk(child, nextDepth, nextParentName);
+    }
+  };
+
+  walk(root, 0, "");
+  if (lines.length === 0) return null;
+  if (skipped > 0) {
+    lines.push(
+      `… truncated — ${skipped} more nodes. Use browser_read for full text, or act on the refs above.`,
+    );
+  }
+  return { text: lines.join("\n"), map };
+}
+
+/**
+ * Page-side DOM snapshot (v1 fallback — used when CDP isn't attached).
+ * Clears stale refs, then tags every visible interactive element with a
+ * fresh `data-mz-ref` and returns a compact JSON array
+ * `[{ ref, role, name, value, tag }]` for the agent to target.
  */
 const SNAPSHOT_JS = `(() => {
   document.querySelectorAll('[data-mz-ref]').forEach((e) => e.removeAttribute('data-mz-ref'));
@@ -909,9 +1570,6 @@ const SMOOTH_SCROLL_BODY = `
   }
   requestAnimationFrame(step);
 `;
-
-const buildSmoothScrollRefJs = (ref: string): string =>
-  `(() => { const el = document.querySelector('[data-mz-ref=${JSON.stringify(ref)}]'); if (!el) return JSON.stringify({ ok:false, error:'No element with that ref — re-snapshot first.' }); const r = el.getBoundingClientRect(); const targetY = Math.max(0, window.scrollY + r.top - (window.innerHeight - r.height) / 2); ${SMOOTH_SCROLL_BODY} return JSON.stringify({ ok:true, detail:'Scrolled element into view.' }); })()`;
 
 const buildSmoothScrollDirJs = (
   dir: "up" | "down" | "top" | "bottom",

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -254,10 +254,12 @@ export function BrowserPane() {
     setInputValue(resolved);
     const wv = webviewRef.current as WebviewElement | null;
     // Setting `src` programmatically also works, but loadURL is more
-    // predictable when the same URL is re-entered (forces a reload).
+    // predictable when the same URL is re-entered (forces a reload). The
+    // rejection catch matters: a load superseded by a newer navigation
+    // rejects with ERR_ABORTED, which is routine, not an error.
     if (wv !== null) {
       try {
-        void wv.loadURL(resolved);
+        void wv.loadURL(resolved).catch(() => {});
       } catch {
         wv.src = resolved;
       }
@@ -348,7 +350,12 @@ export function BrowserPane() {
         ) : null}
         <webview
           ref={webviewRef as unknown as React.RefObject<HTMLElement>}
-          src={url === "" ? "about:blank" : url}
+          // src is intentionally NOT bound to `url` state. All navigation is
+          // imperative (loadURL); if src tracked state, every navigation would
+          // fire twice — once from loadURL, once from React re-setting the
+          // attribute — and the loads abort each other (ERR_ABORTED -3, agent
+          // navigations intermittently reporting about:blank).
+          src="about:blank"
           allowpopups={true}
           style={{
             display: url === "" ? "none" : "flex",

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -111,6 +111,41 @@ export type BrowserInputAction =
     }
   | { readonly type: "insertText"; readonly text: string };
 
+/** Outcome of an allowlisted CDP call routed through main. */
+export interface CdpCommandOutcome {
+  readonly ok: boolean;
+  readonly result?: unknown;
+  readonly error?: string;
+}
+
+/** One network request summary from main's CDP Network buffer. */
+export interface NetworkRequestSummary {
+  readonly id: string;
+  readonly method: string;
+  readonly url: string;
+  readonly resourceType?: string;
+  readonly status?: number;
+  readonly mimeType?: string;
+  readonly failed?: string;
+}
+
+export interface NetworkRequestDetail extends NetworkRequestSummary {
+  readonly responseHeaders?: Readonly<Record<string, string>>;
+  readonly body?: string;
+  readonly bodyBase64?: boolean;
+}
+
+export type NetworkQueryResult =
+  | { readonly requests: ReadonlyArray<NetworkRequestSummary> }
+  | { readonly detail: NetworkRequestDetail }
+  | null;
+
+export interface BrowserDialogState {
+  readonly type: string;
+  readonly message: string;
+  readonly defaultPrompt?: string;
+}
+
 export interface BrowserBridge {
   /**
    * Attach Chrome DevTools Protocol to the embedded webview's webContents so
@@ -123,6 +158,27 @@ export interface BrowserBridge {
     webContentsId: number,
     action: BrowserInputAction,
   ) => Promise<boolean>;
+  /**
+   * Allowlisted CDP passthrough (Accessibility/DOM/Runtime/Page). Optional —
+   * absent on preload builds that predate agent-browser v2, so callers must
+   * fall back to the injected-JS paths when undefined.
+   */
+  readonly cdpCommand?: (
+    webContentsId: number,
+    method: string,
+    params?: unknown,
+  ) => Promise<CdpCommandOutcome>;
+  /** Network requests captured since the last load (buffered in main). */
+  readonly getNetwork?: (
+    webContentsId: number,
+    query?: { filter?: string; id?: string },
+  ) => Promise<NetworkQueryResult>;
+  /** Uncaught page exceptions captured via CDP since the last load. */
+  readonly getPageErrors?: (webContentsId: number) => Promise<string[]>;
+  /** The currently open JS dialog, if any. */
+  readonly getDialogState?: (
+    webContentsId: number,
+  ) => Promise<BrowserDialogState | null>;
 }
 
 export interface ZuseBridge {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.126",
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "@openai/codex-sdk": "^0.128.0",
     "@opencode-ai/sdk": "^1.3.15",
     "@effect/experimental": "catalog:",

--- a/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
@@ -1,0 +1,637 @@
+import { randomBytes } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type {
+  BrowserCommand,
+  BrowserCommandResult,
+  PermissionDecision,
+  PermissionKind,
+  PermissionMode,
+  RuntimeMode,
+} from "@zuse/wire";
+
+import type { BrowserSend } from "../browser-tools.ts";
+
+type JsonObject = Record<string, unknown>;
+
+type McpText = { readonly type: "text"; readonly text: string };
+type McpImage = {
+  readonly type: "image";
+  readonly data: string;
+  readonly mimeType: "image/png";
+};
+
+export type BrowserMcpToolResult = {
+  readonly content: ReadonlyArray<McpText | McpImage>;
+  readonly isError?: boolean;
+};
+
+export type BrowserMcpToolDef = {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: JsonObject;
+};
+
+const objectSchema = (
+  properties: JsonObject,
+  required: ReadonlyArray<string> = [],
+): JsonObject => ({
+  type: "object",
+  properties,
+  required,
+  additionalProperties: false,
+});
+
+const stringProp = (description: string): JsonObject => ({
+  type: "string",
+  description,
+});
+
+const booleanProp = (description: string): JsonObject => ({
+  type: "boolean",
+  description,
+});
+
+const numberProp = (description: string, maximum?: number): JsonObject => ({
+  type: "number",
+  description,
+  ...(maximum !== undefined ? { maximum } : {}),
+});
+
+export const BROWSER_MCP_TOOLS: ReadonlyArray<BrowserMcpToolDef> = [
+  {
+    name: "browser_navigate",
+    description:
+      "Open a URL in Zuse's visible in-app browser and wait for it to settle. Use this for JS apps, dev servers, dashboards, screenshots, and browser interactions.",
+    inputSchema: objectSchema(
+      { url: stringProp("Absolute URL, or localhost host/path.") },
+      ["url"],
+    ),
+  },
+  {
+    name: "browser_screenshot",
+    description:
+      "Capture the visible browser viewport as a PNG image. Set fullPage to capture beyond the viewport when supported.",
+    inputSchema: objectSchema({
+      fullPage: booleanProp("Capture the entire scrollable page."),
+    }),
+  },
+  {
+    name: "browser_snapshot",
+    description:
+      "Return a compact accessibility-tree snapshot with refs. Use this before clicking, typing, selecting, or reading a specific element.",
+    inputSchema: objectSchema({}),
+  },
+  {
+    name: "browser_click",
+    description:
+      "Click an element by ref from browser_snapshot. Requires approval unless full-access mode is active.",
+    inputSchema: objectSchema(
+      {
+        ref: stringProp("Element ref from browser_snapshot, e.g. e3."),
+        element: stringProp("Human-readable target description."),
+      },
+      ["ref"],
+    ),
+  },
+  {
+    name: "browser_type",
+    description:
+      "Replace the value of an input/textarea by ref. Set submit to press Enter afterward. Prefer browser_fill_form for multiple fields.",
+    inputSchema: objectSchema(
+      {
+        ref: stringProp("Element ref from browser_snapshot."),
+        text: stringProp("Text to type."),
+        submit: booleanProp("Press Enter after typing."),
+        element: stringProp("Human-readable field description."),
+      },
+      ["ref", "text"],
+    ),
+  },
+  {
+    name: "browser_wait",
+    description:
+      "Wait for a fixed delay, for a CSS selector, or for exact text to appear.",
+    inputSchema: objectSchema({
+      ms: numberProp("Fixed delay in milliseconds.", 15000),
+      selector: stringProp("CSS selector to wait for."),
+      text: stringProp("Exact visible text to wait for."),
+      timeoutMs: numberProp("Selector/text timeout in milliseconds.", 25000),
+    }),
+  },
+  {
+    name: "browser_scroll",
+    description:
+      "Scroll the page up/down/top/bottom, or scroll a snapshot ref into view.",
+    inputSchema: objectSchema({
+      direction: {
+        type: "string",
+        enum: ["up", "down", "top", "bottom"],
+      },
+      ref: stringProp("Element ref to scroll into view."),
+    }),
+  },
+  {
+    name: "browser_hover",
+    description: "Hover an element by ref to reveal menus or tooltips.",
+    inputSchema: objectSchema(
+      { ref: stringProp("Element ref from browser_snapshot.") },
+      ["ref"],
+    ),
+  },
+  {
+    name: "browser_select",
+    description: "Choose an option in a select dropdown by ref.",
+    inputSchema: objectSchema(
+      {
+        ref: stringProp("Select element ref from browser_snapshot."),
+        value: stringProp("Option value or visible label."),
+        element: stringProp("Human-readable dropdown description."),
+      },
+      ["ref", "value"],
+    ),
+  },
+  {
+    name: "browser_press",
+    description:
+      "Press a keyboard key on a ref, or on the currently focused element when ref is omitted.",
+    inputSchema: objectSchema(
+      {
+        key: stringProp("Key name, e.g. Enter, Tab, Escape, ArrowDown."),
+        ref: stringProp("Optional target element ref."),
+        element: stringProp("Human-readable target description."),
+      },
+      ["key"],
+    ),
+  },
+  {
+    name: "browser_read",
+    description: "Read visible text from the page, or from one element by ref.",
+    inputSchema: objectSchema({
+      ref: stringProp("Optional element ref from browser_snapshot."),
+    }),
+  },
+  {
+    name: "browser_history",
+    description: "Go back, go forward, or reload the visible browser.",
+    inputSchema: objectSchema(
+      { action: { type: "string", enum: ["back", "forward", "reload"] } },
+      ["action"],
+    ),
+  },
+  {
+    name: "browser_console",
+    description:
+      "Read recent console messages, uncaught exceptions, load failures, and dialog state.",
+    inputSchema: objectSchema({}),
+  },
+  {
+    name: "browser_network",
+    description:
+      "List network requests since last load, or inspect one request by id.",
+    inputSchema: objectSchema({
+      filter: stringProp("Only list requests whose URL contains this text."),
+      id: stringProp("Request id from a previous listing."),
+    }),
+  },
+  {
+    name: "browser_fill_form",
+    description:
+      "Fill several input/select fields by snapshot refs in one action. Requires approval unless full-access mode is active.",
+    inputSchema: objectSchema(
+      {
+        fields: {
+          type: "array",
+          minItems: 1,
+          items: objectSchema(
+            {
+              ref: stringProp("Field ref from browser_snapshot."),
+              value: stringProp("Text, or select option value/label."),
+              element: stringProp("Human-readable field description."),
+            },
+            ["ref", "value"],
+          ),
+        },
+        submit: booleanProp("Press Enter in the last field after filling."),
+      },
+      ["fields"],
+    ),
+  },
+  {
+    name: "browser_dialog",
+    description:
+      "Accept or dismiss the currently open JavaScript alert/confirm/prompt dialog.",
+    inputSchema: objectSchema(
+      {
+        action: { type: "string", enum: ["accept", "dismiss"] },
+        promptText: stringProp("Text to enter when accepting a prompt()."),
+      },
+      ["action"],
+    ),
+  },
+  {
+    name: "browser_login",
+    description:
+      "Fill and submit saved dummy/test credentials for an origin. Always requires approval.",
+    inputSchema: objectSchema(
+      { origin: stringProp("Site origin, e.g. https://app.example.com.") },
+      ["origin"],
+    ),
+  },
+];
+
+const READ_ONLY_BROWSER_TOOLS = new Set([
+  "browser_navigate",
+  "browser_screenshot",
+  "browser_snapshot",
+  "browser_wait",
+  "browser_scroll",
+  "browser_hover",
+  "browser_read",
+  "browser_history",
+  "browser_console",
+  "browser_network",
+]);
+
+const text = (value: string, isError = false): BrowserMcpToolResult => ({
+  content: [{ type: "text", text: value }],
+  ...(isError ? { isError: true } : {}),
+});
+
+const asString = (
+  args: JsonObject,
+  key: string,
+  required = false,
+): string | undefined => {
+  const value = args[key];
+  if (typeof value === "string" && value.length > 0) return value;
+  if (required) throw new Error(`Missing ${key}.`);
+  return undefined;
+};
+
+const asBoolean = (args: JsonObject, key: string): boolean | undefined =>
+  typeof args[key] === "boolean" ? (args[key] as boolean) : undefined;
+
+const asNumber = (args: JsonObject, key: string): number | undefined =>
+  typeof args[key] === "number" && Number.isFinite(args[key])
+    ? (args[key] as number)
+    : undefined;
+
+const commandFor = (name: string, args: JsonObject): BrowserCommand => {
+  switch (name) {
+    case "browser_navigate":
+      return { _tag: "Navigate", url: asString(args, "url", true)! };
+    case "browser_screenshot":
+      return {
+        _tag: "Screenshot",
+        ...(asBoolean(args, "fullPage") !== undefined
+          ? { fullPage: asBoolean(args, "fullPage") }
+          : {}),
+      };
+    case "browser_snapshot":
+      return { _tag: "Snapshot" };
+    case "browser_click":
+      return { _tag: "Click", ref: asString(args, "ref", true)! };
+    case "browser_type":
+      return {
+        _tag: "Type",
+        ref: asString(args, "ref", true)!,
+        text: asString(args, "text", true)!,
+        ...(asBoolean(args, "submit") !== undefined
+          ? { submit: asBoolean(args, "submit") }
+          : {}),
+      };
+    case "browser_wait":
+      return {
+        _tag: "Wait",
+        ...(asNumber(args, "ms") !== undefined
+          ? { ms: asNumber(args, "ms") }
+          : {}),
+        ...(asString(args, "selector") !== undefined
+          ? { selector: asString(args, "selector") }
+          : {}),
+        ...(asString(args, "text") !== undefined
+          ? { text: asString(args, "text") }
+          : {}),
+        ...(asNumber(args, "timeoutMs") !== undefined
+          ? { timeoutMs: asNumber(args, "timeoutMs") }
+          : {}),
+      };
+    case "browser_scroll": {
+      const direction = asString(args, "direction");
+      if (
+        direction !== undefined &&
+        !["up", "down", "top", "bottom"].includes(direction)
+      ) {
+        throw new Error("direction must be up, down, top, or bottom.");
+      }
+      return {
+        _tag: "Scroll",
+        ...(direction !== undefined
+          ? { direction: direction as "up" | "down" | "top" | "bottom" }
+          : {}),
+        ...(asString(args, "ref") !== undefined
+          ? { ref: asString(args, "ref") }
+          : {}),
+      };
+    }
+    case "browser_hover":
+      return { _tag: "Hover", ref: asString(args, "ref", true)! };
+    case "browser_select":
+      return {
+        _tag: "Select",
+        ref: asString(args, "ref", true)!,
+        value: asString(args, "value", true)!,
+      };
+    case "browser_press":
+      return {
+        _tag: "Press",
+        key: asString(args, "key", true)!,
+        ...(asString(args, "ref") !== undefined
+          ? { ref: asString(args, "ref") }
+          : {}),
+      };
+    case "browser_read":
+      return {
+        _tag: "Read",
+        ...(asString(args, "ref") !== undefined
+          ? { ref: asString(args, "ref") }
+          : {}),
+      };
+    case "browser_history": {
+      const action = asString(args, "action", true)!;
+      if (!["back", "forward", "reload"].includes(action)) {
+        throw new Error("action must be back, forward, or reload.");
+      }
+      return {
+        _tag: "History",
+        action: action as "back" | "forward" | "reload",
+      };
+    }
+    case "browser_console":
+      return { _tag: "Console" };
+    case "browser_network":
+      return {
+        _tag: "Network",
+        ...(asString(args, "filter") !== undefined
+          ? { filter: asString(args, "filter") }
+          : {}),
+        ...(asString(args, "id") !== undefined
+          ? { id: asString(args, "id") }
+          : {}),
+      };
+    case "browser_fill_form": {
+      const rawFields = args["fields"];
+      if (!Array.isArray(rawFields) || rawFields.length === 0) {
+        throw new Error("fields must be a non-empty array.");
+      }
+      return {
+        _tag: "FillForm",
+        fields: rawFields.map((field) => {
+          if (field === null || typeof field !== "object") {
+            throw new Error("Each field must be an object.");
+          }
+          const f = field as JsonObject;
+          return {
+            ref: asString(f, "ref", true)!,
+            value: asString(f, "value", true)!,
+          };
+        }),
+        ...(asBoolean(args, "submit") !== undefined
+          ? { submit: asBoolean(args, "submit") }
+          : {}),
+      };
+    }
+    case "browser_dialog": {
+      const action = asString(args, "action", true)!;
+      if (action !== "accept" && action !== "dismiss") {
+        throw new Error("action must be accept or dismiss.");
+      }
+      return {
+        _tag: "Dialog",
+        action,
+        ...(asString(args, "promptText") !== undefined
+          ? { promptText: asString(args, "promptText") }
+          : {}),
+      };
+    }
+    case "browser_login":
+      return { _tag: "Login", origin: asString(args, "origin", true)! };
+    default:
+      throw new Error(`Unknown browser tool: ${name}`);
+  }
+};
+
+const resultFor = (
+  name: string,
+  args: JsonObject,
+  result: BrowserCommandResult,
+): BrowserMcpToolResult => {
+  if (!result.ok) {
+    return text(result.error ?? "Browser action failed.", true);
+  }
+  switch (name) {
+    case "browser_navigate": {
+      const title = result.title ?? "";
+      return text(
+        `Loaded ${result.url ?? asString(args, "url") ?? ""}${title.length > 0 ? ` - "${title}"` : ""}.`,
+      );
+    }
+    case "browser_screenshot":
+      return result.screenshot !== undefined
+        ? {
+            content: [
+              { type: "image", data: result.screenshot, mimeType: "image/png" },
+            ],
+          }
+        : text("Could not capture a screenshot.", true);
+    case "browser_snapshot":
+      return text(result.snapshot ?? "[]");
+    case "browser_read":
+    case "browser_console":
+    case "browser_network":
+      return text(result.text ?? "");
+    default:
+      return text(result.detail ?? "Done.");
+  }
+};
+
+const permissionSummary = (name: string, args: JsonObject): string => {
+  const element = asString(args, "element");
+  switch (name) {
+    case "browser_click":
+      return `Click ${element ?? asString(args, "ref") ?? "an element"}`;
+    case "browser_type":
+      return `Type into ${element ?? asString(args, "ref") ?? "a field"}`;
+    case "browser_select":
+      return `Select ${asString(args, "value") ?? "an option"} in ${
+        element ?? asString(args, "ref") ?? "a dropdown"
+      }`;
+    case "browser_press":
+      return `Press ${asString(args, "key") ?? "a key"}${
+        element !== undefined ? ` on ${element}` : ""
+      }`;
+    case "browser_fill_form":
+      return `Fill ${Array.isArray(args["fields"]) ? args["fields"].length : "a"} browser form field(s)`;
+    case "browser_dialog":
+      return `${asString(args, "action") ?? "Resolve"} browser dialog`;
+    case "browser_login":
+      return `Submit saved dummy login for ${asString(args, "origin") ?? "origin"}`;
+    default:
+      return name;
+  }
+};
+
+export interface BrowserMcpBridgeOptions {
+  readonly send: BrowserSend;
+  readonly command: string;
+  readonly requestPermission: (
+    kind: PermissionKind,
+    options: { readonly forcePrompt: boolean },
+  ) => Promise<PermissionDecision>;
+  readonly getRuntimeMode: () => RuntimeMode;
+  readonly getPermissionMode: () => PermissionMode;
+}
+
+const ensureBrowserPermission = async (
+  name: string,
+  args: JsonObject,
+  opts: BrowserMcpBridgeOptions,
+): Promise<void> => {
+  if (READ_ONLY_BROWSER_TOOLS.has(name)) return;
+
+  const forcePrompt =
+    name === "browser_login" || opts.getPermissionMode() === "plan";
+  if (!forcePrompt && opts.getRuntimeMode() === "full-access") return;
+
+  const decision = await opts.requestPermission(
+    {
+      _tag: "Other",
+      tool: name,
+      summary: permissionSummary(name, args),
+    },
+    { forcePrompt },
+  );
+  if (decision._tag === "Deny") {
+    throw new Error(`Permission denied for ${name}.`);
+  }
+};
+
+const handleBrowserTool = async (
+  name: string,
+  args: JsonObject,
+  opts: BrowserMcpBridgeOptions,
+): Promise<BrowserMcpToolResult> => {
+  await ensureBrowserPermission(name, args, opts);
+  const command = commandFor(name, args);
+  const result = await opts.send(command);
+  return resultFor(name, args, result);
+};
+
+const readBody = async (req: import("node:http").IncomingMessage) =>
+  new Promise<string>((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+      if (body.length > 1_000_000) {
+        reject(new Error("request too large"));
+        req.destroy();
+      }
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+
+export interface BrowserMcpBridge {
+  readonly serverConfig: {
+    readonly type: "stdio";
+    readonly name: string;
+    readonly command: string;
+    readonly args: ReadonlyArray<string>;
+    readonly env: ReadonlyArray<{
+      readonly name: string;
+      readonly value: string;
+    }>;
+  };
+  readonly close: () => Promise<void>;
+}
+
+export const startBrowserMcpBridge = async (
+  opts: BrowserMcpBridgeOptions,
+): Promise<BrowserMcpBridge> => {
+  const token = randomBytes(24).toString("hex");
+  const server: Server = createServer(async (req, res) => {
+    try {
+      if (req.method !== "POST" || req.url !== "/tool") {
+        res.writeHead(404).end("not found");
+        return;
+      }
+      if (req.headers.authorization !== `Bearer ${token}`) {
+        res.writeHead(401).end("unauthorized");
+        return;
+      }
+      const body = JSON.parse(await readBody(req)) as unknown;
+      if (body === null || typeof body !== "object") {
+        throw new Error("Expected JSON object.");
+      }
+      const payload = body as JsonObject;
+      const name = asString(payload, "name", true)!;
+      const rawArgs = payload["arguments"];
+      const args =
+        rawArgs !== null &&
+        typeof rawArgs === "object" &&
+        !Array.isArray(rawArgs)
+          ? (rawArgs as JsonObject)
+          : {};
+      const result = await handleBrowserTool(name, args, opts);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(result));
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(text(message, true)));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Could not bind browser MCP bridge.");
+  }
+
+  const childPath = fileURLToPath(
+    new URL("./browser-mcp-child.ts", import.meta.url),
+  );
+  const command = basename(opts.command).includes("bun")
+    ? opts.command
+    : process.execPath;
+
+  return {
+    serverConfig: {
+      type: "stdio",
+      name: "zuse",
+      command,
+      args: [childPath],
+      env: [
+        {
+          name: "ZUSE_BROWSER_MCP_URL",
+          value: `http://127.0.0.1:${address.port}`,
+        },
+        { name: "ZUSE_BROWSER_MCP_TOKEN", value: token },
+      ],
+    },
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+};

--- a/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
@@ -555,6 +555,7 @@ export interface BrowserMcpBridge {
       readonly value: string;
     }>;
   };
+  readonly projectConfigToml: string;
   readonly close: () => Promise<void>;
 }
 
@@ -613,6 +614,8 @@ export const startBrowserMcpBridge = async (
   const command = basename(opts.command).includes("bun")
     ? opts.command
     : process.execPath;
+  const envToml = `ZUSE_BROWSER_MCP_URL = "http://127.0.0.1:${address.port}", ZUSE_BROWSER_MCP_TOKEN = "${token}"`;
+  const argsToml = JSON.stringify([childPath]);
   console.info(
     `[grok.browser-mcp] listening on 127.0.0.1:${address.port}; command=${command}; child=${childPath}`,
   );
@@ -630,6 +633,20 @@ export const startBrowserMcpBridge = async (
         { name: "ZUSE_BROWSER_MCP_TOKEN", value: token },
       ],
     },
+    projectConfigToml: [
+      `[mcp_servers.zuse]`,
+      `command = ${JSON.stringify(command)}`,
+      `args = ${argsToml}`,
+      `env = { ${envToml} }`,
+      `enabled = true`,
+      ``,
+      `[mcp_servers."cursor-ide-browser"]`,
+      `command = ${JSON.stringify(command)}`,
+      `args = ${argsToml}`,
+      `env = { ${envToml} }`,
+      `enabled = true`,
+      ``,
+    ].join("\n"),
     close: () =>
       new Promise<void>((resolve) => {
         server.close(() => resolve());

--- a/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
@@ -547,7 +547,6 @@ const readBody = async (req: import("node:http").IncomingMessage) =>
 
 export interface BrowserMcpBridge {
   readonly serverConfig: {
-    readonly type: "stdio";
     readonly name: string;
     readonly command: string;
     readonly args: ReadonlyArray<string>;
@@ -614,10 +613,12 @@ export const startBrowserMcpBridge = async (
   const command = basename(opts.command).includes("bun")
     ? opts.command
     : process.execPath;
+  console.info(
+    `[grok.browser-mcp] listening on 127.0.0.1:${address.port}; command=${command}; child=${childPath}`,
+  );
 
   return {
     serverConfig: {
-      type: "stdio",
       name: "zuse",
       command,
       args: [childPath],

--- a/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
@@ -622,7 +622,7 @@ export const startBrowserMcpBridge = async (
 
   return {
     serverConfig: {
-      name: "zuse",
+      name: "zuse-browser",
       command,
       args: [childPath],
       env: [
@@ -634,13 +634,7 @@ export const startBrowserMcpBridge = async (
       ],
     },
     projectConfigToml: [
-      `[mcp_servers.zuse]`,
-      `command = ${JSON.stringify(command)}`,
-      `args = ${argsToml}`,
-      `env = { ${envToml} }`,
-      `enabled = true`,
-      ``,
-      `[mcp_servers."cursor-ide-browser"]`,
+      `[mcp_servers."zuse-browser"]`,
       `command = ${JSON.stringify(command)}`,
       `args = ${argsToml}`,
       `env = { ${envToml} }`,

--- a/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-bridge.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
 import { createServer, type Server } from "node:http";
-import { basename } from "node:path";
+import { basename, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type {
@@ -241,6 +242,36 @@ export const BROWSER_MCP_TOOLS: ReadonlyArray<BrowserMcpToolDef> = [
     ),
   },
 ];
+
+/**
+ * Compact per-session context hint for ACP models. Grok's CLI surfaces MCP
+ * tools through a generic `CallMcpTool` + on-disk schema descriptors instead
+ * of inlining schemas into the model's context — without this hint the model
+ * burns a dozen Glob/Grep/Read calls hunting for the descriptor files before
+ * its first browser action. Generated from BROWSER_MCP_TOOLS so the tool list
+ * can never drift from what the child actually serves.
+ */
+export const browserMcpPromptHint = (): string => {
+  const signature = (tool: BrowserMcpToolDef): string => {
+    const properties =
+      (tool.inputSchema["properties"] as Record<string, unknown> | undefined) ??
+      {};
+    const required = new Set(
+      (tool.inputSchema["required"] as ReadonlyArray<string> | undefined) ?? [],
+    );
+    const args = Object.keys(properties)
+      .map((key) => (required.has(key) ? key : `${key}?`))
+      .join(",");
+    return `${tool.name}{${args}}`;
+  };
+  return [
+    "<zuse-browser-tools>",
+    'The "zuse-browser" MCP server controls Zuse\'s visible in-app browser. Call its tools directly via MCP (server name "zuse-browser") — do NOT search the filesystem for tool schemas or descriptor files.',
+    `Tools: ${BROWSER_MCP_TOOLS.map(signature).join(", ")}.`,
+    "Typical flow: browser_navigate → browser_snapshot (a11y tree with refs; read it before clicking/typing) → act by ref → browser_console/browser_network to verify.",
+    "</zuse-browser-tools>",
+  ].join("\n");
+};
 
 const READ_ONLY_BROWSER_TOOLS = new Set([
   "browser_navigate",
@@ -559,6 +590,44 @@ export interface BrowserMcpBridge {
   readonly close: () => Promise<void>;
 }
 
+/**
+ * Locate the stdio MCP child script the ACP provider will spawn. This module
+ * gets bundled into `dist-electron/main.cjs` by tsdown, so `import.meta.url`
+ * points at the bundle directory, NOT the source tree — a bare
+ * `./browser-mcp-child.ts` sibling lookup resolves to a file that was never
+ * emitted and the child dies at spawn ("Transport channel closed", every
+ * tool call "Tool not found"). Resolution order:
+ *
+ *   1. `browser-mcp-child.cjs` next to the bundle (built by the dedicated
+ *      tsdown entry), remapped out of the asar in packaged builds — bun is
+ *      an external process and cannot read inside `app.asar`.
+ *   2. The `.ts` source sibling — running unbundled from source (headless
+ *      server under bun, tests), where bun executes TypeScript directly.
+ */
+const resolveChildScript = (): string => {
+  const bundled = fileURLToPath(
+    new URL("./browser-mcp-child.cjs", import.meta.url),
+  );
+  const unpacked = bundled.replace(
+    `${sep}app.asar${sep}`,
+    `${sep}app.asar.unpacked${sep}`,
+  );
+  if (existsSync(unpacked)) return unpacked;
+  if (existsSync(bundled)) return bundled;
+  const source = fileURLToPath(
+    new URL("./browser-mcp-child.ts", import.meta.url),
+  );
+  if (!existsSync(source)) {
+    // Don't fail the whole agent session over browser tools, but be loud:
+    // this exact silent failure already shipped once.
+    console.error(
+      `[grok.browser-mcp] child script missing — looked for ${unpacked}, ${bundled}, ${source}. ` +
+        "Browser tools will be unavailable to this ACP session (did the desktop build emit browser-mcp-child.cjs?).",
+    );
+  }
+  return source;
+};
+
 export const startBrowserMcpBridge = async (
   opts: BrowserMcpBridgeOptions,
 ): Promise<BrowserMcpBridge> => {
@@ -608,9 +677,7 @@ export const startBrowserMcpBridge = async (
     throw new Error("Could not bind browser MCP bridge.");
   }
 
-  const childPath = fileURLToPath(
-    new URL("./browser-mcp-child.ts", import.meta.url),
-  );
+  const childPath = resolveChildScript();
   const command = basename(opts.command).includes("bun")
     ? opts.command
     : process.execPath;

--- a/apps/server/src/provider/drivers/acp/browser-mcp-child.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-child.ts
@@ -85,5 +85,15 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   }
 });
 
+// No top-level await: this file is also bundled to CJS for the packaged app
+// (dist-electron/browser-mcp-child.cjs), where TLA is unsupported. The stdio
+// transport keeps the event loop alive once connected.
 const transport = new StdioServerTransport();
-await server.connect(transport);
+server.connect(transport).catch((cause: unknown) => {
+  process.stderr.write(
+    `[zuse-browser-mcp] failed to connect stdio transport: ${
+      cause instanceof Error ? cause.message : String(cause)
+    }\n`,
+  );
+  process.exit(1);
+});

--- a/apps/server/src/provider/drivers/acp/browser-mcp-child.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-child.ts
@@ -48,7 +48,7 @@ const callParent = async (
 };
 
 const server = new Server(
-  { name: "zuse", version: "0.0.1" },
+  { name: "zuse-browser", version: "0.0.1" },
   { capabilities: { tools: {} } },
 );
 

--- a/apps/server/src/provider/drivers/acp/browser-mcp-child.ts
+++ b/apps/server/src/provider/drivers/acp/browser-mcp-child.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import {
+  BROWSER_MCP_TOOLS,
+  type BrowserMcpToolResult,
+} from "./browser-mcp-bridge.ts";
+
+const bridgeUrl = process.env.ZUSE_BROWSER_MCP_URL;
+const token = process.env.ZUSE_BROWSER_MCP_TOKEN;
+
+if (bridgeUrl === undefined || token === undefined) {
+  process.stderr.write(
+    "[zuse-browser-mcp] missing ZUSE_BROWSER_MCP_URL/ZUSE_BROWSER_MCP_TOKEN\n",
+  );
+  process.exit(2);
+}
+
+const callParent = async (
+  name: string,
+  args: unknown,
+): Promise<BrowserMcpToolResult> => {
+  const res = await fetch(`${bridgeUrl}/tool`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name, arguments: args ?? {} }),
+  });
+  if (!res.ok) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Browser bridge failed: HTTP ${res.status}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+  return (await res.json()) as BrowserMcpToolResult;
+};
+
+const server = new Server(
+  { name: "zuse", version: "0.0.1" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: BROWSER_MCP_TOOLS.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const name = req.params.name;
+  if (!BROWSER_MCP_TOOLS.some((tool) => tool.name === name)) {
+    return {
+      content: [{ type: "text", text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  }
+  try {
+    return await callParent(name, req.params.arguments ?? {});
+  } catch (cause) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Browser tool ${name} failed: ${
+            cause instanceof Error ? cause.message : String(cause)
+          }`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -110,6 +110,12 @@ const toNiceToolLabel = (raw: string): string => {
  */
 const normalizeAcpKind = (rawKind: string): string => {
   const k = rawKind.toLowerCase();
+  if (k.startsWith("zuse-browser__browser_")) {
+    return `mcp__zuse__${k.slice("zuse-browser__".length)}`;
+  }
+  if (k.startsWith("mcp__zuse-browser__browser_")) {
+    return `mcp__zuse__${k.slice("mcp__zuse-browser__".length)}`;
+  }
   switch (k) {
     case "browser_navigate":
     case "browser_screenshot":

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -111,6 +111,24 @@ const toNiceToolLabel = (raw: string): string => {
 const normalizeAcpKind = (rawKind: string): string => {
   const k = rawKind.toLowerCase();
   switch (k) {
+    case "browser_navigate":
+    case "browser_screenshot":
+    case "browser_snapshot":
+    case "browser_click":
+    case "browser_type":
+    case "browser_wait":
+    case "browser_scroll":
+    case "browser_hover":
+    case "browser_select":
+    case "browser_press":
+    case "browser_read":
+    case "browser_history":
+    case "browser_console":
+    case "browser_network":
+    case "browser_fill_form":
+    case "browser_dialog":
+    case "browser_login":
+      return `mcp__zuse__${k}`;
     case "read":
     case "read_file":
     case "readfile":
@@ -209,7 +227,8 @@ const extractDiffBlock = (
           ? (b["new_text"] as string)
           : null;
     if (oldText === null || newText === null) continue;
-    const path = typeof b["path"] === "string" ? (b["path"] as string) : undefined;
+    const path =
+      typeof b["path"] === "string" ? (b["path"] as string) : undefined;
     return { path, oldText, newText };
   }
   return null;
@@ -238,7 +257,11 @@ const asSearchReplaceEnvelope = (
   const o = v as Record<string, unknown>;
   const type =
     typeof o["type"] === "string" ? (o["type"] as string).toLowerCase() : null;
-  if (type === "searchreplace" || type === "search_replace" || "EditsApplied" in o) {
+  if (
+    type === "searchreplace" ||
+    type === "search_replace" ||
+    "EditsApplied" in o
+  ) {
     return o;
   }
   if ("content" in o) return asSearchReplaceEnvelope(o["content"]);
@@ -273,7 +296,10 @@ const extractSearchReplaceEdits = (
       ? (env["EditsApplied"] as Record<string, unknown>)
       : env;
 
-  const strField = (src: Record<string, unknown>, key: string): string | null =>
+  const strField = (
+    src: Record<string, unknown>,
+    key: string,
+  ): string | null =>
     typeof src[key] === "string" && (src[key] as string).length > 0
       ? (src[key] as string)
       : null;
@@ -298,16 +324,28 @@ const extractSearchReplaceEdits = (
     for (const d of details) {
       if (d === null || typeof d !== "object") continue;
       const r = d as Record<string, unknown>;
-      const oldS = typeof r["old_string"] === "string" ? (r["old_string"] as string) : null;
-      const newS = typeof r["new_string"] === "string" ? (r["new_string"] as string) : null;
+      const oldS =
+        typeof r["old_string"] === "string"
+          ? (r["old_string"] as string)
+          : null;
+      const newS =
+        typeof r["new_string"] === "string"
+          ? (r["new_string"] as string)
+          : null;
       if (oldS !== null || newS !== null) {
         edits.push({ old_string: oldS ?? "", new_string: newS ?? "" });
       }
     }
   }
   if (edits.length === 0) {
-    const oldS = typeof applied["old_string"] === "string" ? (applied["old_string"] as string) : null;
-    const newS = typeof applied["new_string"] === "string" ? (applied["new_string"] as string) : null;
+    const oldS =
+      typeof applied["old_string"] === "string"
+        ? (applied["old_string"] as string)
+        : null;
+    const newS =
+      typeof applied["new_string"] === "string"
+        ? (applied["new_string"] as string)
+        : null;
     if (oldS !== null || newS !== null) {
       edits.push({ old_string: oldS ?? "", new_string: newS ?? "" });
     }
@@ -387,22 +425,20 @@ const buildCanonicalInput = (
         };
       }
       const file_path =
-        firstLocationPath(u) ??
-        (rawInput !== null ? pathFrom(rawInput) : null);
+        firstLocationPath(u) ?? (rawInput !== null ? pathFrom(rawInput) : null);
       if (file_path !== null) return { file_path };
       break;
     }
     case "Write": {
       const file_path =
-        firstLocationPath(u) ??
-        (rawInput !== null ? pathFrom(rawInput) : null);
+        firstLocationPath(u) ?? (rawInput !== null ? pathFrom(rawInput) : null);
       const content =
         typeof u["content"] === "string"
           ? (u["content"] as string)
-          : extractMessageText(u["content"]) ??
+          : (extractMessageText(u["content"]) ??
             (rawInput !== null && typeof rawInput["content"] === "string"
               ? (rawInput["content"] as string)
-              : null);
+              : null));
       const out: Record<string, unknown> = {};
       if (file_path !== null) out["file_path"] = file_path;
       if (content !== null) out["content"] = content;
@@ -410,8 +446,7 @@ const buildCanonicalInput = (
     }
     case "Read": {
       const file_path =
-        firstLocationPath(u) ??
-        (rawInput !== null ? pathFrom(rawInput) : null);
+        firstLocationPath(u) ?? (rawInput !== null ? pathFrom(rawInput) : null);
       if (file_path !== null) {
         const out: Record<string, unknown> = { file_path };
         if (typeof u["offset"] === "number") out["offset"] = u["offset"];
@@ -488,10 +523,14 @@ const extractToolName = (u: Record<string, unknown>): string => {
   const kind = typeof u["kind"] === "string" ? (u["kind"] as string) : null;
   if (kind !== null && kind.length > 0) return normalizeAcpKind(kind);
 
-  if (typeof u["tool"] === "string" && u["tool"].length > 0) return u["tool"] as string;
-  if (typeof u["name"] === "string" && u["name"].length > 0) return u["name"] as string;
-  if (typeof u["execution"] === "string" && u["execution"].length > 0) return u["execution"] as string;
-  if (typeof u["command"] === "string" && u["command"].length > 0) return u["command"] as string;
+  if (typeof u["tool"] === "string" && u["tool"].length > 0)
+    return u["tool"] as string;
+  if (typeof u["name"] === "string" && u["name"].length > 0)
+    return u["name"] as string;
+  if (typeof u["execution"] === "string" && u["execution"].length > 0)
+    return u["execution"] as string;
+  if (typeof u["command"] === "string" && u["command"].length > 0)
+    return u["command"] as string;
 
   // Grok (and some other agents) sometimes nest the tool identity under
   // toolCall / tool_call / toolInfo. Look one level deeper so we don't
@@ -506,13 +545,19 @@ const extractToolName = (u: Record<string, unknown>): string => {
   for (const cand of nestedCandidates) {
     if (cand && typeof cand === "object") {
       const c = cand as Record<string, unknown>;
-      const nestedKind = typeof c["kind"] === "string" ? (c["kind"] as string) : null;
-      if (nestedKind && nestedKind.length > 0) return normalizeAcpKind(nestedKind);
+      const nestedKind =
+        typeof c["kind"] === "string" ? (c["kind"] as string) : null;
+      if (nestedKind && nestedKind.length > 0)
+        return normalizeAcpKind(nestedKind);
       const nestedName =
         (typeof c["name"] === "string" && c["name"]) ||
         (typeof c["tool"] === "string" && c["tool"]) ||
         (typeof c["command"] === "string" && c["command"]);
-      if (nestedName && typeof nestedName === "string" && nestedName.length > 0) {
+      if (
+        nestedName &&
+        typeof nestedName === "string" &&
+        nestedName.length > 0
+      ) {
         return normalizeAcpKind(nestedName);
       }
     }
@@ -728,7 +773,9 @@ const normalizeNativeToolResult = (output: unknown): unknown => {
         ? (o["FileContent"] as Record<string, unknown>)
         : null;
     const rawOutput =
-      fc !== null && typeof fc["raw_output"] === "string" && fc["raw_output"].length > 0
+      fc !== null &&
+      typeof fc["raw_output"] === "string" &&
+      fc["raw_output"].length > 0
         ? (fc["raw_output"] as string)
         : null;
     if (rawOutput !== null) return rawOutput;
@@ -755,7 +802,11 @@ const normalizeNativeToolResult = (output: unknown): unknown => {
   // SearchReplace (edit) → a short summary. The diff itself is surfaced via
   // the canonical Edit input (see buildCanonicalInput); this is the fallback
   // for any path that renders the raw result instead of the Edit row.
-  if (type === "searchreplace" || type === "search_replace" || "EditsApplied" in o) {
+  if (
+    type === "searchreplace" ||
+    type === "search_replace" ||
+    "EditsApplied" in o
+  ) {
     const { filePath, edits } = extractSearchReplaceEdits(o);
     if (edits.length > 0) {
       const where = filePath !== null ? ` to ${filePath}` : "";
@@ -827,10 +878,7 @@ const logUnknownToolIfNeeded = (
 ): void => {
   if (toolName !== "tool") return;
   if (!ACP_TRACE) return;
-  trace(
-    provider,
-    `unknown tool ${phase} — raw payload=${safePreview(u, 800)}`,
-  );
+  trace(provider, `unknown tool ${phase} — raw payload=${safePreview(u, 800)}`);
 };
 
 /**
@@ -960,7 +1008,9 @@ const grokCallPrefix = (itemId: string): string | null => {
   return match?.[1] ?? null;
 };
 
-const isGrokCursorTaskInput = (input: unknown): input is Record<string, unknown> => {
+const isGrokCursorTaskInput = (
+  input: unknown,
+): input is Record<string, unknown> => {
   const record = recordFrom(input);
   if (record === null) return false;
   return (
@@ -969,7 +1019,9 @@ const isGrokCursorTaskInput = (input: unknown): input is Record<string, unknown>
   );
 };
 
-const grokTaskText = (input: Record<string, unknown>): {
+const grokTaskText = (
+  input: Record<string, unknown>,
+): {
   readonly description: string;
   readonly prompt: string;
   readonly model: string;
@@ -1005,16 +1057,14 @@ const GROK_TASK_STOP_WORDS = new Set([
 
 const tokenizeForGrokTaskScore = (value: string): Set<string> => {
   const out = new Set<string>();
-  for (const token of value.toLowerCase().match(/[a-z0-9][a-z0-9_-]{3,}/g) ?? []) {
+  for (const token of value.toLowerCase().match(/[a-z0-9][a-z0-9_-]{3,}/g) ??
+    []) {
     if (!GROK_TASK_STOP_WORDS.has(token)) out.add(token);
   }
   return out;
 };
 
-const scoreGrokTaskMatch = (
-  task: GrokCursorTaskRun,
-  text: string,
-): number => {
+const scoreGrokTaskMatch = (task: GrokCursorTaskRun, text: string): number => {
   const haystack = text.toLowerCase();
   const description = task.description.toLowerCase();
   let score = haystack.includes(description) ? 20 : 0;
@@ -1045,7 +1095,9 @@ const appendStreamText = (buffer: string, text: string): string => {
  *   2. `tool_call_update` is also a delta protocol — we dedupe so the
  *      renderer doesn't show a stack of "Read foo.ts" rows for one read.
  */
-export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => {
+export const createAcpTranslator = (
+  provider: AcpProviderTag,
+): AcpTranslator => {
   // Buffer for the in-flight assistant message text. Reset to "" after
   // each flush.
   let assistantBuffer = "";
@@ -1205,7 +1257,9 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
     if (prefix !== null) grokTaskLaunchPrefixes.add(prefix);
   };
 
-  const bestGrokCursorTaskForText = (text: string): GrokCursorTaskRun | null => {
+  const bestGrokCursorTaskForText = (
+    text: string,
+  ): GrokCursorTaskRun | null => {
     if (provider !== "grok" || grokCursorTaskOrder.length === 0) return null;
     let best: GrokCursorTaskRun | null = null;
     let bestScore = 0;
@@ -1221,9 +1275,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
     return bestScore > 0 ? best : null;
   };
 
-  const grokCursorTextParentFor = (
-    text: string,
-  ): AgentItemId | undefined => {
+  const grokCursorTextParentFor = (text: string): AgentItemId | undefined => {
     if (provider !== "grok") return undefined;
     const best = bestGrokCursorTaskForText(text);
     if (best !== null) return best.itemId;
@@ -1238,7 +1290,8 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
     update: Record<string, unknown>,
     input: unknown,
   ): AgentItemId | undefined => {
-    if (provider !== "grok" || grokCursorTaskOrder.length === 0) return undefined;
+    if (provider !== "grok" || grokCursorTaskOrder.length === 0)
+      return undefined;
     if (toolName === "Task" || toolName === "Agent") return undefined;
     const prefix = grokCallPrefix(itemId);
     if (prefix === null || grokTaskLaunchPrefixes.has(prefix)) return undefined;
@@ -1344,7 +1397,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
       }
       if (thinkingItemId === null) thinkingItemId = nextItemId();
       thinkingBuffer = appendStreamText(thinkingBuffer, text);
-      trace(provider, `buffer thinking chunk len=${text.length} totalLen=${thinkingBuffer.length}`);
+      trace(
+        provider,
+        `buffer thinking chunk len=${text.length} totalLen=${thinkingBuffer.length}`,
+      );
       return flushed;
     }
 
@@ -1358,7 +1414,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
       if (text === null || text.length === 0) return flushed;
       if (assistantItemId === null) assistantItemId = nextItemId();
       assistantBuffer = appendStreamText(assistantBuffer, text);
-      trace(provider, `buffer message chunk len=${text.length} totalLen=${assistantBuffer.length}`);
+      trace(
+        provider,
+        `buffer message chunk len=${text.length} totalLen=${assistantBuffer.length}`,
+      );
       return flushed;
     }
 
@@ -1531,8 +1590,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
             content !== undefined &&
             Array.isArray(content) &&
             (content as ReadonlyArray<unknown>).length > 0;
-          const isDiffOnly =
-            hasContent && extractDiffBlock(content) !== null;
+          const isDiffOnly = hasContent && extractDiffBlock(content) !== null;
           const status = typeof u["status"] === "string" ? u["status"] : null;
           const completed = status === "completed" || status === "failed";
 
@@ -1541,7 +1599,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           //   - Status flipped to completed/failed (terminal — even if
           //     there's no content, the renderer needs to know the call
           //     finished so spinners stop).
-          if (!state.resultEmitted && ((hasContent && !isDiffOnly) || completed)) {
+          if (
+            !state.resultEmitted &&
+            ((hasContent && !isDiffOnly) || completed)
+          ) {
             state.resultEmitted = true;
             const output = extractOutput(u);
             const isError =
@@ -1700,7 +1761,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           const isTerminal =
             status === "completed" ||
             status === "failed" ||
-            item["exitCode"] !== null && item["exitCode"] !== undefined;
+            (item["exitCode"] !== null && item["exitCode"] !== undefined);
           const state = getOrInitToolState(itemId as string);
           const events: AgentEvent[] = [];
           if (!state.useEmitted) {
@@ -1721,7 +1782,8 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
               output,
               isError:
                 status === "failed" ||
-                (typeof item["exitCode"] === "number" && item["exitCode"] !== 0),
+                (typeof item["exitCode"] === "number" &&
+                  item["exitCode"] !== 0),
               parentItemId,
             });
           }
@@ -1801,7 +1863,8 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
             events.push({
               _tag: "ToolResult",
               itemId,
-              output: item["result"] ?? item["contentItems"] ?? item["error"] ?? null,
+              output:
+                item["result"] ?? item["contentItems"] ?? item["error"] ?? null,
               isError:
                 status === "failed" ||
                 item["success"] === false ||
@@ -1852,15 +1915,30 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           }
 
           const collab = candidate;
-          const tool = typeof collab["tool"] === "string" ? (collab["tool"] as string) : "unknown";
+          const tool =
+            typeof collab["tool"] === "string"
+              ? (collab["tool"] as string)
+              : "unknown";
           const callId = extractCallId(collab);
-          const status = typeof collab["status"] === "string" ? (collab["status"] as string) : null;
+          const status =
+            typeof collab["status"] === "string"
+              ? (collab["status"] as string)
+              : null;
           const receiverThreadIds = Array.isArray(collab["receiverThreadIds"])
             ? (collab["receiverThreadIds"] as string[])
             : [];
-          const prompt = typeof collab["prompt"] === "string" ? (collab["prompt"] as string) : null;
-          const model = typeof collab["model"] === "string" ? (collab["model"] as string) : null;
-          const agentsStates = (collab["agentsStates"] ?? {}) as Record<string, unknown>;
+          const prompt =
+            typeof collab["prompt"] === "string"
+              ? (collab["prompt"] as string)
+              : null;
+          const model =
+            typeof collab["model"] === "string"
+              ? (collab["model"] as string)
+              : null;
+          const agentsStates = (collab["agentsStates"] ?? {}) as Record<
+            string,
+            unknown
+          >;
           const parentItemId = parentItemIdForThread(collab["senderThreadId"]);
 
           if (tool === "spawnAgent") {
@@ -1876,11 +1954,7 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
               state.lastInputJson = JSON.stringify(input);
               state.toolName = "Agent";
               for (const threadId of receiverThreadIds) {
-                rememberCollabAgent(
-                  callId,
-                  threadId,
-                  model ?? "inherit",
-                );
+                rememberCollabAgent(callId, threadId, model ?? "inherit");
               }
               const events: AgentEvent[] = [
                 {
@@ -1964,7 +2038,10 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
           // Intermediate state updates (agentsStates changing while running) — we can
           // optionally emit a non-intrusive result or just trace. For v1 we stay silent
           // to avoid spamming the timeline; the live states live in the initial row's input.
-          trace(provider, `skip duplicate collab update id=${callId} tool=${tool}`);
+          trace(
+            provider,
+            `skip duplicate collab update id=${callId} tool=${tool}`,
+          );
           return [];
         }
 
@@ -1982,7 +2059,9 @@ export const createAcpTranslator = (provider: AcpProviderTag): AcpTranslator => 
     flush: () => {
       const pending = flushPending();
       const finishedTasks = finishGrokCursorTasks();
-      return finishedTasks.length === 0 ? pending : [...pending, ...finishedTasks];
+      return finishedTasks.length === 0
+        ? pending
+        : [...pending, ...finishedTasks];
     },
   };
 };

--- a/apps/server/src/provider/drivers/browser-tools.ts
+++ b/apps/server/src/provider/drivers/browser-tools.ts
@@ -33,12 +33,13 @@ const textResult = (result: BrowserCommandResult, fallback: string) => ({
  * Build the in-process MCP tool definitions for the agent browser. They drive
  * the app's existing on-screen `<webview>` (round-tripping through the
  * renderer) rather than spinning up a headless Chrome, so the user watches
- * every action live. Phase 1: navigate + screenshot. Interaction
- * (snapshot/click/type) and login arrive in later phases as new tools here.
+ * every action live. v2 surface: a11y-tree snapshot + ref targeting, network
+ * and console observability, batch form fill, dialogs, full-page capture.
  *
  * Descriptions are blunt on purpose — the model reads them to choose the
  * browser over `WebFetch`: this one renders JS, shows the user what's
- * happening, and can screenshot what it sees.
+ * happening, and can screenshot what it sees. They also steer the model into
+ * the verification loop: navigate → wait → snapshot → act → console/network.
  */
 export const buildBrowserTools = (send: BrowserSend) => [
   tool(
@@ -80,10 +81,20 @@ export const buildBrowserTools = (send: BrowserSend) => [
 
   tool(
     "browser_screenshot",
-    "Capture what the in-app browser is currently showing (the visible viewport) and return it as an image you can see. The user sees a camera-shutter flash when this fires. Use it to verify a page rendered correctly, read content that didn't come through as text, or confirm the result of an action. Navigate first if nothing is loaded.",
-    {},
-    async () => {
-      const result = await send({ _tag: "Screenshot" });
+    "Capture what the in-app browser is showing and return it as an image you can see. Default is the visible viewport; set `fullPage: true` to capture the whole scrollable page. The user sees a camera-shutter flash when this fires. Prefer browser_snapshot for reading page structure/content — it's far cheaper; screenshot only when layout or visuals matter. Navigate first if nothing is loaded.",
+    {
+      fullPage: z
+        .boolean()
+        .optional()
+        .describe(
+          "Capture the entire page height, not just the viewport. Falls back to the viewport if the debugger is unavailable.",
+        ),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "Screenshot",
+        ...(args.fullPage !== undefined ? { fullPage: args.fullPage } : {}),
+      });
       if (!result.ok || result.screenshot === undefined) {
         return {
           content: [
@@ -111,7 +122,7 @@ export const buildBrowserTools = (send: BrowserSend) => [
 
   tool(
     "browser_snapshot",
-    "List the interactive and visible elements on the current page — links, buttons, inputs, etc. — each with a stable `ref`, its role, accessible name, and current value. Read this BEFORE clicking or typing: you target elements by `ref`, never by coordinates. Cheaper and more reliable than a screenshot for figuring out what's on the page and what to do next.",
+    "Snapshot the current page as an accessibility tree: headings, landmarks, text, and every interactive element (links, buttons, inputs, …) with its role, accessible name, state, and a `ref=eN` you target with click/type/etc. Covers the whole document, not just the viewport. Read this BEFORE acting — you target elements by `ref`, never by coordinates — and re-snapshot after the page changes (refs go stale on navigation/re-render). Cheaper and more reliable than a screenshot.",
     {},
     async () => {
       const result = await send({ _tag: "Snapshot" });
@@ -134,12 +145,20 @@ export const buildBrowserTools = (send: BrowserSend) => [
 
   tool(
     "browser_click",
-    "Click an element by the `ref` you got from browser_snapshot. Re-snapshot first if the page changed — refs are only valid for the snapshot that produced them. Requires user approval.",
+    "Click an element by the `ref` you got from browser_snapshot. Also pass `element` — a short human-readable description of what you're clicking — so the user's approval prompt is legible. Re-snapshot first if the page changed — refs are only valid for the snapshot that produced them. Requires user approval.",
     {
       ref: z
         .string()
         .min(1)
-        .describe("The `ref` of the target element from a recent browser_snapshot."),
+        .describe(
+          "The `ref` of the target element from a recent browser_snapshot.",
+        ),
+      element: z
+        .string()
+        .optional()
+        .describe(
+          'Human-readable description of the target, e.g. "the Sign in button".',
+        ),
     },
     async (args) => {
       const result = await send({ _tag: "Click", ref: args.ref });
@@ -148,7 +167,7 @@ export const buildBrowserTools = (send: BrowserSend) => [
           {
             type: "text" as const,
             text: result.ok
-              ? (result.detail ?? `Clicked ${args.ref}.`)
+              ? (result.detail ?? `Clicked ${args.element ?? args.ref}.`)
               : (result.error ?? "Click failed."),
           },
         ],
@@ -159,14 +178,25 @@ export const buildBrowserTools = (send: BrowserSend) => [
 
   tool(
     "browser_type",
-    "Type text into the input/textarea identified by `ref` (from browser_snapshot). Replaces the field's current value. Set `submit: true` to press Enter afterward (submit a search box or login form). Requires user approval.",
+    "Type text into the input/textarea identified by `ref` (from browser_snapshot). Replaces the field's current value. Set `submit: true` to press Enter afterward (submit a search box or login form). Pass `element` describing the field for a legible approval prompt. For several fields at once, prefer browser_fill_form — one approval instead of one per field. Requires user approval.",
     {
-      ref: z.string().min(1).describe("The `ref` of the target input from a recent browser_snapshot."),
+      ref: z
+        .string()
+        .min(1)
+        .describe(
+          "The `ref` of the target input from a recent browser_snapshot.",
+        ),
       text: z.string().describe("The text to type into the field."),
       submit: z
         .boolean()
         .optional()
         .describe("Press Enter after typing (e.g. to submit the form)."),
+      element: z
+        .string()
+        .optional()
+        .describe(
+          'Human-readable description of the field, e.g. "the email field".',
+        ),
     },
     async (args) => {
       const result = await send({
@@ -180,7 +210,7 @@ export const buildBrowserTools = (send: BrowserSend) => [
           {
             type: "text" as const,
             text: result.ok
-              ? (result.detail ?? `Typed into ${args.ref}.`)
+              ? (result.detail ?? `Typed into ${args.element ?? args.ref}.`)
               : (result.error ?? "Type failed."),
           },
         ],
@@ -191,16 +221,34 @@ export const buildBrowserTools = (send: BrowserSend) => [
 
   tool(
     "browser_wait",
-    "Pause for the page to settle after a navigation or AJAX update. Give `selector` to wait until a CSS selector appears (up to ~10s), or `ms` for a fixed delay. Use sparingly — prefer re-snapshotting.",
+    "Pause for the page to settle after a navigation or AJAX update. Give `selector` to wait until a CSS selector appears, `text` to wait until that text is visible on the page, or `ms` for a fixed delay. `timeoutMs` bounds the selector/text poll (default 10s, max 25s). Use sparingly — prefer re-snapshotting.",
     {
       ms: z.number().int().positive().max(15000).optional(),
       selector: z.string().min(1).optional(),
+      text: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Wait until this exact text appears in the page's visible text.",
+        ),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .max(25000)
+        .optional()
+        .describe(
+          "How long to keep polling for `selector`/`text` (default 10000).",
+        ),
     },
     async (args) => {
       const result = await send({
         _tag: "Wait",
         ...(args.ms !== undefined ? { ms: args.ms } : {}),
         ...(args.selector !== undefined ? { selector: args.selector } : {}),
+        ...(args.text !== undefined ? { text: args.text } : {}),
+        ...(args.timeoutMs !== undefined ? { timeoutMs: args.timeoutMs } : {}),
       });
       return {
         content: [
@@ -224,7 +272,9 @@ export const buildBrowserTools = (send: BrowserSend) => [
       ref: z
         .string()
         .optional()
-        .describe("Scroll this snapshot ref into view instead of moving the viewport."),
+        .describe(
+          "Scroll this snapshot ref into view instead of moving the viewport.",
+        ),
     },
     async (args) => {
       const result = await send({
@@ -248,26 +298,40 @@ export const buildBrowserTools = (send: BrowserSend) => [
 
   tool(
     "browser_select",
-    "Choose an option in a <select> dropdown identified by `ref` (from browser_snapshot). `value` matches either the option's value or its visible label. Requires user approval.",
+    "Choose an option in a <select> dropdown identified by `ref` (from browser_snapshot). `value` matches either the option's value or its visible label. Pass `element` describing the dropdown for a legible approval prompt. Requires user approval.",
     {
       ref: z.string().min(1),
       value: z.string().describe("The option value or visible text to select."),
+      element: z
+        .string()
+        .optional()
+        .describe('Human-readable description, e.g. "the country dropdown".'),
     },
     async (args) => {
-      const result = await send({ _tag: "Select", ref: args.ref, value: args.value });
+      const result = await send({
+        _tag: "Select",
+        ref: args.ref,
+        value: args.value,
+      });
       return textResult(result, `Selected "${args.value}".`);
     },
   ),
 
   tool(
     "browser_press",
-    "Press a keyboard key — Enter, Tab, Escape, ArrowDown, Backspace, etc. Targets the element `ref` if given, otherwise whatever is currently focused. Good for submitting, dismissing dialogs, or keyboard navigation. Requires user approval.",
+    "Press a keyboard key — Enter, Tab, Escape, ArrowDown, Backspace, etc. Targets the element `ref` if given, otherwise whatever is currently focused. Good for submitting, dismissing in-page overlays, or keyboard navigation (for native alert/confirm dialogs use browser_dialog). Requires user approval.",
     {
       key: z
         .string()
         .min(1)
-        .describe("Key name, e.g. Enter, Tab, Escape, ArrowDown, PageDown, Backspace."),
+        .describe(
+          "Key name, e.g. Enter, Tab, Escape, ArrowDown, PageDown, Backspace.",
+        ),
       ref: z.string().optional(),
+      element: z
+        .string()
+        .optional()
+        .describe("Human-readable description of the target element, if any."),
     },
     async (args) => {
       const result = await send({
@@ -290,7 +354,12 @@ export const buildBrowserTools = (send: BrowserSend) => [
       });
       if (!result.ok) {
         return {
-          content: [{ type: "text" as const, text: result.error ?? "Could not read the page." }],
+          content: [
+            {
+              type: "text" as const,
+              text: result.error ?? "Could not read the page.",
+            },
+          ],
           isError: true,
         };
       }
@@ -312,13 +381,18 @@ export const buildBrowserTools = (send: BrowserSend) => [
 
   tool(
     "browser_console",
-    "Return the page's recent console messages and uncaught JavaScript errors (captured since the last navigation). Use this to verify a page is healthy or to debug why something didn't work.",
+    "Return the page's recent console messages, uncaught JavaScript exceptions, and load failures (captured since the last navigation), plus a note if a JS dialog is blocking the page. Check this after acting on a page — it's how you catch the error the UI didn't show. Use with browser_network to verify a page is healthy.",
     {},
     async () => {
       const result = await send({ _tag: "Console" });
       if (!result.ok) {
         return {
-          content: [{ type: "text" as const, text: result.error ?? "Could not read the console." }],
+          content: [
+            {
+              type: "text" as const,
+              text: result.error ?? "Could not read the console.",
+            },
+          ],
           isError: true,
         };
       }
@@ -326,12 +400,120 @@ export const buildBrowserTools = (send: BrowserSend) => [
         content: [
           {
             type: "text" as const,
-            text: result.text && result.text.length > 0
-              ? result.text
-              : "(console is empty — no messages or errors since the last navigation)",
+            text:
+              result.text && result.text.length > 0
+                ? result.text
+                : "(console is empty — no messages or errors since the last navigation)",
           },
         ],
       };
+    },
+  ),
+
+  tool(
+    "browser_network",
+    "List the network requests the page has made since its last load (method, status, type, URL, id), or pass `id` to inspect one request's response headers and a truncated body. Use it to verify API calls succeeded, spot 4xx/5xx failures, or read a response the page didn't render. `filter` substring-matches URLs.",
+    {
+      filter: z
+        .string()
+        .optional()
+        .describe("Only list requests whose URL contains this substring."),
+      id: z
+        .string()
+        .optional()
+        .describe(
+          "Request id from a previous listing — returns that request's detail.",
+        ),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "Network",
+        ...(args.filter !== undefined ? { filter: args.filter } : {}),
+        ...(args.id !== undefined ? { id: args.id } : {}),
+      });
+      if (!result.ok) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: result.error ?? "Could not read network activity.",
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              result.text && result.text.length > 0
+                ? result.text
+                : "(no requests captured since the last page load)",
+          },
+        ],
+      };
+    },
+  ),
+
+  tool(
+    "browser_fill_form",
+    "Fill several form fields in one action — text inputs, textareas, and <select> dropdowns, each identified by a `ref` from browser_snapshot. One approval covers the whole form, and the user watches the cursor move field to field. Set `submit: true` to press Enter in the last field afterward. Prefer this over repeated browser_type calls. Requires user approval.",
+    {
+      fields: z
+        .array(
+          z.object({
+            ref: z
+              .string()
+              .min(1)
+              .describe("The field's `ref` from a recent browser_snapshot."),
+            value: z
+              .string()
+              .describe(
+                "Text to fill, or the option value/label for a <select>.",
+              ),
+            element: z
+              .string()
+              .optional()
+              .describe('Human-readable description, e.g. "the email field".'),
+          }),
+        )
+        .min(1)
+        .describe("Fields to fill, in order."),
+      submit: z
+        .boolean()
+        .optional()
+        .describe("Press Enter in the last field after filling everything."),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "FillForm",
+        fields: args.fields.map((f) => ({ ref: f.ref, value: f.value })),
+        ...(args.submit !== undefined ? { submit: args.submit } : {}),
+      });
+      return textResult(result, `Filled ${args.fields.length} fields.`);
+    },
+  ),
+
+  tool(
+    "browser_dialog",
+    "Resolve the JavaScript dialog (alert/confirm/prompt) currently blocking the page: accept or dismiss it, with optional `promptText` to answer a prompt(). browser_console tells you when a dialog is open and what it says. Requires user approval.",
+    {
+      action: z.enum(["accept", "dismiss"]),
+      promptText: z
+        .string()
+        .optional()
+        .describe("Answer text when accepting a prompt() dialog."),
+    },
+    async (args) => {
+      const result = await send({
+        _tag: "Dialog",
+        action: args.action,
+        ...(args.promptText !== undefined
+          ? { promptText: args.promptText }
+          : {}),
+      });
+      return textResult(result, `Dialog ${args.action}ed.`);
     },
   ),
 
@@ -353,7 +535,8 @@ export const buildBrowserTools = (send: BrowserSend) => [
           {
             type: "text" as const,
             text: result.ok
-              ? (result.detail ?? `Submitted the saved login for ${args.origin}.`)
+              ? (result.detail ??
+                `Submitted the saved login for ${args.origin}.`)
               : (result.error ??
                 `No saved credential for ${args.origin}. Ask the user to add one in Settings → Browser.`),
           },

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -1015,12 +1015,15 @@ const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
   `mcp__${ZUSE_MCP_NAME}__browser_snapshot`,
   `mcp__${ZUSE_MCP_NAME}__browser_wait`,
   // Read-only / non-mutating browsing: scroll, hover, read text, console,
-  // and history (back/forward/reload — like navigate, which also auto-allows).
-  // `browser_select` and `browser_press` change page state, so they prompt.
+  // network (pure read of captured request metadata), and history
+  // (back/forward/reload — like navigate, which also auto-allows).
+  // `browser_select`, `browser_press`, `browser_fill_form`, and
+  // `browser_dialog` change page state, so they prompt.
   `mcp__${ZUSE_MCP_NAME}__browser_scroll`,
   `mcp__${ZUSE_MCP_NAME}__browser_hover`,
   `mcp__${ZUSE_MCP_NAME}__browser_read`,
   `mcp__${ZUSE_MCP_NAME}__browser_console`,
+  `mcp__${ZUSE_MCP_NAME}__browser_network`,
   `mcp__${ZUSE_MCP_NAME}__browser_history`,
 ]);
 

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -1,5 +1,12 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { appendFileSync, mkdirSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import * as readline from "node:readline";
 import { Effect, Mailbox, Stream } from "effect";
@@ -100,6 +107,53 @@ type PendingResolver = {
   resolve: (v: unknown) => void;
   reject: (e: Error) => void;
   timer: NodeJS.Timeout;
+};
+
+const BROWSER_MCP_CONFIG_START =
+  "# >>> zuse-generated-browser-mcp: do not edit";
+const BROWSER_MCP_CONFIG_END = "# <<< zuse-generated-browser-mcp";
+
+const stripGeneratedBrowserMcpConfig = (value: string): string =>
+  value
+    .replace(
+      new RegExp(
+        `\\n?${BROWSER_MCP_CONFIG_START}[\\s\\S]*?${BROWSER_MCP_CONFIG_END}\\n?`,
+        "g",
+      ),
+      "\n",
+    )
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
+
+const installProjectBrowserMcpConfig = (
+  cwd: string,
+  toml: string,
+): (() => void) => {
+  const grokDir = join(cwd, ".grok");
+  const configPath = join(grokDir, "config.toml");
+  const previous = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
+  const userConfig = stripGeneratedBrowserMcpConfig(previous);
+  const next = `${userConfig.length > 0 ? `${userConfig}\n\n` : ""}${BROWSER_MCP_CONFIG_START}\n${toml.trimEnd()}\n${BROWSER_MCP_CONFIG_END}\n`;
+
+  mkdirSync(grokDir, { recursive: true });
+  writeFileSync(configPath, next, "utf8");
+  console.info(`[grok.browser-mcp] wrote project MCP config ${configPath}`);
+
+  return () => {
+    try {
+      if (userConfig.length > 0) {
+        writeFileSync(configPath, `${userConfig}\n`, "utf8");
+      } else {
+        rmSync(configPath, { force: true });
+      }
+    } catch (cause) {
+      console.warn(
+        `[grok.browser-mcp] could not restore project MCP config ${configPath}: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
+  };
 };
 
 /**
@@ -326,6 +380,10 @@ export const startGrokSession = (
           }`,
         }),
     });
+    const restoreProjectBrowserMcpConfig = installProjectBrowserMcpConfig(
+      cwd,
+      browserMcpBridge.projectConfigToml,
+    );
 
     let acpSessionId: string | null = null;
     let nextRpcId = 1;
@@ -378,7 +436,7 @@ export const startGrokSession = (
      *  returned promise rejects and the caller decides whether to surface
      *  the error or just bubble it. */
     const connectChild = async (): Promise<string> => {
-      child = spawn(grokPath, ["agent", "stdio"], {
+      child = spawn(grokPath, ["--trust", "agent", "stdio"], {
         cwd,
         env: {
           ...process.env,
@@ -860,6 +918,7 @@ export const startGrokSession = (
           } catch {
             // ignore — child may not be alive
           }
+          restoreProjectBrowserMcpConfig();
           void browserMcpBridge.close();
         }),
       ),
@@ -1092,6 +1151,7 @@ export const startGrokSession = (
           }
           child.kill("SIGTERM");
           rl.close();
+          restoreProjectBrowserMcpConfig();
           yield* Effect.promise(() => browserMcpBridge.close());
           yield* events.end;
         }),

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -440,6 +440,7 @@ export const startGrokSession = (
         cwd,
         env: {
           ...process.env,
+          GROK_CURSOR_MCPS_ENABLED: "0",
           ...(apiKey !== null ? { GROK_CODE_XAI_API_KEY: apiKey } : {}),
         },
         stdio: ["pipe", "pipe", "pipe"],

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -29,7 +29,9 @@ import {
 } from "./compact.ts";
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
+import { startBrowserMcpBridge } from "./acp/browser-mcp-bridge.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
+import type { BrowserSend } from "./browser-tools.ts";
 
 /**
  * Live-only handle for one Grok conversation. Mirrors Codex/Claude handle
@@ -270,9 +272,11 @@ export const startGrokSession = (
   cwd: string,
   apiKey: string | null,
   grokPath: string,
+  browserMcpCommand: string,
   sessionId: AgentSessionId,
   requestPermission: RequestPermission,
   getRuntimeMode: GetRuntimeMode,
+  browserSend: BrowserSend,
   resumeCursor: string | null = null,
 ): Effect.Effect<
   GrokSessionHandle,
@@ -302,6 +306,25 @@ export const startGrokSession = (
       ) => requestPermission(sessionId, kind, options),
       getRuntimeMode,
       getPermissionMode: () => currentMode,
+    });
+
+    const browserMcpBridge = yield* Effect.tryPromise({
+      try: () =>
+        startBrowserMcpBridge({
+          send: browserSend,
+          command: browserMcpCommand,
+          requestPermission: (kind, options) =>
+            requestPermission(sessionId, kind, options),
+          getRuntimeMode,
+          getPermissionMode: () => currentMode,
+        }),
+      catch: (cause) =>
+        new AgentSessionStartError({
+          providerId: "grok",
+          reason: `Could not start browser MCP bridge: ${
+            cause instanceof Error ? cause.message : String(cause)
+          }`,
+        }),
     });
 
     let acpSessionId: string | null = null;
@@ -807,7 +830,7 @@ export const startGrokSession = (
 
       const sessionResult = (await request("session/new", {
         cwd,
-        mcpServers: [],
+        mcpServers: [browserMcpBridge.serverConfig],
       })) as { sessionId?: unknown };
 
       if (typeof sessionResult.sessionId !== "string") {
@@ -837,6 +860,7 @@ export const startGrokSession = (
           } catch {
             // ignore — child may not be alive
           }
+          void browserMcpBridge.close();
         }),
       ),
     );
@@ -1068,6 +1092,7 @@ export const startGrokSession = (
           }
           child.kill("SIGTERM");
           rl.close();
+          yield* Effect.promise(() => browserMcpBridge.close());
           yield* events.end;
         }),
       setPermissionMode: (mode) =>

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -36,7 +36,10 @@ import {
 } from "./compact.ts";
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
-import { startBrowserMcpBridge } from "./acp/browser-mcp-bridge.ts";
+import {
+  browserMcpPromptHint,
+  startBrowserMcpBridge,
+} from "./acp/browser-mcp-bridge.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
 import type { BrowserSend } from "./browser-tools.ts";
 
@@ -397,6 +400,11 @@ export const startGrokSession = (
      *  instead of queuing doomed RPCs that will 5-minute timeout.
      */
     let dead = false;
+    // One-shot browser-tools hint for the model. True whenever the ACP
+    // server-side context is fresh (initial connect + every respawn); the
+    // next session/prompt prepends the zuse-browser tool list so the model
+    // calls tools directly instead of hunting the filesystem for schemas.
+    let browserHintPending = true;
     let inflight: Promise<void> = Promise.resolve();
     const pending = new Map<number, PendingResolver>();
     // Trailing window of grok's stderr — used to enrich error reports when
@@ -436,7 +444,7 @@ export const startGrokSession = (
      *  returned promise rejects and the caller decides whether to surface
      *  the error or just bubble it. */
     const connectChild = async (): Promise<string> => {
-      child = spawn(grokPath, ["--trust", "agent", "stdio"], {
+      child = spawn(grokPath, ["--trust", "agent", "--no-leader", "stdio"], {
         cwd,
         env: {
           ...process.env,
@@ -901,6 +909,10 @@ export const startGrokSession = (
       });
       acpSessionId = sessionResult.sessionId;
       dead = false;
+      // Fresh server-side context → the model hasn't seen the browser-tools
+      // hint yet. Re-arm it so the next prompt carries the tool list (also
+      // covers transparent respawns after a child death).
+      browserHintPending = true;
       return sessionResult.sessionId;
     };
 
@@ -995,13 +1007,22 @@ export const startGrokSession = (
           }
           const sid = acpSessionId;
           if (sid === null) return;
+          // Prepend the browser-tools hint on the first prompt of each fresh
+          // ACP context (computed here, after the potential respawn above,
+          // so a respawned context gets it too). Compact turns skip it —
+          // they replay a synthetic summary, not a user ask.
+          const finalPromptText =
+            browserHintPending && compactSnapshot === null
+              ? `${browserMcpPromptHint()}\n\n${promptText}`
+              : promptText;
+          browserHintPending = false;
           if (GROK_RPC_TRACE || GROK_DIAG) {
             process.stderr.write(
-              `[grok.prompt] enqueue len=${promptText.length} mode=${currentMode}\n`,
+              `[grok.prompt] enqueue len=${finalPromptText.length} mode=${currentMode}\n`,
             );
           }
           grokDiag("session/prompt starting", {
-            promptLen: promptText.length,
+            promptLen: finalPromptText.length,
             permissionMode: currentMode,
             model: input.model,
           });
@@ -1012,7 +1033,7 @@ export const startGrokSession = (
               "session/prompt",
               {
                 sessionId: sid,
-                prompt: [{ type: "text", text: promptText }],
+                prompt: [{ type: "text", text: finalPromptText }],
                 // Server may ignore unknown keys; pass mode + model as
                 // metadata so a future ACP rev can honour them without a
                 // driver change.

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -232,14 +232,31 @@ export const ProviderServiceLive = Layer.effect(
                 }),
               );
             }
+            const bunPath = yield* resolveCliPath("bun").pipe(
+              Effect.provideService(CommandExecutor.CommandExecutor, executor),
+            );
+            if (bunPath === null) {
+              return yield* Effect.fail(
+                new AgentSessionStartError({
+                  providerId: "grok",
+                  reason:
+                    "Bun was not found on PATH. It is required to expose Zuse browser tools to Grok via ACP MCP.",
+                }),
+              );
+            }
             handle = yield* startGrokSession(
               input,
               cwd,
               apiKey,
               grokPath,
+              bunPath,
               sessionId,
               buildRequestPermission(input.folderId),
               runtimeModeGetter,
+              (command) =>
+                Runtime.runPromise(runtime)(
+                  browserBridge.send(sessionId, command),
+                ),
               resumeCursor,
             ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else if (input.providerId === "opencode") {

--- a/bun.lock
+++ b/bun.lock
@@ -137,6 +137,7 @@
         "@effect/rpc": "catalog:",
         "@effect/sql": "catalog:",
         "@effect/sql-sqlite-node": "catalog:",
+        "@modelcontextprotocol/sdk": "^1.0.0",
         "@openai/codex-sdk": "^0.128.0",
         "@opencode-ai/sdk": "^1.3.15",
         "@zuse/index": "*",

--- a/packages/wire/src/browser.ts
+++ b/packages/wire/src/browser.ts
@@ -12,19 +12,27 @@ import { SessionId } from "./session.ts";
  * on `browser.commands`, the renderer drives the webview, and posts the
  * outcome back via `browser.respond`, which resolves a server-side Deferred.
  *
- * The command union is intentionally small for Phase 1 (navigate + screenshot);
- * interaction commands (snapshot/click/type/wait) and login land in later
- * phases as new members — a wire change, never a stringly-typed addition.
+ * Every capability is a union member here — a wire change, never a
+ * stringly-typed addition. v2 members (FillForm/Network/Dialog + the Wait and
+ * Screenshot extensions) ride the same request/respond round-trip as v1.
  */
 export const BrowserCommand = Schema.Union(
   /** Load a URL into the shared in-app webview and wait for it to settle. */
   Schema.TaggedStruct("Navigate", { url: Schema.String }),
-  /** Capture the visible viewport. The renderer returns a base64 PNG. */
-  Schema.TaggedStruct("Screenshot", {}),
   /**
-   * Walk the page and return a compact list of interactive/visible elements,
-   * each tagged with a stable `ref` the agent then targets with Click/Type.
-   * Cheaper for the model than a screenshot and robust to scroll/DPI.
+   * Capture the page. Default is the visible viewport via `capturePage`;
+   * `fullPage` captures beyond the viewport through CDP
+   * (`Page.captureScreenshot`) when the debugger is attached.
+   */
+  Schema.TaggedStruct("Screenshot", {
+    fullPage: Schema.optional(Schema.Boolean),
+  }),
+  /**
+   * Snapshot the page for targeting. v2: the renderer prefers a pruned
+   * accessibility tree over CDP (roles/names/states, interactive elements
+   * carrying `ref=eN` mapped to backendNodeIds renderer-side) and falls back
+   * to v1's injected DOM walk when CDP isn't attached. Cheaper for the model
+   * than a screenshot and robust to scroll/DPI.
    */
   Schema.TaggedStruct("Snapshot", {}),
   /** Click the element carrying this snapshot `ref`. */
@@ -39,21 +47,24 @@ export const BrowserCommand = Schema.Union(
     submit: Schema.optional(Schema.Boolean),
   }),
   /**
-   * Settle after navigation/AJAX. Either wait a fixed `ms`, or poll until a
-   * CSS `selector` appears (whichever is given; selector wins).
+   * Settle after navigation/AJAX. Wait a fixed `ms`, poll until a CSS
+   * `selector` appears, or poll until `text` shows up in the page's visible
+   * text (selector wins over text; either wins over ms). `timeoutMs` bounds
+   * the poll — capped renderer-side below the bridge's 30s deadline so a
+   * hopeless wait fails as a clean tool error, not a bridge timeout.
    */
   Schema.TaggedStruct("Wait", {
     ms: Schema.optional(Schema.Number),
     selector: Schema.optional(Schema.String),
+    text: Schema.optional(Schema.String),
+    timeoutMs: Schema.optional(Schema.Number),
   }),
   /**
    * Scroll the page (or a `ref` into view). `direction` moves the viewport;
    * `ref` (when given) scrolls that element to center instead.
    */
   Schema.TaggedStruct("Scroll", {
-    direction: Schema.optional(
-      Schema.Literal("up", "down", "top", "bottom"),
-    ),
+    direction: Schema.optional(Schema.Literal("up", "down", "top", "bottom")),
     ref: Schema.optional(Schema.String),
   }),
   /** Hover an element by `ref` (reveal menus / tooltips). */
@@ -79,6 +90,39 @@ export const BrowserCommand = Schema.Union(
   }),
   /** Return recent console messages + page errors captured since last load. */
   Schema.TaggedStruct("Console", {}),
+  /**
+   * Fill several fields in one round-trip — inputs/textareas and <select>s by
+   * snapshot `ref`. One permission prompt covers the whole form. `submit`
+   * presses Enter in the last filled field afterward.
+   */
+  Schema.TaggedStruct("FillForm", {
+    fields: Schema.Array(
+      Schema.Struct({
+        ref: Schema.String,
+        value: Schema.String,
+      }),
+    ),
+    submit: Schema.optional(Schema.Boolean),
+  }),
+  /**
+   * Network activity captured since the last page load (CDP Network domain,
+   * buffered in main). No `id` → compact request list, optionally substring-
+   * filtered by `filter`. With `id` → one request's detail incl. response
+   * headers and a truncated body.
+   */
+  Schema.TaggedStruct("Network", {
+    filter: Schema.optional(Schema.String),
+    id: Schema.optional(Schema.String),
+  }),
+  /**
+   * Resolve the pending JavaScript dialog (alert/confirm/prompt/beforeunload)
+   * via `Page.handleJavaScriptDialog`. `promptText` answers a prompt() when
+   * accepting. Fails cleanly when no dialog is open.
+   */
+  Schema.TaggedStruct("Dialog", {
+    action: Schema.Literal("accept", "dismiss"),
+    promptText: Schema.optional(Schema.String),
+  }),
   /**
    * Autofill + submit the saved (DUMMY/TEST) credentials for this origin.
    * SECURITY: the command carries ONLY the origin — never the password. The
@@ -143,11 +187,17 @@ export class BrowserCommandResult extends Schema.Class<BrowserCommandResult>(
   url: Schema.optional(Schema.String),
   title: Schema.optional(Schema.String),
   screenshot: Schema.optional(Schema.String),
-  /** Snapshot → JSON array of `{ ref, role, name, value }`. */
+  /**
+   * Snapshot → a11y-tree text (CDP path) or JSON array of
+   * `{ ref, role, name, value }` (v1 DOM fallback).
+   */
   snapshot: Schema.optional(Schema.String),
   /** Click/Type/Scroll/… → short human-readable note for the agent. */
   detail: Schema.optional(Schema.String),
-  /** Read → page/element text; Console → captured console + error log. */
+  /**
+   * Read → page/element text; Console → console + error log;
+   * Network → request list or one request's detail.
+   */
   text: Schema.optional(Schema.String),
 }) {}
 

--- a/specs/0.05-MVP/features/agent-browser-v2.md
+++ b/specs/0.05-MVP/features/agent-browser-v2.md
@@ -1,0 +1,200 @@
+# Feature: Agent Browser v2 — DevTools eyes, test-runner hands
+
+v1 gave the agent a visible browser it can drive: 14 `mcp__zuse__browser_*`
+tools over the app's on-screen `<webview>`, real CDP input, a rendered cursor,
+and a shutter flash on screenshots. v2 upgrades **what the agent can perceive**
+— a real accessibility-tree snapshot, network activity, uncaught exceptions,
+full-page captures — and **how cheaply it can act**: batch form fill, richer
+waits, dialog handling. The webview stays visible; the user keeps watching.
+
+## Why v2
+
+Two things changed since the v1 spec:
+
+1. **The industry converged on a targeting model.** Playwright MCP, Chrome
+   DevTools MCP, and Vercel's agent-browser all snapshot the browser's
+   _accessibility tree_ and hand the model per-element refs (`e5`, `uid=…`,
+   `@e1`). A structured snapshot costs roughly 500–5,000 tokens where a
+   screenshot costs 10,000–50,000 — a 10–100× reduction — and it works for
+   models without vision, survives scroll/DPI changes, and describes the whole
+   document, not just the viewport. Screenshots are demoted to "when layout
+   actually matters."
+2. **Observability became table stakes.** Chrome DevTools MCP ships network
+   request listing, console messages, and script evaluation as core tools;
+   Cursor's embedded browser wires Chrome-level diagnostics into the agent.
+   An agent that can't see the failed `POST /api/login` or the uncaught
+   `TypeError` is debugging blind.
+
+v1's snapshot walks the DOM from injected page JS: it tags interactive
+elements with `data-mz-ref` attributes, sees only ~the viewport (+400px), and
+can't describe page structure. v2 replaces it at the root.
+
+### What competitors do (and what we keep doing differently)
+
+|                         | Targeting                | Observability                       | User sees it?                              | Where it runs                    |
+| ----------------------- | ------------------------ | ----------------------------------- | ------------------------------------------ | -------------------------------- |
+| Playwright MCP          | a11y snapshot + refs     | console, network, tracing (opt-in)  | headed or headless, separate window        | spawned browser                  |
+| Chrome DevTools MCP     | a11y snapshot + uids     | network, console, perf traces, heap | user's Chrome or spawned                   | CDP to real Chrome               |
+| Cursor embedded browser | CDP + element picker     | DevTools in-editor                  | yes, editor tab                            | Chromium in IDE                  |
+| Claude in Chrome        | screenshots + DOM        | page-level                          | yes, side panel                            | extension in user's Chrome       |
+| Vercel agent-browser    | a11y snapshot + refs     | console, network                    | headless daemon                            | background process               |
+| **Zuse v2**             | **a11y snapshot + refs** | **console, errors, network**        | **always — same webview the user browses** | **in-app, zero extra processes** |
+
+Public references:
+[Playwright MCP snapshots](https://playwright.dev/docs/mcp#snapshots),
+[Playwright MCP tools](https://playwright.dev/docs/mcp#tools),
+[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp),
+and
+[Electron web embeds](https://www.electronjs.org/docs/latest/tutorial/web-embeds).
+
+Our differentiator survives v2 unchanged: the agent drives **the browser tab
+the user is already looking at**. Every action is watchable (cursor glide,
+shutter flash), every mutation maps to a legible permission prompt, and there
+is no second Chromium. **No headless mode in v2** — if concurrent sessions
+ever contend for the browser, the answer is agent-owned _visible_ tabs
+(P4), not a hidden browser the user can't audit.
+
+## Architecture (unchanged hard fact)
+
+> MCP tools run in the **server** process; the `<webview>` lives in the
+> **renderer**. Every tool round-trips server → renderer → server via
+> `BrowserBridgeService` (PubSub + Deferred, 30s deadline).
+
+What v2 adds rides the plumbing v1 already built:
+
+- Main already attaches `webContents.debugger` (CDP 1.3) to the webview for
+  real input (`apps/desktop/src/main.ts`, `browser:registerWebview` /
+  `browser:dispatchInput`). v2 opens that same attachment to more domains —
+  **Accessibility** (tree snapshots), **DOM** (ref → coordinates), **Runtime**
+  (exceptions, per-element function calls), **Network** (request log),
+  **Page** (full-page capture, dialogs) — behind a method-allowlisted
+  `browser:cdpCommand` IPC seam plus purpose-built buffer readers.
+- The renderer keeps a per-snapshot `ref → backendNodeId` map. Actions resolve
+  a ref through `DOM.scrollIntoViewIfNeeded` + `DOM.getContentQuads` to fresh
+  viewport coordinates, then dispatch the same real CDP input as v1 (cursor
+  glide and click pulse preserved). Element-value work (type/select/read)
+  goes through `DOM.resolveNode` + `Runtime.callFunctionOn`, carrying over
+  v1's React-safe value-setter verbatim.
+- **Every CDP path falls back to the v1 behavior** (injected-JS snapshot,
+  `data-mz-ref` targeting, synthetic events) when the debugger isn't attached
+  — same graceful degradation contract as v1's click fallback.
+
+## Tools (v2 surface — all `mcp__zuse__browser_*`)
+
+Unchanged from v1: `navigate`, `read`, `scroll`, `hover`, `history`,
+`click`, `type`, `select`, `press`, `login`. Upgraded or new:
+
+| Tool                 | Does                                                                                                                                                                     | Permission  |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `browser_snapshot`   | **Upgraded:** full-page accessibility tree (roles, names, states, values), interactive elements carry `ref=eN`. Structural nodes give context; refs are what you act on. | auto-allow  |
+| `browser_wait`       | **Upgraded:** settle by `ms`, CSS `selector`, or **`text`** appearing on the page, with a configurable `timeoutMs` (≤25s, under the bridge's 30s deadline).              | auto-allow  |
+| `browser_screenshot` | **Upgraded:** optional `fullPage: true` captures beyond the viewport via `Page.captureScreenshot`. Shutter flash still fires.                                            | auto-allow  |
+| `browser_console`    | **Upgraded:** now includes uncaught exceptions (`Runtime.exceptionThrown`) captured in main, not just `console.*` events.                                                | auto-allow  |
+| `browser_network`    | **New:** list requests since last load (method, URL, status, type), or drill into one by `id` (headers + truncated body).                                                | auto-allow  |
+| `browser_fill_form`  | **New:** fill many fields (inputs and selects) in one call — one permission prompt, one round-trip, then optional submit.                                                | **prompts** |
+| `browser_dialog`     | **New:** accept/dismiss the pending JS dialog (`alert`/`confirm`/`prompt`, optional `promptText`).                                                                       | **prompts** |
+
+Mutation tools (`click`, `type`, `select`, `press`, `fill_form`) gain an
+optional `element` argument — a human-readable description of the target
+("the Sign in button") echoed into results and permission surfaces, following
+Playwright MCP's ref + description convention.
+
+Permission rule of thumb is unchanged: reads and user-visible navigation
+auto-allow; page mutations prompt; `login` always prompts, even in
+full-access mode. New classifications: `network` joins the read-only set;
+`fill_form` and `dialog` fall through to the standard prompt.
+
+## The verification loop (why all of this exists)
+
+The canonical post-edit check the agent should run without hand-holding:
+
+1. `browser_navigate` to the dev server (or `browser_history` reload).
+2. `browser_wait` for the text/selector that proves the page rendered.
+3. `browser_snapshot` — assert the expected structure/labels/values exist.
+4. `browser_console` + `browser_network` — assert no new exceptions, no
+   failed requests.
+5. Only if layout itself is in question: `browser_screenshot`.
+
+Steps 2–4 are pure text, auto-allowed, and cost a few thousand tokens total —
+cheap enough to run after every meaningful change. Tool descriptions steer
+the model toward this loop (snapshot-before-act, console/network-after-act).
+
+## Non-goals (v2)
+
+- **Headless / hidden browsing** — the visible webview is the product.
+- **Real credentials** — dummy/test logins only; the v1 keychain design and
+  always-prompt stance carry over untouched.
+- **Performance tracing, heap analysis, Lighthouse** — Chrome DevTools MCP
+  territory; revisit on demand.
+- **Cross-origin iframe (OOPIF) targeting** — `Accessibility.getFullAXTree`
+  covers same-process frames; OOPIFs need `Target.autoAttach` plumbing.
+  Deferred.
+- **Multi-provider** — tools remain on Claude's in-process MCP server; the
+  bridge stays provider-agnostic for later ACP wiring.
+
+## Implementation phases
+
+| Phase  | What                                                                                                                                                                                                                                                                                                                                | Effort                     |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| **P0** | A11y-tree snapshot over CDP + ref targeting via backendNodeId; `browser_wait` text/timeout. Spike inside: confirm `Accessibility.getFullAXTree` behavior over Electron's `webContents.debugger` (it's not part of the frozen 1.3 protocol on paper, but the live Chromium speaks it — fall back to the v1 DOM snapshot on failure). | M                          |
+| **P1** | `browser_network` + uncaught-exception capture (Network/Runtime domains enabled at attach, ring buffers in main, cleared per load).                                                                                                                                                                                                 | M                          |
+| **P2** | `browser_fill_form`, `fullPage` screenshots, `browser_dialog`, `element` descriptions on mutation tools; auto-allow unload (`will-prevent-unload`) so navigations can't wedge.                                                                                                                                                      | S–M                        |
+| **P3** | Multi-tab (`browser_tabs`: agent-owned visible tabs in the pane) + localhost auto-attach: when the session's dev-server port is known, bare paths resolve against it (seam exists in `resolveUrl`, `browser-pane.tsx`).                                                                                                             | M                          |
+| **P4** | `browser_verify_*` assertion tools (Playwright `--caps=testing` precedent), WebContentsView migration, ACP providers.                                                                                                                                                                                                               | L, triggered not scheduled |
+
+P0–P2 ship together in this branch. P3+ are specced here, built later.
+
+## Key files
+
+Everything from the v1 spec's list, plus:
+
+- CDP seam: `apps/desktop/src/main.ts` (`browser:cdpCommand` allowlist,
+  domain enables, network/error ring buffers, dialog state).
+- Preload/typing: `apps/desktop/src/preload.ts`,
+  `apps/renderer/src/lib/bridge.ts`.
+- Snapshot builder + ref store + new command handlers:
+  `apps/renderer/src/components/browser-pane.tsx`.
+- Wire: `packages/wire/src/browser.ts` (`FillForm`, `Network`, `Dialog`,
+  extended `Wait`/`Screenshot`).
+- Tools + policy: `apps/server/src/provider/drivers/browser-tools.ts`,
+  `drivers/claude.ts` (`READ_ONLY_TOOLS`).
+
+## Risks / verification notes
+
+- **`getFullAXTree` over Electron's debugger** — Accessibility is formally an
+  experimental CDP domain. Expected to work (the attached debugger speaks the
+  running Chromium's full protocol); if it throws, the renderer silently
+  falls back to the v1 snapshot. Verify on a real page, and on a page inside
+  an iframe.
+- **Snapshot size** — big pages produce big trees. Prune ignored/generic
+  nodes, cap output (~15k chars) with an explicit truncation note so the
+  model knows to scroll/re-read rather than trust a silent cut.
+- **Dialogs in `<webview>`** — Electron's handling of `alert()`/`confirm()`
+  inside webviews differs from BrowserWindows. `Page.handleJavaScriptDialog`
+  is best-effort; verify empirically, keep the 30s bridge deadline as the
+  backstop so a stuck dialog fails the tool cleanly.
+- **backendNodeId staleness** — refs die on navigation or DOM rebuild. Every
+  ref-resolution failure returns "re-snapshot the page first," same contract
+  as v1.
+- **Desktop Electron 33 / `<webview>` deprecation risk** — the desktop package
+  currently depends on Electron `^33.2.0`, and Electron discourages the tag;
+  WebContentsView is the sanctioned replacement. We stay: the tag composites
+  in-page (the cursor/shutter overlays depend on that) and the entire CDP seam
+  is `WebContents`-level, so a future migration moves the hosting surface, not
+  the agent plumbing.
+
+## How to verify end-to-end
+
+1. **Snapshot**: `"open example.com and snapshot"` → tree with roles/names,
+   `ref=eN` on the link; click by ref lands with cursor glide (real CDP).
+2. **Verification loop**: edit a local dev page to add a button; ask the
+   agent to verify → it should navigate, wait, snapshot, and assert the
+   button exists without taking a screenshot.
+3. **Errors**: on a page that throws in a click handler, click it →
+   `browser_console` reports the uncaught exception.
+4. **Network**: `browser_network` lists the page's requests; drilling into a
+   JSON API call shows status + truncated body.
+5. **Form**: `browser_fill_form` fills email + password + a select in one
+   permission prompt; a follow-up snapshot shows the values.
+6. **Full page**: `fullPage: true` screenshot of a long page captures below
+   the fold; the viewport variant still flashes the shutter.


### PR DESCRIPTION
## Summary
- upgrade the in-app agent browser to v2 with CDP accessibility snapshots and backendNodeId ref targeting
- add browser network/error observability, full-page screenshots, dialog handling, richer waits, and batch form fill
- document the v2 architecture, tool surface, risks, and verification flow

## Validation
- bun run check-types
- git diff --check
