### PR TITLE
[codex] Add advertised endpoint model

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -25,7 +25,7 @@ import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 import { makeMainLayer } from "@zuse/server";
-import { AGENTS_RUNNING_COUNT_CHANNEL } from "@zuse/wire";
+import { AGENTS_RUNNING_COUNT_CHANNEL, AuthFlowError } from "@zuse/wire";
 
 // macOS GUI apps launched from Finder inherit a minimal PATH
 // (`/usr/bin:/bin:/usr/sbin:/sbin`), not the user's shell PATH. The Claude
@@ -611,8 +611,17 @@ const folderPicker = {
 const authShell = {
   redirectUri: AUTH_REDIRECT_URI,
   open: (url: string) =>
-    Effect.sync(() => {
-      void shell.openExternal(url);
+    Effect.tryPromise({
+      try: async () => {
+        await shell.openExternal(url);
+      },
+      catch: (cause) =>
+        new AuthFlowError({
+          reason:
+            cause instanceof Error
+              ? `Could not open browser: ${cause.message}`
+              : "Could not open browser.",
+        }),
     }),
   onCallbackUrl: (handler: (url: string) => void) =>
     Effect.sync(() => {

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -356,7 +356,7 @@ export function BrowserPane() {
           // attribute — and the loads abort each other (ERR_ABORTED -3, agent
           // navigations intermittently reporting about:blank).
           src="about:blank"
-          allowpopups={true}
+          {...({ allowpopups: "true" } as Record<string, string>)}
           style={{
             display: url === "" ? "none" : "flex",
             width: "100%",

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -9,6 +9,7 @@ import {
   selectAdvertisedEndpoint,
   writeEndpointOverride,
 } from "../../lib/advertised-endpoints.ts";
+import { formatError } from "../../lib/format-error.ts";
 import { getRpcClient } from "../../lib/rpc-client.ts";
 import { Button } from "../ui/button.tsx";
 import {
@@ -18,10 +19,35 @@ import {
 } from "../ui/collapsible.tsx";
 import { Input } from "../ui/input.tsx";
 import { Spinner } from "../ui/spinner.tsx";
+import { toastManager } from "../ui/toast.tsx";
 
 const DEFAULT_RELAY_URL =
   (import.meta.env.VITE_ZUSE_RELAY_URL as string | undefined) ??
   "https://relay.stuff.md";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const relayErrorMessage = (cause: unknown): string => {
+  const formatted = formatError(cause);
+  return formatted.includes("not_signed_in")
+    ? "Sign in before linking this Mac to your account."
+    : formatted;
+};
+
+const showRelayErrorToast = (title: string, cause: unknown): void => {
+  toastManager.add({
+    type: "error",
+    title,
+    description: relayErrorMessage(cause),
+  });
+};
+
+const isStatusLoadError = (cause: unknown): boolean =>
+  isRecord(cause) &&
+  (cause.reason === "not_signed_in" ||
+    (typeof cause.message === "string" &&
+      cause.message.includes("not_signed_in")));
 
 /**
  * "Devices" settings pane. Links this Mac to the account relay so it appears on
@@ -32,7 +58,6 @@ export function DevicesPane() {
   const [status, setStatus] = useState<RelayLinkStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
   const [label, setLabel] = useState("");
   const [endpointOverrideId, setEndpointOverrideId] = useState<string | null>(
@@ -45,9 +70,10 @@ export function DevicesPane() {
       const client = await getRpcClient();
       const next = await Effect.runPromise(client.relay.status());
       setStatus(next);
-      setError(null);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      if (!isStatusLoadError(cause)) {
+        showRelayErrorToast("Could not load device status", cause);
+      }
     } finally {
       setLoading(false);
     }
@@ -60,7 +86,6 @@ export function DevicesPane() {
   const onConnect = useCallback(async () => {
     if (relayUrl.trim().length === 0) return;
     setBusy(true);
-    setError(null);
     try {
       const client = await getRpcClient();
       const next = await Effect.runPromise(
@@ -71,7 +96,7 @@ export function DevicesPane() {
       );
       setStatus(next);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      showRelayErrorToast("Could not connect this Mac", cause);
     } finally {
       setBusy(false);
     }
@@ -79,13 +104,12 @@ export function DevicesPane() {
 
   const onUnlink = useCallback(async () => {
     setBusy(true);
-    setError(null);
     try {
       const client = await getRpcClient();
       await Effect.runPromise(client.relay.unlink());
       await refresh();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      showRelayErrorToast("Could not unlink this Mac", cause);
     } finally {
       setBusy(false);
     }
@@ -237,8 +261,6 @@ export function DevicesPane() {
           </div>
         </Collapsible>
       )}
-
-      {error !== null && <p className="text-xs text-destructive">{error}</p>}
     </section>
   );
 }

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -1,10 +1,21 @@
 import { Effect } from "effect";
+import { Check, ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
-import type { RelayLinkStatus } from "@zuse/wire";
+import type { AdvertisedEndpoint, RelayLinkStatus } from "@zuse/wire";
 
+import {
+  readEndpointOverride,
+  selectAdvertisedEndpoint,
+  writeEndpointOverride,
+} from "../../lib/advertised-endpoints.ts";
 import { getRpcClient } from "../../lib/rpc-client.ts";
 import { Button } from "../ui/button.tsx";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../ui/collapsible.tsx";
 import { Input } from "../ui/input.tsx";
 import { Spinner } from "../ui/spinner.tsx";
 
@@ -24,6 +35,10 @@ export function DevicesPane() {
   const [error, setError] = useState<string | null>(null);
   const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
   const [label, setLabel] = useState("");
+  const [endpointOverrideId, setEndpointOverrideId] = useState<string | null>(
+    () => readEndpointOverride(),
+  );
+  const [endpointsOpen, setEndpointsOpen] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -85,6 +100,16 @@ export function DevicesPane() {
   }
 
   const linked = status?.linked === true;
+  const advertisedEndpoints = status?.advertisedEndpoints ?? [];
+  const selectedEndpoint = selectAdvertisedEndpoint(
+    advertisedEndpoints,
+    endpointOverrideId,
+  );
+
+  const onSelectEndpoint = useCallback((endpointId: string) => {
+    setEndpointOverrideId(endpointId);
+    writeEndpointOverride(endpointId);
+  }, []);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-4 p-6">
@@ -118,6 +143,9 @@ export function DevicesPane() {
               Unlink
             </Button>
           </div>
+          {selectedEndpoint !== null && (
+            <EndpointSummary endpoint={selectedEndpoint} />
+          )}
           <p className="mt-3 text-xs text-muted-foreground">
             This Mac is reachable from your phone after you sign in to the same
             account there.
@@ -157,9 +185,109 @@ export function DevicesPane() {
         </div>
       )}
 
-      {error !== null && (
-        <p className="text-xs text-destructive">{error}</p>
+      {advertisedEndpoints.length > 0 && (
+        <Collapsible open={endpointsOpen} onOpenChange={setEndpointsOpen}>
+          <div className="rounded-xl border border-border/50 bg-background p-4">
+            <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
+              <div>
+                <div className="text-sm font-medium text-foreground">
+                  All endpoints
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {advertisedEndpoints.length} advertised route
+                  {advertisedEndpoints.length === 1 ? "" : "s"}
+                </div>
+              </div>
+              <ChevronDown
+                className={
+                  endpointsOpen
+                    ? "size-4 rotate-180 text-muted-foreground transition-transform"
+                    : "size-4 text-muted-foreground transition-transform"
+                }
+                aria-hidden
+              />
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-3 flex flex-col gap-2">
+                {advertisedEndpoints.map((endpoint) => {
+                  const selected = selectedEndpoint?.id === endpoint.id;
+                  return (
+                    <button
+                      key={endpoint.id}
+                      type="button"
+                      className="flex min-w-0 items-start gap-3 rounded-lg border border-border/50 bg-muted/20 p-3 text-left hover:bg-muted/40"
+                      onClick={() => onSelectEndpoint(endpoint.id)}
+                    >
+                      <span
+                        className={
+                          selected
+                            ? "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                            : "mt-0.5 size-5 shrink-0 rounded-full border border-border"
+                        }
+                        aria-hidden
+                      >
+                        {selected ? <Check className="size-3" /> : null}
+                      </span>
+                      <EndpointDetails endpoint={endpoint} />
+                    </button>
+                  );
+                })}
+              </div>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
       )}
+
+      {error !== null && <p className="text-xs text-destructive">{error}</p>}
     </section>
+  );
+}
+
+function EndpointSummary({ endpoint }: { endpoint: AdvertisedEndpoint }) {
+  return (
+    <div className="mt-3 rounded-lg border border-border/50 bg-muted/20 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="truncate text-xs font-medium text-foreground">
+          Default endpoint
+        </span>
+        <EndpointBadge endpoint={endpoint} />
+      </div>
+      <p className="mt-1 truncate text-xs text-muted-foreground">
+        {endpoint.label} · {endpoint.wsBaseUrl}
+      </p>
+    </div>
+  );
+}
+
+function EndpointDetails({ endpoint }: { endpoint: AdvertisedEndpoint }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="truncate text-sm font-medium text-foreground">
+          {endpoint.label}
+        </div>
+        <EndpointBadge endpoint={endpoint} />
+      </div>
+      <div className="mt-1 flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+        <span>{endpoint.providerKind}</span>
+        <span>·</span>
+        <span>{endpoint.reachability}</span>
+        <span>·</span>
+        <span>{endpoint.compatibility.hostedHttpsApp}</span>
+        <span>·</span>
+        <span>{endpoint.status}</span>
+      </div>
+      <p className="mt-1 break-all text-xs text-muted-foreground">
+        {endpoint.wsBaseUrl}
+      </p>
+    </div>
+  );
+}
+
+function EndpointBadge({ endpoint }: { endpoint: AdvertisedEndpoint }) {
+  return (
+    <span className="shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+      {endpoint.reachability}
+    </span>
   );
 }

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -30,9 +30,26 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const relayErrorMessage = (cause: unknown): string => {
   const formatted = formatError(cause);
-  return formatted.includes("not_signed_in")
-    ? "Sign in before linking this Mac to your account."
-    : formatted;
+  if (formatted.includes("not_signed_in")) {
+    return "Sign in before linking this Mac to your account.";
+  }
+  if (
+    formatted.includes("relay_auth_rejected") ||
+    formatted.includes("invalid_workos_token") ||
+    formatted.includes("relay_401")
+  ) {
+    return "We couldn't verify your sign-in. Sign out, sign in again, and try connecting this Mac once more.";
+  }
+  if (
+    formatted.includes("Failed to fetch") ||
+    formatted.includes("NetworkError") ||
+    formatted.includes("relay_502") ||
+    formatted.includes("relay_503") ||
+    formatted.includes("relay_504")
+  ) {
+    return "We couldn't reach the device relay. Check your internet connection and try again.";
+  }
+  return "Something went wrong while updating this Mac. Try again.";
 };
 
 const showRelayErrorToast = (title: string, cause: unknown): void => {

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -170,12 +170,13 @@ export function DevicesPane() {
                 </span>
               </div>
               <p className="mt-1 truncate text-xs text-muted-foreground">
-                {status?.heartbeatActive === true ? "Online · " : "Idle · "}
-                linked to {status?.relayUrl}
+                {status?.heartbeatActive === true ? "Online" : "Idle"} · Linked
+                to your account
               </p>
             </div>
             <Button
-              variant="destructive-outline"
+              variant="destructive"
+              className="min-w-20"
               onClick={() => void onUnlink()}
               disabled={busy}
             >
@@ -281,7 +282,7 @@ function EndpointSummary({ endpoint }: { endpoint: AdvertisedEndpoint }) {
         <EndpointBadge endpoint={endpoint} />
       </div>
       <p className="mt-1 truncate text-xs text-muted-foreground">
-        {endpoint.label} · {endpoint.wsBaseUrl}
+        {endpoint.label} · {endpoint.status}
       </p>
     </div>
   );
@@ -305,9 +306,6 @@ function EndpointDetails({ endpoint }: { endpoint: AdvertisedEndpoint }) {
         <span>·</span>
         <span>{endpoint.status}</span>
       </div>
-      <p className="mt-1 break-all text-xs text-muted-foreground">
-        {endpoint.wsBaseUrl}
-      </p>
     </div>
   );
 }

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -19,7 +19,6 @@ import {
 } from "../ui/collapsible.tsx";
 import {
   Frame,
-  FrameDescription,
   FrameFooter,
   FrameHeader,
   FramePanel,
@@ -162,37 +161,33 @@ export function DevicesPane() {
     <section className="flex min-h-0 flex-1 flex-col gap-4 p-6">
       {linked ? (
         <Frame>
-          <FrameHeader className="flex-row items-start justify-between gap-3 px-3 py-2.5">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <span
-                  className={
-                    status?.heartbeatActive === true
-                      ? "size-2 rounded-full bg-emerald-500"
-                      : "size-2 rounded-full bg-muted-foreground/40"
-                  }
-                  aria-hidden
-                />
-                <FrameTitle className="truncate">
-                  {status?.label ?? "This Mac"}
-                </FrameTitle>
-              </div>
-              <FrameDescription className="mt-1 truncate text-xs">
-                {status?.heartbeatActive === true ? "Online" : "Idle"} · Linked
-                to your account
-              </FrameDescription>
-            </div>
+          <FrameHeader className="flex-row items-center gap-2 px-3 py-2.5">
+            <span
+              className={
+                status?.heartbeatActive === true
+                  ? "size-2 rounded-full bg-emerald-500"
+                  : "size-2 rounded-full bg-muted-foreground/40"
+              }
+              aria-hidden
+            />
+            <FrameTitle className="truncate">
+              {status?.label ?? "This Mac"}
+            </FrameTitle>
           </FrameHeader>
-          {selectedEndpoint !== null && (
-            <FramePanel className="p-3">
+          <FramePanel className="space-y-3 p-3">
+            <p className="text-xs text-muted-foreground">
+              {status?.heartbeatActive === true ? "Online" : "Idle"} · Linked to
+              your account
+            </p>
+            {selectedEndpoint !== null && (
               <EndpointSummary endpoint={selectedEndpoint} />
-            </FramePanel>
-          )}
-          <FrameFooter className="flex items-center justify-between gap-3 px-3 py-2.5">
-            <p className="min-w-0 text-xs text-muted-foreground">
+            )}
+            <p className="text-xs text-muted-foreground">
               This Mac is reachable from your phone after you sign in to the
               same account there.
             </p>
+          </FramePanel>
+          <FrameFooter className="flex justify-end px-3 py-2.5">
             <Button
               variant="destructive"
               className="min-w-20"
@@ -207,11 +202,11 @@ export function DevicesPane() {
         <Frame>
           <FrameHeader className="px-3 py-2.5">
             <FrameTitle>This Mac</FrameTitle>
-            <FrameDescription className="mt-1">
-              Link this Mac to your account so it shows up on your phone.
-            </FrameDescription>
           </FrameHeader>
-          <FramePanel className="p-3">
+          <FramePanel className="space-y-3 p-3">
+            <p className="text-sm text-muted-foreground">
+              Link this Mac to your account so it shows up on your phone.
+            </p>
             <div className="flex flex-col gap-2">
               <label className="text-sm font-medium text-foreground">
                 Name (optional)
@@ -236,13 +231,7 @@ export function DevicesPane() {
           <Frame>
             <FrameHeader className="px-3 py-2.5">
               <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
-                <div>
-                  <FrameTitle>All endpoints</FrameTitle>
-                  <FrameDescription className="mt-1 text-xs">
-                    {advertisedEndpoints.length} advertised route
-                    {advertisedEndpoints.length === 1 ? "" : "s"}
-                  </FrameDescription>
-                </div>
+                <FrameTitle>All endpoints</FrameTitle>
                 <ChevronDown
                   className={
                     endpointsOpen
@@ -255,6 +244,10 @@ export function DevicesPane() {
             </FrameHeader>
             <CollapsibleContent>
               <FramePanel className="p-3">
+                <div className="mb-2 text-xs text-muted-foreground">
+                  {advertisedEndpoints.length} advertised route
+                  {advertisedEndpoints.length === 1 ? "" : "s"}
+                </div>
                 <div className="flex flex-col gap-2">
                   {advertisedEndpoints.map((endpoint) => {
                     const selected = selectedEndpoint?.id === endpoint.id;

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -36,10 +36,27 @@ const relayErrorMessage = (cause: unknown): string => {
   }
   if (
     formatted.includes("relay_auth_rejected") ||
-    formatted.includes("invalid_workos_token") ||
-    formatted.includes("relay_401")
+    formatted.includes("invalid_workos_token")
   ) {
-    return "We couldn't verify your sign-in. Sign out, sign in again, and try connecting this Mac once more.";
+    return "We couldn't verify your account session. Sign out, sign in again, and try connecting this Mac once more.";
+  }
+  if (formatted.includes("cloudflared_not_found")) {
+    return "The secure tunnel is ready, but cloudflared is not installed on this Mac. Install cloudflared, then try again.";
+  }
+  if (formatted.includes("tunnel_provision_failed")) {
+    return "We couldn't set up the secure tunnel. Check the Cloudflare token permissions and try again.";
+  }
+  if (
+    formatted.includes("invalid_challenge") ||
+    formatted.includes("expired_challenge")
+  ) {
+    return "That connection attempt expired. Try connecting this Mac again.";
+  }
+  if (formatted.includes("relay_401")) {
+    return "The device relay rejected this request. Try signing in again if it keeps happening.";
+  }
+  if (formatted.includes("relay_403")) {
+    return "The device relay rejected the tunnel setup. Check the Cloudflare permissions and try again.";
   }
   if (
     formatted.includes("Failed to fetch") ||

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -58,7 +58,6 @@ export function DevicesPane() {
   const [status, setStatus] = useState<RelayLinkStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
-  const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
   const [label, setLabel] = useState("");
   const [endpointOverrideId, setEndpointOverrideId] = useState<string | null>(
     () => readEndpointOverride(),
@@ -84,13 +83,12 @@ export function DevicesPane() {
   }, [refresh]);
 
   const onConnect = useCallback(async () => {
-    if (relayUrl.trim().length === 0) return;
     setBusy(true);
     try {
       const client = await getRpcClient();
       const next = await Effect.runPromise(
         client.relay.link({
-          relayUrl: relayUrl.trim().replace(/\/$/, ""),
+          relayUrl: DEFAULT_RELAY_URL.trim().replace(/\/$/, ""),
           label: label.trim().length > 0 ? label.trim() : undefined,
         }),
       );
@@ -100,7 +98,7 @@ export function DevicesPane() {
     } finally {
       setBusy(false);
     }
-  }, [relayUrl, label]);
+  }, [label]);
 
   const onUnlink = useCallback(async () => {
     setBusy(true);
@@ -178,19 +176,10 @@ export function DevicesPane() {
       ) : (
         <div className="rounded-xl border border-border/50 bg-background p-4">
           <p className="text-sm text-muted-foreground">
-            Link this Mac to your account so it shows up on your phone. You must
-            be signed in.
+            Link this Mac to your account so it shows up on your phone.
           </p>
           <div className="mt-3 flex flex-col gap-2">
             <label className="text-sm font-medium text-foreground">
-              Relay URL
-            </label>
-            <Input
-              value={relayUrl}
-              onChange={(event) => setRelayUrl(event.target.value)}
-              placeholder="https://relay.stuff.md"
-            />
-            <label className="mt-1 text-sm font-medium text-foreground">
               Name (optional)
             </label>
             <Input
@@ -201,7 +190,7 @@ export function DevicesPane() {
             <Button
               className="mt-2 self-start"
               onClick={() => void onConnect()}
-              disabled={busy || relayUrl.trim().length === 0}
+              disabled={busy}
             >
               {busy ? "Connecting…" : "Connect this Mac"}
             </Button>

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -17,6 +17,14 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../ui/collapsible.tsx";
+import {
+  Frame,
+  FrameDescription,
+  FrameFooter,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "../ui/frame.tsx";
 import { Input } from "../ui/input.tsx";
 import { Spinner } from "../ui/spinner.tsx";
 import { toastManager } from "../ui/toast.tsx";
@@ -153,8 +161,8 @@ export function DevicesPane() {
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-4 p-6">
       {linked ? (
-        <div className="rounded-xl border border-border/50 bg-background p-4">
-          <div className="flex items-center justify-between gap-4">
+        <Frame>
+          <FrameHeader className="flex-row items-start justify-between gap-3 px-3 py-2.5">
             <div className="min-w-0">
               <div className="flex items-center gap-2">
                 <span
@@ -165,15 +173,26 @@ export function DevicesPane() {
                   }
                   aria-hidden
                 />
-                <span className="truncate text-sm font-medium text-foreground">
+                <FrameTitle className="truncate">
                   {status?.label ?? "This Mac"}
-                </span>
+                </FrameTitle>
               </div>
-              <p className="mt-1 truncate text-xs text-muted-foreground">
+              <FrameDescription className="mt-1 truncate text-xs">
                 {status?.heartbeatActive === true ? "Online" : "Idle"} · Linked
                 to your account
-              </p>
+              </FrameDescription>
             </div>
+          </FrameHeader>
+          {selectedEndpoint !== null && (
+            <FramePanel className="p-3">
+              <EndpointSummary endpoint={selectedEndpoint} />
+            </FramePanel>
+          )}
+          <FrameFooter className="flex items-center justify-between gap-3 px-3 py-2.5">
+            <p className="min-w-0 text-xs text-muted-foreground">
+              This Mac is reachable from your phone after you sign in to the
+              same account there.
+            </p>
             <Button
               variant="destructive"
               className="min-w-20"
@@ -182,90 +201,88 @@ export function DevicesPane() {
             >
               Unlink
             </Button>
-          </div>
-          {selectedEndpoint !== null && (
-            <EndpointSummary endpoint={selectedEndpoint} />
-          )}
-          <p className="mt-3 text-xs text-muted-foreground">
-            This Mac is reachable from your phone after you sign in to the same
-            account there.
-          </p>
-        </div>
+          </FrameFooter>
+        </Frame>
       ) : (
-        <div className="rounded-xl border border-border/50 bg-background p-4">
-          <p className="text-sm text-muted-foreground">
-            Link this Mac to your account so it shows up on your phone.
-          </p>
-          <div className="mt-3 flex flex-col gap-2">
-            <label className="text-sm font-medium text-foreground">
-              Name (optional)
-            </label>
-            <Input
-              value={label}
-              onChange={(event) => setLabel(event.target.value)}
-              placeholder="This Mac"
-            />
-            <Button
-              className="mt-2 self-start"
-              onClick={() => void onConnect()}
-              disabled={busy}
-            >
+        <Frame>
+          <FrameHeader className="px-3 py-2.5">
+            <FrameTitle>This Mac</FrameTitle>
+            <FrameDescription className="mt-1">
+              Link this Mac to your account so it shows up on your phone.
+            </FrameDescription>
+          </FrameHeader>
+          <FramePanel className="p-3">
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-foreground">
+                Name (optional)
+              </label>
+              <Input
+                value={label}
+                onChange={(event) => setLabel(event.target.value)}
+                placeholder="This Mac"
+              />
+            </div>
+          </FramePanel>
+          <FrameFooter className="flex justify-end px-3 py-2.5">
+            <Button onClick={() => void onConnect()} disabled={busy}>
               {busy ? "Connecting…" : "Connect this Mac"}
             </Button>
-          </div>
-        </div>
+          </FrameFooter>
+        </Frame>
       )}
 
       {advertisedEndpoints.length > 0 && (
         <Collapsible open={endpointsOpen} onOpenChange={setEndpointsOpen}>
-          <div className="rounded-xl border border-border/50 bg-background p-4">
-            <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
-              <div>
-                <div className="text-sm font-medium text-foreground">
-                  All endpoints
+          <Frame>
+            <FrameHeader className="px-3 py-2.5">
+              <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
+                <div>
+                  <FrameTitle>All endpoints</FrameTitle>
+                  <FrameDescription className="mt-1 text-xs">
+                    {advertisedEndpoints.length} advertised route
+                    {advertisedEndpoints.length === 1 ? "" : "s"}
+                  </FrameDescription>
                 </div>
-                <div className="text-xs text-muted-foreground">
-                  {advertisedEndpoints.length} advertised route
-                  {advertisedEndpoints.length === 1 ? "" : "s"}
-                </div>
-              </div>
-              <ChevronDown
-                className={
-                  endpointsOpen
-                    ? "size-4 rotate-180 text-muted-foreground transition-transform"
-                    : "size-4 text-muted-foreground transition-transform"
-                }
-                aria-hidden
-              />
-            </CollapsibleTrigger>
+                <ChevronDown
+                  className={
+                    endpointsOpen
+                      ? "size-4 rotate-180 text-muted-foreground transition-transform"
+                      : "size-4 text-muted-foreground transition-transform"
+                  }
+                  aria-hidden
+                />
+              </CollapsibleTrigger>
+            </FrameHeader>
             <CollapsibleContent>
-              <div className="mt-3 flex flex-col gap-2">
-                {advertisedEndpoints.map((endpoint) => {
-                  const selected = selectedEndpoint?.id === endpoint.id;
-                  return (
-                    <button
-                      key={endpoint.id}
-                      type="button"
-                      className="flex min-w-0 items-start gap-3 rounded-lg border border-border/50 bg-muted/20 p-3 text-left hover:bg-muted/40"
-                      onClick={() => onSelectEndpoint(endpoint.id)}
-                    >
-                      <span
-                        className={
-                          selected
-                            ? "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
-                            : "mt-0.5 size-5 shrink-0 rounded-full border border-border"
-                        }
-                        aria-hidden
+              <FramePanel className="p-3">
+                <div className="flex flex-col gap-2">
+                  {advertisedEndpoints.map((endpoint) => {
+                    const selected = selectedEndpoint?.id === endpoint.id;
+                    return (
+                      <button
+                        key={endpoint.id}
+                        type="button"
+                        className="flex min-w-0 items-start gap-3 rounded-lg border border-border/50 bg-muted/20 p-3 text-left hover:bg-muted/40"
+                        onClick={() => onSelectEndpoint(endpoint.id)}
                       >
-                        {selected ? <Check className="size-3" /> : null}
-                      </span>
-                      <EndpointDetails endpoint={endpoint} />
-                    </button>
-                  );
-                })}
-              </div>
+                        <span
+                          className={
+                            selected
+                              ? "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                              : "mt-0.5 size-5 shrink-0 rounded-full border border-border"
+                          }
+                          aria-hidden
+                        >
+                          {selected ? <Check className="size-3" /> : null}
+                        </span>
+                        <EndpointDetails endpoint={endpoint} />
+                      </button>
+                    );
+                  })}
+                </div>
+              </FramePanel>
             </CollapsibleContent>
-          </div>
+          </Frame>
         </Collapsible>
       )}
     </section>
@@ -274,7 +291,7 @@ export function DevicesPane() {
 
 function EndpointSummary({ endpoint }: { endpoint: AdvertisedEndpoint }) {
   return (
-    <div className="mt-3 rounded-lg border border-border/50 bg-muted/20 p-3">
+    <div>
       <div className="flex items-center justify-between gap-3">
         <span className="truncate text-xs font-medium text-foreground">
           Default endpoint

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -91,6 +91,11 @@ export function DevicesPane() {
     }
   }, [refresh]);
 
+  const onSelectEndpoint = useCallback((endpointId: string) => {
+    setEndpointOverrideId(endpointId);
+    writeEndpointOverride(endpointId);
+  }, []);
+
   if (loading) {
     return (
       <section className="flex flex-1 items-center justify-center p-6">
@@ -105,11 +110,6 @@ export function DevicesPane() {
     advertisedEndpoints,
     endpointOverrideId,
   );
-
-  const onSelectEndpoint = useCallback((endpointId: string) => {
-    setEndpointOverrideId(endpointId);
-    writeEndpointOverride(endpointId);
-  }, []);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-4 p-6">

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { Check, ChevronDown } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { AdvertisedEndpoint, RelayLinkStatus } from "@zuse/wire";
 
@@ -98,6 +98,7 @@ export function DevicesPane() {
     () => readEndpointOverride(),
   );
   const [endpointsOpen, setEndpointsOpen] = useState(false);
+  const actionInFlightRef = useRef(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -118,6 +119,10 @@ export function DevicesPane() {
   }, [refresh]);
 
   const onConnect = useCallback(async () => {
+    if (actionInFlightRef.current) {
+      return;
+    }
+    actionInFlightRef.current = true;
     setBusy(true);
     try {
       const client = await getRpcClient();
@@ -131,11 +136,16 @@ export function DevicesPane() {
     } catch (cause) {
       showRelayErrorToast("Could not connect this Mac", cause);
     } finally {
+      actionInFlightRef.current = false;
       setBusy(false);
     }
   }, [label]);
 
   const onUnlink = useCallback(async () => {
+    if (actionInFlightRef.current) {
+      return;
+    }
+    actionInFlightRef.current = true;
     setBusy(true);
     try {
       const client = await getRpcClient();
@@ -144,6 +154,7 @@ export function DevicesPane() {
     } catch (cause) {
       showRelayErrorToast("Could not unlink this Mac", cause);
     } finally {
+      actionInFlightRef.current = false;
       setBusy(false);
     }
   }, [refresh]);

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -17,13 +17,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../ui/collapsible.tsx";
-import {
-  Frame,
-  FrameFooter,
-  FrameHeader,
-  FramePanel,
-  FrameTitle,
-} from "../ui/frame.tsx";
+import { Frame, FrameFooter, FramePanel, FrameTitle } from "../ui/frame.tsx";
 import { Input } from "../ui/input.tsx";
 import { Spinner } from "../ui/spinner.tsx";
 import { toastManager } from "../ui/toast.tsx";
@@ -161,20 +155,20 @@ export function DevicesPane() {
     <section className="flex min-h-0 flex-1 flex-col gap-4 p-6">
       {linked ? (
         <Frame>
-          <FrameHeader className="flex-row items-center gap-2 px-3 py-2.5">
-            <span
-              className={
-                status?.heartbeatActive === true
-                  ? "size-2 rounded-full bg-emerald-500"
-                  : "size-2 rounded-full bg-muted-foreground/40"
-              }
-              aria-hidden
-            />
-            <FrameTitle className="truncate">
-              {status?.label ?? "This Mac"}
-            </FrameTitle>
-          </FrameHeader>
           <FramePanel className="space-y-3 p-3">
+            <div className="flex items-center gap-2">
+              <span
+                className={
+                  status?.heartbeatActive === true
+                    ? "size-2 rounded-full bg-emerald-500"
+                    : "size-2 rounded-full bg-muted-foreground/40"
+                }
+                aria-hidden
+              />
+              <FrameTitle className="truncate">
+                {status?.label ?? "This Mac"}
+              </FrameTitle>
+            </div>
             <p className="text-xs text-muted-foreground">
               {status?.heartbeatActive === true ? "Online" : "Idle"} · Linked to
               your account
@@ -200,10 +194,8 @@ export function DevicesPane() {
         </Frame>
       ) : (
         <Frame>
-          <FrameHeader className="px-3 py-2.5">
-            <FrameTitle>This Mac</FrameTitle>
-          </FrameHeader>
           <FramePanel className="space-y-3 p-3">
+            <FrameTitle>This Mac</FrameTitle>
             <p className="text-sm text-muted-foreground">
               Link this Mac to your account so it shows up on your phone.
             </p>
@@ -229,7 +221,7 @@ export function DevicesPane() {
       {advertisedEndpoints.length > 0 && (
         <Collapsible open={endpointsOpen} onOpenChange={setEndpointsOpen}>
           <Frame>
-            <FrameHeader className="px-3 py-2.5">
+            <FramePanel className="p-3">
               <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
                 <FrameTitle>All endpoints</FrameTitle>
                 <ChevronDown
@@ -241,9 +233,7 @@ export function DevicesPane() {
                   aria-hidden
                 />
               </CollapsibleTrigger>
-            </FrameHeader>
-            <CollapsibleContent>
-              <FramePanel className="p-3">
+              <CollapsibleContent>
                 <div className="mb-2 text-xs text-muted-foreground">
                   {advertisedEndpoints.length} advertised route
                   {advertisedEndpoints.length === 1 ? "" : "s"}
@@ -273,8 +263,8 @@ export function DevicesPane() {
                     );
                   })}
                 </div>
-              </FramePanel>
-            </CollapsibleContent>
+              </CollapsibleContent>
+            </FramePanel>
           </Frame>
         </Collapsible>
       )}

--- a/apps/renderer/src/lib/advertised-endpoints.ts
+++ b/apps/renderer/src/lib/advertised-endpoints.ts
@@ -1,0 +1,58 @@
+import type { AdvertisedEndpoint } from "@zuse/wire";
+
+export const DEVICES_ENDPOINT_OVERRIDE_KEY = "zuse.devices.endpointOverride.v1";
+
+const isHttpsEndpoint = (endpoint: AdvertisedEndpoint): boolean =>
+  endpoint.httpBaseUrl.startsWith("https://") &&
+  endpoint.wsBaseUrl.startsWith("wss://");
+
+const rankEndpoint = (endpoint: AdvertisedEndpoint): number => {
+  if (isHttpsEndpoint(endpoint)) return 0;
+  if (endpoint.reachability === "lan") return 1;
+  if (endpoint.reachability === "loopback") return 2;
+  return 3;
+};
+
+export const selectAdvertisedEndpoint = (
+  endpoints: ReadonlyArray<AdvertisedEndpoint> | undefined,
+  overrideId?: string | null,
+): AdvertisedEndpoint | null => {
+  if (endpoints === undefined || endpoints.length === 0) return null;
+
+  const override = overrideId
+    ? endpoints.find((endpoint) => endpoint.id === overrideId)
+    : undefined;
+  if (override !== undefined) return override;
+
+  const serverDefault = endpoints.find((endpoint) => endpoint.isDefault);
+  if (serverDefault !== undefined) return serverDefault;
+
+  return (
+    [...endpoints].sort((a, b) => rankEndpoint(a) - rankEndpoint(b))[0] ?? null
+  );
+};
+
+export const readEndpointOverride = (): string | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = window.localStorage
+      .getItem(DEVICES_ENDPOINT_OVERRIDE_KEY)
+      ?.trim();
+    return value && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+export const writeEndpointOverride = (endpointId: string | null): void => {
+  if (typeof window === "undefined") return;
+  try {
+    if (endpointId === null) {
+      window.localStorage.removeItem(DEVICES_ENDPOINT_OVERRIDE_KEY);
+    } else {
+      window.localStorage.setItem(DEVICES_ENDPOINT_OVERRIDE_KEY, endpointId);
+    }
+  } catch {
+    // Endpoint override is a convenience preference; ignore storage failures.
+  }
+};

--- a/apps/renderer/src/store/auth.ts
+++ b/apps/renderer/src/store/auth.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 
 import type { AuthState } from "@zuse/wire";
 
+import { toastManager } from "../components/ui/toast.tsx";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import {
   readStorageWithLegacy,
@@ -56,6 +57,21 @@ const writeDisplayName = (value: string): void => {
 };
 
 const SIGNED_OUT: AuthState = { _tag: "SignedOut" };
+
+const signInFailureMessage = (err: unknown): string =>
+  typeof err === "object" &&
+  err !== null &&
+  "_tag" in err &&
+  err._tag === "AuthCancelledError"
+    ? "No sign-in callback was received. Check the WorkOS client ID and redirect URI, then try again."
+    : typeof err === "object" &&
+        err !== null &&
+        "reason" in err &&
+        typeof err.reason === "string"
+      ? err.reason
+      : err instanceof Error
+        ? err.message
+        : "Sign-in failed. Please try again.";
 
 type AuthStore = {
   /** null until the first getSession / stream emit resolves. */
@@ -125,6 +141,11 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   signIn: async () => {
     if (get().signingIn) return;
     set({ signingIn: true, error: null });
+    toastManager.add({
+      type: "info",
+      title: "Opening browser sign-in",
+      description: "Complete WorkOS sign-in in your browser.",
+    });
     try {
       const client = await getRpcClient();
       // Match the Effect to a result object so a user-cancel (silent) and a
@@ -141,18 +162,26 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         set({ state: result.next, signingIn: false, error: null });
         return;
       }
+      const message = signInFailureMessage(result.err);
       set({
         signingIn: false,
-        error:
-          result.err._tag === "AuthCancelledError"
-            ? "No sign-in callback was received. Check the WorkOS client ID and redirect URI, then try again."
-            : ("reason" in result.err && result.err.reason) ||
-              "Sign-in failed. Please try again.",
+        error: message,
+      });
+      toastManager.add({
+        type: "error",
+        title: "Sign-in failed",
+        description: message,
       });
     } catch (err) {
+      const message = signInFailureMessage(err);
       set({
         signingIn: false,
-        error: err instanceof Error ? err.message : "Sign-in failed.",
+        error: message,
+      });
+      toastManager.add({
+        type: "error",
+        title: "Sign-in failed",
+        description: message,
       });
     }
   },

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -364,7 +364,7 @@ body,
   --accent-green: hsl(131 72% 59%);
   --accent-blue: hsl(220 96% 68%);
   --accent-amber: hsl(18 96% 62%);
-  --accent-red: hsl(0 91% 71%);
+  --accent-red: hsl(0 84% 60%);
   --accent-zinc: hsl(72 2% 63%);
 
   --secondary: hsl(72 4% 10%);
@@ -380,8 +380,8 @@ body,
   --accent: hsl(72 4% 27%);
   --accent-foreground: hsl(72 4% 92%);
 
-  --destructive: hsl(0 91% 71%);
-  --destructive-foreground: hsl(72 5% 6%);
+  --destructive: hsl(0 84% 52%);
+  --destructive-foreground: hsl(0 0% 100%);
 
   --success: hsl(131 72% 59%);
   --success-foreground: hsl(130 66% 10%);
@@ -392,7 +392,7 @@ body,
   --info: hsl(220 96% 68%);
   --info-foreground: hsl(217 45% 14%);
 
-  --alert-error-bg: hsl(360 15% 22%);
+  --alert-error-bg: hsl(0 54% 18%);
   --alert-warning-bg: hsl(360 15% 22%);
   --alert-info-bg: hsl(217 45% 18%);
   --alert-success-bg: hsl(130 64% 11%);
@@ -422,7 +422,7 @@ body,
   --chart-2: hsl(131 72% 59%);
   --chart-3: hsl(18 96% 62%);
   --chart-4: hsl(220 96% 68%);
-  --chart-5: hsl(0 91% 71%);
+  --chart-5: hsl(0 84% 60%);
 
   --user-bubble: hsl(72 4% 13%);
   --user-bubble-foreground: hsl(72 4% 92%);

--- a/apps/renderer/test/advertised-endpoints.test.ts
+++ b/apps/renderer/test/advertised-endpoints.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+
+import type { AdvertisedEndpoint } from "@zuse/wire";
+
+import { selectAdvertisedEndpoint } from "../src/lib/advertised-endpoints.ts";
+
+const endpoint = (
+  input: Partial<AdvertisedEndpoint> &
+    Pick<AdvertisedEndpoint, "id" | "reachability">,
+): AdvertisedEndpoint =>
+  ({
+    label: input.id,
+    providerKind: "core",
+    httpBaseUrl:
+      input.reachability === "tunnel"
+        ? `https://${input.id}.example.test`
+        : `http://${input.id}.example.test`,
+    wsBaseUrl:
+      input.reachability === "tunnel"
+        ? `wss://${input.id}.example.test/rpc`
+        : `ws://${input.id}.example.test`,
+    compatibility: {
+      hostedHttpsApp:
+        input.reachability === "tunnel"
+          ? "compatible"
+          : "mixed-content-blocked",
+    },
+    status: "available",
+    isDefault: false,
+    ...input,
+  }) as AdvertisedEndpoint;
+
+describe("selectAdvertisedEndpoint", () => {
+  it("uses a valid user override by stable endpoint id", () => {
+    const endpoints = [
+      endpoint({ id: "core:lan", reachability: "lan" }),
+      endpoint({
+        id: "tunnel:managed-relay",
+        reachability: "tunnel",
+        isDefault: true,
+      }),
+    ];
+
+    expect(selectAdvertisedEndpoint(endpoints, "core:lan")?.id).toBe(
+      "core:lan",
+    );
+  });
+
+  it("ignores stale overrides and falls back to the server default", () => {
+    const endpoints = [
+      endpoint({ id: "core:lan", reachability: "lan" }),
+      endpoint({
+        id: "tunnel:managed-relay",
+        reachability: "tunnel",
+        isDefault: true,
+      }),
+    ];
+
+    expect(selectAdvertisedEndpoint(endpoints, "missing")?.id).toBe(
+      "tunnel:managed-relay",
+    );
+  });
+
+  it("prefers hosted HTTPS compatible endpoints without server default", () => {
+    const endpoints = [
+      endpoint({ id: "core:loopback", reachability: "loopback" }),
+      endpoint({ id: "core:lan", reachability: "lan" }),
+      endpoint({ id: "tunnel:managed-relay", reachability: "tunnel" }),
+    ];
+
+    expect(selectAdvertisedEndpoint(endpoints, null)?.id).toBe(
+      "tunnel:managed-relay",
+    );
+  });
+});

--- a/apps/server/src/auth/services/auth-shell.ts
+++ b/apps/server/src/auth/services/auth-shell.ts
@@ -1,5 +1,7 @@
 import { Context, type Effect } from "effect";
 
+import type { AuthFlowError } from "@zuse/wire";
+
 /**
  * The host-shell seam for the OAuth deep-link flow — the auth analogue of
  * `FolderPicker`. `apps/server` stays free of any electron import (ADR 0007);
@@ -17,7 +19,7 @@ import { Context, type Effect } from "effect";
  */
 export interface AuthShellShape {
   readonly redirectUri: string;
-  readonly open: (url: string) => Effect.Effect<void>;
+  readonly open: (url: string) => Effect.Effect<void, AuthFlowError>;
   readonly onCallbackUrl: (
     handler: (url: string) => void,
   ) => Effect.Effect<void>;

--- a/apps/server/src/lan-auth/advertised-endpoints.ts
+++ b/apps/server/src/lan-auth/advertised-endpoints.ts
@@ -1,0 +1,131 @@
+import {
+  AdvertisedEndpoint,
+  type AdvertisedEndpointHostedHttpsCompatibility,
+  type AdvertisedEndpointReachability,
+  type AdvertisedEndpointStatus,
+} from "@zuse/wire";
+
+import type { LanAuthConfigShape } from "./services/lan-auth-service.ts";
+
+export interface RelayEndpointConfig {
+  readonly tunnelHostname?: string;
+  readonly linked: boolean;
+  readonly heartbeatActive: boolean;
+}
+
+const isLoopbackHost = (host: string): boolean =>
+  host === "127.0.0.1" || host === "::1" || host === "localhost";
+
+const isHttpsEndpoint = (httpBaseUrl: string, wsBaseUrl: string): boolean =>
+  httpBaseUrl.startsWith("https://") && wsBaseUrl.startsWith("wss://");
+
+const compatibilityFor = (
+  httpBaseUrl: string,
+  wsBaseUrl: string,
+): AdvertisedEndpointHostedHttpsCompatibility =>
+  isHttpsEndpoint(httpBaseUrl, wsBaseUrl)
+    ? "compatible"
+    : "mixed-content-blocked";
+
+const defaultRank = (endpoint: AdvertisedEndpoint): number => {
+  if (isHttpsEndpoint(endpoint.httpBaseUrl, endpoint.wsBaseUrl)) return 0;
+  if (endpoint.reachability === "lan") return 1;
+  if (endpoint.reachability === "loopback") return 2;
+  return 3;
+};
+
+const withDefault = (
+  endpoints: ReadonlyArray<AdvertisedEndpoint>,
+): ReadonlyArray<AdvertisedEndpoint> => {
+  if (endpoints.length === 0) return endpoints;
+  const defaultId = [...endpoints].sort(
+    (a, b) => defaultRank(a) - defaultRank(b),
+  )[0]!.id;
+  return endpoints.map((endpoint) =>
+    AdvertisedEndpoint.make({
+      ...endpoint,
+      isDefault: endpoint.id === defaultId,
+    }),
+  );
+};
+
+const coreEndpoint = (input: {
+  readonly id: string;
+  readonly label: string;
+  readonly host: string;
+  readonly port: number;
+  readonly reachability: AdvertisedEndpointReachability;
+}): AdvertisedEndpoint =>
+  AdvertisedEndpoint.make({
+    id: input.id,
+    label: input.label,
+    providerKind: "core",
+    httpBaseUrl: `http://${input.host}:${input.port}`,
+    wsBaseUrl: `ws://${input.host}:${input.port}`,
+    reachability: input.reachability,
+    compatibility: { hostedHttpsApp: "mixed-content-blocked" },
+    status: "available",
+    isDefault: false,
+  });
+
+export const buildAdvertisedEndpoints = (input: {
+  readonly lan: LanAuthConfigShape;
+  readonly relay?: RelayEndpointConfig | null;
+}): ReadonlyArray<AdvertisedEndpoint> => {
+  const endpoints: AdvertisedEndpoint[] = [];
+  const port = input.lan.port;
+
+  if (port !== null) {
+    const advertisedHost = input.lan.advertisedHost;
+    if (advertisedHost !== null && !isLoopbackHost(advertisedHost)) {
+      endpoints.push(
+        coreEndpoint({
+          id: "core:lan",
+          label: "LAN",
+          host: advertisedHost,
+          port,
+          reachability: "lan",
+        }),
+      );
+    }
+
+    endpoints.push(
+      coreEndpoint({
+        id: "core:loopback",
+        label: "This Mac",
+        host: "127.0.0.1",
+        port,
+        reachability: "loopback",
+      }),
+    );
+  }
+
+  const tunnelHostname = input.relay?.tunnelHostname?.trim();
+  if (tunnelHostname) {
+    const httpBaseUrl = `https://${tunnelHostname}`;
+    const wsBaseUrl = `wss://${tunnelHostname}/rpc`;
+    const status: AdvertisedEndpointStatus =
+      input.relay?.linked === true
+        ? input.relay.heartbeatActive
+          ? "available"
+          : "unknown"
+        : "unavailable";
+    endpoints.push(
+      AdvertisedEndpoint.make({
+        id: "tunnel:managed-relay",
+        label: "Managed tunnel",
+        providerKind: "tunnel",
+        httpBaseUrl,
+        wsBaseUrl,
+        reachability: "tunnel",
+        compatibility: {
+          hostedHttpsApp: compatibilityFor(httpBaseUrl, wsBaseUrl),
+        },
+        status,
+        isDefault: false,
+      }),
+    );
+  }
+
+  return withDefault(endpoints);
+};

--- a/apps/server/src/lan-auth/handlers.ts
+++ b/apps/server/src/lan-auth/handlers.ts
@@ -8,6 +8,7 @@ import {
   PairingError,
 } from "@zuse/wire";
 
+import { buildAdvertisedEndpoints } from "./advertised-endpoints.ts";
 import { LanAuthConfig } from "./services/lan-auth-service.ts";
 import { LanAuthService } from "./services/lan-auth-service.ts";
 
@@ -62,6 +63,7 @@ const ConnectDescribe = MemoizeRpcs.toLayerHandler("connect.describe", () =>
       environmentId: yield* auth.environmentId(),
       providerKind: "desktop",
       endpoint: EnvironmentEndpoint.make({ httpBaseUrl, wsBaseUrl }),
+      advertisedEndpoints: buildAdvertisedEndpoints({ lan: config }),
     });
   }).pipe(
     Effect.mapError((error) =>
@@ -79,10 +81,12 @@ const ConnectLinkProof = MemoizeRpcs.toLayerHandler(
       const auth = yield* LanAuthService;
       return yield* auth.linkProof(input);
     }).pipe(
-      Effect.mapError((error) =>
-        new ConnectAuthError({
-          reason: error instanceof Error ? error.message : "link_proof_failed",
-        }),
+      Effect.mapError(
+        (error) =>
+          new ConnectAuthError({
+            reason:
+              error instanceof Error ? error.message : "link_proof_failed",
+          }),
       ),
     ),
 );
@@ -94,11 +98,12 @@ const ConnectRelayConfig = MemoizeRpcs.toLayerHandler(
       const auth = yield* LanAuthService;
       yield* auth.saveRelayConfig(input);
     }).pipe(
-      Effect.mapError((error) =>
-        new ConnectAuthError({
-          reason:
-            error instanceof Error ? error.message : "relay_config_failed",
-        }),
+      Effect.mapError(
+        (error) =>
+          new ConnectAuthError({
+            reason:
+              error instanceof Error ? error.message : "relay_config_failed",
+          }),
       ),
     ),
 );

--- a/apps/server/src/lan-auth/layers/lan-auth-service.ts
+++ b/apps/server/src/lan-auth/layers/lan-auth-service.ts
@@ -311,17 +311,19 @@ export const LanAuthServiceLive = Layer.effect(
           const updatedAt = yield* nowIso;
           yield* sql`
             INSERT INTO relay_config
-              (environment_id, relay_url, relay_issuer, environment_credential, label, connector_token, updated_at)
+              (environment_id, relay_url, relay_issuer, environment_credential, label, connector_token, tunnel_hostname, updated_at)
             VALUES
               (${input.environmentId}, ${input.relayUrl}, ${input.relayIssuer},
                ${input.environmentCredential}, ${input.label ?? null},
-               ${input.connectorToken ?? null}, ${updatedAt})
+               ${input.connectorToken ?? null}, ${input.tunnelHostname ?? null},
+               ${updatedAt})
             ON CONFLICT(environment_id) DO UPDATE SET
               relay_url = excluded.relay_url,
               relay_issuer = excluded.relay_issuer,
               environment_credential = excluded.environment_credential,
               label = excluded.label,
               connector_token = excluded.connector_token,
+              tunnel_hostname = excluded.tunnel_hostname,
               updated_at = excluded.updated_at
           `;
         }).pipe(Effect.asVoid, Effect.mapError(toLanAuthError)),
@@ -334,8 +336,9 @@ export const LanAuthServiceLive = Layer.effect(
             readonly environment_credential: string;
             readonly label: string | null;
             readonly connector_token: string | null;
+            readonly tunnel_hostname: string | null;
           }>`
-            SELECT relay_url, relay_issuer, environment_id, environment_credential, label, connector_token
+            SELECT relay_url, relay_issuer, environment_id, environment_credential, label, connector_token, tunnel_hostname
             FROM relay_config
             LIMIT 1
           `;
@@ -348,6 +351,7 @@ export const LanAuthServiceLive = Layer.effect(
             environmentCredential: row.environment_credential,
             label: row.label ?? undefined,
             connectorToken: row.connector_token ?? undefined,
+            tunnelHostname: row.tunnel_hostname ?? undefined,
           };
         }).pipe(Effect.mapError(toLanAuthError)),
       clearRelayConfig: () =>

--- a/apps/server/src/lan-auth/services/lan-auth-service.ts
+++ b/apps/server/src/lan-auth/services/lan-auth-service.ts
@@ -89,6 +89,8 @@ export interface LanAuthServiceShape {
     readonly label?: string;
     /** `cloudflared` connector token for the managed tunnel, if provisioned. */
     readonly connectorToken?: string;
+    /** Public hostname for the managed tunnel, if provisioned. */
+    readonly tunnelHostname?: string;
   }) => Effect.Effect<void, LanAuthError>;
   /** Current relay link, or null if this environment isn't linked. */
   readonly getRelayConfig: () => Effect.Effect<
@@ -99,6 +101,7 @@ export interface LanAuthServiceShape {
       readonly environmentCredential: string;
       readonly label: string | undefined;
       readonly connectorToken: string | undefined;
+      readonly tunnelHostname: string | undefined;
     } | null,
     LanAuthError
   >;

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -26,6 +26,7 @@ import { Migration0022AttachmentAbsPath } from "./migrations/0022_attachment_abs
 import { Migration0024RemoteConnectState } from "./migrations/0024_remote_connect_state.ts";
 import { Migration0025RelayEnvironmentKeys } from "./migrations/0025_relay_environment_keys.ts";
 import { Migration0026RelayConnectorToken } from "./migrations/0026_relay_connector_token.ts";
+import { Migration0027RelayTunnelHostname } from "./migrations/0027_relay_tunnel_hostname.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -70,6 +71,7 @@ export const MigrationsLive = Layer.effectDiscard(
       "0024_remote_connect_state": Migration0024RemoteConnectState,
       "0025_relay_environment_keys": Migration0025RelayEnvironmentKeys,
       "0026_relay_connector_token": Migration0026RelayConnectorToken,
+      "0027_relay_tunnel_hostname": Migration0027RelayTunnelHostname,
     }),
   }),
 );

