### PR TITLE
Refine plan handoff sessions

### DIFF
--- a/apps/renderer/src/components/composer/plan-approval-tray.tsx
+++ b/apps/renderer/src/components/composer/plan-approval-tray.tsx
@@ -1,5 +1,5 @@
-import { CheckListIcon } from "@hugeicons-pro/core-bulk-rounded";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { CheckListIcon } from "@hugeicons-pro/core-bulk-rounded";
 
 import type { SessionId } from "@zuse/contracts";
 
@@ -8,7 +8,6 @@ import {
   latestPlanText,
   saveContextFile,
 } from "../../lib/context-handoff.ts";
-import { useChatsStore } from "../../store/chats.ts";
 import { usePermissionsStore } from "../../store/permissions.ts";
 import { useSessionsStore } from "../../store/sessions.ts";
 import { toastManager } from "../ui/toast.tsx";
@@ -48,9 +47,9 @@ export function PlanApprovalTray({
   });
   const decide = usePermissionsStore((s) => s.decide);
 
-  // Hand the proposed plan off to a fresh chat that starts in build mode. The
-  // current plan-mode session is left untouched (its ExitPlanMode prompt stays
-  // open), so the user can keep iterating on the plan or discard it.
+  // Hand the proposed plan off to a fresh build-mode session in the same chat.
+  // The current plan-mode session is left untouched (its ExitPlanMode prompt
+  // stays open), so the user can keep iterating on the plan or discard it.
   const handoff = async () => {
     const source = Object.values(
       useSessionsStore.getState().sessionsByProject,
@@ -66,31 +65,36 @@ export function PlanApprovalTray({
       });
       return;
     }
-    const created = await useChatsStore
+    const created = await useSessionsStore
       .getState()
-      .create(source.projectId, source.providerId, source.model, {
-        title: `Build: ${source.title}`,
+      .create(source.chatId, source.providerId, source.model, {
         permissionMode: "default",
-        // Fresh chat in the project's main checkout — the handoff is a new
-        // conversation, not a continuation of the plan session's worktree.
-        worktreeId: null,
+        runtimeMode: source.runtimeMode,
       });
     if (created === null) {
       toastManager.add({
         title: "Handoff failed",
-        description: "Could not create the build chat.",
+        description: "Could not create the build session.",
         type: "error",
       });
       return;
     }
-    const ref = await saveContextFile(created.initialSessionId, planText);
+    const ref = await saveContextFile(created, planText);
     if (ref !== null) attachFileWhenReady(ref);
+    if (pendingRequest !== null) {
+      await decide(pendingRequest.id, { _tag: "Deny" });
+      await useSessionsStore
+        .getState()
+        .setPermissionMode(sessionId, "default");
+    } else {
+      onCancelEmulatedPlan?.();
+    }
     toastManager.add({
       title: "Plan handed off",
       description:
         ref !== null
-          ? "New chat opened in build mode with the plan attached."
-          : "New chat opened in build mode.",
+          ? "New session opened in build mode with the plan attached."
+          : "New session opened in build mode.",
       type: "success",
     });
   };
@@ -116,7 +120,7 @@ export function PlanApprovalTray({
           <button
             type="button"
             onClick={() => void handoff()}
-            title="Open a new chat in build mode with this plan attached"
+            title="Open a new session in build mode with this plan attached"
             className="rounded-md px-2.5 py-0.5 text-[12px] text-muted-foreground hover:bg-muted/60 hover:text-foreground"
           >
             Hand off →

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -1,5 +1,8 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { SquareLock01Icon } from "@hugeicons-pro/core-bulk-rounded";
+import {
+  SquareLock01Icon,
+  TaskDone01Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
 import { Plus, X } from "lucide-react";
 import { useMemo } from "react";
 
@@ -18,11 +21,13 @@ import { usePermissionsStore } from "../store/permissions.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useSettingsStore } from "../store/settings.ts";
+import { useSidebarMessageStatusStore } from "../store/sidebar-message-status.ts";
 import { useUiStore } from "../store/ui.ts";
 import {
   activeChatId as deriveActiveChatId,
   orderedChatTabs,
 } from "../lib/tab-order.ts";
+import { deriveChatAttentionState } from "../lib/chat-attention-state.ts";
 import { FileIcon } from "./file-icon.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { Spinner } from "./ui/spinner";
@@ -81,6 +86,9 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
   // Per-session running flag — drives the provider-icon → Spinner swap on
   // each tab so the user sees which session is streaming at a glance.
   const runningBySession = useMessagesStore((s) => s.runningBySession);
+  const sidebarMessagesBySession = useSidebarMessageStatusStore(
+    (s) => s.messagesBySession,
+  );
   // Sessions with a pending permission prompt. Surfaced on the tab as a lock
   // so a supervised-mode request is visible without opening the session.
   // ExitPlanMode is excluded — plan mode owns its own inline approval card.
@@ -89,6 +97,15 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
     const ids = new Set<SessionId>();
     for (const req of Object.values(requestsById)) {
       if (req.kind._tag === "Other" && req.kind.tool === "ExitPlanMode")
+        continue;
+      ids.add(req.sessionId);
+    }
+    return ids;
+  }, [requestsById]);
+  const awaitingPlanApproval = useMemo(() => {
+    const ids = new Set<SessionId>();
+    for (const req of Object.values(requestsById)) {
+      if (req.kind._tag !== "Other" || req.kind.tool !== "ExitPlanMode")
         continue;
       ids.add(req.sessionId);
     }
@@ -143,6 +160,13 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
               providerId={session.providerId}
               running={runningBySession[session.id] === true}
               awaitingPermission={awaitingPermission.has(session.id)}
+              awaitingPlanApproval={
+                awaitingPlanApproval.has(session.id) ||
+                deriveChatAttentionState(
+                  sidebarMessagesBySession[session.id] ?? [],
+                  false,
+                ) === "planReady"
+              }
               onClick={() => {
                 if (selectedSessionId !== session.id) {
                   selectSession(session.id);
@@ -302,6 +326,7 @@ function ChatTabButton({
   providerId,
   running,
   awaitingPermission,
+  awaitingPlanApproval,
   onClick,
   onClose,
 }: {
@@ -311,6 +336,7 @@ function ChatTabButton({
   providerId: ProviderId;
   running: boolean;
   awaitingPermission: boolean;
+  awaitingPlanApproval: boolean;
   onClick: () => void;
   onClose: () => void;
 }) {
@@ -328,10 +354,16 @@ function ChatTabButton({
         title={title ?? label}
         className="flex min-w-0 flex-1 items-center gap-1.5 py-0"
       >
-        {awaitingPermission ? (
+        {awaitingPlanApproval ? (
+          <span
+            className="inline-flex size-3.5 shrink-0 items-center justify-center text-emerald-300"
+            title="Plan ready to approve"
+          >
+            <HugeiconsIcon icon={TaskDone01Icon} className="size-3.5" />
+          </span>
+        ) : awaitingPermission ? (
           <span
             className="inline-flex size-3.5 shrink-0 items-center justify-center text-amber-300"
-            aria-label="Waiting for permission"
             title="Waiting for permission"
           >
             <HugeiconsIcon icon={SquareLock01Icon} className="size-3.5" />


### PR DESCRIPTION
## Summary

- hand off approved plans into a new session in the current chat
- cancel and exit plan mode in the originating session after handoff
- show the plan-ready indicator in top tabs only while approval is pending

## Why

Plan handoff previously created a separate chat and left the source session waiting for approval. Top tabs also treated all plan-mode sessions as approval-ready.

## Validation

- `bun run check-types` (from `apps/renderer`)
- `bunx biome lint src/components/composer/plan-approval-tray.tsx src/components/main-tabs.tsx`

Biome reports six pre-existing non-null-assertion warnings in `main-tabs.tsx`; no new lint errors.