### PR TITLE
Route pasted text & dropped files into .context/files

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,6 +18,7 @@ import { execFile, spawn } from "node:child_process";
 import * as http from "node:http";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import * as Path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1374,6 +1375,66 @@ const findAssetFilename = async (
   return cache.byStem.get(id) ?? null;
 };
 
+const ZUSE_SQLITE_FILENAME = "zuse.sqlite";
+
+// Attachment ids resolve to an immutable on-disk path, so caching id → path
+// avoids re-opening the DB for every `<img>` request.
+const attachmentPathCache = new Map<string, string>();
+
+/**
+ * Resolve `<id>` → the attachment blob's absolute path via a read-only probe
+ * of the app database. Blobs now live in each workspace's per-session
+ * `.context/files/` dir (recorded in `attachments.abs_path`), so a single-dir
+ * scan can no longer find them. Returns `null` on any failure (missing row,
+ * NULL `abs_path`, or DB unavailable) — the caller then tries the legacy
+ * flat-dir layout.
+ */
+const resolveAttachmentAbsPathFromDb = (
+  userData: string,
+  id: string,
+): string | null => {
+  const cached = attachmentPathCache.get(id);
+  if (cached !== undefined) return cached;
+  try {
+    // Lazy require: `node:sqlite` is a builtin in this Electron's Node
+    // runtime — the same client the server uses.
+    const req = createRequire(import.meta.url);
+    const { DatabaseSync } = req("node:sqlite") as typeof import("node:sqlite");
+    const db = new DatabaseSync(Path.join(userData, ZUSE_SQLITE_FILENAME), {
+      readOnly: true,
+    });
+    try {
+      const row = db
+        .prepare("SELECT abs_path FROM attachments WHERE id = ?")
+        .get(id) as { abs_path?: string | null } | undefined;
+      const abs = typeof row?.abs_path === "string" ? row.abs_path : null;
+      if (abs !== null) attachmentPathCache.set(id, abs);
+      return abs;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Defense-in-depth: only serve a DB-recorded path when it lives inside the
+ * legacy attachments dir or a `.context/files` directory. The path is
+ * server-written and the id is already sanitised, but this keeps a corrupted
+ * row from turning the protocol into an arbitrary-file reader.
+ */
+const isServableAttachmentPath = (
+  attachmentsDir: string,
+  p: string,
+): boolean => {
+  const norm = Path.normalize(p);
+  return (
+    norm.startsWith(attachmentsDir + Path.sep) ||
+    norm.includes(`${Path.sep}.context${Path.sep}files${Path.sep}`)
+  );
+};
+
 const registerZuseProtocol = (): void => {
   const attachmentsDir = Path.join(app.getPath("userData"), "attachments");
   const pokemonDir = Path.join(app.getPath("userData"), "pokemon-sprites");
@@ -1388,33 +1449,57 @@ const registerZuseProtocol = (): void => {
 
   const handleAssetRequest = async (request: Request) => {
     const url = new URL(request.url);
-    const asset =
-      url.host === ATTACHMENTS_HOST
-        ? { cache: attachmentFilenames, dir: attachmentsDir }
-        : url.host === POKEMON_HOST
-          ? { cache: pokemonFilenames, dir: pokemonDir }
-          : null;
-    if (asset === null) {
+    if (url.host !== ATTACHMENTS_HOST && url.host !== POKEMON_HOST) {
       return new Response(null, { status: 404 });
     }
 
     // The path is `/<id>`; sanitise to a single segment so a crafted url
-    // like `zuse://attachments/../foo` cannot escape `attachmentsDir`.
+    // like `zuse://attachments/../foo` cannot escape the asset dirs.
     const id = decodeURIComponent(url.pathname.replace(/^\//, ""));
     if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
       return new Response(null, { status: 400 });
     }
 
-    let filename: string | null;
-    try {
-      filename = await findAssetFilename(asset.dir, asset.cache, id);
-    } catch {
-      return new Response(null, { status: 404 });
+    let absPath: string | null = null;
+    if (url.host === ATTACHMENTS_HOST) {
+      // Prefer the DB-recorded absolute path (new `.context/files` layout).
+      const fromDb = resolveAttachmentAbsPathFromDb(
+        app.getPath("userData"),
+        id,
+      );
+      if (fromDb !== null && isServableAttachmentPath(attachmentsDir, fromDb)) {
+        absPath = fromDb;
+      } else {
+        // Legacy fallback: scan the flat userData/attachments dir for
+        // pre-migration blobs.
+        try {
+          const filename = await findAssetFilename(
+            attachmentsDir,
+            attachmentFilenames,
+            id,
+          );
+          if (filename) absPath = Path.join(attachmentsDir, filename);
+        } catch {
+          absPath = null;
+        }
+      }
+    } else {
+      try {
+        const filename = await findAssetFilename(
+          pokemonDir,
+          pokemonFilenames,
+          id,
+        );
+        if (filename) absPath = Path.join(pokemonDir, filename);
+      } catch {
+        absPath = null;
+      }
     }
-    if (!filename) return new Response(null, { status: 404 });
 
-    const absPath = Path.join(asset.dir, filename);
-    const ext = filename.slice(filename.lastIndexOf(".") + 1).toLowerCase();
+    if (absPath === null) return new Response(null, { status: 404 });
+
+    const base = Path.basename(absPath);
+    const ext = base.slice(base.lastIndexOf(".") + 1).toLowerCase();
     const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
 
     const response = await net.fetch(pathToFileURL(absPath).toString());

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -15,6 +15,7 @@ import {
   Upload01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import type { EditorView } from "@codemirror/view";
+import { Effect } from "effect";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -56,6 +57,7 @@ import {
   setComposerDoc,
   type ActiveTrigger,
 } from "~/lib/codemirror/composer";
+import { getRpcClient } from "~/lib/rpc-client";
 import { readStorageWithLegacy } from "~/lib/storage-keys";
 import { useKeybindingsStore } from "../store/keybindings";
 import {
@@ -345,7 +347,6 @@ export function ChatComposer({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
   const uploadOne = useAttachmentsStore((s) => s.uploadOne);
-  const forgetActive = useAttachmentsStore((s) => s.forgetActive);
   // Submit reads through a ref so the keymap, captured at editor creation
   // time, always sees the current sessionId / send / inFlight without
   // recreating the editor on every render.
@@ -355,6 +356,10 @@ export function ChatComposer({
   const filesDroppedRef = useRef<(files: ReadonlyArray<File>) => void>(
     () => undefined,
   );
+  // Same indirection for large text pastes. Returns whether the paste was
+  // consumed (diverted to a `.context/files` file chip) so CodeMirror knows
+  // to skip its default insert.
+  const textPastedRef = useRef<(text: string) => boolean>(() => false);
   // Same pattern for the Shift+Tab plan-mode toggle. Latest session +
   // mode without reconstructing the editor on every state change.
   const togglePlanModeRef = useRef<() => void>(() => undefined);
@@ -398,6 +403,7 @@ export function ChatComposer({
       onTrigger: (t: ActiveTrigger | null) => setTrigger(t),
       onFilesDropped: (files: ReadonlyArray<File>) =>
         filesDroppedRef.current(files),
+      onTextPaste: (text: string) => textPastedRef.current(text),
       onTogglePlanMode: () => togglePlanModeRef.current(),
     };
     const view = createComposerView({
@@ -601,7 +607,7 @@ export function ChatComposer({
         }),
       });
 
-      void uploadOne(sessionId, file)
+      void uploadOne(sessionId, file, workspaceRoot ?? undefined)
         .then((ref) => {
           const finalUrl = isImage ? `zuse://attachments/${ref.id}` : "";
           editorViewRef.current?.dispatch({
@@ -626,6 +632,53 @@ export function ChatComposer({
     }
   };
 
+  /**
+   * A paste counts as "big" when it spans more than 10 lines or 2,000
+   * characters. Such pastes become a `.context/files/paste-<uuid>.md` file
+   * chip instead of flooding the composer with inline text.
+   */
+  const isBigTextPaste = (text: string): boolean =>
+    text.split("\n").length > 10 || text.length > 2000;
+
+  /**
+   * Persist a large paste as a workspace file and drop a file chip for it.
+   * Reuses the `@`-file pipeline (`FileRef`), so the agent reads the file
+   * from its cwd. On failure, fall back to inserting the raw text so nothing
+   * the user pasted is ever lost.
+   */
+  const attachPastedText = async (text: string): Promise<void> => {
+    if (editorViewRef.current === null) return;
+    try {
+      const client = await getRpcClient();
+      const res = await Effect.runPromise(
+        client.context.saveText({
+          sessionId,
+          text,
+          ext: "md",
+          ...(workspaceRoot ? { rootPath: workspaceRoot } : {}),
+        }),
+      );
+      const view = editorViewRef.current;
+      if (view === null) return;
+      const sel = view.state.selection.main;
+      replaceWithChip(view, sel.from, sel.to, `@${res.relPath}`, {
+        kind: "file",
+        relPath: res.relPath,
+        absPath: res.absPath,
+        entryKind: "file",
+      });
+    } catch (err) {
+      console.error("[chat-composer] saveText failed", err);
+      const view = editorViewRef.current;
+      if (view === null) return;
+      const sel = view.state.selection.main;
+      view.dispatch({
+        changes: { from: sel.from, to: sel.to, insert: text },
+        selection: { anchor: sel.from + text.length },
+      });
+    }
+  };
+
   // Paperclip → hidden file input.
   const onPickFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -635,7 +688,9 @@ export function ChatComposer({
   };
 
   // Paste handler — accepts any file type pasted into the composer (images,
-  // PDFs, docs, etc.).
+  // PDFs, docs, etc.). Large *text* pastes are handled one layer down, inside
+  // CodeMirror (`onTextPaste`), because CM inserts pasted text before this
+  // React handler runs — see `textPastedRef` / composer.ts.
   const onPaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
     const items = e.clipboardData?.items;
     if (!items) return;
@@ -677,18 +732,6 @@ export function ChatComposer({
     const files = Array.from(e.dataTransfer.files);
     if (files.length > 0) attachFiles(files);
   };
-
-  // Forget any stale tempId-keyed attachments when the composer unmounts —
-  // the heartbeat tracks ids, so dropping unattached blobs is enough to
-  // let the GC reap them.
-  useEffect(
-    () => () => {
-      // No-op for now: forgetActive is called per-id only when a chip is
-      // dropped explicitly. Server GC handles long-lived orphans.
-      void forgetActive;
-    },
-    [forgetActive],
-  );
 
   const submit = (): boolean => {
     // Don't submit while a popover is open — Enter belongs to the popover.
@@ -800,6 +843,12 @@ export function ChatComposer({
     dragDepthRef.current = 0;
     setIsDragging(false);
     attachFiles(files);
+  };
+
+  textPastedRef.current = (text) => {
+    if (!isBigTextPaste(text)) return false;
+    void attachPastedText(text);
+    return true;
   };
 
   const inPlanMode = session.permissionMode === "plan";

--- a/apps/renderer/src/lib/codemirror/composer.ts
+++ b/apps/renderer/src/lib/codemirror/composer.ts
@@ -47,6 +47,17 @@ export type ComposerCallbacks = {
    */
   readonly onFilesDropped: (files: ReadonlyArray<File>) => void;
   /**
+   * Called when plain text is pasted into the editor. Return `true` to
+   * consume the paste (CodeMirror will not insert the text) — used to divert
+   * a large paste into a `.context/files` attachment instead of flooding the
+   * composer. Return `false` to let CodeMirror insert the text normally.
+   *
+   * This must live at the CodeMirror layer (not a React `onPaste`): CM's own
+   * paste handler inserts the text at the editor DOM before the event bubbles
+   * to React, so a React-level `preventDefault` fires too late to stop it.
+   */
+  readonly onTextPaste?: (text: string) => boolean;
+  /**
    * Toggle plan mode. Bound to `Shift+Tab` in the composer keymap. The
    * caller is responsible for the actual mode flip and any visual
    * feedback (chip, dashed accent on the composer card).
@@ -127,6 +138,23 @@ export const createComposerView = ({
         // native event still bubbles otherwise.
         event.stopPropagation();
         callbacks.onFilesDropped(Array.from(files));
+        return true;
+      },
+      // Text pastes: give the host first refusal so a large paste can be
+      // diverted into a `.context/files` attachment. File pastes fall
+      // through to the parent Card's React `onPaste` (same upload pipeline
+      // as paperclip / drop). Returning true + preventDefault stops CM from
+      // inserting the raw text.
+      paste: (event) => {
+        const data = event.clipboardData;
+        if (data === null || data === undefined) return false;
+        if (data.files.length > 0) return false;
+        const text = data.getData("text/plain");
+        if (text === "") return false;
+        const consumed = callbacks.onTextPaste?.(text) ?? false;
+        if (!consumed) return false;
+        event.preventDefault();
+        event.stopPropagation();
         return true;
       },
     }),

--- a/apps/renderer/src/store/attachments.ts
+++ b/apps/renderer/src/store/attachments.ts
@@ -12,19 +12,11 @@ import { getRpcClient } from "../lib/rpc-client.ts";
  */
 const MAX_IMAGE_BYTES = 100 * 1024 * 1024;
 
-/**
- * The set of attachment ids the renderer is currently keeping alive. Any
- * id in this set is heartbeat by `attachments.touch` every 30 s so the
- * server's GC sweep doesn't reap a blob that's still referenced by a draft
- * composer chip or a queued message.
- */
 type AttachmentsState = {
-  readonly activeIds: ReadonlySet<string>;
-  readonly registerActive: (id: string) => void;
-  readonly forgetActive: (id: string) => void;
   readonly uploadOne: (
     sessionId: SessionId,
     file: File,
+    rootPath?: string,
   ) => Promise<AttachmentRef>;
 };
 
@@ -40,22 +32,8 @@ const fileToBytes = (file: File): Promise<Uint8Array> =>
     reader.readAsArrayBuffer(file);
   });
 
-export const useAttachmentsStore = create<AttachmentsState>((set, get) => ({
-  activeIds: new Set(),
-  registerActive: (id) =>
-    set((s) => {
-      const next = new Set(s.activeIds);
-      next.add(id);
-      return { activeIds: next };
-    }),
-  forgetActive: (id) =>
-    set((s) => {
-      if (!s.activeIds.has(id)) return s;
-      const next = new Set(s.activeIds);
-      next.delete(id);
-      return { activeIds: next };
-    }),
-  uploadOne: async (sessionId, file) => {
+export const useAttachmentsStore = create<AttachmentsState>(() => ({
+  uploadOne: async (sessionId, file, rootPath) => {
     if (file.size > MAX_IMAGE_BYTES) {
       throw new Error(`Image too large (max 100 MB)`);
     }
@@ -67,6 +45,9 @@ export const useAttachmentsStore = create<AttachmentsState>((set, get) => ({
         bytes,
         mimeType: file.type || "application/octet-stream",
         originalName: file.name || "image",
+        // `rootPath` is a fallback the server uses only when it can't resolve
+        // the session's cwd itself (e.g. a brand-new chat before first send).
+        ...(rootPath ? { rootPath } : {}),
       }),
     );
     const ref: AttachmentRef = {
@@ -74,35 +55,6 @@ export const useAttachmentsStore = create<AttachmentsState>((set, get) => ({
       mimeType: result.mimeType,
       originalName: file.name || "image",
     };
-    get().registerActive(result.id);
     return ref;
   },
 }));
-
-/**
- * Heartbeat: ping `attachments.touch` every 30 s with the current active
- * set. Boot once at app start; tears down only when the renderer unloads.
- * The interval is half the server's 90 s GC TTL so a single missed tick
- * still keeps blobs alive.
- */
-export const startAttachmentsHeartbeat = (): (() => void) => {
-  let stopped = false;
-  const tick = async () => {
-    if (stopped) return;
-    const ids = Array.from(useAttachmentsStore.getState().activeIds);
-    if (ids.length === 0) return;
-    try {
-      const client = await getRpcClient();
-      await Effect.runPromise(client.attachments.touch({ ids }));
-    } catch {
-      // Heartbeat is best-effort; a dropped tick just means the GC may run
-      // sooner. The chip will swap to a missing-attachment placeholder if
-      // the blob actually disappears.
-    }
-  };
-  const handle = window.setInterval(tick, 30_000);
-  return () => {
-    stopped = true;
-    window.clearInterval(handle);
-  };
-};

--- a/apps/server/src/attachment/handlers.ts
+++ b/apps/server/src/attachment/handlers.ts
@@ -5,14 +5,18 @@ import { AttachmentService } from "./services/attachment-service.ts";
 
 const Upload = MemoizeRpcs.toLayerHandler(
   "attachments.upload",
-  ({ sessionId, bytes, mimeType, originalName }) =>
+  ({ sessionId, bytes, mimeType, originalName, rootPath }) =>
     Effect.flatMap(AttachmentService, (svc) =>
-      svc.upload(sessionId, bytes, mimeType, originalName),
+      svc.upload(sessionId, bytes, mimeType, originalName, rootPath),
     ),
 );
 
-const Touch = MemoizeRpcs.toLayerHandler("attachments.touch", ({ ids }) =>
-  Effect.flatMap(AttachmentService, (svc) => svc.touch(ids)),
+const SaveText = MemoizeRpcs.toLayerHandler(
+  "context.saveText",
+  ({ sessionId, text, ext, rootPath }) =>
+    Effect.flatMap(AttachmentService, (svc) =>
+      svc.saveText(sessionId, text, ext, rootPath),
+    ),
 );
 
-export const AttachmentHandlersLayer = Layer.mergeAll(Upload, Touch);
+export const AttachmentHandlersLayer = Layer.mergeAll(Upload, SaveText);

--- a/apps/server/src/attachment/layers/attachment-service.ts
+++ b/apps/server/src/attachment/layers/attachment-service.ts
@@ -2,13 +2,15 @@ import { randomUUID } from "node:crypto";
 
 import { FileSystem, Path } from "@effect/platform";
 import { SqlClient } from "@effect/sql";
-import { Duration, Effect, Fiber, Layer, Ref, Schedule } from "effect";
+import { Effect, Layer } from "effect";
 
-import {
-  AttachmentTooLargeError,
-} from "@zuse/wire";
+import { AttachmentTooLargeError, ContextWriteError } from "@zuse/wire";
 
 import { AppPaths } from "../../app-paths.ts";
+import {
+  ensureContextFilesDir,
+  resolveSessionCwd,
+} from "../../context/context-files.ts";
 import { extForUpload } from "../image-mime.ts";
 import {
   AttachmentService,
@@ -21,22 +23,22 @@ import {
  */
 const MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 
-/** GC keeps a blob if it was last touched within this window. */
-const HEARTBEAT_TTL_MS = 90_000;
-
-/** Minimum age before a *referenced-by-nothing* blob is eligible for GC. */
-const MIN_AGE_MS = 24 * 60 * 60 * 1000;
-
-/** Sweep cadence: once on boot, then once a day. */
-const GC_INTERVAL = Duration.hours(24);
-
 const sessionSegment = (sessionId: string): string =>
   sessionId.toLowerCase().replace(/[^a-z0-9-]+/g, "-").slice(0, 80);
 
-const attachmentsDir = (userData: string, pathSvc: Path.Path): string =>
+/**
+ * Legacy flat blob directory under userData. New uploads land in the
+ * workspace's `.context/files/`, but this is still used (a) as a fallback
+ * when a session's cwd cannot be resolved and (b) to resolve pre-migration
+ * rows whose `abs_path` is NULL.
+ */
+const legacyAttachmentsDir = (userData: string, pathSvc: Path.Path): string =>
   pathSvc.join(userData, "attachments");
 
 const blobFilename = (id: string, ext: string): string => `${id}.${ext}`;
+
+const sanitizeExt = (ext: string): string =>
+  ext.replace(/[^a-zA-Z0-9]+/g, "").slice(0, 12) || "txt";
 
 export const AttachmentServiceLive = Layer.scoped(
   AttachmentService,
@@ -46,27 +48,14 @@ export const AttachmentServiceLive = Layer.scoped(
     const sql = yield* SqlClient.SqlClient;
     const { userData } = yield* AppPaths;
 
-    const dir = attachmentsDir(userData, pathSvc);
-    yield* fs.makeDirectory(dir, { recursive: true }).pipe(Effect.orDie);
-
-    // In-memory heartbeat map. The renderer touches ids it cares about
-    // every 30 s; blobs not seen recently become GC-eligible after the
-    // 24 h floor. Initialised eagerly on upload so freshly written blobs
-    // are not reaped before the first heartbeat fires.
-    const lastTouched = yield* Ref.make<Map<string, number>>(new Map());
-
-    const touchOne = (id: string): Effect.Effect<void> =>
-      Ref.update(lastTouched, (m) => {
-        const next = new Map(m);
-        next.set(id, Date.now());
-        return next;
-      });
+    const legacyDir = legacyAttachmentsDir(userData, pathSvc);
 
     const upload: AttachmentServiceShape["upload"] = (
       sessionId,
       bytes,
       mimeType,
       originalName,
+      rootPath,
     ) =>
       Effect.gen(function* () {
         if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
@@ -79,31 +68,36 @@ export const AttachmentServiceLive = Layer.scoped(
           );
         }
 
-        // We do not validate `sessionId` against the sessions table here.
-        // The session exists by the time the renderer can reach the
-        // composer; bouncing on a missing row is overkill and would
-        // require a second query per upload. The id only flavours the
-        // on-disk filename for human-debuggability.
+        // Bytes land in the workspace's gitignored `.context/files/` so they
+        // sit inside the agent's cwd rather than hidden app data. When the
+        // cwd can't be resolved (e.g. an orphaned session id) we fall back to
+        // the legacy userData directory so the upload never hard-fails.
+        const cwd = yield* resolveSessionCwd(sql, sessionId, rootPath);
+        let dir: string;
+        if (cwd === null) {
+          dir = legacyDir;
+          yield* fs.makeDirectory(dir, { recursive: true }).pipe(Effect.orDie);
+        } else {
+          dir = yield* ensureContextFilesDir(fs, pathSvc, cwd);
+        }
 
         const id = `${sessionSegment(sessionId)}-${randomUUID()}`;
         const ext = extForUpload(mimeType, originalName);
-        const filename = blobFilename(id, ext);
-        const absPath = pathSvc.join(dir, filename);
+        const absPath = pathSvc.join(dir, blobFilename(id, ext));
 
         yield* fs.writeFile(absPath, bytes).pipe(Effect.orDie);
 
         const now = new Date().toISOString();
         yield* sql`
           INSERT INTO attachments (
-            id, session_id, mime_type, size_bytes, original_name, created_at
+            id, session_id, mime_type, size_bytes, original_name, created_at,
+            abs_path
           )
           VALUES (
             ${id}, ${sessionId as string}, ${mimeType}, ${bytes.byteLength},
-            ${originalName}, ${now}
+            ${originalName}, ${now}, ${absPath}
           )
         `.pipe(Effect.orDie);
-
-        yield* touchOne(id);
 
         return {
           id,
@@ -113,15 +107,41 @@ export const AttachmentServiceLive = Layer.scoped(
         };
       });
 
+    const saveText: AttachmentServiceShape["saveText"] = (
+      sessionId,
+      text,
+      ext,
+      rootPath,
+    ) =>
+      Effect.gen(function* () {
+        const cwd = yield* resolveSessionCwd(sql, sessionId, rootPath);
+        if (cwd === null) {
+          return yield* Effect.fail(
+            new ContextWriteError({
+              sessionId,
+              reason: "Could not resolve a workspace root for this session.",
+            }),
+          );
+        }
+        const dir = yield* ensureContextFilesDir(fs, pathSvc, cwd);
+        const name = `paste-${randomUUID()}.${sanitizeExt(ext)}`;
+        const absPath = pathSvc.join(dir, name);
+        yield* fs.writeFileString(absPath, text).pipe(Effect.orDie);
+        const relPath = pathSvc.relative(cwd, absPath);
+        return { relPath, absPath };
+      });
+
     interface AttachmentMetaRow {
       readonly mime_type: string;
       readonly original_name: string;
+      readonly abs_path: string | null;
     }
 
     const resolveAttachmentPath = (id: string) =>
       Effect.gen(function* () {
         const rows = yield* sql<AttachmentMetaRow>`
-          SELECT mime_type, original_name FROM attachments WHERE id = ${id}
+          SELECT mime_type, original_name, abs_path
+          FROM attachments WHERE id = ${id}
         `.pipe(
           Effect.orElseSucceed(
             () => [] as ReadonlyArray<AttachmentMetaRow>,
@@ -129,8 +149,14 @@ export const AttachmentServiceLive = Layer.scoped(
         );
         const row = rows[0];
         if (row === undefined) return null;
-        const ext = extForUpload(row.mime_type, row.original_name);
-        const absPath = pathSvc.join(dir, blobFilename(id, ext));
+        // Pre-migration rows have no `abs_path`; reconstruct the legacy
+        // flat-dir path from the id + extension.
+        const absPath =
+          row.abs_path ??
+          pathSvc.join(
+            legacyDir,
+            blobFilename(id, extForUpload(row.mime_type, row.original_name)),
+          );
         return { absPath, mimeType: row.mime_type };
       });
 
@@ -156,76 +182,9 @@ export const AttachmentServiceLive = Layer.scoped(
         return { path: resolved.absPath, mimeType: resolved.mimeType };
       });
 
-    const touch: AttachmentServiceShape["touch"] = (ids) =>
-      Ref.update(lastTouched, (m) => {
-        const next = new Map(m);
-        const now = Date.now();
-        for (const id of ids) next.set(id, now);
-        return next;
-      });
-
-    /**
-     * Sweep: drop rows + blob files for attachments that
-     *   - are not referenced by any message_attachments row, and
-     *   - were created at least MIN_AGE_MS ago, and
-     *   - haven't been heartbeat in HEARTBEAT_TTL_MS.
-     * The triple-guard keeps drafts and queued chips alive across the
-     * "user typed it but hasn't sent yet" window.
-     */
-    const sweep = Effect.gen(function* () {
-      const cutoff = new Date(Date.now() - MIN_AGE_MS).toISOString();
-      const heartbeats = yield* Ref.get(lastTouched);
-      const stale = (id: string): boolean => {
-        const seen = heartbeats.get(id);
-        return seen === undefined || Date.now() - seen > HEARTBEAT_TTL_MS;
-      };
-
-      interface Candidate {
-        readonly id: string;
-        readonly mime_type: string;
-        readonly original_name: string;
-      }
-      const candidates = yield* sql<Candidate>`
-        SELECT a.id, a.mime_type, a.original_name
-        FROM attachments a
-        LEFT JOIN message_attachments ma ON ma.attachment_id = a.id
-        WHERE ma.attachment_id IS NULL
-          AND a.created_at < ${cutoff}
-      `.pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<Candidate>));
-
-      for (const { id, mime_type, original_name } of candidates) {
-        if (!stale(id)) continue;
-        const absPath = pathSvc.join(
-          dir,
-          blobFilename(id, extForUpload(mime_type, original_name)),
-        );
-        yield* fs
-          .remove(absPath, { force: true })
-          .pipe(Effect.ignoreLogged);
-        yield* sql`DELETE FROM attachments WHERE id = ${id}`.pipe(
-          Effect.ignoreLogged,
-        );
-        yield* Ref.update(lastTouched, (m) => {
-          const next = new Map(m);
-          next.delete(id);
-          return next;
-        });
-      }
-    });
-
-    // Run once on boot and then every 24 h. The sweep is best-effort —
-    // any failure is logged and we keep the service alive.
-    const gcFiber = yield* Effect.forkScoped(
-      sweep.pipe(
-        Effect.ignoreLogged,
-        Effect.repeat(Schedule.spaced(GC_INTERVAL)),
-      ),
-    );
-    yield* Effect.addFinalizer(() => Fiber.interrupt(gcFiber));
-
     return {
       upload,
-      touch,
+      saveText,
       read,
       readPath,
     } satisfies AttachmentServiceShape;

--- a/apps/server/src/attachment/services/attachment-service.ts
+++ b/apps/server/src/attachment/services/attachment-service.ts
@@ -3,6 +3,7 @@ import { Context, type Effect } from "effect";
 import type {
   AttachmentBadMimeError,
   AttachmentTooLargeError,
+  ContextWriteError,
   SessionId,
   SessionNotFoundError,
 } from "@zuse/wire";
@@ -18,6 +19,7 @@ export interface AttachmentServiceShape {
     bytes: Uint8Array,
     mimeType: string,
     originalName: string,
+    rootPath?: string,
   ) => Effect.Effect<
     {
       readonly id: string;
@@ -27,7 +29,20 @@ export interface AttachmentServiceShape {
     },
     UploadFailure
   >;
-  readonly touch: (ids: ReadonlyArray<string>) => Effect.Effect<void>;
+  /**
+   * Persist raw text as a file under the workspace's `.context/files/`
+   * directory and return its workspace-relative + absolute paths. Backs the
+   * `context.saveText` RPC (big-paste-to-file).
+   */
+  readonly saveText: (
+    sessionId: SessionId,
+    text: string,
+    ext: string,
+    rootPath?: string,
+  ) => Effect.Effect<
+    { readonly relPath: string; readonly absPath: string },
+    ContextWriteError
+  >;
   readonly read: (
     id: string,
   ) => Effect.Effect<

--- a/apps/server/src/context/context-files.ts
+++ b/apps/server/src/context/context-files.ts
@@ -1,0 +1,71 @@
+import type { FileSystem, Path } from "@effect/platform";
+import type { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Shared helpers for writing files into a workspace's gitignored
+ * `.context/files/` directory. Both the attachment upload path (images and
+ * dropped files) and `context.saveText` (big text pastes) land here so the
+ * bytes live inside the agent's cwd instead of hidden app data.
+ *
+ * The functions take service *instances* (rather than requiring them from the
+ * Effect context) so callers that captured `SqlClient` / `FileSystem` / `Path`
+ * at layer-construction time can reuse them without widening their effect's
+ * `R` channel.
+ */
+
+interface SessionRow {
+  readonly project_id: string;
+  readonly worktree_id: string | null;
+}
+interface PathRow {
+  readonly path: string;
+}
+
+/**
+ * Resolve the workspace cwd a session runs in: the worktree path when the
+ * session is pinned to one, otherwise the project's checkout. Falls back to
+ * `fallbackRoot` (a renderer-supplied root) when the session row does not
+ * exist yet — e.g. a brand-new chat before its first send. Returns `null`
+ * when nothing resolves.
+ */
+export const resolveSessionCwd = (
+  sql: SqlClient.SqlClient,
+  sessionId: string,
+  fallbackRoot?: string,
+): Effect.Effect<string | null> =>
+  Effect.gen(function* () {
+    const sessions = yield* sql<SessionRow>`
+      SELECT project_id, worktree_id FROM sessions WHERE id = ${sessionId} LIMIT 1
+    `.pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<SessionRow>));
+    const session = sessions[0];
+    if (session === undefined) return fallbackRoot ?? null;
+
+    if (session.worktree_id !== null) {
+      const wt = yield* sql<PathRow>`
+        SELECT path FROM worktrees WHERE id = ${session.worktree_id} LIMIT 1
+      `.pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<PathRow>));
+      if (wt[0] !== undefined) return wt[0].path;
+    }
+
+    const proj = yield* sql<PathRow>`
+      SELECT path FROM projects WHERE id = ${session.project_id} LIMIT 1
+    `.pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<PathRow>));
+    return proj[0]?.path ?? fallbackRoot ?? null;
+  });
+
+/**
+ * Absolute path of `<cwd>/.context/files`, created (recursively) if missing.
+ * `.context` is already registered in the project's `.gitignore` at workspace
+ * registration, so files written here are ignored by git.
+ */
+export const ensureContextFilesDir = (
+  fs: FileSystem.FileSystem,
+  pathSvc: Path.Path,
+  cwd: string,
+): Effect.Effect<string> =>
+  Effect.gen(function* () {
+    const dir = pathSvc.join(cwd, ".context", "files");
+    yield* fs.makeDirectory(dir, { recursive: true }).pipe(Effect.orDie);
+    return dir;
+  });

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -22,6 +22,7 @@ import { Migration0018PokemonWorktrees } from "./migrations/0018_pokemon_worktre
 import { Migration0019QueuePaused } from "./migrations/0019_queue_paused.ts";
 import { Migration0020Events } from "./migrations/0020_events.ts";
 import { Migration0021AuthTokens } from "./migrations/0021_auth_tokens.ts";
+import { Migration0022AttachmentAbsPath } from "./migrations/0022_attachment_abs_path.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -62,6 +63,7 @@ export const MigrationsLive = Layer.effectDiscard(
       "0019_queue_paused": Migration0019QueuePaused,
       "0020_events": Migration0020Events,
       "0021_auth_tokens": Migration0021AuthTokens,
+      "0022_attachment_abs_path": Migration0022AttachmentAbsPath,
     }),
   }),
 );

--- a/apps/server/src/persistence/migrations/0022_attachment_abs_path.ts
+++ b/apps/server/src/persistence/migrations/0022_attachment_abs_path.ts
@@ -1,0 +1,21 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Records the absolute on-disk path of each attachment blob.
+ *
+ * Blobs used to live in a single flat `{userData}/attachments/` directory, so
+ * the path could be reconstructed from the id + extension. They now live in
+ * the workspace's per-session `.context/files/` directory, whose location
+ * depends on the session's cwd — so we persist the resolved absolute path and
+ * read it back directly. Existing rows keep `abs_path` NULL; readers fall back
+ * to the legacy flat-dir layout for those, so pre-migration blobs still
+ * resolve.
+ */
+export const Migration0022AttachmentAbsPath = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    ALTER TABLE attachments ADD COLUMN abs_path TEXT
+  `;
+});

--- a/packages/wire/src/attachment.ts
+++ b/packages/wire/src/attachment.ts
@@ -21,9 +21,16 @@ export class AttachmentBadMimeError extends Schema.TaggedError<AttachmentBadMime
 ) {}
 
 /**
- * Upload an image attachment for a session. Bytes land under the desktop
- * app's userData directory; the returned id is what the renderer stores on
- * `ComposerInput.attachments` and renders via `zuse://attachments/<id>`.
+ * Upload an image attachment for a session. Bytes land in the workspace's
+ * gitignored `.context/files/` directory; the returned id is what the
+ * renderer stores on `ComposerInput.attachments` and renders via
+ * `zuse://attachments/<id>`.
+ *
+ * `rootPath` is an optional fallback workspace root the renderer already
+ * knows. The server prefers to resolve the cwd from `sessionId`, but for a
+ * brand-new chat whose session row does not exist yet the fallback keeps
+ * drop/paste working; when neither resolves, the upload falls back to the
+ * legacy userData attachments directory.
  */
 export const AttachmentUploadRpc = Rpc.make("attachments.upload", {
   payload: Schema.Struct({
@@ -31,6 +38,7 @@ export const AttachmentUploadRpc = Rpc.make("attachments.upload", {
     bytes: Schema.Uint8ArrayFromBase64,
     mimeType: Schema.String,
     originalName: Schema.String,
+    rootPath: Schema.optional(Schema.String),
   }),
   success: Schema.Struct({
     id: Schema.String,
@@ -43,14 +51,4 @@ export const AttachmentUploadRpc = Rpc.make("attachments.upload", {
     AttachmentBadMimeError,
     SessionNotFoundError,
   ),
-});
-
-/**
- * Heartbeat call: keep these attachment ids alive on the server so the GC
- * sweep does not reap blobs that are still referenced by a draft composer
- * input or a queued message. Renderer calls every 30 s with the current set.
- */
-export const AttachmentTouchRpc = Rpc.make("attachments.touch", {
-  payload: Schema.Struct({ ids: Schema.Array(Schema.String) }),
-  success: Schema.Void,
 });

--- a/packages/wire/src/context.ts
+++ b/packages/wire/src/context.ts
@@ -1,0 +1,43 @@
+import { Rpc } from "@effect/rpc";
+import { Schema } from "effect";
+
+import { SessionId } from "./session.ts";
+
+/**
+ * Raised when the server cannot figure out where to write a context file —
+ * e.g. the session row is gone and no fallback workspace root was supplied.
+ */
+export class ContextWriteError extends Schema.TaggedError<ContextWriteError>()(
+  "ContextWriteError",
+  {
+    sessionId: SessionId,
+    reason: Schema.String,
+  },
+) {}
+
+/**
+ * Persist a chunk of text as a file under the workspace's gitignored
+ * `.context/files/` directory and hand back its paths. The renderer uses
+ * this when a large paste would otherwise flood the composer: instead of
+ * inlining the text it drops a `@.context/files/paste-<uuid>.md` file chip,
+ * which flows through the normal `FileRef` pipeline so the agent reads the
+ * file from its own cwd.
+ *
+ * `rootPath` is an optional fallback workspace root the renderer already
+ * knows (`useActiveWorkspaceRoot`). The server prefers to resolve the cwd
+ * from `sessionId`, but for a brand-new chat whose session row does not
+ * exist yet the fallback keeps paste-to-file working.
+ */
+export const ContextSaveTextRpc = Rpc.make("context.saveText", {
+  payload: Schema.Struct({
+    sessionId: SessionId,
+    text: Schema.String,
+    ext: Schema.String,
+    rootPath: Schema.optional(Schema.String),
+  }),
+  success: Schema.Struct({
+    relPath: Schema.String,
+    absPath: Schema.String,
+  }),
+  error: ContextWriteError,
+});

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -5,6 +5,7 @@ export * from "./browser.ts";
 export * from "./code-index.ts";
 export * from "./composer.ts";
 export * from "./connect.ts";
+export * from "./context.ts";
 export * from "./diagnostics.ts";
 export * from "./external-thread.ts";
 export * from "./fs.ts";

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -12,7 +12,8 @@ import {
   AgentStartRpc,
   AgentUpdateProviderRpc,
 } from "./agent.ts";
-import { AttachmentTouchRpc, AttachmentUploadRpc } from "./attachment.ts";
+import { AttachmentUploadRpc } from "./attachment.ts";
+import { ContextSaveTextRpc } from "./context.ts";
 import {
   AuthGetSessionRpc,
   AuthSessionChangesRpc,
@@ -291,7 +292,7 @@ export const MemoizeRpcs = RpcGroup.make(
   MessagesQueueFlushRpc,
   MessagesQueueResumeRpc,
   AttachmentUploadRpc,
-  AttachmentTouchRpc,
+  ContextSaveTextRpc,
   SkillListRpc,
   SkillStreamRpc,
   PermissionRequestsRpc,


### PR DESCRIPTION
## What & why

Composer attachments were written to Electron **app data** (`{userData}/attachments/`), and large text pastes dumped straight into the chatbox. This moves both into the workspace's gitignored **`.context/files/`** directory — inside the agent's cwd, so files are inspectable and read as normal workspace files — and turns a big paste into an attached file instead of noise.

## Changes

**Big text paste → file chip** (new)
- Paste of **>10 lines OR >2,000 chars** becomes `.context/files/paste-<uuid>.md`, inserted as a `FileRef` chip (reuses the `@`-file pipeline; the agent reads it at send time). Backed by a new `context.saveText` RPC.
- Intercepted **inside CodeMirror** (`onTextPaste`), not React `onPaste` — CM inserts pasted text at the editor DOM before a React handler can `preventDefault`.

**Dropped/pasted images & files → `.context/files`** (vision preserved)
- `AttachmentService.upload` resolves the session cwd and writes into `<cwd>/.context/files/`; images still flow through the attachment/`zuse://`/base64-vision pipeline (the model still *sees* them).
- New `abs_path` column on `attachments` (migration `0022`); `read`/`readPath` resolve from it, with a legacy `{userData}/attachments` fallback for pre-migration blobs.
- Desktop `zuse://attachments/<id>` handler resolves `id → abs_path` via a cached read-only `node:sqlite` lookup (with a `.context/files` containment guard), falling back to the old flat-dir scan.
- **Persist decision:** removed the 24h GC sweep + heartbeat (`attachments.touch` RPC, active-id store API).

Shared cwd/dir resolution lives in `apps/server/src/context/context-files.ts`.

## Verification
- `check-types`: `@zuse/wire`, `@zuse/server`, `renderer` pass. (The one `desktop` `LanAuthConfig` error is pre-existing on the branch — reproduces with this change stashed.)
- Tests: server 204/204, renderer 48/48.
- Manual: confirmed in-app that a large paste now becomes a `paste-*.md` file chip (initial React-only attempt failed because CM inserted the text first; fixed by the CodeMirror-level handler).

## Notes for reviewers
- Touches the RPC surface (removed `attachments.touch`, added `context.saveText`) and adds a DB migration — worth a manual smoke test of image drop/paste + history rendering before merge.