### PR TITLE
Stabilize chat open and release 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2]
+
+### Changed
+- Stabilize chat transcript ingestion
+
 ## [0.12.1]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/renderer/src/lib/chat-timeline-rows.ts
+++ b/apps/renderer/src/lib/chat-timeline-rows.ts
@@ -61,6 +61,70 @@ export function rowAnchorMessageId(row: ChatTimelineRow): string | null {
     : null;
 }
 
+const toolUseKey = (message: Message): string | null =>
+  message.content._tag === "tool_use"
+    ? `${message.sessionId}:${message.content.itemId}`
+    : null;
+
+const inputScore = (input: unknown): number => {
+  if (input === null || input === undefined) return 0;
+  let score = 1;
+  if (typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    if (typeof obj["file_path"] === "string") score += 4;
+    if (typeof obj["command"] === "string") score += 4;
+    if (typeof obj["old_string"] === "string") score += 3;
+    if (typeof obj["new_string"] === "string") score += 3;
+  }
+  try {
+    score += JSON.stringify(input)?.length ?? 0;
+  } catch {
+    score += String(input).length;
+  }
+  return score;
+};
+
+const preferToolUse = (current: Message, next: Message): Message => {
+  if (
+    current.content._tag !== "tool_use" ||
+    next.content._tag !== "tool_use"
+  ) {
+    return current;
+  }
+  return inputScore(next.content.input) > inputScore(current.content.input)
+    ? next
+    : current;
+};
+
+export function normalizeTimelineMessages(
+  messages: ReadonlyArray<Message>,
+): Message[] {
+  const normalized: Message[] = [];
+  const toolUseIndexByKey = new Map<string, number>();
+
+  for (const message of messages) {
+    const key = toolUseKey(message);
+    if (key === null) {
+      normalized.push(message);
+      continue;
+    }
+
+    const existingIndex = toolUseIndexByKey.get(key);
+    if (existingIndex === undefined) {
+      toolUseIndexByKey.set(key, normalized.length);
+      normalized.push(message);
+      continue;
+    }
+
+    normalized[existingIndex] = preferToolUse(
+      normalized[existingIndex]!,
+      message,
+    );
+  }
+
+  return normalized;
+}
+
 export function deriveChatTimelineRows({
   messages,
   inFlight,
@@ -70,13 +134,14 @@ export function deriveChatTimelineRows({
   readonly inFlight: boolean;
   readonly awaitingPlanApproval: boolean;
 }): ChatTimelineRow[] {
+  const normalizedMessages = normalizeTimelineMessages(messages);
   const turns: Array<{
     user: Message | null;
     body: Message[];
   }> = [];
   let current: { user: Message | null; body: Message[] } | null = null;
 
-  for (const message of messages) {
+  for (const message of normalizedMessages) {
     if (isUserMessage(message)) {
       if (current !== null) turns.push(current);
       current = { user: message, body: [] };

--- a/apps/renderer/test/chat-timeline-rows.test.ts
+++ b/apps/renderer/test/chat-timeline-rows.test.ts
@@ -4,6 +4,7 @@ import type { Message, SessionId } from "@zuse/wire";
 
 import {
   deriveChatTimelineRows,
+  normalizeTimelineMessages,
   resolveLatestUserMessageId,
   rowAnchorMessageId,
 } from "../src/lib/chat-timeline-rows.ts";
@@ -101,5 +102,54 @@ describe("chat timeline rows", () => {
     });
 
     expect(second.map((row) => row.id)).toEqual(first.map((row) => row.id));
+  });
+
+  it("collapses duplicate tool_use rows with the same provider item id", () => {
+    const messages = [
+      message("u1", { _tag: "user", text: "inspect", goal: null }),
+      message("t1", {
+        _tag: "tool_use",
+        itemId: "call-1" as never,
+        tool: "Read",
+        input: { target_file: "/repo/a.ts" },
+      }),
+      message("t2", {
+        _tag: "tool_use",
+        itemId: "call-1" as never,
+        tool: "Read",
+        input: { file_path: "/repo/a.ts", limit: 80 },
+      }),
+      message("r1", {
+        _tag: "tool_result",
+        itemId: "call-1" as never,
+        output: "body",
+        isError: false,
+      }),
+      message("a1", { _tag: "assistant", text: "done" }),
+    ];
+
+    const normalized = normalizeTimelineMessages(messages);
+    expect(
+      normalized.filter((m) => m.content._tag === "tool_use"),
+    ).toHaveLength(1);
+    expect(
+      normalized.find((m) => m.content._tag === "tool_use")?.content,
+    ).toMatchObject({
+      _tag: "tool_use",
+      input: { file_path: "/repo/a.ts", limit: 80 },
+    });
+
+    const rows = deriveChatTimelineRows({
+      messages,
+      inFlight: false,
+      awaitingPlanApproval: false,
+    });
+    const summary = rows.find((row) => row.kind === "turn-summary");
+    expect(summary?.kind).toBe("turn-summary");
+    expect(
+      summary?.kind === "turn-summary"
+        ? summary.body.filter((m) => m.content._tag === "tool_use")
+        : [],
+    ).toHaveLength(1);
   });
 });

--- a/apps/server/src/provider/drivers/acp/translate.ts
+++ b/apps/server/src/provider/drivers/acp/translate.ts
@@ -37,6 +37,32 @@ const safePreview = (v: unknown, max = 240): string => {
   }
 };
 
+const canonicalizeToolInput = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalizeToolInput);
+  if (value === null || typeof value !== "object") return value;
+
+  const input = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(input)) {
+    const canonicalKey =
+      key === "target_file" || key === "filePath" ? "file_path" : key;
+    out[canonicalKey] = canonicalizeToolInput(raw);
+  }
+
+  return Object.fromEntries(
+    Object.entries(out).sort(([a], [b]) => a.localeCompare(b)),
+  );
+};
+
+const toolInputFingerprint = (input: unknown): string =>
+  (() => {
+    try {
+      return JSON.stringify({ input: canonicalizeToolInput(input) });
+    } catch {
+      return String(input);
+    }
+  })();
+
 let itemCounter = 0;
 const nextItemId = (): AgentItemId =>
   `i_acp_${Date.now()}_${++itemCounter}` as AgentItemId;
