### PR TITLE
Improve chat timeline scrolling

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -33,6 +33,7 @@
     "@hugeicons-pro/core-bulk-rounded": "^4.2.1",
     "@hugeicons-pro/core-solid-rounded": "^4.2.1",
     "@hugeicons/react": "^1.1.7",
+    "@legendapp/list": "3.2.0",
     "@lezer/highlight": "^1.2.0",
     "@zuse/wire": "*",
     "@pierre/diffs": "^1.1.22",

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -1,21 +1,43 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Message01Icon } from "@hugeicons-pro/core-bulk-rounded";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { LegendList, type LegendListRef } from "@legendapp/list/react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+} from "react";
 
 import type {
   AgentItemId,
   Message,
+  MessageId,
   SessionId,
   UserQuestionAnswer,
 } from "@zuse/wire";
 
-import { groupMessages } from "../lib/group-messages.ts";
+import {
+  CHAT_LIST_ANCHOR_OFFSET,
+  resolveChatListAnchoredEndSpace,
+} from "../lib/chat-list-anchor.ts";
+import {
+  deriveChatTimelineRows,
+  resolveLatestUserMessageId,
+  rowAnchorMessageId,
+  type ChatTimelineRow,
+} from "../lib/chat-timeline-rows.ts";
+import {
+  getAnchoredTurnMetrics,
+  type TimelineScrollMode,
+} from "../lib/timeline-scroll-anchoring.ts";
 import {
   chatArchiveProgressLabel,
   type ChatArchiveProgressPhase,
   useChatsStore,
 } from "../store/chats.ts";
-import { useChatScroll } from "../lib/use-chat-scroll.ts";
 import { useRegisterPane } from "../store/pane-focus.ts";
 import { teardownLiveStreams, useMessagesStore } from "../store/messages.ts";
 import { usePermissionsStore } from "../store/permissions.ts";
@@ -42,12 +64,31 @@ import { Spinner } from "./ui/spinner";
 // `[]` from a Zustand selector each call breaks `useSyncExternalStore`'s
 // snapshot-equality check and triggers an infinite re-render loop.
 const EMPTY_MESSAGES: ReadonlyArray<Message> = [];
+const TIMELINE_HEADER = (
+  <>
+    <WorktreeSetupCard />
+    <div className="h-2" />
+  </>
+);
+const TIMELINE_FOOTER = <div className="h-2" />;
+
+interface TimelineEndState {
+  readonly isAtEnd?: boolean;
+  readonly isNearEnd?: boolean;
+}
+
+function resolveTimelineIsAtEnd(
+  state: TimelineEndState | undefined,
+): boolean | undefined {
+  return state?.isNearEnd ?? state?.isAtEnd;
+}
 
 /**
  * Read-only timeline of one session. Subscribes to `messages.stream` via the
  * messages store on mount / session-change; the store owns the live fiber.
- * Scroll behavior is owned by `useChatScroll`: it sticks to the bottom while
- * the reader is there and releases the instant they scroll up.
+ * LegendList owns virtualization and measurement. This component owns the
+ * chat-specific follow mode: initial land at the live edge, then anchor new
+ * turns near the top until the user manually navigates away.
  */
 export function ChatView({ sessionId }: { sessionId: SessionId }) {
   const forkMenu = useForkMenu();
@@ -109,9 +150,180 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       : (s.archiveProgressByChat[session.chatId] ?? null),
   );
 
