### PR TITLE
Prevent desktop relay port collisions

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -52,6 +52,7 @@ import {
 	NotchTrayController,
 	type NotchTrayItem,
 } from "./notch-tray-controller.ts";
+import { resolveDesktopRelayPort } from "./relay-port.ts";
 import {
 	ensureSshEnvironment,
 	listSshHosts,
@@ -694,7 +695,10 @@ const authShell = {
 		}),
 };
 
-function createMainWindow() {
+async function createMainWindow() {
+	const relayPort = await resolveDesktopRelayPort({
+		configuredPort: process.env.ZUSE_DESKTOP_WS_PORT,
+	});
 	const isMac = process.platform === "darwin";
 	mainWindow = new BrowserWindow({
 		width: 1280,
@@ -1404,7 +1408,7 @@ function createMainWindow() {
 	const serverProtocol = electronServerProtocolLayer(
 		mainWindow.webContents,
 	).pipe(Layer.provide(RpcSerialization.layerJson));
-	const relayWsPort = Number(process.env.ZUSE_DESKTOP_WS_PORT ?? 8787);
+	const relayWsPort = relayPort.port;
 	const relayWsProtocol = wsServerProtocolLayer({
 		port: relayWsPort,
 		host: "127.0.0.1",
@@ -1414,6 +1418,11 @@ function createMainWindow() {
 		relayWsPort,
 		userData: app.getPath("userData"),
 	});
+	if (relayPort.fellBack) {
+		appendRemoteConnectionLog("desktop.runtime.port_fallback", {
+			relayWsPort,
+		});
+	}
 
 	runtimeFiber = Effect.runFork(
 		Layer.launch(
@@ -1841,7 +1850,7 @@ void app.whenReady().then(async () => {
 	});
 
 	installAppMenu(() => mainWindow, lastAccelerators, getLastStatus());
-	createMainWindow();
+	await createMainWindow();
 	if (mainWindow !== null) {
 		if (isDevelopment) {
 			// Wire the dev console helper (window.__zuseUpdateDemo) to a real
@@ -1854,7 +1863,7 @@ void app.whenReady().then(async () => {
 
 	app.on("activate", () => {
 		if (mainWindow === null) {
-			createMainWindow();
+			void createMainWindow();
 		}
 	});
 });

--- a/apps/desktop/src/relay-port.ts
+++ b/apps/desktop/src/relay-port.ts
@@ -1,0 +1,70 @@
+import * as net from "node:net";
+import { DEFAULT_LOCAL_DESKTOP_PORT } from "@zuse/contracts";
+
+const FALLBACK_PORT_ATTEMPTS = 10;
+
+const canBindLoopback = (port: number): Promise<boolean> =>
+	new Promise((resolve) => {
+		const server = net.createServer();
+		const finish = (available: boolean) => {
+			server.removeAllListeners();
+			if (server.listening) {
+				server.close(() => resolve(available));
+				return;
+			}
+			resolve(available);
+		};
+		server.once("error", () => finish(false));
+		server.once("listening", () => finish(true));
+		server.listen(port, "127.0.0.1");
+	});
+
+/**
+ * The desktop relay is useful for paired devices, but it must never stop the
+ * local Electron application from opening. A user can legitimately have an
+ * unrelated development server on the conventional relay port, so packaged
+ * builds move to a nearby available port before booting the shared runtime.
+ *
+ * An explicit port remains authoritative: it is normally supplied by tests or
+ * operators who need a stable endpoint and should fail loudly if unavailable.
+ */
+export const resolveDesktopRelayPort = async (input: {
+	readonly configuredPort: string | undefined;
+	/** Test seam; production always uses the conventional relay port. */
+	readonly defaultPort?: number;
+}): Promise<{ readonly port: number; readonly fellBack: boolean }> => {
+	const configured = input.configuredPort?.trim();
+	if (configured !== undefined && configured.length > 0) {
+		const port = Number(configured);
+		if (Number.isInteger(port) && port >= 0 && port <= 65_535) {
+			return { port, fellBack: false };
+		}
+		throw new Error("ZUSE_DESKTOP_WS_PORT must be an integer from 0 to 65535");
+	}
+
+	const defaultPort = input.defaultPort ?? DEFAULT_LOCAL_DESKTOP_PORT;
+	for (let offset = 0; offset < FALLBACK_PORT_ATTEMPTS; offset += 1) {
+		const port = defaultPort + offset;
+		if (await canBindLoopback(port)) return { port, fellBack: offset > 0 };
+	}
+
+	// Asking the OS for a port is the final fallback when the conventional
+	// range is busy. The selected port is passed through the runtime's LAN
+	// config, so pairing and relay registration advertise the same endpoint.
+	const server = net.createServer();
+	const port = await new Promise<number>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (address === null || typeof address === "string") {
+				reject(new Error("Could not allocate a loopback relay port"));
+				return;
+			}
+			resolve(address.port);
+		});
+	});
+	await new Promise<void>((resolve, reject) =>
+		server.close((error) => (error === undefined ? resolve() : reject(error))),
+	);
+	return { port, fellBack: true };
+};

--- a/apps/desktop/test/unit/relay-port.test.ts
+++ b/apps/desktop/test/unit/relay-port.test.ts
@@ -1,0 +1,51 @@
+import * as net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveDesktopRelayPort } from "../../src/relay-port.ts";
+
+const servers: net.Server[] = [];
+
+const listen = (port: number): Promise<net.Server> =>
+	new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			servers.push(server);
+			resolve(server);
+		});
+	});
+
+afterEach(async () => {
+	await Promise.all(
+		servers
+			.splice(0)
+			.map(
+				(server) =>
+					new Promise<void>((resolve) => server.close(() => resolve())),
+			),
+	);
+});
+
+describe("resolveDesktopRelayPort", () => {
+	it("moves the default relay listener when its conventional port is occupied", async () => {
+		const occupied = await listen(0);
+		const address = occupied.address();
+		expect(address).not.toBeNull();
+		expect(typeof address).not.toBe("string");
+		const preferredPort = (address as net.AddressInfo).port;
+
+		const resolved = await resolveDesktopRelayPort({
+			configuredPort: undefined,
+			defaultPort: preferredPort,
+		});
+
+		expect(resolved.port).not.toBe(preferredPort);
+		expect(resolved.fellBack).toBe(true);
+	});
+
+	it("keeps an explicit relay port unchanged", async () => {
+		await expect(
+			resolveDesktopRelayPort({ configuredPort: "0" }),
+		).resolves.toEqual({ port: 0, fellBack: false });
+	});
+});

--- a/apps/mobile/app/connect/manual.tsx
+++ b/apps/mobile/app/connect/manual.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { DEFAULT_LOCAL_DESKTOP_PORT } from "@zuse/contracts";
 import { router } from "expo-router";
+import { useMemo, useState } from "react";
 import { KeyboardAvoidingView, ScrollView, Text, TextInput, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -15,7 +16,7 @@ export default function ManualConnectScreen() {
   const insets = useSafeAreaInsets();
   const add = useConnectionsStore((state) => state.add);
   const [host, setHost] = useState("127.0.0.1");
-  const [port, setPort] = useState("8787");
+  const [port, setPort] = useState(String(DEFAULT_LOCAL_DESKTOP_PORT));
   const [token, setToken] = useState("");
 
   const canAdd = useMemo(
@@ -54,7 +55,7 @@ export default function ManualConnectScreen() {
             value={port}
             onChangeText={setPort}
             keyboardType="number-pad"
-            placeholder="8787"
+            placeholder={String(DEFAULT_LOCAL_DESKTOP_PORT)}
           />
           <View className="ml-4 h-px bg-border" />
           <Field

--- a/apps/mobile/app/smoke.tsx
+++ b/apps/mobile/app/smoke.tsx
@@ -1,8 +1,11 @@
-import { MessageEnvelope } from "@zuse/contracts";
+import {
+  DEFAULT_LOCAL_DESKTOP_PORT,
+  MessageEnvelope,
+} from "@zuse/contracts";
+import { Effect, Fiber, Result, Schema, Stream } from "effect";
 import { CheckCircle2, CircleAlert } from "lucide-react-native";
 import { useCallback, useEffect, useState } from "react";
 import { ScrollView, Text, View } from "react-native";
-import { Effect, Fiber, Result, Schema, Stream } from "effect";
 
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -169,7 +172,10 @@ const runLiveProbe = async (
 ) => {
   try {
     const client = await Effect.runPromise(
-      getConnectionClient({ host: "127.0.0.1", port: 8787 }),
+      getConnectionClient({
+        host: "127.0.0.1",
+        port: DEFAULT_LOCAL_DESKTOP_PORT,
+      }),
     );
     const ping = await Effect.runPromise(client["ping.ping"]({}));
     const projects = await Effect.runPromise(client["workspace.list"]({}));

--- a/apps/mobile/src/lib/connection-params.ts
+++ b/apps/mobile/src/lib/connection-params.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCAL_DESKTOP_PORT } from "@zuse/contracts";
 import type { ConnectionRecord } from "~/store/connections";
 import type { WsProtocolOptions } from "~/rpc/ws-protocol";
 
@@ -6,8 +7,9 @@ export const normalizeConnParam = (
 ): string => (Array.isArray(param) ? (param[0] ?? "") : (param ?? ""));
 
 export const parseConnectionKey = (key: string): WsProtocolOptions => {
-  const [host = "127.0.0.1", port = "8787"] = key.split(":");
-  return { host, port: Number(port) || 8787 };
+	const [host = "127.0.0.1", port = String(DEFAULT_LOCAL_DESKTOP_PORT)] =
+		key.split(":");
+	return { host, port: Number(port) || DEFAULT_LOCAL_DESKTOP_PORT };
 };
 
 export const optionsForConnection = (

--- a/apps/mobile/src/offline/cache-utils.ts
+++ b/apps/mobile/src/offline/cache-utils.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_LOCAL_DESKTOP_PORT } from "@zuse/contracts";
+
 export const slugConnectionKey = (key: string): string =>
   key.replace(/[^a-zA-Z0-9._-]+/g, "_");
 
@@ -14,7 +16,7 @@ export const parsePairingUrl = (
     : undefined;
   return {
     host: normalized.hostname,
-    port: Number(normalized.port || "8787"),
+    port: Number(normalized.port || String(DEFAULT_LOCAL_DESKTOP_PORT)),
     token
   };
 };

--- a/apps/mobile/src/store/connections.ts
+++ b/apps/mobile/src/store/connections.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCAL_DESKTOP_PORT } from "@zuse/contracts";
 import * as SecureStore from "expo-secure-store";
 import { create } from "zustand";
 import { Effect } from "effect";
@@ -53,7 +54,7 @@ const parseHostPort = (wsBaseUrl: string): { host: string; port: number } => {
       port: Number(url.port) || (url.protocol === "wss:" ? 443 : 80),
     };
   } catch {
-    return { host: "127.0.0.1", port: 8787 };
+    return { host: "127.0.0.1", port: DEFAULT_LOCAL_DESKTOP_PORT };
   }
 };
 

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -13,6 +13,7 @@
 import { pathToFileURL } from "node:url";
 
 import { NodeRuntime } from "@effect/platform-node";
+import { DEFAULT_LOCAL_DESKTOP_PORT } from "@zuse/contracts";
 import { Effect, Layer } from "effect";
 
 import { resolveAuthPolicy } from "./lan-auth/policy.ts";
@@ -35,7 +36,7 @@ const resolveUserData = (): string => {
 };
 
 export const runHeadlessServer = (): void => {
-	const port = Number(process.env.ZUSE_PORT ?? 8787);
+	const port = Number(process.env.ZUSE_PORT ?? DEFAULT_LOCAL_DESKTOP_PORT);
 	const host = process.env.ZUSE_HOST ?? "127.0.0.1";
 	const userData = resolveUserData();
 	const policy = resolveAuthPolicy(host);

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -1,6 +1,9 @@
+import {
+  DEFAULT_LOCAL_DESKTOP_PORT,
+  RelayPaths,
+  type EnvironmentId,
+} from "@zuse/contracts";
 import { Clock, Context, Data, Effect, Fiber, Layer, Ref } from "effect";
-
-import { RelayPaths, type EnvironmentId } from "@zuse/contracts";
 
 import { AppPaths } from "../app-paths.ts";
 import { AuthService } from "../auth/services/auth-service.ts";
@@ -96,7 +99,7 @@ const postJson = <A>(
 
 const computeEndpoint = (config: LanAuthConfigShape) => {
   const host = config.advertisedHost ?? "127.0.0.1";
-  const port = config.port ?? 8787;
+  const port = config.port ?? DEFAULT_LOCAL_DESKTOP_PORT;
   return {
     httpBaseUrl: `http://${host}:${port}`,
     wsBaseUrl: `ws://${host}:${port}`,
@@ -105,7 +108,7 @@ const computeEndpoint = (config: LanAuthConfigShape) => {
 
 const computeOrigin = (config: LanAuthConfigShape) => ({
   localHttpHost: "127.0.0.1",
-  localHttpPort: config.port ?? 8787,
+  localHttpPort: config.port ?? DEFAULT_LOCAL_DESKTOP_PORT,
 });
 
 export const RelayLinkServiceLive: Layer.Layer<

--- a/packages/contracts/src/connect.ts
+++ b/packages/contracts/src/connect.ts
@@ -3,6 +3,9 @@ import { Schema } from "effect";
 
 import { EnvironmentId } from "./ids.ts";
 
+/** Conventional loopback port for a local desktop environment. */
+export const DEFAULT_LOCAL_DESKTOP_PORT = 47837;
+
 // ---------------------------------------------------------------------------
 // Environment abstraction
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Move the conventional local desktop relay port to `47837`.
- Fall back to an available loopback port when the default is occupied.
- Keep desktop, headless server, and mobile local connection defaults aligned.

## Root cause

The desktop treated a bind failure on its local relay port as fatal. Common development processes can claim the former default port, causing the production app to exit immediately.

## Validation

- `bun run check-types` and `bun run test` in `apps/desktop`
- `bun run check-types` and `bun run test:unit` in `apps/mobile`
- `bun run check-types` in `apps/server`
- Rebuilt Electron launch verified with the previous port occupied and with the new default port