### PR TITLE
[codex] add renderer websocket rpc client

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:web": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "check-types": "tsc --noEmit",
@@ -25,6 +26,7 @@
     "@codemirror/language": "^6.11.4",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.39.0",
+    "@effect/platform": "catalog:",
     "@effect/rpc": "catalog:",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@fontsource-variable/inter": "^5.2.8",

--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -3,8 +3,8 @@ import { Effect, Layer, ManagedRuntime, Scope } from "effect";
 
 import { MemoizeRpcs } from "@zuse/wire";
 
-import { getBridge } from "./bridge.ts";
 import { electronClientProtocolLayer } from "./electron-client-protocol.ts";
+import { wsClientProtocolLayer } from "./ws-client-protocol.ts";
 
 /**
  * Lazy-initialized renderer-side RPC. The bridge call is deferred so this
@@ -19,11 +19,22 @@ type MemoizeClient = RpcClient.RpcClient<RpcGroup.Rpcs<typeof MemoizeRpcs>>;
 let runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never> | null = null;
 let cachedClient: Promise<MemoizeClient> | null = null;
 
+function resolveWebSocketUrl() {
+  return (
+    import.meta.env.VITE_ZUSE_WS_URL?.trim() || `ws://${location.host}/rpc`
+  );
+}
+
 function getRuntime() {
   if (runtime === null) {
-    const protocolLayer = electronClientProtocolLayer(getBridge().rpc).pipe(
-      Layer.provide(RpcSerialization.layerJson),
-    );
+    const bridge = globalThis.window?.zuse ?? globalThis.window?.memoize;
+    const protocolLayer = bridge
+      ? electronClientProtocolLayer(bridge.rpc).pipe(
+          Layer.provide(RpcSerialization.layerJson),
+        )
+      : wsClientProtocolLayer(resolveWebSocketUrl());
+    // Future reconnect policy belongs at this socket/protocol boundary. For
+    // now failures surface to stream consumers and stores resume by cursor.
     runtime = ManagedRuntime.make(protocolLayer);
   }
   return runtime;

--- a/apps/renderer/src/lib/ws-client-protocol.ts
+++ b/apps/renderer/src/lib/ws-client-protocol.ts
@@ -1,0 +1,10 @@
+import { Socket } from "@effect/platform";
+import { RpcClient, RpcSerialization } from "@effect/rpc";
+import { Layer } from "effect";
+
+export const wsClientProtocolLayer = (url: string) =>
+  RpcClient.layerProtocolSocket().pipe(
+    Layer.provide(Socket.layerWebSocket(url)),
+    Layer.provide(Socket.layerWebSocketConstructorGlobal),
+    Layer.provide(RpcSerialization.layerJson),
+  );

--- a/bun.lock
+++ b/bun.lock
@@ -79,6 +79,7 @@
         "@codemirror/language": "^6.11.4",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.39.0",
+        "@effect/platform": "catalog:",
         "@effect/rpc": "catalog:",
         "@fontsource-variable/geist-mono": "^5.2.7",
         "@fontsource-variable/inter": "^5.2.8",


### PR DESCRIPTION
## Summary
- add a renderer WebSocket RPC protocol layer using Effect socket transport and JSON serialization
- select Electron IPC when the preload bridge is present and WebSocket when it is absent
- add `VITE_ZUSE_WS_URL` support plus a `dev:web` renderer script

## Impact
Electron IPC remains the default desktop path. Plain browser renderer builds can now talk directly to a headless server over `/rpc` without touching the Electron bridge helper.

## Validation
- `bun install`
- `bunx turbo build lint check-types test --filter=renderer`
- Booted headless server on port 8787 and confirmed `GET /rpc` returns `426 Upgrade Required`
- Ran a WebSocket RPC smoke against the real server: `ping` returned `pong`, `workspace.list` returned an empty list
- Started `dev:web` with `VITE_ZUSE_WS_URL=ws://127.0.0.1:8787/rpc`; Vite served the app shell with HTTP 200

## Notes
Provider-backed send was not exercised because it requires an initialized provider session. Reconnect/backoff, auth, pairing, and mobile-specific work remain out of scope for this PR.