### PR TITLE
Fix permission card mislabeling plan-mode prompts as sensitive paths

### DIFF
--- a/apps/mobile/src/components/messages/pending-approval-card.tsx
+++ b/apps/mobile/src/components/messages/pending-approval-card.tsx
@@ -7,8 +7,9 @@ import { describePermissionKind } from "~/lib/permission-presentation";
 
 /**
  * Inline card for a pending tool-permission prompt. `forcePrompt` requests
- * (sensitive paths) hide "Allow session" so the user can't silence future
- * prompts on them by accident — mirroring the renderer's rule.
+ * hide "Allow session" so the user can't silence future prompts by accident
+ * — mirroring the renderer. That flag is used for sensitive paths, plan
+ * mode, and a few always-prompt tools; it is not only "sensitive path".
  */
 export const PendingApprovalCard = ({
   request,

--- a/apps/renderer/src/components/permission-card.tsx
+++ b/apps/renderer/src/components/permission-card.tsx
@@ -36,6 +36,26 @@ const kindDetail = (kind: PermissionKind): string => {
   }
 };
 
+/**
+ * `forcePrompt` is overloaded server-side: sensitive credential paths always
+ * force a one-shot approval, but so does plan mode (every bash/write/network
+ * call). The old copy always said "Sensitive path", which was wrong for the
+ * common Grok/ACP case of plan-mode shell prompts on ordinary commands.
+ */
+const forcePromptHint = (kind: PermissionKind): string => {
+  switch (kind._tag) {
+    case "Bash":
+    case "Network":
+      // Bash policy never path-scans the command string — forcePrompt here is
+      // plan mode (or an equivalent "never silence this class" gate).
+      return "Plan mode — only “Allow once” is available.";
+    case "FileWrite":
+      return "Sensitive path or plan mode — only “Allow once” is available.";
+    case "Other":
+      return "Only “Allow once” is available for this request.";
+  }
+};
+
 const ALLOW_ONCE: PermissionDecision = { _tag: "AllowOnce" };
 const ALLOW_FOR_SESSION: PermissionDecision = { _tag: "AllowForSession" };
 const ALWAYS_ALLOW_FOLDER: PermissionDecision = {
@@ -90,7 +110,7 @@ export function PermissionCard({
 
       {persistentDisabled ? (
         <div className="mt-2 text-xs text-muted-foreground">
-          Sensitive path — only “Allow once” is available.
+          {forcePromptHint(head.kind)}
         </div>
       ) : null}
 

--- a/apps/server/src/provider/policy.ts
+++ b/apps/server/src/provider/policy.ts
@@ -123,6 +123,13 @@ export type BashPolicy =
  *     is NOT auto-accepted in this mode.
  *  5. default (approval-required) → prompt (forcePrompt: false).
  *
+ * Important: this policy does **not** path-scan `command` for sensitive
+ * strings (`.env`, keys, etc.). A shell line that `ls`s another project
+ * directory is not a "sensitive path". When `forcePrompt` is true for Bash,
+ * the cause is plan mode (or a future per-command heuristic), never
+ * `isSensitivePath`. The renderer must not label Bash force-prompts as
+ * "Sensitive path" — that copy confuses Grok/ACP users in plan mode.
+ *
  * `command` is accepted for future per-command heuristics (e.g. forcing a
  * prompt on obviously destructive commands) but is not inspected yet.
  */

--- a/packages/wire/src/permission.ts
+++ b/packages/wire/src/permission.ts
@@ -53,9 +53,16 @@ export class PermissionRequest extends Schema.Class<PermissionRequest>(
   kind: PermissionKind,
   requestedAt: Schema.DateFromString,
   /**
-   * Sensitive paths (e.g. `.env`, SSH keys) flip this to `true` server-side.
-   * The renderer disables `AllowForSession` and `AlwaysAllow` for these so
-   * the user can't silence future prompts on them by accident.
+   * When true, the renderer disables `AllowForSession` and `AlwaysAllow` so
+   * the user can't silence future matching prompts by accident.
+   *
+   * Set server-side for more than just credential files:
+   *  - sensitive paths (`.env`, `.ssh`, keys, etc.) on file ops
+   *  - plan mode (every bash / mutating / network gate)
+   *  - a few always-prompt tools (e.g. browser login, ExitPlanMode)
+   *
+   * Do not treat `forcePrompt` as "this path is sensitive" in the UI —
+   * bash/network prompts almost never are; they usually mean plan mode.
    */
   forcePrompt: Schema.Boolean,
 }) {}


### PR DESCRIPTION
## Summary
- Permission cards no longer always show “Sensitive path” when `forcePrompt` is true.
- Bash/Network force-prompts are labeled as **plan mode** (Bash policy does not path-scan command strings).
- FileWrite keeps a combined “sensitive path or plan mode” hint; wire/policy docs clarify the overloaded flag.

## Why
Grok (and other ACP agents) use emulated plan mode. In plan mode every shell call sets `forcePrompt: true`, so ordinary commands like `ls` another project were shown as “Sensitive path — only Allow once,” which was incorrect and blocked session/always allow for the wrong reason.

## Test plan
- [ ] Start a Grok session in **plan mode**, trigger a shell command → card should say “Plan mode — only Allow once,” with session/always disabled
- [ ] Exit plan mode, trigger a shell command under approval-required → no force-prompt banner; session/always available
- [ ] Trigger a write/read of a real sensitive path (e.g. `.env`) → still force one-shot approve with sensitive/plan copy for FileWrite
- [ ] Confirm Claude/Codex plan-mode bash prompts get the same Bash copy