### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1]
+
+### Changed
+- Fix macOS launch entitlement rejection
+
 ## [0.15.0]
 
 ### Changed

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -27,13 +27,5 @@
   <true/>
   <key>com.apple.security.network.server</key>
   <true/>
-
-  <!-- The signed desktop helper and iOS app share only a random, synchronized
-       local-pairing trust record. Account identity is never inferred from a
-       device name or network address. -->
-  <key>keychain-access-groups</key>
-  <array>
-    <string>HMCST4VV42.com.zuse.shared-connectivity</string>
-  </array>
 </dict>
 </plist>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "type": "module",
   "productName": "Zuse (Beta)",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Zuse (Beta) desktop app",
   "private": true,
   "author": {

--- a/apps/desktop/test/unit/local-connectivity-helper.test.ts
+++ b/apps/desktop/test/unit/local-connectivity-helper.test.ts
@@ -2,6 +2,15 @@ import { readFileSync } from "node:fs";
 import { describe, expect, test } from "vitest";
 
 describe("local connectivity helper", () => {
+	test("does not require an unavailable desktop keychain access group", () => {
+		const entitlements = readFileSync(
+			new URL("../../build/entitlements.mac.plist", import.meta.url),
+			"utf8",
+		);
+
+		expect(entitlements).not.toContain("<key>keychain-access-groups</key>");
+	});
+
 	test("replaces the active Bonjour listener before publishing another", () => {
 		const source = readFileSync(
 			new URL("../../native/local-connectivity/main.swift", import.meta.url),

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.15.1",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix macOS launch entitlement rejection"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.15.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release Zuse v0.15.1
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.15.1 after this PR lands.