### PR TITLE
Fix mobile chat scrolling and viewport boundaries

### DIFF
--- a/apps/mobile/app/c/[conn]/session/[sessionId].tsx
+++ b/apps/mobile/app/c/[conn]/session/[sessionId].tsx
@@ -7,6 +7,7 @@ import type {
 } from "@zuse/contracts";
 import { Effect } from "effect";
 import { router, Stack, useLocalSearchParams } from "expo-router";
+import { useHeaderHeight } from "expo-router/react-navigation";
 import { ChevronDown } from "lucide-react-native";
 import React, {
 	useCallback,
@@ -16,9 +17,13 @@ import React, {
 	useState,
 } from "react";
 import {
+	AccessibilityInfo,
 	Alert,
+	Dimensions,
 	FlatList,
+	Keyboard,
 	KeyboardAvoidingView,
+	type KeyboardEvent,
 	type LayoutChangeEvent,
 	type NativeScrollEvent,
 	type NativeSyntheticEvent,
@@ -57,6 +62,14 @@ import { selectConnectionBundles } from "~/lib/session-bundles";
 import { connectionSessionKey } from "~/lib/session-key";
 import { selectSessionMessages } from "~/lib/session-messages";
 import {
+	latestTurnAnchorSpace,
+	nextThreadScrollMode,
+	shouldFollowTranscript,
+	shouldShowLatestAction,
+	type ThreadScrollMode,
+	transcriptBottomInset,
+} from "~/lib/thread-scroll";
+import {
 	answerQuestion,
 	flushServerQueue,
 	makeTextInput,
@@ -91,6 +104,7 @@ export default function ThreadScreenRoute() {
 
 function ThreadScreen() {
 	const insets = useSafeAreaInsets();
+	const headerHeight = useHeaderHeight();
 	const { theme } = useUniwind();
 	const { conn, sessionId } = useLocalSearchParams<{
 		conn: string;
@@ -101,8 +115,16 @@ function ThreadScreen() {
 	const listRef = useRef<FlatList>(null);
 	const didInitialScroll = useRef(false);
 	const initialScrollQuietUntil = useRef(0);
-	const atBottomRef = useRef(true);
+	const scrollModeRef = useRef<ThreadScrollMode>("initial");
+	const distanceFromBottomRef = useRef(0);
+	const hasUnseenContentRef = useRef(false);
+	const previousMessagesRef = useRef<readonly unknown[] | null>(null);
 	const [showJumpButton, setShowJumpButton] = useState(false);
+	const [hasUnseenContent, setHasUnseenContent] = useState(false);
+	const [keyboardOverlap, setKeyboardOverlap] = useState(0);
+	const [listViewportHeight, setListViewportHeight] = useState(0);
+	const [latestTurnHeight, setLatestTurnHeight] = useState(0);
+	const [liveFooterHeight, setLiveFooterHeight] = useState(0);
 	const [bottomAccessoryHeight, setBottomAccessoryHeight] = useState(
 		Math.max(insets.bottom, 12) + 64,
 	);
@@ -145,6 +167,7 @@ function ThreadScreen() {
 	const hydrate = useMobileMessagesStore((state) => state.hydrate);
 	const messages = useMemo(() => sanitizeMessages(rawMessages), [rawMessages]);
 	const turns = useMemo(() => groupTimelineTurns(messages), [messages]);
+	const latestTurnId = turns.at(-1)?.id ?? null;
 	const detail = selectSessionChat(bundles, normalizedSessionId);
 	const title = detail?.chat?.title ?? detail?.session.title ?? "Thread";
 	const sessionStatus =
@@ -371,8 +394,65 @@ function ThreadScreen() {
 		void stateKey;
 		didInitialScroll.current = false;
 		initialScrollQuietUntil.current = Date.now() + 500;
-		atBottomRef.current = true;
+		scrollModeRef.current = "initial";
+		distanceFromBottomRef.current = 0;
+		hasUnseenContentRef.current = false;
+		previousMessagesRef.current = null;
+		setHasUnseenContent(false);
+		setShowJumpButton(false);
+		setLatestTurnHeight(0);
 	}, [stateKey]);
+
+	useEffect(() => {
+		void latestTurnId;
+		setLatestTurnHeight(0);
+	}, [latestTurnId]);
+
+	useEffect(() => {
+		const updateKeyboardOverlap = (event: KeyboardEvent) => {
+			const screenHeight = Dimensions.get("screen").height;
+			const keyboardBottom =
+				event.endCoordinates.screenY + event.endCoordinates.height;
+			const isDocked = keyboardBottom >= screenHeight - 2;
+			const nextOverlap = isDocked
+				? Math.max(0, screenHeight - event.endCoordinates.screenY)
+				: 0;
+			setKeyboardOverlap(nextOverlap);
+		};
+		const showEvent =
+			process.env.EXPO_OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+		const hideEvent =
+			process.env.EXPO_OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+		const showSubscription = Keyboard.addListener(
+			showEvent,
+			updateKeyboardOverlap,
+		);
+		const hideSubscription = Keyboard.addListener(hideEvent, () => {
+			setKeyboardOverlap(0);
+		});
+		return () => {
+			showSubscription.remove();
+			hideSubscription.remove();
+		};
+	}, []);
+
+	useEffect(() => {
+		if (previousMessagesRef.current === null) {
+			previousMessagesRef.current = messages;
+			return;
+		}
+		if (previousMessagesRef.current === messages) return;
+		previousMessagesRef.current = messages;
+		if (scrollModeRef.current !== "detached" || hasUnseenContentRef.current) {
+			return;
+		}
+		hasUnseenContentRef.current = true;
+		setHasUnseenContent(true);
+		setShowJumpButton(true);
+		void AccessibilityInfo.announceForAccessibility(
+			"New response available below.",
+		);
+	}, [messages]);
 
 	// Fade the jump button in/out from its visibility state (assignment must
 	// live in an effect for the React Compiler's shared-value immutability rule).
@@ -382,15 +462,17 @@ function ThreadScreen() {
 
 	const scrollToLatest = useCallback(() => {
 		if (messages.length === 0) return;
-		// Only autoscroll when the user is already at the bottom, or during the
-		// very first positioning of a freshly-opened chat. Otherwise leave the
-		// scroll position alone so reading isn't yanked (D6).
-		if (didInitialScroll.current && !atBottomRef.current) return;
+		if (!shouldFollowTranscript(scrollModeRef.current)) return;
 		const animated =
 			didInitialScroll.current && Date.now() > initialScrollQuietUntil.current;
 		didInitialScroll.current = true;
 		requestAnimationFrame(() => {
 			listRef.current?.scrollToEnd({ animated });
+			if (scrollModeRef.current === "initial") {
+				scrollModeRef.current = nextThreadScrollMode("initial", {
+					type: "initial-positioned",
+				});
+			}
 		});
 	}, [messages.length]);
 
@@ -400,16 +482,67 @@ function ThreadScreen() {
 		const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
 		const distanceFromBottom =
 			contentSize.height - (contentOffset.y + layoutMeasurement.height);
-		const atBottom = distanceFromBottom <= 40;
-		atBottomRef.current = atBottom;
-		if (atBottom === showJumpButton) setShowJumpButton(!atBottom);
+		distanceFromBottomRef.current = Math.max(0, distanceFromBottom);
+		setShowJumpButton(
+			shouldShowLatestAction({
+				mode: scrollModeRef.current,
+				distance: distanceFromBottomRef.current,
+				hasUnseenContent: hasUnseenContentRef.current,
+			}),
+		);
+	};
+	const detachReader = () => {
+		scrollModeRef.current = nextThreadScrollMode(scrollModeRef.current, {
+			type: "reader-interacted",
+		});
+		setShowJumpButton(
+			shouldShowLatestAction({
+				mode: scrollModeRef.current,
+				distance: distanceFromBottomRef.current,
+				hasUnseenContent: hasUnseenContentRef.current,
+			}),
+		);
+	};
+	const resumeAtLiveEdge = () => {
+		scrollModeRef.current = nextThreadScrollMode(scrollModeRef.current, {
+			type: "returned-to-live-edge",
+			distance: distanceFromBottomRef.current,
+		});
+		if (scrollModeRef.current !== "following") return;
+		hasUnseenContentRef.current = false;
+		setHasUnseenContent(false);
+		setShowJumpButton(false);
 	};
 
 	const jumpToBottom = () => {
-		atBottomRef.current = true;
+		scrollModeRef.current = nextThreadScrollMode(scrollModeRef.current, {
+			type: "jumped-to-latest",
+		});
+		hasUnseenContentRef.current = false;
+		setHasUnseenContent(false);
 		setShowJumpButton(false);
 		listRef.current?.scrollToEnd({ animated: true });
 	};
+	const onMessageSubmitted = () => {
+		scrollModeRef.current = nextThreadScrollMode(scrollModeRef.current, {
+			type: "message-submitted",
+		});
+		hasUnseenContentRef.current = false;
+		setHasUnseenContent(false);
+		setShowJumpButton(false);
+		setLatestTurnHeight(0);
+		requestAnimationFrame(scrollToLatest);
+	};
+	const onComposerFocusChange = (focused: boolean) => {
+		if (focused && shouldFollowTranscript(scrollModeRef.current)) {
+			requestAnimationFrame(scrollToLatest);
+		}
+	};
+	useEffect(() => {
+		if (keyboardOverlap > 0 && shouldFollowTranscript(scrollModeRef.current)) {
+			scrollToLatest();
+		}
+	}, [keyboardOverlap, scrollToLatest]);
 
 	const jumpStyle = useAnimatedStyle(() => ({ opacity: jumpOpacity.value }));
 	const onBottomAccessoryLayout = (event: LayoutChangeEvent) => {
@@ -418,6 +551,20 @@ function ThreadScreen() {
 			Math.abs(current - nextHeight) < 1 ? current : nextHeight,
 		);
 	};
+	const effectiveBottomInset = transcriptBottomInset(
+		bottomAccessoryHeight,
+		keyboardOverlap,
+	);
+	const anchorSpace =
+		turns.length === 0
+			? 0
+			: latestTurnAnchorSpace({
+					viewportHeight: listViewportHeight,
+					bottomInset: effectiveBottomInset,
+					latestTurnHeight: latestTurnHeight + liveFooterHeight,
+					previousContext: headerHeight + 12,
+				});
+	const transcriptFooterHeight = effectiveBottomInset + anchorSpace;
 
 	const onRename = useCallback(() => {
 		if (chatId === null || options === null) return;
@@ -582,17 +729,34 @@ function ThreadScreen() {
 				data={turns}
 				keyExtractor={(turn) => turn.id}
 				renderItem={({ item, index }) => (
-					<TurnRow
-						turn={item}
-						context={ctx}
-						live={sessionStatus === "running" && index === turns.length - 1}
-					/>
+					<View
+						onLayout={
+							index === turns.length - 1
+								? (event) => {
+										const nextHeight = event.nativeEvent.layout.height;
+										setLatestTurnHeight((current) =>
+											Math.abs(current - nextHeight) < 1 ? current : nextHeight,
+										);
+									}
+								: undefined
+						}
+					>
+						<TurnRow
+							turn={item}
+							context={ctx}
+							live={sessionStatus === "running" && index === turns.length - 1}
+						/>
+					</View>
 				)}
-				contentInsetAdjustmentBehavior="automatic"
-				contentContainerClassName="gap-1 px-4 pt-3"
-				contentContainerStyle={{ paddingBottom: bottomAccessoryHeight + 12 }}
-				scrollIndicatorInsets={{ bottom: bottomAccessoryHeight }}
+				contentInsetAdjustmentBehavior="never"
+				contentContainerClassName="gap-1 px-4"
+				contentContainerStyle={{ paddingTop: headerHeight + 12 }}
+				scrollIndicatorInsets={{
+					top: headerHeight,
+					bottom: effectiveBottomInset,
+				}}
 				keyboardDismissMode="interactive"
+				keyboardShouldPersistTaps="handled"
 				ListHeaderComponent={
 					error || connectionProblem ? (
 						<View className="gap-2 pb-2">
@@ -612,8 +776,16 @@ function ThreadScreen() {
 					) : null
 				}
 				ListFooterComponent={
-					workingActive || localQueued.length > 0 || serverQueued.length > 0 ? (
-						<View className="pt-1">
+					<View>
+						<View
+							className="pt-1"
+							onLayout={(event) => {
+								const nextHeight = event.nativeEvent.layout.height;
+								setLiveFooterHeight((current) =>
+									Math.abs(current - nextHeight) < 1 ? current : nextHeight,
+								);
+							}}
+						>
 							{workingActive ? <WorkingIndicator since={workingSince} /> : null}
 							{serverQueued.map((item) => (
 								<QueuedBubble
@@ -645,13 +817,24 @@ function ThreadScreen() {
 								/>
 							))}
 						</View>
-					) : null
+						<View style={{ height: transcriptFooterHeight }} />
+					</View>
 				}
 				onScroll={onScroll}
+				onScrollBeginDrag={detachReader}
+				onScrollEndDrag={resumeAtLiveEdge}
+				onMomentumScrollEnd={resumeAtLiveEdge}
+				onTouchStart={detachReader}
 				scrollEventThrottle={32}
 				maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
 				onContentSizeChange={scrollToLatest}
-				onLayout={scrollToLatest}
+				onLayout={(event) => {
+					const nextHeight = event.nativeEvent.layout.height;
+					setListViewportHeight((current) =>
+						Math.abs(current - nextHeight) < 1 ? current : nextHeight,
+					);
+					scrollToLatest();
+				}}
 			/>
 			<KeyboardAvoidingView
 				behavior={process.env.EXPO_OS === "ios" ? "position" : "height"}
@@ -675,19 +858,50 @@ function ThreadScreen() {
 					>
 						<Pressable
 							accessibilityRole="button"
-							accessibilityLabel="Scroll to latest"
+							accessibilityLabel={
+								hasUnseenContent
+									? "Jump to latest, new response available"
+									: "Jump to latest"
+							}
+							accessibilityHint="Resumes following the live response"
 							onPress={jumpToBottom}
 						>
 							<GlassSurface
 								style={{
-									width: 40,
-									height: 40,
-									borderRadius: 20,
+									width: 46,
+									height: 46,
+									borderRadius: 23,
+									borderWidth: 1,
+									borderColor:
+										theme === "dark"
+											? "rgba(255,255,255,0.16)"
+											: "rgba(0,0,0,0.12)",
+									backgroundColor:
+										theme === "dark"
+											? "rgba(24,24,24,0.72)"
+											: "rgba(255,255,255,0.78)",
 									alignItems: "center",
 									justifyContent: "center",
+									shadowColor: "#000",
+									shadowOpacity: theme === "dark" ? 0.32 : 0.14,
+									shadowRadius: 14,
+									shadowOffset: { width: 0, height: 6 },
 								}}
 							>
 								<ChevronDown size={20} color={colors.fg} />
+								{hasUnseenContent ? (
+									<View
+										style={{
+											position: "absolute",
+											top: 5,
+											right: 5,
+											width: 7,
+											height: 7,
+											borderRadius: 4,
+											backgroundColor: colors.accent,
+										}}
+									/>
+								) : null}
 							</GlassSurface>
 						</Pressable>
 					</Animated.View>
@@ -757,6 +971,8 @@ function ThreadScreen() {
 								online={transportOnline}
 								connectionStatus={connectionSnapshot?.status}
 								onRetryConnection={() => retryConnection(connKey, options)}
+								onFocusChange={onComposerFocusChange}
+								onMessageSubmitted={onMessageSubmitted}
 								bottomInset={insets.bottom}
 							/>
 						</View>

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -2920,7 +2920,7 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: 2a3445af48b78130a1d570616c83692e9a3d0275
   EXUpdatesInterface: 92d2aa5194b6fb93ca8ab749db75665cb28b2e60
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: f0e74392152dfa404c08b282951c911be569d8fc
+  hermes-engine: 81bc8e476e1bae3c96b3c88056b8a2ab41581651
   OpenSSL-Universal: ecee7b138fa75a74ecf00d7ffd248fb584739b9e
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
@@ -2930,7 +2930,7 @@ SPEC CHECKSUMS:
   React: 2574546f2d017abd14d0c9b48cf2b6a0547c2591
   React-callinvoker: 03cd4b931d1d583d87aae99b8f7b6fe26bf571ee
   React-Core: 1c824d9c7dd8aa760b5f1b50d5a54c2a3f598f87
-  React-Core-prebuilt: 13924a267683b3d6fa4bde9c80380becf83a9c5c
+  React-Core-prebuilt: 28e7badf40b16a6565396b81f197cf287d638fb8
   React-CoreModules: 2f9ed75bca7f6dea2b70e8a1f4a5ca9b6be52d76
   React-cxxreact: 7103d5ba69848c039e11079e74ceede05efe795e
   React-debug: 8cc8d99ccc664ef9e873027f7fc3fb0a50496012
@@ -2996,7 +2996,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: dcdd0e1b9559a6d8d8aea05286f4ed085091978e
   ReactCodegen: 21807c5e7d6d0e334667f755e23063834d581e62
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
-  ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
+  ReactNativeDependencies: 1bde419b968a85b78fcb444a0870d66fcdc9c937
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
   RNReanimated: c66c5c9b1200bb4c0ca7b597064328b16bb1d667

--- a/apps/mobile/src/components/composer.tsx
+++ b/apps/mobile/src/components/composer.tsx
@@ -5,7 +5,6 @@ import {
 } from "@hugeicons-pro/core-solid-rounded";
 import type { ConnectionStatus } from "@zuse/client-runtime/supervisor";
 import {
-	extractFileChanges,
 	groupTimelineTurns,
 	summarizeTurnActivity,
 } from "@zuse/client-runtime/timeline";
@@ -84,6 +83,8 @@ export const Composer = ({
 	online,
 	connectionStatus,
 	onRetryConnection,
+	onFocusChange,
+	onMessageSubmitted,
 	bottomInset = 0,
 }: {
 	connKey: string;
@@ -95,6 +96,8 @@ export const Composer = ({
 	online: boolean;
 	connectionStatus?: ConnectionStatus;
 	onRetryConnection?: () => void;
+	onFocusChange?: (focused: boolean) => void;
+	onMessageSubmitted?: () => void;
 	bottomInset?: number;
 }) => {
 	const [text, setText] = useState("");
@@ -125,13 +128,6 @@ export const Composer = ({
 		const turn = groupTimelineTurns(messages).at(-1);
 		if (turn === undefined) return null;
 		const summary = summarizeTurnActivity(turn.body);
-		const firstFileTool = turn.body.find((message) => {
-			const content = message.content;
-			return (
-				content._tag === "tool_use" &&
-				extractFileChanges(content.tool, content.input).length > 0
-			);
-		});
 		const firstAgentTool = turn.body.find((message) => {
 			const content = message.content;
 			return (
@@ -140,10 +136,6 @@ export const Composer = ({
 		});
 		return {
 			...summary,
-			fileItemId:
-				firstFileTool?.content._tag === "tool_use"
-					? firstFileTool.content.itemId
-					: null,
 			agentItemId:
 				firstAgentTool?.content._tag === "tool_use"
 					? firstAgentTool.content.itemId
@@ -186,10 +178,8 @@ export const Composer = ({
 		showInterrupt ||
 		modelSheetOpen;
 
-	const fileCount = currentActivity?.files.length ?? 0;
 	const agentCount = currentActivity?.agents ?? 0;
-	const hasPills =
-		!online || queuedCount > 0 || fileCount > 0 || agentCount > 0;
+	const hasPills = !online || queuedCount > 0 || agentCount > 0;
 
 	const submit = async () => {
 		if (!canSend) return;
@@ -199,10 +189,12 @@ export const Composer = ({
 				setComposerError("Attachments and goals require an active connection.");
 				return;
 			}
+			onMessageSubmitted?.();
 			setText("");
 			await enqueue(connKey, sessionId, value);
 			return;
 		}
+		onMessageSubmitted?.();
 		setBusy(true);
 		setComposerError(null);
 		let optimisticMessageId: MessageId | null = null;
@@ -365,25 +357,6 @@ export const Composer = ({
 							tone={queueError ? "danger" : "neutral"}
 						/>
 					) : null}
-					{fileCount > 0 ? (
-						<StatusPill
-							label={`${fileCount} files  +${currentActivity?.added ?? 0} −${currentActivity?.removed ?? 0}`}
-							tone="files"
-							onPress={
-								currentActivity?.fileItemId == null
-									? undefined
-									: () =>
-											router.push({
-												pathname: "/c/[conn]/session/[sessionId]/tool/[itemId]",
-												params: {
-													conn: connKey,
-													sessionId,
-													itemId: currentActivity?.fileItemId ?? "",
-												},
-											})
-							}
-						/>
-					) : null}
 					{agentCount > 0 ? (
 						<StatusPill
 							label={`${agentCount} ${agentCount === 1 ? "agent" : "agents"}`}
@@ -441,8 +414,14 @@ export const Composer = ({
 							placeholderTextColor={colors.tertiaryFg}
 							value={text}
 							onChangeText={setText}
-							onFocus={() => setFocused(true)}
-							onBlur={() => setFocused(false)}
+							onFocus={() => {
+								setFocused(true);
+								onFocusChange?.(true);
+							}}
+							onBlur={() => {
+								setFocused(false);
+								onFocusChange?.(false);
+							}}
 						/>
 						{planMode || goalMode ? (
 							<View className="flex-row flex-wrap gap-2 px-1">
@@ -638,7 +617,7 @@ function StatusPill({
 	onPress,
 }: {
 	label: string;
-	tone: "neutral" | "warning" | "danger" | "files";
+	tone: "neutral" | "warning" | "danger";
 	onPress?: () => void;
 }) {
 	const color =

--- a/apps/mobile/src/lib/thread-scroll.ts
+++ b/apps/mobile/src/lib/thread-scroll.ts
@@ -1,0 +1,67 @@
+export type ThreadScrollMode = "initial" | "following" | "detached";
+
+export type ThreadScrollEvent =
+	| { readonly type: "initial-positioned" }
+	| { readonly type: "reader-interacted" }
+	| { readonly type: "returned-to-live-edge"; readonly distance: number }
+	| { readonly type: "message-submitted" }
+	| { readonly type: "jumped-to-latest" };
+
+/** Enter and leave thresholds are deliberately different to avoid edge flicker. */
+export const LIVE_EDGE_ENTER_PX = 48;
+export const LIVE_EDGE_EXIT_PX = 96;
+
+export const nextThreadScrollMode = (
+	mode: ThreadScrollMode,
+	event: ThreadScrollEvent,
+): ThreadScrollMode => {
+	switch (event.type) {
+		case "reader-interacted":
+			return "detached";
+		case "returned-to-live-edge":
+			return event.distance <= LIVE_EDGE_ENTER_PX ? "following" : mode;
+		case "initial-positioned":
+		case "message-submitted":
+		case "jumped-to-latest":
+			return "following";
+	}
+};
+
+export const shouldFollowTranscript = (mode: ThreadScrollMode): boolean =>
+	mode !== "detached";
+
+export const shouldShowLatestAction = (options: {
+	readonly mode: ThreadScrollMode;
+	readonly distance: number;
+	readonly hasUnseenContent: boolean;
+}): boolean =>
+	options.mode === "detached" &&
+	(options.hasUnseenContent || options.distance > LIVE_EDGE_EXIT_PX);
+
+export const transcriptBottomInset = (
+	accessoryHeight: number,
+	keyboardOverlap: number,
+	spacing = 12,
+): number =>
+	Math.max(0, accessoryHeight) +
+	Math.max(0, keyboardOverlap) +
+	Math.max(0, spacing);
+
+/**
+ * Reserve only the unused part of the latest-turn viewport. As the response
+ * grows, this space shrinks by the same amount, so the turn remains anchored
+ * without manually compensating the list offset.
+ */
+export const latestTurnAnchorSpace = (options: {
+	readonly viewportHeight: number;
+	readonly bottomInset: number;
+	readonly latestTurnHeight: number;
+	readonly previousContext: number;
+}): number =>
+	Math.max(
+		0,
+		options.viewportHeight -
+			Math.max(0, options.bottomInset) -
+			Math.max(0, options.latestTurnHeight) -
+			Math.max(0, options.previousContext),
+	);

--- a/apps/mobile/test/unit/lib/thread-scroll.test.ts
+++ b/apps/mobile/test/unit/lib/thread-scroll.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	latestTurnAnchorSpace,
+	nextThreadScrollMode,
+	shouldFollowTranscript,
+	shouldShowLatestAction,
+	transcriptBottomInset,
+} from "../../../src/lib/thread-scroll";
+
+describe("thread scroll policy", () => {
+	test("follows after initial positioning, submission, and an explicit jump", () => {
+		expect(
+			nextThreadScrollMode("initial", { type: "initial-positioned" }),
+		).toBe("following");
+		expect(
+			nextThreadScrollMode("detached", { type: "message-submitted" }),
+		).toBe("following");
+		expect(nextThreadScrollMode("detached", { type: "jumped-to-latest" })).toBe(
+			"following",
+		);
+	});
+
+	test("detaches for reader interaction and resumes only at the live edge", () => {
+		expect(
+			nextThreadScrollMode("following", { type: "reader-interacted" }),
+		).toBe("detached");
+		expect(
+			nextThreadScrollMode("detached", {
+				type: "returned-to-live-edge",
+				distance: 49,
+			}),
+		).toBe("detached");
+		expect(
+			nextThreadScrollMode("detached", {
+				type: "returned-to-live-edge",
+				distance: 48,
+			}),
+		).toBe("following");
+	});
+
+	test("shows the latest action only for detached offscreen or unseen content", () => {
+		expect(
+			shouldShowLatestAction({
+				mode: "following",
+				distance: 200,
+				hasUnseenContent: true,
+			}),
+		).toBe(false);
+		expect(
+			shouldShowLatestAction({
+				mode: "detached",
+				distance: 20,
+				hasUnseenContent: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldShowLatestAction({
+				mode: "detached",
+				distance: 97,
+				hasUnseenContent: false,
+			}),
+		).toBe(true);
+	});
+
+	test("combines composer and keyboard clearance without negative values", () => {
+		expect(transcriptBottomInset(72, 310)).toBe(394);
+		expect(transcriptBottomInset(-1, -2)).toBe(12);
+	});
+
+	test("shrinks anchor space as the latest turn fills the viewport", () => {
+		expect(
+			latestTurnAnchorSpace({
+				viewportHeight: 800,
+				bottomInset: 300,
+				latestTurnHeight: 120,
+				previousContext: 72,
+			}),
+		).toBe(308);
+		expect(
+			latestTurnAnchorSpace({
+				viewportHeight: 800,
+				bottomInset: 300,
+				latestTurnHeight: 500,
+				previousContext: 72,
+			}),
+		).toBe(0);
+	});
+
+	test("only initial and following modes permit content-driven movement", () => {
+		expect(shouldFollowTranscript("initial")).toBe(true);
+		expect(shouldFollowTranscript("following")).toBe(true);
+		expect(shouldFollowTranscript("detached")).toBe(false);
+	});
+});

--- a/apps/mobile/test/unit/mobile-ui-contract.test.ts
+++ b/apps/mobile/test/unit/mobile-ui-contract.test.ts
@@ -82,6 +82,8 @@ describe("mobile UI contracts", () => {
 			expect(source).toContain("<PlanPill");
 			expect(source).toContain("<ComposerPlusMenu");
 		}
+		expect(threadComposer).not.toContain("fileCount > 0");
+		expect(threadComposer).not.toContain("fileItemId");
 	});
 
 	test("keeps the camera preview active and explicitly full screen", () => {
@@ -93,7 +95,13 @@ describe("mobile UI contracts", () => {
 
 	test("floats the composer over the feed and centers the jump control", () => {
 		const thread = appFile("c/[conn]/session/[sessionId].tsx");
-		expect(thread).toContain("paddingBottom: bottomAccessoryHeight + 12");
+		expect(thread).toContain("useHeaderHeight");
+		expect(thread).toContain("paddingTop: headerHeight + 12");
+		expect(thread).toContain("height: transcriptFooterHeight");
+		expect(thread).toContain('contentInsetAdjustmentBehavior="never"');
+		expect(thread).toContain("transcriptBottomInset(");
+		expect(thread).toContain("onScrollBeginDrag={detachReader}");
+		expect(thread).toContain("onMessageSubmitted={onMessageSubmitted}");
 		expect(thread).toContain(
 			'position: "absolute", left: 0, right: 0, bottom: 0',
 		);


### PR DESCRIPTION
## What changed

- added an intent-aware transcript scroll policy with follow, detach, unseen-content, and jump-to-latest behavior
- anchored new and reopened turns below the native header
- made composer and keyboard clearance part of the real scrollable footer so content never hides underneath them
- strengthened the jump-to-latest glass control and accessibility feedback
- removed the redundant latest-turn file status pill from the composer while preserving the workspace and transcript change summaries
- synchronized the iOS dependency lock checksums used by the validated native build

## Why

The transcript could move readers during streaming, place new turns beneath the native header, and scroll latest content underneath the composer or keyboard. Padding-only clearance was not reliable during iOS layout changes, and duplicate file summaries added noise near the composer.

## Validation

- Biome checks
- mobile TypeScript checks
- 110 mobile unit tests
- mobile WebSocket integration test
- iOS simulator native build
- git diff whitespace checks