### PR TITLE
fix(plan-mode): Codex native collaborationMode + richer plan instructions

### DIFF
--- a/apps/renderer/src/lib/plan-feedback-routing.ts
+++ b/apps/renderer/src/lib/plan-feedback-routing.ts
@@ -10,9 +10,10 @@ import type {
  * Whether a provider drives plan mode through the transcript-shape heuristic
  * rather than a native `ExitPlanMode` permission request. Claude is the only
  * provider whose driver emits a real `ExitPlanMode` permission; every other
- * provider (Codex / Grok / Gemini / Cursor / opencode) emulates plan mode via
- * a developer-instructions prefix, so we infer "plan is ready" from the
- * transcript instead.
+ * provider (Codex / Grok / Gemini / Cursor / opencode) surfaces plan completion
+ * as assistant text (Codex via native collaborationMode + `<proposed_plan>`,
+ * Grok/Gemini via a developer-instructions prefix), so we infer "plan is
+ * ready" from the transcript instead.
  */
 export const providerUsesEmulatedPlanMode = (providerId: ProviderId): boolean =>
   providerId !== "claude";

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join, resolve } from "node:path";
 
 import {
   AgentSessionStartError,
+  defaultModelFor,
   resolveModelSlug,
   type AgentEvent,
   type AgentItemId,
@@ -24,7 +25,7 @@ import {
 } from "@zuse/wire";
 
 import { AttachmentService } from "../../attachment/services/attachment-service.ts";
-import { applyPlanModePrefix } from "./planMode.ts";
+import { buildCodexCollaborationMode } from "./planMode.ts";
 import { CodexAppServerClient } from "../codex-app-server-client.ts";
 import { startBrowserMcpBridge } from "./acp/browser-mcp-bridge.ts";
 import { startOrchestrationMcpBridge } from "./acp/orchestration-mcp-bridge.ts";
@@ -1272,10 +1273,10 @@ export const startCodexSession = (
       if (commandHandled) return;
 
       emit({ _tag: "Status", status: "running" });
-      // Plan-mode emulation: Codex has no native "plan" runtime mode, so
-      // prepend a developer-instructions block while plan mode is active.
-      // The sandbox policy still gates writes, so this is belt-and-braces.
-      const basePromptText = applyPlanModePrefix(currentMode, text);
+      // Plan mode is a native Codex collaboration mode. Pass it on every
+      // turn/start so toggles actually stick (omitting the field leaves the
+      // previous collaboration mode active on the Codex side). Sandbox
+      // policy still gates writes as belt-and-braces.
       const promptHints = [
         ...(browserHintPending ? [browserMcpPromptHint()] : []),
         ...(orchestrationHintPending && orchestrationTools !== null
@@ -1284,8 +1285,8 @@ export const startCodexSession = (
       ];
       const promptText =
         promptHints.length > 0
-          ? `${promptHints.join("\n\n")}\n\n${basePromptText}`
-          : basePromptText;
+          ? `${promptHints.join("\n\n")}\n\n${text}`
+          : text;
       browserHintPending = false;
       orchestrationHintPending = false;
       // Reasoning effort: forwarded from FE picker via
@@ -1312,6 +1313,11 @@ export const startCodexSession = (
           text: "Fast mode isn't available for this model — running at the standard tier.",
         });
       }
+      const collaborationMode = buildCodexCollaborationMode({
+        permissionMode: currentMode,
+        model: input.model ?? defaultModelFor("codex"),
+        effort,
+      });
       const turn = await app.request<{ turn: { id: string } }>("turn/start", {
         threadId: activeThreadId,
         input: [
@@ -1326,6 +1332,7 @@ export const startCodexSession = (
         approvalPolicy: codexApprovalPolicy(getRuntimeMode(), currentMode),
         sandboxPolicy: toSandboxPolicy(getRuntimeMode(), currentMode, cwd),
         model: input.model ?? null,
+        collaborationMode,
         ...(effort !== null ? { effort } : {}),
         ...(fastMode ? { serviceTier: "fast" } : {}),
       });
@@ -1512,6 +1519,10 @@ export const startCodexSession = (
             cwd,
             approvalPolicy: codexApprovalPolicy(getRuntimeMode(), currentMode),
             sandboxPolicy: toSandboxPolicy(getRuntimeMode(), currentMode, cwd),
+            collaborationMode: buildCodexCollaborationMode({
+              permissionMode: currentMode,
+              model: input.model ?? defaultModelFor("codex"),
+            }),
           });
           return true;
         case "ps":

--- a/apps/server/src/provider/drivers/grok.ts
+++ b/apps/server/src/provider/drivers/grok.ts
@@ -1331,8 +1331,10 @@ export const startGrokSession = (
           startCompactEvent({ providerId: "grok", snapshot: compactSnapshot }),
         );
       }
-      // Plan-mode emulation: grok ACP has no native read-only switch, so
-      // prepend a developer-instructions block while plan mode is active.
+      // Plan-mode emulation: Grok ACP has no session-level plan switch, so
+      // prepend the rich plan-mode developer-instructions block (including
+      // `<proposed_plan>` finalization) while plan mode is active. Mutating
+      // tools still go through permission policy as the hard gate.
       const promptText =
         compactSnapshot !== null
           ? text.trim()

--- a/apps/server/src/provider/drivers/planMode.ts
+++ b/apps/server/src/provider/drivers/planMode.ts
@@ -1,27 +1,251 @@
 import type { PermissionMode } from "@zuse/wire";
 
+import type { CollaborationMode } from "../codex-app-protocol/CollaborationMode.ts";
+import type { ModeKind } from "../codex-app-protocol/ModeKind.ts";
+import type { ReasoningEffort } from "../codex-app-protocol/ReasoningEffort.ts";
+
 /**
- * Developer-instructions prefix that emulates plan mode for providers that
- * don't have a native equivalent. The Claude Agent SDK has `permissionMode:
- * "plan"`, Cursor's ACP has `setSessionMode("plan")`, but Codex/Grok/Gemini
- * don't expose a runtime read-only switch — so we prepend this block to the
- * user's prompt while plan mode is active.
+ * Plan-mode developer instructions for providers that lack a native
+ * collaboration / plan switch (Grok, Gemini, and any future emulated
+ * providers). Prepended to the user prompt while `permissionMode === "plan"`.
  *
- * The model is still free to ignore it, which is why we ALSO keep
- * `RuntimeMode: "approval-required"` as the safety net for any tool call
- * that wants to mutate state.
+ * Codex uses {@link CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS} via native
+ * `turn/start.collaborationMode` instead of this prefix.
+ *
+ * The model is still free to ignore soft instructions, which is why we ALSO
+ * keep permission / sandbox gates as the safety net for mutating tools.
  */
-export const PLAN_MODE_INSTRUCTIONS =
-  "PLAN MODE — you are in read-only planning mode. Investigate the " +
-  "codebase, ask clarifying questions if needed, then propose a concrete " +
-  "plan. DO NOT modify files, run mutating commands, or invoke any tool " +
-  "that writes to disk or the network. When you have a complete plan, " +
-  "present it for approval and wait for the user to confirm before " +
-  "exiting plan mode.";
+export const PLAN_MODE_INSTRUCTIONS = `<plan_mode>
+# Plan Mode
+
+You are in **Plan Mode** until the product explicitly ends it.
+
+Plan Mode is not changed by user intent, tone, or imperative language. If a user asks for execution while still in Plan Mode, treat it as a request to **plan the execution**, not perform it.
+
+You work in 3 phases, and you should *chat your way* to a great plan before finalizing it. A great plan is very detailed — intent- and implementation-wise — so that it can be handed to another engineer or agent to implement right away. It must be **decision complete**, where the implementer does not need to make any decisions.
+
+## Execution vs. mutation in Plan Mode
+
+You may explore and execute **non-mutating** actions that improve the plan. You must not perform **mutating** actions.
+
+### Allowed (non-mutating, plan-improving)
+
+* Reading or searching files, configs, schemas, types, manifests, and docs
+* Static analysis, inspection, and repo exploration
+* Dry-run style commands when they do not edit repo-tracked files
+* Tests, builds, or checks that may write to caches or build artifacts so long as they do not edit repo-tracked files
+
+### Not allowed (mutating, plan-executing)
+
+* Editing or writing files
+* Running formatters or linters that rewrite files
+* Applying patches, migrations, or codegen that updates repo-tracked files
+* Side-effectful commands whose purpose is to carry out the plan rather than refine it
+
+When in doubt: if the action would reasonably be described as "doing the work" rather than "planning the work," do not do it.
+
+## PHASE 1 — Ground in the environment (explore first, ask second)
+
+Begin by grounding yourself in the actual environment. Eliminate unknowns by discovering facts, not by asking the user. Resolve questions that can be answered through exploration. Silent exploration between turns is allowed and encouraged.
+
+Before asking the user any question, perform at least one targeted non-mutating exploration pass unless no local environment/repo is available.
+
+## PHASE 2 — Intent chat (what they actually want)
+
+Keep asking until you can clearly state: goal + success criteria, audience, in/out of scope, constraints, current state, and the key preferences/tradeoffs. Bias toward questions over guessing for high-impact ambiguity.
+
+## PHASE 3 — Implementation chat (what/how we'll build)
+
+Once intent is stable, keep refining until the spec is decision complete: approach, interfaces (APIs/schemas/I/O), data flow, edge cases/failure modes, testing + acceptance criteria, rollout/monitoring, and any migrations/compat constraints.
+
+## Asking questions
+
+Prefer structured multiple-choice questions when the product exposes a question tool. Each question must materially change the plan, confirm an important assumption, or choose between meaningful tradeoffs — and must not be answerable by non-mutating exploration.
+
+## Finalization rule
+
+Only output the final plan when it is decision complete and leaves no decisions to the implementer.
+
+When you present the official plan, wrap it in a \`<proposed_plan>\` block so the client can render it specially:
+
+1) The opening tag must be on its own line.
+2) Start the plan content on the next line (no text on the same line as the tag).
+3) The closing tag must be on its own line.
+4) Use Markdown inside the block.
+5) Keep the tags exactly as \`<proposed_plan>\` and \`</proposed_plan>\`.
+
+Example:
+
+<proposed_plan>
+plan content
+</proposed_plan>
+
+The final plan must be plan-only and include:
+
+* A clear title
+* A brief summary section
+* Important changes or additions to public APIs/interfaces/types
+* Test cases and scenarios
+* Explicit assumptions and defaults chosen where needed
+
+Do not ask "should I proceed?" in the final output. The user can switch out of Plan mode and request implementation after a \`<proposed_plan>\` block, or stay in Plan mode and continue refining.
+
+Only produce at most one \`<proposed_plan>\` block per turn, and only when you are presenting a complete spec.
+</plan_mode>`;
+
+/**
+ * Codex native plan collaboration-mode developer instructions. Sent as
+ * `turn/start.collaborationMode.settings.developer_instructions` while the
+ * session is in plan mode. Codex treats this as a first-class mode switch
+ * (not a user-message prefix), including blocking `update_plan` while plan
+ * mode is active.
+ */
+export const CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Plan Mode (Conversational)
+
+You work in 3 phases, and you should *chat your way* to a great plan before finalizing it. A great plan is very detailed — intent- and implementation-wise — so that it can be handed to another engineer or agent to be implemented right away. It must be **decision complete**, where the implementer does not need to make any decisions.
+
+## Mode rules (strict)
+
+You are in **Plan Mode** until a developer message explicitly ends it.
+
+Plan Mode is not changed by user intent, tone, or imperative language. If a user asks for execution while still in Plan Mode, treat it as a request to **plan the execution**, not perform it.
+
+## Plan Mode vs update_plan tool
+
+Plan Mode is a collaboration mode that can involve requesting user input and eventually issuing a \`<proposed_plan>\` block.
+
+Separately, \`update_plan\` is a checklist/progress/TODOs tool; it does not enter or exit Plan Mode. Do not confuse it with Plan mode or try to use it while in Plan mode. If you try to use \`update_plan\` in Plan mode, it will return an error.
+
+## Execution vs. mutation in Plan Mode
+
+You may explore and execute **non-mutating** actions that improve the plan. You must not perform **mutating** actions.
+
+### Allowed (non-mutating, plan-improving)
+
+Actions that gather truth, reduce ambiguity, or validate feasibility without changing repo-tracked state. Examples:
+
+* Reading or searching files, configs, schemas, types, manifests, and docs
+* Static analysis, inspection, and repo exploration
+* Dry-run style commands when they do not edit repo-tracked files
+* Tests, builds, or checks that may write to caches or build artifacts (for example, \`target/\`, \`.cache/\`, or snapshots) so long as they do not edit repo-tracked files
+
+### Not allowed (mutating, plan-executing)
+
+Actions that implement the plan or change repo-tracked state. Examples:
+
+* Editing or writing files
+* Running formatters or linters that rewrite files
+* Applying patches, migrations, or codegen that updates repo-tracked files
+* Side-effectful commands whose purpose is to carry out the plan rather than refine it
+
+When in doubt: if the action would reasonably be described as "doing the work" rather than "planning the work," do not do it.
+
+## PHASE 1 - Ground in the environment (explore first, ask second)
+
+Begin by grounding yourself in the actual environment. Eliminate unknowns in the prompt by discovering facts, not by asking the user. Resolve all questions that can be answered through exploration or inspection. Identify missing or ambiguous details only if they cannot be derived from the environment. Silent exploration between turns is allowed and encouraged.
+
+Before asking the user any question, perform at least one targeted non-mutating exploration pass (for example: search relevant files, inspect likely entrypoints/configs, confirm current implementation shape), unless no local environment/repo is available.
+
+Exception: you may ask clarifying questions about the user's prompt before exploring, ONLY if there are obvious ambiguities or contradictions in the prompt itself. However, if ambiguity might be resolved by exploring, always prefer exploring first.
+
+Do not ask questions that can be answered from the repo or system (for example, "where is this struct?" or "which UI component should we use?" when exploration can make it clear). Only ask once you have exhausted reasonable non-mutating exploration.
+
+## PHASE 2 - Intent chat (what they actually want)
+
+* Keep asking until you can clearly state: goal + success criteria, audience, in/out of scope, constraints, current state, and the key preferences/tradeoffs.
+* Bias toward questions over guessing: if any high-impact ambiguity remains, do NOT plan yet — ask.
+
+## PHASE 3 - Implementation chat (what/how we'll build)
+
+* Once intent is stable, keep asking until the spec is decision complete: approach, interfaces (APIs/schemas/I/O), data flow, edge cases/failure modes, testing + acceptance criteria, rollout/monitoring, and any migrations/compat constraints.
+
+## Asking questions
+
+Critical rules:
+
+* Strongly prefer using the \`request_user_input\` tool to ask any questions.
+* Offer only meaningful multiple-choice options; don't include filler choices that are obviously wrong or irrelevant.
+* In rare cases where an unavoidable, important question can't be expressed with reasonable multiple-choice options (due to extreme ambiguity), you may ask it directly without the tool.
+
+You SHOULD ask many questions, but each question must:
+
+* materially change the spec/plan, OR
+* confirm/lock an assumption, OR
+* choose between meaningful tradeoffs.
+* not be answerable by non-mutating commands.
+
+Use the \`request_user_input\` tool only for decisions that materially change the plan, for confirming important assumptions, or for information that cannot be discovered via non-mutating exploration.
+
+## Two kinds of unknowns (treat differently)
+
+1. **Discoverable facts** (repo/system truth): explore first.
+
+   * Before asking, run targeted searches and check likely sources of truth (configs/manifests/entrypoints/schemas/types/constants).
+   * Ask only if: multiple plausible candidates; nothing found but you need a missing identifier/context; or ambiguity is actually product intent.
+   * If asking, present concrete candidates (paths/service names) + recommend one.
+   * Never ask questions you can answer from your environment (e.g., "where is this struct").
+
+2. **Preferences/tradeoffs** (not discoverable): ask early.
+
+   * These are intent or implementation preferences that cannot be derived from exploration.
+   * Provide 2-4 mutually exclusive options + a recommended default.
+   * If unanswered, proceed with the recommended option and record it as an assumption in the final plan.
+
+## Finalization rule
+
+Only output the final plan when it is decision complete and leaves no decisions to the implementer.
+
+When you present the official plan, wrap it in a \`<proposed_plan>\` block so the client can render it specially:
+
+1) The opening tag must be on its own line.
+2) Start the plan content on the next line (no text on the same line as the tag).
+3) The closing tag must be on its own line.
+4) Use Markdown inside the block.
+5) Keep the tags exactly as \`<proposed_plan>\` and \`</proposed_plan>\` (do not translate or rename them), even if the plan content is in another language.
+
+Example:
+
+<proposed_plan>
+plan content
+</proposed_plan>
+
+plan content should be human and agent digestible. The final plan must be plan-only and include:
+
+* A clear title
+* A brief summary section
+* Important changes or additions to public APIs/interfaces/types
+* Test cases and scenarios
+* Explicit assumptions and defaults chosen where needed
+
+Do not ask "should I proceed?" in the final output. The user can easily switch out of Plan mode and request implementation if you have included a \`<proposed_plan>\` block in your response. Alternatively, they can decide to stay in Plan mode and continue refining the plan.
+
+Only produce at most one \`<proposed_plan>\` block per turn, and only when you are presenting a complete spec.
+</collaboration_mode>`;
+
+/**
+ * Codex native default collaboration-mode developer instructions. Sent when
+ * the session leaves plan mode so Codex clears the previous collaboration
+ * mode rather than leaving plan rules active.
+ */
+export const CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Collaboration Mode: Default
+
+You are now in Default mode. Any previous instructions for other modes (e.g. Plan mode) are no longer active.
+
+Your active mode changes only when new developer instructions with a different \`<collaboration_mode>...</collaboration_mode>\` change it; user requests or tool descriptions do not change mode by themselves. Known mode names are Default and Plan.
+
+## request_user_input availability
+
+The \`request_user_input\` tool is unavailable in Default mode. If you call it while in Default mode, it will return an error.
+
+In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
+</collaboration_mode>`;
 
 /**
  * Wrap a user-supplied prompt with the plan-mode developer-instructions
  * prefix iff plan mode is active. No-op for `default` / `acceptEdits`.
+ *
+ * Used by providers that cannot express plan mode natively (Grok / Gemini).
+ * Codex should use {@link buildCodexCollaborationMode} instead.
  */
 export const applyPlanModePrefix = (
   permissionMode: PermissionMode,
@@ -30,3 +254,31 @@ export const applyPlanModePrefix = (
   permissionMode === "plan"
     ? `${PLAN_MODE_INSTRUCTIONS}\n\n---\n\n${text}`
     : text;
+
+const permissionModeToCollaborationModeKind = (
+  permissionMode: PermissionMode,
+): ModeKind => (permissionMode === "plan" ? "plan" : "default");
+
+/**
+ * Build Codex `turn/start.collaborationMode`. Always returns a value so a
+ * live toggle from plan → default actually ends plan mode on the Codex side
+ * (omitting the field leaves the previous collaboration mode sticky).
+ */
+export const buildCodexCollaborationMode = (input: {
+  readonly permissionMode: PermissionMode;
+  readonly model: string;
+  readonly effort?: ReasoningEffort | null;
+}): CollaborationMode => {
+  const mode = permissionModeToCollaborationModeKind(input.permissionMode);
+  return {
+    mode,
+    settings: {
+      model: input.model,
+      reasoning_effort: input.effort ?? "medium",
+      developer_instructions:
+        mode === "plan"
+          ? CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS
+          : CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
+    },
+  };
+};

--- a/apps/server/test/planMode.test.ts
+++ b/apps/server/test/planMode.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "bun:test";
 
 import type { PermissionMode } from "@zuse/wire";
 
-import { applyPlanModePrefix, PLAN_MODE_INSTRUCTIONS } from "../src/provider/drivers/planMode.ts";
+import {
+  applyPlanModePrefix,
+  buildCodexCollaborationMode,
+  CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
+  CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
+  PLAN_MODE_INSTRUCTIONS,
+} from "../src/provider/drivers/planMode.ts";
 
 describe("applyPlanModePrefix", () => {
   it("prepends the plan-mode instructions when plan mode is active", () => {
@@ -23,6 +29,76 @@ describe("applyPlanModePrefix", () => {
     expect(applyPlanModePrefix("default", "")).toBe("");
     expect(applyPlanModePrefix("plan", "")).toBe(
       `${PLAN_MODE_INSTRUCTIONS}\n\n---\n\n`,
+    );
+  });
+
+  it("asks emulated providers for a proposed_plan block", () => {
+    expect(PLAN_MODE_INSTRUCTIONS).toContain("<proposed_plan>");
+    expect(PLAN_MODE_INSTRUCTIONS).toContain("</proposed_plan>");
+    expect(PLAN_MODE_INSTRUCTIONS).toContain("Plan Mode");
+  });
+});
+
+describe("buildCodexCollaborationMode", () => {
+  it("builds plan collaboration mode with codex plan developer instructions", () => {
+    expect(
+      buildCodexCollaborationMode({
+        permissionMode: "plan",
+        model: "gpt-5.5",
+        effort: "medium",
+      }),
+    ).toEqual({
+      mode: "plan",
+      settings: {
+        model: "gpt-5.5",
+        reasoning_effort: "medium",
+        developer_instructions: CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
+      },
+    });
+  });
+
+  it("builds default collaboration mode when leaving plan mode", () => {
+    expect(
+      buildCodexCollaborationMode({
+        permissionMode: "default",
+        model: "gpt-5.5",
+      }),
+    ).toEqual({
+      mode: "default",
+      settings: {
+        model: "gpt-5.5",
+        reasoning_effort: "medium",
+        developer_instructions: CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
+      },
+    });
+  });
+
+  it("maps acceptEdits onto default collaboration mode", () => {
+    const mode = buildCodexCollaborationMode({
+      permissionMode: "acceptEdits",
+      model: "gpt-5.3-codex",
+      effort: "high",
+    });
+    expect(mode.mode).toBe("default");
+    expect(mode.settings.reasoning_effort).toBe("high");
+    expect(mode.settings.developer_instructions).toBe(
+      CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
+    );
+  });
+
+  it("keeps codex plan instructions decision-complete and proposed_plan tagged", () => {
+    expect(CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS).toContain(
+      "<collaboration_mode>",
+    );
+    expect(CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS).toContain(
+      "<proposed_plan>",
+    );
+    expect(CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS).toContain("update_plan");
+    expect(CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS).toContain(
+      "request_user_input",
+    );
+    expect(CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS).toContain(
+      "Default mode",
     );
   });
 });

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -739,9 +739,10 @@ export type StartSessionInput = typeof StartSessionInput.Type;
  *   - `optionDescriptors`: per-model knobs the composer renders (reasoning,
  *     etc.). Omitting the descriptor hides the control.
  *   - `supportsPlanMode`: whether the plan-mode toggle is shown for this
- *     model. `true` for every model today (native for Claude/Cursor,
- *     emulated via dev-instructions prefix for Codex/Grok/Gemini); set
- *     `false` only when there's a hard reason not to allow planning.
+ *     model. `true` for every model today (native for Claude/Cursor/Codex
+ *     collaborationMode; emulated via dev-instructions prefix for
+ *     Grok/Gemini); set `false` only when there's a hard reason not to
+ *     allow planning.
  *   - `supportsWebSearch`: `"native"` (driver emits real results),
  *     `"queryOnly"` (driver emits the query but no results), or omitted
  *     (provider doesn't search).


### PR DESCRIPTION
## Summary
- Switch Codex plan mode from a soft developer-instructions prefix to native `turn/start.collaborationMode`, and send it on every turn (and resume) so plan → default toggles actually clear on the Codex side.
- Expand emulated plan-mode instructions for Grok/Gemini with a full conversational planning protocol, including decision-complete specs and `<proposed_plan>` finalization.
- Add `buildCodexCollaborationMode` helpers + unit coverage; update wire/renderer comments to match native Codex vs emulated providers.

## Test plan
- [ ] Unit: `bun test apps/server/test/planMode.test.ts`
- [ ] Codex: enter plan mode, confirm collaborationMode is plan; ask for a plan and get a `<proposed_plan>`-style result without file writes
- [ ] Codex: leave plan mode mid-session and confirm subsequent turns run in default collaboration mode (writes allowed under normal permissions)
- [ ] Grok/Gemini: plan mode still prefixes rich instructions and still gates mutations via permissions
- [ ] Claude: plan mode path unchanged (native ExitPlanMode)