### PR TITLE
Fix provider inline authentication recovery

### DIFF
--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -5,6 +5,7 @@ import {
 	ArrowRight01Icon,
 	Copy01Icon,
 	DashboardSpeedIcon,
+	LinkSquare01Icon,
 	Loading02Icon,
 	PlayIcon,
 	Settings01Icon,
@@ -30,9 +31,14 @@ import {
 	orchestrationToolName,
 	parseOrchestrationResult,
 } from "~/lib/orchestration-tools";
-import { normalizeToolCallEnvelope } from "~/lib/tool-call-envelope";
 import { attachmentUrl } from "~/lib/platform-capabilities";
-import { openExternal, useProviderLogin } from "~/lib/use-provider-login";
+import { resumeAfterProviderLogin } from "~/lib/provider-auth-recovery";
+import { normalizeToolCallEnvelope } from "~/lib/tool-call-envelope";
+import {
+	openExternal,
+	supportsProviderLogin,
+	useProviderLogin,
+} from "~/lib/use-provider-login";
 import { cn } from "~/lib/utils";
 import { useChatsStore } from "~/store/chats";
 import {
@@ -42,6 +48,7 @@ import {
 	useMessagesStore,
 } from "~/store/messages";
 import { useProvidersStore } from "~/store/providers";
+import { useSessionsStore } from "~/store/sessions";
 import { useUiStore } from "~/store/ui";
 import { useRevealAnnotation } from "./annotation/annotation-navigation.ts";
 import { AssistantMessageActions } from "./assistant-message-actions.tsx";
@@ -747,17 +754,9 @@ const PROVIDER_LABEL_FOR_ERROR: Record<ProviderId, string> = {
 	opencode: "OpenCode",
 };
 
-// Providers with a real in-app `agent.startLogin` handler — for these we offer
-// the inline one-click sign-in directly in the auth error bubble instead of
-// only pointing the user at Settings.
-const PROVIDERS_WITH_LOGIN: ReadonlySet<ProviderId> = new Set<ProviderId>([
-	"cursor",
-	"claude",
-]);
-
 /**
- * "Authentication required" card shown when a login-capable provider (Claude,
- * Cursor) reports an auth failure. Reuses the shared `useProviderLogin` flow
+ * "Authentication required" card shown when a login-capable provider reports
+ * an auth failure. Reuses the shared `useProviderLogin` flow
  * (open browser → wait for the OAuth callback → done): on success it re-probes
  * availability and clears the bottom error.
  *
@@ -784,18 +783,23 @@ function ProviderAuthCard({
 	);
 	const clearError = useMessagesStore((s) => s.clearError);
 	const retry = useMessagesStore((s) => s.retry);
+	const resumeQueue = useMessagesStore((s) => s.resumeQueue);
+	const reopenSession = useSessionsStore((s) => s.resume);
 	const { state, start, cancel } = useProviderLogin(providerId, {
 		onSuccess: () => {
 			// Re-probe first so the keychain write has landed and this card
-			// resolves (hides) before we resume — then re-send the pending message
-			// so the turn the user was blocked on actually runs. The server
-			// restarts the stale (unauthenticated) provider process on send, so it
-			// picks up the fresh credentials.
+			// resolves (hides) before recovery. Reopen the provider with the fresh
+			// credentials, then retry an existing turn or release a fresh chat's
+			// queued first message.
 			void (async () => {
 				await refreshProviders();
 				if (sessionId !== undefined) {
-					clearError(sessionId);
-					void retry(sessionId);
+					const resumed = await resumeAfterProviderLogin({
+						reopen: () => reopenSession(sessionId),
+						retry: () => retry(sessionId),
+						resumeQueue: () => resumeQueue(sessionId),
+					});
+					if (resumed) clearError(sessionId);
 				}
 			})();
 		},
@@ -830,32 +834,62 @@ function ProviderAuthCard({
 				</div>
 
 				{state.kind === "waiting" ? (
-					<div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
-						<HugeiconsIcon
-							icon={Loading02Icon}
-							className="size-3.5 animate-spin"
-							aria-hidden
-						/>
-						<ShimmerText as="span">Waiting for browser sign-in…</ShimmerText>
-						<button
-							type="button"
-							onClick={cancel}
-							className="rounded px-1 py-0.5 text-muted-foreground hover:text-foreground"
+					<div className="mt-2 flex min-h-[3.75rem] flex-col gap-2">
+						<div
+							className="flex items-center gap-2 text-[11px] text-muted-foreground"
+							role="status"
+							aria-live="polite"
 						>
-							Cancel
-						</button>
+							<HugeiconsIcon
+								icon={Loading02Icon}
+								className="size-3.5 animate-spin motion-reduce:animate-none"
+								aria-hidden
+							/>
+							<ShimmerText as="span">
+								{state.url === null
+									? `Starting ${label} sign-in…`
+									: "Waiting for browser sign-in…"}
+							</ShimmerText>
+						</div>
+						<div className="flex flex-wrap items-center gap-1.5">
+							{state.url !== null && (
+								<Button
+									type="button"
+									size="xs"
+									variant="outline"
+									onClick={() => {
+										if (state.url !== null) openExternal(state.url);
+									}}
+									className="gap-1.5"
+								>
+									<HugeiconsIcon
+										icon={LinkSquare01Icon}
+										className="size-3"
+										aria-hidden
+									/>
+									Open browser again
+								</Button>
+							)}
+							<Button type="button" size="xs" variant="ghost" onClick={cancel}>
+								Cancel
+							</Button>
+						</div>
 					</div>
 				) : state.kind === "success" ? (
-					<div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+					<div
+						className="mt-2 flex min-h-[3.75rem] items-start gap-2 text-[11px] text-muted-foreground"
+						role="status"
+						aria-live="polite"
+					>
 						<HugeiconsIcon
 							icon={Loading02Icon}
-							className="size-3.5 animate-spin"
+							className="size-3.5 animate-spin motion-reduce:animate-none"
 							aria-hidden
 						/>
 						<ShimmerText as="span">Signed in. Finishing…</ShimmerText>
 					</div>
 				) : (
-					<>
+					<div className="min-h-[3.75rem]">
 						<p className="mt-1 leading-relaxed text-muted-foreground">
 							To resolve, sign in to {label}. We&apos;ll validate the login
 							automatically.
@@ -893,7 +927,7 @@ function ProviderAuthCard({
 								Settings
 							</Button>
 						</div>
-					</>
+					</div>
 				)}
 			</div>
 		</div>
@@ -1059,7 +1093,7 @@ export function ErrorBubble({
 	if (
 		error.kind === "auth" &&
 		error.providerId !== undefined &&
-		PROVIDERS_WITH_LOGIN.has(error.providerId)
+		supportsProviderLogin(error.providerId)
 	) {
 		return (
 			<ProviderAuthCard

--- a/apps/renderer/src/components/provider-card.tsx
+++ b/apps/renderer/src/components/provider-card.tsx
@@ -38,7 +38,11 @@ import {
 	PROVIDER_STATUS_STYLES,
 } from "~/lib/provider-status";
 import { getRpcClient } from "~/lib/rpc-client";
-import { openExternal, useProviderLogin } from "~/lib/use-provider-login";
+import {
+	openExternal,
+	supportsProviderLogin,
+	useProviderLogin,
+} from "~/lib/use-provider-login";
 import { cn } from "~/lib/utils";
 import {
 	IDLE_PROVIDER_UPDATE_STATE,
@@ -67,7 +71,7 @@ const INSTALL_HINT: Record<ProviderId, string> = {
 const LOGIN_HINT: Record<ProviderId, string> = {
 	claude: "claude /login",
 	codex: "codex login",
-	grok: "grok",
+	grok: "grok login",
 	gemini: "gemini /auth",
 	cursor: "cursor-agent login",
 	opencode: "opencode auth login",
@@ -236,7 +240,7 @@ export function ProviderCard({
 				)}
 				{availability?.cliInstalled &&
 					availability.authStatus === "unauthenticated" &&
-					(providerId === "cursor" || providerId === "claude" ? (
+					(supportsProviderLogin(providerId) ? (
 						<ProviderSignInRow providerId={providerId} />
 					) : (
 						<CodeRow label="Sign in" command={LOGIN_HINT[providerId]} />
@@ -427,13 +431,13 @@ function SubscriptionRow({
 
 /**
  * One-click sign-in row for providers with a real in-app login handler
- * (`cursor`, `claude`). Click → subscribe to `agent.startLogin`, which spawns
- * the provider's `login` subcommand server-side and streams progress. The
- * first `url` event opens the OAuth page in the OS browser; the terminal
- * `done` event triggers an availability refresh and (on success) collapses the
- * row. Cancel interrupts the stream, which closes the server-side scope and
- * SIGTERMs the child process. The whole state machine lives in
- * `useProviderLogin` so the inline auth ErrorBubble can reuse it verbatim.
+ * (`cursor`, `claude`, `grok`). Click → subscribe to `provider.startLogin`,
+ * which spawns the provider's `login` subcommand server-side and streams
+ * progress. The terminal `done` event triggers an availability refresh and
+ * (on success) collapses the row. Cancel interrupts the stream, which closes
+ * the server-side scope and SIGTERMs the child process. The whole state
+ * machine lives in `useProviderLogin` so the inline auth ErrorBubble can reuse
+ * it verbatim.
  */
 function ProviderSignInRow({ providerId }: { providerId: ProviderId }) {
 	const refresh = useProvidersStore((s) => s.refresh);
@@ -459,7 +463,7 @@ function ProviderSignInRow({ providerId }: { providerId: ProviderId }) {
 				<div className="flex items-center gap-2 text-muted-foreground">
 					<HugeiconsIcon
 						icon={Loading02Icon}
-						className="size-3.5 animate-spin"
+						className="size-3.5 animate-spin motion-reduce:animate-none"
 						aria-hidden
 					/>
 					<ShimmerText as="span">
@@ -476,7 +480,7 @@ function ProviderSignInRow({ providerId }: { providerId: ProviderId }) {
 							variant="outline"
 							onClick={(e) => {
 								e.stopPropagation();
-								openExternal(state.url!);
+								if (state.url !== null) openExternal(state.url);
 							}}
 							className="h-6 px-2 text-[11px]"
 						>

--- a/apps/renderer/src/lib/provider-auth-recovery.ts
+++ b/apps/renderer/src/lib/provider-auth-recovery.ts
@@ -1,0 +1,22 @@
+export interface ProviderAuthRecoveryActions {
+	readonly reopen: () => Promise<boolean>;
+	readonly retry: () => Promise<boolean>;
+	readonly resumeQueue: () => Promise<void>;
+}
+
+/**
+ * Reconnect the provider before releasing any durable user intent.
+ *
+ * Existing chats already have a persisted user turn to retry. Fresh chats
+ * instead hold their first prompt in the startup queue, so a retry correctly
+ * reports false and recovery releases that queue item.
+ */
+export const resumeAfterProviderLogin = async (
+	actions: ProviderAuthRecoveryActions,
+): Promise<boolean> => {
+	if (!(await actions.reopen())) return false;
+	if (!(await actions.retry())) {
+		await actions.resumeQueue();
+	}
+	return true;
+};

--- a/apps/renderer/src/lib/use-provider-login.ts
+++ b/apps/renderer/src/lib/use-provider-login.ts
@@ -1,7 +1,7 @@
 import { Effect, Fiber, Stream } from "effect";
 import { useEffect, useRef, useState } from "react";
 
-import { type LoginEvent, type ProviderId } from "@zuse/contracts";
+import type { LoginEvent, ProviderId } from "@zuse/contracts";
 
 import { getRpcClient } from "./rpc-client";
 
@@ -10,6 +10,12 @@ export type ProviderLoginState =
   | { readonly kind: "waiting"; readonly url: string | null }
   | { readonly kind: "success" }
   | { readonly kind: "failed"; readonly reason: string };
+
+const PROVIDERS_WITH_INLINE_LOGIN: ReadonlySet<ProviderId> =
+  new Set<ProviderId>(["cursor", "claude", "grok"]);
+
+export const supportsProviderLogin = (providerId: ProviderId): boolean =>
+  PROVIDERS_WITH_INLINE_LOGIN.has(providerId);
 
 /**
  * Open a URL in the user's OS browser via the preload bridge (Electron's
@@ -28,9 +34,10 @@ export const openExternal = (url: string): void => {
 
 /**
  * Shared one-click provider sign-in state machine. Subscribes to
- * `agent.startLogin`, which spawns the provider's `login` subcommand
+ * `provider.startLogin`, which spawns the provider's `login` subcommand
  * server-side and streams progress. The first `url` event opens the OAuth page
- * in the OS browser; the terminal `done` event resolves to success/failure.
+ * when the provider CLI does not own browser launch; the terminal `done` event
+ * resolves to success/failure.
  * Cancel (or unmount) interrupts the stream, which closes the server-side
  * scope and SIGTERMs the child process.
  *
@@ -76,7 +83,9 @@ export function useProviderLogin(
         (event: LoginEvent) =>
           Effect.sync(() => {
             if (event._tag === "url") {
-              openExternal(event.url);
+              // Grok's official login command opens its own browser. Keep the
+              // URL for explicit recovery without opening a duplicate tab.
+              if (providerId !== "grok") openExternal(event.url);
               setState({ kind: "waiting", url: event.url });
             } else if (event._tag === "done") {
               fiberRef.current = null;

--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -64,7 +64,7 @@ export type ChatError =
   | { readonly kind: "generic"; readonly message: string };
 
 const AUTH_PATTERN =
-  /\b401\b|\bunauthorized\b|expired token|invalid_grant|signed?\s?out|sign\s?in required|please log in|please run \/login|not logged in|invalid authentication credentials|invalid api key|authorizationrequired|auth\(authorizationrequired\)|authentication failed/i;
+  /\b401\b|\bunauthorized\b|expired token|invalid_grant|signed?\s?out|sign\s?in required|please log in|please run \/login|not logged in|invalid authentication credentials|invalid api key|authorizationrequired|auth\(authorizationrequired\)|authentication (?:failed|required)/i;
 const NETWORK_PATTERN =
   /\b(network|fetch|econn|enotfound|etimedout|timeout|getaddrinfo)\b/i;
 
@@ -239,7 +239,7 @@ type MessagesState = {
    * after the user fixed the underlying issue (re-auth, network back up).
    * No-op when there's no prior user message on the session.
    */
-  readonly retry: (sessionId: SessionId) => Promise<void>;
+  readonly retry: (sessionId: SessionId) => Promise<boolean>;
 };
 
 const timelineFibers = new Map<SessionId, Fiber.Fiber<unknown, unknown>>();
@@ -248,6 +248,11 @@ const timelineRegistry = new SessionTimelineRegistry();
 const retainedTimelineSessions = new Set<SessionId>();
 const pendingTimelineSessionCreations = new Set<SessionId>();
 const timelineEvictionTimers = new Map<SessionId, ReturnType<typeof setTimeout>>();
+const timelineReconnectAttempts = new Map<SessionId, number>();
+const timelineReconnectTimers = new Map<
+	SessionId,
+	ReturnType<typeof setTimeout>
+>();
 const goalFibers = new Map<SessionId, Fiber.Fiber<unknown, unknown>>();
 let liveConnectionGeneration: number | null = null;
 let unsubscribeLiveConnection: (() => void) | null = null;
@@ -275,6 +280,7 @@ const ensureLiveConnectionSubscription = (): void => {
 		liveConnectionGeneration = snapshot.generation;
 		const sessions = [...retainedTimelineSessions];
 		for (const [sessionId, fiber] of timelineFibers) {
+			clearTimelineReconnect(sessionId);
 			timelineFibers.delete(sessionId);
 			timelineTokens.delete(sessionId);
 			void Effect.runPromise(Fiber.interrupt(fiber));
@@ -287,6 +293,38 @@ const reportActiveStreamFailure = (cause: unknown): void => {
 	const generation = liveConnectionGeneration;
 	if (generation === null) return;
 	reportRendererRpcStreamFailure(generation, cause);
+};
+
+const clearTimelineReconnect = (sessionId: SessionId): void => {
+	const timer = timelineReconnectTimers.get(sessionId);
+	if (timer !== undefined) clearTimeout(timer);
+	timelineReconnectTimers.delete(sessionId);
+	timelineReconnectAttempts.delete(sessionId);
+};
+
+const scheduleTimelineReconnect = (sessionId: SessionId): void => {
+	if (
+		!retainedTimelineSessions.has(sessionId) ||
+		pendingTimelineSessionCreations.has(sessionId) ||
+		timelineReconnectTimers.has(sessionId)
+	) {
+		return;
+	}
+	const attempt = (timelineReconnectAttempts.get(sessionId) ?? 0) + 1;
+	timelineReconnectAttempts.set(sessionId, attempt);
+	const delayMs = Math.min(100 * 2 ** (attempt - 1), 5_000);
+	timelineReconnectTimers.set(
+		sessionId,
+		setTimeout(() => {
+			timelineReconnectTimers.delete(sessionId);
+			if (
+				retainedTimelineSessions.has(sessionId) &&
+				!timelineFibers.has(sessionId)
+			) {
+				void useMessagesStore.getState().hydrate(sessionId);
+			}
+		}, delayMs),
+	);
 };
 
 export const deferTimelineUntilSessionCreated = (sessionId: SessionId): void => {
@@ -309,6 +347,7 @@ export const discardTimelineSessionCreation = (sessionId: SessionId): void => {
 export const teardownLiveStreams = async (sessionId?: SessionId): Promise<void> => {
 	if (sessionId !== undefined) {
 		retainedTimelineSessions.delete(sessionId);
+		clearTimelineReconnect(sessionId);
 		const previous = timelineEvictionTimers.get(sessionId);
 		if (previous !== undefined) clearTimeout(previous);
 		if (timelineRegistry.state(sessionId).projection?.currentTurn != null) return;
@@ -326,6 +365,9 @@ export const teardownLiveStreams = async (sessionId?: SessionId): Promise<void> 
 	stopLiveConnectionSubscription();
 	for (const timer of timelineEvictionTimers.values()) clearTimeout(timer);
 	timelineEvictionTimers.clear();
+	for (const timer of timelineReconnectTimers.values()) clearTimeout(timer);
+	timelineReconnectTimers.clear();
+	timelineReconnectAttempts.clear();
 	retainedTimelineSessions.clear();
 	pendingTimelineSessionCreations.clear();
 	const fibers = [...timelineFibers.values(), ...goalFibers.values()];
@@ -458,11 +500,18 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
 						if (timelineTokens.get(sessionId) === streamToken) {
 							timelineTokens.delete(sessionId);
 							timelineFibers.delete(sessionId);
+							scheduleTimelineReconnect(sessionId);
 							}
             }),
         ),
       );
-			const timelineFiber = Effect.runFork(messageProgram);
+			// Defer execution by one scheduler turn so the ownership token and
+			// fiber are registered before a synchronously failing RPC stream can
+			// run its finalizer. Without this boundary, an immediate termination
+			// leaves a dead fiber in the registry and suppresses reconnection.
+			const timelineFiber = Effect.runFork(
+				Effect.yieldNow.pipe(Effect.andThen(messageProgram)),
+			);
 			timelineTokens.set(sessionId, streamToken);
 			timelineFibers.set(sessionId, timelineFiber);
       const goalProvider = lookupSessionProvider(sessionId);
@@ -976,13 +1025,14 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
             annotations: c.annotations,
           }),
         );
-        return;
+        return true;
       }
       if (c._tag === "user") {
         await get().send(sessionId, c.text);
-        return;
+        return true;
       }
     }
+    return false;
   },
 }));
 

