### PR TITLE
[codex] add zuse repository settings and bundled skill

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,7 +1,7 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]
-setup = "node scripts/conductor-setup.mjs"
-archive = "rm -rf \"$PWD/.context/user-data\""
+setup = "node scripts/setup.mjs"
+archive = "node scripts/archive.mjs"
 run = "PORT=${CONDUCTOR_PORT:-5733} MEMOIZE_USER_DATA_DIR=\"$PWD/.context/user-data\" bun run dev:desktop"
 run_mode = "concurrent"

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,5 +2,6 @@
 
 [scripts]
 setup = "node scripts/conductor-setup.mjs"
+archive = "rm -rf \"$PWD/.context/user-data\""
 run = "PORT=${CONDUCTOR_PORT:-5733} MEMOIZE_USER_DATA_DIR=\"$PWD/.context/user-data\" bun run dev:desktop"
 run_mode = "concurrent"

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ yarn-error.log*
 # Local-only project data (workspace + private agent notes)
 .context
 .notes
+.zuse/*
+!.zuse/
+!.zuse/settings.toml
 
 .gstack/
 

--- a/.zuse/settings.toml
+++ b/.zuse/settings.toml
@@ -3,7 +3,12 @@
 schemaVersion = 1
 autoCreateWorktree = false
 archiveRemoveWorktree = false
-file_include_globs = ".env\n.env.local\n.env.*.local\n"
+
+file_include_globs = [
+  ".env",
+  ".env.local",
+  ".env.*.local",
+]
 
 [scripts]
 setup = "bun install"

--- a/.zuse/settings.toml
+++ b/.zuse/settings.toml
@@ -1,0 +1,14 @@
+# Zuse repository settings. Commit this file to share setup with your team.
+# Add files below that should be linked from the main checkout into every Zuse worktree.
+schemaVersion = 1
+autoCreateWorktree = false
+archiveRemoveWorktree = false
+file_include_globs = ".env\n.env.local\n.env.*.local\n"
+
+[scripts]
+setup = "bun install"
+run = "bun run dev"
+archive = ""
+auto_run_after_setup = false
+
+[environment_variables]

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -49,6 +49,9 @@ extraResources:
   - from: ../renderer/dist
     to: app/renderer/dist
     filter: ["**/*"]
+  - from: resources/skills
+    to: app/skills
+    filter: ["**/*"]
 
 # Native bindings can't load from inside an asar; they need to live as
 # real files on disk. electron-builder writes these to app.asar.unpacked/

--- a/apps/desktop/resources/skills/zuse/SKILL.md
+++ b/apps/desktop/resources/skills/zuse/SKILL.md
@@ -24,7 +24,12 @@ Canonical repository settings file:
 schemaVersion = 1
 autoCreateWorktree = false
 archiveRemoveWorktree = false
-file_include_globs = ".env\n.env.local\n.env.*.local\n"
+
+file_include_globs = [
+  ".env",
+  ".env.local",
+  ".env.*.local",
+]
 
 [scripts]
 setup = "bun install"
@@ -38,9 +43,8 @@ NODE_ENV = "development"
 
 Important fields:
 
-- `file_include_globs`: newline-separated patterns linked from the main
-  checkout into every worktree. Existing files in the worktree are never
-  overwritten.
+- `file_include_globs`: file patterns linked from the main checkout into every
+  worktree. Existing files in the worktree are never overwritten.
 - `[scripts].setup`: runs after a worktree is created.
 - `[scripts].run`: runs when the user starts the repository run script.
 - `[scripts].archive`: runs before archiving a worktree-backed chat.
@@ -52,10 +56,10 @@ compatibility, but `.zuse/settings.toml` is the shared format to create or edit.
 
 ## Worktree Includes
 
-Prefer explicit `file_include_globs` in `.zuse/settings.toml` for local files
-that every worktree needs. Typical entries are `.env`, `.env.local`,
-`.env.*.local`, app-specific env files, local certificates, or private config
-files. Do not commit secrets themselves.
+Prefer explicit `file_include_globs` entries in `.zuse/settings.toml` for local
+files that every worktree needs. Typical entries are `.env`,
+`.env.local`, `.env.*.local`, app-specific env files, local certificates, or
+private config files. Do not commit secrets themselves.
 
 ## Schemas
 

--- a/apps/desktop/resources/skills/zuse/SKILL.md
+++ b/apps/desktop/resources/skills/zuse/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: zuse
+description: Configure and troubleshoot Zuse projects, repository settings, worktrees, scripts, schemas, and native provider skills.
+---
+
+# Zuse
+
+Use this skill when helping with Zuse project setup, `.zuse/settings.toml`,
+worktree creation, setup/run/archive scripts, files to include in worktrees,
+provider skills, user settings, keybindings, or schema URLs.
+
+Zuse is a local-first macOS app for running coding agents against registered
+projects and git worktrees. Repository-shared configuration lives in
+`.zuse/settings.toml` and should be committed when it is intended for the
+team.
+
+## Repository Settings
+
+Canonical repository settings file:
+
+```toml
+# Zuse repository settings. Commit this file to share setup with your team.
+# Add files below that should be linked from the main checkout into every Zuse worktree.
+schemaVersion = 1
+autoCreateWorktree = false
+archiveRemoveWorktree = false
+file_include_globs = ".env\n.env.local\n.env.*.local\n"
+
+[scripts]
+setup = "bun install"
+run = "bun run dev"
+archive = ""
+auto_run_after_setup = false
+
+[environment_variables]
+NODE_ENV = "development"
+```
+
+Important fields:
+
+- `file_include_globs`: newline-separated patterns linked from the main
+  checkout into every worktree. Existing files in the worktree are never
+  overwritten.
+- `[scripts].setup`: runs after a worktree is created.
+- `[scripts].run`: runs when the user starts the repository run script.
+- `[scripts].archive`: runs before archiving a worktree-backed chat.
+- `[environment_variables]`: key/value pairs passed to setup, run, and archive
+  scripts.
+
+Legacy `.zuse/settings.json` and `.worktreeinclude` may be read for backward
+compatibility, but `.zuse/settings.toml` is the shared format to create or edit.
+
+## Worktree Includes
+
+Prefer explicit `file_include_globs` in `.zuse/settings.toml` for local files
+that every worktree needs. Typical entries are `.env`, `.env.local`,
+`.env.*.local`, app-specific env files, local certificates, or private config
+files. Do not commit secrets themselves.
+
+## Schemas
+
+Public schemas are served by the Zuse website:
+
+- `https://zuse.dev/schemas/settings.schema.json`
+- `https://zuse.dev/schemas/repository-settings.schema.json`
+- `https://zuse.dev/schemas/keybindings.schema.json`
+
+Use these URLs in editor configuration and documentation examples.

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -111,6 +111,7 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
         archiveScript={settings.archiveCleanupScript}
         autoRunAfterSetup={settings.autoRunAfterSetup}
         environmentVariables={settings.environmentVariables}
+        fileIncludeGlobs={settings.fileIncludeGlobs}
         onSetupScriptChange={(value) =>
           void update(projectId, { setupScript: value })
         }
@@ -125,6 +126,9 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
         }
         onEnvironmentVariablesChange={(value) =>
           void update(projectId, { environmentVariables: value })
+        }
+        onFileIncludeGlobsChange={(value) =>
+          void update(projectId, { fileIncludeGlobs: value })
         }
       />
 
