### PR TITLE
Add GPT-5.6 models and harden local dev startup

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -115,7 +115,7 @@ function startApp() {
   app.once("error", (error) => {
     console.error("[desktop:electron] failed to launch", error);
     if (currentApp === app) currentApp = null;
-    if (!shuttingDown) scheduleRestart();
+    if (!shuttingDown) void shutdown(1);
   });
 
   app.once("exit", (code, signal) => {
@@ -124,7 +124,9 @@ function startApp() {
     );
     if (currentApp === app) currentApp = null;
     const abnormal = signal !== null || code !== 0;
-    if (!shuttingDown && !expectedExits.has(app) && abnormal) scheduleRestart();
+    if (!shuttingDown && !expectedExits.has(app) && abnormal) {
+      void shutdown(code ?? 1);
+    }
   });
 }
 

--- a/apps/mobile/src/lib/model-options.test.ts
+++ b/apps/mobile/src/lib/model-options.test.ts
@@ -1,7 +1,7 @@
 import type { AgentAvailability } from "@zuse/wire";
 import { describe, expect, test } from "bun:test";
 
-import { availableProviderIds } from "./model-options";
+import { availableProviderIds, reasoningValueForModel } from "./model-options";
 
 const entry = (
   providerId: AgentAvailability["providerId"],
@@ -43,5 +43,13 @@ describe("availableProviderIds", () => {
     expect(availableProviderIds([entry("codex", { status: "error" })])).toEqual(
       [],
     );
+  });
+});
+
+describe("reasoningValueForModel", () => {
+  test("falls back to the model default when a stored effort is unsupported", () => {
+    expect(
+      reasoningValueForModel("codex", "gpt-5.5", { reasoning: "ultra" }),
+    ).toMatchObject({ value: "medium", label: "Medium" });
   });
 });

--- a/apps/mobile/src/lib/model-options.ts
+++ b/apps/mobile/src/lib/model-options.ts
@@ -114,10 +114,12 @@ export const reasoningValueForModel = (
 } | null => {
   const descriptor = reasoningDescriptorForModel(providerId, model);
   if (descriptor === null) return null;
+  const requestedValue = modelOptions?.[descriptor.id];
+  const requestedOption = descriptor.options.find(
+    (option) => option.id === requestedValue,
+  );
   const value =
-    modelOptions?.[descriptor.id] ??
-    descriptor.defaultId ??
-    descriptor.options[0]?.id;
+    requestedOption?.id ?? descriptor.defaultId ?? descriptor.options[0]?.id;
   if (value === undefined) return null;
   const label =
     descriptor.options.find((option) => option.id === value)?.label ?? value;

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1685,12 +1685,20 @@ function ReasoningPicker({
   });
 
   useEffect(() => {
-    if (resolved === null || !resolved.options.some((o) => o.id === level)) {
+    if (resolved === null) {
       onLevelChange?.(null);
       return;
     }
+    if (!resolved.options.some((o) => o.id === level)) {
+      setLevel(defaultId);
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem(storageKey, defaultId);
+      }
+      onLevelChange?.(defaultId);
+      return;
+    }
     onLevelChange?.(level);
-  }, [level, onLevelChange, resolved]);
+  }, [defaultId, level, onLevelChange, resolved, storageKey]);
 
   if (resolved === null) return null;
 

