### PR TITLE
[codex] Fix auth client startup retry

### DIFF
--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -16,15 +16,15 @@ import { wsClientProtocolLayer } from "./ws-client-protocol.ts";
  */
 type MemoizeClient = RpcClient.RpcClient<RpcGroup.Rpcs<typeof MemoizeRpcs>>;
 
-let runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never> | null = null;
+let runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never> | null =
+  null;
 let cachedClient: Promise<MemoizeClient> | null = null;
 
 function resolveWebSocketUrl() {
-  const env = (import.meta as { readonly env?: Record<string, string | undefined> })
-    .env;
-  return (
-    env?.VITE_ZUSE_WS_URL?.trim() || `ws://${location.host}/rpc`
-  );
+  const env = (
+    import.meta as { readonly env?: Record<string, string | undefined> }
+  ).env;
+  return env?.VITE_ZUSE_WS_URL?.trim() || `ws://${location.host}/rpc`;
 }
 
 export function resolveRendererRpcTransportForTest(): {
@@ -55,12 +55,21 @@ function getRuntime() {
 export function getRpcClient(): Promise<MemoizeClient> {
   if (cachedClient === null) {
     const rt = getRuntime();
-    cachedClient = rt.runPromise(
+    const next = rt.runPromise(
       Effect.gen(function* () {
         const scope = yield* Scope.make();
         return yield* RpcClient.make(MemoizeRpcs).pipe(Scope.extend(scope));
       }),
     );
+    let guarded: Promise<MemoizeClient>;
+    guarded = next.catch((err) => {
+      if (cachedClient === guarded) {
+        cachedClient = null;
+        runtime = null;
+      }
+      throw err;
+    });
+    cachedClient = guarded;
   }
   return cachedClient;
 }

--- a/apps/renderer/src/store/auth.ts
+++ b/apps/renderer/src/store/auth.ts
@@ -101,32 +101,26 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   start: () => {
     if (started) return;
     started = true;
-    void (async () => {
-      let client: Awaited<ReturnType<typeof getRpcClient>>;
-      try {
-        client = await getRpcClient();
-      } catch {
-        started = false;
-        return;
-      }
-      const subscribe = Stream.runForEach(
-        client.auth.sessionChanges({}),
-        (next) => Effect.sync(() => set({ state: next })),
-      );
-      // Self-healing: re-establish after any completion/error with bounded
-      // backoff so a server restart / dev HMR doesn't kill live delivery.
-      const program = subscribe.pipe(
-        Effect.catchAll(() => Effect.void),
-        Effect.repeat(Schedule.spaced("2 seconds")),
-        Effect.ensuring(
-          Effect.sync(() => {
-            streamFiber = null;
-            started = false;
-          }),
+    const subscribeOnce = Effect.tryPromise(() => getRpcClient()).pipe(
+      Effect.flatMap((client) =>
+        Stream.runForEach(client.auth.sessionChanges({}), (next) =>
+          Effect.sync(() => set({ state: next })),
         ),
-      );
-      streamFiber = Effect.runFork(program);
-    })();
+      ),
+    );
+    // Self-healing: re-establish after any completion/error with bounded
+    // backoff so a server restart / dev HMR doesn't kill live delivery.
+    const program = subscribeOnce.pipe(
+      Effect.catchAll(() => Effect.void),
+      Effect.repeat(Schedule.spaced("2 seconds")),
+      Effect.ensuring(
+        Effect.sync(() => {
+          streamFiber = null;
+          started = false;
+        }),
+      ),
+    );
+    streamFiber = Effect.runFork(program);
   },
   hydrate: async () => {
     try {
@@ -140,9 +134,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         const next = await Effect.runPromise(client.auth.getSession({}));
         set({ state: next });
       } catch {
-        // Bridge not up yet / transient — assume signed out so the UI can
-        // render. A later stream emit or re-hydrate corrects it.
-        set((prev) => ({ state: prev.state ?? SIGNED_OUT }));
+        // Bridge not up yet / transient. Keep the previous/loading state; the
+        // retrying sessionChanges stream will publish the definitive state.
+        set((prev) => ({ state: prev.state }));
       }
     }
   },


### PR DESCRIPTION
## What changed

- Clear the cached renderer RPC client/runtime when initial client creation fails.
- Make the auth session stream retry client creation every 2 seconds instead of giving up after the first startup race.
- Stop latching renderer auth state to `SignedOut` after transient hydrate failures; the retrying stream now owns convergence to the real server state.

## Why

After the file-backed WorkOS session fix, `~/.zuse/auth.json` could be valid while `bun dev` still showed signed out. The remaining failure was a renderer startup race: if the first `getRpcClient()` happened before Electron IPC was ready, the failed/wrong transport was cached and auth hydrate/sessionChanges could never recover.

## Validation

- `bunx tsc -p apps/renderer/tsconfig.json --noEmit`
- `git diff --check origin/main...HEAD`
