### PR TITLE
[codex] Fix chat autoscroll performance

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -863,7 +863,7 @@ export function ChatComposer({
     <TooltipProvider delay={0}>
       {showCard ? (
         <div className="shrink-0 px-3 pb-3 pt-2">
-          <div className="mx-auto">
+          <div className="mx-auto w-full max-w-4xl">
             {headPermission !== undefined ? (
               <PermissionCard
                 head={headPermission}
@@ -885,7 +885,7 @@ export function ChatComposer({
         style={showCard ? { display: "none" } : undefined}
         aria-hidden={showCard || undefined}
       >
-        <div className="mx-auto">
+        <div className="mx-auto w-full max-w-4xl">
           {!isDraft ? (
             <AnnotationTray
               sessionId={sessionId}

--- a/apps/renderer/src/components/chat-lookups.tsx
+++ b/apps/renderer/src/components/chat-lookups.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext } from "react";
+
+import type { AgentItemId, UserQuestionAnswer } from "@zuse/wire";
+
+export interface ToolResultRecord {
+  readonly output: unknown;
+  readonly isError: boolean;
+}
+
+export interface ChatLookups {
+  readonly resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
+  readonly answersByItemId: ReadonlyMap<
+    AgentItemId,
+    ReadonlyArray<UserQuestionAnswer>
+  >;
+}
+
+const EMPTY_RESULTS = new Map<AgentItemId, ToolResultRecord>();
+const EMPTY_ANSWERS = new Map<AgentItemId, ReadonlyArray<UserQuestionAnswer>>();
+
+const ChatLookupsContext = createContext<ChatLookups>({
+  resultsByItemId: EMPTY_RESULTS,
+  answersByItemId: EMPTY_ANSWERS,
+});
+
+export function ChatLookupsProvider({
+  value,
+  children,
+}: {
+  readonly value: ChatLookups;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <ChatLookupsContext.Provider value={value}>
+      {children}
+    </ChatLookupsContext.Provider>
+  );
+}
+
+export const useChatLookups = () => useContext(ChatLookupsContext);

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -30,6 +30,7 @@ import {
   MessageRow,
   type ToolResultRecord,
 } from "./message-row.tsx";
+import { ChatLookupsProvider } from "./chat-lookups.tsx";
 import { JumpToLatestPill } from "./jump-to-latest-pill.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { TurnSummary } from "./turn-summary.tsx";
@@ -45,8 +46,8 @@ const EMPTY_MESSAGES: ReadonlyArray<Message> = [];
 /**
  * Read-only timeline of one session. Subscribes to `messages.stream` via the
  * messages store on mount / session-change; the store owns the live fiber.
- * Scroll behavior is owned by `useChatScroll`: it anchors each new turn near
- * the top and follows the live edge only while the reader is there.
+ * Scroll behavior is owned by `useChatScroll`: it sticks to the bottom while
+ * the reader is there and releases the instant they scroll up.
  */
 export function ChatView({ sessionId }: { sessionId: SessionId }) {
   const forkMenu = useForkMenu();
@@ -99,8 +100,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     }
     return false;
   });
-  const externalResume =
-    session !== null && session.resumeStrategy !== "none";
+  const externalResume = session !== null && session.resumeStrategy !== "none";
   const setupActive =
     worktreeSetupActive || (!externalResume && session?.status === "booting");
   const archiveProgress = useChatsStore((s) =>
@@ -109,16 +109,8 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       : (s.archiveProgressByChat[session.chatId] ?? null),
   );
 
-  const {
-    scrollRef,
-    contentRef,
-    sentinelRef,
-    spacerRef,
-    spacerHeight,
-    showPill,
-    streaming,
-    jumpToLatest,
-  } = useChatScroll({ sessionId, messages, inFlight });
+  const { scrollRef, contentRef, showPill, streaming, jumpToLatest } =
+    useChatScroll({ sessionId, messages, inFlight });
   useRegisterPane("chat", scrollRef);
 
   useEffect(() => {
@@ -204,6 +196,11 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     return map;
   }, [messages]);
 
+  const chatLookups = useMemo(
+    () => ({ resultsByItemId, answersByItemId }),
+    [resultsByItemId, answersByItemId],
+  );
+
   return (
     <FileChipProvider
       folderId={session?.projectId ?? null}
@@ -234,146 +231,132 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
             )
           ) : (
             <div ref={contentRef} className="flex flex-col py-2">
-              {turns.map((turn, idx) => {
-                const isLastTurn = idx === turns.length - 1;
-                const isLive = inFlight && isLastTurn;
-                const hasToolCalls = turn.body.some(
-                  (m) => m.content._tag === "tool_use",
-                );
-                // Only collapse into a summary when there's a final assistant
-                // message worth showing as the body — otherwise a turn with
-                // just tool calls would lose its content behind the accordion.
-                const hasFinalText = turn.body.some(
-                  (m) =>
-                    m.content._tag === "assistant" &&
-                    m.content.text.trim().length > 0,
-                );
-                const showSummary = !isLive && hasToolCalls && hasFinalText;
-                const turnKey = turn.user?.id ?? `turn-${idx}`;
-                // Within an open (non-collapsed) turn, group sub-agent rows
-                // under a SubagentRow wrapper. TurnSummary handles its own
-                // rendering for collapsed turns; sub-agents inside a collapsed
-                // turn render via TurnSummary's existing path.
-                const bodyGroups = groupMessages(turn.body);
-                // Hoist ExitPlanMode rows out of TurnSummary so the Plan card
-                // (and its resolved accordion) stays a top-level row in
-                // scrollback — it's a user-facing decision, not just another
-                // tool call to bury in the "N tool calls" rollup.
-                const planMessages = turn.body.filter(
-                  (m) =>
-                    m.content._tag === "tool_use" &&
-                    m.content.tool === "ExitPlanMode",
-                );
-                const planItemIds = new Set(
-                  planMessages.flatMap((m) =>
-                    m.content._tag === "tool_use" ? [m.content.itemId] : [],
-                  ),
-                );
-                const summaryBody =
-                  planMessages.length === 0
-                    ? turn.body
-                    : turn.body.filter((m) => {
-                        if (
-                          m.content._tag === "tool_use" &&
-                          m.content.tool === "ExitPlanMode"
-                        ) {
-                          return false;
-                        }
-                        if (
-                          m.content._tag === "tool_result" &&
-                          planItemIds.has(m.content.itemId)
-                        ) {
-                          return false;
-                        }
-                        return true;
-                      });
-                return (
-                  <Fragment key={turnKey}>
-                    {turn.user !== null ? (
-                      <div
-                        data-user-anchor={turn.user.id}
-                        className="chat-row-enter chat-row-enter-user scroll-mt-6"
-                        onContextMenu={(e) =>
-                          forkMenu.openAt(e, sessionId, turn.user!.id)
-                        }
-                      >
-                        <MessageRow
-                          message={turn.user}
-                          resultsByItemId={resultsByItemId}
-                          answersByItemId={answersByItemId}
-                          sessionId={sessionId}
-                        />
-                      </div>
-                    ) : null}
-                    {showSummary ? (
-                      <>
-                        {planMessages.map((m) => (
-                          <div key={m.id} className="chat-row-enter">
-                            <MessageRow
-                              message={m}
-                              resultsByItemId={resultsByItemId}
-                              answersByItemId={answersByItemId}
-                              sessionId={sessionId}
-                            />
-                          </div>
-                        ))}
-                        <div className="chat-row-enter">
-                          <TurnSummary
-                            body={summaryBody}
-                            resultsByItemId={resultsByItemId}
-                            answersByItemId={answersByItemId}
+              <ChatLookupsProvider value={chatLookups}>
+                {turns.map((turn, idx) => {
+                  const isLastTurn = idx === turns.length - 1;
+                  const isLive = inFlight && isLastTurn;
+                  const hasToolCalls = turn.body.some(
+                    (m) => m.content._tag === "tool_use",
+                  );
+                  // Only collapse into a summary when there's a final assistant
+                  // message worth showing as the body — otherwise a turn with
+                  // just tool calls would lose its content behind the accordion.
+                  const hasFinalText = turn.body.some(
+                    (m) =>
+                      m.content._tag === "assistant" &&
+                      m.content.text.trim().length > 0,
+                  );
+                  const showSummary = !isLive && hasToolCalls && hasFinalText;
+                  const turnKey = turn.user?.id ?? `turn-${idx}`;
+                  // Within an open (non-collapsed) turn, group sub-agent rows
+                  // under a SubagentRow wrapper. TurnSummary handles its own
+                  // rendering for collapsed turns; sub-agents inside a collapsed
+                  // turn render via TurnSummary's existing path.
+                  const bodyGroups = groupMessages(turn.body);
+                  // Hoist ExitPlanMode rows out of TurnSummary so the Plan card
+                  // (and its resolved accordion) stays a top-level row in
+                  // scrollback — it's a user-facing decision, not just another
+                  // tool call to bury in the "N tool calls" rollup.
+                  const planMessages = turn.body.filter(
+                    (m) =>
+                      m.content._tag === "tool_use" &&
+                      m.content.tool === "ExitPlanMode",
+                  );
+                  const planItemIds = new Set(
+                    planMessages.flatMap((m) =>
+                      m.content._tag === "tool_use" ? [m.content.itemId] : [],
+                    ),
+                  );
+                  const summaryBody =
+                    planMessages.length === 0
+                      ? turn.body
+                      : turn.body.filter((m) => {
+                          if (
+                            m.content._tag === "tool_use" &&
+                            m.content.tool === "ExitPlanMode"
+                          ) {
+                            return false;
+                          }
+                          if (
+                            m.content._tag === "tool_result" &&
+                            planItemIds.has(m.content.itemId)
+                          ) {
+                            return false;
+                          }
+                          return true;
+                        });
+                  return (
+                    <Fragment key={turnKey}>
+                      {turn.user !== null ? (
+                        <div
+                          className="chat-row-enter chat-row-enter-user"
+                          onContextMenu={(e) =>
+                            forkMenu.openAt(e, sessionId, turn.user!.id)
+                          }
+                        >
+                          <MessageRow
+                            message={turn.user}
+                            sessionId={sessionId}
                           />
                         </div>
-                      </>
-                    ) : (
-                      bodyGroups.map((group) =>
-                        group.kind === "single" ? (
-                          <div
-                            key={group.message.id}
-                            className="chat-row-enter"
-                            onContextMenu={
-                              group.message.content._tag === "assistant"
-                                ? (e) =>
-                                    forkMenu.openAt(
-                                      e,
-                                      sessionId,
-                                      group.message.id,
-                                    )
-                                : undefined
-                            }
-                          >
-                            <MessageRow
-                              message={group.message}
-                              resultsByItemId={resultsByItemId}
-                              answersByItemId={answersByItemId}
-                              sessionId={sessionId}
-                            />
+                      ) : null}
+                      {showSummary ? (
+                        <>
+                          {planMessages.map((m) => (
+                            <div key={m.id} className="chat-row-enter">
+                              <MessageRow message={m} sessionId={sessionId} />
+                            </div>
+                          ))}
+                          <div className="chat-row-enter">
+                            <TurnSummary body={summaryBody} />
                           </div>
-                        ) : (
-                          <div
-                            key={group.parent.id}
-                            className="chat-row-enter"
-                          >
-                            <SubagentRow
-                              agentToolUseId={group.parentItemId}
-                              agentName={group.agentName}
-                              prompt={group.prompt}
-                              modelRequested={group.modelRequested}
-                              children={group.children}
-                              summary={group.summary}
-                              resultsByItemId={resultsByItemId}
-                              answersByItemId={answersByItemId}
-                            />
-                          </div>
-                        ),
-                      )
-                    )}
-                  </Fragment>
-                );
-              })}
-              {inFlight && !awaitingPlanApproval && (
-                <WorkingRow messages={messages} />
-              )}
+                        </>
+                      ) : (
+                        bodyGroups.map((group) =>
+                          group.kind === "single" ? (
+                            <div
+                              key={group.message.id}
+                              className="chat-row-enter"
+                              onContextMenu={
+                                group.message.content._tag === "assistant"
+                                  ? (e) =>
+                                      forkMenu.openAt(
+                                        e,
+                                        sessionId,
+                                        group.message.id,
+                                      )
+                                  : undefined
+                              }
+                            >
+                              <MessageRow
+                                message={group.message}
+                                sessionId={sessionId}
+                              />
+                            </div>
+                          ) : (
+                            <div
+                              key={group.parent.id}
+                              className="chat-row-enter"
+                            >
+                              <SubagentRow
+                                agentToolUseId={group.parentItemId}
+                                agentName={group.agentName}
+                                prompt={group.prompt}
+                                modelRequested={group.modelRequested}
+                                children={group.children}
+                                summary={group.summary}
+                              />
+                            </div>
+                          ),
+                        )
+                      )}
+                    </Fragment>
+                  );
+                })}
+                {inFlight && !awaitingPlanApproval && (
+                  <WorkingRow messages={messages} />
+                )}
+              </ChatLookupsProvider>
             </div>
           )}
           {error !== null && (
@@ -383,17 +366,6 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
               onDismiss={() => clearError(sessionId)}
             />
           )}
-          {/* Live-edge sentinel — must be the last child so it sits at the very
-          bottom of the real content (before the spacer). */}
-          <div ref={sentinelRef} aria-hidden className="h-px w-full shrink-0" />
-          {/* Dynamic spacer: lets a freshly-sent turn be read from the top while
-          its answer streams into the space below. */}
-          <div
-            ref={spacerRef}
-            aria-hidden
-            className="shrink-0"
-            style={{ height: spacerHeight }}
-          />
         </div>
         <JumpToLatestPill
           visible={showPill}

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -230,7 +230,10 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
               </div>
             )
           ) : (
-            <div ref={contentRef} className="flex flex-col py-2">
+            <div
+              ref={contentRef}
+              className="mx-auto flex w-full max-w-4xl flex-col py-2"
+            >
               <ChatLookupsProvider value={chatLookups}>
                 {turns.map((turn, idx) => {
                   const isLastTurn = idx === turns.length - 1;

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -485,7 +485,7 @@ function AssistantBubble({
 }) {
   return (
     <div className="px-4 py-2">
-      <div className="max-w-[88%]">
+      <div className="max-w-full">
         <MarkdownBody>{text}</MarkdownBody>
         <div className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
           {createdAt !== undefined ? (

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -11,9 +11,8 @@ import {
 } from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { RefreshCw as RefreshIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import type {
-  AgentItemId,
   AttachmentRef,
   CodeAnnotation,
   FileRef,
@@ -21,7 +20,6 @@ import type {
   ProviderId,
   SessionId,
   SkillRef,
-  UserQuestionAnswer,
 } from "@zuse/wire";
 
 import { getFileIconUrl } from "~/lib/icons/material-icons";
@@ -38,6 +36,7 @@ import { useUiStore } from "~/store/ui";
 
 import { CopyButton } from "./copy-button.tsx";
 import { useRevealAnnotation } from "./annotation/annotation-navigation.ts";
+import { useChatLookups } from "./chat-lookups.tsx";
 import { AnnotationFileChip, FileChip } from "./file-chip.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
 import {
@@ -49,10 +48,12 @@ import {
 import { Button } from "./ui/button.tsx";
 import { ShimmerText } from "./ui/shimmer-text.tsx";
 
-export interface ToolResultRecord {
-  readonly output: unknown;
-  readonly isError: boolean;
-}
+export type { ToolResultRecord } from "./chat-lookups.tsx";
+
+type MessageContent<Tag extends Message["content"]["_tag"]> = Extract<
+  Message["content"],
+  { readonly _tag: Tag }
+>;
 
 const stringifyJson = (value: unknown): string => {
   try {
@@ -107,19 +108,14 @@ const formatCompactTokenDelta = (
  * than `role` because role collapses tool_use and assistant text into one
  * bucket, but their visual treatment differs.
  *
- * `resultsByItemId` lets `tool_use` rows render their paired `tool_result`
- * inline. Standalone `tool_result` rows are suppressed when they pair with
- * a tool_use; only orphan errors fall through to the standalone error row.
+ * Tool and user-question pairing data lives in ChatLookups context so settled
+ * text rows can be memoized without receiving fresh lookup-map props.
  */
-export function MessageRow({
+function MessageRowImpl({
   message,
-  resultsByItemId,
-  answersByItemId,
   sessionId,
 }: {
   message: Message;
-  resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
-  answersByItemId?: ReadonlyMap<AgentItemId, ReadonlyArray<UserQuestionAnswer>>;
   sessionId?: SessionId;
 }) {
   switch (message.content._tag) {
@@ -153,42 +149,11 @@ export function MessageRow({
         />
       );
     case "tool_use":
-      if (message.content.tool === "ExitPlanMode") {
-        return (
-          <ExitPlanModeRow
-            input={message.content.input}
-            result={resultsByItemId.get(message.content.itemId)}
-          />
-        );
-      }
-      return (
-        <ToolRow
-          tool={message.content.tool}
-          input={message.content.input}
-          result={resultsByItemId.get(message.content.itemId)}
-        />
-      );
-    case "tool_result": {
-      // Suppress paired results — the matching ToolRow renders them inline.
-      // Only orphan errors (no tool_use found, e.g. driver dropped the use
-      // event) surface as a standalone error row.
-      const paired = resultsByItemId.has(message.content.itemId);
-      if (paired) return null;
-      return message.content.isError ? (
-        <ToolErrorRow output={message.content.output} />
-      ) : null;
-    }
-    case "user_question": {
-      // Pending questions live in the composer slot — ChatComposer swaps the
-      // editor for a QuestionCard. Once answered, the question + the user's
-      // selections render here as a `UserInputRow` accordion so the Q&A
-      // stays visible in scrollback like every other tool call.
-      const answers = answersByItemId?.get(message.content.itemId);
-      if (answers === undefined) return null;
-      return (
-        <UserInputRow questions={message.content.questions} answers={answers} />
-      );
-    }
+      return <ToolUseMessageRow content={message.content} />;
+    case "tool_result":
+      return <ToolResultMessageRow content={message.content} />;
+    case "user_question":
+      return <UserQuestionMessageRow content={message.content} />;
     case "user_question_answer":
       // The paired `user_question` row above renders the answer inline, so
       // the standalone answer row is suppressed.
@@ -233,6 +198,51 @@ export function MessageRow({
         </div>
       );
   }
+}
+
+export const MessageRow = memo(MessageRowImpl);
+MessageRow.displayName = "MessageRow";
+
+function ToolUseMessageRow({
+  content,
+}: {
+  content: MessageContent<"tool_use">;
+}) {
+  const { resultsByItemId } = useChatLookups();
+  const result = resultsByItemId.get(content.itemId);
+  if (content.tool === "ExitPlanMode") {
+    return <ExitPlanModeRow input={content.input} result={result} />;
+  }
+  return <ToolRow tool={content.tool} input={content.input} result={result} />;
+}
+
+function ToolResultMessageRow({
+  content,
+}: {
+  content: MessageContent<"tool_result">;
+}) {
+  const { resultsByItemId } = useChatLookups();
+  // Suppress paired results — the matching ToolRow renders them inline.
+  // Only orphan errors (no tool_use found, e.g. driver dropped the use
+  // event) surface as a standalone error row.
+  const paired = resultsByItemId.has(content.itemId);
+  if (paired) return null;
+  return content.isError ? <ToolErrorRow output={content.output} /> : null;
+}
+
+function UserQuestionMessageRow({
+  content,
+}: {
+  content: MessageContent<"user_question">;
+}) {
+  const { answersByItemId } = useChatLookups();
+  // Pending questions live in the composer slot — ChatComposer swaps the
+  // editor for a QuestionCard. Once answered, the question + the user's
+  // selections render here as a `UserInputRow` accordion so the Q&A
+  // stays visible in scrollback like every other tool call.
+  const answers = answersByItemId.get(content.itemId);
+  if (answers === undefined) return null;
+  return <UserInputRow questions={content.questions} answers={answers} />;
 }
 
 function CompactRow({

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -5,15 +5,15 @@ import {
   Robot01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 
-import type { AgentItemId, Message, UserQuestionAnswer } from "@zuse/wire";
+import type { AgentItemId, Message } from "@zuse/wire";
 
 import { cn } from "~/lib/utils";
 
 import { CopyButton } from "./copy-button.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
-import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import { MessageRow } from "./message-row.tsx";
 import { Spinner } from "./ui/spinner";
 
 const MODEL_LABEL: Record<string, string> = {
@@ -50,15 +50,13 @@ const formatDuration = (ms: number): string => {
  * Default expansion: open while running (no summary yet), collapsed once
  * the sub-agent finishes.
  */
-export function SubagentRow({
+function SubagentRowImpl({
   agentToolUseId,
   agentName,
   prompt,
   modelRequested,
   children,
   summary,
-  resultsByItemId,
-  answersByItemId,
 }: {
   readonly agentToolUseId: AgentItemId;
   readonly agentName: string;
@@ -72,11 +70,6 @@ export function SubagentRow({
     readonly model: string;
     readonly isError: boolean;
   } | null;
-  readonly resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
-  readonly answersByItemId?: ReadonlyMap<
-    AgentItemId,
-    ReadonlyArray<UserQuestionAnswer>
-  >;
 }) {
   // Auto-expand while running (no summary yet) so the user can watch the
   // sub-agent work. Once finished, collapse to a one-line meta summary.
@@ -152,12 +145,7 @@ export function SubagentRow({
           <PromptRow text={prompt} />
           <div className="flex flex-col">
             {children.map((m) => (
-              <MessageRow
-                key={m.id}
-                message={m}
-                resultsByItemId={resultsByItemId}
-                answersByItemId={answersByItemId}
-              />
+              <MessageRow key={m.id} message={m} />
             ))}
           </div>
           {summary !== null && summary.text.length > 0 ? (
@@ -170,6 +158,9 @@ export function SubagentRow({
     </div>
   );
 }
+
+export const SubagentRow = memo(SubagentRowImpl);
+SubagentRow.displayName = "SubagentRow";
 
 function PromptRow({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false);

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -47,8 +47,8 @@ const formatDuration = (ms: number): string => {
  * message tagged with this `parentItemId`. Closes with the sub-agent's
  * final assistant text once the `SubagentSummary` lands.
  *
- * Default expansion: open while running (no summary yet), collapsed once
- * the sub-agent finishes.
+ * Sub-agent rows stay collapsed by default, including while running, so long
+ * nested agent work does not dominate the main transcript.
  */
 function SubagentRowImpl({
   agentToolUseId,
@@ -71,9 +71,7 @@ function SubagentRowImpl({
     readonly isError: boolean;
   } | null;
 }) {
-  // Auto-expand while running (no summary yet) so the user can watch the
-  // sub-agent work. Once finished, collapse to a one-line meta summary.
-  const [expanded, setExpanded] = useState<boolean>(summary === null);
+  const [expanded, setExpanded] = useState(false);
 
   const trailingMeta = useMemo(() => {
     if (summary !== null) {

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -197,7 +197,10 @@ const firstSentence = (text: string, hardCap = 160): string => {
 
 function InlineCodeChip({ value }: { value: string }) {
   return (
-    <span className="ml-1 truncate rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+    <span
+      className="ml-1 inline-block max-w-full truncate rounded bg-muted/60 px-1.5 py-0.5 align-bottom font-mono text-[10px] text-muted-foreground"
+      title={value}
+    >
       {value}
     </span>
   );
@@ -205,7 +208,12 @@ function InlineCodeChip({ value }: { value: string }) {
 
 function InlineTextHint({ value }: { value: string }) {
   return (
-    <span className="ml-1 truncate text-muted-foreground italic">{value}</span>
+    <span
+      className="ml-1 inline-block max-w-full truncate align-bottom text-muted-foreground italic"
+      title={value}
+    >
+      {value}
+    </span>
   );
 }
 
@@ -464,7 +472,7 @@ function ExpandableIconRow({
         </div>
         <span className="font-medium text-foreground/90 shrink-0">{label}</span>
         {trailing !== undefined ? (
-          <span className="min-w-0 flex-1 truncate flex items-center">
+          <span className="flex min-w-0 flex-1 items-center overflow-hidden">
             {trailing}
           </span>
         ) : null}
@@ -511,15 +519,34 @@ const buildToolView = (
       : {};
 
   switch (normalizedTool) {
-    case "Bash": {
-      const cmd = asString(obj.command);
+    case "Bash":
+    case "Shell":
+    case "shell":
+    case "Execute":
+    case "execute":
+    case "Run":
+    case "run":
+    case "run_shell_command":
+    case "run_terminal_cmd": {
+      const cmd =
+        asString(obj.command) ??
+        asString(obj.cmd) ??
+        asString(obj.shell_command) ??
+        asString(input);
       const desc = asString(obj.description);
+      const label =
+        desc ??
+        (normalizedTool === "Bash"
+          ? "Bash"
+          : normalizedTool === "Shell"
+            ? "Shell"
+            : "Execute");
       return {
         icon: TerminalIcon,
-        label: desc ?? "Bash",
+        label,
         trailing:
           cmd !== null ? (
-            <InlineCodeChip value={truncate(cmd, 120)} />
+            <InlineCodeChip value={truncate(cmd, 56)} />
           ) : undefined,
         inputPanel: cmd !== null ? <TerminalBlock command={cmd} /> : undefined,
         resultPanel: (result) => (

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -470,9 +470,14 @@ function ExpandableIconRow({
             />
           ) : null}
         </div>
-        <span className="font-medium text-foreground/90 shrink-0">{label}</span>
+        <span
+          className="max-w-[12rem] shrink-0 truncate font-medium text-foreground/90"
+          title={typeof label === "string" ? label : undefined}
+        >
+          {label}
+        </span>
         {trailing !== undefined ? (
-          <span className="flex min-w-0 flex-1 items-center overflow-hidden">
+          <span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap [&>*]:min-w-0 [&>*]:max-w-full [&>*]:overflow-hidden [&>*]:text-ellipsis">
             {trailing}
           </span>
         ) : null}

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -239,7 +239,7 @@ function TurnSummaryImpl({ body }: { body: ReadonlyArray<Message> }) {
       {finalAssistant !== null &&
       finalAssistant.content._tag === "assistant" ? (
         <div className="px-4 py-2">
-          <div className="max-w-[88%]">
+          <div className="max-w-full">
             <MarkdownBody>{finalAssistant.content.text}</MarkdownBody>
           </div>
         </div>

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -5,9 +5,9 @@ import {
   Wrench01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 
-import type { AgentItemId, Message, UserQuestionAnswer } from "@zuse/wire";
+import type { Message } from "@zuse/wire";
 
 import { groupMessages } from "../lib/group-messages.ts";
 import { cn } from "~/lib/utils";
@@ -21,7 +21,7 @@ import {
   patchStats,
 } from "./inline-diff.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
-import { MessageRow, type ToolResultRecord } from "./message-row.tsx";
+import { MessageRow } from "./message-row.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { iconForTool } from "./tool-row.tsx";
 
@@ -88,15 +88,7 @@ const MAX_FILE_CHIPS = 4;
  * shows below; the footer carries elapsed time and file edit stats. No
  * outer card — sections sit flat in the timeline like every other row.
  */
-export function TurnSummary({
-  body,
-  resultsByItemId,
-  answersByItemId,
-}: {
-  body: ReadonlyArray<Message>;
-  resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
-  answersByItemId?: ReadonlyMap<AgentItemId, ReadonlyArray<UserQuestionAnswer>>;
-}) {
+function TurnSummaryImpl({ body }: { body: ReadonlyArray<Message> }) {
   const [expanded, setExpanded] = useState(false);
   const [filesExpanded, setFilesExpanded] = useState(false);
 
@@ -228,12 +220,7 @@ export function TurnSummary({
         <div className="py-1">
           {detailGroups.map((group) =>
             group.kind === "single" ? (
-              <MessageRow
-                key={group.message.id}
-                message={group.message}
-                resultsByItemId={resultsByItemId}
-                answersByItemId={answersByItemId}
-              />
+              <MessageRow key={group.message.id} message={group.message} />
             ) : (
               <SubagentRow
                 key={group.parent.id}
@@ -243,8 +230,6 @@ export function TurnSummary({
                 modelRequested={group.modelRequested}
                 children={group.children}
                 summary={group.summary}
-                resultsByItemId={resultsByItemId}
-                answersByItemId={answersByItemId}
               />
             ),
           )}
@@ -318,3 +303,6 @@ export function TurnSummary({
     </div>
   );
 }
+
+export const TurnSummary = memo(TurnSummaryImpl);
+TurnSummary.displayName = "TurnSummary";

--- a/apps/renderer/src/lib/use-chat-scroll.ts
+++ b/apps/renderer/src/lib/use-chat-scroll.ts
@@ -9,51 +9,33 @@ import type { RefObject } from "react";
 
 import type { Message, SessionId } from "@zuse/wire";
 
-// How far below the top of the viewport a freshly-sent user message lands, so
-// the tail of the previous turn stays visible above it (principle 6).
-const TOP_GAP = 24;
-// The sentinel counts as "at the live edge" while it sits within this many px
-// of the bottom of the scroll viewport.
-const LIVE_EDGE_BAND_PX = 80;
-
-const prefersReducedMotion = (): boolean =>
-  typeof window !== "undefined" &&
-  typeof window.matchMedia === "function" &&
-  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-const isUserMessage = (m: Message | undefined): boolean =>
-  m !== undefined &&
-  (m.content._tag === "user" || m.content._tag === "user_rich");
+// The reader counts as "at the bottom" while the viewport is within this many
+// px of the true bottom. Our own pin writes land at distance 0, so following
+// stays engaged; a genuine scroll-up grows the distance past this and releases.
+const NEAR_BOTTOM_PX = 64;
 
 export interface ChatScroll {
   /** The scrollable viewport. */
   scrollRef: RefObject<HTMLDivElement | null>;
-  /** Wraps every turn; observed for size changes. */
+  /** Wraps every turn; observed for size changes (async layout shifts). */
   contentRef: RefObject<HTMLDivElement | null>;
-  /** Zero-height marker after the last real message; drives live-edge detection. */
-  sentinelRef: RefObject<HTMLDivElement | null>;
-  /** Dynamic bottom spacer that lets a short answer be read from the top. */
-  spacerRef: RefObject<HTMLDivElement | null>;
-  spacerHeight: number;
-  /** Show the "Jump to latest" pill (reader has scrolled away from the edge). */
+  /** Show the "Jump to latest" pill (reader has scrolled away from the bottom). */
   showPill: boolean;
-  /** A response is streaming out of view (drives the pill's activity dot). */
+  /** A response is streaming while the reader is scrolled away (drives the dot). */
   streaming: boolean;
   jumpToLatest: () => void;
 }
 
 /**
- * Scroll controller for the streaming chat timeline. Honors the "great
- * streaming chat" principles: never moves the reader against their intent
- * (1-3), anchors each new turn near the top so the answer streams into the
- * space below (4-7), surfaces offscreen activity (8), offers a jump-to-latest
- * affordance (9), preserves position across layout shifts (12), and never lets
- * an interruption / error steal scroll position (13).
+ * Minimal stick-to-bottom controller for the streaming chat timeline.
  *
- * Live-edge detection uses an IntersectionObserver on a bottom sentinel rather
- * than scroll math, so it stays correct even while the dynamic spacer is
- * present. "Following" (stick-to-bottom) is mirrored in a ref so event handlers
- * and layout effects read the latest value synchronously.
+ * The whole thing is derived from one measurement: the distance from the
+ * bottom of the viewport. While that distance is within {@link NEAR_BOTTOM_PX}
+ * we "follow" — pinning to the bottom as new content arrives. The instant the
+ * reader scrolls up, the distance grows and following releases; because we read
+ * position (never scroll deltas) and our own pin writes leave the distance at
+ * ~0, there is no way for a programmatic scroll to be mistaken for user intent,
+ * and a scroll-up always wins immediately. No sentinel, no spacer, no guard.
  */
 export function useChatScroll(opts: {
   sessionId: SessionId;
@@ -64,255 +46,91 @@ export function useChatScroll(opts: {
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  const spacerRef = useRef<HTMLDivElement | null>(null);
 
-  // `following` = stick-to-bottom engaged. Ref mirror for synchronous reads.
-  const followingRef = useRef(true);
-  const [, setFollowingState] = useState(true);
-  const setFollowing = useCallback((v: boolean) => {
-    if (followingRef.current === v) return;
-    followingRef.current = v;
-    setFollowingState(v);
+  // `stick` = follow-to-bottom engaged. Ref mirror for synchronous reads inside
+  // effects/observers; state mirror so the pill can react to changes.
+  const stickRef = useRef(true);
+  const [stuck, setStuckState] = useState(true);
+  const setStuck = useCallback((v: boolean) => {
+    if (stickRef.current === v) return;
+    stickRef.current = v;
+    setStuckState(v);
   }, []);
 
-  const [atLiveEdge, setAtLiveEdge] = useState(true);
-  const [spacerHeight, setSpacerHeight] = useState(0);
-  const setSpacer = useCallback((px: number) => {
-    setSpacerHeight((prev) => (prev === px ? prev : px));
-  }, []);
-
-  // Bookkeeping refs (synchronous; safe to read inside effects/handlers).
   const prevSessionRef = useRef<SessionId>(sessionId);
   const didInitialScrollRef = useRef(false);
-  const lastAnchoredUserIdRef = useRef<Message["id"] | null>(null);
-  // True while a freshly-sent turn is top-anchored (drives spacer sizing).
-  const anchorModeRef = useRef(false);
-  // Guards our own scroll writes from being mis-read as user intent.
-  const programmaticRef = useRef(false);
 
-  const markProgrammatic = useCallback(() => {
-    programmaticRef.current = true;
-    // Clear after the resulting scroll event has fired (two frames is plenty
-    // for an instant scroll; smooth scrolls only move downward, which the
-    // intent listener ignores anyway).
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        programmaticRef.current = false;
-      });
-    });
+  const pin = useCallback((el: HTMLDivElement) => {
+    // Instant — no smooth animation. Smooth writes fight rapid streaming updates.
+    el.scrollTop = el.scrollHeight;
   }, []);
 
-  // Size the spacer so the anchored user message can sit TOP_GAP from the top
-  // even when the answer is shorter than the viewport. Shrinks to 0 as the
-  // answer grows past the available space.
-  const recomputeSpacer = useCallback(() => {
-    const el = scrollRef.current;
-    const content = contentRef.current;
-    const id = lastAnchoredUserIdRef.current;
-    if (
-      el === null ||
-      content === null ||
-      !anchorModeRef.current ||
-      id === null
-    )
-      return;
-    const anchor = content.querySelector<HTMLElement>(
-      `[data-user-anchor="${CSS.escape(String(id))}"]`,
-    );
-    if (anchor === null) return;
-    const anchorTop =
-      anchor.getBoundingClientRect().top - content.getBoundingClientRect().top;
-    const belowAnchor = content.offsetHeight - anchorTop;
-    setSpacer(Math.max(0, el.clientHeight - TOP_GAP - belowAnchor));
-  }, [setSpacer]);
-
   const jumpToLatest = useCallback(() => {
-    anchorModeRef.current = false;
-    setSpacer(0);
-    setFollowing(true);
-    // Collapse the spacer on this paint, then scroll to the true bottom.
-    requestAnimationFrame(() => {
-      const el = scrollRef.current;
-      if (el === null) return;
-      markProgrammatic();
-      el.scrollTo({
-        top: el.scrollHeight,
-        behavior: prefersReducedMotion() ? "auto" : "smooth",
-      });
-    });
-  }, [markProgrammatic, setFollowing, setSpacer]);
+    const el = scrollRef.current;
+    if (el === null) return;
+    setStuck(true);
+    pin(el);
+  }, [pin, setStuck]);
 
-  // --- Live-edge detection + re-engage (IntersectionObserver on sentinel) ---
-  useEffect(() => {
-    const root = scrollRef.current;
-    const sentinel = sentinelRef.current;
-    if (root === null || sentinel === null) return;
-    const io = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[entries.length - 1];
-        if (entry === undefined) return;
-        const edge = entry.isIntersecting;
-        setAtLiveEdge(edge);
-        // Reaching the edge via a user scroll resumes following. Our own
-        // programmatic scrolls (jump-to-latest, pin) are guarded out.
-        if (edge && !programmaticRef.current) {
-          anchorModeRef.current = false;
-          setSpacer(0);
-          setFollowing(true);
-        }
-      },
-      { root, rootMargin: `0px 0px ${LIVE_EDGE_BAND_PX}px 0px`, threshold: 0 },
-    );
-    io.observe(sentinel);
-    return () => io.disconnect();
-  }, [sessionId, setFollowing, setSpacer]);
-
-  // --- Disengage on a genuine upward user scroll ---
-  // A user scroll-up decreases scrollTop; content growth does not, so this
-  // never fires from streaming or from our own pinning (which is guarded).
+  // --- Derive stickiness from scroll position on every scroll ---
   useEffect(() => {
     const el = scrollRef.current;
     if (el === null) return;
-    let lastTop = el.scrollTop;
     const onScroll = () => {
-      const cur = el.scrollTop;
-      const delta = cur - lastTop;
-      lastTop = cur;
-      if (programmaticRef.current || delta >= -2) return;
-      const sentinel = sentinelRef.current;
-      if (sentinel === null) {
-        setFollowing(false);
-        return;
-      }
-      const dist =
-        sentinel.getBoundingClientRect().bottom -
-        el.getBoundingClientRect().bottom;
-      if (dist > LIVE_EDGE_BAND_PX) setFollowing(false);
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      setStuck(distance <= NEAR_BOTTOM_PX);
     };
     el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
-  }, [sessionId, setFollowing]);
+  }, [sessionId, setStuck]);
 
-  // --- Selecting text inside the transcript is reading intent (principle 3) ---
+  // --- Pin on async layout shifts (images, code blocks, markdown expanding) ---
   useEffect(() => {
-    const onSelect = () => {
-      const sel = document.getSelection();
-      if (sel === null || sel.isCollapsed || sel.rangeCount === 0) return;
-      const el = scrollRef.current;
-      const node = sel.anchorNode;
-      if (el !== null && node !== null && el.contains(node))
-        setFollowing(false);
-    };
-    document.addEventListener("selectionchange", onSelect);
-    return () => document.removeEventListener("selectionchange", onSelect);
-  }, [setFollowing]);
-
-  // --- Keep position across layout shifts (images, code, markdown expanding) ---
-  // While following, re-pin to the bottom; while anchored, resize the spacer.
-  // (Reading position when not following is preserved by Chromium's native
-  // `overflow-anchor`, which we never disable.)
-  useEffect(() => {
-    const content = contentRef.current;
     const el = scrollRef.current;
-    if (content === null || el === null) return;
+    const content = contentRef.current;
+    if (el === null || content === null) return;
     const ro = new ResizeObserver(() => {
-      if (followingRef.current) {
-        markProgrammatic();
-        el.scrollTop = el.scrollHeight;
-      } else if (anchorModeRef.current) {
-        recomputeSpacer();
-      }
+      if (stickRef.current) pin(el);
     });
     ro.observe(content);
     return () => ro.disconnect();
-  }, [sessionId, markProgrammatic, recomputeSpacer]);
+  }, [sessionId, pin]);
 
-  // --- React to new messages: initial land, new-turn anchor, follow-pin ---
+  // --- New content: land initially, reset on session switch, follow-pin ---
   useLayoutEffect(() => {
     // Session switch: reset to a fresh "follow + land at bottom" state.
     if (prevSessionRef.current !== sessionId) {
       prevSessionRef.current = sessionId;
-      followingRef.current = true;
-      setFollowingState(true);
+      stickRef.current = true;
+      setStuckState(true);
       didInitialScrollRef.current = false;
-      anchorModeRef.current = false;
-      lastAnchoredUserIdRef.current = null;
-      setSpacer(0);
-      setAtLiveEdge(true);
     }
 
     const el = scrollRef.current;
-    const content = contentRef.current;
     if (el === null) return;
 
     if (messages.length === 0) {
       didInitialScrollRef.current = true;
       return;
     }
-    const last = messages[messages.length - 1]!;
 
-    // First paint of a (possibly backfilled) transcript: land at the bottom
-    // and record the newest user id so history never triggers a top-anchor.
+    // First paint of a (possibly backfilled) transcript: land at the bottom.
     if (!didInitialScrollRef.current) {
       didInitialScrollRef.current = true;
-      for (let i = messages.length - 1; i >= 0; i--) {
-        if (isUserMessage(messages[i])) {
-          lastAnchoredUserIdRef.current = messages[i]!.id;
-          break;
-        }
-      }
-      markProgrammatic();
-      el.scrollTop = el.scrollHeight;
+      pin(el);
       return;
     }
 
-    // A brand-new user turn: anchor it near the top, open space below for the
-    // answer, and stop following so the reader stays at the top of the answer.
-    if (isUserMessage(last) && last.id !== lastAnchoredUserIdRef.current) {
-      lastAnchoredUserIdRef.current = last.id;
-      anchorModeRef.current = true;
-      followingRef.current = false;
-      setFollowingState(false);
-      if (content !== null) {
-        const anchor = content.querySelector<HTMLElement>(
-          `[data-user-anchor="${CSS.escape(String(last.id))}"]`,
-        );
-        if (anchor !== null) {
-          const anchorTop =
-            anchor.getBoundingClientRect().top -
-            content.getBoundingClientRect().top;
-          const belowAnchor = content.offsetHeight - anchorTop;
-          const next = Math.max(0, el.clientHeight - TOP_GAP - belowAnchor);
-          // Apply synchronously so scrollIntoView has room to reach the top.
-          if (spacerRef.current !== null)
-            spacerRef.current.style.height = `${next}px`;
-          setSpacer(next);
-          markProgrammatic();
-          anchor.scrollIntoView({ block: "start", behavior: "auto" });
-        }
-      }
-      return;
-    }
-
-    // Streamed rows (assistant / thinking / tool): pin to bottom only while
-    // following; otherwise let them arrive offscreen without moving the reader.
-    if (followingRef.current) {
-      markProgrammatic();
-      el.scrollTop = el.scrollHeight;
-    } else if (anchorModeRef.current) {
-      recomputeSpacer();
-    }
-  }, [sessionId, messages, markProgrammatic, recomputeSpacer, setSpacer]);
+    // Streamed rows: pin only while following; otherwise let them arrive
+    // offscreen without moving the reader.
+    if (stickRef.current) pin(el);
+  }, [sessionId, messages, pin]);
 
   return {
     scrollRef,
     contentRef,
-    sentinelRef,
-    spacerRef,
-    spacerHeight,
-    showPill: !atLiveEdge && messages.length > 0,
-    streaming: inFlight && !atLiveEdge,
+    showPill: !stuck && messages.length > 0,
+    streaming: inFlight && !stuck,
     jumpToLatest,
   };
 }


### PR DESCRIPTION
## Summary
- replace the chat scroll controller with a position-derived stick-to-bottom model
- remove the sentinel/spacer/top-anchor scroll machinery that fought user scroll intent
- add chat lookup context and memoize chat rows so settled rows avoid streaming re-renders
- constrain the chat transcript and composer to a centered max-width column on wide panes
- keep sub-agent accordions collapsed by default and hard-constrain all collapsed tool row labels/summaries

## Root cause
The previous chat scroll controller combined a live-edge sentinel, dynamic spacer, top anchoring, selection handling, and programmatic-scroll guards. During streaming, resize events repeatedly re-armed the programmatic guard, so upward user scrolls could be swallowed and the transcript snapped back to the bottom. Separately, fresh lookup map props caused settled message rows to reconcile on each streamed token. Wide panes also let chat/tool content occupy too much horizontal space, and long collapsed tool summaries could dominate a single row.

## Validation
- `bun run check-types` in `apps/renderer`
- `bun test` in `apps/renderer`
- `git diff --check`