@@ -556,22 +560,26 @@ function ScriptsSection({
   archiveScript,
   autoRunAfterSetup,
   environmentVariables,
+  fileIncludeGlobs,
   onSetupScriptChange,
   onRunScriptChange,
   onArchiveScriptChange,
   onAutoRunAfterSetupChange,
   onEnvironmentVariablesChange,
+  onFileIncludeGlobsChange,
 }: {
   setupScript: string | null;
   runScript: string | null;
   archiveScript: string | null;
   autoRunAfterSetup: boolean;
   environmentVariables: Readonly<Record<string, string>>;
+  fileIncludeGlobs: string;
   onSetupScriptChange: (v: string | null) => void;
   onRunScriptChange: (v: string | null) => void;
   onArchiveScriptChange: (v: string | null) => void;
   onAutoRunAfterSetupChange: (v: boolean) => void;
   onEnvironmentVariablesChange: (v: Record<string, string>) => void;
+  onFileIncludeGlobsChange: (v: string) => void;
 }) {
   const envText = Object.entries(environmentVariables)
     .map(([key, value]) => `${key}=${value}`)
@@ -643,13 +651,51 @@ function ScriptsSection({
           minHeightClassName="min-h-24"
         />
       </div>
+      <FileIncludesEditor
+        value={fileIncludeGlobs}
+        onChange={onFileIncludeGlobsChange}
+      />
       <div className="px-4 py-3">
         <p className="text-xs leading-relaxed text-muted-foreground">
           Want to hand-edit or share repository settings? Use{" "}
-          <span className="font-mono">.zuse/settings.json</span>.
+          <span className="font-mono">.zuse/settings.toml</span>.
         </p>
       </div>
     </SettingsGroup>
+  );
+}
+
+function FileIncludesEditor({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+  const persist = () => {
+    if (draft !== value) onChange(draft);
+  };
+  return (
+    <div className="px-4 py-3.5">
+      <div className="mb-2">
+        <p className="text-sm font-medium text-foreground">
+          Worktree file includes
+        </p>
+        <p className="text-xs text-muted-foreground">
+          One pattern per line, linked from the main checkout into each new
+          worktree.
+        </p>
+      </div>
+      <CodeTextarea
+        value={draft}
+        onChange={(event) => setDraft(event.currentTarget.value)}
+        onBlur={persist}
+        placeholder={".env\n.env.local\n.env.*.local"}
+        minHeightClassName="min-h-20"
+      />
+    </div>
   );
 }
 

--- a/apps/server/src/provider/drivers/claude.ts
+++ b/apps/server/src/provider/drivers/claude.ts
@@ -1574,7 +1574,9 @@ export const startClaudeSession = (
       systemPrompt: {
         type: "preset",
         preset: "claude_code",
-        append: claudeWorktreePrompt(cwd),
+        append: [input.workspaceInstructions, claudeWorktreePrompt(cwd)]
+          .filter((part): part is string => part !== undefined)
+          .join("\n\n"),
       },
       abortController: abort,
       ...(claudeExecutablePath !== null

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -888,6 +888,7 @@ export const startCodexSession = (
       approvalPolicy: "never" as const,
       sandbox: toSandboxMode(currentMode),
       serviceName: "zuse",
+      developerInstructions: input.workspaceInstructions ?? null,
     };
 
     const startOrResume = async (): Promise<void> => {

--- a/apps/server/src/provider/drivers/cursor.ts
+++ b/apps/server/src/provider/drivers/cursor.ts
@@ -32,6 +32,7 @@ import {
   startCompactSnapshot,
 } from "./compact.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
+import { prefixFirstPromptWithWorkspaceInstructions } from "../workspace-instructions.ts";
 
 /**
  * Live-only handle for one Cursor Agent conversation. Mirrors Grok's
@@ -734,6 +735,7 @@ export const startCursorSession = (
     let inflight: Promise<void> = Promise.resolve();
     const log = makePhaseLogger(String(sessionId));
     let promptCount = 0;
+    let workspaceInstructionsPending = input.workspaceInstructions;
     let firstChunkSeenForPrompt = false;
 
     events.unsafeOffer({
@@ -1024,7 +1026,14 @@ export const startCursorSession = (
           }),
         );
       }
-      const promptText = compactSnapshot !== null ? text.trim() : text;
+      const promptText =
+        compactSnapshot !== null
+          ? text.trim()
+          : prefixFirstPromptWithWorkspaceInstructions(
+              workspaceInstructionsPending,
+              text,
+            );
+      if (compactSnapshot === null) workspaceInstructionsPending = undefined;
       const n = ++promptCount;
       inflight = inflight
         .then(async () => {

--- a/apps/server/src/provider/drivers/gemini.ts
+++ b/apps/server/src/provider/drivers/gemini.ts
@@ -28,6 +28,7 @@ import {
 import { handleFsRequest } from "./acp/fs.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
+import { prefixFirstPromptWithWorkspaceInstructions } from "../workspace-instructions.ts";
 
 /**
  * Live-only handle for one Gemini conversation. Mirrors the Grok/Codex/Claude
@@ -273,6 +274,7 @@ export const startGeminiSession = (
     let nextRpcId = 1;
     let closed = false;
     let inflight: Promise<void> = Promise.resolve();
+    let workspaceInstructionsPending = input.workspaceInstructions;
     const pending = new Map<number, PendingResolver>();
     let stderrTail = "";
     let stdoutNoiseTail = "";
@@ -673,7 +675,14 @@ export const startGeminiSession = (
       const promptText =
         compactSnapshot !== null
           ? text.trim()
-          : applyPlanModePrefix(currentMode, text);
+          : applyPlanModePrefix(
+              currentMode,
+              prefixFirstPromptWithWorkspaceInstructions(
+                workspaceInstructionsPending,
+                text,
+              ),
+            );
+      if (compactSnapshot === null) workspaceInstructionsPending = undefined;
       inflight = inflight
         .then(async () => {
           if (closed) return;

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -42,6 +42,7 @@ import {
 } from "./acp/browser-mcp-bridge.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
 import type { BrowserSend } from "./browser-tools.ts";
+import { prefixFirstPromptWithWorkspaceInstructions } from "../workspace-instructions.ts";
 
 /**
  * Live-only handle for one Grok conversation. Mirrors Codex/Claude handle
@@ -134,7 +135,9 @@ const installProjectBrowserMcpConfig = (
 ): (() => void) => {
   const grokDir = join(cwd, ".grok");
   const configPath = join(grokDir, "config.toml");
-  const previous = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
+  const previous = existsSync(configPath)
+    ? readFileSync(configPath, "utf8")
+    : "";
   const userConfig = stripGeneratedBrowserMcpConfig(previous);
   const next = `${userConfig.length > 0 ? `${userConfig}\n\n` : ""}${BROWSER_MCP_CONFIG_START}\n${toml.trimEnd()}\n${BROWSER_MCP_CONFIG_END}\n`;
 
@@ -406,6 +409,7 @@ export const startGrokSession = (
     // calls tools directly instead of hunting the filesystem for schemas.
     let browserHintPending = true;
     let inflight: Promise<void> = Promise.resolve();
+    let workspaceInstructionsPending = input.workspaceInstructions;
     const pending = new Map<number, PendingResolver>();
     // Trailing window of grok's stderr — used to enrich error reports when
     // the JSON-RPC envelope itself is opaque ("Internal error" with no data).
@@ -967,7 +971,14 @@ export const startGrokSession = (
       const promptText =
         compactSnapshot !== null
           ? text.trim()
-          : applyPlanModePrefix(currentMode, text);
+          : applyPlanModePrefix(
+              currentMode,
+              prefixFirstPromptWithWorkspaceInstructions(
+                workspaceInstructionsPending,
+                text,
+              ),
+            );
+      if (compactSnapshot === null) workspaceInstructionsPending = undefined;
       inflight = inflight
         .then(async () => {
           if (closed) return;

--- a/apps/server/src/provider/drivers/opencode.ts
+++ b/apps/server/src/provider/drivers/opencode.ts
@@ -34,6 +34,7 @@ import {
   startCompactEvent,
   startCompactSnapshot,
 } from "./compact.ts";
+import { prefixFirstPromptWithWorkspaceInstructions } from "../workspace-instructions.ts";
 
 /**
  * Live handle for one OpenCode conversation. Mirrors the other driver
@@ -948,6 +949,7 @@ export const startOpencodeSession = (
 
     // === Prompt queue — serializes turns inside a single session. ===
     let inflight: Promise<void> = Promise.resolve();
+    let workspaceInstructionsPending = input.workspaceInstructions;
     const enqueuePrompt = (text: string): void => {
       const compactSnapshot = isCompactCommand(text)
         ? startCompactSnapshot(null)
@@ -960,7 +962,14 @@ export const startOpencodeSession = (
           }),
         );
       }
-      const promptText = compactSnapshot !== null ? text.trim() : text;
+      const promptText =
+        compactSnapshot !== null
+          ? text.trim()
+          : prefixFirstPromptWithWorkspaceInstructions(
+              workspaceInstructionsPending,
+              text,
+            );
+      if (compactSnapshot === null) workspaceInstructionsPending = undefined;
       inflight = inflight
         .then(async () => {
           if (closed) return;

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -45,6 +45,7 @@ import { CredentialsService } from "../services/credentials-service.ts";
 import { PermissionService } from "../services/permission-service.ts";
 import { ProviderService } from "../services/provider-service.ts";
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
+import { zuseWorkspaceInstructions } from "../workspace-instructions.ts";
 
 /**
  * Live `ProviderService`. PR 5 wires the Claude SDK driver behind the session
@@ -181,6 +182,13 @@ export const ProviderServiceLive = Layer.effect(
             );
           }
           const cwd = input.cwdOverride ?? folder.path;
+          const driverInput = {
+            ...input,
+            workspaceInstructions: zuseWorkspaceInstructions({
+              projectPath: folder.path,
+              cwd,
+            }),
+          };
           const apiKey = yield* credentials
             .get(input.providerId)
             .pipe(Effect.catchAll(() => Effect.succeed<string | null>(null)));
@@ -203,7 +211,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startGeminiSession(
-              input,
+              driverInput,
               cwd,
               apiKey,
               geminiPath,
@@ -242,7 +250,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startGrokSession(
-              input,
+              driverInput,
               cwd,
               apiKey,
               grokPath,
@@ -274,7 +282,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startOpencodeSession(
-              input,
+              driverInput,
               cwd,
               apiKey,
               opencodePath,
@@ -302,7 +310,7 @@ export const ProviderServiceLive = Layer.effect(
               );
             }
             handle = yield* startCursorSession(
-              input,
+              driverInput,
               cwd,
               apiKey,
               cursorPath,
@@ -340,7 +348,7 @@ export const ProviderServiceLive = Layer.effect(
             );
 
             handle = yield* startClaudeSession(
-              input,
+              driverInput,
               cwd,
               apiKey,
               claudePath,
@@ -379,7 +387,7 @@ export const ProviderServiceLive = Layer.effect(
             // either the banner before sending or the friendly error after,
             // never the cryptic SDK trace.
             handle = yield* startCodexSession(
-              input,
+              driverInput,
               cwd,
               apiKey,
               codexPath,

--- a/apps/server/src/provider/workspace-instructions.ts
+++ b/apps/server/src/provider/workspace-instructions.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+
+const currentBranch = (cwd: string): string | null => {
+  try {
+    const out = execFileSync("git", ["branch", "--show-current"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+};
+
+export const zuseWorkspaceInstructions = ({
+  projectPath,
+  cwd,
+}: {
+  readonly projectPath: string;
+  readonly cwd: string;
+}): string => {
+  const branch = currentBranch(cwd);
+  const isWorktree = path.resolve(cwd) !== path.resolve(projectPath);
+  const contextDir = path.join(cwd, ".context");
+  return [
+    "<system_instruction>",
+    "You are running inside Zuse, a local-first macOS workspace for working with coding agents across projects and git worktrees.",
+    `Project root: ${projectPath}`,
+    `Current working directory: ${cwd}`,
+    `Current checkout type: ${isWorktree ? "git worktree" : "main project checkout"}`,
+    `Current branch: ${branch ?? "unknown"}`,
+    "Target base ref: origin/main. Use it for comparisons such as `git diff origin/main...` and for pull requests unless the user explicitly gives another base.",
+    `Use ${contextDir} for scratch notes or handoff files that should stay out of Git.`,
+    "Do not rename the current branch unless the user explicitly asks you to.",
+    "Keep the final response self-contained because the user may only read the last message.",
+    "If the user asks for several unrelated tasks, recommend separate Zuse workspaces.",
+    "Zuse is not a remote execution service, not the source of truth for GitHub state, and not a replacement for the user's chosen provider CLI. It orchestrates local provider sessions, workspace context, and git worktrees on this machine.",
+    "</system_instruction>",
+  ].join("\n");
+};
+
+export const prefixFirstPromptWithWorkspaceInstructions = (
+  instructions: string | undefined,
+  text: string,
+): string => {
+  if (instructions === undefined || instructions.trim().length === 0) {
+    return text;
+  }
+  return `${instructions}\n\n${text}`;
+};

--- a/apps/server/src/repository-settings/layers/repository-settings-service.ts
+++ b/apps/server/src/repository-settings/layers/repository-settings-service.ts
@@ -68,6 +68,7 @@ const emptyFileSettings = (): RepositorySettingsFile => ({
   runScript: null,
   autoRunAfterSetup: false,
   environmentVariables: {},
+  fileIncludeGlobs: "",
 });
 
 const parseEnvJson = (value: string | null): Record<string, string> => {
@@ -87,13 +88,30 @@ const parseEnvJson = (value: string | null): Record<string, string> => {
 
 const parseTomlString = (raw: string): string => {
   const trimmed = raw.trim();
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      return JSON.parse(trimmed) as string;
+    } catch {
+      return trimmed.slice(1, -1);
+    }
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
     return trimmed.slice(1, -1);
   }
   return trimmed;
+};
+
+const parseTomlNullableString = (raw: string): string | null => {
+  if (raw.trim() === "null") return null;
+  const parsed = parseTomlString(raw);
+  return parsed.length === 0 ? null : parsed;
+};
+
+const parseTomlBoolean = (raw: string, fallback: boolean): boolean => {
+  const trimmed = raw.trim();
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  return fallback;
 };
 
 const settingsDir = (repoPath: string): string => Path.join(repoPath, ".zuse");
@@ -101,12 +119,33 @@ const jsonPath = (repoPath: string): string =>
   Path.join(settingsDir(repoPath), "settings.json");
 const tomlPath = (repoPath: string): string =>
   Path.join(settingsDir(repoPath), "settings.toml");
+const worktreeIncludePath = (repoPath: string): string =>
+  Path.join(repoPath, ".worktreeinclude");
+
+const readLegacyWorktreeInclude = (repoPath: string): string => {
+  const filePath = worktreeIncludePath(repoPath);
+  if (!fsSync.existsSync(filePath)) return "";
+  try {
+    return fsSync
+      .readFileSync(filePath, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"))
+      .join("\n");
+  } catch {
+    return "";
+  }
+};
 
 const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
   const filePath = tomlPath(repoPath);
-  if (!fsSync.existsSync(filePath)) return emptyFileSettings();
-  const settings: MutableRepositorySettingsFile = {
+  const fallback: RepositorySettingsFile = {
     ...emptyFileSettings(),
+    fileIncludeGlobs: readLegacyWorktreeInclude(repoPath),
+  };
+  if (!fsSync.existsSync(filePath)) return fallback;
+  const settings: MutableRepositorySettingsFile = {
+    ...fallback,
     environmentVariables: {},
   };
   let section = "";
@@ -122,11 +161,48 @@ const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
     if (!match) continue;
     const key = match[1]!;
     const value = match[2]!;
-    if (section === "scripts") {
-      if (key === "setup") settings.setupScript = parseTomlString(value);
-      else if (key === "run") settings.runScript = parseTomlString(value);
+    if (section === "") {
+      if (key === "schemaVersion") {
+        // v1 is the only supported shape; keep parsing with v1 defaults if a
+        // future value appears so a hand-edit does not blank settings.
+      } else if (key === "defaultProviderId") {
+        const parsed = parseTomlNullableString(value);
+        settings.defaultProviderId = isProviderId(parsed)
+          ? parsed
+          : parsed === null
+            ? null
+            : settings.defaultProviderId;
+      } else if (key === "defaultModel") {
+        settings.defaultModel = parseTomlNullableString(value);
+      } else if (key === "defaultRuntimeMode") {
+        const parsed = parseTomlNullableString(value);
+        settings.defaultRuntimeMode = isRuntimeMode(parsed)
+          ? parsed
+          : parsed === null
+            ? null
+            : settings.defaultRuntimeMode;
+      } else if (key === "autoCreateWorktree") {
+        settings.autoCreateWorktree = parseTomlBoolean(
+          value,
+          settings.autoCreateWorktree,
+        );
+      } else if (key === "worktreeBaseDir") {
+        settings.worktreeBaseDir = parseTomlNullableString(value);
+      } else if (key === "archiveRemoveWorktree") {
+        settings.archiveRemoveWorktree = parseTomlBoolean(
+          value,
+          settings.archiveRemoveWorktree,
+        );
+      } else if (key === "file_include_globs") {
+        settings.fileIncludeGlobs = parseTomlString(value);
+      }
+    } else if (section === "scripts") {
+      if (key === "setup")
+        settings.setupScript = parseTomlNullableString(value);
+      else if (key === "run")
+        settings.runScript = parseTomlNullableString(value);
       else if (key === "archive") {
-        settings.archiveCleanupScript = parseTomlString(value);
+        settings.archiveCleanupScript = parseTomlNullableString(value);
       } else if (key === "auto_run_after_setup") {
         settings.autoRunAfterSetup = value.trim() === "true";
       }
@@ -205,6 +281,12 @@ const coerceJsonSettings = (
         ? obj.autoRunAfterSetup
         : fallback.autoRunAfterSetup,
     environmentVariables,
+    fileIncludeGlobs:
+      typeof obj.fileIncludeGlobs === "string"
+        ? obj.fileIncludeGlobs
+        : typeof obj.file_include_globs === "string"
+          ? obj.file_include_globs
+          : fallback.fileIncludeGlobs,
   };
 };
 
@@ -222,16 +304,55 @@ const readJsonSettings = (
   }
 };
 
-const writeJsonSettings = (
+const tomlString = (value: string): string => JSON.stringify(value);
+
+const tomlNullableString = (value: string | null): string =>
+  value === null ? '""' : tomlString(value);
+
+const writeTomlSettings = (
   repoPath: string,
   settings: RepositorySettingsFile,
 ): void => {
   const dir = settingsDir(repoPath);
   fsSync.mkdirSync(dir, { recursive: true });
-  const filePath = jsonPath(repoPath);
+  const filePath = tomlPath(repoPath);
   const tmp = `${filePath}.${randomBytes(6).toString("hex")}.tmp`;
-  fsSync.writeFileSync(tmp, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+  const lines = [
+    "# Zuse repository settings. Commit this file to share setup with your team.",
+    "# Add files below that should be linked from the main checkout into every Zuse worktree.",
+    '# Example: file_include_globs = ".env\\n.env.local\\n.env.*.local\\n"',
+    "",
+    `schemaVersion = ${settings.schemaVersion}`,
+    `defaultProviderId = ${tomlNullableString(settings.defaultProviderId)}`,
+    `defaultModel = ${tomlNullableString(settings.defaultModel)}`,
+    `defaultRuntimeMode = ${tomlNullableString(settings.defaultRuntimeMode)}`,
+    `autoCreateWorktree = ${settings.autoCreateWorktree ? "true" : "false"}`,
+    `worktreeBaseDir = ${tomlNullableString(settings.worktreeBaseDir)}`,
+    `archiveRemoveWorktree = ${settings.archiveRemoveWorktree ? "true" : "false"}`,
+    `file_include_globs = ${tomlString(settings.fileIncludeGlobs)}`,
+    "",
+    "[scripts]",
+    `setup = ${tomlNullableString(cleanScript(settings.setupScript))}`,
+    `run = ${tomlNullableString(cleanScript(settings.runScript))}`,
+    `archive = ${tomlNullableString(cleanScript(settings.archiveCleanupScript))}`,
+    `auto_run_after_setup = ${settings.autoRunAfterSetup ? "true" : "false"}`,
+    "",
+    "[environment_variables]",
+    ...Object.entries(settings.environmentVariables)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${key} = ${tomlString(value)}`),
+    "",
+  ];
+  fsSync.writeFileSync(tmp, lines.join("\n"), "utf8");
   fsSync.renameSync(tmp, filePath);
+};
+
+const removeLegacyJsonSettings = (repoPath: string): void => {
+  try {
+    fsSync.rmSync(jsonPath(repoPath), { force: true });
+  } catch {
+    // Best-effort migration cleanup only.
+  }
 };
 
 const fileToSettings = (
@@ -251,6 +372,7 @@ const fileToSettings = (
     runScript: cleanScript(file.runScript),
     autoRunAfterSetup: file.autoRunAfterSetup,
     environmentVariables: file.environmentVariables,
+    fileIncludeGlobs: file.fileIncludeGlobs,
   });
 
 const settingsToFile = (
@@ -268,6 +390,7 @@ const settingsToFile = (
   runScript: cleanScript(settings.runScript),
   autoRunAfterSetup: settings.autoRunAfterSetup,
   environmentVariables: settings.environmentVariables,
+  fileIncludeGlobs: settings.fileIncludeGlobs,
 });
 
 const rowToFile = (
@@ -297,6 +420,7 @@ const rowToFile = (
       ...fallback.environmentVariables,
       ...parseEnvJson(row.environment_variables_json),
     },
+    fileIncludeGlobs: fallback.fileIncludeGlobs,
   };
 };
 
@@ -339,6 +463,7 @@ const applyPatch = (
     autoRunAfterSetup: patch.autoRunAfterSetup ?? current.autoRunAfterSetup,
     environmentVariables:
       patch.environmentVariables ?? current.environmentVariables,
+    fileIncludeGlobs: patch.fileIncludeGlobs ?? current.fileIncludeGlobs,
   });
 
 export const RepositorySettingsServiceLive = Layer.effect(
@@ -426,7 +551,7 @@ export const RepositorySettingsServiceLive = Layer.effect(
         const rows = yield* legacyRow(projectId);
         if (rows[0] !== undefined) {
           const migrated = rowToFile(rows[0], toml);
-          writeJsonSettings(repoPath, migrated);
+          writeTomlSettings(repoPath, migrated);
           yield* clearLegacyRow(projectId);
           return migrated;
         }
@@ -453,7 +578,8 @@ export const RepositorySettingsServiceLive = Layer.effect(
         const current = yield* get(projectId);
         const next = applyPatch(projectId, current, patch);
         if (repoPath !== null) {
-          writeJsonSettings(repoPath, settingsToFile(next));
+          writeTomlSettings(repoPath, settingsToFile(next));
+          removeLegacyJsonSettings(repoPath);
           yield* clearLegacyRow(projectId);
         }
         return next;

--- a/apps/server/src/repository-settings/layers/repository-settings-service.ts
+++ b/apps/server/src/repository-settings/layers/repository-settings-service.ts
@@ -149,9 +149,30 @@ const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
     environmentVariables: {},
   };
   let section = "";
+  const legacyIncludeSectionValues: string[] = [];
+  let pendingArrayKey: "file_include_globs" | null = null;
+  let pendingArrayRaw = "";
+  const parseTomlStringArray = (raw: string): string[] =>
+    [...raw.matchAll(/"(?:\\.|[^"\\])*"|'[^']*'/g)]
+      .map((match) => parseTomlString(match[0] ?? ""))
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+  const finishPendingArray = (): void => {
+    if (pendingArrayKey === "file_include_globs") {
+      settings.fileIncludeGlobs =
+        parseTomlStringArray(pendingArrayRaw).join("\n");
+    }
+    pendingArrayKey = null;
+    pendingArrayRaw = "";
+  };
   for (const line of fsSync.readFileSync(filePath, "utf8").split(/\r?\n/)) {
     const trimmed = line.trim();
     if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    if (pendingArrayKey !== null) {
+      pendingArrayRaw = `${pendingArrayRaw}\n${trimmed}`;
+      if (trimmed.includes("]")) finishPendingArray();
+      continue;
+    }
     const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
     if (sectionMatch) {
       section = sectionMatch[1] ?? "";
@@ -193,6 +214,10 @@ const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
           value,
           settings.archiveRemoveWorktree,
         );
+      } else if (key === "file_include_globs" && value.trim().startsWith("[")) {
+        pendingArrayKey = "file_include_globs";
+        pendingArrayRaw = value;
+        if (value.includes("]")) finishPendingArray();
       } else if (key === "file_include_globs") {
         settings.fileIncludeGlobs = parseTomlString(value);
       }
@@ -208,7 +233,14 @@ const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
       }
     } else if (section === "environment_variables") {
       settings.environmentVariables[key] = parseTomlString(value);
+    } else if (section === "file_include_globs") {
+      const parsed = parseTomlNullableString(value)?.trim() ?? "";
+      if (parsed.length > 0) legacyIncludeSectionValues.push(parsed);
     }
+  }
+  if (pendingArrayKey !== null) finishPendingArray();
+  if (legacyIncludeSectionValues.length > 0) {
+    settings.fileIncludeGlobs = legacyIncludeSectionValues.join("\n");
   }
   return settings;
 };
@@ -309,6 +341,21 @@ const tomlString = (value: string): string => JSON.stringify(value);
 const tomlNullableString = (value: string | null): string =>
   value === null ? '""' : tomlString(value);
 
+const includeGlobValues = (value: string): string[] =>
+  value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+const tomlStringArray = (key: string, values: string[]): string[] => {
+  if (values.length === 0) return [`${key} = []`];
+  return [
+    `${key} = [`,
+    ...values.map((value) => `  ${tomlString(value)},`),
+    "]",
+  ];
+};
+
 const writeTomlSettings = (
   repoPath: string,
   settings: RepositorySettingsFile,
@@ -320,7 +367,6 @@ const writeTomlSettings = (
   const lines = [
     "# Zuse repository settings. Commit this file to share setup with your team.",
     "# Add files below that should be linked from the main checkout into every Zuse worktree.",
-    '# Example: file_include_globs = ".env\\n.env.local\\n.env.*.local\\n"',
     "",
     `schemaVersion = ${settings.schemaVersion}`,
     `defaultProviderId = ${tomlNullableString(settings.defaultProviderId)}`,
@@ -329,7 +375,11 @@ const writeTomlSettings = (
     `autoCreateWorktree = ${settings.autoCreateWorktree ? "true" : "false"}`,
     `worktreeBaseDir = ${tomlNullableString(settings.worktreeBaseDir)}`,
     `archiveRemoveWorktree = ${settings.archiveRemoveWorktree ? "true" : "false"}`,
-    `file_include_globs = ${tomlString(settings.fileIncludeGlobs)}`,
+    "",
+    ...tomlStringArray(
+      "file_include_globs",
+      includeGlobValues(settings.fileIncludeGlobs),
+    ),
     "",
     "[scripts]",
     `setup = ${tomlNullableString(cleanScript(settings.setupScript))}`,

--- a/apps/server/src/skill/bundled-zuse-skill.ts
+++ b/apps/server/src/skill/bundled-zuse-skill.ts
@@ -1,0 +1,89 @@
+import * as fsSync from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { ProviderId } from "@zuse/wire";
+
+const FALLBACK_SKILL = `---
+name: zuse
+description: Configure and troubleshoot Zuse projects, repository settings, worktrees, scripts, schemas, and native provider skills.
+---
+
+# Zuse
+
+Use this skill when helping with Zuse project setup, \`.zuse/settings.toml\`,
+worktree creation, setup/run/archive scripts, files to include in worktrees,
+provider skills, user settings, keybindings, or schema URLs.
+
+Canonical repository settings live in \`.zuse/settings.toml\`. Use
+\`file_include_globs\` for files that should be linked from the main checkout
+into every worktree. Public schemas are served from
+\`https://zuse.dev/schemas/\`.
+`;
+
+const assetCandidates = (): string[] => {
+  const cwd = process.cwd();
+  const electronProcess = process as NodeJS.Process & {
+    readonly resourcesPath?: string;
+  };
+  const resourcesPath =
+    typeof electronProcess.resourcesPath === "string"
+      ? electronProcess.resourcesPath
+      : "";
+  return [
+    path.join(
+      cwd,
+      "apps",
+      "desktop",
+      "resources",
+      "skills",
+      "zuse",
+      "SKILL.md",
+    ),
+    path.join(resourcesPath, "app", "skills", "zuse", "SKILL.md"),
+    path.join(resourcesPath, "skills", "zuse", "SKILL.md"),
+  ].filter((candidate) => candidate.length > 0);
+};
+
+export const readBundledZuseSkill = (): string => {
+  for (const candidate of assetCandidates()) {
+    try {
+      return fsSync.readFileSync(candidate, "utf8");
+    } catch {
+      // Try the next dev/packaged location.
+    }
+  }
+  return FALLBACK_SKILL;
+};
+
+export const bundledZuseSkillPath = (
+  providerId: ProviderId,
+  home = os.homedir(),
+): string | null => {
+  if (providerId === "claude") {
+    return path.join(home, ".claude", "skills", "zuse", "SKILL.md");
+  }
+  if (providerId === "codex") {
+    return path.join(home, ".codex", "skills", "zuse", "SKILL.md");
+  }
+  return null;
+};
+
+export const ensureBundledZuseSkillInstalled = (
+  providerId: ProviderId,
+  home = os.homedir(),
+): string | null => {
+  const target = bundledZuseSkillPath(providerId, home);
+  if (target === null) return null;
+  const content = readBundledZuseSkill();
+  try {
+    fsSync.mkdirSync(path.dirname(target), { recursive: true });
+    const existing = fsSync.existsSync(target)
+      ? fsSync.readFileSync(target, "utf8")
+      : null;
+    if (existing !== content) fsSync.writeFileSync(target, content, "utf8");
+  } catch {
+    return null;
+  }
+  return target;
+};

--- a/apps/server/src/skill/layers/skill-discovery.ts
+++ b/apps/server/src/skill/layers/skill-discovery.ts
@@ -7,6 +7,7 @@ import { Effect, Layer } from "effect";
 import { Skill, type ProviderId } from "@zuse/wire";
 
 import { CodexAppServerClient } from "../../provider/codex-app-server-client.ts";
+import { ensureBundledZuseSkillInstalled } from "../bundled-zuse-skill.ts";
 import { SkillDiscoveryService } from "../services/skill-discovery.ts";
 
 interface RawSkill {
@@ -29,7 +30,8 @@ const parseFrontmatter = (
   const end = content.indexOf("\n---", 3);
   if (end < 0) return {};
   const block = content.slice(3, end);
-  const out: { name?: string; description?: string; argumentHint?: string } = {};
+  const out: { name?: string; description?: string; argumentHint?: string } =
+    {};
   for (const line of block.split("\n")) {
     const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.*)$/);
     if (!m) continue;
@@ -78,12 +80,10 @@ const isDirSafe = (
   fs: FileSystem.FileSystem,
   abs: string,
 ): Effect.Effect<boolean> =>
-  fs
-    .stat(abs)
-    .pipe(
-      Effect.map((s) => s.type === "Directory"),
-      Effect.orElseSucceed(() => false),
-    );
+  fs.stat(abs).pipe(
+    Effect.map((s) => s.type === "Directory"),
+    Effect.orElseSucceed(() => false),
+  );
 
 /**
  * Project a parsed file into the wire `Skill` shape. The folder containing
@@ -236,6 +236,7 @@ export const SkillDiscoveryServiceLive = Layer.effect(
       projectCwd: string,
     ): Effect.Effect<ReadonlyArray<Skill>> =>
       Effect.gen(function* () {
+        ensureBundledZuseSkillInstalled("claude", home);
         const projectRoot = path.join(projectCwd, ".claude", "skills");
         const globalRoot = path.join(home, ".claude", "skills");
         const pluginsRoot = path.join(home, ".claude", "plugins");
@@ -256,6 +257,7 @@ export const SkillDiscoveryServiceLive = Layer.effect(
       projectCwd: string,
     ): Effect.Effect<ReadonlyArray<Skill>> =>
       Effect.gen(function* () {
+        ensureBundledZuseSkillInstalled("codex", home);
         const viaAppServer = yield* Effect.tryPromise({
           try: async (): Promise<ReadonlyArray<Skill>> => {
             const client = await CodexAppServerClient.start({
@@ -302,10 +304,16 @@ export const SkillDiscoveryServiceLive = Layer.effect(
 
         const projectRoot = path.join(projectCwd, ".codex", "prompts");
         const globalRoot = path.join(home, ".codex", "prompts");
+        const projectSkillsRoot = path.join(projectCwd, ".codex", "skills");
+        const globalSkillsRoot = path.join(home, ".codex", "skills");
         const projectRaw = yield* readCodexPromptsRoot(projectRoot);
         const globalRaw = yield* readCodexPromptsRoot(globalRoot);
+        const projectSkillsRaw = yield* readClaudeSkillsRoot(projectSkillsRoot);
+        const globalSkillsRaw = yield* readClaudeSkillsRoot(globalSkillsRoot);
         const merged: Skill[] = [
+          ...projectSkillsRaw.map((r) => toSkill(r, "project", "codex")),
           ...projectRaw.map((r) => toSkill(r, "project", "codex")),
+          ...globalSkillsRaw.map((r) => toSkill(r, "global", "codex")),
           ...globalRaw.map((r) => toSkill(r, "global", "codex")),
         ];
         return dedupeProjectFirst(merged);
@@ -317,7 +325,9 @@ export const SkillDiscoveryServiceLive = Layer.effect(
     ) =>
       providerId === "claude"
         ? discoverClaude(projectCwd)
-        : discoverCodex(projectCwd);
+        : providerId === "codex"
+          ? discoverCodex(projectCwd)
+          : Effect.succeed([]);
 
     return { discover };
   }),

--- a/apps/server/src/workspace/project-registration.ts
+++ b/apps/server/src/workspace/project-registration.ts
@@ -8,7 +8,12 @@ const DEFAULT_SETTINGS_TOML = `# Zuse repository settings. Commit this file to s
 schemaVersion = 1
 autoCreateWorktree = false
 archiveRemoveWorktree = false
-file_include_globs = ".env\\n.env.local\\n.env.*.local\\n"
+
+file_include_globs = [
+  ".env",
+  ".env.local",
+  ".env.*.local",
+]
 
 [scripts]
 setup = ""

--- a/apps/server/src/workspace/project-registration.ts
+++ b/apps/server/src/workspace/project-registration.ts
@@ -3,6 +3,21 @@ import * as path from "node:path";
 
 const CONTEXT_IGNORE_ENTRY = ".context";
 const SQLITE_SUFFIXES = [".sqlite", ".sqlite-shm", ".sqlite-wal"] as const;
+const DEFAULT_SETTINGS_TOML = `# Zuse repository settings. Commit this file to share setup with your team.
+# Add files below that should be linked from the main checkout into every Zuse worktree.
+schemaVersion = 1
+autoCreateWorktree = false
+archiveRemoveWorktree = false
+file_include_globs = ".env\\n.env.local\\n.env.*.local\\n"
+
+[scripts]
+setup = ""
+run = ""
+archive = ""
+auto_run_after_setup = false
+
+[environment_variables]
+`;
 
 const hasContextIgnore = (content: string): boolean =>
   content
@@ -58,10 +73,24 @@ const removeSqliteArtifacts = async (dir: string): Promise<void> => {
   );
 };
 
+const ensureRepositorySettings = async (root: string): Promise<void> => {
+  const zuseDir = path.join(root, ".zuse");
+  const settingsPath = path.join(zuseDir, "settings.toml");
+  try {
+    await fs.access(settingsPath);
+    return;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  await fs.mkdir(zuseDir, { recursive: true });
+  await fs.writeFile(settingsPath, DEFAULT_SETTINGS_TOML, "utf8");
+};
+
 export const prepareProjectRegistration = async (
   root: string,
 ): Promise<void> => {
   await ensureContextGitignore(root);
+  await ensureRepositorySettings(root);
   await Promise.all([
     removeSqliteArtifacts(path.join(root, ".zuse")),
     removeSqliteArtifacts(path.join(root, ".memoize")),

--- a/apps/server/src/worktree/layers/env-files.ts
+++ b/apps/server/src/worktree/layers/env-files.ts
@@ -25,10 +25,51 @@ const PRUNED_DIRS = new Set<string>([
  * They're tracked (so already materialized in the worktree checkout) and pointless
  * to link — excluding them keeps the setup output clean.
  */
-const TEMPLATE_SUFFIXES = [".example", ".sample", ".template", ".dist"] as const;
+const TEMPLATE_SUFFIXES = [
+  ".example",
+  ".sample",
+  ".template",
+  ".dist",
+] as const;
 
 /** Safety backstop against pathological trees; real env files sit 1-3 levels deep. */
 const MAX_DEPTH = 6;
+
+const toPosix = (value: string): string => value.split(Path.sep).join("/");
+
+const normalizePattern = (value: string): string =>
+  value
+    .trim()
+    .replace(/^\.?\//, "")
+    .replace(/\\/g, "/");
+
+const globToRegExp = (pattern: string): RegExp => {
+  let out = "^";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const char = pattern[i]!;
+    const next = pattern[i + 1];
+    if (char === "*" && next === "*") {
+      out += ".*";
+      i += 1;
+    } else if (char === "*") {
+      out += "[^/]*";
+    } else if (char === "?") {
+      out += "[^/]";
+    } else {
+      out += char.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+    }
+  }
+  return new RegExp(`${out}$`);
+};
+
+const parseIncludeGlobs = (raw: string): string[] =>
+  raw
+    .split(/\r?\n/)
+    .map(normalizePattern)
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+const hasGlobMagic = (pattern: string): boolean =>
+  pattern.includes("*") || pattern.includes("?");
 
 /**
  * True for secret env files we want to bring into a worktree:
@@ -94,5 +135,74 @@ export const linkEnvFiles = async (
   };
 
   await walk("", 0);
+  return output;
+};
+
+export const linkIncludedFiles = async (
+  repoPath: string,
+  worktreePath: string,
+  includeGlobs: string,
+): Promise<string> => {
+  const patterns = parseIncludeGlobs(includeGlobs);
+  if (patterns.length === 0) return linkEnvFiles(repoPath, worktreePath);
+
+  const exact = new Set(patterns.filter((pattern) => !hasGlobMagic(pattern)));
+  const globs = patterns
+    .filter(hasGlobMagic)
+    .map((pattern) => globToRegExp(pattern));
+  const matches: string[] = [];
+
+  const maybeAdd = (rel: string): void => {
+    const posixRel = toPosix(rel);
+    if (exact.has(posixRel) || globs.some((glob) => glob.test(posixRel))) {
+      matches.push(rel);
+    }
+  };
+
+  for (const rel of exact) {
+    const abs = Path.join(repoPath, rel);
+    try {
+      const stat = await fs.lstat(abs);
+      if (stat.isFile() || stat.isSymbolicLink()) maybeAdd(rel);
+    } catch {
+      // Missing exact includes are ignored; they may be optional per machine.
+    }
+  }
+
+  if (globs.length > 0) {
+    const walk = async (relDir: string, depth: number): Promise<void> => {
+      const absDir = relDir === "" ? repoPath : Path.join(repoPath, relDir);
+      let entries: fsSync.Dirent[];
+      try {
+        entries = await fs.readdir(absDir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+
+      for (const entry of entries) {
+        const rel = relDir === "" ? entry.name : Path.join(relDir, entry.name);
+        if (entry.isDirectory()) {
+          if (depth >= MAX_DEPTH) continue;
+          if (PRUNED_DIRS.has(entry.name)) continue;
+          if (fsSync.existsSync(Path.join(repoPath, rel, ".git"))) continue;
+          await walk(rel, depth + 1);
+          continue;
+        }
+        if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+        maybeAdd(rel);
+      }
+    };
+    await walk("", 0);
+  }
+
+  let output = "";
+  for (const rel of [...new Set(matches)].sort()) {
+    const source = Path.join(repoPath, rel);
+    const target = Path.join(worktreePath, rel);
+    if (fsSync.existsSync(target)) continue;
+    await fs.mkdir(Path.dirname(target), { recursive: true });
+    await fs.symlink(source, target, "file");
+    output += `linked ${toPosix(rel)} -> ${source}\n`;
+  }
   return output;
 };

--- a/apps/server/src/worktree/layers/worktree-service.ts
+++ b/apps/server/src/worktree/layers/worktree-service.ts
@@ -37,7 +37,7 @@ import {
   WorktreeService,
   type WorktreeRestoreSnapshot,
 } from "../services/worktree-service.ts";
-import { linkEnvFiles } from "./env-files.ts";
+import { linkIncludedFiles } from "./env-files.ts";
 
 interface WorktreeRow {
   readonly id: string;
@@ -178,6 +178,7 @@ const isEmptyDirectory = async (path: string): Promise<boolean> => {
 const prepareLocalFiles = async (
   repoPath: string,
   worktreePath: string,
+  includeGlobs: string,
 ): Promise<string> => {
   let output = "";
 
@@ -219,7 +220,7 @@ const prepareLocalFiles = async (
     }
   }
 
-  output += await linkEnvFiles(repoPath, worktreePath);
+  output += await linkIncludedFiles(repoPath, worktreePath, includeGlobs);
 
   return output;
 };
@@ -988,7 +989,12 @@ export const WorktreeServiceLive = Layer.effect(
         emitStatus(worktreeId, "running", startedAtDate, null);
 
         const prep = yield* Effect.tryPromise({
-          try: () => prepareLocalFiles(folder.path, worktree.path),
+          try: () =>
+            prepareLocalFiles(
+              folder.path,
+              worktree.path,
+              settings.fileIncludeGlobs,
+            ),
           catch: (err) =>
             new WorktreeSetupError({
               worktreeId,

--- a/apps/server/test/bundled-zuse-skill.test.ts
+++ b/apps/server/test/bundled-zuse-skill.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  bundledZuseSkillPath,
+  ensureBundledZuseSkillInstalled,
+} from "../src/skill/bundled-zuse-skill.ts";
+
+describe("bundled Zuse skill installer", () => {
+  it("installs Claude and Codex native skill files idempotently", () => {
+    const home = mkdtempSync(join(tmpdir(), "zuse-skill-"));
+    try {
+      const claudePath = ensureBundledZuseSkillInstalled("claude", home);
+      const codexPath = ensureBundledZuseSkillInstalled("codex", home);
+
+      expect(claudePath).toBe(
+        join(home, ".claude", "skills", "zuse", "SKILL.md"),
+      );
+      expect(codexPath).toBe(
+        join(home, ".codex", "skills", "zuse", "SKILL.md"),
+      );
+      expect(existsSync(claudePath!)).toBe(true);
+      expect(existsSync(codexPath!)).toBe(true);
+
+      writeFileSync(claudePath!, "stale", "utf8");
+      ensureBundledZuseSkillInstalled("claude", home);
+      expect(readFileSync(claudePath!, "utf8")).toContain("name: zuse");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not install unsupported provider skill files", () => {
+    const home = mkdtempSync(join(tmpdir(), "zuse-skill-"));
+    try {
+      expect(bundledZuseSkillPath("grok", home)).toBeNull();
+      expect(ensureBundledZuseSkillInstalled("grok", home)).toBeNull();
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/test/env-files.test.ts
+++ b/apps/server/test/env-files.test.ts
@@ -4,7 +4,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as Path from "node:path";
 
-import { isEnvFileName, linkEnvFiles } from "../src/worktree/layers/env-files.ts";
+import {
+  isEnvFileName,
+  linkEnvFiles,
+  linkIncludedFiles,
+} from "../src/worktree/layers/env-files.ts";
 
 describe("isEnvFileName", () => {
   const cases: ReadonlyArray<readonly [string, boolean]> = [
@@ -108,5 +112,41 @@ describe("linkEnvFiles", () => {
     await linkEnvFiles(repo, worktree);
 
     expect(fsSync.existsSync(Path.join(worktree, "vendored/.env"))).toBe(false);
+  });
+
+  it("links configured include globs instead of only env files", async () => {
+    await write(repo, ".env.local", "ENV=1");
+    await write(repo, "certs/dev.pem", "CERT=1");
+    await write(repo, "apps/web/.env.preview", "WEB=1");
+
+    const output = await linkIncludedFiles(
+      repo,
+      worktree,
+      ".env.local\ncerts/*.pem\napps/web/.env.*\n",
+    );
+
+    expect(await fs.readlink(Path.join(worktree, ".env.local"))).toBe(
+      Path.join(repo, ".env.local"),
+    );
+    expect(await fs.readlink(Path.join(worktree, "certs/dev.pem"))).toBe(
+      Path.join(repo, "certs/dev.pem"),
+    );
+    expect(
+      await fs.readlink(Path.join(worktree, "apps/web/.env.preview")),
+    ).toBe(Path.join(repo, "apps/web/.env.preview"));
+    expect(output).toContain("linked certs/dev.pem ");
+  });
+
+  it("leaves existing configured include targets untouched", async () => {
+    await write(repo, "certs/dev.pem", "FROM_REPO=1");
+    await write(worktree, "certs/dev.pem", "LOCAL=1");
+
+    await linkIncludedFiles(repo, worktree, "certs/*.pem\n");
+
+    const stat = await fs.lstat(Path.join(worktree, "certs/dev.pem"));
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(
+      await fs.readFile(Path.join(worktree, "certs/dev.pem"), "utf8"),
+    ).toBe("LOCAL=1");
   });
 });

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -170,6 +170,11 @@ const StubRepositorySettingsLive = Layer.succeed(RepositorySettingsService, {
         worktreeBaseDir: null,
         archiveCleanupScript: null,
         archiveRemoveWorktree: false,
+        setupScript: null,
+        runScript: null,
+        autoRunAfterSetup: false,
+        environmentVariables: {},
+        fileIncludeGlobs: "",
       }),
     ),
   update: (projectId, patch) =>
@@ -183,6 +188,11 @@ const StubRepositorySettingsLive = Layer.succeed(RepositorySettingsService, {
         worktreeBaseDir: patch.worktreeBaseDir ?? null,
         archiveCleanupScript: patch.archiveCleanupScript ?? null,
         archiveRemoveWorktree: patch.archiveRemoveWorktree ?? false,
+        setupScript: patch.setupScript ?? null,
+        runScript: patch.runScript ?? null,
+        autoRunAfterSetup: patch.autoRunAfterSetup ?? false,
+        environmentVariables: patch.environmentVariables ?? {},
+        fileIncludeGlobs: patch.fileIncludeGlobs ?? "",
       }),
     ),
 });
@@ -1267,7 +1277,9 @@ describe("MessageStore — fork & transcript export", () => {
         ),
       );
       const md = await run(
-        Effect.flatMap(store, (s) => s.exportTranscript(chat.initialSession.id)),
+        Effect.flatMap(store, (s) =>
+          s.exportTranscript(chat.initialSession.id),
+        ),
       );
       expect(md).toContain("## User");
       expect(md).toContain("fix the bug");
@@ -1386,7 +1398,9 @@ describe("MessageStore — fork & transcript export", () => {
       );
       const sourceId = chat.initialSession.id;
       // Add a user message so there is a tail to fork from.
-      await run(Effect.flatMap(store, (s) => s.sendMessage(sourceId, "keep going")));
+      await run(
+        Effect.flatMap(store, (s) => s.sendMessage(sourceId, "keep going")),
+      );
       const messages = await run(
         Effect.flatMap(store, (s) => s.listMessages(sourceId)),
       );

--- a/apps/server/test/project-registration.test.ts
+++ b/apps/server/test/project-registration.test.ts
@@ -42,6 +42,28 @@ describe("prepareProjectRegistration", () => {
     );
   });
 
+  it("creates a commented .zuse/settings.toml when missing", async () => {
+    await prepareProjectRegistration(dir);
+
+    const content = await fs.readFile(
+      Path.join(dir, ".zuse", "settings.toml"),
+      "utf8",
+    );
+    expect(content).toContain("Zuse repository settings");
+    expect(content).toContain("file_include_globs");
+  });
+
+  it("does not overwrite an existing .zuse/settings.toml", async () => {
+    await fs.mkdir(Path.join(dir, ".zuse"), { recursive: true });
+    await fs.writeFile(Path.join(dir, ".zuse", "settings.toml"), "custom");
+
+    await prepareProjectRegistration(dir);
+
+    expect(
+      await fs.readFile(Path.join(dir, ".zuse", "settings.toml"), "utf8"),
+    ).toBe("custom");
+  });
+
   it("does not duplicate .context", async () => {
     await fs.writeFile(Path.join(dir, ".gitignore"), ".context\n");
 

--- a/apps/server/test/repository-settings.test.ts
+++ b/apps/server/test/repository-settings.test.ts
@@ -203,7 +203,11 @@ describe("RepositorySettingsService repository file persistence", () => {
       writeFileSync(
         join(repoPath, ".zuse", "settings.toml"),
         [
-          'file_include_globs = ".env\\n.env.local\\n"',
+          "file_include_globs = [",
+          '  ".env",',
+          '  ".env.local",',
+          "]",
+          "",
           "",
           "[scripts]",
           'setup = "bun install"',
@@ -223,10 +227,48 @@ describe("RepositorySettingsService repository file persistence", () => {
       expect(settings.setupScript).toBe("bun install");
       expect(settings.runScript).toBe("bun dev");
       expect(settings.autoRunAfterSetup).toBe(true);
-      expect(settings.fileIncludeGlobs).toBe(".env\n.env.local\n");
+      expect(settings.fileIncludeGlobs).toBe(".env\n.env.local");
       expect(settings.environmentVariables.API_BASE).toBe(
         "http://localhost:3000",
       );
+    });
+  });
+
+  it("still reads legacy root file_include_globs strings", async () => {
+    await withRuntime(async ({ run, repoPath }) => {
+      mkdirSync(join(repoPath, ".zuse"), { recursive: true });
+      writeFileSync(
+        join(repoPath, ".zuse", "settings.toml"),
+        'file_include_globs = ".env\\n.env.local\\n"\n',
+        "utf8",
+      );
+
+      const settings = await run(
+        Effect.flatMap(RepositorySettingsService, (svc) => svc.get(PROJECT_ID)),
+      );
+
+      expect(settings.fileIncludeGlobs).toBe(".env\n.env.local\n");
+    });
+  });
+
+  it("still reads legacy file_include_globs tables", async () => {
+    await withRuntime(async ({ run, repoPath }) => {
+      mkdirSync(join(repoPath, ".zuse"), { recursive: true });
+      writeFileSync(
+        join(repoPath, ".zuse", "settings.toml"),
+        [
+          "[file_include_globs]",
+          'env = ".env"',
+          'env_local = ".env.local"',
+        ].join("\n"),
+        "utf8",
+      );
+
+      const settings = await run(
+        Effect.flatMap(RepositorySettingsService, (svc) => svc.get(PROJECT_ID)),
+      );
+
+      expect(settings.fileIncludeGlobs).toBe(".env\n.env.local");
     });
   });
 
@@ -286,7 +328,8 @@ describe("RepositorySettingsService repository file persistence", () => {
       expect(toml).toContain('defaultProviderId = "claude"');
       expect(toml).toContain('run = "bun dev"');
       expect(toml).toContain("auto_run_after_setup = true");
-      expect(toml).toContain('file_include_globs = ".env\\n"');
+      expect(toml).toContain("file_include_globs = [");
+      expect(toml).toContain('  ".env",');
     });
   });
 });

--- a/apps/server/test/repository-settings.test.ts
+++ b/apps/server/test/repository-settings.test.ts
@@ -84,6 +84,8 @@ const seedProject = (repoPath: string) =>
 
 const settingsPath = (repoPath: string): string =>
   join(repoPath, ".zuse", "settings.json");
+const tomlSettingsPath = (repoPath: string): string =>
+  join(repoPath, ".zuse", "settings.toml");
 
 const writeRepoSettings = (
   repoPath: string,
@@ -102,13 +104,16 @@ const readRepoSettings = (repoPath: string): RepositorySettingsFile =>
     readFileSync(settingsPath(repoPath), "utf8"),
   ) as RepositorySettingsFile;
 
+const readRepoSettingsToml = (repoPath: string): string =>
+  readFileSync(tomlSettingsPath(repoPath), "utf8");
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-describe("RepositorySettingsService JSON persistence", () => {
+describe("RepositorySettingsService repository file persistence", () => {
   it("returns defaults when no JSON, TOML, or legacy row exists", async () => {
     await withRuntime(async ({ run }) => {
       const settings = await run(
@@ -121,7 +126,7 @@ describe("RepositorySettingsService JSON persistence", () => {
     });
   });
 
-  it("migrates an existing SQLite row into .zuse/settings.json", async () => {
+  it("migrates an existing SQLite row into .zuse/settings.toml", async () => {
     await withRuntime(async ({ run, repoPath }) => {
       await run(
         Effect.gen(function* () {
@@ -157,8 +162,8 @@ describe("RepositorySettingsService JSON persistence", () => {
       expect(settings.autoCreateWorktree).toBe(true);
       expect(settings.archiveRemoveWorktree).toBe(true);
       expect(settings.environmentVariables.NODE_ENV).toBe("development");
-      expect(existsSync(settingsPath(repoPath))).toBe(true);
-      expect(readRepoSettings(repoPath).runScript).toBe("bun dev");
+      expect(existsSync(tomlSettingsPath(repoPath))).toBe(true);
+      expect(readRepoSettingsToml(repoPath)).toContain('run = "bun dev"');
       expect(rows[0]?.count).toBe(0);
     });
   });
@@ -198,6 +203,8 @@ describe("RepositorySettingsService JSON persistence", () => {
       writeFileSync(
         join(repoPath, ".zuse", "settings.toml"),
         [
+          'file_include_globs = ".env\\n.env.local\\n"',
+          "",
           "[scripts]",
           'setup = "bun install"',
           'run = "bun dev"',
@@ -216,9 +223,26 @@ describe("RepositorySettingsService JSON persistence", () => {
       expect(settings.setupScript).toBe("bun install");
       expect(settings.runScript).toBe("bun dev");
       expect(settings.autoRunAfterSetup).toBe(true);
+      expect(settings.fileIncludeGlobs).toBe(".env\n.env.local\n");
       expect(settings.environmentVariables.API_BASE).toBe(
         "http://localhost:3000",
       );
+    });
+  });
+
+  it("uses .worktreeinclude as a legacy include fallback", async () => {
+    await withRuntime(async ({ run, repoPath }) => {
+      writeFileSync(
+        join(repoPath, ".worktreeinclude"),
+        "# local files\n.env\n.env.local\n",
+        "utf8",
+      );
+
+      const settings = await run(
+        Effect.flatMap(RepositorySettingsService, (svc) => svc.get(PROJECT_ID)),
+      );
+
+      expect(settings.fileIncludeGlobs).toBe(".env\n.env.local");
     });
   });
 
@@ -239,12 +263,13 @@ describe("RepositorySettingsService JSON persistence", () => {
     });
   });
 
-  it("updates JSON atomically while preserving unspecified fields", async () => {
+  it("updates TOML atomically while preserving unspecified fields", async () => {
     await withRuntime(async ({ run, repoPath }) => {
       writeRepoSettings(repoPath, {
         schemaVersion: 1,
         defaultProviderId: "claude",
         runScript: "bun dev",
+        fileIncludeGlobs: ".env\n",
       });
 
       const settings = await run(
@@ -252,14 +277,16 @@ describe("RepositorySettingsService JSON persistence", () => {
           svc.update(PROJECT_ID, { autoRunAfterSetup: true }),
         ),
       );
-      const file = readRepoSettings(repoPath);
+      const toml = readRepoSettingsToml(repoPath);
 
       expect(settings.defaultProviderId).toBe("claude");
       expect(settings.runScript).toBe("bun dev");
       expect(settings.autoRunAfterSetup).toBe(true);
-      expect(file.defaultProviderId).toBe("claude");
-      expect(file.runScript).toBe("bun dev");
-      expect(file.autoRunAfterSetup).toBe(true);
+      expect(existsSync(settingsPath(repoPath))).toBe(false);
+      expect(toml).toContain('defaultProviderId = "claude"');
+      expect(toml).toContain('run = "bun dev"');
+      expect(toml).toContain("auto_run_after_setup = true");
+      expect(toml).toContain('file_include_globs = ".env\\n"');
     });
   });
 });

--- a/apps/server/test/settings-schemas.test.ts
+++ b/apps/server/test/settings-schemas.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..", "..");
+
+describe("public settings schemas", () => {
+  it("are generated and committed", () => {
+    execFileSync("node", ["scripts/generate-settings-schemas.mjs", "--check"], {
+      cwd: repoRoot,
+      stdio: "pipe",
+    });
+  });
+
+  it("exposes stable schema ids", () => {
+    const schemaDir = join(repoRoot, "apps", "web", "public", "schemas");
+    const repository = JSON.parse(
+      readFileSync(join(schemaDir, "repository-settings.schema.json"), "utf8"),
+    ) as { $id?: string };
+    const settings = JSON.parse(
+      readFileSync(join(schemaDir, "settings.schema.json"), "utf8"),
+    ) as { $id?: string };
+    const keybindings = JSON.parse(
+      readFileSync(join(schemaDir, "keybindings.schema.json"), "utf8"),
+    ) as { $id?: string };
+
+    expect(repository.$id).toBe(
+      "https://zuse.dev/schemas/repository-settings.schema.json",
+    );
+    expect(settings.$id).toBe("https://zuse.dev/schemas/settings.schema.json");
+    expect(keybindings.$id).toBe(
+      "https://zuse.dev/schemas/keybindings.schema.json",
+    );
+  });
+});

--- a/apps/server/test/support/message-store-fixture-harness.ts
+++ b/apps/server/test/support/message-store-fixture-harness.ts
@@ -154,6 +154,11 @@ const makeRuntime = (
           worktreeBaseDir: null,
           archiveCleanupScript: null,
           archiveRemoveWorktree: false,
+          setupScript: null,
+          runScript: null,
+          autoRunAfterSetup: false,
+          environmentVariables: {},
+          fileIncludeGlobs: "",
         }),
       ),
     update: (projectId, patch) =>
@@ -167,6 +172,11 @@ const makeRuntime = (
           worktreeBaseDir: patch.worktreeBaseDir ?? null,
           archiveCleanupScript: patch.archiveCleanupScript ?? null,
           archiveRemoveWorktree: patch.archiveRemoveWorktree ?? false,
+          setupScript: patch.setupScript ?? null,
+          runScript: patch.runScript ?? null,
+          autoRunAfterSetup: patch.autoRunAfterSetup ?? false,
+          environmentVariables: patch.environmentVariables ?? {},
+          fileIncludeGlobs: patch.fileIncludeGlobs ?? "",
         }),
       ),
   });

--- a/apps/server/test/workspace-instructions.test.ts
+++ b/apps/server/test/workspace-instructions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+
+import { zuseWorkspaceInstructions } from "../src/provider/workspace-instructions.ts";
+
+describe("zuseWorkspaceInstructions", () => {
+  it("renders Zuse-specific workspace context without naming other workspace apps", () => {
+    const text = zuseWorkspaceInstructions({
+      projectPath: "/repo",
+      cwd: "/repo/worktrees/demo",
+    });
+
+    expect(text).toContain("You are running inside Zuse");
+    expect(text).toContain("Project root: /repo");
+    expect(text).toContain("Current working directory: /repo/worktrees/demo");
+    expect(text).toContain("Target base ref: origin/main");
+    expect(text).toContain("Zuse is not a remote execution service");
+  });
+});

--- a/apps/web/app/docs/repository-settings/page.tsx
+++ b/apps/web/app/docs/repository-settings/page.tsx
@@ -1,0 +1,52 @@
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+  title: "Zuse Repository Settings",
+  description: "Configure .zuse/settings.toml for shared Zuse project setup.",
+  path: "/docs/repository-settings",
+});
+
+export default function RepositorySettingsDocs() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-20 text-foreground">
+      <header className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">Docs</p>
+        <h1 className="text-4xl font-semibold">Repository settings</h1>
+        <p className="text-muted-foreground">
+          Commit <code>.zuse/settings.toml</code> when setup should be shared by
+          everyone working in a repository.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Example</h2>
+        <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/30 p-4 text-sm">
+          {`# Zuse repository settings. Commit this file to share setup with your team.
+# Add files below that should be linked from the main checkout into every Zuse worktree.
+schemaVersion = 1
+autoCreateWorktree = false
+archiveRemoveWorktree = false
+file_include_globs = ".env\\n.env.local\\n.env.*.local\\n"
+
+[scripts]
+setup = "bun install"
+run = "bun run dev"
+archive = ""
+auto_run_after_setup = false
+
+[environment_variables]
+NODE_ENV = "development"`}
+        </pre>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Schema</h2>
+        <p className="text-muted-foreground">
+          Use{" "}
+          <code>https://zuse.dev/schemas/repository-settings.schema.json</code>
+          for editor validation.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/docs/repository-settings/page.tsx
+++ b/apps/web/app/docs/repository-settings/page.tsx
@@ -26,7 +26,12 @@ export default function RepositorySettingsDocs() {
 schemaVersion = 1
 autoCreateWorktree = false
 archiveRemoveWorktree = false
-file_include_globs = ".env\\n.env.local\\n.env.*.local\\n"
+
+file_include_globs = [
+  ".env",
+  ".env.local",
+  ".env.*.local",
+]
 
 [scripts]
 setup = "bun install"

--- a/apps/web/app/docs/schemas/page.tsx
+++ b/apps/web/app/docs/schemas/page.tsx
@@ -1,0 +1,28 @@
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+  title: "Zuse Schema URLs",
+  description: "Public JSON Schemas for Zuse settings files.",
+  path: "/docs/schemas",
+});
+
+export default function SchemaDocs() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-20 text-foreground">
+      <header className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">Docs</p>
+        <h1 className="text-4xl font-semibold">Schema URLs</h1>
+        <p className="text-muted-foreground">
+          Zuse publishes stable schemas for editor validation and agent
+          guidance.
+        </p>
+      </header>
+
+      <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/30 p-4 text-sm">
+        {`https://zuse.dev/schemas/settings.schema.json
+https://zuse.dev/schemas/repository-settings.schema.json
+https://zuse.dev/schemas/keybindings.schema.json`}
+      </pre>
+    </main>
+  );
+}

--- a/apps/web/app/docs/scripts/page.tsx
+++ b/apps/web/app/docs/scripts/page.tsx
@@ -1,0 +1,42 @@
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+  title: "Zuse Repository Scripts",
+  description: "Configure setup, run, and archive scripts for Zuse worktrees.",
+  path: "/docs/scripts",
+});
+
+export default function ScriptsDocs() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-20 text-foreground">
+      <header className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">Docs</p>
+        <h1 className="text-4xl font-semibold">Repository scripts</h1>
+        <p className="text-muted-foreground">
+          Scripts in <code>.zuse/settings.toml</code> run from the worktree
+          directory and receive Zuse environment variables.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Fields</h2>
+        <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/30 p-4 text-sm">
+          {`[scripts]
+setup = "bun install"
+run = "bun run dev"
+archive = "rm -rf node_modules .next"
+auto_run_after_setup = false`}
+        </pre>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Environment</h2>
+        <p className="text-muted-foreground">
+          Zuse passes <code>ZUSE_ROOT_PATH</code>,{" "}
+          <code>ZUSE_WORKTREE_PATH</code>, <code>ZUSE_WORKTREE_ID</code>, and
+          values from the <code>[environment_variables]</code> table.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/docs/settings/page.tsx
+++ b/apps/web/app/docs/settings/page.tsx
@@ -1,0 +1,42 @@
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+  title: "Zuse User Settings",
+  description: "User-level Zuse settings, keybindings, and schema URLs.",
+  path: "/docs/settings",
+});
+
+export default function SettingsDocs() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-20 text-foreground">
+      <header className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">Docs</p>
+        <h1 className="text-4xl font-semibold">User settings</h1>
+        <p className="text-muted-foreground">
+          Zuse stores user-level preferences in{" "}
+          <code>~/.zuse/settings.json</code>
+          and keybinding overrides in <code>~/.zuse/keybindings.json</code>.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Schemas</h2>
+        <p className="text-muted-foreground">
+          Editors can use these public schemas for validation and completion.
+        </p>
+        <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/30 p-4 text-sm">
+          {`https://zuse.dev/schemas/settings.schema.json
+https://zuse.dev/schemas/keybindings.schema.json`}
+        </pre>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Repository settings</h2>
+        <p className="text-muted-foreground">
+          Team-shared project setup belongs in <code>.zuse/settings.toml</code>,
+          not user settings.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/docs/worktree-includes/page.tsx
+++ b/apps/web/app/docs/worktree-includes/page.tsx
@@ -1,0 +1,43 @@
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+  title: "Zuse Worktree File Includes",
+  description: "Copy or link local files into Zuse worktrees.",
+  path: "/docs/worktree-includes",
+});
+
+export default function WorktreeIncludesDocs() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-20 text-foreground">
+      <header className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">Docs</p>
+        <h1 className="text-4xl font-semibold">Worktree file includes</h1>
+        <p className="text-muted-foreground">
+          Use <code>file_include_globs</code> in{" "}
+          <code>.zuse/settings.toml</code> for local files every worktree needs.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Behavior</h2>
+        <p className="text-muted-foreground">
+          Zuse links matching files from the main checkout into each new
+          worktree at the same relative path. Existing worktree files are left
+          untouched.
+        </p>
+        <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/30 p-4 text-sm">
+          {`file_include_globs = ".env\\n.env.local\\napps/web/.env.local\\n"`}
+        </pre>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Legacy file</h2>
+        <p className="text-muted-foreground">
+          A root <code>.worktreeinclude</code> file may still be read for
+          compatibility, but new projects should use{" "}
+          <code>.zuse/settings.toml</code>.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/docs/worktree-includes/page.tsx
+++ b/apps/web/app/docs/worktree-includes/page.tsx
@@ -26,7 +26,11 @@ export default function WorktreeIncludesDocs() {
           untouched.
         </p>
         <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/30 p-4 text-sm">
-          {`file_include_globs = ".env\\n.env.local\\napps/web/.env.local\\n"`}
+          {`file_include_globs = [
+  ".env",
+  ".env.local",
+  "apps/web/.env.local",
+]`}
         </pre>
       </section>
 

--- a/apps/web/app/docs/zuse-skill/page.tsx
+++ b/apps/web/app/docs/zuse-skill/page.tsx
@@ -1,0 +1,43 @@
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+  title: "Bundled Zuse Skill",
+  description: "How the first-party Zuse skill is installed and used.",
+  path: "/docs/zuse-skill",
+});
+
+export default function ZuseSkillDocs() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-20 text-foreground">
+      <header className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">Docs</p>
+        <h1 className="text-4xl font-semibold">Bundled Zuse skill</h1>
+        <p className="text-muted-foreground">
+          Zuse ships one first-party native skill for help with project setup,
+          repository settings, worktrees, scripts, schemas, and troubleshooting.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Native providers</h2>
+        <p className="text-muted-foreground">
+          Zuse installs the skill for Claude and Codex, the providers with
+          native skill discovery currently wired in Zuse.
+        </p>
+        <pre className="overflow-x-auto rounded-lg border border-border/60 bg-muted/30 p-4 text-sm">
+          {`~/.claude/skills/zuse/SKILL.md
+~/.codex/skills/zuse/SKILL.md`}
+        </pre>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Unsupported providers</h2>
+        <p className="text-muted-foreground">
+          Grok, OpenCode, Cursor, and Gemini do not receive injected fallback
+          skill text. They can support this later when native provider skill
+          surfaces are available in Zuse.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/public/schemas/keybindings.schema.json
+++ b/apps/web/public/schemas/keybindings.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zuse.dev/schemas/keybindings.schema.json",
+  "title": "Zuse Keybindings",
+  "description": "User keybinding overrides stored in ~/.zuse/keybindings.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "rules"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "rules": {
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "command"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "command": {
+            "enum": [
+              "new-chat",
+              "open-project",
+              "settings",
+              "close-tab",
+              "toggle-left-sidebar",
+              "toggle-right-sidebar",
+              "toggle-terminal",
+              "focus-composer",
+              "next-tab",
+              "prev-tab",
+              "select-tab-1",
+              "select-tab-2",
+              "select-tab-3",
+              "select-tab-4",
+              "select-tab-5",
+              "select-tab-6",
+              "select-tab-7",
+              "select-tab-8",
+              "select-last-tab",
+              "new-tab",
+              "next-chat",
+              "prev-chat",
+              "next-panel",
+              "prev-panel",
+              "focus-next-pane",
+              "focus-prev-pane",
+              "open-chat-switcher",
+              "composer.submit",
+              "composer.newline",
+              "composer.forceSubmit",
+              "composer.togglePlanMode",
+              "editor.save",
+              "editor.annotate"
+            ]
+          },
+          "when": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/public/schemas/repository-settings.schema.json
+++ b/apps/web/public/schemas/repository-settings.schema.json
@@ -68,8 +68,19 @@
       "type": "boolean"
     },
     "file_include_globs": {
-      "type": "string",
-      "description": "Newline-separated patterns linked from the main checkout into every Zuse worktree."
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string",
+          "description": "Legacy newline-separated pattern list."
+        }
+      ],
+      "description": "Patterns linked from the main checkout into every Zuse worktree."
     },
     "scripts": {
       "type": "object",

--- a/apps/web/public/schemas/repository-settings.schema.json
+++ b/apps/web/public/schemas/repository-settings.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zuse.dev/schemas/repository-settings.schema.json",
+  "title": "Zuse Repository Settings",
+  "description": "Committed repository settings for .zuse/settings.toml.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "defaultProviderId": {
+      "anyOf": [
+        {
+          "enum": [
+            "claude",
+            "codex",
+            "grok",
+            "gemini",
+            "cursor",
+            "opencode"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "defaultModel": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "defaultRuntimeMode": {
+      "anyOf": [
+        {
+          "enum": [
+            "approval-required",
+            "auto-accept-edits",
+            "auto-accept-edits-and-bash",
+            "full-access"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "autoCreateWorktree": {
+      "type": "boolean"
+    },
+    "worktreeBaseDir": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "archiveRemoveWorktree": {
+      "type": "boolean"
+    },
+    "file_include_globs": {
+      "type": "string",
+      "description": "Newline-separated patterns linked from the main checkout into every Zuse worktree."
+    },
+    "scripts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "setup": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "run": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "archive": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "auto_run_after_setup": {
+          "type": "boolean"
+        }
+      }
+    },
+    "environment_variables": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/apps/web/public/schemas/settings.schema.json
+++ b/apps/web/public/schemas/settings.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zuse.dev/schemas/settings.schema.json",
+  "title": "Zuse User Settings",
+  "description": "User-level settings stored in ~/.zuse/settings.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "defaultProviderId",
+    "defaultModelByProvider",
+    "defaultRuntimeMode",
+    "defaultAutoCreateWorktree",
+    "onboardingCompleted",
+    "appearanceMode",
+    "completionSoundEnabled",
+    "completionSoundPreset",
+    "providerEnabled",
+    "modelEnabledByProvider",
+    "subagents",
+    "branchNamingStyle",
+    "branchNamingPrefix",
+    "mergePrefs",
+    "notchTrayEnabled",
+    "notchTrayPinned"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "defaultProviderId": {
+      "enum": [
+        "claude",
+        "codex",
+        "grok",
+        "gemini",
+        "cursor",
+        "opencode"
+      ]
+    },
+    "defaultModelByProvider": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "defaultRuntimeMode": {
+      "enum": [
+        "approval-required",
+        "auto-accept-edits",
+        "auto-accept-edits-and-bash",
+        "full-access"
+      ]
+    },
+    "defaultAutoCreateWorktree": {
+      "type": "boolean"
+    },
+    "onboardingCompleted": {
+      "type": "boolean"
+    },
+    "appearanceMode": {
+      "enum": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "completionSoundEnabled": {
+      "type": "boolean"
+    },
+    "completionSoundPreset": {
+      "enum": [
+        "chime",
+        "soft",
+        "pop",
+        "bell",
+        "rise",
+        "bloom"
+      ]
+    },
+    "providerEnabled": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "modelEnabledByProvider": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      }
+    },
+    "subagents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enableForNewSessions",
+        "presets"
+      ],
+      "properties": {
+        "enableForNewSessions": {
+          "type": "boolean"
+        },
+        "presets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "enabled",
+              "overrides"
+            ],
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "overrides": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "branchNamingStyle": {
+      "enum": [
+        "username-slug",
+        "slug",
+        "feat-slug",
+        "custom"
+      ]
+    },
+    "branchNamingPrefix": {
+      "type": "string"
+    },
+    "mergePrefs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method",
+        "deleteBranch"
+      ],
+      "properties": {
+        "method": {
+          "enum": [
+            "merge",
+            "squash",
+            "rebase"
+          ]
+        },
+        "deleteBranch": {
+          "type": "boolean"
+        }
+      }
+    },
+    "notchTrayEnabled": {
+      "type": "boolean"
+    },
+    "notchTrayPinned": {
+      "type": "boolean"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check-types": "turbo run check-types",
     "test": "turbo run test",
     "test:live-agents": "cd apps/server && bun run test:live-agents",
+    "schemas:generate": "node scripts/generate-settings-schemas.mjs",
     "diagnostics:inspect": "node scripts/diagnostics-inspect.mjs",
     "rebuild:pty": "cd apps/desktop && electron-rebuild -f -w node-pty",
     "dist:mac": "bun run build:desktop && cd apps/desktop && bun run dist:mac",

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -660,6 +660,13 @@ export const StartSessionInput = Schema.Struct({
   providerId: ProviderId,
   mode: SessionMode,
   initialPrompt: Schema.optional(Schema.String),
+  /**
+   * Internal Zuse-provided workspace context. The renderer does not set this;
+   * ProviderService fills it after resolving the project/worktree cwd so
+   * drivers can pass it through native system/developer instruction channels
+   * where available.
+   */
+  workspaceInstructions: Schema.optional(Schema.String),
   // Optional caller-supplied id. When omitted, ProviderService mints a fresh
   // one. MessageStore uses this to lazy-restart a closed session without
   // moving its persisted history to a new row.

--- a/packages/wire/src/repository-settings.ts
+++ b/packages/wire/src/repository-settings.ts
@@ -46,6 +46,12 @@ export class RepositorySettings extends Schema.Class<RepositorySettings>(
     key: Schema.String,
     value: Schema.String,
   }),
+  /**
+   * Newline-separated gitignore-style patterns for local files that should be
+   * linked into every Zuse worktree from the main checkout. Empty means "use
+   * Zuse's built-in env-file discovery fallback".
+   */
+  fileIncludeGlobs: Schema.String,
 }) {}
 
 /**
@@ -67,6 +73,7 @@ export const RepositorySettingsPatch = Schema.Struct({
   environmentVariables: Schema.optional(
     Schema.Record({ key: Schema.String, value: Schema.String }),
   ),
+  fileIncludeGlobs: Schema.optional(Schema.String),
 });
 export type RepositorySettingsPatch = typeof RepositorySettingsPatch.Type;
 
@@ -90,6 +97,7 @@ export const RepositorySettingsFile = Schema.Struct({
     key: Schema.String,
     value: Schema.String,
   }),
+  fileIncludeGlobs: Schema.String,
 });
 export type RepositorySettingsFile = typeof RepositorySettingsFile.Type;
 

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -574,6 +574,7 @@ describe("RepositorySettingsFile round-trip", () => {
       environmentVariables: {
         NODE_ENV: "development",
       },
+      fileIncludeGlobs: ".env\n.env.local\n",
     });
   });
 });

--- a/scripts/archive.mjs
+++ b/scripts/archive.mjs
@@ -1,0 +1,153 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+const workspaceRoot = process.cwd();
+const dryRun = process.argv.includes("--dry-run");
+
+const removableDirNames = new Set([
+  "node_modules",
+  ".turbo",
+  ".next",
+  ".vercel",
+  ".vite",
+  ".cache",
+  ".parcel-cache",
+  ".nuxt",
+  ".output",
+  ".svelte-kit",
+  "coverage",
+  "build",
+  "dist",
+  "dist-electron",
+  "out",
+  "playwright-report",
+  "test-results",
+]);
+
+const explicitRelativeDirs = [
+  ".context/user-data",
+  ".electron-runtime",
+  "apps/renderer/hugeicons-migrate-backup-*",
+  "apps/renderer/hugeicons-migration-report-*.html",
+];
+
+const runGit = (args) =>
+  execFileSync("git", args, {
+    cwd: workspaceRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+
+const root = runGit(["rev-parse", "--show-toplevel"]);
+if (resolve(root) !== resolve(workspaceRoot)) {
+  throw new Error(
+    `Archive cleanup must run from the workspace root. Expected ${root}, got ${workspaceRoot}.`,
+  );
+}
+
+const isInsideRoot = (path) => {
+  const resolved = resolve(path);
+  return (
+    resolved === resolve(workspaceRoot) ||
+    resolved.startsWith(`${resolve(workspaceRoot)}/`)
+  );
+};
+
+const toRelative = (path) => relative(workspaceRoot, path);
+
+const hasTrackedContent = (path) => {
+  try {
+    const tracked = execFileSync("git", ["ls-files", "--", toRelative(path)], {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return tracked.trim().length > 0;
+  } catch {
+    return false;
+  }
+};
+
+const shouldRemove = (path) => {
+  if (!isInsideRoot(path)) return false;
+  if (!existsSync(path)) return false;
+  return !hasTrackedContent(path);
+};
+
+const removePath = (path, removed) => {
+  if (!shouldRemove(path)) return;
+  removed.push(toRelative(path) || ".");
+  if (dryRun) return;
+  rmSync(path, { recursive: true, force: true });
+};
+
+const walk = (dir, removed) => {
+  let entries = [];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const path = resolve(dir, entry.name);
+    if (entry.name === ".git") continue;
+
+    if (entry.isDirectory()) {
+      if (removableDirNames.has(entry.name)) {
+        removePath(path, removed);
+        continue;
+      }
+      walk(path, removed);
+      continue;
+    }
+
+    if (
+      entry.isFile() &&
+      (entry.name === ".DS_Store" ||
+        entry.name.startsWith("npm-debug.log") ||
+        entry.name.startsWith("yarn-debug.log") ||
+        entry.name.startsWith("yarn-error.log"))
+    ) {
+      removePath(path, removed);
+    }
+  }
+};
+
+const expandGlob = (pattern) => {
+  try {
+    const output = execFileSync(
+      "bash",
+      ["-lc", `compgen -G ${JSON.stringify(pattern)}`],
+      {
+        cwd: workspaceRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    ).trim();
+    return output.length === 0
+      ? []
+      : output.split("\n").map((path) => resolve(workspaceRoot, path));
+  } catch {
+    return [];
+  }
+};
+
+const removed = [];
+for (const relativePath of explicitRelativeDirs) {
+  if (relativePath.includes("*")) {
+    for (const path of expandGlob(relativePath)) removePath(path, removed);
+  } else {
+    removePath(resolve(workspaceRoot, relativePath), removed);
+  }
+}
+walk(workspaceRoot, removed);
+
+if (removed.length === 0) {
+  console.log("archive cleanup: nothing to remove");
+} else {
+  for (const path of removed.sort()) {
+    console.log(`${dryRun ? "would remove" : "removed"} ${path}`);
+  }
+}

--- a/scripts/generate-settings-schemas.mjs
+++ b/scripts/generate-settings-schemas.mjs
@@ -100,9 +100,18 @@ writeSchema("repository-settings.schema.json", {
     worktreeBaseDir: nullableString,
     archiveRemoveWorktree: { type: "boolean" },
     file_include_globs: {
-      type: "string",
+      anyOf: [
+        {
+          type: "array",
+          items: { type: "string" },
+        },
+        {
+          type: "string",
+          description: "Legacy newline-separated pattern list.",
+        },
+      ],
       description:
-        "Newline-separated patterns linked from the main checkout into every Zuse worktree.",
+        "Patterns linked from the main checkout into every Zuse worktree.",
     },
     scripts: {
       type: "object",

--- a/scripts/generate-settings-schemas.mjs
+++ b/scripts/generate-settings-schemas.mjs
@@ -1,0 +1,228 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const outDir = join(process.cwd(), "apps", "web", "public", "schemas");
+const check = process.argv.includes("--check");
+const pending = [];
+
+const providerIds = ["claude", "codex", "grok", "gemini", "cursor", "opencode"];
+const runtimeModes = [
+  "approval-required",
+  "auto-accept-edits",
+  "auto-accept-edits-and-bash",
+  "full-access",
+];
+const appearanceModes = ["system", "light", "dark"];
+const completionSounds = ["chime", "soft", "pop", "bell", "rise", "bloom"];
+const branchNamingStyles = ["username-slug", "slug", "feat-slug", "custom"];
+const mergeMethods = ["merge", "squash", "rebase"];
+const commands = [
+  "new-chat",
+  "open-project",
+  "settings",
+  "close-tab",
+  "toggle-left-sidebar",
+  "toggle-right-sidebar",
+  "toggle-terminal",
+  "focus-composer",
+  "next-tab",
+  "prev-tab",
+  "select-tab-1",
+  "select-tab-2",
+  "select-tab-3",
+  "select-tab-4",
+  "select-tab-5",
+  "select-tab-6",
+  "select-tab-7",
+  "select-tab-8",
+  "select-last-tab",
+  "new-tab",
+  "next-chat",
+  "prev-chat",
+  "next-panel",
+  "prev-panel",
+  "focus-next-pane",
+  "focus-prev-pane",
+  "open-chat-switcher",
+  "composer.submit",
+  "composer.newline",
+  "composer.forceSubmit",
+  "composer.togglePlanMode",
+  "editor.save",
+  "editor.annotate",
+];
+
+const stringMap = {
+  type: "object",
+  additionalProperties: { type: "string" },
+};
+
+const boolMap = {
+  type: "object",
+  additionalProperties: { type: "boolean" },
+};
+
+const nullableString = {
+  anyOf: [{ type: "string" }, { type: "null" }],
+};
+
+const nullableEnum = (values) => ({
+  anyOf: [{ enum: values }, { type: "null" }],
+});
+
+const writeSchema = (name, schema) => {
+  const filePath = join(outDir, name);
+  const serialized = `${JSON.stringify(schema, null, 2)}\n`;
+  if (check) {
+    const current = existsSync(filePath)
+      ? readFileSync(filePath, "utf8")
+      : null;
+    if (current !== serialized) pending.push(name);
+    return;
+  }
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, serialized, "utf8");
+};
+
+writeSchema("repository-settings.schema.json", {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "https://zuse.dev/schemas/repository-settings.schema.json",
+  title: "Zuse Repository Settings",
+  description: "Committed repository settings for .zuse/settings.toml.",
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    schemaVersion: { const: 1 },
+    defaultProviderId: nullableEnum(providerIds),
+    defaultModel: nullableString,
+    defaultRuntimeMode: nullableEnum(runtimeModes),
+    autoCreateWorktree: { type: "boolean" },
+    worktreeBaseDir: nullableString,
+    archiveRemoveWorktree: { type: "boolean" },
+    file_include_globs: {
+      type: "string",
+      description:
+        "Newline-separated patterns linked from the main checkout into every Zuse worktree.",
+    },
+    scripts: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        setup: nullableString,
+        run: nullableString,
+        archive: nullableString,
+        auto_run_after_setup: { type: "boolean" },
+      },
+    },
+    environment_variables: stringMap,
+  },
+});
+
+writeSchema("settings.schema.json", {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "https://zuse.dev/schemas/settings.schema.json",
+  title: "Zuse User Settings",
+  description: "User-level settings stored in ~/.zuse/settings.json.",
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "schemaVersion",
+    "defaultProviderId",
+    "defaultModelByProvider",
+    "defaultRuntimeMode",
+    "defaultAutoCreateWorktree",
+    "onboardingCompleted",
+    "appearanceMode",
+    "completionSoundEnabled",
+    "completionSoundPreset",
+    "providerEnabled",
+    "modelEnabledByProvider",
+    "subagents",
+    "branchNamingStyle",
+    "branchNamingPrefix",
+    "mergePrefs",
+    "notchTrayEnabled",
+    "notchTrayPinned",
+  ],
+  properties: {
+    schemaVersion: { const: 1 },
+    defaultProviderId: { enum: providerIds },
+    defaultModelByProvider: stringMap,
+    defaultRuntimeMode: { enum: runtimeModes },
+    defaultAutoCreateWorktree: { type: "boolean" },
+    onboardingCompleted: { type: "boolean" },
+    appearanceMode: { enum: appearanceModes },
+    completionSoundEnabled: { type: "boolean" },
+    completionSoundPreset: { enum: completionSounds },
+    providerEnabled: boolMap,
+    modelEnabledByProvider: {
+      type: "object",
+      additionalProperties: boolMap,
+    },
+    subagents: {
+      type: "object",
+      additionalProperties: false,
+      required: ["enableForNewSessions", "presets"],
+      properties: {
+        enableForNewSessions: { type: "boolean" },
+        presets: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            additionalProperties: true,
+            required: ["enabled", "overrides"],
+            properties: {
+              enabled: { type: "boolean" },
+              overrides: { type: "object", additionalProperties: true },
+            },
+          },
+        },
+      },
+    },
+    branchNamingStyle: { enum: branchNamingStyles },
+    branchNamingPrefix: { type: "string" },
+    mergePrefs: {
+      type: "object",
+      additionalProperties: false,
+      required: ["method", "deleteBranch"],
+      properties: {
+        method: { enum: mergeMethods },
+        deleteBranch: { type: "boolean" },
+      },
+    },
+    notchTrayEnabled: { type: "boolean" },
+    notchTrayPinned: { type: "boolean" },
+  },
+});
+
+writeSchema("keybindings.schema.json", {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "https://zuse.dev/schemas/keybindings.schema.json",
+  title: "Zuse Keybindings",
+  description: "User keybinding overrides stored in ~/.zuse/keybindings.json.",
+  type: "object",
+  additionalProperties: false,
+  required: ["schemaVersion", "rules"],
+  properties: {
+    schemaVersion: { const: 1 },
+    rules: {
+      type: "array",
+      maxItems: 256,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["key", "command"],
+        properties: {
+          key: { type: "string" },
+          command: { enum: commands },
+          when: { type: "string" },
+        },
+      },
+    },
+  },
+});
+
+if (pending.length > 0) {
+  console.error(`Schema files are out of date: ${pending.join(", ")}`);
+  process.exit(1);
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,13 +1,20 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, lstatSync, readdirSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 
 const workspaceRoot = process.cwd();
-const commonDir = execFileSync("git", [
-  "rev-parse",
-  "--path-format=absolute",
-  "--git-common-dir",
-], { cwd: workspaceRoot, encoding: "utf8" }).trim();
+const commonDir = execFileSync(
+  "git",
+  ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+  { cwd: workspaceRoot, encoding: "utf8" },
+).trim();
 const repoRoot = join(commonDir, "..");
 
 const lockfiles = [
@@ -29,7 +36,8 @@ function lockfilesMatch() {
   for (const lockfile of lockfiles) {
     const source = join(repoRoot, lockfile);
     const target = join(workspaceRoot, lockfile);
-    if (existsSync(source) || existsSync(target)) return sameFile(source, target);
+    if (existsSync(source) || existsSync(target))
+      return sameFile(source, target);
   }
   return false;
 }

--- a/specs/0.03-MVP/decisions/0011-skills-via-provider.md
+++ b/specs/0.03-MVP/decisions/0011-skills-via-provider.md
@@ -49,7 +49,7 @@ frontmatter conventions, override semantics, or hot-reload signals.
   underlying tool does the discovery and parsing; memoize consumes
   the projected `Skill` shape.
 - For Claude, the Agent SDK already does this work (`settingSources:
-  ["user", "project", "local"]` exposes commands via `init.commands`);
+["user", "project", "local"]` exposes commands via `init.commands`);
   the driver projects each entry onto our `Skill` schema.
 - For Codex, the CLI exposes `skills/list` over its RPC interface and
   emits `SkillsChangedNotification` on changes.
@@ -96,7 +96,7 @@ inherits those improvements without code changes.
 
 - Skill body expansion happens on the provider side. When the user
   picks a `skill` chip and submits, memoize passes a `SkillRef
-  { name, scope, args }` to the driver, which calls into the SDK or
+{ name, scope, args }` to the driver, which calls into the SDK or
   CLI to invoke the skill. Memoize never inlines skill body text
   into the prompt. This keeps memoize's behavior identical to using
   the underlying tool directly — users get the same skill semantics
@@ -143,3 +143,18 @@ Concretely for 0.03:
 - A future iteration may swap to SDK / RPC discovery (e.g. when the
   Claude SDK exposes a session-less listing) — the renderer surface
   doesn't change.
+
+## Amendment (2026-07-05): bundled first-party Zuse skill
+
+Zuse still does not own arbitrary user-authored skills. The exception is one
+first-party `zuse` skill shipped with the app, used for Zuse setup,
+repository settings, worktrees, scripts, schema URLs, and troubleshooting.
+
+The bundled skill is installed only into providers with native skill support
+that Zuse already discovers:
+
+- Claude: `~/.claude/skills/zuse/SKILL.md`
+- Codex: `~/.codex/skills/zuse/SKILL.md`
+
+Providers without a native skill surface in Zuse, such as Grok, OpenCode,
+Cursor, and Gemini, do not receive prompt-injected fallback skill text.


### PR DESCRIPTION
## Summary

- Promote committed repository config to `.zuse/settings.toml` with `file_include_globs = [...]` for worktree-local files.
- Keep `.zuse/settings.json`, legacy newline-string `file_include_globs`, legacy table-shaped `file_include_globs`, and `.worktreeinclude` readable as compatibility inputs while writing TOML arrays going forward.
- Add public settings schemas, docs pages, and a bundled first-party Zuse skill installed natively for Claude and Codex.
- Wire repository settings UI and worktree setup to configured include globs while preserving non-clobber symlink behavior.
- Inject Zuse workspace context into provider sessions so agents know the project root, active cwd, base ref, branch rules, and `.context` handoff location.

## Validation

- `bun test apps/server/test/workspace-instructions.test.ts apps/server/test/repository-settings.test.ts apps/server/test/env-files.test.ts apps/server/test/bundled-zuse-skill.test.ts apps/server/test/settings-schemas.test.ts apps/server/test/project-registration.test.ts packages/wire/test/schema.test.ts`
- `bun test apps/server/test/repository-settings.test.ts apps/server/test/project-registration.test.ts apps/server/test/settings-schemas.test.ts`
- `bunx turbo run check-types --filter=@zuse/wire --filter=@zuse/server --filter=renderer --filter=desktop`
- `rg -n "Conductor|conductor" . --glob '!node_modules/**' --glob '!bun.lock' --glob '!dist/**' --glob '!coverage/**'` returned no matches

Full `bun run check-types` is still blocked by existing `apps/web` fumadocs/blog typing issues unrelated to this change.

## Smoke Test Notes

Manual coverage: repository TOML creation/editing with array include globs, worktree include linking, legacy `.worktreeinclude` fallback, public schema URLs, Claude/Codex bundled skill installation, and provider session startup with Zuse workspace context.
