### PR TITLE
Coalesce auxiliary agent server startup

### DIFF
--- a/apps/server/src/codex/auxiliary-app-server.ts
+++ b/apps/server/src/codex/auxiliary-app-server.ts
@@ -1,0 +1,169 @@
+import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+
+type StartOptions = Parameters<typeof CodexAppServerClient.start>[0];
+type NotificationHandler = StartOptions["onNotification"];
+
+export interface CodexAuxiliaryConnection {
+	readonly isClosed: boolean;
+	readonly request: CodexAppServerClient["request"];
+	readonly close: () => void;
+}
+
+interface PoolOptions {
+	readonly start: (options: StartOptions) => Promise<CodexAuxiliaryConnection>;
+	readonly idleTimeoutMs: number;
+}
+
+export interface CodexAuxiliaryRequestOptions {
+	readonly codexPath: string | null;
+	readonly startupTimeoutMs?: number;
+	readonly onNotification?: NotificationHandler;
+}
+
+export interface CodexAuxiliaryAppServerPool {
+	readonly withClient: <A>(
+		options: CodexAuxiliaryRequestOptions,
+		run: (client: CodexAuxiliaryConnection) => Promise<A>,
+	) => Promise<A>;
+	readonly shutdown: () => Promise<void>;
+}
+
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
+
+/**
+ * Owns the single short-lived Codex process used by server-side metadata
+ * features. A Codex app-server refreshes its model catalog during initialize,
+ * so starting one process per feature creates an avoidable request burst.
+ *
+ * Live agent sessions intentionally do not use this pool: their notification
+ * and permission lifecycles belong to the session driver.
+ */
+export const createCodexAuxiliaryAppServerPool = ({
+	start,
+	idleTimeoutMs,
+}: PoolOptions): CodexAuxiliaryAppServerPool => {
+	let client: CodexAuxiliaryConnection | null = null;
+	let starting: Promise<CodexAuxiliaryConnection> | null = null;
+	let activeOperations = 0;
+	let idleTimer: NodeJS.Timeout | null = null;
+	const notificationHandlers = new Map<NotificationHandler, number>();
+
+	const clearIdleTimer = (): void => {
+		if (idleTimer === null) return;
+		clearTimeout(idleTimer);
+		idleTimer = null;
+	};
+
+	const discardClient = (candidate: CodexAuxiliaryConnection): void => {
+		if (client !== candidate) return;
+		client = null;
+		starting = null;
+		candidate.close();
+	};
+
+	const closeIdleClient = (): void => {
+		idleTimer = null;
+		if (activeOperations > 0 || client === null) return;
+		discardClient(client);
+	};
+
+	const scheduleIdleClose = (): void => {
+		if (activeOperations > 0 || client === null || idleTimer !== null) return;
+		idleTimer = setTimeout(closeIdleClient, idleTimeoutMs);
+		idleTimer.unref?.();
+	};
+
+	const getOrStart = async (
+		options: CodexAuxiliaryRequestOptions,
+	): Promise<CodexAuxiliaryConnection> => {
+		if (client?.isClosed === true) {
+			client = null;
+			starting = null;
+		}
+		if (client !== null) return client;
+		if (starting !== null) return starting;
+
+		const pending = start({
+			codexPath: options.codexPath,
+			startupTimeoutMs: options.startupTimeoutMs,
+			onNotification: (notification) => {
+				for (const handler of notificationHandlers.keys()) {
+					try {
+						handler(notification);
+					} catch {
+						// Metadata notifications are best-effort. One feature must
+						// not prevent another feature from receiving its event.
+					}
+				}
+			},
+			onServerRequest: (_request, respond) => respond({}),
+		});
+		starting = pending;
+		try {
+			const started = await pending;
+			if (starting === pending) client = started;
+			return started;
+		} catch (cause) {
+			if (starting === pending) starting = null;
+			throw cause;
+		}
+	};
+
+	const withClient: CodexAuxiliaryAppServerPool["withClient"] = async (
+		options,
+		run,
+	) => {
+		clearIdleTimer();
+		activeOperations += 1;
+		const handler = options.onNotification;
+		if (handler !== undefined) {
+			notificationHandlers.set(
+				handler,
+				(notificationHandlers.get(handler) ?? 0) + 1,
+			);
+		}
+		let acquired: CodexAuxiliaryConnection | null = null;
+		try {
+			acquired = await getOrStart(options);
+			return await run(acquired);
+		} finally {
+			if (handler !== undefined) {
+				const remaining = (notificationHandlers.get(handler) ?? 1) - 1;
+				if (remaining === 0) notificationHandlers.delete(handler);
+				else notificationHandlers.set(handler, remaining);
+			}
+			activeOperations -= 1;
+			if (acquired?.isClosed === true) discardClient(acquired);
+			scheduleIdleClose();
+		}
+	};
+
+	const shutdown = async (): Promise<void> => {
+		clearIdleTimer();
+		const pending = starting;
+		const current = client;
+		client = null;
+		starting = null;
+		if (current !== null) {
+			current.close();
+			return;
+		}
+		if (pending === null) return;
+		try {
+			(await pending).close();
+		} catch {
+			// A failed startup has no child left to close.
+		}
+	};
+
+	return { withClient, shutdown };
+};
+
+const sharedPool = createCodexAuxiliaryAppServerPool({
+	start: CodexAppServerClient.start,
+	idleTimeoutMs: DEFAULT_IDLE_TIMEOUT_MS,
+});
+
+export const withCodexAuxiliaryAppServer = sharedPool.withClient;
+
+export const shutdownCodexAuxiliaryAppServer = sharedPool.shutdown;

