### PR TITLE
Refine mobile composer controls

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -78,6 +78,14 @@ export default function RootLayout() {
           }}
         />
         <Stack.Screen
+          name="plan-viewer"
+          options={{
+            title: "Plan",
+            presentation: "modal",
+            headerLargeTitle: false,
+          }}
+        />
+        <Stack.Screen
           name="connect/manual"
           options={{
             title: "Add connection",

--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -274,6 +274,13 @@ export default function ThreadScreen() {
           session={detail?.session ?? null}
           status={sessionStatus}
           fresh={fresh}
+          projectLabel={detail?.project.name}
+          sourceLabel={
+            detail?.session.worktreeId === null ||
+            detail?.session.worktreeId === undefined
+              ? "Main"
+              : "Branch"
+          }
           bottomInset={insets.bottom}
         />
       )}

--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -170,10 +170,12 @@ export default function ThreadScreen() {
       answeredQuestionIds,
       questionsByItemId,
       toolResultsByItemId,
+      planMode: detail?.session.permissionMode === "plan",
       onAnswerQuestion,
     }),
     [
       answeredQuestionIds,
+      detail?.session.permissionMode,
       onAnswerQuestion,
       questionsByItemId,
       toolResultsByItemId,

--- a/apps/mobile/app/new-chat.tsx
+++ b/apps/mobile/app/new-chat.tsx
@@ -6,7 +6,7 @@ import type {
 } from "@zuse/wire";
 import { Effect } from "effect";
 import { router, Stack } from "expo-router";
-import { CloudOff, Send } from "lucide-react-native";
+import { CloudOff, Folder as FolderIcon, GitBranch, Send } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
@@ -38,6 +38,8 @@ import { useSessionsStore } from "~/store/sessions";
 import { Button } from "~/components/ui/button";
 import { GlassSurface } from "~/components/ui/glass-surface";
 import {
+  ComposerApprovalMenu,
+  ComposerModeMenu,
   ComposerModelMenu,
   NativeButton,
   ProjectPill,
@@ -243,21 +245,13 @@ export default function NewChatScreen() {
       >
         <GlassSurface
           style={{
-            flexDirection: "row",
-            alignItems: "flex-end",
             gap: 8,
-            padding: 8,
+            padding: 10,
           }}
         >
-          <View className="min-w-0 flex-1 gap-2">
-            <View className="flex-row flex-wrap items-center gap-2">
-              <Button
-                size="sm"
-                variant="secondary"
-                className="h-10 w-10 rounded-full px-0"
-              >
-                <Text className="font-sans text-[26px] leading-7 text-foreground">+</Text>
-              </Button>
+          <View className="flex-row items-center gap-2 px-1">
+            <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated px-2.5 py-1.5">
+              <FolderIcon size={13} color="hsl(72 4% 76%)" />
               <ProjectPill
                 label={
                   selectedProject === undefined
@@ -273,6 +267,9 @@ export default function NewChatScreen() {
                   setSource(MAIN_SOURCE);
                 }}
               />
+            </View>
+            <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated px-2.5 py-1.5">
+              <GitBranch size={13} color="hsl(72 4% 76%)" />
               <SourcePill label={sourceLabel}>
                 <NativeButton
                   label="Main"
@@ -348,36 +345,45 @@ export default function NewChatScreen() {
                 ))}
               </SourcePill>
             </View>
-            <TextInput
-              className="min-h-10 px-2 py-2 font-sans text-[17px] text-foreground"
-              multiline
-              placeholder="Ask Zuse"
-              placeholderTextColor="hsl(72 4% 56%)"
-              value={text}
-              onChangeText={setText}
-            />
-            <View className="flex-row items-center justify-between">
-              <View className="h-10 w-10" />
+          </View>
+          <TextInput
+            className="max-h-36 min-h-12 px-1 py-2 font-sans text-[17px] leading-6 text-foreground"
+            multiline
+            placeholder="Ask Zuse"
+            placeholderTextColor="hsl(72 4% 56%)"
+            value={text}
+            onChangeText={setText}
+          />
+          <View className="flex-row items-center gap-2">
+            <ComposerModeMenu value={modelMode} editable onChange={setModelMode} />
+            <View className="min-w-0 flex-1 items-center">
               <ComposerModelMenu
                 value={modelMode}
                 editable
                 onChange={setModelMode}
               />
             </View>
+            <ComposerApprovalMenu
+              value={modelMode}
+              editable
+              onChange={setModelMode}
+            />
+            <Button
+              size="sm"
+              variant="primary"
+              className="h-10 w-10 rounded-full px-0"
+              disabled={!canSubmit}
+              onPress={() => void submit()}
+            >
+              {submitting ? (
+                <ActivityIndicator color="hsl(72 5% 6%)" />
+              ) : selectedOptions === null ? (
+                <CloudOff size={15} color="hsl(72 5% 6%)" />
+              ) : (
+                <Send size={15} color="hsl(72 5% 6%)" />
+              )}
+            </Button>
           </View>
-          <Button
-            variant="primary"
-            disabled={!canSubmit}
-            onPress={() => void submit()}
-          >
-            {submitting ? (
-              <ActivityIndicator color="hsl(72 5% 6%)" />
-            ) : selectedOptions === null ? (
-              <CloudOff size={16} color="hsl(72 5% 6%)" />
-            ) : (
-              <Send size={16} color="hsl(72 5% 6%)" />
-            )}
-          </Button>
         </GlassSurface>
       </View>
     </KeyboardAvoidingView>

--- a/apps/mobile/app/new-chat.tsx
+++ b/apps/mobile/app/new-chat.tsx
@@ -4,9 +4,14 @@ import type {
   GitPrSummary,
   Worktree,
 } from "@zuse/wire";
+import {
+  CloudOffIcon,
+  Folder01Icon,
+  GitBranchIcon,
+  SentIcon,
+} from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
 import { router, Stack } from "expo-router";
-import { CloudOff, Folder as FolderIcon, GitBranch, Send } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
@@ -37,6 +42,7 @@ import { useConnectionsStore } from "~/store/connections";
 import { useSessionsStore } from "~/store/sessions";
 import { Button } from "~/components/ui/button";
 import { GlassSurface } from "~/components/ui/glass-surface";
+import { HugeIcon } from "~/components/ui/huge-icon";
 import {
   ComposerApprovalMenu,
   ComposerModeMenu,
@@ -251,7 +257,7 @@ export default function NewChatScreen() {
         >
           <View className="flex-row items-center gap-2 px-1">
             <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated px-2.5 py-1.5">
-              <FolderIcon size={13} color="hsl(72 4% 76%)" />
+              <HugeIcon icon={Folder01Icon} size={13} color="hsl(72 4% 76%)" />
               <ProjectPill
                 label={
                   selectedProject === undefined
@@ -269,7 +275,7 @@ export default function NewChatScreen() {
               />
             </View>
             <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated px-2.5 py-1.5">
-              <GitBranch size={13} color="hsl(72 4% 76%)" />
+              <HugeIcon icon={GitBranchIcon} size={13} color="hsl(72 4% 76%)" />
               <SourcePill label={sourceLabel}>
                 <NativeButton
                   label="Main"
@@ -378,9 +384,9 @@ export default function NewChatScreen() {
               {submitting ? (
                 <ActivityIndicator color="hsl(72 5% 6%)" />
               ) : selectedOptions === null ? (
-                <CloudOff size={15} color="hsl(72 5% 6%)" />
+                <HugeIcon icon={CloudOffIcon} size={15} color="hsl(72 5% 6%)" />
               ) : (
-                <Send size={15} color="hsl(72 5% 6%)" />
+                <HugeIcon icon={SentIcon} size={15} color="hsl(72 5% 6%)" />
               )}
             </Button>
           </View>

--- a/apps/mobile/app/new-chat.tsx
+++ b/apps/mobile/app/new-chat.tsx
@@ -1,14 +1,10 @@
-import type {
-  Folder,
-  GitBranchInfo,
-  GitPrSummary,
-  Worktree,
-} from "@zuse/wire";
+import type { Folder, GitBranchInfo, GitPrSummary, Worktree } from "@zuse/wire";
 import {
+  ArrowUp01Icon,
   CloudOffIcon,
+  CancelCircleIcon,
   Folder01Icon,
   GitBranchIcon,
-  SentIcon,
 } from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
 import { router, Stack } from "expo-router";
@@ -16,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
+  Pressable,
   ScrollView,
   Text,
   TextInput,
@@ -37,6 +34,7 @@ import {
 } from "~/lib/new-chat";
 import {
   defaultModelForProvider,
+  reasoningDescriptorForModel,
 } from "~/lib/model-options";
 import { useConnectionsStore } from "~/store/connections";
 import { useSessionsStore } from "~/store/sessions";
@@ -44,9 +42,8 @@ import { Button } from "~/components/ui/button";
 import { GlassSurface } from "~/components/ui/glass-surface";
 import { HugeIcon } from "~/components/ui/huge-icon";
 import {
-  ComposerApprovalMenu,
-  ComposerModeMenu,
   ComposerModelMenu,
+  ComposerSettingsMenu,
   NativeButton,
   ProjectPill,
   SourcePill,
@@ -58,14 +55,20 @@ export default function NewChatScreen() {
   const [text, setText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedConnectionKey, setSelectedConnectionKey] = useState<string | null>(null);
-  const [selectedProjectId, setSelectedProjectId] = useState<Folder["id"] | null>(null);
+  const [selectedConnectionKey, setSelectedConnectionKey] = useState<
+    string | null
+  >(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<
+    Folder["id"] | null
+  >(null);
   const [source, setSource] = useState<NewChatSource>(MAIN_SOURCE);
+  const initialModel = defaultModelForProvider("codex");
   const [modelMode, setModelMode] = useState<ModelModeValue>({
     providerId: "codex",
-    model: defaultModelForProvider("codex"),
+    model: initialModel,
     runtimeMode: "approval-required",
     permissionMode: "default",
+    modelOptions: defaultModelOptions("codex", initialModel),
   });
   const [worktrees, setWorktrees] = useState<readonly Worktree[]>([]);
   const [branches, setBranches] = useState<readonly GitBranchInfo[]>([]);
@@ -99,10 +102,12 @@ export default function NewChatScreen() {
 
   const projectChoices = useMemo(() => {
     if (effectiveConnectionKey === null) return [];
-    return (bundlesByConnection[effectiveConnectionKey] ?? []).map((bundle) => ({
-      project: bundle.project,
-      connectionKey: effectiveConnectionKey,
-    }));
+    return (bundlesByConnection[effectiveConnectionKey] ?? []).map(
+      (bundle) => ({
+        project: bundle.project,
+        connectionKey: effectiveConnectionKey,
+      }),
+    );
   }, [bundlesByConnection, effectiveConnectionKey]);
 
   const projectMenuGroups = useMemo(
@@ -138,13 +143,22 @@ export default function NewChatScreen() {
     let cancelled = false;
     void Promise.all([
       Effect.runPromise(
-        listWorktrees({ connection: selectedOptions, projectId: effectiveProjectId }),
+        listWorktrees({
+          connection: selectedOptions,
+          projectId: effectiveProjectId,
+        }),
       ).catch(() => [] as readonly Worktree[]),
       Effect.runPromise(
-        listBranches({ connection: selectedOptions, projectId: effectiveProjectId }),
+        listBranches({
+          connection: selectedOptions,
+          projectId: effectiveProjectId,
+        }),
       ),
       Effect.runPromise(
-        listPullRequests({ connection: selectedOptions, projectId: effectiveProjectId }),
+        listPullRequests({
+          connection: selectedOptions,
+          projectId: effectiveProjectId,
+        }),
       ),
     ]).then(([nextWorktrees, nextBranches, nextPrs]) => {
       if (cancelled) return;
@@ -177,10 +191,15 @@ export default function NewChatScreen() {
       model: modelMode.model,
       runtimeMode: modelMode.runtimeMode,
       permissionMode: modelMode.permissionMode,
+      modelOptions: modelMode.modelOptions,
       source,
       text,
     });
-    if (payload === null || effectiveConnectionKey === null || selectedOptions === null) {
+    if (
+      payload === null ||
+      effectiveConnectionKey === null ||
+      selectedOptions === null
+    ) {
       return;
     }
     setSubmitting(true);
@@ -205,6 +224,7 @@ export default function NewChatScreen() {
         initialPrompt: payload.initialPrompt,
         runtimeMode: payload.runtimeMode,
         permissionMode: payload.permissionMode,
+        modelOptions: payload.modelOptions,
         worktreeId,
       });
       router.replace(
@@ -234,124 +254,143 @@ export default function NewChatScreen() {
         className="flex-1"
         contentInsetAdjustmentBehavior="automatic"
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ padding: 18, paddingBottom: 180, gap: 18, flexGrow: 1 }}
+        contentContainerStyle={{
+          padding: 18,
+          paddingBottom: 180,
+          gap: 18,
+          flexGrow: 1,
+        }}
       >
         <View className="flex-1" />
 
         {error === null ? null : (
-          <Text selectable className="font-sans text-[13px] leading-5 text-danger">
+          <Text
+            selectable
+            className="font-sans text-[13px] leading-5 text-danger"
+          >
             {error}
           </Text>
         )}
       </ScrollView>
 
       <View
-        className="border-t border-border px-3 pt-3"
+        className="px-3 pt-2"
         style={{ paddingBottom: insets.bottom > 0 ? insets.bottom : 12 }}
       >
+        <View className="mb-2 flex-row items-center gap-2 px-1">
+          <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated/70 px-2.5 py-1.5">
+            <HugeIcon icon={Folder01Icon} size={13} color="hsl(72 4% 76%)" />
+            <ProjectPill
+              label={
+                selectedProject === undefined
+                  ? loading
+                    ? "Loading projects"
+                    : "Project"
+                  : selectedProject.name
+              }
+              options={projectMenuGroups}
+              onSelect={(connectionKey, projectId) => {
+                setSelectedConnectionKey(connectionKey);
+                setSelectedProjectId(projectId as Folder["id"]);
+                setSource(MAIN_SOURCE);
+              }}
+            />
+          </View>
+          <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated/70 px-2.5 py-1.5">
+            <HugeIcon icon={GitBranchIcon} size={13} color="hsl(72 4% 76%)" />
+            <SourcePill label={sourceLabel}>
+              <NativeButton
+                label="Main"
+                systemImage={source.kind === "main" ? "checkmark" : "folder"}
+                onPress={() => setSource(MAIN_SOURCE)}
+              />
+              {worktrees.slice(0, 8).map((worktree) => (
+                <NativeButton
+                  key={worktree.id}
+                  label={worktree.branch}
+                  systemImage={
+                    source.kind === "worktree" &&
+                    source.worktreeId === worktree.id
+                      ? "checkmark"
+                      : "point.topleft.down.curvedto.point.bottomright.up"
+                  }
+                  onPress={() =>
+                    setSource({
+                      kind: "worktree",
+                      label: worktree.branch,
+                      worktreeId: worktree.id,
+                    })
+                  }
+                />
+              ))}
+              {branches
+                .filter((branch) => !branch.current)
+                .slice(0, 8)
+                .map((branch) => (
+                  <NativeButton
+                    key={`${branch.kind}:${branch.name}`}
+                    label={branch.name}
+                    systemImage={
+                      source.kind === "branch" && source.label === branch.name
+                        ? "checkmark"
+                        : "arrow.branch"
+                    }
+                    onPress={() =>
+                      setSource({
+                        kind: "branch",
+                        label: branch.name,
+                        worktreeId: null,
+                        createSource: {
+                          _tag: "branch",
+                          branch: branch.name,
+                          remote: branch.remote,
+                        },
+                      })
+                    }
+                  />
+                ))}
+              {prs.slice(0, 8).map((pr) => (
+                <NativeButton
+                  key={`pr:${pr.number}`}
+                  label={`#${pr.number} ${pr.title}`}
+                  systemImage={
+                    source.kind === "pr" && source.label === `#${pr.number}`
+                      ? "checkmark"
+                      : "arrow.triangle.pull"
+                  }
+                  onPress={() =>
+                    setSource({
+                      kind: "pr",
+                      label: `#${pr.number}`,
+                      worktreeId: null,
+                      createSource: {
+                        _tag: "pr",
+                        number: pr.number,
+                        headRefName: pr.headRefName,
+                      },
+                    })
+                  }
+                />
+              ))}
+            </SourcePill>
+          </View>
+        </View>
         <GlassSurface
           style={{
             gap: 8,
             padding: 10,
           }}
         >
-          <View className="flex-row items-center gap-2 px-1">
-            <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated px-2.5 py-1.5">
-              <HugeIcon icon={Folder01Icon} size={13} color="hsl(72 4% 76%)" />
-              <ProjectPill
-                label={
-                  selectedProject === undefined
-                    ? loading
-                      ? "Loading projects"
-                      : "Project"
-                    : selectedProject.name
-                }
-                options={projectMenuGroups}
-                onSelect={(connectionKey, projectId) => {
-                  setSelectedConnectionKey(connectionKey);
-                  setSelectedProjectId(projectId as Folder["id"]);
-                  setSource(MAIN_SOURCE);
-                }}
-              />
-            </View>
-            <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated px-2.5 py-1.5">
-              <HugeIcon icon={GitBranchIcon} size={13} color="hsl(72 4% 76%)" />
-              <SourcePill label={sourceLabel}>
-                <NativeButton
-                  label="Main"
-                  systemImage={source.kind === "main" ? "checkmark" : "folder"}
-                  onPress={() => setSource(MAIN_SOURCE)}
-                />
-                {worktrees.slice(0, 8).map((worktree) => (
-                  <NativeButton
-                    key={worktree.id}
-                    label={worktree.branch}
-                    systemImage={
-                      source.kind === "worktree" && source.worktreeId === worktree.id
-                        ? "checkmark"
-                        : "point.topleft.down.curvedto.point.bottomright.up"
-                    }
-                    onPress={() =>
-                      setSource({
-                        kind: "worktree",
-                        label: worktree.branch,
-                        worktreeId: worktree.id,
-                      })
-                    }
-                  />
-                ))}
-                {branches
-                  .filter((branch) => !branch.current)
-                  .slice(0, 8)
-                  .map((branch) => (
-                    <NativeButton
-                      key={`${branch.kind}:${branch.name}`}
-                      label={branch.name}
-                      systemImage={
-                        source.kind === "branch" && source.label === branch.name
-                          ? "checkmark"
-                          : "arrow.branch"
-                      }
-                      onPress={() =>
-                        setSource({
-                          kind: "branch",
-                          label: branch.name,
-                          worktreeId: null,
-                          createSource: {
-                            _tag: "branch",
-                            branch: branch.name,
-                            remote: branch.remote,
-                          },
-                        })
-                      }
-                    />
-                  ))}
-                {prs.slice(0, 8).map((pr) => (
-                  <NativeButton
-                    key={`pr:${pr.number}`}
-                    label={`#${pr.number} ${pr.title}`}
-                    systemImage={
-                      source.kind === "pr" && source.label === `#${pr.number}`
-                        ? "checkmark"
-                        : "arrow.triangle.pull"
-                    }
-                    onPress={() =>
-                      setSource({
-                        kind: "pr",
-                        label: `#${pr.number}`,
-                        worktreeId: null,
-                        createSource: {
-                          _tag: "pr",
-                          number: pr.number,
-                          headRefName: pr.headRefName,
-                        },
-                      })
-                    }
-                  />
-                ))}
-              </SourcePill>
-            </View>
-          </View>
+          {modelMode.permissionMode === "plan" ? (
+            <PlanPill
+              onClear={() =>
+                setModelMode((value) => ({
+                  ...value,
+                  permissionMode: "default",
+                }))
+              }
+            />
+          ) : null}
           <TextInput
             className="max-h-36 min-h-12 px-1 py-2 font-sans text-[17px] leading-6 text-foreground"
             multiline
@@ -361,7 +400,11 @@ export default function NewChatScreen() {
             onChangeText={setText}
           />
           <View className="flex-row items-center gap-2">
-            <ComposerModeMenu value={modelMode} editable onChange={setModelMode} />
+            <ComposerSettingsMenu
+              value={modelMode}
+              editable
+              onChange={setModelMode}
+            />
             <View className="min-w-0 flex-1 items-center">
               <ComposerModelMenu
                 value={modelMode}
@@ -369,11 +412,6 @@ export default function NewChatScreen() {
                 onChange={setModelMode}
               />
             </View>
-            <ComposerApprovalMenu
-              value={modelMode}
-              editable
-              onChange={setModelMode}
-            />
             <Button
               size="sm"
               variant="primary"
@@ -386,7 +424,11 @@ export default function NewChatScreen() {
               ) : selectedOptions === null ? (
                 <HugeIcon icon={CloudOffIcon} size={15} color="hsl(72 5% 6%)" />
               ) : (
-                <HugeIcon icon={SentIcon} size={15} color="hsl(72 5% 6%)" />
+                <HugeIcon
+                  icon={ArrowUp01Icon}
+                  size={16}
+                  color="hsl(72 5% 6%)"
+                />
               )}
             </Button>
           </View>
@@ -395,3 +437,23 @@ export default function NewChatScreen() {
     </KeyboardAvoidingView>
   );
 }
+
+const PlanPill = ({ onClear }: { onClear: () => void }) => (
+  <View className="self-start flex-row items-center gap-2 rounded-full bg-card-elevated px-3 py-2">
+    <Text className="font-sans-medium text-[15px] text-foreground">Plan</Text>
+    <Pressable accessibilityRole="button" onPress={onClear} hitSlop={8}>
+      <HugeIcon icon={CancelCircleIcon} size={15} color="hsl(72 4% 76%)" />
+    </Pressable>
+  </View>
+);
+
+const defaultModelOptions = (
+  providerId: ModelModeValue["providerId"],
+  model: string,
+): Record<string, string> | undefined => {
+  const descriptor = reasoningDescriptorForModel(providerId, model);
+  const value = descriptor?.defaultId ?? descriptor?.options[0]?.id;
+  return descriptor !== null && value !== undefined
+    ? { [descriptor.id]: value }
+    : undefined;
+};

--- a/apps/mobile/app/plan-viewer.tsx
+++ b/apps/mobile/app/plan-viewer.tsx
@@ -1,0 +1,29 @@
+import { Stack, useLocalSearchParams } from "expo-router";
+import { ScrollView, Text, View } from "react-native";
+
+import { Markdown } from "~/components/messages/markdown";
+import { getPlanDocument } from "~/store/plan-viewer";
+
+export default function PlanViewerScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const text = typeof id === "string" ? getPlanDocument(id) : null;
+
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen options={{ title: "Plan", presentation: "modal" }} />
+      <ScrollView
+        className="flex-1"
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={{ padding: 24, paddingBottom: 48 }}
+      >
+        {text === null ? (
+          <Text className="font-sans text-[15px] leading-6 text-muted-foreground">
+            This plan is no longer available.
+          </Text>
+        ) : (
+          <Markdown>{text}</Markdown>
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -1,6 +1,12 @@
 import type { Session, SessionId, SessionStatus } from "@zuse/wire";
+import {
+  CloudOffIcon,
+  Folder01Icon,
+  GitBranchIcon,
+  SentIcon,
+  Square01Icon,
+} from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
-import { CloudOff, Folder, GitBranch, Send, Square } from "lucide-react-native";
 import { useState } from "react";
 import { ActivityIndicator, Text, TextInput, View } from "react-native";
 
@@ -26,6 +32,7 @@ import {
 } from "./model-mode-menu";
 import { Button } from "./ui/button";
 import { GlassSurface } from "./ui/glass-surface";
+import { HugeIcon } from "./ui/huge-icon";
 
 export const Composer = ({
   connKey,
@@ -154,7 +161,7 @@ export const Composer = ({
     >
       {queuedCount > 0 ? (
         <View className="mb-2 flex-row items-center gap-1.5 px-1">
-          <CloudOff size={13} color="hsl(42 93% 56%)" />
+          <HugeIcon icon={CloudOffIcon} size={13} color="hsl(42 93% 56%)" />
           <Text className="font-sans-medium text-xs text-warning">
             {queuedCount} queued · will send when reconnected
           </Text>
@@ -214,7 +221,7 @@ export const Composer = ({
               disabled={busy || !online}
               onPress={interrupt}
             >
-              <Square size={15} color="hsl(72 4% 92%)" />
+              <HugeIcon icon={Square01Icon} size={15} color="hsl(72 4% 92%)" />
             </Button>
           ) : null}
           <Button
@@ -227,9 +234,9 @@ export const Composer = ({
             {busy ? (
               <ActivityIndicator color="hsl(72 5% 6%)" />
             ) : online ? (
-              <Send size={15} color="hsl(72 5% 6%)" />
+              <HugeIcon icon={SentIcon} size={15} color="hsl(72 5% 6%)" />
             ) : (
-              <CloudOff size={15} color="hsl(72 4% 92%)" />
+              <HugeIcon icon={CloudOffIcon} size={15} color="hsl(72 4% 92%)" />
             )}
           </Button>
         </View>
@@ -247,9 +254,9 @@ const ChromeLabel = ({
 }) => (
   <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated/70 px-2.5 py-1.5">
     {icon === "project" ? (
-      <Folder size={13} color="hsl(72 4% 76%)" />
+      <HugeIcon icon={Folder01Icon} size={13} color="hsl(72 4% 76%)" />
     ) : (
-      <GitBranch size={13} color="hsl(72 4% 76%)" />
+      <HugeIcon icon={GitBranchIcon} size={13} color="hsl(72 4% 76%)" />
     )}
     <Text
       className="min-w-0 flex-1 font-sans-medium text-[12px] text-muted-foreground"

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -1,6 +1,6 @@
 import type { Session, SessionId, SessionStatus } from "@zuse/wire";
 import { Effect } from "effect";
-import { CloudOff, Send, Square } from "lucide-react-native";
+import { CloudOff, Folder, GitBranch, Send, Square } from "lucide-react-native";
 import { useState } from "react";
 import { ActivityIndicator, Text, TextInput, View } from "react-native";
 
@@ -19,6 +19,8 @@ import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 import { useMobileMessagesStore } from "~/store/messages";
 import { useOutboxStore } from "~/store/outbox";
 import {
+  ComposerApprovalMenu,
+  ComposerModeMenu,
   ComposerModelMenu,
   type ModelModeValue,
 } from "./model-mode-menu";
@@ -32,6 +34,8 @@ export const Composer = ({
   session,
   status,
   fresh,
+  projectLabel,
+  sourceLabel,
   bottomInset = 0,
 }: {
   connKey: string;
@@ -40,6 +44,8 @@ export const Composer = ({
   session: Session | null;
   status?: SessionStatus;
   fresh: boolean;
+  projectLabel?: string;
+  sourceLabel?: string;
   bottomInset?: number;
 }) => {
   const [text, setText] = useState("");
@@ -143,7 +149,7 @@ export const Composer = ({
 
   return (
     <View
-      className="border-t border-border px-3 pt-3"
+      className="px-3 pt-2"
       style={{ paddingBottom: bottomInset > 0 ? bottomInset : 12 }}
     >
       {queuedCount > 0 ? (
@@ -156,55 +162,100 @@ export const Composer = ({
       ) : null}
       <GlassSurface
         style={{
-          flexDirection: "row",
-          alignItems: "flex-end",
           gap: 8,
-          padding: 8,
+          padding: 10,
         }}
       >
-        <View className="min-w-0 flex-1 gap-2">
-          <TextInput
-            className="min-h-10 px-2 py-2 font-sans text-[17px] text-foreground"
-            multiline
-            placeholder={online ? "Message" : "Offline · message will queue"}
-            placeholderTextColor="hsl(72 4% 56%)"
-            value={text}
-            onChangeText={setText}
-          />
-          <View className="flex-row items-center justify-between">
-            <View className="h-10 w-10" />
-            {modelValue === null ? null : (
-              <ComposerModelMenu
+        {projectLabel !== undefined || sourceLabel !== undefined ? (
+          <View className="flex-row items-center gap-2 px-1">
+            {projectLabel !== undefined ? (
+              <ChromeLabel icon="project" label={projectLabel} />
+            ) : null}
+            {sourceLabel !== undefined ? (
+              <ChromeLabel icon="branch" label={sourceLabel} />
+            ) : null}
+          </View>
+        ) : null}
+        <TextInput
+          className="max-h-36 min-h-12 px-1 py-2 font-sans text-[17px] leading-6 text-foreground"
+          multiline
+          placeholder={online ? "Message" : "Offline · message will queue"}
+          placeholderTextColor="hsl(72 4% 56%)"
+          value={text}
+          onChangeText={setText}
+        />
+        <View className="flex-row items-center gap-2">
+          {modelValue === null ? null : (
+            <>
+              <ComposerModeMenu
                 value={modelValue}
                 editable={fresh}
                 onChange={(next) => void changeModelMode(next)}
               />
-            )}
-          </View>
-        </View>
-        {showInterrupt ? (
-          <Button
-            variant="secondary"
-            disabled={busy || !online}
-            onPress={interrupt}
-          >
-            <Square size={16} color="hsl(72 4% 92%)" />
-          </Button>
-        ) : null}
-        <Button
-          variant={online ? "primary" : "secondary"}
-          disabled={!canSend}
-          onPress={submit}
-        >
-          {busy ? (
-            <ActivityIndicator color="hsl(72 5% 6%)" />
-          ) : online ? (
-            <Send size={16} color="hsl(72 5% 6%)" />
-          ) : (
-            <CloudOff size={16} color="hsl(72 4% 92%)" />
+              <View className="min-w-0 flex-1 items-center">
+                <ComposerModelMenu
+                  value={modelValue}
+                  editable={fresh}
+                  onChange={(next) => void changeModelMode(next)}
+                />
+              </View>
+              <ComposerApprovalMenu
+                value={modelValue}
+                editable={fresh}
+                onChange={(next) => void changeModelMode(next)}
+              />
+            </>
           )}
-        </Button>
+          {showInterrupt ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-10 w-10 rounded-full px-0"
+              disabled={busy || !online}
+              onPress={interrupt}
+            >
+              <Square size={15} color="hsl(72 4% 92%)" />
+            </Button>
+          ) : null}
+          <Button
+            size="sm"
+            variant={online ? "primary" : "secondary"}
+            className="h-10 w-10 rounded-full px-0"
+            disabled={!canSend}
+            onPress={submit}
+          >
+            {busy ? (
+              <ActivityIndicator color="hsl(72 5% 6%)" />
+            ) : online ? (
+              <Send size={15} color="hsl(72 5% 6%)" />
+            ) : (
+              <CloudOff size={15} color="hsl(72 4% 92%)" />
+            )}
+          </Button>
+        </View>
       </GlassSurface>
     </View>
   );
 };
+
+const ChromeLabel = ({
+  icon,
+  label,
+}: {
+  icon: "project" | "branch";
+  label: string;
+}) => (
+  <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated/70 px-2.5 py-1.5">
+    {icon === "project" ? (
+      <Folder size={13} color="hsl(72 4% 76%)" />
+    ) : (
+      <GitBranch size={13} color="hsl(72 4% 76%)" />
+    )}
+    <Text
+      className="min-w-0 flex-1 font-sans-medium text-[12px] text-muted-foreground"
+      numberOfLines={1}
+    >
+      {label}
+    </Text>
+  </View>
+);

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -1,14 +1,21 @@
 import type { Session, SessionId, SessionStatus } from "@zuse/wire";
 import {
+  ArrowUp01Icon,
   CloudOffIcon,
+  CancelCircleIcon,
   Folder01Icon,
   GitBranchIcon,
-  SentIcon,
   Square01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
 import { useState } from "react";
-import { ActivityIndicator, Text, TextInput, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 
 import {
   interruptSession,
@@ -25,9 +32,8 @@ import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 import { useMobileMessagesStore } from "~/store/messages";
 import { useOutboxStore } from "~/store/outbox";
 import {
-  ComposerApprovalMenu,
-  ComposerModeMenu,
   ComposerModelMenu,
+  ComposerSettingsMenu,
   type ModelModeValue,
 } from "./model-mode-menu";
 import { Button } from "./ui/button";
@@ -167,21 +173,29 @@ export const Composer = ({
           </Text>
         </View>
       ) : null}
+      {projectLabel !== undefined || sourceLabel !== undefined ? (
+        <View className="mb-2 flex-row items-center gap-2 px-1">
+          {projectLabel !== undefined ? (
+            <ChromeLabel icon="project" label={projectLabel} />
+          ) : null}
+          {sourceLabel !== undefined ? (
+            <ChromeLabel icon="branch" label={sourceLabel} />
+          ) : null}
+        </View>
+      ) : null}
       <GlassSurface
         style={{
           gap: 8,
           padding: 10,
         }}
       >
-        {projectLabel !== undefined || sourceLabel !== undefined ? (
-          <View className="flex-row items-center gap-2 px-1">
-            {projectLabel !== undefined ? (
-              <ChromeLabel icon="project" label={projectLabel} />
-            ) : null}
-            {sourceLabel !== undefined ? (
-              <ChromeLabel icon="branch" label={sourceLabel} />
-            ) : null}
-          </View>
+        {modelValue?.permissionMode === "plan" ? (
+          <PlanPill
+            editable={fresh}
+            onClear={() =>
+              void changeModelMode({ ...modelValue, permissionMode: "default" })
+            }
+          />
         ) : null}
         <TextInput
           className="max-h-36 min-h-12 px-1 py-2 font-sans text-[17px] leading-6 text-foreground"
@@ -194,7 +208,7 @@ export const Composer = ({
         <View className="flex-row items-center gap-2">
           {modelValue === null ? null : (
             <>
-              <ComposerModeMenu
+              <ComposerSettingsMenu
                 value={modelValue}
                 editable={fresh}
                 onChange={(next) => void changeModelMode(next)}
@@ -206,11 +220,6 @@ export const Composer = ({
                   onChange={(next) => void changeModelMode(next)}
                 />
               </View>
-              <ComposerApprovalMenu
-                value={modelValue}
-                editable={fresh}
-                onChange={(next) => void changeModelMode(next)}
-              />
             </>
           )}
           {showInterrupt ? (
@@ -234,7 +243,7 @@ export const Composer = ({
             {busy ? (
               <ActivityIndicator color="hsl(72 5% 6%)" />
             ) : online ? (
-              <HugeIcon icon={SentIcon} size={15} color="hsl(72 5% 6%)" />
+              <HugeIcon icon={ArrowUp01Icon} size={16} color="hsl(72 5% 6%)" />
             ) : (
               <HugeIcon icon={CloudOffIcon} size={15} color="hsl(72 4% 92%)" />
             )}
@@ -264,5 +273,22 @@ const ChromeLabel = ({
     >
       {label}
     </Text>
+  </View>
+);
+
+const PlanPill = ({
+  editable,
+  onClear,
+}: {
+  editable: boolean;
+  onClear: () => void;
+}) => (
+  <View className="self-start flex-row items-center gap-2 rounded-full bg-card-elevated px-3 py-2">
+    <Text className="font-sans-medium text-[15px] text-foreground">Plan</Text>
+    {editable ? (
+      <Pressable accessibilityRole="button" onPress={onClear} hitSlop={8}>
+        <HugeIcon icon={CancelCircleIcon} size={15} color="hsl(72 4% 76%)" />
+      </Pressable>
+    ) : null}
   </View>
 );

--- a/apps/mobile/src/components/messages/message-row.tsx
+++ b/apps/mobile/src/components/messages/message-row.tsx
@@ -1,4 +1,5 @@
 import type { Message, MessageContent, UserQuestion } from "@zuse/wire";
+import { router } from "expo-router";
 import {
   Bot,
   Brain,
@@ -27,20 +28,28 @@ import {
   buildToolPresentation,
   type MobileToolIcon,
 } from "~/lib/tool-presentation";
+import { putPlanDocument } from "~/store/plan-viewer";
 import { Markdown } from "./markdown";
-import { PendingUserInputCard, type QuestionAnswer } from "./pending-user-input-card";
+import {
+  PendingUserInputCard,
+  type QuestionAnswer,
+} from "./pending-user-input-card";
 
 /** Extra context the stream provides so question rows can render statefully. */
 export type MessageRowContext = {
   answeredQuestionIds: ReadonlySet<string>;
   questionsByItemId: ReadonlyMap<string, readonly UserQuestion[]>;
   toolResultsByItemId: ReadonlyMap<string, ToolResultRecord>;
-  onAnswerQuestion: (itemId: string, answers: readonly QuestionAnswer[]) => void | Promise<void>;
+  planMode?: boolean;
+  onAnswerQuestion: (
+    itemId: string,
+    answers: readonly QuestionAnswer[],
+  ) => void | Promise<void>;
 };
 
 export const MessageRow = ({
   message,
-  ctx
+  ctx,
 }: {
   message: Message;
   ctx: MessageRowContext;
@@ -50,15 +59,33 @@ export const MessageRow = ({
     case "user":
       return <UserBubble text={content.text} goal={content.goal} />;
     case "user_rich":
-      return <UserBubble text={content.text} chips={richChips(content)} goal={content.goal} />;
+      return (
+        <UserBubble
+          text={content.text}
+          chips={richChips(content)}
+          goal={content.goal}
+        />
+      );
     case "assistant":
-      return <AssistantMarkdown text={content.text} />;
+      return (
+        <AssistantMarkdown
+          text={content.text}
+          planMode={ctx.planMode === true}
+        />
+      );
     case "thinking":
       return <ThinkingRow content={content} />;
     case "tool_use":
-      return <ToolUseRow content={content} result={ctx.toolResultsByItemId.get(content.itemId)} />;
+      return (
+        <ToolUseRow
+          content={content}
+          result={ctx.toolResultsByItemId.get(content.itemId)}
+        />
+      );
     case "tool_result":
-      return ctx.toolResultsByItemId.has(content.itemId) ? null : <ToolResultRow content={content} />;
+      return ctx.toolResultsByItemId.has(content.itemId) ? null : (
+        <ToolResultRow content={content} />
+      );
     case "error":
       return <ErrorRow message={content.message} />;
     case "user_question":
@@ -73,7 +100,10 @@ export const MessageRow = ({
       );
     case "user_question_answer":
       return (
-        <AnswerBubble content={content} questions={ctx.questionsByItemId.get(content.itemId)} />
+        <AnswerBubble
+          content={content}
+          questions={ctx.questionsByItemId.get(content.itemId)}
+        />
       );
     default:
       return <FallbackRow content={content} />;
@@ -83,7 +113,7 @@ export const MessageRow = ({
 const UserBubble = ({
   text,
   goal,
-  chips = []
+  chips = [],
 }: {
   text: string;
   goal?: boolean;
@@ -95,9 +125,13 @@ const UserBubble = ({
       className="max-w-[88%] rounded-2xl bg-primary px-3.5 py-2.5"
     >
       {goal === true ? (
-        <Text className="mb-1 font-sans-medium text-xs text-primary-foreground/75">Goal</Text>
+        <Text className="mb-1 font-sans-medium text-xs text-primary-foreground/75">
+          Goal
+        </Text>
       ) : null}
-      <Text className="font-sans text-[15px] leading-5 text-primary-foreground">{text}</Text>
+      <Text className="font-sans text-[15px] leading-5 text-primary-foreground">
+        {text}
+      </Text>
       {chips.length > 0 ? (
         <View className="mt-2 flex-row flex-wrap gap-1">
           {chips.map((chip) => (
@@ -114,14 +148,62 @@ const UserBubble = ({
   </View>
 );
 
-const AssistantMarkdown = ({ text }: { text: string }) => (
-  <View className="px-2 py-2">
-    <Markdown>{text}</Markdown>
-  </View>
-);
+const AssistantMarkdown = ({
+  text,
+  planMode,
+}: {
+  text: string;
+  planMode: boolean;
+}) =>
+  planMode || isLikelyPlan(text) ? (
+    <PlanPreview text={text} />
+  ) : (
+    <View className="px-2 py-2">
+      <Markdown>{text}</Markdown>
+    </View>
+  );
+
+const PlanPreview = ({ text }: { text: string }) => {
+  const title = planTitle(text);
+  const preview = planPreview(text);
+  return (
+    <View className="px-2 py-2">
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => {
+          const id = putPlanDocument(text);
+          router.push(`/plan-viewer?id=${encodeURIComponent(id)}`);
+        }}
+        className="rounded-2xl border border-border bg-card px-4 py-4 active:opacity-80"
+        style={{ borderCurve: "continuous" }}
+      >
+        <View className="mb-3 flex-row items-center gap-2">
+          <Text className="font-sans-medium text-[13px] text-muted-foreground">
+            Plan
+          </Text>
+          <Text className="ml-auto font-sans text-[12px] text-muted-foreground">
+            Open
+          </Text>
+        </View>
+        <Text
+          className="font-sans-bold text-[22px] leading-7 text-foreground"
+          numberOfLines={2}
+        >
+          {title}
+        </Text>
+        <Text
+          className="mt-3 font-sans text-[15px] leading-6 text-muted-foreground"
+          numberOfLines={5}
+        >
+          {preview}
+        </Text>
+      </Pressable>
+    </View>
+  );
+};
 
 const ThinkingRow = ({
-  content
+  content,
 }: {
   content: Extract<MessageContent, { _tag: "thinking" }>;
 }) => (
@@ -163,7 +245,10 @@ const ToolUseRow = ({
             >
               <View className="flex-row items-center gap-2">
                 <FilePenLine size={14} color="hsl(72 98% 54%)" />
-                <Text className="min-w-0 flex-1 font-mono text-xs text-foreground" numberOfLines={1}>
+                <Text
+                  className="min-w-0 flex-1 font-mono text-xs text-foreground"
+                  numberOfLines={1}
+                >
                   {summary.path}
                 </Text>
                 <Text className="font-mono text-[11px] text-presence-online">
@@ -211,7 +296,7 @@ const ToolUseRow = ({
 };
 
 const ToolResultRow = ({
-  content
+  content,
 }: {
   content: Extract<MessageContent, { _tag: "tool_result" }>;
 }) => (
@@ -221,7 +306,10 @@ const ToolResultRow = ({
     detail={summarizeValue(content.output, 96)}
     danger={content.isError}
   >
-    <Text selectable className="font-mono text-xs leading-5 text-muted-foreground">
+    <Text
+      selectable
+      className="font-mono text-xs leading-5 text-muted-foreground"
+    >
       {summarizeValue(content.output)}
     </Text>
   </ExpandableEventRow>
@@ -241,16 +329,22 @@ const ErrorRow = ({ message }: { message: string }) => (
   </View>
 );
 
-const AnsweredQuestion = ({ questions }: { questions: readonly UserQuestion[] }) => (
+const AnsweredQuestion = ({
+  questions,
+}: {
+  questions: readonly UserQuestion[];
+}) => (
   <View className="px-2 py-2">
     <View className="rounded-2xl border border-border bg-card px-3 py-3 opacity-70">
-      <Text className="font-sans-medium text-xs text-muted-foreground">Question · answered</Text>
+      <Text className="font-sans-medium text-xs text-muted-foreground">
+        Question · answered
+      </Text>
       {questions.map((question, qi) => (
         <Text
           key={`answered-${qi}`}
           className={cn(
             "font-sans-medium text-sm text-foreground",
-            qi > 0 ? "mt-2" : "mt-1"
+            qi > 0 ? "mt-2" : "mt-1",
           )}
         >
           {question.question}
@@ -262,7 +356,7 @@ const AnsweredQuestion = ({ questions }: { questions: readonly UserQuestion[] })
 
 const AnswerBubble = ({
   content,
-  questions
+  questions,
 }: {
   content: Extract<MessageContent, { _tag: "user_question_answer" }>;
   questions?: readonly UserQuestion[];
@@ -273,7 +367,9 @@ const AnswerBubble = ({
       .map((index) => options[index])
       .filter((label): label is string => label !== undefined);
     const other = answer.other?.trim();
-    return other !== undefined && other.length > 0 ? [...picked, other] : picked;
+    return other !== undefined && other.length > 0
+      ? [...picked, other]
+      : picked;
   });
   const summary = labels.length > 0 ? labels.join(", ") : "Answered";
   return (
@@ -282,8 +378,12 @@ const AnswerBubble = ({
         style={{ borderCurve: "continuous" }}
         className="max-w-[88%] rounded-2xl bg-primary px-3.5 py-2.5"
       >
-        <Text className="mb-1 font-sans-medium text-xs text-primary-foreground/75">Answer</Text>
-        <Text className="font-sans text-[15px] leading-5 text-primary-foreground">{summary}</Text>
+        <Text className="mb-1 font-sans-medium text-xs text-primary-foreground/75">
+          Answer
+        </Text>
+        <Text className="font-sans text-[15px] leading-5 text-primary-foreground">
+          {summary}
+        </Text>
       </View>
     </View>
   );
@@ -292,8 +392,13 @@ const AnswerBubble = ({
 const FallbackRow = ({ content }: { content: MessageContent }) => (
   <View className="px-2 py-2">
     <View className="rounded-2xl border border-border bg-muted px-3 py-2">
-      <Text className="font-sans-medium text-xs text-muted-foreground">{content._tag}</Text>
-      <Text className="mt-1 font-mono text-xs leading-5 text-muted-foreground" numberOfLines={4}>
+      <Text className="font-sans-medium text-xs text-muted-foreground">
+        {content._tag}
+      </Text>
+      <Text
+        className="mt-1 font-mono text-xs leading-5 text-muted-foreground"
+        numberOfLines={4}
+      >
         {summarizeValue(content)}
       </Text>
     </View>
@@ -303,7 +408,7 @@ const FallbackRow = ({ content }: { content: MessageContent }) => (
 const richChips = (content: Extract<MessageContent, { _tag: "user_rich" }>) => [
   ...content.attachments.map((attachment) => attachment.originalName),
   ...content.fileRefs.map((file) => file.relPath),
-  ...content.skillRefs.map((skill) => skill.name)
+  ...content.skillRefs.map((skill) => skill.name),
 ];
 
 function ExpandableEventRow({
@@ -354,7 +459,9 @@ function ExpandableEventRow({
             <Text
               className={cn(
                 "rounded-full px-2 py-0.5 font-sans-medium text-[11px]",
-                danger ? "bg-danger/15 text-danger" : "bg-muted text-muted-foreground",
+                danger
+                  ? "bg-danger/15 text-danger"
+                  : "bg-muted text-muted-foreground",
               )}
             >
               {badge}
@@ -409,3 +516,33 @@ const firstLine = (value: string): string => {
   const line = value.trim().split(/\r\n|\r|\n/)[0] ?? "";
   return line.length > 0 ? line : "(empty)";
 };
+
+const isLikelyPlan = (text: string): boolean => {
+  const value = text.toLowerCase();
+  return (
+    value.includes("## summary") ||
+    value.includes("## key changes") ||
+    value.includes("## test plan") ||
+    value.includes("# implementation plan") ||
+    value.includes("implementation plan")
+  );
+};
+
+const planTitle = (text: string): string => {
+  const heading = text
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.trim())
+    .find((line) => /^#{1,3}\s+\S/.test(line));
+  if (heading !== undefined) return heading.replace(/^#{1,3}\s+/, "");
+  return "Implementation Plan";
+};
+
+const planPreview = (text: string): string =>
+  text
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*]\s+/gm, "• ")
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(1, 8)
+    .join("\n");

--- a/apps/mobile/src/components/model-mode-menu.ios.tsx
+++ b/apps/mobile/src/components/model-mode-menu.ios.tsx
@@ -61,15 +61,43 @@ export function ComposerModelMenu({
         label={compactModelLabel(value)}
         systemImage={providerSystemImage(value.providerId)}
       >
-        <Menu label="Model" systemImage={providerSystemImage(value.providerId)}>
-          <ProviderModelMenus value={value} editable={editable} onChange={onChange} />
-        </Menu>
-        <Menu label="Mode" systemImage="wand.and.stars">
-          <ModeButtons value={value} editable={editable} onChange={onChange} />
-        </Menu>
-        <Menu label="Permissions" systemImage="lock.open">
-          <PermissionButtons value={value} editable={editable} onChange={onChange} />
-        </Menu>
+        <ProviderModelMenus value={value} editable={editable} onChange={onChange} />
+      </Menu>
+    </Host>
+  );
+}
+
+export function ComposerModeMenu({
+  value,
+  editable,
+  onChange,
+}: {
+  value: ModelModeValue;
+  editable: boolean;
+  onChange: (value: ModelModeValue) => void;
+}) {
+  return (
+    <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
+      <Menu label={modeLabel(value)} systemImage="slider.horizontal.3">
+        <ModeButtons value={value} editable={editable} onChange={onChange} />
+      </Menu>
+    </Host>
+  );
+}
+
+export function ComposerApprovalMenu({
+  value,
+  editable,
+  onChange,
+}: {
+  value: ModelModeValue;
+  editable: boolean;
+  onChange: (value: ModelModeValue) => void;
+}) {
+  return (
+    <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
+      <Menu label={approvalShortLabel(value)} systemImage="hand.raised">
+        <PermissionButtons value={value} editable={editable} onChange={onChange} />
       </Menu>
     </Host>
   );
@@ -172,25 +200,28 @@ export function ProjectPill({
   }[];
   onSelect: (connectionKey: string, projectId: string) => void;
 }) {
+  const projects = options.flatMap((group) =>
+    group.projects.map((project) => ({
+      ...project,
+      connectionKey: group.connectionKey,
+    })),
+  );
+
   return (
     <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
       <Menu label={label} systemImage="folder">
-        {options.map((group) => (
-          <Menu
-            key={group.connectionKey}
-            label={group.connectionLabel}
-            systemImage="desktopcomputer"
-          >
-            {group.projects.map((project) => (
-              <NativeButton
-                key={project.id}
-                label={project.name}
-                systemImage="folder"
-                onPress={() => onSelect(group.connectionKey, project.id)}
-              />
-            ))}
-          </Menu>
-        ))}
+        {projects.length === 0 ? (
+          <NativeButton label="No projects" systemImage="folder" onPress={() => {}} />
+        ) : (
+          projects.map((project) => (
+            <NativeButton
+              key={`${project.connectionKey}:${project.id}`}
+              label={project.name}
+              systemImage="folder"
+              onPress={() => onSelect(project.connectionKey, project.id)}
+            />
+          ))
+        )}
       </Menu>
     </Host>
   );
@@ -362,7 +393,7 @@ function PermissionButtons({
   onChange: (value: ModelModeValue) => void;
 }) {
   return (
-    <Section title="Permissions">
+    <Section title="Approval">
       {RUNTIME_OPTIONS.map((item) => (
         <NativeButton
           key={item.value}
@@ -398,6 +429,19 @@ const modeLabel = (value: ModelModeValue): string =>
 const runtimeLabel = (value: ModelModeValue): string =>
   RUNTIME_OPTIONS.find((item) => item.value === value.runtimeMode)?.label ??
   value.runtimeMode;
+
+const approvalShortLabel = (value: ModelModeValue): string => {
+  switch (value.runtimeMode) {
+    case "approval-required":
+      return "Ask";
+    case "auto-accept-edits":
+      return "Edits";
+    case "auto-accept-edits-and-bash":
+      return "Shell";
+    case "full-access":
+      return "Full";
+  }
+};
 
 const providerSystemImage = (providerId: ProviderId): string => {
   switch (providerId) {

--- a/apps/mobile/src/components/model-mode-menu.ios.tsx
+++ b/apps/mobile/src/components/model-mode-menu.ios.tsx
@@ -12,6 +12,8 @@ import {
   PERMISSION_OPTIONS,
   PROVIDER_LABEL,
   providerOptions,
+  reasoningDescriptorForModel,
+  reasoningValueForModel,
   RUNTIME_OPTIONS,
 } from "~/lib/model-options";
 
@@ -20,6 +22,7 @@ export type ModelModeValue = {
   model: string;
   runtimeMode: RuntimeMode;
   permissionMode: PermissionMode;
+  modelOptions?: Record<string, string>;
 };
 
 export function ModelModePill({
@@ -37,10 +40,18 @@ export function ModelModePill({
         label={modelLabel(value)}
         systemImage={providerSystemImage(value.providerId)}
       >
-        <ProviderModelMenus value={value} editable={editable} onChange={onChange} />
+        <ProviderModelMenus
+          value={value}
+          editable={editable}
+          onChange={onChange}
+        />
         <Divider />
         <ModeButtons value={value} editable={editable} onChange={onChange} />
-        <PermissionButtons value={value} editable={editable} onChange={onChange} />
+        <PermissionButtons
+          value={value}
+          editable={editable}
+          onChange={onChange}
+        />
       </Menu>
     </Host>
   );
@@ -61,13 +72,22 @@ export function ComposerModelMenu({
         label={compactModelLabel(value)}
         systemImage={providerSystemImage(value.providerId)}
       >
-        <ProviderModelMenus value={value} editable={editable} onChange={onChange} />
+        <ProviderModelMenus
+          value={value}
+          editable={editable}
+          onChange={onChange}
+        />
+        <ReasoningButtons
+          value={value}
+          editable={editable}
+          onChange={onChange}
+        />
       </Menu>
     </Host>
   );
 }
 
-export function ComposerModeMenu({
+export function ComposerSettingsMenu({
   value,
   editable,
   onChange,
@@ -78,30 +98,24 @@ export function ComposerModeMenu({
 }) {
   return (
     <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
-      <Menu label={modeLabel(value)} systemImage="slider.horizontal.3">
-        <ModeButtons value={value} editable={editable} onChange={onChange} />
+      <Menu label="" systemImage="gearshape">
+        <Menu label="Mode" systemImage="slider.horizontal.3">
+          <ModeButtons value={value} editable={editable} onChange={onChange} />
+        </Menu>
+        <Menu label="Approval" systemImage="hand.raised">
+          <PermissionButtons
+            value={value}
+            editable={editable}
+            onChange={onChange}
+          />
+        </Menu>
       </Menu>
     </Host>
   );
 }
 
-export function ComposerApprovalMenu({
-  value,
-  editable,
-  onChange,
-}: {
-  value: ModelModeValue;
-  editable: boolean;
-  onChange: (value: ModelModeValue) => void;
-}) {
-  return (
-    <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
-      <Menu label={approvalShortLabel(value)} systemImage="hand.raised">
-        <PermissionButtons value={value} editable={editable} onChange={onChange} />
-      </Menu>
-    </Host>
-  );
-}
+export const ComposerModeMenu = ComposerSettingsMenu;
+export const ComposerApprovalMenu = ComposerSettingsMenu;
 
 export function ModePill({
   value,
@@ -135,11 +149,12 @@ export function RuntimePill({
 }) {
   return (
     <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
-      <Menu
-        label={runtimeLabel(value)}
-        systemImage="lock.open"
-      >
-        <PermissionButtons value={value} editable={editable} onChange={onChange} />
+      <Menu label={runtimeLabel(value)} systemImage="lock.open">
+        <PermissionButtons
+          value={value}
+          editable={editable}
+          onChange={onChange}
+        />
       </Menu>
     </Host>
   );
@@ -160,7 +175,11 @@ export function StaticModelTitle({
         label={modelLabel(value)}
         systemImage={providerSystemImage(value.providerId)}
       >
-        <ProviderModelMenus value={value} editable={editable} onChange={onChange} />
+        <ProviderModelMenus
+          value={value}
+          editable={editable}
+          onChange={onChange}
+        />
       </Menu>
     </Host>
   );
@@ -211,7 +230,11 @@ export function ProjectPill({
     <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
       <Menu label={label} systemImage="folder">
         {projects.length === 0 ? (
-          <NativeButton label="No projects" systemImage="folder" onPress={() => {}} />
+          <NativeButton
+            label="No projects"
+            systemImage="folder"
+            onPress={() => {}}
+          />
         ) : (
           projects.map((project) => (
             <NativeButton
@@ -263,10 +286,7 @@ export function ProjectMenuRow({
 }) {
   return (
     <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
-      <Menu
-        label={`${label} · ${subtitle}`}
-        systemImage="desktopcomputer"
-      >
+      <Menu label={`${label} · ${subtitle}`} systemImage="desktopcomputer">
         {options.map((group) => (
           <Menu
             key={group.connectionKey}
@@ -274,7 +294,11 @@ export function ProjectMenuRow({
             systemImage="desktopcomputer"
           >
             {group.projects.length === 0 ? (
-              <NativeButton label="No projects" systemImage="folder" onPress={() => {}} />
+              <NativeButton
+                label="No projects"
+                systemImage="folder"
+                onPress={() => {}}
+              />
             ) : (
               group.projects.map((project) => (
                 <NativeButton
@@ -337,7 +361,8 @@ function ProviderModelMenus({
               key={model.value}
               label={model.label}
               systemImage={sf(
-                value.providerId === provider.value && value.model === model.value
+                value.providerId === provider.value &&
+                  value.model === model.value
                   ? "checkmark"
                   : providerSystemImage(provider.value),
               )}
@@ -347,11 +372,56 @@ function ProviderModelMenus({
                   ...value,
                   providerId: provider.value,
                   model: model.value,
+                  modelOptions: defaultModelOptions(
+                    provider.value,
+                    model.value,
+                  ),
                 });
               }}
             />
           ))}
         </Menu>
+      ))}
+    </Section>
+  );
+}
+
+function ReasoningButtons({
+  value,
+  editable,
+  onChange,
+}: {
+  value: ModelModeValue;
+  editable: boolean;
+  onChange: (value: ModelModeValue) => void;
+}) {
+  const reasoning = reasoningValueForModel(
+    value.providerId,
+    value.model,
+    value.modelOptions,
+  );
+  if (reasoning === null) return null;
+
+  return (
+    <Section title={reasoning.descriptor.label}>
+      {reasoning.descriptor.options.map((option) => (
+        <NativeButton
+          key={option.id}
+          label={option.label}
+          systemImage={sf(
+            reasoning.value === option.id ? "checkmark" : "brain",
+          )}
+          onPress={() => {
+            if (!editable) return;
+            onChange({
+              ...value,
+              modelOptions: {
+                ...(value.modelOptions ?? {}),
+                [reasoning.descriptor.id]: option.id,
+              },
+            });
+          }}
+        />
       ))}
     </Section>
   );
@@ -372,7 +442,11 @@ function ModeButtons({
         <NativeButton
           key={item.value}
           label={item.label}
-          systemImage={sf(value.permissionMode === item.value ? "checkmark" : "wand.and.stars")}
+          systemImage={sf(
+            value.permissionMode === item.value
+              ? "checkmark"
+              : "wand.and.stars",
+          )}
           onPress={() => {
             if (!editable) return;
             onChange({ ...value, permissionMode: item.value });
@@ -398,7 +472,9 @@ function PermissionButtons({
         <NativeButton
           key={item.value}
           label={item.label}
-          systemImage={sf(value.runtimeMode === item.value ? "checkmark" : "lock.open")}
+          systemImage={sf(
+            value.runtimeMode === item.value ? "checkmark" : "lock.open",
+          )}
           onPress={() => {
             if (!editable) return;
             onChange({ ...value, runtimeMode: item.value });
@@ -415,32 +491,39 @@ const modelLabel = (value: ModelModeValue): string =>
   )?.label ?? value.model;
 
 const compactModelLabel = (value: ModelModeValue): string =>
-  shortModelLabel(modelLabel(value));
+  [
+    shortModelLabel(modelLabel(value)),
+    reasoningValueForModel(value.providerId, value.model, value.modelOptions)
+      ?.label,
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(" ");
 
 const shortModelLabel = (label: string): string => {
-  const trimmed = label.replace(/^GPT-?/i, "").replace(/^Claude\s+/i, "").trim();
+  const trimmed = label
+    .replace(/^GPT-?/i, "")
+    .replace(/^Claude\s+/i, "")
+    .trim();
   return trimmed.length > 0 ? trimmed : label;
 };
 
 const modeLabel = (value: ModelModeValue): string =>
-  PERMISSION_OPTIONS.find((item) => item.value === value.permissionMode)?.label ??
-  value.permissionMode;
+  PERMISSION_OPTIONS.find((item) => item.value === value.permissionMode)
+    ?.label ?? value.permissionMode;
 
 const runtimeLabel = (value: ModelModeValue): string =>
   RUNTIME_OPTIONS.find((item) => item.value === value.runtimeMode)?.label ??
   value.runtimeMode;
 
-const approvalShortLabel = (value: ModelModeValue): string => {
-  switch (value.runtimeMode) {
-    case "approval-required":
-      return "Ask";
-    case "auto-accept-edits":
-      return "Edits";
-    case "auto-accept-edits-and-bash":
-      return "Shell";
-    case "full-access":
-      return "Full";
-  }
+const defaultModelOptions = (
+  providerId: ProviderId,
+  model: string,
+): Record<string, string> | undefined => {
+  const descriptor = reasoningDescriptorForModel(providerId, model);
+  const value = descriptor?.defaultId ?? descriptor?.options[0]?.id;
+  return descriptor !== null && value !== undefined
+    ? { [descriptor.id]: value }
+    : undefined;
 };
 
 const providerSystemImage = (providerId: ProviderId): string => {

--- a/apps/mobile/src/components/model-mode-menu.tsx
+++ b/apps/mobile/src/components/model-mode-menu.tsx
@@ -8,6 +8,7 @@ export type ModelModeValue = {
   model: string;
   runtimeMode: RuntimeMode;
   permissionMode: PermissionMode;
+  modelOptions?: Record<string, string>;
 };
 
 export function ModelModePill({
@@ -17,9 +18,10 @@ export function ModelModePill({
   editable: boolean;
   onChange: (value: ModelModeValue) => void;
 }) {
-  const modelLabel = modelOptionsForProvider(value.providerId).find(
-    (model) => model.value === value.model,
-  )?.label ?? value.model;
+  const modelLabel =
+    modelOptionsForProvider(value.providerId).find(
+      (model) => model.value === value.model,
+    )?.label ?? value.model;
   return <FallbackPill label={modelLabel} />;
 }
 
@@ -30,19 +32,19 @@ export function ComposerModelMenu({
   editable: boolean;
   onChange: (value: ModelModeValue) => void;
 }) {
-  const modelLabel = modelOptionsForProvider(value.providerId).find(
-    (model) => model.value === value.model,
-  )?.label ?? value.model;
+  const modelLabel =
+    modelOptionsForProvider(value.providerId).find(
+      (model) => model.value === value.model,
+    )?.label ?? value.model;
   return <FallbackPill label={modelLabel} />;
 }
 
-export const ComposerModeMenu = ({ value }: ModelModeProps) => (
+export const ComposerSettingsMenu = ({ value }: ModelModeProps) => (
   <FallbackPill label={value.permissionMode} />
 );
 
-export const ComposerApprovalMenu = ({ value }: ModelModeProps) => (
-  <FallbackPill label={value.runtimeMode} />
-);
+export const ComposerModeMenu = ComposerSettingsMenu;
+export const ComposerApprovalMenu = ComposerSettingsMenu;
 
 export const ModePill = ({ value }: ModelModeProps) => (
   <FallbackPill label={value.permissionMode} />
@@ -53,9 +55,10 @@ export const RuntimePill = ({ value }: ModelModeProps) => (
 );
 
 export const StaticModelTitle = ({ value }: ModelModeProps) => {
-  const modelLabel = modelOptionsForProvider(value.providerId).find(
-    (model) => model.value === value.model,
-  )?.label ?? value.model;
+  const modelLabel =
+    modelOptionsForProvider(value.providerId).find(
+      (model) => model.value === value.model,
+    )?.label ?? value.model;
   return <FallbackPill label={modelLabel} />;
 };
 
@@ -119,8 +122,12 @@ export const NativeButton = (_props: {
   systemImage?: string;
   onPress?: () => void;
 }) => null;
-export const Menu = (_props: { label: string; children: React.ReactNode }) => null;
-export const Section = (_props: { title?: string; children: React.ReactNode }) => null;
+export const Menu = (_props: { label: string; children: React.ReactNode }) =>
+  null;
+export const Section = (_props: {
+  title?: string;
+  children: React.ReactNode;
+}) => null;
 export const Divider = () => null;
 
 type ModelModeProps = {
@@ -134,7 +141,10 @@ const FallbackPill = ({ label }: { label: string }) => (
     className="rounded-full border border-border bg-card-elevated px-3 py-2 active:opacity-75"
     style={{ borderCurve: "continuous" }}
   >
-    <Text className="font-sans-medium text-[14px] text-foreground" numberOfLines={1}>
+    <Text
+      className="font-sans-medium text-[14px] text-foreground"
+      numberOfLines={1}
+    >
       {label}
     </Text>
   </Pressable>

--- a/apps/mobile/src/components/model-mode-menu.tsx
+++ b/apps/mobile/src/components/model-mode-menu.tsx
@@ -36,6 +36,14 @@ export function ComposerModelMenu({
   return <FallbackPill label={modelLabel} />;
 }
 
+export const ComposerModeMenu = ({ value }: ModelModeProps) => (
+  <FallbackPill label={value.permissionMode} />
+);
+
+export const ComposerApprovalMenu = ({ value }: ModelModeProps) => (
+  <FallbackPill label={value.runtimeMode} />
+);
+
 export const ModePill = ({ value }: ModelModeProps) => (
   <FallbackPill label={value.permissionMode} />
 );

--- a/apps/mobile/src/components/ui/huge-icon.tsx
+++ b/apps/mobile/src/components/ui/huge-icon.tsx
@@ -1,0 +1,11 @@
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react-native";
+
+type HugeIconProps = {
+  icon: IconSvgElement;
+  size?: number;
+  color: string;
+};
+
+export const HugeIcon = ({ icon, size = 16, color }: HugeIconProps) => (
+  <HugeiconsIcon icon={icon} size={size} color={color} />
+);

--- a/apps/mobile/src/lib/model-options.ts
+++ b/apps/mobile/src/lib/model-options.ts
@@ -1,6 +1,8 @@
 import {
   defaultModelFor,
+  findModelDescriptor,
   MODELS_BY_PROVIDER,
+  type SelectOptionDescriptor,
   type PermissionMode,
   type ProviderId,
   type RuntimeMode,
@@ -48,3 +50,37 @@ export const modelOptionsForProvider = (providerId: ProviderId) =>
 
 export const defaultModelForProvider = (providerId: ProviderId): string =>
   defaultModelFor(providerId);
+
+export const reasoningDescriptorForModel = (
+  providerId: ProviderId,
+  model: string,
+): SelectOptionDescriptor | null => {
+  const descriptor = findModelDescriptor(providerId, model);
+  const option = descriptor?.optionDescriptors?.find(
+    (item): item is SelectOptionDescriptor =>
+      item.kind === "select" &&
+      (item.id === "reasoning" || item.id === "effort"),
+  );
+  return option ?? null;
+};
+
+export const reasoningValueForModel = (
+  providerId: ProviderId,
+  model: string,
+  modelOptions: Readonly<Record<string, string>> | undefined,
+): {
+  descriptor: SelectOptionDescriptor;
+  value: string;
+  label: string;
+} | null => {
+  const descriptor = reasoningDescriptorForModel(providerId, model);
+  if (descriptor === null) return null;
+  const value =
+    modelOptions?.[descriptor.id] ??
+    descriptor.defaultId ??
+    descriptor.options[0]?.id;
+  if (value === undefined) return null;
+  const label =
+    descriptor.options.find((option) => option.id === value)?.label ?? value;
+  return { descriptor, value, label };
+};

--- a/apps/mobile/src/lib/new-chat.test.ts
+++ b/apps/mobile/src/lib/new-chat.test.ts
@@ -28,6 +28,7 @@ describe("new chat helper", () => {
       model: "claude-sonnet-5",
       runtimeMode: "full-access",
       permissionMode: "plan",
+      modelOptions: { effort: "high" },
       source: {
         kind: "branch",
         label: "feature",
@@ -43,6 +44,7 @@ describe("new chat helper", () => {
       model: "claude-sonnet-5",
       runtimeMode: "full-access",
       permissionMode: "plan",
+      modelOptions: { effort: "high" },
       initialPrompt: "build it",
       createSource: { _tag: "branch", branch: "feature", remote: "origin" },
     });

--- a/apps/mobile/src/lib/new-chat.ts
+++ b/apps/mobile/src/lib/new-chat.ts
@@ -10,9 +10,24 @@ import type {
 
 export type NewChatSource =
   | { kind: "main"; label: string; worktreeId: null; createSource?: undefined }
-  | { kind: "worktree"; label: string; worktreeId: WorktreeId; createSource?: undefined }
-  | { kind: "branch"; label: string; worktreeId: null; createSource: WorktreeCreateSource }
-  | { kind: "pr"; label: string; worktreeId: null; createSource: WorktreeCreateSource };
+  | {
+      kind: "worktree";
+      label: string;
+      worktreeId: WorktreeId;
+      createSource?: undefined;
+    }
+  | {
+      kind: "branch";
+      label: string;
+      worktreeId: null;
+      createSource: WorktreeCreateSource;
+    }
+  | {
+      kind: "pr";
+      label: string;
+      worktreeId: null;
+      createSource: WorktreeCreateSource;
+    };
 
 export type NewChatDraft = {
   connectionKey: string | null;
@@ -21,6 +36,7 @@ export type NewChatDraft = {
   model: string;
   runtimeMode: RuntimeMode;
   permissionMode: PermissionMode;
+  modelOptions?: Record<string, string>;
   source: NewChatSource;
   text: string;
 };
@@ -31,6 +47,7 @@ export type NewChatCreatePayload = {
   model: string;
   runtimeMode: RuntimeMode;
   permissionMode: PermissionMode;
+  modelOptions?: Record<string, string>;
   initialPrompt: string;
   worktreeId: WorktreeId | null;
   createSource: WorktreeCreateSource | null;
@@ -53,6 +70,9 @@ export const buildNewChatCreatePayload = (
     model: draft.model,
     runtimeMode: draft.runtimeMode,
     permissionMode: draft.permissionMode,
+    ...(draft.modelOptions !== undefined
+      ? { modelOptions: draft.modelOptions }
+      : {}),
     initialPrompt: text,
     worktreeId: draft.source.worktreeId,
     createSource: draft.source.createSource ?? null,
@@ -60,7 +80,11 @@ export const buildNewChatCreatePayload = (
 };
 
 export const patchBundlesWithCreatedChat = (
-  bundles: readonly { project: Folder; chats: readonly Chat[]; sessions: readonly ChatSessionLike[] }[],
+  bundles: readonly {
+    project: Folder;
+    chats: readonly Chat[];
+    sessions: readonly ChatSessionLike[];
+  }[],
   projectId: Folder["id"],
   chat: Chat,
   initialSession: ChatSessionLike,

--- a/apps/mobile/src/rpc/actions.ts
+++ b/apps/mobile/src/rpc/actions.ts
@@ -42,8 +42,8 @@ export const sendMessage = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -57,8 +57,8 @@ export const interruptSession = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -76,8 +76,8 @@ export const decidePermission = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -105,8 +105,8 @@ export const answerQuestion = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -118,6 +118,7 @@ export const createChat = (options: {
   initialPrompt: string;
   runtimeMode?: RuntimeMode;
   permissionMode?: PermissionMode;
+  modelOptions?: Record<string, string>;
   worktreeId?: WorktreeId | null;
 }) => {
   const program = Effect.gen(function* () {
@@ -129,13 +130,14 @@ export const createChat = (options: {
       initialPrompt: options.initialPrompt,
       runtimeMode: options.runtimeMode,
       permissionMode: options.permissionMode,
+      modelOptions: options.modelOptions,
       worktreeId: options.worktreeId ?? null,
     });
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -155,8 +157,8 @@ export const setSessionProvider = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -174,8 +176,8 @@ export const setSessionModel = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -193,8 +195,8 @@ export const setSessionRuntimeMode = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -212,8 +214,8 @@ export const setSessionPermissionMode = (options: {
   });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -221,14 +223,15 @@ export const listWorktrees = (options: {
   connection: WsProtocolOptions;
   projectId: Folder["id"];
 }) => {
-  const program: Effect.Effect<readonly Worktree[], unknown, never> = Effect.gen(function* () {
-    const client = yield* getConnectionClient(options.connection);
-    return yield* client.worktree.list({ projectId: options.projectId });
-  });
+  const program: Effect.Effect<readonly Worktree[], unknown, never> =
+    Effect.gen(function* () {
+      const client = yield* getConnectionClient(options.connection);
+      return yield* client.worktree.list({ projectId: options.projectId });
+    });
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -237,17 +240,19 @@ export const createWorktree = (options: {
   projectId: Folder["id"];
   source?: WorktreeCreateSource;
 }) => {
-  const program: Effect.Effect<Worktree, unknown, never> = Effect.gen(function* () {
-    const client = yield* getConnectionClient(options.connection);
-    return yield* client.worktree.create({
-      projectId: options.projectId,
-      source: options.source,
-    });
-  });
+  const program: Effect.Effect<Worktree, unknown, never> = Effect.gen(
+    function* () {
+      const client = yield* getConnectionClient(options.connection);
+      return yield* client.worktree.create({
+        projectId: options.projectId,
+        source: options.source,
+      });
+    },
+  );
   return program.pipe(
     Effect.tapError((cause) =>
-      Effect.sync(() => reportConnectionFailure(options.connection, cause))
-    )
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
   );
 };
 
@@ -255,24 +260,22 @@ export const listBranches = (options: {
   connection: WsProtocolOptions;
   projectId: Folder["id"];
 }) => {
-  const program: Effect.Effect<readonly GitBranchInfo[], unknown, never> = Effect.gen(function* () {
-    const client = yield* getConnectionClient(options.connection);
-    return yield* client.git.branches({ folderId: options.projectId });
-  });
-  return program.pipe(
-    Effect.catchAll(() => Effect.succeed([])),
-  );
+  const program: Effect.Effect<readonly GitBranchInfo[], unknown, never> =
+    Effect.gen(function* () {
+      const client = yield* getConnectionClient(options.connection);
+      return yield* client.git.branches({ folderId: options.projectId });
+    });
+  return program.pipe(Effect.catchAll(() => Effect.succeed([])));
 };
 
 export const listPullRequests = (options: {
   connection: WsProtocolOptions;
   projectId: Folder["id"];
 }) => {
-  const program: Effect.Effect<readonly GitPrSummary[], unknown, never> = Effect.gen(function* () {
-    const client = yield* getConnectionClient(options.connection);
-    return yield* client.git.listPrs({ folderId: options.projectId });
-  });
-  return program.pipe(
-    Effect.catchAll(() => Effect.succeed([])),
-  );
+  const program: Effect.Effect<readonly GitPrSummary[], unknown, never> =
+    Effect.gen(function* () {
+      const client = yield* getConnectionClient(options.connection);
+      return yield* client.git.listPrs({ folderId: options.projectId });
+    });
+  return program.pipe(Effect.catchAll(() => Effect.succeed([])));
 };

--- a/apps/mobile/src/store/plan-viewer.ts
+++ b/apps/mobile/src/store/plan-viewer.ts
@@ -1,0 +1,10 @@
+const documents = new Map<string, string>();
+
+export const putPlanDocument = (text: string): string => {
+  const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  documents.set(id, text);
+  return id;
+};
+
+export const getPlanDocument = (id: string): string | null =>
+  documents.get(id) ?? null;

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -50,9 +50,14 @@ type SessionsState = {
       initialPrompt: string;
       runtimeMode?: RuntimeMode;
       permissionMode?: PermissionMode;
+      modelOptions?: Record<string, string>;
       worktreeId?: WorktreeId | null;
     },
-  ) => Promise<{ chat: Chat; initialSession: Session; initialMessage: Message | null }>;
+  ) => Promise<{
+    chat: Chat;
+    initialSession: Session;
+    initialMessage: Message | null;
+  }>;
 };
 
 const statusFibers = new Map<string, Fiber.RuntimeFiber<unknown, unknown>>();
@@ -135,6 +140,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
           initialPrompt: input.initialPrompt,
           runtimeMode: input.runtimeMode,
           permissionMode: input.permissionMode,
+          modelOptions: input.modelOptions,
           worktreeId: input.worktreeId ?? null,
         }),
       );
@@ -334,7 +340,7 @@ const patchChat = (
             chat,
             ...bundle.chats.filter((existing) => existing.id !== chat.id),
           ].sort((a, b) => timestampOf(b.updatedAt) - timestampOf(a.updatedAt)),
-      },
+        },
   );
 
 const patchCreatedChat = (

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -231,6 +231,7 @@ const SessionCreate = MemoizeRpcs.toLayerHandler("session.create", (input) =>
       agents: input.agents,
       enableSubagents: input.enableSubagents,
       permissionMode: input.permissionMode,
+      modelOptions: input.modelOptions,
       toolSearch: input.toolSearch,
       // Detach `provider.start` so the new in-chat tab appears in
       // ~hundreds of ms; the booting status flips when the CLI handshake
@@ -266,6 +267,7 @@ const ChatCreate = MemoizeRpcs.toLayerHandler("chat.create", (input) =>
       agents: input.agents,
       enableSubagents: input.enableSubagents,
       permissionMode: input.permissionMode,
+      modelOptions: input.modelOptions,
       toolSearch: input.toolSearch,
     }),
   ),

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -1165,13 +1165,15 @@ export const MessageStoreLive = Layer.scoped(
         | "error"
         | "running",
     ): Effect.Effect<void> =>
-      relayActivity.publish({ sessionId, kind }).pipe(
-        Effect.catchAll((error) =>
-          Effect.logDebug(
-            `[MessageStore] relay activity publish failed: ${error.reason}`,
+      relayActivity
+        .publish({ sessionId, kind })
+        .pipe(
+          Effect.catchAll((error) =>
+            Effect.logDebug(
+              `[MessageStore] relay activity publish failed: ${error.reason}`,
+            ),
           ),
-        ),
-      );
+        );
 
     const broadcastMessage = (
       sessionId: SessionId,
@@ -1673,6 +1675,7 @@ export const MessageStoreLive = Layer.scoped(
                   enableSubagents: effectiveEnableSubagents,
                   cwdOverride,
                   permissionMode: initialPermissionMode,
+                  modelOptions: input.modelOptions,
                   toolSearch: initialToolSearch,
                   forkFromResume,
                 },
@@ -1745,6 +1748,7 @@ export const MessageStoreLive = Layer.scoped(
               enableSubagents: effectiveEnableSubagents,
               cwdOverride,
               permissionMode: initialPermissionMode,
+              modelOptions: input.modelOptions,
               toolSearch: initialToolSearch,
               forkFromResume,
             },
@@ -2123,6 +2127,7 @@ export const MessageStoreLive = Layer.scoped(
           agents: input.agents,
           enableSubagents: input.enableSubagents,
           permissionMode: input.permissionMode,
+          modelOptions: input.modelOptions,
           toolSearch: input.toolSearch,
           resumeCursor: input.resumeCursor,
           resumeStrategy: input.resumeStrategy,

--- a/apps/server/src/provider/services/message-store.ts
+++ b/apps/server/src/provider/services/message-store.ts
@@ -87,6 +87,7 @@ export interface CreateSessionInput {
    * `ExitPlanMode`. Defaults to `'default'`.
    */
   readonly permissionMode?: PermissionMode;
+  readonly modelOptions?: Readonly<Record<string, string>>;
   /**
    * Persist the deferred-tools toggle on the session row. No-op today
    * (the AskUserQuestion server is the only MCP server and is small);
@@ -127,6 +128,7 @@ export interface CreateChatInput {
   readonly agents?: Readonly<Record<string, AgentDefinition>>;
   readonly enableSubagents?: boolean;
   readonly permissionMode?: PermissionMode;
+  readonly modelOptions?: Readonly<Record<string, string>>;
   readonly toolSearch?: boolean;
   readonly resumeCursor?: string | null;
   readonly resumeStrategy?: ResumeStrategy;

--- a/packages/wire/src/session.ts
+++ b/packages/wire/src/session.ts
@@ -486,6 +486,9 @@ export const SessionCreateRpc = Rpc.make("session.create", {
      * `'default'` (immediate execution).
      */
     permissionMode: Schema.optional(PermissionMode),
+    modelOptions: Schema.optional(
+      Schema.Record({ key: Schema.String, value: Schema.String }),
+    ),
     /**
      * Persist the deferred-tools toggle for this session. Reserved for
      * 0.04 code-index MCP servers; no-op today.
@@ -731,6 +734,9 @@ export const ChatCreateRpc = Rpc.make("chat.create", {
     enableSubagents: Schema.optional(Schema.Boolean),
     permissionMode: Schema.optional(PermissionMode),
     toolSearch: Schema.optional(Schema.Boolean),
+    modelOptions: Schema.optional(
+      Schema.Record({ key: Schema.String, value: Schema.String }),
+    ),
   }),
   success: Schema.Struct({
     chat: Chat,


### PR DESCRIPTION
## Summary
- restructure the mobile chat composer as a single glass input module with project/source chips above the textarea
- split model, mode, and approval into separate native menu controls
- simplify new-chat controls and hide computer grouping from the visible project selector

## Tests
- bun run --cwd apps/mobile check-types
- bun run --cwd apps/mobile lint
- bun run --cwd apps/mobile test