### PR TITLE
Add Grok 4.5 model picker support

### DIFF
--- a/apps/server/test/config-store.test.ts
+++ b/apps/server/test/config-store.test.ts
@@ -101,6 +101,7 @@ describe("config-store settings coercion", () => {
     );
     expect(settings.modelEnabledByProvider.codex["gpt-5.5"]).toBe(true);
     expect(settings.modelEnabledByProvider.codex["gpt-5.3-codex"]).toBe(false);
+    expect(settings.modelEnabledByProvider.grok["grok-4.5"]).toBe(true);
   });
 
   it("keeps valid model visibility overrides and drops unknown model ids", () => {

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -1057,6 +1057,12 @@ export const MODELS_BY_PROVIDER: Record<
       supportsWebSearch: "queryOnly",
     },
     {
+      id: "grok-4.5",
+      label: "Grok 4.5",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
       id: "grok-composer-2.5-fast",
       label: "Grok Composer 2.5 Fast",
       supportsPlanMode: true,
@@ -1292,7 +1298,10 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<
     "gpt-5-codex": "gpt-5.5",
     "gpt-5": "gpt-5.5",
   },
-  grok: {},
+  grok: {
+    "grok-4.5-latest": "grok-4.5",
+    "grok-build-latest": "grok-4.5",
+  },
   gemini: {
     "gemini-3-pro": "gemini-3-pro-preview",
     "gemini-3.1-pro-preview": "gemini-3-pro-preview",

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -717,6 +717,18 @@ describe("model visibility helpers", () => {
     ).toBe(true);
   });
 
+  it("surfaces Grok 4.5 without changing the Grok default", () => {
+    expect(defaultModelFor("grok")).toBe("grok-build");
+    expect(MODELS_BY_PROVIDER.grok.some((m) => m.id === "grok-4.5")).toBe(
+      true,
+    );
+    expect(
+      visibleModelsForProvider("grok").some((m) => m.id === "grok-4.5"),
+    ).toBe(true);
+    expect(resolveModelSlug("grok", "grok-4.5-latest")).toBe("grok-4.5");
+    expect(resolveModelSlug("grok", "grok-build-latest")).toBe("grok-4.5");
+  });
+
   it("can include a hidden selected model without making all hidden models visible", () => {
     const models = visibleModelsForProvider("codex", undefined, {
       includeModelId: "gpt-5.3-codex",


### PR DESCRIPTION
## Summary
- add Grok 4.5 as a visible, non-default Grok picker option
- preserve Grok Build as the default Grok model
- add latest-slug aliases for Grok 4.5 and cover catalog/config seeding with tests

## Tests
- bun test packages/wire/test/schema.test.ts
- bun test apps/server/test/config-store.test.ts
- bun test apps/server/test/availability.test.ts