### PR TITLE
Upgrade the in-app agent browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ build
 dist
 dist-electron
 .electron-runtime
+apps/desktop/native/*/bin/
 
 # electron-builder packaged artifacts (root-level dist/) — separately ignored
 # above. Below: re-include the apps/desktop/build/ directory which holds

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -55,6 +55,8 @@ extraResources:
     filter: ["**/*"]
   - from: native/local-connectivity/bin/zuse-local-connectivity
     to: app/local-connectivity/zuse-local-connectivity
+  - from: native/browser-credentials/bin/zuse-browser-credentials
+    to: app/browser-credentials/zuse-browser-credentials
 
 # Native bindings can't load from inside an asar; they need to live as
 # real files on disk. electron-builder writes these to app.asar.unpacked/

--- a/apps/desktop/native/browser-credentials/main.swift
+++ b/apps/desktop/native/browser-credentials/main.swift
@@ -1,0 +1,109 @@
+import AppKit
+import AuthenticationServices
+import Foundation
+import Security
+
+private func emit(_ payload: [String: Any]) {
+  guard let data = try? JSONSerialization.data(withJSONObject: payload) else { exit(70) }
+  FileHandle.standardOutput.write(data)
+}
+
+if CommandLine.arguments.contains("--probe") {
+  var code: SecCode?
+  let copyStatus = SecCodeCopySelf([], &code)
+  let validityStatus = code.map { SecCodeCheckValidity($0, [], nil) } ?? errSecParam
+  emit(["supported": copyStatus == errSecSuccess && validityStatus == errSecSuccess])
+  exit(copyStatus == errSecSuccess && validityStatus == errSecSuccess ? 0 : 1)
+}
+
+guard
+  CommandLine.arguments.count == 2,
+  let requestedURL = URL(string: CommandLine.arguments[1]),
+  let requestedHost = requestedURL.host,
+  ["http", "https"].contains(requestedURL.scheme?.lowercased() ?? "")
+else {
+  emit(["ok": false, "error": "A valid website origin is required."])
+  exit(64)
+}
+
+private final class PasswordAuthorization: NSObject,
+  ASAuthorizationControllerDelegate,
+  ASAuthorizationControllerPresentationContextProviding {
+  private let window: NSWindow
+  private let requestedHost: String
+
+  init(requestedHost: String) {
+    self.requestedHost = requestedHost
+    window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 1, height: 1),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    window.level = .floating
+    window.isOpaque = false
+    window.backgroundColor = .clear
+    super.init()
+  }
+
+  func start() {
+    NSApp.setActivationPolicy(.accessory)
+    NSApp.activate(ignoringOtherApps: true)
+    window.center()
+    window.makeKeyAndOrderFront(nil)
+    let request = ASAuthorizationPasswordProvider().createRequest()
+    let controller = ASAuthorizationController(authorizationRequests: [request])
+    controller.delegate = self
+    controller.presentationContextProvider = self
+    controller.performRequests()
+  }
+
+  func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    window
+  }
+
+  func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithAuthorization authorization: ASAuthorization
+  ) {
+    guard let credential = authorization.credential as? ASPasswordCredential else {
+      emit(["ok": false, "error": "The system did not return a password credential."])
+      NSApp.terminate(nil)
+      return
+    }
+    let confirmation = NSAlert()
+    confirmation.messageText = "Fill password for \(requestedHost)?"
+    confirmation.informativeText =
+      "The selected account is \(credential.user). Continue only if it belongs to this website."
+    confirmation.alertStyle = .informational
+    confirmation.addButton(withTitle: "Fill Password")
+    confirmation.addButton(withTitle: "Cancel")
+    guard confirmation.runModal() == .alertFirstButtonReturn else {
+      emit(["ok": false, "cancelled": true, "error": "Password filling was cancelled."])
+      NSApp.terminate(nil)
+      return
+    }
+    emit(["ok": true, "username": credential.user, "password": credential.password])
+    NSApp.terminate(nil)
+  }
+
+  func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithError error: Error
+  ) {
+    let authorizationError = error as? ASAuthorizationError
+    let cancelled = authorizationError?.code == .canceled
+    emit([
+      "ok": false,
+      "cancelled": cancelled,
+      "error": cancelled ? "Password selection was cancelled." : error.localizedDescription,
+    ])
+    NSApp.terminate(nil)
+  }
+}
+
+private let app = NSApplication.shared
+private let authorization = PasswordAuthorization(requestedHost: requestedHost)
+app.delegate = nil
+DispatchQueue.main.async { authorization.start() }
+app.run()

