### PR TITLE
Release v0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4]
+
+### Changed
+- [codex] Fix landing composer attachments (#309)
+- Mobile new-chat: docked selectors, real provider logos, menu polish (#308)
+- Fix chat scroll anchoring (#307)
+
 ## [0.12.3]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "0.12.4",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "[codex] Fix landing composer attachments (#309)",
+          "Mobile new-chat: docked selectors, real provider logos, menu polish (#308)",
+          "Fix chat scroll anchoring (#307)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.12.3",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release Zuse v0.12.4
- update CHANGELOG.md and desktop package metadata
- regenerate the website changelog JSON

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.12.4 after this PR lands.