-  const { scrollRef, contentRef, showPill, streaming, jumpToLatest } =
-    useChatScroll({ sessionId, messages, inFlight });
-  useRegisterPane("chat", scrollRef);
+  const rows = useMemo(
+    () =>
+      deriveChatTimelineRows({
+        messages,
+        inFlight,
+        awaitingPlanApproval,
+      }),
+    [awaitingPlanApproval, inFlight, messages],
+  );
+
+  const latestUserMessageId = useMemo(
+    () => resolveLatestUserMessageId(rows),
+    [rows],
+  );
+  const [timelineAnchorMessageId, setTimelineAnchorMessageId] = useState<
+    string | null
+  >(null);
+  const anchoredEndSpace = useMemo(
+    () =>
+      resolveChatListAnchoredEndSpace(rows, timelineAnchorMessageId, (row) =>
+        rowAnchorMessageId(row),
+      ),
+    [rows, timelineAnchorMessageId],
+  );
+
+  const listRef = useRef<LegendListRef | null>(null);
+  const scrollElementRef = useRef<HTMLDivElement | null>(null);
+  const timelineScrollModeRef =
+    useRef<TimelineScrollMode>("following-end");
+  const activeTimelineAnchorIndexRef = useRef<number | null>(null);
+  const lastAnchoredUserMessageIdRef = useRef<string | null>(null);
+  const positionedTimelineAnchorRef = useRef<string | null>(null);
+  const userNavigationGenerationRef = useRef(0);
+  const liveFollowGenerationRef = useRef<number | null>(0);
+  const showPillTimerRef = useRef<number | null>(null);
+  const isAtEndRef = useRef(true);
+  const [showPill, setShowPill] = useState(false);
+  useRegisterPane("chat", scrollElementRef);
+
+  const clearShowPillTimer = useCallback(() => {
+    if (showPillTimerRef.current !== null) {
+      window.clearTimeout(showPillTimerRef.current);
+      showPillTimerRef.current = null;
+    }
+  }, []);
+
+  const hideJumpPill = useCallback(() => {
+    clearShowPillTimer();
+    setShowPill(false);
+  }, [clearShowPillTimer]);
+
+  const showJumpPillSoon = useCallback(() => {
+    if (showPillTimerRef.current !== null) return;
+    showPillTimerRef.current = window.setTimeout(() => {
+      showPillTimerRef.current = null;
+      setShowPill(true);
+    }, 150);
+  }, []);
+
+  const cancelTimelineLiveFollowForUserNavigation = useCallback(() => {
+    userNavigationGenerationRef.current += 1;
+    timelineScrollModeRef.current = "free-scrolling";
+    liveFollowGenerationRef.current = null;
+    activeTimelineAnchorIndexRef.current = null;
+    positionedTimelineAnchorRef.current = null;
+    setTimelineAnchorMessageId(null);
+  }, []);
+
+  const scrollToEnd = useCallback(
+    (animated = false) => {
+      isAtEndRef.current = true;
+      timelineScrollModeRef.current = "following-end";
+      liveFollowGenerationRef.current = userNavigationGenerationRef.current;
+      activeTimelineAnchorIndexRef.current = null;
+      positionedTimelineAnchorRef.current = null;
+      setTimelineAnchorMessageId(null);
+      lastAnchoredUserMessageIdRef.current = latestUserMessageId;
+      hideJumpPill();
+      void listRef.current?.scrollToEnd({ animated });
+    },
+    [hideJumpPill, latestUserMessageId],
+  );
+
+  const getActiveTimelineTurnMetrics = useCallback(
+    (list?: LegendListRef | null) => {
+      const resolvedList = list ?? listRef.current;
+      const anchorIndex = activeTimelineAnchorIndexRef.current;
+      const state = resolvedList?.getState();
+      if (!resolvedList || !state || anchorIndex === null) {
+        return null;
+      }
+
+      return getAnchoredTurnMetrics({
+        state,
+        anchorIndex,
+        composerOverlayHeight: 0,
+        anchorOffset: CHAT_LIST_ANCHOR_OFFSET,
+      });
+    },
+    [],
+  );
+
+  const timelineRealContentOverflowsViewport = useCallback(
+    (list?: LegendListRef | null) => {
+      const resolvedList = list ?? listRef.current;
+      const state = resolvedList?.getState();
+      if (!resolvedList || !state || state.data.length === 0) {
+        return false;
+      }
+
+      const lastRowIndex = state.data.length - 1;
+      const lastRowTop = state.positionAtIndex(lastRowIndex);
+      const lastRowHeight = state.sizeAtIndex(lastRowIndex);
+      if (
+        typeof lastRowTop !== "number" ||
+        typeof lastRowHeight !== "number" ||
+        !Number.isFinite(lastRowTop) ||
+        !Number.isFinite(lastRowHeight)
+      ) {
+        return false;
+      }
+
+      const realContentBottom = lastRowTop + Math.max(1, lastRowHeight);
+      const visibleScrollLength = Math.max(
+        0,
+        (state.scrollLength ?? 0) - CHAT_LIST_ANCHOR_OFFSET,
+      );
+      return realContentBottom > visibleScrollLength;
+    },
+    [],
+  );
+
+  const handleAnchorReady = useCallback(
+    (info: { anchorIndex: number | undefined }) => {
+      if (info.anchorIndex === undefined) return;
+      activeTimelineAnchorIndexRef.current = info.anchorIndex;
+      if (
+        timelineAnchorMessageId === null ||
+        positionedTimelineAnchorRef.current === timelineAnchorMessageId
+      ) {
+        return;
+      }
+      positionedTimelineAnchorRef.current = timelineAnchorMessageId;
+      void listRef.current?.scrollToIndex({
+        index: info.anchorIndex,
+        animated: true,
+        viewPosition: 0,
+        viewOffset: CHAT_LIST_ANCHOR_OFFSET,
+      });
+    },
+    [timelineAnchorMessageId],
+  );
+
+  const handleScroll = useCallback(() => {
+    const isAtEnd = resolveTimelineIsAtEnd(listRef.current?.getState());
+    if (isAtEnd === undefined || isAtEndRef.current === isAtEnd) return;
+
+    isAtEndRef.current = isAtEnd;
+    if (isAtEnd) {
+      timelineScrollModeRef.current = "following-end";
+      liveFollowGenerationRef.current = userNavigationGenerationRef.current;
+      hideJumpPill();
+    } else {
+      if (
+        liveFollowGenerationRef.current === userNavigationGenerationRef.current
+      ) {
+        hideJumpPill();
+        return;
+      }
+      timelineScrollModeRef.current = "free-scrolling";
+      liveFollowGenerationRef.current = null;
+      showJumpPillSoon();
+    }
+  }, [hideJumpPill, showJumpPillSoon]);
 
   useEffect(() => {
     void hydrate(sessionId);
@@ -127,35 +339,133 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     };
   }, [sessionId, hydrate, hydrateSkills]);
 
