### PR TITLE
Configure agent workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,20 @@ If a tradeoff is required, choose correctness and robustness over short-term con
 
 - When making UI or UX decisions, explicitly use the `emil-design-engineering` skill. It helps keep the product fast, accessible, consistent, and polished.
 
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues; external pull requests are not a triage request surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the standard `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix` labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This monorepo uses a multi-context domain-documentation layout. See `docs/agents/domain.md`.
+
 ## Workspace Boundaries
 
 - `apps/desktop` owns the Electron shell and native desktop integration; `apps/renderer` owns the desktop UI; `apps/server` owns backend composition, transports, persistence wiring, sessions, and IPC.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,21 @@
+# Domain docs
+
+This repository uses a multi-context domain-documentation layout. A root `CONTEXT-MAP.md`, when present, points to the relevant context documents under `apps/` and `packages/`.
+
+## Before exploring
+
+- Read the root `CONTEXT-MAP.md` when it exists, then read each linked `CONTEXT.md` relevant to the work.
+- Read relevant system-wide decisions under `docs/adr/`.
+- Read relevant context-specific decisions in an app or package's `docs/adr/` directory.
+
+If these files do not exist, proceed silently. Domain-modeling workflows create them when terminology or decisions are actually resolved.
+
+## Vocabulary
+
+Use the terms defined in the relevant `CONTEXT.md` in issue titles, plans, hypotheses, tests, and implementation notes. Avoid introducing synonyms for concepts the glossary already names.
+
+If a needed concept is absent, reconsider whether it belongs to the domain or record the gap for a domain-modeling session.
+
+## Architectural decisions
+
+Surface any conflict with an existing architectural decision explicitly instead of silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,33 @@
+# Issue tracker: GitHub
+
+Issues and planning artifacts for this repository live in GitHub Issues. Use the `gh` CLI for all operations and infer the repository from the current checkout.
+
+## Conventions
+
+- Create an issue with `gh issue create`.
+- Read an issue and its discussion with `gh issue view <number> --comments`.
+- List and filter issues with `gh issue list --json ...`.
+- Comment with `gh issue comment <number>`.
+- Apply or remove labels with `gh issue edit <number> --add-label ...` or `--remove-label ...`.
+- Close an issue with `gh issue close <number>`.
+
+## Pull requests as a triage surface
+
+External pull requests are not treated as requests by the triage workflow.
+
+## Skill operations
+
+- When a skill says to publish to the issue tracker, create a GitHub issue.
+- When a skill says to fetch a ticket, use `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+The map is a GitHub issue labelled `wayfinder:map`. Its tickets are child issues linked through GitHub sub-issues.
+
+- **Child ticket:** Create an issue with one `wayfinder:<type>` label (`research`, `prototype`, `grilling`, or `task`), then link it through GitHub's sub-issues API. If sub-issues are unavailable, add the child to a task list in the map and put `Part of #<map>` at the top of the child body.
+- **Blocking:** Use GitHub's native issue dependencies. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-database-id>`. Obtain the database ID with `gh api repos/<owner>/<repo>/issues/<number> --jq .id`. If dependencies are unavailable, use a `Blocked by: #<number>` line in the child body.
+- **Frontier:** List the map's open children in map order, then exclude assigned tickets and tickets with open blockers. The first remaining ticket is the next frontier ticket.
+- **Claim:** Assign the ticket before investigation with `gh issue edit <number> --add-assignee @me`.
+- **Resolve:** Post the answer as a resolution comment, close the ticket, and append a one-line gist with a link under the map's `Decisions so far` section.
+
+GitHub reports open dependency counts through `issue_dependencies_summary.blocked_by`; a ticket is unblocked when that count is zero.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage labels
+
+The engineering skills use five canonical triage roles. Their repository labels are:
+
+| Canonical role | Repository label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | A maintainer needs to evaluate the issue |
+| `needs-info` | `needs-info` | Waiting for more information from the reporter |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and ready for an autonomous agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation or judgment |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill names a triage role, use its corresponding repository label.


### PR DESCRIPTION
## What changed

- Documented GitHub Issues as the repository tracker and recorded its Wayfinder operations.
- Added the canonical triage-label mapping.
- Added multi-context domain-documentation consumer guidance.
- Linked these repository agent conventions from `AGENTS.md`.

## Why

Engineering planning skills need one durable source of truth for issue operations, triage vocabulary, and domain-document locations. This configuration makes those workflows predictable across sessions.

## Impact

Documentation and agent guidance only. No application behavior changes.

## Validation

- `git diff --cached --check`
- Reviewed the staged scope: four documentation files, 81 additions.
- Biome, type checks, and behavior tests are not applicable because no source files changed.
