### PR TITLE
[codex] Align chat footer controls

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -375,8 +375,10 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
           streaming={streaming}
           onClick={jumpToLatest}
         />
-        <div className="pointer-events-none absolute right-3 bottom-3 z-20 flex items-center gap-2">
-          <NextUnreadButton />
+        <div className="pointer-events-none absolute inset-x-0 bottom-3 z-20">
+          <div className="mx-auto flex w-full max-w-4xl justify-end px-3">
+            <NextUnreadButton />
+          </div>
         </div>
         {archiveProgress !== null ? (
           <ArchiveProgressOverlay phase={archiveProgress} />

--- a/apps/renderer/src/components/cost-footer.tsx
+++ b/apps/renderer/src/components/cost-footer.tsx
@@ -169,15 +169,17 @@ export function CostFooter({ sessionId }: { sessionId: SessionId }) {
   if (summary === null) return null;
 
   return (
-    <div className="px-4 pb-1 text-[10px] text-muted-foreground">
-      <span className="tabular-nums">
-        {summary.lines.join(" · ")}
-        {summary.saved > 0.005 ? (
-          <span className="ml-2 text-emerald-300/80">
-            saved ~{formatUsd(summary.saved)}
-          </span>
-        ) : null}
-      </span>
+    <div className="px-3 pb-1 text-[10px] text-muted-foreground">
+      <div className="mx-auto w-full max-w-4xl">
+        <span className="tabular-nums">
+          {summary.lines.join(" · ")}
+          {summary.saved > 0.005 ? (
+            <span className="ml-2 text-emerald-300/80">
+              saved ~{formatUsd(summary.saved)}
+            </span>
+          ) : null}
+        </span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Align the token/cost footer to the centered chat max-width area.
- Align the floating Next unread button to the same max-width right edge.

## Why
On wide chat panes, these controls were pinned to the full pane edges while the composer and transcript stayed centered, making the footer controls look detached from the main chat surface.

## Validation
- bun run --cwd apps/renderer check-types
- bun run --cwd apps/renderer test
