### PR TITLE
Fix release packaging and updater retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,4 +69,6 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: bunx electron-builder --mac --universal --publish always
+        run: |
+          bun run native:build:universal
+          bunx electron-builder --mac --universal --publish always

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -84,6 +84,15 @@ npmRebuild: false
 
 mac:
   category: public.app-category.developer-tools
+  # Both per-architecture staging apps intentionally embed the same prebuilt
+  # universal Swift helpers. Allow the universal merger to keep that identical
+  # fat binary instead of rejecting it as an unexpected shared executable.
+  x64ArchFiles: "Contents/Resources/app/{local-connectivity,browser-credentials}/*"
+  # The bundled provider runtime has enough unpacked native files to exceed
+  # @electron/asar's minimatch pattern limit while merging architecture ASARs.
+  # Keep the architecture ASARs split; @electron/universal installs its tiny
+  # process.arch entrypoint and still produces one universal application.
+  mergeASARs: false
   # Two targets, one signed/notarized `.app`:
   #   * dmg  — what humans download from the Releases page for first install.
   #   * zip  — what `electron-updater` (Squirrel.Mac under the hood) consumes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -54,7 +54,7 @@
     "@types/node": "catalog:",
     "effect": "catalog:",
     "electron-builder": "^25.1.8",
-    "electron": "^42.1.0",
+    "electron": "42.1.0",
     "fix-path": "^4.0.0",
     "sharp": "^0.34.1",
     "tsdown": "^0.21.10",

--- a/apps/desktop/src/updater-errors.ts
+++ b/apps/desktop/src/updater-errors.ts
@@ -1,0 +1,34 @@
+const TRANSIENT_HTTP_STATUS =
+	/\b(?:408|425|429|500|502|503|504)\b|gateway time-out|service unavailable/i;
+const TRANSIENT_NETWORK_ERROR =
+	/\b(?:ECONNRESET|ECONNREFUSED|ENETDOWN|ENETUNREACH|ETIMEDOUT|EAI_AGAIN)\b/i;
+
+export const AUTOMATIC_UPDATE_RETRY_DELAYS_MS = [
+	15_000,
+	60_000,
+	5 * 60_000,
+] as const;
+
+const errorMessage = (error: unknown): string =>
+	error instanceof Error ? error.message : String(error);
+
+export const isTransientUpdateCheckError = (error: unknown): boolean => {
+	const message = errorMessage(error);
+	return (
+		TRANSIENT_HTTP_STATUS.test(message) || TRANSIENT_NETWORK_ERROR.test(message)
+	);
+};
+
+export const automaticUpdateRetryDelay = (
+	failedAttempt: number,
+): number | null => AUTOMATIC_UPDATE_RETRY_DELAYS_MS[failedAttempt] ?? null;
+
+export const updateCheckErrorMessage = (error: unknown): string =>
+	isTransientUpdateCheckError(error)
+		? "GitHub is temporarily unavailable. Try again in a moment."
+		: "Couldn’t check for updates. Try again.";
+
+export const updateDownloadErrorMessage = (error: unknown): string =>
+	isTransientUpdateCheckError(error)
+		? "The update service is temporarily unavailable. Try again in a moment."
+		: "Couldn’t download the update. Check your connection and try again.";

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -12,6 +12,12 @@ import {
   UPDATE_STATUS_CHANNEL,
   type UpdateStatus,
 } from "@zuse/contracts";
+import {
+  automaticUpdateRetryDelay,
+  isTransientUpdateCheckError,
+  updateCheckErrorMessage,
+  updateDownloadErrorMessage,
+} from "./updater-errors.ts";
 
 // electron-updater talks to the GitHub Releases feed configured in
 // apps/desktop/electron-builder.yml (`publish.provider: github`). It reads
@@ -33,6 +39,9 @@ const DOWNLOAD_STALL_MS = 60_000;
 
 let lastStatus: UpdateStatus = { kind: "idle" };
 let started = false;
