### PR TITLE
Refresh short-lived auth tokens before expiry

### DIFF
--- a/apps/server/src/auth/layers/auth-service.ts
+++ b/apps/server/src/auth/layers/auth-service.ts
@@ -33,6 +33,8 @@ import {
 
 /** Refresh when the access token is within this window of expiry. */
 const REFRESH_SKEW_MS = 60_000;
+/** Re-check often enough to cover production's five-minute access tokens. */
+const REFRESH_POLL_INTERVAL = "30 seconds";
 const FORCE_REFRESH_SKIP_MS = 10 * 60_000;
 
 /** How long `signIn` waits for the browser callback before giving up. */
@@ -374,8 +376,8 @@ export const AuthServiceLive = Layer.effect(
       refreshIfPresent(true).pipe(
         Effect.andThen(
           Effect.repeat(
-            refreshIfPresent(true),
-            Schedule.spaced("45 minutes").pipe(Schedule.jittered),
+            refreshIfPresent(false),
+            Schedule.spaced(REFRESH_POLL_INTERVAL),
           ),
         ),
         Effect.catch(() => Effect.void),

--- a/apps/server/test/integration/auth-service.test.ts
+++ b/apps/server/test/integration/auth-service.test.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "@zuse/contracts";
 import { Effect, Layer, ManagedRuntime, Stream } from "effect";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AuthServiceLive } from "../../src/auth/layers/auth-service.ts";
 import type { SessionBundle } from "../../src/auth/layers/workos.ts";
@@ -13,6 +13,7 @@ const originalFetch = globalThis.fetch;
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+	vi.useRealTimers();
 });
 
 const jwtWithExp = (expMs: number): string => {
@@ -164,6 +165,45 @@ const mockAuthenticate = (
 };
 
 describe("AuthService WorkOS refresh", () => {
+	it("proactively refreshes a five-minute production token before it expires", async () => {
+		vi.useFakeTimers();
+		const now = new Date("2026-07-15T00:00:00.000Z");
+		vi.setSystemTime(now);
+		const initial = makeBundle({
+			accessToken: jwtWithExp(now.getTime() + 5 * 60_000),
+			refreshToken: "production-refresh",
+			expiresAt: now.getTime() + 5 * 60_000,
+			refreshedAt: now.getTime(),
+		});
+		const nextAccessToken = jwtWithExp(now.getTime() + 10 * 60_000);
+		const calls = mockAuthenticate(() =>
+			Response.json({
+				access_token: nextAccessToken,
+				refresh_token: "rotated-production-refresh",
+				user: { id: "user_123", email: "user@example.com" },
+			}),
+		);
+		const harness = makeHarness(initial);
+		try {
+			const state = await harness.run(
+				Effect.flatMap(AuthService, (svc) => svc.getSession()),
+			);
+			expect(state._tag).toBe("SignedIn");
+			expect(calls).toHaveLength(0);
+
+			await vi.advanceTimersByTimeAsync(4 * 60_000);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(calls).toHaveLength(1);
+			expect(harness.readStored()?.refreshToken).toBe(
+				"rotated-production-refresh",
+			);
+			expect(harness.readStored()?.accessToken).toBe(nextAccessToken);
+		} finally {
+			await harness.dispose();
+		}
+	});
+
 	it("refreshes an expired access token and persists the rotated refresh token", async () => {
 		const old = makeBundle({
 			accessToken: jwtWithExp(Date.now() - 5 * 60_000),


### PR DESCRIPTION
## What changed

- Check persisted auth sessions every 30 seconds and refresh only when they enter the existing one-minute expiry window.
- Persist rotated access and refresh tokens through the existing locked refresh path.
- Add a fake-time regression test for production's five-minute access-token lifetime.

## Why

Production access tokens expire after five minutes, but the previous proactive refresh schedule ran roughly every 45 minutes. That left the token expired until another action happened to request one, causing account and cloud functionality to appear signed out.

The new schedule performs inexpensive local expiry checks and makes a network refresh request only near expiry, preserving the configured long-lived session.

## Validation

- `bunx vitest run test/integration/auth-service.test.ts`
- `bun run check-types` in `apps/server`
- `bunx biome lint apps/server/src/auth/layers/auth-service.ts apps/server/test/integration/auth-service.test.ts`
- `bun run build:desktop`
- Full server suite: 217/218 passed; one unrelated parallel performance-threshold test passed when rerun independently.
