### PR TITLE
Avoid decrypting unrelated keychain credentials

### DIFF
--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -10,9 +10,9 @@ const LEGACY_SERVICE_NAME = "memoize";
 
 /**
  * Keychain entries are namespaced as `apiKey:<providerId>` under the
- * `zuse` service. Listing uses `findCredentials(SERVICE_NAME)` and filters
- * to the `apiKey:` prefix — keeps room for future credential kinds (refresh
- * tokens, OAuth state) without colliding with API keys.
+ * `zuse` service. Discovery queries these exact accounts instead of enumerating
+ * the service: `findCredentials` decrypts every matching item, which can make
+ * macOS prompt for unrelated browser, integration, auth, or MCP credentials.
  */
 const accountFor = (providerId: ProviderId): string => `apiKey:${providerId}`;
 
@@ -82,9 +82,6 @@ const KNOWN_PROVIDERS: ReadonlyArray<ProviderId> = [
 	"cursor",
 ];
 
-const isKnownProvider = (id: string): id is ProviderId =>
-	(KNOWN_PROVIDERS as ReadonlyArray<string>).includes(id);
-
 const providerCache = new Map<ProviderId, string | null>();
 const browserCache = new Map<string, BrowserCred | null>();
 let configuredCache: ReadonlyArray<ProviderId> | null = null;
@@ -99,19 +96,6 @@ const invalidateProviderList = (): void => {
 
 const invalidateBrowserList = (): void => {
 	browserListCache = null;
-};
-
-const collectConfigured = (
-	entries: ReadonlyArray<{ account: string }>,
-): ProviderId[] => {
-	const out: ProviderId[] = [];
-	for (const { account } of entries) {
-		const idx = account.indexOf(":");
-		if (idx === -1 || account.slice(0, idx) !== "apiKey") continue;
-		const id = account.slice(idx + 1);
-		if (isKnownProvider(id) && !out.includes(id)) out.push(id);
-	}
-	return out;
 };
 
 const collectBrowser = (
@@ -152,6 +136,18 @@ const getPasswordWithLegacyPromotion = async (
 		await keytar.setPassword(SERVICE_NAME, account, legacy);
 	}
 	return legacy;
+};
+
+const findConfiguredProviders = async (): Promise<ProviderId[]> => {
+	const entries = await Promise.all(
+		KNOWN_PROVIDERS.map(async (providerId) => ({
+			providerId,
+			password: await getPasswordWithLegacyPromotion(accountFor(providerId)),
+		})),
+	);
+	return entries
+		.filter(({ password }) => password !== null)
+		.map(({ providerId }) => providerId);
 };
 
 export const CredentialsServiceLive = Layer.succeed(
@@ -201,9 +197,7 @@ export const CredentialsServiceLive = Layer.succeed(
 		listConfigured: () =>
 			configuredCache !== null
 				? Effect.succeed(configuredCache)
-				: tryKeychain("*", () =>
-						keytar.findCredentials(SERVICE_NAME).then(collectConfigured),
-					).pipe(
+				: tryKeychain("*", findConfiguredProviders).pipe(
 						Effect.tap((value) =>
 							Effect.sync(() => {
 								configuredCache = value;

--- a/apps/server/test/unit/credentials-service.test.ts
+++ b/apps/server/test/unit/credentials-service.test.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, type Mock, vi } from "vitest";
 
 const keytar = vi.hoisted(() => ({
 	deletePassword: vi.fn(async () => false),
@@ -14,7 +14,17 @@ import { CredentialsServiceLive } from "../../src/provider/layers/credentials-se
 import { CredentialsService } from "../../src/provider/services/credentials-service.ts";
 
 describe("CredentialsService", () => {
-	it("does not enumerate legacy keychain entries during startup discovery", async () => {
+	it("discovers API keys without decrypting unrelated keychain entries", async () => {
+		keytar.findCredentials.mockRejectedValue(
+			new Error("would prompt for an unrelated integration credential"),
+		);
+		const credentialLookup = keytar.getPassword as unknown as Mock<
+			(service: string, account: string) => Promise<string | null>
+		>;
+		credentialLookup.mockImplementation(async (service, account) =>
+			service === "zuse" && account === "apiKey:codex" ? "" : null,
+		);
+
 		const configured = await Effect.runPromise(
 			Effect.gen(function* () {
 				const credentials = yield* CredentialsService;
@@ -22,8 +32,8 @@ describe("CredentialsService", () => {
 			}).pipe(Effect.provide(CredentialsServiceLive)),
 		);
 
-		expect(configured).toEqual([]);
-		expect(keytar.findCredentials).toHaveBeenCalledTimes(1);
-		expect(keytar.findCredentials).toHaveBeenCalledWith("zuse");
+		expect(configured).toEqual(["codex"]);
+		expect(keytar.findCredentials).not.toHaveBeenCalled();
+		expect(keytar.getPassword).toHaveBeenCalledWith("zuse", "apiKey:codex");
 	});
 });


### PR DESCRIPTION
## Summary

- replace service-wide Keychain enumeration during provider discovery with exact `apiKey:<provider>` lookups
- preserve legacy provider-key promotion without touching browser, integration, auth, or MCP credentials
- add a regression test that fails if provider discovery enumerates unrelated Keychain items

## Root cause

Provider availability called `keytar.findCredentials("zuse")`. On macOS, that API requests the secret data for every item under the shared service, so opening provider discovery could trigger a native password prompt for an unrelated integration credential.

## Impact

Opening the model picker or otherwise refreshing provider availability no longer decrypts unrelated credentials. Credential access remains scoped to the provider API-key accounts being discovered.

## Validation

- `bun run --filter @zuse/server test:unit -- credentials-service.test.ts` (158 tests passed)
- `bun run --filter @zuse/server check-types`
- `bunx biome check apps/server/src/provider/layers/credentials-service.ts apps/server/test/unit/credentials-service.test.ts`
- `git diff --check`