### PR TITLE
Add Linear-powered issue sessions

### DIFF
--- a/apps/desktop/src/linear-context-image.ts
+++ b/apps/desktop/src/linear-context-image.ts
@@ -1,0 +1,26 @@
+const IMAGE_EXTENSIONS = new Set([
+	"avif",
+	"gif",
+	"jpeg",
+	"jpg",
+	"png",
+	"svg",
+	"webp",
+]);
+
+export const isLinearContextImagePath = (path: string): boolean => {
+	const segments = path
+		.split(/[\\/]+/u)
+		.filter((segment) => segment.length > 0);
+	const contextIndex = segments.lastIndexOf(".context");
+	if (contextIndex === -1 || segments[contextIndex + 1] !== "linear") {
+		return false;
+	}
+	const tail = segments.slice(contextIndex + 2);
+	if (tail.length !== 4 || tail[1] !== "assets") return false;
+	const filename = tail[3];
+	if (filename === undefined) return false;
+	const dot = filename.lastIndexOf(".");
+	if (dot <= 0) return false;
+	return IMAGE_EXTENSIONS.has(filename.slice(dot + 1).toLowerCase());
+};

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -197,8 +197,23 @@ const isAuthDeepLink = (arg: string): boolean =>
 
 let deliverAuthUrl: ((url: string) => void) | null = null;
 let pendingAuthUrls: string[] = [];
