### PR TITLE
Keep interrupts and steering alive across disconnects

### DIFF
--- a/apps/renderer/src/store/messages.ts
+++ b/apps/renderer/src/store/messages.ts
@@ -39,6 +39,8 @@ let getMessagesRpcClient: typeof getRpcClient = getRpcClient;
 let dispatchMessagesRpcCommand: typeof dispatchRetryableRpcCommand =
   dispatchRetryableRpcCommand;
 const queueFlushTails = new Map<SessionId, Promise<void>>();
+const pendingInterrupts = new Set<SessionId>();
+const pendingSteers = new Set<string>();
 
 export const setMessagesRpcClientForTest = (fn: typeof getRpcClient): void => {
   getMessagesRpcClient = fn;
@@ -1019,6 +1021,8 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     }
   },
   interrupt: async (sessionId) => {
+    if (pendingInterrupts.has(sessionId)) return;
+    pendingInterrupts.add(sessionId);
     try {
 			const turnId =
 				timelineRegistry.state(sessionId).projection?.currentTurn?.turnId;
@@ -1034,6 +1038,8 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
           [sessionId]: classifyError(err, lookupSessionProvider(sessionId)),
         },
       }));
+    } finally {
+      pendingInterrupts.delete(sessionId);
     }
   },
 	queue: (sessionId, input, options) => {
@@ -1268,19 +1274,12 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
     })();
   },
   steerFromQueue: async (sessionId, queueId) => {
+    const pendingKey = `${sessionId}:${queueId}`;
+    if (pendingSteers.has(pendingKey)) return;
     const queue = get().queueBySession[sessionId] ?? [];
     const item = queue.find((q) => q.id === queueId);
     if (!item) return;
-    // Optimistic — drop the chip from the queue before issuing the RPCs so
-    // a re-click can't fire twice.
-    set((s) => ({
-      queueBySession: {
-        ...s.queueBySession,
-        [sessionId]: (s.queueBySession[sessionId] ?? []).filter(
-          (q) => q.id !== queueId,
-        ),
-      },
-    }));
+    pendingSteers.add(pendingKey);
     try {
       const client = await getMessagesRpcClient();
 			const currentTurn =
@@ -1295,11 +1294,19 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
 						sessionId,
 						expectedTurnId: currentTurn.turnId,
 						queueId,
-						successorTurnId: AgentTurnId.make(`turn_${crypto.randomUUID()}`),
-						commandId: `steer:${sessionId}:${queueId}:${crypto.randomUUID()}`,
+						successorTurnId: AgentTurnId.make(`turn_${queueId}`),
+						commandId: `steer:${sessionId}:${queueId}`,
 					}),
 				);
 			}
