### PR TITLE
[codex] continue external agent threads

### DIFF
--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -6,7 +6,7 @@ import {
   Tick01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import { X } from "lucide-react";
-import { useLayoutEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 
 import {
   type ComposerInput,
@@ -24,11 +24,20 @@ import {
   MenuSeparator,
   MenuTrigger,
 } from "~/components/ui/menu";
+import {
+  Frame,
+  FrameFooter,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "~/components/ui/frame";
+import { Skeleton } from "~/components/ui/skeleton";
 import { Spinner } from "~/components/ui/spinner";
 import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
 import { useChatsStore } from "~/store/chats";
 import { useMessagesStore } from "~/store/messages";
 import { useProvidersStore } from "~/store/providers";
+import { useExternalThreadsStore } from "~/store/external-threads";
 import { DRAFT_SESSION_ID, useSessionsStore } from "~/store/sessions";
 import { useSettingsStore } from "~/store/settings";
 import { useWorkspaceStore } from "~/store/workspace";
@@ -36,6 +45,7 @@ import { EMPTY_WORKTREES, useWorktreesStore } from "~/store/worktrees";
 import { composerDraftKeyForLanding } from "~/store/composer-drafts";
 import { ChatComposer } from "./chat-composer.tsx";
 import { PROVIDER_LABEL } from "./settings-page";
+import { ProviderIcon } from "./provider-icons";
 import { SetupCardView } from "./worktree-setup-card.tsx";
 
 /**
@@ -70,6 +80,17 @@ const migrateModelOptions = (fromId: string, toId: string): void => {
   }
 };
 
+const formatThreadRelative = (date: Date): string => {
+  const ms = Math.max(0, Date.now() - date.getTime());
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return "now";
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  return `${day}d`;
+};
+
 /**
  * Landing surface shown in the main pane whenever no chat session is
  * selected — including cold start, after archiving the active session, and
@@ -87,6 +108,15 @@ export function ChatLanding() {
   const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
   const selectFolder = useWorkspaceStore((s) => s.select);
   const addFolder = useWorkspaceStore((s) => s.add);
+  const externalThreads = useExternalThreadsStore((s) => s.threads);
+  const externalThreadsLoading = useExternalThreadsStore((s) => s.loading);
+  const continuingExternalThreadId = useExternalThreadsStore(
+    (s) => s.continuingId,
+  );
+  const hydrateExternalThreads = useExternalThreadsStore((s) => s.hydrate);
+  const continueExternalThread = useExternalThreadsStore(
+    (s) => s.continueThread,
+  );
 
   const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
   // Goal mode is offered for Codex (version-gated `goalMode` capability) and
@@ -171,6 +201,10 @@ export function ChatLanding() {
     return () => clearDraft();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFolderId]);
+
+  useEffect(() => {
+    void hydrateExternalThreads();
+  }, [hydrateExternalThreads]);
 
   const headline = selectedFolder
     ? `What should we build in ${selectedFolder.name}?`
@@ -313,6 +347,13 @@ export function ChatLanding() {
           </p>
         )}
 
+        <ContinueThreadsSection
+          threads={externalThreads}
+          loading={externalThreadsLoading}
+          continuingId={continuingExternalThreadId}
+          onContinue={(thread) => void continueExternalThread(thread)}
+        />
+
         <div className="flex justify-center">
           <ProjectPicker
             folders={folders}
@@ -324,6 +365,160 @@ export function ChatLanding() {
         </div>
       </div>
     </div>
+  );
+}
+
+function ContinueThreadsSection({
+  threads,
+  loading,
+  continuingId,
+  onContinue,
+}: {
+  threads: ReturnType<typeof useExternalThreadsStore.getState>["threads"];
+  loading: boolean;
+  continuingId: string | null;
+  onContinue: (
+    thread: ReturnType<
+      typeof useExternalThreadsStore.getState
+    >["threads"][number],
+  ) => void;
+}) {
+  if (!loading && threads.length === 0) return null;
+  return (
+    <section className="mt-2 min-w-0">
+      <div className="mb-2 flex items-center justify-between gap-3 px-1">
+        <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <span>Continue Threads</span>
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] tracking-normal text-muted-foreground">
+            {loading && threads.length === 0 ? "..." : threads.length}
+          </span>
+        </div>
+      </div>
+      <div className="flex gap-3 overflow-x-auto pb-1">
+        {loading && threads.length === 0
+          ? Array.from({ length: 3 }).map((_, index) => (
+              <ContinueThreadSkeleton
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+              />
+            ))
+          : threads.map((thread) => {
+              const disabled = !thread.available || continuingId !== null;
+              const active = continuingId === thread.id;
+              return (
+                <button
+                  type="button"
+                  key={thread.id}
+                  disabled={disabled}
+                  onClick={() => onContinue(thread)}
+                  title={
+                    thread.available
+                      ? thread.projectPath
+                      : `${thread.projectPath || "Project folder"} is missing`
+                  }
+                  className={cn(
+                    "group min-w-[17.5rem] max-w-[19rem] text-left outline-none transition-transform focus-visible:rounded-lg focus-visible:ring-2 focus-visible:ring-ring",
+                    !disabled && "hover:-translate-y-px",
+                    disabled &&
+                      "cursor-default hover:translate-y-0",
+                  )}
+                >
+                  <Frame
+                    className={cn(
+                      "h-40 min-w-[17.5rem] overflow-hidden bg-muted/50 p-1 transition-colors",
+                      !thread.available && "opacity-55",
+                    )}
+                  >
+                    <FrameHeader className="flex-row items-center justify-between gap-2 px-3 py-1.5">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground shadow-xs/5">
+                          <ProviderIcon
+                            providerId={thread.providerId}
+                            className="size-4"
+                          />
+                        </span>
+                        <FrameTitle className="truncate text-[11px] font-medium text-muted-foreground">
+                          {providerThreadLabel(thread.providerId)}
+                        </FrameTitle>
+                      </div>
+                      {active ? (
+                        <Spinner className="size-3.5 shrink-0 text-muted-foreground" />
+                      ) : (
+                        <span className="shrink-0 text-[11px] text-muted-foreground">
+                          {formatThreadRelative(thread.updatedAt)}
+                        </span>
+                      )}
+                    </FrameHeader>
+                    <FramePanel
+                      className={cn(
+                        "min-h-0 flex-1 overflow-hidden px-3 py-2 transition-colors",
+                        !disabled &&
+                          "group-hover:border-border group-hover:bg-muted/20",
+                      )}
+                    >
+                      <div className="min-w-0">
+                        <div className="line-clamp-2 text-[13px] font-medium leading-snug text-foreground">
+                          {thread.title}
+                        </div>
+                        <div className="mt-1.5 line-clamp-2 text-[12px] leading-snug text-muted-foreground">
+                          {thread.preview}
+                        </div>
+                      </div>
+                    </FramePanel>
+                    <FrameFooter className="flex min-w-0 items-center justify-between gap-2 px-3 py-2 text-[11px] text-muted-foreground">
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <HugeiconsIcon
+                          icon={Folder01Icon}
+                          className="size-3.5 shrink-0"
+                        />
+                        <span className="truncate">
+                          {thread.projectName}
+                        </span>
+                      </span>
+                      {!thread.available && (
+                        <span className="shrink-0 rounded bg-destructive/10 px-1.5 py-0.5 text-[10px] text-destructive">
+                          Missing
+                        </span>
+                      )}
+                    </FrameFooter>
+                  </Frame>
+                </button>
+              );
+            })}
+      </div>
+    </section>
+  );
+}
+
+function providerThreadLabel(providerId: ProviderId): string {
+  if (providerId === "claude") return "Claude Code";
+  if (providerId === "codex") return "Codex";
+  return PROVIDER_LABEL[providerId] ?? providerId;
+}
+
+function ContinueThreadSkeleton() {
+  return (
+    <Frame className="h-40 min-w-[17.5rem] bg-muted/50 p-1">
+      <FrameHeader className="flex-row items-center justify-between gap-2 px-3 py-1.5">
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="size-7 rounded-md" />
+          <Skeleton className="h-3 w-14" />
+        </div>
+        <Skeleton className="h-3 w-8" />
+      </FrameHeader>
+      <FramePanel className="min-h-0 flex-1 px-3 py-2">
+        <div>
+          <Skeleton className="h-4 w-48" />
+          <Skeleton className="mt-2 h-4 w-36" />
+          <Skeleton className="mt-3 h-3 w-52" />
+          <Skeleton className="mt-1.5 h-3 w-40" />
+        </div>
+      </FramePanel>
+      <FrameFooter className="flex items-center gap-1.5 px-3 py-2">
+        <Skeleton className="size-3.5" />
+        <Skeleton className="h-3 w-24" />
+      </FrameFooter>
+    </Frame>
   );
 }
 

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -112,7 +112,10 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     }
     return false;
   });
-  const setupActive = worktreeSetupActive || session?.status === "booting";
+  const externalResume =
+    session !== null && session.resumeStrategy !== "none";
+  const setupActive =
+    worktreeSetupActive || (!externalResume && session?.status === "booting");
   const archiveProgress = useChatsStore((s) =>
     session?.chatId === undefined
       ? null

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -80,6 +80,8 @@ export function WorktreeSetupCard() {
   const worktreePending = ctx.status === "ready" && ctx.worktreePending;
   const setupStatus = worktree?.setupStatus ?? null;
   const setupDone = setupStatus === "succeeded" || setupStatus === "skipped";
+  const externalResume =
+    session !== null && session.resumeStrategy !== "none";
   const providerBooting = session?.status === "booting";
   const providerErrored = session?.status === "error";
 
@@ -88,7 +90,9 @@ export function WorktreeSetupCard() {
   // Once the provider errors we stop occupying the screen with a fake
   // "Starting…" spinner — the ErrorBubble below carries the failure + the
   // inline "Sign in" CTA — so a worktree-less errored session hides the card.
-  const visible = (hasWorktree && !setupDone) || providerBooting === true;
+  const visible =
+    !externalResume &&
+    ((hasWorktree && !setupDone) || providerBooting === true);
   if (!visible) return null;
 
   const providerLabel: string =

--- a/apps/renderer/src/store/external-threads.ts
+++ b/apps/renderer/src/store/external-threads.ts
@@ -1,0 +1,132 @@
+import { Effect } from "effect";
+import { create } from "zustand";
+
+import type { ExternalThread } from "@zuse/wire";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
+import { formatError } from "../lib/format-error.ts";
+import { useChatsStore } from "./chats.ts";
+import { useMessagesStore } from "./messages.ts";
+import { useSessionsStore } from "./sessions.ts";
+import { useWorktreesStore } from "./worktrees.ts";
+import { useWorkspaceStore } from "./workspace.ts";
+
+type ExternalThreadsState = {
+  readonly threads: ReadonlyArray<ExternalThread>;
+  readonly loading: boolean;
+  readonly continuingId: string | null;
+  readonly error: string | null;
+  readonly hydrate: () => Promise<void>;
+  readonly continueThread: (thread: ExternalThread) => Promise<boolean>;
+};
+
+export const useExternalThreadsStore = create<ExternalThreadsState>(
+  (set, get) => ({
+    threads: [],
+    loading: false,
+    continuingId: null,
+    error: null,
+    hydrate: async () => {
+      if (get().loading) return;
+      set({ loading: true, error: null });
+      try {
+        const client = await getRpcClient();
+        const threads = await Effect.runPromise(
+          client.externalThreads.list({ limit: 12 }),
+        );
+        set({ threads, loading: false });
+      } catch (err) {
+        set({ error: formatError(err), loading: false });
+      }
+    },
+    continueThread: async (thread) => {
+      if (!thread.available || get().continuingId !== null) return false;
+      set({ continuingId: thread.id, error: null });
+      try {
+        const client = await getRpcClient();
+        const result = await Effect.runPromise(
+          client.externalThreads.continue({
+            providerId: thread.providerId,
+            cursor: thread.cursor,
+            projectPath: thread.projectPath,
+            title: thread.title,
+            sourcePath: thread.sourcePath,
+          }),
+        );
+        useWorkspaceStore.setState((s) => ({
+          folders: s.folders.some((folder) => folder.id === result.project.id)
+            ? s.folders
+            : [...s.folders, result.project],
+          selectedFolderId: result.project.id,
+        }));
+        if (result.messages.length > 0) {
+          useMessagesStore.setState((s) => ({
+            messagesBySession: {
+              ...s.messagesBySession,
+              [result.session.id]: result.messages,
+            },
+          }));
+        }
+        const continuedWorktree = result.worktree;
+        if (continuedWorktree !== null) {
+          useWorktreesStore.setState((s) => {
+            const existing = s.byProject[result.project.id] ?? [];
+            return {
+              byProject: {
+                ...s.byProject,
+                [result.project.id]: existing.some(
+                  (worktree) => worktree.id === continuedWorktree.id,
+                )
+                  ? existing
+                  : [continuedWorktree, ...existing],
+              },
+            };
+          });
+        }
+        await useWorkspaceStore.getState().select(result.project.id);
+        useChatsStore.setState((s) => {
+          const existing = s.chatsByProject[result.project.id] ?? [];
+          return {
+            chatsByProject: {
+              ...s.chatsByProject,
+              [result.project.id]: existing.some(
+                (chat) => chat.id === result.chat.id,
+              )
+                ? existing
+                : [result.chat, ...existing],
+            },
+            selectedChatId: result.chat.id,
+            selectedChatByProject: {
+              ...s.selectedChatByProject,
+              [result.project.id]: result.chat.id,
+            },
+          };
+        });
+        useSessionsStore.setState((s) => {
+          const existing = s.sessionsByProject[result.project.id] ?? [];
+          return {
+            sessionsByProject: {
+              ...s.sessionsByProject,
+              [result.project.id]: existing.some(
+                (session) => session.id === result.session.id,
+              )
+                ? existing
+                : [result.session, ...existing],
+            },
+            selectedSessionId: result.session.id,
+            selectedSessionByProject: {
+              ...s.selectedSessionByProject,
+              [result.project.id]: result.session.id,
+            },
+          };
+        });
+        useChatsStore.getState().select(result.chat.id);
+        set({ continuingId: null });
+        return true;
+      } catch (err) {
+        set({ error: formatError(err), continuingId: null });
+        return false;
+      }
+    },
+  }),
+);

--- a/apps/server/src/external-thread/handlers.ts
+++ b/apps/server/src/external-thread/handlers.ts
@@ -1,0 +1,16 @@
+import { MemoizeRpcs } from "@zuse/wire";
+import { Effect, Layer } from "effect";
+
+import { ExternalThreadService } from "./services/external-thread-service.ts";
+
+const List = MemoizeRpcs.toLayerHandler("externalThreads.list", ({ limit }) =>
+  Effect.flatMap(ExternalThreadService, (svc) => svc.list(limit ?? 12)),
+);
+
+const Continue = MemoizeRpcs.toLayerHandler(
+  "externalThreads.continue",
+  (input) =>
+    Effect.flatMap(ExternalThreadService, (svc) => svc.continueThread(input)),
+);
+
+export const ExternalThreadHandlersLayer = Layer.mergeAll(List, Continue);

--- a/apps/server/src/external-thread/layers/external-thread-service.ts
+++ b/apps/server/src/external-thread/layers/external-thread-service.ts
@@ -1,0 +1,734 @@
+import { CommandExecutor } from "@effect/platform";
+import { SqlClient } from "@effect/sql";
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { Effect, Layer } from "effect";
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import {
+  ContinueExternalThreadResult,
+  defaultModelFor,
+  ExternalThread,
+  type AgentEvent,
+  type Folder,
+  type Message,
+  type MessageContent,
+  type ProviderId,
+  type Worktree,
+  WorktreeId,
+} from "@zuse/wire";
+
+import { resolveCliPath } from "../../provider/availability.ts";
+import { CodexAppServerClient } from "../../provider/codex-app-server-client.ts";
+import type { ThreadListResponse } from "../../provider/codex-app-protocol/v2/ThreadListResponse.ts";
+import type { ThreadReadResponse } from "../../provider/codex-app-protocol/v2/ThreadReadResponse.ts";
+import type { UserInput } from "../../provider/codex-app-protocol/v2/UserInput.ts";
+import { translateClaudeSdkMessages } from "../../provider/drivers/claude.ts";
+import { translateCodexItem } from "../../provider/drivers/codex.ts";
+import { MessageStore } from "../../provider/services/message-store.ts";
+import { WorktreeService } from "../../worktree/services/worktree-service.ts";
+import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
+import { ExternalThreadService } from "../services/external-thread-service.ts";
+
+type DiscoveredThread = {
+  readonly id: string;
+  readonly providerId: "claude" | "codex";
+  readonly title: string;
+  readonly preview: string;
+  readonly projectPath: string;
+  readonly updatedAt: Date;
+  readonly sourcePath: string | null;
+  readonly cursor: string;
+  readonly resumeStrategy: "claude-session-id" | "codex-thread-id";
+};
+
+const clamp = (value: string, max: number): string => {
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+
+const firstString = (...values: ReadonlyArray<unknown>): string | null => {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+};
+
+const contentText = (value: unknown): string | null => {
+  if (typeof value === "string") return value.trim() || null;
+  if (Array.isArray(value)) {
+    const text = value
+      .flatMap((item) => {
+        const record = asRecord(item);
+        if (record === null) return [];
+        const type = firstString(record["type"])?.toLowerCase() ?? "";
+        if (type.length > 0 && type !== "text") return [];
+        const text = firstString(record["text"]);
+        return text === null ? [] : [text];
+      })
+      .join("\n")
+      .trim();
+    return text.length > 0 ? text : null;
+  }
+  const record = asRecord(value);
+  if (record !== null) {
+    return contentText(record["content"]) ?? firstString(record["text"]);
+  }
+  return null;
+};
+
+const rowMessage = (
+  row: Record<string, unknown>,
+): Record<string, unknown> | null => asRecord(row["message"]);
+
+const rowRole = (row: Record<string, unknown>): string => {
+  const message = rowMessage(row);
+  return (
+    firstString(row["role"], message?.["role"], row["type"])?.toLowerCase() ??
+    ""
+  );
+};
+
+const rowText = (row: Record<string, unknown>): string | null => {
+  const message = rowMessage(row);
+  return (
+    contentText(message?.["content"]) ??
+    contentText(row["content"]) ??
+    firstString(row["text"])
+  );
+};
+
+const isSystemLikeText = (text: string): boolean =>
+  text.includes("<system_instruction>") ||
+  text.includes("<task-notification>") ||
+  text.startsWith("You are working inside ");
+
+const isMeaningfulConversationText = (
+  row: Record<string, unknown>,
+  text: string,
+): boolean => {
+  const type = firstString(row["type"])?.toLowerCase() ?? "";
+  const role = rowRole(row);
+  return (
+    !isSystemLikeText(text) &&
+    type !== "queue-operation" &&
+    type !== "attachment" &&
+    type !== "last-prompt" &&
+    (role === "user" || role === "assistant")
+  );
+};
+
+const projectPathFromText = (text: string): string | null => {
+  const match = text.match(
+    /work should take place in the ([^\n]+?) directory/i,
+  );
+  return match?.[1]?.trim() ?? null;
+};
+
+const fallbackProjectPathFromClaudeDir = (dirName: string): string | null => {
+  if (!dirName.startsWith("-")) return null;
+  const decoded = `/${dirName.slice(1).replaceAll("-", "/")}`;
+  return decoded.length > 1 ? decoded : null;
+};
+
+const parseJsonLines = (
+  file: string,
+): ReadonlyArray<Record<string, unknown>> => {
+  try {
+    return readFileSync(file, "utf8")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          const parsed = JSON.parse(line);
+          const record = asRecord(parsed);
+          return record === null ? [] : [record];
+        } catch {
+          return [];
+        }
+      });
+  } catch {
+    return [];
+  }
+};
+
+export const discoverClaudeThreads = (
+  root = path.join(homedir(), ".claude", "projects"),
+): ReadonlyArray<DiscoveredThread> => {
+  if (!existsSync(root)) return [];
+  const out: DiscoveredThread[] = [];
+  for (const projectDir of readdirSync(root, { withFileTypes: true })) {
+    if (!projectDir.isDirectory()) continue;
+    const dirPath = path.join(root, projectDir.name);
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      const sourcePath = path.join(dirPath, entry.name);
+      const rows = parseJsonLines(sourcePath);
+      if (rows.length === 0) continue;
+      const stat = statSync(sourcePath);
+      let sessionId = entry.name.replace(/\.jsonl$/, "");
+      let title: string | null = null;
+      let preview: string | null = null;
+      let projectPath: string | null = null;
+      let updatedAt = stat.mtime;
+
+      for (const row of rows) {
+        sessionId = firstString(row["sessionId"], sessionId) ?? sessionId;
+        title = title ?? firstString(row["aiTitle"], row["summary"]);
+        const timestamp = firstString(row["timestamp"], row["created_at"]);
+        if (timestamp !== null) {
+          const parsed = new Date(timestamp);
+          if (!Number.isNaN(parsed.getTime()) && parsed > updatedAt) {
+            updatedAt = parsed;
+          }
+        }
+        const cwd = firstString(row["cwd"]);
+        if (cwd !== null) projectPath = cwd;
+        const content = rowText(row);
+        if (content !== null) {
+          projectPath = projectPath ?? projectPathFromText(content);
+          if (preview === null && isMeaningfulConversationText(row, content)) {
+            preview = content;
+          }
+        }
+      }
+
+      projectPath =
+        projectPath ?? fallbackProjectPathFromClaudeDir(projectDir.name);
+      if (projectPath === null) continue;
+      const finalPreview = preview ?? title ?? "Claude Code conversation";
+      out.push({
+        id: `claude:${sessionId}`,
+        providerId: "claude",
+        title: clamp(title ?? finalPreview, 96),
+        preview: clamp(finalPreview, 140),
+        projectPath,
+        updatedAt,
+        sourcePath,
+        cursor: sessionId,
+        resumeStrategy: "claude-session-id",
+      });
+    }
+  }
+  return out;
+};
+
+const discoverCodexViaAppServer = (limit: number) =>
+  Effect.gen(function* () {
+    const codexPath = yield* resolveCliPath("codex");
+    if (codexPath === null) return [] as ReadonlyArray<DiscoveredThread>;
+    const app = yield* Effect.tryPromise({
+      try: () =>
+        CodexAppServerClient.start({
+          codexPath,
+          onNotification: () => {},
+          onServerRequest: (_request, respond) => respond(null),
+        }),
+      catch: () => null,
+    });
+    if (app === null) return [] as ReadonlyArray<DiscoveredThread>;
+    try {
+      const response = yield* Effect.tryPromise({
+        try: () =>
+          app.request<ThreadListResponse>("thread/list", {
+            limit,
+            sortKey: "updated_at",
+            sortDirection: "desc",
+            archived: false,
+          }),
+        catch: () => null,
+      });
+      if (response === null) return [] as ReadonlyArray<DiscoveredThread>;
+      return response.data
+        .filter((thread) => thread.cwd.length > 0)
+        .map(
+          (thread): DiscoveredThread => ({
+            id: `codex:${thread.id}`,
+            providerId: "codex",
+            title: clamp(
+              thread.name ?? thread.preview ?? "Codex conversation",
+              96,
+            ),
+            preview: clamp(
+              thread.preview ?? thread.name ?? "Codex conversation",
+              140,
+            ),
+            projectPath: thread.cwd,
+            updatedAt: new Date(thread.updatedAt * 1000),
+            sourcePath: thread.path,
+            cursor: thread.id,
+            resumeStrategy: "codex-thread-id",
+          }),
+        );
+    } finally {
+      app.close();
+    }
+  });
+
+const discoverCodexFromIndex = (): ReadonlyArray<DiscoveredThread> => {
+  const file = path.join(homedir(), ".codex", "session_index.jsonl");
+  if (!existsSync(file)) return [];
+  return parseJsonLines(file).flatMap(
+    (row): ReadonlyArray<DiscoveredThread> => {
+      const id = firstString(row["id"]);
+      if (id === null) return [];
+      const title = firstString(row["thread_name"]) ?? "Codex conversation";
+      const updated = firstString(row["updated_at"]);
+      const updatedAt =
+        updated === null || Number.isNaN(new Date(updated).getTime())
+          ? new Date(0)
+          : new Date(updated);
+      return [
+        {
+          id: `codex:${id}`,
+          providerId: "codex",
+          title: clamp(title, 96),
+          preview: clamp(title, 140),
+          projectPath: "",
+          updatedAt,
+          sourcePath: file,
+          cursor: id,
+          resumeStrategy: "codex-thread-id",
+        },
+      ];
+    },
+  );
+};
+
+export const claudeTranscriptMessages = (
+  sourcePath: string | null | undefined,
+): ReadonlyArray<MessageContent> => {
+  if (sourcePath === null || sourcePath === undefined) return [];
+  return parseJsonLines(sourcePath).flatMap(
+    (row): ReadonlyArray<MessageContent> => {
+      const message = rowMessage(row);
+      const content = rowText(row);
+      if (message !== null && rowRole(row) !== "user") {
+        return translateClaudeSdkMessages([row as unknown as SDKMessage])
+          .flatMap((event) => {
+            const translated = agentEventToMessageContent(event);
+            return translated === null ? [] : [translated];
+          });
+      }
+      if (
+        message !== null &&
+        rowRole(row) === "user" &&
+        Array.isArray(message["content"]) &&
+        message["content"].some(
+          (block) => asRecord(block)?.["type"] === "tool_result",
+        )
+      ) {
+        return translateClaudeSdkMessages([row as unknown as SDKMessage])
+          .flatMap((event) => {
+            const translated = agentEventToMessageContent(event);
+            return translated === null ? [] : [translated];
+          });
+      }
+      if (content === null || !isMeaningfulConversationText(row, content)) {
+        return [];
+      }
+      const role = rowRole(row);
+      if (role === "user" || role === "human") {
+        return [{ _tag: "user", text: content, goal: false }];
+      }
+      if (role === "assistant") {
+        return [{ _tag: "assistant", text: content }];
+      }
+      return [];
+    },
+  );
+};
+
+const codexUserInputText = (input: UserInput): string | null => {
+  switch (input.type) {
+    case "text":
+      return input.text.trim() || null;
+    case "mention":
+      return `@${input.name}`;
+    case "skill":
+      return `/${input.name}`;
+    case "image":
+      return `[image](${input.url})`;
+    case "localImage":
+      return `[image](${input.path})`;
+  }
+};
+
+const agentEventToMessageContent = (
+  event: AgentEvent,
+): MessageContent | null => {
+  switch (event._tag) {
+    case "AssistantMessage":
+      return {
+        _tag: "assistant",
+        text: event.text,
+        parentItemId: event.parentItemId,
+      };
+    case "Thinking":
+      return {
+        _tag: "thinking",
+        itemId: event.itemId,
+        text: event.text,
+        redacted: event.redacted,
+        parentItemId: event.parentItemId,
+      };
+    case "ToolUse":
+      return {
+        _tag: "tool_use",
+        itemId: event.itemId,
+        tool: event.tool,
+        input: event.input,
+        parentItemId: event.parentItemId,
+      };
+    case "ToolResult":
+      return {
+        _tag: "tool_result",
+        itemId: event.itemId,
+        output: event.output,
+        isError: event.isError,
+        parentItemId: event.parentItemId,
+      };
+    case "SubagentSummary":
+      return {
+        _tag: "subagent_summary",
+        itemId: event.itemId,
+        agentName: event.agentName,
+        model: event.model,
+        turns: event.turns,
+        durationMs: event.durationMs,
+        summary: event.summary,
+        isError: event.isError,
+      };
+    case "UsageDelta":
+      return {
+        _tag: "usage",
+        parentItemId: event.parentItemId,
+        inputTokens: event.inputTokens,
+        outputTokens: event.outputTokens,
+        cacheReadTokens: event.cacheReadTokens,
+        cacheCreationTokens: event.cacheCreationTokens,
+        model: event.model,
+      };
+    case "ContextUsage":
+      return {
+        _tag: "context_usage",
+        providerId: event.providerId,
+        usedTokens: event.usedTokens,
+        windowTokens: event.windowTokens,
+        precision: event.precision,
+        source: event.source,
+      };
+    case "ContextCompaction":
+      return {
+        _tag: "context_compaction",
+        itemId: event.itemId,
+        providerId: event.providerId,
+        startedAt: event.startedAt,
+        durationMs: event.durationMs,
+        beforeTokens: event.beforeTokens,
+        afterTokens: event.afterTokens,
+        status: event.status,
+      };
+    case "UsageLimit":
+      return {
+        _tag: "usage_limit",
+        providerId: event.providerId,
+        label: event.label,
+        usedPercent: event.usedPercent,
+        resetsAt: event.resetsAt,
+        windowMinutes: event.windowMinutes,
+      };
+    case "UserQuestion":
+      return {
+        _tag: "user_question",
+        itemId: event.itemId,
+        questions: event.questions,
+        parentItemId: event.parentItemId,
+      };
+    case "Error":
+      return { _tag: "error", message: event.message };
+    case "Interrupted":
+      return { _tag: "interrupted" };
+    default:
+      return null;
+  }
+};
+
+const codexTranscriptMessages = (cursor: string) =>
+  Effect.gen(function* () {
+    const codexPath = yield* resolveCliPath("codex");
+    if (codexPath === null) return [];
+    const app = yield* Effect.tryPromise({
+      try: () =>
+        CodexAppServerClient.start({
+          codexPath,
+          onNotification: () => {},
+          onServerRequest: (_request, respond) => respond(null),
+        }),
+      catch: () => null,
+    });
+    if (app === null) return [];
+    try {
+      const response = yield* Effect.tryPromise({
+        try: () =>
+          app.request<ThreadReadResponse>("thread/read", {
+            threadId: cursor,
+            includeTurns: true,
+          }),
+        catch: () => null,
+      });
+      if (response === null) return [];
+      const out: MessageContent[] = [];
+      for (const turn of response.thread.turns) {
+        for (const item of turn.items) {
+          if (item.type === "userMessage") {
+            const text = item.content
+              .flatMap((input) => {
+                const fragment = codexUserInputText(input);
+                return fragment === null ? [] : [fragment];
+              })
+              .join("\n")
+              .trim();
+            if (text.length > 0) {
+              out.push({ _tag: "user", text, goal: false });
+            }
+            continue;
+          }
+          for (const event of translateCodexItem(item, "completed")) {
+            const content = agentEventToMessageContent(event);
+            if (content !== null) out.push(content);
+          }
+        }
+        if (turn.status === "failed" && turn.error !== null) {
+          out.push({
+            _tag: "error",
+            message: turn.error.message,
+          });
+        }
+      }
+      return out;
+    } finally {
+      app.close();
+    }
+  }).pipe(Effect.catchAll(() => Effect.succeed([])));
+
+const toExternalThread = (thread: DiscoveredThread): ExternalThread =>
+  ExternalThread.make({
+    ...thread,
+    projectName:
+      thread.projectPath.length > 0
+        ? path.basename(thread.projectPath)
+        : "Unknown project",
+    available: thread.projectPath.length > 0 && existsSync(thread.projectPath),
+  });
+
+const findOrAddProject = (
+  workspace: WorkspaceService["Type"],
+  worktrees: WorktreeService["Type"],
+  sql: SqlClient.SqlClient,
+  projectPath: string,
+): Effect.Effect<
+  {
+    readonly project: Folder;
+    readonly worktreeId: WorktreeId | null;
+    readonly worktree: Worktree | null;
+  },
+  unknown
+> =>
+  Effect.gen(function* () {
+    const resolved = path.resolve(projectPath);
+    const folders = yield* workspace.list();
+    for (const folder of folders) {
+      const knownWorktrees = yield* worktrees.list(folder.id);
+      const known = knownWorktrees.find(
+        (wt) => path.resolve(wt.path) === resolved,
+      );
+      if (known !== undefined) {
+        return { project: folder, worktreeId: known.id, worktree: known };
+      }
+    }
+
+    const externalCommonDir = gitCommonDir(resolved);
+    const externalGitDir = gitDir(resolved);
+    const isLinkedWorktree =
+      externalCommonDir !== null &&
+      externalGitDir !== null &&
+      externalCommonDir !== externalGitDir;
+    if (externalCommonDir !== null && isLinkedWorktree) {
+      for (const folder of folders) {
+        const folderCommonDir = gitCommonDir(folder.path);
+        if (
+          folderCommonDir !== null &&
+          folderCommonDir === externalCommonDir &&
+          path.resolve(folder.path) !== resolved
+        ) {
+          const worktreeId = yield* registerExistingWorktree(
+            sql,
+            folder,
+            resolved,
+          );
+          const worktree = yield* worktrees.get(worktreeId);
+          return { project: folder, worktreeId, worktree };
+        }
+      }
+    }
+
+    const existing = folders.find((folder) => folder.path === resolved);
+    if (existing !== undefined) {
+      return { project: existing, worktreeId: null, worktree: null };
+    }
+
+    const project = yield* workspace.add(resolved);
+    return { project, worktreeId: null, worktree: null };
+  });
+
+const gitOutput = (cwd: string, args: ReadonlyArray<string>): string | null => {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+};
+
+const gitCommonDir = (cwd: string): string | null => {
+  const out = gitOutput(cwd, [
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-common-dir",
+  ]);
+  return out === null || out.length === 0 ? null : path.resolve(out);
+};
+
+const gitDir = (cwd: string): string | null => {
+  const out = gitOutput(cwd, [
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-dir",
+  ]);
+  return out === null || out.length === 0 ? null : path.resolve(out);
+};
+
+const gitBranch = (cwd: string): string =>
+  gitOutput(cwd, ["branch", "--show-current"]) ||
+  gitOutput(cwd, ["rev-parse", "--short", "HEAD"]) ||
+  "HEAD";
+
+const registerExistingWorktree = (
+  sql: SqlClient.SqlClient,
+  project: Folder,
+  worktreePath: string,
+): Effect.Effect<WorktreeId> =>
+  Effect.gen(function* () {
+    const existing = yield* sql<{ readonly id: string }>`
+      SELECT id FROM worktrees WHERE path = ${worktreePath} LIMIT 1
+    `.pipe(Effect.orDie);
+    if (existing.length > 0) return WorktreeId.make(existing[0]!.id);
+
+    const id = WorktreeId.make(crypto.randomUUID());
+    const name = path.basename(worktreePath) || gitBranch(worktreePath);
+    const branch = gitBranch(worktreePath);
+    const nowIso = new Date().toISOString();
+    yield* sql`
+      INSERT INTO worktrees
+        (id, project_id, path, name, branch, base_branch, created_at,
+         setup_status, setup_output)
+      VALUES
+        (${id}, ${project.id}, ${worktreePath}, ${name}, ${branch}, 'HEAD',
+         ${nowIso}, 'skipped', '')
+    `.pipe(Effect.orDie);
+    return id;
+  });
+
+export const ExternalThreadServiceLive = Layer.effect(
+  ExternalThreadService,
+  Effect.gen(function* () {
+    const executor = yield* CommandExecutor.CommandExecutor;
+    const sql = yield* SqlClient.SqlClient;
+    const workspace = yield* WorkspaceService;
+    const worktrees = yield* WorktreeService;
+    const messages = yield* MessageStore;
+
+    const list: ExternalThreadService["Type"]["list"] = (limit) =>
+      Effect.gen(function* () {
+        const codex = yield* discoverCodexViaAppServer(limit).pipe(
+          Effect.provideService(CommandExecutor.CommandExecutor, executor),
+          Effect.catchAll(() => Effect.succeed(discoverCodexFromIndex())),
+        );
+        const codexRows = codex.length > 0 ? codex : discoverCodexFromIndex();
+        const rows = [...discoverClaudeThreads(), ...codexRows]
+          .map(toExternalThread)
+          .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+        return rows.slice(0, limit);
+      });
+
+    const continueThread: ExternalThreadService["Type"]["continueThread"] = (
+      input,
+    ) =>
+      Effect.gen(function* () {
+        const providerId = input.providerId as ProviderId;
+        const binding = yield* findOrAddProject(
+          workspace,
+          worktrees,
+          sql,
+          input.projectPath,
+        ).pipe(Effect.orDie);
+        const resumeStrategy =
+          providerId === "claude" ? "claude-session-id" : "codex-thread-id";
+        const title =
+          input.title?.trim() ||
+          `${providerId === "claude" ? "Claude" : "Codex"} thread`;
+        const result = yield* messages
+          .continueExternalThread({
+            projectId: binding.project.id,
+            worktreeId: binding.worktreeId,
+            providerId,
+            model: defaultModelFor(providerId),
+            title,
+            resumeCursor: input.cursor,
+            resumeStrategy,
+          })
+          .pipe(Effect.orDie);
+        let importedMessages: ReadonlyArray<Message> = [];
+        if (providerId === "claude") {
+          const imported = claudeTranscriptMessages(input.sourcePath);
+          if (imported.length > 0) {
+            importedMessages = yield* messages
+              .importExternalMessages(result.initialSession.id, imported)
+              .pipe(Effect.orDie);
+          }
+        } else if (providerId === "codex") {
+          const imported = yield* codexTranscriptMessages(input.cursor).pipe(
+            Effect.provideService(CommandExecutor.CommandExecutor, executor),
+          );
+          if (imported.length > 0) {
+            importedMessages = yield* messages
+              .importExternalMessages(result.initialSession.id, imported)
+              .pipe(Effect.orDie);
+          }
+        }
+        return ContinueExternalThreadResult.make({
+          project: binding.project,
+          worktree: binding.worktree,
+          chat: result.chat,
+          session: result.initialSession,
+          messages: importedMessages,
+        });
+      });
+
+    return { list, continueThread } as const;
+  }),
+);

--- a/apps/server/src/external-thread/services/external-thread-service.ts
+++ b/apps/server/src/external-thread/services/external-thread-service.ts
@@ -1,0 +1,20 @@
+import { Context, type Effect } from "effect";
+
+import type {
+  ContinueExternalThreadInput,
+  ContinueExternalThreadResult,
+  ExternalThread,
+} from "@zuse/wire";
+
+export interface ExternalThreadServiceShape {
+  readonly list: (
+    limit: number,
+  ) => Effect.Effect<ReadonlyArray<ExternalThread>>;
+  readonly continueThread: (
+    input: ContinueExternalThreadInput,
+  ) => Effect.Effect<ContinueExternalThreadResult>;
+}
+
+export class ExternalThreadService extends Context.Tag(
+  "memoize/ExternalThreadService",
+)<ExternalThreadService, ExternalThreadServiceShape>() {}

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -5,6 +5,7 @@ import { AuthHandlersLayer } from "./auth/handlers.ts";
 import { CodeIndexHandlersLayer } from "./code-index/handlers.ts";
 import { ConfigStoreHandlersLayer } from "./config-store/handlers.ts";
 import { DiagnosticsHandlersLayer } from "./diagnostics/handlers.ts";
+import { ExternalThreadHandlersLayer } from "./external-thread/handlers.ts";
 import { FsHandlersLayer } from "./fs/handlers.ts";
 import { GitHandlersLayer } from "./git/handlers.ts";
 import { PingHandlersLayer } from "./ping/handlers.ts";
@@ -40,4 +41,5 @@ export const HandlersLayer = Layer.mergeAll(
   PokemonHandlersLayer,
   UsageHandlersLayer,
   DiagnosticsHandlersLayer,
+  ExternalThreadHandlersLayer,
 );

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -185,8 +185,7 @@ export const selectCliPathCandidate = (
   // managed binary.
   return (
     candidates.find(
-      (candidate) =>
-        !isManagedCodexShimPath(normalizeCommandPath(candidate)),
+      (candidate) => !isManagedCodexShimPath(normalizeCommandPath(candidate)),
     ) ?? null
   );
 };
@@ -437,8 +436,10 @@ const isHomebrewPath = (p: string): boolean =>
   p.startsWith("/usr/local/bin/");
 
 const isManagedCodexShimPath = (p: string): boolean =>
-  p.endsWith("/application support/com.conductor.app/bin/codex") ||
-  (p.includes("/application support/com.conductor.app/agent-binaries/codex/") &&
+  p.endsWith("/application support/app.memoize.desktop/bin/codex") ||
+  (p.includes(
+    "/application support/app.memoize.desktop/agent-binaries/codex/",
+  ) &&
     p.endsWith("/codex"));
 
 // A plain `npm i -g <pkg>@latest` re-install fails with ENOTEMPTY during npm's

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -976,6 +976,13 @@ const translate = (
   return [];
 };
 
+export const translateClaudeSdkMessages = (
+  messages: ReadonlyArray<SDKMessage>,
+): ReadonlyArray<AgentEvent> => {
+  const state = newTranslateState();
+  return messages.flatMap((message) => translate(message, state));
+};
+
 /**
  * Tools the agent can run without a prompt. These are pure reads or
  * internal-state tools (`TodoWrite`) with no observable blast radius. The

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -109,8 +109,18 @@ const CURSOR_LOG_PATH = ((): string => {
   }
 })();
 
+const safeStderrWrite = (line: string): void => {
+  if (!process.stderr.writable) return;
+  try {
+    process.stderr.write(line, () => {});
+  } catch {
+    // Stderr can be closed by Electron's parent process. Logging must not
+    // crash provider module initialization.
+  }
+};
+
 const writeCursorLog = (line: string): void => {
-  process.stderr.write(line);
+  safeStderrWrite(line);
   try {
     appendFileSync(CURSOR_LOG_PATH, line);
   } catch {
@@ -119,7 +129,7 @@ const writeCursorLog = (line: string): void => {
 };
 
 // One-time banner at module load so the user knows where to tail.
-process.stderr.write(`[cursor] phase logs → ${CURSOR_LOG_PATH}\n`);
+safeStderrWrite(`[cursor] phase logs → ${CURSOR_LOG_PATH}\n`);
 
 type PhaseLogger = (phase: string, detail?: string) => void;
 

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -32,6 +32,7 @@ import {
   type ProviderId,
   QueueState,
   QueuedMessage,
+  type ResumeStrategy,
   type RuntimeMode,
   Session,
   SessionId,
@@ -1397,6 +1398,9 @@ export const MessageStoreLive = Layer.scoped(
           input.initialPrompt !== undefined &&
           input.initialPrompt.trim().length > 0;
         const background = input.background === true;
+        const resumeCursor = input.resumeCursor ?? null;
+        const resumeStrategy: ResumeStrategy =
+          resumeCursor === null ? "none" : (input.resumeStrategy ?? "none");
         const postBootStatus: Session["status"] = hasInitial
           ? "running"
           : "idle";
@@ -1412,13 +1416,13 @@ export const MessageStoreLive = Layer.scoped(
             INSERT INTO sessions
               (id, project_id, title, provider_id, model, status, runtime_mode,
                agents_json, worktree_id, chat_id, permission_mode,
-               tool_search, created_at, updated_at)
+               tool_search, cursor, resume_strategy, created_at, updated_at)
             VALUES
               (${sessionId}, ${projectId}, ${title}, ${input.providerId},
                ${input.model}, ${rowStatus}, ${initialRuntimeMode},
                ${agentsJson}, ${worktreeId}, ${input.chatId},
                ${initialPermissionMode}, ${initialToolSearch ? 1 : 0},
-               ${nowIso}, ${nowIso})
+               ${resumeCursor}, ${resumeStrategy}, ${nowIso}, ${nowIso})
           `.pipe(Effect.orDie);
           yield* sql`
             UPDATE chats
@@ -1452,7 +1456,7 @@ export const MessageStoreLive = Layer.scoped(
                   permissionMode: initialPermissionMode,
                   toolSearch: initialToolSearch,
                 },
-                null,
+                resumeCursor,
                 newSessionRuntimeMode,
               )
               .pipe(
@@ -1490,8 +1494,8 @@ export const MessageStoreLive = Layer.scoped(
             model: input.model,
             status: "booting",
             archivedAt: null,
-            cursor: null,
-            resumeStrategy: "none",
+            cursor: resumeCursor,
+            resumeStrategy,
             runtimeMode: initialRuntimeMode,
             worktreeId,
             chatId: input.chatId,
@@ -1523,7 +1527,7 @@ export const MessageStoreLive = Layer.scoped(
               permissionMode: initialPermissionMode,
               toolSearch: initialToolSearch,
             },
-            null,
+            resumeCursor,
             newSessionRuntimeMode,
           )
           .pipe(
@@ -1543,13 +1547,13 @@ export const MessageStoreLive = Layer.scoped(
           INSERT INTO sessions
             (id, project_id, title, provider_id, model, status, runtime_mode,
              agents_json, worktree_id, chat_id, permission_mode,
-             tool_search, created_at, updated_at)
+             tool_search, cursor, resume_strategy, created_at, updated_at)
           VALUES
             (${sessionId}, ${projectId}, ${title}, ${input.providerId},
              ${input.model}, ${rowStatus}, ${initialRuntimeMode},
              ${agentsJson}, ${worktreeId}, ${input.chatId},
              ${initialPermissionMode}, ${initialToolSearch ? 1 : 0},
-             ${nowIso}, ${nowIso})
+             ${resumeCursor}, ${resumeStrategy}, ${nowIso}, ${nowIso})
         `.pipe(Effect.orDie);
         yield* sql`
           UPDATE chats
@@ -1572,8 +1576,8 @@ export const MessageStoreLive = Layer.scoped(
           model: input.model,
           status: postBootStatus,
           archivedAt: null,
-          cursor: null,
-          resumeStrategy: "none",
+          cursor: resumeCursor,
+          resumeStrategy,
           runtimeMode: initialRuntimeMode,
           worktreeId,
           chatId: input.chatId,
@@ -1897,6 +1901,8 @@ export const MessageStoreLive = Layer.scoped(
           enableSubagents: input.enableSubagents,
           permissionMode: input.permissionMode,
           toolSearch: input.toolSearch,
+          resumeCursor: input.resumeCursor,
+          resumeStrategy: input.resumeStrategy,
         }).pipe(
           Effect.tapError(() =>
             // Roll back the chat row if the provider failed to boot —
@@ -1943,6 +1949,32 @@ export const MessageStoreLive = Layer.scoped(
         }
         return { chat, initialSession, initialMessage };
       });
+
+    const continueExternalThread: MessageStoreShape["continueExternalThread"] =
+      (input) =>
+        Effect.gen(function* () {
+          const result = yield* createChat({
+            ...input,
+            resumeCursor: input.resumeCursor,
+            resumeStrategy: input.resumeStrategy,
+          });
+          return {
+            chat: result.chat,
+            initialSession: result.initialSession,
+          };
+        });
+
+    const importExternalMessages: MessageStoreShape["importExternalMessages"] =
+      (sessionId, messages) =>
+        Effect.gen(function* () {
+          yield* lookupSession(sessionId);
+          const imported: Message[] = [];
+          for (const content of messages) {
+            const persisted = yield* persistMessage(sessionId, content);
+            imported.push(persisted.message);
+          }
+          return imported;
+        });
 
     const renameChat: MessageStoreShape["renameChat"] = (chatId, title) =>
       Effect.gen(function* () {
@@ -3257,6 +3289,8 @@ export const MessageStoreLive = Layer.scoped(
       listChats,
       getChat,
       createChat,
+      continueExternalThread,
+      importExternalMessages,
       renameChat,
       markChatRead,
       streamChatChanges,

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -19,12 +19,14 @@ import type {
   FolderId,
   GoalUnsupportedError,
   Message,
+  MessageContent,
   MessageEnvelope,
   MessageId,
   PermissionMode,
   ProviderId,
   QueueState,
   QueuedMessage,
+  ResumeStrategy,
   RuntimeMode,
   Session,
   SessionAlreadyStartedError,
@@ -99,6 +101,8 @@ export interface CreateSessionInput {
    * timing is preserved.
    */
   readonly background?: boolean;
+  readonly resumeCursor?: string | null;
+  readonly resumeStrategy?: ResumeStrategy;
 }
 
 export interface CreateChatInput {
@@ -113,6 +117,8 @@ export interface CreateChatInput {
   readonly enableSubagents?: boolean;
   readonly permissionMode?: PermissionMode;
   readonly toolSearch?: boolean;
+  readonly resumeCursor?: string | null;
+  readonly resumeStrategy?: ResumeStrategy;
 }
 
 export interface MessageStoreShape {
@@ -231,6 +237,24 @@ export interface MessageStoreShape {
     },
     SessionStartError
   >;
+
+  readonly continueExternalThread: (
+    input: CreateChatInput & {
+      readonly resumeCursor: string;
+      readonly resumeStrategy: Exclude<ResumeStrategy, "none">;
+    },
+  ) => Effect.Effect<
+    {
+      readonly chat: Chat;
+      readonly initialSession: Session;
+    },
+    SessionStartError
+  >;
+
+  readonly importExternalMessages: (
+    sessionId: SessionId,
+    messages: ReadonlyArray<MessageContent>,
+  ) => Effect.Effect<ReadonlyArray<Message>, SessionNotFoundError>;
 
   readonly renameChat: (
     chatId: ChatId,

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -12,6 +12,7 @@ import { AttachmentServiceLive } from "./attachment/layers/attachment-service.ts
 import { IndexRegistryLive } from "./code-index/layers/index-registry.ts";
 import { ConfigStoreServiceLive } from "./config-store/layers/config-store-service.ts";
 import { DiagnosticsServiceLive } from "./diagnostics/layers/diagnostics-service.ts";
+import { ExternalThreadServiceLive } from "./external-thread/layers/external-thread-service.ts";
 import { FsServiceLive } from "./fs/layers/fs-service.ts";
 import { GitServiceLive } from "./git/layers/git-service.ts";
 import { HandlersLayer } from "./handlers.ts";
@@ -263,6 +264,14 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(ProviderLayer),
   );
 
+  const ExternalThreadLayer = ExternalThreadServiceLive.pipe(
+    Layer.provide(WorkspaceLayer),
+    Layer.provide(WorktreeLayer),
+    Layer.provide(MessageStoreLayer),
+    Layer.provide(MigratedSqlite),
+    Layer.provide(NodeContext.layer),
+  );
+
   // SkillBridge surfaces the user's per-provider skill library to the
   // composer's slash popover. Discovery walks disk; the bridge caches per
   // (provider, projectCwd) and re-emits on watcher fire so editing a
@@ -317,6 +326,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     SkillBridgeLayer,
     IndexLayer,
     DiagnosticsLayer,
+    ExternalThreadLayer,
     FolderPickerLayer,
   );
 

--- a/apps/server/test/availability.test.ts
+++ b/apps/server/test/availability.test.ts
@@ -278,7 +278,7 @@ describe("selectCliPathCandidate", () => {
   it("prefers a user Codex install over a managed Codex shim", () => {
     expect(
       selectCliPathCandidate("codex", [
-        "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
+        "/Users/me/Library/Application Support/app.memoize.desktop/./bin/codex",
         "/Users/me/.nvm/versions/node/v23.10.0/bin/codex",
       ]),
     ).toBe("/Users/me/.nvm/versions/node/v23.10.0/bin/codex");
@@ -287,7 +287,7 @@ describe("selectCliPathCandidate", () => {
   it("does not select a managed Codex shim when it is the only candidate", () => {
     expect(
       selectCliPathCandidate("codex", [
-        "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
+        "/Users/me/Library/Application Support/app.memoize.desktop/./bin/codex",
       ]),
     ).toBeNull();
   });
@@ -306,8 +306,8 @@ describe("buildUpdateCommand — install-method detection", () => {
   it("does not offer an updater for a managed standalone Codex shim", () => {
     expect(
       buildUpdateCommand("codex", [
-        "/Users/me/Library/Application Support/com.conductor.app/./bin/codex",
-        "/Users/me/Library/Application Support/com.conductor.app/agent-binaries/codex/0.138.0/codex",
+        "/Users/me/Library/Application Support/app.memoize.desktop/./bin/codex",
+        "/Users/me/Library/Application Support/app.memoize.desktop/agent-binaries/codex/0.138.0/codex",
       ]),
     ).toBeNull();
   });

--- a/apps/server/test/external-thread-discovery.test.ts
+++ b/apps/server/test/external-thread-discovery.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  claudeTranscriptMessages,
+  discoverClaudeThreads,
+} from "../src/external-thread/layers/external-thread-service.ts";
+
+describe("external thread discovery", () => {
+  it("discovers Claude JSONL threads with title, project path, cursor, and recency", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "zuse-claude-threads-"));
+    try {
+      const firstDir = path.join(root, "-Users-whizzy-projects-alpha");
+      const secondDir = path.join(root, "-Users-whizzy-projects-beta");
+      mkdirSync(firstDir, { recursive: true });
+      mkdirSync(secondDir, { recursive: true });
+
+      writeFileSync(
+        path.join(firstDir, "session-a.jsonl"),
+        [
+          JSON.stringify({
+            type: "queue-operation",
+            timestamp: "2026-07-01T10:00:00.000Z",
+            sessionId: "session-a",
+            content:
+              "<system_instruction>You are working inside Zuse. Your work should take place in the /tmp/alpha directory.</system_instruction>",
+          }),
+          JSON.stringify({
+            type: "ai-title",
+            aiTitle: "Fix alpha flow",
+            sessionId: "session-a",
+          }),
+          JSON.stringify({
+            type: "user",
+            timestamp: "2026-07-01T10:10:00.000Z",
+            sessionId: "session-a",
+            content: "Please fix the alpha flow",
+          }),
+        ].join("\n"),
+      );
+      writeFileSync(
+        path.join(secondDir, "session-b.jsonl"),
+        [
+          JSON.stringify({
+            type: "queue-operation",
+            timestamp: "2026-07-02T10:00:00.000Z",
+            sessionId: "session-b",
+            content:
+              "<system_instruction>You are working inside Zuse. Your work should take place in the /tmp/beta directory.</system_instruction>",
+          }),
+          JSON.stringify({
+            type: "user",
+            timestamp: "2026-07-02T10:10:00.000Z",
+            sessionId: "session-b",
+            content: "Please inspect beta",
+          }),
+        ].join("\n"),
+      );
+
+      const threads = discoverClaudeThreads(root);
+
+      expect(threads.map((thread) => thread.cursor)).toEqual([
+        "session-a",
+        "session-b",
+      ]);
+      expect(threads[0]).toMatchObject({
+        providerId: "claude",
+        title: "Fix alpha flow",
+        preview: "Please fix the alpha flow",
+        projectPath: "/tmp/alpha",
+        resumeStrategy: "claude-session-id",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("extracts Claude title and preview from nested message rows instead of metadata rows", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "zuse-claude-threads-"));
+    try {
+      const projectDir = path.join(root, "-Users-whizzy-projects-nested");
+      mkdirSync(projectDir, { recursive: true });
+
+      writeFileSync(
+        path.join(projectDir, "session-nested.jsonl"),
+        [
+          JSON.stringify({
+            type: "queue-operation",
+            timestamp: "2026-07-02T10:00:00.000Z",
+            sessionId: "session-nested",
+            content:
+              "<system_instruction>You are working inside Zuse. Your work should take place in the /tmp/wrong directory.</system_instruction>",
+          }),
+          JSON.stringify({
+            type: "user",
+            timestamp: "2026-07-02T10:10:00.000Z",
+            cwd: "/tmp/nested-worktree",
+            sessionId: "session-nested",
+            message: {
+              role: "user",
+              content: "Continue the nested Claude thread",
+            },
+          }),
+          JSON.stringify({
+            type: "user",
+            timestamp: "2026-07-02T10:10:30.000Z",
+            cwd: "/tmp/nested-worktree",
+            sessionId: "session-nested",
+            message: {
+              role: "user",
+              content:
+                "<task-notification><task-id>abc</task-id><status>completed</status><summary>Agent finished</summary><result>done</result></task-notification>",
+            },
+          }),
+          JSON.stringify({
+            type: "assistant",
+            timestamp: "2026-07-02T10:11:00.000Z",
+            sessionId: "session-nested",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "I can continue it." }],
+            },
+          }),
+        ].join("\n"),
+      );
+
+      const threads = discoverClaudeThreads(root);
+
+      expect(threads).toHaveLength(1);
+      expect(threads[0]).toMatchObject({
+        cursor: "session-nested",
+        title: "Continue the nested Claude thread",
+        preview: "Continue the nested Claude thread",
+        projectPath: "/tmp/nested-worktree",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("imports Claude JSONL tool calls as structured transcript rows", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "zuse-claude-threads-"));
+    try {
+      const sourcePath = path.join(root, "structured.jsonl");
+      writeFileSync(
+        sourcePath,
+        [
+          JSON.stringify({
+            type: "user",
+            timestamp: "2026-07-02T10:10:00.000Z",
+            sessionId: "session-structured",
+            message: {
+              role: "user",
+              content: "Patch the button label",
+            },
+          }),
+          JSON.stringify({
+            type: "assistant",
+            timestamp: "2026-07-02T10:11:00.000Z",
+            sessionId: "session-structured",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "I will update the component." },
+                {
+                  type: "tool_use",
+                  id: "toolu_edit_1",
+                  name: "Edit",
+                  input: {
+                    file_path: "apps/renderer/src/button.tsx",
+                    old_string: "Save",
+                    new_string: "Create",
+                  },
+                },
+              ],
+            },
+          }),
+          JSON.stringify({
+            type: "user",
+            timestamp: "2026-07-02T10:11:30.000Z",
+            sessionId: "session-structured",
+            message: {
+              role: "user",
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "toolu_edit_1",
+                  content: "Updated apps/renderer/src/button.tsx",
+                  is_error: false,
+                },
+              ],
+            },
+          }),
+        ].join("\n"),
+      );
+
+      const messages = claudeTranscriptMessages(sourcePath);
+
+      expect(messages.map((message) => message._tag)).toEqual([
+        "user",
+        "assistant",
+        "tool_use",
+        "tool_result",
+      ]);
+      expect(messages[2]).toMatchObject({
+        _tag: "tool_use",
+        itemId: "toolu_edit_1",
+        tool: "Edit",
+        input: {
+          file_path: "apps/renderer/src/button.tsx",
+          old_string: "Save",
+          new_string: "Create",
+        },
+      });
+      expect(messages[3]).toMatchObject({
+        _tag: "tool_result",
+        itemId: "toolu_edit_1",
+        output: "Updated apps/renderer/src/button.tsx",
+        isError: false,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -68,13 +68,15 @@ const TEST_WORKTREE_PATH = "/tmp/project/.memo/pikachu";
  */
 let scriptedEvents: ReadonlyArray<AgentEvent> = [];
 let providerStartInputs: StartSessionInput[] = [];
+let providerStartCursors: Array<string | null> = [];
 
 /** A no-op ProviderService: starts/sends succeed; events replay the script. */
 const StubProviderLive = Layer.succeed(ProviderService, {
   availability: () => Effect.succeed([]),
-  start: (input) =>
+  start: (input, resumeCursor) =>
     Effect.sync(() => {
       providerStartInputs.push(input);
+      providerStartCursors.push(resumeCursor);
       return {
         sessionId: input.sessionId ?? ("stub" as AgentSessionId),
       };
@@ -288,6 +290,7 @@ const store = MessageStore;
 
 beforeEach(() => {
   providerStartInputs = [];
+  providerStartCursors = [];
 });
 
 describe("MessageStore migrations", () => {
@@ -405,6 +408,33 @@ describe("MessageStore — chat & session lifecycle", () => {
       expect(result.chat.worktreeId).toBe(TEST_WORKTREE_ID);
       expect(result.initialSession.worktreeId).toBe(TEST_WORKTREE_ID);
       expect(providerStartInputs.at(-1)?.cwdOverride).toBe(TEST_WORKTREE_PATH);
+    });
+  });
+
+  it("creates an external continued thread with a persisted resume cursor and no initial message", async () => {
+    await withRuntime(async (run) => {
+      const result = await run(
+        Effect.flatMap(store, (s) =>
+          s.continueExternalThread({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+            title: "Existing Claude thread",
+            resumeCursor: "claude-session-123",
+            resumeStrategy: "claude-session-id",
+          }),
+        ),
+      );
+
+      expect(result.chat.title).toBe("Existing Claude thread");
+      expect(result.initialSession.cursor).toBe("claude-session-123");
+      expect(result.initialSession.resumeStrategy).toBe("claude-session-id");
+      expect(providerStartCursors.at(-1)).toBe("claude-session-123");
+
+      const messages = await run(
+        Effect.flatMap(store, (s) => s.listMessages(result.initialSession.id)),
+      );
+      expect(messages).toEqual([]);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "node scripts/dev.mjs",
     "dev:turbo": "turbo run dev --filter=renderer --filter=desktop",
     "dev:desktop": "node scripts/dev.mjs",
+    "kill-port": "node scripts/kill-port.mjs",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",

--- a/packages/wire/src/external-thread.ts
+++ b/packages/wire/src/external-thread.ts
@@ -1,0 +1,55 @@
+import { Rpc } from "@effect/rpc";
+import { Schema } from "effect";
+
+import { ProviderId } from "./agent.ts";
+import { Chat, Message, ResumeStrategy, Session } from "./session.ts";
+import { Worktree } from "./worktree.ts";
+import { Folder } from "./workspace.ts";
+
+export class ExternalThread extends Schema.Class<ExternalThread>(
+  "ExternalThread",
+)({
+  id: Schema.String,
+  providerId: ProviderId,
+  title: Schema.String,
+  preview: Schema.String,
+  projectPath: Schema.String,
+  projectName: Schema.String,
+  updatedAt: Schema.DateFromString,
+  sourcePath: Schema.NullOr(Schema.String),
+  cursor: Schema.String,
+  resumeStrategy: ResumeStrategy,
+  available: Schema.Boolean,
+}) {}
+
+export const ContinueExternalThreadInput = Schema.Struct({
+  providerId: ProviderId,
+  cursor: Schema.String,
+  projectPath: Schema.String,
+  title: Schema.optional(Schema.String),
+  sourcePath: Schema.optional(Schema.NullOr(Schema.String)),
+});
+export type ContinueExternalThreadInput =
+  typeof ContinueExternalThreadInput.Type;
+
+export class ContinueExternalThreadResult extends Schema.Class<ContinueExternalThreadResult>(
+  "ContinueExternalThreadResult",
+)({
+  project: Folder,
+  worktree: Schema.NullOr(Worktree),
+  chat: Chat,
+  session: Session,
+  messages: Schema.Array(Message),
+}) {}
+
+export const ExternalThreadsListRpc = Rpc.make("externalThreads.list", {
+  payload: Schema.Struct({
+    limit: Schema.optional(Schema.Number),
+  }),
+  success: Schema.Array(ExternalThread),
+});
+
+export const ExternalThreadsContinueRpc = Rpc.make("externalThreads.continue", {
+  payload: ContinueExternalThreadInput,
+  success: ContinueExternalThreadResult,
+});

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -6,6 +6,7 @@ export * from "./code-index.ts";
 export * from "./composer.ts";
 export * from "./connect.ts";
 export * from "./diagnostics.ts";
+export * from "./external-thread.ts";
 export * from "./fs.ts";
 export * from "./git.ts";
 export * from "./ids.ts";

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -48,6 +48,10 @@ import {
   FsWriteExternalFileRpc,
   FsWriteFileRpc,
 } from "./fs.ts";
+import {
+  ExternalThreadsContinueRpc,
+  ExternalThreadsListRpc,
+} from "./external-thread.ts";
 import { DiagnosticsExportRpc } from "./diagnostics.ts";
 import {
   GitBranchesRpc,
@@ -196,6 +200,8 @@ export const MemoizeRpcs = RpcGroup.make(
   WorkspaceCreateProjectRpc,
   WorkspaceListGithubReposRpc,
   WorkspaceGhAuthStatusRpc,
+  ExternalThreadsListRpc,
+  ExternalThreadsContinueRpc,
   PtyOpenRpc,
   PtyWriteRpc,
   PtyResizeRpc,

--- a/scripts/kill-port.mjs
+++ b/scripts/kill-port.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const usage = `Usage:
+  bun run kill-port -- <port>
+  bun run kill-port -- <port> --force
+
+Examples:
+  bun run kill-port -- 5733
+  bun run kill-port -- 5733 --force`;
+
+const args = process.argv.slice(2);
+const portArg = args.find((arg) => arg !== "--force");
+const force = args.includes("--force");
+const port = Number(portArg);
+
+if (!Number.isInteger(port) || port <= 0) {
+  console.error(usage);
+  process.exit(1);
+}
+
+let output = "";
+try {
+  output = execFileSync("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], {
+    encoding: "utf8",
+  }).trim();
+} catch {
+  console.log(`No listener found on port ${port}.`);
+  process.exit(0);
+}
+
+console.log(output);
+
+const pids = [
+  ...new Set(
+    output
+      .split("\n")
+      .slice(1)
+      .map((line) => Number(line.trim().split(/\s+/)[1]))
+      .filter((pid) => Number.isInteger(pid) && pid > 0),
+  ),
+];
+
+if (pids.length === 0) {
+  console.log(`No killable listener found on port ${port}.`);
+  process.exit(0);
+}
+
+if (!force) {
+  console.log(
+    `\nRun with --force to kill ${pids.length === 1 ? "PID" : "PIDs"} ${pids.join(", ")}.`,
+  );
+  process.exit(0);
+}
+
+for (const pid of pids) {
+  process.kill(pid, "SIGTERM");
+  console.log(`Sent SIGTERM to PID ${pid}.`);
+}


### PR DESCRIPTION
## Summary
- add external thread discovery/continue RPCs for Claude Code and Codex
- hydrate resumed transcripts into structured Zuse messages, including Codex and Claude tool calls
- auto-register existing project folders/worktrees and avoid showing new-worktree setup UI for resumed sessions
- add the Continue Threads landing carousel with framed cards and loading skeletons
- add a kill-port helper and fix Cursor stderr EPIPE handling

## Validation
- bun run check-types
- bun run --filter @zuse/server test

## Notes
- Missing external project folders remain visible but disabled.
- Existing linked git worktrees are attached to the registered main project instead of creating a new worktree.