### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+
+### Changed
+- Fix new agent startup loader race (#329)
+- Improve tool activity and subagent inspection (#325)
+- Improve usage limits and reporting (#328)
+- Add fullscreen environment summary (#327)
+- Prevent desktop relay port collisions (#326)
+- Build production-shaped test suite (#324)
+- Complete provider runtime and durable migration (#323)
+- Complete durable runtime ownership cutovers (#322)
+- Move Git/worktree into packages and harden durable domain dispatch (#321)
+- Build the Effect 4 backend foundation and CQRS core (#320)
+- Remove orchestration prefixes from provider prompts (#319)
+
 ## [0.12.6]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.13.0]
 
 ### Changed
+- Refine plan handoff sessions (#331)
 - Fix new agent startup loader race (#329)
 - Improve tool activity and subagent inspection (#325)
 - Improve usage limits and reporting (#328)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,57 +1,57 @@
 {
-	"name": "desktop",
-	"type": "module",
-	"productName": "Zuse Alpha",
-	"version": "0.12.6",
-	"description": "Zuse Alpha desktop app",
-	"private": true,
-	"author": {
-		"name": "Swaraj Bachu",
-		"email": "swarajkumar4444@gmail.com"
-	},
-	"homepage": "https://github.com/swarajbachu/zuse",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/swarajbachu/zuse.git"
-	},
-	"main": "dist-electron/main.cjs",
-	"scripts": {
-		"dev": "bun run --parallel dev:bundle dev:electron",
-		"dev:bundle": "tsdown --watch",
-		"dev:electron": "node scripts/dev-electron.mjs",
-		"build": "tsdown",
-		"check-types": "tsc --noEmit",
-		"test": "vitest run test && node scripts/sqlite-runtime-smoke.mjs",
-		"test:unit": "vitest run test/unit",
-		"test:integration": "vitest run test/integration --passWithNoTests",
-		"postinstall": "electron-rebuild -f -o node-pty,keytar",
-		"icon": "node scripts/make-icon.mjs",
-		"dist:mac": "electron-builder --mac --universal",
-		"dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
-	},
-	"dependencies": {
-		"electron-updater": "^6.3.9",
-		"keytar": "^7.9.0",
-		"node-pty": "^1.1.0",
-		"tree-sitter": "^0.21.1",
-		"tree-sitter-javascript": "^0.23.1",
-		"tree-sitter-json": "^0.24.8",
-		"tree-sitter-typescript": "^0.23.2"
-	},
-	"devDependencies": {
-		"@electron/rebuild": "^4.0.4",
-		"@zuse/server": "*",
-		"@zuse/ssh": "*",
-		"@zuse/contracts": "*",
-		"@repo/typescript-config": "*",
-		"@types/node": "catalog:",
-		"effect": "catalog:",
-		"electron-builder": "^25.1.8",
-		"electron": "^42.1.0",
-		"fix-path": "^4.0.0",
-		"sharp": "^0.34.1",
-		"tsdown": "^0.21.10",
-		"typescript": "catalog:",
-		"vitest": "catalog:"
-	}
+  "name": "desktop",
+  "type": "module",
+  "productName": "Zuse Alpha",
+  "version": "0.13.0",
+  "description": "Zuse Alpha desktop app",
+  "private": true,
+  "author": {
+    "name": "Swaraj Bachu",
+    "email": "swarajkumar4444@gmail.com"
+  },
+  "homepage": "https://github.com/swarajbachu/zuse",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarajbachu/zuse.git"
+  },
+  "main": "dist-electron/main.cjs",
+  "scripts": {
+    "dev": "bun run --parallel dev:bundle dev:electron",
+    "dev:bundle": "tsdown --watch",
+    "dev:electron": "node scripts/dev-electron.mjs",
+    "build": "tsdown",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run test && node scripts/sqlite-runtime-smoke.mjs",
+    "test:unit": "vitest run test/unit",
+    "test:integration": "vitest run test/integration --passWithNoTests",
+    "postinstall": "electron-rebuild -f -o node-pty,keytar",
+    "icon": "node scripts/make-icon.mjs",
+    "dist:mac": "electron-builder --mac --universal",
+    "dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
+  },
+  "dependencies": {
+    "electron-updater": "^6.3.9",
+    "keytar": "^7.9.0",
+    "node-pty": "^1.1.0",
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-javascript": "^0.23.1",
+    "tree-sitter-json": "^0.24.8",
+    "tree-sitter-typescript": "^0.23.2"
+  },
+  "devDependencies": {
+    "@electron/rebuild": "^4.0.4",
+    "@zuse/server": "*",
+    "@zuse/ssh": "*",
+    "@zuse/contracts": "*",
+    "@repo/typescript-config": "*",
+    "@types/node": "catalog:",
+    "effect": "catalog:",
+    "electron-builder": "^25.1.8",
+    "electron": "^42.1.0",
+    "fix-path": "^4.0.0",
+    "sharp": "^0.34.1",
+    "tsdown": "^0.21.10",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
 }

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,26 @@
 [
   {
+    "version": "0.13.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix new agent startup loader race (#329)",
+          "Improve tool activity and subagent inspection (#325)",
+          "Improve usage limits and reporting (#328)",
+          "Add fullscreen environment summary (#327)",
+          "Prevent desktop relay port collisions (#326)",
+          "Build production-shaped test suite (#324)",
+          "Complete provider runtime and durable migration (#323)",
+          "Complete durable runtime ownership cutovers (#322)",
+          "Move Git/worktree into packages and harden durable domain dispatch (#321)",
+          "Build the Effect 4 backend foundation and CQRS core (#320)",
+          "Remove orchestration prefixes from provider prompts (#319)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.12.6",
     "sections": [
       {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -5,6 +5,7 @@
       {
         "title": "Changed",
         "items": [
+          "Refine plan handoff sessions (#331)",
           "Fix new agent startup loader race (#329)",
           "Improve tool activity and subagent inspection (#325)",
           "Improve usage limits and reporting (#328)",

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.12.6",
+      "version": "0.13.0",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "keytar": "^7.9.0",


### PR DESCRIPTION
## Summary
- release Zuse v0.13.0
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.13.0 after this PR lands.