### PR TITLE
Mobile UI overhaul: naming, new chat, session, stream, permission, inbox

### DIFF
--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -1,7 +1,28 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
-import { Stack, useLocalSearchParams } from "expo-router";
-import { FlatList, KeyboardAvoidingView, Text, View } from "react-native";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { router, Stack, useLocalSearchParams } from "expo-router";
+import {
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  Text,
+  View,
+} from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ChevronDown, ChevronLeft, Plus } from "lucide-react-native";
 import type { SessionId, UserQuestion } from "@zuse/wire";
 import { Effect } from "effect";
 
@@ -11,12 +32,21 @@ import {
   MessageRow,
   type MessageRowContext,
 } from "~/components/messages/message-row";
+import { SessionActionsMenu } from "~/components/session-actions-menu";
+import { GlassSurface } from "~/components/ui/glass-surface";
+import { ShimmerText } from "~/components/ui/shimmer-text";
 import {
   normalizeConnParam,
   optionsForConnection,
 } from "~/lib/connection-params";
+import { visibleConnectionLabel } from "~/lib/display-names";
 import { connectionSessionKey } from "~/lib/session-key";
-import { answerQuestion } from "~/rpc/actions";
+import {
+  answerQuestion,
+  flushServerQueue,
+  makeTextInput,
+  queueMessage,
+} from "~/rpc/actions";
 import { isFreshChat } from "~/lib/composer-state";
 import { messageKey, sanitizeMessages } from "~/lib/message-safety";
 import { buildToolResultsByItemId } from "~/lib/message-presentation";