--- a/apps/server/src/provider/drivers/codex.ts
+++ b/apps/server/src/provider/drivers/codex.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join, resolve } from "node:path";
 
 import {
   AgentSessionStartError,
+  findModelDescriptor,
   resolveModelSlug,
   type AgentEvent,
   type AgentItemId,
@@ -74,6 +75,49 @@ export type RequestPermission = (
   kind: PermissionKind,
   options: { readonly forcePrompt: boolean },
 ) => Promise<PermissionDecision>;
+
+export type CodexReasoningEffort =
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "ultra";
+
+/** Keep the user-selected reasoning tier intact when Codex supports it. */
+export const codexReasoningEffort = (
+  model: string | undefined,
+  value: string | undefined,
+): CodexReasoningEffort | null => {
+  if (
+    value !== "low" &&
+    value !== "medium" &&
+    value !== "high" &&
+    value !== "xhigh" &&
+    value !== "max" &&
+    value !== "ultra"
+  ) {
+    return null;
+  }
+
+  const descriptor =
+    model === undefined
+      ? undefined
+      : findModelDescriptor("codex", resolveModelSlug("codex", model));
+  if (descriptor === undefined) {
+    return value === "low" || value === "medium" || value === "high"
+      ? value
+      : null;
+  }
+
+  const reasoning = descriptor.optionDescriptors?.find(
+    (option) => option.kind === "select" && option.id === "reasoning",
+  );
+  return reasoning?.kind === "select" &&
+    reasoning.options.some((option) => option.id === value)
+    ? value
+    : null;
+};
 
 const codexApprovalPolicy = (
   runtimeMode: RuntimeMode,
@@ -1289,14 +1333,13 @@ export const startCodexSession = (
       browserHintPending = false;
       orchestrationHintPending = false;
       // Reasoning effort: forwarded from FE picker via
-      // `input.modelOptions.reasoning`. Pass through low/medium/high
-      // directly — Codex accepts the same literal set we use in wire's
-      // `ReasoningLevel`.
-      const reasoning = input.modelOptions?.["reasoning"];
-      const effort: "low" | "medium" | "high" | null =
-        reasoning === "low" || reasoning === "medium" || reasoning === "high"
-          ? reasoning
-          : null;
+      // `input.modelOptions.reasoning`. Each model's wire descriptor limits
+      // the picker to the tiers it supports; the selected literal is then
+      // forwarded unchanged to Codex.
+      const effort = codexReasoningEffort(
+        input.model,
+        input.modelOptions?.["reasoning"],
+      );
       // Fast mode: the `fastMode` per-model boolean knob maps onto Codex's
       // `serviceTier: "fast"` (the 1.5× speed tier). The FE only shows the
       // toggle when the CLI version + static model catalog allow it; the live

--- a/apps/server/test/codex-translate.test.ts
+++ b/apps/server/test/codex-translate.test.ts
@@ -5,6 +5,7 @@ import type { AgentEvent } from "@zuse/wire";
 
 import type { ThreadItem } from "../src/provider/codex-app-protocol/v2/ThreadItem.ts";
 import {
+  codexReasoningEffort,
   codexWritableRootsForCwd,
   translateCodexItem,
   translateCodexStatusNotification,
@@ -401,5 +402,22 @@ describe("codexWritableRootsForCwd", () => {
     expect(codexWritableRootsForCwd(cwd)).toEqual(
       expect.arrayContaining([cwd, ...gitDirs]),
     );
+  });
+});
+
+describe("codexReasoningEffort", () => {
+  it("passes only the selected model's supported efforts through to Codex", () => {
+    expect(codexReasoningEffort("gpt-5.5", "xhigh")).toBe("xhigh");
+    expect(codexReasoningEffort("gpt-5.5", "max")).toBeNull();
+    expect(codexReasoningEffort("gpt-5.6-sol", "max")).toBe("max");
+    expect(codexReasoningEffort("gpt-5.6-terra", "ultra")).toBe("ultra");
+    expect(codexReasoningEffort("gpt-5.4", "xhigh")).toBeNull();
+  });
+
+  it("keeps standard efforts for custom models and drops unknown values", () => {
+    expect(codexReasoningEffort("custom-model", "high")).toBe("high");
+    expect(codexReasoningEffort("custom-model", "ultra")).toBeNull();
+    expect(codexReasoningEffort(undefined, undefined)).toBeNull();
+    expect(codexReasoningEffort("gpt-5.6-luna", "turbo")).toBeNull();
   });
 });

--- a/apps/server/test/config-store.test.ts
+++ b/apps/server/test/config-store.test.ts
@@ -99,6 +99,9 @@ describe("config-store settings coercion", () => {
     expect(settings.modelEnabledByProvider.claude["claude-sonnet-4-6"]).toBe(
       false,
     );
+    expect(settings.modelEnabledByProvider.codex["gpt-5.6-sol"]).toBe(true);
+    expect(settings.modelEnabledByProvider.codex["gpt-5.6-terra"]).toBe(true);
+    expect(settings.modelEnabledByProvider.codex["gpt-5.6-luna"]).toBe(true);
     expect(settings.modelEnabledByProvider.codex["gpt-5.5"]).toBe(true);
     expect(settings.modelEnabledByProvider.codex["gpt-5.3-codex"]).toBe(false);
     expect(settings.modelEnabledByProvider.grok["grok-4.5"]).toBe(true);

--- a/packages/wire/src/agent.ts
+++ b/packages/wire/src/agent.ts
@@ -86,8 +86,7 @@ export const DEFAULT_PERMISSION_MODE: PermissionMode = "default";
  *   - Claude → `maxThinkingTokens` (low=5k, medium=15k, high=60k) + SDK
  *     `effort` enum (low/medium/high/xhigh/max). `ultracode` is a Claude
  *     Code preset that normalizes to `xhigh` + `settings.ultracode: true`.
- *   - Codex → `reasoning_effort` enum (low/medium/high pass through; higher
- *     tiers fall back to `high`).
+ *   - Codex → `reasoning_effort` enum (supported tiers pass through).
  *   - Gemini Pro → `thinkingConfig.thinkingBudget` (low=4k, medium=16k, high=32k)
  *
  * Providers/models that don't support thinking simply omit the descriptor
@@ -99,6 +98,7 @@ export const ReasoningLevel = Schema.Literal(
   "high",
   "xhigh",
   "max",
+  "ultra",
   "ultracode",
 );
 export type ReasoningLevel = typeof ReasoningLevel.Type;
@@ -718,8 +718,8 @@ export const StartSessionInput = Schema.Struct({
   /**
    * Opaque per-model knob values. Keys map to
    * `ModelDescriptor.optionDescriptors[].id` (e.g. `"reasoning"`); values
-   * are the selected option id (`"low" | "medium" | "high"`) for selects
-   * or `"true" | "false"` for booleans. Drivers consume what they support
+   * are the selected option id (for example, `"low"` or `"ultra"`) for
+   * selects or `"true" | "false"` for booleans. Drivers consume what they support
    * and ignore the rest — the FE composer renders only the descriptors
    * the current model declared, so no value should arrive that the driver
    * can't interpret.
@@ -769,12 +769,13 @@ export interface ModelOption {
 }
 
 /**
- * Standard 3-level reasoning descriptor for Codex/Gemini/Cursor and the
- * `reasoning` knob name used across non-Claude providers. Keep id/options
- * aligned with `ReasoningLevel`.
+ * Reasoning descriptor for Codex/Gemini/Cursor and the `reasoning` knob name
+ * used across non-Claude providers. Models can append provider-supported
+ * tiers beyond the standard low/medium/high set.
  */
 const reasoningSelectDescriptor = (
   defaultId: ReasoningLevel = "medium",
+  additionalOptions: ReadonlyArray<{ id: ReasoningLevel; label: string }> = [],
 ): SelectOptionDescriptor => ({
   kind: "select",
   id: "reasoning",
@@ -783,8 +784,30 @@ const reasoningSelectDescriptor = (
     { id: "low", label: "Low" },
     { id: "medium", label: "Medium" },
     { id: "high", label: "High" },
+    ...additionalOptions,
   ],
   defaultId,
+});
+
+const extraHighReasoningOption = {
+  id: "xhigh",
+  label: "Extra High",
+} as const;
+
+const gpt56ExtendedReasoningOptions = [
+  extraHighReasoningOption,
+  { id: "max", label: "Max" },
+  { id: "ultra", label: "Ultra" },
+] as const;
+
+const gpt56Model = (id: string, label: string): ModelOption => ({
+  id,
+  label,
+  optionDescriptors: [
+    reasoningSelectDescriptor("medium", gpt56ExtendedReasoningOptions),
+  ],
+  supportsPlanMode: true,
+  supportsWebSearch: "native",
 });
 
 /**
@@ -994,12 +1017,16 @@ export const MODELS_BY_PROVIDER: Record<
     },
   ],
   codex: [
+    gpt56Model("gpt-5.6-sol", "GPT-5.6 Sol"),
+    gpt56Model("gpt-5.6-terra", "GPT-5.6 Terra"),
+    gpt56Model("gpt-5.6-luna", "GPT-5.6 Luna"),
     {
       id: "gpt-5.5",
       label: "GPT-5.5",
+      defaultModel: true,
       // Fast tier supported — see gpt-5.4 note above.
       optionDescriptors: [
-        reasoningSelectDescriptor("medium"),
+        reasoningSelectDescriptor("medium", [extraHighReasoningOption]),
         booleanDescriptor("fastMode", "Fast"),
       ],
       supportsPlanMode: true,

--- a/packages/wire/test/schema.test.ts
+++ b/packages/wire/test/schema.test.ts
@@ -681,6 +681,43 @@ describe("SettingsFile round-trip", () => {
 });
 
 describe("model visibility helpers", () => {
+  it("exposes GPT-5.6 variants in quality order with their supported reasoning efforts", () => {
+    expect(
+      MODELS_BY_PROVIDER.codex.slice(0, 4).map((model) => model.id),
+    ).toEqual(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"]);
+    expect(defaultModelFor("codex")).toBe("gpt-5.5");
+
+    const reasoningOptions = (modelId: string) => {
+      const descriptor = MODELS_BY_PROVIDER.codex
+        .find((model) => model.id === modelId)
+        ?.optionDescriptors?.find(
+          (option) => option.kind === "select" && option.id === "reasoning",
+        );
+      return descriptor?.kind === "select"
+        ? descriptor.options.map(({ id, label }) => ({ id, label }))
+        : [];
+    };
+
+    expect(reasoningOptions("gpt-5.5")).toEqual([
+      { id: "low", label: "Low" },
+      { id: "medium", label: "Medium" },
+      { id: "high", label: "High" },
+      { id: "xhigh", label: "Extra High" },
+    ]);
+
+    const gpt56Options = [
+      { id: "low", label: "Low" },
+      { id: "medium", label: "Medium" },
+      { id: "high", label: "High" },
+      { id: "xhigh", label: "Extra High" },
+      { id: "max", label: "Max" },
+      { id: "ultra", label: "Ultra" },
+    ];
+    for (const modelId of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+      expect(reasoningOptions(modelId)).toEqual(gpt56Options);
+    }
+  });
+
   it("uses Sonnet 5 as the default visible Claude model", () => {
     expect(defaultModelFor("claude")).toBe("claude-sonnet-5");
     expect(visibleModelsForProvider("claude")[0]?.id).toBe("claude-fable-5");
@@ -719,9 +756,7 @@ describe("model visibility helpers", () => {
 
   it("surfaces Grok 4.5 without changing the Grok default", () => {
     expect(defaultModelFor("grok")).toBe("grok-build");
-    expect(MODELS_BY_PROVIDER.grok.some((m) => m.id === "grok-4.5")).toBe(
-      true,
-    );
+    expect(MODELS_BY_PROVIDER.grok.some((m) => m.id === "grok-4.5")).toBe(true);
     expect(
       visibleModelsForProvider("grok").some((m) => m.id === "grok-4.5"),
     ).toBe(true);

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -5,15 +5,49 @@
 
 import { spawn } from "node:child_process";
 import { rmSync } from "node:fs";
+import { createServer } from "node:net";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "..");
 
-const RENDERER_PORT = Number(process.env.PORT ?? 5733);
+function parsePort(name, fallback) {
+  const raw = process.env[name] ?? fallback;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    console.error(`[dev] ${name} must be a TCP port number, got ${raw}`);
+    process.exit(1);
+  }
+  return port;
+}
+
+function assertPortAvailable(name, host, port) {
+  return new Promise((resolveAvailable, rejectUnavailable) => {
+    const server = createServer();
+    server.once("error", (error) => {
+      const reason =
+        error && typeof error === "object" && "code" in error
+          ? `${error.code}`
+          : String(error);
+      rejectUnavailable(
+        new Error(
+          `[dev] ${name} port ${host}:${port} is unavailable (${reason}).`,
+        ),
+      );
+    });
+    server.once("listening", () => {
+      server.close(() => resolveAvailable());
+    });
+    server.listen(port, host);
+  });
+}
+
+const RENDERER_PORT = parsePort("PORT", 5733);
+const DESKTOP_WS_PORT = parsePort("ZUSE_DESKTOP_WS_PORT", 8788);
 const RENDERER_HOST = process.env.HOST?.trim() || "localhost";
 const DEV_SERVER_URL = `http://${RENDERER_HOST}:${RENDERER_PORT}`;
+const DESKTOP_WS_HOST = "127.0.0.1";
 
 // Force Electron to wait for the bundle produced by this dev run. Otherwise a
 // stale dist-electron from a previous build can launch immediately, then the
@@ -23,6 +57,20 @@ rmSync(resolve(repoRoot, "apps", "desktop", "dist-electron"), {
   recursive: true,
   force: true,
 });
+
+try {
+  await Promise.all([
+    assertPortAvailable("renderer", RENDERER_HOST, RENDERER_PORT),
+    assertPortAvailable("desktop websocket", DESKTOP_WS_HOST, DESKTOP_WS_PORT),
+  ]);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+console.log(
+  `[dev] using fixed ports: renderer ${RENDERER_HOST}:${RENDERER_PORT}, desktop websocket ${DESKTOP_WS_HOST}:${DESKTOP_WS_PORT}`,
+);
 
 const children = [];
 let shuttingDown = false;
@@ -62,6 +110,7 @@ run("renderer", "bun", ["run", "--filter", "renderer", "dev"], {
 run("desktop:bundle", "bun", ["run", "--filter", "desktop", "dev:bundle"]);
 run("desktop:electron", "bun", ["run", "--filter", "desktop", "dev:electron"], {
   VITE_DEV_SERVER_URL: DEV_SERVER_URL,
+  ZUSE_DESKTOP_WS_PORT: String(DESKTOP_WS_PORT),
 });
 
 process.once("SIGINT", () => void shutdown(130));


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna to the Codex model catalog in quality order
- add Extra High reasoning for GPT-5.5 and Extra High, Max, and Ultra for all GPT-5.6 variants
- validate stored reasoning choices against the selected model across server, desktop, and mobile
- validate fixed local development ports before startup and stop cleanly when Electron exits abnormally

## Impact

GPT-5.6 variants are available without changing the existing GPT-5.5 default. Unsupported persisted effort choices reset safely instead of leaking across models. Local development now fails fast with a clear error when required ports are unavailable.

## Validation

- full monorepo test suite: 10/10 tasks passed
- server: 304 tests passed
- renderer: 95 tests passed
- affected package TypeScript checks passed
- lint passed
- independent standards and spec reviews passed