### PR TITLE
Fix chat timeline live scrolling

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -31,6 +31,8 @@ import {
 } from "../lib/chat-timeline-rows.ts";
 import {
   getAnchoredTurnMetrics,
+  shouldDeferAutomaticEndScroll,
+  shouldRestoreAnchorScrollOffset,
   type TimelineScrollMode,
 } from "../lib/timeline-scroll-anchoring.ts";
 import {
@@ -181,7 +183,15 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     useRef<TimelineScrollMode>("following-end");
   const activeTimelineAnchorIndexRef = useRef<number | null>(null);
   const lastAnchoredUserMessageIdRef = useRef<string | null>(null);
+  const pendingTimelineAnchorRef = useRef<string | null>(null);
   const positionedTimelineAnchorRef = useRef<string | null>(null);
+  const settledTimelineAnchorRef = useRef<string | null>(null);
+  const pendingAnchorScrollRestoreRef = useRef<{
+    readonly messageId: string;
+    readonly offset: number;
+    readonly userNavigationGeneration: number;
+  } | null>(null);
+  const anchorScrollRestoreFrameRef = useRef<number | null>(null);
   const userNavigationGenerationRef = useRef(0);
   const liveFollowGenerationRef = useRef<number | null>(0);
   const showPillTimerRef = useRef<number | null>(null);
@@ -213,8 +223,15 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     userNavigationGenerationRef.current += 1;
     timelineScrollModeRef.current = "free-scrolling";
     liveFollowGenerationRef.current = null;
+    pendingTimelineAnchorRef.current = null;
     activeTimelineAnchorIndexRef.current = null;
     positionedTimelineAnchorRef.current = null;
+    settledTimelineAnchorRef.current = null;
+    pendingAnchorScrollRestoreRef.current = null;
+    if (anchorScrollRestoreFrameRef.current !== null) {
+      cancelAnimationFrame(anchorScrollRestoreFrameRef.current);
+      anchorScrollRestoreFrameRef.current = null;
+    }
     setTimelineAnchorMessageId(null);
   }, []);
 
@@ -223,8 +240,15 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       isAtEndRef.current = true;
       timelineScrollModeRef.current = "following-end";
       liveFollowGenerationRef.current = userNavigationGenerationRef.current;
+      pendingTimelineAnchorRef.current = null;
       activeTimelineAnchorIndexRef.current = null;
       positionedTimelineAnchorRef.current = null;
+      settledTimelineAnchorRef.current = null;
+      pendingAnchorScrollRestoreRef.current = null;
+      if (anchorScrollRestoreFrameRef.current !== null) {
+        cancelAnimationFrame(anchorScrollRestoreFrameRef.current);
+        anchorScrollRestoreFrameRef.current = null;
+      }
       setTimelineAnchorMessageId(null);
       lastAnchoredUserMessageIdRef.current = latestUserMessageId;
       hideJumpPill();
@@ -285,6 +309,12 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   const handleAnchorReady = useCallback(
     (info: { anchorIndex: number | undefined }) => {
       if (info.anchorIndex === undefined) return;
+      if (timelineAnchorMessageId !== null) {
+        pendingTimelineAnchorRef.current =
+          pendingTimelineAnchorRef.current === timelineAnchorMessageId
+            ? null
+            : pendingTimelineAnchorRef.current;
+      }
       activeTimelineAnchorIndexRef.current = info.anchorIndex;
       if (
         timelineAnchorMessageId === null ||
@@ -293,32 +323,122 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
         return;
       }
       positionedTimelineAnchorRef.current = timelineAnchorMessageId;
-      void listRef.current?.scrollToIndex({
-        index: info.anchorIndex,
-        animated: true,
-        viewPosition: 0,
-        viewOffset: CHAT_LIST_ANCHOR_OFFSET,
-      });
+      settledTimelineAnchorRef.current = null;
+      const messageId = timelineAnchorMessageId;
+      const positionAnchor = (remainingAttempts: number) => {
+        requestAnimationFrame(() => {
+          if (positionedTimelineAnchorRef.current !== messageId) return;
+
+          const list = listRef.current;
+          if (!list) {
+            if (remainingAttempts > 0) positionAnchor(remainingAttempts - 1);
+            return;
+          }
+
+          const scrollNode = list.getScrollableNode();
+          let finished = false;
+          let fallbackTimer = 0;
+          const finishAnimatedPositioning = () => {
+            if (finished) return;
+            finished = true;
+            window.clearTimeout(fallbackTimer);
+            scrollNode?.removeEventListener(
+              "scrollend",
+              finishAnimatedPositioning,
+            );
+            if (positionedTimelineAnchorRef.current !== messageId) return;
+
+            const scrollOffset = list.getState().scroll;
+            void list.scrollToOffset({ offset: scrollOffset, animated: false });
+            settledTimelineAnchorRef.current = messageId;
+          };
+
+          fallbackTimer = window.setTimeout(finishAnimatedPositioning, 750);
+          scrollNode?.addEventListener("scrollend", finishAnimatedPositioning, {
+            once: true,
+          });
+          void list.scrollToIndex({
+            index: info.anchorIndex!,
+            animated: true,
+            viewPosition: 0,
+            viewOffset: CHAT_LIST_ANCHOR_OFFSET,
+          });
+        });
+      };
+      requestAnimationFrame(() => positionAnchor(12));
     },
     [timelineAnchorMessageId],
   );
 
