### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0]
+
+### Changed
+- Fix New Chat from usage and archive views (#344)
+- Restore and preview archived chats safely (#335)
+- Fix realtime orchestration updates (#333)
+- Start agents independently of workspace setup (#334)
+- Use native plan modes without permission churn (#332)
+
 ## [0.13.0]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "type": "module",
   "productName": "Zuse Alpha",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Zuse Alpha desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.14.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix New Chat from usage and archive views (#344)",
+          "Restore and preview archived chats safely (#335)",
+          "Fix realtime orchestration updates (#333)",
+          "Start agents independently of workspace setup (#334)",
+          "Use native plan modes without permission churn (#332)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.13.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "keytar": "^7.9.0",


### PR DESCRIPTION
## Summary
- release Zuse v0.14.0
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.14.0 after this PR lands.