--- a/apps/renderer/test/unit/messages-store.test.ts
+++ b/apps/renderer/test/unit/messages-store.test.ts
@@ -1,5 +1,6 @@
 import type { ConnectionSnapshot } from "@zuse/client-runtime/supervisor";
 import {
+	AgentTurnId,
 	ComposerInput,
 	Message,
 	MessageId,
@@ -318,6 +319,91 @@ describe("messages store queue actions", () => {
 					},
 				}),
 			]);
+	});
+
+	it("reconnects a terminated active transcript and receives auth settlement without reload", async () => {
+		let streamCalls = 0;
+		let publishEvent: ((event: SessionTimelineFrame) => void) | undefined;
+		rpcClientFactory = () =>
+			({
+				"session.events": () => {
+					streamCalls += 1;
+					if (streamCalls === 1) {
+						return Stream.die(new Error("session event transport terminated"));
+					}
+					return Stream.callback<SessionTimelineFrame>((queue) =>
+						Effect.sync(() => {
+							publishEvent = (event) => Queue.offerUnsafe(queue, event);
+						}),
+					);
+				},
+			}) as unknown as Awaited<
+				ReturnType<typeof import("../../src/lib/rpc-client.ts").getRpcClient>
+			>;
+
+		await useMessagesStore.getState().hydrate(sessionId);
+		await expect.poll(() => streamCalls).toBe(2);
+		await expect.poll(() => publishEvent).toBeDefined();
+
+		const turnId = AgentTurnId.make("turn-auth");
+		publishEvent?.({
+			kind: "snapshot",
+			sessionId,
+			throughVersion: 1,
+			projection: SessionTimelineProjection.make({
+				messages: [],
+				status: "running",
+				currentTurn: { turnId, phase: "running" },
+				queue: QueueState.make({ items: [], paused: false }),
+				permissionMode: "default",
+				runtimeMode: "approval-required",
+			}),
+		});
+		publishEvent?.({
+			kind: "event",
+			eventId: "event-auth-error",
+			sessionId,
+			streamVersion: 2,
+			event: {
+				_tag: "MessagePersisted",
+				message: Message.make({
+					id: MessageId.make("message-auth-error"),
+					sessionId,
+					role: "assistant",
+					content: {
+						_tag: "error",
+						message: "Authentication required. Sign in to Grok to continue.",
+					},
+					createdAt: new Date("2026-06-21T00:00:02.000Z"),
+				}),
+			},
+		});
+		publishEvent?.({
+			kind: "event",
+			eventId: "event-auth-settled",
+			sessionId,
+			streamVersion: 3,
+			event: { _tag: "TurnSettled", turnId, outcome: "error" },
+		});
+		publishEvent?.({
+			kind: "event",
+			eventId: "event-auth-status",
+			sessionId,
+			streamVersion: 4,
+			event: { _tag: "StatusSet", status: "error" },
+		});
+
+		await expect
+			.poll(() => useMessagesStore.getState().messagesBySession[sessionId])
+			.toEqual([
+				expect.objectContaining({
+					id: "message-auth-error",
+					content: expect.objectContaining({ _tag: "error" }),
+				}),
+			]);
+		await expect
+			.poll(() => useMessagesStore.getState().runningBySession[sessionId])
+			.toBe(false);
 	});
 
 	it("resubscribes the active transcript after its connection generation changes", async () => {

--- a/apps/renderer/test/unit/provider-login.test.ts
+++ b/apps/renderer/test/unit/provider-login.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { resumeAfterProviderLogin } from "../../src/lib/provider-auth-recovery.ts";
+import { supportsProviderLogin } from "../../src/lib/use-provider-login.ts";
+import { classifyMessage } from "../../src/store/messages.ts";
+
+describe("provider inline login", () => {
+	it("supports every provider with a server-side login handler", () => {
+		expect(supportsProviderLogin("claude")).toBe(true);
+		expect(supportsProviderLogin("cursor")).toBe(true);
+		expect(supportsProviderLogin("grok")).toBe(true);
+		expect(supportsProviderLogin("codex")).toBe(false);
+		expect(supportsProviderLogin("gemini")).toBe(false);
+		expect(supportsProviderLogin("opencode")).toBe(false);
+	});
+
+	it("classifies the Grok session-start message as authentication", () => {
+		expect(
+			classifyMessage(
+				"Authentication required. Sign in to Grok to continue.",
+				"grok",
+			),
+		).toEqual({
+			kind: "auth",
+			providerId: "grok",
+			message: "Authentication required. Sign in to Grok to continue.",
+		});
+	});
+
+	it("does not classify entitlement failures as authentication", () => {
+		expect(
+			classifyMessage("This account does not include Grok Build.", "grok"),
+		).toEqual({
+			kind: "generic",
+			message: "This account does not include Grok Build.",
+		});
+	});
+
+	it("reopens before retrying a blocked existing-chat turn", async () => {
+		const calls: string[] = [];
+		await expect(
+			resumeAfterProviderLogin({
+				reopen: async () => {
+					calls.push("reopen");
+					return true;
+				},
+				retry: async () => {
+					calls.push("retry");
+					return true;
+				},
+				resumeQueue: async () => {
+					calls.push("queue");
+				},
+			}),
+		).resolves.toBe(true);
+		expect(calls).toEqual(["reopen", "retry"]);
+	});
+
+	it("flushes a fresh chat's startup queue when there is no sent turn", async () => {
+		const calls: string[] = [];
+		await expect(
+			resumeAfterProviderLogin({
+				reopen: async () => {
+					calls.push("reopen");
+					return true;
+				},
+				retry: async () => {
+					calls.push("retry");
+					return false;
+				},
+				resumeQueue: async () => {
+					calls.push("queue");
+				},
+			}),
+		).resolves.toBe(true);
+		expect(calls).toEqual(["reopen", "retry", "queue"]);
+	});
+});

--- a/apps/server/src/conversation/core/message-operations.ts
+++ b/apps/server/src/conversation/core/message-operations.ts
@@ -141,21 +141,20 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 		) =>
 			Effect.gen(function* () {
 				const session = yield* lookupSession(sessionId);
-				if (session.resumeStrategy === "none" || session.cursor === null) {
-					return yield* Effect.fail(
-						new SessionStartError({
-							providerId: session.providerId,
-							reason: "resume_unsupported",
-						}),
-					);
-				}
 				// Best-effort cleanup of any stale in-memory session before opening
 				// a fresh handle attached to the same DB row. Renderer subscriptions
-				// stay connected across the
-				// resume — only the event-pump fiber needs to restart.
+				// stay connected across the reopen — only the event-pump fiber needs
+				// to restart. A null cursor starts a fresh provider process for the
+				// same durable Zuse session; a persisted cursor resumes provider
+				// context when the driver supports it.
 				yield* closeProvider(sessionId);
 				yield* interruptProviderFiber(sessionId);
-				yield* openProviderSession(session, { postBootStatus: "running" });
+				yield* openProviderSession(session, {
+					// Keep a failed session held until the caller decides whether to
+					// retry its persisted turn or release its startup queue. This
+					// prevents queued follow-ups from overtaking the blocked turn.
+					postBootStatus: session.status === "error" ? undefined : "idle",
+				});
 				return yield* lookupSession(sessionId);
 			});
 

--- a/apps/server/src/conversation/core/provider-reactor-handlers.ts
+++ b/apps/server/src/conversation/core/provider-reactor-handlers.ts
@@ -33,6 +33,8 @@ const decodeProviderModelOptions = Schema.decodeUnknownEffect(
 const decodeProviderTurnInput = Schema.decodeUnknownEffect(
 	Schema.fromJsonString(ComposerInput),
 );
+const isAuthenticationRequired = (reason: string): boolean =>
+	/\bauthentication required\b/i.test(reason);
 
 export interface ProviderReactorHandlersOptions {
 	readonly reactorEffects: ReturnType<typeof makeReactorEffectJournal>;
@@ -140,18 +142,11 @@ export const makeProviderReactorHandlers = (
 								request.initialTurnId !== null &&
 								request.initialTurnId !== undefined
 							) {
-								yield* sessionDomain
-									.dispatch({
-										commandId: `${reactorInput.commandId}:initial-turn-failed`,
-										streamId: sessionId,
-										command: {
-											_tag: "SettleTurn",
-											turnId: request.initialTurnId,
-											outcome: "error",
-											settledAt: Date.now(),
-										},
-									})
-									.pipe(Effect.orDie);
+								yield* settleTurnFromReactor(
+									sessionId,
+									request.initialTurnId,
+									"error",
+								);
 							} else {
 								yield* setStatus(sessionId, "error");
 							}
@@ -213,26 +208,32 @@ export const makeProviderReactorHandlers = (
 						fileRefs: input.fileRefs,
 						skillRefs: input.skillRefs,
 					},
-				}).pipe(Effect.exit);
-				if (restarted._tag === "Success") {
+				}).pipe(
+					Effect.match({
+						onFailure: (error) => ({ ok: false as const, error }),
+						onSuccess: () => ({ ok: true as const }),
+					}),
+				);
+				if (restarted.ok) {
 					yield* reactorEffects.complete(reactorInput.commandId);
 					return;
 				}
