### PR TITLE
Release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3]
+
+### Changed
+- Fix merge action render loop
+- Fix Jump to latest threshold and chat scroll lifecycle (#304)
+- Fix permission card mislabeling plan-mode prompts as sensitive paths (#302)
+
 ## [0.12.2]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -66,6 +66,7 @@ import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { useWorktreesStore } from "../store/worktrees.ts";
 import { Button } from "./ui/button.tsx";
+import { ErrorBoundary } from "./ui/error-boundary.tsx";
 import { toastManager } from "./ui/toast.tsx";
 import {
   Dialog,
@@ -882,6 +883,36 @@ function RunButton() {
 }
 
 export function TopBarRight() {
+  const ctx = useActiveContext();
+  const selectedChatId = useChatsStore((s) => s.selectedChatId);
+  const resetKey =
+    ctx.status === "ready"
+      ? `${ctx.folderId}:${ctx.worktreeId ?? "main"}:${selectedChatId ?? "none"}`
+      : `empty:${selectedChatId ?? "none"}`;
+
+  return (
+    <ErrorBoundary
+      resetKey={resetKey}
+      fallback={
+        <header className={`${SECTION_CLASS} justify-between px-2`}>
+          <div className={ACTION_CLASS} />
+          <div
+            className={`text-[11px] text-[var(--accent-red)] ${ACTION_CLASS}`}
+          >
+            Actions unavailable
+          </div>
+        </header>
+      }
+      onError={(error) => {
+        console.error("[top-bar] action surface crashed", error);
+      }}
+    >
+      <TopBarRightContent />
+    </ErrorBoundary>
+  );
+}
+
+function TopBarRightContent() {
   const ctx = useActiveContext();
   const folderId = ctx.status === "ready" ? ctx.folderId : null;
   const worktreeId = ctx.status === "ready" ? ctx.worktreeId : null;

--- a/apps/renderer/src/components/ui/error-boundary.tsx
+++ b/apps/renderer/src/components/ui/error-boundary.tsx
@@ -1,0 +1,44 @@
+import { Component, type ReactNode } from "react";
+
+type ErrorBoundaryProps = {
+  readonly children: ReactNode;
+  readonly fallback: ReactNode;
+  readonly resetKey?: string;
+  readonly onError?: (error: Error, info: { componentStack?: string }) => void;
+};
+
+type ErrorBoundaryState = {
+  readonly error: Error | null;
+};
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(
+    error: Error,
+    info: { componentStack?: string },
+  ): void {
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(previous: ErrorBoundaryProps): void {
+    if (
+      this.state.error !== null &&
+      previous.resetKey !== this.props.resetKey
+    ) {
+      this.setState({ error: null });
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.error !== null) return this.props.fallback;
+    return this.props.children;
+  }
+}

--- a/apps/renderer/src/store/merge-prefs.ts
+++ b/apps/renderer/src/store/merge-prefs.ts
@@ -9,6 +9,16 @@ type MergePrefsState = {
   readonly setDeleteBranch: (deleteBranch: boolean) => void;
 };
 
+const setMethod = (method: GitMergeMethod): void => {
+  const settings = useSettingsStore.getState();
+  settings.setMergePrefs({ ...settings.mergePrefs, method });
+};
+
+const setDeleteBranch = (deleteBranch: boolean): void => {
+  const settings = useSettingsStore.getState();
+  settings.setMergePrefs({ ...settings.mergePrefs, deleteBranch });
+};
+
 /**
  * Compatibility hook for the top-bar merge menu. Preferences now persist in
  * `settings.json` through `useSettingsStore`.
@@ -18,10 +28,8 @@ export function useMergePrefs<T>(selector: (state: MergePrefsState) => T): T {
     selector({
       method: settings.mergePrefs.method,
       deleteBranch: settings.mergePrefs.deleteBranch,
-      setMethod: (method) =>
-        settings.setMergePrefs({ ...settings.mergePrefs, method }),
-      setDeleteBranch: (deleteBranch) =>
-        settings.setMergePrefs({ ...settings.mergePrefs, deleteBranch }),
+      setMethod,
+      setDeleteBranch,
     }),
   );
 }

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "0.12.3",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix merge action render loop",
+          "Fix Jump to latest threshold and chat scroll lifecycle (#304)",
+          "Fix permission card mislabeling plan-mode prompts as sensitive paths (#302)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.12.2",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release Zuse v0.12.3
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.12.3 after this PR lands.