--- a/apps/server/src/external-thread/layers/external-thread-service.ts
+++ b/apps/server/src/external-thread/layers/external-thread-service.ts
@@ -8,7 +8,6 @@ import type { ThreadReadResponse } from "@zuse/agents/codex-generated/v2/ThreadR
 import type { UserInput } from "@zuse/agents/codex-generated/v2/UserInput";
 import { translateClaudeSdkMessages } from "@zuse/agents/drivers/claude";
 import { translateCodexItem } from "@zuse/agents/drivers/codex";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
 import {
   ContinueExternalThreadResult,
   defaultModelFor,
@@ -24,6 +23,7 @@ import { WorktreeService } from "@zuse/git/worktree-service";
 import { Effect, Layer } from "effect";
 import { ChildProcessSpawner as CommandExecutor } from "effect/unstable/process";
 import { SqlClient } from "effect/unstable/sql";
+import { withCodexAuxiliaryAppServer } from "../../codex/auxiliary-app-server.ts";
 import { eventToContent } from "../../conversation/core/conversation-message-mapping.ts";
 import { TranscriptService } from "../../conversation/services/conversation-services.ts";
 import { resolveCliPath } from "../../provider/availability.ts";
@@ -225,25 +225,17 @@ const discoverCodexViaAppServer = (limit: number) =>
   Effect.gen(function* () {
     const codexPath = yield* resolveCliPath("codex");
     if (codexPath === null) return [] as ReadonlyArray<DiscoveredThread>;
-    const app = yield* Effect.tryPromise({
-      try: () =>
-        CodexAppServerClient.start({
-          codexPath,
-          onNotification: () => {},
-          onServerRequest: (_request, respond) => respond(null),
-        }),
-      catch: () => null,
-    });
-    if (app === null) return [] as ReadonlyArray<DiscoveredThread>;
-    try {
+    {
       const response = yield* Effect.tryPromise({
         try: () =>
-          app.request<ThreadListResponse>("thread/list", {
-            limit,
-            sortKey: "updated_at",
-            sortDirection: "desc",
-            archived: false,
-          }),
+          withCodexAuxiliaryAppServer({ codexPath }, (app) =>
+            app.request<ThreadListResponse>("thread/list", {
+              limit,
+              sortKey: "updated_at",
+              sortDirection: "desc",
+              archived: false,
+            }),
+          ),
         catch: () => null,
       });
       if (response === null) return [] as ReadonlyArray<DiscoveredThread>;
@@ -268,8 +260,6 @@ const discoverCodexViaAppServer = (limit: number) =>
             resumeStrategy: "codex-thread-id",
           }),
         );
-    } finally {
-      app.close();
     }
   });
 
