### PR TITLE
Fix mobile relay and queued sends

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,6 +14,8 @@ import { useEffect } from "react";
 import { View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 
+import { CrashReportOverlay } from "~/components/crash-report-overlay";
+import { installCrashReporting } from "~/lib/crash-reporting";
 import { installNotificationResponseHandler } from "~/notifications/push";
 
 const BG = "hsl(72 5% 6%)";
@@ -28,7 +30,10 @@ export default function RootLayout() {
     GeistMono_400Regular,
   });
 
-  useEffect(() => installNotificationResponseHandler(), []);
+  useEffect(() => {
+    installCrashReporting();
+    return installNotificationResponseHandler();
+  }, []);
 
   if (!fontsLoaded) {
     return <View className="flex-1 bg-background" />;
@@ -115,6 +120,7 @@ export default function RootLayout() {
           options={{ title: "Smoke", headerLargeTitle: false }}
         />
       </Stack>
+      <CrashReportOverlay />
     </GestureHandlerRootView>
   );
 }

--- a/apps/mobile/app/c/[conn]/index.tsx
+++ b/apps/mobile/app/c/[conn]/index.tsx
@@ -14,7 +14,6 @@ import { visibleConnectionLabel } from "~/lib/display-names";
 import { connectionSessionKey } from "~/lib/session-key";
 import { useConnectionsStore } from "~/store/connections";
 import {
-  connectionStatusLabel,
   useConnectionRuntimeStore,
 } from "~/store/connection-runtime";
 import { isUnread, useSessionsStore } from "~/store/sessions";
@@ -110,11 +109,11 @@ export default function SessionsScreen() {
             {errorByConnection[connKey]}
           </Text>
         ) : null}
