### PR TITLE
Release v0.10.3 — land WorkOS sign-in on a success page, drop open-app prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3]
+
+### Changed
+- Finish WorkOS sign-in on a proper "Signed in — you can close this tab" page instead of leaving the browser hanging on a dead `zuse://` URL, and drop the OS "Open in Zuse Alpha?" prompt. Packaged builds now use the localhost loopback redirect (like dev); the `zuse://` scheme handler stays registered as a fallback.
+
 ## [0.10.2]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -166,13 +166,16 @@ app.setAsDefaultProtocolClient("zuse");
 // ---------------------------------------------------------------------------
 const AUTH_LOOPBACK_PORT = 8976;
 const AUTH_LOOPBACK_URI = `http://localhost:${AUTH_LOOPBACK_PORT}/callback`;
-const AUTH_SCHEME_URI = "zuse://auth/callback";
-// Packaged builds use the custom scheme — a signed app with its own bundle id
-// (app.memoize.desktop) + Info.plist `CFBundleURLTypes` (electron-builder
-// `protocols`) resolves it unambiguously, and it's the same mechanism mobile
-// will use. Dev uses the loopback because the prebuilt Electron.app's shared
-// `com.github.Electron` bundle id makes custom schemes unroutable.
-const AUTH_REDIRECT_URI = app.isPackaged ? AUTH_SCHEME_URI : AUTH_LOOPBACK_URI;
+// Both dev and packaged use the loopback as the WorkOS redirect_uri. It's the
+// RFC 8252 native-app pattern and gives a strictly better sign-in finish:
+//   - the browser lands on a real HTML page ("Signed in, you can close this
+//     tab") instead of a dead `zuse://` URL that leaves the tab hanging, and
+//   - no OS "Open in Zuse Alpha?" prompt — the browser hits localhost and the
+//     already-running app answers directly, no deep-link handoff needed.
+// The `zuse://auth/callback` scheme handler stays registered below as a
+// fallback (and the future mobile path), but is no longer the primary flow.
+// Register `http://localhost:8976/callback` in the WorkOS dashboard.
+const AUTH_REDIRECT_URI = AUTH_LOOPBACK_URI;
 const AUTH_DEEP_LINK_SCHEMES = ["zuse://", "memoize://"] as const;
 
 const isAuthDeepLink = (arg: string): boolean =>
@@ -1561,9 +1564,11 @@ void app.whenReady().then(() => {
   // don't build a window or boot the runtime.
   if (!gotSingleInstanceLock) return;
 
-  // Dev only: localhost loopback that catches the WorkOS OAuth callback.
-  // Packaged builds receive it via the `zuse://` deep link instead.
-  if (!app.isPackaged) startAuthLoopback();
+  // Localhost loopback that catches the WorkOS OAuth callback (dev + packaged).
+  // It's the redirect_uri for both, so the browser finishes on a real HTML
+  // page and no `zuse://` deep-link handoff/prompt is needed. The scheme
+  // handler stays registered below as a fallback.
+  startAuthLoopback();
 
   // Win/Linux cold launch from a deep link: the URL is an argv entry.
   const initialDeepLink = process.argv.find(isAuthDeepLink);

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.10.3",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Finish WorkOS sign-in on a proper \"Signed in — you can close this tab\" page instead of leaving the browser hanging on a dead `zuse://` URL, and drop the OS \"Open in Zuse Alpha?\" prompt. Packaged builds now use the localhost loopback redirect (like dev); the `zuse://` scheme handler stays registered as a fallback."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.10.2",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## What
After WorkOS sign-in, packaged builds left the browser hanging on a dead `zuse://auth/callback` URL (a custom scheme can't render a page) and required approving an OS "Open in Zuse Alpha?" prompt.

Now packaged builds use the localhost loopback redirect (same as dev), so:
- the browser finishes on the existing **"Signed in — you can close this tab and return to Zuse Alpha"** HTML page, and
- no OS open-app prompt — the browser hits `localhost` and the already-running app answers directly.

The `zuse://` scheme handler stays registered as a fallback.

## Dashboard prerequisite (done)
`http://localhost:8976/callback` is registered in the WorkOS dashboard (same environment as the client id), alongside `zuse://auth/callback`.

## Trade-off
Fixed loopback port 8976 — if another process holds it at sign-in time, the loopback can't bind. Rare; scheme handler remains as fallback.

## Test
- `bun run check-types` — all 10 packages pass

Release artifacts produced by pushing tag v0.10.3 after merge.