+  const handleAnchorSizeChanged = useCallback((size: number) => {
+    void size;
+    const messageId = timelineAnchorMessageId;
+    if (
+      messageId === null ||
+      settledTimelineAnchorRef.current !== messageId ||
+      liveFollowGenerationRef.current === userNavigationGenerationRef.current
+    ) {
+      return;
+    }
+
+    const scrollOffset = listRef.current?.getState().scroll;
+    if (scrollOffset === undefined) return;
+
+    if (pendingAnchorScrollRestoreRef.current === null) {
+      pendingAnchorScrollRestoreRef.current = {
+        messageId,
+        offset: scrollOffset,
+        userNavigationGeneration: userNavigationGenerationRef.current,
+      };
+    }
+    if (anchorScrollRestoreFrameRef.current !== null) return;
+
+    anchorScrollRestoreFrameRef.current = requestAnimationFrame(() => {
+      anchorScrollRestoreFrameRef.current = null;
+      const pending = pendingAnchorScrollRestoreRef.current;
+      pendingAnchorScrollRestoreRef.current = null;
+      const list = listRef.current;
+      const currentOffset = list?.getState().scroll;
+      if (
+        list === null ||
+        pending === null ||
+        typeof currentOffset !== "number" ||
+        !shouldRestoreAnchorScrollOffset({
+          anchorId: pending.messageId,
+          settledAnchorId: settledTimelineAnchorRef.current,
+          expectedOffset: pending.offset,
+          currentOffset,
+          expectedUserNavigationGeneration: pending.userNavigationGeneration,
+          currentUserNavigationGeneration: userNavigationGenerationRef.current,
+        })
+      ) {
+        return;
+      }
+
+      void list.scrollToOffset({ offset: pending.offset, animated: false });
+    });
+  }, [timelineAnchorMessageId]);
+
   const handleScroll = useCallback(() => {
     const isAtEnd = resolveTimelineIsAtEnd(listRef.current?.getState());
-    if (isAtEnd === undefined || isAtEndRef.current === isAtEnd) return;
+    if (isAtEnd === undefined) return;
 
+    if (
+      !isAtEnd &&
+      liveFollowGenerationRef.current === userNavigationGenerationRef.current
+    ) {
+      hideJumpPill();
+      return;
+    }
+
+    if (isAtEndRef.current === isAtEnd) return;
     isAtEndRef.current = isAtEnd;
+
     if (isAtEnd) {
       timelineScrollModeRef.current = "following-end";
       liveFollowGenerationRef.current = userNavigationGenerationRef.current;
       hideJumpPill();
     } else {
-      if (
-        liveFollowGenerationRef.current === userNavigationGenerationRef.current
-      ) {
-        hideJumpPill();
-        return;
-      }
       timelineScrollModeRef.current = "free-scrolling";
       liveFollowGenerationRef.current = null;
       showJumpPillSoon();
@@ -355,7 +475,14 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   useEffect(() => {
     timelineScrollModeRef.current = "following-end";
     activeTimelineAnchorIndexRef.current = null;
+    pendingTimelineAnchorRef.current = null;
     positionedTimelineAnchorRef.current = null;
+    settledTimelineAnchorRef.current = null;
+    pendingAnchorScrollRestoreRef.current = null;
+    if (anchorScrollRestoreFrameRef.current !== null) {
+      cancelAnimationFrame(anchorScrollRestoreFrameRef.current);
+      anchorScrollRestoreFrameRef.current = null;
+    }
     setTimelineAnchorMessageId(null);
     lastAnchoredUserMessageIdRef.current = null;
     userNavigationGenerationRef.current = 0;
@@ -402,21 +529,29 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   }, [cancelTimelineLiveFollowForUserNavigation, sessionId]);
 
   useEffect(() => {
-    if (!inFlight || latestUserMessageId === null) return;
-    if (lastAnchoredUserMessageIdRef.current === latestUserMessageId) return;
+    if (latestUserMessageId === null) return;
+    const previousLatestUserMessageId = lastAnchoredUserMessageIdRef.current;
+    if (previousLatestUserMessageId === latestUserMessageId) return;
 
     lastAnchoredUserMessageIdRef.current = latestUserMessageId;
+    if (previousLatestUserMessageId === null && !inFlight) return;
+
     timelineScrollModeRef.current = "anchoring-new-turn";
     liveFollowGenerationRef.current = userNavigationGenerationRef.current;
+    pendingTimelineAnchorRef.current = latestUserMessageId;
     activeTimelineAnchorIndexRef.current = null;
     positionedTimelineAnchorRef.current = null;
+    settledTimelineAnchorRef.current = null;
+    pendingAnchorScrollRestoreRef.current = null;
     setTimelineAnchorMessageId(latestUserMessageId);
     hideJumpPill();
   }, [hideJumpPill, inFlight, latestUserMessageId]);
 
   useEffect(() => {
     if (inFlight) return;
+    pendingTimelineAnchorRef.current = null;
     positionedTimelineAnchorRef.current = null;
+    settledTimelineAnchorRef.current = null;
     setTimelineAnchorMessageId(null);
   }, [inFlight]);
 
@@ -438,6 +573,15 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
 
         const list = listRef.current;
         if (!list) return;
+        if (
+          shouldDeferAutomaticEndScroll({
+            pendingAnchorId: pendingTimelineAnchorRef.current,
+            positionedAnchorId: positionedTimelineAnchorRef.current,
+            settledAnchorId: settledTimelineAnchorRef.current,
+          })
+        ) {
+          return;
+        }
 
         if (timelineScrollModeRef.current === "anchoring-new-turn") {
           const metrics = getActiveTimelineTurnMetrics(list);
@@ -569,6 +713,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                       anchoredEndSpace: {
                         ...anchoredEndSpace,
                         onReady: handleAnchorReady,
+                        onSizeChanged: handleAnchorSizeChanged,
                       },
                     }
                   : {})}

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -220,6 +220,11 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     }, 150);
   }, []);
 
