### PR TITLE
Fix live chat sync

### DIFF
--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -118,17 +118,14 @@ export default function ThreadScreen() {
 
   const reconnecting = reconnectingBySession[stateKey];
   const error = errorBySession[stateKey];
-  const online =
-    connectionSnapshot?.status === "connected" &&
-    reconnecting !== true &&
-    (error ?? null) === null;
+  const transportOnline = connectionSnapshot?.status === "connected";
 
   // Drain the outbox in order the moment the session is back online.
   useEffect(() => {
-    if (online && normalizedSessionId.length > 0 && options !== null) {
+    if (transportOnline && normalizedSessionId.length > 0 && options !== null) {
       void flushOutbox(connKey, options, normalizedSessionId);
     }
-  }, [connKey, flushOutbox, normalizedSessionId, online, options]);
+  }, [connKey, flushOutbox, normalizedSessionId, transportOnline, options]);
 
   // Cross-reference question rows so answered prompts collapse and the answer
   // row can resolve selected option labels.
@@ -283,6 +280,7 @@ export default function ThreadScreen() {
               ? "Main"
               : "Branch"
           }
+          online={transportOnline}
           bottomInset={insets.bottom}
         />
       )}

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -40,7 +40,6 @@ import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 import {
   addOptimisticMessage,
   removeOptimisticMessage,
-  useMobileMessagesStore,
 } from "~/store/messages";
 import { useOutboxStore } from "~/store/outbox";
 import {
@@ -61,6 +60,7 @@ export const Composer = ({
   fresh,
   projectLabel,
   sourceLabel,
+  online,
   bottomInset = 0,
 }: {
   connKey: string;
@@ -71,19 +71,13 @@ export const Composer = ({
   fresh: boolean;
   projectLabel?: string;
   sourceLabel?: string;
+  online: boolean;
   bottomInset?: number;
 }) => {
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
   const stateKey = connectionSessionKey(connKey, sessionId);
 
-  // Offline = the message stream is retrying or has surfaced an error. Sends
-  // made in this state are queued instead of dropped.
-  const online = useMobileMessagesStore(
-    (state) =>
-      state.reconnectingBySession[stateKey] !== true &&
-      (state.errorBySession[stateKey] ?? null) === null,
-  );
   const queuedCount = useOutboxStore(
     (state) => (state.queuedBySession[stateKey] ?? []).length,
   );
@@ -203,7 +197,8 @@ export const Composer = ({
         <View className="mb-2 flex-row items-center gap-1.5 px-1">
           <HugeIcon icon={CloudOffIcon} size={13} color="hsl(42 93% 56%)" />
           <Text className="font-sans-medium text-xs text-warning">
-            {queuedCount} queued · will send when reconnected
+            {queuedCount} queued ·{" "}
+            {online ? "sending…" : "will send when reconnected"}
           </Text>
         </View>
       ) : null}

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -1,4 +1,11 @@
-import type { Session, SessionId, SessionStatus } from "@zuse/wire";
+import {
+  Message,
+  MessageId,
+  type MessageContent,
+  type Session,
+  type SessionId,
+  type SessionStatus,
+} from "@zuse/wire";
 import {
   ArrowUp01Icon,
   CloudOffIcon,
@@ -8,6 +15,7 @@ import {
   Square01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
+import * as Crypto from "expo-crypto";
 import { useState } from "react";
 import {
   ActivityIndicator,
@@ -29,7 +37,11 @@ import {
 import { isInterruptVisible } from "~/lib/composer-state";
 import { connectionSessionKey } from "~/lib/session-key";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
-import { useMobileMessagesStore } from "~/store/messages";
+import {
+  addOptimisticMessage,
+  removeOptimisticMessage,
+  useMobileMessagesStore,
+} from "~/store/messages";
 import { useOutboxStore } from "~/store/outbox";
 import {
   ComposerModelMenu,
@@ -98,11 +110,33 @@ export const Composer = ({
       return;
     }
     setBusy(true);
+    const messageId = MessageId.make(Crypto.randomUUID());
+    const optimisticContent: MessageContent = {
+      _tag: "user",
+      text: value,
+      goal: false,
+    };
+    addOptimisticMessage(
+      stateKey,
+      Message.make({
+        id: messageId,
+        sessionId,
+        role: "user",
+        content: optimisticContent,
+        createdAt: new Date(),
+      }),
+    );
     try {
       await Effect.runPromise(
-        sendMessage({ connection, sessionId, input: makeTextInput(value) }),
+        sendMessage({
+          connection,
+          sessionId,
+          input: makeTextInput(value),
+          clientMessageId: messageId,
+        }),
       );
     } catch {
+      removeOptimisticMessage(stateKey, messageId);
       // Lost the connection mid-send — keep the text safe in the outbox.
       await enqueue(connKey, sessionId, value);
     } finally {

--- a/apps/mobile/src/rpc/actions.ts
+++ b/apps/mobile/src/rpc/actions.ts
@@ -3,6 +3,7 @@ import type {
   Folder,
   GitBranchInfo,
   GitPrSummary,
+  MessageId,
   PermissionDecision,
   PermissionMode,
   ProviderId,
@@ -30,13 +31,17 @@ export const sendMessage = (options: {
   sessionId: SessionId;
   input: ComposerInput;
   asGoal?: boolean;
+  clientMessageId?: MessageId;
 }) => {
   const program = Effect.gen(function* () {
     const client = yield* getConnectionClient(options.connection);
     const payload = {
       sessionId: options.sessionId,
-      text: options.input.text,
+      input: options.input,
       ...(options.asGoal === undefined ? {} : { asGoal: options.asGoal }),
+      ...(options.clientMessageId === undefined
+        ? {}
+        : { clientMessageId: options.clientMessageId }),
     };
     yield* client.messages.send(payload);
   });

--- a/apps/mobile/src/store/messages.ts
+++ b/apps/mobile/src/store/messages.ts
@@ -130,9 +130,6 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
               void get().flush(connKey, sessionId);
             }),
         ).pipe(
-          Effect.tapError((cause) =>
-            Effect.sync(() => reportConnectionFailure(options, cause)),
-          ),
           Effect.catchAll((cause) =>
             Effect.sync(() => {
               set((state) => ({

--- a/apps/mobile/src/store/messages.ts
+++ b/apps/mobile/src/store/messages.ts
@@ -149,8 +149,7 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
             }),
           ),
         );
-        const fiber = await Effect.runPromise(program.pipe(Effect.fork));
-        liveFibers.set(liveKey, fiber);
+        liveFibers.set(liveKey, Effect.runFork(program));
       } catch (cause) {
         reportConnectionFailure(options, cause);
         set((state) => ({

--- a/apps/mobile/src/store/messages.ts
+++ b/apps/mobile/src/store/messages.ts
@@ -78,15 +78,15 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
           }));
           void get().flush(connKey, sessionId);
         }
-        const sinceSequence = highestSequenceBySession.get(liveKey);
-        console.info("[mobile] messages.stream", { sessionId, sinceSequence });
+        console.info("[mobile] messages.stream", { sessionId });
         const program = Stream.runForEach(
-          client.messages.stream({ sessionId, sinceSequence }),
+          client.messages.stream({ sessionId }),
           (envelope) =>
             Effect.sync(() => {
               const previous = highestSequenceBySession.get(liveKey) ?? 0;
-              if (envelope.sequence <= previous) return;
-              highestSequenceBySession.set(liveKey, envelope.sequence);
+              if (envelope.sequence > previous) {
+                highestSequenceBySession.set(liveKey, envelope.sequence);
+              }
               console.info("[mobile] messages.stream envelope", {
                 sessionId,
                 sequence: envelope.sequence,
@@ -132,6 +132,21 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
         ).pipe(
           Effect.tapError((cause) =>
             Effect.sync(() => reportConnectionFailure(options, cause)),
+          ),
+          Effect.catchAll((cause) =>
+            Effect.sync(() => {
+              set((state) => ({
+                reconnectingBySession: {
+                  ...state.reconnectingBySession,
+                  [liveKey]: true,
+                },
+                errorBySession: {
+                  ...state.errorBySession,
+                  [liveKey]:
+                    cause instanceof Error ? cause.message : String(cause),
+                },
+              }));
+            }),
           ),
         );
         const fiber = await Effect.runPromise(program.pipe(Effect.fork));

--- a/apps/mobile/src/store/messages.ts
+++ b/apps/mobile/src/store/messages.ts
@@ -1,4 +1,4 @@
-import type { Message, SessionId } from "@zuse/wire";
+import type { Message, MessageId, SessionId } from "@zuse/wire";
 import { Effect, Fiber, Stream } from "effect";
 import { AppState } from "react-native";
 import { create } from "zustand";
@@ -22,6 +22,7 @@ type MessagesState = {
 
 const liveFibers = new Map<string, Fiber.RuntimeFiber<unknown, unknown>>();
 const highestSequenceBySession = new Map<string, number>();
+const optimisticIds = new Set<MessageId>();
 let appStateInstalled = false;
 
 const stop = async (key: string) => {
@@ -92,10 +93,31 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
               });
               set((state) => {
                 const current = state.messagesBySession[liveKey] ?? [];
-                if (
-                  current.some((message) => message.id === envelope.message.id)
-                ) {
-                  return state;
+                if (optimisticIds.has(envelope.message.id)) {
+                  optimisticIds.delete(envelope.message.id);
+                  return {
+                    messagesBySession: {
+                      ...state.messagesBySession,
+                      [liveKey]: current.map((message) =>
+                        message.id === envelope.message.id
+                          ? envelope.message
+                          : message,
+                      ),
+                    },
+                  };
+                }
+                const existingIndex = current.findIndex(
+                  (message) => message.id === envelope.message.id,
+                );
+                if (existingIndex !== -1) {
+                  return {
+                    messagesBySession: {
+                      ...state.messagesBySession,
+                      [liveKey]: current.map((message, index) =>
+                        index === existingIndex ? envelope.message : message,
+                      ),
+                    },
+                  };
                 }
                 const next = [...current, envelope.message].slice(-500);
                 return {
@@ -142,6 +164,31 @@ export const useMobileMessagesStore = create<MessagesState>((set, get) => ({
     ).catch(() => {});
   },
 }));
+
+export const addOptimisticMessage = (key: string, message: Message): void => {
+  optimisticIds.add(message.id);
+  useMobileMessagesStore.setState((state) => ({
+    messagesBySession: {
+      ...state.messagesBySession,
+      [key]: [...(state.messagesBySession[key] ?? []), message].slice(-500),
+    },
+  }));
+};
+
+export const removeOptimisticMessage = (
+  key: string,
+  messageId: MessageId,
+): void => {
+  optimisticIds.delete(messageId);
+  useMobileMessagesStore.setState((state) => ({
+    messagesBySession: {
+      ...state.messagesBySession,
+      [key]: (state.messagesBySession[key] ?? []).filter(
+        (message) => message.id !== messageId,
+      ),
+    },
+  }));
+};
 
 const installAppStateFlush = (get: () => MessagesState) => {
   if (appStateInstalled) return;

--- a/apps/mobile/src/store/permissions.ts
+++ b/apps/mobile/src/store/permissions.ts
@@ -81,8 +81,7 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
           Effect.sync(() => reportConnectionFailure(options, cause)),
         ),
       );
-      const fiber = await Effect.runPromise(program.pipe(Effect.fork));
-      liveFibers.set(liveKey, fiber);
+      liveFibers.set(liveKey, Effect.runFork(program));
     } catch (cause) {
       reportConnectionFailure(options, cause);
       // A dropped permission stream is non-fatal: the messages store already

--- a/apps/mobile/src/store/permissions.ts
+++ b/apps/mobile/src/store/permissions.ts
@@ -76,11 +76,7 @@ export const usePermissionsStore = create<PermissionsState>((set, get) => ({
               };
             });
           }),
-      ).pipe(
-        Effect.tapError((cause) =>
-          Effect.sync(() => reportConnectionFailure(options, cause)),
-        ),
-      );
+      ).pipe(Effect.catchAll(() => Effect.void));
       liveFibers.set(liveKey, Effect.runFork(program));
     } catch (cause) {
       reportConnectionFailure(options, cause);

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -248,11 +248,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
                 },
               }));
             }),
-        ).pipe(
-          Effect.tapError((cause) =>
-            Effect.sync(() => reportConnectionFailure(options, cause)),
-          ),
-        );
+        ).pipe(Effect.catchAll(() => Effect.void));
         chatFibers.set(
           `${connKey}:chat:${bundle.project.id}`,
           Effect.runFork(chatProgram),
@@ -274,11 +270,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
                 },
               }));
             }),
