### PR TITLE
Fix image previews in the file viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A chat-first desktop app for developers who work with AI coding agents. Wraps Cl
 - File tree with Material Icon Theme file-type icons
 - Click-to-open any file in the main pane
 - CodeMirror 6 editor — TS/TSX, JS, JSON, Markdown, HTML, CSS, Python, Rust, Go
+- Inline previews for PNG, JPEG, GIF, WebP, and AVIF images
 - `Cmd+S` to save, mtime-based optimistic concurrency
 
 ### Layout & UI

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -7,6 +7,10 @@ import type { CodeAnnotation, GitDiffResult } from "@zuse/contracts";
 import { cn } from "~/lib/utils";
 import { ShimmerText } from "~/components/ui/shimmer-text";
 import { classifyGit } from "../lib/git-rpc.ts";
+import {
+  bytesForImageContent,
+  imageMimeForFile,
+} from "../lib/image-preview.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { GitInitCta } from "./git-init-cta.tsx";
 import {
@@ -155,6 +159,10 @@ export function FileEditor() {
     return <ImageBody src={openFile.src} name={openFile.name} />;
   }
 
+  if (imageMimeForFile(openFile.name) !== null) {
+    return <FileImageBody openFile={openFile} />;
+  }
+
   const canPreview = isPreviewableFileName(openFile.name);
   // External files have no git/folder context, so they're edit/preview only.
   const isExternal = openFile.kind === "external";
@@ -203,6 +211,74 @@ function ImageBody({ src, name }: { src: string; name: string }) {
       />
     </div>
   );
+}
+
+type FileImageState =
+  | { status: "loading" }
+  | { status: "ready"; src: string }
+  | { status: "error"; reason: string };
+
+/** Loads project and external images through the same path-validated fs RPC
+ * as the editor, then gives the browser a short-lived local object URL. */
+function FileImageBody({ openFile }: { openFile: EditableFile }) {
+  const [state, setState] = useState<FileImageState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setState({ status: "loading" });
+
+    void (async () => {
+      try {
+        const client = await getRpcClient();
+        const result =
+          openFile.kind === "external"
+            ? await Effect.runPromise(
+                client["fs.readExternalFile"]({ path: openFile.absPath }),
+              )
+            : await Effect.runPromise(
+                client["fs.readFile"]({
+                  folderId: openFile.folderId,
+                  path: openFile.path,
+                  worktreeId: openFile.worktreeId,
+                }),
+              );
+        if (cancelled) return;
+        const mimeType = imageMimeForFile(openFile.name);
+        if (mimeType === null) return;
+        const bytes = bytesForImageContent(result);
+        objectUrl = URL.createObjectURL(
+          new Blob([bytes.slice().buffer], { type: mimeType }),
+        );
+        setState({ status: "ready", src: objectUrl });
+      } catch (err) {
+        if (!cancelled) {
+          setState({ status: "error", reason: formatError(err) });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
+    };
+  }, [openFile]);
+
+  if (state.status === "loading") {
+    return (
+      <Placeholder>
+        <ShimmerText>Loading image…</ShimmerText>
+      </Placeholder>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <Placeholder>
+        <span className="text-destructive">{state.reason}</span>
+      </Placeholder>
+    );
+  }
+  return <ImageBody src={state.src} name={openFile.name} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/renderer/src/lib/image-preview.ts
+++ b/apps/renderer/src/lib/image-preview.ts
@@ -1,0 +1,25 @@
+const IMAGE_MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
+  ".avif": "image/avif",
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+};
+
+export const imageMimeForFile = (name: string): string | null => {
+  const lower = name.toLowerCase();
+  const dot = lower.lastIndexOf(".");
+  return dot === -1
+    ? null
+    : (IMAGE_MIME_BY_EXTENSION[lower.slice(dot)] ?? null);
+};
+
+/** Strict UTF-8 decoding can succeed for some valid image files. Re-encoding
+ * that text preserves the original bytes, so both fs result variants preview. */
+export const bytesForImageContent = (
+  result:
+    | { readonly kind: "binary"; readonly bytes: Uint8Array }
+    | { readonly kind: "text"; readonly content: string },
+): Uint8Array =>
+  result.kind === "binary" ? result.bytes : new TextEncoder().encode(result.content);

--- a/apps/renderer/test/unit/image-preview.test.ts
+++ b/apps/renderer/test/unit/image-preview.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bytesForImageContent,
+  imageMimeForFile,
+} from "../../src/lib/image-preview.ts";
+
+describe("image preview helpers", () => {
+  it("recognizes supported image extensions case-insensitively", () => {
+    expect(imageMimeForFile("preview.JPG")).toBe("image/jpeg");
+    expect(imageMimeForFile("animation.GIF")).toBe("image/gif");
+    expect(imageMimeForFile("diagram.svg")).toBeNull();
+  });
+
+  it("preserves binary image bytes", () => {
+    const bytes = new Uint8Array([0, 255, 1, 2]);
+    expect(bytesForImageContent({ kind: "binary", bytes })).toBe(bytes);
+  });
+
+  it("restores image bytes that passed strict UTF-8 decoding", () => {
+    const gifHeader = "GIF89a";
+    expect(
+      bytesForImageContent({ kind: "text", content: gifHeader }),
+    ).toEqual(new TextEncoder().encode(gifHeader));
+  });
+});

--- a/apps/server/src/fs/layers/fs-service.ts
+++ b/apps/server/src/fs/layers/fs-service.ts
@@ -284,7 +284,7 @@ export const FsServiceLive = Layer.effect(
             size,
           };
         } catch {
-          return { kind: "binary" as const, size };
+          return { kind: "binary" as const, bytes, size };
         }
       });
 
