### PR TITLE
Add native MCP discovery and authentication

### DIFF
--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -133,6 +133,7 @@ import { ProjectPlanTray } from "./composer/project-plan-tray.tsx";
 import { QueueTray } from "./composer/queue-tray.tsx";
 import { SlashCommandPopover } from "./composer/slash-command-popover.tsx";
 import { TrayPill, trayPillActionClass } from "./composer/tray-pill.tsx";
+import { McpPopover } from "./mcp-popover.tsx";
 import { ModelPicker } from "./model-picker.tsx";
 import { resetLabel, StickMeter } from "./usage/usage-meter.tsx";
 
@@ -1221,6 +1222,10 @@ export function ChatComposer({
                     current={session.permissionMode}
                   />
                 )}
+                <McpPopover
+                  projectId={session.projectId}
+                  providerId={session.providerId}
+                />
               </div>
               <div className="flex items-center gap-2">
                 {!isDraft ? <ContextStatusPopover session={session} /> : null}

--- a/apps/renderer/src/components/mcp-popover.tsx
+++ b/apps/renderer/src/components/mcp-popover.tsx
@@ -309,7 +309,7 @@ export function McpPopover({
 			<PopoverPopup
 				side="top"
 				align="start"
-				className="w-80 [&_[data-slot=popover-viewport]]:!h-auto [&_[data-slot=popover-viewport]]:!overflow-hidden [&_[data-slot=popover-viewport]]:flex [&_[data-slot=popover-viewport]]:max-h-[min(var(--available-height),28rem)] [&_[data-slot=popover-viewport]]:flex-col [&_[data-slot=popover-viewport]]:p-px [&_[data-slot=popover-viewport]]:[--viewport-inline-padding:1px]"
+				className="w-80 [&_[data-slot=popover-viewport]]:!overflow-hidden [&_[data-slot=popover-viewport]]:p-px [&_[data-slot=popover-viewport]]:[--viewport-inline-padding:1px]"
 			>
 				<div className="flex h-8 shrink-0 items-center justify-between border-border/40 border-b px-2">
 					<span className="text-[13px] font-medium text-foreground">MCPs</span>
@@ -329,7 +329,7 @@ export function McpPopover({
 						/>
 					</button>
 				</div>
-				<div className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain">
+				<div className="max-h-[min(24rem,calc(var(--available-height)-4rem))] overflow-y-auto overscroll-y-contain">
 					{topLevel.length === 0 ? (
 						<p className="px-2 py-2.5 text-[12px] leading-relaxed text-muted-foreground">
 							No MCP servers discovered.

--- a/apps/renderer/src/components/mcp-popover.tsx
+++ b/apps/renderer/src/components/mcp-popover.tsx
@@ -309,9 +309,9 @@ export function McpPopover({
 			<PopoverPopup
 				side="top"
 				align="start"
-				className="w-80 [&_[data-slot=popover-viewport]]:p-px [&_[data-slot=popover-viewport]]:[--viewport-inline-padding:1px]"
+				className="w-80 [&_[data-slot=popover-viewport]]:!h-auto [&_[data-slot=popover-viewport]]:!overflow-hidden [&_[data-slot=popover-viewport]]:flex [&_[data-slot=popover-viewport]]:max-h-[min(var(--available-height),28rem)] [&_[data-slot=popover-viewport]]:flex-col [&_[data-slot=popover-viewport]]:p-px [&_[data-slot=popover-viewport]]:[--viewport-inline-padding:1px]"
 			>
-				<div className="flex h-8 items-center justify-between border-border/40 border-b px-2">
+				<div className="flex h-8 shrink-0 items-center justify-between border-border/40 border-b px-2">
 					<span className="text-[13px] font-medium text-foreground">MCPs</span>
 					<button
 						type="button"
@@ -329,7 +329,7 @@ export function McpPopover({
 						/>
 					</button>
 				</div>
-				<div className="max-h-96 overflow-y-auto">
+				<div className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain">
 					{topLevel.length === 0 ? (
 						<p className="px-2 py-2.5 text-[12px] leading-relaxed text-muted-foreground">
 							No MCP servers discovered.
@@ -376,7 +376,7 @@ export function McpPopover({
 						})
 					)}
 				</div>
-				<div className="border-t border-border/40">
+				<div className="shrink-0 border-t border-border/40">
 					<button
 						type="button"
 						onClick={() => {

--- a/apps/renderer/src/components/mcp-popover.tsx
+++ b/apps/renderer/src/components/mcp-popover.tsx
@@ -1,0 +1,398 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	Alert02Icon,
+	ArrowDown01Icon,
+	Key01Icon,
+	Loading02Icon,
+	PlugSocketIcon,
+	RefreshIcon,
+	Tick02Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import type {
+	FolderId,
+	McpServerDescriptor,
+	McpServerStatus,
+	ProviderId,
+} from "@zuse/contracts";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+	MCP_DISPLAY_GROUPS,
+	mcpChildrenForParent,
+	mcpProviderAvailabilityLabel,
+	mcpServersForProvider,
+	mcpTopLevelServers,
+} from "~/lib/mcp-display.ts";
+import { cn } from "~/lib/utils";
+import { useMcpStore } from "../store/mcp.ts";
+import { useUiStore } from "../store/ui.ts";
+import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
+
+function StateGlyph({
+	status,
+	available,
+}: {
+	status: McpServerStatus;
+	available: boolean;
+}) {
+	if (!available) {
+		return (
+			<span
+				aria-hidden
+				className="size-1.5 rounded-full bg-muted-foreground/40"
+			/>
+		);
+	}
+	if (status.state === "connected") {
+		return (
+			<HugeiconsIcon
+				icon={Tick02Icon}
+				className="size-3.5 text-emerald-500"
+				aria-hidden
+			/>
+		);
+	}
+	if (status.state === "connecting") {
+		return (
+			<HugeiconsIcon
+				icon={Loading02Icon}
+				className="size-3.5 animate-spin text-muted-foreground motion-reduce:animate-none"
+				aria-hidden
+			/>
+		);
+	}
+	if (status.state === "needs-auth") {
+		return (
+			<HugeiconsIcon
+				icon={Key01Icon}
+				className="size-3.5 text-amber-400"
+				aria-hidden
+			/>
+		);
+	}
+	if (status.state === "error") {
+		return (
+			<HugeiconsIcon
+				icon={Alert02Icon}
+				className="size-3.5 text-red-400"
+				aria-hidden
+			/>
+		);
+	}
+	return (
+		<span
+			aria-hidden
+			className="size-1.5 rounded-full bg-muted-foreground/40"
+		/>
+	);
+}
+
+const placeholder = (server: McpServerDescriptor): McpServerStatus => ({
+	key: server.key,
+	name: server.name,
+	source: server.source,
+	state:
+		server.disabledByZuse || !server.enabledInConfig
+			? "disabled"
+			: "connecting",
+	toolCount: null,
+	toolNames: [],
+	error: null,
+	authMethod: null,
+	requirements: [],
+	checkedAt: 0,
+});
+
+function ServerRow({
+	server,
+	status,
+	projectId,
+	providerId,
+	indented = false,
+}: {
+	server: McpServerDescriptor;
+	status: McpServerStatus;
+	projectId: FolderId | undefined;
+	providerId: ProviderId;
+	indented?: boolean;
+}) {
+	const authenticate = useMcpStore((state) => state.authenticate);
+	const authenticating = useMcpStore((state) =>
+		state.authenticating.has(server.key),
+	);
+	const available = server.availableProviders.includes(providerId);
+	const unmet = status.requirements.filter(
+		(requirement) => !requirement.satisfied,
+	);
+	const providerHint = mcpProviderAvailabilityLabel(server);
+	const secondary = !available
+		? `Available in ${providerHint} sessions`
+		: status.state === "error"
+			? status.error
+			: unmet.length > 0 && status.state !== "needs-auth"
+				? unmet
+						.map((requirement) => `${requirement.detail} missing`)
+						.join(" · ")
+				: null;
+
+	return (
+		<div
+			className={cn("flex flex-col gap-0.5 px-2 py-0.5", indented && "pl-7")}
+		>
+			<div className="flex min-h-7 items-center gap-2">
+				<span className="flex size-4 shrink-0 items-center justify-center">
+					<StateGlyph status={status} available={available} />
+				</span>
+				<span
+					className={cn(
+						"min-w-0 flex-1 truncate text-[13px]",
+						status.state === "disabled" || !available
+							? "text-muted-foreground/70"
+							: "text-foreground",
+					)}
+					title={server.name}
+				>
+					{server.name}
+				</span>
+				{status.state === "needs-auth" &&
+				server.authenticationAction !== null ? (
+					<button
+						type="button"
+						disabled={authenticating}
+						onClick={() => void authenticate(server.key, projectId, providerId)}
+						className="h-6 shrink-0 rounded-sm border border-border/60 px-1.5 text-[10px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:opacity-60"
+					>
+						{authenticating ? "Waiting…" : "Connect"}
+					</button>
+				) : status.state === "needs-auth" ? (
+					<span className="shrink-0 text-[10px] text-amber-500/80">
+						Needs auth
+					</span>
+				) : !available ? (
+					<span className="shrink-0 text-[11px] text-muted-foreground">
+						{providerHint}
+					</span>
+				) : status.state === "connecting" ? (
+					<span className="shrink-0 text-[10px] text-muted-foreground">
+						Checking…
+					</span>
+				) : status.toolCount !== null ? (
+					<span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+						{status.toolCount} {status.toolCount === 1 ? "tool" : "tools"}
+					</span>
+				) : null}
+			</div>
+			{secondary !== null ? (
+				<p
+					className="truncate pl-6 text-[11px] leading-snug text-muted-foreground"
+					title={secondary}
+				>
+					{secondary}
+				</p>
+			) : null}
+		</div>
+	);
+}
+
+function AppGroup({
+	server,
+	status,
+	children,
+	statuses,
+	projectId,
+	providerId,
+}: {
+	server: McpServerDescriptor;
+	status: McpServerStatus;
+	children: ReadonlyArray<McpServerDescriptor>;
+	statuses: ReadonlyMap<string, McpServerStatus>;
+	projectId: FolderId | undefined;
+	providerId: ProviderId;
+}) {
+	const [expanded, setExpanded] = useState(true);
+	const available = server.availableProviders.includes(providerId);
+	return (
+		<div>
+			<button
+				type="button"
+				aria-expanded={expanded}
+				onClick={() => setExpanded((current) => !current)}
+				className="flex min-h-8 w-full items-center gap-2 rounded-md px-2 text-left transition-colors hover:bg-muted/50"
+			>
+				<HugeiconsIcon
+					icon={ArrowDown01Icon}
+					className={cn(
+						"size-3.5 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none",
+						!expanded && "-rotate-90",
+					)}
+					aria-hidden
+				/>
+				<span className="flex size-4 shrink-0 items-center justify-center">
+					<StateGlyph status={status} available={available} />
+				</span>
+				<span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
+					{server.name}
+				</span>
+				<span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+					{status.toolCount ?? 0} tools · {children.length} apps
+				</span>
+			</button>
+			{mcpChildrenForParent(children, server.key, expanded).map((child) => (
+				<ServerRow
+					key={child.key}
+					server={child}
+					status={statuses.get(child.key) ?? placeholder(child)}
+					projectId={projectId}
+					providerId={providerId}
+					indented
+				/>
+			))}
+		</div>
+	);
+}
+
+export function McpPopover({
+	projectId,
+	providerId,
+}: {
+	projectId: FolderId | undefined;
+	providerId: ProviderId;
+}) {
+	const [open, setOpen] = useState(false);
+	const servers = useMcpStore((state) => state.servers);
+	const statuses = useMcpStore((state) => state.statuses);
+	const refreshing = useMcpStore((state) => state.refreshing);
+	const load = useMcpStore((state) => state.load);
+	const refresh = useMcpStore((state) => state.refresh);
+	const setView = useUiStore((state) => state.setView);
+	const setSettingsSection = useUiStore((state) => state.setSettingsSection);
+	const scope = useMemo(
+		() => ({ projectId, provider: providerId }),
+		[projectId, providerId],
+	);
+
+	useEffect(() => {
+		if (!open) return;
+		void load(scope);
+	}, [load, open, scope]);
+
+	const providerServers = mcpServersForProvider(servers, providerId);
+	const topLevel = mcpTopLevelServers(providerServers);
+	const leaves = providerServers.filter(
+		(server) => server.kind !== "app-group",
+	);
+	const connectedCount = leaves.filter(
+		(server) => statuses.get(server.key)?.state === "connected",
+	).length;
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<Tooltip>
+				<TooltipTrigger
+					render={
+						<PopoverTrigger
+							aria-label="MCP servers"
+							className={cn(
+								"flex size-5 items-center justify-center rounded-sm transition-colors hover:bg-muted/60",
+								open
+									? "bg-muted/60 text-foreground"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							<HugeiconsIcon icon={PlugSocketIcon} className="size-3" />
+						</PopoverTrigger>
+					}
+				/>
+				<TooltipPopup>MCP servers</TooltipPopup>
+			</Tooltip>
+			<PopoverPopup
+				side="top"
+				align="start"
+				className="w-80 [&_[data-slot=popover-viewport]]:p-px [&_[data-slot=popover-viewport]]:[--viewport-inline-padding:1px]"
+			>
+				<div className="flex h-8 items-center justify-between border-border/40 border-b px-2">
+					<span className="text-[13px] font-medium text-foreground">MCPs</span>
+					<button
+						type="button"
+						aria-label="Refresh MCP server status"
+						disabled={refreshing}
+						onClick={() => void refresh(scope)}
+						className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:opacity-60"
+					>
+						<HugeiconsIcon
+							icon={RefreshIcon}
+							className={cn(
+								"size-3.5",
+								refreshing && "animate-spin motion-reduce:animate-none",
+							)}
+						/>
+					</button>
+				</div>
+				<div className="max-h-96 overflow-y-auto">
+					{topLevel.length === 0 ? (
+						<p className="px-2 py-2.5 text-[12px] leading-relaxed text-muted-foreground">
+							No MCP servers discovered.
+						</p>
+					) : (
+						MCP_DISPLAY_GROUPS.map((group) => {
+							const grouped = topLevel.filter(group.matches);
+							if (grouped.length === 0) return null;
+							return (
+								<section key={group.label} aria-label={group.label}>
+									<p className="px-2 pt-1.5 pb-0.5 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+										{group.label}
+									</p>
+									{grouped.map((server) => {
+										const status =
+											statuses.get(server.key) ?? placeholder(server);
+										if (server.kind === "app-group") {
+											return (
+												<AppGroup
+													key={server.key}
+													server={server}
+													status={status}
+													children={providerServers.filter(
+														(child) => child.parentKey === server.key,
+													)}
+													statuses={statuses}
+													projectId={projectId}
+													providerId={providerId}
+												/>
+											);
+										}
+										return (
+											<ServerRow
+												key={server.key}
+												server={server}
+												status={status}
+												projectId={projectId}
+												providerId={providerId}
+											/>
+										);
+									})}
+								</section>
+							);
+						})
+					)}
+				</div>
+				<div className="border-t border-border/40">
+					<button
+						type="button"
+						onClick={() => {
+							setOpen(false);
+							setView("settings");
+							setSettingsSection({ kind: "mcp" });
+						}}
+						className="flex min-h-8 w-full items-center justify-between rounded-md px-2 text-[12px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+					>
+						<span>Manage MCP servers</span>
+						<span className="text-[11px] tabular-nums">
+							{connectedCount}/{leaves.length} connected
+						</span>
+					</button>
+				</div>
+			</PopoverPopup>
+		</Popover>
+	);
+}

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -12,6 +12,7 @@ import {
   KeyboardIcon,
   PackageIcon,
   PencilEdit01Icon,
+  PlugSocketIcon,
   Settings01Icon,
   SmartPhone01Icon,
   TaskDone01Icon,
@@ -61,6 +62,7 @@ import { DeveloperPane } from "./settings/developer-pane.tsx";
 import { DevicesPane } from "./settings/devices-pane.tsx";
 import { KeybindingsPane } from "./settings/keybindings-editor.tsx";
 import { LinearIntegrationsPane } from "./settings/linear-integrations-pane.tsx";
+import { McpServersPane } from "./settings/mcp-servers-pane.tsx";
 import { PokedexPane } from "./settings/pokedex-pane.tsx";
 import { RepositorySettings } from "./settings-repository.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar.tsx";
@@ -104,6 +106,12 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
     label: "Providers",
     Icon: PackageIcon,
     section: { kind: "providers" },
+  },
+  {
+    id: "mcp",
+    label: "MCP Servers",
+    Icon: PlugSocketIcon,
+    section: { kind: "mcp" },
   },
   {
     id: "workspace",
@@ -337,6 +345,13 @@ function SectionTitle({
           "Connect issue workspaces and bring tickets into new sessions.",
       };
     }
+    if (section.kind === "mcp") {
+      return {
+        title: "MCP Servers",
+        subtitle:
+          "Configured servers and provider-managed connectors, with live availability and authentication.",
+      };
+    }
     if (section.kind === "devices") {
       return {
         title: "Devices",
@@ -416,7 +431,8 @@ function SectionTitle({
 function Pane({ section }: { section: SettingsSection }) {
   if (section.kind === "general") return <GeneralPane />;
   if (section.kind === "providers") return <ProvidersPane />;
-  if (section.kind === "integrations") return <LinearIntegrationsPane />;
+	if (section.kind === "integrations") return <LinearIntegrationsPane />;
+	if (section.kind === "mcp") return <McpServersPane />;
   if (section.kind === "workspace") return <WorkspacePane />;
   if (section.kind === "devices") return <DevicesPane />;
   if (section.kind === "pokedex") return <PokedexPane />;

--- a/apps/renderer/src/components/settings/mcp-servers-pane.tsx
+++ b/apps/renderer/src/components/settings/mcp-servers-pane.tsx
@@ -1,0 +1,295 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	Alert02Icon,
+	Key01Icon,
+	Loading02Icon,
+	Tick02Icon,
+} from "@hugeicons-pro/core-bulk-rounded";
+import type {
+	McpServerDescriptor,
+	McpServerSource,
+	McpServerStatus,
+} from "@zuse/contracts";
+import { RefreshCw as RefreshIcon } from "lucide-react";
+import { useEffect } from "react";
+
+import { cn } from "~/lib/utils";
+import { useMcpStore } from "../../store/mcp.ts";
+import { SettingsFrame, SettingsGroup } from "../settings-page.tsx";
+import { Button } from "../ui/button.tsx";
+import { Switch } from "../ui/switch";
+
+const SOURCE_GROUPS: ReadonlyArray<{
+	readonly title: string;
+	readonly description: string;
+	readonly sources: ReadonlyArray<McpServerSource>;
+}> = [
+	{
+		title: "Built-in",
+		description:
+			"Zuse's own tool servers, injected into every session. Always on.",
+		sources: ["builtin"],
+	},
+	{
+		title: "Claude Code",
+		description:
+			"Configured servers, installed plugins, and connected apps available to Claude sessions.",
+		sources: [
+			"claude-user",
+			"claude-project",
+			"claude-local",
+			"claude-plugin",
+			"claude-app",
+		],
+	},
+	{
+		title: "Codex",
+		description:
+			"Configured and provider-managed MCP servers available to Codex sessions. Config-backed toggles apply to Codex everywhere.",
+		sources: ["codex"],
+	},
+	{
+		title: "Provider apps",
+		description:
+			"Apps and connectors reported by the provider. Connected tools are grouped under the aggregate apps server.",
+		sources: ["codex-app"],
+	},
+];
+
+const SOURCE_LABEL: Record<McpServerSource, string> = {
+	"claude-user": "user",
+	"claude-project": "project",
+	"claude-local": "project (local)",
+	"claude-plugin": "plugin",
+	"claude-app": "connected app",
+	codex: "codex",
+	"codex-app": "provider app",
+	builtin: "built-in",
+};
+
+function StatusBadge({ status }: { status: McpServerStatus | undefined }) {
+	if (status === undefined || status.state === "connecting") {
+		return (
+			<span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+				<HugeiconsIcon
+					icon={Loading02Icon}
+					className="size-3 animate-spin motion-reduce:animate-none"
+					aria-hidden
+				/>
+				checking
+			</span>
+		);
+	}
+	if (status.state === "connected") {
+		return (
+			<span className="flex items-center gap-1 text-[11px] text-emerald-500">
+				<HugeiconsIcon icon={Tick02Icon} className="size-3" aria-hidden />
+				{status.toolCount ?? 0} {status.toolCount === 1 ? "tool" : "tools"}
+			</span>
+		);
+	}
+	if (status.state === "needs-auth") {
+		return (
+			<span className="flex items-center gap-1 text-[11px] text-amber-400">
+				<HugeiconsIcon icon={Key01Icon} className="size-3" aria-hidden />
+				auth required
+			</span>
+		);
+	}
+	if (status.state === "error") {
+		return (
+			<span
+				className="flex max-w-56 items-center gap-1 truncate text-[11px] text-red-400"
+				title={status.error ?? "error"}
+			>
+				<HugeiconsIcon
+					icon={Alert02Icon}
+					className="size-3 shrink-0"
+					aria-hidden
+				/>
+				<span className="truncate">{status.error ?? "error"}</span>
+			</span>
+		);
+	}
+	return <span className="text-[11px] text-muted-foreground">off</span>;
+}
+
+function ServerSettingsRow({
+	server,
+	status,
+}: {
+	server: McpServerDescriptor;
+	status: McpServerStatus | undefined;
+}) {
+	const setEnabled = useMcpStore((s) => s.setEnabled);
+	const authenticate = useMcpStore((s) => s.authenticate);
+	const authenticating = useMcpStore((s) => s.authenticating.has(server.key));
+	const detail =
+		server.transport === null
+			? server.kind === "app-group"
+				? "Aggregate provider app server"
+				: "Managed by the provider"
+			: server.transport === "stdio"
+				? [server.command, ...server.args].filter(Boolean).join(" ")
+				: (server.url ?? "");
+	const enabled = server.enabledInConfig && !server.disabledByZuse;
+	const unmet = (status?.requirements ?? []).filter((req) => !req.satisfied);
+
+	return (
+		<div
+			className={cn(
+				"flex flex-col gap-1 px-4 py-3",
+				server.parentKey !== null && "pl-8",
+			)}
+		>
+			<div className="flex items-center gap-3">
+				<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+					<div className="flex items-baseline gap-2">
+						<span className="text-sm font-medium text-foreground">
+							{server.name}
+						</span>
+						<span className="text-[11px] text-muted-foreground">
+							{SOURCE_LABEL[server.source]}
+						</span>
+					</div>
+					<p
+						className="truncate font-mono text-[11px] text-muted-foreground"
+						title={detail}
+					>
+						{detail}
+					</p>
+				</div>
+				<StatusBadge status={status} />
+				{status?.state === "needs-auth" &&
+				server.authenticationAction !== null ? (
+					<Button
+						size="sm"
+						variant="outline"
+						disabled={authenticating}
+						onClick={() => void authenticate(server.key)}
+					>
+						{authenticating ? "Waiting…" : "Connect"}
+					</Button>
+				) : null}
+				{server.toggleSupported ? (
+					<Switch
+						checked={enabled}
+						disabled={!server.enabledInConfig && server.source !== "codex-app"}
+						aria-label={`${enabled ? "Disable" : "Enable"} ${server.name}`}
+						onCheckedChange={(next) => void setEnabled(server.key, next)}
+					/>
+				) : (
+					<span className="text-[11px] text-muted-foreground">read-only</span>
+				)}
+			</div>
+			{unmet.length > 0 && status?.state !== "needs-auth" ? (
+				<ul className="flex flex-col gap-0.5">
+					{unmet.map((req) => (
+						<li
+							key={`${req.kind}:${req.detail}`}
+							className="text-[11px] text-amber-400/90"
+						>
+							{req.kind === "command"
+								? `command not found: ${req.detail}`
+								: `${req.detail} is not set`}
+						</li>
+					))}
+				</ul>
+			) : null}
+		</div>
+	);
+}
+
+/**
+ * Settings → MCP Servers. Read-through view of the user's native MCP
+ * configs (Zuse keeps no registry of its own): every server Claude Code
+ * and Codex are configured with, its live status and requirements, an
+ * enable/disable toggle, and OAuth sign-in for servers that need it.
+ * Adding or editing servers happens in the native config files.
+ */
+export function McpServersPane() {
+	const servers = useMcpStore((s) => s.servers);
+	const statuses = useMcpStore((s) => s.statuses);
+	const refreshing = useMcpStore((s) => s.refreshing);
+	const load = useMcpStore((s) => s.load);
+	const refresh = useMcpStore((s) => s.refresh);
+
+	useEffect(() => {
+		void load({});
+	}, [load]);
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex items-center justify-end">
+				<Button
+					size="sm"
+					variant="outline"
+					disabled={refreshing}
+					onClick={() => void refresh({})}
+				>
+					<RefreshIcon
+						className={cn(
+							"size-3.5",
+							refreshing && "animate-spin motion-reduce:animate-none",
+						)}
+					/>
+					Refresh all
+				</Button>
+			</div>
+			{SOURCE_GROUPS.map((group) => {
+				const groupServers = servers.filter((server) =>
+					group.sources.includes(server.source),
+				);
+				if (groupServers.length === 0 && group.sources[0] !== "builtin") {
+					return (
+						<SettingsFrame
+							key={group.title}
+							title={group.title}
+							description={group.description}
+						>
+							<p className="text-[13px] text-muted-foreground">
+								No servers configured.
+							</p>
+						</SettingsFrame>
+					);
+				}
+				return (
+					<SettingsGroup
+						key={group.title}
+						title={group.title}
+						description={group.description}
+					>
+						{groupServers.map((server) => (
+							<ServerSettingsRow
+								key={server.key}
+								server={server}
+								status={statuses.get(server.key)}
+							/>
+						))}
+					</SettingsGroup>
+				);
+			})}
+			<SettingsFrame
+				title="Adding servers"
+				description="Zuse combines your agents' native MCP configs with servers, plugins, and connectors reported by the provider."
+			>
+				<div className="flex flex-col gap-1.5 text-[13px] leading-relaxed text-muted-foreground">
+					<p>
+						Claude Code:{" "}
+						<code className="font-mono text-[12px]">claude mcp add …</code> or
+						edit <code className="font-mono text-[12px]">.mcp.json</code> /{" "}
+						<code className="font-mono text-[12px]">~/.claude.json</code>
+					</p>
+					<p>
+						Codex: add a{" "}
+						<code className="font-mono text-[12px]">
+							[mcp_servers.&lt;name&gt;]
+						</code>{" "}
+						block to{" "}
+						<code className="font-mono text-[12px]">~/.codex/config.toml</code>
+					</p>
+				</div>
+			</SettingsFrame>
+		</div>
+	);
+}

--- a/apps/renderer/src/lib/mcp-display.ts
+++ b/apps/renderer/src/lib/mcp-display.ts
@@ -1,0 +1,55 @@
+import type { McpServerDescriptor, ProviderId } from "@zuse/contracts";
+
+export const MCP_PROVIDER_LABEL: Record<ProviderId, string> = {
+	claude: "Claude",
+	codex: "Codex",
+	grok: "Grok",
+	gemini: "Gemini",
+	cursor: "Cursor",
+	opencode: "OpenCode",
+};
+
+export const MCP_DISPLAY_GROUPS = [
+	{
+		label: "Built-in",
+		matches: (server: McpServerDescriptor) => server.source === "builtin",
+	},
+	{
+		label: "Claude",
+		matches: (server: McpServerDescriptor) =>
+			server.source.startsWith("claude-"),
+	},
+	{
+		label: "Codex",
+		matches: (server: McpServerDescriptor) => server.source === "codex",
+	},
+	{
+		label: "Provider apps",
+		matches: (server: McpServerDescriptor) => server.kind === "app-group",
+	},
+] as const;
+
+export const mcpTopLevelServers = (
+	servers: ReadonlyArray<McpServerDescriptor>,
+): ReadonlyArray<McpServerDescriptor> =>
+	servers.filter((server) => server.parentKey === null);
+
+export const mcpServersForProvider = (
+	servers: ReadonlyArray<McpServerDescriptor>,
+	provider: ProviderId,
+): ReadonlyArray<McpServerDescriptor> =>
+	servers.filter((server) => server.availableProviders.includes(provider));
+
+export const mcpChildrenForParent = (
+	servers: ReadonlyArray<McpServerDescriptor>,
+	parentKey: string,
+	expanded: boolean,
+): ReadonlyArray<McpServerDescriptor> =>
+	expanded ? servers.filter((server) => server.parentKey === parentKey) : [];
+
+export const mcpProviderAvailabilityLabel = (
+	server: McpServerDescriptor,
+): string =>
+	server.availableProviders
+		.map((provider) => MCP_PROVIDER_LABEL[provider])
+		.join(", ");

--- a/apps/renderer/src/store/mcp.ts
+++ b/apps/renderer/src/store/mcp.ts
@@ -1,0 +1,157 @@
+import type {
+	FolderId,
+	McpServerDescriptor,
+	McpServerStatus,
+	ProviderId,
+} from "@zuse/contracts";
+import { Effect, Stream } from "effect";
+import { create } from "zustand";
+
+import { formatError } from "../lib/format-error.ts";
+import { getRpcClient } from "../lib/rpc-client.ts";
+
+export interface McpScope {
+	readonly projectId?: FolderId;
+	readonly provider?: ProviderId;
+}
+
+/**
+ * Renderer cache of the user's MCP server inventory + connection statuses.
+ * `load()` is cache-only after the initial provider discovery, so the popover
+ * can call it on open without repeatedly invoking native provider CLIs.
+ * `refresh()` explicitly forces discovery and status probes.
+ */
+type State = {
+	readonly servers: ReadonlyArray<McpServerDescriptor>;
+	readonly statuses: ReadonlyMap<string, McpServerStatus>;
+	readonly loaded: boolean;
+	readonly refreshing: boolean;
+	readonly error: string | null;
+	/** Keys with an OAuth round-trip in flight (drives the Connect spinner). */
+	readonly authenticating: ReadonlySet<string>;
+	readonly load: (scope: McpScope) => Promise<void>;
+	readonly refresh: (scope: McpScope) => Promise<void>;
+	readonly setEnabled: (
+		key: string,
+		enabled: boolean,
+		projectId?: FolderId,
+	) => Promise<void>;
+	readonly authenticate: (
+		key: string,
+		projectId?: FolderId,
+		provider?: ProviderId,
+	) => Promise<void>;
+};
+
+const statusMap = (
+	statuses: ReadonlyArray<McpServerStatus>,
+): Map<string, McpServerStatus> =>
+	new Map(statuses.map((status) => [status.key, status]));
+
+const openExternal = (url: string): void => {
+	const bridge = window.zuse ?? window.memoize;
+	if (bridge?.app?.openExternal) {
+		bridge.app.openExternal(url);
+		return;
+	}
+	window.open(url, "_blank", "noopener,noreferrer");
+};
+
+export const useMcpStore = create<State>((set, get) => ({
+	servers: [],
+	statuses: new Map(),
+	loaded: false,
+	refreshing: false,
+	error: null,
+	authenticating: new Set(),
+
+	load: async (scope) => {
+		try {
+			const client = await getRpcClient();
+			const result = await Effect.runPromise(
+				client["mcp.list"]({
+					projectId: scope.projectId,
+					provider: scope.provider,
+				}),
+			);
+			set({
+				servers: result.servers,
+				statuses: statusMap(result.statuses),
+				loaded: true,
+				error: null,
+			});
+		} catch (err) {
+			// Keep the previous inventory visible; a transient RPC failure
+			// shouldn't blank a working popover.
+			set({ loaded: true, error: get().loaded ? null : formatError(err) });
+		}
+	},
+
+	refresh: async (scope) => {
+		set({ refreshing: true });
+		try {
+			const client = await getRpcClient();
+			const result = await Effect.runPromise(
+				client["mcp.refresh"]({
+					projectId: scope.projectId,
+					provider: scope.provider,
+				}),
+			);
+			set({
+				servers: result.servers,
+				statuses: statusMap(result.statuses),
+				refreshing: false,
+				error: null,
+			});
+		} catch (err) {
+			set({ refreshing: false, error: formatError(err) });
+		}
+	},
+
+	setEnabled: async (key, enabled, projectId) => {
+		// Optimistic: flip the descriptor immediately, reconcile on reload.
+		set({
+			servers: get().servers.map((server) =>
+				server.key !== key
+					? server
+					: server.source === "codex" || server.source === "codex-app"
+						? { ...server, enabledInConfig: enabled }
+						: { ...server, disabledByZuse: !enabled },
+			),
+		});
+		try {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["mcp.setEnabled"]({ key, enabled, projectId }),
+			);
+			await get().load({ projectId });
+		} catch (err) {
+			set({ error: formatError(err) });
+			await get().load({ projectId });
+		}
+	},
+
+	authenticate: async (key, projectId, provider) => {
+		set({ authenticating: new Set([...get().authenticating, key]) });
+		try {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				Stream.runForEach(
+					client["mcp.authenticate"]({ key, projectId }),
+					(event) =>
+						Effect.sync(() => {
+							if (event._tag === "browser-opened") openExternal(event.url);
+							if (event._tag === "failed") set({ error: event.error });
+						}),
+				),
+			);
+		} catch (err) {
+			set({ error: formatError(err) });
+		} finally {
+			const next = new Set(get().authenticating);
+			next.delete(key);
+			set({ authenticating: next });
+			await get().refresh({ projectId, provider });
+		}
+	},
+}));

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -29,7 +29,8 @@ export type View = "chat" | "settings";
 export type SettingsSection =
   | { readonly kind: "general" }
   | { readonly kind: "providers" }
-  | { readonly kind: "integrations" }
+	| { readonly kind: "integrations" }
+	| { readonly kind: "mcp" }
   | { readonly kind: "workspace" }
   | { readonly kind: "devices" }
   | { readonly kind: "pokedex" }

--- a/apps/renderer/test/unit/mcp-display.test.ts
+++ b/apps/renderer/test/unit/mcp-display.test.ts
@@ -1,0 +1,117 @@
+import type { McpServerDescriptor } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+	MCP_DISPLAY_GROUPS,
+	mcpChildrenForParent,
+	mcpProviderAvailabilityLabel,
+	mcpServersForProvider,
+	mcpTopLevelServers,
+} from "../../src/lib/mcp-display.ts";
+
+const descriptor = (
+	key: string,
+	overrides: Partial<McpServerDescriptor> = {},
+): McpServerDescriptor => ({
+	key,
+	name: key,
+	source: "codex",
+	kind: "configured",
+	parentKey: null,
+	availableProviders: ["codex"],
+	transport: "stdio",
+	command: "node",
+	args: [],
+	url: null,
+	envVarNames: [],
+	enabledInConfig: true,
+	disabledByZuse: false,
+	toggleSupported: true,
+	authenticationAction: null,
+	manageUrl: null,
+	...overrides,
+});
+
+describe("MCP display grouping", () => {
+	it("groups top-level rows without duplicating connector children", () => {
+		const rows = [
+			descriptor("builtin:zuse", { source: "builtin", kind: "builtin" }),
+			descriptor("claude:local", {
+				source: "claude-user",
+				availableProviders: ["claude"],
+			}),
+			descriptor("codex-apps:codex_apps", {
+				source: "codex-app",
+				kind: "app-group",
+			}),
+			descriptor("codex-app:mail", {
+				source: "codex-app",
+				kind: "app",
+				parentKey: "codex-apps:codex_apps",
+			}),
+		];
+		const topLevel = mcpTopLevelServers(rows);
+
+		expect(topLevel).toHaveLength(3);
+		expect(
+			MCP_DISPLAY_GROUPS.map((group) => ({
+				label: group.label,
+				keys: topLevel.filter(group.matches).map((row) => row.key),
+			})),
+		).toEqual([
+			{ label: "Built-in", keys: ["builtin:zuse"] },
+			{ label: "Claude", keys: ["claude:local"] },
+			{ label: "Codex", keys: [] },
+			{ label: "Provider apps", keys: ["codex-apps:codex_apps"] },
+		]);
+	});
+
+	it("shows connector children only while their aggregate is expanded", () => {
+		const child = descriptor("codex-app:mail", {
+			kind: "app",
+			parentKey: "codex-apps:codex_apps",
+		});
+		expect(
+			mcpChildrenForParent([child], "codex-apps:codex_apps", true),
+		).toEqual([child]);
+		expect(
+			mcpChildrenForParent([child], "codex-apps:codex_apps", false),
+		).toEqual([]);
+	});
+
+	it("labels provider availability without implying cross-provider access", () => {
+		expect(
+			mcpProviderAvailabilityLabel(
+				descriptor("claude:only", {
+					availableProviders: ["claude"],
+				}),
+			),
+		).toBe("Claude");
+		expect(
+			mcpProviderAvailabilityLabel(
+				descriptor("builtin:zuse", {
+					availableProviders: ["claude", "codex"],
+				}),
+			),
+		).toBe("Claude, Codex");
+	});
+
+	it("shows only entries available to the active provider", () => {
+		const rows = [
+			descriptor("builtin:zuse", {
+				source: "builtin",
+				kind: "builtin",
+				availableProviders: ["claude", "codex"],
+			}),
+			descriptor("claude:local", {
+				source: "claude-user",
+				availableProviders: ["claude"],
+			}),
+			descriptor("codex:local"),
+		];
+
+		expect(mcpServersForProvider(rows, "claude").map((row) => row.key)).toEqual(
+			["builtin:zuse", "claude:local"],
+		);
+	});
+});

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,6 +27,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.2.126",
+		"@modelcontextprotocol/sdk": "^1.0.0",
 		"@zuse/agents": "*",
 		"@zuse/domain": "*",
 		"@zuse/git": "*",
@@ -41,6 +42,7 @@
 		"jose": "^6.2.3",
 		"keytar": "^7.9.0",
 		"node-pty": "^1.1.0",
+		"smol-toml": "^1.3.1",
 		"tokenmaxer": "*",
 		"zod": "^4.0.0"
 	},

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -88,6 +88,7 @@ const freshSettings = (): SettingsFile =>
     opencodeProviderVisible: {},
     opencodeModelVisibleByProvider: {},
     opencodeCustomProviders: [],
+    mcpDisabledServers: [],
     subagents: { enableForNewSessions: true, presets: {} },
     branchNamingStyle: "username-slug",
     branchNamingPrefix: "",
@@ -359,6 +360,15 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     }
   }
 
+  const mcpDisabledServers: string[] = [];
+  if (Array.isArray(obj.mcpDisabledServers)) {
+    for (const item of obj.mcpDisabledServers) {
+      if (typeof item === "string" && item.length > 0) {
+        mcpDisabledServers.push(item);
+      }
+    }
+  }
+
   let subagents = base.subagents;
   if (typeof obj.subagents === "object" && obj.subagents !== null) {
     const sub = obj.subagents as Record<string, unknown>;
@@ -434,6 +444,7 @@ const coerceSettings = (raw: unknown): SettingsFile => {
     opencodeProviderVisible,
     opencodeModelVisibleByProvider,
     opencodeCustomProviders,
+    mcpDisabledServers,
     subagents,
     branchNamingStyle,
     branchNamingPrefix,
@@ -713,6 +724,8 @@ export const ConfigStoreServiceLive = Layer.effect(
             cur.opencodeModelVisibleByProvider,
           opencodeCustomProviders:
             patch.opencodeCustomProviders ?? cur.opencodeCustomProviders,
+          mcpDisabledServers:
+            patch.mcpDisabledServers ?? cur.mcpDisabledServers,
           subagents: patch.subagents ?? cur.subagents,
           branchNamingStyle: patch.branchNamingStyle ?? cur.branchNamingStyle,
           branchNamingPrefix:
@@ -844,6 +857,7 @@ export const ConfigStoreServiceLive = Layer.effect(
             opencodeProviderVisible: cur.opencodeProviderVisible,
             opencodeModelVisibleByProvider: cur.opencodeModelVisibleByProvider,
             opencodeCustomProviders: cur.opencodeCustomProviders,
+            mcpDisabledServers: cur.mcpDisabledServers,
             subagents,
             branchNamingStyle: cur.branchNamingStyle,
             branchNamingPrefix: cur.branchNamingPrefix,

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -9,6 +9,7 @@ import { FsHandlersLayer } from "./fs/handlers.ts";
 import { GitHandlersLayer } from "./git/handlers.ts";
 import { LanAuthHandlersLayer } from "./lan-auth/handlers.ts";
 import { LinearHandlersLayer } from "./linear/handlers.ts";
+import { McpHandlersLayer } from "./mcp/handlers.ts";
 import { PingHandlersLayer } from "./ping/handlers.ts";
 import { PokemonHandlersLayer } from "./pokemon/handlers.ts";
 import { ProviderHandlersLayer } from "./provider/handlers.ts";
@@ -39,6 +40,7 @@ export const HandlersLayer = Layer.mergeAll(
   RepositorySettingsHandlersLayer,
   ConfigStoreHandlersLayer,
   ProviderHandlersLayer,
+  McpHandlersLayer,
   FsHandlersLayer,
   AttachmentHandlersLayer,
   SkillHandlersLayer,

--- a/apps/server/src/mcp/claude-status.ts
+++ b/apps/server/src/mcp/claude-status.ts
@@ -1,0 +1,365 @@
+import { execFile } from "node:child_process";
+import * as fsSync from "node:fs";
+import { homedir } from "node:os";
+import * as Path from "node:path";
+
+import { scrubInheritedClaudeMarkers } from "@zuse/agents/drivers/claude-env";
+import type {
+	McpServerDescriptor,
+	McpServerSource,
+	McpServerState,
+	McpServerStatus,
+	McpTransport,
+} from "@zuse/contracts";
+import { Effect } from "effect";
+import * as pty from "node-pty";
+
+export interface ClaudeLiveMcpEntry {
+	readonly name: string;
+	readonly source: Extract<
+		McpServerSource,
+		"claude-user" | "claude-plugin" | "claude-app"
+	>;
+	readonly transport: McpTransport | null;
+	readonly command: string | null;
+	readonly url: string | null;
+	readonly state: McpServerState;
+	readonly error: string | null;
+	readonly checkedAt: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readJson = (filePath: string): unknown => {
+	try {
+		return JSON.parse(fsSync.readFileSync(filePath, "utf8")) as unknown;
+	} catch {
+		return null;
+	}
+};
+
+const sourceForName = (name: string): ClaudeLiveMcpEntry["source"] =>
+	name.startsWith("plugin:")
+		? "claude-plugin"
+		: name.startsWith("claude.ai ")
+			? "claude-app"
+			: "claude-user";
+
+const statusFromText = (
+	text: string,
+): Pick<ClaudeLiveMcpEntry, "state" | "error"> => {
+	const normalized = text.toLowerCase();
+	if (/(^|\s)connected$/u.test(normalized)) {
+		return { state: "connected", error: null };
+	}
+	if (normalized.includes("needs authentication")) {
+		return { state: "needs-auth", error: null };
+	}
+	if (normalized.includes("disabled")) {
+		return { state: "disabled", error: null };
+	}
+	if (normalized.includes("pending") || normalized.includes("checking")) {
+		return { state: "connecting", error: null };
+	}
+	return { state: "error", error: text.replace(/^[^\p{L}\p{N}]+/u, "") };
+};
+
+/** Parse the stable line-oriented output of `claude mcp list`. */
+export const parseClaudeMcpList = (
+	stdout: string,
+	checkedAt: number,
+): ReadonlyArray<ClaudeLiveMcpEntry> => {
+	const entries: ClaudeLiveMcpEntry[] = [];
+	for (const rawLine of stdout.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		const nameEnd = line.indexOf(": ");
+		const statusStart = line.lastIndexOf(" - ");
+		if (nameEnd <= 0 || statusStart <= nameEnd + 2) continue;
+		const name = line.slice(0, nameEnd).trim();
+		const endpoint = line.slice(nameEnd + 2, statusStart).trim();
+		const statusText = line.slice(statusStart + 3).trim();
+		if (name.length === 0 || statusText.length === 0) continue;
+		const { state, error } = statusFromText(statusText);
+		const urlMatch = endpoint.match(/^https?:\/\/[^\s]+/);
+		entries.push({
+			name,
+			source: sourceForName(name),
+			transport:
+				urlMatch !== null
+					? endpoint.includes("(SSE)")
+						? "sse"
+						: "http"
+					: "stdio",
+			command: urlMatch === null ? endpoint : null,
+			url: urlMatch?.[0] ?? null,
+			state,
+			error,
+			checkedAt,
+		});
+	}
+	return entries;
+};
+
+const managedEntry = (
+	name: string,
+	needsAuth: boolean,
+): ClaudeLiveMcpEntry => ({
+	name,
+	source: sourceForName(name),
+	transport: null,
+	command: null,
+	url: null,
+	state: needsAuth ? "needs-auth" : "connecting",
+	error: null,
+	checkedAt: 0,
+});
+
+/**
+ * Read only installed plugins and currently auth-required hosted apps. This
+ * makes known managed entries visible immediately without exposing the
+ * provider's marketplace or reviving stale previously-connected apps.
+ */
+export const readClaudeManagedMcpEntries =
+	(): ReadonlyArray<ClaudeLiveMcpEntry> => {
+		const claudeDir = Path.join(homedir(), ".claude");
+		const authCache = readJson(
+			Path.join(claudeDir, "mcp-needs-auth-cache.json"),
+		);
+		const authNames = new Set(
+			isRecord(authCache)
+				? Object.keys(authCache).filter(
+						(name) =>
+							name.startsWith("plugin:") || name.startsWith("claude.ai "),
+					)
+				: [],
+		);
+		const names = new Set<string>();
+		const installed = readJson(
+			Path.join(claudeDir, "plugins", "installed_plugins.json"),
+		);
+		if (isRecord(installed) && isRecord(installed.plugins)) {
+			for (const [pluginId, installations] of Object.entries(
+				installed.plugins,
+			)) {
+				if (!Array.isArray(installations)) continue;
+				const pluginName = pluginId.split("@")[0];
+				for (const installation of installations) {
+					if (
+						!isRecord(installation) ||
+						typeof installation.installPath !== "string"
+					) {
+						continue;
+					}
+					const manifest = readJson(
+						Path.join(installation.installPath, ".mcp.json"),
+					);
+					if (!isRecord(manifest) || !isRecord(manifest.mcpServers)) continue;
+					for (const serverName of Object.keys(manifest.mcpServers)) {
+						names.add(`plugin:${pluginName}:${serverName}`);
+					}
+				}
+			}
+		}
+		for (const name of authNames) names.add(name);
+		return [...names]
+			.sort((a, b) => a.localeCompare(b))
+			.map((name) => managedEntry(name, authNames.has(name)));
+	};
+
+export interface ClaudeManagedInventory {
+	readonly descriptors: ReadonlyArray<McpServerDescriptor>;
+	readonly statuses: ReadonlyArray<McpServerStatus>;
+}
+
+export const reconcileClaudeManagedInventory = (options: {
+	readonly configured: ReadonlyArray<McpServerDescriptor>;
+	readonly entries: ReadonlyArray<ClaudeLiveMcpEntry>;
+}): ClaudeManagedInventory => {
+	const configuredByName = new Map(
+		options.configured.map((descriptor) => [descriptor.name, descriptor]),
+	);
+	const descriptors: McpServerDescriptor[] = [];
+	const statuses: McpServerStatus[] = [];
+	for (const entry of options.entries) {
+		const configured = configuredByName.get(entry.name);
+		const descriptor: McpServerDescriptor = configured ?? {
+			key: `claude-live:${entry.name}`,
+			name: entry.name,
+			source: entry.source,
+			kind: "provider",
+			parentKey: null,
+			availableProviders: ["claude"],
+			transport: entry.transport,
+			command: null,
+			args: [],
+			url: entry.url,
+			envVarNames: [],
+			enabledInConfig: true,
+			disabledByZuse: false,
+			toggleSupported: false,
+			authenticationAction: "native-oauth",
+			manageUrl: null,
+		};
+		if (configured === undefined) descriptors.push(descriptor);
+		statuses.push({
+			key: descriptor.key,
+			name: descriptor.name,
+			source: descriptor.source,
+			state: entry.state,
+			toolCount: null,
+			toolNames: [],
+			error: entry.error,
+			authMethod: entry.state === "needs-auth" ? "oauth" : null,
+			requirements:
+				entry.state === "needs-auth"
+					? [
+							{
+								kind: "auth",
+								detail: "sign-in required in Claude",
+								satisfied: false,
+							},
+						]
+					: [],
+			checkedAt: entry.checkedAt,
+		});
+	}
+	return { descriptors, statuses };
+};
+
+export const readClaudeLiveMcpSnapshot = (
+	claudePath: string | null,
+	cwd: string | null,
+): Effect.Effect<ReadonlyArray<ClaudeLiveMcpEntry>, Error> =>
+	Effect.tryPromise({
+		try: (signal) =>
+			new Promise<string>((resolve, reject) => {
+				execFile(
+					claudePath ?? "claude",
+					["mcp", "list"],
+					{
+						cwd: cwd ?? undefined,
+						env: scrubInheritedClaudeMarkers(process.env),
+						signal,
+						timeout: 30_000,
+						maxBuffer: 2 * 1024 * 1024,
+					},
+					(error, stdout) => {
+						if (error !== null) reject(error);
+						else resolve(stdout);
+					},
+				);
+			}),
+		catch: (cause) =>
+			cause instanceof Error ? cause : new Error(String(cause)),
+	}).pipe(Effect.map((stdout) => parseClaudeMcpList(stdout, Date.now())));
+
+export interface ClaudeMcpLoginOutcome {
+	readonly success: boolean;
+	readonly error: string | null;
+}
+
+export interface ClaudeMcpLoginOptions {
+	readonly onAuthorizationUrl?: (url: string) => void;
+}
+
+const ANSI_ESCAPE = new RegExp(
+	`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
+	"g",
+);
+const URL_PATTERN = /https?:\/\/[^\s<>"']+/g;
+
+const authorizationUrls = (text: string): ReadonlyArray<string> =>
+	(text.replace(ANSI_ESCAPE, "").match(URL_PATTERN) ?? []).map((url) =>
+		url.replace(/[),.;]+$/u, ""),
+	);
+
+const redactUrls = (text: string): string =>
+	text.replace(URL_PATTERN, (raw) => {
+		try {
+			const url = new URL(raw.replace(/[),.;]+$/u, ""));
+			return `${url.origin}${url.pathname}${url.search.length > 0 ? "?[redacted]" : ""}`;
+		} catch {
+			return "[url redacted]";
+		}
+	});
+
+const ptyEnvironment = (): Record<string, string> =>
+	Object.fromEntries(
+		Object.entries(scrubInheritedClaudeMarkers(process.env)).filter(
+			(entry): entry is [string, string] => entry[1] !== undefined,
+		),
+	);
+
+/**
+ * Authenticate a provider-managed server through Claude's native credential
+ * store. The CLI launches the system browser and waits for its OAuth callback.
+ */
+export const claudeMcpLogin = (
+	claudePath: string | null,
+	cwd: string | null,
+	serverName: string,
+	options: ClaudeMcpLoginOptions = {},
+): Effect.Effect<ClaudeMcpLoginOutcome, Error> =>
+	Effect.tryPromise({
+		try: (signal) =>
+			new Promise<ClaudeMcpLoginOutcome>((resolve) => {
+				let settled = false;
+				let output = "";
+				let authorizationUrlSent = false;
+				let timeout: ReturnType<typeof setTimeout> | null = null;
+				let child: pty.IPty | null = null;
+				const abort = (): void => {
+					try {
+						child?.kill();
+					} catch {
+						// The process may have exited between the signal and cleanup.
+					}
+				};
+				const finish = (outcome: ClaudeMcpLoginOutcome): void => {
+					if (settled) return;
+					settled = true;
+					if (timeout !== null) clearTimeout(timeout);
+					signal.removeEventListener("abort", abort);
+					resolve(outcome);
+				};
+				const receive = (text: string): void => {
+					output += text;
+					if (authorizationUrlSent) return;
+					const url = authorizationUrls(text)[0];
+					if (url !== undefined) {
+						authorizationUrlSent = true;
+						options.onAuthorizationUrl?.(url);
+					}
+				};
+				child = pty.spawn(
+					claudePath ?? "claude",
+					["mcp", "login", serverName],
+					{
+						name: "xterm-256color",
+						cols: 100,
+						rows: 24,
+						cwd: cwd ?? process.cwd(),
+						env: { ...ptyEnvironment(), TERM: "xterm-256color" },
+					},
+				);
+				child.onData(receive);
+				child.onExit(({ exitCode }) => {
+					finish({
+						success: exitCode === 0,
+						error:
+							exitCode === 0
+								? null
+								: redactUrls(output.replace(ANSI_ESCAPE, "")).trim() ||
+									`native login exited with code ${exitCode}`,
+					});
+				});
+				signal.addEventListener("abort", abort, { once: true });
+				timeout = setTimeout(() => {
+					abort();
+					finish({ success: false, error: "sign-in timed out" });
+				}, 5 * 60_000);
+			}),
+		catch: (cause) =>
+			cause instanceof Error ? cause : new Error(String(cause)),
+	});

--- a/apps/server/src/mcp/codex-inventory.ts
+++ b/apps/server/src/mcp/codex-inventory.ts
@@ -1,0 +1,311 @@
+import type { Tool } from "@zuse/agents/codex-generated/Tool";
+import type {
+	McpRequirement,
+	McpServerDescriptor,
+	McpServerStatus,
+} from "@zuse/contracts";
+import { Predicate } from "effect";
+
+import type { CodexLiveMcpSnapshot } from "./codex-status.ts";
+
+export interface ConfiguredCodexInventoryEntry {
+	readonly descriptor: McpServerDescriptor;
+	readonly requirements: ReadonlyArray<McpRequirement>;
+}
+
+export interface ReconciledCodexInventory {
+	readonly descriptors: ReadonlyArray<McpServerDescriptor>;
+	readonly statuses: ReadonlyArray<McpServerStatus>;
+}
+
+const APPS_GROUP_KEY = "codex-apps:codex_apps";
+
+const providerDescriptor = (
+	name: string,
+	authenticationAction: McpServerDescriptor["authenticationAction"],
+): McpServerDescriptor => ({
+	key: `codex-live:${name}`,
+	name,
+	source: "codex",
+	kind: "provider",
+	parentKey: null,
+	availableProviders: ["codex"],
+	transport: null,
+	command: null,
+	args: [],
+	url: null,
+	envVarNames: [],
+	enabledInConfig: true,
+	disabledByZuse: false,
+	toggleSupported: false,
+	authenticationAction,
+	manageUrl: null,
+});
+
+const appGroupDescriptor = (): McpServerDescriptor => ({
+	key: APPS_GROUP_KEY,
+	name: "Apps & connectors",
+	source: "codex-app",
+	kind: "app-group",
+	parentKey: null,
+	availableProviders: ["codex"],
+	transport: null,
+	command: null,
+	args: [],
+	url: null,
+	envVarNames: [],
+	enabledInConfig: true,
+	disabledByZuse: false,
+	toggleSupported: false,
+	authenticationAction: null,
+	manageUrl: null,
+});
+
+interface ConnectorTools {
+	readonly id: string;
+	readonly name: string;
+	readonly toolNames: ReadonlyArray<string>;
+}
+
+const recordString = (value: unknown, key: string): string | null => {
+	if (!Predicate.hasProperty(value, key)) return null;
+	const field = value[key];
+	return Predicate.isString(field) ? field : null;
+};
+
+/** Group aggregate app-server tools by the stable connector metadata. */
+export const groupCodexAppTools = (
+	tools: Readonly<Record<string, Tool | undefined>>,
+): ReadonlyArray<ConnectorTools> => {
+	const grouped = new Map<string, { name: string; toolNames: string[] }>();
+	for (const [fallbackName, tool] of Object.entries(tools)) {
+		if (tool === undefined) continue;
+		const id = recordString(tool._meta, "connector_id");
+		if (id === null) continue;
+		const name = recordString(tool._meta, "connector_name") ?? id;
+		const current = grouped.get(id) ?? { name, toolNames: [] };
+		current.toolNames.push(tool.name || fallbackName);
+		grouped.set(id, current);
+	}
+	return [...grouped.entries()].map(([id, value]) => ({ id, ...value }));
+};
+
+const statusFromLive = (options: {
+	readonly descriptor: McpServerDescriptor;
+	readonly authStatus: "unsupported" | "notLoggedIn" | "bearerToken" | "oAuth";
+	readonly tools: Readonly<Record<string, Tool | undefined>>;
+	readonly requirements: ReadonlyArray<McpRequirement>;
+	readonly now: number;
+}): McpServerStatus => {
+	const needsAuth = options.authStatus === "notLoggedIn";
+	const toolNames = Object.values(options.tools).flatMap((tool) =>
+		tool === undefined ? [] : [tool.name],
+	);
+	return {
+		key: options.descriptor.key,
+		name: options.descriptor.name,
+		source: options.descriptor.source,
+		state: needsAuth ? "needs-auth" : "connected",
+		toolCount: needsAuth ? null : toolNames.length,
+		toolNames,
+		error: null,
+		authMethod: needsAuth ? "oauth" : null,
+		requirements: needsAuth
+			? [
+					...options.requirements,
+					{ kind: "auth", detail: "sign-in required", satisfied: false },
+				]
+			: [...options.requirements],
+		checkedAt: options.now,
+	};
+};
+
+export const reconcileCodexInventory = (options: {
+	readonly configured: ReadonlyArray<ConfiguredCodexInventoryEntry>;
+	readonly live: CodexLiveMcpSnapshot;
+	readonly excludedNames: ReadonlySet<string>;
+	readonly now: number;
+}): ReconciledCodexInventory => {
+	const descriptors: McpServerDescriptor[] = [];
+	const statuses: McpServerStatus[] = [];
+	const configuredNames = new Set(
+		options.configured.map((entry) => entry.descriptor.name),
+	);
+	const liveByName = new Map(
+		options.live.statuses.map((status) => [status.name, status]),
+	);
+
+	for (const entry of options.configured) {
+		descriptors.push(entry.descriptor);
+		if (entry.descriptor.disabledByZuse || !entry.descriptor.enabledInConfig) {
+			statuses.push({
+				key: entry.descriptor.key,
+				name: entry.descriptor.name,
+				source: entry.descriptor.source,
+				state: "disabled",
+				toolCount: null,
+				toolNames: [],
+				error: null,
+				authMethod: null,
+				requirements: [...entry.requirements],
+				checkedAt: options.now,
+			});
+			continue;
+		}
+		const live = liveByName.get(entry.descriptor.name);
+		if (live === undefined) {
+			statuses.push({
+				key: entry.descriptor.key,
+				name: entry.descriptor.name,
+				source: entry.descriptor.source,
+				state: "error",
+				toolCount: null,
+				toolNames: [],
+				error: "Codex did not report this server (it may have failed to start)",
+				authMethod: null,
+				requirements: [...entry.requirements],
+				checkedAt: options.now,
+			});
+			continue;
+		}
+		statuses.push(
+			statusFromLive({
+				descriptor: entry.descriptor,
+				authStatus: live.authStatus,
+				tools: live.tools,
+				requirements: entry.requirements,
+				now: options.now,
+			}),
+		);
+	}
+
+	const aggregate = liveByName.get("codex_apps");
+	for (const live of options.live.statuses) {
+		if (
+			configuredNames.has(live.name) ||
+			options.excludedNames.has(live.name) ||
+			live.name === "codex_apps"
+		) {
+			continue;
+		}
+		const descriptor = providerDescriptor(
+			live.name,
+			live.authStatus === "notLoggedIn" ? "native-oauth" : null,
+		);
+		descriptors.push(descriptor);
+		statuses.push(
+			statusFromLive({
+				descriptor,
+				authStatus: live.authStatus,
+				tools: live.tools,
+				requirements: [],
+				now: options.now,
+			}),
+		);
+	}
+	for (const pluginServer of options.live.pluginServers) {
+		if (
+			configuredNames.has(pluginServer.name) ||
+			liveByName.has(pluginServer.name) ||
+			options.excludedNames.has(pluginServer.name)
+		) {
+			continue;
+		}
+		const descriptor = providerDescriptor(pluginServer.name, null);
+		descriptors.push(descriptor);
+		statuses.push({
+			key: descriptor.key,
+			name: descriptor.name,
+			source: descriptor.source,
+			state: "error",
+			toolCount: null,
+			toolNames: [],
+			error: `${pluginServer.pluginName} did not report this MCP server`,
+			authMethod: null,
+			requirements: [],
+			checkedAt: options.now,
+		});
+	}
+
+	const groupedTools = new Map(
+		groupCodexAppTools(aggregate?.tools ?? {}).map((group) => [
+			group.id,
+			group,
+		]),
+	);
+	const connectorIds = new Set([
+		...options.live.connectors.map((connector) => connector.id),
+		...groupedTools.keys(),
+	]);
+	if (aggregate !== undefined || connectorIds.size > 0) {
+		const groupDescriptor = appGroupDescriptor();
+		descriptors.push(groupDescriptor);
+		statuses.push(
+			aggregate === undefined
+				? {
+						key: groupDescriptor.key,
+						name: groupDescriptor.name,
+						source: groupDescriptor.source,
+						state: "connected",
+						toolCount: 0,
+						toolNames: [],
+						error: null,
+						authMethod: null,
+						requirements: [],
+						checkedAt: options.now,
+					}
+				: statusFromLive({
+						descriptor: groupDescriptor,
+						authStatus: aggregate.authStatus,
+						tools: aggregate.tools,
+						requirements: [],
+						now: options.now,
+					}),
+		);
+	}
+
+	for (const id of connectorIds) {
+		const connector = options.live.connectors.find((item) => item.id === id);
+		const tools = groupedTools.get(id);
+		const descriptor: McpServerDescriptor = {
+			key: `codex-app:${id}`,
+			name: connector?.name ?? tools?.name ?? id,
+			source: "codex-app",
+			kind: "app",
+			parentKey: APPS_GROUP_KEY,
+			availableProviders: ["codex"],
+			transport: null,
+			command: null,
+			args: [],
+			url: null,
+			envVarNames: [],
+			enabledInConfig: connector?.isEnabled ?? true,
+			disabledByZuse: false,
+			toggleSupported: connector !== undefined,
+			authenticationAction:
+				connector?.needsAuth === true && connector.installUrl !== null
+					? "open-url"
+					: null,
+			manageUrl: connector?.installUrl ?? null,
+		};
+		descriptors.push(descriptor);
+		const needsAuth = connector?.needsAuth === true;
+		const enabled = connector?.isEnabled ?? true;
+		statuses.push({
+			key: descriptor.key,
+			name: descriptor.name,
+			source: descriptor.source,
+			state: !enabled ? "disabled" : needsAuth ? "needs-auth" : "connected",
+			toolCount: enabled && !needsAuth ? (tools?.toolNames.length ?? 0) : null,
+			toolNames: [...(tools?.toolNames ?? [])],
+			error: null,
+			authMethod: needsAuth ? "oauth" : null,
+			requirements: needsAuth
+				? [{ kind: "auth", detail: "sign-in required", satisfied: false }]
+				: [],
+			checkedAt: options.now,
+		});
+	}
+
+	return { descriptors, statuses };
+};

--- a/apps/server/src/mcp/codex-status.ts
+++ b/apps/server/src/mcp/codex-status.ts
@@ -1,0 +1,288 @@
+import type { AppInfo } from "@zuse/agents/codex-generated/v2/AppInfo";
+import type { AppsListResponse } from "@zuse/agents/codex-generated/v2/AppsListResponse";
+import type { ListMcpServerStatusResponse } from "@zuse/agents/codex-generated/v2/ListMcpServerStatusResponse";
+import type { McpServerOauthLoginResponse } from "@zuse/agents/codex-generated/v2/McpServerOauthLoginResponse";
+import type { McpServerStatus as CodexMcpServerStatus } from "@zuse/agents/codex-generated/v2/McpServerStatus";
+import type { PluginDetail } from "@zuse/agents/codex-generated/v2/PluginDetail";
+import type { PluginListResponse } from "@zuse/agents/codex-generated/v2/PluginListResponse";
+import type { PluginReadResponse } from "@zuse/agents/codex-generated/v2/PluginReadResponse";
+import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import { Effect } from "effect";
+
+export interface CodexConnectorSnapshot {
+	readonly id: string;
+	readonly name: string;
+	readonly installUrl: string | null;
+	readonly isAccessible: boolean;
+	readonly isEnabled: boolean;
+	readonly needsAuth: boolean;
+}
+
+export interface CodexPluginMcpSnapshot {
+	readonly name: string;
+	readonly pluginName: string;
+}
+
+export interface CodexLiveMcpSnapshot {
+	readonly statuses: ReadonlyArray<CodexMcpServerStatus>;
+	readonly connectors: ReadonlyArray<CodexConnectorSnapshot>;
+	readonly pluginServers: ReadonlyArray<CodexPluginMcpSnapshot>;
+}
+
+/**
+ * Short-lived `codex app-server` used when no Codex session is running:
+ * status listing, the enabled toggle, and the native OAuth login all go
+ * through the provider itself so config semantics, live inventory, and token
+ * storage remain native to that provider.
+ */
+const withCodexApp = <A>(
+	codexPath: string | null,
+	run: (app: CodexAppServerClient) => Promise<A>,
+	options?: {
+		readonly onNotification?: (notification: {
+			method: string;
+			params?: unknown;
+		}) => void;
+	},
+): Effect.Effect<A, Error> =>
+	Effect.tryPromise({
+		try: async () => {
+			const app = await CodexAppServerClient.start({
+				codexPath,
+				startupTimeoutMs: 20_000,
+				onNotification: (notification) =>
+					options?.onNotification?.(
+						notification as { method: string; params?: unknown },
+					),
+				// Nothing interactive runs in these one-shot calls; deny-by-noop
+				// keeps a stray server request from wedging the child.
+				onServerRequest: (_request, respond) => respond({}),
+			});
+			try {
+				return await run(app);
+			} finally {
+				app.close();
+			}
+		},
+		catch: (cause) =>
+			cause instanceof Error ? cause : new Error(String(cause)),
+	});
+
+const listMcpStatuses = async (
+	app: CodexAppServerClient,
+): Promise<ReadonlyArray<CodexMcpServerStatus>> => {
+	const out: CodexMcpServerStatus[] = [];
+	let cursor: string | null = null;
+	do {
+		const page: ListMcpServerStatusResponse =
+			await app.request<ListMcpServerStatusResponse>("mcpServerStatus/list", {
+				detail: "toolsAndAuthOnly",
+				cursor,
+			});
+		out.push(...page.data);
+		cursor = page.nextCursor;
+	} while (cursor !== null);
+	return out;
+};
+
+const readInstalledPluginDetails = async (
+	app: CodexAppServerClient,
+	cwd: string | null,
+): Promise<ReadonlyArray<PluginDetail>> => {
+	let response: PluginListResponse;
+	try {
+		response = await app.request<PluginListResponse>("plugin/list", {
+			cwds: cwd === null ? null : [cwd],
+		});
+	} catch {
+		return [];
+	}
+	const installed = response.marketplaces.flatMap((marketplace) =>
+		marketplace.plugins
+			.filter((plugin) => plugin.installed && plugin.enabled)
+			.map((plugin) => ({ marketplace, plugin })),
+	);
+	const details = await Promise.all(
+		installed.map(async ({ marketplace, plugin }) => {
+			try {
+				const response = await app.request<PluginReadResponse>("plugin/read", {
+					marketplacePath: marketplace.path,
+					remoteMarketplaceName:
+						marketplace.path === null ? marketplace.name : null,
+					pluginName: plugin.name,
+				});
+				return response.plugin;
+			} catch {
+				// A remote catalog can disappear between list/read. The MCP status
+				// response still discovers its running servers, so omit only the
+				// optional ownership/app metadata.
+				return null;
+			}
+		}),
+	);
+	return details.filter((detail): detail is PluginDetail => detail !== null);
+};
+
+export const reconcileCodexConnectors = (
+	apps: ReadonlyArray<AppInfo>,
+	plugins: ReadonlyArray<PluginDetail>,
+): ReadonlyArray<CodexConnectorSnapshot> => {
+	const installed = new Map(
+		plugins.flatMap((plugin) =>
+			plugin.apps.map((app) => [app.id, app] as const),
+		),
+	);
+	const connectors = new Map<string, CodexConnectorSnapshot>();
+	for (const app of apps) {
+		const pluginApp = installed.get(app.id);
+		if (!app.isAccessible && pluginApp === undefined) continue;
+		connectors.set(app.id, {
+			id: app.id,
+			name: app.name,
+			installUrl: app.installUrl ?? pluginApp?.installUrl ?? null,
+			isAccessible: app.isAccessible,
+			isEnabled: app.isEnabled,
+			needsAuth: !app.isAccessible,
+		});
+	}
+	for (const app of installed.values()) {
+		if (connectors.has(app.id)) continue;
+		connectors.set(app.id, {
+			id: app.id,
+			name: app.name,
+			installUrl: app.installUrl,
+			isAccessible: !app.needsAuth,
+			isEnabled: true,
+			needsAuth: app.needsAuth,
+		});
+	}
+	return [...connectors.values()];
+};
+
+/**
+ * Reads every provider-owned MCP source through one app-server process. The
+ * app catalog request is intentionally limited to its prioritized first page:
+ * linked apps are returned first, while installed-but-unlinked apps are added
+ * from plugin metadata. This avoids treating the full marketplace as an MCP
+ * inventory.
+ */
+export const readCodexLiveMcpSnapshot = (
+	codexPath: string | null,
+	cwd: string | null,
+): Effect.Effect<CodexLiveMcpSnapshot, Error> =>
+	withCodexApp(codexPath, async (app) => {
+		const [statuses, apps, plugins] = await Promise.all([
+			listMcpStatuses(app),
+			app
+				.request<AppsListResponse>("app/list", {
+					limit: 200,
+					forceRefetch: false,
+				})
+				.then(
+					(page) => page.data,
+					() => [],
+				),
+			readInstalledPluginDetails(app, cwd),
+		]);
+		return {
+			statuses,
+			connectors: reconcileCodexConnectors(apps, plugins),
+			pluginServers: plugins.flatMap((plugin) =>
+				plugin.mcpServers.map((name) => ({
+					name,
+					pluginName: plugin.summary.name,
+				})),
+			),
+		};
+	});
+
+export const listCodexMcpStatus = (
+	codexPath: string | null,
+): Effect.Effect<ReadonlyArray<CodexMcpServerStatus>, Error> =>
+	readCodexLiveMcpSnapshot(codexPath, null).pipe(
+		Effect.map((snapshot) => snapshot.statuses),
+	);
+
+/**
+ * Writes the native `enabled` flag. This intentionally persists into the
+ * user's `~/.codex/config.toml` — toggling a codex-source server in Zuse
+ * toggles it for Codex everywhere, which is the documented semantics of a
+ * native-config passthrough.
+ */
+export const setCodexMcpEnabled = (
+	codexPath: string | null,
+	serverName: string,
+	enabled: boolean,
+): Effect.Effect<void, Error> =>
+	withCodexApp(codexPath, async (app) => {
+		await app.request("config/value/write", {
+			keyPath: `mcp_servers.${JSON.stringify(serverName)}.enabled`,
+			value: enabled,
+			mergeStrategy: "replace",
+		});
+		await app.request("config/mcpServer/reload", undefined);
+	});
+
+export const setCodexAppEnabled = (
+	codexPath: string | null,
+	appId: string,
+	enabled: boolean,
+): Effect.Effect<void, Error> =>
+	withCodexApp(codexPath, async (app) => {
+		await app.request("config/value/write", {
+			keyPath: `apps.${JSON.stringify(appId)}.enabled`,
+			value: enabled,
+			mergeStrategy: "replace",
+		});
+	});
+
+export interface CodexOauthLoginProgress {
+	readonly onAuthorizationUrl: (url: string) => void;
+}
+
+/**
+ * Codex-native OAuth login. Codex runs discovery/registration/PKCE and its
+ * own loopback listener; we surface the authorization URL (the renderer
+ * opens the browser) and resolve when `mcpServer/oauthLogin/completed`
+ * arrives for this server.
+ */
+export const codexMcpOauthLogin = (
+	codexPath: string | null,
+	serverName: string,
+	progress: CodexOauthLoginProgress,
+): Effect.Effect<{ success: boolean; error: string | null }, Error> => {
+	let completed: { success: boolean; error: string | null } | null = null;
+	let notifyCompleted: (() => void) | null = null;
+	return withCodexApp(
+		codexPath,
+		async (app) => {
+			const done = new Promise<void>((resolve) => {
+				notifyCompleted = resolve;
+				if (completed !== null) resolve();
+			});
+			const login = await app.request<McpServerOauthLoginResponse>(
+				"mcpServer/oauth/login",
+				{ name: serverName, timeoutSecs: 300 },
+			);
+			progress.onAuthorizationUrl(login.authorizationUrl);
+			await done;
+			return completed ?? { success: false, error: "login did not complete" };
+		},
+		{
+			onNotification: (notification) => {
+				if (notification.method !== "mcpServer/oauthLogin/completed") return;
+				const params = notification.params as {
+					name?: string;
+					success?: boolean;
+					error?: string;
+				};
+				if (params.name !== serverName) return;
+				completed = {
+					success: params.success === true,
+					error: params.error ?? null,
+				};
+				notifyCompleted?.();
+			},
+		},
+	);
+};

--- a/apps/server/src/mcp/handlers.ts
+++ b/apps/server/src/mcp/handlers.ts
@@ -1,0 +1,46 @@
+import { MemoizeRpcs } from "@zuse/contracts";
+import { Effect, Layer, Stream } from "effect";
+
+import { McpService } from "./services/mcp-service.ts";
+
+/**
+ * mcp.* RPC handlers — thin passthroughs to McpService. The renderer's
+ * composer popover polls `mcp.list` on open (cached snapshots return
+ * immediately after one initial discovery), the refresh button awaits
+ * `mcp.refresh`, and the settings pane drives `mcp.setEnabled` /
+ * `mcp.authenticate`.
+ */
+const McpList = MemoizeRpcs.toLayerHandler(
+	"mcp.list",
+	({ projectId, provider }) =>
+		Effect.flatMap(McpService, (svc) => svc.list({ projectId, provider })),
+);
+
+const McpRefresh = MemoizeRpcs.toLayerHandler(
+	"mcp.refresh",
+	({ projectId, provider }) =>
+		Effect.flatMap(McpService, (svc) => svc.refresh({ projectId, provider })),
+);
+
+const McpSetEnabled = MemoizeRpcs.toLayerHandler(
+	"mcp.setEnabled",
+	({ key, enabled, projectId }) =>
+		Effect.flatMap(McpService, (svc) =>
+			svc.setEnabled(key, enabled, projectId),
+		),
+);
+
+const McpAuthenticate = MemoizeRpcs.toLayerHandler(
+	"mcp.authenticate",
+	({ key, projectId }) =>
+		Stream.unwrap(
+			Effect.map(McpService, (svc) => svc.authenticate(key, projectId)),
+		),
+);
+
+export const McpHandlersLayer = Layer.mergeAll(
+	McpList,
+	McpRefresh,
+	McpSetEnabled,
+	McpAuthenticate,
+);

--- a/apps/server/src/mcp/layers/mcp-service.ts
+++ b/apps/server/src/mcp/layers/mcp-service.ts
@@ -1,0 +1,846 @@
+import { BROWSER_MCP_TOOLS } from "@zuse/agents/drivers/browser-mcp-tools";
+import {
+	ORCHESTRATION_MCP_SERVER_NAME,
+	ORCHESTRATION_MCP_TOOLS,
+} from "@zuse/agents/drivers/orchestration-tools";
+import { probeMcpServer } from "@zuse/agents/user-mcp/probe";
+import type { ResolvedMcpServer } from "@zuse/agents/user-mcp/types";
+import {
+	type FolderId,
+	type McpAuthenticateEvent,
+	McpConfigError,
+	type McpRequirement,
+	type McpServerDescriptor,
+	type McpServerStatus,
+	type ProviderId,
+} from "@zuse/contracts";
+import { type Cause, Effect, Layer, Queue, Stream } from "effect";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import { SqlClient } from "effect/unstable/sql";
+
+import { ConfigStoreService } from "../../config-store/services/config-store-service.ts";
+import { resolveCliPath } from "../../provider/availability.ts";
+import { CredentialsService } from "../../provider/services/credentials-service.ts";
+import { RepositorySettingsService } from "../../repository-settings/services/repository-settings-service.ts";
+import {
+	type ClaudeManagedInventory,
+	claudeMcpLogin,
+	readClaudeLiveMcpSnapshot,
+	readClaudeManagedMcpEntries,
+	reconcileClaudeManagedInventory,
+} from "../claude-status.ts";
+import {
+	type ReconciledCodexInventory,
+	reconcileCodexInventory,
+} from "../codex-inventory.ts";
+import {
+	codexMcpOauthLogin,
+	readCodexLiveMcpSnapshot,
+	setCodexAppEnabled,
+	setCodexMcpEnabled,
+} from "../codex-status.ts";
+import { getValidMcpAccessToken, runMcpOauthFlow } from "../mcp-oauth.ts";
+import {
+	expandEnvRefs,
+	type NativeMcpServer,
+	readNativeServers,
+} from "../native-config.ts";
+import { type McpScope, McpService } from "../services/mcp-service.ts";
+
+const BUILTIN_ZUSE = "zuse";
+/** Codex config.toml entries the Codex driver writes for Zuse's gateway. */
+const RESERVED_CODEX_NAMES = [BUILTIN_ZUSE, ORCHESTRATION_MCP_SERVER_NAME];
+
+const keyFor = (server: NativeMcpServer): string =>
+	server.source === "codex" ? `codex:${server.name}` : `claude:${server.name}`;
+
+const toDescriptor = (
+	server: NativeMcpServer,
+	disabledKeys: ReadonlySet<string>,
+): McpServerDescriptor => ({
+	key: keyFor(server),
+	name: server.name,
+	source: server.source,
+	kind: "configured",
+	parentKey: null,
+	availableProviders: [server.source === "codex" ? "codex" : "claude"],
+	transport: server.transport,
+	command: server.command,
+	args: server.args,
+	url: server.url,
+	envVarNames: server.envVarNames,
+	enabledInConfig: server.enabledInConfig,
+	disabledByZuse: disabledKeys.has(keyFor(server)),
+	toggleSupported: true,
+	authenticationAction: server.transport === "stdio" ? null : "native-oauth",
+	manageUrl: null,
+});
+
+const builtinDescriptor = (name: string): McpServerDescriptor => ({
+	key: `builtin:${name}`,
+	name,
+	source: "builtin",
+	kind: "builtin",
+	parentKey: null,
+	availableProviders: [
+		"claude",
+		"codex",
+		"grok",
+		"gemini",
+		"cursor",
+		"opencode",
+	],
+	transport: "http",
+	command: null,
+	args: [],
+	url: null,
+	envVarNames: [],
+	enabledInConfig: true,
+	disabledByZuse: false,
+	toggleSupported: false,
+	authenticationAction: null,
+	manageUrl: null,
+});
+
+const builtinStatus = (
+	name: string,
+	toolNames: ReadonlyArray<string>,
+): McpServerStatus => ({
+	key: `builtin:${name}`,
+	name,
+	source: "builtin",
+	state: "connected",
+	toolCount: toolNames.length,
+	toolNames,
+	error: null,
+	authMethod: null,
+	requirements: [],
+	checkedAt: 0,
+});
+
+const BUILTIN_DESCRIPTORS: ReadonlyArray<McpServerDescriptor> = [
+	builtinDescriptor(BUILTIN_ZUSE),
+	builtinDescriptor(ORCHESTRATION_MCP_SERVER_NAME),
+];
+
+const BUILTIN_STATUSES: ReadonlyArray<McpServerStatus> = [
+	builtinStatus(BUILTIN_ZUSE, [
+		"ask_user_question",
+		...BROWSER_MCP_TOOLS.map((tool) => tool.name),
+	]),
+	builtinStatus(
+		ORCHESTRATION_MCP_SERVER_NAME,
+		ORCHESTRATION_MCP_TOOLS.map((tool) => tool.name),
+	),
+];
+
+const placeholderStatus = (
+	descriptor: McpServerDescriptor,
+	state: "connecting" | "disabled",
+): McpServerStatus => ({
+	key: descriptor.key,
+	name: descriptor.name,
+	source: descriptor.source,
+	state,
+	toolCount: null,
+	toolNames: [],
+	error: null,
+	authMethod: null,
+	requirements: [],
+	checkedAt: 0,
+});
+
+const envRequirements = (server: NativeMcpServer): McpRequirement[] => {
+	const requirements: McpRequirement[] = [];
+	for (const name of server.envVarNames) {
+		requirements.push({
+			kind: "env",
+			detail: `environment variable ${name}`,
+			satisfied:
+				server.env[name] !== undefined || process.env[name] !== undefined,
+		});
+	}
+	if (server.bearerTokenEnvVar !== null) {
+		requirements.push({
+			kind: "env",
+			detail: `environment variable ${server.bearerTokenEnvVar}`,
+			satisfied: process.env[server.bearerTokenEnvVar] !== undefined,
+		});
+	}
+	return requirements;
+};
+
+const expandRecord = (
+	record: Readonly<Record<string, string>>,
+	localEnv: Readonly<Record<string, string>>,
+): Record<string, string> =>
+	Object.fromEntries(
+		Object.entries(record).map(([k, v]) => [k, expandEnvRefs(v, localEnv)]),
+	);
+
+/** Env-expand a native entry and inject a held OAuth token, if any. */
+const resolveServer = (
+	server: NativeMcpServer,
+	accessToken: string | null,
+): ResolvedMcpServer => {
+	const expand = (text: string): string => expandEnvRefs(text, server.env);
+	if (server.transport === "stdio") {
+		return {
+			name: server.name,
+			transport: "stdio",
+			command: expand(server.command ?? ""),
+			args: server.args.map(expand),
+			env: expandRecord(server.env, server.env),
+		};
+	}
+	const headers = expandRecord(server.headers, server.env);
+	if (accessToken !== null && headers.Authorization === undefined) {
+		headers.Authorization = `Bearer ${accessToken}`;
+	}
+	return {
+		name: server.name,
+		transport: server.transport,
+		url: expand(server.url ?? ""),
+		headers,
+	};
+};
+
+export const McpServiceLive = Layer.effect(
+	McpService,
+	Effect.gen(function* () {
+		const configStore = yield* ConfigStoreService;
+		const repositorySettings = yield* RepositorySettingsService;
+		const credentials = yield* CredentialsService;
+		const sql = yield* SqlClient.SqlClient;
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+		// Provider inventories and statuses stay cached until an explicit refresh
+		// or a mutation invalidates them. Normal popover polling is read-only.
+		const statusCache = new Map<string, McpServerStatus>();
+		const claudeInventoryCache = new Map<string, ClaudeManagedInventory>();
+		const codexInventoryCache = new Map<string, ReconciledCodexInventory>();
+		const inventoryCacheKey = (cwd: string | null): string => cwd ?? "<global>";
+
+		const codexPath = (): Effect.Effect<string | null> =>
+			resolveCliPath("codex").pipe(
+				Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+			);
+		const claudePath = (): Effect.Effect<string | null> =>
+			resolveCliPath("claude").pipe(
+				Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+			);
+
+		const projectPath = (projectId: FolderId): Effect.Effect<string | null> =>
+			Effect.gen(function* () {
+				const rows = yield* sql<{ readonly path: string }>`
+					SELECT path FROM projects WHERE id = ${projectId} LIMIT 1
+				`.pipe(Effect.orDie);
+				return rows[0]?.path ?? null;
+			});
+
+		const oauthStore = (key: string) => ({
+			load: () =>
+				Effect.runPromise(
+					credentials
+						.getMcpOauth(key)
+						.pipe(Effect.catch(() => Effect.succeed(null))),
+				),
+			save: (bundleJson: string) =>
+				Effect.runPromise(
+					credentials
+						.setMcpOauth(key, bundleJson)
+						.pipe(Effect.catch(() => Effect.void)),
+				),
+		});
+
+		interface Inventory {
+			readonly cwd: string | null;
+			readonly native: ReadonlyArray<NativeMcpServer>;
+			readonly disabledKeys: ReadonlySet<string>;
+			readonly descriptors: ReadonlyArray<McpServerDescriptor>;
+			readonly includeClaudeLive: boolean;
+			readonly claudeManaged: ClaudeManagedInventory;
+			readonly includeCodexLive: boolean;
+		}
+
+		const sourcesMatch = (
+			server: NativeMcpServer,
+			provider: ProviderId | undefined,
+		): boolean =>
+			provider === undefined ||
+			(provider === "codex"
+				? server.source === "codex"
+				: provider === "claude"
+					? server.source !== "codex"
+					: false);
+
+		const inventoryFor = (scope: McpScope): Effect.Effect<Inventory> =>
+			Effect.gen(function* () {
+				const cwd =
+					scope.projectId === undefined
+						? null
+						: yield* projectPath(scope.projectId);
+				const settings = yield* configStore.getSettings().pipe(Effect.orDie);
+				const repoDisabled =
+					scope.projectId === undefined
+						? []
+						: (yield* repositorySettings
+								.get(scope.projectId)
+								.pipe(Effect.orDie)).mcpDisabledServers;
+				const disabledKeys = new Set([
+					...settings.mcpDisabledServers,
+					...repoDisabled,
+				]);
+				const native = yield* Effect.sync(() =>
+					readNativeServers({
+						cwd,
+						excludeCodexNames: RESERVED_CODEX_NAMES,
+					}),
+				).pipe(
+					Effect.map((servers) =>
+						servers.filter((server) => sourcesMatch(server, scope.provider)),
+					),
+				);
+				const configuredDescriptors = native.map((server) =>
+					toDescriptor(server, disabledKeys),
+				);
+				const configuredKeys = new Set(
+					configuredDescriptors.map((descriptor) => descriptor.key),
+				);
+				const includeClaudeLive =
+					scope.provider === undefined || scope.provider === "claude";
+				const configuredClaude = configuredDescriptors.filter((descriptor) =>
+					descriptor.source.startsWith("claude-"),
+				);
+				const claudeManaged = includeClaudeLive
+					? (claudeInventoryCache.get(inventoryCacheKey(cwd)) ??
+						reconcileClaudeManagedInventory({
+							configured: configuredClaude,
+							entries: readClaudeManagedMcpEntries(),
+						}))
+					: { descriptors: [], statuses: [] };
+				const includeCodexLive =
+					scope.provider === undefined || scope.provider === "codex";
+				const liveDescriptors = includeCodexLive
+					? (
+							codexInventoryCache.get(inventoryCacheKey(cwd))?.descriptors ?? []
+						).filter((descriptor) => !configuredKeys.has(descriptor.key))
+					: [];
+				return {
+					cwd,
+					native,
+					disabledKeys,
+					descriptors: [
+						...BUILTIN_DESCRIPTORS,
+						...configuredDescriptors,
+						...claudeManaged.descriptors.filter(
+							(descriptor) => !configuredKeys.has(descriptor.key),
+						),
+						...liveDescriptors,
+					],
+					includeClaudeLive,
+					claudeManaged,
+					includeCodexLive,
+				};
+			});
+
+		const claudeProbeStatus = (
+			server: NativeMcpServer,
+		): Effect.Effect<McpServerStatus> =>
+			Effect.gen(function* () {
+				const key = keyFor(server);
+				const token =
+					server.transport === "stdio" || server.url === null
+						? null
+						: yield* getValidMcpAccessToken({
+								serverUrl: expandEnvRefs(server.url, server.env),
+								store: oauthStore(key),
+							});
+				const probe = yield* probeMcpServer(resolveServer(server, token));
+				const requirements = envRequirements(server);
+				if (probe.state === "needs-auth") {
+					requirements.push({
+						kind: "auth",
+						detail:
+							probe.authMethod === "token"
+								? "access token required"
+								: "sign-in required",
+						satisfied: false,
+					});
+				}
+				if (probe.error?.startsWith("command not found") === true) {
+					requirements.push({
+						kind: "command",
+						detail: server.command ?? "",
+						satisfied: false,
+					});
+				}
+				return {
+					key,
+					name: server.name,
+					source: server.source,
+					state: probe.state,
+					toolCount:
+						probe.state === "connected" ? probe.toolNames.length : null,
+					toolNames: probe.toolNames,
+					error: probe.error,
+					authMethod: probe.authMethod,
+					requirements,
+					checkedAt: Date.now(),
+				};
+			});
+
+		const codexInventoryStatuses = (
+			servers: ReadonlyArray<NativeMcpServer>,
+			inventory: Inventory,
+		): Effect.Effect<ReconciledCodexInventory> =>
+			Effect.gen(function* () {
+				const path = yield* codexPath();
+				const live = yield* readCodexLiveMcpSnapshot(path, inventory.cwd).pipe(
+					Effect.catch((cause) => Effect.succeed(cause)),
+				);
+				const now = Date.now();
+				const configured = servers.map((server) => ({
+					descriptor: toDescriptor(server, inventory.disabledKeys),
+					requirements: envRequirements(server),
+				}));
+				if (live instanceof Error) {
+					return {
+						descriptors: configured.map((entry) => entry.descriptor),
+						statuses: configured.map(
+							(entry): McpServerStatus => ({
+								key: entry.descriptor.key,
+								name: entry.descriptor.name,
+								source: entry.descriptor.source,
+								state:
+									entry.descriptor.disabledByZuse ||
+									!entry.descriptor.enabledInConfig
+										? "disabled"
+										: "error",
+								toolCount: null,
+								toolNames: [],
+								error:
+									entry.descriptor.disabledByZuse ||
+									!entry.descriptor.enabledInConfig
+										? null
+										: `could not query Codex: ${live.message}`,
+								authMethod: null,
+								requirements: [...entry.requirements],
+								checkedAt: now,
+							}),
+						),
+					};
+				}
+				return reconcileCodexInventory({
+					configured,
+					live,
+					excludedNames: new Set(RESERVED_CODEX_NAMES),
+					now,
+				});
+			});
+
+		const refreshStatuses = (
+			inventory: Inventory,
+		): Effect.Effect<McpServerStatus[]> =>
+			Effect.gen(function* () {
+				const activeClaude: NativeMcpServer[] = [];
+				const results: McpServerStatus[] = [];
+				for (const server of inventory.native.filter(
+					(server) => server.source !== "codex",
+				)) {
+					const key = keyFor(server);
+					if (inventory.disabledKeys.has(key) || !server.enabledInConfig) {
+						const descriptor = toDescriptor(server, inventory.disabledKeys);
+						results.push(placeholderStatus(descriptor, "disabled"));
+					} else {
+						activeClaude.push(server);
+					}
+				}
+				const claudeStatuses = yield* Effect.forEach(
+					activeClaude,
+					claudeProbeStatus,
+					{ concurrency: 4 },
+				);
+				const configuredClaude = inventory.descriptors.filter(
+					(descriptor) =>
+						descriptor.kind === "configured" &&
+						descriptor.source.startsWith("claude-"),
+				);
+				const claudeManaged = inventory.includeClaudeLive
+					? yield* Effect.gen(function* () {
+							const path = yield* claudePath();
+							const entries = yield* readClaudeLiveMcpSnapshot(
+								path,
+								inventory.cwd,
+							).pipe(
+								Effect.catch(() =>
+									Effect.sync(() => {
+										const now = Date.now();
+										return readClaudeManagedMcpEntries().map((entry) => ({
+											...entry,
+											checkedAt: now,
+										}));
+									}),
+								),
+							);
+							return reconcileClaudeManagedInventory({
+								configured: configuredClaude,
+								entries,
+							});
+						})
+					: { descriptors: [], statuses: [] };
+				if (inventory.includeClaudeLive) {
+					claudeInventoryCache.set(
+						inventoryCacheKey(inventory.cwd),
+						claudeManaged,
+					);
+				}
+				const codexServers = inventory.native.filter(
+					(server) => server.source === "codex",
+				);
+				const codexInventory = inventory.includeCodexLive
+					? yield* codexInventoryStatuses(codexServers, inventory)
+					: { descriptors: [], statuses: [] };
+				if (inventory.includeCodexLive) {
+					codexInventoryCache.set(
+						inventoryCacheKey(inventory.cwd),
+						codexInventory,
+					);
+				}
+				results.push(
+					...claudeStatuses,
+					...claudeManaged.statuses,
+					...codexInventory.statuses,
+				);
+				const deduplicated = [
+					...new Map(results.map((status) => [status.key, status])).values(),
+				];
+				for (const status of deduplicated) statusCache.set(status.key, status);
+				return deduplicated;
+			});
+
+		const statusesFromCache = (inventory: Inventory): McpServerStatus[] =>
+			inventory.descriptors.map((descriptor) => {
+				if (descriptor.source === "builtin") {
+					return (
+						BUILTIN_STATUSES.find((status) => status.key === descriptor.key) ??
+						placeholderStatus(descriptor, "connecting")
+					);
+				}
+				if (descriptor.disabledByZuse || !descriptor.enabledInConfig) {
+					return placeholderStatus(descriptor, "disabled");
+				}
+				const cached = statusCache.get(descriptor.key);
+				const managed = inventory.claudeManaged.statuses.find(
+					(status) => status.key === descriptor.key,
+				);
+				return cached !== undefined && cached.state !== "disabled"
+					? cached
+					: (managed ?? placeholderStatus(descriptor, "connecting"));
+			});
+
+		const list: McpService["Service"]["list"] = (scope) =>
+			Effect.gen(function* () {
+				let inventory = yield* inventoryFor(scope);
+				const needsInitialDiscovery =
+					(inventory.includeClaudeLive &&
+						!claudeInventoryCache.has(inventoryCacheKey(inventory.cwd))) ||
+					(inventory.includeCodexLive &&
+						!codexInventoryCache.has(inventoryCacheKey(inventory.cwd)));
+				if (needsInitialDiscovery) {
+					yield* refreshStatuses(inventory);
+					inventory = yield* inventoryFor(scope);
+				}
+				return {
+					servers: inventory.descriptors,
+					statuses: statusesFromCache(inventory),
+				};
+			});
+
+		const refresh: McpService["Service"]["refresh"] = (scope) =>
+			Effect.gen(function* () {
+				const inventory = yield* inventoryFor(scope);
+				yield* refreshStatuses(inventory);
+				const latest = yield* inventoryFor(scope);
+				return {
+					servers: latest.descriptors,
+					statuses: statusesFromCache(latest),
+				};
+			});
+
+		const setEnabled: McpService["Service"]["setEnabled"] = (
+			key,
+			enabled,
+			projectId,
+		) =>
+			Effect.gen(function* () {
+				if (key.startsWith("builtin:")) {
+					return yield* Effect.fail(
+						new McpConfigError({
+							key,
+							reason: "built-in servers cannot be toggled",
+						}),
+					);
+				}
+				if (key.startsWith("codex-app:")) {
+					const path = yield* codexPath();
+					yield* setCodexAppEnabled(
+						path,
+						key.slice("codex-app:".length),
+						enabled,
+					).pipe(
+						Effect.mapError(
+							(cause) => new McpConfigError({ key, reason: cause.message }),
+						),
+					);
+					codexInventoryCache.clear();
+					statusCache.delete(key);
+					return;
+				}
+				if (key.startsWith("codex-live:") || key.startsWith("codex-apps:")) {
+					return yield* Effect.fail(
+						new McpConfigError({
+							key,
+							reason: "this provider-managed entry cannot be toggled directly",
+						}),
+					);
+				}
+				if (key.startsWith("codex:")) {
+					// Codex owns its config — write the native `enabled` flag (this
+					// affects Codex everywhere, including outside Zuse; per-repo
+					// scoping is a claude-source-only concept).
+					const path = yield* codexPath();
+					yield* setCodexMcpEnabled(
+						path,
+						key.slice("codex:".length),
+						enabled,
+					).pipe(
+						Effect.mapError(
+							(cause) => new McpConfigError({ key, reason: cause.message }),
+						),
+					);
+					codexInventoryCache.clear();
+					statusCache.delete(key);
+					return;
+				}
+				const toggle = (current: ReadonlyArray<string>): string[] =>
+					enabled
+						? current.filter((k) => k !== key)
+						: current.includes(key)
+							? [...current]
+							: [...current, key];
+				if (projectId === undefined) {
+					const settings = yield* configStore.getSettings().pipe(Effect.orDie);
+					yield* configStore
+						.updateSettings({
+							mcpDisabledServers: toggle(settings.mcpDisabledServers),
+						})
+						.pipe(Effect.orDie);
+				} else {
+					const settings = yield* repositorySettings
+						.get(projectId)
+						.pipe(Effect.orDie);
+					yield* repositorySettings
+						.update(projectId, {
+							mcpDisabledServers: toggle(settings.mcpDisabledServers),
+						})
+						.pipe(Effect.orDie);
+				}
+			});
+
+		const authenticate: McpService["Service"]["authenticate"] = (
+			key,
+			projectId,
+		) =>
+			Stream.unwrap(
+				Effect.gen(function* () {
+					const events = yield* Queue.make<McpAuthenticateEvent, Cause.Done>();
+					const emit = (event: McpAuthenticateEvent): void => {
+						Queue.offerUnsafe(events, event);
+					};
+					const finish = (event: McpAuthenticateEvent): void => {
+						emit(event);
+						Queue.endUnsafe(events);
+					};
+					const inventory = yield* inventoryFor({ projectId });
+					const descriptor = inventory.descriptors.find(
+						(candidate) => candidate.key === key,
+					);
+					if (key.startsWith("codex-app:")) {
+						if (
+							descriptor?.authenticationAction !== "open-url" ||
+							descriptor.manageUrl === null
+						) {
+							return yield* Effect.fail(
+								new McpConfigError({
+									key,
+									reason: "this connector has no available sign-in URL",
+								}),
+							);
+						}
+						emit({ _tag: "browser-opened", url: descriptor.manageUrl });
+						codexInventoryCache.clear();
+						statusCache.delete(key);
+						finish({ _tag: "completed" });
+						return Stream.fromQueue(events);
+					}
+					if (key.startsWith("claude-live:")) {
+						const serverName = key.slice("claude-live:".length);
+						const flow = Effect.gen(function* () {
+							const path = yield* claudePath();
+							const outcome = yield* claudeMcpLogin(
+								path,
+								inventory.cwd,
+								serverName,
+								{
+									onAuthorizationUrl: (url) => {
+										emit({ _tag: "browser-opened", url });
+									},
+								},
+							).pipe(
+								Effect.catch((cause) =>
+									Effect.succeed({ success: false, error: cause.message }),
+								),
+							);
+							claudeInventoryCache.delete(inventoryCacheKey(inventory.cwd));
+							statusCache.delete(key);
+							finish(
+								outcome.success
+									? { _tag: "completed" }
+									: {
+											_tag: "failed",
+											error: outcome.error ?? "sign-in did not complete",
+										},
+							);
+						});
+						yield* Effect.forkDetach(flow);
+						return Stream.fromQueue(events);
+					}
+					const server = inventory.native.find(
+						(candidate) => keyFor(candidate) === key,
+					);
+					const liveCodexName = key.startsWith("codex-live:")
+						? key.slice("codex-live:".length)
+						: null;
+					if (server === undefined && liveCodexName === null) {
+						return yield* Effect.fail(
+							new McpConfigError({ key, reason: "unknown MCP server" }),
+						);
+					}
+					const flow: Effect.Effect<void> = Effect.gen(function* () {
+						if (server?.source === "codex" || liveCodexName !== null) {
+							const path = yield* codexPath();
+							const serverName = liveCodexName ?? server?.name ?? "";
+							const outcome = yield* codexMcpOauthLogin(path, serverName, {
+								onAuthorizationUrl: (url) =>
+									emit({ _tag: "browser-opened", url }),
+							}).pipe(
+								Effect.catch((cause) =>
+									Effect.succeed({
+										success: false,
+										error: cause.message,
+									}),
+								),
+							);
+							finish(
+								outcome.success
+									? { _tag: "completed" }
+									: {
+											_tag: "failed",
+											error: outcome.error ?? "sign-in did not complete",
+										},
+							);
+						} else if (
+							server === undefined ||
+							server.transport === "stdio" ||
+							server.url === null
+						) {
+							finish({
+								_tag: "failed",
+								error:
+									"stdio servers authenticate through their own env/config",
+							});
+						} else {
+							const outcome = yield* runMcpOauthFlow({
+								serverUrl: expandEnvRefs(server.url, server.env),
+								store: oauthStore(key),
+								onAuthorizationUrl: (url) => {
+									emit({ _tag: "browser-opened", url });
+								},
+							}).pipe(
+								Effect.as<Error | null>(null),
+								Effect.catch((cause) => Effect.succeed(cause)),
+							);
+							finish(
+								outcome === null
+									? { _tag: "completed" }
+									: { _tag: "failed", error: outcome.message },
+							);
+						}
+						if (liveCodexName !== null || server?.source === "codex") {
+							codexInventoryCache.clear();
+						}
+						statusCache.delete(key);
+					});
+					yield* Effect.forkDetach(flow);
+					return Stream.fromQueue(events);
+				}),
+			);
+
+		const resolveForClaudeSession: McpService["Service"]["resolveForClaudeSession"] =
+			(cwd) =>
+				Effect.gen(function* () {
+					const settings = yield* configStore.getSettings();
+					const native = readNativeServers({
+						cwd,
+						excludeCodexNames: RESERVED_CODEX_NAMES,
+					}).filter(
+						(server) =>
+							server.source !== "codex" &&
+							server.enabledInConfig &&
+							!settings.mcpDisabledServers.includes(keyFor(server)),
+					);
+					// Per-repository disables also apply when the cwd maps to a known
+					// project (worktrees resolve to the project's repo settings file
+					// living in the checkout itself — read via the repo service when
+					// a projectId is known; sessions pass cwd only, so match by path).
+					const rows = yield* sql<{ readonly id: string }>`
+						SELECT id FROM projects WHERE path = ${cwd} LIMIT 1
+					`.pipe(Effect.catch(() => Effect.succeed([])));
+					const projectId = rows[0]?.id as FolderId | undefined;
+					const repoDisabled =
+						projectId === undefined
+							? new Set<string>()
+							: new Set(
+									(yield* repositorySettings
+										.get(projectId)
+										.pipe(
+											Effect.catch(() =>
+												Effect.succeed({ mcpDisabledServers: [] }),
+											),
+										)).mcpDisabledServers,
+								);
+					const resolved: ResolvedMcpServer[] = [];
+					for (const server of native) {
+						if (repoDisabled.has(keyFor(server))) continue;
+						const token =
+							server.transport === "stdio" || server.url === null
+								? null
+								: yield* getValidMcpAccessToken({
+										serverUrl: expandEnvRefs(server.url, server.env),
+										store: oauthStore(keyFor(server)),
+									});
+						resolved.push(resolveServer(server, token));
+					}
+					return resolved;
+				}).pipe(Effect.catch(() => Effect.succeed([])));
+
+		return {
+			list,
+			refresh,
+			setEnabled,
+			authenticate,
+			resolveForClaudeSession,
+		} as const;
+	}),
+);

--- a/apps/server/src/mcp/mcp-oauth.ts
+++ b/apps/server/src/mcp/mcp-oauth.ts
@@ -1,0 +1,225 @@
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import {
+	auth,
+	type OAuthClientProvider,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+	OAuthClientInformationMixed,
+	OAuthClientMetadata,
+	OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { Effect } from "effect";
+
+/**
+ * Everything the MCP SDK's OAuthClientProvider needs to persist between
+ * runs, serialized as one JSON keychain entry per server
+ * (`mcpOAuth:<serverKey>`): the dynamic client registration, the token
+ * set, and the in-flight PKCE verifier.
+ */
+interface McpOauthBundle {
+	clientInformation?: OAuthClientInformationMixed;
+	tokens?: OAuthTokens;
+	codeVerifier?: string;
+}
+
+const parseBundle = (raw: string | null): McpOauthBundle => {
+	if (raw === null) return {};
+	try {
+		return JSON.parse(raw) as McpOauthBundle;
+	} catch {
+		return {};
+	}
+};
+
+export interface McpOauthStore {
+	readonly load: () => Promise<string | null>;
+	readonly save: (bundleJson: string) => Promise<void>;
+}
+
+class RedirectRequested extends Error {
+	constructor(readonly url: string) {
+		super("oauth redirect requested");
+	}
+}
+
+const makeProvider = (options: {
+	readonly bundle: McpOauthBundle;
+	readonly redirectUrl: string | undefined;
+	readonly persist: () => Promise<void>;
+	readonly onRedirect: (url: string) => void;
+}): OAuthClientProvider => ({
+	get redirectUrl() {
+		return options.redirectUrl;
+	},
+	get clientMetadata(): OAuthClientMetadata {
+		return {
+			client_name: "Zuse",
+			redirect_uris:
+				options.redirectUrl === undefined ? [] : [options.redirectUrl],
+			grant_types: ["authorization_code", "refresh_token"],
+			response_types: ["code"],
+			token_endpoint_auth_method: "none",
+		};
+	},
+	clientInformation: () => options.bundle.clientInformation,
+	saveClientInformation: async (clientInformation) => {
+		options.bundle.clientInformation = clientInformation;
+		await options.persist();
+	},
+	tokens: () => options.bundle.tokens,
+	saveTokens: async (tokens) => {
+		options.bundle.tokens = tokens;
+		await options.persist();
+	},
+	redirectToAuthorization: (authorizationUrl) => {
+		options.onRedirect(authorizationUrl.toString());
+	},
+	saveCodeVerifier: async (codeVerifier) => {
+		options.bundle.codeVerifier = codeVerifier;
+		await options.persist();
+	},
+	codeVerifier: () => options.bundle.codeVerifier ?? "",
+});
+
+const CALLBACK_PATH = "/callback";
+const CALLBACK_PAGE = `<!doctype html><meta charset="utf-8"><title>Zuse</title>
+<body style="font-family:system-ui;display:grid;place-items:center;height:100vh;margin:0">
+<p>You're connected. You can close this tab and return to Zuse.</p></body>`;
+
+/**
+ * One loopback HTTP listener per flow, on an ephemeral 127.0.0.1 port —
+ * the same shape the WorkOS dev flow uses. Resolves with the `code` query
+ * param of the first `/callback` hit.
+ */
+const listenForCallback = (): Promise<{
+	redirectUrl: string;
+	waitForCode: Promise<string>;
+	close: () => void;
+}> =>
+	new Promise((resolveListener, rejectListener) => {
+		let resolveCode: (code: string) => void;
+		let rejectCode: (error: Error) => void;
+		const waitForCode = new Promise<string>((resolve, reject) => {
+			resolveCode = resolve;
+			rejectCode = reject;
+		});
+		const server = http.createServer((req, res) => {
+			const url = new URL(req.url ?? "/", "http://127.0.0.1");
+			if (url.pathname !== CALLBACK_PATH) {
+				res.writeHead(404).end();
+				return;
+			}
+			res.writeHead(200, { "content-type": "text/html" }).end(CALLBACK_PAGE);
+			const code = url.searchParams.get("code");
+			const error = url.searchParams.get("error");
+			if (code !== null) resolveCode(code);
+			else {
+				rejectCode(
+					new Error(
+						error !== null
+							? `authorization failed: ${error}`
+							: "authorization response had no code",
+					),
+				);
+			}
+		});
+		server.once("error", rejectListener);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address() as AddressInfo;
+			resolveListener({
+				redirectUrl: `http://127.0.0.1:${address.port}${CALLBACK_PATH}`,
+				waitForCode,
+				close: () => server.close(),
+			});
+		});
+	});
+
+const CODE_TIMEOUT_MS = 300_000;
+
+/**
+ * Full OAuth 2.1 flow for a claude-source http server: metadata discovery,
+ * dynamic client registration, PKCE, loopback redirect. The SDK's `auth()`
+ * drives the protocol; we supply persistence (keychain via `store`) and
+ * hand the authorization URL to `onAuthorizationUrl` (the renderer opens
+ * the browser). Resolves once tokens are saved.
+ */
+export const runMcpOauthFlow = (options: {
+	readonly serverUrl: string;
+	readonly store: McpOauthStore;
+	readonly onAuthorizationUrl: (url: string) => void;
+}): Effect.Effect<void, Error> =>
+	Effect.tryPromise({
+		try: async () => {
+			const bundle = parseBundle(await options.store.load());
+			const listener = await listenForCallback();
+			try {
+				const provider = makeProvider({
+					bundle,
+					redirectUrl: listener.redirectUrl,
+					persist: () => options.store.save(JSON.stringify(bundle)),
+					onRedirect: options.onAuthorizationUrl,
+				});
+				const first = await auth(provider, { serverUrl: options.serverUrl });
+				if (first === "AUTHORIZED") return;
+				const code = await Promise.race([
+					listener.waitForCode,
+					new Promise<never>((_resolve, reject) =>
+						setTimeout(
+							() => reject(new Error("timed out waiting for the browser")),
+							CODE_TIMEOUT_MS,
+						),
+					),
+				]);
+				const second = await auth(provider, {
+					serverUrl: options.serverUrl,
+					authorizationCode: code,
+				});
+				if (second !== "AUTHORIZED") {
+					throw new Error("token exchange did not complete");
+				}
+			} finally {
+				listener.close();
+			}
+		},
+		catch: (cause) =>
+			cause instanceof Error ? cause : new Error(String(cause)),
+	});
+
+/**
+ * Returns a currently-valid access token for header injection at session
+ * start / probe time, refreshing through the SDK when expired. Never
+ * interactive: if a fresh authorization would be needed, resolves `null`
+ * (the status layer then reports `needs-auth`).
+ */
+export const getValidMcpAccessToken = (options: {
+	readonly serverUrl: string;
+	readonly store: McpOauthStore;
+}): Effect.Effect<string | null> =>
+	Effect.tryPromise({
+		try: async () => {
+			const bundle = parseBundle(await options.store.load());
+			if (bundle.tokens === undefined) return null;
+			const provider = makeProvider({
+				bundle,
+				redirectUrl: undefined,
+				persist: () => options.store.save(JSON.stringify(bundle)),
+				onRedirect: (url) => {
+					throw new RedirectRequested(url);
+				},
+			});
+			try {
+				const result = await auth(provider, { serverUrl: options.serverUrl });
+				return result === "AUTHORIZED"
+					? (bundle.tokens?.access_token ?? null)
+					: null;
+			} catch {
+				// Refresh failed (revoked, expired refresh token, offline) — fall
+				// back to the stored access token if present; the server will 401
+				// and status will flip to needs-auth.
+				return bundle.tokens?.access_token ?? null;
+			}
+		},
+		catch: () => null,
+	}).pipe(Effect.catch(() => Effect.succeed(null)));

--- a/apps/server/src/mcp/native-config.ts
+++ b/apps/server/src/mcp/native-config.ts
@@ -1,0 +1,278 @@
+import * as fsSync from "node:fs";
+import { homedir } from "node:os";
+import * as Path from "node:path";
+
+import type { McpServerSource, McpTransport } from "@zuse/contracts";
+import { parse as parseToml } from "smol-toml";
+
+/**
+ * One MCP server as read from a native config file, before Zuse's
+ * enable/disable overrides or secret resolution are applied. Env/header
+ * values stay server-side; `envVarNames` feeds the requirements UI.
+ *
+ * Zuse keeps no MCP registry of its own — these files are the source of
+ * truth (see ADR 0032):
+ *   - `~/.claude.json`               → `mcpServers` (user scope) and
+ *                                      `projects[<cwd>].mcpServers` (local scope)
+ *   - `<cwd>/.mcp.json`              → project scope
+ *   - `~/.codex/config.toml`         → `[mcp_servers.<name>]`
+ */
+export interface NativeMcpServer {
+	readonly name: string;
+	readonly source: McpServerSource;
+	readonly transport: McpTransport;
+	readonly command: string | null;
+	readonly args: ReadonlyArray<string>;
+	readonly env: Readonly<Record<string, string>>;
+	readonly url: string | null;
+	readonly headers: Readonly<Record<string, string>>;
+	/** Codex `enabled = false` (claude configs have no such flag → true). */
+	readonly enabledInConfig: boolean;
+	/** `${VAR}` references found anywhere in the entry (requirements UI). */
+	readonly envVarNames: ReadonlyArray<string>;
+	/** Codex `bearer_token_env_var` — resolved from the env at spawn time. */
+	readonly bearerTokenEnvVar: string | null;
+	/** Codex `startup_timeout_sec`, when present. */
+	readonly startupTimeoutMs: number | null;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stringRecord = (value: unknown): Record<string, string> => {
+	if (!isRecord(value)) return {};
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(value)) {
+		if (typeof v === "string") out[k] = v;
+	}
+	return out;
+};
+
+const stringArray = (value: unknown): string[] =>
+	Array.isArray(value)
+		? value.filter((v): v is string => typeof v === "string")
+		: [];
+
+const ENV_REF = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+const collectEnvRefs = (entry: {
+	command: string | null;
+	args: ReadonlyArray<string>;
+	env: Readonly<Record<string, string>>;
+	url: string | null;
+	headers: Readonly<Record<string, string>>;
+}): string[] => {
+	const refs = new Set<string>();
+	const scan = (text: string | null): void => {
+		if (text === null) return;
+		for (const match of text.matchAll(ENV_REF)) {
+			const name = match[1];
+			if (name !== undefined) refs.add(name);
+		}
+	};
+	scan(entry.command);
+	for (const arg of entry.args) scan(arg);
+	for (const value of Object.values(entry.env)) scan(value);
+	scan(entry.url);
+	for (const value of Object.values(entry.headers)) scan(value);
+	return [...refs];
+};
+
+/**
+ * `${VAR}` expansion, matching Claude Code's config semantics: values come
+ * from the entry's own `env` block first, then the process environment.
+ * Unresolvable references are left verbatim (and reported as an unmet
+ * requirement by the status layer).
+ */
+export const expandEnvRefs = (
+	text: string,
+	localEnv: Readonly<Record<string, string>>,
+): string =>
+	text.replace(
+		ENV_REF,
+		(whole, name: string) => localEnv[name] ?? process.env[name] ?? whole,
+	);
+
+const VALID_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+
+const claudeEntry = (
+	name: string,
+	raw: unknown,
+	source: McpServerSource,
+): NativeMcpServer | null => {
+	if (!isRecord(raw) || !VALID_NAME.test(name)) return null;
+	const type = typeof raw.type === "string" ? raw.type : null;
+	const url = typeof raw.url === "string" ? raw.url : null;
+	const command = typeof raw.command === "string" ? raw.command : null;
+	// Claude Code treats a missing `type` as stdio when `command` is present
+	// and http when only `url` is.
+	const transport: McpTransport | null =
+		type === "http" || type === "sse"
+			? type
+			: type === "stdio" || (type === null && command !== null)
+				? "stdio"
+				: type === null && url !== null
+					? "http"
+					: null;
+	if (transport === null) return null;
+	if (transport === "stdio" && command === null) return null;
+	if (transport !== "stdio" && url === null) return null;
+	const base = {
+		command: transport === "stdio" ? command : null,
+		args: transport === "stdio" ? stringArray(raw.args) : [],
+		env: stringRecord(raw.env),
+		url: transport === "stdio" ? null : url,
+		headers: transport === "stdio" ? {} : stringRecord(raw.headers),
+	};
+	return {
+		name,
+		source,
+		transport,
+		...base,
+		enabledInConfig: true,
+		envVarNames: collectEnvRefs(base),
+		bearerTokenEnvVar: null,
+		startupTimeoutMs: null,
+	};
+};
+
+const entriesFrom = (
+	raw: unknown,
+	source: McpServerSource,
+): NativeMcpServer[] => {
+	if (!isRecord(raw)) return [];
+	const out: NativeMcpServer[] = [];
+	for (const [name, value] of Object.entries(raw)) {
+		const entry = claudeEntry(name, value, source);
+		if (entry !== null) out.push(entry);
+	}
+	return out;
+};
+
+/**
+ * Claude-source servers effective for `cwd`, already collapsed by Claude
+ * Code's own precedence: local (`~/.claude.json#projects[cwd]`) > project
+ * (`<cwd>/.mcp.json`) > user (`~/.claude.json#mcpServers`). One entry per
+ * name; `source` records the winning scope.
+ */
+export const parseClaudeServers = (
+	claudeJson: unknown,
+	mcpJson: unknown,
+	cwd: string | null,
+): NativeMcpServer[] => {
+	const byName = new Map<string, NativeMcpServer>();
+	const add = (entries: NativeMcpServer[]): void => {
+		for (const entry of entries) byName.set(entry.name, entry);
+	};
+	if (isRecord(claudeJson)) {
+		add(entriesFrom(claudeJson.mcpServers, "claude-user"));
+	}
+	if (isRecord(mcpJson)) {
+		add(entriesFrom(mcpJson.mcpServers, "claude-project"));
+	}
+	if (cwd !== null && isRecord(claudeJson) && isRecord(claudeJson.projects)) {
+		const project = (claudeJson.projects as Record<string, unknown>)[cwd];
+		if (isRecord(project)) {
+			add(entriesFrom(project.mcpServers, "claude-local"));
+		}
+	}
+	return [...byName.values()];
+};
+
+/**
+ * Codex-source servers from `[mcp_servers.*]`. Zuse's own gateway entries
+ * (`zuse`, `zuse-orchestration`) are written into this file by the Codex
+ * driver at session start — they are excluded here and rendered as static
+ * `builtin` rows instead.
+ */
+export const parseCodexServers = (
+	configToml: string,
+	excludeNames: ReadonlyArray<string>,
+): NativeMcpServer[] => {
+	let parsed: unknown;
+	try {
+		parsed = parseToml(configToml);
+	} catch {
+		return [];
+	}
+	if (!isRecord(parsed) || !isRecord(parsed.mcp_servers)) return [];
+	const out: NativeMcpServer[] = [];
+	for (const [name, raw] of Object.entries(parsed.mcp_servers)) {
+		if (!isRecord(raw) || !VALID_NAME.test(name)) continue;
+		if (excludeNames.includes(name)) continue;
+		const command = typeof raw.command === "string" ? raw.command : null;
+		const url = typeof raw.url === "string" ? raw.url : null;
+		const transport: McpTransport | null =
+			command !== null ? "stdio" : url !== null ? "http" : null;
+		if (transport === null) continue;
+		const base = {
+			command,
+			args: stringArray(raw.args),
+			env: stringRecord(raw.env),
+			url,
+			headers: stringRecord(raw.http_headers),
+		};
+		const startupTimeoutSec =
+			typeof raw.startup_timeout_sec === "number"
+				? raw.startup_timeout_sec
+				: null;
+		out.push({
+			name,
+			source: "codex",
+			transport,
+			...base,
+			enabledInConfig: raw.enabled !== false,
+			envVarNames: collectEnvRefs(base),
+			bearerTokenEnvVar:
+				typeof raw.bearer_token_env_var === "string"
+					? raw.bearer_token_env_var
+					: null,
+			startupTimeoutMs:
+				startupTimeoutSec !== null ? startupTimeoutSec * 1000 : null,
+		});
+	}
+	return out;
+};
+
+export const claudeJsonPath = (): string =>
+	Path.join(homedir(), ".claude.json");
+export const codexConfigPath = (): string =>
+	Path.join(homedir(), ".codex", "config.toml");
+export const projectMcpJsonPath = (cwd: string): string =>
+	Path.join(cwd, ".mcp.json");
+
+const readJsonFile = (filePath: string): unknown => {
+	try {
+		return JSON.parse(fsSync.readFileSync(filePath, "utf8")) as unknown;
+	} catch {
+		return null;
+	}
+};
+
+const readTextFile = (filePath: string): string => {
+	try {
+		return fsSync.readFileSync(filePath, "utf8");
+	} catch {
+		return "";
+	}
+};
+
+/**
+ * Synchronous read of every native source for one working directory. All
+ * reads are tolerant: a missing or malformed file contributes no servers
+ * rather than failing the inventory.
+ */
+export const readNativeServers = (options: {
+	readonly cwd: string | null;
+	readonly excludeCodexNames: ReadonlyArray<string>;
+}): NativeMcpServer[] => {
+	const claudeJson = readJsonFile(claudeJsonPath());
+	const mcpJson =
+		options.cwd !== null ? readJsonFile(projectMcpJsonPath(options.cwd)) : null;
+	const claude = parseClaudeServers(claudeJson, mcpJson, options.cwd);
+	const codex = parseCodexServers(
+		readTextFile(codexConfigPath()),
+		options.excludeCodexNames,
+	);
+	return [...claude, ...codex];
+};

--- a/apps/server/src/mcp/services/mcp-service.ts
+++ b/apps/server/src/mcp/services/mcp-service.ts
@@ -1,0 +1,64 @@
+import type { ResolvedMcpServer } from "@zuse/agents/user-mcp/types";
+
+import type {
+	FolderId,
+	McpAuthenticateEvent,
+	McpConfigError,
+	McpServerDescriptor,
+	McpServerStatus,
+	ProviderId,
+} from "@zuse/contracts";
+import { Context, type Effect, type Stream } from "effect";
+
+export interface McpScope {
+	readonly projectId?: FolderId | undefined;
+	readonly provider?: ProviderId | undefined;
+}
+
+/**
+ * Unified inventory over native MCP configs, provider-reported servers,
+ * plugins, connected apps, and Zuse's builtins, with live connection status.
+ * Provider definitions are never persisted by Zuse — only enable/disable
+ * overrides (settings + repository settings) and OAuth tokens (keychain).
+ */
+export interface McpServiceShape {
+	/** Inventory + cached statuses (bootstraps provider discovery once). */
+	readonly list: (scope: McpScope) => Effect.Effect<
+		{
+			readonly servers: ReadonlyArray<McpServerDescriptor>;
+			readonly statuses: ReadonlyArray<McpServerStatus>;
+		},
+		McpConfigError
+	>;
+	/** Force provider discovery and a status probe for every enabled server. */
+	readonly refresh: (scope: McpScope) => Effect.Effect<
+		{
+			readonly servers: ReadonlyArray<McpServerDescriptor>;
+			readonly statuses: ReadonlyArray<McpServerStatus>;
+		},
+		McpConfigError
+	>;
+	readonly setEnabled: (
+		key: string,
+		enabled: boolean,
+		projectId: FolderId | undefined,
+	) => Effect.Effect<void, McpConfigError>;
+	/** OAuth round-trip for a `needs-auth` server; emits progress events. */
+	readonly authenticate: (
+		key: string,
+		projectId: FolderId | undefined,
+	) => Stream.Stream<McpAuthenticateEvent, McpConfigError>;
+	/**
+	 * Enabled claude-source servers for a session working directory, env
+	 * expanded and stored OAuth tokens injected as Authorization headers.
+	 * Never fails — a config/keychain problem yields [] so session start is
+	 * unaffected.
+	 */
+	readonly resolveForClaudeSession: (
+		cwd: string,
+	) => Effect.Effect<ReadonlyArray<ResolvedMcpServer>>;
+}
+
+export class McpService extends Context.Service<McpService, McpServiceShape>()(
+	"memoize/McpService",
+) {}

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -38,6 +38,15 @@ const integrationAccountFor = (
 	accountId: string,
 ): string => `${integrationPrefix(integration)}${accountId}`;
 
+/**
+ * OAuth bundles for user MCP servers, one account per server descriptor
+ * key (`mcpOAuth:claude:<name>`). No legacy-service promotion — the prefix
+ * is new with this feature.
+ */
+const MCP_OAUTH_PREFIX = "mcpOAuth:";
+const mcpOauthAccountFor = (serverKey: string): string =>
+	`${MCP_OAUTH_PREFIX}${serverKey}`;
+
 const normalizeOrigin = (input: string): string => {
 	try {
 		return new URL(input).origin;
@@ -316,5 +325,21 @@ export const CredentialsServiceLive = Layer.succeed(
 					.filter((account) => account.startsWith(prefix))
 					.map((account) => account.slice(prefix.length));
 			}),
+		getMcpOauth: (serverKey) =>
+			tryKeychain("*", () =>
+				keytar.getPassword(SERVICE_NAME, mcpOauthAccountFor(serverKey)),
+			),
+		setMcpOauth: (serverKey, bundleJson) =>
+			tryKeychain("*", () =>
+				keytar.setPassword(
+					SERVICE_NAME,
+					mcpOauthAccountFor(serverKey),
+					bundleJson,
+				),
+			),
+		removeMcpOauth: (serverKey) =>
+			tryKeychain("*", () =>
+				keytar.deletePassword(SERVICE_NAME, mcpOauthAccountFor(serverKey)),
+			).pipe(Effect.asVoid),
 	}),
 );

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -27,6 +27,7 @@ import {
 import { Cache, Effect, FileSystem, Layer, Ref, Stream } from "effect";
 import { ChildProcessSpawner as CommandExecutor } from "effect/unstable/process";
 import { ConfigStoreService } from "../../config-store/services/config-store-service.ts";
+import { McpService } from "../../mcp/services/mcp-service.ts";
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
 import { probeAllProviders, resolveCliPath } from "../availability.ts";
 import { BrowserBridgeService } from "../services/browser-bridge-service.ts";
@@ -71,6 +72,7 @@ export const ProviderServiceLive = Layer.effect(
     const attachmentService = yield* AttachmentService;
     const browserBridge = yield* BrowserBridgeService;
     const configStore = yield* ConfigStoreService;
+    const mcp = yield* McpService;
     const runtime = yield* Effect.context<never>();
     const sessions = yield* Ref.make<Map<AgentSessionId, SessionEntry>>(
       new Map(),
@@ -394,6 +396,8 @@ export const ProviderServiceLive = Layer.effect(
               ),
             );
 
+            const userMcpServers = yield* mcp.resolveForClaudeSession(cwd);
+
             handle = yield* startClaudeSession(
               driverInput,
               cwd,
@@ -405,9 +409,10 @@ export const ProviderServiceLive = Layer.effect(
               resumeCursor,
               browserTools,
               // Control-plane orchestration tools (when autonomy != off) use
-              // their own provider-neutral `zuse-orchestration` MCP server.
-              orchestrationTools?.claudeTools ?? [],
-              orchestrationTools?.linearTools?.claudeTools ?? [],
+								// their own provider-neutral `zuse-orchestration` MCP server.
+								orchestrationTools?.claudeTools ?? [],
+								orchestrationTools?.linearTools?.claudeTools ?? [],
+								userMcpServers,
             ).pipe(Effect.provideService(AttachmentService, attachmentService));
           } else {
             // Same story as Claude: we don't ship the SDK's bundled native

--- a/apps/server/src/provider/services/credentials-service.ts
+++ b/apps/server/src/provider/services/credentials-service.ts
@@ -68,7 +68,7 @@ export interface CredentialsServiceShape {
   ) => Effect.Effect<void, CredentialsError>;
   readonly removeWorkosSession: () => Effect.Effect<void, CredentialsError>;
 
-  /** Secret JSON bundles for native third-party integrations. */
+	/** Secret JSON bundles for native third-party integrations. */
   readonly getIntegration: (
     integration: string,
     accountId: string,
@@ -82,9 +82,27 @@ export interface CredentialsServiceShape {
     integration: string,
     accountId: string,
   ) => Effect.Effect<void, CredentialsError>;
-  readonly listIntegrationAccounts: (
-    integration: string,
-  ) => Effect.Effect<ReadonlyArray<string>, CredentialsError>;
+	readonly listIntegrationAccounts: (
+		integration: string,
+	) => Effect.Effect<ReadonlyArray<string>, CredentialsError>;
+
+	/**
+   * OAuth token bundle for a user MCP server (claude-source servers Zuse
+   * authenticates itself — codex-source tokens live in Codex's own store).
+   * Keyed by the server's descriptor key (`claude:<name>`), namespaced
+   * `mcpOAuth:<key>`, stored as the JSON the MCP SDK's OAuthClientProvider
+   * round-trips (tokens + client registration). Never crosses the wire.
+   */
+  readonly getMcpOauth: (
+    serverKey: string,
+  ) => Effect.Effect<string | null, CredentialsError>;
+  readonly setMcpOauth: (
+    serverKey: string,
+    bundleJson: string,
+  ) => Effect.Effect<void, CredentialsError>;
+	readonly removeMcpOauth: (
+		serverKey: string,
+	) => Effect.Effect<void, CredentialsError>;
 }
 
 export class CredentialsService extends Context.Service<

--- a/apps/server/src/repository-settings/layers/repository-settings-service.ts
+++ b/apps/server/src/repository-settings/layers/repository-settings-service.ts
@@ -32,6 +32,7 @@ type MutableRepositorySettingsFile = {
   -readonly [K in keyof RepositorySettingsFile]: RepositorySettingsFile[K];
 } & {
   environmentVariables: Record<string, string>;
+  mcpDisabledServers: string[];
 };
 
 const isProviderId = (v: unknown): v is ProviderId =>
@@ -66,6 +67,7 @@ const emptyFileSettings = (): RepositorySettingsFile => ({
   autoRunAfterSetup: false,
   environmentVariables: {},
   fileIncludeGlobs: "",
+  mcpDisabledServers: [],
 });
 
 const parseEnvJson = (value: string | null): Record<string, string> => {
@@ -144,10 +146,12 @@ const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
   const settings: MutableRepositorySettingsFile = {
     ...fallback,
     environmentVariables: {},
+    mcpDisabledServers: [...fallback.mcpDisabledServers],
   };
   let section = "";
   const legacyIncludeSectionValues: string[] = [];
-  let pendingArrayKey: "file_include_globs" | null = null;
+  let pendingArrayKey: "file_include_globs" | "mcp_disabled_servers" | null =
+    null;
   let pendingArrayRaw = "";
   const parseTomlStringArray = (raw: string): string[] =>
     [...raw.matchAll(/"(?:\\.|[^"\\])*"|'[^']*'/g)]
@@ -158,6 +162,8 @@ const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
     if (pendingArrayKey === "file_include_globs") {
       settings.fileIncludeGlobs =
         parseTomlStringArray(pendingArrayRaw).join("\n");
+    } else if (pendingArrayKey === "mcp_disabled_servers") {
+      settings.mcpDisabledServers = parseTomlStringArray(pendingArrayRaw);
     }
     pendingArrayKey = null;
     pendingArrayRaw = "";
@@ -212,6 +218,13 @@ const parseTomlSettings = (repoPath: string): RepositorySettingsFile => {
         if (value.includes("]")) finishPendingArray();
       } else if (key === "file_include_globs") {
         settings.fileIncludeGlobs = parseTomlString(value);
+      } else if (
+        key === "mcp_disabled_servers" &&
+        value.trim().startsWith("[")
+      ) {
+        pendingArrayKey = "mcp_disabled_servers";
+        pendingArrayRaw = value;
+        if (value.includes("]")) finishPendingArray();
       }
     } else if (section === "scripts") {
       if (key === "setup")
@@ -307,6 +320,11 @@ const coerceJsonSettings = (
         : typeof obj.file_include_globs === "string"
           ? obj.file_include_globs
           : fallback.fileIncludeGlobs,
+    mcpDisabledServers: Array.isArray(obj.mcpDisabledServers)
+      ? obj.mcpDisabledServers.filter(
+          (v): v is string => typeof v === "string" && v.length > 0,
+        )
+      : fallback.mcpDisabledServers,
   };
 };
 
@@ -368,6 +386,11 @@ const writeTomlSettings = (
       includeGlobValues(settings.fileIncludeGlobs),
     ),
     "",
+    ...tomlStringArray(
+      "mcp_disabled_servers",
+      [...settings.mcpDisabledServers],
+    ),
+    "",
     "[scripts]",
     `setup = ${tomlNullableString(cleanScript(settings.setupScript))}`,
     `run = ${tomlNullableString(cleanScript(settings.runScript))}`,
@@ -409,6 +432,7 @@ const fileToSettings = (
     autoRunAfterSetup: file.autoRunAfterSetup,
     environmentVariables: file.environmentVariables,
     fileIncludeGlobs: file.fileIncludeGlobs,
+    mcpDisabledServers: file.mcpDisabledServers,
   });
 
 const settingsToFile = (
@@ -426,6 +450,7 @@ const settingsToFile = (
   autoRunAfterSetup: settings.autoRunAfterSetup,
   environmentVariables: settings.environmentVariables,
   fileIncludeGlobs: settings.fileIncludeGlobs,
+  mcpDisabledServers: settings.mcpDisabledServers,
 });
 
 const rowToFile = (
@@ -455,6 +480,7 @@ const rowToFile = (
       ...parseEnvJson(row.environment_variables_json),
     },
     fileIncludeGlobs: fallback.fileIncludeGlobs,
+    mcpDisabledServers: fallback.mcpDisabledServers,
   };
 };
 
@@ -496,6 +522,7 @@ const applyPatch = (
     environmentVariables:
       patch.environmentVariables ?? current.environmentVariables,
     fileIncludeGlobs: patch.fileIncludeGlobs ?? current.fileIncludeGlobs,
+    mcpDisabledServers: patch.mcpDisabledServers ?? current.mcpDisabledServers,
   });
 
 export const RepositorySettingsServiceLive = Layer.effect(

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -28,6 +28,7 @@ import {
 	type LanAuthService,
 } from "./lan-auth/services/lan-auth-service.ts";
 import { LinearServiceLive } from "./linear/layers/linear-service.ts";
+import { McpServiceLive } from "./mcp/layers/mcp-service.ts";
 import { runLifecycleBackfill } from "./persistence/backfill.ts";
 import { importWorkspacesJson } from "./persistence/import-workspaces.ts";
 import { MigrationsLive } from "./persistence/migrations.ts";
@@ -272,6 +273,18 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(NodeServices.layer),
 	);
 
+	// McpService reads the user's native Claude/Codex MCP configs, tracks
+	// per-server connection status (SDK probe for claude-source, ephemeral
+	// codex app-server for codex-source), stores enable/disable overrides in
+	// settings, and runs OAuth flows (tokens in the keychain).
+	const McpLayer = McpServiceLive.pipe(
+		Layer.provide(ConfigStoreLayer),
+		Layer.provide(RepositorySettingsLayer),
+		Layer.provide(CredentialsServiceLive),
+		Layer.provide(MigratedSqlite),
+		Layer.provide(NodeServices.layer),
+	);
+
 	// ProviderService probes installed CLIs via CommandExecutor, consults
 	// CredentialsService for SDK keys, resolves folderId → cwd via
 	// WorkspaceService, and forwards the SDK's tool-permission callback to
@@ -283,8 +296,10 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(AttachmentLayer),
 		Layer.provide(BrowserBridgeLayer),
 		// OpenCode session-start reads `opencodeCustomProviders` from settings to
-		// inject user-defined providers into `opencode serve`.
+		// inject user-defined providers into `opencode serve`; Claude session
+		// start resolves the user's native MCP servers through McpService.
 		Layer.provide(ConfigStoreLayer),
+		Layer.provide(McpLayer),
 		Layer.provide(NodeServices.layer),
 	);
 
@@ -427,6 +442,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		FileSearchLayer,
 		ProjectScaffoldLayer,
 		ProviderLayer,
+		McpLayer,
 		SessionDomainLayer,
 		ConversationServicesLayer,
 		PermissionLayer,

--- a/apps/server/test/fixtures/fake-claude-mcp-login.sh
+++ b/apps/server/test/fixtures/fake-claude-mcp-login.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ "$1" != "mcp" ] || [ "$2" != "login" ] || [ "$3" != "plugin:figma:figma" ]; then
+	echo "unexpected arguments" >&2
+	exit 2
+fi
+
+if [ ! -t 0 ]; then
+	echo "stdin isn't a terminal" >&2
+	exit 3
+fi
+
+echo "Open this URL to authenticate: https://auth.example.test/authorize?server=figma"
+sleep 0.1
+echo "Authentication successful"

--- a/apps/server/test/integration/auth-service.test.ts
+++ b/apps/server/test/integration/auth-service.test.ts
@@ -102,6 +102,9 @@ const makeHarness = (
 			setIntegration: () => Effect.void,
 			removeIntegration: () => Effect.void,
 			listIntegrationAccounts: () => Effect.succeed([]),
+			getMcpOauth: (_serverKey: string) => Effect.succeed(null),
+			setMcpOauth: (_serverKey: string, _bundleJson: string) => Effect.void,
+			removeMcpOauth: (_serverKey: string) => Effect.void,
 		}),
 	);
 	const AuthShellLayer = Layer.succeed(

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -321,6 +321,7 @@ const StubRepositorySettingsLive = Layer.succeed(RepositorySettingsService, {
 				autoRunAfterSetup: false,
 				environmentVariables: {},
 				fileIncludeGlobs: "",
+				mcpDisabledServers: [],
 			}),
 		),
 	update: (projectId, patch) =>
@@ -338,6 +339,7 @@ const StubRepositorySettingsLive = Layer.succeed(RepositorySettingsService, {
 				autoRunAfterSetup: patch.autoRunAfterSetup ?? false,
 				environmentVariables: patch.environmentVariables ?? {},
 				fileIncludeGlobs: patch.fileIncludeGlobs ?? "",
+				mcpDisabledServers: patch.mcpDisabledServers ?? [],
 			}),
 		),
 });

--- a/apps/server/test/support/conversation-services-fixture-harness.ts
+++ b/apps/server/test/support/conversation-services-fixture-harness.ts
@@ -223,6 +223,7 @@ const makeRuntime = (
 					autoRunAfterSetup: false,
 					environmentVariables: {},
 					fileIncludeGlobs: "",
+					mcpDisabledServers: [],
 				}),
 			),
 		update: (projectId, patch) =>
@@ -240,6 +241,7 @@ const makeRuntime = (
 					autoRunAfterSetup: patch.autoRunAfterSetup ?? false,
 					environmentVariables: patch.environmentVariables ?? {},
 					fileIncludeGlobs: patch.fileIncludeGlobs ?? "",
+					mcpDisabledServers: patch.mcpDisabledServers ?? [],
 				}),
 			),
 	});