+  useEffect(() => () => clearShowPillTimer(), [clearShowPillTimer]);
+
+  useLayoutEffect(() => {
+    const node = listRef.current?.getScrollableNode() ?? null;
+    if (node instanceof HTMLDivElement) {
+      node.dataset.pane = "chat";
+      node.tabIndex = -1;
+      scrollElementRef.current = node;
+    } else {
+      scrollElementRef.current = null;
+    }
+  }, [sessionId, rows.length]);
+
+  useEffect(() => {
+    timelineScrollModeRef.current = "following-end";
+    activeTimelineAnchorIndexRef.current = null;
+    positionedTimelineAnchorRef.current = null;
+    setTimelineAnchorMessageId(null);
+    lastAnchoredUserMessageIdRef.current = null;
+    userNavigationGenerationRef.current = 0;
+    liveFollowGenerationRef.current = 0;
+    isAtEndRef.current = true;
+    hideJumpPill();
+  }, [hideJumpPill, sessionId]);
+
+  useEffect(() => {
+    let removeListeners: (() => void) | null = null;
+    const frame = requestAnimationFrame(() => {
+      const scrollNode = listRef.current?.getScrollableNode();
+      if (!scrollNode) return;
+      if (scrollNode instanceof HTMLDivElement) {
+        scrollNode.dataset.pane = "chat";
+        scrollNode.tabIndex = -1;
+        scrollElementRef.current = scrollNode;
+      } else {
+        scrollElementRef.current = null;
+      }
+      const handleManualNavigation = () => {
+        cancelTimelineLiveFollowForUserNavigation();
+      };
+      scrollNode.addEventListener("wheel", handleManualNavigation, {
+        passive: true,
+      });
+      scrollNode.addEventListener("touchmove", handleManualNavigation, {
+        passive: true,
+      });
+      scrollNode.addEventListener("pointerdown", handleManualNavigation, {
+        passive: true,
+      });
+      removeListeners = () => {
+        scrollNode.removeEventListener("wheel", handleManualNavigation);
+        scrollNode.removeEventListener("touchmove", handleManualNavigation);
+        scrollNode.removeEventListener("pointerdown", handleManualNavigation);
+      };
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      removeListeners?.();
+    };
+  }, [cancelTimelineLiveFollowForUserNavigation, sessionId]);
+
+  useEffect(() => {
+    if (!inFlight || latestUserMessageId === null) return;
+    if (lastAnchoredUserMessageIdRef.current === latestUserMessageId) return;
+
+    lastAnchoredUserMessageIdRef.current = latestUserMessageId;
+    timelineScrollModeRef.current = "anchoring-new-turn";
+    liveFollowGenerationRef.current = userNavigationGenerationRef.current;
+    activeTimelineAnchorIndexRef.current = null;
+    positionedTimelineAnchorRef.current = null;
+    setTimelineAnchorMessageId(latestUserMessageId);
+    hideJumpPill();
+  }, [hideJumpPill, inFlight, latestUserMessageId]);
+
+  useEffect(() => {
+    if (inFlight) return;
+    positionedTimelineAnchorRef.current = null;
+    setTimelineAnchorMessageId(null);
+  }, [inFlight]);
+
+  useEffect(() => {
+    if (
+      liveFollowGenerationRef.current !== userNavigationGenerationRef.current
+    ) {
+      return;
+    }
+
+    let secondFrame: number | null = null;
+    const frame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => {
+        if (
+          liveFollowGenerationRef.current !== userNavigationGenerationRef.current
+        ) {
+          return;
+        }
+
+        const list = listRef.current;
+        if (!list) return;
+
+        if (timelineScrollModeRef.current === "anchoring-new-turn") {
+          const metrics = getActiveTimelineTurnMetrics(list);
+          if (!metrics || metrics.scrollDeltaToRevealEnd <= 1) return;
+
+          const nextOffset = list.getState().scroll + metrics.scrollDeltaToRevealEnd;
+          void list.scrollToOffset({ offset: nextOffset, animated: false });
+          return;
+        }
+
+        if (timelineScrollModeRef.current !== "following-end") return;
+        if (!timelineRealContentOverflowsViewport(list)) return;
+        void list.scrollToEnd({ animated: false });
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      if (secondFrame !== null) cancelAnimationFrame(secondFrame);
+    };
+  }, [getActiveTimelineTurnMetrics, rows, timelineRealContentOverflowsViewport]);
+
   // Pair tool_result rows back to their originating tool_use by AgentItemId.
   // The driver assigns the SDK's tool_use id to both events, so each
   // ToolRow can render its own result inline. We only record results that
   // have a preceding tool_use in this transcript so true orphans (e.g. a
   // dropped tool_use event) still fall through to a standalone error row
   // in MessageRow rather than disappearing silently.
-  // Split the flat message stream into turns: each turn is one user message
-  // (or null for an open response with no preceding user msg) plus every
-  // assistant / thinking / tool message that follows until the next user
-  // message. Used to wrap completed turns in a TurnSummary card.
-  const turns = useMemo(() => {
-    const out: Array<{
-      user: Message | null;
-      body: Message[];
-    }> = [];
-    let current: { user: Message | null; body: Message[] } | null = null;
-    for (const m of messages) {
-      if (m.content._tag === "user" || m.content._tag === "user_rich") {
-        if (current !== null) out.push(current);
-        current = { user: m, body: [] };
-      } else {
-        if (current === null) current = { user: null, body: [] };
-        current.body.push(m);
-      }
-    }
-    if (current !== null) out.push(current);
-    return out;
-  }, [messages]);
-
   const resultsByItemId = useMemo(() => {
     const seenUseIds = new Set<AgentItemId>();
     const map = new Map<AgentItemId, ToolResultRecord>();
@@ -201,179 +511,101 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     [resultsByItemId, answersByItemId],
   );
 
+  const renderTimelineRow = useCallback(
+    ({ item }: { item: ChatTimelineRow }) => (
+      <div className="mx-auto w-full max-w-4xl">
+        <TimelineRow
+          row={item}
+          sessionId={sessionId}
+          onFork={forkMenu.openAt}
+        />
+      </div>
+    ),
+    [forkMenu.openAt, sessionId],
+  );
+
   return (
     <FileChipProvider
       folderId={session?.projectId ?? null}
       worktreeId={session?.worktreeId ?? null}
     >
       <div className="relative flex min-h-0 flex-1">
-        <div
-          ref={scrollRef}
-          data-pane="chat"
-          tabIndex={-1}
-          className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto outline-none"
-        >
-          <WorktreeSetupCard />
+        <div className="flex h-full min-h-0 flex-1 flex-col">
           {messages.length === 0 ? (
-            setupActive ? null : (
-              <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
-                <HugeiconsIcon
-                  icon={Message01Icon}
-                  className="size-10 opacity-40"
-                />
-                <div>
-                  <p className="text-sm">{session?.title ?? "New chat"}</p>
-                  <p className="mt-1 text-xs">
-                    Type a message below to get started.
-                  </p>
-                </div>
-              </div>
-            )
-          ) : (
             <div
-              ref={contentRef}
-              className="mx-auto flex w-full max-w-4xl flex-col py-2"
+              data-pane="chat"
+              tabIndex={-1}
+              ref={scrollElementRef}
+              className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto outline-none"
             >
-              <ChatLookupsProvider value={chatLookups}>
-                {turns.map((turn, idx) => {
-                  const isLastTurn = idx === turns.length - 1;
-                  const isLive = inFlight && isLastTurn;
-                  const hasToolCalls = turn.body.some(
-                    (m) => m.content._tag === "tool_use",
-                  );
-                  // Only collapse into a summary when there's a final assistant
-                  // message worth showing as the body — otherwise a turn with
-                  // just tool calls would lose its content behind the accordion.
-                  const hasFinalText = turn.body.some(
-                    (m) =>
-                      m.content._tag === "assistant" &&
-                      m.content.text.trim().length > 0,
-                  );
-                  const showSummary = !isLive && hasToolCalls && hasFinalText;
-                  const turnKey = turn.user?.id ?? `turn-${idx}`;
-                  // Within an open (non-collapsed) turn, group sub-agent rows
-                  // under a SubagentRow wrapper. TurnSummary handles its own
-                  // rendering for collapsed turns; sub-agents inside a collapsed
-                  // turn render via TurnSummary's existing path.
-                  const bodyGroups = groupMessages(turn.body);
-                  // Hoist ExitPlanMode rows out of TurnSummary so the Plan card
-                  // (and its resolved accordion) stays a top-level row in
-                  // scrollback — it's a user-facing decision, not just another
-                  // tool call to bury in the "N tool calls" rollup.
-                  const planMessages = turn.body.filter(
-                    (m) =>
-                      m.content._tag === "tool_use" &&
-                      m.content.tool === "ExitPlanMode",
-                  );
-                  const planItemIds = new Set(
-                    planMessages.flatMap((m) =>
-                      m.content._tag === "tool_use" ? [m.content.itemId] : [],
-                    ),
-                  );
-                  const summaryBody =
-                    planMessages.length === 0
-                      ? turn.body
-                      : turn.body.filter((m) => {
-                          if (
-                            m.content._tag === "tool_use" &&
-                            m.content.tool === "ExitPlanMode"
-                          ) {
-                            return false;
-                          }
-                          if (
-                            m.content._tag === "tool_result" &&
-                            planItemIds.has(m.content.itemId)
-                          ) {
-                            return false;
-                          }
-                          return true;
-                        });
-                  return (
-                    <Fragment key={turnKey}>
-                      {turn.user !== null ? (
-                        <div
-                          className="chat-row-enter chat-row-enter-user"
-                          onContextMenu={(e) =>
-                            forkMenu.openAt(e, sessionId, turn.user!.id)
-                          }
-                        >
-                          <MessageRow
-                            message={turn.user}
-                            sessionId={sessionId}
-                          />
-                        </div>
-                      ) : null}
-                      {showSummary ? (
-                        <>
-                          {planMessages.map((m) => (
-                            <div key={m.id} className="chat-row-enter">
-                              <MessageRow message={m} sessionId={sessionId} />
-                            </div>
-                          ))}
-                          <div className="chat-row-enter">
-                            <TurnSummary body={summaryBody} />
-                          </div>
-                        </>
-                      ) : (
-                        bodyGroups.map((group) =>
-                          group.kind === "single" ? (
-                            <div
-                              key={group.message.id}
-                              className="chat-row-enter"
-                              onContextMenu={
-                                group.message.content._tag === "assistant"
-                                  ? (e) =>
-                                      forkMenu.openAt(
-                                        e,
-                                        sessionId,
-                                        group.message.id,
-                                      )
-                                  : undefined
-                              }
-                            >
-                              <MessageRow
-                                message={group.message}
-                                sessionId={sessionId}
-                              />
-                            </div>
-                          ) : (
-                            <div
-                              key={group.parent.id}
-                              className="chat-row-enter"
-                            >
-                              <SubagentRow
-                                agentToolUseId={group.parentItemId}
-                                agentName={group.agentName}
-                                prompt={group.prompt}
-                                modelRequested={group.modelRequested}
-                                children={group.children}
-                                summary={group.summary}
-                              />
-                            </div>
-                          ),
-                        )
-                      )}
-                    </Fragment>
-                  );
-                })}
-                {inFlight && !awaitingPlanApproval && (
-                  <WorkingRow messages={messages} />
-                )}
-              </ChatLookupsProvider>
+              <WorktreeSetupCard />
+              {setupActive ? null : (
+                <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+                  <HugeiconsIcon
+                    icon={Message01Icon}
+                    className="size-10 opacity-40"
+                  />
+                  <div>
+                    <p className="text-sm">{session?.title ?? "New chat"}</p>
+                    <p className="mt-1 text-xs">
+                      Type a message below to get started.
+                    </p>
+                  </div>
+                </div>
+              )}
             </div>
+          ) : (
+            <ChatLookupsProvider value={chatLookups}>
+              <LegendList<ChatTimelineRow>
+                ref={listRef}
+                data={rows}
+                keyExtractor={(row) => row.id}
+                getItemType={(row) => row.kind}
+                renderItem={renderTimelineRow}
+                estimatedItemSize={96}
+                initialScrollAtEnd
+                {...(anchoredEndSpace
+                  ? {
+                      anchoredEndSpace: {
+                        ...anchoredEndSpace,
+                        onReady: handleAnchorReady,
+                      },
+                    }
+                  : {})}
+                maintainScrollAtEnd={
+                  anchoredEndSpace
+                    ? false
+                    : {
+                        animated: false,
+                        on: {
+                          dataChange: true,
+                          itemLayout: true,
+                          layout: true,
+                        },
+                      }
+                }
+                maintainVisibleContentPosition={{ data: true, size: false }}
+                onScroll={handleScroll}
+                className="h-full min-h-0 flex-1 overflow-x-hidden px-3 outline-none [overflow-anchor:none]"
+                data-pane="chat"
+                tabIndex={-1}
+                ListHeaderComponent={TIMELINE_HEADER}
+                ListFooterComponent={TIMELINE_FOOTER}
+              />
+            </ChatLookupsProvider>
           )}
-          {error !== null && (
+          {error !== null ? (
             <ErrorBubble
               error={error}
               sessionId={sessionId}
               onDismiss={() => clearError(sessionId)}
             />
-          )}
+          ) : null}
         </div>
         <JumpToLatestPill
           visible={showPill}
-          streaming={streaming}
-          onClick={jumpToLatest}
+          streaming={inFlight && showPill}
+          onClick={() => scrollToEnd(true)}
         />
         <div className="pointer-events-none absolute inset-x-0 bottom-3 z-20">
           <div className="mx-auto flex w-full max-w-4xl justify-end px-3">
@@ -387,6 +619,63 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       {forkMenu.menu}
     </FileChipProvider>
   );
+}
+
+function TimelineRow({
+  row,
+  sessionId,
+  onFork,
+}: {
+  row: ChatTimelineRow;
+  sessionId: SessionId;
+  onFork: (
+    event: MouseEvent,
+    sourceSessionId: SessionId,
+    fromMessageId: MessageId,
+  ) => void;
+}) {
+  switch (row.kind) {
+    case "message":
+      return (
+        <div
+          className={
+            row.enterUser
+              ? "chat-row-enter chat-row-enter-user"
+              : "chat-row-enter"
+          }
+          onContextMenu={
+            row.message.content._tag === "user" ||
+            row.message.content._tag === "user_rich" ||
+            row.message.content._tag === "assistant"
+              ? (event) => onFork(event, sessionId, row.message.id)
+              : undefined
+          }
+        >
+          <MessageRow message={row.message} sessionId={sessionId} />
+        </div>
+      );
+    case "subagent":
+      return (
+        <div className="chat-row-enter">
+          <SubagentRow
+            agentToolUseId={row.parentItemId}
+            agentName={row.agentName}
+            prompt={row.prompt}
+            modelRequested={row.modelRequested}
+            children={row.children}
+            summary={row.summary}
+          />
+        </div>
+      );
+    case "turn-summary":
+      return (
+        <div className="chat-row-enter">
+          <TurnSummary body={row.body} />
+        </div>
+      );
+    case "working":
+      return <WorkingRow messages={row.messages} />;
+  }
 }
 
 function ArchiveProgressOverlay({

--- a/apps/renderer/src/lib/chat-list-anchor.ts
+++ b/apps/renderer/src/lib/chat-list-anchor.ts
@@ -1,0 +1,26 @@
+export const CHAT_LIST_ANCHOR_OFFSET = 16;
+
+export interface ChatListAnchoredEndSpace {
+  readonly anchorIndex: number;
+  readonly anchorOffset: number;
+}
+
+export function resolveChatListAnchoredEndSpace<Item, AnchorId>(
+  items: ReadonlyArray<Item>,
+  anchorId: AnchorId | null,
+  getAnchorId: (item: Item) => AnchorId | null,
+): ChatListAnchoredEndSpace | undefined {
+  if (anchorId === null) return undefined;
+
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item !== undefined && getAnchorId(item) === anchorId) {
+      return {
+        anchorIndex: index,
+        anchorOffset: CHAT_LIST_ANCHOR_OFFSET,
+      };
+    }
+  }
+
+  return undefined;
+}

--- a/apps/renderer/src/lib/chat-timeline-rows.ts
+++ b/apps/renderer/src/lib/chat-timeline-rows.ts
@@ -1,0 +1,195 @@
+import type { AgentItemId, Message } from "@zuse/wire";
+
+import { groupMessages } from "./group-messages.ts";
+
+export type ChatTimelineRow =
+  | {
+      readonly kind: "message";
+      readonly id: string;
+      readonly message: Message;
+      readonly enterUser: boolean;
+    }
+  | {
+      readonly kind: "subagent";
+      readonly id: string;
+      readonly parent: Message;
+      readonly parentItemId: AgentItemId;
+      readonly agentName: string;
+      readonly prompt: string;
+      readonly modelRequested: string | undefined;
+      readonly children: ReadonlyArray<Message>;
+      readonly summary: {
+        readonly text: string;
+        readonly turns: number;
+        readonly durationMs: number;
+        readonly model: string;
+        readonly isError: boolean;
+      } | null;
+    }
+  | {
+      readonly kind: "turn-summary";
+      readonly id: string;
+      readonly body: ReadonlyArray<Message>;
+    }
+  | {
+      readonly kind: "working";
+      readonly id: string;
+      readonly messages: ReadonlyArray<Message>;
+    };
+
+export function isUserMessage(message: Message): boolean {
+  return (
+    message.content._tag === "user" || message.content._tag === "user_rich"
+  );
+}
+
+export function resolveLatestUserMessageId(
+  rows: ReadonlyArray<ChatTimelineRow>,
+): string | null {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (row?.kind === "message" && isUserMessage(row.message)) {
+      return row.message.id;
+    }
+  }
+  return null;
+}
+
+export function rowAnchorMessageId(row: ChatTimelineRow): string | null {
+  return row.kind === "message" && isUserMessage(row.message)
+    ? row.message.id
+    : null;
+}
+
+export function deriveChatTimelineRows({
+  messages,
+  inFlight,
+  awaitingPlanApproval,
+}: {
+  readonly messages: ReadonlyArray<Message>;
+  readonly inFlight: boolean;
+  readonly awaitingPlanApproval: boolean;
+}): ChatTimelineRow[] {
+  const turns: Array<{
+    user: Message | null;
+    body: Message[];
+  }> = [];
+  let current: { user: Message | null; body: Message[] } | null = null;
+
+  for (const message of messages) {
+    if (isUserMessage(message)) {
+      if (current !== null) turns.push(current);
+      current = { user: message, body: [] };
+    } else {
+      if (current === null) current = { user: null, body: [] };
+      current.body.push(message);
+    }
+  }
+  if (current !== null) turns.push(current);
+
+  const rows: ChatTimelineRow[] = [];
+
+  for (let index = 0; index < turns.length; index += 1) {
+    const turn = turns[index]!;
+    const isLastTurn = index === turns.length - 1;
+    const isLive = inFlight && isLastTurn;
+
+    if (turn.user !== null) {
+      rows.push({
+        kind: "message",
+        id: `message:${turn.user.id}`,
+        message: turn.user,
+        enterUser: true,
+      });
+    }
+
+    const hasToolCalls = turn.body.some(
+      (message) => message.content._tag === "tool_use",
+    );
+    const hasFinalText = turn.body.some(
+      (message) =>
+        message.content._tag === "assistant" &&
+        message.content.text.trim().length > 0,
+    );
+    const showSummary = !isLive && hasToolCalls && hasFinalText;
+    const bodyGroups = groupMessages(turn.body);
+    const planMessages = turn.body.filter(
+      (message) =>
+        message.content._tag === "tool_use" &&
+        message.content.tool === "ExitPlanMode",
+    );
+    const planItemIds = new Set(
+      planMessages.flatMap((message) =>
+        message.content._tag === "tool_use" ? [message.content.itemId] : [],
+      ),
+    );
+    const summaryBody =
+      planMessages.length === 0
+        ? turn.body
+        : turn.body.filter((message) => {
+            if (
+              message.content._tag === "tool_use" &&
+              message.content.tool === "ExitPlanMode"
+            ) {
+              return false;
+            }
+            if (
+              message.content._tag === "tool_result" &&
+              planItemIds.has(message.content.itemId)
+            ) {
+              return false;
+            }
+            return true;
+          });
+
+    if (showSummary) {
+      for (const message of planMessages) {
+        rows.push({
+          kind: "message",
+          id: `message:${message.id}`,
+          message,
+          enterUser: false,
+        });
+      }
+      rows.push({
+        kind: "turn-summary",
+        id: `summary:${turn.user?.id ?? `turn-${index}`}`,
+        body: summaryBody,
+      });
+      continue;
+    }
+
+    for (const group of bodyGroups) {
+      if (group.kind === "single") {
+        rows.push({
+          kind: "message",
+          id: `message:${group.message.id}`,
+          message: group.message,
+          enterUser: false,
+        });
+      } else {
+        rows.push({
+          kind: "subagent",
+          id: `subagent:${group.parent.id}`,
+          parent: group.parent,
+          parentItemId: group.parentItemId,
+          agentName: group.agentName,
+          prompt: group.prompt,
+          modelRequested: group.modelRequested,
+          children: group.children,
+          summary: group.summary,
+        });
+      }
+    }
+  }
+
+  if (inFlight && !awaitingPlanApproval) {
+    rows.push({
+      kind: "working",
+      id: "working",
+      messages,
+    });
+  }
+
+  return rows;
+}

