### PR TITLE
Fix new agent startup loader race

### DIFF
--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -328,12 +328,18 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
       // on the very next render.
       useSessionsStore.setState((s) => {
         const list = s.sessionsByProject[projectId] ?? [];
-        if (list.some((row) => row.id === initialSession.id)) return s;
+        // The live chat stream can hydrate this row before create() resolves.
+        // Deduplicate the row without dropping the selection transition.
+        const sessionAlreadyHydrated = list.some(
+          (row) => row.id === initialSession.id,
+        );
         return {
-          sessionsByProject: {
-            ...s.sessionsByProject,
-            [projectId]: [initialSession, ...list],
-          },
+          sessionsByProject: sessionAlreadyHydrated
+            ? s.sessionsByProject
+            : {
+                ...s.sessionsByProject,
+                [projectId]: [initialSession, ...list],
+              },
           selectedSessionId: initialSession.id,
           selectedSessionByProject: {
             ...s.selectedSessionByProject,

--- a/apps/renderer/test/unit/chats-store.test.ts
+++ b/apps/renderer/test/unit/chats-store.test.ts
@@ -5,7 +5,21 @@ import type {
 	Session,
 	SessionId,
 } from "@zuse/contracts";
-import { beforeEach, describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { rpcClientFactory } = vi.hoisted(() => ({
+	rpcClientFactory: vi.fn(),
+}));
+
+vi.mock("../../src/lib/rpc-client.ts", async (importOriginal) => {
+	const original =
+		await importOriginal<typeof import("../../src/lib/rpc-client.ts")>();
+	return {
+		...original,
+		getRpcClient: async () => rpcClientFactory(),
+	};
+});
 
 import {
 	archiveChatWithConfirm,
@@ -123,6 +137,24 @@ describe("chats store selection", () => {
 		expect(useUiStore.getState().activeMainTab).toBe("usage");
 		expect(useChatsStore.getState().selectedChatId).toBeNull();
 		expect(useSessionsStore.getState().selectedSessionId).toBeNull();
+	});
+
+	it("selects a newly created session even when hydration inserted it first", async () => {
+		rpcClientFactory.mockReturnValue({
+			"chat.create": () =>
+				Effect.succeed({ chat, initialSession: session, initialMessage: null }),
+		});
+
+		const result = await useChatsStore
+			.getState()
+			.create(projectId, session.providerId, session.model);
+
+		expect(result).toEqual({ chatId, initialSessionId: sessionId });
+		expect(useChatsStore.getState().selectedChatId).toBe(chatId);
+		expect(useSessionsStore.getState().selectedSessionId).toBe(sessionId);
+		expect(
+			useSessionsStore.getState().selectedSessionByProject[projectId],
+		).toBe(sessionId);
 	});
 });
 


### PR DESCRIPTION
## Summary

- preserve the new session selection when live hydration inserts its row before chat creation resolves
- keep the hydrated session data while still transitioning the renderer to the new chat
- add a regression test covering the hydrate/create race

## Root cause

The session deduplication path returned the existing store state when the live chat stream hydrated the new session first. That also discarded the selection update, so the creation loader stayed mounted until navigating away and back selected the session through another path.

## User impact

New agent chats now appear immediately after creation instead of remaining on the worktree setup loader.

## Validation

- `bunx vitest run test/unit/chats-store.test.ts` — 8 passed
- renderer unit suite — 109 passed
- `bun run --cwd apps/renderer check-types`
- `git diff --check`

## Notes

The scoped Biome lint completed without errors. It continues to report two unrelated existing warnings in the chat store.
