### PR TITLE
[codex] Fix WorkOS auth persistence

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -175,8 +175,7 @@ app.setAsDefaultProtocolClient("zuse");
 // A callback can arrive before the server runtime (and thus the sink) exists —
 // buffer and flush on register (R2).
 // ---------------------------------------------------------------------------
-const AUTH_LOOPBACK_PORT = 8976;
-const AUTH_LOOPBACK_URI = `http://localhost:${AUTH_LOOPBACK_PORT}/callback`;
+const AUTH_LOOPBACK_PORTS = [8976, 8977, 8978, 8979] as const;
 // Both dev and packaged use the loopback as the WorkOS redirect_uri. It's the
 // RFC 8252 native-app pattern and gives a strictly better sign-in finish:
 //   - the browser lands on a real HTML page ("Signed in, you can close this
@@ -185,8 +184,8 @@ const AUTH_LOOPBACK_URI = `http://localhost:${AUTH_LOOPBACK_PORT}/callback`;
 //     already-running app answers directly, no deep-link handoff needed.
 // The `zuse://auth/callback` scheme handler stays registered below as a
 // fallback (and the future mobile path), but is no longer the primary flow.
-// Register `http://localhost:8976/callback` in the WorkOS dashboard.
-const AUTH_REDIRECT_URI = AUTH_LOOPBACK_URI;
+// Register `http://localhost:8976/callback` through `:8979` in the WorkOS
+// dashboard so parallel worktree instances can each finish sign-in.
 const AUTH_DEEP_LINK_SCHEMES = ["zuse://", "memoize://"] as const;
 
 const isAuthDeepLink = (arg: string): boolean =>
@@ -210,14 +209,39 @@ const focusMainWindow = (): void => {
 };
 
 let authLoopbackServer: http.Server | null = null;
+let boundAuthPort: number | null = null;
+let authLoopbackFailure: string | null = null;
 