+let deliverLinearUrl: ((url: string) => void) | null = null;
+let pendingLinearUrls: string[] = [];
 
 const handleAuthCallback = (url: string): void => {
+	let isLinear = false;
+	try {
+		const parsed = new URL(url);
+		isLinear =
+			parsed.pathname === "/linear/callback" || parsed.hostname === "linear";
+	} catch {
+		// Invalid callback URLs are delivered to the account flow and rejected there.
+	}
+	if (isLinear) {
+		if (deliverLinearUrl !== null) deliverLinearUrl(url);
+		else pendingLinearUrls.push(url);
+		return;
+	}
 	if (deliverAuthUrl !== null) {
 		deliverAuthUrl(url);
 	} else {
@@ -251,7 +266,10 @@ const startAuthLoopback = async (): Promise<void> => {
 			res.end();
 			return;
 		}
-		if (parsed.pathname !== "/callback") {
+		if (
+			parsed.pathname !== "/callback" &&
+			parsed.pathname !== "/linear/callback"
+		) {
 			res.writeHead(404);
 			res.end("Not found");
 			return;
@@ -667,6 +685,9 @@ const authShell = {
 	get redirectUri() {
 		return `http://localhost:${boundAuthPort ?? AUTH_LOOPBACK_PORTS[0]}/callback`;
 	},
+	get linearRedirectUri() {
+		return `http://localhost:${boundAuthPort ?? AUTH_LOOPBACK_PORTS[0]}/linear/callback`;
+	},
 	open: (url: string) =>
 		Effect.tryPromise({
 			try: async () => {
@@ -691,6 +712,13 @@ const authShell = {
 			deliverAuthUrl = handler;
 			const queued = pendingAuthUrls;
 			pendingAuthUrls = [];
+			for (const url of queued) handler(url);
+		}),
+	onLinearCallbackUrl: (handler: (url: string) => void) =>
+		Effect.sync(() => {
+			deliverLinearUrl = handler;
+			const queued = pendingLinearUrls;
+			pendingLinearUrls = [];
 			for (const url of queued) handler(url);
 		}),
 };

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -42,6 +42,7 @@ if (
 }
 
 import { electronServerProtocolLayer } from "./ipc/electron-server-protocol.ts";
+import { isLinearContextImagePath } from "./linear-context-image.ts";
 import {
 	DEFAULT_MENU_ACCELERATORS,
 	installAppMenu,
@@ -1530,6 +1531,7 @@ async function createMainWindow() {
  */
 const ATTACHMENTS_HOST = "attachments";
 const POKEMON_HOST = "pokemon";
+const LINEAR_CONTEXT_HOST = "linear-context";
 
 const MIME_BY_EXT: Record<string, string> = {
 	png: "image/png",
@@ -1538,6 +1540,7 @@ const MIME_BY_EXT: Record<string, string> = {
 	webp: "image/webp",
 	gif: "image/gif",
 	avif: "image/avif",
+	svg: "image/svg+xml",
 };
 
 type AssetFilenameCache = {
@@ -1647,6 +1650,28 @@ const registerZuseProtocol = (): void => {
 
 	const handleAssetRequest = async (request: Request) => {
 		const url = new URL(request.url);
+		if (url.host === LINEAR_CONTEXT_HOST) {
+			try {
+				const requestedPath = decodeURIComponent(url.pathname);
+				const realPath = await fs.realpath(requestedPath);
+				if (!isLinearContextImagePath(realPath)) {
+					return new Response(null, { status: 403 });
+				}
+				const ext = Path.extname(realPath).slice(1).toLowerCase();
+				const mime = MIME_BY_EXT[ext];
+				if (mime === undefined) return new Response(null, { status: 415 });
+				const response = await net.fetch(pathToFileURL(realPath).toString());
+				const headers = new Headers(response.headers);
+				headers.set("content-type", mime);
+				headers.set("cache-control", "private, max-age=3600");
+				return new Response(response.body, {
+					status: response.status,
+					headers,
+				});
+			} catch {
+				return new Response(null, { status: 404 });
+			}
+		}
 		if (url.host !== ATTACHMENTS_HOST && url.host !== POKEMON_HOST) {
 			return new Response(null, { status: 404 });
 		}

--- a/apps/desktop/test/unit/linear-context-image.test.ts
+++ b/apps/desktop/test/unit/linear-context-image.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { isLinearContextImagePath } from "../../src/linear-context-image.ts";
+
+describe("Linear context image protocol", () => {
+	it("allows generated issue images", () => {
+		expect(
+			isLinearContextImagePath(
+				"/workspace/.context/linear/team-a1b2/assets/ABC-123/image.png",
+			),
+		).toBe(true);
+	});
+
+	it("rejects traversal targets and non-images", () => {
+		expect(
+			isLinearContextImagePath("/workspace/.context/linear/secret.png"),
+		).toBe(false);
+		expect(
+			isLinearContextImagePath(
+				"/workspace/.context/linear/team-a1b2/assets/ABC-123/notes.txt",
+			),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -11,8 +11,10 @@ const repoRoot = resolve(__dirname, "..", "..");
 // bun's automatic `.env` loading doesn't reach it. Read .env files ourselves
 // so both dev (`tsdown --watch`) and packaged builds inline the public WorkOS
 // client id. A real shell/CI env var always wins.
-const resolveWorkosClientId = (): string => {
-  if (process.env.WORKOS_CLIENT_ID) return process.env.WORKOS_CLIENT_ID;
+const resolveClientId = (
+  name: "WORKOS_CLIENT_ID" | "LINEAR_CLIENT_ID",
+): string => {
+  if (process.env[name]) return process.env[name];
   const envPaths = [
     resolve(process.cwd(), ".env"),
     resolve(__dirname, ".env"),
@@ -21,7 +23,7 @@ const resolveWorkosClientId = (): string => {
   for (const envPath of envPaths) {
     if (!existsSync(envPath)) continue;
     for (const line of readFileSync(envPath, "utf8").split("\n")) {
-      const match = line.match(/^\s*WORKOS_CLIENT_ID\s*=\s*(.*?)\s*$/);
+      const match = line.match(new RegExp(`^\\s*${name}\\s*=\\s*(.*?)\\s*$`));
       if (match?.[1] !== undefined) {
         return match[1].replace(/^["']|["']$/g, "");
       }
@@ -30,7 +32,8 @@ const resolveWorkosClientId = (): string => {
   return "";
 };
 
-const WORKOS_CLIENT_ID = resolveWorkosClientId();
+const WORKOS_CLIENT_ID = resolveClientId("WORKOS_CLIENT_ID");
+const LINEAR_CLIENT_ID = resolveClientId("LINEAR_CLIENT_ID");
 
 const shared = {
   format: "cjs" as const,
@@ -44,6 +47,7 @@ const shared = {
   // Dev: `export WORKOS_CLIENT_ID=client_… ` before `bun run dev`.
   define: {
     "process.env.WORKOS_CLIENT_ID": JSON.stringify(WORKOS_CLIENT_ID),
+    "process.env.LINEAR_CLIENT_ID": JSON.stringify(LINEAR_CLIENT_ID),
   },
   // Workspace packages ship as raw .ts source — bundle them in instead of
   // letting Node try to require() the .ts file at runtime.
@@ -114,6 +118,20 @@ export default defineConfig([
     entry: {
       "orchestration-mcp-child":
         "../../packages/agents/src/drivers/acp/orchestration-mcp-child.ts",
+    },
+    deps: {
+      alwaysBundle: [
+        "@zuse/contracts",
+        "@zuse/agents",
+        "@modelcontextprotocol/sdk",
+      ],
+    },
+  },
+  {
+    ...shared,
+    entry: {
+      "linear-mcp-child":
+        "../../packages/agents/src/drivers/acp/linear-mcp-child.ts",
     },
     deps: {
       alwaysBundle: [

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -5,28 +5,20 @@ import {
   FolderAddIcon,
   Tick01Icon,
 } from "@hugeicons-pro/core-bulk-rounded";
-import { X } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useState } from "react";
-
-import { Effect } from "effect";
-
 import {
-  type ComposerInput,
+  type ChatId,
+  ComposerInput,
   defaultModelFor,
   type FolderId,
+  type LinearIssueSummary,
   type ProviderId,
+  type SessionId,
   type WorktreeCreateSource,
   type WorktreeId,
 } from "@zuse/contracts";
-
-import { cn } from "~/lib/utils";
-import {
-  Menu,
-  MenuItem,
-  MenuPopup,
-  MenuSeparator,
-  MenuTrigger,
-} from "~/components/ui/menu";
+import { Effect } from "effect";
+import { X } from "lucide-react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
   Frame,
   FrameFooter,
@@ -34,9 +26,16 @@ import {
   FramePanel,
   FrameTitle,
 } from "~/components/ui/frame";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuSeparator,
+  MenuTrigger,
+} from "~/components/ui/menu";
 import { Skeleton } from "~/components/ui/skeleton";
 import { Spinner } from "~/components/ui/spinner";
-import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
+import { toastManager } from "~/components/ui/toast.tsx";
 import {
   appendContextFileRef,
   finalizeDraftAttachments,
@@ -44,26 +43,28 @@ import {
   type PendingDraftAttachment,
   type PendingDraftContextFile,
 } from "~/composer/draft-attachments";
+import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
+import { saveContextFile } from "~/lib/context-handoff";
+import { getRpcClient } from "~/lib/rpc-client";
+import { cn } from "~/lib/utils";
+import { useAttachmentsStore } from "~/store/attachments";
 import { useChatsStore } from "~/store/chats";
+import { useComposerBridge } from "~/store/composer-bridge";
+import { composerDraftKeyForLanding } from "~/store/composer-drafts";
+import { useExternalThreadsStore } from "~/store/external-threads";
 import { useMessagesStore } from "~/store/messages";
 import { useProvidersStore } from "~/store/providers";
-import { useExternalThreadsStore } from "~/store/external-threads";
 import { DRAFT_SESSION_ID, useSessionsStore } from "~/store/sessions";
 import { useSettingsStore } from "~/store/settings";
 import { useWorkspaceStore } from "~/store/workspace";
 import { EMPTY_WORKTREES, useWorktreesStore } from "~/store/worktrees";
-import { useAttachmentsStore } from "~/store/attachments";
-import { composerDraftKeyForLanding } from "~/store/composer-drafts";
-import { useComposerBridge } from "~/store/composer-bridge";
-import { saveContextFile } from "~/lib/context-handoff";
-import { getRpcClient } from "~/lib/rpc-client";
+import { ChatComposer } from "./chat-composer.tsx";
 import {
   CreateFromMenu,
   type CreateFromSelection,
 } from "./composer/create-from-menu.tsx";
-import { ChatComposer } from "./chat-composer.tsx";
-import { PROVIDER_LABEL } from "./settings-page";
 import { ProviderIcon } from "./provider-icons";
+import { PROVIDER_LABEL } from "./settings-page";
 import { SetupCardView } from "./worktree-setup-card.tsx";
 
 /**
@@ -198,6 +199,10 @@ export function ChatLanding() {
       readonly markdown: string;
       readonly title: string;
     } | null;
+    readonly linear: {
+      readonly issues: ReadonlyArray<LinearIssueSummary>;
+      readonly mode: "combined" | "separate";
+    } | null;
   } | null>(null);
   const [creatingSource, setCreatingSource] = useState(false);
 
@@ -262,6 +267,24 @@ export function ChatLanding() {
   ): Promise<void> => {
     if (selectedFolderId === null || creatingSource) return;
     setSubmitError(null);
+    if (sel.kind === "linear") {
+      const identifiers = sel.issues
+        .map((issue) => issue.identifier)
+        .join(", ");
+      setCreateSource({
+        kind: "linear",
+        worktreeId: null,
+        label: identifiers,
+        issue: null,
+        linear: { issues: sel.issues, mode: sel.mode },
+      });
+      const generated =
+        sel.mode === "combined"
+          ? `Implement ${identifiers} together in one pull request. Work through every selected ticket and verify the combined result.`
+          : `Implement each selected Linear ticket in its own session and pull request. Verify each ticket before completing it.`;
+      useComposerBridge.getState().insertText?.(generated);
+      return;
+    }
     if (sel.kind === "issue") {
       try {
         const client = await getRpcClient();
@@ -276,6 +299,7 @@ export function ChatLanding() {
           worktreeId: null,
           label: `#${sel.number}`,
           issue: { markdown: res.markdown, title: res.title || sel.title },
+          linear: null,
         });
         // Prefill the composer with an editable default the user can rewrite.
         const insert = useComposerBridge.getState().insertText;
@@ -297,6 +321,7 @@ export function ChatLanding() {
         worktreeId: sel.existingWorktreeId,
         label,
         issue: null,
+        linear: null,
       });
       return;
     }
@@ -315,7 +340,53 @@ export function ChatLanding() {
       );
       return;
     }
-    setCreateSource({ kind: sel.kind, worktreeId: wt.id, label, issue: null });
+    setCreateSource({
+      kind: sel.kind,
+      worktreeId: wt.id,
+      label,
+      issue: null,
+      linear: null,
+    });
+  };
+
+  const prepareLinearInput = async (
+    sessionId: SessionId,
+    issues: ReadonlyArray<LinearIssueSummary>,
+    input: ComposerInput,
+  ): Promise<ComposerInput> => {
+    const client = await getRpcClient();
+    const prepared = await Effect.runPromise(
+      client["linear.prepareContext"]({
+        sessionId,
+        issues: issues.map((issue) => ({
+          workspaceId: issue.workspaceId,
+          issueId: issue.issueId,
+          identifier: issue.identifier,
+        })),
+      }),
+    );
+    if (prepared.warnings.length > 0) {
+      toastManager.add({
+        type: "error",
+        title: "Some Linear context was incomplete",
+        description: prepared.warnings
+          .map((warning) => warning.message)
+          .join(" · "),
+      });
+    }
+    const withPreamble = ComposerInput.make({
+      ...input,
+      text: [
+        "For the selected Linear tickets: move active work into an appropriate started state, post useful progress and completion comments, and only mark work complete after relevant verification. Ask for mutation permission when required.",
+        input.text,
+      ]
+        .filter((part) => part.trim().length > 0)
+        .join("\n\n"),
+    });
+    return prepared.files.reduce(
+      (current, file) => appendContextFileRef(current, file),
+      withPreamble,
+    );
   };
 
   // Driven by the real ChatComposer (draft mode): it hands back the parsed
@@ -340,6 +411,120 @@ export function ChatLanding() {
     setPendingPrompt(
       input.text.trim().length > 0 ? input.text.trim() : "New chat",
     );
+    if (
+      createSource?.linear?.mode === "separate" &&
+      createSource.linear.issues.length > 0
+    ) {
+      const issues = createSource.linear.issues;
+      const successes: Array<{
+        chatId: ChatId;
+        sessionId: SessionId;
+      }> = [];
+      const failures: string[] = [];
+      let cursor = 0;
+      const launchOne = async (issue: LinearIssueSummary) => {
+        const worktreeId = await resolveAutoWorktreeId(selectedFolderId);
+        const result = await create(
+          selectedFolderId,
+          draft.providerId,
+          draft.model,
+          {
+            title: `${issue.identifier} ${issue.title}`,
+            runtimeMode: draft.runtimeMode,
+            permissionMode: draft.permissionMode,
+            worktreeId,
+          },
+        );
+        if (result === null) {
+          failures.push(`${issue.identifier}: couldn't create session`);
+          return;
+        }
+        migrateModelOptions(DRAFT_SESSION_ID, result.initialSessionId);
+        try {
+          let ticketInput = await prepareLinearInput(
+            result.initialSessionId,
+            [issue],
+            input,
+          );
+          const uploadRoot =
+            worktreeId === null
+              ? (selectedFolder?.path ?? null)
+              : ((
+                  useWorktreesStore.getState().byProject[selectedFolderId] ??
+                  EMPTY_WORKTREES
+                ).find((worktree) => worktree.id === worktreeId)?.path ??
+                selectedFolder?.path ??
+                null);
+          ticketInput = await finalizeDraftContextFiles(
+            ticketInput,
+            opts.pendingContextFiles,
+            async (pending) => {
+              const saved = await Effect.runPromise(
+                (await getRpcClient())["context.saveText"]({
+                  sessionId: result.initialSessionId,
+                  text: pending.text,
+                  ext: pending.ext,
+                  ...(uploadRoot ? { rootPath: uploadRoot } : {}),
+                }),
+              );
+              return { relPath: saved.relPath, absPath: saved.absPath };
+            },
+          );
+          ticketInput = await finalizeDraftAttachments(
+            ticketInput,
+            opts.pendingAttachments,
+            (pending) =>
+              uploadOne(
+                result.initialSessionId,
+                pending.file,
+                uploadRoot ?? undefined,
+              ),
+          );
+          void send(result.initialSessionId, ticketInput, {
+            asGoal: opts.asGoal && goalSupported,
+          });
+          successes.push({
+            chatId: result.chatId,
+            sessionId: result.initialSessionId,
+          });
+        } catch (error) {
+          failures.push(
+            `${issue.identifier}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      };
+      const workers = Array.from(
+        { length: Math.min(3, issues.length) },
+        async () => {
+          while (cursor < issues.length) {
+            const issue = issues[cursor++];
+            if (issue !== undefined) await launchOne(issue);
+          }
+        },
+      );
+      await Promise.all(workers);
+      for (const pending of opts.pendingAttachments) {
+        if (pending.previewUrl) URL.revokeObjectURL(pending.previewUrl);
+      }
+      if (failures.length > 0) {
+        toastManager.add({
+          type: "error",
+          title: `${failures.length} Linear session${failures.length === 1 ? "" : "s"} failed`,
+          description: failures.join(" · "),
+        });
+      }
+      const first = successes[0];
+      if (first === undefined) {
+        setSubmitError("Couldn't start any of the selected Linear tickets.");
+        setSubmitting(false);
+        return;
+      }
+      useChatsStore.getState().select(first.chatId);
+      useSessionsStore.getState().select(first.sessionId);
+      setCreateSource(null);
+      useSessionsStore.getState().clearDraft();
+      return;
+    }
     // A "Create from…" PR/branch already checked out (or reused) a worktree —
     // pin the chat to it. Otherwise fall back to the normal auto-worktree.
     const worktreeId =
@@ -378,6 +563,21 @@ export function ChatLanding() {
       const ref = await saveContextFile(sessionId, createSource.issue.markdown);
       if (ref !== null) {
         finalInput = appendContextFileRef(input, ref);
+      }
+    }
+    if (createSource?.linear?.mode === "combined") {
+      try {
+        finalInput = await prepareLinearInput(
+          sessionId,
+          createSource.linear.issues,
+          finalInput,
+        );
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Linear context could not be fully prepared",
+          description: error instanceof Error ? error.message : String(error),
+        });
       }
     }
     const uploadRoot = (() => {
@@ -526,22 +726,66 @@ export function ChatLanding() {
                 />
                 <div className="flex min-w-0 items-center gap-1.5">
                   {createSource !== null && (
-                    <span className="flex min-w-0 items-center gap-1 rounded-md bg-muted/60 py-1 pl-2 pr-1 text-[11px] text-muted-foreground">
-                      {createSource.kind === "issue" ? (
+                    <span className="flex min-w-0 items-center gap-1 overflow-x-auto">
+                      {createSource.linear !== null ? (
+                        createSource.linear.issues.map((issue) => (
+                          <span
+                            key={`${issue.workspaceId}:${issue.issueId}`}
+                            className="flex shrink-0 items-center gap-1 rounded-md bg-muted/60 py-1 pl-2 pr-1 text-[11px] text-muted-foreground"
+                          >
+                            <span>{issue.identifier}</span>
+                            <button
+                              type="button"
+                              aria-label={`Remove ${issue.identifier}`}
+                              onClick={() =>
+                                setCreateSource((current) => {
+                                  if (
+                                    current?.linear === null ||
+                                    current === null
+                                  )
+                                    return current;
+                                  const issues = current.linear.issues.filter(
+                                    (candidate) =>
+                                      candidate.workspaceId !==
+                                        issue.workspaceId ||
+                                      candidate.issueId !== issue.issueId,
+                                  );
+                                  return issues.length === 0
+                                    ? null
+                                    : {
+                                        ...current,
+                                        label: issues
+                                          .map(
+                                            (candidate) => candidate.identifier,
+                                          )
+                                          .join(", "),
+                                        linear: { ...current.linear, issues },
+                                      };
+                                })
+                              }
+                              className="rounded p-0.5 hover:bg-muted hover:text-foreground"
+                            >
+                              <X className="size-3" strokeWidth={2} />
+                            </button>
+                          </span>
+                        ))
+                      ) : createSource.kind === "issue" ? (
                         <span>Issue {createSource.label} attached</span>
                       ) : (
                         <span className="max-w-[16rem] truncate">
                           {createSource.label}
                         </span>
                       )}
-                      <button
-                        type="button"
-                        onClick={() => setCreateSource(null)}
-                        aria-label="Clear create-from source"
-                        className="shrink-0 rounded p-0.5 hover:bg-muted hover:text-foreground"
-                      >
-                        <X className="size-3" strokeWidth={2} />
-                      </button>
+                      {createSource.linear === null && (
+                        <button
+                          type="button"
+                          onClick={() => setCreateSource(null)}
+                          aria-label="Clear create-from source"
+                          className="shrink-0 rounded p-0.5 hover:bg-muted hover:text-foreground"
+                        >
+                          <X className="size-3" strokeWidth={2} />
+                        </button>
+                      )}
                     </span>
                   )}
                   {creatingSource && (

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -7,7 +7,7 @@ import {
 } from "@hugeicons-pro/core-bulk-rounded";
 import {
   type ChatId,
-  ComposerInput,
+  type ComposerInput,
   defaultModelFor,
   type FolderId,
   type LinearIssueSummary,
@@ -43,6 +43,7 @@ import {
   type PendingDraftAttachment,
   type PendingDraftContextFile,
 } from "~/composer/draft-attachments";
+import { applyPreparedLinearContext } from "~/composer/linear-context-input";
 import { resolveAutoWorktreeId } from "~/lib/auto-worktree";
 import { saveContextFile } from "~/lib/context-handoff";
 import { getRpcClient } from "~/lib/rpc-client";
@@ -374,19 +375,7 @@ export function ChatLanding() {
           .join(" · "),
       });
     }
-    const withPreamble = ComposerInput.make({
-      ...input,
-      text: [
-        "For the selected Linear tickets: move active work into an appropriate started state, post useful progress and completion comments, and only mark work complete after relevant verification. Ask for mutation permission when required.",
-        input.text,
-      ]
-        .filter((part) => part.trim().length > 0)
-        .join("\n\n"),
-    });
-    return prepared.files.reduce(
-      (current, file) => appendContextFileRef(current, file),
-      withPreamble,
-    );
+    return applyPreparedLinearContext(input, prepared);
   };
 
   // Driven by the real ChatComposer (draft mode): it hands back the parsed

--- a/apps/renderer/src/components/composer/create-from-menu.tsx
+++ b/apps/renderer/src/components/composer/create-from-menu.tsx
@@ -108,9 +108,7 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
   const [selectedLinear, setSelectedLinear] = useState<
     ReadonlyMap<string, LinearIssueSummary>
   >(new Map());
-  const [linearMode, setLinearMode] = useState<"combined" | "separate" | null>(
-    null,
-  );
+  const [separateLinearThreads, setSeparateLinearThreads] = useState(false);
   const [worktreesLoadedForOpen, setWorktreesLoadedForOpen] = useState(false);
   // branch name → worktreeId, for the "In use" badge + reuse behaviour.
   const [worktreeByBranch, setWorktreeByBranch] = useState<
@@ -344,15 +342,18 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
   };
 
   const confirmLinear = () => {
-    if (selectedLinear.size === 0 || linearMode === null) return;
+    if (selectedLinear.size === 0) return;
     onSelect({
       kind: "linear",
       issues: [...selectedLinear.values()],
-      mode: linearMode,
+      mode:
+        selectedLinear.size > 1 && separateLinearThreads
+          ? "separate"
+          : "combined",
     });
     setOpen(false);
     setSelectedLinear(new Map());
-    setLinearMode(null);
+    setSeparateLinearThreads(false);
   };
 
   return (
@@ -566,25 +567,22 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                 <span className="mr-auto text-xs text-muted-foreground">
                   {selectedLinear.size} selected
                 </span>
-                {(["combined", "separate"] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    type="button"
-                    aria-pressed={linearMode === mode}
-                    onClick={() => setLinearMode(mode)}
-                    className={cn(
-                      "rounded-md border px-2.5 py-1.5 text-xs capitalize",
-                      linearMode === mode
-                        ? "border-primary bg-primary/10 text-foreground"
-                        : "border-border text-muted-foreground hover:bg-muted",
-                    )}
-                  >
-                    {mode}
-                  </button>
-                ))}
+                {selectedLinear.size > 1 && (
+                  <label className="flex min-h-8 cursor-pointer select-none items-center gap-2 rounded-md px-1 text-xs text-muted-foreground pointer-coarse:min-h-11">
+                    <input
+                      type="checkbox"
+                      checked={separateLinearThreads}
+                      onChange={(event) =>
+                        setSeparateLinearThreads(event.target.checked)
+                      }
+                      className="size-4 shrink-0 cursor-pointer accent-primary"
+                    />
+                    <span>Separate threads</span>
+                  </label>
+                )}
                 <button
                   type="button"
-                  disabled={selectedLinear.size === 0 || linearMode === null}
+                  disabled={selectedLinear.size === 0}
                   onClick={confirmLinear}
                   className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-40"
                 >

--- a/apps/renderer/src/components/composer/create-from-menu.tsx
+++ b/apps/renderer/src/components/composer/create-from-menu.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowDown01Icon,
   GitBranchIcon,
@@ -5,17 +6,17 @@ import {
   RecordIcon,
   Search01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { Effect } from "effect";
-import { useEffect, useMemo, useRef, useState } from "react";
-
 import type {
   FolderId,
   GitBranchInfo,
   GitIssueSummary,
   GitPrSummary,
+  LinearConnection,
+  LinearIssueSummary,
   WorktreeId,
 } from "@zuse/contracts";
+import { Effect } from "effect";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { PopoverPrimitive } from "~/components/ui/popover";
 import { getRpcClient } from "~/lib/rpc-client.ts";
@@ -45,9 +46,14 @@ export type CreateFromSelection =
       readonly kind: "issue";
       readonly number: number;
       readonly title: string;
+    }
+  | {
+      readonly kind: "linear";
+      readonly issues: ReadonlyArray<LinearIssueSummary>;
+      readonly mode: "combined" | "separate";
     };
 
-type Tab = "prs" | "branches" | "issues";
+type Tab = "prs" | "branches" | "issues" | "linear";
 
 interface Row {
   readonly key: string;
@@ -63,6 +69,7 @@ const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: "prs", label: "PRs" },
   { id: "branches", label: "Branches" },
   { id: "issues", label: "Issues" },
+  { id: "linear", label: "Linear" },
 ];
 
 export interface CreateFromMenuProps {
@@ -89,6 +96,17 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
   const [issues, setIssues] = useState<ReadonlyArray<GitIssueSummary> | null>(
     null,
   );
+  const [linearConnections, setLinearConnections] =
+    useState<ReadonlyArray<LinearConnection> | null>(null);
+  const [linearIssues, setLinearIssues] =
+    useState<ReadonlyArray<LinearIssueSummary> | null>(null);
+  const [linearWorkspaceId, setLinearWorkspaceId] = useState("");
+  const [selectedLinear, setSelectedLinear] = useState<
+    ReadonlyMap<string, LinearIssueSummary>
+  >(new Map());
+  const [linearMode, setLinearMode] = useState<"combined" | "separate" | null>(
+    null,
+  );
   const [worktreesLoadedForOpen, setWorktreesLoadedForOpen] = useState(false);
   // branch name → worktreeId, for the "In use" badge + reuse behaviour.
   const [worktreeByBranch, setWorktreeByBranch] = useState<
@@ -104,6 +122,42 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
     setWorktreeByBranch(new Map());
     setWorktreesLoadedForOpen(false);
   }, [folderId]);
+
+  useEffect(() => {
+    if (!open || tab !== "linear") return;
+    let cancelled = false;
+    const timer = window.setTimeout(
+      () => {
+        void (async () => {
+          try {
+            const client = await getRpcClient();
+            if (linearConnections === null) {
+              const connections = await Effect.runPromise(
+                client["linear.listConnections"]({}),
+              );
+              if (!cancelled) setLinearConnections(connections);
+            }
+            const result = await Effect.runPromise(
+              client["linear.listIssues"]({
+                ...(query.trim() === "" ? {} : { query: query.trim() }),
+                ...(linearWorkspaceId === ""
+                  ? {}
+                  : { workspaceIds: [linearWorkspaceId] }),
+              }),
+            );
+            if (!cancelled) setLinearIssues(result.issues);
+          } catch {
+            if (!cancelled) setLinearIssues([]);
+          }
+        })();
+      },
+      query.trim() === "" ? 0 : 250,
+    );
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [open, tab, query, linearWorkspaceId, linearConnections]);
 
   useEffect(() => {
     if (!open) {
@@ -159,7 +213,8 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
   const loading =
     (tab === "prs" && prs === null) ||
     (tab === "branches" && branches === null) ||
-    (tab === "issues" && issues === null);
+    (tab === "issues" && issues === null) ||
+    (tab === "linear" && linearIssues === null);
 
   const rows = useMemo<ReadonlyArray<Row>>(() => {
     if (tab === "prs") {
@@ -206,22 +261,25 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
           };
         });
     }
-    return (issues ?? []).map((issue) => ({
-      key: `is:${issue.number}`,
-      icon: RecordIcon,
-      lead: `#${issue.number}`,
-      label: issue.title,
-      inUse: false,
-      selection: { kind: "issue", number: issue.number, title: issue.title },
-      haystack: `${issue.number} ${issue.title} ${issue.author}`,
-    }));
+    if (tab === "issues")
+      return (issues ?? []).map((issue) => ({
+        key: `is:${issue.number}`,
+        icon: RecordIcon,
+        lead: `#${issue.number}`,
+        label: issue.title,
+        inUse: false,
+        selection: { kind: "issue", number: issue.number, title: issue.title },
+        haystack: `${issue.number} ${issue.title} ${issue.author}`,
+      }));
+    return [];
   }, [tab, prs, branches, issues, worktreeByBranch]);
 
   const filtered = useMemo(() => {
+    if (tab === "linear") return [];
     const q = query.trim().toLowerCase();
     if (q.length === 0) return rows;
     return rows.filter((r) => r.haystack.toLowerCase().includes(q));
-  }, [rows, query]);
+  }, [rows, query, tab]);
 
   useEffect(() => setHighlight(0), [filtered]);
 
@@ -232,6 +290,23 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
+    if (tab === "linear") {
+      const issue = (linearIssues ?? [])[highlight];
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const count = linearIssues?.length ?? 0;
+        if (count > 0)
+          setHighlight((value) =>
+            e.key === "ArrowDown"
+              ? (value + 1) % count
+              : (value - 1 + count) % count,
+          );
+      } else if ((e.key === "Enter" || e.key === " ") && issue !== undefined) {
+        e.preventDefault();
+        toggleLinear(issue);
+      }
+      return;
+    }
     if (filtered.length === 0) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -244,6 +319,30 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
       const row = filtered[highlight];
       if (row !== undefined) confirm(row);
     }
+  };
+
+  const linearKey = (issue: LinearIssueSummary) =>
+    `${issue.workspaceId}:${issue.issueId}`;
+  const toggleLinear = (issue: LinearIssueSummary) => {
+    setSelectedLinear((current) => {
+      const next = new Map(current);
+      const key = linearKey(issue);
+      if (next.has(key)) next.delete(key);
+      else next.set(key, issue);
+      return next;
+    });
+  };
+
+  const confirmLinear = () => {
+    if (selectedLinear.size === 0 || linearMode === null) return;
+    onSelect({
+      kind: "linear",
+      issues: [...selectedLinear.values()],
+      mode: linearMode,
+    });
+    setOpen(false);
+    setSelectedLinear(new Map());
+    setLinearMode(null);
   };
 
   return (
@@ -262,7 +361,7 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
           "hover:bg-accent data-[popup-open]:bg-accent",
           folderId === null && "pointer-events-none opacity-50",
         )}
-        aria-label="Create from an existing PR, branch, or issue"
+        aria-label="Create from an existing PR, branch, or issue tracker ticket"
       >
         <HugeiconsIcon
           icon={GitPullRequestIcon}
@@ -294,7 +393,9 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                 placeholder={
                   tab === "branches"
                     ? "Search by name"
-                    : "Search by title, number, or author"
+                    : tab === "linear"
+                      ? "Search ticker or title"
+                      : "Search by title, number, or author"
                 }
                 className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
               />
@@ -319,11 +420,86 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                 </button>
               ))}
             </div>
+            {tab === "linear" && (linearConnections?.length ?? 0) > 1 && (
+              <div className="border-b border-border/50 px-3 py-2">
+                <select
+                  aria-label="Filter by Linear workspace"
+                  value={linearWorkspaceId}
+                  onChange={(event) => setLinearWorkspaceId(event.target.value)}
+                  className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <option value="">All workspaces</option>
+                  {linearConnections?.map((connection) => (
+                    <option
+                      key={connection.workspaceId}
+                      value={connection.workspaceId}
+                    >
+                      {connection.workspaceName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
             <div className="max-h-80 min-h-24 overflow-y-auto py-1">
               {loading ? (
                 <div className="px-3 py-6 text-center text-sm text-muted-foreground">
                   Loading…
                 </div>
+              ) : tab === "linear" && (linearConnections?.length ?? 0) === 0 ? (
+                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  Connect a Linear workspace in Settings → Integrations.
+                </div>
+              ) : tab === "linear" ? (
+                (linearIssues ?? []).length === 0 ? (
+                  <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                    {query.trim() === ""
+                      ? "No assigned open issues."
+                      : "No matching issues."}
+                  </div>
+                ) : (
+                  (linearIssues ?? []).map((issue, index) => {
+                    const checked = selectedLinear.has(linearKey(issue));
+                    const active = index === highlight;
+                    return (
+                      <label
+                        key={linearKey(issue)}
+                        onMouseEnter={() => setHighlight(index)}
+                        className={cn(
+                          "flex w-full items-center gap-3 px-3 py-2 text-left transition-colors",
+                          active ? "bg-accent" : "hover:bg-muted",
+                        )}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggleLinear(issue)}
+                          aria-label={`Select ${issue.identifier}: ${issue.title}`}
+                          className="sr-only"
+                        />
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            "grid size-4 shrink-0 place-items-center rounded border text-[10px]",
+                            checked
+                              ? "border-primary bg-primary text-primary-foreground"
+                              : "border-border",
+                          )}
+                        >
+                          {checked ? "✓" : ""}
+                        </span>
+                        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                          {issue.identifier}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate text-sm">
+                          {issue.title}
+                        </span>
+                        <span className="max-w-24 shrink-0 truncate text-xs text-muted-foreground">
+                          {issue.workspaceName}
+                        </span>
+                      </label>
+                    );
+                  })
+                )
               ) : filtered.length === 0 ? (
                 <div className="px-3 py-6 text-center text-sm text-muted-foreground">
                   {tab === "branches"
@@ -366,6 +542,37 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                 })
               )}
             </div>
+            {tab === "linear" && (
+              <div className="flex items-center gap-2 border-t border-border/50 px-3 py-2">
+                <span className="mr-auto text-xs text-muted-foreground">
+                  {selectedLinear.size} selected
+                </span>
+                {(["combined", "separate"] as const).map((mode) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    aria-pressed={linearMode === mode}
+                    onClick={() => setLinearMode(mode)}
+                    className={cn(
+                      "rounded-md border px-2.5 py-1.5 text-xs capitalize",
+                      linearMode === mode
+                        ? "border-primary bg-primary/10 text-foreground"
+                        : "border-border text-muted-foreground hover:bg-muted",
+                    )}
+                  >
+                    {mode}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  disabled={selectedLinear.size === 0 || linearMode === null}
+                  onClick={confirmLinear}
+                  className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-40"
+                >
+                  Stage
+                </button>
+              </div>
+            )}
           </PopoverPrimitive.Popup>
         </PopoverPrimitive.Positioner>
       </PopoverPrimitive.Portal>

--- a/apps/renderer/src/components/composer/create-from-menu.tsx
+++ b/apps/renderer/src/components/composer/create-from-menu.tsx
@@ -1,8 +1,12 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowDown01Icon,
+  CancelCircleIcon,
+  CheckmarkCircle01Icon,
+  CircleDashedIcon,
   GitBranchIcon,
   GitPullRequestIcon,
+  Progress03Icon,
   RecordIcon,
   Search01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
@@ -18,6 +22,11 @@ import type {
 import { Effect } from "effect";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "~/components/ui/avatar.tsx";
 import { Button } from "~/components/ui/button.tsx";
 import { PopoverPrimitive } from "~/components/ui/popover";
 import { getRpcClient } from "~/lib/rpc-client.ts";
@@ -74,6 +83,31 @@ const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
   { id: "linear", label: "Linear" },
 ];
 
+const linearStateIcon = (stateType: string) => {
+  switch (stateType) {
+    case "started":
+      return Progress03Icon;
+    case "completed":
+      return CheckmarkCircle01Icon;
+    case "canceled":
+      return CancelCircleIcon;
+    case "backlog":
+    case "triage":
+      return CircleDashedIcon;
+    default:
+      return RecordIcon;
+  }
+};
+
+const assigneeInitials = (name: string): string =>
+  name
+    .trim()
+    .split(/\s+/u)
+    .slice(0, 2)
+    .map((part) => part[0] ?? "")
+    .join("")
+    .toUpperCase();
+
 export interface CreateFromMenuProps {
   readonly folderId: FolderId | null;
   readonly onSelect: (selection: CreateFromSelection) => void;
@@ -104,6 +138,7 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
     useState<ReadonlyArray<LinearConnection> | null>(null);
   const [linearIssues, setLinearIssues] =
     useState<ReadonlyArray<LinearIssueSummary> | null>(null);
+  const [linearError, setLinearError] = useState<string | null>(null);
   const [linearWorkspaceId, setLinearWorkspaceId] = useState("");
   const [selectedLinear, setSelectedLinear] = useState<
     ReadonlyMap<string, LinearIssueSummary>
@@ -134,6 +169,8 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
   useEffect(() => {
     if (!open || tab !== "linear") return;
     let cancelled = false;
+    setLinearIssues(null);
+    setLinearError(null);
     const timer = window.setTimeout(
       () => {
         void (async () => {
@@ -153,9 +190,19 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                   : { workspaceIds: [linearWorkspaceId] }),
               }),
             );
-            if (!cancelled) setLinearIssues(result.issues);
-          } catch {
-            if (!cancelled) setLinearIssues([]);
+            if (!cancelled) {
+              setLinearIssues(result.issues);
+              setLinearError(null);
+            }
+          } catch (cause) {
+            if (!cancelled) {
+              setLinearIssues([]);
+              setLinearError(
+                cause instanceof Error
+                  ? cause.message
+                  : "Could not search Linear issues.",
+              );
+            }
           }
         })();
       },
@@ -469,6 +516,13 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                     Open integrations
                   </Button>
                 </div>
+              ) : tab === "linear" && linearError !== null ? (
+                <div
+                  role="alert"
+                  className="px-3 py-6 text-center text-sm text-destructive"
+                >
+                  {linearError}
+                </div>
               ) : tab === "linear" ? (
                 (linearIssues ?? []).length === 0 ? (
                   <div className="px-3 py-6 text-center text-sm text-muted-foreground">
@@ -507,12 +561,49 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                         >
                           {checked ? "✓" : ""}
                         </span>
+                        <span
+                          role="img"
+                          aria-label={`Status: ${issue.state || "Unknown"}`}
+                          title={issue.state || "Unknown status"}
+                          className={cn(
+                            "grid size-4 shrink-0 place-items-center",
+                            issue.stateColor === null && "text-muted-foreground",
+                          )}
+                          style={
+                            issue.stateColor === null
+                              ? undefined
+                              : { color: issue.stateColor }
+                          }
+                        >
+                          <HugeiconsIcon
+                            aria-hidden="true"
+                            icon={linearStateIcon(issue.stateType)}
+                            className="size-3.5"
+                          />
+                        </span>
                         <span className="shrink-0 font-mono text-xs text-muted-foreground">
                           {issue.identifier}
                         </span>
                         <span className="min-w-0 flex-1 truncate text-sm">
                           {issue.title}
                         </span>
+                        {issue.assignee !== null && (
+                          <Avatar
+                            aria-label={`Assigned to ${issue.assignee}`}
+                            title={`Assigned to ${issue.assignee}`}
+                            className="size-5 border border-border/60"
+                          >
+                            {issue.assigneeAvatarUrl !== null && (
+                              <AvatarImage
+                                src={issue.assigneeAvatarUrl}
+                                alt=""
+                              />
+                            )}
+                            <AvatarFallback className="text-[8px]">
+                              {assigneeInitials(issue.assignee)}
+                            </AvatarFallback>
+                          </Avatar>
+                        )}
                         <span className="max-w-24 shrink-0 truncate text-xs text-muted-foreground">
                           {issue.workspaceName}
                         </span>

--- a/apps/renderer/src/components/composer/create-from-menu.tsx
+++ b/apps/renderer/src/components/composer/create-from-menu.tsx
@@ -18,9 +18,11 @@ import type {
 import { Effect } from "effect";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { Button } from "~/components/ui/button.tsx";
 import { PopoverPrimitive } from "~/components/ui/popover";
 import { getRpcClient } from "~/lib/rpc-client.ts";
 import { cn } from "~/lib/utils";
+import { useUiStore } from "~/store/ui.ts";
 
 /**
  * What the "Create from…" picker hands back to the Chat Lander. PRs + branches
@@ -84,6 +86,8 @@ export interface CreateFromMenuProps {
  * chat against that PR/branch (checkout) or issue (attach + prefill).
  */
 export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
+  const setView = useUiStore((state) => state.setView);
+  const setSettingsSection = useUiStore((state) => state.setSettingsSection);
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<Tab>("prs");
   const [query, setQuery] = useState("");
@@ -114,6 +118,12 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
   >(new Map());
 
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const openIntegrations = () => {
+    setOpen(false);
+    setSettingsSection({ kind: "integrations" });
+    setView("settings");
+  };
 
   useEffect(() => {
     setPrs(null);
@@ -446,8 +456,17 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
                   Loading…
                 </div>
               ) : tab === "linear" && (linearConnections?.length ?? 0) === 0 ? (
-                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
-                  Connect a Linear workspace in Settings → Integrations.
+                <div className="flex min-h-24 flex-col items-center justify-center gap-3 px-3 py-5 text-center">
+                  <p className="text-sm text-muted-foreground">
+                    Connect a workspace to start from Linear issues.
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={openIntegrations}
+                  >
+                    Open integrations
+                  </Button>
                 </div>
               ) : tab === "linear" ? (
                 (linearIssues ?? []).length === 0 ? (

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -905,7 +905,11 @@ function PreviewViewBody({ openFile }: { openFile: EditableFile }) {
   if (state.kind === "markdown") {
     return (
       <div className="min-h-0 flex-1 overflow-auto px-8 py-6">
-        <MarkdownBody className="mx-auto max-w-3xl" children={state.content} />
+        <MarkdownBody
+          baseHref={state.baseHref}
+          className="mx-auto max-w-3xl"
+          children={state.content}
+        />
       </div>
     );
   }

--- a/apps/renderer/src/components/markdown-body.tsx
+++ b/apps/renderer/src/components/markdown-body.tsx
@@ -15,9 +15,10 @@ import {
   type ReactNode,
   type PointerEvent,
 } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { resolveMarkdownPreviewUrl } from "~/lib/file-preview";
 import { cn } from "~/lib/utils";
 import { useUiStore } from "~/store/ui";
 import { useWorkspaceStore } from "~/store/workspace";
@@ -25,6 +26,7 @@ import { useWorktreesStore } from "~/store/worktrees";
 
 import { CodeBlock } from "./code-block.tsx";
 import { resolveFileOpenTarget, useFileChipContext } from "./file-chip.tsx";
+import { Button } from "./ui/button.tsx";
 import {
   Dialog,
   DialogDescription,
@@ -32,7 +34,6 @@ import {
   DialogPopup,
   DialogTitle,
 } from "./ui/dialog.tsx";
-import { Button } from "./ui/button.tsx";
 
 const languageFromClassName = (className: unknown): string | undefined => {
   if (typeof className !== "string") return undefined;
@@ -411,9 +412,11 @@ function MermaidDiagram({ source }: { source: string }) {
 export function MarkdownBody({
   children,
   className,
+  baseHref,
 }: {
   children: string;
   className?: string;
+  baseHref?: string;
 }) {
   const { folderId, worktreeId } = useFileChipContext();
   const openFileInTab = useUiStore((s) => s.openFileInTab);
@@ -431,6 +434,14 @@ export function MarkdownBody({
     <div className={cn("fz-prose", className)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        urlTransform={(value, property, node) =>
+          resolveMarkdownPreviewUrl(
+            value,
+            property,
+            node.tagName,
+            baseHref,
+          ) ?? defaultUrlTransform(value)
+        }
         components={{
           a: ({ href, children, ...rest }) => (
             <a

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -1,5 +1,5 @@
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { IconSvgElement } from "@hugeicons/react";
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
   Alert01Icon,
   ArrowLeft01Icon,
@@ -18,54 +18,54 @@ import {
   Tick01Icon,
   VolumeHighIcon,
 } from "@hugeicons-pro/core-bulk-rounded";
-import { Plus, RefreshCw as RefreshIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-
-import { Effect } from "effect";
-
-import { getRpcClient } from "../lib/rpc-client.ts";
-
 import {
   type AppearanceMode,
   type BranchNamingStyle,
-  MODELS_BY_PROVIDER,
   type CompletionSoundPreset,
   type Folder,
   type FolderId,
+  MODELS_BY_PROVIDER,
   type ProviderId,
   type RuntimeMode,
   visibleModelsForProvider,
 } from "@zuse/contracts";
+import { Effect } from "effect";
+import { Plus, RefreshCw as RefreshIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { isInitialProviderAvailabilityLoading } from "~/lib/provider-status";
 
 import {
   formatRelativeTime,
   useRelativeTimeTick,
 } from "~/lib/use-relative-time.ts";
-import { isInitialProviderAvailabilityLoading } from "~/lib/provider-status";
 import { cn } from "~/lib/utils";
-import { collectDiagnosticsClientContext } from "../lib/diagnostics-client-context.ts";
-import { recordUiAction } from "../lib/diagnostics-recorder.ts";
+import { useAuth } from "../hooks/use-auth.ts";
 import {
   COMPLETION_SOUND_PRESETS,
   playCompletionSound,
   prepareCompletionSound,
 } from "../lib/completion-sounds.ts";
-import { useAuth } from "../hooks/use-auth.ts";
+import { collectDiagnosticsClientContext } from "../lib/diagnostics-client-context.ts";
+import { recordUiAction } from "../lib/diagnostics-recorder.ts";
+import { getRpcClient } from "../lib/rpc-client.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSettingsStore } from "../store/settings.ts";
-import { useUiStore, type SettingsSection } from "../store/ui.ts";
+import { type SettingsSection, useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { BlurredEmail } from "./blurred-email.tsx";
 import { ProviderCard } from "./provider-card.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
-import { MODES_ORDER, MODE_META } from "./runtime-mode-meta.ts";
+import { MODE_META, MODES_ORDER } from "./runtime-mode-meta.ts";
 import { DeveloperPane } from "./settings/developer-pane.tsx";
 import { DevicesPane } from "./settings/devices-pane.tsx";
 import { KeybindingsPane } from "./settings/keybindings-editor.tsx";
+import { LinearIntegrationsPane } from "./settings/linear-integrations-pane.tsx";
 import { PokedexPane } from "./settings/pokedex-pane.tsx";
 import { RepositorySettings } from "./settings-repository.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar.tsx";
 import { Button } from "./ui/button.tsx";
+import { Card } from "./ui/card.tsx";
+import { Frame, FrameFooter, FrameHeader } from "./ui/frame.tsx";
 import {
   Select,
   SelectItem,
@@ -74,8 +74,6 @@ import {
   SelectValue,
 } from "./ui/select.tsx";
 import { Switch } from "./ui/switch";
-import { Frame, FrameFooter, FrameHeader } from "./ui/frame.tsx";
-import { Card } from "./ui/card.tsx";
 
 const PROVIDER_LABEL: Record<ProviderId, string> = {
   claude: "Claude Code",
@@ -111,6 +109,12 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
     label: "Workspace",
     Icon: GitBranchIcon,
     section: { kind: "workspace" },
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    Icon: GlobeIcon,
+    section: { kind: "integrations" },
   },
   {
     id: "devices",
@@ -325,6 +329,13 @@ function SectionTitle({
           "Verify what's installed, signed in, and which subscription each provider runs on.",
       };
     }
+    if (section.kind === "integrations") {
+      return {
+        title: "Integrations",
+        subtitle:
+          "Connect issue workspaces and bring tickets into new sessions.",
+      };
+    }
     if (section.kind === "devices") {
       return {
         title: "Devices",
@@ -404,6 +415,7 @@ function SectionTitle({
 function Pane({ section }: { section: SettingsSection }) {
   if (section.kind === "general") return <GeneralPane />;
   if (section.kind === "providers") return <ProvidersPane />;
+  if (section.kind === "integrations") return <LinearIntegrationsPane />;
   if (section.kind === "workspace") return <WorkspacePane />;
   if (section.kind === "devices") return <DevicesPane />;
   if (section.kind === "pokedex") return <PokedexPane />;
@@ -2022,5 +2034,5 @@ export function ensureValidDefaultsForRuntime(
   };
 }
 
-export { PROVIDER_LABEL };
 export type { FolderId };
+export { PROVIDER_LABEL };

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import {
   Alert01Icon,
   ArrowLeft01Icon,
+  ConnectIcon,
   Delete02Icon,
   DocumentAttachmentIcon,
   Folder01Icon,
@@ -113,7 +114,7 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
   {
     id: "integrations",
     label: "Integrations",
-    Icon: GlobeIcon,
+    Icon: ConnectIcon,
     section: { kind: "integrations" },
   },
   {

--- a/apps/renderer/src/components/settings/linear-integrations-pane.tsx
+++ b/apps/renderer/src/components/settings/linear-integrations-pane.tsx
@@ -1,0 +1,136 @@
+import type { LinearConnection } from "@zuse/contracts";
+import { Effect } from "effect";
+import { useCallback, useEffect, useState } from "react";
+
+import { getRpcClient } from "~/lib/rpc-client.ts";
+import { Button } from "../ui/button.tsx";
+import { Card } from "../ui/card.tsx";
+import { Spinner } from "../ui/spinner.tsx";
+
+export function LinearIntegrationsPane() {
+	const [connections, setConnections] =
+		useState<ReadonlyArray<LinearConnection> | null>(null);
+	const [busy, setBusy] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			const client = await getRpcClient();
+			setConnections(
+				await Effect.runPromise(client["linear.listConnections"]({})),
+			);
+			setError(null);
+		} catch (cause) {
+			setConnections([]);
+			setError(cause instanceof Error ? cause.message : String(cause));
+		}
+	}, []);
+
+	useEffect(() => {
+		void load();
+	}, [load]);
+
+	const connect = async () => {
+		if (busy !== null) return;
+		setBusy("connect");
+		setError(null);
+		try {
+			const client = await getRpcClient();
+			await Effect.runPromise(client["linear.connect"]({}));
+			await load();
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	const disconnect = async (connection: LinearConnection) => {
+		if (
+			!window.confirm(
+				`Disconnect ${connection.workspaceName}? Existing local ticket context will remain.`,
+			)
+		)
+			return;
+		setBusy(connection.workspaceId);
+		setError(null);
+		try {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["linear.disconnect"]({ workspaceId: connection.workspaceId }),
+			);
+			await load();
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Card className="flex items-center justify-between gap-4 p-4">
+				<div className="min-w-0">
+					<h2 className="text-sm font-medium">Linear</h2>
+					<p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+						Select tickets when creating a chat. Ticket details, comments, and
+						images are copied into the session workspace.
+					</p>
+				</div>
+				<Button
+					type="button"
+					onClick={() => void connect()}
+					disabled={busy !== null}
+				>
+					{busy === "connect" && <Spinner className="mr-2 size-3.5" />}
+					Add workspace
+				</Button>
+			</Card>
+
+			{error !== null && (
+				<p role="alert" className="text-xs text-destructive">
+					{error}
+				</p>
+			)}
+
+			{connections === null ? (
+				<div className="grid min-h-24 place-items-center">
+					<Spinner className="size-4 text-muted-foreground" />
+				</div>
+			) : connections.length === 0 ? (
+				<p className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+					No Linear workspaces connected yet.
+				</p>
+			) : (
+				<div className="flex flex-col gap-2">
+					{connections.map((connection) => (
+						<Card
+							key={connection.workspaceId}
+							className="flex items-center justify-between gap-4 p-4"
+						>
+							<div className="min-w-0">
+								<p className="truncate text-sm font-medium">
+									{connection.workspaceName}
+								</p>
+								<p className="truncate text-xs text-muted-foreground">
+									{connection.viewerName} · {connection.viewerEmail}
+								</p>
+							</div>
+							<Button
+								type="button"
+								variant="outline"
+								disabled={busy !== null}
+								onClick={() => void disconnect(connection)}
+							>
+								{busy === connection.workspaceId && (
+									<Spinner className="mr-2 size-3.5" />
+								)}
+								Disconnect
+							</Button>
+						</Card>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/renderer/src/components/settings/linear-integrations-pane.tsx
+++ b/apps/renderer/src/components/settings/linear-integrations-pane.tsx
@@ -5,6 +5,13 @@ import { useCallback, useEffect, useState } from "react";
 import { getRpcClient } from "~/lib/rpc-client.ts";
 import { Button } from "../ui/button.tsx";
 import { Card } from "../ui/card.tsx";
+import {
+	Frame,
+	FrameDescription,
+	FrameFooter,
+	FrameHeader,
+	FrameTitle,
+} from "../ui/frame.tsx";
 import { Spinner } from "../ui/spinner.tsx";
 
 export function LinearIntegrationsPane() {
@@ -66,71 +73,88 @@ export function LinearIntegrationsPane() {
 			setBusy(null);
 		}
 	};
+	const hasConnections = connections !== null && connections.length > 0;
 
 	return (
-		<div className="flex flex-col gap-4">
-			<Card className="flex items-center justify-between gap-4 p-4">
-				<div className="min-w-0">
-					<h2 className="text-sm font-medium">Linear</h2>
-					<p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-						Select tickets when creating a chat. Ticket details, comments, and
-						images are copied into the session workspace.
+		<Frame>
+			<FrameHeader className="gap-1 px-4 py-3">
+				<FrameTitle>Linear</FrameTitle>
+				<FrameDescription>
+					Select tickets when creating a chat. Ticket details, comments, and
+					images are copied into the session workspace.
+				</FrameDescription>
+			</FrameHeader>
+
+			<Card className="mx-1 overflow-hidden rounded-md">
+				{error !== null && (
+					<p
+						role="alert"
+						className="border-b border-border/60 px-4 py-3 text-xs text-destructive"
+					>
+						{error}
 					</p>
-				</div>
-				<Button
-					type="button"
-					onClick={() => void connect()}
-					disabled={busy !== null}
-				>
-					{busy === "connect" && <Spinner className="mr-2 size-3.5" />}
-					Add workspace
-				</Button>
+				)}
+
+				{connections === null ? (
+					<div className="grid min-h-32 place-items-center">
+						<Spinner className="size-4 text-muted-foreground" />
+					</div>
+				) : connections.length === 0 ? (
+					<div className="flex min-h-36 flex-col items-center justify-center gap-3 p-6 text-center">
+						<p className="text-sm text-muted-foreground">
+							No Linear workspaces connected yet.
+						</p>
+						<Button
+							type="button"
+							onClick={() => void connect()}
+							disabled={busy !== null}
+							loading={busy === "connect"}
+						>
+							Connect workspace
+						</Button>
+					</div>
+				) : (
+					<div className="divide-y divide-border/60">
+						{connections.map((connection) => (
+							<div
+								key={connection.workspaceId}
+								className="flex items-center justify-between gap-4 p-4"
+							>
+								<div className="min-w-0">
+									<p className="truncate text-sm font-medium">
+										{connection.workspaceName}
+									</p>
+									<p className="truncate text-xs text-muted-foreground">
+										{connection.viewerName} · {connection.viewerEmail}
+									</p>
+								</div>
+								<Button
+									type="button"
+									variant="outline"
+									disabled={busy !== null}
+									loading={busy === connection.workspaceId}
+									onClick={() => void disconnect(connection)}
+								>
+									Disconnect
+								</Button>
+							</div>
+						))}
+					</div>
+				)}
 			</Card>
 
-			{error !== null && (
-				<p role="alert" className="text-xs text-destructive">
-					{error}
-				</p>
+			{hasConnections && (
+				<FrameFooter className="flex justify-end px-4 py-3">
+					<Button
+						type="button"
+						onClick={() => void connect()}
+						disabled={busy !== null}
+						loading={busy === "connect"}
+					>
+						Add workspace
+					</Button>
+				</FrameFooter>
 			)}
-
-			{connections === null ? (
-				<div className="grid min-h-24 place-items-center">
-					<Spinner className="size-4 text-muted-foreground" />
-				</div>
-			) : connections.length === 0 ? (
-				<p className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
-					No Linear workspaces connected yet.
-				</p>
-			) : (
-				<div className="flex flex-col gap-2">
-					{connections.map((connection) => (
-						<Card
-							key={connection.workspaceId}
-							className="flex items-center justify-between gap-4 p-4"
-						>
-							<div className="min-w-0">
-								<p className="truncate text-sm font-medium">
-									{connection.workspaceName}
-								</p>
-								<p className="truncate text-xs text-muted-foreground">
-									{connection.viewerName} · {connection.viewerEmail}
-								</p>
-							</div>
-							<Button
-								type="button"
-								variant="outline"
-								disabled={busy !== null}
-								onClick={() => void disconnect(connection)}
-							>
-								{busy === connection.workspaceId && (
-									<Spinner className="mr-2 size-3.5" />
-								)}
-								Disconnect
-							</Button>
-						</Card>
-					))}
-				</div>
-			)}
-		</div>
+		</Frame>
 	);
 }

--- a/apps/renderer/src/composer/linear-context-input.ts
+++ b/apps/renderer/src/composer/linear-context-input.ts
@@ -1,0 +1,30 @@
+import {
+	type AttachmentRef,
+	ComposerInput,
+	type LinearContextFile,
+} from "@zuse/contracts";
+
+import { appendContextFileRef } from "./draft-attachments.ts";
+
+const LINEAR_AGENT_PREAMBLE =
+	"For the selected Linear tickets: move active work into an appropriate started state, post useful progress and completion comments, and only mark work complete after relevant verification. Ask for mutation permission when required. Downloaded ticket images are attached to this message as vision inputs and are also available at the relative paths referenced by the ticket Markdown.";
+
+export const applyPreparedLinearContext = (
+	input: ComposerInput,
+	prepared: {
+		readonly files: ReadonlyArray<LinearContextFile>;
+		readonly attachments: ReadonlyArray<AttachmentRef>;
+	},
+): ComposerInput => {
+	const withContext = ComposerInput.make({
+		...input,
+		text: [LINEAR_AGENT_PREAMBLE, input.text]
+			.filter((part) => part.trim().length > 0)
+			.join("\n\n"),
+		attachments: [...input.attachments, ...prepared.attachments],
+	});
+	return prepared.files.reduce(
+		(current, file) => appendContextFileRef(current, file),
+		withContext,
+	);
+};

--- a/apps/renderer/src/lib/file-preview.ts
+++ b/apps/renderer/src/lib/file-preview.ts
@@ -1,0 +1,57 @@
+const PREVIEWABLE_EXTENSIONS = new Set([
+	".htm",
+	".html",
+	".markdown",
+	".md",
+	".mdown",
+	".mkd",
+]);
+
+const MARKDOWN_EXTENSIONS = new Set([".markdown", ".md", ".mdown", ".mkd"]);
+
+const extensionOf = (name: string): string => {
+	const lower = name.toLowerCase();
+	const dot = lower.lastIndexOf(".");
+	return dot === -1 ? "" : lower.slice(dot);
+};
+
+export const isPreviewableFileName = (name: string): boolean => {
+	return PREVIEWABLE_EXTENSIONS.has(extensionOf(name));
+};
+
+export const defaultFileViewForName = (name: string): "edit" | "preview" =>
+	MARKDOWN_EXTENSIONS.has(extensionOf(name)) ? "preview" : "edit";
+
+/**
+ * Resolve a relative image in a local Markdown preview against the directory
+ * containing the Markdown file. Keep all other URLs on react-markdown's
+ * normal sanitising path, and do not let Markdown traverse above its own
+ * directory when resolving an image.
+ */
+export const resolveMarkdownPreviewUrl = (
+	value: string,
+	property: string,
+	tagName: string,
+	baseHref: string | undefined,
+): string | null => {
+	if (baseHref === undefined || property !== "src" || tagName !== "img") {
+		return null;
+	}
+	try {
+		const base = new URL(baseHref);
+		if (base.protocol !== "file:") return null;
+		const resolved = new URL(value, base);
+		if (resolved.protocol !== "file:") return null;
+		if (!resolved.pathname.startsWith(base.pathname)) return null;
+		if (
+			!/\/\.context\/linear\/[^/]+\/assets\/[^/]+\/[^/]+$/u.test(
+				resolved.pathname,
+			)
+		) {
+			return null;
+		}
+		return `zuse://linear-context${resolved.pathname}`;
+	} catch {
+		return null;
+	}
+};

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -6,7 +6,14 @@ import type {
 } from "@zuse/contracts";
 import { create } from "zustand";
 
+import {
+  defaultFileViewForName,
+  isPreviewableFileName,
+} from "~/lib/file-preview";
+
 import { useChatsStore } from "./chats.ts";
+
+export { isPreviewableFileName } from "~/lib/file-preview";
 
 /**
  * Top-level renderer view. The settings page replaces the chat surface in the
@@ -98,22 +105,6 @@ export type PanelInstance =
  * per entry point.
  */
 export type FileView = "edit" | "diff" | "preview";
-
-const PREVIEWABLE_EXTENSIONS = new Set([
-  ".htm",
-  ".html",
-  ".markdown",
-  ".md",
-  ".mdown",
-  ".mkd",
-]);
-
-export const isPreviewableFileName = (name: string): boolean => {
-  const lower = name.toLowerCase();
-  const dot = lower.lastIndexOf(".");
-  if (dot === -1) return false;
-  return PREVIEWABLE_EXTENSIONS.has(lower.slice(dot));
-};
 
 const coerceFileView = (
   file: { readonly kind: "text" | "external"; readonly name: string },
@@ -343,7 +334,10 @@ export const useUiStore = create<UiState>((set, get) => ({
           ? file
           : {
               ...file,
-              view: coerceFileView(file, file.view ?? "edit"),
+              view: coerceFileView(
+                file,
+                file.view ?? defaultFileViewForName(file.name),
+              ),
             },
       activeMainTab: "file",
       fileDirty: false,

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -22,6 +22,7 @@ export type View = "chat" | "settings";
 export type SettingsSection =
   | { readonly kind: "general" }
   | { readonly kind: "providers" }
+  | { readonly kind: "integrations" }
   | { readonly kind: "workspace" }
   | { readonly kind: "devices" }
   | { readonly kind: "pokedex" }

--- a/apps/renderer/test/unit/file-preview.test.ts
+++ b/apps/renderer/test/unit/file-preview.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	defaultFileViewForName,
+	resolveMarkdownPreviewUrl,
+} from "../../src/lib/file-preview.ts";
+
+describe("file preview", () => {
+	it("opens markdown files in preview by default", () => {
+		expect(defaultFileViewForName("LULU-27.md")).toBe("preview");
+		expect(defaultFileViewForName("notes.markdown")).toBe("preview");
+		expect(defaultFileViewForName("index.ts")).toBe("edit");
+		expect(defaultFileViewForName("index.html")).toBe("edit");
+	});
+
+	it("resolves relative markdown images from the markdown file directory", () => {
+		expect(
+			resolveMarkdownPreviewUrl(
+				"assets/LULU-27/image.png",
+				"src",
+				"img",
+				"file:///workspace/.context/linear/team/",
+			),
+		).toBe(
+			"zuse://linear-context/workspace/.context/linear/team/assets/LULU-27/image.png",
+		);
+	});
+
+	it("does not rewrite links, remote images, or paths outside the file directory", () => {
+		const baseHref = "file:///workspace/docs/";
+		expect(
+			resolveMarkdownPreviewUrl("guide.md", "href", "a", baseHref),
+		).toBeNull();
+		expect(
+			resolveMarkdownPreviewUrl(
+				"https://example.com/a.png",
+				"src",
+				"img",
+				baseHref,
+			),
+		).toBeNull();
+		expect(
+			resolveMarkdownPreviewUrl("image.png", "src", "img", baseHref),
+		).toBeNull();
+		expect(
+			resolveMarkdownPreviewUrl("../secret.png", "src", "img", baseHref),
+		).toBeNull();
+	});
+});

--- a/apps/renderer/test/unit/linear-context-input.test.ts
+++ b/apps/renderer/test/unit/linear-context-input.test.ts
@@ -1,0 +1,57 @@
+import { ComposerInput } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import { applyPreparedLinearContext } from "../../src/composer/linear-context-input.ts";
+
+describe("prepared Linear context", () => {
+	it("adds ticket markdown and downloaded images to the initial message", () => {
+		const input = ComposerInput.make({
+			text: "Finish the selected work",
+			attachments: [
+				{
+					id: "existing-image",
+					mimeType: "image/jpeg",
+					originalName: "existing.jpg",
+				},
+			],
+			fileRefs: [],
+			skillRefs: [],
+			annotations: [],
+		});
+		const result = applyPreparedLinearContext(input, {
+			files: [
+				{
+					issue: {
+						workspaceId: "workspace-1",
+						issueId: "issue-1",
+						identifier: "ABC-123",
+					},
+					relPath: ".context/linear/team/ABC-123.md",
+					absPath: "/workspace/.context/linear/team/ABC-123.md",
+				},
+			],
+			attachments: [
+				{
+					id: "session-image-1",
+					mimeType: "image/png",
+					originalName: "ABC-123-image.png",
+				},
+			],
+		});
+
+		expect(result.fileRefs).toHaveLength(1);
+		expect(result.attachments).toEqual([
+			{
+				id: "existing-image",
+				mimeType: "image/jpeg",
+				originalName: "existing.jpg",
+			},
+			{
+				id: "session-image-1",
+				mimeType: "image/png",
+				originalName: "ABC-123-image.png",
+			},
+		]);
+		expect(result.text).toContain("Downloaded ticket images are attached");
+	});
+});

--- a/apps/server/src/auth/services/auth-shell.ts
+++ b/apps/server/src/auth/services/auth-shell.ts
@@ -1,6 +1,5 @@
-import { Context, type Effect } from "effect";
-
 import type { AuthFlowError } from "@zuse/contracts";
+import { Context, type Effect } from "effect";
 
 /**
  * The host-shell seam for the OAuth deep-link flow — the auth analogue of
@@ -19,13 +18,17 @@ import type { AuthFlowError } from "@zuse/contracts";
  */
 export interface AuthShellShape {
   readonly redirectUri: string;
+  /** Optional native-integration callback route served by the same host. */
+  readonly linearRedirectUri?: string;
   readonly open: (url: string) => Effect.Effect<void, AuthFlowError>;
   readonly onCallbackUrl: (
     handler: (url: string) => void,
   ) => Effect.Effect<void>;
+  readonly onLinearCallbackUrl?: (
+    handler: (url: string) => void,
+  ) => Effect.Effect<void>;
 }
 
-export class AuthShell extends Context.Service<
-  AuthShell,
-  AuthShellShape
->()("memoize/AuthShell") {}
+export class AuthShell extends Context.Service<AuthShell, AuthShellShape>()(
+  "memoize/AuthShell",
+) {}

--- a/apps/server/src/conversation/core/conversation-orchestration.ts
+++ b/apps/server/src/conversation/core/conversation-orchestration.ts
@@ -1,4 +1,9 @@
 /** Builds the session-bound orchestration tool surface. */
+
+import {
+	buildLinearTools,
+	type LinearToolDeps,
+} from "@zuse/agents/drivers/linear-tools";
 import {
 	buildOrchestrationTools,
 	type OrchestrationSessionTools,
@@ -88,6 +93,7 @@ export interface ConversationOrchestrationDependencies {
 		projectId: FolderId,
 		includeArchived: boolean,
 	) => Effect.Effect<ReadonlyArray<Session>, unknown>;
+	readonly linearTools?: LinearToolDeps;
 }
 
 export const makeConversationOrchestration = (
@@ -425,5 +431,13 @@ export const makeConversationOrchestration = (
 		return {
 			deps: toolDependencies,
 			claudeTools: buildOrchestrationTools(toolDependencies),
+			...(dependencies.linearTools === undefined
+				? {}
+				: {
+						linearTools: {
+							deps: dependencies.linearTools,
+							claudeTools: buildLinearTools(dependencies.linearTools),
+						},
+					}),
 		};
 	});

--- a/apps/server/src/conversation/core/provider-session-runtime.ts
+++ b/apps/server/src/conversation/core/provider-session-runtime.ts
@@ -1,3 +1,4 @@
+import type { LinearToolDeps } from "@zuse/agents/drivers/linear-tools";
 import {
 	type AttachmentRef,
 	type ProviderId,
@@ -66,6 +67,7 @@ export interface ProviderSessionRuntimeOptions {
 		status: Session["status"],
 	) => Effect.Effect<void>;
 	readonly startSubscription: (sessionId: SessionId) => Effect.Effect<void>;
+	readonly linearTools?: LinearToolDeps;
 }
 
 export const makeProviderSessionRuntime = (
@@ -90,6 +92,7 @@ export const makeProviderSessionRuntime = (
 		attachProvider,
 		setStatus,
 		startSubscription,
+		linearTools,
 	} = options;
 	const openProviderSession = (
 		session: Session,
@@ -124,6 +127,7 @@ export const makeProviderSessionRuntime = (
 					listMessages,
 					listChats,
 					listSessions,
+					linearTools,
 				},
 				{
 					sessionId: session.id,

--- a/apps/server/src/conversation/core/session-operations.ts
+++ b/apps/server/src/conversation/core/session-operations.ts
@@ -109,6 +109,7 @@ export const makeSessionOperations = (options: SessionOperationsOptions) => {
 		attachProvider,
 		setStatus,
 		startSubscription,
+		linearTools,
 		broadcastChat,
 		beginTurn,
 		persistMessage,
@@ -182,6 +183,7 @@ export const makeSessionOperations = (options: SessionOperationsOptions) => {
 		attachProvider,
 		setStatus,
 		startSubscription,
+		linearTools,
 	});
 
 	const createSession: ConversationOperations["createSession"] = (

--- a/apps/server/src/conversation/layers/conversation-services.ts
+++ b/apps/server/src/conversation/layers/conversation-services.ts
@@ -1,3 +1,4 @@
+import type { LinearToolDeps } from "@zuse/agents/drivers/linear-tools";
 import {
 	type ChatId,
 	type FolderId,
@@ -13,9 +14,10 @@ import { SessionDomain } from "@zuse/domain/engine/session-domain";
 import { SqlSessionQueries } from "@zuse/domain/queries/sql-session-queries";
 import { GitService } from "@zuse/git/git-service";
 import { WorktreeService } from "@zuse/git/worktree-service";
-import { DateTime, Effect, Layer } from "effect";
+import { DateTime, Effect, Layer, Option } from "effect";
 import { SqlClient } from "effect/unstable/sql";
 import { ConfigStoreService } from "../../config-store/services/config-store-service.ts";
+import { LinearService } from "../../linear/services/linear-service.ts";
 import { NdjsonLogger } from "../../persistence/ndjson-logger.ts";
 import { makeReactorEffectJournal } from "../../provider/reactor-effect-journal.ts";
 import { ProviderService } from "../../provider/services/provider-service.ts";
@@ -132,6 +134,40 @@ const ConversationRuntimeLive = Layer.effect(
 		// browser-bridge tool binding in ProviderService.
 		const runtime = yield* Effect.context<never>();
 		const relayActivity = yield* RelayActivityPublisher;
+		const linear = yield* Effect.serviceOption(LinearService);
+		const settleLinear = <A>(
+			effect: Effect.Effect<A, { readonly reason: string }>,
+		) =>
+			Effect.runPromiseWith(runtime)(
+				effect.pipe(
+					Effect.map((data) => ({ ok: true as const, data })),
+					Effect.catch((error) =>
+						Effect.succeed({ ok: false as const, error: error.reason }),
+					),
+				),
+			);
+		const linearTools: LinearToolDeps | undefined = Option.match(linear, {
+			onNone: () => undefined,
+			onSome: (service) => ({
+				searchIssues: (input) =>
+					settleLinear(
+						service.listIssues({
+							query: input.query,
+							workspaceIds:
+								input.workspaceId === undefined
+									? undefined
+									: [input.workspaceId],
+						}),
+					),
+				getIssue: (input) =>
+					settleLinear(service.getIssueForTool(input.workspaceId, input.issue)),
+				addComment: (input) =>
+					settleLinear(
+						service.addComment(input.workspaceId, input.issue, input.body),
+					),
+				updateIssue: (input) => settleLinear(service.updateIssue(input)),
+			}),
+		});
 
 		const chatColumns = yield* sql<{ readonly name: string }>`
       PRAGMA table_info(chats)
@@ -231,6 +267,7 @@ const ConversationRuntimeLive = Layer.effect(
 			closeProvider,
 			interruptProviderFiber,
 			teardownSubscription,
+			linearTools,
 		});
 		const {
 			listSessions,

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -8,6 +8,7 @@ import { ExternalThreadHandlersLayer } from "./external-thread/handlers.ts";
 import { FsHandlersLayer } from "./fs/handlers.ts";
 import { GitHandlersLayer } from "./git/handlers.ts";
 import { LanAuthHandlersLayer } from "./lan-auth/handlers.ts";
+import { LinearHandlersLayer } from "./linear/handlers.ts";
 import { PingHandlersLayer } from "./ping/handlers.ts";
 import { PokemonHandlersLayer } from "./pokemon/handlers.ts";
 import { ProviderHandlersLayer } from "./provider/handlers.ts";
@@ -30,6 +31,7 @@ export const HandlersLayer = Layer.mergeAll(
   LanAuthHandlersLayer,
   RelayHandlersLayer,
   AuthHandlersLayer,
+  LinearHandlersLayer,
   WorkspaceHandlersLayer,
   PtyHandlersLayer,
   GitHandlersLayer,

--- a/apps/server/src/linear/handlers.ts
+++ b/apps/server/src/linear/handlers.ts
@@ -1,0 +1,33 @@
+import { MemoizeRpcs } from "@zuse/contracts";
+import { Effect, Layer } from "effect";
+
+import { LinearService } from "./services/linear-service.ts";
+
+const ListConnections = MemoizeRpcs.toLayerHandler(
+	"linear.listConnections",
+	() => Effect.flatMap(LinearService, (service) => service.listConnections()),
+);
+const Connect = MemoizeRpcs.toLayerHandler("linear.connect", () =>
+	Effect.flatMap(LinearService, (service) => service.connect()),
+);
+const Disconnect = MemoizeRpcs.toLayerHandler(
+	"linear.disconnect",
+	({ workspaceId }) =>
+		Effect.flatMap(LinearService, (service) => service.disconnect(workspaceId)),
+);
+const ListIssues = MemoizeRpcs.toLayerHandler("linear.listIssues", (input) =>
+	Effect.flatMap(LinearService, (service) => service.listIssues(input)),
+);
+const PrepareContext = MemoizeRpcs.toLayerHandler(
+	"linear.prepareContext",
+	(input) =>
+		Effect.flatMap(LinearService, (service) => service.prepareContext(input)),
+);
+
+export const LinearHandlersLayer = Layer.mergeAll(
+	ListConnections,
+	Connect,
+	Disconnect,
+	ListIssues,
+	PrepareContext,
+);

--- a/apps/server/src/linear/layers/linear-service.ts
+++ b/apps/server/src/linear/layers/linear-service.ts
@@ -21,6 +21,7 @@ import {
 	type LinearFetch,
 	type LinearIssueDocument,
 	linearGraphql,
+	makeLinearIssueListRequest,
 	renderLinearIssueMarkdown,
 	rewriteMarkdownImages,
 } from "../linear-api.ts";
@@ -72,8 +73,15 @@ interface IssueSummaryPayload {
 	readonly title: string;
 	readonly priority?: number | null;
 	readonly updatedAt: string;
-	readonly state?: { readonly name?: string | null } | null;
-	readonly assignee?: { readonly name?: string | null } | null;
+	readonly state?: {
+		readonly name?: string | null;
+		readonly type?: string | null;
+		readonly color?: string | null;
+	} | null;
+	readonly assignee?: {
+		readonly name?: string | null;
+		readonly avatarUrl?: string | null;
+	} | null;
 	readonly labels?: {
 		readonly nodes?: ReadonlyArray<{ readonly name: string }>;
 	};
@@ -203,13 +211,6 @@ const exchangeToken = async (
 
 const VIEWER_QUERY = `query ZuseLinearViewer {
   viewer { id name email organization { id name urlKey } }
-}`;
-
-const ISSUES_QUERY = `query ZuseLinearIssues($first: Int!, $after: String, $filter: IssueFilter) {
-  issues(first: $first, after: $after, filter: $filter, orderBy: updatedAt) {
-    nodes { id identifier title priority updatedAt url state { name type } assignee { name } labels { nodes { name } } }
-    pageInfo { hasNextPage endCursor }
-  }
 }`;
 
 const ISSUE_QUERY = `query ZuseLinearIssue($id: String!) {
@@ -574,36 +575,37 @@ export const LinearServiceLive = Layer.effect(
 				selected.map((connection) =>
 					Effect.gen(function* () {
 						const bundle = yield* freshBundle(connection.workspaceId);
-						const query = input.query?.trim() ?? "";
-						const filter =
-							query.length === 0
-								? {
-										assignee: { id: { eq: bundle.viewerId } },
-										state: { type: { nin: ["completed", "canceled"] } },
-									}
-								: {
-										or: [
-											{ title: { containsIgnoreCase: query } },
-											{ identifier: { containsIgnoreCase: query } },
-										],
-									};
-						const data = yield* graphql<{
-							issues: {
-								nodes: ReadonlyArray<IssueSummaryPayload>;
-								pageInfo: { hasNextPage: boolean; endCursor: string | null };
-							};
-						}>(connection.workspaceId, ISSUES_QUERY, {
-							first: 50,
+						const request = makeLinearIssueListRequest({
+							query: input.query ?? "",
+							viewerId: bundle.viewerId,
 							after: cursorByWorkspace[connection.workspaceId] ?? null,
-							filter,
 						});
+						const data = yield* graphql<
+							Partial<
+								Record<
+									"issues" | "issueSearch",
+									{
+										nodes: ReadonlyArray<IssueSummaryPayload>;
+										pageInfo: {
+											hasNextPage: boolean;
+											endCursor: string | null;
+										};
+									}
+								>
+							>
+						>(connection.workspaceId, request.document, request.variables);
+						const issueConnection = data[request.rootField];
+						if (issueConnection === undefined)
+							return yield* Effect.fail(
+								fail("Linear returned no issue connection."),
+							);
 						return {
 							workspaceId: connection.workspaceId,
 							error: null as string | null,
-							endCursor: data.issues.pageInfo.hasNextPage
-								? data.issues.pageInfo.endCursor
+							endCursor: issueConnection.pageInfo.hasNextPage
+								? issueConnection.pageInfo.endCursor
 								: null,
-							issues: data.issues.nodes.map((issue) =>
+							issues: issueConnection.nodes.map((issue) =>
 								LinearIssueSummary.make({
 									workspaceId: connection.workspaceId,
 									workspaceName: connection.workspaceName,
@@ -611,8 +613,11 @@ export const LinearServiceLive = Layer.effect(
 									identifier: issue.identifier,
 									title: issue.title,
 									state: issue.state?.name ?? "",
+									stateType: issue.state?.type ?? "",
+									stateColor: issue.state?.color ?? null,
 									priority: issue.priority ?? 0,
 									assignee: issue.assignee?.name ?? null,
+									assigneeAvatarUrl: issue.assignee?.avatarUrl ?? null,
 									labels: (issue.labels?.nodes ?? []).map(
 										(label) => label.name,
 									),

--- a/apps/server/src/linear/layers/linear-service.ts
+++ b/apps/server/src/linear/layers/linear-service.ts
@@ -1,0 +1,1039 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+import {
+	LinearConnection,
+	LinearContextFile,
+	LinearContextWarning,
+	LinearIntegrationError,
+	type LinearIssueRef,
+	LinearIssueSummary,
+	type SessionId,
+} from "@zuse/contracts";
+import { Effect, FileSystem, Layer, Path, Schema, Semaphore } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+import { AuthShell } from "../../auth/services/auth-shell.ts";
+import { resolveSessionCwd } from "../../context/context-files.ts";
+import { CredentialsService } from "../../provider/services/credentials-service.ts";
+import {
+	LinearApiError,
+	type LinearFetch,
+	type LinearIssueDocument,
+	linearGraphql,
+	renderLinearIssueMarkdown,
+	rewriteMarkdownImages,
+} from "../linear-api.ts";
+import type { LinearToolIssueUpdate } from "../services/linear-service.ts";
+import { LinearService } from "../services/linear-service.ts";
+
+const CLIENT_ID = (process.env.LINEAR_CLIENT_ID ?? "").trim();
+const INTEGRATION = "linear";
+const REFRESH_SKEW_MS = 60_000;
+const MAX_IMAGE_BYTES = 100 * 1024 * 1024;
+
+const TokenBundleSchema = Schema.Struct({
+	accessToken: Schema.String,
+	refreshToken: Schema.String,
+	expiresAt: Schema.Number,
+	workspaceId: Schema.String,
+	workspaceName: Schema.String,
+	workspaceKey: Schema.String,
+	viewerId: Schema.String,
+	viewerName: Schema.String,
+	viewerEmail: Schema.String,
+	connectedAt: Schema.String,
+});
+type TokenBundle = typeof TokenBundleSchema.Type;
+
+interface NamedNode {
+	readonly id: string;
+	readonly name: string;
+	readonly email?: string;
+}
+
+interface CommentNode {
+	readonly body?: string | null;
+	readonly createdAt?: string | null;
+	readonly user?: { readonly name?: string | null } | null;
+}
+
+interface CommentConnection {
+	readonly nodes?: ReadonlyArray<CommentNode>;
+	readonly pageInfo?: {
+		readonly hasNextPage: boolean;
+		readonly endCursor: string | null;
+	};
+}
+
+interface IssueSummaryPayload {
+	readonly id: string;
+	readonly identifier: string;
+	readonly title: string;
+	readonly priority?: number | null;
+	readonly updatedAt: string;
+	readonly state?: { readonly name?: string | null } | null;
+	readonly assignee?: { readonly name?: string | null } | null;
+	readonly labels?: {
+		readonly nodes?: ReadonlyArray<{ readonly name: string }>;
+	};
+}
+
+interface IssueDocumentPayload {
+	readonly identifier: string;
+	readonly title: string;
+	readonly url: string;
+	readonly description?: string | null;
+	readonly priorityLabel?: string | null;
+	readonly state?: { readonly name?: string | null } | null;
+	readonly assignee?: { readonly name?: string | null } | null;
+	readonly labels?: {
+		readonly nodes?: ReadonlyArray<{ readonly name: string }>;
+	};
+	readonly project?: { readonly name?: string | null } | null;
+	readonly cycle?: { readonly name?: string | null } | null;
+	readonly relations?: {
+		readonly nodes?: ReadonlyArray<{
+			readonly type?: string | null;
+			readonly relatedIssue?: {
+				readonly identifier?: string | null;
+				readonly title?: string | null;
+			} | null;
+		}>;
+	};
+	readonly comments?: CommentConnection;
+}
+
+interface IssueLookupPayload {
+	readonly id: string;
+	readonly identifier: string;
+	readonly title: string;
+	readonly url: string;
+	readonly project?: NamedNode | null;
+	readonly team?: {
+		readonly states?: { readonly nodes?: ReadonlyArray<NamedNode> };
+		readonly labels?: { readonly nodes?: ReadonlyArray<NamedNode> };
+		readonly members?: { readonly nodes?: ReadonlyArray<NamedNode> };
+		readonly projects?: { readonly nodes?: ReadonlyArray<NamedNode> };
+	};
+}
+
+const TokenResponseSchema = Schema.Struct({
+	access_token: Schema.String,
+	refresh_token: Schema.String,
+	expires_in: Schema.Number,
+});
+
+const fail = (reason: string): LinearIntegrationError =>
+	new LinearIntegrationError({ reason });
+
+const errorMessage = (cause: unknown): string =>
+	cause instanceof Error ? cause.message : String(cause);
+
+const parseBundle = (raw: string | null): TokenBundle | null => {
+	if (raw === null) return null;
+	try {
+		return Schema.decodeUnknownSync(TokenBundleSchema)(JSON.parse(raw));
+	} catch {
+		return null;
+	}
+};
+
+const toConnection = (bundle: TokenBundle): LinearConnection =>
+	LinearConnection.make({
+		workspaceId: bundle.workspaceId,
+		workspaceName: bundle.workspaceName,
+		workspaceKey: bundle.workspaceKey,
+		viewerName: bundle.viewerName,
+		viewerEmail: bundle.viewerEmail,
+		connectedAt: new Date(bundle.connectedAt),
+	});
+
+const base64url = (bytes: Uint8Array): string =>
+	Buffer.from(bytes).toString("base64url");
+
+const makePkce = () => {
+	const verifier = base64url(randomBytes(32));
+	return {
+		verifier,
+		challenge: createHash("sha256").update(verifier).digest("base64url"),
+		state: base64url(randomBytes(16)),
+	};
+};
+
+const authorizeUrl = (
+	challenge: string,
+	state: string,
+	redirectUri: string,
+): string => {
+	const url = new URL("https://linear.app/oauth/authorize");
+	url.searchParams.set("client_id", CLIENT_ID);
+	url.searchParams.set("redirect_uri", redirectUri);
+	url.searchParams.set("response_type", "code");
+	url.searchParams.set("scope", "read,write");
+	url.searchParams.set("actor", "user");
+	url.searchParams.set("prompt", "consent");
+	url.searchParams.set("code_challenge", challenge);
+	url.searchParams.set("code_challenge_method", "S256");
+	url.searchParams.set("state", state);
+	return url.toString();
+};
+
+interface PendingConnect {
+	readonly state: string;
+	readonly verifier: string;
+	readonly resolve: (url: string) => void;
+	readonly reject: (cause: Error) => void;
+}
+
+const exchangeToken = async (
+	fetcher: LinearFetch,
+	params: Readonly<Record<string, string>>,
+): Promise<typeof TokenResponseSchema.Type> => {
+	const response = await fetcher("https://api.linear.app/oauth/token", {
+		method: "POST",
+		headers: { "content-type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams(params),
+	});
+	const value: unknown = await response.json().catch(() => null);
+	if (!response.ok)
+		throw new Error(`Linear OAuth failed (${response.status}).`);
+	return Schema.decodeUnknownSync(TokenResponseSchema)(value);
+};
+
+const VIEWER_QUERY = `query ZuseLinearViewer {
+  viewer { id name email organization { id name urlKey } }
+}`;
+
+const ISSUES_QUERY = `query ZuseLinearIssues($first: Int!, $after: String, $filter: IssueFilter) {
+  issues(first: $first, after: $after, filter: $filter, orderBy: updatedAt) {
+    nodes { id identifier title priority updatedAt url state { name type } assignee { name } labels { nodes { name } } }
+    pageInfo { hasNextPage endCursor }
+  }
+}`;
+
+const ISSUE_QUERY = `query ZuseLinearIssue($id: String!) {
+  issue(id: $id) {
+    id identifier title url description priorityLabel
+    state { name } assignee { name } labels { nodes { name } }
+    project { name } cycle { name }
+    relations { nodes { type relatedIssue { identifier title } } }
+    comments(first: 100) { nodes { body createdAt user { name } } pageInfo { hasNextPage endCursor } }
+  }
+}`;
+
+const COMMENTS_QUERY = `query ZuseLinearComments($id: String!, $after: String) {
+  issue(id: $id) {
+    comments(first: 100, after: $after) {
+      nodes { body createdAt user { name } }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`;
+
+const ISSUE_LOOKUP_QUERY = `query ZuseLinearIssueLookup($id: String!) {
+  issue(id: $id) {
+    id identifier title url description priority
+    state { id name } assignee { id name } labels { nodes { id name } }
+    project { id name } team { id states { nodes { id name } } labels { nodes { id name } } members { nodes { id name email } } projects(first: 250) { nodes { id name } } }
+  }
+}`;
+
+const COMMENT_MUTATION = `mutation ZuseLinearComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) { success comment { id body } }
+}`;
+
+const UPDATE_MUTATION = `mutation ZuseLinearUpdate($id: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $id, input: $input) { success issue { id identifier title url } }
+}`;
+
+const safeSegment = (value: string): string =>
+	value
+		.normalize("NFKD")
+		.toLowerCase()
+		.replace(/[^a-z0-9-]+/gu, "-")
+		.replace(/^-+|-+$/gu, "")
+		.slice(0, 80) || "workspace";
+
+const isPrivateIp = (address: string): boolean => {
+	if (isIP(address) === 4) {
+		const [a, b] = address.split(".").map(Number);
+		return (
+			a === 10 ||
+			a === 127 ||
+			a === 0 ||
+			(a === 169 && b === 254) ||
+			(a === 172 && (b ?? 0) >= 16 && (b ?? 0) <= 31) ||
+			(a === 192 && b === 168)
+		);
+	}
+	const lower = address.toLowerCase();
+	return (
+		lower === "::1" ||
+		lower.startsWith("fe80:") ||
+		lower.startsWith("fc") ||
+		lower.startsWith("fd")
+	);
+};
+
+const validatePublicImageUrl = async (url: URL): Promise<void> => {
+	if (url.protocol !== "https:")
+		throw new Error("Only HTTPS images are allowed.");
+	if (url.hostname === "uploads.linear.app") return;
+	const addresses = await lookup(url.hostname, { all: true });
+	if (
+		addresses.length === 0 ||
+		addresses.some(({ address }) => isPrivateIp(address))
+	) {
+		throw new Error("Private image hosts are not allowed.");
+	}
+};
+
+const imageExtension = (mime: string): string | null => {
+	const base = mime.split(";")[0]?.trim().toLowerCase();
+	if (base === "image/png") return "png";
+	if (base === "image/jpeg" || base === "image/jpg") return "jpg";
+	if (base === "image/gif") return "gif";
+	if (base === "image/webp") return "webp";
+	if (base === "image/avif") return "avif";
+	if (base === "image/svg+xml") return "svg";
+	return null;
+};
+
+export const LinearServiceLive = Layer.effect(
+	LinearService,
+	Effect.gen(function* () {
+		const credentials = yield* CredentialsService;
+		const shell = yield* AuthShell;
+		const fs = yield* FileSystem.FileSystem;
+		const pathSvc = yield* Path.Path;
+		const sql = yield* SqlClient.SqlClient;
+		const refreshLocks = new Map<string, Semaphore.Semaphore>();
+		let pending: PendingConnect | null = null;
+		const fetcher: LinearFetch = globalThis.fetch.bind(globalThis);
+
+		const readBundle = Effect.fn("LinearService.readBundle")(function* (
+			workspaceId: string,
+		) {
+			const raw = yield* credentials
+				.getIntegration(INTEGRATION, workspaceId)
+				.pipe(Effect.mapError((cause) => fail(cause.reason)));
+			const bundle = parseBundle(raw);
+			if (bundle === null)
+				return yield* Effect.fail(fail("Linear workspace is not connected."));
+			return bundle;
+		});
+
+		const persistBundle = Effect.fn("LinearService.persistBundle")(function* (
+			bundle: TokenBundle,
+		) {
+			yield* credentials
+				.setIntegration(INTEGRATION, bundle.workspaceId, JSON.stringify(bundle))
+				.pipe(Effect.mapError((cause) => fail(cause.reason)));
+			return bundle;
+		});
+
+		const freshBundle = Effect.fn("LinearService.freshBundle")(function* (
+			workspaceId: string,
+		) {
+			const seed = yield* readBundle(workspaceId);
+			if (seed.expiresAt - Date.now() > REFRESH_SKEW_MS) return seed;
+			let lock = refreshLocks.get(workspaceId);
+			if (lock === undefined) {
+				lock = yield* Semaphore.make(1);
+				refreshLocks.set(workspaceId, lock);
+			}
+			return yield* lock.withPermits(1)(
+				Effect.gen(function* () {
+					const current = yield* readBundle(workspaceId);
+					if (current.expiresAt - Date.now() > REFRESH_SKEW_MS) return current;
+					const token = yield* Effect.tryPromise({
+						try: () =>
+							exchangeToken(fetcher, {
+								grant_type: "refresh_token",
+								refresh_token: current.refreshToken,
+								client_id: CLIENT_ID,
+							}),
+						catch: (cause) => fail(errorMessage(cause)),
+					});
+					return yield* persistBundle({
+						...current,
+						accessToken: token.access_token,
+						refreshToken: token.refresh_token,
+						expiresAt: Date.now() + token.expires_in * 1_000,
+					});
+				}),
+			);
+		});
+
+		const graphql = <A>(
+			workspaceId: string,
+			query: string,
+			variables: Readonly<Record<string, unknown>>,
+		) =>
+			Effect.gen(function* () {
+				let bundle = yield* freshBundle(workspaceId);
+				const first = yield* Effect.tryPromise({
+					try: () =>
+						linearGraphql<A>(fetcher, bundle.accessToken, query, variables),
+					catch: (cause) => cause,
+				}).pipe(Effect.result);
+				if (first._tag === "Success") return first.success;
+				if (
+					!(first.failure instanceof LinearApiError) ||
+					first.failure.status !== 401
+				) {
+					return yield* Effect.fail(fail(errorMessage(first.failure)));
+				}
+				bundle = yield* persistBundle({ ...bundle, expiresAt: 0 });
+				bundle = yield* freshBundle(workspaceId);
+				return yield* Effect.tryPromise({
+					try: () =>
+						linearGraphql<A>(fetcher, bundle.accessToken, query, variables),
+					catch: (cause) => fail(errorMessage(cause)),
+				});
+			});
+
+		if (shell.onLinearCallbackUrl !== undefined) {
+			yield* shell.onLinearCallbackUrl((url) => {
+				const current = pending;
+				if (current === null) return;
+				try {
+					const parsed = new URL(url);
+					if (parsed.searchParams.get("state") !== current.state) {
+						current.reject(new Error("Linear OAuth state did not match."));
+					} else {
+						current.resolve(url);
+					}
+				} catch (cause) {
+					current.reject(
+						cause instanceof Error ? cause : new Error(String(cause)),
+					);
+				}
+			});
+		}
+
+		const listConnections = Effect.fn("LinearService.listConnections")(
+			function* () {
+				const ids = yield* credentials
+					.listIntegrationAccounts(INTEGRATION)
+					.pipe(Effect.mapError((cause) => fail(cause.reason)));
+				const connections: LinearConnection[] = [];
+				for (const id of ids) {
+					const raw = yield* credentials
+						.getIntegration(INTEGRATION, id)
+						.pipe(Effect.mapError((cause) => fail(cause.reason)));
+					const bundle = parseBundle(raw);
+					if (bundle !== null) connections.push(toConnection(bundle));
+				}
+				return connections.sort((a, b) =>
+					a.workspaceName.localeCompare(b.workspaceName),
+				);
+			},
+		);
+
+		const connect = Effect.fn("LinearService.connect")(function* () {
+			if (CLIENT_ID.length === 0)
+				return yield* Effect.fail(
+					fail("Linear OAuth is not configured in this build."),
+				);
+			if (
+				shell.linearRedirectUri === undefined ||
+				shell.onLinearCallbackUrl === undefined
+			) {
+				return yield* Effect.fail(
+					fail("This host does not support Linear OAuth."),
+				);
+			}
+			if (pending !== null)
+				return yield* Effect.fail(
+					fail("A Linear connection is already in progress."),
+				);
+			const redirectUri = shell.linearRedirectUri;
+			const pkce = makePkce();
+			const callback = new Promise<string>((resolve, reject) => {
+				pending = {
+					state: pkce.state,
+					verifier: pkce.verifier,
+					resolve,
+					reject,
+				};
+			});
+			yield* shell
+				.open(authorizeUrl(pkce.challenge, pkce.state, redirectUri))
+				.pipe(Effect.mapError((cause) => fail(cause.reason)));
+			const callbackUrl = yield* Effect.tryPromise({
+				try: async () => {
+					const timeout = new Promise<never>((_, reject) =>
+						setTimeout(
+							() => reject(new Error("Linear connection timed out.")),
+							90_000,
+						),
+					);
+					return await Promise.race([callback, timeout]);
+				},
+				catch: (cause) => fail(errorMessage(cause)),
+			}).pipe(
+				Effect.ensuring(
+					Effect.sync(() => {
+						pending = null;
+					}),
+				),
+			);
+			const code = new URL(callbackUrl).searchParams.get("code");
+			if (code === null)
+				return yield* Effect.fail(
+					fail("Linear OAuth returned no authorization code."),
+				);
+			const token = yield* Effect.tryPromise({
+				try: () =>
+					exchangeToken(fetcher, {
+						grant_type: "authorization_code",
+						code,
+						redirect_uri: redirectUri,
+						client_id: CLIENT_ID,
+						code_verifier: pkce.verifier,
+					}),
+				catch: (cause) => fail(errorMessage(cause)),
+			});
+			const viewer = yield* Effect.tryPromise({
+				try: () =>
+					linearGraphql<{
+						viewer: {
+							id: string;
+							name: string;
+							email: string;
+							organization: { id: string; name: string; urlKey: string };
+						};
+					}>(fetcher, token.access_token, VIEWER_QUERY, {}),
+				catch: (cause) => fail(errorMessage(cause)),
+			});
+			const now = new Date().toISOString();
+			const bundle: TokenBundle = {
+				accessToken: token.access_token,
+				refreshToken: token.refresh_token,
+				expiresAt: Date.now() + token.expires_in * 1_000,
+				workspaceId: viewer.viewer.organization.id,
+				workspaceName: viewer.viewer.organization.name,
+				workspaceKey: viewer.viewer.organization.urlKey,
+				viewerId: viewer.viewer.id,
+				viewerName: viewer.viewer.name,
+				viewerEmail: viewer.viewer.email,
+				connectedAt: now,
+			};
+			yield* persistBundle(bundle);
+			return toConnection(bundle);
+		});
+
+		const disconnect = Effect.fn("LinearService.disconnect")(function* (
+			workspaceId: string,
+		) {
+			const bundle = yield* readBundle(workspaceId);
+			yield* Effect.tryPromise({
+				try: () =>
+					fetcher("https://api.linear.app/oauth/revoke", {
+						method: "POST",
+						headers: { "content-type": "application/x-www-form-urlencoded" },
+						body: new URLSearchParams({
+							token: bundle.refreshToken,
+							token_type_hint: "refresh_token",
+						}),
+					}),
+				catch: () => null,
+			}).pipe(Effect.ignore);
+			yield* credentials
+				.removeIntegration(INTEGRATION, workspaceId)
+				.pipe(Effect.mapError((cause) => fail(cause.reason)));
+		});
+
+		const listIssues = Effect.fn("LinearService.listIssues")(function* (input: {
+			readonly query?: string;
+			readonly workspaceIds?: ReadonlyArray<string>;
+			readonly cursor?: string;
+		}) {
+			const connections = yield* listConnections();
+			const requested = new Set(
+				input.workspaceIds ?? connections.map((row) => row.workspaceId),
+			);
+			const selected = connections.filter((row) =>
+				requested.has(row.workspaceId),
+			);
+			const cursorByWorkspace =
+				input.cursor === undefined
+					? {}
+					: (() => {
+							try {
+								return JSON.parse(
+									Buffer.from(input.cursor, "base64url").toString("utf8"),
+								) as Record<string, string>;
+							} catch {
+								return {};
+							}
+						})();
+			const pages = yield* Effect.all(
+				selected.map((connection) =>
+					Effect.gen(function* () {
+						const bundle = yield* freshBundle(connection.workspaceId);
+						const query = input.query?.trim() ?? "";
+						const filter =
+							query.length === 0
+								? {
+										assignee: { id: { eq: bundle.viewerId } },
+										state: { type: { nin: ["completed", "canceled"] } },
+									}
+								: {
+										or: [
+											{ title: { containsIgnoreCase: query } },
+											{ identifier: { containsIgnoreCase: query } },
+										],
+									};
+						const data = yield* graphql<{
+							issues: {
+								nodes: ReadonlyArray<IssueSummaryPayload>;
+								pageInfo: { hasNextPage: boolean; endCursor: string | null };
+							};
+						}>(connection.workspaceId, ISSUES_QUERY, {
+							first: 50,
+							after: cursorByWorkspace[connection.workspaceId] ?? null,
+							filter,
+						});
+						return {
+							workspaceId: connection.workspaceId,
+							error: null as string | null,
+							endCursor: data.issues.pageInfo.hasNextPage
+								? data.issues.pageInfo.endCursor
+								: null,
+							issues: data.issues.nodes.map((issue) =>
+								LinearIssueSummary.make({
+									workspaceId: connection.workspaceId,
+									workspaceName: connection.workspaceName,
+									issueId: issue.id,
+									identifier: issue.identifier,
+									title: issue.title,
+									state: issue.state?.name ?? "",
+									priority: issue.priority ?? 0,
+									assignee: issue.assignee?.name ?? null,
+									labels: (issue.labels?.nodes ?? []).map(
+										(label) => label.name,
+									),
+									updatedAt: new Date(issue.updatedAt),
+								}),
+							),
+						};
+					}).pipe(
+						Effect.catch((error) =>
+							Effect.succeed({
+								workspaceId: connection.workspaceId,
+								error: error.reason,
+								endCursor: null,
+								issues: [] as LinearIssueSummary[],
+							}),
+						),
+					),
+				),
+				{ concurrency: 3 },
+			);
+			if (selected.length > 0 && pages.every((page) => page.error !== null)) {
+				return yield* Effect.fail(
+					fail(
+						pages
+							.map((page) => page.error)
+							.filter((message): message is string => message !== null)
+							.join("; ") || "Linear issue search failed.",
+					),
+				);
+			}
+			const next = Object.fromEntries(
+				pages.flatMap((page) =>
+					page.endCursor === null ? [] : [[page.workspaceId, page.endCursor]],
+				),
+			);
+			return {
+				issues: pages
+					.flatMap((page) => page.issues)
+					.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()),
+				nextCursor:
+					Object.keys(next).length === 0
+						? null
+						: Buffer.from(JSON.stringify(next)).toString("base64url"),
+			};
+		});
+
+		const fetchIssueDocument = Effect.fn("LinearService.fetchIssueDocument")(
+			function* (workspaceId: string, issueId: string) {
+				const connection = (yield* listConnections()).find(
+					(row) => row.workspaceId === workspaceId,
+				);
+				if (connection === undefined)
+					return yield* Effect.fail(fail("Linear workspace is not connected."));
+				const data = yield* graphql<{ issue: IssueDocumentPayload | null }>(
+					workspaceId,
+					ISSUE_QUERY,
+					{ id: issueId },
+				);
+				if (data.issue == null)
+					return yield* Effect.fail(fail("Linear issue was not found."));
+				const issue = data.issue;
+				const comments = [...(issue.comments?.nodes ?? [])];
+				let commentCursor = issue.comments?.pageInfo?.endCursor ?? null;
+				while (
+					issue.comments?.pageInfo?.hasNextPage &&
+					commentCursor !== null
+				) {
+					const page = yield* graphql<{
+						issue: { comments?: CommentConnection };
+					}>(workspaceId, COMMENTS_QUERY, {
+						id: issueId,
+						after: commentCursor,
+					});
+					comments.push(...(page.issue.comments?.nodes ?? []));
+					if (!page.issue.comments?.pageInfo?.hasNextPage) break;
+					commentCursor = page.issue.comments.pageInfo.endCursor ?? null;
+				}
+				return {
+					identifier: issue.identifier,
+					title: issue.title,
+					url: issue.url,
+					workspaceName: connection.workspaceName,
+					state: issue.state?.name ?? "",
+					priorityLabel: issue.priorityLabel ?? "No priority",
+					assignee: issue.assignee?.name ?? null,
+					labels: (issue.labels?.nodes ?? []).map((label) => label.name),
+					project: issue.project?.name ?? null,
+					cycle: issue.cycle?.name ?? null,
+					description: issue.description ?? "",
+					relations: (issue.relations?.nodes ?? []).map((relation) => ({
+						type: relation.type ?? "related",
+						identifier: relation.relatedIssue?.identifier ?? "",
+						title: relation.relatedIssue?.title ?? "",
+					})),
+					comments: comments.map((comment) => ({
+						author: comment.user?.name ?? "Unknown",
+						createdAt: comment.createdAt ?? "",
+						body: comment.body ?? "",
+					})),
+					warnings: [],
+				} satisfies LinearIssueDocument;
+			},
+		);
+
+		const prepareContext = Effect.fn("LinearService.prepareContext")(
+			function* (input: {
+				readonly sessionId: SessionId;
+				readonly issues: ReadonlyArray<LinearIssueRef>;
+				readonly rootPath?: string;
+			}) {
+				const cwd = yield* resolveSessionCwd(
+					sql,
+					input.sessionId,
+					input.rootPath,
+				);
+				if (cwd === null)
+					return yield* Effect.fail(
+						fail("Could not resolve the session workspace."),
+					);
+				const files: LinearContextFile[] = [];
+				const warnings: LinearContextWarning[] = [];
+				const connections = yield* listConnections();
+				for (const ref of input.issues) {
+					const connection = connections.find(
+						(row) => row.workspaceId === ref.workspaceId,
+					);
+					const workspaceDir = `${safeSegment(connection?.workspaceKey ?? connection?.workspaceName ?? "workspace")}-${safeSegment(ref.workspaceId).slice(0, 8)}`;
+					const dir = pathSvc.join(cwd, ".context", "linear", workspaceDir);
+					const assetsDir = pathSvc.join(
+						dir,
+						"assets",
+						safeSegment(ref.identifier).toUpperCase(),
+					);
+					yield* fs
+						.makeDirectory(assetsDir, { recursive: true })
+						.pipe(Effect.orDie);
+					let document: LinearIssueDocument;
+					const fetched = yield* fetchIssueDocument(
+						ref.workspaceId,
+						ref.issueId,
+					).pipe(Effect.result);
+					if (fetched._tag === "Failure") {
+						const message = fetched.failure.reason;
+						warnings.push(LinearContextWarning.make({ issue: ref, message }));
+						document = {
+							identifier: ref.identifier,
+							title: "Context unavailable",
+							url: "",
+							workspaceName: connection?.workspaceName ?? "Unknown workspace",
+							state: "Unknown",
+							priorityLabel: "Unknown",
+							assignee: null,
+							labels: [],
+							project: null,
+							cycle: null,
+							description:
+								"The issue could not be downloaded. Use the Linear tools to retry.",
+							relations: [],
+							comments: [],
+							warnings: [message],
+						};
+					} else {
+						document = fetched.success;
+					}
+					const bundle = yield* freshBundle(ref.workspaceId).pipe(
+						Effect.result,
+					);
+					const imageCache = new Map<string, string>();
+					const downloadImage = async (
+						rawUrl: string,
+					): Promise<string | null> => {
+						const cached = imageCache.get(rawUrl);
+						if (cached !== undefined) return cached;
+						if (rawUrl.startsWith("data:image/")) {
+							const match = /^data:([^;,]+)(;base64)?,(.*)$/u.exec(rawUrl);
+							if (match === null) return null;
+							const mime = match[1];
+							const encoding = match[2];
+							const encoded = match[3];
+							if (mime === undefined || encoded === undefined) return null;
+							const ext = imageExtension(mime);
+							if (ext === null) return null;
+							const bytes =
+								encoding === ";base64"
+									? Buffer.from(encoded, "base64")
+									: Buffer.from(decodeURIComponent(encoded), "utf8");
+							if (bytes.byteLength > MAX_IMAGE_BYTES) return null;
+							const name = `${createHash("sha256").update(rawUrl).digest("hex").slice(0, 20)}.${ext}`;
+							await Effect.runPromise(
+								fs.writeFile(pathSvc.join(assetsDir, name), bytes),
+							);
+							const rel = `assets/${safeSegment(ref.identifier).toUpperCase()}/${name}`;
+							imageCache.set(rawUrl, rel);
+							return rel;
+						}
+						let url = new URL(rawUrl);
+						for (let redirects = 0; redirects < 4; redirects++) {
+							await validatePublicImageUrl(url);
+							const headers: Record<string, string> = {};
+							if (
+								url.hostname === "uploads.linear.app" &&
+								bundle._tag === "Success"
+							) {
+								headers.authorization = `Bearer ${bundle.success.accessToken}`;
+							}
+							const response = await fetcher(url, {
+								headers,
+								redirect: "manual",
+							});
+							if (response.status >= 300 && response.status < 400) {
+								const location = response.headers.get("location");
+								if (location === null) return null;
+								url = new URL(location, url);
+								continue;
+							}
+							if (!response.ok) return null;
+							const ext = imageExtension(
+								response.headers.get("content-type") ?? "",
+							);
+							if (ext === null) return null;
+							const length = Number(
+								response.headers.get("content-length") ?? 0,
+							);
+							if (length > MAX_IMAGE_BYTES) return null;
+							const bytes = new Uint8Array(await response.arrayBuffer());
+							if (bytes.byteLength > MAX_IMAGE_BYTES) return null;
+							const name = `${createHash("sha256").update(rawUrl).digest("hex").slice(0, 20)}.${ext}`;
+							await Effect.runPromise(
+								fs.writeFile(pathSvc.join(assetsDir, name), bytes),
+							);
+							const rel = `assets/${safeSegment(ref.identifier).toUpperCase()}/${name}`;
+							imageCache.set(rawUrl, rel);
+							return rel;
+						}
+						return null;
+					};
+					const description = yield* Effect.promise(() =>
+						rewriteMarkdownImages(document.description, downloadImage),
+					);
+					const commentResults = yield* Effect.all(
+						document.comments.map((comment) =>
+							Effect.promise(async () => ({
+								...comment,
+								...(await rewriteMarkdownImages(comment.body, downloadImage)),
+							})),
+						),
+						{ concurrency: 3 },
+					);
+					const imageWarnings = [
+						...description.warnings,
+						...commentResults.flatMap((comment) => comment.warnings),
+					];
+					for (const message of imageWarnings)
+						warnings.push(LinearContextWarning.make({ issue: ref, message }));
+					const markdown = renderLinearIssueMarkdown({
+						...document,
+						description: description.markdown,
+						comments: commentResults.map(({ markdown, ...comment }) => ({
+							...comment,
+							body: markdown,
+						})),
+						warnings: [...document.warnings, ...imageWarnings],
+					});
+					const filename = `${safeSegment(ref.identifier).toUpperCase()}.md`;
+					const target = pathSvc.join(dir, filename);
+					const temp = `${target}.tmp-${randomUUID()}`;
+					yield* fs.writeFileString(temp, markdown).pipe(Effect.orDie);
+					yield* fs.rename(temp, target).pipe(Effect.orDie);
+					files.push(
+						LinearContextFile.make({
+							issue: ref,
+							relPath: pathSvc.relative(cwd, target),
+							absPath: target,
+						}),
+					);
+				}
+				return { files, warnings };
+			},
+		);
+
+		const resolveToolIssue = Effect.fn("LinearService.resolveToolIssue")(
+			function* (workspaceId: string | undefined, issue: string) {
+				const connections = yield* listConnections();
+				const candidates =
+					workspaceId === undefined
+						? connections
+						: connections.filter((row) => row.workspaceId === workspaceId);
+				const matches: Array<{
+					workspaceId: string;
+					issue: IssueLookupPayload;
+				}> = [];
+				for (const connection of candidates) {
+					const result = yield* graphql<{
+						issue: IssueLookupPayload | null;
+					}>(connection.workspaceId, ISSUE_LOOKUP_QUERY, { id: issue }).pipe(
+						Effect.result,
+					);
+					if (result._tag === "Success" && result.success.issue != null)
+						matches.push({
+							workspaceId: connection.workspaceId,
+							issue: result.success.issue,
+						});
+				}
+				if (matches.length === 0)
+					return yield* Effect.fail(
+						fail(`Linear issue ${issue} was not found.`),
+					);
+				if (matches.length > 1)
+					return yield* Effect.fail(
+						fail(
+							`Linear issue ${issue} exists in multiple workspaces; provide workspaceId.`,
+						),
+					);
+				const match = matches[0];
+				if (match === undefined)
+					return yield* Effect.fail(
+						fail(`Linear issue ${issue} was not found.`),
+					);
+				return match;
+			},
+		);
+
+		const getIssueForTool = Effect.fn("LinearService.getIssueForTool")(
+			function* (workspaceId: string | undefined, issue: string) {
+				return yield* resolveToolIssue(workspaceId, issue);
+			},
+		);
+
+		const addComment = Effect.fn("LinearService.addComment")(function* (
+			workspaceId: string | undefined,
+			issue: string,
+			body: string,
+		) {
+			const resolved = yield* resolveToolIssue(workspaceId, issue);
+			return yield* graphql(resolved.workspaceId, COMMENT_MUTATION, {
+				issueId: resolved.issue.id,
+				body,
+			});
+		});
+
+		const findNamed = (
+			values: ReadonlyArray<NamedNode>,
+			requested: string,
+			kind: string,
+		) => {
+			const normalized = requested.trim().toLowerCase();
+			const matches = values.filter(
+				(value) =>
+					value.name?.trim().toLowerCase() === normalized ||
+					value.email?.trim().toLowerCase() === normalized,
+			);
+			if (matches.length !== 1)
+				throw new Error(
+					matches.length === 0
+						? `${kind} “${requested}” was not found.`
+						: `${kind} “${requested}” is ambiguous.`,
+				);
+			const match = matches[0];
+			if (match === undefined)
+				throw new Error(`${kind} “${requested}” was not found.`);
+			return match;
+		};
+
+		const updateIssue = Effect.fn("LinearService.updateIssue")(function* (
+			input: LinearToolIssueUpdate,
+		) {
+			const resolved = yield* resolveToolIssue(input.workspaceId, input.issue);
+			const current = resolved.issue;
+			const update: Record<string, unknown> = {};
+			if (input.title !== undefined) update.title = input.title;
+			if (input.description !== undefined)
+				update.description = input.description;
+			if (input.priority !== undefined) update.priority = input.priority;
+			try {
+				if (input.status !== undefined)
+					update.stateId = findNamed(
+						current.team?.states?.nodes ?? [],
+						input.status,
+						"Status",
+					).id;
+				if (input.assignee !== undefined)
+					update.assigneeId =
+						input.assignee === null
+							? null
+							: findNamed(
+									current.team?.members?.nodes ?? [],
+									input.assignee,
+									"Assignee",
+								).id;
+				if (input.labels !== undefined)
+					update.labelIds = input.labels.map(
+						(label: string) =>
+							findNamed(current.team?.labels?.nodes ?? [], label, "Label").id,
+					);
+				if (input.project !== undefined) {
+					if (input.project === null) update.projectId = null;
+					else
+						update.projectId = findNamed(
+							current.team?.projects?.nodes ?? [],
+							input.project,
+							"Project",
+						).id;
+				}
+			} catch (cause) {
+				return yield* Effect.fail(fail(errorMessage(cause)));
+			}
+			return yield* graphql(resolved.workspaceId, UPDATE_MUTATION, {
+				id: current.id,
+				input: update,
+			});
+		});
+
+		return LinearService.of({
+			listConnections,
+			connect,
+			disconnect,
+			listIssues,
+			prepareContext,
+			getIssueForTool,
+			addComment,
+			updateIssue,
+		});
+	}),
+);

--- a/apps/server/src/linear/layers/linear-service.ts
+++ b/apps/server/src/linear/layers/linear-service.ts
@@ -2,7 +2,9 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 
+import { AttachmentService } from "@zuse/agents/kernel/attachment-service";
 import {
+	AttachmentRef,
 	LinearConnection,
 	LinearContextFile,
 	LinearContextWarning,
@@ -290,15 +292,47 @@ const validatePublicImageUrl = async (url: URL): Promise<void> => {
 	}
 };
 
+const IMAGE_TYPES = [
+	{ mime: "image/png", acceptedMimes: ["image/png"], extensions: ["png"] },
+	{
+		mime: "image/jpeg",
+		acceptedMimes: ["image/jpeg", "image/jpg"],
+		extensions: ["jpg", "jpeg"],
+	},
+	{ mime: "image/gif", acceptedMimes: ["image/gif"], extensions: ["gif"] },
+	{
+		mime: "image/webp",
+		acceptedMimes: ["image/webp"],
+		extensions: ["webp"],
+	},
+	{
+		mime: "image/avif",
+		acceptedMimes: ["image/avif"],
+		extensions: ["avif"],
+	},
+	{
+		mime: "image/svg+xml",
+		acceptedMimes: ["image/svg+xml"],
+		extensions: ["svg"],
+	},
+] as const;
+
 const imageExtension = (mime: string): string | null => {
 	const base = mime.split(";")[0]?.trim().toLowerCase();
-	if (base === "image/png") return "png";
-	if (base === "image/jpeg" || base === "image/jpg") return "jpg";
-	if (base === "image/gif") return "gif";
-	if (base === "image/webp") return "webp";
-	if (base === "image/avif") return "avif";
-	if (base === "image/svg+xml") return "svg";
-	return null;
+	return (
+		IMAGE_TYPES.find((type) =>
+			type.acceptedMimes.some((candidate) => candidate === base),
+		)?.extensions[0] ?? null
+	);
+};
+
+const imageMimeFromPath = (path: string): string | null => {
+	const ext = path.slice(path.lastIndexOf(".") + 1).toLowerCase();
+	return (
+		IMAGE_TYPES.find((type) =>
+			type.extensions.some((candidate) => candidate === ext),
+		)?.mime ?? null
+	);
 };
 
 export const LinearServiceLive = Layer.effect(
@@ -309,6 +343,7 @@ export const LinearServiceLive = Layer.effect(
 		const fs = yield* FileSystem.FileSystem;
 		const pathSvc = yield* Path.Path;
 		const sql = yield* SqlClient.SqlClient;
+		const attachmentService = yield* AttachmentService;
 		const refreshLocks = new Map<string, Semaphore.Semaphore>();
 		let pending: PendingConnect | null = null;
 		const fetcher: LinearFetch = globalThis.fetch.bind(globalThis);
@@ -738,6 +773,7 @@ export const LinearServiceLive = Layer.effect(
 						fail("Could not resolve the session workspace."),
 					);
 				const files: LinearContextFile[] = [];
+				const attachments: AttachmentRef[] = [];
 				const warnings: LinearContextWarning[] = [];
 				const connections = yield* listConnections();
 				for (const ref of input.issues) {
@@ -866,9 +902,46 @@ export const LinearServiceLive = Layer.effect(
 						),
 						{ concurrency: 3 },
 					);
+					const attachmentWarnings: string[] = [];
+					for (const relPath of new Set(imageCache.values())) {
+						const mimeType = imageMimeFromPath(relPath);
+						if (mimeType === null) continue;
+						const absPath = pathSvc.join(dir, relPath);
+						const bytes = yield* fs.readFile(absPath).pipe(Effect.result);
+						if (bytes._tag === "Failure") {
+							attachmentWarnings.push(
+								`Downloaded image could not be attached to the agent: ${relPath}`,
+							);
+							continue;
+						}
+						const originalName = `${safeSegment(ref.identifier).toUpperCase()}-${pathSvc.basename(relPath)}`;
+						const uploaded = yield* attachmentService
+							.upload(
+								input.sessionId,
+								bytes.success,
+								mimeType,
+								originalName,
+								cwd,
+							)
+							.pipe(Effect.result);
+						if (uploaded._tag === "Failure") {
+							attachmentWarnings.push(
+								`Downloaded image could not be attached to the agent: ${relPath}`,
+							);
+							continue;
+						}
+						attachments.push(
+							AttachmentRef.make({
+								id: uploaded.success.id,
+								mimeType: uploaded.success.mimeType,
+								originalName,
+							}),
+						);
+					}
 					const imageWarnings = [
 						...description.warnings,
 						...commentResults.flatMap((comment) => comment.warnings),
+						...attachmentWarnings,
 					];
 					for (const message of imageWarnings)
 						warnings.push(LinearContextWarning.make({ issue: ref, message }));
@@ -894,7 +967,7 @@ export const LinearServiceLive = Layer.effect(
 						}),
 					);
 				}
-				return { files, warnings };
+				return { files, attachments, warnings };
 			},
 		);
 

--- a/apps/server/src/linear/linear-api.ts
+++ b/apps/server/src/linear/linear-api.ts
@@ -1,0 +1,199 @@
+import { Schema } from "effect";
+
+const GraphqlEnvelope = Schema.Struct({
+	data: Schema.optional(Schema.Unknown),
+	errors: Schema.optional(
+		Schema.Array(
+			Schema.Struct({
+				message: Schema.String,
+			}),
+		),
+	),
+});
+
+export type LinearFetch = (
+	input: string | URL | Request,
+	init?: RequestInit,
+) => Promise<Response>;
+
+export class LinearApiError extends Error {
+	readonly status: number | null;
+
+	constructor(message: string, status: number | null = null) {
+		super(message);
+		this.name = "LinearApiError";
+		this.status = status;
+	}
+}
+
+export const linearGraphql = async <A>(
+	fetcher: LinearFetch,
+	accessToken: string,
+	query: string,
+	variables: Readonly<Record<string, unknown>>,
+): Promise<A> => {
+	const request = () =>
+		fetcher("https://api.linear.app/graphql", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${accessToken}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ query, variables }),
+		});
+	let response = await request();
+	if (response.status === 429) {
+		const retryAfterSeconds = Number(response.headers.get("retry-after") ?? 1);
+		await new Promise((resolve) =>
+			setTimeout(resolve, Math.min(Math.max(retryAfterSeconds, 0), 60) * 1_000),
+		);
+		response = await request();
+	}
+	const raw = await response.text();
+	if (!response.ok) {
+		throw new LinearApiError(
+			`Linear request failed (${response.status}).`,
+			response.status,
+		);
+	}
+	let json: unknown;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		throw new LinearApiError("Linear returned invalid JSON.", response.status);
+	}
+	const envelope = Schema.decodeUnknownSync(GraphqlEnvelope)(json);
+	if (envelope.errors !== undefined && envelope.errors.length > 0) {
+		throw new LinearApiError(
+			envelope.errors.map((error) => error.message).join("; "),
+			response.status,
+		);
+	}
+	if (envelope.data === undefined) {
+		throw new LinearApiError("Linear returned no data.", response.status);
+	}
+	return envelope.data as A;
+};
+
+export interface LinearIssueDocument {
+	readonly identifier: string;
+	readonly title: string;
+	readonly url: string;
+	readonly workspaceName: string;
+	readonly state: string;
+	readonly priorityLabel: string;
+	readonly assignee: string | null;
+	readonly labels: ReadonlyArray<string>;
+	readonly project: string | null;
+	readonly cycle: string | null;
+	readonly description: string;
+	readonly relations: ReadonlyArray<{
+		readonly type: string;
+		readonly identifier: string;
+		readonly title: string;
+	}>;
+	readonly comments: ReadonlyArray<{
+		readonly author: string;
+		readonly createdAt: string;
+		readonly body: string;
+	}>;
+	readonly warnings: ReadonlyArray<string>;
+}
+
+const metadataLine = (label: string, value: string | null): string | null =>
+	value === null || value.length === 0 ? null : `**${label}:** ${value}`;
+
+export const renderLinearIssueMarkdown = (
+	issue: LinearIssueDocument,
+): string => {
+	const lines = [`# ${issue.identifier} — ${issue.title}`, ""];
+	const metadata = [
+		metadataLine("Workspace", issue.workspaceName),
+		metadataLine("URL", issue.url),
+		metadataLine("State", issue.state),
+		metadataLine("Priority", issue.priorityLabel),
+		metadataLine("Assignee", issue.assignee),
+		metadataLine(
+			"Labels",
+			issue.labels.length > 0 ? issue.labels.join(", ") : null,
+		),
+		metadataLine("Project", issue.project),
+		metadataLine("Cycle", issue.cycle),
+	].filter((line): line is string => line !== null);
+	lines.push(metadata.join(" · "), "");
+	if (issue.warnings.length > 0) {
+		lines.push("> [!WARNING]", `> ${issue.warnings.join(" ")}`, "");
+	}
+	lines.push(
+		"## Description",
+		"",
+		issue.description.trim() || "_(no description)_",
+		"",
+	);
+	if (issue.relations.length > 0) {
+		lines.push("## Relations", "");
+		for (const relation of issue.relations) {
+			lines.push(
+				`- ${relation.type}: **${relation.identifier}** — ${relation.title}`,
+			);
+		}
+		lines.push("");
+	}
+	for (const comment of issue.comments) {
+		lines.push(
+			`## Comment by ${comment.author}`,
+			"",
+			`_${comment.createdAt}_`,
+			"",
+			comment.body.trim() || "_(empty comment)_",
+			"",
+		);
+	}
+	return `${lines
+		.join("\n")
+		.replace(/\n{3,}/gu, "\n\n")
+		.trimEnd()}\n`;
+};
+
+export interface RewrittenMarkdown {
+	readonly markdown: string;
+	readonly warnings: ReadonlyArray<string>;
+}
+
+const MARKDOWN_IMAGE = /!\[([^\]]*)\]\(([^\s)]+)(?:\s+["'][^"']*["'])?\)/gu;
+
+export const rewriteMarkdownImages = async (
+	markdown: string,
+	download: (url: string) => Promise<string | null>,
+): Promise<RewrittenMarkdown> => {
+	const urls = Array.from(
+		markdown.matchAll(MARKDOWN_IMAGE),
+		(match) => match[2],
+	)
+		.filter((url): url is string => url !== undefined)
+		.filter((url, index, all) => all.indexOf(url) === index);
+	const localByUrl = new Map<string, string | null>();
+	const warnings: string[] = [];
+	for (const url of urls) {
+		try {
+			const local = await download(url);
+			localByUrl.set(url, local);
+			if (local === null) warnings.push(`Could not download image: ${url}`);
+		} catch {
+			localByUrl.set(url, null);
+			warnings.push(`Could not download image: ${url}`);
+		}
+	}
+	return {
+		markdown: markdown.replace(
+			MARKDOWN_IMAGE,
+			(original, alt: string, url: string) => {
+				const local = localByUrl.get(url);
+				return local === undefined || local === null
+					? original
+					: `![${alt}](${local})`;
+			},
+		),
+		warnings,
+	};
+};

--- a/apps/server/src/linear/linear-api.ts
+++ b/apps/server/src/linear/linear-api.ts
@@ -26,6 +26,61 @@ export class LinearApiError extends Error {
 	}
 }
 
+const ISSUE_SUMMARY_FIELDS = `
+  nodes {
+    id identifier title priority updatedAt url
+    state { name type color }
+    assignee { name avatarUrl }
+    labels { nodes { name } }
+  }
+  pageInfo { hasNextPage endCursor }
+`;
+
+const ASSIGNED_ISSUES_DOCUMENT = `query ZuseLinearIssues($first: Int!, $after: String, $filter: IssueFilter) {
+  issues(first: $first, after: $after, filter: $filter, orderBy: updatedAt) {
+    ${ISSUE_SUMMARY_FIELDS}
+  }
+}`;
+
+const SEARCH_ISSUES_DOCUMENT = `query ZuseLinearIssueSearch($query: String!, $first: Int!, $after: String) {
+  issueSearch(query: $query, first: $first, after: $after) {
+    ${ISSUE_SUMMARY_FIELDS}
+  }
+}`;
+
+export interface LinearIssueListRequest {
+	readonly document: string;
+	readonly rootField: "issues" | "issueSearch";
+	readonly variables: Readonly<Record<string, unknown>>;
+}
+
+export const makeLinearIssueListRequest = (input: {
+	readonly query: string;
+	readonly viewerId: string;
+	readonly after: string | null;
+}): LinearIssueListRequest => {
+	const query = input.query.trim();
+	if (query.length > 0) {
+		return {
+			document: SEARCH_ISSUES_DOCUMENT,
+			rootField: "issueSearch",
+			variables: { first: 50, after: input.after, query },
+		};
+	}
+	return {
+		document: ASSIGNED_ISSUES_DOCUMENT,
+		rootField: "issues",
+		variables: {
+			first: 50,
+			after: input.after,
+			filter: {
+				assignee: { id: { eq: input.viewerId } },
+				state: { type: { nin: ["completed", "canceled"] } },
+			},
+		},
+	};
+};
+
 export const linearGraphql = async <A>(
 	fetcher: LinearFetch,
 	accessToken: string,

--- a/apps/server/src/linear/linear-api.ts
+++ b/apps/server/src/linear/linear-api.ts
@@ -42,15 +42,15 @@ const ASSIGNED_ISSUES_DOCUMENT = `query ZuseLinearIssues($first: Int!, $after: S
   }
 }`;
 
-const SEARCH_ISSUES_DOCUMENT = `query ZuseLinearIssueSearch($query: String!, $first: Int!, $after: String) {
-  issueSearch(query: $query, first: $first, after: $after) {
+const SEARCH_ISSUES_DOCUMENT = `query ZuseLinearIssueSearch($first: Int!, $after: String, $filter: IssueFilter) {
+  issues(first: $first, after: $after, filter: $filter, orderBy: updatedAt) {
     ${ISSUE_SUMMARY_FIELDS}
   }
 }`;
 
 export interface LinearIssueListRequest {
 	readonly document: string;
-	readonly rootField: "issues" | "issueSearch";
+	readonly rootField: "issues";
 	readonly variables: Readonly<Record<string, unknown>>;
 }
 
@@ -63,8 +63,12 @@ export const makeLinearIssueListRequest = (input: {
 	if (query.length > 0) {
 		return {
 			document: SEARCH_ISSUES_DOCUMENT,
-			rootField: "issueSearch",
-			variables: { first: 50, after: input.after, query },
+			rootField: "issues",
+			variables: {
+				first: 50,
+				after: input.after,
+				filter: { searchableContent: { contains: query } },
+			},
 		};
 	}
 	return {

--- a/apps/server/src/linear/services/linear-service.ts
+++ b/apps/server/src/linear/services/linear-service.ts
@@ -1,0 +1,75 @@
+import type {
+	LinearConnection,
+	LinearContextFile,
+	LinearContextWarning,
+	LinearIntegrationError,
+	LinearIssueRef,
+	LinearIssueSummary,
+	SessionId,
+} from "@zuse/contracts";
+import { Context, type Effect } from "effect";
+
+export interface LinearToolIssueUpdate {
+	readonly workspaceId?: string;
+	readonly issue: string;
+	readonly title?: string;
+	readonly description?: string;
+	readonly status?: string;
+	readonly priority?: number;
+	readonly assignee?: string | null;
+	readonly labels?: ReadonlyArray<string>;
+	readonly project?: string | null;
+}
+
+export interface LinearServiceShape {
+	readonly listConnections: () => Effect.Effect<
+		ReadonlyArray<LinearConnection>,
+		LinearIntegrationError
+	>;
+	readonly connect: () => Effect.Effect<
+		LinearConnection,
+		LinearIntegrationError
+	>;
+	readonly disconnect: (
+		workspaceId: string,
+	) => Effect.Effect<void, LinearIntegrationError>;
+	readonly listIssues: (input: {
+		readonly query?: string;
+		readonly workspaceIds?: ReadonlyArray<string>;
+		readonly cursor?: string;
+	}) => Effect.Effect<
+		{
+			readonly issues: ReadonlyArray<LinearIssueSummary>;
+			readonly nextCursor: string | null;
+		},
+		LinearIntegrationError
+	>;
+	readonly prepareContext: (input: {
+		readonly sessionId: SessionId;
+		readonly issues: ReadonlyArray<LinearIssueRef>;
+		readonly rootPath?: string;
+	}) => Effect.Effect<
+		{
+			readonly files: ReadonlyArray<LinearContextFile>;
+			readonly warnings: ReadonlyArray<LinearContextWarning>;
+		},
+		LinearIntegrationError
+	>;
+	readonly getIssueForTool: (
+		workspaceId: string | undefined,
+		issue: string,
+	) => Effect.Effect<unknown, LinearIntegrationError>;
+	readonly addComment: (
+		workspaceId: string | undefined,
+		issue: string,
+		body: string,
+	) => Effect.Effect<unknown, LinearIntegrationError>;
+	readonly updateIssue: (
+		input: LinearToolIssueUpdate,
+	) => Effect.Effect<unknown, LinearIntegrationError>;
+}
+
+export class LinearService extends Context.Service<
+	LinearService,
+	LinearServiceShape
+>()("@zuse/server/linear/LinearService") {}

--- a/apps/server/src/linear/services/linear-service.ts
+++ b/apps/server/src/linear/services/linear-service.ts
@@ -1,4 +1,5 @@
 import type {
+	AttachmentRef,
 	LinearConnection,
 	LinearContextFile,
 	LinearContextWarning,
@@ -51,6 +52,7 @@ export interface LinearServiceShape {
 	}) => Effect.Effect<
 		{
 			readonly files: ReadonlyArray<LinearContextFile>;
+			readonly attachments: ReadonlyArray<AttachmentRef>;
 			readonly warnings: ReadonlyArray<LinearContextWarning>;
 		},
 		LinearIntegrationError

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -31,6 +31,12 @@ const browserAccountFor = (origin: string): string =>
  * installation — signing in overwrites it, signing out deletes it.
  */
 const WORKOS_SESSION_ACCOUNT = "workos:session";
+const integrationPrefix = (integration: string): string =>
+	`integration:${integration}:`;
+const integrationAccountFor = (
+	integration: string,
+	accountId: string,
+): string => `${integrationPrefix(integration)}${accountId}`;
 
 const normalizeOrigin = (input: string): string => {
 	try {
@@ -280,5 +286,35 @@ export const CredentialsServiceLive = Layer.succeed(
 			tryKeychain("*", () =>
 				keytar.deletePassword(SERVICE_NAME, WORKOS_SESSION_ACCOUNT),
 			).pipe(Effect.asVoid),
+		getIntegration: (integration, accountId) =>
+			tryKeychain("*", () =>
+				keytar.getPassword(
+					SERVICE_NAME,
+					integrationAccountFor(integration, accountId),
+				),
+			),
+		setIntegration: (integration, accountId, value) =>
+			tryKeychain("*", () =>
+				keytar.setPassword(
+					SERVICE_NAME,
+					integrationAccountFor(integration, accountId),
+					value,
+				),
+			),
+		removeIntegration: (integration, accountId) =>
+			tryKeychain("*", () =>
+				keytar.deletePassword(
+					SERVICE_NAME,
+					integrationAccountFor(integration, accountId),
+				),
+			).pipe(Effect.asVoid),
+		listIntegrationAccounts: (integration) =>
+			tryKeychain("*", async () => {
+				const prefix = integrationPrefix(integration);
+				return (await keytar.findCredentials(SERVICE_NAME))
+					.map(({ account }) => account)
+					.filter((account) => account.startsWith(prefix))
+					.map((account) => account.slice(prefix.length));
+			}),
 	}),
 );

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -421,6 +421,7 @@ export const ProviderServiceLive = Layer.effect(
               // Control-plane orchestration tools (when autonomy != off) use
               // their own provider-neutral `zuse-orchestration` MCP server.
               orchestrationTools?.claudeTools ?? [],
+              orchestrationTools?.linearTools?.claudeTools ?? [],
             ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else {
             // Same story as Claude: we don't ship the SDK's bundled native

--- a/apps/server/src/provider/services/credentials-service.ts
+++ b/apps/server/src/provider/services/credentials-service.ts
@@ -1,6 +1,5 @@
-import { Context, type Effect } from "effect";
-
 import type { ProviderId } from "@zuse/contracts";
+import { Context, type Effect } from "effect";
 
 import type { CredentialsError } from "../errors.ts";
 
@@ -41,7 +40,10 @@ export interface CredentialsServiceShape {
   ) => Effect.Effect<void, CredentialsError>;
   readonly getBrowser: (
     origin: string,
-  ) => Effect.Effect<{ username: string; password: string } | null, CredentialsError>;
+  ) => Effect.Effect<
+    { username: string; password: string } | null,
+    CredentialsError
+  >;
   readonly removeBrowser: (
     origin: string,
   ) => Effect.Effect<void, CredentialsError>;
@@ -57,13 +59,35 @@ export interface CredentialsServiceShape {
    * `memoize` service. The tokens NEVER leave the server — only the AuthService
    * reads this; the renderer sees a redacted `AuthState` over the wire.
    */
-  readonly getWorkosSession: () => Effect.Effect<string | null, CredentialsError>;
+  readonly getWorkosSession: () => Effect.Effect<
+    string | null,
+    CredentialsError
+  >;
   readonly setWorkosSession: (
     bundleJson: string,
   ) => Effect.Effect<void, CredentialsError>;
   readonly removeWorkosSession: () => Effect.Effect<void, CredentialsError>;
+
+  /** Secret JSON bundles for native third-party integrations. */
+  readonly getIntegration: (
+    integration: string,
+    accountId: string,
+  ) => Effect.Effect<string | null, CredentialsError>;
+  readonly setIntegration: (
+    integration: string,
+    accountId: string,
+    value: string,
+  ) => Effect.Effect<void, CredentialsError>;
+  readonly removeIntegration: (
+    integration: string,
+    accountId: string,
+  ) => Effect.Effect<void, CredentialsError>;
+  readonly listIntegrationAccounts: (
+    integration: string,
+  ) => Effect.Effect<ReadonlyArray<string>, CredentialsError>;
 }
 
-export class CredentialsService extends Context.Service<CredentialsService, CredentialsServiceShape>()(
-  "memoize/CredentialsService",
-) {}
+export class CredentialsService extends Context.Service<
+  CredentialsService,
+  CredentialsServiceShape
+>()("memoize/CredentialsService") {}

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -325,6 +325,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 	const LinearLayer = LinearServiceLive.pipe(
 		Layer.provide(CredentialsServiceLive),
 		Layer.provide(AuthShellLayer),
+		Layer.provide(AttachmentLayer),
 		Layer.provide(MigratedSqlite),
 		Layer.provide(NodeServices.layer),
 	);

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -27,6 +27,7 @@ import {
 	LanAuthConfig,
 	type LanAuthService,
 } from "./lan-auth/services/lan-auth-service.ts";
+import { LinearServiceLive } from "./linear/layers/linear-service.ts";
 import { runLifecycleBackfill } from "./persistence/backfill.ts";
 import { importWorkspacesJson } from "./persistence/import-workspaces.ts";
 import { MigrationsLive } from "./persistence/migrations.ts";
@@ -321,6 +322,12 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 	const RelayActivityPublisherLayer = RelayActivityPublisherLive.pipe(
 		Layer.provide(LanAuthLayer),
 	);
+	const LinearLayer = LinearServiceLive.pipe(
+		Layer.provide(CredentialsServiceLive),
+		Layer.provide(AuthShellLayer),
+		Layer.provide(MigratedSqlite),
+		Layer.provide(NodeServices.layer),
+	);
 
 	const ConversationServicesLayer = ConversationServicesLive.pipe(
 		Layer.provide(ConversationState.layer),
@@ -334,6 +341,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(ConfigStoreLayer),
 		Layer.provide(TitleGeneratorLayer),
 		Layer.provide(RelayActivityPublisherLayer),
+		Layer.provide(LinearLayer),
 		Layer.provide(ProjectorCatchup),
 		Layer.provide(SessionDomainLayer),
 		Layer.provide(ChatDomainLayer),
@@ -377,7 +385,6 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(SessionStoreLive),
 		Layer.provide(AuthShellLayer),
 	);
-
 	// RelayLinkService orchestrates the desktop's self-registration with the
 	// account relay (challenge → Ed25519 proof → link → persist → heartbeat). It
 	// reuses the environment identity (LanAuthService) and the WorkOS token
@@ -431,6 +438,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		LanAuthLayer,
 		RelayLinkLayer,
 		ExternalThreadLayer,
+		LinearLayer,
 		FolderPickerLayer,
 	);
 

--- a/apps/server/test/integration/auth-service.test.ts
+++ b/apps/server/test/integration/auth-service.test.ts
@@ -97,6 +97,10 @@ const makeHarness = (
 				Effect.sync(() => {
 					stored = null;
 				}),
+			getIntegration: () => Effect.succeed(null),
+			setIntegration: () => Effect.void,
+			removeIntegration: () => Effect.void,
+			listIntegrationAccounts: () => Effect.succeed([]),
 		}),
 	);
 	const AuthShellLayer = Layer.succeed(

--- a/apps/server/test/unit/linear-api.test.ts
+++ b/apps/server/test/unit/linear-api.test.ts
@@ -2,11 +2,43 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
 	linearGraphql,
+	makeLinearIssueListRequest,
 	renderLinearIssueMarkdown,
 	rewriteMarkdownImages,
 } from "../../src/linear/linear-api.ts";
 
 describe("Linear API boundary", () => {
+	it("uses workspace-wide issue search for non-empty queries", () => {
+		const request = makeLinearIssueListRequest({
+			query: "  new test  ",
+			viewerId: "viewer-1",
+			after: "cursor-1",
+		});
+		expect(request.rootField).toBe("issueSearch");
+		expect(request.document).toContain("issueSearch(");
+		expect(request.variables).toEqual({
+			first: 50,
+			after: "cursor-1",
+			query: "new test",
+		});
+		expect(request.variables).not.toHaveProperty("filter");
+	});
+
+	it("keeps the empty issue list scoped to the viewer's open work", () => {
+		const request = makeLinearIssueListRequest({
+			query: "",
+			viewerId: "viewer-1",
+			after: null,
+		});
+		expect(request.rootField).toBe("issues");
+		expect(request.variables).toMatchObject({
+			filter: {
+				assignee: { id: { eq: "viewer-1" } },
+				state: { type: { nin: ["completed", "canceled"] } },
+			},
+		});
+	});
+
 	it("rejects GraphQL partial errors even when HTTP succeeds", async () => {
 		const fetcher = vi.fn(
 			async () =>

--- a/apps/server/test/unit/linear-api.test.ts
+++ b/apps/server/test/unit/linear-api.test.ts
@@ -8,20 +8,20 @@ import {
 } from "../../src/linear/linear-api.ts";
 
 describe("Linear API boundary", () => {
-	it("uses workspace-wide issue search for non-empty queries", () => {
+	it("uses public workspace-wide issue filtering for non-empty queries", () => {
 		const request = makeLinearIssueListRequest({
 			query: "  new test  ",
 			viewerId: "viewer-1",
 			after: "cursor-1",
 		});
-		expect(request.rootField).toBe("issueSearch");
-		expect(request.document).toContain("issueSearch(");
+		expect(request.rootField).toBe("issues");
+		expect(request.document).toContain("issues(");
+		expect(request.document).not.toContain("issueSearch(");
 		expect(request.variables).toEqual({
 			first: 50,
 			after: "cursor-1",
-			query: "new test",
+			filter: { searchableContent: { contains: "new test" } },
 		});
-		expect(request.variables).not.toHaveProperty("filter");
 	});
 
 	it("keeps the empty issue list scoped to the viewer's open work", () => {

--- a/apps/server/test/unit/linear-api.test.ts
+++ b/apps/server/test/unit/linear-api.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	linearGraphql,
+	renderLinearIssueMarkdown,
+	rewriteMarkdownImages,
+} from "../../src/linear/linear-api.ts";
+
+describe("Linear API boundary", () => {
+	it("rejects GraphQL partial errors even when HTTP succeeds", async () => {
+		const fetcher = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: { viewer: null },
+						errors: [{ message: "nope" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+		);
+		await expect(
+			linearGraphql(fetcher, "secret", "query Viewer { viewer { id } }", {}),
+		).rejects.toThrow("nope");
+	});
+
+	it("retries one rate-limited GraphQL request using retry-after", async () => {
+		const fetcher = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response("rate limited", {
+					status: 429,
+					headers: { "retry-after": "0" },
+				}),
+			)
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ data: { viewer: { id: "viewer" } } }), {
+					status: 200,
+				}),
+			);
+		await expect(
+			linearGraphql<{ viewer: { id: string } }>(
+				fetcher,
+				"secret",
+				"query Viewer { viewer { id } }",
+				{},
+			),
+		).resolves.toEqual({ viewer: { id: "viewer" } });
+		expect(fetcher).toHaveBeenCalledTimes(2);
+	});
+
+	it("renders a complete issue document", () => {
+		const markdown = renderLinearIssueMarkdown({
+			identifier: "ENG-123",
+			title: "Fix sync",
+			url: "https://linear.app/acme/issue/ENG-123/fix-sync",
+			workspaceName: "Acme",
+			state: "In Progress",
+			priorityLabel: "High",
+			assignee: "Ada",
+			labels: ["bug", "desktop"],
+			project: "Reliability",
+			cycle: "Cycle 8",
+			description: "The description.",
+			relations: [
+				{ type: "blocks", identifier: "ENG-124", title: "Follow-up" },
+			],
+			comments: [
+				{
+					author: "Lin",
+					createdAt: "2026-07-15T01:02:03.000Z",
+					body: "A comment.",
+				},
+			],
+			warnings: [],
+		});
+		expect(markdown).toContain("# ENG-123 — Fix sync");
+		expect(markdown).toContain("**State:** In Progress");
+		expect(markdown).toContain("## Relations");
+		expect(markdown).toContain("## Comment by Lin");
+	});
+
+	it("deduplicates images and preserves failed remote URLs", async () => {
+		const download = vi.fn(async (url: string) =>
+			url.includes("ok") ? `assets/ENG-123/image.png` : null,
+		);
+		const result = await rewriteMarkdownImages(
+			"![one](https://uploads.linear.app/ok)\n![again](https://uploads.linear.app/ok)\n![bad](https://uploads.linear.app/bad)",
+			download,
+		);
+		expect(download).toHaveBeenCalledTimes(2);
+		expect(result.markdown.match(/assets\/ENG-123\/image\.png/g)).toHaveLength(
+			2,
+		);
+		expect(result.markdown).toContain("https://uploads.linear.app/bad");
+		expect(result.warnings).toHaveLength(1);
+	});
+});

--- a/packages/agents/src/drivers/acp/linear-mcp-bridge.ts
+++ b/packages/agents/src/drivers/acp/linear-mcp-bridge.ts
@@ -1,0 +1,54 @@
+import type {
+	PermissionDecision,
+	PermissionKind,
+	PermissionMode,
+	RuntimeMode,
+} from "@zuse/contracts";
+
+import {
+	callLinearTool,
+	ensureLinearToolPermission,
+	isLinearToolName,
+	LINEAR_MCP_SERVER_NAME,
+	type LinearToolDeps,
+} from "../linear-tools.ts";
+import {
+	type LocalMcpBridge,
+	startLocalMcpBridge,
+} from "./local-mcp-bridge.ts";
+
+export interface LinearMcpBridgeOptions {
+	readonly deps: LinearToolDeps;
+	readonly command: string;
+	readonly requestPermission: (
+		kind: PermissionKind,
+		options: { readonly forcePrompt: boolean },
+	) => Promise<PermissionDecision>;
+	readonly getRuntimeMode: () => RuntimeMode;
+	readonly getPermissionMode: () => PermissionMode;
+}
+
+export type LinearMcpBridge = LocalMcpBridge;
+
+export const startLinearMcpBridge = (
+	options: LinearMcpBridgeOptions,
+): Promise<LinearMcpBridge> =>
+	startLocalMcpBridge({
+		serverName: LINEAR_MCP_SERVER_NAME,
+		command: options.command,
+		environmentPrefix: "ZUSE_LINEAR_MCP",
+		bundledChildUrl: new URL("./linear-mcp-child.cjs", import.meta.url),
+		sourceChildUrl: new URL("./linear-mcp-child.ts", import.meta.url),
+		logLabel: "zuse-linear-mcp",
+		missingChildMessage: (paths) =>
+			`[zuse-linear-mcp] child script missing — looked for ${paths.join(", ")}.`,
+		handleTool: async (name, args) => {
+			if (!isLinearToolName(name)) throw new Error(`Unknown tool: ${name}`);
+			await ensureLinearToolPermission(name, args, options);
+			return callLinearTool(options.deps, name, args);
+		},
+		errorResult: (message) => ({
+			content: [{ type: "text" as const, text: message }],
+			isError: true as const,
+		}),
+	});

--- a/packages/agents/src/drivers/acp/linear-mcp-child.ts
+++ b/packages/agents/src/drivers/acp/linear-mcp-child.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+	CallToolRequestSchema,
+	ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { LINEAR_MCP_SERVER_NAME, LINEAR_MCP_TOOLS } from "../linear-tools.ts";
+
+const bridgeUrl = process.env.ZUSE_LINEAR_MCP_URL;
+const token = process.env.ZUSE_LINEAR_MCP_TOKEN;
+if (bridgeUrl === undefined || token === undefined) process.exit(2);
+
+const server = new Server(
+	{ name: LINEAR_MCP_SERVER_NAME, version: "0.0.1" },
+	{ capabilities: { tools: {} } },
+);
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+	tools: LINEAR_MCP_TOOLS.map((tool) => ({ ...tool })),
+}));
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+	try {
+		const response = await fetch(`${bridgeUrl}/tool`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({
+				name: request.params.name,
+				arguments: request.params.arguments ?? {},
+			}),
+		});
+		return (await response.json()) as {
+			content: Array<{ type: "text"; text: string }>;
+			isError?: boolean;
+		};
+	} catch (cause) {
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text: cause instanceof Error ? cause.message : String(cause),
+				},
+			],
+			isError: true,
+		};
+	}
+});
+server.connect(new StdioServerTransport()).catch((cause: unknown) => {
+	process.stderr.write(
+		`[zuse-linear-mcp] failed to connect stdio transport: ${
+			cause instanceof Error ? cause.message : String(cause)
+		}\n`,
+	);
+	process.exit(1);
+});

--- a/packages/agents/src/drivers/claude.ts
+++ b/packages/agents/src/drivers/claude.ts
@@ -44,6 +44,11 @@ import {
 	startCompactSnapshot,
 } from "./compact.ts";
 import {
+	type buildLinearTools,
+	LINEAR_MCP_SERVER_NAME,
+	LINEAR_MCP_TOOLS,
+} from "./linear-tools.ts";
+import {
 	type buildOrchestrationTools,
 	ORCHESTRATION_MCP_SERVER_NAME,
 	ORCHESTRATION_MCP_TOOLS,
@@ -1411,6 +1416,7 @@ export type GetRuntimeMode = () => RuntimeMode;
 
 type BrowserSdkTool = ReturnType<typeof buildBrowserTools>[number];
 type OrchestrationSdkTool = ReturnType<typeof buildOrchestrationTools>[number];
+type LinearSdkTool = ReturnType<typeof buildLinearTools>[number];
 
 export const startClaudeSession = (
 	input: StartSessionInput,
@@ -1428,6 +1434,7 @@ export const startClaudeSession = (
 	// separate server name (`zuse-orchestration`) so Claude, Codex, and Grok see
 	// the same MCP surface and smoke-test instructions.
 	orchestrationTools: ReadonlyArray<OrchestrationSdkTool> = [],
+	linearTools: ReadonlyArray<LinearSdkTool> = [],
 ): Effect.Effect<
 	ClaudeSessionHandle,
 	AgentSessionStartError,
@@ -1638,6 +1645,14 @@ export const startClaudeSession = (
 						tools: [...orchestrationTools],
 						alwaysLoad: !(input.toolSearch ?? false),
 					});
+		const linearMcpServer =
+			linearTools.length === 0
+				? null
+				: createSdkMcpServer({
+						name: LINEAR_MCP_SERVER_NAME,
+						tools: [...linearTools],
+						alwaysLoad: !(input.toolSearch ?? false),
+					});
 
 		const env = applyClaudeWorktreeEnv(
 			scrubInheritedClaudeMarkers(process.env),
@@ -1663,6 +1678,9 @@ export const startClaudeSession = (
 						"Agent",
 						ASK_USER_QUESTION_FQN,
 						...ORCHESTRATION_TOOL_FQNS,
+						...LINEAR_MCP_TOOLS.map(
+							(tool) => `mcp__${LINEAR_MCP_SERVER_NAME}__${tool.name}`,
+						),
 					],
 				} as Pick<Options, "agents" | "allowedTools">)
 			: {};
@@ -1675,10 +1693,10 @@ export const startClaudeSession = (
 		const disallowedTools: ReadonlyArray<string> = [
 			SDK_BUILTIN_ASK_USER_QUESTION,
 		];
-		const initialPermissionMode = input.permissionMode ?? "default";
+		let currentPermissionMode = input.permissionMode ?? "default";
 		const initialSdkPermissionMode = runtimeModeToSdkPermissionMode(
 			getRuntimeMode(),
-			initialPermissionMode,
+			currentPermissionMode,
 		);
 		const options: Options = {
 			cwd,
@@ -1707,6 +1725,9 @@ export const startClaudeSession = (
 				...(orchestrationMcpServer === null
 					? {}
 					: { [ORCHESTRATION_MCP_SERVER_NAME]: orchestrationMcpServer }),
+				...(linearMcpServer === null
+					? {}
+					: { [LINEAR_MCP_SERVER_NAME]: linearMcpServer }),
 			},
 			permissionMode: initialSdkPermissionMode,
 			...(initialSdkPermissionMode === "bypassPermissions"
@@ -1748,6 +1769,21 @@ export const startClaudeSession = (
 			// `PermissionService`. The renderer's toast eventually fulfills the
 			// promise this awaits.
 			canUseTool: async (toolName, toolInput) => {
+				const isLinearRead =
+					toolName.endsWith("__linear_search_issues") ||
+					toolName.endsWith("__linear_get_issue");
+				const isLinearMutation =
+					toolName.endsWith("__linear_add_comment") ||
+					toolName.endsWith("__linear_update_issue");
+				if (isLinearRead) {
+					return { behavior: "allow", updatedInput: toolInput };
+				}
+				if (isLinearMutation && currentPermissionMode === "plan") {
+					return {
+						behavior: "deny",
+						message: "Issue mutations are unavailable in plan mode.",
+					};
+				}
 				const policy = policyFor(toolName, toolInput, getRuntimeMode());
 				// One-line debug so if the auto-allow ever misses (e.g. SDK
 				// changes the MCP-tool naming convention) we can see the
@@ -1962,6 +1998,7 @@ export const startClaudeSession = (
 				}).pipe(
 					Effect.tap(() =>
 						Effect.sync(() => {
+							currentPermissionMode = mode;
 							Queue.offerUnsafe(events, {
 								_tag: "PermissionModeChanged",
 								mode,

--- a/packages/agents/src/drivers/codex.ts
+++ b/packages/agents/src/drivers/codex.ts
@@ -37,6 +37,7 @@ import type { GoalCapableSessionHandle } from "../kernel/driver.ts";
 import { getBashPolicy, getFsPolicy } from "../kernel/policy.ts";
 import { issueProviderMcpSession } from "../kernel/provider-mcp-session.ts";
 import { startBrowserMcpBridge } from "./acp/browser-mcp-bridge.ts";
+import { startLinearMcpBridge } from "./acp/linear-mcp-bridge.ts";
 import { startOrchestrationMcpBridge } from "./acp/orchestration-mcp-bridge.ts";
 import {
 	BROWSER_MCP_SERVER_NAME,
@@ -51,6 +52,7 @@ import {
 	startCompactEvent,
 	startCompactSnapshot,
 } from "./compact.ts";
+import { LINEAR_MCP_SERVER_NAME } from "./linear-tools.ts";
 import {
 	ORCHESTRATION_MCP_SERVER_NAME,
 	type OrchestrationSessionTools,
@@ -68,6 +70,7 @@ const SUPPORTED_CODEX_IMAGE_MIME = new Set([
 const MANAGED_MCP_SERVER_NAMES = new Set([
 	BROWSER_MCP_SERVER_NAME,
 	ORCHESTRATION_MCP_SERVER_NAME,
+	LINEAR_MCP_SERVER_NAME,
 ]);
 
 export type RequestPermission = (
@@ -1271,6 +1274,9 @@ export const startCodexSession = (
 		let orchestrationMcpBridge: Awaited<
 			ReturnType<typeof startOrchestrationMcpBridge>
 		> | null = null;
+		let linearMcpBridge: Awaited<
+			ReturnType<typeof startLinearMcpBridge>
+		> | null = null;
 
 		const expectCodexMcpServers = async (
 			names: ReadonlyArray<string>,
@@ -1304,10 +1310,20 @@ export const startCodexSession = (
 					mergeStrategy: "replace",
 				});
 			}
+			if (orchestrationTools?.linearTools !== undefined) {
+				await app.request("config/value/write", {
+					keyPath: `mcp_servers.${JSON.stringify(LINEAR_MCP_SERVER_NAME)}`,
+					value: mcpGatewaySession.codexServerConfigs.linear,
+					mergeStrategy: "replace",
+				});
+			}
 			await app.request("config/mcpServer/reload", undefined);
 			await expectCodexMcpServers([
 				BROWSER_MCP_SERVER_NAME,
 				...(orchestrationTools === null ? [] : [ORCHESTRATION_MCP_SERVER_NAME]),
+				...(orchestrationTools?.linearTools === undefined
+					? []
+					: [LINEAR_MCP_SERVER_NAME]),
 			]);
 			console.info(`[mcp-gateway] session ${sessionId} connected via http`);
 		};
@@ -1364,10 +1380,27 @@ export const startCodexSession = (
 					orchestrationMcpBridge.serverConfig,
 				);
 			}
+			if (orchestrationTools?.linearTools !== undefined) {
+				linearMcpBridge = await startLinearMcpBridge({
+					deps: orchestrationTools.linearTools.deps,
+					command: orchestrationMcpCommand ?? browserMcpCommand,
+					requestPermission: (kind, options) =>
+						requestPermission(sessionId, kind, options),
+					getRuntimeMode,
+					getPermissionMode: () => currentMode,
+				});
+				await writeStdioServer(
+					LINEAR_MCP_SERVER_NAME,
+					linearMcpBridge.serverConfig,
+				);
+			}
 			await app.request("config/mcpServer/reload", undefined);
 			await expectCodexMcpServers([
 				BROWSER_MCP_SERVER_NAME,
 				...(orchestrationTools === null ? [] : [ORCHESTRATION_MCP_SERVER_NAME]),
+				...(orchestrationTools?.linearTools === undefined
+					? []
+					: [LINEAR_MCP_SERVER_NAME]),
 			]);
 			console.info(
 				`[mcp-gateway] session ${sessionId} connected via stdio-fallback`,
@@ -2253,6 +2286,9 @@ export const startCodexSession = (
 					closed = true;
 					if (orchestrationMcpBridge !== null) {
 						void orchestrationMcpBridge.close();
+					}
+					if (linearMcpBridge !== null) {
+						void linearMcpBridge.close();
 					}
 					if (browserMcpBridge !== null) {
 						void browserMcpBridge.close();

--- a/packages/agents/src/drivers/gemini.ts
+++ b/packages/agents/src/drivers/gemini.ts
@@ -541,6 +541,9 @@ export const startGeminiSession = (
 					...(orchestrationTools === null
 						? []
 						: [mcpGatewaySession.httpServerConfigs.orchestration]),
+					...(orchestrationTools?.linearTools === undefined
+						? []
+						: [mcpGatewaySession.httpServerConfigs.linear]),
 				];
 				return createAcpSession({
 					request,

--- a/packages/agents/src/drivers/grok.ts
+++ b/packages/agents/src/drivers/grok.ts
@@ -1123,6 +1123,9 @@ export const startGrokSession = (
 				...(orchestrationTools === null
 					? []
 					: [mcpGatewaySession.httpServerConfigs.orchestration]),
+				...(orchestrationTools?.linearTools === undefined
+					? []
+					: [mcpGatewaySession.httpServerConfigs.linear]),
 			];
 			const acquisition = await createAcpSession({
 				request,

--- a/packages/agents/src/drivers/linear-tools.ts
+++ b/packages/agents/src/drivers/linear-tools.ts
@@ -1,0 +1,302 @@
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import type {
+	PermissionDecision,
+	PermissionKind,
+	PermissionMode,
+	RuntimeMode,
+} from "@zuse/contracts";
+import { z } from "zod";
+
+import { getToolPolicy } from "../kernel/policy.ts";
+import {
+	type JsonSchemaObject,
+	numberProp,
+	objectSchema,
+	stringProp,
+} from "./mcp-tool-schema.ts";
+
+export const LINEAR_MCP_SERVER_NAME = "zuse-connectors";
+
+type ToolResult =
+	| { readonly ok: true; readonly data: unknown }
+	| { readonly ok: false; readonly error: string };
+
+export interface LinearToolDeps {
+	readonly searchIssues: (input: {
+		readonly query?: string;
+		readonly workspaceId?: string;
+	}) => Promise<ToolResult>;
+	readonly getIssue: (input: {
+		readonly issue: string;
+		readonly workspaceId?: string;
+	}) => Promise<ToolResult>;
+	readonly addComment: (input: {
+		readonly issue: string;
+		readonly body: string;
+		readonly workspaceId?: string;
+	}) => Promise<ToolResult>;
+	readonly updateIssue: (input: {
+		readonly issue: string;
+		readonly workspaceId?: string;
+		readonly title?: string;
+		readonly description?: string;
+		readonly status?: string;
+		readonly priority?: number;
+		readonly assignee?: string | null;
+		readonly labels?: ReadonlyArray<string>;
+		readonly project?: string | null;
+	}) => Promise<ToolResult>;
+}
+
+export interface LinearPermissionOptions {
+	readonly requestPermission: (
+		kind: PermissionKind,
+		options: { readonly forcePrompt: boolean },
+	) => Promise<PermissionDecision>;
+	readonly getRuntimeMode: () => RuntimeMode;
+	readonly getPermissionMode: () => PermissionMode;
+}
+
+export interface LinearSessionTools {
+	readonly deps: LinearToolDeps;
+	readonly claudeTools: ReturnType<typeof buildLinearTools>;
+}
+
+const toolDefs = [
+	{
+		name: "linear_search_issues",
+		description: "Search issues in the user's connected Linear workspaces.",
+		inputSchema: objectSchema({
+			query: stringProp("Ticker or title text. Omit for assigned open issues."),
+			workspaceId: stringProp("Optional connected workspace id."),
+		}),
+	},
+	{
+		name: "linear_get_issue",
+		description: "Read the current fields and discussion for a Linear issue.",
+		inputSchema: objectSchema(
+			{
+				issue: stringProp("Issue identifier such as ENG-123 or its UUID."),
+				workspaceId: stringProp(
+					"Required only when the identifier is ambiguous.",
+				),
+			},
+			["issue"],
+		),
+	},
+	{
+		name: "linear_add_comment",
+		description: "Post a comment to a Linear issue.",
+		inputSchema: objectSchema(
+			{
+				issue: stringProp("Issue identifier or UUID."),
+				body: stringProp("Markdown comment body."),
+				workspaceId: stringProp(
+					"Required only when the identifier is ambiguous.",
+				),
+			},
+			["issue", "body"],
+		),
+	},
+	{
+		name: "linear_update_issue",
+		description:
+			"Update a Linear issue's title, description, status, priority, assignee, labels, or project. Names must resolve unambiguously.",
+		inputSchema: objectSchema(
+			{
+				issue: stringProp("Issue identifier or UUID."),
+				workspaceId: stringProp(
+					"Required only when the identifier is ambiguous.",
+				),
+				title: stringProp("Replacement title."),
+				description: stringProp("Replacement Markdown description."),
+				status: stringProp("Workflow status name."),
+				priority: numberProp("Linear priority number from 0 through 4.", 4),
+				assignee: {
+					type: ["string", "null"],
+					description: "Assignee name/email, or null to clear.",
+				},
+				labels: {
+					type: "array",
+					items: { type: "string" },
+					description: "Complete replacement label-name list.",
+				},
+				project: {
+					type: ["string", "null"],
+					description: "Project name, or null to clear.",
+				},
+			},
+			["issue"],
+		),
+	},
+] as const satisfies ReadonlyArray<{
+	readonly name: string;
+	readonly description: string;
+	readonly inputSchema: JsonSchemaObject;
+}>;
+
+export const LINEAR_MCP_TOOLS = toolDefs;
+export type LinearToolName = (typeof toolDefs)[number]["name"];
+
+export const isLinearToolName = (name: string): name is LinearToolName =>
+	LINEAR_MCP_TOOLS.some((definition) => definition.name === name);
+
+const mutating = new Set<LinearToolName>([
+	"linear_add_comment",
+	"linear_update_issue",
+]);
+
+export const ensureLinearToolPermission = async (
+	name: LinearToolName,
+	args: Readonly<Record<string, unknown>>,
+	options: LinearPermissionOptions,
+): Promise<void> => {
+	if (!mutating.has(name)) return;
+	const policy = getToolPolicy(
+		"other",
+		options.getRuntimeMode(),
+		options.getPermissionMode(),
+	);
+	if (policy.kind === "auto-deny") {
+		throw new Error(`Linear action blocked in plan mode: ${name}.`);
+	}
+	if (policy.kind === "auto-allow") return;
+	const issue = typeof args.issue === "string" ? args.issue : "issue";
+	const decision = await options.requestPermission(
+		{
+			_tag: "Other",
+			tool: name,
+			summary:
+				name === "linear_add_comment"
+					? `Comment on Linear issue ${issue}`
+					: `Update Linear issue ${issue}`,
+		},
+		{ forcePrompt: false },
+	);
+	if (decision._tag === "Deny")
+		throw new Error(`Permission denied for ${name}.`);
+};
+
+const record = (value: unknown): Record<string, unknown> =>
+	value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+const text = (
+	args: Record<string, unknown>,
+	key: string,
+): string | undefined =>
+	typeof args[key] === "string" && args[key].length > 0
+		? (args[key] as string)
+		: undefined;
+
+const result = (value: ToolResult) =>
+	value.ok
+		? {
+				content: [
+					{ type: "text" as const, text: JSON.stringify(value.data, null, 2) },
+				],
+			}
+		: {
+				content: [{ type: "text" as const, text: value.error }],
+				isError: true as const,
+			};
+
+export const callLinearTool = async (
+	deps: LinearToolDeps,
+	name: LinearToolName,
+	rawArgs: unknown,
+) => {
+	const args = record(rawArgs);
+	const workspaceId = text(args, "workspaceId");
+	const issue = text(args, "issue");
+	if (name === "linear_search_issues") {
+		return result(
+			await deps.searchIssues({ query: text(args, "query"), workspaceId }),
+		);
+	}
+	if (issue === undefined) {
+		return {
+			content: [{ type: "text" as const, text: `${name} requires issue.` }],
+			isError: true as const,
+		};
+	}
+	if (name === "linear_get_issue")
+		return result(await deps.getIssue({ issue, workspaceId }));
+	if (name === "linear_add_comment") {
+		const body = text(args, "body");
+		if (body === undefined)
+			return {
+				content: [
+					{ type: "text" as const, text: "linear_add_comment requires body." },
+				],
+				isError: true as const,
+			};
+		return result(await deps.addComment({ issue, body, workspaceId }));
+	}
+	const update: Parameters<LinearToolDeps["updateIssue"]>[0] = {
+		issue,
+		...(workspaceId === undefined ? {} : { workspaceId }),
+		...(text(args, "title") === undefined
+			? {}
+			: { title: text(args, "title") }),
+		...(text(args, "description") === undefined
+			? {}
+			: { description: text(args, "description") }),
+		...(text(args, "status") === undefined
+			? {}
+			: { status: text(args, "status") }),
+		...(typeof args.priority === "number" ? { priority: args.priority } : {}),
+		...(args.assignee === null || typeof args.assignee === "string"
+			? { assignee: args.assignee }
+			: {}),
+		...(Array.isArray(args.labels) &&
+		args.labels.every((label) => typeof label === "string")
+			? { labels: args.labels as string[] }
+			: {}),
+		...(args.project === null || typeof args.project === "string"
+			? { project: args.project }
+			: {}),
+	};
+	return result(await deps.updateIssue(update));
+};
+
+export const buildLinearTools = (deps: LinearToolDeps) => [
+	tool(
+		"linear_search_issues",
+		LINEAR_MCP_TOOLS[0].description,
+		{ query: z.string().optional(), workspaceId: z.string().optional() },
+		async (args) => result(await deps.searchIssues(args)),
+	),
+	tool(
+		"linear_get_issue",
+		LINEAR_MCP_TOOLS[1].description,
+		{ issue: z.string().min(1), workspaceId: z.string().optional() },
+		async (args) => result(await deps.getIssue(args)),
+	),
+	tool(
+		"linear_add_comment",
+		LINEAR_MCP_TOOLS[2].description,
+		{
+			issue: z.string().min(1),
+			body: z.string().min(1),
+			workspaceId: z.string().optional(),
+		},
+		async (args) => result(await deps.addComment(args)),
+	),
+	tool(
+		"linear_update_issue",
+		LINEAR_MCP_TOOLS[3].description,
+		{
+			issue: z.string().min(1),
+			workspaceId: z.string().optional(),
+			title: z.string().optional(),
+			description: z.string().optional(),
+			status: z.string().optional(),
+			priority: z.number().int().min(0).max(4).optional(),
+			assignee: z.string().nullable().optional(),
+			labels: z.array(z.string()).optional(),
+			project: z.string().nullable().optional(),
+		},
+		async (args) => result(await deps.updateIssue(args)),
+	),
+];

--- a/packages/agents/src/drivers/orchestration-tools.ts
+++ b/packages/agents/src/drivers/orchestration-tools.ts
@@ -7,6 +7,7 @@ import type {
 } from "@zuse/contracts";
 import { z } from "zod";
 import { getToolPolicy } from "../kernel/policy.ts";
+import type { LinearSessionTools } from "./linear-tools.ts";
 import {
 	booleanProp,
 	type JsonSchemaObject,
@@ -182,6 +183,7 @@ export interface OrchestrationPermissionOptions {
 export interface OrchestrationSessionTools {
 	readonly deps: OrchestrationToolDeps;
 	readonly claudeTools: ReturnType<typeof buildOrchestrationTools>;
+	readonly linearTools?: LinearSessionTools;
 }
 
 // ── MCP text-result helpers ─────────────────────────────────────────────────

--- a/packages/agents/src/kernel/provider-mcp-session.ts
+++ b/packages/agents/src/kernel/provider-mcp-session.ts
@@ -41,6 +41,7 @@ export const issueProviderMcpSession = Effect.fn("ProviderMcpSession.issue")(
 					scopes: {
 						browser: true,
 						orchestration: options.orchestrationTools !== null,
+						linear: options.orchestrationTools?.linearTools !== undefined,
 					},
 					ctx: {
 						browser: {
@@ -54,6 +55,16 @@ export const issueProviderMcpSession = Effect.fn("ProviderMcpSession.issue")(
 							: {
 									orchestration: {
 										deps: options.orchestrationTools.deps,
+										requestPermission: options.requestPermission,
+										getRuntimeMode: options.getRuntimeMode,
+										getPermissionMode: options.getPermissionMode,
+									},
+								}),
+						...(options.orchestrationTools?.linearTools === undefined
+							? {}
+							: {
+									linear: {
+										deps: options.orchestrationTools.linearTools.deps,
 										requestPermission: options.requestPermission,
 										getRuntimeMode: options.getRuntimeMode,
 										getPermissionMode: options.getPermissionMode,

--- a/packages/agents/src/kernel/stdio-mcp-fallback.ts
+++ b/packages/agents/src/kernel/stdio-mcp-fallback.ts
@@ -10,6 +10,10 @@ import {
 	startBrowserMcpBridge,
 } from "../drivers/acp/browser-mcp-bridge.ts";
 import {
+	type LinearMcpBridge,
+	startLinearMcpBridge,
+} from "../drivers/acp/linear-mcp-bridge.ts";
+import {
 	type OrchestrationMcpBridge,
 	startOrchestrationMcpBridge,
 } from "../drivers/acp/orchestration-mcp-bridge.ts";
@@ -43,6 +47,7 @@ export const makeStdioMcpFallback = (
 ): StdioMcpFallback => {
 	let browser: BrowserMcpBridge | null = null;
 	let orchestration: OrchestrationMcpBridge | null = null;
+	let linear: LinearMcpBridge | null = null;
 
 	const ensure = async () => {
 		browser ??= await startBrowserMcpBridge({
@@ -61,9 +66,22 @@ export const makeStdioMcpFallback = (
 				getPermissionMode: options.getPermissionMode,
 			});
 		}
+		if (
+			options.orchestrationTools?.linearTools !== undefined &&
+			linear === null
+		) {
+			linear = await startLinearMcpBridge({
+				deps: options.orchestrationTools.linearTools.deps,
+				command: options.command,
+				requestPermission: options.requestPermission,
+				getRuntimeMode: options.getRuntimeMode,
+				getPermissionMode: options.getPermissionMode,
+			});
+		}
 		return [
 			browser.serverConfig,
 			...(orchestration === null ? [] : [orchestration.serverConfig]),
+			...(linear === null ? [] : [linear.serverConfig]),
 		];
 	};
 
@@ -72,14 +90,17 @@ export const makeStdioMcpFallback = (
 		projectConfigToml: () => [
 			...(browser === null ? [] : [browser.projectConfigToml]),
 			...(orchestration === null ? [] : [orchestration.projectConfigToml]),
+			...(linear === null ? [] : [linear.projectConfigToml]),
 		],
 		close: async () => {
 			await Promise.all([
 				...(browser === null ? [] : [browser.close()]),
 				...(orchestration === null ? [] : [orchestration.close()]),
+				...(linear === null ? [] : [linear.close()]),
 			]);
 			browser = null;
 			orchestration = null;
+			linear = null;
 		},
 	};
 };

--- a/packages/agents/src/mcp-gateway/index.ts
+++ b/packages/agents/src/mcp-gateway/index.ts
@@ -20,6 +20,15 @@ import {
 	handleBrowserTool,
 } from "../drivers/browser-mcp-tools.ts";
 import {
+	callLinearTool,
+	ensureLinearToolPermission,
+	isLinearToolName,
+	LINEAR_MCP_SERVER_NAME,
+	LINEAR_MCP_TOOLS,
+	type LinearPermissionOptions,
+	type LinearToolDeps,
+} from "../drivers/linear-tools.ts";
+import {
 	callOrchestrationTool,
 	ensureOrchestrationPermission,
 	isOrchestrationToolName,
@@ -36,12 +45,14 @@ const MAX_LIFETIME_MS = 8 * 60 * 60 * 1_000;
 
 const BROWSER_PATH = `/mcp/${BROWSER_MCP_SERVER_NAME}`;
 const ORCHESTRATION_PATH = `/mcp/${ORCHESTRATION_MCP_SERVER_NAME}`;
+const LINEAR_PATH = `/mcp/${LINEAR_MCP_SERVER_NAME}`;
 
 export interface McpGatewaySessionContext {
 	readonly browser?: BrowserMcpToolOptions;
 	readonly orchestration?: OrchestrationPermissionOptions & {
 		readonly deps: OrchestrationToolDeps;
 	};
+	readonly linear?: LinearPermissionOptions & { readonly deps: LinearToolDeps };
 }
 
 export interface McpGatewayIssueInput {
@@ -49,6 +60,7 @@ export interface McpGatewayIssueInput {
 	readonly scopes: {
 		readonly browser: boolean;
 		readonly orchestration: boolean;
+		readonly linear?: boolean;
 	};
 	readonly ctx: McpGatewaySessionContext;
 }
@@ -58,14 +70,17 @@ export interface McpGatewaySession {
 	readonly endpoints: {
 		readonly browser: string;
 		readonly orchestration: string;
+		readonly linear: string;
 	};
 	readonly httpServerConfigs: {
 		readonly browser: AcpHttpMcpServerConfig;
 		readonly orchestration: AcpHttpMcpServerConfig;
+		readonly linear: AcpHttpMcpServerConfig;
 	};
 	readonly codexServerConfigs: {
 		readonly browser: CodexHttpMcpServerConfig;
 		readonly orchestration: CodexHttpMcpServerConfig;
+		readonly linear: CodexHttpMcpServerConfig;
 	};
 	readonly close: () => Promise<void>;
 }
@@ -94,6 +109,7 @@ interface RegistryRecord {
 	readonly scopes: {
 		readonly browser: boolean;
 		readonly orchestration: boolean;
+		readonly linear?: boolean;
 	};
 	readonly ctx: McpGatewaySessionContext;
 	readonly lastUsedAt: number;
@@ -120,7 +136,7 @@ export const parseMcpBearerAuthorization = (
 ): string | null => {
 	if (authorization === undefined) return null;
 	const match = /^Bearer ([A-Za-z0-9_-]+)$/u.exec(authorization);
-	return match ? match[1]! : null;
+	return match?.[1] ?? null;
 };
 
 const pruneExpired = (now = Date.now()): void => {
@@ -134,7 +150,7 @@ const pruneExpired = (now = Date.now()): void => {
 
 const resolveRecord = (
 	rawToken: string,
-	scope: "browser" | "orchestration",
+	scope: "browser" | "orchestration" | "linear",
 ): RegistryRecord | null => {
 	pruneExpired();
 	const hash = tokenHash(rawToken);
@@ -251,10 +267,43 @@ const buildOrchestrationServer = (
 	return server;
 };
 
+const buildLinearServer = (
+	ctx: LinearPermissionOptions & { readonly deps: LinearToolDeps },
+): Server => {
+	const server = new Server(
+		{ name: LINEAR_MCP_SERVER_NAME, version: "0.0.1" },
+		{ capabilities: { tools: {} } },
+	);
+	server.setRequestHandler(ListToolsRequestSchema, async () => ({
+		tools: LINEAR_MCP_TOOLS.map((definition) => ({
+			name: definition.name,
+			description: definition.description,
+			inputSchema: definition.inputSchema,
+		})),
+	}));
+	server.setRequestHandler(CallToolRequestSchema, async (request) => {
+		const name = request.params.name;
+		if (!isLinearToolName(name)) {
+			return {
+				content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+				isError: true,
+			};
+		}
+		const args = asJsonObject(request.params.arguments ?? {});
+		try {
+			await ensureLinearToolPermission(name, args, ctx);
+			return await callLinearTool(ctx.deps, name, args);
+		} catch (cause) {
+			return toolResultFromError(name, cause);
+		}
+	});
+	return server;
+};
+
 const handleMcpRequest = async (
 	req: IncomingMessage,
 	res: ServerResponse,
-	scope: "browser" | "orchestration",
+	scope: "browser" | "orchestration" | "linear",
 	record: RegistryRecord,
 ): Promise<void> => {
 	const mcpServer =
@@ -262,9 +311,13 @@ const handleMcpRequest = async (
 			? record.ctx.browser === undefined
 				? null
 				: buildBrowserServer(record.ctx.browser)
-			: record.ctx.orchestration === undefined
-				? null
-				: buildOrchestrationServer(record.ctx.orchestration);
+			: scope === "orchestration"
+				? record.ctx.orchestration === undefined
+					? null
+					: buildOrchestrationServer(record.ctx.orchestration)
+				: record.ctx.linear === undefined
+					? null
+					: buildLinearServer(record.ctx.linear);
 	if (mcpServer === null) {
 		writeText(res, 404, "not found");
 		return;
@@ -288,7 +341,9 @@ const requestHandler = (req: IncomingMessage, res: ServerResponse): void => {
 				? "browser"
 				: path === ORCHESTRATION_PATH
 					? "orchestration"
-					: null;
+					: path === LINEAR_PATH
+						? "linear"
+						: null;
 		if (scope === null) {
 			writeText(res, 404, "not found");
 			return;
@@ -366,10 +421,11 @@ export const issueMcpGatewaySession = async (
 	recordsByHash.set(hash, record);
 	const browser = `http://127.0.0.1:${port}${BROWSER_PATH}`;
 	const orchestration = `http://127.0.0.1:${port}${ORCHESTRATION_PATH}`;
+	const linear = `http://127.0.0.1:${port}${LINEAR_PATH}`;
 	const authorizationHeader = `Bearer ${token}`;
 	return {
 		token,
-		endpoints: { browser, orchestration },
+		endpoints: { browser, orchestration, linear },
 		httpServerConfigs: {
 			browser: {
 				type: "http",
@@ -383,6 +439,12 @@ export const issueMcpGatewaySession = async (
 				url: orchestration,
 				headers: [{ name: "Authorization", value: authorizationHeader }],
 			},
+			linear: {
+				type: "http",
+				name: LINEAR_MCP_SERVER_NAME,
+				url: linear,
+				headers: [{ name: "Authorization", value: authorizationHeader }],
+			},
 		},
 		codexServerConfigs: {
 			browser: {
@@ -392,6 +454,11 @@ export const issueMcpGatewaySession = async (
 			},
 			orchestration: {
 				url: orchestration,
+				bearer_token_env_var: "ZUSE_MCP_TOKEN",
+				enabled: true,
+			},
+			linear: {
+				url: linear,
 				bearer_token_env_var: "ZUSE_MCP_TOKEN",
 				enabled: true,
 			},

--- a/packages/agents/test/unit/linear-tools.test.ts
+++ b/packages/agents/test/unit/linear-tools.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	callLinearTool,
+	ensureLinearToolPermission,
+	type LinearToolDeps,
+} from "../../src/drivers/linear-tools.ts";
+
+const deps: LinearToolDeps = {
+	searchIssues: vi.fn(async () => ({ ok: true as const, data: [] })),
+	getIssue: vi.fn(async () => ({
+		ok: true as const,
+		data: { identifier: "ENG-1" },
+	})),
+	addComment: vi.fn(async () => ({
+		ok: true as const,
+		data: { id: "comment-1" },
+	})),
+	updateIssue: vi.fn(async () => ({
+		ok: true as const,
+		data: { identifier: "ENG-1" },
+	})),
+};
+
+describe("Linear connector tools", () => {
+	it("executes reads without a mutation permission", async () => {
+		const requestPermission = vi.fn();
+		await ensureLinearToolPermission(
+			"linear_get_issue",
+			{ issue: "ENG-1" },
+			{
+				requestPermission,
+				getRuntimeMode: () => "full-access",
+				getPermissionMode: () => "default",
+			},
+		);
+		expect(requestPermission).not.toHaveBeenCalled();
+	});
+
+	it("denies mutations in plan mode", async () => {
+		await expect(
+			ensureLinearToolPermission(
+				"linear_update_issue",
+				{ issue: "ENG-1" },
+				{
+					requestPermission: vi.fn(),
+					getRuntimeMode: () => "full-access",
+					getPermissionMode: () => "plan",
+				},
+			),
+		).rejects.toThrow("blocked in plan mode");
+	});
+
+	it("passes broad update fields through the public tool seam", async () => {
+		const result = await callLinearTool(deps, "linear_update_issue", {
+			issue: "ENG-1",
+			status: "Done",
+			labels: ["bug"],
+		});
+		expect(result.isError).not.toBe(true);
+		expect(deps.updateIssue).toHaveBeenCalledWith({
+			issue: "ENG-1",
+			status: "Done",
+			labels: ["bug"],
+		});
+	});
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,6 +15,7 @@ export * from "./handshake.ts";
 export * from "./ids.ts";
 export * from "./keybindings.ts";
 export * from "./keybindings-parse.ts";
+export * from "./linear.ts";
 export * from "./pairing.ts";
 export * from "./permission.ts";
 export * from "./ping.ts";

--- a/packages/contracts/src/linear.ts
+++ b/packages/contracts/src/linear.ts
@@ -31,8 +31,11 @@ export class LinearIssueSummary extends Schema.Class<LinearIssueSummary>(
 	identifier: Schema.String,
 	title: Schema.String,
 	state: Schema.String,
+	stateType: Schema.String,
+	stateColor: Schema.NullOr(Schema.String),
 	priority: Schema.Number,
 	assignee: Schema.NullOr(Schema.String),
+	assigneeAvatarUrl: Schema.NullOr(Schema.String),
 	labels: Schema.Array(Schema.String),
 	updatedAt: Schema.DateFromString,
 }) {}

--- a/packages/contracts/src/linear.ts
+++ b/packages/contracts/src/linear.ts
@@ -1,6 +1,7 @@
 import { Schema } from "effect";
 import { Rpc } from "effect/unstable/rpc";
 
+import { AttachmentRef } from "./composer.ts";
 import { SessionId } from "./session.ts";
 
 export class LinearConnection extends Schema.Class<LinearConnection>(
@@ -99,6 +100,7 @@ export const LinearPrepareContextRpc = Rpc.make("linear.prepareContext", {
 	}),
 	success: Schema.Struct({
 		files: Schema.Array(LinearContextFile),
+		attachments: Schema.Array(AttachmentRef),
 		warnings: Schema.Array(LinearContextWarning),
 	}),
 	error: LinearIntegrationError,

--- a/packages/contracts/src/linear.ts
+++ b/packages/contracts/src/linear.ts
@@ -1,0 +1,102 @@
+import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
+
+import { SessionId } from "./session.ts";
+
+export class LinearConnection extends Schema.Class<LinearConnection>(
+	"LinearConnection",
+)({
+	workspaceId: Schema.String,
+	workspaceName: Schema.String,
+	workspaceKey: Schema.String,
+	viewerName: Schema.String,
+	viewerEmail: Schema.String,
+	connectedAt: Schema.DateFromString,
+}) {}
+
+export class LinearIssueRef extends Schema.Class<LinearIssueRef>(
+	"LinearIssueRef",
+)({
+	workspaceId: Schema.String,
+	issueId: Schema.String,
+	identifier: Schema.String,
+}) {}
+
+export class LinearIssueSummary extends Schema.Class<LinearIssueSummary>(
+	"LinearIssueSummary",
+)({
+	workspaceId: Schema.String,
+	workspaceName: Schema.String,
+	issueId: Schema.String,
+	identifier: Schema.String,
+	title: Schema.String,
+	state: Schema.String,
+	priority: Schema.Number,
+	assignee: Schema.NullOr(Schema.String),
+	labels: Schema.Array(Schema.String),
+	updatedAt: Schema.DateFromString,
+}) {}
+
+export class LinearContextFile extends Schema.Class<LinearContextFile>(
+	"LinearContextFile",
+)({
+	issue: LinearIssueRef,
+	relPath: Schema.String,
+	absPath: Schema.String,
+}) {}
+
+export class LinearContextWarning extends Schema.Class<LinearContextWarning>(
+	"LinearContextWarning",
+)({
+	issue: LinearIssueRef,
+	message: Schema.String,
+}) {}
+
+export class LinearIntegrationError extends Schema.TaggedErrorClass<LinearIntegrationError>()(
+	"LinearIntegrationError",
+	{ reason: Schema.String },
+) {}
+
+export const LinearListConnectionsRpc = Rpc.make("linear.listConnections", {
+	payload: Schema.Struct({}),
+	success: Schema.Array(LinearConnection),
+	error: LinearIntegrationError,
+});
+
+export const LinearConnectRpc = Rpc.make("linear.connect", {
+	payload: Schema.Struct({}),
+	success: LinearConnection,
+	error: LinearIntegrationError,
+});
+
+export const LinearDisconnectRpc = Rpc.make("linear.disconnect", {
+	payload: Schema.Struct({ workspaceId: Schema.String }),
+	success: Schema.Void,
+	error: LinearIntegrationError,
+});
+
+export const LinearListIssuesRpc = Rpc.make("linear.listIssues", {
+	payload: Schema.Struct({
+		query: Schema.optional(Schema.String),
+		workspaceIds: Schema.optional(Schema.Array(Schema.String)),
+		cursor: Schema.optional(Schema.String),
+	}),
+	success: Schema.Struct({
+		issues: Schema.Array(LinearIssueSummary),
+		nextCursor: Schema.NullOr(Schema.String),
+	}),
+	error: LinearIntegrationError,
+});
+
+export const LinearPrepareContextRpc = Rpc.make("linear.prepareContext", {
+	payload: Schema.Struct({
+		sessionId: SessionId,
+		issues: Schema.Array(LinearIssueRef),
+		rootPath: Schema.optional(Schema.String),
+	}),
+	success: Schema.Struct({
+		files: Schema.Array(LinearContextFile),
+		warnings: Schema.Array(LinearContextWarning),
+	}),
+	error: LinearIntegrationError,
+});

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -84,6 +84,13 @@ import {
 	KeybindingsStreamRpc,
 } from "./keybindings.ts";
 import {
+	LinearConnectRpc,
+	LinearDisconnectRpc,
+	LinearListConnectionsRpc,
+	LinearListIssuesRpc,
+	LinearPrepareContextRpc,
+} from "./linear.ts";
+import {
 	PairingListTokensRpc,
 	PairingRevokeTokenRpc,
 	PairingStartRpc,
@@ -203,6 +210,11 @@ export const MemoizeRpcs = RpcGroup.make(
 	AuthSignInRpc,
 	AuthSignOutRpc,
 	AuthSessionChangesRpc,
+	LinearListConnectionsRpc,
+	LinearConnectRpc,
+	LinearDisconnectRpc,
+	LinearListIssuesRpc,
+	LinearPrepareContextRpc,
 	PairingStartRpc,
 	PairingListTokensRpc,
 	PairingRevokeTokenRpc,

--- a/packages/contracts/test/unit/linear.test.ts
+++ b/packages/contracts/test/unit/linear.test.ts
@@ -1,0 +1,57 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+import {
+	LinearConnection,
+	LinearIssueRef,
+	LinearIssueSummary,
+} from "../../src/linear.ts";
+
+describe("Linear wire contracts", () => {
+	it("round-trips workspace-qualified issue references", () => {
+		const encoded = {
+			workspaceId: "workspace-1",
+			issueId: "issue-1",
+			identifier: "ENG-123",
+		};
+		const decoded = Schema.decodeUnknownSync(LinearIssueRef)(encoded);
+		expect(Schema.encodeSync(LinearIssueRef)(decoded)).toEqual(encoded);
+	});
+
+	it("keeps duplicate tickers distinct across workspaces", () => {
+		const first = LinearIssueSummary.make({
+			workspaceId: "workspace-1",
+			workspaceName: "Acme",
+			issueId: "issue-1",
+			identifier: "ENG-123",
+			title: "First",
+			state: "Todo",
+			priority: 2,
+			assignee: "Ada",
+			labels: [],
+			updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+		});
+		const second = LinearIssueSummary.make({
+			...first,
+			workspaceId: "workspace-2",
+			workspaceName: "Beta",
+			issueId: "issue-2",
+		});
+		expect(`${first.workspaceId}:${first.issueId}`).not.toBe(
+			`${second.workspaceId}:${second.issueId}`,
+		);
+	});
+
+	it("never includes OAuth tokens in renderer-visible connections", () => {
+		const connection = LinearConnection.make({
+			workspaceId: "workspace-1",
+			workspaceName: "Acme",
+			workspaceKey: "acme",
+			viewerName: "Ada",
+			viewerEmail: "ada@example.com",
+			connectedAt: new Date("2026-01-01T00:00:00.000Z"),
+		});
+		const encoded = Schema.encodeSync(LinearConnection)(connection);
+		expect(JSON.stringify(encoded)).not.toMatch(/access|refresh|token/i);
+	});
+});

--- a/packages/contracts/test/unit/linear.test.ts
+++ b/packages/contracts/test/unit/linear.test.ts
@@ -26,8 +26,11 @@ describe("Linear wire contracts", () => {
 			identifier: "ENG-123",
 			title: "First",
 			state: "Todo",
+			stateType: "unstarted",
+			stateColor: "#6b7280",
 			priority: 2,
 			assignee: "Ada",
+			assigneeAvatarUrl: "https://example.com/ada.png",
 			labels: [],
 			updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 		});
@@ -40,6 +43,30 @@ describe("Linear wire contracts", () => {
 		expect(`${first.workspaceId}:${first.issueId}`).not.toBe(
 			`${second.workspaceId}:${second.issueId}`,
 		);
+	});
+
+	it("preserves issue status and assignee presentation metadata", () => {
+		const decoded = Schema.decodeUnknownSync(LinearIssueSummary)({
+			workspaceId: "workspace-1",
+			workspaceName: "Acme",
+			issueId: "issue-1",
+			identifier: "ENG-123",
+			title: "First",
+			state: "In Progress",
+			stateType: "started",
+			stateColor: "#f59e0b",
+			priority: 2,
+			assignee: "Ada Lovelace",
+			assigneeAvatarUrl: "https://example.com/ada.png",
+			labels: [],
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		});
+		const encoded = Schema.encodeSync(LinearIssueSummary)(decoded);
+		expect(encoded).toMatchObject({
+			stateType: "started",
+			stateColor: "#f59e0b",
+			assigneeAvatarUrl: "https://example.com/ada.png",
+		});
 	});
 
 	it("never includes OAuth tokens in renderer-visible connections", () => {

--- a/turbo.json
+++ b/turbo.json
@@ -6,12 +6,12 @@
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
 			// Turbo runs in strict env mode: env vars not listed here are stripped
-			// from the task before it runs. tsdown inlines the public WorkOS client
-			// id from process.env.WORKOS_CLIENT_ID at build time, so it must survive
-			// into the build task (CI supplies it; empty locally is fine). Listing it
-			// under `env` also makes it part of the cache key, so changing the id
-			// busts stale build output.
-			"env": ["WORKOS_CLIENT_ID"],
+			// from the task before it runs. tsdown reads public OAuth client ids from
+			// process.env at build time, so they must
+			// survive into the build task (CI supplies them; empty locally is fine).
+			// Listing them under `env` also makes them part of the cache key, so
+			// changing either id busts stale build output.
+			"env": ["WORKOS_CLIENT_ID", "LINEAR_CLIENT_ID"],
 			"outputs": [".next/**", "!.next/cache/**", "dist/**", "dist-electron/**"]
 		},
 		"lint": {


### PR DESCRIPTION
## Summary

- add multi-workspace Linear OAuth connections with secure credential storage, refresh handling, workspace management, issue listing, and workspace-wide search
- add multi-ticket session staging with combined and separate-thread launches that preserve provider, model, runtime, permission, and worktree preferences
- materialize complete issue context under `.context/linear`, including comments and safely downloaded images
- expose shared permission-aware Linear read and mutation tools to supported agent providers
- attach downloaded ticket images as native vision inputs while retaining local Markdown references and preview support

## Why

Users can now start coding sessions directly from one or more Linear tickets. The session receives durable local context, agents can keep issue state and comments current through the existing permission model, and multiple tickets can be handled as one PR or independent sessions.

Follow-up fixes in this branch use the broadly available issue filtering API for workspace search, resolve local ticket images through the secure desktop asset protocol, default Markdown files to Preview, and send downloaded images through the provider attachment pipeline so vision-capable agents can inspect them.

## Validation

- `bun run check-types` — 22 targets passed
- renderer unit suite — 117 tests passed
- server unit suite — 95 tests passed
- contracts unit suite — 67 tests passed
- applicable Biome checks passed
- `bun run build:desktop` passed
- Electron image protocol probe loaded the staged test image at its full 2490px width

## Configuration

Packaged builds must provide `LINEAR_CLIENT_ID` and register the supported desktop OAuth callback URL.
