### PR TITLE
Add semantic agent activity orbs

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -65,6 +65,7 @@
 		"shadcn": "^4.6.0",
 		"shiki": "^4.0.2",
 		"tailwind-merge": "^3.5.0",
+		"thinking-orbs": "^0.1.1",
 		"tw-animate-css": "^1.4.0"
 	},
 	"devDependencies": {

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -10,6 +10,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { deriveAgentActivityState } from "../lib/agent-activity-state.ts";
 import { deriveChatAttentionState } from "../lib/chat-attention-state.ts";
 import {
 	CHAT_LIST_ANCHOR_OFFSET,
@@ -43,8 +44,8 @@ import { ErrorBubble, MessageRow } from "./message-row.tsx";
 import { NextUnreadButton } from "./next-unread-button.tsx";
 import { SubagentRow } from "./subagent-row.tsx";
 import { TurnSummary } from "./turn-summary.tsx";
+import { AgentActivityOrb } from "./ui/agent-activity-orb.tsx";
 import { ShimmerText } from "./ui/shimmer-text.tsx";
-import { Spinner } from "./ui/spinner";
 import { WorktreeSetupCard } from "./worktree-setup-card.tsx";
 
 // Stable empty-array reference for the selector below. Returning a fresh
@@ -847,7 +848,8 @@ function WorkingRow({ messages }: { messages: ReadonlyArray<Message> }) {
 	// elapsed time beside the loader, not the session-wide total.
 	const anchorMs = useMemo(() => {
 		for (let i = messages.length - 1; i >= 0; i--) {
-			const m = messages[i]!;
+			const m = messages[i];
+			if (m === undefined) continue;
 			if (m.content._tag === "user" || m.content._tag === "user_rich")
 				return m.createdAt.getTime();
 		}
@@ -863,10 +865,11 @@ function WorkingRow({ messages }: { messages: ReadonlyArray<Message> }) {
 	}, []);
 
 	const elapsed = anchorMs === null ? 0 : Math.max(0, now - anchorMs);
+	const activityState = deriveAgentActivityState(messages);
 
 	return (
-		<div className="flex items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground">
-			<Spinner className="size-3" />
+		<div className="flex min-h-9 items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground">
+			<AgentActivityOrb state={activityState} />
 			<ShimmerText tone="lime" className="tabular-nums">
 				{formatElapsed(elapsed)}
 			</ShimmerText>

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -14,6 +14,10 @@ import {
 } from "@zuse/contracts";
 import { Plus, X } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
+import {
+	type AgentActivityState,
+	deriveAgentActivityState,
+} from "../lib/agent-activity-state.ts";
 import { deriveChatAttentionState } from "../lib/chat-attention-state.ts";
 import {
 	activeChatId as deriveActiveChatId,
@@ -28,6 +32,7 @@ import { useSettingsStore } from "../store/settings.ts";
 import { useUiStore } from "../store/ui.ts";
 import { FileIcon } from "./file-icon.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
+import { AgentActivityOrb } from "./ui/agent-activity-orb.tsx";
 import { Spinner } from "./ui/spinner";
 
 type Props = {
@@ -185,6 +190,9 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
 							providerId={session.providerId}
 							booting={session.status === "booting"}
 							running={runningBySession[session.id] === true}
+							activityState={deriveAgentActivityState(
+								sidebarMessagesBySession[session.id] ?? [],
+							)}
 							awaitingPermission={awaitingPermission.has(session.id)}
 							awaitingPlanApproval={
 								awaitingPlanApproval.has(session.id) ||
@@ -334,6 +342,7 @@ function ChatTabButton({
 	providerId,
 	booting,
 	running,
+	activityState,
 	awaitingPermission,
 	awaitingPlanApproval,
 	onClick,
@@ -345,6 +354,7 @@ function ChatTabButton({
 	providerId: ProviderId;
 	booting: boolean;
 	running: boolean;
+	activityState: AgentActivityState;
 	awaitingPermission: boolean;
 	awaitingPlanApproval: boolean;
 	onClick: () => void;
@@ -364,30 +374,27 @@ function ChatTabButton({
 				title={title ?? label}
 				className="flex h-full min-w-0 flex-1 items-center gap-1.5 py-0 leading-none"
 			>
-				{awaitingPlanApproval ? (
-					<span
-						className="inline-flex size-3.5 shrink-0 items-center justify-center text-emerald-300"
-						title="Plan ready to approve"
-					>
-						<HugeiconsIcon icon={TaskDone01Icon} className="size-3.5" />
-					</span>
-				) : awaitingPermission ? (
-					<span
-						className="inline-flex size-3.5 shrink-0 items-center justify-center text-amber-300"
-						title="Waiting for permission"
-					>
-						<HugeiconsIcon icon={SquareLock01Icon} className="size-3.5" />
-					</span>
-				) : booting || running ? (
-					<span className="inline-flex size-3.5 shrink-0 items-center justify-center text-foreground">
-						<Spinner className="size-3.5" />
-					</span>
-				) : (
-					<ProviderIcon
-						providerId={providerId}
-						className="size-3.5 shrink-0 text-foreground"
-					/>
-				)}
+				<span className="inline-grid size-5 shrink-0 place-items-center">
+					{awaitingPlanApproval ? (
+						<span className="text-emerald-300" title="Plan ready to approve">
+							<HugeiconsIcon icon={TaskDone01Icon} className="size-3.5" />
+						</span>
+					) : awaitingPermission ? (
+						<span className="text-amber-300" title="Waiting for permission">
+							<HugeiconsIcon icon={SquareLock01Icon} className="size-3.5" />
+						</span>
+					) : booting || running ? (
+						<AgentActivityOrb
+							state={booting ? "working" : activityState}
+							label={booting ? "Starting agent" : `Agent is ${activityState}`}
+						/>
+					) : (
+						<ProviderIcon
+							providerId={providerId}
+							className="size-3.5 text-foreground"
+						/>
+					)}
+				</span>
 				<span
 					className="truncate leading-none"
 					aria-live={booting ? "polite" : undefined}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -78,6 +78,7 @@ import { useUsageLimitsStore } from "../store/usage-limits.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { BranchIcon, type BranchState } from "./branch-icon.tsx";
 import { ProjectAddMenu } from "./project-add-menu.tsx";
+import { AgentActivityOrb } from "./ui/agent-activity-orb.tsx";
 import { Spinner } from "./ui/spinner";
 
 const sidebarErrorToastCache = {
@@ -1160,19 +1161,13 @@ function ChatRow({ chat }: { chat: Chat }) {
 					)}
 					title={chat.title}
 				>
-					{attentionState !== "idle" ? (
-						<ChatAttentionIcon
-							state={attentionState}
-							selected={isSelected}
-							className="ml-3"
-						/>
-					) : (
-						<BranchIcon
-							state={branchState}
-							selected={isSelected}
-							className="ml-3"
-						/>
-					)}
+					<span className="ml-3 inline-grid size-5 shrink-0 place-items-center">
+						{attentionState !== "idle" ? (
+							<ChatAttentionIcon state={attentionState} selected={isSelected} />
+						) : (
+							<BranchIcon state={branchState} selected={isSelected} />
+						)}
+					</span>
 					<TypewriterText
 						text={chat.title}
 						className="min-w-0 flex-1 truncate"
@@ -1307,26 +1302,40 @@ function ChatAttentionIcon({
 					: context === "project"
 						? "Agent is working in a session"
 						: "Agent is working";
+	const classes = cn(
+		"inline-grid size-5 shrink-0 place-items-center",
+		color,
+		className,
+	);
+
+	if (state === "running") {
+		return (
+			<span className={classes} title={label}>
+				<AgentActivityOrb state="working" label={label} />
+			</span>
+		);
+	}
 
 	return (
-		<span
-			role="img"
-			className={cn(
-				"inline-flex size-3.5 shrink-0 items-center justify-center",
-				color,
-				className,
-			)}
-			aria-label={label}
-			title={label}
-		>
-			{state === "running" ? (
-				<Spinner className="size-4" />
-			) : state === "question" ? (
-				<HugeiconsIcon icon={HelpCircleIcon} className="size-3.5" />
+		<span className={classes} role="img" aria-label={label} title={label}>
+			{state === "question" ? (
+				<HugeiconsIcon
+					icon={HelpCircleIcon}
+					className="size-3.5"
+					aria-hidden="true"
+				/>
 			) : state === "permission" ? (
-				<HugeiconsIcon icon={SquareLock01Icon} className="size-3.5" />
+				<HugeiconsIcon
+					icon={SquareLock01Icon}
+					className="size-3.5"
+					aria-hidden="true"
+				/>
 			) : (
-				<HugeiconsIcon icon={TaskDone01Icon} className="size-3.5" />
+				<HugeiconsIcon
+					icon={TaskDone01Icon}
+					className="size-3.5"
+					aria-hidden="true"
+				/>
 			)}
 		</span>
 	);

--- a/apps/renderer/src/components/ui/agent-activity-orb.tsx
+++ b/apps/renderer/src/components/ui/agent-activity-orb.tsx
@@ -1,0 +1,37 @@
+import type React from "react";
+import { ThinkingOrb } from "thinking-orbs";
+import type { AgentActivityState } from "~/lib/agent-activity-state";
+import { cn } from "~/lib/utils";
+
+type AgentActivityOrbProps = {
+	readonly state?: AgentActivityState;
+	readonly label?: string;
+	readonly size?: "compact" | "prominent";
+	readonly className?: string;
+};
+
+const PIXELS_BY_SIZE = {
+	compact: 20,
+	prominent: 64,
+} as const;
+
+/**
+ * Project wrapper for agent-only activity. The dependency owns theme changes,
+ * reduced-motion rendering, and offscreen/hidden-tab pausing.
+ */
+export function AgentActivityOrb({
+	state = "working",
+	label,
+	size = "compact",
+	className,
+}: AgentActivityOrbProps): React.ReactElement {
+	return (
+		<ThinkingOrb
+			state={state}
+			size={PIXELS_BY_SIZE[size]}
+			theme="auto"
+			aria-label={label}
+			className={cn("shrink-0", className)}
+		/>
+	);
+}

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -10,6 +10,7 @@ import { useActiveContext } from "../store/active-workspace.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
+import { AgentActivityOrb } from "./ui/agent-activity-orb.tsx";
 import { Button } from "./ui/button.tsx";
 import { ShimmerText } from "./ui/shimmer-text.tsx";
 import { Spinner } from "./ui/spinner";
@@ -159,6 +160,10 @@ export function SetupCardView({ data }: { data: SetupCardData }) {
 		providerState === "active" ||
 		setupStatus === "running" ||
 		setupStatus === "pending";
+	const activityState =
+		worktreePending || setupStatus === "running" || setupStatus === "pending"
+			? "shaping"
+			: "working";
 
 	const name = worktreeName ?? "your workspace";
 
@@ -179,14 +184,23 @@ export function SetupCardView({ data }: { data: SetupCardData }) {
 							"Creating a worktree and running setup"
 						)}
 					</span>
-					{busy ? (
-						<Spinner className="size-3.5 text-muted-foreground" />
-					) : failed ? (
-						<HugeiconsIcon
-							icon={Alert01Icon}
-							className="size-4 text-[var(--accent-red)]"
-						/>
-					) : null}
+					<span className="inline-grid size-5 shrink-0 place-items-center">
+						{busy ? (
+							<AgentActivityOrb
+								state={activityState}
+								label={
+									activityState === "shaping"
+										? "Preparing workspace"
+										: `Starting ${providerLabel}`
+								}
+							/>
+						) : failed ? (
+							<HugeiconsIcon
+								icon={Alert01Icon}
+								className="size-4 text-[var(--accent-red)]"
+							/>
+						) : null}
+					</span>
 				</header>
 				<div className="flex flex-col gap-1.5 px-3.5 py-2.5 text-[12px]">
 					{hasWorktree ? (

--- a/apps/renderer/src/lib/agent-activity-state.ts
+++ b/apps/renderer/src/lib/agent-activity-state.ts
@@ -1,0 +1,140 @@
+import type { Message } from "@zuse/contracts";
+import type { OrbState } from "thinking-orbs";
+
+export type AgentActivityState = OrbState;
+
+const SEARCHING_TOOLS = new Set([
+	"glob",
+	"grep",
+	"listdir",
+	"listdirectory",
+	"read",
+	"readfile",
+	"search",
+	"viewimage",
+	"webfetch",
+	"websearch",
+]);
+
+const SHAPING_TOOLS = new Set([
+	"apply_patch",
+	"edit",
+	"multiedit",
+	"write",
+	"writefile",
+]);
+
+const SOLVING_TOOLS = new Set(["bash", "exec_command"]);
+
+const normalizeToolName = (tool: string): string =>
+	tool.replace(/^mcp__memoize__/, "mcp__zuse__").toLowerCase();
+
+export const agentActivityStateForTool = (tool: string): AgentActivityState => {
+	const normalized = normalizeToolName(tool);
+	const compact = normalized.replace(/[^a-z0-9_]/g, "");
+
+	if (
+		normalized === "askuserquestion" ||
+		normalized.endsWith("__ask_user_question")
+	) {
+		return "listening";
+	}
+
+	if (
+		SEARCHING_TOOLS.has(compact) ||
+		normalized.includes("__browser_") ||
+		normalized.includes("search") ||
+		normalized.includes("grep") ||
+		normalized.includes("glob") ||
+		normalized.includes("find") ||
+		normalized.includes("fetch") ||
+		normalized.includes("read_mcp_resource") ||
+		normalized.includes("list_mcp_resource")
+	) {
+		return "searching";
+	}
+
+	if (
+		SHAPING_TOOLS.has(compact) ||
+		normalized.includes("apply_patch") ||
+		normalized.includes("file_write") ||
+		normalized.includes("write_file") ||
+		normalized.includes("create_file") ||
+		normalized.includes("multi_edit")
+	) {
+		return "shaping";
+	}
+
+	if (
+		SOLVING_TOOLS.has(compact) ||
+		normalized.includes("shell") ||
+		normalized.includes("terminal") ||
+		normalized.includes("command") ||
+		normalized.includes("compile") ||
+		normalized.includes("build") ||
+		normalized.includes("test") ||
+		normalized.includes("diagnos")
+	) {
+		return "solving";
+	}
+
+	return "working";
+};
+
+const isTurnInput = (message: Message): boolean => {
+	const tag = message.content._tag;
+	return (
+		tag === "user" || tag === "user_rich" || tag === "user_question_answer"
+	);
+};
+
+/**
+ * Resolve the best-known activity for the current live turn. Only unmatched
+ * tool calls receive a semantic tool state: after a result lands, the agent is
+ * simply working again until it emits its next visible action.
+ */
+export const deriveAgentActivityState = (
+	messages: ReadonlyArray<Message>,
+): AgentActivityState => {
+	let turnStart = -1;
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (message !== undefined && isTurnInput(message)) {
+			turnStart = index;
+			break;
+		}
+	}
+
+	const completedTools = new Set<string>();
+	const answeredQuestions = new Set<string>();
+	for (let index = turnStart + 1; index < messages.length; index += 1) {
+		const content = messages[index]?.content;
+		if (content?._tag === "tool_result") completedTools.add(content.itemId);
+		if (content?._tag === "user_question_answer") {
+			answeredQuestions.add(content.itemId);
+		}
+	}
+
+	for (let index = messages.length - 1; index > turnStart; index -= 1) {
+		const message = messages[index];
+		if (message === undefined) continue;
+		const content = message.content;
+		switch (content._tag) {
+			case "assistant":
+				if (content.text.trim().length > 0) return "composing";
+				break;
+			case "user_question":
+				if (!answeredQuestions.has(content.itemId)) return "listening";
+				break;
+			case "tool_use":
+				if (!completedTools.has(content.itemId)) {
+					return agentActivityStateForTool(content.tool);
+				}
+				break;
+			case "tool_result":
+				return "working";
+		}
+	}
+
+	return "working";
+};

--- a/apps/renderer/test/unit/agent-activity-state.test.ts
+++ b/apps/renderer/test/unit/agent-activity-state.test.ts
@@ -1,0 +1,121 @@
+import type { Message, SessionId } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+import {
+	agentActivityStateForTool,
+	deriveAgentActivityState,
+} from "../../src/lib/agent-activity-state.ts";
+
+const sessionId = "session-activity" as SessionId;
+
+function message(id: string, content: Message["content"]): Message {
+	return {
+		id,
+		sessionId,
+		role:
+			content._tag === "user" ||
+			content._tag === "user_rich" ||
+			content._tag === "user_question_answer"
+				? "user"
+				: "assistant",
+		content,
+		createdAt: new Date("2026-07-22T00:00:00.000Z"),
+	} as Message;
+}
+
+describe("agent activity state", () => {
+	it.each([
+		["Read", "searching"],
+		["Grep", "searching"],
+		["WebSearch", "searching"],
+		["mcp__zuse__browser_navigate", "searching"],
+		["Edit", "shaping"],
+		["WriteFile", "shaping"],
+		["apply_patch", "shaping"],
+		["Bash", "solving"],
+		["exec_command", "solving"],
+		["run_tests", "solving"],
+		["AskUserQuestion", "listening"],
+		["Task", "working"],
+		["future_unknown_tool", "working"],
+	] as const)("maps %s to %s", (tool, expected) => {
+		expect(agentActivityStateForTool(tool)).toBe(expected);
+	});
+
+	it("uses working for an empty live turn", () => {
+		expect(deriveAgentActivityState([])).toBe("working");
+	});
+
+	it("uses the latest unmatched tool call", () => {
+		expect(
+			deriveAgentActivityState([
+				message("u1", { _tag: "user", text: "Find the config" }),
+				message("t1", {
+					_tag: "tool_use",
+					itemId: "tool-1" as never,
+					tool: "Glob",
+					input: {},
+				}),
+			]),
+		).toBe("searching");
+	});
+
+	it("falls back to working after a tool completes", () => {
+		expect(
+			deriveAgentActivityState([
+				message("u1", { _tag: "user", text: "Run the tests" }),
+				message("t1", {
+					_tag: "tool_use",
+					itemId: "tool-1" as never,
+					tool: "Bash",
+					input: {},
+				}),
+				message("r1", {
+					_tag: "tool_result",
+					itemId: "tool-1" as never,
+					output: "passed",
+					isError: false,
+				}),
+			]),
+		).toBe("working");
+	});
+
+	it("uses composing for live assistant text", () => {
+		expect(
+			deriveAgentActivityState([
+				message("u1", { _tag: "user", text: "Explain it" }),
+				message("a1", { _tag: "assistant", text: "The issue is" }),
+			]),
+		).toBe("composing");
+	});
+
+	it("uses listening for an unanswered question", () => {
+		expect(
+			deriveAgentActivityState([
+				message("u1", { _tag: "user", text: "Set this up" }),
+				message("q1", {
+					_tag: "user_question",
+					itemId: "question-1" as never,
+					questions: [],
+				}),
+			]),
+		).toBe("listening");
+	});
+
+	it("returns to working after a question is answered", () => {
+		expect(
+			deriveAgentActivityState([
+				message("u1", { _tag: "user", text: "Set this up" }),
+				message("q1", {
+					_tag: "user_question",
+					itemId: "question-1" as never,
+					questions: [],
+				}),
+				message("a1", {
+					_tag: "user_question_answer",
+					itemId: "question-1" as never,
+					answers: [],
+				}),
+			]),
+		).toBe("working");
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -199,6 +199,7 @@
         "shadcn": "^4.6.0",
         "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
+        "thinking-orbs": "^0.1.1",
         "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
@@ -4269,6 +4270,8 @@
     "terser": ["terser@5.48.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q=="],
 
     "text-encoding": ["text-encoding@0.7.0", "", {}, "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="],
+
+    "thinking-orbs": ["thinking-orbs@0.1.1", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-nLvLTGJtk74K13MmP7XiRdzFiQx7UsoZAIyBZNgXyl7Q3h2mdz0r3eKn9LCsuzb3DGOVjwDvMhtnAkIqJJRVQA=="],
 
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 


### PR DESCRIPTION
## What changed

- add a shared `AgentActivityOrb` wrapper with compact and prominent presets, automatic theme support, accessible labels, and reduced-motion behavior
- derive semantic activity states from live assistant messages and tool calls
- replace agent-running spinners in chat tabs, sidebar attention surfaces, the live generation row, and the workspace setup header
- preserve existing question, permission, plan-ready, success, error, action-button, and content-loading indicators
- add unit coverage for tool mappings, composing/listening states, pending and completed tools, and fallback behavior

## Why

Generic spinners communicate that something is busy, but not what the agent is doing. Semantic orbs make meaningful agent activity easier to scan while keeping ordinary loading UI unchanged.

## User impact

Desktop users now see compact, state-specific activity feedback for composing, searching, shaping, solving, listening, and aggregated work. Existing row heights and priority indicators remain stable.

## Validation

- renderer unit tests: 201 passed
- renderer TypeScript and state checks
- applicable Biome checks: no errors; 12 pre-existing warnings in touched legacy files
- renderer production build
- renderer bundle-size guard