@@ -492,7 +492,7 @@ export const FsServiceLive = Layer.effect(
             size,
           };
         } catch {
-          return { kind: "binary" as const, size };
+          return { kind: "binary" as const, bytes, size };
         }
       });
 

--- a/packages/contracts/src/fs.ts
+++ b/packages/contracts/src/fs.ts
@@ -152,8 +152,8 @@ export const FsWatchTreeRpc = Rpc.make("fs.watchTree", {
 /**
  * The shape returned by `fs.readFile`. Text files come back with their
  * UTF-8 contents and the modification time used as an optimistic-concurrency
- * token by `fs.writeFile`. Files that fail UTF-8 decoding return as
- * `kind: "binary"` so the editor can render a placeholder instead of mojibake.
+ * token by `fs.writeFile`. Files that fail UTF-8 decoding return their bytes as
+ * `kind: "binary"` so supported formats can be previewed without another read.
  */
 export const FsFileContent = Schema.Union([
   Schema.Struct({
@@ -164,6 +164,7 @@ export const FsFileContent = Schema.Union([
   }),
   Schema.Struct({
     kind: Schema.Literal("binary"),
+    bytes: Schema.Uint8ArrayFromBase64,
     size: Schema.Number,
   }),
 ]);

--- a/packages/contracts/test/unit/schema.test.ts
+++ b/packages/contracts/test/unit/schema.test.ts
@@ -9,6 +9,7 @@ import {
 	defaultModelEnabledByProvider,
 	defaultModelFor,
 	GitBranchInfo,
+	FsFileContent,
 	isModelVisible,
 	Message,
 	MODELS_BY_PROVIDER,
@@ -35,6 +36,16 @@ const roundTrip = <A, I>(schema: Schema.Codec<A, I>, encoded: I): void => {
 	const reEncoded = Schema.encodeSync(schema)(decoded);
 	expect(reEncoded).toEqual(encoded);
 };
+
+describe("FsFileContent round-trip", () => {
+	it("preserves binary bytes over the wire", () => {
+		roundTrip(FsFileContent, {
+			kind: "binary",
+			bytes: "AAEC/w==",
+			size: 4,
+		});
+	});
+});
 
 describe("AgentEvent round-trips", () => {
 	const cases: ReadonlyArray<{ name: string; encoded: unknown }> = [

--- a/specs/0.02-MVP/README.md
+++ b/specs/0.02-MVP/README.md
@@ -18,8 +18,8 @@ click-to-open, and a minimal editor that can save changes back to disk.
   Rust/Go), dirty-dot indicator, `Cmd/Ctrl+S` to save.
 - **Conflict-aware writes** via mtime-based optimistic concurrency: the
   server rejects writes if the file changed on disk since we read it.
-- **Binary / oversize guard**: files >5 MB or non-UTF-8 render a placeholder
-  instead of garbled text.
+- **Image preview and binary guard**: supported raster images render inline;
+  other non-UTF-8 files and files over 5 MB render a placeholder.
 
 ## What's deliberately deferred
 

--- a/specs/0.02-MVP/features/file-viewer.md
+++ b/specs/0.02-MVP/features/file-viewer.md
@@ -82,9 +82,9 @@ minimal editor.
 
 - Server caps reads at 5 MB; over the cap returns `FsTooLargeError`.
 - Server attempts UTF-8 decode; if it fails, returns
-  `{ kind: "binary", size }`.
-- Editor renders a "Binary file (N bytes)" placeholder; `Cmd+S` is
-  no-oped while in binary mode.
+  `{ kind: "binary", bytes, size }`.
+- Supported raster images render inline. Other binary files retain the
+  "Binary file (N bytes)" placeholder; `Cmd+S` is no-oped in binary mode.
 
 ## RPC contracts
 
@@ -94,7 +94,7 @@ Added to `packages/contracts/src/fs.ts`:
 // fs.readFile
 payload: { folderId, path }
 success: { kind: "text", content, mtime, size }
-       | { kind: "binary", size }
+       | { kind: "binary", bytes, size }
 error:   FsFolderNotFoundError | FsPathOutsideError
        | FsReadError | FsTooLargeError
 
@@ -176,7 +176,8 @@ A5. Edit and `Cmd+S` writes to disk; dirty-dot clears; `git diff`
 A6. External edit + in-app `Cmd+S` produces a conflict toast and
     preserves the user's in-editor changes.
 
-A7. Opening a `.png` shows the binary placeholder; `Cmd+S` is a no-op.
+A7. Opening a supported raster image shows it inline without exposing its
+    local path to the renderer.
 
 A8. Switching projects in the left sidebar closes the file tab and
     selects the chat tab.


### PR DESCRIPTION
## Summary

- Preview PNG, JPEG, GIF, WebP, and AVIF files directly in the file viewer.
- Transport binary bytes through the existing path-validated filesystem RPC and release temporary object URLs on tab changes.
- Handle image files whose bytes also form valid UTF-8, and keep unsupported binaries on the existing placeholder.
- Update the file-viewer specification for the new behavior.

## Test coverage

- Added unit coverage for MIME detection, binary byte preservation, UTF-8-decodable image bytes, and RPC schema round-tripping.
- Renderer: 25 files, 124 tests passed.
- Contracts: 2 files, 64 tests passed.

## Verification

- Renderer, server, and contracts type checks passed.
- Biome lint passed for changed source and test files.
- Renderer production build passed.
- `git diff --check` passed.

## Review

- Scope matches the reported image-preview failure.
- No prompt-related files changed; evals were not applicable.