### PR TITLE
Release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1]
+
+### Fixed
+- Supply the public WorkOS client id at release build time so sign-in works in packaged builds instead of surfacing "WorkOS is not configured".
+
+### Changed
+- Fork chat + plan/context handoff (#252)
+- Route pasted text & dropped files into .context/files (#246)
+
 ## [0.10.0]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.10.1",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Supply the public WorkOS client id at release build time so sign-in works in packaged builds instead of surfacing \"WorkOS is not configured\"."
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Fork chat + plan/context handoff (#252)",
+          "Route pasted text & dropped files into .context/files (#246)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.10.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- Release Zuse v0.10.1
- **Fix:** supply the public WorkOS client id at release build time (GitHub secret `WORKOS_CLIENT_ID` corrected) so sign-in works in packaged builds instead of surfacing "WorkOS is not configured"
- Update CHANGELOG.md + package metadata; regenerate website Change Log page

## Included since v0.10.0
- Fork chat + plan/context handoff (#252)
- Route pasted text & dropped files into .context/files (#246)

## Test
- bun run check-types (all 10 packages pass)

Release artifacts are produced by pushing tag v0.10.1 after this PR lands.