### PR TITLE
Fix mobile relay DPoP auth

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -24,7 +24,7 @@ import * as Path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
-import { makeMainLayer } from "@zuse/server";
+import { makeMainLayer, wsServerProtocolLayer } from "@zuse/server";
 import { AGENTS_RUNNING_COUNT_CHANNEL, AuthFlowError } from "@zuse/wire";
 
 // macOS GUI apps launched from Finder inherit a minimal PATH
@@ -1342,6 +1342,11 @@ function createMainWindow() {
   const serverProtocol = electronServerProtocolLayer(
     mainWindow.webContents,
   ).pipe(Layer.provide(RpcSerialization.layerJson));
+  const relayWsPort = Number(process.env.ZUSE_DESKTOP_WS_PORT ?? 8787);
+  const relayWsProtocol = wsServerProtocolLayer({
+    port: relayWsPort,
+    host: "127.0.0.1",
+  });
 
   runtimeFiber = Effect.runFork(
     Layer.launch(
@@ -1349,7 +1354,14 @@ function createMainWindow() {
         userData: app.getPath("userData"),
         folderPicker,
         serverProtocol,
+        additionalServerProtocols: [relayWsProtocol],
         authShell,
+        lanAuth: {
+          policy: "protected",
+          advertisedHost: null,
+          port: relayWsPort,
+          pairingBootstrap: false,
+        },
       }),
     ).pipe(
       Effect.catchAllCause((cause) =>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -323,6 +323,27 @@ const appendAppLog = (fileName: string, line: string): void => {
   }
 };
 
+const appendRemoteConnectionLog = (
+  event: string,
+  fields: Record<string, unknown> = {},
+): void => {
+  appendAppLog(
+    "remote-connection.log",
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      event,
+      ...Object.fromEntries(
+        Object.entries(fields).map(([key, value]) => [
+          key,
+          value instanceof Error
+            ? { name: value.name, message: value.message }
+            : value,
+        ]),
+      ),
+    }),
+  );
+};
+
 type OpenTargetDefinition = {
   readonly id: string;
   readonly label: string;
@@ -1346,6 +1367,11 @@ function createMainWindow() {
   const relayWsProtocol = wsServerProtocolLayer({
     port: relayWsPort,
     host: "127.0.0.1",
+    onDiagnostic: appendRemoteConnectionLog,
+  });
+  appendRemoteConnectionLog("desktop.runtime.start", {
+    relayWsPort,
+    userData: app.getPath("userData"),
   });
 
   runtimeFiber = Effect.runFork(
@@ -1369,6 +1395,9 @@ function createMainWindow() {
           // Boot-time layer failures (sqlite open, migrator, config) are
           // unrecoverable — surface the cause and bail. Quiet
           // success-after-restart is preferable to a half-running app.
+          appendRemoteConnectionLog("desktop.runtime.fatal", {
+            cause: String(cause),
+          });
           console.error("[zuse] fatal boot error", cause);
           app.exit(1);
         }),

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -15,11 +15,16 @@ import { useConnectionsStore } from "~/store/connections";
 export default function ConnectionsScreen() {
   const { connections, hydrated, hydrate } = useConnectionsStore();
   const watchConnection = useConnectionRuntimeStore((state) => state.watch);
-  const snapshots = useConnectionRuntimeStore((state) => state.snapshotsByConnection);
+  const snapshots = useConnectionRuntimeStore(
+    (state) => state.snapshotsByConnection,
+  );
   const [search, setSearch] = useState("");
-  const onChangeSearch = useCallback((event: { nativeEvent: { text: string } }) => {
-    setSearch(event.nativeEvent.text);
-  }, []);
+  const onChangeSearch = useCallback(
+    (event: { nativeEvent: { text: string } }) => {
+      setSearch(event.nativeEvent.text);
+    },
+    [],
+  );
   const searchOptions = useMemo(
     () => ({
       placeholder: "Search connections",
@@ -28,7 +33,7 @@ export default function ConnectionsScreen() {
       onChangeText: onChangeSearch,
       onCancelButtonPress: () => setSearch(""),
     }),
-    [onChangeSearch]
+    [onChangeSearch],
   );
 
   useEffect(() => {
@@ -36,9 +41,10 @@ export default function ConnectionsScreen() {
   }, [hydrate, hydrated]);
 
   useEffect(() => {
-    const unwatch = connections.map((connection) =>
-      watchConnection(connection.key, optionsForConnection(connection.key, connections))
-    );
+    const unwatch = connections.flatMap((connection) => {
+      const options = optionsForConnection(connection.key, connections);
+      return options === null ? [] : [watchConnection(connection.key, options)];
+    });
     return () => {
       for (const stop of unwatch) stop();
     };

--- a/apps/mobile/app/c/[conn]/index.tsx
+++ b/apps/mobile/app/c/[conn]/index.tsx
@@ -6,7 +6,11 @@ import { RefreshControl, ScrollView, Text, View } from "react-native";
 import { SessionRow } from "~/components/session-row";
 import { EmptyState } from "~/components/ui/empty-state";
 import { ListSection } from "~/components/ui/list";
-import { normalizeConnParam, optionsForConnection } from "~/lib/connection-params";
+import {
+  normalizeConnParam,
+  optionsForConnection,
+} from "~/lib/connection-params";
+import { connectionSessionKey } from "~/lib/session-key";
 import { useConnectionsStore } from "~/store/connections";
 import {
   connectionStatusLabel,
@@ -20,29 +24,36 @@ export default function SessionsScreen() {
   const { conn } = useLocalSearchParams<{ conn: string }>();
   const connKey = normalizeConnParam(conn);
   const [search, setSearch] = useState("");
-  const { connections, hydrated, hydrate: hydrateConnections } = useConnectionsStore();
+  const {
+    connections,
+    hydrated,
+    hydrate: hydrateConnections,
+  } = useConnectionsStore();
   const {
     bundlesByConnection,
     statusBySession,
     errorByConnection,
     loadingByConnection,
-    hydrate
+    hydrate,
   } = useSessionsStore();
   const options = useMemo(
     () => optionsForConnection(connKey, connections),
-    [connKey, connections]
+    [connKey, connections],
   );
   const watchConnection = useConnectionRuntimeStore((state) => state.watch);
   const connectionSnapshot = useConnectionRuntimeStore(
-    (state) => state.snapshotsByConnection[connKey]
+    (state) => state.snapshotsByConnection[connKey],
   );
   const bundles = useMemo(
     () => bundlesByConnection[connKey] ?? [],
-    [bundlesByConnection, connKey]
+    [bundlesByConnection, connKey],
   );
-  const onChangeSearch = useCallback((event: { nativeEvent: { text: string } }) => {
-    setSearch(event.nativeEvent.text);
-  }, []);
+  const onChangeSearch = useCallback(
+    (event: { nativeEvent: { text: string } }) => {
+      setSearch(event.nativeEvent.text);
+    },
+    [],
+  );
   const searchOptions = useMemo(
     () => ({
       placeholder: "Search sessions",
@@ -51,7 +62,7 @@ export default function SessionsScreen() {
       onChangeText: onChangeSearch,
       onCancelButtonPress: () => setSearch(""),
     }),
-    [onChangeSearch]
+    [onChangeSearch],
   );
 
   useEffect(() => {
@@ -59,12 +70,12 @@ export default function SessionsScreen() {
   }, [hydrateConnections, hydrated]);
 
   useEffect(() => {
-    if (connKey.length === 0) return;
+    if (connKey.length === 0 || options === null) return;
     return watchConnection(connKey, options);
   }, [connKey, options, watchConnection]);
 
   useEffect(() => {
-    if (connKey.length > 0) void hydrate(connKey, options);
+    if (connKey.length > 0 && options !== null) void hydrate(connKey, options);
   }, [connKey, connectionSnapshot?.generation, hydrate, options]);
 
   const rows = useMemo(
@@ -73,9 +84,9 @@ export default function SessionsScreen() {
         bundle.sessions.map((session) => {
           const chat = bundle.chats.find((item) => item.id === session.chatId);
           return { project: bundle.project, session, chat };
-        })
+        }),
       ),
-    [bundles]
+    [bundles],
   );
   const filteredRows = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -114,11 +125,19 @@ export default function SessionsScreen() {
         refreshControl={
           <RefreshControl
             refreshing={loadingByConnection[connKey] === true}
-            onRefresh={() => void hydrate(connKey, options)}
+            onRefresh={() => {
+              if (options !== null) void hydrate(connKey, options);
+            }}
             tintColor={ACCENT}
           />
         }
       >
+        {hydrated && options === null ? (
+          <Text selectable className="px-4 font-sans text-[13px] text-danger">
+            This saved connection could not be found on this phone. Go back and
+            connect the computer again.
+          </Text>
+        ) : null}
         {errorByConnection[connKey] ? (
           <Text selectable className="px-4 font-sans text-[13px] text-danger">
             {errorByConnection[connKey]}
@@ -151,11 +170,13 @@ export default function SessionsScreen() {
                 key={session.id}
                 session={session}
                 chat={chat}
-                status={statusBySession[session.id]}
+                status={
+                  statusBySession[connectionSessionKey(connKey, session.id)]
+                }
                 unread={chat !== undefined && isUnread(chat)}
                 onPress={() =>
                   router.push(
-                    `/c/${encodeURIComponent(connKey)}/session/${encodeURIComponent(session.id)}`
+                    `/c/${encodeURIComponent(connKey)}/session/${encodeURIComponent(session.id)}`,
                   )
                 }
               />

--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -8,10 +8,14 @@ import { Effect } from "effect";
 import { Composer } from "~/components/composer";
 import {
   MessageRow,
-  type MessageRowContext
+  type MessageRowContext,
 } from "~/components/messages/message-row";
 import { PendingApprovalCard } from "~/components/messages/pending-approval-card";
-import { normalizeConnParam, optionsForConnection } from "~/lib/connection-params";
+import {
+  normalizeConnParam,
+  optionsForConnection,
+} from "~/lib/connection-params";
+import { connectionSessionKey } from "~/lib/session-key";
 import { answerQuestion } from "~/rpc/actions";
 import { useConnectionsStore } from "~/store/connections";
 import {
@@ -23,33 +27,47 @@ import { useMobileMessagesStore } from "~/store/messages";
 import { useOutboxStore } from "~/store/outbox";
 import { usePermissionsStore } from "~/store/permissions";
 
-const EMPTY_BUNDLES: ReturnType<typeof useSessionsStore.getState>["bundlesByConnection"][string] = [];
-const EMPTY_PENDING: ReturnType<typeof usePermissionsStore.getState>["pendingBySession"][string] = [];
-const EMPTY_QUEUED: ReturnType<typeof useOutboxStore.getState>["queuedBySession"][string] = [];
+const EMPTY_BUNDLES: ReturnType<
+  typeof useSessionsStore.getState
+>["bundlesByConnection"][string] = [];
+const EMPTY_PENDING: ReturnType<
+  typeof usePermissionsStore.getState
+>["pendingBySession"][string] = [];
+const EMPTY_QUEUED: ReturnType<
+  typeof useOutboxStore.getState
+>["queuedBySession"][string] = [];
 
 export default function ThreadScreen() {
   const insets = useSafeAreaInsets();
-  const { conn, sessionId } = useLocalSearchParams<{ conn: string; sessionId: string }>();
+  const { conn, sessionId } = useLocalSearchParams<{
+    conn: string;
+    sessionId: string;
+  }>();
   const connKey = normalizeConnParam(conn);
   const normalizedSessionId = normalizeConnParam(sessionId) as SessionId;
   const listRef = useRef<FlatList>(null);
-  const { connections, hydrated, hydrate: hydrateConnections } = useConnectionsStore();
+  const {
+    connections,
+    hydrated,
+    hydrate: hydrateConnections,
+  } = useConnectionsStore();
   const options = useMemo(
     () => optionsForConnection(connKey, connections),
-    [connKey, connections]
+    [connKey, connections],
   );
+  const stateKey = connectionSessionKey(connKey, normalizedSessionId);
   const watchConnection = useConnectionRuntimeStore((state) => state.watch);
   const connectionSnapshot = useConnectionRuntimeStore(
-    (state) => state.snapshotsByConnection[connKey]
+    (state) => state.snapshotsByConnection[connKey],
   );
   const bundles = useSessionsStore(
-    (state) => state.bundlesByConnection[connKey] ?? EMPTY_BUNDLES
+    (state) => state.bundlesByConnection[connKey] ?? EMPTY_BUNDLES,
   );
   const { messagesBySession, reconnectingBySession, errorBySession, hydrate } =
     useMobileMessagesStore();
   const messages = useMemo(
-    () => messagesBySession[normalizedSessionId] ?? [],
-    [messagesBySession, normalizedSessionId]
+    () => messagesBySession[stateKey] ?? [],
+    [messagesBySession, stateKey],
   );
   const detail = selectSessionChat(bundles, normalizedSessionId);
   const title = detail?.chat?.title ?? detail?.session.title ?? "Thread";
@@ -57,12 +75,12 @@ export default function ThreadScreen() {
   const hydratePermissions = usePermissionsStore((state) => state.hydrate);
   const decidePermission = usePermissionsStore((state) => state.decide);
   const pending = usePermissionsStore(
-    (state) => state.pendingBySession[normalizedSessionId] ?? EMPTY_PENDING
+    (state) => state.pendingBySession[stateKey] ?? EMPTY_PENDING,
   );
   const hydrateOutbox = useOutboxStore((state) => state.hydrate);
   const flushOutbox = useOutboxStore((state) => state.flush);
   const queued = useOutboxStore(
-    (state) => state.queuedBySession[normalizedSessionId] ?? EMPTY_QUEUED
+    (state) => state.queuedBySession[stateKey] ?? EMPTY_QUEUED,
   );
 
   useEffect(() => {
@@ -70,12 +88,12 @@ export default function ThreadScreen() {
   }, [hydrateConnections, hydrated]);
 
   useEffect(() => {
-    if (connKey.length === 0) return;
+    if (connKey.length === 0 || options === null) return;
     return watchConnection(connKey, options);
   }, [connKey, options, watchConnection]);
 
   useEffect(() => {
-    if (normalizedSessionId.length > 0) {
+    if (normalizedSessionId.length > 0 && options !== null) {
       void hydrate(connKey, options, normalizedSessionId);
       void hydratePermissions(connKey, options, normalizedSessionId);
       void hydrateOutbox(connKey, normalizedSessionId);
@@ -90,8 +108,8 @@ export default function ThreadScreen() {
     options,
   ]);
 
-  const reconnecting = reconnectingBySession[normalizedSessionId];
-  const error = errorBySession[normalizedSessionId];
+  const reconnecting = reconnectingBySession[stateKey];
+  const error = errorBySession[stateKey];
   const online =
     connectionSnapshot?.status === "connected" &&
     reconnecting !== true &&
@@ -99,7 +117,7 @@ export default function ThreadScreen() {
 
   // Drain the outbox in order the moment the session is back online.
   useEffect(() => {
-    if (online && normalizedSessionId.length > 0) {
+    if (online && normalizedSessionId.length > 0 && options !== null) {
       void flushOutbox(connKey, options, normalizedSessionId);
     }
   }, [connKey, flushOutbox, normalizedSessionId, online, options]);
@@ -122,25 +140,35 @@ export default function ThreadScreen() {
 
   const onAnswerQuestion = useCallback<MessageRowContext["onAnswerQuestion"]>(
     (itemId, answers) =>
-      Effect.runPromise(
-        answerQuestion({
-          connection: options,
-          sessionId: normalizedSessionId,
-          itemId,
-          answers
-        })
-      ).catch(() => {}),
-    [normalizedSessionId, options]
+      options === null
+        ? Promise.resolve()
+        : Effect.runPromise(
+            answerQuestion({
+              connection: options,
+              sessionId: normalizedSessionId,
+              itemId,
+              answers,
+            }),
+          ).catch(() => {}),
+    [normalizedSessionId, options],
   );
 
   const ctx = useMemo<MessageRowContext>(
     () => ({ answeredQuestionIds, questionsByItemId, onAnswerQuestion }),
-    [answeredQuestionIds, questionsByItemId, onAnswerQuestion]
+    [answeredQuestionIds, questionsByItemId, onAnswerQuestion],
   );
 
   return (
     <KeyboardAvoidingView behavior="padding" className="flex-1 bg-background">
       <Stack.Screen options={{ title }} />
+      {hydrated && options === null ? (
+        <View className="px-4 py-3">
+          <Text selectable className="font-sans text-[13px] text-danger">
+            This saved connection could not be found on this phone. Go back and
+            connect the computer again.
+          </Text>
+        </View>
+      ) : null}
       <FlatList
         ref={listRef}
         data={messages}
@@ -149,12 +177,16 @@ export default function ThreadScreen() {
         contentInsetAdjustmentBehavior="automatic"
         contentContainerClassName="gap-1 px-4 py-3"
         ListHeaderComponent={
-          reconnecting || error || connectionSnapshot?.status !== "connected" ? (
+          reconnecting ||
+          error ||
+          connectionSnapshot?.status !== "connected" ? (
             <View className="pb-2">
               {connectionSnapshot?.status !== "connected" ? (
                 <Text className="font-sans text-[13px] text-warning">
                   {connectionStatusLabel(connectionSnapshot)}
-                  {connectionSnapshot?.error ? `: ${connectionSnapshot.error}` : ""}
+                  {connectionSnapshot?.error
+                    ? `: ${connectionSnapshot.error}`
+                    : ""}
                 </Text>
               ) : null}
               {reconnecting ? (
@@ -181,21 +213,33 @@ export default function ThreadScreen() {
                   key={request.id}
                   request={request}
                   onDecide={(decision) =>
-                    decidePermission(options, normalizedSessionId, request.id, decision)
+                    options === null
+                      ? undefined
+                      : decidePermission(
+                          connKey,
+                          options,
+                          normalizedSessionId,
+                          request.id,
+                          decision,
+                        )
                   }
                 />
               ))}
             </View>
           ) : null
         }
-        onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
+        onContentSizeChange={() =>
+          listRef.current?.scrollToEnd({ animated: true })
+        }
       />
-      <Composer
-        connKey={connKey}
-        connection={options}
-        sessionId={normalizedSessionId}
-        bottomInset={insets.bottom}
-      />
+      {options === null ? null : (
+        <Composer
+          connKey={connKey}
+          connection={options}
+          sessionId={normalizedSessionId}
+          bottomInset={insets.bottom}
+        />
+      )}
     </KeyboardAvoidingView>
   );
 }
@@ -203,8 +247,12 @@ export default function ThreadScreen() {
 const QueuedBubble = ({ text }: { text: string }) => (
   <View className="items-end px-3 py-1.5">
     <View className="max-w-[88%] rounded-lg border border-primary/40 bg-primary/20 px-3 py-2">
-      <Text className="mb-0.5 font-sans-medium text-[11px] text-warning">Queued</Text>
-      <Text className="font-sans text-[15px] leading-5 text-foreground">{text}</Text>
+      <Text className="mb-0.5 font-sans-medium text-[11px] text-warning">
+        Queued
+      </Text>
+      <Text className="font-sans text-[15px] leading-5 text-foreground">
+        {text}
+      </Text>
     </View>
   </View>
 );

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,6 +25,8 @@
     "@expo-google-fonts/geist-mono": "^0.4.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo/ui": "~57.0.3",
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0",
     "@zuse/wire": "*",
     "clsx": "^2.1.1",
     "effect": "catalog:",

--- a/apps/mobile/src/auth/dpop.ts
+++ b/apps/mobile/src/auth/dpop.ts
@@ -1,3 +1,6 @@
+import { p256 } from "@noble/curves/nist";
+import { sha256 } from "@noble/hashes/sha2";
+import * as ExpoCrypto from "expo-crypto";
 import * as SecureStore from "expo-secure-store";
 import { calculateJwkThumbprint, type JWK } from "jose";
 
@@ -11,7 +14,7 @@ const PRIVATE_KEY = "zuse.mobile.dpop.private.v1";
 const PUBLIC_KEY = "zuse.mobile.dpop.public.v1";
 
 interface DeviceKey {
-  readonly privateJwk: JWK;
+  readonly privateJwk: JWK & { readonly d: string };
   readonly publicJwk: JWK;
 }
 
@@ -25,22 +28,14 @@ const loadOrCreate = async (): Promise<DeviceKey> => {
   ]);
   if (priv !== null && pub !== null) {
     cached = {
-      privateJwk: JSON.parse(priv) as JWK,
+      privateJwk: parsePrivateJwk(JSON.parse(priv)),
       publicJwk: JSON.parse(pub) as JWK,
     };
     return cached;
   }
-  const { privateKey, publicKey } = await subtle().generateKey(
-    { name: "ECDSA", namedCurve: "P-256" },
-    true,
-    ["sign", "verify"],
-  );
-  const privateJwk = normalizePrivateJwk(
-    await subtle().exportKey("jwk", privateKey),
-  );
-  const publicJwk = normalizePublicJwk(
-    await subtle().exportKey("jwk", publicKey),
-  );
+  const privateKey = generatePrivateKey();
+  const publicJwk = publicJwkFromPrivateKey(privateKey);
+  const privateJwk = { ...publicJwk, d: base64UrlBytes(privateKey) };
   await Promise.all([
     SecureStore.setItemAsync(PRIVATE_KEY, JSON.stringify(privateJwk)),
     SecureStore.setItemAsync(PUBLIC_KEY, JSON.stringify(publicJwk)),
@@ -76,55 +71,48 @@ export const signDpopProof = async (input: {
     iat: Math.floor(Date.now() / 1000),
   };
   const signingInput = `${base64UrlJson(protectedHeader)}.${base64UrlJson(payload)}`;
-  const key = await subtle().importKey(
-    "jwk",
-    privateJwk,
-    { name: "ECDSA", namedCurve: "P-256" },
-    false,
-    ["sign"],
-  );
-  const signature = await subtle().sign(
-    { name: "ECDSA", hash: "SHA-256" },
-    key,
-    new TextEncoder().encode(signingInput),
-  );
-  return `${signingInput}.${base64UrlBytes(new Uint8Array(signature))}`;
+  const privateKey = base64UrlToBytes(privateJwk.d);
+  const signature = p256
+    .sign(sha256(new TextEncoder().encode(signingInput)), privateKey, {
+      prehash: false,
+    })
+    .toCompactRawBytes();
+  return `${signingInput}.${base64UrlBytes(signature)}`;
 };
 
-const subtle = (): SubtleCrypto => {
-  const crypto = globalThis.crypto;
-  if (crypto?.subtle === undefined) {
-    throw new Error("mobile_crypto_unavailable");
+const generatePrivateKey = (): Uint8Array => {
+  for (;;) {
+    const privateKey = ExpoCrypto.getRandomBytes(32);
+    if (p256.utils.isValidPrivateKey(privateKey)) return privateKey;
   }
-  return crypto.subtle;
 };
 
-const normalizePrivateJwk = (jwk: JsonWebKey): JWK => ({
-  kty: "EC",
-  crv: "P-256",
-  alg: "ES256",
-  key_ops: ["sign"],
-  ext: true,
-  x: requiredJwkPart(jwk.x, "x"),
-  y: requiredJwkPart(jwk.y, "y"),
-  d: requiredJwkPart(jwk.d, "d"),
-});
-
-const normalizePublicJwk = (jwk: JsonWebKey): JWK => ({
-  kty: "EC",
-  crv: "P-256",
-  alg: "ES256",
-  key_ops: ["verify"],
-  ext: true,
-  x: requiredJwkPart(jwk.x, "x"),
-  y: requiredJwkPart(jwk.y, "y"),
-});
-
-const requiredJwkPart = (value: string | undefined, name: string): string => {
-  if (value === undefined || value.length === 0) {
-    throw new Error(`mobile_dpop_jwk_missing_${name}`);
+const publicJwkFromPrivateKey = (privateKey: Uint8Array): JWK => {
+  const publicKey = p256.getPublicKey(privateKey, false);
+  if (publicKey.length !== 65 || publicKey[0] !== 0x04) {
+    throw new Error("mobile_dpop_public_key_invalid");
   }
-  return value;
+  return {
+    kty: "EC",
+    crv: "P-256",
+    alg: "ES256",
+    key_ops: ["verify"],
+    ext: true,
+    x: base64UrlBytes(publicKey.slice(1, 33)),
+    y: base64UrlBytes(publicKey.slice(33, 65)),
+  };
+};
+
+const parsePrivateJwk = (value: unknown): JWK & { readonly d: string } => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("d" in value) ||
+    typeof value.d !== "string"
+  ) {
+    throw new Error("mobile_dpop_private_jwk_invalid");
+  }
+  return value as JWK & { readonly d: string };
 };
 
 const base64UrlJson = (value: unknown): string =>
@@ -146,6 +134,20 @@ const base64UrlBytes = (bytes: Uint8Array): string => {
     output += alphabet[c & 63]!;
   }
   return output;
+};
+
+const base64UrlToBytes = (value: string): Uint8Array => {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "=",
+  );
+  const binary = globalThis.atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
 };
 
 const normalizeUrl = (value: string): string => {

--- a/apps/mobile/src/auth/dpop.ts
+++ b/apps/mobile/src/auth/dpop.ts
@@ -27,12 +27,17 @@ const loadOrCreate = async (): Promise<DeviceKey> => {
     SecureStore.getItemAsync(PUBLIC_KEY),
   ]);
   if (priv !== null && pub !== null) {
-    cached = {
-      privateJwk: parsePrivateJwk(JSON.parse(priv)),
-      publicJwk: JSON.parse(pub) as JWK,
-    };
-    return cached;
+    const restored = await restoreStoredKey(priv, pub);
+    if (restored !== null) {
+      cached = restored;
+      return cached;
+    }
   }
+  cached = await createAndStoreKey();
+  return cached;
+};
+
+const createAndStoreKey = async (): Promise<DeviceKey> => {
   const privateKey = generatePrivateKey();
   const publicJwk = publicJwkFromPrivateKey(privateKey);
   const privateJwk = { ...publicJwk, d: base64UrlBytes(privateKey) };
@@ -40,8 +45,32 @@ const loadOrCreate = async (): Promise<DeviceKey> => {
     SecureStore.setItemAsync(PRIVATE_KEY, JSON.stringify(privateJwk)),
     SecureStore.setItemAsync(PUBLIC_KEY, JSON.stringify(publicJwk)),
   ]);
-  cached = { privateJwk, publicJwk };
-  return cached;
+  return { privateJwk, publicJwk };
+};
+
+const restoreStoredKey = async (
+  privateJson: string,
+  publicJson: string,
+): Promise<DeviceKey | null> => {
+  try {
+    const privateJwk = parsePrivateJwk(JSON.parse(privateJson));
+    const publicJwk = JSON.parse(publicJson) as JWK;
+    const privateKey = base64UrlToBytes(privateJwk.d);
+    if (!p256.utils.isValidPrivateKey(privateKey)) {
+      throw new Error("mobile_dpop_private_key_invalid");
+    }
+    const derivedPublicJwk = publicJwkFromPrivateKey(privateKey);
+    if (derivedPublicJwk.x !== publicJwk.x || derivedPublicJwk.y !== publicJwk.y) {
+      throw new Error("mobile_dpop_public_key_mismatch");
+    }
+    return { privateJwk, publicJwk };
+  } catch {
+    await Promise.all([
+      SecureStore.deleteItemAsync(PRIVATE_KEY),
+      SecureStore.deleteItemAsync(PUBLIC_KEY),
+    ]);
+    return null;
+  }
 };
 
 export const devicePublicJwk = async (): Promise<JWK> =>
@@ -137,17 +166,26 @@ const base64UrlBytes = (bytes: Uint8Array): string => {
 };
 
 const base64UrlToBytes = (value: string): Uint8Array => {
-  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
-  const padded = normalized.padEnd(
-    normalized.length + ((4 - (normalized.length % 4)) % 4),
-    "=",
-  );
-  const binary = globalThis.atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  const clean = value.replace(/=+$/g, "");
+  if (clean.length % 4 === 1) {
+    throw new Error("mobile_dpop_base64url_invalid_length");
   }
-  return bytes;
+  const bytes: number[] = [];
+  for (let index = 0; index < clean.length; index += 4) {
+    const chunk = clean.slice(index, index + 4);
+    const values = [...chunk].map((char) => alphabet.indexOf(char));
+    if (values.some((item) => item < 0)) {
+      throw new Error("mobile_dpop_base64url_invalid_character");
+    }
+    const [a = 0, b = 0, c = 0, d = 0] = values;
+    const triple = (a << 18) | (b << 12) | (c << 6) | d;
+    bytes.push((triple >> 16) & 0xff);
+    if (chunk.length > 2) bytes.push((triple >> 8) & 0xff);
+    if (chunk.length > 3) bytes.push(triple & 0xff);
+  }
+  return new Uint8Array(bytes);
 };
 
 const normalizeUrl = (value: string): string => {

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { ActivityIndicator, Text, TextInput, View } from "react-native";
 
 import { interruptSession, makeTextInput, sendMessage } from "~/rpc/actions";
+import { connectionSessionKey } from "~/lib/session-key";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 import { useMobileMessagesStore } from "~/store/messages";
 import { useOutboxStore } from "~/store/outbox";
@@ -15,7 +16,7 @@ export const Composer = ({
   connKey,
   connection,
   sessionId,
-  bottomInset = 0
+  bottomInset = 0,
 }: {
   connKey: string;
   connection: WsProtocolOptions;
@@ -24,16 +25,17 @@ export const Composer = ({
 }) => {
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
+  const stateKey = connectionSessionKey(connKey, sessionId);
 
   // Offline = the message stream is retrying or has surfaced an error. Sends
   // made in this state are queued instead of dropped.
   const online = useMobileMessagesStore(
     (state) =>
-      state.reconnectingBySession[sessionId] !== true &&
-      (state.errorBySession[sessionId] ?? null) === null
+      state.reconnectingBySession[stateKey] !== true &&
+      (state.errorBySession[stateKey] ?? null) === null,
   );
   const queuedCount = useOutboxStore(
-    (state) => (state.queuedBySession[sessionId] ?? []).length
+    (state) => (state.queuedBySession[stateKey] ?? []).length,
   );
   const enqueue = useOutboxStore((state) => state.enqueue);
 
@@ -50,7 +52,7 @@ export const Composer = ({
     setBusy(true);
     try {
       await Effect.runPromise(
-        sendMessage({ connection, sessionId, input: makeTextInput(value) })
+        sendMessage({ connection, sessionId, input: makeTextInput(value) }),
       );
     } catch {
       // Lost the connection mid-send — keep the text safe in the outbox.
@@ -98,10 +100,18 @@ export const Composer = ({
           value={text}
           onChangeText={setText}
         />
-        <Button variant="secondary" disabled={busy || !online} onPress={interrupt}>
+        <Button
+          variant="secondary"
+          disabled={busy || !online}
+          onPress={interrupt}
+        >
           <Square size={16} color="hsl(72 4% 92%)" />
         </Button>
-        <Button variant={online ? "primary" : "secondary"} disabled={!canSend} onPress={submit}>
+        <Button
+          variant={online ? "primary" : "secondary"}
+          disabled={!canSend}
+          onPress={submit}
+        >
           {busy ? (
             <ActivityIndicator color="hsl(72 4% 8%)" />
           ) : online ? (

--- a/apps/mobile/src/lib/connection-params.ts
+++ b/apps/mobile/src/lib/connection-params.ts
@@ -1,8 +1,9 @@
 import type { ConnectionRecord } from "~/store/connections";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 
-export const normalizeConnParam = (param: string | string[] | undefined): string =>
-  Array.isArray(param) ? param[0] ?? "" : param ?? "";
+export const normalizeConnParam = (
+  param: string | string[] | undefined,
+): string => (Array.isArray(param) ? (param[0] ?? "") : (param ?? ""));
 
 export const parseConnectionKey = (key: string): WsProtocolOptions => {
   const [host = "127.0.0.1", port = "8787"] = key.split(":");
@@ -11,11 +12,12 @@ export const parseConnectionKey = (key: string): WsProtocolOptions => {
 
 export const optionsForConnection = (
   key: string,
-  connections: ConnectionRecord[]
-): WsProtocolOptions => {
+  connections: ConnectionRecord[],
+): WsProtocolOptions | null => {
   const existing = connections.find(
-    (connection) =>
-      connection.key === key || connection.environmentId === key
+    (connection) => connection.key === key || connection.environmentId === key,
   );
-  return existing ?? parseConnectionKey(key);
+  if (existing !== undefined) return existing;
+  if (!key.includes(":")) return null;
+  return parseConnectionKey(key);
 };

--- a/apps/mobile/src/lib/session-key.ts
+++ b/apps/mobile/src/lib/session-key.ts
@@ -1,0 +1,6 @@
+import type { SessionId } from "@zuse/wire";
+
+export const connectionSessionKey = (
+  connKey: string,
+  sessionId: SessionId | string,
+): string => JSON.stringify([connKey, sessionId]);

--- a/apps/mobile/src/rpc/connection-diagnostics.ts
+++ b/apps/mobile/src/rpc/connection-diagnostics.ts
@@ -1,0 +1,35 @@
+type DiagnosticFields = Record<string, unknown>;
+
+const safeFields = (fields: DiagnosticFields): DiagnosticFields =>
+  Object.fromEntries(
+    Object.entries(fields).map(([key, value]) => [
+      key,
+      value instanceof Error
+        ? { name: value.name, message: value.message }
+        : value,
+    ]),
+  );
+
+export const logConnectionDiagnostic = (
+  event: string,
+  fields: DiagnosticFields = {},
+): void => {
+  const payload = {
+    ts: new Date().toISOString(),
+    event,
+    ...safeFields(fields),
+  };
+  console.info("[zuse:remote]", JSON.stringify(payload));
+};
+
+export const logConnectionProblem = (
+  event: string,
+  fields: DiagnosticFields = {},
+): void => {
+  const payload = {
+    ts: new Date().toISOString(),
+    event,
+    ...safeFields(fields),
+  };
+  console.warn("[zuse:remote]", JSON.stringify(payload));
+};

--- a/apps/mobile/src/rpc/connection-supervisor.ts
+++ b/apps/mobile/src/rpc/connection-supervisor.ts
@@ -3,6 +3,10 @@ import type { MemoizeRpcs } from "@zuse/wire";
 import { Effect } from "effect";
 
 import { ConnectionFailed } from "./errors";
+import {
+  logConnectionDiagnostic,
+  logConnectionProblem,
+} from "./connection-diagnostics";
 import type { WsProtocolOptions } from "./ws-protocol";
 
 export type MemoizeClient = RpcClient.RpcClient<RpcGroup.Rpcs<typeof MemoizeRpcs>>;
@@ -115,10 +119,22 @@ class SupervisorEntryImpl implements SupervisorEntry {
       attempt: 0,
       error: null,
     };
+    logConnectionDiagnostic("supervisor.entry.created", {
+      key,
+      status: this.state.status,
+      relay: options.environmentId !== undefined,
+    });
   }
 
   updateOptions(options: WsProtocolOptions): void {
     this.options = options;
+    logConnectionDiagnostic("supervisor.options.updated", {
+      key: this.key,
+      relay: options.environmentId !== undefined,
+      wsBaseUrl: options.wsBaseUrl ?? null,
+      host: options.host,
+      port: options.port,
+    });
   }
 
   snapshot(): ConnectionSnapshot {
@@ -144,12 +160,17 @@ class SupervisorEntryImpl implements SupervisorEntry {
   }
 
   reportFailure(cause: unknown): void {
+    logConnectionProblem("supervisor.report_failure", {
+      key: this.key,
+      reason: messageOf(cause),
+    });
     void this.closeCurrent();
     this.inFlight = null;
     this.markFailure(cause);
   }
 
   retryNow(): void {
+    logConnectionDiagnostic("supervisor.retry_now", { key: this.key });
     this.clearRetry();
     if (!this.deps.isOnline()) {
       this.emit({ status: "offline", error: null });
@@ -161,6 +182,11 @@ class SupervisorEntryImpl implements SupervisorEntry {
   }
 
   setOnline(online: boolean): void {
+    logConnectionDiagnostic("supervisor.online_changed", {
+      key: this.key,
+      online,
+      status: this.state.status,
+    });
     if (!online) {
       this.clearRetry();
       void this.closeCurrent();
@@ -175,6 +201,7 @@ class SupervisorEntryImpl implements SupervisorEntry {
   }
 
   async remove(): Promise<void> {
+    logConnectionDiagnostic("supervisor.entry.removed", { key: this.key });
     this.clearRetry();
     await this.closeCurrent();
     this.inFlight = null;
@@ -191,6 +218,11 @@ class SupervisorEntryImpl implements SupervisorEntry {
     if (this.inFlight !== null) return this.inFlight;
 
     this.clearRetry();
+    logConnectionDiagnostic("supervisor.connect.start", {
+      key: this.key,
+      generation: this.state.generation,
+      attempt: this.state.attempt,
+    });
     this.emit({
       status: this.state.generation === 0 ? "connecting" : "reconnecting",
       error: null,
@@ -207,25 +239,51 @@ class SupervisorEntryImpl implements SupervisorEntry {
         attempt: 0,
         error: null,
       });
+      logConnectionDiagnostic("supervisor.connect.ok", {
+        key: this.key,
+        generation: this.state.generation,
+      });
       return client;
     } catch (cause) {
       this.inFlight = null;
+      logConnectionProblem("supervisor.connect.fail", {
+        key: this.key,
+        reason: messageOf(cause),
+      });
       this.markFailure(cause);
       throw cause;
     }
   }
 
   private async connectOnce(): Promise<MemoizeClient> {
+    logConnectionDiagnostic("supervisor.prepare_options.start", {
+      key: this.key,
+      relay: this.options.environmentId !== undefined,
+    });
     const prepared = await this.deps.prepareOptions(this.options);
     this.options = prepared;
+    logConnectionDiagnostic("supervisor.prepare_options.ok", {
+      key: this.key,
+      relay: prepared.environmentId !== undefined,
+      wsBaseUrl: prepared.wsBaseUrl ?? null,
+      host: prepared.host,
+      port: prepared.port,
+      hasToken: prepared.token !== undefined && prepared.token !== null,
+    });
     const session = await this.deps.createClient(prepared);
     this.disposeClient = session.dispose;
     try {
+      logConnectionDiagnostic("supervisor.describe.start", { key: this.key });
       await Effect.runPromise(session.client.connect.describe());
+      logConnectionDiagnostic("supervisor.describe.ok", { key: this.key });
       return session.client;
     } catch (cause) {
       await session.dispose().catch(() => {});
       this.disposeClient = null;
+      logConnectionProblem("supervisor.describe.fail", {
+        key: this.key,
+        reason: messageOf(cause),
+      });
       throw cause;
     }
   }
@@ -237,6 +295,10 @@ class SupervisorEntryImpl implements SupervisorEntry {
     }
     const classify = this.deps.classifyError ?? defaultClassifyError;
     if (classify(cause) === "auth") {
+      logConnectionProblem("supervisor.blocked_auth", {
+        key: this.key,
+        reason: messageOf(cause),
+      });
       this.emit({ status: "blockedAuth", error: messageOf(cause) });
       return;
     }
@@ -246,6 +308,12 @@ class SupervisorEntryImpl implements SupervisorEntry {
       MAX_BACKOFF_MS,
       INITIAL_BACKOFF_MS * 2 ** Math.max(0, attempt - 1),
     );
+    logConnectionProblem("supervisor.retry_scheduled", {
+      key: this.key,
+      attempt,
+      delayMs: delay,
+      reason: messageOf(cause),
+    });
     this.retryCancel = this.deps.schedule(delay, () => {
       this.retryCancel = null;
       void this.ensureClient().catch(() => {});
@@ -257,6 +325,7 @@ class SupervisorEntryImpl implements SupervisorEntry {
     this.client = null;
     this.disposeClient = null;
     if (dispose !== null) {
+      logConnectionDiagnostic("supervisor.client.dispose", { key: this.key });
       await dispose().catch(() => {});
     }
   }
@@ -269,7 +338,21 @@ class SupervisorEntryImpl implements SupervisorEntry {
   }
 
   private emit(patch: Partial<Omit<ConnectionSnapshot, "key">>): void {
+    const previous = this.state;
     this.state = { ...this.state, ...patch };
+    if (
+      previous.status !== this.state.status ||
+      previous.error !== this.state.error ||
+      previous.attempt !== this.state.attempt
+    ) {
+      logConnectionDiagnostic("supervisor.state", {
+        key: this.key,
+        status: this.state.status,
+        attempt: this.state.attempt,
+        generation: this.state.generation,
+        error: this.state.error,
+      });
+    }
     for (const listener of this.listeners) listener(this.state);
   }
 }

--- a/apps/mobile/src/rpc/connection.ts
+++ b/apps/mobile/src/rpc/connection.ts
@@ -4,6 +4,10 @@ import { Effect, Layer, ManagedRuntime, Scope } from "effect";
 
 import { ConnectionFailed } from "./errors";
 import {
+  logConnectionDiagnostic,
+  logConnectionProblem,
+} from "./connection-diagnostics";
+import {
   createConnectionSupervisor,
   type ConnectionSnapshot,
 } from "./connection-supervisor";
@@ -20,6 +24,14 @@ const runtimeKey = (options: WsProtocolOptions) =>
   `${options.wsBaseUrl ?? `${options.host}:${options.port}`}`;
 
 const makeRuntime = (options: WsProtocolOptions) => {
+  logConnectionDiagnostic("runtime.create", {
+    key: runtimeKey(options),
+    relay: options.environmentId !== undefined,
+    wsBaseUrl: options.wsBaseUrl ?? null,
+    host: options.host,
+    port: options.port,
+    hasToken: options.token !== undefined && options.token !== null,
+  });
   const protocolLayer = wsClientProtocolLayer(options).pipe(Layer.orDie);
   const runtime = ManagedRuntime.make(protocolLayer);
   const client = runtime.runPromise(
@@ -37,7 +49,17 @@ const prepareOptions = async (
   if (options.environmentId === undefined || options.wsBaseUrl === undefined) {
     return options;
   }
+  logConnectionDiagnostic("relay.connect_grant.start", {
+    key: runtimeKey(options),
+    environmentId: options.environmentId,
+  });
   const grant = await connectEnvironment(options.environmentId);
+  logConnectionDiagnostic("relay.connect_grant.ok", {
+    key: runtimeKey(options),
+    environmentId: options.environmentId,
+    wsBaseUrl: grant.endpoint.wsBaseUrl,
+    expiresAt: grant.expiresAt,
+  });
   return {
     ...options,
     host: new URL(grant.endpoint.wsBaseUrl).hostname,
@@ -81,6 +103,10 @@ export const reportConnectionFailure = (
   options: WsProtocolOptions,
   cause: unknown
 ): void => {
+  logConnectionProblem("runtime.report_failure", {
+    key: runtimeKey(options),
+    reason: cause instanceof Error ? cause.message : String(cause),
+  });
   supervisor.get(options).reportFailure(cause);
 };
 
@@ -94,6 +120,7 @@ export const subscribeConnection = (
 ): (() => void) => supervisor.get(options).subscribe(listener);
 
 export const setConnectionOnline = (online: boolean): void => {
+  logConnectionDiagnostic("runtime.online_set", { online });
   currentOnline = online;
   supervisor.setOnline(online);
 };

--- a/apps/mobile/src/rpc/relay-client.ts
+++ b/apps/mobile/src/rpc/relay-client.ts
@@ -27,6 +27,24 @@ const decodeAccess = Schema.decodeUnknownPromise(RelayAccessToken);
 
 const url = (path: string): string => `${relayBaseUrl()}${path}`;
 
+const relayError = async (
+  response: Response,
+  prefix: string,
+): Promise<Error> => {
+  const fallback = `${prefix}_${response.status}`;
+  const text = await response.text().catch(() => "");
+  if (text.trim().length === 0) return new Error(fallback);
+  try {
+    const body = JSON.parse(text) as { readonly error?: unknown };
+    if (typeof body.error === "string" && body.error.length > 0) {
+      return new Error(`${fallback}:${body.error}`);
+    }
+  } catch {
+    // Non-JSON relay errors still get surfaced in truncated form.
+  }
+  return new Error(`${fallback}:${text.slice(0, 120)}`);
+};
+
 const ensureAccessToken = async (): Promise<string> => {
   if (accessToken !== null && accessToken.expiresAtMs - Date.now() > 30_000) {
     return accessToken.token;
@@ -40,7 +58,7 @@ const ensureAccessToken = async (): Promise<string> => {
       dpop: await signDpopProof({ method: "POST", url: target }),
     },
   });
-  if (!response.ok) throw new Error(`relay_dpop_token_${response.status}`);
+  if (!response.ok) throw await relayError(response, "relay_dpop_token");
   const grant = await decodeAccess(await response.json());
   accessToken = {
     token: grant.accessToken,
@@ -66,7 +84,7 @@ export const listEnvironments = async (): Promise<RelayEnvironmentList> => {
   const response = await fetch(url(RelayPaths.environments), {
     headers: { authorization: `Bearer ${workosToken}` },
   });
-  if (!response.ok) throw new Error(`relay_list_${response.status}`);
+  if (!response.ok) throw await relayError(response, "relay_list");
   return decodeList(await response.json());
 };
 
@@ -74,7 +92,7 @@ export const getEnvironmentStatus = async (
   environmentId: string,
 ): Promise<RelayEnvironmentStatus> => {
   const response = await dpopFetch(RelayPaths.status(environmentId), "POST");
-  if (!response.ok) throw new Error(`relay_status_${response.status}`);
+  if (!response.ok) throw await relayError(response, "relay_status");
   return decodeStatus(await response.json());
 };
 
@@ -82,7 +100,7 @@ export const connectEnvironment = async (
   environmentId: string,
 ): Promise<RelayConnectGrant> => {
   const response = await dpopFetch(RelayPaths.connect(environmentId), "POST");
-  if (!response.ok) throw new Error(`relay_connect_${response.status}`);
+  if (!response.ok) throw await relayError(response, "relay_connect");
   return decodeGrant(await response.json());
 };
 
@@ -107,7 +125,7 @@ export const registerDevice = async (input: {
       dpopJwk: await devicePublicJwk(),
     }),
   });
-  if (!response.ok) throw new Error(`relay_register_${response.status}`);
+  if (!response.ok) throw await relayError(response, "relay_register");
 };
 
 export const resetRelayAccessToken = (): void => {

--- a/apps/mobile/src/rpc/relay-client.ts
+++ b/apps/mobile/src/rpc/relay-client.ts
@@ -10,6 +10,10 @@ import {
 import { relayBaseUrl } from "../auth/config.ts";
 import { devicePublicJwk, signDpopProof } from "../auth/dpop.ts";
 import { getAccessToken as getWorkosToken } from "../auth/workos.ts";
+import {
+  logConnectionDiagnostic,
+  logConnectionProblem,
+} from "./connection-diagnostics";
 
 /**
  * Client for the account relay's HTTP API. WorkOS-authenticated endpoints
@@ -47,8 +51,12 @@ const relayError = async (
 
 const ensureAccessToken = async (): Promise<string> => {
   if (accessToken !== null && accessToken.expiresAtMs - Date.now() > 30_000) {
+    logConnectionDiagnostic("relay.dpop_token.cache_hit", {
+      expiresAtMs: accessToken.expiresAtMs,
+    });
     return accessToken.token;
   }
+  logConnectionDiagnostic("relay.dpop_token.refresh.start");
   const workosToken = await getWorkosToken();
   const target = url(RelayPaths.dpopToken);
   const response = await fetch(target, {
@@ -58,18 +66,29 @@ const ensureAccessToken = async (): Promise<string> => {
       dpop: await signDpopProof({ method: "POST", url: target }),
     },
   });
-  if (!response.ok) throw await relayError(response, "relay_dpop_token");
+  if (!response.ok) {
+    const error = await relayError(response, "relay_dpop_token");
+    logConnectionProblem("relay.dpop_token.refresh.fail", {
+      reason: error.message,
+    });
+    throw error;
+  }
   const grant = await decodeAccess(await response.json());
   accessToken = {
     token: grant.accessToken,
     expiresAtMs: Date.now() + grant.expiresIn,
   };
+  logConnectionDiagnostic("relay.dpop_token.refresh.ok", {
+    expiresIn: grant.expiresIn,
+    expiresAtMs: accessToken.expiresAtMs,
+  });
   return grant.accessToken;
 };
 
 const dpopFetch = async (path: string, method: string): Promise<Response> => {
   const token = await ensureAccessToken();
   const target = url(path);
+  logConnectionDiagnostic("relay.request.start", { method, path });
   return fetch(target, {
     method,
     headers: {
@@ -81,27 +100,62 @@ const dpopFetch = async (path: string, method: string): Promise<Response> => {
 
 export const listEnvironments = async (): Promise<RelayEnvironmentList> => {
   const workosToken = await getWorkosToken();
+  logConnectionDiagnostic("relay.list.start");
   const response = await fetch(url(RelayPaths.environments), {
     headers: { authorization: `Bearer ${workosToken}` },
   });
-  if (!response.ok) throw await relayError(response, "relay_list");
-  return decodeList(await response.json());
+  if (!response.ok) {
+    const error = await relayError(response, "relay_list");
+    logConnectionProblem("relay.list.fail", { reason: error.message });
+    throw error;
+  }
+  const decoded = await decodeList(await response.json());
+  logConnectionDiagnostic("relay.list.ok", {
+    environments: decoded.environments.length,
+  });
+  return decoded;
 };
 
 export const getEnvironmentStatus = async (
   environmentId: string,
 ): Promise<RelayEnvironmentStatus> => {
   const response = await dpopFetch(RelayPaths.status(environmentId), "POST");
-  if (!response.ok) throw await relayError(response, "relay_status");
-  return decodeStatus(await response.json());
+  if (!response.ok) {
+    const error = await relayError(response, "relay_status");
+    logConnectionProblem("relay.status.fail", {
+      environmentId,
+      reason: error.message,
+    });
+    throw error;
+  }
+  const decoded = await decodeStatus(await response.json());
+  logConnectionDiagnostic("relay.status.ok", {
+    environmentId,
+    status: decoded.status,
+    wsBaseUrl: decoded.endpoint.wsBaseUrl,
+  });
+  return decoded;
 };
 
 export const connectEnvironment = async (
   environmentId: string,
 ): Promise<RelayConnectGrant> => {
   const response = await dpopFetch(RelayPaths.connect(environmentId), "POST");
-  if (!response.ok) throw await relayError(response, "relay_connect");
-  return decodeGrant(await response.json());
+  if (!response.ok) {
+    const error = await relayError(response, "relay_connect");
+    logConnectionProblem("relay.connect.fail", {
+      environmentId,
+      reason: error.message,
+    });
+    throw error;
+  }
+  const decoded = await decodeGrant(await response.json());
+  logConnectionDiagnostic("relay.connect.ok", {
+    environmentId,
+    wsBaseUrl: decoded.endpoint.wsBaseUrl,
+    expiresAt: decoded.expiresAt,
+  });
+  return decoded;
 };
 
 export const registerDevice = async (input: {
@@ -126,8 +180,13 @@ export const registerDevice = async (input: {
     }),
   });
   if (!response.ok) throw await relayError(response, "relay_register");
+  logConnectionDiagnostic("relay.register_device.ok", {
+    platform: input.platform,
+    hasPushToken: input.pushToken !== undefined,
+  });
 };
 
 export const resetRelayAccessToken = (): void => {
+  logConnectionDiagnostic("relay.dpop_token.reset");
   accessToken = null;
 };

--- a/apps/mobile/src/rpc/ws-protocol.ts
+++ b/apps/mobile/src/rpc/ws-protocol.ts
@@ -12,7 +12,7 @@ export type WsProtocolOptions = {
   token?: string | null;
   /**
    * A full ws(s):// base URL, used for relay-connected environments reached via
-   * a managed tunnel (e.g. `wss://env-x.relay.example/rpc`). When present it
+   * a managed tunnel (e.g. `wss://env-x.relay.example`). When present it
    * takes precedence over host/port.
    */
   wsBaseUrl?: string | null;

--- a/apps/mobile/src/store/environments.ts
+++ b/apps/mobile/src/store/environments.ts
@@ -33,7 +33,22 @@ const message = (cause: unknown): string => {
     return "Could not load your computers from the relay.";
   }
   if (text.startsWith("relay_status_")) {
+    if (text.includes("invalid_dpop_proof")) {
+      return "Could not verify this phone with the relay. Restart the app and try again.";
+    }
+    if (text.includes("invalid_workos_token")) {
+      return "Your sign-in expired. Sign out, sign in again, and refresh computers.";
+    }
     return "Could not check computer presence.";
+  }
+  if (text.startsWith("relay_dpop_token_")) {
+    if (text.includes("invalid_dpop_proof")) {
+      return "Could not verify this phone with the relay. Restart the app and try again.";
+    }
+    if (text.includes("invalid_workos_token")) {
+      return "Your sign-in expired. Sign out, sign in again, and refresh computers.";
+    }
+    return "Could not authorize this phone with the relay.";
   }
   if (text.startsWith("relay_connect_")) {
     return "Could not connect to that computer.";
@@ -69,7 +84,16 @@ export const useEnvironmentsStore = create<EnvironmentsState>((set, get) => ({
                   : item,
               ),
             }));
-          } catch {
+          } catch (cause) {
+            const error = message(cause);
+            if (
+              error.startsWith("Could not authorize") ||
+              error.startsWith("Could not verify") ||
+              error.startsWith("Your sign-in expired")
+            ) {
+              set({ error });
+              return;
+            }
             set((state) => ({
               environments: state.environments.map((item) =>
                 item.environmentId === environment.environmentId

--- a/apps/mobile/src/store/messages.ts
+++ b/apps/mobile/src/store/messages.ts
@@ -3,10 +3,8 @@ import { Effect, Fiber, Stream } from "effect";
 import { AppState } from "react-native";
 import { create } from "zustand";
 
-import {
-  readMessagesSnapshot,
-  writeMessagesSnapshot
-} from "~/offline/cache";
+import { readMessagesSnapshot, writeMessagesSnapshot } from "~/offline/cache";
+import { connectionSessionKey } from "~/lib/session-key";
 import { getConnectionClient, reportConnectionFailure } from "~/rpc/connection";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 
@@ -17,7 +15,7 @@ type MessagesState = {
   hydrate: (
     connKey: string,
     options: WsProtocolOptions,
-    sessionId: SessionId
+    sessionId: SessionId,
   ) => Promise<void>;
   flush: (connKey: string, sessionId: SessionId) => Promise<void>;
 };
@@ -40,35 +38,42 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
   errorBySession: {},
   hydrate: async (connKey, options, sessionId) => {
     installAppStateFlush(get);
-    const liveKey = makeLiveKey(connKey, sessionId);
+    const liveKey = connectionSessionKey(connKey, sessionId);
     await stop(liveKey);
 
-    const cached = await Effect.runPromise(readMessagesSnapshot(connKey, sessionId));
+    const cached = await Effect.runPromise(
+      readMessagesSnapshot(connKey, sessionId),
+    );
     if (cached !== null) {
       highestSequenceBySession.set(liveKey, cached.highestSequence);
       set((state) => ({
         messagesBySession: {
           ...state.messagesBySession,
-          [sessionId]: cached.messages
-        }
+          [liveKey]: cached.messages,
+        },
       }));
     }
 
     set((state) => ({
-      reconnectingBySession: { ...state.reconnectingBySession, [sessionId]: false },
-      errorBySession: { ...state.errorBySession, [sessionId]: null }
+      reconnectingBySession: {
+        ...state.reconnectingBySession,
+        [liveKey]: false,
+      },
+      errorBySession: { ...state.errorBySession, [liveKey]: null },
     }));
 
     const run = async () => {
       try {
         const client = await Effect.runPromise(getConnectionClient(options));
-        const listed = await Effect.runPromise(client.messages.list({ sessionId }));
+        const listed = await Effect.runPromise(
+          client.messages.list({ sessionId }),
+        );
         if (listed.length > 0) {
           set((state) => ({
             messagesBySession: {
               ...state.messagesBySession,
-              [sessionId]: listed
-            }
+              [liveKey]: listed,
+            },
           }));
           void get().flush(connKey, sessionId);
         }
@@ -83,27 +88,29 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
               highestSequenceBySession.set(liveKey, envelope.sequence);
               console.info("[mobile] messages.stream envelope", {
                 sessionId,
-                sequence: envelope.sequence
+                sequence: envelope.sequence,
               });
               set((state) => {
-                const current = state.messagesBySession[sessionId] ?? [];
-                if (current.some((message) => message.id === envelope.message.id)) {
+                const current = state.messagesBySession[liveKey] ?? [];
+                if (
+                  current.some((message) => message.id === envelope.message.id)
+                ) {
                   return state;
                 }
                 const next = [...current, envelope.message].slice(-500);
                 return {
                   messagesBySession: {
                     ...state.messagesBySession,
-                    [sessionId]: next
-                  }
+                    [liveKey]: next,
+                  },
                 };
               });
               void get().flush(connKey, sessionId);
-            })
+            }),
         ).pipe(
           Effect.tapError((cause) =>
-            Effect.sync(() => reportConnectionFailure(options, cause))
-          )
+            Effect.sync(() => reportConnectionFailure(options, cause)),
+          ),
         );
         const fiber = await Effect.runPromise(program.pipe(Effect.fork));
         liveFibers.set(liveKey, fiber);
@@ -112,12 +119,12 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
         set((state) => ({
           reconnectingBySession: {
             ...state.reconnectingBySession,
-            [sessionId]: true
+            [liveKey]: true,
           },
           errorBySession: {
             ...state.errorBySession,
-            [sessionId]: cause instanceof Error ? cause.message : String(cause)
-          }
+            [liveKey]: cause instanceof Error ? cause.message : String(cause),
+          },
         }));
       }
     };
@@ -125,15 +132,15 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
     await run();
   },
   flush: async (connKey, sessionId) => {
-    const liveKey = makeLiveKey(connKey, sessionId);
-    const messages = get().messagesBySession[sessionId] ?? [];
+    const liveKey = connectionSessionKey(connKey, sessionId);
+    const messages = get().messagesBySession[liveKey] ?? [];
     await Effect.runPromise(
       writeMessagesSnapshot(connKey, sessionId, {
         highestSequence: highestSequenceBySession.get(liveKey) ?? 0,
-        messages
-      })
+        messages,
+      }),
     ).catch(() => {});
-  }
+  },
 }));
 
 const installAppStateFlush = (get: () => MessagesState) => {
@@ -151,10 +158,9 @@ const installAppStateFlush = (get: () => MessagesState) => {
   });
 };
 
-const makeLiveKey = (connKey: string, sessionId: SessionId) =>
-  JSON.stringify([connKey, sessionId]);
-
-const parseLiveKey = (key: string): [string | undefined, string | undefined] => {
+const parseLiveKey = (
+  key: string,
+): [string | undefined, string | undefined] => {
   try {
     return JSON.parse(key) as [string, string];
   } catch {

--- a/apps/mobile/src/store/outbox.ts
+++ b/apps/mobile/src/store/outbox.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 
 import type { QueuedMessage } from "~/offline/cache";
 import { readOutboxSnapshot, writeOutboxSnapshot } from "~/offline/cache";
+import { connectionSessionKey } from "~/lib/session-key";
 import { makeTextInput, sendMessage } from "~/rpc/actions";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 
@@ -20,12 +21,12 @@ type OutboxState = {
   enqueue: (
     connKey: string,
     sessionId: SessionId,
-    text: string
+    text: string,
   ) => Promise<void>;
   flush: (
     connKey: string,
     options: WsProtocolOptions,
-    sessionId: SessionId
+    sessionId: SessionId,
   ) => Promise<void>;
 };
 
@@ -34,27 +35,29 @@ type OutboxState = {
 const flushing = new Set<string>();
 let counter = 0;
 
-const makeClientId = () => `${Date.now().toString(36)}-${(counter++).toString(36)}`;
+const makeClientId = () =>
+  `${Date.now().toString(36)}-${(counter++).toString(36)}`;
 
 const persist = (
   connKey: string,
   sessionId: SessionId,
-  items: readonly QueuedMessage[]
+  items: readonly QueuedMessage[],
 ) =>
-  Effect.runPromise(
-    writeOutboxSnapshot(connKey, sessionId, { items })
-  ).catch(() => {});
+  Effect.runPromise(writeOutboxSnapshot(connKey, sessionId, { items })).catch(
+    () => {},
+  );
 
 export const useOutboxStore = create<OutboxState>((set, get) => ({
   queuedBySession: {},
   hydrate: async (connKey, sessionId) => {
-    if (get().queuedBySession[sessionId] !== undefined) return;
+    const key = connectionSessionKey(connKey, sessionId);
+    if (get().queuedBySession[key] !== undefined) return;
     const cached = await Effect.runPromise(
-      readOutboxSnapshot(connKey, sessionId)
+      readOutboxSnapshot(connKey, sessionId),
     ).catch(() => null);
     const items = cached?.items ?? [];
     set((state) => ({
-      queuedBySession: { ...state.queuedBySession, [sessionId]: items }
+      queuedBySession: { ...state.queuedBySession, [key]: items },
     }));
   },
   enqueue: async (connKey, sessionId, text) => {
@@ -63,19 +66,21 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
     const item: QueuedMessage = {
       clientId: makeClientId(),
       text: trimmed,
-      createdAt: Date.now()
+      createdAt: Date.now(),
     };
-    const next = [...(get().queuedBySession[sessionId] ?? []), item];
+    const key = connectionSessionKey(connKey, sessionId);
+    const next = [...(get().queuedBySession[key] ?? []), item];
     set((state) => ({
-      queuedBySession: { ...state.queuedBySession, [sessionId]: next }
+      queuedBySession: { ...state.queuedBySession, [key]: next },
     }));
     await persist(connKey, sessionId, next);
   },
   flush: async (connKey, options, sessionId) => {
-    if (flushing.has(sessionId)) return;
-    const queued = get().queuedBySession[sessionId] ?? [];
+    const key = connectionSessionKey(connKey, sessionId);
+    if (flushing.has(key)) return;
+    const queued = get().queuedBySession[key] ?? [];
     if (queued.length === 0) return;
-    flushing.add(sessionId);
+    flushing.add(key);
     try {
       // Send strictly in order; stop at the first failure so ordering holds and
       // the remaining items stay queued for the next reconnect.
@@ -86,20 +91,22 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
             sendMessage({
               connection: options,
               sessionId,
-              input: makeTextInput(item.text)
-            })
+              input: makeTextInput(item.text),
+            }),
           );
         } catch {
           break;
         }
-        remaining = remaining.filter((entry) => entry.clientId !== item.clientId);
+        remaining = remaining.filter(
+          (entry) => entry.clientId !== item.clientId,
+        );
         set((state) => ({
-          queuedBySession: { ...state.queuedBySession, [sessionId]: remaining }
+          queuedBySession: { ...state.queuedBySession, [key]: remaining },
         }));
         await persist(connKey, sessionId, remaining);
       }
     } finally {
-      flushing.delete(sessionId);
+      flushing.delete(key);
     }
-  }
+  },
 }));

--- a/apps/mobile/src/store/permissions.ts
+++ b/apps/mobile/src/store/permissions.ts
@@ -1,8 +1,13 @@
-import type { PermissionDecision, PermissionRequest, SessionId } from "@zuse/wire";
+import type {
+  PermissionDecision,
+  PermissionRequest,
+  SessionId,
+} from "@zuse/wire";
 import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
 import { decidePermission } from "~/rpc/actions";
+import { connectionSessionKey } from "~/lib/session-key";
 import { getConnectionClient, reportConnectionFailure } from "~/rpc/connection";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 
@@ -18,20 +23,18 @@ type PermissionsState = {
   hydrate: (
     connKey: string,
     options: WsProtocolOptions,
-    sessionId: SessionId
+    sessionId: SessionId,
   ) => Promise<void>;
   decide: (
+    connKey: string,
     options: WsProtocolOptions,
     sessionId: SessionId,
     requestId: string,
-    decision: PermissionDecision
+    decision: PermissionDecision,
   ) => Promise<void>;
 };
 
 const liveFibers = new Map<string, Fiber.RuntimeFiber<unknown, unknown>>();
-
-const makeLiveKey = (connKey: string, sessionId: SessionId) =>
-  JSON.stringify([connKey, sessionId]);
 
 const stop = async (key: string) => {
   const fiber = liveFibers.get(key);
@@ -44,16 +47,16 @@ const stop = async (key: string) => {
 export const usePermissionsStore = create<PermissionsState>((set, get) => ({
   pendingBySession: {},
   hydrate: async (connKey, options, sessionId) => {
-    const liveKey = makeLiveKey(connKey, sessionId);
+    const liveKey = connectionSessionKey(connKey, sessionId);
     await stop(liveKey);
     try {
       const client = await Effect.runPromise(getConnectionClient(options));
 
       const listed = await Effect.runPromise(
-        client.permission.listPending({ sessionId })
+        client.permission.listPending({ sessionId }),
       );
       set((state) => ({
-        pendingBySession: { ...state.pendingBySession, [sessionId]: listed }
+        pendingBySession: { ...state.pendingBySession, [liveKey]: listed },
       }));
 
       const program = Stream.runForEach(
@@ -62,20 +65,21 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
           Effect.sync(() => {
             if (request.sessionId !== sessionId) return;
             set((state) => {
-              const current = state.pendingBySession[sessionId] ?? [];
-              if (current.some((entry) => entry.id === request.id)) return state;
+              const current = state.pendingBySession[liveKey] ?? [];
+              if (current.some((entry) => entry.id === request.id))
+                return state;
               return {
                 pendingBySession: {
                   ...state.pendingBySession,
-                  [sessionId]: [...current, request]
-                }
+                  [liveKey]: [...current, request],
+                },
               };
             });
-          })
+          }),
       ).pipe(
         Effect.tapError((cause) =>
-          Effect.sync(() => reportConnectionFailure(options, cause))
-        )
+          Effect.sync(() => reportConnectionFailure(options, cause)),
+        ),
       );
       const fiber = await Effect.runPromise(program.pipe(Effect.fork));
       liveFibers.set(liveKey, fiber);
@@ -85,18 +89,19 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
       // surfaces the connection error, and hydrate re-runs on the next mount.
     }
   },
-  decide: async (options, sessionId, requestId, decision) => {
+  decide: async (connKey, options, sessionId, requestId, decision) => {
     // Optimistically drop the card; the server won't re-emit a decided request.
+    const key = connectionSessionKey(connKey, sessionId);
     set((state) => ({
       pendingBySession: {
         ...state.pendingBySession,
-        [sessionId]: (state.pendingBySession[sessionId] ?? []).filter(
-          (entry) => entry.id !== requestId
-        )
-      }
+        [key]: (state.pendingBySession[key] ?? []).filter(
+          (entry) => entry.id !== requestId,
+        ),
+      },
     }));
     await Effect.runPromise(
-      decidePermission({ connection: options, requestId, decision })
+      decidePermission({ connection: options, requestId, decision }),
     ).catch(() => {});
-  }
+  },
 }));

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -3,6 +3,7 @@ import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
 import { readSessionsSnapshot, writeSessionsSnapshot } from "~/offline/cache";
+import { connectionSessionKey } from "~/lib/session-key";
 import { getConnectionClient, reportConnectionFailure } from "~/rpc/connection";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 
@@ -23,7 +24,10 @@ type SessionsState = {
 const statusFibers = new Map<string, Fiber.RuntimeFiber<unknown, unknown>>();
 const chatFibers = new Map<string, Fiber.RuntimeFiber<unknown, unknown>>();
 
-const stopFiber = async (key: string, map: Map<string, Fiber.RuntimeFiber<unknown, unknown>>) => {
+const stopFiber = async (
+  key: string,
+  map: Map<string, Fiber.RuntimeFiber<unknown, unknown>>,
+) => {
   const fiber = map.get(key);
   if (fiber !== undefined) {
     map.delete(key);
@@ -45,15 +49,15 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
           [connKey]: rebuildBundles(
             cached.projects as readonly Folder[],
             cached.chats as readonly Chat[],
-            cached.sessions as readonly Session[]
-          )
-        }
+            cached.sessions as readonly Session[],
+          ),
+        },
       }));
     }
 
     set((state) => ({
       loadingByConnection: { ...state.loadingByConnection, [connKey]: true },
-      errorByConnection: { ...state.errorByConnection, [connKey]: null }
+      errorByConnection: { ...state.errorByConnection, [connKey]: null },
     }));
 
     try {
@@ -63,15 +67,18 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
         projects.map(async (project) => {
           const [chats, sessions] = await Promise.all([
             Effect.runPromise(client.chat.list({ projectId: project.id })),
-            Effect.runPromise(client.session.list({ projectId: project.id }))
+            Effect.runPromise(client.session.list({ projectId: project.id })),
           ]);
           return { project, chats, sessions };
-        })
+        }),
       );
 
       set((state) => ({
-        bundlesByConnection: { ...state.bundlesByConnection, [connKey]: bundles },
-        loadingByConnection: { ...state.loadingByConnection, [connKey]: false }
+        bundlesByConnection: {
+          ...state.bundlesByConnection,
+          [connKey]: bundles,
+        },
+        loadingByConnection: { ...state.loadingByConnection, [connKey]: false },
       }));
 
       await Effect.runPromise(
@@ -79,8 +86,8 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
           projects,
           chats: bundles.flatMap((b) => b.chats),
           sessions: bundles.flatMap((b) => b.sessions),
-          savedAt: Date.now()
-        })
+          savedAt: Date.now(),
+        }),
       );
 
       for (const bundle of bundles) {
@@ -93,16 +100,19 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
                 set((state) => ({
                   bundlesByConnection: {
                     ...state.bundlesByConnection,
-                    [connKey]: patchChat(state.bundlesByConnection[connKey] ?? [], chat)
-                  }
+                    [connKey]: patchChat(
+                      state.bundlesByConnection[connKey] ?? [],
+                      chat,
+                    ),
+                  },
                 }));
-              })
+              }),
           ).pipe(
             Effect.tapError((cause) =>
-              Effect.sync(() => reportConnectionFailure(options, cause))
+              Effect.sync(() => reportConnectionFailure(options, cause)),
             ),
-            Effect.fork
-          )
+            Effect.fork,
+          ),
         );
         chatFibers.set(`${connKey}:chat:${bundle.project.id}`, chatFiber);
       }
@@ -118,16 +128,17 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
                 set((state) => ({
                   statusBySession: {
                     ...state.statusBySession,
-                    [event.sessionId]: event.status
-                  }
+                    [connectionSessionKey(connKey, event.sessionId)]:
+                      event.status,
+                  },
                 }));
-              })
+              }),
           ).pipe(
             Effect.tapError((cause) =>
-              Effect.sync(() => reportConnectionFailure(options, cause))
+              Effect.sync(() => reportConnectionFailure(options, cause)),
             ),
-            Effect.fork
-          )
+            Effect.fork,
+          ),
         );
         statusFibers.set(key, fiber);
       }
@@ -137,25 +148,28 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
         loadingByConnection: { ...state.loadingByConnection, [connKey]: false },
         errorByConnection: {
           ...state.errorByConnection,
-          [connKey]: cause instanceof Error ? cause.message : String(cause)
-        }
+          [connKey]: cause instanceof Error ? cause.message : String(cause),
+        },
       }));
     }