@@ -392,7 +418,9 @@ const buildCanonicalInput = (
     const v =
       typeof src["file_path"] === "string"
         ? (src["file_path"] as string)
-        : typeof src["filePath"] === "string"
+        : typeof src["target_file"] === "string"
+          ? (src["target_file"] as string)
+          : typeof src["filePath"] === "string"
           ? (src["filePath"] as string)
           : typeof src["path"] === "string"
             ? (src["path"] as string)
@@ -1486,7 +1514,7 @@ export const createAcpTranslator = (
             u,
             input,
           );
-          const inputJson = safeStringify({ input });
+          const inputJson = toolInputFingerprint(input);
           const state = getOrInitToolState(callId);
           // Pin the canonical tool name on first sight so later update
           // frames (which omit `kind` for Cursor) still resolve to the
@@ -1576,7 +1604,7 @@ export const createAcpTranslator = (
               );
               return events;
             }
-            const inputJson = safeStringify({ input });
+            const inputJson = toolInputFingerprint(input);
             if (state.lastInputJson !== inputJson) {
               state.lastInputJson = inputJson;
               state.useEmitted = true;

--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -806,6 +806,12 @@ export const MessageStoreLive = Layer.scoped(
       `.pipe(Effect.orDie);
     }
 
+    yield* sql`
+      UPDATE sessions
+      SET status = 'idle', updated_at = ${new Date().toISOString()}
+      WHERE status IN ('running', 'booting') AND archived_at IS NULL
+    `.pipe(Effect.asVoid, Effect.orDie);
+
     /**
      * Resolve the cwd a session should run in. NULL `worktreeId` falls
      * through to the project's main checkout (handled by `provider.start`
@@ -1152,6 +1158,64 @@ export const MessageStoreLive = Layer.scoped(
 
     const agentsFor = (sessionId: SessionId) => agentsBySession.get(sessionId);
 
+    const canonicalizeToolInput = (value: unknown): unknown => {
+      if (Array.isArray(value)) return value.map(canonicalizeToolInput);
+      if (value === null || typeof value !== "object") return value;
+      const input = value as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const [key, raw] of Object.entries(input)) {
+        const canonicalKey =
+          key === "target_file" || key === "filePath" ? "file_path" : key;
+        out[canonicalKey] = canonicalizeToolInput(raw);
+      }
+      return Object.fromEntries(
+        Object.entries(out).sort(([a], [b]) => a.localeCompare(b)),
+      );
+    };
+
+    const toolUseFingerprint = (
+      content: Extract<MessageContent, { readonly _tag: "tool_use" }>,
+    ): string => {
+      try {
+        return JSON.stringify({
+          itemId: content.itemId,
+          tool: content.tool,
+          input: canonicalizeToolInput(content.input),
+          parentItemId: content.parentItemId ?? null,
+        });
+      } catch {
+        return `${content.itemId}:${content.tool}:${String(content.input)}:${content.parentItemId ?? ""}`;
+      }
+    };
+
+    const isDuplicateToolUse = (
+      sessionId: SessionId,
+      content: Extract<MessageContent, { readonly _tag: "tool_use" }>,
+    ): Effect.Effect<boolean> =>
+      Effect.gen(function* () {
+        const rows = yield* sql<{ readonly content_json: string }>`
+          SELECT content_json FROM messages
+          WHERE session_id = ${sessionId} AND kind = 'tool_use'
+          ORDER BY sequence DESC
+        `.pipe(Effect.orDie);
+        const nextFingerprint = toolUseFingerprint(content);
+        for (const row of rows) {
+          try {
+            const existing = JSON.parse(row.content_json) as MessageContent;
+            if (
+              existing._tag === "tool_use" &&
+              existing.itemId === content.itemId &&
+              toolUseFingerprint(existing) === nextFingerprint
+            ) {
+              return true;
+            }
+          } catch {
+            // Ignore malformed legacy rows; the normal schema path keeps JSON valid.
+          }
+        }
+        return false;
+      });
+
     const persistMessage = (
       sessionId: SessionId,
       content: MessageContent,
@@ -1434,6 +1498,12 @@ export const MessageStoreLive = Layer.scoped(
               }
               const content = eventToContent(event);
               if (content === null) return;
+              if (
+                content._tag === "tool_use" &&
+                (yield* isDuplicateToolUse(sessionId, content))
+              ) {
+                return;
+              }
               const persisted = yield* persistMessage(sessionId, content);
               yield* broadcastMessage(sessionId, persisted);
               yield* ndjsonAppend(sessionId, persisted);

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -1738,6 +1738,65 @@ describe("MessageStore — provider event persistence", () => {
       scriptedEvents = [];
     }
   });
+
+  it("does not persist duplicate tool_use events for equivalent tool input", async () => {
+    scriptedEvents = [
+      {
+        _tag: "ToolUse",
+        itemId: "call-read" as never,
+        tool: "Read",
+        input: { target_file: "/repo/a.ts" },
+      },
+      {
+        _tag: "ToolUse",
+        itemId: "call-read" as never,
+        tool: "Read",
+        input: { file_path: "/repo/a.ts" },
+      },
+      { _tag: "Completed", reason: "ended" },
+    ];
+    try {
+      await withRuntime(async (run) => {
+        const { initialSession } = await run(
+          Effect.flatMap(store, (s) =>
+            s.createChat({
+              projectId: PROJECT_ID,
+              providerId: "grok",
+              model: "grok-4.5",
+              initialPrompt: "read file",
+            }),
+          ),
+        );
+        const id = initialSession.id;
+
+        const findToolRows = Effect.flatMap(store, (s) =>
+          s.listMessages(id),
+        ).pipe(
+          Effect.map((msgs) =>
+            msgs.filter((m) => m.content._tag === "tool_use"),
+          ),
+          Effect.flatMap((rows) =>
+            rows.length > 0 ? Effect.succeed(rows) : Effect.fail("not yet"),
+          ),
+          Effect.retry(
+            Schedule.spaced("10 millis").pipe(
+              Schedule.intersect(Schedule.recurs(100)),
+            ),
+          ),
+        );
+
+        const toolRows = await run(findToolRows);
+        expect(toolRows).toHaveLength(1);
+        expect(toolRows[0]?.content).toMatchObject({
+          _tag: "tool_use",
+          itemId: "call-read",
+          tool: "Read",
+        });
+      });
+    } finally {
+      scriptedEvents = [];
+    }
+  });
 });
 
 describe("MessageStore cursor streaming", () => {

--- a/apps/server/test/translate.test.ts
+++ b/apps/server/test/translate.test.ts
@@ -342,6 +342,28 @@ describe("createAcpTranslator — tool_call_update dedup & re-emit", () => {
     expect(second).toEqual([]);
   });
 
+  it("dedupes equivalent file path aliases for the same tool call", () => {
+    const t = createAcpTranslator("grok");
+    const first = t.translate({
+      sessionUpdate: "tool_call",
+      kind: "read",
+      toolCallId: "read-1",
+      rawInput: { target_file: "/repo/a.ts" },
+    });
+    expect(tags(first)).toEqual(["ToolUse"]);
+    expect(only(first, "ToolUse").input).toEqual({
+      file_path: "/repo/a.ts",
+    });
+
+    const second = t.translate({
+      sessionUpdate: "tool_call_update",
+      kind: "read",
+      toolCallId: "read-1",
+      rawInput: { file_path: "/repo/a.ts" },
+    });
+    expect(second).toEqual([]);
+  });
+
   it("re-emits ToolUse when a diff first appears on an Edit update", () => {
     const t = createAcpTranslator("cursor");
     t.translate({

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.12.2",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Stabilize chat transcript ingestion"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.12.1",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- normalize duplicate tool-call transcript rows before renderer timeline rendering
- canonicalize provider tool input and skip duplicate tool-use persistence
- reset stale in-progress sessions on startup
- bump desktop release metadata to 0.12.2

## Validation
- bun test apps/renderer/test/chat-timeline-rows.test.ts
- bun test apps/server/test/translate.test.ts
- bun test apps/server/test/message-store.test.ts --test-name-pattern "duplicate tool_use|scripted AssistantMessage"
- bun run --cwd apps/renderer check-types
- bun run --cwd apps/server check-types
- bun run check-types
