### PR TITLE
Release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2]
+
+### Changed
+- Add Claude Opus 5 model support
+
 ## [0.15.1]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "type": "module",
   "productName": "Zuse (Beta)",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Zuse (Beta) desktop app",
   "private": true,
   "author": {

--- a/apps/renderer/src/components/cost-footer.tsx
+++ b/apps/renderer/src/components/cost-footer.tsx
@@ -13,6 +13,7 @@ const EMPTY: ReadonlyArray<Message> = [];
 const MODEL_LABEL: Record<string, string> = {
 	"claude-sonnet-5": "Sonnet",
 	"claude-fable-5": "Fable",
+	"claude-opus-5": "Opus",
 	"claude-opus-4-7": "Opus",
 	"claude-sonnet-4-6": "Sonnet",
 	"claude-haiku-4-5": "Haiku",

--- a/apps/renderer/src/components/subagent-row.tsx
+++ b/apps/renderer/src/components/subagent-row.tsx
@@ -19,6 +19,7 @@ import { Spinner } from "./ui/spinner";
 const MODEL_LABEL: Record<string, string> = {
 	"claude-sonnet-5": "Sonnet 5",
 	"claude-fable-5": "Fable 5",
+	"claude-opus-5": "Opus 5",
 	"claude-opus-4-7": "Opus 4.7",
 	"claude-sonnet-4-6": "Sonnet 4.6",
 	"claude-haiku-4-5": "Haiku 4.5",

--- a/apps/server/test/integration/config-store.test.ts
+++ b/apps/server/test/integration/config-store.test.ts
@@ -97,6 +97,7 @@ describe("config-store settings coercion", () => {
 			true,
 		);
 		expect(settings.modelEnabledByProvider.claude["claude-fable-5"]).toBe(true);
+		expect(settings.modelEnabledByProvider.claude["claude-opus-5"]).toBe(true);
 		expect(settings.modelEnabledByProvider.claude["claude-sonnet-4-6"]).toBe(
 			false,
 		);

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.15.2",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Add Claude Opus 5 model support"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.15.1",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -1006,6 +1006,27 @@ export const MODELS_BY_PROVIDER: Record<
       supportsWebSearch: "native",
     },
     {
+      id: "claude-opus-5",
+      label: "Opus 5",
+      badgeLabel: "New",
+      optionDescriptors: [
+        claudeEffortDescriptor({
+          options: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "xhigh", label: "Extra High" },
+            { id: "max", label: "Max" },
+            { id: "ultracode", label: "Ultracode" },
+          ],
+          defaultId: "high",
+        }),
+        staticContextWindowDescriptor("1m", "1M"),
+      ],
+      supportsPlanMode: true,
+      supportsWebSearch: "native",
+    },
+    {
       id: "claude-sonnet-5",
       label: "Sonnet 5",
       badgeLabel: "New",
@@ -1390,10 +1411,12 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<
   Record<string, string>
 > = {
   // Short / vendor-formatted slugs and pre-pricing-reset names route to the
-  // canonical 4.x slugs above, so a user typing `opus` or `sonnet-4.6`
+  // canonical slugs above, so a user typing `opus` or `sonnet-4.6`
   // resolves to the current model id.
   claude: {
-    opus: "claude-opus-4-8",
+    opus: "claude-opus-5",
+    "opus-5": "claude-opus-5",
+    "claude-opus-5": "claude-opus-5",
     "opus-4.8": "claude-opus-4-8",
     "claude-opus-4.8": "claude-opus-4-8",
     "opus-4.7": "claude-opus-4-7",
@@ -1480,6 +1503,12 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   // to $10 in / $50 out for ~2.5x throughput; we don't encode that here,
   // the renderer's cost footer applies the multiplier when the session
   // flips the boolean. 1M context window: no per-token premium.
+  "claude-opus-5": {
+    input: 5,
+    output: 25,
+    cacheRead: 0.5,
+    cacheCreate: 6.25,
+  },
   "claude-opus-4-8": {
     input: 5,
     output: 25,

--- a/packages/contracts/test/unit/schema.test.ts
+++ b/packages/contracts/test/unit/schema.test.ts
@@ -755,9 +755,13 @@ describe("model visibility helpers", () => {
 	it("uses Sonnet 5 as the default visible Claude model", () => {
 		expect(defaultModelFor("claude")).toBe("claude-sonnet-5");
 		expect(visibleModelsForProvider("claude")[0]?.id).toBe("claude-fable-5");
+		expect(visibleModelsForProvider("claude")[1]?.id).toBe("claude-opus-5");
 		expect(isModelVisible("claude", "claude-sonnet-5")).toBe(true);
 		expect(isModelVisible("claude", "claude-fable-5")).toBe(true);
+		expect(isModelVisible("claude", "claude-opus-5")).toBe(true);
 		expect(resolveModelSlug("claude", "fable")).toBe("claude-fable-5");
+		expect(resolveModelSlug("claude", "opus")).toBe("claude-opus-5");
+		expect(resolveModelSlug("claude", "opus-5")).toBe("claude-opus-5");
 		expect(
 			MODELS_BY_PROVIDER.claude.find((m) => m.id === "claude-sonnet-5")
 				?.badgeLabel,
@@ -766,6 +770,10 @@ describe("model visibility helpers", () => {
 			MODELS_BY_PROVIDER.claude.find((m) => m.id === "claude-fable-5")
 				?.badgeLabel,
 		).toBe("Available now");
+		expect(
+			MODELS_BY_PROVIDER.claude.find((m) => m.id === "claude-opus-5")
+				?.badgeLabel,
+		).toBe("New");
 		expect(isModelVisible("claude", "claude-sonnet-4-6")).toBe(false);
 	});
 


### PR DESCRIPTION
## Summary
- release Zuse v0.15.2
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.15.2 after this PR lands.