--- a/apps/server/test/unit/mcp-claude-status.test.ts
+++ b/apps/server/test/unit/mcp-claude-status.test.ts
@@ -1,0 +1,116 @@
+import { fileURLToPath } from "node:url";
+import type { McpServerDescriptor } from "@zuse/contracts";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import {
+	claudeMcpLogin,
+	parseClaudeMcpList,
+	reconcileClaudeManagedInventory,
+} from "../../src/mcp/claude-status.ts";
+
+describe("Claude native MCP status", () => {
+	it("forwards the native authorization URL before login completes", async () => {
+		const executable = fileURLToPath(
+			new URL("../fixtures/fake-claude-mcp-login.sh", import.meta.url),
+		);
+		const urls: string[] = [];
+
+		const outcome = await Effect.runPromise(
+			claudeMcpLogin(executable, process.cwd(), "plugin:figma:figma", {
+				onAuthorizationUrl: (url) => urls.push(url),
+			}),
+		);
+
+		expect(outcome.success).toBe(true);
+		expect(urls).toEqual(["https://auth.example.test/authorize?server=figma"]);
+	});
+
+	it("parses configured, plugin, and hosted app rows", () => {
+		const rows = parseClaudeMcpList(
+			[
+				"Checking MCP server health…",
+				"claude.ai Calendar: https://calendar.example/mcp - ✔ Connected",
+				"plugin:design:canvas: https://canvas.example/mcp (HTTP) - ! Needs authentication",
+				"local: bun run-server --flag - ✘ Failed to connect",
+			].join("\n"),
+			123,
+		);
+
+		expect(rows).toEqual([
+			expect.objectContaining({
+				name: "claude.ai Calendar",
+				source: "claude-app",
+				transport: "http",
+				state: "connected",
+				checkedAt: 123,
+			}),
+			expect.objectContaining({
+				name: "plugin:design:canvas",
+				source: "claude-plugin",
+				state: "needs-auth",
+			}),
+			expect.objectContaining({
+				name: "local",
+				source: "claude-user",
+				transport: "stdio",
+				state: "error",
+			}),
+		]);
+	});
+
+	it("ignores diagnostics and unrelated output", () => {
+		expect(
+			parseClaudeMcpList(
+				"MCP config diagnostics ⚠\nFor help configuring MCP servers, see: https://example.test",
+				123,
+			),
+		).toEqual([]);
+	});
+
+	it("keeps configured identities and creates read-only managed rows", () => {
+		const configured: McpServerDescriptor = {
+			key: "claude:local",
+			name: "local",
+			source: "claude-user",
+			kind: "configured",
+			parentKey: null,
+			availableProviders: ["claude"],
+			transport: "stdio",
+			command: "bun",
+			args: [],
+			url: null,
+			envVarNames: [],
+			enabledInConfig: true,
+			disabledByZuse: false,
+			toggleSupported: true,
+			authenticationAction: null,
+			manageUrl: null,
+		};
+		const entries = parseClaudeMcpList(
+			[
+				"local: bun server - ✔ Connected",
+				"plugin:design:canvas: https://canvas.example/mcp (HTTP) - ! Needs authentication",
+			].join("\n"),
+			123,
+		);
+		const inventory = reconcileClaudeManagedInventory({
+			configured: [configured],
+			entries,
+		});
+
+		expect(inventory.descriptors).toEqual([
+			expect.objectContaining({
+				key: "claude-live:plugin:design:canvas",
+				source: "claude-plugin",
+				kind: "provider",
+				toggleSupported: false,
+				authenticationAction: "native-oauth",
+			}),
+		]);
+		expect(inventory.statuses.map((status) => status.key)).toEqual([
+			"claude:local",
+			"claude-live:plugin:design:canvas",
+		]);
+	});
+});