--- a/apps/desktop/scripts/build-local-connectivity-helper.mjs
+++ b/apps/desktop/scripts/build-local-connectivity-helper.mjs
@@ -4,19 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const desktopRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const source = join(desktopRoot, "native", "local-connectivity", "main.swift");
-const outputDirectory = join(
-	desktopRoot,
-	"native",
-	"local-connectivity",
-	"bin",
-);
-const output = join(outputDirectory, "zuse-local-connectivity");
-mkdirSync(outputDirectory, { recursive: true });
-const moduleCache = join(outputDirectory, "module-cache");
-mkdirSync(moduleCache, { recursive: true });
-
-const run = (command, args) => {
+const run = (command, args, moduleCache) => {
 	const result = spawnSync(command, args, {
 		stdio: "inherit",
 		env: {
@@ -28,28 +16,36 @@ const run = (command, args) => {
 	if (result.status !== 0) process.exit(result.status ?? 1);
 };
 
-if (process.argv.includes("--universal")) {
-	const arm = `${output}.arm64`;
-	const intel = `${output}.x86_64`;
-	run("xcrun", [
-		"swiftc",
-		"-O",
-		"-target",
-		"arm64-apple-macos13",
-		source,
-		"-o",
-		arm,
-	]);
-	run("xcrun", [
-		"swiftc",
-		"-O",
-		"-target",
-		"x86_64-apple-macos13",
-		source,
-		"-o",
-		intel,
-	]);
-	run("xcrun", ["lipo", "-create", arm, intel, "-output", output]);
-} else {
-	run("xcrun", ["swiftc", source, "-o", output]);
-}
+const buildHelper = (directory, executable) => {
+	const source = join(desktopRoot, "native", directory, "main.swift");
+	const outputDirectory = join(desktopRoot, "native", directory, "bin");
+	const output = join(outputDirectory, executable);
+	mkdirSync(outputDirectory, { recursive: true });
+	const moduleCache = join(outputDirectory, "module-cache");
+	mkdirSync(moduleCache, { recursive: true });
+
+	if (process.argv.includes("--universal")) {
+		const arm = `${output}.arm64`;
+		const intel = `${output}.x86_64`;
+		for (const [target, targetOutput] of [
+			["arm64-apple-macos13", arm],
+			["x86_64-apple-macos13", intel],
+		]) {
+			run(
+				"xcrun",
+				["swiftc", "-O", "-target", target, source, "-o", targetOutput],
+				moduleCache,
+			);
+		}
+		run(
+			"xcrun",
+			["lipo", "-create", arm, intel, "-output", output],
+			moduleCache,
+		);
+	} else {
+		run("xcrun", ["swiftc", source, "-o", output], moduleCache);
+	}
+};
+
+buildHelper("local-connectivity", "zuse-local-connectivity");
+buildHelper("browser-credentials", "zuse-browser-credentials");

--- a/apps/desktop/src/browser-session-service.ts
+++ b/apps/desktop/src/browser-session-service.ts
@@ -1,0 +1,472 @@
+import { execFile } from "node:child_process";
+import { createDecipheriv, createHash, pbkdf2Sync } from "node:crypto";
+import * as fs from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import * as Path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { promisify } from "node:util";
+import type { Session } from "electron";
+import keytar from "keytar";
+
+const execFileAsync = promisify(execFile);
+const PARTITION = "persist:zuse-browser";
+const COOKIE_EPOCH_OFFSET_SECONDS = 11_644_473_600;
+
+type ImportedCookieIdentity = {
+	domain: string;
+	path: string;
+	name: string;
+	secure?: boolean;
+	valueHash?: string;
+};
+
+type ImportState = {
+	version: 1;
+	migratedExistingSession: boolean;
+	lastImportTime?: string;
+	source?: string;
+	profile?: string;
+	identities: ImportedCookieIdentity[];
+};
+
+export interface BrowserCookieImportStatus {
+	readonly supported: boolean;
+	readonly source?: string;
+	readonly profile?: string;
+	readonly lastImportTime?: string;
+	readonly importedDomainCount: number;
+	readonly importedCookieCount: number;
+	readonly importedDomains: ReadonlyArray<string>;
+	readonly message?: string;
+}
+
+const statePath = (userData: string) =>
+	Path.join(userData, "browser-cookie-import.json");
+
+const readState = async (userData: string): Promise<ImportState> => {
+	try {
+		const parsed = JSON.parse(
+			await fs.readFile(statePath(userData), "utf8"),
+		) as Partial<ImportState>;
+		return {
+			version: 1,
+			migratedExistingSession: parsed.migratedExistingSession === true,
+			...(typeof parsed.lastImportTime === "string"
+				? { lastImportTime: parsed.lastImportTime }
+				: {}),
+			...(typeof parsed.source === "string" ? { source: parsed.source } : {}),
+			...(typeof parsed.profile === "string"
+				? { profile: parsed.profile }
+				: {}),
+			identities: Array.isArray(parsed.identities)
+				? parsed.identities.filter(isIdentity)
+				: [],
+		};
+	} catch {
+		return { version: 1, migratedExistingSession: false, identities: [] };
+	}
+};
+
+const isIdentity = (value: unknown): value is ImportedCookieIdentity => {
+	if (value === null || typeof value !== "object") return false;
+	const item = value as Partial<ImportedCookieIdentity>;
+	return (
+		typeof item.domain === "string" &&
+		typeof item.path === "string" &&
+		typeof item.name === "string" &&
+		(item.secure === undefined || typeof item.secure === "boolean") &&
+		(item.valueHash === undefined || typeof item.valueHash === "string")
+	);
+};
+
+const writeState = async (
+	userData: string,
+	state: ImportState,
+): Promise<void> => {
+	await fs.writeFile(statePath(userData), JSON.stringify(state, null, 2), {
+		mode: 0o600,
+	});
+};
+
+export const migrateExistingBrowserCookies = async (
+	userData: string,
+	legacy: Session,
+	persistent: Session,
+): Promise<void> => {
+	const state = await readState(userData);
+	if (state.migratedExistingSession) return;
+	for (const cookie of await legacy.cookies.get({})) {
+		if (cookie.domain === undefined) continue;
+		try {
+			await persistent.cookies.set({
+				url: `${cookie.secure ? "https" : "http"}://${cookie.domain.replace(/^\./, "")}${cookie.path}`,
+				name: cookie.name,
+				value: cookie.value,
+				domain: cookie.domain,
+				path: cookie.path,
+				secure: cookie.secure,
+				httpOnly: cookie.httpOnly,
+				...(cookie.expirationDate === undefined
+					? {}
+					: { expirationDate: cookie.expirationDate }),
+				...(cookie.sameSite === "unspecified"
+					? {}
+					: { sameSite: cookie.sameSite }),
+			});
+		} catch {
+			// Individual invalid or internal cookies must not abort first-use migration.
+		}
+	}
+	await writeState(userData, { ...state, migratedExistingSession: true });
+};
+
+const defaultHandlerBundle = async (): Promise<string | null> => {
+	if (process.platform !== "darwin") return null;
+	try {
+		const { stdout } = await execFileAsync("defaults", [
+			"read",
+			"com.apple.LaunchServices/com.apple.launchservices.secure",
+			"LSHandlers",
+		]);
+		const blocks = stdout.split("},");
+		for (const block of blocks) {
+			if (!/LSHandlerURLScheme\s*=\s*https/i.test(block)) continue;
+			const match = block.match(/LSHandlerRoleAll\s*=\s*"?([^";\s]+)"?/i);
+			if (match?.[1]) return match[1];
+		}
+		return null;
+	} catch {
+		return null;
+	}
+};
+
+const findApplication = async (bundleId: string): Promise<string | null> => {
+	try {
+		const { stdout } = await execFileAsync("mdfind", [
+			`kMDItemCFBundleIdentifier == '${bundleId}'`,
+		]);
+		return stdout.split("\n").find((line) => line.endsWith(".app")) ?? null;
+	} catch {
+		return null;
+	}
+};
+
+const normalized = (value: string) =>
+	value.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+const findProfileRoot = async (sourceName: string): Promise<string | null> => {
+	const support = Path.join(homedir(), "Library", "Application Support");
+	const wanted = normalized(sourceName);
+	const found: Array<{ path: string; score: number }> = [];
+	const walk = async (directory: string, depth: number): Promise<void> => {
+		if (depth > 2) return;
+		let entries: Array<{
+			name: string;
+			isFile(): boolean;
+			isDirectory(): boolean;
+		}>;
+		try {
+			entries = await fs.readdir(directory, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		if (
+			entries.some((entry) => entry.isFile() && entry.name === "Local State")
+		) {
+			const base = normalized(Path.basename(directory));
+			found.push({
+				path: directory,
+				score: wanted.includes(base) || base.includes(wanted) ? 10 : 1,
+			});
+			return;
+		}
+		await Promise.all(
+			entries
+				.filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+				.map((entry) => walk(Path.join(directory, entry.name), depth + 1)),
+		);
+	};
+	await walk(support, 0);
+	return found.sort((a, b) => b.score - a.score)[0]?.path ?? null;
+};
+
+type DetectedProfile = {
+	source: string;
+	profile: string;
+	root: string;
+	cookieDb: string;
+};
+
+const detectProfile = async (): Promise<DetectedProfile | null> => {
+	const bundleId = await defaultHandlerBundle();
+	if (bundleId === null) return null;
+	const application = await findApplication(bundleId);
+	const source =
+		application === null ? bundleId : Path.basename(application, ".app");
+	const root = await findProfileRoot(source);
+	if (root === null) return null;
+	let profile = "Default";
+	try {
+		const localState = JSON.parse(
+			await fs.readFile(Path.join(root, "Local State"), "utf8"),
+		) as { profile?: { last_used?: unknown } };
+		if (typeof localState.profile?.last_used === "string")
+			profile = localState.profile.last_used;
+	} catch {
+		// Default is the conventional first profile.
+	}
+	for (const candidate of [
+		Path.join(root, profile, "Network", "Cookies"),
+		Path.join(root, profile, "Cookies"),
+	]) {
+		try {
+			await fs.access(candidate);
+			return { source, profile, root, cookieDb: candidate };
+		} catch {
+			// Try the next layout.
+		}
+	}
+	return null;
+};
+
+const decryptCookie = (
+	encrypted: Uint8Array,
+	key: Buffer,
+	host: string,
+): string | null => {
+	if (encrypted.length < 4) return null;
+	const prefix = Buffer.from(encrypted.subarray(0, 3)).toString("ascii");
+	if (prefix !== "v10" && prefix !== "v11") return null;
+	try {
+		const decipher = createDecipheriv(
+			"aes-128-cbc",
+			key,
+			Buffer.alloc(16, " "),
+		);
+		let plain = Buffer.concat([
+			decipher.update(encrypted.subarray(3)),
+			decipher.final(),
+		]);
+		const hostDigest = createHash("sha256").update(host).digest();
+		if (plain.length > 32 && plain.subarray(0, 32).equals(hostDigest))
+			plain = plain.subarray(32);
+		return plain.toString("utf8");
+	} catch {
+		return null;
+	}
+};
+
+const safeStorageServiceCandidates = (source: string): string[] => {
+	const words = source.trim().split(/\s+/).filter(Boolean);
+	const withoutGenericSuffix =
+		words.at(-1)?.toLowerCase() === "browser" ? words.slice(0, -1) : words;
+	return [
+		source,
+		withoutGenericSuffix.join(" "),
+		words[0] ?? "",
+		words.at(-1) ?? "",
+	]
+		.filter(
+			(value, index, values) =>
+				value.length > 0 && values.indexOf(value) === index,
+		)
+		.map((value) => `${value} Safe Storage`);
+};
+
+const readSafeStoragePassword = async (
+	source: string,
+): Promise<string | null> => {
+	for (const service of safeStorageServiceCandidates(source)) {
+		const entries = await keytar.findCredentials(service).catch(() => []);
+		const password = entries[0]?.password;
+		if (password !== undefined) return password;
+	}
+	return null;
+};
+
+const removeImportedIdentity = async (
+	target: Session,
+	identity: ImportedCookieIdentity,
+): Promise<void> => {
+	const scheme = identity.secure === false ? "http" : "https";
+	const url = `${scheme}://${identity.domain.replace(/^\./, "")}${identity.path}`;
+	if (identity.valueHash === undefined) return;
+	const current = await target.cookies.get({ url, name: identity.name });
+	const stillImported = current.some(
+		(cookie) =>
+			(cookie.domain ?? "").replace(/^\./, "") ===
+				identity.domain.replace(/^\./, "") &&
+			cookie.path === identity.path &&
+			createHash("sha256").update(cookie.value).digest("hex") ===
+				identity.valueHash,
+	);
+	if (!stillImported) return;
+	await target.cookies.remove(url, identity.name).catch(() => {});
+};
+
+export const getBrowserCookieImportStatus = async (
+	userData: string,
+): Promise<BrowserCookieImportStatus> => {
+	const state = await readState(userData);
+	const detected = await detectProfile();
+	return {
+		supported: detected !== null,
+		...(detected === null
+			? {}
+			: { source: detected.source, profile: detected.profile }),
+		...(state.lastImportTime === undefined
+			? {}
+			: { lastImportTime: state.lastImportTime }),
+		importedDomainCount: new Set(
+			state.identities.map((item) => item.domain.replace(/^\./, "")),
+		).size,
+		importedCookieCount: state.identities.length,
+		importedDomains: [
+			...new Set(
+				state.identities.map((item) => item.domain.replace(/^\./, "")),
+			),
+		].sort(),
+		...(detected === null
+			? {
+					message:
+						"The default browser profile is unavailable or uses an unsupported cookie store.",
+				}
+			: {}),
+	};
+};
+
+export const importDefaultBrowserCookies = async (
+	userData: string,
+	target: Session,
+): Promise<BrowserCookieImportStatus> => {
+	const detected = await detectProfile();
+	if (detected === null)
+		throw new Error(
+			"The default browser cookie profile is unavailable or unsupported.",
+		);
+	const password = await readSafeStoragePassword(detected.source);
+	const key =
+		password === null
+			? null
+			: pbkdf2Sync(password, "saltysalt", 1003, 16, "sha1");
+	const temporary = await fs.mkdtemp(
+		Path.join(tmpdir(), "zuse-browser-import-"),
+	);
+	const snapshot = Path.join(temporary, "Cookies");
+	try {
+		await fs.copyFile(detected.cookieDb, snapshot);
+		for (const suffix of ["-wal", "-shm"]) {
+			try {
+				await fs.copyFile(
+					`${detected.cookieDb}${suffix}`,
+					`${snapshot}${suffix}`,
+				);
+			} catch {
+				/* optional SQLite sidecar */
+			}
+		}
+		const db = new DatabaseSync(snapshot, { readOnly: true });
+		let rows: Array<Record<string, unknown>>;
+		try {
+			rows = db
+				.prepare(
+					"SELECT host_key, name, value, encrypted_value, path, expires_utc, is_secure, is_httponly, samesite FROM cookies",
+				)
+				.all() as Array<Record<string, unknown>>;
+		} finally {
+			db.close();
+		}
+		const previousState = await readState(userData);
+		await Promise.all(
+			previousState.identities.map((identity) =>
+				removeImportedIdentity(target, identity),
+			),
+		);
+		const now = Date.now() / 1000;
+		const identities: ImportedCookieIdentity[] = [];
+		for (const row of rows) {
+			const domain = String(row.host_key ?? "");
+			const name = String(row.name ?? "");
+			const path = String(row.path ?? "/");
+			if (domain.length === 0 || name.length === 0) continue;
+			const rawExpiry = Number(row.expires_utc ?? 0);
+			const expirationDate =
+				rawExpiry > 0
+					? rawExpiry / 1_000_000 - COOKIE_EPOCH_OFFSET_SECONDS
+					: undefined;
+			if (expirationDate !== undefined && expirationDate <= now) continue;
+			let value = String(row.value ?? "");
+			const encrypted = row.encrypted_value;
+			if (value.length === 0 && encrypted instanceof Uint8Array && key !== null)
+				value = decryptCookie(encrypted, key, domain) ?? "";
+			if (value.length === 0) continue;
+			try {
+				const secure = Number(row.is_secure) === 1;
+				const sameSite = Number(row.samesite);
+				await target.cookies.set({
+					url: `${secure ? "https" : "http"}://${domain.replace(/^\./, "")}${path}`,
+					name,
+					value,
+					domain,
+					path,
+					secure,
+					httpOnly: Number(row.is_httponly) === 1,
+					...(expirationDate === undefined ? {} : { expirationDate }),
+					...(sameSite < 0
+						? {}
+						: {
+								sameSite:
+									sameSite === 2
+										? "strict"
+										: sameSite === 1
+											? "lax"
+											: "no_restriction",
+							}),
+				});
+				identities.push({
+					domain,
+					path,
+					name,
+					secure,
+					valueHash: createHash("sha256").update(value).digest("hex"),
+				});
+			} catch {
+				// Skip invalid individual records while preserving the rest of the import.
+			}
+		}
+		const state = await readState(userData);
+		await writeState(userData, {
+			...state,
+			lastImportTime: new Date().toISOString(),
+			source: detected.source,
+			profile: detected.profile,
+			identities,
+		});
+		return getBrowserCookieImportStatus(userData);
+	} finally {
+		await fs.rm(temporary, { recursive: true, force: true });
+	}
+};
+
+export const clearImportedBrowserCookies = async (
+	userData: string,
+	target: Session,
+): Promise<BrowserCookieImportStatus> => {
+	const state = await readState(userData);
+	for (const item of state.identities) {
+		await removeImportedIdentity(target, item);
+	}
+	await writeState(userData, {
+		version: 1,
+		migratedExistingSession: state.migratedExistingSession,
+		identities: [],
+	});
+	return getBrowserCookieImportStatus(userData);
+};
+
+export const BROWSER_PARTITION = PARTITION;
+
+export const browserCookieImportInternals = {
+	decryptCookie,
+	safeStorageServiceCandidates,
+};

--- a/apps/desktop/src/browser-session-service.ts
+++ b/apps/desktop/src/browser-session-service.ts
@@ -23,14 +23,24 @@ type ImportedCookieIdentity = {
 type ImportState = {
 	version: 1;
 	migratedExistingSession: boolean;
+	selectedProfileId?: string;
 	lastImportTime?: string;
 	source?: string;
 	profile?: string;
 	identities: ImportedCookieIdentity[];
 };
 
+export interface BrowserCookieImportProfile {
+	readonly id: string;
+	readonly source: string;
+	readonly profile: string;
+	readonly isDefault: boolean;
+}
+
 export interface BrowserCookieImportStatus {
 	readonly supported: boolean;
+	readonly selectedProfileId?: string;
+	readonly availableProfiles: ReadonlyArray<BrowserCookieImportProfile>;
 	readonly source?: string;
 	readonly profile?: string;
 	readonly lastImportTime?: string;
@@ -51,6 +61,9 @@ const readState = async (userData: string): Promise<ImportState> => {
 		return {
 			version: 1,
 			migratedExistingSession: parsed.migratedExistingSession === true,
+			...(typeof parsed.selectedProfileId === "string"
+				? { selectedProfileId: parsed.selectedProfileId }
+				: {}),
 			...(typeof parsed.lastImportTime === "string"
 				? { lastImportTime: parsed.lastImportTime }
 				: {}),
@@ -176,11 +189,9 @@ const findApplication = async (bundleId: string): Promise<string | null> => {
 const normalized = (value: string) =>
 	value.toLowerCase().replace(/[^a-z0-9]/g, "");
 
-const findProfileRoot = async (sourceName: string): Promise<string | null> => {
+const findProfileRoots = async (): Promise<ReadonlyArray<string>> => {
 	const support = Path.join(homedir(), "Library", "Application Support");
-	const wanted = normalized(sourceName);
-	if (wanted.length === 0) return null;
-	const found: Array<{ path: string; score: number }> = [];
+	const found: string[] = [];
 	const walk = async (directory: string, depth: number): Promise<void> => {
 		if (depth > 2) return;
 		let entries: Array<{
@@ -196,11 +207,7 @@ const findProfileRoot = async (sourceName: string): Promise<string | null> => {
 		if (
 			entries.some((entry) => entry.isFile() && entry.name === "Local State")
 		) {
-			const base = normalized(Path.basename(directory));
-			found.push({
-				path: directory,
-				score: wanted.includes(base) || base.includes(wanted) ? 10 : 1,
-			});
+			found.push(directory);
 			return;
 		}
 		await Promise.all(
@@ -210,18 +217,183 @@ const findProfileRoot = async (sourceName: string): Promise<string | null> => {
 		);
 	};
 	await walk(support, 0);
-	const best = found.sort((a, b) => b.score - a.score)[0];
+	return found.sort();
+};
+
+const findProfileRoot = async (sourceName: string): Promise<string | null> => {
+	const wanted = normalized(sourceName);
+	if (wanted.length === 0) return null;
+	const scored = (await findProfileRoots()).map((path) => {
+		const base = normalized(Path.basename(path));
+		return {
+			path,
+			score: wanted.includes(base) || base.includes(wanted) ? 10 : 1,
+		};
+	});
+	const best = scored.sort((a, b) => b.score - a.score)[0];
 	return best?.score === 10 ? best.path : null;
 };
 
 type DetectedProfile = {
+	id: string;
 	source: string;
 	profile: string;
+	profileDirectory: string;
 	root: string;
 	cookieDb: string;
 };
 
-const detectProfile = async (): Promise<DetectedProfile | null> => {
+const sourceNameForRoot = (root: string): string => {
+	const rootName = Path.basename(root);
+	return (
+		rootName === "User Data" ? Path.basename(Path.dirname(root)) : rootName
+	)
+		.replaceAll("-", " ")
+		.trim();
+};
+
+const installedBrowserSources = async (
+	sources: ReadonlySet<string>,
+): Promise<ReadonlySet<string>> => {
+	const applications: Array<{ name: string; path: string }> = [];
+	for (const directory of [
+		"/Applications",
+		Path.join(homedir(), "Applications"),
+	]) {
+		try {
+			for (const entry of await fs.readdir(directory, {
+				withFileTypes: true,
+			})) {
+				if (!entry.isDirectory() || !entry.name.endsWith(".app")) continue;
+				const name = Path.basename(entry.name, ".app");
+				const normalizedName = normalized(name);
+				if (
+					![...sources].some((source) => {
+						const normalizedSource = normalized(source);
+						return (
+							normalizedName.includes(normalizedSource) ||
+							normalizedSource.includes(normalizedName)
+						);
+					})
+				)
+					continue;
+				applications.push({ name, path: Path.join(directory, entry.name) });
+			}
+		} catch {
+			// An optional application directory may not exist or be readable.
+		}
+	}
+	const browserNames = new Set<string>();
+	await Promise.all(
+		applications.map(async (application) => {
+			try {
+				const { stdout } = await execFileAsync("plutil", [
+					"-extract",
+					"CFBundleURLTypes",
+					"json",
+					"-o",
+					"-",
+					Path.join(application.path, "Contents", "Info.plist"),
+				]);
+				const urlTypes = JSON.parse(stdout) as Array<{
+					CFBundleURLSchemes?: unknown;
+				}>;
+				const handlesWebUrls = urlTypes.some(
+					(type) =>
+						Array.isArray(type.CFBundleURLSchemes) &&
+						type.CFBundleURLSchemes.some(
+							(scheme) => scheme === "http" || scheme === "https",
+						),
+				);
+				if (handlesWebUrls) browserNames.add(normalized(application.name));
+			} catch {
+				// Applications without declared web URL schemes are not browsers.
+			}
+		}),
+	);
+	return new Set(
+		[...sources].filter((source) => {
+			const normalizedSource = normalized(source);
+			return [...browserNames].some(
+				(name) =>
+					name.includes(normalizedSource) || normalizedSource.includes(name),
+			);
+		}),
+	);
+};
+
+const profileId = (root: string, profile: string): string =>
+	createHash("sha256").update(`${root}\0${profile}`).digest("hex").slice(0, 20);
+
+const findCookieDb = async (
+	root: string,
+	profile: string,
+): Promise<string | null> => {
+	for (const candidate of [
+		Path.join(root, profile, "Network", "Cookies"),
+		Path.join(root, profile, "Cookies"),
+	]) {
+		try {
+			await fs.access(candidate);
+			return candidate;
+		} catch {
+			// Try the next Chromium cookie database layout.
+		}
+	}
+	return null;
+};
+
+const profilesForRoot = async (
+	root: string,
+	source = sourceNameForRoot(root),
+): Promise<DetectedProfile[]> => {
+	let localState: {
+		profile?: {
+			last_used?: unknown;
+			info_cache?: Record<string, unknown>;
+		};
+	};
+	try {
+		localState = JSON.parse(
+			await fs.readFile(Path.join(root, "Local State"), "utf8"),
+		) as typeof localState;
+	} catch {
+		return [];
+	}
+	const lastUsed =
+		typeof localState.profile?.last_used === "string"
+			? localState.profile.last_used
+			: "Default";
+	const names = [
+		lastUsed,
+		...Object.keys(localState.profile?.info_cache ?? {}).filter(
+			(name) => name !== lastUsed,
+		),
+	];
+	const profiles: DetectedProfile[] = [];
+	for (const profileDirectory of names) {
+		const cookieDb = await findCookieDb(root, profileDirectory);
+		if (cookieDb === null) continue;
+		const metadata = localState.profile?.info_cache?.[profileDirectory] as
+			| { name?: unknown }
+			| undefined;
+		const profile =
+			typeof metadata?.name === "string" && metadata.name.trim().length > 0
+				? metadata.name.trim()
+				: profileDirectory;
+		profiles.push({
+			id: profileId(root, profileDirectory),
+			source,
+			profile,
+			profileDirectory,
+			root,
+			cookieDb,
+		});
+	}
+	return profiles;
+};
+
+const detectDefaultProfile = async (): Promise<DetectedProfile | null> => {
 	const bundleId = await defaultHandlerBundle();
 	if (bundleId === null) return null;
 	const application = await findApplication(bundleId);
@@ -229,36 +401,39 @@ const detectProfile = async (): Promise<DetectedProfile | null> => {
 		application === null ? bundleId : Path.basename(application, ".app");
 	const root = await findProfileRoot(sourceHint);
 	if (root === null) return null;
-	const rootName = Path.basename(root);
-	const source =
-		application === null
-			? (rootName === "User Data"
-					? Path.basename(Path.dirname(root))
-					: rootName
-				).replaceAll("-", " ")
-			: sourceHint;
-	let profile = "Default";
-	try {
-		const localState = JSON.parse(
-			await fs.readFile(Path.join(root, "Local State"), "utf8"),
-		) as { profile?: { last_used?: unknown } };
-		if (typeof localState.profile?.last_used === "string")
-			profile = localState.profile.last_used;
-	} catch {
-		// Default is the conventional first profile.
-	}
-	for (const candidate of [
-		Path.join(root, profile, "Network", "Cookies"),
-		Path.join(root, profile, "Cookies"),
-	]) {
-		try {
-			await fs.access(candidate);
-			return { source, profile, root, cookieDb: candidate };
-		} catch {
-			// Try the next layout.
-		}
-	}
-	return null;
+	const source = application === null ? sourceNameForRoot(root) : sourceHint;
+	return (await profilesForRoot(root, source))[0] ?? null;
+};
+
+const detectProfiles = async (): Promise<{
+	defaultProfile: DetectedProfile | null;
+	profiles: DetectedProfile[];
+}> => {
+	const [defaultProfile, roots] = await Promise.all([
+		detectDefaultProfile(),
+		findProfileRoots(),
+	]);
+	const allDiscovered = (
+		await Promise.all(roots.map((root) => profilesForRoot(root)))
+	)
+		.flat()
+		.filter((profile) => profile.source.length > 0);
+	const installedSources = await installedBrowserSources(
+		new Set(allDiscovered.map((profile) => profile.source)),
+	);
+	const discovered = allDiscovered.filter((profile) =>
+		installedSources.has(profile.source),
+	);
+	const byId = new Map(discovered.map((profile) => [profile.id, profile]));
+	if (defaultProfile !== null) byId.set(defaultProfile.id, defaultProfile);
+	const profiles = [...byId.values()].sort((a, b) => {
+		if (a.id === defaultProfile?.id) return -1;
+		if (b.id === defaultProfile?.id) return 1;
+		return `${a.source}\0${a.profile}`.localeCompare(
+			`${b.source}\0${b.profile}`,
+		);
+	});
+	return { defaultProfile, profiles };
 };
 
 const decryptCookie = (
@@ -316,6 +491,14 @@ const readSafeStoragePassword = async (
 	return null;
 };
 
+const readCookieRows = (db: DatabaseSync): Array<Record<string, unknown>> => {
+	const statement = db.prepare(
+		"SELECT host_key, name, value, encrypted_value, path, expires_utc, is_secure, is_httponly, samesite FROM cookies",
+	);
+	statement.setReadBigInts(true);
+	return statement.all() as Array<Record<string, unknown>>;
+};
+
 const removeImportedIdentity = async (
 	target: Session,
 	identity: ImportedCookieIdentity,
@@ -340,12 +523,27 @@ export const getBrowserCookieImportStatus = async (
 	userData: string,
 ): Promise<BrowserCookieImportStatus> => {
 	const state = await readState(userData);
-	const detected = await detectProfile();
+	const { defaultProfile, profiles } = await detectProfiles();
+	const detected =
+		profiles.find((profile) => profile.id === state.selectedProfileId) ??
+		defaultProfile ??
+		profiles[0] ??
+		null;
 	return {
-		supported: detected !== null,
+		supported: profiles.length > 0,
+		availableProfiles: profiles.map((profile) => ({
+			id: profile.id,
+			source: profile.source,
+			profile: profile.profile,
+			isDefault: profile.id === defaultProfile?.id,
+		})),
 		...(detected === null
 			? {}
-			: { source: detected.source, profile: detected.profile }),
+			: {
+					selectedProfileId: detected.id,
+					source: detected.source,
+					profile: detected.profile,
+				}),
 		...(state.lastImportTime === undefined
 			? {}
 			: { lastImportTime: state.lastImportTime }),
@@ -370,8 +568,13 @@ export const getBrowserCookieImportStatus = async (
 export const importDefaultBrowserCookies = async (
 	userData: string,
 	target: Session,
+	selectedProfileId?: string,
 ): Promise<BrowserCookieImportStatus> => {
-	const detected = await detectProfile();
+	const { defaultProfile, profiles } = await detectProfiles();
+	const detected =
+		(selectedProfileId === undefined
+			? defaultProfile
+			: profiles.find((profile) => profile.id === selectedProfileId)) ?? null;
 	if (detected === null)
 		throw new Error(
 			"The default browser cookie profile is unavailable or unsupported.",
@@ -400,11 +603,7 @@ export const importDefaultBrowserCookies = async (
 		const db = new DatabaseSync(snapshot, { readOnly: true });
 		let rows: Array<Record<string, unknown>>;
 		try {
-			rows = db
-				.prepare(
-					"SELECT host_key, name, value, encrypted_value, path, expires_utc, is_secure, is_httponly, samesite FROM cookies",
-				)
-				.all() as Array<Record<string, unknown>>;
+			rows = readCookieRows(db);
 		} finally {
 			db.close();
 		}
@@ -469,6 +668,7 @@ export const importDefaultBrowserCookies = async (
 		const state = await readState(userData);
 		await writeState(userData, {
 			...state,
+			selectedProfileId: detected.id,
 			lastImportTime: new Date().toISOString(),
 			source: detected.source,
 			profile: detected.profile,
@@ -491,6 +691,9 @@ export const clearImportedBrowserCookies = async (
 	await writeState(userData, {
 		version: 1,
 		migratedExistingSession: state.migratedExistingSession,
+		...(state.selectedProfileId === undefined
+			? {}
+			: { selectedProfileId: state.selectedProfileId }),
 		identities: [],
 	});
 	return getBrowserCookieImportStatus(userData);
@@ -501,5 +704,6 @@ export const BROWSER_PARTITION = PARTITION;
 export const browserCookieImportInternals = {
 	decryptCookie,
 	parseDefaultHandlerBundle,
+	readCookieRows,
 	safeStorageServiceCandidates,
 };

--- a/apps/desktop/src/browser-session-service.ts
+++ b/apps/desktop/src/browser-session-service.ts
@@ -120,6 +120,34 @@ export const migrateExistingBrowserCookies = async (
 	await writeState(userData, { ...state, migratedExistingSession: true });
 };
 
+const parseDefaultHandlerBundle = (stdout: string): string | null => {
+	let depth = 0;
+	let role: string | null = null;
+	let scheme: string | null = null;
+	for (const line of stdout.split("\n")) {
+		const trimmed = line.trim();
+		if (depth === 1) {
+			const roleMatch = trimmed.match(
+				/^LSHandlerRoleAll\s*=\s*"?([^";\s]+)"?;$/i,
+			);
+			if (roleMatch?.[1]) role = roleMatch[1];
+			const schemeMatch = trimmed.match(
+				/^LSHandlerURLScheme\s*=\s*"?([^";\s]+)"?;$/i,
+			);
+			if (schemeMatch?.[1]) scheme = schemeMatch[1];
+		}
+		depth += (trimmed.match(/\{/g) ?? []).length;
+		depth -= (trimmed.match(/\}/g) ?? []).length;
+		if (depth === 0) {
+			if (scheme?.toLowerCase() === "https" && role !== null && role !== "-")
+				return role;
+			role = null;
+			scheme = null;
+		}
+	}
+	return null;
+};
+
 const defaultHandlerBundle = async (): Promise<string | null> => {
 	if (process.platform !== "darwin") return null;
 	try {
@@ -128,13 +156,7 @@ const defaultHandlerBundle = async (): Promise<string | null> => {
 			"com.apple.LaunchServices/com.apple.launchservices.secure",
 			"LSHandlers",
 		]);
-		const blocks = stdout.split("},");
-		for (const block of blocks) {
-			if (!/LSHandlerURLScheme\s*=\s*https/i.test(block)) continue;
-			const match = block.match(/LSHandlerRoleAll\s*=\s*"?([^";\s]+)"?/i);
-			if (match?.[1]) return match[1];
-		}
-		return null;
+		return parseDefaultHandlerBundle(stdout);
 	} catch {
 		return null;
 	}
@@ -157,6 +179,7 @@ const normalized = (value: string) =>
 const findProfileRoot = async (sourceName: string): Promise<string | null> => {
 	const support = Path.join(homedir(), "Library", "Application Support");
 	const wanted = normalized(sourceName);
+	if (wanted.length === 0) return null;
 	const found: Array<{ path: string; score: number }> = [];
 	const walk = async (directory: string, depth: number): Promise<void> => {
 		if (depth > 2) return;
@@ -187,7 +210,8 @@ const findProfileRoot = async (sourceName: string): Promise<string | null> => {
 		);
 	};
 	await walk(support, 0);
-	return found.sort((a, b) => b.score - a.score)[0]?.path ?? null;
+	const best = found.sort((a, b) => b.score - a.score)[0];
+	return best?.score === 10 ? best.path : null;
 };
 
 type DetectedProfile = {
@@ -201,10 +225,18 @@ const detectProfile = async (): Promise<DetectedProfile | null> => {
 	const bundleId = await defaultHandlerBundle();
 	if (bundleId === null) return null;
 	const application = await findApplication(bundleId);
-	const source =
+	const sourceHint =
 		application === null ? bundleId : Path.basename(application, ".app");
-	const root = await findProfileRoot(source);
+	const root = await findProfileRoot(sourceHint);
 	if (root === null) return null;
+	const rootName = Path.basename(root);
+	const source =
+		application === null
+			? (rootName === "User Data"
+					? Path.basename(Path.dirname(root))
+					: rootName
+				).replaceAll("-", " ")
+			: sourceHint;
 	let profile = "Default";
 	try {
 		const localState = JSON.parse(
@@ -468,5 +500,6 @@ export const BROWSER_PARTITION = PARTITION;
 
 export const browserCookieImportInternals = {
 	decryptCookie,
+	parseDefaultHandlerBundle,
 	safeStorageServiceCandidates,
 };

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -26,6 +26,7 @@ import {
 	nativeTheme,
 	net,
 	protocol,
+	session,
 	shell,
 	type WebContents,
 	webContents as webContentsModule,
@@ -48,6 +49,13 @@ if (
 	fixPath();
 }
 
+import {
+	BROWSER_PARTITION,
+	clearImportedBrowserCookies,
+	getBrowserCookieImportStatus,
+	importDefaultBrowserCookies,
+	migrateExistingBrowserCookies,
+} from "./browser-session-service.ts";
 import { electronServerProtocolLayer } from "./ipc/electron-server-protocol.ts";
 import { isLinearContextImagePath } from "./linear-context-image.ts";
 import {
@@ -431,6 +439,59 @@ const localConnectivityHelperPath = (): string =>
 				"bin",
 				"zuse-local-connectivity",
 			);
+
+const browserCredentialHelperPath = (): string =>
+	app.isPackaged
+		? Path.join(
+				process.resourcesPath,
+				"app",
+				"browser-credentials",
+				"zuse-browser-credentials",
+			)
+		: Path.join(
+				app.getAppPath(),
+				"native",
+				"browser-credentials",
+				"bin",
+				"zuse-browser-credentials",
+			);
+
+const probeNativeCredentialHelper = async (): Promise<{
+	readonly supported: boolean;
+	readonly reason?: string;
+}> => {
+	if (process.platform !== "darwin") {
+		return {
+			supported: false,
+			reason: "Native password filling is currently available only on macOS.",
+		};
+	}
+	const executable = browserCredentialHelperPath();
+	if (!fsSync.existsSync(executable)) {
+		return {
+			supported: false,
+			reason: "The native password helper is not installed in this build.",
+		};
+	}
+	try {
+		const { stdout } = await execFileAsync(executable, ["--probe"], {
+			timeout: 5_000,
+			maxBuffer: 16 * 1024,
+		});
+		const result = JSON.parse(stdout) as { supported?: unknown };
+		return result.supported === true
+			? { supported: true }
+			: {
+					supported: false,
+					reason: "The native password helper failed its capability probe.",
+				};
+	} catch {
+		return {
+			supported: false,
+			reason: "The native password helper failed its capability probe.",
+		};
+	}
+};
 
 type LocalTrustRecord = {
 	readonly recordId: string;
@@ -1189,6 +1250,10 @@ async function createMainWindow() {
 		number,
 		{ type: string; message: string; defaultPrompt?: string }
 	>();
+	const browserScreencasts = new Map<
+		number,
+		{ owner: WebContents; awaitingRenderer: boolean }
+	>();
 
 	const dropBrowserBuffers = (id: number): void => {
 		browserNetworkLog.delete(id);
@@ -1197,6 +1262,11 @@ async function createMainWindow() {
 	};
 
 	const detachDebugger = (id: number): void => {
+		const screencast = browserScreencasts.get(id);
+		if (screencast !== undefined && !screencast.owner.isDestroyed()) {
+			screencast.owner.send("browser:screencastInterrupted", id);
+		}
+		browserScreencasts.delete(id);
 		const wc = webContentsModule.fromId(id);
 		if (wc === undefined || wc.isDestroyed()) {
 			attachedWebContents.delete(id);
@@ -1218,16 +1288,19 @@ async function createMainWindow() {
 	 */
 	const installCdpEventTaps = (id: number, wc: WebContents): void => {
 		wc.debugger.on("message", (_event, method, rawParams) => {
-			const params = (rawParams ?? {}) as Record<string, any>;
+			const params = (rawParams ?? {}) as Record<string, unknown>;
 			switch (method) {
 				case "Network.requestWillBeSent": {
-					const log =
-						browserNetworkLog.get(id) ??
-						browserNetworkLog.set(id, new Map()).get(id)!;
+					let log = browserNetworkLog.get(id);
+					if (log === undefined) {
+						log = new Map();
+						browserNetworkLog.set(id, log);
+					}
+					const request = params.request as Record<string, unknown> | undefined;
 					log.set(String(params.requestId), {
 						id: String(params.requestId),
-						method: String(params.request?.method ?? "GET"),
-						url: String(params.request?.url ?? ""),
+						method: String(request?.method ?? "GET"),
+						url: String(request?.url ?? ""),
 						resourceType:
 							typeof params.type === "string" ? params.type : undefined,
 					});
@@ -1242,12 +1315,15 @@ async function createMainWindow() {
 						.get(id)
 						?.get(String(params.requestId));
 					if (entry === undefined) return;
-					entry.status = Number(params.response?.status ?? 0);
+					const response = params.response as
+						| Record<string, unknown>
+						| undefined;
+					entry.status = Number(response?.status ?? 0);
 					entry.mimeType =
-						typeof params.response?.mimeType === "string"
-							? params.response.mimeType
+						typeof response?.mimeType === "string"
+							? response.mimeType
 							: undefined;
-					const headers = params.response?.headers;
+					const headers = response?.headers;
 					if (headers !== null && typeof headers === "object") {
 						entry.responseHeaders = headers as Record<string, string>;
 					}
@@ -1264,12 +1340,13 @@ async function createMainWindow() {
 				}
 				case "Runtime.exceptionThrown": {
 					const details = params.exceptionDetails as
-						| Record<string, any>
+						| Record<string, unknown>
+						| undefined;
+					const exception = details?.exception as
+						| Record<string, unknown>
 						| undefined;
 					const description =
-						details?.exception?.description ??
-						details?.text ??
-						"Uncaught exception";
+						exception?.description ?? details?.text ?? "Uncaught exception";
 					const where =
 						typeof details?.url === "string" && details.url.length > 0
 							? ` (${details.url}:${details.lineNumber ?? 0})`
@@ -1297,6 +1374,27 @@ async function createMainWindow() {
 				}
 				case "Page.javascriptDialogClosed": {
 					browserPendingDialog.delete(id);
+					return;
+				}
+				case "Page.screencastFrame": {
+					void wc.debugger
+						.sendCommand("Page.screencastFrameAck", {
+							sessionId: params.sessionId,
+						})
+						.catch(() => {});
+					const screencast = browserScreencasts.get(id);
+					if (
+						screencast === undefined ||
+						screencast.awaitingRenderer ||
+						screencast.owner.isDestroyed() ||
+						typeof params.data !== "string"
+					)
+						return;
+					screencast.awaitingRenderer = true;
+					screencast.owner.send("browser:screencastFrame", {
+						webContentsId: id,
+						data: params.data,
+					});
 					return;
 				}
 				default:
@@ -1357,6 +1455,11 @@ async function createMainWindow() {
 				// teardown, full crash). Without this, a `Another debugger is already
 				// attached` error fires on the next register-after-reload.
 				wc.once("destroyed", () => {
+					const screencast = browserScreencasts.get(rawId);
+					if (screencast !== undefined && !screencast.owner.isDestroyed()) {
+						screencast.owner.send("browser:screencastInterrupted", rawId);
+					}
+					browserScreencasts.delete(rawId);
 					attachedWebContents.delete(rawId);
 					tappedWebContents.delete(rawId);
 					dropBrowserBuffers(rawId);
@@ -1432,6 +1535,53 @@ async function createMainWindow() {
 		},
 	);
 
+	ipcMain.handle("browser:startScreencast", async (event, rawId: unknown) => {
+		if (typeof rawId !== "number" || !Number.isInteger(rawId)) return false;
+		const wc = webContentsModule.fromId(rawId);
+		if (
+			wc === undefined ||
+			wc.isDestroyed() ||
+			!wc.debugger.isAttached() ||
+			browserScreencasts.has(rawId)
+		)
+			return false;
+		try {
+			browserScreencasts.set(rawId, {
+				owner: event.sender,
+				awaitingRenderer: false,
+			});
+			await wc.debugger.sendCommand("Page.startScreencast", {
+				format: "jpeg",
+				quality: 85,
+				everyNthFrame: 1,
+			});
+			return true;
+		} catch {
+			browserScreencasts.delete(rawId);
+			return false;
+		}
+	});
+
+	ipcMain.on("browser:ackScreencastFrame", (_event, rawId: unknown) => {
+		if (typeof rawId !== "number") return;
+		const screencast = browserScreencasts.get(rawId);
+		if (screencast !== undefined) screencast.awaitingRenderer = false;
+	});
+
+	ipcMain.handle("browser:stopScreencast", async (_event, rawId: unknown) => {
+		if (typeof rawId !== "number" || !Number.isInteger(rawId)) return false;
+		browserScreencasts.delete(rawId);
+		const wc = webContentsModule.fromId(rawId);
+		if (wc === undefined || wc.isDestroyed() || !wc.debugger.isAttached())
+			return false;
+		try {
+			await wc.debugger.sendCommand("Page.stopScreencast");
+			return true;
+		} catch {
+			return false;
+		}
+	});
+
 	ipcMain.handle(
 		"browser:getNetwork",
 		async (_event, rawId: unknown, rawQuery: unknown) => {
@@ -1489,6 +1639,135 @@ async function createMainWindow() {
 		return browserPendingDialog.get(rawId) ?? null;
 	});
 
+	ipcMain.handle("browser:getCookieImportStatus", async () => {
+		const persistent = session.fromPartition(BROWSER_PARTITION);
+		await migrateExistingBrowserCookies(
+			app.getPath("userData"),
+			session.defaultSession,
+			persistent,
+		);
+		return getBrowserCookieImportStatus(app.getPath("userData"));
+	});
+
+	ipcMain.handle("browser:importCookies", async () =>
+		importDefaultBrowserCookies(
+			app.getPath("userData"),
+			session.fromPartition(BROWSER_PARTITION),
+		),
+	);
+
+	ipcMain.handle("browser:clearImportedCookies", async () =>
+		clearImportedBrowserCookies(
+			app.getPath("userData"),
+			session.fromPartition(BROWSER_PARTITION),
+		),
+	);
+
+	ipcMain.handle("browser:clearBrowsingData", async () => {
+		const userData = app.getPath("userData");
+		const persistent = session.fromPartition(BROWSER_PARTITION);
+		await clearImportedBrowserCookies(userData, persistent);
+		await persistent.clearStorageData();
+		await persistent.clearCache();
+		return getBrowserCookieImportStatus(userData);
+	});
+
+	ipcMain.handle("browser:getNativeCredentialCapability", async () =>
+		probeNativeCredentialHelper(),
+	);
+
+	ipcMain.handle(
+		"browser:fillNativeCredential",
+		async (_event, rawId: unknown, rawOrigin: unknown, rawSubmit: unknown) => {
+			if (typeof rawId !== "number" || typeof rawOrigin !== "string")
+				return { ok: false, error: "Invalid native credential request." };
+			const wc = webContentsModule.fromId(rawId);
+			if (wc === undefined || wc.isDestroyed())
+				return { ok: false, error: "The browser surface is unavailable." };
+			let activeOrigin: string;
+			let requestedOrigin: string;
+			try {
+				activeOrigin = new URL(wc.getURL()).origin;
+				requestedOrigin = new URL(rawOrigin).origin;
+			} catch {
+				return { ok: false, error: "A valid active page origin is required." };
+			}
+			if (activeOrigin !== requestedOrigin)
+				return {
+					ok: false,
+					error: "Credential origin does not match the active page.",
+				};
+			const capability = await probeNativeCredentialHelper();
+			if (!capability.supported) {
+				return {
+					ok: false,
+					error:
+						capability.reason ??
+						"Native Passwords access is unavailable in this build.",
+				};
+			}
+			try {
+				const { stdout } = await execFileAsync(
+					browserCredentialHelperPath(),
+					[requestedOrigin],
+					{
+						timeout: 120_000,
+						maxBuffer: 64 * 1024,
+					},
+				);
+				const selected = JSON.parse(stdout) as {
+					ok?: unknown;
+					username?: unknown;
+					password?: unknown;
+					error?: unknown;
+				};
+				if (
+					selected.ok !== true ||
+					typeof selected.username !== "string" ||
+					typeof selected.password !== "string"
+				) {
+					return {
+						ok: false,
+						error:
+							typeof selected.error === "string"
+								? selected.error
+								: "No password was selected.",
+					};
+				}
+				if (
+					wc.isDestroyed() ||
+					new URL(wc.getURL()).origin !== requestedOrigin
+				) {
+					return {
+						ok: false,
+						error: "The page changed before the credential could be filled.",
+					};
+				}
+				const result = (await wc.executeJavaScript(
+					`(() => { const username = ${JSON.stringify(selected.username)}; const password = ${JSON.stringify(selected.password)}; const passwordField = document.querySelector('input[type="password"]'); if (!(passwordField instanceof HTMLInputElement)) return { ok: false, error: 'No password field is focused or visible on this page.' }; const usernameField = document.querySelector('input[autocomplete="username"], input[type="email"], input[name*="user" i], input[name*="email" i], input[id*="user" i], input[id*="email" i]') || Array.from(document.querySelectorAll('input')).find((element) => element instanceof HTMLInputElement && /^(text|email)$/.test(element.type)); const setValue = (element, value) => { const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value'); descriptor?.set?.call(element, value); element.dispatchEvent(new Event('input', { bubbles: true })); element.dispatchEvent(new Event('change', { bubbles: true })); }; if (usernameField instanceof HTMLInputElement) setValue(usernameField, username); setValue(passwordField, password); ${rawSubmit === true ? "if (passwordField.form?.requestSubmit) passwordField.form.requestSubmit();" : "passwordField.focus();"} return { ok: true }; })()`,
+					true,
+				)) as { ok?: unknown; error?: unknown };
+				return result.ok === true
+					? { ok: true }
+					: {
+							ok: false,
+							error:
+								typeof result.error === "string"
+									? result.error
+									: "The selected password could not be filled.",
+						};
+			} catch (error) {
+				return {
+					ok: false,
+					error:
+						error instanceof Error && error.message.includes("timed out")
+							? "Password selection timed out."
+							: "Password selection was cancelled or unavailable.",
+				};
+			}
+		},
+	);
+
 	ipcMain.handle("browser:listLocalServers", async () => {
 		try {
 			const byPort = new Map<number, string>();
@@ -1531,6 +1810,44 @@ async function createMainWindow() {
 			return [];
 		}
 	});
+
+	ipcMain.handle(
+		"browser:saveRecording",
+		async (
+			_event,
+			rawBytes: unknown,
+			rawMime: unknown,
+			rawDuration: unknown,
+		) => {
+			if (!(rawBytes instanceof Uint8Array)) {
+				throw new Error("Recording bytes are invalid.");
+			}
+			if (
+				rawBytes.byteLength === 0 ||
+				rawBytes.byteLength > 300 * 1024 * 1024
+			) {
+				throw new Error("Recording must be between 1 byte and 300 MB.");
+			}
+			const mimeType = rawMime === "video/mp4" ? "video/mp4" : "video/webm";
+			const extension = mimeType === "video/mp4" ? "mp4" : "webm";
+			const id = randomUUID();
+			const createdAt = new Date().toISOString();
+			const directory = Path.join(app.getPath("userData"), "browser-artifacts");
+			await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+			const target = Path.join(directory, `${id}.${extension}`);
+			await fs.writeFile(target, rawBytes, { mode: 0o600 });
+			return {
+				id,
+				type: mimeType,
+				size: rawBytes.byteLength,
+				durationMs: Math.max(
+					0,
+					Math.min(10 * 60 * 1000, Number(rawDuration) || 0),
+				),
+				createdAt,
+			};
+		},
+	);
 
 	ipcMain.handle(
 		"browser:dispatchInput",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1649,10 +1649,11 @@ async function createMainWindow() {
 		return getBrowserCookieImportStatus(app.getPath("userData"));
 	});
 
-	ipcMain.handle("browser:importCookies", async () =>
+	ipcMain.handle("browser:importCookies", async (_event, profileId: unknown) =>
 		importDefaultBrowserCookies(
 			app.getPath("userData"),
 			session.fromPartition(BROWSER_PARTITION),
+			typeof profileId === "string" ? profileId : undefined,
 		),
 	);
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -92,6 +92,35 @@ const bridge = {
 				method,
 				params ?? {},
 			) as Promise<{ ok: boolean; result?: unknown; error?: string }>,
+		startScreencast: (webContentsId: number) =>
+			ipcRenderer.invoke(
+				"browser:startScreencast",
+				webContentsId,
+			) as Promise<boolean>,
+		stopScreencast: (webContentsId: number) =>
+			ipcRenderer.invoke(
+				"browser:stopScreencast",
+				webContentsId,
+			) as Promise<boolean>,
+		onScreencastFrame: (
+			handler: (frame: { webContentsId: number; data: string }) => void,
+		) => {
+			const wrapped = (
+				_event: IpcRendererEvent,
+				frame: { webContentsId: number; data: string },
+			) => {
+				handler(frame);
+				ipcRenderer.send("browser:ackScreencastFrame", frame.webContentsId);
+			};
+			ipcRenderer.on("browser:screencastFrame", wrapped);
+			return () => ipcRenderer.off("browser:screencastFrame", wrapped);
+		},
+		onScreencastInterrupted: (handler: (webContentsId: number) => void) => {
+			const wrapped = (_event: IpcRendererEvent, webContentsId: number) =>
+				handler(webContentsId);
+			ipcRenderer.on("browser:screencastInterrupted", wrapped);
+			return () => ipcRenderer.off("browser:screencastInterrupted", wrapped);
+		},
 		/** Network requests captured since the last load (buffered in main). */
 		getNetwork: (webContentsId: number, query?: unknown) =>
 			ipcRenderer.invoke(
@@ -115,6 +144,43 @@ const bridge = {
 			ipcRenderer.invoke("browser:listLocalServers") as Promise<
 				ReadonlyArray<{ name: string; port: number }>
 			>,
+		saveRecording: (bytes: Uint8Array, mimeType: string, durationMs: number) =>
+			ipcRenderer.invoke(
+				"browser:saveRecording",
+				bytes,
+				mimeType,
+				durationMs,
+			) as Promise<{
+				id: string;
+				type: string;
+				size: number;
+				durationMs: number;
+				createdAt: string;
+			}>,
+		getCookieImportStatus: () =>
+			ipcRenderer.invoke("browser:getCookieImportStatus") as Promise<unknown>,
+		importCookies: () =>
+			ipcRenderer.invoke("browser:importCookies") as Promise<unknown>,
+		clearImportedCookies: () =>
+			ipcRenderer.invoke("browser:clearImportedCookies") as Promise<unknown>,
+		clearBrowsingData: () =>
+			ipcRenderer.invoke("browser:clearBrowsingData") as Promise<unknown>,
+		getNativeCredentialCapability: () =>
+			ipcRenderer.invoke("browser:getNativeCredentialCapability") as Promise<{
+				supported: boolean;
+				reason?: string;
+			}>,
+		fillNativeCredential: (
+			webContentsId: number,
+			origin: string,
+			submit = false,
+		) =>
+			ipcRenderer.invoke(
+				"browser:fillNativeCredential",
+				webContentsId,
+				origin,
+				submit,
+			) as Promise<{ ok: boolean; error?: string }>,
 	},
 	notch: {
 		setItems: (items: unknown) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -159,8 +159,11 @@ const bridge = {
 			}>,
 		getCookieImportStatus: () =>
 			ipcRenderer.invoke("browser:getCookieImportStatus") as Promise<unknown>,
-		importCookies: () =>
-			ipcRenderer.invoke("browser:importCookies") as Promise<unknown>,
+		importCookies: (profileId?: string) =>
+			ipcRenderer.invoke(
+				"browser:importCookies",
+				profileId,
+			) as Promise<unknown>,
 		clearImportedCookies: () =>
 			ipcRenderer.invoke("browser:clearImportedCookies") as Promise<unknown>,
 		clearBrowsingData: () =>

--- a/apps/desktop/test/unit/browser-session-service.test.ts
+++ b/apps/desktop/test/unit/browser-session-service.test.ts
@@ -4,6 +4,35 @@ import { describe, expect, it } from "vitest";
 import { browserCookieImportInternals } from "../../src/browser-session-service.ts";
 
 describe("browser cookie import internals", () => {
+	it("ignores nested LaunchServices placeholders when reading the HTTPS handler", () => {
+		const launchServices = `(
+			{
+				LSHandlerPreferredVersions = {
+					LSHandlerRoleAll = "-";
+				};
+				LSHandlerRoleAll = "com.example.browser";
+				LSHandlerURLScheme = https;
+			},
+		)`;
+
+		expect(
+			browserCookieImportInternals.parseDefaultHandlerBundle(launchServices),
+		).toBe("com.example.browser");
+	});
+
+	it("rejects a placeholder-only HTTPS handler", () => {
+		const launchServices = `(
+			{
+				LSHandlerRoleAll = "-";
+				LSHandlerURLScheme = https;
+			},
+		)`;
+
+		expect(
+			browserCookieImportInternals.parseDefaultHandlerBundle(launchServices),
+		).toBeNull();
+	});
+
 	it("decrypts a host-bound Chromium cookie fixture", () => {
 		const host = ".example.test";
 		const key = Buffer.from("0123456789abcdef");

--- a/apps/desktop/test/unit/browser-session-service.test.ts
+++ b/apps/desktop/test/unit/browser-session-service.test.ts
@@ -1,9 +1,39 @@
 import { createCipheriv, createHash } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 import { browserCookieImportInternals } from "../../src/browser-session-service.ts";
 
 describe("browser cookie import internals", () => {
+	it("reads Chromium 64-bit cookie timestamps without numeric overflow", () => {
+		const db = new DatabaseSync(":memory:");
+		db.exec(`
+			CREATE TABLE cookies (
+				host_key TEXT, name TEXT, value TEXT, encrypted_value BLOB,
+				path TEXT, expires_utc INTEGER, is_secure INTEGER,
+				is_httponly INTEGER, samesite INTEGER
+			)
+		`);
+		db.prepare("INSERT INTO cookies VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+			".example.test",
+			"session",
+			"value",
+			new Uint8Array(),
+			"/",
+			13_463_487_147_398_676n,
+			1,
+			1,
+			1,
+		);
+
+		try {
+			const rows = browserCookieImportInternals.readCookieRows(db);
+			expect(rows[0]?.expires_utc).toBe(13_463_487_147_398_676n);
+		} finally {
+			db.close();
+		}
+	});
+
 	it("ignores nested LaunchServices placeholders when reading the HTTPS handler", () => {
 		const launchServices = `(
 			{

--- a/apps/desktop/test/unit/browser-session-service.test.ts
+++ b/apps/desktop/test/unit/browser-session-service.test.ts
@@ -1,0 +1,41 @@
+import { createCipheriv, createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { browserCookieImportInternals } from "../../src/browser-session-service.ts";
+
+describe("browser cookie import internals", () => {
+	it("decrypts a host-bound Chromium cookie fixture", () => {
+		const host = ".example.test";
+		const key = Buffer.from("0123456789abcdef");
+		const cipher = createCipheriv("aes-128-cbc", key, Buffer.alloc(16, " "));
+		const encrypted = Buffer.concat([
+			Buffer.from("v10"),
+			cipher.update(
+				Buffer.concat([
+					createHash("sha256").update(host).digest(),
+					Buffer.from("session-value"),
+				]),
+			),
+			cipher.final(),
+		]);
+
+		expect(
+			browserCookieImportInternals.decryptCookie(encrypted, key, host),
+		).toBe("session-value");
+		expect(
+			browserCookieImportInternals.decryptCookie(encrypted, key, "wrong.test"),
+		).not.toBe("session-value");
+	});
+
+	it("derives generic safe-storage service candidates without duplicates", () => {
+		expect(
+			browserCookieImportInternals.safeStorageServiceCandidates(
+				"Example Browser",
+			),
+		).toEqual([
+			"Example Browser Safe Storage",
+			"Example Safe Storage",
+			"Browser Safe Storage",
+		]);
+	});
+});

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -417,6 +417,7 @@ export function BrowserPane() {
 	]);
 	const displayedCookieStatus: BrowserCookieImportStatus = cookieStatus ?? {
 		supported: false,
+		availableProfiles: [],
 		importedDomainCount: 0,
 		importedCookieCount: 0,
 		importedDomains: [],
@@ -537,10 +538,10 @@ export function BrowserPane() {
 		};
 	}, []);
 
-	const runCookieImport = async () => {
+	const runCookieImport = async (profileId?: string) => {
 		setCookieImportBusy(true);
 		try {
-			const status = await window.zuse?.browser?.importCookies?.();
+			const status = await window.zuse?.browser?.importCookies?.(profileId);
 			if (status === undefined)
 				throw new Error("Browser session import is unavailable in this build.");
 			cookieStatusRef.current = status;

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -254,6 +254,14 @@ const drawRecordingDecorations = (
 	context.restore();
 };
 
+const browserContentBounds = (element: HTMLElement): DOMRect =>
+	new DOMRect(
+		0,
+		0,
+		Math.max(1, element.clientWidth),
+		Math.max(1, element.clientHeight),
+	);
+
 const pngBase64ToFile = (base64: string, name: string): File => {
 	const binary = atob(base64);
 	const bytes = new Uint8Array(binary.length);
@@ -353,7 +361,6 @@ export function BrowserPane() {
 	const [nativeCredentialError, setNativeCredentialError] = useState<
 		string | null
 	>(null);
-	const [domainGrantVersion, setDomainGrantVersion] = useState(0);
 	const [domainAccessRequest, setDomainAccessRequest] = useState<{
 		domain: string;
 		sessionId: string;
@@ -371,6 +378,11 @@ export function BrowserPane() {
 		} catch {
 			return DEFAULT_VIEWPORT;
 		}
+	});
+	const viewportStageRef = useRef<HTMLDivElement | null>(null);
+	const [viewportStageSize, setViewportStageSize] = useState({
+		width: 0,
+		height: 0,
 	});
 	const viewportRef = useRef(viewport);
 	const loadingRef = useRef(isLoading);
@@ -408,6 +420,16 @@ export function BrowserPane() {
 	const [localServers, setLocalServers] =
 		useState<ReadonlyArray<LocalServerSummary>>(fallbackLocalServers);
 	const hasLoadedPage = url !== "" && url !== "about:blank";
+	const viewportPreviewScale =
+		viewport.mode === "fill" ||
+		viewportStageSize.width === 0 ||
+		viewportStageSize.height === 0
+			? 1
+			: Math.min(
+					1,
+					Math.max(1, viewportStageSize.width - 24) / viewport.width,
+					Math.max(1, viewportStageSize.height - 24) / viewport.height,
+				);
 	const hasAnnotationTargets =
 		pickedElements.length > 0 || regions.length > 0 || strokes.length > 0;
 	const annotationBounds = unionRects([
@@ -428,6 +450,27 @@ export function BrowserPane() {
 		viewportRef.current = viewport;
 		localStorage.setItem("zuse.browser.viewport.v1", JSON.stringify(viewport));
 	}, [viewport]);
+	useEffect(() => {
+		const stage = viewportStageRef.current;
+		if (stage === null || typeof ResizeObserver === "undefined") return;
+		const update = (width: number, height: number) =>
+			setViewportStageSize((current) =>
+				current.width === width && current.height === height
+					? current
+					: { width, height },
+			);
+		const initial = stage.getBoundingClientRect();
+		update(Math.round(initial.width), Math.round(initial.height));
+		const observer = new ResizeObserver(([entry]) => {
+			if (entry === undefined) return;
+			update(
+				Math.round(entry.contentRect.width),
+				Math.round(entry.contentRect.height),
+			);
+		});
+		observer.observe(stage);
+		return () => observer.disconnect();
+	}, []);
 	useEffect(() => {
 		loadingRef.current = isLoading;
 	}, [isLoading]);
@@ -555,26 +598,6 @@ export function BrowserPane() {
 		}
 	};
 
-	const clearImportedCookies = async () => {
-		setCookieImportBusy(true);
-		try {
-			const status = await window.zuse?.browser?.clearImportedCookies?.();
-			if (status === undefined)
-				throw new Error(
-					"Imported-session controls are unavailable in this build.",
-				);
-			cookieStatusRef.current = status;
-			setCookieStatus(status);
-			domainGrantsRef.current.clear();
-			setDomainGrantVersion(0);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			throw new Error(message);
-		} finally {
-			setCookieImportBusy(false);
-		}
-	};
-
 	const clearBrowsingData = async () => {
 		setCookieImportBusy(true);
 		try {
@@ -584,7 +607,6 @@ export function BrowserPane() {
 			cookieStatusRef.current = status;
 			setCookieStatus(status);
 			domainGrantsRef.current.clear();
-			setDomainGrantVersion(0);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			throw new Error(message);
@@ -854,7 +876,7 @@ export function BrowserPane() {
 					setRecordingState("starting");
 					await recordingRef.current.start({
 						capturePage: () => wv.capturePage(),
-						getBoundingClientRect: () => wv.getBoundingClientRect(),
+						getBoundingClientRect: () => browserContentBounds(wv),
 						subscribeFrames: async (handler) => {
 							const bridge = window.zuse?.browser;
 							const id = webContentsIdRef.current;
@@ -883,7 +905,7 @@ export function BrowserPane() {
 								context,
 								width,
 								height,
-								wv.getBoundingClientRect(),
+								browserContentBounds(wv),
 								agentOverlaysRef.current,
 								cursorIntentRef.current,
 							),
@@ -1040,8 +1062,10 @@ export function BrowserPane() {
 		const startY = event.clientY;
 		const initial = viewportRef.current;
 		const onMove = (moveEvent: PointerEvent) => {
-			const width = initial.width + moveEvent.clientX - startX;
-			const height = initial.height + moveEvent.clientY - startY;
+			const width =
+				initial.width + (moveEvent.clientX - startX) / viewportPreviewScale;
+			const height =
+				initial.height + (moveEvent.clientY - startY) / viewportPreviewScale;
 			if (initial.lockAspectRatio) {
 				updateViewportDimension("width", width);
 			} else {
@@ -1104,8 +1128,12 @@ export function BrowserPane() {
 	): BrowserAnnotationPoint => {
 		const rect = event.currentTarget.getBoundingClientRect();
 		return {
-			x: event.clientX - rect.left,
-			y: event.clientY - rect.top,
+			x:
+				(event.clientX - rect.left) *
+				(event.currentTarget.clientWidth / Math.max(1, rect.width)),
+			y:
+				(event.clientY - rect.top) *
+				(event.currentTarget.clientHeight / Math.max(1, rect.height)),
 		};
 	};
 
@@ -1314,7 +1342,7 @@ export function BrowserPane() {
 			];
 			const base64 = await compositeBrowserImage(
 				image.toDataURL(),
-				wv.getBoundingClientRect(),
+				browserContentBounds(wv),
 				[...agentOverlays, ...humanShapes],
 				null,
 			);
@@ -1522,15 +1550,13 @@ export function BrowserPane() {
 				</ToolbarButton>
 				<BrowserSettingsMenu
 					status={displayedCookieStatus}
-					credentialCapability={nativeCredentialCapability}
 					busy={cookieImportBusy}
-					domainGrantCount={domainGrantVersion}
 					onImport={runCookieImport}
-					onClearImported={clearImportedCookies}
 					onClearBrowsingData={clearBrowsingData}
-					onRevokeTaskAccess={() => {
-						domainGrantsRef.current.clear();
-						setDomainGrantVersion(0);
+					onOpenSettings={() => {
+						const ui = useUiStore.getState();
+						ui.setSettingsSection({ kind: "browser" });
+						ui.setView("settings");
 					}}
 				/>
 			</form>
@@ -1597,7 +1623,6 @@ export function BrowserPane() {
 								domainGrantsRef.current.add(
 									`${domainAccessRequest.sessionId}:${domainAccessRequest.domain}`,
 								);
-								setDomainGrantVersion((value) => value + 1);
 								domainAccessRequest.resolve(true);
 								setDomainAccessRequest(null);
 							}}
@@ -1607,75 +1632,97 @@ export function BrowserPane() {
 					</div>
 				</section>
 			) : null}
-			<div className="relative flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted/20">
+			<div
+				ref={viewportStageRef}
+				className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-muted/20"
+			>
 				{!hasLoadedPage ? (
 					<BrowserEmptyState servers={localServers} onOpen={navigate} />
 				) : null}
 				<div
-					className="relative shrink-0 overflow-hidden bg-background shadow-sm"
+					className="relative shrink-0"
 					style={{
-						width: viewport.mode === "fill" ? "100%" : `${viewport.width}px`,
-						height: viewport.mode === "fill" ? "100%" : `${viewport.height}px`,
+						width:
+							viewport.mode === "fill"
+								? "100%"
+								: `${viewport.width * viewportPreviewScale}px`,
+						height:
+							viewport.mode === "fill"
+								? "100%"
+								: `${viewport.height * viewportPreviewScale}px`,
 					}}
 				>
-					<webview
-						ref={webviewRef as unknown as React.RefObject<HTMLElement>}
-						// src is intentionally NOT bound to `url` state. All navigation is
-						// imperative (loadURL); if src tracked state, every navigation would
-						// fire twice — once from loadURL, once from React re-setting the
-						// attribute — and the loads abort each other (ERR_ABORTED -3, agent
-						// navigations intermittently reporting about:blank).
-						src="about:blank"
-						{...({
-							allowpopups: "true",
-							partition: "persist:zuse-browser",
-						} as Record<string, string>)}
+					<div
+						className="relative origin-top-left overflow-hidden bg-background shadow-sm"
 						style={{
-							display: !hasLoadedPage ? "none" : "flex",
-							width: "100%",
-							height: "100%",
+							width: viewport.mode === "fill" ? "100%" : `${viewport.width}px`,
+							height:
+								viewport.mode === "fill" ? "100%" : `${viewport.height}px`,
+							transform:
+								viewport.mode === "fill"
+									? undefined
+									: `scale(${viewportPreviewScale})`,
 						}}
-					/>
-					<BrowserAgentOverlay shapes={agentOverlays} />
-					{viewport.mode !== "fill" ? (
-						<button
-							type="button"
-							onPointerDown={beginViewportResize}
-							aria-label="Resize browser viewport"
-							className="absolute bottom-0 right-0 z-30 size-8 cursor-nwse-resize touch-none bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 after:absolute after:bottom-1 after:right-1 after:size-3 after:border-b-2 after:border-r-2 after:border-muted-foreground/60"
-						/>
-					) : null}
-					{annotating && hasLoadedPage ? (
-						<BrowserAnnotationOverlay
-							tool={annotationTool}
-							setTool={setAnnotationTool}
-							hoverPick={hoverPick}
-							elements={pickedElements}
-							regions={regions}
-							strokes={strokes}
-							dragRect={dragRect}
-							activeStroke={activeStroke}
-							bounds={annotationBounds}
-							comment={annotationComment}
-							setComment={setAnnotationComment}
-							canAttach={
-								selectedSessionId !== null &&
-								hasAnnotationTargets &&
-								annotationComment.trim().length > 0
-							}
-							attaching={attachingAnnotation}
-							onAttach={() => void attachBrowserAnnotation()}
-							onCancel={() => {
-								resetAnnotationDraft();
-								setAnnotating(false);
+					>
+						<webview
+							ref={webviewRef as unknown as React.RefObject<HTMLElement>}
+							// src is intentionally NOT bound to `url` state. All navigation is
+							// imperative (loadURL); if src tracked state, every navigation would
+							// fire twice — once from loadURL, once from React re-setting the
+							// attribute — and the loads abort each other (ERR_ABORTED -3, agent
+							// navigations intermittently reporting about:blank).
+							src="about:blank"
+							{...({
+								allowpopups: "true",
+								partition: "persist:zuse-browser",
+							} as Record<string, string>)}
+							style={{
+								display: !hasLoadedPage ? "none" : "flex",
+								width: "100%",
+								height: "100%",
 							}}
-							onPointerDown={handleAnnotationPointerDown}
-							onPointerMove={handleAnnotationPointerMove}
-							onPointerUp={handleAnnotationPointerUp}
 						/>
-					) : null}
-					<AgentCursor intent={cursorIntent} visible={hasLoadedPage} />
-					<BrowserShutter nonce={shutterNonce} />
+						<BrowserAgentOverlay shapes={agentOverlays} />
+						{viewport.mode !== "fill" ? (
+							<button
+								type="button"
+								onPointerDown={beginViewportResize}
+								aria-label="Resize browser viewport"
+								className="absolute bottom-0 right-0 z-30 size-8 cursor-nwse-resize touch-none bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 after:absolute after:bottom-1 after:right-1 after:size-3 after:border-b-2 after:border-r-2 after:border-muted-foreground/60"
+							/>
+						) : null}
+						{annotating && hasLoadedPage ? (
+							<BrowserAnnotationOverlay
+								tool={annotationTool}
+								setTool={setAnnotationTool}
+								hoverPick={hoverPick}
+								elements={pickedElements}
+								regions={regions}
+								strokes={strokes}
+								dragRect={dragRect}
+								activeStroke={activeStroke}
+								bounds={annotationBounds}
+								comment={annotationComment}
+								setComment={setAnnotationComment}
+								canAttach={
+									selectedSessionId !== null &&
+									hasAnnotationTargets &&
+									annotationComment.trim().length > 0
+								}
+								attaching={attachingAnnotation}
+								onAttach={() => void attachBrowserAnnotation()}
+								onCancel={() => {
+									resetAnnotationDraft();
+									setAnnotating(false);
+								}}
+								onPointerDown={handleAnnotationPointerDown}
+								onPointerMove={handleAnnotationPointerMove}
+								onPointerUp={handleAnnotationPointerUp}
+							/>
+						) : null}
+						<AgentCursor intent={cursorIntent} visible={hasLoadedPage} />
+						<BrowserShutter nonce={shutterNonce} />
+					</div>
 				</div>
 			</div>
 		</div>
@@ -1812,7 +1859,7 @@ async function resolveBrowserTarget(
 	target: BrowserTarget,
 ): Promise<ResolvedBrowserTarget> {
 	if (target._tag === "Point") {
-		const bounds = wv.getBoundingClientRect();
+		const bounds = browserContentBounds(wv);
 		if (
 			target.x < 0 ||
 			target.y < 0 ||
@@ -2077,7 +2124,7 @@ async function runBrowserCommand(
 				}
 				const base64 = await compositeBrowserImage(
 					image.toDataURL(),
-					wv.getBoundingClientRect(),
+					browserContentBounds(wv),
 					hooks.getOverlays(),
 					hooks.getCursor(),
 				);

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -8,6 +8,9 @@ import {
 	type BrowserAnnotationStroke,
 	type BrowserCommandRequest,
 	BrowserCommandResult,
+	type BrowserOverlayShape,
+	type BrowserTarget,
+	type BrowserViewportMode,
 	type SessionId,
 } from "@zuse/contracts";
 import { Effect, Fiber, Stream } from "effect";
@@ -35,17 +38,23 @@ import {
 } from "react";
 
 import type {
+	BrowserCookieImportStatus,
 	BrowserInputAction,
 	CdpCommandOutcome,
 	LocalServerSummary,
 	NetworkQueryResult,
 } from "../lib/bridge.ts";
+import {
+	type BrowserRecordingArtifact,
+	BrowserRecordingController,
+} from "../lib/browser-recording.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useAnnotationsStore } from "../store/annotations.ts";
 import { useAttachmentsStore } from "../store/attachments.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
 import { AgentCursor, type AgentCursorIntent } from "./agent-cursor.tsx";
+import { BrowserSettingsMenu } from "./browser-settings-menu.tsx";
 import { BrowserShutter } from "./browser-shutter.tsx";
 
 /**
@@ -64,6 +73,41 @@ const CURSOR_GLIDE_MS = 350;
  * this long plus a small buffer before letting the next command run.
  */
 const SMOOTH_SCROLL_MS = 700;
+
+type BrowserViewportSetting = {
+	mode: BrowserViewportMode;
+	width: number;
+	height: number;
+	orientation: "portrait" | "landscape";
+	lockAspectRatio: boolean;
+};
+
+const VIEWPORT_PRESETS: Record<
+	Exclude<BrowserViewportMode, "fill" | "custom">,
+	{ width: number; height: number }
+> = {
+	phone: { width: 390, height: 844 },
+	tablet: { width: 768, height: 1024 },
+	laptop: { width: 1366, height: 768 },
+	desktop: { width: 1440, height: 900 },
+};
+
+const DEFAULT_VIEWPORT: BrowserViewportSetting = {
+	mode: "fill",
+	width: 1440,
+	height: 900,
+	orientation: "landscape",
+	lockAspectRatio: false,
+};
+
+type BrowserActionEvent = {
+	id: string;
+	command: string;
+	state: "running" | "succeeded" | "failed" | "interrupted";
+	startedAt: string;
+	finishedAt?: string;
+	error?: string;
+};
 
 type AnnotationTool = "select" | "region" | "draw" | "erase";
 
@@ -149,15 +193,106 @@ const pathFromPoints = (
 		.join(" ");
 };
 
-const nativeImageToFile = async (
-	image: NativeImageLike,
-	name: string,
-): Promise<File> => {
-	const png = image.toPNG();
-	const source = png instanceof Uint8Array ? png : new Uint8Array(png);
-	const bytes = new Uint8Array(source.length);
-	bytes.set(source);
+const drawRecordingDecorations = (
+	context: CanvasRenderingContext2D,
+	width: number,
+	height: number,
+	bounds: DOMRect,
+	shapes: ReadonlyArray<BrowserOverlayShape>,
+	cursor: AgentCursorIntent | null,
+) => {
+	const scaleX = width / Math.max(1, bounds.width);
+	const scaleY = height / Math.max(1, bounds.height);
+	context.save();
+	context.scale(scaleX, scaleY);
+	context.lineWidth = 3;
+	context.lineCap = "round";
+	context.lineJoin = "round";
+	for (const shape of shapes) {
+		context.strokeStyle = shape.color ?? "rgb(37 99 235)";
+		context.fillStyle = shape.color ?? "rgb(37 99 235)";
+		if (shape._tag === "Rectangle" || shape._tag === "Highlight") {
+			if (shape._tag === "Highlight") {
+				context.globalAlpha = 0.22;
+				context.fillRect(shape.x, shape.y, shape.width, shape.height);
+				context.globalAlpha = 1;
+			} else context.strokeRect(shape.x, shape.y, shape.width, shape.height);
+		}
+		if (shape._tag === "Arrow") {
+			context.beginPath();
+			context.moveTo(shape.fromX, shape.fromY);
+			context.lineTo(shape.toX, shape.toY);
+			context.stroke();
+		}
+		if (shape._tag === "Label") {
+			context.font = "600 12px system-ui";
+			context.fillText(shape.text, shape.x, shape.y);
+		}
+		if (shape._tag === "Freehand" && shape.points.length > 1) {
+			const first = shape.points[0];
+			if (first === undefined) continue;
+			context.beginPath();
+			context.moveTo(first.x, first.y);
+			for (const point of shape.points.slice(1))
+				context.lineTo(point.x, point.y);
+			context.stroke();
+		}
+	}
+	if (cursor !== null) {
+		context.fillStyle = "white";
+		context.strokeStyle = "rgb(15 23 42)";
+		context.lineWidth = 2;
+		context.beginPath();
+		context.moveTo(cursor.x, cursor.y);
+		context.lineTo(cursor.x + 4, cursor.y + 17);
+		context.lineTo(cursor.x + 8, cursor.y + 12);
+		context.lineTo(cursor.x + 14, cursor.y + 13);
+		context.closePath();
+		context.fill();
+		context.stroke();
+	}
+	context.restore();
+};
+
+const pngBase64ToFile = (base64: string, name: string): File => {
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index += 1)
+		bytes[index] = binary.charCodeAt(index);
 	return new File([bytes], name, { type: "image/png" });
+};
+
+const compositeBrowserImage = async (
+	dataUrl: string,
+	bounds: DOMRect,
+	shapes: ReadonlyArray<BrowserOverlayShape>,
+	cursor: AgentCursorIntent | null,
+): Promise<string> => {
+	if (shapes.length === 0 && cursor === null)
+		return dataUrl.replace(/^data:image\/png;base64,/, "");
+	const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+		const element = new Image();
+		element.onload = () => resolve(element);
+		element.onerror = () =>
+			reject(new Error("Could not composite the browser screenshot."));
+		element.src = dataUrl;
+	});
+	const canvas = document.createElement("canvas");
+	canvas.width = image.naturalWidth;
+	canvas.height = image.naturalHeight;
+	const context = canvas.getContext("2d", { alpha: false });
+	if (context === null)
+		throw new Error("Screenshot compositing is unavailable.");
+	context.drawImage(image, 0, 0);
+	drawRecordingDecorations(
+		context,
+		canvas.width,
+		canvas.height,
+		bounds,
+		shapes,
+		cursor,
+	);
+	return canvas.toDataURL("image/png").replace(/^data:image\/png;base64,/, "");
 };
 
 /**
@@ -188,11 +323,57 @@ export function BrowserPane() {
 	// (Click/Type/Hover/Press fall back to the previous synthetic behaviour so
 	// we never silently no-op if the bridge somehow doesn't load).
 	const webContentsIdRef = useRef<number | null>(null);
+	const recordingRef = useRef(new BrowserRecordingController());
+	const actionTimelineRef = useRef<BrowserActionEvent[]>([]);
+	const agentOverlaysRef = useRef<BrowserOverlayShape[]>([]);
+	const cookieStatusRef = useRef<BrowserCookieImportStatus | null>(null);
+	const domainGrantsRef = useRef(new Set<string>());
 	const [url, setUrl] = useState<string>("");
 	const [inputValue, setInputValue] = useState<string>("");
 	const [canGoBack, setCanGoBack] = useState(false);
 	const [canGoForward, setCanGoForward] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
+	const [recordingState, setRecordingState] = useState<
+		"idle" | "starting" | "recording" | "stopping"
+	>("idle");
+	const [lastRecording, setLastRecording] =
+		useState<BrowserRecordingArtifact | null>(null);
+	const [agentOverlays, setAgentOverlays] = useState<BrowserOverlayShape[]>([]);
+	const [cookieStatus, setCookieStatus] =
+		useState<BrowserCookieImportStatus | null>(null);
+	const [cookieImportBusy, setCookieImportBusy] = useState(false);
+	const [nativeCredentialCapability, setNativeCredentialCapability] = useState<{
+		supported: boolean;
+		reason?: string;
+	} | null>(null);
+	const [passwordFieldOrigin, setPasswordFieldOrigin] = useState<string | null>(
+		null,
+	);
+	const [nativeCredentialBusy, setNativeCredentialBusy] = useState(false);
+	const [nativeCredentialError, setNativeCredentialError] = useState<
+		string | null
+	>(null);
+	const [domainGrantVersion, setDomainGrantVersion] = useState(0);
+	const [domainAccessRequest, setDomainAccessRequest] = useState<{
+		domain: string;
+		sessionId: string;
+		resolve: (allowed: boolean) => void;
+	} | null>(null);
+	const [viewport, setViewport] = useState<BrowserViewportSetting>(() => {
+		try {
+			const raw = localStorage.getItem("zuse.browser.viewport.v1");
+			return raw === null
+				? DEFAULT_VIEWPORT
+				: {
+						...DEFAULT_VIEWPORT,
+						...(JSON.parse(raw) as Partial<BrowserViewportSetting>),
+					};
+		} catch {
+			return DEFAULT_VIEWPORT;
+		}
+	});
+	const viewportRef = useRef(viewport);
+	const loadingRef = useRef(isLoading);
 	// Bumped each time the agent takes a screenshot — drives the shutter flash.
 	const [shutterNonce, setShutterNonce] = useState(0);
 	// The current "intent" for the agent cursor overlay. Bumped on every
@@ -203,6 +384,7 @@ export function BrowserPane() {
 		null,
 	);
 	const cursorNonceRef = useRef(0);
+	const cursorIntentRef = useRef<AgentCursorIntent | null>(null);
 	const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
 	const addBrowserAnnotation = useAnnotationsStore((s) => s.addBrowser);
 	const uploadAttachment = useAttachmentsStore((s) => s.uploadOne);
@@ -233,6 +415,229 @@ export function BrowserPane() {
 		...regions.map((region) => region.rect),
 		...strokes.map((stroke) => stroke.bounds),
 	]);
+	const displayedCookieStatus: BrowserCookieImportStatus = cookieStatus ?? {
+		supported: false,
+		importedDomainCount: 0,
+		importedCookieCount: 0,
+		importedDomains: [],
+		message: "Browser session import is initializing.",
+	};
+
+	useEffect(() => {
+		viewportRef.current = viewport;
+		localStorage.setItem("zuse.browser.viewport.v1", JSON.stringify(viewport));
+	}, [viewport]);
+	useEffect(() => {
+		loadingRef.current = isLoading;
+	}, [isLoading]);
+
+	useEffect(() => {
+		let cancelled = false;
+		void window.zuse?.browser
+			?.getNativeCredentialCapability?.()
+			.then((capability) => {
+				if (!cancelled) setNativeCredentialCapability(capability);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!hasLoadedPage) {
+			setPasswordFieldOrigin(null);
+			return;
+		}
+		let cancelled = false;
+		const inspectFocus = async () => {
+			const wv = webviewRef.current as WebviewElement | null;
+			if (wv === null) return;
+			try {
+				const focused = (await wv.executeJavaScript(
+					`(() => { const active = document.activeElement; return active instanceof HTMLInputElement && active.type === 'password' ? location.origin : null; })()`,
+				)) as unknown;
+				if (!cancelled)
+					setPasswordFieldOrigin(typeof focused === "string" ? focused : null);
+			} catch {
+				if (!cancelled) setPasswordFieldOrigin(null);
+			}
+		};
+		void inspectFocus();
+		const interval = window.setInterval(() => void inspectFocus(), 500);
+		return () => {
+			cancelled = true;
+			window.clearInterval(interval);
+		};
+	}, [hasLoadedPage]);
+	useEffect(() => {
+		cursorIntentRef.current = cursorIntent;
+	}, [cursorIntent]);
+
+	useEffect(
+		() => () => {
+			if (recordingRef.current.state !== "idle")
+				void recordingRef.current.stop().catch(() => {});
+		},
+		[],
+	);
+
+	useEffect(() => {
+		const subscribe = window.zuse?.browser?.onScreencastInterrupted;
+		if (subscribe === undefined) return;
+		return subscribe((webContentsId) => {
+			if (
+				webContentsIdRef.current !== webContentsId ||
+				recordingRef.current.state === "idle"
+			)
+				return;
+			setRecordingState("stopping");
+			void recordingRef.current
+				.stop()
+				.then((artifact) => setLastRecording(artifact))
+				.finally(() => setRecordingState("idle"));
+		});
+	}, []);
+
+	useEffect(() => {
+		const element = webviewRef.current;
+		if (element === null || typeof ResizeObserver === "undefined") return;
+		const observer = new ResizeObserver((entries) => {
+			const box = entries[0]?.contentRect;
+			if (
+				box === undefined ||
+				(box.width > 0 && box.height > 0) ||
+				recordingRef.current.state === "idle"
+			)
+				return;
+			setRecordingState("stopping");
+			void recordingRef.current
+				.stop()
+				.then((artifact) => {
+					setLastRecording(artifact);
+					setRecordingState("idle");
+				})
+				.catch(() => setRecordingState("idle"));
+		});
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		void window.zuse?.browser
+			?.getCookieImportStatus?.()
+			.then((status) => {
+				if (cancelled) return;
+				cookieStatusRef.current = status;
+				setCookieStatus(status);
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const runCookieImport = async () => {
+		setCookieImportBusy(true);
+		try {
+			const status = await window.zuse?.browser?.importCookies?.();
+			if (status === undefined)
+				throw new Error("Browser session import is unavailable in this build.");
+			cookieStatusRef.current = status;
+			setCookieStatus(status);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(message);
+		} finally {
+			setCookieImportBusy(false);
+		}
+	};
+
+	const clearImportedCookies = async () => {
+		setCookieImportBusy(true);
+		try {
+			const status = await window.zuse?.browser?.clearImportedCookies?.();
+			if (status === undefined)
+				throw new Error(
+					"Imported-session controls are unavailable in this build.",
+				);
+			cookieStatusRef.current = status;
+			setCookieStatus(status);
+			domainGrantsRef.current.clear();
+			setDomainGrantVersion(0);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(message);
+		} finally {
+			setCookieImportBusy(false);
+		}
+	};
+
+	const clearBrowsingData = async () => {
+		setCookieImportBusy(true);
+		try {
+			const status = await window.zuse?.browser?.clearBrowsingData?.();
+			if (status === undefined)
+				throw new Error("Clearing browser data is unavailable in this build.");
+			cookieStatusRef.current = status;
+			setCookieStatus(status);
+			domainGrantsRef.current.clear();
+			setDomainGrantVersion(0);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(message);
+		} finally {
+			setCookieImportBusy(false);
+		}
+	};
+
+	const requestAgentDomainAccess = async (
+		req: BrowserCommandRequest,
+		wv: WebviewElement | null,
+		resolvedCandidate?: string,
+	): Promise<boolean> => {
+		let status = cookieStatusRef.current;
+		if (status === null) {
+			const loadStatus = window.zuse?.browser?.getCookieImportStatus;
+			if (loadStatus === undefined) return false;
+			try {
+				status = await loadStatus();
+				cookieStatusRef.current = status;
+				setCookieStatus(status);
+			} catch {
+				return false;
+			}
+		}
+		if (status.importedDomains.length === 0) return true;
+		let candidate =
+			resolvedCandidate ?? (wv === null ? "" : safeCall(() => wv.getURL(), ""));
+		if (resolvedCandidate === undefined && req.command._tag === "Navigate") {
+			candidate =
+				req.command.environmentPort !== undefined &&
+				req.command.url.startsWith("/")
+					? `${req.command.environmentProtocol ?? "http"}://localhost:${req.command.environmentPort}${req.command.url}`
+					: req.command.url;
+		}
+		let host: string;
+		try {
+			host = new URL(resolveUrl(candidate) ?? candidate).hostname;
+		} catch {
+			return true;
+		}
+		const importedDomain = status.importedDomains.find(
+			(domain) => host === domain || host.endsWith(`.${domain}`),
+		);
+		if (importedDomain === undefined) return true;
+		const key = `${req.sessionId}:${importedDomain}`;
+		if (domainGrantsRef.current.has(key)) return true;
+		return new Promise<boolean>((resolve) =>
+			setDomainAccessRequest({
+				domain: importedDomain,
+				sessionId: String(req.sessionId),
+				resolve,
+			}),
+		);
+	};
 
 	useEffect(() => {
 		let cancelled = false;
@@ -388,27 +793,132 @@ export function BrowserPane() {
 			// works (it returns an empty image for a `display:none` element).
 			useUiStore.getState().revealPanel("browser");
 			const wv = webviewRef.current as WebviewElement | null;
-			const result = await runBrowserCommand(req, wv, {
+			const accessAllowed = await requestAgentDomainAccess(req, wv);
+			if (!accessAllowed) {
+				const result = BrowserCommandResult.make({
+					id: req.id,
+					ok: false,
+					error:
+						"Access to this imported authenticated domain was denied for the current task.",
+				});
+				try {
+					const client = await getRpcClient();
+					await Effect.runPromise(client["browser.respond"]({ result }));
+				} catch {}
+				return;
+			}
+			const action: BrowserActionEvent = {
+				id: req.id,
+				command: req.command._tag,
+				state: "running",
+				startedAt: new Date().toISOString(),
+			};
+			actionTimelineRef.current = [
+				...actionTimelineRef.current.slice(-98),
+				action,
+			];
+			let result = await runBrowserCommand(req, wv, {
 				setUrl,
 				setInputValue,
 				flashShutter: () => setShutterNonce((n) => n + 1),
 				readConsole: () => consoleBufferRef.current.join("\n"),
 				moveCursor: (x, y, opts) => {
 					cursorNonceRef.current += 1;
-					setCursorIntent({
+					const intent = {
 						nonce: cursorNonceRef.current,
 						x,
 						y,
 						click: opts?.click === true,
 						pressed: opts?.pressed === true,
-					});
+					};
+					cursorIntentRef.current = intent;
+					setCursorIntent(intent);
 				},
 				getWebContentsId: () => webContentsIdRef.current,
 				getRefStore: () => refStoreRef.current,
 				setRefStore: (store) => {
 					refStoreRef.current = store;
 				},
+				getLoading: () => loadingRef.current,
+				getViewport: () => viewportRef.current,
+				setViewport: (next) => {
+					viewportRef.current = next;
+					setViewport(next);
+				},
+				getRecordingState: () => recordingRef.current.state,
+				startRecording: async () => {
+					if (wv === null)
+						throw new Error("The browser surface is unavailable.");
+					setRecordingState("starting");
+					await recordingRef.current.start({
+						capturePage: () => wv.capturePage(),
+						getBoundingClientRect: () => wv.getBoundingClientRect(),
+						subscribeFrames: async (handler) => {
+							const bridge = window.zuse?.browser;
+							const id = webContentsIdRef.current;
+							if (
+								id === null ||
+								bridge?.startScreencast === undefined ||
+								bridge.stopScreencast === undefined ||
+								bridge.onScreencastFrame === undefined
+							)
+								throw new Error("CDP screencast is unavailable.");
+							const unsubscribe = bridge.onScreencastFrame((frame) => {
+								if (frame.webContentsId === id)
+									handler(`data:image/jpeg;base64,${frame.data}`);
+							});
+							if (!(await bridge.startScreencast(id))) {
+								unsubscribe();
+								throw new Error("CDP screencast could not start.");
+							}
+							return async () => {
+								unsubscribe();
+								await bridge.stopScreencast?.(id);
+							};
+						},
+						drawDecorations: (context, width, height) =>
+							drawRecordingDecorations(
+								context,
+								width,
+								height,
+								wv.getBoundingClientRect(),
+								agentOverlaysRef.current,
+								cursorIntentRef.current,
+							),
+					});
+					setRecordingState("recording");
+				},
+				stopRecording: async () => {
+					setRecordingState("stopping");
+					const artifact = await recordingRef.current.stop();
+					setRecordingState("idle");
+					setLastRecording(artifact);
+					return artifact;
+				},
+				getTimeline: () => actionTimelineRef.current,
+				getOverlays: () => agentOverlaysRef.current,
+				getCursor: () => cursorIntentRef.current,
+				setOverlays: (next) => {
+					agentOverlaysRef.current = next;
+					setAgentOverlays(next);
+				},
 			});
+			if (
+				result.ok &&
+				req.command._tag === "Navigate" &&
+				result.url !== undefined &&
+				!(await requestAgentDomainAccess(req, wv, result.url))
+			) {
+				result = BrowserCommandResult.make({
+					id: req.id,
+					ok: false,
+					error:
+						"The navigation redirected to an imported authenticated domain that was not approved for this task.",
+				});
+			}
+			action.state = result.ok ? "succeeded" : "failed";
+			action.finishedAt = new Date().toISOString();
+			if (!result.ok) action.error = result.error;
 			try {
 				const client = await getRpcClient();
 				await Effect.runPromise(client["browser.respond"]({ result }));
@@ -468,6 +978,111 @@ export function BrowserPane() {
 			else wv.reload();
 		} catch {
 			// ignore
+		}
+	};
+
+	const changeViewportMode = (mode: BrowserViewportMode) => {
+		setViewport((current) => {
+			if (mode === "fill" || mode === "custom") return { ...current, mode };
+			const preset = VIEWPORT_PRESETS[mode];
+			const portrait = current.orientation === "portrait";
+			return {
+				...current,
+				mode,
+				width: portrait
+					? Math.min(preset.width, preset.height)
+					: Math.max(preset.width, preset.height),
+				height: portrait
+					? Math.max(preset.width, preset.height)
+					: Math.min(preset.width, preset.height),
+			};
+		});
+	};
+
+	const updateViewportDimension = (
+		axis: "width" | "height",
+		rawValue: number,
+	) => {
+		if (!Number.isFinite(rawValue)) return;
+		setViewport((current) => {
+			const widthLimit = (value: number) =>
+				Math.max(240, Math.min(2560, value));
+			const heightLimit = (value: number) =>
+				Math.max(240, Math.min(1600, value));
+			if (axis === "width") {
+				const width = widthLimit(Math.round(rawValue));
+				return {
+					...current,
+					mode: "custom",
+					width,
+					height: current.lockAspectRatio
+						? heightLimit(Math.round(width / (current.width / current.height)))
+						: current.height,
+				};
+			}
+			const height = heightLimit(Math.round(rawValue));
+			return {
+				...current,
+				mode: "custom",
+				height,
+				width: current.lockAspectRatio
+					? widthLimit(Math.round(height * (current.width / current.height)))
+					: current.width,
+			};
+		});
+	};
+
+	const beginViewportResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		const startX = event.clientX;
+		const startY = event.clientY;
+		const initial = viewportRef.current;
+		const onMove = (moveEvent: PointerEvent) => {
+			const width = initial.width + moveEvent.clientX - startX;
+			const height = initial.height + moveEvent.clientY - startY;
+			if (initial.lockAspectRatio) {
+				updateViewportDimension("width", width);
+			} else {
+				setViewport((current) => ({
+					...current,
+					mode: "custom",
+					width: Math.max(240, Math.min(2560, Math.round(width))),
+					height: Math.max(240, Math.min(1600, Math.round(height))),
+				}));
+			}
+		};
+		const onUp = () => {
+			window.removeEventListener("pointermove", onMove);
+			window.removeEventListener("pointerup", onUp);
+		};
+		window.addEventListener("pointermove", onMove);
+		window.addEventListener("pointerup", onUp, { once: true });
+	};
+
+	const fillNativeCredential = async (submit = false) => {
+		const wv = webviewRef.current as WebviewElement | null;
+		const bridge = window.zuse?.browser;
+		if (
+			wv === null ||
+			passwordFieldOrigin === null ||
+			bridge?.fillNativeCredential === undefined
+		)
+			return { ok: false, error: "The password field is no longer available." };
+		setNativeCredentialBusy(true);
+		setNativeCredentialError(null);
+		try {
+			const result = await bridge.fillNativeCredential(
+				wv.getWebContentsId(),
+				passwordFieldOrigin,
+				submit,
+			);
+			if (!result.ok)
+				setNativeCredentialError(
+					result.error ?? "The password could not be filled.",
+				);
+			return result;
+		} finally {
+			setNativeCredentialBusy(false);
 		}
 	};
 
@@ -668,9 +1283,41 @@ export function BrowserPane() {
 		}
 		setAttachingAnnotation(true);
 		try {
+			const pagePosition = (await wv
+				.executeJavaScript(
+					`(() => ({ scrollX, scrollY, deviceScaleFactor: devicePixelRatio || 1 }))()`,
+				)
+				.catch(() => ({ scrollX: 0, scrollY: 0, deviceScaleFactor: 1 }))) as {
+				scrollX: number;
+				scrollY: number;
+				deviceScaleFactor: number;
+			};
 			const image = await wv.capturePage();
-			const file = await nativeImageToFile(
-				image,
+			const humanShapes: BrowserOverlayShape[] = [
+				...pickedElements.map((element) => ({
+					_tag: "Rectangle" as const,
+					id: element.id,
+					...element.rect,
+				})),
+				...regions.map((region) => ({
+					_tag: "Rectangle" as const,
+					id: region.id,
+					...region.rect,
+				})),
+				...strokes.map((stroke) => ({
+					_tag: "Freehand" as const,
+					id: stroke.id,
+					points: [...stroke.points],
+				})),
+			];
+			const base64 = await compositeBrowserImage(
+				image.toDataURL(),
+				wv.getBoundingClientRect(),
+				[...agentOverlays, ...humanShapes],
+				null,
+			);
+			const file = pngBase64ToFile(
+				base64,
 				`browser-annotation-${Date.now()}.png`,
 			);
 			const screenshotAttachment = await uploadAttachment(
@@ -684,6 +1331,21 @@ export function BrowserPane() {
 				elements: pickedElements.map(({ id: _id, ...element }) => element),
 				regions,
 				strokes,
+				overlays: agentOverlays,
+				viewport: {
+					mode: viewport.mode,
+					width:
+						viewport.mode === "fill"
+							? Math.round(wv.getBoundingClientRect().width)
+							: viewport.width,
+					height:
+						viewport.mode === "fill"
+							? Math.round(wv.getBoundingClientRect().height)
+							: viewport.height,
+					scrollX: pagePosition.scrollX,
+					scrollY: pagePosition.scrollY,
+					deviceScaleFactor: pagePosition.deviceScaleFactor,
+				},
 				screenshotAttachment,
 			});
 			resetAnnotationDraft();
@@ -742,6 +1404,96 @@ export function BrowserPane() {
 					spellCheck={false}
 					className="flex-1 rounded bg-transparent px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/70 focus:bg-muted/40"
 				/>
+				<select
+					value={viewport.mode}
+					onChange={(event) =>
+						changeViewportMode(event.target.value as BrowserViewportMode)
+					}
+					aria-label="Browser viewport"
+					className="h-8 rounded-md border border-border/70 bg-background px-2 text-[11px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+				>
+					<option value="fill">Fill</option>
+					<option value="phone">Phone</option>
+					<option value="tablet">Tablet</option>
+					<option value="laptop">Laptop</option>
+					<option value="desktop">Desktop</option>
+					<option value="custom">Custom</option>
+				</select>
+				{viewport.mode === "custom" ? (
+					<div className="flex h-8 items-center rounded-md border border-border/70 bg-background">
+						<input
+							type="number"
+							min={240}
+							max={2560}
+							value={viewport.width}
+							onChange={(event) =>
+								updateViewportDimension("width", event.target.valueAsNumber)
+							}
+							aria-label="Viewport width"
+							className="h-full w-14 bg-transparent px-1 text-center text-[11px] tabular-nums outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+						/>
+						<span className="text-[10px] text-muted-foreground">×</span>
+						<input
+							type="number"
+							min={240}
+							max={1600}
+							value={viewport.height}
+							onChange={(event) =>
+								updateViewportDimension("height", event.target.valueAsNumber)
+							}
+							aria-label="Viewport height"
+							className="h-full w-14 bg-transparent px-1 text-center text-[11px] tabular-nums outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+						/>
+						<button
+							type="button"
+							aria-pressed={viewport.lockAspectRatio}
+							aria-label="Lock viewport aspect ratio"
+							onClick={() =>
+								setViewport((current) => ({
+									...current,
+									lockAspectRatio: !current.lockAspectRatio,
+								}))
+							}
+							className={`h-full px-2 text-[10px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${viewport.lockAspectRatio ? "text-primary" : "text-muted-foreground"}`}
+						>
+							Ratio
+						</button>
+					</div>
+				) : null}
+				{viewport.mode !== "fill" ? (
+					<button
+						type="button"
+						onClick={() =>
+							setViewport((current) => ({
+								...current,
+								width: current.height,
+								height: current.width,
+								orientation:
+									current.orientation === "portrait" ? "landscape" : "portrait",
+							}))
+						}
+						className="h-8 rounded-md px-2 text-[11px] tabular-nums text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+						aria-label="Rotate browser viewport"
+					>
+						{viewport.width}×{viewport.height}
+					</button>
+				) : null}
+				{recordingState !== "idle" ? (
+					<span
+						className="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-red-600"
+						aria-live="polite"
+					>
+						<span className="size-2 rounded-full bg-red-500" />
+						{recordingState === "recording" ? "Recording" : recordingState}
+					</span>
+				) : lastRecording !== null ? (
+					<span
+						className="max-w-24 truncate text-[10px] text-muted-foreground"
+						title={lastRecording.id}
+					>
+						Saved
+					</span>
+				) : null}
 				<ToolbarButton
 					onClick={() => {
 						if (!hasLoadedPage) return;
@@ -766,60 +1518,384 @@ export function BrowserPane() {
 				>
 					<Camera className="size-3.5" strokeWidth={1.8} />
 				</ToolbarButton>
+				<BrowserSettingsMenu
+					status={displayedCookieStatus}
+					credentialCapability={nativeCredentialCapability}
+					busy={cookieImportBusy}
+					domainGrantCount={domainGrantVersion}
+					onImport={runCookieImport}
+					onClearImported={clearImportedCookies}
+					onClearBrowsingData={clearBrowsingData}
+					onRevokeTaskAccess={() => {
+						domainGrantsRef.current.clear();
+						setDomainGrantVersion(0);
+					}}
+				/>
 			</form>
-			<div className="relative min-h-0 flex-1">
+			{passwordFieldOrigin !== null ? (
+				<section
+					className="flex min-h-8 shrink-0 items-center gap-2 border-b border-border/70 bg-card/80 px-3 py-1 text-xs"
+					aria-label="Password autofill"
+				>
+					<div className="min-w-0 flex-1">
+						<p className="font-medium text-foreground">
+							Password field detected
+						</p>
+						<p className="truncate text-muted-foreground">
+							{nativeCredentialError ??
+								nativeCredentialCapability?.reason ??
+								`Use the system password picker for ${passwordFieldOrigin}.`}
+						</p>
+					</div>
+					<button
+						type="button"
+						disabled={
+							nativeCredentialBusy ||
+							nativeCredentialCapability?.supported !== true
+						}
+						className="h-8 rounded-md bg-primary px-2.5 font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
+						onClick={() => void fillNativeCredential()}
+					>
+						{nativeCredentialBusy
+							? "Opening Passwords…"
+							: "Fill from Passwords"}
+					</button>
+				</section>
+			) : null}
+			{domainAccessRequest !== null ? (
+				<section
+					className="shrink-0 border-b border-border/70 bg-card/80 px-3 py-2 text-xs"
+					aria-label="Browser session access"
+				>
+					<div className="flex flex-wrap items-center gap-2">
+						<div className="min-w-0 flex-1">
+							<p className="font-medium text-foreground">
+								Allow this task to use the signed-in session for{" "}
+								{domainAccessRequest.domain}?
+							</p>
+							<p className="mt-0.5 text-muted-foreground">
+								The grant stays in memory and applies only to this task and
+								domain.
+							</p>
+						</div>
+						<button
+							type="button"
+							className="h-8 rounded-md border border-border px-2.5 font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+							onClick={() => {
+								domainAccessRequest.resolve(false);
+								setDomainAccessRequest(null);
+							}}
+						>
+							Deny
+						</button>
+						<button
+							type="button"
+							className="h-8 rounded-md bg-primary px-2.5 font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+							onClick={() => {
+								domainGrantsRef.current.add(
+									`${domainAccessRequest.sessionId}:${domainAccessRequest.domain}`,
+								);
+								setDomainGrantVersion((value) => value + 1);
+								domainAccessRequest.resolve(true);
+								setDomainAccessRequest(null);
+							}}
+						>
+							Allow for task
+						</button>
+					</div>
+				</section>
+			) : null}
+			<div className="relative flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted/20">
 				{!hasLoadedPage ? (
 					<BrowserEmptyState servers={localServers} onOpen={navigate} />
 				) : null}
-				<webview
-					ref={webviewRef as unknown as React.RefObject<HTMLElement>}
-					// src is intentionally NOT bound to `url` state. All navigation is
-					// imperative (loadURL); if src tracked state, every navigation would
-					// fire twice — once from loadURL, once from React re-setting the
-					// attribute — and the loads abort each other (ERR_ABORTED -3, agent
-					// navigations intermittently reporting about:blank).
-					src="about:blank"
-					{...({ allowpopups: "true" } as Record<string, string>)}
+				<div
+					className="relative shrink-0 overflow-hidden bg-background shadow-sm"
 					style={{
-						display: !hasLoadedPage ? "none" : "flex",
-						width: "100%",
-						height: "100%",
+						width: viewport.mode === "fill" ? "100%" : `${viewport.width}px`,
+						height: viewport.mode === "fill" ? "100%" : `${viewport.height}px`,
 					}}
-				/>
-				{annotating && hasLoadedPage ? (
-					<BrowserAnnotationOverlay
-						tool={annotationTool}
-						setTool={setAnnotationTool}
-						hoverPick={hoverPick}
-						elements={pickedElements}
-						regions={regions}
-						strokes={strokes}
-						dragRect={dragRect}
-						activeStroke={activeStroke}
-						bounds={annotationBounds}
-						comment={annotationComment}
-						setComment={setAnnotationComment}
-						canAttach={
-							selectedSessionId !== null &&
-							hasAnnotationTargets &&
-							annotationComment.trim().length > 0
-						}
-						attaching={attachingAnnotation}
-						onAttach={() => void attachBrowserAnnotation()}
-						onCancel={() => {
-							resetAnnotationDraft();
-							setAnnotating(false);
+				>
+					<webview
+						ref={webviewRef as unknown as React.RefObject<HTMLElement>}
+						// src is intentionally NOT bound to `url` state. All navigation is
+						// imperative (loadURL); if src tracked state, every navigation would
+						// fire twice — once from loadURL, once from React re-setting the
+						// attribute — and the loads abort each other (ERR_ABORTED -3, agent
+						// navigations intermittently reporting about:blank).
+						src="about:blank"
+						{...({
+							allowpopups: "true",
+							partition: "persist:zuse-browser",
+						} as Record<string, string>)}
+						style={{
+							display: !hasLoadedPage ? "none" : "flex",
+							width: "100%",
+							height: "100%",
 						}}
-						onPointerDown={handleAnnotationPointerDown}
-						onPointerMove={handleAnnotationPointerMove}
-						onPointerUp={handleAnnotationPointerUp}
 					/>
-				) : null}
-				<AgentCursor intent={cursorIntent} visible={hasLoadedPage} />
-				<BrowserShutter nonce={shutterNonce} />
+					<BrowserAgentOverlay shapes={agentOverlays} />
+					{viewport.mode !== "fill" ? (
+						<button
+							type="button"
+							onPointerDown={beginViewportResize}
+							aria-label="Resize browser viewport"
+							className="absolute bottom-0 right-0 z-30 size-8 cursor-nwse-resize touch-none bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 after:absolute after:bottom-1 after:right-1 after:size-3 after:border-b-2 after:border-r-2 after:border-muted-foreground/60"
+						/>
+					) : null}
+					{annotating && hasLoadedPage ? (
+						<BrowserAnnotationOverlay
+							tool={annotationTool}
+							setTool={setAnnotationTool}
+							hoverPick={hoverPick}
+							elements={pickedElements}
+							regions={regions}
+							strokes={strokes}
+							dragRect={dragRect}
+							activeStroke={activeStroke}
+							bounds={annotationBounds}
+							comment={annotationComment}
+							setComment={setAnnotationComment}
+							canAttach={
+								selectedSessionId !== null &&
+								hasAnnotationTargets &&
+								annotationComment.trim().length > 0
+							}
+							attaching={attachingAnnotation}
+							onAttach={() => void attachBrowserAnnotation()}
+							onCancel={() => {
+								resetAnnotationDraft();
+								setAnnotating(false);
+							}}
+							onPointerDown={handleAnnotationPointerDown}
+							onPointerMove={handleAnnotationPointerMove}
+							onPointerUp={handleAnnotationPointerUp}
+						/>
+					) : null}
+					<AgentCursor intent={cursorIntent} visible={hasLoadedPage} />
+					<BrowserShutter nonce={shutterNonce} />
+				</div>
 			</div>
 		</div>
 	);
+}
+
+async function loadUntilEvent(
+	wv: WebviewElement,
+	url: string,
+	eventName: "dom-ready" | "did-stop-loading",
+): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			cleanup();
+			reject(new Error(`Timed out waiting for ${eventName}.`));
+		}, 25_000);
+		const done = () => {
+			cleanup();
+			resolve();
+		};
+		const cleanup = () => {
+			clearTimeout(timeout);
+			wv.removeEventListener(eventName, done);
+		};
+		wv.addEventListener(eventName, done, { once: true });
+		try {
+			void wv.loadURL(url).catch((error) => {
+				cleanup();
+				reject(error);
+			});
+		} catch (error) {
+			cleanup();
+			reject(error);
+		}
+	});
+}
+
+async function buildDiagnosticPayload(
+	wv: WebviewElement,
+	hooks: {
+		readConsole: () => string;
+		getWebContentsId: () => number | null;
+		getViewport: () => BrowserViewportSetting;
+		getLoading: () => boolean;
+		getTimeline: () => ReadonlyArray<BrowserActionEvent>;
+		getRecordingState: () => string;
+	},
+	accessibilityTree: string,
+	requestedScreenshot?: "viewport" | "full-page",
+): Promise<Record<string, unknown>> {
+	const visibleTextRaw = await wv
+		.executeJavaScript(
+			`(() => (document.body?.innerText || document.body?.textContent || '').replace(/\n{3,}/g, '\n\n').trim().slice(0, 50000))()`,
+		)
+		.catch(() => "");
+	const wcId = hooks.getWebContentsId();
+	const network =
+		wcId === null
+			? []
+			: await window.zuse?.browser
+					?.getNetwork?.(wcId, {})
+					.then((value) =>
+						value !== null && "requests" in value
+							? value.requests.slice(-200)
+							: [],
+					)
+					.catch(() => []);
+	let payload: Record<string, unknown> = {
+		url: safeCall(() => wv.getURL(), ""),
+		title: safeCall(() => wv.getTitle(), ""),
+		loading: hooks.getLoading(),
+		viewport: hooks.getViewport(),
+		visibleText: typeof visibleTextRaw === "string" ? visibleTextRaw : "",
+		accessibilityTree,
+		console: hooks.readConsole().split("\n").slice(-100),
+		network,
+		actions: hooks.getTimeline().slice(-100),
+		recording: hooks.getRecordingState(),
+		...(requestedScreenshot === undefined
+			? {}
+			: {
+					screenshot: {
+						requested: requestedScreenshot,
+						availableVia: "browser_screenshot",
+					},
+				}),
+	};
+	const structuredBytes = () =>
+		new TextEncoder().encode(JSON.stringify(payload)).byteLength;
+	for (
+		let attempt = 0;
+		attempt < 10 && structuredBytes() > 256 * 1024;
+		attempt++
+	) {
+		payload.truncated = true;
+		payload.visibleText = String(payload.visibleText).slice(
+			0,
+			Math.max(1_000, Math.floor(String(payload.visibleText).length / 2)),
+		);
+		payload.accessibilityTree = String(payload.accessibilityTree).slice(
+			0,
+			Math.max(2_000, Math.floor(String(payload.accessibilityTree).length / 2)),
+		);
+		for (const key of ["console", "network", "actions"] as const) {
+			const entries = payload[key];
+			if (Array.isArray(entries) && entries.length > 5)
+				payload[key] = entries.slice(
+					-Math.max(5, Math.floor(entries.length / 2)),
+				);
+		}
+	}
+	if (structuredBytes() > 256 * 1024) {
+		payload = {
+			url: payload.url,
+			title: payload.title,
+			loading: payload.loading,
+			viewport: payload.viewport,
+			recording: payload.recording,
+			truncated: true,
+			error: "Diagnostic details exceeded the structured-output limit.",
+		};
+	}
+	return payload;
+}
+
+type ResolvedBrowserTarget =
+	| { ok: true; cx: number; cy: number; label: string; selector?: string }
+	| { ok: false; error: string };
+
+async function resolveBrowserTarget(
+	wv: WebviewElement,
+	webContentsId: number | null,
+	store: RefStore,
+	target: BrowserTarget,
+): Promise<ResolvedBrowserTarget> {
+	if (target._tag === "Point") {
+		const bounds = wv.getBoundingClientRect();
+		if (
+			target.x < 0 ||
+			target.y < 0 ||
+			target.x > bounds.width ||
+			target.y > bounds.height
+		) {
+			return { ok: false, error: "Target coordinate is outside the viewport." };
+		}
+		return {
+			ok: true,
+			cx: target.x,
+			cy: target.y,
+			label: `point (${target.x}, ${target.y})`,
+		};
+	}
+	if (target._tag === "Ref") {
+		if (!isValidRef(target.ref))
+			return { ok: false, error: "Invalid snapshot ref." };
+		const resolved = await resolveRefTarget(
+			wv,
+			webContentsId,
+			store,
+			target.ref,
+		);
+		return resolved === null
+			? { ok: false, error: "Snapshot ref is stale — take a new snapshot." }
+			: { ok: true, ...resolved };
+	}
+	const raw = await wv.executeJavaScript(`(() => {
+		const spec = ${JSON.stringify(target)};
+		const visible = (el) => { const r = el.getBoundingClientRect(); const s = getComputedStyle(el); return r.width > 0 && r.height > 0 && s.display !== 'none' && s.visibility !== 'hidden' && Number(s.opacity) !== 0; };
+		const roleOf = (el) => el.getAttribute('role') || ({ A:'link', BUTTON:'button', INPUT: el.type === 'checkbox' ? 'checkbox' : el.type === 'radio' ? 'radio' : 'textbox', TEXTAREA:'textbox', SELECT:'combobox' }[el.tagName] || '');
+		const nameOf = (el) => (el.getAttribute('aria-label') || el.getAttribute('title') || el.getAttribute('placeholder') || el.innerText || el.textContent || '').replace(/\\s+/g, ' ').trim();
+		let matches = [];
+		if (spec._tag === 'Css') { try { matches = Array.from(document.querySelectorAll(spec.selector)); } catch { return { error:'Invalid CSS selector.' }; } }
+		if (spec._tag === 'Text') matches = Array.from(document.querySelectorAll('body *')).filter((el) => { const value = nameOf(el); return spec.exact ? value === spec.text : value.includes(spec.text); });
+		if (spec._tag === 'Role') matches = Array.from(document.querySelectorAll('body *')).filter((el) => { if (roleOf(el).toLowerCase() !== spec.role.toLowerCase()) return false; if (!spec.name) return true; const value = nameOf(el); return spec.exact ? value === spec.name : value.toLowerCase().includes(spec.name.toLowerCase()); });
+		matches = matches.filter(visible);
+		if (matches.length === 0) return { error:'Target was not found or is not visible.' };
+		if (matches.length > 1) return { error:'Target is ambiguous: ' + matches.length + ' visible elements match.' };
+		const el = matches[0];
+		if (el.matches(':disabled,[aria-disabled="true"]')) return { error:'Target is disabled.' };
+		el.scrollIntoView({ block:'center', inline:'center' });
+		const r = el.getBoundingClientRect();
+		const selector = el.id ? '#' + CSS.escape(el.id) : el.tagName.toLowerCase() + (el.getAttribute('name') ? '[name="' + CSS.escape(el.getAttribute('name')) + '"]' : '');
+		return { cx:r.left+r.width/2, cy:r.top+r.height/2, label:nameOf(el).slice(0,80) || el.tagName.toLowerCase(), selector };
+	})()`);
+	if (raw === null || typeof raw !== "object")
+		return { ok: false, error: "The page did not resolve the target." };
+	const value = raw as {
+		error?: string;
+		cx?: number;
+		cy?: number;
+		label?: string;
+		selector?: string;
+	};
+	if (value.error !== undefined) return { ok: false, error: value.error };
+	if (typeof value.cx !== "number" || typeof value.cy !== "number")
+		return { ok: false, error: "Target geometry is unavailable." };
+	return {
+		ok: true,
+		cx: value.cx,
+		cy: value.cy,
+		label: value.label ?? "element",
+		...(value.selector !== undefined ? { selector: value.selector } : {}),
+	};
+}
+
+async function inspectBrowserTarget(
+	wv: WebviewElement,
+	_target: BrowserTarget,
+	resolved: Extract<ResolvedBrowserTarget, { ok: true }>,
+): Promise<unknown> {
+	return wv.executeJavaScript(`(() => {
+		const el = document.elementFromPoint(${JSON.stringify(resolved.cx)}, ${JSON.stringify(resolved.cy)});
+		if (!el) return null;
+		const r = el.getBoundingClientRect(); const s = getComputedStyle(el);
+		return {
+			tagName: el.tagName.toLowerCase(), selector: ${JSON.stringify(resolved.selector ?? null)},
+			attributes: Object.fromEntries(Array.from(el.attributes).slice(0,100).map((a) => [a.name, a.value.slice(0,1000)])),
+			accessible: { role: el.getAttribute('role'), name: el.getAttribute('aria-label') || el.innerText?.trim().slice(0,200) || null, disabled: el.matches(':disabled,[aria-disabled="true"]') },
+			box: { x:r.x, y:r.y, width:r.width, height:r.height, pageX:r.x+scrollX, pageY:r.y+scrollY },
+			styles: { display:s.display, visibility:s.visibility, opacity:s.opacity, position:s.position, zIndex:s.zIndex, color:s.color, backgroundColor:s.backgroundColor, font:s.font }
+		};
+	})()`);
 }
 
 /**
@@ -854,6 +1930,16 @@ async function runBrowserCommand(
 		getRefStore: () => RefStore;
 		/** Replace the ref store after a fresh snapshot. */
 		setRefStore: (store: RefStore) => void;
+		getLoading: () => boolean;
+		getViewport: () => BrowserViewportSetting;
+		setViewport: (setting: BrowserViewportSetting) => void;
+		getRecordingState: () => "idle" | "starting" | "recording" | "stopping";
+		startRecording: () => Promise<void>;
+		stopRecording: () => Promise<BrowserRecordingArtifact>;
+		getTimeline: () => ReadonlyArray<BrowserActionEvent>;
+		getOverlays: () => ReadonlyArray<BrowserOverlayShape>;
+		getCursor: () => AgentCursorIntent | null;
+		setOverlays: (shapes: BrowserOverlayShape[]) => void;
 	},
 ): Promise<BrowserCommandResult> {
 	const fail = (error: string) =>
@@ -864,12 +1950,85 @@ async function runBrowserCommand(
 	const command = req.command;
 	try {
 		switch (command._tag) {
+			case "Status": {
+				const viewport = hooks.getViewport();
+				return BrowserCommandResult.make({
+					id: req.id,
+					ok: true,
+					payload: {
+						available: true,
+						url: safeCall(() => wv.getURL(), ""),
+						title: safeCall(() => wv.getTitle(), ""),
+						loading: hooks.getLoading(),
+						visible:
+							wv.getBoundingClientRect().width > 0 &&
+							wv.getBoundingClientRect().height > 0,
+						viewport,
+						recording: hooks.getRecordingState(),
+						domainAccess: "manual-or-approved",
+						capabilities: {
+							cdp: hooks.getWebContentsId() !== null,
+							accessibility: hooks.getWebContentsId() !== null,
+							network: window.zuse?.browser?.getNetwork !== undefined,
+							inspection: true,
+							evaluation: true,
+							recording: window.zuse?.browser?.saveRecording !== undefined,
+							overlays: true,
+						},
+					},
+				});
+			}
+			case "Resize": {
+				const current = hooks.getViewport();
+				const preset =
+					command.mode === "fill" || command.mode === "custom"
+						? null
+						: VIEWPORT_PRESETS[command.mode];
+				let width = Math.round(command.width ?? preset?.width ?? current.width);
+				let height = Math.round(
+					command.height ?? preset?.height ?? current.height,
+				);
+				width = Math.min(3840, Math.max(240, width));
+				height = Math.min(2160, Math.max(240, height));
+				const orientation = command.orientation ?? current.orientation;
+				if (
+					(orientation === "portrait" && width > height) ||
+					(orientation === "landscape" && height > width)
+				) {
+					[width, height] = [height, width];
+				}
+				const next: BrowserViewportSetting = {
+					mode: command.mode,
+					width,
+					height,
+					orientation,
+					lockAspectRatio: command.lockAspectRatio ?? current.lockAspectRatio,
+				};
+				hooks.setViewport(next);
+				return BrowserCommandResult.make({
+					id: req.id,
+					ok: true,
+					payload: next,
+					detail: `Viewport set to ${command.mode}${command.mode === "fill" ? "" : ` (${width}×${height})`}.`,
+				});
+			}
 			case "Navigate": {
-				const resolved = resolveUrl(command.url);
+				const environmentUrl =
+					command.environmentPort !== undefined && command.url.startsWith("/")
+						? `${command.environmentProtocol ?? "http"}://localhost:${command.environmentPort}${command.url}`
+						: command.url;
+				const resolved = resolveUrl(environmentUrl);
 				if (resolved === null) return fail(`Invalid URL: ${command.url}`);
 				hooks.setUrl(resolved);
 				hooks.setInputValue(resolved);
-				await loadAndWait(wv, resolved);
+				if (command.readiness === "immediate") {
+					void wv.loadURL(resolved).catch(() => {});
+					await delay(0);
+				} else if (command.readiness === "dom-ready") {
+					await loadUntilEvent(wv, resolved, "dom-ready");
+				} else {
+					await loadAndWait(wv, resolved);
+				}
 				return BrowserCommandResult.make({
 					id: req.id,
 					ok: true,
@@ -914,9 +2073,12 @@ async function runBrowserCommand(
 						"Screenshot came back empty — the page may still be loading.",
 					);
 				}
-				const base64 = image
-					.toDataURL()
-					.replace(/^data:image\/png;base64,/, "");
+				const base64 = await compositeBrowserImage(
+					image.toDataURL(),
+					wv.getBoundingClientRect(),
+					hooks.getOverlays(),
+					hooks.getCursor(),
+				);
 				hooks.flashShutter();
 				return BrowserCommandResult.make({
 					id: req.id,
@@ -936,33 +2098,52 @@ async function runBrowserCommand(
 					const built = await buildA11ySnapshot(wcId);
 					if (built !== null) {
 						hooks.setRefStore({ mode: "cdp", map: built.map });
+						const payload = await buildDiagnosticPayload(
+							wv,
+							hooks,
+							built.text,
+							command.screenshot,
+						);
 						return BrowserCommandResult.make({
 							id: req.id,
 							ok: true,
 							url: safeCall(() => wv.getURL(), ""),
 							title: safeCall(() => wv.getTitle(), ""),
 							snapshot: built.text,
+							payload,
 						});
 					}
 				}
 				const raw = await wv.executeJavaScript(SNAPSHOT_JS);
 				hooks.setRefStore({ mode: "dom", map: new Map() });
+				const snapshot =
+					typeof raw === "string" ? raw : JSON.stringify(raw ?? []);
 				return BrowserCommandResult.make({
 					id: req.id,
 					ok: true,
 					url: safeCall(() => wv.getURL(), ""),
 					title: safeCall(() => wv.getTitle(), ""),
-					snapshot: typeof raw === "string" ? raw : JSON.stringify(raw ?? []),
+					snapshot,
+					payload: await buildDiagnosticPayload(
+						wv,
+						hooks,
+						snapshot,
+						command.screenshot,
+					),
 				});
 			}
 			case "Click": {
-				if (!isValidRef(command.ref)) return fail("Invalid element ref.");
 				const wcId = hooks.getWebContentsId();
 				const store = hooks.getRefStore();
-				const target = await resolveRefTarget(wv, wcId, store, command.ref);
-				if (target === null) {
-					return fail("No element with that ref — re-snapshot the page first.");
-				}
+				const spec =
+					command.target ??
+					(command.ref !== undefined
+						? { _tag: "Ref" as const, ref: command.ref }
+						: null);
+				if (spec === null)
+					return fail("Click requires a browser target or snapshot ref.");
+				const target = await resolveBrowserTarget(wv, wcId, store, spec);
+				if (!target.ok) return fail(target.error);
 				// Without CDP attached (preload bridge missing, attach failed) we
 				// can't deliver real input. Fall back to the synthetic click so the
 				// agent still makes progress — the cursor animation still runs so
@@ -973,14 +2154,13 @@ async function runBrowserCommand(
 					(await dispatchClickViaCdp(wcId, target.cx, target.cy));
 				if (!delivered) {
 					if (wcId === null) await delay(CURSOR_GLIDE_MS + 20);
-					const res = await callOnRefElement(
-						wv,
-						wcId,
-						store,
-						command.ref,
-						CLICK_FN,
-						[],
-					);
+					const res =
+						spec._tag === "Ref"
+							? await callOnRefElement(wv, wcId, store, spec.ref, CLICK_FN, [])
+							: await runJsObject(
+									wv,
+									`(() => { const el = document.elementFromPoint(${target.cx}, ${target.cy}); if (!el) return JSON.stringify({ok:false,error:'Target is no longer visible.'}); el.click(); return JSON.stringify({ok:true}); })()`,
+								);
 					if (res === null || !res.ok) {
 						return fail(
 							res?.error ??
@@ -995,14 +2175,18 @@ async function runBrowserCommand(
 				});
 			}
 			case "Type": {
-				if (!isValidRef(command.ref)) return fail("Invalid element ref.");
 				const submit = command.submit === true;
 				const wcId = hooks.getWebContentsId();
 				const store = hooks.getRefStore();
-				const target = await resolveRefTarget(wv, wcId, store, command.ref);
-				if (target === null) {
-					return fail("No element with that ref — re-snapshot first.");
-				}
+				const spec =
+					command.target ??
+					(command.ref !== undefined
+						? { _tag: "Ref" as const, ref: command.ref }
+						: null);
+				if (spec === null)
+					return fail("Type requires a browser target or snapshot ref.");
+				const target = await resolveBrowserTarget(wv, wcId, store, spec);
+				if (!target.ok) return fail(target.error);
 				// Glide the cursor to the field with a click pulse — visually frames
 				// the field activation. Real focus happens via CDP click (or .focus()
 				// when CDP isn't available) so the input shows its native focus ring.
@@ -1016,22 +2200,29 @@ async function runBrowserCommand(
 				// input. Switching to CDP's `Input.insertText` here would regress on
 				// common SPA login forms; the real click above already gave the
 				// field a true focus event.
-				const res = await callOnRefElement(
-					wv,
-					wcId,
-					store,
-					command.ref,
-					FILL_FIELD_FN,
-					[command.text],
-				);
+				const res =
+					spec._tag === "Ref"
+						? await callOnRefElement(wv, wcId, store, spec.ref, FILL_FIELD_FN, [
+								command.text,
+							])
+						: await runJsObject(
+								wv,
+								`(() => { const el = document.elementFromPoint(${target.cx}, ${target.cy}); if (!el) return JSON.stringify({ok:false,error:'Target is no longer visible.'}); return JSON.stringify((${FILL_FIELD_FN}).call(el, ${JSON.stringify(command.text)})); })()`,
+							);
 				if (submit) {
 					if (wcId !== null) {
 						await dispatchKeyTap(wcId, "Enter");
 					} else {
-						await callOnRefElement(wv, wcId, store, command.ref, ENTER_FN, []);
+						if (spec._tag === "Ref")
+							await callOnRefElement(wv, wcId, store, spec.ref, ENTER_FN, []);
+						else
+							await runJsObject(
+								wv,
+								`(() => JSON.stringify((${ENTER_FN}).call(document.elementFromPoint(${target.cx}, ${target.cy}))))()`,
+							);
 					}
 				}
-				return resultFromJs(req.id, res, `Typed into ${command.ref}.`);
+				return resultFromJs(req.id, res, `Typed into ${target.label}.`);
 			}
 			case "Wait": {
 				// Bounded below the bridge's 30s deadline so a hopeless wait comes
@@ -1064,6 +2255,62 @@ async function runBrowserCommand(
 					ok: true,
 					detail: `Waited ${ms}ms.`,
 				});
+			}
+			case "WaitFor": {
+				const timeoutMs = Math.min(
+					Math.max(command.timeoutMs ?? 10_000, 100),
+					25_000,
+				);
+				const started = Date.now();
+				let lastError = "conditions were not met";
+				while (Date.now() - started < timeoutMs) {
+					const failures: string[] = [];
+					if (
+						command.ms !== undefined &&
+						Date.now() - started < Math.max(0, command.ms)
+					)
+						failures.push("delay");
+					if (
+						command.urlIncludes !== undefined &&
+						!safeCall(() => wv.getURL(), "").includes(command.urlIncludes)
+					)
+						failures.push("URL");
+					if (command.loadingComplete === true && hooks.getLoading())
+						failures.push("loading");
+					if (command.selector !== undefined || command.text !== undefined) {
+						const state = await wv.executeJavaScript(
+							`(() => { const selector = ${JSON.stringify(command.selector ?? null)}; const text = ${JSON.stringify(command.text ?? null)}; const visible = (el) => { const r = el.getBoundingClientRect(); const s = getComputedStyle(el); return r.width > 0 && r.height > 0 && s.visibility !== 'hidden' && s.display !== 'none'; }; return { selector: selector === null || Array.from(document.querySelectorAll(selector)).some(visible), text: text === null || (document.body?.innerText || '').includes(text) }; })()`,
+						);
+						const value = state as { selector?: boolean; text?: boolean };
+						if (value.selector !== true) failures.push("selector");
+						if (value.text !== true) failures.push("text");
+					}
+					if (command.target !== undefined) {
+						const target = await resolveBrowserTarget(
+							wv,
+							hooks.getWebContentsId(),
+							hooks.getRefStore(),
+							command.target,
+						);
+						if (!target.ok) failures.push(`target (${target.error})`);
+					}
+					if (failures.length === 0) {
+						return BrowserCommandResult.make({
+							id: req.id,
+							ok: true,
+							payload: {
+								elapsedMs: Date.now() - started,
+								conditions: "all-passed",
+							},
+							detail: "All browser wait conditions passed.",
+						});
+					}
+					lastError = failures.join(", ");
+					await delay(150);
+				}
+				return fail(
+					`Timed out after ${timeoutMs}ms waiting for: ${lastError}.`,
+				);
 			}
 			case "Scroll": {
 				if (typeof command.ref === "string" && command.ref.length > 0) {
@@ -1313,7 +2560,10 @@ async function runBrowserCommand(
 					await delay(120);
 				}
 				if (command.submit === true) {
-					const lastRef = command.fields[command.fields.length - 1]!.ref;
+					const lastField = command.fields.at(-1);
+					if (lastField === undefined)
+						return fail("At least one field is required before submitting.");
+					const lastRef = lastField.ref;
 					if (wcId !== null) {
 						await dispatchKeyTap(wcId, "Enter");
 					} else {
@@ -1424,6 +2674,44 @@ async function runBrowserCommand(
 				});
 			}
 			case "Login": {
+				const activeOrigin = safeCall(() => new URL(wv.getURL()).origin, "");
+				let requestedOrigin: string;
+				try {
+					requestedOrigin = new URL(command.origin).origin;
+				} catch {
+					return fail("Login origin must be an absolute http(s) origin.");
+				}
+				if (requestedOrigin !== activeOrigin) {
+					return fail(
+						`Login origin does not match the active page (${activeOrigin || "no page"}).`,
+					);
+				}
+				const nativeBridge = window.zuse?.browser;
+				const nativeCapability =
+					await nativeBridge?.getNativeCredentialCapability?.();
+				const nativeWebContentsId = hooks.getWebContentsId();
+				if (
+					nativeCapability?.supported === true &&
+					nativeWebContentsId !== null &&
+					nativeBridge?.fillNativeCredential !== undefined
+				) {
+					const nativeResult = await nativeBridge.fillNativeCredential(
+						nativeWebContentsId,
+						activeOrigin,
+						true,
+					);
+					if (nativeResult.ok) {
+						return BrowserCommandResult.make({
+							id: req.id,
+							ok: true,
+							detail: `Filled the system credential for ${activeOrigin} and submitted the login form.`,
+						});
+					}
+					return fail(
+						nativeResult.error ??
+							"The system password picker was cancelled or unavailable.",
+					);
+				}
 				// Pull the dummy secret out-of-band (renderer-only RPC) and inject it
 				// straight into the page. The password never returns to the agent —
 				// only the ok/detail below, which omit it.
@@ -1433,7 +2721,7 @@ async function runBrowserCommand(
 				);
 				if (secret === null) {
 					return fail(
-						`No saved credential for ${command.origin}. Add a dummy login in Settings → Browser.`,
+						`No system or saved test credential is available for ${command.origin}. Sign in manually or add a test login in Settings → Browser.`,
 					);
 				}
 				const res = await runJsObject(
@@ -1441,6 +2729,91 @@ async function runBrowserCommand(
 					`(() => { const U = ${JSON.stringify(secret.username)}; const P = ${JSON.stringify(secret.password)}; const pw = document.querySelector('input[type="password"]'); if (!pw) return JSON.stringify({ ok:false, error:'No password field on this page — navigate to the login form first.' }); let user = document.querySelector('input[autocomplete="username"], input[type="email"], input[name*="user" i], input[name*="email" i], input[id*="user" i], input[id*="email" i]'); if (!user) { user = Array.from(document.querySelectorAll('input')).find((i) => /^(text|email|)$/.test(i.type)) || null; } const setVal = (el, v) => { const proto = el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype; const d = Object.getOwnPropertyDescriptor(proto, 'value'); if (d && d.set) d.set.call(el, v); else el.value = v; el.dispatchEvent(new Event('input', { bubbles:true })); el.dispatchEvent(new Event('change', { bubbles:true })); }; if (user) setVal(user, U); setVal(pw, P); const form = pw.form; if (form && typeof form.requestSubmit === 'function') { try { form.requestSubmit(); return JSON.stringify({ ok:true, detail:'Filled and submitted the login form.' }); } catch (e) {} } pw.dispatchEvent(new KeyboardEvent('keydown', { key:'Enter', keyCode:13, which:13, bubbles:true })); return JSON.stringify({ ok:true, detail:'Filled the saved credentials and pressed Enter.' }); })()`,
 				);
 				return resultFromJs(req.id, res, "Submitted the saved login.");
+			}
+			case "Inspect": {
+				const target = await resolveBrowserTarget(
+					wv,
+					hooks.getWebContentsId(),
+					hooks.getRefStore(),
+					command.target,
+				);
+				if (!target.ok) return fail(target.error);
+				const inspection = await inspectBrowserTarget(
+					wv,
+					command.target,
+					target,
+				);
+				return BrowserCommandResult.make({
+					id: req.id,
+					ok: true,
+					payload: inspection,
+					detail: `Inspected ${target.label}.`,
+				});
+			}
+			case "Evaluate": {
+				if (command.expression.length > 64 * 1024)
+					return fail("JavaScript expression exceeds 64 KiB.");
+				const value = await wv.executeJavaScript(
+					`(async () => { const value = ${command.awaitPromise === true ? "await " : ""}(${command.expression}); return value === undefined ? null : value; })()`,
+				);
+				let encoded: string;
+				try {
+					encoded = JSON.stringify(value);
+				} catch {
+					return fail("Evaluation result is not JSON serializable.");
+				}
+				if (encoded.length > 64 * 1024)
+					return fail("Evaluation result exceeds 64 KiB.");
+				return BrowserCommandResult.make({
+					id: req.id,
+					ok: true,
+					payload: { value },
+					detail: "Evaluation completed.",
+				});
+			}
+			case "RecordingStart": {
+				await hooks.startRecording();
+				return BrowserCommandResult.make({
+					id: req.id,
+					ok: true,
+					payload: { state: "recording", startedAt: new Date().toISOString() },
+					detail: "Browser recording started.",
+				});
+			}
+			case "RecordingStop": {
+				const artifact = await hooks.stopRecording();
+				return BrowserCommandResult.make({
+					id: req.id,
+					ok: true,
+					payload: artifact,
+					detail: "Browser recording saved.",
+				});
+			}
+			case "Overlay": {
+				const previous = [...hooks.getOverlays()];
+				let next = previous;
+				if (command.action === "clear") next = [];
+				if (command.action === "remove" && command.id !== undefined)
+					next = previous.filter((shape) => shape.id !== command.id);
+				if (command.action === "add") {
+					if (command.shape === undefined)
+						return fail("Overlay add requires a shape.");
+					const addedShape = command.shape;
+					next = [
+						...previous.filter((shape) => shape.id !== addedShape.id),
+						addedShape,
+					];
+				}
+				if (command.action === "undo") next = previous.slice(0, -1);
+				if (command.action === "redo")
+					return fail("Nothing to redo in this browser session.");
+				hooks.setOverlays(next);
+				return BrowserCommandResult.make({
+					id: req.id,
+					ok: true,
+					payload: { count: next.length, shapes: next },
+					detail: `Browser overlay now has ${next.length} mark(s).`,
+				});
 			}
 		}
 	} catch (err) {
@@ -1509,8 +2882,18 @@ async function resolveRefTarget(
 		if (!Array.isArray(quads) || quads.length === 0) return null;
 		const q = quads[0] as number[];
 		if (!Array.isArray(q) || q.length < 8) return null;
-		const cx = (q[0]! + q[2]! + q[4]! + q[6]!) / 4;
-		const cy = (q[1]! + q[3]! + q[5]! + q[7]!) / 4;
+		const [
+			x0 = Number.NaN,
+			y0 = Number.NaN,
+			x1 = Number.NaN,
+			y1 = Number.NaN,
+			x2 = Number.NaN,
+			y2 = Number.NaN,
+			x3 = Number.NaN,
+			y3 = Number.NaN,
+		] = q;
+		const cx = (x0 + x1 + x2 + x3) / 4;
+		const cy = (y0 + y1 + y2 + y3) / 4;
 		if (!Number.isFinite(cx) || !Number.isFinite(cy)) return null;
 		return { cx, cy, label: entry.label };
 	}
@@ -1877,7 +3260,8 @@ async function buildA11ySnapshot(webContentsId: number): Promise<{
 	}
 	const root =
 		(nodes as AxNode[]).find((n) => n.parentId === undefined) ??
-		(nodes as AxNode[])[0]!;
+		(nodes as AxNode[])[0];
+	if (root === undefined) return null;
 
 	const map = new Map<string, { backendNodeId: number; label: string }>();
 	const lines: string[] = [];
@@ -1929,11 +3313,11 @@ async function buildA11ySnapshot(webContentsId: number): Promise<{
 					parts.push(lrole);
 					if (name.length > 0) parts.push(` "${name}"`);
 				}
-				if (interactive) {
+				if (interactive && typeof node.backendDOMNodeId === "number") {
 					refCounter += 1;
 					const ref = `e${refCounter}`;
 					map.set(ref, {
-						backendNodeId: node.backendDOMNodeId!,
+						backendNodeId: node.backendDOMNodeId,
 						label: name.length > 0 ? name : lrole,
 					});
 					parts.push(` [ref=${ref}]`);
@@ -2097,6 +3481,110 @@ function loadAndWait(wv: WebviewElement, url: string): Promise<void> {
 	});
 }
 
+function BrowserAgentOverlay({
+	shapes,
+}: {
+	shapes: ReadonlyArray<BrowserOverlayShape>;
+}) {
+	if (shapes.length === 0) return null;
+	return (
+		<svg
+			className="pointer-events-none absolute inset-0 z-[15] h-full w-full overflow-visible"
+			aria-hidden="true"
+		>
+			<defs>
+				<marker
+					id="browser-agent-arrow"
+					markerWidth="8"
+					markerHeight="8"
+					refX="7"
+					refY="4"
+					orient="auto"
+				>
+					<path d="M0,0 L8,4 L0,8 Z" fill="context-stroke" />
+				</marker>
+			</defs>
+			{shapes.map((shape) => {
+				const color = shape.color ?? "rgb(37 99 235)";
+				switch (shape._tag) {
+					case "Rectangle":
+						return (
+							<rect
+								key={shape.id}
+								x={shape.x}
+								y={shape.y}
+								width={shape.width}
+								height={shape.height}
+								fill="none"
+								stroke={color}
+								strokeWidth={3}
+								rx={4}
+							/>
+						);
+					case "Highlight":
+						return (
+							<rect
+								key={shape.id}
+								x={shape.x}
+								y={shape.y}
+								width={shape.width}
+								height={shape.height}
+								fill={color}
+								fillOpacity={0.22}
+								stroke={color}
+								strokeWidth={1}
+								rx={3}
+							/>
+						);
+					case "Arrow":
+						return (
+							<line
+								key={shape.id}
+								x1={shape.fromX}
+								y1={shape.fromY}
+								x2={shape.toX}
+								y2={shape.toY}
+								stroke={color}
+								strokeWidth={3}
+								strokeLinecap="round"
+								markerEnd="url(#browser-agent-arrow)"
+							/>
+						);
+					case "Label":
+						return (
+							<g key={shape.id} transform={`translate(${shape.x} ${shape.y})`}>
+								<rect
+									x={0}
+									y={-22}
+									width={Math.max(44, shape.text.length * 7 + 16)}
+									height={28}
+									rx={6}
+									fill={color}
+								/>
+								<text x={8} y={-4} fill="white" fontSize={12} fontWeight={600}>
+									{shape.text}
+								</text>
+							</g>
+						);
+					case "Freehand":
+						return (
+							<path
+								key={shape.id}
+								d={pathFromPoints(shape.points)}
+								fill="none"
+								stroke={color}
+								strokeWidth={3}
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							/>
+						);
+				}
+				return null;
+			})}
+		</svg>
+	);
+}
+
 function BrowserEmptyState({
 	servers,
 	onOpen,
@@ -2257,7 +3745,10 @@ function BrowserAnnotationOverlay({
 				<AnnotationRect rect={dragRect} label="region" subtle />
 			) : null}
 
-			<svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
+			<svg
+				aria-hidden="true"
+				className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
+			>
 				{strokes.map((stroke) => (
 					<path
 						key={stroke.id}
@@ -2306,7 +3797,6 @@ function BrowserAnnotationOverlay({
 						placeholder="Describe the change..."
 						rows={1}
 						className="min-h-9 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground"
-						autoFocus
 					/>
 					<button
 						type="button"

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -546,6 +546,7 @@ export function BrowserPane() {
 				throw new Error("Browser session import is unavailable in this build.");
 			cookieStatusRef.current = status;
 			setCookieStatus(status);
+			(webviewRef.current as WebviewElement | null)?.reload();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			throw new Error(message);

--- a/apps/renderer/src/components/browser-profile-select.tsx
+++ b/apps/renderer/src/components/browser-profile-select.tsx
@@ -1,0 +1,53 @@
+import type { BrowserCookieImportStatus } from "../lib/bridge.ts";
+import {
+	Select,
+	SelectItem,
+	SelectPopup,
+	SelectTrigger,
+	SelectValue,
+} from "./ui/select.tsx";
+
+export function BrowserProfileSelect({
+	profiles,
+	value,
+	onValueChange,
+	className,
+}: {
+	profiles: BrowserCookieImportStatus["availableProfiles"];
+	value: string | undefined;
+	onValueChange: (value: string | undefined) => void;
+	className?: string;
+}) {
+	const selected =
+		profiles.find((profile) => profile.id === value) ?? profiles[0];
+	return (
+		<Select
+			value={value}
+			onValueChange={(next) =>
+				onValueChange(typeof next === "string" ? next : undefined)
+			}
+		>
+			<SelectTrigger
+				size="sm"
+				className={className}
+				aria-label="Browser profile"
+			>
+				<SelectValue>
+					{selected === undefined
+						? "No supported profile found"
+						: `${selected.source} · ${selected.profile}`}
+				</SelectValue>
+			</SelectTrigger>
+			<SelectPopup>
+				{profiles.map((profile) => (
+					<SelectItem key={profile.id} value={profile.id}>
+						<span className="truncate">
+							{profile.source} · {profile.profile}
+							{profile.isDefault ? " (Default)" : ""}
+						</span>
+					</SelectItem>
+				))}
+			</SelectPopup>
+		</Select>
+	);
+}

--- a/apps/renderer/src/components/browser-settings-menu.tsx
+++ b/apps/renderer/src/components/browser-settings-menu.tsx
@@ -4,12 +4,12 @@ import {
 	EllipsisVertical,
 	KeyRound,
 	Settings,
-	ShieldCheck,
 	Trash2,
 } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 
 import type { BrowserCookieImportStatus } from "../lib/bridge.ts";
+import { BrowserProfileSelect } from "./browser-profile-select.tsx";
 import {
 	AlertDialog,
 	AlertDialogClose,
@@ -36,40 +36,20 @@ import {
 	MenuSeparator,
 	MenuTrigger,
 } from "./ui/menu.tsx";
-import {
-	Select,
-	SelectItem,
-	SelectPopup,
-	SelectTrigger,
-	SelectValue,
-} from "./ui/select.tsx";
-
-type NativeCredentialCapability = {
-	readonly supported: boolean;
-	readonly reason?: string;
-};
-
 export function BrowserSettingsMenu({
 	status,
-	credentialCapability,
 	busy,
-	domainGrantCount,
 	onImport,
-	onClearImported,
 	onClearBrowsingData,
-	onRevokeTaskAccess,
+	onOpenSettings,
 }: {
 	status: BrowserCookieImportStatus;
-	credentialCapability: NativeCredentialCapability | null;
 	busy: boolean;
-	domainGrantCount: number;
 	onImport: (profileId?: string) => Promise<void>;
-	onClearImported: () => Promise<void>;
 	onClearBrowsingData: () => Promise<void>;
-	onRevokeTaskAccess: () => void;
+	onOpenSettings: () => void;
 }) {
 	const [importOpen, setImportOpen] = useState(false);
-	const [settingsOpen, setSettingsOpen] = useState(false);
 	const [clearOpen, setClearOpen] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [selectedProfileId, setSelectedProfileId] = useState<
@@ -91,12 +71,11 @@ export function BrowserSettingsMenu({
 		setSelectedProfileId(
 			status.selectedProfileId ?? status.availableProfiles[0]?.id,
 		);
-		setSettingsOpen(false);
 		setImportOpen(true);
 	};
 	const openSettings = () => {
 		setError(null);
-		setSettingsOpen(true);
+		onOpenSettings();
 	};
 	const openClear = () => {
 		setError(null);
@@ -160,36 +139,12 @@ export function BrowserSettingsMenu({
 					<DialogPanel className="space-y-3 px-4 pb-4 pt-0" scrollFade={false}>
 						<div className="grid grid-cols-[4rem_1fr] items-center gap-2 text-xs">
 							<span className="text-muted-foreground">Browser</span>
-							<Select
+							<BrowserProfileSelect
+								profiles={status.availableProfiles}
 								value={selectedProfileId}
-								onValueChange={(value) =>
-									setSelectedProfileId(
-										typeof value === "string" ? value : undefined,
-									)
-								}
-							>
-								<SelectTrigger
-									size="sm"
-									className="min-w-0 bg-muted/70 shadow-none"
-									aria-label="Browser profile"
-								>
-									<SelectValue>
-										{selectedProfile === undefined
-											? "No supported profile found"
-											: `${selectedProfile.source} · ${selectedProfile.profile}`}
-									</SelectValue>
-								</SelectTrigger>
-								<SelectPopup>
-									{status.availableProfiles.map((profile) => (
-										<SelectItem key={profile.id} value={profile.id}>
-											<span className="truncate">
-												{profile.source} · {profile.profile}
-												{profile.isDefault ? " (Default)" : ""}
-											</span>
-										</SelectItem>
-									))}
-								</SelectPopup>
-							</Select>
+								onValueChange={setSelectedProfileId}
+								className="min-w-0 bg-muted/70 shadow-none"
+							/>
 						</div>
 						<p className="text-[11px] text-muted-foreground">
 							{selectedProfile
@@ -240,88 +195,6 @@ export function BrowserSettingsMenu({
 							}
 						>
 							Import sessions
-						</Button>
-					</DialogFooter>
-				</DialogPopup>
-			</Dialog>
-
-			<Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-				<DialogPopup className="max-w-lg rounded-xl">
-					<DialogHeader className="gap-1 px-4 pb-3 pt-4">
-						<DialogTitle className="text-lg">Browser settings</DialogTitle>
-						<DialogDescription className="text-xs">
-							Sessions, password filling, and agent access.
-						</DialogDescription>
-					</DialogHeader>
-					<DialogPanel className="space-y-4 px-4 pb-4 pt-0" scrollFade={false}>
-						<SettingsGroup title="Imported session">
-							<SettingsRow
-								label="Source"
-								detail={`${status.source ?? "Not detected"} · ${status.profile ?? "No profile"}`}
-								action={
-									<Button size="xs" variant="settings" onClick={openImport}>
-										Import…
-									</Button>
-								}
-							/>
-							<SettingsRow
-								label="Session data"
-								detail={`${status.importedCookieCount} cookies across ${status.importedDomainCount} domains${status.lastImportTime ? ` · ${new Date(status.lastImportTime).toLocaleString()}` : ""}`}
-								action={
-									<Button
-										size="xs"
-										variant="settings"
-										disabled={status.importedCookieCount === 0 || busy}
-										onClick={() => void run(onClearImported)}
-									>
-										Clear
-									</Button>
-								}
-							/>
-						</SettingsGroup>
-
-						<SettingsGroup title="Passwords and autofill">
-							<SettingsRow
-								label="System Passwords"
-								detail={
-									credentialCapability?.supported
-										? "Requested for the active website with system confirmation"
-										: (credentialCapability?.reason ??
-											"Checking system capability…")
-								}
-								action={
-									<ShieldCheck className="size-4 text-muted-foreground" />
-								}
-							/>
-						</SettingsGroup>
-
-						<SettingsGroup title="Agent access">
-							<SettingsRow
-								label="Authenticated domains"
-								detail={`${domainGrantCount} task grant${domainGrantCount === 1 ? "" : "s"} active`}
-								action={
-									<Button
-										size="xs"
-										variant="settings"
-										disabled={domainGrantCount === 0}
-										onClick={onRevokeTaskAccess}
-									>
-										Revoke
-									</Button>
-								}
-							/>
-						</SettingsGroup>
-						{error ? (
-							<p className="text-[11px] text-destructive-foreground">{error}</p>
-						) : null}
-					</DialogPanel>
-					<DialogFooter className="px-4 py-2">
-						<Button
-							size="xs"
-							variant="ghost"
-							onClick={() => setSettingsOpen(false)}
-						>
-							Done
 						</Button>
 					</DialogFooter>
 				</DialogPopup>
@@ -387,50 +260,6 @@ function ImportDataRow({
 					Per site
 				</span>
 			)}
-		</div>
-	);
-}
-
-function SettingsGroup({
-	title,
-	children,
-}: {
-	title: string;
-	children: ReactNode;
-}) {
-	return (
-		<section>
-			<h3 className="mb-1.5 text-[11px] font-medium text-muted-foreground">
-				{title}
-			</h3>
-			<div className="divide-y divide-border/60 rounded-lg bg-muted/45 px-3">
-				{children}
-			</div>
-		</section>
-	);
-}
-
-function SettingsRow({
-	label,
-	detail,
-	action,
-}: {
-	label: string;
-	detail: string;
-	action: ReactNode;
-}) {
-	return (
-		<div className="flex min-h-12 items-center gap-3 py-2">
-			<div className="min-w-0 flex-1">
-				<p className="text-xs font-medium text-foreground">{label}</p>
-				<p
-					className="truncate text-[11px] text-muted-foreground"
-					title={detail}
-				>
-					{detail}
-				</p>
-			</div>
-			{action}
 		</div>
 	);
 }

--- a/apps/renderer/src/components/browser-settings-menu.tsx
+++ b/apps/renderer/src/components/browser-settings-menu.tsx
@@ -1,0 +1,378 @@
+import {
+	Check,
+	Cookie,
+	EllipsisVertical,
+	KeyRound,
+	Settings,
+	ShieldCheck,
+	Trash2,
+} from "lucide-react";
+import { type ReactNode, useState } from "react";
+
+import type { BrowserCookieImportStatus } from "../lib/bridge.ts";
+import {
+	AlertDialog,
+	AlertDialogClose,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogPopup,
+	AlertDialogTitle,
+} from "./ui/alert-dialog.tsx";
+import { Button } from "./ui/button.tsx";
+import {
+	Dialog,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogPanel,
+	DialogPopup,
+	DialogTitle,
+} from "./ui/dialog.tsx";
+import {
+	Menu,
+	MenuItem,
+	MenuPopup,
+	MenuSeparator,
+	MenuTrigger,
+} from "./ui/menu.tsx";
+
+type NativeCredentialCapability = {
+	readonly supported: boolean;
+	readonly reason?: string;
+};
+
+export function BrowserSettingsMenu({
+	status,
+	credentialCapability,
+	busy,
+	domainGrantCount,
+	onImport,
+	onClearImported,
+	onClearBrowsingData,
+	onRevokeTaskAccess,
+}: {
+	status: BrowserCookieImportStatus;
+	credentialCapability: NativeCredentialCapability | null;
+	busy: boolean;
+	domainGrantCount: number;
+	onImport: () => Promise<void>;
+	onClearImported: () => Promise<void>;
+	onClearBrowsingData: () => Promise<void>;
+	onRevokeTaskAccess: () => void;
+}) {
+	const [importOpen, setImportOpen] = useState(false);
+	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [clearOpen, setClearOpen] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const openImport = () => {
+		setError(null);
+		setSettingsOpen(false);
+		setImportOpen(true);
+	};
+	const openSettings = () => {
+		setError(null);
+		setSettingsOpen(true);
+	};
+	const openClear = () => {
+		setError(null);
+		setClearOpen(true);
+	};
+
+	const run = async (
+		operation: () => Promise<void>,
+		onSuccess?: () => void,
+	) => {
+		setError(null);
+		try {
+			await operation();
+			onSuccess?.();
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+		}
+	};
+
+	return (
+		<>
+			<Menu>
+				<MenuTrigger
+					className="flex size-7 items-center justify-center rounded-md text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+					aria-label="Browser menu"
+				>
+					<EllipsisVertical className="size-3.5" />
+				</MenuTrigger>
+				<MenuPopup align="end" className="w-60 rounded-xl">
+					<MenuItem onClick={openImport}>
+						<Cookie />
+						Import browser sessions…
+					</MenuItem>
+					<MenuItem onClick={openSettings}>
+						<KeyRound />
+						Passwords and autofill
+					</MenuItem>
+					<MenuSeparator />
+					<MenuItem onClick={openClear}>
+						<Trash2 />
+						Clear browsing data…
+					</MenuItem>
+					<MenuSeparator />
+					<MenuItem onClick={openSettings}>
+						<Settings />
+						Browser settings
+					</MenuItem>
+				</MenuPopup>
+			</Menu>
+
+			<Dialog open={importOpen} onOpenChange={setImportOpen}>
+				<DialogPopup className="max-w-md rounded-xl">
+					<DialogHeader className="gap-1 px-4 pb-3 pt-4">
+						<DialogTitle className="text-lg">
+							Import from your browser
+						</DialogTitle>
+						<DialogDescription className="text-xs">
+							Bring signed-in sessions into the built-in browser.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogPanel className="space-y-3 px-4 pb-4 pt-0" scrollFade={false}>
+						<div className="grid grid-cols-[4rem_1fr] items-center gap-2 text-xs">
+							<span className="text-muted-foreground">Browser</span>
+							<div className="min-w-0 rounded-md bg-muted/70 px-2.5 py-1.5">
+								<span className="font-medium text-foreground">
+									{status.source ?? "Not detected"}
+								</span>
+								<span className="ml-2 text-muted-foreground">
+									{status.profile ?? "No profile"}
+								</span>
+							</div>
+						</div>
+						<p className="text-[11px] text-muted-foreground">
+							{status.source
+								? `Close ${status.source} completely before importing.`
+								: (status.message ?? "No supported browser profile was found.")}
+						</p>
+						<div className="divide-y divide-border/60 rounded-lg bg-muted/45 px-3">
+							<ImportDataRow
+								icon={<Cookie className="size-3.5" />}
+								label="Cookies and signed-in sessions"
+								detail="Valid cookies from the selected profile"
+							/>
+							<ImportDataRow
+								icon={<KeyRound className="size-3.5" />}
+								label="Passwords"
+								detail="Never imported — requested per site from macOS"
+								enabled={false}
+							/>
+						</div>
+						{error ? (
+							<p className="text-[11px] text-destructive-foreground">{error}</p>
+						) : null}
+					</DialogPanel>
+					<DialogFooter className="px-4 py-2">
+						<Button
+							size="xs"
+							variant="ghost"
+							onClick={() => setImportOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							size="xs"
+							loading={busy}
+							disabled={!status.supported}
+							onClick={() => void run(onImport, () => setImportOpen(false))}
+						>
+							Import sessions
+						</Button>
+					</DialogFooter>
+				</DialogPopup>
+			</Dialog>
+
+			<Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+				<DialogPopup className="max-w-lg rounded-xl">
+					<DialogHeader className="gap-1 px-4 pb-3 pt-4">
+						<DialogTitle className="text-lg">Browser settings</DialogTitle>
+						<DialogDescription className="text-xs">
+							Sessions, password filling, and agent access.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogPanel className="space-y-4 px-4 pb-4 pt-0" scrollFade={false}>
+						<SettingsGroup title="Imported session">
+							<SettingsRow
+								label="Source"
+								detail={`${status.source ?? "Not detected"} · ${status.profile ?? "No profile"}`}
+								action={
+									<Button size="xs" variant="settings" onClick={openImport}>
+										Import…
+									</Button>
+								}
+							/>
+							<SettingsRow
+								label="Session data"
+								detail={`${status.importedCookieCount} cookies across ${status.importedDomainCount} domains${status.lastImportTime ? ` · ${new Date(status.lastImportTime).toLocaleString()}` : ""}`}
+								action={
+									<Button
+										size="xs"
+										variant="settings"
+										disabled={status.importedCookieCount === 0 || busy}
+										onClick={() => void run(onClearImported)}
+									>
+										Clear
+									</Button>
+								}
+							/>
+						</SettingsGroup>
+
+						<SettingsGroup title="Passwords and autofill">
+							<SettingsRow
+								label="System Passwords"
+								detail={
+									credentialCapability?.supported
+										? "Requested for the active website with system confirmation"
+										: (credentialCapability?.reason ??
+											"Checking system capability…")
+								}
+								action={
+									<ShieldCheck className="size-4 text-muted-foreground" />
+								}
+							/>
+						</SettingsGroup>
+
+						<SettingsGroup title="Agent access">
+							<SettingsRow
+								label="Authenticated domains"
+								detail={`${domainGrantCount} task grant${domainGrantCount === 1 ? "" : "s"} active`}
+								action={
+									<Button
+										size="xs"
+										variant="settings"
+										disabled={domainGrantCount === 0}
+										onClick={onRevokeTaskAccess}
+									>
+										Revoke
+									</Button>
+								}
+							/>
+						</SettingsGroup>
+						{error ? (
+							<p className="text-[11px] text-destructive-foreground">{error}</p>
+						) : null}
+					</DialogPanel>
+					<DialogFooter className="px-4 py-2">
+						<Button
+							size="xs"
+							variant="ghost"
+							onClick={() => setSettingsOpen(false)}
+						>
+							Done
+						</Button>
+					</DialogFooter>
+				</DialogPopup>
+			</Dialog>
+
+			<AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+				<AlertDialogPopup className="max-w-sm rounded-xl">
+					<AlertDialogHeader className="gap-1 px-4 pb-3 pt-4">
+						<AlertDialogTitle className="text-lg">
+							Clear browsing data?
+						</AlertDialogTitle>
+						<AlertDialogDescription className="text-xs">
+							This removes cookies, site storage, and cache from the built-in
+							browser. It does not change your other browser.
+						</AlertDialogDescription>
+						{error ? (
+							<p className="text-[11px] text-destructive-foreground">{error}</p>
+						) : null}
+					</AlertDialogHeader>
+					<AlertDialogFooter className="px-4 py-2">
+						<AlertDialogClose render={<Button size="xs" variant="ghost" />}>
+							Cancel
+						</AlertDialogClose>
+						<Button
+							size="xs"
+							variant="destructive"
+							loading={busy}
+							onClick={() =>
+								void run(onClearBrowsingData, () => setClearOpen(false))
+							}
+						>
+							Clear data
+						</Button>
+					</AlertDialogFooter>
+				</AlertDialogPopup>
+			</AlertDialog>
+		</>
+	);
+}
+
+function ImportDataRow({
+	icon,
+	label,
+	detail,
+	enabled = true,
+}: {
+	icon: ReactNode;
+	label: string;
+	detail: string;
+	enabled?: boolean;
+}) {
+	return (
+		<div className="flex min-h-12 items-center gap-2.5 py-2">
+			<span className="text-muted-foreground">{icon}</span>
+			<div className="min-w-0 flex-1">
+				<p className="text-xs font-medium text-foreground">{label}</p>
+				<p className="truncate text-[11px] text-muted-foreground">{detail}</p>
+			</div>
+			{enabled ? (
+				<Check className="size-3.5 text-primary" aria-label="Included" />
+			) : (
+				<span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+					Per site
+				</span>
+			)}
+		</div>
+	);
+}
+
+function SettingsGroup({
+	title,
+	children,
+}: {
+	title: string;
+	children: ReactNode;
+}) {
+	return (
+		<section>
+			<h3 className="mb-1.5 text-[11px] font-medium text-muted-foreground">
+				{title}
+			</h3>
+			<div className="divide-y divide-border/60 rounded-lg bg-muted/45 px-3">
+				{children}
+			</div>
+		</section>
+	);
+}
+
+function SettingsRow({
+	label,
+	detail,
+	action,
+}: {
+	label: string;
+	detail: string;
+	action: ReactNode;
+}) {
+	return (
+		<div className="flex min-h-12 items-center gap-3 py-2">
+			<div className="min-w-0 flex-1">
+				<p className="text-xs font-medium text-foreground">{label}</p>
+				<p
+					className="truncate text-[11px] text-muted-foreground"
+					title={detail}
+				>
+					{detail}
+				</p>
+			</div>
+			{action}
+		</div>
+	);
+}

--- a/apps/renderer/src/components/browser-settings-menu.tsx
+++ b/apps/renderer/src/components/browser-settings-menu.tsx
@@ -7,7 +7,7 @@ import {
 	ShieldCheck,
 	Trash2,
 } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 import type { BrowserCookieImportStatus } from "../lib/bridge.ts";
 import {
@@ -36,6 +36,13 @@ import {
 	MenuSeparator,
 	MenuTrigger,
 } from "./ui/menu.tsx";
+import {
+	Select,
+	SelectItem,
+	SelectPopup,
+	SelectTrigger,
+	SelectValue,
+} from "./ui/select.tsx";
 
 type NativeCredentialCapability = {
 	readonly supported: boolean;
@@ -56,7 +63,7 @@ export function BrowserSettingsMenu({
 	credentialCapability: NativeCredentialCapability | null;
 	busy: boolean;
 	domainGrantCount: number;
-	onImport: () => Promise<void>;
+	onImport: (profileId?: string) => Promise<void>;
 	onClearImported: () => Promise<void>;
 	onClearBrowsingData: () => Promise<void>;
 	onRevokeTaskAccess: () => void;
@@ -65,8 +72,25 @@ export function BrowserSettingsMenu({
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	const [clearOpen, setClearOpen] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [selectedProfileId, setSelectedProfileId] = useState<
+		string | undefined
+	>(status.selectedProfileId ?? status.availableProfiles[0]?.id);
+	const selectedProfile =
+		status.availableProfiles.find(
+			(profile) => profile.id === selectedProfileId,
+		) ?? status.availableProfiles[0];
+	useEffect(() => {
+		setSelectedProfileId((current) =>
+			status.availableProfiles.some((profile) => profile.id === current)
+				? current
+				: (status.selectedProfileId ?? status.availableProfiles[0]?.id),
+		);
+	}, [status.availableProfiles, status.selectedProfileId]);
 	const openImport = () => {
 		setError(null);
+		setSelectedProfileId(
+			status.selectedProfileId ?? status.availableProfiles[0]?.id,
+		);
 		setSettingsOpen(false);
 		setImportOpen(true);
 	};
@@ -136,20 +160,49 @@ export function BrowserSettingsMenu({
 					<DialogPanel className="space-y-3 px-4 pb-4 pt-0" scrollFade={false}>
 						<div className="grid grid-cols-[4rem_1fr] items-center gap-2 text-xs">
 							<span className="text-muted-foreground">Browser</span>
-							<div className="min-w-0 rounded-md bg-muted/70 px-2.5 py-1.5">
-								<span className="font-medium text-foreground">
-									{status.source ?? "Not detected"}
-								</span>
-								<span className="ml-2 text-muted-foreground">
-									{status.profile ?? "No profile"}
-								</span>
-							</div>
+							<Select
+								value={selectedProfileId}
+								onValueChange={(value) =>
+									setSelectedProfileId(
+										typeof value === "string" ? value : undefined,
+									)
+								}
+							>
+								<SelectTrigger
+									size="sm"
+									className="min-w-0 bg-muted/70 shadow-none"
+									aria-label="Browser profile"
+								>
+									<SelectValue>
+										{selectedProfile === undefined
+											? "No supported profile found"
+											: `${selectedProfile.source} · ${selectedProfile.profile}`}
+									</SelectValue>
+								</SelectTrigger>
+								<SelectPopup>
+									{status.availableProfiles.map((profile) => (
+										<SelectItem key={profile.id} value={profile.id}>
+											<span className="truncate">
+												{profile.source} · {profile.profile}
+												{profile.isDefault ? " (Default)" : ""}
+											</span>
+										</SelectItem>
+									))}
+								</SelectPopup>
+							</Select>
 						</div>
 						<p className="text-[11px] text-muted-foreground">
-							{status.source
-								? `Close ${status.source} completely before importing.`
+							{selectedProfile
+								? `Close ${selectedProfile.source} completely before importing.`
 								: (status.message ?? "No supported browser profile was found.")}
 						</p>
+						{selectedProfile ? (
+							<p className="rounded-md bg-muted/45 px-2.5 py-2 text-[11px] text-muted-foreground">
+								macOS may ask Zuse—or Electron in development—to access{" "}
+								{selectedProfile.source} Safe Storage. This unlocks cookie
+								decryption only; passwords are never imported.
+							</p>
+						) : null}
 						<div className="divide-y divide-border/60 rounded-lg bg-muted/45 px-3">
 							<ImportDataRow
 								icon={<Cookie className="size-3.5" />}
@@ -178,8 +231,13 @@ export function BrowserSettingsMenu({
 						<Button
 							size="xs"
 							loading={busy}
-							disabled={!status.supported}
-							onClick={() => void run(onImport, () => setImportOpen(false))}
+							disabled={!status.supported || selectedProfileId === undefined}
+							onClick={() =>
+								void run(
+									() => onImport(selectedProfileId),
+									() => setImportOpen(false),
+								)
+							}
 						>
 							Import sessions
 						</Button>

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	Alert01Icon,
 	ArrowLeft01Icon,
+	BrowserIcon,
 	ConnectIcon,
 	Delete02Icon,
 	DocumentAttachmentIcon,
@@ -42,6 +43,7 @@ import {
 } from "~/lib/use-relative-time.ts";
 import { cn } from "~/lib/utils";
 import { useAuth } from "../hooks/use-auth.ts";
+import type { BrowserCookieImportStatus } from "../lib/bridge.ts";
 import {
 	COMPLETION_SOUND_PRESETS,
 	playCompletionSound,
@@ -56,6 +58,7 @@ import { useSettingsStore } from "../store/settings.ts";
 import { type SettingsSection, useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { BlurredEmail } from "./blurred-email.tsx";
+import { BrowserProfileSelect } from "./browser-profile-select.tsx";
 import { ProviderCard } from "./provider-card.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 import { MODE_META, MODES_ORDER } from "./runtime-mode-meta.ts";
@@ -66,6 +69,15 @@ import { LinearIntegrationsPane } from "./settings/linear-integrations-pane.tsx"
 import { McpServersPane } from "./settings/mcp-servers-pane.tsx";
 import { PokedexPane } from "./settings/pokedex-pane.tsx";
 import { RepositorySettings } from "./settings-repository.tsx";
+import {
+	AlertDialog,
+	AlertDialogClose,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogPopup,
+	AlertDialogTitle,
+} from "./ui/alert-dialog.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar.tsx";
 import { Button } from "./ui/button.tsx";
 import { Card } from "./ui/card.tsx";
@@ -117,6 +129,12 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
 		label: "Devices",
 		Icon: SmartPhone01Icon,
 		section: { kind: "devices" },
+	},
+	{
+		id: "browser",
+		label: "Browser",
+		Icon: BrowserIcon,
+		section: { kind: "browser" },
 	},
 	{
 		id: "pokedex",
@@ -334,6 +352,12 @@ function SectionTitle({
 					"Link this Mac to your account so you can drive it from your phone.",
 			};
 		}
+		if (section.kind === "browser") {
+			return {
+				title: "Browser",
+				subtitle: "Sessions, password filling, privacy, and agent access.",
+			};
+		}
 		if (section.kind === "pokedex") {
 			return {
 				title: "Pokedex",
@@ -406,6 +430,7 @@ function Pane({ section }: { section: SettingsSection }) {
 	if (section.kind === "integrations") return <LinearIntegrationsPane />;
 	if (section.kind === "mcp") return <McpServersPane />;
 	if (section.kind === "devices") return <DevicesPane />;
+	if (section.kind === "browser") return <BrowserSettingsPagePane />;
 	if (section.kind === "pokedex") return <PokedexPane />;
 	if (section.kind === "advanced") return <AdvancedPane />;
 	if (section.kind === "shortcuts") return <KeybindingsPane />;
@@ -600,6 +625,211 @@ function DiagnosticsPane() {
 	);
 }
 
+const EMPTY_BROWSER_IMPORT_STATUS: BrowserCookieImportStatus = {
+	supported: false,
+	availableProfiles: [],
+	importedDomainCount: 0,
+	importedCookieCount: 0,
+	importedDomains: [],
+	message: "Checking local browser profiles…",
+};
+
+function BrowserSettingsPagePane() {
+	const [status, setStatus] = useState<BrowserCookieImportStatus>(
+		EMPTY_BROWSER_IMPORT_STATUS,
+	);
+	const [selectedProfileId, setSelectedProfileId] = useState<
+		string | undefined
+	>();
+	const [credentialCapability, setCredentialCapability] = useState<{
+		supported: boolean;
+		reason?: string;
+	} | null>(null);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [clearOpen, setClearOpen] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		const browser = window.zuse?.browser;
+		void Promise.all([
+			browser?.getCookieImportStatus?.(),
+			browser?.getNativeCredentialCapability?.(),
+		]).then(([nextStatus, capability]) => {
+			if (cancelled) return;
+			if (nextStatus !== undefined) setStatus(nextStatus);
+			if (capability !== undefined) setCredentialCapability(capability);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		setSelectedProfileId((current) =>
+			status.availableProfiles.some((profile) => profile.id === current)
+				? current
+				: (status.selectedProfileId ?? status.availableProfiles[0]?.id),
+		);
+	}, [status]);
+
+	const run = async (
+		operation: () => Promise<BrowserCookieImportStatus> | undefined,
+	): Promise<boolean> => {
+		setBusy(true);
+		setError(null);
+		try {
+			const request = operation();
+			const next = request === undefined ? undefined : await request;
+			if (next === undefined)
+				throw new Error(
+					"Browser session controls are unavailable in this build.",
+				);
+			setStatus(next);
+			return true;
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+			return false;
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const selectedProfile = status.availableProfiles.find(
+		(profile) => profile.id === selectedProfileId,
+	);
+	const sessionDescription =
+		status.importedCookieCount === 0
+			? "No browser sessions have been imported."
+			: `${status.importedCookieCount} cookies across ${status.importedDomainCount} domains${status.lastImportTime ? ` · Imported ${new Date(status.lastImportTime).toLocaleString()}` : ""}`;
+
+	return (
+		<div className="flex flex-col gap-4">
+			<SettingsGroup
+				title="Browser sessions"
+				description="Copy valid cookies from a local browser profile into the built-in browser. Cookie values never enter renderer state, logs, or chat."
+			>
+				<SettingsRow
+					title="Import source"
+					description={
+						selectedProfile === undefined
+							? (status.message ?? "No supported browser profile found.")
+							: `Close ${selectedProfile.source} before importing. macOS may request Safe Storage access.`
+					}
+				>
+					<div className="flex flex-wrap items-center gap-2">
+						<BrowserProfileSelect
+							profiles={status.availableProfiles}
+							value={selectedProfileId}
+							onValueChange={setSelectedProfileId}
+							className="w-full max-w-72 bg-background shadow-none"
+						/>
+						<Button
+							size="sm"
+							loading={busy}
+							disabled={!status.supported || selectedProfileId === undefined}
+							onClick={() =>
+								void run(() =>
+									window.zuse?.browser?.importCookies?.(selectedProfileId),
+								)
+							}
+						>
+							Import
+						</Button>
+					</div>
+				</SettingsRow>
+				<SettingsRow
+					title="Imported data"
+					description={sessionDescription}
+					action={
+						<Button
+							size="sm"
+							variant="settings"
+							disabled={busy || status.importedCookieCount === 0}
+							onClick={() =>
+								void run(() => window.zuse?.browser?.clearImportedCookies?.())
+							}
+						>
+							Clear imported
+						</Button>
+					}
+				/>
+			</SettingsGroup>
+
+			<SettingsGroup
+				title="Passwords and autofill"
+				description="Passwords are requested individually for the active website and never bulk imported."
+			>
+				<SettingsRow
+					title="System Passwords"
+					description={
+						credentialCapability?.supported
+							? "Available. Filling uses the macOS system confirmation flow for the active origin."
+							: (credentialCapability?.reason ??
+								"Checking native password capability…")
+					}
+				/>
+			</SettingsGroup>
+
+			<SettingsGroup
+				title="Privacy"
+				description="Built-in browser data stays in its dedicated persistent desktop partition."
+			>
+				<SettingsRow
+					title="Browsing data"
+					description="Remove cookies, site storage, and cache from the built-in browser without changing other browsers."
+					action={
+						<Button
+							size="sm"
+							variant="destructive-outline"
+							onClick={() => setClearOpen(true)}
+						>
+							Clear all…
+						</Button>
+					}
+				/>
+			</SettingsGroup>
+
+			{error ? (
+				<p className="text-xs text-destructive-foreground">{error}</p>
+			) : null}
+
+			<BrowserTestLoginsPane />
+
+			<AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+				<AlertDialogPopup className="max-w-sm rounded-xl">
+					<AlertDialogHeader className="gap-1 px-4 pb-3 pt-4">
+						<AlertDialogTitle>Clear browsing data?</AlertDialogTitle>
+						<AlertDialogDescription className="text-xs">
+							This removes cookies, site storage, and cache from the built-in
+							browser. Other browsers are unchanged.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter className="px-4 py-2">
+						<AlertDialogClose render={<Button size="xs" variant="ghost" />}>
+							Cancel
+						</AlertDialogClose>
+						<Button
+							size="xs"
+							variant="destructive"
+							loading={busy}
+							onClick={() =>
+								void run(() =>
+									window.zuse?.browser?.clearBrowsingData?.(),
+								).then((ok) => {
+									if (ok) setClearOpen(false);
+								})
+							}
+						>
+							Clear data
+						</Button>
+					</AlertDialogFooter>
+				</AlertDialogPopup>
+			</AlertDialog>
+		</div>
+	);
+}
+
 interface BrowserCredRow {
 	readonly origin: string;
 	readonly username: string;
@@ -611,7 +841,7 @@ interface BrowserCredRow {
  * from here; the list RPC never returns them). The warning banner is
  * load-bearing: real credentials must never live here.
  */
-function BrowserSettingsPane() {
+function BrowserTestLoginsPane() {
 	const [creds, setCreds] = useState<ReadonlyArray<BrowserCredRow>>([]);
 	const [origin, setOrigin] = useState("");
 	const [username, setUsername] = useState("");
@@ -1250,13 +1480,11 @@ function GeneralPane() {
 }
 
 /**
- * Rarely-needed settings that used to be standalone rail sections (browser
- * test logins + diagnostics). One pane keeps the rail short.
+ * Rarely-needed diagnostic settings kept out of the primary rail flow.
  */
 function AdvancedPane() {
 	return (
 		<div className="flex flex-col gap-4">
-			<BrowserSettingsPane />
 			<DiagnosticsPane />
 		</div>
 	);

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -179,6 +179,17 @@ export interface BrowserDialogState {
 	readonly defaultPrompt?: string;
 }
 
+export interface BrowserCookieImportStatus {
+	readonly supported: boolean;
+	readonly source?: string;
+	readonly profile?: string;
+	readonly lastImportTime?: string;
+	readonly importedDomainCount: number;
+	readonly importedCookieCount: number;
+	readonly importedDomains: ReadonlyArray<string>;
+	readonly message?: string;
+}
+
 export interface LocalServerSummary {
 	readonly name: string;
 	readonly port: number;
@@ -206,6 +217,17 @@ export interface BrowserBridge {
 		method: string,
 		params?: unknown,
 	) => Promise<CdpCommandOutcome>;
+	readonly startScreencast?: (webContentsId: number) => Promise<boolean>;
+	readonly stopScreencast?: (webContentsId: number) => Promise<boolean>;
+	readonly onScreencastFrame?: (
+		handler: (frame: {
+			readonly webContentsId: number;
+			readonly data: string;
+		}) => void,
+	) => () => void;
+	readonly onScreencastInterrupted?: (
+		handler: (webContentsId: number) => void,
+	) => () => void;
 	/** Network requests captured since the last load (buffered in main). */
 	readonly getNetwork?: (
 		webContentsId: number,
@@ -218,6 +240,30 @@ export interface BrowserBridge {
 		webContentsId: number,
 	) => Promise<BrowserDialogState | null>;
 	readonly listLocalServers?: () => Promise<ReadonlyArray<LocalServerSummary>>;
+	readonly saveRecording?: (
+		bytes: Uint8Array,
+		mimeType: string,
+		durationMs: number,
+	) => Promise<{
+		readonly id: string;
+		readonly type: string;
+		readonly size: number;
+		readonly durationMs: number;
+		readonly createdAt: string;
+	}>;
+	readonly getCookieImportStatus?: () => Promise<BrowserCookieImportStatus>;
+	readonly importCookies?: () => Promise<BrowserCookieImportStatus>;
+	readonly clearImportedCookies?: () => Promise<BrowserCookieImportStatus>;
+	readonly clearBrowsingData?: () => Promise<BrowserCookieImportStatus>;
+	readonly getNativeCredentialCapability?: () => Promise<{
+		readonly supported: boolean;
+		readonly reason?: string;
+	}>;
+	readonly fillNativeCredential?: (
+		webContentsId: number,
+		origin: string,
+		submit?: boolean,
+	) => Promise<{ readonly ok: boolean; readonly error?: string }>;
 }
 
 export interface SshBridge {

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -181,6 +181,13 @@ export interface BrowserDialogState {
 
 export interface BrowserCookieImportStatus {
 	readonly supported: boolean;
+	readonly selectedProfileId?: string;
+	readonly availableProfiles: ReadonlyArray<{
+		readonly id: string;
+		readonly source: string;
+		readonly profile: string;
+		readonly isDefault: boolean;
+	}>;
 	readonly source?: string;
 	readonly profile?: string;
 	readonly lastImportTime?: string;
@@ -252,7 +259,9 @@ export interface BrowserBridge {
 		readonly createdAt: string;
 	}>;
 	readonly getCookieImportStatus?: () => Promise<BrowserCookieImportStatus>;
-	readonly importCookies?: () => Promise<BrowserCookieImportStatus>;
+	readonly importCookies?: (
+		profileId?: string,
+	) => Promise<BrowserCookieImportStatus>;
 	readonly clearImportedCookies?: () => Promise<BrowserCookieImportStatus>;
 	readonly clearBrowsingData?: () => Promise<BrowserCookieImportStatus>;
 	readonly getNativeCredentialCapability?: () => Promise<{

--- a/apps/renderer/src/lib/browser-recording.ts
+++ b/apps/renderer/src/lib/browser-recording.ts
@@ -1,0 +1,210 @@
+export type BrowserRecordingState =
+	| "idle"
+	| "starting"
+	| "recording"
+	| "stopping";
+
+export interface BrowserRecordingArtifact {
+	readonly id: string;
+	readonly type: string;
+	readonly size: number;
+	readonly durationMs: number;
+	readonly createdAt: string;
+}
+
+interface CaptureImage {
+	isEmpty(): boolean;
+	toDataURL(): string;
+}
+
+export interface BrowserRecordingSource {
+	capturePage(): Promise<CaptureImage>;
+	getBoundingClientRect(): DOMRect;
+	subscribeFrames?(
+		handler: (dataUrl: string) => void,
+	): Promise<() => void | Promise<void>>;
+	drawDecorations?(
+		context: CanvasRenderingContext2D,
+		width: number,
+		height: number,
+	): void;
+}
+
+const MAX_DURATION_MS = 10 * 60 * 1000;
+const MAX_BYTES = 300 * 1024 * 1024;
+const FRAME_INTERVAL_MS = 100;
+
+const supportedMimeType = (): string => {
+	for (const candidate of [
+		"video/mp4;codecs=avc1",
+		"video/webm;codecs=vp9",
+		"video/webm;codecs=vp8",
+		"video/webm",
+	]) {
+		if (MediaRecorder.isTypeSupported(candidate)) return candidate;
+	}
+	return "";
+};
+
+const loadFrame = (dataUrl: string): Promise<HTMLImageElement> =>
+	new Promise((resolve, reject) => {
+		const image = new Image();
+		image.onload = () => resolve(image);
+		image.onerror = () =>
+			reject(new Error("Could not decode a browser frame."));
+		image.src = dataUrl;
+	});
+
+export class BrowserRecordingController {
+	state: BrowserRecordingState = "idle";
+	startedAt: number | null = null;
+	private recorder: MediaRecorder | null = null;
+	private chunks: Blob[] = [];
+	private chunkBytes = 0;
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private capTimer: ReturnType<typeof setTimeout> | null = null;
+	private unsubscribeFrames: (() => void | Promise<void>) | null = null;
+	private drawing = false;
+	private stopPromise: Promise<BrowserRecordingArtifact> | null = null;
+
+	async start(source: BrowserRecordingSource): Promise<void> {
+		if (this.state !== "idle")
+			throw new Error("A browser recording is already active.");
+		if (
+			source.getBoundingClientRect().width < 1 ||
+			source.getBoundingClientRect().height < 1
+		) {
+			throw new Error("The browser must be visible before recording starts.");
+		}
+		this.state = "starting";
+		try {
+			const first = await Promise.race([
+				source.capturePage(),
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() =>
+							reject(new Error("Browser recording did not receive a frame.")),
+						3000,
+					),
+				),
+			]);
+			if (first.isEmpty()) {
+				this.state = "idle";
+				throw new Error("The first browser recording frame was empty.");
+			}
+			const frame = await loadFrame(first.toDataURL());
+			const canvas = document.createElement("canvas");
+			canvas.width = frame.naturalWidth;
+			canvas.height = frame.naturalHeight;
+			const context = canvas.getContext("2d", { alpha: false });
+			if (context === null) throw new Error("Canvas recording is unavailable.");
+			context.drawImage(frame, 0, 0);
+			source.drawDecorations?.(context, canvas.width, canvas.height);
+			const stream = canvas.captureStream(10);
+			const mimeType = supportedMimeType();
+			this.chunks = [];
+			this.chunkBytes = 0;
+			this.recorder = new MediaRecorder(
+				stream,
+				mimeType === "" ? undefined : { mimeType },
+			);
+			this.recorder.ondataavailable = (event) => {
+				if (event.data.size <= 0) return;
+				if (this.chunkBytes + event.data.size > MAX_BYTES) {
+					void this.stop().catch(() => {});
+					return;
+				}
+				this.chunks.push(event.data);
+				this.chunkBytes += event.data.size;
+			};
+			this.recorder.start(1000);
+			this.startedAt = Date.now();
+			this.state = "recording";
+			const drawFrame = (dataUrl: string) => {
+				if (this.drawing || this.state !== "recording") return;
+				this.drawing = true;
+				void loadFrame(dataUrl)
+					.then((next) => {
+						context.drawImage(next, 0, 0, canvas.width, canvas.height);
+						source.drawDecorations?.(context, canvas.width, canvas.height);
+					})
+					.catch(() => {})
+					.finally(() => {
+						this.drawing = false;
+					});
+			};
+			if (source.subscribeFrames !== undefined) {
+				try {
+					this.unsubscribeFrames = await source.subscribeFrames(drawFrame);
+				} catch {
+					this.unsubscribeFrames = null;
+				}
+			}
+			if (this.unsubscribeFrames === null) {
+				this.timer = setInterval(() => {
+					void source
+						.capturePage()
+						.then((image) => {
+							if (!image.isEmpty()) drawFrame(image.toDataURL());
+						})
+						.catch(() => {});
+				}, FRAME_INTERVAL_MS);
+			}
+			this.capTimer = setTimeout(() => void this.stop(), MAX_DURATION_MS);
+		} catch (error) {
+			this.state = "idle";
+			this.startedAt = null;
+			this.recorder = null;
+			throw error;
+		}
+	}
+
+	stop(): Promise<BrowserRecordingArtifact> {
+		if (this.state === "idle" || this.recorder === null) {
+			return Promise.reject(new Error("No browser recording is active."));
+		}
+		if (this.stopPromise !== null) return this.stopPromise;
+		this.stopPromise = this.finish();
+		return this.stopPromise;
+	}
+
+	private async finish(): Promise<BrowserRecordingArtifact> {
+		if (this.recorder === null || this.startedAt === null)
+			throw new Error("No browser recording is active.");
+		this.state = "stopping";
+		if (this.timer !== null) clearInterval(this.timer);
+		if (this.capTimer !== null) clearTimeout(this.capTimer);
+		if (this.unsubscribeFrames !== null) await this.unsubscribeFrames();
+		const recorder = this.recorder;
+		await new Promise<void>((resolve) => {
+			recorder.addEventListener("stop", () => resolve(), { once: true });
+			recorder.stop();
+		});
+		try {
+			const durationMs = Date.now() - this.startedAt;
+			const blob = new Blob(this.chunks, {
+				type: recorder.mimeType || "video/webm",
+			});
+			if (blob.size > MAX_BYTES)
+				throw new Error("Browser recording exceeded 300 MB.");
+			const save = window.zuse?.browser?.saveRecording;
+			if (save === undefined)
+				throw new Error("Recording artifacts are unavailable in this build.");
+			return await save(
+				new Uint8Array(await blob.arrayBuffer()),
+				blob.type,
+				durationMs,
+			);
+		} finally {
+			this.state = "idle";
+			this.startedAt = null;
+			this.recorder = null;
+			this.chunks = [];
+			this.chunkBytes = 0;
+			this.timer = null;
+			this.capTimer = null;
+			this.unsubscribeFrames = null;
+			this.stopPromise = null;
+		}
+	}
+}

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -32,6 +32,7 @@ export type SettingsSection =
 	| { readonly kind: "integrations" }
 	| { readonly kind: "mcp" }
 	| { readonly kind: "devices" }
+	| { readonly kind: "browser" }
 	| { readonly kind: "pokedex" }
 	| { readonly kind: "advanced" }
 	| { readonly kind: "shortcuts" }

--- a/packages/agents/src/drivers/browser-mcp-tools.ts
+++ b/packages/agents/src/drivers/browser-mcp-tools.ts
@@ -1,6 +1,8 @@
 import type {
 	BrowserCommand,
 	BrowserCommandResult,
+	BrowserOverlayShape,
+	BrowserTarget,
 	PermissionDecision,
 	PermissionKind,
 	PermissionMode,
@@ -20,6 +22,45 @@ import {
 export const BROWSER_MCP_SERVER_NAME = "zuse";
 
 type JsonObject = JsonSchemaObject;
+
+const targetProp: JsonObject = {
+	oneOf: [
+		objectSchema({ kind: { const: "ref" }, ref: stringProp("Snapshot ref.") }, [
+			"kind",
+			"ref",
+		]),
+		objectSchema(
+			{
+				kind: { const: "role" },
+				role: stringProp("Accessible role."),
+				name: stringProp("Accessible name."),
+				exact: booleanProp("Require an exact name match."),
+			},
+			["kind", "role"],
+		),
+		objectSchema(
+			{
+				kind: { const: "text" },
+				text: stringProp("Visible text."),
+				exact: booleanProp("Require an exact match."),
+			},
+			["kind", "text"],
+		),
+		objectSchema(
+			{ kind: { const: "css" }, selector: stringProp("CSS selector.") },
+			["kind", "selector"],
+		),
+		objectSchema(
+			{
+				kind: { const: "point" },
+				x: numberProp("Viewport x coordinate."),
+				y: numberProp("Viewport y coordinate."),
+			},
+			["kind", "x", "y"],
+		),
+	],
+	description: "Semantic, CSS, snapshot-ref, or viewport-coordinate target.",
+};
 
 type McpText = { readonly type: "text"; readonly text: string };
 type McpImage = {
@@ -45,8 +86,41 @@ export const BROWSER_MCP_TOOLS: ReadonlyArray<BrowserMcpToolDef> = [
 		description:
 			"Open a URL in Zuse's visible in-app browser and wait for it to settle. Use this for JS apps, dev servers, dashboards, screenshots, and browser interactions.",
 		inputSchema: objectSchema(
-			{ url: stringProp("Absolute URL, or localhost host/path.") },
+			{
+				url: stringProp(
+					"Absolute URL, localhost host/path, or an environment-relative path.",
+				),
+				readiness: { type: "string", enum: ["immediate", "dom-ready", "load"] },
+				environmentPort: numberProp("Local environment server port."),
+				environmentProtocol: { type: "string", enum: ["http", "https"] },
+			},
 			["url"],
+		),
+	},
+	{
+		name: "browser_status",
+		description:
+			"Report browser availability, page, viewport, recording, access, and protocol capabilities.",
+		inputSchema: objectSchema({}),
+	},
+	{
+		name: "browser_resize",
+		description:
+			"Resize the single visible browser surface using a responsive preset or custom dimensions.",
+		inputSchema: objectSchema(
+			{
+				mode: {
+					type: "string",
+					enum: ["fill", "phone", "tablet", "laptop", "desktop", "custom"],
+				},
+				width: numberProp("Custom viewport width in CSS pixels.", 3840),
+				height: numberProp("Custom viewport height in CSS pixels.", 2160),
+				orientation: { type: "string", enum: ["portrait", "landscape"] },
+				lockAspectRatio: booleanProp(
+					"Keep the current aspect ratio during manual resizing.",
+				),
+			},
+			["mode"],
 		),
 	},
 	{
@@ -61,19 +135,19 @@ export const BROWSER_MCP_TOOLS: ReadonlyArray<BrowserMcpToolDef> = [
 		name: "browser_snapshot",
 		description:
 			"Return a compact accessibility-tree snapshot with refs. Use this before clicking, typing, selecting, or reading a specific element.",
-		inputSchema: objectSchema({}),
+		inputSchema: objectSchema({
+			screenshot: { type: "string", enum: ["viewport", "full-page"] },
+		}),
 	},
 	{
 		name: "browser_click",
 		description:
 			"Click an element by ref from browser_snapshot. Requires approval unless full-access mode is active.",
-		inputSchema: objectSchema(
-			{
-				ref: stringProp("Element ref from browser_snapshot, e.g. e3."),
-				element: stringProp("Human-readable target description."),
-			},
-			["ref"],
-		),
+		inputSchema: objectSchema({
+			ref: stringProp("Element ref from browser_snapshot, e.g. e3."),
+			target: targetProp,
+			element: stringProp("Human-readable target description."),
+		}),
 	},
 	{
 		name: "browser_type",
@@ -82,11 +156,12 @@ export const BROWSER_MCP_TOOLS: ReadonlyArray<BrowserMcpToolDef> = [
 		inputSchema: objectSchema(
 			{
 				ref: stringProp("Element ref from browser_snapshot."),
+				target: targetProp,
 				text: stringProp("Text to type."),
 				submit: booleanProp("Press Enter after typing."),
 				element: stringProp("Human-readable field description."),
 			},
-			["ref", "text"],
+			["text"],
 		),
 	},
 	{
@@ -219,6 +294,70 @@ export const BROWSER_MCP_TOOLS: ReadonlyArray<BrowserMcpToolDef> = [
 			["origin"],
 		),
 	},
+	{
+		name: "browser_wait_for",
+		description:
+			"Wait until every supplied semantic, selector, text, URL, loading, and delay condition passes within one timeout.",
+		inputSchema: objectSchema({
+			target: targetProp,
+			selector: stringProp("CSS selector that must exist and be visible."),
+			text: stringProp("Visible text that must appear."),
+			urlIncludes: stringProp("Substring required in the current URL."),
+			loadingComplete: booleanProp("Require document loading to complete."),
+			ms: numberProp("Minimum delay in milliseconds.", 15000),
+			timeoutMs: numberProp("Overall timeout in milliseconds.", 25000),
+		}),
+	},
+	{
+		name: "browser_inspect",
+		description:
+			"Inspect one unambiguous target: attributes, accessible state, styles, box model, selector hints, and geometry.",
+		inputSchema: objectSchema({ target: targetProp }, ["target"]),
+	},
+	{
+		name: "browser_evaluate",
+		description:
+			"Evaluate bounded JavaScript in the page. Always requires explicit approval; results must be JSON serializable.",
+		inputSchema: objectSchema(
+			{
+				expression: stringProp("JavaScript expression, up to 64 KiB."),
+				awaitPromise: booleanProp("Await a returned promise."),
+			},
+			["expression"],
+		),
+	},
+	{
+		name: "browser_recording_start",
+		description:
+			"Start recording the visible browser surface, agent cursor, and annotations.",
+		inputSchema: objectSchema({}),
+	},
+	{
+		name: "browser_recording_stop",
+		description:
+			"Stop the active recording and return compact artifact metadata.",
+		inputSchema: objectSchema({}),
+	},
+	{
+		name: "browser_overlay",
+		description:
+			"Add, remove, undo, redo, or clear non-destructive browser overlay marks.",
+		inputSchema: objectSchema(
+			{
+				action: {
+					type: "string",
+					enum: ["add", "remove", "undo", "redo", "clear"],
+				},
+				id: stringProp("Shape id for removal."),
+				shape: {
+					type: "object",
+					description:
+						"Tagged rectangle, highlight, arrow, label, or freehand shape.",
+				},
+			},
+			["action"],
+		),
+	},
 ];
 
 export const browserMcpPromptHint = (): string => {
@@ -244,6 +383,7 @@ export const browserMcpPromptHint = (): string => {
 };
 
 const READ_ONLY_BROWSER_TOOLS = new Set([
+	"browser_status",
 	"browser_navigate",
 	"browser_screenshot",
 	"browser_snapshot",
@@ -254,6 +394,8 @@ const READ_ONLY_BROWSER_TOOLS = new Set([
 	"browser_history",
 	"browser_console",
 	"browser_network",
+	"browser_wait_for",
+	"browser_inspect",
 ]);
 
 const text = (value: string, isError = false): BrowserMcpToolResult => ({
@@ -280,10 +422,105 @@ const asNumber = (args: JsonObject, key: string): number | undefined =>
 		? (args[key] as number)
 		: undefined;
 
+const asTarget = (
+	value: unknown,
+	required = false,
+): BrowserTarget | undefined => {
+	if (value === null || typeof value !== "object") {
+		if (required) throw new Error("Missing target.");
+		return undefined;
+	}
+	const raw = value as JsonObject;
+	const kind = asString(raw, "kind", true)!;
+	switch (kind) {
+		case "ref":
+			return { _tag: "Ref", ref: asString(raw, "ref", true)! };
+		case "role":
+			return {
+				_tag: "Role",
+				role: asString(raw, "role", true)!,
+				...(asString(raw, "name") !== undefined
+					? { name: asString(raw, "name") }
+					: {}),
+				...(asBoolean(raw, "exact") !== undefined
+					? { exact: asBoolean(raw, "exact") }
+					: {}),
+			};
+		case "text":
+			return {
+				_tag: "Text",
+				text: asString(raw, "text", true)!,
+				...(asBoolean(raw, "exact") !== undefined
+					? { exact: asBoolean(raw, "exact") }
+					: {}),
+			};
+		case "css":
+			return { _tag: "Css", selector: asString(raw, "selector", true)! };
+		case "point":
+			return {
+				_tag: "Point",
+				x: asNumber(raw, "x") ?? 0,
+				y: asNumber(raw, "y") ?? 0,
+			};
+		default:
+			throw new Error("target.kind must be ref, role, text, css, or point.");
+	}
+};
+
 const commandFor = (name: string, args: JsonObject): BrowserCommand => {
 	switch (name) {
 		case "browser_navigate":
-			return { _tag: "Navigate", url: asString(args, "url", true)! };
+			return {
+				_tag: "Navigate",
+				url: asString(args, "url", true)!,
+				...(asString(args, "readiness") !== undefined
+					? {
+							readiness: asString(args, "readiness") as
+								| "immediate"
+								| "dom-ready"
+								| "load",
+						}
+					: {}),
+				...(asNumber(args, "environmentPort") !== undefined
+					? { environmentPort: asNumber(args, "environmentPort") }
+					: {}),
+				...(asString(args, "environmentProtocol") !== undefined
+					? {
+							environmentProtocol: asString(args, "environmentProtocol") as
+								| "http"
+								| "https",
+						}
+					: {}),
+			};
+		case "browser_status":
+			return { _tag: "Status" };
+		case "browser_resize":
+			return {
+				_tag: "Resize",
+				mode: asString(args, "mode", true)! as
+					| "fill"
+					| "phone"
+					| "tablet"
+					| "laptop"
+					| "desktop"
+					| "custom",
+				...(asNumber(args, "width") !== undefined
+					? { width: asNumber(args, "width") }
+					: {}),
+				...(asNumber(args, "height") !== undefined
+					? { height: asNumber(args, "height") }
+					: {}),
+				...(asString(args, "orientation") !== undefined
+					? {
+							orientation: asString(args, "orientation") as
+								| "portrait"
+								| "landscape",
+						}
+					: {}),
+				...(asBoolean(args, "lockAspectRatio") !== undefined
+					? { lockAspectRatio: asBoolean(args, "lockAspectRatio") }
+					: {}),
+			};
 		case "browser_screenshot":
 			return {
 				_tag: "Screenshot",
@@ -292,13 +529,35 @@ const commandFor = (name: string, args: JsonObject): BrowserCommand => {
 					: {}),
 			};
 		case "browser_snapshot":
-			return { _tag: "Snapshot" };
+			return {
+				_tag: "Snapshot",
+				...(asString(args, "screenshot") !== undefined
+					? {
+							screenshot: asString(args, "screenshot") as
+								| "viewport"
+								| "full-page",
+						}
+					: {}),
+			};
 		case "browser_click":
-			return { _tag: "Click", ref: asString(args, "ref", true)! };
+			return {
+				_tag: "Click",
+				...(asString(args, "ref") !== undefined
+					? { ref: asString(args, "ref") }
+					: {}),
+				...(asTarget(args["target"]) !== undefined
+					? { target: asTarget(args["target"]) }
+					: {}),
+			};
 		case "browser_type":
 			return {
 				_tag: "Type",
-				ref: asString(args, "ref", true)!,
+				...(asString(args, "ref") !== undefined
+					? { ref: asString(args, "ref") }
+					: {}),
+				...(asTarget(args["target"]) !== undefined
+					? { target: asTarget(args["target"]) }
+					: {}),
 				text: asString(args, "text", true)!,
 				...(asBoolean(args, "submit") !== undefined
 					? { submit: asBoolean(args, "submit") }
@@ -420,6 +679,63 @@ const commandFor = (name: string, args: JsonObject): BrowserCommand => {
 		}
 		case "browser_login":
 			return { _tag: "Login", origin: asString(args, "origin", true)! };
+		case "browser_wait_for":
+			return {
+				_tag: "WaitFor",
+				...(asTarget(args["target"]) !== undefined
+					? { target: asTarget(args["target"]) }
+					: {}),
+				...(asString(args, "selector") !== undefined
+					? { selector: asString(args, "selector") }
+					: {}),
+				...(asString(args, "text") !== undefined
+					? { text: asString(args, "text") }
+					: {}),
+				...(asString(args, "urlIncludes") !== undefined
+					? { urlIncludes: asString(args, "urlIncludes") }
+					: {}),
+				...(asBoolean(args, "loadingComplete") !== undefined
+					? { loadingComplete: asBoolean(args, "loadingComplete") }
+					: {}),
+				...(asNumber(args, "ms") !== undefined
+					? { ms: asNumber(args, "ms") }
+					: {}),
+				...(asNumber(args, "timeoutMs") !== undefined
+					? { timeoutMs: asNumber(args, "timeoutMs") }
+					: {}),
+			};
+		case "browser_inspect":
+			return { _tag: "Inspect", target: asTarget(args["target"], true)! };
+		case "browser_evaluate":
+			return {
+				_tag: "Evaluate",
+				expression: asString(args, "expression", true)!,
+				...(asBoolean(args, "awaitPromise") !== undefined
+					? { awaitPromise: asBoolean(args, "awaitPromise") }
+					: {}),
+			};
+		case "browser_recording_start":
+			return { _tag: "RecordingStart" };
+		case "browser_recording_stop":
+			return { _tag: "RecordingStop" };
+		case "browser_overlay": {
+			const action = asString(args, "action", true)! as
+				| "add"
+				| "remove"
+				| "undo"
+				| "redo"
+				| "clear";
+			return {
+				_tag: "Overlay",
+				action,
+				...(asString(args, "id") !== undefined
+					? { id: asString(args, "id") }
+					: {}),
+				...(args["shape"] !== undefined
+					? { shape: args["shape"] as BrowserOverlayShape }
+					: {}),
+			};
+		}
 		default:
 			throw new Error(`Unknown browser tool: ${name}`);
 	}
@@ -449,7 +765,26 @@ const resultFor = (
 					}
 				: text("Could not capture a screenshot.", true);
 		case "browser_snapshot":
-			return text(result.snapshot ?? "[]");
+			return text(
+				result.payload === undefined
+					? (result.snapshot ?? "[]")
+					: JSON.stringify(result.payload, null, 2),
+			);
+		case "browser_status":
+		case "browser_resize":
+		case "browser_wait_for":
+		case "browser_inspect":
+		case "browser_evaluate":
+		case "browser_recording_start":
+		case "browser_recording_stop":
+		case "browser_overlay":
+			return text(
+				JSON.stringify(
+					result.payload ?? { detail: result.detail ?? "Done." },
+					null,
+					2,
+				),
+			);
 		case "browser_read":
 		case "browser_console":
 		case "browser_network":
@@ -511,7 +846,7 @@ export const ensureBrowserPermission = async (
 		throw new Error(`Browser action blocked in plan mode: ${name}.`);
 	}
 
-	const forcePrompt = name === "browser_login";
+	const forcePrompt = name === "browser_login" || name === "browser_evaluate";
 	if (!forcePrompt && policy.kind === "auto-allow") return;
 
 	const decision = await opts.requestPermission(

--- a/packages/agents/src/drivers/browser-tools.ts
+++ b/packages/agents/src/drivers/browser-tools.ts
@@ -28,6 +28,63 @@ const textResult = (result: BrowserCommandResult, fallback: string) => ({
 	...(result.ok ? {} : { isError: true as const }),
 });
 
+const structuredResult = (result: BrowserCommandResult, fallback: string) => ({
+	content: [
+		{
+			type: "text" as const,
+			text: result.ok
+				? JSON.stringify(
+						result.payload ?? { detail: result.detail ?? fallback },
+						null,
+						2,
+					)
+				: (result.error ?? "Browser action failed."),
+		},
+	],
+	...(result.ok ? {} : { isError: true as const }),
+});
+
+const targetSchema = z.discriminatedUnion("kind", [
+	z.object({ kind: z.literal("ref"), ref: z.string().min(1) }),
+	z.object({
+		kind: z.literal("role"),
+		role: z.string().min(1),
+		name: z.string().optional(),
+		exact: z.boolean().optional(),
+	}),
+	z.object({
+		kind: z.literal("text"),
+		text: z.string().min(1),
+		exact: z.boolean().optional(),
+	}),
+	z.object({ kind: z.literal("css"), selector: z.string().min(1) }),
+	z.object({ kind: z.literal("point"), x: z.number(), y: z.number() }),
+]);
+
+const toBrowserTarget = (target: z.infer<typeof targetSchema>) => {
+	switch (target.kind) {
+		case "ref":
+			return { _tag: "Ref" as const, ref: target.ref };
+		case "role":
+			return {
+				_tag: "Role" as const,
+				role: target.role,
+				...(target.name === undefined ? {} : { name: target.name }),
+				...(target.exact === undefined ? {} : { exact: target.exact }),
+			};
+		case "text":
+			return {
+				_tag: "Text" as const,
+				text: target.text,
+				...(target.exact === undefined ? {} : { exact: target.exact }),
+			};
+		case "css":
+			return { _tag: "Css" as const, selector: target.selector };
+		case "point":
+			return { _tag: "Point" as const, x: target.x, y: target.y };
+	}
+};
+
 /**
  * Build the in-process MCP tool definitions for the agent browser. They drive
  * the app's existing on-screen `<webview>` (round-tripping through the
@@ -137,7 +194,15 @@ export const buildBrowserTools = (send: BrowserSend) => [
 				};
 			}
 			return {
-				content: [{ type: "text" as const, text: result.snapshot }],
+				content: [
+					{
+						type: "text" as const,
+						text:
+							result.payload === undefined
+								? result.snapshot
+								: JSON.stringify(result.payload, null, 2),
+					},
+				],
 			};
 		},
 	),
@@ -543,5 +608,112 @@ export const buildBrowserTools = (send: BrowserSend) => [
 				...(result.ok ? {} : { isError: true }),
 			};
 		},
+	),
+
+	tool(
+		"browser_status",
+		"Report whether the visible in-app browser is ready, including URL, loading state, viewport, recording, domain access, and negotiated capabilities.",
+		{},
+		async () =>
+			structuredResult(await send({ _tag: "Status" }), "Browser status read."),
+	),
+
+	tool(
+		"browser_resize",
+		"Resize the single browser surface using a responsive preset or bounded custom dimensions. The setting persists across pane switches and renderer reloads.",
+		{
+			mode: z.enum(["fill", "phone", "tablet", "laptop", "desktop", "custom"]),
+			width: z.number().min(240).max(3840).optional(),
+			height: z.number().min(240).max(2160).optional(),
+			orientation: z.enum(["portrait", "landscape"]).optional(),
+			lockAspectRatio: z.boolean().optional(),
+		},
+		async (args) =>
+			structuredResult(
+				await send({ _tag: "Resize", ...args }),
+				"Viewport resized.",
+			),
+	),
+
+	tool(
+		"browser_wait_for",
+		"Wait until every supplied condition passes within one timeout: semantic target, selector, visible text, URL substring, loading completion, and/or minimum delay.",
+		{
+			target: targetSchema.optional(),
+			selector: z.string().optional(),
+			text: z.string().optional(),
+			urlIncludes: z.string().optional(),
+			loadingComplete: z.boolean().optional(),
+			ms: z.number().min(0).max(15000).optional(),
+			timeoutMs: z.number().min(100).max(25000).optional(),
+		},
+		async (args) =>
+			structuredResult(
+				await send({
+					_tag: "WaitFor",
+					...(args.target === undefined
+						? {}
+						: { target: toBrowserTarget(args.target) }),
+					...Object.fromEntries(
+						Object.entries(args).filter(
+							([key, value]) => key !== "target" && value !== undefined,
+						),
+					),
+				}),
+				"Wait conditions passed.",
+			),
+	),
+
+	tool(
+		"browser_inspect",
+		"Inspect one unambiguous semantic, CSS, ref, text, or coordinate target. Returns attributes, accessibility state, computed styles, box geometry, and a selector hint.",
+		{ target: targetSchema },
+		async (args) =>
+			structuredResult(
+				await send({ _tag: "Inspect", target: toBrowserTarget(args.target) }),
+				"Target inspected.",
+			),
+	),
+
+	tool(
+		"browser_evaluate",
+		"Evaluate up to 64 KiB of JavaScript in the active page and return a bounded JSON-serializable result. Always requires explicit approval.",
+		{
+			expression: z.string().max(64 * 1024),
+			awaitPromise: z.boolean().optional(),
+		},
+		async (args) =>
+			structuredResult(
+				await send({
+					_tag: "Evaluate",
+					expression: args.expression,
+					...(args.awaitPromise === undefined
+						? {}
+						: { awaitPromise: args.awaitPromise }),
+				}),
+				"Evaluation completed.",
+			),
+	),
+
+	tool(
+		"browser_recording_start",
+		"Start one bounded recording of the visible in-app browser. The browser must be visible.",
+		{},
+		async () =>
+			structuredResult(
+				await send({ _tag: "RecordingStart" }),
+				"Recording started.",
+			),
+	),
+
+	tool(
+		"browser_recording_stop",
+		"Stop the active browser recording and return artifact metadata without embedding video bytes in the tool result.",
+		{},
+		async () =>
+			structuredResult(
+				await send({ _tag: "RecordingStop" }),
+				"Recording stopped.",
+			),
 	),
 ];

--- a/packages/agents/src/drivers/claude.ts
+++ b/packages/agents/src/drivers/claude.ts
@@ -1158,6 +1158,10 @@ const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
 	`mcp__${ZUSE_MCP_NAME}__browser_console`,
 	`mcp__${ZUSE_MCP_NAME}__browser_network`,
 	`mcp__${ZUSE_MCP_NAME}__browser_history`,
+	`mcp__${ZUSE_MCP_NAME}__browser_status`,
+	`mcp__${ZUSE_MCP_NAME}__browser_resize`,
+	`mcp__${ZUSE_MCP_NAME}__browser_wait_for`,
+	`mcp__${ZUSE_MCP_NAME}__browser_inspect`,
 	// Control-plane (orchestration) reads. Inspecting threads/models is
 	// non-mutating and visible to the user, so auto-allow like the browser
 	// reads. The MUTATING control-plane tools — create_thread, create_session,
@@ -1240,7 +1244,10 @@ const policyFor = (
 	// 0b. Agent browser login submits saved (dummy) credentials into a page.
 	//     Always prompt, even in full-access mode — a login attempt should
 	//     never fire silently. Treated like a sensitive path.
-	if (toolName.endsWith("__browser_login")) {
+	if (
+		toolName.endsWith("__browser_login") ||
+		toolName.endsWith("__browser_evaluate")
+	) {
 		return { kind: "prompt", forcePrompt: true };
 	}
 	const path =

--- a/packages/agents/test/unit/drivers/browser-mcp-tools.test.ts
+++ b/packages/agents/test/unit/drivers/browser-mcp-tools.test.ts
@@ -39,4 +39,46 @@ describe("browser MCP plan permissions", () => {
 		).rejects.toThrow(/blocked/i);
 		expect(requestCount).toBe(0);
 	});
+
+	it("treats status, compound waits, and inspection as read-only", async () => {
+		let requestCount = 0;
+		for (const tool of [
+			"browser_status",
+			"browser_wait_for",
+			"browser_inspect",
+		]) {
+			await ensureBrowserPermission(
+				tool,
+				{},
+				{
+					send: async () => ({ id: "browser-test", ok: true }),
+					getPermissionMode: () => "default",
+					getRuntimeMode: () => "full-access",
+					requestPermission: async () => {
+						requestCount += 1;
+						return { _tag: "AllowOnce" };
+					},
+				},
+			);
+		}
+		expect(requestCount).toBe(0);
+	});
+
+	it("always prompts before page evaluation", async () => {
+		let forced = false;
+		await ensureBrowserPermission(
+			"browser_evaluate",
+			{ expression: "document.title" },
+			{
+				send: async () => ({ id: "browser-test", ok: true }),
+				getPermissionMode: () => "default",
+				getRuntimeMode: () => "full-access",
+				requestPermission: async (_kind, options) => {
+					forced = options.forcePrompt;
+					return { _tag: "AllowOnce" };
+				},
+			},
+		);
+		expect(forced).toBe(true);
+	});
 });

--- a/packages/contracts/src/browser-shared.ts
+++ b/packages/contracts/src/browser-shared.ts
@@ -1,0 +1,51 @@
+import { Schema } from "effect";
+
+export const BrowserViewportMode = Schema.Literals([
+	"fill",
+	"phone",
+	"tablet",
+	"laptop",
+	"desktop",
+	"custom",
+]);
+export type BrowserViewportMode = typeof BrowserViewportMode.Type;
+
+export const BrowserOverlayShape = Schema.Union([
+	Schema.TaggedStruct("Rectangle", {
+		id: Schema.String,
+		x: Schema.Number,
+		y: Schema.Number,
+		width: Schema.Number,
+		height: Schema.Number,
+		color: Schema.optional(Schema.String),
+	}),
+	Schema.TaggedStruct("Highlight", {
+		id: Schema.String,
+		x: Schema.Number,
+		y: Schema.Number,
+		width: Schema.Number,
+		height: Schema.Number,
+		color: Schema.optional(Schema.String),
+	}),
+	Schema.TaggedStruct("Arrow", {
+		id: Schema.String,
+		fromX: Schema.Number,
+		fromY: Schema.Number,
+		toX: Schema.Number,
+		toY: Schema.Number,
+		color: Schema.optional(Schema.String),
+	}),
+	Schema.TaggedStruct("Label", {
+		id: Schema.String,
+		x: Schema.Number,
+		y: Schema.Number,
+		text: Schema.String,
+		color: Schema.optional(Schema.String),
+	}),
+	Schema.TaggedStruct("Freehand", {
+		id: Schema.String,
+		points: Schema.Array(Schema.Struct({ x: Schema.Number, y: Schema.Number })),
+		color: Schema.optional(Schema.String),
+	}),
+]);
+export type BrowserOverlayShape = typeof BrowserOverlayShape.Type;

--- a/packages/contracts/src/browser.ts
+++ b/packages/contracts/src/browser.ts
@@ -1,7 +1,37 @@
-import { Rpc } from "effect/unstable/rpc";
 import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
 
 import { SessionId } from "./session.ts";
+
+export {
+	BrowserOverlayShape,
+	BrowserViewportMode,
+} from "./browser-shared.ts";
+
+import { BrowserOverlayShape, BrowserViewportMode } from "./browser-shared.ts";
+
+export const BrowserTarget = Schema.Union([
+	Schema.TaggedStruct("Ref", { ref: Schema.String }),
+	Schema.TaggedStruct("Role", {
+		role: Schema.String,
+		name: Schema.optional(Schema.String),
+		exact: Schema.optional(Schema.Boolean),
+	}),
+	Schema.TaggedStruct("Text", {
+		text: Schema.String,
+		exact: Schema.optional(Schema.Boolean),
+	}),
+	Schema.TaggedStruct("Css", { selector: Schema.String }),
+	Schema.TaggedStruct("Point", { x: Schema.Number, y: Schema.Number }),
+]);
+export type BrowserTarget = typeof BrowserTarget.Type;
+
+export const BrowserReadiness = Schema.Literals([
+	"immediate",
+	"dom-ready",
+	"load",
+]);
+export type BrowserReadiness = typeof BrowserReadiness.Type;
 
 /**
  * In-app agent browser bridge.
@@ -17,120 +47,162 @@ import { SessionId } from "./session.ts";
  * Screenshot extensions) ride the same request/respond round-trip as v1.
  */
 export const BrowserCommand = Schema.Union([
-  /** Load a URL into the shared in-app webview and wait for it to settle. */
-  Schema.TaggedStruct("Navigate", { url: Schema.String }),
-  /**
-   * Capture the page. Default is the visible viewport via `capturePage`;
-   * `fullPage` captures beyond the viewport through CDP
-   * (`Page.captureScreenshot`) when the debugger is attached.
-   */
-  Schema.TaggedStruct("Screenshot", {
-    fullPage: Schema.optional(Schema.Boolean),
-  }),
-  /**
-   * Snapshot the page for targeting. v2: the renderer prefers a pruned
-   * accessibility tree over CDP (roles/names/states, interactive elements
-   * carrying `ref=eN` mapped to backendNodeIds renderer-side) and falls back
-   * to v1's injected DOM walk when CDP isn't attached. Cheaper for the model
-   * than a screenshot and robust to scroll/DPI.
-   */
-  Schema.TaggedStruct("Snapshot", {}),
-  /** Click the element carrying this snapshot `ref`. */
-  Schema.TaggedStruct("Click", { ref: Schema.String }),
-  /**
-   * Type into the element with this `ref`. `submit` presses Enter afterward
-   * (e.g. to submit a search box / login form).
-   */
-  Schema.TaggedStruct("Type", {
-    ref: Schema.String,
-    text: Schema.String,
-    submit: Schema.optional(Schema.Boolean),
-  }),
-  /**
-   * Settle after navigation/AJAX. Wait a fixed `ms`, poll until a CSS
-   * `selector` appears, or poll until `text` shows up in the page's visible
-   * text (selector wins over text; either wins over ms). `timeoutMs` bounds
-   * the poll — capped renderer-side below the bridge's 30s deadline so a
-   * hopeless wait fails as a clean tool error, not a bridge timeout.
-   */
-  Schema.TaggedStruct("Wait", {
-    ms: Schema.optional(Schema.Number),
-    selector: Schema.optional(Schema.String),
-    text: Schema.optional(Schema.String),
-    timeoutMs: Schema.optional(Schema.Number),
-  }),
-  /**
-   * Scroll the page (or a `ref` into view). `direction` moves the viewport;
-   * `ref` (when given) scrolls that element to center instead.
-   */
-  Schema.TaggedStruct("Scroll", {
-    direction: Schema.optional(Schema.Literals(["up", "down", "top", "bottom"])),
-    ref: Schema.optional(Schema.String),
-  }),
-  /** Hover an element by `ref` (reveal menus / tooltips). */
-  Schema.TaggedStruct("Hover", { ref: Schema.String }),
-  /** Choose an option in a <select> by `ref`, matching value or visible label. */
-  Schema.TaggedStruct("Select", { ref: Schema.String, value: Schema.String }),
-  /**
-   * Press a key (Enter, Tab, Escape, ArrowDown, …) on the element `ref`, or on
-   * whatever is focused when `ref` is omitted.
-   */
-  Schema.TaggedStruct("Press", {
-    key: Schema.String,
-    ref: Schema.optional(Schema.String),
-  }),
-  /**
-   * Read the visible text of the page, or of one element when `ref` is given.
-   * Cheaper than a screenshot for confirming content / verifying a flow.
-   */
-  Schema.TaggedStruct("Read", { ref: Schema.optional(Schema.String) }),
-  /** Browser history / reload — back, forward, or reload the current page. */
-  Schema.TaggedStruct("History", {
-    action: Schema.Literals(["back", "forward", "reload"]),
-  }),
-  /** Return recent console messages + page errors captured since last load. */
-  Schema.TaggedStruct("Console", {}),
-  /**
-   * Fill several fields in one round-trip — inputs/textareas and <select>s by
-   * snapshot `ref`. One permission prompt covers the whole form. `submit`
-   * presses Enter in the last filled field afterward.
-   */
-  Schema.TaggedStruct("FillForm", {
-    fields: Schema.Array(
-      Schema.Struct({
-        ref: Schema.String,
-        value: Schema.String,
-      }),
-    ),
-    submit: Schema.optional(Schema.Boolean),
-  }),
-  /**
-   * Network activity captured since the last page load (CDP Network domain,
-   * buffered in main). No `id` → compact request list, optionally substring-
-   * filtered by `filter`. With `id` → one request's detail incl. response
-   * headers and a truncated body.
-   */
-  Schema.TaggedStruct("Network", {
-    filter: Schema.optional(Schema.String),
-    id: Schema.optional(Schema.String),
-  }),
-  /**
-   * Resolve the pending JavaScript dialog (alert/confirm/prompt/beforeunload)
-   * via `Page.handleJavaScriptDialog`. `promptText` answers a prompt() when
-   * accepting. Fails cleanly when no dialog is open.
-   */
-  Schema.TaggedStruct("Dialog", {
-    action: Schema.Literals(["accept", "dismiss"]),
-    promptText: Schema.optional(Schema.String),
-  }),
-  /**
-   * Autofill + submit the saved (DUMMY/TEST) credentials for this origin.
-   * SECURITY: the command carries ONLY the origin — never the password. The
-   * renderer pulls the secret out-of-band via `browser.fillForOrigin` and
-   * injects it into the page, so the password never enters the agent's tool
-   * args/results or the LLM context.
-   */
-  Schema.TaggedStruct("Login", { origin: Schema.String }),
+	/** Load a URL into the shared in-app webview and wait for it to settle. */
+	Schema.TaggedStruct("Navigate", {
+		url: Schema.String,
+		readiness: Schema.optional(BrowserReadiness),
+		environmentPort: Schema.optional(Schema.Number),
+		environmentProtocol: Schema.optional(Schema.Literals(["http", "https"])),
+	}),
+	Schema.TaggedStruct("Status", {}),
+	Schema.TaggedStruct("Resize", {
+		mode: BrowserViewportMode,
+		width: Schema.optional(Schema.Number),
+		height: Schema.optional(Schema.Number),
+		orientation: Schema.optional(Schema.Literals(["portrait", "landscape"])),
+		lockAspectRatio: Schema.optional(Schema.Boolean),
+	}),
+	/**
+	 * Capture the page. Default is the visible viewport via `capturePage`;
+	 * `fullPage` captures beyond the viewport through CDP
+	 * (`Page.captureScreenshot`) when the debugger is attached.
+	 */
+	Schema.TaggedStruct("Screenshot", {
+		fullPage: Schema.optional(Schema.Boolean),
+	}),
+	/**
+	 * Snapshot the page for targeting. v2: the renderer prefers a pruned
+	 * accessibility tree over CDP (roles/names/states, interactive elements
+	 * carrying `ref=eN` mapped to backendNodeIds renderer-side) and falls back
+	 * to v1's injected DOM walk when CDP isn't attached. Cheaper for the model
+	 * than a screenshot and robust to scroll/DPI.
+	 */
+	Schema.TaggedStruct("Snapshot", {
+		screenshot: Schema.optional(Schema.Literals(["viewport", "full-page"])),
+	}),
+	/** Click the element carrying this snapshot `ref`. */
+	Schema.TaggedStruct("Click", {
+		ref: Schema.optional(Schema.String),
+		target: Schema.optional(BrowserTarget),
+	}),
+	/**
+	 * Type into the element with this `ref`. `submit` presses Enter afterward
+	 * (e.g. to submit a search box / login form).
+	 */
+	Schema.TaggedStruct("Type", {
+		ref: Schema.optional(Schema.String),
+		target: Schema.optional(BrowserTarget),
+		text: Schema.String,
+		submit: Schema.optional(Schema.Boolean),
+	}),
+	/**
+	 * Settle after navigation/AJAX. Wait a fixed `ms`, poll until a CSS
+	 * `selector` appears, or poll until `text` shows up in the page's visible
+	 * text (selector wins over text; either wins over ms). `timeoutMs` bounds
+	 * the poll — capped renderer-side below the bridge's 30s deadline so a
+	 * hopeless wait fails as a clean tool error, not a bridge timeout.
+	 */
+	Schema.TaggedStruct("Wait", {
+		ms: Schema.optional(Schema.Number),
+		selector: Schema.optional(Schema.String),
+		text: Schema.optional(Schema.String),
+		timeoutMs: Schema.optional(Schema.Number),
+	}),
+	Schema.TaggedStruct("WaitFor", {
+		target: Schema.optional(BrowserTarget),
+		selector: Schema.optional(Schema.String),
+		text: Schema.optional(Schema.String),
+		urlIncludes: Schema.optional(Schema.String),
+		loadingComplete: Schema.optional(Schema.Boolean),
+		ms: Schema.optional(Schema.Number),
+		timeoutMs: Schema.optional(Schema.Number),
+	}),
+	/**
+	 * Scroll the page (or a `ref` into view). `direction` moves the viewport;
+	 * `ref` (when given) scrolls that element to center instead.
+	 */
+	Schema.TaggedStruct("Scroll", {
+		direction: Schema.optional(
+			Schema.Literals(["up", "down", "top", "bottom"]),
+		),
+		ref: Schema.optional(Schema.String),
+	}),
+	/** Hover an element by `ref` (reveal menus / tooltips). */
+	Schema.TaggedStruct("Hover", { ref: Schema.String }),
+	/** Choose an option in a <select> by `ref`, matching value or visible label. */
+	Schema.TaggedStruct("Select", { ref: Schema.String, value: Schema.String }),
+	/**
+	 * Press a key (Enter, Tab, Escape, ArrowDown, …) on the element `ref`, or on
+	 * whatever is focused when `ref` is omitted.
+	 */
+	Schema.TaggedStruct("Press", {
+		key: Schema.String,
+		ref: Schema.optional(Schema.String),
+	}),
+	/**
+	 * Read the visible text of the page, or of one element when `ref` is given.
+	 * Cheaper than a screenshot for confirming content / verifying a flow.
+	 */
+	Schema.TaggedStruct("Read", { ref: Schema.optional(Schema.String) }),
+	/** Browser history / reload — back, forward, or reload the current page. */
+	Schema.TaggedStruct("History", {
+		action: Schema.Literals(["back", "forward", "reload"]),
+	}),
+	/** Return recent console messages + page errors captured since last load. */
+	Schema.TaggedStruct("Console", {}),
+	/**
+	 * Fill several fields in one round-trip — inputs/textareas and <select>s by
+	 * snapshot `ref`. One permission prompt covers the whole form. `submit`
+	 * presses Enter in the last filled field afterward.
+	 */
+	Schema.TaggedStruct("FillForm", {
+		fields: Schema.Array(
+			Schema.Struct({
+				ref: Schema.String,
+				value: Schema.String,
+			}),
+		),
+		submit: Schema.optional(Schema.Boolean),
+	}),
+	/**
+	 * Network activity captured since the last page load (CDP Network domain,
+	 * buffered in main). No `id` → compact request list, optionally substring-
+	 * filtered by `filter`. With `id` → one request's detail incl. response
+	 * headers and a truncated body.
+	 */
+	Schema.TaggedStruct("Network", {
+		filter: Schema.optional(Schema.String),
+		id: Schema.optional(Schema.String),
+	}),
+	/**
+	 * Resolve the pending JavaScript dialog (alert/confirm/prompt/beforeunload)
+	 * via `Page.handleJavaScriptDialog`. `promptText` answers a prompt() when
+	 * accepting. Fails cleanly when no dialog is open.
+	 */
+	Schema.TaggedStruct("Dialog", {
+		action: Schema.Literals(["accept", "dismiss"]),
+		promptText: Schema.optional(Schema.String),
+	}),
+	/**
+	 * Autofill + submit the saved (DUMMY/TEST) credentials for this origin.
+	 * SECURITY: the command carries ONLY the origin — never the password. The
+	 * renderer pulls the secret out-of-band via `browser.fillForOrigin` and
+	 * injects it into the page, so the password never enters the agent's tool
+	 * args/results or the LLM context.
+	 */
+	Schema.TaggedStruct("Login", { origin: Schema.String }),
+	Schema.TaggedStruct("Inspect", { target: BrowserTarget }),
+	Schema.TaggedStruct("Evaluate", {
+		expression: Schema.String,
+		awaitPromise: Schema.optional(Schema.Boolean),
+	}),
+	Schema.TaggedStruct("RecordingStart", {}),
+	Schema.TaggedStruct("RecordingStop", {}),
+	Schema.TaggedStruct("Overlay", {
+		action: Schema.Literals(["add", "remove", "undo", "redo", "clear"]),
+		shape: Schema.optional(BrowserOverlayShape),
+		id: Schema.optional(Schema.String),
+	}),
 ]);
 export type BrowserCommand = typeof BrowserCommand.Type;
 
@@ -140,10 +212,10 @@ export type BrowserCommand = typeof BrowserCommand.Type;
  * the `hasApiKey` boolean exposure for provider API keys.
  */
 export class BrowserCredentialSummary extends Schema.Class<BrowserCredentialSummary>(
-  "BrowserCredentialSummary",
+	"BrowserCredentialSummary",
 )({
-  origin: Schema.String,
-  username: Schema.String,
+	origin: Schema.String,
+	username: Schema.String,
 }) {}
 
 /**
@@ -152,10 +224,10 @@ export class BrowserCredentialSummary extends Schema.Class<BrowserCredentialSumm
  * tool result, or the command broadcast.
  */
 export class BrowserCredentialSecret extends Schema.Class<BrowserCredentialSecret>(
-  "BrowserCredentialSecret",
+	"BrowserCredentialSecret",
 )({
-  username: Schema.String,
-  password: Schema.String,
+	username: Schema.String,
+	password: Schema.String,
 }) {}
 
 /**
@@ -164,11 +236,11 @@ export class BrowserCredentialSecret extends Schema.Class<BrowserCredentialSecre
  * issued it — the renderer uses it only for display/attribution today.
  */
 export class BrowserCommandRequest extends Schema.Class<BrowserCommandRequest>(
-  "BrowserCommandRequest",
+	"BrowserCommandRequest",
 )({
-  id: Schema.String,
-  sessionId: SessionId,
-  command: BrowserCommand,
+	id: Schema.String,
+	sessionId: SessionId,
+	command: BrowserCommand,
 }) {}
 
 /**
@@ -179,31 +251,33 @@ export class BrowserCommandRequest extends Schema.Class<BrowserCommandRequest>(
  *   - Screenshot → `screenshot` (base64 PNG, no data-URL prefix)
  */
 export class BrowserCommandResult extends Schema.Class<BrowserCommandResult>(
-  "BrowserCommandResult",
+	"BrowserCommandResult",
 )({
-  id: Schema.String,
-  ok: Schema.Boolean,
-  error: Schema.optional(Schema.String),
-  url: Schema.optional(Schema.String),
-  title: Schema.optional(Schema.String),
-  screenshot: Schema.optional(Schema.String),
-  /**
-   * Snapshot → a11y-tree text (CDP path) or JSON array of
-   * `{ ref, role, name, value }` (v1 DOM fallback).
-   */
-  snapshot: Schema.optional(Schema.String),
-  /** Click/Type/Scroll/… → short human-readable note for the agent. */
-  detail: Schema.optional(Schema.String),
-  /**
-   * Read → page/element text; Console → console + error log;
-   * Network → request list or one request's detail.
-   */
-  text: Schema.optional(Schema.String),
+	id: Schema.String,
+	ok: Schema.Boolean,
+	error: Schema.optional(Schema.String),
+	url: Schema.optional(Schema.String),
+	title: Schema.optional(Schema.String),
+	screenshot: Schema.optional(Schema.String),
+	/**
+	 * Snapshot → a11y-tree text (CDP path) or JSON array of
+	 * `{ ref, role, name, value }` (v1 DOM fallback).
+	 */
+	snapshot: Schema.optional(Schema.String),
+	/** Click/Type/Scroll/… → short human-readable note for the agent. */
+	detail: Schema.optional(Schema.String),
+	/**
+	 * Read → page/element text; Console → console + error log;
+	 * Network → request list or one request's detail.
+	 */
+	text: Schema.optional(Schema.String),
+	/** Command-tagged structured response. New commands use this field. */
+	payload: Schema.optional(Schema.Unknown),
 }) {}
 
 export class BrowserCommandNotFoundError extends Schema.TaggedErrorClass<BrowserCommandNotFoundError>()(
-  "BrowserCommandNotFoundError",
-  { id: Schema.String },
+	"BrowserCommandNotFoundError",
+	{ id: Schema.String },
 ) {}
 
 // ---------------------------------------------------------------------------
@@ -217,9 +291,9 @@ export class BrowserCommandNotFoundError extends Schema.TaggedErrorClass<Browser
  * client mirrors `permission.requests`.
  */
 export const BrowserCommandsRpc = Rpc.make("browser.commands", {
-  payload: Schema.Struct({}),
-  success: BrowserCommandRequest,
-  stream: true,
+	payload: Schema.Struct({}),
+	success: BrowserCommandRequest,
+	stream: true,
 });
 
 /**
@@ -228,9 +302,9 @@ export const BrowserCommandsRpc = Rpc.make("browser.commands", {
  * (already resolved, timed out, or from a previous server run).
  */
 export const BrowserRespondRpc = Rpc.make("browser.respond", {
-  payload: Schema.Struct({ result: BrowserCommandResult }),
-  success: Schema.Void,
-  error: BrowserCommandNotFoundError,
+	payload: Schema.Struct({ result: BrowserCommandResult }),
+	success: Schema.Void,
+	error: BrowserCommandNotFoundError,
 });
 
 // ---------------------------------------------------------------------------
@@ -242,23 +316,23 @@ export const BrowserRespondRpc = Rpc.make("browser.respond", {
 
 /** Save (or overwrite) the dummy credential for an origin. */
 export const BrowserSetCredentialRpc = Rpc.make("browser.setCredential", {
-  payload: Schema.Struct({
-    origin: Schema.String,
-    username: Schema.String,
-    password: Schema.String,
-  }),
-  success: Schema.Void,
+	payload: Schema.Struct({
+		origin: Schema.String,
+		username: Schema.String,
+		password: Schema.String,
+	}),
+	success: Schema.Void,
 });
 
 /** List saved credentials (origin + username only — never the password). */
 export const BrowserListCredentialsRpc = Rpc.make("browser.listCredentials", {
-  payload: Schema.Struct({}),
-  success: Schema.Array(BrowserCredentialSummary),
+	payload: Schema.Struct({}),
+	success: Schema.Array(BrowserCredentialSummary),
 });
 
 export const BrowserRemoveCredentialRpc = Rpc.make("browser.removeCredential", {
-  payload: Schema.Struct({ origin: Schema.String }),
-  success: Schema.Void,
+	payload: Schema.Struct({ origin: Schema.String }),
+	success: Schema.Void,
 });
 
 /**
@@ -267,6 +341,6 @@ export const BrowserRemoveCredentialRpc = Rpc.make("browser.removeCredential", {
  * agent-facing path — the result is the cleartext dummy password.
  */
 export const BrowserFillForOriginRpc = Rpc.make("browser.fillForOrigin", {
-  payload: Schema.Struct({ origin: Schema.String }),
-  success: Schema.NullOr(BrowserCredentialSecret),
+	payload: Schema.Struct({ origin: Schema.String }),
+	success: Schema.NullOr(BrowserCredentialSecret),
 });

--- a/packages/contracts/src/composer.ts
+++ b/packages/contracts/src/composer.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 
 import { ProviderId } from "./agent.ts";
+import { BrowserOverlayShape, BrowserViewportMode } from "./browser-shared.ts";
 
 /**
  * Reference to an uploaded attachment. The renderer carries this on
@@ -11,9 +12,9 @@ import { ProviderId } from "./agent.ts";
  * `id` shape: `<sessionSegment>-<uuid>` (sanitised session id + v4 UUID).
  */
 export const AttachmentRef = Schema.Struct({
-  id: Schema.String,
-  mimeType: Schema.String,
-  originalName: Schema.String,
+	id: Schema.String,
+	mimeType: Schema.String,
+	originalName: Schema.String,
 });
 export type AttachmentRef = typeof AttachmentRef.Type;
 
@@ -23,9 +24,9 @@ export type AttachmentRef = typeof AttachmentRef.Type;
  * send time so the provider sees the files inline.
  */
 export const FileRef = Schema.Struct({
-  relPath: Schema.String,
-  absPath: Schema.String,
-  kind: Schema.Literals(["file", "directory"]),
+	relPath: Schema.String,
+	absPath: Schema.String,
+	kind: Schema.Literals(["file", "directory"]),
 });
 export type FileRef = typeof FileRef.Type;
 
@@ -35,10 +36,10 @@ export type FileRef = typeof FileRef.Type;
  * provider-side so semantics match the underlying CLI.
  */
 export const SkillRef = Schema.Struct({
-  name: Schema.String,
-  scope: Schema.Literals(["global", "project"]),
-  args: Schema.String,
-  providerId: ProviderId,
+	name: Schema.String,
+	scope: Schema.Literals(["global", "project"]),
+	args: Schema.String,
+	providerId: ProviderId,
 });
 export type SkillRef = typeof SkillRef.Type;
 
@@ -51,64 +52,64 @@ export type SkillRef = typeof SkillRef.Type;
  * serialises these into a numbered list appended to the prompt text.
  */
 export const CodeAnnotation = Schema.Struct({
-  /** Client-generated v4 UUID — list keys + removal. */
-  id: Schema.String,
-  /**
-   * Workspace-rooted path, for display + the model (the agent's cwd is the
-   * workspace root, so a relative path resolves). For files outside any
-   * project folder this holds the absolute path instead.
-   */
-  relPath: Schema.String,
-  /** Absolute path used by renderer affordances that can reopen the target. */
-  absPath: Schema.String,
-  /** 1-based, inclusive. `startLine === endLine` for a single line. */
-  startLine: Schema.Number,
-  endLine: Schema.Number,
-  comment: Schema.String,
-  /** Diff side for branch-review annotations. Omitted for plain file notes. */
-  diffSide: Schema.optional(Schema.Literals(["additions", "deletions"])),
-  /** Exact diff line that owns the annotation slot after range normalization. */
-  diffAnchorLine: Schema.optional(Schema.Number),
-  /** Previous path when the selected line belongs to a renamed file. */
-  oldPath: Schema.optional(Schema.String),
-  /** Comparison ref shown when the annotation was created. */
-  baseRef: Schema.optional(Schema.String),
+	/** Client-generated v4 UUID — list keys + removal. */
+	id: Schema.String,
+	/**
+	 * Workspace-rooted path, for display + the model (the agent's cwd is the
+	 * workspace root, so a relative path resolves). For files outside any
+	 * project folder this holds the absolute path instead.
+	 */
+	relPath: Schema.String,
+	/** Absolute path used by renderer affordances that can reopen the target. */
+	absPath: Schema.String,
+	/** 1-based, inclusive. `startLine === endLine` for a single line. */
+	startLine: Schema.Number,
+	endLine: Schema.Number,
+	comment: Schema.String,
+	/** Diff side for branch-review annotations. Omitted for plain file notes. */
+	diffSide: Schema.optional(Schema.Literals(["additions", "deletions"])),
+	/** Exact diff line that owns the annotation slot after range normalization. */
+	diffAnchorLine: Schema.optional(Schema.Number),
+	/** Previous path when the selected line belongs to a renamed file. */
+	oldPath: Schema.optional(Schema.String),
+	/** Comparison ref shown when the annotation was created. */
+	baseRef: Schema.optional(Schema.String),
 });
 export type CodeAnnotation = typeof CodeAnnotation.Type;
 
 export const BrowserAnnotationRect = Schema.Struct({
-  x: Schema.Number,
-  y: Schema.Number,
-  width: Schema.Number,
-  height: Schema.Number,
+	x: Schema.Number,
+	y: Schema.Number,
+	width: Schema.Number,
+	height: Schema.Number,
 });
 export type BrowserAnnotationRect = typeof BrowserAnnotationRect.Type;
 
 export const BrowserAnnotationPoint = Schema.Struct({
-  x: Schema.Number,
-  y: Schema.Number,
+	x: Schema.Number,
+	y: Schema.Number,
 });
 export type BrowserAnnotationPoint = typeof BrowserAnnotationPoint.Type;
 
 export const BrowserAnnotationElement = Schema.Struct({
-  tagName: Schema.String,
-  selector: Schema.NullOr(Schema.String),
-  label: Schema.String,
-  rect: BrowserAnnotationRect,
-  textPreview: Schema.String,
+	tagName: Schema.String,
+	selector: Schema.NullOr(Schema.String),
+	label: Schema.String,
+	rect: BrowserAnnotationRect,
+	textPreview: Schema.String,
 });
 export type BrowserAnnotationElement = typeof BrowserAnnotationElement.Type;
 
 export const BrowserAnnotationRegion = Schema.Struct({
-  id: Schema.String,
-  rect: BrowserAnnotationRect,
+	id: Schema.String,
+	rect: BrowserAnnotationRect,
 });
 export type BrowserAnnotationRegion = typeof BrowserAnnotationRegion.Type;
 
 export const BrowserAnnotationStroke = Schema.Struct({
-  id: Schema.String,
-  points: Schema.Array(BrowserAnnotationPoint),
-  bounds: BrowserAnnotationRect,
+	id: Schema.String,
+	points: Schema.Array(BrowserAnnotationPoint),
+	bounds: BrowserAnnotationRect,
 });
 export type BrowserAnnotationStroke = typeof BrowserAnnotationStroke.Type;
 
@@ -118,22 +119,33 @@ export type BrowserAnnotationStroke = typeof BrowserAnnotationStroke.Type;
  * annotation never carries raw image bytes or full page text.
  */
 export const BrowserAnnotation = Schema.Struct({
-  _tag: Schema.Literal("browser"),
-  id: Schema.String,
-  comment: Schema.String,
-  createdAt: Schema.String,
-  pageUrl: Schema.String,
-  pageTitle: Schema.NullOr(Schema.String),
-  elements: Schema.Array(BrowserAnnotationElement),
-  regions: Schema.Array(BrowserAnnotationRegion),
-  strokes: Schema.Array(BrowserAnnotationStroke),
-  screenshotAttachment: Schema.NullOr(AttachmentRef),
+	_tag: Schema.Literal("browser"),
+	id: Schema.String,
+	comment: Schema.String,
+	createdAt: Schema.String,
+	pageUrl: Schema.String,
+	pageTitle: Schema.NullOr(Schema.String),
+	elements: Schema.Array(BrowserAnnotationElement),
+	regions: Schema.Array(BrowserAnnotationRegion),
+	strokes: Schema.Array(BrowserAnnotationStroke),
+	overlays: Schema.optional(Schema.Array(BrowserOverlayShape)),
+	viewport: Schema.optional(
+		Schema.Struct({
+			mode: BrowserViewportMode,
+			width: Schema.Number,
+			height: Schema.Number,
+			scrollX: Schema.Number,
+			scrollY: Schema.Number,
+			deviceScaleFactor: Schema.Number,
+		}),
+	),
+	screenshotAttachment: Schema.NullOr(AttachmentRef),
 });
 export type BrowserAnnotation = typeof BrowserAnnotation.Type;
 
 export const ComposerAnnotation = Schema.Union([
-  CodeAnnotation,
-  BrowserAnnotation,
+	CodeAnnotation,
+	BrowserAnnotation,
 ]);
 export type ComposerAnnotation = typeof ComposerAnnotation.Type;
 
@@ -143,16 +155,16 @@ export type ComposerAnnotation = typeof ComposerAnnotation.Type;
  * give the server enough metadata to expand each segment without re-parsing.
  */
 export class ComposerInput extends Schema.Class<ComposerInput>("ComposerInput")(
-  {
-    text: Schema.String,
-    attachments: Schema.Array(AttachmentRef),
-    fileRefs: Schema.Array(FileRef),
-    skillRefs: Schema.Array(SkillRef),
-    annotations: Schema.Array(ComposerAnnotation).pipe(
-      Schema.withConstructorDefault(Effect.succeed([])),
-      Schema.withDecodingDefaultType(Effect.succeed([])),
-    ),
+	{
+		text: Schema.String,
+		attachments: Schema.Array(AttachmentRef),
+		fileRefs: Schema.Array(FileRef),
+		skillRefs: Schema.Array(SkillRef),
+		annotations: Schema.Array(ComposerAnnotation).pipe(
+			Schema.withConstructorDefault(Effect.succeed([])),
+			Schema.withDecodingDefaultType(Effect.succeed([])),
+		),
 		/** Preserve the submission mode while this input waits in the durable queue. */
 		asGoal: Schema.optional(Schema.Boolean),
-  },
+	},
 ) {}


### PR DESCRIPTION
## What changed

- adds a persistent in-app browser session with browser/profile cookie import and per-site native password filling
- adds capability-aware browser status, semantic targets, richer snapshots and inspection, compound waits, responsive viewport controls, overlays, evidence capture, and recording
- adds a compact native-style browser menu plus a dedicated Browser settings page
- keeps real emulated device dimensions while scaling the preview to fit the available pane
- hardens cookie import for macOS profile detection, 64-bit Chromium timestamps, selective clearing, and post-import reload

## Why

The built-in browser previously lacked reliable session continuity and enough inspection and evidence tooling for agent-driven browser work. Fixed-size device previews could also overflow the browser pane, and browser management controls were confined to a menu/dialog instead of a full settings surface.

## Impact

People can bring existing signed-in browser sessions into the dedicated browser partition, request passwords per site through the native system flow, choose browser profiles, use accurate responsive presets without layout overflow, and manage browser data from Settings. Agent tools gain richer, bounded automation and evidence capabilities without exposing cookie or password values.

## Validation

- `bun run --filter renderer check-types`
- renderer Vitest suite: 177 tests passed
- targeted desktop browser-session unit tests
- applicable Biome checks
- staged diff whitespace validation

## Notes

- Passwords are never bulk imported.
- Tabs and download management remain out of scope.
- The branch is one commit behind current `main`; its merge base is unchanged from when implementation began.