### PR TITLE
Improve chat auto-naming with real-time sidebar updates

### DIFF
--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -40,6 +40,7 @@ import {
   MenuTrigger,
 } from "~/components/ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { TypewriterText } from "~/components/typewriter-text.tsx";
 import { toastManager } from "~/components/ui/toast.tsx";
 import { useAuth } from "~/hooks/use-auth.ts";
 import {
@@ -1117,7 +1118,7 @@ function ChatRow({ chat }: { chat: Chat }) {
             className="ml-3"
           />
         )}
-        <span className="min-w-0 flex-1 truncate">{chat.title}</span>
+        <TypewriterText text={chat.title} className="min-w-0 flex-1 truncate" />
         <div className="relative flex h-4 w-16 shrink-0 items-center justify-end">
           <span className="tabular-nums text-[10px] text-muted-foreground transition-opacity duration-150 ease-out motion-reduce:transition-none group-hover:hidden">
             {showDiff && stats !== null ? (

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -1028,7 +1028,7 @@ function GeneralPane() {
       >
         <SettingsRow
           title="Branch naming"
-          description="When a new chat with its own worktree gets its first message, Zuse Alpha summarizes it and renames the chat plus its git branch in this shape."
+          description="When a new chat gets its first real message, Zuse Alpha summarizes the conversation and renames the chat. Worktree-backed chats also rename their git branch in this shape."
           action={
             <Select
               value={branchNamingStyle}

--- a/apps/renderer/src/components/typewriter-text.tsx
+++ b/apps/renderer/src/components/typewriter-text.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "~/lib/utils";
+
+const CHAR_MS = 28;
+
+/**
+ * Reveals `text` character-by-character when it changes. Skips animation on
+ * first mount and when the user prefers reduced motion.
+ */
+export function TypewriterText({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const mountedRef = useRef(false);
+  const prevTextRef = useRef(text);
+  const [displayed, setDisplayed] = useState(text);
+
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      prevTextRef.current = text;
+      setDisplayed(text);
+      return;
+    }
+    if (text === prevTextRef.current) return;
+    prevTextRef.current = text;
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setDisplayed(text);
+      return;
+    }
+
+    let index = 0;
+    setDisplayed("");
+    const timer = window.setInterval(() => {
+      index += 1;
+      setDisplayed(text.slice(0, index));
+      if (index >= text.length) {
+        window.clearInterval(timer);
+      }
+    }, CHAR_MS);
+    return () => window.clearInterval(timer);
+  }, [text]);
+
+  return <span className={cn(className)}>{displayed}</span>;
+}

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -193,6 +193,22 @@ const ensureChangeStream = (projectId: FolderId): void => {
                   },
                 };
               });
+              // Mirror the server-side auto-namer onto member session tabs.
+              useSessionsStore.setState((s) => {
+                const sessions = s.sessionsByProject[projectId];
+                if (sessions === undefined) return s;
+                if (!sessions.some((row) => row.chatId === chat.id)) return s;
+                return {
+                  sessionsByProject: {
+                    ...s.sessionsByProject,
+                    [projectId]: sessions.map((row) =>
+                      row.chatId === chat.id
+                        ? { ...row, title: chat.title }
+                        : row,
+                    ),
+                  },
+                };
+              });
             }),
           ),
       ),

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -53,7 +53,13 @@ import { makeEventStore } from "../../persistence/event-store.ts";
 import { NdjsonLogger } from "../../persistence/ndjson-logger.ts";
 import { PtyService } from "../../pty/services/pty-service.ts";
 import { RepositorySettingsService } from "../../repository-settings/services/repository-settings-service.ts";