--- a/apps/server/test/unit/mcp-codex-inventory.test.ts
+++ b/apps/server/test/unit/mcp-codex-inventory.test.ts
@@ -1,0 +1,243 @@
+import type { Tool } from "@zuse/agents/codex-generated/Tool";
+import type { AppInfo } from "@zuse/agents/codex-generated/v2/AppInfo";
+import type { McpServerStatus as NativeStatus } from "@zuse/agents/codex-generated/v2/McpServerStatus";
+import type { PluginDetail } from "@zuse/agents/codex-generated/v2/PluginDetail";
+import type { McpServerDescriptor } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+	groupCodexAppTools,
+	reconcileCodexInventory,
+} from "../../src/mcp/codex-inventory.ts";
+import {
+	type CodexLiveMcpSnapshot,
+	reconcileCodexConnectors,
+} from "../../src/mcp/codex-status.ts";
+
+const tool = (name: string, meta?: unknown): Tool => ({
+	name,
+	inputSchema: {},
+	_meta: meta as Tool["_meta"],
+});
+
+const nativeStatus = (
+	name: string,
+	options: {
+		readonly authStatus?: NativeStatus["authStatus"];
+		readonly tools?: Readonly<Record<string, Tool>>;
+	} = {},
+): NativeStatus => ({
+	name,
+	tools: options.tools ?? {},
+	resources: [],
+	resourceTemplates: [],
+	authStatus: options.authStatus ?? "unsupported",
+});
+
+const configuredDescriptor = (
+	name: string,
+	overrides: Partial<McpServerDescriptor> = {},
+): McpServerDescriptor => ({
+	key: `codex:${name}`,
+	name,
+	source: "codex",
+	kind: "configured",
+	parentKey: null,
+	availableProviders: ["codex"],
+	transport: "stdio",
+	command: "node",
+	args: [],
+	url: null,
+	envVarNames: [],
+	enabledInConfig: true,
+	disabledByZuse: false,
+	toggleSupported: true,
+	authenticationAction: null,
+	manageUrl: null,
+	...overrides,
+});
+
+const snapshot = (
+	overrides: Partial<CodexLiveMcpSnapshot> = {},
+): CodexLiveMcpSnapshot => ({
+	statuses: [],
+	connectors: [],
+	pluginServers: [],
+	...overrides,
+});
+
+describe("reconcileCodexInventory", () => {
+	it("keeps configured identity while adding live-only provider servers", () => {
+		const result = reconcileCodexInventory({
+			configured: [
+				{ descriptor: configuredDescriptor("configured"), requirements: [] },
+			],
+			live: snapshot({
+				statuses: [
+					nativeStatus("configured", { tools: { one: tool("one") } }),
+					nativeStatus("plugin:design:server", {
+						authStatus: "notLoggedIn",
+					}),
+				],
+			}),
+			excludedNames: new Set(),
+			now: 42,
+		});
+
+		expect(result.descriptors.map((row) => row.key)).toEqual([
+			"codex:configured",
+			"codex-live:plugin:design:server",
+		]);
+		expect(result.statuses[0]).toMatchObject({
+			state: "connected",
+			toolCount: 1,
+		});
+		expect(result.statuses[1]).toMatchObject({
+			state: "needs-auth",
+			authMethod: "oauth",
+		});
+	});
+
+	it("preserves disabled and missing configured server states", () => {
+		const result = reconcileCodexInventory({
+			configured: [
+				{
+					descriptor: configuredDescriptor("off", {
+						enabledInConfig: false,
+					}),
+					requirements: [],
+				},
+				{ descriptor: configuredDescriptor("missing"), requirements: [] },
+			],
+			live: snapshot(),
+			excludedNames: new Set(),
+			now: 42,
+		});
+
+		expect(result.statuses.map((status) => status.state)).toEqual([
+			"disabled",
+			"error",
+		]);
+		expect(result.statuses[1]?.error).toContain("did not report");
+	});
+
+	it("keeps installed plugin MCPs visible when they fail before status", () => {
+		const result = reconcileCodexInventory({
+			configured: [],
+			live: snapshot({
+				pluginServers: [{ name: "plugin-server", pluginName: "Design plugin" }],
+			}),
+			excludedNames: new Set(),
+			now: 42,
+		});
+
+		expect(result.descriptors[0]).toMatchObject({
+			key: "codex-live:plugin-server",
+			kind: "provider",
+		});
+		expect(result.statuses[0]).toMatchObject({
+			state: "error",
+			error: "Design plugin did not report this MCP server",
+		});
+	});
+
+	it("keeps an aggregate app row and derives connected and auth child rows", () => {
+		const aggregateTools = {
+			mail: tool("mail.search", {
+				connector_id: "mail-id",
+				connector_name: "Mail",
+			}),
+			unscoped: tool("internal.health"),
+		};
+		const result = reconcileCodexInventory({
+			configured: [],
+			live: snapshot({
+				statuses: [nativeStatus("codex_apps", { tools: aggregateTools })],
+				connectors: [
+					{
+						id: "mail-id",
+						name: "Mail",
+						installUrl: "https://example.test/mail",
+						isAccessible: true,
+						isEnabled: true,
+						needsAuth: false,
+					},
+					{
+						id: "drive-id",
+						name: "Drive",
+						installUrl: "https://example.test/drive",
+						isAccessible: false,
+						isEnabled: true,
+						needsAuth: true,
+					},
+				],
+			}),
+			excludedNames: new Set(),
+			now: 42,
+		});
+
+		expect(result.descriptors.map((row) => row.kind)).toEqual([
+			"app-group",
+			"app",
+			"app",
+		]);
+		expect(result.statuses[0]).toMatchObject({ toolCount: 2 });
+		expect(result.statuses[1]).toMatchObject({
+			name: "Mail",
+			state: "connected",
+			toolCount: 1,
+		});
+		expect(result.statuses[2]).toMatchObject({
+			name: "Drive",
+			state: "needs-auth",
+		});
+		expect(groupCodexAppTools(aggregateTools)).toHaveLength(1);
+	});
+});
+
+describe("reconcileCodexConnectors", () => {
+	it("excludes the marketplace but retains linked and installed auth-required apps", () => {
+		const apps = [
+			{
+				id: "linked",
+				name: "Linked",
+				isAccessible: true,
+				isEnabled: true,
+				installUrl: "https://example.test/linked",
+			},
+			{
+				id: "catalog-only",
+				name: "Catalog only",
+				isAccessible: false,
+				isEnabled: true,
+				installUrl: "https://example.test/catalog",
+			},
+			{
+				id: "installed",
+				name: "Installed",
+				isAccessible: false,
+				isEnabled: true,
+				installUrl: "https://example.test/installed",
+			},
+		] as unknown as ReadonlyArray<AppInfo>;
+		const plugins = [
+			{
+				apps: [
+					{
+						id: "installed",
+						name: "Installed",
+						description: null,
+						installUrl: "https://example.test/installed",
+						needsAuth: true,
+					},
+				],
+				mcpServers: [],
+			} as unknown as PluginDetail,
+		];
+
+		expect(reconcileCodexConnectors(apps, plugins)).toEqual([
+			expect.objectContaining({ id: "linked", needsAuth: false }),
+			expect.objectContaining({ id: "installed", needsAuth: true }),
+		]);
+	});
+});

