### PR TITLE
[codex] Fix project accordion toggle

### DIFF
--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -673,22 +673,19 @@ function ProjectGroup({
 
   return (
     <Fragment>
-      {/* Project header — clicking it toggles expansion + selects the folder.
-          Intentionally not highlighted; the active row is the selected
-          session, not the project. */}
+      {/* Project header toggles expansion only. Explicit actions below select
+          the project when they need project context. */}
       <li>
         <div
           role="button"
           tabIndex={0}
           onContextMenu={onContextMenu}
           onClick={() => {
-            onSelect();
             onToggleExpanded();
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
-              onSelect();
               onToggleExpanded();
             }
           }}


### PR DESCRIPTION
## Summary

- Make project header clicks toggle the sidebar accordion only.
- Stop project header mouse and keyboard activation from selecting the project and showing the chat landing view.
- Keep explicit project actions, including New Chat, Archived chats, and Usage, responsible for selecting project context when needed.

## Root Cause

The project header click and keyboard handlers called `onSelect()` before toggling expansion. That updated the active project, which caused the main chat area to fall through to the project chat landing screen even when the user only wanted to expand or collapse the sidebar group.

## Validation

- `bun run --cwd apps/renderer check-types`
