### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0]
+
+### Added
+- Self-orchestrating agents: Phase 1 control plane + spec (#250)
+- [codex] Add shared HTTP MCP gateway (#292)
+- Add Grok 4.5 model picker support (#294)
+
+### Changed
+- Mobile UI overhaul: naming, new chat, session, stream, permission, inbox (#295)
+- [codex] Remove manual sub-agent settings (#297)
+- [codex] Improve model picker defaults (#299)
+
+### Fixed
+- [codex] Fix Grok native permission handling (#291)
+- [codex] Fix WorkOS auth persistence (#296)
+- [codex] Fix auth client startup retry (#298)
+
 ## [0.11.0]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,34 @@
 [
   {
+    "version": "0.12.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Self-orchestrating agents: Phase 1 control plane + spec (#250)",
+          "[codex] Add shared HTTP MCP gateway (#292)",
+          "Add Grok 4.5 model picker support (#294)"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Mobile UI overhaul: naming, new chat, session, stream, permission, inbox (#295)",
+          "[codex] Remove manual sub-agent settings (#297)",
+          "[codex] Improve model picker defaults (#299)"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "[codex] Fix Grok native permission handling (#291)",
+          "[codex] Fix WorkOS auth persistence (#296)",
+          "[codex] Fix auth client startup retry (#298)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.11.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release Zuse v0.12.0
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Highlights
- Self-orchestrating agents Phase 1 control plane
- Shared HTTP MCP gateway
- Grok 4.5 model picker support
- Mobile UI overhaul
- Auth and permission fixes

## Test
- bun run check-types

Release artifacts are produced by pushing tag `v0.12.0` after this PR lands.