-        ).pipe(
-          Effect.tapError((cause) =>
-            Effect.sync(() => reportConnectionFailure(options, cause)),
-          ),
-        );
+        ).pipe(Effect.catchAll(() => Effect.void));
         statusFibers.set(key, Effect.runFork(statusProgram));
       }
     } catch (cause) {

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -234,55 +234,52 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 
       for (const bundle of bundles) {
         await stopFiber(`${connKey}:chat:${bundle.project.id}`, chatFibers);
-        const chatFiber = await Effect.runPromise(
-          Stream.runForEach(
-            client.chat.streamChanges({ projectId: bundle.project.id }),
-            (chat) =>
-              Effect.sync(() => {
-                set((state) => ({
-                  bundlesByConnection: {
-                    ...state.bundlesByConnection,
-                    [connKey]: patchChat(
-                      state.bundlesByConnection[connKey] ?? [],
-                      chat,
-                    ),
-                  },
-                }));
-              }),
-          ).pipe(
-            Effect.tapError((cause) =>
-              Effect.sync(() => reportConnectionFailure(options, cause)),
-            ),
-            Effect.fork,
+        const chatProgram = Stream.runForEach(
+          client.chat.streamChanges({ projectId: bundle.project.id }),
+          (chat) =>
+            Effect.sync(() => {
+              set((state) => ({
+                bundlesByConnection: {
+                  ...state.bundlesByConnection,
+                  [connKey]: patchChat(
+                    state.bundlesByConnection[connKey] ?? [],
+                    chat,
+                  ),
+                },
+              }));
+            }),
+        ).pipe(
+          Effect.tapError((cause) =>
+            Effect.sync(() => reportConnectionFailure(options, cause)),
           ),
         );
-        chatFibers.set(`${connKey}:chat:${bundle.project.id}`, chatFiber);
+        chatFibers.set(
+          `${connKey}:chat:${bundle.project.id}`,
+          Effect.runFork(chatProgram),
+        );
       }
 
       for (const session of bundles.flatMap((b) => b.sessions)) {
         const key = `${connKey}:status:${session.id}`;
         await stopFiber(key, statusFibers);
-        const fiber = await Effect.runPromise(
-          Stream.runForEach(
-            client.session.streamStatus({ sessionId: session.id }),
-            (event) =>
-              Effect.sync(() => {
-                set((state) => ({
-                  statusBySession: {
-                    ...state.statusBySession,
-                    [connectionSessionKey(connKey, event.sessionId)]:
-                      event.status,
-                  },
-                }));
-              }),
-          ).pipe(
-            Effect.tapError((cause) =>
-              Effect.sync(() => reportConnectionFailure(options, cause)),
-            ),
-            Effect.fork,
+        const statusProgram = Stream.runForEach(
+          client.session.streamStatus({ sessionId: session.id }),
+          (event) =>
+            Effect.sync(() => {
+              set((state) => ({
+                statusBySession: {
+                  ...state.statusBySession,
+                  [connectionSessionKey(connKey, event.sessionId)]:
+                    event.status,
+                },
+              }));
+            }),
+        ).pipe(
+          Effect.tapError((cause) =>
+            Effect.sync(() => reportConnectionFailure(options, cause)),
           ),
         );
-        statusFibers.set(key, fiber);
+        statusFibers.set(key, Effect.runFork(statusProgram));
       }
     } catch (cause) {
       reportConnectionFailure(options, cause);

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -183,7 +183,15 @@ const ensureChangeStream = (projectId: FolderId): void => {
               useChatsStore.setState((s) => {
                 const chats = s.chatsByProject[projectId];
                 if (chats === undefined) return s;
-                if (!chats.some((c) => c.id === chat.id)) return s;
+                if (!chats.some((c) => c.id === chat.id)) {
+                  void useSessionsStore.getState().hydrate(projectId);
+                  return {
+                    chatsByProject: {
+                      ...s.chatsByProject,
+                      [projectId]: [chat, ...chats],
+                    },
+                  };
+                }
                 return {
                   chatsByProject: {
                     ...s.chatsByProject,

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -2168,6 +2168,7 @@ export const MessageStoreLive = Layer.scoped(
               ),
             )
           : null;
+        yield* broadcastChat(chat);
         // Path 1: the chat was created WITH its first message (the common
         // composer flow). Kick off the background auto-name when there is
         // enough context (trivial-only greetings wait for a follow-up).


### PR DESCRIPTION
## Summary
- optimistically render mobile user sends with server-reconciled message ids
- broadcast newly created chats over the live chat stream
- let desktop insert externally-created chat rows and refresh sessions without reload

## Verification
- bun run --cwd apps/mobile check-types
- bun run --cwd apps/mobile lint
- bun run --cwd apps/mobile test
- bun run --cwd apps/renderer check-types
- bun run --cwd apps/server check-types
- git diff --check