### PR TITLE
Mobile: interactive chat — question cards, permission approvals, offline outbox, markdown

### DIFF
--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -1,15 +1,23 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { FlatList, KeyboardAvoidingView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import type { SessionId } from "@zuse/wire";
+import type { SessionId, UserQuestion } from "@zuse/wire";
+import { Effect } from "effect";
 
-import { ComposerStub } from "~/components/composer-stub";
-import { MessageRow } from "~/components/messages/message-row";
+import { Composer } from "~/components/composer";
+import {
+  MessageRow,
+  type MessageRowContext
+} from "~/components/messages/message-row";
+import { PendingApprovalCard } from "~/components/messages/pending-approval-card";
 import { normalizeConnParam, optionsForConnection } from "~/lib/connection-params";
+import { answerQuestion } from "~/rpc/actions";
 import { useConnectionsStore } from "~/store/connections";
 import { selectSessionChat, useSessionsStore } from "~/store/sessions";
 import { useMobileMessagesStore } from "~/store/messages";
+import { useOutboxStore } from "~/store/outbox";
+import { usePermissionsStore } from "~/store/permissions";
 
 export default function ThreadScreen() {
   const insets = useSafeAreaInsets();
@@ -25,9 +33,23 @@ export default function ThreadScreen() {
   const bundles = useSessionsStore((state) => state.bundlesByConnection[connKey] ?? []);
   const { messagesBySession, reconnectingBySession, errorBySession, hydrate } =
     useMobileMessagesStore();
-  const messages = messagesBySession[normalizedSessionId] ?? [];
+  const messages = useMemo(
+    () => messagesBySession[normalizedSessionId] ?? [],
+    [messagesBySession, normalizedSessionId]
+  );
   const detail = selectSessionChat(bundles, normalizedSessionId);
   const title = detail?.chat?.title ?? detail?.session.title ?? "Thread";
+
+  const hydratePermissions = usePermissionsStore((state) => state.hydrate);
+  const decidePermission = usePermissionsStore((state) => state.decide);
+  const pending = usePermissionsStore(
+    (state) => state.pendingBySession[normalizedSessionId] ?? []
+  );
+  const hydrateOutbox = useOutboxStore((state) => state.hydrate);
+  const flushOutbox = useOutboxStore((state) => state.flush);
+  const queued = useOutboxStore(
+    (state) => state.queuedBySession[normalizedSessionId] ?? []
+  );
 
   useEffect(() => {
     if (!hydrated) void hydrateConnections();
@@ -36,11 +58,55 @@ export default function ThreadScreen() {
   useEffect(() => {
     if (normalizedSessionId.length > 0) {
       void hydrate(connKey, options, normalizedSessionId);
+      void hydratePermissions(connKey, options, normalizedSessionId);
+      void hydrateOutbox(connKey, normalizedSessionId);
     }
-  }, [connKey, hydrate, normalizedSessionId, options]);
+  }, [connKey, hydrate, hydrateOutbox, hydratePermissions, normalizedSessionId, options]);
 
   const reconnecting = reconnectingBySession[normalizedSessionId];
   const error = errorBySession[normalizedSessionId];
+  const online = reconnecting !== true && (error ?? null) === null;
+
+  // Drain the outbox in order the moment the session is back online.
+  useEffect(() => {
+    if (online && normalizedSessionId.length > 0) {
+      void flushOutbox(connKey, options, normalizedSessionId);
+    }
+  }, [connKey, flushOutbox, normalizedSessionId, online, options]);
+
+  // Cross-reference question rows so answered prompts collapse and the answer
+  // row can resolve selected option labels.
+  const { answeredQuestionIds, questionsByItemId } = useMemo(() => {
+    const answered = new Set<string>();
+    const questions = new Map<string, readonly UserQuestion[]>();
+    for (const message of messages) {
+      const content = message.content;
+      if (content._tag === "user_question") {
+        questions.set(content.itemId, content.questions);
+      } else if (content._tag === "user_question_answer") {
+        answered.add(content.itemId);
+      }
+    }
+    return { answeredQuestionIds: answered, questionsByItemId: questions };
+  }, [messages]);
+
+  const onAnswerQuestion = useCallback<MessageRowContext["onAnswerQuestion"]>(
+    (itemId, answers) =>
+      Effect.runPromise(
+        answerQuestion({
+          connection: options,
+          sessionId: normalizedSessionId,
+          itemId,
+          answers
+        })
+      ).catch(() => {}),
+    [normalizedSessionId, options]
+  );
+
+  const ctx = useMemo<MessageRowContext>(
+    () => ({ answeredQuestionIds, questionsByItemId, onAnswerQuestion }),
+    [answeredQuestionIds, questionsByItemId, onAnswerQuestion]
+  );
 
   return (
     <KeyboardAvoidingView behavior="padding" className="flex-1 bg-background">
@@ -49,7 +115,7 @@ export default function ThreadScreen() {
         ref={listRef}
         data={messages}
         keyExtractor={(message) => message.id}
-        renderItem={({ item }) => <MessageRow message={item} />}
+        renderItem={({ item }) => <MessageRow message={item} ctx={ctx} />}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerClassName="gap-1 px-4 py-3"
         ListHeaderComponent={
@@ -68,9 +134,28 @@ export default function ThreadScreen() {
             </View>
           ) : null
         }
+        ListFooterComponent={
+          queued.length > 0 || pending.length > 0 ? (
+            <View className="pt-1">
+              {queued.map((item) => (
+                <QueuedBubble key={item.clientId} text={item.text} />
+              ))}
+              {pending.map((request) => (
+                <PendingApprovalCard
+                  key={request.id}
+                  request={request}
+                  onDecide={(decision) =>
+                    decidePermission(options, normalizedSessionId, request.id, decision)
+                  }
+                />
+              ))}
+            </View>
+          ) : null
+        }
         onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
       />
-      <ComposerStub
+      <Composer
+        connKey={connKey}
         connection={options}
         sessionId={normalizedSessionId}
         bottomInset={insets.bottom}
@@ -78,3 +163,12 @@ export default function ThreadScreen() {
     </KeyboardAvoidingView>
   );
 }
+
+const QueuedBubble = ({ text }: { text: string }) => (
+  <View className="items-end px-3 py-1.5">
+    <View className="max-w-[88%] rounded-lg border border-primary/40 bg-primary/20 px-3 py-2">
+      <Text className="mb-0.5 font-sans-medium text-[11px] text-warning">Queued</Text>
+      <Text className="font-sans text-[15px] leading-5 text-foreground">{text}</Text>
+    </View>
+  </View>
+);

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -44,6 +44,7 @@
     "lucide-react-native": "^0.475.0",
     "react": "19.2.3",
     "react-native": "0.86.0",
+    "react-native-markdown-display": "^7.0.2",
     "react-native-quick-crypto": "^0.7.0",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -1,40 +1,60 @@
 import type { SessionId } from "@zuse/wire";
 import { Effect } from "effect";
-import { Send, Square } from "lucide-react-native";
+import { CloudOff, Send, Square } from "lucide-react-native";
 import { useState } from "react";
-import { ActivityIndicator, TextInput, View } from "react-native";
+import { ActivityIndicator, Text, TextInput, View } from "react-native";
 
 import { interruptSession, makeTextInput, sendMessage } from "~/rpc/actions";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
+import { useMobileMessagesStore } from "~/store/messages";
+import { useOutboxStore } from "~/store/outbox";
 import { Button } from "./ui/button";
 import { GlassSurface } from "./ui/glass-surface";
 
-export const ComposerStub = ({
+export const Composer = ({
+  connKey,
   connection,
   sessionId,
-  bottomInset = 0,
+  bottomInset = 0
 }: {
+  connKey: string;
   connection: WsProtocolOptions;
   sessionId: SessionId;
   bottomInset?: number;
 }) => {
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
+
+  // Offline = the message stream is retrying or has surfaced an error. Sends
+  // made in this state are queued instead of dropped.
+  const online = useMobileMessagesStore(
+    (state) =>
+      state.reconnectingBySession[sessionId] !== true &&
+      (state.errorBySession[sessionId] ?? null) === null
+  );
+  const queuedCount = useOutboxStore(
+    (state) => (state.queuedBySession[sessionId] ?? []).length
+  );
+  const enqueue = useOutboxStore((state) => state.enqueue);
+
   const canSend = text.trim().length > 0 && !busy;
 
   const submit = async () => {
     if (!canSend) return;
     const value = text.trim();
     setText("");
+    if (!online) {
+      await enqueue(connKey, sessionId, value);
+      return;
+    }
     setBusy(true);
     try {
       await Effect.runPromise(
-        sendMessage({
-          connection,
-          sessionId,
-          input: makeTextInput(value),
-        })
+        sendMessage({ connection, sessionId, input: makeTextInput(value) })
       );
+    } catch {
+      // Lost the connection mid-send — keep the text safe in the outbox.
+      await enqueue(connKey, sessionId, value);
     } finally {
       setBusy(false);
     }
@@ -54,6 +74,14 @@ export const ComposerStub = ({
       className="border-t border-border px-3 pt-3"
       style={{ paddingBottom: bottomInset > 0 ? bottomInset : 12 }}
     >
+      {queuedCount > 0 ? (
+        <View className="mb-2 flex-row items-center gap-1.5 px-1">
+          <CloudOff size={13} color="hsl(42 93% 56%)" />
+          <Text className="font-sans-medium text-xs text-warning">
+            {queuedCount} queued · will send when reconnected
+          </Text>
+        </View>
+      ) : null}
       <GlassSurface
         style={{
           flexDirection: "row",
@@ -65,19 +93,21 @@ export const ComposerStub = ({
         <TextInput
           className="min-h-10 flex-1 px-2 py-2 font-sans text-[17px] text-foreground"
           multiline
-          placeholder="Message"
+          placeholder={online ? "Message" : "Offline · message will queue"}
           placeholderTextColor="hsl(72 4% 56%)"
           value={text}
           onChangeText={setText}
         />
-        <Button variant="secondary" disabled={busy} onPress={interrupt}>
+        <Button variant="secondary" disabled={busy || !online} onPress={interrupt}>
           <Square size={16} color="hsl(72 4% 92%)" />
         </Button>
-        <Button disabled={!canSend} onPress={submit}>
+        <Button variant={online ? "primary" : "secondary"} disabled={!canSend} onPress={submit}>
           {busy ? (
             <ActivityIndicator color="hsl(72 4% 8%)" />
-          ) : (
+          ) : online ? (
             <Send size={16} color="hsl(72 4% 8%)" />
+          ) : (
+            <CloudOff size={16} color="hsl(72 4% 92%)" />
           )}
         </Button>
       </GlassSurface>

--- a/apps/mobile/src/components/messages/markdown.tsx
+++ b/apps/mobile/src/components/messages/markdown.tsx
@@ -1,0 +1,88 @@
+import { memo } from "react";
+import { StyleSheet } from "react-native";
+import MarkdownDisplay from "react-native-markdown-display";
+
+import { colors } from "~/theme";
+
+const SANS = "Inter_400Regular";
+const SANS_MEDIUM = "Inter_600SemiBold";
+const MONO = "GeistMono_400Regular";
+
+// Theme-mapped styles for react-native-markdown-display. Keys are the library's
+// rule names; anything unspecified inherits from `body`.
+const markdownStyles = StyleSheet.create({
+  body: {
+    color: colors.fg,
+    fontFamily: SANS,
+    fontSize: 15,
+    lineHeight: 22
+  },
+  heading1: { fontFamily: SANS_MEDIUM, fontSize: 22, lineHeight: 28, marginBottom: 6, marginTop: 8 },
+  heading2: { fontFamily: SANS_MEDIUM, fontSize: 19, lineHeight: 25, marginBottom: 6, marginTop: 8 },
+  heading3: { fontFamily: SANS_MEDIUM, fontSize: 17, lineHeight: 23, marginBottom: 4, marginTop: 6 },
+  heading4: { fontFamily: SANS_MEDIUM, fontSize: 15, lineHeight: 21, marginBottom: 4, marginTop: 6 },
+  heading5: { fontFamily: SANS_MEDIUM, fontSize: 14, lineHeight: 20 },
+  heading6: { fontFamily: SANS_MEDIUM, fontSize: 13, lineHeight: 19, color: colors.mutedFg },
+  strong: { fontFamily: SANS_MEDIUM },
+  em: { fontStyle: "italic" },
+  link: { color: colors.accent, textDecorationLine: "underline" },
+  blockquote: {
+    backgroundColor: colors.card,
+    borderColor: colors.border,
+    borderLeftWidth: 3,
+    borderRadius: 6,
+    marginVertical: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 4
+  },
+  hr: { backgroundColor: colors.border, height: StyleSheet.hairlineWidth, marginVertical: 8 },
+  bullet_list: { marginVertical: 2 },
+  ordered_list: { marginVertical: 2 },
+  code_inline: {
+    backgroundColor: colors.card,
+    borderRadius: 4,
+    color: colors.fg,
+    fontFamily: MONO,
+    fontSize: 13,
+    paddingHorizontal: 4,
+    paddingVertical: 1
+  },
+  code_block: {
+    backgroundColor: colors.card,
+    borderColor: colors.border,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    color: colors.fg,
+    fontFamily: MONO,
+    fontSize: 13,
+    lineHeight: 19,
+    marginVertical: 4,
+    padding: 10
+  },
+  fence: {
+    backgroundColor: colors.card,
+    borderColor: colors.border,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    color: colors.fg,
+    fontFamily: MONO,
+    fontSize: 13,
+    lineHeight: 19,
+    marginVertical: 4,
+    padding: 10
+  },
+  table: { borderColor: colors.border, borderRadius: 6, borderWidth: StyleSheet.hairlineWidth, marginVertical: 4 },
+  th: { fontFamily: SANS_MEDIUM, padding: 6 },
+  td: { borderColor: colors.border, padding: 6 },
+  tr: { borderColor: colors.border }
+});
+
+/**
+ * Renders assistant markdown full-width with the app's typography and palette.
+ * Memoized because assistant text is immutable once streamed.
+ */
+export const Markdown = memo(({ children }: { children: string }) => (
+  <MarkdownDisplay style={markdownStyles}>{children}</MarkdownDisplay>
+));
+
+Markdown.displayName = "Markdown";

--- a/apps/mobile/src/components/messages/message-row.tsx
+++ b/apps/mobile/src/components/messages/message-row.tsx
@@ -1,9 +1,24 @@
-import type { Message, MessageContent } from "@zuse/wire";
+import type { Message, MessageContent, UserQuestion } from "@zuse/wire";
 import { Text, View } from "react-native";
 
 import { cn } from "~/lib/cn";
+import { Markdown } from "./markdown";
+import { PendingUserInputCard, type QuestionAnswer } from "./pending-user-input-card";
 
-export const MessageRow = ({ message }: { message: Message }) => {
+/** Extra context the stream provides so question rows can render statefully. */
+export type MessageRowContext = {
+  answeredQuestionIds: ReadonlySet<string>;
+  questionsByItemId: ReadonlyMap<string, readonly UserQuestion[]>;
+  onAnswerQuestion: (itemId: string, answers: readonly QuestionAnswer[]) => void | Promise<void>;
+};
+
+export const MessageRow = ({
+  message,
+  ctx
+}: {
+  message: Message;
+  ctx: MessageRowContext;
+}) => {
   const content = message.content;
   switch (content._tag) {
     case "user":
@@ -11,13 +26,29 @@ export const MessageRow = ({ message }: { message: Message }) => {
     case "user_rich":
       return <UserBubble text={content.text} chips={richChips(content)} goal={content.goal} />;
     case "assistant":
-      return <AssistantBubble text={content.text} />;
+      return <AssistantMarkdown text={content.text} />;
     case "thinking":
       return <ThinkingRow content={content} />;
     case "tool_use":
       return <ToolUseRow content={content} />;
     case "tool_result":
       return <ToolResultRow content={content} />;
+    case "error":
+      return <ErrorRow message={content.message} />;
+    case "user_question":
+      return ctx.answeredQuestionIds.has(content.itemId) ? (
+        <AnsweredQuestion questions={content.questions} />
+      ) : (
+        <PendingUserInputCard
+          itemId={content.itemId}
+          questions={content.questions}
+          onSubmit={ctx.onAnswerQuestion}
+        />
+      );
+    case "user_question_answer":
+      return (
+        <AnswerBubble content={content} questions={ctx.questionsByItemId.get(content.itemId)} />
+      );
     default:
       return <FallbackRow content={content} />;
   }
@@ -54,11 +85,9 @@ const UserBubble = ({
   </View>
 );
 
-const AssistantBubble = ({ text }: { text: string }) => (
-  <View className="items-start px-3 py-1.5">
-    <View className="max-w-[92%] rounded-lg border border-border bg-card px-3 py-2">
-      <Text className="font-sans text-[15px] leading-5 text-foreground">{text}</Text>
-    </View>
+const AssistantMarkdown = ({ text }: { text: string }) => (
+  <View className="px-3 py-1.5">
+    <Markdown>{text}</Markdown>
   </View>
 );
 
@@ -122,6 +151,62 @@ const ToolResultRow = ({
     </View>
   </View>
 );
+
+const ErrorRow = ({ message }: { message: string }) => (
+  <View className="px-3 py-1.5">
+    <View className="rounded-lg border border-danger bg-danger/10 px-3 py-2">
+      <Text className="font-sans-medium text-xs text-danger">Error</Text>
+      <Text selectable className="mt-1 font-sans text-sm leading-5 text-danger">
+        {message}
+      </Text>
+    </View>
+  </View>
+);
+
+const AnsweredQuestion = ({ questions }: { questions: readonly UserQuestion[] }) => (
+  <View className="px-3 py-1.5">
+    <View className="rounded-2xl border border-border bg-card px-3 py-3 opacity-70">
+      <Text className="font-sans-medium text-xs text-muted-foreground">Question · answered</Text>
+      {questions.map((question, qi) => (
+        <Text
+          key={`answered-${qi}`}
+          className={cn(
+            "font-sans-medium text-sm text-foreground",
+            qi > 0 ? "mt-2" : "mt-1"
+          )}
+        >
+          {question.question}
+        </Text>
+      ))}
+    </View>
+  </View>
+);
+
+const AnswerBubble = ({
+  content,
+  questions
+}: {
+  content: Extract<MessageContent, { _tag: "user_question_answer" }>;
+  questions?: readonly UserQuestion[];
+}) => {
+  const labels = content.answers.flatMap((answer) => {
+    const options = questions?.[answer.questionIndex]?.options ?? [];
+    const picked = answer.selected
+      .map((index) => options[index])
+      .filter((label): label is string => label !== undefined);
+    const other = answer.other?.trim();
+    return other !== undefined && other.length > 0 ? [...picked, other] : picked;
+  });
+  const summary = labels.length > 0 ? labels.join(", ") : "Answered";
+  return (
+    <View className="items-end px-3 py-1.5">
+      <View className="max-w-[88%] rounded-lg bg-primary px-3 py-2">
+        <Text className="mb-1 font-sans-medium text-xs text-primary-foreground/75">Answer</Text>
+        <Text className="font-sans text-[15px] leading-5 text-primary-foreground">{summary}</Text>
+      </View>
+    </View>
+  );
+};
 
 const FallbackRow = ({ content }: { content: MessageContent }) => (
   <View className="px-3 py-1.5">

--- a/apps/mobile/src/components/messages/pending-approval-card.tsx
+++ b/apps/mobile/src/components/messages/pending-approval-card.tsx
@@ -1,0 +1,81 @@
+import type { PermissionDecision, PermissionKind, PermissionRequest } from "@zuse/wire";
+import { useState } from "react";
+import { Text, View } from "react-native";
+
+import { Button } from "~/components/ui/button";
+
+/** Human summary + whether the detail reads better in monospace. */
+const describeKind = (kind: PermissionKind): { label: string; detail: string; mono: boolean } => {
+  switch (kind._tag) {
+    case "FileWrite":
+      return { label: "Write file", detail: kind.path, mono: true };
+    case "Bash":
+      return { label: "Run command", detail: kind.command, mono: true };
+    case "Network":
+      return { label: "Network request", detail: kind.url, mono: true };
+    case "Other":
+      return { label: kind.tool, detail: kind.summary, mono: false };
+  }
+};
+
+/**
+ * Inline card for a pending tool-permission prompt. `forcePrompt` requests
+ * (sensitive paths) hide "Allow session" so the user can't silence future
+ * prompts on them by accident — mirroring the renderer's rule.
+ */
+export const PendingApprovalCard = ({
+  request,
+  onDecide
+}: {
+  request: PermissionRequest;
+  onDecide: (decision: PermissionDecision) => void | Promise<void>;
+}) => {
+  const [deciding, setDeciding] = useState(false);
+  const { label, detail, mono } = describeKind(request.kind);
+
+  const decide = async (decision: PermissionDecision) => {
+    if (deciding) return;
+    setDeciding(true);
+    try {
+      await onDecide(decision);
+    } finally {
+      setDeciding(false);
+    }
+  };
+
+  return (
+    <View className="px-3 py-1.5">
+      <View
+        style={{ borderCurve: "continuous" }}
+        className="rounded-2xl border border-primary/40 bg-card px-3 py-3"
+      >
+        <Text className="font-sans-medium text-xs text-primary">Permission required</Text>
+        <Text className="mt-1 font-sans-medium text-sm text-foreground">{label}</Text>
+        <Text
+          className={mono ? "mt-1 font-mono text-xs leading-5 text-muted-foreground" : "mt-1 font-sans text-sm leading-5 text-muted-foreground"}
+          numberOfLines={6}
+        >
+          {detail}
+        </Text>
+        <View className="mt-3 flex-row flex-wrap gap-2">
+          <Button size="sm" disabled={deciding} onPress={() => decide({ _tag: "AllowOnce" })}>
+            Allow once
+          </Button>
+          {request.forcePrompt ? null : (
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={deciding}
+              onPress={() => decide({ _tag: "AllowForSession" })}
+            >
+              Allow session
+            </Button>
+          )}
+          <Button size="sm" variant="danger" disabled={deciding} onPress={() => decide({ _tag: "Deny" })}>
+            Decline
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/src/components/messages/pending-user-input-card.tsx
+++ b/apps/mobile/src/components/messages/pending-user-input-card.tsx
@@ -1,0 +1,119 @@
+import type { UserQuestion } from "@zuse/wire";
+import { useState } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/cn";
+
+export type QuestionAnswer = {
+  questionIndex: number;
+  selected: readonly number[];
+  other?: string;
+};
+
+/**
+ * Inline card for an `AskUserQuestion` prompt — option pills (single- or
+ * multi-select per question) plus a free-text "Other" field. Not a modal: it
+ * lives in the message stream and submits via the session answer RPC.
+ */
+export const PendingUserInputCard = ({
+  itemId,
+  questions,
+  onSubmit
+}: {
+  itemId: string;
+  questions: readonly UserQuestion[];
+  onSubmit: (itemId: string, answers: readonly QuestionAnswer[]) => void | Promise<void>;
+}) => {
+  const [selected, setSelected] = useState<number[][]>(() => questions.map(() => []));
+  const [other, setOther] = useState<string[]>(() => questions.map(() => ""));
+  const [submitting, setSubmitting] = useState(false);
+
+  const toggle = (qi: number, oi: number, multi: boolean) => {
+    setSelected((prev) =>
+      prev.map((picks, index) => {
+        if (index !== qi) return picks;
+        if (!multi) return picks.includes(oi) ? [] : [oi];
+        return picks.includes(oi) ? picks.filter((value) => value !== oi) : [...picks, oi];
+      })
+    );
+  };
+
+  const answerable = questions.every(
+    (_, qi) => (selected[qi] ?? []).length > 0 || (other[qi] ?? "").trim().length > 0
+  );
+
+  const submit = async () => {
+    if (!answerable || submitting) return;
+    setSubmitting(true);
+    try {
+      const answers: QuestionAnswer[] = questions.map((_, qi) => {
+        const trimmed = (other[qi] ?? "").trim();
+        return {
+          questionIndex: qi,
+          selected: selected[qi] ?? [],
+          ...(trimmed.length > 0 ? { other: trimmed } : {})
+        };
+      });
+      await onSubmit(itemId, answers);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View className="px-3 py-1.5">
+      <View
+        style={{ borderCurve: "continuous" }}
+        className="rounded-2xl border border-primary/40 bg-card px-3 py-3"
+      >
+        <Text className="font-sans-medium text-xs text-primary">Question</Text>
+        {questions.map((question, qi) => (
+          <View key={`${itemId}-${qi}`} className={qi > 0 ? "mt-4" : "mt-1"}>
+            <Text className="font-sans-medium text-sm text-foreground">{question.question}</Text>
+            <View className="mt-2 flex-row flex-wrap gap-2">
+              {question.options.map((option, oi) => {
+                const active = (selected[qi] ?? []).includes(oi);
+                return (
+                  <Pressable
+                    key={`${itemId}-${qi}-${oi}`}
+                    onPress={() => toggle(qi, oi, question.multiSelect === true)}
+                    style={{ borderCurve: "continuous" }}
+                    className={cn(
+                      "rounded-full border px-3 py-1.5 active:opacity-80",
+                      active ? "border-primary bg-primary" : "border-border bg-card-elevated"
+                    )}
+                  >
+                    <Text
+                      className={cn(
+                        "font-sans text-[13px]",
+                        active ? "text-primary-foreground" : "text-foreground"
+                      )}
+                    >
+                      {option}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            <TextInput
+              className="mt-2 min-h-9 rounded-xl border border-border bg-card-elevated px-3 py-2 font-sans text-[15px] text-foreground"
+              style={{ borderCurve: "continuous" }}
+              placeholder="Other…"
+              placeholderTextColor="hsl(72 4% 56%)"
+              value={other[qi]}
+              onChangeText={(value) =>
+                setOther((prev) => prev.map((entry, index) => (index === qi ? value : entry)))
+              }
+            />
+          </View>
+        ))}
+        <View className="mt-3 flex-row justify-end">
+          <Button size="sm" disabled={!answerable || submitting} onPress={submit}>
+            Submit
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/src/offline/cache.ts
+++ b/apps/mobile/src/offline/cache.ts
@@ -19,6 +19,17 @@ export type MessagesSnapshot = {
   messages: readonly Message[];
 };
 
+/** One message the user sent while offline, awaiting flush to the server. */
+export type QueuedMessage = {
+  clientId: string;
+  text: string;
+  createdAt: number;
+};
+
+export type OutboxSnapshot = {
+  items: readonly QueuedMessage[];
+};
+
 const ensureDir = (path: string) =>
   Effect.tryPromise({
     try: async () => {
@@ -56,6 +67,9 @@ export const sessionsPath = (connKey: string) =>
 
 export const messagesPath = (connKey: string, sessionId: string) =>
   `${ROOT}/${slugConnectionKey(connKey)}/messages/${slugConnectionKey(sessionId)}.json`;
+
+export const outboxPath = (connKey: string, sessionId: string) =>
+  `${ROOT}/${slugConnectionKey(connKey)}/outbox/${slugConnectionKey(sessionId)}.json`;
 
 export const readSessionsSnapshot = (connKey: string) =>
   readJson(sessionsPath(connKey), (u) => u as SessionsSnapshot).pipe(
@@ -98,6 +112,23 @@ export const writeMessagesSnapshot = (
       writeJson(path, Schema.encodeSync(EncodedMessagesSnapshot)(snapshot))
     )
   );
+};
+
+export const readOutboxSnapshot = (connKey: string, sessionId: string) =>
+  readJson(outboxPath(connKey, sessionId), (u) => u as OutboxSnapshot).pipe(
+    Effect.catchTag("CacheCorrupt", (error) =>
+      Effect.zipRight(deletePath(error.path), Effect.succeed(null))
+    )
+  );
+
+export const writeOutboxSnapshot = (
+  connKey: string,
+  sessionId: string,
+  snapshot: OutboxSnapshot
+) => {
+  const path = outboxPath(connKey, sessionId);
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  return ensureDir(dir).pipe(Effect.zipRight(writeJson(path, snapshot)));
 };
 
 export const decodeEnvelopeFixture = (value: unknown): MessageEnvelope =>

--- a/apps/mobile/src/store/outbox.ts
+++ b/apps/mobile/src/store/outbox.ts
@@ -1,0 +1,105 @@
+import type { SessionId } from "@zuse/wire";
+import { Effect } from "effect";
+import { create } from "zustand";
+
+import type { QueuedMessage } from "~/offline/cache";
+import { readOutboxSnapshot, writeOutboxSnapshot } from "~/offline/cache";
+import { makeTextInput, sendMessage } from "~/rpc/actions";
+import type { WsProtocolOptions } from "~/rpc/ws-protocol";
+
+/**
+ * Per-session outbox for messages composed while the session is offline. Items
+ * are persisted to disk on every mutation so a force-quit doesn't lose queued
+ * text, and flushed in order the moment the session reconnects. Flush keeps the
+ * server-generated message id (no `clientMessageId`) — the live stream echoes
+ * the row back and the message store dedupes by id.
+ */
+type OutboxState = {
+  queuedBySession: Record<string, readonly QueuedMessage[]>;
+  hydrate: (connKey: string, sessionId: SessionId) => Promise<void>;
+  enqueue: (
+    connKey: string,
+    sessionId: SessionId,
+    text: string
+  ) => Promise<void>;
+  flush: (
+    connKey: string,
+    options: WsProtocolOptions,
+    sessionId: SessionId
+  ) => Promise<void>;
+};
+
+// In-flight guard so a reconnect burst can't start two overlapping flushes for
+// the same session (which would double-send the head of the queue).
+const flushing = new Set<string>();
+let counter = 0;
+
+const makeClientId = () => `${Date.now().toString(36)}-${(counter++).toString(36)}`;
+
+const persist = (
+  connKey: string,
+  sessionId: SessionId,
+  items: readonly QueuedMessage[]
+) =>
+  Effect.runPromise(
+    writeOutboxSnapshot(connKey, sessionId, { items })
+  ).catch(() => {});
+
+export const useOutboxStore = create<OutboxState>((set, get) => ({
+  queuedBySession: {},
+  hydrate: async (connKey, sessionId) => {
+    if (get().queuedBySession[sessionId] !== undefined) return;
+    const cached = await Effect.runPromise(
+      readOutboxSnapshot(connKey, sessionId)
+    ).catch(() => null);
+    const items = cached?.items ?? [];
+    set((state) => ({
+      queuedBySession: { ...state.queuedBySession, [sessionId]: items }
+    }));
+  },
+  enqueue: async (connKey, sessionId, text) => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return;
+    const item: QueuedMessage = {
+      clientId: makeClientId(),
+      text: trimmed,
+      createdAt: Date.now()
+    };
+    const next = [...(get().queuedBySession[sessionId] ?? []), item];
+    set((state) => ({
+      queuedBySession: { ...state.queuedBySession, [sessionId]: next }
+    }));
+    await persist(connKey, sessionId, next);
+  },
+  flush: async (connKey, options, sessionId) => {
+    if (flushing.has(sessionId)) return;
+    const queued = get().queuedBySession[sessionId] ?? [];
+    if (queued.length === 0) return;
+    flushing.add(sessionId);
+    try {
+      // Send strictly in order; stop at the first failure so ordering holds and
+      // the remaining items stay queued for the next reconnect.
+      let remaining = queued;
+      for (const item of queued) {
+        try {
+          await Effect.runPromise(
+            sendMessage({
+              connection: options,
+              sessionId,
+              input: makeTextInput(item.text)
+            })
+          );
+        } catch {
+          break;
+        }
+        remaining = remaining.filter((entry) => entry.clientId !== item.clientId);
+        set((state) => ({
+          queuedBySession: { ...state.queuedBySession, [sessionId]: remaining }
+        }));
+        await persist(connKey, sessionId, remaining);
+      }
+    } finally {
+      flushing.delete(sessionId);
+    }
+  }
+}));

--- a/apps/mobile/src/store/permissions.ts
+++ b/apps/mobile/src/store/permissions.ts
@@ -1,0 +1,97 @@
+import type { PermissionDecision, PermissionRequest, SessionId } from "@zuse/wire";
+import { Effect, Fiber, Stream } from "effect";
+import { create } from "zustand";
+
+import { decidePermission } from "~/rpc/actions";
+import { getConnectionClient } from "~/rpc/connection";
+import type { WsProtocolOptions } from "~/rpc/ws-protocol";
+
+/**
+ * Pending tool-permission prompts, surfaced as inline approval cards. These
+ * arrive on the global `permission.requests` stream (not the message log), so
+ * this store cold-loads via `permission.listPending` on mount and then filters
+ * the live stream down to the active session — mirroring the fiber lifecycle of
+ * the messages store.
+ */
+type PermissionsState = {
+  pendingBySession: Record<string, readonly PermissionRequest[]>;
+  hydrate: (
+    connKey: string,
+    options: WsProtocolOptions,
+    sessionId: SessionId
+  ) => Promise<void>;
+  decide: (
+    options: WsProtocolOptions,
+    sessionId: SessionId,
+    requestId: string,
+    decision: PermissionDecision
+  ) => Promise<void>;
+};
+
+const liveFibers = new Map<string, Fiber.RuntimeFiber<unknown, unknown>>();
+
+const makeLiveKey = (connKey: string, sessionId: SessionId) =>
+  JSON.stringify([connKey, sessionId]);
+
+const stop = async (key: string) => {
+  const fiber = liveFibers.get(key);
+  if (fiber !== undefined) {
+    liveFibers.delete(key);
+    await Effect.runPromise(Fiber.interrupt(fiber)).catch(() => {});
+  }
+};
+
+export const usePermissionsStore = create<PermissionsState>((set, get) => ({
+  pendingBySession: {},
+  hydrate: async (connKey, options, sessionId) => {
+    const liveKey = makeLiveKey(connKey, sessionId);
+    await stop(liveKey);
+    try {
+      const client = await Effect.runPromise(getConnectionClient(options));
+
+      const listed = await Effect.runPromise(
+        client.permission.listPending({ sessionId })
+      );
+      set((state) => ({
+        pendingBySession: { ...state.pendingBySession, [sessionId]: listed }
+      }));
+
+      const program = Stream.runForEach(
+        client.permission.requests({}),
+        (request) =>
+          Effect.sync(() => {
+            if (request.sessionId !== sessionId) return;
+            set((state) => {
+              const current = state.pendingBySession[sessionId] ?? [];
+              if (current.some((entry) => entry.id === request.id)) return state;
+              return {
+                pendingBySession: {
+                  ...state.pendingBySession,
+                  [sessionId]: [...current, request]
+                }
+              };
+            });
+          })
+      );
+      const fiber = await Effect.runPromise(program.pipe(Effect.fork));
+      liveFibers.set(liveKey, fiber);
+    } catch {
+      // A dropped permission stream is non-fatal: the messages store already
+      // surfaces the connection error, and hydrate re-runs on the next mount.
+    }
+  },
+  decide: async (options, sessionId, requestId, decision) => {
+    // Optimistically drop the card; the server won't re-emit a decided request.
+    set((state) => ({
+      pendingBySession: {
+        ...state.pendingBySession,
+        [sessionId]: (state.pendingBySession[sessionId] ?? []).filter(
+          (entry) => entry.id !== requestId
+        )
+      }
+    }));
+    await Effect.runPromise(
+      decidePermission({ connection: options, requestId, decision })
+    ).catch(() => {});
+  }
+}));

--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
         "lucide-react-native": "^0.475.0",
         "react": "19.2.3",
         "react-native": "0.86.0",
+        "react-native-markdown-display": "^7.0.2",
         "react-native-quick-crypto": "^0.7.0",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
@@ -1869,6 +1870,8 @@
 
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
+    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001791", "http://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
 
     "ccount": ["ccount@2.0.1", "http://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
@@ -1987,7 +1990,11 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "http://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
+
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
 
     "css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
 
@@ -2219,7 +2226,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@2.0.3", "", {}, "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="],
 
     "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
@@ -2847,6 +2854,8 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "http://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
+    "linkify-it": ["linkify-it@2.2.0", "", { "dependencies": { "uc.micro": "^1.0.1" } }, "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw=="],
+
     "locate-path": ["locate-path@6.0.0", "http://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
@@ -2899,6 +2908,8 @@
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
+    "markdown-it": ["markdown-it@10.0.0", "", { "dependencies": { "argparse": "^1.0.7", "entities": "~2.0.0", "linkify-it": "^2.0.0", "mdurl": "^1.0.1", "uc.micro": "^1.0.5" }, "bin": { "markdown-it": "bin/markdown-it.js" } }, "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg=="],
+
     "markdown-table": ["markdown-table@3.0.4", "http://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
@@ -2944,6 +2955,8 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "http://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
+
+    "mdurl": ["mdurl@1.0.1", "", {}, "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="],
 
     "media-typer": ["media-typer@1.1.0", "http://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
@@ -3303,6 +3316,8 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
     "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
@@ -3399,9 +3414,13 @@
 
     "react-native-drawer-layout": ["react-native-drawer-layout@4.2.7", "", { "dependencies": { "color": "^4.2.3", "use-latest-callback": "^0.2.4" }, "peerDependencies": { "react": ">= 18.2.0", "react-native": "*", "react-native-gesture-handler": ">= 2.0.0", "react-native-reanimated": ">= 2.0.0" } }, "sha512-hhD+E0QmUPkP2Sj1MsUdrvU7GeOiHChPAFPtKahroTwlBGnpgJsUVSL0GWOy5cG3oCZfnu4Pb+gIzOa4ItGNuA=="],
 
+    "react-native-fit-image": ["react-native-fit-image@1.5.5", "", { "dependencies": { "prop-types": "^15.5.10" } }, "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg=="],
+
     "react-native-gesture-handler": ["react-native-gesture-handler@3.0.2", "", { "dependencies": { "@types/react-test-renderer": "^19.1.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-XBTgmvr2jh/xrMwlHTV2Z1x6IFUl3zfLxyaCAnvj3GSXK5YlY3ZmiIs57hniPmh3I7RtjPFxtGdRr0i+PzyBrg=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA=="],
+
+    "react-native-markdown-display": ["react-native-markdown-display@7.0.2", "", { "dependencies": { "css-to-react-native": "^3.0.0", "markdown-it": "^10.0.0", "prop-types": "^15.7.2", "react-native-fit-image": "^1.5.5" }, "peerDependencies": { "react": ">=16.2.0", "react-native": ">=0.50.4" } }, "sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ=="],
 
     "react-native-quick-base64": ["react-native-quick-base64@3.0.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-gnJhA4a/QIGrptZQJv0hLLne8yyJPkdXtn33LHEzq3nhzsv+jRhrxr07wYwYX+CKCRXmuNkZ3Wo7LapSrFVmQg=="],
 
@@ -3643,7 +3662,7 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
-    "sprintf-js": ["sprintf-js@1.1.3", "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "ssri": ["ssri@9.0.1", "", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q=="],
 
@@ -3824,6 +3843,8 @@
     "typescript": ["typescript@5.9.2", "http://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
     "typescript-eslint": ["typescript-eslint@8.59.1", "http://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.1", "@typescript-eslint/parser": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ=="],
+
+    "uc.micro": ["uc.micro@1.0.6", "", {}, "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "http://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
@@ -4491,6 +4512,8 @@
 
     "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
+    "markdown-it/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "metro/@babel/generator": ["@babel/generator@7.29.1", "http://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
@@ -4609,6 +4632,8 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "http://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "plist/@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
@@ -4648,6 +4673,8 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "http://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "roarr/sprintf-js": ["sprintf-js@1.1.3", "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "http://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 


### PR DESCRIPTION
## Summary

Makes the mobile chat session interactive — the app can now prompt the user mid-session for tool permissions and question answers, queue messages sent while offline, and render rich markdown in assistant replies.

## Changes

**New stores**
- `store/permissions.ts` — subscribes to the live `permission.requests` stream, surfaces `PendingApprovalCard` for each prompt on the current session. Optimistically removes cards once decided.
- `store/outbox.ts` — per-session queue for text composed while offline. Persisted to disk so force-quits don't lose queued messages. Auto-flushed in order on reconnect.

**New components**
- `PendingApprovalCard` — inline card for tool permission requests (FileWrite, Bash, Network, Other). Offers Allow Once / Allow once for session / Deny; hides "Allow for session" for `forcePrompt` requests.
- `PendingUserInputCard` — inline multi-question form with option pills (single/multi-select) and free-text "Other" per question. Submits via the session answer RPC.
- `Composer` — replaces `ComposerStub`. Detects online/offline state from the message store; queues sends when offline and shows a queued-count indicator. Mid-send connection drops also fall back to the outbox.

**Markdown rendering**
- `Markdown` component wrapping `react-native-markdown-display` with the app theme (Inter/GeistMono, semantic colors, code blocks, tables, blockquotes). Replaces plain-Text assistant bubbles.

**Message row updates** (`message-row.tsx`)
- Adds renderers for `error`, `user_question`, and `user_question_answer` content tags.
- Question cards collapse to a dimmed "answered" state after submission.
- Answer bubbles resolve selected option labels in the sent summary.
- All variant-specific state lives in the stream page (answered set, question map, answer RPC callback), passed as `MessageRowContext`.

**Cache layer** (`offline/cache.ts`)
- `readOutboxSnapshot` / `writeOutboxSnapshot` — persists the per-session outbox queue alongside existing sessions/messages data.

**Session screen** (`session/[sessionId].tsx`)
- Hydrates permissions + outbox stores on mount alongside messages.
- Auto-triggers outbox flush when the session transitions back online.
- Queued items shown as `QueuedBubble` above the composer; pending permission requests shown as cards in the footer.