### PR TITLE
Release v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3]
+
+### Changed
+- Recover and cache stalled chat timelines (#392)
+
 ## [0.15.2]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "type": "module",
   "productName": "Zuse (Beta)",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Zuse (Beta) desktop app",
   "private": true,
   "author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.15.3",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Recover and cache stalled chat timelines (#392)"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.15.2",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary
- release Zuse v0.15.3
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.15.3 after this PR lands.