### PR TITLE
Fix chat-scoped right pane state

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useLayoutEffect, useState } from "react";
 import {
 	Group,
 	Panel,
@@ -37,13 +37,14 @@ import { AppearanceController } from "./lib/appearance.tsx";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { shouldMountRightPane } from "./shell/right-pane-lifecycle.ts";
 import { useAuthStore } from "./store/auth.ts";
+import { useChatsStore } from "./store/chats.ts";
 import { useKeybindingsStore } from "./store/keybindings.ts";
 import { usePermissionsStore } from "./store/permissions.ts";
 import { useQueueHydrationStore } from "./store/queue-hydration.ts";
 import { getSessionById, useSessionsStore } from "./store/sessions.ts";
 import { useSettingsStore } from "./store/settings.ts";
 import { useTerminalsStore } from "./store/terminals.ts";
-import { useUiStore } from "./store/ui.ts";
+import { DEFAULT_RIGHT_PANE_WIDTH_PERCENT, useUiStore } from "./store/ui.ts";
 import { useWorkspaceStore } from "./store/workspace.ts";
 import { useWorktreesStore } from "./store/worktrees.ts";
 
@@ -265,6 +266,7 @@ function MainShell() {
 	const folders = useWorkspaceStore((s) => s.folders);
 	const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
 	const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
+	const selectedChatId = useChatsStore((s) => s.selectedChatId);
 	const selectedSession = useSessionsStore((s) => {
 		if (s.selectedSessionId === null) return null;
 		return getSessionById(s.selectedSessionId);
@@ -294,8 +296,23 @@ function MainShell() {
 	const closeChangesTab = useUiStore((s) => s.closeChangesTab);
 	const leftSidebarOpen = useUiStore((s) => s.leftSidebarOpen);
 	const setLeftSidebarOpen = useUiStore((s) => s.setLeftSidebarOpen);
-	const rightSidebarOpen = useUiStore((s) => s.rightSidebarOpen);
-	const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
+	const rightSidebarOpen = useUiStore((s) =>
+		selectedChatId === null
+			? false
+			: (s.rightPaneLayoutByChat[selectedChatId]?.open ?? false),
+	);
+	const rightSidebarWidth = useUiStore((s) =>
+		selectedChatId === null
+			? DEFAULT_RIGHT_PANE_WIDTH_PERCENT
+			: (s.rightPaneLayoutByChat[selectedChatId]?.widthPercent ??
+				DEFAULT_RIGHT_PANE_WIDTH_PERCENT),
+	);
+	const setRightSidebarOpenForChat = useUiStore(
+		(s) => s.setRightSidebarOpenForChat,
+	);
+	const setRightSidebarWidthForChat = useUiStore(
+		(s) => s.setRightSidebarWidthForChat,
+	);
 	const environmentSummaryOpen = useUiStore((s) => s.environmentSummaryOpen);
 	const environmentSummaryFits = useMediaQuery({ min: 1180 });
 	const environmentSummaryAvailable =
@@ -398,7 +415,16 @@ function MainShell() {
 		return () => ro.disconnect();
 	}, [composerNode]);
 	usePanelCollapse(leftPanelRef, leftSidebarOpen);
-	usePanelCollapse(rightPanelRef, rightSidebarOpen);
+	useLayoutEffect(() => {
+		const panel = rightPanelRef.current;
+		if (panel === null) return;
+		if (!rightSidebarOpen) {
+			if (!panel.isCollapsed()) panel.collapse();
+			return;
+		}
+		if (panel.isCollapsed()) panel.expand();
+		panel.resize(`${rightSidebarWidth}%`);
+	}, [rightPanelRef, rightSidebarOpen, rightSidebarWidth]);
 
 	return (
 		<div className="flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden text-foreground">
@@ -603,8 +629,14 @@ function MainShell() {
 						// persisted/default panel width would otherwise fire here and
 						// flip the sidebar open before the collapse effect runs.
 						if (prev === undefined) return;
+						if (selectedChatId === null) return;
 						const open = size.asPercentage > 0;
-						if (open !== rightSidebarOpen) setRightSidebarOpen(open);
+						if (open !== rightSidebarOpen) {
+							setRightSidebarOpenForChat(selectedChatId, open);
+						}
+						if (open && size.asPercentage !== rightSidebarWidth) {
+							setRightSidebarWidthForChat(selectedChatId, size.asPercentage);
+						}
 					}}
 				>
 					<div className="flex h-full min-h-0 flex-col bg-background">

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -11,6 +11,7 @@ import {
 	type BrowserOverlayShape,
 	type BrowserTarget,
 	type BrowserViewportMode,
+	type ChatId,
 	type SessionId,
 } from "@zuse/contracts";
 import { Effect, Fiber, Schedule, Stream } from "effect";
@@ -45,12 +46,18 @@ import type {
 	NetworkQueryResult,
 } from "../lib/bridge.ts";
 import {
+	browserChatIdForSession,
+	registerBrowserController,
+	waitForBrowserController,
+} from "../lib/browser-controller-registry.ts";
+import {
 	type BrowserRecordingArtifact,
 	BrowserRecordingController,
 } from "../lib/browser-recording.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useAnnotationsStore } from "../store/annotations.ts";
 import { useAttachmentsStore } from "../store/attachments.ts";
+import { useChatsStore } from "../store/chats.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
 import { AgentCursor, type AgentCursorIntent } from "./agent-cursor.tsx";
@@ -314,7 +321,123 @@ const compositeBrowserImage = async (
  * Reloading the renderer resets the URL to blank — persistence is out of
  * scope for v1.
  */
-export function BrowserPane() {
+const respondBrowserUnavailable = async (
+	request: BrowserCommandRequest,
+	error: string,
+): Promise<void> => {
+	try {
+		const client = await getRpcClient();
+		await Effect.runPromise(
+			client["browser.respond"]({
+				result: BrowserCommandResult.make({
+					id: request.id,
+					ok: false,
+					error,
+				}),
+			}),
+		);
+	} catch {}
+};
+
+/**
+ * Owns the single browser command subscription and the lazily-created
+ * browser controller for every chat that has a Browser panel. Hidden
+ * controllers stay mounted so switching chats preserves webview history and
+ * background agents continue against their owning chat.
+ */
+export function BrowserPaneHost({
+	activeChatId,
+	browserActive,
+}: {
+	readonly activeChatId: ChatId | null;
+	readonly browserActive: boolean;
+}) {
+	const panelsByChat = useUiStore((state) => state.rightPanelsByChat);
+	const chatsByProject = useChatsStore((state) => state.chatsByProject);
+	const selectedSessionId = useSessionsStore(
+		(state) => state.selectedSessionId,
+	);
+	const browserChatIds = Object.entries(panelsByChat)
+		.filter(([, panels]) => panels.some((panel) => panel.kind === "browser"))
+		.map(([chatId]) => chatId as ChatId);
+
+	useEffect(() => {
+		let fiber: Fiber.Fiber<unknown, unknown> | null = null;
+		let cancelled = false;
+		const subscribe = Effect.suspend(() =>
+			Effect.promise(getRpcClient).pipe(
+				Effect.flatMap((client) =>
+					Stream.runForEach(client["browser.commands"]({}), (request) =>
+						Effect.promise(async () => {
+							const chatId = browserChatIdForSession(
+								useSessionsStore.getState().sessionsByProject,
+								request.sessionId,
+							);
+							if (chatId === null) {
+								await respondBrowserUnavailable(
+									request,
+									"The browser command belongs to a session that is not available in this renderer.",
+								);
+								return;
+							}
+							useUiStore.getState().revealPanelForChat(chatId, "browser");
+							const controller = await waitForBrowserController(chatId);
+							if (controller === null) {
+								await respondBrowserUnavailable(
+									request,
+									"The browser for this chat could not be started.",
+								);
+								return;
+							}
+							await controller(request);
+						}),
+					),
+				),
+			),
+		).pipe(Effect.retry(Schedule.spaced("500 millis")));
+		if (!cancelled) fiber = Effect.runFork(subscribe);
+		return () => {
+			cancelled = true;
+			if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
+		};
+	}, []);
+
+	return browserChatIds.map((chatId) => {
+		const chat =
+			Object.values(chatsByProject)
+				.flat()
+				.find((candidate) => candidate.id === chatId) ?? null;
+		const visible = chatId === activeChatId && browserActive;
+		const sessionId =
+			chatId === activeChatId
+				? selectedSessionId
+				: (chat?.activeSessionId ?? null);
+		return (
+			<div
+				key={chatId}
+				aria-hidden={!visible}
+				inert={!visible}
+				className={
+					visible
+						? "flex min-h-0 min-w-0 flex-1 flex-col"
+						: "pointer-events-none fixed -left-[10000px] top-0 flex h-[900px] w-[1440px] flex-col opacity-0"
+				}
+			>
+				<BrowserPane chatId={chatId} sessionId={sessionId} visible={visible} />
+			</div>
+		);
+	});
+}
+
+export function BrowserPane({
+	chatId,
+	sessionId: selectedSessionId,
+	visible,
+}: {
+	readonly chatId: ChatId;
+	readonly sessionId: SessionId | null;
+	readonly visible: boolean;
+}) {
 	const webviewRef = useRef<HTMLElement | null>(null);
 	// Ring buffer of console messages + page errors, captured per page load so
 	// `browser_console` can report them to the agent. Cleared on navigation.
@@ -397,7 +520,7 @@ export function BrowserPane() {
 	);
 	const cursorNonceRef = useRef(0);
 	const cursorIntentRef = useRef<AgentCursorIntent | null>(null);
-	const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
+	const visibleRef = useRef(visible);
 	const addBrowserAnnotation = useAnnotationsStore((s) => s.addBrowser);
 	const uploadAttachment = useAttachmentsStore((s) => s.uploadOne);
 	const [annotating, setAnnotating] = useState(false);
@@ -516,6 +639,9 @@ export function BrowserPane() {
 	useEffect(() => {
 		cursorIntentRef.current = cursorIntent;
 	}, [cursorIntent]);
+	useEffect(() => {
+		visibleRef.current = visible;
+	}, [visible]);
 
 	useEffect(
 		() => () => {
@@ -654,6 +780,7 @@ export function BrowserPane() {
 		if (importedDomain === undefined) return true;
 		const key = `${req.sessionId}:${importedDomain}`;
 		if (domainGrantsRef.current.has(key)) return true;
+		if (!visibleRef.current) return false;
 		return new Promise<boolean>((resolve) =>
 			setDomainAccessRequest({
 				domain: importedDomain,
@@ -795,36 +922,13 @@ export function BrowserPane() {
 		};
 	}, []);
 
-	// Agent browser executor. Subscribe once to the server's `browser.commands`
-	// broadcast and drive the webview for each command, replying on
-	// `browser.respond`. Commands run serially (runForEach awaits each) so the
-	// agent's navigate→screenshot sequence can't race. The component stays
-	// mounted while a project is open, so this subscription lives as long as the
-	// pane does.
+	// Register this chat's browser with the single BrowserPaneHost dispatcher.
+	// The host routes command.sessionId → chatId, so background agents never
+	// drive whichever chat merely happens to be selected.
 	useEffect(() => {
-		let fiber: Fiber.Fiber<unknown, unknown> | null = null;
-		let cancelled = false;
-		const subscribe = Effect.suspend(() =>
-			Effect.promise(getRpcClient).pipe(
-				Effect.flatMap((client) =>
-					Stream.runForEach(client["browser.commands"]({}), (req) =>
-						Effect.promise(() => executeBrowserCommand(req)),
-					),
-				),
-			),
-		).pipe(Effect.retry(Schedule.spaced("500 millis")));
-		if (!cancelled) fiber = Effect.runFork(subscribe);
-
 		const executeBrowserCommand = async (
 			req: BrowserCommandRequest,
 		): Promise<void> => {
-			// Always surface the action: open the sidebar and force the Browser
-			// panel visible+active. This also un-hides the webview so `capturePage`
-			// works (it returns an empty image for a `display:none` element).
-			useUiStore.getState().revealPanel("browser");
-			await new Promise<void>((resolve) => {
-				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-			});
 			const wv = webviewRef.current as WebviewElement | null;
 			const accessAllowed = await requestAgentDomainAccess(req, wv);
 			if (!accessAllowed) {
@@ -832,7 +936,7 @@ export function BrowserPane() {
 					id: req.id,
 					ok: false,
 					error:
-						"Access to this imported authenticated domain was denied for the current task.",
+						"Access to this imported authenticated domain was not approved. Open this chat's Browser panel and retry.",
 				});
 				try {
 					const client = await getRpcClient();
@@ -961,11 +1065,8 @@ export function BrowserPane() {
 			}
 		};
 
-		return () => {
-			cancelled = true;
-			if (fiber !== null) void Effect.runPromise(Fiber.interrupt(fiber));
-		};
-	}, []);
+		return registerBrowserController(chatId, executeBrowserCommand);
+	}, [chatId]);
 
 	const navigate = (next: string) => {
 		const resolved = resolveUrl(next);

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -54,9 +54,9 @@ import {
 } from "./ui/menu.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
-const BrowserPane = lazy(() =>
+const BrowserPaneHost = lazy(() =>
 	import("./browser-pane.tsx").then((module) => ({
-		default: module.BrowserPane,
+		default: module.BrowserPaneHost,
 	})),
 );
 
@@ -365,22 +365,23 @@ export function RightPane({
 							/>
 						</div>
 					))}
-				{/* Browser is always mounted (display:none when not the active tab)
-            so the agent `browser.commands` stream stays alive even with no
-            browser tab open or the sidebar collapsed — a command then calls
-            revealPanel("browser") to surface it. Mounting it only on add
-            would drop commands issued while it's closed. */}
-				<div
-					hidden={!browserActive}
-					className="flex min-h-0 min-w-0 flex-1 flex-col"
-				>
-					{browserAvailable ? (
-						<Suspense
-							fallback={<div className="min-h-0 flex-1" aria-busy="true" />}
-						>
-							<BrowserPane />
-						</Suspense>
-					) : (
+				{/* One host owns the command stream and keeps a webview mounted for
+            every chat with a Browser panel. Only the selected chat is visible;
+            background chats retain history and receive only their commands. */}
+				{browserAvailable ? (
+					<Suspense
+						fallback={<div className="min-h-0 flex-1" aria-busy="true" />}
+					>
+						<BrowserPaneHost
+							activeChatId={chatId}
+							browserActive={browserActive}
+						/>
+					</Suspense>
+				) : (
+					<div
+						hidden={!browserActive}
+						className="flex min-h-0 min-w-0 flex-1 flex-col"
+					>
 						<div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center">
 							<div className="max-w-sm">
 								<h2 className="font-medium text-sm">
@@ -392,8 +393,8 @@ export function RightPane({
 								</p>
 							</div>
 						</div>
-					)}
-				</div>
+					</div>
+				)}
 			</div>
 		</aside>
 	);

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -158,7 +158,12 @@ export function TopBarMain() {
 	const refreshPr = usePrStateStore((s) => s.refresh);
 	const leftSidebarOpen = useUiStore((s) => s.leftSidebarOpen);
 	const setLeftSidebarOpen = useUiStore((s) => s.setLeftSidebarOpen);
-	const rightSidebarOpen = useUiStore((s) => s.rightSidebarOpen);
+	const selectedChatId = useChatsStore((s) => s.selectedChatId);
+	const rightSidebarOpen = useUiStore((s) =>
+		selectedChatId === null
+			? false
+			: (s.rightPaneLayoutByChat[selectedChatId]?.open ?? false),
+	);
 	const setRightSidebarOpen = useUiStore((s) => s.setRightSidebarOpen);
 	const isFullScreen = useUiStore((s) => s.isFullScreen);
 	const environmentSummaryOpen = useUiStore((s) => s.environmentSummaryOpen);

--- a/apps/renderer/src/lib/browser-controller-registry.ts
+++ b/apps/renderer/src/lib/browser-controller-registry.ts
@@ -1,0 +1,65 @@
+import type {
+	BrowserCommandRequest,
+	ChatId,
+	Session,
+	SessionId,
+} from "@zuse/contracts";
+
+export type BrowserController = (
+	request: BrowserCommandRequest,
+) => Promise<void>;
+
+const controllers = new Map<string, BrowserController>();
+const waiters = new Map<
+	string,
+	Set<(controller: BrowserController | null) => void>
+>();
+
+export const registerBrowserController = (
+	chatId: ChatId,
+	controller: BrowserController,
+): (() => void) => {
+	controllers.set(chatId, controller);
+	const pending = waiters.get(chatId);
+	if (pending !== undefined) {
+		for (const resolve of pending) resolve(controller);
+		waiters.delete(chatId);
+	}
+	return () => {
+		if (controllers.get(chatId) === controller) controllers.delete(chatId);
+	};
+};
+
+export const waitForBrowserController = (
+	chatId: ChatId,
+	timeoutMs = 5_000,
+): Promise<BrowserController | null> => {
+	const existing = controllers.get(chatId);
+	if (existing !== undefined) return Promise.resolve(existing);
+	return new Promise((resolve) => {
+		const pending = waiters.get(chatId) ?? new Set();
+		let timeout: ReturnType<typeof setTimeout>;
+		const wrappedResolve = (controller: BrowserController | null) => {
+			clearTimeout(timeout);
+			resolve(controller);
+		};
+		pending.add(wrappedResolve);
+		waiters.set(chatId, pending);
+		timeout = setTimeout(() => {
+			pending.delete(wrappedResolve);
+			if (pending.size === 0) waiters.delete(chatId);
+			resolve(null);
+		}, timeoutMs);
+	});
+};
+
+export const browserChatIdForSession = (
+	sessionsByProject: Record<string, ReadonlyArray<Session>>,
+	sessionId: SessionId,
+): ChatId | null => {
+	for (const sessions of Object.values(sessionsByProject)) {
+		const session = sessions.find((candidate) => candidate.id === sessionId);
+		if (session !== undefined) return session.chatId;
+	}
+	return null;
+};

--- a/apps/renderer/src/lib/commands.ts
+++ b/apps/renderer/src/lib/commands.ts
@@ -21,93 +21,98 @@ import { activeChatId, orderedChatTabs } from "./tab-order";
 
 /** Sessions belonging to the currently-selected project. */
 function currentProjectSessions(): ReadonlyArray<Session> {
-  const projectId = useWorkspaceStore.getState().selectedFolderId;
-  if (projectId === null) return [];
-  return useSessionsStore.getState().sessionsByProject[projectId] ?? [];
+	const projectId = useWorkspaceStore.getState().selectedFolderId;
+	if (projectId === null) return [];
+	return useSessionsStore.getState().sessionsByProject[projectId] ?? [];
 }
 
 /** The chat whose sessions fill the tab strip right now. */
 function currentChatId(): ChatId | null {
-  return activeChatId(
-    currentProjectSessions(),
-    useSessionsStore.getState().selectedSessionId,
-    useChatsStore.getState().selectedChatId,
-  );
+	return activeChatId(
+		currentProjectSessions(),
+		useSessionsStore.getState().selectedSessionId,
+		useChatsStore.getState().selectedChatId,
+	);
 }
 
 /** Move the active tab by `delta` within the active chat, wrapping around. */
 function stepTab(delta: 1 | -1): void {
-  const tabs = orderedChatTabs(currentProjectSessions(), currentChatId());
-  if (tabs.length === 0) return;
-  const selectedId = useSessionsStore.getState().selectedSessionId;
-  const idx = tabs.findIndex((t) => t.id === selectedId);
-  const base = idx === -1 ? 0 : idx;
-  const next = (base + delta + tabs.length) % tabs.length;
-  useSessionsStore.getState().select(tabs[next]!.id);
+	const tabs = orderedChatTabs(currentProjectSessions(), currentChatId());
+	if (tabs.length === 0) return;
+	const selectedId = useSessionsStore.getState().selectedSessionId;
+	const idx = tabs.findIndex((t) => t.id === selectedId);
+	const base = idx === -1 ? 0 : idx;
+	const next = (base + delta + tabs.length) % tabs.length;
+	const target = tabs[next];
+	if (target !== undefined) useSessionsStore.getState().select(target.id);
 }
 
 /** Select the 1-based Nth tab; no-op if it doesn't exist. */
 function selectTabAt(oneBased: number): void {
-  const tabs = orderedChatTabs(currentProjectSessions(), currentChatId());
-  const target = tabs[oneBased - 1];
-  if (target !== undefined) useSessionsStore.getState().select(target.id);
+	const tabs = orderedChatTabs(currentProjectSessions(), currentChatId());
+	const target = tabs[oneBased - 1];
+	if (target !== undefined) useSessionsStore.getState().select(target.id);
 }
 
 /** Select the last tab in the active chat. */
 function selectLastTab(): void {
-  const tabs = orderedChatTabs(currentProjectSessions(), currentChatId());
-  const target = tabs[tabs.length - 1];
-  if (target !== undefined) useSessionsStore.getState().select(target.id);
+	const tabs = orderedChatTabs(currentProjectSessions(), currentChatId());
+	const target = tabs[tabs.length - 1];
+	if (target !== undefined) useSessionsStore.getState().select(target.id);
 }
 
 /** Open a fresh session in the active chat — the tab-strip "+" button, by key. */
 async function newTabInActiveChat(): Promise<void> {
-  const chatId = currentChatId();
-  if (chatId === null) return;
-  const settings = useSettingsStore.getState();
-  const providerId = settings.defaultProviderId;
-  // Warm path skips the provider refresh when a default model is cached;
-  // cold path pays the round-trip first so `create` gets a real model id.
-  if (settings.defaultModelByProvider[providerId] === undefined) {
-    await useProvidersStore.getState().refresh();
-  }
-  const fresh = useSettingsStore.getState();
-  const model =
-    fresh.defaultModelByProvider[providerId] ?? defaultModelFor(providerId);
-  await useSessionsStore.getState().create(chatId, providerId, model, {
-    runtimeMode: fresh.defaultRuntimeMode,
-  });
+	const chatId = currentChatId();
+	if (chatId === null) return;
+	const settings = useSettingsStore.getState();
+	const providerId = settings.defaultProviderId;
+	// Warm path skips the provider refresh when a default model is cached;
+	// cold path pays the round-trip first so `create` gets a real model id.
+	if (settings.defaultModelByProvider[providerId] === undefined) {
+		await useProvidersStore.getState().refresh();
+	}
+	const fresh = useSettingsStore.getState();
+	const model =
+		fresh.defaultModelByProvider[providerId] ?? defaultModelFor(providerId);
+	await useSessionsStore.getState().create(chatId, providerId, model, {
+		runtimeMode: fresh.defaultRuntimeMode,
+	});
 }
 
 /** Move the selected chat by `delta` within the project, wrapping around. */
 function stepChat(delta: 1 | -1): void {
-  const projectId = useWorkspaceStore.getState().selectedFolderId;
-  if (projectId === null) return;
-  const chats = useChatsStore.getState();
-  const list = (chats.chatsByProject[projectId] ?? []).filter(
-    (c) => c.archivedAt === null,
-  );
-  if (list.length === 0) return;
-  const idx = list.findIndex((c) => c.id === chats.selectedChatId);
-  const base = idx === -1 ? 0 : idx;
-  const next = (base + delta + list.length) % list.length;
-  chats.select(list[next]!.id);
+	const projectId = useWorkspaceStore.getState().selectedFolderId;
+	if (projectId === null) return;
+	const chats = useChatsStore.getState();
+	const list = (chats.chatsByProject[projectId] ?? []).filter(
+		(c) => c.archivedAt === null,
+	);
+	if (list.length === 0) return;
+	const idx = list.findIndex((c) => c.id === chats.selectedChatId);
+	const base = idx === -1 ? 0 : idx;
+	const next = (base + delta + list.length) % list.length;
+	const target = list[next];
+	if (target !== undefined) chats.select(target.id);
 }
 
 /** Move the active right-pane panel by `delta`, wrapping around; opens the
  *  right sidebar first if it's collapsed. */
 function stepPanel(delta: 1 | -1): void {
-  const ui = useUiStore.getState();
-  const chatId = currentChatId();
-  if (chatId === null) return;
-  const panels = ui.rightPanelsByChat[chatId] ?? [];
-  if (panels.length === 0) return;
-  if (!ui.rightSidebarOpen) ui.setRightSidebarOpen(true);
-  const activeId = ui.activeRightPanelByChat[chatId] ?? null;
-  const idx = panels.findIndex((p) => p.id === activeId);
-  const base = idx === -1 ? 0 : idx;
-  const next = (base + delta + panels.length) % panels.length;
-  ui.setActiveRightPanel(panels[next]!.id);
+	const ui = useUiStore.getState();
+	const chatId = currentChatId();
+	if (chatId === null) return;
+	const panels = ui.rightPanelsByChat[chatId] ?? [];
+	if (panels.length === 0) return;
+	if (ui.rightPaneLayoutByChat[chatId]?.open !== true) {
+		ui.setRightSidebarOpenForChat(chatId, true);
+	}
+	const activeId = ui.activeRightPanelByChat[chatId] ?? null;
+	const idx = panels.findIndex((p) => p.id === activeId);
+	const base = idx === -1 ? 0 : idx;
+	const next = (base + delta + panels.length) % panels.length;
+	const target = panels[next];
+	if (target !== undefined) ui.setActiveRightPanel(target.id);
 }
 
 /**
@@ -126,67 +131,72 @@ function stepPanel(delta: 1 | -1): void {
  * anything — it just fires effects.
  */
 const HANDLERS: Record<Command, () => void> = {
-  "new-chat": () => {
-    const projectId = useWorkspaceStore.getState().selectedFolderId;
-    if (projectId === null) return;
-    void createNewSession(projectId);
-  },
-  "open-project": () => {
-    void useWorkspaceStore.getState().add();
-  },
-  settings: () => {
-    const ui = useUiStore.getState();
-    ui.setView(ui.view === "settings" ? "chat" : "settings");
-  },
-  "close-tab": () => {
-    // Owned by `app.tsx` directly — kept here for completeness so the
-    // settings UI lists Close Tab in the same table as the others. The
-    // native menu's Cmd+W still uses its dedicated IPC signal, and the
-    // document dispatcher doesn't fire this scope.
-  },
-  "toggle-left-sidebar": () => {
-    const ui = useUiStore.getState();
-    ui.setLeftSidebarOpen(!ui.leftSidebarOpen);
-  },
-  "toggle-right-sidebar": () => {
-    const ui = useUiStore.getState();
-    ui.setRightSidebarOpen(!ui.rightSidebarOpen);
-  },
-  "toggle-terminal": () => {
-    // Open the sidebar (if closed) and reveal a terminal panel — focus an
-    // existing one or add a fresh terminal tab.
-    useUiStore.getState().revealPanel("terminal");
-  },
-  "focus-composer": () => {
-    useComposerBridge.getState().focus?.();
-  },
-  "next-tab": () => stepTab(1),
-  "prev-tab": () => stepTab(-1),
-  "select-tab-1": () => selectTabAt(1),
-  "select-tab-2": () => selectTabAt(2),
-  "select-tab-3": () => selectTabAt(3),
-  "select-tab-4": () => selectTabAt(4),
-  "select-tab-5": () => selectTabAt(5),
-  "select-tab-6": () => selectTabAt(6),
-  "select-tab-7": () => selectTabAt(7),
-  "select-tab-8": () => selectTabAt(8),
-  "select-last-tab": () => selectLastTab(),
-  "new-tab": () => {
-    void newTabInActiveChat();
-  },
-  "next-chat": () => stepChat(1),
-  "prev-chat": () => stepChat(-1),
-  "next-panel": () => stepPanel(1),
-  "prev-panel": () => stepPanel(-1),
-  "focus-next-pane": () => usePaneFocus.getState().focusAdjacent(1),
-  "focus-prev-pane": () => usePaneFocus.getState().focusAdjacent(-1),
-  "open-chat-switcher": () => useUiStore.getState().toggleChatSwitcher(),
-  "composer.submit": () => {},
-  "composer.newline": () => {},
-  "composer.forceSubmit": () => {},
-  "composer.togglePlanMode": () => {},
-  "editor.save": () => {},
-  "editor.annotate": () => {},
+	"new-chat": () => {
+		const projectId = useWorkspaceStore.getState().selectedFolderId;
+		if (projectId === null) return;
+		void createNewSession(projectId);
+	},
+	"open-project": () => {
+		void useWorkspaceStore.getState().add();
+	},
+	settings: () => {
+		const ui = useUiStore.getState();
+		ui.setView(ui.view === "settings" ? "chat" : "settings");
+	},
+	"close-tab": () => {
+		// Owned by `app.tsx` directly — kept here for completeness so the
+		// settings UI lists Close Tab in the same table as the others. The
+		// native menu's Cmd+W still uses its dedicated IPC signal, and the
+		// document dispatcher doesn't fire this scope.
+	},
+	"toggle-left-sidebar": () => {
+		const ui = useUiStore.getState();
+		ui.setLeftSidebarOpen(!ui.leftSidebarOpen);
+	},
+	"toggle-right-sidebar": () => {
+		const ui = useUiStore.getState();
+		const chatId = currentChatId();
+		if (chatId === null) return;
+		ui.setRightSidebarOpenForChat(
+			chatId,
+			ui.rightPaneLayoutByChat[chatId]?.open !== true,
+		);
+	},
+	"toggle-terminal": () => {
+		// Open the sidebar (if closed) and reveal a terminal panel — focus an
+		// existing one or add a fresh terminal tab.
+		useUiStore.getState().revealPanel("terminal");
+	},
+	"focus-composer": () => {
+		useComposerBridge.getState().focus?.();
+	},
+	"next-tab": () => stepTab(1),
+	"prev-tab": () => stepTab(-1),
+	"select-tab-1": () => selectTabAt(1),
+	"select-tab-2": () => selectTabAt(2),
+	"select-tab-3": () => selectTabAt(3),
+	"select-tab-4": () => selectTabAt(4),
+	"select-tab-5": () => selectTabAt(5),
+	"select-tab-6": () => selectTabAt(6),
+	"select-tab-7": () => selectTabAt(7),
+	"select-tab-8": () => selectTabAt(8),
+	"select-last-tab": () => selectLastTab(),
+	"new-tab": () => {
+		void newTabInActiveChat();
+	},
+	"next-chat": () => stepChat(1),
+	"prev-chat": () => stepChat(-1),
+	"next-panel": () => stepPanel(1),
+	"prev-panel": () => stepPanel(-1),
+	"focus-next-pane": () => usePaneFocus.getState().focusAdjacent(1),
+	"focus-prev-pane": () => usePaneFocus.getState().focusAdjacent(-1),
+	"open-chat-switcher": () => useUiStore.getState().toggleChatSwitcher(),
+	"composer.submit": () => {},
+	"composer.newline": () => {},
+	"composer.forceSubmit": () => {},
+	"composer.togglePlanMode": () => {},
+	"editor.save": () => {},
+	"editor.annotate": () => {},
 };
 
 /**
@@ -201,8 +211,8 @@ export function dispatchCommand(command: Command): void {
 		control: `command.${command}`,
 		interaction_source: "command",
 	});
-  const fn = HANDLERS[command];
-  fn();
+	const fn = HANDLERS[command];
+	fn();
 }
 
 /**
@@ -212,31 +222,31 @@ export function dispatchCommand(command: Command): void {
  * would (a) submit twice and (b) preventDefault on the native typing event.
  */
 export const APPLICATION_COMMANDS: ReadonlySet<Command> = new Set<Command>([
-  "new-chat",
-  "open-project",
-  "settings",
-  "toggle-left-sidebar",
-  "toggle-right-sidebar",
-  "toggle-terminal",
-  "focus-composer",
-  "next-tab",
-  "prev-tab",
-  "select-tab-1",
-  "select-tab-2",
-  "select-tab-3",
-  "select-tab-4",
-  "select-tab-5",
-  "select-tab-6",
-  "select-tab-7",
-  "select-tab-8",
-  "select-last-tab",
-  "new-tab",
-  "next-chat",
-  "prev-chat",
-  "next-panel",
-  "prev-panel",
-  "focus-next-pane",
-  "focus-prev-pane",
-  "open-chat-switcher",
-  // `close-tab` deliberately omitted — see app.tsx's onCloseTab handler.
+	"new-chat",
+	"open-project",
+	"settings",
+	"toggle-left-sidebar",
+	"toggle-right-sidebar",
+	"toggle-terminal",
+	"focus-composer",
+	"next-tab",
+	"prev-tab",
+	"select-tab-1",
+	"select-tab-2",
+	"select-tab-3",
+	"select-tab-4",
+	"select-tab-5",
+	"select-tab-6",
+	"select-tab-7",
+	"select-tab-8",
+	"select-last-tab",
+	"new-tab",
+	"next-chat",
+	"prev-chat",
+	"next-panel",
+	"prev-panel",
+	"focus-next-pane",
+	"focus-prev-pane",
+	"open-chat-switcher",
+	// `close-tab` deliberately omitted — see app.tsx's onCloseTab handler.
 ]);

--- a/apps/renderer/src/lib/diagnostics-client-context.ts
+++ b/apps/renderer/src/lib/diagnostics-client-context.ts
@@ -1,56 +1,59 @@
-import {
-  getDiagnosticUiActions,
-  getRendererDiagnosticLogs,
-  type DiagnosticLogEntry,
-  type DiagnosticUiAction,
-} from "./diagnostics-recorder.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { useSessionsStore } from "../store/sessions.ts";
-import { useUiStore, type OpenFile } from "../store/ui.ts";
+import { type OpenFile, useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
+import {
+	type DiagnosticLogEntry,
+	type DiagnosticUiAction,
+	getDiagnosticUiActions,
+	getRendererDiagnosticLogs,
+} from "./diagnostics-recorder.ts";
 
 export interface DiagnosticsClientContext {
-  readonly view?: string;
-  readonly settingsSection?: string;
-  readonly activeMainTab?: string;
-  readonly selectedFolderId?: string | null;
-  readonly selectedChatId?: string | null;
-  readonly activeSessionId?: string | null;
-  readonly openFile?: string | null;
-  readonly rightSidebarOpen?: boolean;
-  readonly leftSidebarOpen?: boolean;
-  readonly recentUiActions: ReadonlyArray<DiagnosticUiAction>;
-  readonly rendererLogs: ReadonlyArray<DiagnosticLogEntry>;
-  readonly mainProcessLogs: ReadonlyArray<DiagnosticLogEntry>;
+	readonly view?: string;
+	readonly settingsSection?: string;
+	readonly activeMainTab?: string;
+	readonly selectedFolderId?: string | null;
+	readonly selectedChatId?: string | null;
+	readonly activeSessionId?: string | null;
+	readonly openFile?: string | null;
+	readonly rightSidebarOpen?: boolean;
+	readonly leftSidebarOpen?: boolean;
+	readonly recentUiActions: ReadonlyArray<DiagnosticUiAction>;
+	readonly rendererLogs: ReadonlyArray<DiagnosticLogEntry>;
+	readonly mainProcessLogs: ReadonlyArray<DiagnosticLogEntry>;
 }
 
 function describeOpenFile(openFile: OpenFile | null): string | null {
-  if (openFile === null) return null;
-  if (openFile.kind === "text") return `text:${openFile.path}`;
-  if (openFile.kind === "image") return `image:${openFile.name}`;
-  return `external:${openFile.absPath}`;
+	if (openFile === null) return null;
+	if (openFile.kind === "text") return `text:${openFile.path}`;
+	if (openFile.kind === "image") return `image:${openFile.name}`;
+	return `external:${openFile.absPath}`;
 }
 
 export async function collectDiagnosticsClientContext(): Promise<DiagnosticsClientContext> {
-  const ui = useUiStore.getState();
-  const workspace = useWorkspaceStore.getState();
-  const chats = useChatsStore.getState();
-  const sessions = useSessionsStore.getState();
-  const mainProcessLogs =
-    (await window.zuse?.app?.getMainDiagnostics?.().catch(() => [])) ?? [];
+	const ui = useUiStore.getState();
+	const workspace = useWorkspaceStore.getState();
+	const chats = useChatsStore.getState();
+	const sessions = useSessionsStore.getState();
+	const mainProcessLogs =
+		(await window.zuse?.app?.getMainDiagnostics?.().catch(() => [])) ?? [];
 
-  return {
-    view: ui.view,
-    settingsSection: ui.settingsSection.kind,
-    activeMainTab: ui.activeMainTab,
-    selectedFolderId: workspace.selectedFolderId,
-    selectedChatId: chats.selectedChatId,
-    activeSessionId: sessions.selectedSessionId,
-    openFile: describeOpenFile(ui.openFile),
-    rightSidebarOpen: ui.rightSidebarOpen,
-    leftSidebarOpen: ui.leftSidebarOpen,
-    recentUiActions: getDiagnosticUiActions(),
-    rendererLogs: getRendererDiagnosticLogs(),
-    mainProcessLogs,
-  };
+	return {
+		view: ui.view,
+		settingsSection: ui.settingsSection.kind,
+		activeMainTab: ui.activeMainTab,
+		selectedFolderId: workspace.selectedFolderId,
+		selectedChatId: chats.selectedChatId,
+		activeSessionId: sessions.selectedSessionId,
+		openFile: describeOpenFile(ui.openFile),
+		rightSidebarOpen:
+			chats.selectedChatId === null
+				? false
+				: ui.rightPaneLayoutByChat[chats.selectedChatId]?.open === true,
+		leftSidebarOpen: ui.leftSidebarOpen,
+		recentUiActions: getDiagnosticUiActions(),
+		rendererLogs: getRendererDiagnosticLogs(),
+		mainProcessLogs,
+	};
 }

--- a/apps/renderer/src/lib/run-terminal.ts
+++ b/apps/renderer/src/lib/run-terminal.ts
@@ -1,9 +1,9 @@
 import type { ChatId } from "@zuse/contracts";
 
 import {
-  type TerminalInstance,
-  terminalsKey,
-  useTerminalsStore,
+	type TerminalInstance,
+	terminalsKey,
+	useTerminalsStore,
 } from "../store/terminals.ts";
 import { useUiStore } from "../store/ui.ts";
 
@@ -20,16 +20,16 @@ import { useUiStore } from "../store/ui.ts";
  * guarantees the new tab shows the command output instead of a blank shell.
  */
 export function openTerminalCommand(args: {
-  readonly chatId: ChatId;
-  readonly cwd: string;
-  readonly title: string;
-  readonly command: NonNullable<TerminalInstance["command"]>;
+	readonly chatId: ChatId;
+	readonly cwd: string;
+	readonly title: string;
+	readonly command: NonNullable<TerminalInstance["command"]>;
 }): void {
-  const key = terminalsKey(args.chatId);
-  const index = useTerminalsStore
-    .getState()
-    .addCommand(key, args.cwd, args.title, args.command);
-  const ui = useUiStore.getState();
-  ui.addTerminalPanelForSlot(args.chatId, index);
-  ui.setRightSidebarOpen(true);
+	const key = terminalsKey(args.chatId);
+	const index = useTerminalsStore
+		.getState()
+		.addCommand(key, args.cwd, args.title, args.command);
+	const ui = useUiStore.getState();
+	ui.addTerminalPanelForSlot(args.chatId, index);
+	ui.setRightSidebarOpenForChat(args.chatId, true);
 }

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -189,7 +189,8 @@ type UiState = {
 	 * (macOS Dock-style auto-reveal). Resets on reload — never persisted.
 	 */
 	readonly leftSidebarPeek: boolean;
-	readonly rightSidebarOpen: boolean;
+	/** Right-dock visibility and width, scoped per sidebar chat. */
+	readonly rightPaneLayoutByChat: Record<string, RightPaneLayout>;
 	/** Whether the cross-project chat quick-switcher (Cmd+K) overlay is open. */
 	readonly chatSwitcherOpen: boolean;
 	readonly isFullScreen: boolean;
@@ -225,7 +226,13 @@ type UiState = {
 	readonly setFileDirty: (dirty: boolean) => void;
 	readonly setLeftSidebarOpen: (open: boolean) => void;
 	readonly setLeftSidebarPeek: (peek: boolean) => void;
+	/** Set visibility for the selected chat. */
 	readonly setRightSidebarOpen: (open: boolean) => void;
+	readonly setRightSidebarOpenForChat: (chatId: ChatId, open: boolean) => void;
+	readonly setRightSidebarWidthForChat: (
+		chatId: ChatId,
+		widthPercent: number,
+	) => void;
 	readonly setChatSwitcherOpen: (open: boolean) => void;
 	readonly toggleChatSwitcher: () => void;
 	readonly setFullScreen: (full: boolean) => void;
@@ -252,6 +259,7 @@ type UiState = {
 	 * Replaces the old `setRightSidebarOpen(true) + setActiveRightTab(kind)`
 	 * pairs. For terminals, focuses an existing one or adds a new slot. */
 	readonly revealPanel: (kind: PanelKind) => void;
+	readonly revealPanelForChat: (chatId: ChatId, kind: PanelKind) => void;
 	readonly revealSubagent: (childSessionId: string) => void;
 	readonly selectSubagent: (childSessionId: string | null) => void;
 	readonly revealAnnotation: (annotation: CodeAnnotation) => void;
@@ -264,6 +272,25 @@ const newPanelId = (): string =>
 
 export const ENVIRONMENT_SUMMARY_STORAGE_KEY =
 	"zuse.environmentSummary.open.v1";
+export const RIGHT_PANE_WIDTHS_STORAGE_KEY = "zuse.rightPane.widths.v1";
+export const DEFAULT_RIGHT_PANE_WIDTH_PERCENT = 22;
+
+export type RightPaneLayout = {
+	readonly open: boolean;
+	readonly widthPercent: number;
+};
+
+export const closedRightPaneLayout = (
+	widthPercent = DEFAULT_RIGHT_PANE_WIDTH_PERCENT,
+): RightPaneLayout => ({ open: false, widthPercent });
+
+export const rightPaneLayoutForChat = (
+	state: Pick<UiState, "rightPaneLayoutByChat">,
+	chatId: ChatId | null,
+): RightPaneLayout =>
+	chatId === null
+		? closedRightPaneLayout()
+		: (state.rightPaneLayoutByChat[chatId] ?? closedRightPaneLayout());
 
 const initialEnvironmentSummaryOpen = (): boolean => {
 	if (typeof window === "undefined") return true;
@@ -281,6 +308,54 @@ const persistEnvironmentSummaryOpen = (open: boolean): void => {
 		window.localStorage.setItem(ENVIRONMENT_SUMMARY_STORAGE_KEY, String(open));
 	} catch {
 		// The preference remains usable for this session when storage is blocked.
+	}
+};
+
+const initialRightPaneWidths = (): Record<string, number> => {
+	if (typeof window === "undefined") return {};
+	try {
+		const parsed = JSON.parse(
+			window.localStorage.getItem(RIGHT_PANE_WIDTHS_STORAGE_KEY) ?? "{}",
+		) as Record<string, unknown>;
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				(entry): entry is [string, number] =>
+					typeof entry[1] === "number" &&
+					Number.isFinite(entry[1]) &&
+					entry[1] > 0 &&
+					entry[1] <= 100,
+			),
+		);
+	} catch {
+		return {};
+	}
+};
+
+const initialRightPaneLayout = (): Record<string, RightPaneLayout> =>
+	Object.fromEntries(
+		Object.entries(initialRightPaneWidths()).map(([chatId, widthPercent]) => [
+			chatId,
+			closedRightPaneLayout(widthPercent),
+		]),
+	);
+
+const persistRightPaneWidths = (
+	layoutByChat: Record<string, RightPaneLayout>,
+): void => {
+	try {
+		window.localStorage.setItem(
+			RIGHT_PANE_WIDTHS_STORAGE_KEY,
+			JSON.stringify(
+				Object.fromEntries(
+					Object.entries(layoutByChat).map(([chatId, layout]) => [
+						chatId,
+						layout.widthPercent,
+					]),
+				),
+			),
+		);
+	} catch {
+		// Pane sizing remains available for this renderer session.
 	}
 };
 
@@ -332,7 +407,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	autosave: false,
 	leftSidebarOpen: true,
 	leftSidebarPeek: false,
-	rightSidebarOpen: false,
+	rightPaneLayoutByChat: initialRightPaneLayout(),
 	chatSwitcherOpen: false,
 	isFullScreen: false,
 	environmentSummaryOpen: initialEnvironmentSummaryOpen(),
@@ -412,7 +487,34 @@ export const useUiStore = create<UiState>((set, get) => ({
 	setLeftSidebarOpen: (open) =>
 		set({ leftSidebarOpen: open, leftSidebarPeek: false }),
 	setLeftSidebarPeek: (peek) => set({ leftSidebarPeek: peek }),
-	setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
+	setRightSidebarOpen: (open) => {
+		const chatId = activeChatId();
+		if (chatId === null) return;
+		get().setRightSidebarOpenForChat(chatId as ChatId, open);
+	},
+	setRightSidebarOpenForChat: (chatId, open) =>
+		set((s) => ({
+			rightPaneLayoutByChat: {
+				...s.rightPaneLayoutByChat,
+				[chatId]: {
+					...(s.rightPaneLayoutByChat[chatId] ?? closedRightPaneLayout()),
+					open,
+				},
+			},
+		})),
+	setRightSidebarWidthForChat: (chatId, widthPercent) =>
+		set((s) => {
+			if (!Number.isFinite(widthPercent) || widthPercent <= 0) return s;
+			const rightPaneLayoutByChat = {
+				...s.rightPaneLayoutByChat,
+				[chatId]: {
+					...(s.rightPaneLayoutByChat[chatId] ?? closedRightPaneLayout()),
+					widthPercent,
+				},
+			};
+			persistRightPaneWidths(rightPaneLayoutByChat);
+			return { rightPaneLayoutByChat };
+		}),
 	setChatSwitcherOpen: (open) => set({ chatSwitcherOpen: open }),
 	toggleChatSwitcher: () =>
 		set((s) => ({ chatSwitcherOpen: !s.chatSwitcherOpen })),
@@ -486,17 +588,24 @@ export const useUiStore = create<UiState>((set, get) => ({
 				s.activeRightPanelByChat;
 			const { [chatId]: _droppedSubagent, ...selectedSubagentByChat } =
 				s.selectedSubagentByChat;
+			const { [chatId]: _droppedLayout, ...rightPaneLayoutByChat } =
+				s.rightPaneLayoutByChat;
+			persistRightPaneWidths(rightPaneLayoutByChat);
 			return {
 				rightPanelsByChat,
 				activeRightPanelByChat,
 				selectedSubagentByChat,
+				rightPaneLayoutByChat,
 			};
 		}),
 	revealPanel: (kind) => {
-		const s = get();
-		if (!s.rightSidebarOpen) set({ rightSidebarOpen: true });
 		const chatId = activeChatId();
 		if (chatId === null) return;
+		get().revealPanelForChat(chatId as ChatId, kind);
+	},
+	revealPanelForChat: (chatId, kind) => {
+		get().setRightSidebarOpenForChat(chatId, true);
+		const s = get();
 		const panels = s.rightPanelsByChat[chatId] ?? EMPTY_PANELS;
 		const existing = panels.find((p) => p.kind === kind);
 		if (existing !== undefined) {
@@ -508,14 +617,24 @@ export const useUiStore = create<UiState>((set, get) => ({
 			}));
 			return;
 		}
-		// No panel of this kind yet — add one (terminals add a fresh slot).
-		s.addPanel(kind);
+		const slot = panels.filter((p) => p.kind === "terminal").length;
+		const panel =
+			kind === "terminal"
+				? ({ id: newPanelId(), kind, slot } satisfies PanelInstance)
+				: ({ id: newPanelId(), kind } as PanelInstance);
+		set((st) => writePanels(st, chatId, [...panels, panel], panel.id));
 	},
 	revealSubagent: (childSessionId) => {
 		const chatId = activeChatId();
 		if (chatId === null) return;
 		set((s) => ({
-			rightSidebarOpen: true,
+			rightPaneLayoutByChat: {
+				...s.rightPaneLayoutByChat,
+				[chatId]: {
+					...(s.rightPaneLayoutByChat[chatId] ?? closedRightPaneLayout()),
+					open: true,
+				},
+			},
 			selectedSubagentByChat: {
 				...s.selectedSubagentByChat,
 				[chatId]: childSessionId,

--- a/apps/renderer/test/unit/browser-controller-registry.test.ts
+++ b/apps/renderer/test/unit/browser-controller-registry.test.ts
@@ -1,0 +1,58 @@
+import type {
+	BrowserCommandRequest,
+	ChatId,
+	FolderId,
+	Session,
+	SessionId,
+} from "@zuse/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	browserChatIdForSession,
+	registerBrowserController,
+	waitForBrowserController,
+} from "../../src/lib/browser-controller-registry.ts";
+
+const chatA = "chat-a" as ChatId;
+const chatB = "chat-b" as ChatId;
+const sessionA = "session-a" as SessionId;
+const sessionB = "session-b" as SessionId;
+const projectId = "project" as FolderId;
+
+const session = (id: SessionId, chatId: ChatId): Session =>
+	({ id, chatId, projectId }) as Session;
+
+describe("browser controller routing", () => {
+	it("resolves a browser request to the session's owning chat", () => {
+		const sessions = {
+			[projectId]: [session(sessionA, chatA), session(sessionB, chatB)],
+		};
+
+		expect(browserChatIdForSession(sessions, sessionB)).toBe(chatB);
+		expect(
+			browserChatIdForSession(sessions, "missing" as SessionId),
+		).toBeNull();
+	});
+
+	it("returns only the controller registered for the requested chat", async () => {
+		const controllerA = vi.fn(async (_request: BrowserCommandRequest) => {});
+		const controllerB = vi.fn(async (_request: BrowserCommandRequest) => {});
+		const unregisterA = registerBrowserController(chatA, controllerA);
+		const unregisterB = registerBrowserController(chatB, controllerB);
+
+		expect(await waitForBrowserController(chatB)).toBe(controllerB);
+		expect(await waitForBrowserController(chatA)).toBe(controllerA);
+
+		unregisterA();
+		unregisterB();
+	});
+
+	it("wakes a pending request when its chat controller mounts", async () => {
+		const pending = waitForBrowserController(chatB, 100);
+		const controller = vi.fn(async (_request: BrowserCommandRequest) => {});
+		const unregister = registerBrowserController(chatB, controller);
+
+		expect(await pending).toBe(controller);
+		unregister();
+	});
+});

--- a/apps/renderer/test/unit/right-pane-state.test.ts
+++ b/apps/renderer/test/unit/right-pane-state.test.ts
@@ -1,0 +1,69 @@
+import type { ChatId } from "@zuse/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useChatsStore } from "../../src/store/chats.ts";
+import {
+	DEFAULT_RIGHT_PANE_WIDTH_PERCENT,
+	useUiStore,
+} from "../../src/store/ui.ts";
+
+const chatA = "chat-a" as ChatId;
+const chatB = "chat-b" as ChatId;
+
+describe("chat-scoped right pane state", () => {
+	beforeEach(() => {
+		useChatsStore.setState({ selectedChatId: chatA });
+		useUiStore.setState({
+			rightPaneLayoutByChat: {},
+			rightPanelsByChat: {},
+			activeRightPanelByChat: {},
+			selectedSubagentByChat: {},
+		});
+	});
+
+	it("keeps visibility and width independent between chats", () => {
+		const ui = useUiStore.getState();
+		ui.setRightSidebarOpen(true);
+		ui.setRightSidebarWidthForChat(chatA, 31);
+		ui.setRightSidebarOpenForChat(chatB, false);
+		ui.setRightSidebarWidthForChat(chatB, 44);
+
+		expect(useUiStore.getState().rightPaneLayoutByChat).toMatchObject({
+			[chatA]: { open: true, widthPercent: 31 },
+			[chatB]: { open: false, widthPercent: 44 },
+		});
+	});
+
+	it("reveals a panel in a background chat without touching the selected chat", () => {
+		useUiStore.getState().revealPanelForChat(chatB, "browser");
+
+		const state = useUiStore.getState();
+		expect(state.rightPaneLayoutByChat[chatA]).toBeUndefined();
+		expect(state.rightPaneLayoutByChat[chatB]).toEqual({
+			open: true,
+			widthPercent: DEFAULT_RIGHT_PANE_WIDTH_PERCENT,
+		});
+		expect(state.rightPanelsByChat[chatA]).toBeUndefined();
+		expect(state.rightPanelsByChat[chatB]?.map((panel) => panel.kind)).toEqual([
+			"browser",
+		]);
+		expect(state.activeRightPanelByChat[chatB]).toBe(
+			state.rightPanelsByChat[chatB]?.[0]?.id,
+		);
+	});
+
+	it("clears every right-pane record when a chat is removed", () => {
+		const ui = useUiStore.getState();
+		ui.revealPanelForChat(chatB, "browser");
+		ui.setRightSidebarWidthForChat(chatB, 37);
+		ui.selectSubagent("session-child");
+
+		ui.clearChatPanels(chatB);
+
+		const state = useUiStore.getState();
+		expect(state.rightPaneLayoutByChat[chatB]).toBeUndefined();
+		expect(state.rightPanelsByChat[chatB]).toBeUndefined();
+		expect(state.activeRightPanelByChat[chatB]).toBeUndefined();
+		expect(state.selectedSubagentByChat[chatB]).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What changed

- Scope right-pane visibility, active panels, and persisted width to each sidebar chat.
- Keep one isolated browser webview per chat so URL, history, overlays, and background activity do not leak across chats.
- Route browser commands from the issuing session to its owning chat through a shared dispatcher.
- Target background terminal and browser reveals at the correct chat and clear all pane state when that chat is removed.
- Add regression coverage for pane isolation and browser controller routing.

## Why

The dock panel list was chat-scoped, but its expanded state and the embedded browser controller were global. Switching chats could therefore carry an expanded pane or live browser state into another conversation, and background browser commands could act on whichever chat happened to be visible.

## Impact

Each chat now restores its own right-pane visibility, width, active panel, and browser history. Background agent browser work remains attached to the chat that issued it without switching or mutating the user's current chat.

## Validation

- `bun run --cwd apps/renderer check-types`
- `bun run --cwd apps/renderer test:unit` (232 tests)
- `bun run --cwd apps/renderer build`
- Biome checks on all changed files