--- a/apps/renderer/src/lib/timeline-scroll-anchoring.ts
+++ b/apps/renderer/src/lib/timeline-scroll-anchoring.ts
@@ -1,0 +1,95 @@
+export type TimelineScrollMode =
+  | "following-end"
+  | "anchoring-new-turn"
+  | "free-scrolling";
+
+export interface TimelineListMeasurementState {
+  readonly data: readonly unknown[];
+  readonly scroll: number;
+  readonly scrollLength: number;
+  readonly positionAtIndex: (index: number) => number | undefined;
+  readonly sizeAtIndex: (index: number) => number | undefined;
+}
+
+export interface AnchoredTurnMetrics {
+  readonly anchorTop: number;
+  readonly lastBottom: number;
+  readonly turnHeight: number;
+  readonly usableViewportHeight: number;
+  readonly visibleUsableBottom: number;
+  readonly overflowsUsableViewport: boolean;
+  readonly targetScrollToRevealEnd: number;
+  readonly scrollDeltaToRevealEnd: number;
+}
+
+export function getRowBottom(
+  state: TimelineListMeasurementState,
+  index: number,
+): number | null {
+  const top = state.positionAtIndex(index);
+  const height = state.sizeAtIndex(index);
+  if (
+    typeof top !== "number" ||
+    typeof height !== "number" ||
+    !Number.isFinite(top) ||
+    !Number.isFinite(height)
+  ) {
+    return null;
+  }
+
+  return top + Math.max(1, height);
+}
+
+export function getAnchoredTurnMetrics({
+  state,
+  anchorIndex,
+  composerOverlayHeight,
+  anchorOffset,
+}: {
+  readonly state: TimelineListMeasurementState;
+  readonly anchorIndex: number;
+  readonly composerOverlayHeight: number;
+  readonly anchorOffset: number;
+}): AnchoredTurnMetrics | null {
+  if (state.data.length === 0) return null;
+
+  const boundedAnchorIndex = Math.max(
+    0,
+    Math.min(anchorIndex, state.data.length - 1),
+  );
+  const anchorTop = state.positionAtIndex(boundedAnchorIndex);
+  const lastBottom = getRowBottom(state, state.data.length - 1);
+  if (
+    typeof anchorTop !== "number" ||
+    !Number.isFinite(anchorTop) ||
+    lastBottom === null
+  ) {
+    return null;
+  }
+
+  const usableViewportHeight = Math.max(
+    0,
+    state.scrollLength - composerOverlayHeight - anchorOffset,
+  );
+  const turnHeight = Math.max(0, lastBottom - anchorTop);
+  const visibleUsableBottom = state.scroll + usableViewportHeight;
+  const targetScrollToRevealEnd = Math.max(
+    0,
+    lastBottom - usableViewportHeight,
+  );
+  const scrollDeltaToRevealEnd = Math.max(
+    0,
+    targetScrollToRevealEnd - state.scroll,
+  );
+
+  return {
+    anchorTop,
+    lastBottom,
+    turnHeight,
+    usableViewportHeight,
+    visibleUsableBottom,
+    overflowsUsableViewport: turnHeight > usableViewportHeight,
+    targetScrollToRevealEnd,
+    scrollDeltaToRevealEnd,
+  };
+}

