### PR TITLE
Constrain active chat content rail

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -412,15 +412,22 @@ function MainShell() {
                 // All that progress is surfaced inline by `WorktreeSetupCard`
                 // at the top of the timeline, with the composer pinned at the
                 // bottom (no full-screen takeover).
-                <>
+                <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col px-3">
                   <ChatView sessionId={selectedSessionId} />
-                  <CostFooter sessionId={selectedSessionId} />
-                  <CliUpgradeBanner providerId={selectedSession.providerId} />
+                  <CostFooter
+                    sessionId={selectedSessionId}
+                    constrain={false}
+                  />
+                  <CliUpgradeBanner
+                    providerId={selectedSession.providerId}
+                    constrain={false}
+                  />
                   <ChatComposer
                     key={selectedSession.id}
                     session={selectedSession}
+                    constrain={false}
                   />
-                </>
+                </div>
               ) : (
                 <ChatLanding />
               )}

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -169,9 +169,11 @@ export function ChatComposer({
   onDraftSubmit,
   composerDraftKey,
   headerSlot,
+  constrain = true,
 }: {
   session: Session;
   composerDraftKey?: string;
+  constrain?: boolean;
   /**
    * Optional content rendered as a header row inside the composer frame, above
    * the editor. Used by the new-chat landing to host the "Create from…" picker
@@ -972,8 +974,13 @@ export function ChatComposer({
   return (
     <TooltipProvider delay={0}>
       {showCard ? (
-        <div className="shrink-0 px-3 pb-3 pt-2">
-          <div className="mx-auto w-full max-w-4xl">
+        <div
+          className={cn(
+            "shrink-0 pb-3 pt-2",
+            constrain ? "px-3" : undefined,
+          )}
+        >
+          <div className={constrain ? "mx-auto w-full max-w-4xl" : "w-full"}>
             {headPermission !== undefined ? (
               <PermissionCard
                 head={headPermission}
@@ -991,11 +998,14 @@ export function ChatComposer({
       ) : null}
       <div
         data-pane="composer"
-        className="shrink-0 px-3 pb-3 pt-2"
+        className={cn(
+          "shrink-0 pb-3 pt-2",
+          constrain ? "px-3" : undefined,
+        )}
         style={showCard ? { display: "none" } : undefined}
         aria-hidden={showCard || undefined}
       >
-        <div className="mx-auto w-full max-w-4xl">
+        <div className={constrain ? "mx-auto w-full max-w-4xl" : "w-full"}>
           {!isDraft ? (
             <AnnotationTray
               sessionId={sessionId}

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -724,13 +724,11 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
 
   const renderTimelineRow = useCallback(
     ({ item }: { item: ChatTimelineRow }) => (
-      <div className="mx-auto w-full max-w-4xl">
-        <TimelineRow
-          row={item}
-          sessionId={sessionId}
-          onFork={forkMenu.openAt}
-        />
-      </div>
+      <TimelineRow
+        row={item}
+        sessionId={sessionId}
+        onFork={forkMenu.openAt}
+      />
     ),
     [forkMenu.openAt, sessionId],
   );
@@ -741,7 +739,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
       worktreeId={session?.worktreeId ?? null}
     >
       <div className="relative flex min-h-0 flex-1">
-        <div className="flex h-full min-h-0 flex-1 flex-col">
+        <div className="relative flex h-full min-h-0 flex-1 flex-col">
           {messages.length === 0 ? (
             <div
               data-pane="chat"
@@ -799,7 +797,7 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
                 }
                 maintainVisibleContentPosition={{ data: true, size: false }}
                 onScroll={handleScroll}
-                className="h-full min-h-0 flex-1 overflow-x-hidden px-3 outline-none [overflow-anchor:none]"
+                className="h-full min-h-0 flex-1 overflow-x-hidden outline-none [overflow-anchor:none]"
                 data-pane="chat"
                 tabIndex={-1}
                 ListHeaderComponent={TIMELINE_HEADER}
@@ -814,14 +812,12 @@ export function ChatView({ sessionId }: { sessionId: SessionId }) {
               onDismiss={() => clearError(sessionId)}
             />
           ) : null}
-        </div>
-        <JumpToLatestPill
-          visible={showPill}
-          streaming={inFlight && showPill}
-          onClick={() => scrollToEnd(true)}
-        />
-        <div className="pointer-events-none absolute inset-x-0 bottom-3 z-20">
-          <div className="mx-auto flex w-full max-w-4xl justify-end px-3">
+          <JumpToLatestPill
+            visible={showPill}
+            streaming={inFlight && showPill}
+            onClick={() => scrollToEnd(true)}
+          />
+          <div className="pointer-events-none absolute inset-x-0 bottom-3 z-20 flex justify-end">
             <NextUnreadButton />
           </div>
         </div>

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -34,7 +34,13 @@ const UPGRADE_DOCS_URL: Record<ProviderId, string> = {
  * Renders nothing for `ok` / `unknown` so it's safe to mount unconditionally
  * inside the chat shell.
  */
-export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
+export function CliUpgradeBanner({
+  providerId,
+  constrain = true,
+}: {
+  providerId: ProviderId;
+  constrain?: boolean;
+}) {
   const availability = useProvidersStore((s) => s.availability);
   const refresh = useProvidersStore((s) => s.refresh);
   const refreshing = useProvidersStore((s) => s.loading);
@@ -71,7 +77,13 @@ export function CliUpgradeBanner({ providerId }: { providerId: ProviderId }) {
   };
 
   return (
-    <div className="mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-alert-warning-bg p-3">
+    <div
+      className={
+        constrain
+          ? "mx-3 mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-alert-warning-bg p-3"
+          : "mb-2 mt-1 flex flex-col gap-2 rounded-2xl bg-alert-warning-bg p-3"
+      }
+    >
       <div className="flex items-start gap-2.5">
         <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg text-warning">
           <HugeiconsIcon icon={CircleArrowUp01Icon} className="size-3.5" />

--- a/apps/renderer/src/components/cost-footer.tsx
+++ b/apps/renderer/src/components/cost-footer.tsx
@@ -89,7 +89,13 @@ interface AgentSlot {
  * "saved" figure (cost if every sub-agent turn had run on the main
  * model). Hidden when no usage rows exist.
  */
-export function CostFooter({ sessionId }: { sessionId: SessionId }) {
+export function CostFooter({
+  sessionId,
+  constrain = true,
+}: {
+  sessionId: SessionId;
+  constrain?: boolean;
+}) {
   const messages = useMessagesStore(
     (s) => s.messagesBySession[sessionId] ?? EMPTY,
   );
@@ -169,8 +175,14 @@ export function CostFooter({ sessionId }: { sessionId: SessionId }) {
   if (summary === null) return null;
 
   return (
-    <div className="px-3 pb-1 text-[10px] text-muted-foreground">
-      <div className="mx-auto w-full max-w-4xl">
+    <div
+      className={
+        constrain
+          ? "px-3 pb-1 text-[10px] text-muted-foreground"
+          : "pb-1 text-[10px] text-muted-foreground"
+      }
+    >
+      <div className={constrain ? "mx-auto w-full max-w-4xl" : "w-full"}>
         <span className="tabular-nums">
           {summary.lines.join(" · ")}
           {summary.saved > 0.005 ? (

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -28,7 +28,7 @@ export function JumpToLatestPill({
         "animate-in fade-in slide-in-from-bottom-1 duration-150 motion-reduce:animate-none",
       )}
     >
-      <div className="mx-auto flex w-full max-w-4xl justify-start px-3">
+      <div className="flex w-full justify-start">
         <button
           type="button"
           onClick={onClick}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -1038,14 +1038,14 @@ export function ErrorBubble({
     error.kind === "network" ? "bg-alert-warning-bg" : "bg-alert-error-bg";
 
   return (
-    <div className="px-4 py-2">
+    <div className="py-2">
       <div
         className={cn(
-          "max-w-[88%] rounded-xl px-3 py-2 text-xs text-foreground",
+          "w-full rounded-xl px-3 py-2 text-xs text-foreground",
           bg,
         )}
       >
-        <div className="flex items-start gap-2">
+        <div className="flex min-w-0 items-start gap-2">
           <HugeiconsIcon
             icon={AlertCircleIcon}
             strokeWidth={2}
@@ -1060,7 +1060,7 @@ export function ErrorBubble({
                 Provider error
               </span>
             )}
-            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
+            <pre className="min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground [overflow-wrap:anywhere]">
               {error.message || "(empty)"}
             </pre>
             {sessionId !== undefined && (
@@ -1098,7 +1098,7 @@ export function ErrorBubble({
             <button
               type="button"
               onClick={onDismiss}
-              className="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              className="shrink-0 rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
             >
               Dismiss
             </button>


### PR DESCRIPTION
## Summary
- Move the active chat surface onto one shared `max-w-4xl` content rail at the selected-chat root.
- Let timeline rows, provider errors, floating controls, footer, upgrade banner, and composer inherit that rail instead of each defining their own width wrapper.
- Keep long provider error output layout-safe so schema/JSON text does not overflow the chat width.

## Why
The provider error banner was constrained locally, but the underlying layout repeated chat width rules across multiple child components. This makes the active chat shell own the width once and keeps reusable components self-constraining only when rendered outside that shell.

## Validation
- `bun run --filter renderer check-types`
- `bun run --filter renderer test`
- `git diff --check`