-import { TitleGenerator, formatBranchName } from "../title-generator.ts";
+import {
+  TitleGenerator,
+  buildConversationText,
+  formatBranchName,
+  isTrivialUserMessage,
+  shouldDeferAutoName,
+} from "../title-generator.ts";
 import { isIgnorableGrokAuthNoise } from "../drivers/acp/grok-auth-noise.ts";
 import {
   MessageStore,
@@ -479,6 +485,23 @@ const titleFromInitial = (prompt: string | undefined): string => {
   return truncated.length > 0 ? truncated : "New chat";
 };
 
+/** Provisional sidebar title before the LLM auto-namer runs. */
+const deriveProvisionalTitle = (prompt: string | undefined): string => {
+  if (prompt === undefined) return "New chat";
+  if (isTrivialUserMessage(prompt)) return "New chat";
+  return titleFromInitial(prompt);
+};
+
+const textFromMessageContent = (content: MessageContent): string | null => {
+  if (content._tag === "user" || content._tag === "user_rich") {
+    return content.text;
+  }
+  if (content._tag === "assistant") {
+    return content.text;
+  }
+  return null;
+};
+
 /**
  * Render stacked code annotations into the numbered list the model receives.
  * Each entry is `path:lineRange — comment`; the agent's cwd is the workspace
@@ -786,11 +809,10 @@ export const MessageStoreLive = Layer.scoped(
     const broadcastChat = (chat: Chat): Effect.Effect<void> =>
       PubSub.publish(chatChangesHub, chat).pipe(Effect.asVoid);
 
-    // Chats whose first-message auto-name is in flight, so a second message
-    // arriving mid-rename can't kick off a duplicate pass. One-shot per chat
-    // per process — entries are never removed because the triggering hooks
-    // only fire on the first user message anyway.
-    const autoNamingChats = new Set<string>();
+    // Chats whose LLM auto-name is in flight — cleared when the fiber ends.
+    const autoNamingInFlight = new Set<string>();
+    // Chats that already received a successful LLM title this process lifetime.
+    const autoNamedChats = new Set<string>();
 
     const getOrMakePubsub = (sessionId: SessionId) =>
       Effect.gen(function* () {
@@ -1115,6 +1137,9 @@ export const MessageStoreLive = Layer.scoped(
                   event.status === "idle"
                 ) {
                   yield* setStatus(sessionId, event.status);
+                  if (event.status === "idle") {
+                    yield* maybeForkAutoName(session.chatId, sessionId);
+                  }
                 }
                 return;
               }
@@ -1123,6 +1148,9 @@ export const MessageStoreLive = Layer.scoped(
                   sessionId,
                   event.reason === "error" ? "error" : "closed",
                 );
+                if (event.reason !== "error") {
+                  yield* maybeForkAutoName(session.chatId, sessionId);
+                }
                 return;
               }
               if (event._tag === "SessionCursor") {
@@ -1396,7 +1424,7 @@ export const MessageStoreLive = Layer.scoped(
         const now = new Date();
         const nowIso = now.toISOString();
         const title =
-          input.title?.trim() || titleFromInitial(input.initialPrompt);
+          input.title?.trim() || deriveProvisionalTitle(input.initialPrompt);
         const agentsJson =
           input.agents !== undefined && Object.keys(input.agents).length > 0
             ? JSON.stringify({
@@ -1890,7 +1918,7 @@ export const MessageStoreLive = Layer.scoped(
         const nowIso = now.toISOString();
         const chatId = crypto.randomUUID() as unknown as ChatId;
         const title =
-          input.title?.trim() || titleFromInitial(input.initialPrompt);
+          input.title?.trim() || deriveProvisionalTitle(input.initialPrompt);
         const worktreeId = input.worktreeId ?? null;
         yield* sql`
           INSERT INTO chats
@@ -1948,14 +1976,10 @@ export const MessageStoreLive = Layer.scoped(
             )
           : null;
         // Path 1: the chat was created WITH its first message (the common
-        // composer flow). Kick off the background auto-name now — it no-ops
-        // unless the chat has its own worktree.
-        if (
-          hasInitial &&
-          chat.worktreeId !== null &&
-          input.initialPrompt !== undefined
-        ) {
-          yield* forkAutoName(chat.id, initialSession.id, input.initialPrompt);
+        // composer flow). Kick off the background auto-name when there is
+        // enough context (trivial-only greetings wait for a follow-up).
+        if (hasInitial && input.initialPrompt !== undefined) {
+          yield* maybeForkAutoName(chat.id, initialSession.id);
         }
         return { chat, initialSession, initialMessage };
       });
@@ -2024,34 +2048,73 @@ export const MessageStoreLive = Layer.scoped(
       );
 
     /**
-     * Worktree-backed auto-name: on a chat's first user message, summarize it
-     * into a short title (LLM, with truncation fallback) and use that to
-     * rename both the chat and — when the chat has its own worktree — the
-     * worktree's git branch per the user's `branchNamingStyle`. Runs on a
-     * background fiber so the agent's first reply is never delayed; swallows
-     * every failure so a flaky title call can't wedge the session.
-     *
-     * Only chats WITH a worktree are renamed (a bare main-checkout chat keeps
-     * the cheap first-line title set elsewhere).
+     * LLM auto-name: summarize recent user/assistant turns into a short title
+     * and rename the chat (always) plus the worktree git branch (when the chat
+     * has its own worktree). Runs on a background fiber so the agent turn is
+     * never delayed; swallows every failure so a flaky title call can't wedge
+     * the session.
      */
+    const collectAutoNameContext = (
+      chatId: ChatId,
+    ): Effect.Effect<{
+      readonly userTexts: string[];
+      readonly assistantTexts: string[];
+      readonly conversationText: string;
+    }> =>
+      Effect.gen(function* () {
+        const rows = yield* sql<{
+          readonly role: string;
+          readonly content_json: string;
+        }>`
+          SELECT m.role, m.content_json
+          FROM messages m
+          INNER JOIN sessions s ON s.id = m.session_id
+          WHERE s.chat_id = ${chatId}
+            AND m.role IN ('user', 'assistant')
+          ORDER BY m.created_at ASC
+          LIMIT 24
+        `.pipe(Effect.orDie);
+        const turns: Array<{ role: "user" | "assistant"; text: string }> = [];
+        const userTexts: string[] = [];
+        const assistantTexts: string[] = [];
+        for (const row of rows) {
+          try {
+            const content = JSON.parse(row.content_json) as MessageContent;
+            const text = textFromMessageContent(content);
+            if (text === null || text.trim().length === 0) continue;
+            if (row.role === "user") {
+              userTexts.push(text);
+              turns.push({ role: "user", text });
+            } else if (row.role === "assistant") {
+              assistantTexts.push(text);
+              turns.push({ role: "assistant", text });
+            }
+          } catch {
+            // Skip malformed rows — title gen can still fall back.
+          }
+        }
+        return {
+          userTexts,
+          assistantTexts,
+          conversationText: buildConversationText(turns),
+        };
+      });
+
     const autoNameChat = (
       chatId: ChatId,
       sessionId: SessionId,
-      firstText: string,
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
-        if (autoNamingChats.has(chatId)) return;
-        autoNamingChats.add(chatId);
         const chat = yield* lookupChat(chatId).pipe(
           Effect.catchAll(() => Effect.succeed(null)),
         );
-        if (chat === null || chat.worktreeId === null) return;
-        const worktreeId = chat.worktreeId;
-        const wt = yield* worktrees.get(worktreeId);
-        if (wt === null) return;
+        if (chat === null) return;
 
-        // Name the chat with the SAME provider/model the session uses, so a
-        // user without Claude auth (e.g. Grok-only) still gets an LLM title.
+        const context = yield* collectAutoNameContext(chatId);
+        if (shouldDeferAutoName(context.userTexts, context.assistantTexts)) {
+          return;
+        }
+
         const session = yield* lookupSession(sessionId).pipe(
           Effect.catchAll(() => Effect.succeed(null)),
         );
@@ -2060,7 +2123,7 @@ export const MessageStoreLive = Layer.scoped(
           folderId: chat.projectId,
           providerId: session.providerId,
           model: session.model,
-          firstMessage: firstText,
+          conversationText: context.conversationText,
         });
         if (title.length === 0 || title === "New chat") return;
 
@@ -2068,8 +2131,14 @@ export const MessageStoreLive = Layer.scoped(
         // the branch rename below is skipped or fails.
         yield* renameChat(chatId, title);
         yield* sql`
-          UPDATE sessions SET title = ${title} WHERE id = ${sessionId}
+          UPDATE sessions SET title = ${title} WHERE chat_id = ${chatId}
         `.pipe(Effect.ignoreLogged);
+        autoNamedChats.add(chatId);
+
+        if (chat.worktreeId === null) return;
+        const worktreeId = chat.worktreeId;
+        const wt = yield* worktrees.get(worktreeId);
+        if (wt === null) return;
 
         const settings = yield* configStore.getSettings();
         const username = yield* git
@@ -2089,14 +2158,25 @@ export const MessageStoreLive = Layer.scoped(
         );
       }).pipe(Effect.catchAllCause(() => Effect.void));
 