--- a/apps/renderer/test/chat-timeline-rows.test.ts
+++ b/apps/renderer/test/chat-timeline-rows.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Message, SessionId } from "@zuse/wire";
+
+import {
+  deriveChatTimelineRows,
+  resolveLatestUserMessageId,
+  rowAnchorMessageId,
+} from "../src/lib/chat-timeline-rows.ts";
+
+const sessionId = "session-timeline" as SessionId;
+
+function message(
+  id: string,
+  content: Message["content"],
+  createdAt = new Date("2026-07-06T00:00:00.000Z"),
+): Message {
+  return {
+    id,
+    sessionId,
+    role:
+      content._tag === "user" || content._tag === "user_rich"
+        ? "user"
+        : "assistant",
+    content,
+    createdAt,
+  } as Message;
+}
+
+describe("chat timeline rows", () => {
+  it("returns no anchor for an empty timeline", () => {
+    expect(resolveLatestUserMessageId([])).toBe(null);
+  });
+
+  it("resolves the latest user message anchor", () => {
+    const rows = deriveChatTimelineRows({
+      messages: [
+        message("u1", { _tag: "user", text: "first", goal: null }),
+        message("a1", { _tag: "assistant", text: "reply" }),
+        message("u2", { _tag: "user", text: "second", goal: null }),
+      ],
+      inFlight: true,
+      awaitingPlanApproval: false,
+    });
+
+    expect(resolveLatestUserMessageId(rows)).toBe("u2");
+    expect(rows.map((row) => rowAnchorMessageId(row))).toContain("u2");
+  });
+
+  it("preserves stable row ids for unchanged messages", () => {
+    const messages = [
+      message("u1", { _tag: "user", text: "first", goal: null }),
+      message("a1", { _tag: "assistant", text: "reply" }),
+    ];
+    const first = deriveChatTimelineRows({
+      messages,
+      inFlight: false,
+      awaitingPlanApproval: false,
+    });
+    const second = deriveChatTimelineRows({
+      messages,
+      inFlight: false,
+      awaitingPlanApproval: false,
+    });
+
+    expect(second.map((row) => row.id)).toEqual(first.map((row) => row.id));
+  });
+});

