### PR TITLE
[codex] Fix provider update state bleed

### DIFF
--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -13,6 +13,7 @@ import { ProviderIcon } from "~/components/provider-icons";
 import { PROVIDER_LABEL } from "~/components/settings-page";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { isInitialProviderAvailabilityLoading } from "~/lib/provider-status";
 import { cn } from "~/lib/utils";
 import { useProvidersStore } from "../../../store/providers.ts";
 import { useSettingsStore } from "../../../store/settings.ts";
@@ -123,6 +124,7 @@ export function ProviderStep() {
   const setDefaultProvider = useSettingsStore((s) => s.setDefaultProvider);
   const availability = useProvidersStore((s) => s.availability);
   const loading = useProvidersStore((s) => s.loading);
+  const availabilityLoaded = useProvidersStore((s) => s.availabilityLoaded);
 
   const providers: ReadonlyArray<ProviderId> = [
     "claude",
@@ -133,7 +135,15 @@ export function ProviderStep() {
     "opencode",
   ];
 
-  const selectedState = deriveState(defaultProviderId, availability, loading);
+  const initialLoading = isInitialProviderAvailabilityLoading(
+    loading,
+    availabilityLoaded,
+  );
+  const selectedState = deriveState(
+    defaultProviderId,
+    availability,
+    initialLoading,
+  );
 
   return (
     <div className="flex flex-col gap-4">
@@ -150,7 +160,7 @@ export function ProviderStep() {
           <ProviderCard
             key={pid}
             providerId={pid}
-            state={deriveState(pid, availability, loading)}
+            state={deriveState(pid, availability, initialLoading)}
             active={pid === defaultProviderId}
             onClick={() => setDefaultProvider(pid)}
           />

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -26,7 +26,10 @@ import { Button } from "~/components/ui/button";
 import { ShimmerText } from "~/components/ui/shimmer-text";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { getRpcClient } from "~/lib/rpc-client";
-import { useProvidersStore } from "~/store/providers";
+import {
+  IDLE_PROVIDER_UPDATE_STATE,
+  useProvidersStore,
+} from "~/store/providers";
 import {
   Select,
   SelectItem,
@@ -580,12 +583,6 @@ function ProviderSignInRow({ providerId }: { providerId: ProviderId }) {
   );
 }
 
-type UpdateState =
-  | { readonly kind: "idle" }
-  | { readonly kind: "running"; readonly line: string | null }
-  | { readonly kind: "success" }
-  | { readonly kind: "failed"; readonly reason: string };
-
 /**
  * Subscribe to `agent.updateProvider`, which spawns the provider's update
  * command server-side and streams its output. On the terminal `done` event we
@@ -594,7 +591,12 @@ type UpdateState =
  */
 function useProviderUpdate(providerId: ProviderId) {
   const refresh = useProvidersStore((s) => s.refresh);
-  const [state, setState] = useState<UpdateState>({ kind: "idle" });
+  const state = useProvidersStore(
+    (s) => s.updateStateByProvider[providerId] ?? IDLE_PROVIDER_UPDATE_STATE,
+  );
+  const setProviderUpdateState = useProvidersStore(
+    (s) => s.setProviderUpdateState,
+  );
   const fiberRef = useRef<Fiber.RuntimeFiber<unknown, unknown> | null>(null);
   const resetTimerRef = useRef<number | null>(null);
 
@@ -602,10 +604,11 @@ function useProviderUpdate(providerId: ProviderId) {
     () => () => {
       const fiber = fiberRef.current;
       if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
+      setProviderUpdateState(providerId, IDLE_PROVIDER_UPDATE_STATE);
       if (resetTimerRef.current !== null)
         window.clearTimeout(resetTimerRef.current);
     },
-    [],
+    [providerId, setProviderUpdateState],
   );
 
   const run = async () => {
@@ -614,15 +617,27 @@ function useProviderUpdate(providerId: ProviderId) {
       window.clearTimeout(resetTimerRef.current);
       resetTimerRef.current = null;
     }
-    setState({ kind: "running", line: null });
-    const client = await getRpcClient();
+    setProviderUpdateState(providerId, { kind: "running", line: null });
+    let client: Awaited<ReturnType<typeof getRpcClient>>;
+    try {
+      client = await getRpcClient();
+    } catch (err) {
+      setProviderUpdateState(providerId, {
+        kind: "failed",
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
     const fiber = Effect.runFork(
       Stream.runForEach(
         client.agent.updateProvider({ providerId }),
         (event: ProviderUpdateEvent) =>
           Effect.sync(() => {
             if (event._tag === "log") {
-              setState({ kind: "running", line: event.text });
+              setProviderUpdateState(providerId, {
+                kind: "running",
+                line: event.text,
+              });
             } else if (event._tag === "done") {
               fiberRef.current = null;
               if (event.ok) {
@@ -631,17 +646,20 @@ function useProviderUpdate(providerId: ProviderId) {
                 // version show together for a beat. Stay on the spinner until
                 // the probe lands.
                 void refresh().finally(() => {
-                  setState({ kind: "success" });
+                  setProviderUpdateState(providerId, { kind: "success" });
                   // Re-probe hides the icon if now on latest; for
                   // version-unknown CLIs (Grok) drop the "Updated" badge after
                   // a moment so the control returns to idle.
                   resetTimerRef.current = window.setTimeout(() => {
-                    setState({ kind: "idle" });
+                    setProviderUpdateState(
+                      providerId,
+                      IDLE_PROVIDER_UPDATE_STATE,
+                    );
                     resetTimerRef.current = null;
                   }, 4_000);
                 });
               } else {
-                setState({
+                setProviderUpdateState(providerId, {
                   kind: "failed",
                   reason: event.reason ?? "Update failed.",
                 });
@@ -652,7 +670,7 @@ function useProviderUpdate(providerId: ProviderId) {
         Effect.catchAll((err) =>
           Effect.sync(() => {
             fiberRef.current = null;
-            setState({
+            setProviderUpdateState(providerId, {
               kind: "failed",
               reason: err instanceof Error ? err.message : String(err),
             });

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -40,6 +40,7 @@ import {
   formatRelativeTime,
   useRelativeTimeTick,
 } from "~/lib/use-relative-time.ts";
+import { isInitialProviderAvailabilityLoading } from "~/lib/provider-status";
 import { cn } from "~/lib/utils";
 import {
   collectDiagnosticsClientContext,
@@ -1223,6 +1224,7 @@ function GeneralPane() {
 function ProvidersPane() {
   const availability = useProvidersStore((s) => s.availability);
   const loading = useProvidersStore((s) => s.loading);
+  const availabilityLoaded = useProvidersStore((s) => s.availabilityLoaded);
   const error = useProvidersStore((s) => s.error);
   const refresh = useProvidersStore((s) => s.refresh);
   const defaultProviderId = useSettingsStore((s) => s.defaultProviderId);
@@ -1338,7 +1340,10 @@ function ProvidersPane() {
             <ProviderCard
               providerId={selectedProvider}
               availability={availabilityById.get(selectedProvider)}
-              loading={loading}
+              loading={isInitialProviderAvailabilityLoading(
+                loading,
+                availabilityLoaded,
+              )}
             />
           </Card>
         </div>

--- a/apps/renderer/src/lib/provider-status.ts
+++ b/apps/renderer/src/lib/provider-status.ts
@@ -33,6 +33,13 @@ export interface ProviderSummary {
   readonly actionable: boolean;
 }
 
+export function isInitialProviderAvailabilityLoading(
+  loading: boolean,
+  availabilityLoaded: boolean,
+): boolean {
+  return loading && !availabilityLoaded;
+}
+
 const PROVIDER_DISPLAY: Record<ProviderId, string> = {
   claude: "Claude Code",
   codex: "Codex",

--- a/apps/renderer/src/store/providers.ts
+++ b/apps/renderer/src/store/providers.ts
@@ -11,6 +11,16 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 // subscribers on every unrelated store update).
 const EMPTY_CAPABILITIES: ReadonlyArray<string> = [];
 
+export type ProviderUpdateState =
+  | { readonly kind: "idle" }
+  | { readonly kind: "running"; readonly line: string | null }
+  | { readonly kind: "success" }
+  | { readonly kind: "failed"; readonly reason: string };
+
+export const IDLE_PROVIDER_UPDATE_STATE: ProviderUpdateState = {
+  kind: "idle",
+};
+
 /**
  * Renderer-side cache of provider availability + the credentials sheet
  * controller. Replaces the per-session state that used to live in
@@ -19,10 +29,18 @@ const EMPTY_CAPABILITIES: ReadonlyArray<string> = [];
 type ProvidersState = {
   readonly availability: ReadonlyArray<AgentAvailability>;
   readonly loading: boolean;
+  readonly availabilityLoaded: boolean;
   readonly error: string | null;
   readonly credentialsOpen: boolean;
+  readonly updateStateByProvider: Partial<
+    Record<ProviderId, ProviderUpdateState>
+  >;
   readonly refresh: () => Promise<void>;
   readonly setCredentialsOpen: (open: boolean) => void;
+  readonly setProviderUpdateState: (
+    providerId: ProviderId,
+    state: ProviderUpdateState,
+  ) => void;
   /**
    * Version-gated features the installed CLI supports for `providerId` (the
    * `capabilities` list from the availability probe). `[]` when the provider
@@ -39,19 +57,28 @@ type ProvidersState = {
 export const useProvidersStore = create<ProvidersState>((set, get) => ({
   availability: [],
   loading: false,
+  availabilityLoaded: false,
   error: null,
   credentialsOpen: false,
+  updateStateByProvider: {},
   refresh: async () => {
     set({ loading: true, error: null });
     try {
       const client = await getRpcClient();
       const list = await Effect.runPromise(client.agent.availability({}));
-      set({ availability: list, loading: false });
+      set({ availability: list, loading: false, availabilityLoaded: true });
     } catch (err) {
       set({ error: formatError(err), loading: false });
     }
   },
   setCredentialsOpen: (open) => set({ credentialsOpen: open }),
+  setProviderUpdateState: (providerId, state) =>
+    set((current) => ({
+      updateStateByProvider: {
+        ...current.updateStateByProvider,
+        [providerId]: state,
+      },
+    })),
   capabilitiesFor: (providerId) =>
     get().availability.find((a) => a.providerId === providerId)?.capabilities ??
     EMPTY_CAPABILITIES,

--- a/apps/renderer/test/provider-status.test.ts
+++ b/apps/renderer/test/provider-status.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import type { AgentAvailability, ProviderId } from "@zuse/wire";
+
+import {
+  getProviderSummary,
+  isInitialProviderAvailabilityLoading,
+} from "../src/lib/provider-status.ts";
+import {
+  IDLE_PROVIDER_UPDATE_STATE,
+  useProvidersStore,
+} from "../src/store/providers.ts";
+
+const providers: ReadonlyArray<ProviderId> = [
+  "claude",
+  "codex",
+  "grok",
+  "gemini",
+  "cursor",
+  "opencode",
+];
+
+const availabilityFor = (
+  providerId: ProviderId,
+  displayName: string,
+): AgentAvailability => ({
+  providerId,
+  displayName,
+  cliInstalled: true,
+  cliLoggedIn: true,
+  hasApiKey: false,
+  authStatus: "authenticated",
+});
+
+describe("provider update state", () => {
+  beforeEach(() => {
+    useProvidersStore.setState({
+      availability: [],
+      loading: false,
+      availabilityLoaded: false,
+      error: null,
+      updateStateByProvider: {},
+    });
+  });
+
+  it("tracks one-click updates by provider", () => {
+    useProvidersStore
+      .getState()
+      .setProviderUpdateState("claude", {
+        kind: "running",
+        line: "installing Claude",
+      });
+
+    const state = useProvidersStore.getState();
+    expect(state.updateStateByProvider.claude).toEqual({
+      kind: "running",
+      line: "installing Claude",
+    });
+    for (const providerId of providers.filter((p) => p !== "claude")) {
+      expect(
+        state.updateStateByProvider[providerId] ??
+          IDLE_PROVIDER_UPDATE_STATE,
+      ).toEqual(IDLE_PROVIDER_UPDATE_STATE);
+    }
+  });
+});
+
+describe("provider availability loading", () => {
+  it("only treats global loading as card loading before availability has loaded", () => {
+    expect(isInitialProviderAvailabilityLoading(true, false)).toBe(true);
+    expect(isInitialProviderAvailabilityLoading(true, true)).toBe(false);
+    expect(isInitialProviderAvailabilityLoading(false, false)).toBe(false);
+  });
+
+  it("keeps other providers on their availability state during a post-update refresh", () => {
+    const codex = availabilityFor("codex", "Codex");
+    const summary = getProviderSummary(
+      codex,
+      true,
+      isInitialProviderAvailabilityLoading(true, true),
+    );
+
+    expect(summary.statusKey).toBe("ready");
+    expect(summary.headline).toBe("Authenticated");
+  });
+
+  it("still shows checking for missing provider rows during initial load", () => {
+    const summary = getProviderSummary(
+      undefined,
+      true,
+      isInitialProviderAvailabilityLoading(true, false),
+    );
+
+    expect(summary.statusKey).toBe("loading");
+    expect(summary.headline).toBe("Checking…");
+  });
+});


### PR DESCRIPTION
## Summary
- track one-click provider update progress per provider instead of local/global loading state
- keep global provider availability loading scoped to first-load card states
- add renderer tests for provider-specific update state and initial availability loading

## Root Cause
The provider settings UI reused the global provider availability `loading` flag for card status. After updating one provider, the follow-up availability refresh could make unrelated provider rows look like they were also updating/checking.

## Validation
- `cd apps/renderer && bun test test/provider-status.test.ts`
- `cd apps/renderer && bun run check-types`
- `cd apps/renderer && bun run test`