-				yield* sessionDomain
-					.dispatch({
-						commandId: `${reactorInput.commandId}:failed`,
-						streamId: sessionId,
-						command: {
-							_tag: "SettleTurn",
-							turnId: reactorInput.command.turnId,
-							outcome: "error",
-							settledAt: Date.now(),
-						},
-					})
-					.pipe(Effect.orDie);
-				return yield* Effect.die(
-					new Error("Provider turn could not be started after durable intent"),
+				const persistedError = yield* persistMessage(sessionId, {
+					_tag: "error",
+					message: restarted.error.reason,
+				});
+				yield* ndjsonAppend(sessionId, persistedError);
+				yield* settleTurnFromReactor(
+					sessionId,
+					AgentTurnId.make(reactorInput.command.turnId),
+					"error",
 				);
+				// Authentication is recoverable through the inline login flow, so
+				// acknowledge this failed side effect and let a fresh turn retry it.
+				// Other transient failures retain the existing replay behavior.
+				if (!isAuthenticationRequired(restarted.error.reason)) {
+					return yield* Effect.die(new Error(restarted.error.reason));
+				}
 			}
 			yield* reactorEffects.complete(reactorInput.commandId);
 		});

--- a/apps/server/src/conversation/core/queue-service-runtime.ts
+++ b/apps/server/src/conversation/core/queue-service-runtime.ts
@@ -388,7 +388,14 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 			sessionId,
 		) =>
 			Effect.gen(function* () {
-				yield* lookupSession(sessionId);
+				const session = yield* lookupSession(sessionId);
+				if (session.status === "error") {
+					yield* dispatchSessionCommand(sessionId, {
+						_tag: "SetStatus",
+						status: "idle",
+						updatedAt: Date.now(),
+					});
+				}
 				yield* setPaused(sessionId, false);
 				yield* flushQueuedMessages(sessionId);
 			});

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -68,11 +68,11 @@ const SetCredential = MemoizeRpcs.toLayerHandler(
 );
 
 // Renderer subscribes to this when the user clicks the "Sign in" button on a
