### PR TITLE
Add fullscreen environment summary

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -304,12 +304,15 @@ function MainShell() {
   const isFullScreen = useUiStore((s) => s.isFullScreen);
   const environmentSummaryOpen = useUiStore((s) => s.environmentSummaryOpen);
   const environmentSummaryFits = useMediaQuery({ min: 1180 });
-  const showEnvironmentSummary =
+  const environmentSummaryAvailable =
     isFullScreen &&
-    environmentSummaryOpen &&
     environmentSummaryFits &&
     selectedSessionId !== null &&
     activeMainTab === "chat";
+  const showEnvironmentSummary =
+    environmentSummaryAvailable &&
+    environmentSummaryOpen &&
+    !rightSidebarOpen;
 
   // Switching projects closes the file tab — its path wouldn't resolve
   // under the new project's root anyway.
@@ -449,7 +452,27 @@ function MainShell() {
                       constrain={false}
                     />
                   </div>
-                  {showEnvironmentSummary ? <EnvironmentSummary /> : null}
+                  {environmentSummaryAvailable ? (
+                    <div
+                      className={`shrink-0 overflow-hidden transition-[width,opacity] duration-150 ease-[cubic-bezier(0.165,0.84,0.44,1)] motion-reduce:transition-none ${
+                        showEnvironmentSummary
+                          ? "w-[18.75rem] opacity-100"
+                          : "w-0 opacity-0"
+                      }`}
+                      aria-hidden={!showEnvironmentSummary}
+                      inert={!showEnvironmentSummary}
+                    >
+                      <div
+                        className={`w-[18.75rem] transition-transform duration-150 ease-[cubic-bezier(0.165,0.84,0.44,1)] motion-reduce:transition-none ${
+                          showEnvironmentSummary
+                            ? "translate-x-0"
+                            : "translate-x-3"
+                        }`}
+                      >
+                        <EnvironmentSummary />
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               ) : (
                 <ChatLanding />

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
 import { Effect } from "effect";
+import { useEffect, useRef } from "react";
 import {
   Group,
   Panel,
@@ -7,20 +7,19 @@ import {
   useDefaultLayout,
   usePanelRef,
 } from "react-resizable-panels";
-
+import { ArchiveDirtyWorktreeDialogHost } from "./components/archive-dirty-worktree-dialog.tsx";
+import { ArchivedChatsPage } from "./components/archived-chats-page.tsx";
 import { ChatComposer } from "./components/chat-composer";
 import { ChatLanding } from "./components/chat-landing.tsx";
 import { ChatSwitcher } from "./components/chat-switcher.tsx";
-import { ArchiveDirtyWorktreeDialogHost } from "./components/archive-dirty-worktree-dialog.tsx";
-import { ArchivedChatsPage } from "./components/archived-chats-page.tsx";
-import { CliUpgradeBanner } from "./components/cli-upgrade-banner.tsx";
-import { TooltipProvider } from "./components/ui/tooltip.tsx";
 import { ChatView } from "./components/chat-view";
+import { CliUpgradeBanner } from "./components/cli-upgrade-banner.tsx";
 import { CostFooter } from "./components/cost-footer";
+import { EnvironmentSummary } from "./components/environment-summary.tsx";
 import { FileEditor } from "./components/file-editor.tsx";
 import { closeActiveChatTab, MainTabs } from "./components/main-tabs.tsx";
-import { OnboardingWizard } from "./components/onboarding/onboarding-wizard.tsx";
 import { NotchTrayBridge } from "./components/notch-tray-bridge.tsx";
+import { OnboardingWizard } from "./components/onboarding/onboarding-wizard.tsx";
 import { ProjectsSidebar } from "./components/projects-sidebar";
 import { ProviderUpdatesToast } from "./components/provider-updates-toast.tsx";
 import { RightPane } from "./components/right-pane";
@@ -30,13 +29,15 @@ import {
   SidebarPeekTrigger,
 } from "./components/sidebar-peek.tsx";
 import { TopBarLeft, TopBarMain, TopBarRight } from "./components/top-bar.tsx";
+import { TooltipProvider } from "./components/ui/tooltip.tsx";
 import { UpdateBanner } from "./components/update-banner.tsx";
 import { UsageDashboard } from "./components/usage-dashboard.tsx";
 import { useKeybindingDispatch } from "./hooks/use-keybinding-dispatch.ts";
+import { useMediaQuery } from "./hooks/use-media-query.ts";
 import { useMenuShortcuts } from "./hooks/use-menu-shortcuts.ts";
 import { useReportRunningAgents } from "./hooks/use-report-running-agents.ts";
-import { getRpcClient } from "./lib/rpc-client.ts";
 import { AppearanceController } from "./lib/appearance.tsx";
+import { getRpcClient } from "./lib/rpc-client.ts";
 import { useAuthStore } from "./store/auth.ts";
 import { useKeybindingsStore } from "./store/keybindings.ts";
 import { usePermissionsStore } from "./store/permissions.ts";
@@ -51,7 +52,7 @@ const PANEL_GROUP_ID = "zuse.shell.v3";
 const PANEL_IDS = ["projects", "main", "files"];
 
 const SIDEBAR_ANIM_MS = 150;
-const easeOutQuart = (t: number) => 1 - Math.pow(1 - t, 4);
+const easeOutQuart = (t: number) => 1 - (1 - t) ** 4;
 
 /**
  * Animate a collapsible side panel open/closed by driving the library's own
@@ -300,6 +301,15 @@ function MainShell() {
   const setLeftSidebarOpen = useUiStore((s) => s.setLeftSidebarOpen);
   const rightSidebarOpen = useUiStore((s) => s.rightSidebarOpen);
   const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
+  const isFullScreen = useUiStore((s) => s.isFullScreen);
+  const environmentSummaryOpen = useUiStore((s) => s.environmentSummaryOpen);
+  const environmentSummaryFits = useMediaQuery({ min: 1180 });
+  const showEnvironmentSummary =
+    isFullScreen &&
+    environmentSummaryOpen &&
+    environmentSummaryFits &&
+    selectedSessionId !== null &&
+    activeMainTab === "chat";
 
   // Switching projects closes the file tab — its path wouldn't resolve
   // under the new project's root anyway.
@@ -422,21 +432,24 @@ function MainShell() {
                 // All that progress is surfaced inline by `WorktreeSetupCard`
                 // at the top of the timeline, with the composer pinned at the
                 // bottom (no full-screen takeover).
-                <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col px-3">
-                  <ChatView sessionId={selectedSessionId} />
-                  <CostFooter
-                    sessionId={selectedSessionId}
-                    constrain={false}
-                  />
-                  <CliUpgradeBanner
-                    providerId={selectedSession.providerId}
-                    constrain={false}
-                  />
-                  <ChatComposer
-                    key={selectedSession.id}
-                    session={selectedSession}
-                    constrain={false}
-                  />
+                <div className="flex min-h-0 min-w-0 flex-1 px-3">
+                  <div className="mx-auto flex min-h-0 min-w-0 w-full max-w-4xl flex-1 flex-col">
+                    <ChatView sessionId={selectedSessionId} />
+                    <CostFooter
+                      sessionId={selectedSessionId}
+                      constrain={false}
+                    />
+                    <CliUpgradeBanner
+                      providerId={selectedSession.providerId}
+                      constrain={false}
+                    />
+                    <ChatComposer
+                      key={selectedSession.id}
+                      session={selectedSession}
+                      constrain={false}
+                    />
+                  </div>
+                  {showEnvironmentSummary ? <EnvironmentSummary /> : null}
                 </div>
               ) : (
                 <ChatLanding />

--- a/apps/renderer/src/components/composer/project-plan-tray.tsx
+++ b/apps/renderer/src/components/composer/project-plan-tray.tsx
@@ -36,6 +36,12 @@ interface Todo {
   readonly status: TodoStatus;
 }
 
+export interface ProjectPlanSummary {
+  readonly title: string;
+  readonly done: number;
+  readonly total: number;
+}
+
 const EMPTY_MESSAGES: ReadonlyArray<Message> = [];
 
 const asString = (v: unknown): string | undefined =>
@@ -200,6 +206,23 @@ const activeHeaderTodo = (todos: ReadonlyArray<Todo>): Todo | undefined =>
   todos.find((t) => t.status !== TODO_STATUS.completed) ??
   todos.at(-1);
 
+const projectPlanFromMessages = (messages: ReadonlyArray<Message>): Todo[] => {
+  const tasks = tasksFromMessages(messages);
+  if (tasks.length > 0) return tasks;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i]?.content;
+    if (content === undefined) continue;
+    if (content._tag === "tool_use" && content.tool === "TodoWrite") {
+      const parsed = parseTodosFromInput(content.input);
+      if (parsed.length > 0) return parsed;
+    } else if (content._tag === "tool_result") {
+      const parsed = parseTodosFromOutput(content.output);
+      if (parsed.length > 0) return parsed;
+    }
+  }
+  return [];
+};
+
 /**
  * "Project Plan" panel docked above the composer. Surfaces the agent's live
  * plan — reconstructed from the newer `TaskCreate`/`TaskUpdate` tools, falling
@@ -224,22 +247,7 @@ export function ProjectPlanTray({ sessionId }: { sessionId: SessionId }) {
     // Preferred: the newer Task tools (TaskCreate/TaskUpdate), replayed into a
     // live list. This is what current Claude (Agent SDK ≥ 0.2.x) sessions emit
     // instead of TodoWrite.
-    const tasks = tasksFromMessages(messages);
-    if (tasks.length > 0) return tasks;
-    // Fallback: legacy TodoWrite single-snapshot. Walk newest→oldest and take
-    // the first signal — Claude puts the list on the tool_use input; Grok (ACP)
-    // puts it on the tool_result output. Whichever is latest wins.
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const c = messages[i]!.content;
-      if (c._tag === "tool_use" && c.tool === "TodoWrite") {
-        const parsed = parseTodosFromInput(c.input);
-        if (parsed.length > 0) return parsed;
-      } else if (c._tag === "tool_result") {
-        const parsed = parseTodosFromOutput(c.output);
-        if (parsed.length > 0) return parsed;
-      }
-    }
-    return [];
+    return projectPlanFromMessages(messages);
   }, [messages]);
 
   if (todos.length === 0) return null;
@@ -312,6 +320,27 @@ export function ProjectPlanTray({ sessionId }: { sessionId: SessionId }) {
       }
     />
   );
+}
+
+/** Compact read model shared by the environment summary and Plan dock. */
+export function useProjectPlanSummary(
+  sessionId: SessionId | null,
+): ProjectPlanSummary | null {
+  const messages = useMessagesStore((s) =>
+    sessionId === null
+      ? EMPTY_MESSAGES
+      : (s.messagesBySession[sessionId] ?? EMPTY_MESSAGES),
+  );
+  return useMemo(() => {
+    const todos = projectPlanFromMessages(messages);
+    if (todos.length === 0) return null;
+    const active = activeHeaderTodo(todos);
+    return {
+      title: active?.text ?? "Project plan",
+      done: todos.filter((todo) => todo.status === TODO_STATUS.completed).length,
+      total: todos.length,
+    };
+  }, [messages]);
 }
 
 function TodoStatusIcon({ status }: { status: TodoStatus }) {

--- a/apps/renderer/src/components/environment-summary.tsx
+++ b/apps/renderer/src/components/environment-summary.tsx
@@ -16,8 +16,8 @@ import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useSessionsStore } from "../store/sessions.ts";
+import { useMessagesStore } from "../store/messages.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
-import { TopBarRightContent } from "./top-bar.tsx";
 import { useProjectPlanSummary } from "./composer/project-plan-tray.tsx";
 
 const rowClass =
@@ -49,7 +49,7 @@ export function EnvironmentSummary() {
 
 	const checkoutLabel =
 		ctx.rootKind === "worktree"
-			? (worktree?.name ?? "Preparing worktree…")
+			? `Worktree ${worktree?.name ?? "preparing…"}`
 			: "Main checkout";
 	const branchLabel = status?.branch ?? worktree?.branch ?? "Loading branch…";
 	const changesLabel =
@@ -93,6 +93,15 @@ export function EnvironmentSummary() {
 		}
 		return { icon: GitPullRequestIcon, label: "No pull request", className: "text-muted-foreground" };
 	})();
+	const openPullRequest = () => {
+		if (pr?.state === "none" && sessionId !== null) {
+			void useMessagesStore
+				.getState()
+				.send(sessionId, "create a pull request for this branch");
+			return;
+		}
+		revealPanel("pr");
+	};
 
 	return (
 		<aside
@@ -135,7 +144,7 @@ export function EnvironmentSummary() {
 			<button
 				type="button"
 				className={`${rowClass} hover:bg-muted/60`}
-				onClick={() => revealPanel("pr")}
+				onClick={openPullRequest}
 			>
 				<HugeiconsIcon
 					icon={prStatus.icon}
@@ -151,8 +160,8 @@ export function EnvironmentSummary() {
 					) : null}
 				</span>
 				{pr?.state === "none" ? (
-					<span className="shrink-0 rounded-full border border-border bg-muted/50 px-2 py-0.5 text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
-						No PR
+					<span className="shrink-0 rounded-full border border-[var(--accent-pink)]/30 bg-[var(--accent-pink)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--accent-pink)]">
+						Create PR
 					</span>
 				) : null}
 			</button>
@@ -169,12 +178,6 @@ export function EnvironmentSummary() {
 					</span>
 				</button>
 			) : null}
-			<div className="border-t border-border/60 px-2.5 py-2">
-				<div className="mb-2 text-[11px] font-medium text-muted-foreground">
-					Status
-				</div>
-				<TopBarRightContent compact />
-			</div>
 		</aside>
 	);
 }

--- a/apps/renderer/src/components/environment-summary.tsx
+++ b/apps/renderer/src/components/environment-summary.tsx
@@ -1,9 +1,13 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	ComputerTerminal01Icon,
+	Alert01Icon,
+	CheckListIcon,
 	GitBranchIcon,
 	GitCompareIcon,
-	LinkSquare01Icon,
+	GitMergeIcon,
+	Loading02Icon,
+	Tick02Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import { GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
 
@@ -11,11 +15,13 @@ import { useActiveContext } from "../store/active-workspace.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
 import { useUiStore } from "../store/ui.ts";
+import { useSessionsStore } from "../store/sessions.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { TopBarRightContent } from "./top-bar.tsx";
+import { useProjectPlanSummary } from "./composer/project-plan-tray.tsx";
 
 const rowClass =
-	"flex min-h-11 w-full min-w-0 items-center gap-3 rounded-lg px-3 text-left text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60";
+	"group flex min-h-9 w-full min-w-0 items-center gap-2 rounded-lg px-2.5 text-left text-[13px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60";
 
 export function EnvironmentSummary() {
 	const ctx = useActiveContext();
@@ -28,6 +34,8 @@ export function EnvironmentSummary() {
 		folderId ? (s.byKey[prStateKey(folderId, worktreeId)] ?? null) : null,
 	);
 	const revealPanel = useUiStore((s) => s.revealPanel);
+	const sessionId = useSessionsStore((s) => s.selectedSessionId);
+	const plan = useProjectPlanSummary(sessionId);
 	const worktree = useWorktreesStore((s) => {
 		if (ctx.status !== "ready" || ctx.worktreeId === null) return null;
 		return (
@@ -54,7 +62,7 @@ export function EnvironmentSummary() {
 		pr === null
 			? "Loading pull request…"
 			: pr.state === "none"
-				? "No pull request"
+				? "Pull request"
 				: `PR #${pr.number ?? "?"} · ${pr.state}`;
 	const checksLabel =
 		pr?.state === "open" && pr.checksTotal > 0
@@ -64,13 +72,34 @@ export function EnvironmentSummary() {
 					? `${pr.checksFailing} checks failing`
 					: "Checks passed"
 			: null;
+	const prStatus = (() => {
+		if (pr === null) {
+			return { icon: Loading02Icon, label: "Loading pull request", className: "animate-spin text-muted-foreground" };
+		}
+		if (pr.state === "merged") {
+			return { icon: GitMergeIcon, label: "Pull request merged", className: "text-primary" };
+		}
+		if (pr.state === "closed") {
+			return { icon: Alert01Icon, label: "Pull request closed", className: "text-muted-foreground" };
+		}
+		if (pr.state === "open" && (pr.checksFailing > 0 || pr.mergeable === "conflicting")) {
+			return { icon: Alert01Icon, label: "Pull request needs attention", className: "text-[var(--accent-red)]" };
+		}
+		if (pr.state === "open" && pr.checksRunning > 0) {
+			return { icon: Loading02Icon, label: "Pull request checks running", className: "animate-spin text-[var(--accent-amber)]" };
+		}
+		if (pr.state === "open") {
+			return { icon: Tick02Icon, label: "Pull request open", className: "text-[var(--accent-green)]" };
+		}
+		return { icon: GitPullRequestIcon, label: "No pull request", className: "text-muted-foreground" };
+	})();
 
 	return (
 		<aside
 			aria-label="Environment summary"
-			className="ml-4 mt-4 w-72 shrink-0 self-start rounded-2xl border border-border/70 bg-card/80 p-2 shadow-sm"
+			className="ml-3 mt-3 w-72 shrink-0 self-start rounded-3xl border border-border/70 bg-card/80 p-1.5 shadow-sm"
 		>
-			<h2 className="px-3 pb-1 pt-2 text-xs font-medium text-muted-foreground">
+			<h2 className="px-2.5 pb-1 pt-1.5 text-xs font-medium text-muted-foreground">
 				Environment
 			</h2>
 			<button
@@ -108,7 +137,11 @@ export function EnvironmentSummary() {
 				className={`${rowClass} hover:bg-muted/60`}
 				onClick={() => revealPanel("pr")}
 			>
-				<HugeiconsIcon icon={GitPullRequestIcon} className="size-4 shrink-0" />
+				<HugeiconsIcon
+					icon={prStatus.icon}
+					className={`size-4 shrink-0 ${prStatus.className}`}
+					aria-label={prStatus.label}
+				/>
 				<span className="min-w-0 flex-1 truncate">
 					<span className="block truncate">{prLabel}</span>
 					{checksLabel !== null ? (
@@ -117,14 +150,26 @@ export function EnvironmentSummary() {
 						</span>
 					) : null}
 				</span>
-				{pr?.url ? (
-					<HugeiconsIcon
-						icon={LinkSquare01Icon}
-						className="size-3.5 shrink-0 text-muted-foreground"
-					/>
+				{pr?.state === "none" ? (
+					<span className="shrink-0 rounded-full border border-border bg-muted/50 px-2 py-0.5 text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+						No PR
+					</span>
 				) : null}
 			</button>
-			<div className="border-t border-border/60 px-3 py-3">
+			{plan !== null ? (
+				<button
+					type="button"
+					className={`${rowClass} hover:bg-muted/60`}
+					onClick={() => revealPanel("plan")}
+				>
+					<HugeiconsIcon icon={CheckListIcon} className="size-4 shrink-0 text-primary" />
+					<span className="min-w-0 flex-1 truncate">{plan.title}</span>
+					<span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+						{plan.done}/{plan.total}
+					</span>
+				</button>
+			) : null}
+			<div className="border-t border-border/60 px-2.5 py-2">
 				<div className="mb-2 text-[11px] font-medium text-muted-foreground">
 					Status
 				</div>

--- a/apps/renderer/src/components/environment-summary.tsx
+++ b/apps/renderer/src/components/environment-summary.tsx
@@ -160,7 +160,7 @@ export function EnvironmentSummary() {
 					) : null}
 				</span>
 				{pr?.state === "none" ? (
-					<span className="shrink-0 rounded-full border border-[var(--accent-pink)]/30 bg-[var(--accent-pink)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--accent-pink)]">
+					<span className="shrink-0 rounded-md bg-[var(--accent-pink)] px-2 py-1 text-[10px] font-semibold text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
 						Create PR
 					</span>
 				) : null}

--- a/apps/renderer/src/components/environment-summary.tsx
+++ b/apps/renderer/src/components/environment-summary.tsx
@@ -143,7 +143,7 @@ export function EnvironmentSummary() {
 			</div>
 			<button
 				type="button"
-				className={`${rowClass} hover:bg-muted/60`}
+				className={`${rowClass} cursor-pointer hover:bg-muted/60`}
 				onClick={openPullRequest}
 			>
 				<HugeiconsIcon

--- a/apps/renderer/src/components/environment-summary.tsx
+++ b/apps/renderer/src/components/environment-summary.tsx
@@ -1,0 +1,135 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	ComputerTerminal01Icon,
+	GitBranchIcon,
+	GitCompareIcon,
+	LinkSquare01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import { GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
+
+import { useActiveContext } from "../store/active-workspace.ts";
+import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
+import { prStateKey, usePrStateStore } from "../store/pr-state.ts";
+import { useUiStore } from "../store/ui.ts";
+import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
+import { TopBarRightContent } from "./top-bar.tsx";
+
+const rowClass =
+	"flex min-h-11 w-full min-w-0 items-center gap-3 rounded-lg px-3 text-left text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60";
+
+export function EnvironmentSummary() {
+	const ctx = useActiveContext();
+	const folderId = ctx.status === "ready" ? ctx.folderId : null;
+	const worktreeId = ctx.status === "ready" ? ctx.worktreeId : null;
+	const status = useGitStatusStore((s) =>
+		folderId ? (s.byKey[gitStatusKey(folderId, worktreeId)] ?? null) : null,
+	);
+	const pr = usePrStateStore((s) =>
+		folderId ? (s.byKey[prStateKey(folderId, worktreeId)] ?? null) : null,
+	);
+	const revealPanel = useUiStore((s) => s.revealPanel);
+	const worktree = useWorktreesStore((s) => {
+		if (ctx.status !== "ready" || ctx.worktreeId === null) return null;
+		return (
+			(s.byProject[ctx.folderId] ?? EMPTY_WORKTREES).find(
+				(item) => item.id === ctx.worktreeId,
+			) ?? null
+		);
+	});
+
+	if (ctx.status !== "ready") return null;
+
+	const checkoutLabel =
+		ctx.rootKind === "worktree"
+			? (worktree?.name ?? "Preparing worktree…")
+			: "Main checkout";
+	const branchLabel = status?.branch ?? worktree?.branch ?? "Loading branch…";
+	const changesLabel =
+		status === null
+			? "Changes"
+			: status.dirtyFiles === 0
+				? "No changes"
+				: `${status.dirtyFiles} change${status.dirtyFiles === 1 ? "" : "s"}`;
+	const prLabel =
+		pr === null
+			? "Loading pull request…"
+			: pr.state === "none"
+				? "No pull request"
+				: `PR #${pr.number ?? "?"} · ${pr.state}`;
+	const checksLabel =
+		pr?.state === "open" && pr.checksTotal > 0
+			? pr.checksRunning > 0
+				? `${pr.checksRunning} checks running`
+				: pr.checksFailing > 0
+					? `${pr.checksFailing} checks failing`
+					: "Checks passed"
+			: null;
+
+	return (
+		<aside
+			aria-label="Environment summary"
+			className="ml-4 mt-4 w-72 shrink-0 self-start rounded-2xl border border-border/70 bg-card/80 p-2 shadow-sm"
+		>
+			<h2 className="px-3 pb-1 pt-2 text-xs font-medium text-muted-foreground">
+				Environment
+			</h2>
+			<button
+				type="button"
+				className={`${rowClass} hover:bg-muted/60`}
+				onClick={() => revealPanel("changes")}
+			>
+				<HugeiconsIcon icon={GitCompareIcon} className="size-4 shrink-0" />
+				<span className="min-w-0 flex-1 truncate">{changesLabel}</span>
+			</button>
+			<div className={rowClass} title={ctx.rootPath}>
+				<HugeiconsIcon
+					icon={ComputerTerminal01Icon}
+					className="size-4 shrink-0 text-muted-foreground"
+				/>
+				<span className="min-w-0 flex-1 truncate">{checkoutLabel}</span>
+			</div>
+			<div className={rowClass}>
+				<HugeiconsIcon
+					icon={GitBranchIcon}
+					className="size-4 shrink-0 text-muted-foreground"
+				/>
+				<span className="min-w-0 flex-1 truncate" title={branchLabel}>
+					{branchLabel}
+				</span>
+				{status !== null && (status.ahead > 0 || status.behind > 0) ? (
+					<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+						{status.ahead > 0 ? `↑${status.ahead}` : ""}
+						{status.behind > 0 ? ` ↓${status.behind}` : ""}
+					</span>
+				) : null}
+			</div>
+			<button
+				type="button"
+				className={`${rowClass} hover:bg-muted/60`}
+				onClick={() => revealPanel("pr")}
+			>
+				<HugeiconsIcon icon={GitPullRequestIcon} className="size-4 shrink-0" />
+				<span className="min-w-0 flex-1 truncate">
+					<span className="block truncate">{prLabel}</span>
+					{checksLabel !== null ? (
+						<span className="block truncate text-[11px] text-muted-foreground">
+							{checksLabel}
+						</span>
+					) : null}
+				</span>
+				{pr?.url ? (
+					<HugeiconsIcon
+						icon={LinkSquare01Icon}
+						className="size-3.5 shrink-0 text-muted-foreground"
+					/>
+				) : null}
+			</button>
+			<div className="border-t border-border/60 px-3 py-3">
+				<div className="mb-2 text-[11px] font-medium text-muted-foreground">
+					Status
+				</div>
+				<TopBarRightContent compact />
+			</div>
+		</aside>
+	);
+}

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -3,6 +3,7 @@ import {
   Folder01Icon,
   GitBranchIcon,
   GitCompareIcon,
+  CheckListIcon,
   GlobeIcon,
 } from "@hugeicons-pro/core-bulk-rounded";
 import { GitPullRequestIcon } from "@hugeicons-pro/core-solid-rounded";
@@ -16,6 +17,7 @@ import { useAutoAnimate } from "../lib/use-auto-animate.ts";
 
 import { formatShortcut } from "../lib/shortcuts.ts";
 import { useRegisterPane } from "../store/pane-focus.ts";
+import { useSessionsStore } from "../store/sessions.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
@@ -39,6 +41,7 @@ import { BrowserPane } from "./browser-pane.tsx";
 import { DiffPane } from "./diff-pane.tsx";
 import { FileTree } from "./file-tree.tsx";
 import { PrPane } from "./pr-pane.tsx";
+import { ProjectPlanTray } from "./composer/project-plan-tray.tsx";
 import { TerminalSlotPane } from "./terminal-pane.tsx";
 import {
   Menu,
@@ -69,6 +72,7 @@ const PANEL_META: Record<
   },
   changes: { label: "Changes", icon: GitCompareIcon },
   pr: { label: "PR", icon: GitPullRequestIcon },
+  plan: { label: "Plan", icon: CheckListIcon },
   browser: { label: "Browser", icon: GlobeIcon },
 };
 
@@ -78,6 +82,7 @@ const PANEL_ORDER: ReadonlyArray<PanelKind> = [
   "terminal",
   "changes",
   "pr",
+  "plan",
   "browser",
 ];
 
@@ -289,11 +294,23 @@ function PanelBody({
       return <DiffPane folderId={folderId} worktreeId={worktreeId} />;
     case "pr":
       return <PrPane folderId={folderId} worktreeId={worktreeId} />;
+    case "plan":
+      return <PlanPane />;
     case "browser":
       // Browser is rendered once, always-mounted, by RightPane (so the agent
       // command stream survives close/collapse) — never via this map.
       return null;
   }
+}
+
+function PlanPane() {
+  const sessionId = useSessionsStore((s) => s.selectedSessionId);
+  if (sessionId === null) return null;
+  return (
+    <div className="p-3">
+      <ProjectPlanTray key={sessionId} sessionId={sessionId} />
+    </div>
+  );
 }
 
 /**

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -8,6 +8,7 @@ import {
   LinkSquare01Icon,
   Loading02Icon,
   MagicWand01Icon,
+  Menu01Icon,
   PanelLeftCloseIcon,
   PanelLeftOpenIcon,
   PanelRightCloseIcon,
@@ -22,6 +23,13 @@ import {
   ArchiveArrowDownIcon,
   GitPullRequestIcon,
 } from "@hugeicons-pro/core-solid-rounded";
+import {
+  ComposerInput,
+  type FolderId,
+  type GitBranchInfo,
+  type GitMergeMethod,
+  type WorktreeId,
+} from "@zuse/contracts";
 import { Effect } from "effect";
 import {
   type CSSProperties,
@@ -31,25 +39,10 @@ import {
   useMemo,
   useState,
 } from "react";
-
-import {
-  ComposerInput,
-  type FolderId,
-  type GitBranchInfo,
-  type GitMergeMethod,
-  type WorktreeId,
-} from "@zuse/contracts";
-
-import { getRpcClient } from "../lib/rpc-client.ts";
 import type { OpenTarget } from "../lib/bridge.ts";
-import { formatShortcut } from "../lib/shortcuts.ts";
+import { getRpcClient } from "../lib/rpc-client.ts";
 import { openTerminalCommand } from "../lib/run-terminal.ts";
-import {
-  GlassActionButton,
-  GlassChip,
-  type GlassTone,
-} from "./glass-action.tsx";
-import { TooltipShortcut } from "./projects-sidebar.tsx";
+import { formatShortcut } from "../lib/shortcuts.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
 import {
   archiveChatWithConfirm,
@@ -65,9 +58,13 @@ import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { useWorktreesStore } from "../store/worktrees.ts";
+import {
+  GlassActionButton,
+  GlassChip,
+  type GlassTone,
+} from "./glass-action.tsx";
+import { TooltipShortcut } from "./projects-sidebar.tsx";
 import { Button } from "./ui/button.tsx";
-import { ErrorBoundary } from "./ui/error-boundary.tsx";
-import { toastManager } from "./ui/toast.tsx";
 import {
   Dialog,
   DialogClose,
@@ -78,6 +75,7 @@ import {
   DialogPopup,
   DialogTitle,
 } from "./ui/dialog.tsx";
+import { ErrorBoundary } from "./ui/error-boundary.tsx";
 import { Input } from "./ui/input.tsx";
 import {
   Menu,
@@ -87,6 +85,7 @@ import {
   MenuShortcut,
   MenuTrigger,
 } from "./ui/menu.tsx";
+import { toastManager } from "./ui/toast.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 /**
@@ -173,6 +172,10 @@ export function TopBarMain() {
   const rightSidebarOpen = useUiStore((s) => s.rightSidebarOpen);
   const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
   const isFullScreen = useUiStore((s) => s.isFullScreen);
+  const environmentSummaryOpen = useUiStore((s) => s.environmentSummaryOpen);
+  const toggleEnvironmentSummary = useUiStore(
+    (s) => s.toggleEnvironmentSummary,
+  );
   // On the empty new-chat landing (no session yet) we hide the repo/branch
   // label + open-in menu so the surface reads as a clean blank chat. The
   // sidebar toggle buttons stay.
@@ -223,7 +226,9 @@ export function TopBarMain() {
     void (async () => {
       try {
         const client = await getRpcClient();
-        const origin = await Effect.runPromise(client["git.origin"]({ folderId }));
+        const origin = await Effect.runPromise(
+          client["git.origin"]({ folderId }),
+        );
         if (cancelled) return;
         setOriginLabel(
           origin !== null ? `${origin.owner}/${origin.repo}` : null,
@@ -359,6 +364,28 @@ export function TopBarMain() {
       ) : null}
       {hasSession ? (
         <OpenInMenu rootPath={ctx.status === "ready" ? ctx.rootPath : null} />
+      ) : null}
+      {isFullScreen && hasSession ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={toggleEnvironmentSummary}
+                className={`${ICON_BUTTON_CLASS} ${
+                  environmentSummaryOpen
+                    ? "bg-foreground/10 text-foreground"
+                    : ""
+                }`}
+                aria-label="Toggle environment summary"
+                aria-pressed={environmentSummaryOpen}
+              >
+                <HugeiconsIcon icon={Menu01Icon} className="size-3.5" />
+              </button>
+            }
+          />
+          <TooltipPopup>Toggle environment summary</TooltipPopup>
+        </Tooltip>
       ) : null}
       <Tooltip>
         <TooltipTrigger
@@ -912,7 +939,11 @@ export function TopBarRight() {
   );
 }
 
-function TopBarRightContent() {
+export function TopBarRightContent({
+  compact = false,
+}: {
+  compact?: boolean;
+} = {}) {
   const ctx = useActiveContext();
   const folderId = ctx.status === "ready" ? ctx.folderId : null;
   const worktreeId = ctx.status === "ready" ? ctx.worktreeId : null;
@@ -942,8 +973,15 @@ function TopBarRightContent() {
   const workflow = deriveWorkflow(status, pr, canCreatePrWhenSynced);
   const agentReady = selectedSessionId !== null;
 
+  const Root = compact ? "div" : "header";
   return (
-    <header className={`${SECTION_CLASS} justify-between px-2`}>
+    <Root
+      className={
+        compact
+          ? "flex min-w-0 flex-col gap-2"
+          : `${SECTION_CLASS} justify-between px-2`
+      }
+    >
       <div className={`flex min-w-0 flex-1 items-center gap-2 ${ACTION_CLASS}`}>
         {agentReady && workflow.kind === "dirty" ? (
           <GlassChip tone="amber">
@@ -966,7 +1004,11 @@ function TopBarRightContent() {
           </>
         ) : null}
       </div>
-      <div className={`flex shrink-0 items-center gap-1 ${ACTION_CLASS}`}>
+      <div
+        className={`flex shrink-0 items-center gap-1 ${ACTION_CLASS} ${
+          compact ? "flex-wrap" : ""
+        }`}
+      >
         <RunButton />
         {workflow.kind === "dirty" ? (
           <GlassActionButton
@@ -1067,20 +1109,18 @@ function TopBarRightContent() {
         workflow.checks !== "failure" &&
         !workflow.isDraft &&
         folderId !== null ? (
-          <>
-            {workflow.checks === "pending" ? (
-              <AutoMergeToggle
-                folderId={folderId}
-                worktreeId={worktreeId}
-                enabled={workflow.autoMergeEnabled}
-              />
-            ) : (
-              <MergeButton folderId={folderId} worktreeId={worktreeId} />
-            )}
-          </>
+          workflow.checks === "pending" ? (
+            <AutoMergeToggle
+              folderId={folderId}
+              worktreeId={worktreeId}
+              enabled={workflow.autoMergeEnabled}
+            />
+          ) : (
+            <MergeButton folderId={folderId} worktreeId={worktreeId} />
+          )
         ) : null}
       </div>
-    </header>
+    </Root>
   );
 }
 

--- a/apps/renderer/src/components/ui/menu.tsx
+++ b/apps/renderer/src/components/ui/menu.tsx
@@ -66,7 +66,7 @@ export function MenuPopup({
           data-slot="menu-popup"
           {...props}
         >
-          <div className="max-h-(--available-height) w-full overflow-y-auto p-1">
+          <div className="max-h-(--available-height) w-full overflow-y-auto p-0.5">
             {children}
           </div>
         </MenuPrimitive.Popup>
@@ -93,7 +93,7 @@ export function MenuItem({
   return (
     <MenuPrimitive.Item
       className={cn(
-        "flex min-h-8 cursor-default select-none items-center gap-2 rounded-sm px-2 py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-inset:ps-8 data-[variant=destructive]:text-destructive-foreground data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
+        "flex min-h-7 cursor-default select-none items-center gap-1.5 rounded-sm px-2 py-0.5 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-inset:ps-8 data-[variant=destructive]:text-destructive-foreground data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-6 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
         className,
       )}
       data-inset={inset}

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -51,7 +51,13 @@ export type UsageScope = "global" | "project";
  * are added from a launcher / "+" menu and closed individually, rather than
  * being a fixed tab set.
  */
-export type PanelKind = "files" | "terminal" | "changes" | "pr" | "browser";
+export type PanelKind =
+  | "files"
+  | "terminal"
+  | "changes"
+  | "pr"
+  | "plan"
+  | "browser";
 
 /**
  * Kinds that may have at most one open instance. Terminal is the only
@@ -61,6 +67,7 @@ export const SINGLETON_PANEL_KINDS: ReadonlySet<PanelKind> = new Set([
   "files",
   "changes",
   "pr",
+  "plan",
   "browser",
 ]);
 
@@ -76,6 +83,7 @@ export type PanelInstance =
   | { readonly id: string; readonly kind: "files" }
   | { readonly id: string; readonly kind: "changes" }
   | { readonly id: string; readonly kind: "pr" }
+  | { readonly id: string; readonly kind: "plan" }
   | { readonly id: string; readonly kind: "browser" }
   | { readonly id: string; readonly kind: "terminal"; readonly slot: number };
 

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -1,6 +1,10 @@
+import type {
+  ChatId,
+  CodeAnnotation,
+  FolderId,
+  WorktreeId,
+} from "@zuse/contracts";
 import { create } from "zustand";
-
-import type { ChatId, CodeAnnotation, FolderId, WorktreeId } from "@zuse/contracts";
 
 import { useChatsStore } from "./chats.ts";
 
@@ -178,6 +182,9 @@ type UiState = {
   /** Whether the cross-project chat quick-switcher (Cmd+K) overlay is open. */
   readonly chatSwitcherOpen: boolean;
   readonly isFullScreen: boolean;
+  /** User preference for the fullscreen environment summary. The summary is
+   * still gated by native fullscreen and available width at render time. */
+  readonly environmentSummaryOpen: boolean;
   /** Right-dock tab layout, scoped per sidebar-chat. */
   readonly rightPanelsByChat: Record<string, ReadonlyArray<PanelInstance>>;
   readonly activeRightPanelByChat: Record<string, string | null>;
@@ -204,6 +211,8 @@ type UiState = {
   readonly setChatSwitcherOpen: (open: boolean) => void;
   readonly toggleChatSwitcher: () => void;
   readonly setFullScreen: (full: boolean) => void;
+  readonly setEnvironmentSummaryOpen: (open: boolean) => void;
+  readonly toggleEnvironmentSummary: () => void;
   /** Add a panel to the dock. Singletons that are already open are focused
    * instead of duplicated; terminals always append a new slot. */
   readonly addPanel: (kind: PanelKind) => void;
@@ -232,6 +241,28 @@ type UiState = {
 const newPanelId = (): string =>
   globalThis.crypto?.randomUUID?.() ??
   `p-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+export const ENVIRONMENT_SUMMARY_STORAGE_KEY =
+  "zuse.environmentSummary.open.v1";
+
+const initialEnvironmentSummaryOpen = (): boolean => {
+  if (typeof window === "undefined") return true;
+  try {
+    return (
+      window.localStorage.getItem(ENVIRONMENT_SUMMARY_STORAGE_KEY) !== "false"
+    );
+  } catch {
+    return true;
+  }
+};
+
+const persistEnvironmentSummaryOpen = (open: boolean): void => {
+  try {
+    window.localStorage.setItem(ENVIRONMENT_SUMMARY_STORAGE_KEY, String(open));
+  } catch {
+    // The preference remains usable for this session when storage is blocked.
+  }
+};
 
 /** Renumber terminal panels' slots to stay contiguous (0..n-1) in tab order
  * after one is removed, so they keep mapping to the owning chat's terminal
@@ -282,6 +313,7 @@ export const useUiStore = create<UiState>((set, get) => ({
   rightSidebarOpen: false,
   chatSwitcherOpen: false,
   isFullScreen: false,
+  environmentSummaryOpen: initialEnvironmentSummaryOpen(),
   rightPanelsByChat: {},
   activeRightPanelByChat: {},
   revealedAnnotation: null,
@@ -326,6 +358,16 @@ export const useUiStore = create<UiState>((set, get) => ({
   toggleChatSwitcher: () =>
     set((s) => ({ chatSwitcherOpen: !s.chatSwitcherOpen })),
   setFullScreen: (full) => set({ isFullScreen: full }),
+  setEnvironmentSummaryOpen: (open) => {
+    persistEnvironmentSummaryOpen(open);
+    set({ environmentSummaryOpen: open });
+  },
+  toggleEnvironmentSummary: () =>
+    set((s) => {
+      const open = !s.environmentSummaryOpen;
+      persistEnvironmentSummaryOpen(open);
+      return { environmentSummaryOpen: open };
+    }),
   addPanel: (kind) =>
     set((s) => {
       const chatId = activeChatId();

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -205,7 +205,7 @@ body,
 /* Same moss/lime identity as dark mode, lifted onto a quiet paper surface.
    Primary stays chartreuse instead of becoming a generic blue/gray light UI. */
 :root {
-  --radius: 0.5rem;
+  --radius: 0.75rem;
   --lime: hsl(72 92% 48%);
   --brand-highlight: hsl(72 92% 48%);
   --brand-highlight-muted: hsl(74 70% 58%);

--- a/apps/renderer/test/environment-summary-store.test.ts
+++ b/apps/renderer/test/environment-summary-store.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+	ENVIRONMENT_SUMMARY_STORAGE_KEY,
+	useUiStore,
+} from "../src/store/ui.ts";
+
+const values = new Map<string, string>();
+const localStorage = {
+	clear: () => values.clear(),
+	getItem: (key: string) => values.get(key) ?? null,
+	setItem: (key: string, value: string) => values.set(key, value),
+};
+
+Object.defineProperty(globalThis, "window", {
+	configurable: true,
+	value: { localStorage },
+});
+
+describe("environment summary preference", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useUiStore.setState({ environmentSummaryOpen: true });
+	});
+
+	it("defaults to open", () => {
+		expect(useUiStore.getState().environmentSummaryOpen).toBe(true);
+	});
+
+	it("persists explicit visibility changes", () => {
+		useUiStore.getState().setEnvironmentSummaryOpen(false);
+
+		expect(useUiStore.getState().environmentSummaryOpen).toBe(false);
+		expect(localStorage.getItem(ENVIRONMENT_SUMMARY_STORAGE_KEY)).toBe("false");
+	});
+
+	it("toggles and persists the next value", () => {
+		useUiStore.getState().toggleEnvironmentSummary();
+
+		expect(useUiStore.getState().environmentSummaryOpen).toBe(false);
+		expect(localStorage.getItem(ENVIRONMENT_SUMMARY_STORAGE_KEY)).toBe("false");
+	});
+});


### PR DESCRIPTION
## What changed

- add a fullscreen environment summary with live checkout, branch, changes, pull request, and plan state
- add compact PR-state affordances, a hover-only create-PR action, and a singleton Plan sidebar panel
- animate summary visibility and automatically yield its space while the right sidebar is open
- increase shared corner-radius tokens and tighten menu item density

## Why

The fullscreen chat surface needed a compact, glanceable view of the active development environment without requiring users to keep the right sidebar open. The summary keeps repository and plan context visible while preserving chat space and reuses the existing dock and workflow actions.

## Impact

The summary is enabled by default in fullscreen, can be toggled from the top bar, persists its preference, hides at narrow widths or while the right sidebar is active, and respects reduced-motion settings.

## Validation

- `bun run check-types --filter=renderer`
- `bun run --cwd apps/renderer test` (101 tests)
