### PR TITLE
Scope context handoffs to the current chat

### DIFF
--- a/apps/renderer/src/components/composer/context-tray.tsx
+++ b/apps/renderer/src/components/composer/context-tray.tsx
@@ -9,6 +9,7 @@ import {
 	fetchTranscriptMarkdown,
 	saveContextFile,
 } from "../../lib/context-handoff.ts";
+import { selectContextSources } from "../../lib/context-sources.ts";
 import { useMessagesStore } from "../../store/messages.ts";
 import { useSessionsStore } from "../../store/sessions.ts";
 import { ProviderIcon } from "../provider-icons.tsx";
@@ -16,11 +17,11 @@ import { toastManager } from "../ui/toast.tsx";
 
 /**
  * Compact tray above the composer on a fresh session. Offers one-click chips to
- * pull a sibling chat's transcript or proposed plan into this one — the text is
- * written to `.context/files/` and dropped in as a composer file chip. Sources
- * are scoped to the SAME worktree (or, for main-checkout chats, the same
- * project with no worktree) so unrelated branches never leak in. Hidden once
- * the session has a message, or when there's nothing to pull from.
+ * pull a sibling session's transcript or proposed plan into this one — the text
+ * is written to `.context/files/` and dropped in as a composer file chip.
+ * Sources are scoped to the same chat, so starting a separate chat never
+ * surfaces unrelated context. Hidden once the session has a message, or when
+ * there's nothing to pull from.
  */
 export function ContextTray({ sessionId }: { sessionId: SessionId }) {
 	const sessionsByProject = useSessionsStore((s) => s.sessionsByProject);
@@ -30,28 +31,10 @@ export function ContextTray({ sessionId }: { sessionId: SessionId }) {
 	const [plans, setPlans] = useState<Record<string, string>>({});
 	const [busy, setBusy] = useState<string | null>(null);
 
-	const current = useMemo(
-		() =>
-			Object.values(sessionsByProject)
-				.flat()
-				.find((row) => row.id === sessionId) ?? null,
+	const sources = useMemo(
+		() => selectContextSources(sessionsByProject, sessionId),
 		[sessionsByProject, sessionId],
 	);
-
-	const sources = useMemo<ReadonlyArray<Session>>(() => {
-		if (current === null) return [];
-		return Object.values(sessionsByProject)
-			.flat()
-			.filter(
-				(row) =>
-					row.id !== sessionId &&
-					row.archivedAt === null &&
-					row.projectId === current.projectId &&
-					// Same worktree only (both null = same main checkout).
-					row.worktreeId === current.worktreeId,
-			)
-			.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-	}, [sessionsByProject, current, sessionId]);
 
 	useEffect(() => {
 		let cancelled = false;

--- a/apps/renderer/src/lib/context-sources.ts
+++ b/apps/renderer/src/lib/context-sources.ts
@@ -1,0 +1,19 @@
+import type { Session, SessionId } from "@zuse/contracts";
+
+export const selectContextSources = (
+	sessionsByProject: Readonly<Record<string, ReadonlyArray<Session>>>,
+	sessionId: SessionId,
+): ReadonlyArray<Session> => {
+	const sessions = Object.values(sessionsByProject).flat();
+	const current = sessions.find((row) => row.id === sessionId);
+	if (current === undefined) return [];
+
+	return sessions
+		.filter(
+			(row) =>
+				row.id !== sessionId &&
+				row.archivedAt === null &&
+				row.chatId === current.chatId,
+		)
+		.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+};

--- a/apps/renderer/test/unit/context-sources.test.ts
+++ b/apps/renderer/test/unit/context-sources.test.ts
@@ -1,0 +1,49 @@
+import type { ChatId, FolderId, Session, SessionId } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import { selectContextSources } from "../../src/lib/context-sources.ts";
+
+const projectId = "project-1" as FolderId;
+const chatId = "chat-1" as ChatId;
+const now = new Date("2026-07-24T00:00:00.000Z");
+
+const session = (id: string, overrides: Partial<Session> = {}): Session =>
+	({
+		id: id as SessionId,
+		projectId,
+		title: id,
+		titleProvenance: "manual",
+		providerId: "codex",
+		model: "gpt-5.4",
+		status: "idle",
+		archivedAt: null,
+		cursor: null,
+		resumeStrategy: "none",
+		runtimeMode: "approval-required",
+		worktreeId: null,
+		chatId,
+		forkedFromSessionId: null,
+		forkedFromMessageId: null,
+		permissionMode: "default",
+		toolSearch: false,
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	}) as Session;
+
+describe("context sources", () => {
+	it("offers prior sessions from the same chat, but never sessions from another chat", () => {
+		const current = session("current");
+		const sameChat = session("same-chat");
+		const otherChat = session("other-chat", {
+			chatId: "chat-2" as ChatId,
+		});
+
+		expect(
+			selectContextSources(
+				{ [projectId]: [otherChat, sameChat, current] },
+				current.id,
+			).map((row) => row.id),
+		).toEqual([sameChat.id]);
+	});
+});

--- a/apps/server/src/conversation/services/conversation-services.ts
+++ b/apps/server/src/conversation/services/conversation-services.ts
@@ -360,7 +360,7 @@ export interface ConversationOperations {
 
 	/**
 	 * The latest `ExitPlanMode` plan text for a session, or `null` if none.
-	 * Backs the "Add plans" chip on a new chat.
+	 * Backs the plan context chip shown between sessions in the same chat.
 	 */
 	readonly latestPlan: (
 		sessionId: SessionId,

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -756,8 +756,9 @@ export const SessionExportTranscriptRpc = Rpc.make("session.exportTranscript", {
 
 /**
  * The most recent `ExitPlanMode` plan text for a session, or `null` if it has
- * never proposed a plan. Backs the "Add plans" chip on a new chat — cheap
- * enough to probe candidate sources without hydrating their full message log.
+ * never proposed a plan. Backs the plan context chip between sessions in one
+ * chat — cheap enough to probe candidate sources without hydrating their full
+ * message log.
  */
 export const SessionLatestPlanRpc = Rpc.make("session.latestPlan", {
 	payload: Schema.Struct({ sessionId: SessionId }),


### PR DESCRIPTION
## What changed

- filter transcript and plan context sources by `chatId`
- keep context handoff available across sessions within the same chat
- hide unrelated transcript and plan options when a separate chat is created
- add a regression test for cross-chat context leakage
- update the associated API documentation to describe chat-local behavior

## Root cause

The composer context tray selected candidate sessions by project and worktree. Separate chats can share both values, so every session in those chats appeared as an attachable transcript or plan source.

## Impact

New chats no longer receive floods of context options from unrelated chats. Existing multi-session chats can continue handing off transcripts and plans between their own sessions.

## Validation

- `bun run --cwd apps/renderer test:unit -- context-sources.test.ts` (45 files, 210 tests passed)
- `bun run --cwd apps/renderer check-types`
- `bunx biome check apps/renderer/src/lib/context-sources.ts apps/renderer/src/components/composer/context-tray.tsx apps/renderer/test/unit/context-sources.test.ts apps/server/src/conversation/services/conversation-services.ts packages/contracts/src/session.ts`
- `git diff --check`