-// provider card or in an auth error bubble. `cursor` and `claude` have real
-// handlers — they spawn the provider's `login` subcommand, extract the OAuth
-// URL, and stream progress back. When the renderer unsubscribes (cancel,
-// navigate away, IPC drop), the stream's scope closes and the child process is
-// SIGTERM'd by the service's finalizer.
+// provider card or in an auth error bubble. `cursor`, `claude`, and `grok`
+// have real handlers — they spawn the provider's `login` subcommand, extract
+// the OAuth URL, and stream progress back. When the renderer unsubscribes
+// (cancel, navigate away, IPC drop), the stream's scope closes and the child
+// process is SIGTERM'd by the service's finalizer.
 const StartLogin = MemoizeRpcs.toLayerHandler(
 	"provider.startLogin",
 	({ providerId }) => startProviderLogin(providerId),

--- a/apps/server/src/provider/services/login-service.ts
+++ b/apps/server/src/provider/services/login-service.ts
@@ -14,22 +14,40 @@ import {
 
 // Each provider's interactive login command prints an OAuth URL to stdout (or
 // to stderr inside its TUI frame) and waits for the user to complete the flow
-// in their browser. We anchor each pattern on the provider's own hosts to
-// avoid matching install-instruction or doc URLs the CLI may also print on
-// startup.
-const CURSOR_URL_PATTERN = /https?:\/\/[^\s]*cursor\.(?:com|sh|so)\/[^\s]*/i;
+// in their browser. Fixed-host providers use an allow-list pattern. Grok may
+// use an arbitrary enterprise IdP, so its candidates are scheme/host validated
+// instead.
+type LoginUrlPolicy = (url: URL) => boolean;
+
+const hasDomain = (hostname: string, domain: string): boolean =>
+  hostname === domain || hostname.endsWith(`.${domain}`);
+
+const CURSOR_URL_POLICY: LoginUrlPolicy = ({ hostname }) =>
+  ["cursor.com", "cursor.sh", "cursor.so"].some((domain) =>
+    hasDomain(hostname, domain),
+  );
 // `claude auth login` runs an OAuth 2.0 + PKCE flow against claude.ai with a
 // localhost callback server, so it auto-completes once the browser approves —
 // no code paste-back. The authorize URL lives on claude.ai / anthropic.com.
-const CLAUDE_URL_PATTERN =
-  /https?:\/\/[^\s]*(?:claude\.ai|(?:console\.)?anthropic\.com)\/[^\s]*/i;
-const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const CLAUDE_URL_POLICY: LoginUrlPolicy = ({ hostname }) =>
+  hasDomain(hostname, "claude.ai") || hasDomain(hostname, "anthropic.com");
+const ESC = "\u001B";
+const BEL = "\u0007";
+// Constructed from a string so the source contains no control characters in a
+// regex literal. This is the same CSI/single-escape matcher used previously.
+// biome-ignore lint/complexity/useRegexLiterals: a literal is rejected for containing control characters
+const CSI_PATTERN = new RegExp(
+  "\\u001B(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])",
+  "g",
+);
+const URL_CANDIDATE_PATTERN = /https?:\/\/[^\s"'<>]+/gi;
+const TRAILING_URL_PUNCTUATION = /[),.;\]}]+$/;
 
 interface LoginSpawnSpec {
   readonly providerId: ProviderId;
   readonly command: string;
   readonly args: ReadonlyArray<string>;
-  readonly urlPattern: RegExp;
+  readonly urlPolicy?: LoginUrlPolicy;
 }
 
 const LOGIN_SPECS: Partial<Record<ProviderId, LoginSpawnSpec>> = {
@@ -37,7 +55,7 @@ const LOGIN_SPECS: Partial<Record<ProviderId, LoginSpawnSpec>> = {
     providerId: "cursor",
     command: "cursor-agent",
     args: ["login"],
-    urlPattern: CURSOR_URL_PATTERN,
+    urlPolicy: CURSOR_URL_POLICY,
   },
   claude: {
     providerId: "claude",
@@ -45,14 +63,131 @@ const LOGIN_SPECS: Partial<Record<ProviderId, LoginSpawnSpec>> = {
     // `--claudeai` selects the Claude subscription OAuth (vs `--console` API
     // billing), matching the default the interactive `/login` menu offers.
     args: ["auth", "login", "--claudeai"],
-    urlPattern: CLAUDE_URL_PATTERN,
+    urlPolicy: CLAUDE_URL_POLICY,
   },
+  grok: {
+    providerId: "grok",
+    command: "grok",
+    // Use the short-code browser approval flow. External providers still run
+    // first, and enterprise OIDC falls back to its supported loopback flow.
+    args: ["login", "--device-auth"],
+  },
+};
+
+export const getProviderLoginCommand = (
+  providerId: ProviderId,
+): {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+} | null => {
+  const spec = LOGIN_SPECS[providerId];
+  return spec === undefined
+    ? null
+    : { command: spec.command, args: spec.args };
+};
+
+const oscTerminator = (
+  raw: string,
+  from: number,
+): { readonly index: number; readonly length: number } | null => {
+  const bel = raw.indexOf(BEL, from);
+  const stringTerminator = raw.indexOf(`${ESC}\\`, from);
+  if (bel === -1 && stringTerminator === -1) return null;
+  if (bel !== -1 && (stringTerminator === -1 || bel < stringTerminator)) {
+    return { index: bel, length: BEL.length };
+  }
+  return { index: stringTerminator, length: 2 };
+};
+
+const oscHyperlinkUrls = (raw: string): ReadonlyArray<string> => {
+  const urls: string[] = [];
+  const prefix = `${ESC}]8;`;
+  let cursor = 0;
+  while (cursor < raw.length) {
+    const start = raw.indexOf(prefix, cursor);
+    if (start === -1) break;
+    const urlStart = raw.indexOf(";", start + prefix.length);
+    if (urlStart === -1) break;
+    const terminator = oscTerminator(raw, urlStart + 1);
+    if (terminator === null) break;
+    const url = raw.slice(urlStart + 1, terminator.index);
+    if (url.length > 0) urls.push(url);
+    cursor = terminator.index + terminator.length;
+  }
+  return urls;
+};
+
+const stripOscSequences = (raw: string): string => {
+  let output = "";
+  let cursor = 0;
+  while (cursor < raw.length) {
+    const start = raw.indexOf(`${ESC}]`, cursor);
+    if (start === -1) {
+      output += raw.slice(cursor);
+      break;
+    }
+    output += raw.slice(cursor, start);
+    const terminator = oscTerminator(raw, start + 2);
+    if (terminator === null) {
+      output += raw.slice(start);
+      break;
+    }
+    cursor = terminator.index + terminator.length;
+  }
+  return output;
+};
+
+export const stripLoginTerminalControls = (raw: string): string =>
+  stripOscSequences(raw).replace(CSI_PATTERN, "");
+
+const safeLoginUrl = (candidate: string): URL | null => {
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.username.length > 0 || parsed.password.length > 0) return null;
+    if (parsed.protocol === "https:") return parsed;
+    if (parsed.protocol !== "http:") return null;
+    const isLoopback =
+      parsed.hostname === "localhost" ||
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "::1" ||
+      parsed.hostname === "[::1]";
+    return isLoopback ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const normalizedUrlCandidate = (
+  candidate: string,
+  policy: LoginUrlPolicy | undefined,
+): string | null => {
+  const trimmed = candidate.replace(TRAILING_URL_PUNCTUATION, "");
+  const parsed = safeLoginUrl(trimmed);
+  if (parsed === null || (policy !== undefined && !policy(parsed))) return null;
+  return trimmed;
+};
+
+export const extractProviderLoginUrl = (
+  raw: string,
+  urlPolicy?: LoginUrlPolicy,
+): string | null => {
+  const candidates = [...oscHyperlinkUrls(raw)];
+  const cleaned = stripLoginTerminalControls(raw);
+  for (const match of cleaned.matchAll(URL_CANDIDATE_PATTERN)) {
+    if (match[0] !== undefined) candidates.push(match[0]);
+  }
+
+  for (const candidate of candidates) {
+    const normalized = normalizedUrlCandidate(candidate, urlPolicy);
+    if (normalized !== null) return normalized;
+  }
+  return null;
 };
 
 /**
  * Spawn a provider's interactive login subcommand and stream progress back
- * to the renderer. Today `cursor` and `claude` have real handlers — other
- * providers resolve to an immediate `{ kind: "done", ok: false, reason: … }`.
+ * to the renderer. Today `cursor`, `claude`, and `grok` have real handlers;
+ * other providers resolve to an immediate `done(ok=false)`.
  *
  * Cancellation: the stream is wrapped in `Stream.unwrap`, so when the
  * renderer unsubscribes (or the IPC drops), the scope closes and the
@@ -110,14 +245,14 @@ const spawnLoginProcess = (
     let exited = false;
 
     const handleLine = (raw: string): void => {
-      const cleaned = raw.replace(ANSI_PATTERN, "").trim();
+      const cleaned = stripLoginTerminalControls(raw).trim();
       if (cleaned.length === 0) return;
       Queue.offerUnsafe(events, { _tag: "log", text: cleaned });
       if (!urlEmitted) {
-        const m = cleaned.match(spec.urlPattern);
-        if (m !== null) {
+        const url = extractProviderLoginUrl(raw, spec.urlPolicy);
+        if (url !== null) {
           urlEmitted = true;
-          Queue.offerUnsafe(events, { _tag: "url", url: m[0] });
+          Queue.offerUnsafe(events, { _tag: "url", url });
         }
       }
     };
@@ -127,30 +262,29 @@ const spawnLoginProcess = (
     rlOut.on("line", handleLine);
     rlErr.on("line", handleLine);
 
-    child.once("exit", (code, signal) => {
+    const finish = (ok: boolean, reason?: string): void => {
+      if (exited) return;
       exited = true;
-      const ok = code === 0;
-      const reason = ok
-        ? undefined
-        : signal !== null
-          ? `${spec.command} login was terminated (${signal})`
-          : `${spec.command} login exited with code ${code ?? "?"}`;
       Queue.offerUnsafe(events, {
         _tag: "done",
         ok,
         ...(reason !== undefined ? { reason } : {}),
       });
       Queue.endUnsafe(events);
+    };
+
+    child.once("exit", (code, signal) => {
+      const ok = code === 0;
+      const reason = ok
+        ? undefined
+        : signal !== null
+          ? `${spec.command} login was terminated (${signal})`
+          : `${spec.command} login exited with code ${code ?? "?"}`;
+      finish(ok, reason);
     });
 
     child.once("error", (err) => {
-      exited = true;
-      Queue.offerUnsafe(events, {
-        _tag: "done",
-        ok: false,
-        reason: err.message,
-      });
-      Queue.endUnsafe(events);
+      finish(false, err.message);
     });
 
     yield* Effect.addFinalizer(() =>

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -143,6 +143,7 @@ let providerStartOrchestrationTools: Array<
 > = [];
 let failProviderStart = false;
 let failProviderSend = false;
+let providerStartFailureReason = "scripted start failure";
 let providerStartBarrier: Promise<void> | null = null;
 let testAutonomyLevel: AutonomyLevel = "approval-gated";
 let createdWorktreeCount = 0;
@@ -180,7 +181,7 @@ const StubProviderLive = Layer.succeed(ProviderService, {
 			if (failProviderStart) {
 				return yield* new AgentSessionStartError({
 					providerId: input.providerId,
-					reason: "scripted start failure",
+					reason: providerStartFailureReason,
 				});
 			}
 			return {
@@ -590,6 +591,7 @@ beforeEach(() => {
 	providerStartOrchestrationTools = [];
 	failProviderStart = false;
 	failProviderSend = false;
+	providerStartFailureReason = "scripted start failure";
 	providerStartBarrier = null;
 	testAutonomyLevel = "approval-gated";
 	createdWorktreeCount = 0;
@@ -2801,6 +2803,149 @@ describe("ConversationServices — chat & session lifecycle", () => {
 				"q_after_boot_failure",
 			]);
 			expect(providerSentTexts).toEqual([]);
+		});
+	});
+
+	it("reopens a failed startup and flushes the queued first message", async () => {
+		await withRuntime(async (run) => {
+			failProviderStart = true;
+			providerStartFailureReason =
+				"Authentication required. Sign in to Grok to continue.";
+			const created = await run(
+				Effect.flatMap(store, (service) =>
+					service.createChat({
+						projectId: PROJECT_ID,
+						providerId: "grok",
+						model: "grok-code-fast-1",
+						background: true,
+					}),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.addQueuedMessage(
+						created.initialSession.id,
+						new ComposerInput({
+							text: "send after authentication",
+							attachments: [],
+							fileRefs: [],
+							skillRefs: [],
+						}),
+						"q_auth_startup",
+					),
+				),
+			);
+			await expect
+				.poll(
+					async () =>
+						(
+							await run(
+								Effect.flatMap(store, (service) =>
+									service.getSession(created.initialSession.id),
+								),
+							)
+						).status,
+				)
+				.toBe("error");
+
+			failProviderStart = false;
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.resumeSession(created.initialSession.id),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.resumeQueuedMessages(created.initialSession.id),
+				),
+			);
+
+			await expect
+				.poll(() => providerSentTexts)
+				.toEqual(["send after authentication"]);
+			await expect
+				.poll(async () =>
+					(
+						await run(
+							Effect.flatMap(store, (service) =>
+								service.listQueuedMessages(created.initialSession.id),
+							),
+						)
+					).items,
+				)
+				.toEqual([]);
+		});
+	});
+
+	it("reopens an existing session after a turn restart fails", async () => {
+		await withRuntime(async (run) => {
+			const created = await run(
+				Effect.flatMap(store, (service) =>
+					service.createChat({
+						projectId: PROJECT_ID,
+						providerId: "grok",
+						model: "grok-code-fast-1",
+						background: true,
+					}),
+				),
+			);
+			await expect
+				.poll(
+					async () =>
+						(
+							await run(
+								Effect.flatMap(store, (service) =>
+									service.getSession(created.initialSession.id),
+								),
+							)
+						).status,
+				)
+				.toBe("idle");
+
+			failProviderSend = true;
+			failProviderStart = true;
+			providerStartFailureReason =
+				"Authentication required. Sign in to Grok to continue.";
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.sendMessage(
+						created.initialSession.id,
+						"blocked by authentication",
+					),
+				),
+			);
+			await expect
+				.poll(
+					async () =>
+						(
+							await run(
+								Effect.flatMap(store, (service) =>
+									service.getSession(created.initialSession.id),
+								),
+							)
+						).status,
+				)
+				.toBe("error");
+
+			failProviderSend = false;
+			failProviderStart = false;
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.resumeSession(created.initialSession.id),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.sendMessage(
+						created.initialSession.id,
+						"blocked by authentication",
+					),
+				),
+			);
+
+			await expect
+				.poll(() => providerSentTexts)
+				.toEqual(["blocked by authentication"]);
 		});
 	});
 

--- a/apps/server/test/unit/provider-login.test.ts
+++ b/apps/server/test/unit/provider-login.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	extractProviderLoginUrl,
+	getProviderLoginCommand,
+	stripLoginTerminalControls,
+} from "../../src/provider/services/login-service.ts";
+
+describe("provider login output", () => {
+	it("uses Grok's short-code browser approval flow", () => {
+		expect(getProviderLoginCommand("grok")).toEqual({
+			command: "grok",
+			args: ["login", "--device-auth"],
+		});
+	});
+
+	it("extracts default and enterprise browser URLs", () => {
+		expect(
+			extractProviderLoginUrl(
+				"Open https://auth.x.ai/authorize?client_id=zuse to continue.",
+			),
+		).toBe("https://auth.x.ai/authorize?client_id=zuse");
+		expect(
+			extractProviderLoginUrl(
+				"Continue at https://login.example-corp.test/oauth2/authorize",
+			),
+		).toBe("https://login.example-corp.test/oauth2/authorize");
+	});
+
+	it("extracts URLs from ANSI text and OSC hyperlinks", () => {
+		expect(
+			extractProviderLoginUrl(
+				"\u001b[32mhttps://auth.x.ai/authorize?state=abc\u001b[0m",
+			),
+		).toBe("https://auth.x.ai/authorize?state=abc");
+
+		const osc =
+			"\u001b]8;;https://sso.example.test/authorize?state=abc\u001b\\Open browser\u001b]8;;\u001b\\";
+		expect(extractProviderLoginUrl(osc)).toBe(
+			"https://sso.example.test/authorize?state=abc",
+		);
+		expect(stripLoginTerminalControls(osc)).toBe("Open browser");
+	});
+
+	it("rejects unsafe URLs while allowing loopback HTTP callbacks", () => {
+		expect(extractProviderLoginUrl("javascript:alert(1)")).toBeNull();
+		expect(
+			extractProviderLoginUrl("Open http://login.example.test/authorize"),
+		).toBeNull();
+		expect(extractProviderLoginUrl("Open http://127.0.0.1:4567/callback")).toBe(
+			"http://127.0.0.1:4567/callback",
+		);
+		expect(
+			extractProviderLoginUrl("Open https://user:secret@example.test/login"),
+		).toBeNull();
+	});
+
+	it("honors fixed-host provider policies", () => {
+		const cursorPolicy = (url: URL) =>
+			url.hostname === "cursor.com" || url.hostname.endsWith(".cursor.com");
+		expect(
+			extractProviderLoginUrl(
+				"Open https://auth.cursor.com/login",
+				cursorPolicy,
+			),
+		).toBe("https://auth.cursor.com/login");
+		expect(
+			extractProviderLoginUrl(
+				"Open https://unrelated.example.test/login",
+				cursorPolicy,
+			),
+		).toBeNull();
+		expect(
+			extractProviderLoginUrl(
+				"Open https://unrelated.example.test/cursor.com/login",
+				cursorPolicy,
+			),
+		).toBeNull();
+	});
+});

--- a/packages/agents/src/drivers/grok.ts
+++ b/packages/agents/src/drivers/grok.ts
@@ -30,11 +30,11 @@ import type { ToolCategory } from "../kernel/permission-policy.ts";
 import { getBashPolicy, getFsPolicy, getToolPolicy } from "../kernel/policy.ts";
 import { issueProviderMcpSession } from "../kernel/provider-mcp-session.ts";
 import { prefixFirstPromptWithWorkspaceInstructions } from "../kernel/workspace-instructions.ts";
-import { buildAcpPromptContent } from "./acp-image-content.ts";
 import { handleFsRequest } from "./acp/fs.ts";
 import { replyToAcpRequest } from "./acp/request-reply.ts";
 import { handleTerminalRequest } from "./acp/terminal.ts";
 import { createAcpTranslator } from "./acp/translate.ts";
+import { buildAcpPromptContent } from "./acp-image-content.ts";
 import type { BrowserSend } from "./browser-tools.ts";
 import type { GetRuntimeMode, RequestPermission } from "./claude.ts";
 import {
@@ -55,8 +55,10 @@ import {
 	GROK_MINIMUM_VERSION,
 	GROK_UPDATE_COMMAND,
 	type GrokAskUserQuestionRequest,
+	grokSessionFailureAction,
 	isSupportedGrokVersion,
 	mapGrokMode,
+	selectGrokHandshakeAuth,
 	translateGrokExtensionMethod,
 	translateGrokExtensionUpdate,
 } from "./grok/protocol.ts";
@@ -1168,20 +1170,24 @@ export const startGrokSession = (
 				);
 			}
 
-			const authIds = new Set(init.authMethods);
-			grokDiag("handshake initialize returned authMethods", [...authIds]);
+			grokDiag("handshake initialize returned authMethods", init.authMethods);
 
-			const methodId =
-				apiKey !== null && authIds.has("xai.api_key")
-					? "xai.api_key"
-					: authIds.has("cached_token")
-						? "cached_token"
-						: null;
-			if (methodId === null) {
-				throw new Error(
-					"Grok ACP offered no usable auth method. Run `grok login`, or set GROK_CODE_XAI_API_KEY.",
+			const authSelection = selectGrokHandshakeAuth(
+				init.authMethods,
+				apiKey !== null,
+			);
+			if (authSelection.kind === "interactive") {
+				throw new GrokProtocolError(
+					"auth",
+					"Authentication required. Sign in to Grok to continue.",
 				);
 			}
+			if (authSelection.kind === "unavailable") {
+				throw new Error(
+					"Grok authentication is unavailable with the current configuration. Configure the required login method or set GROK_CODE_XAI_API_KEY.",
+				);
+			}
+			const { methodId } = authSelection;
 			authMethodUsed = methodId;
 			grokDiag("choosing auth method", {
 				methodId,
@@ -1312,9 +1318,13 @@ export const startGrokSession = (
 							grokDiag("respawn failed", { reason });
 							const reconnectKind =
 								cause instanceof GrokProtocolError ? cause.kind : "transport";
-							if (reconnectKind === "auth" || reconnectKind === "billing") {
-								terminalFailure = true;
-								lifecycle.transition("error");
+							const failureAction =
+								grokSessionFailureAction(reconnectKind);
+							if (failureAction !== "continue") {
+								if (failureAction === "terminal") {
+									terminalFailure = true;
+									lifecycle.transition("error");
+								}
 								Queue.offerUnsafe(events, {
 									_tag: "Error",
 									message: reason,
@@ -1404,19 +1414,39 @@ export const startGrokSession = (
 						const errorKind =
 							cause instanceof GrokProtocolError ? cause.kind : "provider";
 						const isCancellation = errorKind === "cancellation";
-						const isTerminal = errorKind === "auth" || errorKind === "billing";
-						if (isTerminal) terminalFailure = true;
+						const failureAction = grokSessionFailureAction(errorKind);
+						const requiresUserAction = failureAction !== "continue";
+						if (failureAction === "restart") {
+							// The login command updates credentials out of process. Kill
+							// this authenticated child so the next send re-handshakes and
+							// reloads the same durable ACP conversation.
+							dead = true;
+							try {
+								child.kill("SIGTERM");
+							} catch {
+								// Child may already be closing after the auth failure.
+							}
+						}
+						if (failureAction === "terminal") terminalFailure = true;
 						if (
 							!isCancellation &&
-							!isTerminal &&
+							!requiresUserAction &&
 							dead &&
 							reconnectAttempt < 2
 						) {
 							enqueuePrompt(text, attachmentRefs, reconnectAttempt + 1);
 							return;
 						}
-						if (dead && reconnectAttempt >= 2) terminalFailure = true;
-						if (terminalFailure && lifecycle.current() !== "error")
+						if (
+							failureAction === "continue" &&
+							dead &&
+							reconnectAttempt >= 2
+						)
+							terminalFailure = true;
+						if (
+							failureAction === "terminal" &&
+							lifecycle.current() !== "error"
+						)
 							lifecycle.transition("error");
 						if (!closed && !isCancellation) {
 							Queue.offerUnsafe(events, {

--- a/packages/agents/src/drivers/grok/protocol.ts
+++ b/packages/agents/src/drivers/grok/protocol.ts
@@ -56,6 +56,45 @@ export const decodeGrokInitializeResult = (
 	};
 };
 
+export type GrokHandshakeAuthSelection =
+	| {
+			readonly kind: "method";
+			readonly methodId: "xai.api_key" | "cached_token";
+	  }
+	| {
+			readonly kind: "interactive";
+			readonly methodId: "grok.com" | "oidc";
+	  }
+	| { readonly kind: "unavailable" };
+
+/**
+ * Select an auth path from the methods advertised during ACP initialize.
+ *
+ * Interactive methods cannot be completed inside the session-start RPC
+ * because the renderer must show the browser flow first. Preserve the
+ * existing non-interactive priority, but distinguish an offered browser
+ * method from a genuinely unusable configuration so the UI can recover.
+ */
+export const selectGrokHandshakeAuth = (
+	authMethods: ReadonlyArray<string>,
+	hasApiKey: boolean,
+): GrokHandshakeAuthSelection => {
+	const ids = new Set(authMethods);
+	if (hasApiKey && ids.has("xai.api_key")) {
+		return { kind: "method", methodId: "xai.api_key" };
+	}
+	if (ids.has("cached_token")) {
+		return { kind: "method", methodId: "cached_token" };
+	}
+	if (ids.has("oidc")) {
+		return { kind: "interactive", methodId: "oidc" };
+	}
+	if (ids.has("grok.com")) {
+		return { kind: "interactive", methodId: "grok.com" };
+	}
+	return { kind: "unavailable" };
+};
+
 const NotificationMeta = Schema.Struct({
 	eventId: Schema.optional(Schema.String),
 	promptId: Schema.optional(Schema.String),
@@ -264,6 +303,22 @@ export type GrokRpcErrorKind =
 	| "transport"
 	| "unsupported-method"
 	| "provider";
+
+export type GrokSessionFailureAction = "restart" | "terminal" | "continue";
+
+/**
+ * Authentication failures are recoverable because the official login command
+ * updates credentials outside the running ACP process. Existing conversations
+ * must restart that child on their next send instead of permanently closing
+ * the in-memory session. Billing failures remain terminal.
+ */
+export const grokSessionFailureAction = (
+	kind: GrokRpcErrorKind,
+): GrokSessionFailureAction => {
+	if (kind === "auth") return "restart";
+	if (kind === "billing") return "terminal";
+	return "continue";
+};
 
 export const classifyGrokRpcError = (error: unknown): GrokRpcErrorKind => {
 	if (error === null || typeof error !== "object") return "provider";

--- a/packages/agents/test/unit/drivers/grok-protocol.test.ts
+++ b/packages/agents/test/unit/drivers/grok-protocol.test.ts
@@ -9,8 +9,10 @@ import {
 	decodeGrokNotification,
 	decodeGrokWireMethod,
 	decodePlanApprovalRequest,
+	grokSessionFailureAction,
 	isSupportedGrokVersion,
 	mapGrokMode,
+	selectGrokHandshakeAuth,
 	translateGrokExtensionMethod,
 	translateGrokExtensionUpdate,
 } from "../../../src/drivers/grok/protocol.ts";
@@ -77,6 +79,41 @@ describe("Grok native ACP protocol", () => {
 		expect(result.agentVersion).toBe("0.2.101");
 		expect(result.authMethods).toEqual(["cached_token"]);
 		expect(result.mcp).toEqual({ http: true, sse: true });
+	});
+
+	it("selects non-interactive auth with the existing priority", () => {
+		expect(
+			selectGrokHandshakeAuth(
+				["xai.api_key", "cached_token", "grok.com"],
+				true,
+			),
+		).toEqual({ kind: "method", methodId: "xai.api_key" });
+		expect(
+			selectGrokHandshakeAuth(["xai.api_key", "cached_token"], false),
+		).toEqual({ kind: "method", methodId: "cached_token" });
+	});
+
+	it("distinguishes browser auth from an unavailable configuration", () => {
+		expect(selectGrokHandshakeAuth(["grok.com"], false)).toEqual({
+			kind: "interactive",
+			methodId: "grok.com",
+		});
+		expect(selectGrokHandshakeAuth(["oidc"], false)).toEqual({
+			kind: "interactive",
+			methodId: "oidc",
+		});
+		expect(selectGrokHandshakeAuth([], false)).toEqual({
+			kind: "unavailable",
+		});
+		expect(selectGrokHandshakeAuth(["future-method"], false)).toEqual({
+			kind: "unavailable",
+		});
+	});
+
+	it("keeps authentication failures recoverable for existing sessions", () => {
+		expect(grokSessionFailureAction("auth")).toBe("restart");
+		expect(grokSessionFailureAction("billing")).toBe("terminal");
+		expect(grokSessionFailureAction("provider")).toBe("continue");
 	});
 
 	it("rejects unknown and outdated native ACP releases", () => {

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -1762,7 +1762,7 @@ export const ProviderOpencodeRemoveCustomRpc = Rpc.make(
 // One-click sign-in flow. The renderer subscribes to `provider.startLogin`,
 // which spawns the provider's `login` subcommand server-side, extracts the
 // OAuth URL the CLI prints, and reports progress back as a stream of
-// `LoginEvent`s. Today only `cursor` has a real handler; other providers
+// `LoginEvent`s. Supported providers have a real handler; other providers
 // resolve to an immediate `done(ok=false)`.
 // ---------------------------------------------------------------------------
 

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -1226,10 +1226,9 @@ export const MessagesSteerRpc = Rpc.make("messages.steer", {
 });
 
 /**
- * Re-open a stopped session against the provider. For Claude this passes
- * the persisted `cursor` to the SDK's `resume`; for Codex it currently
- * fails with `SessionStartError({ reason: "resume_unsupported" })` and the
- * renderer offers "Start new session" instead.
+ * Re-open a stopped or failed session against the provider. A persisted
+ * cursor resumes provider context when supported; without one, the provider
+ * starts a fresh process attached to the same durable application session.
  */
 export const SessionResumeRpc = Rpc.make("session.resume", {
 	payload: Schema.Struct({ sessionId: SessionId }),


### PR DESCRIPTION
## Summary

- show inline provider sign-in for authentication-required sessions
- use the official short-code browser approval flow
- reopen failed provider sessions and automatically retry blocked turns or release fresh-chat startup queues
- self-heal terminated transcript streams so authentication errors appear without reloading

## Root cause

Interactive authentication was treated as unusable during the provider handshake. Recovery also left stale provider/turn state behind, and a synchronously terminated transcript stream could remain registered as active, preventing live error and status frames from reaching the renderer until reload.

## Validation

- 80 server conversation and login tests
- 16 renderer recovery and store tests
- 15 provider protocol tests
- renderer, server, agents, and contracts type checks
- renderer production build and bundle budget checks
- focused Biome checks