-    const forkAutoName = (
+    const maybeForkAutoName = (
       chatId: ChatId,
       sessionId: SessionId,
-      firstText: string,
     ): Effect.Effect<void> =>
-      Effect.forkDaemon(autoNameChat(chatId, sessionId, firstText)).pipe(
-        Effect.asVoid,
-      );
+      Effect.gen(function* () {
+        if (autoNamedChats.has(chatId) || autoNamingInFlight.has(chatId)) {
+          return;
+        }
+        autoNamingInFlight.add(chatId);
+        yield* Effect.forkDaemon(
+          autoNameChat(chatId, sessionId).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                autoNamingInFlight.delete(chatId);
+              }),
+            ),
+          ),
+        );
+      });
 
     /**
      * Worktrees are immutable past the first user message in any of the
@@ -2819,32 +2899,25 @@ export const MessageStoreLive = Layer.scoped(
           `.pipe(Effect.ignoreLogged);
         }
         yield* broadcastMessage(sessionId, persisted);
-        // Auto-title: if the session is still on its placeholder title, derive
-        // a cheap first-line title immediately so the tab never reads
-        // "New chat" while the richer LLM pass (below) runs.
-        if (session.title === "New chat") {
-          const derived = titleFromInitial(text);
-          if (derived !== "New chat") {
+        const chat = yield* lookupChat(session.chatId);
+        // Provisional title: update chat + session immediately for real tasks
+        // so the sidebar/tab never sit on "New chat" while the LLM pass runs.
+        const provisional = deriveProvisionalTitle(text);
+        if (provisional !== "New chat") {
+          if (session.title === "New chat") {
             yield* sql`
-              UPDATE sessions SET title = ${derived}
+              UPDATE sessions SET title = ${provisional}
               WHERE id = ${sessionId} AND title = 'New chat'
             `.pipe(Effect.orDie);
           }
+          if (chat.title === "New chat") {
+            yield* renameChat(session.chatId, provisional);
+          }
         }
-        // Path 2: an empty chat (no initialPrompt) receiving its first user
-        // message via messages.send. When this is the chat's first user
-        // message, kick off the worktree-backed auto-name in the background
-        // (no-ops unless the chat has its own worktree).
-        const firstUserCount = yield* sql<{ readonly c: number }>`
-          SELECT COUNT(*) AS c FROM messages m
-          INNER JOIN sessions s ON s.id = m.session_id
-          WHERE s.chat_id = ${session.chatId} AND m.role = 'user'
-        `.pipe(
-          Effect.map((rows) => rows[0]?.c ?? 0),
-          Effect.catchAll(() => Effect.succeed(0)),
-        );
-        if (firstUserCount === 1 && text.trim().length > 0) {
-          yield* forkAutoName(session.chatId, sessionId, text);
+        // Try LLM auto-name when there is enough context (trivial-only
+        // greetings wait until the assistant replies or the user sends more).
+        if (text.trim().length > 0) {
+          yield* maybeForkAutoName(session.chatId, sessionId);
         }
         if (asGoal === true) {
           const objective = text.trim();

--- a/apps/server/src/provider/title-generator.ts
+++ b/apps/server/src/provider/title-generator.ts
@@ -15,13 +15,63 @@ import { ProviderService } from "./services/provider-service.ts";
 const TITLE_TIMEOUT_MS = 25_000;
 
 const PROMPT_PREFIX = [
-  "Summarize the following coding task as a SHORT title of 3 to 5 words in Title Case.",
+  "Summarize the following conversation as a SHORT title of 3 to 5 words in Title Case.",
   "Reply with ONLY the title — no quotes, no punctuation, no preamble, no explanation.",
   "Do NOT use any tools, do NOT read or write files, do NOT run commands. Just output the title text.",
   "",
-  "Task:",
+  "Conversation:",
   "",
 ].join("\n");
+
+/** Greetings / filler the auto-namer should ignore until more context arrives. */
+const TRIVIAL_USER_MESSAGE_RE =
+  /^(hi|hey|yo|hello|sup|hiya|howdy|gm|gn|thanks|thx|ok|okay|yes|no|sure|cool|nice|lol|haha|test)[\s!.?]*$/i;
+
+/**
+ * True when a lone user message is too short or conversational to name from.
+ * Used to defer auto-naming until the user sends a real task or the assistant
+ * replies.
+ */
+export const isTrivialUserMessage = (text: string): boolean => {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return true;
+  if (trimmed.length <= 3) return true;
+  return TRIVIAL_USER_MESSAGE_RE.test(trimmed);
+};
+
+/**
+ * Hold off on LLM auto-naming while the thread is only trivial user ping(s)
+ * and the assistant hasn't replied yet.
+ */
+export const shouldDeferAutoName = (
+  userTexts: readonly string[],
+  assistantTexts: readonly string[],
+): boolean => {
+  if (userTexts.length === 0) return true;
+  const combinedUser = userTexts
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .join(" ");
+  if (combinedUser.length === 0) return true;
+  if (assistantTexts.length > 0) return false;
+  if (userTexts.every(isTrivialUserMessage)) return true;
+  return false;
+};
+
+/** Render user/assistant turns into the throwaway title prompt body. */
+export const buildConversationText = (
+  turns: ReadonlyArray<{ readonly role: "user" | "assistant"; readonly text: string }>,
+): string =>
+  turns
+    .map((turn) => {
+      const label = turn.role === "user" ? "User" : "Assistant";
+      const text = turn.text.trim();
+      if (text.length === 0) return null;
+      return `${label}: ${text}`;
+    })
+    .filter((line): line is string => line !== null)
+    .join("\n\n")
+    .slice(0, 4000);
 
 /* ──────────────────────────── pure helpers ──────────────────────────── */
 
