### PR TITLE
[codex] fix WorkOS refresh token persistence

### DIFF
--- a/apps/server/src/auth/layers/auth-service.ts
+++ b/apps/server/src/auth/layers/auth-service.ts
@@ -95,12 +95,16 @@ export const AuthServiceLive = Layer.scoped(
         Effect.map(parseBundle),
       );
 
-    const persist = (bundle: SessionBundle): Effect.Effect<void> =>
+    const persist = (
+      bundle: SessionBundle,
+    ): Effect.Effect<void, AuthTokenError> =>
       credentials.setWorkosSession(JSON.stringify(bundle)).pipe(
-        Effect.catchAll((cause) =>
-          Effect.sync(() => {
-            console.error("[zuse] failed to persist auth session", cause);
-          }),
+        Effect.mapError(
+          (cause) =>
+            new AuthTokenError({
+              reason: `Failed to persist auth session: ${cause.reason}`,
+              cause,
+            }),
         ),
       );
 
@@ -191,7 +195,14 @@ export const AuthServiceLive = Layer.scoped(
         }
 
         const bundle = result.right;
-        yield* persist(bundle);
+        const persisted = yield* persist(bundle).pipe(Effect.either);
+        if (persisted._tag === "Left") {
+          yield* Deferred.fail(
+            inflight.deferred,
+            new AuthFlowError({ reason: persisted.left.reason }),
+          );
+          return;
+        }
         yield* PubSub.publish(pubsub, toState(bundle));
         yield* Deferred.succeed(inflight.deferred, bundle);
       });

--- a/apps/server/src/auth/layers/workos.ts
+++ b/apps/server/src/auth/layers/workos.ts
@@ -70,6 +70,43 @@ interface WorkosAuthenticateResponse {
   };
 }
 
