### PR TITLE
Release v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.4]
+
+### Changed
+- Fix stale reactor replay crash
+
 ## [0.15.3]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "type": "module",
   "productName": "Zuse (Beta)",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Zuse (Beta) desktop app",
   "private": true,
   "author": {

--- a/apps/server/src/conversation/core/provider-reactor-handlers.ts
+++ b/apps/server/src/conversation/core/provider-reactor-handlers.ts
@@ -332,6 +332,22 @@ export const makeProviderReactorHandlers = (
 							createdAt: Date.now(),
 						},
 					})
+					.pipe(
+						Effect.catchTag("TurnAlreadyRunning", () =>
+							sessionDomain.dispatch({
+								commandId: `${reactorInput.commandId}:requeue`,
+								streamId: sessionId,
+								command: {
+									_tag: "EnqueueTurn",
+									queueId: reactorInput.command.queueId,
+									inputJson: reactorInput.command.inputJson,
+									position: 0,
+									createdAt: Date.now(),
+									ready: true,
+								},
+							}),
+						),
+					)
 					.pipe(Effect.orDie);
 				yield* reactorEffects.complete(reactorInput.commandId);
 			});

--- a/apps/server/test/unit/provider-reactor-handlers.test.ts
+++ b/apps/server/test/unit/provider-reactor-handlers.test.ts
@@ -1,0 +1,91 @@
+import { AgentTurnId, SessionId } from "@zuse/contracts";
+import { TurnAlreadyRunning } from "@zuse/domain/core/decider";
+import type { SessionDomainApi } from "@zuse/domain/engine/session-domain";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	makeProviderReactorHandlers,
+	type ProviderReactorHandlersOptions,
+} from "../../src/conversation/core/provider-reactor-handlers.ts";
+
+describe("provider reactor handlers", () => {
+	it("requeues a scheduled successor that was superseded before replay", async () => {
+		const dispatched: Array<{
+			readonly commandId: string;
+			readonly command: { readonly _tag: string };
+		}> = [];
+		const completed: string[] = [];
+		const sessionDomain = {
+			dispatch: (input: Parameters<SessionDomainApi["dispatch"]>[0]) => {
+				dispatched.push(input);
+				return input.command._tag === "SubmitTurn"
+					? Effect.fail(new TurnAlreadyRunning({ turnId: "turn-current" }))
+					: Effect.succeed({
+							commandId: input.commandId,
+							streamId: input.streamId,
+							streamVersion: 1,
+							eventIds: [],
+						});
+			},
+		} as unknown as SessionDomainApi;
+		const reactorEffects = {
+			isCompleted: () => Effect.succeed(false),
+			complete: (effectId: string) =>
+				Effect.sync(() => {
+					completed.push(effectId);
+				}),
+		} as ProviderReactorHandlersOptions["reactorEffects"];
+		const handlers = makeProviderReactorHandlers({
+			reactorEffects,
+			getSession: (() =>
+				Effect.die("unused")) as ProviderReactorHandlersOptions["getSession"],
+			openProviderSession: (() =>
+				Effect.die(
+					"unused",
+				)) as ProviderReactorHandlersOptions["openProviderSession"],
+			persistMessage: (() =>
+				Effect.die(
+					"unused",
+				)) as ProviderReactorHandlersOptions["persistMessage"],
+			ndjsonAppend: () => Effect.void,
+			setStatus: () => Effect.void,
+			settleTurnFromReactor: () => Effect.void,
+			provider: {} as ProviderReactorHandlersOptions["provider"],
+			sessionDomain,
+			autoNameChat: () => Effect.void,
+		});
+
+		await Effect.runPromise(
+			handlers.handleScheduledSuccessor({
+				commandId: "reactor:scheduled-successor:event-ready:0",
+				streamId: SessionId.make("session-1"),
+				correlationId: "correlation-1",
+				causationEventId: "event-ready",
+				command: {
+					_tag: "StartScheduledSuccessor",
+					turnId: AgentTurnId.make("turn-scheduled"),
+					queueId: "queue-1",
+					inputJson:
+						'{"text":"preserve me","attachments":[],"fileRefs":[],"skillRefs":[],"annotations":[]}',
+				},
+			}),
+		);
+
+		expect(dispatched.map(({ command }) => command._tag)).toEqual([
+			"SubmitTurn",
+			"EnqueueTurn",
+		]);
+		expect(dispatched[1]).toMatchObject({
+			commandId: "reactor:scheduled-successor:event-ready:0:requeue",
+			command: {
+				_tag: "EnqueueTurn",
+				queueId: "queue-1",
+				inputJson:
+					'{"text":"preserve me","attachments":[],"fileRefs":[],"skillRefs":[],"annotations":[]}',
+				position: 0,
+				ready: true,
+			},
+		});
+		expect(completed).toEqual(["reactor:scheduled-successor:event-ready:0"]);
+	});
+});

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.15.4",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix stale reactor replay crash"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.15.3",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/packages/domain/src/core/decider.ts
+++ b/packages/domain/src/core/decider.ts
@@ -248,6 +248,7 @@ export const decide = (
 				: success([{ ...command, _tag: "TurnInterruptRequested" }]);
 		case "AcknowledgeTurnInterrupt":
 			if (state.currentTurnId !== command.turnId) {
+				if (state.settledTurnIds.has(command.turnId)) return success([]);
 				return Result.fail(
 					new TurnConflict({
 						expectedTurnId: command.turnId,
@@ -258,15 +259,18 @@ export const decide = (
 			return state.currentTurnPhase === "interrupt-acknowledged"
 				? success([])
 				: success([{ ...command, _tag: "TurnInterruptAcknowledged" }]);
-		case "FailTurnInterrupt":
-			return state.currentTurnId === command.turnId
-				? success([{ ...command, _tag: "TurnInterruptFailed" }])
-				: Result.fail(
-						new TurnConflict({
-							expectedTurnId: command.turnId,
-							actualTurnId: state.currentTurnId,
-						}),
-					);
+		case "FailTurnInterrupt": {
+			if (state.currentTurnId !== command.turnId) {
+				if (state.settledTurnIds.has(command.turnId)) return success([]);
+				return Result.fail(
+					new TurnConflict({
+						expectedTurnId: command.turnId,
+						actualTurnId: state.currentTurnId,
+					}),
+				);
+			}
+			return success([{ ...command, _tag: "TurnInterruptFailed" }]);
+		}
 		case "EnqueueTurn":
 			return state.queuedTurns.has(command.queueId)
 				? success([])

--- a/packages/domain/test/unit/core/decider.test.ts
+++ b/packages/domain/test/unit/core/decider.test.ts
@@ -329,6 +329,39 @@ describe("session decider", () => {
 		expect(running.currentTurnId).toBe("turn-2");
 	});
 
+	test("treats terminal interrupt replay for a settled turn as idempotent", () => {
+		const running = evolveAll(created(), [
+			{ _tag: "TurnStarted", turnId: "turn-1", startedAt: 2 },
+			{
+				_tag: "TurnSettled",
+				turnId: "turn-1",
+				outcome: "interrupted",
+				settledAt: 3,
+			},
+			{ _tag: "TurnStarted", turnId: "turn-2", startedAt: 4 },
+		]);
+
+		expect(
+			Result.getOrThrow(
+				decide(running, {
+					_tag: "AcknowledgeTurnInterrupt",
+					turnId: "turn-1",
+					acknowledgedAt: 5,
+				}),
+			),
+		).toEqual([]);
+		expect(
+			Result.getOrThrow(
+				decide(running, {
+					_tag: "FailTurnInterrupt",
+					turnId: "turn-1",
+					reason: "replayed after restart",
+					failedAt: 5,
+				}),
+			),
+		).toEqual([]);
+	});
+
 	test("atomically claims a queued turn, requests interrupt, and schedules its successor", () => {
 		const running = evolveAll(created(), [
 			{ _tag: "TurnStarted", turnId: "turn-1", startedAt: 2 },


### PR DESCRIPTION
## Summary
- release Zuse v0.15.4
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.15.4 after this PR lands.