### PR TITLE
Fix assistant message forking and chat tab behavior

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
 		"dev": "bun run --parallel dev:bundle dev:electron",
 		"dev:bundle": "tsdown --watch",
 		"dev:electron": "node scripts/dev-electron.mjs",
-		"build": "tsdown",
+		"build": "tsdown && node scripts/main-bundle-startup-smoke.mjs",
 		"check-types": "tsc --noEmit",
 		"test": "vitest run test && node scripts/sqlite-runtime-smoke.mjs",
 		"test:unit": "vitest run test/unit",

--- a/apps/desktop/scripts/main-bundle-startup-smoke.mjs
+++ b/apps/desktop/scripts/main-bundle-startup-smoke.mjs
@@ -1,0 +1,18 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const bundlePath = fileURLToPath(
+	new URL("../dist-electron/main.cjs", import.meta.url),
+);
+const result = spawnSync(process.execPath, [bundlePath], {
+	env: { ...process.env, ZUSE_MAIN_BUNDLE_SMOKE: "1" },
+	encoding: "utf8",
+});
+
+if (result.error !== undefined) throw result.error;
+if (result.status !== 0) {
+	process.stderr.write(result.stderr);
+	throw new Error(
+		`Desktop main bundle failed startup smoke check (exit ${result.status ?? "unknown"})`,
+	);
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -33,6 +33,14 @@ import {
 import fixPath from "fix-path";
 import selfsigned from "selfsigned";
 
+// Build verification runs the generated CommonJS bundle under Node to ensure
+// its static import graph initializes without temporal-dead-zone failures.
+// Exit before touching Electron APIs; production and normal development never
+// set this flag.
+if (process.env.ZUSE_MAIN_BUNDLE_SMOKE === "1") {
+	process.exit(0);
+}
+
 // macOS GUI apps launched from Finder inherit a minimal PATH
 // (`/usr/bin:/bin:/usr/sbin:/sbin`), not the user's shell PATH. The Claude
 // driver runs `which claude` to locate the user's Claude Code install — that

--- a/apps/renderer/src/components/assistant-message-actions.tsx
+++ b/apps/renderer/src/components/assistant-message-actions.tsx
@@ -1,0 +1,65 @@
+import type { MessageId, SessionId } from "@zuse/contracts";
+
+import { cn } from "~/lib/utils";
+import { CopyButton } from "./copy-button.tsx";
+import { ForkButton } from "./fork-menu.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
+
+const formatMessageTime = (date: Date): string =>
+	date.toLocaleTimeString([], {
+		hour: "numeric",
+		minute: "2-digit",
+	});
+
+const formatFullMessageTime = (date: Date): string =>
+	date.toLocaleString([], {
+		dateStyle: "full",
+		timeStyle: "short",
+	});
+
+export function AssistantMessageActions({
+	text,
+	createdAt,
+	sessionId,
+	messageId,
+	className,
+}: {
+	readonly text: string;
+	readonly createdAt?: Date;
+	readonly sessionId?: SessionId;
+	readonly messageId?: MessageId;
+	readonly className?: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"flex items-center gap-1 opacity-0 transition-opacity duration-150 ease-out group-hover/assistant:opacity-100 group-focus-within/assistant:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100",
+				className,
+			)}
+		>
+			<CopyButton
+				text={text}
+				label="Copy message"
+				className="active:scale-[0.97] [@media(pointer:coarse)]:size-11"
+			/>
+			{sessionId !== undefined && messageId !== undefined ? (
+				<ForkButton sourceSessionId={sessionId} fromMessageId={messageId} />
+			) : null}
+			{createdAt !== undefined ? (
+				<Tooltip>
+					<TooltipTrigger
+						render={
+							<time
+								dateTime={createdAt.toISOString()}
+								className="cursor-default px-1 text-[11px] tabular-nums text-muted-foreground"
+							>
+								{formatMessageTime(createdAt)}
+							</time>
+						}
+					/>
+					<TooltipPopup>{formatFullMessageTime(createdAt)}</TooltipPopup>
+				</Tooltip>
+			) : null}
+		</div>
+	);
+}

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -1,9 +1,8 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Message01Icon } from "@hugeicons-pro/core-solid-rounded";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
-import type { Message, MessageId, SessionId } from "@zuse/contracts";
+import type { Message, SessionId } from "@zuse/contracts";
 import {
-	type MouseEvent,
 	useCallback,
 	useEffect,
 	useLayoutEffect,
@@ -38,7 +37,6 @@ import { useSkillsStore } from "../store/skills.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { ChatLookupsProvider, deriveChatLookups } from "./chat-lookups.tsx";
 import { FileChipProvider } from "./file-chip.tsx";
-import { useForkMenu } from "./fork-menu.tsx";
 import { JumpToLatestPill } from "./jump-to-latest-pill.tsx";
 import { ErrorBubble, MessageRow } from "./message-row.tsx";
 import { NextUnreadButton } from "./next-unread-button.tsx";
@@ -89,7 +87,6 @@ export function ChatView({
 	useLayoutEffect(() => {
 		markRendererInteraction(sessionId, "first-react-commit");
 	}, [sessionId]);
-	const forkMenu = useForkMenu();
 	const messages = useMessagesStore(
 		(s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES,
 	);
@@ -121,9 +118,9 @@ export function ChatView({
 		return getSessionById(sessionId);
 	});
 
-	// While this session's worktree is still being set up — or the provider
-	// CLI is still booting — the inline setup card carries the "what's
-	// happening" message, so suppress the empty "New chat" placeholder under it.
+	// Suppress the empty placeholder only while chat-level worktree setup is
+	// active. Additional sessions boot their own provider in the background but
+	// must not replay the chat setup surface.
 	const worktreeId = session?.worktreeId ?? null;
 	const worktreeSetupActive = useWorktreesStore((s) => {
 		if (worktreeId === null) return false;
@@ -139,9 +136,7 @@ export function ChatView({
 		}
 		return false;
 	});
-	const externalResume = session !== null && session.resumeStrategy !== "none";
-	const setupActive =
-		worktreeSetupActive || (!externalResume && session?.status === "booting");
+	const setupActive = worktreeSetupActive;
 	const rows = useMemo(
 		() =>
 			deriveChatTimelineRows({
@@ -675,9 +670,9 @@ export function ChatView({
 
 	const renderTimelineRow = useCallback(
 		({ item }: { item: ChatTimelineRow }) => (
-			<TimelineRow row={item} sessionId={sessionId} onFork={forkMenu.openAt} />
+			<TimelineRow row={item} sessionId={sessionId} />
 		),
-		[forkMenu.openAt, sessionId],
+		[sessionId],
 	);
 
 	return (
@@ -781,7 +776,6 @@ export function ChatView({
 					</div>
 				</div>
 			</div>
-			{forkMenu.menu}
 		</FileChipProvider>
 	);
 }
@@ -789,32 +783,13 @@ export function ChatView({
 function TimelineRow({
 	row,
 	sessionId,
-	onFork,
 }: {
 	row: ChatTimelineRow;
 	sessionId: SessionId;
-	onFork: (
-		event: MouseEvent,
-		sourceSessionId: SessionId,
-		fromMessageId: MessageId,
-	) => void;
 }) {
 	switch (row.kind) {
 		case "message":
-			return (
-				// biome-ignore lint/a11y/noStaticElementInteractions: context menu is an optional secondary action.
-				<div
-					onContextMenu={
-						row.message.content._tag === "user" ||
-						row.message.content._tag === "user_rich" ||
-						row.message.content._tag === "assistant"
-							? (event) => onFork(event, sessionId, row.message.id)
-							: undefined
-					}
-				>
-					<MessageRow message={row.message} sessionId={sessionId} />
-				</div>
-			);
+			return <MessageRow message={row.message} sessionId={sessionId} />;
 		case "subagent":
 			return (
 				<div>
@@ -833,7 +808,7 @@ function TimelineRow({
 		case "turn-summary":
 			return (
 				<div>
-					<TurnSummary body={row.body} />
+					<TurnSummary body={row.body} sessionId={sessionId} />
 				</div>
 			);
 		case "working":

--- a/apps/renderer/src/components/copy-button.tsx
+++ b/apps/renderer/src/components/copy-button.tsx
@@ -3,6 +3,7 @@ import { Copy01Icon, Tick02Icon } from "@hugeicons-pro/core-solid-rounded";
 import { useEffect, useState } from "react";
 
 import { cn } from "~/lib/utils";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 export function CopyButton({
 	text,
@@ -29,18 +30,28 @@ export function CopyButton({
 	const title = copied ? "Copied" : label;
 
 	return (
-		<button
-			type="button"
-			onClick={onCopy}
-			aria-label={title}
-			title={title}
-			className={cn(
-				"inline-grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground/70 outline-none",
-				"hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring",
-				className,
-			)}
-		>
-			<HugeiconsIcon icon={icon} className="size-3.5" aria-hidden="true" />
-		</button>
+		<Tooltip>
+			<TooltipTrigger
+				render={
+					<button
+						type="button"
+						onClick={onCopy}
+						aria-label={title}
+						className={cn(
+							"inline-grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground/70 outline-none",
+							"hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring",
+							className,
+						)}
+					>
+						<HugeiconsIcon
+							icon={icon}
+							className="size-3.5"
+							aria-hidden="true"
+						/>
+					</button>
+				}
+			/>
+			<TooltipPopup>{title}</TooltipPopup>
+		</Tooltip>
 	);
 }

--- a/apps/renderer/src/components/fork-menu.tsx
+++ b/apps/renderer/src/components/fork-menu.tsx
@@ -1,59 +1,74 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { GitBranchIcon, GitForkIcon } from "@hugeicons-pro/core-solid-rounded";
-import type { MessageId, SessionId } from "@zuse/contracts";
-import { useCallback, useState } from "react";
+import {
+	GitBranchIcon,
+	GitForkIcon,
+	Loading02Icon,
+} from "@hugeicons-pro/core-solid-rounded";
+import type { MessageId, SessionId, Worktree } from "@zuse/contracts";
+import { useState } from "react";
 
-import { useSessionsStore } from "../store/sessions.ts";
-import { Menu, MenuItem, MenuPopup } from "./ui/menu.tsx";
+import { getSessionById, useSessionsStore } from "../store/sessions.ts";
+import { useWorktreesStore } from "../store/worktrees.ts";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu.tsx";
 import { toastManager } from "./ui/toast.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
-type ForkTarget = {
-	anchor: { getBoundingClientRect: () => DOMRect };
-	sourceSessionId: SessionId;
-	fromMessageId: MessageId;
-};
+export function ForkButton({
+	sourceSessionId,
+	fromMessageId,
+}: {
+	readonly sourceSessionId: SessionId;
+	readonly fromMessageId: MessageId;
+}) {
+	const [forking, setForking] = useState(false);
+	const fork = useSessionsStore((state) => state.fork);
 
-/**
- * Right-click "Fork from here" menu. Manages its own anchored popover; the
- * caller wires `openAt` to an `onContextMenu` handler on the message row and
- * renders `menu` once. Both destinations (new tab / new sidebar chat) are
- * offered directly so the user picks in one click.
- */
-export function useForkMenu(): {
-	openAt: (
-		e: React.MouseEvent,
-		sourceSessionId: SessionId,
-		fromMessageId: MessageId,
-	) => void;
-	menu: React.ReactNode;
-} {
-	const [target, setTarget] = useState<ForkTarget | null>(null);
-	const fork = useSessionsStore((s) => s.fork);
+	const run = async (destination: "tab" | "chat") => {
+		if (forking) return;
+		setForking(true);
 
-	const openAt = useCallback<
-		(e: React.MouseEvent, s: SessionId, m: MessageId) => void
-	>((e, sourceSessionId, fromMessageId) => {
-		e.preventDefault();
-		e.stopPropagation();
-		const rect = new DOMRect(e.clientX, e.clientY, 0, 0);
-		setTarget({
-			anchor: { getBoundingClientRect: () => rect },
-			sourceSessionId,
-			fromMessageId,
-		});
-	}, []);
+		let createdWorktree: Worktree | null = null;
+		try {
+			if (destination === "chat") {
+				const source = getSessionById(sourceSessionId);
+				if (source === null) {
+					toastManager.add({
+						title: "Fork failed",
+						description: "The source session is no longer available.",
+						type: "error",
+					});
+					return;
+				}
+				createdWorktree = await useWorktreesStore
+					.getState()
+					.create(source.projectId);
+				if (createdWorktree === null) {
+					toastManager.add({
+						title: "Worktree creation failed",
+						description:
+							useWorktreesStore.getState().error ??
+							"Could not create an isolated worktree for this fork.",
+						type: "error",
+					});
+					return;
+				}
+			}
 
-	const run = useCallback(
-		async (destination: "tab" | "chat") => {
-			if (target === null) return;
-			const { sourceSessionId, fromMessageId } = target;
-			setTarget(null);
 			const result = await fork({
 				sourceSessionId,
 				fromMessageId,
 				destination,
+				worktreeId: createdWorktree?.id,
 			});
 			if (result === null) {
+				if (createdWorktree !== null) {
+					const source = getSessionById(sourceSessionId);
+					if (source !== null) {
+						await useWorktreesStore
+							.getState()
+							.remove(source.projectId, createdWorktree.id);
+					}
+				}
 				toastManager.add({
 					title: "Fork failed",
 					description: "Could not branch this conversation.",
@@ -63,43 +78,76 @@ export function useForkMenu(): {
 			}
 			toastManager.add({
 				title:
-					destination === "tab" ? "Forked to new tab" : "Forked to new chat",
+					destination === "tab"
+						? "Forked in this chat"
+						: "Forked into a new worktree",
 				description:
 					result.forkMode === "resume"
-						? "The branch continues with full agent memory."
-						: "The branch was seeded with the conversation so far.",
+						? "The new branch continues with full agent memory."
+						: "The conversation through this response was copied into the new branch.",
 				type: "success",
 			});
-		},
-		[fork, target],
+		} finally {
+			setForking(false);
+		}
+	};
+
+	return (
+		<Menu>
+			<Tooltip>
+				<TooltipTrigger
+					render={
+						<MenuTrigger
+							disabled={forking}
+							aria-label="Fork from this response"
+							className="inline-grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground/70 outline-none hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.97] data-[popup-open]:bg-muted/50 data-[popup-open]:text-foreground [@media(pointer:coarse)]:size-11"
+						>
+							<HugeiconsIcon
+								icon={forking ? Loading02Icon : GitForkIcon}
+								className={forking ? "size-3.5 animate-spin" : "size-3.5"}
+								aria-hidden="true"
+							/>
+						</MenuTrigger>
+					}
+				/>
+				<TooltipPopup>Fork from this response</TooltipPopup>
+			</Tooltip>
+			<MenuPopup align="start" className="min-w-52 bg-glass border-glass">
+				<Tooltip>
+					<TooltipTrigger
+						render={
+							<MenuItem
+								onClick={() => void run("tab")}
+								className="gap-2.5 px-2 py-1.5"
+							>
+								<HugeiconsIcon icon={GitForkIcon} className="size-4" />
+								<span>Fork in this chat</span>
+							</MenuItem>
+						}
+					/>
+					<TooltipPopup side="right" align="start" className="max-w-64">
+						Open a new session tab that shares this chat and its current
+						worktree.
+					</TooltipPopup>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger
+						render={
+							<MenuItem
+								onClick={() => void run("chat")}
+								className="gap-2.5 px-2 py-1.5"
+							>
+								<HugeiconsIcon icon={GitBranchIcon} className="size-4" />
+								<span>Fork into a new worktree</span>
+							</MenuItem>
+						}
+					/>
+					<TooltipPopup side="right" align="start" className="max-w-64">
+						Create a separate chat in an isolated Git worktree for parallel
+						work.
+					</TooltipPopup>
+				</Tooltip>
+			</MenuPopup>
+		</Menu>
 	);
-
-	const menu =
-		target === null ? null : (
-			<Menu open onOpenChange={(open) => !open && setTarget(null)}>
-				<MenuPopup
-					anchor={target.anchor}
-					align="start"
-					side="bottom"
-					className="min-w-[184px]"
-				>
-					<MenuItem
-						onClick={() => void run("tab")}
-						className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent"
-					>
-						<HugeiconsIcon icon={GitBranchIcon} className="size-3.5" />
-						Fork to new tab
-					</MenuItem>
-					<MenuItem
-						onClick={() => void run("chat")}
-						className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent"
-					>
-						<HugeiconsIcon icon={GitForkIcon} className="size-3.5" />
-						Fork to new chat
-					</MenuItem>
-				</MenuPopup>
-			</Menu>
-		);
-
-	return { openAt, menu };
 }

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -130,8 +130,8 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
 	);
 
 	return (
-		<header className="flex h-10 shrink-0 items-stretch border-b border-border">
-			<div className="flex items-stretch gap-1 px-2">
+		<header className="flex h-10 min-w-0 max-w-full shrink-0 items-stretch overflow-hidden border-b border-border">
+			<div className="flex min-w-0 flex-1 items-stretch gap-1 overflow-x-auto overflow-y-hidden px-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 				{changesTabOpen ? (
 					<FileTabButton
 						active={activeMainTab === "changes"}
@@ -208,7 +208,6 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
 					<NewChatTabButton chatId={activeChatId} />
 				)}
 			</div>
-			<div className="flex-1" />
 		</header>
 	);
 }
@@ -316,7 +315,7 @@ function TabButton({
 			type="button"
 			onClick={onClick}
 			title={title ?? label}
-			className={`relative flex max-w-[280px] items-center gap-2 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
+			className={`relative flex max-w-[280px] shrink-0 items-center gap-2 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
 				active
 					? "text-foreground after:bg-foreground"
 					: "text-muted-foreground hover:text-foreground after:bg-transparent"
@@ -350,7 +349,7 @@ function ChatTabButton({
 }) {
 	return (
 		<div
-			className={`group relative flex max-w-[280px] items-center gap-1.5 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
+			className={`group relative flex max-w-[280px] shrink-0 items-center gap-1.5 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
 				active
 					? "text-foreground after:bg-foreground"
 					: "text-muted-foreground hover:text-foreground after:bg-transparent"
@@ -441,7 +440,7 @@ function NewChatTabButton({
 			disabled={creating}
 			title="New tab in this chat"
 			aria-label="New tab in this chat"
-			className="relative flex items-center justify-center rounded px-2 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+			className="relative flex shrink-0 items-center justify-center rounded px-2 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
 		>
 			{creating ? (
 				<span className="inline-flex size-3.5 items-center justify-center">
@@ -475,7 +474,7 @@ function FileTabButton({
 }) {
 	return (
 		<div
-			className={`group relative flex max-w-[280px] items-center gap-1.5 px-3 text-[12px] leading-none transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
+			className={`group relative flex max-w-[280px] shrink-0 items-center gap-1.5 px-3 text-[12px] leading-none transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
 				active
 					? "text-foreground after:bg-foreground"
 					: "text-muted-foreground hover:text-foreground after:bg-transparent"

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -43,6 +43,7 @@ import {
 import { useProvidersStore } from "~/store/providers";
 import { useUiStore } from "~/store/ui";
 import { useRevealAnnotation } from "./annotation/annotation-navigation.ts";
+import { AssistantMessageActions } from "./assistant-message-actions.tsx";
 import { useChatLookups } from "./chat-lookups.tsx";
 import { CopyButton } from "./copy-button.tsx";
 import { AnnotationFileChip, FileChip } from "./file-chip.tsx";
@@ -176,6 +177,8 @@ function MessageRowImpl({
 				<AssistantBubble
 					text={message.content.text}
 					createdAt={message.createdAt}
+					messageId={message.id}
+					sessionId={readOnly ? undefined : sessionId}
 				/>
 			);
 		case "thinking":
@@ -419,12 +422,6 @@ const stripChipTokens = (
 	return out.replace(/[ \t]{2,}/g, " ").trim();
 };
 
-const formatMessageTime = (date: Date): string =>
-	date.toLocaleTimeString([], {
-		hour: "numeric",
-		minute: "2-digit",
-	});
-
 function UserBubble({
 	text,
 	attachments,
@@ -619,24 +616,25 @@ function UserBubble({
 function AssistantBubble({
 	text,
 	createdAt,
+	messageId,
+	sessionId,
 }: {
 	text: string;
 	createdAt?: Date;
+	messageId: Message["id"];
+	sessionId?: SessionId;
 }) {
 	return (
-		<div className="px-4 py-2">
+		<div className="group/assistant px-4 py-2">
 			<div className="max-w-full">
 				<MarkdownBody>{text}</MarkdownBody>
-				<div className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
-					{createdAt !== undefined ? (
-						<span className="tabular-nums">{formatMessageTime(createdAt)}</span>
-					) : null}
-					<CopyButton
-						text={text}
-						label="Copy message"
-						className="size-5 rounded opacity-70 hover:opacity-100"
-					/>
-				</div>
+				<AssistantMessageActions
+					text={text}
+					createdAt={createdAt}
+					messageId={messageId}
+					sessionId={sessionId}
+					className="mt-1"
+				/>
 			</div>
 		</div>
 	);

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -5,12 +5,12 @@ import {
 	BubbleChatIcon,
 	Wrench01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
-import type { Message } from "@zuse/contracts";
+import type { Message, SessionId } from "@zuse/contracts";
 import { memo, useMemo, useState } from "react";
 import { cn } from "~/lib/utils";
 import { groupMessages } from "../lib/group-messages.ts";
 
-import { CopyButton } from "./copy-button.tsx";
+import { AssistantMessageActions } from "./assistant-message-actions.tsx";
 import { FileBadge } from "./file-badge.tsx";
 import {
 	diffStats,
@@ -86,7 +86,13 @@ const MAX_FILE_CHIPS = 4;
  * shows below; the footer carries elapsed time and file edit stats. No
  * outer card — sections sit flat in the timeline like every other row.
  */
-function TurnSummaryImpl({ body }: { body: ReadonlyArray<Message> }) {
+function TurnSummaryImpl({
+	body,
+	sessionId,
+}: {
+	body: ReadonlyArray<Message>;
+	sessionId?: SessionId;
+}) {
 	const [expanded, setExpanded] = useState(false);
 	const [filesExpanded, setFilesExpanded] = useState(false);
 
@@ -235,9 +241,16 @@ function TurnSummaryImpl({ body }: { body: ReadonlyArray<Message> }) {
 
 			{finalAssistant !== null &&
 			finalAssistant.content._tag === "assistant" ? (
-				<div className="px-4 py-2">
+				<div className="group/assistant px-4 py-2">
 					<div className="max-w-full">
 						<MarkdownBody>{finalAssistant.content.text}</MarkdownBody>
+						<AssistantMessageActions
+							text={finalAssistant.content.text}
+							createdAt={finalAssistant.createdAt}
+							messageId={finalAssistant.id}
+							sessionId={sessionId}
+							className="mt-1"
+						/>
 					</div>
 				</div>
 			) : null}
@@ -249,14 +262,6 @@ function TurnSummaryImpl({ body }: { body: ReadonlyArray<Message> }) {
 				)}
 			>
 				<span className="tabular-nums">{formatElapsed(duration)}</span>
-				{finalAssistant !== null &&
-				finalAssistant.content._tag === "assistant" ? (
-					<CopyButton
-						text={finalAssistant.content.text}
-						label="Copy message"
-						className="size-5 rounded opacity-70 hover:opacity-100"
-					/>
-				) : null}
 				{visibleFileStats.map((f) => (
 					<FileBadge
 						key={f.path}

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -5,6 +5,7 @@ import {
 	Tick01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
 import { PROVIDER_LABEL } from "../lib/provider-labels.ts";
+import { shouldShowSetupCard } from "../lib/setup-card-visibility.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
@@ -83,14 +84,15 @@ export function WorktreeSetupCard() {
 	const providerBooting = session?.status === "booting";
 	const providerErrored = session?.status === "error";
 
-	// Visible while there's worktree/setup work left, OR while the provider CLI
-	// is still booting (covers a worktree-less "new tab in this chat" too).
-	// Once the provider errors we stop occupying the screen with a fake
-	// "Starting…" spinner — the ErrorBubble below carries the failure + the
-	// inline "Sign in" CTA — so a worktree-less errored session hides the card.
-	const visible =
-		!externalResume &&
-		((hasWorktree && !setupDone) || providerBooting === true);
+	// This card belongs to chat/worktree creation. A provider still boots for
+	// every additional session, but that must not replay chat setup UI after the
+	// shared worktree is ready.
+	const visible = shouldShowSetupCard({
+		externalResume,
+		hasWorktree,
+		setupDone,
+		providerBooting: providerBooting === true,
+	});
 	if (!visible) return null;
 
 	const providerLabel: string =

--- a/apps/renderer/src/lib/setup-card-visibility.ts
+++ b/apps/renderer/src/lib/setup-card-visibility.ts
@@ -1,0 +1,13 @@
+export type SetupCardVisibilityInput = {
+	readonly externalResume: boolean;
+	readonly hasWorktree: boolean;
+	readonly setupDone: boolean;
+	readonly providerBooting: boolean;
+};
+
+export const shouldShowSetupCard = ({
+	externalResume,
+	hasWorktree,
+	setupDone,
+}: SetupCardVisibilityInput): boolean =>
+	!externalResume && hasWorktree && !setupDone;

--- a/apps/renderer/test/unit/setup-card-visibility.test.ts
+++ b/apps/renderer/test/unit/setup-card-visibility.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowSetupCard } from "../../src/lib/setup-card-visibility.ts";
+
+describe("shouldShowSetupCard", () => {
+	it("does not show chat setup for an additional session in a ready worktree", () => {
+		expect(
+			shouldShowSetupCard({
+				externalResume: false,
+				hasWorktree: true,
+				setupDone: true,
+				providerBooting: true,
+			}),
+		).toBe(false);
+	});
+
+	it("shows setup while a new chat worktree is not ready", () => {
+		expect(
+			shouldShowSetupCard({
+				externalResume: false,
+				hasWorktree: true,
+				setupDone: false,
+				providerBooting: false,
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/contracts/src/browser.ts
+++ b/packages/contracts/src/browser.ts
@@ -1,7 +1,7 @@
 import { Rpc } from "effect/unstable/rpc";
 import { Schema } from "effect";
 
-import { SessionId } from "./session.ts";
+import { AgentSessionId } from "./ids.ts";
 
 /**
  * In-app agent browser bridge.
@@ -167,7 +167,7 @@ export class BrowserCommandRequest extends Schema.Class<BrowserCommandRequest>(
   "BrowserCommandRequest",
 )({
   id: Schema.String,
-  sessionId: SessionId,
+  sessionId: AgentSessionId,
   command: BrowserCommand,
 }) {}
 


### PR DESCRIPTION
## What changed

- move forking from user messages to explicit assistant-message actions
- show copy, fork, then timestamp on hover
- replace the context-menu flow with a glass fork menu offering same-chat and isolated-worktree destinations
- explain fork destinations through tooltips instead of inline description text
- keep overflowing session tabs contained to a horizontally scrollable tab strip
- stop replaying completed worktree setup UI when an additional session boots
- remove a desktop bundle initialization cycle and add a startup smoke check

## Why

Forking was anchored to the wrong message role and hidden behind a context menu. Long session rows could expand the entire chat pane. The setup card also treated provider startup for every session as chat-level worktree setup, so completed setup output could remain stuck on screen.

The desktop bundle crash came from the browser contract importing the session module only to reuse its ID schema, creating a CommonJS initialization cycle. Importing the canonical ID schema directly removes that cycle.

## Impact

Assistant responses now expose predictable copy and fork controls, fork destinations are clear without clutter, tab overflow stays local to the tab strip, and new sessions inherit their chat worktree without showing setup UI. Desktop builds now fail immediately if their generated main bundle cannot initialize.

## Validation

- renderer unit tests: 170 passed
- contracts tests: 69 passed
- desktop tests: 14 passed
- renderer, contracts, and desktop type checks
- renderer and desktop production builds
- focused Biome checks
- desktop main-bundle startup smoke check