@@ -60,6 +90,9 @@ function ThreadScreen() {
   const listRef = useRef<FlatList>(null);
   const didInitialScroll = useRef(false);
   const initialScrollQuietUntil = useRef(0);
+  const atBottomRef = useRef(true);
+  const [showJumpButton, setShowJumpButton] = useState(false);
+  const jumpOpacity = useSharedValue(0);
   const {
     connections,
     hydrated,
@@ -77,6 +110,16 @@ function ThreadScreen() {
   const bundles = useSessionsStore(
     (state) => state.bundlesByConnection[connKey] ?? EMPTY_BUNDLES,
   );
+  const archiveChat = useSessionsStore((state) => state.archiveChat);
+  const renameChatAction = useSessionsStore((state) => state.renameChat);
+  const markChatRead = useSessionsStore((state) => state.markChatRead);
+  const machineLabel = useMemo(() => {
+    const record = connections.find(
+      (connection) =>
+        connection.key === connKey || connection.environmentId === connKey,
+    );
+    return record?.label ?? visibleConnectionLabel(undefined, connKey);
+  }, [connections, connKey]);
   const { messagesBySession, errorBySession, hydrate } = useMobileMessagesStore();
   const rawMessages = messagesBySession[stateKey] ?? EMPTY_MESSAGES;
   const messages = useMemo(() => sanitizeMessages(rawMessages), [rawMessages]);
@@ -86,6 +129,12 @@ function ThreadScreen() {
     useSessionsStore((state) => state.statusBySession[stateKey]) ??
     detail?.session.status;
   const fresh = isFreshChat(messages);
+  const lastMessageTag = messages[messages.length - 1]?.content._tag;
+  // Show a "Working" shimmer only before the first tool/assistant row streams
+  // in — i.e. the last thing on screen is still the user's message.
+  const showWorking =
+    sessionStatus === "running" &&
+    (lastMessageTag === "user" || lastMessageTag === "user_rich");
 
   const hydratePermissions = usePermissionsStore((state) => state.hydrate);
   const decidePermission = usePermissionsStore((state) => state.decide);
@@ -123,6 +172,14 @@ function ThreadScreen() {
     normalizedSessionId,
     options,
   ]);
+
+  const chatId = detail?.chat?.id ?? null;
+  // Mark the chat read on open/focus (and when the chat resolves after a
+  // hydrate) so the inbox unread styling clears. Idempotent server-side.
+  useEffect(() => {
+    if (chatId === null || options === null) return;
+    void markChatRead(connKey, options, chatId);
+  }, [chatId, connKey, options, markChatRead]);
 
   const error = errorBySession[stateKey];
   const transportOnline = connectionSnapshot?.status === "connected";
@@ -205,6 +262,7 @@ function ThreadScreen() {
       questionsByItemId,
       toolResultsByItemId,
       planMode: detail?.session.permissionMode === "plan",
+      sessionRunning: sessionStatus === "running",
       onAnswerQuestion,
     }),
     [
@@ -212,6 +270,7 @@ function ThreadScreen() {
       detail?.session.permissionMode,
       onAnswerQuestion,
       questionsByItemId,
+      sessionStatus,
       toolResultsByItemId,
     ],
   );
@@ -219,10 +278,21 @@ function ThreadScreen() {
   useEffect(() => {
     didInitialScroll.current = false;
     initialScrollQuietUntil.current = Date.now() + 500;
+    atBottomRef.current = true;
   }, [stateKey]);
+
+  // Fade the jump button in/out from its visibility state (assignment must
+  // live in an effect for the React Compiler's shared-value immutability rule).
+  useEffect(() => {
+    jumpOpacity.value = withTiming(showJumpButton ? 1 : 0, { duration: 160 });
+  }, [showJumpButton, jumpOpacity]);
 
   const scrollToLatest = useCallback(() => {
     if (messages.length === 0) return;
+    // Only autoscroll when the user is already at the bottom, or during the
+    // very first positioning of a freshly-opened chat. Otherwise leave the
+    // scroll position alone so reading isn't yanked (D6).
+    if (didInitialScroll.current && !atBottomRef.current) return;
     const animated =
       didInitialScroll.current && Date.now() > initialScrollQuietUntil.current;
     didInitialScroll.current = true;
@@ -231,9 +301,101 @@ function ThreadScreen() {
     });
   }, [messages.length]);
 
+  // Plain functions (not useCallback): the React Compiler memoizes them, and
+  // manual memoization of setState-calling callbacks trips its preservation rule.
+  const onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+    const distanceFromBottom =
+      contentSize.height - (contentOffset.y + layoutMeasurement.height);
+    const atBottom = distanceFromBottom <= 40;
+    atBottomRef.current = atBottom;
+    if (atBottom === showJumpButton) setShowJumpButton(!atBottom);
+  };
+
+  const jumpToBottom = () => {
+    atBottomRef.current = true;
+    setShowJumpButton(false);
+    listRef.current?.scrollToEnd({ animated: true });
+  };
+
+  const jumpStyle = useAnimatedStyle(() => ({ opacity: jumpOpacity.value }));
+
+  const onRename = useCallback(() => {
+    if (chatId === null || options === null) return;
+    Alert.prompt(
+      "Rename chat",
+      undefined,
+      (value) => {
+        const next = value?.trim() ?? "";
+        if (next.length === 0) return;
+        void renameChatAction(connKey, options, chatId, next);
+      },
+      "plain-text",
+      title,
+    );
+  }, [chatId, connKey, options, renameChatAction, title]);
+
+  const onArchive = useCallback(() => {
+    if (chatId === null || options === null) return;
+    void archiveChat(connKey, options, chatId).then(() => router.back());
+  }, [archiveChat, chatId, connKey, options]);
+
   return (
     <KeyboardAvoidingView behavior="padding" className="flex-1 bg-background">
-      <Stack.Screen options={{ title }} />
+      <Stack.Screen
+        options={{
+          headerBackVisible: false,
+          headerTitleAlign: "center",
+          headerLeft: () => (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Go back"
+              hitSlop={10}
+              onPress={() => router.back()}
+              className="h-9 w-9 items-center justify-center rounded-full bg-card active:opacity-70"
+              style={{ borderCurve: "continuous" }}
+            >
+              <ChevronLeft size={20} color="hsl(72 4% 92%)" />
+            </Pressable>
+          ),
+          headerTitle: () => (
+            <View className="items-center">
+              <Text
+                className="font-sans-medium text-[15px] text-foreground"
+                numberOfLines={1}
+              >
+                {title}
+              </Text>
+              <Text
+                className="font-sans text-[11px] text-muted-foreground"
+                numberOfLines={1}
+              >
+                {detail?.project.name
+                  ? `${detail.project.name} · ${machineLabel}`
+                  : machineLabel}
+              </Text>
+            </View>
+          ),
+          headerRight: () => (
+            <View className="flex-row items-center gap-2">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="New chat"
+                hitSlop={10}
+                onPress={() => router.push("/new-chat")}
+                className="h-9 w-9 items-center justify-center rounded-full bg-card active:opacity-70"
+                style={{ borderCurve: "continuous" }}
+              >
+                <Plus size={19} color="hsl(72 4% 92%)" />
+              </Pressable>
+              <SessionActionsMenu
+                onRename={chatId === null ? undefined : onRename}
+                onArchive={onArchive}
+              />
+            </View>
+          ),
+        }}
+      />
       {hydrated && options === null ? (
         <View className="px-4 py-3">
           <Text selectable className="font-sans text-[13px] text-danger">
@@ -246,7 +408,13 @@ function ThreadScreen() {
         ref={listRef}
         data={messages}
         keyExtractor={messageKey}
-        renderItem={({ item }) => <MessageRow message={item} ctx={ctx} />}
+        renderItem={({ item, index }) => (
+          <MessageRow
+            message={item}
+            ctx={ctx}
+            isLast={index === messages.length - 1}
+          />
+        )}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerClassName="gap-1 px-4 py-3"
         ListHeaderComponent={
@@ -266,17 +434,51 @@ function ThreadScreen() {
           ) : null
         }
         ListFooterComponent={
-          queued.length > 0 ? (
+          showWorking || queued.length > 0 ? (
             <View className="pt-1">
+              {showWorking ? (
+                <View className="px-2 py-1.5">
+                  <ShimmerText className="font-sans text-[13px] text-muted-foreground">
+                    Working
+                  </ShimmerText>
+                </View>
+              ) : null}
               {queued.map((item) => (
                 <QueuedBubble key={item.clientId} text={item.text} />
               ))}
             </View>
           ) : null
         }
+        onScroll={onScroll}
+        scrollEventThrottle={32}
+        maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
         onContentSizeChange={scrollToLatest}
         onLayout={scrollToLatest}
       />
+      {showJumpButton ? (
+        <Animated.View
+          pointerEvents={showJumpButton ? "auto" : "none"}
+          style={[jumpStyle, { position: "absolute", right: 16, bottom: 96 }]}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Scroll to latest"
+            onPress={jumpToBottom}
+          >
+            <GlassSurface
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: 20,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <ChevronDown size={20} color="hsl(72 4% 92%)" />
+            </GlassSurface>
+          </Pressable>
+        </Animated.View>
+      ) : null}
       {options === null || pending.length === 0 ? null : (
         <LivePermissionAccessory
           requests={pending}
@@ -290,6 +492,30 @@ function ThreadScreen() {
               decision,
             )
           }
+          onDenyWithMessage={async (request, message) => {
+            await decidePermission(
+              connKey,
+              options,
+              normalizedSessionId,
+              request.id,
+              { _tag: "Deny" },
+            );
+            // Queue the typed guidance as the next user message (the Deny wire
+            // decision carries no text of its own).
+            await Effect.runPromise(
+              queueMessage({
+                connection: options,
+                sessionId: normalizedSessionId,
+                input: makeTextInput(message),
+              }),
+            ).catch(() => {});
+            await Effect.runPromise(
+              flushServerQueue({
+                connection: options,
+                sessionId: normalizedSessionId,
+              }),
+            ).catch(() => {});
+          }}
         />
       )}
       {options === null ? null : (
@@ -300,13 +526,6 @@ function ThreadScreen() {
           session={detail?.session ?? null}
           status={sessionStatus}
           fresh={fresh}
-          projectLabel={detail?.project.name}
-          sourceLabel={
-            detail?.session.worktreeId === null ||
-            detail?.session.worktreeId === undefined
-              ? "Main"
-              : "Branch"
-          }
           online={transportOnline}
           bottomInset={insets.bottom}
         />

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,15 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, router, Stack } from "expo-router";
 import {
-  AlertTriangle,
   Archive,
   ChevronDown,
   ChevronRight,
-  CircleCheck,
-  CircleX,
-  LoaderCircle,
   Loader2,
-  MessageCircle,
   MessageSquare,
   Search,
   Settings,
@@ -27,7 +22,6 @@ import {
   View,
 } from "react-native";
 import Swipeable from "react-native-gesture-handler/ReanimatedSwipeable";
-import type { SessionStatus } from "@zuse/wire";
 
 import {
   buildInboxGroups,
@@ -58,7 +52,7 @@ import {
 import { EmptyState } from "~/components/ui/empty-state";
 import { Button } from "~/components/ui/button";
 import { GlassSurface } from "~/components/ui/glass-surface";
-import { UnreadBadge } from "~/components/unread-badge";
+import { PresenceDot } from "~/components/ui/presence-dot";
 
 const ACCENT = "hsl(72 98% 54%)";
 const LOGO = require("../assets/icon.png");
@@ -76,6 +70,7 @@ export default function HomeScreen() {
     connections,
     hydrated: connectionsHydrated,
     hydrate: hydrateConnections,
+    refreshLabel,
   } = useConnectionsStore();
   const {
     environments,
@@ -146,8 +141,9 @@ export default function HomeScreen() {
       const options = optionsForConnection(connection.key, connections);
       if (options === null) continue;
       void hydrateSessions(connection.key, options);
+      void refreshLabel(connection.key, options);
     }
-  }, [account, connections, hydrateSessions]);
+  }, [account, connections, hydrateSessions, refreshLabel]);
 
   const groups = useMemo(
     () =>
@@ -508,7 +504,8 @@ function InboxItem({
     );
   }
 
-  const statusLabel = item.row.status;
+  const isActive =
+    item.row.status === "running" || item.row.status === "booting";
   const href =
     `/c/${encodeURIComponent(item.row.connectionKey)}/session/${encodeURIComponent(
       item.row.session.id,
@@ -544,35 +541,38 @@ function InboxItem({
         <Link.Trigger>
           <Pressable
             className={cn(
-              "min-h-[72px] flex-row items-center gap-3 border-x border-t border-border bg-card px-3 py-3 active:bg-card-elevated",
+              "min-h-[64px] flex-row items-center gap-2.5 border-x border-t border-border bg-card px-3 py-3 active:bg-card-elevated",
               item.isLast && "rounded-b-2xl border-b",
             )}
             style={item.isLast ? { borderCurve: "continuous" } : undefined}
           >
-            <Link.AppleZoom>
-              <View
-                collapsable={false}
-                className="h-10 w-10 items-center justify-center rounded-full bg-muted"
-              >
-                <ChatStateIcon status={item.row.status} />
-              </View>
-            </Link.AppleZoom>
+            <View
+              collapsable={false}
+              className="w-4 items-center justify-center"
+            >
+              {isActive ? (
+                <PresenceDot tone="online" pulse size={7} />
+              ) : item.row.unread ? (
+                <View className="h-[7px] w-[7px] rounded-full bg-primary" />
+              ) : null}
+            </View>
             <View className="min-w-0 flex-1">
-              <View className="flex-row items-center gap-2">
-                <Text
-                  className="min-w-0 flex-1 font-sans-medium text-[16px] text-foreground"
-                  numberOfLines={1}
-                >
-                  {item.row.title}
-                </Text>
-                <UnreadBadge visible={item.row.unread} />
-              </View>
+              <Text
+                className={cn(
+                  "font-sans-medium text-[15px]",
+                  item.row.unread ? "text-foreground" : "text-muted-foreground",
+                )}
+                numberOfLines={1}
+              >
+                {item.row.title}
+              </Text>
               <View className="mt-0.5 flex-row items-center gap-2">
                 <Text
-                  className="min-w-0 flex-1 font-sans text-[13px] text-muted-foreground"
+                  className="min-w-0 flex-1 font-sans text-[12px] text-muted-foreground"
                   numberOfLines={1}
                 >
-                  {item.row.subtitle} · {statusLabel}
+                  {item.row.subtitle}
+                  {isActive ? " · Running" : ""}
                 </Text>
                 <BranchStateBadge state={branchState} />
               </View>
@@ -591,18 +591,6 @@ function BrandTitle() {
       <Image source={LOGO} className="h-7 w-7 rounded-lg" resizeMode="cover" />
       <Text className="font-sans-bold text-[18px] text-foreground">Zuse</Text>
     </View>
-  );
-}
-
-function ChatStateIcon({ status }: { status: SessionStatus }) {
-  const meta = iconForStatus(status);
-  const Icon = meta.icon;
-  return (
-    <Icon
-      size={21}
-      color={meta.color}
-      strokeWidth={2.1}
-    />
   );
 }
 
@@ -724,23 +712,6 @@ function branchToneColor(tone: "brand" | "neutral" | "danger" | "success" | "war
       return "hsl(42 93% 48%)";
     case "neutral":
       return "hsl(72 3% 64%)";
-  }
-}
-
-function iconForStatus(status: SessionStatus) {
-  switch (status) {
-    case "running":
-      return { icon: LoaderCircle, color: "hsl(72 98% 54%)" };
-    case "error":
-      return { icon: AlertTriangle, color: "hsl(0 84% 62%)" };
-    case "closed":
-      return { icon: CircleX, color: "hsl(72 3% 64%)" };
-    case "idle":
-      return { icon: CircleCheck, color: "hsl(142 70% 45%)" };
-    case "booting":
-      return { icon: LoaderCircle, color: "hsl(42 93% 48%)" };
-    default:
-      return { icon: MessageCircle, color: "hsl(72 4% 70%)" };
   }
 }
 

--- a/apps/mobile/app/new-chat.tsx
+++ b/apps/mobile/app/new-chat.tsx
@@ -1,10 +1,13 @@
 import type { Folder, GitBranchInfo, GitPrSummary, Worktree } from "@zuse/wire";
 import {
+  Add01Icon,
   ArrowUp01Icon,
   CloudOffIcon,
   CancelCircleIcon,
+  ComputerIcon,
   Folder01Icon,
   GitBranchIcon,
+  LaptopIcon,
 } from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
 import { router, Stack } from "expo-router";
@@ -30,23 +33,27 @@ import { optionsForConnection } from "~/lib/connection-params";
 import {
   buildNewChatCreatePayload,
   MAIN_SOURCE,
+  sourceOptionsForKind,
+  workModeLabel,
+  WORK_MODE_OPTIONS,
   type NewChatSource,
+  type NewChatSourceKind,
 } from "~/lib/new-chat";
 import {
+  availableProviderIds,
   defaultModelForProvider,
-  reasoningDescriptorForModel,
+  defaultModelOptions,
 } from "~/lib/model-options";
+import { useAvailabilityStore } from "~/store/availability";
 import { useConnectionsStore } from "~/store/connections";
 import { useSessionsStore } from "~/store/sessions";
 import { Button } from "~/components/ui/button";
 import { GlassSurface } from "~/components/ui/glass-surface";
 import { HugeIcon } from "~/components/ui/huge-icon";
+import { SelectorRow } from "~/components/selector-row";
 import {
   ComposerModelMenu,
   ComposerSettingsMenu,
-  NativeButton,
-  ProjectPill,
-  SourcePill,
   type ModelModeValue,
 } from "~/components/model-mode-menu";
 
@@ -110,20 +117,6 @@ export default function NewChatScreen() {
     );
   }, [bundlesByConnection, effectiveConnectionKey]);
 
-  const projectMenuGroups = useMemo(
-    () =>
-      connections.map((connection) => ({
-        connectionKey: connection.key,
-        connectionLabel: connection.label,
-        projects: (bundlesByConnection[connection.key] ?? []).map((bundle) => ({
-          id: bundle.project.id,
-          name: bundle.project.name,
-          path: bundle.project.path,
-        })),
-      })),
-    [bundlesByConnection, connections],
-  );
-
   const effectiveProjectId =
     selectedProjectId !== null &&
     projectChoices.some((item) => item.project.id === selectedProjectId)
@@ -137,6 +130,44 @@ export default function NewChatScreen() {
         : optionsForConnection(effectiveConnectionKey, connections),
     [connections, effectiveConnectionKey],
   );
+
+  const hydrateAvailability = useAvailabilityStore((state) => state.hydrate);
+  const availability = useAvailabilityStore((state) =>
+    effectiveConnectionKey === null
+      ? undefined
+      : state.availabilityByConnection[effectiveConnectionKey],
+  );
+  useEffect(() => {
+    if (effectiveConnectionKey === null || selectedOptions === null) return;
+    void hydrateAvailability(effectiveConnectionKey, selectedOptions);
+  }, [effectiveConnectionKey, selectedOptions, hydrateAvailability]);
+  const availableProviders = useMemo(
+    () => availableProviderIds(availability),
+    [availability],
+  );
+
+  // Codex is the hardcoded default provider; if the selected machine doesn't
+  // have it installed, derive a fallback to the first available provider so the
+  // menu and the create payload start on something the server can actually run.
+  // Derived (not stored) to avoid a setState-in-effect cascade — the user's own
+  // picks always come from the filtered menu, so they pass through unchanged.
+  const effectiveModelMode = useMemo<ModelModeValue>(() => {
+    if (
+      availableProviders === null ||
+      availableProviders.length === 0 ||
+      availableProviders.includes(modelMode.providerId)
+    ) {
+      return modelMode;
+    }
+    const providerId = availableProviders[0]!;
+    const model = defaultModelForProvider(providerId);
+    return {
+      ...modelMode,
+      providerId,
+      model,
+      modelOptions: defaultModelOptions(providerId, model),
+    };
+  }, [availableProviders, modelMode]);
 
   useEffect(() => {
     if (selectedOptions === null || effectiveProjectId === null) return;
@@ -175,7 +206,60 @@ export default function NewChatScreen() {
   const selectedProject = projectChoices.find(
     (item) => item.project.id === effectiveProjectId,
   )?.project;
-  const sourceLabel = source.kind === "main" ? "Main" : source.label;
+
+  // Selector-stack derived values (machine → project → work-mode → branch).
+  const machineOptions = connections.map((connection) => ({
+    key: connection.key,
+    label: connection.label,
+    selected: connection.key === effectiveConnectionKey,
+    onSelect: () => {
+      setSelectedConnectionKey(connection.key);
+      setSelectedProjectId(null);
+      setSource(MAIN_SOURCE);
+    },
+  }));
+  const machineLabel =
+    connections.find((connection) => connection.key === effectiveConnectionKey)
+      ?.label ?? (connections.length === 0 ? "No machines" : "Machine");
+
+  const projectOptions = projectChoices.map((item) => ({
+    key: item.project.id,
+    label: item.project.name,
+    selected: item.project.id === effectiveProjectId,
+    onSelect: () => {
+      setSelectedProjectId(item.project.id);
+      setSource(MAIN_SOURCE);
+    },
+  }));
+  const projectLabel =
+    selectedProject?.name ?? (loading ? "Loading projects" : "Project");
+
+  const firstSourceForKind = (kind: NewChatSourceKind): NewChatSource =>
+    sourceOptionsForKind(kind, worktrees, branches, prs)[0]?.source ??
+    MAIN_SOURCE;
+  const workModeOptions = WORK_MODE_OPTIONS.map((option) => ({
+    key: option.kind,
+    label: option.label,
+    selected: source.kind === option.kind,
+    onSelect: () => setSource(firstSourceForKind(option.kind)),
+  }));
+
+  const defaultBranchLabel =
+    branches.find((branch) => branch.current)?.name ?? "main";
+  const branchOptions = sourceOptionsForKind(
+    source.kind,
+    worktrees,
+    branches,
+    prs,
+  ).map((option) => ({
+    key: option.key,
+    label: option.label,
+    selected:
+      option.source.kind === source.kind && option.source.label === source.label,
+    onSelect: () => setSource(option.source),
+  }));
+  const branchLabel = source.kind === "main" ? defaultBranchLabel : source.label;
+
   const canSubmit =
     effectiveConnectionKey !== null &&
     selectedOptions !== null &&
@@ -187,11 +271,11 @@ export default function NewChatScreen() {
     const payload = buildNewChatCreatePayload({
       connectionKey: effectiveConnectionKey,
       projectId: effectiveProjectId,
-      providerId: modelMode.providerId,
-      model: modelMode.model,
-      runtimeMode: modelMode.runtimeMode,
-      permissionMode: modelMode.permissionMode,
-      modelOptions: modelMode.modelOptions,
+      providerId: effectiveModelMode.providerId,
+      model: effectiveModelMode.model,
+      runtimeMode: effectiveModelMode.runtimeMode,
+      permissionMode: effectiveModelMode.permissionMode,
+      modelOptions: effectiveModelMode.modelOptions,
       source,
       text,
     });
@@ -239,7 +323,7 @@ export default function NewChatScreen() {
     }
   }, [
     createChat,
-    modelMode,
+    effectiveModelMode,
     effectiveConnectionKey,
     selectedOptions,
     effectiveProjectId,
@@ -261,6 +345,47 @@ export default function NewChatScreen() {
           flexGrow: 1,
         }}
       >
+        <View className="self-start">
+          <SelectorRow
+            leading={
+              <HugeIcon icon={LaptopIcon} size={16} color="hsl(72 4% 76%)" />
+            }
+            label={machineLabel}
+            options={machineOptions}
+            emptyLabel="No machines"
+          />
+          <SelectorRow
+            leading={
+              <HugeIcon icon={Folder01Icon} size={16} color="hsl(72 4% 76%)" />
+            }
+            label={projectLabel}
+            options={projectOptions}
+            emptyLabel={loading ? "Loading projects" : "No projects"}
+          />
+          <SelectorRow
+            leading={
+              <HugeIcon icon={ComputerIcon} size={16} color="hsl(72 4% 76%)" />
+            }
+            label={workModeLabel(source.kind)}
+            options={workModeOptions}
+          />
+          <SelectorRow
+            leading={
+              <HugeIcon icon={GitBranchIcon} size={16} color="hsl(72 4% 76%)" />
+            }
+            label={branchLabel}
+            options={branchOptions}
+            disabled={source.kind === "main"}
+            emptyLabel={
+              source.kind === "worktree"
+                ? "No worktrees"
+                : source.kind === "pr"
+                  ? "No pull requests"
+                  : "No branches"
+            }
+          />
+        </View>
+
         <View className="flex-1" />
 
         {error === null ? null : (
@@ -277,111 +402,13 @@ export default function NewChatScreen() {
         className="px-3 pt-2"
         style={{ paddingBottom: insets.bottom > 0 ? insets.bottom : 12 }}
       >
-        <View className="mb-2 flex-row items-center gap-2 px-1">
-          <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated/70 px-2.5 py-1.5">
-            <HugeIcon icon={Folder01Icon} size={13} color="hsl(72 4% 76%)" />
-            <ProjectPill
-              label={
-                selectedProject === undefined
-                  ? loading
-                    ? "Loading projects"
-                    : "Project"
-                  : selectedProject.name
-              }
-              options={projectMenuGroups}
-              onSelect={(connectionKey, projectId) => {
-                setSelectedConnectionKey(connectionKey);
-                setSelectedProjectId(projectId as Folder["id"]);
-                setSource(MAIN_SOURCE);
-              }}
-            />
-          </View>
-          <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated/70 px-2.5 py-1.5">
-            <HugeIcon icon={GitBranchIcon} size={13} color="hsl(72 4% 76%)" />
-            <SourcePill label={sourceLabel}>
-              <NativeButton
-                label="Main"
-                systemImage={source.kind === "main" ? "checkmark" : "folder"}
-                onPress={() => setSource(MAIN_SOURCE)}
-              />
-              {worktrees.slice(0, 8).map((worktree) => (
-                <NativeButton
-                  key={worktree.id}
-                  label={worktree.branch}
-                  systemImage={
-                    source.kind === "worktree" &&
-                    source.worktreeId === worktree.id
-                      ? "checkmark"
-                      : "point.topleft.down.curvedto.point.bottomright.up"
-                  }
-                  onPress={() =>
-                    setSource({
-                      kind: "worktree",
-                      label: worktree.branch,
-                      worktreeId: worktree.id,
-                    })
-                  }
-                />
-              ))}
-              {branches
-                .filter((branch) => !branch.current)
-                .slice(0, 8)
-                .map((branch) => (
-                  <NativeButton
-                    key={`${branch.kind}:${branch.name}`}
-                    label={branch.name}
-                    systemImage={
-                      source.kind === "branch" && source.label === branch.name
-                        ? "checkmark"
-                        : "arrow.branch"
-                    }
-                    onPress={() =>
-                      setSource({
-                        kind: "branch",
-                        label: branch.name,
-                        worktreeId: null,
-                        createSource: {
-                          _tag: "branch",
-                          branch: branch.name,
-                          remote: branch.remote,
-                        },
-                      })
-                    }
-                  />
-                ))}
-              {prs.slice(0, 8).map((pr) => (
-                <NativeButton
-                  key={`pr:${pr.number}`}
-                  label={`#${pr.number} ${pr.title}`}
-                  systemImage={
-                    source.kind === "pr" && source.label === `#${pr.number}`
-                      ? "checkmark"
-                      : "arrow.triangle.pull"
-                  }
-                  onPress={() =>
-                    setSource({
-                      kind: "pr",
-                      label: `#${pr.number}`,
-                      worktreeId: null,
-                      createSource: {
-                        _tag: "pr",
-                        number: pr.number,
-                        headRefName: pr.headRefName,
-                      },
-                    })
-                  }
-                />
-              ))}
-            </SourcePill>
-          </View>
-        </View>
         <GlassSurface
           style={{
             gap: 8,
             padding: 10,
           }}
         >
-          {modelMode.permissionMode === "plan" ? (
+          {effectiveModelMode.permissionMode === "plan" ? (
             <PlanPill
               onClear={() =>
                 setModelMode((value) => ({
@@ -400,18 +427,26 @@ export default function NewChatScreen() {
             onChangeText={setText}
           />
           <View className="flex-row items-center gap-2">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Add attachment"
+              disabled
+              className="h-9 w-9 items-center justify-center rounded-full opacity-40"
+            >
+              <HugeIcon icon={Add01Icon} size={18} color="hsl(72 4% 76%)" />
+            </Pressable>
             <ComposerSettingsMenu
-              value={modelMode}
+              value={effectiveModelMode}
               editable
               onChange={setModelMode}
             />
-            <View className="min-w-0 flex-1 items-center">
-              <ComposerModelMenu
-                value={modelMode}
-                editable
-                onChange={setModelMode}
-              />
-            </View>
+            <View className="flex-1" />
+            <ComposerModelMenu
+              value={effectiveModelMode}
+              editable
+              onChange={setModelMode}
+              availableProviders={availableProviders}
+            />
             <Button
               size="sm"
               variant="primary"
@@ -446,14 +481,3 @@ const PlanPill = ({ onClear }: { onClear: () => void }) => (
     </Pressable>
   </View>
 );
-
-const defaultModelOptions = (
-  providerId: ModelModeValue["providerId"],
-  model: string,
-): Record<string, string> | undefined => {
-  const descriptor = reasoningDescriptorForModel(providerId, model);
-  const value = descriptor?.defaultId ?? descriptor?.options[0]?.id;
-  return descriptor !== null && value !== undefined
-    ? { [descriptor.id]: value }
-    : undefined;
-};

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -2704,7 +2704,7 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: 8a96e2075b75641001f55393d7e6600a5b808f09
   ExpoLinking: db6d7a9e9348cca9ada7c39127ab30963deddba3
   ExpoLogBox: b39a76aab749833d58111c3be1264bb90f3b92d4
-  ExpoModulesCore: a2b4737eb14484fa7093056613df341513723bd4
+  ExpoModulesCore: 0389baa548ac8ddd15991777d63132e27c225f69
   ExpoModulesJSI: ef7f197a8e7eeb245557f560ade794bfc1abdc79
   ExpoModulesWorklets: 0340ed9a30017f8597b90a1ef9aa210c43e44c4b
   ExpoModulesWorkletsAdapter: 53334fe0e5a924f6903e52400b6bbb4e9919bfcb
@@ -2715,7 +2715,7 @@ SPEC CHECKSUMS:
   ExpoUI: 811b7e03ff29d426b8690ad5afb4643be3846d02
   ExpoWebBrowser: 32dfd25ad5d384028137a0de71991f28663562e0
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 716e5425653f542526cc93e78114d701da5fa1ae
+  hermes-engine: d1f55d36bfedfdff4c4b0e328af9caabc3113cb8
   OpenSSL-Universal: ecee7b138fa75a74ecf00d7ffd248fb584739b9e
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -10,13 +10,11 @@ import {
   ArrowUp01Icon,
   CloudOffIcon,
   CancelCircleIcon,
-  Folder01Icon,
-  GitBranchIcon,
   Square01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
 import { Effect } from "effect";
 import * as Crypto from "expo-crypto";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -36,9 +34,14 @@ import {
   setSessionProvider,
   setSessionRuntimeMode,
 } from "~/rpc/actions";
-import { isInterruptVisible } from "~/lib/composer-state";
+import {
+  isInterruptVisible,
+  nextModelChangeActions,
+} from "~/lib/composer-state";
+import { availableProviderIds } from "~/lib/model-options";
 import { connectionSessionKey } from "~/lib/session-key";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
+import { useAvailabilityStore } from "~/store/availability";
 import {
   addOptimisticMessage,
   removeOptimisticMessage,
@@ -60,8 +63,6 @@ export const Composer = ({
   session,
   status,
   fresh,
-  projectLabel,
-  sourceLabel,
   online,
   bottomInset = 0,
 }: {
@@ -71,8 +72,6 @@ export const Composer = ({
   session: Session | null;
   status?: SessionStatus;
   fresh: boolean;
-  projectLabel?: string;
-  sourceLabel?: string;
   online: boolean;
   bottomInset?: number;
 }) => {
@@ -90,6 +89,18 @@ export const Composer = ({
     (state) => state.errorBySession[stateKey],
   );
   const enqueue = useOutboxStore((state) => state.enqueue);
+
+  const hydrateAvailability = useAvailabilityStore((state) => state.hydrate);
+  const availability = useAvailabilityStore(
+    (state) => state.availabilityByConnection[connKey],
+  );
+  useEffect(() => {
+    void hydrateAvailability(connKey, connection);
+  }, [connKey, connection, hydrateAvailability]);
+  const availableProviders = useMemo(
+    () => availableProviderIds(availability),
+    [availability],
+  );
 
   const canSend = text.trim().length > 0 && !busy;
   const showInterrupt = isInterruptVisible(status);
@@ -186,39 +197,45 @@ export const Composer = ({
   };
 
   const changeModelMode = async (next: ModelModeValue) => {
-    if (session === null || !fresh) return;
+    if (session === null) return;
+    const actions = nextModelChangeActions(session, next, fresh);
     try {
-      if (next.providerId !== session.providerId) {
-        await Effect.runPromise(
-          setSessionProvider({
-            connection,
-            sessionId,
-            providerId: next.providerId,
-            model: next.model,
-          }),
-        );
-      } else if (next.model !== session.model) {
-        await Effect.runPromise(
-          setSessionModel({ connection, sessionId, model: next.model }),
-        );
-      }
-      if (next.runtimeMode !== session.runtimeMode) {
-        await Effect.runPromise(
-          setSessionRuntimeMode({
-            connection,
-            sessionId,
-            runtimeMode: next.runtimeMode,
-          }),
-        );
-      }
-      if (next.permissionMode !== session.permissionMode) {
-        await Effect.runPromise(
-          setSessionPermissionMode({
-            connection,
-            sessionId,
-            mode: next.permissionMode,
-          }),
-        );
+      for (const action of actions) {
+        switch (action.type) {
+          case "setProvider":
+            await Effect.runPromise(
+              setSessionProvider({
+                connection,
+                sessionId,
+                providerId: action.providerId,
+                model: action.model,
+              }),
+            );
+            break;
+          case "setModel":
+            await Effect.runPromise(
+              setSessionModel({ connection, sessionId, model: action.model }),
+            );
+            break;
+          case "setRuntimeMode":
+            await Effect.runPromise(
+              setSessionRuntimeMode({
+                connection,
+                sessionId,
+                runtimeMode: action.runtimeMode,
+              }),
+            );
+            break;
+          case "setPermissionMode":
+            await Effect.runPromise(
+              setSessionPermissionMode({
+                connection,
+                sessionId,
+                mode: action.permissionMode,
+              }),
+            );
+            break;
+        }
       }
     } catch {
       // Started sessions can reject some changes. Keep this quiet on mobile.
@@ -243,16 +260,6 @@ export const Composer = ({
           </Text>
         </View>
       ) : null}
-      {projectLabel !== undefined || sourceLabel !== undefined ? (
-        <View className="mb-2 flex-row items-center gap-2 px-1">
-          {projectLabel !== undefined ? (
-            <ChromeLabel icon="project" label={projectLabel} />
-          ) : null}
-          {sourceLabel !== undefined ? (
-            <ChromeLabel icon="branch" label={sourceLabel} />
-          ) : null}
-        </View>
-      ) : null}
       <GlassSurface
         style={{
           gap: 8,
@@ -261,7 +268,7 @@ export const Composer = ({
       >
         {modelValue?.permissionMode === "plan" ? (
           <PlanPill
-            editable={fresh}
+            editable
             onClear={() =>
               void changeModelMode({ ...modelValue, permissionMode: "default" })
             }
@@ -280,14 +287,17 @@ export const Composer = ({
             <>
               <ComposerSettingsMenu
                 value={modelValue}
-                editable={fresh}
+                editable
                 onChange={(next) => void changeModelMode(next)}
               />
               <View className="min-w-0 flex-1 items-center">
                 <ComposerModelMenu
                   value={modelValue}
-                  editable={fresh}
+                  editable
                   onChange={(next) => void changeModelMode(next)}
+                  availableProviders={availableProviders}
+                  canChangeProvider={fresh}
+                  canChangeReasoning={fresh}
                 />
               </View>
             </>
@@ -326,28 +336,6 @@ export const Composer = ({
 
 const messageOf = (cause: unknown): string =>
   cause instanceof Error ? cause.message : String(cause);
-
-const ChromeLabel = ({
-  icon,
-  label,
-}: {
-  icon: "project" | "branch";
-  label: string;
-}) => (
-  <View className="min-w-0 flex-1 flex-row items-center gap-1.5 rounded-full bg-card-elevated/70 px-2.5 py-1.5">
-    {icon === "project" ? (
-      <HugeIcon icon={Folder01Icon} size={13} color="hsl(72 4% 76%)" />
-    ) : (
-      <HugeIcon icon={GitBranchIcon} size={13} color="hsl(72 4% 76%)" />
-    )}
-    <Text
-      className="min-w-0 flex-1 font-sans-medium text-[12px] text-muted-foreground"
-      numberOfLines={1}
-    >
-      {label}
-    </Text>
-  </View>
-);
 
 const PlanPill = ({
   editable,

--- a/apps/mobile/src/components/messages/live-permission-accessory.tsx
+++ b/apps/mobile/src/components/messages/live-permission-accessory.tsx
@@ -1,18 +1,18 @@
 import type { PermissionDecision, PermissionRequest } from "@zuse/wire";
-import { ShieldCheck } from "lucide-react-native";
 import { useState } from "react";
-import { Text, View } from "react-native";
+import { Pressable, Text, TextInput, View } from "react-native";
 
-import { Button } from "~/components/ui/button";
 import { GlassSurface } from "~/components/ui/glass-surface";
-import { describePermissionKind } from "~/lib/permission-presentation";
-
-const ACCENT = "hsl(72 98% 54%)";
+import {
+  describePermissionKind,
+  permissionQuestion,
+} from "~/lib/permission-presentation";
 
 export function LivePermissionAccessory({
   requests,
   bottomInset,
   onDecide,
+  onDenyWithMessage,
 }: {
   requests: readonly PermissionRequest[];
   bottomInset: number;
@@ -20,23 +20,47 @@ export function LivePermissionAccessory({
     request: PermissionRequest,
     decision: PermissionDecision,
   ) => void | Promise<void>;
+  /**
+   * Deny the request and hand the agent free-text guidance to try next. Empty
+   * text falls back to a plain Deny.
+   */
+  onDenyWithMessage: (
+    request: PermissionRequest,
+    message: string,
+  ) => void | Promise<void>;
 }) {
   const [decidingId, setDecidingId] = useState<string | null>(null);
+  const [denyText, setDenyText] = useState("");
   const request = requests[0];
 
   if (!request) return null;
 
-  const { label, detail, mono } = describePermissionKind(request.kind);
+  const { detail, mono } = describePermissionKind(request.kind);
+  const question = permissionQuestion(request.kind);
   const countLabel = requests.length > 1 ? ` +${requests.length - 1}` : "";
+  const busy = decidingId !== null;
 
-  const decide = async (decision: PermissionDecision) => {
-    if (decidingId !== null) return;
+  const run = async (task: () => void | Promise<void>) => {
+    if (busy) return;
     setDecidingId(request.id);
     try {
-      await onDecide(request, decision);
+      await task();
     } finally {
       setDecidingId(null);
+      setDenyText("");
     }
+  };
+
+  const decide = (decision: PermissionDecision) =>
+    void run(() => onDecide(request, decision));
+
+  const deny = () => {
+    const message = denyText.trim();
+    void run(() =>
+      message.length > 0
+        ? onDenyWithMessage(request, message)
+        : onDecide(request, { _tag: "Deny" }),
+    );
   };
 
   return (
@@ -47,68 +71,82 @@ export function LivePermissionAccessory({
     >
       <GlassSurface
         style={{
-          minHeight: 104,
-          paddingHorizontal: 12,
-          paddingVertical: 12,
+          paddingHorizontal: 14,
+          paddingVertical: 14,
+          gap: 12,
         }}
       >
-        <View className="flex-row gap-3">
-          <View className="mt-0.5 h-9 w-9 items-center justify-center rounded-full bg-primary/15">
-            <ShieldCheck size={18} color={ACCENT} />
-          </View>
-          <View className="min-w-0 flex-1">
-            <View className="flex-row items-center gap-2">
-              <Text className="font-sans-medium text-[12px] uppercase text-primary">
-                Permission{countLabel}
-              </Text>
-              <Text className="font-sans text-[12px] text-muted-foreground">
-                live
-              </Text>
-            </View>
+        <Text className="font-sans-medium text-[12px] uppercase text-primary">
+          Permission{countLabel}
+        </Text>
+        <Text className="font-sans-bold text-[16px] leading-5 text-foreground">
+          {question}
+        </Text>
+        {mono ? (
+          <View
+            className="rounded-xl border border-border bg-card px-3 py-2"
+            style={{ borderCurve: "continuous" }}
+          >
             <Text
-              className="mt-0.5 font-sans-medium text-[15px] text-foreground"
-              numberOfLines={1}
-            >
-              {label}
-            </Text>
-            <Text
-              className={
-                mono
-                  ? "mt-0.5 font-mono text-[12px] leading-5 text-muted-foreground"
-                  : "mt-0.5 font-sans text-[13px] leading-5 text-muted-foreground"
-              }
-              numberOfLines={2}
+              selectable
+              className="font-mono text-[12px] leading-5 text-foreground"
+              numberOfLines={4}
             >
               {detail}
             </Text>
           </View>
-        </View>
-        <View className="mt-3 flex-row flex-wrap gap-2 pl-12">
-          <Button
-            size="sm"
-            disabled={decidingId !== null}
-            onPress={() => void decide({ _tag: "AllowOnce" })}
+        ) : (
+          <Text
+            className="font-sans text-[13px] leading-5 text-muted-foreground"
+            numberOfLines={3}
           >
-            Allow once
-          </Button>
-          {request.forcePrompt ? null : (
-            <Button
-              size="sm"
-              variant="secondary"
-              disabled={decidingId !== null}
-              onPress={() => void decide({ _tag: "AllowForSession" })}
-            >
-              Allow session
-            </Button>
-          )}
-          <Button
-            size="sm"
-            variant="danger"
-            disabled={decidingId !== null}
-            onPress={() => void decide({ _tag: "Deny" })}
+            {detail}
+          </Text>
+        )}
+        <Pressable
+          accessibilityRole="button"
+          disabled={busy}
+          onPress={() => decide({ _tag: "AllowOnce" })}
+          className="h-12 items-center justify-center rounded-full bg-foreground active:opacity-80"
+          style={{ borderCurve: "continuous", opacity: busy ? 0.45 : 1 }}
+        >
+          <Text className="font-sans-medium text-[16px] text-background">
+            Approve
+          </Text>
+        </Pressable>
+        {request.forcePrompt ? null : (
+          <Pressable
+            accessibilityRole="button"
+            disabled={busy}
+            onPress={() => decide({ _tag: "AllowForSession" })}
+            className="h-11 items-center justify-center rounded-full active:opacity-70"
           >
-            Decline
-          </Button>
+            <Text className="font-sans-medium text-[15px] text-muted-foreground">
+              Always approve
+            </Text>
+          </Pressable>
+        )}
+        <View className="flex-row items-center gap-2">
+          <TextInput
+            className="h-11 min-w-0 flex-1 rounded-full bg-card px-4 font-sans text-[15px] text-foreground"
+            placeholder="Tell the agent what to do"
+            placeholderTextColor="hsl(72 4% 56%)"
+            value={denyText}
+            onChangeText={setDenyText}
+            editable={!busy}
+            style={{ borderCurve: "continuous" }}
+          />
+          <Pressable
+            accessibilityRole="button"
+            disabled={busy}
+            onPress={deny}
+            hitSlop={8}
+            className="px-3 py-2 active:opacity-70"
+          >
+            <Text className="font-sans-medium text-[15px] text-danger">
+              Deny
+            </Text>
+          </Pressable>
         </View>
       </GlassSurface>
     </View>

--- a/apps/mobile/src/components/messages/message-row.tsx
+++ b/apps/mobile/src/components/messages/message-row.tsx
@@ -31,6 +31,7 @@ import {
   type MobileToolIcon,
 } from "~/lib/tool-presentation";
 import { putPlanDocument } from "~/store/plan-viewer";
+import { ShimmerText } from "~/components/ui/shimmer-text";
 import { Markdown } from "./markdown";
 import {
   PendingUserInputCard,
@@ -43,6 +44,8 @@ export type MessageRowContext = {
   questionsByItemId: ReadonlyMap<string, readonly UserQuestion[]>;
   toolResultsByItemId: ReadonlyMap<string, ToolResultRecord>;
   planMode?: boolean;
+  /** Whether the session is actively running (drives the shimmer on the last row). */
+  sessionRunning?: boolean;
   onAnswerQuestion: (
     itemId: string,
     answers: readonly QuestionAnswer[],
@@ -52,14 +55,16 @@ export type MessageRowContext = {
 export const MessageRow = ({
   message,
   ctx,
+  isLast = false,
 }: {
   message: Message;
   ctx: MessageRowContext;
+  isLast?: boolean;
 }) => (
   <MessageRowBoundary
     context={`message-row:${message.id}:${message.content._tag}`}
   >
-    <MessageRowContent message={message} ctx={ctx} />
+    <MessageRowContent message={message} ctx={ctx} isLast={isLast} />
   </MessageRowBoundary>
 );
 
@@ -91,11 +96,14 @@ class MessageRowBoundary extends React.Component<
 const MessageRowContent = ({
   message,
   ctx,
+  isLast,
 }: {
   message: Message;
   ctx: MessageRowContext;
+  isLast: boolean;
 }) => {
   const content = message.content;
+  const shimmerActive = ctx.sessionRunning === true && isLast;
   switch (content._tag) {
     case "user":
       return <UserBubble text={content.text} goal={content.goal} />;
@@ -115,12 +123,13 @@ const MessageRowContent = ({
         />
       );
     case "thinking":
-      return <ThinkingRow content={content} />;
+      return <ThinkingRow content={content} shimmer={shimmerActive} />;
     case "tool_use":
       return (
         <ToolUseRow
           content={content}
           result={ctx.toolResultsByItemId.get(content.itemId)}
+          shimmer={shimmerActive}
         />
       );
     case "tool_result":
@@ -256,38 +265,75 @@ const PlanPreview = ({ text }: { text: string }) => {
 
 const ThinkingRow = ({
   content,
+  shimmer,
 }: {
   content: Extract<MessageContent, { _tag: "thinking" }>;
+  shimmer: boolean;
 }) => (
-  <ExpandableEventRow
+  <PlainEventRow
     icon="thinking"
-    title={content.redacted ? "Redacted thinking" : "Thinking"}
-    detail={content.redacted ? "Hidden by the model" : firstLine(content.text)}
+    label={content.redacted ? "Redacted thinking" : "Thinking"}
+    shimmer={shimmer && !content.redacted}
   >
-    <Text className="font-sans text-sm leading-5 text-muted-foreground">
+    <Text className="font-sans text-[13px] leading-5 text-muted-foreground">
       {content.redacted ? "Thought content was redacted." : content.text}
     </Text>
-  </ExpandableEventRow>
+  </PlainEventRow>
 );
 
 const ToolUseRow = ({
   content,
   result,
+  shimmer,
 }: {
   content: Extract<MessageContent, { _tag: "tool_use" }>;
   result?: ToolResultRecord;
+  shimmer: boolean;
 }) => {
   const view = buildToolPresentation(content, result);
+  const running = view.resultLabel === "Running";
 
-  return (
-    <ExpandableEventRow
-      icon={view.icon}
-      title={view.label}
-      detail={view.detail ?? undefined}
-      badge={view.resultLabel}
-      danger={view.isError}
-    >
-      {view.editSummaries.length > 0 ? (
+  // Errors keep the boxed danger row for readability (risk containment).
+  if (view.isError) {
+    return (
+      <ExpandableEventRow
+        icon={view.icon}
+        title={view.label}
+        detail={view.detail ?? undefined}
+        badge={view.resultLabel}
+        danger
+      >
+        <Text className="font-mono text-xs leading-5 text-muted-foreground">
+          {view.body}
+        </Text>
+        {view.resultBody !== null ? (
+          <View className="mt-3 border-t border-border pt-3">
+            <Text className="mb-1 font-sans-medium text-[11px] uppercase text-danger">
+              Error
+            </Text>
+            <Text
+              selectable
+              className="font-mono text-xs leading-5 text-muted-foreground"
+              numberOfLines={8}
+            >
+              {view.resultBody}
+            </Text>
+          </View>
+        ) : null}
+      </ExpandableEventRow>
+    );
+  }
+
+  // File-changing tools keep a subtle rounded container headed by the change
+  // summary, expandable to the per-file mono diffs.
+  if (view.fileChangeSummary !== null) {
+    return (
+      <ExpandableEventRow
+        icon="edit"
+        title={view.fileChangeSummary}
+        badge={running ? "Running" : undefined}
+        shimmer={shimmer && running}
+      >
         <View className="gap-2">
           {view.editSummaries.map((summary) => (
             <View
@@ -319,31 +365,30 @@ const ToolUseRow = ({
             </View>
           ))}
         </View>
-      ) : (
-        <Text className="font-mono text-xs leading-5 text-muted-foreground">
-          {view.body}
-        </Text>
-      )}
+      </ExpandableEventRow>
+    );
+  }
+
+  // Everything else: a plain full-width tool line.
+  return (
+    <PlainEventRow
+      icon={view.icon}
+      label={view.inlineLabel}
+      shimmer={shimmer && running}
+    >
+      <Text className="font-mono text-xs leading-5 text-muted-foreground">
+        {view.body}
+      </Text>
       {view.resultBody !== null ? (
-        <View className="mt-3 border-t border-border pt-3">
-          <Text
-            className={cn(
-              "mb-1 font-sans-medium text-[11px] uppercase text-muted-foreground",
-              view.isError && "text-danger",
-            )}
-          >
-            {view.isError ? "Error" : "Result"}
-          </Text>
-          <Text
-            selectable
-            className="font-mono text-xs leading-5 text-muted-foreground"
-            numberOfLines={8}
-          >
-            {view.resultBody}
-          </Text>
-        </View>
+        <Text
+          selectable
+          className="mt-2 font-mono text-xs leading-5 text-muted-foreground"
+          numberOfLines={8}
+        >
+          {view.resultBody}
+        </Text>
       ) : null}
-    </ExpandableEventRow>
+    </PlainEventRow>
   );
 };
 
@@ -351,21 +396,31 @@ const ToolResultRow = ({
   content,
 }: {
   content: Extract<MessageContent, { _tag: "tool_result" }>;
-}) => (
-  <ExpandableEventRow
-    icon="wrench"
-    title={content.isError ? "Tool error" : "Tool result"}
-    detail={summarizeValue(content.output, 96)}
-    danger={content.isError}
-  >
-    <Text
-      selectable
-      className="font-mono text-xs leading-5 text-muted-foreground"
+}) =>
+  content.isError ? (
+    <ExpandableEventRow
+      icon="wrench"
+      title="Tool error"
+      detail={summarizeValue(content.output, 96)}
+      danger
     >
-      {summarizeValue(content.output)}
-    </Text>
-  </ExpandableEventRow>
-);
+      <Text
+        selectable
+        className="font-mono text-xs leading-5 text-muted-foreground"
+      >
+        {summarizeValue(content.output)}
+      </Text>
+    </ExpandableEventRow>
+  ) : (
+    <PlainEventRow icon="wrench" label="Tool result">
+      <Text
+        selectable
+        className="font-mono text-xs leading-5 text-muted-foreground"
+      >
+        {summarizeValue(content.output)}
+      </Text>
+    </PlainEventRow>
+  );
 
 const ErrorRow = ({ message }: { message: string }) => (
   <View className="px-2 py-2">
@@ -564,12 +619,60 @@ const richChips = (content: Extract<MessageContent, { _tag: "user_rich" }>) => [
   ...content.skillRefs.map((skill) => skill.name),
 ];
 
+/**
+ * Boxless, full-width event row for thinking / non-error tool lines: a leading
+ * muted icon, a single-line label (optionally shimmering while the row is the
+ * last running one), and a trailing chevron. Expanded content renders as plain
+ * indented text — no border, no background.
+ */
+function PlainEventRow({
+  icon,
+  label,
+  shimmer = false,
+  children,
+}: {
+  icon: "thinking" | "hourglass" | MobileToolIcon;
+  label: string;
+  shimmer?: boolean;
+  children: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ expanded }}
+      onPress={() => setExpanded((value) => !value)}
+      className="px-2 py-1.5 active:opacity-60"
+    >
+      <View className="flex-row items-center gap-2">
+        {renderToolRowIcon(icon, "hsl(72 2% 64%)")}
+        {shimmer ? (
+          <ShimmerText className="min-w-0 flex-1 font-sans text-[13px] text-muted-foreground">
+            {label}
+          </ShimmerText>
+        ) : (
+          <Text
+            className="min-w-0 flex-1 font-sans text-[13px] text-muted-foreground"
+            numberOfLines={1}
+          >
+            {label}
+          </Text>
+        )}
+        <Chevron size={12} color="hsl(72 2% 64%)" />
+      </View>
+      {expanded ? <View className="mt-2 pl-6">{children}</View> : null}
+    </Pressable>
+  );
+}
+
 function ExpandableEventRow({
   title,
   detail,
   badge,
   danger,
   icon,
+  shimmer = false,
   children,
 }: {
   title: string;
@@ -577,6 +680,7 @@ function ExpandableEventRow({
   badge?: string;
   danger?: boolean;
   icon: "thinking" | "hourglass" | MobileToolIcon;
+  shimmer?: boolean;
   children: React.ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -599,15 +703,21 @@ function ExpandableEventRow({
             icon,
             danger ? "hsl(2 86% 64%)" : "hsl(72 98% 54%)",
           )}
-          <Text
-            className={cn(
-              "min-w-0 flex-1 font-sans-medium text-[13px]",
-              danger ? "text-danger" : "text-foreground",
-            )}
-            numberOfLines={1}
-          >
-            {title}
-          </Text>
+          {shimmer && !danger ? (
+            <ShimmerText className="min-w-0 flex-1 font-sans-medium text-[13px] text-foreground">
+              {title}
+            </ShimmerText>
+          ) : (
+            <Text
+              className={cn(
+                "min-w-0 flex-1 font-sans-medium text-[13px]",
+                danger ? "text-danger" : "text-foreground",
+              )}
+              numberOfLines={1}
+            >
+              {title}
+            </Text>
+          )}
           {badge ? (
             <Text
               className={cn(
@@ -713,11 +823,6 @@ function safeSummary(value: unknown): string {
     return "Unsupported message payload";
   }
 }
-
-const firstLine = (value: string): string => {
-  const line = value.trim().split(/\r\n|\r|\n/)[0] ?? "";
-  return line.length > 0 ? line : "(empty)";
-};
 
 const isLikelyPlan = (text: string): boolean => {
   const value = text.toLowerCase();

--- a/apps/mobile/src/components/model-mode-menu.ios.tsx
+++ b/apps/mobile/src/components/model-mode-menu.ios.tsx
@@ -8,11 +8,11 @@ import {
 import type { PermissionMode, ProviderId, RuntimeMode } from "@zuse/wire";
 
 import {
+  defaultModelOptions,
   modelOptionsForProvider,
   PERMISSION_OPTIONS,
   PROVIDER_LABEL,
   providerOptions,
-  reasoningDescriptorForModel,
   reasoningValueForModel,
   RUNTIME_OPTIONS,
 } from "~/lib/model-options";
@@ -61,13 +61,31 @@ export function ComposerModelMenu({
   value,
   editable,
   onChange,
+  availableProviders,
+  canChangeProvider = true,
+  canChangeReasoning = true,
 }: {
   value: ModelModeValue;
   editable: boolean;
   onChange: (value: ModelModeValue) => void;
+  /** Provider ids to show; `null`/`undefined` = no filtering (full catalog). */
+  availableProviders?: readonly ProviderId[] | null;
+  /** When false, only the current provider's model submenu is shown. */
+  canChangeProvider?: boolean;
+  /** When false, the reasoning/effort section is hidden. */
+  canChangeReasoning?: boolean;
 }) {
   return (
-    <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
+    // Re-mount the native Host on provider/model change: iOS UIMenu snapshots
+    // its content when opened, so switching provider/model must rebuild the
+    // menu to refresh the reasoning options on next open. The re-mount is
+    // invisible because a model tap dismisses the menu first.
+    <Host
+      key={`${value.providerId}:${value.model}`}
+      matchContents
+      seedColor="hsl(72 98% 54%)"
+      colorScheme="dark"
+    >
       <Menu
         label={compactModelLabel(value)}
         systemImage={providerSystemImage(value.providerId)}
@@ -76,12 +94,16 @@ export function ComposerModelMenu({
           value={value}
           editable={editable}
           onChange={onChange}
+          availableProviders={availableProviders}
+          canChangeProvider={canChangeProvider}
         />
-        <ReasoningButtons
-          value={value}
-          editable={editable}
-          onChange={onChange}
-        />
+        {canChangeReasoning ? (
+          <ReasoningButtons
+            value={value}
+            editable={editable}
+            onChange={onChange}
+          />
+        ) : null}
       </Menu>
     </Host>
   );
@@ -343,14 +365,30 @@ function ProviderModelMenus({
   value,
   editable,
   onChange,
+  availableProviders,
+  canChangeProvider = true,
 }: {
   value: ModelModeValue;
   editable: boolean;
   onChange: (value: ModelModeValue) => void;
+  availableProviders?: readonly ProviderId[] | null;
+  canChangeProvider?: boolean;
 }) {
+  const providers = providerOptions().filter((provider) => {
+    // Locked to the current provider mid-session (provider swaps need a fresh
+    // chat) — show only its model submenu.
+    if (!canChangeProvider) return provider.value === value.providerId;
+    // Hide providers whose CLI isn't installed; keep the current provider so a
+    // stale selection never vanishes from the menu.
+    if (availableProviders == null) return true;
+    return (
+      provider.value === value.providerId ||
+      availableProviders.includes(provider.value)
+    );
+  });
   return (
     <Section title="Models">
-      {providerOptions().map((provider) => (
+      {providers.map((provider) => (
         <Menu
           key={provider.value}
           label={provider.label}
@@ -514,17 +552,6 @@ const modeLabel = (value: ModelModeValue): string =>
 const runtimeLabel = (value: ModelModeValue): string =>
   RUNTIME_OPTIONS.find((item) => item.value === value.runtimeMode)?.label ??
   value.runtimeMode;
-
-const defaultModelOptions = (
-  providerId: ProviderId,
-  model: string,
-): Record<string, string> | undefined => {
-  const descriptor = reasoningDescriptorForModel(providerId, model);
-  const value = descriptor?.defaultId ?? descriptor?.options[0]?.id;
-  return descriptor !== null && value !== undefined
-    ? { [descriptor.id]: value }
-    : undefined;
-};
 
 const providerSystemImage = (providerId: ProviderId): string => {
   switch (providerId) {

--- a/apps/mobile/src/components/model-mode-menu.tsx
+++ b/apps/mobile/src/components/model-mode-menu.tsx
@@ -31,6 +31,10 @@ export function ComposerModelMenu({
   value: ModelModeValue;
   editable: boolean;
   onChange: (value: ModelModeValue) => void;
+  // Inert on non-iOS; kept to mirror the native twin's signature.
+  availableProviders?: readonly ProviderId[] | null;
+  canChangeProvider?: boolean;
+  canChangeReasoning?: boolean;
 }) {
   const modelLabel =
     modelOptionsForProvider(value.providerId).find(

--- a/apps/mobile/src/components/selector-row.ios.tsx
+++ b/apps/mobile/src/components/selector-row.ios.tsx
@@ -1,0 +1,58 @@
+import { Host } from "@expo/ui";
+import { Button as NativeButton, Menu } from "@expo/ui/swift-ui";
+import type { ReactNode } from "react";
+import { ChevronsUpDown } from "lucide-react-native";
+import { View } from "react-native";
+
+export type SelectorOption = {
+  key: string;
+  label: string;
+  selected: boolean;
+  onSelect: () => void;
+};
+
+/**
+ * A transparent (no pill chrome) new-chat selector row: a muted leading icon, a
+ * native @expo/ui Menu-wrapped label, and a trailing up/down chevron. Tapping
+ * the label opens the native menu of options.
+ */
+export function SelectorRow({
+  leading,
+  label,
+  options,
+  disabled = false,
+  emptyLabel = "None",
+}: {
+  leading: ReactNode;
+  label: string;
+  options: readonly SelectorOption[];
+  disabled?: boolean;
+  emptyLabel?: string;
+}) {
+  return (
+    <View className="flex-row items-center gap-2 py-2">
+      {leading}
+      <View className="min-w-0 flex-1">
+        <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
+          <Menu label={label}>
+            {disabled || options.length === 0 ? (
+              <NativeButton label={emptyLabel} onPress={() => {}} />
+            ) : (
+              options.map((option) => (
+                <NativeButton
+                  key={option.key}
+                  label={option.label}
+                  systemImage={option.selected ? sf("checkmark") : undefined}
+                  onPress={option.onSelect}
+                />
+              ))
+            )}
+          </Menu>
+        </Host>
+      </View>
+      <ChevronsUpDown size={12} color="hsl(72 2% 64%)" />
+    </View>
+  );
+}
+
+const sf = (name: string) => name as never;

--- a/apps/mobile/src/components/selector-row.tsx
+++ b/apps/mobile/src/components/selector-row.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { ChevronsUpDown } from "lucide-react-native";
+import { Text, View } from "react-native";
+
+export type SelectorOption = {
+  key: string;
+  label: string;
+  selected: boolean;
+  onSelect: () => void;
+};
+
+/**
+ * Non-iOS stub of the selector row: renders the icon + current label + chevron
+ * without the native menu (this app is iOS-first).
+ */
+export function SelectorRow({
+  leading,
+  label,
+}: {
+  leading: ReactNode;
+  label: string;
+  options: readonly SelectorOption[];
+  disabled?: boolean;
+  emptyLabel?: string;
+}) {
+  return (
+    <View className="flex-row items-center gap-2 py-2">
+      {leading}
+      <Text
+        className="min-w-0 flex-1 font-sans-medium text-[15px] text-foreground"
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <ChevronsUpDown size={12} color="hsl(72 2% 64%)" />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/session-actions-menu.ios.tsx
+++ b/apps/mobile/src/components/session-actions-menu.ios.tsx
@@ -1,0 +1,34 @@
+import { Host } from "@expo/ui";
+import { Button as NativeButton, Menu } from "@expo/ui/swift-ui";
+
+/**
+ * Header "…" menu for the session screen: Rename (hidden when the chat has no
+ * id yet) and Archive. Native UIMenu via @expo/ui so it matches the platform.
+ */
+export function SessionActionsMenu({
+  onRename,
+  onArchive,
+}: {
+  onRename?: () => void;
+  onArchive: () => void;
+}) {
+  return (
+    <Host matchContents seedColor="hsl(72 98% 54%)" colorScheme="dark">
+      <Menu label="" systemImage="ellipsis">
+        {onRename !== undefined ? (
+          <NativeButton
+            label="Rename chat"
+            systemImage="pencil"
+            onPress={onRename}
+          />
+        ) : null}
+        <NativeButton
+          label="Archive chat"
+          systemImage="archivebox"
+          role="destructive"
+          onPress={onArchive}
+        />
+      </Menu>
+    </Host>
+  );
+}

--- a/apps/mobile/src/components/session-actions-menu.tsx
+++ b/apps/mobile/src/components/session-actions-menu.tsx
@@ -1,0 +1,8 @@
+// Non-iOS stub: the native UIMenu header action lives in the `.ios.tsx` twin.
+// This app is iOS-first; on other platforms the header omits the "…" menu.
+export function SessionActionsMenu(_props: {
+  onRename?: () => void;
+  onArchive: () => void;
+}) {
+  return null;
+}

--- a/apps/mobile/src/components/session-row.tsx
+++ b/apps/mobile/src/components/session-row.tsx
@@ -2,9 +2,9 @@ import type { Chat, Session, SessionStatus } from "@zuse/wire";
 import { Pressable, Text, View } from "react-native";
 import { ChevronRight } from "lucide-react-native";
 
+import { cn } from "~/lib/cn";
 import { lightTap } from "~/lib/haptics";
 import { StatusDot } from "./ui/status-dot";
-import { UnreadBadge } from "./unread-badge";
 
 /**
  * A session row styled to sit inside an iOS grouped list (`ListSection`) — no
@@ -32,17 +32,17 @@ export const SessionRow = ({
   >
     <StatusDot status={status ?? session.status} />
     <View className="min-w-0 flex-1">
-      <View className="flex-row items-center gap-2">
-        <Text
-          className="min-w-0 flex-1 font-sans text-[17px] text-foreground"
-          numberOfLines={1}
-        >
-          {chat?.title ?? session.title}
-        </Text>
-        <UnreadBadge visible={unread} />
-      </View>
       <Text
-        className="mt-0.5 font-sans text-[13px] text-muted-foreground"
+        className={cn(
+          "font-sans-medium text-[15px]",
+          unread ? "text-foreground" : "text-muted-foreground",
+        )}
+        numberOfLines={1}
+      >
+        {chat?.title ?? session.title}
+      </Text>
+      <Text
+        className="mt-0.5 font-sans text-[12px] text-muted-foreground"
         numberOfLines={1}
       >
         {session.providerId} / {session.model} · {status ?? session.status}

--- a/apps/mobile/src/components/ui/shimmer-text.tsx
+++ b/apps/mobile/src/components/ui/shimmer-text.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+
+/**
+ * Text whose opacity breathes 0.45 → 1 on a ~1.1s loop to signal "the agent is
+ * working on this right now" (D4). Reanimated-only opacity loop, no gradient
+ * deps. Respects Reduce Motion by rendering at a flat 0.7 opacity. When
+ * `active` is false it settles to full opacity (plain static label).
+ */
+export function ShimmerText({
+  children,
+  className,
+  active = true,
+}: {
+  children: string;
+  className?: string;
+  active?: boolean;
+}) {
+  const reducedMotion = useReducedMotion();
+  const animating = active && !reducedMotion;
+  const progress = useSharedValue(1);
+
+  useEffect(() => {
+    if (animating) {
+      progress.value = withRepeat(
+        withTiming(0.45, { duration: 1100, easing: Easing.inOut(Easing.quad) }),
+        -1,
+        true,
+      );
+      return;
+    }
+    cancelAnimation(progress);
+    progress.value = withTiming(reducedMotion && active ? 0.7 : 1, {
+      duration: 180,
+    });
+  }, [animating, active, reducedMotion, progress]);
+
+  const style = useAnimatedStyle(() => ({ opacity: progress.value }));
+
+  return (
+    <Animated.Text style={style} className={className} numberOfLines={1}>
+      {children}
+    </Animated.Text>
+  );
+}

--- a/apps/mobile/src/components/unread-badge.tsx
+++ b/apps/mobile/src/components/unread-badge.tsx
@@ -1,4 +1,0 @@
-import { Badge } from "./ui/badge";
-
-export const UnreadBadge = ({ visible }: { visible: boolean }) =>
-  visible ? <Badge tone="primary">NEW</Badge> : null;

--- a/apps/mobile/src/lib/composer-state.test.ts
+++ b/apps/mobile/src/lib/composer-state.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { isFreshChat, isInterruptVisible } from "./composer-state";
+import {
+  isFreshChat,
+  isInterruptVisible,
+  nextModelChangeActions,
+  type ModelModeSelection,
+} from "./composer-state";
+
+const base: ModelModeSelection = {
+  providerId: "grok",
+  model: "grok-4",
+  runtimeMode: "approval-required",
+  permissionMode: "default",
+};
 
 describe("composer state helpers", () => {
   test("shows interrupt only for active statuses", () => {
@@ -14,5 +26,51 @@ describe("composer state helpers", () => {
     expect(isFreshChat([])).toBe(true);
     expect(isFreshChat([{ content: { _tag: "assistant" } }])).toBe(true);
     expect(isFreshChat([{ content: { _tag: "user" } }])).toBe(false);
+  });
+});
+
+describe("nextModelChangeActions", () => {
+  test("switches provider on a fresh chat (grok → claude)", () => {
+    const next: ModelModeSelection = {
+      ...base,
+      providerId: "claude",
+      model: "opus",
+    };
+    expect(nextModelChangeActions(base, next, true)).toEqual([
+      { type: "setProvider", providerId: "claude", model: "opus" },
+    ]);
+  });
+
+  test("ignores a provider change mid-chat", () => {
+    const next: ModelModeSelection = {
+      ...base,
+      providerId: "claude",
+      model: "opus",
+    };
+    expect(nextModelChangeActions(base, next, false)).toEqual([]);
+  });
+
+  test("allows a model-only change mid-chat", () => {
+    const next: ModelModeSelection = { ...base, model: "grok-4-fast" };
+    expect(nextModelChangeActions(base, next, false)).toEqual([
+      { type: "setModel", model: "grok-4-fast" },
+    ]);
+  });
+
+  test("issues runtime and permission changes when they differ", () => {
+    const next: ModelModeSelection = {
+      ...base,
+      runtimeMode: "full-access",
+      permissionMode: "plan",
+    };
+    expect(nextModelChangeActions(base, next, false)).toEqual([
+      { type: "setRuntimeMode", runtimeMode: "full-access" },
+      { type: "setPermissionMode", permissionMode: "plan" },
+    ]);
+  });
+
+  test("returns nothing when the selection is unchanged", () => {
+    expect(nextModelChangeActions(base, { ...base }, true)).toEqual([]);
+    expect(nextModelChangeActions(base, { ...base }, false)).toEqual([]);
   });
 });

--- a/apps/mobile/src/lib/composer-state.ts
+++ b/apps/mobile/src/lib/composer-state.ts
@@ -1,7 +1,67 @@
-import type { SessionStatus } from "@zuse/wire";
+import type {
+  PermissionMode,
+  ProviderId,
+  RuntimeMode,
+  SessionStatus,
+} from "@zuse/wire";
 
 export const isInterruptVisible = (status: SessionStatus | undefined): boolean =>
   status === "running" || status === "booting";
+
+/** The four dimensions a model/mode selection can carry. */
+export type ModelModeSelection = {
+  providerId: ProviderId;
+  model: string;
+  runtimeMode: RuntimeMode;
+  permissionMode: PermissionMode;
+};
+
+/** One RPC the composer should issue to reconcile a model/mode change. */
+export type ModelChangeAction =
+  | { type: "setProvider"; providerId: ProviderId; model: string }
+  | { type: "setModel"; model: string }
+  | { type: "setRuntimeMode"; runtimeMode: RuntimeMode }
+  | { type: "setPermissionMode"; permissionMode: PermissionMode };
+
+/**
+ * Pure decision of which session RPCs to call when the user changes the
+ * model/mode selection (D3):
+ *  - Provider swaps are fresh-chat-only (server enforces via
+ *    `SessionAlreadyStartedError`) — ignored mid-session.
+ *  - A model change within the current provider is allowed anytime.
+ *  - Runtime and permission mode changes are always issued when they differ;
+ *    the server accepts or rejects them per session state.
+ */
+export const nextModelChangeActions = (
+  session: ModelModeSelection,
+  next: ModelModeSelection,
+  fresh: boolean,
+): ModelChangeAction[] => {
+  const actions: ModelChangeAction[] = [];
+  if (next.providerId !== session.providerId) {
+    // Provider swap only on a fresh chat; otherwise ignore it (and the model
+    // that came with it — it belongs to the other provider).
+    if (fresh) {
+      actions.push({
+        type: "setProvider",
+        providerId: next.providerId,
+        model: next.model,
+      });
+    }
+  } else if (next.model !== session.model) {
+    actions.push({ type: "setModel", model: next.model });
+  }
+  if (next.runtimeMode !== session.runtimeMode) {
+    actions.push({ type: "setRuntimeMode", runtimeMode: next.runtimeMode });
+  }
+  if (next.permissionMode !== session.permissionMode) {
+    actions.push({
+      type: "setPermissionMode",
+      permissionMode: next.permissionMode,
+    });
+  }
+  return actions;
+};
 
 export const isFreshChat = (messages: readonly { role?: string; content?: { _tag?: string } }[]): boolean =>
   !messages.some(

--- a/apps/mobile/src/lib/display-names.test.ts
+++ b/apps/mobile/src/lib/display-names.test.ts
@@ -12,6 +12,26 @@ describe("mobile display names", () => {
     expect(visibleConnectionLabel("Studio Mac")).toBe("Studio Mac");
   });
 
+  test("passes through human machine names from the server", () => {
+    // macOS computer name (scutil --get ComputerName)
+    expect(visibleConnectionLabel("Whizzy's MacBook Pro")).toBe(
+      "Whizzy's MacBook Pro",
+    );
+    // hostname fallback with .local already stripped server-side
+    expect(visibleConnectionLabel("whizzy-mbp")).toBe("whizzy-mbp");
+    // username fallback
+    expect(visibleConnectionLabel("whizzy")).toBe("whizzy");
+  });
+
+  test("still hides raw ids even when a real label is unknown", () => {
+    expect(visibleConnectionLabel("env-abcdef012345", "env-abcdef012345")).toBe(
+      "Computer",
+    );
+    expect(
+      visibleConnectionLabel(undefined, "0123456789abcdef0123456789ab"),
+    ).toBe("Computer");
+  });
+
   test("shortens long local paths", () => {
     expect(visibleProjectPath("/Users/example/Developer/work/app")).toBe(
       "Developer/work/app",

--- a/apps/mobile/src/lib/inbox.test.ts
+++ b/apps/mobile/src/lib/inbox.test.ts
@@ -5,6 +5,7 @@ import {
   buildInboxListItems,
   DEFAULT_INBOX_GROUP_DISPLAY,
   nextInboxGroupDisplay,
+  relativeTimeLabel,
 } from "./inbox";
 
 const connection = {
@@ -101,6 +102,50 @@ describe("mobile inbox helpers", () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0]?.rows[0]?.title).toBe("Release checklist");
+  });
+
+  test("keeps provider/model searchable but off the visible subtitle", () => {
+    const build = (query: string) =>
+      buildInboxGroups({
+        connections: [connection],
+        bundlesByConnection: {
+          "env-1": [
+            {
+              project,
+              chats: [chat({ title: "Release checklist" })] as never,
+              sessions: [session({ providerId: "codex", model: "gpt-5" })] as never,
+            },
+          ],
+        },
+        statusBySession: {},
+        query,
+      });
+
+    // Search still matches provider/model even though the subtitle now shows time.
+    expect(build("codex")).toHaveLength(1);
+    const row = build("")[0]?.rows[0];
+    expect(row?.providerModel).toBe("codex / gpt-5");
+    expect(row?.subtitle).not.toContain("/");
+    expect(row?.subtitle).not.toContain("codex");
+  });
+
+  test("relativeTimeLabel formats across boundaries", () => {
+    const now = new Date("2026-07-09T12:00:00.000Z").getTime();
+    const minute = 60_000;
+    const hour = 60 * minute;
+    const day = 24 * hour;
+    expect(relativeTimeLabel(0, now)).toBe("");
+    expect(relativeTimeLabel(now - 30 * 1000, now)).toBe("now");
+    expect(relativeTimeLabel(now - 2 * minute, now)).toBe("2m");
+    expect(relativeTimeLabel(now - 3 * hour, now)).toBe("3h");
+    // 2 days ago is within the week → a weekday label.
+    expect(relativeTimeLabel(now - 2 * day, now)).toMatch(
+      /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat)$/,
+    );
+    // Older than a week → a short date.
+    expect(relativeTimeLabel(now - 40 * day, now)).toMatch(
+      /^[A-Z][a-z]{2} \d{1,2}$/,
+    );
   });
 
   test("builds collapsible show-more list items", () => {

--- a/apps/mobile/src/lib/inbox.ts
+++ b/apps/mobile/src/lib/inbox.ts
@@ -22,7 +22,10 @@ export type InboxChatRow = {
   chat: Chat | null;
   session: Session;
   title: string;
+  /** Relative time since the last message ("2m", "3h", "Mon"). */
   subtitle: string;
+  /** `"${providerId} / ${model}"` — kept off the visible row but searchable. */
+  providerModel: string;
   status: SessionStatus;
   unread: boolean;
   updatedAt: number;
@@ -238,6 +241,9 @@ const rowForSession = ({
 }): InboxChatRow => {
   const status =
     statusBySession[connectionSessionKey(connection.key, session.id)] ?? session.status;
+  const updatedAt = timestampOf(
+    chat?.lastMessageAt ?? chat?.updatedAt ?? chat?.createdAt ?? 0,
+  );
   return {
     key: `chat:${connection.key}:${chat?.id ?? session.id}`,
     connectionKey: connection.key,
@@ -248,12 +254,51 @@ const rowForSession = ({
     chat,
     session,
     title: chat?.title ?? session.title,
-    subtitle: `${session.providerId} / ${session.model}`,
+    subtitle: relativeTimeLabel(updatedAt),
+    providerModel: `${session.providerId} / ${session.model}`,
     status,
     unread: chat !== null && isUnreadChat(chat),
-    updatedAt: timestampOf(chat?.lastMessageAt ?? chat?.updatedAt ?? chat?.createdAt ?? 0),
+    updatedAt,
   };
 };
+
+/**
+ * Compact relative-time label for an inbox row: "now", "2m", "3h", a weekday
+ * for the past week ("Mon"), then a short date ("Jul 3"). Returns "" when the
+ * timestamp is unknown. `now` is injectable for testing.
+ */
+export const relativeTimeLabel = (
+  updatedAt: number,
+  now: number = Date.now(),
+): string => {
+  if (!Number.isFinite(updatedAt) || updatedAt <= 0) return "";
+  const diff = Math.max(0, now - updatedAt);
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "now";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const date = new Date(updatedAt);
+  if (days < 7) return WEEKDAYS[date.getDay()] ?? "";
+  return `${MONTHS[date.getMonth()] ?? ""} ${date.getDate()}`.trim();
+};
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
 
 const compareRows = (a: InboxChatRow, b: InboxChatRow): number => {
   const active = Number(isActiveStatus(b.status)) - Number(isActiveStatus(a.status));
@@ -270,7 +315,7 @@ const matchesQuery = (row: InboxChatRow, query: string): boolean => {
     row.projectName,
     row.projectPath,
     row.connectionLabel,
-    row.subtitle,
+    row.providerModel,
     row.status,
     row.chat?.id,
     row.session.id,

--- a/apps/mobile/src/lib/model-options.test.ts
+++ b/apps/mobile/src/lib/model-options.test.ts
@@ -1,0 +1,47 @@
+import type { AgentAvailability } from "@zuse/wire";
+import { describe, expect, test } from "bun:test";
+
+import { availableProviderIds } from "./model-options";
+
+const entry = (
+  providerId: AgentAvailability["providerId"],
+  overrides: Partial<AgentAvailability> = {},
+): AgentAvailability => ({
+  providerId,
+  displayName: providerId,
+  cliInstalled: true,
+  cliLoggedIn: true,
+  hasApiKey: false,
+  ...overrides,
+});
+
+describe("availableProviderIds", () => {
+  test("returns null (no filtering) for null/undefined availability", () => {
+    expect(availableProviderIds(null)).toBeNull();
+    expect(availableProviderIds(undefined)).toBeNull();
+  });
+
+  test("keeps ready and warning providers, drops error/disabled", () => {
+    const availability: AgentAvailability[] = [
+      entry("codex", { status: "ready" }),
+      entry("claude", { status: "warning" }),
+      entry("grok", { status: "error" }),
+      entry("gemini", { status: "disabled" }),
+    ];
+    expect(availableProviderIds(availability)).toEqual(["codex", "claude"]);
+  });
+
+  test("falls back to cliInstalled when status is missing", () => {
+    const availability: AgentAvailability[] = [
+      entry("codex", { cliInstalled: true }),
+      entry("claude", { cliInstalled: false }),
+    ];
+    expect(availableProviderIds(availability)).toEqual(["codex"]);
+  });
+
+  test("returns an empty list when nothing is available", () => {
+    expect(availableProviderIds([entry("codex", { status: "error" })])).toEqual(
+      [],
+    );
+  });
+});

--- a/apps/mobile/src/lib/model-options.ts
+++ b/apps/mobile/src/lib/model-options.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentAvailability,
   defaultModelFor,
   findModelDescriptor,
   MODELS_BY_PROVIDER,
@@ -62,6 +63,44 @@ export const reasoningDescriptorForModel = (
       (item.id === "reasoning" || item.id === "effort"),
   );
   return option ?? null;
+};
+
+/**
+ * Default `modelOptions` map (just the reasoning/effort dimension) for a
+ * provider+model, or `undefined` when the model exposes no reasoning
+ * selection. Shared by new-chat and the composer model menu.
+ */
+export const defaultModelOptions = (
+  providerId: ProviderId,
+  model: string,
+): Record<string, string> | undefined => {
+  const descriptor = reasoningDescriptorForModel(providerId, model);
+  const value = descriptor?.defaultId ?? descriptor?.options[0]?.id;
+  return descriptor !== null && value !== undefined
+    ? { [descriptor.id]: value }
+    : undefined;
+};
+
+/**
+ * Provider ids that should appear in the model menu given an availability
+ * report. Returns `null` (= no filtering, show the full catalog) when
+ * availability is `null`/`undefined` — i.e. an old server that doesn't
+ * report availability, or before the report has loaded. Otherwise keeps
+ * providers whose `status` is `ready`/`warning` (a warning provider can still
+ * run — e.g. an update is available), falling back to `cliInstalled === true`
+ * when the server omitted `status`.
+ */
+export const availableProviderIds = (
+  availability: readonly AgentAvailability[] | null | undefined,
+): readonly ProviderId[] | null => {
+  if (availability === null || availability === undefined) return null;
+  return availability
+    .filter((entry) =>
+      entry.status === undefined
+        ? entry.cliInstalled === true
+        : entry.status === "ready" || entry.status === "warning",
+    )
+    .map((entry) => entry.providerId);
 };
 
 export const reasoningValueForModel = (

--- a/apps/mobile/src/lib/new-chat.test.ts
+++ b/apps/mobile/src/lib/new-chat.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildNewChatCreatePayload, MAIN_SOURCE } from "./new-chat";
+import {
+  buildNewChatCreatePayload,
+  MAIN_SOURCE,
+  sourceOptionsForKind,
+} from "./new-chat";
 
 describe("new chat helper", () => {
   test("does not create without prompt or project", () => {
@@ -47,6 +51,51 @@ describe("new chat helper", () => {
       modelOptions: { effort: "high" },
       initialPrompt: "build it",
       createSource: { _tag: "branch", branch: "feature", remote: "origin" },
+    });
+  });
+
+  test("sourceOptionsForKind builds per-kind source objects", () => {
+    const worktrees = [{ id: "wt-1", branch: "feature-a" }] as never;
+    const branches = [
+      { kind: "local", name: "main", current: true, remote: null },
+      { kind: "local", name: "feature-b", current: false, remote: "origin" },
+    ] as never;
+    const prs = [
+      { number: 7, title: "Fix bug", headRefName: "fix-bug" },
+    ] as never;
+
+    expect(sourceOptionsForKind("main", worktrees, branches, prs)).toEqual([
+      { key: "main", label: MAIN_SOURCE.label, source: MAIN_SOURCE },
+    ]);
+
+    expect(
+      sourceOptionsForKind("worktree", worktrees, branches, prs),
+    ).toEqual([
+      {
+        key: "wt-1",
+        label: "feature-a",
+        source: { kind: "worktree", label: "feature-a", worktreeId: "wt-1" },
+      },
+    ]);
+
+    // Current branch is excluded.
+    const branchOpts = sourceOptionsForKind("branch", worktrees, branches, prs);
+    expect(branchOpts).toHaveLength(1);
+    expect(branchOpts[0]?.source).toMatchObject({
+      kind: "branch",
+      label: "feature-b",
+      createSource: { _tag: "branch", branch: "feature-b", remote: "origin" },
+    });
+
+    const prOpts = sourceOptionsForKind("pr", worktrees, branches, prs);
+    expect(prOpts[0]).toMatchObject({
+      key: "pr:7",
+      label: "#7 Fix bug",
+      source: {
+        kind: "pr",
+        label: "#7",
+        createSource: { _tag: "pr", number: 7, headRefName: "fix-bug" },
+      },
     });
   });
 });

--- a/apps/mobile/src/lib/new-chat.ts
+++ b/apps/mobile/src/lib/new-chat.ts
@@ -1,9 +1,12 @@
 import type {
   Chat,
   Folder,
+  GitBranchInfo,
+  GitPrSummary,
   PermissionMode,
   ProviderId,
   RuntimeMode,
+  Worktree,
   WorktreeCreateSource,
   WorktreeId,
 } from "@zuse/wire";
@@ -57,6 +60,90 @@ export const MAIN_SOURCE: NewChatSource = {
   kind: "main",
   label: "Main checkout",
   worktreeId: null,
+};
+
+export type NewChatSourceKind = NewChatSource["kind"];
+
+/** A pickable source in the branch selector for a given work-mode. */
+export type NewChatSourceOption = {
+  key: string;
+  label: string;
+  source: NewChatSource;
+};
+
+/** Work-mode categories shown in the new-chat work-mode selector. */
+export const WORK_MODE_OPTIONS: readonly {
+  kind: NewChatSourceKind;
+  label: string;
+}[] = [
+  { kind: "main", label: "Work locally" },
+  { kind: "worktree", label: "New worktree" },
+  { kind: "branch", label: "Existing branch" },
+  { kind: "pr", label: "Pull request" },
+];
+
+export const workModeLabel = (kind: NewChatSourceKind): string =>
+  WORK_MODE_OPTIONS.find((option) => option.kind === kind)?.label ??
+  "Work locally";
+
+/**
+ * The concrete source options for the branch selector given the chosen
+ * work-mode, derived from the already-fetched worktree/branch/PR lists. Pure so
+ * the row content is testable. Builds the same {@link NewChatSource} objects
+ * the screen used before the layout change.
+ */
+export const sourceOptionsForKind = (
+  kind: NewChatSourceKind,
+  worktrees: readonly Worktree[],
+  branches: readonly GitBranchInfo[],
+  prs: readonly GitPrSummary[],
+): NewChatSourceOption[] => {
+  switch (kind) {
+    case "main":
+      return [{ key: "main", label: MAIN_SOURCE.label, source: MAIN_SOURCE }];
+    case "worktree":
+      return worktrees.map((worktree) => ({
+        key: worktree.id,
+        label: worktree.branch,
+        source: {
+          kind: "worktree",
+          label: worktree.branch,
+          worktreeId: worktree.id,
+        },
+      }));
+    case "branch":
+      return branches
+        .filter((branch) => !branch.current)
+        .map((branch) => ({
+          key: `${branch.kind}:${branch.name}`,
+          label: branch.name,
+          source: {
+            kind: "branch",
+            label: branch.name,
+            worktreeId: null,
+            createSource: {
+              _tag: "branch",
+              branch: branch.name,
+              remote: branch.remote,
+            },
+          },
+        }));
+    case "pr":
+      return prs.map((pr) => ({
+        key: `pr:${pr.number}`,
+        label: `#${pr.number} ${pr.title}`,
+        source: {
+          kind: "pr",
+          label: `#${pr.number}`,
+          worktreeId: null,
+          createSource: {
+            _tag: "pr",
+            number: pr.number,
+            headRefName: pr.headRefName,
+          },
+        },
+      }));
+  }
 };
 
 export const buildNewChatCreatePayload = (

--- a/apps/mobile/src/lib/permission-presentation.test.ts
+++ b/apps/mobile/src/lib/permission-presentation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { describePermissionKind } from "./permission-presentation";
+import {
+  describePermissionKind,
+  permissionQuestion,
+} from "./permission-presentation";
 
 describe("permission presentation helpers", () => {
   test("summarizes permission kinds for compact mobile chrome", () => {
@@ -19,5 +22,20 @@ describe("permission presentation helpers", () => {
       detail: "Approve change",
       mono: false,
     });
+  });
+
+  test("phrases a headline question per kind", () => {
+    expect(permissionQuestion({ _tag: "Bash", command: "ls" })).toBe(
+      "Do you want to allow running this command?",
+    );
+    expect(permissionQuestion({ _tag: "FileWrite", path: "a.ts" })).toBe(
+      "Do you want to allow writing to this file?",
+    );
+    expect(
+      permissionQuestion({ _tag: "Network", url: "https://x.dev" }),
+    ).toBe("Do you want to allow this network request?");
+    expect(
+      permissionQuestion({ _tag: "Other", tool: "X", summary: "y" }),
+    ).toBe("Do you want to allow this action?");
   });
 });

--- a/apps/mobile/src/lib/permission-presentation.ts
+++ b/apps/mobile/src/lib/permission-presentation.ts
@@ -20,3 +20,20 @@ export const describePermissionKind = (
       return { label: kind.tool, detail: kind.summary, mono: false };
   }
 };
+
+/**
+ * Bold headline question for the docked permission panel, phrased per kind so
+ * the ask reads naturally above the command/detail box.
+ */
+export const permissionQuestion = (kind: PermissionKind): string => {
+  switch (kind._tag) {
+    case "Bash":
+      return "Do you want to allow running this command?";
+    case "FileWrite":
+      return "Do you want to allow writing to this file?";
+    case "Network":
+      return "Do you want to allow this network request?";
+    case "Other":
+      return "Do you want to allow this action?";
+  }
+};

--- a/apps/mobile/src/lib/tool-presentation.test.ts
+++ b/apps/mobile/src/lib/tool-presentation.test.ts
@@ -56,4 +56,50 @@ describe("mobile tool presentation", () => {
     expect(toResultText([{ type: "text", text: "hello" }])).toBe("hello");
     expect(lineCountOf("a\nb\nc")).toBe(3);
   });
+
+  test("builds compact inline labels per tool", () => {
+    expect(
+      buildToolPresentation(toolUse("Bash", { command: "pwd && ls\nmore" }))
+        .inlineLabel,
+    ).toBe("Ran pwd && ls");
+    expect(
+      buildToolPresentation(toolUse("Read", { file_path: "src/app.ts" }))
+        .inlineLabel,
+    ).toBe("Read app.ts");
+    expect(
+      buildToolPresentation(
+        toolUse("Write", { file_path: "a/b/new.ts", content: "x" }),
+      ).inlineLabel,
+    ).toBe("Created new.ts");
+    expect(
+      buildToolPresentation(
+        toolUse("Edit", {
+          file_path: "src/app.ts",
+          old_string: "a",
+          new_string: "b",
+        }),
+      ).inlineLabel,
+    ).toBe("Edited app.ts");
+    // Falls back to the tool label when the natural argument is missing.
+    expect(buildToolPresentation(toolUse("Bash", {})).inlineLabel).toBe("Bash");
+    expect(
+      buildToolPresentation(toolUse("Grep", { pattern: "foo", path: "src" }))
+        .inlineLabel,
+    ).toBe("Grep");
+  });
+
+  test("summarizes file changes across edits", () => {
+    expect(
+      buildToolPresentation(
+        toolUse("Edit", {
+          file_path: "src/app.ts",
+          old_string: "a",
+          new_string: "a\nb\nc",
+        }),
+      ).fileChangeSummary,
+    ).toBe("1 file changed +3 −1");
+    expect(
+      buildToolPresentation(toolUse("Bash", { command: "ls" })).fileChangeSummary,
+    ).toBeNull();
+  });
 });

--- a/apps/mobile/src/lib/tool-presentation.ts
+++ b/apps/mobile/src/lib/tool-presentation.ts
@@ -21,12 +21,23 @@ export type MobileToolIcon =
 export type MobileToolPresentation = {
   icon: MobileToolIcon;
   label: string;
+  /**
+   * Compact one-line label for the plain (boxless) tool row, e.g. "Ran bun
+   * test", "Edited app.ts", "Read app.ts". Falls back to {@link label} for
+   * tools without a natural verb phrase.
+   */
+  inlineLabel: string;
   detail: string | null;
   body: string;
   resultBody: string | null;
   resultLabel: "Running" | "Result" | "Error";
   isError: boolean;
   editSummaries: ReturnType<typeof extractEditSummaries>;
+  /**
+   * "N file(s) changed +A −B" header for the file-change container, or `null`
+   * when the tool produced no edit summaries.
+   */
+  fileChangeSummary: string | null;
 };
 
 type ToolUseContent = Extract<MessageContent, { _tag: "tool_use" }>;
@@ -44,12 +55,75 @@ export const buildToolPresentation = (
 
   return {
     ...base,
+    inlineLabel: inlineLabelFor(normalizedTool, input, content.input, base.label),
     resultBody: resultText,
     resultLabel:
       result === undefined ? "Running" : result.isError ? "Error" : "Result",
     isError: result?.isError === true,
     editSummaries,
+    fileChangeSummary: fileChangeSummaryFor(editSummaries),
   };
+};
+
+const inlineLabelFor = (
+  tool: string,
+  input: Record<string, unknown>,
+  rawInput: unknown,
+  fallbackLabel: string,
+): string => {
+  switch (tool) {
+    case "Bash":
+    case "Shell":
+    case "Execute":
+    case "Run":
+    case "run_shell_command":
+    case "run_terminal_cmd": {
+      const command =
+        stringValue(input.command) ??
+        stringValue(input.cmd) ??
+        stringValue(input.shell_command);
+      return command === null
+        ? fallbackLabel
+        : `Ran ${firstLineOf(command)}`;
+    }
+    case "Write":
+    case "WriteFile": {
+      const path = stringValue(input.file_path) ?? stringValue(input.path);
+      return path === null ? fallbackLabel : `Created ${basename(path)}`;
+    }
+    case "Edit":
+    case "MultiEdit": {
+      const path = stringValue(input.file_path) ?? stringValue(input.path);
+      return path === null ? fallbackLabel : `Edited ${basename(path)}`;
+    }
+    case "Read":
+    case "ReadFile": {
+      const path = stringValue(input.file_path) ?? stringValue(input.path);
+      return path === null ? fallbackLabel : `Read ${basename(path)}`;
+    }
+    default:
+      return fallbackLabel;
+  }
+};
+
+const fileChangeSummaryFor = (
+  summaries: readonly { added: number; removed: number }[],
+): string | null => {
+  if (summaries.length === 0) return null;
+  const added = summaries.reduce((sum, item) => sum + item.added, 0);
+  const removed = summaries.reduce((sum, item) => sum + item.removed, 0);
+  const files = `${summaries.length} file${summaries.length === 1 ? "" : "s"} changed`;
+  return `${files} +${added} −${removed}`;
+};
+
+const firstLineOf = (value: string): string => {
+  const line = value.trim().split(/\r\n|\r|\n/)[0] ?? "";
+  return line.length > 0 ? line : value.trim();
+};
+
+const basename = (path: string): string => {
+  const parts = path.split("/").filter((part) => part.length > 0);
+  return parts.length > 0 ? parts[parts.length - 1]! : path;
 };
 
 export const toResultText = (output: unknown): string => {
@@ -87,7 +161,15 @@ const buildBaseToolView = (
   input: Record<string, unknown>,
   rawInput: unknown,
   resultText: string | null,
-): Omit<MobileToolPresentation, "resultBody" | "resultLabel" | "isError" | "editSummaries"> => {
+): Omit<
+  MobileToolPresentation,
+  | "resultBody"
+  | "resultLabel"
+  | "isError"
+  | "editSummaries"
+  | "inlineLabel"
+  | "fileChangeSummary"
+> => {
   switch (tool) {
     case "Bash":
     case "Shell":

--- a/apps/mobile/src/rpc/actions.ts
+++ b/apps/mobile/src/rpc/actions.ts
@@ -1,4 +1,6 @@
 import {
+  type AgentAvailability,
+  type Chat,
   ComposerInput,
   type ComposerInput as ComposerInputType,
   Folder,
@@ -222,6 +224,29 @@ export const setSessionModel = (options: {
   );
 };
 
+/**
+ * Fetch the per-provider availability report so the model menu can hide
+ * providers/models whose CLI isn't installed. Resolves to `null` on any
+ * failure (old server without the RPC, transport error) so callers fall back
+ * to the full static catalog rather than showing an empty menu.
+ */
+export const fetchAgentAvailability = (options: {
+  connection: WsProtocolOptions;
+}): Effect.Effect<readonly AgentAvailability[] | null, never, never> => {
+  const program = Effect.gen(function* () {
+    const client = yield* getConnectionClient(options.connection);
+    return yield* client.agent.availability({});
+  });
+  return program.pipe(
+    Effect.catchAll((cause) =>
+      Effect.sync(() => {
+        reportConnectionFailure(options.connection, cause);
+        return null;
+      }),
+    ),
+  );
+};
+
 export const setSessionRuntimeMode = (options: {
   connection: WsProtocolOptions;
   sessionId: SessionId;
@@ -252,6 +277,40 @@ export const setSessionPermissionMode = (options: {
       sessionId: options.sessionId,
       mode: options.mode,
     });
+  });
+  return program.pipe(
+    Effect.tapError((cause) =>
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
+  );
+};
+
+export const renameChat = (options: {
+  connection: WsProtocolOptions;
+  chatId: Chat["id"];
+  title: string;
+}) => {
+  const program = Effect.gen(function* () {
+    const client = yield* getConnectionClient(options.connection);
+    yield* client.chat.rename({
+      chatId: options.chatId,
+      title: options.title,
+    });
+  });
+  return program.pipe(
+    Effect.tapError((cause) =>
+      Effect.sync(() => reportConnectionFailure(options.connection, cause)),
+    ),
+  );
+};
+
+export const markChatRead = (options: {
+  connection: WsProtocolOptions;
+  chatId: Chat["id"];
+}): Effect.Effect<Chat, unknown, never> => {
+  const program: Effect.Effect<Chat, unknown, never> = Effect.gen(function* () {
+    const client = yield* getConnectionClient(options.connection);
+    return yield* client.chat.markRead({ chatId: options.chatId });
   });
   return program.pipe(
     Effect.tapError((cause) =>

--- a/apps/mobile/src/store/availability.ts
+++ b/apps/mobile/src/store/availability.ts
@@ -1,0 +1,55 @@
+import type { AgentAvailability } from "@zuse/wire";
+import { Effect } from "effect";
+import { create } from "zustand";
+
+import { fetchAgentAvailability } from "~/rpc/actions";
+import type { WsProtocolOptions } from "~/rpc/ws-protocol";
+
+type AvailabilityStore = {
+  /**
+   * Per-connection availability report. `undefined` = never fetched, `null` =
+   * fetched but the server doesn't support the RPC (old desktop) — callers
+   * treat `null` as "no filtering, show the full catalog".
+   */
+  availabilityByConnection: Record<
+    string,
+    readonly AgentAvailability[] | null | undefined
+  >;
+  loadingByConnection: Record<string, boolean>;
+  hydrate: (connKey: string, options: WsProtocolOptions) => Promise<void>;
+  /** Drop the cached report so the next hydrate re-fetches (reconnect, etc.). */
+  invalidate: (connKey: string) => void;
+};
+
+export const useAvailabilityStore = create<AvailabilityStore>((set, get) => ({
+  availabilityByConnection: {},
+  loadingByConnection: {},
+  hydrate: async (connKey, options) => {
+    if (
+      get().availabilityByConnection[connKey] !== undefined ||
+      get().loadingByConnection[connKey]
+    ) {
+      return;
+    }
+    set((state) => ({
+      loadingByConnection: { ...state.loadingByConnection, [connKey]: true },
+    }));
+    const result = await Effect.runPromise(
+      fetchAgentAvailability({ connection: options }),
+    );
+    set((state) => ({
+      availabilityByConnection: {
+        ...state.availabilityByConnection,
+        [connKey]: result,
+      },
+      loadingByConnection: { ...state.loadingByConnection, [connKey]: false },
+    }));
+  },
+  invalidate: (connKey) =>
+    set((state) => {
+      if (state.availabilityByConnection[connKey] === undefined) return state;
+      const next = { ...state.availabilityByConnection };
+      delete next[connKey];
+      return { availabilityByConnection: next };
+    }),
+}));

--- a/apps/mobile/src/store/connections.ts
+++ b/apps/mobile/src/store/connections.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 import { Effect } from "effect";
 
 import { getConnectionClient } from "~/rpc/connection";
-import { connectionKey } from "~/rpc/ws-protocol";
+import { connectionKey, type WsProtocolOptions } from "~/rpc/ws-protocol";
 import { visibleConnectionLabel } from "~/lib/display-names";
 
 export type ConnectionRecord = {
@@ -34,6 +34,14 @@ type ConnectionsState = {
     wsBaseUrl: string;
     token: string;
   }) => Promise<ConnectionRecord>;
+  /** Persist a new human label for an already-stored connection. */
+  updateLabel: (key: string, label: string) => Promise<void>;
+  /**
+   * Re-describe an already-paired environment and adopt its human label if the
+   * server now reports a nicer one (e.g. after the Phase 1 machine-naming
+   * change lands on desktop). No-op when the label is unchanged.
+   */
+  refreshLabel: (key: string, options: WsProtocolOptions) => Promise<void>;
   remove: (key: string) => Promise<void>;
 };
 
@@ -120,6 +128,21 @@ export const useConnectionsStore = create<ConnectionsState>((set, get) => ({
     await Effect.runPromise(saveConnections(next));
     return record;
   },
+  updateLabel: async (key, label) => {
+    const next = get().connections.map((c) =>
+      c.key === key ? { ...c, label } : c,
+    );
+    set({ connections: next });
+    await Effect.runPromise(saveConnections(next));
+  },
+  refreshLabel: async (key, options) => {
+    const descriptor = await describeEnvironment(options);
+    if (descriptor === null) return;
+    const nextLabel = visibleConnectionLabel(descriptor.label, key);
+    const current = get().connections.find((c) => c.key === key);
+    if (current === undefined || current.label === nextLabel) return;
+    await get().updateLabel(key, nextLabel);
+  },
   remove: async (key) => {
     const next = get().connections.filter((c) => c.key !== key);
     set({ connections: next });
@@ -155,11 +178,7 @@ const redeemPairingCodeIfNeeded = async ({
   return body.token;
 };
 
-const describeEnvironment = async (options: {
-  host: string;
-  port: number;
-  token: string | null;
-}) => {
+const describeEnvironment = async (options: WsProtocolOptions) => {
   try {
     const client = await Effect.runPromise(getConnectionClient(options));
     return await Effect.runPromise(client.connect.describe());

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -14,6 +14,10 @@ import { create } from "zustand";
 
 import { readSessionsSnapshot, writeSessionsSnapshot } from "~/offline/cache";
 import { connectionSessionKey } from "~/lib/session-key";
+import {
+  markChatRead as markChatReadRpc,
+  renameChat as renameChatRpc,
+} from "~/rpc/actions";
 import { getConnectionClient, reportConnectionFailure } from "~/rpc/connection";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 import { useMobileMessagesStore } from "./messages";
@@ -39,6 +43,17 @@ type SessionsState = {
     connKey: string,
     options: WsProtocolOptions,
     sessionId: Session["id"],
+  ) => Promise<void>;
+  renameChat: (
+    connKey: string,
+    options: WsProtocolOptions,
+    chatId: Chat["id"],
+    title: string,
+  ) => Promise<void>;
+  markChatRead: (
+    connKey: string,
+    options: WsProtocolOptions,
+    chatId: Chat["id"],
   ) => Promise<void>;
   createChat: (
     connKey: string,
@@ -127,6 +142,61 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
           [connKey]: cause instanceof Error ? cause.message : String(cause),
         },
       }));
+    }
+  },
+  renameChat: async (connKey, options, chatId, title) => {
+    const trimmed = title.trim();
+    if (trimmed.length === 0) return;
+    const previous = get().bundlesByConnection[connKey] ?? [];
+    set((state) => ({
+      bundlesByConnection: {
+        ...state.bundlesByConnection,
+        [connKey]: patchChatFields(previous, chatId, { title: trimmed }),
+      },
+    }));
+    try {
+      await Effect.runPromise(
+        renameChatRpc({ connection: options, chatId, title: trimmed }),
+      );
+    } catch (cause) {
+      set((state) => ({
+        bundlesByConnection: {
+          ...state.bundlesByConnection,
+          [connKey]: previous,
+        },
+        errorByConnection: {
+          ...state.errorByConnection,
+          [connKey]: cause instanceof Error ? cause.message : String(cause),
+        },
+      }));
+    }
+  },
+  markChatRead: async (connKey, options, chatId) => {
+    // Optimistically stamp last-read to now so the inbox unread styling clears
+    // immediately; reconcile with the server's canonical chat on success.
+    const now = new Date();
+    set((state) => ({
+      bundlesByConnection: {
+        ...state.bundlesByConnection,
+        [connKey]: patchChatFields(
+          state.bundlesByConnection[connKey] ?? [],
+          chatId,
+          { lastReadAt: now },
+        ),
+      },
+    }));
+    try {
+      const chat = await Effect.runPromise(
+        markChatReadRpc({ connection: options, chatId }),
+      );
+      set((state) => ({
+        bundlesByConnection: {
+          ...state.bundlesByConnection,
+          [connKey]: patchChat(state.bundlesByConnection[connKey] ?? [], chat),
+        },
+      }));
+    } catch {
+      // Non-fatal: the optimistic stamp stands until the next hydrate.
     }
   },
   createChat: async (connKey, options, input) => {
@@ -331,6 +401,18 @@ const patchChat = (
           ].sort((a, b) => timestampOf(b.updatedAt) - timestampOf(a.updatedAt)),
         },
   );
+
+const patchChatFields = (
+  bundles: readonly ProjectBundle[],
+  chatId: Chat["id"],
+  fields: Partial<Chat>,
+): ProjectBundle[] =>
+  bundles.map((bundle) => ({
+    ...bundle,
+    chats: bundle.chats.map((chat) =>
+      chat.id === chatId ? ({ ...chat, ...fields } as Chat) : chat,
+    ),
+  }));
 
 const patchCreatedChat = (
   bundles: readonly ProjectBundle[],

--- a/apps/server/src/lan-auth/environment-label.ts
+++ b/apps/server/src/lan-auth/environment-label.ts
@@ -1,0 +1,56 @@
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+
+import { Effect } from "effect";
+
+/**
+ * Best-effort human name for this machine, computed at request time (no DB
+ * column, no rename RPC this pass). Prefers the macOS "Computer Name" the user
+ * set in System Settings; falls back to hostname (with a trailing `.local`
+ * stripped), then the login username, then a generic "Computer".
+ *
+ * All I/O is wrapped in `Effect.try` per repo Effect conventions; every step
+ * degrades to the next candidate rather than failing, so the Effect never
+ * errors.
+ */
+export const defaultEnvironmentLabel = (): Effect.Effect<string> =>
+  Effect.gen(function* () {
+    if (process.platform === "darwin") {
+      const computerName = yield* computerNameDarwin;
+      if (computerName !== null) return computerName;
+    }
+
+    const hostname = yield* hostnameLabel;
+    if (hostname !== null) return hostname;
+
+    const username = yield* usernameLabel;
+    if (username !== null) return username;
+
+    return "Computer";
+  });
+
+const cleaned = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim();
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : null;
+};
+
+const computerNameDarwin = Effect.try({
+  try: () =>
+    cleaned(
+      execFileSync("scutil", ["--get", "ComputerName"], {
+        encoding: "utf8",
+        timeout: 2_000,
+      }),
+    ),
+  catch: () => null,
+}).pipe(Effect.orElseSucceed(() => null));
+
+const hostnameLabel = Effect.try({
+  try: () => cleaned(os.hostname().replace(/\.local$/i, "")),
+  catch: () => null,
+}).pipe(Effect.orElseSucceed(() => null));
+
+const usernameLabel = Effect.try({
+  try: () => cleaned(os.userInfo().username),
+  catch: () => null,
+}).pipe(Effect.orElseSucceed(() => null));

--- a/apps/server/src/lan-auth/handlers.ts
+++ b/apps/server/src/lan-auth/handlers.ts
@@ -9,6 +9,7 @@ import {
 } from "@zuse/wire";
 
 import { buildAdvertisedEndpoints } from "./advertised-endpoints.ts";
+import { defaultEnvironmentLabel } from "./environment-label.ts";
 import { LanAuthConfig } from "./services/lan-auth-service.ts";
 import { LanAuthService } from "./services/lan-auth-service.ts";
 
@@ -75,6 +76,7 @@ const ConnectDescribe = MemoizeRpcs.toLayerHandler("connect.describe", () =>
       environmentId: yield* auth.environmentId(),
       providerKind: "desktop",
       endpoint,
+      label: yield* defaultEnvironmentLabel(),
       advertisedEndpoints: buildAdvertisedEndpoints({
         lan: config,
         relay:

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -5,6 +5,7 @@ import { RelayPaths, type EnvironmentId } from "@zuse/wire";
 import { AppPaths } from "../app-paths.ts";
 import { AuthService } from "../auth/services/auth-service.ts";
 import { buildAdvertisedEndpoints } from "../lan-auth/advertised-endpoints.ts";
+import { defaultEnvironmentLabel } from "../lan-auth/environment-label.ts";
 import {
   LanAuthConfig,
   LanAuthService,
@@ -198,6 +199,9 @@ export const RelayLinkServiceLive: Layer.Layer<
             relayUrl: input.relayUrl,
             hasLabel: input.label !== undefined && input.label.length > 0,
           });
+          // Give relay-listed environments the same human name as LAN clients.
+          const label =
+            input.label ?? (yield* defaultEnvironmentLabel());
           const token = yield* authService
             .getAccessToken()
             .pipe(
@@ -273,7 +277,7 @@ export const RelayLinkServiceLive: Layer.Layer<
               environmentPublicKey: keys.publicJwk,
               providerKind: "desktop",
               endpoint: computeEndpoint(config),
-              label: input.label,
+              label,
               // Ask the relay to provision a managed Cloudflare tunnel so the
               // phone can reach this Mac from anywhere. If the relay has tunnels
               // disabled it simply returns no connector token and we stay on LAN.
@@ -319,7 +323,7 @@ export const RelayLinkServiceLive: Layer.Layer<
               relayIssuer: linked.relayIssuer,
               environmentId: keys.envId,
               environmentCredential: linked.environmentCredential,
-              label: input.label,
+              label,
               connectorToken: linked.connectorToken,
               tunnelHostname: linked.tunnelHostname,
               mintPublicKey: linked.mintPublicKey,
@@ -353,7 +357,7 @@ export const RelayLinkServiceLive: Layer.Layer<
             linked: true,
             relayUrl: input.relayUrl,
             environmentId: keys.envId,
-            label: input.label,
+            label,
             heartbeatActive: true,
             advertisedEndpoints: buildAdvertisedEndpoints({
               lan: config,


### PR DESCRIPTION
Levels up the mobile app (apps/mobile) to match the reference agent UI, plus the small server change needed to name machines. Implemented as the plan's seven independently-landable phases.

## Phases

- **Machine naming (server → mobile).** New `defaultEnvironmentLabel()` computes a human machine name at request time — macOS `scutil --get ComputerName` → hostname (`.local` stripped) → username → "Computer" — wired into `connect.describe` and the relay `link`/`saveRelayConfig`. Mobile adds `refreshLabel` so already-paired phones adopt the nicer name. No migration, no rename RPC.
- **Availability + model menu correctness.** New `fetchAgentAvailability` action + `availability` store filter providers/models by installed CLIs (graceful full-catalog fallback on old servers). The native model menu re-mounts on model change to fix the stale iOS UIMenu reasoning snapshot; mid-session **model** changes are now allowed (provider stays fresh-chat-only). Duplicated `defaultModelOptions` centralized; change rules extracted to a pure, tested `nextModelChangeActions`.
- **Session screen.** Two-line header (chat title / "project · machine") with circular back, new-chat, and a rename/archive "…" menu; at-bottom scroll tracking with a floating jump-to-bottom button and `maintainVisibleContentPosition` (no more yank while reading); `markChatRead` on open; composer chrome labels removed.
- **Message stream restyle.** `ShimmerText` "Thinking"/"Working" (reanimated opacity loop, respects Reduce Motion); boxless plain tool rows with compact inline labels ("Ran …", "Edited …"); subtle rounded container for file-change summaries; error rows keep the boxed danger styling.
- **Permission panel.** Docked GlassSurface with a bold per-kind question, mono command box, full-width white Approve pill, "Always approve" (hidden on `forcePrompt`), and a deny-with-message input that queues the typed guidance as the next user message.
- **Inbox restyle.** No icon circles / NEW badge; leading lime dot when unread, `PresenceDot` pulse when running; muted-vs-foreground title by read state; relative-time subtitle (`relativeTimeLabel`) with provider/model kept searchable.
- **New chat layout.** Top-left machine → project → work-mode → branch selector stack (new platform-split `SelectorRow`, pure testable `sourceOptionsForKind`); reordered composer dock (`+` placeholder, gear, right-aligned model label, send).

## Deferred (per plan, out of scope)

`session.setModelOptions` (mid-chat reasoning), `agent.opencodeInventory`, machine rename UI, masked-gradient shimmer, and `+` attachment behavior.

## Verification

- `apps/mobile`: `bun test src` (55 pass), `bun run check-types`, `bun run lint` — all green.
- Monorepo `check-types` passes (12/12 packages), including `apps/server`.
- New unit tests cover the added pure helpers (availability filtering, model-change rules, inline/file-change labels, permission question, relative time, source options).

Remaining: on-device/simulator QA (pair → machine name; four source kinds; mid-chat model swap; streaming shimmer/scroll; permission approve/always/deny-with-text; inbox read/unread + swipe archive).