@@ -368,23 +358,15 @@ const codexTranscriptMessages = (cursor: string) =>
   Effect.gen(function* () {
     const codexPath = yield* resolveCliPath("codex");
     if (codexPath === null) return [];
-    const app = yield* Effect.tryPromise({
-      try: () =>
-        CodexAppServerClient.start({
-          codexPath,
-          onNotification: () => {},
-          onServerRequest: (_request, respond) => respond(null),
-        }),
-      catch: () => null,
-    });
-    if (app === null) return [];
-    try {
+    {
       const response = yield* Effect.tryPromise({
         try: () =>
-          app.request<ThreadReadResponse>("thread/read", {
-            threadId: cursor,
-            includeTurns: true,
-          }),
+          withCodexAuxiliaryAppServer({ codexPath }, (app) =>
+            app.request<ThreadReadResponse>("thread/read", {
+              threadId: cursor,
+              includeTurns: true,
+            }),
+          ),
         catch: () => null,
       });
       if (response === null) return [];
@@ -414,10 +396,12 @@ const codexTranscriptMessages = (cursor: string) =>
               item.id as import("@zuse/contracts").AgentItemId;
             const childResponse = yield* Effect.tryPromise({
               try: () =>
-                app.request<ThreadReadResponse>("thread/read", {
-                  threadId: childSessionId,
-                  includeTurns: true,
-                }),
+                withCodexAuxiliaryAppServer({ codexPath }, (app) =>
+                  app.request<ThreadReadResponse>("thread/read", {
+                    threadId: childSessionId,
+                    includeTurns: true,
+                  }),
+                ),
               catch: () => null,
             });
             const childThread = childResponse?.thread ?? null;
@@ -495,8 +479,6 @@ const codexTranscriptMessages = (cursor: string) =>
         }
       }
       return out;
-    } finally {
-      app.close();
     }
   }).pipe(Effect.catch(() => Effect.succeed([])));
 

--- a/apps/server/src/mcp/codex-status.ts
+++ b/apps/server/src/mcp/codex-status.ts
@@ -6,8 +6,11 @@ import type { McpServerStatus as CodexMcpServerStatus } from "@zuse/agents/codex
 import type { PluginDetail } from "@zuse/agents/codex-generated/v2/PluginDetail";
 import type { PluginListResponse } from "@zuse/agents/codex-generated/v2/PluginListResponse";
 import type { PluginReadResponse } from "@zuse/agents/codex-generated/v2/PluginReadResponse";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
 import { Effect } from "effect";
