### PR TITLE
Add production crash recovery tools

### DIFF
--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -125,12 +125,28 @@ export function installAppMenu(
   updateStatus: UpdateStatus = { kind: "idle" },
 ): void {
   const isMac = process.platform === "darwin";
-  const isDev = !app.isPackaged;
-
   const sendAction = (action: Exclude<MenuCommand, "close-tab">) => () => {
     const win = getWindow();
     if (win === null) return;
     win.webContents.send("menu:action", action);
+  };
+
+  const reloadWindow = () => {
+    const win = getWindow();
+    if (win === null) return;
+    win.webContents.reload();
+  };
+
+  const forceReloadWindow = () => {
+    const win = getWindow();
+    if (win === null) return;
+    win.webContents.reloadIgnoringCache();
+  };
+
+  const toggleDevTools = () => {
+    const win = getWindow();
+    if (win === null) return;
+    win.webContents.toggleDevTools();
   };
 
   const sendCloseTab = () => {
@@ -230,19 +246,27 @@ export function installAppMenu(
       },
       { type: "separator" },
       { role: "togglefullscreen" },
-      ...(isDev
-        ? ([
-            { type: "separator" },
-            {
-              label: "Developer",
-              submenu: [
-                { role: "reload" },
-                { role: "forceReload" },
-                { role: "toggleDevTools" },
-              ],
-            },
-          ] satisfies MenuItemConstructorOptions[])
-        : []),
+      { type: "separator" },
+      {
+        label: "Developer",
+        submenu: [
+          {
+            label: "Reload",
+            accelerator: "CmdOrCtrl+R",
+            click: reloadWindow,
+          },
+          {
+            label: "Force Reload",
+            accelerator: "CmdOrCtrl+Shift+R",
+            click: forceReloadWindow,
+          },
+          {
+            label: "Toggle Developer Tools",
+            accelerator: "CmdOrCtrl+Shift+I",
+            click: toggleDevTools,
+          },
+        ],
+      },
     ],
   };
 

--- a/apps/renderer/src/components/ui/error-boundary.tsx
+++ b/apps/renderer/src/components/ui/error-boundary.tsx
@@ -2,7 +2,7 @@ import { Component, type ReactNode } from "react";
 
 type ErrorBoundaryProps = {
   readonly children: ReactNode;
-  readonly fallback: ReactNode;
+  readonly fallback: ReactNode | ((error: Error) => ReactNode);
   readonly resetKey?: string;
   readonly onError?: (error: Error, info: { componentStack?: string }) => void;
 };
@@ -21,10 +21,7 @@ export class ErrorBoundary extends Component<
     return { error };
   }
 
-  componentDidCatch(
-    error: Error,
-    info: { componentStack?: string },
-  ): void {
+  componentDidCatch(error: Error, info: { componentStack?: string }): void {
     this.props.onError?.(error, info);
   }
 
@@ -38,7 +35,11 @@ export class ErrorBoundary extends Component<
   }
 
   render(): ReactNode {
-    if (this.state.error !== null) return this.props.fallback;
+    if (this.state.error !== null) {
+      return typeof this.props.fallback === "function"
+        ? this.props.fallback(this.state.error)
+        : this.props.fallback;
+    }
     return this.props.children;
   }
 }

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -5,8 +5,12 @@ import "@xterm/xterm/css/xterm.css";
 import "./styles.css";
 
 import { App } from "./app";
+import { ErrorBoundary } from "./components/ui/error-boundary.tsx";
 import { ToastProvider } from "./components/ui/toast.tsx";