-const startAuthLoopback = (): void => {
+const tryListenAuthLoopback = (
+  server: http.Server,
+  port: number,
+): Promise<boolean> =>
+  new Promise((resolve) => {
+    const onError = (err: NodeJS.ErrnoException) => {
+      server.off("listening", onListening);
+      if (err.code !== "EADDRINUSE") {
+        console.error("[zuse] auth loopback server error", err);
+      }
+      resolve(false);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve(true);
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, "127.0.0.1");
+  });
+
+const startAuthLoopback = async (): Promise<void> => {
   if (authLoopbackServer !== null) return;
   const server = http.createServer((req, res) => {
     const requestUrl = req.url ?? "";
     let parsed: URL;
     try {
-      parsed = new URL(`http://localhost:${AUTH_LOOPBACK_PORT}${requestUrl}`);
+      parsed = new URL(
+        `http://localhost:${boundAuthPort ?? AUTH_LOOPBACK_PORTS[0]}${requestUrl}`,
+      );
     } catch {
       res.writeHead(400);
       res.end();
@@ -238,11 +262,17 @@ const startAuthLoopback = (): void => {
     );
     focusMainWindow();
   });
-  server.on("error", (err) => {
-    console.error("[zuse] auth loopback server error", err);
-  });
-  server.listen(AUTH_LOOPBACK_PORT, "127.0.0.1");
-  authLoopbackServer = server;
+  for (const port of AUTH_LOOPBACK_PORTS) {
+    if (await tryListenAuthLoopback(server, port)) {
+      boundAuthPort = port;
+      authLoopbackServer = server;
+      authLoopbackFailure = null;
+      return;
+    }
+  }
+  authLoopbackFailure =
+    "Sign-in port unavailable. Close other Zuse windows and retry.";
+  server.close();
 };
 
 const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL?.trim() || "";
@@ -630,10 +660,18 @@ const folderPicker = {
 // module-level `deliverAuthUrl` and prime with any deep links buffered before
 // the runtime came up.
 const authShell = {
-  redirectUri: AUTH_REDIRECT_URI,
+  get redirectUri() {
+    return `http://localhost:${boundAuthPort ?? AUTH_LOOPBACK_PORTS[0]}/callback`;
+  },
   open: (url: string) =>
     Effect.tryPromise({
       try: async () => {
+        if (boundAuthPort === null) {
+          throw new Error(
+            authLoopbackFailure ??
+              "Sign-in port unavailable. Close other Zuse windows and retry.",
+          );
+        }
         await shell.openExternal(url);
       },
       catch: (cause) =>
@@ -1757,7 +1795,7 @@ ipcMain.handle(
     },
 );
 
-void app.whenReady().then(() => {
+void app.whenReady().then(async () => {
   // Non-primary instance is on its way out (lost the single-instance lock) —
   // don't build a window or boot the runtime.
   if (!gotSingleInstanceLock) return;
@@ -1766,7 +1804,7 @@ void app.whenReady().then(() => {
   // It's the redirect_uri for both, so the browser finishes on a real HTML
   // page and no `zuse://` deep-link handoff/prompt is needed. The scheme
   // handler stays registered below as a fallback.
-  startAuthLoopback();
+  await startAuthLoopback();
 
   // Win/Linux cold launch from a deep link: the URL is an argv entry.
   const initialDeepLink = process.argv.find(isAuthDeepLink);

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -1,20 +1,30 @@
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "tsdown";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..", "..");
+
 // tsdown evaluates this config with its own loader (not the bun runtime), so
-// bun's automatic `.env` loading doesn't reach it. Read apps/desktop/.env
-// ourselves so both dev (`tsdown --watch`) and packaged builds inline the
-// public WorkOS client id. A real shell/CI env var always wins.
+// bun's automatic `.env` loading doesn't reach it. Read .env files ourselves
+// so both dev (`tsdown --watch`) and packaged builds inline the public WorkOS
+// client id. A real shell/CI env var always wins.
 const resolveWorkosClientId = (): string => {
   if (process.env.WORKOS_CLIENT_ID) return process.env.WORKOS_CLIENT_ID;
-  const envPath = resolve(process.cwd(), ".env");
-  if (!existsSync(envPath)) return "";
-  for (const line of readFileSync(envPath, "utf8").split("\n")) {
-    const match = line.match(/^\s*WORKOS_CLIENT_ID\s*=\s*(.*?)\s*$/);
-    if (match?.[1] !== undefined) {
-      return match[1].replace(/^["']|["']$/g, "");
+  const envPaths = [
+    resolve(process.cwd(), ".env"),
+    resolve(__dirname, ".env"),
+    resolve(repoRoot, ".env"),
+  ];
+  for (const envPath of envPaths) {
+    if (!existsSync(envPath)) continue;
+    for (const line of readFileSync(envPath, "utf8").split("\n")) {
+      const match = line.match(/^\s*WORKOS_CLIENT_ID\s*=\s*(.*?)\s*$/);
+      if (match?.[1] !== undefined) {
+        return match[1].replace(/^["']|["']$/g, "");
+      }
     }
   }
   return "";

--- a/apps/renderer/src/components/blurred-email.tsx
+++ b/apps/renderer/src/components/blurred-email.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+import { cn } from "~/lib/utils";
+
+/**
+ * Privacy-aware email pill. Blurs the address by default so screen recordings
+ * and screenshots don't leak it; click toggles reveal/hide.
+ */
+export function BlurredEmail({ email }: { email: string }) {
+  const [revealed, setRevealed] = useState(false);
+  return (
+    <span
+      onClick={(e) => {
+        e.stopPropagation();
+        setRevealed((r) => !r);
+      }}
+      title={revealed ? "Click to hide" : "Click to reveal"}
+      aria-label={revealed ? "Hide email" : "Reveal email"}
+      className={cn(
+        "inline-block max-w-[16rem] cursor-pointer truncate rounded bg-muted/40 px-1 py-0.5 text-left font-mono text-[11px] text-foreground transition-[filter,background-color] duration-150",
+        revealed ? "" : "blur-[5px] select-none hover:blur-[3px]",
+      )}
+    >
+      {email}
+    </span>
+  );
+}

--- a/apps/renderer/src/components/onboarding/steps/signin.tsx
+++ b/apps/renderer/src/components/onboarding/steps/signin.tsx
@@ -6,12 +6,14 @@ import {
 } from "@hugeicons-pro/core-bulk-rounded";
 
 import { Button } from "~/components/ui/button";
+import { BlurredEmail } from "~/components/blurred-email";
 import { Spinner } from "~/components/ui/spinner";
 import { useAuth } from "~/hooks/use-auth.ts";
 import { StepHeader } from "./shared.tsx";
 
 export function SigninStep() {
   const { isSignedIn, name, user, signIn, signingIn, error } = useAuth();
+  const nameIsEmail = Boolean(user?.email && name === user.email);
 
   return (
     <div className="flex h-full flex-col gap-6">
@@ -33,11 +35,30 @@ export function SigninStep() {
             <span className="text-sm font-medium text-foreground">
               {isSignedIn ? "Account connected" : "WorkOS sign-in"}
             </span>
-            <p className="max-w-sm text-[12px] leading-relaxed text-muted-foreground">
-              {isSignedIn
-                ? `Signed in as ${name}${user?.email ? ` (${user.email})` : ""}.`
-                : "A browser window opens for authentication and returns here automatically."}
-            </p>
+            {isSignedIn ? (
+              <p className="flex max-w-sm flex-wrap items-center gap-1 text-[12px] leading-relaxed text-muted-foreground">
+                <span>Signed in as</span>
+                {nameIsEmail && user?.email ? (
+                  <BlurredEmail email={user.email} />
+                ) : (
+                  <span>{name}</span>
+                )}
+                {!nameIsEmail && user?.email ? (
+                  <>
+                    <span>(</span>
+                    <BlurredEmail email={user.email} />
+                    <span>).</span>
+                  </>
+                ) : (
+                  <span>.</span>
+                )}
+              </p>
+            ) : (
+              <p className="max-w-sm text-[12px] leading-relaxed text-muted-foreground">
+                A browser window opens for authentication and returns here
+                automatically.
+              </p>
+            )}
           </div>
         </div>
 

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -32,6 +32,7 @@ import {
 } from "@zuse/wire";
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { BlurredEmail } from "~/components/blurred-email";
 import {
   Menu,
   MenuItem,
@@ -526,6 +527,7 @@ function SidebarAccount() {
   }
 
   const initial = (name || user?.email || "?").charAt(0).toUpperCase();
+  const nameIsEmail = Boolean(user?.email && name === user.email);
 
   return (
     <Menu>
@@ -541,7 +543,11 @@ function SidebarAccount() {
               ) : null}
               <AvatarFallback className="text-[9px]">{initial}</AvatarFallback>
             </Avatar>
-            <span className="min-w-0 flex-1 truncate text-left">{name}</span>
+            {nameIsEmail && user?.email ? (
+              <BlurredEmail email={user.email} />
+            ) : (
+              <span className="min-w-0 flex-1 truncate text-left">{name}</span>
+            )}
           </button>
         }
       />

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -19,6 +19,7 @@ import {
 } from "@zuse/wire";
 
 import { ApiKeyRow } from "~/components/api-key-row";
+import { BlurredEmail } from "~/components/blurred-email";
 import { OpencodeProviderManager } from "~/components/opencode-provider-manager";
 import { openExternal, useProviderLogin } from "~/lib/use-provider-login";
 import { ProviderIcon } from "~/components/provider-icons";
@@ -422,33 +423,6 @@ function SubscriptionRow({
         </button>
       </div>
     </div>
-  );
-}
-
-/**
- * Privacy-aware email pill. Blurs the address by default (so screen-records
- * and screenshots don't leak it) and reveals on click; clicking again
- * re-blurs. Rendered as a span because the provider row itself is a button.
- */
-function BlurredEmail({ email }: { email: string }) {
-  const [revealed, setRevealed] = useState(false);
-  return (
-    <span
-      onClick={(e) => {
-        e.stopPropagation();
-        setRevealed((r) => !r);
-      }}
-      title={revealed ? "Click to hide" : "Click to reveal"}
-      aria-label={revealed ? "Hide email" : "Reveal email"}
-      className={cn(
-        "max-w-[16rem] cursor-pointer truncate rounded px-1 py-0.5 text-left font-mono text-[11px] transition-[filter,background-color] duration-150",
-        revealed
-          ? "bg-muted/40 text-foreground"
-          : "bg-muted/40 text-foreground blur-[5px] select-none hover:blur-[3px]",
-      )}
-    >
-      {email}
-    </span>
   );
 }
 

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -10,6 +10,7 @@ import {
   GlobeIcon,
   KeyboardIcon,
   PackageIcon,
+  PencilEdit01Icon,
   Settings01Icon,
   SmartPhone01Icon,
   TaskDone01Icon,
@@ -56,6 +57,7 @@ import { useSettingsStore } from "../store/settings.ts";
 import { useSubagentsStore } from "../store/subagents.ts";
 import { useUiStore, type SettingsSection } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
+import { BlurredEmail } from "./blurred-email.tsx";
 import { ProviderCard } from "./provider-card.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { MODES_ORDER, MODE_META } from "./runtime-mode-meta.ts";
@@ -925,9 +927,13 @@ function GeneralPane() {
   // Display-name override draft (local cosmetic alias; persisted to localStorage
   // via the auth store). Mirror on external change.
   const [nameDraft, setNameDraft] = useState(displayName);
+  const [editingName, setEditingName] = useState(false);
   useEffect(() => {
     setNameDraft(displayName);
+    setEditingName(false);
   }, [displayName]);
+
+  const accountNameIsEmail = Boolean(user?.email && name === user.email);
 
   return (
     <div className="flex flex-col gap-4">
@@ -947,12 +953,55 @@ function GeneralPane() {
                 </AvatarFallback>
               </Avatar>
               <div className="flex min-w-0 flex-1 flex-col">
-                <span className="truncate text-sm font-medium text-foreground">
-                  {name}
-                </span>
-                <span className="truncate text-xs text-muted-foreground">
-                  {user?.email}
-                </span>
+                {editingName ? (
+                  <input
+                    autoFocus
+                    value={nameDraft}
+                    onChange={(e) => setNameDraft(e.target.value)}
+                    onBlur={() => {
+                      setDisplayName(nameDraft);
+                      setEditingName(false);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.currentTarget.blur();
+                      }
+                      if (e.key === "Escape") {
+                        setNameDraft(displayName);
+                        setEditingName(false);
+                      }
+                    }}
+                    placeholder="Your name"
+                    className="h-7 w-full max-w-[220px] rounded-md border border-border/50 bg-background px-2 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 focus:border-border"
+                  />
+                ) : (
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    {accountNameIsEmail && user?.email ? (
+                      <BlurredEmail email={user.email} />
+                    ) : (
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {name}
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setNameDraft(displayName);
+                        setEditingName(true);
+                      }}
+                      aria-label="Edit display name"
+                      className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                    >
+                      <HugeiconsIcon
+                        icon={PencilEdit01Icon}
+                        className="size-3.5"
+                      />
+                    </button>
+                  </div>
+                )}
+                {!accountNameIsEmail && user?.email ? (
+                  <BlurredEmail email={user.email} />
+                ) : null}
               </div>
               <Button
                 variant="settings"
@@ -962,23 +1011,6 @@ function GeneralPane() {
                 Sign out
               </Button>
             </div>
-            <SettingsRow
-              title="Display name"
-              description="How your name shows in Zuse Alpha. Local to this device — it doesn't change your WorkOS profile."
-            >
-              <input
-                value={nameDraft}
-                onChange={(e) => setNameDraft(e.target.value)}
-                onBlur={() => setDisplayName(nameDraft)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.currentTarget.blur();
-                  }
-                }}
-                placeholder={user?.email ?? "Your name"}
-                className="h-8 w-full max-w-[260px] rounded-lg border border-border/50 bg-background px-3 text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 focus:border-border"
-              />
-            </SettingsRow>
           </>
         ) : (
           <SettingsRow

--- a/apps/renderer/src/store/auth.ts
+++ b/apps/renderer/src/store/auth.ts
@@ -57,6 +57,7 @@ const writeDisplayName = (value: string): void => {
 };
 
 const SIGNED_OUT: AuthState = { _tag: "SignedOut" };
+const HYDRATE_RETRY_MS = 1_500;
 
 const signInFailureMessage = (err: unknown): string =>
   typeof err === "object" &&
@@ -133,9 +134,16 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       const next = await Effect.runPromise(client.auth.getSession({}));
       set({ state: next });
     } catch {
-      // Bridge not up yet / transient — assume signed out so the UI can
-      // render. A later stream emit or re-hydrate corrects it.
-      set((prev) => ({ state: prev.state ?? SIGNED_OUT }));
+      await new Promise((resolve) => setTimeout(resolve, HYDRATE_RETRY_MS));
+      try {
+        const client = await getRpcClient();
+        const next = await Effect.runPromise(client.auth.getSession({}));
+        set({ state: next });
+      } catch {
+        // Bridge not up yet / transient — assume signed out so the UI can
+        // render. A later stream emit or re-hydrate corrects it.
+        set((prev) => ({ state: prev.state ?? SIGNED_OUT }));
+      }
     }
   },
   signIn: async () => {

--- a/apps/server/src/auth/errors.ts
+++ b/apps/server/src/auth/errors.ts
@@ -9,5 +9,11 @@ import { Data } from "effect";
  */
 export class AuthTokenError extends Data.TaggedError("AuthTokenError")<{
   readonly reason: string;
+  readonly code?: "invalid_grant";
+  readonly cause?: unknown;
+}> {}
+
+export class SessionStoreError extends Data.TaggedError("SessionStoreError")<{
+  readonly reason: string;
   readonly cause?: unknown;
 }> {}

--- a/apps/server/src/auth/layers/auth-service.ts
+++ b/apps/server/src/auth/layers/auth-service.ts
@@ -1,4 +1,4 @@
-import { Deferred, Effect, Layer, PubSub, Ref, Stream } from "effect";
+import { Deferred, Effect, Layer, PubSub, Ref, Schedule, Stream } from "effect";
 
 import {
   AuthCancelledError,
@@ -9,13 +9,15 @@ import {
 } from "@zuse/wire";
 
 import { CredentialsService } from "../../provider/services/credentials-service.ts";
-import { AuthTokenError } from "../errors.ts";
+import { AuthTokenError, SessionStoreError } from "../errors.ts";
 import { AuthService } from "../services/auth-service.ts";
 import { AuthShell } from "../services/auth-shell.ts";
+import { SessionStore } from "../services/session-store.ts";
 import {
   authorizationUrl,
   exchangeCode,
   makePkce,
+  parseSessionBundle,
   parseCallbackUrl,
   refreshSession,
   type SessionBundle,
@@ -23,6 +25,7 @@ import {
 
 /** Refresh when the access token is within this window of expiry. */
 const REFRESH_SKEW_MS = 60_000;
+const FORCE_REFRESH_SKIP_MS = 10 * 60_000;
 
 /** How long `signIn` waits for the browser callback before giving up. */
 const SIGN_IN_TIMEOUT = "45 seconds";
@@ -43,19 +46,10 @@ interface PendingSignIn {
   readonly state: string;
 }
 
-const parseBundle = (raw: string | null): SessionBundle | null => {
+const parseKeychainBundle = (raw: string | null): SessionBundle | null => {
   if (raw === null) return null;
   try {
-    const obj = JSON.parse(raw) as Partial<SessionBundle>;
-    if (
-      typeof obj.accessToken === "string" &&
-      typeof obj.refreshToken === "string" &&
-      typeof obj.expiresAt === "number" &&
-      obj.user !== undefined &&
-      typeof obj.user.id === "string"
-    ) {
-      return obj as SessionBundle;
-    }
+    return parseSessionBundle(JSON.parse(raw) as unknown);
   } catch {
     // Corrupt entry — treat as signed out.
   }
@@ -81,24 +75,34 @@ export const AuthServiceLive = Layer.scoped(
   AuthService,
   Effect.gen(function* () {
     const credentials = yield* CredentialsService;
+    const store = yield* SessionStore;
     const shell = yield* AuthShell;
 
     const pubsub = yield* PubSub.unbounded<AuthState>();
     const pending = yield* Ref.make<PendingSignIn | null>(null);
+    const lastKnown = yield* Ref.make<SessionBundle | null>(null);
     // Serializes refreshes so two concurrent `getSession`/`getAccessToken`
     // calls can't both mint a new token and clobber the keychain entry (R5).
     const refreshLock = yield* Effect.makeSemaphore(1);
 
     const readBundle = (): Effect.Effect<SessionBundle | null> =>
-      credentials.getWorkosSession().pipe(
-        Effect.catchAll(() => Effect.succeed<string | null>(null)),
-        Effect.map(parseBundle),
+      store.read().pipe(
+        Effect.tap((bundle) => Ref.set(lastKnown, bundle)),
+        Effect.catchAll((cause) =>
+          Effect.gen(function* () {
+            console.warn("[zuse] failed to read auth session", cause.reason);
+            return yield* Ref.get(lastKnown);
+          }),
+        ),
       );
 
     const persist = (
       bundle: SessionBundle,
     ): Effect.Effect<void, AuthTokenError> =>
-      credentials.setWorkosSession(JSON.stringify(bundle)).pipe(
+      store.write(bundle).pipe(
+        Effect.tap((written) => Ref.set(lastKnown, written)),
+        Effect.tap((written) => PubSub.publish(pubsub, toState(written))),
+        Effect.asVoid,
         Effect.mapError(
           (cause) =>
             new AuthTokenError({
@@ -110,32 +114,93 @@ export const AuthServiceLive = Layer.scoped(
 
     // Refresh under the lock, re-reading first so a concurrent refresh that
     // already ran is reused instead of repeated.
+    const mapStoreError = (cause: SessionStoreError): AuthTokenError =>
+      new AuthTokenError({
+        reason: `Failed to access auth session: ${cause.reason}`,
+        cause,
+      });
+
     const doRefresh = (
       seed: SessionBundle,
+      options: { readonly force?: boolean } = {},
     ): Effect.Effect<SessionBundle, AuthTokenError> =>
-      refreshLock.withPermits(1)(
-        Effect.gen(function* () {
-          const current = yield* readBundle();
-          const base = current ?? seed;
-          if (base.expiresAt - Date.now() > REFRESH_SKEW_MS) return base;
-          const fresh = yield* refreshSession(CLIENT_ID, base.refreshToken);
-          yield* persist(fresh);
-          yield* PubSub.publish(pubsub, toState(fresh));
-          return fresh;
-        }),
-      );
+      refreshLock
+        .withPermits(1)(
+          store.withLock(
+            Effect.gen(function* () {
+              const current = yield* store.read();
+              if (current === null) {
+                return yield* Effect.fail(
+                  new AuthTokenError({
+                    reason: "Signed out during refresh.",
+                  }),
+                );
+              }
+              const base = current;
+              const now = Date.now();
+              if (current.refreshToken !== seed.refreshToken) {
+                yield* Ref.set(lastKnown, current);
+                return current;
+              }
+              if (!options.force && base.expiresAt - now > REFRESH_SKEW_MS) {
+                yield* Ref.set(lastKnown, base);
+                return base;
+              }
+              if (
+                options.force &&
+                base.refreshedAt > 0 &&
+                now - base.refreshedAt < FORCE_REFRESH_SKIP_MS &&
+                base.expiresAt - now > REFRESH_SKEW_MS
+              ) {
+                yield* Ref.set(lastKnown, base);
+                return base;
+              }
+              const attemptedRefreshToken = base.refreshToken;
+              const refreshed = yield* refreshSession(
+                CLIENT_ID,
+                attemptedRefreshToken,
+              ).pipe(Effect.either);
+              if (refreshed._tag === "Left") {
+                if (refreshed.left.code === "invalid_grant") {
+                  const winner = yield* store.read();
+                  if (
+                    winner !== null &&
+                    winner.refreshToken !== attemptedRefreshToken
+                  ) {
+                    yield* Ref.set(lastKnown, winner);
+                    return winner;
+                  }
+                }
+                return yield* Effect.fail(refreshed.left);
+              }
+              const written = yield* store.write(refreshed.right);
+              yield* Ref.set(lastKnown, written);
+              yield* PubSub.publish(pubsub, toState(written));
+              return written;
+            }),
+          ),
+        )
+        .pipe(
+          Effect.mapError((cause) =>
+            cause._tag === "SessionStoreError" ? mapStoreError(cause) : cause,
+          ),
+        );
+
+    const refreshIfPresent = (force: boolean): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const bundle = yield* readBundle();
+        if (bundle === null) return;
+        yield* doRefresh(bundle, { force }).pipe(Effect.either);
+      });
 
     const getSession = (): Effect.Effect<AuthState> =>
       Effect.gen(function* () {
         const bundle = yield* readBundle();
         if (bundle === null) return SIGNED_OUT;
-        if (bundle.expiresAt - Date.now() > REFRESH_SKEW_MS) {
-          return toState(bundle);
+        if (bundle.expiresAt - Date.now() <= REFRESH_SKEW_MS) {
+          yield* Effect.forkDaemon(doRefresh(bundle).pipe(Effect.ignore));
         }
-        // Near expiry: refresh, but tolerate transient failure by keeping the
-        // existing identity rather than bouncing the user to the login screen.
-        const refreshed = yield* doRefresh(bundle).pipe(Effect.either);
-        return toState(refreshed._tag === "Right" ? refreshed.right : bundle);
+        return toState(bundle);
       });
 
     const getAccessToken = (): Effect.Effect<string, AuthTokenError> =>
@@ -203,7 +268,6 @@ export const AuthServiceLive = Layer.scoped(
           );
           return;
         }
-        yield* PubSub.publish(pubsub, toState(bundle));
         yield* Deferred.succeed(inflight.deferred, bundle);
       });
 
@@ -255,8 +319,9 @@ export const AuthServiceLive = Layer.scoped(
       });
 
     const signOut = (): Effect.Effect<void> =>
-      credentials.removeWorkosSession().pipe(
+      store.clear().pipe(
         Effect.catchAll(() => Effect.void),
+        Effect.zipRight(Ref.set(lastKnown, null)),
         Effect.zipRight(PubSub.publish(pubsub, SIGNED_OUT)),
         Effect.asVoid,
       );
@@ -265,9 +330,46 @@ export const AuthServiceLive = Layer.scoped(
       Stream.unwrapScoped(
         Effect.gen(function* () {
           const dequeue = yield* pubsub.subscribe;
-          return Stream.fromQueue(dequeue);
+          return Stream.concat(
+            Stream.fromEffect(getSession()),
+            Stream.fromQueue(dequeue),
+          );
         }),
       );
+
+    yield* Effect.gen(function* () {
+      const fileBundle = yield* store
+        .read()
+        .pipe(Effect.catchAll(() => Effect.succeed(null)));
+      if (fileBundle !== null) {
+        yield* Ref.set(lastKnown, fileBundle);
+        return;
+      }
+      const legacy = yield* credentials.getWorkosSession().pipe(
+        Effect.catchAll(() => Effect.succeed(null)),
+        Effect.map(parseKeychainBundle),
+      );
+      if (legacy === null) return;
+      const migrated = yield* store.write(legacy).pipe(Effect.either);
+      if (migrated._tag === "Right") {
+        yield* Ref.set(lastKnown, migrated.right);
+        yield* credentials
+          .removeWorkosSession()
+          .pipe(Effect.catchAll(() => Effect.void));
+      }
+    });
+
+    yield* Effect.forkScoped(
+      refreshIfPresent(true).pipe(
+        Effect.zipRight(
+          Effect.repeat(
+            refreshIfPresent(true),
+            Schedule.spaced("45 minutes").pipe(Schedule.jittered),
+          ),
+        ),
+        Effect.catchAll(() => Effect.void),
+      ),
+    );
 
     // Register our callback sink with the host. From here on, every
     // `zuse://auth/callback` deep link the shell receives is funneled into

--- a/apps/server/src/auth/layers/session-store.ts
+++ b/apps/server/src/auth/layers/session-store.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { Effect, Layer } from "effect";
+
+import { SessionStoreError } from "../errors.ts";
+import { SessionStore } from "../services/session-store.ts";
+import { parseSessionBundle, type SessionBundle } from "./workos.ts";
+
+const LOCK_STALE_MS = 30_000;
+const LOCK_MAX_ATTEMPTS = 40;
+
+const authDir = (): string =>
+  process.env.ZUSE_AUTH_DIR?.trim() || join(homedir(), ".zuse");
+const authFile = (): string => join(authDir(), "auth.json");
+const lockFile = (): string => join(authDir(), "auth.lock");
+
+const failStore = (reason: string, cause?: unknown): SessionStoreError =>
+  new SessionStoreError({ reason, cause });
+
+const io = <A>(
+  description: string,
+  thunk: () => Promise<A>,
+): Effect.Effect<A, SessionStoreError> =>
+  Effect.tryPromise({
+    try: thunk,
+    catch: (cause) => failStore(description, cause),
+  });
+
+const isNotFound = (cause: unknown): boolean =>
+  typeof cause === "object" &&
+  cause !== null &&
+  (cause as { code?: unknown }).code === "ENOENT";
+
+const isExists = (cause: unknown): boolean =>
+  typeof cause === "object" &&
+  cause !== null &&
+  (cause as { code?: unknown }).code === "EEXIST";
+
+const ensureAuthDir = (): Effect.Effect<void, SessionStoreError> =>
+  io("Failed to create auth directory.", async () => {
+    await mkdir(authDir(), { recursive: true, mode: 0o700 });
+    await chmod(authDir(), 0o700);
+  });
+
+const readBundleFile = (): Effect.Effect<
+  SessionBundle | null,
+  SessionStoreError
+> =>
+  Effect.tryPromise({
+    try: async () => await readFile(authFile(), "utf8"),
+    catch: (cause) => failStore("Failed to read auth session.", cause),
+  }).pipe(
+    Effect.catchAll((cause) =>
+      isNotFound(cause.cause) ? Effect.succeed(null) : Effect.fail(cause),
+    ),
+    Effect.flatMap((raw) => {
+      if (raw === null) return Effect.succeed(null);
+      return Effect.try({
+        try: () => JSON.parse(raw) as unknown,
+        catch: (cause) => failStore("Auth session file is corrupt.", cause),
+      }).pipe(Effect.map(parseSessionBundle));
+    }),
+  );
+
+const writeBundleFile = (
+  bundle: SessionBundle,
+): Effect.Effect<void, SessionStoreError> =>
+  Effect.gen(function* () {
+    yield* ensureAuthDir();
+    const target = authFile();
+    const tmp = `${target}.tmp.${process.pid}.${Date.now()}`;
+    const contents = JSON.stringify(bundle);
+    yield* io("Failed to write auth session.", async () => {
+      await writeFile(tmp, contents, { mode: 0o600 });
+      await chmod(tmp, 0o600);
+      await rename(tmp, target);
+      await chmod(target, 0o600);
+    }).pipe(
+      Effect.ensuring(
+        io("Failed to clean temporary auth session.", () =>
+          rm(tmp, { force: true }),
+        ).pipe(Effect.ignore),
+      ),
+    );
+  });
+
+const pidIsAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (cause) {
+    return (
+      typeof cause === "object" &&
+      cause !== null &&
+      (cause as { code?: unknown }).code !== "ESRCH"
+    );
+  }
+};
+
+const lockIsStale = (raw: string): boolean => {
+  try {
+    const parsed = JSON.parse(raw) as { pid?: unknown; createdAt?: unknown };
+    const createdAt =
+      typeof parsed.createdAt === "number" ? parsed.createdAt : 0;
+    const pid = typeof parsed.pid === "number" ? parsed.pid : 0;
+    return Date.now() - createdAt > LOCK_STALE_MS || !pidIsAlive(pid);
+  } catch {
+    return true;
+  }
+};
+
+const readLockRaw = (): Effect.Effect<string | null, never> =>
+  Effect.tryPromise({
+    try: async () => await readFile(lockFile(), "utf8"),
+    catch: (cause) => cause,
+  }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+const acquireLock = (attempt = 0): Effect.Effect<string, SessionStoreError> =>
+  ensureAuthDir().pipe(
+    Effect.zipRight(
+      Effect.tryPromise({
+        try: async () => {
+          const token = randomUUID();
+          const handle = await open(
+            lockFile(),
+            constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+            0o600,
+          );
+          await handle.writeFile(
+            JSON.stringify({ pid: process.pid, createdAt: Date.now(), token }),
+          );
+          await handle.close();
+          return token;
+        },
+        catch: (cause) => cause,
+      }),
+    ),
+    Effect.catchAll((cause) => {
+      if (!isExists(cause)) {
+        return Effect.fail(
+          failStore("Failed to acquire auth session lock.", cause),
+        );
+      }
+      if (attempt >= LOCK_MAX_ATTEMPTS) {
+        return Effect.fail(
+          failStore("Timed out waiting for auth session lock.", cause),
+        );
+      }
+      return Effect.gen(function* () {
+        const raw = yield* readLockRaw();
+        if (raw === null || lockIsStale(raw)) {
+          yield* io("Failed to remove stale auth session lock.", async () => {
+            const current = await readFile(lockFile(), "utf8").catch(
+              () => null,
+            );
+            if (current === raw) await unlink(lockFile());
+          }).pipe(Effect.catchAll(() => Effect.void));
+        } else {
+          yield* Effect.sleep("150 millis");
+        }
+        return yield* acquireLock(attempt + 1);
+      });
+    }),
+  );
+
+const releaseLock = (token: string): Effect.Effect<void, never> =>
+  io("Failed to release auth session lock.", async () => {
+    const raw = await readFile(lockFile(), "utf8").catch(() => null);
+    if (raw === null) return;
+    try {
+      const parsed = JSON.parse(raw) as { token?: unknown };
+      if (parsed.token === token) await unlink(lockFile());
+    } catch {
+      await unlink(lockFile());
+    }
+  }).pipe(Effect.ignore);
+
+export const SessionStoreLive = Layer.succeed(
+  SessionStore,
+  SessionStore.of({
+    read: () => readBundleFile(),
+    write: (incoming) =>
+      Effect.gen(function* () {
+        yield* ensureAuthDir();
+        const current = yield* readBundleFile();
+        if (current !== null && current.refreshedAt > incoming.refreshedAt) {
+          return current;
+        }
+        yield* writeBundleFile(incoming);
+        return incoming;
+      }),
+    clear: () =>
+      io("Failed to clear auth session.", () =>
+        rm(authFile(), { force: true }),
+      ),
+    withLock: (effect) =>
+      Effect.acquireUseRelease(acquireLock(), () => effect, releaseLock),
+  }),
+);

--- a/apps/server/src/auth/layers/workos.ts
+++ b/apps/server/src/auth/layers/workos.ts
@@ -70,6 +70,22 @@ interface WorkosAuthenticateResponse {
   };
 }
 
+interface WorkosErrorResponse {
+  readonly error?: string;
+  readonly error_description?: string;
+  readonly code?: string;
+}
+
+const parseWorkosErrorCode = (raw: string): "invalid_grant" | undefined => {
+  try {
+    const parsed = JSON.parse(raw) as WorkosErrorResponse;
+    const code = parsed.error ?? parsed.code;
+    return code === "invalid_grant" ? "invalid_grant" : undefined;
+  } catch {
+    return raw.includes("invalid_grant") ? "invalid_grant" : undefined;
+  }
+};
+
 const parseAuthenticateResponse = (
   value: unknown,
 ): WorkosAuthenticateResponse => {
@@ -112,6 +128,7 @@ export interface SessionBundle {
   readonly accessToken: string;
   readonly refreshToken: string;
   readonly expiresAt: number;
+  readonly refreshedAt: number;
   readonly organizationId: string | null;
   readonly user: {
     readonly id: string;
@@ -121,6 +138,43 @@ export interface SessionBundle {
     readonly profilePictureUrl: string | null;
   };
 }
+
+export const parseSessionBundle = (value: unknown): SessionBundle | null => {
+  if (typeof value !== "object" || value === null) return null;
+  const obj = value as Partial<SessionBundle>;
+  const user = obj.user;
+  if (
+    typeof obj.accessToken !== "string" ||
+    typeof obj.refreshToken !== "string" ||
+    typeof obj.expiresAt !== "number" ||
+    typeof user !== "object" ||
+    user === null ||
+    typeof user.id !== "string"
+  ) {
+    return null;
+  }
+  return {
+    accessToken: obj.accessToken,
+    refreshToken: obj.refreshToken,
+    expiresAt: obj.expiresAt,
+    refreshedAt:
+      typeof obj.refreshedAt === "number" && Number.isFinite(obj.refreshedAt)
+        ? obj.refreshedAt
+        : 0,
+    organizationId:
+      typeof obj.organizationId === "string" ? obj.organizationId : null,
+    user: {
+      id: user.id,
+      email: typeof user.email === "string" ? user.email : "",
+      firstName: typeof user.firstName === "string" ? user.firstName : null,
+      lastName: typeof user.lastName === "string" ? user.lastName : null,
+      profilePictureUrl:
+        typeof user.profilePictureUrl === "string"
+          ? user.profilePictureUrl
+          : null,
+    },
+  };
+};
 
 /**
  * Read `exp` from a JWT access token without verifying the signature — we only
@@ -146,6 +200,7 @@ const toBundle = (res: WorkosAuthenticateResponse): SessionBundle => ({
   accessToken: res.access_token,
   refreshToken: res.refresh_token,
   expiresAt: expiryFromJwt(res.access_token),
+  refreshedAt: Date.now(),
   organizationId: res.organization_id ?? null,
   user: {
     id: res.user.id,
@@ -165,16 +220,29 @@ const authenticate = (
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(15_000),
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");
-        throw new Error(`WorkOS ${res.status}: ${text.slice(0, 500)}`);
+        const err = new Error(`WorkOS ${res.status}: ${text.slice(0, 500)}`);
+        Object.assign(err, { workosCode: parseWorkosErrorCode(text) });
+        throw err;
       }
       return parseAuthenticateResponse(await res.json());
     },
     catch: (cause) =>
       new AuthTokenError({
-        reason: cause instanceof Error ? cause.message : String(cause),
+        reason:
+          cause instanceof Error && cause.name === "TimeoutError"
+            ? "WorkOS request timed out."
+            : cause instanceof Error
+              ? cause.message
+              : String(cause),
+        code:
+          cause instanceof Error &&
+          (cause as { workosCode?: unknown }).workosCode === "invalid_grant"
+            ? "invalid_grant"
+            : undefined,
         cause,
       }),
   }).pipe(Effect.map(toBundle));

--- a/apps/server/src/auth/services/session-store.ts
+++ b/apps/server/src/auth/services/session-store.ts
@@ -1,0 +1,20 @@
+import { Context, type Effect } from "effect";
+
+import type { SessionStoreError } from "../errors.ts";
+import type { SessionBundle } from "../layers/workos.ts";
+
+export interface SessionStoreShape {
+  readonly read: () => Effect.Effect<SessionBundle | null, SessionStoreError>;
+  readonly write: (
+    bundle: SessionBundle,
+  ) => Effect.Effect<SessionBundle, SessionStoreError>;
+  readonly clear: () => Effect.Effect<void, SessionStoreError>;
+  readonly withLock: <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E | SessionStoreError, R>;
+}
+
+export class SessionStore extends Context.Tag("memoize/SessionStore")<
+  SessionStore,
+  SessionStoreShape
+>() {}

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -1,6 +1,6 @@
 import { Command, CommandExecutor, FileSystem } from "@effect/platform";
 import { Duration, Effect, Stream } from "effect";
-import { homedir, platform } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 import {
@@ -653,6 +653,10 @@ const CLAUDE_SUB_LABEL: Record<string, string> = {
 };
 
 interface ClaudeCredentialBlob {
+  readonly oauthAccount?: {
+    readonly emailAddress?: string;
+    readonly email?: string;
+  };
   readonly claudeAiOauth?: {
     readonly subscriptionType?: string;
     readonly emailAddress?: string;
@@ -691,48 +695,54 @@ const parseClaudeCredentials = (raw: string): AccountInfo => {
   };
 };
 
-const probeClaudeAccount: Effect.Effect<
-  AccountInfo,
-  never,
-  FileSystem.FileSystem | CommandExecutor.CommandExecutor
-> = Effect.gen(function* () {
-  if (platform() === "darwin") {
-    // macOS can prompt for Keychain permission when reading the Claude Code
-    // OAuth secret. Provider availability runs on app boot, so keep this probe
-    // to a metadata presence check and let the Claude CLI perform entitlement
-    // validation when a session starts.
-    const result = yield* runCapture(
-      Command.make(
-        "security",
-        "find-generic-password",
-        "-s",
-        "Claude Code-credentials",
-      ),
-    ).pipe(
-      Effect.timeoutOption(ACCOUNT_PROBE_TIMEOUT),
-      Effect.catchAll(() => Effect.succeedNone),
-    );
-    if (result._tag !== "Some" || result.value.exitCode !== 0) {
-      return { authStatus: "unauthenticated" } satisfies AccountInfo;
-    }
+const parseClaudeAccountFile = (raw: string): AccountInfo | null => {
+  try {
+    const parsed = JSON.parse(raw) as ClaudeCredentialBlob;
+    const oauth = parsed.oauthAccount;
+    if (!oauth) return null;
+    const email = oauth.emailAddress ?? oauth.email;
     return {
       authStatus: "authenticated",
       authType: "oauth",
       authLabel: "Claude subscription",
-    } satisfies AccountInfo;
+      ...(email ? { authEmail: email } : {}),
+    };
+  } catch {
+    return null;
   }
-  const fs = yield* FileSystem.FileSystem;
-  const path = join(homedir(), ".claude", ".credentials.json");
-  const exists = yield* fs
-    .exists(path)
-    .pipe(Effect.catchAll(() => Effect.succeed(false)));
-  if (!exists) return { authStatus: "unauthenticated" };
-  const raw = yield* fs
-    .readFileString(path)
-    .pipe(Effect.catchAll(() => Effect.succeed("")));
-  return raw.length === 0
+};
+
+const readOptionalFile = (
+  path: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const exists = yield* fs
+      .exists(path)
+      .pipe(Effect.catchAll(() => Effect.succeed(false)));
+    if (!exists) return null;
+    return yield* fs
+      .readFileString(path)
+      .pipe(Effect.catchAll(() => Effect.succeed(null)));
+  });
+
+const probeClaudeAccount: Effect.Effect<
+  AccountInfo,
+  never,
+  FileSystem.FileSystem
+> = Effect.gen(function* () {
+  const accountRaw = yield* readOptionalFile(join(homedir(), ".claude.json"));
+  if (accountRaw !== null) {
+    const account = parseClaudeAccountFile(accountRaw);
+    if (account !== null) return account;
+  }
+  const credentialsRaw = yield* readOptionalFile(
+    join(homedir(), ".claude", ".credentials.json"),
+  );
+  if (credentialsRaw === null) return { authStatus: "unauthenticated" };
+  return credentialsRaw.length === 0
     ? { authStatus: "authenticated" }
-    : parseClaudeCredentials(raw);
+    : parseClaudeCredentials(credentialsRaw);
 });
 
 interface GrokAuthEntry {

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -71,6 +71,48 @@ const KNOWN_PROVIDERS: ReadonlyArray<ProviderId> = [
 const isKnownProvider = (id: string): id is ProviderId =>
   (KNOWN_PROVIDERS as ReadonlyArray<string>).includes(id);
 
+const providerCache = new Map<ProviderId, string | null>();
+const browserCache = new Map<string, BrowserCred | null>();
+let configuredCache: ReadonlyArray<ProviderId> | null = null;
+let browserListCache: ReadonlyArray<{
+  origin: string;
+  username: string;
+}> | null = null;
+
+const invalidateProviderList = (): void => {
+  configuredCache = null;
+};
+
+const invalidateBrowserList = (): void => {
+  browserListCache = null;
+};
+
+const collectConfigured = (
+  entries: ReadonlyArray<{ account: string }>,
+): ProviderId[] => {
+  const out: ProviderId[] = [];
+  for (const { account } of entries) {
+    const idx = account.indexOf(":");
+    if (idx === -1 || account.slice(0, idx) !== "apiKey") continue;
+    const id = account.slice(idx + 1);
+    if (isKnownProvider(id) && !out.includes(id)) out.push(id);
+  }
+  return out;
+};
+
+const collectBrowser = (
+  entries: ReadonlyArray<{ account: string; password: string }>,
+): Array<{ origin: string; username: string }> => {
+  const out: Array<{ origin: string; username: string }> = [];
+  for (const { account, password } of entries) {
+    if (!account.startsWith(BROWSER_PREFIX)) continue;
+    const origin = account.slice(BROWSER_PREFIX.length);
+    const cred = parseBrowserCred(password);
+    out.push({ origin, username: cred?.username ?? "" });
+  }
+  return out;
+};
+
 const tryKeychain = <A>(
   providerId: ProviderId | "*",
   thunk: () => Promise<A>,
@@ -102,37 +144,64 @@ export const CredentialsServiceLive = Layer.succeed(
   CredentialsService,
   CredentialsService.of({
     get: (providerId) =>
-      tryKeychain(providerId, () =>
-        getPasswordWithLegacyPromotion(accountFor(providerId)),
-      ),
+      providerCache.has(providerId)
+        ? Effect.succeed(providerCache.get(providerId) ?? null)
+        : tryKeychain(providerId, () =>
+            getPasswordWithLegacyPromotion(accountFor(providerId)),
+          ).pipe(
+            Effect.tap((value) =>
+              Effect.sync(() => {
+                providerCache.set(providerId, value);
+              }),
+            ),
+          ),
     set: (providerId, apiKey) =>
       tryKeychain(providerId, () =>
         keytar.setPassword(SERVICE_NAME, accountFor(providerId), apiKey),
+      ).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            providerCache.set(providerId, apiKey);
+            invalidateProviderList();
+          }),
+        ),
       ),
     remove: (providerId) =>
-      tryKeychain(providerId, async () =>
-        (await keytar.deletePassword(SERVICE_NAME, accountFor(providerId))) ||
-        (await keytar.deletePassword(
-          LEGACY_SERVICE_NAME,
-          accountFor(providerId),
-        )),
-      ).pipe(Effect.asVoid),
-    listConfigured: () =>
-      tryKeychain("*", async () => [
-        ...(await keytar.findCredentials(SERVICE_NAME)),
-        ...(await keytar.findCredentials(LEGACY_SERVICE_NAME)),
-      ]).pipe(
-        Effect.map((entries) => {
-          const out: ProviderId[] = [];
-          for (const { account } of entries) {
-            const idx = account.indexOf(":");
-            if (idx === -1 || account.slice(0, idx) !== "apiKey") continue;
-            const id = account.slice(idx + 1);
-            if (isKnownProvider(id) && !out.includes(id)) out.push(id);
-          }
-          return out;
-        }),
+      tryKeychain(
+        providerId,
+        async () =>
+          (await keytar.deletePassword(SERVICE_NAME, accountFor(providerId))) ||
+          (await keytar.deletePassword(
+            LEGACY_SERVICE_NAME,
+            accountFor(providerId),
+          )),
+      ).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            providerCache.delete(providerId);
+            invalidateProviderList();
+          }),
+        ),
+        Effect.asVoid,
       ),
+    listConfigured: () =>
+      configuredCache !== null
+        ? Effect.succeed(configuredCache)
+        : tryKeychain("*", async () => {
+            const current = collectConfigured(
+              await keytar.findCredentials(SERVICE_NAME),
+            );
+            if (current.length > 0) return current;
+            return collectConfigured(
+              await keytar.findCredentials(LEGACY_SERVICE_NAME),
+            );
+          }).pipe(
+            Effect.tap((value) =>
+              Effect.sync(() => {
+                configuredCache = value;
+              }),
+            ),
+          ),
     setBrowser: (origin, username, password) =>
       tryKeychain("*", () =>
         keytar.setPassword(
@@ -140,35 +209,66 @@ export const CredentialsServiceLive = Layer.succeed(
           browserAccountFor(origin),
           JSON.stringify({ username, password }),
         ),
+      ).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            browserCache.set(normalizeOrigin(origin), { username, password });
+            invalidateBrowserList();
+          }),
+        ),
       ),
     getBrowser: (origin) =>
-      tryKeychain("*", () =>
-        getPasswordWithLegacyPromotion(browserAccountFor(origin)),
-      ).pipe(Effect.map(parseBrowserCred)),
+      browserCache.has(normalizeOrigin(origin))
+        ? Effect.succeed(browserCache.get(normalizeOrigin(origin)) ?? null)
+        : tryKeychain("*", () =>
+            getPasswordWithLegacyPromotion(browserAccountFor(origin)),
+          ).pipe(
+            Effect.map(parseBrowserCred),
+            Effect.tap((value) =>
+              Effect.sync(() => {
+                browserCache.set(normalizeOrigin(origin), value);
+              }),
+            ),
+          ),
     removeBrowser: (origin) =>
-      tryKeychain("*", async () =>
-        (await keytar.deletePassword(SERVICE_NAME, browserAccountFor(origin))) ||
-        (await keytar.deletePassword(
-          LEGACY_SERVICE_NAME,
-          browserAccountFor(origin),
-        )),
-      ).pipe(Effect.asVoid),
-    listBrowser: () =>
-      tryKeychain("*", async () => [
-        ...(await keytar.findCredentials(SERVICE_NAME)),
-        ...(await keytar.findCredentials(LEGACY_SERVICE_NAME)),
-      ]).pipe(
-        Effect.map((entries) => {
-          const out: Array<{ origin: string; username: string }> = [];
-          for (const { account, password } of entries) {
-            if (!account.startsWith(BROWSER_PREFIX)) continue;
-            const origin = account.slice(BROWSER_PREFIX.length);
-            const cred = parseBrowserCred(password);
-            out.push({ origin, username: cred?.username ?? "" });
-          }
-          return out;
-        }),
+      tryKeychain(
+        "*",
+        async () =>
+          (await keytar.deletePassword(
+            SERVICE_NAME,
+            browserAccountFor(origin),
+          )) ||
+          (await keytar.deletePassword(
+            LEGACY_SERVICE_NAME,
+            browserAccountFor(origin),
+          )),
+      ).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            browserCache.delete(normalizeOrigin(origin));
+            invalidateBrowserList();
+          }),
+        ),
+        Effect.asVoid,
       ),
+    listBrowser: () =>
+      browserListCache !== null
+        ? Effect.succeed(browserListCache)
+        : tryKeychain("*", async () => {
+            const current = collectBrowser(
+              await keytar.findCredentials(SERVICE_NAME),
+            );
+            if (current.length > 0) return current;
+            return collectBrowser(
+              await keytar.findCredentials(LEGACY_SERVICE_NAME),
+            );
+          }).pipe(
+            Effect.tap((value) =>
+              Effect.sync(() => {
+                browserListCache = value;
+              }),
+            ),
+          ),
     getWorkosSession: () =>
       tryKeychain("*", () =>
         keytar.getPassword(SERVICE_NAME, WORKOS_SESSION_ACCOUNT),

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -7,6 +7,7 @@ import { MemoizeRpcs } from "@zuse/wire";
 
 import { AppPaths } from "./app-paths.ts";
 import { AuthServiceLive } from "./auth/layers/auth-service.ts";
+import { SessionStoreLive } from "./auth/layers/session-store.ts";
 import { AuthShell } from "./auth/services/auth-shell.ts";
 import { AttachmentServiceLive } from "./attachment/layers/attachment-service.ts";
 import { ConfigStoreServiceLive } from "./config-store/layers/config-store-service.ts";
@@ -319,14 +320,13 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
     Layer.provide(MessageStoreLayer),
     Layer.provide(WorkspaceLayer),
   );
-  // AuthService owns the WorkOS PKCE flow + keychain token bundle. Depends on
-  // CredentialsService (keychain) and the host-supplied AuthShell (browser +
-  // deep-link). It registers its callback sink with the shell at build time,
-  // so it must be constructed at boot — Handlers depends on it, which forces
-  // that. No SqlClient: the (non-secret) profile rides along in the keychain
-  // bundle, so there's no users table to migrate.
+  // AuthService owns the WorkOS PKCE flow + shared file-backed session bundle.
+  // It still depends on CredentialsService for one-time migration from older
+  // keychain storage. The host supplies AuthShell (browser + callback), and
+  // the callback sink is registered at build time, so Handlers forces boot.
   const AuthLayer = AuthServiceLive.pipe(
     Layer.provide(CredentialsServiceLive),
+    Layer.provide(SessionStoreLive),
     Layer.provide(AuthShellLayer),
   );
 

--- a/apps/server/test/auth-service.test.ts
+++ b/apps/server/test/auth-service.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { Effect, Layer, ManagedRuntime } from "effect";
+import { Chunk, Effect, Layer, ManagedRuntime, Stream } from "effect";
 
 import type { ProviderId } from "@zuse/wire";
 
 import { AuthServiceLive } from "../src/auth/layers/auth-service.ts";
 import type { SessionBundle } from "../src/auth/layers/workos.ts";
+import { SessionStore } from "../src/auth/services/session-store.ts";
 import { AuthService } from "../src/auth/services/auth-service.ts";
 import { AuthShell } from "../src/auth/services/auth-shell.ts";
 import { CredentialsService } from "../src/provider/services/credentials-service.ts";
@@ -29,6 +30,7 @@ const makeBundle = (overrides: Partial<SessionBundle> = {}): SessionBundle => ({
   accessToken: jwtWithExp(Date.now() + 15 * 60_000),
   refreshToken: "refresh-token",
   expiresAt: Date.now() + 15 * 60_000,
+  refreshedAt: Date.now(),
   organizationId: null,
   user: {
     id: "user_123",
@@ -40,8 +42,21 @@ const makeBundle = (overrides: Partial<SessionBundle> = {}): SessionBundle => ({
   ...overrides,
 });
 
-const decodeStored = (raw: string | null): SessionBundle | null =>
-  raw === null ? null : (JSON.parse(raw) as SessionBundle);
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs = 500,
+): Promise<void> => {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition.");
+    }
+    await delay(10);
+  }
+};
 
 interface Harness {
   readonly run: <A>(
@@ -51,8 +66,17 @@ interface Harness {
   readonly dispose: () => Promise<void>;
 }
 
-const makeHarness = (initial: SessionBundle): Harness => {
-  let stored: string | null = JSON.stringify(initial);
+const makeHarness = (
+  initial: SessionBundle | null,
+  options: {
+    readonly onRead?: (
+      stored: SessionBundle | null,
+      readCount: number,
+    ) => SessionBundle | null;
+  } = {},
+): Harness => {
+  let stored: SessionBundle | null = initial;
+  let readCount = 0;
   const CredentialsLayer = Layer.succeed(
     CredentialsService,
     CredentialsService.of({
@@ -65,10 +89,10 @@ const makeHarness = (initial: SessionBundle): Harness => {
       getBrowser: (_origin: string) => Effect.succeed(null),
       removeBrowser: (_origin: string) => Effect.void,
       listBrowser: () => Effect.succeed([]),
-      getWorkosSession: () => Effect.succeed(stored),
+      getWorkosSession: () => Effect.succeed(null),
       setWorkosSession: (bundleJson: string) =>
         Effect.sync(() => {
-          stored = bundleJson;
+          stored = JSON.parse(bundleJson) as SessionBundle;
         }),
       removeWorkosSession: () =>
         Effect.sync(() => {
@@ -84,16 +108,40 @@ const makeHarness = (initial: SessionBundle): Harness => {
       onCallbackUrl: (_handler: (url: string) => void) => Effect.void,
     }),
   );
+  const SessionStoreLayer = Layer.succeed(
+    SessionStore,
+    SessionStore.of({
+      read: () =>
+        Effect.sync(() => {
+          readCount += 1;
+          return options.onRead?.(stored, readCount) ?? stored;
+        }),
+      write: (bundle) =>
+        Effect.sync(() => {
+          if (stored !== null && stored.refreshedAt > bundle.refreshedAt) {
+            return stored;
+          }
+          stored = bundle;
+          return bundle;
+        }),
+      clear: () =>
+        Effect.sync(() => {
+          stored = null;
+        }),
+      withLock: (effect) => effect,
+    }),
+  );
   const runtime = ManagedRuntime.make(
     AuthServiceLive.pipe(
       Layer.provide(CredentialsLayer),
+      Layer.provide(SessionStoreLayer),
       Layer.provide(AuthShellLayer),
     ),
   );
   return {
     run: <A>(effect: Effect.Effect<A, unknown, AuthService>) =>
       runtime.runPromise(effect as Effect.Effect<A, unknown, never>),
-    readStored: () => decodeStored(stored),
+    readStored: () => stored,
     dispose: () => runtime.dispose(),
   };
 };
@@ -199,12 +247,89 @@ describe("AuthService WorkOS refresh", () => {
         Effect.flatMap(AuthService, (svc) => svc.getSession()),
       );
       expect(state._tag).toBe("SignedIn");
+      await waitFor(() => calls.length === 1);
       expect(calls).toHaveLength(1);
       expect(harness.readStored()?.refreshToken).toBe(
         "temporarily-failing-refresh",
       );
     } finally {
       await harness.dispose();
+    }
+  });
+
+  it("returns a stale signed-in session immediately while refresh runs in the background", async () => {
+    const old = makeBundle({
+      accessToken: jwtWithExp(Date.now() - 5 * 60_000),
+      refreshToken: "expired-refresh",
+      expiresAt: Date.now() - 5 * 60_000,
+      refreshedAt: Date.now(),
+    });
+    let releaseRefresh: (() => void) | null = null;
+    const nextAccessToken = jwtWithExp(Date.now() + 20 * 60_000);
+    const calls = mockAuthenticate(async () => {
+      await new Promise<void>((resolve) => {
+        releaseRefresh = resolve;
+      });
+      return Response.json({
+        access_token: nextAccessToken,
+        refresh_token: "background-refresh",
+        user: { id: "user_123", email: "user@example.com" },
+      });
+    });
+    const harness = makeHarness(old);
+    try {
+      const state = await harness.run(
+        Effect.flatMap(AuthService, (svc) => svc.getSession()),
+      );
+      expect(state._tag).toBe("SignedIn");
+      await waitFor(() => calls.length === 1);
+      releaseRefresh?.();
+      await waitFor(
+        () => harness.readStored()?.refreshToken === "background-refresh",
+      );
+    } finally {
+      releaseRefresh?.();
+      await harness.dispose();
+    }
+  });
+
+  it("sessionChanges emits the current auth state before live updates", async () => {
+    const signedInHarness = makeHarness(makeBundle());
+    try {
+      const first = await signedInHarness.run(
+        Effect.gen(function* () {
+          const svc = yield* AuthService;
+          return yield* svc
+            .sessionChanges()
+            .pipe(
+              Stream.take(1),
+              Stream.runCollect,
+              Effect.map(Chunk.toReadonlyArray),
+            );
+        }),
+      );
+      expect(first[0]?._tag).toBe("SignedIn");
+    } finally {
+      await signedInHarness.dispose();
+    }
+
+    const signedOutHarness = makeHarness(null);
+    try {
+      const first = await signedOutHarness.run(
+        Effect.gen(function* () {
+          const svc = yield* AuthService;
+          return yield* svc
+            .sessionChanges()
+            .pipe(
+              Stream.take(1),
+              Stream.runCollect,
+              Effect.map(Chunk.toReadonlyArray),
+            );
+        }),
+      );
+      expect(first).toEqual([{ _tag: "SignedOut" }]);
+    } finally {
+      await signedOutHarness.dispose();
     }
   });
 

--- a/apps/server/test/session-store.test.ts
+++ b/apps/server/test/session-store.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Effect, ManagedRuntime } from "effect";
+
+import { SessionStoreLive } from "../src/auth/layers/session-store.ts";
+import type { SessionBundle } from "../src/auth/layers/workos.ts";
+import { SessionStore } from "../src/auth/services/session-store.ts";
+
+const originalAuthDir = process.env.ZUSE_AUTH_DIR;
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  if (originalAuthDir === undefined) {
+    delete process.env.ZUSE_AUTH_DIR;
+  } else {
+    process.env.ZUSE_AUTH_DIR = originalAuthDir;
+  }
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+const makeTempAuthDir = async (): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), "zuse-auth-"));
+  tempDirs.push(dir);
+  process.env.ZUSE_AUTH_DIR = dir;
+  return dir;
+};
+
+const makeBundle = (overrides: Partial<SessionBundle> = {}): SessionBundle => ({
+  accessToken: "access",
+  refreshToken: "refresh",
+  expiresAt: Date.now() + 60_000,
+  refreshedAt: Date.now(),
+  organizationId: null,
+  user: {
+    id: "user_123",
+    email: "user@example.com",
+    firstName: null,
+    lastName: null,
+    profilePictureUrl: null,
+  },
+  ...overrides,
+});
+
+const withStore = async <A>(
+  fn: (svc: typeof SessionStore.Service) => Effect.Effect<A, unknown>,
+): Promise<A> => {
+  const runtime = ManagedRuntime.make(SessionStoreLive);
+  try {
+    return await runtime.runPromise(Effect.flatMap(SessionStore, fn));
+  } finally {
+    await runtime.dispose();
+  }
+};
+
+describe("SessionStoreLive", () => {
+  it("returns null when the session file is absent", async () => {
+    await makeTempAuthDir();
+    const value = await withStore((svc) => svc.read());
+    expect(value).toBe(null);
+  });
+
+  it("writes atomically with 0600 permissions and reads the bundle", async () => {
+    const dir = await makeTempAuthDir();
+    const bundle = makeBundle({ refreshToken: "newer", refreshedAt: 2 });
+    await withStore((svc) => svc.write(bundle));
+    const path = join(dir, "auth.json");
+    const mode = (await stat(path)).mode & 0o777;
+    expect(mode).toBe(0o600);
+    expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({
+      refreshToken: "newer",
+      refreshedAt: 2,
+    });
+    const read = await withStore((svc) => svc.read());
+    expect(read?.refreshToken).toBe("newer");
+  });
+
+  it("fails on corrupt JSON but treats wrong-shape JSON as signed out", async () => {
+    const dir = await makeTempAuthDir();
+    await writeFile(join(dir, "auth.json"), "{", { mode: 0o600 });
+    const corrupt = await withStore((svc) => svc.read().pipe(Effect.either));
+    expect(corrupt._tag).toBe("Left");
+
+    await writeFile(join(dir, "auth.json"), JSON.stringify({ nope: true }), {
+      mode: 0o600,
+    });
+    const wrongShape = await withStore((svc) => svc.read());
+    expect(wrongShape).toBe(null);
+  });
+
+  it("refuses to overwrite a newer bundle", async () => {
+    await makeTempAuthDir();
+    const newer = makeBundle({ refreshToken: "newer", refreshedAt: 10 });
+    const older = makeBundle({ refreshToken: "older", refreshedAt: 1 });
+    await withStore((svc) => svc.write(newer));
+    const winner = await withStore((svc) => svc.write(older));
+    expect(winner.refreshToken).toBe("newer");
+    const stored = await withStore((svc) => svc.read());
+    expect(stored?.refreshToken).toBe("newer");
+  });
+
+  it("serializes work under the lock and breaks stale locks", async () => {
+    const dir = await makeTempAuthDir();
+    await writeFile(
+      join(dir, "auth.lock"),
+      JSON.stringify({ pid: 99999999, createdAt: Date.now() - 60_000 }),
+      { mode: 0o600 },
+    );
+    let active = 0;
+    let maxActive = 0;
+    await Promise.all(
+      Array.from({ length: 3 }, () =>
+        withStore((svc) =>
+          svc.withLock(
+            Effect.gen(function* () {
+              active += 1;
+              maxActive = Math.max(maxActive, active);
+              yield* Effect.sleep("20 millis");
+              active -= 1;
+            }),
+          ),
+        ),
+      ),
+    );
+    expect(maxActive).toBe(1);
+  });
+});


### PR DESCRIPTION
## What changed

- Moved WorkOS session persistence from the macOS keychain to a shared file-backed session store under `~/.zuse/auth.json`.
- Added atomic writes, strict file permissions, monotonic refresh guards, and a cross-process file lock for refresh-token rotation.
- Added one-time migration from the old keychain session entry, last-known-good fallback on store read failures, and background keep-alive refresh.
- Fixed relaunch after access-token expiry by returning stale signed-in identity immediately, replaying current auth state on stream subscribe, and refreshing in the background.
- Added loopback redirect fallback across ports `8976-8979` for parallel desktop instances.
- Reduced keychain prompts by caching provider credential enumeration and replacing the Claude availability keychain probe with file-based detection.
- Fixed desktop bundling so root `.env` can provide `WORKOS_CLIENT_ID` reliably.
- Reused the blurred email privacy pill for WorkOS account surfaces so account emails are hidden by default in Settings, onboarding, and the sidebar.
- Removed the separate Display name settings field; display-name editing now lives beside the account name via `PencilEdit01Icon`.

## Why

The prior session bundle lived in a keychain item that can prompt or fail under unsigned/dev Electron builds. Read failures were folded into signed-out state, and multiple app instances could race WorkOS single-use refresh tokens. Fixed loopback port binding also prevents sign-in timeouts when more than one instance is running.

A follow-up boot issue also caused the renderer to show signed out after relaunching with an expired access token, even though the file-backed session was valid. `getSession` no longer blocks on refresh, and the auth stream now replays current state so the renderer self-heals after missed boot events.

The renderer also previously showed WorkOS emails as normal text in account UI. Those now use the same click-to-reveal blurred email treatment as provider login emails.

## Validation

- `bun test apps/server/test/session-store.test.ts apps/server/test/auth-service.test.ts apps/server/test/claude-auth-detection.test.ts`
- `bunx tsc -p apps/server/tsconfig.json --noEmit`
- `bunx tsc -p apps/desktop/tsconfig.json --noEmit`
- `bunx tsc -p apps/renderer/tsconfig.json --noEmit`
- `git diff --check`