+import {
+	type CodexAuxiliaryConnection,
+	withCodexAuxiliaryAppServer,
+} from "../codex/auxiliary-app-server.ts";
 
 export interface CodexConnectorSnapshot {
 	readonly id: string;
@@ -37,7 +40,7 @@ export interface CodexLiveMcpSnapshot {
  */
 const withCodexApp = <A>(
 	codexPath: string | null,
-	run: (app: CodexAppServerClient) => Promise<A>,
+	run: (app: CodexAuxiliaryConnection) => Promise<A>,
 	options?: {
 		readonly onNotification?: (notification: {
 			method: string;
@@ -46,30 +49,24 @@ const withCodexApp = <A>(
 	},
 ): Effect.Effect<A, Error> =>
 	Effect.tryPromise({
-		try: async () => {
-			const app = await CodexAppServerClient.start({
-				codexPath,
-				startupTimeoutMs: 20_000,
-				onNotification: (notification) =>
-					options?.onNotification?.(
-						notification as { method: string; params?: unknown },
-					),
-				// Nothing interactive runs in these one-shot calls; deny-by-noop
-				// keeps a stray server request from wedging the child.
-				onServerRequest: (_request, respond) => respond({}),
-			});
-			try {
-				return await run(app);
-			} finally {
-				app.close();
-			}
-		},
+		try: () =>
+			withCodexAuxiliaryAppServer(
+				{
+					codexPath,
+					startupTimeoutMs: 20_000,
+					onNotification: (notification) =>
+						options?.onNotification?.(
+							notification as { method: string; params?: unknown },
+						),
+				},
+				run,
+			),
 		catch: (cause) =>
 			cause instanceof Error ? cause : new Error(String(cause)),
 	});
 
 const listMcpStatuses = async (
-	app: CodexAppServerClient,
+	app: CodexAuxiliaryConnection,
 ): Promise<ReadonlyArray<CodexMcpServerStatus>> => {
 	const out: CodexMcpServerStatus[] = [];
 	let cursor: string | null = null;
@@ -86,7 +83,7 @@ const listMcpStatuses = async (
 };
 
 const readInstalledPluginDetails = async (
-	app: CodexAppServerClient,
+	app: CodexAuxiliaryConnection,
 	cwd: string | null,
 ): Promise<ReadonlyArray<PluginDetail>> => {
 	let response: PluginListResponse;

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import type { PlanType } from "@zuse/agents/codex-generated/PlanType";
 import type { Account } from "@zuse/agents/codex-generated/v2/Account";
 import type { GetAccountResponse } from "@zuse/agents/codex-generated/v2/GetAccountResponse";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
 import {
   AgentAvailability,
   type CliVersionStatus,
@@ -18,6 +17,7 @@ import {
   ChildProcess as Command,
   ChildProcessSpawner as CommandExecutor,
 } from "effect/unstable/process";
+import { withCodexAuxiliaryAppServer } from "../codex/auxiliary-app-server.ts";
 import { decodeJwtPayload } from "./jwt.ts";
 
 interface ProviderProbe {
@@ -58,10 +58,10 @@ interface ProviderProbe {
 
 /** Minimum release with the typed native ACP extensions used by our driver. */
 export const MIN_GROK_CLI_VERSION: CliVersion = {
-	major: 0,
-	minor: 2,
-	patch: 101,
-	raw: "0.2.101",
+  major: 0,
+  minor: 2,
+  patch: 101,
+  raw: "0.2.101",
 };
 
 const PROBES: ReadonlyArray<ProviderProbe> = [
@@ -97,7 +97,7 @@ const PROBES: ReadonlyArray<ProviderProbe> = [
     providerId: "grok",
     displayName: "Grok",
     cliBinary: "grok",
-		minVersion: MIN_GROK_CLI_VERSION,
+    minVersion: MIN_GROK_CLI_VERSION,
     upgradeCommand: "curl -fsSL https://x.ai/cli/install.sh | bash",
     // xAI ships Grok via a curl installer, not npm — no registry to poll.
     // The installer reinstalls the latest build, so it doubles as the updater.
@@ -585,17 +585,13 @@ const ACCOUNT_PROBE_TIMEOUT_MS = 5_000;
  */
 const probeCodexAccount = (codexPath: string): Effect.Effect<AccountInfo> =>
   Effect.promise(async () => {
-    let client: CodexAppServerClient | null = null;
     try {
-      client = await CodexAppServerClient.start({
-        codexPath,
-        startupTimeoutMs: ACCOUNT_PROBE_TIMEOUT_MS,
-        onNotification: () => {},
-        onServerRequest: (_req, respond) => respond(null),
-      });
-      const response = await client.request<GetAccountResponse>(
-        "account/read",
-        {},
+      const response = await withCodexAuxiliaryAppServer(
+        {
+          codexPath,
+          startupTimeoutMs: ACCOUNT_PROBE_TIMEOUT_MS,
+        },
+        (client) => client.request<GetAccountResponse>("account/read", {}),
       );
       if (response.account === null) {
         return {
@@ -621,10 +617,6 @@ const probeCodexAccount = (codexPath: string): Effect.Effect<AccountInfo> =>
         statusMessage:
           err instanceof Error ? err.message : "Could not verify Codex auth",
       } satisfies AccountInfo;
-    } finally {
-      // Kill the child process — without this the `codex app-server`
-      // subprocess leaks for several minutes per probe.
-      client?.close();
     }
   });
 

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -14,6 +14,7 @@ import { AttachmentServiceLive } from "./attachment/layers/attachment-service.ts
 import { AuthServiceLive } from "./auth/layers/auth-service.ts";
 import { SessionStoreLive } from "./auth/layers/session-store.ts";
 import { AuthShell } from "./auth/services/auth-shell.ts";
+import { shutdownCodexAuxiliaryAppServer } from "./codex/auxiliary-app-server.ts";
 import { ConfigStoreServiceLive } from "./config-store/layers/config-store-service.ts";
 import { ConversationState } from "./conversation/core/conversation-state.ts";
 import { ConversationServicesLive } from "./conversation/layers/conversation-services.ts";
@@ -517,5 +518,13 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(MigratedSqlite),
 		Layer.provide(AppPathsLayer),
 	);
-	return Layer.mergeAll(ServerLayer, NodeServices.layer, UsagePoller);
+	const CodexAuxiliaryLifecycle = Layer.effectDiscard(
+		Effect.addFinalizer(() => Effect.promise(shutdownCodexAuxiliaryAppServer)),
+	);
+	return Layer.mergeAll(
+		ServerLayer,
+		NodeServices.layer,
+		UsagePoller,
+		CodexAuxiliaryLifecycle,
+	);
 };

--- a/apps/server/src/skill/bundled-zuse-skill.ts
+++ b/apps/server/src/skill/bundled-zuse-skill.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as fsSync from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -107,14 +108,34 @@ export const ensureBundledZuseSkillInstalled = (
   const target = bundledZuseSkillPath(providerId, home);
   if (target === null) return null;
   const content = readBundledZuseSkill();
+  let temporary: string | null = null;
   try {
     fsSync.mkdirSync(path.dirname(target), { recursive: true });
     const existing = fsSync.existsSync(target)
       ? fsSync.readFileSync(target, "utf8")
       : null;
-    if (existing !== content) fsSync.writeFileSync(target, content, "utf8");
+    if (existing !== content) {
+      temporary = path.join(
+        path.dirname(target),
+        `.${path.basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+      );
+      fsSync.writeFileSync(temporary, content, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      fsSync.renameSync(temporary, target);
+      temporary = null;
+    }
   } catch {
     return null;
+  } finally {
+    if (temporary !== null) {
+      try {
+        fsSync.rmSync(temporary, { force: true });
+      } catch {
+        // Best-effort cleanup after a failed atomic replace.
+      }
+    }
   }
   return target;
 };

--- a/apps/server/src/skill/layers/skill-discovery.ts
+++ b/apps/server/src/skill/layers/skill-discovery.ts
@@ -1,8 +1,8 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
 import { type ProviderId, Skill } from "@zuse/contracts";
 import { Effect, FileSystem, Layer } from "effect";
+import { withCodexAuxiliaryAppServer } from "../../codex/auxiliary-app-server.ts";
 import { ensureBundledZuseSkillInstalled } from "../bundled-zuse-skill.ts";
 import { SkillDiscoveryService } from "../services/skill-discovery.ts";
 
@@ -255,13 +255,8 @@ export const SkillDiscoveryServiceLive = Layer.effect(
       Effect.gen(function* () {
         ensureBundledZuseSkillInstalled("codex", home);
         const viaAppServer = yield* Effect.tryPromise({
-          try: async (): Promise<ReadonlyArray<Skill>> => {
-            const client = await CodexAppServerClient.start({
-              codexPath: null,
-              onNotification: () => undefined,
-              onServerRequest: (_request, respond) => respond({}),
-            });
-            try {
+          try: (): Promise<ReadonlyArray<Skill>> =>
+            withCodexAuxiliaryAppServer({ codexPath: null }, async (client) => {
               const response = await client.request<{
                 data: ReadonlyArray<{
                   cwd: string;
@@ -290,10 +285,7 @@ export const SkillDiscoveryServiceLive = Layer.effect(
                     }),
                   ),
               );
-            } finally {
-              client.close();
-            }
-          },
+            }),
           catch: (cause) => cause,
         }).pipe(Effect.catch(() => Effect.succeed(null)));
         if (viaAppServer !== null) return dedupeProjectFirst(viaAppServer);

--- a/apps/server/src/usage/limits/codex-usage.ts
+++ b/apps/server/src/usage/limits/codex-usage.ts
@@ -1,6 +1,6 @@
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
 import type { ProviderUsageLimits, UsageLimitWindow } from "@zuse/contracts";
 
+import { withCodexAuxiliaryAppServer } from "../../codex/auxiliary-app-server.ts";
 import { normalizePercent, normalizeReset, unavailable } from "./shared.ts";
 
 type RateWindow = {
@@ -74,27 +74,24 @@ export const mapCodexRateLimits = (
 };
 
 export const fetchCodexUsage = async (): Promise<ProviderUsageLimits> => {
-	let client: CodexAppServerClient | null = null;
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 	try {
-		client = await CodexAppServerClient.start({
-			codexPath: "codex",
-			startupTimeoutMs: 5_000,
-			onNotification: () => {},
-			onServerRequest: (_request, respond) => respond(null),
-		});
-		const timeoutPromise = new Promise<never>((_, reject) => {
-			timeout = setTimeout(() => reject(new Error("timeout")), 5_000);
-		});
-		const result = await Promise.race([
-			client.request<unknown>("account/rateLimits/read", {}),
-			timeoutPromise,
-		]);
+		const result = await withCodexAuxiliaryAppServer(
+			{ codexPath: "codex", startupTimeoutMs: 5_000 },
+			async (client) => {
+				const timeoutPromise = new Promise<never>((_, reject) => {
+					timeout = setTimeout(() => reject(new Error("timeout")), 5_000);
+				});
+				return Promise.race([
+					client.request<unknown>("account/rateLimits/read", {}),
+					timeoutPromise,
+				]);
+			},
+		);
 		return mapCodexRateLimits(result);
 	} catch {
 		return unavailable("codex", "error");
 	} finally {
 		if (timeout !== undefined) clearTimeout(timeout);
-		client?.close();
 	}
 };

--- a/apps/server/test/unit/bundled-zuse-skill.test.ts
+++ b/apps/server/test/unit/bundled-zuse-skill.test.ts
@@ -1,6 +1,7 @@
 import {
 	existsSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
 	writeFileSync,
@@ -45,6 +46,9 @@ describe("bundled Zuse skill installer", () => {
 			expect(installedClaudeSkill).not.toContain("create_worktree");
 			expect(installedCodexSkill).toContain("zuse-orchestration");
 			expect(installedCodexSkill).toContain("Do not substitute");
+			expect(readdirSync(join(home, ".codex", "skills", "zuse"))).toEqual([
+				"SKILL.md",
+			]);
 		} finally {
 			rmSync(home, { recursive: true, force: true });
 		}

--- a/apps/server/test/unit/codex-auxiliary-app-server.test.ts
+++ b/apps/server/test/unit/codex-auxiliary-app-server.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	type CodexAuxiliaryConnection,
+	createCodexAuxiliaryAppServerPool,
+} from "../../src/codex/auxiliary-app-server.ts";
+
+const connection = () => {
+	const request = vi.fn(async (_method: unknown, _params: unknown) => ({
+		ok: true,
+	}));
+	const app: CodexAuxiliaryConnection = {
+		isClosed: false,
+		request: async <T>(
+			method: Parameters<CodexAuxiliaryConnection["request"]>[0],
+			params: unknown,
+		) => (await request(method, params)) as T,
+		close: vi.fn(),
+	};
+	return { app, request };
+};
+
+describe("Codex auxiliary app-server pool", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("coalesces concurrent feature reads into one app-server process", async () => {
+		const { app, request } = connection();
+		const start = vi.fn(async () => app);
+		const pool = createCodexAuxiliaryAppServerPool({
+			start,
+			idleTimeoutMs: 30_000,
+		});
+
+		await Promise.all(
+			Array.from({ length: 10 }, () =>
+				pool.withClient({ codexPath: "codex" }, (client) =>
+					client.request("account/read", {}),
+				),
+			),
+		);
+
+		expect(start).toHaveBeenCalledTimes(1);
+		expect(request).toHaveBeenCalledTimes(10);
+		expect(app.close).not.toHaveBeenCalled();
+		await pool.shutdown();
+	});
+
+	it("reuses an idle process and closes it after the idle window", async () => {
+		vi.useFakeTimers();
+		const { app } = connection();
+		const start = vi.fn(async () => app);
+		const pool = createCodexAuxiliaryAppServerPool({
+			start,
+			idleTimeoutMs: 1_000,
+		});
+
+		await pool.withClient({ codexPath: "codex" }, async () => "first");
+		await pool.withClient({ codexPath: "/usr/local/bin/codex" }, async () => [
+			"second",
+		]);
+
+		expect(start).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(999);
+		expect(app.close).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+		expect(app.close).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries startup after a failed shared initialization", async () => {
+		const { app } = connection();
+		const start = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("startup failed"))
+			.mockResolvedValueOnce(app);
+		const pool = createCodexAuxiliaryAppServerPool({
+			start,
+			idleTimeoutMs: 30_000,
+		});
+
+		await expect(
+			pool.withClient({ codexPath: "codex" }, async () => "never"),
+		).rejects.toThrow("startup failed");
+		await expect(
+			pool.withClient({ codexPath: "codex" }, async () => "recovered"),
+		).resolves.toBe("recovered");
+		expect(start).toHaveBeenCalledTimes(2);
+		await pool.shutdown();
+	});
+});

--- a/packages/agents/src/drivers/codex-app-server-client.ts
+++ b/packages/agents/src/drivers/codex-app-server-client.ts
@@ -19,6 +19,26 @@ type ServerRequestHandler = (
 
 type NotificationHandler = (notification: ServerNotification) => void;
 
+interface CodexAppServerStartOptions {
+	readonly codexPath: string | null;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly startupTimeoutMs?: number;
+	readonly onNotification: NotificationHandler;
+	readonly onServerRequest: ServerRequestHandler;
+}
+
+let initializationTail = Promise.resolve();
+
+const reserveInitialization = async (): Promise<() => void> => {
+	const previous = initializationTail;
+	let release = (): void => {};
+	initializationTail = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	await previous;
+	return release;
+};
+
 type CodexGoalRequestMethod =
 	| "thread/goal/get"
 	| "thread/goal/set"
@@ -44,6 +64,10 @@ export class CodexAppServerClient {
 
 	initializeResponse: InitializeResponse;
 
+	get isClosed(): boolean {
+		return this.closed;
+	}
+
 	private constructor(
 		child: ChildProcessWithoutNullStreams,
 		rl: readline.Interface,
@@ -56,13 +80,20 @@ export class CodexAppServerClient {
 		this.initializeResponse = initializeResponse;
 	}
 
-	static async start(options: {
-		readonly codexPath: string | null;
-		readonly env?: NodeJS.ProcessEnv;
-		readonly startupTimeoutMs?: number;
-		readonly onNotification: NotificationHandler;
-		readonly onServerRequest: ServerRequestHandler;
-	}): Promise<CodexAppServerClient> {
+	static async start(
+		options: CodexAppServerStartOptions,
+	): Promise<CodexAppServerClient> {
+		const release = await reserveInitialization();
+		try {
+			return await CodexAppServerClient.startUncoordinated(options);
+		} finally {
+			release();
+		}
+	}
+
+	private static async startUncoordinated(
+		options: CodexAppServerStartOptions,
+	): Promise<CodexAppServerClient> {
 		const child = spawn(
 			options.codexPath ?? "codex",
 			["app-server", "--listen", "stdio://"],

--- a/packages/agents/test/unit/drivers/codex-app-server-client.test.ts
+++ b/packages/agents/test/unit/drivers/codex-app-server-client.test.ts
@@ -1,0 +1,74 @@
+import {
+	chmodSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { CodexAppServerClient } from "../../../src/drivers/codex-app-server-client.ts";
+
+const FAKE_CODEX = `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import readline from "node:readline";
+
+const log = process.env.CODEX_START_LOG;
+if (!log) process.exit(2);
+appendFileSync(log, "start\\n");
+const lines = readline.createInterface({ input: process.stdin });
+lines.once("line", (line) => {
+  const request = JSON.parse(line);
+  setTimeout(() => {
+    appendFileSync(log, "end\\n");
+    process.stdout.write(JSON.stringify({
+      id: request.id,
+      result: {
+        userAgent: "fake",
+        codexHome: "",
+        platformFamily: "test",
+        platformOs: "test"
+      }
+    }) + "\\n");
+  }, 50);
+});
+`;
+
+describe("CodexAppServerClient startup", () => {
+	it("serializes concurrent initialization against shared Codex state", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-codex-start-"));
+		const executable = join(directory, "fake-codex.mjs");
+		const log = join(directory, "starts.log");
+		writeFileSync(executable, FAKE_CODEX, "utf8");
+		chmodSync(executable, 0o755);
+
+		try {
+			const options = {
+				codexPath: executable,
+				env: { ...process.env, CODEX_START_LOG: log },
+				onNotification: () => {},
+				onServerRequest: (
+					_request: unknown,
+					respond: (value: unknown) => void,
+				) => respond({}),
+			};
+			const [first, second] = await Promise.all([
+				CodexAppServerClient.start(options),
+				CodexAppServerClient.start(options),
+			]);
+			first.close();
+			second.close();
+
+			expect(readFileSync(log, "utf8").trim().split("\n")).toEqual([
+				"start",
+				"end",
+				"start",
+				"end",
+			]);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- share one auxiliary agent server across account, usage, skill, MCP, and external-thread metadata operations
- coalesce concurrent startup, reuse the process during a short idle window, and close it with the server runtime
- serialize all agent-server initialization so live sessions cannot race while updating shared system skills
- install the bundled Zuse skill with an atomic temporary-file rename
- add concurrency, recovery, idle-shutdown, and startup-serialization regression coverage

## Root cause

Several independent UI and background features each started their own short-lived agent server. Every initialization refreshed the model catalog and touched the shared system-skills directory, so startup fan-out produced bursts of catalog requests, HTTP 429 responses, and filesystem installation races.

## Impact

Metadata reads now collapse onto one reusable helper, while dedicated live-session processes remain isolated and initialize serially. This removes the request burst and prevents concurrent system-skill mutations without changing live chat notification or permission ownership.

## Validation

- `bun run --filter @zuse/server test:unit` — 161 passed
- `bun run --filter @zuse/agents test:unit` — 199 passed
- `bun run --filter @zuse/server check-types` — passed
- `bun run --filter @zuse/agents check-types` — passed
- focused external-thread integration — 4 passed
- Biome lint/format and `git diff --check` — passed

The complete server integration command was also attempted; two unrelated existing failures remain in a stale SQLite fixture and an error-message expectation.