### PR TITLE
Auto-update: background download, restart toast, quit guard

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -25,6 +25,7 @@ import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 import { makeMainLayer } from "@zuse/server";
+import { AGENTS_RUNNING_COUNT_CHANNEL } from "@zuse/wire";
 
 // macOS GUI apps launched from Finder inherit a minimal PATH
 // (`/usr/bin:/bin:/usr/sbin:/sbin`), not the user's shell PATH. The Claude
@@ -45,6 +46,7 @@ import {
   type MenuCommand,
 } from "./menu.ts";
 import {
+  getIsInstallingUpdate,
   getLastStatus,
   onStatusChange,
   registerUpdaterDemo,
@@ -1620,4 +1622,69 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
   }
+});
+
+// ---------------------------------------------------------------------------
+// Quit guard. Agents (Claude/Codex/Grok/… turns) run as child processes owned
+// by the embedded server. Quitting mid-turn kills them, so if any are running
+// we confirm first. The renderer store is the source of truth for "how many
+// are running"; it pushes the count here on every change (see preload
+// `updates.reportRunningCount`). We mirror the latest value so the
+// synchronous `before-quit` handler can read it without a round-trip.
+// ---------------------------------------------------------------------------
+let runningAgentCount = 0;
+// Set once the user has confirmed a quit (or an update install begins) so a
+// re-entrant `before-quit` — Electron fires it again after `app.quit()` — does
+// not pop the dialog a second time.
+let quitConfirmed = false;
+// Armed by the dialog's "Quit when idle" choice: keep running, then quit
+// automatically the moment the last agent finishes.
+let quitWhenIdle = false;
+
+ipcMain.on(AGENTS_RUNNING_COUNT_CHANNEL, (_event, payload: unknown) => {
+  runningAgentCount = typeof payload === "number" && payload >= 0 ? payload : 0;
+  if (quitWhenIdle && runningAgentCount === 0) {
+    quitConfirmed = true;
+    app.quit();
+  }
+});
+
+function pluralAgents(count: number): string {
+  return count === 1 ? "1 agent is running" : `${count} agents are running`;
+}
+
+app.on("before-quit", (event) => {
+  // An update-driven quit (user picked "Restart now") or an already-confirmed
+  // quit passes straight through — the user has opted in, and re-prompting
+  // would strand the relaunch.
+  if (quitConfirmed || getIsInstallingUpdate()) return;
+  if (runningAgentCount <= 0) return;
+
+  event.preventDefault();
+
+  const choice = dialog.showMessageBoxSync({
+    type: "warning",
+    buttons: ["Cancel", "Quit anyway", "Quit when idle"],
+    defaultId: 0,
+    cancelId: 0,
+    title: "Quit Zuse Alpha?",
+    message: `${pluralAgents(runningAgentCount)} currently.`,
+    detail:
+      "Quitting now will stop them mid-turn. You can quit anyway, or have Zuse quit automatically once they finish.",
+  });
+
+  if (choice === 1) {
+    quitConfirmed = true;
+    app.quit();
+  } else if (choice === 2) {
+    quitWhenIdle = true;
+    // Stay open; the running-count handler quits once the count hits zero.
+    // Guard against the race where every agent already finished between the
+    // count push and this click.
+    if (runningAgentCount === 0) {
+      quitConfirmed = true;
+      app.quit();
+    }
+  }
+  // choice === 0 (Cancel): stay open — quit already prevented.
 });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from "electron";
 
 import {
+  AGENTS_RUNNING_COUNT_CHANNEL,
   IPC_CHANNEL,
   UPDATE_CHECK_CHANNEL,
   UPDATE_DOWNLOAD_CHANNEL,
@@ -145,6 +146,14 @@ const bridge = {
       ipcRenderer.invoke(UPDATE_DOWNLOAD_CHANNEL) as Promise<void>,
     installNow: () =>
       ipcRenderer.invoke(UPDATE_INSTALL_CHANNEL) as Promise<void>,
+    /**
+     * Push the current running-agent count to main so the `before-quit` guard
+     * and the "quit/restart when idle" deferrals have a fresh value. Fire on
+     * every change (and once on mount). Renderer store is the source of truth.
+     */
+    reportRunningCount: (count: number) => {
+      ipcRenderer.send(AGENTS_RUNNING_COUNT_CHANNEL, count);
+    },
     // Dev-only escape hatch: only handled in dev (see updater.ts
     // `registerUpdaterDemo`). Calling in a packaged build rejects harmlessly.
     __demoSet: (status: UpdateStatus) =>

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -1,4 +1,4 @@
-import { ipcMain, type BrowserWindow } from "electron";
+import { app, ipcMain, type BrowserWindow } from "electron";
 import {
   autoUpdater,
   type ProgressInfo,
@@ -33,6 +33,47 @@ const DOWNLOAD_STALL_MS = 60_000;
 
 let lastStatus: UpdateStatus = { kind: "idle" };
 let started = false;
+
+// Set for the brief window between "the app is quitting to install an update"
+// and process exit. The `before-quit` agent guard in main.ts reads this so an
+// update-driven quit doesn't pop the "N agents are running — quit anyway?"
+// confirmation (the user already opted into restarting from the toast).
+let installingUpdate = false;
+
+/**
+ * True once `installUpdate()` has kicked off the quit-and-install sequence.
+ * The main-process quit guard checks this to skip its agent confirmation.
+ */
+export function getIsInstallingUpdate(): boolean {
+  return installingUpdate;
+}
+
+/**
+ * Single entry point for "quit, install the downloaded update, relaunch".
+ * Both the renderer IPC (`UPDATE_INSTALL_CHANNEL`) and the native menu route
+ * through here so the `installingUpdate` guard is always set before the app
+ * begins tearing down — otherwise the `before-quit` handler would treat the
+ * install as a user quit and block it behind the agent confirmation.
+ */
+export function installUpdate(): void {
+  installingUpdate = true;
+  autoUpdater.quitAndInstall();
+
+  // Relaunch watchdog. On macOS, `quitAndInstall` hands off to Squirrel.Mac
+  // (ShipIt), which waits for THIS process to terminate, swaps the bundle, and
+  // relaunches. The relaunch is scheduled the instant `quitAndInstall` runs, so
+  // once we're here the only thing that can strand it is the old process
+  // failing to exit promptly (a hung fiber teardown, a wedged child, Electron
+  // waiting on a stuck `will-quit`). If we're still alive after a short grace
+  // period, force the exit so ShipIt can proceed — the symptom this fixes is
+  // "the app quit but never reopened".
+  setTimeout(() => {
+    console.warn(
+      "[zuse:updater] still alive after quitAndInstall — forcing exit so the updater can relaunch",
+    );
+    app.exit(0);
+  }, 4000).unref();
+}
 
 const statusListeners = new Set<(status: UpdateStatus) => void>();
 
@@ -132,10 +173,12 @@ export function startAutoUpdater(window: BrowserWindow): void {
     debug: () => {},
   } as unknown as typeof autoUpdater.logger;
 
-  // Wait for the user to opt in via the banner before consuming bandwidth,
-  // but if they ignore the "Restart" button we still install on next quit so
-  // the update isn't stranded forever.
-  autoUpdater.autoDownload = false;
+  // Download in the background the moment an update is detected — the user
+  // shouldn't have to click "Update now". The restart toast only appears once
+  // the download finishes (`update-downloaded` → `ready`). If they ignore the
+  // "Restart" button we still install on next quit so the update isn't
+  // stranded forever.
+  autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 
   autoUpdater.on("checking-for-update", () => {
@@ -184,9 +227,9 @@ export function startAutoUpdater(window: BrowserWindow): void {
     });
   });
   ipcMain.handle(UPDATE_INSTALL_CHANNEL, () => {
-    // `quitAndInstall` synchronously kicks off shutdown; the await is just
-    // for symmetry with the other handlers.
-    autoUpdater.quitAndInstall();
+    // Routes through `installUpdate` so the `installingUpdate` guard is set
+    // before shutdown begins — otherwise the before-quit agent guard blocks it.
+    installUpdate();
   });
 
   const check = () => {
@@ -218,7 +261,7 @@ export function triggerUpdateDownload(): void {
 }
 
 export function triggerUpdateInstall(): void {
-  autoUpdater.quitAndInstall();
+  installUpdate();
 }
 
 /**

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -33,6 +33,7 @@ import { UpdateBanner } from "./components/update-banner.tsx";
 import { UsageDashboard } from "./components/usage-dashboard.tsx";
 import { useKeybindingDispatch } from "./hooks/use-keybinding-dispatch.ts";
 import { useMenuShortcuts } from "./hooks/use-menu-shortcuts.ts";
+import { useReportRunningAgents } from "./hooks/use-report-running-agents.ts";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { AppearanceController } from "./lib/appearance.tsx";
 import { useAuthStore } from "./store/auth.ts";
@@ -170,6 +171,10 @@ export function App() {
   // and editor commands are handled by CodeMirror keymaps, so this hook
   // ignores them.
   useKeybindingDispatch();
+
+  // Mirror the running-agent count to main so the before-quit guard and the
+  // "quit/restart when idle" deferrals have a live value.
+  useReportRunningAgents();
 
   // Hydrate settings + keybindings + subagents from the on-disk config
   // store. Each call is idempotent; subsequent emits flow through the

--- a/apps/renderer/src/components/update-banner.tsx
+++ b/apps/renderer/src/components/update-banner.tsx
@@ -1,45 +1,53 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   Alert01Icon,
-  CheckmarkCircle02Icon,
   CircleArrowUp01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 
 import type { UpdateStatus } from "@zuse/wire";
 
 import { Button } from "~/components/ui/button";
-import { ShimmerText } from "~/components/ui/shimmer-text";
-import {
-  Progress,
-  ProgressIndicator,
-  ProgressTrack,
-} from "~/components/ui/progress";
+import { useMessagesStore } from "~/store/messages.ts";
 
 /**
  * Bottom-right toast for the electron-updater lifecycle. Subscribes to the
  * preload bridge's `updates.onStatus` channel.
  *
- * Lifecycle:
- *  - `available` → shows "Update now / Install on quit / Later" — nothing
- *     downloads until the user picks.
- *  - `downloading` → progress bar; "Update now" auto-installs when ready,
- *     "Install on quit" silently completes and stays out of the way.
- *  - `ready` → if user picked "Update now", we call installNow immediately;
- *     otherwise the toast hides (electron-updater installs on next quit
- *     because `autoInstallOnAppQuit = true` in the main process).
+ * Downloads happen automatically in the background (`autoDownload = true` in
+ * the main process), so the toast stays silent through `checking` /
+ * `available` / `downloading` and only appears once the update is fully
+ * downloaded (`ready`) — or on `error`.
  *
- * Idle / checking / not-available / error are no-ops.
+ * On `ready` the user picks one of:
+ *  - **Restart now** — installs + relaunches immediately. If agents are still
+ *    running we confirm first ("N agents are running — restart anyway?").
+ *  - **Restart later** — dismiss; electron-updater installs on next quit
+ *    (`autoInstallOnAppQuit = true`).
+ *  - **Restart when idle** — installs automatically once no agents are running.
  */
 export function UpdateBanner() {
   const [status, setStatus] = useState<UpdateStatus>({ kind: "idle" });
   const [dismissed, setDismissed] = useState(false);
-  // Tracks which option the user picked so we know what to do when the
-  // download completes. Ref because we don't want to trigger a re-render
-  // when it changes — only the IPC-driven `status` does.
-  const installModeRef = useRef<"now" | "quit" | null>(null);
+  // Whether the in-toast "restart anyway?" confirmation is showing (set when
+  // the user clicks "Restart now" while agents are running).
+  const [confirming, setConfirming] = useState(false);
+  // When true, we install automatically the moment the running-agent count
+  // reaches zero. Survives a dismiss so "restart when idle" still fires after
+  // the user tucks the toast away.
+  const [installWhenIdle, setInstallWhenIdle] = useState(false);
+
+  // Global count of sessions with an in-flight turn. Primitive selector, so
+  // this only re-renders when the number actually changes.
+  const runningCount = useMessagesStore((s) => {
+    let count = 0;
+    for (const running of Object.values(s.runningBySession)) {
+      if (running) count += 1;
+    }
+    return count;
+  });
 
   useEffect(() => {
     const updates = window.zuse?.updates;
@@ -47,56 +55,56 @@ export function UpdateBanner() {
     return updates.onStatus(setStatus);
   }, []);
 
-  // Re-surface a fresh "available" even if the user dismissed the previous one.
-  // Also re-show on `error` so a silent stall or failed download isn't
-  // invisible — the user needs to see it to retry.
+  // Re-surface a fresh `ready`/`error` even if a previous toast was dismissed,
+  // and reset the transient confirm state. `installWhenIdle` is intentionally
+  // NOT reset here so it persists across a dismiss.
   useEffect(() => {
-    if (status.kind === "available" || status.kind === "error") {
-      installModeRef.current = null;
+    if (status.kind === "ready" || status.kind === "error") {
+      setConfirming(false);
       setDismissed(false);
     }
   }, [status.kind]);
 
-  // Auto-install on ready when the user explicitly chose "Update now".
+  // Install automatically once agents finish, if the user chose "when idle".
   useEffect(() => {
-    if (status.kind === "ready" && installModeRef.current === "now") {
+    if (installWhenIdle && status.kind === "ready" && runningCount === 0) {
       void window.zuse?.updates?.installNow();
     }
-  }, [status.kind]);
+  }, [installWhenIdle, status.kind, runningCount]);
 
-  if (
-    dismissed ||
-    status.kind === "idle" ||
-    status.kind === "checking" ||
-    status.kind === "not-available"
-  ) {
+  if (dismissed || (status.kind !== "ready" && status.kind !== "error")) {
     return null;
   }
 
-  // "Install on quit" mode disappears entirely once download finishes —
-  // electron-updater's autoInstallOnAppQuit handles the rest silently.
-  if (status.kind === "ready" && installModeRef.current === "quit") {
-    return null;
-  }
-
-  const onUpdateNow = () => {
-    installModeRef.current = "now";
-    void window.zuse?.updates?.download();
+  const onRestartNow = () => {
+    if (runningCount > 0) {
+      setConfirming(true);
+      return;
+    }
+    void window.zuse?.updates?.installNow();
   };
-  const onUpdateOnQuit = () => {
-    installModeRef.current = "quit";
-    void window.zuse?.updates?.download();
+  const onConfirmRestart = () => {
+    void window.zuse?.updates?.installNow();
+  };
+  const onCancelConfirm = () => {
+    setConfirming(false);
+  };
+  const onRestartWhenIdle = () => {
+    if (runningCount === 0) {
+      void window.zuse?.updates?.installNow();
+      return;
+    }
+    setInstallWhenIdle(true);
+    setDismissed(true);
   };
   const onLater = () => {
     setDismissed(true);
   };
-  const onRestartNow = () => {
-    void window.zuse?.updates?.installNow();
-  };
   const onRetry = () => {
-    installModeRef.current = null;
     void window.zuse?.updates?.check();
   };
+
+  const isError = status.kind === "error";
 
   // Portal to document.body so the toast escapes any ancestor that creates a
   // containing block — `<main>` uses `backdrop-blur-3xl`, and any
@@ -110,35 +118,29 @@ export function UpdateBanner() {
     >
       <div className="flex items-start gap-3">
         <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
-          {status.kind === "ready" ? (
-            <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-4" />
-          ) : status.kind === "error" ? (
-            <HugeiconsIcon icon={Alert01Icon} className="size-4" />
-          ) : (
-            <HugeiconsIcon icon={CircleArrowUp01Icon} className="size-4" />
-          )}
+          <HugeiconsIcon
+            icon={isError ? Alert01Icon : CircleArrowUp01Icon}
+            className="size-4"
+          />
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <span className="text-[13px] font-medium text-foreground">
-            {status.kind === "available" && "Update available"}
-            {status.kind === "downloading" && (
-              <ShimmerText>Downloading update…</ShimmerText>
-            )}
-            {status.kind === "ready" && "Update ready"}
-            {status.kind === "error" && "Update failed"}
+            {isError
+              ? "Update failed"
+              : confirming
+                ? "Agents are running"
+                : "Update available"}
           </span>
           <span className="text-[12px] leading-snug text-muted-foreground">
-            {status.kind === "available" &&
-              `Zuse Alpha ${status.version} is ready to install.`}
-            {status.kind === "downloading" &&
-              `${Math.round(status.percent)}%${
-                status.bytesPerSecond > 0
-                  ? ` · ${formatRate(status.bytesPerSecond)}`
-                  : ""
-              }`}
+            {isError && status.message}
             {status.kind === "ready" &&
-              `Restart to finish installing Zuse Alpha ${status.version}.`}
-            {status.kind === "error" && status.message}
+              !confirming &&
+              `Zuse Alpha ${status.version} is ready. Restart to finish installing.`}
+            {status.kind === "ready" &&
+              confirming &&
+              `${
+                runningCount === 1 ? "1 agent is" : `${runningCount} agents are`
+              } running and will stop mid-turn. Restart anyway?`}
           </span>
         </div>
         <button
@@ -151,15 +153,7 @@ export function UpdateBanner() {
         </button>
       </div>
 
-      {status.kind === "downloading" && (
-        <Progress value={status.percent}>
-          <ProgressTrack>
-            <ProgressIndicator />
-          </ProgressTrack>
-        </Progress>
-      )}
-
-      {status.kind === "available" && (
+      {status.kind === "ready" && !confirming && (
         <div className="flex flex-wrap items-center justify-end gap-1.5">
           <Button
             size="xs"
@@ -167,35 +161,15 @@ export function UpdateBanner() {
             onClick={onLater}
             className="rounded-full text-[11px]"
           >
-            Later
+            Restart later
           </Button>
           <Button
             size="xs"
             variant="ghost"
-            onClick={onUpdateOnQuit}
+            onClick={onRestartWhenIdle}
             className="rounded-full text-[11px]"
           >
-            Install on quit
-          </Button>
-          <Button
-            size="xs"
-            onClick={onUpdateNow}
-            className="rounded-full text-[11px]"
-          >
-            Update now
-          </Button>
-        </div>
-      )}
-
-      {status.kind === "ready" && (
-        <div className="flex items-center justify-end gap-1.5">
-          <Button
-            size="xs"
-            variant="ghost"
-            onClick={onLater}
-            className="rounded-full text-[11px]"
-          >
-            Later
+            Restart when idle
           </Button>
           <Button
             size="xs"
@@ -207,12 +181,32 @@ export function UpdateBanner() {
         </div>
       )}
 
-      {status.kind === "error" && (
+      {status.kind === "ready" && confirming && (
         <div className="flex items-center justify-end gap-1.5">
           <Button
             size="xs"
             variant="ghost"
-            onClick={onLater}
+            onClick={onCancelConfirm}
+            className="rounded-full text-[11px]"
+          >
+            Cancel
+          </Button>
+          <Button
+            size="xs"
+            onClick={onConfirmRestart}
+            className="rounded-full text-[11px]"
+          >
+            Restart anyway
+          </Button>
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex items-center justify-end gap-1.5">
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={() => setDismissed(true)}
             className="rounded-full text-[11px]"
           >
             Dismiss
@@ -231,14 +225,4 @@ export function UpdateBanner() {
     </div>,
     document.body,
   );
-}
-
-function formatRate(bytesPerSecond: number): string {
-  if (bytesPerSecond >= 1_000_000) {
-    return `${(bytesPerSecond / 1_000_000).toFixed(1)} MB/s`;
-  }
-  if (bytesPerSecond >= 1_000) {
-    return `${(bytesPerSecond / 1_000).toFixed(0)} KB/s`;
-  }
-  return `${Math.round(bytesPerSecond)} B/s`;
 }

--- a/apps/renderer/src/hooks/use-report-running-agents.ts
+++ b/apps/renderer/src/hooks/use-report-running-agents.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+import { useMessagesStore } from "../store/messages.ts";
+
+/**
+ * Mirror the number of currently-running agents to the main process.
+ *
+ * `runningBySession` (fed by the `session.streamStatus` subscription) is the
+ * renderer's source of truth for which sessions have an in-flight turn. Main
+ * needs the *count* for two things it owns: the `before-quit` guard
+ * ("N agents are running — quit anyway?") and the "quit/restart when idle"
+ * deferrals. We push on every change (and once on mount) over the preload
+ * bridge; main just caches the latest value.
+ *
+ * Mount once, near the app root.
+ */
+export function useReportRunningAgents(): void {
+  useEffect(() => {
+    const report = (count: number) => {
+      window.zuse?.updates?.reportRunningCount(count);
+    };
+
+    const countRunning = (state: {
+      runningBySession: Record<string, boolean>;
+    }): number => {
+      let count = 0;
+      for (const running of Object.values(state.runningBySession)) {
+        if (running) count += 1;
+      }
+      return count;
+    };
+
+    let last = countRunning(useMessagesStore.getState());
+    report(last);
+
+    return useMessagesStore.subscribe((state) => {
+      const next = countRunning(state);
+      if (next !== last) {
+        last = next;
+        report(next);
+      }
+    });
+  }, []);
+}

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -28,7 +28,9 @@ export interface AppBridge {
   readonly revealPath?: (path: string) => Promise<void>;
   readonly copyPath?: (path: string) => Promise<void>;
   readonly copyFileContents?: (path: string) => Promise<boolean>;
-  readonly getMainDiagnostics?: () => Promise<ReadonlyArray<DiagnosticLogEntry>>;
+  readonly getMainDiagnostics?: () => Promise<
+    ReadonlyArray<DiagnosticLogEntry>
+  >;
 }
 
 export interface DiagnosticLogEntry {
@@ -51,6 +53,12 @@ export interface UpdatesBridge {
   readonly check: () => Promise<void>;
   readonly download: () => Promise<void>;
   readonly installNow: () => Promise<void>;
+  /**
+   * Push the current running-agent count to main (for the before-quit guard
+   * and "quit/restart when idle" deferrals). Renderer store is the source of
+   * truth; call on every change.
+   */
+  readonly reportRunningCount: (count: number) => void;
   /** Dev-only: round-trips a synthetic status through the real IPC channel. */
   readonly __demoSet?: (status: UpdateStatus) => Promise<void>;
 }

--- a/packages/wire/src/update.ts
+++ b/packages/wire/src/update.ts
@@ -11,6 +11,16 @@ export const UPDATE_CHECK_CHANNEL = "zuse:update-check" as const;
 export const UPDATE_DOWNLOAD_CHANNEL = "zuse:update-download" as const;
 export const UPDATE_INSTALL_CHANNEL = "zuse:update-install" as const;
 
+/**
+ * Renderer → main push of the current number of running agents (sessions with
+ * `status === "running"`, summed across all tabs). The renderer store is the
+ * source of truth for this; main mirrors the latest value so the `before-quit`
+ * guard can ask "N agents are running — quit anyway?" synchronously, and so the
+ * "quit/restart when idle" deferrals know when the count reaches zero.
+ */
+export const AGENTS_RUNNING_COUNT_CHANNEL =
+  "zuse:agents-running-count" as const;
+
 export type UpdateStatus =
   | { readonly kind: "idle" }
   | { readonly kind: "checking" }


### PR DESCRIPTION
## What & why

Overhauls the auto-update flow. Previously updates were **foreground/opt-in** (user had to click "Update now" before anything downloaded), and after installing, the app **quit but never relaunched** — even mid-agent.

### Now
- **Background download** — `autoUpdater.autoDownload = true`. Updates download silently the moment they're detected; no click required.
- **Restart toast** — stays silent through download and only appears once the update is downloaded (`ready`), offering:
  - **Restart now** — installs + relaunches immediately. If agents are running, confirms first ("N agents are running — restart anyway?").
  - **Restart later** — dismiss; installs on next quit (`autoInstallOnAppQuit`).
  - **Restart when idle** — installs automatically once no agents are running.
- **Quit guard** — `before-quit` shows a native dialog *"N agents are running currently."* with **Cancel / Quit anyway / Quit when idle** when agents are mid-turn. Update-driven quits bypass it so restarts aren't blocked or double-prompted.
- **Relaunch fix** — all installs route through one `installUpdate()` that sets an `installingUpdate` guard and adds a watchdog: if the old process is still alive 4s after `quitAndInstall`, it force-exits so Squirrel.Mac/ShipIt (which waits on the old PID) can swap the bundle and relaunch.

### The running-count seam
The renderer store's `runningBySession` is the source of truth. A new `useReportRunningAgents()` hook pushes the count to main over a new IPC channel (`AGENTS_RUNNING_COUNT_CHANNEL`), mirroring the existing accelerator-push pattern. Main caches it for both the quit guard and the idle deferrals.

## Files
- `packages/wire/src/update.ts` — new `AGENTS_RUNNING_COUNT_CHANNEL`.
- `apps/desktop/src/updater.ts` — `autoDownload=true`, `installUpdate()` + `getIsInstallingUpdate()` + relaunch watchdog.
- `apps/desktop/src/main.ts` — before-quit guard, running-count mirror, quit-when-idle.
- `apps/desktop/src/preload.ts` — `updates.reportRunningCount`.
- `apps/renderer/src/hooks/use-report-running-agents.ts` — pushes count to main.
- `apps/renderer/src/components/update-banner.tsx` — ready-only toast, 3 restart options + in-toast confirm.
- `apps/renderer/src/lib/bridge.ts` — bridge type.

## Verification
- `bun run check-types` ✅ (10/10) · `bun run lint` ✅
- **Still needs a real signed-build test** (couldn't be done in-session): build a signed/notarized dmg, install into **/Applications** (avoid Gatekeeper translocation), point at a newer published release, and confirm background download → **Restart now quits *and* reopens** on the new version; plus the quit-guard dialog and "Restart when idle" against a live agent.
