### PR TITLE
Start agents independently of workspace setup

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -155,7 +155,6 @@ const attachmentsWithBrowserAnnotations = (
 
 import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
-import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { PermissionCard } from "./permission-card.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { QuestionCard } from "./question-card.tsx";
@@ -206,29 +205,13 @@ export function ChatComposer({
   const inFlight = useMessagesStore(
     (s) => s.runningBySession[sessionId] === true,
   );
-  // The first message(s) sit in the queue while the worktree branches / setup
-  // runs / the provider boots — the worktrees setup stream flushes them once
-  // the tree is ready. Until then, any submit must APPEND to the queue
-  // (preserving order), never fire a live send into a not-yet-ready session.
-  // The composer is now visible throughout setup, so this path is reachable.
+  // Hold messages only while the provider is unavailable or an earlier message
+  // is already queued. Worktree setup is independent background work and must
+  // not delay an agent that has finished booting.
   const hasQueued = useMessagesStore(
     (s) => (s.queueBySession[sessionId]?.length ?? 0) > 0,
   );
-  const worktreeSetupActive = useWorktreesStore((s) => {
-    const wtId = session.worktreeId;
-    if (wtId === null) return false;
-    for (const list of Object.values(s.byProject)) {
-      const wt = (list ?? EMPTY_WORKTREES).find((w) => w.id === wtId);
-      if (wt !== undefined) {
-        // Only while setup is genuinely in flight — a `failed` status is
-        // terminal (its queue already flushed), so later messages send.
-        return wt.setupStatus === "running" || wt.setupStatus === "pending";
-      }
-    }
-    return false;
-  });
-  const holdForSetup =
-    hasQueued || worktreeSetupActive || session.status === "booting";
+  const holdForAgent = hasQueued || session.status === "booting";
   const goal = useMessagesStore((s) => s.goalBySession[sessionId] ?? null);
   const send = useMessagesStore((s) => s.send);
   const interrupt = useMessagesStore((s) => s.interrupt);
@@ -876,7 +859,7 @@ export function ChatComposer({
         ? chooseComposerSubmitRoute({
             sendPlanFeedbackNow,
             goalSendMode,
-            shouldQueue: inFlight || holdForSetup,
+            shouldQueue: inFlight || holdForAgent,
           })
         : null;
     clearComposer(view, {
@@ -916,9 +899,9 @@ export function ChatComposer({
         void send(sessionId, input, { asGoal: true });
         break;
       case "queue":
-        // Mid-turn submit — or a submit while the worktree/provider is still
-        // coming up — becomes a queue chip; auto-flushed when the turn ends,
-        // setup completes, or steered manually.
+        // Mid-turn submit — or a submit while the provider is still coming up
+        // — becomes a queue chip; auto-flushed when the turn ends or steered
+        // manually.
         queue(sessionId, input);
         break;
       case "send":

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -321,9 +321,8 @@ export function ChatLanding() {
   // Driven by the real ChatComposer (draft mode): it hands back the parsed
   // input (file refs / attachments / skills / annotations intact) and whether
   // goal mode was on. We create the worktree + chat with the draft's chosen
-  // provider/model/runtime/permission, carry the model options over, then
-  // queue the message (held until setup completes, or flushed immediately when
-  // there's no worktree). Identical sequencing to the old textarea submit.
+  // provider/model/runtime/permission, carry the model options over, then send
+  // as soon as the provider is ready. Worktree setup continues independently.
   const handleDraftSubmit = async (
     input: ComposerInput,
     opts: {
@@ -442,29 +441,9 @@ export function ChatLanding() {
     if (opts.asGoal && goalSupported) {
       void send(sessionId, finalInput, { asGoal: true });
     } else {
-      useMessagesStore.getState().queue(sessionId, finalInput);
-      // With no worktree there's nothing to wait for — flush now. With a
-      // worktree, the setup stream flushes the queue on its terminal status —
-      // UNLESS setup already finished (a reused "In use" worktree, or an eager
-      // checkout that completed before this send), in which case that event has
-      // already passed, so flush manually.
-      const setupDone =
-        worktreeId === null ||
-        (() => {
-          const wt = (
-            useWorktreesStore.getState().byProject[selectedFolderId] ??
-            EMPTY_WORKTREES
-          ).find((w) => w.id === worktreeId);
-          return (
-            wt === undefined ||
-            wt.setupStatus === "succeeded" ||
-            wt.setupStatus === "skipped" ||
-            wt.setupStatus === "failed"
-          );
-        })();
-      if (setupDone) {
-        useMessagesStore.getState().flushQueue(sessionId);
-      }
+      // `create()` returns only after the provider handshake completes, so the
+      // agent can begin even when the detached setup script is still running.
+      void send(sessionId, finalInput);
     }
     setCreateSource(null);
     useSessionsStore.getState().clearDraft();

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -29,9 +29,18 @@ import { usePrStateStore } from "./pr-state.ts";
 import { useSessionsStore } from "./sessions.ts";
 
 let getMessagesRpcClient: typeof getRpcClient = getRpcClient;
+let dispatchMessagesRpcCommand: typeof dispatchRetryableRpcCommand =
+  dispatchRetryableRpcCommand;
+const queueFlushTails = new Map<SessionId, Promise<void>>();
 
 export const setMessagesRpcClientForTest = (fn: typeof getRpcClient): void => {
   getMessagesRpcClient = fn;
+};
+
+export const setMessagesRpcCommandDispatcherForTest = (
+  fn: typeof dispatchRetryableRpcCommand,
+): void => {
+  dispatchMessagesRpcCommand = fn;
 };
 
 /**
@@ -779,6 +788,11 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
             },
           };
         });
+        // Probe the durable queue after the add completes. The server ignores
+        // flushes while the provider is booting or a turn is running, but this
+        // closes the opposite race: provider-ready can arrive just before the
+        // queued row is persisted, leaving no later status edge to drain it.
+        get().flushQueue(sessionId);
       } catch (err) {
         set((s) => ({
           errorBySession: {
@@ -850,11 +864,21 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     })();
   },
   flushQueue: (sessionId) => {
-    void (async () => {
-      try {
-        const client = await getMessagesRpcClient();
-        await Effect.runPromise(client["messages.queue.flush"]({ sessionId }));
-      } catch (err) {
+    const previous = queueFlushTails.get(sessionId) ?? Promise.resolve();
+    const commandId = `queue-flush:${sessionId}:${crypto.randomUUID()}`;
+    const current = previous
+      .catch(() => undefined)
+      .then(() =>
+        dispatchMessagesRpcCommand(commandId, async () => {
+          const client = await getMessagesRpcClient();
+          return Effect.runPromise(
+            client["messages.queue.flush"]({ sessionId }),
+          );
+        }),
+      );
+    queueFlushTails.set(sessionId, current);
+    void current
+      .catch((err) => {
         handoffRunningSessions.delete(sessionId);
         set((s) => ({
           errorBySession: {
@@ -863,8 +887,12 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
           },
           runningBySession: { ...s.runningBySession, [sessionId]: false },
         }));
-      }
-    })();
+      })
+      .finally(() => {
+        if (queueFlushTails.get(sessionId) === current) {
+          queueFlushTails.delete(sessionId);
+        }
+      });
   },
   resumeQueue: async (sessionId) => {
     try {

--- a/apps/renderer/src/store/worktrees.ts
+++ b/apps/renderer/src/store/worktrees.ts
@@ -14,9 +14,7 @@ import { formatError } from "../lib/format-error.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { openTerminalCommand } from "../lib/run-terminal.ts";
 import { useChatsStore } from "./chats.ts";
-import { useMessagesStore } from "./messages.ts";
 import { useRepositorySettingsStore } from "./repository-settings.ts";
-import { useSessionsStore } from "./sessions.ts";
 
 /** Rarities worth interrupting the user with a one-off unlock toast. */
 const NOTABLE_RARITIES: ReadonlySet<string> = new Set([
@@ -53,7 +51,7 @@ type WorktreesState = {
   /**
    * Drain a worktree's live `setupStream`, patching `setupStatus`/`setupOutput`
    * as events arrive. Idempotent; auto-stops when setup completes. On a
-   * terminal status it kicks `maybeAutoRun` + flushes queued messages.
+   * terminal status it kicks `maybeAutoRun`.
    */
   readonly subscribeSetup: (
     projectId: FolderId,
@@ -129,22 +127,6 @@ const subscribingSetup = new Set<WorktreeId>();
 
 const TERMINAL_SETUP = new Set(["succeeded", "failed", "skipped"]);
 
-/**
- * Once setup reaches a terminal status, flush any messages queued against
- * sessions bound to this worktree — this is what makes the first message wait
- * for setup before the agent runs. Flush regardless of success/failure so a
- * failed setup never strands the user's message.
- */
-const flushQueuedForWorktree = (worktreeId: WorktreeId): void => {
-  const sessions = useSessionsStore.getState().sessionsByProject;
-  const flush = useMessagesStore.getState().flushQueue;
-  for (const list of Object.values(sessions)) {
-    for (const session of list) {
-      if (session.worktreeId === worktreeId) flush(session.id);
-    }
-  }
-};
-
 export const useWorktreesStore = create<WorktreesState>((set, get) => ({
   byProject: {},
   loading: new Set(),
@@ -216,7 +198,7 @@ export const useWorktreesStore = create<WorktreesState>((set, get) => ({
         });
       }
       // Setup now runs detached on the server; follow it live and let the
-      // stream's terminal-status handler fire maybeAutoRun + flush.
+      // stream's terminal-status handler fire maybeAutoRun.
       get().subscribeSetup(projectId, wt.id);
       return wt;
     } catch (err) {
@@ -308,7 +290,6 @@ export const useWorktreesStore = create<WorktreesState>((set, get) => ({
               (w) => w.id === worktreeId,
             );
             if (wt !== undefined) void maybeAutoRun(projectId, wt);
-            flushQueuedForWorktree(worktreeId);
           }
         };
         const fiber = Effect.runFork(

--- a/apps/renderer/test/unit/messages-store.test.ts
+++ b/apps/renderer/test/unit/messages-store.test.ts
@@ -2,9 +2,11 @@ import { ComposerInput, QueuedMessage, type SessionId } from "@zuse/contracts";
 import { Effect, Stream } from "effect";
 import { beforeEach, describe, expect, it } from "vitest";
 
-const { setMessagesRpcClientForTest, useMessagesStore } = await import(
-	"../../src/store/messages.ts"
-);
+const {
+	setMessagesRpcClientForTest,
+	setMessagesRpcCommandDispatcherForTest,
+	useMessagesStore,
+} = await import("../../src/store/messages.ts");
 
 const sessionId = "session-queue" as SessionId;
 const input = new ComposerInput({
@@ -30,6 +32,11 @@ let sendNowCalls: Array<{
 }> = [];
 let resumeCalls: Array<{ readonly sessionId: SessionId }> = [];
 let flushCalls: Array<{ readonly sessionId: SessionId }> = [];
+let addCalls: Array<{
+	readonly sessionId: SessionId;
+	readonly input: ComposerInput;
+}> = [];
+let dispatchedCommandIds: string[] = [];
 let rpcClientFactory: () => Awaited<
 	ReturnType<typeof import("../../src/lib/rpc-client.ts").getRpcClient>
 >;
@@ -55,11 +62,23 @@ const makeQueueClient = () =>
 			Effect.sync(() => {
 				flushCalls.push(payload);
 			}),
+		"messages.queue.add": (payload: {
+			readonly sessionId: SessionId;
+			readonly input: ComposerInput;
+		}) =>
+			Effect.sync(() => {
+				addCalls.push(payload);
+				return queued;
+			}),
 	}) as unknown as Awaited<
 		ReturnType<typeof import("../../src/lib/rpc-client.ts").getRpcClient>
 	>;
 
 setMessagesRpcClientForTest(async () => rpcClientFactory());
+setMessagesRpcCommandDispatcherForTest(async (commandId, operation) => {
+	dispatchedCommandIds.push(commandId);
+	return operation();
+});
 
 describe("messages store queue actions", () => {
 	beforeEach(() => {
@@ -67,6 +86,8 @@ describe("messages store queue actions", () => {
 		sendNowCalls = [];
 		resumeCalls = [];
 		flushCalls = [];
+		addCalls = [];
+		dispatchedCommandIds = [];
 		rpcClientFactory = makeQueueClient;
 		useMessagesStore.setState({
 			messagesBySession: {},
@@ -105,10 +126,30 @@ describe("messages store queue actions", () => {
 		});
 
 		useMessagesStore.getState().flushQueue(sessionId);
-		await Promise.resolve();
+		await expect.poll(() => flushCalls).toEqual([{ sessionId }]);
 
-		expect(flushCalls).toEqual([{ sessionId }]);
 		expect(useMessagesStore.getState().runningBySession[sessionId]).toBe(false);
+	});
+
+	it("flushes again after a queued row is durable", async () => {
+		useMessagesStore.setState({ queueBySession: { [sessionId]: [] } });
+
+		useMessagesStore.getState().queue(sessionId, input);
+
+		await expect.poll(() => flushCalls).toEqual([{ sessionId }]);
+		expect(addCalls).toEqual([{ sessionId, input }]);
+		expect(useMessagesStore.getState().queueBySession[sessionId]).toEqual([
+			queued,
+		]);
+	});
+
+	it("serializes distinct reconnect-safe flush attempts", async () => {
+		useMessagesStore.getState().flushQueue(sessionId);
+		useMessagesStore.getState().flushQueue(sessionId);
+
+		await expect.poll(() => flushCalls).toHaveLength(2);
+		expect(dispatchedCommandIds).toHaveLength(2);
+		expect(new Set(dispatchedCommandIds).size).toBe(2);
 	});
 
 	it("reconnects the active transcript when it is still empty", async () => {


### PR DESCRIPTION
## Summary

- start a new chat's first agent turn as soon as the provider handshake completes
- keep worktree setup streaming and auto-run behavior independent in the background
- make queued-message draining race-safe and reconnect-aware

## Why

New chat prompts were held until worktree setup reached a terminal state, even when the provider was already ready. This made long setup scripts unnecessarily delay useful agent work.

The queue also needed to handle either ordering of provider readiness and durable queue persistence. Flush attempts are now serialized per session and retain unique retryable command IDs across reconnects.

## Impact

Agents can begin working while repository setup continues. Setup progress remains visible, and queued prompts remain reliable during startup races and connection failures.

## Validation

- `bun run check-types` in `apps/renderer`
- `bun run test` in `apps/renderer` — 24 files, 114 tests passed
- Biome check passed for the new regression test
- `git diff --check origin/main...HEAD`

Broader Biome checks on the touched legacy components continue to report pre-existing formatting and accessibility diagnostics also present on `origin/main`.
