### PR TITLE
Remove orchestration prefixes from provider prompts

### DIFF
--- a/apps/server/src/provider/layers/message-store.ts
+++ b/apps/server/src/provider/layers/message-store.ts
@@ -720,9 +720,6 @@ const serializeAnnotations = (
     .join("\n\n");
 };
 
-const originPromptPreamble = (origin: MessageOrigin): string =>
-  `[Zuse: this message was sent by another agent (provider "${origin.providerId}", session ${origin.sessionId}) from a different chat thread via the zuse-orchestration MCP server — it is not from the human user.]`;
-
 const formatProviderFailure = (cause: unknown): string => {
   if (cause instanceof Error) return cause.message;
   if (cause !== null && typeof cause === "object") {
@@ -2131,10 +2128,7 @@ export const MessageStoreLive = Layer.scoped(
             };
           }
         }
-        const promptForProvider =
-          origin !== undefined && input.initialPrompt !== undefined
-            ? `[Zuse: this task was assigned by an orchestrating agent (provider "${origin.providerId}", session ${origin.sessionId}) in a different chat thread via the zuse-orchestration MCP server — it is not from the human user.]\n\n${input.initialPrompt}`
-            : input.initialPrompt;
+        const promptForProvider = input.initialPrompt;
         const background = input.background === true;
         const resumeCursor = input.resumeCursor ?? null;
         const resumeStrategy: ResumeStrategy =
@@ -3794,7 +3788,6 @@ export const MessageStoreLive = Layer.scoped(
         // persisted `text` above stays clean; the structured `annotations`
         // array drives the rendered bubble.
         const sendText = [
-          origin !== undefined ? originPromptPreamble(origin) : null,
           annotationList.length > 0
             ? serializeAnnotations(annotationList)
             : null,

--- a/apps/server/test/message-store.test.ts
+++ b/apps/server/test/message-store.test.ts
@@ -525,7 +525,7 @@ describe("MessageStore — chat & session lifecycle", () => {
     });
   });
 
-  it("createChat stamps origin + prefixes the provider prompt for spawned chats", async () => {
+  it("createChat stamps origin without changing the provider prompt for spawned chats", async () => {
     await withRuntime(async (run) => {
       const result = await run(
         Effect.gen(function* () {
@@ -555,11 +555,7 @@ describe("MessageStore — chat & session lifecycle", () => {
           providerId: "claude",
         },
       });
-      expect(
-        providerStartInputs
-          .at(-1)
-          ?.initialPrompt?.startsWith("[Zuse: this task was assigned"),
-      ).toBe(true);
+      expect(providerStartInputs.at(-1)?.initialPrompt).toBe("do the spawned task");
     });
   });
 
@@ -963,7 +959,7 @@ describe("MessageStore — chat & session lifecycle", () => {
     });
   });
 
-  it("sendMessage with origin persists origin and prefixes only the provider text", async () => {
+  it("sendMessage with origin persists origin without changing provider text", async () => {
     await withRuntime(async (run) => {
       const { initialSession, chat } = await run(
         Effect.flatMap(store, (s) =>
@@ -1005,10 +1001,7 @@ describe("MessageStore — chat & session lifecycle", () => {
         origin,
       });
       const sent = providerSentTexts.at(-1) ?? "";
-      expect(
-        sent.startsWith("[Zuse: this message was sent by another agent"),
-      ).toBe(true);
-      expect(sent.endsWith("do the thing")).toBe(true);
+      expect(sent).toBe("do the thing");
     });
   });
 


### PR DESCRIPTION
## What changed

- Removed internal MCP/orchestration attribution prefixes from provider-visible prompts.
- Preserved structured message origin metadata and chat lineage.
- Kept annotation serialization unchanged.
- Updated message-store expectations to require the original provider text.

## Why

The attribution was already represented as structured metadata and MCP calls already render as structured tool events. Injecting it into the prompt polluted messages across Claude, Codex, Grok, and other providers.

## Validation

- `bun test apps/server/test` — 306 passed
- `bun run --cwd apps/server check-types` — passed
- `bunx biome check apps/server/src/provider/layers/message-store.ts apps/server/test/message-store.test.ts` — passed