### PR TITLE
[codex] Add browser visual annotations

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1123,6 +1123,49 @@ function createMainWindow() {
     return browserPendingDialog.get(rawId) ?? null;
   });
 
+  ipcMain.handle("browser:listLocalServers", async () => {
+    try {
+      const byPort = new Map<number, string>();
+      if (process.platform === "darwin") {
+        const { stdout } = await execFileAsync("lsof", [
+          "-nP",
+          "-iTCP",
+          "-sTCP:LISTEN",
+        ]);
+        for (const line of stdout.split("\n").slice(1)) {
+          const trimmed = line.trim();
+          if (trimmed.length === 0) continue;
+          const parts = trimmed.split(/\s+/);
+          const command = parts[0] ?? "server";
+          const endpoint = parts.find((part) => /:(\d+)$/.test(part));
+          const match = endpoint?.match(/:(\d+)$/);
+          if (match === undefined || match === null) continue;
+          const port = Number(match[1]);
+          if (!Number.isInteger(port) || port <= 0 || port > 65535) continue;
+          if (!byPort.has(port)) byPort.set(port, command.slice(0, 48));
+        }
+      } else {
+        const { stdout } = await execFileAsync("netstat", ["-an"]);
+        for (const line of stdout.split("\n")) {
+          if (!/\bLISTEN(?:ING)?\b/i.test(line)) continue;
+          const match = line.match(
+            /(?:127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?|\*)[.:](\d+)/,
+          );
+          if (match === null) continue;
+          const port = Number(match[1]);
+          if (!Number.isInteger(port) || port <= 0 || port > 65535) continue;
+          if (!byPort.has(port)) byPort.set(port, "localhost");
+        }
+      }
+      return [...byPort.entries()]
+        .sort(([left], [right]) => left - right)
+        .slice(0, 50)
+        .map(([port, name]) => ({ name, port }));
+    } catch {
+      return [];
+    }
+  });
+
   ipcMain.handle(
     "browser:dispatchInput",
     async (_event, rawId: unknown, rawAction: unknown) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -99,6 +99,10 @@ const bridge = {
         message: string;
         defaultPrompt?: string;
       } | null>,
+    listLocalServers: () =>
+      ipcRenderer.invoke("browser:listLocalServers") as Promise<
+        ReadonlyArray<{ name: string; port: number }>
+      >,
   },
   notch: {
     setItems: (items: unknown) => {

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -1,17 +1,50 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { StarIcon } from "@hugeicons-pro/core-bulk-rounded";
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
 import { Effect, Fiber, Stream } from "effect";
-import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import {
+  Camera,
+  ChevronLeft,
+  ChevronRight,
+  Eraser,
+  MousePointer2,
+  MousePointerClick,
+  PencilLine,
+  RefreshCw,
+  SendHorizontal,
+  Server,
+  SquareDashedMousePointer,
+  X,
+} from "lucide-react";
 
-import { BrowserCommandResult, type BrowserCommandRequest } from "@zuse/wire";
+import {
+  BrowserCommandResult,
+  type BrowserAnnotationElement,
+  type BrowserAnnotationPoint,
+  type BrowserAnnotationRect,
+  type BrowserAnnotationRegion,
+  type BrowserAnnotationStroke,
+  type BrowserCommandRequest,
+  type SessionId,
+} from "@zuse/wire";
 
 import type {
   BrowserInputAction,
   CdpCommandOutcome,
+  LocalServerSummary,
   NetworkQueryResult,
 } from "../lib/bridge.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { useAnnotationsStore } from "../store/annotations.ts";
+import { useAttachmentsStore } from "../store/attachments.ts";
+import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
 import { AgentCursor, type AgentCursorIntent } from "./agent-cursor.tsx";
 import { BrowserShutter } from "./browser-shutter.tsx";
@@ -32,6 +65,101 @@ const CURSOR_GLIDE_MS = 350;
  * this long plus a small buffer before letting the next command run.
  */
 const SMOOTH_SCROLL_MS = 700;
+
+type AnnotationTool = "select" | "region" | "draw" | "erase";
+
+type BrowserElementPick = BrowserAnnotationElement & { id: string };
+
+const annotationTools: ReadonlyArray<{
+  readonly id: AnnotationTool;
+  readonly label: string;
+  readonly icon: ComponentType<{ className?: string; strokeWidth?: number }>;
+}> = [
+  { id: "select", label: "Select", icon: MousePointer2 },
+  { id: "region", label: "Region", icon: SquareDashedMousePointer },
+  { id: "draw", label: "Draw", icon: PencilLine },
+  { id: "erase", label: "Erase", icon: Eraser },
+];
+
+const fallbackLocalServers: ReadonlyArray<LocalServerSummary> = [
+  { name: "T3 Code", port: 3773 },
+  { name: "Vite", port: 5173 },
+  { name: "Zuse", port: 5733 },
+  { name: "Next.js", port: 3000 },
+];
+
+const newAnnotationId = (prefix: string): string => {
+  try {
+    return `${prefix}-${crypto.randomUUID()}`;
+  } catch {
+    return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  }
+};
+
+const normalizeRect = (
+  start: BrowserAnnotationPoint,
+  end: BrowserAnnotationPoint,
+): BrowserAnnotationRect => ({
+  x: Math.min(start.x, end.x),
+  y: Math.min(start.y, end.y),
+  width: Math.abs(end.x - start.x),
+  height: Math.abs(end.y - start.y),
+});
+
+const isUsableRect = (rect: BrowserAnnotationRect): boolean =>
+  rect.width >= 4 && rect.height >= 4;
+
+const boundsForPoints = (
+  points: ReadonlyArray<BrowserAnnotationPoint>,
+): BrowserAnnotationRect => {
+  const xs = points.map((point) => point.x);
+  const ys = points.map((point) => point.y);
+  const left = Math.min(...xs);
+  const top = Math.min(...ys);
+  const right = Math.max(...xs);
+  const bottom = Math.max(...ys);
+  return { x: left, y: top, width: right - left, height: bottom - top };
+};
+
+const unionRects = (
+  rects: ReadonlyArray<BrowserAnnotationRect>,
+): BrowserAnnotationRect | null => {
+  if (rects.length === 0) return null;
+  const left = Math.min(...rects.map((rect) => rect.x));
+  const top = Math.min(...rects.map((rect) => rect.y));
+  const right = Math.max(...rects.map((rect) => rect.x + rect.width));
+  const bottom = Math.max(...rects.map((rect) => rect.y + rect.height));
+  return { x: left, y: top, width: right - left, height: bottom - top };
+};
+
+const pointInRect = (
+  point: BrowserAnnotationPoint,
+  rect: BrowserAnnotationRect,
+): boolean =>
+  point.x >= rect.x &&
+  point.x <= rect.x + rect.width &&
+  point.y >= rect.y &&
+  point.y <= rect.y + rect.height;
+
+const pathFromPoints = (
+  points: ReadonlyArray<BrowserAnnotationPoint>,
+): string => {
+  if (points.length === 0) return "";
+  return points
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+    .join(" ");
+};
+
+const nativeImageToFile = async (
+  image: NativeImageLike,
+  name: string,
+): Promise<File> => {
+  const png = image.toPNG();
+  const source = png instanceof Uint8Array ? png : new Uint8Array(png);
+  const bytes = new Uint8Array(source.length);
+  bytes.set(source);
+  return new File([bytes], name, { type: "image/png" });
+};
 
 /**
  * In-app Browser tab — toolbar (back/forward/refresh/URL bar) + Electron
@@ -76,6 +204,47 @@ export function BrowserPane() {
     null,
   );
   const cursorNonceRef = useRef(0);
+  const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
+  const addBrowserAnnotation = useAnnotationsStore((s) => s.addBrowser);
+  const uploadAttachment = useAttachmentsStore((s) => s.uploadOne);
+  const [annotating, setAnnotating] = useState(false);
+  const [annotationTool, setAnnotationTool] =
+    useState<AnnotationTool>("select");
+  const [hoverPick, setHoverPick] = useState<BrowserElementPick | null>(null);
+  const [pickedElements, setPickedElements] = useState<BrowserElementPick[]>(
+    [],
+  );
+  const [regions, setRegions] = useState<BrowserAnnotationRegion[]>([]);
+  const [strokes, setStrokes] = useState<BrowserAnnotationStroke[]>([]);
+  const [dragStart, setDragStart] = useState<BrowserAnnotationPoint | null>(
+    null,
+  );
+  const [dragRect, setDragRect] = useState<BrowserAnnotationRect | null>(null);
+  const [activeStroke, setActiveStroke] =
+    useState<BrowserAnnotationStroke | null>(null);
+  const [annotationComment, setAnnotationComment] = useState("");
+  const [attachingAnnotation, setAttachingAnnotation] = useState(false);
+  const [localServers, setLocalServers] =
+    useState<ReadonlyArray<LocalServerSummary>>(fallbackLocalServers);
+  const hasLoadedPage = url !== "" && url !== "about:blank";
+  const hasAnnotationTargets =
+    pickedElements.length > 0 || regions.length > 0 || strokes.length > 0;
+  const annotationBounds = unionRects([
+    ...pickedElements.map((element) => element.rect),
+    ...regions.map((region) => region.rect),
+    ...strokes.map((stroke) => stroke.bounds),
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.zuse?.browser?.listLocalServers?.().then((servers) => {
+      if (cancelled || servers.length === 0) return;
+      setLocalServers(servers);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Wire navigation lifecycle events onto the underlying webview element.
   // We attach via `addEventListener` because the webview tag isn't a real
@@ -131,6 +300,15 @@ export function BrowserPane() {
       // Fresh page — drop the previous page's console history and refs.
       consoleBufferRef.current = [];
       refStoreRef.current = { mode: "dom", map: new Map() };
+      setAnnotating(false);
+      setHoverPick(null);
+      setPickedElements([]);
+      setRegions([]);
+      setStrokes([]);
+      setDragStart(null);
+      setDragRect(null);
+      setActiveStroke(null);
+      setAnnotationComment("");
     };
     const onStop = () => {
       setIsLoading(false);
@@ -294,6 +472,230 @@ export function BrowserPane() {
     }
   };
 
+  const resetAnnotationDraft = () => {
+    setHoverPick(null);
+    setPickedElements([]);
+    setRegions([]);
+    setStrokes([]);
+    setDragStart(null);
+    setDragRect(null);
+    setActiveStroke(null);
+    setAnnotationComment("");
+  };
+
+  const pointFromEvent = (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ): BrowserAnnotationPoint => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  };
+
+  const pickElementAt = async (
+    point: BrowserAnnotationPoint,
+  ): Promise<BrowserElementPick | null> => {
+    const wv = webviewRef.current as WebviewElement | null;
+    if (wv === null || url === "") return null;
+    const code = `
+(() => {
+  const x = ${JSON.stringify(point.x)};
+  const y = ${JSON.stringify(point.y)};
+  const element = document.elementFromPoint(x, y);
+  if (!element || element === document.documentElement || element === document.body) return null;
+  const selectorFor = (node) => {
+    if (node.id) return "#" + CSS.escape(node.id);
+    const parts = [];
+    let current = node;
+    while (current && current.nodeType === 1 && current !== document.body && parts.length < 4) {
+      const tag = current.tagName.toLowerCase();
+      const parent = current.parentElement;
+      if (!parent) {
+        parts.unshift(tag);
+        break;
+      }
+      const siblings = Array.from(parent.children).filter((child) => child.tagName === current.tagName);
+      const index = siblings.indexOf(current) + 1;
+      parts.unshift(siblings.length > 1 ? tag + ":nth-of-type(" + index + ")" : tag);
+      current = parent;
+    }
+    return parts.join(" > ");
+  };
+  const rect = element.getBoundingClientRect();
+  const tagName = element.tagName.toLowerCase();
+  const text = (element.innerText || element.textContent || "").replace(/\\s+/g, " ").trim().slice(0, 140);
+  const label = element.id ? tagName + "#" + element.id : tagName;
+  return {
+    tagName,
+    selector: selectorFor(element),
+    label,
+    textPreview: text,
+    rect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height }
+  };
+})()
+`;
+    try {
+      const raw = await wv.executeJavaScript(code);
+      if (raw === null || typeof raw !== "object") return null;
+      const candidate = raw as BrowserAnnotationElement;
+      if (
+        typeof candidate.tagName !== "string" ||
+        typeof candidate.label !== "string" ||
+        typeof candidate.textPreview !== "string" ||
+        candidate.rect === undefined ||
+        !isUsableRect(candidate.rect)
+      ) {
+        return null;
+      }
+      return { ...candidate, id: newAnnotationId("element") };
+    } catch {
+      return null;
+    }
+  };
+
+  const removeAnnotationTargetAt = (point: BrowserAnnotationPoint): void => {
+    setPickedElements((current) =>
+      current.filter((element) => !pointInRect(point, element.rect)),
+    );
+    setRegions((current) =>
+      current.filter((region) => !pointInRect(point, region.rect)),
+    );
+    setStrokes((current) =>
+      current.filter((stroke) => !pointInRect(point, stroke.bounds)),
+    );
+  };
+
+  const handleAnnotationPointerDown = async (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) => {
+    if (!annotating || event.button !== 0) return;
+    const point = pointFromEvent(event);
+    event.currentTarget.setPointerCapture(event.pointerId);
+    event.preventDefault();
+    event.stopPropagation();
+    if (annotationTool === "select") {
+      const picked = await pickElementAt(point);
+      if (picked === null) return;
+      setPickedElements((current) => {
+        const exists = current.some(
+          (element) => element.selector === picked.selector,
+        );
+        return exists ? current : [...current, picked];
+      });
+      return;
+    }
+    if (annotationTool === "erase") {
+      removeAnnotationTargetAt(point);
+      return;
+    }
+    if (annotationTool === "region") {
+      setDragStart(point);
+      setDragRect({ ...point, width: 0, height: 0 });
+      return;
+    }
+    if (annotationTool === "draw") {
+      setActiveStroke({
+        id: newAnnotationId("stroke"),
+        points: [point],
+        bounds: { ...point, width: 0, height: 0 },
+      });
+    }
+  };
+
+  const handleAnnotationPointerMove = async (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) => {
+    if (!annotating) return;
+    const point = pointFromEvent(event);
+    if (annotationTool === "select" && dragStart === null) {
+      const picked = await pickElementAt(point);
+      setHoverPick(picked);
+      return;
+    }
+    if (annotationTool === "region" && dragStart !== null) {
+      setDragRect(normalizeRect(dragStart, point));
+      return;
+    }
+    if (annotationTool === "draw" && activeStroke !== null) {
+      const points = [...activeStroke.points, point];
+      setActiveStroke({
+        ...activeStroke,
+        points,
+        bounds: boundsForPoints(points),
+      });
+    }
+  };
+
+  const handleAnnotationPointerUp = (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) => {
+    if (!annotating) return;
+    const point = pointFromEvent(event);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (annotationTool === "region" && dragStart !== null) {
+      const rect = normalizeRect(dragStart, point);
+      if (isUsableRect(rect)) {
+        setRegions((current) => [
+          ...current,
+          { id: newAnnotationId("region"), rect },
+        ]);
+      }
+      setDragStart(null);
+      setDragRect(null);
+    }
+    if (annotationTool === "draw" && activeStroke !== null) {
+      if (
+        activeStroke.points.length >= 2 &&
+        isUsableRect(activeStroke.bounds)
+      ) {
+        setStrokes((current) => [...current, activeStroke]);
+      }
+      setActiveStroke(null);
+    }
+  };
+
+  const attachBrowserAnnotation = async (): Promise<void> => {
+    const wv = webviewRef.current as WebviewElement | null;
+    if (
+      wv === null ||
+      selectedSessionId === null ||
+      !hasAnnotationTargets ||
+      annotationComment.trim().length === 0
+    ) {
+      return;
+    }
+    setAttachingAnnotation(true);
+    try {
+      const image = await wv.capturePage();
+      const file = await nativeImageToFile(
+        image,
+        `browser-annotation-${Date.now()}.png`,
+      );
+      const screenshotAttachment = await uploadAttachment(
+        selectedSessionId as SessionId,
+        file,
+      );
+      addBrowserAnnotation(selectedSessionId, {
+        comment: annotationComment.trim(),
+        pageUrl: safeCall(() => wv.getURL(), url),
+        pageTitle: safeCall(() => wv.getTitle(), "") || null,
+        elements: pickedElements.map(({ id: _id, ...element }) => element),
+        regions,
+        strokes,
+        screenshotAttachment,
+      });
+      resetAnnotationDraft();
+      setAnnotating(false);
+    } catch (error) {
+      console.warn("[browser.annotation] attach failed", error);
+    } finally {
+      setAttachingAnnotation(false);
+    }
+  };
+
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-background">
       <form
@@ -341,12 +743,34 @@ export function BrowserPane() {
           spellCheck={false}
           className="flex-1 rounded bg-transparent px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/70 focus:bg-muted/40"
         />
+        <ToolbarButton
+          onClick={() => {
+            if (!hasLoadedPage) return;
+            setAnnotating((value) => {
+              const next = !value;
+              if (!next) resetAnnotationDraft();
+              return next;
+            });
+          }}
+          disabled={!hasLoadedPage}
+          ariaLabel={annotating ? "Cancel annotation" : "Annotate page"}
+        >
+          <MousePointerClick
+            className={`size-3.5 ${annotating ? "text-primary" : ""}`}
+            strokeWidth={1.8}
+          />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => setShutterNonce((n) => n + 1)}
+          disabled={!hasLoadedPage}
+          ariaLabel="Capture screenshot"
+        >
+          <Camera className="size-3.5" strokeWidth={1.8} />
+        </ToolbarButton>
       </form>
       <div className="relative min-h-0 flex-1">
-        {url === "" ? (
-          <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
-            Type a URL above to start browsing.
-          </div>
+        {!hasLoadedPage ? (
+          <BrowserEmptyState servers={localServers} onOpen={navigate} />
         ) : null}
         <webview
           ref={webviewRef as unknown as React.RefObject<HTMLElement>}
@@ -358,12 +782,41 @@ export function BrowserPane() {
           src="about:blank"
           allowpopups={true}
           style={{
-            display: url === "" ? "none" : "flex",
+            display: !hasLoadedPage ? "none" : "flex",
             width: "100%",
             height: "100%",
           }}
         />
-        <AgentCursor intent={cursorIntent} visible={url !== ""} />
+        {annotating && hasLoadedPage ? (
+          <BrowserAnnotationOverlay
+            tool={annotationTool}
+            setTool={setAnnotationTool}
+            hoverPick={hoverPick}
+            elements={pickedElements}
+            regions={regions}
+            strokes={strokes}
+            dragRect={dragRect}
+            activeStroke={activeStroke}
+            bounds={annotationBounds}
+            comment={annotationComment}
+            setComment={setAnnotationComment}
+            canAttach={
+              selectedSessionId !== null &&
+              hasAnnotationTargets &&
+              annotationComment.trim().length > 0
+            }
+            attaching={attachingAnnotation}
+            onAttach={() => void attachBrowserAnnotation()}
+            onCancel={() => {
+              resetAnnotationDraft();
+              setAnnotating(false);
+            }}
+            onPointerDown={handleAnnotationPointerDown}
+            onPointerMove={handleAnnotationPointerMove}
+            onPointerUp={handleAnnotationPointerUp}
+          />
+        ) : null}
+        <AgentCursor intent={cursorIntent} visible={hasLoadedPage} />
         <BrowserShutter nonce={shutterNonce} />
       </div>
     </div>
@@ -1645,6 +2098,269 @@ function loadAndWait(wv: WebviewElement, url: string): Promise<void> {
   });
 }
 
+function BrowserEmptyState({
+  servers,
+  onOpen,
+}: {
+  servers: ReadonlyArray<LocalServerSummary>;
+  onOpen: (url: string) => void;
+}) {
+  const rows = servers.length > 0 ? servers : fallbackLocalServers;
+  return (
+    <div className="absolute inset-0 z-10 overflow-auto bg-background px-8 py-10">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-5 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+          <Server className="size-4" strokeWidth={1.8} />
+          Local servers
+        </div>
+        <div className="overflow-hidden rounded-xl border border-border/70 bg-card/70">
+          {rows.map((server) => (
+            <button
+              key={`${server.name}-${server.port}`}
+              type="button"
+              onClick={() => onOpen(`http://localhost:${server.port}`)}
+              className="flex w-full items-center gap-4 border-b border-border/60 px-4 py-3 text-left last:border-b-0 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            >
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
+                <Server className="size-4" strokeWidth={1.8} />
+              </span>
+              <span className="grid min-w-0 flex-1">
+                <span className="truncate text-sm font-semibold text-foreground">
+                  {server.name}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  localhost:{server.port}
+                </span>
+              </span>
+              <span className="size-2.5 rounded-full bg-emerald-500" />
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BrowserAnnotationOverlay({
+  tool,
+  setTool,
+  hoverPick,
+  elements,
+  regions,
+  strokes,
+  dragRect,
+  activeStroke,
+  bounds,
+  comment,
+  setComment,
+  canAttach,
+  attaching,
+  onAttach,
+  onCancel,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+}: {
+  tool: AnnotationTool;
+  setTool: (tool: AnnotationTool) => void;
+  hoverPick: BrowserElementPick | null;
+  elements: ReadonlyArray<BrowserElementPick>;
+  regions: ReadonlyArray<BrowserAnnotationRegion>;
+  strokes: ReadonlyArray<BrowserAnnotationStroke>;
+  dragRect: BrowserAnnotationRect | null;
+  activeStroke: BrowserAnnotationStroke | null;
+  bounds: BrowserAnnotationRect | null;
+  comment: string;
+  setComment: (value: string) => void;
+  canAttach: boolean;
+  attaching: boolean;
+  onAttach: () => void;
+  onCancel: () => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+}) {
+  const maxLeft =
+    typeof window === "undefined" ? 16 : Math.max(16, window.innerWidth - 452);
+  const maxTop =
+    typeof window === "undefined" ? 16 : Math.max(16, window.innerHeight - 92);
+  const editorStyle =
+    bounds === null
+      ? { left: "50%", top: "58%", transform: "translate(-50%, -50%)" }
+      : {
+          left: Math.min(
+            Math.max(16, bounds.x + Math.max(0, bounds.width - 360)),
+            maxLeft,
+          ),
+          top: Math.min(Math.max(16, bounds.y + bounds.height + 12), maxTop),
+          transform: "translate(0, 0)",
+        };
+
+  return (
+    <div
+      className="absolute inset-0 z-20 cursor-crosshair bg-black/[0.03]"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    >
+      <div
+        className="absolute left-1/2 top-4 flex -translate-x-1/2 items-center gap-1 rounded-xl border border-border/70 bg-background/95 p-1 shadow-lg backdrop-blur"
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        {annotationTools.map((item) => {
+          const Icon = item.icon;
+          const active = item.id === tool;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setTool(item.id)}
+              className={`inline-flex h-8 items-center gap-1.5 rounded-lg px-3 text-sm font-medium ${
+                active
+                  ? "bg-primary/10 text-primary"
+                  : "text-foreground hover:bg-muted"
+              }`}
+            >
+              <Icon className="size-3.5" strokeWidth={1.8} />
+              {item.label}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={onCancel}
+          className="ml-1 flex size-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Cancel annotation"
+        >
+          <X className="size-4" strokeWidth={1.8} />
+        </button>
+      </div>
+
+      {hoverPick !== null && tool === "select" ? (
+        <AnnotationRect
+          rect={hoverPick.rect}
+          label={hoverPick.tagName}
+          subtle
+        />
+      ) : null}
+      {elements.map((element) => (
+        <AnnotationRect
+          key={element.id}
+          rect={element.rect}
+          label={element.tagName}
+        />
+      ))}
+      {regions.map((region) => (
+        <AnnotationRect key={region.id} rect={region.rect} label="region" />
+      ))}
+      {dragRect !== null ? (
+        <AnnotationRect rect={dragRect} label="region" subtle />
+      ) : null}
+
+      <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
+        {strokes.map((stroke) => (
+          <path
+            key={stroke.id}
+            d={pathFromPoints(stroke.points)}
+            fill="none"
+            stroke="rgb(37 99 235)"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={3}
+          />
+        ))}
+        {activeStroke !== null ? (
+          <path
+            d={pathFromPoints(activeStroke.points)}
+            fill="none"
+            stroke="rgb(37 99 235)"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={3}
+          />
+        ) : null}
+      </svg>
+
+      {bounds !== null ? (
+        <div
+          className="absolute flex w-[min(420px,calc(100%-32px))] items-start gap-2 rounded-xl border border-border/70 bg-background/95 p-2 shadow-xl backdrop-blur"
+          style={editorStyle}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground"
+            aria-label="Annotation details"
+          >
+            <MousePointerClick className="size-4" strokeWidth={1.8} />
+          </button>
+          <textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey && canAttach) {
+                event.preventDefault();
+                onAttach();
+              }
+            }}
+            placeholder="Describe the change..."
+            rows={1}
+            className="min-h-9 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={onAttach}
+            disabled={!canAttach || attaching}
+            className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg bg-primary px-3 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 disabled:opacity-50"
+          >
+            <SendHorizontal className="size-3.5" strokeWidth={1.8} />
+            {attaching ? "Attaching" : "Attach"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function AnnotationRect({
+  rect,
+  label,
+  subtle = false,
+}: {
+  rect: BrowserAnnotationRect;
+  label: string;
+  subtle?: boolean;
+}) {
+  return (
+    <>
+      <div
+        className={`pointer-events-none absolute rounded border-2 ${
+          subtle
+            ? "border-primary/80 bg-primary/10"
+            : "border-primary bg-primary/20"
+        }`}
+        style={{
+          left: rect.x,
+          top: rect.y,
+          width: rect.width,
+          height: rect.height,
+        }}
+      />
+      <div
+        className="pointer-events-none absolute rounded-md bg-primary px-2 py-0.5 text-xs font-semibold text-primary-foreground shadow"
+        style={{
+          left: Math.max(4, rect.x),
+          top: Math.max(4, rect.y - 24),
+        }}
+      >
+        {label}
+      </div>
+    </>
+  );
+}
+
 function ToolbarButton({
   onClick,
   disabled,
@@ -1654,7 +2370,7 @@ function ToolbarButton({
   onClick: () => void;
   disabled: boolean;
   ariaLabel: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <button
@@ -1709,5 +2425,6 @@ type WebviewElement = HTMLElement & {
 // `toDataURL` keeps us off `Buffer`, which the sandboxed renderer lacks.
 type NativeImageLike = {
   toDataURL: () => string;
+  toPNG: () => Uint8Array | ArrayBuffer;
   isEmpty: () => boolean;
 };

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -21,6 +21,8 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   ComposerInput,
   findModelDescriptor,
+  type BrowserAnnotation,
+  type ComposerAnnotation,
   type BooleanOptionDescriptor,
   type Message,
   type PermissionMode,
@@ -125,6 +127,27 @@ import { useOpencodeInventory } from "../store/opencode-inventory.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSettingsStore } from "../store/settings.ts";
 import { usePermissionsStore } from "../store/permissions.ts";
+
+const isBrowserAnnotation = (
+  annotation: ComposerAnnotation,
+): annotation is BrowserAnnotation =>
+  "_tag" in annotation && annotation._tag === "browser";
+
+const attachmentsWithBrowserAnnotations = (
+  attachments: ComposerInput["attachments"],
+  annotations: ReadonlyArray<ComposerAnnotation>,
+): ComposerInput["attachments"] => {
+  const next = [...attachments];
+  const seen = new Set(next.map((attachment) => attachment.id));
+  for (const annotation of annotations) {
+    if (!isBrowserAnnotation(annotation)) continue;
+    const screenshot = annotation.screenshotAttachment;
+    if (screenshot === null || seen.has(screenshot.id)) continue;
+    next.push(screenshot);
+    seen.add(screenshot.id);
+  }
+  return next;
+};
 import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
@@ -770,7 +793,10 @@ export function ChatComposer({
       annotations.length > 0
         ? ComposerInput.make({
             text: parsed.text,
-            attachments: parsed.attachments,
+            attachments: attachmentsWithBrowserAnnotations(
+              parsed.attachments,
+              annotations,
+            ),
             fileRefs: parsed.fileRefs,
             skillRefs: parsed.skillRefs,
             annotations,

--- a/apps/renderer/src/components/composer/annotation-tray.tsx
+++ b/apps/renderer/src/components/composer/annotation-tray.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDown01Icon,
   BubbleChatIcon,
+  CursorMagicSelection01Icon,
   PencilEdit01Icon,
   Tick01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
@@ -9,7 +10,9 @@ import { X } from "lucide-react";
 import { useState } from "react";
 
 import type {
+  BrowserAnnotation,
   CodeAnnotation,
+  ComposerAnnotation,
   FolderId,
   SessionId,
   WorktreeId,
@@ -21,12 +24,64 @@ import { useAnnotationsStore } from "../../store/annotations.ts";
 import { useRevealAnnotation } from "../annotation/annotation-navigation.ts";
 import { AnnotationFileChip } from "../file-chip.tsx";
 
-const EMPTY: ReadonlyArray<CodeAnnotation> = [];
+const EMPTY: ReadonlyArray<ComposerAnnotation> = [];
+
+const isBrowserAnnotation = (
+  annotation: ComposerAnnotation,
+): annotation is BrowserAnnotation =>
+  "_tag" in annotation && annotation._tag === "browser";
+
+const browserHost = (annotation: BrowserAnnotation): string => {
+  try {
+    return new URL(annotation.pageUrl).host;
+  } catch {
+    return annotation.pageUrl || "Browser";
+  }
+};
+
+const browserTargetLabel = (annotation: BrowserAnnotation): string => {
+  const count =
+    annotation.elements.length +
+    annotation.regions.length +
+    annotation.strokes.length;
+  const first = annotation.elements[0];
+  const targetSummary = `${count} ${count === 1 ? "target" : "targets"}`;
+  return `${first ? `<${first.tagName}> · ` : ""}${targetSummary}${
+    annotation.screenshotAttachment !== null ? " · screenshot" : ""
+  }`;
+};
+
+function BrowserAnnotationChip({
+  annotation,
+  className,
+}: {
+  readonly annotation: BrowserAnnotation;
+  readonly className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-[0.375rem] border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-muted-foreground dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]",
+        className,
+      )}
+    >
+      <HugeiconsIcon
+        icon={CursorMagicSelection01Icon}
+        className="size-3.5 shrink-0 text-primary"
+        aria-hidden="true"
+      />
+      <span className="truncate font-medium text-foreground">
+        {browserHost(annotation)}
+      </span>
+      <span className="truncate">{browserTargetLabel(annotation)}</span>
+    </span>
+  );
+}
 
 /**
- * Stacked code annotations docked above the composer. Draft annotations can be
- * opened in the editor, edited in-place, removed individually, or cleared as a
- * group before submit.
+ * Stacked annotations docked above the composer. Draft annotations can be
+ * opened where possible, edited in-place, removed individually, or cleared as
+ * a group before submit.
  */
 export function AnnotationTray({
   sessionId,
@@ -51,13 +106,13 @@ export function AnnotationTray({
   if (annotations.length === 0) return null;
 
   return (
-    <div className="mb-2 overflow-hidden rounded-lg border border-border/50 bg-card/80 shadow-sm">
-      <div className="flex w-full items-center gap-2 border-b border-border/40 bg-muted/20 px-2.5 py-1.5">
+    <div className="mb-1.5 overflow-hidden rounded-lg border border-border/50 bg-card/80 shadow-sm">
+      <div className="flex w-full items-center gap-1.5 border-b border-border/35 bg-muted/15 px-2 py-1">
         <button
           type="button"
-          onClick={() => setExpanded((v) => !v)}
+          onClick={() => setExpanded((value) => !value)}
           aria-expanded={expanded}
-          className="flex min-h-7 flex-1 items-center gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          className="flex min-h-6 flex-1 items-center gap-1.5 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
         >
           <HugeiconsIcon
             icon={BubbleChatIcon}
@@ -67,7 +122,7 @@ export function AnnotationTray({
           <span className="text-xs font-semibold text-foreground">
             Annotations
           </span>
-          <span className="rounded border border-border/50 bg-background/70 px-1.5 py-px text-[10px] font-medium tabular-nums text-muted-foreground">
+          <span className="rounded border border-border/45 bg-background/70 px-1 py-px text-[10px] font-medium tabular-nums text-muted-foreground">
             {annotations.length}
           </span>
           <HugeiconsIcon
@@ -82,96 +137,114 @@ export function AnnotationTray({
         <button
           type="button"
           onClick={() => clear(sessionId)}
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           aria-label="Clear all annotations"
         >
           <X className="size-3.5" strokeWidth={1.8} />
         </button>
       </div>
       {expanded ? (
-        <ul className="max-h-64 space-y-px overflow-y-auto p-1">
-          {annotations.map((a, i) => (
-            <li
-              key={a.id}
-              className="group/annotation flex items-stretch gap-1.5 rounded-md"
-            >
-              <div className="flex min-w-0 flex-1 items-start gap-2 rounded-md px-2 py-1.5 hover:bg-muted/55">
-                <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-primary/10 text-[11px] font-semibold tabular-nums text-primary">
-                  {i + 1}
-                </span>
-                <span className="grid min-w-0 flex-1 gap-1">
+        <ul className="max-h-48 divide-y divide-border/35 overflow-y-auto">
+          {annotations.map((annotation) => {
+            const browser = isBrowserAnnotation(annotation);
+            return (
+              <li
+                key={annotation.id}
+                className="group/annotation flex min-w-0 items-center gap-1.5 px-2 py-1.5 first:pt-1.5 last:pb-1.5 hover:bg-muted/45"
+              >
+                {browser ? (
+                  <BrowserAnnotationChip
+                    annotation={annotation}
+                    className="max-w-[44%] shrink-0"
+                  />
+                ) : (
                   <button
                     type="button"
-                    onClick={() => revealAnnotation(a)}
-                    className="min-w-0 justify-self-start rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                    onClick={() =>
+                      revealAnnotation(annotation as CodeAnnotation)
+                    }
+                    className="min-w-0 max-w-[44%] shrink-0 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                     title="Open annotation"
                   >
-                    <AnnotationFileChip annotation={a} />
-                  </button>
-                  {editingId === a.id ? (
-                    <textarea
-                      value={editText}
-                      onChange={(e) => setEditText(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Escape") {
-                          e.preventDefault();
-                          setEditingId(null);
-                        } else if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                          updateComment(sessionId, a.id, editText);
-                          setEditingId(null);
-                        }
-                      }}
-                      rows={2}
-                      className="max-h-24 min-h-12 w-full resize-y rounded-md bg-background/70 px-2 py-1.5 text-sm leading-snug text-foreground outline-none ring-1 ring-border/50 focus:ring-ring/50"
-                      autoFocus
+                    <AnnotationFileChip
+                      annotation={annotation as CodeAnnotation}
+                      className="max-w-full py-px"
                     />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => revealAnnotation(a)}
-                      className="min-w-0 truncate rounded text-left text-sm leading-snug text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                    >
-                      {a.comment}
-                    </button>
-                  )}
-                </span>
-              </div>
-              {editingId === a.id ? (
+                  </button>
+                )}
+                <span className="h-4 w-px shrink-0 bg-border/45" />
+                {editingId === annotation.id ? (
+                  <textarea
+                    value={editText}
+                    onChange={(event) => setEditText(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Escape") {
+                        event.preventDefault();
+                        setEditingId(null);
+                      } else if (event.key === "Enter" && !event.shiftKey) {
+                        event.preventDefault();
+                        updateComment(sessionId, annotation.id, editText);
+                        setEditingId(null);
+                      }
+                    }}
+                    rows={1}
+                    className="max-h-20 min-h-7 min-w-0 flex-1 resize-y rounded-md bg-background/70 px-2 py-1 text-xs leading-snug text-foreground outline-none ring-1 ring-border/50 focus:ring-ring/50"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (!browser) {
+                        revealAnnotation(annotation as CodeAnnotation);
+                      }
+                    }}
+                    disabled={browser}
+                    className="min-w-0 flex-1 truncate rounded text-left text-xs leading-snug text-foreground disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                    title={annotation.comment}
+                  >
+                    {annotation.comment}
+                  </button>
+                )}
+                {editingId === annotation.id ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      updateComment(sessionId, annotation.id, editText);
+                      setEditingId(null);
+                    }}
+                    className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                    aria-label="Save annotation"
+                  >
+                    <HugeiconsIcon icon={Tick01Icon} className="size-3.5" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingId(annotation.id);
+                      setEditText(annotation.comment);
+                    }}
+                    className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 group-hover/annotation:opacity-100"
+                    aria-label="Edit annotation"
+                  >
+                    <HugeiconsIcon
+                      icon={PencilEdit01Icon}
+                      className="size-3.5"
+                    />
+                  </button>
+                )}
                 <button
                   type="button"
-                  onClick={() => {
-                    updateComment(sessionId, a.id, editText);
-                    setEditingId(null);
-                  }}
-                  className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                  aria-label="Save annotation"
+                  onClick={() => remove(sessionId, annotation.id)}
+                  className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 group-hover/annotation:opacity-100"
+                  aria-label="Remove annotation"
                 >
-                  <HugeiconsIcon icon={Tick01Icon} className="size-3.5" />
+                  <X className="size-3.5" strokeWidth={1.8} />
                 </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingId(a.id);
-                    setEditText(a.comment);
-                  }}
-                  className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 group-hover/annotation:opacity-100"
-                  aria-label="Edit annotation"
-                >
-                  <HugeiconsIcon icon={PencilEdit01Icon} className="size-3.5" />
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => remove(sessionId, a.id)}
-                className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 group-hover/annotation:opacity-100"
-                aria-label="Remove annotation"
-              >
-                <X className="size-3.5" strokeWidth={1.8} />
-              </button>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       ) : null}
     </div>

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -58,6 +58,13 @@ type PreviewState =
   | { status: "binary"; size: number }
   | { status: "error"; reason: string };
 
+const isCodeAnnotation = (annotation: unknown): annotation is CodeAnnotation =>
+  typeof annotation === "object" &&
+  annotation !== null &&
+  "relPath" in annotation &&
+  "startLine" in annotation &&
+  !("_tag" in annotation);
+
 const formatError = (err: unknown): string => {
   if (typeof err === "object" && err !== null && "_tag" in err) {
     const tag = String((err as { _tag: unknown })._tag);
@@ -108,9 +115,9 @@ const joinPath = (base: string, rel: string): string =>
 
 const fileUrlForDirectory = (dir: string): string => {
   const normalized = dir.endsWith("/") ? dir : `${dir}/`;
-  const segments = normalized.split("/").map((segment) =>
-    segment === "" ? "" : encodeURIComponent(segment),
-  );
+  const segments = normalized
+    .split("/")
+    .map((segment) => (segment === "" ? "" : encodeURIComponent(segment)));
   return `file://${segments.join("/")}`;
 };
 
@@ -261,6 +268,7 @@ function CodeMirrorBody({
   const visibleAnnotations = useMemo(
     () =>
       draftAnnotations
+        .filter(isCodeAnnotation)
         .filter(
           (a) =>
             a.relPath === annotationPath || a.absPath === annotationAbsPath,

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -14,7 +14,9 @@ import { RefreshCw as RefreshIcon } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import type {
   AttachmentRef,
+  BrowserAnnotation,
   CodeAnnotation,
+  ComposerAnnotation,
   FileRef,
   Message,
   ProviderId,
@@ -38,6 +40,25 @@ import { CopyButton } from "./copy-button.tsx";
 import { useRevealAnnotation } from "./annotation/annotation-navigation.ts";
 import { useChatLookups } from "./chat-lookups.tsx";
 import { AnnotationFileChip, FileChip } from "./file-chip.tsx";
+
+const isBrowserAnnotation = (
+  annotation: ComposerAnnotation,
+): annotation is BrowserAnnotation =>
+  "_tag" in annotation && annotation._tag === "browser";
+
+const browserAnnotationMeta = (annotation: BrowserAnnotation): string => {
+  const count =
+    annotation.elements.length +
+    annotation.regions.length +
+    annotation.strokes.length;
+  const first = annotation.elements[0];
+  if (first !== undefined) return `<${first.tagName}> · ${count}`;
+  try {
+    return `${new URL(annotation.pageUrl).host} · ${count}`;
+  } catch {
+    return `Browser · ${count}`;
+  }
+};
 import { MarkdownBody } from "./markdown-body.tsx";
 import {
   ExitPlanModeRow,
@@ -341,7 +362,7 @@ function UserBubble({
   attachments?: ReadonlyArray<AttachmentRef>;
   fileRefs?: ReadonlyArray<FileRef>;
   skillRefs?: ReadonlyArray<SkillRef>;
-  annotations?: ReadonlyArray<CodeAnnotation>;
+  annotations?: ReadonlyArray<ComposerAnnotation>;
   goal?: boolean;
 }) {
   const hasAnnotations = annotations !== undefined && annotations.length > 0;
@@ -372,15 +393,28 @@ function UserBubble({
               <li key={a.id}>
                 <button
                   type="button"
-                  onClick={() => revealAnnotation(a)}
+                  onClick={() => {
+                    if (!isBrowserAnnotation(a)) revealAnnotation(a);
+                  }}
+                  disabled={isBrowserAnnotation(a)}
                   className="flex w-full min-w-0 items-start gap-2 rounded-lg border border-user-bubble-foreground/12 bg-background/10 px-2 py-1.5 text-left text-xs hover:bg-background/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-user-bubble-foreground/30"
-                  title="Open annotation"
+                  title={
+                    isBrowserAnnotation(a)
+                      ? "Browser annotation"
+                      : "Open annotation"
+                  }
                 >
                   <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-background/20 text-[10px] font-semibold tabular-nums">
                     {i + 1}
                   </span>
                   <span className="grid min-w-0 flex-1 gap-1">
-                    <AnnotationFileChip annotation={a} />
+                    {isBrowserAnnotation(a) ? (
+                      <span className="min-w-0 truncate font-medium">
+                        {browserAnnotationMeta(a)}
+                      </span>
+                    ) : (
+                      <AnnotationFileChip annotation={a as CodeAnnotation} />
+                    )}
                     <span className="min-w-0 break-words leading-snug">
                       {a.comment}
                     </span>

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -164,6 +164,11 @@ export interface BrowserDialogState {
   readonly defaultPrompt?: string;
 }
 
+export interface LocalServerSummary {
+  readonly name: string;
+  readonly port: number;
+}
+
 export interface BrowserBridge {
   /**
    * Attach Chrome DevTools Protocol to the embedded webview's webContents so
@@ -197,6 +202,7 @@ export interface BrowserBridge {
   readonly getDialogState?: (
     webContentsId: number,
   ) => Promise<BrowserDialogState | null>;
+  readonly listLocalServers?: () => Promise<ReadonlyArray<LocalServerSummary>>;
 }
 
 export interface SshBridge {

--- a/apps/renderer/src/store/annotations.ts
+++ b/apps/renderer/src/store/annotations.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 
-import type { CodeAnnotation, SessionId } from "@zuse/wire";
+import type {
+  BrowserAnnotation,
+  CodeAnnotation,
+  ComposerAnnotation,
+  SessionId,
+} from "@zuse/wire";
 
 import { readStorageWithLegacy } from "../lib/storage-keys.ts";
 
@@ -17,7 +22,7 @@ import { readStorageWithLegacy } from "../lib/storage-keys.ts";
 const STORAGE_KEY = "zuse.annotations.v1";
 const LEGACY_STORAGE_KEYS = ["memoize.annotations.v1"] as const;
 
-type Persisted = Record<string, ReadonlyArray<CodeAnnotation>>;
+type Persisted = Record<string, ReadonlyArray<ComposerAnnotation>>;
 
 const load = (): Persisted => {
   try {
@@ -59,6 +64,10 @@ type AnnotationsState = {
     sessionId: SessionId,
     annotation: Omit<CodeAnnotation, "id">,
   ) => string;
+  readonly addBrowser: (
+    sessionId: SessionId,
+    annotation: Omit<BrowserAnnotation, "id" | "_tag" | "createdAt">,
+  ) => BrowserAnnotation;
   readonly remove: (sessionId: SessionId, id: string) => void;
   readonly updateComment: (
     sessionId: SessionId,
@@ -78,6 +87,19 @@ export const useAnnotationsStore = create<AnnotationsState>((set, get) => ({
     set({ bySession });
     persist(bySession);
     return id;
+  },
+  addBrowser: (sessionId, annotation) => {
+    const entry: BrowserAnnotation = {
+      ...annotation,
+      _tag: "browser",
+      id: newId(),
+      createdAt: new Date().toISOString(),
+    };
+    const current = get().bySession[sessionId] ?? [];
+    const bySession = { ...get().bySession, [sessionId]: [...current, entry] };
+    set({ bySession });
+    persist(bySession);
+    return entry;
   },
   remove: (sessionId, id) => {
     const current = get().bySession[sessionId];
@@ -113,5 +135,5 @@ export const useAnnotationsStore = create<AnnotationsState>((set, get) => ({
 /** Snapshot read for non-reactive callers (e.g. the submit handler). */
 export const annotationsForSession = (
   sessionId: SessionId,
-): ReadonlyArray<CodeAnnotation> =>
+): ReadonlyArray<ComposerAnnotation> =>
   useAnnotationsStore.getState().bySession[sessionId] ?? [];

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -1028,6 +1028,7 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
             attachments: c.attachments,
             fileRefs: c.fileRefs,
             skillRefs: c.skillRefs,
+            annotations: c.annotations,
           }),
         );
         return;

--- a/apps/renderer/test/annotations-store.test.ts
+++ b/apps/renderer/test/annotations-store.test.ts
@@ -86,6 +86,61 @@ describe("annotations store", () => {
     expect(annotationsForSession(sessionId)).toEqual([]);
   });
 
+  it("edits annotation comments before send", () => {
+    const id = useAnnotationsStore.getState().add(sessionId, {
+      relPath: "src/app.ts",
+      absPath: "/repo/src/app.ts",
+      startLine: 3,
+      endLine: 5,
+      comment: "initial note",
+    });
+
+    useAnnotationsStore
+      .getState()
+      .updateComment(sessionId, id, "  refined instruction  ");
+
+    expect(annotationsForSession(sessionId)).toMatchObject([
+      {
+        id,
+        comment: "refined instruction",
+      },
+    ]);
+  });
+
+  it("adds browser annotations by session", () => {
+    const annotation = useAnnotationsStore.getState().addBrowser(sessionId, {
+      comment: "this can be improved",
+      pageUrl: "https://example.com/",
+      pageTitle: "Example Domain",
+      elements: [
+        {
+          tagName: "p",
+          selector: "p",
+          label: "p",
+          rect: { x: 1, y: 2, width: 300, height: 40 },
+          textPreview: "This domain is for use in documentation examples",
+        },
+      ],
+      regions: [],
+      strokes: [],
+      screenshotAttachment: {
+        id: "shot-1",
+        mimeType: "image/png",
+        originalName: "browser-annotation.png",
+      },
+    });
+
+    expect(annotation._tag).toBe("browser");
+    expect(annotationsForSession(sessionId)).toMatchObject([
+      {
+        id: annotation.id,
+        _tag: "browser",
+        comment: "this can be improved",
+        pageUrl: "https://example.com/",
+      },
+    ]);
+  });
+
   it("persists drafts to localStorage", () => {
     useAnnotationsStore.getState().add(sessionId, {
       relPath: "src/app.ts",

--- a/apps/server/src/provider/layers/browser-bridge-service.ts
+++ b/apps/server/src/provider/layers/browser-bridge-service.ts
@@ -1,4 +1,4 @@
-import { Deferred, Effect, Layer, PubSub, Ref, Stream } from "effect";
+import { Deferred, Effect, Layer, Option, PubSub, Ref, Stream } from "effect";
 
 import {
   BrowserCommandNotFoundError,
@@ -9,6 +9,7 @@ import {
 } from "@zuse/wire";
 
 import {
+  type BrowserBridgeDiagnostics,
   BrowserBridgeService,
   type BrowserBridgeServiceShape,
 } from "../services/browser-bridge-service.ts";
@@ -21,17 +22,37 @@ import {
  * turn forever. 30s comfortably covers a real page load + screenshot.
  */
 const COMMAND_TIMEOUT = "30 seconds";
+const COMMAND_QUEUE_CAPACITY = 64;
+const COMMAND_OFFER_TIMEOUT = "100 millis";
 
 let commandCounter = 0;
 const nextCommandId = (): string => `bc_${Date.now()}_${++commandCounter}`;
 
+const emptyDiagnostics: BrowserBridgeDiagnostics = {
+  connectedRendererCount: 0,
+  pendingCommandCount: 0,
+  issuedCommandCount: 0,
+  timeoutCount: 0,
+  overloadCount: 0,
+  disconnectCount: 0,
+  missingResponseCount: 0,
+};
+
 export const BrowserBridgeServiceLive = Layer.scoped(
   BrowserBridgeService,
   Effect.gen(function* () {
-    const pubsub = yield* PubSub.unbounded<BrowserCommandRequest>();
+    const pubsub = yield* PubSub.bounded<BrowserCommandRequest>(
+      COMMAND_QUEUE_CAPACITY,
+    );
     const pending = yield* Ref.make<
       ReadonlyMap<string, Deferred.Deferred<BrowserCommandResult>>
     >(new Map());
+    const diagnostics =
+      yield* Ref.make<BrowserBridgeDiagnostics>(emptyDiagnostics);
+
+    const updateDiagnostics = (
+      f: (current: BrowserBridgeDiagnostics) => BrowserBridgeDiagnostics,
+    ): Effect.Effect<void> => Ref.update(diagnostics, f);
 
     const forget = (id: string): Effect.Effect<void> =>
       Ref.update(pending, (m) => {
@@ -53,24 +74,65 @@ export const BrowserBridgeServiceLive = Layer.scoped(
           next.set(id, deferred);
           return next;
         });
-        yield* PubSub.publish(pubsub, req);
+        yield* updateDiagnostics((current) => ({
+          ...current,
+          pendingCommandCount: current.pendingCommandCount + 1,
+          issuedCommandCount: current.issuedCommandCount + 1,
+        }));
+        const published = yield* PubSub.publish(pubsub, req).pipe(
+          Effect.timeoutOption(COMMAND_OFFER_TIMEOUT),
+        );
+        if (Option.isNone(published) || !published.value) {
+          yield* forget(id);
+          yield* updateDiagnostics((current) => ({
+            ...current,
+            pendingCommandCount: Math.max(0, current.pendingCommandCount - 1),
+            overloadCount: current.overloadCount + 1,
+          }));
+          return BrowserCommandResult.make({
+            id,
+            ok: false,
+            error:
+              "The in-app browser command queue is overloaded. Try again after the current browser action finishes.",
+          });
+        }
         // Await the renderer's reply, but never longer than COMMAND_TIMEOUT.
         // On timeout we synthesize a failure result rather than failing the
         // effect, so the tool reports a clean error to the agent. `ensuring`
         // guarantees the pending entry is cleared on every exit path.
         const result = yield* Deferred.await(deferred).pipe(
-          Effect.timeoutTo({
-            duration: COMMAND_TIMEOUT,
-            onTimeout: () =>
-              BrowserCommandResult.make({
-                id,
-                ok: false,
-                error:
-                  "The in-app browser did not respond. Open the Browser tab in the right pane and try again.",
-              }),
-            onSuccess: (r: BrowserCommandResult) => r,
+          Effect.timeoutOption(COMMAND_TIMEOUT),
+          Effect.flatMap((maybeResult) => {
+            if (Option.isSome(maybeResult)) {
+              return Effect.succeed(maybeResult.value);
+            }
+            return updateDiagnostics((current) => ({
+              ...current,
+              timeoutCount: current.timeoutCount + 1,
+            })).pipe(
+              Effect.as(
+                BrowserCommandResult.make({
+                  id,
+                  ok: false,
+                  error:
+                    "The in-app browser did not respond. Open the Browser tab in the right pane and try again.",
+                }),
+              ),
+            );
           }),
-          Effect.ensuring(forget(id)),
+          Effect.ensuring(
+            forget(id).pipe(
+              Effect.zipRight(
+                updateDiagnostics((current) => ({
+                  ...current,
+                  pendingCommandCount: Math.max(
+                    0,
+                    current.pendingCommandCount - 1,
+                  ),
+                })),
+              ),
+            ),
+          ),
         );
         return result;
       });
@@ -80,6 +142,10 @@ export const BrowserBridgeServiceLive = Layer.scoped(
         const map = yield* Ref.get(pending);
         const deferred = map.get(result.id);
         if (deferred === undefined) {
+          yield* updateDiagnostics((current) => ({
+            ...current,
+            missingResponseCount: current.missingResponseCount + 1,
+          }));
           return yield* Effect.fail(
             new BrowserCommandNotFoundError({ id: result.id }),
           );
@@ -91,10 +157,30 @@ export const BrowserBridgeServiceLive = Layer.scoped(
       Stream.unwrapScoped(
         Effect.gen(function* () {
           const dequeue = yield* pubsub.subscribe;
-          return Stream.fromQueue(dequeue);
+          yield* updateDiagnostics((current) => ({
+            ...current,
+            connectedRendererCount: current.connectedRendererCount + 1,
+          }));
+          return Stream.fromQueue(dequeue).pipe(
+            Stream.ensuring(
+              updateDiagnostics((current) => ({
+                ...current,
+                connectedRendererCount: Math.max(
+                  0,
+                  current.connectedRendererCount - 1,
+                ),
+                disconnectCount: current.disconnectCount + 1,
+              })),
+            ),
+          );
         }),
       );
 
-    return { send, respond, commands } as const;
+    return {
+      send,
+      respond,
+      commands,
+      diagnostics: Ref.get(diagnostics),
+    } as const;
   }),
 );

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -22,7 +22,9 @@ import {
   type AgentEvent,
   AgentSessionNotFoundError,
   type AttachmentRef,
+  type BrowserAnnotation,
   type CodeAnnotation,
+  type ComposerAnnotation,
   type FileRef,
   type FolderId,
   GoalUnsupportedError,
@@ -605,7 +607,12 @@ const textFromMessageContent = (content: MessageContent): string | null => {
  * root, so the relative path resolves when it reads the file. Pure string fn —
  * no I/O.
  */
-const serializeAnnotations = (
+const isBrowserAnnotation = (
+  annotation: ComposerAnnotation,
+): annotation is BrowserAnnotation =>
+  "_tag" in annotation && annotation._tag === "browser";
+
+const serializeCodeAnnotations = (
   annotations: ReadonlyArray<CodeAnnotation>,
 ): string => {
   const lines = annotations.map((a, i) => {
@@ -616,6 +623,43 @@ const serializeAnnotations = (
     return `${i + 1}. ${a.relPath}:${range} — ${a.comment}`;
   });
   return ["Code annotations:", ...lines].join("\n");
+};
+
+const serializeBrowserAnnotations = (
+  annotations: ReadonlyArray<BrowserAnnotation>,
+): string => {
+  const lines = annotations.map((a, i) => {
+    const targetCount = a.elements.length + a.regions.length + a.strokes.length;
+    const firstElement = a.elements[0];
+    const target =
+      firstElement !== undefined
+        ? `<${firstElement.tagName}> ${firstElement.label}`.trim()
+        : `${targetCount} visual ${targetCount === 1 ? "target" : "targets"}`;
+    const title =
+      a.pageTitle !== null && a.pageTitle.trim().length > 0
+        ? ` (${a.pageTitle.trim()})`
+        : "";
+    const screenshot =
+      a.screenshotAttachment !== null ? " Screenshot attached." : "";
+    return `${i + 1}. ${a.pageUrl}${title} — ${target}; ${a.comment}.${screenshot}`;
+  });
+  return ["Browser annotations:", ...lines].join("\n");
+};
+
+const serializeAnnotations = (
+  annotations: ReadonlyArray<ComposerAnnotation>,
+): string => {
+  const code = annotations.filter(
+    (annotation): annotation is CodeAnnotation =>
+      !isBrowserAnnotation(annotation),
+  );
+  const browser = annotations.filter(isBrowserAnnotation);
+  return [
+    code.length > 0 ? serializeCodeAnnotations(code) : "",
+    browser.length > 0 ? serializeBrowserAnnotations(browser) : "",
+  ]
+    .filter((section) => section.length > 0)
+    .join("\n\n");
 };
 
 const formatProviderFailure = (cause: unknown): string => {
@@ -3093,7 +3137,7 @@ export const MessageStoreLive = Layer.scoped(
       attachments?: ReadonlyArray<AttachmentRef>,
       fileRefs?: ReadonlyArray<FileRef>,
       skillRefs?: ReadonlyArray<SkillRef>,
-      annotations?: ReadonlyArray<CodeAnnotation>,
+      annotations?: ReadonlyArray<ComposerAnnotation>,
       asGoal?: boolean,
       clientMessageId?: MessageId,
     ): Effect.Effect<boolean, SessionNotFoundError> =>

--- a/apps/server/src/provider/services/browser-bridge-service.ts
+++ b/apps/server/src/provider/services/browser-bridge-service.ts
@@ -8,6 +8,16 @@ import type {
   SessionId,
 } from "@zuse/wire";
 
+export interface BrowserBridgeDiagnostics {
+  readonly connectedRendererCount: number;
+  readonly pendingCommandCount: number;
+  readonly issuedCommandCount: number;
+  readonly timeoutCount: number;
+  readonly overloadCount: number;
+  readonly disconnectCount: number;
+  readonly missingResponseCount: number;
+}
+
 /**
  * Bridge between the in-process browser MCP tools (which call `send` from
  * inside the Claude SDK tool handler) and the renderer (which subscribes to
@@ -37,6 +47,8 @@ export interface BrowserBridgeServiceShape {
   ) => Effect.Effect<void, BrowserCommandNotFoundError>;
 
   readonly commands: () => Stream.Stream<BrowserCommandRequest>;
+
+  readonly diagnostics: Effect.Effect<BrowserBridgeDiagnostics>;
 }
 
 export class BrowserBridgeService extends Context.Tag(

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -13,7 +13,7 @@ import type {
   ChatId,
   ChatNotFoundError,
   ChatUnarchiveResult,
-  CodeAnnotation,
+  ComposerAnnotation,
   ComposerInput,
   FileRef,
   FolderId,
@@ -299,7 +299,10 @@ export interface MessageStoreShape {
    */
   readonly forkSession: (
     input: ForkSessionInput,
-  ) => Effect.Effect<ForkSessionResult, SessionNotFoundError | SessionStartError>;
+  ) => Effect.Effect<
+    ForkSessionResult,
+    SessionNotFoundError | SessionStartError
+  >;
 
   /**
    * Serialise a session's transcript to Markdown, optionally truncated at
@@ -439,7 +442,7 @@ export interface MessageStoreShape {
     attachments?: ReadonlyArray<AttachmentRef>,
     fileRefs?: ReadonlyArray<FileRef>,
     skillRefs?: ReadonlyArray<SkillRef>,
-    annotations?: ReadonlyArray<CodeAnnotation>,
+    annotations?: ReadonlyArray<ComposerAnnotation>,
     asGoal?: boolean,
     clientMessageId?: MessageId,
   ) => Effect.Effect<void, SessionNotFoundError>;

--- a/apps/server/test/browser-bridge-service.test.ts
+++ b/apps/server/test/browser-bridge-service.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Stream } from "effect";
+
+import { BrowserCommandResult, type SessionId } from "@zuse/wire";
+
+import { BrowserBridgeServiceLive } from "../src/provider/layers/browser-bridge-service.ts";
+import { BrowserBridgeService } from "../src/provider/services/browser-bridge-service.ts";
+
+const TestLayer = BrowserBridgeServiceLive;
+
+describe("BrowserBridgeService", () => {
+  it("tracks connected renderers, pending commands, and completed responses", async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const bridge = yield* BrowserBridgeService;
+          const sessionId = "session-browser-bridge" as SessionId;
+          const events = bridge.commands();
+          yield* Stream.runForEach(events, (request) =>
+            bridge.respond(
+              BrowserCommandResult.make({
+                id: request.id,
+                ok: true,
+                detail: "loaded",
+              }),
+            ),
+          ).pipe(Effect.forkScoped);
+
+          yield* Effect.sleep("10 millis");
+          expect(yield* bridge.diagnostics).toMatchObject({
+            connectedRendererCount: 1,
+            pendingCommandCount: 0,
+          });
+
+          const result = yield* bridge.send(sessionId, {
+            _tag: "Navigate",
+            url: "http://localhost:3000",
+          });
+          expect(result.ok).toBe(true);
+
+          expect(yield* bridge.diagnostics).toMatchObject({
+            connectedRendererCount: 1,
+            pendingCommandCount: 0,
+            issuedCommandCount: 1,
+            timeoutCount: 0,
+            overloadCount: 0,
+          });
+        }),
+      ).pipe(Effect.provide(TestLayer)),
+    );
+  });
+
+  it("counts stale renderer responses without leaking command details", async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const bridge = yield* BrowserBridgeService;
+          const error = yield* bridge
+            .respond(
+              BrowserCommandResult.make({
+                id: "missing-command",
+                ok: false,
+                error: "stale",
+              }),
+            )
+            .pipe(Effect.flip);
+
+          expect(error._tag).toBe("BrowserCommandNotFoundError");
+          expect(yield* bridge.diagnostics).toMatchObject({
+            pendingCommandCount: 0,
+            missingResponseCount: 1,
+          });
+        }),
+      ).pipe(Effect.provide(TestLayer)),
+    );
+  });
+});

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -69,6 +69,7 @@ const TEST_WORKTREE_PATH = "/tmp/project/.memo/pikachu";
 let scriptedEvents: ReadonlyArray<AgentEvent> = [];
 let providerStartInputs: StartSessionInput[] = [];
 let providerStartCursors: Array<string | null> = [];
+let providerSentTexts: string[] = [];
 
 /** A no-op ProviderService: starts/sends succeed; events replay the script. */
 const StubProviderLive = Layer.succeed(ProviderService, {
@@ -81,7 +82,10 @@ const StubProviderLive = Layer.succeed(ProviderService, {
         sessionId: input.sessionId ?? ("stub" as AgentSessionId),
       };
     }),
-  send: () => Effect.void,
+  send: (_sessionId, text) =>
+    Effect.sync(() => {
+      providerSentTexts.push(text);
+    }),
   interrupt: () => Effect.void,
   close: () => Effect.void,
   events: () => Stream.fromIterable(scriptedEvents),
@@ -301,6 +305,7 @@ const store = MessageStore;
 beforeEach(() => {
   providerStartInputs = [];
   providerStartCursors = [];
+  providerSentTexts = [];
 });
 
 describe("MessageStore migrations", () => {
@@ -691,6 +696,126 @@ describe("MessageStore — chat & session lifecycle", () => {
     });
   });
 
+  it("sendMessage stores human annotations and sends them as provider context", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const id = initialSession.id;
+      const annotations = [
+        {
+          id: "ann-human-1",
+          relPath: "src/app.ts",
+          absPath: "/tmp/project/src/app.ts",
+          startLine: 12,
+          endLine: 16,
+          comment: "make this branch easier to follow",
+        },
+      ];
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          s.sendMessage(
+            id,
+            "please handle this",
+            undefined,
+            undefined,
+            undefined,
+            annotations,
+          ),
+        ),
+      );
+
+      const messages = await run(
+        Effect.flatMap(store, (s) => s.listMessages(id)),
+      );
+      const user = messages.filter((m) => m.role === "user").at(-1);
+      expect(user?.content).toMatchObject({
+        _tag: "user_rich",
+        text: "please handle this",
+        annotations,
+      });
+      expect(providerSentTexts.at(-1)).toBe(
+        "Code annotations:\n1. src/app.ts:12-16 — make this branch easier to follow\n\nplease handle this",
+      );
+    });
+  });
+
+  it("sendMessage serializes browser annotations without leaking page text", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const id = initialSession.id;
+      const annotations = [
+        {
+          _tag: "browser" as const,
+          id: "ann-browser-1",
+          comment: "this hero copy can be improved",
+          createdAt: "2026-07-07T00:00:00.000Z",
+          pageUrl: "https://example.com/",
+          pageTitle: "Example Domain",
+          elements: [
+            {
+              tagName: "p",
+              selector: "main > p",
+              label: "p",
+              rect: { x: 10, y: 20, width: 400, height: 80 },
+              textPreview:
+                "RAW PAGE TEXT THAT SHOULD NOT BE SERIALIZED INTO PROMPT",
+            },
+          ],
+          regions: [],
+          strokes: [],
+          screenshotAttachment: {
+            id: "shot-browser-1",
+            mimeType: "image/png",
+            originalName: "browser-annotation.png",
+          },
+        },
+      ];
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          s.sendMessage(
+            id,
+            "",
+            [
+              {
+                id: "shot-browser-1",
+                mimeType: "image/png",
+                originalName: "browser-annotation.png",
+              },
+            ],
+            undefined,
+            undefined,
+            annotations,
+          ),
+        ),
+      );
+
+      const sent = providerSentTexts.at(-1) ?? "";
+      expect(sent).toContain("Browser annotations:");
+      expect(sent).toContain(
+        "1. https://example.com/ (Example Domain) — <p> p; this hero copy can be improved. Screenshot attached.",
+      );
+      expect(sent).not.toContain("RAW PAGE TEXT");
+      expect(sent).not.toContain("image/png;base64");
+    });
+  });
+
   it("reads legacy context compaction rows without status", async () => {
     await withRuntime(async (run) => {
       const { initialSession } = await run(
@@ -812,6 +937,120 @@ describe("MessageStore — chat & session lifecycle", () => {
         "first edited",
       ]);
       expect(remaining.items[0]?.position).toBe(0);
+    });
+  });
+
+  it("queued messages preserve human annotations until they are sent", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const input = new ComposerInput({
+        text: "",
+        attachments: [],
+        fileRefs: [],
+        skillRefs: [],
+        annotations: [
+          {
+            id: "ann-queued-1",
+            relPath: "src/queued.ts",
+            absPath: "/tmp/project/src/queued.ts",
+            startLine: 4,
+            endLine: 4,
+            comment: "queued annotation only",
+          },
+        ],
+      });
+
+      const queued = await run(
+        Effect.flatMap(store, (s) =>
+          s.addQueuedMessage(initialSession.id, input),
+        ),
+      );
+      expect(queued.input.annotations).toEqual(input.annotations);
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          s.sendQueuedMessageNow(initialSession.id, queued.id),
+        ),
+      );
+
+      expect(providerSentTexts.at(-1)).toBe(
+        "Code annotations:\n1. src/queued.ts:4 — queued annotation only",
+      );
+    });
+  });
+
+  it("queued messages preserve browser annotations and screenshot attachments", async () => {
+    await withRuntime(async (run) => {
+      const { initialSession } = await run(
+        Effect.flatMap(store, (s) =>
+          s.createChat({
+            projectId: PROJECT_ID,
+            providerId: "claude",
+            model: "claude-opus-4-8",
+          }),
+        ),
+      );
+      const input = new ComposerInput({
+        text: "apply this visual note",
+        attachments: [
+          {
+            id: "shot-queued-browser",
+            mimeType: "image/png",
+            originalName: "browser-annotation.png",
+          },
+        ],
+        fileRefs: [],
+        skillRefs: [],
+        annotations: [
+          {
+            _tag: "browser",
+            id: "ann-browser-queued",
+            comment: "align this card with the list",
+            createdAt: "2026-07-07T00:00:00.000Z",
+            pageUrl: "http://localhost:3000/",
+            pageTitle: null,
+            elements: [],
+            regions: [
+              {
+                id: "region-queued",
+                rect: { x: 1, y: 2, width: 3, height: 4 },
+              },
+            ],
+            strokes: [],
+            screenshotAttachment: {
+              id: "shot-queued-browser",
+              mimeType: "image/png",
+              originalName: "browser-annotation.png",
+            },
+          },
+        ],
+      });
+
+      const queued = await run(
+        Effect.flatMap(store, (s) =>
+          s.addQueuedMessage(initialSession.id, input),
+        ),
+      );
+      expect(queued.input.annotations).toEqual(input.annotations);
+      expect(queued.input.attachments).toEqual(input.attachments);
+
+      await run(
+        Effect.flatMap(store, (s) =>
+          s.sendQueuedMessageNow(initialSession.id, queued.id),
+        ),
+      );
+
+      expect(providerSentTexts.at(-1)).toContain(
+        "Browser annotations:\n1. http://localhost:3000/ — 1 visual target; align this card with the list. Screenshot attached.\n\napply this visual note",
+      );
     });
   });
 

--- a/packages/wire/src/composer.ts
+++ b/packages/wire/src/composer.ts
@@ -68,6 +68,67 @@ export const CodeAnnotation = Schema.Struct({
 });
 export type CodeAnnotation = typeof CodeAnnotation.Type;
 
+export const BrowserAnnotationRect = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+  width: Schema.Number,
+  height: Schema.Number,
+});
+export type BrowserAnnotationRect = typeof BrowserAnnotationRect.Type;
+
+export const BrowserAnnotationPoint = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+});
+export type BrowserAnnotationPoint = typeof BrowserAnnotationPoint.Type;
+
+export const BrowserAnnotationElement = Schema.Struct({
+  tagName: Schema.String,
+  selector: Schema.NullOr(Schema.String),
+  label: Schema.String,
+  rect: BrowserAnnotationRect,
+  textPreview: Schema.String,
+});
+export type BrowserAnnotationElement = typeof BrowserAnnotationElement.Type;
+
+export const BrowserAnnotationRegion = Schema.Struct({
+  id: Schema.String,
+  rect: BrowserAnnotationRect,
+});
+export type BrowserAnnotationRegion = typeof BrowserAnnotationRegion.Type;
+
+export const BrowserAnnotationStroke = Schema.Struct({
+  id: Schema.String,
+  points: Schema.Array(BrowserAnnotationPoint),
+  bounds: BrowserAnnotationRect,
+});
+export type BrowserAnnotationStroke = typeof BrowserAnnotationStroke.Type;
+
+/**
+ * A visual annotation the user made directly on the Browser preview. The
+ * screenshot travels through the existing attachment path, so the structured
+ * annotation never carries raw image bytes or full page text.
+ */
+export const BrowserAnnotation = Schema.Struct({
+  _tag: Schema.Literal("browser"),
+  id: Schema.String,
+  comment: Schema.String,
+  createdAt: Schema.String,
+  pageUrl: Schema.String,
+  pageTitle: Schema.NullOr(Schema.String),
+  elements: Schema.Array(BrowserAnnotationElement),
+  regions: Schema.Array(BrowserAnnotationRegion),
+  strokes: Schema.Array(BrowserAnnotationStroke),
+  screenshotAttachment: Schema.NullOr(AttachmentRef),
+});
+export type BrowserAnnotation = typeof BrowserAnnotation.Type;
+
+export const ComposerAnnotation = Schema.Union(
+  CodeAnnotation,
+  BrowserAnnotation,
+);
+export type ComposerAnnotation = typeof ComposerAnnotation.Type;
+
 /**
  * The full payload of a single composer submission. `text` is the editor
  * document with `@` / `/` tokens preserved as plain text; the typed arrays
@@ -79,7 +140,7 @@ export class ComposerInput extends Schema.Class<ComposerInput>("ComposerInput")(
     attachments: Schema.Array(AttachmentRef),
     fileRefs: Schema.Array(FileRef),
     skillRefs: Schema.Array(SkillRef),
-    annotations: Schema.optionalWith(Schema.Array(CodeAnnotation), {
+    annotations: Schema.optionalWith(Schema.Array(ComposerAnnotation), {
       default: () => [],
     }),
   },

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -11,7 +11,7 @@ import {
 } from "./agent.ts";
 import {
   AttachmentRef,
-  CodeAnnotation,
+  ComposerAnnotation,
   ComposerInput,
   FileRef,
   SkillRef,
@@ -177,7 +177,7 @@ const UserRichContent = Schema.TaggedStruct("user_rich", {
   skillRefs: Schema.Array(SkillRef),
   // Additive + back-compat: rows persisted before code annotations existed
   // decode with an empty list rather than failing.
-  annotations: Schema.optionalWith(Schema.Array(CodeAnnotation), {
+  annotations: Schema.optionalWith(Schema.Array(ComposerAnnotation), {
     default: () => [],
   }),
   goal: Schema.optional(Schema.Boolean),

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -387,6 +387,80 @@ describe("ComposerInput round-trip", () => {
       ],
     });
   });
+
+  it("round-trips browser annotations", () => {
+    roundTrip(ComposerInput, {
+      text: "",
+      attachments: [
+        {
+          id: "screenshot-1",
+          mimeType: "image/png",
+          originalName: "browser-annotation.png",
+        },
+      ],
+      fileRefs: [],
+      skillRefs: [],
+      annotations: [
+        {
+          _tag: "browser",
+          id: "ann-browser-1",
+          comment: "tighten the hero copy",
+          createdAt: "2026-07-07T00:00:00.000Z",
+          pageUrl: "https://example.com/",
+          pageTitle: "Example Domain",
+          elements: [
+            {
+              tagName: "h1",
+              selector: "h1",
+              label: "h1",
+              rect: { x: 10, y: 20, width: 300, height: 60 },
+              textPreview: "Example Domain",
+            },
+          ],
+          regions: [],
+          strokes: [],
+          screenshotAttachment: {
+            id: "screenshot-1",
+            mimeType: "image/png",
+            originalName: "browser-annotation.png",
+          },
+        },
+      ],
+    });
+  });
+
+  it("round-trips mixed code and browser annotations", () => {
+    roundTrip(ComposerInput, {
+      text: "review these",
+      attachments: [],
+      fileRefs: [],
+      skillRefs: [],
+      annotations: [
+        {
+          id: "ann-code-1",
+          relPath: "src/app.ts",
+          absPath: "/repo/src/app.ts",
+          startLine: 4,
+          endLine: 8,
+          comment: "extract this branch",
+        },
+        {
+          _tag: "browser",
+          id: "ann-browser-1",
+          comment: "make this button clearer",
+          createdAt: "2026-07-07T00:00:00.000Z",
+          pageUrl: "http://localhost:3000/",
+          pageTitle: null,
+          elements: [],
+          regions: [
+            { id: "region-1", rect: { x: 1, y: 2, width: 3, height: 4 } },
+          ],
+          strokes: [],
+          screenshotAttachment: null,
+        },
+      ],
+    });
+  });
 });
 
 describe("SettingsFile round-trip", () => {


### PR DESCRIPTION
## Summary
- add human-authored browser visual annotations with select, region, draw, and erase overlay tools
- attach browser annotations to composer drafts with screenshot attachments and compact annotation tray rows
- serialize browser annotations into provider prompt context without raw page text, DOM HTML, or screenshot data
- add local server empty state rows and safe browser bridge diagnostics

## Validation
- bun run check-types
- bun test packages/wire/test/schema.test.ts apps/renderer/test/annotations-store.test.ts apps/server/test/message-store.test.ts apps/server/test/browser-bridge-service.test.ts
- git diff --check