--- a/apps/server/src/persistence/migrations/0027_relay_tunnel_hostname.ts
+++ b/apps/server/src/persistence/migrations/0027_relay_tunnel_hostname.ts
@@ -1,0 +1,18 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Persist the relay-managed tunnel hostname locally so the desktop can
+ * advertise its public endpoint after restart without re-linking.
+ * Idempotent.
+ */
+export const Migration0027RelayTunnelHostname = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(relay_config)
+  `;
+  if (!columns.some((column) => column.name === "tunnel_hostname")) {
+    yield* sql`ALTER TABLE relay_config ADD COLUMN tunnel_hostname TEXT`;
+  }
+});

--- a/apps/server/src/relay/handlers.ts
+++ b/apps/server/src/relay/handlers.ts
@@ -2,7 +2,10 @@ import { Effect, Layer } from "effect";
 
 import { ConnectAuthError, MemoizeRpcs, RelayLinkStatus } from "@zuse/wire";
 
-import { RelayLinkService, type RelayLinkStatusValue } from "./relay-link-service.ts";
+import {
+  RelayLinkService,
+  type RelayLinkStatusValue,
+} from "./relay-link-service.ts";
 
 const toStatus = (value: RelayLinkStatusValue): RelayLinkStatus =>
   RelayLinkStatus.make({
@@ -11,6 +14,7 @@ const toStatus = (value: RelayLinkStatusValue): RelayLinkStatus =>
     environmentId: value.environmentId,
     label: value.label,
     heartbeatActive: value.heartbeatActive,
+    advertisedEndpoints: value.advertisedEndpoints,
   });
 
 const toConnectError = (reason: string): ConnectAuthError =>

--- a/apps/server/src/relay/managed-tunnel-runtime.ts
+++ b/apps/server/src/relay/managed-tunnel-runtime.ts
@@ -2,6 +2,9 @@ import { Command, CommandExecutor } from "@effect/platform";
 import { Context, Data, Effect, Fiber, Layer, Ref, Schedule } from "effect";
 import fs from "node:fs";
 
+import { AppPaths } from "../app-paths.ts";
+import { appendRelayDiagnostic } from "./relay-diagnostics.ts";
+
 /**
  * Runs the `cloudflared` connector that backs the environment's managed tunnel.
  * The relay provisions the tunnel + hostname and hands back a connector token;
@@ -38,13 +41,16 @@ const CLOUDFLARED_CANDIDATES = [
 export const ManagedTunnelRuntimeLive: Layer.Layer<
   ManagedTunnelRuntime,
   never,
-  CommandExecutor.CommandExecutor
+  CommandExecutor.CommandExecutor | AppPaths
 > = Layer.scoped(
   ManagedTunnelRuntime,
   Effect.gen(function* () {
     const executor = yield* CommandExecutor.CommandExecutor;
+    const paths = yield* AppPaths;
     const fiberRef = yield* Ref.make<Fiber.RuntimeFiber<void> | null>(null);
     const binaryRef = yield* Ref.make<string | null>(null);
+    const log = (event: string, fields?: Record<string, unknown>) =>
+      appendRelayDiagnostic(paths, event, fields);
 
     const isExecutable = (path: string): boolean => {
       try {
@@ -63,8 +69,12 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
 
       for (const candidate of CLOUDFLARED_CANDIDATES) {
         if (candidate !== CLOUDFLARED && !isExecutable(candidate)) {
+          yield* log("cloudflared.resolve.skip_not_executable", {
+            candidate,
+          });
           continue;
         }
+        yield* log("cloudflared.resolve.try", { candidate });
         const ok = yield* Effect.scoped(
           Effect.gen(function* () {
             const proc = yield* executor.start(
@@ -76,10 +86,13 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
         ).pipe(Effect.catchAll(() => Effect.succeed(false)));
         if (ok) {
           yield* Ref.set(binaryRef, candidate);
+          yield* log("cloudflared.resolve.ok", { candidate });
           return candidate;
         }
+        yield* log("cloudflared.resolve.fail", { candidate });
       }
 
+      yield* log("cloudflared.resolve.not_found");
       return yield* Effect.fail(
         new ManagedTunnelError({
           reason:
@@ -108,7 +121,9 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
             connectorToken,
           ).pipe(Command.stdout("inherit"), Command.stderr("inherit"));
           const proc = yield* executor.start(command);
-          yield* proc.exitCode;
+          yield* log("cloudflared.process.started", { binary });
+          const exitCode = yield* proc.exitCode;
+          yield* log("cloudflared.process.exited", { binary, exitCode });
         }),
       );
 
@@ -120,6 +135,7 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
 
     const start = (connectorToken: string) =>
       Effect.gen(function* () {
+        yield* log("cloudflared.start");
         yield* ensureBinary;
         yield* stop;
         // Restart on crash with a short backoff; a daemon fiber so link() returns.
@@ -130,6 +146,7 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
           Effect.forkDaemon,
         );
         yield* Ref.set(fiberRef, fiber);
+        yield* log("cloudflared.start.ok");
       });
 
     // Ensure the connector is torn down when the runtime scope closes.

--- a/apps/server/src/relay/managed-tunnel-runtime.ts
+++ b/apps/server/src/relay/managed-tunnel-runtime.ts
@@ -1,13 +1,6 @@
 import { Command, CommandExecutor } from "@effect/platform";
-import {
-  Context,
-  Data,
-  Effect,
-  Fiber,
-  Layer,
-  Ref,
-  Schedule,
-} from "effect";
+import { Context, Data, Effect, Fiber, Layer, Ref, Schedule } from "effect";
+import fs from "node:fs";
 
 /**
  * Runs the `cloudflared` connector that backs the environment's managed tunnel.
@@ -27,13 +20,20 @@ export class ManagedTunnelRuntime extends Context.Tag(
   ManagedTunnelRuntime,
   {
     /** Launch (or relaunch) the connector for `connectorToken`. */
-    readonly start: (connectorToken: string) => Effect.Effect<void, ManagedTunnelError>;
+    readonly start: (
+      connectorToken: string,
+    ) => Effect.Effect<void, ManagedTunnelError>;
     /** Stop the connector if running. */
     readonly stop: () => Effect.Effect<void>;
   }
 >() {}
 
 const CLOUDFLARED = "cloudflared";
+const CLOUDFLARED_CANDIDATES = [
+  CLOUDFLARED,
+  "/opt/homebrew/bin/cloudflared",
+  "/usr/local/bin/cloudflared",
+] as const;
 
 export const ManagedTunnelRuntimeLive: Layer.Layer<
   ManagedTunnelRuntime,
@@ -44,25 +44,53 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
   Effect.gen(function* () {
     const executor = yield* CommandExecutor.CommandExecutor;
     const fiberRef = yield* Ref.make<Fiber.RuntimeFiber<void> | null>(null);
+    const binaryRef = yield* Ref.make<string | null>(null);
+
+    const isExecutable = (path: string): boolean => {
+      try {
+        fs.accessSync(path, fs.constants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const resolveBinary = Effect.gen(function* () {
+      const cached = yield* Ref.get(binaryRef);
+      if (cached !== null) {
+        return cached;
+      }
+
+      for (const candidate of CLOUDFLARED_CANDIDATES) {
+        if (candidate !== CLOUDFLARED && !isExecutable(candidate)) {
+          continue;
+        }
+        const ok = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const proc = yield* executor.start(
+              Command.make(candidate, "--version"),
+            );
+            const exitCode = yield* proc.exitCode;
+            return exitCode === 0;
+          }),
+        ).pipe(Effect.catchAll(() => Effect.succeed(false)));
+        if (ok) {
+          yield* Ref.set(binaryRef, candidate);
+          return candidate;
+        }
+      }
+
+      return yield* Effect.fail(
+        new ManagedTunnelError({
+          reason:
+            "cloudflared_not_found: install cloudflared and ensure it is on PATH",
+        }),
+      );
+    });
 
     // Preflight: fail fast with a clear message if the binary is missing, so the
     // link flow can surface an actionable error instead of a silent no-tunnel.
-    const ensureBinary = Effect.scoped(
-      Effect.gen(function* () {
-        const proc = yield* executor.start(
-          Command.make(CLOUDFLARED, "--version"),
-        );
-        yield* proc.exitCode;
-      }),
-    ).pipe(
-      Effect.mapError(
-        () =>
-          new ManagedTunnelError({
-            reason:
-              "cloudflared_not_found: install cloudflared and ensure it is on PATH",
-          }),
-      ),
-    );
+    const ensureBinary = resolveBinary;
 
     // One supervised run. The Scope kills the process on interrupt (stop/unlink
     // or app shutdown). `exitCode` only resolves when cloudflared dies, so a
@@ -70,8 +98,9 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
     const runOnce = (connectorToken: string) =>
       Effect.scoped(
         Effect.gen(function* () {
+          const binary = yield* ensureBinary;
           const command = Command.make(
-            CLOUDFLARED,
+            binary,
             "tunnel",
             "--no-autoupdate",
             "run",

--- a/apps/server/src/relay/relay-diagnostics.ts
+++ b/apps/server/src/relay/relay-diagnostics.ts
@@ -1,0 +1,41 @@
+import { Effect } from "effect";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { AppPaths } from "../app-paths.ts";
+
+type DiagnosticFields = Record<string, unknown>;
+
+const logPathFor = (paths: typeof AppPaths.Service): string =>
+  process.env.ZUSE_RELAY_LINK_LOG?.trim() ||
+  join(paths.userData, "logs", "relay-link.log");
+
+const safeFields = (fields: DiagnosticFields): DiagnosticFields =>
+  Object.fromEntries(
+    Object.entries(fields).map(([key, value]) => [
+      key,
+      value instanceof Error
+        ? { name: value.name, message: value.message }
+        : value,
+    ]),
+  );
+
+export const appendRelayDiagnostic = (
+  paths: typeof AppPaths.Service,
+  event: string,
+  fields: DiagnosticFields = {},
+): Effect.Effect<void> =>
+  Effect.sync(() => {
+    const logPath = logPathFor(paths);
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      event,
+      ...safeFields(fields),
+    });
+    try {
+      mkdirSync(dirname(logPath), { recursive: true });
+      appendFileSync(logPath, `${line}\n`, "utf8");
+    } catch {
+      // Diagnostics are best-effort and must never break app behavior.
+    }
+  });

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -56,7 +56,7 @@ const relayHttpErrorReason = async (response: Response): Promise<string> => {
     const body = JSON.parse(text) as { readonly error?: unknown };
     if (typeof body.error === "string") {
       if (response.status === 401 && body.error === "invalid_workos_token") {
-        return "Relay rejected the WorkOS token. Check that desktop, mobile, and relay use the same WorkOS client id.";
+        return "Relay rejected the sign-in token. Redeploy the relay if its WorkOS config changed, then sign in again.";
       }
       return `relay_${response.status}:${body.error}`;
     }

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -56,7 +56,7 @@ const relayHttpErrorReason = async (response: Response): Promise<string> => {
     const body = JSON.parse(text) as { readonly error?: unknown };
     if (typeof body.error === "string") {
       if (response.status === 401 && body.error === "invalid_workos_token") {
-        return "Relay rejected the sign-in token. Redeploy the relay if its WorkOS config changed, then sign in again.";
+        return "relay_auth_rejected";
       }
       return `relay_${response.status}:${body.error}`;
     }

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -2,6 +2,7 @@ import { Clock, Context, Data, Effect, Fiber, Layer, Ref } from "effect";
 
 import { RelayPaths, type EnvironmentId } from "@zuse/wire";
 
+import { AppPaths } from "../app-paths.ts";
 import { AuthService } from "../auth/services/auth-service.ts";
 import { buildAdvertisedEndpoints } from "../lan-auth/advertised-endpoints.ts";
 import {
@@ -11,6 +12,7 @@ import {
 } from "../lan-auth/services/lan-auth-service.ts";
 import { signEnvironmentLinkProof } from "./link-proof.ts";
 import { ManagedTunnelRuntime } from "./managed-tunnel-runtime.ts";
+import { appendRelayDiagnostic } from "./relay-diagnostics.ts";
 
 const HEARTBEAT_INTERVAL = "30 seconds";
 
@@ -108,7 +110,7 @@ const computeOrigin = (config: LanAuthConfigShape) => ({
 export const RelayLinkServiceLive: Layer.Layer<
   RelayLinkService,
   never,
-  LanAuthService | LanAuthConfig | AuthService | ManagedTunnelRuntime
+  LanAuthService | LanAuthConfig | AuthService | ManagedTunnelRuntime | AppPaths
 > = Layer.scoped(
   RelayLinkService,
   Effect.gen(function* () {
@@ -116,7 +118,16 @@ export const RelayLinkServiceLive: Layer.Layer<
     const config = yield* LanAuthConfig;
     const authService = yield* AuthService;
     const tunnel = yield* ManagedTunnelRuntime;
+    const paths = yield* AppPaths;
     const heartbeatRef = yield* Ref.make<Fiber.RuntimeFiber<void> | null>(null);
+    const log = (event: string, fields?: Record<string, unknown>) =>
+      appendRelayDiagnostic(paths, event, fields);
+
+    yield* log("service.boot", {
+      lanPolicy: config.policy,
+      lanPort: config.port ?? null,
+      advertisedHost: config.advertisedHost ?? null,
+    });
 
     const heartbeatLoop = (input: {
       readonly relayUrl: string;
@@ -155,6 +166,12 @@ export const RelayLinkServiceLive: Layer.Layer<
       .getRelayConfig()
       .pipe(Effect.orElseSucceed(() => null));
     if (existing !== null) {
+      yield* log("service.existing_config", {
+        environmentId: existing.environmentId,
+        relayUrl: existing.relayUrl,
+        hasConnectorToken: existing.connectorToken !== undefined,
+        tunnelHostname: existing.tunnelHostname ?? null,
+      });
       yield* startHeartbeat({
         relayUrl: existing.relayUrl,
         environmentId: existing.environmentId,
@@ -163,27 +180,65 @@ export const RelayLinkServiceLive: Layer.Layer<
       if (existing.connectorToken !== undefined) {
         // Non-fatal on boot: if cloudflared is missing the desktop still works
         // on LAN; the tunnel just won't come up until relinked.
-        yield* tunnel.start(existing.connectorToken).pipe(Effect.ignore);
+        yield* log("service.existing_tunnel_start");
+        yield* tunnel.start(existing.connectorToken).pipe(
+          Effect.tap(() => log("service.existing_tunnel_start.ok")),
+          Effect.tapError((error) =>
+            log("service.existing_tunnel_start.fail", { reason: error.reason }),
+          ),
+          Effect.ignore,
+        );
       }
     }
 
     return RelayLinkService.of({
       link: (input) =>
         Effect.gen(function* () {
+          yield* log("link.start", {
+            relayUrl: input.relayUrl,
+            hasLabel: input.label !== undefined && input.label.length > 0,
+          });
           const token = yield* authService
             .getAccessToken()
+            .pipe(
+              Effect.tap(() => log("link.access_token.ok")),
+              Effect.tapError((error) =>
+                log("link.access_token.fail", { error }),
+              ),
+            )
             .pipe(Effect.mapError(() => failRelay("not_signed_in")));
           const keys = yield* auth
             .environmentKeys()
+            .pipe(
+              Effect.tap((value) =>
+                log("link.environment_keys.ok", {
+                  environmentId: value.envId,
+                }),
+              ),
+              Effect.tapError((error) =>
+                log("link.environment_keys.fail", { reason: error.reason }),
+              ),
+            )
             .pipe(Effect.mapError((error) => failRelay(error.reason)));
 
+          yield* log("link.challenge.post");
           const challenge = yield* postJson<{
             readonly challengeId: string;
             readonly challenge: string;
             readonly relayIssuer: string;
           }>(`${input.relayUrl}${RelayPaths.linkChallenges}`, {
             bearer: token,
-          });
+          }).pipe(
+            Effect.tap((value) =>
+              log("link.challenge.ok", {
+                challengeId: value.challengeId,
+                relayIssuer: value.relayIssuer,
+              }),
+            ),
+            Effect.tapError((error) =>
+              log("link.challenge.fail", { reason: error.reason }),
+            ),
+          );
 
           const nowMs = yield* Clock.currentTimeMillis;
           const proof = yield* signEnvironmentLinkProof({
@@ -193,7 +248,16 @@ export const RelayLinkServiceLive: Layer.Layer<
             relayIssuer: challenge.relayIssuer,
             nowMs,
           });
+          yield* log("link.proof.ok", {
+            environmentId: keys.envId,
+            relayIssuer: challenge.relayIssuer,
+          });
 
+          yield* log("link.environment.post", {
+            endpoint: computeEndpoint(config),
+            origin: computeOrigin(config),
+            managedTunnel: true,
+          });
           const linked = yield* postJson<{
             readonly environmentCredential: string;
             readonly relayIssuer: string;
@@ -215,16 +279,39 @@ export const RelayLinkServiceLive: Layer.Layer<
               managedTunnel: true,
               origin: computeOrigin(config),
             },
-          });
+          }).pipe(
+            Effect.tap((value) =>
+              log("link.environment.ok", {
+                relayIssuer: value.relayIssuer,
+                hasConnectorToken: value.connectorToken !== undefined,
+                tunnelHostname: value.tunnelHostname ?? null,
+              }),
+            ),
+            Effect.tapError((error) =>
+              log("link.environment.fail", { reason: error.reason }),
+            ),
+          );
 
           // Launch the connector before persisting so a missing `cloudflared`
           // surfaces as a link error rather than a silently-dead tunnel.
           if (linked.connectorToken !== undefined) {
+            yield* log("link.tunnel_start");
             yield* tunnel
               .start(linked.connectorToken)
+              .pipe(
+                Effect.tap(() =>
+                  log("link.tunnel_start.ok", {
+                    tunnelHostname: linked.tunnelHostname ?? null,
+                  }),
+                ),
+                Effect.tapError((error) =>
+                  log("link.tunnel_start.fail", { reason: error.reason }),
+                ),
+              )
               .pipe(Effect.mapError((error) => failRelay(error.reason)));
           }
 
+          yield* log("link.save_config");
           yield* auth
             .saveRelayConfig({
               relayUrl: input.relayUrl,
@@ -235,6 +322,18 @@ export const RelayLinkServiceLive: Layer.Layer<
               connectorToken: linked.connectorToken,
               tunnelHostname: linked.tunnelHostname,
             })
+            .pipe(
+              Effect.tap(() =>
+                log("link.save_config.ok", {
+                  environmentId: keys.envId,
+                  tunnelHostname: linked.tunnelHostname ?? null,
+                  hasConnectorToken: linked.connectorToken !== undefined,
+                }),
+              ),
+              Effect.tapError((error) =>
+                log("link.save_config.fail", { reason: error.reason }),
+              ),
+            )
             .pipe(Effect.mapError((error) => failRelay(error.reason)));
 
           yield* startHeartbeat({
@@ -242,7 +341,12 @@ export const RelayLinkServiceLive: Layer.Layer<
             environmentId: keys.envId,
             credential: linked.environmentCredential,
           });
+          yield* log("link.heartbeat.started", { environmentId: keys.envId });
 
+          yield* log("link.success", {
+            environmentId: keys.envId,
+            tunnelHostname: linked.tunnelHostname ?? null,
+          });
           return {
             linked: true,
             relayUrl: input.relayUrl,
@@ -266,12 +370,20 @@ export const RelayLinkServiceLive: Layer.Layer<
             .pipe(Effect.mapError((error) => failRelay(error.reason)));
           const active = (yield* Ref.get(heartbeatRef)) !== null;
           if (cfg === null) {
+            yield* log("status.unlinked", { heartbeatActive: active });
             return {
               linked: false,
               heartbeatActive: false,
               advertisedEndpoints: buildAdvertisedEndpoints({ lan: config }),
             } satisfies RelayLinkStatusValue;
           }
+          yield* log("status.linked", {
+            environmentId: cfg.environmentId,
+            relayUrl: cfg.relayUrl,
+            heartbeatActive: active,
+            hasConnectorToken: cfg.connectorToken !== undefined,
+            tunnelHostname: cfg.tunnelHostname ?? null,
+          });
           return {
             linked: true,
             relayUrl: cfg.relayUrl,
@@ -290,6 +402,7 @@ export const RelayLinkServiceLive: Layer.Layer<
         }),
       unlink: () =>
         Effect.gen(function* () {
+          yield* log("unlink.start");
           const cfg = yield* auth
             .getRelayConfig()
             .pipe(Effect.orElseSucceed(() => null));
@@ -308,10 +421,14 @@ export const RelayLinkServiceLive: Layer.Layer<
               ),
               Effect.ignore,
             );
+            yield* log("unlink.relay_deprovision.done", {
+              environmentId: cfg.environmentId,
+            });
           }
           yield* auth
             .clearRelayConfig()
             .pipe(Effect.mapError((error) => failRelay(error.reason)));
+          yield* log("unlink.success");
         }),
     });
   }),

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -48,6 +48,24 @@ export class RelayLinkService extends Context.Tag("zuse/RelayLinkService")<
 
 const failRelay = (reason: string) => new RelayLinkError({ reason });
 
+const relayHttpErrorReason = async (response: Response): Promise<string> => {
+  const fallback = `relay_${response.status}`;
+  const text = await response.text().catch(() => "");
+  if (text.trim().length === 0) return fallback;
+  try {
+    const body = JSON.parse(text) as { readonly error?: unknown };
+    if (typeof body.error === "string") {
+      if (response.status === 401 && body.error === "invalid_workos_token") {
+        return "Relay rejected the WorkOS token. Check that desktop, mobile, and relay use the same WorkOS client id.";
+      }
+      return `relay_${response.status}:${body.error}`;
+    }
+  } catch {
+    // Fall through to the status-only reason; relay bodies should be JSON.
+  }
+  return fallback;
+};
+
 const postJson = <A>(
   url: string,
   opts: { readonly bearer: string; readonly body?: unknown },
@@ -65,7 +83,7 @@ const postJson = <A>(
         body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
       });
       if (!response.ok) {
-        throw new Error(`relay_${response.status}`);
+        throw new Error(await relayHttpErrorReason(response));
       }
       return (await response.json()) as A;
     },

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -3,6 +3,7 @@ import { Clock, Context, Data, Effect, Fiber, Layer, Ref } from "effect";
 import { RelayPaths, type EnvironmentId } from "@zuse/wire";
 
 import { AuthService } from "../auth/services/auth-service.ts";
+import { buildAdvertisedEndpoints } from "../lan-auth/advertised-endpoints.ts";
 import {
   LanAuthConfig,
   LanAuthService,
@@ -23,6 +24,7 @@ export interface RelayLinkStatusValue {
   readonly environmentId?: EnvironmentId;
   readonly label?: string;
   readonly heartbeatActive: boolean;
+  readonly advertisedEndpoints?: ReturnType<typeof buildAdvertisedEndpoints>;
 }
 
 /**
@@ -56,7 +58,9 @@ const postJson = <A>(
         method: "POST",
         headers: {
           authorization: `Bearer ${opts.bearer}`,
-          ...(opts.body === undefined ? {} : { "content-type": "application/json" }),
+          ...(opts.body === undefined
+            ? {}
+            : { "content-type": "application/json" }),
         },
         body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
       });
@@ -129,7 +133,9 @@ export const RelayLinkServiceLive: Layer.Layer<
     });
 
     // Resume heartbeating (and the managed-tunnel connector) on boot if linked.
-    const existing = yield* auth.getRelayConfig().pipe(Effect.orElseSucceed(() => null));
+    const existing = yield* auth
+      .getRelayConfig()
+      .pipe(Effect.orElseSucceed(() => null));
     if (existing !== null) {
       yield* startHeartbeat({
         relayUrl: existing.relayUrl,
@@ -157,7 +163,9 @@ export const RelayLinkServiceLive: Layer.Layer<
             readonly challengeId: string;
             readonly challenge: string;
             readonly relayIssuer: string;
-          }>(`${input.relayUrl}${RelayPaths.linkChallenges}`, { bearer: token });
+          }>(`${input.relayUrl}${RelayPaths.linkChallenges}`, {
+            bearer: token,
+          });
 
           const nowMs = yield* Clock.currentTimeMillis;
           const proof = yield* signEnvironmentLinkProof({
@@ -207,6 +215,7 @@ export const RelayLinkServiceLive: Layer.Layer<
               environmentCredential: linked.environmentCredential,
               label: input.label,
               connectorToken: linked.connectorToken,
+              tunnelHostname: linked.tunnelHostname,
             })
             .pipe(Effect.mapError((error) => failRelay(error.reason)));
 
@@ -222,6 +231,14 @@ export const RelayLinkServiceLive: Layer.Layer<
             environmentId: keys.envId,
             label: input.label,
             heartbeatActive: true,
+            advertisedEndpoints: buildAdvertisedEndpoints({
+              lan: config,
+              relay: {
+                linked: true,
+                heartbeatActive: true,
+                tunnelHostname: linked.tunnelHostname,
+              },
+            }),
           } satisfies RelayLinkStatusValue;
         }),
       status: () =>
@@ -231,7 +248,11 @@ export const RelayLinkServiceLive: Layer.Layer<
             .pipe(Effect.mapError((error) => failRelay(error.reason)));
           const active = (yield* Ref.get(heartbeatRef)) !== null;
           if (cfg === null) {
-            return { linked: false, heartbeatActive: false } satisfies RelayLinkStatusValue;
+            return {
+              linked: false,
+              heartbeatActive: false,
+              advertisedEndpoints: buildAdvertisedEndpoints({ lan: config }),
+            } satisfies RelayLinkStatusValue;
           }
           return {
             linked: true,
@@ -239,6 +260,14 @@ export const RelayLinkServiceLive: Layer.Layer<
             environmentId: cfg.environmentId,
             label: cfg.label,
             heartbeatActive: active,
+            advertisedEndpoints: buildAdvertisedEndpoints({
+              lan: config,
+              relay: {
+                linked: true,
+                heartbeatActive: active,
+                tunnelHostname: cfg.tunnelHostname,
+              },
+            }),
           } satisfies RelayLinkStatusValue;
         }),
       unlink: () =>
@@ -252,17 +281,15 @@ export const RelayLinkServiceLive: Layer.Layer<
           // removes the environment from the account). Local unlink proceeds
           // even if the relay is unreachable or we're signed out.
           if (cfg !== null) {
-            yield* authService
-              .getAccessToken()
-              .pipe(
-                Effect.flatMap((token) =>
-                  postJson<unknown>(`${cfg.relayUrl}${RelayPaths.unlink}`, {
-                    bearer: token,
-                    body: { environmentId: cfg.environmentId },
-                  }),
-                ),
-                Effect.ignore,
-              );
+            yield* authService.getAccessToken().pipe(
+              Effect.flatMap((token) =>
+                postJson<unknown>(`${cfg.relayUrl}${RelayPaths.unlink}`, {
+                  bearer: token,
+                  body: { environmentId: cfg.environmentId },
+                }),
+              ),
+              Effect.ignore,
+            );
           }
           yield* auth
             .clearRelayConfig()

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -327,7 +327,13 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(LanAuthConfigLayer),
     Layer.provide(AuthLayer),
     // The managed-tunnel connector (`cloudflared`) spawns via CommandExecutor.
-    Layer.provide(ManagedTunnelRuntimeLive.pipe(Layer.provide(NodeContext.layer))),
+    Layer.provide(
+      ManagedTunnelRuntimeLive.pipe(
+        Layer.provide(NodeContext.layer),
+        Layer.provide(AppPathsLayer),
+      ),
+    ),
+    Layer.provide(AppPathsLayer),
   );
 
   const HandlerSupportLayer = Layer.mergeAll(

--- a/apps/server/test/lan-auth-service.test.ts
+++ b/apps/server/test/lan-auth-service.test.ts
@@ -21,6 +21,8 @@ import { Migration0021AuthTokens } from "../src/persistence/migrations/0021_auth
 import { Migration0024RemoteConnectState } from "../src/persistence/migrations/0024_remote_connect_state.ts";
 import { Migration0025RelayEnvironmentKeys } from "../src/persistence/migrations/0025_relay_environment_keys.ts";
 import { Migration0026RelayConnectorToken } from "../src/persistence/migrations/0026_relay_connector_token.ts";
+import { Migration0027RelayTunnelHostname } from "../src/persistence/migrations/0027_relay_tunnel_hostname.ts";
+import { buildAdvertisedEndpoints } from "../src/lan-auth/advertised-endpoints.ts";
 
 const makeRuntime = () => {
   const SqlLive = SqliteClient.layer({ filename: ":memory:" });
@@ -29,10 +31,9 @@ const makeRuntime = () => {
       Effect.zipRight(Migration0024RemoteConnectState),
       Effect.zipRight(Migration0025RelayEnvironmentKeys),
       Effect.zipRight(Migration0026RelayConnectorToken),
+      Effect.zipRight(Migration0027RelayTunnelHostname),
     ),
-  ).pipe(
-    Layer.provideMerge(SqlLive),
-  );
+  ).pipe(Layer.provideMerge(SqlLive));
   const ConfigLive = Layer.succeed(LanAuthConfig, {
     policy: "protected" as const,
     advertisedHost: "192.168.1.10",
@@ -57,7 +58,8 @@ const withRuntime = async <A>(
   const runtime = makeRuntime();
   const run = <X>(
     effect: Effect.Effect<X, unknown, LanAuthService | SqlClient.SqlClient>,
-  ): Promise<X> => runtime.runPromise(effect as Effect.Effect<X, unknown, never>);
+  ): Promise<X> =>
+    runtime.runPromise(effect as Effect.Effect<X, unknown, never>);
   try {
     return await fn(run);
   } finally {
@@ -212,15 +214,19 @@ describe("LanAuthService", () => {
             environmentId,
             environmentCredential: "zec_secret",
             label: "Test Mac",
+            connectorToken: "connector-token",
+            tunnelHostname: "env.example.test",
           });
+          const relayConfig = yield* auth.getRelayConfig();
           const sql = yield* SqlClient.SqlClient;
           const rows = yield* sql<{
             readonly relay_url: string;
             readonly label: string | null;
+            readonly tunnel_hostname: string | null;
           }>`
