### PR TITLE
Release v0.10.2 — fix WorkOS client id stripped by turbo strict env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2]
+
+### Fixed
+- Actually inline the public WorkOS client id into release builds: Turborepo's strict env mode was stripping `WORKOS_CLIENT_ID` before `tsdown` ran, so packaged builds shipped an empty id and sign-in reported "WorkOS is not configured". Declared the var in `turbo.json` so it reaches the build. Supersedes 0.10.1, which still shipped empty.
+
 ## [0.10.1]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.10.2",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Actually inline the public WorkOS client id into release builds: Turborepo's strict env mode was stripping `WORKOS_CLIENT_ID` before `tsdown` ran, so packaged builds shipped an empty id and sign-in reported \"WorkOS is not configured\". Declared the var in `turbo.json` so it reaches the build. Supersedes 0.10.1, which still shipped empty."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.10.1",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,13 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      // Turbo runs in strict env mode: env vars not listed here are stripped
+      // from the task before it runs. tsdown inlines the public WorkOS client
+      // id from process.env.WORKOS_CLIENT_ID at build time, so it must survive
+      // into the build task (CI supplies it; empty locally is fine). Listing it
+      // under `env` also makes it part of the cache key, so changing the id
+      // busts stale build output.
+      "env": ["WORKOS_CLIENT_ID"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", "dist-electron/**"]
     },
     "lint": {


### PR DESCRIPTION
## The real root cause
The shipped **v0.10.0 app has `CLIENT_ID = ""` baked in** (verified by grepping the installed `.app`). The GitHub secret was fine; the problem is **Turborepo strict env mode**.

`bun run build` → `turbo run build`. Turbo 2.x defaults to strict env mode and strips any env var not declared in `turbo.json`. `WORKOS_CLIENT_ID` was declared nowhere, so it never reached `tsdown`, and the client id inlined as an empty string regardless of the secret.

Reproduced: building through turbo with the id explicitly set still produced `CLIENT_ID = ""`. After declaring `env: ["WORKOS_CLIENT_ID"]`, the turbo build inlines `CLIENT_ID = "client_01KWGQ…"`.

## Why v0.10.2 (not v0.10.1)
v0.10.1 only corrected the secret value — it built before this turbo fix and **still ships empty**. This supersedes it; electron-updater pulls users forward.

## Change
- `turbo.json`: add `env: ["WORKOS_CLIENT_ID"]` to the `build` task (also makes the id part of the cache key).

## Test
- `bun run check-types` — all 10 packages pass
- Verified inlining through the turbo path: id set → `CLIENT_ID = "client_01KWGQ…"`; unset → `""` (graceful)

Release artifacts produced by pushing tag v0.10.2 after merge.