+      set((s) => ({
+        queueBySession: {
+          ...s.queueBySession,
+          [sessionId]: (s.queueBySession[sessionId] ?? []).filter(
+            (q) => q.id !== queueId,
+          ),
+        },
+      }));
     } catch (err) {
       set((s) => ({
         errorBySession: {
@@ -1307,6 +1314,8 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
           [sessionId]: classifyError(err, lookupSessionProvider(sessionId)),
         },
       }));
+    } finally {
+      pendingSteers.delete(pendingKey);
     }
   },
   observeSessionStatus: (sessionId, status) => {

--- a/apps/renderer/test/unit/messages-store.test.ts
+++ b/apps/renderer/test/unit/messages-store.test.ts
@@ -187,6 +187,22 @@ describe("messages store queue actions", () => {
 		expect(sendNowCalls).toEqual([{ sessionId, queueId: queued.id }]);
 	});
 
+	it("keeps a queued item visible when steering fails", async () => {
+		rpcClientFactory = () =>
+			({
+				...makeQueueClient(),
+				"messages.queue.sendNow": () => Effect.fail(new Error("conflict")),
+			}) as unknown as Awaited<
+				ReturnType<typeof import("../../src/lib/rpc-client.ts").getRpcClient>
+			>;
+
+		await useMessagesStore.getState().steerFromQueue(sessionId, queued.id);
+
+		expect(useMessagesStore.getState().queueBySession[sessionId]).toEqual([
+			queued,
+		]);
+	});
+
 	it("resumes a paused queue through the resume RPC", async () => {
 		useMessagesStore.setState({
 			queuePausedBySession: { [sessionId]: true },

--- a/apps/server/src/conversation/core/message-operations.ts
+++ b/apps/server/src/conversation/core/message-operations.ts
@@ -11,7 +11,7 @@ import {
 	type Session,
 	SessionId,
 	type SessionNotFoundError,
-	SessionStartError,
+	type SessionStartError,
 	type SkillRef,
 } from "@zuse/contracts";
 import type { SessionCommand } from "@zuse/domain/core/commands";
@@ -24,6 +24,7 @@ import { serializeAnnotations } from "./conversation-input.ts";
 import type { PersistedMessage } from "./conversation-store-types.ts";
 import type { QueueServiceRuntime } from "./queue-service-runtime.ts";
 import { makeQueueServiceRuntime } from "./queue-service-runtime.ts";
+import { handoffToServiceScope } from "./service-scope.ts";
 
 export interface MessageOperationsOptions {
 	readonly sql: SqlClient.SqlClient;
@@ -442,13 +443,17 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 		) =>
 			Effect.gen(function* () {
 				yield* lookupSession(sessionId);
-				yield* dispatchSessionCommand(sessionId, {
-					_tag: "RequestTurnInterrupt",
-					turnId,
-					requestedAt: Date.now(),
-				});
-				yield* queueRuntime.pauseAfterInterrupt(sessionId);
-				yield* runSessionReactors;
+				yield* handoffToServiceScope(
+					dispatchSessionCommand(sessionId, {
+						_tag: "RequestTurnInterrupt",
+						turnId,
+						requestedAt: Date.now(),
+					}).pipe(
+						Effect.andThen(queueRuntime.pauseAfterInterrupt(sessionId)),
+					),
+					runSessionReactors,
+					serviceScope,
+				);
 			});
 
 		return { resumeSession, sendMessage, interruptSession, queueRuntime };

--- a/apps/server/src/conversation/core/queue-service-runtime.ts
+++ b/apps/server/src/conversation/core/queue-service-runtime.ts
@@ -13,6 +13,7 @@ import type { SessionCommand } from "@zuse/domain/core/commands";
 import { Effect, type Scope, Semaphore } from "effect";
 import type { SqlClient } from "effect/unstable/sql";
 import type { QueueServiceShape } from "../services/conversation-services.ts";
+import { handoffToServiceScope } from "./service-scope.ts";
 
 interface QueuedMessageRow {
 	readonly id: string;
@@ -357,14 +358,17 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 		) =>
 			Effect.gen(function* () {
 				yield* lookupSession(sessionId);
-				yield* dispatchSessionCommandWithId(sessionId, commandId, {
-					_tag: "SteerQueuedTurn",
-					expectedTurnId,
-					queueId,
-					successorTurnId,
-					requestedAt: Date.now(),
-				});
-				yield* runSessionReactors;
+				yield* handoffToServiceScope(
+					dispatchSessionCommandWithId(sessionId, commandId, {
+						_tag: "SteerQueuedTurn",
+						expectedTurnId,
+						queueId,
+						successorTurnId,
+						requestedAt: Date.now(),
+					}),
+					runSessionReactors,
+					serviceScope,
+				);
 			});
 
 		const flushQueuedMessages: QueueServiceShape["flushQueuedMessages"] = (

--- a/apps/server/src/conversation/core/service-scope.ts
+++ b/apps/server/src/conversation/core/service-scope.ts
@@ -1,0 +1,18 @@
+import { Effect, Fiber, type Scope } from "effect";
+
+/**
+ * Persists work and hands it to the conversation service lifetime without an
+ * interruptible gap. Connected callers still await the result, but once the
+ * handoff completes their cancellation cannot stop the service-owned fiber.
+ */
+export const handoffToServiceScope = <A, E, R, EPrepare, RPrepare>(
+	prepare: Effect.Effect<void, EPrepare, RPrepare>,
+	work: Effect.Effect<A, E, R>,
+	scope: Scope.Scope,
+): Effect.Effect<A, E | EPrepare, R | RPrepare> =>
+	Effect.uninterruptibleMask((restore) =>
+		prepare.pipe(
+			Effect.andThen(Effect.forkIn(work, scope)),
+			Effect.flatMap((fiber) => restore(Fiber.join(fiber))),
+		),
+	);

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -147,6 +147,7 @@ let failProviderStart = false;
 let failProviderSend = false;
 let providerStartFailureReason = "scripted start failure";
 let providerStartBarrier: Promise<void> | null = null;
+let providerInterruptBarrier: Promise<void> | null = null;
 let testAutonomyLevel: AutonomyLevel = "approval-gated";
 let createdWorktreeCount = 0;
 let createdWorktrees = new Map<string, Worktree>();
@@ -209,7 +210,10 @@ const StubProviderLive = Layer.succeed(ProviderService, {
 						}),
 			),
 		),
-	interrupt: () => Effect.void,
+	interrupt: () =>
+		providerInterruptBarrier === null
+			? Effect.void
+			: Effect.promise(() => providerInterruptBarrier as Promise<void>),
 	close: () => Effect.void,
 	events: (sessionId) =>
 		Stream.suspend(() =>
@@ -629,6 +633,7 @@ beforeEach(() => {
 	failProviderSend = false;
 	providerStartFailureReason = "scripted start failure";
 	providerStartBarrier = null;
+	providerInterruptBarrier = null;
 	testAutonomyLevel = "approval-gated";
 	createdWorktreeCount = 0;
 	createdWorktrees = new Map();
@@ -3504,6 +3509,70 @@ describe("ConversationServices — chat & session lifecycle", () => {
 				Effect.flatMap(store, (s) => s.getSession(initialSession.id)),
 			);
 			expect(interruptedSession.status).toBe("idle");
+		});
+	});
+
+	it("settles an interrupt after the requesting client disconnects", async () => {
+		await withRuntime(async (run) => {
+			const interruptBarrier = deferred<void>();
+			providerInterruptBarrier = interruptBarrier.promise;
+			const { initialSession } = await run(
+				Effect.flatMap(store, (s) =>
+					s.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+						initialPrompt: "already running",
+					}),
+				),
+			);
+			const interruptedTurnId = requireProviderTurnId(initialSession.id);
+
+			await run(
+				Effect.gen(function* () {
+					const service = yield* store;
+					const sql = yield* SqlClient.SqlClient;
+					const requestFiber = yield* Effect.forkChild(
+						service.interruptSession(initialSession.id, interruptedTurnId),
+					);
+					yield* Effect.gen(function* () {
+						const rows = yield* sql<{ readonly count: number }>`
+							SELECT COUNT(*) AS count FROM events
+							WHERE stream_id = ${initialSession.id}
+								AND type = 'TurnInterruptRequested'
+						`;
+						if ((rows[0]?.count ?? 0) === 0) {
+							return yield* Effect.fail("interrupt not requested");
+						}
+					}).pipe(
+						Effect.retry(
+							Schedule.max([
+								Schedule.spaced("10 millis"),
+								Schedule.recurs(100),
+							]),
+						),
+					);
+					yield* Fiber.interrupt(requestFiber);
+					yield* Effect.sync(() => interruptBarrier.resolve());
+					yield* Effect.gen(function* () {
+						const rows = yield* sql<{ readonly count: number }>`
+							SELECT COUNT(*) AS count FROM events
+							WHERE stream_id = ${initialSession.id}
+								AND type = 'TurnSettled'
+						`;
+						if ((rows[0]?.count ?? 0) === 0) {
+							return yield* Effect.fail("interrupt not settled");
+						}
+					}).pipe(
+						Effect.retry(
+							Schedule.max([
+								Schedule.spaced("10 millis"),
+								Schedule.recurs(100),
+							]),
+						),
+					);
+				}),
+			);
 		});
 	});
 


### PR DESCRIPTION
## What changed

- hand durable interrupt and steer reactors to the conversation service scope before awaiting them
- make the persistence-to-worker handoff atomic against request cancellation
- reuse stable command and successor turn identities for steer retries across reloads
- coalesce duplicate renderer actions and keep queued chips visible when steering fails
- add regression coverage for caller disconnects and failed steering

## Root cause

Interrupt and steer reactors ran in the renderer RPC request lifetime. Reloading or losing the renderer connection after durable intent was recorded could cancel the reactor before it settled the turn. Steering also generated new identities on every retry, allowing a lost response to become a distinct durable command.

## Impact

Reloads and RPC disconnects no longer strand active turns in interrupt-requested state. Retried steering is idempotent, duplicate clicks are coalesced, and failed actions remain visibly retryable.

## Validation

- renderer and server type checks
- focused renderer/server regressions: 5 passing
- full affected test files: 94 passing; one unrelated pre-existing server assertion mismatch remains on main
- two-axis standards/spec review: no blocking findings