-import { installRendererDiagnostics } from "./lib/diagnostics-recorder.ts";
+import {
+  installRendererDiagnostics,
+  recordDiagnosticEvent,
+} from "./lib/diagnostics-recorder.ts";
 
 if (import.meta.env.DEV) {
   void import("./lib/update-demo.ts").then((m) => m.installUpdateDemo());
@@ -17,10 +21,80 @@ installRendererDiagnostics();
 const root = document.getElementById("root");
 if (!root) throw new Error("#root missing in index.html");
 
+function formatCrashDetails(error: Error, componentStack?: string): string {
+  return [
+    `${error.name}: ${error.message}`,
+    error.stack ?? "",
+    componentStack ? `React component stack:\n${componentStack}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function RootCrashFallback({ error }: { readonly error: Error }) {
+  const details = formatCrashDetails(error);
+  const copyDetails = () => {
+    void navigator.clipboard?.writeText(details);
+  };
+
+  return (
+    <div className="flex h-dvh w-screen items-center justify-center bg-background px-6 text-foreground">
+      <main
+        aria-labelledby="root-crash-title"
+        className="w-full max-w-[560px] rounded-lg border border-border/70 bg-card p-6 shadow-xs"
+      >
+        <div className="space-y-2">
+          <p className="font-medium text-destructive text-sm">
+            Renderer crashed
+          </p>
+          <h1 id="root-crash-title" className="font-semibold text-xl">
+            Zuse hit a UI error.
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Your local data is still on disk. Reload the window, or copy these
+            crash details for debugging.
+          </p>
+        </div>
+        <pre className="mt-4 max-h-48 overflow-auto rounded-md border border-border/60 bg-muted/60 p-3 text-muted-foreground text-xs leading-5">
+          {details}
+        </pre>
+        <div className="mt-5 flex flex-wrap gap-2">
+          <button
+            className="inline-flex h-10 items-center justify-center rounded-md border border-primary bg-primary px-3 font-medium text-primary-foreground text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            type="button"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+          <button
+            className="inline-flex h-10 items-center justify-center rounded-md border border-border bg-muted px-3 font-medium text-foreground text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            type="button"
+            onClick={copyDetails}
+          >
+            Copy crash details
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+}
+
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <ToastProvider>
-      <App />
-    </ToastProvider>
+    <ErrorBoundary
+      fallback={(error) => <RootCrashFallback error={error} />}
+      onError={(error, info) => {
+        recordDiagnosticEvent({
+          level: "error",
+          source: "renderer.react.root",
+          message: `${error.name}: ${error.message}`,
+          detail: formatCrashDetails(error, info.componentStack),
+        });
+      }}
+    >
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/scripts/import-latest-prod-chat-to-dev.mjs
+++ b/scripts/import-latest-prod-chat-to-dev.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const appSupport = join(homedir(), "Library", "Application Support");
+const prodDb =
+  process.env.ZUSE_PROD_SQLITE ?? join(appSupport, "Zuse Alpha", "zuse.sqlite");
+const devDb =
+  process.env.ZUSE_DEV_SQLITE ??
+  join(appSupport, "Zuse Alpha (Dev)", "zuse.sqlite");
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+const backupDir = join(dirname(devDb), `debug-import-backup-${timestamp}`);
+
+function runSql(dbPath, sql) {
+  return execFileSync("sqlite3", ["-batch", dbPath, sql], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function quoteSql(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function requireFile(path, label) {
+  if (!existsSync(path)) {
+    throw new Error(`${label} does not exist: ${path}`);
+  }
+}
+
+function backupDevDatabase() {
+  mkdirSync(backupDir, { recursive: true });
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const from = `${devDb}${suffix}`;
+    if (!existsSync(from)) continue;
+    copyFileSync(from, join(backupDir, `zuse.sqlite${suffix}`));
+  }
+}
+
+function tableCount(dbPath, table, where) {
+  return runSql(dbPath, `SELECT count(*) FROM ${table} WHERE ${where};`);
+}
+
+requireFile(prodDb, "Production SQLite database");
+requireFile(devDb, "Dev SQLite database");
+
+const chatId = runSql(
+  prodDb,
+  `
+  SELECT c.id
+  FROM chats c
+  JOIN sessions s ON s.chat_id = c.id
+  GROUP BY c.id
+  HAVING
+    SUM(CASE WHEN s.provider_id = 'codex' THEN 1 ELSE 0 END) > 0
+    AND SUM(CASE WHEN s.provider_id = 'claude' OR s.model LIKE '%fable%' THEN 1 ELSE 0 END) > 0
+  ORDER BY c.updated_at DESC
+  LIMIT 1;
+  `,
+);
+
+if (!chatId) {
+  throw new Error(
+    "Could not find a production chat with codex and fable sessions.",
+  );
+}
+
+const sessionIds = runSql(
+  prodDb,
+  `SELECT group_concat(id, ',') FROM sessions WHERE chat_id = ${quoteSql(chatId)};`,
+)
+  .split(",")
+  .filter(Boolean);
+
+if (sessionIds.length === 0) {
+  throw new Error(`Selected chat has no sessions: ${chatId}`);
+}
+
+backupDevDatabase();
+
+const prodDbSql = quoteSql(prodDb);
+const chatIdSql = quoteSql(chatId);
+const importSql = `
+PRAGMA foreign_keys = ON;
+ATTACH DATABASE ${prodDbSql} AS prod;
+
+BEGIN IMMEDIATE;
+
+CREATE TEMP TABLE selected_sessions(id TEXT PRIMARY KEY);
+INSERT INTO selected_sessions(id)
+SELECT id FROM prod.sessions WHERE chat_id = ${chatIdSql};
+
+CREATE TEMP TABLE selected_messages(id TEXT PRIMARY KEY);
+INSERT INTO selected_messages(id)
+SELECT id FROM prod.messages WHERE session_id IN (SELECT id FROM selected_sessions);
+
+CREATE TEMP TABLE selected_attachments(id TEXT PRIMARY KEY);
+INSERT INTO selected_attachments(id)
+SELECT id FROM prod.attachments WHERE session_id IN (SELECT id FROM selected_sessions)
+UNION
+SELECT attachment_id
+FROM prod.message_attachments
+WHERE message_id IN (SELECT id FROM selected_messages);
+
+INSERT OR REPLACE INTO projects
+SELECT p.*
+FROM prod.projects p
+JOIN prod.chats c ON c.project_id = p.id
+WHERE c.id = ${chatIdSql};
+
+INSERT OR REPLACE INTO worktrees
+SELECT DISTINCT w.*
+FROM prod.worktrees w
+WHERE w.id IN (
+  SELECT worktree_id FROM prod.chats WHERE id = ${chatIdSql} AND worktree_id IS NOT NULL
+  UNION
+  SELECT worktree_id FROM prod.sessions WHERE id IN (SELECT id FROM selected_sessions) AND worktree_id IS NOT NULL
+);
+
+INSERT OR REPLACE INTO chats (
+  id,
+  project_id,
+  worktree_id,
+  title,
+  active_session_id,
+  archived_at,
+  created_at,
+  updated_at,
+  archived_worktree_json,
+  last_message_at,
+  last_read_at,
+  origin_session_id
+)
+SELECT
+  id,
+  project_id,
+  worktree_id,
+  title,
+  NULL,
+  archived_at,
+  created_at,
+  updated_at,
+  archived_worktree_json,
+  last_message_at,
+  last_read_at,
+  NULL
+FROM prod.chats
+WHERE id = ${chatIdSql};
+
+INSERT OR REPLACE INTO sessions (
+  id,
+  project_id,
+  title,
+  provider_id,
+  model,
+  status,
+  archived_at,
+  created_at,
+  updated_at,
+  cursor,
+  resume_strategy,
+  runtime_mode,
+  agents_json,
+  worktree_id,
+  permission_mode,
+  tool_search,
+  parent_session_id,
+  chat_id,
+  forked_from_session_id,
+  forked_from_message_id,
+  queue_paused
+)
+SELECT
+  id,
+  project_id,
+  title,
+  provider_id,
+  model,
+  status,
+  archived_at,
+  created_at,
+  updated_at,
+  cursor,
+  resume_strategy,
+  runtime_mode,
+  agents_json,
+  worktree_id,
+  permission_mode,
+  tool_search,
+  NULL,
+  chat_id,
+  NULL,
+  forked_from_message_id,
+  queue_paused
+FROM prod.sessions
+WHERE id IN (SELECT id FROM selected_sessions);
+
+UPDATE sessions
+SET
+  parent_session_id = (
+    SELECT parent_session_id FROM prod.sessions ps WHERE ps.id = sessions.id
+  ),
+  forked_from_session_id = (
+    SELECT forked_from_session_id FROM prod.sessions ps WHERE ps.id = sessions.id
+  )
+WHERE id IN (SELECT id FROM selected_sessions);
+
+INSERT OR REPLACE INTO attachments
+SELECT *
+FROM prod.attachments
+WHERE id IN (SELECT id FROM selected_attachments);
+
+INSERT OR REPLACE INTO messages
+SELECT *
+FROM prod.messages
+WHERE id IN (SELECT id FROM selected_messages);
+
+INSERT OR REPLACE INTO message_attachments
+SELECT *
+FROM prod.message_attachments
+WHERE message_id IN (SELECT id FROM selected_messages)
+  AND attachment_id IN (SELECT id FROM selected_attachments);
+
+INSERT OR REPLACE INTO permission_decisions
+SELECT *
+FROM prod.permission_decisions
+WHERE session_id IN (SELECT id FROM selected_sessions);
+
+INSERT OR REPLACE INTO queued_messages
+SELECT *
+FROM prod.queued_messages
+WHERE session_id IN (SELECT id FROM selected_sessions);
+
+DELETE FROM events
+WHERE stream_kind = 'session'
+  AND stream_id IN (SELECT id FROM selected_sessions);
+
+INSERT INTO events (
+  event_id,
+  stream_kind,
+  stream_id,
+  stream_version,
+  type,
+  occurred_at,
+  actor,
+  payload_json
+)
+SELECT
+  event_id,
+  stream_kind,
+  stream_id,
+  stream_version,
+  type,
+  occurred_at,
+  actor,
+  payload_json
+FROM prod.events
+WHERE stream_kind = 'session'
+  AND stream_id IN (SELECT id FROM selected_sessions)
+ORDER BY sequence;
+
+UPDATE chats
+SET
+  active_session_id = (
+    SELECT active_session_id FROM prod.chats pc WHERE pc.id = chats.id
+  ),
+  origin_session_id = (
+    SELECT origin_session_id FROM prod.chats pc WHERE pc.id = chats.id
+  )
+WHERE id = ${chatIdSql};
+
+COMMIT;
+DETACH DATABASE prod;
+`;
+
+runSql(devDb, importSql);
+
+const sessionWhere = `chat_id = ${quoteSql(chatId)}`;
+const importedSessions = Number(tableCount(devDb, "sessions", sessionWhere));
+const importedMessages = Number(
+  runSql(
+    devDb,
+    `SELECT count(*) FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE chat_id = ${chatIdSql});`,
+  ),
+);
+const importedEvents = Number(
+  runSql(
+    devDb,
+    `SELECT count(*) FROM events WHERE stream_kind = 'session' AND stream_id IN (SELECT id FROM sessions WHERE chat_id = ${chatIdSql});`,
+  ),
+);
+
+console.log(`Imported production chat ${chatId}`);
+console.log(`Dev database backup: ${backupDir}`);
+console.log(`Sessions: ${importedSessions}`);
+console.log(`Messages: ${importedMessages}`);
+console.log(`Events: ${importedEvents}`);
+console.log(`Dev database size: ${statSync(devDb).size} bytes`);


### PR DESCRIPTION
## Summary
- add a root renderer crash boundary with reload and copy-crash-details actions
- expose reload and DevTools toggling from the packaged app menu
- add a repeatable helper to import the latest relevant production chat into the dev SQLite database with a dev DB backup

## Why
Production renderer crashes currently take down the whole UI without a stable recovery surface. This gives the app a last-resort UI, captures React component-stack details in renderer diagnostics, and makes packaged builds inspectable via Cmd/Ctrl+Shift+I.

## Validation
- bun run check-types
- cd apps/renderer && bun run check-types
- cd apps/desktop && bun run check-types
- bun run lint
- node --check scripts/import-latest-prod-chat-to-dev.mjs
- dev SQLite import completed: 3 sessions, 1140 messages, 1140 events
- SQLite integrity check returned ok
