### PR TITLE
Polish latest-response forking and restore desktop startup

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -32,6 +32,7 @@
 		"@fontsource-variable/inter": "^5.2.8",
 		"@formkit/auto-animate": "^0.9.0",
 		"@hugeicons-pro/core-solid-rounded": "^4.2.1",
+		"@hugeicons-pro/core-stroke-rounded": "4.2.2",
 		"@hugeicons/react": "^1.1.7",
 		"@legendapp/list": "3.2.0",
 		"@lezer/highlight": "^1.2.0",

--- a/apps/renderer/src/components/archived-chat-timeline.tsx
+++ b/apps/renderer/src/components/archived-chat-timeline.tsx
@@ -71,7 +71,12 @@ function ArchivedTimelineRow({
   switch (row.kind) {
     case "message":
       return (
-        <MessageRow message={row.message} sessionId={sessionId} readOnly />
+        <MessageRow
+          message={row.message}
+          sessionId={sessionId}
+          readOnly
+          showAssistantCommands={row.showAssistantCommands}
+        />
       );
     case "subagent":
       return (
@@ -88,7 +93,12 @@ function ArchivedTimelineRow({
         />
       );
     case "turn-summary":
-      return <TurnSummary body={row.body} />;
+      return (
+        <TurnSummary
+          body={row.body}
+          showAssistantCommands={row.showAssistantCommands}
+        />
+      );
     case "working":
       return null;
   }

--- a/apps/renderer/src/components/assistant-message-actions.tsx
+++ b/apps/renderer/src/components/assistant-message-actions.tsx
@@ -20,16 +20,22 @@ const formatFullMessageTime = (date: Date): string =>
 export function AssistantMessageActions({
 	text,
 	createdAt,
+	elapsed,
 	sessionId,
 	messageId,
+	showMessageCommands = false,
 	className,
 }: {
 	readonly text: string;
 	readonly createdAt?: Date;
+	readonly elapsed?: string;
 	readonly sessionId?: SessionId;
 	readonly messageId?: MessageId;
+	readonly showMessageCommands?: boolean;
 	readonly className?: string;
 }) {
+	if (!showMessageCommands) return null;
+
 	return (
 		<div
 			className={cn(
@@ -59,6 +65,11 @@ export function AssistantMessageActions({
 					/>
 					<TooltipPopup>{formatFullMessageTime(createdAt)}</TooltipPopup>
 				</Tooltip>
+			) : null}
+			{elapsed !== undefined ? (
+				<span className="cursor-default px-1 text-[11px] tabular-nums text-muted-foreground">
+					{elapsed}
+				</span>
 			) : null}
 		</div>
 	);

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -797,7 +797,13 @@ function TimelineRow({
 }) {
 	switch (row.kind) {
 		case "message":
-			return <MessageRow message={row.message} sessionId={sessionId} />;
+			return (
+				<MessageRow
+					message={row.message}
+					sessionId={sessionId}
+					showAssistantCommands={row.showAssistantCommands}
+				/>
+			);
 		case "subagent":
 			return (
 				<div>
@@ -816,7 +822,11 @@ function TimelineRow({
 		case "turn-summary":
 			return (
 				<div>
-					<TurnSummary body={row.body} sessionId={sessionId} />
+					<TurnSummary
+						body={row.body}
+						sessionId={sessionId}
+						showAssistantCommands={row.showAssistantCommands}
+					/>
 				</div>
 			);
 		case "working":

--- a/apps/renderer/src/components/fork-menu.tsx
+++ b/apps/renderer/src/components/fork-menu.tsx
@@ -1,9 +1,6 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import {
-	GitBranchIcon,
-	GitForkIcon,
-	Loading02Icon,
-} from "@hugeicons-pro/core-solid-rounded";
+import { Loading02Icon } from "@hugeicons-pro/core-solid-rounded";
+import { GitBranchIcon } from "@hugeicons-pro/core-stroke-rounded";
 import type { MessageId, SessionId, Worktree } from "@zuse/contracts";
 import { useState } from "react";
 
@@ -12,6 +9,47 @@ import { useWorktreesStore } from "../store/worktrees.ts";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu.tsx";
 import { toastManager } from "./ui/toast.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
+
+function ForkSplitIcon({ className }: { readonly className?: string }) {
+	return (
+		<svg
+			aria-hidden="true"
+			focusable="false"
+			viewBox="0 0 24 24"
+			fill="none"
+			className={className}
+		>
+			<path
+				d="M4 12h4c2.3 0 3.8-1 5.2-2.7L18 4"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<path
+				d="M13.5 4H18v4.5"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<path
+				d="M8 12c2.3 0 3.8 1 5.2 2.7L18 20"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<path
+				d="M18 15.5V20h-4.5"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}
 
 export function ForkButton({
 	sourceSessionId,
@@ -102,11 +140,15 @@ export function ForkButton({
 							aria-label="Fork from this response"
 							className="inline-grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground/70 outline-none hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.97] data-[popup-open]:bg-muted/50 data-[popup-open]:text-foreground [@media(pointer:coarse)]:size-11"
 						>
-							<HugeiconsIcon
-								icon={forking ? Loading02Icon : GitForkIcon}
-								className={forking ? "size-3.5 animate-spin" : "size-3.5"}
-								aria-hidden="true"
-							/>
+							{forking ? (
+								<HugeiconsIcon
+									icon={Loading02Icon}
+									className="size-3.5 animate-spin"
+									aria-hidden="true"
+								/>
+							) : (
+								<ForkSplitIcon className="size-3.5" />
+							)}
 						</MenuTrigger>
 					}
 				/>
@@ -120,7 +162,7 @@ export function ForkButton({
 								onClick={() => void run("tab")}
 								className="gap-2.5 px-2 py-1.5"
 							>
-								<HugeiconsIcon icon={GitForkIcon} className="size-4" />
+								<ForkSplitIcon className="size-4" />
 								<span>Fork in this chat</span>
 							</MenuItem>
 						}

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -147,10 +147,12 @@ function MessageRowImpl({
 	message,
 	sessionId,
 	readOnly = false,
+	showAssistantCommands = false,
 }: {
 	message: Message;
 	sessionId?: SessionId;
 	readOnly?: boolean;
+	showAssistantCommands?: boolean;
 }) {
 	switch (message.content._tag) {
 		case "user":
@@ -180,6 +182,7 @@ function MessageRowImpl({
 					createdAt={message.createdAt}
 					messageId={message.id}
 					sessionId={readOnly ? undefined : sessionId}
+					showMessageCommands={showAssistantCommands}
 				/>
 			);
 		case "thinking":
@@ -619,11 +622,13 @@ function AssistantBubble({
 	createdAt,
 	messageId,
 	sessionId,
+	showMessageCommands,
 }: {
 	text: string;
 	createdAt?: Date;
 	messageId: Message["id"];
 	sessionId?: SessionId;
+	showMessageCommands: boolean;
 }) {
 	return (
 		<div className="group/assistant px-4 py-2">
@@ -634,6 +639,7 @@ function AssistantBubble({
 					createdAt={createdAt}
 					messageId={messageId}
 					sessionId={sessionId}
+					showMessageCommands={showMessageCommands}
 					className="mt-1"
 				/>
 			</div>

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -83,15 +83,18 @@ const MAX_FILE_CHIPS = 4;
 /**
  * Inline summary of a completed turn. The header (chevron + counts + tool
  * icon preview) toggles the detail rows. The final assistant text always
- * shows below; the footer carries elapsed time and file edit stats. No
- * outer card — sections sit flat in the timeline like every other row.
+ * shows below; its action row carries elapsed time, while the optional footer
+ * carries file edit stats. No outer card — sections sit flat in the timeline
+ * like every other row.
  */
 function TurnSummaryImpl({
 	body,
 	sessionId,
+	showAssistantCommands = false,
 }: {
 	body: ReadonlyArray<Message>;
 	sessionId?: SessionId;
+	showAssistantCommands?: boolean;
 }) {
 	const [expanded, setExpanded] = useState(false);
 	const [filesExpanded, setFilesExpanded] = useState(false);
@@ -249,6 +252,8 @@ function TurnSummaryImpl({
 							createdAt={finalAssistant.createdAt}
 							messageId={finalAssistant.id}
 							sessionId={sessionId}
+							showMessageCommands={showAssistantCommands}
+							elapsed={formatElapsed(duration)}
 							className="mt-1"
 						/>
 					</div>
@@ -258,10 +263,10 @@ function TurnSummaryImpl({
 			<div
 				className={cn(
 					"flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-1.5 text-[11px]",
+					visibleFileStats.length === 0 && "hidden",
 					mutedWhenOpen,
 				)}
 			>
-				<span className="tabular-nums">{formatElapsed(duration)}</span>
 				{visibleFileStats.map((f) => (
 					<FileBadge
 						key={f.path}

--- a/apps/renderer/src/lib/chat-timeline-rows.ts
+++ b/apps/renderer/src/lib/chat-timeline-rows.ts
@@ -12,6 +12,7 @@ export type ChatTimelineRow =
 			readonly id: string;
 			readonly message: Message;
 			readonly enterUser: boolean;
+			readonly showAssistantCommands: boolean;
 	  }
 	| {
 			readonly kind: "subagent";
@@ -36,6 +37,7 @@ export type ChatTimelineRow =
 			readonly kind: "turn-summary";
 			readonly id: string;
 			readonly body: ReadonlyArray<Message>;
+			readonly showAssistantCommands: boolean;
 	  }
 	| {
 			readonly kind: "working";
@@ -75,6 +77,15 @@ export function deriveChatTimelineRows({
 	readonly awaitingPlanApproval: boolean;
 }): ChatTimelineRow[] {
 	const normalizedMessages = normalizeTimelineMessages(messages);
+	const actionableAssistantMessageId = inFlight
+		? null
+		: (normalizedMessages.findLast(
+				(message) =>
+					message.content._tag === "assistant" &&
+					message.content.text.trim().length > 0 &&
+					(!("parentItemId" in message.content) ||
+						message.content.parentItemId === undefined),
+			)?.id ?? null);
 	const turns: Array<{
 		user: Message | null;
 		body: Message[];
@@ -104,6 +115,7 @@ export function deriveChatTimelineRows({
 				id: `message:${turn.user.id}`,
 				message: turn.user,
 				enterUser: true,
+				showAssistantCommands: false,
 			});
 		}
 
@@ -153,12 +165,16 @@ export function deriveChatTimelineRows({
 					id: `message:${message.id}`,
 					message,
 					enterUser: false,
+					showAssistantCommands: message.id === actionableAssistantMessageId,
 				});
 			}
 			rows.push({
 				kind: "turn-summary",
 				id: `summary:${turn.user?.id ?? `turn-${index}`}`,
 				body: summaryBody,
+				showAssistantCommands: summaryBody.some(
+					(message) => message.id === actionableAssistantMessageId,
+				),
 			});
 			continue;
 		}
@@ -170,6 +186,8 @@ export function deriveChatTimelineRows({
 					id: `message:${group.message.id}`,
 					message: group.message,
 					enterUser: false,
+					showAssistantCommands:
+						group.message.id === actionableAssistantMessageId,
 				});
 			} else {
 				rows.push({

--- a/apps/renderer/test/unit/chat-timeline-rows.test.ts
+++ b/apps/renderer/test/unit/chat-timeline-rows.test.ts
@@ -101,6 +101,49 @@ describe("chat timeline rows", () => {
 		expect(second.map((row) => row.id)).toEqual(first.map((row) => row.id));
 	});
 
+	it("enables assistant commands only on the final completed response", () => {
+		const rows = deriveChatTimelineRows({
+			messages: [
+				message("u1", { _tag: "user", text: "first" }),
+				message("a1", { _tag: "assistant", text: "first reply" }),
+				message("u2", { _tag: "user", text: "second" }),
+				message("a2", { _tag: "assistant", text: "second reply" }),
+			],
+			inFlight: false,
+			awaitingPlanApproval: false,
+		});
+
+		const assistantRows = rows.filter(
+			(row) =>
+				row.kind === "message" && row.message.content._tag === "assistant",
+		);
+		expect(
+			assistantRows.map((row) =>
+				row.kind === "message" ? row.showAssistantCommands : false,
+			),
+		).toEqual([false, true]);
+	});
+
+	it("keeps assistant commands hidden until the active turn completes", () => {
+		const rows = deriveChatTimelineRows({
+			messages: [
+				message("u1", { _tag: "user", text: "prompt" }),
+				message("a1", { _tag: "assistant", text: "partial reply" }),
+			],
+			inFlight: true,
+			awaitingPlanApproval: false,
+		});
+
+		expect(
+			rows.some(
+				(row) =>
+					row.kind === "message" &&
+					row.message.content._tag === "assistant" &&
+					row.showAssistantCommands,
+			),
+		).toBe(false);
+	});
+
 	it("collapses duplicate tool_use rows with the same provider item id", () => {
 		const messages = [
 			message("u1", { _tag: "user", text: "inspect" }),
@@ -143,6 +186,11 @@ describe("chat timeline rows", () => {
 		});
 		const summary = rows.find((row) => row.kind === "turn-summary");
 		expect(summary?.kind).toBe("turn-summary");
+		expect(
+			summary?.kind === "turn-summary"
+				? summary.showAssistantCommands
+				: false,
+		).toBe(true);
 		expect(
 			summary?.kind === "turn-summary"
 				? summary.body.filter((m) => m.content._tag === "tool_use")

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,16 +9,18 @@
 	"files": [
 		"dist"
 	],
-	"main": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
+	"main": "./src/index.ts",
+	"types": "./src/index.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.mjs"
+			"types": "./src/index.ts",
+			"import": "./src/index.ts",
+			"require": "./src/index.ts"
 		},
 		"./runtime": {
-			"types": "./dist/runtime.d.ts",
-			"import": "./dist/runtime.mjs"
+			"types": "./src/runtime.ts",
+			"import": "./src/runtime.ts",
+			"require": "./src/runtime.ts"
 		}
 	},
 	"scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -164,6 +164,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@formkit/auto-animate": "^0.9.0",
         "@hugeicons-pro/core-solid-rounded": "^4.2.1",
+        "@hugeicons-pro/core-stroke-rounded": "4.2.2",
         "@hugeicons/react": "^1.1.7",
         "@legendapp/list": "3.2.0",
         "@lezer/highlight": "^1.2.0",
@@ -1077,6 +1078,8 @@
     "@hugeicons-pro/core-bulk-rounded": ["@hugeicons-pro/core-bulk-rounded@4.2.1", "https://npm.hugeicons.com/@hugeicons-pro/core-bulk-rounded/-/core-bulk-rounded-4.2.1.tgz", {}, "sha512-NaV2xmHovYsuGlb+JpGitUYZ10pN+z6YJo9RD1nh7Gu3oxFD4PYIFvOZ2e1zq+0Eo0IfLGArrPIyLltfXG5ESA=="],
 
     "@hugeicons-pro/core-solid-rounded": ["@hugeicons-pro/core-solid-rounded@4.2.1", "https://npm.hugeicons.com/@hugeicons-pro/core-solid-rounded/-/core-solid-rounded-4.2.1.tgz", {}, "sha512-rODm75eQ4TH7DpGxngWKFCulMwr8BI+QaJ9ykngRsc3NWbbOnVq0M50LbmYVItNXG2meWxo9uRanmsF7YaYjGg=="],
+
+    "@hugeicons-pro/core-stroke-rounded": ["@hugeicons-pro/core-stroke-rounded@4.2.2", "https://npm.hugeicons.com/@hugeicons-pro/core-stroke-rounded/-/core-stroke-rounded-4.2.2.tgz", {}, "sha512-+TruczzkMDuo1PVTAQWNOkjzPhOkTE/mGsk3OU1kwGnm66c+pgSrLpSRpp0OWmKaHCDCnKfdufFroK7+gs8oWQ=="],
 
     "@hugeicons/react": ["@hugeicons/react@1.1.7", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-0q1gekPJvNtIsfqi6alVdKfqsLz0PGiZWOzxJDxOd55UpFwcgohBFU4CwTcJ7kg4hO3kwXuzxrn/JEj280GX3g=="],
 


### PR DESCRIPTION
## Summary

- show response actions and timing only on the latest completed assistant response
- simplify the fork control with a custom split-arrow icon and rounded outline Git styling
- restore workspace source exports for `@zuse/server` so Electron starts correctly

## Validation

- renderer type-check
- 182 renderer unit tests
- server type-check
- desktop startup smoke test