### PR TITLE
Fix chat scroll anchoring

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -170,7 +170,6 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   const [timelineAnchorMessageId, setTimelineAnchorMessageId] = useState<
     string | null
   >(null);
-  // Mirror for sync reads in free-scroll cancel / wheel handlers.
   const timelineAnchorMessageIdRef = useRef<string | null>(null);
   timelineAnchorMessageIdRef.current = timelineAnchorMessageId;
   const anchoredEndSpace = useMemo(
@@ -226,13 +225,16 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   }, []);
 
   const showJumpPillIfScrollNodeLeftEnd = useCallback(() => {
-    const scrollNode = listRef.current?.getScrollableNode();
-    const isAtEnd = resolveScrollableNodeIsAtEnd(scrollNode);
+    const list = listRef.current;
+    const stateAtEnd = resolveTimelineIsAtEnd(list?.getState());
+    const nodeAtEnd = resolveScrollableNodeIsAtEnd(list?.getScrollableNode());
+    const isAtEnd = stateAtEnd ?? nodeAtEnd;
     if (isAtEnd === false) {
       isAtEndRef.current = false;
       showJumpPillSoon();
     } else if (isAtEnd === true) {
       isAtEndRef.current = true;
+      liveFollowGenerationRef.current = userNavigationGenerationRef.current;
       hideJumpPill();
     }
   }, [hideJumpPill, showJumpPillSoon]);
@@ -241,33 +243,18 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
   // pill once the scroll node is meaningfully away from the live edge.
   // Never force-show on wheel/touch alone — tiny trackpad ticks used to
   // flash the pill even while still near the bottom.
-  // Keep the turn anchor + positioned/settled markers: clearing the anchor
-  // re-enables maintainScrollAtEnd and yanks to the live edge mid-stream;
-  // clearing positioned lets handleAnchorReady re-run scrollToIndex and
-  // pin the user prompt again while free-scrolling.
   const cancelTimelineLiveFollowForUserNavigation = useCallback(() => {
     userNavigationGenerationRef.current += 1;
     timelineScrollModeRef.current = "free-scrolling";
     liveFollowGenerationRef.current = null;
     pendingTimelineAnchorRef.current = null;
+    positionedTimelineAnchorRef.current = null;
+    settledTimelineAnchorRef.current = null;
+    activeTimelineAnchorIndexRef.current = null;
     pendingAnchorScrollRestoreRef.current = null;
     if (anchorScrollRestoreFrameRef.current !== null) {
       cancelAnimationFrame(anchorScrollRestoreFrameRef.current);
       anchorScrollRestoreFrameRef.current = null;
-    }
-
-    // Lock markers so late ready/size callbacks no-op instead of re-pinning.
-    const anchorId = timelineAnchorMessageIdRef.current;
-    if (anchorId !== null) {
-      positionedTimelineAnchorRef.current = anchorId;
-      settledTimelineAnchorRef.current = anchorId;
-    }
-
-    // Interrupt any in-flight animated scrollToIndex from turn anchoring.
-    const list = listRef.current;
-    const offset = list?.getState().scroll;
-    if (list !== null && list !== undefined && typeof offset === "number") {
-      void list.scrollToOffset({ offset, animated: false });
     }
 
     requestAnimationFrame(showJumpPillIfScrollNodeLeftEnd);
@@ -280,9 +267,6 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       liveFollowGenerationRef.current = userNavigationGenerationRef.current;
       pendingTimelineAnchorRef.current = null;
       activeTimelineAnchorIndexRef.current = null;
-      // Keep the turn anchor + positioned/settled markers so Jump to latest
-      // does not re-run scrollToIndex back to the user prompt, and so
-      // maintainScrollAtEnd stays off for the rest of the session.
       pendingAnchorScrollRestoreRef.current = null;
       if (anchorScrollRestoreFrameRef.current !== null) {
         cancelAnimationFrame(anchorScrollRestoreFrameRef.current);
@@ -290,7 +274,18 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       }
       lastAnchoredUserMessageIdRef.current = latestUserMessageIdRef.current;
       hideJumpPill();
-      void listRef.current?.scrollToEnd({ animated });
+      const scrollUntilSettled = (remainingAttempts: number) => {
+        const list = listRef.current;
+        if (!list) return;
+
+        void list.scrollToEnd({ animated: remainingAttempts === 8 && animated });
+
+        if (remainingAttempts <= 0) return;
+        requestAnimationFrame(() => {
+          scrollUntilSettled(remainingAttempts - 1);
+        });
+      };
+      scrollUntilSettled(8);
     },
     [hideJumpPill],
   );
@@ -360,12 +355,12 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       ) {
         return;
       }
-      // User already free-scrolled away — lock markers without re-pinning.
       if (timelineScrollModeRef.current === "free-scrolling") {
         positionedTimelineAnchorRef.current = timelineAnchorMessageId;
         settledTimelineAnchorRef.current = timelineAnchorMessageId;
         return;
       }
+
       positionedTimelineAnchorRef.current = timelineAnchorMessageId;
       settledTimelineAnchorRef.current = null;
       const messageId = timelineAnchorMessageId;
@@ -423,8 +418,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     [timelineAnchorMessageId],
   );
 
