### PR TITLE
Fix realtime orchestration updates

### DIFF
--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -3,6 +3,7 @@ import {
 	withWireProtocolVersion,
 } from "@zuse/client-runtime/connection";
 import {
+	type ConnectionSnapshot,
 	type ConnectionSupervisorEntry,
 	createConnectionSupervisor,
 } from "@zuse/client-runtime/supervisor";
@@ -114,6 +115,21 @@ export const getRpcClient = (): Promise<MemoizeClient> =>
 export const reportRendererRpcFailure = (cause: unknown): void => {
 	getRendererEntry().reportFailure(cause);
 };
+
+/** Report a long-lived stream failure once for the connection that owned it. */
+export const reportRendererRpcStreamFailure = (
+	generation: number,
+	cause: unknown,
+): boolean => getRendererEntry().reportFailure(cause, generation);
+
+/**
+ * Observe the shared renderer connection lifecycle. Long-lived RPC streams use
+ * the generation edge to resubscribe without implementing their own retry loop
+ * or bypassing the supervisor's bounded exponential backoff.
+ */
+export const subscribeRendererRpcConnection = (
+	listener: (snapshot: ConnectionSnapshot) => void,
+): (() => void) => getRendererEntry().subscribe(listener);
 
 export const dispatchRetryableRpcCommand = <A>(
 	commandId: string,

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -14,7 +14,11 @@ import type {
 } from "@zuse/contracts";
 
 import { toastManager } from "../components/ui/toast.tsx";
-import { getRpcClient } from "../lib/rpc-client.ts";
+import {
+  getRpcClient,
+  reportRendererRpcStreamFailure,
+  subscribeRendererRpcConnection,
+} from "../lib/rpc-client.ts";
 import { formatError } from "../lib/format-error.ts";
 import { useMessagesStore } from "./messages.ts";
 import { useSessionsStore } from "./sessions.ts";
@@ -167,72 +171,134 @@ const upsertChat = (
   );
 
 /**
- * Live `chat.streamChanges` subscription per project — one long-lived fiber
- * keyed by projectId. Carries server-side chat-row patches (notably the
- * background auto-namer rewriting a new chat's title after its first
- * message) so the sidebar updates without a manual refetch.
+ * Snapshot-plus-live `chat.streamChanges` subscription per project — one
+ * long-lived fiber keyed by projectId. Carries server-side chat rows (notably
+ * orchestrated creates and background auto-name updates) so the sidebar stays
+ * reconciled without a manual refetch.
  */
 const changeFibers = new Map<string, Fiber.Fiber<unknown, unknown>>();
+const changeGenerations = new Map<string, number>();
+const changeConnectionSubscriptions = new Map<string, () => void>();
+const changeLifecycles = new Map<string, number>();
 
-const ensureChangeStream = (projectId: FolderId): void => {
-  if (changeFibers.has(projectId)) return;
-  // Reserve the slot synchronously so concurrent hydrate() calls don't race
-  // two subscriptions onto the same project.
-  changeFibers.set(
-    projectId,
-    Effect.runFork(
-      Effect.flatMap(
-        Effect.promise(() => getRpcClient()),
-        (client) =>
-          Stream.runForEach(client["chat.streamChanges"]({ projectId }), (chat) =>
-            Effect.sync(() => {
-              let inserted = false;
-              useChatsStore.setState((s) => {
-                const chats = s.chatsByProject[projectId];
-                if (chats === undefined) return s;
-                inserted = !chats.some((c) => c.id === chat.id);
-                return {
-                  chatsByProject: {
-                    ...s.chatsByProject,
-                    [projectId]: upsertChat(chats, chat),
-                  },
-                };
-              });
-              if (inserted) {
-                void useSessionsStore.getState().hydrate(projectId);
-              }
-              const activeSessionId = chat.activeSessionId;
-              if (activeSessionId !== null) {
-                const knownSessions =
-                  useSessionsStore.getState().sessionsByProject[projectId];
-                if (
-                  knownSessions !== undefined &&
-                  !knownSessions.some((row) => row.id === activeSessionId)
-                ) {
-                  void useSessionsStore.getState().hydrate(projectId);
-                }
-              }
-              // Mirror the server-side auto-namer onto member session tabs.
-              useSessionsStore.setState((s) => {
-                const sessions = s.sessionsByProject[projectId];
-                if (sessions === undefined) return s;
-                if (!sessions.some((row) => row.chatId === chat.id)) return s;
-                return {
-                  sessionsByProject: {
-                    ...s.sessionsByProject,
-                    [projectId]: sessions.map((row) =>
-                      row.chatId === chat.id
-                        ? { ...row, title: chat.title }
-                        : row,
-                    ),
-                  },
-                };
-              });
-            }),
-          ),
+const currentChangeLifecycle = (projectId: FolderId): number =>
+  changeLifecycles.get(projectId) ?? 0;
+
+const applyChatChange = (
+  projectId: FolderId,
+  lifecycle: number,
+  chat: Chat,
+): void => {
+  if (currentChangeLifecycle(projectId) !== lifecycle) return;
+  let inserted = false;
+  useChatsStore.setState((s) => {
+    if (currentChangeLifecycle(projectId) !== lifecycle) return s;
+    const chats = s.chatsByProject[projectId];
+    if (chats === undefined) return s;
+    inserted = !chats.some((c) => c.id === chat.id);
+    return {
+      chatsByProject: {
+        ...s.chatsByProject,
+        [projectId]: upsertChat(chats, chat),
+      },
+    };
+  });
+  const activeSessionId = chat.activeSessionId;
+  const knownSessions =
+    useSessionsStore.getState().sessionsByProject[projectId];
+  const activeSessionMissing =
+    activeSessionId !== null &&
+    knownSessions !== undefined &&
+    !knownSessions.some((row) => row.id === activeSessionId);
+  if (inserted || activeSessionMissing) {
+    void useSessionsStore.getState().hydrate(projectId);
+  }
+  // Mirror the server-side auto-namer onto member session tabs.
+  useSessionsStore.setState((s) => {
+    const sessions = s.sessionsByProject[projectId];
+    if (sessions === undefined) return s;
+    if (!sessions.some((row) => row.chatId === chat.id)) return s;
+    return {
+      sessionsByProject: {
+        ...s.sessionsByProject,
+        [projectId]: sessions.map((row) =>
+          row.chatId === chat.id ? { ...row, title: chat.title } : row,
+        ),
+      },
+    };
+  });
+};
+
+const runChatChangeStream = Effect.fn("ChatsStore.runChatChangeStream")(
+  function* (
+    projectId: FolderId,
+    generation: number,
+    lifecycle: number,
+  ): Effect.fn.Return<void> {
+    const clientResult = yield* Effect.tryPromise(() => getRpcClient()).pipe(
+      Effect.result,
+    );
+    if (
+      changeGenerations.get(projectId) !== generation ||
+      currentChangeLifecycle(projectId) !== lifecycle
+    )
+      return;
+    if (clientResult._tag === "Failure") {
+      reportRendererRpcStreamFailure(generation, clientResult.failure);
+      return;
+    }
+    const streamResult = yield* Stream.runForEach(
+      clientResult.success["chat.streamChanges"]({ projectId }),
+      (chat) => Effect.sync(() => applyChatChange(projectId, lifecycle, chat)),
+    ).pipe(Effect.result);
+    if (
+      changeGenerations.get(projectId) !== generation ||
+      currentChangeLifecycle(projectId) !== lifecycle
+    )
+      return;
+    reportRendererRpcStreamFailure(
+      generation,
+      streamResult._tag === "Failure"
+        ? streamResult.failure
+        : new Error("chat change stream completed unexpectedly"),
+    );
+  },
+);
+
+const ensureChangeStream = (projectId: FolderId, lifecycle: number): void => {
+  if (currentChangeLifecycle(projectId) !== lifecycle) return;
+  if (changeConnectionSubscriptions.has(projectId)) return;
+  const unsubscribe = subscribeRendererRpcConnection((snapshot) => {
+    if (currentChangeLifecycle(projectId) !== lifecycle) return;
+    if (snapshot.status !== "connected") return;
+    if (changeGenerations.get(projectId) === snapshot.generation) return;
+    changeGenerations.set(projectId, snapshot.generation);
+    const previous = changeFibers.get(projectId);
+    if (previous !== undefined) {
+      void Effect.runPromise(Fiber.interrupt(previous)).catch(() => {});
+    }
+    changeFibers.set(
+      projectId,
+      Effect.runFork(
+        runChatChangeStream(projectId, snapshot.generation, lifecycle),
       ),
-    ),
-  );
+    );
+  });
+  changeConnectionSubscriptions.set(projectId, unsubscribe);
+};
+
+export const stopChatChangeStream = async (
+  projectId: FolderId,
+): Promise<void> => {
+  changeLifecycles.set(projectId, currentChangeLifecycle(projectId) + 1);
+  changeConnectionSubscriptions.get(projectId)?.();
+  changeConnectionSubscriptions.delete(projectId);
+  changeGenerations.delete(projectId);
+  const fiber = changeFibers.get(projectId);
+  changeFibers.delete(projectId);
+  if (fiber !== undefined) {
+    await Effect.runPromise(Fiber.interrupt(fiber)).catch(() => {});
+  }
 };
 
 export const useChatsStore = create<ChatsState>((set, get) => ({
@@ -245,6 +311,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
   archiveProgressByChat: {},
   error: null,
   hydrate: async (projectId) => {
+    const lifecycle = currentChangeLifecycle(projectId);
     set((s) => ({
       loadingByProject: { ...s.loadingByProject, [projectId]: true },
       error: null,
@@ -255,18 +322,26 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
       const chats = await Effect.runPromise(
         client["chat.list"]({ projectId, includeArchived }),
       );
+      if (currentChangeLifecycle(projectId) !== lifecycle) return;
       set((s) => ({
         chatsByProject: { ...s.chatsByProject, [projectId]: chats },
         loadingByProject: { ...s.loadingByProject, [projectId]: false },
       }));
-      // Begin (or keep) the live change subscription now that the list is
-      // seeded — patches only land for chats already in the list.
-      ensureChangeStream(projectId);
     } catch (err) {
+      if (currentChangeLifecycle(projectId) !== lifecycle) return;
       set((s) => ({
+        chatsByProject:
+          s.chatsByProject[projectId] === undefined
+            ? { ...s.chatsByProject, [projectId]: [] }
+            : s.chatsByProject,
         error: formatError(err),
         loadingByProject: { ...s.loadingByProject, [projectId]: false },
       }));
+    } finally {
+      // The stream has its own subscribe-before-snapshot backfill, so start it
+      // even when the initial list RPC fails. The shared connection supervisor
+      // controls retry/backoff and announces the next usable generation.
+      ensureChangeStream(projectId, lifecycle);
     }
   },
   create: async (projectId, providerId, model, opts) => {
@@ -548,7 +623,9 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
     set({ error: null });
     try {
       const client = await getRpcClient();
-      const result = await Effect.runPromise(client["chat.unarchive"]({ chatId }));
+      const result = await Effect.runPromise(
+        client["chat.unarchive"]({ chatId }),
+      );
       const projectId = findChatProject(get().chatsByProject, chatId);
       const resolvedProjectId = projectId ?? result.chat.projectId;
       set((s) => {
@@ -727,7 +804,9 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
     });
     try {
       const client = await getRpcClient();
-      const updated = await Effect.runPromise(client["chat.markRead"]({ chatId }));
+      const updated = await Effect.runPromise(
+        client["chat.markRead"]({ chatId }),
+      );
       set((s) => {
         const chats = s.chatsByProject[projectId] ?? [];
         return {

--- a/apps/renderer/src/store/workspace.ts
+++ b/apps/renderer/src/store/workspace.ts
@@ -141,6 +141,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     try {
       const client = await getRpcClient();
       await Effect.runPromise(client["workspace.remove"]({ folderId }));
+      const { stopChatChangeStream } = await import("./chats.ts");
+      await stopChatChangeStream(folderId);
       const nextSelected = (() => {
         const s = get();
         const folders = s.folders.filter((f) => f.id !== folderId);
@@ -151,7 +153,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         set({ folders, selectedFolderId });
         return { selectedFolderId, changed: s.selectedFolderId === folderId };
       })();
-      if (nextSelected.changed) await persistSelection(nextSelected.selectedFolderId);
+      if (nextSelected.changed)
+        await persistSelection(nextSelected.selectedFolderId);
     } catch (err) {
       set({ error: formatError(err) });
     }

--- a/apps/renderer/test/unit/chats-store.test.ts
+++ b/apps/renderer/test/unit/chats-store.test.ts
@@ -1,15 +1,23 @@
+import type { ConnectionSnapshot } from "@zuse/client-runtime/supervisor";
 import type {
 	Chat,
 	ChatId,
+	Folder,
 	FolderId,
 	Session,
 	SessionId,
 } from "@zuse/contracts";
-import { Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect, Stream } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { rpcClientFactory } = vi.hoisted(() => ({
+const {
+	reportRendererRpcStreamFailure,
+	rpcClientFactory,
+	subscribeRendererRpcConnection,
+} = vi.hoisted(() => ({
+	reportRendererRpcStreamFailure: vi.fn(),
 	rpcClientFactory: vi.fn(),
+	subscribeRendererRpcConnection: vi.fn(),
 }));
 
 vi.mock("../../src/lib/rpc-client.ts", async (importOriginal) => {
@@ -18,6 +26,8 @@ vi.mock("../../src/lib/rpc-client.ts", async (importOriginal) => {
 	return {
 		...original,
 		getRpcClient: async () => rpcClientFactory(),
+		reportRendererRpcStreamFailure,
+		subscribeRendererRpcConnection,
 	};
 });
 
@@ -25,6 +35,7 @@ import {
 	archiveChatWithConfirm,
 	resetArchiveDirtyConfirm,
 	setArchiveDirtyConfirm,
+	stopChatChangeStream,
 	useChatsStore,
 } from "../../src/store/chats.ts";
 import { useSessionsStore } from "../../src/store/sessions.ts";
@@ -36,6 +47,16 @@ const chatId = "chat-1" as ChatId;
 const sessionId = "session-1" as SessionId;
 const now = new Date("2026-06-21T00:00:00.000Z");
 const initialChatsState = useChatsStore.getInitialState();
+
+const reconnectProjectId = "proj-reconnect" as FolderId;
+const reconnectChatId = "chat-reconnect" as ChatId;
+const reconnectSessionId = "session-reconnect" as SessionId;
+const reconnectFolder = {
+	id: reconnectProjectId,
+	path: "/tmp/proj-reconnect",
+	name: "Reconnect",
+	addedAt: now,
+} as Folder;
 
 const chat: Chat = {
 	id: chatId,
@@ -70,6 +91,20 @@ const session: Session = {
 	toolSearch: false,
 	createdAt: now,
 	updatedAt: now,
+};
+
+const reconnectChat: Chat = {
+	...chat,
+	id: reconnectChatId,
+	projectId: reconnectProjectId,
+	activeSessionId: reconnectSessionId,
+};
+
+const reconnectSession: Session = {
+	...session,
+	id: reconnectSessionId,
+	projectId: reconnectProjectId,
+	chatId: reconnectChatId,
 };
 
 const withConfirm = async (
@@ -155,6 +190,111 @@ describe("chats store selection", () => {
 		expect(
 			useSessionsStore.getState().selectedSessionByProject[projectId],
 		).toBe(sessionId);
+	});
+});
+
+describe("chats store live changes", () => {
+	afterEach(async () => {
+		await stopChatChangeStream(reconnectProjectId);
+	});
+
+	it("reconnects a completed change stream and reconciles its snapshot", async () => {
+		let streamAttempts = 0;
+		let observeConnection: ((snapshot: ConnectionSnapshot) => void) | undefined;
+		const unsubscribeConnection = vi.fn(() => {
+			observeConnection = undefined;
+		});
+		const listSessions = vi.fn(() => Effect.succeed([reconnectSession]));
+		subscribeRendererRpcConnection.mockImplementation((listener) => {
+			observeConnection = listener;
+			listener({
+				key: "renderer",
+				status: "connected",
+				generation: 1,
+				attempt: 0,
+				error: null,
+			});
+			return unsubscribeConnection;
+		});
+		rpcClientFactory.mockReturnValue({
+			"chat.list": () => Effect.fail(new Error("initial list failed")),
+			"chat.streamChanges": () => {
+				streamAttempts += 1;
+				return streamAttempts === 1
+					? Stream.fail(new Error("connection dropped"))
+					: Stream.make(reconnectChat);
+			},
+			"session.list": listSessions,
+		});
+		useChatsStore.setState({
+			chatsByProject: {},
+			loadingByProject: {},
+			error: null,
+		});
+		useSessionsStore.setState({ sessionsByProject: {} });
+
+		await useChatsStore.getState().hydrate(reconnectProjectId);
+		await vi.waitFor(() =>
+			expect(reportRendererRpcStreamFailure).toHaveBeenCalledWith(
+				1,
+				expect.any(Error),
+			),
+		);
+		expect(observeConnection).toBeDefined();
+		observeConnection?.({
+			key: "renderer",
+			status: "connected",
+			generation: 2,
+			attempt: 0,
+			error: null,
+		});
+		await vi.waitFor(() =>
+			expect(
+				useChatsStore.getState().chatsByProject[reconnectProjectId],
+			).toEqual([reconnectChat]),
+		);
+
+		expect(streamAttempts).toBe(2);
+		expect(
+			useSessionsStore.getState().sessionsByProject[reconnectProjectId],
+		).toEqual([reconnectSession]);
+		expect(listSessions).toHaveBeenCalledTimes(1);
+		await stopChatChangeStream(reconnectProjectId);
+		expect(unsubscribeConnection).toHaveBeenCalledTimes(1);
+		expect(observeConnection).toBeUndefined();
+	});
+
+	it("does not restore chat state or its stream when hydration settles after workspace removal", async () => {
+		const listResult = deferred<ReadonlyArray<Chat>>();
+		const listChats = vi.fn(() => Effect.promise(() => listResult.promise));
+		subscribeRendererRpcConnection.mockClear();
+		rpcClientFactory.mockReturnValue({
+			"chat.list": listChats,
+			"chat.streamChanges": () => Stream.make(reconnectChat),
+			"workspace.remove": () => Effect.void,
+			"workspace.setSelected": () => Effect.void,
+		});
+		useChatsStore.setState({
+			chatsByProject: {},
+			loadingByProject: {},
+			error: null,
+		});
+		useWorkspaceStore.setState({
+			folders: [reconnectFolder],
+			selectedFolderId: reconnectProjectId,
+			error: null,
+		});
+
+		const hydration = useChatsStore.getState().hydrate(reconnectProjectId);
+		await vi.waitFor(() => expect(listChats).toHaveBeenCalledTimes(1));
+		await useWorkspaceStore.getState().remove(reconnectProjectId);
+		listResult.resolve([reconnectChat]);
+		await hydration;
+
+		expect(
+			useChatsStore.getState().chatsByProject[reconnectProjectId],
+		).toBeUndefined();
+		expect(subscribeRendererRpcConnection).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/server/src/conversation/core/auto-name-operations.ts
+++ b/apps/server/src/conversation/core/auto-name-operations.ts
@@ -8,7 +8,7 @@ import type { ChatCommand } from "@zuse/domain/chat/commands";
 import type { SessionDomainApi } from "@zuse/domain/engine/session-domain";
 import type { GitServiceShape } from "@zuse/git/git-service";
 import type { WorktreeServiceShape } from "@zuse/git/worktree-service";
-import { Effect, PubSub, Stream } from "effect";
+import { Effect } from "effect";
 import type { SqlClient } from "effect/unstable/sql";
 import type { ConfigStoreServiceShape } from "../../config-store/services/config-store-service.ts";
 import type { makeReactorEffectJournal } from "../../provider/reactor-effect-journal.ts";
@@ -32,7 +32,6 @@ export interface AutoNameOperationsOptions {
 	readonly lookupChat: ConversationOperations["getChat"];
 	readonly lookupSession: ConversationOperations["getSession"];
 	readonly broadcastChat: (chat: Chat) => Effect.Effect<void>;
-	readonly chatChangesHub: PubSub.PubSub<Chat>;
 	readonly reactorEffects: ReturnType<typeof makeReactorEffectJournal>;
 	readonly titleGen: TitleGeneratorShape;
 	readonly sessionDomain: SessionDomainApi;
@@ -49,7 +48,6 @@ export const makeAutoNameOperations = (options: AutoNameOperationsOptions) => {
 		lookupChat,
 		lookupSession,
 		broadcastChat,
-		chatChangesHub,
 		reactorEffects,
 		titleGen,
 		sessionDomain,
@@ -91,18 +89,6 @@ export const makeAutoNameOperations = (options: AutoNameOperationsOptions) => {
 			});
 			return yield* lookupChat(chatId);
 		});
-
-	const streamChatChanges: ConversationOperations["streamChatChanges"] = (
-		projectId,
-	) =>
-		Stream.unwrap(
-			Effect.gen(function* () {
-				const sub = yield* PubSub.subscribe(chatChangesHub);
-				return Stream.fromSubscription(sub).pipe(
-					Stream.filter((chat) => chat.projectId === projectId),
-				);
-			}),
-		);
 
 	/**
 	 * LLM auto-name: summarize recent user/assistant turns into a short title
@@ -245,7 +231,6 @@ export const makeAutoNameOperations = (options: AutoNameOperationsOptions) => {
 		renameChatWithCommandId,
 		renameChat,
 		markChatRead,
-		streamChatChanges,
 		autoNameChat,
 	};
 };

--- a/apps/server/src/conversation/core/chat-operations.ts
+++ b/apps/server/src/conversation/core/chat-operations.ts
@@ -1,6 +1,6 @@
 import { type Chat, type ChatId, ChatNotFoundError } from "@zuse/contracts";
 import type { ChatCommand } from "@zuse/domain/chat/commands";
-import { Effect } from "effect";
+import { Effect, PubSub, Stream } from "effect";
 import type { SqlClient } from "effect/unstable/sql";
 import type {
 	ConversationOperations,
@@ -19,6 +19,7 @@ export interface ChatOperationsOptions {
 	readonly currentTimestamp: Effect.Effect<number>;
 	readonly createSession: ConversationOperations["createSession"];
 	readonly broadcastChat: (chat: Chat) => Effect.Effect<void>;
+	readonly chatChangesHub: PubSub.PubSub<Chat>;
 	readonly dispatchChatCommand: (
 		chatId: ChatId,
 		command: ChatCommand,
@@ -32,6 +33,7 @@ export const makeChatOperations = (options: ChatOperationsOptions) => {
 		currentTimestamp,
 		createSession,
 		broadcastChat,
+		chatChangesHub,
 		dispatchChatCommand,
 	} = options;
 	const lookupChat = (chatId: ChatId): Effect.Effect<Chat, ChatNotFoundError> =>
@@ -72,6 +74,23 @@ export const makeChatOperations = (options: ChatOperationsOptions) => {
 
 	const getChat: ConversationOperations["getChat"] = (chatId) =>
 		lookupChat(chatId);
+
+	const streamChatChanges: ConversationOperations["streamChatChanges"] = (
+		projectId,
+	) =>
+		Stream.unwrap(
+			Effect.gen(function* () {
+				const sub = yield* PubSub.subscribe(chatChangesHub);
+				// Subscribe before reading the snapshot. A mutation that lands during
+				// the query is present in the snapshot, queued in the subscription, or
+				// both; renderer upserts make the duplicate harmless.
+				const snapshot = yield* listChats(projectId, false);
+				const live = Stream.fromSubscription(sub).pipe(
+					Stream.filter((chat) => chat.projectId === projectId),
+				);
+				return Stream.concat(Stream.fromIterable(snapshot), live);
+			}),
+		);
 
 	/**
 	 * Create a chat row AND its initial session in one effect. Both rows
@@ -156,5 +175,5 @@ export const makeChatOperations = (options: ChatOperationsOptions) => {
 			return { chat, initialSession, initialMessage };
 		});
 
-	return { lookupChat, listChats, getChat, createChat };
+	return { lookupChat, listChats, getChat, streamChatChanges, createChat };
 };

--- a/apps/server/src/conversation/core/conversation-store-runtime.ts
+++ b/apps/server/src/conversation/core/conversation-store-runtime.ts
@@ -175,10 +175,8 @@ export const makeConversationStoreRuntime = Effect.fn(
 
 	// Single hub for chat-row changes (create / title / worktree binding).
 	// Chats are few and updates rare, so one project-filtered hub keeps it
-	// simple. The renderer seeds
-	// from `chat.list`; this stream carries live changes after subscription,
-	// so a Zuse-orchestrated spawn appears in the sidebar without
-	// requiring a full app reload.
+	// simple. `streamChatChanges` subscribes to this hub before reading its SQL
+	// snapshot, closing the backfill-to-live gap for orchestrated creates.
 	const chatChangesHub = yield* PubSub.unbounded<Chat>();
 	const broadcastChat = (chat: Chat): Effect.Effect<void> =>
 		PubSub.publish(chatChangesHub, chat).pipe(Effect.asVoid);

--- a/apps/server/src/conversation/layers/conversation-services.ts
+++ b/apps/server/src/conversation/layers/conversation-services.ts
@@ -257,9 +257,11 @@ const ConversationRuntimeLive = Layer.effect(
 			currentTimestamp,
 			createSession,
 			broadcastChat,
+			chatChangesHub,
 			dispatchChatCommand,
 		});
-		const { lookupChat, listChats, getChat, createChat } = chatOperations;
+		const { lookupChat, listChats, getChat, streamChatChanges, createChat } =
+			chatOperations;
 
 		const transcriptOperations = makeTranscriptOperations({
 			sql,
@@ -283,7 +285,6 @@ const ConversationRuntimeLive = Layer.effect(
 			lookupChat,
 			lookupSession,
 			broadcastChat,
-			chatChangesHub,
 			reactorEffects,
 			titleGen,
 			sessionDomain,
@@ -291,8 +292,7 @@ const ConversationRuntimeLive = Layer.effect(
 			git,
 			configStore,
 		});
-		const { renameChat, markChatRead, streamChatChanges, autoNameChat } =
-			autoNameOperations;
+		const { renameChat, markChatRead, autoNameChat } = autoNameOperations;
 		const { handleProviderStart, handleProviderStop, handleAutoName } =
 			makeProviderReactorHandlers({
 				reactorEffects,

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -953,6 +953,19 @@ describe("ConversationServices — chat & session lifecycle", () => {
 			);
 			expect(child.worktreeId).toBe(TEST_WORKTREE_ID);
 			expect(child.chatId).toBe(parent.chat.id);
+			const replayed = await run(
+				Effect.flatMap(store, (s) =>
+					s.streamChatChanges(PROJECT_ID).pipe(
+						Stream.filter((chat) => chat.id === parent.chat.id),
+						Stream.take(1),
+						Stream.runCollect,
+						Effect.timeout(1_000),
+					),
+				),
+			);
+			expect(replayed.map((chat) => chat.activeSessionId as string)).toEqual([
+				created.sessionId,
+			]);
 		});
 	});
 
@@ -1004,6 +1017,19 @@ describe("ConversationServices — chat & session lifecycle", () => {
 			expect(parent.initialSession.worktreeId).toBe(TEST_WORKTREE_ID);
 			expect(providerStartInputs.at(-1)?.providerId).toBe("codex");
 			expect(providerStartInputs.at(-1)?.model).toBe(defaultModelFor("codex"));
+			const replayed = await run(
+				Effect.flatMap(store, (s) =>
+					s.streamChatChanges(PROJECT_ID).pipe(
+						Stream.filter((chat) => (chat.id as string) === created.chatId),
+						Stream.take(1),
+						Stream.runCollect,
+						Effect.timeout(1_000),
+					),
+				),
+			);
+			expect(replayed.map((chat) => chat.activeSessionId as string)).toEqual([
+				created.sessionId,
+			]);
 		});
 	});
 
@@ -1043,9 +1069,16 @@ describe("ConversationServices — chat & session lifecycle", () => {
 						providerId: "claude",
 						model: "claude-opus-4-8",
 					});
-					const streamFiber = yield* s
-						.streamChatChanges(PROJECT_ID)
-						.pipe(Stream.take(1), Stream.runCollect, Effect.forkChild);
+					const streamFiber = yield* s.streamChatChanges(PROJECT_ID).pipe(
+						Stream.filter(
+							(chat) =>
+								chat.id === created.chat.id &&
+								chat.activeSessionId !== created.initialSession.id,
+						),
+						Stream.take(1),
+						Stream.runCollect,
+						Effect.forkChild,
+					);
 					yield* Effect.sleep("10 millis");
 					const session = yield* s.createSession({
 						chatId: created.chat.id,

--- a/packages/client-runtime/src/supervisor.ts
+++ b/packages/client-runtime/src/supervisor.ts
@@ -34,7 +34,10 @@ export type ConnectionDiagnostic = {
 
 export type ConnectionSupervisorEntry<Client> = {
 	readonly getClient: () => Effect.Effect<Client, ClientConnectionError>;
-	readonly reportFailure: (cause: unknown) => void;
+	readonly reportFailure: (
+		cause: unknown,
+		expectedGeneration?: number,
+	) => boolean;
 	readonly dispatchCommand: <A>(
 		commandId: string,
 		operation: (client: Client) => Promise<A>,
@@ -166,11 +169,25 @@ class SupervisorEntryImpl<Options, Client>
 		});
 	}
 
-	reportFailure(cause: unknown): void {
-		if (this.removed) return;
+	reportFailure(cause: unknown, expectedGeneration?: number): boolean {
+		if (this.removed) return false;
+		if (
+			expectedGeneration !== undefined &&
+			(this.state.status !== "connected" ||
+				this.state.generation !== expectedGeneration)
+		) {
+			this.diagnostic("failure.ignored", {
+				reason: messageOf(cause),
+				expectedGeneration,
+				actualGeneration: this.state.generation,
+				status: this.state.status,
+			});
+			return false;
+		}
 		this.diagnostic("failure.reported", { reason: messageOf(cause) });
 		this.invalidateClient();
 		this.markFailure(cause);
+		return true;
 	}
 
 	dispatchCommand<A>(

--- a/packages/client-runtime/test/unit/supervisor.test.ts
+++ b/packages/client-runtime/test/unit/supervisor.test.ts
@@ -195,6 +195,23 @@ describe("connection supervisor", () => {
 		]);
 	});
 
+	test("accepts only one stream failure report per connected generation", async () => {
+		const harness = makeHarness();
+		const entry = harness.supervisor.get({ key: "remote" });
+		await runClient(entry.getClient());
+
+		expect(entry.reportFailure(new Error("first stream failed"), 1)).toBe(true);
+		expect(entry.reportFailure(new Error("sibling stream failed"), 1)).toBe(
+			false,
+		);
+		expect(entry.snapshot()).toMatchObject({
+			status: "reconnecting",
+			generation: 1,
+			attempt: 1,
+		});
+		expect(harness.scheduled).toHaveLength(1);
+	});
+
 	test("owns stable-id command redispatch across reconnects", async () => {
 		const harness = makeHarness({
 			isRetryableCommandError: (cause) =>

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -804,10 +804,10 @@ export const SessionForkRpc = Rpc.make("session.fork", {
 });
 
 /**
- * Live feed of chat-row changes (title / worktree binding) for one project.
- * Carries only live patches — no backfill — so the renderer keeps its
- * `chat.list` snapshot and patches it as updates arrive (e.g. the background
- * auto-namer rewriting a new chat's title after its first message).
+ * Snapshot-plus-live feed of chat rows for one project. Each subscription
+ * first emits the current non-archived chats, then carries live patches. The
+ * server subscribes before reading the snapshot, so reconnecting clients cannot
+ * miss a chat/session mutation in the handoff between backfill and live events.
  */
 export const ChatStreamChangesRpc = Rpc.make("chat.streamChanges", {
   payload: Schema.Struct({ projectId: FolderId }),


### PR DESCRIPTION
## Summary

- make chat change delivery snapshot-plus-live so orchestrated chats and session tabs appear immediately
- reconnect renderer subscriptions through the shared RPC supervisor without duplicate retries
- keep streaming recovery active after initial list failures and hydrate missing sessions
- stop project streams cleanly and guard against stale hydration after workspace removal

## Root cause

The renderer relied on a live-only chat stream, so changes created before subscription were invisible until a full reload. Stream failures also lacked shared generation-aware recovery, and an in-flight hydration could outlive workspace removal.

## Impact

New chats and session tabs created through orchestration now reconcile in real time, including after reconnects and partial startup failures. Removed workspaces cannot recreate stale chat state.

## Validation

- full repository test suite: 19 of 19 tasks passed
- renderer tests: 114 passed
- server tests: 215 passed
- affected TypeScript checks passed
- Biome lint and formatting passed with only existing non-null assertion warnings
- final reliability review found no remaining actionable issues