### PR TITLE
Fix flickering plan-approval banner

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -81,6 +81,7 @@ import {
   chooseComposerSubmitRoute,
   findPendingPlanApprovalRequest,
   hasEmulatedPlanAwaitingAction,
+  providerUsesEmulatedPlanMode,
   shouldSendPlanFeedbackNow,
 } from "~/lib/plan-feedback-routing";
 import {
@@ -264,14 +265,23 @@ export function ChatComposer({
       findPendingPlanApprovalRequest(Object.values(requestsById), sessionId),
     [requestsById, sessionId],
   );
+  const usesEmulatedPlanMode = providerUsesEmulatedPlanMode(session.providerId);
   const sendPlanFeedbackNow = useMemo(
     () =>
       shouldSendPlanFeedbackNow({
         permissionMode: session.permissionMode,
         messages: sessionMessages ?? [],
         pendingPlanApprovalRequest,
+        usesEmulatedPlanMode,
+        isRunning: inFlight,
       }),
-    [pendingPlanApprovalRequest, session.permissionMode, sessionMessages],
+    [
+      pendingPlanApprovalRequest,
+      session.permissionMode,
+      sessionMessages,
+      usesEmulatedPlanMode,
+      inFlight,
+    ],
   );
   const emulatedPlanReady = useMemo(
     () =>
@@ -279,8 +289,16 @@ export function ChatComposer({
         permissionMode: session.permissionMode,
         messages: sessionMessages ?? [],
         pendingPlanApprovalRequest,
+        usesEmulatedPlanMode,
+        isRunning: inFlight,
       }),
-    [pendingPlanApprovalRequest, session.permissionMode, sessionMessages],
+    [
+      pendingPlanApprovalRequest,
+      session.permissionMode,
+      sessionMessages,
+      usesEmulatedPlanMode,
+      inFlight,
+    ],
   );
   useEffect(() => {
     if (isDraft) return;

--- a/apps/renderer/src/lib/plan-feedback-routing.ts
+++ b/apps/renderer/src/lib/plan-feedback-routing.ts
@@ -2,8 +2,20 @@ import type {
   Message,
   PermissionMode,
   PermissionRequest,
+  ProviderId,
   SessionId,
 } from "@zuse/wire";
+
+/**
+ * Whether a provider drives plan mode through the transcript-shape heuristic
+ * rather than a native `ExitPlanMode` permission request. Claude is the only
+ * provider whose driver emits a real `ExitPlanMode` permission; every other
+ * provider (Codex / Grok / Gemini / Cursor / opencode) emulates plan mode via
+ * a developer-instructions prefix, so we infer "plan is ready" from the
+ * transcript instead.
+ */
+export const providerUsesEmulatedPlanMode = (providerId: ProviderId): boolean =>
+  providerId !== "claude";
 
 export const isPlanApprovalRequest = (
   req: PermissionRequest,
@@ -33,18 +45,29 @@ export const findPendingPlanApprovalRequest = (
  * user message means the agent has produced the plan and is waiting for
  * feedback. If the latest turn is still only the user's prompt or a tool call,
  * the agent is still working and normal queueing should apply.
+ *
+ * The transcript heuristic is gated two ways so the "Review plan" tray can't
+ * flicker: it never runs for a native-plan provider (Claude — driven solely by
+ * `pendingPlanApprovalRequest`), and it never runs mid-turn (`isRunning`),
+ * since the tail message flips assistant↔tool on every streamed chunk.
  */
 export const shouldSendPlanFeedbackNow = ({
   permissionMode,
   messages,
   pendingPlanApprovalRequest,
+  usesEmulatedPlanMode,
+  isRunning,
 }: {
   readonly permissionMode: PermissionMode;
   readonly messages: ReadonlyArray<Pick<Message, "content">>;
   readonly pendingPlanApprovalRequest: PermissionRequest | null;
+  readonly usesEmulatedPlanMode: boolean;
+  readonly isRunning: boolean;
 }): boolean => {
   if (pendingPlanApprovalRequest !== null) return true;
+  if (!usesEmulatedPlanMode) return false;
   if (permissionMode !== "plan") return false;
+  if (isRunning) return false;
 
   for (let i = messages.length - 1; i >= 0; i--) {
     const content = messages[i]!.content;
@@ -77,16 +100,22 @@ export const hasEmulatedPlanAwaitingAction = ({
   permissionMode,
   messages,
   pendingPlanApprovalRequest,
+  usesEmulatedPlanMode,
+  isRunning,
 }: {
   readonly permissionMode: PermissionMode;
   readonly messages: ReadonlyArray<Pick<Message, "content">>;
   readonly pendingPlanApprovalRequest: PermissionRequest | null;
+  readonly usesEmulatedPlanMode: boolean;
+  readonly isRunning: boolean;
 }): boolean =>
   pendingPlanApprovalRequest === null &&
   shouldSendPlanFeedbackNow({
     permissionMode,
     messages,
     pendingPlanApprovalRequest,
+    usesEmulatedPlanMode,
+    isRunning,
   });
 
 export type ComposerSubmitRoute = "planFeedback" | "goal" | "queue" | "send";

--- a/apps/renderer/test/plan-feedback-routing.test.ts
+++ b/apps/renderer/test/plan-feedback-routing.test.ts
@@ -10,6 +10,7 @@ import {
   chooseComposerSubmitRoute,
   findPendingPlanApprovalRequest,
   hasEmulatedPlanAwaitingAction,
+  providerUsesEmulatedPlanMode,
   shouldSendPlanFeedbackNow,
 } from "../src/lib/plan-feedback-routing.ts";
 
@@ -49,6 +50,14 @@ const exitPlanRequest = PermissionRequest.make({
 });
 
 describe("plan feedback routing", () => {
+  it("treats Claude as native and every other provider as emulated", () => {
+    expect(providerUsesEmulatedPlanMode("claude")).toBe(false);
+    expect(providerUsesEmulatedPlanMode("codex")).toBe(true);
+    expect(providerUsesEmulatedPlanMode("grok")).toBe(true);
+    expect(providerUsesEmulatedPlanMode("gemini")).toBe(true);
+    expect(providerUsesEmulatedPlanMode("cursor")).toBe(true);
+  });
+
   it("detects a pending ExitPlanMode approval request", () => {
     expect(findPendingPlanApprovalRequest([exitPlanRequest], sessionId)).toBe(
       exitPlanRequest,
@@ -61,6 +70,8 @@ describe("plan feedback routing", () => {
         permissionMode: "plan",
         messages: [user(), toolUse("ExitPlanMode")],
         pendingPlanApprovalRequest: exitPlanRequest,
+        usesEmulatedPlanMode: false,
+        isRunning: true,
       }),
     ).toBe(true);
   });
@@ -71,6 +82,8 @@ describe("plan feedback routing", () => {
         permissionMode: "plan",
         messages: [user(), assistant()],
         pendingPlanApprovalRequest: null,
+        usesEmulatedPlanMode: true,
+        isRunning: false,
       }),
     ).toBe(true);
   });
@@ -81,6 +94,8 @@ describe("plan feedback routing", () => {
         permissionMode: "plan",
         messages: [user(), assistant()],
         pendingPlanApprovalRequest: null,
+        usesEmulatedPlanMode: true,
+        isRunning: false,
       }),
     ).toBe(true);
   });
@@ -91,8 +106,50 @@ describe("plan feedback routing", () => {
         permissionMode: "plan",
         messages: [user(), toolUse("ExitPlanMode")],
         pendingPlanApprovalRequest: exitPlanRequest,
+        usesEmulatedPlanMode: false,
+        isRunning: true,
       }),
     ).toBe(false);
+  });
+
+  it("never uses the transcript heuristic for a native-plan provider (Claude)", () => {
+    // Claude in plan mode, idle, tail is assistant text, but no ExitPlanMode
+    // request — the tray must NOT show (this is the "Yo!" false-positive).
+    expect(
+      hasEmulatedPlanAwaitingAction({
+        permissionMode: "plan",
+        messages: [user(), assistant()],
+        pendingPlanApprovalRequest: null,
+        usesEmulatedPlanMode: false,
+        isRunning: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flicker the emulated tray mid-turn while streaming", () => {
+    // Same transcript, but the turn is still running — must stay hidden so the
+    // banner can't toggle on/off as chunks stream in.
+    expect(
+      hasEmulatedPlanAwaitingAction({
+        permissionMode: "plan",
+        messages: [user(), assistant()],
+        pendingPlanApprovalRequest: null,
+        usesEmulatedPlanMode: true,
+        isRunning: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps native pending plan approval feedback flowing even when not running", () => {
+    expect(
+      shouldSendPlanFeedbackNow({
+        permissionMode: "plan",
+        messages: [user(), toolUse("ExitPlanMode")],
+        pendingPlanApprovalRequest: exitPlanRequest,
+        usesEmulatedPlanMode: false,
+        isRunning: false,
+      }),
+    ).toBe(true);
   });
 
   it("keeps normal running turns on the queue path before an assistant response", () => {
@@ -101,6 +158,8 @@ describe("plan feedback routing", () => {
         permissionMode: "default",
         messages: [user()],
         pendingPlanApprovalRequest: null,
+        usesEmulatedPlanMode: true,
+        isRunning: false,
       }),
     ).toBe(false);
     expect(
@@ -108,6 +167,8 @@ describe("plan feedback routing", () => {
         permissionMode: "plan",
         messages: [user()],
         pendingPlanApprovalRequest: null,
+        usesEmulatedPlanMode: true,
+        isRunning: false,
       }),
     ).toBe(false);
   });
@@ -118,6 +179,8 @@ describe("plan feedback routing", () => {
         permissionMode: "plan",
         messages: [user(), toolUse("Read")],
         pendingPlanApprovalRequest: null,
+        usesEmulatedPlanMode: true,
+        isRunning: false,
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
## Problem

The pinned **"Review plan — Approve to start building"** tray above the composer flashes on and off as an agent streams, and shows even when the agent never produced a plan.

## Root cause

Two independent gating defects in the FE plan-approval heuristic (`plan-feedback-routing.ts`):

1. **No provider gate.** `emulatedPlanReady` (`hasEmulatedPlanAwaitingAction`) is a transcript-shape heuristic meant only for providers *without* a native plan tool (Codex/Grok/Gemini/Cursor/opencode). It ran for **every** provider, including Claude. Only Claude's driver emits a real `ExitPlanMode` permission — so Claude's tray must be driven solely by that request, never the text heuristic.

2. **No "turn idle" gate.** The heuristic returned `true` whenever the last message was assistant text, regardless of whether the turn was still running. As Claude narrated → ran a tool → spawned a sub-agent, the tail message flipped `assistant ↔ tool` on each streamed chunk, toggling the banner on/off (the flicker). It also stayed up when Claude merely answered in plan mode without proposing a plan.

Same heuristic also mis-routed composer submits — typing mid-turn on an emulated provider would `send` immediately instead of queueing.

## Fix

- Add `providerUsesEmulatedPlanMode(providerId)` (false only for `claude`).
- Gate `shouldSendPlanFeedbackNow` with two new checks: bail for native-plan providers, and bail while `isRunning`. The pending-`ExitPlanMode` fast path is untouched, so Claude's real approval flow (and feedback-while-pending) still works.
- Thread `usesEmulatedPlanMode` + `isRunning: inFlight` through the composer `useMemo`s.

### Result
- **Claude:** tray appears only when a real `ExitPlanMode` request is pending — no flicker during exploration, no false banner on plain answers.
- **Codex / Grok / Gemini / Cursor / opencode:** tray still appears, but only once the turn is idle with a plan on top; mid-turn typing queues.

## Verify
- `bun test apps/renderer/test/plan-feedback-routing.test.ts` → 13 pass (added cases for the false-positive, mid-turn no-flicker, and native-pending-when-idle).
- `tsc --noEmit` on the renderer → clean.