-        {connectionSnapshot?.status !== undefined &&
-        connectionSnapshot.status !== "connected" ? (
-          <Text className="px-4 font-sans text-[13px] text-warning">
-            {connectionStatusLabel(connectionSnapshot)}
-            {connectionSnapshot.error ? `: ${connectionSnapshot.error}` : ""}
+        {(connectionSnapshot?.status === "blockedAuth" ||
+          connectionSnapshot?.status === "error") &&
+        connectionSnapshot.error ? (
+          <Text selectable className="px-4 font-sans text-[13px] text-danger">
+            {connectionSnapshot.error}
           </Text>
         ) : null}
 

--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { FlatList, KeyboardAvoidingView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -20,6 +20,7 @@ import { answerQuestion } from "~/rpc/actions";
 import { isFreshChat } from "~/lib/composer-state";
 import { messageKey, sanitizeMessages } from "~/lib/message-safety";
 import { buildToolResultsByItemId } from "~/lib/message-presentation";
+import { captureMobileError } from "~/lib/crash-reporting";
 import { useConnectionsStore } from "~/store/connections";
 import { useConnectionRuntimeStore } from "~/store/connection-runtime";
 import { selectSessionChat, useSessionsStore } from "~/store/sessions";
@@ -40,7 +41,15 @@ const EMPTY_MESSAGES: ReturnType<
   typeof useMobileMessagesStore.getState
 >["messagesBySession"][string] = [];
 
-export default function ThreadScreen() {
+export default function ThreadScreenRoute() {
+  return (
+    <ThreadScreenBoundary>
+      <ThreadScreen />
+    </ThreadScreenBoundary>
+  );
+}
+
+function ThreadScreen() {
   const insets = useSafeAreaInsets();
   const { conn, sessionId } = useLocalSearchParams<{
     conn: string;
@@ -304,6 +313,40 @@ export default function ThreadScreen() {
       )}
     </KeyboardAvoidingView>
   );
+}
+
+class ThreadScreenBoundary extends React.Component<
+  { readonly children: React.ReactNode },
+  { readonly failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { readonly failed: boolean } {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo): void {
+    void captureMobileError(error, {
+      context: "thread-screen",
+      componentStack: info.componentStack ?? undefined,
+    });
+  }
+
+  render() {
+    if (this.state.failed) {
+      return (
+        <View className="flex-1 items-center justify-center bg-background px-5">
+          <Text className="font-sans-medium text-base text-foreground">
+            This chat could not be opened.
+          </Text>
+          <Text className="mt-2 text-center font-sans text-sm leading-5 text-muted-foreground">
+            The crash report is saved and will stay visible after restart.
+          </Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
 }
 
 const QueuedBubble = ({ text }: { text: string }) => (

--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -18,6 +18,7 @@ import {
 import { connectionSessionKey } from "~/lib/session-key";
 import { answerQuestion } from "~/rpc/actions";
 import { isFreshChat } from "~/lib/composer-state";
+import { messageKey, sanitizeMessages } from "~/lib/message-safety";
 import { buildToolResultsByItemId } from "~/lib/message-presentation";
 import { useConnectionsStore } from "~/store/connections";
 import { useConnectionRuntimeStore } from "~/store/connection-runtime";
@@ -68,7 +69,8 @@ export default function ThreadScreen() {
     (state) => state.bundlesByConnection[connKey] ?? EMPTY_BUNDLES,
   );
   const { messagesBySession, errorBySession, hydrate } = useMobileMessagesStore();
-  const messages = messagesBySession[stateKey] ?? EMPTY_MESSAGES;
+  const rawMessages = messagesBySession[stateKey] ?? EMPTY_MESSAGES;
+  const messages = useMemo(() => sanitizeMessages(rawMessages), [rawMessages]);
   const detail = selectSessionChat(bundles, normalizedSessionId);
   const title = detail?.chat?.title ?? detail?.session.title ?? "Thread";
   const sessionStatus =
@@ -234,7 +236,7 @@ export default function ThreadScreen() {
       <FlatList
         ref={listRef}
         data={messages}
-        keyExtractor={(message) => message.id}
+        keyExtractor={messageKey}
         renderItem={({ item }) => <MessageRow message={item} ctx={ctx} />}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerClassName="gap-1 px-4 py-3"

--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -20,10 +20,7 @@ import { answerQuestion } from "~/rpc/actions";
 import { isFreshChat } from "~/lib/composer-state";
 import { buildToolResultsByItemId } from "~/lib/message-presentation";
 import { useConnectionsStore } from "~/store/connections";
-import {
-  connectionStatusLabel,
-  useConnectionRuntimeStore,
-} from "~/store/connection-runtime";
+import { useConnectionRuntimeStore } from "~/store/connection-runtime";
 import { selectSessionChat, useSessionsStore } from "~/store/sessions";
 import { useMobileMessagesStore } from "~/store/messages";
 import { useOutboxStore } from "~/store/outbox";
@@ -70,8 +67,7 @@ export default function ThreadScreen() {
   const bundles = useSessionsStore(
     (state) => state.bundlesByConnection[connKey] ?? EMPTY_BUNDLES,
   );
-  const { messagesBySession, reconnectingBySession, errorBySession, hydrate } =
-    useMobileMessagesStore();
+  const { messagesBySession, errorBySession, hydrate } = useMobileMessagesStore();
   const messages = messagesBySession[stateKey] ?? EMPTY_MESSAGES;
   const detail = selectSessionChat(bundles, normalizedSessionId);
   const title = detail?.chat?.title ?? detail?.session.title ?? "Thread";
@@ -117,9 +113,14 @@ export default function ThreadScreen() {
     options,
   ]);
 
-  const reconnecting = reconnectingBySession[stateKey];
   const error = errorBySession[stateKey];
   const transportOnline = connectionSnapshot?.status === "connected";
+  const connectionProblem =
+    connectionSnapshot?.status === "blockedAuth" ||
+    connectionSnapshot?.status === "offline" ||
+    connectionSnapshot?.status === "error"
+      ? connectionSnapshot.error
+      : null;
 
   // Drain the outbox in order while the transport is online. This runs both
   // when the connection wakes and when an item gets queued after a failed send.
@@ -238,21 +239,11 @@ export default function ThreadScreen() {
         contentInsetAdjustmentBehavior="automatic"
         contentContainerClassName="gap-1 px-4 py-3"
         ListHeaderComponent={
-          reconnecting ||
-          error ||
-          connectionSnapshot?.status !== "connected" ? (
+          error || connectionProblem ? (
             <View className="pb-2">
-              {connectionSnapshot?.status !== "connected" ? (
-                <Text className="font-sans text-[13px] text-warning">
-                  {connectionStatusLabel(connectionSnapshot)}
-                  {connectionSnapshot?.error
-                    ? `: ${connectionSnapshot.error}`
-                    : ""}
-                </Text>
-              ) : null}
-              {reconnecting ? (
-                <Text className="font-sans text-[13px] text-warning">
-                  Reconnecting…
+              {connectionProblem ? (
+                <Text selectable className="font-sans text-[13px] text-danger">
+                  {connectionProblem}
                 </Text>
               ) : null}
               {error ? (

--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -90,6 +90,7 @@ export default function ThreadScreen() {
   const queued = useOutboxStore(
     (state) => state.queuedBySession[stateKey] ?? EMPTY_QUEUED,
   );
+  const queuedCount = queued.length;
 
   useEffect(() => {
     if (!hydrated) void hydrateConnections();
@@ -120,12 +121,36 @@ export default function ThreadScreen() {
   const error = errorBySession[stateKey];
   const transportOnline = connectionSnapshot?.status === "connected";
 
-  // Drain the outbox in order the moment the session is back online.
+  // Drain the outbox in order while the transport is online. This runs both
+  // when the connection wakes and when an item gets queued after a failed send.
   useEffect(() => {
-    if (transportOnline && normalizedSessionId.length > 0 && options !== null) {
-      void flushOutbox(connKey, options, normalizedSessionId);
+    if (
+      !transportOnline ||
+      normalizedSessionId.length === 0 ||
+      options === null ||
+      queuedCount === 0
+    ) {
+      return;
     }
-  }, [connKey, flushOutbox, normalizedSessionId, transportOnline, options]);
+    let cancelled = false;
+    const run = () => {
+      if (cancelled) return;
+      void flushOutbox(connKey, options, normalizedSessionId);
+    };
+    run();
+    const timer = setInterval(run, 2_000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [
+    connKey,
+    flushOutbox,
+    normalizedSessionId,
+    transportOnline,
+    options,
+    queuedCount,
+  ]);
 
   // Cross-reference question rows so answered prompts collapse and the answer
   // row can resolve selected option labels.

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -45,7 +45,6 @@ import { branchStatePresentation } from "~/lib/pr-state-presentation";
 import { selectionTap, successTap } from "~/lib/haptics";
 import { useAuthStore } from "~/store/auth";
 import {
-  connectionStatusLabel,
   useConnectionRuntimeStore,
 } from "~/store/connection-runtime";
 import { useConnectionsStore } from "~/store/connections";
@@ -509,11 +508,7 @@ function InboxItem({
     );
   }
 
-  const snapshot = snapshots[item.row.connectionKey];
-  const statusLabel =
-    snapshot?.status !== undefined && snapshot.status !== "connected"
-      ? connectionStatusLabel(snapshot)
-      : item.row.status;
+  const statusLabel = item.row.status;
   const href =
     `/c/${encodeURIComponent(item.row.connectionKey)}/session/${encodeURIComponent(
       item.row.session.id,

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -28,6 +28,8 @@ import {
 import {
   interruptSession,
   makeTextInput,
+  flushServerQueue,
+  queueMessage,
   sendMessage,
   setSessionModel,
   setSessionPermissionMode,
@@ -81,6 +83,12 @@ export const Composer = ({
   const queuedCount = useOutboxStore(
     (state) => (state.queuedBySession[stateKey] ?? []).length,
   );
+  const queueSending = useOutboxStore(
+    (state) => state.sendingBySession[stateKey] === true,
+  );
+  const queueError = useOutboxStore(
+    (state) => state.errorBySession[stateKey],
+  );
   const enqueue = useOutboxStore((state) => state.enqueue);
 
   const canSend = text.trim().length > 0 && !busy;
@@ -104,6 +112,23 @@ export const Composer = ({
       return;
     }
     setBusy(true);
+    if (showInterrupt) {
+      try {
+        await Effect.runPromise(
+          queueMessage({
+            connection,
+            sessionId,
+            input: makeTextInput(value),
+          }),
+        );
+        await Effect.runPromise(flushServerQueue({ connection, sessionId }));
+      } catch {
+        await enqueue(connKey, sessionId, value);
+      } finally {
+        setBusy(false);
+      }
+      return;
+    }
     const messageId = MessageId.make(Crypto.randomUUID());
     const optimisticContent: MessageContent = {
       _tag: "user",
@@ -198,7 +223,11 @@ export const Composer = ({
           <HugeIcon icon={CloudOffIcon} size={13} color="hsl(42 93% 56%)" />
           <Text className="font-sans-medium text-xs text-warning">
             {queuedCount} queued ·{" "}
-            {online ? "sending…" : "will send when reconnected"}
+            {online
+              ? queueSending
+                ? "sending…"
+                : queueError ?? "ready to send"
+              : "will send when reconnected"}
           </Text>
         </View>
       ) : null}

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -121,12 +121,24 @@ export const Composer = ({
             input: makeTextInput(value),
           }),
         );
-        await Effect.runPromise(flushServerQueue({ connection, sessionId }));
-      } catch {
+      } catch (cause) {
+        console.warn("[mobile] composer.queue_add_failed", {
+          sessionId,
+          reason: messageOf(cause),
+        });
         await enqueue(connKey, sessionId, value);
-      } finally {
         setBusy(false);
+        return;
       }
+      await Effect.runPromise(flushServerQueue({ connection, sessionId })).catch(
+        (cause) => {
+          console.warn("[mobile] composer.queue_flush_failed", {
+            sessionId,
+            reason: messageOf(cause),
+          });
+        },
+      );
+      setBusy(false);
       return;
     }
     const messageId = MessageId.make(Crypto.randomUUID());
@@ -311,6 +323,9 @@ export const Composer = ({
     </View>
   );
 };
+
+const messageOf = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
 
 const ChromeLabel = ({
   icon,

--- a/apps/mobile/src/components/crash-report-overlay.tsx
+++ b/apps/mobile/src/components/crash-report-overlay.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  clearLastCrashReport,
+  readLastCrashReport,
+  type CrashReport,
+} from "~/lib/crash-reporting";
+
+export const CrashReportOverlay = () => {
+  const insets = useSafeAreaInsets();
+  const [report, setReport] = useState<CrashReport | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void readLastCrashReport().then((next) => {
+      if (!cancelled) {
+        setReport(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (report === null) {
+    return null;
+  }
+
+  return (
+    <View
+      pointerEvents="box-none"
+      className="absolute left-0 right-0 z-50 px-3"
+      style={{ top: insets.top + 8 }}
+    >
+      <View
+        className="rounded-2xl border border-danger/35 bg-background/95 px-3 py-2 shadow-xl"
+        style={{ borderCurve: "continuous" }}
+      >
+        <View className="flex-row items-center gap-2">
+          <Text className="font-sans-medium text-xs text-danger">
+            Last crash
+          </Text>
+          <Text
+            className="min-w-0 flex-1 font-sans text-[11px] text-muted-foreground"
+            numberOfLines={1}
+          >
+            {report.context} · {new Date(report.at).toLocaleTimeString()}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => {
+              setReport(null);
+              void clearLastCrashReport();
+            }}
+            className="rounded-full bg-muted px-2 py-1 active:opacity-75"
+          >
+            <Text className="font-sans-medium text-[11px] text-foreground">
+              Dismiss
+            </Text>
+          </Pressable>
+        </View>
+        <Text
+          selectable
+          className="mt-1 font-sans text-xs leading-4 text-foreground"
+          numberOfLines={3}
+        >
+          {report.message}
+        </Text>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/src/components/messages/markdown.tsx
+++ b/apps/mobile/src/components/messages/markdown.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { StyleSheet } from "react-native";
+import { StyleSheet, Text } from "react-native";
 import MarkdownDisplay from "react-native-markdown-display";
 
 import { colors } from "~/theme";
@@ -82,7 +82,40 @@ const markdownStyles = StyleSheet.create({
  * Memoized because assistant text is immutable once streamed.
  */
 export const Markdown = memo(({ children }: { children: string }) => (
-  <MarkdownDisplay style={markdownStyles}>{children}</MarkdownDisplay>
+  shouldRenderPlainText(children) ? (
+    <Text selectable style={plainTextStyle}>
+      {children}
+    </Text>
+  ) : (
+    <MarkdownDisplay style={markdownStyles}>{children}</MarkdownDisplay>
+  )
 ));
 
 Markdown.displayName = "Markdown";
+
+const plainTextStyle = {
+  color: colors.fg,
+  fontFamily: SANS,
+  fontSize: 15,
+  lineHeight: 22,
+} as const;
+
+const shouldRenderPlainText = (value: string): boolean =>
+  value.length > 32_000 || hasLargeHtmlBlock(value) || hasVeryWideTable(value);
+
+const hasLargeHtmlBlock = (value: string): boolean =>
+  /<\/?(html|body|script|style|table|details|summary)(\s|>)/i.test(value);
+
+const hasVeryWideTable = (value: string): boolean => {
+  const lines = value.split(/\r\n|\r|\n/);
+  let tableLike = 0;
+  for (const line of lines) {
+    if ((line.match(/\|/g)?.length ?? 0) >= 8) {
+      tableLike += 1;
+      if (tableLike >= 6) {
+        return true;
+      }
+    }
+  }
+  return false;
+};

--- a/apps/mobile/src/components/messages/message-row.tsx
+++ b/apps/mobile/src/components/messages/message-row.tsx
@@ -1,6 +1,7 @@
 import type { Message, MessageContent, UserQuestion } from "@zuse/wire";
 import { router } from "expo-router";
 import {
+  AlertCircle,
   Bot,
   Brain,
   Camera,
@@ -11,6 +12,7 @@ import {
   FilePenLine,
   Folder,
   Globe,
+  Hourglass,
   Search,
   Terminal,
   Wrench,
@@ -117,6 +119,17 @@ const MessageRowContent = ({
       );
     case "error":
       return <ErrorRow message={content.message} />;
+    case "usage_limit":
+      return <UsageLimitRow content={content} />;
+    case "interrupted":
+      return <InlineSystemRow label="Interrupted by user" />;
+    case "context_compaction":
+      return <ContextCompactionRow content={content} />;
+    case "subagent_summary":
+      return <SubagentSummaryRow content={content} />;
+    case "usage":
+    case "context_usage":
+      return null;
     case "user_question":
       return ctx.answeredQuestionIds.has(content.itemId) ? (
         <AnsweredQuestion questions={content.questions} />
@@ -358,6 +371,107 @@ const ErrorRow = ({ message }: { message: string }) => (
   </View>
 );
 
+const UsageLimitRow = ({
+  content,
+}: {
+  content: Extract<MessageContent, { _tag: "usage_limit" }>;
+}) => {
+  const reset = formatResetTime(content.resetsAt);
+  const detail =
+    reset !== null
+      ? `${content.label} · resets ${reset}`
+      : content.label.length > 0
+        ? content.label
+        : "This provider has reached its current usage window.";
+
+  return (
+    <View className="px-2 py-1.5">
+      <View
+        style={{ borderCurve: "continuous" }}
+        className="rounded-2xl border border-primary/25 bg-primary/10 px-3 py-2.5"
+      >
+        <View className="flex-row items-center gap-2">
+          <AlertCircle size={15} color="hsl(72 98% 54%)" />
+          <Text className="font-sans-medium text-sm text-foreground">
+            Limit reached
+          </Text>
+          {typeof content.usedPercent === "number" ? (
+            <Text className="ml-auto rounded-full bg-primary/15 px-2 py-0.5 font-sans-medium text-[11px] text-primary">
+              {Math.round(content.usedPercent)}%
+            </Text>
+          ) : null}
+        </View>
+        <Text
+          className="mt-1 font-sans text-[13px] leading-5 text-muted-foreground"
+          numberOfLines={2}
+        >
+          {detail}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const InlineSystemRow = ({ label }: { label: string }) => (
+  <View className="items-center px-2 py-1">
+    <Text className="rounded-full bg-muted px-2.5 py-1 font-sans text-[11px] text-muted-foreground">
+      {label}
+    </Text>
+  </View>
+);
+
+const ContextCompactionRow = ({
+  content,
+}: {
+  content: Extract<MessageContent, { _tag: "context_compaction" }>;
+}) => {
+  const before = formatTokens(content.beforeTokens);
+  const after = formatTokens(content.afterTokens);
+  const detail =
+    before !== null && after !== null
+      ? `${before} to ${after}`
+      : content.status === "in_progress"
+        ? "Compacting context"
+        : "Context compacted";
+
+  return (
+    <ExpandableEventRow
+      icon="hourglass"
+      title={
+        content.status === "in_progress" ? "Compacting context" : "Compacted"
+      }
+      detail={detail}
+      badge={formatDuration(content.durationMs)}
+    >
+      <Text className="font-sans text-sm leading-5 text-muted-foreground">
+        {before !== null && after !== null
+          ? `Context changed from ${before} to ${after}.`
+          : "The conversation context was compacted for the next turn."}
+      </Text>
+    </ExpandableEventRow>
+  );
+};
+
+const SubagentSummaryRow = ({
+  content,
+}: {
+  content: Extract<MessageContent, { _tag: "subagent_summary" }>;
+}) => (
+  <ExpandableEventRow
+    icon="agent"
+    title={content.isError ? `${content.agentName} failed` : content.agentName}
+    detail={`${content.turns} ${content.turns === 1 ? "turn" : "turns"} · ${formatDuration(content.durationMs)}`}
+    danger={content.isError}
+  >
+    <Text
+      selectable
+      className="font-sans text-sm leading-5 text-muted-foreground"
+    >
+      {content.summary}
+    </Text>
+  </ExpandableEventRow>
+);
+
 const AnsweredQuestion = ({
   questions,
 }: {
@@ -428,7 +542,7 @@ const FallbackRow = ({ content }: { content: MessageContent }) => (
         className="mt-1 font-mono text-xs leading-5 text-muted-foreground"
         numberOfLines={4}
       >
-        {summarizeValue(content)}
+        {safeSummary(content)}
       </Text>
     </View>
   </View>
@@ -452,7 +566,7 @@ function ExpandableEventRow({
   detail?: string;
   badge?: string;
   danger?: boolean;
-  icon: "thinking" | MobileToolIcon;
+  icon: "thinking" | "hourglass" | MobileToolIcon;
   children: React.ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -512,12 +626,14 @@ function ExpandableEventRow({
 }
 
 const renderToolRowIcon = (
-  icon: "thinking" | MobileToolIcon,
+  icon: "thinking" | "hourglass" | MobileToolIcon,
   color: string,
 ) => {
   switch (icon) {
     case "thinking":
       return <Brain size={14} color={color} />;
+    case "hourglass":
+      return <Hourglass size={14} color={color} />;
     case "terminal":
       return <Terminal size={14} color={color} />;
     case "file":
@@ -540,6 +656,53 @@ const renderToolRowIcon = (
       return <Wrench size={14} color={color} />;
   }
 };
+
+function formatResetTime(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZoneName: "short",
+    }).format(date);
+  } catch {
+    return date.toLocaleTimeString();
+  }
+}
+
+function formatTokens(value: number | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  if (value >= 1000) {
+    return `${Math.round(value / 100) / 10}k tokens`;
+  }
+  return `${value} tokens`;
+}
+
+function formatDuration(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) {
+    return "now";
+  }
+  if (durationMs < 1000) {
+    return `${Math.round(durationMs)}ms`;
+  }
+  return `${Math.round(durationMs / 1000)}s`;
+}
+
+function safeSummary(value: unknown): string {
+  try {
+    return summarizeValue(value);
+  } catch {
+    return "Unsupported message payload";
+  }
+}
 
 const firstLine = (value: string): string => {
   const line = value.trim().split(/\r\n|\r|\n/)[0] ?? "";

--- a/apps/mobile/src/components/messages/message-row.tsx
+++ b/apps/mobile/src/components/messages/message-row.tsx
@@ -15,8 +15,7 @@ import {
   Terminal,
   Wrench,
 } from "lucide-react-native";
-import type React from "react";
-import { useState } from "react";
+import React, { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 
 import { cn } from "~/lib/cn";
@@ -48,6 +47,36 @@ export type MessageRowContext = {
 };
 
 export const MessageRow = ({
+  message,
+  ctx,
+}: {
+  message: Message;
+  ctx: MessageRowContext;
+}) => (
+  <MessageRowBoundary>
+    <MessageRowContent message={message} ctx={ctx} />
+  </MessageRowBoundary>
+);
+
+class MessageRowBoundary extends React.Component<
+  { readonly children: React.ReactNode },
+  { readonly failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { readonly failed: boolean } {
+    return { failed: true };
+  }
+
+  render() {
+    if (this.state.failed) {
+      return <ErrorRow message="This message could not be rendered." />;
+    }
+    return this.props.children;
+  }
+}
+
+const MessageRowContent = ({
   message,
   ctx,
 }: {

--- a/apps/mobile/src/components/messages/message-row.tsx
+++ b/apps/mobile/src/components/messages/message-row.tsx
@@ -25,6 +25,7 @@ import {
   summarizeValue,
   type ToolResultRecord,
 } from "~/lib/message-presentation";
+import { captureMobileError } from "~/lib/crash-reporting";
 import {
   buildToolPresentation,
   type MobileToolIcon,
@@ -55,19 +56,28 @@ export const MessageRow = ({
   message: Message;
   ctx: MessageRowContext;
 }) => (
-  <MessageRowBoundary>
+  <MessageRowBoundary
+    context={`message-row:${message.id}:${message.content._tag}`}
+  >
     <MessageRowContent message={message} ctx={ctx} />
   </MessageRowBoundary>
 );
 
 class MessageRowBoundary extends React.Component<
-  { readonly children: React.ReactNode },
+  { readonly children: React.ReactNode; readonly context: string },
   { readonly failed: boolean }
 > {
   state = { failed: false };
 
   static getDerivedStateFromError(): { readonly failed: boolean } {
     return { failed: true };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo): void {
+    void captureMobileError(error, {
+      context: this.props.context,
+      componentStack: info.componentStack ?? undefined,
+    });
   }
 
   render() {

--- a/apps/mobile/src/lib/crash-reporting.ts
+++ b/apps/mobile/src/lib/crash-reporting.ts
@@ -1,0 +1,99 @@
+import * as FileSystem from "expo-file-system/legacy";
+
+export type CrashReport = {
+  readonly id: string;
+  readonly at: string;
+  readonly context: string;
+  readonly message: string;
+  readonly stack?: string;
+  readonly componentStack?: string;
+};
+
+const PATH = `${FileSystem.documentDirectory ?? ""}zuse-last-crash.json`;
+let installed = false;
+
+type NativeErrorUtils = {
+  readonly getGlobalHandler?: () => (error: unknown, isFatal?: boolean) => void;
+  readonly setGlobalHandler?: (
+    handler: (error: unknown, isFatal?: boolean) => void,
+  ) => void;
+};
+
+const errorUtils = (): NativeErrorUtils | undefined =>
+  (globalThis as unknown as { readonly ErrorUtils?: NativeErrorUtils })
+    .ErrorUtils;
+
+export const installCrashReporting = (): void => {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  const utils = errorUtils();
+  const previous = utils?.getGlobalHandler?.();
+  utils?.setGlobalHandler?.((error, isFatal) => {
+    void captureMobileError(error, {
+      context: isFatal === true ? "fatal-js" : "global-js",
+    });
+    previous?.(error, isFatal);
+  });
+};
+
+export const captureMobileError = async (
+  error: unknown,
+  input: { readonly context: string; readonly componentStack?: string },
+): Promise<void> => {
+  const report = buildReport(error, input);
+  console.error("[mobile:crash]", report);
+  try {
+    await FileSystem.writeAsStringAsync(PATH, JSON.stringify(report, null, 2));
+  } catch {
+    // Crash reporting must never become another crash source.
+  }
+};
+
+export const readLastCrashReport = async (): Promise<CrashReport | null> => {
+  try {
+    const info = await FileSystem.getInfoAsync(PATH);
+    if (!info.exists) {
+      return null;
+    }
+    return JSON.parse(await FileSystem.readAsStringAsync(PATH)) as CrashReport;
+  } catch {
+    return null;
+  }
+};
+
+export const clearLastCrashReport = async (): Promise<void> => {
+  try {
+    await FileSystem.deleteAsync(PATH, { idempotent: true });
+  } catch {
+    // Best effort.
+  }
+};
+
+const buildReport = (
+  error: unknown,
+  input: { readonly context: string; readonly componentStack?: string },
+): CrashReport => {
+  const err =
+    error instanceof Error
+      ? error
+      : new Error(typeof error === "string" ? error : safeString(error));
+  return {
+    id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    at: new Date().toISOString(),
+    context: input.context,
+    message: err.message,
+    stack: err.stack,
+    componentStack: input.componentStack,
+  };
+};
+
+const safeString = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};

--- a/apps/mobile/src/lib/message-safety.test.ts
+++ b/apps/mobile/src/lib/message-safety.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import type { Message } from "@zuse/wire";
+
+import { messageKey, sanitizeMessages } from "./message-safety";
+
+describe("mobile message safety", () => {
+  test("keeps known renderable messages", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        sessionId: "session-1",
+        role: "assistant",
+        content: { _tag: "assistant", text: "hello" },
+        createdAt: new Date(),
+      },
+      {
+        id: "msg-2",
+        sessionId: "session-1",
+        role: "assistant",
+        content: {
+          _tag: "usage_limit",
+          providerId: "provider",
+          label: "Limit reached",
+          usedPercent: null,
+          resetsAt: null,
+          windowMinutes: null,
+        },
+        createdAt: new Date(),
+      },
+    ] as readonly Message[];
+
+    expect(sanitizeMessages(messages).map((message) => message.id)).toEqual([
+      "msg-1",
+      "msg-2",
+    ]);
+  });
+
+  test("drops malformed rows before chat render logic", () => {
+    const messages = [
+      {
+        id: "msg-good",
+        sessionId: "session-1",
+        role: "assistant",
+        content: { _tag: "assistant", text: "ok" },
+        createdAt: new Date(),
+      },
+      {
+        id: "msg-bad",
+        sessionId: "session-1",
+        role: "assistant",
+        content: { _tag: "assistant", text: { nested: true } },
+        createdAt: new Date(),
+      },
+      {
+        id: "",
+        sessionId: "session-1",
+        role: "assistant",
+        content: { _tag: "error", message: "bad id" },
+        createdAt: new Date(),
+      },
+      {
+        id: "msg-unknown",
+        sessionId: "session-1",
+        role: "assistant",
+        content: { _tag: "future_tag", value: "later" },
+        createdAt: new Date(),
+      },
+    ] as unknown as readonly Message[];
+
+    expect(sanitizeMessages(messages).map((message) => message.id)).toEqual([
+      "msg-good",
+    ]);
+  });
+
+  test("falls back to stable list key when needed", () => {
+    const message = { id: "" } as Message;
+    expect(messageKey(message, 3)).toBe("message-3");
+  });
+});

--- a/apps/mobile/src/lib/message-safety.ts
+++ b/apps/mobile/src/lib/message-safety.ts
@@ -1,0 +1,84 @@
+import type { Message } from "@zuse/wire";
+
+export const sanitizeMessages = (
+  messages: readonly Message[],
+): readonly Message[] => messages.filter(isRenderableMessage);
+
+export const messageKey = (message: Message, index: number): string =>
+  typeof message.id === "string" && message.id.length > 0
+    ? message.id
+    : `message-${index}`;
+
+const isRenderableMessage = (value: unknown): value is Message => {
+  if (!isRecord(value) || !isNonEmptyString(value.id)) {
+    return false;
+  }
+  const content = value.content;
+  if (!isRecord(content) || typeof content._tag !== "string") {
+    return false;
+  }
+
+  switch (content._tag) {
+    case "user":
+    case "assistant":
+      return typeof content.text === "string";
+    case "user_rich":
+      return (
+        typeof content.text === "string" &&
+        Array.isArray(content.attachments) &&
+        Array.isArray(content.fileRefs) &&
+        Array.isArray(content.skillRefs)
+      );
+    case "thinking":
+      return typeof content.text === "string" && typeof content.redacted === "boolean";
+    case "tool_use":
+      return isNonEmptyString(content.itemId) && typeof content.tool === "string";
+    case "tool_result":
+      return isNonEmptyString(content.itemId) && typeof content.isError === "boolean";
+    case "error":
+      return typeof content.message === "string";
+    case "interrupted":
+      return true;
+    case "subagent_summary":
+      return (
+        isNonEmptyString(content.itemId) &&
+        typeof content.agentName === "string" &&
+        typeof content.model === "string" &&
+        typeof content.turns === "number" &&
+        typeof content.durationMs === "number" &&
+        typeof content.summary === "string" &&
+        typeof content.isError === "boolean"
+      );
+    case "usage":
+      return (
+        typeof content.inputTokens === "number" &&
+        typeof content.outputTokens === "number" &&
+        typeof content.cacheReadTokens === "number" &&
+        typeof content.cacheCreationTokens === "number" &&
+        typeof content.model === "string"
+      );
+    case "context_usage":
+      return typeof content.providerId === "string";
+    case "context_compaction":
+      return (
+        isNonEmptyString(content.itemId) &&
+        typeof content.providerId === "string" &&
+        typeof content.startedAt === "number" &&
+        typeof content.durationMs === "number"
+      );
+    case "usage_limit":
+      return typeof content.providerId === "string" && typeof content.label === "string";
+    case "user_question":
+      return isNonEmptyString(content.itemId) && Array.isArray(content.questions);
+    case "user_question_answer":
+      return isNonEmptyString(content.itemId) && Array.isArray(content.answers);
+    default:
+      return false;
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object";
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0;

--- a/apps/mobile/src/rpc/actions.ts
+++ b/apps/mobile/src/rpc/actions.ts
@@ -1,5 +1,6 @@
-import type {
+import {
   ComposerInput,
+  type ComposerInput as ComposerInputType,
   Folder,
   GitBranchInfo,
   GitPrSummary,
@@ -18,18 +19,19 @@ import { Effect } from "effect";
 import { getConnectionClient, reportConnectionFailure } from "./connection";
 import type { WsProtocolOptions } from "./ws-protocol";
 
-export const makeTextInput = (text: string): ComposerInput => ({
-  text,
-  attachments: [],
-  fileRefs: [],
-  skillRefs: [],
-  annotations: [],
-});
+export const makeTextInput = (text: string): ComposerInputType =>
+  ComposerInput.make({
+    text,
+    attachments: [],
+    fileRefs: [],
+    skillRefs: [],
+    annotations: [],
+  });
 
 export const sendMessage = (options: {
   connection: WsProtocolOptions;
   sessionId: SessionId;
-  input: ComposerInput;
+  input: ComposerInputType;
   asGoal?: boolean;
   clientMessageId?: MessageId;
 }) => {
@@ -55,7 +57,7 @@ export const sendMessage = (options: {
 export const queueMessage = (options: {
   connection: WsProtocolOptions;
   sessionId: SessionId;
-  input: ComposerInput;
+  input: ComposerInputType;
 }) => {
   const program = Effect.gen(function* () {
     const client = yield* getConnectionClient(options.connection);

--- a/apps/mobile/src/rpc/actions.ts
+++ b/apps/mobile/src/rpc/actions.ts
@@ -52,6 +52,40 @@ export const sendMessage = (options: {
   );
 };
 
+export const queueMessage = (options: {
+  connection: WsProtocolOptions;
+  sessionId: SessionId;
+  input: ComposerInput;
+}) => {
+  const program = Effect.gen(function* () {
+    const client = yield* getConnectionClient(options.connection);
+    yield* client.messages["queue.add"]({
+      sessionId: options.sessionId,
+      input: options.input,
+    });
+  });
+  return program.pipe(
+    Effect.tapError((cause) =>
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
+  );
+};
+
+export const flushServerQueue = (options: {
+  connection: WsProtocolOptions;
+  sessionId: SessionId;
+}) => {
+  const program = Effect.gen(function* () {
+    const client = yield* getConnectionClient(options.connection);
+    yield* client.messages["queue.flush"]({ sessionId: options.sessionId });
+  });
+  return program.pipe(
+    Effect.tapError((cause) =>
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
+  );
+};
+
 export const interruptSession = (options: {
   connection: WsProtocolOptions;
   sessionId: SessionId;

--- a/apps/mobile/src/rpc/connection-supervisor.test.ts
+++ b/apps/mobile/src/rpc/connection-supervisor.test.ts
@@ -147,6 +147,30 @@ describe("connection supervisor", () => {
     expect(entry.snapshot().status).toBe("connected");
   });
 
+  test("treats relay server errors as transient", async () => {
+    let failures = 1;
+    const harness = makeHarness({
+      createClient: async () => {
+        if (failures > 0) {
+          failures -= 1;
+          throw new Error("relay_connect_500:temporarily unavailable");
+        }
+        return { client: makeClient(), dispose: async () => {} };
+      },
+    });
+    const entry = harness.watch({ host: "relay.test", port: 443 });
+
+    await expect(Effect.runPromise(entry.getClient())).rejects.toThrow(
+      "relay_connect_500",
+    );
+    expect(entry.snapshot().status).toBe("reconnecting");
+    expect(harness.scheduled).toHaveLength(1);
+
+    harness.scheduled[0]?.fn();
+    await Effect.runPromise(entry.getClient());
+    expect(entry.snapshot().status).toBe("connected");
+  });
+
   test("refreshes prepared options before reconnecting relay environments", async () => {
     let token = 0;
     const harness = makeHarness({

--- a/apps/mobile/src/rpc/connection-supervisor.ts
+++ b/apps/mobile/src/rpc/connection-supervisor.ts
@@ -60,9 +60,9 @@ const messageOf = (cause: unknown): string =>
 
 const defaultClassifyError = (cause: unknown): "auth" | "transient" => {
   const message = messageOf(cause).toLowerCase();
-  return message.includes("401") ||
-    message.includes("403") ||
-    message.includes("auth") ||
+  return /_(401|403)(?::|$)/.test(message) ||
+    message.includes("invalid_dpop_proof") ||
+    message.includes("invalid_workos_token") ||
     message.includes("unauthorized") ||
     message.includes("forbidden")
     ? "auth"

--- a/apps/mobile/src/rpc/relay-client.test.ts
+++ b/apps/mobile/src/rpc/relay-client.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeRelayError } from "./relay-errors";
+
+describe("relay client errors", () => {
+  test("hides Cloudflare html bodies for transient connect failures", () => {
+    const html =
+      '<!DOCTYPE html><html><head><title>Worker threw exception</title></head><body style="margin:0;padding:0">Cloudflare<script>if (!navigator.cookieEnabled) { window.addEventListener("DOMContentLoaded", function () {}) }</script></body></html>';
+
+    expect(normalizeRelayError(500, html, "relay_connect")).toBe(
+      "relay_connect_500",
+    );
+  });
+
+  test("hides plain bodies for relay rate limits and server errors", () => {
+    expect(
+      normalizeRelayError(
+        500,
+        "Worker threw exception | relay.stuff.md | Cloudflare body{margin:0}",
+        "relay_connect",
+      ),
+    ).toBe("relay_connect_500");
+    expect(normalizeRelayError(429, "try again later", "relay_connect")).toBe(
+      "relay_connect_429",
+    );
+  });
+
+  test("keeps useful json errors for non-transient failures", () => {
+    expect(
+      normalizeRelayError(
+        401,
+        JSON.stringify({ error: "invalid_dpop_proof" }),
+        "relay_connect",
+      ),
+    ).toBe("relay_connect_401:invalid_dpop_proof");
+  });
+});

--- a/apps/mobile/src/rpc/relay-client.ts
+++ b/apps/mobile/src/rpc/relay-client.ts
@@ -46,7 +46,12 @@ const relayError = async (
   } catch {
     // Non-JSON relay errors still get surfaced in truncated form.
   }
-  return new Error(`${fallback}:${text.slice(0, 120)}`);
+  const compact = text
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+  return new Error(compact.length > 0 ? `${fallback}:${compact}` : fallback);
 };
 
 const ensureAccessToken = async (): Promise<string> => {

--- a/apps/mobile/src/rpc/relay-client.ts
+++ b/apps/mobile/src/rpc/relay-client.ts
@@ -14,6 +14,7 @@ import {
   logConnectionDiagnostic,
   logConnectionProblem,
 } from "./connection-diagnostics";
+import { normalizeRelayError } from "./relay-errors";
 
 /**
  * Client for the account relay's HTTP API. WorkOS-authenticated endpoints
@@ -35,23 +36,8 @@ const relayError = async (
   response: Response,
   prefix: string,
 ): Promise<Error> => {
-  const fallback = `${prefix}_${response.status}`;
   const text = await response.text().catch(() => "");
-  if (text.trim().length === 0) return new Error(fallback);
-  try {
-    const body = JSON.parse(text) as { readonly error?: unknown };
-    if (typeof body.error === "string" && body.error.length > 0) {
-      return new Error(`${fallback}:${body.error}`);
-    }
-  } catch {
-    // Non-JSON relay errors still get surfaced in truncated form.
-  }
-  const compact = text
-    .replace(/<[^>]*>/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 120);
-  return new Error(compact.length > 0 ? `${fallback}:${compact}` : fallback);
+  return new Error(normalizeRelayError(response.status, text, prefix));
 };
 
 const ensureAccessToken = async (): Promise<string> => {

--- a/apps/mobile/src/rpc/relay-errors.ts
+++ b/apps/mobile/src/rpc/relay-errors.ts
@@ -1,0 +1,42 @@
+export const normalizeRelayError = (
+  status: number,
+  text: string,
+  prefix: string,
+): string => {
+  const fallback = `${prefix}_${status}`;
+  if (isTransientRelayStatus(status)) {
+    return fallback;
+  }
+  if (text.trim().length === 0) return fallback;
+  try {
+    const body = JSON.parse(text) as { readonly error?: unknown };
+    if (typeof body.error === "string" && body.error.length > 0) {
+      return `${fallback}:${body.error}`;
+    }
+  } catch {
+    // Fall through to text cleanup.
+  }
+  if (looksLikeHtml(text)) {
+    return fallback;
+  }
+  const compact = text
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+  return compact.length > 0 ? `${fallback}:${compact}` : fallback;
+};
+
+const isTransientRelayStatus = (status: number): boolean =>
+  status === 429 || status >= 500;
+
+const looksLikeHtml = (text: string): boolean => {
+  const value = text.trim().toLowerCase();
+  return (
+    value.startsWith("<!doctype html") ||
+    value.startsWith("<html") ||
+    value.includes("<body") ||
+    value.includes("<script") ||
+    value.includes("cloudflare")
+  );
+};

--- a/apps/mobile/src/store/environments.ts
+++ b/apps/mobile/src/store/environments.ts
@@ -49,9 +49,21 @@ const message = (cause: unknown): string => {
     if (text.includes("invalid_workos_token")) {
       return "Your sign-in expired. Sign out, sign in again, and refresh computers.";
     }
+    if (
+      text.startsWith("relay_dpop_token_5") ||
+      text.startsWith("relay_dpop_token_429")
+    ) {
+      return "Relay is temporarily unavailable. Try again in a moment.";
+    }
     return "Could not authorize this phone with the relay.";
   }
   if (text.startsWith("relay_connect_")) {
+    if (
+      text.startsWith("relay_connect_5") ||
+      text.startsWith("relay_connect_429")
+    ) {
+      return "Relay is temporarily unavailable. Try again in a moment.";
+    }
     return "Could not connect to that computer.";
   }
   return text;

--- a/apps/mobile/src/store/outbox.ts
+++ b/apps/mobile/src/store/outbox.ts
@@ -5,7 +5,7 @@ import { create } from "zustand";
 import type { QueuedMessage } from "~/offline/cache";
 import { readOutboxSnapshot, writeOutboxSnapshot } from "~/offline/cache";
 import { connectionSessionKey } from "~/lib/session-key";
-import { makeTextInput, sendMessage } from "~/rpc/actions";
+import { flushServerQueue, makeTextInput, queueMessage } from "~/rpc/actions";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 
 /**
@@ -17,6 +17,8 @@ import type { WsProtocolOptions } from "~/rpc/ws-protocol";
  */
 type OutboxState = {
   queuedBySession: Record<string, readonly QueuedMessage[]>;
+  sendingBySession: Record<string, boolean>;
+  errorBySession: Record<string, string | null>;
   hydrate: (connKey: string, sessionId: SessionId) => Promise<void>;
   enqueue: (
     connKey: string,
@@ -49,6 +51,8 @@ const persist = (
 
 export const useOutboxStore = create<OutboxState>((set, get) => ({
   queuedBySession: {},
+  sendingBySession: {},
+  errorBySession: {},
   hydrate: async (connKey, sessionId) => {
     const key = connectionSessionKey(connKey, sessionId);
     if (get().queuedBySession[key] !== undefined) return;
@@ -58,6 +62,8 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
     const items = cached?.items ?? [];
     set((state) => ({
       queuedBySession: { ...state.queuedBySession, [key]: items },
+      sendingBySession: { ...state.sendingBySession, [key]: false },
+      errorBySession: { ...state.errorBySession, [key]: null },
     }));
   },
   enqueue: async (connKey, sessionId, text) => {
@@ -72,6 +78,7 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
     const next = [...(get().queuedBySession[key] ?? []), item];
     set((state) => ({
       queuedBySession: { ...state.queuedBySession, [key]: next },
+      errorBySession: { ...state.errorBySession, [key]: null },
     }));
     await persist(connKey, sessionId, next);
   },
@@ -81,20 +88,32 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
     const queued = get().queuedBySession[key] ?? [];
     if (queued.length === 0) return;
     flushing.add(key);
+    set((state) => ({
+      sendingBySession: { ...state.sendingBySession, [key]: true },
+      errorBySession: { ...state.errorBySession, [key]: null },
+    }));
     try {
-      // Send strictly in order; stop at the first failure so ordering holds and
-      // the remaining items stay queued for the next reconnect.
+      // Hand local offline items to the server queue in order. Once accepted by
+      // the server, the item is no longer local state; server queue flushing is
+      // responsible for waiting until the session is idle.
       let remaining = queued;
       for (const item of queued) {
         try {
           await Effect.runPromise(
-            sendMessage({
+            queueMessage({
               connection: options,
               sessionId,
               input: makeTextInput(item.text),
             }),
           );
+          await Effect.runPromise(flushServerQueue({ connection: options, sessionId }));
         } catch {
+          set((state) => ({
+            errorBySession: {
+              ...state.errorBySession,
+              [key]: "Could not send queued message. It will retry when the connection is ready.",
+            },
+          }));
           break;
         }
         remaining = remaining.filter(
@@ -107,6 +126,9 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
       }
     } finally {
       flushing.delete(key);
+      set((state) => ({
+        sendingBySession: { ...state.sendingBySession, [key]: false },
+      }));
     }
   },
 }));

--- a/apps/mobile/src/store/outbox.ts
+++ b/apps/mobile/src/store/outbox.ts
@@ -106,12 +106,16 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
               input: makeTextInput(item.text),
             }),
           );
-          await Effect.runPromise(flushServerQueue({ connection: options, sessionId }));
-        } catch {
+        } catch (cause) {
+          const reason = messageOf(cause);
+          console.warn("[mobile] outbox.queue_add_failed", {
+            sessionId,
+            reason,
+          });
           set((state) => ({
             errorBySession: {
               ...state.errorBySession,
-              [key]: "Could not send queued message. It will retry when the connection is ready.",
+              [key]: `Could not queue message: ${reason}`,
             },
           }));
           break;
@@ -123,6 +127,14 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
           queuedBySession: { ...state.queuedBySession, [key]: remaining },
         }));
         await persist(connKey, sessionId, remaining);
+        await Effect.runPromise(
+          flushServerQueue({ connection: options, sessionId }),
+        ).catch((cause) => {
+          console.warn("[mobile] outbox.flush_failed", {
+            sessionId,
+            reason: messageOf(cause),
+          });
+        });
       }
     } finally {
       flushing.delete(key);
@@ -132,3 +144,6 @@ export const useOutboxStore = create<OutboxState>((set, get) => ({
     }
   },
 }));
+
+const messageOf = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);


### PR DESCRIPTION
## Summary
- treat relay 500/429 failures as transient instead of phone-auth failures
- strip HTML from relay error snippets before surfacing them
- keep retrying queued mobile sends while the transport is connected
- isolate bad historical message rows so one render failure does not crash the chat

## Verification
- bun run --cwd apps/mobile check-types
- bun run --cwd apps/mobile lint
- bun run --cwd apps/mobile test
- git diff --check