### PR TITLE
Fix New Chat from usage and archive views

### DIFF
--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -872,6 +872,10 @@ const LOGIN_HINT: Record<ProviderId, string> = {
  * don't need prop drilling.
  */
 export function createNewSession(projectId: FolderId): void {
+  // The landing lives on the chat tab. Return there before clearing the
+  // selection so creating a chat from Usage or Archives is immediately
+  // visible instead of leaving that takeover surface mounted.
+  useUiStore.getState().setActiveMainTab("chat");
   // Select the project first (synchronous: `workspace.select` sets
   // `selectedFolderId` before awaiting persistence), then clear the chat +
   // session selection for it. `chats.select(null)` cascades into

--- a/apps/renderer/test/unit/chats-store.test.ts
+++ b/apps/renderer/test/unit/chats-store.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../src/lib/rpc-client.ts", async (importOriginal) => {
 	};
 });
 
+import { createNewSession } from "../../src/components/projects-sidebar.tsx";
 import { useArchivePreviewStore } from "../../src/store/archive-preview.ts";
 import {
 	archiveChatWithConfirm,
@@ -171,12 +172,15 @@ describe("chats store selection", () => {
 		expect(useSessionsStore.getState().selectedSessionId).toBe(sessionId);
 	});
 
-	it("does not force the chat surface when clearing selection", () => {
-		useUiStore.setState({ activeMainTab: "usage" });
+	it.each([
+		"usage",
+		"archives",
+	] as const)("opens the new-chat landing from %s", (activeMainTab) => {
+		useUiStore.setState({ activeMainTab });
 
-		useChatsStore.getState().select(null);
+		createNewSession(projectId);
 
-		expect(useUiStore.getState().activeMainTab).toBe("usage");
+		expect(useUiStore.getState().activeMainTab).toBe("chat");
 		expect(useChatsStore.getState().selectedChatId).toBeNull();
 		expect(useSessionsStore.getState().selectedSessionId).toBeNull();
 	});


### PR DESCRIPTION
## Summary
- return the main pane to Chat before opening a project's New Chat landing
- cover New Chat from both Usage and Archived Chats views

## Validation
- `bun --filter renderer test:unit -- chats-store.test.ts`
- `bun --filter renderer check-types`
- `git diff --check`