-  const handleAnchorSizeChanged = useCallback((size: number) => {
-    void size;
+  const handleAnchorSizeChanged = useCallback(() => {
     const messageId = timelineAnchorMessageId;
     if (
       messageId === null ||
@@ -474,9 +468,9 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
 
   const handleScroll = useCallback(() => {
     const list = listRef.current;
-    const nodeAtEnd = resolveScrollableNodeIsAtEnd(list?.getScrollableNode());
     const stateAtEnd = resolveTimelineIsAtEnd(list?.getState());
-    const isAtEnd = nodeAtEnd ?? stateAtEnd;
+    const nodeAtEnd = resolveScrollableNodeIsAtEnd(list?.getScrollableNode());
+    const isAtEnd = stateAtEnd ?? nodeAtEnd;
     if (isAtEnd === undefined) return;
 
     if (
@@ -528,9 +522,8 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     }
   }, [sessionId, rows.length]);
 
-  // Session switch: always land at the live edge. Seed lastAnchored to the
-  // current latest user message so reopening an in-flight chat does not look
-  // like a brand-new send and re-pin the prompt to the top of the viewport.
+  // Session switch: always land at the live edge. The list remounts with
+  // initialScrollAtEnd; the extra frame handles hydration/layout races.
   useEffect(() => {
     timelineScrollModeRef.current = "following-end";
     activeTimelineAnchorIndexRef.current = null;
@@ -609,18 +602,12 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
     };
   }, [cancelTimelineLiveFollowForUserNavigation, sessionId]);
 
-  // Anchor only when a *new* user message appears while this session is
-  // already open. Session switch seeds lastAnchored so reopening never
-  // re-triggers this path for an existing prompt.
   useEffect(() => {
     if (latestUserMessageId === null) return;
     const previousLatestUserMessageId = lastAnchoredUserMessageIdRef.current;
     if (previousLatestUserMessageId === latestUserMessageId) return;
 
     lastAnchoredUserMessageIdRef.current = latestUserMessageId;
-    // Hydrating an idle transcript into an empty seed must not pin the
-    // historical user message. A real first send sets inFlight around the
-    // optimistic row and still anchors.
     if (previousLatestUserMessageId === null && !inFlight) return;
 
     timelineScrollModeRef.current = "anchoring-new-turn";
@@ -666,7 +653,8 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
           const metrics = getActiveTimelineTurnMetrics(list);
           if (!metrics || metrics.scrollDeltaToRevealEnd <= 1) return;
 
-          const nextOffset = list.getState().scroll + metrics.scrollDeltaToRevealEnd;
+          const nextOffset =
+            list.getState().scroll + metrics.scrollDeltaToRevealEnd;
           void list.scrollToOffset({ offset: nextOffset, animated: false });
           return;
         }

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -4,8 +4,8 @@ import { ArrowDown01Icon } from "@hugeicons-pro/core-bulk-rounded";
 import { cn } from "~/lib/utils";
 
 /**
- * Floating "Jump to latest" affordance, pinned above the composer in the
- * center of the chat pane. Appears once the reader has scrolled away from the live edge
+ * Floating "Jump to latest" affordance, pinned above the composer at the
+ * lower-left of the chat column. Appears once the reader has scrolled away from the live edge
  * (principle 9); while a response is still streaming out of view it shows a
  * pulsing activity dot (principle 8). Fades/slides in with a CSS transition
  * that respects `prefers-reduced-motion`.
@@ -24,32 +24,33 @@ export function JumpToLatestPill({
   return (
     <div
       className={cn(
-        "pointer-events-none absolute bottom-4 left-1/2 z-50 flex -translate-x-1/2 opacity-100",
-        "transition-all duration-150 ease-out motion-reduce:transition-none",
+        "pointer-events-none absolute inset-x-0 bottom-4 z-50",
+        "animate-in fade-in slide-in-from-bottom-1 duration-150 motion-reduce:animate-none",
       )}
     >
-      <button
-        type="button"
-        onClick={onClick}
-        aria-label="Jump to latest"
-        className={cn(
-          "pointer-events-auto inline-flex items-center gap-1.5 rounded-full",
-          "border border-border/60 bg-popover/95 px-3 py-1.5 text-xs text-muted-foreground",
-          "backdrop-blur dark:shadow-[0_2px_8px_color-mix(in_oklch,black_28%,transparent)]",
-          "hover:text-foreground hover:bg-popover",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        )}
-      >
-        {streaming ? (
-          <span
-            className="size-1.5 rounded-full bg-current motion-safe:animate-pulse"
-            aria-hidden
-          />
-        ) : (
-          <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5" />
-        )}
-        <span>Jump to latest</span>
-      </button>
+      <div className="mx-auto flex w-full max-w-4xl justify-start px-3">
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label="Jump to latest"
+          className={cn(
+            "pointer-events-auto inline-flex items-center gap-1.5 rounded-md",
+            "border border-border/60 bg-card px-3 py-1 text-xs text-muted-foreground shadow-sm",
+            "transition-colors hover:border-border hover:bg-card hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          {streaming ? (
+            <span
+              className="size-1.5 rounded-full bg-current motion-safe:animate-pulse"
+              aria-hidden
+            />
+          ) : (
+            <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5" />
+          )}
+          <span>Jump to latest</span>
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep the active turn anchor available so sent messages can sit near the top with trailing space
- clear stale anchor measurement state on manual navigation so scrolling is not pulled back unexpectedly
- make Jump to latest retry across animation frames while virtual rows settle
- align the Jump to latest control with the chat column and reduce its radius

## Validation
- bun run --cwd apps/renderer check-types