### PR TITLE
Use native plan modes without permission churn

### DIFF
--- a/packages/agents/src/drivers/acp/fs.ts
+++ b/packages/agents/src/drivers/acp/fs.ts
@@ -68,6 +68,9 @@ async function ensureFsPermission(
 	if (policy.kind === "auto-allow") {
 		return;
 	}
+	if (policy.kind === "auto-deny") {
+		throw new Error(`Filesystem ${op} blocked in plan mode: ${targetPath}`);
+	}
 
 	// Build the canonical FileWrite kind (we treat create/delete/move as
 	// "write" style mutations for the permission system in Phase 1).

--- a/packages/agents/src/drivers/acp/terminal.ts
+++ b/packages/agents/src/drivers/acp/terminal.ts
@@ -124,6 +124,9 @@ async function ensureBashPermission(
 	);
 
 	if (policy.kind === "auto-allow") return;
+	if (policy.kind === "auto-deny") {
+		throw new Error(`Command blocked in plan mode: ${command}`);
+	}
 
 	const decision = await requestPermission(
 		{ _tag: "Bash", command },

--- a/packages/agents/src/drivers/browser-mcp-tools.ts
+++ b/packages/agents/src/drivers/browser-mcp-tools.ts
@@ -6,6 +6,7 @@ import type {
 	PermissionMode,
 	RuntimeMode,
 } from "@zuse/contracts";
+import { getToolPolicy } from "../kernel/policy.ts";
 
 import type { BrowserSend } from "./browser-tools.ts";
 import {
@@ -501,9 +502,17 @@ export const ensureBrowserPermission = async (
 ): Promise<void> => {
 	if (READ_ONLY_BROWSER_TOOLS.has(name)) return;
 
-	const forcePrompt =
-		name === "browser_login" || opts.getPermissionMode() === "plan";
-	if (!forcePrompt && opts.getRuntimeMode() === "full-access") return;
+	const policy = getToolPolicy(
+		"other",
+		opts.getRuntimeMode(),
+		opts.getPermissionMode(),
+	);
+	if (policy.kind === "auto-deny") {
+		throw new Error(`Browser action blocked in plan mode: ${name}.`);
+	}
+
+	const forcePrompt = name === "browser_login";
+	if (!forcePrompt && policy.kind === "auto-allow") return;
 
 	const decision = await opts.requestPermission(
 		{

--- a/packages/agents/src/drivers/codex-app-server-client.ts
+++ b/packages/agents/src/drivers/codex-app-server-client.ts
@@ -24,6 +24,8 @@ type CodexGoalRequestMethod =
 	| "thread/goal/set"
 	| "thread/goal/clear";
 
+type CodexExperimentalRequestMethod = "collaborationMode/list";
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
 
@@ -141,7 +143,10 @@ export class CodexAppServerClient {
 	}
 
 	request<T>(
-		method: ClientRequest["method"] | CodexGoalRequestMethod,
+		method:
+			| ClientRequest["method"]
+			| CodexGoalRequestMethod
+			| CodexExperimentalRequestMethod,
 		params: unknown,
 	): Promise<T> {
 		if (this.closed) {

--- a/packages/agents/src/drivers/codex.ts
+++ b/packages/agents/src/drivers/codex.ts
@@ -16,6 +16,7 @@ import {
 	type AgentSessionId,
 	AgentSessionStartError,
 	type AttachmentRef,
+	defaultModelFor,
 	type FileRef,
 	findModelDescriptor,
 	type PermissionDecision,
@@ -118,11 +119,55 @@ export const codexReasoningEffort = (
 		: null;
 };
 
-const codexApprovalPolicy = (
+export interface CodexCollaborationMode {
+	readonly mode: "plan" | "default";
+	readonly settings: {
+		readonly model: string;
+		readonly reasoning_effort: CodexReasoningEffort | null;
+		readonly developer_instructions: null;
+	};
+}
+
+/**
+ * Build the model-visible mode payload for one Codex turn. Current app-server
+ * releases expose native collaboration modes. Older compatible releases keep
+ * the instruction-prefix fallback until they can be upgraded.
+ */
+export const buildCodexTurnMode = (input: {
+	readonly permissionMode: PermissionMode;
+	readonly supportsNativePlanMode: boolean;
+	readonly prompt: string;
+	readonly model: string;
+	readonly effort: CodexReasoningEffort | null;
+}): {
+	readonly promptText: string;
+	readonly collaborationMode?: CodexCollaborationMode;
+} => {
+	if (!input.supportsNativePlanMode) {
+		return {
+			promptText: applyPlanModePrefix(input.permissionMode, input.prompt),
+		};
+	}
+
+	const mode = input.permissionMode === "plan" ? "plan" : "default";
+	return {
+		promptText: input.prompt,
+		collaborationMode: {
+			mode,
+			settings: {
+				model: input.model,
+				reasoning_effort: input.effort ?? (mode === "plan" ? "medium" : null),
+				developer_instructions: null,
+			},
+		},
+	};
+};
+
+export const codexApprovalPolicy = (
 	runtimeMode: RuntimeMode,
 	permissionMode: PermissionMode,
 ): AskForApproval => {
-	if (permissionMode === "plan") return "untrusted";
+	if (permissionMode === "plan") return "never";
 	switch (runtimeMode) {
 		case "approval-required":
 			return "untrusted";
@@ -193,7 +238,7 @@ export const codexWritableRootsForCwd = (
 	]);
 };
 
-const toSandboxPolicy = (
+export const codexSandboxPolicy = (
 	runtimeMode: RuntimeMode,
 	permissionMode: PermissionMode,
 	cwd: string,
@@ -325,6 +370,44 @@ const probeModelFastTier = async (
 			(entry) => entry.id === activeModel || entry.model === activeModel,
 		) ?? response.data.find((entry) => entry.isDefault);
 	return model === undefined ? null : modelAdvertisesFastTier(model);
+};
+
+export const supportsCodexNativePlanMode = (value: unknown): boolean => {
+	if (value === null || typeof value !== "object") return false;
+	const data = (value as { readonly data?: unknown }).data;
+	if (!Array.isArray(data)) return false;
+	const modes = new Set(
+		data.flatMap((item) =>
+			item !== null &&
+			typeof item === "object" &&
+			typeof (item as { readonly mode?: unknown }).mode === "string"
+				? [(item as { readonly mode: string }).mode]
+				: [],
+		),
+	);
+	return modes.has("plan") && modes.has("default");
+};
+
+const probeNativePlanMode = async (
+	app: CodexAppServerClient,
+): Promise<boolean> => {
+	try {
+		const response = await app.request<unknown>("collaborationMode/list", {});
+		return supportsCodexNativePlanMode(response);
+	} catch (cause) {
+		const message = cause instanceof Error ? cause.message : String(cause);
+		if (
+			!/method (?:not found|unknown)|unknown method|unsupported method/i.test(
+				message,
+			)
+		) {
+			console.warn(
+				"[codex] native plan-mode probe failed; using fallback",
+				cause,
+			);
+		}
+		return false;
+	}
 };
 
 const toolIdentifierPart = (value: string): string =>
@@ -1078,6 +1161,7 @@ export const startCodexSession = (
 		const toolTranslationLog = createCodexToolTranslationLogger(cwd, sessionId);
 		const statusLog = createCodexStatusLogger(cwd, sessionId);
 		let currentMode: PermissionMode = input.permissionMode ?? "default";
+		let activeModel = input.model ?? defaultModelFor("codex");
 		let activeThreadId = resumeCursor;
 		let currentTurnId: string | null = null;
 		let latestDiff = "";
@@ -1176,6 +1260,10 @@ export const startCodexSession = (
 				"[codex] API key credential present; app-server uses Codex CLI auth",
 			);
 		}
+
+		const supportsNativePlanMode = yield* Effect.promise(() =>
+			probeNativePlanMode(app),
+		);
 
 		let browserMcpBridge: Awaited<
 			ReturnType<typeof startBrowserMcpBridge>
@@ -1322,29 +1410,32 @@ export const startCodexSession = (
 				// "Fork chat": branch the source thread into a NEW thread so the
 				// original transcript stays intact. The forked thread id becomes this
 				// session's cursor via the SessionCursor emit below.
-				const forked = await app.request<{ thread: { id: string } }>(
-					"thread/fork",
-					{
-						threadId: activeThreadId,
-						...commonThreadParams,
-					},
-				);
+				const forked = await app.request<{
+					thread: { id: string };
+					model?: string;
+				}>("thread/fork", {
+					threadId: activeThreadId,
+					...commonThreadParams,
+				});
 				activeThreadId = forked.thread.id;
+				if (forked.model !== undefined) activeModel = forked.model;
 			} else if (activeThreadId !== null) {
-				const resumed = await app.request<{ thread: { id: string } }>(
-					"thread/resume",
-					{
-						threadId: activeThreadId,
-						...commonThreadParams,
-					},
-				);
+				const resumed = await app.request<{
+					thread: { id: string };
+					model?: string;
+				}>("thread/resume", {
+					threadId: activeThreadId,
+					...commonThreadParams,
+				});
 				activeThreadId = resumed.thread.id;
+				if (resumed.model !== undefined) activeModel = resumed.model;
 			} else {
-				const started = await app.request<{ thread: { id: string } }>(
-					"thread/start",
-					commonThreadParams,
-				);
+				const started = await app.request<{
+					thread: { id: string };
+					model?: string;
+				}>("thread/start", commonThreadParams);
 				activeThreadId = started.thread.id;
+				if (started.model !== undefined) activeModel = started.model;
 			}
 			emit({
 				_tag: "SessionCursor",
@@ -1368,7 +1459,7 @@ export const startCodexSession = (
 			// authoritative per-model gate enforced at turn time (see `runTurn`).
 			// Best-effort — a failure leaves `modelFastTier` null (trust the FE).
 			try {
-				modelFastTier = await probeModelFastTier(app, input.model ?? null);
+				modelFastTier = await probeModelFastTier(app, activeModel);
 			} catch (cause) {
 				console.warn("[codex] fast-tier probe failed", cause);
 			}
@@ -1460,10 +1551,19 @@ export const startCodexSession = (
 			if (commandHandled) return;
 
 			emit({ _tag: "Status", status: "running" });
-			// Plan-mode emulation: Codex has no native "plan" runtime mode, so
-			// prepend a developer-instructions block while plan mode is active.
-			// The sandbox policy still gates writes, so this is belt-and-braces.
-			const basePromptText = applyPlanModePrefix(currentMode, text);
+			// Reasoning effort is part of native collaboration-mode settings because
+			// that payload takes precedence over the top-level turn fields.
+			const effort = codexReasoningEffort(
+				input.model,
+				input.modelOptions?.["reasoning"],
+			);
+			const turnMode = buildCodexTurnMode({
+				permissionMode: currentMode,
+				supportsNativePlanMode,
+				prompt: text,
+				model: activeModel,
+				effort,
+			});
 			const promptHints = [
 				...(browserHintPending ? [browserMcpPromptHint()] : []),
 				...(orchestrationHintPending && orchestrationTools !== null
@@ -1472,18 +1572,10 @@ export const startCodexSession = (
 			];
 			const promptText =
 				promptHints.length > 0
-					? `${promptHints.join("\n\n")}\n\n${basePromptText}`
-					: basePromptText;
+					? `${promptHints.join("\n\n")}\n\n${turnMode.promptText}`
+					: turnMode.promptText;
 			browserHintPending = false;
 			orchestrationHintPending = false;
-			// Reasoning effort: forwarded from FE picker via
-			// `input.modelOptions.reasoning`. Each model's wire descriptor limits
-			// the picker to the tiers it supports; the selected literal is then
-			// forwarded unchanged to Codex.
-			const effort = codexReasoningEffort(
-				input.model,
-				input.modelOptions?.["reasoning"],
-			);
 			// Fast mode: the `fastMode` per-model boolean knob maps onto Codex's
 			// `serviceTier: "fast"` (the 1.5× speed tier). The FE only shows the
 			// toggle when the CLI version + static model catalog allow it; the live
@@ -1511,10 +1603,13 @@ export const startCodexSession = (
 				],
 				cwd,
 				approvalPolicy: codexApprovalPolicy(getRuntimeMode(), currentMode),
-				sandboxPolicy: toSandboxPolicy(getRuntimeMode(), currentMode, cwd),
+				sandboxPolicy: codexSandboxPolicy(getRuntimeMode(), currentMode, cwd),
 				model: input.model ?? null,
 				...(effort !== null ? { effort } : {}),
 				...(fastMode ? { serviceTier: "fast" } : {}),
+				...(turnMode.collaborationMode !== undefined
+					? { collaborationMode: turnMode.collaborationMode }
+					: {}),
 			});
 			currentTurnId = turn.turn.id;
 		};
@@ -1683,23 +1778,14 @@ export const startCodexSession = (
 					}
 					return true;
 				case "init":
-					emit({ _tag: "Status", status: "running" });
-					await app.request("turn/start", {
-						threadId: activeThreadId,
-						input: [
-							{
-								type: "text",
-								text:
-									args.length > 0
-										? `Initialize repository instructions. ${args}`
-										: "Initialize or update AGENTS.md with concise project instructions for Codex.",
-								text_elements: [],
-							},
-						],
-						cwd,
-						approvalPolicy: codexApprovalPolicy(getRuntimeMode(), currentMode),
-						sandboxPolicy: toSandboxPolicy(getRuntimeMode(), currentMode, cwd),
-					});
+					await runTurn(
+						args.length > 0
+							? `Initialize repository instructions. ${args}`
+							: "Initialize or update AGENTS.md with concise project instructions for Codex.",
+						[],
+						[],
+						[],
+					);
 					return true;
 				case "ps":
 				case "stop":
@@ -1971,6 +2057,9 @@ export const startCodexSession = (
 					if (policy.kind === "auto-allow") {
 						return { decision: "accept" };
 					}
+					if (policy.kind === "auto-deny") {
+						return { decision: "decline" };
+					}
 					emit({
 						_tag: "PermissionRequest",
 						itemId: p.itemId as AgentItemId,
@@ -1996,6 +2085,9 @@ export const startCodexSession = (
 					if (policy.kind === "auto-allow") {
 						return { decision: "accept" };
 					}
+					if (policy.kind === "auto-deny") {
+						return { decision: "decline" };
+					}
 					emit({
 						_tag: "PermissionRequest",
 						itemId: p.itemId as AgentItemId,
@@ -2011,7 +2103,10 @@ export const startCodexSession = (
 				}
 				case "item/permissions/requestApproval": {
 					const p = request.params;
-					if (currentMode !== "plan" && getRuntimeMode() === "full-access") {
+					if (currentMode === "plan") {
+						return { permissions: {}, scope: "turn" };
+					}
+					if (getRuntimeMode() === "full-access") {
 						return { permissions: {}, scope: "session" };
 					}
 					emit({

--- a/packages/agents/src/drivers/grok.ts
+++ b/packages/agents/src/drivers/grok.ts
@@ -33,7 +33,8 @@ import { makeAcpPermissionContext } from "../kernel/acp-permission-context.ts";
 import { createAcpSession } from "../kernel/acp-session.ts";
 import { AttachmentService } from "../kernel/attachment-service.ts";
 import type { GoalCapableSessionHandle } from "../kernel/driver.ts";
-import { getBashPolicy, getFsPolicy } from "../kernel/policy.ts";
+import type { ToolCategory } from "../kernel/permission-policy.ts";
+import { getBashPolicy, getFsPolicy, getToolPolicy } from "../kernel/policy.ts";
 import { issueProviderMcpSession } from "../kernel/provider-mcp-session.ts";
 import { makeStdioMcpFallback } from "../kernel/stdio-mcp-fallback.ts";
 import { prefixFirstPromptWithWorkspaceInstructions } from "../kernel/workspace-instructions.ts";
@@ -327,15 +328,28 @@ const SUMMARY_KEYS = new Set([
 	"question",
 ]);
 
+type ClassifiedGrokPermission = {
+	readonly kind: PermissionKind;
+	readonly category: ToolCategory;
+	readonly path?: string;
+};
+
 const classifyGrokNativePermission = (
 	method: string,
 	params: unknown,
-): PermissionKind => {
+): ClassifiedGrokPermission => {
 	const command = firstStringByKey(params, COMMAND_KEYS);
 	const path = firstStringByKey(params, PATH_KEYS);
 	const url = firstStringByKey(params, URL_KEYS);
 	const tool = firstStringByKey(params, TOOL_KEYS) ?? method;
 	const toolKey = lower(tool);
+	const toolTokens = new Set(
+		tool
+			.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+			.toLowerCase()
+			.split(/[^a-z0-9]+/)
+			.filter((token) => token.length > 0),
+	);
 
 	if (
 		command !== null ||
@@ -343,44 +357,84 @@ const classifyGrokNativePermission = (
 		toolKey.includes("bash") ||
 		toolKey.includes("terminal")
 	) {
-		return { _tag: "Bash", command: command ?? tool };
+		return {
+			kind: { _tag: "Bash", command: command ?? tool },
+			category: "execute",
+		};
 	}
-	if (
-		path !== null ||
-		toolKey.includes("edit") ||
-		toolKey.includes("write") ||
-		toolKey.includes("replace") ||
-		toolKey.includes("delete") ||
-		toolKey.includes("move")
-	) {
-		return { _tag: "FileWrite", path: path ?? tool };
+	const mutates = [
+		"create",
+		"delete",
+		"edit",
+		"move",
+		"patch",
+		"post",
+		"put",
+		"replace",
+		"upload",
+		"write",
+	].some((verb) => toolTokens.has(verb));
+	if (mutates) {
+		return {
+			kind: { _tag: "FileWrite", path: path ?? url ?? tool },
+			category: "edit",
+		};
 	}
-	if (url !== null || toolKey.includes("fetch") || toolKey.includes("web")) {
-		return { _tag: "Network", url: url ?? tool };
+	const reads = [
+		"fetch",
+		"find",
+		"get",
+		"glob",
+		"grep",
+		"inspect",
+		"list",
+		"read",
+		"search",
+		"stat",
+		"view",
+		"web",
+	].some((verb) => toolTokens.has(verb));
+	if (reads) {
+		return {
+			kind:
+				url !== null
+					? { _tag: "Network", url }
+					: {
+							_tag: "Other",
+							tool,
+							summary: path ?? stringifyCompact(params),
+						},
+			category: "read",
+			...(path !== null ? { path } : {}),
+		};
+	}
+	if (path !== null) {
+		return { kind: { _tag: "FileWrite", path }, category: "edit" };
 	}
 
 	return {
-		_tag: "Other",
-		tool,
-		summary:
-			firstStringByKey(params, SUMMARY_KEYS) ??
-			command ??
-			path ??
-			url ??
-			stringifyCompact(params),
+		kind: {
+			_tag: "Other",
+			tool,
+			summary:
+				firstStringByKey(params, SUMMARY_KEYS) ?? stringifyCompact(params),
+		},
+		category: "other",
 	};
 };
 
 const nativePermissionPolicy = (
-	kind: PermissionKind,
+	permission: ClassifiedGrokPermission,
 	runtimeMode: RuntimeMode,
 	permissionMode: PermissionMode,
 ):
 	| { readonly kind: "auto-allow" }
+	| { readonly kind: "auto-deny" }
 	| {
 			readonly kind: "prompt";
 			readonly forcePrompt: boolean;
 	  } => {
+	const { kind } = permission;
 	switch (kind._tag) {
 		case "Bash":
 			return getBashPolicy(kind.command, runtimeMode, permissionMode);
@@ -388,11 +442,15 @@ const nativePermissionPolicy = (
 			return getFsPolicy("write", kind.path, runtimeMode, permissionMode);
 		case "Network":
 		case "Other":
-			if (permissionMode === "plan") {
-				return { kind: "prompt", forcePrompt: true };
+			if (permission.category === "read" && permission.path !== undefined) {
+				return getFsPolicy(
+					"read",
+					permission.path,
+					runtimeMode,
+					permissionMode,
+				);
 			}
-			if (runtimeMode === "full-access") return { kind: "auto-allow" };
-			return { kind: "prompt", forcePrompt: false };
+			return getToolPolicy(permission.category, runtimeMode, permissionMode);
 	}
 };
 
@@ -420,15 +478,16 @@ export const handleGrokNativePermissionRequest = async (
 ): Promise<unknown | null> => {
 	if (!isGrokNativePermissionMethod(method)) return null;
 
-	const kind = classifyGrokNativePermission(method, params);
+	const permission = classifyGrokNativePermission(method, params);
 	const policy = nativePermissionPolicy(
-		kind,
+		permission,
 		ctx.getRuntimeMode(),
 		ctx.getPermissionMode(),
 	);
 	if (policy.kind === "auto-allow") return grokPermissionResponse(true);
+	if (policy.kind === "auto-deny") return grokPermissionResponse(false);
 
-	const decision = await ctx.requestPermission(kind, {
+	const decision = await ctx.requestPermission(permission.kind, {
 		forcePrompt: policy.forcePrompt,
 	});
 	return grokPermissionResponse(decision._tag !== "Deny");

--- a/packages/agents/src/drivers/orchestration-tools.ts
+++ b/packages/agents/src/drivers/orchestration-tools.ts
@@ -6,6 +6,7 @@ import type {
 	RuntimeMode,
 } from "@zuse/contracts";
 import { z } from "zod";
+import { getToolPolicy } from "../kernel/policy.ts";
 import {
 	booleanProp,
 	type JsonSchemaObject,
@@ -401,8 +402,16 @@ export const ensureOrchestrationPermission = async (
 	if (!isOrchestrationToolName(name)) throw new Error(`Unknown tool: ${name}`);
 	if (!MUTATING_ORCHESTRATION_TOOLS.has(name)) return;
 
-	const forcePrompt = opts.getPermissionMode() === "plan";
-	if (!forcePrompt && opts.getRuntimeMode() === "full-access") return;
+	const policy = getToolPolicy(
+		"delegate",
+		opts.getRuntimeMode(),
+		opts.getPermissionMode(),
+	);
+	if (policy.kind === "auto-deny") {
+		throw new Error(`Orchestration action blocked in plan mode: ${name}.`);
+	}
+
+	if (policy.kind === "auto-allow") return;
 
 	const decision = await opts.requestPermission(
 		{
@@ -410,7 +419,7 @@ export const ensureOrchestrationPermission = async (
 			tool: name,
 			summary: permissionSummary(name, args),
 		},
-		{ forcePrompt },
+		{ forcePrompt: false },
 	);
 	if (decision._tag === "Deny") {
 		throw new Error(`Permission denied for ${name}.`);

--- a/packages/agents/src/drivers/planMode.ts
+++ b/packages/agents/src/drivers/planMode.ts
@@ -2,14 +2,14 @@ import type { PermissionMode } from "@zuse/contracts";
 
 /**
  * Developer-instructions prefix that emulates plan mode for providers that
- * don't have a native equivalent. The Claude Agent SDK has `permissionMode:
- * "plan"`, Cursor's ACP has `setSessionMode("plan")`, but Codex/Grok/Gemini
- * don't expose a runtime read-only switch — so we prepend this block to the
- * user's prompt while plan mode is active.
+ * don't have a native equivalent. It is also the compatibility fallback for
+ * older app-server releases that predate native collaboration modes. ACP
+ * providers currently receive this block when their live session protocols
+ * do not expose a mode switch.
  *
- * The model is still free to ignore it, which is why we ALSO keep
- * `RuntimeMode: "approval-required"` as the safety net for any tool call
- * that wants to mutate state.
+ * The model is still free to ignore it, so the permission policy separately
+ * allows reads and rejects mutations without prompting. The instruction mainly
+ * improves UX by preventing attempted writes.
  */
 export const PLAN_MODE_INSTRUCTIONS =
 	"PLAN MODE — you are in read-only planning mode. Investigate the " +

--- a/packages/agents/src/kernel/permission-policy.ts
+++ b/packages/agents/src/kernel/permission-policy.ts
@@ -43,11 +43,15 @@ const promptOrDeny = (canPrompt: boolean | undefined): PermissionVerdict =>
 	canPrompt === false ? "deny" : "prompt";
 
 export const decidePermission = (input: PermissionInput): PermissionVerdict => {
-	if (input.sensitive || input.category === "exit-plan") {
+	if (input.category === "exit-plan") {
 		return promptOrDeny(input.canPrompt);
 	}
 	if (input.permissionMode === "plan") {
-		return input.category === "read" ? "allow" : promptOrDeny(input.canPrompt);
+		if (input.category !== "read") return "deny";
+		return input.sensitive ? promptOrDeny(input.canPrompt) : "allow";
+	}
+	if (input.sensitive) {
+		return promptOrDeny(input.canPrompt);
 	}
 	if (input.category === "read") return "allow";
 	if (input.permissionMode === "acceptEdits" && input.category === "edit") {

--- a/packages/agents/src/kernel/policy.ts
+++ b/packages/agents/src/kernel/policy.ts
@@ -2,6 +2,7 @@ import {
 	decidePermission,
 	isSensitivePath,
 	type PermissionVerdict,
+	type ToolCategory,
 } from "@zuse/agents/kernel/permission-policy";
 import type { PermissionMode, RuntimeMode } from "@zuse/contracts";
 
@@ -24,15 +25,16 @@ import type { PermissionMode, RuntimeMode } from "@zuse/contracts";
 
 // Sensitive-path matching and the runtime/permission decision table live in
 // the provider-neutral agent kernel. This module only adapts kernel verdicts
-// to the ACP handlers' historical `auto-allow | prompt` response shape.
+// to the ACP handlers' `auto-allow | auto-deny | prompt` response shape.
 // ---------------------------------------------------------------------------
 // FS operation policy (used by ACP handleFsRequest)
 // ---------------------------------------------------------------------------
 
 export type FsOp = "read" | "write" | "create" | "delete" | "move";
 
-type ProviderPolicy =
+export type ProviderPolicy =
 	| { readonly kind: "auto-allow" }
+	| { readonly kind: "auto-deny" }
 	| { readonly kind: "prompt"; readonly forcePrompt: boolean };
 
 export type FsPolicy = ProviderPolicy;
@@ -43,7 +45,24 @@ const providerPolicy = (
 ): ProviderPolicy =>
 	verdict === "allow"
 		? { kind: "auto-allow" }
-		: { kind: "prompt", forcePrompt };
+		: verdict === "deny"
+			? { kind: "auto-deny" }
+			: { kind: "prompt", forcePrompt };
+
+export const getToolPolicy = (
+	category: ToolCategory,
+	runtimeMode: RuntimeMode,
+	permissionMode?: PermissionMode,
+): ProviderPolicy =>
+	providerPolicy(
+		decidePermission({
+			runtimeMode,
+			permissionMode: permissionMode ?? "default",
+			category,
+			sensitive: false,
+		}),
+		false,
+	);
 
 /**
  * Decide whether an ACP FS mutation (or read) should prompt the user.
@@ -53,7 +72,7 @@ const providerPolicy = (
  *  2. Pure reads → auto-allow.
  *  3. auto-accept-edits modes → non-sensitive writes/edits are auto-allowed.
  *  4. full-access → auto-allow anything that survived the sensitive check.
- *  5. plan mode (when passed) → we can force-deny or force-prompt (caller decides).
+ *  5. plan mode → deny mutations without prompting.
  *  6. default → prompt (forcePrompt: false).
  */
 export const getFsPolicy = (
@@ -80,34 +99,86 @@ export const getFsPolicy = (
 
 export type BashPolicy = ProviderPolicy;
 
+const SIMPLE_READ_ONLY_COMMANDS = new Set([
+	"cat",
+	"du",
+	"grep",
+	"head",
+	"ls",
+	"pwd",
+	"stat",
+	"tail",
+	"wc",
+]);
+
+/** Conservative allow-list for shell-based codebase inspection in plan mode. */
+export const isReadOnlyShellCommand = (command: string): boolean => {
+	const trimmed = command.trim();
+	if (
+		trimmed.length === 0 ||
+		/[;&|><\n\r`]/.test(trimmed) ||
+		trimmed.includes("$(")
+	) {
+		return false;
+	}
+
+	const words = trimmed.split(/\s+/);
+	if (
+		words.some((word) => {
+			const unquoted = word.replace(/^['"]|['"]$/g, "");
+			const optionValue = unquoted.includes("=")
+				? unquoted.slice(unquoted.indexOf("=") + 1)
+				: unquoted;
+			return isSensitivePath(unquoted) || isSensitivePath(optionValue);
+		})
+	) {
+		return false;
+	}
+	if (
+		words.some((word) => word === "--output" || word.startsWith("--output="))
+	) {
+		return false;
+	}
+	const executable = words[0];
+	if (executable === undefined) return false;
+	if (SIMPLE_READ_ONLY_COMMANDS.has(executable)) return true;
+	if (executable !== "rg") return false;
+	return !words.some(
+		(word) =>
+			word === "--hidden" ||
+			word === "--no-ignore" ||
+			word.startsWith("--no-ignore-") ||
+			word === "--pre" ||
+			word.startsWith("--pre=") ||
+			/^-u{1,3}$/.test(word),
+	);
+};
+
 /**
  * Decide whether an ACP terminal command should prompt the user.
  *
  * Mirrors Claude's `policyFor` handling of the Bash tool exactly so ACP
  * agents (Grok, Gemini, Cursor) get the same gating as the SDK drivers:
- *  1. plan mode → always prompt (forcePrompt) — never silently run commands.
+ *  1. plan mode → allow a conservative set of read-only inspection commands
+ *     and deny everything else without prompting.
  *  2. full-access → auto-allow.
  *  3. auto-accept-edits-and-bash → auto-allow.
  *  4. auto-accept-edits → still prompt. Unlike file edits, command execution
  *     is NOT auto-accepted in this mode.
  *  5. default (approval-required) → prompt (forcePrompt: false).
  *
- * Important: this policy does **not** path-scan `command` for sensitive
- * strings (`.env`, keys, etc.). A shell line that `ls`s another project
- * directory is not a "sensitive path". When `forcePrompt` is true for Bash,
- * the cause is plan mode (or a future per-command heuristic), never
- * `isSensitivePath`. The renderer must not label Bash force-prompts as
- * "Sensitive path" — that copy confuses Grok/ACP users in plan mode.
- *
- * `command` is accepted for future per-command heuristics (e.g. forcing a
- * prompt on obviously destructive commands) but is not inspected yet.
+ * The plan-mode allow-list rejects shell composition, output redirection,
+ * mutating command variants, and sensitive path strings. Unknown commands are
+ * denied rather than guessed safe.
  */
 export const getBashPolicy = (
 	command: string,
 	runtimeMode: RuntimeMode,
 	permissionMode?: PermissionMode,
 ): BashPolicy => {
-	void command;
+	if (permissionMode === "plan" && isReadOnlyShellCommand(command)) {
+		return { kind: "auto-allow" };
+	}
 	return providerPolicy(
 		decidePermission({
 			runtimeMode,

--- a/packages/agents/test/unit/drivers/browser-mcp-tools.test.ts
+++ b/packages/agents/test/unit/drivers/browser-mcp-tools.test.ts
@@ -1,0 +1,42 @@
+import { ensureBrowserPermission } from "@zuse/agents/drivers/browser-mcp-tools";
+import { describe, expect, it } from "vitest";
+
+describe("browser MCP plan permissions", () => {
+	it("allows read-only browser tools without requesting permission", async () => {
+		let requestCount = 0;
+		await ensureBrowserPermission(
+			"browser_snapshot",
+			{},
+			{
+				send: async () => ({ id: "browser-test", ok: true }),
+				getPermissionMode: () => "plan",
+				getRuntimeMode: () => "full-access",
+				requestPermission: async () => {
+					requestCount += 1;
+					return { _tag: "AllowOnce" };
+				},
+			},
+		);
+		expect(requestCount).toBe(0);
+	});
+
+	it("denies mutating browser tools without requesting permission", async () => {
+		let requestCount = 0;
+		await expect(
+			ensureBrowserPermission(
+				"browser_click",
+				{},
+				{
+					send: async () => ({ id: "browser-test", ok: true }),
+					getPermissionMode: () => "plan",
+					getRuntimeMode: () => "full-access",
+					requestPermission: async () => {
+						requestCount += 1;
+						return { _tag: "AllowOnce" };
+					},
+				},
+			),
+		).rejects.toThrow(/blocked/i);
+		expect(requestCount).toBe(0);
+	});
+});

--- a/packages/agents/test/unit/drivers/codex.test.ts
+++ b/packages/agents/test/unit/drivers/codex.test.ts
@@ -1,13 +1,17 @@
 import { execFileSync } from "node:child_process";
 import type { ThreadItem } from "@zuse/agents/codex-generated/v2/ThreadItem";
 import {
+	buildCodexTurnMode,
+	codexApprovalPolicy,
 	codexDetachedAgentFromSubAgentActivity,
 	codexDetachedAgentToolUse,
 	codexFinishDetachedAgent,
 	codexReasoningEffort,
+	codexSandboxPolicy,
 	codexWithDetachedParent,
 	codexWritableRootsForCwd,
 	readCodexSubAgentActivity,
+	supportsCodexNativePlanMode,
 	translateCodexCollabItem,
 	translateCodexItem,
 	translateCodexStatusNotification,
@@ -557,5 +561,85 @@ describe("codexReasoningEffort", () => {
 		expect(codexReasoningEffort("custom-model", "ultra")).toBeNull();
 		expect(codexReasoningEffort(undefined, undefined)).toBeNull();
 		expect(codexReasoningEffort("gpt-5.6-luna", "turbo")).toBeNull();
+	});
+});
+
+describe("Codex plan mode", () => {
+	it("requires both native collaboration modes in the capability response", () => {
+		expect(
+			supportsCodexNativePlanMode({
+				data: [{ mode: "plan" }, { mode: "default" }],
+			}),
+		).toBe(true);
+		expect(supportsCodexNativePlanMode({ data: [{ mode: "plan" }] })).toBe(
+			false,
+		);
+		expect(supportsCodexNativePlanMode({})).toBe(false);
+	});
+
+	it("uses native collaboration mode without rewriting the user prompt", () => {
+		expect(
+			buildCodexTurnMode({
+				permissionMode: "plan",
+				supportsNativePlanMode: true,
+				prompt: "Investigate the queue bug",
+				model: "gpt-5.5",
+				effort: "high",
+			}),
+		).toEqual({
+			promptText: "Investigate the queue bug",
+			collaborationMode: {
+				mode: "plan",
+				settings: {
+					model: "gpt-5.5",
+					reasoning_effort: "high",
+					developer_instructions: null,
+				},
+			},
+		});
+	});
+
+	it("sends native default mode when leaving plan mode", () => {
+		expect(
+			buildCodexTurnMode({
+				permissionMode: "default",
+				supportsNativePlanMode: true,
+				prompt: "Implement it",
+				model: "gpt-5.5",
+				effort: null,
+			}),
+		).toEqual({
+			promptText: "Implement it",
+			collaborationMode: {
+				mode: "default",
+				settings: {
+					model: "gpt-5.5",
+					reasoning_effort: null,
+					developer_instructions: null,
+				},
+			},
+		});
+	});
+
+	it("keeps the instruction-prefix fallback for older app servers", () => {
+		const result = buildCodexTurnMode({
+			permissionMode: "plan",
+			supportsNativePlanMode: false,
+			prompt: "Investigate the queue bug",
+			model: "gpt-5.5",
+			effort: null,
+		});
+
+		expect(result.collaborationMode).toBeUndefined();
+		expect(result.promptText).toContain("PLAN MODE");
+		expect(result.promptText).toContain("Investigate the queue bug");
+	});
+
+	it("never asks for approval while retaining a read-only sandbox", () => {
+		expect(codexApprovalPolicy("full-access", "plan")).toBe("never");
+		expect(codexSandboxPolicy("full-access", "plan", "/repo")).toEqual({
+			type: "readOnly",
+			networkAccess: false,
+		});
 	});
 });

--- a/packages/agents/test/unit/drivers/grok-native-permission.test.ts
+++ b/packages/agents/test/unit/drivers/grok-native-permission.test.ts
@@ -96,7 +96,7 @@ describe("Grok native ACP permission handling", () => {
 		});
 	});
 
-	it("does not silently approve plan-mode native shell permissions", async () => {
+	it("silently denies plan-mode native shell permissions", async () => {
 		const requests: Array<{ kind: PermissionKind; forcePrompt: boolean }> = [];
 		const result = await handleGrokNativePermissionRequest(
 			"tool/requestApproval",
@@ -110,13 +110,75 @@ describe("Grok native ACP permission handling", () => {
 			}),
 		);
 
+		expect(requests).toEqual([]);
+		expect(result).toMatchObject({ outcome: "denied", approved: false });
+	});
+
+	it("allows plan-mode read requests without prompting", async () => {
+		let requestCount = 0;
+		for (const params of [
+			{ tool: "read_file", path: "/repo/src/app.ts" },
+			{ tool: "web_fetch", url: "https://example.com/docs" },
+			{ tool: "Shell", command: "rg TODO src" },
+		]) {
+			const result = await handleGrokNativePermissionRequest(
+				"tool/requestApproval",
+				params,
+				makeCtx({
+					runtimeMode: "full-access",
+					permissionMode: "plan",
+					onRequest: () => {
+						requestCount += 1;
+					},
+				}),
+			);
+			expect(result).toMatchObject({ outcome: "approved", approved: true });
+		}
+		expect(requestCount).toBe(0);
+	});
+
+	it("does not infer reads from verb substrings in unknown tool names", async () => {
+		let requestCount = 0;
+		const result = await handleGrokNativePermissionRequest(
+			"tool/requestApproval",
+			{ tool: "target_window", path: "/repo/src/app.ts" },
+			makeCtx({
+				runtimeMode: "full-access",
+				permissionMode: "plan",
+				onRequest: () => {
+					requestCount += 1;
+				},
+			}),
+		);
+
+		expect(requestCount).toBe(0);
+		expect(result).toMatchObject({ outcome: "denied", approved: false });
+	});
+
+	it("keeps sensitive plan-mode file reads behind the protected-path gate", async () => {
+		const requests: Array<{ kind: PermissionKind; forcePrompt: boolean }> = [];
+		await handleGrokNativePermissionRequest(
+			"tool/requestApproval",
+			{ tool: "read_file", path: "/repo/.env" },
+			makeCtx({
+				runtimeMode: "full-access",
+				permissionMode: "plan",
+				onRequest: (kind, forcePrompt) => {
+					requests.push({ kind, forcePrompt });
+				},
+			}),
+		);
+
 		expect(requests).toEqual([
 			{
-				kind: { _tag: "Bash", command: "bun install" },
+				kind: {
+					_tag: "Other",
+					tool: "read_file",
+					summary: "/repo/.env",
+				},
 				forcePrompt: true,
 			},
 		]);
-		expect(result).toMatchObject({ outcome: "approved", approved: true });
 	});
 
 	it("ignores unknown non-permission ACP methods", async () => {

--- a/packages/agents/test/unit/drivers/orchestration-tools.test.ts
+++ b/packages/agents/test/unit/drivers/orchestration-tools.test.ts
@@ -1,5 +1,6 @@
 import {
 	callOrchestrationTool,
+	ensureOrchestrationPermission,
 	MUTATING_ORCHESTRATION_TOOLS,
 	ORCHESTRATION_MCP_SERVER_NAME,
 	ORCHESTRATION_MCP_TOOLS,
@@ -9,6 +10,25 @@ import {
 import { describe, expect, test } from "vitest";
 
 describe("orchestration MCP tools", () => {
+	test("denies plan-mode mutations without requesting permission", async () => {
+		let requestCount = 0;
+		await expect(
+			ensureOrchestrationPermission(
+				"create_session",
+				{ task: "test" },
+				{
+					getPermissionMode: () => "plan",
+					getRuntimeMode: () => "full-access",
+					requestPermission: async () => {
+						requestCount += 1;
+						return { _tag: "AllowOnce" };
+					},
+				},
+			),
+		).rejects.toThrow(/blocked/i);
+		expect(requestCount).toBe(0);
+	});
+
 	test("exposes the stable provider-neutral tool set", () => {
 		expect(ORCHESTRATION_MCP_SERVER_NAME).toBe("zuse-orchestration");
 		expect(ORCHESTRATION_MCP_TOOLS.map((tool) => tool.name)).toEqual([

--- a/packages/agents/test/unit/kernel/permission-policy.test.ts
+++ b/packages/agents/test/unit/kernel/permission-policy.test.ts
@@ -23,7 +23,7 @@ describe("decidePermission", () => {
 		).toBe(expected);
 	});
 
-	test("keeps plan mode read-only and always prompts to exit", () => {
+	test("keeps plan mode read-only, denies mutations, and prompts only to exit", () => {
 		expect(
 			decidePermission({
 				runtimeMode: "full-access",
@@ -39,7 +39,7 @@ describe("decidePermission", () => {
 				category: "execute",
 				sensitive: false,
 			}),
-		).toBe("prompt");
+		).toBe("deny");
 		expect(
 			decidePermission({
 				runtimeMode: "full-access",

--- a/packages/agents/test/unit/kernel/policy.test.ts
+++ b/packages/agents/test/unit/kernel/policy.test.ts
@@ -2,7 +2,11 @@ import {
 	isSensitivePath,
 	SENSITIVE_PATH_PATTERNS,
 } from "@zuse/agents/kernel/permission-policy";
-import { getBashPolicy, getFsPolicy } from "@zuse/agents/kernel/policy";
+import {
+	getBashPolicy,
+	getFsPolicy,
+	isReadOnlyShellCommand,
+} from "@zuse/agents/kernel/policy";
 import type { PermissionMode, RuntimeMode } from "@zuse/contracts";
 import { describe, expect, it } from "vitest";
 
@@ -80,14 +84,14 @@ describe("getFsPolicy", () => {
 		});
 	});
 
-	it("plan mode forces a prompt for mutations even under full-access", () => {
+	it("plan mode silently denies mutations even under full-access", () => {
 		const policy = getFsPolicy(
 			"write",
 			"/repo/src/a.ts",
 			"full-access",
 			"plan",
 		);
-		expect(policy).toEqual({ kind: "prompt", forcePrompt: true });
+		expect(policy).toEqual({ kind: "auto-deny" });
 	});
 
 	it("auto-accept-edits modes auto-allow non-sensitive mutations", () => {
@@ -120,11 +124,10 @@ describe("getFsPolicy", () => {
 });
 
 describe("getBashPolicy", () => {
-	it("plan mode always forces a prompt", () => {
+	it("plan mode silently denies mutating commands", () => {
 		for (const mode of RUNTIME_MODES) {
 			expect(getBashPolicy("rm -rf /", mode, "plan")).toEqual({
-				kind: "prompt",
-				forcePrompt: true,
+				kind: "auto-deny",
 			});
 		}
 	});
@@ -153,12 +156,41 @@ describe("getBashPolicy", () => {
 		});
 	});
 
-	it("plan mode wins over full-access", () => {
+	it("plan mode permits conservative inspection under full-access", () => {
 		const mode: RuntimeMode = "full-access";
 		const perm: PermissionMode = "plan";
 		expect(getBashPolicy("ls", mode, perm)).toEqual({
-			kind: "prompt",
-			forcePrompt: true,
+			kind: "auto-allow",
 		});
+	});
+
+	it("rejects shell composition, mutating variants, and sensitive reads", () => {
+		for (const command of [
+			"rg TODO | xargs rm",
+			"rg --pre 'touch /tmp/out' pattern",
+			"rg --ignore-file=.env TODO",
+			"find . -delete",
+			"sed -i s/a/b/ app.ts",
+			"sed -n 'w /tmp/out' README.md",
+			"tree -o /tmp/tree.txt",
+			"cat .env",
+			"git checkout main",
+		]) {
+			expect(isReadOnlyShellCommand(command)).toBe(false);
+			expect(getBashPolicy(command, "full-access", "plan")).toEqual({
+				kind: "auto-deny",
+			});
+		}
+	});
+
+	it("allows common read-only codebase inspection", () => {
+		for (const command of [
+			"rg TODO src",
+			"ls -la src",
+			"head -80 README.md",
+			"cat package.json",
+		]) {
+			expect(isReadOnlyShellCommand(command)).toBe(true);
+		}
 	});
 });


### PR DESCRIPTION
## What changed

- Use the app server's native Plan and Default collaboration modes when advertised, with a compatibility fallback for older releases.
- Centralize plan-mode permission decisions so reads remain available while mutations are denied without opening approval dialogs.
- Preserve safe read-only ACP inspection, protected-path handling, and consistent browser and orchestration behavior.
- Add regression coverage for native mode payloads, ACP permissions, browser actions, orchestration actions, and shared policy behavior.

## Why

Plan mode was partly emulated through prompt instructions, while attempted mutations were translated into forced permission prompts. This caused repeated approval dialogs even under full-access runtime settings and let some provider paths bypass the intended plan behavior.

## Impact

Planning now uses native provider behavior where available. Read-only investigation remains usable, unsafe or unknown mutations fail silently, explicit plan exit remains interactive, and protected sensitive reads retain their security gate.

## Validation

- `bun run test` in `packages/agents`: 19 files, 151 tests passed
- `bun run check-types` in `packages/agents`
- Workspace `bun run check-types`: 22 tasks passed
- Biome checks on all changed TypeScript files
- `git diff --check`
