### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0]
+
+### Changed
+- Fix flickering plan-approval banner (#244)
+- Fix mermaid error bomb bar + jittery send animation (#243)
+- [codex] add provider contract test fixtures (#242)
+- [codex] Improve bug report diagnostics flow (#241)
+- [codex] Disable runtime code indexing (#240)
+- Add LAN auth pairing for WS server (#238)
+- [codex] add renderer websocket rpc client (#239)
+- [codex] continue external agent threads (#237)
+- [codex] add agent browser v2 (#236)
+- [codex] Add Expo mobile read-only client (#235)
+- [codex] Add renderer toast notifications (#234)
+- [codex] Add markdown and HTML preview tab (#233)
+- [codex] add event-sourced persistence and cursor streaming (#232)
+- Remote/multi-client foundation: wire contract + WS transport + spec (#218)
+- [codex] add light and system appearance support (#229)
+
 ## [0.9.0]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,30 @@
 [
   {
+    "version": "0.10.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix flickering plan-approval banner (#244)",
+          "Fix mermaid error bomb bar + jittery send animation (#243)",
+          "[codex] add provider contract test fixtures (#242)",
+          "[codex] Improve bug report diagnostics flow (#241)",
+          "[codex] Disable runtime code indexing (#240)",
+          "Add LAN auth pairing for WS server (#238)",
+          "[codex] add renderer websocket rpc client (#239)",
+          "[codex] continue external agent threads (#237)",
+          "[codex] add agent browser v2 (#236)",
+          "[codex] Add Expo mobile read-only client (#235)",
+          "[codex] Add renderer toast notifications (#234)",
+          "[codex] Add markdown and HTML preview tab (#233)",
+          "[codex] add event-sourced persistence and cursor streaming (#232)",
+          "Remote/multi-client foundation: wire contract + WS transport + spec (#218)",
+          "[codex] add light and system appearance support (#229)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.9.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release Zuse v0.10.0
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.10.0 after this PR lands.