+const parseAuthenticateResponse = (
+  value: unknown,
+): WorkosAuthenticateResponse => {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("WorkOS authenticate response was not an object.");
+  }
+  const obj = value as Partial<WorkosAuthenticateResponse>;
+  const user = obj.user;
+  if (typeof obj.access_token !== "string" || obj.access_token === "") {
+    throw new Error("WorkOS authenticate response was missing access_token.");
+  }
+  if (typeof obj.refresh_token !== "string" || obj.refresh_token === "") {
+    throw new Error("WorkOS authenticate response was missing refresh_token.");
+  }
+  if (typeof user !== "object" || user === null) {
+    throw new Error("WorkOS authenticate response was missing user.");
+  }
+  if (typeof user.id !== "string" || user.id === "") {
+    throw new Error("WorkOS authenticate response was missing user.id.");
+  }
+  if (typeof user.email !== "string" || user.email === "") {
+    throw new Error("WorkOS authenticate response was missing user.email.");
+  }
+  return {
+    access_token: obj.access_token,
+    refresh_token: obj.refresh_token,
+    organization_id: obj.organization_id ?? null,
+    user: {
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name ?? null,
+      last_name: user.last_name ?? null,
+      profile_picture_url: user.profile_picture_url ?? null,
+    },
+  };
+};
+
 /** The normalized bundle we persist (keychain) and reason about internally. */
 export interface SessionBundle {
   readonly accessToken: string;
@@ -133,7 +170,7 @@ const authenticate = (
         const text = await res.text().catch(() => "");
         throw new Error(`WorkOS ${res.status}: ${text.slice(0, 500)}`);
       }
-      return (await res.json()) as WorkosAuthenticateResponse;
+      return parseAuthenticateResponse(await res.json());
     },
     catch: (cause) =>
       new AuthTokenError({

--- a/apps/server/test/auth-service.test.ts
+++ b/apps/server/test/auth-service.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Effect, Layer, ManagedRuntime } from "effect";
+
+import type { ProviderId } from "@zuse/wire";
+
+import { AuthServiceLive } from "../src/auth/layers/auth-service.ts";
+import type { SessionBundle } from "../src/auth/layers/workos.ts";
+import { AuthService } from "../src/auth/services/auth-service.ts";
+import { AuthShell } from "../src/auth/services/auth-shell.ts";
+import { CredentialsService } from "../src/provider/services/credentials-service.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const jwtWithExp = (expMs: number): string => {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString(
+    "base64url",
+  );
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(expMs / 1000) }),
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+};
+
+const makeBundle = (overrides: Partial<SessionBundle> = {}): SessionBundle => ({
+  accessToken: jwtWithExp(Date.now() + 15 * 60_000),
+  refreshToken: "refresh-token",
+  expiresAt: Date.now() + 15 * 60_000,
+  organizationId: null,
+  user: {
+    id: "user_123",
+    email: "user@example.com",
+    firstName: "User",
+    lastName: "One",
+    profilePictureUrl: null,
+  },
+  ...overrides,
+});
+
+const decodeStored = (raw: string | null): SessionBundle | null =>
+  raw === null ? null : (JSON.parse(raw) as SessionBundle);
+
+interface Harness {
+  readonly run: <A>(
+    effect: Effect.Effect<A, unknown, AuthService>,
+  ) => Promise<A>;
+  readonly readStored: () => SessionBundle | null;
+  readonly dispose: () => Promise<void>;
+}
+
+const makeHarness = (initial: SessionBundle): Harness => {
+  let stored: string | null = JSON.stringify(initial);
+  const CredentialsLayer = Layer.succeed(
+    CredentialsService,
+    CredentialsService.of({
+      get: (_providerId: ProviderId) => Effect.succeed(null),
+      set: (_providerId: ProviderId, _apiKey: string) => Effect.void,
+      remove: (_providerId: ProviderId) => Effect.void,
+      listConfigured: () => Effect.succeed([]),
+      setBrowser: (_origin: string, _username: string, _password: string) =>
+        Effect.void,
+      getBrowser: (_origin: string) => Effect.succeed(null),
+      removeBrowser: (_origin: string) => Effect.void,
+      listBrowser: () => Effect.succeed([]),
+      getWorkosSession: () => Effect.succeed(stored),
+      setWorkosSession: (bundleJson: string) =>
+        Effect.sync(() => {
+          stored = bundleJson;
+        }),
+      removeWorkosSession: () =>
+        Effect.sync(() => {
+          stored = null;
+        }),
+    }),
+  );
+  const AuthShellLayer = Layer.succeed(
+    AuthShell,
+    AuthShell.of({
+      redirectUri: "zuse://auth/callback",
+      open: (_url: string) => Effect.void,
+      onCallbackUrl: (_handler: (url: string) => void) => Effect.void,
+    }),
+  );
+  const runtime = ManagedRuntime.make(
+    AuthServiceLive.pipe(
+      Layer.provide(CredentialsLayer),
+      Layer.provide(AuthShellLayer),
+    ),
+  );
+  return {
+    run: <A>(effect: Effect.Effect<A, unknown, AuthService>) =>
+      runtime.runPromise(effect as Effect.Effect<A, unknown, never>),
+    readStored: () => decodeStored(stored),
+    dispose: () => runtime.dispose(),
+  };
+};
+
+const mockAuthenticate = (
+  handler: (body: Record<string, string>) => Response | Promise<Response>,
+): Array<Record<string, string>> => {
+  const calls: Array<Record<string, string>> = [];
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<
+      string,
+      string
+    >;
+    calls.push(body);
+    return await handler(body);
+  }) as typeof fetch;
+  return calls;
+};
+
+describe("AuthService WorkOS refresh", () => {
+  it("refreshes an expired access token and persists the rotated refresh token", async () => {
+    const old = makeBundle({
+      accessToken: jwtWithExp(Date.now() - 5 * 60_000),
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() - 5 * 60_000,
+    });
+    const nextAccessToken = jwtWithExp(Date.now() + 20 * 60_000);
+    const calls = mockAuthenticate((body) => {
+      expect(body.grant_type).toBe("refresh_token");
+      expect(body.refresh_token).toBe("old-refresh");
+      return Response.json({
+        access_token: nextAccessToken,
+        refresh_token: "rotated-refresh",
+        organization_id: "org_123",
+        user: {
+          id: "user_123",
+          email: "user@example.com",
+          first_name: "User",
+          last_name: "One",
+        },
+      });
+    });
+    const harness = makeHarness(old);
+    try {
+      const token = await harness.run(
+        Effect.flatMap(AuthService, (svc) => svc.getAccessToken()),
+      );
+      expect(token).toBe(nextAccessToken);
+      expect(calls).toHaveLength(1);
+      expect(harness.readStored()).toMatchObject({
+        accessToken: nextAccessToken,
+        refreshToken: "rotated-refresh",
+        organizationId: "org_123",
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("serializes concurrent refreshes so the stale refresh token is used once", async () => {
+    const old = makeBundle({
+      accessToken: jwtWithExp(Date.now() - 5 * 60_000),
+      refreshToken: "single-use-refresh",
+      expiresAt: Date.now() - 5 * 60_000,
+    });
+    const nextAccessToken = jwtWithExp(Date.now() + 20 * 60_000);
+    const calls = mockAuthenticate(async (body) => {
+      expect(body.refresh_token).toBe("single-use-refresh");
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return Response.json({
+        access_token: nextAccessToken,
+        refresh_token: "rotated-once",
+        user: { id: "user_123", email: "user@example.com" },
+      });
+    });
+    const harness = makeHarness(old);
+    try {
+      const [first, second] = await Promise.all([
+        harness.run(Effect.flatMap(AuthService, (svc) => svc.getAccessToken())),
+        harness.run(Effect.flatMap(AuthService, (svc) => svc.getAccessToken())),
+      ]);
+      expect(first).toBe(nextAccessToken);
+      expect(second).toBe(nextAccessToken);
+      expect(calls).toHaveLength(1);
+      expect(harness.readStored()?.refreshToken).toBe("rotated-once");
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("keeps getSession signed in when refresh has a transient failure", async () => {
+    const old = makeBundle({
+      accessToken: jwtWithExp(Date.now() - 5 * 60_000),
+      refreshToken: "temporarily-failing-refresh",
+      expiresAt: Date.now() - 5 * 60_000,
+    });
+    const calls = mockAuthenticate(
+      () => new Response("temporary outage", { status: 503 }),
+    );
+    const harness = makeHarness(old);
+    try {
+      const state = await harness.run(
+        Effect.flatMap(AuthService, (svc) => svc.getSession()),
+      );
+      expect(state._tag).toBe("SignedIn");
+      expect(calls).toHaveLength(1);
+      expect(harness.readStored()?.refreshToken).toBe(
+        "temporarily-failing-refresh",
+      );
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("rejects refresh responses that do not include a new refresh token", async () => {
+    const old = makeBundle({
+      accessToken: jwtWithExp(Date.now() - 5 * 60_000),
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() - 5 * 60_000,
+    });
+    mockAuthenticate(() =>
+      Response.json({
+        access_token: jwtWithExp(Date.now() + 20 * 60_000),
+        user: { id: "user_123", email: "user@example.com" },
+      }),
+    );
+    const harness = makeHarness(old);
+    try {
+      const result = await harness
+        .run(Effect.flatMap(AuthService, (svc) => svc.getAccessToken()))
+        .then(
+          () => ({ ok: true as const }),
+          (err) => ({ ok: false as const, err }),
+        );
+      expect(result.ok).toBe(false);
+      expect(harness.readStored()?.refreshToken).toBe("old-refresh");
+    } finally {
+      await harness.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- require valid WorkOS authenticate responses, including rotated refresh tokens
- make auth session persistence failures fail sign-in/refresh instead of silently continuing with a spent token
- add server regression coverage for expired access-token refresh, rotated token persistence, concurrent refresh serialization, transient refresh failures, and malformed refresh responses

## Root Cause
WorkOS refresh tokens can rotate and may be single-use. The app previously swallowed keychain persistence failures after refresh, so it could return a fresh access token while leaving the old, already-spent refresh token stored. That could force repeated reauth shortly after the access token expired.

## Validation
- `cd apps/server && bun test ./test/auth-service.test.ts`
- `cd apps/server && bun test`
- `bun run check-types`
- `bunx prettier --check apps/server/src/auth/layers/auth-service.ts apps/server/src/auth/layers/workos.ts apps/server/test/auth-service.test.ts`