--- a/apps/renderer/test/timeline-scroll-anchoring.test.ts
+++ b/apps/renderer/test/timeline-scroll-anchoring.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  getAnchoredTurnMetrics,
+  getRowBottom,
+} from "../src/lib/timeline-scroll-anchoring.ts";
+
+function buildState({
+  positions,
+  sizes,
+  scroll = 0,
+  scrollLength = 700,
+}: {
+  readonly positions: readonly number[];
+  readonly sizes: readonly number[];
+  readonly scroll?: number;
+  readonly scrollLength?: number;
+}) {
+  return {
+    data: positions.map((_, index) => index),
+    scroll,
+    scrollLength,
+    positionAtIndex: (index: number) => positions[index],
+    sizeAtIndex: (index: number) => sizes[index],
+  };
+}
+
+describe("timeline scroll anchoring", () => {
+  it("measures row bottoms from row position and size", () => {
+    const state = buildState({
+      positions: [0, 120],
+      sizes: [80, 40],
+    });
+
+    expect(getRowBottom(state, 1)).toBe(160);
+  });
+
+  it("treats the active turn as fitting when it fits above the composer", () => {
+    const state = buildState({
+      positions: [0, 300, 460],
+      sizes: [240, 80, 140],
+      scrollLength: 760,
+    });
+
+    const metrics = getAnchoredTurnMetrics({
+      state,
+      anchorIndex: 1,
+      composerOverlayHeight: 180,
+      anchorOffset: 16,
+    });
+
+    expect(metrics?.turnHeight).toBe(300);
+    expect(metrics?.usableViewportHeight).toBe(564);
+    expect(metrics?.overflowsUsableViewport).toBe(false);
+    expect(metrics?.targetScrollToRevealEnd).toBe(36);
+    expect(metrics?.scrollDeltaToRevealEnd).toBe(36);
+  });
+
+  it("targets the real row end instead of reserved tail space", () => {
+    const state = buildState({
+      positions: [0, 1720, 1880],
+      sizes: [1600, 80, 120],
+      scroll: 1900,
+      scrollLength: 760,
+    });
+
+    const metrics = getAnchoredTurnMetrics({
+      state,
+      anchorIndex: 1,
+      composerOverlayHeight: 180,
+      anchorOffset: 16,
+    });
+
+    expect(metrics?.lastBottom).toBe(2000);
+    expect(metrics?.targetScrollToRevealEnd).toBe(1436);
+    expect(metrics?.scrollDeltaToRevealEnd).toBe(0);
+  });
+
+  it("reports overflow only for the current anchored turn", () => {
+    const state = buildState({
+      positions: [0, 900, 1180],
+      sizes: [800, 220, 300],
+      scroll: 900,
+      scrollLength: 760,
+    });
+
+    const metrics = getAnchoredTurnMetrics({
+      state,
+      anchorIndex: 1,
+      composerOverlayHeight: 180,
+      anchorOffset: 16,
+    });
+
+    expect(metrics?.turnHeight).toBe(580);
+    expect(metrics?.usableViewportHeight).toBe(564);
+    expect(metrics?.overflowsUsableViewport).toBe(true);
+  });
+
+  it("returns the minimal positive scroll delta needed to reveal the turn end", () => {
+    const state = buildState({
+      positions: [0, 900, 1180],
+      sizes: [800, 220, 360],
+      scroll: 900,
+      scrollLength: 760,
+    });
+
+    const metrics = getAnchoredTurnMetrics({
+      state,
+      anchorIndex: 1,
+      composerOverlayHeight: 180,
+      anchorOffset: 16,
+    });
+
+    expect(metrics?.lastBottom).toBe(1540);
+    expect(metrics?.visibleUsableBottom).toBe(1464);
+    expect(metrics?.scrollDeltaToRevealEnd).toBe(76);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -136,6 +136,7 @@
         "@hugeicons-pro/core-bulk-rounded": "^4.2.1",
         "@hugeicons-pro/core-solid-rounded": "^4.2.1",
         "@hugeicons/react": "^1.1.7",
+        "@legendapp/list": "3.2.0",
         "@lezer/highlight": "^1.2.0",
         "@pierre/diffs": "^1.1.22",
         "@xterm/addon-fit": "^0.10.0",
@@ -953,6 +954,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "http://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "http://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@legendapp/list": ["@legendapp/list@3.2.0", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "*" } }, "sha512-bN+g/oQYjFz+UAyuBN4cmYJAwdJS1TdNcZZOVlh3+VwCQUWrsg0PH46Mvm76gdZSCYMfoFanPY4dKnILcYEzeg=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "http://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 


### PR DESCRIPTION
## Summary
- virtualize the renderer chat timeline with `@legendapp/list`
- anchor new/running turns near the top while preserving manual scroll position
- add focused tests for timeline row derivation and scroll anchoring math

## Validation
- `cd apps/renderer && bun test`
- `cd apps/renderer && bun run check-types`
- `bun run build:desktop`
