### PR TITLE
Release v0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.6]
+
+### Changed
+- Add production crash recovery tools (#317)
+- Quiet live tool-call rows in the chat stream (#316)
+- better animations (#315)
+- Constrain active chat content rail (#314)
+- Agents notes (#313)
+
 ## [0.12.5]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "productName": "Zuse Alpha",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.12.6",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Add production crash recovery tools (#317)",
+          "Quiet live tool-call rows in the chat stream (#316)",
+          "better animations (#315)",
+          "Constrain active chat content rail (#314)",
+          "Agents notes (#313)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.12.5",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "electron-updater": "^6.3.9",

--- a/scripts/release-new-version.mjs
+++ b/scripts/release-new-version.mjs
@@ -26,14 +26,14 @@ function git(args) {
   }).trim();
 }
 
-function run(command, args) {
+function run(command, args, cwd = root) {
   const rendered = [command, ...args].join(" ");
   if (dryRun) {
     console.log(`[dry-run] ${rendered}`);
     return "";
   }
   return execFileSync(command, args, {
-    cwd: root,
+    cwd,
     encoding: "utf8",
     stdio: "inherit",
   });
@@ -150,6 +150,7 @@ if (!changelog.includes(`## [${nextVersion}]`)) {
 }
 
 run("node", ["scripts/generate-website-changelog.mjs"]);
+run("bunx", ["fumadocs-mdx"], join(root, "apps/web"));
 run("bun", ["run", "check-types"]);
 run("git", ["add", "CHANGELOG.md", "apps/desktop/package.json", "bun.lock", "apps/web", "scripts/release-new-version.mjs", ".codex/skills/release-new-version"]);
 run("git", ["commit", "-m", `Release v${nextVersion}`]);


### PR DESCRIPTION
## Summary
- release Zuse v0.12.6
- update CHANGELOG.md and package metadata
- generate the web documentation source before type validation

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.12.6 after this PR lands.