+let activeUpdateCheck: "automatic" | "manual" | null = null;
+let updateCheckInFlight: Promise<void> | null = null;
+let automaticCheckRetryTimer: NodeJS.Timeout | null = null;
 
 // Set for the brief window between "the app is quitting to install an update"
 // and process exit. The `before-quit` agent guard in main.ts reads this so an
@@ -127,6 +136,68 @@ function emit(status: UpdateStatus): void {
   }
 }
 
+function clearAutomaticCheckRetry(): void {
+  if (automaticCheckRetryTimer === null) return;
+  clearTimeout(automaticCheckRetryTimer);
+  automaticCheckRetryTimer = null;
+}
+
+function scheduleAutomaticCheckRetry(
+  failedAttempt: number,
+  delayMs: number,
+): void {
+  clearAutomaticCheckRetry();
+  console.warn(
+    `[zuse:updater] automatic check failed — retrying in ${delayMs}ms`,
+  );
+  automaticCheckRetryTimer = setTimeout(() => {
+    automaticCheckRetryTimer = null;
+    void runUpdateCheck("automatic", failedAttempt + 1);
+  }, delayMs);
+  automaticCheckRetryTimer.unref();
+}
+
+/**
+ * Own every update check so transient failures from background polling can be
+ * retried without leaking electron-updater's raw HTTP response into the UI.
+ * Manual checks skip the backoff and surface a concise retryable error.
+ */
+function runUpdateCheck(
+  kind: "automatic" | "manual",
+  attempt = 0,
+): Promise<void> {
+  if (kind === "manual") clearAutomaticCheckRetry();
+  if (updateCheckInFlight !== null) return updateCheckInFlight;
+
+  activeUpdateCheck = kind;
+  const operation = Promise.resolve()
+    .then(() => autoUpdater.checkForUpdates())
+    .then(() => undefined)
+    .catch((error: unknown) => {
+      const retryDelay =
+        kind === "automatic" && isTransientUpdateCheckError(error)
+          ? automaticUpdateRetryDelay(attempt)
+          : null;
+      if (retryDelay !== null) {
+        console.warn("[zuse:updater] transient automatic check failure", error);
+        scheduleAutomaticCheckRetry(attempt, retryDelay);
+        return;
+      }
+      console.error("[zuse:updater] check failed", error);
+      emit({
+        kind: "error",
+        message: updateCheckErrorMessage(error),
+        retryable: true,
+      });
+    })
+    .finally(() => {
+      activeUpdateCheck = null;
+      updateCheckInFlight = null;
+    });
+  updateCheckInFlight = operation;
+  return operation;
+}
+
 /**
  * Snapshot of the latest update status. Menu rebuilds read this; everyone
  * else should subscribe via `onStatusChange` instead of polling.
@@ -213,13 +284,19 @@ export function startAutoUpdater(window: BrowserWindow): void {
   });
   autoUpdater.on("error", (err: Error) => {
     clearStallTimer();
-    emit({ kind: "error", message: err.message, retryable: true });
+    // checkForUpdates emits this event before rejecting its promise. The
+    // owned check path above decides whether to retry or surface the failure,
+    // avoiding duplicate/raw error toasts.
+    if (activeUpdateCheck !== null) return;
+    emit({
+      kind: "error",
+      message: updateDownloadErrorMessage(err),
+      retryable: true,
+    });
   });
 
   ipcMain.handle(UPDATE_CHECK_CHANNEL, async () => {
-    await autoUpdater.checkForUpdates().catch((err) => {
-      console.error("[zuse:updater] check failed", err);
-    });
+    await runUpdateCheck("manual");
   });
   ipcMain.handle(UPDATE_DOWNLOAD_CHANNEL, async () => {
     await autoUpdater.downloadUpdate().catch((err) => {
@@ -233,9 +310,7 @@ export function startAutoUpdater(window: BrowserWindow): void {
   });
 
   const check = () => {
-    autoUpdater.checkForUpdates().catch((err) => {
-      console.error("[zuse:updater] check failed", err);
-    });
+    void runUpdateCheck("automatic");
   };
   check();
   setInterval(check, UPDATE_POLL_MS);
@@ -247,9 +322,7 @@ export function startAutoUpdater(window: BrowserWindow): void {
  * routing through IPC would just bounce back to the same `autoUpdater` calls.
  */
 export function triggerUpdateCheck(): void {
-  autoUpdater.checkForUpdates().catch((err) => {
-    console.error("[zuse:updater] check failed", err);
-  });
+  void runUpdateCheck("manual");
 }
 
 export function triggerUpdateDownload(): void {

--- a/apps/desktop/test/unit/updater-errors.test.ts
+++ b/apps/desktop/test/unit/updater-errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	AUTOMATIC_UPDATE_RETRY_DELAYS_MS,
+	automaticUpdateRetryDelay,
+	isTransientUpdateCheckError,
+	updateCheckErrorMessage,
+} from "../../src/updater-errors.ts";
+
+describe("desktop updater errors", () => {
+	it.each([
+		408, 425, 429, 500, 502, 503, 504,
+	])("classifies HTTP %i as transient", (status) => {
+		expect(
+			isTransientUpdateCheckError(
+				new Error(`HttpError: ${status} while reading releases/latest`),
+			),
+		).toBe(true);
+	});
+
+	it.each([
+		"ECONNRESET",
+		"ENETUNREACH",
+		"ETIMEDOUT",
+		"EAI_AGAIN",
+	])("classifies %s as transient", (code) => {
+		expect(isTransientUpdateCheckError(new Error(code))).toBe(true);
+	});
+
+	it("does not classify integrity failures as transient", () => {
+		expect(
+			isTransientUpdateCheckError(
+				new Error("Downloaded update has an invalid signature"),
+			),
+		).toBe(false);
+	});
+
+	it("uses bounded retry backoff", () => {
+		expect(AUTOMATIC_UPDATE_RETRY_DELAYS_MS).toEqual([15_000, 60_000, 300_000]);
+		expect(automaticUpdateRetryDelay(0)).toBe(15_000);
+		expect(automaticUpdateRetryDelay(2)).toBe(300_000);
+		expect(automaticUpdateRetryDelay(3)).toBeNull();
+	});
+
+	it("does not expose raw transport responses to the UI", () => {
+		const message = updateCheckErrorMessage(
+			new Error(
+				"HttpError: 504 Data: <html><body><h1>Gateway Time-out</h1></body></html>",
+			),
+		);
+		expect(message).toBe(
+			"GitHub is temporarily unavailable. Try again in a moment.",
+		);
+		expect(message).not.toContain("<html>");
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "@zuse/server": "*",
         "@zuse/ssh": "*",
         "effect": "catalog:",
-        "electron": "^42.1.0",
+        "electron": "42.1.0",
         "electron-builder": "^25.1.8",
         "fix-path": "^4.0.0",
         "sharp": "^0.34.1",


### PR DESCRIPTION
## Summary
- pin Electron so the release packager resolves the runtime deterministically
- build and preserve universal native helpers during release packaging
- retry transient automatic update checks with bounded backoff and concise UI errors

## Root cause
The release runner could not infer an exact Electron version from the Bun workspace. Once pinned, universal packaging also required the existing native-helper build and explicit handling for identical universal executables and large unpacked ASAR sets. Automatic checks surfaced transient GitHub 5xx responses directly instead of retrying.

## Validation
- `bun install --frozen-lockfile`
- `bun run check-types` (23/23 tasks)
- `bun run build`
- desktop unit tests (33/33)
- unsigned universal packaging
- verified both native helpers contain x86_64 and arm64 architectures