-            SELECT relay_url, label FROM relay_config WHERE environment_id = ${environmentId}
+            SELECT relay_url, label, tunnel_hostname FROM relay_config WHERE environment_id = ${environmentId}
           `;
-          return { proof, rows, keys };
+          return { proof, rows, keys, relayConfig };
         }),
       );
 
@@ -228,9 +234,71 @@ describe("LanAuthService", () => {
       expect(result.proof.proof.split(".")).toHaveLength(3);
       expect(JSON.parse(result.keys.publicJwk).crv).toBe("Ed25519");
       expect(result.rows).toEqual([
-        { relay_url: "https://relay.test", label: "Test Mac" },
+        {
+          relay_url: "https://relay.test",
+          label: "Test Mac",
+          tunnel_hostname: "env.example.test",
+        },
       ]);
+      expect(result.relayConfig?.tunnelHostname).toBe("env.example.test");
     });
+  });
+
+  it("builds LAN, loopback, and managed tunnel advertised endpoints", () => {
+    const endpoints = buildAdvertisedEndpoints({
+      lan: {
+        policy: "protected",
+        advertisedHost: "192.168.1.10",
+        port: 8787,
+        pairingBootstrap: false,
+      },
+      relay: {
+        linked: true,
+        heartbeatActive: true,
+        tunnelHostname: "env.example.test",
+      },
+    });
+
+    expect(endpoints.map((endpoint) => endpoint.id)).toEqual([
+      "core:lan",
+      "core:loopback",
+      "tunnel:managed-relay",
+    ]);
+    expect(endpoints.find((endpoint) => endpoint.isDefault)?.id).toBe(
+      "tunnel:managed-relay",
+    );
+    expect(
+      endpoints.find((endpoint) => endpoint.id === "core:lan"),
+    ).toMatchObject({
+      httpBaseUrl: "http://192.168.1.10:8787",
+      wsBaseUrl: "ws://192.168.1.10:8787",
+      reachability: "lan",
+      compatibility: { hostedHttpsApp: "mixed-content-blocked" },
+    });
+    expect(
+      endpoints.find((endpoint) => endpoint.id === "tunnel:managed-relay"),
+    ).toMatchObject({
+      httpBaseUrl: "https://env.example.test",
+      wsBaseUrl: "wss://env.example.test/rpc",
+      reachability: "tunnel",
+      compatibility: { hostedHttpsApp: "compatible" },
+      status: "available",
+    });
+  });
+
+  it("falls back to LAN before loopback when no tunnel is advertised", () => {
+    const endpoints = buildAdvertisedEndpoints({
+      lan: {
+        policy: "protected",
+        advertisedHost: "192.168.1.10",
+        port: 8787,
+        pairingBootstrap: false,
+      },
+    });
+
+    expect(endpoints.find((endpoint) => endpoint.isDefault)?.id).toBe(
+      "core:lan",
+    );
   });
 });
 

--- a/bun.lock
+++ b/bun.lock
@@ -261,6 +261,7 @@
         "@cloudflare/workers-types": "^4.20260601.1",
         "@repo/typescript-config": "*",
         "@types/node": "catalog:",
+        "@types/pg": "^8.20.0",
         "drizzle-kit": "^0.31.4",
         "drizzle-orm": "^0.44.3",
         "pg": "^8.22.0",
@@ -1561,6 +1562,8 @@
     "@types/ms": ["@types/ms@2.1.0", "http://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@22.19.17", "http://registry.npmjs.org/@types/node/-/node-22.19.17.tgz", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
@@ -4304,6 +4307,8 @@
 
     "@types/better-sqlite3/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
 
+    "@types/pg/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "http://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "http://registry.npmjs.org/semver/-/semver-7.7.4.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -5145,6 +5150,8 @@
     "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "http://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@types/better-sqlite3/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "http://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 

--- a/infra/relay/package.json
+++ b/infra/relay/package.json
@@ -27,6 +27,7 @@
     "@cloudflare/workers-types": "^4.20260601.1",
     "@repo/typescript-config": "*",
     "@types/node": "catalog:",
+    "@types/pg": "^8.20.0",
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.44.3",
     "pg": "^8.22.0",

--- a/infra/relay/src/handler.ts
+++ b/infra/relay/src/handler.ts
@@ -107,9 +107,6 @@ const route = (
     // 2. Link an environment: verify the Ed25519 proof, mint a credential.
     if (method === "POST" && path === "/v1/client/environment-links") {
       const principal = yield* requireWorkos(request);
-      console.info("[zuse-relay] link: authenticated", {
-        accountId: principal.accountId,
-      });
       const body = yield* readJson<{
         readonly challengeId?: string;
         readonly proof?: string;
@@ -127,11 +124,6 @@ const route = (
           readonly localHttpPort?: number;
         };
       }>(request);
-      console.info("[zuse-relay] link: body parsed", {
-        environmentId: body.environmentId,
-        managedTunnel: body.managedTunnel,
-        hasOrigin: body.origin !== undefined,
-      });
 
       if (
         typeof body.challengeId !== "string" ||
@@ -149,10 +141,6 @@ const route = (
         body.challengeId,
         principal.accountId,
       );
-      console.info("[zuse-relay] link: challenge consumed", {
-        environmentId: body.environmentId,
-        found: challenge !== null,
-      });
       if (challenge === null) {
         return yield* Effect.fail(gone("invalid_challenge"));
       }
@@ -168,9 +156,6 @@ const route = (
         expectedEnvironmentId: body.environmentId,
         relayIssuer: config.relayIssuer,
       });
-      console.info("[zuse-relay] link: proof verified", {
-        environmentId: body.environmentId,
-      });
 
       yield* store.upsertEnvironment({
         environmentId: body.environmentId,
@@ -183,9 +168,6 @@ const route = (
         wsBaseUrl: body.endpoint.wsBaseUrl,
         linkedAtMs: nowMs,
       });
-      console.info("[zuse-relay] link: environment upserted", {
-        environmentId: body.environmentId,
-      });
 
       const credentialSecret = yield* randomToken("zenv");
       const credentialId = yield* randomToken("cred", 8);
@@ -197,18 +179,11 @@ const route = (
         credentialHash,
         createdAtMs: nowMs,
       });
-      console.info("[zuse-relay] link: credential inserted", {
-        environmentId: body.environmentId,
-      });
 
       // Provision a managed Cloudflare tunnel when requested and enabled, so the
       // environment is reachable from anywhere. On failure we don't fail the
       // link — the desktop keeps its LAN endpoint and can retry.
       const tunnel = yield* ManagedTunnelProvider;
-      console.info("[zuse-relay] link: tunnel provider resolved", {
-        environmentId: body.environmentId,
-        tunnelEnabled: tunnel.enabled,
-      });
       let tunnelHostname: string | undefined;
       let connectorToken: string | undefined;
       if (
@@ -217,9 +192,6 @@ const route = (
         typeof body.origin?.localHttpHost === "string" &&
         typeof body.origin.localHttpPort === "number"
       ) {
-        console.info("[zuse-relay] link: tunnel provision start", {
-          environmentId: body.environmentId,
-        });
         const provisioned = yield* tunnel
           .provision({
             accountId: principal.accountId,
@@ -230,10 +202,6 @@ const route = (
             },
           })
           .pipe(Effect.option);
-        console.info("[zuse-relay] link: tunnel provision finished", {
-          environmentId: body.environmentId,
-          provisioned: provisioned._tag,
-        });
         if (provisioned._tag === "Some") {
           yield* store.setTunnelAllocation(body.environmentId, {
             tunnelHostname: provisioned.value.tunnelHostname,
@@ -245,11 +213,6 @@ const route = (
           connectorToken = provisioned.value.connectorToken;
         }
       }
-      console.info("[zuse-relay] link: responding", {
-        environmentId: body.environmentId,
-        tunnelHostname,
-        hasConnectorToken: connectorToken !== undefined,
-      });
 
       return json({
         environmentId: body.environmentId,

--- a/infra/relay/src/handler.ts
+++ b/infra/relay/src/handler.ts
@@ -63,7 +63,10 @@ const publicEndpoint = (environment: EnvironmentRecord) =>
         httpBaseUrl: `https://${environment.tunnelHostname}`,
         wsBaseUrl: `wss://${environment.tunnelHostname}/rpc`,
       }
