### PR TITLE
Release v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.5]
+
+### Changed
+- Avoid decrypting unrelated keychain credentials (#397)
+- Unify app MCP integration and harden browser control (#399)
+- Fix queued message control flow and editing (#396)
+- Restore session-scoped interruption when the active-turn cache is cold
+
 ## [0.15.4]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "type": "module",
   "productName": "Zuse (Beta)",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Zuse (Beta) desktop app",
   "private": true,
   "author": {

--- a/apps/server/src/conversation/core/conversation-store-runtime.ts
+++ b/apps/server/src/conversation/core/conversation-store-runtime.ts
@@ -1,7 +1,7 @@
 import { canonicalizeToolInput } from "@zuse/agents/kernel/tool-input";
 import {
 	type AgentDefinition,
-	type AgentTurnId,
+	AgentTurnId,
 	type Chat,
 	type FolderId,
 	Message,
@@ -56,6 +56,9 @@ export interface ConversationStoreRuntime {
 		sessionId: SessionId,
 		turnIdOverride?: AgentTurnId,
 	) => Effect.Effect<AgentTurnId>;
+	readonly resolveActiveTurn: (
+		sessionId: SessionId,
+	) => Effect.Effect<AgentTurnId | undefined>;
 	readonly settleTurn: (
 		sessionId: SessionId,
 		turnId: AgentTurnId,
@@ -118,6 +121,31 @@ export const makeConversationStoreRuntime = Effect.fn(
 		flushQueueAfterIdle,
 		shutdownQueueSession,
 	} = options;
+	const resolveActiveTurn = Effect.fn(
+		"ConversationStoreRuntime.resolveActiveTurn",
+	)(function* (sessionId: SessionId) {
+		const cached = state.activeTurn(sessionId);
+		if (cached !== undefined) return AgentTurnId.make(cached);
+		const rows = yield* sql<{
+			readonly type: string;
+			readonly turn_id: string | null;
+		}>`
+			SELECT type, json_extract(payload_json, '$.turnId') AS turn_id
+			FROM events
+			WHERE stream_kind = 'session'
+				AND stream_id = ${sessionId}
+				AND type IN ('TurnStarted', 'TurnSettled')
+			ORDER BY stream_version DESC
+			LIMIT 1
+		`.pipe(Effect.orDie);
+		const latest = rows[0];
+		if (latest?.type !== "TurnStarted" || latest.turn_id === null) {
+			return undefined;
+		}
+		const turnId = AgentTurnId.make(latest.turn_id);
+		state.rememberActiveTurn(sessionId, turnId);
+		return turnId;
+	});
 	const beginTurn = (
 		sessionId: SessionId,
 		turnIdOverride?: AgentTurnId,
@@ -548,6 +576,7 @@ export const makeConversationStoreRuntime = Effect.fn(
 
 	return {
 		beginTurn,
+		resolveActiveTurn,
 		settleTurn,
 		settleTurnFromReactor,
 		ndjsonAppend,

--- a/apps/server/src/conversation/core/message-operations.ts
+++ b/apps/server/src/conversation/core/message-operations.ts
@@ -84,7 +84,9 @@ export interface MessageOperationsOptions {
 		turnId: AgentTurnId,
 		reason: "completed" | "interrupted" | "error",
 	) => Effect.Effect<void>;
-	readonly activeTurn: (sessionId: SessionId) => AgentTurnId | undefined;
+	readonly resolveActiveTurn: (
+		sessionId: SessionId,
+	) => Effect.Effect<AgentTurnId | undefined>;
 	readonly runSessionReactors: Effect.Effect<void>;
 	readonly serviceScope: Scope.Scope;
 	readonly recoverStatus: (
@@ -120,7 +122,7 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 			dispatchSessionCommand,
 			beginTurn,
 			settleTurn,
-			activeTurn,
+			resolveActiveTurn,
 			runSessionReactors,
 			serviceScope,
 			recoverStatus,
@@ -363,7 +365,7 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 					origin,
 				);
 				if (!accepted) {
-					const turnId = activeTurn(sessionId);
+					const turnId = yield* resolveActiveTurn(sessionId);
 					if (turnId !== undefined)
 						yield* settleTurn(sessionId, turnId, "error");
 				}
@@ -394,7 +396,7 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 			dispatchSessionCommandWithId: (sessionId, commandId, command) =>
 				options.dispatchSessionCommandWithId(sessionId, commandId, command),
 			runSessionReactors,
-			activeTurn,
+			resolveActiveTurn,
 		});
 		// Boot recovery runs only after the real queue runtime exists. Demoting a
 		// stale session to idle invokes setStatus → flushAfterIdle, so installing
@@ -409,7 +411,7 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 		for (const stale of staleSessions) {
 			const sessionId = SessionId.make(stale.id);
 			if (stale.status === "running") {
-				const turnId = activeTurn(sessionId);
+				const turnId = yield* resolveActiveTurn(sessionId);
 				if (turnId !== undefined) {
 					const lifecycle = yield* sql<{ readonly type: string }>`
 						SELECT type FROM events
@@ -442,7 +444,7 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 		) =>
 			Effect.gen(function* () {
 				yield* lookupSession(sessionId);
-				const resolvedTurnId = activeTurn(sessionId);
+				const resolvedTurnId = yield* resolveActiveTurn(sessionId);
 				if (resolvedTurnId === undefined) return;
 				yield* dispatchSessionCommand(sessionId, {
 					_tag: "RequestTurnInterrupt",

--- a/apps/server/src/conversation/core/queue-service-runtime.ts
+++ b/apps/server/src/conversation/core/queue-service-runtime.ts
@@ -50,7 +50,9 @@ export interface QueueServiceRuntimeDeps {
 		command: SessionCommand,
 	) => Effect.Effect<void>;
 	readonly runSessionReactors: Effect.Effect<void>;
-	readonly activeTurn: (sessionId: SessionId) => AgentTurnId | undefined;
+	readonly resolveActiveTurn: (
+		sessionId: SessionId,
+	) => Effect.Effect<AgentTurnId | undefined>;
 }
 
 export interface QueueServiceRuntime {
@@ -82,7 +84,7 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 			dispatchSessionCommand,
 			dispatchSessionCommandWithId,
 			runSessionReactors,
-			activeTurn,
+			resolveActiveTurn,
 		} = deps;
 		const flushLocks = new Map<SessionId, Semaphore.Semaphore>();
 		const flushLock = (sessionId: SessionId): Semaphore.Semaphore => {
@@ -359,7 +361,7 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 			flushLock(sessionId).withPermits(1)(
 				Effect.gen(function* () {
 					yield* lookupSession(sessionId);
-					const resolvedTurnId = activeTurn(sessionId);
+					const resolvedTurnId = yield* resolveActiveTurn(sessionId);
 					if (resolvedTurnId === undefined) {
 						yield* runQueuedMessageWhileIdle(sessionId, queueId);
 						return;

--- a/apps/server/src/conversation/layers/conversation-services.ts
+++ b/apps/server/src/conversation/layers/conversation-services.ts
@@ -246,6 +246,7 @@ const ConversationRuntimeLive = Layer.effect(
 			});
 		const {
 			beginTurn,
+			resolveActiveTurn,
 			settleTurn,
 			settleTurnFromReactor,
 			ndjsonAppend,
@@ -481,10 +482,7 @@ const ConversationRuntimeLive = Layer.effect(
 					.pipe(Effect.asVoid, Effect.orDie),
 			beginTurn,
 			settleTurn,
-			activeTurn: (sessionId) =>
-				state.activeTurn(sessionId) as
-					| import("@zuse/contracts").AgentTurnId
-					| undefined,
+			resolveActiveTurn,
 			runSessionReactors: Effect.suspend(() => reactorRuntime.runSession),
 			serviceScope,
 			recoverStatus: (sessionId, status) =>

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "0.15.5",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Avoid decrypting unrelated keychain credentials (#397)",
+          "Unify app MCP integration and harden browser control (#399)",
+          "Fix queued message control flow and editing (#396)",
+          "Restore session-scoped interruption when the active-turn cache is cold"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.15.4",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/tests/system/test/system/conversation-reliability.system.test.ts
+++ b/tests/system/test/system/conversation-reliability.system.test.ts
@@ -124,14 +124,10 @@ describe("conversation process reliability", () => {
 				}),
 			);
 			await controller.waitFor("prompt.held");
-			const turnId = await waitForActiveTurn(
-				session.client,
-				conversation.initialSession.id,
-			);
+			await waitForActiveTurn(session.client, conversation.initialSession.id);
 			await Effect.runPromise(
 				session.client["messages.interrupt"]({
 					sessionId: conversation.initialSession.id,
-					turnId,
 				}),
 			);
 			await controller.waitFor("prompt.cancelled");
@@ -287,14 +283,10 @@ describe("conversation process reliability", () => {
 				}),
 			);
 			await controller.waitFor("prompt.received");
-			const turnId = await waitForActiveTurn(
-				session.client,
-				conversation.initialSession.id,
-			);
+			await waitForActiveTurn(session.client, conversation.initialSession.id);
 			await Effect.runPromise(
 				session.client["messages.interrupt"]({
 					sessionId: conversation.initialSession.id,
-					turnId,
 				}),
 			);
 			await controller.waitFor("prompt.cancelled", undefined, 2_000);


### PR DESCRIPTION
## Summary
- release Zuse v0.15.5
- update package metadata and desktop/web changelogs
- resolve active turns from durable events when the process-local cache is cold
- align interruption reliability fixtures with the session-scoped RPC contract

## Validation
- `bun run check-types` — passed (23/23 tasks)
- focused Biome checks for changed TypeScript files — passed
- focused reliability cases passed independently, but the full reliability test file remains timing-sensitive and produced intermittent timeout failures

Release artifacts are produced by pushing tag `v0.15.5` after this PR lands.