### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1]
+
+### Changed
+- Fix skipped chat lineage migration
+
 ## [0.12.0]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -29,6 +29,7 @@ import { Migration0025RelayEnvironmentKeys } from "./migrations/0025_relay_envir
 import { Migration0026RelayConnectorToken } from "./migrations/0026_relay_connector_token.ts";
 import { Migration0027RelayTunnelHostname } from "./migrations/0027_relay_tunnel_hostname.ts";
 import { Migration0028RelayMintPublicKey } from "./migrations/0028_relay_mint_public_key.ts";
+import { Migration0029ChatLineageRepair } from "./migrations/0029_chat_lineage_repair.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -76,6 +77,7 @@ export const MigrationsLive = Layer.effectDiscard(
       "0026_relay_connector_token": Migration0026RelayConnectorToken,
       "0027_relay_tunnel_hostname": Migration0027RelayTunnelHostname,
       "0028_relay_mint_public_key": Migration0028RelayMintPublicKey,
+      "0029_chat_lineage_repair": Migration0029ChatLineageRepair,
     }),
   }),
 );

--- a/apps/server/src/persistence/migrations/0029_chat_lineage_repair.ts
+++ b/apps/server/src/persistence/migrations/0029_chat_lineage_repair.ts
@@ -1,0 +1,25 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+/**
+ * Repair databases that advanced past migration 23 before the chat lineage
+ * column shipped. The migrator records numeric ids, so once a database has
+ * applied 24+ it will not go back and run 23. Keep this idempotent for both
+ * repaired and already-correct schemas.
+ */
+export const Migration0029ChatLineageRepair = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(chats)
+  `;
+  const hasOriginSessionId = columns.some(
+    (column) => column.name === "origin_session_id",
+  );
+  if (!hasOriginSessionId) {
+    yield* sql`
+      ALTER TABLE chats
+      ADD COLUMN origin_session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL
+    `;
+  }
+});

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -58,6 +58,7 @@ import { Migration0018PokemonWorktrees } from "../src/persistence/migrations/001
 import { Migration0019QueuePaused } from "../src/persistence/migrations/0019_queue_paused.ts";
 import { Migration0020Events } from "../src/persistence/migrations/0020_events.ts";
 import { Migration0023ChatLineage } from "../src/persistence/migrations/0023_chat_lineage.ts";
+import { Migration0029ChatLineageRepair } from "../src/persistence/migrations/0029_chat_lineage_repair.ts";
 import { WorktreeService } from "../src/worktree/services/worktree-service.ts";
 import { MessageStore } from "../src/provider/services/message-store.ts";
 import { ProviderService } from "../src/provider/services/provider-service.ts";
@@ -301,6 +302,7 @@ const runAllMigrations = Effect.all(
     Migration0019QueuePaused,
     Migration0020Events,
     Migration0023ChatLineage,
+    Migration0029ChatLineageRepair,
   ],
   { discard: true },
 );
@@ -440,6 +442,58 @@ describe("MessageStore migrations", () => {
       );
       expect(row?.queue_paused).toBe(0);
     });
+  });
+
+  it("0029 repairs databases that skipped chat lineage", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mz-chat-lineage-repair-"));
+    const dbPath = join(dir, "test.sqlite");
+    const runtime = ManagedRuntime.make(
+      SqliteClient.layer({ filename: dbPath }),
+    );
+    try {
+      await runtime.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`
+            CREATE TABLE projects (
+              id TEXT PRIMARY KEY,
+              path TEXT NOT NULL UNIQUE,
+              name TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+            )
+          `;
+          yield* sql`
+            CREATE TABLE chats (
+              id TEXT PRIMARY KEY,
+              project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+              worktree_id TEXT,
+              title TEXT NOT NULL,
+              active_session_id TEXT,
+              archived_at TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              archived_worktree_json TEXT,
+              last_message_at TEXT,
+              last_read_at TEXT
+            )
+          `;
+
+          yield* Migration0029ChatLineageRepair;
+          yield* Migration0029ChatLineageRepair;
+
+          const columns = yield* sql<{ readonly name: string }>`
+            PRAGMA table_info(chats)
+          `;
+          expect(columns.map((column) => column.name)).toContain(
+            "origin_session_id",
+          );
+        }),
+      );
+    } finally {
+      await runtime.dispose();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.12.1",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix skipped chat lineage migration"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.12.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- repair upgraded 0.12 databases that skipped chat lineage and are missing `chats.origin_session_id`
- bump desktop package metadata to `0.12.1`
- update CHANGELOG.md and the website changelog JSON

## Root cause
Some upgraded databases had migrations 24-28 recorded while migration 23 was absent. The app later prepared queries selecting `chats.origin_session_id`, which failed at prepare time when the column was missing.

## Validation
- `bun test apps/server/test/message-store.test.ts`
- `bunx tsc --noEmit -p apps/server/tsconfig.json`
- `bunx fumadocs-mdx` in `apps/web` to generate ignored source types
- `bun run check-types`
- ran the migration loader against a copied affected release DB and confirmed `origin_session_id` was added and the select prepares successfully

Release artifacts are produced by pushing tag `v0.12.1` after this PR lands.
