### PR TITLE
Add end-to-end diagnostics and runtime telemetry

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -4,7 +4,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { watch } from "node:fs";
-import { access } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createConnection } from "node:net";
 import { dirname, join, resolve } from "node:path";
@@ -34,6 +34,10 @@ const requiredFiles = [
 	join(desktopOutDir, "main.cjs"),
 	join(desktopOutDir, "preload.cjs"),
 ];
+const configuredDevStartedAt = Number(process.env.ZUSE_DEV_STARTED_AT);
+const devStartedAt = Number.isFinite(configuredDevStartedAt)
+	? configuredDevStartedAt
+	: Date.now();
 // One tsdown rebuild flushes several outputs (main, preload, MCP children)
 // spread over a couple of seconds — the debounce must span the whole flush so
 // a rebuild produces ONE restart, not one per file. Too-short debounce plus a
@@ -48,10 +52,9 @@ let currentApp = null;
 let restartQueue = Promise.resolve();
 const expectedExits = new WeakSet();
 
-async function fileExists(p) {
+async function fileIsCurrent(p) {
 	try {
-		await access(p);
-		return true;
+		return (await stat(p)).mtimeMs >= devStartedAt;
 	} catch {
 		return false;
 	}
@@ -80,12 +83,12 @@ async function waitForResources({
 	intervalMs = 100,
 } = {}) {
 	console.log(
-		`[desktop:electron] waiting for ${devServerUrl} and ${requiredFiles.join(", ")}`,
+		`[desktop:electron] waiting for ${devServerUrl} and current-run artifacts ${requiredFiles.join(", ")}`,
 	);
 	const startedAt = Date.now();
 	while (true) {
 		const filesReady = await Promise.all(
-			requiredFiles.map((path) => fileExists(path)),
+			requiredFiles.map((path) => fileIsCurrent(path)),
 		).then((results) => results.every(Boolean));
 		const portReady = await tcpReady(
 			devServer.hostname || "127.0.0.1",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -115,14 +115,11 @@ interface DiagnosticLogEntry {
 const MAIN_DIAGNOSTIC_LOG_LIMIT = 200;
 const mainDiagnosticLogs: DiagnosticLogEntry[] = [];
 
-function stringifyDiagnosticPart(value: unknown): string {
-	if (typeof value === "string") return value;
-	if (value instanceof Error) return `${value.name}: ${value.message}`;
-	try {
-		return JSON.stringify(value);
-	} catch {
-		return String(value);
-	}
+function diagnosticValueKind(value: unknown): string {
+	if (value instanceof Error) return value.name || "Error";
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "array";
+	return typeof value;
 }
 
 function recordMainDiagnostic(
@@ -134,8 +131,81 @@ function recordMainDiagnostic(
 		createdAt: new Date().toISOString(),
 		level,
 		source,
-		message: parts.map(stringifyDiagnosticPart).join(" ").slice(0, 2000),
+		message: `${source} ${level}`,
+		detail: `argumentTypes=${parts.map(diagnosticValueKind).join(",") || "none"} count=${parts.length}`,
 	});
+	if (mainDiagnosticLogs.length > MAIN_DIAGNOSTIC_LOG_LIMIT) {
+		mainDiagnosticLogs.splice(
+			0,
+			mainDiagnosticLogs.length - MAIN_DIAGNOSTIC_LOG_LIMIT,
+		);
+	}
+}
+
+function persistOfflineDiagnostic(
+	source: string,
+	message: string,
+	detail?: string,
+): void {
+	try {
+		const category = "desktop";
+		const offlinePath = Path.join(
+			app.getPath("userData"),
+			"logs",
+			"diagnostics.offline.ndjson",
+		);
+		fsSync.mkdirSync(Path.dirname(offlinePath), { recursive: true });
+		fsSync.appendFileSync(
+			offlinePath,
+			`${JSON.stringify({
+				id: `offline_${randomUUID().replaceAll("-", "").slice(0, 12)}`,
+				createdAt: new Date().toISOString(),
+				severity: "error",
+				source,
+				category,
+				message,
+				...(detail === undefined ? {} : { detail }),
+				fingerprint: createHash("sha256")
+					.update(`${source}\0${category}\0${message}`)
+					.digest("hex")
+					.slice(0, 20),
+				runId: "desktop-offline",
+				recoveryStatus: "unresolved",
+			})}\n`,
+			"utf8",
+		);
+	} catch {
+		// Fatal diagnostics must never mask the original exception.
+	}
+}
+
+function recordMainFailure(
+	source: string,
+	reason: unknown,
+	persistOffline = false,
+): void {
+	const error = reason instanceof Error ? reason : null;
+	const frames = error?.stack?.split(/\r?\n/).slice(1, 21) ?? [];
+	const firstFrameName = /^\s*at\s+([^\s(]+)/.exec(frames[0] ?? "")?.[1];
+	const message = `${error?.name || "UnknownError"} at ${firstFrameName ?? "unknown"}`;
+	const detail = frames
+		.map((frame) => frame.replaceAll(homedir(), "[USER_HOME]"))
+		.join("\n");
+	const createdAt = new Date().toISOString();
+	mainDiagnosticLogs.push({
+		createdAt,
+		level: "error",
+		source,
+		message,
+		...(detail.length === 0 ? {} : { detail }),
+	});
+	if (persistOffline) {
+		persistOfflineDiagnostic(
+			source,
+			message,
+			detail.length === 0 ? undefined : detail,
+		);
+	}
 	if (mainDiagnosticLogs.length > MAIN_DIAGNOSTIC_LOG_LIMIT) {
 		mainDiagnosticLogs.splice(
 			0,
@@ -155,10 +225,10 @@ console.error = (...args: unknown[]) => {
 	originalConsoleError(...args);
 };
 process.on("uncaughtException", (error) => {
-	recordMainDiagnostic("error", "main.uncaughtException", [error]);
+	recordMainFailure("main.uncaughtException", error, true);
 });
 process.on("unhandledRejection", (reason) => {
-	recordMainDiagnostic("error", "main.unhandledRejection", [reason]);
+	recordMainFailure("main.unhandledRejection", reason);
 });
 
 /**
@@ -1060,6 +1130,40 @@ async function createMainWindow() {
 	});
 
 	ipcMain.handle("app:getMainDiagnostics", () => mainDiagnosticLogs.slice());
+	ipcMain.on("app:recordFatalDiagnostic", (event, payload: unknown) => {
+		event.returnValue = false;
+		if (typeof payload !== "object" || payload === null) return;
+		const candidate = payload as Record<string, unknown>;
+		const allowedSources = new Set([
+			"renderer.window.error",
+			"renderer.unhandledrejection",
+			"renderer.react.root",
+		]);
+		if (
+			typeof candidate.source !== "string" ||
+			!allowedSources.has(candidate.source) ||
+			typeof candidate.errorName !== "string" ||
+			!/^[A-Za-z][A-Za-z0-9]*$/.test(candidate.errorName)
+		) {
+			return;
+		}
+		const frameNames = Array.isArray(candidate.frameNames)
+			? candidate.frameNames
+					.filter(
+						(value): value is string =>
+							typeof value === "string" &&
+							/^[A-Za-z0-9_.$<>-]{1,120}$/.test(value),
+					)
+					.slice(0, 20)
+			: [];
+		const firstFrame = frameNames[0] ?? "unknown";
+		persistOfflineDiagnostic(
+			candidate.source,
+			`${candidate.errorName} at ${firstFrame}`,
+			frameNames.length === 0 ? undefined : `frames=${frameNames.join(",")}`,
+		);
+		event.returnValue = true;
+	});
 	ipcMain.handle("app:revealDiagnosticsLogs", async () => {
 		const logPath = Path.join(app.getPath("userData"), "logs");
 		await fs.mkdir(logPath, { recursive: true });
@@ -2450,33 +2554,9 @@ void app.whenReady().then(async () => {
 			"utf8",
 		);
 		if (previousRunUnclean) {
-			const createdAt = new Date().toISOString();
 			const source = "main.previousRunUnclean";
 			const message = "The previous app run did not shut down cleanly.";
-			const eventsPath = Path.join(
-				app.getPath("userData"),
-				"logs",
-				"diagnostics.events.ndjson",
-			);
-			fsSync.mkdirSync(Path.dirname(eventsPath), { recursive: true });
-			fsSync.appendFileSync(
-				eventsPath,
-				`${JSON.stringify({
-					id: `incident_${randomUUID().replaceAll("-", "").slice(0, 12)}`,
-					createdAt,
-					severity: "error",
-					source,
-					category: "lifecycle",
-					message,
-					fingerprint: createHash("sha256")
-						.update(`${source}\0lifecycle\0${message}`)
-						.digest("hex")
-						.slice(0, 20),
-					runId: desktopRunId,
-					recoveryStatus: "unresolved",
-				})}\n`,
-				"utf8",
-			);
+			persistOfflineDiagnostic(source, message);
 			recordMainDiagnostic("error", "main.previousRunUnclean", [message]);
 		}
 	} catch {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -370,6 +370,14 @@ if (!gotSingleInstanceLock) {
 	app.quit();
 }
 
+const runMarkerPath = Path.join(
+	app.getPath("userData"),
+	"diagnostics",
+	"active-run.json",
+);
+const previousRunUnclean = fsSync.existsSync(runMarkerPath);
+const desktopRunId = `desktop_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+
 // macOS: deep links arrive here (also on cold launch, before whenReady).
 app.on("open-url", (event, url) => {
 	event.preventDefault();
@@ -1052,6 +1060,11 @@ async function createMainWindow() {
 	});
 
 	ipcMain.handle("app:getMainDiagnostics", () => mainDiagnosticLogs.slice());
+	ipcMain.handle("app:revealDiagnosticsLogs", async () => {
+		const logPath = Path.join(app.getPath("userData"), "logs");
+		await fs.mkdir(logPath, { recursive: true });
+		await shell.openPath(logPath);
+	});
 
 	ipcMain.handle("network:getAccessState", () => ({
 		mode: networkAccess.mode,
@@ -2425,6 +2438,50 @@ void app.whenReady().then(async () => {
 	// Non-primary instance is on its way out (lost the single-instance lock) —
 	// don't build a window or boot the runtime.
 	if (!gotSingleInstanceLock) return;
+	try {
+		fsSync.mkdirSync(Path.dirname(runMarkerPath), { recursive: true });
+		fsSync.writeFileSync(
+			runMarkerPath,
+			JSON.stringify({
+				pid: process.pid,
+				startedAt: new Date().toISOString(),
+				runId: desktopRunId,
+			}),
+			"utf8",
+		);
+		if (previousRunUnclean) {
+			const createdAt = new Date().toISOString();
+			const source = "main.previousRunUnclean";
+			const message = "The previous app run did not shut down cleanly.";
+			const eventsPath = Path.join(
+				app.getPath("userData"),
+				"logs",
+				"diagnostics.events.ndjson",
+			);
+			fsSync.mkdirSync(Path.dirname(eventsPath), { recursive: true });
+			fsSync.appendFileSync(
+				eventsPath,
+				`${JSON.stringify({
+					id: `incident_${randomUUID().replaceAll("-", "").slice(0, 12)}`,
+					createdAt,
+					severity: "error",
+					source,
+					category: "lifecycle",
+					message,
+					fingerprint: createHash("sha256")
+						.update(`${source}\0lifecycle\0${message}`)
+						.digest("hex")
+						.slice(0, 20),
+					runId: desktopRunId,
+					recoveryStatus: "unresolved",
+				})}\n`,
+				"utf8",
+			);
+			recordMainDiagnostic("error", "main.previousRunUnclean", [message]);
+		}
+	} catch {
+		// A run marker is diagnostic-only and must never block app startup.
+	}
 
 	// Localhost loopback that catches the WorkOS OAuth callback (dev + packaged).
 	// It's the redirect_uri for both, so the browser finishes on a real HTML
@@ -2568,6 +2625,13 @@ app.on("before-quit", (event) => {
 // fires after an un-prevented `before-quit`, so a cancelled quit leaves the
 // tray untouched.
 app.on("will-quit", () => {
+	if (gotSingleInstanceLock) {
+		try {
+			fsSync.unlinkSync(runMarkerPath);
+		} catch {
+			// Missing or unwritable markers are safe to leave for the next run.
+		}
+	}
 	localConnectivityStopping = true;
 	if (localConnectivityRestartTimer !== null) {
 		clearTimeout(localConnectivityRestartTimer);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -284,6 +284,8 @@ const bridge = {
 					readonly detail?: string;
 				}>
 			>,
+		revealDiagnosticsLogs: () =>
+			ipcRenderer.invoke("app:revealDiagnosticsLogs") as Promise<void>,
 	},
 	network: {
 		getAccessState: () =>

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -284,6 +284,11 @@ const bridge = {
 					readonly detail?: string;
 				}>
 			>,
+		recordFatalDiagnostic: (input: {
+			readonly source: string;
+			readonly errorName: string;
+			readonly frameNames: ReadonlyArray<string>;
+		}) => ipcRenderer.sendSync("app:recordFatalDiagnostic", input) === true,
 		revealDiagnosticsLogs: () =>
 			ipcRenderer.invoke("app:revealDiagnosticsLogs") as Promise<void>,
 	},

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -48,12 +48,6 @@ import {
 	playCompletionSound,
 	prepareCompletionSound,
 } from "../lib/completion-sounds.ts";
-import { collectDiagnosticsClientContext } from "../lib/diagnostics-client-context.ts";
-import { recordUiAction } from "../lib/diagnostics-recorder.ts";
-import {
-	openExternal as openExternalUrl,
-	rendererPlatformCapabilities,
-} from "../lib/platform-capabilities.ts";
 import { PROVIDER_LABEL } from "../lib/provider-labels.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useProvidersStore } from "../store/providers.ts";
@@ -67,6 +61,7 @@ import { ProviderIcon } from "./provider-icons.tsx";
 import { MODE_META, MODES_ORDER } from "./runtime-mode-meta.ts";
 import { DeveloperPane } from "./settings/developer-pane.tsx";
 import { DevicesPane } from "./settings/devices-pane.tsx";
+import { DiagnosticsPane as FullDiagnosticsPane } from "./settings/diagnostics-pane.tsx";
 import { KeybindingsPane } from "./settings/keybindings-editor.tsx";
 import { LinearIntegrationsPane } from "./settings/linear-integrations-pane.tsx";
 import { McpServersPane } from "./settings/mcp-servers-pane.tsx";
@@ -152,10 +147,10 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
 		section: { kind: "shortcuts" },
 	},
 	{
-		id: "advanced",
-		label: "Advanced",
+		id: "diagnostics",
+		label: "Diagnostics",
 		Icon: DocumentAttachmentIcon,
-		section: { kind: "advanced" },
+		section: { kind: "diagnostics" },
 	},
 	// Dev-only visual playground (accent swatches + workflow chip/button
 	// showcase). Filtered out of production bundles below.
@@ -207,7 +202,11 @@ export function SettingsPage() {
 					<div
 						className={cn(
 							"mx-auto flex w-full flex-col gap-10",
-							section.kind === "pokedex" ? "max-w-5xl" : "max-w-2xl",
+							section.kind === "diagnostics"
+								? "max-w-6xl"
+								: section.kind === "pokedex"
+									? "max-w-5xl"
+									: "max-w-2xl",
 						)}
 					>
 						<SectionTitle section={section} folders={folders} />
@@ -367,11 +366,11 @@ function SectionTitle({
 				subtitle: "Unlocked Pokémon from all worktrees.",
 			};
 		}
-		if (section.kind === "advanced") {
+		if (section.kind === "diagnostics") {
 			return {
-				title: "Advanced",
+				title: "Diagnostics",
 				subtitle:
-					"Browser test logins and diagnostics — settings you rarely need.",
+					"Inspect failures, traces, processes, resources, and local support bundles.",
 			};
 		}
 		if (section.kind === "shortcuts") {
@@ -435,205 +434,10 @@ function Pane({ section }: { section: SettingsSection }) {
 	if (section.kind === "devices") return <DevicesPane />;
 	if (section.kind === "browser") return <BrowserSettingsPagePane />;
 	if (section.kind === "pokedex") return <PokedexPane />;
-	if (section.kind === "advanced") return <AdvancedPane />;
+	if (section.kind === "diagnostics") return <FullDiagnosticsPane />;
 	if (section.kind === "shortcuts") return <KeybindingsPane />;
 	if (section.kind === "developer") return <DeveloperPane />;
 	return <RepositorySettings projectId={section.projectId} />;
-}
-
-const DIAGNOSTICS_ISSUE_URL =
-	"https://github.com/swarajbachu/zuse/issues/new?template=bug_report.yml";
-
-function openExternal(url: string): void {
-	void openExternalUrl(url);
-}
-
-function revealPath(path: string): void {
-	const bridge = window.zuse ?? window.memoize;
-	void bridge?.app?.revealPath?.(path);
-}
-
-async function copyDiagnosticsJson(path: string): Promise<boolean> {
-	const bridge = window.zuse ?? window.memoize;
-	return (await bridge?.app?.copyFileContents?.(path)) ?? false;
-}
-
-function DiagnosticsPane() {
-	const capabilities = rendererPlatformCapabilities();
-	const [isExporting, setIsExporting] = useState(false);
-	const [lastExport, setLastExport] = useState<{
-		diagnosticId: string;
-		bundlePath: string;
-		summary: string;
-		jsonCopied: boolean;
-		included: ReadonlyArray<string>;
-	} | null>(null);
-	const [error, setError] = useState<string | null>(null);
-	const [copied, setCopied] = useState<"summary" | "json" | null>(null);
-
-	const markCopied = (kind: "summary" | "json") => {
-		setCopied(kind);
-		window.setTimeout(() => {
-			setCopied((current) => (current === kind ? null : current));
-		}, 1400);
-	};
-
-	const copyText = async (text: string) => {
-		await navigator.clipboard?.writeText(text);
-		markCopied("summary");
-	};
-
-	const copyJson = async (path: string) => {
-		const ok = await copyDiagnosticsJson(path);
-		if (ok) markCopied("json");
-		setLastExport((current) =>
-			current && current.bundlePath === path
-				? { ...current, jsonCopied: ok }
-				: current,
-		);
-	};
-
-	const exportDiagnostics = async () => {
-		setIsExporting(true);
-		setError(null);
-		try {
-			const client = await getRpcClient();
-			recordUiAction("diagnostics.export.started");
-			const clientContext = await collectDiagnosticsClientContext();
-			const result = await Effect.runPromise(
-				client["diagnostics.export"]({ clientContext }),
-			);
-			const jsonCopied = await copyDiagnosticsJson(result.bundlePath);
-			if (jsonCopied) markCopied("json");
-			recordUiAction("diagnostics.export.completed", result.diagnosticId);
-			setLastExport({
-				diagnosticId: result.diagnosticId,
-				bundlePath: result.bundlePath,
-				summary: result.summary,
-				jsonCopied,
-				included: result.included,
-			});
-			revealPath(result.bundlePath);
-		} catch (cause) {
-			setError(
-				cause instanceof Error
-					? cause.message
-					: "Could not export diagnostics bundle.",
-			);
-		} finally {
-			setIsExporting(false);
-		}
-	};
-
-	return (
-		<div className="flex flex-col gap-4">
-			<SettingsGroup
-				title="Bug report diagnostics"
-				description={
-					capabilities.revealInFileManager
-						? "Creates a redacted diagnostics JSON file for a GitHub bug report. Raw prompts and full transcripts are not included by default."
-						: "Creates a redacted diagnostics JSON file on the server. Use the desktop app to reveal that server-side file."
-				}
-			>
-				<SettingsRow
-					title="Export diagnostics JSON"
-					description={
-						capabilities.revealInFileManager
-							? "Copies the JSON to your clipboard and reveals the file so you can attach it to the GitHub issue."
-							: "Exports a redacted JSON file on the connected server."
-					}
-					action={
-						<Button
-							size="sm"
-							onClick={() => void exportDiagnostics()}
-							disabled={isExporting}
-						>
-							<HugeiconsIcon
-								icon={DocumentAttachmentIcon}
-								className="size-3.5"
-							/>
-							{isExporting ? "Exporting..." : "Export diagnostics"}
-						</Button>
-					}
-				/>
-				{lastExport && (
-					<SettingsRow
-						title={`Last export: ${lastExport.diagnosticId}`}
-						description={
-							lastExport.jsonCopied
-								? "Diagnostics JSON copied. Attach the revealed JSON file to the GitHub issue."
-								: "Diagnostics exported. Attach the revealed JSON file to the GitHub issue."
-						}
-					>
-						<div className="flex flex-wrap gap-2">
-							<Button
-								variant="settings"
-								size="sm"
-								onClick={() => openExternal(DIAGNOSTICS_ISSUE_URL)}
-							>
-								Open GitHub issue
-							</Button>
-							{capabilities.copyServerFile && (
-								<Button
-									variant="settings"
-									size="sm"
-									onClick={() => void copyJson(lastExport.bundlePath)}
-								>
-									{copied === "json" ? "Copied" : "Copy diagnostics JSON"}
-								</Button>
-							)}
-							{capabilities.revealInFileManager && (
-								<Button
-									variant="settings"
-									size="sm"
-									onClick={() => revealPath(lastExport.bundlePath)}
-								>
-									Reveal diagnostics file
-								</Button>
-							)}
-							<Button
-								variant="settings"
-								size="sm"
-								onClick={() => void copyText(lastExport.summary)}
-							>
-								{copied === "summary" ? "Copied" : "Copy summary"}
-							</Button>
-						</div>
-						<p className="mt-3 text-xs text-muted-foreground">
-							File: {lastExport.bundlePath}
-						</p>
-						<div className="mt-3 rounded-lg border border-border/40 bg-background/60 p-3">
-							<div className="mb-2 text-xs font-medium text-muted-foreground">
-								Bundle contents
-							</div>
-							<div className="flex flex-wrap gap-1.5">
-								{lastExport.included.map((item) => (
-									<span
-										key={item}
-										className="rounded bg-muted px-2 py-0.5 font-mono text-[11px] text-muted-foreground"
-									>
-										{item}
-									</span>
-								))}
-							</div>
-						</div>
-					</SettingsRow>
-				)}
-				{error && (
-					<SettingsRow
-						icon={Alert01Icon}
-						title="Export failed"
-						description={error}
-					/>
-				)}
-			</SettingsGroup>
-
-			<SettingsFrame
-				title="Reporting from GitHub?"
-				description="Open a bug report, follow the template, export diagnostics from Help -> Export Diagnostics for Bug Report, then attach the JSON file before submitting."
-			/>
-		</div>
-	);
 }
 
 const EMPTY_BROWSER_IMPORT_STATUS: BrowserCookieImportStatus = {
@@ -1507,17 +1311,6 @@ function GeneralPane() {
 			</SettingsGroup>
 			<WorkspacePane />
 			<NotchSettingsPane />
-		</div>
-	);
-}
-
-/**
- * Rarely-needed diagnostic settings kept out of the primary rail flow.
- */
-function AdvancedPane() {
-	return (
-		<div className="flex flex-col gap-4">
-			<DiagnosticsPane />
 		</div>
 	);
 }

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -10,6 +10,7 @@ import {
 	AlertTriangle,
 	Archive,
 	Check,
+	ChevronDown,
 	Copy,
 	ExternalLink,
 	FolderOpen,
@@ -19,6 +20,7 @@ import {
 	Pause,
 	Play,
 	RefreshCw,
+	ScrollText,
 	Search,
 	Server,
 	ShieldCheck,
@@ -64,6 +66,7 @@ const VIEW_OPTIONS: ReadonlyArray<{
 	readonly icon: typeof ListTodo;
 }> = [
 	{ id: "issues", label: "Issues", icon: ListTodo },
+	{ id: "logs", label: "Logs", icon: ScrollText },
 	{ id: "performance", label: "Performance", icon: Gauge },
 	{ id: "processes", label: "Processes", icon: Server },
 	{ id: "storage", label: "Storage", icon: HardDrive },
@@ -89,6 +92,13 @@ const relativeTime = (value: string) => {
 	if (seconds < 86_400) return `${Math.floor(seconds / 3_600)}h ago`;
 	return `${Math.floor(seconds / 86_400)}d ago`;
 };
+const formatTimestamp = (value: string) =>
+	new Intl.DateTimeFormat(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		fractionalSecondDigits: 3,
+	}).format(new Date(value));
 
 const readPreferences = (): DiagnosticsPreferences => {
 	if (typeof window === "undefined") return DEFAULT_DIAGNOSTICS_PREFERENCES;
@@ -323,6 +333,91 @@ function CopyButton({
 	);
 }
 
+function DiagnosticsFilters({
+	search,
+	onSearchChange,
+	severity,
+	onSeverityChange,
+	source,
+	onSourceChange,
+	rangeMs,
+	onRangeChange,
+	searchLabel,
+}: {
+	readonly search: string;
+	readonly onSearchChange: (value: string) => void;
+	readonly severity: DiagnosticsSeverityFilter;
+	readonly onSeverityChange: (value: DiagnosticsSeverityFilter) => void;
+	readonly source: string;
+	readonly onSourceChange: (value: string) => void;
+	readonly rangeMs: number;
+	readonly onRangeChange: (value: number) => void;
+	readonly searchLabel: string;
+}) {
+	return (
+		<div className="flex flex-wrap items-center gap-2 border-b border-border/45 p-2.5">
+			<label className="relative min-w-48 flex-1">
+				<span className="sr-only">{searchLabel}</span>
+				<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+				<input
+					type="search"
+					value={search}
+					onChange={(event) => onSearchChange(event.target.value)}
+					className="h-8 w-full rounded-md border border-border/50 bg-background pl-8 pr-2 text-[11px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
+					placeholder="Search messages and details"
+					spellCheck={false}
+				/>
+			</label>
+			<label>
+				<span className="sr-only">Filter by severity</span>
+				<select
+					value={severity}
+					onChange={(event) =>
+						onSeverityChange(event.target.value as DiagnosticsSeverityFilter)
+					}
+					className="h-8 rounded-md border border-border/50 bg-background px-2 text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
+				>
+					<option value="all">All levels</option>
+					<option value="fatal">Fatal</option>
+					<option value="error">Errors</option>
+					<option value="warn">Warnings</option>
+					<option value="info">Info</option>
+					<option value="debug">Debug</option>
+				</select>
+			</label>
+			<label className="min-w-36 flex-1 sm:max-w-48">
+				<span className="sr-only">Filter by source</span>
+				<input
+					value={source}
+					onChange={(event) => onSourceChange(event.target.value)}
+					className="h-8 w-full rounded-md border border-border/50 bg-background px-2 text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
+					placeholder="All sources"
+					spellCheck={false}
+				/>
+			</label>
+			<fieldset className="flex rounded-md border border-border/50 bg-background p-0.5">
+				<legend className="sr-only">Diagnostics time range</legend>
+				{DIAGNOSTICS_RANGE_OPTIONS.map((option) => (
+					<button
+						type="button"
+						key={option.label}
+						aria-pressed={rangeMs === option.milliseconds}
+						onClick={() => onRangeChange(option.milliseconds)}
+						className={cn(
+							"h-6 min-w-8 rounded-[5px] px-1.5 font-mono text-[9px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:min-w-11",
+							rangeMs === option.milliseconds
+								? "bg-muted text-foreground shadow-xs"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						{option.label}
+					</button>
+				))}
+			</fieldset>
+		</div>
+	);
+}
+
 function IncidentDetails({
 	selected,
 	related,
@@ -460,6 +555,7 @@ export function DiagnosticsPane() {
 		null,
 	);
 	const [selected, setSelected] = useState<DiagnosticEvent | null>(null);
+	const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
 	const [mobileDetailsOpen, setMobileDetailsOpen] = useState(false);
 	const [view, setView] = useState<DiagnosticsView>(initialPreferences.view);
 	const [live, setLive] = useState(true);
@@ -927,64 +1023,17 @@ export function DiagnosticsPane() {
 						</p>
 					</FrameHeader>
 					<FramePanel className="overflow-hidden p-0">
-						<div className="flex flex-wrap items-center gap-2 border-b border-border/45 p-2.5">
-							<label className="relative min-w-48 flex-1">
-								<span className="sr-only">Search diagnostic issues</span>
-								<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-								<input
-									type="search"
-									value={search}
-									onChange={(event) => setSearch(event.target.value)}
-									className="h-8 w-full rounded-md border border-border/50 bg-background pl-8 pr-2 text-[11px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
-									placeholder="Search messages and details"
-									spellCheck={false}
-								/>
-							</label>
-							<label>
-								<span className="sr-only">Filter by severity</span>
-								<select
-									value={severity}
-									onChange={(event) =>
-										setSeverity(event.target.value as DiagnosticsSeverityFilter)
-									}
-									className="h-8 rounded-md border border-border/50 bg-background px-2 text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
-								>
-									<option value="all">All levels</option>
-									<option value="fatal">Fatal</option>
-									<option value="error">Errors</option>
-									<option value="warn">Warnings</option>
-									<option value="info">Info</option>
-								</select>
-							</label>
-							<label className="min-w-36 flex-1 sm:max-w-48">
-								<span className="sr-only">Filter by source</span>
-								<input
-									value={source}
-									onChange={(event) => setSource(event.target.value)}
-									className="h-8 w-full rounded-md border border-border/50 bg-background px-2 text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
-									placeholder="All sources"
-									spellCheck={false}
-								/>
-							</label>
-							<div className="flex rounded-md border border-border/50 bg-background p-0.5">
-								{DIAGNOSTICS_RANGE_OPTIONS.map((option) => (
-									<button
-										type="button"
-										key={option.label}
-										aria-pressed={rangeMs === option.milliseconds}
-										onClick={() => setRangeMs(option.milliseconds)}
-										className={cn(
-											"h-6 min-w-8 rounded-[5px] px-1.5 font-mono text-[9px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:min-w-11",
-											rangeMs === option.milliseconds
-												? "bg-muted text-foreground shadow-xs"
-												: "text-muted-foreground hover:text-foreground",
-										)}
-									>
-										{option.label}
-									</button>
-								))}
-							</div>
-						</div>
+						<DiagnosticsFilters
+							search={search}
+							onSearchChange={setSearch}
+							severity={severity}
+							onSeverityChange={setSeverity}
+							source={source}
+							onSourceChange={setSource}
+							rangeMs={rangeMs}
+							onRangeChange={setRangeMs}
+							searchLabel="Search diagnostic issues"
+						/>
 
 						<div className="grid min-h-[480px] min-w-0 xl:grid-cols-[minmax(0,1fr)_340px]">
 							<div className="min-w-0 xl:border-r xl:border-border/45">
@@ -1100,6 +1149,218 @@ export function DiagnosticsPane() {
 									onCopy={copyText}
 								/>
 							</aside>
+						</div>
+					</FramePanel>
+				</Frame>
+			)}
+
+			{view === "logs" && (
+				<Frame aria-label="Live diagnostic logs">
+					<FrameHeader className="flex w-full flex-row flex-wrap items-center justify-between gap-3 px-3 py-2.5">
+						<div>
+							<FrameTitle className="flex items-center gap-2 text-[12px]">
+								Live logs
+								<span
+									className={cn(
+										"inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-normal text-[9px]",
+										live
+											? "bg-success/10 text-success"
+											: "bg-muted text-muted-foreground",
+									)}
+								>
+									<span
+										className={cn(
+											"size-1.5 rounded-full",
+											live ? "bg-success" : "bg-muted-foreground/60",
+										)}
+									/>
+									{live ? "Following" : "Paused"}
+								</span>
+							</FrameTitle>
+							<FrameDescription className="text-[9px] leading-3.5">
+								Structured local events. The newest filtered page refreshes
+								every five seconds while live.
+							</FrameDescription>
+						</div>
+						<p
+							className="font-mono text-[9px] text-muted-foreground tabular-nums"
+							aria-live="polite"
+						>
+							{formatCount.format(events.length)} loaded ·{" "}
+							{formatCount.format(eventTotal)} matching
+						</p>
+					</FrameHeader>
+					<FramePanel className="overflow-hidden p-0">
+						<DiagnosticsFilters
+							search={search}
+							onSearchChange={setSearch}
+							severity={severity}
+							onSeverityChange={setSeverity}
+							source={source}
+							onSourceChange={setSource}
+							rangeMs={rangeMs}
+							onRangeChange={setRangeMs}
+							searchLabel="Search diagnostic logs"
+						/>
+
+						<div className="overflow-x-auto">
+							<div className="min-w-[760px]">
+								<div className="grid h-8 grid-cols-[86px_72px_150px_minmax(240px,1fr)_128px_24px] items-center gap-3 border-b border-border/45 px-4 font-medium text-[9px] text-muted-foreground uppercase tracking-[0.08em]">
+									<span>Time</span>
+									<span>Level</span>
+									<span>Source</span>
+									<span>Message</span>
+									<span>Trace</span>
+									<span className="sr-only">Details</span>
+								</div>
+								<div className="max-h-[620px] divide-y divide-border/40 overflow-y-auto">
+									{events.map((item) => {
+										const expanded = expandedLogId === item.id;
+										return (
+											<div key={item.id}>
+												<button
+													type="button"
+													aria-expanded={expanded}
+													onClick={() =>
+														setExpandedLogId(expanded ? null : item.id)
+													}
+													className={cn(
+														"grid min-h-10 w-full grid-cols-[86px_72px_150px_minmax(240px,1fr)_128px_24px] items-center gap-3 px-4 text-left outline-none hover:bg-muted/20 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+														expanded && "bg-muted/30",
+													)}
+												>
+													<time
+														dateTime={item.createdAt}
+														title={new Date(item.createdAt).toLocaleString()}
+														className="font-mono text-[9px] text-muted-foreground tabular-nums"
+													>
+														{formatTimestamp(item.createdAt)}
+													</time>
+													<SeverityPill severity={item.severity} />
+													<span
+														className="truncate font-mono text-[9px] text-muted-foreground"
+														title={item.source}
+													>
+														{item.source}
+													</span>
+													<span
+														className="truncate text-[10px]"
+														title={item.message}
+													>
+														{item.message}
+													</span>
+													<span
+														className="truncate font-mono text-[9px] text-muted-foreground"
+														title={item.traceId ?? "Not correlated"}
+													>
+														{item.traceId ?? "—"}
+													</span>
+													<ChevronDown
+														className={cn(
+															"size-3.5 text-muted-foreground",
+															expanded && "rotate-180",
+														)}
+													/>
+												</button>
+												{expanded && (
+													<div className="grid gap-4 border-t border-border/30 bg-muted/15 px-4 py-3 lg:grid-cols-[minmax(0,1fr)_260px]">
+														<div className="min-w-0">
+															<p className="font-medium text-[9px] text-muted-foreground uppercase tracking-[0.08em]">
+																Sanitized detail
+															</p>
+															{item.detail ? (
+																<pre className="mt-2 max-h-52 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/70 p-3 font-mono text-[9px] leading-4">
+																	{item.detail}
+																</pre>
+															) : (
+																<p className="mt-2 text-[10px] text-muted-foreground">
+																	No additional detail was captured for this
+																	event.
+																</p>
+															)}
+														</div>
+														<div className="min-w-0">
+															<dl className="grid grid-cols-[64px_minmax(0,1fr)] gap-x-2 gap-y-1.5 text-[9px]">
+																<dt className="text-muted-foreground">Event</dt>
+																<dd
+																	className="truncate font-mono"
+																	title={item.id}
+																>
+																	{item.id}
+																</dd>
+																<dt className="text-muted-foreground">
+																	Category
+																</dt>
+																<dd className="truncate">{item.category}</dd>
+																<dt className="text-muted-foreground">Run</dt>
+																<dd className="truncate font-mono">
+																	{item.runId}
+																</dd>
+																<dt className="text-muted-foreground">Span</dt>
+																<dd className="truncate font-mono">
+																	{item.spanId ?? "—"}
+																</dd>
+																<dt className="text-muted-foreground">
+																	Session
+																</dt>
+																<dd className="truncate font-mono">
+																	{item.sessionId ?? item.chatId ?? "—"}
+																</dd>
+																<dt className="text-muted-foreground">
+																	Provider
+																</dt>
+																<dd className="truncate font-mono">
+																	{item.providerId ?? "—"}
+																</dd>
+															</dl>
+															<div className="mt-3">
+																<CopyButton
+																	copyKey={`log:${item.id}`}
+																	copiedKey={copiedKey}
+																	onCopy={copyText}
+																	label="Copy event"
+																	text={`${item.createdAt}\n${item.severity.toUpperCase()} ${item.source}\n${item.message}\nEvent: ${item.id}\nTrace: ${item.traceId ?? "—"}\n${item.detail ?? ""}`}
+																/>
+															</div>
+														</div>
+													</div>
+												)}
+											</div>
+										);
+									})}
+									{!loading && events.length === 0 && (
+										<EmptyState
+											icon={ScrollText}
+											title="No matching logs"
+											description="Change the filters or time range. New structured events will appear here while capture is live."
+										/>
+									)}
+									{loading && events.length === 0 && (
+										<EmptyState
+											icon={Activity}
+											title="Reading live logs"
+											description="Loading the newest structured events from local diagnostics."
+										/>
+									)}
+								</div>
+							</div>
+						</div>
+						<div className="flex min-h-11 items-center justify-between border-t border-border/45 px-4 py-2 text-[9px] text-muted-foreground">
+							<span>
+								{live
+									? "Following the newest events"
+									: "Live refresh is paused"}
+							</span>
+							{nextEventCursor && (
+								<Button
+									size="sm"
+									variant="settings"
+									className="h-7 px-2.5 !text-[10px]"
+									onClick={() => void loadMoreEvents()}
+								>
+									Load older
+								</Button>
+							)}
 						</div>
 					</FramePanel>
 				</Frame>

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -9,9 +9,13 @@ import {
 	Activity,
 	AlertTriangle,
 	Archive,
+	Check,
 	Copy,
 	ExternalLink,
 	FolderOpen,
+	Gauge,
+	HardDrive,
+	ListTodo,
 	Pause,
 	Play,
 	RefreshCw,
@@ -21,20 +25,49 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { useMediaQuery } from "../../hooks/use-media-query.ts";
 import { collectDiagnosticsClientContext } from "../../lib/diagnostics-client-context.ts";
 import { flushRendererDiagnostics } from "../../lib/diagnostics-recorder.ts";
+import {
+	DEFAULT_DIAGNOSTICS_PREFERENCES,
+	DIAGNOSTICS_PREFERENCES_KEY,
+	DIAGNOSTICS_RANGE_OPTIONS,
+	type DiagnosticsPreferences,
+	type DiagnosticsSeverityFilter,
+	type DiagnosticsView,
+	groupDiagnosticEvents,
+	parseDiagnosticsPreferences,
+	relatedDiagnosticEvents,
+} from "../../lib/diagnostics-view-model.ts";
 import { getRpcClient } from "../../lib/rpc-client.ts";
 import { cn } from "../../lib/utils.ts";
 import { Button } from "../ui/button.tsx";
-import { Card } from "../ui/card.tsx";
-import { Frame, FrameHeader } from "../ui/frame.tsx";
+import {
+	Dialog,
+	DialogDescription,
+	DialogHeader,
+	DialogPanel,
+	DialogPopup,
+	DialogTitle,
+} from "../ui/dialog.tsx";
+import {
+	Frame,
+	FrameDescription,
+	FrameHeader,
+	FramePanel,
+	FrameTitle,
+} from "../ui/frame.tsx";
 
-const RANGE_OPTIONS = [
-	{ label: "15m", milliseconds: 15 * 60_000 },
-	{ label: "1h", milliseconds: 60 * 60_000 },
-	{ label: "24h", milliseconds: 24 * 60 * 60_000 },
-	{ label: "7d", milliseconds: 7 * 24 * 60 * 60_000 },
-] as const;
+const VIEW_OPTIONS: ReadonlyArray<{
+	readonly id: DiagnosticsView;
+	readonly label: string;
+	readonly icon: typeof ListTodo;
+}> = [
+	{ id: "issues", label: "Issues", icon: ListTodo },
+	{ id: "performance", label: "Performance", icon: Gauge },
+	{ id: "processes", label: "Processes", icon: Server },
+	{ id: "storage", label: "Storage", icon: HardDrive },
+];
 
 const formatCount = new Intl.NumberFormat();
 const formatBytes = (bytes: number) => {
@@ -57,149 +90,22 @@ const relativeTime = (value: string) => {
 	return `${Math.floor(seconds / 86_400)}d ago`;
 };
 
-function DiagnosticsSection({
-	title,
-	description,
-	action,
-	children,
-}: {
-	readonly title: string;
-	readonly description?: string;
-	readonly action?: React.ReactNode;
-	readonly children: React.ReactNode;
-}) {
-	return (
-		<Frame role="region" aria-label={title}>
-			<FrameHeader className="flex w-full flex-row items-center justify-between gap-3 px-2 py-1.5">
-				<div className="min-w-0">
-					<h2 className="truncate font-medium text-[12px] text-foreground">
-						{title}
-					</h2>
-					{description && (
-						<p className="truncate text-[9px] text-muted-foreground leading-3.5">
-							{description}
-						</p>
-					)}
-				</div>
-				{action && <div className="shrink-0">{action}</div>}
-			</FrameHeader>
-			<Card className="overflow-hidden">{children}</Card>
-		</Frame>
-	);
-}
-
-function Stat({
-	label,
-	value,
-	tone = "default",
-}: {
-	label: string;
-	value: string;
-	tone?: "default" | "warning" | "danger";
-}) {
-	return (
-		<div className="min-w-0 px-4 py-3">
-			<p className="truncate font-medium text-[9px] text-muted-foreground uppercase tracking-[0.12em]">
-				{label}
-			</p>
-			<p
-				className={cn(
-					"mt-1 truncate font-mono font-medium text-base tabular-nums",
-					tone === "danger" && "text-destructive",
-					tone === "warning" && "text-warning",
-				)}
-			>
-				{value}
-			</p>
-		</div>
-	);
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-	return (
-		<div className="px-4 py-6 text-center text-[11px] text-muted-foreground">
-			{children}
-		</div>
-	);
-}
-
-function ResourceChart({
-	label,
-	value,
-	peak,
-	values,
-	formatValue,
-	lineClassName,
-}: {
-	readonly label: string;
-	readonly value: number;
-	readonly peak: number;
-	readonly values: ReadonlyArray<number>;
-	readonly formatValue: (value: number) => string;
-	readonly lineClassName: string;
-}) {
-	const width = 320;
-	const height = 92;
-	const ceiling = Math.max(1, peak);
-	const chartValues =
-		values.length === 0
-			? [0, 0]
-			: values.length === 1
-				? [values[0] ?? 0, values[0] ?? 0]
-				: values;
-	const points = chartValues.map((sample, index, all) => {
-		const x = (index / Math.max(1, all.length - 1)) * width;
-		const y = height - Math.min(1, sample / ceiling) * (height - 8) - 4;
-		return `${x.toFixed(1)},${y.toFixed(1)}`;
-	});
-	const areaPoints = `0,${height} ${points.join(" ")} ${width},${height}`;
-
-	return (
-		<Card className="overflow-hidden bg-background/35">
-			<div className="flex items-start justify-between gap-3 px-3 pt-3">
-				<div>
-					<p className="font-medium text-[10px] text-muted-foreground">
-						{label}
-					</p>
-					<p className="mt-0.5 font-mono text-sm tabular-nums">
-						{formatValue(value)}
-					</p>
-				</div>
-				<p className="pt-0.5 text-[9px] text-muted-foreground">
-					Peak{" "}
-					<span className="font-mono tabular-nums">{formatValue(peak)}</span>
-				</p>
-			</div>
-			<svg
-				viewBox={`0 0 ${width} ${height}`}
-				preserveAspectRatio="none"
-				className="mt-2 block h-24 w-full"
-				role="img"
-				aria-label={`${label}: ${formatValue(value)}, peak ${formatValue(peak)}`}
-			>
-				<line x1="0" x2={width} y1="31" y2="31" className="stroke-border/35" />
-				<line x1="0" x2={width} y1="61" y2="61" className="stroke-border/35" />
-				<polygon
-					points={areaPoints}
-					className={cn(lineClassName, "opacity-10")}
-				/>
-				<polyline
-					points={points.join(" ")}
-					fill="none"
-					vectorEffect="non-scaling-stroke"
-					strokeWidth="1.5"
-					className={lineClassName}
-				/>
-			</svg>
-		</Card>
-	);
-}
+const readPreferences = (): DiagnosticsPreferences => {
+	if (typeof window === "undefined") return DEFAULT_DIAGNOSTICS_PREFERENCES;
+	try {
+		return parseDiagnosticsPreferences(
+			window.localStorage.getItem(DIAGNOSTICS_PREFERENCES_KEY),
+		);
+	} catch {
+		return DEFAULT_DIAGNOSTICS_PREFERENCES;
+	}
+};
 
 function SeverityPill({ severity }: { severity: DiagnosticSeverity }) {
 	return (
 		<span
 			className={cn(
-				"inline-flex rounded-md px-1.5 py-0.5 font-medium text-[10px] uppercase",
+				"inline-flex rounded-md px-1.5 py-0.5 font-medium text-[9px] uppercase tracking-[0.08em]",
 				severity === "fatal" || severity === "error"
 					? "bg-destructive/12 text-destructive"
 					: severity === "warn"
@@ -212,8 +118,338 @@ function SeverityPill({ severity }: { severity: DiagnosticSeverity }) {
 	);
 }
 
+function Sparkline({
+	values,
+	className,
+	label,
+}: {
+	readonly values: ReadonlyArray<number>;
+	readonly className?: string;
+	readonly label: string;
+}) {
+	const width = 112;
+	const height = 30;
+	const chartValues =
+		values.length === 0
+			? [0, 0]
+			: values.length === 1
+				? [values[0] ?? 0, values[0] ?? 0]
+				: values;
+	const peak = Math.max(1, ...chartValues);
+	const points = chartValues
+		.map((value, index) => {
+			const x = (index / Math.max(1, chartValues.length - 1)) * width;
+			const y = height - Math.min(1, value / peak) * (height - 4) - 2;
+			return `${x.toFixed(1)},${y.toFixed(1)}`;
+		})
+		.join(" ");
+
+	return (
+		<svg
+			viewBox={`0 0 ${width} ${height}`}
+			preserveAspectRatio="none"
+			className={cn("h-[30px] w-28", className)}
+			role="img"
+			aria-label={label}
+		>
+			<polyline
+				points={points}
+				fill="none"
+				vectorEffect="non-scaling-stroke"
+				strokeWidth="1.5"
+				className="stroke-current"
+			/>
+		</svg>
+	);
+}
+
+function PulseMetric({
+	label,
+	value,
+	tone = "default",
+	values,
+}: {
+	readonly label: string;
+	readonly value: string;
+	readonly tone?: "default" | "warning" | "danger";
+	readonly values?: ReadonlyArray<number>;
+}) {
+	return (
+		<div className="flex min-h-[68px] min-w-0 items-center justify-between gap-3 px-4 py-3">
+			<div className="min-w-0">
+				<p className="truncate font-medium text-[9px] text-muted-foreground uppercase tracking-[0.12em]">
+					{label}
+				</p>
+				<p
+					className={cn(
+						"mt-1 truncate font-mono font-medium text-base tabular-nums",
+						tone === "danger" && "text-destructive",
+						tone === "warning" && "text-warning",
+					)}
+				>
+					{value}
+				</p>
+			</div>
+			{values && (
+				<Sparkline
+					values={values}
+					label={`${label} live trend`}
+					className={cn(
+						"shrink-0 text-muted-foreground/65",
+						tone === "danger" && "text-destructive/70",
+						tone === "warning" && "text-warning/70",
+					)}
+				/>
+			)}
+		</div>
+	);
+}
+
+function ResourceChart({
+	label,
+	value,
+	peak,
+	values,
+	formatValue,
+	className,
+}: {
+	readonly label: string;
+	readonly value: number;
+	readonly peak: number;
+	readonly values: ReadonlyArray<number>;
+	readonly formatValue: (value: number) => string;
+	readonly className: string;
+}) {
+	const width = 420;
+	const height = 116;
+	const ceiling = Math.max(1, peak);
+	const chartValues =
+		values.length === 0
+			? [0, 0]
+			: values.length === 1
+				? [values[0] ?? 0, values[0] ?? 0]
+				: values;
+	const points = chartValues.map((sample, index, all) => {
+		const x = (index / Math.max(1, all.length - 1)) * width;
+		const y = height - Math.min(1, sample / ceiling) * (height - 10) - 5;
+		return `${x.toFixed(1)},${y.toFixed(1)}`;
+	});
+
+	return (
+		<div className="min-w-0 p-4">
+			<div className="flex items-start justify-between gap-3">
+				<div>
+					<p className="font-medium text-[10px] text-muted-foreground">
+						{label}
+					</p>
+					<p className="mt-0.5 font-mono text-sm tabular-nums">
+						{formatValue(value)}
+					</p>
+				</div>
+				<p className="pt-0.5 text-[9px] text-muted-foreground">
+					Peak <span className="font-mono">{formatValue(peak)}</span>
+				</p>
+			</div>
+			<svg
+				viewBox={`0 0 ${width} ${height}`}
+				preserveAspectRatio="none"
+				className="mt-3 block h-28 w-full"
+				role="img"
+				aria-label={`${label}: ${formatValue(value)}, peak ${formatValue(peak)}`}
+			>
+				<line x1="0" x2={width} y1="38" y2="38" className="stroke-border/45" />
+				<line x1="0" x2={width} y1="77" y2="77" className="stroke-border/45" />
+				<polyline
+					points={points.join(" ")}
+					fill="none"
+					vectorEffect="non-scaling-stroke"
+					strokeWidth="1.5"
+					className={className}
+				/>
+			</svg>
+			<p className="text-[9px] text-muted-foreground">
+				Live samples from this page session
+			</p>
+		</div>
+	);
+}
+
+function EmptyState({
+	icon: Icon = ShieldCheck,
+	title,
+	description,
+}: {
+	readonly icon?: typeof ShieldCheck;
+	readonly title: string;
+	readonly description: string;
+}) {
+	return (
+		<div className="flex min-h-56 flex-col items-center justify-center px-6 text-center">
+			<div className="flex size-9 items-center justify-center rounded-full bg-muted/60 text-muted-foreground">
+				<Icon className="size-4" />
+			</div>
+			<p className="mt-3 font-medium text-[12px]">{title}</p>
+			<p className="mt-1 max-w-72 text-[10px] text-muted-foreground leading-4">
+				{description}
+			</p>
+		</div>
+	);
+}
+
+function CopyButton({
+	copyKey,
+	copiedKey,
+	onCopy,
+	text,
+	label,
+}: {
+	readonly copyKey: string;
+	readonly copiedKey: string | null;
+	readonly onCopy: (key: string, text: string) => void;
+	readonly text: string;
+	readonly label: string;
+}) {
+	const copied = copiedKey === copyKey;
+	return (
+		<Button
+			size="sm"
+			variant="settings"
+			className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
+			onClick={() => onCopy(copyKey, text)}
+		>
+			{copied ? <Check /> : <Copy />}
+			{copied ? "Copied" : label}
+		</Button>
+	);
+}
+
+function IncidentDetails({
+	selected,
+	related,
+	copiedKey,
+	onCopy,
+}: {
+	readonly selected: DiagnosticEvent | null;
+	readonly related: ReadonlyArray<DiagnosticEvent>;
+	readonly copiedKey: string | null;
+	readonly onCopy: (key: string, text: string) => void;
+}) {
+	if (!selected) {
+		return (
+			<EmptyState
+				title="Select an issue"
+				description="Its sanitized details, related occurrences, and correlation IDs will appear here."
+			/>
+		);
+	}
+
+	return (
+		<div className="min-w-0">
+			<div className="border-b border-border/45 p-4">
+				<div className="flex items-start justify-between gap-3">
+					<div className="min-w-0">
+						<SeverityPill severity={selected.severity} />
+						<h3 className="mt-2 text-balance font-medium text-[12px] leading-5">
+							{selected.message}
+						</h3>
+						<p className="mt-1 font-mono text-[9px] text-muted-foreground">
+							{selected.source} · {relativeTime(selected.createdAt)}
+						</p>
+					</div>
+					<Button
+						size="icon-sm"
+						variant="ghost"
+						aria-label={
+							copiedKey === "diagnostic-id"
+								? "Diagnostic ID copied"
+								: "Copy diagnostic ID"
+						}
+						onClick={() => onCopy("diagnostic-id", selected.id)}
+					>
+						{copiedKey === "diagnostic-id" ? <Check /> : <Copy />}
+					</Button>
+				</div>
+			</div>
+
+			<div className="space-y-4 p-4">
+				<dl className="grid grid-cols-[82px_minmax(0,1fr)] gap-x-3 gap-y-2 text-[10px]">
+					<dt className="text-muted-foreground">Diagnostic ID</dt>
+					<dd className="truncate font-mono" title={selected.id}>
+						{selected.id}
+					</dd>
+					<dt className="text-muted-foreground">Run</dt>
+					<dd className="truncate font-mono">{selected.runId}</dd>
+					<dt className="text-muted-foreground">Recovery</dt>
+					<dd className="capitalize">{selected.recoveryStatus}</dd>
+					<dt className="text-muted-foreground">Trace</dt>
+					<dd className="truncate font-mono">
+						{selected.traceId ?? "Not correlated"}
+					</dd>
+					<dt className="text-muted-foreground">Session</dt>
+					<dd className="truncate font-mono">
+						{selected.sessionId ?? selected.chatId ?? "Not correlated"}
+					</dd>
+					<dt className="text-muted-foreground">Provider</dt>
+					<dd className="truncate font-mono">
+						{selected.providerId ?? "Not correlated"}
+					</dd>
+				</dl>
+
+				{selected.detail ? (
+					<div>
+						<p className="mb-1.5 font-medium text-[10px]">Sanitized details</p>
+						<pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 p-3 font-mono text-[9px] leading-4">
+							{selected.detail}
+						</pre>
+					</div>
+				) : (
+					<p className="rounded-md bg-muted/35 px-3 py-2 text-[10px] text-muted-foreground">
+						No additional stack or cause was captured.
+					</p>
+				)}
+
+				<div>
+					<div className="mb-1.5 flex items-center justify-between">
+						<p className="font-medium text-[10px]">Related occurrences</p>
+						<span className="font-mono text-[9px] text-muted-foreground tabular-nums">
+							{related.length} loaded
+						</span>
+					</div>
+					<div className="max-h-36 divide-y divide-border/40 overflow-auto rounded-md border border-border/45">
+						{related.slice(0, 12).map((item, index) => (
+							<div
+								key={`${item.id}:${index}`}
+								className="flex items-center justify-between gap-3 px-2.5 py-2 text-[9px]"
+							>
+								<span className="truncate font-mono text-muted-foreground">
+									{item.id}
+								</span>
+								<span className="shrink-0 font-mono text-muted-foreground tabular-nums">
+									{relativeTime(item.createdAt)}
+								</span>
+							</div>
+						))}
+					</div>
+				</div>
+
+				<CopyButton
+					copyKey="incident-details"
+					copiedKey={copiedKey}
+					onCopy={onCopy}
+					label="Copy details"
+					text={`${selected.id}\n${selected.message}\n${selected.detail ?? ""}`}
+				/>
+			</div>
+		</div>
+	);
+}
+
 export function DiagnosticsPane() {
+	const initialPreferences = useRef(readPreferences()).current;
 	const mainLogsIngestedRef = useRef(false);
+	const copyTimerRef = useRef<number | null>(null);
+	const incidentListRef = useRef<HTMLDivElement | null>(null);
+	const isNarrow = useMediaQuery("max-xl");
 	const [overview, setOverview] = useState<DiagnosticsOverviewResult | null>(
 		null,
 	);
@@ -224,83 +460,151 @@ export function DiagnosticsPane() {
 		null,
 	);
 	const [selected, setSelected] = useState<DiagnosticEvent | null>(null);
+	const [mobileDetailsOpen, setMobileDetailsOpen] = useState(false);
+	const [view, setView] = useState<DiagnosticsView>(initialPreferences.view);
 	const [live, setLive] = useState(true);
 	const [loading, setLoading] = useState(true);
+	const [refreshing, setRefreshing] = useState(false);
 	const [exporting, setExporting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [search, setSearch] = useState("");
-	const [severity, setSeverity] = useState<DiagnosticSeverity | "all">("all");
-	const [source, setSource] = useState("");
-	const [rangeMs, setRangeMs] = useState(RANGE_OPTIONS[2].milliseconds);
+	const [search, setSearch] = useState(initialPreferences.search);
+	const [source, setSource] = useState(initialPreferences.source);
+	const [querySearch, setQuerySearch] = useState(initialPreferences.search);
+	const [querySource, setQuerySource] = useState(initialPreferences.source);
+	const [severity, setSeverity] = useState<DiagnosticsSeverityFilter>(
+		initialPreferences.severity,
+	);
+	const [rangeMs, setRangeMs] = useState(initialPreferences.rangeMs);
+	const [copiedKey, setCopiedKey] = useState<string | null>(null);
 	const [samples, setSamples] = useState<
-		ReadonlyArray<{ at: string; cpu: number; memory: number }>
+		ReadonlyArray<{
+			at: string;
+			cpu: number;
+			memory: number;
+			failures: number;
+		}>
 	>([]);
 
-	const since = useMemo(
-		() => new Date(Date.now() - rangeMs).toISOString(),
-		[rangeMs],
+	useEffect(() => {
+		const timer = window.setTimeout(() => {
+			setQuerySearch(search.trim());
+			setQuerySource(source.trim());
+		}, 300);
+		return () => window.clearTimeout(timer);
+	}, [search, source]);
+
+	useEffect(() => {
+		try {
+			window.localStorage.setItem(
+				DIAGNOSTICS_PREFERENCES_KEY,
+				JSON.stringify({ view, rangeMs, severity, source, search }),
+			);
+		} catch {
+			// The workspace remains usable when local storage is unavailable.
+		}
+	}, [rangeMs, search, severity, source, view]);
+
+	useEffect(
+		() => () => {
+			if (copyTimerRef.current !== null) {
+				window.clearTimeout(copyTimerRef.current);
+			}
+		},
+		[],
 	);
+
 	const refresh = useCallback(async () => {
+		setRefreshing(true);
 		try {
 			await flushRendererDiagnostics();
 			const client = await getRpcClient();
 			if (!mainLogsIngestedRef.current) {
-				const mainLogs =
-					(await window.zuse?.app?.getMainDiagnostics?.().catch(() => [])) ??
-					[];
-				const unpublishedMainLogs = mainLogs.filter(
-					(log) => log.source !== "main.previousRunUnclean",
-				);
-				if (unpublishedMainLogs.length > 0) {
-					await Effect.runPromise(
-						client["diagnostics.ingest"]({
-							events: unpublishedMainLogs.map((log, index) => ({
-								id: `main_${log.createdAt}_${index}`,
-								createdAt: log.createdAt,
-								severity: log.level,
-								source: log.source,
-								category: "desktop",
-								message: log.message,
-								...(log.detail ? { detail: log.detail } : {}),
-								fingerprint: `${log.source}:${log.message}`,
-								runId: "desktop-main",
-								recoveryStatus:
-									log.level === "error" ? "unresolved" : "not-needed",
-							})),
-						}),
+				try {
+					const mainLogs =
+						(await window.zuse?.app?.getMainDiagnostics?.().catch(() => [])) ??
+						[];
+					const unpublishedMainLogs = mainLogs.filter(
+						(log) => log.source !== "main.previousRunUnclean",
 					);
+					if (unpublishedMainLogs.length > 0) {
+						await Effect.runPromise(
+							client["diagnostics.ingest"]({
+								events: unpublishedMainLogs.map((log, index) => ({
+									id: `main_${log.createdAt}_${index}`,
+									createdAt: log.createdAt,
+									severity: log.level,
+									source: log.source,
+									category: "desktop",
+									message: log.message,
+									...(log.detail ? { detail: log.detail } : {}),
+									fingerprint: `${log.source}:${log.message}`,
+									runId: "desktop-main",
+									recoveryStatus:
+										log.level === "error" ? "unresolved" : "not-needed",
+								})),
+							}),
+						);
+					}
+					mainLogsIngestedRef.current = true;
+				} catch {
+					// Main-process ingestion is best effort and must not block inspection.
 				}
-				mainLogsIngestedRef.current = true;
 			}
-			const [nextOverview, nextEvents, nextProcesses] = await Promise.all([
-				Effect.runPromise(client["diagnostics.overview"]({ since })),
-				Effect.runPromise(
-					client["diagnostics.events"]({
-						limit: 200,
-						since,
-						...(severity === "all" ? {} : { severities: [severity] }),
-						...(source.trim() ? { source: source.trim() } : {}),
-						...(search.trim() ? { search: search.trim() } : {}),
-					}),
-				),
-				Effect.runPromise(client["diagnostics.processes"]()),
-			]);
-			setOverview(nextOverview);
-			setEvents(nextEvents.events);
-			setNextEventCursor(nextEvents.nextCursor);
-			setEventTotal(nextEvents.total);
-			setProcesses(nextProcesses);
-			setSamples((current) =>
-				[
-					...current,
-					{
-						at: nextProcesses.readAt,
-						cpu: nextProcesses.totalCpuPercent,
-						memory: nextProcesses.totalRssBytes,
-					},
-				].slice(-720),
+
+			const since = new Date(Date.now() - rangeMs).toISOString();
+			const [overviewResult, eventsResult, processesResult] =
+				await Promise.allSettled([
+					Effect.runPromise(client["diagnostics.overview"]({ since })),
+					Effect.runPromise(
+						client["diagnostics.events"]({
+							limit: 200,
+							since,
+							...(severity === "all" ? {} : { severities: [severity] }),
+							...(querySource ? { source: querySource } : {}),
+							...(querySearch ? { search: querySearch } : {}),
+						}),
+					),
+					Effect.runPromise(client["diagnostics.processes"]()),
+				]);
+
+			const failures: string[] = [];
+			if (overviewResult.status === "fulfilled") {
+				setOverview(overviewResult.value);
+			} else {
+				failures.push("health overview");
+			}
+			if (eventsResult.status === "fulfilled") {
+				setEvents(eventsResult.value.events);
+				setNextEventCursor(eventsResult.value.nextCursor);
+				setEventTotal(eventsResult.value.total);
+			} else {
+				failures.push("issue list");
+			}
+			if (processesResult.status === "fulfilled") {
+				setProcesses(processesResult.value);
+				setSamples((current) =>
+					[
+						...current,
+						{
+							at: processesResult.value.readAt,
+							cpu: processesResult.value.totalCpuPercent,
+							memory: processesResult.value.totalRssBytes,
+							failures:
+								overviewResult.status === "fulfilled"
+									? overviewResult.value.errorCount +
+										overviewResult.value.fatalCount
+									: (current.at(-1)?.failures ?? 0),
+						},
+					].slice(-720),
+				);
+			} else {
+				failures.push("process sample");
+			}
+			setError(
+				failures.length > 0
+					? `Some diagnostics could not refresh: ${failures.join(", ")}. Showing the latest available data.`
+					: null,
 			);
-			setError(null);
 		} catch (cause) {
 			setError(
 				cause instanceof Error
@@ -309,33 +613,9 @@ export function DiagnosticsPane() {
 			);
 		} finally {
 			setLoading(false);
+			setRefreshing(false);
 		}
-	}, [search, severity, since, source]);
-	const loadMoreEvents = async () => {
-		if (!nextEventCursor) return;
-		try {
-			const client = await getRpcClient();
-			const page = await Effect.runPromise(
-				client["diagnostics.events"]({
-					cursor: nextEventCursor,
-					limit: 200,
-					since,
-					...(severity === "all" ? {} : { severities: [severity] }),
-					...(source.trim() ? { source: source.trim() } : {}),
-					...(search.trim() ? { search: search.trim() } : {}),
-				}),
-			);
-			setEvents((current) => [...current, ...page.events]);
-			setNextEventCursor(page.nextCursor);
-			setEventTotal(page.total);
-		} catch (cause) {
-			setError(
-				cause instanceof Error
-					? cause.message
-					: "More events could not be loaded.",
-			);
-		}
-	};
+	}, [querySearch, querySource, rangeMs, severity]);
 
 	useEffect(() => {
 		void refresh();
@@ -346,6 +626,44 @@ export function DiagnosticsPane() {
 		return () => window.clearInterval(timer);
 	}, [live, refresh]);
 
+	useEffect(() => {
+		setSelected((current) => {
+			if (!current) return null;
+			return (
+				events.find((event) => event.id === current.id) ??
+				events.find((event) => event.fingerprint === current.fingerprint) ??
+				null
+			);
+		});
+	}, [events]);
+
+	const loadMoreEvents = async () => {
+		if (!nextEventCursor) return;
+		try {
+			const client = await getRpcClient();
+			const page = await Effect.runPromise(
+				client["diagnostics.events"]({
+					cursor: nextEventCursor,
+					limit: 200,
+					since: new Date(Date.now() - rangeMs).toISOString(),
+					...(severity === "all" ? {} : { severities: [severity] }),
+					...(querySource ? { source: querySource } : {}),
+					...(querySearch ? { search: querySearch } : {}),
+				}),
+			);
+			setEvents((current) => [...current, ...page.events]);
+			setNextEventCursor(page.nextCursor);
+			setEventTotal(page.total);
+			setError(null);
+		} catch (cause) {
+			setError(
+				cause instanceof Error
+					? cause.message
+					: "More issues could not be loaded.",
+			);
+		}
+	};
+
 	const exportBundle = async () => {
 		setExporting(true);
 		try {
@@ -354,7 +672,7 @@ export function DiagnosticsPane() {
 			const result = await Effect.runPromise(
 				client["diagnostics.export"]({
 					clientContext,
-					since,
+					since: new Date(Date.now() - rangeMs).toISOString(),
 					includeSessionEvents: false,
 				}),
 			);
@@ -384,17 +702,61 @@ export function DiagnosticsPane() {
 			)
 		)
 			return;
-		const client = await getRpcClient();
-		const result = await Effect.runPromise(
-			client["diagnostics.signalProcess"]({ pid, signal }),
-		);
-		if (!result.signaled)
-			setError(result.message ?? "The process could not be signaled.");
-		await refresh();
+		try {
+			const client = await getRpcClient();
+			const result = await Effect.runPromise(
+				client["diagnostics.signalProcess"]({ pid, signal }),
+			);
+			if (!result.signaled) {
+				setError(result.message ?? "The process could not be signaled.");
+			}
+			await refresh();
+		} catch (cause) {
+			setError(
+				cause instanceof Error ? cause.message : "The process action failed.",
+			);
+		}
 	};
 
+	const copyText = (key: string, text: string) => {
+		void navigator.clipboard
+			.writeText(text)
+			.then(() => {
+				setCopiedKey(key);
+				if (copyTimerRef.current !== null) {
+					window.clearTimeout(copyTimerRef.current);
+				}
+				copyTimerRef.current = window.setTimeout(
+					() => setCopiedKey(null),
+					1_500,
+				);
+			})
+			.catch(() => setError("The diagnostic details could not be copied."));
+	};
+
+	const commonCounts = useMemo(
+		() =>
+			new Map(
+				overview?.commonFailures.map((group) => [
+					group.fingerprint,
+					group.count,
+				]) ?? [],
+			),
+		[overview],
+	);
+	const incidents = useMemo(
+		() => groupDiagnosticEvents(events, commonCounts),
+		[commonCounts, events],
+	);
+	const related = useMemo(
+		() =>
+			selected ? relatedDiagnosticEvents(events, selected.fingerprint) : [],
+		[events, selected],
+	);
 	const maxCpu = Math.max(1, ...samples.map((sample) => sample.cpu));
 	const maxMemory = Math.max(1, ...samples.map((sample) => sample.memory));
+	const failureCount =
+		(overview?.errorCount ?? 0) + (overview?.fatalCount ?? 0);
 	const statusTone =
 		overview?.status === "failing"
 			? "text-destructive"
@@ -402,612 +764,710 @@ export function DiagnosticsPane() {
 				? "text-warning"
 				: "text-success";
 
+	const selectIncident = (event: DiagnosticEvent) => {
+		setSelected(event);
+		if (isNarrow) setMobileDetailsOpen(true);
+	};
+
 	return (
 		<div className="flex min-w-0 flex-col gap-3 pb-12 text-[11px]">
-			<div className="sticky top-0 z-20 -mx-2 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/92 px-3 py-2.5 shadow-sm backdrop-blur-xl">
-				<div className="flex min-w-0 items-center gap-3">
-					<div
-						className={cn(
-							"flex size-8 items-center justify-center rounded-md border border-border/45 bg-muted/50",
-							statusTone,
-						)}
-					>
-						<Activity className="size-3.5" />
+			<Frame aria-label="Diagnostics status">
+				<FrameHeader className="flex w-full flex-row flex-wrap items-center justify-between gap-3 px-3 py-2.5">
+					<div className="flex min-w-0 items-center gap-2.5">
+						<div
+							className={cn(
+								"flex size-7 items-center justify-center rounded-md border border-border/45 bg-muted/50",
+								statusTone,
+							)}
+						>
+							<Activity className="size-3.5" />
+						</div>
+						<div className="min-w-0">
+							<p className="truncate font-medium text-[11px] capitalize">
+								{overview?.status ?? (loading ? "Checking" : "Unavailable")}
+							</p>
+							<p className="truncate font-mono text-[9px] text-muted-foreground tabular-nums">
+								{overview
+									? `${overview.unseenCount} unseen · ${live ? "Live capture" : "Updates paused"} · ${relativeTime(overview.readAt)}`
+									: "Reading local diagnostics…"}
+							</p>
+						</div>
 					</div>
-					<div>
-						<p className="font-medium text-[12px] capitalize">
-							{overview?.status ?? (loading ? "Checking" : "Unavailable")}
-						</p>
-						<p className="font-mono text-[10px] text-muted-foreground tabular-nums">
-							{overview
-								? `Run ${overview.runId} · ${overview.unseenCount} unseen`
-								: "Loading diagnostics…"}
-						</p>
+					<div className="flex flex-wrap items-center gap-1.5">
+						<Button
+							size="sm"
+							variant="settings"
+							className="h-7 min-w-24 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
+							onClick={() => setLive((value) => !value)}
+						>
+							{live ? <Pause /> : <Play />}
+							{live ? "Pause live" : "Resume live"}
+						</Button>
+						<Button
+							size="sm"
+							variant="settings"
+							className="h-7 min-w-24 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
+							loading={refreshing}
+							onClick={() => void refresh()}
+						>
+							<RefreshCw />
+							Refresh
+						</Button>
+						<Button
+							size="sm"
+							variant="settings"
+							className="h-7 min-w-24 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
+							onClick={() =>
+								void (
+									window.zuse ?? window.memoize
+								)?.app?.revealDiagnosticsLogs?.()
+							}
+						>
+							<FolderOpen />
+							Open logs
+						</Button>
+						<Button
+							size="sm"
+							className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
+							loading={exporting}
+							onClick={() => void exportBundle()}
+						>
+							<Archive />
+							Export support bundle
+						</Button>
 					</div>
-				</div>
-				<div className="flex flex-wrap items-center gap-1.5">
-					<Button
-						size="sm"
-						variant="settings"
-						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
-						onClick={() => setLive((value) => !value)}
-					>
-						{live ? <Pause /> : <Play />}
-						{live ? "Pause live" : "Resume live"}
-					</Button>
-					<Button
-						size="sm"
-						variant="settings"
-						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
-						aria-label="Refresh diagnostics"
-						onClick={() => void refresh()}
-					>
-						<RefreshCw />
-						Refresh
-					</Button>
-					<Button
-						size="sm"
-						variant="settings"
-						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
-						onClick={() =>
-							void (
-								window.zuse ?? window.memoize
-							)?.app?.revealDiagnosticsLogs?.()
-						}
-					>
-						<FolderOpen />
-						Open logs
-					</Button>
-					<Button
-						size="sm"
-						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
-						loading={exporting}
-						onClick={() => void exportBundle()}
-					>
-						<Archive />
-						Export support bundle
-					</Button>
-				</div>
-			</div>
+				</FrameHeader>
+				<FramePanel className="grid min-h-[68px] grid-cols-2 divide-x divide-y divide-border/45 p-0 lg:grid-cols-5 lg:divide-y-0">
+					<PulseMetric
+						label="Failures"
+						value={overview ? formatCount.format(failureCount) : "—"}
+						tone={failureCount > 0 ? "danger" : "default"}
+						values={samples.map((sample) => sample.failures)}
+					/>
+					<PulseMetric
+						label="Warnings"
+						value={overview ? formatCount.format(overview.warningCount) : "—"}
+						tone={(overview?.warningCount ?? 0) > 0 ? "warning" : "default"}
+					/>
+					<PulseMetric
+						label="CPU"
+						value={processes ? `${processes.totalCpuPercent.toFixed(1)}%` : "—"}
+						values={samples.map((sample) => sample.cpu)}
+					/>
+					<PulseMetric
+						label="Memory"
+						value={processes ? formatBytes(processes.totalRssBytes) : "—"}
+						values={samples.map((sample) => sample.memory)}
+					/>
+					<PulseMetric
+						label="Stored locally"
+						value={overview ? formatBytes(overview.storageBytes) : "—"}
+					/>
+				</FramePanel>
+			</Frame>
 
 			{error && (
 				<div
 					role="alert"
-					className="flex items-start gap-2 rounded-lg border border-destructive/25 bg-destructive/8 px-3 py-2 text-[11px] text-destructive"
+					className="flex min-h-10 items-start gap-2 rounded-lg bg-alert-error-bg px-3 py-2 text-[10px] text-destructive-foreground"
 				>
-					<AlertTriangle className="mt-0.5 size-4 shrink-0" />
-					<span>{error}</span>
+					<AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+					<span className="flex-1">{error}</span>
+					<Button
+						size="xs"
+						variant="ghost"
+						className="h-6 !text-[9px]"
+						onClick={() => void refresh()}
+					>
+						Retry
+					</Button>
 				</div>
 			)}
 
-			<DiagnosticsSection
-				title="Health overview"
-				description="Current capture health across the desktop, renderer, server, and subprocesses."
+			<nav
+				aria-label="Diagnostics views"
+				className="flex min-h-9 items-center gap-1 overflow-x-auto rounded-lg border border-border/55 bg-muted/25 p-1"
 			>
-				<div className="grid grid-cols-2 divide-x divide-y divide-border/45 md:grid-cols-4">
-					<Stat
-						label="Failures"
-						value={formatCount.format(
-							(overview?.errorCount ?? 0) + (overview?.fatalCount ?? 0),
-						)}
-						tone={(overview?.errorCount ?? 0) > 0 ? "danger" : "default"}
-					/>
-					<Stat
-						label="Warnings"
-						value={formatCount.format(overview?.warningCount ?? 0)}
-						tone={(overview?.warningCount ?? 0) > 0 ? "warning" : "default"}
-					/>
-					<Stat
-						label="Slow operations"
-						value={formatCount.format(overview?.slowOperationCount ?? 0)}
-					/>
-					<Stat
-						label="Stored locally"
-						value={formatBytes(overview?.storageBytes ?? 0)}
-					/>
-				</div>
-			</DiagnosticsSection>
+				{VIEW_OPTIONS.map((option) => {
+					const Icon = option.icon;
+					const active = view === option.id;
+					return (
+						<button
+							type="button"
+							key={option.id}
+							aria-current={active ? "page" : undefined}
+							onClick={() => setView(option.id)}
+							className={cn(
+								"flex h-7 min-w-24 items-center justify-center gap-1.5 rounded-md px-3 font-medium text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:min-h-11",
+								active
+									? "bg-foreground text-background shadow-xs"
+									: "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+							)}
+						>
+							<Icon className="size-3.5" />
+							{option.label}
+						</button>
+					);
+				})}
+			</nav>
 
-			<DiagnosticsSection
-				title="Live processes"
-				description="Server-owned agents and helper processes. Signals are ancestry-validated immediately before dispatch."
-				action={<Server className="size-4 text-muted-foreground" />}
-			>
-				<div className="overflow-x-auto">
-					<table className="w-full min-w-[780px] text-left text-[11px]">
-						<thead className="border-b border-border/45 text-[10px] text-muted-foreground uppercase tracking-wider">
-							<tr>
-								<th className="px-4 py-2">Process</th>
-								<th className="px-3 py-2 text-right">CPU</th>
-								<th className="px-3 py-2 text-right">Memory</th>
-								<th className="px-3 py-2">Command</th>
-								<th className="px-3 py-2 text-right">PID</th>
-								<th className="px-4 py-2 text-right">Actions</th>
-							</tr>
-						</thead>
-						<tbody className="divide-y divide-border/40">
-							{processes?.processes.map((item) => (
-								<tr key={item.pid} className="hover:bg-muted/20">
-									<td
-										className="px-4 py-2 font-medium"
-										style={{
-											paddingLeft: `${16 + Math.min(item.depth, 6) * 14}px`,
-										}}
-									>
-										{item.name}
-									</td>
-									<td className="px-3 py-2 text-right font-mono tabular-nums">
-										{item.cpuPercent.toFixed(1)}%
-									</td>
-									<td className="px-3 py-2 text-right font-mono tabular-nums">
-										{formatBytes(item.rssBytes)}
-									</td>
-									<td
-										className="max-w-72 truncate px-3 py-2 text-muted-foreground"
-										title={item.command}
-									>
-										{item.command}
-									</td>
-									<td className="px-3 py-2 text-right font-mono tabular-nums">
-										{item.pid}
-									</td>
-									<td className="px-4 py-2">
-										<div className="flex justify-end gap-1">
-											<Button
-												size="xs"
-												variant="ghost"
-												className="!text-[10px]"
-												disabled={item.pid === processes.serverPid}
-												onClick={() =>
-													void signalProcess(item.pid, "interrupt")
-												}
-											>
-												Interrupt
-											</Button>
-											<Button
-												size="xs"
-												variant="destructive-outline"
-												className="!text-[10px]"
-												disabled={item.pid === processes.serverPid}
-												onClick={() => void signalProcess(item.pid, "kill")}
-											>
-												Kill
-											</Button>
-										</div>
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-					{!processes?.processes.length && (
-						<Empty>{processes?.error ?? "No live descendant processes."}</Empty>
-					)}
-				</div>
-			</DiagnosticsSection>
-
-			<DiagnosticsSection
-				title="Resource history"
-				description="Five-second CPU and memory samples retained while this page is open."
-				action={
-					<div className="flex rounded-md border border-border/45 bg-background/40 p-0.5">
-						{RANGE_OPTIONS.map((option) => (
-							<button
-								type="button"
-								key={option.label}
-								className={cn(
-									"h-6 min-w-8 rounded-[5px] px-1.5 font-mono text-[9px] tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-									rangeMs === option.milliseconds
-										? "bg-muted text-foreground shadow-xs"
-										: "text-muted-foreground hover:bg-muted/60",
-								)}
-								onClick={() => setRangeMs(option.milliseconds)}
-							>
-								{option.label}
-							</button>
-						))}
-					</div>
-				}
-			>
-				<div className="grid gap-3 p-3 md:grid-cols-2">
-					<ResourceChart
-						label="CPU usage"
-						value={processes?.totalCpuPercent ?? 0}
-						peak={maxCpu}
-						values={samples.map((sample) => sample.cpu)}
-						formatValue={(value) => `${value.toFixed(1)}%`}
-						lineClassName="fill-foreground stroke-foreground"
-					/>
-					<ResourceChart
-						label="Memory usage"
-						value={processes?.totalRssBytes ?? 0}
-						peak={maxMemory}
-						values={samples.map((sample) => sample.memory)}
-						formatValue={formatBytes}
-						lineClassName="fill-warning stroke-warning"
-					/>
-				</div>
-			</DiagnosticsSection>
-
-			<DiagnosticsSection
-				title="Trace diagnostics"
-				description="Structured spans, failures, slow operations, and parser health."
-			>
-				<div className="grid grid-cols-2 divide-x divide-y divide-border/45 md:grid-cols-4">
-					<Stat
-						label="Events"
-						value={formatCount.format(overview?.eventCount ?? 0)}
-					/>
-					<Stat
-						label="Failures"
-						value={formatCount.format(overview?.errorCount ?? 0)}
-						tone={(overview?.errorCount ?? 0) ? "danger" : "default"}
-					/>
-					<Stat
-						label="Slow spans"
-						value={formatCount.format(overview?.slowOperationCount ?? 0)}
-					/>
-					<Stat
-						label="Parse errors"
-						value={formatCount.format(overview?.parseErrorCount ?? 0)}
-						tone={(overview?.parseErrorCount ?? 0) ? "warning" : "default"}
-					/>
-				</div>
-			</DiagnosticsSection>
-
-			<div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">
-				<DiagnosticsSection
-					title="Latest incidents"
-					description={`${events.length} matching events loaded`}
-					action={
-						<div className="flex items-center gap-1.5">
-							<div className="relative">
-								<Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+			{view === "issues" && (
+				<Frame aria-label="Issue triage workspace">
+					<FrameHeader className="flex w-full flex-row flex-wrap items-center justify-between gap-3 px-3 py-2.5">
+						<div>
+							<FrameTitle className="text-[12px]">Issue inbox</FrameTitle>
+							<FrameDescription className="text-[9px] leading-3.5">
+								Repeated failures are grouped so the most important work stays
+								visible.
+							</FrameDescription>
+						</div>
+						<p className="font-mono text-[9px] text-muted-foreground tabular-nums">
+							{formatCount.format(incidents.length)} groups ·{" "}
+							{formatCount.format(eventTotal)} events
+						</p>
+					</FrameHeader>
+					<FramePanel className="overflow-hidden p-0">
+						<div className="flex flex-wrap items-center gap-2 border-b border-border/45 p-2.5">
+							<label className="relative min-w-48 flex-1">
+								<span className="sr-only">Search diagnostic issues</span>
+								<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
 								<input
-									aria-label="Search diagnostics"
+									type="search"
 									value={search}
 									onChange={(event) => setSearch(event.target.value)}
-									className="h-7 w-44 rounded-md border border-border/50 bg-background pl-7 pr-2 text-[11px] outline-none focus:ring-2 focus:ring-ring"
-									placeholder="Search errors"
+									className="h-8 w-full rounded-md border border-border/50 bg-background pl-8 pr-2 text-[11px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
+									placeholder="Search messages and details"
+									spellCheck={false}
 								/>
-							</div>
-							<select
-								aria-label="Filter severity"
-								value={severity}
-								onChange={(event) =>
-									setSeverity(event.target.value as DiagnosticSeverity | "all")
-								}
-								className="h-7 rounded-md border border-border/50 bg-background px-2 text-[11px]"
-							>
-								<option value="all">All levels</option>
-								<option value="fatal">Fatal</option>
-								<option value="error">Errors</option>
-								<option value="warn">Warnings</option>
-								<option value="info">Info</option>
-							</select>
-						</div>
-					}
-				>
-					<div className="border-b border-border/45 px-4 py-2">
-						<label className="flex max-w-sm items-center gap-2 text-[11px] text-muted-foreground">
-							<span>Source</span>
-							<input
-								aria-label="Filter diagnostic source"
-								value={source}
-								onChange={(event) => setSource(event.target.value)}
-								className="h-7 flex-1 rounded-md border border-border/50 bg-background px-2 text-foreground outline-none focus:ring-2 focus:ring-ring"
-								placeholder="All sources"
-							/>
-						</label>
-					</div>
-					<div className="max-h-[520px] overflow-auto">
-						<table className="w-full min-w-[640px] text-left text-[11px]">
-							<thead className="sticky top-0 border-b border-border/45 bg-card">
-								<tr>
-									<th className="px-4 py-2">Level</th>
-									<th className="px-3 py-2">Source</th>
-									<th className="px-3 py-2">Message</th>
-									<th className="px-4 py-2 text-right">Seen</th>
-								</tr>
-							</thead>
-							<tbody className="divide-y divide-border/40">
-								{events.map((item) => (
-									<tr
-										key={item.id}
+							</label>
+							<label>
+								<span className="sr-only">Filter by severity</span>
+								<select
+									value={severity}
+									onChange={(event) =>
+										setSeverity(event.target.value as DiagnosticsSeverityFilter)
+									}
+									className="h-8 rounded-md border border-border/50 bg-background px-2 text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
+								>
+									<option value="all">All levels</option>
+									<option value="fatal">Fatal</option>
+									<option value="error">Errors</option>
+									<option value="warn">Warnings</option>
+									<option value="info">Info</option>
+								</select>
+							</label>
+							<label className="min-w-36 flex-1 sm:max-w-48">
+								<span className="sr-only">Filter by source</span>
+								<input
+									value={source}
+									onChange={(event) => setSource(event.target.value)}
+									className="h-8 w-full rounded-md border border-border/50 bg-background px-2 text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:text-base"
+									placeholder="All sources"
+									spellCheck={false}
+								/>
+							</label>
+							<div className="flex rounded-md border border-border/50 bg-background p-0.5">
+								{DIAGNOSTICS_RANGE_OPTIONS.map((option) => (
+									<button
+										type="button"
+										key={option.label}
+										aria-pressed={rangeMs === option.milliseconds}
+										onClick={() => setRangeMs(option.milliseconds)}
 										className={cn(
-											"cursor-pointer hover:bg-muted/25 focus-within:bg-muted/25",
-											selected?.id === item.id && "bg-muted/40",
+											"h-6 min-w-8 rounded-[5px] px-1.5 font-mono text-[9px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:min-w-11",
+											rangeMs === option.milliseconds
+												? "bg-muted text-foreground shadow-xs"
+												: "text-muted-foreground hover:text-foreground",
 										)}
 									>
-										<td className="px-4 py-2">
-											<SeverityPill severity={item.severity} />
-										</td>
-										<td className="px-3 py-2 font-mono text-[11px] text-muted-foreground">
-											{item.source}
-										</td>
-										<td className="px-3 py-2">
+										{option.label}
+									</button>
+								))}
+							</div>
+						</div>
+
+						<div className="grid min-h-[480px] min-w-0 xl:grid-cols-[minmax(0,1fr)_340px]">
+							<div className="min-w-0 xl:border-r xl:border-border/45">
+								<div
+									ref={incidentListRef}
+									className="max-h-[620px] divide-y divide-border/40 overflow-auto"
+								>
+									{incidents.map((incident, incidentIndex) => {
+										const item = incident.event;
+										return (
 											<button
 												type="button"
-												className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-												onClick={() => setSelected(item)}
+												key={item.fingerprint}
+												onClick={() => selectIncident(item)}
+												onFocus={(event) =>
+													event.currentTarget.scrollIntoView({
+														block: "nearest",
+													})
+												}
+												onKeyDown={(event) => {
+													if (
+														event.key !== "ArrowDown" &&
+														event.key !== "ArrowUp"
+													) {
+														return;
+													}
+													event.preventDefault();
+													const nextIndex = Math.min(
+														incidents.length - 1,
+														Math.max(
+															0,
+															incidentIndex +
+																(event.key === "ArrowDown" ? 1 : -1),
+														),
+													);
+													incidentListRef.current
+														?.querySelector<HTMLButtonElement>(
+															`[data-incident-index="${nextIndex}"]`,
+														)
+														?.focus();
+												}}
+												data-incident-index={incidentIndex}
+												className={cn(
+													"grid min-h-16 w-full grid-cols-[70px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left outline-none hover:bg-muted/25 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+													selected?.fingerprint === item.fingerprint &&
+														"bg-muted/40",
+												)}
 											>
-												{item.message}
+												<SeverityPill severity={item.severity} />
+												<span className="min-w-0">
+													<span className="block truncate font-medium text-[11px]">
+														{item.message}
+													</span>
+													<span className="mt-1 block truncate font-mono text-[9px] text-muted-foreground">
+														{item.source}
+														{item.sessionId
+															? ` · session ${item.sessionId}`
+															: ""}
+													</span>
+												</span>
+												<span className="text-right">
+													<span className="block font-mono text-[10px] tabular-nums">
+														{incident.occurrences > 1
+															? `${incident.occurrences}×`
+															: "Once"}
+													</span>
+													<span className="mt-1 block whitespace-nowrap font-mono text-[9px] text-muted-foreground">
+														{relativeTime(item.createdAt)}
+													</span>
+												</span>
 											</button>
-										</td>
-										<td className="whitespace-nowrap px-4 py-2 text-right font-mono text-muted-foreground tabular-nums">
-											{relativeTime(item.createdAt)}
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-						{events.length === 0 && (
-							<Empty>No incidents match these filters.</Empty>
+										);
+									})}
+									{!loading && incidents.length === 0 && (
+										<EmptyState
+											title="No matching issues"
+											description="Change the filters or time range. Healthy captures will appear here only when they need attention."
+										/>
+									)}
+									{loading && incidents.length === 0 && (
+										<EmptyState
+											icon={Activity}
+											title="Checking the system"
+											description="Reading recent incidents and correlating local process state."
+										/>
+									)}
+								</div>
+								{nextEventCursor && (
+									<div className="flex min-h-11 items-center justify-between border-t border-border/45 px-4 py-2 text-[9px] text-muted-foreground">
+										<span className="font-mono tabular-nums">
+											{formatCount.format(events.length)} of{" "}
+											{formatCount.format(eventTotal)} events loaded
+										</span>
+										<Button
+											size="sm"
+											variant="settings"
+											className="h-7 px-2.5 !text-[10px]"
+											onClick={() => void loadMoreEvents()}
+										>
+											Load more
+										</Button>
+									</div>
+								)}
+							</div>
+							<aside
+								className="hidden min-w-0 xl:block"
+								aria-label="Issue details"
+							>
+								<IncidentDetails
+									selected={selected}
+									related={related}
+									copiedKey={copiedKey}
+									onCopy={copyText}
+								/>
+							</aside>
+						</div>
+					</FramePanel>
+				</Frame>
+			)}
+
+			{view === "performance" && (
+				<Frame aria-label="Performance diagnostics">
+					<FrameHeader className="flex w-full flex-row flex-wrap items-center justify-between gap-3 px-3 py-2.5">
+						<div>
+							<FrameTitle className="text-[12px]">Performance</FrameTitle>
+							<FrameDescription className="text-[9px] leading-3.5">
+								Live resource pressure and the operations most likely to slow
+								the app down.
+							</FrameDescription>
+						</div>
+						<div className="flex rounded-md border border-border/45 bg-background/40 p-0.5">
+							{DIAGNOSTICS_RANGE_OPTIONS.map((option) => (
+								<button
+									type="button"
+									key={option.label}
+									aria-pressed={rangeMs === option.milliseconds}
+									onClick={() => setRangeMs(option.milliseconds)}
+									className={cn(
+										"h-6 min-w-8 rounded-[5px] px-1.5 font-mono text-[9px] outline-none focus-visible:ring-2 focus-visible:ring-ring pointer-coarse:h-11 pointer-coarse:min-w-11",
+										rangeMs === option.milliseconds
+											? "bg-muted text-foreground shadow-xs"
+											: "text-muted-foreground hover:text-foreground",
+									)}
+								>
+									{option.label}
+								</button>
+							))}
+						</div>
+					</FrameHeader>
+					<FramePanel className="overflow-hidden p-0">
+						<div className="grid grid-cols-2 divide-x divide-y divide-border/45 lg:grid-cols-4 lg:divide-y-0">
+							<PulseMetric
+								label="Captured events"
+								value={formatCount.format(overview?.eventCount ?? 0)}
+							/>
+							<PulseMetric
+								label="Slow spans"
+								value={formatCount.format(overview?.slowOperationCount ?? 0)}
+							/>
+							<PulseMetric
+								label="Parse errors"
+								value={formatCount.format(overview?.parseErrorCount ?? 0)}
+								tone={
+									(overview?.parseErrorCount ?? 0) > 0 ? "warning" : "default"
+								}
+							/>
+							<PulseMetric
+								label="Trace state"
+								value={
+									(overview?.parseErrorCount ?? 0) > 0 ? "Partial" : "Ready"
+								}
+							/>
+						</div>
+						<div className="grid divide-y divide-border/45 border-t border-border/45 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+							<ResourceChart
+								label="CPU usage"
+								value={processes?.totalCpuPercent ?? 0}
+								peak={maxCpu}
+								values={samples.map((sample) => sample.cpu)}
+								formatValue={(value) => `${value.toFixed(1)}%`}
+								className="stroke-foreground"
+							/>
+							<ResourceChart
+								label="Memory usage"
+								value={processes?.totalRssBytes ?? 0}
+								peak={maxMemory}
+								values={samples.map((sample) => sample.memory)}
+								formatValue={formatBytes}
+								className="stroke-warning"
+							/>
+						</div>
+						<div className="grid border-t border-border/45 lg:grid-cols-2 lg:divide-x lg:divide-border/45">
+							<section className="min-w-0">
+								<div className="border-b border-border/45 px-4 py-2.5">
+									<h3 className="font-medium text-[10px]">
+										Slowest operations
+									</h3>
+								</div>
+								{overview?.slowestOperations.length ? (
+									<div className="divide-y divide-border/40">
+										{overview.slowestOperations.slice(0, 8).map((item) => (
+											<div
+												key={item.id}
+												className="flex items-center justify-between gap-4 px-4 py-3"
+											>
+												<div className="min-w-0">
+													<p className="truncate font-medium text-[10px]">
+														{item.message}
+													</p>
+													<p className="mt-1 truncate font-mono text-[9px] text-muted-foreground">
+														{item.traceId ?? item.id}
+													</p>
+												</div>
+												<span className="shrink-0 font-mono text-[10px] tabular-nums">
+													{formatDuration(item.durationMs ?? 0)}
+												</span>
+											</div>
+										))}
+									</div>
+								) : (
+									<EmptyState
+										title="No slow operations"
+										description="Operations taking at least one second will appear here."
+									/>
+								)}
+							</section>
+							<section className="min-w-0 border-t border-border/45 lg:border-t-0">
+								<div className="border-b border-border/45 px-4 py-2.5">
+									<h3 className="font-medium text-[10px]">Top operations</h3>
+								</div>
+								{overview?.topOperations.length ? (
+									<div className="divide-y divide-border/40">
+										{overview.topOperations.slice(0, 8).map((item) => (
+											<div
+												key={item.name}
+												className="grid grid-cols-[minmax(0,1fr)_repeat(5,48px)] gap-2 px-4 py-3 text-[9px]"
+											>
+												<span className="truncate font-medium text-[10px]">
+													{item.name}
+												</span>
+												<span
+													className="text-right font-mono tabular-nums"
+													title="Count"
+												>
+													{item.count}×
+												</span>
+												<span
+													className="text-right font-mono tabular-nums"
+													title="Failures"
+												>
+													{item.failureCount} fail
+												</span>
+												<span
+													className="text-right font-mono tabular-nums"
+													title="Average"
+												>
+													{formatDuration(item.averageDurationMs)}
+												</span>
+												<span
+													className="text-right font-mono tabular-nums"
+													title="95th percentile"
+												>
+													{formatDuration(item.p95DurationMs)}
+												</span>
+												<span
+													className="text-right font-mono tabular-nums"
+													title="Maximum"
+												>
+													{formatDuration(item.maxDurationMs)}
+												</span>
+											</div>
+										))}
+									</div>
+								) : (
+									<EmptyState
+										title="No operation summaries"
+										description="Instrumented traces will build an operation profile here."
+									/>
+								)}
+							</section>
+						</div>
+					</FramePanel>
+				</Frame>
+			)}
+
+			{view === "processes" && (
+				<Frame aria-label="Live processes">
+					<FrameHeader className="flex w-full flex-row items-center justify-between gap-3 px-3 py-2.5">
+						<div>
+							<FrameTitle className="text-[12px]">Live processes</FrameTitle>
+							<FrameDescription className="text-[9px] leading-3.5">
+								Server-owned helpers. Process ancestry is validated again before
+								every signal.
+							</FrameDescription>
+						</div>
+						<p className="shrink-0 font-mono text-[9px] text-muted-foreground tabular-nums">
+							{processes?.processes.length ?? 0} running
+						</p>
+					</FrameHeader>
+					<FramePanel className="overflow-hidden p-0">
+						{processes && !processes.supported && (
+							<div className="flex items-center gap-2 border-b border-border/45 bg-warning/8 px-4 py-2.5 text-[10px] text-warning">
+								<AlertTriangle className="size-3.5" />
+								{processes.error ??
+									"Process sampling is not supported on this platform."}
+							</div>
 						)}
-						{nextEventCursor && (
-							<div className="flex items-center justify-between border-t border-border/45 px-4 py-3 text-[11px] text-muted-foreground">
-								<span>
-									{formatCount.format(events.length)} of{" "}
-									{formatCount.format(eventTotal)}
-								</span>
+						<div className="overflow-x-auto">
+							<table className="w-full min-w-[780px] text-left text-[10px]">
+								<thead className="border-b border-border/45 text-[9px] text-muted-foreground uppercase tracking-wider">
+									<tr>
+										<th className="px-4 py-2">Process</th>
+										<th className="px-3 py-2 text-right">CPU</th>
+										<th className="px-3 py-2 text-right">Memory</th>
+										<th className="px-3 py-2">Command</th>
+										<th className="px-3 py-2 text-right">PID</th>
+										<th className="px-4 py-2 text-right">Actions</th>
+									</tr>
+								</thead>
+								<tbody className="divide-y divide-border/40">
+									{processes?.processes.map((item) => (
+										<tr key={item.pid} className="hover:bg-muted/20">
+											<td
+												className="px-4 py-2.5 font-medium"
+												style={{
+													paddingLeft: `${16 + Math.min(item.depth, 6) * 14}px`,
+												}}
+											>
+												{item.name}
+											</td>
+											<td className="px-3 py-2.5 text-right font-mono tabular-nums">
+												{item.cpuPercent.toFixed(1)}%
+											</td>
+											<td className="px-3 py-2.5 text-right font-mono tabular-nums">
+												{formatBytes(item.rssBytes)}
+											</td>
+											<td
+												className="max-w-72 truncate px-3 py-2.5 text-muted-foreground"
+												title={item.command}
+											>
+												{item.command}
+											</td>
+											<td className="px-3 py-2.5 text-right font-mono tabular-nums">
+												{item.pid}
+											</td>
+											<td className="px-4 py-2">
+												<div className="flex justify-end gap-1">
+													<Button
+														size="sm"
+														variant="ghost"
+														className="h-7 min-w-16 !text-[9px]"
+														disabled={item.pid === processes.serverPid}
+														onClick={() =>
+															void signalProcess(item.pid, "interrupt")
+														}
+													>
+														Interrupt
+													</Button>
+													<Button
+														size="sm"
+														variant="destructive-outline"
+														className="h-7 min-w-16 !text-[9px]"
+														disabled={item.pid === processes.serverPid}
+														onClick={() => void signalProcess(item.pid, "kill")}
+													>
+														Kill
+													</Button>
+												</div>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+							{!loading && !processes?.processes.length && (
+								<EmptyState
+									icon={Server}
+									title="No helper processes"
+									description={
+										processes?.error ??
+										"No live descendants are owned by the diagnostics root."
+									}
+								/>
+							)}
+						</div>
+					</FramePanel>
+				</Frame>
+			)}
+
+			{view === "storage" && (
+				<Frame aria-label="Diagnostics storage and privacy">
+					<FrameHeader className="px-3 py-2.5">
+						<FrameTitle className="text-[12px]">Storage and privacy</FrameTitle>
+						<FrameDescription className="text-[9px] leading-3.5">
+							Diagnostics stay on this device unless you explicitly export them.
+						</FrameDescription>
+					</FrameHeader>
+					<FramePanel className="overflow-hidden p-0">
+						<div className="grid divide-y divide-border/45 md:grid-cols-3 md:divide-x md:divide-y-0">
+							<div className="p-4">
+								<p className="font-medium text-[10px]">Retention</p>
+								<p className="mt-1 font-mono text-sm tabular-nums">7 days</p>
+								<p className="mt-1 text-[9px] text-muted-foreground">
+									250 MB maximum across rotating diagnostic files.
+								</p>
+							</div>
+							<div className="p-4">
+								<p className="font-medium text-[10px]">Local usage</p>
+								<p className="mt-1 font-mono text-sm tabular-nums">
+									{formatBytes(overview?.storageBytes ?? 0)}
+								</p>
+								<p className="mt-1 text-[9px] text-muted-foreground">
+									Old files are pruned by age and storage budget.
+								</p>
+							</div>
+							<div className="p-4">
+								<p className="font-medium text-[10px]">Capture</p>
+								<p className="mt-1 text-sm">
+									{overview?.capturePaused ? "Paused" : "Standard"}
+								</p>
+								<p className="mt-1 text-[9px] text-muted-foreground">
+									Secrets and conversation content are excluded by default.
+								</p>
+							</div>
+						</div>
+						<div className="border-t border-border/45 p-4">
+							<div className="max-w-2xl">
+								<h3 className="font-medium text-[11px]">Support bundle</h3>
+								<p className="mt-1 text-[10px] text-muted-foreground leading-4">
+									Creates a sanitized local bundle for the selected time range.
+									Prompts, transcripts, files, terminal output, credentials,
+									environment values, and URL query strings remain excluded.
+								</p>
+							</div>
+							<div className="mt-4 flex flex-wrap gap-2">
+								<Button
+									size="sm"
+									className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
+									loading={exporting}
+									onClick={() => void exportBundle()}
+								>
+									<Archive />
+									Export support bundle
+								</Button>
 								<Button
 									size="sm"
 									variant="settings"
-									className="h-7 px-2.5 !text-[10px]"
-									onClick={() => void loadMoreEvents()}
-								>
-									Load more
-								</Button>
-							</div>
-						)}
-					</div>
-				</DiagnosticsSection>
-				<aside
-					className="self-start rounded-lg border border-border/60 bg-muted/30 p-4 xl:sticky xl:top-20"
-					aria-label="Incident details"
-				>
-					{selected ? (
-						<div className="space-y-4">
-							<div className="flex items-start justify-between gap-3">
-								<div>
-									<SeverityPill severity={selected.severity} />
-									<h3 className="mt-2 font-medium text-[12px]">
-										{selected.message}
-									</h3>
-								</div>
-								<Button
-									size="icon-xs"
-									variant="ghost"
-									aria-label="Copy diagnostic ID"
+									className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 									onClick={() =>
-										void navigator.clipboard.writeText(selected.id)
+										void (
+											window.zuse ?? window.memoize
+										)?.app?.revealDiagnosticsLogs?.()
 									}
 								>
-									<Copy />
+									<ExternalLink />
+									Open diagnostics folder
 								</Button>
 							</div>
-							<dl className="grid grid-cols-[90px_1fr] gap-2 text-[11px]">
-								<dt className="text-muted-foreground">Diagnostic ID</dt>
-								<dd className="break-all font-mono">{selected.id}</dd>
-								<dt className="text-muted-foreground">Source</dt>
-								<dd className="font-mono">{selected.source}</dd>
-								<dt className="text-muted-foreground">Run</dt>
-								<dd className="font-mono">{selected.runId}</dd>
-								<dt className="text-muted-foreground">Recovery</dt>
-								<dd>{selected.recoveryStatus}</dd>
-								<dt className="text-muted-foreground">Trace</dt>
-								<dd className="break-all font-mono">
-									{selected.traceId ?? "Not correlated"}
-								</dd>
-							</dl>
-							{selected.detail && (
-								<pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-3 text-[11px] leading-5">
-									{selected.detail}
-								</pre>
-							)}
-							<Button
-								size="sm"
-								variant="settings"
-								className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
-								onClick={() =>
-									void navigator.clipboard.writeText(
-										`${selected.id}\n${selected.message}\n${selected.detail ?? ""}`,
-									)
-								}
-							>
-								<Copy />
-								Copy details
-							</Button>
 						</div>
-					) : (
-						<div className="flex min-h-48 flex-col items-center justify-center text-center">
-							<ShieldCheck className="size-6 text-muted-foreground" />
-							<p className="mt-2 font-medium text-[12px]">Select an incident</p>
-							<p className="mt-1 max-w-52 text-[11px] text-muted-foreground">
-								Inspect its sanitized details, correlation IDs, and recovery
-								state.
-							</p>
-						</div>
-					)}
-				</aside>
-			</div>
+					</FramePanel>
+				</Frame>
+			)}
 
-			<DiagnosticsSection
-				title="Most common failures"
-				description="Repeated incidents grouped by stable fingerprint."
+			<Dialog
+				open={isNarrow && mobileDetailsOpen}
+				onOpenChange={setMobileDetailsOpen}
 			>
-				{overview?.commonFailures.length ? (
-					<div className="divide-y divide-border/40">
-						{overview.commonFailures.map((group) => (
-							<div
-								key={group.fingerprint}
-								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-[11px]"
-							>
-								<div>
-									<p className="font-medium">{group.message}</p>
-									<p className="mt-1 font-mono text-[11px] text-muted-foreground">
-										{group.source} · {group.fingerprint}
-									</p>
-								</div>
-								<div className="text-right">
-									<p className="font-mono font-semibold tabular-nums">
-										{group.count}×
-									</p>
-									<p className="text-muted-foreground">
-										{relativeTime(group.lastSeenAt)}
-									</p>
-								</div>
-							</div>
-						))}
-					</div>
-				) : (
-					<Empty>No repeated failures in this range.</Empty>
-				)}
-			</DiagnosticsSection>
-
-			<DiagnosticsSection
-				title="Slowest operations"
-				description="Operations taking one second or longer."
-			>
-				{overview?.slowestOperations.length ? (
-					<div className="divide-y divide-border/40">
-						{overview.slowestOperations.map((item) => (
-							<div
-								key={item.id}
-								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-[11px]"
-							>
-								<div>
-									<p className="font-medium">{item.message}</p>
-									<p className="mt-1 font-mono text-muted-foreground">
-										{item.source} · {item.traceId ?? item.id}
-									</p>
-								</div>
-								<p className="font-mono font-semibold tabular-nums">
-									{formatDuration(item.durationMs ?? 0)}
-								</p>
-							</div>
-						))}
-					</div>
-				) : (
-					<Empty>No slow operations captured.</Empty>
-				)}
-			</DiagnosticsSection>
-
-			<DiagnosticsSection
-				title="Warning and error logs"
-				description="Sanitized structured events from every application boundary."
-			>
-				<div className="divide-y divide-border/40">
-					{events
-						.filter(
-							(item) =>
-								item.severity === "warn" ||
-								item.severity === "error" ||
-								item.severity === "fatal",
-						)
-						.slice(0, 20)
-						.map((item) => (
-							<button
-								type="button"
-								key={item.id}
-								onClick={() => setSelected(item)}
-								className="grid w-full grid-cols-[70px_160px_1fr_auto] gap-3 px-4 py-3 text-left text-[11px] hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-							>
-								<SeverityPill severity={item.severity} />
-								<span className="truncate font-mono text-muted-foreground">
-									{item.source}
-								</span>
-								<span className="truncate">{item.message}</span>
-								<span className="font-mono text-muted-foreground tabular-nums">
-									{relativeTime(item.createdAt)}
-								</span>
-							</button>
-						))}
-				</div>
-			</DiagnosticsSection>
-
-			<DiagnosticsSection
-				title="Top operations"
-				description="Count, failures, average, p95, and maximum duration."
-			>
-				{overview?.topOperations.length ? (
-					<div className="divide-y divide-border/40">
-						{overview.topOperations.map((item) => (
-							<div
-								key={item.name}
-								className="grid grid-cols-[1fr_repeat(4,90px)] gap-3 px-4 py-3 text-[11px]"
-							>
-								<span className="font-medium">{item.name}</span>
-								<span className="text-right font-mono tabular-nums">
-									{item.count}
-								</span>
-								<span className="text-right font-mono tabular-nums">
-									{item.failureCount}
-								</span>
-								<span className="text-right font-mono tabular-nums">
-									{formatDuration(item.p95DurationMs)}
-								</span>
-								<span className="text-right font-mono tabular-nums">
-									{formatDuration(item.maxDurationMs)}
-								</span>
-							</div>
-						))}
-					</div>
-				) : (
-					<Empty>
-						Operation summaries appear as instrumented traces are captured.
-					</Empty>
-				)}
-			</DiagnosticsSection>
-
-			<DiagnosticsSection
-				title="Storage and capture tools"
-				description="Diagnostics stay on this device unless you explicitly export them."
-			>
-				<div className="grid gap-3 p-4 md:grid-cols-3">
-					<div className="rounded-lg border border-border/50 bg-background/35 p-3">
-						<p className="font-medium text-[11px]">Retention</p>
-						<p className="mt-1 text-[10px] text-muted-foreground">
-							7 days · 250 MB maximum
-						</p>
-					</div>
-					<div className="rounded-lg border border-border/50 bg-background/35 p-3">
-						<p className="font-medium text-[11px]">Verbose capture</p>
-						<p className="mt-1 text-[10px] text-muted-foreground">
-							Off · secrets and conversation content excluded
-						</p>
-					</div>
-					<div className="rounded-lg border border-border/50 bg-background/35 p-3">
-						<p className="font-medium text-[11px]">Remote export</p>
-						<p className="mt-1 text-[10px] text-muted-foreground">
-							Disabled · local-first
-						</p>
-					</div>
-				</div>
-				<div className="flex flex-wrap gap-2 border-t border-border/45 p-4">
-					<Button
-						size="sm"
-						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
-						onClick={() => void exportBundle()}
-						loading={exporting}
-					>
-						<Archive />
-						Export support bundle
-					</Button>
-					<Button
-						size="sm"
-						variant="settings"
-						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
-						onClick={() =>
-							void (
-								window.zuse ?? window.memoize
-							)?.app?.revealDiagnosticsLogs?.()
-						}
-					>
-						<ExternalLink />
-						Open diagnostics folder
-					</Button>
-				</div>
-			</DiagnosticsSection>
+				<DialogPopup className="max-w-lg">
+					<DialogHeader>
+						<DialogTitle className="text-base">Issue details</DialogTitle>
+						<DialogDescription className="text-[10px]">
+							Sanitized diagnostic context and related occurrences.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogPanel className="p-0" scrollFade={false}>
+						<IncidentDetails
+							selected={selected}
+							related={related}
+							copiedKey={copiedKey}
+							onCopy={copyText}
+						/>
+					</DialogPanel>
+				</DialogPopup>
+			</Dialog>
 		</div>
 	);
 }

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -429,7 +429,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 						onClick={() => setLive((value) => !value)}
 					>
 						{live ? <Pause /> : <Play />}
@@ -438,7 +438,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 						aria-label="Refresh diagnostics"
 						onClick={() => void refresh()}
 					>
@@ -448,7 +448,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 						onClick={() =>
 							void (
 								window.zuse ?? window.memoize
@@ -460,7 +460,7 @@ export function DiagnosticsPane() {
 					</Button>
 					<Button
 						size="sm"
-						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 						loading={exporting}
 						onClick={() => void exportBundle()}
 					>
@@ -556,7 +556,7 @@ export function DiagnosticsPane() {
 											<Button
 												size="xs"
 												variant="ghost"
-												className="text-[10px]"
+												className="!text-[10px]"
 												disabled={item.pid === processes.serverPid}
 												onClick={() =>
 													void signalProcess(item.pid, "interrupt")
@@ -567,7 +567,7 @@ export function DiagnosticsPane() {
 											<Button
 												size="xs"
 												variant="destructive-outline"
-												className="text-[10px]"
+												className="!text-[10px]"
 												disabled={item.pid === processes.serverPid}
 												onClick={() => void signalProcess(item.pid, "kill")}
 											>
@@ -752,7 +752,7 @@ export function DiagnosticsPane() {
 								<Button
 									size="sm"
 									variant="settings"
-									className="h-7 px-2.5 text-[10px]"
+									className="h-7 px-2.5 !text-[10px]"
 									onClick={() => void loadMoreEvents()}
 								>
 									Load more
@@ -807,7 +807,7 @@ export function DiagnosticsPane() {
 							<Button
 								size="sm"
 								variant="settings"
-								className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
+								className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 								onClick={() =>
 									void navigator.clipboard.writeText(
 										`${selected.id}\n${selected.message}\n${selected.detail ?? ""}`,
@@ -986,7 +986,7 @@ export function DiagnosticsPane() {
 				<div className="flex flex-wrap gap-2 border-t border-border/45 p-4">
 					<Button
 						size="sm"
-						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 						onClick={() => void exportBundle()}
 						loading={exporting}
 					>
@@ -996,7 +996,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 !text-[10px] [&_svg]:size-3.5"
 						onClick={() =>
 							void (
 								window.zuse ?? window.memoize

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -67,12 +67,12 @@ function DiagnosticsSection({
 	readonly children: React.ReactNode;
 }) {
 	return (
-		<section className="overflow-hidden rounded-xl border border-border/50 bg-card/70 shadow-xs">
-			<header className="flex min-h-14 items-center justify-between gap-4 border-b border-border/45 px-4 py-3">
+		<section className="overflow-hidden rounded-lg border border-border/60 bg-muted/30">
+			<header className="flex min-h-11 items-center justify-between gap-4 border-b border-border/40 px-4 py-2.5">
 				<div className="min-w-0">
-					<h2 className="font-semibold text-sm text-foreground">{title}</h2>
+					<h2 className="font-medium text-[12px] text-foreground">{title}</h2>
 					{description && (
-						<p className="mt-0.5 text-muted-foreground text-xs">
+						<p className="mt-0.5 truncate text-[10px] text-muted-foreground leading-4">
 							{description}
 						</p>
 					)}
@@ -95,12 +95,12 @@ function Stat({
 }) {
 	return (
 		<div className="min-w-0 px-4 py-3">
-			<p className="truncate font-medium text-[10px] text-muted-foreground uppercase tracking-[0.1em]">
+			<p className="truncate font-medium text-[9px] text-muted-foreground uppercase tracking-[0.12em]">
 				{label}
 			</p>
 			<p
 				className={cn(
-					"mt-1 truncate font-mono font-semibold text-lg tabular-nums",
+					"mt-1 truncate font-mono font-medium text-base tabular-nums",
 					tone === "danger" && "text-destructive",
 					tone === "warning" && "text-warning",
 				)}
@@ -113,8 +113,80 @@ function Stat({
 
 function Empty({ children }: { children: React.ReactNode }) {
 	return (
-		<div className="px-4 py-6 text-center text-muted-foreground text-xs">
+		<div className="px-4 py-6 text-center text-[11px] text-muted-foreground">
 			{children}
+		</div>
+	);
+}
+
+function ResourceChart({
+	label,
+	value,
+	peak,
+	values,
+	formatValue,
+	lineClassName,
+}: {
+	readonly label: string;
+	readonly value: number;
+	readonly peak: number;
+	readonly values: ReadonlyArray<number>;
+	readonly formatValue: (value: number) => string;
+	readonly lineClassName: string;
+}) {
+	const width = 320;
+	const height = 92;
+	const ceiling = Math.max(1, peak);
+	const chartValues =
+		values.length === 0
+			? [0, 0]
+			: values.length === 1
+				? [values[0] ?? 0, values[0] ?? 0]
+				: values;
+	const points = chartValues.map((sample, index, all) => {
+		const x = (index / Math.max(1, all.length - 1)) * width;
+		const y = height - Math.min(1, sample / ceiling) * (height - 8) - 4;
+		return `${x.toFixed(1)},${y.toFixed(1)}`;
+	});
+	const areaPoints = `0,${height} ${points.join(" ")} ${width},${height}`;
+
+	return (
+		<div className="overflow-hidden rounded-lg border border-border/50 bg-background/35">
+			<div className="flex items-start justify-between gap-3 px-3 pt-3">
+				<div>
+					<p className="font-medium text-[10px] text-muted-foreground">
+						{label}
+					</p>
+					<p className="mt-0.5 font-mono text-sm tabular-nums">
+						{formatValue(value)}
+					</p>
+				</div>
+				<p className="pt-0.5 text-[9px] text-muted-foreground">
+					Peak{" "}
+					<span className="font-mono tabular-nums">{formatValue(peak)}</span>
+				</p>
+			</div>
+			<svg
+				viewBox={`0 0 ${width} ${height}`}
+				preserveAspectRatio="none"
+				className="mt-2 block h-24 w-full"
+				role="img"
+				aria-label={`${label}: ${formatValue(value)}, peak ${formatValue(peak)}`}
+			>
+				<line x1="0" x2={width} y1="31" y2="31" className="stroke-border/35" />
+				<line x1="0" x2={width} y1="61" y2="61" className="stroke-border/35" />
+				<polygon
+					points={areaPoints}
+					className={cn(lineClassName, "opacity-10")}
+				/>
+				<polyline
+					points={points.join(" ")}
+					fill="none"
+					vectorEffect="non-scaling-stroke"
+					strokeWidth="1.5"
+					className={lineClassName}
+				/>
+			</svg>
 		</div>
 	);
 }
@@ -318,6 +390,7 @@ export function DiagnosticsPane() {
 	};
 
 	const maxCpu = Math.max(1, ...samples.map((sample) => sample.cpu));
+	const maxMemory = Math.max(1, ...samples.map((sample) => sample.memory));
 	const statusTone =
 		overview?.status === "failing"
 			? "text-destructive"
@@ -326,32 +399,33 @@ export function DiagnosticsPane() {
 				: "text-success";
 
 	return (
-		<div className="flex min-w-0 flex-col gap-4 pb-12">
-			<div className="sticky top-0 z-20 -mx-2 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/45 bg-background/92 px-4 py-3 shadow-sm backdrop-blur-xl">
+		<div className="flex min-w-0 flex-col gap-3 pb-12 text-[11px]">
+			<div className="sticky top-0 z-20 -mx-2 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/92 px-3 py-2.5 shadow-sm backdrop-blur-xl">
 				<div className="flex min-w-0 items-center gap-3">
 					<div
 						className={cn(
-							"flex size-9 items-center justify-center rounded-lg bg-muted",
+							"flex size-8 items-center justify-center rounded-md border border-border/45 bg-muted/50",
 							statusTone,
 						)}
 					>
-						<Activity className="size-4" />
+						<Activity className="size-3.5" />
 					</div>
 					<div>
-						<p className="font-semibold text-sm capitalize">
+						<p className="font-medium text-[12px] capitalize">
 							{overview?.status ?? (loading ? "Checking" : "Unavailable")}
 						</p>
-						<p className="font-mono text-[11px] text-muted-foreground tabular-nums">
+						<p className="font-mono text-[10px] text-muted-foreground tabular-nums">
 							{overview
 								? `Run ${overview.runId} · ${overview.unseenCount} unseen`
 								: "Loading diagnostics…"}
 						</p>
 					</div>
 				</div>
-				<div className="flex flex-wrap items-center gap-2">
+				<div className="flex flex-wrap items-center gap-1.5">
 					<Button
 						size="sm"
 						variant="settings"
+						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
 						onClick={() => setLive((value) => !value)}
 					>
 						{live ? <Pause /> : <Play />}
@@ -360,6 +434,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
+						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
 						aria-label="Refresh diagnostics"
 						onClick={() => void refresh()}
 					>
@@ -369,6 +444,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
+						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
 						onClick={() =>
 							void (
 								window.zuse ?? window.memoize
@@ -380,6 +456,7 @@ export function DiagnosticsPane() {
 					</Button>
 					<Button
 						size="sm"
+						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
 						loading={exporting}
 						onClick={() => void exportBundle()}
 					>
@@ -392,7 +469,7 @@ export function DiagnosticsPane() {
 			{error && (
 				<div
 					role="alert"
-					className="flex items-start gap-2 rounded-lg border border-destructive/25 bg-destructive/8 px-3 py-2 text-destructive text-xs"
+					className="flex items-start gap-2 rounded-lg border border-destructive/25 bg-destructive/8 px-3 py-2 text-[11px] text-destructive"
 				>
 					<AlertTriangle className="mt-0.5 size-4 shrink-0" />
 					<span>{error}</span>
@@ -433,7 +510,7 @@ export function DiagnosticsPane() {
 				action={<Server className="size-4 text-muted-foreground" />}
 			>
 				<div className="overflow-x-auto">
-					<table className="w-full min-w-[780px] text-left text-xs">
+					<table className="w-full min-w-[780px] text-left text-[11px]">
 						<thead className="border-b border-border/45 text-[10px] text-muted-foreground uppercase tracking-wider">
 							<tr>
 								<th className="px-4 py-2">Process</th>
@@ -506,15 +583,15 @@ export function DiagnosticsPane() {
 				title="Resource history"
 				description="Five-second CPU and memory samples retained while this page is open."
 				action={
-					<div className="flex gap-1">
+					<div className="flex rounded-md border border-border/45 bg-background/40 p-0.5">
 						{RANGE_OPTIONS.map((option) => (
 							<button
 								type="button"
 								key={option.label}
 								className={cn(
-									"h-7 rounded-md px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+									"h-6 min-w-8 rounded-[5px] px-1.5 font-mono text-[9px] tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
 									rangeMs === option.milliseconds
-										? "bg-muted text-foreground"
+										? "bg-muted text-foreground shadow-xs"
 										: "text-muted-foreground hover:bg-muted/60",
 								)}
 								onClick={() => setRangeMs(option.milliseconds)}
@@ -525,29 +602,23 @@ export function DiagnosticsPane() {
 					</div>
 				}
 			>
-				<div className="grid grid-cols-2 divide-x divide-border/45">
-					<Stat
-						label="Current CPU"
-						value={`${(processes?.totalCpuPercent ?? 0).toFixed(1)}%`}
+				<div className="grid gap-3 p-3 md:grid-cols-2">
+					<ResourceChart
+						label="CPU usage"
+						value={processes?.totalCpuPercent ?? 0}
+						peak={maxCpu}
+						values={samples.map((sample) => sample.cpu)}
+						formatValue={(value) => `${value.toFixed(1)}%`}
+						lineClassName="fill-foreground stroke-foreground"
 					/>
-					<Stat
-						label="Current memory"
-						value={formatBytes(processes?.totalRssBytes ?? 0)}
+					<ResourceChart
+						label="Memory usage"
+						value={processes?.totalRssBytes ?? 0}
+						peak={maxMemory}
+						values={samples.map((sample) => sample.memory)}
+						formatValue={formatBytes}
+						lineClassName="fill-warning stroke-warning"
 					/>
-				</div>
-				<div
-					className="flex h-32 items-end gap-1 border-t border-border/45 p-4"
-					role="img"
-					aria-label="Recent process CPU usage"
-				>
-					{samples.map((sample) => (
-						<div
-							key={sample.at}
-							className="min-w-1 flex-1 rounded-t-sm bg-foreground/55"
-							style={{ height: `${Math.max(3, (sample.cpu / maxCpu) * 100)}%` }}
-							title={`${sample.cpu.toFixed(1)}% CPU · ${formatBytes(sample.memory)}`}
-						/>
-					))}
 				</div>
 			</DiagnosticsSection>
 
@@ -589,7 +660,7 @@ export function DiagnosticsPane() {
 									aria-label="Search diagnostics"
 									value={search}
 									onChange={(event) => setSearch(event.target.value)}
-									className="h-8 w-48 rounded-lg border border-border/50 bg-background pl-7 pr-2 text-xs outline-none focus:ring-2 focus:ring-ring"
+									className="h-7 w-44 rounded-md border border-border/50 bg-background pl-7 pr-2 text-[11px] outline-none focus:ring-2 focus:ring-ring"
 									placeholder="Search errors"
 								/>
 							</div>
@@ -599,7 +670,7 @@ export function DiagnosticsPane() {
 								onChange={(event) =>
 									setSeverity(event.target.value as DiagnosticSeverity | "all")
 								}
-								className="h-8 rounded-lg border border-border/50 bg-background px-2 text-xs"
+								className="h-7 rounded-md border border-border/50 bg-background px-2 text-[11px]"
 							>
 								<option value="all">All levels</option>
 								<option value="fatal">Fatal</option>
@@ -611,7 +682,7 @@ export function DiagnosticsPane() {
 					}
 				>
 					<div className="border-b border-border/45 px-4 py-2">
-						<label className="flex max-w-sm items-center gap-2 text-muted-foreground text-xs">
+						<label className="flex max-w-sm items-center gap-2 text-[11px] text-muted-foreground">
 							<span>Source</span>
 							<input
 								aria-label="Filter diagnostic source"
@@ -623,7 +694,7 @@ export function DiagnosticsPane() {
 						</label>
 					</div>
 					<div className="max-h-[520px] overflow-auto">
-						<table className="w-full min-w-[640px] text-left text-xs">
+						<table className="w-full min-w-[640px] text-left text-[11px]">
 							<thead className="sticky top-0 border-b border-border/45 bg-card">
 								<tr>
 									<th className="px-4 py-2">Level</th>
@@ -667,7 +738,7 @@ export function DiagnosticsPane() {
 							<Empty>No incidents match these filters.</Empty>
 						)}
 						{nextEventCursor && (
-							<div className="flex items-center justify-between border-t border-border/45 px-4 py-3 text-muted-foreground text-xs">
+							<div className="flex items-center justify-between border-t border-border/45 px-4 py-3 text-[11px] text-muted-foreground">
 								<span>
 									{formatCount.format(events.length)} of{" "}
 									{formatCount.format(eventTotal)}
@@ -675,6 +746,7 @@ export function DiagnosticsPane() {
 								<Button
 									size="sm"
 									variant="settings"
+									className="h-7 px-2.5 text-[11px]"
 									onClick={() => void loadMoreEvents()}
 								>
 									Load more
@@ -684,7 +756,7 @@ export function DiagnosticsPane() {
 					</div>
 				</DiagnosticsSection>
 				<aside
-					className="self-start rounded-xl border border-border/50 bg-card/70 p-4 shadow-xs xl:sticky xl:top-20"
+					className="self-start rounded-lg border border-border/60 bg-muted/30 p-4 xl:sticky xl:top-20"
 					aria-label="Incident details"
 				>
 					{selected ? (
@@ -692,7 +764,7 @@ export function DiagnosticsPane() {
 							<div className="flex items-start justify-between gap-3">
 								<div>
 									<SeverityPill severity={selected.severity} />
-									<h3 className="mt-2 font-semibold text-sm">
+									<h3 className="mt-2 font-medium text-[12px]">
 										{selected.message}
 									</h3>
 								</div>
@@ -707,7 +779,7 @@ export function DiagnosticsPane() {
 									<Copy />
 								</Button>
 							</div>
-							<dl className="grid grid-cols-[90px_1fr] gap-2 text-xs">
+							<dl className="grid grid-cols-[90px_1fr] gap-2 text-[11px]">
 								<dt className="text-muted-foreground">Diagnostic ID</dt>
 								<dd className="break-all font-mono">{selected.id}</dd>
 								<dt className="text-muted-foreground">Source</dt>
@@ -729,6 +801,7 @@ export function DiagnosticsPane() {
 							<Button
 								size="sm"
 								variant="settings"
+								className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
 								onClick={() =>
 									void navigator.clipboard.writeText(
 										`${selected.id}\n${selected.message}\n${selected.detail ?? ""}`,
@@ -742,8 +815,8 @@ export function DiagnosticsPane() {
 					) : (
 						<div className="flex min-h-48 flex-col items-center justify-center text-center">
 							<ShieldCheck className="size-6 text-muted-foreground" />
-							<p className="mt-2 font-medium text-sm">Select an incident</p>
-							<p className="mt-1 max-w-52 text-muted-foreground text-xs">
+							<p className="mt-2 font-medium text-[12px]">Select an incident</p>
+							<p className="mt-1 max-w-52 text-[11px] text-muted-foreground">
 								Inspect its sanitized details, correlation IDs, and recovery
 								state.
 							</p>
@@ -761,7 +834,7 @@ export function DiagnosticsPane() {
 						{overview.commonFailures.map((group) => (
 							<div
 								key={group.fingerprint}
-								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-xs"
+								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-[11px]"
 							>
 								<div>
 									<p className="font-medium">{group.message}</p>
@@ -794,7 +867,7 @@ export function DiagnosticsPane() {
 						{overview.slowestOperations.map((item) => (
 							<div
 								key={item.id}
-								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-xs"
+								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-[11px]"
 							>
 								<div>
 									<p className="font-medium">{item.message}</p>
@@ -831,7 +904,7 @@ export function DiagnosticsPane() {
 								type="button"
 								key={item.id}
 								onClick={() => setSelected(item)}
-								className="grid w-full grid-cols-[70px_160px_1fr_auto] gap-3 px-4 py-3 text-left text-xs hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+								className="grid w-full grid-cols-[70px_160px_1fr_auto] gap-3 px-4 py-3 text-left text-[11px] hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
 							>
 								<SeverityPill severity={item.severity} />
 								<span className="truncate font-mono text-muted-foreground">
@@ -855,7 +928,7 @@ export function DiagnosticsPane() {
 						{overview.topOperations.map((item) => (
 							<div
 								key={item.name}
-								className="grid grid-cols-[1fr_repeat(4,90px)] gap-3 px-4 py-3 text-xs"
+								className="grid grid-cols-[1fr_repeat(4,90px)] gap-3 px-4 py-3 text-[11px]"
 							>
 								<span className="font-medium">{item.name}</span>
 								<span className="text-right font-mono tabular-nums">
@@ -885,21 +958,21 @@ export function DiagnosticsPane() {
 				description="Diagnostics stay on this device unless you explicitly export them."
 			>
 				<div className="grid gap-3 p-4 md:grid-cols-3">
-					<div className="rounded-lg bg-muted/35 p-3">
-						<p className="font-medium text-xs">Retention</p>
-						<p className="mt-1 text-muted-foreground text-xs">
+					<div className="rounded-lg border border-border/50 bg-background/35 p-3">
+						<p className="font-medium text-[11px]">Retention</p>
+						<p className="mt-1 text-[10px] text-muted-foreground">
 							7 days · 250 MB maximum
 						</p>
 					</div>
-					<div className="rounded-lg bg-muted/35 p-3">
-						<p className="font-medium text-xs">Verbose capture</p>
-						<p className="mt-1 text-muted-foreground text-xs">
+					<div className="rounded-lg border border-border/50 bg-background/35 p-3">
+						<p className="font-medium text-[11px]">Verbose capture</p>
+						<p className="mt-1 text-[10px] text-muted-foreground">
 							Off · secrets and conversation content excluded
 						</p>
 					</div>
-					<div className="rounded-lg bg-muted/35 p-3">
-						<p className="font-medium text-xs">Remote export</p>
-						<p className="mt-1 text-muted-foreground text-xs">
+					<div className="rounded-lg border border-border/50 bg-background/35 p-3">
+						<p className="font-medium text-[11px]">Remote export</p>
+						<p className="mt-1 text-[10px] text-muted-foreground">
 							Disabled · local-first
 						</p>
 					</div>
@@ -907,6 +980,7 @@ export function DiagnosticsPane() {
 				<div className="flex flex-wrap gap-2 border-t border-border/45 p-4">
 					<Button
 						size="sm"
+						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
 						onClick={() => void exportBundle()}
 						loading={exporting}
 					>
@@ -916,6 +990,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
+						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
 						onClick={() =>
 							void (
 								window.zuse ?? window.memoize

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -1,0 +1,932 @@
+import type {
+	DiagnosticEvent,
+	DiagnosticSeverity,
+	DiagnosticsOverviewResult,
+	DiagnosticsProcessesResult,
+} from "@zuse/contracts";
+import { Effect } from "effect";
+import {
+	Activity,
+	AlertTriangle,
+	Archive,
+	Copy,
+	ExternalLink,
+	FolderOpen,
+	Pause,
+	Play,
+	RefreshCw,
+	Search,
+	Server,
+	ShieldCheck,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { collectDiagnosticsClientContext } from "../../lib/diagnostics-client-context.ts";
+import { flushRendererDiagnostics } from "../../lib/diagnostics-recorder.ts";
+import { getRpcClient } from "../../lib/rpc-client.ts";
+import { cn } from "../../lib/utils.ts";
+import { Button } from "../ui/button.tsx";
+
+const RANGE_OPTIONS = [
+	{ label: "15m", milliseconds: 15 * 60_000 },
+	{ label: "1h", milliseconds: 60 * 60_000 },
+	{ label: "24h", milliseconds: 24 * 60 * 60_000 },
+	{ label: "7d", milliseconds: 7 * 24 * 60 * 60_000 },
+] as const;
+
+const formatCount = new Intl.NumberFormat();
+const formatBytes = (bytes: number) => {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
+};
+const formatDuration = (milliseconds: number) =>
+	milliseconds < 1_000
+		? `${Math.round(milliseconds)} ms`
+		: `${(milliseconds / 1_000).toFixed(2)} s`;
+const relativeTime = (value: string) => {
+	const seconds = Math.max(
+		0,
+		Math.round((Date.now() - new Date(value).getTime()) / 1_000),
+	);
+	if (seconds < 60) return `${seconds}s ago`;
+	if (seconds < 3_600) return `${Math.floor(seconds / 60)}m ago`;
+	if (seconds < 86_400) return `${Math.floor(seconds / 3_600)}h ago`;
+	return `${Math.floor(seconds / 86_400)}d ago`;
+};
+
+function DiagnosticsSection({
+	title,
+	description,
+	action,
+	children,
+}: {
+	readonly title: string;
+	readonly description?: string;
+	readonly action?: React.ReactNode;
+	readonly children: React.ReactNode;
+}) {
+	return (
+		<section className="overflow-hidden rounded-xl border border-border/50 bg-card/70 shadow-xs">
+			<header className="flex min-h-14 items-center justify-between gap-4 border-b border-border/45 px-4 py-3">
+				<div className="min-w-0">
+					<h2 className="font-semibold text-sm text-foreground">{title}</h2>
+					{description && (
+						<p className="mt-0.5 text-muted-foreground text-xs">
+							{description}
+						</p>
+					)}
+				</div>
+				{action}
+			</header>
+			{children}
+		</section>
+	);
+}
+
+function Stat({
+	label,
+	value,
+	tone = "default",
+}: {
+	label: string;
+	value: string;
+	tone?: "default" | "warning" | "danger";
+}) {
+	return (
+		<div className="min-w-0 px-4 py-3">
+			<p className="truncate font-medium text-[10px] text-muted-foreground uppercase tracking-[0.1em]">
+				{label}
+			</p>
+			<p
+				className={cn(
+					"mt-1 truncate font-mono font-semibold text-lg tabular-nums",
+					tone === "danger" && "text-destructive",
+					tone === "warning" && "text-warning",
+				)}
+			>
+				{value}
+			</p>
+		</div>
+	);
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+	return (
+		<div className="px-4 py-6 text-center text-muted-foreground text-xs">
+			{children}
+		</div>
+	);
+}
+
+function SeverityPill({ severity }: { severity: DiagnosticSeverity }) {
+	return (
+		<span
+			className={cn(
+				"inline-flex rounded-md px-1.5 py-0.5 font-medium text-[10px] uppercase",
+				severity === "fatal" || severity === "error"
+					? "bg-destructive/12 text-destructive"
+					: severity === "warn"
+						? "bg-warning/12 text-warning"
+						: "bg-muted text-muted-foreground",
+			)}
+		>
+			{severity}
+		</span>
+	);
+}
+
+export function DiagnosticsPane() {
+	const mainLogsIngestedRef = useRef(false);
+	const [overview, setOverview] = useState<DiagnosticsOverviewResult | null>(
+		null,
+	);
+	const [events, setEvents] = useState<ReadonlyArray<DiagnosticEvent>>([]);
+	const [nextEventCursor, setNextEventCursor] = useState<string | null>(null);
+	const [eventTotal, setEventTotal] = useState(0);
+	const [processes, setProcesses] = useState<DiagnosticsProcessesResult | null>(
+		null,
+	);
+	const [selected, setSelected] = useState<DiagnosticEvent | null>(null);
+	const [live, setLive] = useState(true);
+	const [loading, setLoading] = useState(true);
+	const [exporting, setExporting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [search, setSearch] = useState("");
+	const [severity, setSeverity] = useState<DiagnosticSeverity | "all">("all");
+	const [source, setSource] = useState("");
+	const [rangeMs, setRangeMs] = useState(RANGE_OPTIONS[2].milliseconds);
+	const [samples, setSamples] = useState<
+		ReadonlyArray<{ at: string; cpu: number; memory: number }>
+	>([]);
+
+	const since = useMemo(
+		() => new Date(Date.now() - rangeMs).toISOString(),
+		[rangeMs],
+	);
+	const refresh = useCallback(async () => {
+		try {
+			await flushRendererDiagnostics();
+			const client = await getRpcClient();
+			if (!mainLogsIngestedRef.current) {
+				const mainLogs =
+					(await window.zuse?.app?.getMainDiagnostics?.().catch(() => [])) ??
+					[];
+				const unpublishedMainLogs = mainLogs.filter(
+					(log) => log.source !== "main.previousRunUnclean",
+				);
+				if (unpublishedMainLogs.length > 0) {
+					await Effect.runPromise(
+						client["diagnostics.ingest"]({
+							events: unpublishedMainLogs.map((log, index) => ({
+								id: `main_${log.createdAt}_${index}`,
+								createdAt: log.createdAt,
+								severity: log.level,
+								source: log.source,
+								category: "desktop",
+								message: log.message,
+								...(log.detail ? { detail: log.detail } : {}),
+								fingerprint: `${log.source}:${log.message}`,
+								runId: "desktop-main",
+								recoveryStatus:
+									log.level === "error" ? "unresolved" : "not-needed",
+							})),
+						}),
+					);
+				}
+				mainLogsIngestedRef.current = true;
+			}
+			const [nextOverview, nextEvents, nextProcesses] = await Promise.all([
+				Effect.runPromise(client["diagnostics.overview"]({ since })),
+				Effect.runPromise(
+					client["diagnostics.events"]({
+						limit: 200,
+						since,
+						...(severity === "all" ? {} : { severities: [severity] }),
+						...(source.trim() ? { source: source.trim() } : {}),
+						...(search.trim() ? { search: search.trim() } : {}),
+					}),
+				),
+				Effect.runPromise(client["diagnostics.processes"]()),
+			]);
+			setOverview(nextOverview);
+			setEvents(nextEvents.events);
+			setNextEventCursor(nextEvents.nextCursor);
+			setEventTotal(nextEvents.total);
+			setProcesses(nextProcesses);
+			setSamples((current) =>
+				[
+					...current,
+					{
+						at: nextProcesses.readAt,
+						cpu: nextProcesses.totalCpuPercent,
+						memory: nextProcesses.totalRssBytes,
+					},
+				].slice(-720),
+			);
+			setError(null);
+		} catch (cause) {
+			setError(
+				cause instanceof Error
+					? cause.message
+					: "Diagnostics could not be refreshed.",
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, [search, severity, since, source]);
+	const loadMoreEvents = async () => {
+		if (!nextEventCursor) return;
+		try {
+			const client = await getRpcClient();
+			const page = await Effect.runPromise(
+				client["diagnostics.events"]({
+					cursor: nextEventCursor,
+					limit: 200,
+					since,
+					...(severity === "all" ? {} : { severities: [severity] }),
+					...(source.trim() ? { source: source.trim() } : {}),
+					...(search.trim() ? { search: search.trim() } : {}),
+				}),
+			);
+			setEvents((current) => [...current, ...page.events]);
+			setNextEventCursor(page.nextCursor);
+			setEventTotal(page.total);
+		} catch (cause) {
+			setError(
+				cause instanceof Error
+					? cause.message
+					: "More events could not be loaded.",
+			);
+		}
+	};
+
+	useEffect(() => {
+		void refresh();
+	}, [refresh]);
+	useEffect(() => {
+		if (!live) return;
+		const timer = window.setInterval(() => void refresh(), 5_000);
+		return () => window.clearInterval(timer);
+	}, [live, refresh]);
+
+	const exportBundle = async () => {
+		setExporting(true);
+		try {
+			const client = await getRpcClient();
+			const clientContext = await collectDiagnosticsClientContext();
+			const result = await Effect.runPromise(
+				client["diagnostics.export"]({
+					clientContext,
+					since,
+					includeSessionEvents: false,
+				}),
+			);
+			await (window.zuse ?? window.memoize)?.app?.revealPath?.(
+				result.bundlePath,
+			);
+			setError(null);
+		} catch (cause) {
+			setError(
+				cause instanceof Error
+					? cause.message
+					: "Support bundle export failed.",
+			);
+		} finally {
+			setExporting(false);
+		}
+	};
+
+	const signalProcess = async (
+		pid: number,
+		signal: "interrupt" | "terminate" | "kill",
+	) => {
+		if (
+			signal === "kill" &&
+			!window.confirm(
+				`Force quit process ${pid}? Unsaved subprocess work may be lost.`,
+			)
+		)
+			return;
+		const client = await getRpcClient();
+		const result = await Effect.runPromise(
+			client["diagnostics.signalProcess"]({ pid, signal }),
+		);
+		if (!result.signaled)
+			setError(result.message ?? "The process could not be signaled.");
+		await refresh();
+	};
+
+	const maxCpu = Math.max(1, ...samples.map((sample) => sample.cpu));
+	const statusTone =
+		overview?.status === "failing"
+			? "text-destructive"
+			: overview?.status === "degraded"
+				? "text-warning"
+				: "text-success";
+
+	return (
+		<div className="flex min-w-0 flex-col gap-4 pb-12">
+			<div className="sticky top-0 z-20 -mx-2 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/45 bg-background/92 px-4 py-3 shadow-sm backdrop-blur-xl">
+				<div className="flex min-w-0 items-center gap-3">
+					<div
+						className={cn(
+							"flex size-9 items-center justify-center rounded-lg bg-muted",
+							statusTone,
+						)}
+					>
+						<Activity className="size-4" />
+					</div>
+					<div>
+						<p className="font-semibold text-sm capitalize">
+							{overview?.status ?? (loading ? "Checking" : "Unavailable")}
+						</p>
+						<p className="font-mono text-[11px] text-muted-foreground tabular-nums">
+							{overview
+								? `Run ${overview.runId} · ${overview.unseenCount} unseen`
+								: "Loading diagnostics…"}
+						</p>
+					</div>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						size="sm"
+						variant="settings"
+						onClick={() => setLive((value) => !value)}
+					>
+						{live ? <Pause /> : <Play />}
+						{live ? "Pause live" : "Resume live"}
+					</Button>
+					<Button
+						size="sm"
+						variant="settings"
+						aria-label="Refresh diagnostics"
+						onClick={() => void refresh()}
+					>
+						<RefreshCw />
+						Refresh
+					</Button>
+					<Button
+						size="sm"
+						variant="settings"
+						onClick={() =>
+							void (
+								window.zuse ?? window.memoize
+							)?.app?.revealDiagnosticsLogs?.()
+						}
+					>
+						<FolderOpen />
+						Open logs
+					</Button>
+					<Button
+						size="sm"
+						loading={exporting}
+						onClick={() => void exportBundle()}
+					>
+						<Archive />
+						Export support bundle
+					</Button>
+				</div>
+			</div>
+
+			{error && (
+				<div
+					role="alert"
+					className="flex items-start gap-2 rounded-lg border border-destructive/25 bg-destructive/8 px-3 py-2 text-destructive text-xs"
+				>
+					<AlertTriangle className="mt-0.5 size-4 shrink-0" />
+					<span>{error}</span>
+				</div>
+			)}
+
+			<DiagnosticsSection
+				title="Health overview"
+				description="Current capture health across the desktop, renderer, server, and subprocesses."
+			>
+				<div className="grid grid-cols-2 divide-x divide-y divide-border/45 md:grid-cols-4">
+					<Stat
+						label="Failures"
+						value={formatCount.format(
+							(overview?.errorCount ?? 0) + (overview?.fatalCount ?? 0),
+						)}
+						tone={(overview?.errorCount ?? 0) > 0 ? "danger" : "default"}
+					/>
+					<Stat
+						label="Warnings"
+						value={formatCount.format(overview?.warningCount ?? 0)}
+						tone={(overview?.warningCount ?? 0) > 0 ? "warning" : "default"}
+					/>
+					<Stat
+						label="Slow operations"
+						value={formatCount.format(overview?.slowOperationCount ?? 0)}
+					/>
+					<Stat
+						label="Stored locally"
+						value={formatBytes(overview?.storageBytes ?? 0)}
+					/>
+				</div>
+			</DiagnosticsSection>
+
+			<DiagnosticsSection
+				title="Live processes"
+				description="Server-owned agents and helper processes. Signals are ancestry-validated immediately before dispatch."
+				action={<Server className="size-4 text-muted-foreground" />}
+			>
+				<div className="overflow-x-auto">
+					<table className="w-full min-w-[780px] text-left text-xs">
+						<thead className="border-b border-border/45 text-[10px] text-muted-foreground uppercase tracking-wider">
+							<tr>
+								<th className="px-4 py-2">Process</th>
+								<th className="px-3 py-2 text-right">CPU</th>
+								<th className="px-3 py-2 text-right">Memory</th>
+								<th className="px-3 py-2">Command</th>
+								<th className="px-3 py-2 text-right">PID</th>
+								<th className="px-4 py-2 text-right">Actions</th>
+							</tr>
+						</thead>
+						<tbody className="divide-y divide-border/40">
+							{processes?.processes.map((item) => (
+								<tr key={item.pid} className="hover:bg-muted/20">
+									<td
+										className="px-4 py-2 font-medium"
+										style={{
+											paddingLeft: `${16 + Math.min(item.depth, 6) * 14}px`,
+										}}
+									>
+										{item.name}
+									</td>
+									<td className="px-3 py-2 text-right font-mono tabular-nums">
+										{item.cpuPercent.toFixed(1)}%
+									</td>
+									<td className="px-3 py-2 text-right font-mono tabular-nums">
+										{formatBytes(item.rssBytes)}
+									</td>
+									<td
+										className="max-w-72 truncate px-3 py-2 text-muted-foreground"
+										title={item.command}
+									>
+										{item.command}
+									</td>
+									<td className="px-3 py-2 text-right font-mono tabular-nums">
+										{item.pid}
+									</td>
+									<td className="px-4 py-2">
+										<div className="flex justify-end gap-1">
+											<Button
+												size="xs"
+												variant="ghost"
+												disabled={item.pid === processes.serverPid}
+												onClick={() =>
+													void signalProcess(item.pid, "interrupt")
+												}
+											>
+												Interrupt
+											</Button>
+											<Button
+												size="xs"
+												variant="destructive-outline"
+												disabled={item.pid === processes.serverPid}
+												onClick={() => void signalProcess(item.pid, "kill")}
+											>
+												Kill
+											</Button>
+										</div>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+					{!processes?.processes.length && (
+						<Empty>{processes?.error ?? "No live descendant processes."}</Empty>
+					)}
+				</div>
+			</DiagnosticsSection>
+
+			<DiagnosticsSection
+				title="Resource history"
+				description="Five-second CPU and memory samples retained while this page is open."
+				action={
+					<div className="flex gap-1">
+						{RANGE_OPTIONS.map((option) => (
+							<button
+								type="button"
+								key={option.label}
+								className={cn(
+									"h-7 rounded-md px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+									rangeMs === option.milliseconds
+										? "bg-muted text-foreground"
+										: "text-muted-foreground hover:bg-muted/60",
+								)}
+								onClick={() => setRangeMs(option.milliseconds)}
+							>
+								{option.label}
+							</button>
+						))}
+					</div>
+				}
+			>
+				<div className="grid grid-cols-2 divide-x divide-border/45">
+					<Stat
+						label="Current CPU"
+						value={`${(processes?.totalCpuPercent ?? 0).toFixed(1)}%`}
+					/>
+					<Stat
+						label="Current memory"
+						value={formatBytes(processes?.totalRssBytes ?? 0)}
+					/>
+				</div>
+				<div
+					className="flex h-32 items-end gap-1 border-t border-border/45 p-4"
+					role="img"
+					aria-label="Recent process CPU usage"
+				>
+					{samples.map((sample) => (
+						<div
+							key={sample.at}
+							className="min-w-1 flex-1 rounded-t-sm bg-foreground/55"
+							style={{ height: `${Math.max(3, (sample.cpu / maxCpu) * 100)}%` }}
+							title={`${sample.cpu.toFixed(1)}% CPU · ${formatBytes(sample.memory)}`}
+						/>
+					))}
+				</div>
+			</DiagnosticsSection>
+
+			<DiagnosticsSection
+				title="Trace diagnostics"
+				description="Structured spans, failures, slow operations, and parser health."
+			>
+				<div className="grid grid-cols-2 divide-x divide-y divide-border/45 md:grid-cols-4">
+					<Stat
+						label="Events"
+						value={formatCount.format(overview?.eventCount ?? 0)}
+					/>
+					<Stat
+						label="Failures"
+						value={formatCount.format(overview?.errorCount ?? 0)}
+						tone={(overview?.errorCount ?? 0) ? "danger" : "default"}
+					/>
+					<Stat
+						label="Slow spans"
+						value={formatCount.format(overview?.slowOperationCount ?? 0)}
+					/>
+					<Stat
+						label="Parse errors"
+						value={formatCount.format(overview?.parseErrorCount ?? 0)}
+						tone={(overview?.parseErrorCount ?? 0) ? "warning" : "default"}
+					/>
+				</div>
+			</DiagnosticsSection>
+
+			<div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">
+				<DiagnosticsSection
+					title="Latest incidents"
+					description={`${events.length} matching events loaded`}
+					action={
+						<div className="flex items-center gap-1.5">
+							<div className="relative">
+								<Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+								<input
+									aria-label="Search diagnostics"
+									value={search}
+									onChange={(event) => setSearch(event.target.value)}
+									className="h-8 w-48 rounded-lg border border-border/50 bg-background pl-7 pr-2 text-xs outline-none focus:ring-2 focus:ring-ring"
+									placeholder="Search errors"
+								/>
+							</div>
+							<select
+								aria-label="Filter severity"
+								value={severity}
+								onChange={(event) =>
+									setSeverity(event.target.value as DiagnosticSeverity | "all")
+								}
+								className="h-8 rounded-lg border border-border/50 bg-background px-2 text-xs"
+							>
+								<option value="all">All levels</option>
+								<option value="fatal">Fatal</option>
+								<option value="error">Errors</option>
+								<option value="warn">Warnings</option>
+								<option value="info">Info</option>
+							</select>
+						</div>
+					}
+				>
+					<div className="border-b border-border/45 px-4 py-2">
+						<label className="flex max-w-sm items-center gap-2 text-muted-foreground text-xs">
+							<span>Source</span>
+							<input
+								aria-label="Filter diagnostic source"
+								value={source}
+								onChange={(event) => setSource(event.target.value)}
+								className="h-7 flex-1 rounded-md border border-border/50 bg-background px-2 text-foreground outline-none focus:ring-2 focus:ring-ring"
+								placeholder="All sources"
+							/>
+						</label>
+					</div>
+					<div className="max-h-[520px] overflow-auto">
+						<table className="w-full min-w-[640px] text-left text-xs">
+							<thead className="sticky top-0 border-b border-border/45 bg-card">
+								<tr>
+									<th className="px-4 py-2">Level</th>
+									<th className="px-3 py-2">Source</th>
+									<th className="px-3 py-2">Message</th>
+									<th className="px-4 py-2 text-right">Seen</th>
+								</tr>
+							</thead>
+							<tbody className="divide-y divide-border/40">
+								{events.map((item) => (
+									<tr
+										key={item.id}
+										className={cn(
+											"cursor-pointer hover:bg-muted/25 focus-within:bg-muted/25",
+											selected?.id === item.id && "bg-muted/40",
+										)}
+									>
+										<td className="px-4 py-2">
+											<SeverityPill severity={item.severity} />
+										</td>
+										<td className="px-3 py-2 font-mono text-[11px] text-muted-foreground">
+											{item.source}
+										</td>
+										<td className="px-3 py-2">
+											<button
+												type="button"
+												className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+												onClick={() => setSelected(item)}
+											>
+												{item.message}
+											</button>
+										</td>
+										<td className="whitespace-nowrap px-4 py-2 text-right font-mono text-muted-foreground tabular-nums">
+											{relativeTime(item.createdAt)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+						{events.length === 0 && (
+							<Empty>No incidents match these filters.</Empty>
+						)}
+						{nextEventCursor && (
+							<div className="flex items-center justify-between border-t border-border/45 px-4 py-3 text-muted-foreground text-xs">
+								<span>
+									{formatCount.format(events.length)} of{" "}
+									{formatCount.format(eventTotal)}
+								</span>
+								<Button
+									size="sm"
+									variant="settings"
+									onClick={() => void loadMoreEvents()}
+								>
+									Load more
+								</Button>
+							</div>
+						)}
+					</div>
+				</DiagnosticsSection>
+				<aside
+					className="self-start rounded-xl border border-border/50 bg-card/70 p-4 shadow-xs xl:sticky xl:top-20"
+					aria-label="Incident details"
+				>
+					{selected ? (
+						<div className="space-y-4">
+							<div className="flex items-start justify-between gap-3">
+								<div>
+									<SeverityPill severity={selected.severity} />
+									<h3 className="mt-2 font-semibold text-sm">
+										{selected.message}
+									</h3>
+								</div>
+								<Button
+									size="icon-xs"
+									variant="ghost"
+									aria-label="Copy diagnostic ID"
+									onClick={() =>
+										void navigator.clipboard.writeText(selected.id)
+									}
+								>
+									<Copy />
+								</Button>
+							</div>
+							<dl className="grid grid-cols-[90px_1fr] gap-2 text-xs">
+								<dt className="text-muted-foreground">Diagnostic ID</dt>
+								<dd className="break-all font-mono">{selected.id}</dd>
+								<dt className="text-muted-foreground">Source</dt>
+								<dd className="font-mono">{selected.source}</dd>
+								<dt className="text-muted-foreground">Run</dt>
+								<dd className="font-mono">{selected.runId}</dd>
+								<dt className="text-muted-foreground">Recovery</dt>
+								<dd>{selected.recoveryStatus}</dd>
+								<dt className="text-muted-foreground">Trace</dt>
+								<dd className="break-all font-mono">
+									{selected.traceId ?? "Not correlated"}
+								</dd>
+							</dl>
+							{selected.detail && (
+								<pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-3 text-[11px] leading-5">
+									{selected.detail}
+								</pre>
+							)}
+							<Button
+								size="sm"
+								variant="settings"
+								onClick={() =>
+									void navigator.clipboard.writeText(
+										`${selected.id}\n${selected.message}\n${selected.detail ?? ""}`,
+									)
+								}
+							>
+								<Copy />
+								Copy details
+							</Button>
+						</div>
+					) : (
+						<div className="flex min-h-48 flex-col items-center justify-center text-center">
+							<ShieldCheck className="size-6 text-muted-foreground" />
+							<p className="mt-2 font-medium text-sm">Select an incident</p>
+							<p className="mt-1 max-w-52 text-muted-foreground text-xs">
+								Inspect its sanitized details, correlation IDs, and recovery
+								state.
+							</p>
+						</div>
+					)}
+				</aside>
+			</div>
+
+			<DiagnosticsSection
+				title="Most common failures"
+				description="Repeated incidents grouped by stable fingerprint."
+			>
+				{overview?.commonFailures.length ? (
+					<div className="divide-y divide-border/40">
+						{overview.commonFailures.map((group) => (
+							<div
+								key={group.fingerprint}
+								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-xs"
+							>
+								<div>
+									<p className="font-medium">{group.message}</p>
+									<p className="mt-1 font-mono text-[11px] text-muted-foreground">
+										{group.source} · {group.fingerprint}
+									</p>
+								</div>
+								<div className="text-right">
+									<p className="font-mono font-semibold tabular-nums">
+										{group.count}×
+									</p>
+									<p className="text-muted-foreground">
+										{relativeTime(group.lastSeenAt)}
+									</p>
+								</div>
+							</div>
+						))}
+					</div>
+				) : (
+					<Empty>No repeated failures in this range.</Empty>
+				)}
+			</DiagnosticsSection>
+
+			<DiagnosticsSection
+				title="Slowest operations"
+				description="Operations taking one second or longer."
+			>
+				{overview?.slowestOperations.length ? (
+					<div className="divide-y divide-border/40">
+						{overview.slowestOperations.map((item) => (
+							<div
+								key={item.id}
+								className="grid grid-cols-[1fr_auto] gap-4 px-4 py-3 text-xs"
+							>
+								<div>
+									<p className="font-medium">{item.message}</p>
+									<p className="mt-1 font-mono text-muted-foreground">
+										{item.source} · {item.traceId ?? item.id}
+									</p>
+								</div>
+								<p className="font-mono font-semibold tabular-nums">
+									{formatDuration(item.durationMs ?? 0)}
+								</p>
+							</div>
+						))}
+					</div>
+				) : (
+					<Empty>No slow operations captured.</Empty>
+				)}
+			</DiagnosticsSection>
+
+			<DiagnosticsSection
+				title="Warning and error logs"
+				description="Sanitized structured events from every application boundary."
+			>
+				<div className="divide-y divide-border/40">
+					{events
+						.filter(
+							(item) =>
+								item.severity === "warn" ||
+								item.severity === "error" ||
+								item.severity === "fatal",
+						)
+						.slice(0, 20)
+						.map((item) => (
+							<button
+								type="button"
+								key={item.id}
+								onClick={() => setSelected(item)}
+								className="grid w-full grid-cols-[70px_160px_1fr_auto] gap-3 px-4 py-3 text-left text-xs hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+							>
+								<SeverityPill severity={item.severity} />
+								<span className="truncate font-mono text-muted-foreground">
+									{item.source}
+								</span>
+								<span className="truncate">{item.message}</span>
+								<span className="font-mono text-muted-foreground tabular-nums">
+									{relativeTime(item.createdAt)}
+								</span>
+							</button>
+						))}
+				</div>
+			</DiagnosticsSection>
+
+			<DiagnosticsSection
+				title="Top operations"
+				description="Count, failures, average, p95, and maximum duration."
+			>
+				{overview?.topOperations.length ? (
+					<div className="divide-y divide-border/40">
+						{overview.topOperations.map((item) => (
+							<div
+								key={item.name}
+								className="grid grid-cols-[1fr_repeat(4,90px)] gap-3 px-4 py-3 text-xs"
+							>
+								<span className="font-medium">{item.name}</span>
+								<span className="text-right font-mono tabular-nums">
+									{item.count}
+								</span>
+								<span className="text-right font-mono tabular-nums">
+									{item.failureCount}
+								</span>
+								<span className="text-right font-mono tabular-nums">
+									{formatDuration(item.p95DurationMs)}
+								</span>
+								<span className="text-right font-mono tabular-nums">
+									{formatDuration(item.maxDurationMs)}
+								</span>
+							</div>
+						))}
+					</div>
+				) : (
+					<Empty>
+						Operation summaries appear as instrumented traces are captured.
+					</Empty>
+				)}
+			</DiagnosticsSection>
+
+			<DiagnosticsSection
+				title="Storage and capture tools"
+				description="Diagnostics stay on this device unless you explicitly export them."
+			>
+				<div className="grid gap-3 p-4 md:grid-cols-3">
+					<div className="rounded-lg bg-muted/35 p-3">
+						<p className="font-medium text-xs">Retention</p>
+						<p className="mt-1 text-muted-foreground text-xs">
+							7 days · 250 MB maximum
+						</p>
+					</div>
+					<div className="rounded-lg bg-muted/35 p-3">
+						<p className="font-medium text-xs">Verbose capture</p>
+						<p className="mt-1 text-muted-foreground text-xs">
+							Off · secrets and conversation content excluded
+						</p>
+					</div>
+					<div className="rounded-lg bg-muted/35 p-3">
+						<p className="font-medium text-xs">Remote export</p>
+						<p className="mt-1 text-muted-foreground text-xs">
+							Disabled · local-first
+						</p>
+					</div>
+				</div>
+				<div className="flex flex-wrap gap-2 border-t border-border/45 p-4">
+					<Button
+						size="sm"
+						onClick={() => void exportBundle()}
+						loading={exporting}
+					>
+						<Archive />
+						Export support bundle
+					</Button>
+					<Button
+						size="sm"
+						variant="settings"
+						onClick={() =>
+							void (
+								window.zuse ?? window.memoize
+							)?.app?.revealDiagnosticsLogs?.()
+						}
+					>
+						<ExternalLink />
+						Open diagnostics folder
+					</Button>
+				</div>
+			</DiagnosticsSection>
+		</div>
+	);
+}

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -26,6 +26,8 @@ import { flushRendererDiagnostics } from "../../lib/diagnostics-recorder.ts";
 import { getRpcClient } from "../../lib/rpc-client.ts";
 import { cn } from "../../lib/utils.ts";
 import { Button } from "../ui/button.tsx";
+import { Card } from "../ui/card.tsx";
+import { Frame, FrameHeader } from "../ui/frame.tsx";
 
 const RANGE_OPTIONS = [
 	{ label: "15m", milliseconds: 15 * 60_000 },
@@ -67,20 +69,22 @@ function DiagnosticsSection({
 	readonly children: React.ReactNode;
 }) {
 	return (
-		<section className="overflow-hidden rounded-lg border border-border/60 bg-muted/30">
-			<header className="flex min-h-11 items-center justify-between gap-4 border-b border-border/40 px-4 py-2.5">
+		<Frame role="region" aria-label={title}>
+			<FrameHeader className="flex w-full flex-row items-center justify-between gap-3 px-2 py-1.5">
 				<div className="min-w-0">
-					<h2 className="font-medium text-[12px] text-foreground">{title}</h2>
+					<h2 className="truncate font-medium text-[12px] text-foreground">
+						{title}
+					</h2>
 					{description && (
-						<p className="mt-0.5 truncate text-[10px] text-muted-foreground leading-4">
+						<p className="truncate text-[9px] text-muted-foreground leading-3.5">
 							{description}
 						</p>
 					)}
 				</div>
-				{action}
-			</header>
-			{children}
-		</section>
+				{action && <div className="shrink-0">{action}</div>}
+			</FrameHeader>
+			<Card className="overflow-hidden">{children}</Card>
+		</Frame>
 	);
 }
 
@@ -151,7 +155,7 @@ function ResourceChart({
 	const areaPoints = `0,${height} ${points.join(" ")} ${width},${height}`;
 
 	return (
-		<div className="overflow-hidden rounded-lg border border-border/50 bg-background/35">
+		<Card className="overflow-hidden bg-background/35">
 			<div className="flex items-start justify-between gap-3 px-3 pt-3">
 				<div>
 					<p className="font-medium text-[10px] text-muted-foreground">
@@ -187,7 +191,7 @@ function ResourceChart({
 					className={lineClassName}
 				/>
 			</svg>
-		</div>
+		</Card>
 	);
 }
 
@@ -425,7 +429,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
 						onClick={() => setLive((value) => !value)}
 					>
 						{live ? <Pause /> : <Play />}
@@ -434,7 +438,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
 						aria-label="Refresh diagnostics"
 						onClick={() => void refresh()}
 					>
@@ -444,7 +448,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
 						onClick={() =>
 							void (
 								window.zuse ?? window.memoize
@@ -456,7 +460,7 @@ export function DiagnosticsPane() {
 					</Button>
 					<Button
 						size="sm"
-						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
 						loading={exporting}
 						onClick={() => void exportBundle()}
 					>
@@ -552,6 +556,7 @@ export function DiagnosticsPane() {
 											<Button
 												size="xs"
 												variant="ghost"
+												className="text-[10px]"
 												disabled={item.pid === processes.serverPid}
 												onClick={() =>
 													void signalProcess(item.pid, "interrupt")
@@ -562,6 +567,7 @@ export function DiagnosticsPane() {
 											<Button
 												size="xs"
 												variant="destructive-outline"
+												className="text-[10px]"
 												disabled={item.pid === processes.serverPid}
 												onClick={() => void signalProcess(item.pid, "kill")}
 											>
@@ -746,7 +752,7 @@ export function DiagnosticsPane() {
 								<Button
 									size="sm"
 									variant="settings"
-									className="h-7 px-2.5 text-[11px]"
+									className="h-7 px-2.5 text-[10px]"
 									onClick={() => void loadMoreEvents()}
 								>
 									Load more
@@ -801,7 +807,7 @@ export function DiagnosticsPane() {
 							<Button
 								size="sm"
 								variant="settings"
-								className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
+								className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
 								onClick={() =>
 									void navigator.clipboard.writeText(
 										`${selected.id}\n${selected.message}\n${selected.detail ?? ""}`,
@@ -980,7 +986,7 @@ export function DiagnosticsPane() {
 				<div className="flex flex-wrap gap-2 border-t border-border/45 p-4">
 					<Button
 						size="sm"
-						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
 						onClick={() => void exportBundle()}
 						loading={exporting}
 					>
@@ -990,7 +996,7 @@ export function DiagnosticsPane() {
 					<Button
 						size="sm"
 						variant="settings"
-						className="h-7 gap-1.5 px-2.5 text-[11px] [&_svg]:size-3.5"
+						className="h-7 gap-1.5 px-2.5 text-[10px] [&_svg]:size-3.5"
 						onClick={() =>
 							void (
 								window.zuse ?? window.memoize

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -37,6 +37,8 @@ import {
 	type DiagnosticsPreferences,
 	type DiagnosticsSeverityFilter,
 	type DiagnosticsView,
+	diagnosticsSeveritySelection,
+	diagnosticsSince,
 	groupDiagnosticEvents,
 	parseDiagnosticsPreferences,
 	relatedDiagnosticEvents,
@@ -647,7 +649,8 @@ export function DiagnosticsPane() {
 				}
 			}
 
-			const since = new Date(Date.now() - rangeMs).toISOString();
+			const since = diagnosticsSince(rangeMs);
+			const selectedSeverities = diagnosticsSeveritySelection(view, severity);
 			const [overviewResult, eventsResult, processesResult] =
 				await Promise.allSettled([
 					Effect.runPromise(client["diagnostics.overview"]({ since })),
@@ -655,7 +658,9 @@ export function DiagnosticsPane() {
 						client["diagnostics.events"]({
 							limit: 200,
 							since,
-							...(severity === "all" ? {} : { severities: [severity] }),
+							...(selectedSeverities === undefined
+								? {}
+								: { severities: selectedSeverities }),
 							...(querySource ? { source: querySource } : {}),
 							...(querySearch ? { search: querySearch } : {}),
 						}),
@@ -711,7 +716,7 @@ export function DiagnosticsPane() {
 			setLoading(false);
 			setRefreshing(false);
 		}
-	}, [querySearch, querySource, rangeMs, severity]);
+	}, [querySearch, querySource, rangeMs, severity, view]);
 
 	useEffect(() => {
 		void refresh();
@@ -737,12 +742,15 @@ export function DiagnosticsPane() {
 		if (!nextEventCursor) return;
 		try {
 			const client = await getRpcClient();
+			const selectedSeverities = diagnosticsSeveritySelection(view, severity);
 			const page = await Effect.runPromise(
 				client["diagnostics.events"]({
 					cursor: nextEventCursor,
 					limit: 200,
-					since: new Date(Date.now() - rangeMs).toISOString(),
-					...(severity === "all" ? {} : { severities: [severity] }),
+					since: diagnosticsSince(rangeMs),
+					...(selectedSeverities === undefined
+						? {}
+						: { severities: selectedSeverities }),
 					...(querySource ? { source: querySource } : {}),
 					...(querySearch ? { search: querySearch } : {}),
 				}),
@@ -768,7 +776,7 @@ export function DiagnosticsPane() {
 			const result = await Effect.runPromise(
 				client["diagnostics.export"]({
 					clientContext,
-					since: new Date(Date.now() - rangeMs).toISOString(),
+					since: diagnosticsSince(rangeMs),
 					includeSessionEvents: false,
 				}),
 			);
@@ -1648,7 +1656,7 @@ export function DiagnosticsPane() {
 								<p className="font-medium text-[10px]">Retention</p>
 								<p className="mt-1 font-mono text-sm tabular-nums">7 days</p>
 								<p className="mt-1 text-[9px] text-muted-foreground">
-									250 MB maximum across rotating diagnostic files.
+									100 MB maximum for rotating event telemetry.
 								</p>
 							</div>
 							<div className="p-4">
@@ -1657,7 +1665,7 @@ export function DiagnosticsPane() {
 									{formatBytes(overview?.storageBytes ?? 0)}
 								</p>
 								<p className="mt-1 text-[9px] text-muted-foreground">
-									Old files are pruned by age and storage budget.
+									Event files are pruned by age and their rotation limit.
 								</p>
 							</div>
 							<div className="p-4">

--- a/apps/renderer/src/hooks/use-menu-shortcuts.ts
+++ b/apps/renderer/src/hooks/use-menu-shortcuts.ts
@@ -24,7 +24,7 @@ export function useMenuShortcuts(): void {
 			recordUiAction("menu.action", action);
 			if (action === "export-diagnostics") {
 				const ui = useUiStore.getState();
-				ui.setSettingsSection({ kind: "advanced" });
+				ui.setSettingsSection({ kind: "diagnostics" });
 				ui.setView("settings");
 				return;
 			}

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -41,6 +41,7 @@ export interface AppBridge {
 	readonly getMainDiagnostics?: () => Promise<
 		ReadonlyArray<DiagnosticLogEntry>
 	>;
+	readonly revealDiagnosticsLogs?: () => Promise<void>;
 }
 
 export interface NetworkBridge {

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -41,6 +41,11 @@ export interface AppBridge {
 	readonly getMainDiagnostics?: () => Promise<
 		ReadonlyArray<DiagnosticLogEntry>
 	>;
+	readonly recordFatalDiagnostic?: (input: {
+		readonly source: string;
+		readonly errorName: string;
+		readonly frameNames: ReadonlyArray<string>;
+	}) => boolean;
 	readonly revealDiagnosticsLogs?: () => Promise<void>;
 }
 

--- a/apps/renderer/src/lib/diagnostics-recorder.ts
+++ b/apps/renderer/src/lib/diagnostics-recorder.ts
@@ -1,116 +1,162 @@
 export type DiagnosticLogLevel = "debug" | "info" | "warn" | "error";
 
 export interface DiagnosticLogEntry {
-  readonly createdAt: string;
-  readonly level: DiagnosticLogLevel;
-  readonly source: string;
-  readonly message: string;
-  readonly detail?: string;
+	readonly createdAt: string;
+	readonly level: DiagnosticLogLevel;
+	readonly source: string;
+	readonly message: string;
+	readonly detail?: string;
 }
 
 export interface DiagnosticUiAction {
-  readonly createdAt: string;
-  readonly action: string;
-  readonly detail?: string;
+	readonly createdAt: string;
+	readonly action: string;
+	readonly detail?: string;
 }
 
 const LOG_LIMIT = 200;
 const ACTION_LIMIT = 100;
 const rendererLogs: DiagnosticLogEntry[] = [];
+const pendingRendererLogs: DiagnosticLogEntry[] = [];
 const uiActions: DiagnosticUiAction[] = [];
+const rendererRunId = `renderer_${crypto.randomUUID?.() ?? Date.now().toString(36)}`;
 
 let installed = false;
+let flushTimer: number | null = null;
+let flushing = false;
 
 function pushBounded<T>(items: T[], item: T, limit: number): void {
-  items.push(item);
-  if (items.length > limit) items.splice(0, items.length - limit);
+	items.push(item);
+	if (items.length > limit) items.splice(0, items.length - limit);
 }
 
 function stringifyDiagnosticPart(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value instanceof Error) return `${value.name}: ${value.message}`;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
+	if (typeof value === "string") return value;
+	if (value instanceof Error) return `${value.name}: ${value.message}`;
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
 }
 
 export function recordDiagnosticEvent(input: {
-  readonly level: DiagnosticLogLevel;
-  readonly source: string;
-  readonly message: string;
-  readonly detail?: string;
+	readonly level: DiagnosticLogLevel;
+	readonly source: string;
+	readonly message: string;
+	readonly detail?: string;
 }): void {
-  pushBounded(
-    rendererLogs,
-    {
-      createdAt: new Date().toISOString(),
-      level: input.level,
-      source: input.source,
-      message: input.message.slice(0, 2000),
-      detail: input.detail?.slice(0, 4000),
-    },
-    LOG_LIMIT,
-  );
+	const entry = {
+		createdAt: new Date().toISOString(),
+		level: input.level,
+		source: input.source,
+		message: input.message.slice(0, 2000),
+		detail: input.detail?.slice(0, 4000),
+	} satisfies DiagnosticLogEntry;
+	pushBounded(rendererLogs, entry, LOG_LIMIT);
+	pushBounded(pendingRendererLogs, entry, LOG_LIMIT);
+	scheduleDiagnosticsFlush();
+}
+
+function scheduleDiagnosticsFlush(): void {
+	if (typeof window === "undefined" || flushTimer !== null) return;
+	flushTimer = window.setTimeout(() => {
+		flushTimer = null;
+		void flushRendererDiagnostics();
+	}, 250);
+}
+
+export async function flushRendererDiagnostics(): Promise<void> {
+	if (flushing || pendingRendererLogs.length === 0) return;
+	flushing = true;
+	const pending = pendingRendererLogs.slice();
+	try {
+		const [{ getRpcClient }, { Effect }] = await Promise.all([
+			import("./rpc-client.ts"),
+			import("effect"),
+		]);
+		const client = await getRpcClient();
+		await Effect.runPromise(
+			client["diagnostics.ingest"]({
+				events: pending.map((entry, index) => ({
+					id: `renderer_${Date.now().toString(36)}_${index}`,
+					createdAt: entry.createdAt,
+					severity: entry.level,
+					source: entry.source,
+					category: entry.source.split(".")[1] ?? "renderer",
+					message: entry.message,
+					detail: entry.detail,
+					fingerprint: `${entry.source}:${entry.message.slice(0, 160)}`,
+					runId: rendererRunId,
+					recoveryStatus: entry.level === "error" ? "unresolved" : "not-needed",
+				})),
+			}),
+		);
+		pendingRendererLogs.splice(0, pending.length);
+	} catch {
+		// Diagnostics transport is best-effort and must never create another error.
+	} finally {
+		flushing = false;
+		if (pendingRendererLogs.length > 0) scheduleDiagnosticsFlush();
+	}
 }
 
 export function recordUiAction(action: string, detail?: string): void {
-  pushBounded(
-    uiActions,
-    {
-      createdAt: new Date().toISOString(),
-      action,
-      detail: detail?.slice(0, 1000),
-    },
-    ACTION_LIMIT,
-  );
+	pushBounded(
+		uiActions,
+		{
+			createdAt: new Date().toISOString(),
+			action,
+			detail: detail?.slice(0, 1000),
+		},
+		ACTION_LIMIT,
+	);
 }
 
 export function getRendererDiagnosticLogs(): ReadonlyArray<DiagnosticLogEntry> {
-  return rendererLogs.slice();
+	return rendererLogs.slice();
 }
 
 export function getDiagnosticUiActions(): ReadonlyArray<DiagnosticUiAction> {
-  return uiActions.slice();
+	return uiActions.slice();
 }
 
 export function installRendererDiagnostics(): void {
-  if (installed || typeof window === "undefined") return;
-  installed = true;
+	if (installed || typeof window === "undefined") return;
+	installed = true;
 
-  const originalWarn = console.warn.bind(console);
-  const originalError = console.error.bind(console);
-  console.warn = (...args: unknown[]) => {
-    recordDiagnosticEvent({
-      level: "warn",
-      source: "renderer.console",
-      message: args.map(stringifyDiagnosticPart).join(" "),
-    });
-    originalWarn(...args);
-  };
-  console.error = (...args: unknown[]) => {
-    recordDiagnosticEvent({
-      level: "error",
-      source: "renderer.console",
-      message: args.map(stringifyDiagnosticPart).join(" "),
-    });
-    originalError(...args);
-  };
+	const originalWarn = console.warn.bind(console);
+	const originalError = console.error.bind(console);
+	console.warn = (...args: unknown[]) => {
+		recordDiagnosticEvent({
+			level: "warn",
+			source: "renderer.console",
+			message: args.map(stringifyDiagnosticPart).join(" "),
+		});
+		originalWarn(...args);
+	};
+	console.error = (...args: unknown[]) => {
+		recordDiagnosticEvent({
+			level: "error",
+			source: "renderer.console",
+			message: args.map(stringifyDiagnosticPart).join(" "),
+		});
+		originalError(...args);
+	};
 
-  window.addEventListener("error", (event) => {
-    recordDiagnosticEvent({
-      level: "error",
-      source: "renderer.window.error",
-      message: event.message,
-      detail: event.error instanceof Error ? event.error.stack : undefined,
-    });
-  });
-  window.addEventListener("unhandledrejection", (event) => {
-    recordDiagnosticEvent({
-      level: "error",
-      source: "renderer.unhandledrejection",
-      message: stringifyDiagnosticPart(event.reason),
-    });
-  });
+	window.addEventListener("error", (event) => {
+		recordDiagnosticEvent({
+			level: "error",
+			source: "renderer.window.error",
+			message: event.message,
+			detail: event.error instanceof Error ? event.error.stack : undefined,
+		});
+	});
+	window.addEventListener("unhandledrejection", (event) => {
+		recordDiagnosticEvent({
+			level: "error",
+			source: "renderer.unhandledrejection",
+			message: stringifyDiagnosticPart(event.reason),
+		});
+	});
 }

--- a/apps/renderer/src/lib/diagnostics-recorder.ts
+++ b/apps/renderer/src/lib/diagnostics-recorder.ts
@@ -30,15 +30,58 @@ function pushBounded<T>(items: T[], item: T, limit: number): void {
 	if (items.length > limit) items.splice(0, items.length - limit);
 }
 
-function stringifyDiagnosticPart(value: unknown): string {
-	if (typeof value === "string") return value;
-	if (value instanceof Error) return `${value.name}: ${value.message}`;
+const diagnosticValueKind = (value: unknown): string => {
+	if (value instanceof Error) return value.name || "Error";
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "array";
+	return typeof value;
+};
+
+const sanitizedStackFrames = (error: Error): string | undefined => {
+	const frames = error.stack?.split(/\r?\n/).slice(1, 21).join("\n").trim();
+	return frames || undefined;
+};
+
+export const summarizeDiagnosticError = (
+	error: Error,
+	fallback: string,
+): { readonly message: string; readonly detail?: string } => {
+	const detail = sanitizedStackFrames(error);
+	const firstFrameName = /^\s*at\s+([^\s(]+)/.exec(detail ?? "")?.[1];
+	return {
+		message: `${error.name || fallback} at ${firstFrameName ?? "unknown"}`,
+		...(detail === undefined ? {} : { detail }),
+	};
+};
+
+export function persistFatalRendererDiagnostic(
+	source:
+		| "renderer.window.error"
+		| "renderer.unhandledrejection"
+		| "renderer.react.root",
+	error: Error,
+): void {
 	try {
-		return JSON.stringify(value);
+		const frameNames = (error.stack?.split(/\r?\n/).slice(1, 21) ?? []).flatMap(
+			(frame) => {
+				const name = /^\s*at\s+([^\s(]+)/.exec(frame)?.[1];
+				return name === undefined ? [] : [name];
+			},
+		);
+		window.zuse?.app?.recordFatalDiagnostic?.({
+			source,
+			errorName: error.name || "Error",
+			frameNames,
+		});
 	} catch {
-		return String(value);
+		// The synchronous crash path is best effort and cannot mask the failure.
 	}
 }
+
+export const summarizeDiagnosticArguments = (
+	args: ReadonlyArray<unknown>,
+): string =>
+	`argumentTypes=${args.map(diagnosticValueKind).join(",") || "none"} count=${args.length}`;
 
 export function recordDiagnosticEvent(input: {
 	readonly level: DiagnosticLogLevel;
@@ -131,7 +174,8 @@ export function installRendererDiagnostics(): void {
 		recordDiagnosticEvent({
 			level: "warn",
 			source: "renderer.console",
-			message: args.map(stringifyDiagnosticPart).join(" "),
+			message: "Renderer console warning",
+			detail: summarizeDiagnosticArguments(args),
 		});
 		originalWarn(...args);
 	};
@@ -139,24 +183,44 @@ export function installRendererDiagnostics(): void {
 		recordDiagnosticEvent({
 			level: "error",
 			source: "renderer.console",
-			message: args.map(stringifyDiagnosticPart).join(" "),
+			message: "Renderer console error",
+			detail: summarizeDiagnosticArguments(args),
 		});
 		originalError(...args);
 	};
 
 	window.addEventListener("error", (event) => {
+		if (event.error instanceof Error) {
+			persistFatalRendererDiagnostic("renderer.window.error", event.error);
+		}
+		const summary =
+			event.error instanceof Error
+				? summarizeDiagnosticError(event.error, "RendererError")
+				: { message: "RendererError at unknown" };
 		recordDiagnosticEvent({
 			level: "error",
 			source: "renderer.window.error",
-			message: event.message,
-			detail: event.error instanceof Error ? event.error.stack : undefined,
+			...summary,
 		});
 	});
 	window.addEventListener("unhandledrejection", (event) => {
+		if (event.reason instanceof Error) {
+			persistFatalRendererDiagnostic(
+				"renderer.unhandledrejection",
+				event.reason,
+			);
+		}
+		const summary =
+			event.reason instanceof Error
+				? summarizeDiagnosticError(event.reason, "UnhandledRejection")
+				: {
+						message: "UnhandledRejection at unknown",
+						detail: `reasonType=${diagnosticValueKind(event.reason)}`,
+					};
 		recordDiagnosticEvent({
 			level: "error",
 			source: "renderer.unhandledrejection",
-			message: stringifyDiagnosticPart(event.reason),
+			...summary,
 		});
 	});
 }

--- a/apps/renderer/src/lib/diagnostics-view-model.ts
+++ b/apps/renderer/src/lib/diagnostics-view-model.ts
@@ -1,0 +1,144 @@
+import type { DiagnosticEvent, DiagnosticSeverity } from "@zuse/contracts";
+
+export const DIAGNOSTICS_PREFERENCES_KEY =
+	"zuse.diagnostics.workspace-preferences.v1";
+
+export const DIAGNOSTICS_VIEWS = [
+	"issues",
+	"performance",
+	"processes",
+	"storage",
+] as const;
+
+export type DiagnosticsView = (typeof DIAGNOSTICS_VIEWS)[number];
+export type DiagnosticsSeverityFilter = DiagnosticSeverity | "all";
+
+export type DiagnosticsPreferences = {
+	readonly view: DiagnosticsView;
+	readonly rangeMs: number;
+	readonly severity: DiagnosticsSeverityFilter;
+	readonly source: string;
+	readonly search: string;
+};
+
+export const DIAGNOSTICS_RANGE_OPTIONS = [
+	{ label: "15m", milliseconds: 15 * 60_000 },
+	{ label: "1h", milliseconds: 60 * 60_000 },
+	{ label: "24h", milliseconds: 24 * 60 * 60_000 },
+	{ label: "7d", milliseconds: 7 * 24 * 60 * 60_000 },
+] as const;
+
+export const DEFAULT_DIAGNOSTICS_PREFERENCES: DiagnosticsPreferences = {
+	view: "issues",
+	rangeMs: DIAGNOSTICS_RANGE_OPTIONS[2].milliseconds,
+	severity: "all",
+	source: "",
+	search: "",
+};
+
+const SEVERITIES: ReadonlySet<string> = new Set([
+	"all",
+	"debug",
+	"info",
+	"warn",
+	"error",
+	"fatal",
+]);
+const VIEWS: ReadonlySet<string> = new Set(DIAGNOSTICS_VIEWS);
+const RANGES: ReadonlySet<number> = new Set(
+	DIAGNOSTICS_RANGE_OPTIONS.map((option) => option.milliseconds),
+);
+
+export function parseDiagnosticsPreferences(
+	value: string | null,
+): DiagnosticsPreferences {
+	if (!value) return DEFAULT_DIAGNOSTICS_PREFERENCES;
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!parsed || typeof parsed !== "object") {
+			return DEFAULT_DIAGNOSTICS_PREFERENCES;
+		}
+		const candidate = parsed as Record<string, unknown>;
+		return {
+			view:
+				typeof candidate.view === "string" && VIEWS.has(candidate.view)
+					? (candidate.view as DiagnosticsView)
+					: DEFAULT_DIAGNOSTICS_PREFERENCES.view,
+			rangeMs:
+				typeof candidate.rangeMs === "number" && RANGES.has(candidate.rangeMs)
+					? candidate.rangeMs
+					: DEFAULT_DIAGNOSTICS_PREFERENCES.rangeMs,
+			severity:
+				typeof candidate.severity === "string" &&
+				SEVERITIES.has(candidate.severity)
+					? (candidate.severity as DiagnosticsSeverityFilter)
+					: DEFAULT_DIAGNOSTICS_PREFERENCES.severity,
+			source: typeof candidate.source === "string" ? candidate.source : "",
+			search: typeof candidate.search === "string" ? candidate.search : "",
+		};
+	} catch {
+		return DEFAULT_DIAGNOSTICS_PREFERENCES;
+	}
+}
+
+export type DiagnosticIncident = {
+	readonly event: DiagnosticEvent;
+	readonly occurrences: number;
+};
+
+const severityRank: Record<DiagnosticSeverity, number> = {
+	debug: 0,
+	info: 1,
+	warn: 2,
+	error: 3,
+	fatal: 4,
+};
+
+export function groupDiagnosticEvents(
+	events: ReadonlyArray<DiagnosticEvent>,
+	knownCounts: ReadonlyMap<string, number> = new Map(),
+): ReadonlyArray<DiagnosticIncident> {
+	const groups = new Map<
+		string,
+		{ event: DiagnosticEvent; occurrences: number }
+	>();
+	for (const event of events) {
+		const current = groups.get(event.fingerprint);
+		if (!current) {
+			groups.set(event.fingerprint, { event, occurrences: 1 });
+			continue;
+		}
+		current.occurrences += 1;
+		if (Date.parse(event.createdAt) > Date.parse(current.event.createdAt)) {
+			current.event = event;
+		}
+	}
+
+	return [...groups.values()]
+		.map((group) => ({
+			...group,
+			occurrences: Math.max(
+				group.occurrences,
+				knownCounts.get(group.event.fingerprint) ?? 0,
+			),
+		}))
+		.sort((left, right) => {
+			const time =
+				Date.parse(right.event.createdAt) - Date.parse(left.event.createdAt);
+			if (time !== 0) return time;
+			return (
+				severityRank[right.event.severity] - severityRank[left.event.severity]
+			);
+		});
+}
+
+export function relatedDiagnosticEvents(
+	events: ReadonlyArray<DiagnosticEvent>,
+	fingerprint: string,
+): ReadonlyArray<DiagnosticEvent> {
+	return events
+		.filter((event) => event.fingerprint === fingerprint)
+		.sort(
+			(left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt),
+		);
+}

--- a/apps/renderer/src/lib/diagnostics-view-model.ts
+++ b/apps/renderer/src/lib/diagnostics-view-model.ts
@@ -5,6 +5,7 @@ export const DIAGNOSTICS_PREFERENCES_KEY =
 
 export const DIAGNOSTICS_VIEWS = [
 	"issues",
+	"logs",
 	"performance",
 	"processes",
 	"storage",

--- a/apps/renderer/src/lib/diagnostics-view-model.ts
+++ b/apps/renderer/src/lib/diagnostics-view-model.ts
@@ -37,6 +37,21 @@ export const DEFAULT_DIAGNOSTICS_PREFERENCES: DiagnosticsPreferences = {
 	search: "",
 };
 
+export function diagnosticsSeveritySelection(
+	view: DiagnosticsView,
+	severity: DiagnosticsSeverityFilter,
+): ReadonlyArray<DiagnosticSeverity> | undefined {
+	if (severity !== "all") return [severity];
+	return view === "issues" ? ["warn", "error", "fatal"] : undefined;
+}
+
+export function diagnosticsSince(rangeMs: number, now = Date.now()): string {
+	const bucketMs = 60_000;
+	return new Date(
+		Math.floor((now - rangeMs) / bucketMs) * bucketMs,
+	).toISOString();
+}
+
 const SEVERITIES: ReadonlySet<string> = new Set([
 	"all",
 	"debug",

--- a/apps/renderer/src/lib/format-error.ts
+++ b/apps/renderer/src/lib/format-error.ts
@@ -3,6 +3,19 @@ import { recordDiagnosticEvent } from "./diagnostics-recorder.ts";
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
 
+const diagnosticErrorType = (value: unknown): string => {
+	if (isRecord(value)) {
+		const tag = value._tag;
+		if (typeof tag === "string" && /^[A-Za-z][A-Za-z0-9]*$/.test(tag)) {
+			return tag;
+		}
+	}
+	if (value instanceof Error && /^[A-Za-z][A-Za-z0-9]*$/.test(value.name)) {
+		return value.name;
+	}
+	return "RendererError";
+};
+
 // Tagged errors that carry only ids (no `reason`/`message`) would otherwise
 // fall through to a raw JSON dump like `{ "folderId": "…" }`. Map them to
 // human copy here so any surface that formats them stays readable.
@@ -38,7 +51,7 @@ export const formatError = (err: unknown): string => {
 	recordDiagnosticEvent({
 		level: "error",
 		source: "renderer.formatError",
-		message: formatted,
+		message: diagnosticErrorType(err),
 	});
 	return formatted;
 };

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -10,7 +10,9 @@ import { ErrorBoundary } from "./components/ui/error-boundary.tsx";
 import { ToastProvider } from "./components/ui/toast.tsx";
 import {
 	installRendererDiagnostics,
+	persistFatalRendererDiagnostic,
 	recordDiagnosticEvent,
+	summarizeDiagnosticError,
 } from "./lib/diagnostics-recorder.ts";
 import { AppAtomProvider } from "./state/registry.tsx";
 
@@ -32,6 +34,9 @@ function formatCrashDetails(error: Error, componentStack?: string): string {
 		.filter(Boolean)
 		.join("\n\n");
 }
+
+const sanitizedComponentDiagnostics = (componentStack?: string): string =>
+	componentStack ? `React component stack:\n${componentStack}` : "";
 
 function RootCrashFallback({ error }: { readonly error: Error }) {
 	const details = formatCrashDetails(error);
@@ -86,11 +91,18 @@ ReactDOM.createRoot(root).render(
 		<ErrorBoundary
 			fallback={(error) => <RootCrashFallback error={error} />}
 			onError={(error, info) => {
+				persistFatalRendererDiagnostic("renderer.react.root", error);
+				const summary = summarizeDiagnosticError(error, "ReactError");
 				recordDiagnosticEvent({
 					level: "error",
 					source: "renderer.react.root",
-					message: `${error.name}: ${error.message}`,
-					detail: formatCrashDetails(error, info.componentStack),
+					message: summary.message,
+					detail: [
+						summary.detail,
+						sanitizedComponentDiagnostics(info.componentStack),
+					]
+						.filter(Boolean)
+						.join("\n\n"),
 				});
 			}}
 		>

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -34,7 +34,7 @@ export type SettingsSection =
 	| { readonly kind: "devices" }
 	| { readonly kind: "browser" }
 	| { readonly kind: "pokedex" }
-	| { readonly kind: "advanced" }
+	| { readonly kind: "diagnostics" }
 	| { readonly kind: "shortcuts" }
 	| { readonly kind: "developer" }
 	| { readonly kind: "repository"; readonly projectId: FolderId };

--- a/apps/renderer/test/unit/diagnostics-recorder.test.ts
+++ b/apps/renderer/test/unit/diagnostics-recorder.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeDiagnosticArguments } from "../../src/lib/diagnostics-recorder.ts";
+
+describe("diagnostics recorder", () => {
+	it("records console argument metadata without serializing values", () => {
+		const summary = summarizeDiagnosticArguments([
+			"private prompt",
+			{ terminalOutput: "secret output" },
+			new Error("Bearer secret-token"),
+		]);
+
+		expect(summary).toBe("argumentTypes=string,object,Error count=3");
+		expect(summary).not.toContain("private prompt");
+		expect(summary).not.toContain("secret output");
+		expect(summary).not.toContain("secret-token");
+	});
+});

--- a/apps/renderer/test/unit/diagnostics-view-model.test.ts
+++ b/apps/renderer/test/unit/diagnostics-view-model.test.ts
@@ -60,6 +60,20 @@ describe("diagnostics view model", () => {
 		});
 	});
 
+	it("restores the live logs view", () => {
+		expect(
+			parseDiagnosticsPreferences(
+				JSON.stringify({
+					view: "logs",
+					rangeMs: 86_400_000,
+					severity: "all",
+					source: "",
+					search: "",
+				}),
+			).view,
+		).toBe("logs");
+	});
+
 	it("groups repeated failures and preserves the newest representative", () => {
 		const grouped = groupDiagnosticEvents(
 			[

--- a/apps/renderer/test/unit/diagnostics-view-model.test.ts
+++ b/apps/renderer/test/unit/diagnostics-view-model.test.ts
@@ -1,0 +1,88 @@
+import type { DiagnosticEvent } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_DIAGNOSTICS_PREFERENCES,
+	groupDiagnosticEvents,
+	parseDiagnosticsPreferences,
+	relatedDiagnosticEvents,
+} from "../../src/lib/diagnostics-view-model.ts";
+
+const event = (
+	id: string,
+	fingerprint: string,
+	createdAt: string,
+	severity: DiagnosticEvent["severity"] = "error",
+): DiagnosticEvent => ({
+	id,
+	createdAt,
+	severity,
+	source: "provider.stream",
+	category: "provider",
+	message: `Failure ${id}`,
+	fingerprint,
+	runId: "run-1",
+	recoveryStatus: "unresolved",
+});
+
+describe("diagnostics view model", () => {
+	it("falls back safely for missing or corrupted preferences", () => {
+		expect(parseDiagnosticsPreferences(null)).toEqual(
+			DEFAULT_DIAGNOSTICS_PREFERENCES,
+		);
+		expect(parseDiagnosticsPreferences("{nope")).toEqual(
+			DEFAULT_DIAGNOSTICS_PREFERENCES,
+		);
+		expect(
+			parseDiagnosticsPreferences(
+				JSON.stringify({ view: "unknown", rangeMs: 42, severity: "loud" }),
+			),
+		).toEqual(DEFAULT_DIAGNOSTICS_PREFERENCES);
+	});
+
+	it("restores valid preferences without trusting invalid fields", () => {
+		expect(
+			parseDiagnosticsPreferences(
+				JSON.stringify({
+					view: "performance",
+					rangeMs: 3_600_000,
+					severity: "warn",
+					source: "server",
+					search: "timeout",
+				}),
+			),
+		).toEqual({
+			view: "performance",
+			rangeMs: 3_600_000,
+			severity: "warn",
+			source: "server",
+			search: "timeout",
+		});
+	});
+
+	it("groups repeated failures and preserves the newest representative", () => {
+		const grouped = groupDiagnosticEvents(
+			[
+				event("old", "same", "2026-07-22T10:00:00.000Z"),
+				event("other", "other", "2026-07-22T11:00:00.000Z", "warn"),
+				event("new", "same", "2026-07-22T12:00:00.000Z", "fatal"),
+			],
+			new Map([["same", 8]]),
+		);
+
+		expect(grouped.map((item) => item.event.id)).toEqual(["new", "other"]);
+		expect(grouped[0]?.occurrences).toBe(8);
+	});
+
+	it("returns related occurrences newest first", () => {
+		const related = relatedDiagnosticEvents(
+			[
+				event("old", "same", "2026-07-22T10:00:00.000Z"),
+				event("other", "other", "2026-07-22T11:00:00.000Z"),
+				event("new", "same", "2026-07-22T12:00:00.000Z"),
+			],
+			"same",
+		);
+		expect(related.map((item) => item.id)).toEqual(["new", "old"]);
+	});
+});

--- a/apps/renderer/test/unit/diagnostics-view-model.test.ts
+++ b/apps/renderer/test/unit/diagnostics-view-model.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import {
 	DEFAULT_DIAGNOSTICS_PREFERENCES,
+	diagnosticsSeveritySelection,
+	diagnosticsSince,
 	groupDiagnosticEvents,
 	parseDiagnosticsPreferences,
 	relatedDiagnosticEvents,
@@ -72,6 +74,29 @@ describe("diagnostics view model", () => {
 				}),
 			).view,
 		).toBe("logs");
+	});
+
+	it("keeps successful operations out of the default issue inbox", () => {
+		expect(diagnosticsSeveritySelection("issues", "all")).toEqual([
+			"warn",
+			"error",
+			"fatal",
+		]);
+		expect(diagnosticsSeveritySelection("logs", "all")).toBeUndefined();
+		expect(diagnosticsSeveritySelection("issues", "error")).toEqual(["error"]);
+	});
+
+	it("uses stable minute buckets for live time-range queries", () => {
+		const first = diagnosticsSince(
+			3_600_000,
+			Date.parse("2026-07-29T12:00:05Z"),
+		);
+		const second = diagnosticsSince(
+			3_600_000,
+			Date.parse("2026-07-29T12:00:55Z"),
+		);
+		expect(first).toBe("2026-07-29T11:00:00.000Z");
+		expect(second).toBe(first);
 	});
 
 	it("groups repeated failures and preserves the newest representative", () => {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,6 +41,7 @@
 	},
 	"scripts": {
 		"serve": "tsx src/bin.ts",
+		"build:bundle": "vp pack && tsc -p tsconfig.build.json",
 		"build": "bun run --filter renderer build && vp pack && tsc -p tsconfig.build.json && node scripts/copy-client.mjs",
 		"check-types": "tsc --noEmit",
 		"test": "vp test run test/unit test/integration",

--- a/apps/server/src/diagnostics/diagnostics-model.ts
+++ b/apps/server/src/diagnostics/diagnostics-model.ts
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+
+import type {
+	DiagnosticEvent,
+	DiagnosticFailureGroup,
+	DiagnosticSeverity,
+} from "@zuse/contracts";
+
+const SECRET_PATTERNS: ReadonlyArray<[RegExp, string]> = [
+	[/\b(Bearer\s+)[^\s]+/gi, "$1[REDACTED]"],
+	[/([?&])[^=\s]+=[^&\s]+/g, "$1[REDACTED]"],
+	[
+		/\b(?:sk|ghp|github_pat|xox[abprs])[-_][A-Za-z0-9._-]{8,}\b/gi,
+		"[REDACTED]",
+	],
+	[
+		/\b([A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*)\s*[:=]\s*["']?[^\s"',;]+/gi,
+		"$1=[REDACTED]",
+	],
+];
+
+const EXCLUDED_EXPORT_KEYS =
+	/^(?:prompt|transcript|conversation|content|environment|env|credentials?|secrets?|tokens?|terminalOutput|openFile|path|sourcePath|rawCommand)$/i;
+
+export function sanitizeDiagnosticText(value: string): string {
+	let result = value;
+	for (const [pattern, replacement] of SECRET_PATTERNS) {
+		result = result.replace(pattern, replacement);
+	}
+	return result.slice(0, 8_000);
+}
+
+export function sanitizeDiagnosticValue(value: unknown, depth = 0): unknown {
+	if (depth > 8) return "[TRUNCATED]";
+	if (typeof value === "string") return sanitizeDiagnosticText(value);
+	if (Array.isArray(value))
+		return value
+			.slice(0, 500)
+			.map((item) => sanitizeDiagnosticValue(item, depth + 1));
+	if (value === null || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.filter(([key]) => !EXCLUDED_EXPORT_KEYS.test(key))
+			.slice(0, 500)
+			.map(([key, item]) => [key, sanitizeDiagnosticValue(item, depth + 1)]),
+	);
+}
+
+export function diagnosticFingerprint(input: {
+	readonly source: string;
+	readonly category: string;
+	readonly message: string;
+}): string {
+	return createHash("sha256")
+		.update(`${input.source}\0${input.category}\0${input.message}`)
+		.digest("hex")
+		.slice(0, 20);
+}
+
+export interface DiagnosticFilters {
+	readonly severities?: ReadonlyArray<DiagnosticSeverity>;
+	readonly source?: string;
+	readonly search?: string;
+	readonly since?: string;
+}
+
+export function filterDiagnosticEvents(
+	events: ReadonlyArray<DiagnosticEvent>,
+	filters: DiagnosticFilters,
+): ReadonlyArray<DiagnosticEvent> {
+	const search = filters.search?.trim().toLowerCase();
+	return events.filter((event) => {
+		if (filters.severities && !filters.severities.includes(event.severity))
+			return false;
+		if (
+			filters.source &&
+			!event.source.toLowerCase().includes(filters.source.toLowerCase())
+		) {
+			return false;
+		}
+		if (filters.since && event.createdAt < filters.since) return false;
+		if (
+			search &&
+			!`${event.message} ${event.detail ?? ""} ${event.source}`
+				.toLowerCase()
+				.includes(search)
+		)
+			return false;
+		return true;
+	});
+}
+
+export function aggregateDiagnostics(events: ReadonlyArray<DiagnosticEvent>) {
+	const sorted = [...events].sort((a, b) =>
+		b.createdAt.localeCompare(a.createdAt),
+	);
+	const groups = new Map<string, DiagnosticFailureGroup>();
+	for (const event of sorted.filter(
+		(item) => item.severity !== "debug" && item.severity !== "info",
+	)) {
+		const current = groups.get(event.fingerprint);
+		groups.set(event.fingerprint, {
+			fingerprint: event.fingerprint,
+			severity: event.severity,
+			source: event.source,
+			message: event.message,
+			count: (current?.count ?? 0) + 1,
+			firstSeenAt:
+				current && current.firstSeenAt < event.createdAt
+					? current.firstSeenAt
+					: event.createdAt,
+			lastSeenAt:
+				current && current.lastSeenAt > event.createdAt
+					? current.lastSeenAt
+					: event.createdAt,
+			recoveredCount:
+				(current?.recoveredCount ?? 0) +
+				(event.recoveryStatus === "recovered" ? 1 : 0),
+		});
+	}
+	return {
+		eventCount: events.length,
+		errorCount: events.filter((event) => event.severity === "error").length,
+		warningCount: events.filter((event) => event.severity === "warn").length,
+		fatalCount: events.filter((event) => event.severity === "fatal").length,
+		slowOperationCount: events.filter(
+			(event) => (event.durationMs ?? 0) >= 1_000,
+		).length,
+		latestIncidents: sorted
+			.filter((event) => ["warn", "error", "fatal"].includes(event.severity))
+			.slice(0, 20),
+		commonFailures: [...groups.values()]
+			.sort((a, b) => b.count - a.count)
+			.slice(0, 10),
+		slowestOperations: sorted
+			.filter((event) => event.durationMs !== undefined)
+			.sort((a, b) => (b.durationMs ?? 0) - (a.durationMs ?? 0))
+			.slice(0, 10),
+	};
+}

--- a/apps/server/src/diagnostics/diagnostics-model.ts
+++ b/apps/server/src/diagnostics/diagnostics-model.ts
@@ -9,6 +9,9 @@ import type {
 const SECRET_PATTERNS: ReadonlyArray<[RegExp, string]> = [
 	[/\b(Bearer\s+)[^\s]+/gi, "$1[REDACTED]"],
 	[/([?&])[^=\s]+=[^&\s]+/g, "$1[REDACTED]"],
+	[/\/Users\/[^/\s]+/g, "/Users/[USER]"],
+	[/\/home\/[^/\s]+/g, "/home/[USER]"],
+	[/\b[A-Za-z]:\\Users\\[^\\\s]+/g, "[DRIVE]:\\Users\\[USER]"],
 	[
 		/\b(?:sk|ghp|github_pat|xox[abprs])[-_][A-Za-z0-9._-]{8,}\b/gi,
 		"[REDACTED]",
@@ -90,11 +93,97 @@ export function filterDiagnosticEvents(
 	});
 }
 
+const compareEventsNewestFirst = (
+	left: DiagnosticEvent,
+	right: DiagnosticEvent,
+): number =>
+	right.createdAt.localeCompare(left.createdAt) ||
+	right.id.localeCompare(left.id);
+
+const encodeEventCursor = (event: DiagnosticEvent): string =>
+	Buffer.from(
+		JSON.stringify({ createdAt: event.createdAt, id: event.id }),
+	).toString("base64url");
+
+const decodeEventCursor = (
+	cursor: string,
+): { readonly createdAt: string; readonly id: string } | null => {
+	try {
+		const parsed: unknown = JSON.parse(
+			Buffer.from(cursor, "base64url").toString("utf8"),
+		);
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			"createdAt" in parsed &&
+			typeof parsed.createdAt === "string" &&
+			"id" in parsed &&
+			typeof parsed.id === "string"
+		) {
+			return { createdAt: parsed.createdAt, id: parsed.id };
+		}
+	} catch {
+		// Legacy numeric cursors are handled by the caller.
+	}
+	return null;
+};
+
+export function paginateDiagnosticEvents(
+	events: ReadonlyArray<DiagnosticEvent>,
+	input: { readonly cursor?: string; readonly limit: number },
+): {
+	readonly events: ReadonlyArray<DiagnosticEvent>;
+	readonly nextCursor: string | null;
+} {
+	const sorted = [...events].sort(compareEventsNewestFirst);
+	const legacyOffset = /^\d+$/.test(input.cursor ?? "")
+		? Number(input.cursor)
+		: null;
+	const decoded = input.cursor ? decodeEventCursor(input.cursor) : null;
+	const eligible =
+		legacyOffset !== null
+			? sorted.slice(legacyOffset)
+			: decoded === null
+				? sorted
+				: sorted.filter(
+						(event) =>
+							event.createdAt < decoded.createdAt ||
+							(event.createdAt === decoded.createdAt && event.id < decoded.id),
+					);
+	const page = eligible.slice(0, input.limit);
+	const last = page.at(-1);
+	return {
+		events: page,
+		nextCursor:
+			last !== undefined &&
+			page.length === input.limit &&
+			eligible.length > input.limit
+				? encodeEventCursor(last)
+				: null,
+	};
+}
+
 export function aggregateDiagnostics(events: ReadonlyArray<DiagnosticEvent>) {
 	const sorted = [...events].sort((a, b) =>
 		b.createdAt.localeCompare(a.createdAt),
 	);
 	const groups = new Map<string, DiagnosticFailureGroup>();
+	const operations = new Map<
+		string,
+		{ durations: number[]; failureCount: number }
+	>();
+	for (const event of sorted) {
+		if (event.durationMs === undefined) continue;
+		const current = operations.get(event.message) ?? {
+			durations: [],
+			failureCount: 0,
+		};
+		current.durations.push(event.durationMs);
+		if (event.severity === "error" || event.severity === "fatal") {
+			current.failureCount += 1;
+		}
+		operations.set(event.message, current);
+	}
 	for (const event of sorted.filter(
 		(item) => item.severity !== "debug" && item.severity !== "info",
 	)) {
@@ -136,5 +225,30 @@ export function aggregateDiagnostics(events: ReadonlyArray<DiagnosticEvent>) {
 			.filter((event) => event.durationMs !== undefined)
 			.sort((a, b) => (b.durationMs ?? 0) - (a.durationMs ?? 0))
 			.slice(0, 10),
+		topOperations: [...operations.entries()]
+			.map(([name, operation]) => {
+				const durations = [...operation.durations].sort(
+					(left, right) => left - right,
+				);
+				const total = durations.reduce((sum, duration) => sum + duration, 0);
+				const percentileIndex = Math.max(
+					0,
+					Math.ceil(durations.length * 0.95) - 1,
+				);
+				return {
+					name,
+					count: durations.length,
+					failureCount: operation.failureCount,
+					averageDurationMs: total / durations.length,
+					p95DurationMs: durations[percentileIndex] ?? 0,
+					maxDurationMs: durations.at(-1) ?? 0,
+				};
+			})
+			.sort(
+				(left, right) =>
+					right.count - left.count ||
+					right.averageDurationMs - left.averageDurationMs,
+			)
+			.slice(0, 20),
 	};
 }

--- a/apps/server/src/diagnostics/handlers.ts
+++ b/apps/server/src/diagnostics/handlers.ts
@@ -20,4 +20,29 @@ const ExportBundle = MemoizeRpcs.toLayerHandler(
 		}),
 );
 
-export const DiagnosticsHandlersLayer = Layer.mergeAll(ExportBundle);
+const Overview = MemoizeRpcs.toLayerHandler("diagnostics.overview", (payload) =>
+	Effect.flatMap(DiagnosticsService, (svc) => svc.overview(payload)),
+);
+const Events = MemoizeRpcs.toLayerHandler("diagnostics.events", (payload) =>
+	Effect.flatMap(DiagnosticsService, (svc) => svc.events(payload)),
+);
+const Processes = MemoizeRpcs.toLayerHandler("diagnostics.processes", () =>
+	Effect.flatMap(DiagnosticsService, (svc) => svc.processes),
+);
+const SignalProcess = MemoizeRpcs.toLayerHandler(
+	"diagnostics.signalProcess",
+	(payload) =>
+		Effect.flatMap(DiagnosticsService, (svc) => svc.signalProcess(payload)),
+);
+const Ingest = MemoizeRpcs.toLayerHandler("diagnostics.ingest", (payload) =>
+	Effect.flatMap(DiagnosticsService, (svc) => svc.ingest(payload.events)),
+);
+
+export const DiagnosticsHandlersLayer = Layer.mergeAll(
+	ExportBundle,
+	Overview,
+	Events,
+	Processes,
+	SignalProcess,
+	Ingest,
+);

--- a/apps/server/src/diagnostics/layers/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/layers/diagnostics-service.ts
@@ -1,236 +1,583 @@
-import { SqlClient } from "effect/unstable/sql";
-import { Effect, Layer } from "effect";
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
 import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
 } from "node:fs";
+import { appendFile, mkdir, rename, stat } from "node:fs/promises";
 import { arch, platform, release } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { randomUUID } from "node:crypto";
-
+import { promisify } from "node:util";
 import {
-  DiagnosticsExportError,
-  DiagnosticsExportResult,
-  type AgentAvailability,
+	type AgentAvailability,
+	DiagnosticEvent,
+	DiagnosticsEventsResult,
+	DiagnosticsExportError,
+	DiagnosticsExportResult,
+	DiagnosticsOverviewResult,
+	DiagnosticsProcessesResult,
+	DiagnosticsSignalResult,
 } from "@zuse/contracts";
+import { Effect, Layer, Ref, Schema } from "effect";
+import { SqlClient } from "effect/unstable/sql";
 
 import packageJson from "../../../package.json" with { type: "json" };
 import { AppPaths } from "../../app-paths.ts";
 import { ProviderService } from "../../provider/services/provider-service.ts";
+import {
+	aggregateDiagnostics,
+	diagnosticFingerprint,
+	filterDiagnosticEvents,
+	sanitizeDiagnosticText,
+	sanitizeDiagnosticValue,
+} from "../diagnostics-model.ts";
 import { DiagnosticsService } from "../services/diagnostics-service.ts";
+import { createStoredZip } from "../zip-bundle.ts";
 
 const MAX_RECENT_ERRORS = 20;
 const MAX_SESSION_EVENTS = 8;
 const MAX_REDACTED_EVENTS_PER_FILE = 200;
 const MAX_TEXT_PREVIEW = 240;
+const MAX_DIAGNOSTIC_EVENTS = 100_000;
+const MAX_DIAGNOSTIC_FILE_BYTES = 20 * 1024 * 1024;
+const DIAGNOSTIC_FILE_COUNT = 5;
+const DIAGNOSTIC_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+const execFileAsync = promisify(execFile);
+
+const diagnosticsError = (cause: unknown) =>
+	new DiagnosticsExportError({
+		reason:
+			cause instanceof Error ? cause.message : "Diagnostics operation failed.",
+	});
+
+function loadPersistedEvents(path: string): {
+	events: DiagnosticEvent[];
+	parseErrors: number;
+} {
+	let parseErrors = 0;
+	const retainedFiles = Array.from(
+		{ length: DIAGNOSTIC_FILE_COUNT },
+		(_, index) =>
+			index === DIAGNOSTIC_FILE_COUNT - 1
+				? path
+				: `${path}.${DIAGNOSTIC_FILE_COUNT - 1 - index}`,
+	).filter((file) => {
+		if (!existsSync(file)) return false;
+		if (Date.now() - statSync(file).mtimeMs <= DIAGNOSTIC_RETENTION_MS)
+			return true;
+		try {
+			unlinkSync(file);
+		} catch {
+			// Retention is best-effort and must never block diagnostics startup.
+		}
+		return false;
+	});
+	const lines = retainedFiles.flatMap((file) =>
+		readFileSync(file, "utf8").split(/\r?\n/),
+	);
+	const events = lines
+		.filter(Boolean)
+		.slice(-MAX_DIAGNOSTIC_EVENTS)
+		.flatMap((line) => {
+			try {
+				return [Schema.decodeUnknownSync(DiagnosticEvent)(JSON.parse(line))];
+			} catch {
+				parseErrors += 1;
+				return [];
+			}
+		});
+	return { events, parseErrors };
+}
+
+function sanitizeEvent(event: DiagnosticEvent): DiagnosticEvent {
+	const message = sanitizeDiagnosticText(event.message);
+	const detail = event.detail
+		? sanitizeDiagnosticText(event.detail)
+		: undefined;
+	return {
+		...event,
+		message,
+		detail,
+		fingerprint: diagnosticFingerprint({
+			source: event.source,
+			category: event.category,
+			message,
+		}),
+	};
+}
+
+async function rotateAndAppend(
+	path: string,
+	events: ReadonlyArray<DiagnosticEvent>,
+): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	const chunk = events.map((event) => `${JSON.stringify(event)}\n`).join("");
+	const currentSize = await stat(path)
+		.then((value) => value.size)
+		.catch(() => 0);
+	if (
+		currentSize > 0 &&
+		currentSize + Buffer.byteLength(chunk) > MAX_DIAGNOSTIC_FILE_BYTES
+	) {
+		for (let index = DIAGNOSTIC_FILE_COUNT - 1; index >= 1; index -= 1) {
+			const source = index === 1 ? path : `${path}.${index - 1}`;
+			const target = `${path}.${index}`;
+			await rename(source, target).catch(() => undefined);
+		}
+	}
+	await appendFile(path, chunk, "utf8");
+}
+
+function parseElapsedSeconds(value: string): number {
+	const [dayPart, timePart] = value.includes("-")
+		? value.split("-", 2)
+		: ["0", value];
+	const parts = (timePart ?? "0")
+		.split(":")
+		.map((part) => Number(part))
+		.reverse();
+	return (
+		(Number(dayPart) || 0) * 86_400 +
+		(parts[0] ?? 0) +
+		(parts[1] ?? 0) * 60 +
+		(parts[2] ?? 0) * 3_600
+	);
+}
+
+async function readProcessTree(): Promise<DiagnosticsProcessesResult> {
+	const readAt = new Date().toISOString();
+	if (process.platform === "win32") {
+		return DiagnosticsProcessesResult.make({
+			supported: false,
+			readAt,
+			serverPid: process.pid,
+			processes: [],
+			totalCpuPercent: 0,
+			totalRssBytes: 0,
+			error: "Process inspection is not available on this Windows build.",
+		});
+	}
+	try {
+		const { stdout } = await execFileAsync("ps", [
+			"-axo",
+			"pid=,ppid=,%cpu=,rss=,etime=,comm=,args=",
+		]);
+		const rows = stdout.split(/\r?\n/).flatMap((line) => {
+			const match = line
+				.trim()
+				.match(/^(\d+)\s+(\d+)\s+([\d.]+)\s+(\d+)\s+(\S+)\s+(\S+)\s*(.*)$/);
+			if (!match) return [];
+			return [
+				{
+					pid: Number(match[1]),
+					parentPid: Number(match[2]),
+					cpuPercent: Number(match[3]),
+					rssBytes: Number(match[4]) * 1024,
+					elapsed: match[5] ?? "0",
+					name: basename(match[6] ?? "process"),
+					command: basename(match[6] ?? "process"),
+				},
+			];
+		});
+		const byParent = new Map<number, number[]>();
+		for (const row of rows)
+			byParent.set(row.parentPid, [
+				...(byParent.get(row.parentPid) ?? []),
+				row.pid,
+			]);
+		const descendants: Array<(typeof rows)[number] & { depth: number }> = [];
+		const visit = (pid: number, depth: number) => {
+			for (const childPid of byParent.get(pid) ?? []) {
+				const child = rows.find((row) => row.pid === childPid);
+				if (child) {
+					descendants.push({ ...child, depth });
+					visit(child.pid, depth + 1);
+				}
+			}
+		};
+		visit(process.pid, 1);
+		const server = rows.find((row) => row.pid === process.pid);
+		const ownedRows = [
+			...(server ? [{ ...server, depth: 0 }] : []),
+			...descendants,
+		];
+		const processes = ownedRows.map((row) => ({
+			pid: row.pid,
+			parentPid: row.parentPid,
+			depth: row.depth,
+			name: row.name,
+			command: row.command,
+			cpuPercent: row.cpuPercent,
+			rssBytes: row.rssBytes,
+			uptimeSeconds: parseElapsedSeconds(row.elapsed),
+			childPids: byParent.get(row.pid) ?? [],
+		}));
+		return DiagnosticsProcessesResult.make({
+			supported: true,
+			readAt,
+			serverPid: process.pid,
+			processes,
+			totalCpuPercent: processes.reduce(
+				(sum, item) => sum + item.cpuPercent,
+				0,
+			),
+			totalRssBytes: processes.reduce((sum, item) => sum + item.rssBytes, 0),
+		});
+	} catch (cause) {
+		return DiagnosticsProcessesResult.make({
+			supported: false,
+			readAt,
+			serverPid: process.pid,
+			processes: [],
+			totalCpuPercent: 0,
+			totalRssBytes: 0,
+			error:
+				cause instanceof Error ? cause.message : "Process inspection failed.",
+		});
+	}
+}
 
 interface RecentErrorRow {
-  readonly message_id: string;
-  readonly session_id: string;
-  readonly chat_id: string | null;
-  readonly project_id: string;
-  readonly provider_id: string;
-  readonly model: string;
-  readonly kind: string;
-  readonly content_json: string;
-  readonly created_at: string;
+	readonly message_id: string;
+	readonly session_id: string;
+	readonly chat_id: string | null;
+	readonly project_id: string;
+	readonly provider_id: string;
+	readonly model: string;
+	readonly kind: string;
+	readonly content_json: string;
+	readonly created_at: string;
 }
 
 interface SessionEventFile {
-  readonly sessionId: string;
-  readonly projectId: string;
-  readonly sourcePath: string;
-  readonly eventCount: number;
-  readonly truncated: boolean;
-  readonly events: ReadonlyArray<unknown>;
+	readonly sessionId: string;
+	readonly projectId: string;
+	readonly sourcePath: string;
+	readonly eventCount: number;
+	readonly truncated: boolean;
+	readonly events: ReadonlyArray<unknown>;
 }
 
 type BundleArtifactName =
-  | "manifest"
-  | "bundle-summary"
-  | "trace-summary"
-  | "recent-errors"
-  | "environment"
-  | "provider-status"
-  | "client-context"
-  | "redacted-session-events";
+	| "manifest"
+	| "bundle-summary"
+	| "trace-summary"
+	| "recent-errors"
+	| "environment"
+	| "provider-status"
+	| "client-context"
+	| "redacted-session-events";
+
+type ExtendedBundleArtifactName =
+	| BundleArtifactName
+	| "diagnostic-events"
+	| "process-snapshot"
+	| "redaction-report"
+	| "report";
 
 function safeIsoForFile(date: Date): string {
-  return date.toISOString().replace(/[:.]/g, "-");
+	return date.toISOString().replace(/[:.]/g, "-");
 }
 
 function truncate(value: string): string {
-  return value.length <= MAX_TEXT_PREVIEW
-    ? value
-    : `${value.slice(0, MAX_TEXT_PREVIEW)}...`;
+	return value.length <= MAX_TEXT_PREVIEW
+		? value
+		: `${value.slice(0, MAX_TEXT_PREVIEW)}...`;
 }
 
 function summarizeUnknown(value: unknown): unknown {
-  if (typeof value === "string") {
-    return {
-      redacted: true,
-      length: value.length,
-      preview: truncate(value),
-    };
-  }
-  if (Array.isArray(value)) {
-    return value.slice(0, 20).map(summarizeUnknown);
-  }
-  if (typeof value === "object" && value !== null) {
-    const entries = Object.entries(value as Record<string, unknown>).map(
-      ([key, entry]) => {
-        if (
-          key.toLowerCase().includes("text") ||
-          key.toLowerCase().includes("prompt") ||
-          key.toLowerCase().includes("output") ||
-          key.toLowerCase().includes("summary")
-        ) {
-          return [key, summarizeUnknown(entry)] as const;
-        }
-        return [key, summarizeUnknown(entry)] as const;
-      },
-    );
-    return Object.fromEntries(entries);
-  }
-  return value;
+	if (typeof value === "string") {
+		return {
+			redacted: true,
+			length: value.length,
+		};
+	}
+	if (Array.isArray(value)) {
+		return value.slice(0, 20).map(summarizeUnknown);
+	}
+	if (typeof value === "object" && value !== null) {
+		const entries = Object.entries(value as Record<string, unknown>).map(
+			([key, entry]) => {
+				if (
+					key.toLowerCase().includes("text") ||
+					key.toLowerCase().includes("prompt") ||
+					key.toLowerCase().includes("output") ||
+					key.toLowerCase().includes("summary")
+				) {
+					return [key, summarizeUnknown(entry)] as const;
+				}
+				return [key, summarizeUnknown(entry)] as const;
+			},
+		);
+		return Object.fromEntries(entries);
+	}
+	return value;
 }
 
 function readErrorMessage(contentJson: string): string {
-  try {
-    const parsed = JSON.parse(contentJson) as unknown;
-    if (typeof parsed === "object" && parsed !== null && "message" in parsed) {
-      const message = (parsed as { readonly message?: unknown }).message;
-      return typeof message === "string"
-        ? truncate(message)
-        : "Error message unavailable";
-    }
-    return truncate(JSON.stringify(summarizeUnknown(parsed)));
-  } catch {
-    return "Could not parse persisted error content.";
-  }
+	try {
+		const parsed = JSON.parse(contentJson) as unknown;
+		if (typeof parsed === "object" && parsed !== null && "message" in parsed) {
+			const message = (parsed as { readonly message?: unknown }).message;
+			return typeof message === "string"
+				? sanitizeDiagnosticText(truncate(message))
+				: "Error message unavailable";
+		}
+		return truncate(JSON.stringify(summarizeUnknown(parsed)));
+	} catch {
+		return "Could not parse persisted error content.";
+	}
 }
 
 function listSessionEventFiles(
-  userData: string,
+	userData: string,
 ): ReadonlyArray<{ projectId: string; path: string }> {
-  const root = join(userData, "sessions");
-  if (!existsSync(root)) return [];
-  const files: Array<{ projectId: string; path: string; mtimeMs: number }> = [];
-  for (const projectId of readdirSync(root)) {
-    const projectDir = join(root, projectId);
-    if (!statSync(projectDir).isDirectory()) continue;
-    for (const entry of readdirSync(projectDir)) {
-      if (!entry.endsWith(".events.ndjson")) continue;
-      const path = join(projectDir, entry);
-      const stat = statSync(path);
-      files.push({ projectId, path, mtimeMs: stat.mtimeMs });
-    }
-  }
-  return [...files]
-    .sort((left, right) => right.mtimeMs - left.mtimeMs)
-    .slice(0, MAX_SESSION_EVENTS)
-    .map(({ projectId, path }) => ({ projectId, path }));
+	const root = join(userData, "sessions");
+	if (!existsSync(root)) return [];
+	const files: Array<{ projectId: string; path: string; mtimeMs: number }> = [];
+	for (const projectId of readdirSync(root)) {
+		const projectDir = join(root, projectId);
+		if (!statSync(projectDir).isDirectory()) continue;
+		for (const entry of readdirSync(projectDir)) {
+			if (!entry.endsWith(".events.ndjson")) continue;
+			const path = join(projectDir, entry);
+			const stat = statSync(path);
+			files.push({ projectId, path, mtimeMs: stat.mtimeMs });
+		}
+	}
+	return [...files]
+		.sort((left, right) => right.mtimeMs - left.mtimeMs)
+		.slice(0, MAX_SESSION_EVENTS)
+		.map(({ projectId, path }) => ({ projectId, path }));
 }
 
 function redactSessionEventFile(input: {
-  readonly projectId: string;
-  readonly path: string;
+	readonly projectId: string;
+	readonly path: string;
 }): SessionEventFile {
-  const text = readFileSync(input.path, "utf8");
-  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  const events = lines.slice(-MAX_REDACTED_EVENTS_PER_FILE).flatMap((line) => {
-    try {
-      return [summarizeUnknown(JSON.parse(line) as unknown)];
-    } catch {
-      return [{ parseError: true, bytes: Buffer.byteLength(line) }];
-    }
-  });
-  const fileName = basename(input.path);
-  const sessionId = fileName.replace(/\.events\.ndjson$/, "");
-  return {
-    projectId: input.projectId,
-    sessionId,
-    sourcePath: input.path,
-    eventCount: lines.length,
-    truncated: lines.length > MAX_REDACTED_EVENTS_PER_FILE,
-    events,
-  };
+	const text = readFileSync(input.path, "utf8");
+	const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+	const events = lines.slice(-MAX_REDACTED_EVENTS_PER_FILE).flatMap((line) => {
+		try {
+			return [summarizeUnknown(JSON.parse(line) as unknown)];
+		} catch {
+			return [{ parseError: true, bytes: Buffer.byteLength(line) }];
+		}
+	});
+	const fileName = basename(input.path);
+	const sessionId = fileName.replace(/\.events\.ndjson$/, "");
+	return {
+		projectId: input.projectId,
+		sessionId,
+		sourcePath: basename(input.path),
+		eventCount: lines.length,
+		truncated: lines.length > MAX_REDACTED_EVENTS_PER_FILE,
+		events,
+	};
 }
 
 function summarizeProvider(provider: AgentAvailability) {
-  return {
-    providerId: provider.providerId,
-    displayName: provider.displayName,
-    cliInstalled: provider.cliInstalled,
-    cliVersion: provider.cliVersion,
-    cliLoggedIn: provider.cliLoggedIn,
-    hasApiKey: provider.hasApiKey,
-    cliVersionStatus: provider.cliVersionStatus,
-    latestVersionStatus: provider.latestVersionStatus,
-    authStatus: provider.authStatus,
-    authType: provider.authType,
-    status: provider.status,
-    statusMessage: provider.statusMessage,
-    lastCheckedAt: provider.lastCheckedAt,
-  };
+	return {
+		providerId: provider.providerId,
+		displayName: provider.displayName,
+		cliInstalled: provider.cliInstalled,
+		cliVersion: provider.cliVersion,
+		cliLoggedIn: provider.cliLoggedIn,
+		hasApiKey: provider.hasApiKey,
+		cliVersionStatus: provider.cliVersionStatus,
+		latestVersionStatus: provider.latestVersionStatus,
+		authStatus: provider.authStatus,
+		authType: provider.authType,
+		status: provider.status,
+		statusMessage: provider.statusMessage,
+		lastCheckedAt: provider.lastCheckedAt,
+	};
 }
 
 function prettyJson(value: unknown): string {
-  return `${JSON.stringify(value, null, 2)}\n`;
+	return `${JSON.stringify(value, null, 2)}\n`;
 }
 
 function jsonByteLength(value: unknown): number {
-  return Buffer.byteLength(JSON.stringify(value));
+	return Buffer.byteLength(JSON.stringify(value));
 }
 
 function writeJson(path: string, value: unknown): void {
-  writeFileSync(path, prettyJson(value), "utf8");
+	writeFileSync(path, prettyJson(value), "utf8");
 }
 
 function buildSummary(input: {
-  readonly diagnosticId: string;
-  readonly bundlePath: string;
-  readonly version: string;
-  readonly platform: string;
-  readonly arch: string;
-  readonly osRelease: string;
-  readonly latestFailures: ReadonlyArray<{
-    readonly span: string;
-    readonly message: string;
-  }>;
-  readonly providerCount: number;
+	readonly diagnosticId: string;
+	readonly bundlePath: string;
+	readonly version: string;
+	readonly platform: string;
+	readonly arch: string;
+	readonly osRelease: string;
+	readonly latestFailures: ReadonlyArray<{
+		readonly span: string;
+		readonly message: string;
+	}>;
+	readonly providerCount: number;
 }): string {
-  const topFailure = input.latestFailures[0];
-  return [
-    `Diagnostic ID: ${input.diagnosticId}`,
-    `Bundle: ${input.bundlePath}`,
-    `App: Zuse ${input.version}`,
-    `Platform: ${input.platform}-${input.arch} ${input.osRelease}`,
-    `Latest failure: ${topFailure ? `${topFailure.span} - ${topFailure.message}` : "none found"}`,
-    `Providers captured: ${input.providerCount}`,
-  ].join("\n");
+	const topFailure = input.latestFailures[0];
+	return [
+		`Diagnostic ID: ${input.diagnosticId}`,
+		`Bundle: ${input.bundlePath}`,
+		`App: Zuse ${input.version}`,
+		`Platform: ${input.platform}-${input.arch} ${input.osRelease}`,
+		`Latest failure: ${topFailure ? `${topFailure.span} - ${topFailure.message}` : "none found"}`,
+		`Providers captured: ${input.providerCount}`,
+	].join("\n");
 }
 
 export const DiagnosticsServiceLive = Layer.effect(
-  DiagnosticsService,
-  Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-    const paths = yield* AppPaths;
-    const providerService = yield* ProviderService;
+	DiagnosticsService,
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient;
+		const paths = yield* AppPaths;
+		const providerService = yield* ProviderService;
+		const runId = `run_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+		const eventsPath = join(
+			paths.userData,
+			"logs",
+			"diagnostics.events.ndjson",
+		);
+		const loaded = yield* Effect.try(() =>
+			loadPersistedEvents(eventsPath),
+		).pipe(
+			Effect.orElseSucceed(() => ({
+				events: [] as DiagnosticEvent[],
+				parseErrors: 0,
+			})),
+		);
+		const eventRef = yield* Ref.make<ReadonlyArray<DiagnosticEvent>>(
+			loaded.events,
+		);
+		let persistChain: Promise<void> = Promise.resolve();
+		const persistEvents = (events: ReadonlyArray<DiagnosticEvent>) => {
+			persistChain = persistChain
+				.catch(() => undefined)
+				.then(() => rotateAndAppend(eventsPath, events));
+			return persistChain;
+		};
 
-    const exportBundle = (payload: { readonly clientContext?: unknown }) =>
-      Effect.gen(function* () {
-        const createdAt = new Date();
-        const diagnosticId = `diag_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
-        const bundleDir = join(paths.userData, "diagnostics", diagnosticId);
-        yield* Effect.try(() => mkdirSync(bundleDir, { recursive: true }));
+		const ingest = (incoming: ReadonlyArray<DiagnosticEvent>) => {
+			const sanitized = incoming.map(sanitizeEvent);
+			return Effect.gen(function* () {
+				yield* Ref.update(eventRef, (current) =>
+					[...current, ...sanitized].slice(-MAX_DIAGNOSTIC_EVENTS),
+				);
+				yield* Effect.tryPromise(() => persistEvents(sanitized));
+			}).pipe(Effect.mapError(diagnosticsError));
+		};
 
-        const recentErrorRows = yield* sql<RecentErrorRow>`
+		const overview = (payload: { readonly since?: string }) =>
+			Effect.gen(function* () {
+				const all = yield* Ref.get(eventRef);
+				const events = filterDiagnosticEvents(all, { since: payload.since });
+				const aggregate = aggregateDiagnostics(events);
+				const storageBytes = yield* Effect.try(() =>
+					Array.from({ length: DIAGNOSTIC_FILE_COUNT }, (_, index) =>
+						index === 0 ? eventsPath : `${eventsPath}.${index}`,
+					)
+						.filter(existsSync)
+						.reduce((total, file) => total + statSync(file).size, 0),
+				).pipe(Effect.orElseSucceed(() => 0));
+				const status =
+					aggregate.fatalCount > 0 || aggregate.errorCount > 3
+						? ("failing" as const)
+						: aggregate.errorCount > 0 || aggregate.warningCount > 0
+							? ("degraded" as const)
+							: ("healthy" as const);
+				return DiagnosticsOverviewResult.make({
+					status,
+					runId,
+					readAt: new Date().toISOString(),
+					...aggregate,
+					parseErrorCount: loaded.parseErrors,
+					unseenCount: aggregate.errorCount + aggregate.fatalCount,
+					storageBytes,
+					capturePaused: false,
+					previousRunUnclean: events.some(
+						(event) => event.source === "main.previousRunUnclean",
+					),
+					topOperations: [],
+				});
+			}).pipe(Effect.mapError(diagnosticsError));
+
+		const events = (payload: {
+			readonly cursor?: string;
+			readonly limit?: number;
+			readonly severities?: ReadonlyArray<
+				import("@zuse/contracts").DiagnosticSeverity
+			>;
+			readonly source?: string;
+			readonly search?: string;
+			readonly since?: string;
+		}) =>
+			Effect.gen(function* () {
+				const all = yield* Ref.get(eventRef);
+				const filtered = [...filterDiagnosticEvents(all, payload)].sort(
+					(a, b) => b.createdAt.localeCompare(a.createdAt),
+				);
+				const offset = Math.max(0, Number(payload.cursor ?? "0") || 0);
+				const limit = Math.min(200, Math.max(1, payload.limit ?? 100));
+				return DiagnosticsEventsResult.make({
+					events: filtered.slice(offset, offset + limit),
+					nextCursor:
+						offset + limit < filtered.length ? String(offset + limit) : null,
+					total: filtered.length,
+				});
+			}).pipe(Effect.mapError(diagnosticsError));
+
+		const processes = Effect.tryPromise(readProcessTree).pipe(
+			Effect.mapError(diagnosticsError),
+		);
+		const signalProcess = (payload: {
+			readonly pid: number;
+			readonly signal: "interrupt" | "terminate" | "kill";
+		}) =>
+			Effect.gen(function* () {
+				const snapshot = yield* processes;
+				if (
+					payload.pid === snapshot.serverPid ||
+					!snapshot.processes.some((item) => item.pid === payload.pid)
+				) {
+					return DiagnosticsSignalResult.make({
+						signaled: false,
+						message: "The process is not a live descendant of the server.",
+					});
+				}
+				const signal =
+					payload.signal === "interrupt"
+						? "SIGINT"
+						: payload.signal === "terminate"
+							? "SIGTERM"
+							: "SIGKILL";
+				return yield* Effect.try(() => {
+					process.kill(payload.pid, signal);
+					return DiagnosticsSignalResult.make({ signaled: true });
+				}).pipe(Effect.mapError(diagnosticsError));
+			});
+
+		const exportBundle = (payload: {
+			readonly clientContext?: unknown;
+			readonly since?: string;
+			readonly includeSessionEvents?: boolean;
+		}) =>
+			Effect.gen(function* () {
+				const createdAt = new Date();
+				const diagnosticId = `diag_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+				const bundleDir = join(paths.userData, "diagnostics", diagnosticId);
+				yield* Effect.try(() => mkdirSync(bundleDir, { recursive: true }));
+
+				const recentErrorRows = yield* sql<RecentErrorRow>`
             SELECT
               m.id AS message_id,
               m.session_id,
@@ -248,184 +595,255 @@ export const DiagnosticsServiceLive = Layer.effect(
             LIMIT ${MAX_RECENT_ERRORS}
           `;
 
-        const providers = yield* providerService
-          .availability()
-          .pipe(Effect.orElseSucceed(() => []));
+				const providers = yield* providerService
+					.availability()
+					.pipe(Effect.orElseSucceed(() => []));
 
-        const latestFailures = recentErrorRows.map((row) => ({
-          traceId: null,
-          span: `message.${row.kind}`,
-          message: readErrorMessage(row.content_json),
-          chatId: row.chat_id,
-          sessionId: row.session_id,
-          providerId: row.provider_id,
-          model: row.model,
-          occurredAt: row.created_at,
-        }));
+				const latestFailures = recentErrorRows.map((row) => ({
+					traceId: null,
+					span: `message.${row.kind}`,
+					message: readErrorMessage(row.content_json),
+					chatId: row.chat_id,
+					sessionId: row.session_id,
+					providerId: row.provider_id,
+					model: row.model,
+					occurredAt: row.created_at,
+				}));
 
-        const commonFailureMap = new Map<
-          string,
-          { span: string; count: number; errorTag: string }
-        >();
-        for (const failure of latestFailures) {
-          const key = `${failure.span}:${failure.message}`;
-          const existing = commonFailureMap.get(key);
-          commonFailureMap.set(key, {
-            span: failure.span,
-            count: (existing?.count ?? 0) + 1,
-            errorTag: failure.message,
-          });
-        }
+				const commonFailureMap = new Map<
+					string,
+					{ span: string; count: number; errorTag: string }
+				>();
+				for (const failure of latestFailures) {
+					const key = `${failure.span}:${failure.message}`;
+					const existing = commonFailureMap.get(key);
+					commonFailureMap.set(key, {
+						span: failure.span,
+						count: (existing?.count ?? 0) + 1,
+						errorTag: failure.message,
+					});
+				}
 
-        const traceSummary = {
-          latestFailures,
-          slowestSpans: [],
-          commonFailures: [...commonFailureMap.values()].sort(
-            (left, right) => right.count - left.count,
-          ),
-        };
-        const recentErrors = {
-          errors: latestFailures,
-        };
-        const environment = {
-          app: "zuse",
-          version: packageJson.version,
-          createdAt: createdAt.toISOString(),
-          platform: platform(),
-          arch: arch(),
-          osRelease: release(),
-          node: process.version,
-        };
-        const providerStatus = {
-          providers: providers.map(summarizeProvider),
-        };
-        const sessionEvents = yield* Effect.try(() => ({
-          files: listSessionEventFiles(paths.userData).map(
-            redactSessionEventFile,
-          ),
-        }));
-        const artifacts: Record<string, unknown> = {
-          "trace-summary": traceSummary,
-          "recent-errors": recentErrors,
-          environment,
-          "provider-status": providerStatus,
-          "redacted-session-events": sessionEvents,
-        };
-        if (payload.clientContext !== undefined) {
-          artifacts["client-context"] = payload.clientContext;
-        }
+				const traceSummary = {
+					latestFailures,
+					slowestSpans: [],
+					commonFailures: [...commonFailureMap.values()].sort(
+						(left, right) => right.count - left.count,
+					),
+				};
+				const recentErrors = {
+					errors: latestFailures,
+				};
+				const environment = {
+					app: "zuse",
+					version: packageJson.version,
+					createdAt: createdAt.toISOString(),
+					platform: platform(),
+					arch: arch(),
+					osRelease: release(),
+					node: process.version,
+				};
+				const providerStatus = {
+					providers: providers.map(summarizeProvider),
+				};
+				const sessionEvents =
+					payload.includeSessionEvents === true
+						? yield* Effect.try(() => ({
+								files: listSessionEventFiles(paths.userData).map(
+									redactSessionEventFile,
+								),
+							}))
+						: { files: [] };
+				const diagnosticEvents = filterDiagnosticEvents(
+					yield* Ref.get(eventRef),
+					{ since: payload.since },
+				);
+				const processSnapshot = yield* processes.pipe(
+					Effect.orElseSucceed(() =>
+						DiagnosticsProcessesResult.make({
+							supported: false,
+							readAt: new Date().toISOString(),
+							serverPid: process.pid,
+							processes: [],
+							totalCpuPercent: 0,
+							totalRssBytes: 0,
+							error: "Process snapshot unavailable during export.",
+						}),
+					),
+				);
+				const redactionReport = {
+					rawPromptsIncluded: false,
+					rawTranscriptsIncluded: false,
+					terminalOutputIncluded: false,
+					environmentValuesIncluded: false,
+					strategy:
+						"allowlisted structural fields and secret-pattern scrubbing",
+				};
+				const artifacts: Record<string, unknown> = {
+					"trace-summary": traceSummary,
+					"recent-errors": recentErrors,
+					environment,
+					"provider-status": providerStatus,
+					"redacted-session-events": sessionEvents,
+					"diagnostic-events": { events: diagnosticEvents },
+					"process-snapshot": processSnapshot,
+					"redaction-report": redactionReport,
+				};
+				if (payload.clientContext !== undefined) {
+					artifacts["client-context"] = sanitizeDiagnosticValue(
+						payload.clientContext,
+					);
+				}
 
-        const artifactSizes = Object.fromEntries(
-          Object.entries(artifacts).map(([name, artifact]) => [
-            name,
-            jsonByteLength(artifact),
-          ]),
-        );
-        const diagnosticWarnings = [
-          latestFailures.length === 0
-            ? "No persisted message errors were captured."
-            : null,
-          payload.clientContext === undefined
-            ? "No renderer client context was provided."
-            : null,
-        ].filter((warning): warning is string => warning !== null);
-        const bundleSummary = {
-          diagnosticId,
-          generatedFor: "github-bug-report",
-          attachFileToIssue: true,
-          pasteJsonOnlyIfAttachmentFails: true,
-          artifactSizes,
-          diagnosticWarnings,
-        };
-        artifacts["bundle-summary"] = bundleSummary;
-        artifactSizes["bundle-summary"] = jsonByteLength(bundleSummary);
+				const artifactSizes = Object.fromEntries(
+					Object.entries(artifacts).map(([name, artifact]) => [
+						name,
+						jsonByteLength(artifact),
+					]),
+				);
+				const diagnosticWarnings = [
+					latestFailures.length === 0
+						? "No persisted message errors were captured."
+						: null,
+					payload.clientContext === undefined
+						? "No renderer client context was provided."
+						: null,
+				].filter((warning): warning is string => warning !== null);
+				const bundleSummary = {
+					diagnosticId,
+					generatedFor: "github-bug-report",
+					attachFileToIssue: true,
+					pasteJsonOnlyIfAttachmentFails: true,
+					artifactSizes,
+					diagnosticWarnings,
+				};
+				artifacts["bundle-summary"] = bundleSummary;
+				artifactSizes["bundle-summary"] = jsonByteLength(bundleSummary);
 
-        const included: BundleArtifactName[] = [
-          "manifest",
-          "bundle-summary",
-          "trace-summary",
-          "recent-errors",
-          "environment",
-          "provider-status",
-          ...(payload.clientContext !== undefined
-            ? (["client-context"] as const)
-            : []),
-          "redacted-session-events",
-        ];
-        const manifest = {
-          app: "zuse",
-          version: packageJson.version,
-          createdAt: createdAt.toISOString(),
-          platform: `${platform()}-${arch()}`,
-          diagnosticId,
-          included,
-          redaction: {
-            default:
-              "text fields are summarized with length and short previews",
-            rawPromptsIncluded: false,
-            rawTranscriptsIncluded: false,
-          },
-        };
+				const included: ExtendedBundleArtifactName[] = [
+					"manifest",
+					"bundle-summary",
+					"trace-summary",
+					"recent-errors",
+					"environment",
+					"provider-status",
+					...(payload.clientContext !== undefined
+						? (["client-context"] as const)
+						: []),
+					"redacted-session-events",
+					"diagnostic-events",
+					"process-snapshot",
+					"redaction-report",
+					"report",
+				];
+				const bundlePath = join(
+					paths.userData,
+					"diagnostics",
+					`zuse-diagnostics-${safeIsoForFile(createdAt)}-${diagnosticId}.zip`,
+				);
+				const summary = buildSummary({
+					diagnosticId,
+					bundlePath,
+					version: packageJson.version,
+					platform: platform(),
+					arch: arch(),
+					osRelease: release(),
+					latestFailures,
+					providerCount: providers.length,
+				});
+				const report = Buffer.from(
+					`# Diagnostic report\n\n\`\`\`\n${summary}\n\`\`\`\n`,
+				);
+				const artifactEntries = Object.entries(artifacts).map(
+					([name, artifact]) => ({
+						name: `${name}.json`,
+						data: Buffer.from(prettyJson(artifact)),
+					}),
+				);
+				const checksums = Object.fromEntries(
+					[{ name: "REPORT.md", data: report }, ...artifactEntries].map(
+						(entry) => [
+							entry.name,
+							createHash("sha256").update(entry.data).digest("hex"),
+						],
+					),
+				);
+				const manifest = {
+					app: "zuse",
+					version: packageJson.version,
+					createdAt: createdAt.toISOString(),
+					platform: `${platform()}-${arch()}`,
+					diagnosticId,
+					included,
+					redaction: {
+						default:
+							"content fields are excluded or summarized without previews",
+						rawPromptsIncluded: false,
+						rawTranscriptsIncluded: false,
+					},
+					checksums,
+				};
 
-        yield* Effect.try(() => {
-          writeJson(join(bundleDir, "manifest.json"), manifest);
-          writeJson(join(bundleDir, "bundle-summary.json"), bundleSummary);
-          writeJson(join(bundleDir, "trace-summary.json"), traceSummary);
-          writeJson(join(bundleDir, "recent-errors.json"), recentErrors);
-          writeJson(join(bundleDir, "environment.json"), environment);
-          writeJson(join(bundleDir, "provider-status.json"), providerStatus);
-          if (payload.clientContext !== undefined) {
-            writeJson(join(bundleDir, "client-context.json"), payload.clientContext);
-          }
-          writeJson(
-            join(bundleDir, "session-events-redacted.json"),
-            sessionEvents,
-          );
-        });
+				yield* Effect.try(() => {
+					writeJson(join(bundleDir, "manifest.json"), manifest);
+					writeJson(join(bundleDir, "bundle-summary.json"), bundleSummary);
+					writeJson(join(bundleDir, "trace-summary.json"), traceSummary);
+					writeJson(join(bundleDir, "recent-errors.json"), recentErrors);
+					writeJson(join(bundleDir, "environment.json"), environment);
+					writeJson(join(bundleDir, "provider-status.json"), providerStatus);
+					if (payload.clientContext !== undefined) {
+						writeJson(
+							join(bundleDir, "client-context.json"),
+							artifacts["client-context"],
+						);
+					}
+					writeJson(
+						join(bundleDir, "session-events-redacted.json"),
+						sessionEvents,
+					);
+				});
 
-        const bundlePath = join(
-          paths.userData,
-          "diagnostics",
-          `zuse-diagnostics-${safeIsoForFile(createdAt)}-${diagnosticId}.json`,
-        );
-        const bundle = {
-          manifest,
-          artifacts,
-        };
-        yield* Effect.try(() => {
-          writeJson(bundlePath, bundle);
-          copyFileSync(bundlePath, join(bundleDir, basename(bundlePath)));
-        });
+				yield* Effect.try(() => {
+					const entries = [
+						{
+							name: "manifest.json",
+							data: Buffer.from(prettyJson(manifest)),
+						},
+						{
+							name: "REPORT.md",
+							data: report,
+						},
+						...artifactEntries,
+					];
+					writeFileSync(bundlePath, createStoredZip(entries));
+					copyFileSync(bundlePath, join(bundleDir, basename(bundlePath)));
+				});
+				return DiagnosticsExportResult.make({
+					diagnosticId,
+					createdAt,
+					bundlePath,
+					summary,
+					included,
+				});
+			}).pipe(
+				Effect.mapError(
+					(cause) =>
+						new DiagnosticsExportError({
+							reason:
+								cause instanceof Error
+									? cause.message
+									: "Failed to export diagnostics.",
+						}),
+				),
+			);
 
-        const summary = buildSummary({
-          diagnosticId,
-          bundlePath,
-          version: packageJson.version,
-          platform: platform(),
-          arch: arch(),
-          osRelease: release(),
-          latestFailures,
-          providerCount: providers.length,
-        });
-        return DiagnosticsExportResult.make({
-          diagnosticId,
-          createdAt,
-          bundlePath,
-          summary,
-          included,
-        });
-      }).pipe(
-        Effect.mapError(
-          (cause) =>
-            new DiagnosticsExportError({
-              reason:
-                cause instanceof Error
-                  ? cause.message
-                  : "Failed to export diagnostics.",
-            }),
-        ),
-      );
-
-    return { exportBundle } as const;
-  }),
+		return {
+			overview,
+			events,
+			ingest,
+			processes,
+			signalProcess,
+			exportBundle,
+		} as const;
+	}),
 );

--- a/apps/server/src/diagnostics/layers/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/layers/diagnostics-service.ts
@@ -7,16 +7,14 @@ import {
 	readdirSync,
 	readFileSync,
 	statSync,
-	unlinkSync,
 	writeFileSync,
 } from "node:fs";
-import { appendFile, mkdir, rename, stat } from "node:fs/promises";
 import { arch, platform, release } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, join } from "node:path";
 import { promisify } from "node:util";
 import {
 	type AgentAvailability,
-	DiagnosticEvent,
+	type DiagnosticEvent,
 	DiagnosticsEventsResult,
 	DiagnosticsExportError,
 	DiagnosticsExportResult,
@@ -24,16 +22,17 @@ import {
 	DiagnosticsProcessesResult,
 	DiagnosticsSignalResult,
 } from "@zuse/contracts";
-import { Effect, Layer, Ref, Schema } from "effect";
+import { Effect, Layer } from "effect";
 import { SqlClient } from "effect/unstable/sql";
 
 import packageJson from "../../../package.json" with { type: "json" };
 import { AppPaths } from "../../app-paths.ts";
+import { TelemetryStore } from "../../observability/telemetry-store.ts";
 import { ProviderService } from "../../provider/services/provider-service.ts";
 import {
 	aggregateDiagnostics,
-	diagnosticFingerprint,
 	filterDiagnosticEvents,
+	paginateDiagnosticEvents,
 	sanitizeDiagnosticText,
 	sanitizeDiagnosticValue,
 } from "../diagnostics-model.ts";
@@ -44,10 +43,6 @@ const MAX_RECENT_ERRORS = 20;
 const MAX_SESSION_EVENTS = 8;
 const MAX_REDACTED_EVENTS_PER_FILE = 200;
 const MAX_TEXT_PREVIEW = 240;
-const MAX_DIAGNOSTIC_EVENTS = 100_000;
-const MAX_DIAGNOSTIC_FILE_BYTES = 20 * 1024 * 1024;
-const DIAGNOSTIC_FILE_COUNT = 5;
-const DIAGNOSTIC_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
 const execFileAsync = promisify(execFile);
 
 const diagnosticsError = (cause: unknown) =>
@@ -55,84 +50,6 @@ const diagnosticsError = (cause: unknown) =>
 		reason:
 			cause instanceof Error ? cause.message : "Diagnostics operation failed.",
 	});
-
-function loadPersistedEvents(path: string): {
-	events: DiagnosticEvent[];
-	parseErrors: number;
-} {
-	let parseErrors = 0;
-	const retainedFiles = Array.from(
-		{ length: DIAGNOSTIC_FILE_COUNT },
-		(_, index) =>
-			index === DIAGNOSTIC_FILE_COUNT - 1
-				? path
-				: `${path}.${DIAGNOSTIC_FILE_COUNT - 1 - index}`,
-	).filter((file) => {
-		if (!existsSync(file)) return false;
-		if (Date.now() - statSync(file).mtimeMs <= DIAGNOSTIC_RETENTION_MS)
-			return true;
-		try {
-			unlinkSync(file);
-		} catch {
-			// Retention is best-effort and must never block diagnostics startup.
-		}
-		return false;
-	});
-	const lines = retainedFiles.flatMap((file) =>
-		readFileSync(file, "utf8").split(/\r?\n/),
-	);
-	const events = lines
-		.filter(Boolean)
-		.slice(-MAX_DIAGNOSTIC_EVENTS)
-		.flatMap((line) => {
-			try {
-				return [Schema.decodeUnknownSync(DiagnosticEvent)(JSON.parse(line))];
-			} catch {
-				parseErrors += 1;
-				return [];
-			}
-		});
-	return { events, parseErrors };
-}
-
-function sanitizeEvent(event: DiagnosticEvent): DiagnosticEvent {
-	const message = sanitizeDiagnosticText(event.message);
-	const detail = event.detail
-		? sanitizeDiagnosticText(event.detail)
-		: undefined;
-	return {
-		...event,
-		message,
-		detail,
-		fingerprint: diagnosticFingerprint({
-			source: event.source,
-			category: event.category,
-			message,
-		}),
-	};
-}
-
-async function rotateAndAppend(
-	path: string,
-	events: ReadonlyArray<DiagnosticEvent>,
-): Promise<void> {
-	await mkdir(dirname(path), { recursive: true });
-	const chunk = events.map((event) => `${JSON.stringify(event)}\n`).join("");
-	const currentSize = await stat(path)
-		.then((value) => value.size)
-		.catch(() => 0);
-	if (
-		currentSize > 0 &&
-		currentSize + Buffer.byteLength(chunk) > MAX_DIAGNOSTIC_FILE_BYTES
-	) {
-		for (let index = DIAGNOSTIC_FILE_COUNT - 1; index >= 1; index -= 1) {
-			const source = index === 1 ? path : `${path}.${index - 1}`;
-			const target = `${path}.${index}`;
-			await rename(source, target).catch(() => undefined);
-		}
-	}
-	await appendFile(path, chunk, "utf8");
-}
 
 function parseElapsedSeconds(value: string): number {
 	const [dayPart, timePart] = value.includes("-")
@@ -442,73 +359,56 @@ export const DiagnosticsServiceLive = Layer.effect(
 		const sql = yield* SqlClient.SqlClient;
 		const paths = yield* AppPaths;
 		const providerService = yield* ProviderService;
-		const runId = `run_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
-		const eventsPath = join(
-			paths.userData,
-			"logs",
-			"diagnostics.events.ndjson",
-		);
-		const loaded = yield* Effect.try(() =>
-			loadPersistedEvents(eventsPath),
-		).pipe(
-			Effect.orElseSucceed(() => ({
-				events: [] as DiagnosticEvent[],
-				parseErrors: 0,
-			})),
-		);
-		const eventRef = yield* Ref.make<ReadonlyArray<DiagnosticEvent>>(
-			loaded.events,
-		);
-		let persistChain: Promise<void> = Promise.resolve();
-		const persistEvents = (events: ReadonlyArray<DiagnosticEvent>) => {
-			persistChain = persistChain
-				.catch(() => undefined)
-				.then(() => rotateAndAppend(eventsPath, events));
-			return persistChain;
-		};
-
-		const ingest = (incoming: ReadonlyArray<DiagnosticEvent>) => {
-			const sanitized = incoming.map(sanitizeEvent);
-			return Effect.gen(function* () {
-				yield* Ref.update(eventRef, (current) =>
-					[...current, ...sanitized].slice(-MAX_DIAGNOSTIC_EVENTS),
-				);
-				yield* Effect.tryPromise(() => persistEvents(sanitized));
-			}).pipe(Effect.mapError(diagnosticsError));
-		};
+		const telemetry = yield* TelemetryStore;
+		const runId = telemetry.runId;
+		let overviewCache:
+			| {
+					readonly since: string | undefined;
+					readonly version: number;
+					readonly value: DiagnosticsOverviewResult;
+			  }
+			| undefined;
+		const eventQueryCache = new Map<
+			string,
+			{ readonly version: number; readonly value: DiagnosticsEventsResult }
+		>();
+		const ingest = (incoming: ReadonlyArray<DiagnosticEvent>) =>
+			Effect.sync(() => telemetry.recordMany(incoming));
 
 		const overview = (payload: { readonly since?: string }) =>
 			Effect.gen(function* () {
-				const all = yield* Ref.get(eventRef);
+				const version = telemetry.version();
+				if (
+					overviewCache?.version === version &&
+					overviewCache.since === payload.since
+				) {
+					return overviewCache.value;
+				}
+				const all = telemetry.snapshot();
 				const events = filterDiagnosticEvents(all, { since: payload.since });
 				const aggregate = aggregateDiagnostics(events);
-				const storageBytes = yield* Effect.try(() =>
-					Array.from({ length: DIAGNOSTIC_FILE_COUNT }, (_, index) =>
-						index === 0 ? eventsPath : `${eventsPath}.${index}`,
-					)
-						.filter(existsSync)
-						.reduce((total, file) => total + statSync(file).size, 0),
-				).pipe(Effect.orElseSucceed(() => 0));
+				const storageBytes = yield* telemetry.storageBytes;
 				const status =
 					aggregate.fatalCount > 0 || aggregate.errorCount > 3
 						? ("failing" as const)
 						: aggregate.errorCount > 0 || aggregate.warningCount > 0
 							? ("degraded" as const)
 							: ("healthy" as const);
-				return DiagnosticsOverviewResult.make({
+				const value = DiagnosticsOverviewResult.make({
 					status,
 					runId,
 					readAt: new Date().toISOString(),
 					...aggregate,
-					parseErrorCount: loaded.parseErrors,
+					parseErrorCount: telemetry.parseErrorCount,
 					unseenCount: aggregate.errorCount + aggregate.fatalCount,
 					storageBytes,
 					capturePaused: false,
 					previousRunUnclean: events.some(
 						(event) => event.source === "main.previousRunUnclean",
 					),
-					topOperations: [],
 				});
+				overviewCache = { since: payload.since, version, value };
+				return value;
 			}).pipe(Effect.mapError(diagnosticsError));
 
 		const events = (payload: {
@@ -521,20 +421,29 @@ export const DiagnosticsServiceLive = Layer.effect(
 			readonly search?: string;
 			readonly since?: string;
 		}) =>
-			Effect.gen(function* () {
-				const all = yield* Ref.get(eventRef);
-				const filtered = [...filterDiagnosticEvents(all, payload)].sort(
-					(a, b) => b.createdAt.localeCompare(a.createdAt),
-				);
-				const offset = Math.max(0, Number(payload.cursor ?? "0") || 0);
+			Effect.sync(() => {
+				const version = telemetry.version();
+				const cacheKey = JSON.stringify(payload);
+				const cached = eventQueryCache.get(cacheKey);
+				if (cached?.version === version) return cached.value;
+				const all = telemetry.snapshot();
+				const filtered = filterDiagnosticEvents(all, payload);
 				const limit = Math.min(200, Math.max(1, payload.limit ?? 100));
-				return DiagnosticsEventsResult.make({
-					events: filtered.slice(offset, offset + limit),
-					nextCursor:
-						offset + limit < filtered.length ? String(offset + limit) : null,
+				const page = paginateDiagnosticEvents(filtered, {
+					cursor: payload.cursor,
+					limit,
+				});
+				const value = DiagnosticsEventsResult.make({
+					events: page.events,
+					nextCursor: page.nextCursor,
 					total: filtered.length,
 				});
-			}).pipe(Effect.mapError(diagnosticsError));
+				if (eventQueryCache.size >= 12) {
+					eventQueryCache.delete(eventQueryCache.keys().next().value ?? "");
+				}
+				eventQueryCache.set(cacheKey, { version, value });
+				return value;
+			});
 
 		const processes = Effect.tryPromise(readProcessTree).pipe(
 			Effect.mapError(diagnosticsError),
@@ -624,12 +533,19 @@ export const DiagnosticsServiceLive = Layer.effect(
 					});
 				}
 
+				const diagnosticEvents = filterDiagnosticEvents(telemetry.snapshot(), {
+					since: payload.since,
+				});
+				const diagnosticAggregate = aggregateDiagnostics(diagnosticEvents);
 				const traceSummary = {
 					latestFailures,
-					slowestSpans: [],
-					commonFailures: [...commonFailureMap.values()].sort(
-						(left, right) => right.count - left.count,
-					),
+					slowestSpans: diagnosticAggregate.slowestOperations,
+					commonFailures:
+						diagnosticAggregate.commonFailures.length > 0
+							? diagnosticAggregate.commonFailures
+							: [...commonFailureMap.values()].sort(
+									(left, right) => right.count - left.count,
+								),
 				};
 				const recentErrors = {
 					errors: latestFailures,
@@ -654,10 +570,6 @@ export const DiagnosticsServiceLive = Layer.effect(
 								),
 							}))
 						: { files: [] };
-				const diagnosticEvents = filterDiagnosticEvents(
-					yield* Ref.get(eventRef),
-					{ since: payload.since },
-				);
 				const processSnapshot = yield* processes.pipe(
 					Effect.orElseSucceed(() =>
 						DiagnosticsProcessesResult.make({

--- a/apps/server/src/diagnostics/services/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/services/diagnostics-service.ts
@@ -1,19 +1,46 @@
+import type {
+	DiagnosticEvent,
+	DiagnosticSeverity,
+	DiagnosticsEventsResult,
+	DiagnosticsExportError,
+	DiagnosticsExportResult,
+	DiagnosticsOverviewResult,
+	DiagnosticsProcessesResult,
+	DiagnosticsSignalResult,
+} from "@zuse/contracts";
 import { Context, type Effect } from "effect";
 
-import type {
-  DiagnosticsExportError,
-  DiagnosticsExportResult,
-} from "@zuse/contracts";
-
 export interface DiagnosticsServiceShape {
-  readonly exportBundle: (payload: {
-    readonly clientContext?: unknown;
-  }) => Effect.Effect<
-    DiagnosticsExportResult,
-    DiagnosticsExportError
-  >;
+	readonly overview: (payload: {
+		readonly since?: string;
+	}) => Effect.Effect<DiagnosticsOverviewResult, DiagnosticsExportError>;
+	readonly events: (payload: {
+		readonly cursor?: string;
+		readonly limit?: number;
+		readonly severities?: ReadonlyArray<DiagnosticSeverity>;
+		readonly source?: string;
+		readonly search?: string;
+		readonly since?: string;
+	}) => Effect.Effect<DiagnosticsEventsResult, DiagnosticsExportError>;
+	readonly ingest: (
+		events: ReadonlyArray<DiagnosticEvent>,
+	) => Effect.Effect<void, DiagnosticsExportError>;
+	readonly processes: Effect.Effect<
+		DiagnosticsProcessesResult,
+		DiagnosticsExportError
+	>;
+	readonly signalProcess: (payload: {
+		readonly pid: number;
+		readonly signal: "interrupt" | "terminate" | "kill";
+	}) => Effect.Effect<DiagnosticsSignalResult, DiagnosticsExportError>;
+	readonly exportBundle: (payload: {
+		readonly clientContext?: unknown;
+		readonly since?: string;
+		readonly includeSessionEvents?: boolean;
+	}) => Effect.Effect<DiagnosticsExportResult, DiagnosticsExportError>;
 }
 
-export class DiagnosticsService extends Context.Service<DiagnosticsService, DiagnosticsServiceShape>()(
-  "memoize/DiagnosticsService",
-) {}
+export class DiagnosticsService extends Context.Service<
+	DiagnosticsService,
+	DiagnosticsServiceShape
+>()("memoize/DiagnosticsService") {}

--- a/apps/server/src/diagnostics/zip-bundle.ts
+++ b/apps/server/src/diagnostics/zip-bundle.ts
@@ -1,0 +1,59 @@
+export interface ZipEntry {
+	readonly name: string;
+	readonly data: Buffer;
+}
+
+const CRC_TABLE = Array.from({ length: 256 }, (_, index) => {
+	let value = index;
+	for (let bit = 0; bit < 8; bit += 1) {
+		value = (value & 1) !== 0 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+	}
+	return value >>> 0;
+});
+
+function crc32(data: Buffer): number {
+	let crc = 0xffffffff;
+	for (const byte of data)
+		crc = (crc >>> 8) ^ (CRC_TABLE[(crc ^ byte) & 0xff] ?? 0);
+	return (crc ^ 0xffffffff) >>> 0;
+}
+
+export function createStoredZip(entries: ReadonlyArray<ZipEntry>): Buffer {
+	const localParts: Buffer[] = [];
+	const centralParts: Buffer[] = [];
+	let offset = 0;
+
+	for (const entry of entries) {
+		const name = Buffer.from(entry.name.replaceAll("\\", "/"), "utf8");
+		const checksum = crc32(entry.data);
+		const localHeader = Buffer.alloc(30);
+		localHeader.writeUInt32LE(0x04034b50, 0);
+		localHeader.writeUInt16LE(20, 4);
+		localHeader.writeUInt32LE(checksum, 14);
+		localHeader.writeUInt32LE(entry.data.length, 18);
+		localHeader.writeUInt32LE(entry.data.length, 22);
+		localHeader.writeUInt16LE(name.length, 26);
+		localParts.push(localHeader, name, entry.data);
+
+		const centralHeader = Buffer.alloc(46);
+		centralHeader.writeUInt32LE(0x02014b50, 0);
+		centralHeader.writeUInt16LE(20, 4);
+		centralHeader.writeUInt16LE(20, 6);
+		centralHeader.writeUInt32LE(checksum, 16);
+		centralHeader.writeUInt32LE(entry.data.length, 20);
+		centralHeader.writeUInt32LE(entry.data.length, 24);
+		centralHeader.writeUInt16LE(name.length, 28);
+		centralHeader.writeUInt32LE(offset, 42);
+		centralParts.push(centralHeader, name);
+		offset += localHeader.length + name.length + entry.data.length;
+	}
+
+	const centralDirectory = Buffer.concat(centralParts);
+	const end = Buffer.alloc(22);
+	end.writeUInt32LE(0x06054b50, 0);
+	end.writeUInt16LE(entries.length, 8);
+	end.writeUInt16LE(entries.length, 10);
+	end.writeUInt32LE(centralDirectory.length, 12);
+	end.writeUInt32LE(offset, 16);
+	return Buffer.concat([...localParts, centralDirectory, end]);
+}

--- a/apps/server/src/observability/telemetry-layer.ts
+++ b/apps/server/src/observability/telemetry-layer.ts
@@ -1,0 +1,206 @@
+import {
+	Cause,
+	Duration,
+	Effect,
+	Exit,
+	Layer,
+	type Option,
+	Tracer,
+} from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import {
+	OtlpMetrics,
+	OtlpSerialization,
+	OtlpTracer,
+} from "effect/unstable/observability";
+import { sanitizeDiagnosticText } from "../diagnostics/diagnostics-model.ts";
+import { recordOperationMetrics } from "./telemetry-metrics.ts";
+import {
+	filterTelemetryAttributes,
+	telemetryCategoryForSpan,
+	telemetryCauseSummary,
+	telemetryEventFromSpan,
+} from "./telemetry-model.ts";
+import { TelemetryStore } from "./telemetry-store.ts";
+
+const TRACE_URL = (process.env.ZUSE_OTLP_TRACES_URL ?? "").trim();
+const METRICS_URL = (process.env.ZUSE_OTLP_METRICS_URL ?? "").trim();
+const SERVICE_NAME =
+	(process.env.ZUSE_OTLP_SERVICE_NAME ?? "").trim() || "zuse-server";
+const EXPORT_INTERVAL_MS = Math.max(
+	1_000,
+	Number(process.env.ZUSE_OTLP_EXPORT_INTERVAL_MS) || 10_000,
+);
+
+const shouldRecordLocally = (name: string): boolean =>
+	!name.startsWith("RpcServer.diagnostics.") &&
+	!name.startsWith("RpcClient.diagnostics.");
+
+class TelemetrySpan implements Tracer.Span {
+	readonly _tag = "Span";
+	readonly name: string;
+	readonly spanId: string;
+	readonly traceId: string;
+	readonly parent: Option.Option<Tracer.AnySpan>;
+	readonly annotations: Tracer.Span["annotations"];
+	readonly links: Array<Tracer.SpanLink>;
+	readonly sampled: boolean;
+	readonly kind: Tracer.SpanKind;
+
+	status: Tracer.SpanStatus;
+	attributes = new Map<string, unknown>();
+	events: Array<readonly [string, bigint, Record<string, unknown>]> = [];
+
+	constructor(
+		private readonly options: Parameters<Tracer.Tracer["span"]>[0],
+		private readonly delegate: Tracer.Span,
+		private readonly store: TelemetryStore["Service"],
+	) {
+		this.name = delegate.name;
+		this.spanId = delegate.spanId;
+		this.traceId = delegate.traceId;
+		this.parent = options.parent;
+		this.annotations = options.annotations;
+		this.links = [...options.links];
+		this.sampled = delegate.sampled;
+		this.kind = delegate.kind;
+		this.status = { _tag: "Started", startTime: options.startTime };
+	}
+
+	end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+		this.status = {
+			_tag: "Ended",
+			startTime: this.options.startTime,
+			endTime,
+			exit,
+		};
+		this.delegate.end(
+			endTime,
+			Exit.isSuccess(exit)
+				? exit
+				: Exit.fail(telemetryCauseSummary(exit.cause).type),
+		);
+		const durationMs =
+			Number(
+				endTime > this.options.startTime
+					? endTime - this.options.startTime
+					: 0n,
+			) / 1_000_000;
+		const outcome = Exit.isSuccess(exit)
+			? "success"
+			: Cause.hasInterruptsOnly(exit.cause)
+				? "interrupted"
+				: "failure";
+		recordOperationMetrics({
+			operation: this.name,
+			category: telemetryCategoryForSpan(this.name),
+			outcome,
+			durationMs,
+			context: this.annotations,
+		});
+		if (!this.sampled || !shouldRecordLocally(this.name)) return;
+		this.store.record(
+			telemetryEventFromSpan({
+				name: this.name,
+				traceId: this.traceId,
+				spanId: this.spanId,
+				startTime: this.options.startTime,
+				endTime,
+				exit,
+				attributes: this.attributes,
+				runId: this.store.runId,
+			}),
+		);
+	}
+
+	attribute(key: string, value: unknown): void {
+		const allowed = filterTelemetryAttributes({ [key]: value });
+		if (!(key in allowed)) return;
+		this.attributes.set(key, allowed[key]);
+		this.delegate.attribute(key, allowed[key]);
+	}
+
+	event(
+		name: string,
+		startTime: bigint,
+		attributes: Record<string, unknown> = {},
+	): void {
+		const safeName = sanitizeDiagnosticText(name);
+		const safeAttributes = filterTelemetryAttributes(attributes);
+		this.events.push([safeName, startTime, safeAttributes]);
+		this.delegate.event(safeName, startTime, safeAttributes);
+	}
+
+	addLinks(links: ReadonlyArray<Tracer.SpanLink>): void {
+		const safeLinks = links.map((link) => ({
+			...link,
+			attributes: filterTelemetryAttributes(link.attributes),
+		}));
+		this.links.push(...safeLinks);
+		this.delegate.addLinks(safeLinks);
+	}
+}
+
+const makeRecordingTracer = (
+	store: TelemetryStore["Service"],
+	delegate: Tracer.Tracer,
+): Tracer.Tracer =>
+	Tracer.make({
+		span: (options) => {
+			const safeOptions = {
+				...options,
+				links: options.links.map((link) => ({
+					...link,
+					attributes: filterTelemetryAttributes(link.attributes),
+				})),
+			};
+			return new TelemetrySpan(safeOptions, delegate.span(safeOptions), store);
+		},
+		...(delegate.context === undefined ? {} : { context: delegate.context }),
+	});
+
+export const TelemetryObservabilityLive = Layer.unwrap(
+	Effect.gen(function* () {
+		const store = yield* TelemetryStore;
+		const delegate =
+			TRACE_URL.length === 0
+				? Tracer.make({
+						span: (options) => new Tracer.NativeSpan(options),
+					})
+				: yield* OtlpTracer.make({
+						url: TRACE_URL,
+						exportInterval: Duration.millis(EXPORT_INTERVAL_MS),
+						resource: {
+							serviceName: SERVICE_NAME,
+							serviceVersion: process.env.ZUSE_APP_VERSION ?? "unknown",
+							attributes: {
+								"service.runtime": "server",
+								"service.environment": process.env.NODE_ENV ?? "development",
+							},
+						},
+					});
+		const tracerLayer = Layer.succeed(
+			Tracer.Tracer,
+			makeRecordingTracer(store, delegate),
+		);
+		const metricsLayer =
+			METRICS_URL.length === 0
+				? Layer.empty
+				: OtlpMetrics.layer({
+						url: METRICS_URL,
+						exportInterval: Duration.millis(EXPORT_INTERVAL_MS),
+						resource: {
+							serviceName: SERVICE_NAME,
+							serviceVersion: process.env.ZUSE_APP_VERSION ?? "unknown",
+							attributes: {
+								"service.runtime": "server",
+								"service.environment": process.env.NODE_ENV ?? "development",
+							},
+						},
+					});
+		return Layer.merge(tracerLayer, metricsLayer);
+	}),
+).pipe(
+	Layer.provideMerge(OtlpSerialization.layerJson),
+	Layer.provideMerge(FetchHttpClient.layer),
+);

--- a/apps/server/src/observability/telemetry-metrics.ts
+++ b/apps/server/src/observability/telemetry-metrics.ts
@@ -1,0 +1,48 @@
+import { Context, Duration, Metric } from "effect";
+
+export const operationsTotal = Metric.counter("zuse_operations_total", {
+	description: "Completed application operations grouped by stable boundary.",
+	incremental: true,
+});
+
+export const operationDuration = Metric.timer("zuse_operation_duration", {
+	description: "Application operation duration grouped by stable boundary.",
+});
+
+export const failuresTotal = Metric.counter("zuse_failures_total", {
+	description: "Failed application operations grouped by stable boundary.",
+	incremental: true,
+});
+
+const labels = (input: {
+	readonly operation: string;
+	readonly category: string;
+	readonly outcome: string;
+}): ReadonlyArray<[string, string]> => [
+	["operation", input.operation],
+	["category", input.category],
+	["outcome", input.outcome],
+];
+
+export const recordOperationMetrics = (input: {
+	readonly operation: string;
+	readonly category: string;
+	readonly outcome: "success" | "failure" | "interrupted";
+	readonly durationMs: number;
+	readonly context?: Context.Context<never>;
+}): void => {
+	try {
+		const context = input.context ?? Context.empty();
+		const attributes = labels(input);
+		Metric.withAttributes(operationsTotal, attributes).updateUnsafe(1, context);
+		Metric.withAttributes(operationDuration, attributes).updateUnsafe(
+			Duration.millis(input.durationMs),
+			context,
+		);
+		if (input.outcome === "failure") {
+			Metric.withAttributes(failuresTotal, attributes).updateUnsafe(1, context);
+		}
+	} catch {
+		// Metric collection is observational and must remain failure-isolated.
+	}
+};

--- a/apps/server/src/observability/telemetry-model.ts
+++ b/apps/server/src/observability/telemetry-model.ts
@@ -1,0 +1,208 @@
+import type { DiagnosticEvent } from "@zuse/contracts";
+import { Cause, Exit } from "effect";
+
+import {
+	diagnosticFingerprint,
+	sanitizeDiagnosticText,
+	sanitizeDiagnosticValue,
+} from "../diagnostics/diagnostics-model.ts";
+
+const correlationAttribute = (
+	attributes: ReadonlyMap<string, unknown>,
+	keys: ReadonlyArray<string>,
+): string | null => {
+	for (const key of keys) {
+		const value = attributes.get(key);
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return null;
+};
+
+const ALLOWED_ATTRIBUTE_KEYS = new Set([
+	"project.id",
+	"projectId",
+	"chat.id",
+	"chatId",
+	"session.id",
+	"sessionId",
+	"provider.id",
+	"providerId",
+	"provider.model",
+	"rpc.method",
+	"rpc.service",
+	"error.type",
+	"error.tag",
+	"operation",
+	"subsystem",
+	"process.type",
+	"process.pid",
+]);
+
+export const filterTelemetryAttributes = (
+	attributes: ReadonlyMap<string, unknown> | Record<string, unknown>,
+): Record<string, unknown> => {
+	const entries =
+		attributes instanceof Map
+			? [...attributes.entries()]
+			: Object.entries(attributes);
+	return Object.fromEntries(
+		entries
+			.filter(([key]) => ALLOWED_ATTRIBUTE_KEYS.has(key))
+			.map(([key, value]) => [key, sanitizeDiagnosticValue(value)]),
+	);
+};
+
+export const telemetryCategoryForSpan = (name: string): string => {
+	const normalized = name.toLowerCase();
+	if (normalized.startsWith("rpcserver.")) {
+		const method = normalized.slice("rpcserver.".length);
+		if (method.startsWith("provider.")) return "provider";
+		if (method.startsWith("git.") || method.startsWith("worktree."))
+			return "git";
+		if (method.startsWith("pty.") || method.startsWith("terminal.")) {
+			return "terminal";
+		}
+		if (
+			method.startsWith("relay.") ||
+			method.startsWith("pairing.") ||
+			method.startsWith("network.")
+		) {
+			return "network";
+		}
+		if (method.startsWith("diagnostics.")) return "diagnostics";
+		if (method.startsWith("permission.")) return "permission";
+		if (method.startsWith("attachment.")) return "attachment";
+		if (method.startsWith("mcp.")) return "mcp";
+		if (
+			method.startsWith("session.") ||
+			method.startsWith("chat.") ||
+			method.startsWith("workspace.")
+		) {
+			return "persistence";
+		}
+		return "rpc";
+	}
+	if (normalized.startsWith("rpc.")) {
+		return "rpc";
+	}
+	if (normalized.startsWith("provider.")) return "provider";
+	if (normalized.startsWith("git.")) return "git";
+	if (normalized.startsWith("pty.") || normalized.startsWith("terminal.")) {
+		return "terminal";
+	}
+	if (normalized.startsWith("sql.") || normalized.startsWith("persistence.")) {
+		return "persistence";
+	}
+	if (normalized.startsWith("relay.") || normalized.startsWith("network.")) {
+		return "network";
+	}
+	if (normalized.startsWith("diagnostics.")) return "diagnostics";
+	return "server";
+};
+
+export interface CompletedTelemetrySpan {
+	readonly name: string;
+	readonly traceId: string;
+	readonly spanId: string;
+	readonly startTime: bigint;
+	readonly endTime: bigint;
+	readonly exit: Exit.Exit<unknown, unknown>;
+	readonly attributes: ReadonlyMap<string, unknown>;
+	readonly runId: string;
+}
+
+const safeErrorType = (value: unknown): string => {
+	if (
+		typeof value === "object" &&
+		value !== null &&
+		"_tag" in value &&
+		typeof value._tag === "string" &&
+		/^[A-Za-z][A-Za-z0-9]*$/.test(value._tag)
+	) {
+		return value._tag;
+	}
+	if (value instanceof Error && /^[A-Za-z][A-Za-z0-9]*$/.test(value.name)) {
+		return value.name;
+	}
+	return "UnknownError";
+};
+
+export const telemetryCauseSummary = (
+	cause: Cause.Cause<unknown>,
+): {
+	readonly kind: "failure" | "defect" | "interrupted";
+	readonly type: string;
+	readonly stackFrames?: string;
+} => {
+	if (Cause.hasInterruptsOnly(cause)) {
+		return { kind: "interrupted", type: "Interrupted" };
+	}
+	const value = Cause.squash(cause);
+	const stackFrames =
+		value instanceof Error
+			? sanitizeDiagnosticText(
+					value.stack?.split(/\r?\n/).slice(1, 21).join("\n") ?? "",
+				).trim()
+			: "";
+	return {
+		kind: Cause.hasDies(cause) ? "defect" : "failure",
+		type: safeErrorType(value),
+		...(stackFrames.length === 0 ? {} : { stackFrames }),
+	};
+};
+
+export const telemetryEventFromSpan = (
+	span: CompletedTelemetrySpan,
+): DiagnosticEvent => {
+	const category = telemetryCategoryForSpan(span.name);
+	const failed = Exit.isFailure(span.exit);
+	const interrupted = failed && Cause.hasInterruptsOnly(span.exit.cause);
+	const severity = interrupted ? "warn" : failed ? "error" : "info";
+	const attributes = filterTelemetryAttributes(span.attributes);
+	const cause = failed ? telemetryCauseSummary(span.exit.cause) : null;
+	const detail =
+		Object.keys(attributes).length > 0 || cause !== null
+			? JSON.stringify(
+					{
+						...(cause === null ? {} : { cause }),
+						...(Object.keys(attributes).length === 0 ? {} : { attributes }),
+					},
+					null,
+					2,
+				)
+			: undefined;
+	const durationMs =
+		Number(span.endTime > span.startTime ? span.endTime - span.startTime : 0n) /
+		1_000_000;
+	const message = sanitizeDiagnosticText(span.name);
+	const source = `server.${category}`;
+
+	return {
+		id: `span_${span.traceId}_${span.spanId}`,
+		createdAt: new Date(Number(span.endTime / 1_000_000n)).toISOString(),
+		severity,
+		source,
+		category,
+		message,
+		...(detail === undefined ? {} : { detail }),
+		fingerprint: diagnosticFingerprint({ source, category, message }),
+		runId: span.runId,
+		recoveryStatus: failed && !interrupted ? "unresolved" : "not-needed",
+		traceId: span.traceId,
+		spanId: span.spanId,
+		projectId: correlationAttribute(span.attributes, [
+			"project.id",
+			"projectId",
+		]),
+		chatId: correlationAttribute(span.attributes, ["chat.id", "chatId"]),
+		sessionId: correlationAttribute(span.attributes, [
+			"session.id",
+			"sessionId",
+		]),
+		providerId: correlationAttribute(span.attributes, [
+			"provider.id",
+			"providerId",
+		]),
+		durationMs,
+	};
+};

--- a/apps/server/src/observability/telemetry-model.ts
+++ b/apps/server/src/observability/telemetry-model.ts
@@ -70,6 +70,7 @@ export const telemetryCategoryForSpan = (name: string): string => {
 			return "network";
 		}
 		if (method.startsWith("diagnostics.")) return "diagnostics";
+		if (method.startsWith("auth.")) return "auth";
 		if (method.startsWith("permission.")) return "permission";
 		if (method.startsWith("attachment.")) return "attachment";
 		if (method.startsWith("mcp.")) return "mcp";

--- a/apps/server/src/observability/telemetry-store.ts
+++ b/apps/server/src/observability/telemetry-store.ts
@@ -1,0 +1,287 @@
+import { existsSync, statSync } from "node:fs";
+import {
+	appendFile,
+	mkdir,
+	readFile,
+	rename,
+	stat,
+	unlink,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import {
+	type DiagnosticEvent,
+	DiagnosticEvent as DiagnosticEventSchema,
+} from "@zuse/contracts";
+import { Context, Duration, Effect, Layer, Schema } from "effect";
+
+import { AppPaths } from "../app-paths.ts";
+import {
+	diagnosticFingerprint,
+	sanitizeDiagnosticText,
+} from "../diagnostics/diagnostics-model.ts";
+
+const MAX_EVENTS = 100_000;
+const MAX_FILE_BYTES = 20 * 1024 * 1024;
+const FILE_COUNT = 5;
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+const PERSIST_BATCH_MS = 250;
+const PERSIST_BATCH_SIZE = 500;
+const MAX_PENDING_PERSISTENCE_EVENTS = 5_000;
+
+class EventRingBuffer {
+	private readonly values: Array<DiagnosticEvent | undefined>;
+	private start = 0;
+	private length = 0;
+
+	constructor(
+		private readonly capacity: number,
+		initial: ReadonlyArray<DiagnosticEvent>,
+	) {
+		this.values = new Array(capacity);
+		this.pushMany(initial);
+	}
+
+	pushMany(events: ReadonlyArray<DiagnosticEvent>): void {
+		for (const event of events) {
+			const index = (this.start + this.length) % this.capacity;
+			this.values[index] = event;
+			if (this.length < this.capacity) {
+				this.length += 1;
+			} else {
+				this.start = (this.start + 1) % this.capacity;
+			}
+		}
+	}
+
+	snapshot(): ReadonlyArray<DiagnosticEvent> {
+		const snapshot: DiagnosticEvent[] = [];
+		for (let offset = 0; offset < this.length; offset += 1) {
+			const value = this.values[(this.start + offset) % this.capacity];
+			if (value !== undefined) snapshot.push(value);
+		}
+		return snapshot;
+	}
+}
+
+const retainedPaths = (path: string): ReadonlyArray<string> =>
+	Array.from({ length: FILE_COUNT }, (_, index) =>
+		index === 0 ? path : `${path}.${index}`,
+	);
+
+const loadEvents = async (
+	path: string,
+): Promise<{ events: DiagnosticEvent[]; parseErrors: number }> => {
+	let parseErrors = 0;
+	const lines: string[] = [];
+	for (const file of [...retainedPaths(path)].reverse()) {
+		try {
+			const fileStat = await stat(file);
+			if (Date.now() - fileStat.mtimeMs > RETENTION_MS) {
+				await unlink(file).catch(() => undefined);
+				continue;
+			}
+			lines.push(...(await readFile(file, "utf8")).split(/\r?\n/));
+		} catch {
+			// Missing or unreadable telemetry files do not affect startup.
+		}
+	}
+	const offlinePath = join(dirname(path), "diagnostics.offline.ndjson");
+	try {
+		const offline = await readFile(offlinePath, "utf8");
+		if (offline.trim().length > 0) {
+			await mkdir(dirname(path), { recursive: true });
+			await appendFile(path, offline.endsWith("\n") ? offline : `${offline}\n`);
+			lines.push(...offline.split(/\r?\n/));
+		}
+		await unlink(offlinePath).catch(() => undefined);
+	} catch {
+		// An absent offline crash file is the normal path.
+	}
+	const events = lines
+		.filter(Boolean)
+		.slice(-MAX_EVENTS)
+		.flatMap((line) => {
+			try {
+				return [
+					Schema.decodeUnknownSync(DiagnosticEventSchema)(JSON.parse(line)),
+				];
+			} catch {
+				parseErrors += 1;
+				return [];
+			}
+		});
+	return { events, parseErrors };
+};
+
+const sanitizeEvent = (event: DiagnosticEvent): DiagnosticEvent => {
+	const message = sanitizeDiagnosticText(event.message);
+	const detail =
+		event.detail === undefined
+			? undefined
+			: sanitizeDiagnosticText(event.detail);
+	return {
+		...event,
+		message,
+		...(detail === undefined ? {} : { detail }),
+		fingerprint: diagnosticFingerprint({
+			source: event.source,
+			category: event.category,
+			message,
+		}),
+	};
+};
+
+const appendEvents = async (
+	path: string,
+	events: ReadonlyArray<DiagnosticEvent>,
+): Promise<void> => {
+	if (events.length === 0) return;
+	await mkdir(dirname(path), { recursive: true });
+	const chunk = events.map((event) => `${JSON.stringify(event)}\n`).join("");
+	const currentSize = await stat(path)
+		.then((value) => value.size)
+		.catch(() => 0);
+	if (
+		currentSize > 0 &&
+		currentSize + Buffer.byteLength(chunk) > MAX_FILE_BYTES
+	) {
+		for (let index = FILE_COUNT - 1; index >= 1; index -= 1) {
+			const source = index === 1 ? path : `${path}.${index - 1}`;
+			const target = `${path}.${index}`;
+			await unlink(target).catch(() => undefined);
+			await rename(source, target).catch(() => undefined);
+		}
+	}
+	await appendFile(path, chunk, "utf8");
+};
+
+export interface TelemetryStoreShape {
+	readonly runId: string;
+	readonly parseErrorCount: number;
+	readonly record: (event: DiagnosticEvent) => void;
+	readonly recordMany: (events: ReadonlyArray<DiagnosticEvent>) => void;
+	readonly snapshot: () => ReadonlyArray<DiagnosticEvent>;
+	readonly version: () => number;
+	readonly storageBytes: Effect.Effect<number>;
+	readonly flush: Effect.Effect<void>;
+}
+
+export class TelemetryStore extends Context.Service<
+	TelemetryStore,
+	TelemetryStoreShape
+>()("zuse/TelemetryStore") {}
+
+export const TelemetryStoreLive = Layer.effect(
+	TelemetryStore,
+	Effect.gen(function* () {
+		const paths = yield* AppPaths;
+		const path = join(paths.userData, "logs", "diagnostics.events.ndjson");
+		const loaded = yield* Effect.tryPromise(() => loadEvents(path)).pipe(
+			Effect.orElseSucceed(() => ({
+				events: [] as DiagnosticEvent[],
+				parseErrors: 0,
+			})),
+		);
+		const runId = `run_${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
+		const events = new EventRingBuffer(MAX_EVENTS, loaded.events);
+		let version = loaded.events.length;
+		const pendingPersistence: DiagnosticEvent[] = [];
+		let persistenceDrain: Promise<void> | undefined;
+		let persistTimer: ReturnType<typeof setTimeout> | undefined;
+		let droppedPersistenceEvents = 0;
+		let lastDropWarningAt = 0;
+
+		const startPersistenceDrain = (): void => {
+			if (persistTimer !== undefined) {
+				clearTimeout(persistTimer);
+				persistTimer = undefined;
+			}
+			if (persistenceDrain !== undefined || pendingPersistence.length === 0)
+				return;
+			persistenceDrain = (async () => {
+				while (pendingPersistence.length > 0) {
+					const batch = pendingPersistence.splice(0, PERSIST_BATCH_SIZE);
+					await appendEvents(path, batch).catch(() => undefined);
+				}
+			})().finally(() => {
+				persistenceDrain = undefined;
+				if (pendingPersistence.length > 0) startPersistenceDrain();
+			});
+		};
+
+		const schedulePersistence = (): void => {
+			if (pendingPersistence.length >= PERSIST_BATCH_SIZE) {
+				startPersistenceDrain();
+				return;
+			}
+			if (persistTimer !== undefined) return;
+			persistTimer = setTimeout(startPersistenceDrain, PERSIST_BATCH_MS);
+			persistTimer.unref?.();
+		};
+
+		const recordMany = (incoming: ReadonlyArray<DiagnosticEvent>): void => {
+			if (incoming.length === 0) return;
+			try {
+				const sanitized = incoming.map(sanitizeEvent);
+				events.pushMany(sanitized);
+				version += sanitized.length;
+				pendingPersistence.push(...sanitized);
+				if (pendingPersistence.length > MAX_PENDING_PERSISTENCE_EVENTS) {
+					const dropped =
+						pendingPersistence.length - MAX_PENDING_PERSISTENCE_EVENTS;
+					pendingPersistence.splice(0, dropped);
+					droppedPersistenceEvents += dropped;
+					const now = Date.now();
+					if (now - lastDropWarningAt >= 5_000) {
+						events.pushMany([
+							sanitizeEvent({
+								id: `telemetry_drop_${runId}_${version}`,
+								createdAt: new Date(now).toISOString(),
+								severity: "warn",
+								source: "server.telemetry",
+								category: "persistence",
+								message: "Telemetry persistence queue dropped events",
+								detail: `dropped=${droppedPersistenceEvents}`,
+								fingerprint: "telemetry-persistence-drop",
+								runId,
+								recoveryStatus: "unresolved",
+							}),
+						]);
+						droppedPersistenceEvents = 0;
+						lastDropWarningAt = now;
+						version += 1;
+					}
+				}
+				schedulePersistence();
+			} catch {
+				// Telemetry must never interrupt the application path it observes.
+			}
+		};
+
+		const flush = Effect.promise(async () => {
+			startPersistenceDrain();
+			await persistenceDrain;
+		}).pipe(
+			Effect.timeoutOption(Duration.seconds(2)),
+			Effect.asVoid,
+			Effect.ignore,
+		);
+		yield* Effect.addFinalizer(() => flush);
+
+		return TelemetryStore.of({
+			runId,
+			parseErrorCount: loaded.parseErrors,
+			record: (event) => recordMany([event]),
+			recordMany,
+			snapshot: () => events.snapshot(),
+			version: () => version,
+			storageBytes: Effect.sync(() =>
+				retainedPaths(path)
+					.filter(existsSync)
+					.reduce((total, file) => total + statSync(file).size, 0),
+			).pipe(Effect.orElseSucceed(() => 0)),
+			flush,
+		});
+	}),
+);

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -588,6 +588,14 @@ export const ProviderServiceLive = Layer.effect(
 							error_code: "startup_failed",
 						}),
 					),
+					Effect.withSpan("provider.start", {
+						attributes: {
+							"provider.id": input.providerId,
+							"provider.model": input.model
+								? safeModelId(input.providerId, input.model)
+								: "custom",
+						},
+					}),
 				);
 			},
 			send: (sessionId, turnId, text, attachments, fileRefs, skillRefs) =>
@@ -612,7 +620,15 @@ export const ProviderServiceLive = Layer.effect(
 							fileRefs,
 							skillRefs,
 						);
-					}),
+					}).pipe(
+						Effect.withSpan("provider.send", {
+							attributes: {
+								"provider.id": entry.providerId,
+								"provider.model": entry.model,
+								"session.id": sessionId,
+							},
+						}),
+					),
 				),
 			interrupt: (sessionId, turnId) =>
 				Effect.flatMap(lookup(sessionId), (entry) =>
@@ -633,10 +649,17 @@ export const ProviderServiceLive = Layer.effect(
 								entry.turnStartedAt = null;
 							}),
 						),
+						Effect.withSpan("provider.interrupt", {
+							attributes: {
+								"provider.id": entry.providerId,
+								"provider.model": entry.model,
+								"session.id": sessionId,
+							},
+						}),
 					),
 				),
 			close: (sessionId) =>
-				Effect.flatMap(lookup(sessionId), ({ handle }) =>
+				Effect.flatMap(lookup(sessionId), ({ handle, providerId, model }) =>
 					handle.close().pipe(
 						Effect.andThen(
 							Ref.update(sessions, (map) => {
@@ -645,6 +668,13 @@ export const ProviderServiceLive = Layer.effect(
 								return next;
 							}),
 						),
+						Effect.withSpan("provider.close", {
+							attributes: {
+								"provider.id": providerId,
+								"provider.model": model,
+								"session.id": sessionId,
+							},
+						}),
 					),
 				),
 			events: (sessionId) =>

--- a/apps/server/src/relay/managed-tunnel-runtime.ts
+++ b/apps/server/src/relay/managed-tunnel-runtime.ts
@@ -6,6 +6,7 @@ import {
 } from "effect/unstable/process";
 
 import { AppPaths } from "../app-paths.ts";
+import { TelemetryStore } from "../observability/telemetry-store.ts";
 import { ensurePinnedCloudflared } from "./cloudflared-install.ts";
 import { appendRelayDiagnostic } from "./relay-diagnostics.ts";
 
@@ -43,16 +44,17 @@ const CLOUDFLARED_CANDIDATES = [
 export const ManagedTunnelRuntimeLive: Layer.Layer<
   ManagedTunnelRuntime,
   never,
-  CommandExecutor.ChildProcessSpawner | AppPaths
+  CommandExecutor.ChildProcessSpawner | AppPaths | TelemetryStore
 > = Layer.effect(
   ManagedTunnelRuntime,
   Effect.gen(function* () {
     const executor = yield* CommandExecutor.ChildProcessSpawner;
     const paths = yield* AppPaths;
+    const telemetry = yield* TelemetryStore;
     const fiberRef = yield* Ref.make<Fiber.Fiber<void> | null>(null);
     const binaryRef = yield* Ref.make<string | null>(null);
     const log = (event: string, fields?: Record<string, unknown>) =>
-      appendRelayDiagnostic(paths, event, fields);
+      appendRelayDiagnostic(telemetry, event, fields);
 
     const isExecutable = (path: string): boolean => {
       try {

--- a/apps/server/src/relay/relay-diagnostics.ts
+++ b/apps/server/src/relay/relay-diagnostics.ts
@@ -1,41 +1,93 @@
-import { Effect } from "effect";
-import { appendFileSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
 
-import type { AppPaths } from "../app-paths.ts";
+import { Effect } from "effect";
+
+import {
+	diagnosticFingerprint,
+	sanitizeDiagnosticText,
+} from "../diagnostics/diagnostics-model.ts";
+import type { TelemetryStore } from "../observability/telemetry-store.ts";
 
 type DiagnosticFields = Record<string, unknown>;
 
-const logPathFor = (paths: typeof AppPaths.Service): string =>
-  process.env.ZUSE_RELAY_LINK_LOG?.trim() ||
-  join(paths.userData, "logs", "relay-link.log");
+const SAFE_FIELD_KEYS = new Set([
+	"environmentId",
+	"exitCode",
+	"hasConnectorToken",
+	"hasLabel",
+	"heartbeatActive",
+	"lanPolicy",
+	"lanPort",
+	"managedTunnel",
+]);
 
-const safeFields = (fields: DiagnosticFields): DiagnosticFields =>
-  Object.fromEntries(
-    Object.entries(fields).map(([key, value]) => [
-      key,
-      value instanceof Error
-        ? { name: value.name, message: value.message }
-        : value,
-    ]),
-  );
+const structuralReason = (value: unknown): string => {
+	const candidate =
+		value instanceof Error
+			? value.name
+			: typeof value === "object" &&
+					value !== null &&
+					"_tag" in value &&
+					typeof value._tag === "string"
+				? value._tag
+				: typeof value === "string"
+					? (value.split(/[\s:]/u, 1)[0] ?? "")
+					: typeof value;
+	return /^[A-Za-z][A-Za-z0-9_.-]{0,80}$/u.test(candidate)
+		? candidate
+		: "UnknownError";
+};
+
+const safeFields = (fields: DiagnosticFields): DiagnosticFields => {
+	const safe = Object.fromEntries(
+		Object.entries(fields).filter(
+			([key, value]) =>
+				SAFE_FIELD_KEYS.has(key) &&
+				(typeof value === "string" ||
+					typeof value === "number" ||
+					typeof value === "boolean" ||
+					value === null),
+		),
+	);
+	if ("reason" in fields || "error" in fields) {
+		safe.reasonType = structuralReason(fields.reason ?? fields.error);
+	}
+	return safe;
+};
 
 export const appendRelayDiagnostic = (
-  paths: typeof AppPaths.Service,
-  event: string,
-  fields: DiagnosticFields = {},
+	store: TelemetryStore["Service"],
+	event: string,
+	fields: DiagnosticFields = {},
 ): Effect.Effect<void> =>
-  Effect.sync(() => {
-    const logPath = logPathFor(paths);
-    const line = JSON.stringify({
-      ts: new Date().toISOString(),
-      event,
-      ...safeFields(fields),
-    });
-    try {
-      mkdirSync(dirname(logPath), { recursive: true });
-      appendFileSync(logPath, `${line}\n`, "utf8");
-    } catch {
-      // Diagnostics are best-effort and must never break app behavior.
-    }
-  });
+	Effect.sync(() => {
+		const message = sanitizeDiagnosticText(`relay.${event}`);
+		const source = event.startsWith("cloudflared.")
+			? "server.managed-tunnel"
+			: "server.relay";
+		const exitCode =
+			typeof fields.exitCode === "number" ? fields.exitCode : undefined;
+		const failed =
+			event.endsWith(".fail") ||
+			event.endsWith(".error") ||
+			(event.endsWith(".exited") && exitCode !== undefined && exitCode !== 0);
+		const detailFields = safeFields(fields);
+		store.record({
+			id: `relay_${randomUUID().replaceAll("-", "").slice(0, 12)}`,
+			createdAt: new Date().toISOString(),
+			severity: failed ? "error" : "info",
+			source,
+			category: "network",
+			message,
+			...(Object.keys(detailFields).length === 0
+				? {}
+				: { detail: JSON.stringify(detailFields) }),
+			fingerprint: diagnosticFingerprint({
+				source,
+				category: "network",
+				message,
+			}),
+			runId: store.runId,
+			recoveryStatus: failed ? "unresolved" : "not-needed",
+		});
+	});

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -8,7 +8,6 @@ import {
 } from "@zuse/contracts";
 import { Clock, Context, Data, Effect, Fiber, Layer, Ref } from "effect";
 
-import { AppPaths } from "../app-paths.ts";
 import { AuthService } from "../auth/services/auth-service.ts";
 import { buildAdvertisedEndpoints } from "../lan-auth/advertised-endpoints.ts";
 import { defaultEnvironmentLabel } from "../lan-auth/environment-label.ts";
@@ -17,6 +16,7 @@ import {
   type LanAuthConfigShape,
   LanAuthService,
 } from "../lan-auth/services/lan-auth-service.ts";
+import { TelemetryStore } from "../observability/telemetry-store.ts";
 import { signEnvironmentLinkProof } from "./link-proof.ts";
 import { ManagedTunnelRuntime } from "./managed-tunnel-runtime.ts";
 import { appendRelayDiagnostic } from "./relay-diagnostics.ts";
@@ -165,7 +165,11 @@ const computeOrigin = (config: LanAuthConfigShape) => ({
 export const RelayLinkServiceLive: Layer.Layer<
   RelayLinkService,
   never,
-  LanAuthService | LanAuthConfig | AuthService | ManagedTunnelRuntime | AppPaths
+  | LanAuthService
+  | LanAuthConfig
+  | AuthService
+  | ManagedTunnelRuntime
+  | TelemetryStore
 > = Layer.effect(
   RelayLinkService,
   Effect.gen(function* () {
@@ -173,10 +177,10 @@ export const RelayLinkServiceLive: Layer.Layer<
     const config = yield* LanAuthConfig;
     const authService = yield* AuthService;
     const tunnel = yield* ManagedTunnelRuntime;
-    const paths = yield* AppPaths;
+    const telemetry = yield* TelemetryStore;
     const heartbeatRef = yield* Ref.make<Fiber.Fiber<void> | null>(null);
     const log = (event: string, fields?: Record<string, unknown>) =>
-      appendRelayDiagnostic(paths, event, fields);
+      appendRelayDiagnostic(telemetry, event, fields);
 
     yield* log("service.boot", {
       lanPolicy: config.policy,

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -453,9 +453,10 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 			ManagedTunnelRuntimeLive.pipe(
 				Layer.provide(NodeServices.layer),
 				Layer.provide(AppPathsLayer),
+				Layer.provide(TelemetryStoreLayer),
 			),
 		),
-		Layer.provide(AppPathsLayer),
+		Layer.provide(TelemetryStoreLayer),
 	);
 	const autoRelayLink = deps.autoRelayLink;
 	const AutoRelayLinkLayer =
@@ -555,7 +556,5 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		NodeServices.layer,
 		UsagePoller,
 		AutoRelayLinkLayer,
-	).pipe(
-		Layer.provide(TelemetryLayer),
-	);
+	).pipe(Layer.provide(TelemetryLayer));
 };

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -30,6 +30,8 @@ import {
 } from "./lan-auth/services/lan-auth-service.ts";
 import { LinearServiceLive } from "./linear/layers/linear-service.ts";
 import { McpServiceLive } from "./mcp/layers/mcp-service.ts";
+import { TelemetryObservabilityLive } from "./observability/telemetry-layer.ts";
+import { TelemetryStoreLive } from "./observability/telemetry-store.ts";
 import { runLifecycleBackfill } from "./persistence/backfill.ts";
 import { importWorkspacesJson } from "./persistence/import-workspaces.ts";
 import { MigrationsLive } from "./persistence/migrations.ts";
@@ -122,6 +124,12 @@ export interface MainLayerDeps {
  */
 export const makeMainLayer = (deps: MainLayerDeps) => {
 	const AppPathsLayer = Layer.succeed(AppPaths, { userData: deps.userData });
+	const TelemetryStoreLayer = TelemetryStoreLive.pipe(
+		Layer.provide(AppPathsLayer),
+	);
+	const TelemetryLayer = TelemetryObservabilityLive.pipe(
+		Layer.provide(TelemetryStoreLayer),
+	);
 	const FolderPickerLayer = Layer.succeed(FolderPicker, deps.folderPicker);
 	const AuthShellLayer = Layer.succeed(AuthShell, deps.authShell);
 	const LanAuthConfigLayer = Layer.succeed(LanAuthConfig, {
@@ -409,6 +417,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(MigratedSqlite),
 		Layer.provide(AppPathsLayer),
 		Layer.provide(ProviderLayer),
+		Layer.provide(TelemetryStoreLayer),
 	);
 
 	const ExternalThreadLayer = ExternalThreadServiceLive.pipe(
@@ -546,5 +555,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		NodeServices.layer,
 		UsagePoller,
 		AutoRelayLinkLayer,
+	).pipe(
+		Layer.provide(TelemetryLayer),
 	);
 };

--- a/apps/server/test/unit/diagnostics-model.test.ts
+++ b/apps/server/test/unit/diagnostics-model.test.ts
@@ -1,0 +1,94 @@
+import type { DiagnosticEvent } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+	aggregateDiagnostics,
+	filterDiagnosticEvents,
+	sanitizeDiagnosticText,
+	sanitizeDiagnosticValue,
+} from "../../src/diagnostics/diagnostics-model.ts";
+
+const event = (overrides: Partial<DiagnosticEvent> = {}): DiagnosticEvent => ({
+	id: "diag_event_1",
+	createdAt: "2026-07-22T10:00:00.000Z",
+	severity: "error",
+	source: "server.provider",
+	category: "provider",
+	message: "Provider exited",
+	fingerprint: "provider-exited",
+	runId: "run_1",
+	recoveryStatus: "unresolved",
+	...overrides,
+});
+
+describe("diagnostics model", () => {
+	it("redacts credentials before diagnostic text is persisted", () => {
+		expect(
+			sanitizeDiagnosticText(
+				"Authorization: Bearer secret-token https://example.test/path?token=hidden",
+			),
+		).toBe(
+			"Authorization: Bearer [REDACTED] https://example.test/path?[REDACTED]",
+		);
+		expect(sanitizeDiagnosticText("OPENAI_API_KEY=super-secret-value")).toBe(
+			"OPENAI_API_KEY=[REDACTED]",
+		);
+	});
+
+	it("removes conversation, environment, path, and terminal fields from exports", () => {
+		expect(
+			sanitizeDiagnosticValue({
+				view: "settings",
+				prompt: "private conversation",
+				openFile: "/private/project/secret.ts",
+				env: { TOKEN: "secret" },
+				terminalOutput: "secret output",
+				log: "Authorization: Bearer hidden",
+			}),
+		).toEqual({ view: "settings", log: "Authorization: Bearer [REDACTED]" });
+	});
+
+	it("groups repeated failures and reports the latest incident", () => {
+		const result = aggregateDiagnostics([
+			event(),
+			event({
+				id: "diag_event_2",
+				createdAt: "2026-07-22T10:01:00.000Z",
+			}),
+			event({
+				id: "diag_event_3",
+				severity: "warn",
+				fingerprint: "slow-provider",
+				message: "Provider startup was slow",
+			}),
+		]);
+
+		expect(result.errorCount).toBe(2);
+		expect(result.warningCount).toBe(1);
+		expect(result.commonFailures[0]).toMatchObject({
+			fingerprint: "provider-exited",
+			count: 2,
+		});
+		expect(result.latestIncidents[0]?.id).toBe("diag_event_2");
+	});
+
+	it("filters by severity, source, and search text", () => {
+		const events = [
+			event(),
+			event({
+				id: "diag_event_2",
+				severity: "warn",
+				source: "renderer.network",
+				message: "Connection retry scheduled",
+			}),
+		];
+
+		expect(
+			filterDiagnosticEvents(events, {
+				severities: ["warn"],
+				source: "renderer",
+				search: "retry",
+			}),
+		).toEqual([events[1]]);
+	});
+});

--- a/apps/server/test/unit/diagnostics-model.test.ts
+++ b/apps/server/test/unit/diagnostics-model.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
 	aggregateDiagnostics,
 	filterDiagnosticEvents,
+	paginateDiagnosticEvents,
 	sanitizeDiagnosticText,
 	sanitizeDiagnosticValue,
 } from "../../src/diagnostics/diagnostics-model.ts";
@@ -32,6 +33,13 @@ describe("diagnostics model", () => {
 		);
 		expect(sanitizeDiagnosticText("OPENAI_API_KEY=super-secret-value")).toBe(
 			"OPENAI_API_KEY=[REDACTED]",
+		);
+		expect(
+			sanitizeDiagnosticText(
+				"at /Users/alice/private-project/src/main.ts and C:\\Users\\alice\\secret\\main.ts",
+			),
+		).toBe(
+			"at /Users/[USER]/private-project/src/main.ts and [DRIVE]:\\Users\\[USER]\\secret\\main.ts",
 		);
 	});
 
@@ -90,5 +98,64 @@ describe("diagnostics model", () => {
 				search: "retry",
 			}),
 		).toEqual([events[1]]);
+	});
+
+	it("paginates with a stable cursor when newer events arrive", () => {
+		const retained = [
+			event({ id: "event-3", createdAt: "2026-07-22T10:03:00.000Z" }),
+			event({ id: "event-2", createdAt: "2026-07-22T10:02:00.000Z" }),
+			event({ id: "event-1", createdAt: "2026-07-22T10:01:00.000Z" }),
+		];
+		const first = paginateDiagnosticEvents(retained, { limit: 2 });
+		expect(first.events.map((item) => item.id)).toEqual(["event-3", "event-2"]);
+
+		const second = paginateDiagnosticEvents(
+			[
+				event({ id: "event-4", createdAt: "2026-07-22T10:04:00.000Z" }),
+				...retained,
+			],
+			{ cursor: first.nextCursor ?? undefined, limit: 2 },
+		);
+		expect(second.events.map((item) => item.id)).toEqual(["event-1"]);
+	});
+
+	it("summarizes operation volume, failures, and latency percentiles", () => {
+		const result = aggregateDiagnostics([
+			event({
+				id: "span_1",
+				severity: "info",
+				source: "server.rpc",
+				category: "rpc",
+				message: "RpcServer.git.status",
+				durationMs: 10,
+				recoveryStatus: "not-needed",
+			}),
+			event({
+				id: "span_2",
+				severity: "error",
+				source: "server.rpc",
+				category: "rpc",
+				message: "RpcServer.git.status",
+				durationMs: 50,
+			}),
+			event({
+				id: "span_3",
+				severity: "info",
+				source: "server.provider",
+				category: "provider",
+				message: "provider.send",
+				durationMs: 200,
+				recoveryStatus: "not-needed",
+			}),
+		]);
+
+		expect(result.topOperations[0]).toEqual({
+			name: "RpcServer.git.status",
+			count: 2,
+			failureCount: 1,
+			averageDurationMs: 30,
+			p95DurationMs: 50,
+			maxDurationMs: 50,
+		});
 	});
 });

--- a/apps/server/test/unit/diagnostics-zip.test.ts
+++ b/apps/server/test/unit/diagnostics-zip.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { createStoredZip } from "../../src/diagnostics/zip-bundle.ts";
+
+describe("diagnostics zip bundle", () => {
+	it("creates a standard zip containing named artifacts", () => {
+		const zip = createStoredZip([
+			{ name: "manifest.json", data: Buffer.from('{"ok":true}') },
+			{ name: "REPORT.md", data: Buffer.from("# Report") },
+		]);
+
+		expect(zip.subarray(0, 4).toString("hex")).toBe("504b0304");
+		expect(zip.includes(Buffer.from("manifest.json"))).toBe(true);
+		expect(zip.includes(Buffer.from("REPORT.md"))).toBe(true);
+		expect(zip.subarray(-22, -18).toString("hex")).toBe("504b0506");
+	});
+});

--- a/apps/server/test/unit/telemetry-model.test.ts
+++ b/apps/server/test/unit/telemetry-model.test.ts
@@ -1,0 +1,86 @@
+import { Exit } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { telemetryEventFromSpan } from "../../src/observability/telemetry-model.ts";
+
+describe("telemetry model", () => {
+	it("creates a correlated successful operation without persisting sensitive attributes", () => {
+		const result = telemetryEventFromSpan({
+			name: "RpcServer.session.get",
+			traceId: "trace-1",
+			spanId: "span-1",
+			startTime: 1_000_000_000n,
+			endTime: 1_025_000_000n,
+			exit: Exit.succeed("ok"),
+			attributes: new Map([
+				["session.id", "session-1"],
+				["provider.id", "codex"],
+				["prompt", "do not persist me"],
+			]),
+			runId: "run-1",
+		});
+
+		expect(result).toMatchObject({
+			id: "span_trace-1_span-1",
+			severity: "info",
+			source: "server.persistence",
+			category: "persistence",
+			message: "RpcServer.session.get",
+			traceId: "trace-1",
+			spanId: "span-1",
+			sessionId: "session-1",
+			providerId: "codex",
+			durationMs: 25,
+			recoveryStatus: "not-needed",
+		});
+		expect(result.detail).not.toContain("do not persist me");
+	});
+
+	it("classifies RPC boundaries by subsystem", () => {
+		const names = [
+			["RpcServer.permission.respond", "permission"],
+			["RpcServer.git.status", "git"],
+			["RpcServer.pty.open", "terminal"],
+			["RpcServer.relay.connect", "network"],
+			["RpcServer.attachment.add", "attachment"],
+			["RpcServer.mcp.list", "mcp"],
+		] as const;
+
+		for (const [name, category] of names) {
+			const result = telemetryEventFromSpan({
+				name,
+				traceId: `trace-${category}`,
+				spanId: `span-${category}`,
+				startTime: 1_000_000_000n,
+				endTime: 1_001_000_000n,
+				exit: Exit.succeed("ok"),
+				attributes: new Map(),
+				runId: "run-1",
+			});
+			expect(result.category).toBe(category);
+		}
+	});
+
+	it("captures a sanitized failure and classifies provider operations", () => {
+		const result = telemetryEventFromSpan({
+			name: "provider.send",
+			traceId: "trace-2",
+			spanId: "span-2",
+			startTime: 2_000_000_000n,
+			endTime: 2_500_000_000n,
+			exit: Exit.fail(new Error("Authorization: Bearer secret-value")),
+			attributes: new Map(),
+			runId: "run-1",
+		});
+
+		expect(result).toMatchObject({
+			severity: "error",
+			source: "server.provider",
+			category: "provider",
+			recoveryStatus: "unresolved",
+		});
+		expect(result.detail).toContain('"type": "Error"');
+		expect(result.detail).not.toContain("Authorization");
+		expect(result.detail).not.toContain("secret-value");
+	});
+});

--- a/apps/server/test/unit/telemetry-model.test.ts
+++ b/apps/server/test/unit/telemetry-model.test.ts
@@ -42,6 +42,7 @@ describe("telemetry model", () => {
 			["RpcServer.git.status", "git"],
 			["RpcServer.pty.open", "terminal"],
 			["RpcServer.relay.connect", "network"],
+			["RpcServer.auth.signIn", "auth"],
 			["RpcServer.attachment.add", "attachment"],
 			["RpcServer.mcp.list", "mcp"],
 		] as const;

--- a/apps/server/test/unit/telemetry-store.test.ts
+++ b/apps/server/test/unit/telemetry-store.test.ts
@@ -1,0 +1,182 @@
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { DiagnosticEvent } from "@zuse/contracts";
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { AppPaths } from "../../src/app-paths.ts";
+import { TelemetryObservabilityLive } from "../../src/observability/telemetry-layer.ts";
+import {
+	TelemetryStore,
+	TelemetryStoreLive,
+} from "../../src/observability/telemetry-store.ts";
+
+const event = (id: string): DiagnosticEvent => ({
+	id,
+	createdAt: new Date().toISOString(),
+	severity: "error",
+	source: "server.provider",
+	category: "provider",
+	message: "Authorization: Bearer secret-value",
+	detail: "OPENAI_API_KEY=another-secret",
+	fingerprint: "will-be-replaced",
+	runId: "run-test",
+	recoveryStatus: "unresolved",
+});
+
+describe("telemetry store", () => {
+	it("serializes concurrent records, persists redacted data, and reloads it", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-telemetry-"));
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+
+		try {
+			const snapshot = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						store.record(event("span-1"));
+						store.recordMany([event("span-2"), event("span-3")]);
+						yield* store.flush;
+						return store.snapshot();
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+
+			expect(snapshot).toHaveLength(3);
+			const persisted = readFileSync(
+				join(directory, "logs", "diagnostics.events.ndjson"),
+				"utf8",
+			);
+			expect(persisted).toContain("Bearer [REDACTED]");
+			expect(persisted).toContain("OPENAI_API_KEY=[REDACTED]");
+			expect(persisted).not.toContain("secret-value");
+			expect(persisted).not.toContain("another-secret");
+
+			const reloaded = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						return store.snapshot();
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(reloaded).toHaveLength(3);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("records completed Effect spans through the runtime tracer", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-tracer-"));
+		const storeLayer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		const telemetryLayer = TelemetryObservabilityLive.pipe(
+			Layer.provideMerge(storeLayer),
+		);
+
+		try {
+			const events = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						yield* Effect.succeed("ok").pipe(
+							Effect.withSpan("provider.send", {
+								attributes: {
+									"provider.id": "codex",
+									"session.id": "session-1",
+									prompt: "private",
+								},
+							}),
+						);
+						const store = yield* TelemetryStore;
+						yield* store.flush;
+						return store.snapshot();
+					}).pipe(Effect.provide(telemetryLayer)),
+				),
+			);
+
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({
+				message: "provider.send",
+				category: "provider",
+				providerId: "codex",
+				sessionId: "session-1",
+				severity: "info",
+			});
+			expect(events[0]?.detail).not.toContain("private");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("recovers valid events when a persisted NDJSON line is corrupt", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-telemetry-recovery-"));
+		const logsDirectory = join(directory, "logs");
+		mkdirSync(logsDirectory, { recursive: true });
+		writeFileSync(
+			join(logsDirectory, "diagnostics.events.ndjson"),
+			`${JSON.stringify(event("span-valid"))}\n{not-json}\n`,
+		);
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+
+		try {
+			const result = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						return {
+							events: store.snapshot(),
+							parseErrors: store.parseErrorCount,
+						};
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0]?.id).toBe("span-valid");
+			expect(result.parseErrors).toBe(1);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("imports offline desktop crashes into durable telemetry", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-offline-crash-"));
+		const logsDirectory = join(directory, "logs");
+		mkdirSync(logsDirectory, { recursive: true });
+		const offlinePath = join(logsDirectory, "diagnostics.offline.ndjson");
+		writeFileSync(offlinePath, `${JSON.stringify(event("offline-crash"))}\n`);
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+
+		try {
+			const events = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						return store.snapshot();
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(events.map((item) => item.id)).toContain("offline-crash");
+			expect(() => readFileSync(offlinePath, "utf8")).toThrow();
+			expect(
+				readFileSync(join(logsDirectory, "diagnostics.events.ndjson"), "utf8"),
+			).toContain("offline-crash");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/apps/server/test/unit/telemetry-store.test.ts
+++ b/apps/server/test/unit/telemetry-store.test.ts
@@ -18,6 +18,7 @@ import {
 	TelemetryStore,
 	TelemetryStoreLive,
 } from "../../src/observability/telemetry-store.ts";
+import { appendRelayDiagnostic } from "../../src/relay/relay-diagnostics.ts";
 
 const event = (id: string): DiagnosticEvent => ({
 	id,
@@ -114,6 +115,45 @@ describe("telemetry store", () => {
 				severity: "info",
 			});
 			expect(events[0]?.detail).not.toContain("private");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("routes relay diagnostics through the bounded store without sensitive fields", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-relay-telemetry-"));
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+
+		try {
+			const events = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						yield* appendRelayDiagnostic(store, "link.environment.fail", {
+							environmentId: "environment-1",
+							reason: "Authorization: Bearer secret-value",
+							relayUrl: "https://relay.example.test?token=private",
+							candidate: "/Users/private/bin",
+						});
+						yield* store.flush;
+						return store.snapshot();
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({
+				severity: "error",
+				source: "server.relay",
+				category: "network",
+				message: "relay.link.environment.fail",
+			});
+			expect(events[0]?.detail).toContain("environment-1");
+			expect(events[0]?.detail).not.toContain("secret-value");
+			expect(events[0]?.detail).not.toContain("relay.example.test");
+			expect(events[0]?.detail).not.toContain("/Users/private");
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}

--- a/docs/specs/runtime-telemetry.md
+++ b/docs/specs/runtime-telemetry.md
@@ -1,0 +1,61 @@
+# Runtime telemetry
+
+Zuse records operational telemetry locally so failures can be diagnosed without
+sending user content to another service. Product analytics and runtime telemetry
+are separate:
+
+- Product analytics contains only the typed, allowlisted aggregate events in
+  `packages/analytics`.
+- Runtime telemetry contains operation timings, outcomes, trace identifiers,
+  process ownership, and sanitized failure causes. It powers Settings →
+  Diagnostics and support bundles.
+
+## Local capture
+
+The server installs one Effect tracer around the complete RPC runtime. RPC
+operations and explicitly instrumented provider boundaries are recorded as
+structured diagnostic events. Events are kept in memory for live queries and
+written asynchronously to rotating NDJSON files under the app data directory.
+
+The store retains at most 100,000 events, rotates at 20 MB, keeps five files,
+and removes files older than seven days. Capture, serialization, rotation, and
+cleanup failures are isolated from normal application behavior.
+
+Diagnostic polling RPCs are excluded from local span capture so opening the
+Diagnostics page cannot create a feedback loop.
+
+## Data safety
+
+Persisted span attributes use an explicit allowlist. Prompts, transcripts,
+message content, files, terminal output, environment values, credentials, URL
+query values, and raw command arguments are excluded. Failure causes and
+allowed string attributes are scrubbed again before persistence and export.
+
+Support bundles apply the existing second redaction pass.
+
+## Optional OTLP export
+
+Remote export is disabled unless an endpoint is explicitly configured:
+
+```sh
+ZUSE_OTLP_TRACES_URL=http://127.0.0.1:4318/v1/traces
+ZUSE_OTLP_METRICS_URL=http://127.0.0.1:4318/v1/metrics
+ZUSE_OTLP_SERVICE_NAME=zuse-server
+ZUSE_OTLP_EXPORT_INTERVAL_MS=10000
+```
+
+Traces and metrics can be enabled independently. Export uses the same
+allowlisted attributes as local capture and sends sanitized failure causes.
+Exporter outages, retries, and shutdown flushing are handled by the Effect OTLP
+exporter and do not block application work.
+
+## Metrics
+
+The runtime exposes low-cardinality counters and histograms:
+
+- `zuse_operations_total`
+- `zuse_operation_duration`
+- `zuse_failures_total`
+
+Labels are limited to operation, category, and outcome. IDs and user-derived
+values are never metric labels.

--- a/packages/contracts/src/diagnostics.ts
+++ b/packages/contracts/src/diagnostics.ts
@@ -1,67 +1,215 @@
-import { Rpc } from "effect/unstable/rpc";
 import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
 
-const DiagnosticArtifactName = Schema.Literals([
-  "manifest",
-  "bundle-summary",
-  "trace-summary",
-  "recent-errors",
-  "environment",
-  "provider-status",
-  "client-context",
-  "redacted-session-events",
+export const DiagnosticSeverity = Schema.Literals([
+	"debug",
+	"info",
+	"warn",
+	"error",
+	"fatal",
 ]);
+export type DiagnosticSeverity = typeof DiagnosticSeverity.Type;
 
+export const DiagnosticRecoveryStatus = Schema.Literals([
+	"not-needed",
+	"unresolved",
+	"recovering",
+	"recovered",
+	"failed",
+]);
+export type DiagnosticRecoveryStatus = typeof DiagnosticRecoveryStatus.Type;
+
+export const DiagnosticEvent = Schema.Struct({
+	id: Schema.String,
+	createdAt: Schema.String,
+	severity: DiagnosticSeverity,
+	source: Schema.String,
+	category: Schema.String,
+	message: Schema.String,
+	detail: Schema.optional(Schema.String),
+	fingerprint: Schema.String,
+	runId: Schema.String,
+	recoveryStatus: DiagnosticRecoveryStatus,
+	traceId: Schema.optional(Schema.String),
+	spanId: Schema.optional(Schema.String),
+	projectId: Schema.optional(Schema.NullOr(Schema.String)),
+	chatId: Schema.optional(Schema.NullOr(Schema.String)),
+	sessionId: Schema.optional(Schema.NullOr(Schema.String)),
+	providerId: Schema.optional(Schema.NullOr(Schema.String)),
+	durationMs: Schema.optional(Schema.Number),
+});
+export type DiagnosticEvent = typeof DiagnosticEvent.Type;
+
+export const DiagnosticFailureGroup = Schema.Struct({
+	fingerprint: Schema.String,
+	severity: DiagnosticSeverity,
+	source: Schema.String,
+	message: Schema.String,
+	count: Schema.Number,
+	firstSeenAt: Schema.String,
+	lastSeenAt: Schema.String,
+	recoveredCount: Schema.Number,
+});
+export type DiagnosticFailureGroup = typeof DiagnosticFailureGroup.Type;
+
+export class DiagnosticsOverviewResult extends Schema.Class<DiagnosticsOverviewResult>(
+	"DiagnosticsOverviewResult",
+)({
+	status: Schema.Literals(["healthy", "degraded", "failing"]),
+	runId: Schema.String,
+	readAt: Schema.String,
+	eventCount: Schema.Number,
+	errorCount: Schema.Number,
+	warningCount: Schema.Number,
+	fatalCount: Schema.Number,
+	slowOperationCount: Schema.Number,
+	parseErrorCount: Schema.Number,
+	unseenCount: Schema.Number,
+	storageBytes: Schema.Number,
+	capturePaused: Schema.Boolean,
+	previousRunUnclean: Schema.Boolean,
+	latestIncidents: Schema.Array(DiagnosticEvent),
+	commonFailures: Schema.Array(DiagnosticFailureGroup),
+	slowestOperations: Schema.Array(DiagnosticEvent),
+	topOperations: Schema.Array(
+		Schema.Struct({
+			name: Schema.String,
+			count: Schema.Number,
+			failureCount: Schema.Number,
+			averageDurationMs: Schema.Number,
+			p95DurationMs: Schema.Number,
+			maxDurationMs: Schema.Number,
+		}),
+	),
+}) {}
+
+export class DiagnosticsEventsResult extends Schema.Class<DiagnosticsEventsResult>(
+	"DiagnosticsEventsResult",
+)({
+	events: Schema.Array(DiagnosticEvent),
+	nextCursor: Schema.NullOr(Schema.String),
+	total: Schema.Number,
+}) {}
+
+export const DiagnosticProcess = Schema.Struct({
+	pid: Schema.Number,
+	parentPid: Schema.Number,
+	depth: Schema.Number,
+	name: Schema.String,
+	command: Schema.String,
+	cpuPercent: Schema.Number,
+	rssBytes: Schema.Number,
+	uptimeSeconds: Schema.Number,
+	childPids: Schema.Array(Schema.Number),
+});
+export type DiagnosticProcess = typeof DiagnosticProcess.Type;
+
+export class DiagnosticsProcessesResult extends Schema.Class<DiagnosticsProcessesResult>(
+	"DiagnosticsProcessesResult",
+)({
+	supported: Schema.Boolean,
+	readAt: Schema.String,
+	serverPid: Schema.Number,
+	processes: Schema.Array(DiagnosticProcess),
+	totalCpuPercent: Schema.Number,
+	totalRssBytes: Schema.Number,
+	error: Schema.optional(Schema.String),
+}) {}
+
+export class DiagnosticsSignalResult extends Schema.Class<DiagnosticsSignalResult>(
+	"DiagnosticsSignalResult",
+)({ signaled: Schema.Boolean, message: Schema.optional(Schema.String) }) {}
+
+const DiagnosticArtifactName = Schema.String;
 const DiagnosticsLogEntry = Schema.Struct({
-  createdAt: Schema.String,
-  level: Schema.Literals(["debug", "info", "warn", "error"]),
-  source: Schema.String,
-  message: Schema.String,
-  detail: Schema.optional(Schema.String),
+	createdAt: Schema.String,
+	level: Schema.Literals(["debug", "info", "warn", "error"]),
+	source: Schema.String,
+	message: Schema.String,
+	detail: Schema.optional(Schema.String),
 });
-
 const DiagnosticsUiAction = Schema.Struct({
-  createdAt: Schema.String,
-  action: Schema.String,
-  detail: Schema.optional(Schema.String),
+	createdAt: Schema.String,
+	action: Schema.String,
+	detail: Schema.optional(Schema.String),
 });
-
 const DiagnosticsClientContext = Schema.Struct({
-  view: Schema.optional(Schema.String),
-  settingsSection: Schema.optional(Schema.String),
-  activeMainTab: Schema.optional(Schema.String),
-  selectedFolderId: Schema.optional(Schema.NullOr(Schema.String)),
-  selectedChatId: Schema.optional(Schema.NullOr(Schema.String)),
-  activeSessionId: Schema.optional(Schema.NullOr(Schema.String)),
-  openFile: Schema.optional(Schema.NullOr(Schema.String)),
-  rightSidebarOpen: Schema.optional(Schema.Boolean),
-  leftSidebarOpen: Schema.optional(Schema.Boolean),
-  recentUiActions: Schema.Array(DiagnosticsUiAction),
-  rendererLogs: Schema.Array(DiagnosticsLogEntry),
-  mainProcessLogs: Schema.Array(DiagnosticsLogEntry),
+	view: Schema.optional(Schema.String),
+	settingsSection: Schema.optional(Schema.String),
+	activeMainTab: Schema.optional(Schema.String),
+	selectedFolderId: Schema.optional(Schema.NullOr(Schema.String)),
+	selectedChatId: Schema.optional(Schema.NullOr(Schema.String)),
+	activeSessionId: Schema.optional(Schema.NullOr(Schema.String)),
+	openFile: Schema.optional(Schema.NullOr(Schema.String)),
+	rightSidebarOpen: Schema.optional(Schema.Boolean),
+	leftSidebarOpen: Schema.optional(Schema.Boolean),
+	recentUiActions: Schema.Array(DiagnosticsUiAction),
+	rendererLogs: Schema.Array(DiagnosticsLogEntry),
+	mainProcessLogs: Schema.Array(DiagnosticsLogEntry),
 });
 
 export class DiagnosticsExportResult extends Schema.Class<DiagnosticsExportResult>(
-  "DiagnosticsExportResult",
+	"DiagnosticsExportResult",
 )({
-  diagnosticId: Schema.String,
-  createdAt: Schema.DateFromString,
-  bundlePath: Schema.String,
-  summary: Schema.String,
-  included: Schema.Array(DiagnosticArtifactName),
+	diagnosticId: Schema.String,
+	createdAt: Schema.DateFromString,
+	bundlePath: Schema.String,
+	summary: Schema.String,
+	included: Schema.Array(DiagnosticArtifactName),
 }) {}
 
 export class DiagnosticsExportError extends Schema.TaggedErrorClass<DiagnosticsExportError>()(
-  "DiagnosticsExportError",
-  {
-    reason: Schema.String,
-  },
+	"DiagnosticsExportError",
+	{ reason: Schema.String },
 ) {}
 
+const DiagnosticsError = DiagnosticsExportError;
+
+export const DiagnosticsOverviewRpc = Rpc.make("diagnostics.overview", {
+	payload: Schema.Struct({ since: Schema.optional(Schema.String) }),
+	success: DiagnosticsOverviewResult,
+	error: DiagnosticsError,
+});
+
+export const DiagnosticsEventsRpc = Rpc.make("diagnostics.events", {
+	payload: Schema.Struct({
+		cursor: Schema.optional(Schema.String),
+		limit: Schema.optional(Schema.Number),
+		severities: Schema.optional(Schema.Array(DiagnosticSeverity)),
+		source: Schema.optional(Schema.String),
+		search: Schema.optional(Schema.String),
+		since: Schema.optional(Schema.String),
+	}),
+	success: DiagnosticsEventsResult,
+	error: DiagnosticsError,
+});
+
+export const DiagnosticsProcessesRpc = Rpc.make("diagnostics.processes", {
+	success: DiagnosticsProcessesResult,
+	error: DiagnosticsError,
+});
+
+export const DiagnosticsSignalRpc = Rpc.make("diagnostics.signalProcess", {
+	payload: Schema.Struct({
+		pid: Schema.Number,
+		signal: Schema.Literals(["interrupt", "terminate", "kill"]),
+	}),
+	success: DiagnosticsSignalResult,
+	error: DiagnosticsError,
+});
+
+export const DiagnosticsIngestRpc = Rpc.make("diagnostics.ingest", {
+	payload: Schema.Struct({ events: Schema.Array(DiagnosticEvent) }),
+	success: Schema.Void,
+	error: DiagnosticsError,
+});
+
 export const DiagnosticsExportRpc = Rpc.make("diagnostics.export", {
-  payload: Schema.Struct({
-    clientContext: Schema.optional(DiagnosticsClientContext),
-  }),
-  success: DiagnosticsExportResult,
-  error: DiagnosticsExportError,
+	payload: Schema.Struct({
+		clientContext: Schema.optional(DiagnosticsClientContext),
+		since: Schema.optional(Schema.String),
+		includeSessionEvents: Schema.optional(Schema.Boolean),
+	}),
+	success: DiagnosticsExportResult,
+	error: DiagnosticsExportError,
 });

--- a/packages/contracts/src/handshake.ts
+++ b/packages/contracts/src/handshake.ts
@@ -1,26 +1,26 @@
 import { Schema } from "effect";
 import { Rpc } from "effect/unstable/rpc";
 
-export const WIRE_PROTOCOL_VERSION = 2 as const;
+export const WIRE_PROTOCOL_VERSION = 3 as const;
 
 export class WireHello extends Schema.Class<WireHello>("WireHello")({
-  protocolVersion: Schema.Number,
+	protocolVersion: Schema.Number,
 }) {}
 
 export class WireWelcome extends Schema.Class<WireWelcome>("WireWelcome")({
-  protocolVersion: Schema.Number,
+	protocolVersion: Schema.Number,
 }) {}
 
 export class WireProtocolRejected extends Schema.TaggedErrorClass<WireProtocolRejected>()(
-  "WireProtocolRejected",
-  {
-    expectedVersion: Schema.Number,
-    receivedVersion: Schema.Number,
-  },
+	"WireProtocolRejected",
+	{
+		expectedVersion: Schema.Number,
+		receivedVersion: Schema.Number,
+	},
 ) {}
 
 export const ConnectHandshakeRpc = Rpc.make("connect.handshake", {
-  payload: WireHello,
-  success: WireWelcome,
-  error: WireProtocolRejected,
+	payload: WireHello,
+	success: WireWelcome,
+	error: WireProtocolRejected,
 });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -39,7 +39,14 @@ import {
 	RelayUnlinkRpc,
 } from "./connect.ts";
 import { ContextSaveTextRpc } from "./context.ts";
-import { DiagnosticsExportRpc } from "./diagnostics.ts";
+import {
+	DiagnosticsEventsRpc,
+	DiagnosticsExportRpc,
+	DiagnosticsIngestRpc,
+	DiagnosticsOverviewRpc,
+	DiagnosticsProcessesRpc,
+	DiagnosticsSignalRpc,
+} from "./diagnostics.ts";
 import {
 	ExternalThreadsContinueRpc,
 	ExternalThreadsListRpc,
@@ -427,6 +434,11 @@ export const MemoizeRpcs = RpcGroup.make(
 	UsageLimitsRpc,
 	UsageLimitsHistoryRpc,
 	DiagnosticsExportRpc,
+	DiagnosticsOverviewRpc,
+	DiagnosticsEventsRpc,
+	DiagnosticsProcessesRpc,
+	DiagnosticsSignalRpc,
+	DiagnosticsIngestRpc,
 	KeybindingsGetRpc,
 	KeybindingsReplaceRpc,
 	KeybindingsStreamRpc,

--- a/packages/domain/test/integration/engine/sql-consumer-storage.test.ts
+++ b/packages/domain/test/integration/engine/sql-consumer-storage.test.ts
@@ -344,4 +344,30 @@ describe("SqlConsumerStorage", () => {
 			recordId: "bad-event",
 		});
 	});
+
+	test("replays durable provider-turn lifecycle events written by newer app runs", async () => {
+		const events = await run(
+			Effect.gen(function* () {
+				yield* createDomainTestSchema();
+				const sql = yield* SqlClient.SqlClient;
+				yield* insertEvent("provider-turn-requested", "session-1", 1, {
+					_tag: "ProviderTurnRequested",
+					turnId: "turn-1",
+					providerInputJson: '{"text":"hello"}',
+					requestedAt: 1,
+				});
+				return yield* makeSqlConsumerStorage(sql).eventsAfter(0);
+			}),
+		);
+
+		expect(events).toMatchObject([
+			{
+				eventId: "provider-turn-requested",
+				event: {
+					_tag: "ProviderTurnRequested",
+					turnId: "turn-1",
+				},
+			},
+		]);
+	});
 });

--- a/packages/domain/test/unit/core/decider.test.ts
+++ b/packages/domain/test/unit/core/decider.test.ts
@@ -303,6 +303,37 @@ describe("session decider", () => {
 		).toEqual([]);
 	});
 
+	test("treats late interrupt outcomes after exact-turn settlement as no-ops", () => {
+		const settled = evolveAll(created(), [
+			{ _tag: "TurnStarted", turnId: "turn-1", startedAt: 2 },
+			{
+				_tag: "TurnSettled",
+				turnId: "turn-1",
+				outcome: "completed",
+				settledAt: 3,
+			},
+		]);
+		expect(
+			Result.getOrThrow(
+				decide(settled, {
+					_tag: "AcknowledgeTurnInterrupt",
+					turnId: "turn-1",
+					acknowledgedAt: 4,
+				}),
+			),
+		).toEqual([]);
+		expect(
+			Result.getOrThrow(
+				decide(settled, {
+					_tag: "FailTurnInterrupt",
+					turnId: "turn-1",
+					reason: "provider already completed",
+					failedAt: 4,
+				}),
+			),
+		).toEqual([]);
+	});
+
 	test("rejects stale interrupt and terminal commands", () => {
 		const running = evolveAll(created(), [
 			{ _tag: "TurnStarted", turnId: "turn-2", startedAt: 2 },

--- a/scripts/dev-instance.mjs
+++ b/scripts/dev-instance.mjs
@@ -179,10 +179,12 @@ export const withScannedPorts = async (
 				return {
 					...initial,
 					...(portsShifted
-						? instanceResources(
-								initial.repoRoot,
-								`${initial.instance}-p${rendererPort}`,
-							)
+						? {
+								packDir: instanceResources(
+									initial.repoRoot,
+									`${initial.instance}-p${rendererPort}`,
+								).packDir,
+							}
 						: {}),
 					...(initial.userDataExplicit
 						? { userDataDir: initial.userDataDir }
@@ -195,10 +197,11 @@ export const withScannedPorts = async (
 			const instance = validateInstance(`port-${rendererPort}`);
 			return {
 				...initial,
-				...(rendererPort === RENDERER_BASE_PORT &&
-				websocketPort === WEBSOCKET_BASE_PORT
-					? defaultInstanceResources(initial.repoRoot)
-					: instanceResources(initial.repoRoot, instance)),
+				packDir:
+					rendererPort === RENDERER_BASE_PORT &&
+					websocketPort === WEBSOCKET_BASE_PORT
+						? defaultInstanceResources(initial.repoRoot).packDir
+						: instanceResources(initial.repoRoot, instance).packDir,
 				...(initial.userDataExplicit
 					? { userDataDir: initial.userDataDir }
 					: {}),

--- a/scripts/dev-instance.test.mjs
+++ b/scripts/dev-instance.test.mjs
@@ -90,7 +90,7 @@ test("scans paired ports forward and fails occupied explicit overrides", async (
 	);
 	assert.equal(scanned.rendererPort, 5735);
 	assert.equal(scanned.websocketPort, 8790);
-	assert.match(scanned.userDataDir, /scan-p5735\/user-data$/u);
+	assert.equal(scanned.userDataDir, initial.userDataDir);
 	assert.match(scanned.packDir, /scan-p5735\/dist-electron$/u);
 
 	const explicit = initialDevInstance({
@@ -104,7 +104,7 @@ test("scans paired ports forward and fails occupied explicit overrides", async (
 	);
 });
 
-test("automatic scans isolate directories by the allocated port", async () => {
+test("automatic scans preserve the existing development profile", async () => {
 	const initial = initialDevInstance({
 		argv: [],
 		env: {},
@@ -115,7 +115,7 @@ test("automatic scans isolate directories by the allocated port", async () => {
 		async (port) => port !== 5733 && port !== 8788,
 	);
 	assert.equal(scanned.instance, "port-5734");
-	assert.match(scanned.userDataDir, /port-5734\/user-data$/u);
+	assert.equal(scanned.userDataDir, initial.userDataDir);
 	assert.match(scanned.packDir, /port-5734\/dist-electron$/u);
 });
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -50,6 +50,8 @@ const diagnostics = devInstanceDiagnostics(instance, rendererHost);
 console.log(`[dev] ${JSON.stringify(diagnostics, null, 2)}`);
 if (instance.dryRun) process.exit(0);
 
+const devStartedAt = Date.now();
+
 const children = [];
 let shuttingDown = false;
 
@@ -81,6 +83,7 @@ async function shutdown(code) {
 
 const sharedEnv = {
 	ZUSE_DEV_INSTANCE: instance.instance,
+	ZUSE_DEV_STARTED_AT: String(devStartedAt),
 	ZUSE_DESKTOP_WS_PORT: String(instance.websocketPort),
 	...(instance.userDataDir ? { ZUSE_USER_DATA_DIR: instance.userDataDir } : {}),
 	ZUSE_DESKTOP_OUT_DIR: instance.packDir,

--- a/scripts/diagnostics-inspect.mjs
+++ b/scripts/diagnostics-inspect.mjs
@@ -3,239 +3,269 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 
 function usage() {
-  return "Usage: bun run diagnostics:inspect <zuse-diagnostics.json>";
+	return "Usage: bun run diagnostics:inspect <diagnostics.zip|diagnostics.json>";
 }
 
-function readJson(path) {
-  return JSON.parse(readFileSync(path, "utf8"));
+function readBundle(path) {
+	const bytes = readFileSync(path);
+	if (bytes.readUInt32LE(0) !== 0x04034b50)
+		return JSON.parse(bytes.toString("utf8"));
+	const artifacts = {};
+	let manifest = {};
+	let offset = 0;
+	while (
+		offset + 30 <= bytes.length &&
+		bytes.readUInt32LE(offset) === 0x04034b50
+	) {
+		const method = bytes.readUInt16LE(offset + 8);
+		const size = bytes.readUInt32LE(offset + 18);
+		const nameLength = bytes.readUInt16LE(offset + 26);
+		const extraLength = bytes.readUInt16LE(offset + 28);
+		const nameStart = offset + 30;
+		const dataStart = nameStart + nameLength + extraLength;
+		const name = bytes
+			.subarray(nameStart, nameStart + nameLength)
+			.toString("utf8");
+		if (method !== 0)
+			throw new Error(`Unsupported compressed ZIP entry: ${name}`);
+		if (name.endsWith(".json")) {
+			const value = JSON.parse(
+				bytes.subarray(dataStart, dataStart + size).toString("utf8"),
+			);
+			if (name === "manifest.json") manifest = value;
+			else artifacts[name.slice(0, -5)] = value;
+		}
+		offset = dataStart + size;
+	}
+	return { manifest, artifacts };
 }
 
 function writeJson(path, value) {
-  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
 function getDiagnosticId(bundle, inputPath) {
-  const id = bundle?.manifest?.diagnosticId;
-  if (typeof id === "string" && id.length > 0) return id;
-  return basename(inputPath).replace(/[^A-Za-z0-9._-]+/g, "-");
+	const id = bundle?.manifest?.diagnosticId;
+	if (typeof id === "string" && id.length > 0) return id;
+	return basename(inputPath).replace(/[^A-Za-z0-9._-]+/g, "-");
 }
 
 function likelyIssue(traceSummary) {
-  const first = traceSummary?.latestFailures?.[0];
-  if (!first) {
-    return "No recent persisted error messages were found in this diagnostics bundle.";
-  }
-  const span = typeof first.span === "string" ? first.span : "unknown span";
-  const message =
-    typeof first.message === "string"
-      ? first.message
-      : "No error message was captured.";
-  return `${span}: ${message}`;
+	const first = traceSummary?.latestFailures?.[0];
+	if (!first) {
+		return "No recent persisted error messages were found in this diagnostics bundle.";
+	}
+	const span = typeof first.span === "string" ? first.span : "unknown span";
+	const message =
+		typeof first.message === "string"
+			? first.message
+			: "No error message was captured.";
+	return `${span}: ${message}`;
 }
 
 function relevantHints(traceSummary) {
-  const failures = Array.isArray(traceSummary?.latestFailures)
-    ? traceSummary.latestFailures
-    : [];
-  const providerIds = new Set(
-    failures
-      .map((failure) => failure?.providerId)
-      .filter(
-        (providerId) => typeof providerId === "string" && providerId.length > 0,
-      ),
-  );
-  const spans = new Set(
-    failures
-      .map((failure) => failure?.span)
-      .filter((span) => typeof span === "string" && span.length > 0),
-  );
+	const failures = Array.isArray(traceSummary?.latestFailures)
+		? traceSummary.latestFailures
+		: [];
+	const providerIds = new Set(
+		failures
+			.map((failure) => failure?.providerId)
+			.filter(
+				(providerId) => typeof providerId === "string" && providerId.length > 0,
+			),
+	);
+	const spans = new Set(
+		failures
+			.map((failure) => failure?.span)
+			.filter((span) => typeof span === "string" && span.length > 0),
+	);
 
-  const hints = new Set([
-    "apps/server/src/provider/",
-    "apps/server/src/provider/layers/message-store.ts",
-    "apps/renderer/src/components/",
-  ]);
-  for (const providerId of providerIds) {
-    hints.add(`packages/agents/src/drivers/${providerId}.ts`);
-  }
-  if ([...spans].some((span) => span.includes("message"))) {
-    hints.add("packages/contracts/src/session.ts");
-  }
-  return [...hints];
+	const hints = new Set([
+		"apps/server/src/provider/",
+		"apps/server/src/provider/layers/message-store.ts",
+		"apps/renderer/src/components/",
+	]);
+	for (const providerId of providerIds) {
+		hints.add(`packages/agents/src/drivers/${providerId}.ts`);
+	}
+	if ([...spans].some((span) => span.includes("message"))) {
+		hints.add("packages/contracts/src/session.ts");
+	}
+	return [...hints];
 }
 
 function buildReport({ diagnosticId, bundlePath, bundle }) {
-  const traceSummary = bundle.artifacts?.["trace-summary"] ?? {};
-  const bundleSummary = bundle.artifacts?.["bundle-summary"] ?? {};
-  const clientContext = bundle.artifacts?.["client-context"] ?? {};
-  const recentErrors = bundle.artifacts?.["recent-errors"] ?? {};
-  const providerStatus = bundle.artifacts?.["provider-status"] ?? {};
-  const environment = bundle.artifacts?.environment ?? {};
-  const latestFailures = Array.isArray(traceSummary.latestFailures)
-    ? traceSummary.latestFailures
-    : [];
-  const firstTraceId =
-    latestFailures.find((failure) => failure?.traceId)?.traceId ??
-    "not captured";
+	const traceSummary = bundle.artifacts?.["trace-summary"] ?? {};
+	const bundleSummary = bundle.artifacts?.["bundle-summary"] ?? {};
+	const clientContext = bundle.artifacts?.["client-context"] ?? {};
+	const recentErrors = bundle.artifacts?.["recent-errors"] ?? {};
+	const providerStatus = bundle.artifacts?.["provider-status"] ?? {};
+	const environment = bundle.artifacts?.environment ?? {};
+	const latestFailures = Array.isArray(traceSummary.latestFailures)
+		? traceSummary.latestFailures
+		: [];
+	const firstTraceId =
+		latestFailures.find((failure) => failure?.traceId)?.traceId ??
+		"not captured";
 
-  const lines = [
-    "# Diagnostic Report",
-    "",
-    `Diagnostic ID: ${diagnosticId}`,
-    `Source bundle: ${bundlePath}`,
-    "",
-    "## Likely Issue",
-    "",
-    likelyIssue(traceSummary),
-    "",
-    "## Bundle Health",
-    "",
-  ];
+	const lines = [
+		"# Diagnostic Report",
+		"",
+		`Diagnostic ID: ${diagnosticId}`,
+		`Source bundle: ${bundlePath}`,
+		"",
+		"## Likely Issue",
+		"",
+		likelyIssue(traceSummary),
+		"",
+		"## Bundle Health",
+		"",
+	];
 
-  const warnings = Array.isArray(bundleSummary.diagnosticWarnings)
-    ? bundleSummary.diagnosticWarnings
-    : [];
-  if (warnings.length === 0) {
-    lines.push("No bundle warnings.", "");
-  } else {
-    for (const warning of warnings) lines.push(`- ${warning}`);
-    lines.push("");
-  }
+	const warnings = Array.isArray(bundleSummary.diagnosticWarnings)
+		? bundleSummary.diagnosticWarnings
+		: [];
+	if (warnings.length === 0) {
+		lines.push("No bundle warnings.", "");
+	} else {
+		for (const warning of warnings) lines.push(`- ${warning}`);
+		lines.push("");
+	}
 
-  const artifactSizes =
-    typeof bundleSummary.artifactSizes === "object" &&
-    bundleSummary.artifactSizes !== null
-      ? Object.entries(bundleSummary.artifactSizes)
-      : [];
-  if (artifactSizes.length > 0) {
-    lines.push("### Artifact Sizes", "");
-    for (const [name, size] of artifactSizes) {
-      lines.push(`- ${name}: ${size} bytes`);
-    }
-    lines.push("");
-  }
+	const artifactSizes =
+		typeof bundleSummary.artifactSizes === "object" &&
+		bundleSummary.artifactSizes !== null
+			? Object.entries(bundleSummary.artifactSizes)
+			: [];
+	if (artifactSizes.length > 0) {
+		lines.push("### Artifact Sizes", "");
+		for (const [name, size] of artifactSizes) {
+			lines.push(`- ${name}: ${size} bytes`);
+		}
+		lines.push("");
+	}
 
-  lines.push(
-    "## Client Context",
-    "",
-    `- view=${clientContext.view ?? "unknown"} settings=${clientContext.settingsSection ?? "unknown"} mainTab=${clientContext.activeMainTab ?? "unknown"}`,
-    `- project=${clientContext.selectedFolderId ?? "none"} chat=${clientContext.selectedChatId ?? "none"} session=${clientContext.activeSessionId ?? "none"}`,
-    `- openFile=${clientContext.openFile ?? "none"}`,
-    "",
-  );
+	lines.push(
+		"## Client Context",
+		"",
+		`- view=${clientContext.view ?? "unknown"} settings=${clientContext.settingsSection ?? "unknown"} mainTab=${clientContext.activeMainTab ?? "unknown"}`,
+		`- project=${clientContext.selectedFolderId ?? "none"} chat=${clientContext.selectedChatId ?? "none"} session=${clientContext.activeSessionId ?? "none"}`,
+		`- openFile=${clientContext.openFile ?? "none"}`,
+		"",
+	);
 
-  const rendererLogs = Array.isArray(clientContext.rendererLogs)
-    ? clientContext.rendererLogs
-    : [];
-  const mainProcessLogs = Array.isArray(clientContext.mainProcessLogs)
-    ? clientContext.mainProcessLogs
-    : [];
-  const recentUiActions = Array.isArray(clientContext.recentUiActions)
-    ? clientContext.recentUiActions
-    : [];
+	const rendererLogs = Array.isArray(clientContext.rendererLogs)
+		? clientContext.rendererLogs
+		: [];
+	const mainProcessLogs = Array.isArray(clientContext.mainProcessLogs)
+		? clientContext.mainProcessLogs
+		: [];
+	const recentUiActions = Array.isArray(clientContext.recentUiActions)
+		? clientContext.recentUiActions
+		: [];
 
-  if (recentUiActions.length > 0) {
-    lines.push("### Recent UI Actions", "");
-    for (const action of recentUiActions.slice(-12)) {
-      lines.push(
-        `- ${action.createdAt ?? "unknown"} · ${action.action ?? "unknown"}${action.detail ? ` · ${action.detail}` : ""}`,
-      );
-    }
-    lines.push("");
-  }
+	if (recentUiActions.length > 0) {
+		lines.push("### Recent UI Actions", "");
+		for (const action of recentUiActions.slice(-12)) {
+			lines.push(
+				`- ${action.createdAt ?? "unknown"} · ${action.action ?? "unknown"}${action.detail ? ` · ${action.detail}` : ""}`,
+			);
+		}
+		lines.push("");
+	}
 
-  if (rendererLogs.length > 0 || mainProcessLogs.length > 0) {
-    lines.push("### Recent App Logs", "");
-    for (const log of [...rendererLogs, ...mainProcessLogs].slice(-20)) {
-      lines.push(
-        `- ${log.createdAt ?? "unknown"} · ${log.level ?? "unknown"} · ${log.source ?? "unknown"} · ${log.message ?? ""}`,
-      );
-    }
-    lines.push("");
-  }
+	if (rendererLogs.length > 0 || mainProcessLogs.length > 0) {
+		lines.push("### Recent App Logs", "");
+		for (const log of [...rendererLogs, ...mainProcessLogs].slice(-20)) {
+			lines.push(
+				`- ${log.createdAt ?? "unknown"} · ${log.level ?? "unknown"} · ${log.source ?? "unknown"} · ${log.message ?? ""}`,
+			);
+		}
+		lines.push("");
+	}
 
-  lines.push(
-    "## Relevant Trace",
-    "",
-    String(firstTraceId),
-    "",
-    "## Recent Failures",
-    "",
-  );
+	lines.push(
+		"## Relevant Trace",
+		"",
+		String(firstTraceId),
+		"",
+		"## Recent Failures",
+		"",
+	);
 
-  if (latestFailures.length === 0) {
-    lines.push("No recent failures found.", "");
-  } else {
-    for (const failure of latestFailures.slice(0, 8)) {
-      lines.push(
-        `- ${failure.occurredAt ?? "unknown time"} · ${failure.span ?? "unknown span"} · ${failure.message ?? "no message"} · session=${failure.sessionId ?? "unknown"}`,
-      );
-    }
-    lines.push("");
-  }
+	if (latestFailures.length === 0) {
+		lines.push("No recent failures found.", "");
+	} else {
+		for (const failure of latestFailures.slice(0, 8)) {
+			lines.push(
+				`- ${failure.occurredAt ?? "unknown time"} · ${failure.span ?? "unknown span"} · ${failure.message ?? "no message"} · session=${failure.sessionId ?? "unknown"}`,
+			);
+		}
+		lines.push("");
+	}
 
-  lines.push("## Provider Status", "");
-  const providers = Array.isArray(providerStatus.providers)
-    ? providerStatus.providers
-    : [];
-  if (providers.length === 0) {
-    lines.push("No provider status captured.", "");
-  } else {
-    for (const provider of providers) {
-      lines.push(
-        `- ${provider.providerId}: status=${provider.status ?? "unknown"}, cliInstalled=${provider.cliInstalled}, auth=${provider.authStatus ?? "unknown"}, version=${provider.cliVersion ?? "unknown"}`,
-      );
-    }
-    lines.push("");
-  }
+	lines.push("## Provider Status", "");
+	const providers = Array.isArray(providerStatus.providers)
+		? providerStatus.providers
+		: [];
+	if (providers.length === 0) {
+		lines.push("No provider status captured.", "");
+	} else {
+		for (const provider of providers) {
+			lines.push(
+				`- ${provider.providerId}: status=${provider.status ?? "unknown"}, cliInstalled=${provider.cliInstalled}, auth=${provider.authStatus ?? "unknown"}, version=${provider.cliVersion ?? "unknown"}`,
+			);
+		}
+		lines.push("");
+	}
 
-  lines.push("## Environment", "");
-  lines.push(
-    `- app=${environment.app ?? "unknown"} version=${environment.version ?? "unknown"} platform=${environment.platform ?? "unknown"} arch=${environment.arch ?? "unknown"} node=${environment.node ?? "unknown"}`,
-    "",
-  );
+	lines.push("## Environment", "");
+	lines.push(
+		`- app=${environment.app ?? "unknown"} version=${environment.version ?? "unknown"} platform=${environment.platform ?? "unknown"} arch=${environment.arch ?? "unknown"} node=${environment.node ?? "unknown"}`,
+		"",
+	);
 
-  lines.push("## Relevant Files To Inspect", "");
-  for (const hint of relevantHints(traceSummary)) {
-    lines.push(`- ${hint}`);
-  }
-  lines.push(
-    "",
-    "## Agent Prompt",
-    "",
-    `Debug this user issue using .context/diagnostics/${diagnosticId}/REPORT.md and the raw bundle files.`,
-    "Find the root cause and propose or implement a fix. Do not include sensitive user content in the final summary.",
-    "",
-  );
+	lines.push("## Relevant Files To Inspect", "");
+	for (const hint of relevantHints(traceSummary)) {
+		lines.push(`- ${hint}`);
+	}
+	lines.push(
+		"",
+		"## Agent Prompt",
+		"",
+		`Debug this user issue using .context/diagnostics/${diagnosticId}/REPORT.md and the raw bundle files.`,
+		"Find the root cause and propose or implement a fix. Do not include sensitive user content in the final summary.",
+		"",
+	);
 
-  if (Array.isArray(recentErrors.errors) && recentErrors.errors.length > 0) {
-    lines.push("## Raw Error Summary", "");
-    for (const error of recentErrors.errors.slice(0, 12)) {
-      lines.push(`- ${error.message ?? "no message"}`);
-    }
-    lines.push("");
-  }
+	if (Array.isArray(recentErrors.errors) && recentErrors.errors.length > 0) {
+		lines.push("## Raw Error Summary", "");
+		for (const error of recentErrors.errors.slice(0, 12)) {
+			lines.push(`- ${error.message ?? "no message"}`);
+		}
+		lines.push("");
+	}
 
-  return lines.join("\n");
+	return lines.join("\n");
 }
 
 const input = process.argv[2];
 if (!input) {
-  console.error(usage());
-  process.exit(2);
+	console.error(usage());
+	process.exit(2);
 }
 
 const bundlePath = resolve(input);
-const bundle = readJson(bundlePath);
+const bundle = readBundle(bundlePath);
 const diagnosticId = getDiagnosticId(bundle, bundlePath);
 const outputDir = resolve(".context", "diagnostics", diagnosticId);
 mkdirSync(outputDir, { recursive: true });
 
 writeJson(join(outputDir, "manifest.json"), bundle.manifest ?? {});
 for (const [name, artifact] of Object.entries(bundle.artifacts ?? {})) {
-  writeJson(join(outputDir, `${name}.json`), artifact);
+	writeJson(join(outputDir, `${name}.json`), artifact);
 }
-writeJson(join(outputDir, basename(bundlePath)), bundle);
+writeJson(join(outputDir, "bundle.json"), bundle);
 
 const report = buildReport({ diagnosticId, bundlePath, bundle });
 writeFileSync(join(outputDir, "REPORT.md"), report, "utf8");


### PR DESCRIPTION
## Summary

- add persistent, structured diagnostics across desktop main/preload, renderer, server RPCs, providers, terminals, networking, permissions, attachments, Git/worktrees, MCP, sessions, and persistence boundaries
- install a real Effect tracer around the server runtime with correlated trace/span IDs, operation latency, outcomes, failure grouping, and populated top/slow operation views
- add an issue-first Settings → Diagnostics workspace with Issues, Logs, Performance, Processes, and Storage views
- keep successful operation telemetry in Logs/Performance while the default Issues inbox shows warnings, errors, and fatal incidents
- add stable cursor pagination, version-cached polling, live CPU/memory/failure trends, grouped incidents, and process controls with ancestry validation
- add rotating seven-day local NDJSON telemetry with a 100,000-event O(1) ring buffer, batched writes, corrupted-line recovery, bounded stalled-disk queues, and explicit dropped-event incidents
- add synchronous renderer-to-main fatal capture and offline crash import so fatal events survive a dead renderer or server
- add optional OTLP traces and metrics, disabled by default, with low-cardinality labels and the same strict attribute allowlist used by local persistence
- add redacted ZIP support bundles with manifests, reports, SHA-256 checksums, process snapshots, trace summaries, and legacy JSON inspection compatibility
- preserve one logical development profile when fallback ports are selected and require current-run Electron artifacts before launch
- route managed-tunnel and relay lifecycle diagnostics through the same bounded telemetry sink, with structural error classification and no raw paths, URLs, tokens, or arbitrary error messages
- classify authentication RPC telemetry separately so hosted and desktop sign-in failures are easy to filter

## Privacy

Runtime telemetry stays on-device unless OTLP endpoints are explicitly configured. Persisted and forwarded telemetry excludes prompts, transcripts, terminal output, environment values, credentials, raw command arguments, query values, arbitrary console arguments, and raw relay/tunnel fields. Failures retain structural error type/tag and sanitized stack frames without persisting raw error messages. Export applies a second redaction pass.

## Validation

- rebased cleanly onto current `main` (`de76fbfb`)
- server typecheck passed
- renderer typecheck and renderer state check passed
- desktop typecheck passed
- server unit tests: 189 passed
- renderer unit tests: 256 passed
- desktop tests: 34 passed
- development profile/port tests: 8 passed
- server production bundle passed
- desktop production bundle and startup smoke passed
- targeted Biome lint passed
- PR is mergeable against current `main`

The server integration suite has two unrelated baseline failures: a stale test database missing `title_provenance`, and an existing provider-recovery error-message expectation. The renderer production compile succeeds, but its separate initial-bundle budget remains above the repository's existing 500 KiB gzip gate (625.4 KiB observed).