-    : { httpBaseUrl: environment.httpBaseUrl, wsBaseUrl: environment.wsBaseUrl };
+    : {
+        httpBaseUrl: environment.httpBaseUrl,
+        wsBaseUrl: environment.wsBaseUrl,
+      };
 
 /** Routes a request to the matching endpoint. Failures surface as RelayError. */
 const route = (
@@ -78,7 +81,10 @@ const route = (
     const nowMs = yield* Clock.currentTimeMillis;
 
     // 1. Issue a link challenge (desktop, WorkOS-authenticated).
-    if (method === "POST" && path === "/v1/client/environment-link-challenges") {
+    if (
+      method === "POST" &&
+      path === "/v1/client/environment-link-challenges"
+    ) {
       const principal = yield* requireWorkos(request);
       const challengeId = yield* randomToken("chl");
       const challenge = yield* randomToken("nonce", 32);
@@ -101,13 +107,19 @@ const route = (
     // 2. Link an environment: verify the Ed25519 proof, mint a credential.
     if (method === "POST" && path === "/v1/client/environment-links") {
       const principal = yield* requireWorkos(request);
+      console.info("[zuse-relay] link: authenticated", {
+        accountId: principal.accountId,
+      });
       const body = yield* readJson<{
         readonly challengeId?: string;
         readonly proof?: string;
         readonly environmentId?: string;
         readonly environmentPublicKey?: string;
         readonly providerKind?: string;
-        readonly endpoint?: { readonly httpBaseUrl?: string; readonly wsBaseUrl?: string };
+        readonly endpoint?: {
+          readonly httpBaseUrl?: string;
+          readonly wsBaseUrl?: string;
+        };
         readonly label?: string;
         readonly managedTunnel?: boolean;
         readonly origin?: {
@@ -115,6 +127,11 @@ const route = (
           readonly localHttpPort?: number;
         };
       }>(request);
+      console.info("[zuse-relay] link: body parsed", {
+        environmentId: body.environmentId,
+        managedTunnel: body.managedTunnel,
+        hasOrigin: body.origin !== undefined,
+      });
 
       if (
         typeof body.challengeId !== "string" ||
@@ -132,6 +149,10 @@ const route = (
         body.challengeId,
         principal.accountId,
       );
+      console.info("[zuse-relay] link: challenge consumed", {
+        environmentId: body.environmentId,
+        found: challenge !== null,
+      });
       if (challenge === null) {
         return yield* Effect.fail(gone("invalid_challenge"));
       }
@@ -147,6 +168,9 @@ const route = (
         expectedEnvironmentId: body.environmentId,
         relayIssuer: config.relayIssuer,
       });
+      console.info("[zuse-relay] link: proof verified", {
+        environmentId: body.environmentId,
+      });
 
       yield* store.upsertEnvironment({
         environmentId: body.environmentId,
@@ -159,6 +183,9 @@ const route = (
         wsBaseUrl: body.endpoint.wsBaseUrl,
         linkedAtMs: nowMs,
       });
+      console.info("[zuse-relay] link: environment upserted", {
+        environmentId: body.environmentId,
+      });
 
       const credentialSecret = yield* randomToken("zenv");
       const credentialId = yield* randomToken("cred", 8);
@@ -170,11 +197,18 @@ const route = (
         credentialHash,
         createdAtMs: nowMs,
       });
+      console.info("[zuse-relay] link: credential inserted", {
+        environmentId: body.environmentId,
+      });
 
       // Provision a managed Cloudflare tunnel when requested and enabled, so the
       // environment is reachable from anywhere. On failure we don't fail the
       // link — the desktop keeps its LAN endpoint and can retry.
       const tunnel = yield* ManagedTunnelProvider;
+      console.info("[zuse-relay] link: tunnel provider resolved", {
+        environmentId: body.environmentId,
+        tunnelEnabled: tunnel.enabled,
+      });
       let tunnelHostname: string | undefined;
       let connectorToken: string | undefined;
       if (
@@ -183,6 +217,9 @@ const route = (
         typeof body.origin?.localHttpHost === "string" &&
         typeof body.origin.localHttpPort === "number"
       ) {
+        console.info("[zuse-relay] link: tunnel provision start", {
+          environmentId: body.environmentId,
+        });
         const provisioned = yield* tunnel
           .provision({
             accountId: principal.accountId,
@@ -193,6 +230,10 @@ const route = (
             },
           })
           .pipe(Effect.option);
+        console.info("[zuse-relay] link: tunnel provision finished", {
+          environmentId: body.environmentId,
+          provisioned: provisioned._tag,
+        });
         if (provisioned._tag === "Some") {
           yield* store.setTunnelAllocation(body.environmentId, {
             tunnelHostname: provisioned.value.tunnelHostname,
@@ -204,6 +245,11 @@ const route = (
           connectorToken = provisioned.value.connectorToken;
         }
       }
+      console.info("[zuse-relay] link: responding", {
+        environmentId: body.environmentId,
+        tunnelHostname,
+        hasConnectorToken: connectorToken !== undefined,
+      });
 
       return json({
         environmentId: body.environmentId,
@@ -213,7 +259,10 @@ const route = (
                 httpBaseUrl: `https://${tunnelHostname}`,
                 wsBaseUrl: `wss://${tunnelHostname}/rpc`,
               }
-            : { httpBaseUrl: body.endpoint.httpBaseUrl, wsBaseUrl: body.endpoint.wsBaseUrl },
+            : {
+                httpBaseUrl: body.endpoint.httpBaseUrl,
+                wsBaseUrl: body.endpoint.wsBaseUrl,
+              },
         relayIssuer: config.relayIssuer,
         environmentCredential: credentialSecret,
         mintPublicKey: config.mintPublicKey,
@@ -226,12 +275,17 @@ const route = (
     // tunnel and delete the record so it disappears from the account.
     if (method === "POST" && path === "/v1/client/environment-unlink") {
       const principal = yield* requireWorkos(request);
-      const body = yield* readJson<{ readonly environmentId?: string }>(request);
+      const body = yield* readJson<{ readonly environmentId?: string }>(
+        request,
+      );
       if (typeof body.environmentId !== "string") {
         return yield* Effect.fail(badRequest("invalid_environment"));
       }
       const environment = yield* store.getEnvironment(body.environmentId);
-      if (environment === null || environment.accountId !== principal.accountId) {
+      if (
+        environment === null ||
+        environment.accountId !== principal.accountId
+      ) {
         return yield* Effect.fail(notFound());
       }
       if (environment.tunnelId !== undefined) {
@@ -269,7 +323,10 @@ const route = (
         RELAY_SCOPES.connect,
         RELAY_SCOPES.register,
       ]);
-      return json({ accessToken: minted.accessToken, expiresIn: minted.expiresInMs });
+      return json({
+        accessToken: minted.accessToken,
+        expiresIn: minted.expiresInMs,
+      });
     }
 
     // 5. Register a mobile device (DPoP-scoped).
@@ -301,7 +358,10 @@ const route = (
       const environmentId = decodeURIComponent(statusMatch[1]!);
       const principal = yield* requireDpop(request, RELAY_SCOPES.status);
       const environment = yield* store.getEnvironment(environmentId);
-      if (environment === null || environment.accountId !== principal.accountId) {
+      if (
+        environment === null ||
+        environment.accountId !== principal.accountId
+      ) {
         return yield* Effect.fail(notFound());
       }
       const online =
@@ -319,7 +379,10 @@ const route = (
       const environmentId = decodeURIComponent(connectMatch[1]!);
       const principal = yield* requireDpop(request, RELAY_SCOPES.connect);
       const environment = yield* store.getEnvironment(environmentId);
-      if (environment === null || environment.accountId !== principal.accountId) {
+      if (
+        environment === null ||
+        environment.accountId !== principal.accountId
+      ) {
         return yield* Effect.fail(notFound());
       }
       const connectToken = yield* signConnectToken({
@@ -339,7 +402,9 @@ const route = (
     }
 
     // 6. Heartbeat (desktop, environment-credential auth) — presence origin.
-    const heartbeatMatch = /^\/v1\/environments\/([^/]+)\/heartbeat$/.exec(path);
+    const heartbeatMatch = /^\/v1\/environments\/([^/]+)\/heartbeat$/.exec(
+      path,
+    );
     if (method === "POST" && heartbeatMatch !== null) {
       const environmentId = decodeURIComponent(heartbeatMatch[1]!);
       yield* requireEnvironmentCredential(request, environmentId);
@@ -348,10 +413,15 @@ const route = (
     }
 
     // 7. Agent activity (desktop, environment-credential auth) — never chat data.
-    const activityMatch = /^\/v1\/environments\/([^/]+)\/agent-activity$/.exec(path);
+    const activityMatch = /^\/v1\/environments\/([^/]+)\/agent-activity$/.exec(
+      path,
+    );
     if (method === "POST" && activityMatch !== null) {
       const environmentId = decodeURIComponent(activityMatch[1]!);
-      const principal = yield* requireEnvironmentCredential(request, environmentId);
+      const principal = yield* requireEnvironmentCredential(
+        request,
+        environmentId,
+      );
       const body = yield* readJson<{
         readonly sessionId?: string;
         readonly kind?: string;
@@ -374,7 +444,9 @@ const route = (
         occurredAtMs: nowMs,
       });
       const devices = yield* store.listDevices(principal.accountId);
-      return json({ delivered: devices.filter((device) => device.pushToken).length });
+      return json({
+        delivered: devices.filter((device) => device.pushToken).length,
+      });
     }
 
     return yield* Effect.fail(notFound());

--- a/infra/relay/src/store.ts
+++ b/infra/relay/src/store.ts
@@ -303,52 +303,26 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
     RelayStore,
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
+      const challenges = yield* Ref.make(
+        new Map<string, LinkChallengeRecord>(),
+      );
       const orDie = <A>(effect: Effect.Effect<A, unknown>): Effect.Effect<A> =>
         effect.pipe(Effect.orDie);
 
       return RelayStore.of({
         createChallenge: (challenge) =>
-          orDie(
-            sql`
-            INSERT INTO relay_link_challenges
-              (challenge_id, account_id, challenge, relay_issuer, expires_at)
-            VALUES (
-              ${challenge.challengeId}, ${challenge.accountId}, ${challenge.challenge},
-              ${challenge.relayIssuer}, ${challenge.expiresAtMs}
-            )
-          `.pipe(Effect.asVoid),
+          Ref.update(challenges, (map) =>
+            new Map(map).set(challenge.challengeId, challenge),
           ),
         consumeChallenge: (challengeId, accountId) =>
-          orDie(
-            sql<{
-              readonly challenge_id: string;
-              readonly account_id: string;
-              readonly challenge: string;
-              readonly relay_issuer: string;
-              readonly expires_at: number;
-            }>`
-              SELECT challenge_id, account_id, challenge, relay_issuer, expires_at
-              FROM relay_link_challenges
-              WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
-            `.pipe(
-              Effect.flatMap((rows) => {
-                const row = rows[0];
-                if (row === undefined) return Effect.succeed(null);
-                return sql`
-                  DELETE FROM relay_link_challenges
-                  WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
-                `.pipe(
-                  Effect.as({
-                    challengeId: row.challenge_id,
-                    accountId: row.account_id,
-                    challenge: row.challenge,
-                    relayIssuer: row.relay_issuer,
-                    expiresAtMs: Number(row.expires_at),
-                  } satisfies LinkChallengeRecord),
-                );
-              }),
-            ),
-          ),
+          Ref.modify(challenges, (map) => {
+            const found = map.get(challengeId) ?? null;
+            if (found === null || found.accountId !== accountId)
+              return [null, map];
+            const next = new Map(map);
+            next.delete(challengeId);
+            return [found, next];
+          }),
         upsertEnvironment: (env) =>
           orDie(
             sql`

--- a/infra/relay/src/store.ts
+++ b/infra/relay/src/store.ts
@@ -327,25 +327,20 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
               readonly relay_issuer: string;
               readonly expires_at: number;
             }>`
-              SELECT challenge_id, account_id, challenge, relay_issuer, expires_at
-              FROM relay_link_challenges
+              DELETE FROM relay_link_challenges
               WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
+              RETURNING challenge_id, account_id, challenge, relay_issuer, expires_at
             `.pipe(
-              Effect.flatMap((rows) => {
+              Effect.map((rows) => {
                 const row = rows[0];
-                if (row === undefined) return Effect.succeed(null);
-                return sql`
-                  DELETE FROM relay_link_challenges
-                  WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
-                `.pipe(
-                  Effect.as({
-                    challengeId: row.challenge_id,
-                    accountId: row.account_id,
-                    challenge: row.challenge,
-                    relayIssuer: row.relay_issuer,
-                    expiresAtMs: Number(row.expires_at),
-                  } satisfies LinkChallengeRecord),
-                );
+                if (row === undefined) return null;
+                return {
+                  challengeId: row.challenge_id,
+                  accountId: row.account_id,
+                  challenge: row.challenge,
+                  relayIssuer: row.relay_issuer,
+                  expiresAtMs: Number(row.expires_at),
+                } satisfies LinkChallengeRecord;
               }),
             ),
           ),

--- a/infra/relay/src/store.ts
+++ b/infra/relay/src/store.ts
@@ -70,13 +70,17 @@ export interface ActivityRecord {
 }
 
 export interface RelayStoreApi {
-  readonly createChallenge: (challenge: LinkChallengeRecord) => Effect.Effect<void>;
+  readonly createChallenge: (
+    challenge: LinkChallengeRecord,
+  ) => Effect.Effect<void>;
   /** Single-use: returns the challenge and deletes it, only if it belongs to `accountId`. */
   readonly consumeChallenge: (
     challengeId: string,
     accountId: string,
   ) => Effect.Effect<LinkChallengeRecord | null>;
-  readonly upsertEnvironment: (environment: EnvironmentRecord) => Effect.Effect<void>;
+  readonly upsertEnvironment: (
+    environment: EnvironmentRecord,
+  ) => Effect.Effect<void>;
   readonly listEnvironments: (
     accountId: string,
   ) => Effect.Effect<ReadonlyArray<EnvironmentRecord>>;
@@ -101,7 +105,9 @@ export interface RelayStoreApi {
     environmentId: string,
     accountId: string,
   ) => Effect.Effect<void>;
-  readonly insertCredential: (credential: CredentialRecord) => Effect.Effect<void>;
+  readonly insertCredential: (
+    credential: CredentialRecord,
+  ) => Effect.Effect<void>;
   readonly findActiveCredentialByHash: (
     credentialHash: string,
   ) => Effect.Effect<CredentialRecord | null>;
@@ -146,7 +152,8 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
       consumeChallenge: (challengeId, accountId) =>
         Ref.modify(challenges, (map) => {
           const found = map.get(challengeId) ?? null;
-          if (found === null || found.accountId !== accountId) return [null, map];
+          if (found === null || found.accountId !== accountId)
+            return [null, map];
           const next = new Map(map);
           next.delete(challengeId);
           return [found, next];
@@ -199,7 +206,8 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
         Effect.zipRight(
           Ref.update(environments, (map) => {
             const found = map.get(environmentId);
-            if (found === undefined || found.accountId !== accountId) return map;
+            if (found === undefined || found.accountId !== accountId)
+              return map;
             const next = new Map(map);
             next.delete(environmentId);
             return next;
@@ -232,7 +240,9 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
       listDevices: (accountId) =>
         Ref.get(devices).pipe(
           Effect.map((map) =>
-            [...map.values()].filter((device) => device.accountId === accountId),
+            [...map.values()].filter(
+              (device) => device.accountId === accountId,
+            ),
           ),
         ),
       consumeDpopProof: (input) =>
@@ -284,7 +294,8 @@ const toEnvironment = (row: EnvironmentRow): EnvironmentRecord => ({
   dnsRecordId: row.dns_record_id ?? undefined,
   tunnelStatus: row.tunnel_status ?? undefined,
   linkedAtMs: Number(row.linked_at),
-  lastSeenAtMs: row.last_seen_at === null ? undefined : Number(row.last_seen_at),
+  lastSeenAtMs:
+    row.last_seen_at === null ? undefined : Number(row.last_seen_at),
 });
 
 export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
@@ -297,14 +308,16 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
 
       return RelayStore.of({
         createChallenge: (challenge) =>
-          orDie(sql`
+          orDie(
+            sql`
             INSERT INTO relay_link_challenges
               (challenge_id, account_id, challenge, relay_issuer, expires_at)
             VALUES (
               ${challenge.challengeId}, ${challenge.accountId}, ${challenge.challenge},
               ${challenge.relayIssuer}, ${challenge.expiresAtMs}
             )
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         consumeChallenge: (challengeId, accountId) =>
           orDie(
             sql<{
@@ -314,25 +327,31 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
               readonly relay_issuer: string;
               readonly expires_at: number;
             }>`
-              DELETE FROM relay_link_challenges
+              SELECT challenge_id, account_id, challenge, relay_issuer, expires_at
+              FROM relay_link_challenges
               WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
-              RETURNING challenge_id, account_id, challenge, relay_issuer, expires_at
             `.pipe(
-              Effect.map((rows) => {
+              Effect.flatMap((rows) => {
                 const row = rows[0];
-                if (row === undefined) return null;
-                return {
-                  challengeId: row.challenge_id,
-                  accountId: row.account_id,
-                  challenge: row.challenge,
-                  relayIssuer: row.relay_issuer,
-                  expiresAtMs: Number(row.expires_at),
-                } satisfies LinkChallengeRecord;
+                if (row === undefined) return Effect.succeed(null);
+                return sql`
+                  DELETE FROM relay_link_challenges
+                  WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
+                `.pipe(
+                  Effect.as({
+                    challengeId: row.challenge_id,
+                    accountId: row.account_id,
+                    challenge: row.challenge,
+                    relayIssuer: row.relay_issuer,
+                    expiresAtMs: Number(row.expires_at),
+                  } satisfies LinkChallengeRecord),
+                );
               }),
             ),
           ),
         upsertEnvironment: (env) =>
-          orDie(sql`
+          orDie(
+            sql`
             INSERT INTO relay_environments
               (environment_id, account_id, org_id, provider_kind, label,
                environment_public_key, http_base_url, ws_base_url, tunnel_hostname,
@@ -352,7 +371,8 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
               http_base_url = EXCLUDED.http_base_url,
               ws_base_url = EXCLUDED.ws_base_url,
               linked_at = EXCLUDED.linked_at
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         listEnvironments: (accountId) =>
           orDie(
             sql<EnvironmentRow>`
@@ -370,42 +390,52 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
             ),
           ),
         touchEnvironment: (environmentId, lastSeenAtMs) =>
-          orDie(sql`
+          orDie(
+            sql`
             UPDATE relay_environments SET last_seen_at = ${lastSeenAtMs}
             WHERE environment_id = ${environmentId}
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         setTunnelAllocation: (environmentId, allocation) =>
-          orDie(sql`
+          orDie(
+            sql`
             UPDATE relay_environments SET
               tunnel_hostname = ${allocation.tunnelHostname},
               tunnel_id = ${allocation.tunnelId},
               dns_record_id = ${allocation.dnsRecordId ?? null},
               tunnel_status = ${allocation.tunnelStatus}
             WHERE environment_id = ${environmentId}
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         clearTunnelAllocation: (environmentId) =>
-          orDie(sql`
+          orDie(
+            sql`
             UPDATE relay_environments SET
               tunnel_hostname = NULL,
               tunnel_id = NULL,
               dns_record_id = NULL,
               tunnel_status = NULL
             WHERE environment_id = ${environmentId}
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         deleteEnvironment: (environmentId, accountId) =>
-          orDie(sql`
+          orDie(
+            sql`
             DELETE FROM relay_environments
             WHERE environment_id = ${environmentId} AND account_id = ${accountId}
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         insertCredential: (cred) =>
-          orDie(sql`
+          orDie(
+            sql`
             INSERT INTO relay_environment_credentials
               (credential_id, environment_id, account_id, credential_hash, created_at)
             VALUES (
               ${cred.credentialId}, ${cred.environmentId}, ${cred.accountId},
               ${cred.credentialHash}, ${cred.createdAtMs}
             )
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         findActiveCredentialByHash: (credentialHash) =>
           orDie(
             sql<{
@@ -429,13 +459,16 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
                   credentialHash: row.credential_hash,
                   createdAtMs: Number(row.created_at),
                   revokedAtMs:
-                    row.revoked_at === null ? undefined : Number(row.revoked_at),
+                    row.revoked_at === null
+                      ? undefined
+                      : Number(row.revoked_at),
                 } satisfies CredentialRecord;
               }),
             ),
           ),
         upsertDevice: (device) =>
-          orDie(sql`
+          orDie(
+            sql`
             INSERT INTO relay_devices
               (device_id, account_id, platform, push_token, dpop_jwk, updated_at)
             VALUES (
@@ -450,7 +483,8 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
               push_token = EXCLUDED.push_token,
               dpop_jwk = EXCLUDED.dpop_jwk,
               updated_at = EXCLUDED.updated_at
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
         listDevices: (accountId) =>
           orDie(
             sql<{
@@ -485,14 +519,16 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
             `.pipe(Effect.map((rows) => rows.length > 0)),
           ),
         recordActivity: (activity) =>
-          orDie(sql`
+          orDie(
+            sql`
             INSERT INTO relay_agent_activity
               (environment_id, account_id, session_id, kind, title, occurred_at)
             VALUES (
               ${activity.environmentId}, ${activity.accountId}, ${activity.sessionId},
               ${activity.kind}, ${activity.title ?? null}, ${activity.occurredAtMs}
             )
-          `.pipe(Effect.asVoid)),
+          `.pipe(Effect.asVoid),
+          ),
       });
     }),
   );

--- a/infra/relay/src/store.ts
+++ b/infra/relay/src/store.ts
@@ -303,26 +303,52 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
     RelayStore,
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
-      const challenges = yield* Ref.make(
-        new Map<string, LinkChallengeRecord>(),
-      );
       const orDie = <A>(effect: Effect.Effect<A, unknown>): Effect.Effect<A> =>
         effect.pipe(Effect.orDie);
 
       return RelayStore.of({
         createChallenge: (challenge) =>
-          Ref.update(challenges, (map) =>
-            new Map(map).set(challenge.challengeId, challenge),
+          orDie(
+            sql`
+            INSERT INTO relay_link_challenges
+              (challenge_id, account_id, challenge, relay_issuer, expires_at)
+            VALUES (
+              ${challenge.challengeId}, ${challenge.accountId}, ${challenge.challenge},
+              ${challenge.relayIssuer}, ${challenge.expiresAtMs}
+            )
+          `.pipe(Effect.asVoid),
           ),
         consumeChallenge: (challengeId, accountId) =>
-          Ref.modify(challenges, (map) => {
-            const found = map.get(challengeId) ?? null;
-            if (found === null || found.accountId !== accountId)
-              return [null, map];
-            const next = new Map(map);
-            next.delete(challengeId);
-            return [found, next];
-          }),
+          orDie(
+            sql<{
+              readonly challenge_id: string;
+              readonly account_id: string;
+              readonly challenge: string;
+              readonly relay_issuer: string;
+              readonly expires_at: number;
+            }>`
+              SELECT challenge_id, account_id, challenge, relay_issuer, expires_at
+              FROM relay_link_challenges
+              WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
+            `.pipe(
+              Effect.flatMap((rows) => {
+                const row = rows[0];
+                if (row === undefined) return Effect.succeed(null);
+                return sql`
+                  DELETE FROM relay_link_challenges
+                  WHERE challenge_id = ${challengeId} AND account_id = ${accountId}
+                `.pipe(
+                  Effect.as({
+                    challengeId: row.challenge_id,
+                    accountId: row.account_id,
+                    challenge: row.challenge,
+                    relayIssuer: row.relay_issuer,
+                    expiresAtMs: Number(row.expires_at),
+                  } satisfies LinkChallengeRecord),
+                );
+              }),
+            ),
+          ),
         upsertEnvironment: (env) =>
           orDie(
             sql`

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -1,5 +1,6 @@
 import { PgClient } from "@effect/sql-pg";
-import { Layer, Redacted } from "effect";
+import { Effect, Layer, Redacted } from "effect";
+import { Pool } from "pg";
 
 import * as Config from "./config.ts";
 import { makeRelay } from "./index.ts";
@@ -65,8 +66,18 @@ const build = (env: Env): ReturnType<typeof makeRelay> => {
     mintPublicKey: env.RELAY_MINT_PUBLIC_JWK,
     managedTunnel: managedTunnelConfig(env),
   });
-  const dbLayer = PgClient.layer({
-    url: Redacted.make(env.HYPERDRIVE.connectionString),
+  const dbLayer = PgClient.layerFromPool({
+    acquire: Effect.acquireRelease(
+      Effect.sync(
+        () =>
+          new Pool({
+            connectionString: env.HYPERDRIVE.connectionString,
+            max: 1,
+            maxUses: 1,
+          }),
+      ),
+      (pool) => Effect.promise(() => pool.end()),
+    ),
   });
   const appLayer = Layer.mergeAll(
     configLayer,

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -27,13 +27,20 @@ interface Env {
   readonly MANAGED_TUNNEL_NAMESPACE?: string;
 }
 
-const managedTunnelConfig = (env: Env): Config.ManagedTunnelConfig | undefined => {
+const configured = (value: string | undefined): value is string =>
+  value !== undefined &&
+  value.trim().length > 0 &&
+  !value.trim().startsWith("REPLACE_WITH");
+
+const managedTunnelConfig = (
+  env: Env,
+): Config.ManagedTunnelConfig | undefined => {
   if (
-    env.CF_API_TOKEN === undefined ||
-    env.CF_ACCOUNT_ID === undefined ||
-    env.CF_ZONE_ID === undefined ||
-    env.MANAGED_TUNNEL_BASE_DOMAIN === undefined ||
-    env.MANAGED_TUNNEL_NAMESPACE === undefined
+    !configured(env.CF_API_TOKEN) ||
+    !configured(env.CF_ACCOUNT_ID) ||
+    !configured(env.CF_ZONE_ID) ||
+    !configured(env.MANAGED_TUNNEL_BASE_DOMAIN) ||
+    !configured(env.MANAGED_TUNNEL_NAMESPACE)
   ) {
     return undefined;
   }

--- a/infra/relay/src/workos.ts
+++ b/infra/relay/src/workos.ts
@@ -31,6 +31,57 @@ export const acceptedWorkosIssuers = (issuer: string): string[] => {
   return withoutSlash === withSlash ? [trimmed] : [withoutSlash, withSlash];
 };
 
+const decodeJwtPart = (part: string): Record<string, unknown> | null => {
+  try {
+    const padded = part.padEnd(
+      part.length + ((4 - (part.length % 4)) % 4),
+      "=",
+    );
+    const json = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+    const value = JSON.parse(json) as unknown;
+    return typeof value === "object" && value !== null
+      ? (value as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+const logWorkosVerifyFailure = (
+  token: string,
+  config: {
+    readonly workosIssuer: string;
+    readonly workosJwksUrl: string;
+    readonly acceptedIssuers: readonly string[];
+  },
+  cause: unknown,
+): void => {
+  const parts = token.split(".");
+  const header = parts[0] === undefined ? null : decodeJwtPart(parts[0]);
+  const payload = parts[1] === undefined ? null : decodeJwtPart(parts[1]);
+  console.warn("[zuse-relay] WorkOS token verification failed", {
+    configuredIssuer: config.workosIssuer,
+    acceptedIssuers: config.acceptedIssuers,
+    jwksUrl: config.workosJwksUrl,
+    tokenHeader: {
+      alg: header?.alg,
+      kid: header?.kid,
+      typ: header?.typ,
+    },
+    tokenClaims: {
+      iss: payload?.iss,
+      client_id: payload?.client_id,
+      aud: payload?.aud,
+      exp: payload?.exp,
+      iat: payload?.iat,
+    },
+    cause:
+      cause instanceof Error
+        ? { name: cause.name, message: cause.message }
+        : String(cause),
+  });
+};
+
 /** Production verifier: validates the JWT against WorkOS's JWKS. */
 export const WorkosVerifierLive: Layer.Layer<
   WorkosVerifier,
@@ -47,7 +98,18 @@ export const WorkosVerifierLive: Layer.Layer<
         Effect.gen(function* () {
           const verified = yield* Effect.tryPromise({
             try: () => jwtVerify(token, jwks, { issuer: issuers }),
-            catch: () => unauthorized("invalid_workos_token"),
+            catch: (cause) => {
+              logWorkosVerifyFailure(
+                token,
+                {
+                  workosIssuer: config.workosIssuer,
+                  workosJwksUrl: config.workosJwksUrl,
+                  acceptedIssuers: issuers,
+                },
+                cause,
+              );
+              return unauthorized("invalid_workos_token");
+            },
           });
           const payload = verified.payload as {
             readonly sub?: unknown;

--- a/infra/relay/src/workos.ts
+++ b/infra/relay/src/workos.ts
@@ -18,9 +18,18 @@ export interface WorkosPrincipal {
 export class WorkosVerifier extends Context.Tag("@zuse/relay/WorkosVerifier")<
   WorkosVerifier,
   {
-    readonly verify: (token: string) => Effect.Effect<WorkosPrincipal, RelayError>;
+    readonly verify: (
+      token: string,
+    ) => Effect.Effect<WorkosPrincipal, RelayError>;
   }
 >() {}
+
+export const acceptedWorkosIssuers = (issuer: string): string[] => {
+  const trimmed = issuer.trim();
+  const withoutSlash = trimmed.replace(/\/+$/, "");
+  const withSlash = `${withoutSlash}/`;
+  return withoutSlash === withSlash ? [trimmed] : [withoutSlash, withSlash];
+};
 
 /** Production verifier: validates the JWT against WorkOS's JWKS. */
 export const WorkosVerifierLive: Layer.Layer<
@@ -32,11 +41,12 @@ export const WorkosVerifierLive: Layer.Layer<
   Effect.gen(function* () {
     const config = yield* RelayConfiguration;
     const jwks = createRemoteJWKSet(new URL(config.workosJwksUrl));
+    const issuers = acceptedWorkosIssuers(config.workosIssuer);
     return {
       verify: (token) =>
         Effect.gen(function* () {
           const verified = yield* Effect.tryPromise({
-            try: () => jwtVerify(token, jwks, { issuer: config.workosIssuer }),
+            try: () => jwtVerify(token, jwks, { issuer: issuers }),
             catch: () => unauthorized("invalid_workos_token"),
           });
           const payload = verified.payload as {

--- a/infra/relay/src/workos.ts
+++ b/infra/relay/src/workos.ts
@@ -31,6 +31,28 @@ export const acceptedWorkosIssuers = (issuer: string): string[] => {
   return withoutSlash === withSlash ? [trimmed] : [withoutSlash, withSlash];
 };
 
+export const isAcceptedWorkosIssuer = (
+  tokenIssuer: string,
+  configuredIssuer: string,
+): boolean => {
+  const base = configuredIssuer.trim().replace(/\/+$/, "");
+  return (
+    tokenIssuer === base ||
+    tokenIssuer === `${base}/` ||
+    tokenIssuer.startsWith(`${base}/user_management/`)
+  );
+};
+
+export const expectedWorkosClientId = (jwksUrl: string): string | undefined => {
+  try {
+    const url = new URL(jwksUrl);
+    const match = /\/jwks\/([^/]+)$/.exec(url.pathname);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+};
+
 const decodeJwtPart = (part: string): Record<string, unknown> | null => {
   try {
     const padded = part.padEnd(
@@ -93,11 +115,12 @@ export const WorkosVerifierLive: Layer.Layer<
     const config = yield* RelayConfiguration;
     const jwks = createRemoteJWKSet(new URL(config.workosJwksUrl));
     const issuers = acceptedWorkosIssuers(config.workosIssuer);
+    const expectedClientId = expectedWorkosClientId(config.workosJwksUrl);
     return {
       verify: (token) =>
         Effect.gen(function* () {
           const verified = yield* Effect.tryPromise({
-            try: () => jwtVerify(token, jwks, { issuer: issuers }),
+            try: () => jwtVerify(token, jwks),
             catch: (cause) => {
               logWorkosVerifyFailure(
                 token,
@@ -112,10 +135,42 @@ export const WorkosVerifierLive: Layer.Layer<
             },
           });
           const payload = verified.payload as {
+            readonly iss?: unknown;
             readonly sub?: unknown;
+            readonly client_id?: unknown;
             readonly org_id?: unknown;
             readonly organization_id?: unknown;
           };
+          if (
+            typeof payload.iss !== "string" ||
+            !isAcceptedWorkosIssuer(payload.iss, config.workosIssuer)
+          ) {
+            logWorkosVerifyFailure(
+              token,
+              {
+                workosIssuer: config.workosIssuer,
+                workosJwksUrl: config.workosJwksUrl,
+                acceptedIssuers: issuers,
+              },
+              new Error("unexpected WorkOS issuer claim"),
+            );
+            return yield* Effect.fail(unauthorized("invalid_workos_token"));
+          }
+          if (
+            expectedClientId !== undefined &&
+            payload.client_id !== expectedClientId
+          ) {
+            logWorkosVerifyFailure(
+              token,
+              {
+                workosIssuer: config.workosIssuer,
+                workosJwksUrl: config.workosJwksUrl,
+                acceptedIssuers: issuers,
+              },
+              new Error("unexpected WorkOS client_id claim"),
+            );
+            return yield* Effect.fail(unauthorized("invalid_workos_token"));
+          }
           if (typeof payload.sub !== "string") {
             return yield* Effect.fail(unauthorized("workos_token_no_subject"));
           }

--- a/infra/relay/test/workos.test.ts
+++ b/infra/relay/test/workos.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { acceptedWorkosIssuers } from "../src/workos.ts";
+
+describe("acceptedWorkosIssuers", () => {
+  test("accepts WorkOS issuer with and without trailing slash", () => {
+    expect(acceptedWorkosIssuers("https://api.workos.com")).toEqual([
+      "https://api.workos.com",
+      "https://api.workos.com/",
+    ]);
+    expect(acceptedWorkosIssuers("https://api.workos.com/")).toEqual([
+      "https://api.workos.com",
+      "https://api.workos.com/",
+    ]);
+  });
+});

--- a/infra/relay/test/workos.test.ts
+++ b/infra/relay/test/workos.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { acceptedWorkosIssuers } from "../src/workos.ts";
+import {
+  acceptedWorkosIssuers,
+  expectedWorkosClientId,
+  isAcceptedWorkosIssuer,
+} from "../src/workos.ts";
 
 describe("acceptedWorkosIssuers", () => {
   test("accepts WorkOS issuer with and without trailing slash", () => {
@@ -12,5 +16,28 @@ describe("acceptedWorkosIssuers", () => {
       "https://api.workos.com",
       "https://api.workos.com/",
     ]);
+  });
+
+  test("accepts WorkOS User Management token issuers", () => {
+    expect(
+      isAcceptedWorkosIssuer(
+        "https://api.workos.com/user_management/client_01KW6ZF0389TC20FTQHK4VP8KA",
+        "https://api.workos.com",
+      ),
+    ).toBe(true);
+    expect(
+      isAcceptedWorkosIssuer(
+        "https://example.test/user_management/client_01KW6ZF0389TC20FTQHK4VP8KA",
+        "https://api.workos.com",
+      ),
+    ).toBe(false);
+  });
+
+  test("extracts expected client id from WorkOS JWKS URL", () => {
+    expect(
+      expectedWorkosClientId(
+        "https://api.workos.com/sso/jwks/client_01KWGQ818571ARFATQ3G9AR2Y2",
+      ),
+    ).toBe("client_01KWGQ818571ARFATQ3G9AR2Y2");
   });
 });

--- a/infra/relay/wrangler.jsonc
+++ b/infra/relay/wrangler.jsonc
@@ -18,7 +18,7 @@
   "vars": {
     "RELAY_ISSUER": "https://relay.stuff.md",
     "WORKOS_ISSUER": "https://api.workos.com",
-    "WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KW6ZEZKVMZ0G429A89XZD83Q",
+    "WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KWGQ818571ARFATQ3G9AR2Y2",
     // Public key only — the matching private key is a secret (RELAY_MINT_PRIVATE_JWK).
     "RELAY_MINT_PUBLIC_JWK": "{\"crv\":\"Ed25519\",\"x\":\"A2Ig1XwHKDznhyTbPD9IVTlJpaN4YImgQadx-Gl81Bs\",\"kty\":\"OKP\"}",
 

--- a/infra/relay/wrangler.jsonc
+++ b/infra/relay/wrangler.jsonc
@@ -18,7 +18,7 @@
   "vars": {
     "RELAY_ISSUER": "https://relay.stuff.md",
     "WORKOS_ISSUER": "https://api.workos.com",
-    "WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KWGQ818571ARFATQ3G9AR2Y2",
+    "WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KW6ZEZKVMZ0G429A89XZD83Q",
     // Public key only — the matching private key is a secret (RELAY_MINT_PRIVATE_JWK).
     "RELAY_MINT_PUBLIC_JWK": "{\"crv\":\"Ed25519\",\"x\":\"A2Ig1XwHKDznhyTbPD9IVTlJpaN4YImgQadx-Gl81Bs\",\"kty\":\"OKP\"}",
 
@@ -33,7 +33,7 @@
     "MANAGED_TUNNEL_BASE_DOMAIN": "t.stuff.md",
     "MANAGED_TUNNEL_NAMESPACE": "zenv",
     "CF_ACCOUNT_ID": "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID",
-    "CF_ZONE_ID": "REPLACE_WITH_ZONE_ID_FOR_BASE_DOMAIN"
+    "CF_ZONE_ID": "REPLACE_WITH_ZONE_ID_FOR_BASE_DOMAIN",
   },
 
   // Hyperdrive fronting PlanetScale Postgres. Create with:
@@ -42,7 +42,7 @@
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",
-      "id": "c49c02e939494a958fb5fe6805e7b0f2"
-    }
-  ]
+      "id": "c49c02e939494a958fb5fe6805e7b0f2",
+    },
+  ],
 }

--- a/infra/relay/wrangler.jsonc
+++ b/infra/relay/wrangler.jsonc
@@ -29,11 +29,12 @@
     //   MANAGED_TUNNEL_BASE_DOMAIN — apex the tunnel hostnames live under (must be
     //     a zone on this Cloudflare account), e.g. "t.stuff.md".
     //   MANAGED_TUNNEL_NAMESPACE   — per-deployment prefix for tunnel + hostname.
-    //   CF_ACCOUNT_ID / CF_ZONE_ID — the account, and the zone id of BASE_DOMAIN.
+    //   CF_ACCOUNT_ID / CF_ZONE_ID — the account, and the DNS zone id that owns
+    //     BASE_DOMAIN (for t.stuff.md, this is the stuff.md zone).
     "MANAGED_TUNNEL_BASE_DOMAIN": "t.stuff.md",
     "MANAGED_TUNNEL_NAMESPACE": "zenv",
-    "CF_ACCOUNT_ID": "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID",
-    "CF_ZONE_ID": "REPLACE_WITH_ZONE_ID_FOR_BASE_DOMAIN",
+    "CF_ACCOUNT_ID": "40dd16663d44dc635537be6d183af841",
+    "CF_ZONE_ID": "1ebb00c5fd61050e9f48ce1c791a29da",
   },
 
   // Hyperdrive fronting PlanetScale Postgres. Create with:

--- a/packages/wire/src/connect.ts
+++ b/packages/wire/src/connect.ts
@@ -35,6 +35,60 @@ export class EnvironmentEndpoint extends Schema.Class<EnvironmentEndpoint>(
   wsBaseUrl: Schema.String,
 }) {}
 
+export const AdvertisedEndpointProviderKind = Schema.Literal(
+  "core",
+  "tunnel",
+  "manual",
+  "private-network",
+);
+export type AdvertisedEndpointProviderKind =
+  typeof AdvertisedEndpointProviderKind.Type;
+
+export const AdvertisedEndpointReachability = Schema.Literal(
+  "loopback",
+  "lan",
+  "public",
+  "tunnel",
+  "private-network",
+);
+export type AdvertisedEndpointReachability =
+  typeof AdvertisedEndpointReachability.Type;
+
+export const AdvertisedEndpointHostedHttpsCompatibility = Schema.Literal(
+  "compatible",
+  "mixed-content-blocked",
+  "unknown",
+);
+export type AdvertisedEndpointHostedHttpsCompatibility =
+  typeof AdvertisedEndpointHostedHttpsCompatibility.Type;
+
+export const AdvertisedEndpointStatus = Schema.Literal(
+  "available",
+  "unavailable",
+  "unknown",
+);
+export type AdvertisedEndpointStatus = typeof AdvertisedEndpointStatus.Type;
+
+export const AdvertisedEndpointCompatibility = Schema.Struct({
+  hostedHttpsApp: AdvertisedEndpointHostedHttpsCompatibility,
+});
+export type AdvertisedEndpointCompatibility =
+  typeof AdvertisedEndpointCompatibility.Type;
+
+export class AdvertisedEndpoint extends Schema.Class<AdvertisedEndpoint>(
+  "AdvertisedEndpoint",
+)({
+  id: Schema.String,
+  label: Schema.String,
+  providerKind: AdvertisedEndpointProviderKind,
+  httpBaseUrl: Schema.String,
+  wsBaseUrl: Schema.String,
+  reachability: AdvertisedEndpointReachability,
+  compatibility: AdvertisedEndpointCompatibility,
+  status: AdvertisedEndpointStatus,
+  isDefault: Schema.Boolean,
+}) {}
+
 /**
  * Everything a client needs to identify and reach an environment. Keyed by
  * `environmentId` (never by "this laptop"), so the relay and clients treat
@@ -46,6 +100,7 @@ export class EnvironmentDescriptor extends Schema.Class<EnvironmentDescriptor>(
   environmentId: EnvironmentId,
   providerKind: ProviderKind,
   endpoint: EnvironmentEndpoint,
+  advertisedEndpoints: Schema.optional(Schema.Array(AdvertisedEndpoint)),
   label: Schema.optional(Schema.String),
 }) {}
 
@@ -121,6 +176,7 @@ export class RelayLinkStatus extends Schema.Class<RelayLinkStatus>(
   environmentId: Schema.optional(EnvironmentId),
   label: Schema.optional(Schema.String),
   heartbeatActive: Schema.Boolean,
+  advertisedEndpoints: Schema.optional(Schema.Array(AdvertisedEndpoint)),
 }) {}
 
 /** Link this environment to a relay under the signed-in WorkOS account. */

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -3,6 +3,7 @@ import { Schema } from "effect";
 
 import {
   AgentEvent,
+  AdvertisedEndpoint,
   Chat,
   ComposerInput,
   defaultModelEnabledByProvider,
@@ -13,6 +14,7 @@ import {
   MODELS_BY_PROVIDER,
   PokemonPokedexEntry,
   RepositorySettingsFile,
+  RelayLinkStatus,
   resolveModelSlug,
   SettingsFile,
   Session,
@@ -143,6 +145,68 @@ describe("AgentEvent round-trips", () => {
         status: "spinning",
       }),
     ).toThrow();
+  });
+});
+
+describe("AdvertisedEndpoint round-trip", () => {
+  const encoded = {
+    id: "tunnel:managed-relay",
+    label: "Managed tunnel",
+    providerKind: "tunnel" as const,
+    httpBaseUrl: "https://env.example.test",
+    wsBaseUrl: "wss://env.example.test/rpc",
+    reachability: "tunnel" as const,
+    compatibility: { hostedHttpsApp: "compatible" as const },
+    status: "available" as const,
+    isDefault: true,
+  };
+
+  it("round-trips the advertised endpoint wire shape", () => {
+    roundTrip(AdvertisedEndpoint, encoded);
+  });
+
+  it("rejects invalid enum literals", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(AdvertisedEndpoint)({
+        ...encoded,
+        reachability: "vpn",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("RelayLinkStatus advertised endpoint compatibility", () => {
+  const base = {
+    linked: true,
+    relayUrl: "https://relay.example.test",
+    environmentId: "env_123",
+    label: "Mac",
+    heartbeatActive: true,
+  };
+
+  it("decodes legacy status without advertisedEndpoints", () => {
+    const decoded = Schema.decodeUnknownSync(RelayLinkStatus)(base);
+    expect(decoded.linked).toBe(true);
+    expect(decoded.advertisedEndpoints).toBeUndefined();
+  });
+
+  it("round-trips status with advertisedEndpoints", () => {
+    roundTrip(RelayLinkStatus, {
+      ...base,
+      advertisedEndpoints: [
+        {
+          id: "core:lan",
+          label: "LAN",
+          providerKind: "core" as const,
+          httpBaseUrl: "http://192.168.1.10:8787",
+          wsBaseUrl: "ws://192.168.1.10:8787",
+          reachability: "lan" as const,
+          compatibility: { hostedHttpsApp: "mixed-content-blocked" as const },
+          status: "available" as const,
+          isDefault: true,
+        },
+      ],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add additive `AdvertisedEndpoint` wire types and include advertised endpoints on environment/relay status responses
- generate LAN, loopback, and managed relay tunnel endpoints from server config with stable ids and default ordering
- persist managed tunnel host with an idempotent SQLite migration and show selectable advertised endpoints in Devices

## Validation
- `bun --filter @zuse/wire test`
- `bun --filter @zuse/server test`
- `bun --filter renderer test`
- `bun --filter @zuse/relay test`
- `bun --filter @zuse/wire check-types`
- `bun --filter @zuse/server check-types`
- `bun --filter renderer check-types`
- `bunx prettier --check ...`
- `git diff --check`