-  }
+  },
 }));
 
 const rebuildBundles = (
   projects: readonly Folder[],
   chats: readonly Chat[],
-  sessions: readonly Session[]
+  sessions: readonly Session[],
 ): ProjectBundle[] =>
   projects.map((project) => ({
     project,
     chats: chats.filter((chat) => chat.projectId === project.id),
-    sessions: sessions.filter((session) => session.projectId === project.id)
+    sessions: sessions.filter((session) => session.projectId === project.id),
   }));
 
-const patchChat = (bundles: readonly ProjectBundle[], chat: Chat): ProjectBundle[] =>
+const patchChat = (
+  bundles: readonly ProjectBundle[],
+  chat: Chat,
+): ProjectBundle[] =>
   bundles.map((bundle) =>
     bundle.project.id !== chat.projectId
       ? bundle
@@ -163,14 +177,14 @@ const patchChat = (bundles: readonly ProjectBundle[], chat: Chat): ProjectBundle
           ...bundle,
           chats: [
             chat,
-            ...bundle.chats.filter((existing) => existing.id !== chat.id)
-          ].sort((a, b) => timestampOf(b.updatedAt) - timestampOf(a.updatedAt))
-        }
+            ...bundle.chats.filter((existing) => existing.id !== chat.id),
+          ].sort((a, b) => timestampOf(b.updatedAt) - timestampOf(a.updatedAt)),
+        },
   );
 
 export const selectSessionChat = (
   bundles: readonly ProjectBundle[],
-  sessionId: string
+  sessionId: string,
 ): { session: Session; chat: Chat | undefined; project: Folder } | null => {
   for (const bundle of bundles) {
     const session = bundle.sessions.find((item) => item.id === sessionId);
@@ -178,7 +192,7 @@ export const selectSessionChat = (
       return {
         session,
         chat: bundle.chats.find((chat) => chat.id === session.chatId),
-        project: bundle.project
+        project: bundle.project,
       };
     }
   }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,4 +5,5 @@
  */
 export { AppPaths } from "./app-paths.ts";
 export { makeMainLayer, type MainLayerDeps } from "./runtime.ts";
+export { wsServerProtocolLayer } from "./transports/ws.ts";
 export { FolderPicker } from "./workspace/services/folder-picker.ts";

--- a/apps/server/src/lan-auth/advertised-endpoints.ts
+++ b/apps/server/src/lan-auth/advertised-endpoints.ts
@@ -103,7 +103,7 @@ export const buildAdvertisedEndpoints = (input: {
   const tunnelHostname = input.relay?.tunnelHostname?.trim();
   if (tunnelHostname) {
     const httpBaseUrl = `https://${tunnelHostname}`;
-    const wsBaseUrl = `wss://${tunnelHostname}/rpc`;
+    const wsBaseUrl = `wss://${tunnelHostname}`;
     const status: AdvertisedEndpointStatus =
       input.relay?.linked === true
         ? input.relay.heartbeatActive

--- a/apps/server/src/lan-auth/handlers.ts
+++ b/apps/server/src/lan-auth/handlers.ts
@@ -56,7 +56,7 @@ const ConnectDescribe = MemoizeRpcs.toLayerHandler("connect.describe", () =>
       relayConfig?.tunnelHostname !== undefined
         ? EnvironmentEndpoint.make({
             httpBaseUrl: `https://${relayConfig.tunnelHostname}`,
-            wsBaseUrl: `wss://${relayConfig.tunnelHostname}/rpc`,
+            wsBaseUrl: `wss://${relayConfig.tunnelHostname}`,
           })
         : config.advertisedHost !== null && config.port !== null
           ? EnvironmentEndpoint.make({

--- a/apps/server/src/lan-auth/handlers.ts
+++ b/apps/server/src/lan-auth/handlers.ts
@@ -51,19 +51,41 @@ const ConnectDescribe = MemoizeRpcs.toLayerHandler("connect.describe", () =>
   Effect.gen(function* () {
     const auth = yield* LanAuthService;
     const config = yield* LanAuthConfig;
-    if (config.advertisedHost === null || config.port === null) {
+    const relayConfig = yield* auth.getRelayConfig();
+    const endpoint =
+      relayConfig?.tunnelHostname !== undefined
+        ? EnvironmentEndpoint.make({
+            httpBaseUrl: `https://${relayConfig.tunnelHostname}`,
+            wsBaseUrl: `wss://${relayConfig.tunnelHostname}/rpc`,
+          })
+        : config.advertisedHost !== null && config.port !== null
+          ? EnvironmentEndpoint.make({
+              httpBaseUrl: `http://${config.advertisedHost}:${config.port}`,
+              wsBaseUrl: `ws://${config.advertisedHost}:${config.port}`,
+            })
+          : null;
+
+    if (endpoint === null) {
       return yield* Effect.fail(
         new ConnectAuthError({ reason: "no_endpoint_configured" }),
       );
     }
 
-    const httpBaseUrl = `http://${config.advertisedHost}:${config.port}`;
-    const wsBaseUrl = `ws://${config.advertisedHost}:${config.port}`;
     return EnvironmentDescriptor.make({
       environmentId: yield* auth.environmentId(),
       providerKind: "desktop",
-      endpoint: EnvironmentEndpoint.make({ httpBaseUrl, wsBaseUrl }),
-      advertisedEndpoints: buildAdvertisedEndpoints({ lan: config }),
+      endpoint,
+      advertisedEndpoints: buildAdvertisedEndpoints({
+        lan: config,
+        relay:
+          relayConfig === null
+            ? null
+            : {
+                linked: true,
+                heartbeatActive: true,
+                tunnelHostname: relayConfig.tunnelHostname,
+              },
+      }),
     });
   }).pipe(
     Effect.mapError((error) =>

--- a/apps/server/src/lan-auth/layers/lan-auth-service.ts
+++ b/apps/server/src/lan-auth/layers/lan-auth-service.ts
@@ -1,5 +1,6 @@
 import { SqlClient } from "@effect/sql";
 import { Clock, Effect, Layer, Ref } from "effect";
+import { importJWK, jwtVerify, type JWK } from "jose";
 import { createHash, randomBytes } from "node:crypto";
 import { networkInterfaces } from "node:os";
 
@@ -42,6 +43,12 @@ interface EnvironmentKeyRow {
 
 interface PairingCodeState {
   readonly expiresAtMs: number;
+}
+
+interface RelayConfigAuthRow {
+  readonly environment_id: string;
+  readonly relay_issuer: string;
+  readonly relay_mint_public_key: string | null;
 }
 
 const randomBase64Url = (bytes: number): Effect.Effect<string> =>
@@ -191,7 +198,34 @@ export const LanAuthServiceLive = Layer.effect(
               AND revoked_at IS NULL
             LIMIT 1
           `;
-          if (rows.length === 0) return false;
+          if (rows.length === 0) {
+            const relayRows = yield* sql<RelayConfigAuthRow>`
+              SELECT environment_id, relay_issuer, relay_mint_public_key
+              FROM relay_config
+              LIMIT 1
+            `;
+            const relay = relayRows[0];
+            if (
+              relay === undefined ||
+              relay.relay_mint_public_key === null
+            ) {
+              return false;
+            }
+            const mintPublicKey = relay.relay_mint_public_key;
+            return yield* Effect.tryPromise({
+              try: async () => {
+                const jwk = JSON.parse(mintPublicKey) as JWK;
+                const key = await importJWK(jwk, "EdDSA");
+                const verified = await jwtVerify(token, key, {
+                  issuer: relay.relay_issuer,
+                  audience: `zuse-env:${relay.environment_id}`,
+                  typ: "connect+jwt",
+                });
+                return verified.payload.environmentId === relay.environment_id;
+              },
+              catch: () => false,
+            });
+          }
           const usedAt = yield* nowIso;
           yield* sql`
             UPDATE auth_tokens
@@ -311,11 +345,12 @@ export const LanAuthServiceLive = Layer.effect(
           const updatedAt = yield* nowIso;
           yield* sql`
             INSERT INTO relay_config
-              (environment_id, relay_url, relay_issuer, environment_credential, label, connector_token, tunnel_hostname, updated_at)
+              (environment_id, relay_url, relay_issuer, environment_credential, label, connector_token, tunnel_hostname, relay_mint_public_key, updated_at)
             VALUES
               (${input.environmentId}, ${input.relayUrl}, ${input.relayIssuer},
                ${input.environmentCredential}, ${input.label ?? null},
                ${input.connectorToken ?? null}, ${input.tunnelHostname ?? null},
+               ${input.mintPublicKey ?? null},
                ${updatedAt})
             ON CONFLICT(environment_id) DO UPDATE SET
               relay_url = excluded.relay_url,
@@ -324,6 +359,7 @@ export const LanAuthServiceLive = Layer.effect(
               label = excluded.label,
               connector_token = excluded.connector_token,
               tunnel_hostname = excluded.tunnel_hostname,
+              relay_mint_public_key = excluded.relay_mint_public_key,
               updated_at = excluded.updated_at
           `;
         }).pipe(Effect.asVoid, Effect.mapError(toLanAuthError)),
@@ -337,8 +373,9 @@ export const LanAuthServiceLive = Layer.effect(
             readonly label: string | null;
             readonly connector_token: string | null;
             readonly tunnel_hostname: string | null;
+            readonly relay_mint_public_key: string | null;
           }>`
-            SELECT relay_url, relay_issuer, environment_id, environment_credential, label, connector_token, tunnel_hostname
+            SELECT relay_url, relay_issuer, environment_id, environment_credential, label, connector_token, tunnel_hostname, relay_mint_public_key
             FROM relay_config
             LIMIT 1
           `;
@@ -352,6 +389,7 @@ export const LanAuthServiceLive = Layer.effect(
             label: row.label ?? undefined,
             connectorToken: row.connector_token ?? undefined,
             tunnelHostname: row.tunnel_hostname ?? undefined,
+            mintPublicKey: row.relay_mint_public_key ?? undefined,
           };
         }).pipe(Effect.mapError(toLanAuthError)),
       clearRelayConfig: () =>

--- a/apps/server/src/lan-auth/layers/lan-auth-service.ts
+++ b/apps/server/src/lan-auth/layers/lan-auth-service.ts
@@ -223,8 +223,8 @@ export const LanAuthServiceLive = Layer.effect(
                 });
                 return verified.payload.environmentId === relay.environment_id;
               },
-              catch: () => false,
-            });
+              catch: (cause) => cause,
+            }).pipe(Effect.catchAll(() => Effect.succeed(false)));
           }
           const usedAt = yield* nowIso;
           yield* sql`

--- a/apps/server/src/lan-auth/services/lan-auth-service.ts
+++ b/apps/server/src/lan-auth/services/lan-auth-service.ts
@@ -91,6 +91,8 @@ export interface LanAuthServiceShape {
     readonly connectorToken?: string;
     /** Public hostname for the managed tunnel, if provisioned. */
     readonly tunnelHostname?: string;
+    /** Relay Ed25519 public key (JWK JSON) for verifying relay connect JWTs. */
+    readonly mintPublicKey?: string;
   }) => Effect.Effect<void, LanAuthError>;
   /** Current relay link, or null if this environment isn't linked. */
   readonly getRelayConfig: () => Effect.Effect<
@@ -102,6 +104,7 @@ export interface LanAuthServiceShape {
       readonly label: string | undefined;
       readonly connectorToken: string | undefined;
       readonly tunnelHostname: string | undefined;
+      readonly mintPublicKey: string | undefined;
     } | null,
     LanAuthError
   >;

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -27,6 +27,7 @@ import { Migration0024RemoteConnectState } from "./migrations/0024_remote_connec
 import { Migration0025RelayEnvironmentKeys } from "./migrations/0025_relay_environment_keys.ts";
 import { Migration0026RelayConnectorToken } from "./migrations/0026_relay_connector_token.ts";
 import { Migration0027RelayTunnelHostname } from "./migrations/0027_relay_tunnel_hostname.ts";
+import { Migration0028RelayMintPublicKey } from "./migrations/0028_relay_mint_public_key.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -72,6 +73,7 @@ export const MigrationsLive = Layer.effectDiscard(
       "0025_relay_environment_keys": Migration0025RelayEnvironmentKeys,
       "0026_relay_connector_token": Migration0026RelayConnectorToken,
       "0027_relay_tunnel_hostname": Migration0027RelayTunnelHostname,
+      "0028_relay_mint_public_key": Migration0028RelayMintPublicKey,
     }),
   }),
 );

--- a/apps/server/src/persistence/migrations/0028_relay_mint_public_key.ts
+++ b/apps/server/src/persistence/migrations/0028_relay_mint_public_key.ts
@@ -1,0 +1,15 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+export const Migration0028RelayMintPublicKey = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(relay_config)
+  `;
+  const hasMintPublicKeyColumn = columns.some(
+    (column) => column.name === "relay_mint_public_key",
+  );
+  if (!hasMintPublicKeyColumn) {
+    yield* sql`ALTER TABLE relay_config ADD COLUMN relay_mint_public_key TEXT`;
+  }
+});

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -261,6 +261,7 @@ export const RelayLinkServiceLive: Layer.Layer<
           const linked = yield* postJson<{
             readonly environmentCredential: string;
             readonly relayIssuer: string;
+            readonly mintPublicKey: string;
             readonly tunnelHostname?: string;
             readonly connectorToken?: string;
           }>(`${input.relayUrl}${RelayPaths.links}`, {
@@ -321,6 +322,7 @@ export const RelayLinkServiceLive: Layer.Layer<
               label: input.label,
               connectorToken: linked.connectorToken,
               tunnelHostname: linked.tunnelHostname,
+              mintPublicKey: linked.mintPublicKey,
             })
             .pipe(
               Effect.tap(() =>

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -59,7 +59,10 @@ import { WorktreeServiceLive } from "./worktree/layers/worktree-service.ts";
  *   wraps `dialog.showOpenDialog`; a headless server returns null (or
  *   forwards the prompt to a connected client).
  * - `serverProtocol`: the RPC transport. Electron supplies an in-process
- *   IPC protocol; the future WS server will supply a WebSocket protocol.
+ *   IPC protocol; a headless server supplies a WebSocket protocol.
+ * - `additionalServerProtocols`: optional secondary transports that serve the
+ *   same RPC handlers from the same runtime, for example Electron IPC plus a
+ *   protected local WebSocket origin for relay tunnels.
  * - `authShell`: the WorkOS OAuth deep-link seam. Electron opens the system
  *   browser via `shell.openExternal` and funnels the `zuse://auth/callback`
  *   deep link back in; a headless server supplies a loopback-HTTP variant.
@@ -71,6 +74,9 @@ export interface MainLayerDeps {
     RpcServer.Protocol,
     never,
     LanAuthService
+  >;
+  readonly additionalServerProtocols?: ReadonlyArray<
+    Layer.Layer<RpcServer.Protocol, never, LanAuthService>
   >;
   readonly authShell: typeof AuthShell.Service;
   readonly lanAuth?: {
@@ -388,9 +394,21 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(HandlerSupportLayer),
   );
 
-  const ServerLayer = RpcServer.layer(MemoizeRpcs).pipe(
-    Layer.provide(Handlers),
-    Layer.provide(deps.serverProtocol.pipe(Layer.provide(LanAuthLayer))),
+  const serverProtocols = [
+    deps.serverProtocol,
+    ...(deps.additionalServerProtocols ?? []),
+  ] as const;
+  const makeServerLayer = (
+    serverProtocol: Layer.Layer<RpcServer.Protocol, never, LanAuthService>,
+  ) =>
+    RpcServer.layer(MemoizeRpcs).pipe(
+      Layer.provide(Handlers),
+      Layer.provide(serverProtocol.pipe(Layer.provide(LanAuthLayer))),
+    );
+
+  const ServerLayer = Layer.mergeAll(
+    makeServerLayer(serverProtocols[0]),
+    ...serverProtocols.slice(1).map(makeServerLayer),
   );
 
   return Layer.mergeAll(ServerLayer, NodeContext.layer);

--- a/apps/server/src/transports/ws.ts
+++ b/apps/server/src/transports/ws.ts
@@ -73,14 +73,6 @@ export const wsServerProtocolLayer = (opts: {
     RpcServer.Protocol,
     Effect.gen(function* () {
       const auth = yield* LanAuthService;
-      if (auth.policy === "protected") {
-        const ok = (yield* auth.hasActiveTokens()) || auth.pairingBootstrap;
-        if (!ok) {
-          return yield* Effect.dieMessage(
-            "refusing to bind non-loopback without auth: mint a token or set ZUSE_ENABLE_PAIRING=1",
-          );
-        }
-      }
 
       const { protocol, httpApp } =
         yield* RpcServer.makeProtocolWithHttpAppWebsocket;

--- a/apps/server/src/transports/ws.ts
+++ b/apps/server/src/transports/ws.ts
@@ -17,6 +17,11 @@ import {
 
 const PairRequest = Schema.Struct({ code: Schema.String });
 
+type WsDiagnostic = (
+  event: string,
+  fields?: Record<string, unknown>,
+) => void;
+
 const json = (body: unknown, status: number) =>
   HttpServerResponse.json(body, { status }).pipe(Effect.orDie);
 
@@ -32,19 +37,24 @@ const bearerFromRequest = (
   return url.searchParams.get("token");
 };
 
-const pairApp = (auth: LanAuthServiceShape) =>
+const pairApp = (auth: LanAuthServiceShape, log: WsDiagnostic) =>
   Effect.gen(function* () {
     const body = yield* HttpServerRequest.schemaBodyJson(PairRequest).pipe(
       Effect.catchAll(() => Effect.fail("bad_request" as const)),
     );
+    yield* Effect.sync(() => log("ws.pair.redeem.start"));
     const redeemed = yield* auth.redeemPairingCode(body.code).pipe(
       Effect.mapError((error) =>
         error instanceof PairingRedeemError ? error.reason : "internal",
       ),
     );
+    yield* Effect.sync(() =>
+      log("ws.pair.redeem.ok", { environmentId: redeemed.environmentId }),
+    );
     return yield* json(redeemed, 200);
   }).pipe(
     Effect.catchAll((error) => {
+      log("ws.pair.redeem.fail", { reason: error });
       if (error === "expired_code") {
         return json({ error }, 410);
       }
@@ -68,20 +78,43 @@ const pairApp = (auth: LanAuthServiceShape) =>
 export const wsServerProtocolLayer = (opts: {
   readonly port: number;
   readonly host?: string;
+  readonly onDiagnostic?: WsDiagnostic;
 }): Layer.Layer<RpcServer.Protocol, never, LanAuthService> =>
   Layer.scoped(
     RpcServer.Protocol,
     Effect.gen(function* () {
       const auth = yield* LanAuthService;
+      const log = opts.onDiagnostic ?? (() => {});
+      yield* Effect.sync(() =>
+        log("ws.bind.start", {
+          host: opts.host ?? "127.0.0.1",
+          port: opts.port,
+          policy: auth.policy,
+          pairingBootstrap: auth.pairingBootstrap,
+        }),
+      );
 
       const { protocol, httpApp } =
         yield* RpcServer.makeProtocolWithHttpAppWebsocket;
 
       const guarded = Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest;
+        const token = bearerFromRequest(request);
+        yield* Effect.sync(() =>
+          log("ws.request", {
+            url: request.url,
+            protected: auth.policy === "protected",
+            hasToken: token !== null,
+          }),
+        );
         if (auth.policy === "protected") {
-          const token = bearerFromRequest(request);
           const ok = token !== null && (yield* auth.verifyToken(token));
+          yield* Effect.sync(() =>
+            log(ok ? "ws.auth.ok" : "ws.auth.fail", {
+              url: request.url,
+              hasToken: token !== null,
+            }),
+          );
           if (!ok) return yield* json({ error: "unauthorized" }, 401);
         }
         return yield* httpApp;
@@ -89,10 +122,17 @@ export const wsServerProtocolLayer = (opts: {
 
       const router = HttpRouter.empty.pipe(
         HttpRouter.get("/", guarded),
-        HttpRouter.post("/pair", pairApp(auth)),
+        HttpRouter.post("/pair", pairApp(auth, log)),
       );
 
       yield* HttpServer.serveEffect(router).pipe(Effect.forkScoped);
+      yield* Effect.sync(() =>
+        log("ws.bind.ok", {
+          host: opts.host ?? "127.0.0.1",
+          port: opts.port,
+          policy: auth.policy,
+        }),
+      );
 
       if (auth.policy === "protected" && auth.pairingBootstrap) {
         const pairing = yield* auth.createPairingCode();

--- a/apps/server/src/transports/ws.ts
+++ b/apps/server/src/transports/ws.ts
@@ -122,6 +122,9 @@ export const wsServerProtocolLayer = (opts: {
 
       const router = HttpRouter.empty.pipe(
         HttpRouter.get("/", guarded),
+        // Existing relay deployments and previously linked environments may
+        // still advertise `/rpc`. Keep accepting it while newer links use `/`.
+        HttpRouter.get("/rpc", guarded),
         HttpRouter.post("/pair", pairApp(auth, log)),
       );
 

--- a/apps/server/test/lan-auth-service.test.ts
+++ b/apps/server/test/lan-auth-service.test.ts
@@ -10,6 +10,7 @@ import {
   TestClock,
   TestContext,
 } from "effect";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
 
 import { LanAuthServiceLive } from "../src/lan-auth/layers/lan-auth-service.ts";
 import { resolveAuthPolicy } from "../src/lan-auth/policy.ts";
@@ -22,6 +23,7 @@ import { Migration0024RemoteConnectState } from "../src/persistence/migrations/0
 import { Migration0025RelayEnvironmentKeys } from "../src/persistence/migrations/0025_relay_environment_keys.ts";
 import { Migration0026RelayConnectorToken } from "../src/persistence/migrations/0026_relay_connector_token.ts";
 import { Migration0027RelayTunnelHostname } from "../src/persistence/migrations/0027_relay_tunnel_hostname.ts";
+import { Migration0028RelayMintPublicKey } from "../src/persistence/migrations/0028_relay_mint_public_key.ts";
 import { buildAdvertisedEndpoints } from "../src/lan-auth/advertised-endpoints.ts";
 
 const makeRuntime = () => {
@@ -32,6 +34,7 @@ const makeRuntime = () => {
       Effect.zipRight(Migration0025RelayEnvironmentKeys),
       Effect.zipRight(Migration0026RelayConnectorToken),
       Effect.zipRight(Migration0027RelayTunnelHostname),
+      Effect.zipRight(Migration0028RelayMintPublicKey),
     ),
   ).pipe(Layer.provideMerge(SqlLive));
   const ConfigLive = Layer.succeed(LanAuthConfig, {
@@ -244,6 +247,49 @@ describe("LanAuthService", () => {
     });
   });
 
+  it("verifies relay-issued connect tokens with persisted relay mint key", async () => {
+    await withRuntime(async (run) => {
+      const mintKey = await generateKeyPair("EdDSA", { extractable: true });
+      const mintPublicKey = JSON.stringify(await exportJWK(mintKey.publicKey));
+      const environmentId = await run(
+        Effect.gen(function* () {
+          const auth = yield* LanAuthService;
+          const environmentId = yield* auth.environmentId();
+          yield* auth.saveRelayConfig({
+            relayUrl: "https://relay.test",
+            relayIssuer: "https://relay.test",
+            environmentId,
+            environmentCredential: "zec_secret",
+            mintPublicKey,
+          });
+          return environmentId;
+        }),
+      );
+
+      const nowSec = Math.floor(Date.now() / 1000);
+      const token = await new SignJWT({
+        environmentId,
+        cnf: { jkt: "thumbprint" },
+      })
+        .setProtectedHeader({ alg: "EdDSA", typ: "connect+jwt" })
+        .setIssuer("https://relay.test")
+        .setAudience(`zuse-env:${environmentId}`)
+        .setSubject("acct_test")
+        .setIssuedAt(nowSec)
+        .setExpirationTime(nowSec + 60)
+        .sign(mintKey.privateKey);
+
+      await expect(
+        run(
+          Effect.gen(function* () {
+            const auth = yield* LanAuthService;
+            return yield* auth.verifyToken(token);
+          }),
+        ),
+      ).resolves.toBe(true);
+    });
+  });
+
   it("builds LAN, loopback, and managed tunnel advertised endpoints", () => {
     const endpoints = buildAdvertisedEndpoints({
       lan: {
@@ -279,7 +325,7 @@ describe("LanAuthService", () => {
       endpoints.find((endpoint) => endpoint.id === "tunnel:managed-relay"),
     ).toMatchObject({
       httpBaseUrl: "https://env.example.test",
-      wsBaseUrl: "wss://env.example.test/rpc",
+      wsBaseUrl: "wss://env.example.test",
       reachability: "tunnel",
       compatibility: { hostedHttpsApp: "compatible" },
       status: "available",

--- a/apps/server/test/lan-auth-service.test.ts
+++ b/apps/server/test/lan-auth-service.test.ts
@@ -290,6 +290,35 @@ describe("LanAuthService", () => {
     });
   });
 
+  it("rejects malformed relay connect tokens without failing verification", async () => {
+    await withRuntime(async (run) => {
+      const mintKey = await generateKeyPair("EdDSA", { extractable: true });
+      const mintPublicKey = JSON.stringify(await exportJWK(mintKey.publicKey));
+      await run(
+        Effect.gen(function* () {
+          const auth = yield* LanAuthService;
+          const environmentId = yield* auth.environmentId();
+          yield* auth.saveRelayConfig({
+            relayUrl: "https://relay.test",
+            relayIssuer: "https://relay.test",
+            environmentId,
+            environmentCredential: "zec_secret",
+            mintPublicKey,
+          });
+        }),
+      );
+
+      await expect(
+        run(
+          Effect.gen(function* () {
+            const auth = yield* LanAuthService;
+            return yield* auth.verifyToken("not-a-jwt");
+          }),
+        ),
+      ).resolves.toBe(false);
+    });
+  });
+
   it("builds LAN, loopback, and managed tunnel advertised endpoints", () => {
     const endpoints = buildAdvertisedEndpoints({
       lan: {

--- a/apps/server/test/ws-auth.test.ts
+++ b/apps/server/test/ws-auth.test.ts
@@ -15,6 +15,7 @@ import {
 import type { LanAuthPolicy } from "../src/lan-auth/policy.ts";
 import { Migration0021AuthTokens } from "../src/persistence/migrations/0021_auth_tokens.ts";
 import { Migration0024RemoteConnectState } from "../src/persistence/migrations/0024_remote_connect_state.ts";
+import { Migration0028RelayMintPublicKey } from "../src/persistence/migrations/0028_relay_mint_public_key.ts";
 import { wsServerProtocolLayer } from "../src/transports/ws.ts";
 
 const TestRpcs = RpcGroup.make(PingRpc);
@@ -45,7 +46,10 @@ const makeRuntime = (opts: {
 }) => {
   const SqlLive = SqliteClient.layer({ filename: ":memory:" });
   const Migrated = Layer.effectDiscard(
-    Migration0021AuthTokens.pipe(Effect.zipRight(Migration0024RemoteConnectState)),
+    Migration0021AuthTokens.pipe(
+      Effect.zipRight(Migration0024RemoteConnectState),
+      Effect.zipRight(Migration0028RelayMintPublicKey),
+    ),
   ).pipe(
     Layer.provideMerge(SqlLive),
   );
@@ -220,13 +224,14 @@ describe("WS LAN auth", () => {
     }
   });
 
-  it("fails closed for protected boot with no token and no bootstrap", async () => {
+  it("binds protected servers without existing tokens and rejects requests", async () => {
     const port = await freePort();
     const runtime = makeRuntime({ policy: "protected", port });
     try {
-      await expect(
-        runtime.runPromise(Effect.void),
-      ).rejects.toThrow(/refusing to bind non-loopback without auth/);
+      await runtime.runPromise(Effect.void);
+      const response = await fetch(`http://127.0.0.1:${port}/`);
+      expect(response.status).toBe(401);
+      await expect(upgradeStatus(port, "/")).resolves.toBe(401);
     } finally {
       await disposeRuntime(runtime);
     }

--- a/apps/server/test/ws-auth.test.ts
+++ b/apps/server/test/ws-auth.test.ts
@@ -184,6 +184,9 @@ describe("WS LAN auth", () => {
       await expect(
         upgradeStatus(port, `/?token=${encodeURIComponent(body.token)}`),
       ).resolves.toBe(101);
+      await expect(
+        upgradeStatus(port, `/rpc?token=${encodeURIComponent(body.token)}`),
+      ).resolves.toBe(101);
     } finally {
       await disposeRuntime(runtime);
     }

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,8 @@
         "@expo-google-fonts/geist-mono": "^0.4.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo/ui": "~57.0.3",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
         "@zuse/wire": "*",
         "clsx": "^2.1.1",
         "effect": "catalog:",

--- a/infra/relay/README.md
+++ b/infra/relay/README.md
@@ -60,8 +60,11 @@ connect, cross-account isolation, proof forgery, and replay rejection.
    and paste the id into `wrangler.jsonc`.
 4. **WorkOS**: set `WORKOS_JWKS_URL` (`https://api.workos.com/sso/jwks/<client_id>`) and `WORKOS_ISSUER`.
 5. **Managed Cloudflare tunnel** (optional — enables reach-from-anywhere; leave off for LAN-only):
-   - In `wrangler.jsonc` set `MANAGED_TUNNEL_BASE_DOMAIN` (a zone on this CF account),
+   - In `wrangler.jsonc` set `MANAGED_TUNNEL_BASE_DOMAIN` (the CF zone apex),
      `MANAGED_TUNNEL_NAMESPACE`, `CF_ACCOUNT_ID`, and `CF_ZONE_ID` (the base domain's zone id).
+     Keep generated tunnel hostnames one label under the zone, for example
+     `zenv-<hash>.stuff.md`; a nested hostname like `zenv-<hash>.t.stuff.md`
+     can resolve but fail TLS unless a matching Cloudflare certificate exists.
    - Set the API token secret: `bun run secret:cf` (`wrangler secret put CF_API_TOKEN`). The token
      needs **Account: Cloudflare Tunnel: Edit** + **Zone: DNS: Edit** on that zone.
    - The desktop must have **`cloudflared`** on PATH (`brew install cloudflared`); it runs the

--- a/infra/relay/README.md
+++ b/infra/relay/README.md
@@ -76,5 +76,5 @@ connect, cross-account isolation, proof forgery, and replay rejection.
 - **Managed tunnels**: on link the relay creates a per-`(account, environment)` named tunnel,
   pushes its ingress (hostname → the desktop's loopback WS origin), sets a proxied CNAME, and
   returns a connector token the desktop runs `cloudflared` with. Presence/connect then route to
-  `wss://<hostname>/rpc`. Unlink tears the tunnel + DNS down. Chat bytes never touch the relay —
+  `wss://<hostname>`. Unlink tears the tunnel + DNS down. Chat bytes never touch the relay —
   the data path is phone ↔ Cloudflare edge ↔ desktop connector.

--- a/infra/relay/src/config.ts
+++ b/infra/relay/src/config.ts
@@ -22,7 +22,7 @@ export interface ManagedTunnelConfig {
   readonly cfApiToken: Redacted.Redacted<string>;
   readonly cfAccountId: string;
   readonly cfZoneId: string;
-  /** Apex/base domain the tunnel hostnames live under, e.g. `t.stuff.md`. */
+  /** Zone apex the tunnel hostnames live under, e.g. `stuff.md`. */
   readonly baseDomain: string;
   /** Prefix that namespaces tunnel/hostnames per deployment, e.g. `zenv`. */
   readonly namespace: string;

--- a/infra/relay/src/handler.ts
+++ b/infra/relay/src/handler.ts
@@ -85,10 +85,10 @@ const hasSensitiveActivityKey = (value: unknown): boolean => {
 
 const publicEndpoint = (environment: EnvironmentRecord) =>
   environment.tunnelHostname !== undefined
-    ? {
-        httpBaseUrl: `https://${environment.tunnelHostname}`,
-        wsBaseUrl: `wss://${environment.tunnelHostname}/rpc`,
-      }
+      ? {
+          httpBaseUrl: `https://${environment.tunnelHostname}`,
+          wsBaseUrl: `wss://${environment.tunnelHostname}`,
+        }
     : {
         httpBaseUrl: environment.httpBaseUrl,
         wsBaseUrl: environment.wsBaseUrl,
@@ -247,7 +247,7 @@ const route = (
           tunnelHostname !== undefined
             ? {
                 httpBaseUrl: `https://${tunnelHostname}`,
-                wsBaseUrl: `wss://${tunnelHostname}/rpc`,
+                wsBaseUrl: `wss://${tunnelHostname}`,
               }
             : {
                 httpBaseUrl: body.endpoint.httpBaseUrl,

--- a/infra/relay/test/relay.test.ts
+++ b/infra/relay/test/relay.test.ts
@@ -494,7 +494,7 @@ describe("@zuse/relay managed tunnel", () => {
       };
       expect(body.connectorToken).toBe("connector-token-xyz");
       expect(body.tunnelHostname).toBe("zenv-" + body.tunnelHostname!.split("-")[1]);
-      expect(body.endpoint.wsBaseUrl).toBe(`wss://${body.tunnelHostname}/rpc`);
+      expect(body.endpoint.wsBaseUrl).toBe(`wss://${body.tunnelHostname}`);
 
       // The discovery list now advertises the managed endpoint.
       const list = await relay.fetch(
@@ -504,7 +504,7 @@ describe("@zuse/relay managed tunnel", () => {
         }),
       );
       const listed = (await list.json()).environments[0];
-      expect(listed.endpoint.wsBaseUrl).toBe(`wss://${body.tunnelHostname}/rpc`);
+      expect(listed.endpoint.wsBaseUrl).toBe(`wss://${body.tunnelHostname}`);
     } finally {
       cf.restore();
     }

--- a/infra/relay/test/relay.test.ts
+++ b/infra/relay/test/relay.test.ts
@@ -406,7 +406,7 @@ const FAKE_TUNNEL: Config.ManagedTunnelConfig = {
   cfApiToken: Redacted.make("cf-token"),
   cfAccountId: "acct_1",
   cfZoneId: "zone_1",
-  baseDomain: "t.test",
+  baseDomain: "test",
   namespace: "zenv",
 };
 

--- a/infra/relay/wrangler.jsonc
+++ b/infra/relay/wrangler.jsonc
@@ -26,12 +26,14 @@
     // tunnels; leave any unset to disable (the relay then advertises the LAN
     // endpoint the desktop sends). CF_API_TOKEN is the only secret — set it via
     // `bunx wrangler secret put CF_API_TOKEN`.
-    //   MANAGED_TUNNEL_BASE_DOMAIN — apex the tunnel hostnames live under (must be
-    //     a zone on this Cloudflare account), e.g. "t.stuff.md".
+    //   MANAGED_TUNNEL_BASE_DOMAIN — zone apex the tunnel hostnames live under.
+    //     Keep generated hostnames one label below the zone so Cloudflare's
+    //     managed edge certificate covers them, e.g. "stuff.md" gives
+    //     "zenv-<hash>.stuff.md".
     //   MANAGED_TUNNEL_NAMESPACE   — per-deployment prefix for tunnel + hostname.
     //   CF_ACCOUNT_ID / CF_ZONE_ID — the account, and the DNS zone id that owns
-    //     BASE_DOMAIN (for t.stuff.md, this is the stuff.md zone).
-    "MANAGED_TUNNEL_BASE_DOMAIN": "t.stuff.md",
+    //     BASE_DOMAIN.
+    "MANAGED_TUNNEL_BASE_DOMAIN": "stuff.md",
     "MANAGED_TUNNEL_NAMESPACE": "zenv",
     "CF_ACCOUNT_ID": "40dd16663d44dc635537be6d183af841",
     "CF_ZONE_ID": "1ebb00c5fd61050e9f48ce1c791a29da",

--- a/packages/wire/src/connect.ts
+++ b/packages/wire/src/connect.ts
@@ -153,6 +153,7 @@ export const ConnectRelayConfigRpc = Rpc.make("connect.relayConfig", {
     relayIssuer: Schema.String,
     environmentId: EnvironmentId,
     environmentCredential: Schema.String,
+    mintPublicKey: Schema.optional(Schema.String),
   }),
   success: Schema.Void,
   error: ConnectAuthError,


### PR DESCRIPTION
## Summary
- replace mobile DPoP CryptoKey/WebCrypto signing with pure JS P-256 signing for React Native compatibility
- keep relay response bodies in mobile errors so 401s show the actual relay reason
- surface relay auth failures as refresh errors instead of marking computers offline

## Validation
- bun --filter mobile check-types
- bun --filter mobile lint
- bun --filter mobile test

Superseded by #279.