### PR TITLE
[codex] Fix landing composer attachments

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -92,6 +92,10 @@ import {
   matchBuiltin,
   type BuiltinCommand,
 } from "../composer/builtin-commands.ts";
+import type {
+  PendingDraftAttachment,
+  PendingDraftContextFile,
+} from "../composer/draft-attachments.ts";
 import { parseComposerInput } from "../composer/segment-parser.ts";
 import { AnnotationTray } from "./composer/annotation-tray.tsx";
 import { ComposerChipOverlay } from "./composer/composer-chip-overlay.tsx";
@@ -127,6 +131,7 @@ import { useOpencodeInventory } from "../store/opencode-inventory.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSettingsStore } from "../store/settings.ts";
 import { usePermissionsStore } from "../store/permissions.ts";
+import { useSkillsStore } from "../store/skills.ts";
 
 const isBrowserAnnotation = (
   annotation: ComposerAnnotation,
@@ -183,7 +188,14 @@ export function ChatComposer({
    * model/runtime/permission/provider toggles still work — their store setters
    * route to the draft slot — so the user's picks carry into `create()`.
    */
-  onDraftSubmit?: (input: ComposerInput, opts: { asGoal: boolean }) => void;
+  onDraftSubmit?: (
+    input: ComposerInput,
+    opts: {
+      readonly asGoal: boolean;
+      readonly pendingAttachments: ReadonlyArray<PendingDraftAttachment>;
+      readonly pendingContextFiles: ReadonlyArray<PendingDraftContextFile>;
+    },
+  ) => void;
 }) {
   const sessionId: SessionId = session.id;
   const draftKey = composerDraftKey ?? composerDraftKeyForSession(sessionId);
@@ -383,6 +395,9 @@ export function ChatComposer({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
   const uploadOne = useAttachmentsStore((s) => s.uploadOne);
+  const hydrateDraftSkills = useSkillsStore((s) => s.hydrateForDraft);
+  const pendingDraftAttachmentsRef = useRef<PendingDraftAttachment[]>([]);
+  const pendingDraftContextFilesRef = useRef<PendingDraftContextFile[]>([]);
   // Submit reads through a ref so the keymap, captured at editor creation
   // time, always sees the current sessionId / send / inFlight without
   // recreating the editor on every render.
@@ -410,6 +425,17 @@ export function ChatComposer({
   const annotationCount = useAnnotationsStore(
     (s) => (s.bySession[sessionId] ?? []).length,
   );
+
+  useEffect(() => {
+    if (!isDraft) return;
+    void hydrateDraftSkills(sessionId, session.projectId, session.providerId);
+  }, [
+    hydrateDraftSkills,
+    isDraft,
+    sessionId,
+    session.projectId,
+    session.providerId,
+  ]);
 
   // Stacked annotations are a valid message on their own, so they enable Send
   // even with an empty text box.
@@ -504,6 +530,11 @@ export function ChatComposer({
       b.setInsertText(null);
       b.setFocus(null);
       usePaneFocus.getState().unregister("composer");
+      for (const pending of pendingDraftAttachmentsRef.current) {
+        if (pending.previewUrl) URL.revokeObjectURL(pending.previewUrl);
+      }
+      pendingDraftAttachmentsRef.current = [];
+      pendingDraftContextFilesRef.current = [];
       view.destroy();
       editorViewRef.current = null;
     };
@@ -524,11 +555,21 @@ export function ChatComposer({
     view.focus();
   }, [session.providerId, session.model]);
 
-  const clearComposer = (view: EditorView): void => {
+  const clearComposer = (
+    view: EditorView,
+    opts?: { readonly clearPendingAttachments?: boolean },
+  ): void => {
     setComposerDoc(view, "");
     view.dispatch({ effects: clearChipsEffect.of() });
     setHasText(false);
     setTrigger(null);
+    if (opts?.clearPendingAttachments !== false) {
+      for (const pending of pendingDraftAttachmentsRef.current) {
+        if (pending.previewUrl) URL.revokeObjectURL(pending.previewUrl);
+      }
+      pendingDraftAttachmentsRef.current = [];
+      pendingDraftContextFilesRef.current = [];
+    }
   };
 
   const dispatchBuiltin = (parsed: {
@@ -642,6 +683,14 @@ export function ChatComposer({
         }),
       });
 
+      if (isDraft) {
+        pendingDraftAttachmentsRef.current = [
+          ...pendingDraftAttachmentsRef.current,
+          { tempId, file, previewUrl: blobUrl },
+        ];
+        continue;
+      }
+
       void uploadOne(sessionId, file, workspaceRoot ?? undefined)
         .then((ref) => {
           const finalUrl = isImage ? `zuse://attachments/${ref.id}` : "";
@@ -683,6 +732,24 @@ export function ChatComposer({
    */
   const attachPastedText = async (text: string): Promise<void> => {
     if (editorViewRef.current === null) return;
+    if (isDraft) {
+      const tempRelPath = `.context/files/paste-pending-${Math.random()
+        .toString(36)
+        .slice(2, 10)}.md`;
+      pendingDraftContextFilesRef.current = [
+        ...pendingDraftContextFilesRef.current,
+        { tempRelPath, text, ext: "md" },
+      ];
+      const view = editorViewRef.current;
+      const sel = view.state.selection.main;
+      replaceWithChip(view, sel.from, sel.to, `@${tempRelPath}`, {
+        kind: "file",
+        relPath: tempRelPath,
+        absPath: tempRelPath,
+        entryKind: "file",
+      });
+      return;
+    }
     try {
       const client = await getRpcClient();
       const res = await Effect.runPromise(
@@ -810,7 +877,9 @@ export function ChatComposer({
             shouldQueue: inFlight || holdForSetup,
           })
         : null;
-    clearComposer(view);
+    clearComposer(view, {
+      clearPendingAttachments: onDraftSubmit === undefined,
+    });
     clearComposerDraft(draftKey);
     setGoalSendMode(false);
     // Drain the tray: the annotations now live on `input` (carried into the
@@ -819,7 +888,15 @@ export function ChatComposer({
     // Draft mode (new-chat landing): hand the input back to the landing, which
     // creates the worktree + chat and queues this as the first message.
     if (onDraftSubmit !== undefined) {
-      onDraftSubmit(input, { asGoal: goalSendMode });
+      const pendingDraftAttachments = pendingDraftAttachmentsRef.current;
+      const pendingDraftContextFiles = pendingDraftContextFilesRef.current;
+      pendingDraftAttachmentsRef.current = [];
+      pendingDraftContextFilesRef.current = [];
+      onDraftSubmit(input, {
+        asGoal: goalSendMode,
+        pendingAttachments: pendingDraftAttachments,
+        pendingContextFiles: pendingDraftContextFiles,
+      });
       return true;
     }
     switch (route) {

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -37,6 +37,12 @@ import {
 import { Skeleton } from "~/components/ui/skeleton";
 import { Spinner } from "~/components/ui/spinner";
 import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
+import {
+  finalizeDraftAttachments,
+  finalizeDraftContextFiles,
+  type PendingDraftAttachment,
+  type PendingDraftContextFile,
+} from "~/composer/draft-attachments";
 import { useChatsStore } from "~/store/chats";
 import { useMessagesStore } from "~/store/messages";
 import { useProvidersStore } from "~/store/providers";
@@ -45,6 +51,7 @@ import { DRAFT_SESSION_ID, useSessionsStore } from "~/store/sessions";
 import { useSettingsStore } from "~/store/settings";
 import { useWorkspaceStore } from "~/store/workspace";
 import { EMPTY_WORKTREES, useWorktreesStore } from "~/store/worktrees";
+import { useAttachmentsStore } from "~/store/attachments";
 import { composerDraftKeyForLanding } from "~/store/composer-drafts";
 import { useComposerBridge } from "~/store/composer-bridge";
 import { saveContextFile } from "~/lib/context-handoff";
@@ -149,6 +156,7 @@ export function ChatLanding() {
 
   const create = useChatsStore((s) => s.create);
   const send = useMessagesStore((s) => s.send);
+  const uploadOne = useAttachmentsStore((s) => s.uploadOne);
   const beginDraft = useSessionsStore((s) => s.beginDraft);
   const clearDraft = useSessionsStore((s) => s.clearDraft);
   // The synthetic draft session that drives the real ChatComposer below. Its
@@ -317,7 +325,11 @@ export function ChatLanding() {
   // there's no worktree). Identical sequencing to the old textarea submit.
   const handleDraftSubmit = async (
     input: ComposerInput,
-    opts: { asGoal: boolean },
+    opts: {
+      readonly asGoal: boolean;
+      readonly pendingAttachments: ReadonlyArray<PendingDraftAttachment>;
+      readonly pendingContextFiles: ReadonlyArray<PendingDraftContextFile>;
+    },
   ): Promise<void> => {
     if (selectedFolderId === null || submitting) return;
     const draft = useSessionsStore.getState().draftSession;
@@ -372,6 +384,64 @@ export function ChatLanding() {
             { relPath: ref.relPath, absPath: ref.absPath, kind: "file" },
           ],
         };
+      }
+    }
+    const uploadRoot = (() => {
+      if (worktreeId === null) return selectedFolder?.path ?? null;
+      const wt = (
+        useWorktreesStore.getState().byProject[selectedFolderId] ??
+        EMPTY_WORKTREES
+      ).find((w) => w.id === worktreeId);
+      return wt?.path ?? selectedFolder?.path ?? null;
+    })();
+    if (opts.pendingContextFiles.length > 0) {
+      try {
+        const client = await getRpcClient();
+        finalInput = await finalizeDraftContextFiles(
+          finalInput,
+          opts.pendingContextFiles,
+          async (pending) => {
+            const res = await Effect.runPromise(
+              client.context.saveText({
+                sessionId,
+                text: pending.text,
+                ext: pending.ext,
+                ...(uploadRoot ? { rootPath: uploadRoot } : {}),
+              }),
+            );
+            return { relPath: res.relPath, absPath: res.absPath };
+          },
+        );
+      } catch (err) {
+        console.error("[chat-landing] deferred context file failed", err);
+        setSubmitError("Couldn't attach pasted text. Please try again.");
+        setPendingPrompt(null);
+        setPendingWorktreeId(null);
+        setPendingProviderId(null);
+        setSubmitting(false);
+        return;
+      }
+    }
+    if (opts.pendingAttachments.length > 0) {
+      try {
+        finalInput = await finalizeDraftAttachments(
+          finalInput,
+          opts.pendingAttachments,
+          (pending) =>
+            uploadOne(sessionId, pending.file, uploadRoot ?? undefined),
+        );
+      } catch (err) {
+        console.error("[chat-landing] deferred upload failed", err);
+        setSubmitError("Couldn't attach one of those files. Please try again.");
+        setPendingPrompt(null);
+        setPendingWorktreeId(null);
+        setPendingProviderId(null);
+        setSubmitting(false);
+        return;
+      } finally {
+        for (const pending of opts.pendingAttachments) {
+          if (pending.previewUrl) URL.revokeObjectURL(pending.previewUrl);
+        }
       }
     }
     if (opts.asGoal && goalSupported) {

--- a/apps/renderer/src/components/composer/composer-chip-overlay.tsx
+++ b/apps/renderer/src/components/composer/composer-chip-overlay.tsx
@@ -9,12 +9,21 @@ import {
 } from "~/components/ui/tooltip.tsx";
 import { useUiStore } from "~/store/ui";
 
-interface HoverState {
-  readonly rect: DOMRect;
-  readonly relPath: string;
-  readonly absPath: string;
-  readonly entryKind: "file" | "directory";
-}
+type HoverState =
+  | {
+      readonly kind: "file";
+      readonly rect: DOMRect;
+      readonly relPath: string;
+      readonly absPath: string;
+      readonly entryKind: "file" | "directory";
+    }
+  | {
+      readonly kind: "image";
+      readonly rect: DOMRect;
+      readonly previewUrl: string;
+      readonly originalName: string;
+      readonly mimeType: string;
+    };
 
 const HIDE_DELAY_MS = 80;
 
@@ -24,11 +33,12 @@ const basename = (p: string): string => {
 };
 
 /**
- * Overlay that adds two behaviours to file chips inside the composer:
+ * Overlay that adds behaviours to atomic chips inside the composer:
  *
- *   - **hover** → a Base UI tooltip anchored to the chip showing
+ *   - **file hover** → a Base UI tooltip anchored to the chip showing
  *     `Open <relPath>` (or `View <relPath>` for directories).
- *   - **click** → opens the file in the right pane's file editor.
+ *   - **file click** → opens the file in the right pane's file editor.
+ *   - **image hover** → shows a constrained preview of the attachment.
  *
  * The chip widget lives inside CodeMirror's DOM (see `composer-chips.ts`)
  * so we event-delegate from the editor host rather than mounting React
@@ -60,34 +70,66 @@ export function ComposerChipOverlay({
       }
     };
 
-    const findChip = (target: EventTarget | null): HTMLElement | null => {
+    const findFileChip = (target: EventTarget | null): HTMLElement | null => {
       if (!(target instanceof HTMLElement)) return null;
       return target.closest<HTMLElement>('.fz-chip[data-kind="file"]');
     };
+    const findImageChip = (target: EventTarget | null): HTMLElement | null => {
+      if (!(target instanceof HTMLElement)) return null;
+      return target.closest<HTMLElement>('.fz-chip[data-kind="image"]');
+    };
 
     const onOver = (e: MouseEvent) => {
-      const chip = findChip(e.target);
+      const fileChip = findFileChip(e.target);
+      const imageChip = findImageChip(e.target);
+      const chip = fileChip ?? imageChip;
       if (chip === null) return;
-      const relPath = chip.dataset.relPath;
-      const absPath = chip.dataset.absPath;
-      const entryKind = chip.dataset.entryKind;
-      if (relPath === undefined || absPath === undefined) return;
       cancelHide();
-      setState({
-        rect: chip.getBoundingClientRect(),
-        relPath,
-        absPath,
-        entryKind: entryKind === "directory" ? "directory" : "file",
-      });
+      if (fileChip !== null) {
+        const relPath = fileChip.dataset.relPath;
+        const absPath = fileChip.dataset.absPath;
+        const entryKind = fileChip.dataset.entryKind;
+        if (relPath === undefined || absPath === undefined) return;
+        setState({
+          kind: "file",
+          rect: fileChip.getBoundingClientRect(),
+          relPath,
+          absPath,
+          entryKind: entryKind === "directory" ? "directory" : "file",
+        });
+        return;
+      }
+      if (imageChip !== null) {
+        const previewUrl = imageChip.dataset.previewUrl;
+        const originalName = imageChip.dataset.originalName;
+        const mimeType = imageChip.dataset.mimeType;
+        if (
+          previewUrl === undefined ||
+          previewUrl.length === 0 ||
+          originalName === undefined ||
+          mimeType === undefined ||
+          !mimeType.startsWith("image/")
+        ) {
+          return;
+        }
+        setState({
+          kind: "image",
+          rect: imageChip.getBoundingClientRect(),
+          previewUrl,
+          originalName,
+          mimeType,
+        });
+      }
     };
 
     const onOut = (e: MouseEvent) => {
-      const chip = findChip(e.target);
+      const chip = findFileChip(e.target) ?? findImageChip(e.target);
       if (chip === null) return;
       const next = e.relatedTarget;
       if (
         next instanceof HTMLElement &&
-        next.closest('.fz-chip[data-kind="file"]')
+        (next.closest('.fz-chip[data-kind="file"]') !== null ||
+          next.closest('.fz-chip[data-kind="image"]') !== null)
       ) {
         return;
       }
@@ -102,7 +144,7 @@ export function ComposerChipOverlay({
     // routes the click as needed; openFileInTab just switches the main
     // tab to "file" and the right pane reads the new state.
     const onClick = (e: MouseEvent) => {
-      const chip = findChip(e.target);
+      const chip = findFileChip(e.target);
       if (chip === null) return;
       const relPath = chip.dataset.relPath;
       const entryKind = chip.dataset.entryKind;
@@ -138,10 +180,6 @@ export function ComposerChipOverlay({
 
   if (state === null) return null;
 
-  const label =
-    state.entryKind === "directory"
-      ? `View ${state.relPath}`
-      : `Open ${state.relPath}`;
   const rect = state.rect;
 
   return (
@@ -162,7 +200,33 @@ export function ComposerChipOverlay({
           />
         }
       />
-      <TooltipPopup>{label}</TooltipPopup>
+      <TooltipPopup
+        className={
+          state.kind === "image"
+            ? "max-w-[min(24rem,calc(100vw-2rem))] p-2"
+            : undefined
+        }
+      >
+        {state.kind === "file" ? (
+          state.entryKind === "directory" ? (
+            `View ${state.relPath}`
+          ) : (
+            `Open ${state.relPath}`
+          )
+        ) : (
+          <div className="min-w-0">
+            <img
+              src={state.previewUrl}
+              alt=""
+              className="block max-h-72 max-w-full rounded-md object-contain"
+              draggable={false}
+            />
+            <div className="mt-1.5 max-w-80 truncate px-0.5 text-[11px] text-muted-foreground">
+              {state.originalName}
+            </div>
+          </div>
+        )}
+      </TooltipPopup>
     </Tooltip>
   );
 }

--- a/apps/renderer/src/composer/draft-attachments.ts
+++ b/apps/renderer/src/composer/draft-attachments.ts
@@ -1,0 +1,98 @@
+import type { AttachmentRef, ComposerInput, FileRef } from "@zuse/wire";
+
+export interface PendingDraftAttachment {
+  readonly tempId: string;
+  readonly file: File;
+  readonly previewUrl: string;
+}
+
+export interface PendingDraftContextFile {
+  readonly tempRelPath: string;
+  readonly text: string;
+  readonly ext: string;
+}
+
+export type UploadDraftAttachment = (
+  pending: PendingDraftAttachment,
+) => Promise<AttachmentRef>;
+
+export type SaveDraftContextFile = (
+  pending: PendingDraftContextFile,
+) => Promise<Pick<FileRef, "relPath" | "absPath">>;
+
+export const hasPendingAttachmentIds = (input: ComposerInput): boolean =>
+  input.attachments.some((attachment) => attachment.id.startsWith("pending-"));
+
+export const finalizeDraftAttachments = async (
+  input: ComposerInput,
+  pending: ReadonlyArray<PendingDraftAttachment>,
+  upload: UploadDraftAttachment,
+): Promise<ComposerInput> => {
+  if (pending.length === 0 && !hasPendingAttachmentIds(input)) return input;
+
+  const byTempId = new Map(pending.map((item) => [item.tempId, item]));
+  const resolved = new Map<string, AttachmentRef>();
+  const attachments: AttachmentRef[] = [];
+
+  for (const attachment of input.attachments) {
+    const pendingItem = byTempId.get(attachment.id);
+    if (pendingItem === undefined) {
+      if (attachment.id.startsWith("pending-")) {
+        throw new Error(`Missing pending attachment file for ${attachment.id}`);
+      }
+      attachments.push(attachment);
+      continue;
+    }
+    const cached = resolved.get(attachment.id);
+    if (cached !== undefined) {
+      attachments.push(cached);
+      continue;
+    }
+    const ref = await upload(pendingItem);
+    resolved.set(attachment.id, ref);
+    attachments.push(ref);
+  }
+
+  return { ...input, attachments };
+};
+
+const isPendingContextRelPath = (relPath: string): boolean =>
+  relPath.startsWith(".context/files/paste-pending-");
+
+export const hasPendingContextFileRefs = (input: ComposerInput): boolean =>
+  input.fileRefs.some((ref) => isPendingContextRelPath(ref.relPath));
+
+export const finalizeDraftContextFiles = async (
+  input: ComposerInput,
+  pending: ReadonlyArray<PendingDraftContextFile>,
+  save: SaveDraftContextFile,
+): Promise<ComposerInput> => {
+  if (pending.length === 0 && !hasPendingContextFileRefs(input)) return input;
+
+  const byRelPath = new Map(pending.map((item) => [item.tempRelPath, item]));
+  const resolved = new Map<string, Pick<FileRef, "relPath" | "absPath">>();
+  const fileRefs: FileRef[] = [];
+  let text = input.text;
+
+  for (const ref of input.fileRefs) {
+    const pendingItem = byRelPath.get(ref.relPath);
+    if (pendingItem === undefined) {
+      if (isPendingContextRelPath(ref.relPath)) {
+        throw new Error(`Missing pending context file text for ${ref.relPath}`);
+      }
+      fileRefs.push(ref);
+      continue;
+    }
+    const cached = resolved.get(ref.relPath);
+    const saved = cached ?? (await save(pendingItem));
+    resolved.set(ref.relPath, saved);
+    text = text.replaceAll(`@${ref.relPath}`, `@${saved.relPath}`);
+    fileRefs.push({
+      relPath: saved.relPath,
+      absPath: saved.absPath,
+      kind: ref.kind,
+    });
+  }
+
+  return { ...input, text, fileRefs };
+};

--- a/apps/renderer/src/lib/codemirror/composer-chips.ts
+++ b/apps/renderer/src/lib/codemirror/composer-chips.ts
@@ -12,10 +12,7 @@ import {
   WidgetType,
 } from "@codemirror/view";
 
-import {
-  getFileIconUrl,
-  getFolderIconUrl,
-} from "../icons/material-icons.ts";
+import { getFileIconUrl, getFolderIconUrl } from "../icons/material-icons.ts";
 
 /**
  * One inline chip in the composer document. The chip renders as an atomic
@@ -31,7 +28,11 @@ export type ChipMeta =
       readonly absPath: string;
       readonly entryKind: "file" | "directory";
     }
-  | { readonly kind: "skill"; readonly name: string; readonly scope: "global" | "project" }
+  | {
+      readonly kind: "skill";
+      readonly name: string;
+      readonly scope: "global" | "project";
+    }
   | {
       readonly kind: "image";
       readonly id: string;
@@ -143,6 +144,11 @@ class ChipWidget extends WidgetType {
     } else if (this.meta.kind === "skill") {
       span.dataset.skillName = this.meta.name;
       span.dataset.skillScope = this.meta.scope;
+    } else if (this.meta.kind === "image") {
+      span.dataset.attachmentId = this.meta.id;
+      span.dataset.mimeType = this.meta.mimeType;
+      span.dataset.originalName = this.meta.originalName;
+      span.dataset.previewUrl = this.meta.previewUrl;
     }
 
     const label = document.createElement("span");
@@ -213,12 +219,14 @@ const buildIconNode = (meta: ChipMeta): Node => {
     // Image attachment → thumbnail. Non-image attachments share the same
     // chip kind (so the wire shape stays tidy) but render with the
     // file-type material icon instead.
-    const isImage = meta.mimeType.startsWith("image/") && meta.previewUrl !== "";
+    const isImage =
+      meta.mimeType.startsWith("image/") && meta.previewUrl !== "";
     if (isImage) {
       const img = document.createElement("img");
       img.src = meta.previewUrl;
       img.alt = "";
       img.className = "fz-chip-thumb";
+      img.draggable = false;
       return img;
     }
     const url = getFileIconUrl(meta.originalName);
@@ -270,9 +278,7 @@ export const chipExtensions = [
 /** Look up the chip range that covers (or starts at) `pos`. */
 export const chipAt = (state: EditorState, pos: number): ChipRange | null => {
   const chips = state.field(chipsField);
-  return (
-    chips.find((c) => pos >= c.from && pos <= c.to) ?? null
-  );
+  return chips.find((c) => pos >= c.from && pos <= c.to) ?? null;
 };
 
 /** Used by the segment parser at submit time. */

--- a/apps/renderer/src/store/skills.ts
+++ b/apps/renderer/src/store/skills.ts
@@ -1,7 +1,7 @@
 import { Effect, Fiber, Stream } from "effect";
 import { create } from "zustand";
 
-import type { SessionId, Skill } from "@zuse/wire";
+import type { FolderId, ProviderId, SessionId, Skill } from "@zuse/wire";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 
@@ -14,6 +14,11 @@ import { getRpcClient } from "../lib/rpc-client.ts";
 type SkillsState = {
   readonly skillsBySession: Record<string, ReadonlyArray<Skill>>;
   readonly hydrate: (sessionId: SessionId) => Promise<void>;
+  readonly hydrateForDraft: (
+    sessionId: SessionId,
+    projectId: FolderId,
+    providerId: ProviderId,
+  ) => Promise<void>;
 };
 
 const EMPTY: ReadonlyArray<Skill> = [];
@@ -53,6 +58,23 @@ export const useSkillsStore = create<SkillsState>((set) => ({
     } catch {
       // Best-effort: if the stream errors (e.g. session not found), keep
       // the empty list — the slash popover degrades to built-ins only.
+    }
+  },
+  hydrateForDraft: async (sessionId, projectId, providerId) => {
+    await stopLiveFiber();
+    set((s) => ({
+      skillsBySession: { ...s.skillsBySession, [sessionId]: EMPTY },
+    }));
+    try {
+      const client = await getRpcClient();
+      const skills = await Effect.runPromise(
+        client.skill.listForProject({ projectId, providerId }),
+      );
+      set((s) => ({
+        skillsBySession: { ...s.skillsBySession, [sessionId]: skills },
+      }));
+    } catch {
+      // Best-effort: draft slash commands still show built-ins.
     }
   },
 }));

--- a/apps/renderer/test/draft-attachments.test.ts
+++ b/apps/renderer/test/draft-attachments.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "bun:test";
+
+import { ComposerInput, type AttachmentRef } from "@zuse/wire";
+
+import {
+  finalizeDraftAttachments,
+  finalizeDraftContextFiles,
+  hasPendingAttachmentIds,
+  hasPendingContextFileRefs,
+  type PendingDraftAttachment,
+} from "../src/composer/draft-attachments.ts";
+
+const makeFile = (name: string): File =>
+  new File([new Uint8Array([1, 2, 3])], name, { type: "image/png" });
+
+describe("draft attachment finalization", () => {
+  it("replaces pending attachment ids with uploaded refs", async () => {
+    const input = ComposerInput.make({
+      text: "inspect this",
+      attachments: [
+        {
+          id: "pending-a",
+          mimeType: "image/png",
+          originalName: "before.png",
+        },
+      ],
+      fileRefs: [],
+      skillRefs: [],
+    });
+    const pending: PendingDraftAttachment = {
+      tempId: "pending-a",
+      file: makeFile("before.png"),
+      previewUrl: "blob:test",
+    };
+    const uploaded: AttachmentRef = {
+      id: "session-1-real",
+      mimeType: "image/png",
+      originalName: "before.png",
+    };
+
+    const finalized = await finalizeDraftAttachments(input, [pending], () =>
+      Promise.resolve(uploaded),
+    );
+
+    expect(finalized.attachments).toEqual([uploaded]);
+    expect(hasPendingAttachmentIds(finalized)).toBe(false);
+  });
+
+  it("throws instead of letting a stale pending id through", async () => {
+    const input = ComposerInput.make({
+      text: "inspect this",
+      attachments: [
+        {
+          id: "pending-stale",
+          mimeType: "image/png",
+          originalName: "stale.png",
+        },
+      ],
+      fileRefs: [],
+      skillRefs: [],
+    });
+
+    await expect(
+      finalizeDraftAttachments(input, [], () => {
+        throw new Error("should not upload");
+      }),
+    ).rejects.toThrow("Missing pending attachment file");
+  });
+
+  it("replaces pending context file refs and text mentions", async () => {
+    const input = ComposerInput.make({
+      text: "read @.context/files/paste-pending-abc123.md",
+      attachments: [],
+      fileRefs: [
+        {
+          relPath: ".context/files/paste-pending-abc123.md",
+          absPath: ".context/files/paste-pending-abc123.md",
+          kind: "file",
+        },
+      ],
+      skillRefs: [],
+    });
+
+    const finalized = await finalizeDraftContextFiles(
+      input,
+      [
+        {
+          tempRelPath: ".context/files/paste-pending-abc123.md",
+          text: "large paste",
+          ext: "md",
+        },
+      ],
+      () =>
+        Promise.resolve({
+          relPath: ".context/files/paste-real.md",
+          absPath: "/worktree/.context/files/paste-real.md",
+        }),
+    );
+
+    expect(finalized.text).toBe("read @.context/files/paste-real.md");
+    expect(finalized.fileRefs).toEqual([
+      {
+        relPath: ".context/files/paste-real.md",
+        absPath: "/worktree/.context/files/paste-real.md",
+        kind: "file",
+      },
+    ]);
+    expect(hasPendingContextFileRefs(finalized)).toBe(false);
+  });
+});

--- a/apps/server/src/skill/handlers.ts
+++ b/apps/server/src/skill/handlers.ts
@@ -7,12 +7,22 @@ const SkillList = MemoizeRpcs.toLayerHandler("skill.list", ({ sessionId }) =>
   Effect.flatMap(SkillBridge, (svc) => svc.list(sessionId)),
 );
 
-const SkillStream = MemoizeRpcs.toLayerHandler(
-  "skill.stream",
-  ({ sessionId }) =>
-    Stream.unwrap(
-      Effect.map(SkillBridge, (svc) => svc.stream(sessionId)),
+const SkillListForProject = MemoizeRpcs.toLayerHandler(
+  "skill.listForProject",
+  ({ projectId, providerId }) =>
+    Effect.flatMap(SkillBridge, (svc) =>
+      svc.listForProject(projectId, providerId),
     ),
 );
 
-export const SkillHandlersLayer = Layer.mergeAll(SkillList, SkillStream);
+const SkillStream = MemoizeRpcs.toLayerHandler(
+  "skill.stream",
+  ({ sessionId }) =>
+    Stream.unwrap(Effect.map(SkillBridge, (svc) => svc.stream(sessionId))),
+);
+
+export const SkillHandlersLayer = Layer.mergeAll(
+  SkillList,
+  SkillListForProject,
+  SkillStream,
+);

--- a/apps/server/src/skill/layers/skill-bridge.ts
+++ b/apps/server/src/skill/layers/skill-bridge.ts
@@ -151,6 +151,17 @@ export const SkillBridgeLive = Layer.scoped(
         return entry.skills;
       });
 
+    const listForProject: SkillBridge["Type"]["listForProject"] = (
+      projectId,
+      providerId,
+    ) =>
+      Effect.gen(function* () {
+        const folder = yield* workspace.findById(projectId);
+        const projectCwd = folder?.path ?? process.cwd();
+        const entry = yield* ensureEntry(providerId, projectCwd);
+        return entry.skills;
+      });
+
     const stream: SkillBridge["Type"]["stream"] = (sessionId) =>
       Stream.unwrap(
         Effect.gen(function* () {
@@ -172,6 +183,6 @@ export const SkillBridgeLive = Layer.scoped(
       }),
     );
 
-    return { list, stream };
+    return { list, listForProject, stream };
   }),
 );

--- a/apps/server/src/skill/services/skill-bridge.ts
+++ b/apps/server/src/skill/services/skill-bridge.ts
@@ -1,6 +1,8 @@
 import { Context, type Effect, type Stream } from "effect";
 
 import type {
+  FolderId,
+  ProviderId,
   SessionId,
   SessionNotFoundError,
   Skill,
@@ -15,6 +17,11 @@ export interface SkillBridgeShape {
   readonly list: (
     sessionId: SessionId,
   ) => Effect.Effect<ReadonlyArray<Skill>, SessionNotFoundError>;
+
+  readonly listForProject: (
+    projectId: FolderId,
+    providerId: ProviderId,
+  ) => Effect.Effect<ReadonlyArray<Skill>>;
 
   readonly stream: (
     sessionId: SessionId,

--- a/packages/wire/src/rpc.ts
+++ b/packages/wire/src/rpc.ts
@@ -167,7 +167,11 @@ import {
   SessionStatusStreamRpc,
   SessionUnarchiveRpc,
 } from "./session.ts";
-import { SkillListRpc, SkillStreamRpc } from "./skill.ts";
+import {
+  SkillListForProjectRpc,
+  SkillListRpc,
+  SkillStreamRpc,
+} from "./skill.ts";
 import {
   WorkspaceAddRpc,
   WorkspaceCloneRepoRpc,
@@ -326,6 +330,7 @@ export const MemoizeRpcs = RpcGroup.make(
   AttachmentUploadRpc,
   ContextSaveTextRpc,
   SkillListRpc,
+  SkillListForProjectRpc,
   SkillStreamRpc,
   PermissionRequestsRpc,
   PermissionDecideRpc,

--- a/packages/wire/src/skill.ts
+++ b/packages/wire/src/skill.ts
@@ -2,6 +2,7 @@ import { Rpc } from "@effect/rpc";
 import { Schema } from "effect";
 
 import { ProviderId } from "./agent.ts";
+import { FolderId } from "./ids.ts";
 import { SessionId, SessionNotFoundError } from "./session.ts";
 
 /**
@@ -32,6 +33,20 @@ export const SkillListRpc = Rpc.make("skill.list", {
   payload: Schema.Struct({ sessionId: SessionId }),
   success: Schema.Array(Skill),
   error: SessionNotFoundError,
+});
+
+/**
+ * One-shot fetch for a draft composer before a real session row exists.
+ * Skill discovery only needs the provider and project checkout, so the
+ * landing composer can hydrate slash-command skills without creating a
+ * temporary server session.
+ */
+export const SkillListForProjectRpc = Rpc.make("skill.listForProject", {
+  payload: Schema.Struct({
+    projectId: FolderId,
+    providerId: ProviderId,
+  }),
+  success: Schema.Array(Skill),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Defer landing composer image uploads until the real chat workspace exists.
- Hydrate draft slash-command skills by project and provider.
- Add image chip metadata and hover previews, plus draft attachment finalization tests.

## Root cause
The landing composer used a synthetic draft session before the real chat/workspace binding existed, so dropped files could be uploaded against the project checkout instead of the new workspace. The same draft surface also skipped the normal chat view skill hydration path.

## Validation
- bun --filter renderer check-types
- bun --filter @zuse/wire check-types
- bun --filter @zuse/server check-types
- bun --filter renderer test
- bunx prettier --check <touched files>
- git diff --check
