### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0]
+
+### Changed
+- Promote Zuse to Beta and restore release checks
+- Replace target provider CLI runtime with bundled SDK (#386)
+- Scope context handoffs to the current chat (#385)
+- Fix provider inline authentication recovery (#384)
+- Safe automatic and manual naming (#383)
+- Add semantic agent activity orbs (#382)
+- Mobile: Effect Atom state, home redesign, connectivity recovery (#377)
+- Polish latest-response forking and restore desktop startup (#381)
+- Add end-to-end product analytics (#380)
+- Rebuild realtime chat and interrupt lifecycle (#379)
+- Upgrade the in-app agent browser (#376)
+- Add authenticated browser access and isolated parallel development (#375)
+- Fix assistant message forking and chat tab behavior (#374)
+- Add quarantined-fork verification: E2B passes, no egress control on the alternate
+- Make chat archiving instant and failure-safe (#373)
+- Add ADR 0033: fork identity and event-log divergence
+- Update PR-E/PR-H and Phase 1 status after tunnel+push verification (#343)
+- Add cloud storage research notes
+- Add threaded bug tracker forum
+- Add Discord community enhancement workflow
+- Add community channel setup script
+- Add reliable nearby device pairing and recovery (#370)
+- Polish renderer UI: neutral grays, glass overlays, cleaner settings (#368)
+- Add clean mobile multi-thread chats (#367)
+- Fix mobile chat scrolling and viewport boundaries (#366)
+- feat(mobile): add workspace files and change review
+- Polish mobile connections and native chat UI (#364)
+- fix: simplify paired phone access
+- chore: update iOS dependency checksums
+- fix: unify mobile connection experience
+- fix: construct encodable pairing responses
+- feat: add secure cross-device network access
+- Make renderer creation and streaming immediately responsive (#361)
+- feat: add full changes review and inline conflict resolution (#362)
+- Add native MCP discovery and authentication (#360)
+- Fix terminal input ordering and recovery (#359)
+- Modernize native ACP session interactions (#358)
+- Publish cloud platform roadmap (#357)
+- Configure agent workflow guidance (#356)
+- Rework mobile chat composer, model sheet, and turn display (#352)
+- Surface plans and subagents in environment summary (#349)
+- Finish iPhone review experience and relay reliability (#350)
+- Fix image previews in the file viewer (#348)
+- Add Linear-powered issue sessions (#347)
+- Refresh short-lived auth tokens before expiry (#346)
+
 ## [0.14.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Zuse Alpha will be documented in this file.
+All notable changes to Zuse (Beta) will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -2,7 +2,7 @@
 # auto-update in place through Squirrel.Mac. The visible app name and release
 # feed are Zuse, but macOS updater identity must remain stable.
 appId: app.memoize.desktop
-productName: Zuse Alpha
+productName: Zuse (Beta)
 copyright: © ${author}
 
 # Register the `zuse://` custom scheme so packaged builds receive the WorkOS
@@ -103,8 +103,8 @@ mac:
   entitlementsInherit: build/entitlements.mac.plist
   icon: build/icon.png
   extendInfo:
-    NSCameraUsageDescription: Zuse Alpha does not use the camera.
-    NSMicrophoneUsageDescription: Zuse Alpha does not use the microphone.
+    NSCameraUsageDescription: Zuse (Beta) does not use the camera.
+    NSMicrophoneUsageDescription: Zuse (Beta) does not use the microphone.
 
 dmg:
   writeUpdateInfo: true

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,65 +1,65 @@
 {
-	"name": "desktop",
-	"type": "module",
-	"productName": "Zuse (Beta)",
-	"version": "0.14.0",
-	"description": "Zuse (Beta) desktop app",
-	"private": true,
-	"author": {
-		"name": "Swaraj Bachu",
-		"email": "swarajkumar4444@gmail.com"
-	},
-	"homepage": "https://github.com/swarajbachu/zuse",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/swarajbachu/zuse.git"
-	},
-	"main": "dist-electron/main.cjs",
-	"scripts": {
-		"predev": "node scripts/build-local-connectivity-helper.mjs",
-		"dev": "bun run --parallel dev:bundle dev:electron",
-		"dev:bundle": "vp pack --watch",
-		"dev:electron": "node scripts/dev-electron.mjs",
-		"build": "vp pack && node scripts/main-bundle-startup-smoke.mjs",
-		"check-types": "tsc --noEmit",
-		"test": "vp test run test && node scripts/sqlite-runtime-smoke.mjs && node scripts/provider-sdk-runtime-smoke.mjs",
-		"test:unit": "vp test run test/unit",
-		"test:integration": "vp test run test/integration --passWithNoTests",
-		"postinstall": "electron-rebuild -f -o node-pty,keytar",
-		"icon": "node scripts/make-icon.mjs",
-		"native:build": "node scripts/build-local-connectivity-helper.mjs",
-		"native:build:universal": "node scripts/build-local-connectivity-helper.mjs --universal",
-		"predist:mac": "bun run native:build:universal",
-		"dist:mac": "electron-builder --mac --universal",
-		"predist:mac:unsigned": "bun run native:build:universal",
-		"dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
-	},
-	"dependencies": {
-		"@cursor/sdk": "1.0.23",
-		"electron-updater": "^6.3.9",
-		"keytar": "^7.9.0",
-		"node-pty": "^1.1.0",
-		"selfsigned": "^5.5.0",
-		"tree-sitter": "^0.21.1",
-		"tree-sitter-javascript": "^0.23.1",
-		"tree-sitter-json": "^0.24.8",
-		"tree-sitter-typescript": "^0.23.2"
-	},
-	"devDependencies": {
-		"@electron/rebuild": "^4.0.4",
-		"@zuse/server": "*",
-		"@zuse/ssh": "*",
-		"@zuse/contracts": "*",
-		"@repo/typescript-config": "*",
-		"@types/node": "catalog:",
-		"effect": "catalog:",
-		"electron-builder": "^25.1.8",
-		"electron": "^42.1.0",
-		"fix-path": "^4.0.0",
-		"sharp": "^0.34.1",
-		"tsdown": "^0.21.10",
-		"typescript": "catalog:",
-		"vite-plus": "0.2.5",
-		"vitest": "catalog:"
-	}
+  "name": "desktop",
+  "type": "module",
+  "productName": "Zuse (Beta)",
+  "version": "0.15.0",
+  "description": "Zuse (Beta) desktop app",
+  "private": true,
+  "author": {
+    "name": "Swaraj Bachu",
+    "email": "swarajkumar4444@gmail.com"
+  },
+  "homepage": "https://github.com/swarajbachu/zuse",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarajbachu/zuse.git"
+  },
+  "main": "dist-electron/main.cjs",
+  "scripts": {
+    "predev": "node scripts/build-local-connectivity-helper.mjs",
+    "dev": "bun run --parallel dev:bundle dev:electron",
+    "dev:bundle": "vp pack --watch",
+    "dev:electron": "node scripts/dev-electron.mjs",
+    "build": "vp pack && node scripts/main-bundle-startup-smoke.mjs",
+    "check-types": "tsc --noEmit",
+    "test": "vp test run test && node scripts/sqlite-runtime-smoke.mjs && node scripts/provider-sdk-runtime-smoke.mjs",
+    "test:unit": "vp test run test/unit",
+    "test:integration": "vp test run test/integration --passWithNoTests",
+    "postinstall": "electron-rebuild -f -o node-pty,keytar",
+    "icon": "node scripts/make-icon.mjs",
+    "native:build": "node scripts/build-local-connectivity-helper.mjs",
+    "native:build:universal": "node scripts/build-local-connectivity-helper.mjs --universal",
+    "predist:mac": "bun run native:build:universal",
+    "dist:mac": "electron-builder --mac --universal",
+    "predist:mac:unsigned": "bun run native:build:universal",
+    "dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
+  },
+  "dependencies": {
+    "@cursor/sdk": "1.0.23",
+    "electron-updater": "^6.3.9",
+    "keytar": "^7.9.0",
+    "node-pty": "^1.1.0",
+    "selfsigned": "^5.5.0",
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-javascript": "^0.23.1",
+    "tree-sitter-json": "^0.24.8",
+    "tree-sitter-typescript": "^0.23.2"
+  },
+  "devDependencies": {
+    "@electron/rebuild": "^4.0.4",
+    "@zuse/server": "*",
+    "@zuse/ssh": "*",
+    "@zuse/contracts": "*",
+    "@repo/typescript-config": "*",
+    "@types/node": "catalog:",
+    "effect": "catalog:",
+    "electron-builder": "^25.1.8",
+    "electron": "^42.1.0",
+    "fix-path": "^4.0.0",
+    "sharp": "^0.34.1",
+    "tsdown": "^0.21.10",
+    "typescript": "catalog:",
+    "vite-plus": "0.2.5",
+    "vitest": "catalog:"
+  }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "desktop",
 	"type": "module",
-	"productName": "Zuse Alpha",
+	"productName": "Zuse (Beta)",
 	"version": "0.14.0",
-	"description": "Zuse Alpha desktop app",
+	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {
 		"name": "Swaraj Bachu",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -214,7 +214,7 @@ const AUTH_LOOPBACK_PORTS = [8976, 8977, 8978, 8979] as const;
 // RFC 8252 native-app pattern and gives a strictly better sign-in finish:
 //   - the browser lands on a real HTML page ("Signed in, you can close this
 //     tab") instead of a dead `zuse://` URL that leaves the tab hanging, and
-//   - no OS "Open in Zuse Alpha?" prompt — the browser hits localhost and the
+//   - no OS "Open in Zuse (Beta)?" prompt — the browser hits localhost and the
 //     already-running app answers directly, no deep-link handoff needed.
 // The `zuse://auth/callback` scheme handler stays registered below as a
 // fallback (and the future mobile path), but is no longer the primary flow.
@@ -309,10 +309,10 @@ const startAuthLoopback = async (): Promise<void> => {
 		handleAuthCallback(parsed.toString());
 		res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
 		res.end(
-			`<!doctype html><meta charset="utf-8"><title>Zuse Alpha</title>` +
+			`<!doctype html><meta charset="utf-8"><title>Zuse (Beta)</title>` +
 				`<body style="font-family:-apple-system,system-ui,sans-serif;background:#0b0b0c;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">` +
 				`<div style="text-align:center"><h2 style="font-weight:600">Signed in</h2>` +
-				`<p style="color:#a3a3a3">You can close this tab and return to Zuse Alpha.</p></div>`,
+				`<p style="color:#a3a3a3">You can close this tab and return to Zuse (Beta).</p></div>`,
 		);
 		focusMainWindow();
 	});
@@ -332,7 +332,8 @@ const startAuthLoopback = async (): Promise<void> => {
 const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL?.trim() || "";
 const isDevelopment = Boolean(DEV_SERVER_URL);
 
-const APP_NAME = isDevelopment ? "Zuse Alpha (Dev)" : "Zuse Alpha";
+const APP_NAME = isDevelopment ? "Zuse (Beta) (Dev)" : "Zuse (Beta)";
+const STABLE_USER_DATA_NAME = isDevelopment ? "Zuse Alpha (Dev)" : "Zuse Alpha";
 const DESKTOP_SOURCE_DIR =
 	process.env.ZUSE_DESKTOP_DIR?.trim() || Path.resolve(__dirname, "..");
 const DEV_ICON_PATH = Path.resolve(DESKTOP_SOURCE_DIR, "build", "icon.png");
@@ -348,11 +349,10 @@ if (
 
 const ZUSE_USER_DATA_DIR =
 	process.env.ZUSE_USER_DATA_DIR?.trim() ||
-	process.env.MEMOIZE_USER_DATA_DIR?.trim();
-if (ZUSE_USER_DATA_DIR) {
-	fsSync.mkdirSync(ZUSE_USER_DATA_DIR, { recursive: true });
-	app.setPath("userData", ZUSE_USER_DATA_DIR);
-}
+	process.env.MEMOIZE_USER_DATA_DIR?.trim() ||
+	Path.join(app.getPath("appData"), STABLE_USER_DATA_NAME);
+fsSync.mkdirSync(ZUSE_USER_DATA_DIR, { recursive: true });
+app.setPath("userData", ZUSE_USER_DATA_DIR);
 
 // Single-instance lock: required so a deep link launched while the app is
 // already running routes through `second-instance` (Win/Linux) rather than
@@ -2589,7 +2589,7 @@ void app.whenReady().then(async () => {
 	// the app name. macOS reads these once at panel-open time, so it's safe
 	// to call once on startup.
 	app.setAboutPanelOptions({
-		applicationName: "Zuse Alpha",
+		applicationName: "Zuse (Beta)",
 		applicationVersion: app.getVersion(),
 		version: app.getVersion(),
 		copyright: "© Swaraj Bachu",
@@ -2673,7 +2673,7 @@ app.on("before-quit", (event) => {
 		buttons: ["Cancel", "Quit anyway", "Quit when idle"],
 		defaultId: 0,
 		cancelId: 0,
-		title: "Quit Zuse Alpha?",
+		title: "Quit Zuse (Beta)?",
 		message: `${pluralAgents(runningAgentCount)} currently.`,
 		detail:
 			"Quitting now will stop them mid-turn. You can quit anyway, or have Zuse quit automatically once they finish.",

--- a/apps/renderer/index.html
+++ b/apps/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Zuse Alpha</title>
+    <title>Zuse (Beta)</title>
     <style>
       /* No background here — it would block macOS vibrancy from showing
          through transparent panes (sidebar). Per-pane bg lives in app.tsx

--- a/apps/renderer/notch.html
+++ b/apps/renderer/notch.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Zuse Alpha Notch</title>
+    <title>Zuse (Beta) Notch</title>
     <style>
       html,
       body,

--- a/apps/renderer/src/components/cli-upgrade-banner.tsx
+++ b/apps/renderer/src/components/cli-upgrade-banner.tsx
@@ -94,7 +94,7 @@ export function CliUpgradeBanner({
 							{row.cliVersion ?? "an unknown version"}
 						</code>
 						{row.cliVersionMinRequired !== undefined &&
-							` — Zuse Alpha needs ${row.cliVersionMinRequired} or newer.`}
+							` — Zuse (Beta) needs ${row.cliVersionMinRequired} or newer.`}
 						{
 							" Sending in this session will fail until you upgrade; start a new session with a different provider to keep working in the meantime."
 						}

--- a/apps/renderer/src/components/credentials-sheet.tsx
+++ b/apps/renderer/src/components/credentials-sheet.tsx
@@ -28,7 +28,7 @@ export function CredentialsSheet() {
 					<SheetTitle>Settings · API keys</SheetTitle>
 					<SheetDescription>
 						Most users don&apos;t need this. Run <code>claude /login</code> or{" "}
-						<code>codex login</code> in your terminal and Zuse Alpha uses those
+						<code>codex login</code> in your terminal and Zuse (Beta) uses those
 						credentials automatically. API keys here are an advanced fallback,
 						stored in your OS keychain and only sent to the provider&apos;s SDK.
 					</SheetDescription>

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -968,7 +968,7 @@ function GeminiUpgradeCard({ onDismiss }: { onDismiss?: () => void }) {
 						</div>
 						<p className="mt-1 leading-relaxed text-muted-foreground">
 							Your installed Gemini CLI does not support ACP mode yet, so Zuse
-							Alpha cannot start Gemini sessions until the CLI is updated.
+							Zuse (Beta) cannot start Gemini sessions until the CLI is updated.
 						</p>
 						<div className="mt-3 flex flex-wrap items-center gap-2">
 							<code className="rounded-md border border-border/60 bg-background/60 px-2 py-1 font-mono text-[11px] text-foreground">

--- a/apps/renderer/src/components/onboarding/steps/done.tsx
+++ b/apps/renderer/src/components/onboarding/steps/done.tsx
@@ -26,7 +26,7 @@ export function DoneStep({ onFinish }: { onFinish: () => void }) {
 				</p>
 			</div>
 			<Button size="default" onClick={onFinish} className="rounded-lg px-6">
-				Open Zuse Alpha
+				Open Zuse (Beta)
 			</Button>
 		</div>
 	);

--- a/apps/renderer/src/components/onboarding/steps/provider.tsx
+++ b/apps/renderer/src/components/onboarding/steps/provider.tsx
@@ -359,7 +359,7 @@ function ProviderStatus({
         : state.kind === "subscription"
           ? "Your CLI login was detected, but the required paid plan was not confirmed."
           : state.kind === "outdated"
-            ? `${PROVIDER_LABEL[providerId]} ${state.current} is too old; Zuse Alpha needs ${state.required}.`
+            ? `${PROVIDER_LABEL[providerId]} ${state.current} is too old; Zuse (Beta) needs ${state.required}.`
             : `${PROVIDER_LABEL[providerId]}'s CLI isn't on your PATH yet.`;
 
   const command =

--- a/apps/renderer/src/components/onboarding/steps/welcome.tsx
+++ b/apps/renderer/src/components/onboarding/steps/welcome.tsx
@@ -3,7 +3,7 @@ export function WelcomeStep() {
     <div className="flex h-full flex-col gap-10">
       <div className="flex flex-col gap-3">
         <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
-          Welcome to Zuse Alpha
+          Welcome to Zuse (Beta)
         </span>
         <h1 className="text-4xl font-semibold leading-[1.05] tracking-tight text-foreground">
           Every agent,

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -1252,7 +1252,7 @@ function GeneralPane() {
 				) : (
 					<SettingsRow
 						title="Not signed in"
-						description="You're using Zuse Alpha locally without an account. Sign in to sync and unlock remote agents."
+						description="You're using Zuse (Beta) locally without an account. Sign in to sync and unlock remote agents."
 						action={
 							<Button
 								variant="settings"
@@ -1442,7 +1442,7 @@ function GeneralPane() {
 
 			<SettingsGroup
 				title="Workspace naming"
-				description="Controls how Zuse Alpha names new worktree-backed branches."
+				description="Controls how Zuse (Beta) names new worktree-backed branches."
 			>
 				<SettingsRow
 					title="Branch naming"
@@ -1674,7 +1674,7 @@ function ProvidersPane() {
 				</div>
 				<FrameFooter className="px-2 py-1 w-full">
 					<p className="text-xs leading-relaxed text-muted-foreground">
-						Zuse Alpha uses your existing CLI credentials — Claude Code, Codex,
+						Zuse (Beta) uses your existing CLI credentials — Claude Code, Codex,
 						Grok, Gemini, Cursor, and OpenCode all sign in through their own
 						login flows.
 					</p>

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -437,7 +437,7 @@ function WorktreeSection({
 			<div className="flex flex-col">
 				{sorted.length === 0 ? (
 					<p className="px-4 py-8 text-center text-xs text-muted-foreground">
-						No worktrees yet. Zuse Alpha creates one for you when you start a
+						No worktrees yet. Zuse (Beta) creates one for you when you start a
 						new chat.
 					</p>
 				) : (

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -110,7 +110,7 @@ export function TopBarLeft() {
 			className={`${SECTION_CLASS} pr-1 ${isFullScreen ? "pl-3" : "pl-20"}`}
 		>
 			<span className="truncate font-semibold tracking-tight text-foreground">
-				Zuse Alpha
+				Zuse (Beta)
 			</span>
 			<span className="flex-1" />
 			<Tooltip>

--- a/apps/renderer/src/components/update-banner.tsx
+++ b/apps/renderer/src/components/update-banner.tsx
@@ -139,7 +139,7 @@ export function UpdateBanner() {
 						{isError && status.message}
 						{status.kind === "ready" &&
 							!confirming &&
-							`Zuse Alpha ${status.version} is ready. Restart to finish installing.`}
+							`Zuse (Beta) ${status.version} is ready. Restart to finish installing.`}
 						{status.kind === "ready" &&
 							confirming &&
 							`${

--- a/apps/server/test/unit/usage-cache.test.ts
+++ b/apps/server/test/unit/usage-cache.test.ts
@@ -33,7 +33,7 @@ const emptyUsage = (id: string): PricedUsage => ({
 	sources: [
 		{
 			id: "zuse",
-			label: `Zuse Alpha ${id}`,
+			label: `Zuse (Beta) ${id}`,
 			detected: true,
 			recordCount: 0,
 			paths: [],
@@ -206,7 +206,7 @@ describe("usage report cache", () => {
 		const records = Array.from({ length: 300 }, (_, index) =>
 			makeUsageRecord({
 				sourceId: "zuse",
-				sourceLabel: "Zuse Alpha",
+				sourceLabel: "Zuse (Beta)",
 				providerId: "codex",
 				model: "gpt-5.4",
 				sessionId: `session-${index}`,
@@ -234,7 +234,7 @@ describe("usage report cache", () => {
 		const records = Array.from({ length: 5_000 }, (_, index) =>
 			makeUsageRecord({
 				sourceId: "zuse",
-				sourceLabel: "Zuse Alpha",
+				sourceLabel: "Zuse (Beta)",
 				providerId: "codex",
 				model: `model-${index % 8}`,
 				sessionId: `session-${index}`,
@@ -263,7 +263,7 @@ describe("usage report cache", () => {
 			(label, index) =>
 				makeUsageRecord({
 					sourceId: "zuse",
-					sourceLabel: "Zuse Alpha",
+					sourceLabel: "Zuse (Beta)",
 					providerId: "codex",
 					model: "gpt-5.4",
 					sessionId: label,

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -7,7 +7,7 @@ import { BlogCard } from "@/components/resources/blog-card";
 export const metadata = getSEO({
   title: "Blog",
   description:
-    "Release notes, changelog, and deep dives on Zuse Alpha — the chat-first macOS workspace for AI coding agents.",
+    "Release notes, changelog, and deep dives on Zuse (Beta) — the chat-first macOS workspace for AI coding agents.",
   path: "/blog",
 });
 

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -5,7 +5,7 @@ import { getSEO } from "@/lib/seo";
 
 export const metadata = getSEO({
   title: "Change Log",
-  description: "All notable Zuse Alpha product changes, grouped by release.",
+  description: "All notable Zuse (Beta) product changes, grouped by release.",
   path: "/changelog",
 });
 
@@ -28,7 +28,7 @@ export default async function ChangelogPage() {
         <div className="flex max-w-3xl flex-col gap-5">
           <Header>Change Log</Header>
           <p className="text-muted-foreground text-lg leading-8">
-            Product updates, fixes, and release notes for Zuse Alpha.
+            Product updates, fixes, and release notes for Zuse (Beta).
           </p>
         </div>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,7 @@ import { Projects } from "@/components/projects";
 export const metadata = getSEO({
   title: "Token max every coding agent",
   description:
-    "Zuse Alpha is a local-first macOS workspace for developers who want to code all day, max out their AI subscriptions, and ship more parallel attempts safely.",
+    "Zuse (Beta) is a local-first macOS workspace for developers who want to code all day, max out their AI subscriptions, and ship more parallel attempts safely.",
   path: "/",
 });
 

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -4,7 +4,7 @@ export default function PrivacyPage() {
 	return (
 		<main className="mx-auto min-h-screen max-w-3xl px-6 py-20 text-foreground">
 			<Link href="/" className="text-sm text-primary">
-				← Back to Zuse Alpha
+				← Back to Zuse (Beta)
 			</Link>
 			<h1 className="mt-8 text-4xl font-semibold">Privacy policy</h1>
 			<p className="mt-3 text-sm text-muted-foreground">
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
 					</h2>
 					<p className="mt-2">
 						Chats, project data, and settings remain on your devices. Model
-						requests go to the provider you choose. Zuse Alpha does not upload
+						requests go to the provider you choose. Zuse (Beta) does not upload
 						prompts, responses, reasoning, source code, commands, tool contents,
 						file or repository names, paths, URLs, branches, titles, diagnostics
 						contents, account details, credentials, tokens, or error stacks for

--- a/apps/web/components/about/index.tsx
+++ b/apps/web/components/about/index.tsx
@@ -27,7 +27,7 @@ export const AboutSection = () => {
             Code all day. Keep the agents busy.
           </h2>
           <p className="text-muted-foreground text-base leading-6 font-medium md:text-lg md:leading-7">
-            Zuse Alpha is for people who want to become the kind of builder who can
+            Zuse (Beta) is for people who want to become the kind of builder who can
             keep multiple projects moving, max out their AI subscriptions, and
             still know exactly what changed.
           </p>

--- a/apps/web/components/bento-one/index.tsx
+++ b/apps/web/components/bento-one/index.tsx
@@ -16,7 +16,7 @@ const features = [
   },
   {
     title: "Stay local and keep the margin",
-    body: "Bring your own keys. Chats stay in SQLite, keys stay in Keychain, and Zuse Alpha adds no token markup.",
+    body: "Bring your own keys. Chats stay in SQLite, keys stay in Keychain, and Zuse (Beta) adds no token markup.",
   },
 ];
 

--- a/apps/web/components/blogs/blog-cta-section.tsx
+++ b/apps/web/components/blogs/blog-cta-section.tsx
@@ -10,13 +10,13 @@ export const BlogCtaSection = () => {
             Token max every coding agent from one Mac app.
           </span>
           <span className="-tracking-xs text-muted-foreground text-base leading-6 font-medium">
-            Zuse Alpha is for power users running Claude Code, Codex, Cursor,
+            Zuse (Beta) is for power users running Claude Code, Codex, Cursor,
             Gemini, Grok, and OpenCode across real projects. Keep the agents
             busy, isolate the work, and review the diffs before anything lands.
           </span>
           <span className="-tracking-xs text-muted-foreground text-base leading-6 font-medium">
             It is local-first by design: chats in SQLite on disk, keys in the
-            macOS Keychain. Bring your own keys and run it free during alpha.
+            macOS Keychain. Bring your own keys and run it free during beta.
           </span>
           <div>
             <Button />

--- a/apps/web/components/comparison/comparison-accordion.tsx
+++ b/apps/web/components/comparison/comparison-accordion.tsx
@@ -35,7 +35,7 @@ export const ComparisonAccordion = ({ cards }: { cards: ComparisonData[] }) => {
                 <div className="flex items-center gap-3">
                   <LogoMark className="size-7" />
                   <span className="-tracking-sm text-foreground text-lg leading-4.5 font-medium">
-                    Zuse Alpha
+                    Zuse (Beta)
                   </span>
                 </div>
                 <div className="flex items-center gap-3">

--- a/apps/web/components/comparison/comparison-tabel.tsx
+++ b/apps/web/components/comparison/comparison-tabel.tsx
@@ -27,7 +27,7 @@ export const ComparisonTabel = ({ cards }: { cards: ComparisonData[] }) => {
         <div data-slot="tabel-cell">
           <LogoMark className="size-7" />
           <span className="-tracking-sm text-foreground text-lg leading-4.5 font-medium">
-            Zuse Alpha
+            Zuse (Beta)
           </span>
         </div>
         <div data-slot="tabel-cell">
@@ -82,7 +82,7 @@ export const ComparisonTabel = ({ cards }: { cards: ComparisonData[] }) => {
             <CallIcon />
           </span>
           <span className="-tracking-sm text-foreground z-10 text-lg leading-4.5 font-medium">
-            Free public Alpha
+            Free public Beta
           </span>
         </div>
         <div data-slot="tabel-cell">

--- a/apps/web/components/comparison/index.tsx
+++ b/apps/web/components/comparison/index.tsx
@@ -27,7 +27,7 @@ const cardsData: InfoCardsProps[] = [
   {
     title: "No token resale",
     description:
-      "Use your own API keys or subscriptions. Zuse Alpha adds $0 markup to the model usage you run.",
+      "Use your own API keys or subscriptions. Zuse (Beta) adds $0 markup to the model usage you run.",
     icon: <DocsIcon />,
   },
   {

--- a/apps/web/components/faq/index.tsx
+++ b/apps/web/components/faq/index.tsx
@@ -15,22 +15,22 @@ const data = [
 	{
     question: "What do you mean by token maxing?",
     answer:
-      "Token maxing means using the model access you already pay for on more real work: parallel feature attempts, bug fixes, refactors, and reviews. Zuse Alpha makes that sane by keeping each run visible, isolated, and reviewable.",
+      "Token maxing means using the model access you already pay for on more real work: parallel feature attempts, bug fixes, refactors, and reviews. Zuse (Beta) makes that sane by keeping each run visible, isolated, and reviewable.",
   },
   {
-    question: "Who is Zuse Alpha for?",
+    question: "Who is Zuse (Beta) for?",
     answer:
-      "Zuse Alpha is for developers who want to become power users: people trying to code all day, keep multiple projects moving, max out their AI subscriptions, and still review exactly what ships.",
+      "Zuse (Beta) is for developers who want to become power users: people trying to code all day, keep multiple projects moving, max out their AI subscriptions, and still review exactly what ships.",
   },
   {
     question: "Which agents are supported?",
     answer:
-      "Zuse Alpha wraps six coding agent CLIs in one workspace: Claude Code, Codex, Cursor, Gemini, Grok, and OpenCode. You can run them side by side and switch providers without leaving the app.",
+      "Zuse (Beta) wraps six coding agent CLIs in one workspace: Claude Code, Codex, Cursor, Gemini, Grok, and OpenCode. You can run them side by side and switch providers without leaving the app.",
   },
   {
     question: "Do I need my own API keys or subscriptions?",
     answer:
-      "Yes. Zuse Alpha is bring your own keys. You plug in your own provider keys or subscriptions, and Zuse Alpha talks to them directly. It never resells tokens and adds $0 markup, so you only pay the agent providers.",
+      "Yes. Zuse (Beta) is bring your own keys. You plug in your own provider keys or subscriptions, and Zuse (Beta) talks to them directly. It never resells tokens and adds $0 markup, so you only pay the agent providers.",
   },
 	{
 		question: "Is my code or data sent anywhere?",
@@ -40,12 +40,12 @@ const data = [
 	{
 		question: "Is it macOS only?",
     answer:
-      "For now, yes. Zuse Alpha is a native macOS desktop app and ships as a universal build for both Apple Silicon and Intel. Other platforms may come later.",
+      "For now, yes. Zuse (Beta) is a native macOS desktop app and ships as a universal build for both Apple Silicon and Intel. Other platforms may come later.",
   },
   {
     question: "How much does it cost?",
     answer:
-      "Zuse Alpha is free while it is in public alpha. You only pay for the agent usage on your own keys. Paid Pro and Team plans are planned for later, but the alpha is free.",
+      "Zuse (Beta) is free while it is in public beta. You only pay for the agent usage on your own keys. Paid Pro and Team plans are planned for later, but the beta is free.",
   },
   {
     question: "Can I run multiple agents at once?",

--- a/apps/web/components/footer/index.tsx
+++ b/apps/web/components/footer/index.tsx
@@ -58,7 +58,7 @@ export const Footer = () => {
               "bg-[linear-gradient(90deg,#FFFFFF_0%,rgba(52,52,52,0)_100%)] bg-clip-text text-transparent",
             )}
           >
-            Zuse Alpha
+            Zuse (Beta)
           </div>
           <div className="relative z-10 grid min-h-112 grid-cols-1 gap-8 px-6 py-10 md:px-15 md:py-16 lg:grid-cols-[1fr_520px] lg:items-start">
             <div className="flex flex-col gap-8">
@@ -80,7 +80,7 @@ export const Footer = () => {
                   />
                   <div>
                     <div className="text-natural-white text-sm font-semibold">
-                      Zuse Alpha workspace
+                      Zuse (Beta) workspace
                     </div>
                     <div className="text-muted-foreground text-xs">
                       subscriptions ready
@@ -89,7 +89,7 @@ export const Footer = () => {
                 </div>
                 <Link
                   href={DOWNLOAD_URL}
-                  aria-label="Download Zuse Alpha for Mac"
+                  aria-label="Download Zuse (Beta) for Mac"
                   className="bg-primary text-primary-foreground shadow-card-md inline-flex size-12 items-center justify-center rounded-xl"
                 >
                   <ArrowRightLongerIcon className="scale-125" />
@@ -165,7 +165,7 @@ export const Footer = () => {
               <span className="flex items-center gap-1">
                 <CopyRightIcon />
                 <span className="text-muted-foreground text-xs leading-5 font-medium">
-                  2026 Zuse Alpha — All Rights Reserved
+                  2026 Zuse (Beta) — All Rights Reserved
                 </span>
               </span>
             </div>

--- a/apps/web/components/hero/index.tsx
+++ b/apps/web/components/hero/index.tsx
@@ -84,10 +84,10 @@ export const Hero = () => {
             >
               <div className="flex items-center gap-1 sm:gap-2">
                 <div className="bg-primary text-primary-foreground rounded-full px-2 py-1 text-[10px] font-medium sm:text-xs">
-                  Alpha
+                  Beta
                 </div>
                 <div className="text-natural-white rounded-full pr-2 text-[10px] sm:text-xs">
-                  Public alpha — built for token maxing
+                  Public beta — built for token maxing
                 </div>
               </div>
             </Link>

--- a/apps/web/components/logo-cloud.tsx
+++ b/apps/web/components/logo-cloud.tsx
@@ -4,7 +4,7 @@ import { Container } from "@/components/container";
 import { motion, AnimatePresence } from "motion/react";
 import { AGENTS } from "@/lib/site";
 
-// The coding agents Zuse Alpha wraps. We have no logo assets, so render the
+// The coding agents Zuse (Beta) wraps. We have no logo assets, so render the
 // agent names as clean text badges in the marquee row.
 const allAgents = AGENTS.map((name, i) => ({ id: i + 1, name }));
 
@@ -40,7 +40,7 @@ export const LogoCloud = () => {
           Use the subscriptions you already pay for
         </h2>
         <p className="text-muted-foreground text-base leading-6 font-medium">
-          Zuse Alpha does not sell model credits. Bring your own keys, run the
+          Zuse (Beta) does not sell model credits. Bring your own keys, run the
           agents you already trust, and push more useful work through them.
         </p>
       </div>

--- a/apps/web/components/resources/index.tsx
+++ b/apps/web/components/resources/index.tsx
@@ -15,7 +15,7 @@ const data: CardData[] = [
   {
     title: "Bring your own keys",
     description:
-      "Your API keys stay in the macOS Keychain. Zuse Alpha is not a reseller and never marks up your model usage.",
+      "Your API keys stay in the macOS Keychain. Zuse (Beta) is not a reseller and never marks up your model usage.",
     time: "4 min read",
     image: "/assets/blog-preview-keys-clean.svg",
     href: "/blog/bring-your-own-keys",

--- a/apps/web/content/blog/bring-your-own-keys.mdx
+++ b/apps/web/content/blog/bring-your-own-keys.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Bring your own keys: why Zuse Alpha never resells tokens"
-description: "Your API keys stay in the macOS Keychain. Zuse Alpha is not a reseller and never marks up your model usage."
+title: "Bring your own keys: why Zuse (Beta) never resells tokens"
+description: "Your API keys stay in the macOS Keychain. Zuse (Beta) is not a reseller and never marks up your model usage."
 date: "2026-06-04"
 timeToRead: "4 min read"
-authorName: "Zuse Alpha team"
+authorName: "Zuse (Beta) team"
 authorRole: "Product notes"
 authorAvatar: "/app-icon.png"
 previewImage: "/assets/blog-preview-keys-clean.svg"
@@ -14,17 +14,17 @@ labels:
   ]
 ---
 
-# Bring your own keys: why Zuse Alpha never resells tokens
+# Bring your own keys: why Zuse (Beta) never resells tokens
 
 A lot of agent tools sit between you and the model provider. They take your prompt, run it through their account, and bill you a marked-up rate. That means an opaque margin on every token and your code passing through a third party you did not choose.
 
-Zuse Alpha does not do that. You bring your own keys or your own provider subscription, and your usage is billed directly by the provider at provider rates.
+Zuse (Beta) does not do that. You bring your own keys or your own provider subscription, and your usage is billed directly by the provider at provider rates.
 
 ---
 
 ## Where your keys live
 
-API keys are stored in the macOS Keychain, encrypted by the OS. They are not synced to a server, not logged, and not sent anywhere except the provider you are calling. Zuse Alpha is local-first by design: your chats and project data live in a local SQLite database on your machine.
+API keys are stored in the macOS Keychain, encrypted by the OS. They are not synced to a server, not logged, and not sent anywhere except the provider you are calling. Zuse (Beta) is local-first by design: your chats and project data live in a local SQLite database on your machine.
 
 ---
 
@@ -48,7 +48,7 @@ Bundled credits make a tool feel simpler on day one. You sign in, enter a credit
 
 When a coding app resells tokens, it becomes the middle layer between your machine and the provider. That layer decides which model versions are available, how usage is metered, whether requests are retried, what gets logged for billing, and how quickly new provider features show up. Even when the reseller has good intentions, your workflow is now coupled to their commercial contract with the model provider. If they change prices, change quotas, lose access to a model, or decide to steer traffic toward a cheaper backend, you feel it directly.
 
-Bring-your-own-key keeps that relationship explicit. You decide whether to use Claude, Codex, Gemini, Grok, OpenCode, Cursor, or another provider path supported by the app. You decide which account pays the bill. You decide how keys are rotated, who can create them, and what limits sit on the provider side. Zuse Alpha becomes the local workspace where agents are orchestrated, not the toll booth for every token.
+Bring-your-own-key keeps that relationship explicit. You decide whether to use Claude, Codex, Gemini, Grok, OpenCode, Cursor, or another provider path supported by the app. You decide which account pays the bill. You decide how keys are rotated, who can create them, and what limits sit on the provider side. Zuse (Beta) becomes the local workspace where agents are orchestrated, not the toll booth for every token.
 
 ## Better cost control for real teams
 
@@ -56,13 +56,13 @@ Most engineering teams already have a model procurement story. Some have an Open
 
 That creates awkward accounting. The developer sees one bill in the tool, finance sees another vendor, and security has to review one more processor. Worse, the markup is usually hard to reason about because agent work is bursty. One afternoon of broad repository analysis can cost more than a week of small patch requests. If the tool hides the underlying token price, you cannot tell whether a bill grew because your team did more work, because the model was more expensive, because the product added overhead, or because the reseller margin changed.
 
-With your own keys, provider dashboards remain the source of truth. Rate limits, spend caps, usage exports, and audit controls stay where your organization already manages them. Zuse Alpha does not need to invent a parallel version of those systems. It can focus on making the local agent workflow better: clear timelines, isolated worktrees, visible tool calls, reviewable diffs, and a clean handoff from conversation to commit.
+With your own keys, provider dashboards remain the source of truth. Rate limits, spend caps, usage exports, and audit controls stay where your organization already manages them. Zuse (Beta) does not need to invent a parallel version of those systems. It can focus on making the local agent workflow better: clear timelines, isolated worktrees, visible tool calls, reviewable diffs, and a clean handoff from conversation to commit.
 
 ## Security is simpler when there are fewer custodians
 
 Every additional system that handles credentials becomes a system you have to trust. A hosted token reseller has to store or mint access on your behalf, associate usage with your account, and defend that infrastructure. For many products that is a reasonable trade. For a coding agent workspace, the safer default is to avoid taking custody in the first place.
 
-Zuse Alpha stores provider keys in the macOS Keychain because that is the native place for application secrets on a Mac. The operating system encrypts the items and controls access. The app can read a key when it needs to call the provider you configured, but the key is not uploaded to a Zuse Alpha service for billing. There is no remote Zuse Alpha account that can be compromised to retrieve your provider credentials, and there is no token broker where your requests have to pass through a vendor-controlled gateway.
+Zuse (Beta) stores provider keys in the macOS Keychain because that is the native place for application secrets on a Mac. The operating system encrypts the items and controls access. The app can read a key when it needs to call the provider you configured, but the key is not uploaded to a Zuse (Beta) service for billing. There is no remote Zuse (Beta) account that can be compromised to retrieve your provider credentials, and there is no token broker where your requests have to pass through a vendor-controlled gateway.
 
 That does not mean model requests are private from the provider. If you send a prompt to a hosted model, that provider receives it. BYOK is not magic privacy dust. The point is narrower and more concrete: your request goes to the provider you chose, under the account and policy you control, without an extra application vendor proxying the exchange for markup. That is a smaller trust boundary, and smaller trust boundaries are easier to reason about.
 
@@ -70,7 +70,7 @@ That does not mean model requests are private from the provider. If you send a p
 
 Credentials should be easy to replace. If a teammate leaves, a laptop is lost, a provider changes its policy, or an internal rule says keys must rotate every quarter, you should be able to update the key at the provider and in the app without opening a support ticket. BYOK makes that flow straightforward.
 
-Create a new provider key, paste it into Zuse Alpha, verify that requests work, then revoke the old key in the provider dashboard. If you want a hard monthly cap, set it with the provider. If you want a separate key for a specific repo, project, or experiment, create one. If you want to stop using a provider entirely, revoke the key and remove it locally. Zuse Alpha does not need to approve that decision because Zuse Alpha is not the account of record for the tokens.
+Create a new provider key, paste it into Zuse (Beta), verify that requests work, then revoke the old key in the provider dashboard. If you want a hard monthly cap, set it with the provider. If you want a separate key for a specific repo, project, or experiment, create one. If you want to stop using a provider entirely, revoke the key and remove it locally. Zuse (Beta) does not need to approve that decision because Zuse (Beta) is not the account of record for the tokens.
 
 This is also useful when evaluating models. Teams often want to try a new provider for one class of task before committing broadly. With BYOK, that can be a local experiment. Add the key, run the same task in a separate chat, compare the diff, and remove the key if it does not earn a place in the workflow. There is no migration from one credit wallet to another.
 
@@ -78,6 +78,6 @@ This is also useful when evaluating models. Teams often want to try a new provid
 
 The deeper reason for BYOK is alignment. A coding agent app should make it easy to see what happened. You should see what the agent read, what command it ran, what changed in the repository, what failed, and what it cost at the provider level. The app should not benefit when your token usage becomes harder to inspect.
 
-Zuse Alpha is built around that bias. The chat timeline shows tool calls and output instead of turning the session into a mystery. The changes pane makes diffs reviewable before they become commits. Worktrees isolate experiments so one agent's attempt does not silently bleed into another. BYOK fits the same pattern: keep the important mechanics visible, keep ownership close to the developer, and avoid inventing a dependency where the platform does not need one.
+Zuse (Beta) is built around that bias. The chat timeline shows tool calls and output instead of turning the session into a mystery. The changes pane makes diffs reviewable before they become commits. Worktrees isolate experiments so one agent's attempt does not silently bleed into another. BYOK fits the same pattern: keep the important mechanics visible, keep ownership close to the developer, and avoid inventing a dependency where the platform does not need one.
 
-There will still be teams that prefer centralized procurement, pooled credits, or a fully hosted product. That is fine. Zuse Alpha is for the teams and individual developers who want the opposite shape: a Mac app that runs locally, respects the provider relationships they already have, and does not turn model access into a markup layer. If the app earns trust, it should be because it improves the work, not because it controls the meter.
+There will still be teams that prefer centralized procurement, pooled credits, or a fully hosted product. That is fine. Zuse (Beta) is for the teams and individual developers who want the opposite shape: a Mac app that runs locally, respects the provider relationships they already have, and does not turn model access into a markup layer. If the app earns trust, it should be because it improves the work, not because it controls the meter.

--- a/apps/web/content/blog/git-worktrees-for-every-chat.mdx
+++ b/apps/web/content/blog/git-worktrees-for-every-chat.mdx
@@ -3,7 +3,7 @@ title: "Git worktrees for every chat"
 description: "Each chat gets an isolated working tree, so parallel agents never clobber each other's changes."
 date: "2026-05-28"
 timeToRead: "5 min read"
-authorName: "Zuse Alpha team"
+authorName: "Zuse (Beta) team"
 authorRole: "Product notes"
 authorAvatar: "/app-icon.png"
 previewImage: "/assets/blog-preview-worktrees-clean.svg"
@@ -18,13 +18,13 @@ labels:
 
 Running two agents against the same checkout is a recipe for conflicts. One edits a file while the other reads a stale version, builds collide, and you end up untangling changes that were never meant to mix.
 
-Zuse Alpha gives every chat its own git worktree. The branch is isolated, the working directory is isolated, and the agent in that chat sees only its own changes.
+Zuse (Beta) gives every chat its own git worktree. The branch is isolated, the working directory is isolated, and the agent in that chat sees only its own changes.
 
 ---
 
 ## Why worktrees
 
-A worktree is a real, native git feature: a second checkout of the same repository on its own branch, sharing one object store. Zuse Alpha creates one per chat automatically, so you get isolation without cloning the repo or copying files.
+A worktree is a real, native git feature: a second checkout of the same repository on its own branch, sharing one object store. Zuse (Beta) creates one per chat automatically, so you get isolation without cloning the repo or copying files.
 
 - Run several agents on the same project at once.
 - Keep an experimental refactor separate from a quick fix.
@@ -48,13 +48,13 @@ The first problem is file edits. One agent may read a file, plan a change, and t
 
 Humans can sometimes manage this manually by stashing, branching, cloning, or carefully sequencing work. Agents make the manual approach too fragile. If the product encourages parallel sessions, isolation has to be the default infrastructure rather than a discipline the user remembers under pressure.
 
-## Worktrees are native git, not a Zuse Alpha invention
+## Worktrees are native git, not a Zuse (Beta) invention
 
 Git worktrees solve this with a feature that already exists in git. A worktree is another checkout of the same repository, usually attached to a different branch, while sharing the underlying object database. It is lighter than cloning because it does not duplicate the full repository history, and it is safer than sharing a single checkout because each worktree has its own working directory and index.
 
-Zuse Alpha uses that native mechanism instead of inventing a separate file-copy system. When a chat gets a worktree, git still understands what is happening. You can inspect the branch from the command line, use normal git commands, run your usual tooling, and merge or delete the branch with standard workflows. The app adds automation and visibility around a real version-control primitive.
+Zuse (Beta) uses that native mechanism instead of inventing a separate file-copy system. When a chat gets a worktree, git still understands what is happening. You can inspect the branch from the command line, use normal git commands, run your usual tooling, and merge or delete the branch with standard workflows. The app adds automation and visibility around a real version-control primitive.
 
-This matters for trust. Developers already know how git branches behave. They know how to review diffs, resolve conflicts, and throw away an experiment. A product-specific isolation layer would have to earn that trust from scratch. Worktrees let Zuse Alpha integrate with the grain of the tools teams already use.
+This matters for trust. Developers already know how git branches behave. They know how to review diffs, resolve conflicts, and throw away an experiment. A product-specific isolation layer would have to earn that trust from scratch. Worktrees let Zuse (Beta) integrate with the grain of the tools teams already use.
 
 ## One chat, one branch, one story
 
@@ -76,7 +76,7 @@ This is especially useful for exploratory work. Suppose you are not sure whether
 
 Worktrees do not magically eliminate merge conflicts. If two branches edit the same code, git will still ask you to reconcile them. That is good. The conflict appears at integration time, where you can make a deliberate decision, rather than silently during two agents' file writes. The difference is that each branch remains internally understandable.
 
-This mirrors how teams already collaborate. Two engineers can work on separate branches and handle conflicts when one branch lands after the other. The branch boundary does not remove all coordination costs, but it preserves intent. Zuse Alpha applies the same pattern inside a single developer's agent workflow.
+This mirrors how teams already collaborate. Two engineers can work on separate branches and handle conflicts when one branch lands after the other. The branch boundary does not remove all coordination costs, but it preserves intent. Zuse (Beta) applies the same pattern inside a single developer's agent workflow.
 
 It also makes sequencing easier. You can land the small fix first, rebase the refactor worktree, and ask the agent to adjust. You can keep a risky experiment around while continuing normal work elsewhere. You can delete stale attempts once the chosen branch merges. The cleanup steps are git steps, not mysterious app-specific recovery.
 
@@ -86,7 +86,7 @@ Cloning per chat would provide isolation, but it is heavier and clumsier. Large 
 
 There are still costs. A worktree has files on disk, can produce build artifacts, and may require dependencies to be installed depending on the project. But it is a better baseline for frequent parallel sessions than full clones. It gives the app a fast path to create isolated work without making the user's machine feel like it is filling with duplicate repositories.
 
-The native git foundation also keeps escape hatches open. If you want to inspect a worktree in your editor, you can. If you want to run a command manually in that directory, you can. If you want to manage the branch from the terminal, git recognizes it. Zuse Alpha is not asking you to abandon the workflows you already trust.
+The native git foundation also keeps escape hatches open. If you want to inspect a worktree in your editor, you can. If you want to run a command manually in that directory, you can. If you want to manage the branch from the terminal, git recognizes it. Zuse (Beta) is not asking you to abandon the workflows you already trust.
 
 ## A calmer way to use more agents
 
@@ -94,4 +94,4 @@ The point of worktrees is not to make the UI look organized. It is to make paral
 
 That changes how you can use the tool. You can let a long task run while starting a short one. You can compare providers on the same issue. You can ask for a conservative fix and a more ambitious refactor, then choose. You can preserve your main checkout as the stable place you return to, instead of letting every agent experiment accumulate there.
 
-Zuse Alpha makes this the default because the workflow should protect you before you remember to protect yourself. Agents are most useful when they let you explore more options. Git worktrees make that exploration reviewable, reversible, and compatible with the version-control habits developers already have.
+Zuse (Beta) makes this the default because the workflow should protect you before you remember to protect yourself. Agents are most useful when they let you explore more options. Git worktrees make that exploration reviewable, reversible, and compatible with the version-control habits developers already have.

--- a/apps/web/content/blog/know-your-token-spend.mdx
+++ b/apps/web/content/blog/know-your-token-spend.mdx
@@ -3,7 +3,7 @@ title: "Know your token spend"
 description: "Tokenmaxer reads your agent CLI logs and unifies token counts and dollar cost by day, source, model, and session. All of it stays on your Mac."
 date: "2026-06-21"
 timeToRead: "6 min read"
-authorName: "Zuse Alpha team"
+authorName: "Zuse (Beta) team"
 authorRole: "Product notes"
 authorAvatar: "/app-icon.png"
 previewImage: "/assets/blog-preview-local-clean.svg"
@@ -16,11 +16,11 @@ labels:
 
 # Know your token spend
 
-> **Update — July 22, 2026:** The detailed Tokenmaxer dashboard and source logs described here remain local. Zuse Alpha separately sends default-on pseudonymous aggregate usage events, including safe model IDs and token/cost totals, with standard geographic enrichment. Prompts, responses, logs, code, paths, and entity IDs are excluded, and analytics can be disabled in Settings.
+> **Update — July 22, 2026:** The detailed Tokenmaxer dashboard and source logs described here remain local. Zuse (Beta) separately sends default-on pseudonymous aggregate usage events, including safe model IDs and token/cost totals, with standard geographic enrichment. Prompts, responses, logs, code, paths, and entity IDs are excluded, and analytics can be disabled in Settings.
 
 Most developers running coding agents have no idea how many tokens they burned last week. The usage exists, the dollars are real, but the number is invisible. It is scattered across Claude Code, Codex, OpenCode, Amp, Grok, and whatever else is installed, each writing its own logs in its own format, in its own corner of the disk.
 
-Zuse Alpha is a tool for token maxers. The first step to maxing anything is being able to see it. So Zuse Alpha ships Tokenmaxer: a local dashboard that reads the logs your agent CLIs already write and turns them into one honest picture of what you actually run.
+Zuse (Beta) is a tool for token maxers. The first step to maxing anything is being able to see it. So Zuse (Beta) ships Tokenmaxer: a local dashboard that reads the logs your agent CLIs already write and turns them into one honest picture of what you actually run.
 
 ---
 
@@ -44,7 +44,7 @@ Tokenmaxer scans the local logs of your installed agent CLIs and aggregates them
 - OpenCode
 - Amp
 - Grok
-- and Zuse Alpha's own sessions
+- and Zuse (Beta)'s own sessions
 
 It parses the session records each tool leaves behind, pulls out the token counts, and rolls them up by day, week, and month. Then it slices the same totals by source, by model, and by session, so the same spend can be read from whichever angle answers your question.
 
@@ -87,7 +87,7 @@ The same totals are useful in different shapes depending on what you are trying 
 
 ## Local by default
 
-Tokenmaxer is built on the same principle as the rest of Zuse Alpha: it runs on your Mac, and your data stays there.
+Tokenmaxer is built on the same principle as the rest of Zuse (Beta): it runs on your Mac, and your data stays there.
 
 Reading token usage could easily have been a cloud feature. Upload the logs, crunch them on a server, render a dashboard. That is the normal shape for analytics, and it is exactly the shape we did not want for a tool that reads your coding history.
 

--- a/apps/web/content/blog/local-first-by-design.mdx
+++ b/apps/web/content/blog/local-first-by-design.mdx
@@ -3,7 +3,7 @@ title: "Local-first by design"
 description: "SQLite on disk, keys in the Keychain, no account required. Your work stays on your machine."
 date: "2026-05-12"
 timeToRead: "4 min read"
-authorName: "Zuse Alpha team"
+authorName: "Zuse (Beta) team"
 authorRole: "Product notes"
 authorAvatar: "/app-icon.png"
 previewImage: "/assets/blog-preview-local-clean.svg"
@@ -16,9 +16,9 @@ labels:
 
 # Local-first by design
 
-> **Update — July 22, 2026:** Zuse Alpha now sends default-on pseudonymous product and reliability analytics. It never includes prompts, responses, code, paths, commands, account details, or error stacks, and can be disabled immediately in Settings. Standard geographic enrichment applies. The local storage and provider data path described below is unchanged.
+> **Update — July 22, 2026:** Zuse (Beta) now sends default-on pseudonymous product and reliability analytics. It never includes prompts, responses, code, paths, commands, account details, or error stacks, and can be disabled immediately in Settings. Standard geographic enrichment applies. The local storage and provider data path described below is unchanged.
 
-Zuse Alpha runs on your Mac, not in our cloud. There is no account to create before you can use it, no server holding your chat history, and no telemetry pulling your code off the machine.
+Zuse (Beta) runs on your Mac, not in our cloud. There is no account to create before you can use it, no server holding your chat history, and no telemetry pulling your code off the machine.
 
 Local-first is not a feature we bolted on. It is how the app is built.
 
@@ -52,21 +52,21 @@ Local-first means we cannot inspect your work. Aggregated reliability events can
 
 It is easy for software to say "privacy first" while still depending on a remote account for the product to function. The app may store a cache locally, but the source of truth lives on a server. The server knows which projects you opened, which conversations you had, which files were attached, and which model requests passed through the system. That design can be appropriate for collaboration-heavy web products. It is not the default we wanted for a coding agent workspace.
 
-Zuse Alpha starts from the opposite assumption. The Mac app should be useful as a local tool. The project is on your disk. The git repository is on your disk. Chat history and settings are stored locally. Provider credentials are stored by the operating system. The app does not need a Zuse Alpha-hosted account before you can begin using it, and it does not need to copy your repository metadata to a backend just to render the sidebar.
+Zuse (Beta) starts from the opposite assumption. The Mac app should be useful as a local tool. The project is on your disk. The git repository is on your disk. Chat history and settings are stored locally. Provider credentials are stored by the operating system. The app does not need a Zuse (Beta)-hosted account before you can begin using it, and it does not need to copy your repository metadata to a backend just to render the sidebar.
 
 That matters because coding agents sit unusually close to sensitive material. They read source code, configuration files, logs, test fixtures, issue descriptions, and sometimes proprietary design notes. Even if a vendor promises careful handling, centralizing all of that context creates a larger target and a larger policy surface. Local-first does not remove every risk, but it removes a whole class of vendor custody from the core workflow.
 
 ## What still leaves your machine
 
-Local-first should be described precisely. If you use a hosted model provider, the prompts and context you send to that provider leave your machine. If an agent runs a command that talks to a package registry, git remote, deployment platform, or issue tracker, that command uses the network according to the tool involved. Zuse Alpha does not claim that agentic coding happens in an air gap.
+Local-first should be described precisely. If you use a hosted model provider, the prompts and context you send to that provider leave your machine. If an agent runs a command that talks to a package registry, git remote, deployment platform, or issue tracker, that command uses the network according to the tool involved. Zuse (Beta) does not claim that agentic coding happens in an air gap.
 
-The point is that Zuse Alpha itself is not an extra cloud hop for your work. Model requests go to the provider path you configured. API keys are not uploaded to a Zuse Alpha billing service. Chat history is not synced to a Zuse Alpha account. Local project data is not mirrored to us so we can power search or analytics. The app's job is to orchestrate local workflow, not to become the central store for your engineering context.
+The point is that Zuse (Beta) itself is not an extra cloud hop for your work. Model requests go to the provider path you configured. API keys are not uploaded to a Zuse (Beta) billing service. Chat history is not synced to a Zuse (Beta) account. Local project data is not mirrored to us so we can power search or analytics. The app's job is to orchestrate local workflow, not to become the central store for your engineering context.
 
-Being clear about this distinction helps teams make better decisions. If a repository cannot be sent to a particular model provider, BYOK alone does not solve that. You still need the right provider policy, local models, or stricter rules. But if your team has already approved a provider, Zuse Alpha does not add a second vendor database containing the same prompts and files.
+Being clear about this distinction helps teams make better decisions. If a repository cannot be sent to a particular model provider, BYOK alone does not solve that. You still need the right provider policy, local models, or stricter rules. But if your team has already approved a provider, Zuse (Beta) does not add a second vendor database containing the same prompts and files.
 
 ## Why SQLite is a good fit
 
-SQLite is boring in the best way. It is a local database file with strong transactional behavior, mature tooling, and no server process to manage. For a desktop app that needs to remember chats, projects, settings, message state, and workflow metadata, that is a practical foundation. It lets Zuse Alpha keep state durable without turning persistence into a hosted dependency.
+SQLite is boring in the best way. It is a local database file with strong transactional behavior, mature tooling, and no server process to manage. For a desktop app that needs to remember chats, projects, settings, message state, and workflow metadata, that is a practical foundation. It lets Zuse (Beta) keep state durable without turning persistence into a hosted dependency.
 
 A local database also makes the app easier to reason about. Your data has a concrete location. It can be backed up with the rest of your machine. It can be inspected during debugging. It does not disappear because a remote service is down. When we evolve the schema, migrations run on the local store rather than requiring a cloud account migration behind the scenes.
 
@@ -74,17 +74,17 @@ There are engineering responsibilities that come with this choice. Migrations mu
 
 ## Keys belong in the Keychain
 
-Provider keys are secrets, and macOS already has a native system for application secrets: the Keychain. Storing keys there means encryption and access control are handled by the operating system instead of by a custom file format in the app. Zuse Alpha reads the key when it needs to call the provider you selected, but it does not sync that key to a Zuse Alpha backend.
+Provider keys are secrets, and macOS already has a native system for application secrets: the Keychain. Storing keys there means encryption and access control are handled by the operating system instead of by a custom file format in the app. Zuse (Beta) reads the key when it needs to call the provider you selected, but it does not sync that key to a Zuse (Beta) backend.
 
-This is important for both individuals and teams. An individual developer can experiment without creating yet another vendor account. A team can use provider-side controls for spend, rotation, and revocation. If a key needs to be replaced, the owner can rotate it through the provider dashboard and update the local app. There is no support queue required to detach your model access from Zuse Alpha.
+This is important for both individuals and teams. An individual developer can experiment without creating yet another vendor account. A team can use provider-side controls for spend, rotation, and revocation. If a key needs to be replaced, the owner can rotate it through the provider dashboard and update the local app. There is no support queue required to detach your model access from Zuse (Beta).
 
-It also keeps incentives cleaner. A product that stores keys only to help you call your chosen provider has a different relationship to your usage than a product that resells model access. Zuse Alpha does not need to mark up tokens or obscure the underlying provider cost. It can make money, eventually, by being a good tool, not by sitting between you and every model request.
+It also keeps incentives cleaner. A product that stores keys only to help you call your chosen provider has a different relationship to your usage than a product that resells model access. Zuse (Beta) does not need to mark up tokens or obscure the underlying provider cost. It can make money, eventually, by being a good tool, not by sitting between you and every model request.
 
 ## Offline and degraded workflows matter
 
 Coding work often happens in imperfect environments: trains, flights, cafes, conference Wi-Fi, corporate networks with strict proxies, or local setups where the internet is intentionally limited. A cloud-centered app tends to fail broadly when it cannot reach its own backend. Local-first software can degrade more gracefully.
 
-If the model provider is unreachable, you obviously cannot complete a hosted model request. But the rest of the workspace should still make sense. You can inspect previous chats, review diffs, look at project state, adjust settings, and continue with local files. The app does not need to ask Zuse Alpha servers whether your sidebar is allowed to load. That sounds small until you have lost work to a web app that treats connectivity as a prerequisite for memory.
+If the model provider is unreachable, you obviously cannot complete a hosted model request. But the rest of the workspace should still make sense. You can inspect previous chats, review diffs, look at project state, adjust settings, and continue with local files. The app does not need to ask Zuse (Beta) servers whether your sidebar is allowed to load. That sounds small until you have lost work to a web app that treats connectivity as a prerequisite for memory.
 
 Local state also helps with speed. The app can render known project and chat data without round-tripping to a server. Search, navigation, and review surfaces can be designed around local access patterns. Not every feature becomes faster automatically, but the architecture gives the desktop app room to feel like a desktop app.
 
@@ -94,10 +94,10 @@ The hardest part of local-first design is collaboration. Teams often want shared
 
 That is a good constraint. Not every piece of agent history should become shared team data by default. Some conversations are scratch work. Some include sensitive logs. Some are failed explorations that should be discarded. When collaboration features are added, they should make sharing intentional: export this summary, commit this change, open this PR, copy this configuration, or attach this context to an issue.
 
-Git already gives developers a strong collaboration substrate for code. Zuse Alpha leans into that by making worktrees and diffs central. The artifact that crosses from one person to another should often be a branch, a commit, a PR, or a clear written summary, not an invisible sync of every local thought the agent produced.
+Git already gives developers a strong collaboration substrate for code. Zuse (Beta) leans into that by making worktrees and diffs central. The artifact that crosses from one person to another should often be a branch, a commit, a PR, or a clear written summary, not an invisible sync of every local thought the agent produced.
 
 ## Trust is built through restraint
 
 The easiest way to build features is often to collect more data. The local-first approach asks a harder question: can this be useful without taking custody of the user's work? Sometimes the answer is yes with a better local design. Sometimes the answer is yes if sharing is explicit. Sometimes the answer is no, and the feature needs a serious trust discussion before it belongs in the product.
 
-That restraint is part of Zuse Alpha's identity. We want the app to feel like a tool you can put next to a private repository without wondering which hidden service is watching the session. You should know where your data lives, which provider receives a request, and what changed in the working tree. Local-first is how we make those answers concrete.
+That restraint is part of Zuse (Beta)'s identity. We want the app to feel like a tool you can put next to a private repository without wondering which hidden service is watching the session. You should know where your data lives, which provider receives a request, and what changed in the working tree. Local-first is how we make those answers concrete.

--- a/apps/web/content/blog/run-six-agents-side-by-side.mdx
+++ b/apps/web/content/blog/run-six-agents-side-by-side.mdx
@@ -3,7 +3,7 @@ title: "Run six coding agents side by side"
 description: "Claude Code, Codex, Cursor, Gemini, Grok, and OpenCode in one window. Switch providers without losing context."
 date: "2026-06-10"
 timeToRead: "5 min read"
-authorName: "Zuse Alpha team"
+authorName: "Zuse (Beta) team"
 authorRole: "Product notes"
 authorAvatar: "/app-icon.png"
 previewImage: "/assets/blog-preview-agents-clean.svg"
@@ -18,7 +18,7 @@ labels:
 
 Every agent CLI has its own strengths. Claude Code is great at large refactors, Codex is fast on tight loops, Gemini has a huge context window. The problem is that each one lives in its own terminal with its own auth, its own flags, and its own output format.
 
-Zuse Alpha wraps all six behind one chat-first surface so you can use the right agent for each task without leaving the app.
+Zuse (Beta) wraps all six behind one chat-first surface so you can use the right agent for each task without leaving the app.
 
 ---
 
@@ -34,7 +34,7 @@ Open a chat, pick a provider, and start. The chat timeline renders tool calls, t
 
 ## No new format to learn
 
-Zuse Alpha speaks each CLI's native protocol underneath. There is no proprietary agent runtime to adopt and nothing to migrate. The agents you already trust run exactly as they do on the command line, just rendered in a timeline you can actually read.
+Zuse (Beta) speaks each CLI's native protocol underneath. There is no proprietary agent runtime to adopt and nothing to migrate. The agents you already trust run exactly as they do on the command line, just rendered in a timeline you can actually read.
 
 ---
 
@@ -50,7 +50,7 @@ The agent landscape is moving too quickly for one provider to be the best choice
 
 The problem is not provider variety. Variety is useful. The problem is that each provider often brings a separate workflow with it. You authenticate differently, invoke it differently, read its output differently, and recover from failure differently. The more agents you use, the more time you spend managing the wrappers around them instead of evaluating the work they produce.
 
-Zuse Alpha is designed around the idea that provider choice should be easy to change without making the rest of the workflow unstable. The app gives each agent a shared project-aware surface: chats, timelines, worktrees, diffs, and review. The underlying CLIs can keep their strengths, but the developer should not need to rebuild their environment every time they switch models.
+Zuse (Beta) is designed around the idea that provider choice should be easy to change without making the rest of the workflow unstable. The app gives each agent a shared project-aware surface: chats, timelines, worktrees, diffs, and review. The underlying CLIs can keep their strengths, but the developer should not need to rebuild their environment every time they switch models.
 
 ## Side by side is different from one at a time
 
@@ -64,7 +64,7 @@ Side-by-side work also helps with confidence. A developer can ask two providers 
 
 Agent output is hard to review when it is just a terminal stream. Tool calls, command output, reasoning notes, diffs, errors, and final summaries all compete for attention. Each provider formats those events differently, which means the developer has to learn multiple output languages before they can judge the work.
 
-Zuse Alpha renders sessions as a structured chat timeline. The goal is not to hide details. The goal is to make details readable. A command should look like a command. A failed command should be easy to spot. A tool call should not disappear into a wall of text. A diff should be connected to the session that produced it. When those events have a consistent shape, switching providers becomes less mentally expensive.
+Zuse (Beta) renders sessions as a structured chat timeline. The goal is not to hide details. The goal is to make details readable. A command should look like a command. A failed command should be easy to spot. A tool call should not disappear into a wall of text. A diff should be connected to the session that produced it. When those events have a consistent shape, switching providers becomes less mentally expensive.
 
 This matters most during long tasks. A useful coding session may involve several attempts, a few failed tests, a corrected assumption, and a final patch. If the timeline preserves that story, the developer can review the outcome without replaying the entire terminal in their head. The agent remains accountable because the intermediate steps are visible.
 
@@ -72,17 +72,17 @@ This matters most during long tasks. A useful coding session may involve several
 
 One common failure mode in agent work is the stuck session. The model loops, misses an obvious file, overfits to a bad assumption, or runs out of useful context. In a terminal-only workflow, switching providers often means starting over: copy the prompt, summarize the current state, point the new tool at the repository, and hope you did not omit the important failure.
 
-Zuse Alpha's shared workspace makes provider switching less disruptive. The project, chat history, files, and worktree remain part of the surrounding context. A new provider can enter the same workflow with a clearer view of what has already happened. That does not guarantee a better answer, but it lowers the cost of trying.
+Zuse (Beta)'s shared workspace makes provider switching less disruptive. The project, chat history, files, and worktree remain part of the surrounding context. A new provider can enter the same workflow with a clearer view of what has already happened. That does not guarantee a better answer, but it lowers the cost of trying.
 
 The same idea applies before a task gets stuck. You might begin with a cheaper or faster provider for exploration, then switch to a stronger model for the final implementation. Or you might use a model with a large context window to understand the repository, then hand a narrow patch to another agent. Provider choice becomes a tactical decision instead of a one-way commitment at the start of a session.
 
 ## Native CLIs still matter
 
-Zuse Alpha is not trying to replace every agent with a proprietary runtime. The existing CLIs matter because providers invest in them, developers already trust them, and their capabilities change quickly. A wrapper that ignores native behavior would either lag behind or flatten useful differences.
+Zuse (Beta) is not trying to replace every agent with a proprietary runtime. The existing CLIs matter because providers invest in them, developers already trust them, and their capabilities change quickly. A wrapper that ignores native behavior would either lag behind or flatten useful differences.
 
-Instead, Zuse Alpha wraps the workflow around those tools. It handles the project surface, the chat timeline, the worktree isolation, and the review pane while speaking to the agents underneath. That gives developers a consistent place to work without pretending that all agents are interchangeable.
+Instead, Zuse (Beta) wraps the workflow around those tools. It handles the project surface, the chat timeline, the worktree isolation, and the review pane while speaking to the agents underneath. That gives developers a consistent place to work without pretending that all agents are interchangeable.
 
-This is also better for adoption. Teams do not need to abandon the tools they already evaluated. If Claude Code is approved for one kind of work, Codex for another, and Gemini for a third, Zuse Alpha can sit above that mix as the local workspace. The provider decision remains with the team.
+This is also better for adoption. Teams do not need to abandon the tools they already evaluated. If Claude Code is approved for one kind of work, Codex for another, and Gemini for a third, Zuse (Beta) can sit above that mix as the local workspace. The provider decision remains with the team.
 
 ## What side-by-side work looks like in practice
 
@@ -94,6 +94,6 @@ This pattern changes the emotional feel of agent work. Instead of treating a sin
 
 ## The goal is leverage without chaos
 
-More agents can create more noise if the product does not impose structure. Six terminals streaming at once is not a workflow; it is a distraction. Zuse Alpha tries to make multi-agent work calm by giving each session a clear home, each branch a clear owner, and each diff a clear review path.
+More agents can create more noise if the product does not impose structure. Six terminals streaming at once is not a workflow; it is a distraction. Zuse (Beta) tries to make multi-agent work calm by giving each session a clear home, each branch a clear owner, and each diff a clear review path.
 
 That structure is what makes the provider list valuable. Claude Code, Codex, Cursor, Gemini, Grok, and OpenCode can all be useful, but the real product is the workspace that lets you use them intentionally. Pick the right agent, compare alternatives, switch when a task changes, and keep the resulting code under the same review standards you would apply to a teammate's patch.

--- a/apps/web/content/blog/sub-agent-delegation.mdx
+++ b/apps/web/content/blog/sub-agent-delegation.mdx
@@ -3,7 +3,7 @@ title: "Sub-agent delegation to cut cost"
 description: "Let a lead agent spawn cheaper models for the grunt work, then keep the expensive model for the hard parts."
 date: "2026-05-20"
 timeToRead: "5 min read"
-authorName: "Zuse Alpha team"
+authorName: "Zuse (Beta) team"
 authorRole: "Product notes"
 authorAvatar: "/app-icon.png"
 previewImage: "/assets/blog-preview-subagents-clean.svg"
@@ -18,7 +18,7 @@ labels:
 
 Not every step in a task needs your most capable model. Reading files, grepping, summarizing logs, and running checks are cheap work. Designing the change and reasoning through the tricky cases is where you want the strong model.
 
-Zuse Alpha lets a lead agent delegate to sub-agents, so the expensive model orchestrates while cheaper models do the legwork.
+Zuse (Beta) lets a lead agent delegate to sub-agents, so the expensive model orchestrates while cheaper models do the legwork.
 
 ---
 
@@ -52,7 +52,7 @@ Sub-agent delegation takes advantage of that uneven shape. The lead agent keeps 
 
 Bad delegation would be worse than no delegation. If a lead agent spawns helpers that wander through the repository, make silent edits, or return vague conclusions, the developer gets a distributed mess. The useful version has clear boundaries. A sub-agent should have a specific question, a defined scope, and an output that can be checked by the lead agent and the human reviewer.
 
-Zuse Alpha treats sub-agent work as part of the visible session. Tool calls and outputs are not hidden behind a single "done" message. You can see what the helper inspected and what it concluded. That matters because agentic work should be auditable. If the lead agent bases a design decision on a sub-agent's summary, you should be able to inspect the summary and decide whether it was grounded.
+Zuse (Beta) treats sub-agent work as part of the visible session. Tool calls and outputs are not hidden behind a single "done" message. You can see what the helper inspected and what it concluded. That matters because agentic work should be auditable. If the lead agent bases a design decision on a sub-agent's summary, you should be able to inspect the summary and decide whether it was grounded.
 
 This visibility also makes it easier to tune your own habits. Over time, you learn which tasks are safe to delegate to smaller models and which tasks deserve a stronger one. You might use a cheaper model for repository mapping, a mid-tier model for writing straightforward tests, and the strongest model for the final patch. The point is not to automate the human out of the loop. The point is to spend attention and model budget where they produce the most value.
 
@@ -86,4 +86,4 @@ Start by delegating read-only work. Ask a helper to map related files, summarize
 
 Review the sub-agent output the same way you would review a teammate's notes. Check that it cites concrete files, distinguishes facts from guesses, and does not overstate certainty. If the output is vague, narrow the next prompt. If the helper reads too much, reduce the scope. Delegation improves when the lead agent gives smaller, sharper assignments.
 
-Zuse Alpha's role is to make that workflow normal inside the app. Multiple agents can work inside the same project-aware environment, their outputs remain visible, and the lead agent can use their findings without turning the session into a tangle of terminals. The economics are useful, but the deeper win is operational: better division of labor for agentic coding.
+Zuse (Beta)'s role is to make that workflow normal inside the app. Multiple agents can work inside the same project-aware environment, their outputs remain visible, and the lead agent can use their findings without turning the session into a tangle of terminals. The economics are useful, but the deeper win is operational: better division of labor for agentic coding.

--- a/apps/web/content/blog/token-maxing-your-subscriptions.mdx
+++ b/apps/web/content/blog/token-maxing-your-subscriptions.mdx
@@ -3,7 +3,7 @@ title: "Token maxing your AI coding subscriptions"
 description: "You already pay a flat fee for Claude, Codex, and the rest. Running one agent at a time leaves most of that included usage on the table."
 date: "2026-06-21"
 timeToRead: "6 min read"
-authorName: "Zuse Alpha team"
+authorName: "Zuse (Beta) team"
 authorRole: "Product notes"
 authorAvatar: "/app-icon.png"
 previewImage: "/assets/blog-preview-agents-clean.svg"
@@ -20,7 +20,7 @@ Most developers now pay for at least one AI coding plan, and many pay for severa
 
 Here is the part most people miss: a flat fee rewards volume. The included usage in your plan is a budget, not a meter. If you only ever run one agent at a time, you spend a small fraction of that budget and pay full price for it anyway. Token maxing is the practice of using more of what you already bought.
 
-Zuse Alpha is built for exactly this. It wraps every coding agent CLI in one project-aware workspace, gives each chat its own git worktree, and tracks your spend locally so you can see your leverage. This post is about how to use that to get multiples more work out of the subscriptions you already have.
+Zuse (Beta) is built for exactly this. It wraps every coding agent CLI in one project-aware workspace, gives each chat its own git worktree, and tracks your spend locally so you can see your leverage. This post is about how to use that to get multiples more work out of the subscriptions you already have.
 
 ---
 
@@ -36,7 +36,7 @@ The fix is not to upgrade to a bigger plan. It is to put more cars in the lane y
 
 ## Three to six agents, same monthly fee
 
-The practical move is to run several agents side by side instead of one after another. Zuse Alpha is designed so this feels normal rather than chaotic. Open a chat, pick a provider, start a task. Open another chat, pick a provider, start a different task. Each chat is its own unit of work with its own timeline.
+The practical move is to run several agents side by side instead of one after another. Zuse (Beta) is designed so this feels normal rather than chaotic. Open a chat, pick a provider, start a task. Open another chat, pick a provider, start a different task. Each chat is its own unit of work with its own timeline.
 
 What does that buy you in a real session?
 
@@ -50,7 +50,7 @@ The multiplier here is real but bounded by your attention, not your wallet. You 
 
 ## Worktrees keep parallel work from colliding
 
-Running several agents against one repo only works if they cannot clobber each other. That is what git worktrees handle, and Zuse Alpha creates one per chat automatically. Each chat gets its own branch and its own working directory while sharing the repository's object store, so agents edit in isolation and you review each change on its own branch.
+Running several agents against one repo only works if they cannot clobber each other. That is what git worktrees handle, and Zuse (Beta) creates one per chat automatically. Each chat gets its own branch and its own working directory while sharing the repository's object store, so agents edit in isolation and you review each change on its own branch.
 
 We have written about the mechanics of worktrees elsewhere, so the short version here is what they mean for token maxing: isolation is the thing that makes parallelism safe enough to actually do. Without it, every additional agent raises the odds of a stale read or a build collision, and the safe move is to fall back to one-at-a-time. With it, adding another agent just adds another branch with a clear owner. Parallelism stops being risky, which is the whole point, because the leverage only exists if you are comfortable running many agents at once.
 
@@ -62,7 +62,7 @@ When an attempt does not pan out, you discard the worktree and your main checkou
 
 Each plan has its own included usage and its own rate limits. If you push a single provider hard enough, you will eventually hit a ceiling and stall. Spreading work across providers is both a throughput trick and a resilience one.
 
-Because Zuse Alpha speaks each CLI's native protocol under one surface, the provider is just a choice you make per chat. So you can run Claude Code in two chats, Codex in two more, and Grok in another, all against the same project. Five agents working, five different usage budgets being drawn down, and no single provider getting throttled because you concentrated everything on it.
+Because Zuse (Beta) speaks each CLI's native protocol under one surface, the provider is just a choice you make per chat. So you can run Claude Code in two chats, Codex in two more, and Grok in another, all against the same project. Five agents working, five different usage budgets being drawn down, and no single provider getting throttled because you concentrated everything on it.
 
 This also lets you match the agent to the task while you are at it. A model with a huge context window can hold the whole repo while it investigates. A faster provider can churn through a tight test-fix loop. A different one can do the review pass. You are not just dodging limits; you are spending each plan's included usage on the work it is best at. The mix is the point. Provider variety stops being a tab-management headache and becomes a way to keep more lanes open at once.
 
@@ -72,7 +72,7 @@ A practical note: keep an eye on which provider is carrying the load. If one pla
 
 ## Tokenmaxer: see exactly what you spent
 
-You cannot maximize what you cannot measure. Zuse Alpha includes a local token dashboard we call Tokenmaxer that reads usage across the providers you run and shows it in one place. It is on your machine, not a provider portal you have to log into five separate times.
+You cannot maximize what you cannot measure. Zuse (Beta) includes a local token dashboard we call Tokenmaxer that reads usage across the providers you run and shows it in one place. It is on your machine, not a provider portal you have to log into five separate times.
 
 The dashboard answers the questions that actually tell you whether token maxing is working:
 
@@ -92,4 +92,4 @@ Token maxing is not about being wasteful or spinning up agents for the sake of i
 
 The pieces fit together. Several agents side by side put more of your plan to work at once. Worktrees keep those agents from stepping on each other so parallel work stays reviewable. Mixing providers spreads the load so no single plan throttles you. And Tokenmaxer shows you the result, so you can see that the same monthly fee is now doing several times the work.
 
-You are still the editor. The agents produce candidates; you decide what lands. But the version of that job where one agent works while three plans sit idle was always leaving value on the table. Zuse Alpha is the workspace that lets you use what you already pay for.
+You are still the editor. The agents produce candidates; you decide what lands. But the version of that job where one agent works while three plans sit idle was always leaving value on the table. Zuse (Beta) is the workspace that lets you use what you already pay for.

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,60 @@
 [
   {
+    "version": "0.15.0",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Promote Zuse to Beta and restore release checks",
+          "Replace target provider CLI runtime with bundled SDK (#386)",
+          "Scope context handoffs to the current chat (#385)",
+          "Fix provider inline authentication recovery (#384)",
+          "Safe automatic and manual naming (#383)",
+          "Add semantic agent activity orbs (#382)",
+          "Mobile: Effect Atom state, home redesign, connectivity recovery (#377)",
+          "Polish latest-response forking and restore desktop startup (#381)",
+          "Add end-to-end product analytics (#380)",
+          "Rebuild realtime chat and interrupt lifecycle (#379)",
+          "Upgrade the in-app agent browser (#376)",
+          "Add authenticated browser access and isolated parallel development (#375)",
+          "Fix assistant message forking and chat tab behavior (#374)",
+          "Add quarantined-fork verification: E2B passes, no egress control on the alternate",
+          "Make chat archiving instant and failure-safe (#373)",
+          "Add ADR 0033: fork identity and event-log divergence",
+          "Update PR-E/PR-H and Phase 1 status after tunnel+push verification (#343)",
+          "Add cloud storage research notes",
+          "Add threaded bug tracker forum",
+          "Add Discord community enhancement workflow",
+          "Add community channel setup script",
+          "Add reliable nearby device pairing and recovery (#370)",
+          "Polish renderer UI: neutral grays, glass overlays, cleaner settings (#368)",
+          "Add clean mobile multi-thread chats (#367)",
+          "Fix mobile chat scrolling and viewport boundaries (#366)",
+          "feat(mobile): add workspace files and change review",
+          "Polish mobile connections and native chat UI (#364)",
+          "fix: simplify paired phone access",
+          "chore: update iOS dependency checksums",
+          "fix: unify mobile connection experience",
+          "fix: construct encodable pairing responses",
+          "feat: add secure cross-device network access",
+          "Make renderer creation and streaming immediately responsive (#361)",
+          "feat: add full changes review and inline conflict resolution (#362)",
+          "Add native MCP discovery and authentication (#360)",
+          "Fix terminal input ordering and recovery (#359)",
+          "Modernize native ACP session interactions (#358)",
+          "Publish cloud platform roadmap (#357)",
+          "Configure agent workflow guidance (#356)",
+          "Rework mobile chat composer, model sheet, and turn display (#352)",
+          "Surface plans and subagents in environment summary (#349)",
+          "Finish iPhone review experience and relay reliability (#350)",
+          "Fix image previews in the file viewer (#348)",
+          "Add Linear-powered issue sessions (#347)",
+          "Refresh short-lived auth tokens before expiry (#346)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.14.0",
     "sections": [
       {

--- a/apps/web/lib/seo.ts
+++ b/apps/web/lib/seo.ts
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
 export const siteConfig = {
-  name: "Zuse Alpha",
+  name: "Zuse (Beta)",
   description:
-    "Zuse Alpha helps power users token max Claude Code, Codex, Cursor, Gemini, Grok and OpenCode from one local Mac workspace with worktrees, diffs, and no token markup.",
+    "Zuse (Beta) helps power users token max Claude Code, Codex, Cursor, Gemini, Grok and OpenCode from one local Mac workspace with worktrees, diffs, and no token markup.",
   // Override in production via NEXT_PUBLIC_SITE_URL.
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://zuse.sh",
   ogImage: "/og.png",

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -1,7 +1,7 @@
-// Central place for Zuse Alpha's brand constants and outbound links so we only
+// Central place for Zuse (Beta)'s brand constants and outbound links so we only
 // edit them once.
 
-export const SITE_NAME = "Zuse Alpha";
+export const SITE_NAME = "Zuse (Beta)";
 
 export const GITHUB_URL = "https://github.com/swarajbachu/zuse";
 export const RELEASES_URL = "https://github.com/swarajbachu/zuse/releases";
@@ -12,7 +12,7 @@ export const DOWNLOAD_URL = "/download";
 export const TAGLINE =
   "Token max every coding agent from one local Mac workspace.";
 
-// The coding agents Zuse Alpha wraps. Used by the logo cloud / brands marquee.
+// The coding agents Zuse (Beta) wraps. Used by the logo cloud / brands marquee.
 export const AGENTS = [
   "Claude Code",
   "Codex",

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/packages/tokenmaxer/src/bin.ts
+++ b/packages/tokenmaxer/src/bin.ts
@@ -31,7 +31,7 @@ Options:
   --json                 Print JSON
   --no-cost              Hide cost column
   --offline              Use bundled pricing; skip the network
-  --zuse-db <path>       Zuse Alpha SQLite path
+  --zuse-db <path>       Zuse (Beta) SQLite path
   --memoize-db <path>    Legacy alias for --zuse-db
 `;
 

--- a/packages/tokenmaxer/src/sources/catalog.ts
+++ b/packages/tokenmaxer/src/sources/catalog.ts
@@ -1,7 +1,7 @@
 import type { UsageSourceId } from "../types.ts";
 
 export const SOURCE_LABELS: Record<UsageSourceId, string> = {
-  zuse: "Zuse Alpha",
+  zuse: "Zuse (Beta)",
   memoize: "Memoize",
   claude: "Claude Code",
   codex: "Codex",

--- a/packages/tokenmaxer/src/sources/memoize.ts
+++ b/packages/tokenmaxer/src/sources/memoize.ts
@@ -31,6 +31,8 @@ export const memoizeDbPathCandidates = (): string[] => {
     return appDbPaths(
       base,
       [
+        "Zuse (Beta)",
+        "Zuse (Beta) (Dev)",
         "Zuse Alpha",
         "Zuse Alpha (Dev)",
         "memoize Alpha",
@@ -76,11 +78,11 @@ export const readMemoizeUsage = (dbPath?: string | null): UsageSourceReadResult 
     return {
       status: {
         id: "zuse",
-        label: "Zuse Alpha",
+        label: "Zuse (Beta)",
         detected: false,
         recordCount: 0,
         paths: statusPaths,
-        warning: "Zuse Alpha SQLite database was not found.",
+        warning: "Zuse (Beta) SQLite database was not found.",
       },
       records: [],
     };
@@ -116,7 +118,7 @@ export const readMemoizeUsage = (dbPath?: string | null): UsageSourceReadResult 
           records.push(
             makeUsageRecord({
               sourceId: "zuse",
-              sourceLabel: "Zuse Alpha",
+              sourceLabel: "Zuse (Beta)",
               providerId: row.provider_id ?? "zuse",
               model: resolveModel(content.model, row.session_model) ?? "unknown",
               sessionId: row.session_id,
@@ -144,7 +146,7 @@ export const readMemoizeUsage = (dbPath?: string | null): UsageSourceReadResult 
       return {
         status: {
           id: "zuse",
-          label: "Zuse Alpha",
+          label: "Zuse (Beta)",
           detected: true,
           recordCount: records.length,
           paths: candidates,
@@ -166,7 +168,7 @@ export const readMemoizeUsage = (dbPath?: string | null): UsageSourceReadResult 
   return {
     status: {
       id: "zuse",
-      label: "Zuse Alpha",
+      label: "Zuse (Beta)",
       detected: true,
       recordCount: 0,
       paths: candidates,

--- a/packages/tokenmaxer/test/unit/aggregate.test.ts
+++ b/packages/tokenmaxer/test/unit/aggregate.test.ts
@@ -21,7 +21,7 @@ describe("tokenmaxer aggregation", () => {
 			[
 				makeUsageRecord({
 					sourceId: "zuse",
-					sourceLabel: "Zuse Alpha",
+					sourceLabel: "Zuse (Beta)",
 					providerId: "claude",
 					model: "claude-sonnet-4-6",
 					sessionId: "s1",
@@ -105,7 +105,7 @@ describe("tokenmaxer aggregation", () => {
 		const records = ["claude", "codex"].map((providerId) =>
 			makeUsageRecord({
 				sourceId: "zuse",
-				sourceLabel: "Zuse Alpha",
+				sourceLabel: "Zuse (Beta)",
 				providerId,
 				model: `${providerId}-model`,
 				sessionId: `${providerId}-session`,
@@ -131,7 +131,7 @@ describe("tokenmaxer aggregation", () => {
 	it("marks duplicate-looking rows and excludes them by default", () => {
 		const base = makeUsageRecord({
 			sourceId: "zuse",
-			sourceLabel: "Zuse Alpha",
+			sourceLabel: "Zuse (Beta)",
 			providerId: "claude",
 			model: "claude-sonnet-4-6",
 			sessionId: "same",

--- a/tests/system/src/session-observer.ts
+++ b/tests/system/src/session-observer.ts
@@ -1,7 +1,24 @@
-import { projectSessionEvent } from "@zuse/client-runtime/session-events";
-import type { Message, SessionId } from "@zuse/contracts";
+import type {
+	AgentTurnId,
+	Message,
+	SessionId,
+	SessionTimelineFrame,
+} from "@zuse/contracts";
 import { Effect, Stream } from "effect";
 import type { SystemRpcClient } from "./rpc-client.ts";
+
+export const sessionFrameMessages = (
+	frame: SessionTimelineFrame,
+): ReadonlyArray<Message> => {
+	if (frame.kind === "snapshot") return frame.projection.messages;
+	if (frame.kind === "event" && frame.event._tag === "MessagePersisted") {
+		return [frame.event.message];
+	}
+	return [];
+};
+
+export const sessionFrameVersion = (frame: SessionTimelineFrame): number =>
+	frame.kind === "event" ? frame.streamVersion : frame.throughVersion;
 
 export const waitForSessionMessages = (
 	client: SystemRpcClient,
@@ -12,18 +29,46 @@ export const waitForSessionMessages = (
 ): Promise<ReadonlyArray<Message>> =>
 	Effect.runPromise(
 		client["session.events"]({ sessionId }).pipe(
-			Stream.map(projectSessionEvent),
-			Stream.filter(
-				(projection) =>
-					projection._tag === "message" && predicate(projection.message),
+			Stream.flatMap((frame) =>
+				Stream.fromIterable(sessionFrameMessages(frame)),
 			),
-			Stream.map((projection) =>
-				projection._tag === "message" ? projection.message : null,
-			),
-			Stream.filter((message): message is Message => message !== null),
+			Stream.filter(predicate),
 			Stream.take(count),
 			Stream.runCollect,
 			Effect.map((messages) => Array.from(messages)),
+			Effect.timeout(timeoutMs),
+		),
+	);
+
+export const waitForActiveTurn = (
+	client: SystemRpcClient,
+	sessionId: SessionId,
+	timeoutMs = 10_000,
+): Promise<AgentTurnId> =>
+	Effect.runPromise(
+		client["session.events"]({ sessionId }).pipe(
+			Stream.map((frame): AgentTurnId | null => {
+				if (frame.kind === "snapshot") {
+					return frame.projection.currentTurn?.turnId ?? null;
+				}
+				if (
+					frame.kind === "event" &&
+					(frame.event._tag === "TurnStarted" ||
+						frame.event._tag === "TurnPhaseSet")
+				) {
+					return frame.event.turnId;
+				}
+				return null;
+			}),
+			Stream.filter((turnId): turnId is AgentTurnId => turnId !== null),
+			Stream.runHead,
+			Effect.flatMap((turnId) =>
+				turnId._tag === "Some"
+					? Effect.succeed(turnId.value)
+					: Effect.fail(
+							new Error("Session stream ended without an active turn."),
+						),
+			),
 			Effect.timeout(timeoutMs),
 		),
 	);

--- a/tests/system/test/system/conversation-reliability.system.test.ts
+++ b/tests/system/test/system/conversation-reliability.system.test.ts
@@ -1,5 +1,4 @@
 import type { ClientSession } from "@zuse/client-runtime/connection";
-import { projectSessionEvent } from "@zuse/client-runtime/session-events";
 import { MessageId } from "@zuse/contracts";
 import { Effect, Stream } from "effect";
 import { describe, expect, it } from "vitest";
@@ -8,7 +7,12 @@ import {
 	initializeSystemRepository,
 } from "../../src/conversation-fixture.ts";
 import type { SystemRpcClient } from "../../src/rpc-client.ts";
-import { waitForSessionMessages } from "../../src/session-observer.ts";
+import {
+	sessionFrameMessages,
+	sessionFrameVersion,
+	waitForActiveTurn,
+	waitForSessionMessages,
+} from "../../src/session-observer.ts";
 import { withSystemTest } from "../../src/system-scope.ts";
 
 describe("conversation process reliability", () => {
@@ -40,13 +44,13 @@ describe("conversation process reliability", () => {
 					session.client["session.events"]({
 						sessionId: conversation.initialSession.id,
 					}).pipe(
-						Stream.takeUntil(
-							(envelope) => projectSessionEvent(envelope)._tag === "message",
-						),
+						Stream.takeUntil((frame) => sessionFrameMessages(frame).length > 0),
 					),
 				),
 			);
-			const cursor = beforeDrop.at(-1)?.sequence;
+			const lastFrame = beforeDrop.at(-1);
+			const cursor =
+				lastFrame === undefined ? undefined : sessionFrameVersion(lastFrame);
 			if (cursor === undefined)
 				throw new Error("No replay cursor before disconnect.");
 
@@ -58,29 +62,25 @@ describe("conversation process reliability", () => {
 				Stream.runCollect(
 					session.client["session.events"]({
 						sessionId: conversation.initialSession.id,
-						afterSequence: cursor,
+						afterVersion: cursor,
+						hasProjection: true,
 					}).pipe(
-						Stream.takeUntil((envelope) => {
-							const projected = projectSessionEvent(envelope);
-							return (
-								projected._tag === "message" &&
-								projected.message.content._tag === "assistant"
-							);
-						}),
+						Stream.takeUntil((frame) =>
+							sessionFrameMessages(frame).some(
+								(message) => message.content._tag === "assistant",
+							),
+						),
 					),
 				),
 			);
-			expect(resumed.every((envelope) => envelope.sequence > cursor)).toBe(
+			const resumedEvents = resumed.filter((frame) => frame.kind === "event");
+			expect(resumedEvents.every((frame) => frame.streamVersion > cursor)).toBe(
 				true,
 			);
-			expect(new Set(resumed.map((envelope) => envelope.sequence)).size).toBe(
-				resumed.length,
-			);
 			expect(
-				resumed.filter(
-					(envelope) => projectSessionEvent(envelope)._tag === "message",
-				),
-			).toHaveLength(1);
+				new Set(resumedEvents.map((frame) => frame.streamVersion)).size,
+			).toBe(resumedEvents.length);
+			expect(resumed.flatMap(sessionFrameMessages)).toHaveLength(1);
 
 			await waitForSessionMessages(
 				session.client,
@@ -124,9 +124,14 @@ describe("conversation process reliability", () => {
 				}),
 			);
 			await controller.waitFor("prompt.held");
+			const turnId = await waitForActiveTurn(
+				session.client,
+				conversation.initialSession.id,
+			);
 			await Effect.runPromise(
 				session.client["messages.interrupt"]({
 					sessionId: conversation.initialSession.id,
+					turnId,
 				}),
 			);
 			await controller.waitFor("prompt.cancelled");
@@ -282,9 +287,14 @@ describe("conversation process reliability", () => {
 				}),
 			);
 			await controller.waitFor("prompt.received");
+			const turnId = await waitForActiveTurn(
+				session.client,
+				conversation.initialSession.id,
+			);
 			await Effect.runPromise(
 				session.client["messages.interrupt"]({
 					sessionId: conversation.initialSession.id,
+					turnId,
 				}),
 			);
 			await controller.waitFor("prompt.cancelled", undefined, 2_000);


### PR DESCRIPTION
## Summary
- release Zuse v0.15.0
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.15.0 after this PR lands.