### PR TITLE
Release v0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5]
+
+### Changed
+- Add GPT-5.6 model support with high and extra-high reasoning effort options.
+- Harden local development startup and Electron reload behavior.
+- Fix image and context attachments failing validation when starting a new chat.
+
 ## [0.12.4]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.5]
 
-### Changed
+### Added
 - Add GPT-5.6 model support with high and extra-high reasoning effort options.
+
+### Changed
 - Harden local development startup and Electron reload behavior.
+
+### Fixed
 - Fix image and context attachments failing validation when starting a new chat.
 
 ## [0.12.4]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -38,6 +38,7 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { Spinner } from "~/components/ui/spinner";
 import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
 import {
+  appendContextFileRef,
   finalizeDraftAttachments,
   finalizeDraftContextFiles,
   type PendingDraftAttachment,
@@ -377,13 +378,7 @@ export function ChatLanding() {
     if (createSource?.issue != null) {
       const ref = await saveContextFile(sessionId, createSource.issue.markdown);
       if (ref !== null) {
-        finalInput = {
-          ...input,
-          fileRefs: [
-            ...input.fileRefs,
-            { relPath: ref.relPath, absPath: ref.absPath, kind: "file" },
-          ],
-        };
+        finalInput = appendContextFileRef(input, ref);
       }
     }
     const uploadRoot = (() => {

--- a/apps/renderer/src/composer/draft-attachments.ts
+++ b/apps/renderer/src/composer/draft-attachments.ts
@@ -1,4 +1,4 @@
-import type { AttachmentRef, ComposerInput, FileRef } from "@zuse/wire";
+import { ComposerInput, type AttachmentRef, type FileRef } from "@zuse/wire";
 
 export interface PendingDraftAttachment {
   readonly tempId: string;
@@ -19,6 +19,15 @@ export type UploadDraftAttachment = (
 export type SaveDraftContextFile = (
   pending: PendingDraftContextFile,
 ) => Promise<Pick<FileRef, "relPath" | "absPath">>;
+
+export const appendContextFileRef = (
+  input: ComposerInput,
+  ref: Pick<FileRef, "relPath" | "absPath">,
+): ComposerInput =>
+  ComposerInput.make({
+    ...input,
+    fileRefs: [...input.fileRefs, { ...ref, kind: "file" }],
+  });
 
 export const hasPendingAttachmentIds = (input: ComposerInput): boolean =>
   input.attachments.some((attachment) => attachment.id.startsWith("pending-"));
@@ -53,7 +62,7 @@ export const finalizeDraftAttachments = async (
     attachments.push(ref);
   }
 
-  return { ...input, attachments };
+  return ComposerInput.make({ ...input, attachments });
 };
 
 const isPendingContextRelPath = (relPath: string): boolean =>
@@ -94,5 +103,5 @@ export const finalizeDraftContextFiles = async (
     });
   }
 
-  return { ...input, text, fileRefs };
+  return ComposerInput.make({ ...input, text, fileRefs });
 };

--- a/apps/renderer/test/draft-attachments.test.ts
+++ b/apps/renderer/test/draft-attachments.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import { Schema } from "effect";
 
 import { ComposerInput, type AttachmentRef } from "@zuse/wire";
 
 import {
+  appendContextFileRef,
   finalizeDraftAttachments,
   finalizeDraftContextFiles,
   hasPendingAttachmentIds,
@@ -14,6 +16,29 @@ const makeFile = (name: string): File =>
   new File([new Uint8Array([1, 2, 3])], name, { type: "image/png" });
 
 describe("draft attachment finalization", () => {
+  it("preserves ComposerInput when appending an issue context file", () => {
+    const input = ComposerInput.make({
+      text: "inspect this issue",
+      attachments: [],
+      fileRefs: [],
+      skillRefs: [],
+    });
+
+    const finalized = appendContextFileRef(input, {
+      relPath: ".context/files/issue.md",
+      absPath: "/worktree/.context/files/issue.md",
+    });
+
+    expect(finalized.fileRefs).toEqual([
+      {
+        relPath: ".context/files/issue.md",
+        absPath: "/worktree/.context/files/issue.md",
+        kind: "file",
+      },
+    ]);
+    expect(() => Schema.validateSync(ComposerInput)(finalized)).not.toThrow();
+  });
+
   it("replaces pending attachment ids with uploaded refs", async () => {
     const input = ComposerInput.make({
       text: "inspect this",
@@ -44,6 +69,7 @@ describe("draft attachment finalization", () => {
 
     expect(finalized.attachments).toEqual([uploaded]);
     expect(hasPendingAttachmentIds(finalized)).toBe(false);
+    expect(() => Schema.validateSync(ComposerInput)(finalized)).not.toThrow();
   });
 
   it("throws instead of letting a stale pending id through", async () => {
@@ -106,5 +132,6 @@ describe("draft attachment finalization", () => {
       },
     ]);
     expect(hasPendingContextFileRefs(finalized)).toBe(false);
+    expect(() => Schema.validateSync(ComposerInput)(finalized)).not.toThrow();
   });
 });

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "0.12.5",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Add GPT-5.6 model support with high and extra-high reasoning effort options.",
+          "Harden local development startup and Electron reload behavior.",
+          "Fix image and context attachments failing validation when starting a new chat."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.12.4",
     "sections": [
       {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -3,10 +3,20 @@
     "version": "0.12.5",
     "sections": [
       {
+        "title": "Added",
+        "items": [
+          "Add GPT-5.6 model support with high and extra-high reasoning effort options."
+        ]
+      },
+      {
         "title": "Changed",
         "items": [
-          "Add GPT-5.6 model support with high and extra-high reasoning effort options.",
-          "Harden local development startup and Electron reload behavior.",
+          "Harden local development startup and Electron reload behavior."
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
           "Fix image and context attachments failing validation when starting a new chat."
         ]
       }

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- add GPT-5.6 model variants with high and extra-high reasoning effort support
- harden local development startup and Electron reload behavior
- preserve rich composer input identity after attachment and context finalization
- release Zuse v0.12.5 and update desktop/website changelog metadata

## Test coverage
- 100% of changed composer payload reconstruction paths directly covered
- 4 focused regression tests passed

## Verification
- `bun test`: 562 passed, 0 failed
- `bun run check-types`: 12 tasks passed
- web production build passed
- pre-landing review: no issues found