@@ -128,8 +178,8 @@ export interface GenerateTitleInput {
   readonly providerId: ProviderId;
   /** The chat's chosen model. */
   readonly model: string;
-  /** The user's first message. */
-  readonly firstMessage: string;
+  /** Recent user/assistant turns to summarize. */
+  readonly conversationText: string;
 }
 
 export interface TitleGeneratorShape {
@@ -161,9 +211,9 @@ export const TitleGeneratorLive = Layer.effect(
 
     const generate: TitleGeneratorShape["generate"] = (input) =>
       Effect.gen(function* () {
-        const fallback = fallbackTitle(input.firstMessage);
+        const fallback = fallbackTitle(input.conversationText);
         const sid = AgentSessionId.make(`title-${crypto.randomUUID()}`);
-        const prompt = `${PROMPT_PREFIX}${input.firstMessage.slice(0, 2000)}`;
+        const prompt = `${PROMPT_PREFIX}${input.conversationText.slice(0, 4000)}`;
 
         const text = yield* Effect.gen(function* () {
           yield* provider.start(

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -260,8 +260,8 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(WorktreeLayer),
     Layer.provide(RepositorySettingsLayer),
     Layer.provide(PtyLayer),
-    // GitService + ConfigStore + TitleGenerator back the first-message
-    // auto-namer (rename chat + branch); see message-store `autoNameChat`.
+    // GitService + ConfigStore + TitleGenerator back the background auto-namer
+    // (rename chat + optional branch); see message-store `autoNameChat`.
     Layer.provide(GitLayer),
     Layer.provide(ConfigStoreLayer),
     Layer.provide(TitleGeneratorLayer),

--- a/apps/server/test/title-generator.test.ts
+++ b/apps/server/test/title-generator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildConversationText,
+  isTrivialUserMessage,
+  shouldDeferAutoName,
+} from "../src/provider/title-generator.ts";
+
+describe("isTrivialUserMessage", () => {
+  it("treats greetings and filler as trivial", () => {
+    expect(isTrivialUserMessage("hi")).toBe(true);
+    expect(isTrivialUserMessage("yo!")).toBe(true);
+    expect(isTrivialUserMessage("hello there")).toBe(false);
+    expect(isTrivialUserMessage("fix the login bug")).toBe(false);
+  });
+});
+
+describe("shouldDeferAutoName", () => {
+  it("waits when only trivial user pings and no assistant reply", () => {
+    expect(shouldDeferAutoName(["hi"], [])).toBe(true);
+    expect(shouldDeferAutoName(["yo", "sup"], [])).toBe(true);
+  });
+
+  it("names once the assistant has replied", () => {
+    expect(shouldDeferAutoName(["hi"], ["Hello! How can I help?"])).toBe(
+      false,
+    );
+  });
+
+  it("names immediately for substantive user tasks", () => {
+    expect(shouldDeferAutoName(["fix the auth redirect"], [])).toBe(false);
+  });
+});
+
+describe("buildConversationText", () => {
+  it("formats ordered turns for the title prompt", () => {
+    expect(
+      buildConversationText([
+        { role: "user", text: "hi" },
+        { role: "assistant", text: "Hey!" },
+        { role: "user", text: "fix login" },
+      ]),
+    ).toBe("User: hi\n\nAssistant: Hey!\n\nUser: fix login");
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-rename **all chats** via LLM after meaningful conversation (worktree git branch rename remains worktree-only)
- Defer naming for trivial openers (`hi`, `yo`, etc.) until the assistant replies or the user sends a real task
- Show provisional titles immediately for substantive messages; stream LLM renames to the sidebar in real time with a typewriter animation
- Sync session tab titles when the chat title updates over `chat.streamChanges`

## Test plan
- [ ] Create a chat **without** a worktree, send a real task → sidebar title updates immediately (provisional), then LLM title with typewriter
- [ ] Create a chat **with** auto-worktree, send a real task → chat title and git branch both rename
- [ ] Send only `hi` → sidebar stays "New chat" until agent replies → LLM title appears with typewriter
- [ ] Send `hi` then a real follow-up → names from full conversation context
- [ ] Confirm session tab title stays in sync with sidebar after auto-rename
- [ ] Confirm reduced-motion preference skips typewriter animation


Made with [Cursor](https://cursor.com)