+  const showJumpPillNow = useCallback(() => {
+    clearShowPillTimer();
+    setShowPill(true);
+  }, [clearShowPillTimer]);
+
   const showJumpPillIfScrollNodeLeftEnd = useCallback(() => {
     const scrollNode = listRef.current?.getScrollableNode();
     const isAtEnd = resolveScrollableNodeIsAtEnd(scrollNode);
@@ -232,7 +237,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     }
   }, [hideJumpPill, showJumpPillSoon]);
 
-  const cancelTimelineLiveFollowForUserNavigation = useCallback(() => {
+  const cancelTimelineLiveFollowForUserNavigation = useCallback((showPillForGesture = false) => {
     userNavigationGenerationRef.current += 1;
     timelineScrollModeRef.current = "free-scrolling";
     liveFollowGenerationRef.current = null;
@@ -246,8 +251,13 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       anchorScrollRestoreFrameRef.current = null;
     }
     setTimelineAnchorMessageId(null);
+    if (showPillForGesture) {
+      isAtEndRef.current = false;
+      showJumpPillNow();
+      return;
+    }
     requestAnimationFrame(showJumpPillIfScrollNodeLeftEnd);
-  }, [showJumpPillIfScrollNodeLeftEnd]);
+  }, [showJumpPillIfScrollNodeLeftEnd, showJumpPillNow]);
 
   const scrollToEnd = useCallback(
     (animated = false) => {
@@ -520,22 +530,25 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       } else {
         scrollElementRef.current = null;
       }
-      const handleManualNavigation = () => {
-        cancelTimelineLiveFollowForUserNavigation();
+      const handleManualScrollNavigation = () => {
+        cancelTimelineLiveFollowForUserNavigation(true);
       };
-      scrollNode.addEventListener("wheel", handleManualNavigation, {
+      const handleManualPointerNavigation = () => {
+        cancelTimelineLiveFollowForUserNavigation(false);
+      };
+      scrollNode.addEventListener("wheel", handleManualScrollNavigation, {
         passive: true,
       });
-      scrollNode.addEventListener("touchmove", handleManualNavigation, {
+      scrollNode.addEventListener("touchmove", handleManualScrollNavigation, {
         passive: true,
       });
-      scrollNode.addEventListener("pointerdown", handleManualNavigation, {
+      scrollNode.addEventListener("pointerdown", handleManualPointerNavigation, {
         passive: true,
       });
       removeListeners = () => {
-        scrollNode.removeEventListener("wheel", handleManualNavigation);
-        scrollNode.removeEventListener("touchmove", handleManualNavigation);
-        scrollNode.removeEventListener("pointerdown", handleManualNavigation);
+        scrollNode.removeEventListener("wheel", handleManualScrollNavigation);
+        scrollNode.removeEventListener("touchmove", handleManualScrollNavigation);
+        scrollNode.removeEventListener("pointerdown", handleManualPointerNavigation);
       };
     });
 

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -31,6 +31,7 @@ import {
 } from "../lib/chat-timeline-rows.ts";
 import {
   getAnchoredTurnMetrics,
+  resolveScrollableNodeIsAtEnd,
   shouldDeferAutomaticEndScroll,
   shouldRestoreAnchorScrollOffset,
   type TimelineScrollMode,
@@ -219,6 +220,18 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     }, 150);
   }, []);
 
+  const showJumpPillIfScrollNodeLeftEnd = useCallback(() => {
+    const scrollNode = listRef.current?.getScrollableNode();
+    const isAtEnd = resolveScrollableNodeIsAtEnd(scrollNode);
+    if (isAtEnd === false) {
+      isAtEndRef.current = false;
+      showJumpPillSoon();
+    } else if (isAtEnd === true) {
+      isAtEndRef.current = true;
+      hideJumpPill();
+    }
+  }, [hideJumpPill, showJumpPillSoon]);
+
   const cancelTimelineLiveFollowForUserNavigation = useCallback(() => {
     userNavigationGenerationRef.current += 1;
     timelineScrollModeRef.current = "free-scrolling";
@@ -233,7 +246,8 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       anchorScrollRestoreFrameRef.current = null;
     }
     setTimelineAnchorMessageId(null);
-  }, []);
+    requestAnimationFrame(showJumpPillIfScrollNodeLeftEnd);
+  }, [showJumpPillIfScrollNodeLeftEnd]);
 
   const scrollToEnd = useCallback(
     (animated = false) => {
@@ -420,7 +434,10 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   }, [timelineAnchorMessageId]);
 
   const handleScroll = useCallback(() => {
-    const isAtEnd = resolveTimelineIsAtEnd(listRef.current?.getState());
+    const list = listRef.current;
+    const nodeAtEnd = resolveScrollableNodeIsAtEnd(list?.getScrollableNode());
+    const stateAtEnd = resolveTimelineIsAtEnd(list?.getState());
+    const isAtEnd = nodeAtEnd ?? stateAtEnd;
     if (isAtEnd === undefined) return;
 
     if (

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -520,9 +520,17 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
 
   useEffect(() => {
     let removeListeners: (() => void) | null = null;
-    const frame = requestAnimationFrame(() => {
+    let frame: number | null = null;
+    const attachListeners = (remainingAttempts: number) => {
       const scrollNode = listRef.current?.getScrollableNode();
-      if (!scrollNode) return;
+      if (!scrollNode) {
+        if (remainingAttempts > 0) {
+          frame = requestAnimationFrame(() =>
+            attachListeners(remainingAttempts - 1),
+          );
+        }
+        return;
+      }
       if (scrollNode instanceof HTMLDivElement) {
         scrollNode.dataset.pane = "chat";
         scrollNode.tabIndex = -1;
@@ -547,13 +555,20 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       });
       removeListeners = () => {
         scrollNode.removeEventListener("wheel", handleManualScrollNavigation);
-        scrollNode.removeEventListener("touchmove", handleManualScrollNavigation);
-        scrollNode.removeEventListener("pointerdown", handleManualPointerNavigation);
+        scrollNode.removeEventListener(
+          "touchmove",
+          handleManualScrollNavigation,
+        );
+        scrollNode.removeEventListener(
+          "pointerdown",
+          handleManualPointerNavigation,
+        );
       };
-    });
+    };
+    frame = requestAnimationFrame(() => attachListeners(30));
 
     return () => {
-      cancelAnimationFrame(frame);
+      if (frame !== null) cancelAnimationFrame(frame);
       removeListeners?.();
     };
   }, [cancelTimelineLiveFollowForUserNavigation, sessionId]);

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -19,20 +19,17 @@ export function JumpToLatestPill({
   streaming: boolean;
   onClick: () => void;
 }) {
+  if (!visible) return null;
+
   return (
     <div
       className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-3 z-10 flex justify-center",
+        "pointer-events-none absolute inset-x-0 bottom-3 z-40 flex translate-y-0 justify-center opacity-100",
         "transition-all duration-150 ease-out motion-reduce:transition-none",
-        visible
-          ? "translate-y-0 opacity-100"
-          : "pointer-events-none translate-y-1 opacity-0",
       )}
-      aria-hidden={!visible}
     >
       <button
         type="button"
-        tabIndex={visible ? 0 : -1}
         onClick={onClick}
         aria-label="Jump to latest"
         className={cn(
@@ -41,7 +38,6 @@ export function JumpToLatestPill({
           "backdrop-blur dark:shadow-[0_2px_8px_color-mix(in_oklch,black_28%,transparent)]",
           "hover:text-foreground hover:bg-popover",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          !visible && "pointer-events-none",
         )}
       >
         {streaming ? (
@@ -52,7 +48,7 @@ export function JumpToLatestPill({
         ) : (
           <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5" />
         )}
-        <span>{streaming ? "Streaming…" : "Jump to latest"}</span>
+        <span>Jump to latest</span>
       </button>
     </div>
   );

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -4,8 +4,8 @@ import { ArrowDown01Icon } from "@hugeicons-pro/core-bulk-rounded";
 import { cn } from "~/lib/utils";
 
 /**
- * Floating "Jump to latest" affordance, pinned to the center-right of the
- * chat pane. Appears once the reader has scrolled away from the live edge
+ * Floating "Jump to latest" affordance, pinned above the composer in the
+ * center of the chat pane. Appears once the reader has scrolled away from the live edge
  * (principle 9); while a response is still streaming out of view it shows a
  * pulsing activity dot (principle 8). Fades/slides in with a CSS transition
  * that respects `prefers-reduced-motion`.
@@ -24,7 +24,7 @@ export function JumpToLatestPill({
   return (
     <div
       className={cn(
-        "pointer-events-none absolute top-1/2 right-4 z-50 flex -translate-y-1/2 opacity-100",
+        "pointer-events-none absolute bottom-4 left-1/2 z-50 flex -translate-x-1/2 opacity-100",
         "transition-all duration-150 ease-out motion-reduce:transition-none",
       )}
     >

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -4,7 +4,7 @@ import { ArrowDown01Icon } from "@hugeicons-pro/core-bulk-rounded";
 import { cn } from "~/lib/utils";
 
 /**
- * Floating "Jump to latest" affordance, pinned to the bottom-center of the
+ * Floating "Jump to latest" affordance, pinned to the center-right of the
  * chat pane. Appears once the reader has scrolled away from the live edge
  * (principle 9); while a response is still streaming out of view it shows a
  * pulsing activity dot (principle 8). Fades/slides in with a CSS transition
@@ -24,7 +24,7 @@ export function JumpToLatestPill({
   return (
     <div
       className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-3 z-40 flex translate-y-0 justify-center opacity-100",
+        "pointer-events-none absolute top-1/2 right-4 z-50 flex -translate-y-1/2 opacity-100",
         "transition-all duration-150 ease-out motion-reduce:transition-none",
       )}
     >

--- a/apps/renderer/src/lib/timeline-scroll-anchoring.ts
+++ b/apps/renderer/src/lib/timeline-scroll-anchoring.ts
@@ -11,6 +11,12 @@ export interface TimelineListMeasurementState {
   readonly sizeAtIndex: (index: number) => number | undefined;
 }
 
+export interface TimelineScrollableNodeState {
+  readonly scrollTop: number;
+  readonly scrollHeight: number;
+  readonly clientHeight: number;
+}
+
 export interface AnchoredTurnMetrics {
   readonly anchorTop: number;
   readonly lastBottom: number;
@@ -59,6 +65,23 @@ export function shouldRestoreAnchorScrollOffset({
     expectedUserNavigationGeneration === currentUserNavigationGeneration &&
     Math.abs(currentOffset - expectedOffset) <= tolerance
   );
+}
+
+export function resolveScrollableNodeIsAtEnd(
+  node: TimelineScrollableNodeState | null | undefined,
+  threshold = 24,
+): boolean | undefined {
+  if (node === null || node === undefined) return undefined;
+  const { scrollTop, scrollHeight, clientHeight } = node;
+  if (
+    !Number.isFinite(scrollTop) ||
+    !Number.isFinite(scrollHeight) ||
+    !Number.isFinite(clientHeight)
+  ) {
+    return undefined;
+  }
+
+  return scrollHeight - scrollTop - clientHeight <= threshold;
 }
 
 export function getRowBottom(

--- a/apps/renderer/src/lib/timeline-scroll-anchoring.ts
+++ b/apps/renderer/src/lib/timeline-scroll-anchoring.ts
@@ -22,6 +22,45 @@ export interface AnchoredTurnMetrics {
   readonly scrollDeltaToRevealEnd: number;
 }
 
+export function shouldDeferAutomaticEndScroll({
+  pendingAnchorId,
+  positionedAnchorId,
+  settledAnchorId,
+}: {
+  readonly pendingAnchorId: string | null;
+  readonly positionedAnchorId: string | null;
+  readonly settledAnchorId: string | null;
+}): boolean {
+  return (
+    pendingAnchorId !== null ||
+    (positionedAnchorId !== null && settledAnchorId !== positionedAnchorId)
+  );
+}
+
+export function shouldRestoreAnchorScrollOffset({
+  anchorId,
+  settledAnchorId,
+  expectedOffset,
+  currentOffset,
+  expectedUserNavigationGeneration,
+  currentUserNavigationGeneration,
+  tolerance = 2,
+}: {
+  readonly anchorId: string;
+  readonly settledAnchorId: string | null;
+  readonly expectedOffset: number;
+  readonly currentOffset: number;
+  readonly expectedUserNavigationGeneration: number;
+  readonly currentUserNavigationGeneration: number;
+  readonly tolerance?: number;
+}): boolean {
+  return (
+    settledAnchorId === anchorId &&
+    expectedUserNavigationGeneration === currentUserNavigationGeneration &&
+    Math.abs(currentOffset - expectedOffset) <= tolerance
+  );
+}
+
 export function getRowBottom(
   state: TimelineListMeasurementState,
   index: number,

--- a/apps/renderer/test/chat-timeline-rows.test.ts
+++ b/apps/renderer/test/chat-timeline-rows.test.ts
@@ -47,6 +47,43 @@ describe("chat timeline rows", () => {
     expect(rows.map((row) => rowAnchorMessageId(row))).toContain("u2");
   });
 
+  it("resolves the first optimistic user message as the new-chat anchor", () => {
+    const rows = deriveChatTimelineRows({
+      messages: [
+        message("u1", { _tag: "user", text: "first prompt", goal: null }),
+      ],
+      inFlight: true,
+      awaitingPlanApproval: false,
+    });
+
+    expect(resolveLatestUserMessageId(rows)).toBe("u1");
+    expect(rowAnchorMessageId(rows[0]!)).toBe("u1");
+  });
+
+  it("moves the anchor when a later user message appears before assistant output", () => {
+    const first = deriveChatTimelineRows({
+      messages: [
+        message("u1", { _tag: "user", text: "first prompt", goal: null }),
+        message("a1", { _tag: "assistant", text: "first reply" }),
+      ],
+      inFlight: false,
+      awaitingPlanApproval: false,
+    });
+    const second = deriveChatTimelineRows({
+      messages: [
+        message("u1", { _tag: "user", text: "first prompt", goal: null }),
+        message("a1", { _tag: "assistant", text: "first reply" }),
+        message("u2", { _tag: "user", text: "second prompt", goal: null }),
+      ],
+      inFlight: true,
+      awaitingPlanApproval: false,
+    });
+
+    expect(resolveLatestUserMessageId(first)).toBe("u1");
+    expect(resolveLatestUserMessageId(second)).toBe("u2");
+    expect(second.map((row) => rowAnchorMessageId(row))).toContain("u2");
+  });
+
   it("preserves stable row ids for unchanged messages", () => {
     const messages = [
       message("u1", { _tag: "user", text: "first", goal: null }),

--- a/apps/renderer/test/timeline-scroll-anchoring.test.ts
+++ b/apps/renderer/test/timeline-scroll-anchoring.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "bun:test";
 import {
   getAnchoredTurnMetrics,
   getRowBottom,
+  shouldDeferAutomaticEndScroll,
+  shouldRestoreAnchorScrollOffset,
 } from "../src/lib/timeline-scroll-anchoring.ts";
 
 function buildState({
@@ -114,5 +116,77 @@ describe("timeline scroll anchoring", () => {
     expect(metrics?.lastBottom).toBe(1540);
     expect(metrics?.visibleUsableBottom).toBe(1464);
     expect(metrics?.scrollDeltaToRevealEnd).toBe(76);
+  });
+
+  it("defers automatic end-follow while an anchor is pending or settling", () => {
+    expect(
+      shouldDeferAutomaticEndScroll({
+        pendingAnchorId: "u1",
+        positionedAnchorId: null,
+        settledAnchorId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDeferAutomaticEndScroll({
+        pendingAnchorId: null,
+        positionedAnchorId: "u1",
+        settledAnchorId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDeferAutomaticEndScroll({
+        pendingAnchorId: null,
+        positionedAnchorId: "u1",
+        settledAnchorId: "u1",
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves an anchored offset only while the same settled anchor is stable", () => {
+    expect(
+      shouldRestoreAnchorScrollOffset({
+        anchorId: "u1",
+        settledAnchorId: "u1",
+        expectedOffset: 320,
+        currentOffset: 321.5,
+        expectedUserNavigationGeneration: 2,
+        currentUserNavigationGeneration: 2,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRestoreAnchorScrollOffset({
+        anchorId: "u1",
+        settledAnchorId: "u2",
+        expectedOffset: 320,
+        currentOffset: 321,
+        expectedUserNavigationGeneration: 2,
+        currentUserNavigationGeneration: 2,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRestoreAnchorScrollOffset({
+        anchorId: "u1",
+        settledAnchorId: "u1",
+        expectedOffset: 320,
+        currentOffset: 326,
+        expectedUserNavigationGeneration: 2,
+        currentUserNavigationGeneration: 2,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRestoreAnchorScrollOffset({
+        anchorId: "u1",
+        settledAnchorId: "u1",
+        expectedOffset: 320,
+        currentOffset: 321,
+        expectedUserNavigationGeneration: 2,
+        currentUserNavigationGeneration: 3,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/renderer/test/timeline-scroll-anchoring.test.ts
+++ b/apps/renderer/test/timeline-scroll-anchoring.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   getAnchoredTurnMetrics,
   getRowBottom,
+  resolveScrollableNodeIsAtEnd,
   shouldDeferAutomaticEndScroll,
   shouldRestoreAnchorScrollOffset,
 } from "../src/lib/timeline-scroll-anchoring.ts";
@@ -188,5 +189,25 @@ describe("timeline scroll anchoring", () => {
         currentUserNavigationGeneration: 3,
       }),
     ).toBe(false);
+  });
+
+  it("detects whether the actual scroll node has left the live edge", () => {
+    expect(
+      resolveScrollableNodeIsAtEnd({
+        scrollTop: 960,
+        scrollHeight: 1400,
+        clientHeight: 420,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveScrollableNodeIsAtEnd({
+        scrollTop: 820,
+        scrollHeight: 1400,
+        clientHeight: 420,
+      }),
+    ).toBe(false);
+
+    expect(resolveScrollableNodeIsAtEnd(null)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- keep new user turns anchored near the top while their live response starts streaming
- defer automatic end-follow until pending anchor positioning has settled
- fix Jump to latest visibility after manual scrolling away from the live edge

## Root Cause
The timeline was committing transient `isAtEnd=false` scroll events produced by live-follow/anchor positioning. That could hide the Jump to latest pill and consume the state transition before a real user scroll occurred.

## Validation
- `cd apps/renderer && bun test`
- `cd apps/renderer && bun run check-types`
- `bun run build:desktop`