### PR TITLE
[codex] Update mobile app identity

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "Zuse Mobile",
-    "slug": "zuse-mobile",
+    "name": "Zuse",
+    "slug": "zuse",
     "scheme": "zuse",
     "version": "0.0.0",
     "orientation": "portrait",
@@ -17,7 +17,7 @@
           "NSAllowsLocalNetworking": true
         }
       },
-      "bundleIdentifier": "com.swarajbachu.zuse-mobile",
+      "bundleIdentifier": "com.zuse.sh",
       "appleTeamId": "HMCST4VV42"
     },
     "plugins": [

--- a/apps/mobile/ios/ZuseMobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/ZuseMobile.xcodeproj/project.pbxproj
@@ -382,8 +382,8 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.swarajbachu.zuse-mobile";
-				PRODUCT_NAME = ZuseMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zuse.sh;
+				PRODUCT_NAME = Zuse;
 				SWIFT_OBJC_BRIDGING_HEADER = "ZuseMobile/ZuseMobile-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -417,8 +417,8 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.swarajbachu.zuse-mobile";
-				PRODUCT_NAME = ZuseMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zuse.sh;
+				PRODUCT_NAME = Zuse;
 				SWIFT_OBJC_BRIDGING_HEADER = "ZuseMobile/ZuseMobile-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/mobile/ios/ZuseMobile/Info.plist
+++ b/apps/mobile/ios/ZuseMobile/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Zuse Mobile</string>
+	<string>Zuse</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -28,7 +28,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>zuse</string>
-				<string>com.swarajbachu.zuse-mobile</string>
+				<string>com.zuse.sh</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## Summary
- Rename the Expo mobile app from Zuse Mobile to Zuse.
- Change the Expo slug from zuse-mobile to zuse.
- Change the iOS bundle identifier and native URL scheme entry to com.zuse.sh.

## Validation
- cd apps/mobile && bun run check-types
- cd apps/mobile && plutil -lint ios/ZuseMobile/Info.plist