--- a/apps/server/test/unit/mcp-native-config.test.ts
+++ b/apps/server/test/unit/mcp-native-config.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	expandEnvRefs,
+	parseClaudeServers,
+	parseCodexServers,
+} from "../../src/mcp/native-config.ts";
+
+const CWD = "/Users/dev/project";
+
+/** Builds a `${NAME}` config env-ref without tripping noTemplateCurlyInString. */
+const ref = (name: string): string => ["${", name, "}"].join("");
+
+describe("parseClaudeServers", () => {
+	it("reads user-scope servers of every transport", () => {
+		const servers = parseClaudeServers(
+			{
+				mcpServers: {
+					posthog: {
+						command: "npx",
+						args: [
+							"-y",
+							"mcp-remote@latest",
+							"https://mcp.example.com/sse",
+							"--header",
+							`Authorization:${ref("AUTH_HEADER")}`,
+						],
+						env: { AUTH_HEADER: "Bearer abc" },
+					},
+					vidiq: { type: "http", url: "https://mcp.vidiq.com/mcp" },
+					legacy: { type: "sse", url: "https://legacy.example.com/sse" },
+				},
+			},
+			null,
+			null,
+		);
+		expect(servers.map((s) => [s.name, s.transport, s.source])).toEqual([
+			["posthog", "stdio", "claude-user"],
+			["vidiq", "http", "claude-user"],
+			["legacy", "sse", "claude-user"],
+		]);
+		const posthog = servers.find((s) => s.name === "posthog");
+		expect(posthog?.command).toBe("npx");
+		expect(posthog?.envVarNames).toEqual(["AUTH_HEADER"]);
+		expect(posthog?.enabledInConfig).toBe(true);
+	});
+
+	it("collapses scopes with local > project > user precedence", () => {
+		const servers = parseClaudeServers(
+			{
+				mcpServers: {
+					shared: { type: "http", url: "https://user.example.com" },
+					userOnly: { type: "http", url: "https://user-only.example.com" },
+				},
+				projects: {
+					[CWD]: {
+						mcpServers: {
+							shared: { type: "http", url: "https://local.example.com" },
+						},
+					},
+				},
+			},
+			{
+				mcpServers: {
+					shared: { type: "http", url: "https://project.example.com" },
+					projectOnly: { command: "uvx", args: ["some-server"] },
+				},
+			},
+			CWD,
+		);
+		const byName = new Map(servers.map((s) => [s.name, s]));
+		expect(byName.get("shared")?.url).toBe("https://local.example.com");
+		expect(byName.get("shared")?.source).toBe("claude-local");
+		expect(byName.get("projectOnly")?.source).toBe("claude-project");
+		expect(byName.get("userOnly")?.source).toBe("claude-user");
+	});
+
+	it("skips malformed entries without failing the rest", () => {
+		const servers = parseClaudeServers(
+			{
+				mcpServers: {
+					good: { type: "http", url: "https://ok.example.com" },
+					noUrl: { type: "http" },
+					noCommand: { type: "stdio" },
+					"bad name!": { type: "http", url: "https://x.example.com" },
+					notAnObject: 42,
+				},
+			},
+			null,
+			null,
+		);
+		expect(servers.map((s) => s.name)).toEqual(["good"]);
+	});
+});
+
+describe("parseCodexServers", () => {
+	const TOML = `
+[mcp_servers.pencil]
+command = "/Applications/Pencil.app/mcp-server"
+args = ["--ws-port", "55509"]
+
+[mcp_servers.node_repl]
+command = "node_repl"
+startup_timeout_sec = 120
+
+[mcp_servers.node_repl.env]
+NODE_PATH = "/opt/node"
+
+[mcp_servers.polar]
+url = "https://mcp.polar.sh/mcp"
+
+[mcp_servers.disabled_one]
+command = "whatever"
+enabled = false
+
+[mcp_servers.zuse]
+url = "http://127.0.0.1:55302/mcp/zuse"
+bearer_token_env_var = "ZUSE_MCP_TOKEN"
+`;
+
+	it("reads stdio and http servers with codex-specific fields", () => {
+		const servers = parseCodexServers(TOML, ["zuse", "zuse-orchestration"]);
+		const byName = new Map(servers.map((s) => [s.name, s]));
+		expect(byName.get("pencil")?.transport).toBe("stdio");
+		expect(byName.get("pencil")?.args).toEqual(["--ws-port", "55509"]);
+		expect(byName.get("node_repl")?.env).toEqual({ NODE_PATH: "/opt/node" });
+		expect(byName.get("node_repl")?.startupTimeoutMs).toBe(120_000);
+		expect(byName.get("polar")?.transport).toBe("http");
+		expect(byName.get("disabled_one")?.enabledInConfig).toBe(false);
+	});
+
+	it("excludes Zuse's own gateway entries", () => {
+		const servers = parseCodexServers(TOML, ["zuse", "zuse-orchestration"]);
+		expect(servers.find((s) => s.name === "zuse")).toBeUndefined();
+	});
+
+	it("returns [] for malformed toml", () => {
+		expect(parseCodexServers("not = [valid", [])).toEqual([]);
+	});
+});
+
+describe("expandEnvRefs", () => {
+	it("prefers the entry env, falls back to process.env, keeps unknown refs", () => {
+		process.env.MCP_TEST_FROM_PROCESS = "proc";
+		try {
+			expect(
+				expandEnvRefs(
+					[ref("LOCAL"), ref("MCP_TEST_FROM_PROCESS"), ref("MISSING_REF")].join(
+						"/",
+					),
+					{ LOCAL: "local" },
+				),
+			).toBe(`local/proc/${ref("MISSING_REF")}`);
+		} finally {
+			delete process.env.MCP_TEST_FROM_PROCESS;
+		}
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -202,6 +202,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.126",
         "@effect/platform-node": "catalog:",
+        "@modelcontextprotocol/sdk": "^1.0.0",
         "@zuse/agents": "*",
         "@zuse/contracts": "*",
         "@zuse/domain": "*",
@@ -215,6 +216,7 @@
         "jose": "^6.2.3",
         "keytar": "^7.9.0",
         "node-pty": "^1.1.0",
+        "smol-toml": "^1.3.1",
         "tokenmaxer": "*",
         "zod": "^4.0.0",
       },
@@ -3860,6 +3862,8 @@
     "slugify": ["slugify@1.6.9", "", {}, "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "smol-toml": ["smol-toml@1.7.0", "", {}, "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ=="],
 
     "socks": ["socks@2.8.8", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -308,7 +308,6 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.126",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@openai/codex-sdk": "^0.128.0",
         "@opencode-ai/sdk": "^1.3.15",
         "@zuse/acp": "*",
         "@zuse/contracts": "*",
@@ -1212,22 +1211,6 @@
     "@npmcli/fs": ["@npmcli/fs@2.1.2", "", { "dependencies": { "@gar/promisify": "^1.1.3", "semver": "^7.3.5" } }, "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ=="],
 
     "@npmcli/move-file": ["@npmcli/move-file@2.0.1", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ=="],
-
-    "@openai/codex": ["@openai/codex@0.128.0", "http://registry.npmjs.org/@openai/codex/-/codex-0.128.0.tgz", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.128.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.128.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.128.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.128.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.128.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.128.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A=="],
-
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.128.0-darwin-arm64", "http://registry.npmjs.org/@openai/codex/-/codex-0.128.0-darwin-arm64.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug=="],
-
-    "@openai/codex-darwin-x64": ["@openai/codex@0.128.0-darwin-x64", "http://registry.npmjs.org/@openai/codex/-/codex-0.128.0-darwin-x64.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw=="],
-
-    "@openai/codex-linux-arm64": ["@openai/codex@0.128.0-linux-arm64", "http://registry.npmjs.org/@openai/codex/-/codex-0.128.0-linux-arm64.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w=="],
-
-    "@openai/codex-linux-x64": ["@openai/codex@0.128.0-linux-x64", "http://registry.npmjs.org/@openai/codex/-/codex-0.128.0-linux-x64.tgz", { "os": "linux", "cpu": "x64" }, "sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ=="],
-
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.128.0", "http://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.128.0.tgz", { "dependencies": { "@openai/codex": "0.128.0" } }, "sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ=="],
-
-    "@openai/codex-win32-arm64": ["@openai/codex@0.128.0-win32-arm64", "http://registry.npmjs.org/@openai/codex/-/codex-0.128.0-win32-arm64.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA=="],
-
-    "@openai/codex-win32-x64": ["@openai/codex@0.128.0-win32-x64", "http://registry.npmjs.org/@openai/codex/-/codex-0.128.0-win32-x64.tgz", { "os": "win32", "cpu": "x64" }, "sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.1", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-IHxGuizTR2x40GtB49o0swFTc1N4AZIdeYzJ5D8gVAJzfISKyOYn5o5YxDprYJ7z4oWxBXNELIDpYioGVDUkNw=="],
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -27,7 +27,6 @@
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.2.126",
 		"@modelcontextprotocol/sdk": "^1.0.0",
-		"@openai/codex-sdk": "^0.128.0",
 		"@opencode-ai/sdk": "^1.3.15",
 		"@zuse/acp": "*",
 		"@zuse/contracts": "*",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -9,6 +9,7 @@
 		"./drivers/*": "./src/drivers/*.ts",
 		"./drivers/acp/*": "./src/drivers/acp/*.ts",
 		"./mcp-gateway": "./src/mcp-gateway/index.ts",
+		"./user-mcp/*": "./src/user-mcp/*.ts",
 		"./kernel/attachment-service": "./src/kernel/attachment-service.ts",
 		"./kernel/driver": "./src/kernel/driver.ts",
 		"./kernel/permission-policy": "./src/kernel/permission-policy.ts",

--- a/packages/agents/src/drivers/claude-env.ts
+++ b/packages/agents/src/drivers/claude-env.ts
@@ -1,0 +1,19 @@
+// Markers injected by a parent Claude process. Native CLI subprocesses must
+// not inherit them or they can resolve auth/session state as a nested call.
+const INHERITED_CLAUDE_MARKERS = [
+	"CLAUDECODE",
+	"CLAUDE_CODE_ENTRYPOINT",
+	"CLAUDE_CODE_EXECPATH",
+	"CLAUDE_AGENT_SDK_VERSION",
+	"CLAUDE_CODE_SESSION_ID",
+	"CLAUDE_CODE_SESSION_NAME",
+	"CLAUDE_CODE_SESSION_LOG",
+] as const;
+
+export const scrubInheritedClaudeMarkers = (
+	base: NodeJS.ProcessEnv,
+): Record<string, string | undefined> => {
+	const next: Record<string, string | undefined> = { ...base };
+	for (const key of INHERITED_CLAUDE_MARKERS) delete next[key];
+	return next;
+};

--- a/packages/agents/src/drivers/claude.ts
+++ b/packages/agents/src/drivers/claude.ts
@@ -1,5 +1,6 @@
 import {
 	createSdkMcpServer,
+	type McpServerConfig,
 	type Options,
 	type Query,
 	query,
@@ -31,7 +32,9 @@ import { z } from "zod";
 
 import { AttachmentService } from "../kernel/attachment-service.ts";
 import type { ProviderSessionHandle } from "../kernel/driver.ts";
+import type { ResolvedMcpServer } from "../user-mcp/types.ts";
 import type { buildBrowserTools } from "./browser-tools.ts";
+import { scrubInheritedClaudeMarkers } from "./claude-env.ts";
 import {
 	applyClaudeWorktreeEnv,
 	claudeWorktreePrompt,
@@ -53,6 +56,37 @@ import {
 	ORCHESTRATION_MCP_SERVER_NAME,
 	ORCHESTRATION_MCP_TOOLS,
 } from "./orchestration-tools.ts";
+
+/**
+ * User MCP servers → SDK external-server config entries. Tools surface as
+ * `mcp__<name>__<tool>` and fall through `policyFor` to the permission
+ * broker like any unlisted tool. With toolSearch on, the SDK defers their
+ * tool schemas behind search (the default); with it off we pin
+ * `alwaysLoad` so behavior matches the builtins.
+ */
+const userMcpConfigEntries = (
+	servers: ReadonlyArray<ResolvedMcpServer>,
+	toolSearch: boolean,
+): Record<string, McpServerConfig> =>
+	Object.fromEntries(
+		servers.map((server): [string, McpServerConfig] => [
+			server.name,
+			server.transport === "stdio"
+				? {
+						type: "stdio",
+						command: server.command ?? "",
+						args: [...(server.args ?? [])],
+						env: { ...(server.env ?? {}) },
+						alwaysLoad: !toolSearch,
+					}
+				: {
+						type: server.transport,
+						url: server.url ?? "",
+						headers: { ...(server.headers ?? {}) },
+						alwaysLoad: !toolSearch,
+					},
+		]),
+	);
 
 /**
  * Live-only handle for one Claude SDK conversation. The orchestrator
@@ -231,29 +265,6 @@ const userMessageOf = (
 let itemCounter = 0;
 const nextItemId = (): AgentItemId =>
 	`i_${Date.now()}_${++itemCounter}` as AgentItemId;
-
-// Markers Claude Code injects into every subprocess it spawns. If memoize
-// is launched from a Claude Code terminal these get inherited, and the
-// nested `claude` binary then loads a different parent's session state
-// instead of the user's `claude /login` OAuth. Strip them so our spawn
-// runs as if the user had launched it from a fresh shell.
-const INHERITED_CLAUDE_MARKERS = [
-	"CLAUDECODE",
-	"CLAUDE_CODE_ENTRYPOINT",
-	"CLAUDE_CODE_EXECPATH",
-	"CLAUDE_AGENT_SDK_VERSION",
-	"CLAUDE_CODE_SESSION_ID",
-	"CLAUDE_CODE_SESSION_NAME",
-	"CLAUDE_CODE_SESSION_LOG",
-] as const;
-
-const scrubInheritedClaudeMarkers = (
-	base: NodeJS.ProcessEnv,
-): Record<string, string | undefined> => {
-	const next: Record<string, string | undefined> = { ...base };
-	for (const key of INHERITED_CLAUDE_MARKERS) delete next[key];
-	return next;
-};
 
 /**
  * Per-turn accumulator for thinking_delta / redacted_thinking blocks. The
@@ -1435,6 +1446,11 @@ export const startClaudeSession = (
 	// the same MCP surface and smoke-test instructions.
 	orchestrationTools: ReadonlyArray<OrchestrationSdkTool> = [],
 	linearTools: ReadonlyArray<LinearSdkTool> = [],
+	// The user's native MCP servers (from ~/.claude.json / .mcp.json), already
+	// resolved server-side: env refs expanded, held OAuth tokens injected as
+	// Authorization headers. Spread into `Options.mcpServers` after the
+	// builtins, whose names win any collision.
+	userMcpServers: ReadonlyArray<ResolvedMcpServer> = [],
 ): Effect.Effect<
 	ClaudeSessionHandle,
 	AgentSessionStartError,
@@ -1670,7 +1686,9 @@ export const startClaudeSession = (
 			Object.keys(agentsMap).length > 0;
 		// `allowedTools` is a strict allow-list when set: anything not listed
 		// gets disallowed. So when sub-agents are on we must also list our
-		// in-process AskUserQuestion tool by its fully-qualified name.
+		// in-process AskUserQuestion tool by its fully-qualified name, plus a
+		// server-level `mcp__<name>` entry per user MCP server (allowing the
+		// whole server keeps the list stable as its tool set changes).
 		const subagentOptions = subagentsEffective
 			? ({
 					agents: agentsMap,
@@ -1681,6 +1699,7 @@ export const startClaudeSession = (
 						...LINEAR_MCP_TOOLS.map(
 							(tool) => `mcp__${LINEAR_MCP_SERVER_NAME}__${tool.name}`,
 						),
+						...userMcpServers.map((server) => `mcp__${server.name}`),
 					],
 				} as Pick<Options, "agents" | "allowedTools">)
 			: {};
@@ -1721,6 +1740,7 @@ export const startClaudeSession = (
 						)),
 			],
 			mcpServers: {
+				...userMcpConfigEntries(userMcpServers, input.toolSearch ?? false),
 				[ZUSE_MCP_NAME]: memoizeMcpServer,
 				...(orchestrationMcpServer === null
 					? {}

--- a/packages/agents/src/user-mcp/probe.ts
+++ b/packages/agents/src/user-mcp/probe.ts
@@ -1,0 +1,212 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { Effect } from "effect";
+
+import type { ResolvedMcpServer } from "./types.ts";
+
+/**
+ * Outcome of one connection attempt against a user MCP server. `state`
+ * deliberately matches the wire `McpServerState` subset a probe can produce
+ * (a probe never yields "connecting"/"disabled" — those are inventory
+ * states).
+ */
+export interface McpProbeResult {
+	readonly state: "connected" | "error" | "needs-auth";
+	readonly toolNames: ReadonlyArray<string>;
+	readonly error: string | null;
+	/**
+	 * Set when `state === "needs-auth"`: "oauth" when the server answered
+	 * with an OAuth challenge (WWW-Authenticate / 401 on a bare request),
+	 * "token" when a static credential is referenced but missing.
+	 */
+	readonly authMethod: "oauth" | "token" | null;
+}
+
+const connected = (toolNames: ReadonlyArray<string>): McpProbeResult => ({
+	state: "connected",
+	toolNames,
+	error: null,
+	authMethod: null,
+});
+
+const needsAuth = (method: "oauth" | "token"): McpProbeResult => ({
+	state: "needs-auth",
+	toolNames: [],
+	error: null,
+	authMethod: method,
+});
+
+const failed = (error: string): McpProbeResult => ({
+	state: "error",
+	toolNames: [],
+	error,
+	authMethod: null,
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+/**
+ * Flatten an error and its `cause` chain (fetch buries ECONNREFUSED two
+ * levels deep) into one searchable string of messages + codes.
+ */
+const failureText = (cause: unknown): string => {
+	const parts: string[] = [];
+	let current: unknown = cause;
+	for (let depth = 0; depth < 5 && current !== undefined; depth++) {
+		if (current instanceof Error) parts.push(current.message);
+		else if (typeof current === "string") parts.push(current);
+		if (isRecord(current)) {
+			if (typeof current.code === "string" || typeof current.code === "number")
+				parts.push(String(current.code));
+			if (Array.isArray(current.errors)) {
+				for (const nested of current.errors as unknown[]) {
+					parts.push(failureText(nested));
+				}
+			}
+			current = current.cause;
+		} else {
+			break;
+		}
+	}
+	return parts.join(" | ");
+};
+
+/**
+ * The SDK surfaces a 401 as `UnauthorizedError` when an auth provider is
+ * configured and as `StreamableHTTPError`/`SseError` with `code: 401`
+ * otherwise; stdio spawn failures bubble up as ENOENT/EACCES. Everything
+ * else is a plain connection error.
+ */
+const classifyFailure = (
+	server: ResolvedMcpServer,
+	cause: unknown,
+): McpProbeResult => {
+	if (cause instanceof UnauthorizedError) return needsAuth("oauth");
+	const message = cause instanceof Error ? cause.message : String(cause);
+	const text = failureText(cause);
+	if (isRecord(cause) && (cause.code === 401 || /\b401\b/.test(text))) {
+		return needsAuth("oauth");
+	}
+	if (isRecord(cause) && (cause.code === 403 || /\b403\b/.test(text))) {
+		return needsAuth("token");
+	}
+	if (/ENOENT/.test(text)) {
+		return failed(`command not found: ${server.command ?? ""}`.trim());
+	}
+	if (/EACCES/.test(text)) {
+		return failed(`command not executable: ${server.command ?? ""}`.trim());
+	}
+	if (/ECONNREFUSED/.test(text)) return failed("connection refused");
+	if (/TimeoutException|timed? ?out/i.test(text)) {
+		return failed("timed out waiting for the server");
+	}
+	return failed(message);
+};
+
+const makeTransport = (
+	server: ResolvedMcpServer,
+	kind: "stdio" | "streamable-http" | "sse",
+): Transport => {
+	if (kind === "stdio") {
+		return new StdioClientTransport({
+			command: server.command ?? "",
+			args: [...(server.args ?? [])],
+			// Merge over the parent env like the driver spawn will, so a server
+			// that needs PATH/HOME behaves the same in probe and session.
+			env: {
+				...(process.env as Record<string, string>),
+				...(server.env ?? {}),
+			},
+			stderr: "ignore",
+		});
+	}
+	const url = new URL(server.url ?? "");
+	const headers = { ...(server.headers ?? {}) };
+	if (kind === "sse") {
+		return new SSEClientTransport(url, {
+			requestInit: { headers },
+			// The SSE GET goes through EventSource, which cannot carry custom
+			// headers — inject them via a fetch override instead.
+			eventSourceInit: {
+				fetch: (input, init) =>
+					fetch(input, {
+						...init,
+						headers: {
+							...Object.fromEntries(new Headers(init?.headers).entries()),
+							...headers,
+						},
+					}),
+			},
+		});
+	}
+	return new StreamableHTTPClientTransport(url, {
+		requestInit: { headers },
+	});
+};
+
+const attempt = async (
+	server: ResolvedMcpServer,
+	kind: "stdio" | "streamable-http" | "sse",
+): Promise<ReadonlyArray<string>> => {
+	const client = new Client({ name: "zuse-mcp-probe", version: "1.0.0" });
+	const transport = makeTransport(server, kind);
+	try {
+		await client.connect(transport);
+		const tools = await client.listTools();
+		return tools.tools.map((tool) => tool.name);
+	} finally {
+		await client.close().catch(() => undefined);
+	}
+};
+
+/**
+ * Connect to one user MCP server, list its tools, and disconnect. HTTP
+ * servers are tried over Streamable HTTP first with a legacy-SSE fallback
+ * (unless the config explicitly says `sse`); an auth challenge on either
+ * attempt wins over the fallback's transport error so the UI shows
+ * "auth required" rather than a confusing protocol failure.
+ */
+export const probeMcpServer = (
+	server: ResolvedMcpServer,
+	timeoutMs = 10_000,
+): Effect.Effect<McpProbeResult> =>
+	Effect.tryPromise({
+		try: async (): Promise<McpProbeResult> => {
+			if (server.transport === "stdio") {
+				try {
+					return connected(await attempt(server, "stdio"));
+				} catch (cause) {
+					return classifyFailure(server, cause);
+				}
+			}
+			const order: ReadonlyArray<"streamable-http" | "sse"> =
+				server.transport === "sse"
+					? ["sse", "streamable-http"]
+					: ["streamable-http", "sse"];
+			let first: McpProbeResult | null = null;
+			for (const kind of order) {
+				try {
+					return connected(await attempt(server, kind));
+				} catch (cause) {
+					const result = classifyFailure(server, cause);
+					if (result.state === "needs-auth") return result;
+					first = first ?? result;
+				}
+			}
+			return first ?? failed("unreachable");
+		},
+		catch: (cause) => classifyFailure(server, cause),
+	}).pipe(
+		Effect.catch((result) => Effect.succeed(result)),
+		Effect.timeoutOption(timeoutMs),
+		Effect.map((option) =>
+			option._tag === "Some"
+				? option.value
+				: failed("timed out waiting for the server"),
+		),
+	);

--- a/packages/agents/src/user-mcp/types.ts
+++ b/packages/agents/src/user-mcp/types.ts
@@ -1,0 +1,18 @@
+/**
+ * A user MCP server after Zuse has resolved it for use: env vars expanded,
+ * any keychain-held token already injected into `headers`/`env`. This is the
+ * shape drivers consume (Claude spreads it into `Options.mcpServers`) and
+ * the shape the status probe connects with. It never crosses the renderer
+ * wire — headers/env may hold secrets.
+ */
+export interface ResolvedMcpServer {
+	readonly name: string;
+	readonly transport: "stdio" | "http" | "sse";
+	/** stdio */
+	readonly command?: string;
+	readonly args?: ReadonlyArray<string>;
+	readonly env?: Readonly<Record<string, string>>;
+	/** http/sse */
+	readonly url?: string;
+	readonly headers?: Readonly<Record<string, string>>;
+}

--- a/packages/agents/test/fixtures/stdio-mcp-server.mjs
+++ b/packages/agents/test/fixtures/stdio-mcp-server.mjs
@@ -1,0 +1,13 @@
+// Minimal stdio MCP server used by user-mcp-probe.test.ts to exercise the
+// full connect → listTools → close round-trip against a real child process.
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const server = new McpServer({ name: "probe-fixture", version: "1.0.0" });
+server.tool("echo", async () => ({
+	content: [{ type: "text", text: "ok" }],
+}));
+server.tool("ping", async () => ({
+	content: [{ type: "text", text: "pong" }],
+}));
+await server.connect(new StdioServerTransport());

--- a/packages/agents/test/unit/user-mcp-probe.test.ts
+++ b/packages/agents/test/unit/user-mcp-probe.test.ts
@@ -1,0 +1,102 @@
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as Path from "node:path";
+import { Effect } from "effect";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { probeMcpServer } from "../../src/user-mcp/probe.ts";
+
+const FIXTURE = Path.join(
+	import.meta.dirname,
+	"..",
+	"fixtures",
+	"stdio-mcp-server.mjs",
+);
+
+const servers: http.Server[] = [];
+
+const listen = (
+	handler: http.RequestListener,
+): Promise<{ url: string; close: () => void }> =>
+	new Promise((resolve) => {
+		const server = http.createServer(handler);
+		servers.push(server);
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address() as AddressInfo;
+			resolve({
+				url: `http://127.0.0.1:${port}/mcp`,
+				close: () => server.close(),
+			});
+		});
+	});
+
+afterAll(() => {
+	for (const server of servers) server.close();
+});
+
+describe("probeMcpServer classification", () => {
+	it("connects to a real stdio server and lists its tools", async () => {
+		const result = await Effect.runPromise(
+			probeMcpServer(
+				{
+					transport: "stdio",
+					name: "fixture",
+					command: process.execPath,
+					args: [FIXTURE],
+				},
+				10_000,
+			),
+		);
+		expect(result.state).toBe("connected");
+		expect([...result.toolNames].sort()).toEqual(["echo", "ping"]);
+	});
+
+	it("reports a missing stdio command as 'command not found'", async () => {
+		const result = await Effect.runPromise(
+			probeMcpServer(
+				{
+					transport: "stdio",
+					name: "ghost",
+					command: "definitely-not-a-real-command-zx9",
+					args: [],
+				},
+				5_000,
+			),
+		);
+		expect(result.state).toBe("error");
+		expect(result.error).toContain("command not found");
+	});
+
+	it("reports an http 401 as needs-auth (oauth)", async () => {
+		const fixture = await listen((_req, res) => {
+			res.writeHead(401, {
+				"www-authenticate": 'Bearer resource_metadata="https://x/meta"',
+			});
+			res.end();
+		});
+		const result = await Effect.runPromise(
+			probeMcpServer(
+				{ transport: "http", name: "authy", url: fixture.url },
+				5_000,
+			),
+		);
+		fixture.close();
+		expect(result.state).toBe("needs-auth");
+		expect(result.authMethod).toBe("oauth");
+	});
+
+	it("reports a refused connection as an error", async () => {
+		// Grab a free port, then close it so nothing is listening.
+		const fixture = await listen((_req, res) => res.end());
+		fixture.close();
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		const result = await Effect.runPromise(
+			probeMcpServer(
+				{ transport: "http", name: "gone", url: fixture.url },
+				5_000,
+			),
+		);
+		expect(result.state).toBe("error");
+		expect(result.error).toBeTruthy();
+	});
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,6 +16,7 @@ export * from "./ids.ts";
 export * from "./keybindings.ts";
 export * from "./keybindings-parse.ts";
 export * from "./linear.ts";
+export * from "./mcp.ts";
 export * from "./pairing.ts";
 export * from "./permission.ts";
 export * from "./ping.ts";

--- a/packages/contracts/src/mcp.ts
+++ b/packages/contracts/src/mcp.ts
@@ -1,0 +1,210 @@
+import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
+
+import { ProviderId } from "./agent.ts";
+import { FolderId } from "./ids.ts";
+
+// ---------------------------------------------------------------------------
+// User MCP servers. Zuse keeps NO registry of its own: it reconciles native
+// config files with provider-reported servers, plugins, and connected apps.
+// Config sources include `~/.claude.json` (user + per-project "local"
+// scopes), the project `.mcp.json` (project scope), and
+// `~/.codex/config.toml [mcp_servers.*]`. Zuse shows the reconciled inventory,
+// injects only compatible configured servers into agent sessions, and stores
+// only enable/disable overrides (keys, never server definitions) in settings.
+// See specs/self-orchestration/decisions/0032-mcp-connector-passthrough.md.
+// ---------------------------------------------------------------------------
+
+/**
+ * Where a server definition came from. The configured Claude scopes mirror
+ * native precedence (local > project > user); plugin/app sources are native
+ * provider-managed entries. `codex` is the user's config entry and
+ * `codex-app` covers provider-managed apps. `builtin` covers Zuse's
+ * in-process servers, which are always injected and shown as connected.
+ */
+export const McpServerSource = Schema.Literals([
+	"claude-user",
+	"claude-project",
+	"claude-local",
+	"claude-plugin",
+	"claude-app",
+	"codex",
+	"codex-app",
+	"builtin",
+]);
+export type McpServerSource = typeof McpServerSource.Type;
+
+export const McpTransport = Schema.Literals(["stdio", "http", "sse"]);
+export type McpTransport = typeof McpTransport.Type;
+
+export const McpServerKind = Schema.Literals([
+	"configured",
+	"builtin",
+	"provider",
+	"app-group",
+	"app",
+]);
+export type McpServerKind = typeof McpServerKind.Type;
+
+export const McpAuthenticationAction = Schema.Literals([
+	"native-oauth",
+	"open-url",
+]);
+export type McpAuthenticationAction = typeof McpAuthenticationAction.Type;
+
+/**
+ * One configured or provider-reported inventory entry. Env/header *values*
+ * never cross the wire (they may hold secrets) — only variable names, so the
+ * UI can surface unmet requirements like "env var FOO is not set".
+ */
+export const McpServerDescriptor = Schema.Struct({
+	/**
+	 * Stable identity across refreshes: `<family>:<name>` where family is
+	 * `claude` | `codex` | `builtin` (Claude scopes collapse to one effective
+	 * server per name, `source` records the winning scope). Also the key used
+	 * by the enable/disable overrides in settings.
+	 */
+	key: Schema.String,
+	name: Schema.String,
+	source: McpServerSource,
+	kind: McpServerKind,
+	/** Parent aggregate for virtual connector rows. */
+	parentKey: Schema.NullOr(Schema.String),
+	/** Providers whose sessions can actually call this entry. */
+	availableProviders: Schema.Array(ProviderId),
+	transport: Schema.NullOr(McpTransport),
+	/** stdio only. */
+	command: Schema.NullOr(Schema.String),
+	args: Schema.Array(Schema.String),
+	/** http/sse only. */
+	url: Schema.NullOr(Schema.String),
+	/** Names of env vars / headers the config references (values withheld). */
+	envVarNames: Schema.Array(Schema.String),
+	/** `enabled = false` in the native config itself (codex supports this). */
+	enabledInConfig: Schema.Boolean,
+	/** Effective Zuse-side toggle (global ∪ per-repository overrides). */
+	disabledByZuse: Schema.Boolean,
+	/** False for provider-managed entries with no safe native mutation API. */
+	toggleSupported: Schema.Boolean,
+	/** Authentication action offered by the UI, if any. */
+	authenticationAction: Schema.NullOr(McpAuthenticationAction),
+	/** Provider-owned connect/manage URL; never contains held credentials. */
+	manageUrl: Schema.NullOr(Schema.String),
+});
+export type McpServerDescriptor = typeof McpServerDescriptor.Type;
+
+export const McpServerState = Schema.Literals([
+	"connected",
+	"connecting",
+	"error",
+	"needs-auth",
+	"disabled",
+]);
+export type McpServerState = typeof McpServerState.Type;
+
+/**
+ * A prerequisite the server needs before it can connect, shown under the
+ * row in the popover/settings ("command not found: uvx", "env var
+ * LINEAR_API_KEY is not set", "authentication required").
+ */
+export const McpRequirement = Schema.Struct({
+	kind: Schema.Literals(["command", "env", "auth"]),
+	detail: Schema.String,
+	satisfied: Schema.Boolean,
+});
+export type McpRequirement = typeof McpRequirement.Type;
+
+export const McpServerStatus = Schema.Struct({
+	key: Schema.String,
+	name: Schema.String,
+	source: McpServerSource,
+	state: McpServerState,
+	toolCount: Schema.NullOr(Schema.Number),
+	toolNames: Schema.Array(Schema.String),
+	/** Human-readable failure reason when `state === "error"`. */
+	error: Schema.NullOr(Schema.String),
+	/** How the server authenticates when `state === "needs-auth"`. */
+	authMethod: Schema.NullOr(Schema.Literals(["oauth", "token"])),
+	requirements: Schema.Array(McpRequirement),
+	/** Epoch ms of the probe that produced this status; 0 = never probed. */
+	checkedAt: Schema.Number,
+});
+export type McpServerStatus = typeof McpServerStatus.Type;
+
+export class McpConfigError extends Schema.TaggedErrorClass<McpConfigError>()(
+	"McpConfigError",
+	{ key: Schema.NullOr(Schema.String), reason: Schema.String },
+) {}
+
+/**
+ * Filter for list/refresh. `projectId` resolves the project-scoped Claude
+ * configs (`.mcp.json` + `~/.claude.json#projects[cwd]`) and applies
+ * per-repository disable overrides; absent means user-level scopes only.
+ * `provider` narrows to entries usable by that provider's sessions; absent
+ * means the complete cross-provider inventory.
+ */
+const McpScopePayload = Schema.Struct({
+	projectId: Schema.optional(FolderId),
+	provider: Schema.optional(ProviderId),
+});
+
+/**
+ * Unified inventory + last-known statuses. Returns the cached snapshot after
+ * one initial provider discovery; `mcp.refresh` explicitly forces a new
+ * discovery and status probe.
+ */
+export const McpListRpc = Rpc.make("mcp.list", {
+	payload: McpScopePayload,
+	success: Schema.Struct({
+		servers: Schema.Array(McpServerDescriptor),
+		statuses: Schema.Array(McpServerStatus),
+	}),
+	error: McpConfigError,
+});
+
+export const McpRefreshRpc = Rpc.make("mcp.refresh", {
+	payload: McpScopePayload,
+	success: Schema.Struct({
+		servers: Schema.Array(McpServerDescriptor),
+		statuses: Schema.Array(McpServerStatus),
+	}),
+	error: McpConfigError,
+});
+
+/**
+ * Zuse-side enable/disable override (never rewrites claude configs; for
+ * codex-source servers it writes the native `enabled` flag, which is the
+ * documented Codex semantics). Omitted `projectId` toggles globally.
+ */
+export const McpSetEnabledRpc = Rpc.make("mcp.setEnabled", {
+	payload: Schema.Struct({
+		key: Schema.String,
+		enabled: Schema.Boolean,
+		projectId: Schema.optional(FolderId),
+	}),
+	success: Schema.Void,
+	error: McpConfigError,
+});
+
+export const McpAuthenticateEvent = Schema.Union([
+	Schema.TaggedStruct("browser-opened", { url: Schema.String }),
+	Schema.TaggedStruct("completed", {}),
+	Schema.TaggedStruct("failed", { error: Schema.String }),
+]);
+export type McpAuthenticateEvent = typeof McpAuthenticateEvent.Type;
+
+/**
+ * Runs the OAuth flow for a `needs-auth` server: discovery + dynamic client
+ * registration + PKCE with a loopback redirect for claude-source servers,
+ * codex-native `mcpServer/oauth/login` for codex-source ones. Emits
+ * progress until the browser round-trip completes.
+ */
+export const McpAuthenticateRpc = Rpc.make("mcp.authenticate", {
+	payload: Schema.Struct({
+		key: Schema.String,
+		projectId: Schema.optional(FolderId),
+	}),
+	success: McpAuthenticateEvent,
+	error: McpConfigError,
+	stream: true,
+});

--- a/packages/contracts/src/repository-settings.ts
+++ b/packages/contracts/src/repository-settings.ts
@@ -43,6 +43,12 @@ export class RepositorySettings extends Schema.Class<RepositorySettings>(
    * Zuse's built-in env-file discovery fallback".
    */
   fileIncludeGlobs: Schema.String,
+  /**
+   * User MCP servers switched off for this repository, by descriptor key
+   * (`claude:<name>` / `codex:<name>`). Unioned with the global
+   * `mcpDisabledServers` list at read-time.
+   */
+  mcpDisabledServers: Schema.Array(Schema.String),
 }) {}
 
 /**
@@ -64,6 +70,7 @@ export const RepositorySettingsPatch = Schema.Struct({
     Schema.Record(Schema.String, Schema.String),
   ),
   fileIncludeGlobs: Schema.optional(Schema.String),
+  mcpDisabledServers: Schema.optional(Schema.Array(Schema.String)),
 });
 export type RepositorySettingsPatch = typeof RepositorySettingsPatch.Type;
 
@@ -84,6 +91,7 @@ export const RepositorySettingsFile = Schema.Struct({
   autoRunAfterSetup: Schema.Boolean,
   environmentVariables: Schema.Record(Schema.String, Schema.String),
   fileIncludeGlobs: Schema.String,
+  mcpDisabledServers: Schema.Array(Schema.String),
 });
 export type RepositorySettingsFile = typeof RepositorySettingsFile.Type;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -91,6 +91,12 @@ import {
 	LinearPrepareContextRpc,
 } from "./linear.ts";
 import {
+	McpAuthenticateRpc,
+	McpListRpc,
+	McpRefreshRpc,
+	McpSetEnabledRpc,
+} from "./mcp.ts";
+import {
 	PairingListTokensRpc,
 	PairingRevokeTokenRpc,
 	PairingStartRpc,
@@ -289,6 +295,10 @@ export const MemoizeRpcs = RpcGroup.make(
 	ProviderStartLoginRpc,
 	ProviderUpdateRpc,
 	ChatArchivePreviewRpc,
+	McpListRpc,
+	McpRefreshRpc,
+	McpSetEnabledRpc,
+	McpAuthenticateRpc,
 	ChatListRpc,
 	ChatGetRpc,
 	ChatCreateRpc,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -120,6 +120,13 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
    * via `OPENCODE_CONFIG_CONTENT` so both inventory and sessions see them.
    */
   opencodeCustomProviders: Schema.Array(OpencodeCustomProvider),
+  /**
+   * User MCP servers switched off globally, by descriptor key
+   * (`claude:<name>` / `codex:<name>` — see `McpServerDescriptor.key`).
+   * Server *definitions* never live here; the user's native Claude/Codex
+   * config files are the source of truth and this stores only overrides.
+   */
+  mcpDisabledServers: Schema.Array(Schema.String),
   subagents: Schema.Struct({
     enableForNewSessions: Schema.Boolean,
     presets: Schema.Record(Schema.String, SubagentPresetState),
@@ -182,6 +189,7 @@ export const SettingsPatch = Schema.Struct({
   opencodeCustomProviders: Schema.optional(
     Schema.Array(OpencodeCustomProvider),
   ),
+  mcpDisabledServers: Schema.optional(Schema.Array(Schema.String)),
   subagents: Schema.optional(
     Schema.Struct({
       enableForNewSessions: Schema.Boolean,

--- a/packages/contracts/test/unit/schema.test.ts
+++ b/packages/contracts/test/unit/schema.test.ts
@@ -605,6 +605,7 @@ describe("SettingsFile round-trip", () => {
 					models: [{ id: "my-model", name: "My Model" }],
 				},
 			],
+			mcpDisabledServers: ["claude:posthog"],
 			subagents: { enableForNewSessions: true, presets: {} },
 			branchNamingStyle: "username-slug",
 			branchNamingPrefix: "",
@@ -803,6 +804,7 @@ describe("RepositorySettingsFile round-trip", () => {
 				NODE_ENV: "development",
 			},
 			fileIncludeGlobs: ".env\n.env.local\n",
+			mcpDisabledServers: ["codex:pencil"],
 		});
 	});
 });


### PR DESCRIPTION
## What changed

- add a unified MCP inventory covering native provider configuration, live provider-reported servers, installed plugins, and connected provider apps
- add compact composer and settings surfaces with provider-aware availability, authentication, tool counts, and capability-aware controls
- inject enabled user MCP servers into compatible sessions without bridging provider-managed tools across incompatible providers
- support configured OAuth, native provider OAuth, connector URLs, and terminal-backed native login flows
- cache provider inventory after initial discovery; normal view opens are cache-only, while Refresh, authentication completion, and provider mutations force discovery
- add reconciliation, parsing, probing, authentication, and renderer display tests

## Why

Configuration files are not a complete MCP inventory. Provider-managed servers, plugins, apps, and connectors also need to be reconciled with live provider state so the UI can show what is actually installed, connected, or awaiting authentication.

The native managed-server login command also requires a terminal. Running it through ordinary subprocess pipes caused Connect to fail before the browser flow began, so it now runs in a pseudo-terminal.

## User impact

Users can see and manage the MCPs available to the active provider, connect auth-required entries, inspect the same inventory in Settings, and manually refresh discovery. Opening the popover no longer repeatedly invokes native provider inventory commands.

## Validation

- `bun run check-types` — 22/22 targets passed
- `bun run test:unit` — 19/19 targets passed
- `cd apps/server && bun run test:integration` — 135 tests passed
- focused Biome checks for all new MCP modules and tests
- desktop production bundle
- `git diff origin/main...HEAD --check`
