### PR TITLE
Fix integration auth and consolidate secure storage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,15 @@ jobs:
           # time (apps/desktop/.env is gitignored, so CI must supply it here).
           # Not sensitive — a repo variable would also work.
           WORKOS_CLIENT_ID: ${{ secrets.WORKOS_CLIENT_ID }}
+          # Public OAuth client id for the issue-tracker integration. The
+          # desktop bundle intentionally contains the id, never a client secret.
+          LINEAR_CLIENT_ID: ${{ secrets.LINEAR_CLIENT_ID }}
           # Analytics keys are injected at build time and never committed.
           ZUSE_POSTHOG_KEY: ${{ secrets.ZUSE_POSTHOG_KEY }}
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
-        run: bun run build
+        run: |
+          test -n "$LINEAR_CLIENT_ID"
+          bun run build
 
       - name: Package + sign + notarize + publish
         working-directory: apps/desktop

--- a/apps/desktop/native/local-connectivity/main.swift
+++ b/apps/desktop/native/local-connectivity/main.swift
@@ -1,51 +1,8 @@
 import AppKit
 import Foundation
 import Network
-import Security
 
 private let queue = DispatchQueue(label: "com.zuse.local-connectivity.helper")
-private let sharedKeychainGroup = "HMCST4VV42.com.zuse.shared-connectivity"
-
-private func base64URL(_ data: Data) -> String {
-  data.base64EncodedString()
-    .replacingOccurrences(of: "+", with: "-")
-    .replacingOccurrences(of: "/", with: "_")
-    .replacingOccurrences(of: "=", with: "")
-}
-
-private func ensureTrustRecord(_ recordId: String) throws -> Data {
-  let baseQuery: [CFString: Any] = [
-    kSecClass: kSecClassGenericPassword,
-    kSecAttrService: "com.zuse.local-trust",
-    kSecAttrAccount: recordId,
-    kSecAttrAccessGroup: sharedKeychainGroup,
-    kSecAttrSynchronizable: kCFBooleanTrue as Any,
-    kSecUseDataProtectionKeychain: kCFBooleanTrue as Any,
-  ]
-  var readQuery = baseQuery
-  readQuery[kSecReturnData] = kCFBooleanTrue
-  readQuery[kSecMatchLimit] = kSecMatchLimitOne
-  var existing: CFTypeRef?
-  let readStatus = SecItemCopyMatching(readQuery as CFDictionary, &existing)
-  if readStatus == errSecSuccess, let secret = existing as? Data { return secret }
-  guard readStatus == errSecItemNotFound else {
-    throw NSError(domain: NSOSStatusErrorDomain, code: Int(readStatus))
-  }
-
-  var bytes = [UInt8](repeating: 0, count: 32)
-  guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
-    throw NSError(domain: "ZuseLocalConnectivity", code: 2)
-  }
-  let secret = Data(bytes)
-  var addQuery = baseQuery
-  addQuery[kSecValueData] = secret
-  addQuery[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
-  let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-  guard addStatus == errSecSuccess else {
-    throw NSError(domain: NSOSStatusErrorDomain, code: Int(addStatus))
-  }
-  return secret
-}
 
 private func emit(_ event: String, _ fields: [String: Any] = [:]) {
   var payload = fields
@@ -147,18 +104,15 @@ private final class NearbyListener {
   private var retryWork: DispatchWorkItem?
   private var retryAttempt = 0
 
-  private let trustRecordId: String?
   private let tlsCertificatePin: String
 
   init(
     targetPort: NWEndpoint.Port,
     serviceName: String,
-    trustRecordId: String?,
     tlsCertificatePin: String
   ) {
     self.targetPort = targetPort
     self.serviceName = serviceName
-    self.trustRecordId = trustRecordId
     self.tlsCertificatePin = tlsCertificatePin
   }
 
@@ -173,9 +127,9 @@ private final class NearbyListener {
     parameters.allowLocalEndpointReuse = true
     do {
       let listener = try NWListener(using: parameters, on: .any)
-      var txtEntries = ["tls": Data(tlsCertificatePin.utf8)]
-      if let trustRecordId { txtEntries["trust"] = Data(trustRecordId.utf8) }
-      let txtRecord = NetService.data(fromTXTRecord: txtEntries)
+      let txtRecord = NetService.data(
+        fromTXTRecord: ["tls": Data(tlsCertificatePin.utf8)]
+      )
       listener.service = NWListener.Service(
         name: serviceName,
         type: "_zuse._tcp",
@@ -239,20 +193,6 @@ private final class NearbyListener {
   }
 }
 
-if CommandLine.arguments.count >= 3, CommandLine.arguments[1] == "--ensure-trust" {
-  do {
-    let recordId = String(CommandLine.arguments[2].prefix(128))
-    let secret = try ensureTrustRecord(recordId)
-    let output = ["recordId": recordId, "secret": base64URL(secret)]
-    let data = try JSONSerialization.data(withJSONObject: output)
-    FileHandle.standardOutput.write(data)
-    exit(0)
-  } catch {
-    FileHandle.standardError.write(Data("trust record unavailable: \(error.localizedDescription)\n".utf8))
-    exit(1)
-  }
-}
-
 guard
   CommandLine.arguments.count >= 2,
   let portValue = UInt16(CommandLine.arguments[1]),
@@ -265,11 +205,8 @@ else {
 private let serviceName = CommandLine.arguments.count >= 3
   ? String(CommandLine.arguments[2].prefix(48))
   : "Zuse Mac"
-private let trustRecordId = CommandLine.arguments.count >= 4
-  ? (CommandLine.arguments[3] == "-" ? nil : String(CommandLine.arguments[3].prefix(128)))
-  : nil
-private let tlsCertificatePin = CommandLine.arguments.count >= 5
-  ? String(CommandLine.arguments[4].prefix(128))
+private let tlsCertificatePin = CommandLine.arguments.count >= 4
+  ? String(CommandLine.arguments[3].prefix(128))
   : ""
 guard tlsCertificatePin.count == 43 else {
   FileHandle.standardError.write(Data("missing TLS certificate pin\n".utf8))
@@ -278,7 +215,6 @@ guard tlsCertificatePin.count == 43 else {
 private let nearby = NearbyListener(
   targetPort: targetPort,
   serviceName: serviceName,
-  trustRecordId: trustRecordId,
   tlsCertificatePin: tlsCertificatePin
 )
 private let monitor = NWPathMonitor()

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,65 +1,65 @@
 {
-  "name": "desktop",
-  "type": "module",
-  "productName": "Zuse (Beta)",
-  "version": "0.15.5",
-  "description": "Zuse (Beta) desktop app",
-  "private": true,
-  "author": {
-    "name": "Swaraj Bachu",
-    "email": "swarajkumar4444@gmail.com"
-  },
-  "homepage": "https://github.com/swarajbachu/zuse",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/swarajbachu/zuse.git"
-  },
-  "main": "dist-electron/main.cjs",
-  "scripts": {
-    "predev": "node scripts/build-local-connectivity-helper.mjs",
-    "dev": "bun run --parallel dev:bundle dev:electron",
-    "dev:bundle": "vp pack --watch",
-    "dev:electron": "node scripts/dev-electron.mjs",
-    "build": "vp pack && node scripts/main-bundle-startup-smoke.mjs",
-    "check-types": "tsc --noEmit",
-    "test": "vp test run test && node scripts/sqlite-runtime-smoke.mjs && node scripts/provider-sdk-runtime-smoke.mjs",
-    "test:unit": "vp test run test/unit",
-    "test:integration": "vp test run test/integration --passWithNoTests",
-    "postinstall": "electron-rebuild -f -o node-pty,keytar",
-    "icon": "node scripts/make-icon.mjs",
-    "native:build": "node scripts/build-local-connectivity-helper.mjs",
-    "native:build:universal": "node scripts/build-local-connectivity-helper.mjs --universal",
-    "predist:mac": "bun run native:build:universal",
-    "dist:mac": "electron-builder --mac --universal",
-    "predist:mac:unsigned": "bun run native:build:universal",
-    "dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
-  },
-  "dependencies": {
-    "@cursor/sdk": "1.0.23",
-    "electron-updater": "^6.3.9",
-    "keytar": "^7.9.0",
-    "node-pty": "^1.1.0",
-    "selfsigned": "^5.5.0",
-    "tree-sitter": "^0.21.1",
-    "tree-sitter-javascript": "^0.23.1",
-    "tree-sitter-json": "^0.24.8",
-    "tree-sitter-typescript": "^0.23.2"
-  },
-  "devDependencies": {
-    "@electron/rebuild": "^4.0.4",
-    "@zuse/server": "*",
-    "@zuse/ssh": "*",
-    "@zuse/contracts": "*",
-    "@repo/typescript-config": "*",
-    "@types/node": "catalog:",
-    "effect": "catalog:",
-    "electron-builder": "^25.1.8",
-    "electron": "42.1.0",
-    "fix-path": "^4.0.0",
-    "sharp": "^0.34.1",
-    "tsdown": "^0.21.10",
-    "typescript": "catalog:",
-    "vite-plus": "0.2.5",
-    "vitest": "catalog:"
-  }
+	"name": "desktop",
+	"type": "module",
+	"productName": "Zuse (Beta)",
+	"version": "0.15.5",
+	"description": "Zuse (Beta) desktop app",
+	"private": true,
+	"author": {
+		"name": "Swaraj Bachu",
+		"email": "swarajkumar4444@gmail.com"
+	},
+	"homepage": "https://github.com/swarajbachu/zuse",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/swarajbachu/zuse.git"
+	},
+	"main": "dist-electron/main.cjs",
+	"scripts": {
+		"predev": "node scripts/build-local-connectivity-helper.mjs",
+		"dev": "bun run --parallel dev:bundle dev:electron",
+		"dev:bundle": "vp pack --watch",
+		"dev:electron": "node scripts/dev-electron.mjs",
+		"build": "vp pack && node scripts/main-bundle-startup-smoke.mjs",
+		"check-types": "tsc --noEmit",
+		"test": "vp test run test && node scripts/sqlite-runtime-smoke.mjs && node scripts/provider-sdk-runtime-smoke.mjs",
+		"test:unit": "vp test run test/unit",
+		"test:integration": "vp test run test/integration --passWithNoTests",
+		"postinstall": "electron-rebuild -f -o node-pty,keytar",
+		"icon": "node scripts/make-icon.mjs",
+		"native:build": "node scripts/build-local-connectivity-helper.mjs",
+		"native:build:universal": "node scripts/build-local-connectivity-helper.mjs --universal",
+		"predist:mac": "bun run native:build:universal",
+		"dist:mac": "electron-builder --mac --universal",
+		"predist:mac:unsigned": "bun run native:build:universal",
+		"dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
+	},
+	"dependencies": {
+		"@cursor/sdk": "1.0.23",
+		"electron-updater": "^6.3.9",
+		"keytar": "^7.9.0",
+		"node-pty": "^1.1.0",
+		"selfsigned": "^5.5.0",
+		"tree-sitter": "^0.21.1",
+		"tree-sitter-javascript": "^0.23.1",
+		"tree-sitter-json": "^0.24.8",
+		"tree-sitter-typescript": "^0.23.2"
+	},
+	"devDependencies": {
+		"@electron/rebuild": "^4.0.4",
+		"@zuse/server": "*",
+		"@zuse/ssh": "*",
+		"@zuse/contracts": "*",
+		"@repo/typescript-config": "*",
+		"@types/node": "catalog:",
+		"effect": "catalog:",
+		"electron-builder": "^25.1.8",
+		"electron": "42.4.1",
+		"fix-path": "^4.0.0",
+		"sharp": "^0.34.1",
+		"tsdown": "^0.21.10",
+		"typescript": "catalog:",
+		"vite-plus": "0.2.5",
+		"vitest": "catalog:"
+	}
 }

--- a/apps/desktop/src/browser-session-service.ts
+++ b/apps/desktop/src/browser-session-service.ts
@@ -1,16 +1,28 @@
 import { execFile } from "node:child_process";
-import { createDecipheriv, createHash, pbkdf2Sync } from "node:crypto";
+import {
+	createCipheriv,
+	createDecipheriv,
+	createHash,
+	pbkdf2Sync,
+	randomBytes,
+} from "node:crypto";
 import * as fs from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import * as Path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
-import type { Session } from "electron";
+import { secureStorageMasterKey } from "@zuse/server/secure-storage-master-key";
+import type { Cookie, Session } from "electron";
 import keytar from "keytar";
 
 const execFileAsync = promisify(execFile);
-const PARTITION = "persist:zuse-browser";
+// Keep Chromium's own cookie store in memory. Persistent Chromium partitions
+// initialize OS cryptography and can create a second macOS Keychain access
+// path. Imported cookies are restored only through the explicit import flow.
+const PARTITION = "zuse-browser";
 const COOKIE_EPOCH_OFFSET_SECONDS = 11_644_473_600;
+const COOKIE_VAULT_AAD = Buffer.from("zuse-browser-cookies:v1", "utf8");
+const COOKIE_VAULT_FILENAME = "browser-cookies.enc";
 
 type ImportedCookieIdentity = {
 	domain: string;
@@ -27,6 +39,7 @@ type ImportState = {
 	lastImportTime?: string;
 	source?: string;
 	profile?: string;
+	trackedDomains: string[];
 	identities: ImportedCookieIdentity[];
 };
 
@@ -71,12 +84,22 @@ const readState = async (userData: string): Promise<ImportState> => {
 			...(typeof parsed.profile === "string"
 				? { profile: parsed.profile }
 				: {}),
+			trackedDomains: Array.isArray(parsed.trackedDomains)
+				? parsed.trackedDomains.filter(
+						(domain): domain is string => typeof domain === "string",
+					)
+				: [],
 			identities: Array.isArray(parsed.identities)
 				? parsed.identities.filter(isIdentity)
 				: [],
 		};
 	} catch {
-		return { version: 1, migratedExistingSession: false, identities: [] };
+		return {
+			version: 1,
+			migratedExistingSession: false,
+			trackedDomains: [],
+			identities: [],
+		};
 	}
 };
 
@@ -99,6 +122,145 @@ const writeState = async (
 	await fs.writeFile(statePath(userData), JSON.stringify(state, null, 2), {
 		mode: 0o600,
 	});
+};
+
+interface PersistedCookie {
+	readonly url: string;
+	readonly name: string;
+	readonly value: string;
+	readonly domain: string;
+	readonly path: string;
+	readonly secure: boolean;
+	readonly httpOnly: boolean;
+	readonly expirationDate?: number;
+	readonly sameSite?: "unspecified" | "no_restriction" | "lax" | "strict";
+}
+
+const cookieVaultPath = (userData: string) =>
+	Path.join(userData, COOKIE_VAULT_FILENAME);
+
+const persistCookies = async (
+	userData: string,
+	cookies: ReadonlyArray<PersistedCookie>,
+): Promise<void> => {
+	const key = await secureStorageMasterKey();
+	const iv = randomBytes(12);
+	const cipher = createCipheriv("aes-256-gcm", key, iv);
+	cipher.setAAD(COOKIE_VAULT_AAD);
+	const ciphertext = Buffer.concat([
+		cipher.update(JSON.stringify(cookies), "utf8"),
+		cipher.final(),
+	]);
+	const envelope = JSON.stringify({
+		version: 1,
+		iv: iv.toString("base64url"),
+		ciphertext: ciphertext.toString("base64url"),
+		tag: cipher.getAuthTag().toString("base64url"),
+	});
+	await fs.mkdir(userData, { recursive: true, mode: 0o700 });
+	const target = cookieVaultPath(userData);
+	const temporary = `${target}.tmp.${process.pid}.${Date.now()}`;
+	try {
+		await fs.writeFile(temporary, envelope, { mode: 0o600 });
+		await fs.rename(temporary, target);
+		await fs.chmod(target, 0o600);
+	} finally {
+		await fs.rm(temporary, { force: true }).catch(() => {});
+	}
+};
+
+const readPersistedCookies = async (
+	userData: string,
+): Promise<ReadonlyArray<PersistedCookie>> => {
+	let raw: string;
+	try {
+		raw = await fs.readFile(cookieVaultPath(userData), "utf8");
+	} catch (cause) {
+		if (
+			typeof cause === "object" &&
+			cause !== null &&
+			(cause as { code?: unknown }).code === "ENOENT"
+		)
+			return [];
+		throw cause;
+	}
+	const envelope = JSON.parse(raw) as {
+		version?: unknown;
+		iv?: unknown;
+		ciphertext?: unknown;
+		tag?: unknown;
+	};
+	if (
+		envelope.version !== 1 ||
+		typeof envelope.iv !== "string" ||
+		typeof envelope.ciphertext !== "string" ||
+		typeof envelope.tag !== "string"
+	)
+		throw new Error("Saved browser cookies are corrupt.");
+	const key = await secureStorageMasterKey(false);
+	const decipher = createDecipheriv(
+		"aes-256-gcm",
+		key,
+		Buffer.from(envelope.iv, "base64url"),
+	);
+	decipher.setAAD(COOKIE_VAULT_AAD);
+	decipher.setAuthTag(Buffer.from(envelope.tag, "base64url"));
+	const decoded = JSON.parse(
+		Buffer.concat([
+			decipher.update(Buffer.from(envelope.ciphertext, "base64url")),
+			decipher.final(),
+		]).toString("utf8"),
+	) as unknown;
+	if (!Array.isArray(decoded))
+		throw new Error("Saved browser cookies are corrupt.");
+	return decoded as ReadonlyArray<PersistedCookie>;
+};
+
+const toPersistedCookie = (cookie: Cookie): PersistedCookie | null => {
+	if (cookie.domain === undefined) return null;
+	const path = cookie.path ?? "/";
+	return {
+		url: `${cookie.secure ? "https" : "http"}://${cookie.domain.replace(/^\./, "")}${path}`,
+		name: cookie.name,
+		value: cookie.value,
+		domain: cookie.domain,
+		path,
+		secure: cookie.secure === true,
+		httpOnly: cookie.httpOnly === true,
+		...(cookie.expirationDate === undefined
+			? {}
+			: { expirationDate: cookie.expirationDate }),
+		...(cookie.sameSite === "unspecified" ? {} : { sameSite: cookie.sameSite }),
+	};
+};
+
+const syncPersistedBrowserCookies = async (
+	userData: string,
+	target: Session,
+): Promise<void> => {
+	const state = await readState(userData);
+	if (state.trackedDomains.length === 0) return;
+	const tracked = new Set(
+		state.trackedDomains.map((domain) => domain.replace(/^\./, "")),
+	);
+	const cookies = (await target.cookies.get({})).filter((cookie) => {
+		const domain = (cookie.domain ?? "").replace(/^\./, "");
+		return [...tracked].some(
+			(root) => domain === root || domain.endsWith(`.${root}`),
+		);
+	});
+	const persisted = cookies
+		.map(toPersistedCookie)
+		.filter((cookie): cookie is PersistedCookie => cookie !== null);
+	const identities = persisted.map((cookie) => ({
+		domain: cookie.domain,
+		path: cookie.path,
+		name: cookie.name,
+		secure: cookie.secure,
+		valueHash: createHash("sha256").update(cookie.value).digest("hex"),
+	}));
+	await persistCookies(userData, persisted);
+	await writeState(userData, { ...state, identities });
 };
 
 export const migrateExistingBrowserCookies = async (
@@ -615,6 +777,7 @@ export const importDefaultBrowserCookies = async (
 		);
 		const now = Date.now() / 1000;
 		const identities: ImportedCookieIdentity[] = [];
+		const persistedCookies: PersistedCookie[] = [];
 		for (const row of rows) {
 			const domain = String(row.host_key ?? "");
 			const name = String(row.name ?? "");
@@ -661,10 +824,31 @@ export const importDefaultBrowserCookies = async (
 					secure,
 					valueHash: createHash("sha256").update(value).digest("hex"),
 				});
+				persistedCookies.push({
+					url: `${secure ? "https" : "http"}://${domain.replace(/^\./, "")}${path}`,
+					name,
+					value,
+					domain,
+					path,
+					secure,
+					httpOnly: Number(row.is_httponly) === 1,
+					...(expirationDate === undefined ? {} : { expirationDate }),
+					...(sameSite < 0
+						? {}
+						: {
+								sameSite:
+									sameSite === 2
+										? "strict"
+										: sameSite === 1
+											? "lax"
+											: "no_restriction",
+							}),
+				});
 			} catch {
 				// Skip invalid individual records while preserving the rest of the import.
 			}
 		}
+		await persistCookies(userData, persistedCookies);
 		const state = await readState(userData);
 		await writeState(userData, {
 			...state,
@@ -672,6 +856,9 @@ export const importDefaultBrowserCookies = async (
 			lastImportTime: new Date().toISOString(),
 			source: detected.source,
 			profile: detected.profile,
+			trackedDomains: [
+				...new Set(identities.map((identity) => identity.domain)),
+			],
 			identities,
 		});
 		return getBrowserCookieImportStatus(userData);
@@ -688,15 +875,49 @@ export const clearImportedBrowserCookies = async (
 	for (const item of state.identities) {
 		await removeImportedIdentity(target, item);
 	}
+	await fs.rm(cookieVaultPath(userData), { force: true });
 	await writeState(userData, {
 		version: 1,
 		migratedExistingSession: state.migratedExistingSession,
 		...(state.selectedProfileId === undefined
 			? {}
 			: { selectedProfileId: state.selectedProfileId }),
+		trackedDomains: [],
 		identities: [],
 	});
 	return getBrowserCookieImportStatus(userData);
+};
+
+export const restoreImportedBrowserCookies = async (
+	userData: string,
+	target: Session,
+): Promise<void> => {
+	for (const cookie of await readPersistedCookies(userData)) {
+		try {
+			await target.cookies.set(cookie);
+		} catch {
+			// A single stale cookie must not prevent the browser from starting.
+		}
+	}
+};
+
+export const watchImportedBrowserCookies = (
+	userData: string,
+	target: Session,
+): (() => void) => {
+	let timer: NodeJS.Timeout | null = null;
+	const onChanged = () => {
+		if (timer !== null) clearTimeout(timer);
+		timer = setTimeout(() => {
+			timer = null;
+			void syncPersistedBrowserCookies(userData, target).catch(() => {});
+		}, 250);
+	};
+	target.cookies.on("changed", onChanged);
+	return () => {
+		if (timer !== null) clearTimeout(timer);
+		target.cookies.off("changed", onChanged);
+	};
 };
 
 export const BROWSER_PARTITION = PARTITION;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -13,7 +13,11 @@ import * as Path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { AGENTS_RUNNING_COUNT_CHANNEL, AuthFlowError } from "@zuse/contracts";
-import { makeMainLayer, wsServerProtocolLayer } from "@zuse/server";
+import {
+	makeMainLayer,
+	readBrowserCredentialFromVault,
+	wsServerProtocolLayer,
+} from "@zuse/server";
 import { Cause, Effect, Fiber, Layer } from "effect";
 import { RpcSerialization } from "effect/unstable/rpc";
 import {
@@ -63,6 +67,8 @@ import {
 	getBrowserCookieImportStatus,
 	importDefaultBrowserCookies,
 	migrateExistingBrowserCookies,
+	restoreImportedBrowserCookies,
+	watchImportedBrowserCookies,
 } from "./browser-session-service.ts";
 import { electronServerProtocolLayer } from "./ipc/electron-server-protocol.ts";
 import { isLinearContextImagePath } from "./linear-context-image.ts";
@@ -451,116 +457,9 @@ const localConnectivityHelperPath = (): string =>
 				"zuse-local-connectivity",
 			);
 
-const browserCredentialHelperPath = (): string =>
-	app.isPackaged
-		? Path.join(
-				process.resourcesPath,
-				"app",
-				"browser-credentials",
-				"zuse-browser-credentials",
-			)
-		: Path.join(
-				app.getAppPath(),
-				"native",
-				"browser-credentials",
-				"bin",
-				"zuse-browser-credentials",
-			);
-
-const probeNativeCredentialHelper = async (): Promise<{
-	readonly supported: boolean;
-	readonly reason?: string;
-}> => {
-	if (process.platform !== "darwin") {
-		return {
-			supported: false,
-			reason: "Native password filling is currently available only on macOS.",
-		};
-	}
-	const executable = browserCredentialHelperPath();
-	if (!fsSync.existsSync(executable)) {
-		return {
-			supported: false,
-			reason: "The native password helper is not installed in this build.",
-		};
-	}
-	try {
-		const { stdout } = await execFileAsync(executable, ["--probe"], {
-			timeout: 5_000,
-			maxBuffer: 16 * 1024,
-		});
-		const result = JSON.parse(stdout) as { supported?: unknown };
-		return result.supported === true
-			? { supported: true }
-			: {
-					supported: false,
-					reason: "The native password helper failed its capability probe.",
-				};
-	} catch {
-		return {
-			supported: false,
-			reason: "The native password helper failed its capability probe.",
-		};
-	}
-};
-
-type LocalTrustRecord = {
-	readonly recordId: string;
-	readonly secret: string;
-};
-
-const ensureLocalTrustRecord = async (
-	userData: string,
-): Promise<LocalTrustRecord | null> => {
-	if (process.platform !== "darwin") return null;
-	const executable = localConnectivityHelperPath();
-	if (!fsSync.existsSync(executable)) return null;
-	const metadataPath = Path.join(userData, "local-connectivity-trust.json");
-	let recordId: string;
-	try {
-		const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8")) as {
-			recordId?: unknown;
-		};
-		recordId =
-			typeof metadata.recordId === "string" && metadata.recordId.length <= 128
-				? metadata.recordId
-				: randomUUID();
-	} catch {
-		recordId = randomUUID();
-	}
-	try {
-		await fs.mkdir(Path.dirname(metadataPath), { recursive: true });
-		await fs.writeFile(metadataPath, JSON.stringify({ recordId }), {
-			mode: 0o600,
-		});
-		const { stdout } = await execFileAsync(executable, [
-			"--ensure-trust",
-			recordId,
-		]);
-		const result = JSON.parse(stdout) as {
-			recordId?: unknown;
-			secret?: unknown;
-		};
-		if (
-			result.recordId !== recordId ||
-			typeof result.secret !== "string" ||
-			!/^[A-Za-z0-9_-]{43}$/.test(result.secret)
-		) {
-			return null;
-		}
-		return { recordId, secret: result.secret };
-	} catch (cause) {
-		appendRemoteConnectionLog("local.trust.unavailable", {
-			reason: cause instanceof Error ? cause.message : String(cause),
-		});
-		return null;
-	}
-};
-
 const startLocalConnectivityHelper = (
 	targetPort: number,
 	serviceName: string,
-	trustRecordId?: string,
 	tlsCertificatePin?: string,
 ): void => {
 	if (process.platform !== "darwin" || localConnectivityHelper !== null) return;
@@ -574,7 +473,6 @@ const startLocalConnectivityHelper = (
 		[
 			String(targetPort),
 			serviceName,
-			trustRecordId ?? "-",
 			...(tlsCertificatePin === undefined ? [] : [tlsCertificatePin]),
 		],
 		{
@@ -607,12 +505,7 @@ const startLocalConnectivityHelper = (
 		);
 		localConnectivityRestartTimer = setTimeout(() => {
 			localConnectivityRestartTimer = null;
-			startLocalConnectivityHelper(
-				targetPort,
-				serviceName,
-				trustRecordId,
-				tlsCertificatePin,
-			);
+			startLocalConnectivityHelper(targetPort, serviceName, tlsCertificatePin);
 		}, delayMs);
 	});
 	child.once("error", (cause) => {
@@ -1021,10 +914,6 @@ async function createMainWindow() {
 		});
 	}
 	const isMac = process.platform === "darwin";
-	const localTrust =
-		networkAccess.mode === "network-accessible"
-			? await ensureLocalTrustRecord(userData)
-			: null;
 	const nearbyTls =
 		networkAccess.mode === "network-accessible" && process.platform === "darwin"
 			? await ensureNearbyTlsIdentity(userData)
@@ -1651,21 +1540,24 @@ async function createMainWindow() {
 	});
 
 	ipcMain.handle("browser:getCookieImportStatus", async () => {
-		const persistent = session.fromPartition(BROWSER_PARTITION);
-		await migrateExistingBrowserCookies(
-			app.getPath("userData"),
-			session.defaultSession,
-			persistent,
-		);
 		return getBrowserCookieImportStatus(app.getPath("userData"));
 	});
 
-	ipcMain.handle("browser:importCookies", async (_event, profileId: unknown) =>
-		importDefaultBrowserCookies(
-			app.getPath("userData"),
-			session.fromPartition(BROWSER_PARTITION),
-			typeof profileId === "string" ? profileId : undefined,
-		),
+	ipcMain.handle(
+		"browser:importCookies",
+		async (_event, profileId: unknown) => {
+			const target = session.fromPartition(BROWSER_PARTITION);
+			await migrateExistingBrowserCookies(
+				app.getPath("userData"),
+				session.defaultSession,
+				target,
+			);
+			return importDefaultBrowserCookies(
+				app.getPath("userData"),
+				target,
+				typeof profileId === "string" ? profileId : undefined,
+			);
+		},
 	);
 
 	ipcMain.handle("browser:clearImportedCookies", async () =>
@@ -1684,9 +1576,9 @@ async function createMainWindow() {
 		return getBrowserCookieImportStatus(userData);
 	});
 
-	ipcMain.handle("browser:getNativeCredentialCapability", async () =>
-		probeNativeCredentialHelper(),
-	);
+	ipcMain.handle("browser:getNativeCredentialCapability", async () => ({
+		supported: true,
+	}));
 
 	ipcMain.handle(
 		"browser:fillNativeCredential",
@@ -1709,41 +1601,15 @@ async function createMainWindow() {
 					ok: false,
 					error: "Credential origin does not match the active page.",
 				};
-			const capability = await probeNativeCredentialHelper();
-			if (!capability.supported) {
-				return {
-					ok: false,
-					error:
-						capability.reason ??
-						"Native Passwords access is unavailable in this build.",
-				};
-			}
 			try {
-				const { stdout } = await execFileAsync(
-					browserCredentialHelperPath(),
-					[requestedOrigin],
-					{
-						timeout: 120_000,
-						maxBuffer: 64 * 1024,
-					},
+				const selected = await readBrowserCredentialFromVault(
+					app.getPath("userData"),
+					requestedOrigin,
 				);
-				const selected = JSON.parse(stdout) as {
-					ok?: unknown;
-					username?: unknown;
-					password?: unknown;
-					error?: unknown;
-				};
-				if (
-					selected.ok !== true ||
-					typeof selected.username !== "string" ||
-					typeof selected.password !== "string"
-				) {
+				if (selected === null) {
 					return {
 						ok: false,
-						error:
-							typeof selected.error === "string"
-								? selected.error
-								: "No password was selected.",
+						error: `No saved test credential exists for ${requestedOrigin}.`,
 					};
 				}
 				if (
@@ -1772,9 +1638,9 @@ async function createMainWindow() {
 				return {
 					ok: false,
 					error:
-						error instanceof Error && error.message.includes("timed out")
-							? "Password selection timed out."
-							: "Password selection was cancelled or unavailable.",
+						error instanceof Error
+							? error.message
+							: "The saved credential could not be read.",
 				};
 			}
 		},
@@ -2045,12 +1911,7 @@ async function createMainWindow() {
 					tls: { key: nearbyTls.key, cert: nearbyTls.cert },
 					onDiagnostic: appendRemoteConnectionLog,
 					onListening: ({ port }) =>
-						startLocalConnectivityHelper(
-							port,
-							systemHostname,
-							localTrust?.recordId,
-							nearbyTls.pin,
-						),
+						startLocalConnectivityHelper(port, systemHostname, nearbyTls.pin),
 				});
 	appendRemoteConnectionLog("desktop.runtime.start", {
 		relayWsPort,
@@ -2079,8 +1940,6 @@ async function createMainWindow() {
 					advertisedHost: networkAccess.advertisedHost,
 					port: relayWsPort,
 					pairingBootstrap: false,
-					icloudTrustRecordId: localTrust?.recordId,
-					icloudTrustSecret: localTrust?.secret,
 					transportCertificatePin: nearbyTls?.pin,
 					onNearbyPairingRequest: (request) => {
 						const requestFields = {
@@ -2606,6 +2465,16 @@ void app.whenReady().then(async () => {
 	});
 
 	installAppMenu(() => mainWindow, lastAccelerators, getLastStatus());
+	await restoreImportedBrowserCookies(
+		app.getPath("userData"),
+		session.fromPartition(BROWSER_PARTITION),
+	).catch((cause) => {
+		recordMainDiagnostic("warn", "browser.cookies.restore_failed", [cause]);
+	});
+	watchImportedBrowserCookies(
+		app.getPath("userData"),
+		session.fromPartition(BROWSER_PARTITION),
+	);
 	await createMainWindow();
 	if (mainWindow !== null) {
 		if (isDevelopment) {

--- a/apps/mobile/app/connect/nearby.tsx
+++ b/apps/mobile/app/connect/nearby.tsx
@@ -1,7 +1,7 @@
 import * as ExpoCrypto from "expo-crypto";
 import { router, Stack } from "expo-router";
 import { useHeaderHeight } from "expo-router/react-navigation";
-import { Cloud, Monitor, Radio, ShieldCheck } from "lucide-react-native";
+import { Monitor, Radio, ShieldCheck } from "lucide-react-native";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	ActivityIndicator,
@@ -31,13 +31,12 @@ import {
 } from "~/lib/pairing-device-key";
 import { connectEnvironment } from "~/rpc/relay-client";
 import { authAccountAtom } from "~/store/auth";
-import { appAtomRegistry } from "~/store/registry";
 import { addConnection } from "~/store/connections";
+import { appAtomRegistry } from "~/store/registry";
 import { colors } from "~/theme";
 
 import {
 	closeLocalProxy,
-	hasICloudTrustRecord,
 	type LocalDiscoveryState,
 	type LocalProxy,
 	localConnectivityAvailable,
@@ -46,7 +45,6 @@ import {
 	onLocalDiscoveryStateChanged,
 	onNearbyServicesChanged,
 	openLocalProxy,
-	proofForICloudTrustRecord,
 	startLocalDiscovery,
 } from "../../modules/local-connectivity";
 
@@ -57,12 +55,6 @@ type PendingApproval = {
 	readonly environmentPublicKey: string;
 	readonly service: NearbyService;
 	readonly proxy: LocalProxy;
-};
-
-const iCloudTrustLabel = (available: boolean | undefined): string => {
-	if (available === true) return "iCloud trust available";
-	if (available === false) return "Mac approval required";
-	return "Checking iCloud trust…";
 };
 
 const safetyPhraseLabel = (phrase: string): string =>
@@ -82,9 +74,6 @@ export default function NearbyConnectScreen() {
 	const [starting, setStarting] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [showQrFallback, setShowQrFallback] = useState(false);
-	const [icloudTrust, setIcloudTrust] = useState<
-		Readonly<Record<string, boolean>>
-	>({});
 	const [discoveryState, setDiscoveryState] = useState<LocalDiscoveryState>({
 		state: "starting",
 	});
@@ -112,24 +101,6 @@ export default function NearbyConnectScreen() {
 		const timer = setTimeout(() => setShowQrFallback(true), 8_000);
 		return () => clearTimeout(timer);
 	}, [services.length]);
-
-	useEffect(() => {
-		let cancelled = false;
-		void Promise.all(
-			services.map(
-				async (service) =>
-					[
-						service.id,
-						await hasICloudTrustRecord(service.trustRecordId),
-					] as const,
-			),
-		).then((entries) => {
-			if (!cancelled) setIcloudTrust(Object.fromEntries(entries));
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [services]);
 
 	const requestAccess = useCallback(
 		async (service: NearbyService) => {
@@ -161,27 +132,6 @@ export default function NearbyConnectScreen() {
 						// Account trust is opportunistic; explicit local approval remains.
 					}
 				}
-				const trustRecordId =
-					typeof service.trustRecordId === "string"
-						? service.trustRecordId
-						: undefined;
-				const icloudChallenge =
-					trustRecordId === undefined
-						? undefined
-						: [
-								"zuse-icloud-v1",
-								trustRecordId,
-								deviceId,
-								publicKey,
-								clientNonce,
-								challenge.serverNonce,
-								challenge.environmentPublicKey,
-								service.tlsCertificatePin,
-							].join("|");
-				const icloudTrustProof =
-					trustRecordId === undefined || icloudChallenge === undefined
-						? null
-						: await proofForICloudTrustRecord(trustRecordId, icloudChallenge);
 				const pairing = await startNearbyPairing({
 					host: proxy.host,
 					port: proxy.port,
@@ -192,8 +142,6 @@ export default function NearbyConnectScreen() {
 					ephemeralPublicKey,
 					clientNonce,
 					serverNonce: challenge.serverNonce,
-					icloudTrustRecordId: trustRecordId,
-					icloudTrustProof: icloudTrustProof ?? undefined,
 					accountAssertion,
 					transportCertificatePin: service.tlsCertificatePin,
 				});
@@ -415,7 +363,7 @@ export default function NearbyConnectScreen() {
 									<Pressable
 										key={service.id}
 										accessibilityRole="button"
-										accessibilityLabel={`${nearbyMacDisplayName(service.name)}, ${iCloudTrustLabel(icloudTrust[service.id])}`}
+										accessibilityLabel={`${nearbyMacDisplayName(service.name)}, Mac approval required`}
 										disabled={starting !== null}
 										onPress={() => void requestAccess(service)}
 										className="min-h-44 w-40 items-center justify-start gap-3 rounded-3xl px-3 py-4 active:bg-muted/60"
@@ -431,9 +379,8 @@ export default function NearbyConnectScreen() {
 												{nearbyMacDisplayName(service.name)}
 											</Text>
 											<View className="min-h-5 flex-row items-center gap-1.5">
-												<Cloud color={colors.secondaryFg} size={13} />
 												<Text className="font-sans text-xs text-muted-foreground">
-													{iCloudTrustLabel(icloudTrust[service.id])}
+													Mac approval required
 												</Text>
 											</View>
 										</View>

--- a/apps/mobile/modules/local-connectivity/ios/ZuseLocalConnectivityModule.swift
+++ b/apps/mobile/modules/local-connectivity/ios/ZuseLocalConnectivityModule.swift
@@ -2,11 +2,9 @@ import CryptoKit
 import ExpoModulesCore
 import Foundation
 import Network
-import Security
 
 private let serviceType = "_zuse._tcp"
 private let connectivityQueue = DispatchQueue(label: "com.zuse.local-connectivity")
-private let sharedKeychainGroup = "HMCST4VV42.com.zuse.shared-connectivity"
 
 struct NearbyServiceRecord: Record {
   @Field var id: String = ""
@@ -14,7 +12,6 @@ struct NearbyServiceRecord: Record {
   @Field var type: String = serviceType
   @Field var domain: String = "local."
   @Field var interfaceName: String?
-  @Field var trustRecordId: String?
   @Field var tlsCertificatePin: String = ""
 }
 
@@ -243,23 +240,6 @@ public final class ZuseLocalConnectivityModule: Module {
       self.proxies.removeValue(forKey: id)?.cancel()
     }
 
-    AsyncFunction("proofForTrustRecord") { (recordId: String, challenge: String) -> String? in
-      guard let secret = self.readTrustRecord(recordId: recordId) else { return nil }
-      let key = SymmetricKey(data: secret)
-      let proof = HMAC<SHA256>.authenticationCode(
-        for: Data(challenge.utf8),
-        using: key
-      )
-      return Data(proof).base64EncodedString()
-        .replacingOccurrences(of: "+", with: "-")
-        .replacingOccurrences(of: "/", with: "_")
-        .replacingOccurrences(of: "=", with: "")
-    }
-
-    AsyncFunction("hasTrustRecord") { (recordId: String) -> Bool in
-      self.readTrustRecord(recordId: recordId) != nil
-    }
-
     OnAppEntersForeground {
       self.startDiscovery()
     }
@@ -304,16 +284,8 @@ public final class ZuseLocalConnectivityModule: Module {
         guard case let .service(name, type, domain, interface) = result.endpoint else {
           return nil
         }
-        var trustRecordId: String?
         var tlsCertificatePin: String?
         if case let .bonjour(txtRecord) = result.metadata {
-          if let entry = txtRecord.getEntry(for: "trust") {
-            switch entry {
-            case .string(let value): trustRecordId = value
-            case .data(let data): trustRecordId = String(data: data, encoding: .utf8)
-            default: break
-            }
-          }
           if let entry = txtRecord.getEntry(for: "tls") {
             switch entry {
             case .string(let value): tlsCertificatePin = value
@@ -332,9 +304,6 @@ public final class ZuseLocalConnectivityModule: Module {
         ]
         if let interfaceName = interface?.name {
           service["interfaceName"] = interfaceName
-        }
-        if let trustRecordId {
-          service["trustRecordId"] = trustRecordId
         }
         return service
       }
@@ -443,21 +412,4 @@ public final class ZuseLocalConnectivityModule: Module {
     connectivityQueue.asyncAfter(deadline: .now() + delay, execute: work)
   }
 
-  private func readTrustRecord(recordId: String) -> Data? {
-    let query: [CFString: Any] = [
-      kSecClass: kSecClassGenericPassword,
-      kSecAttrService: "com.zuse.local-trust",
-      kSecAttrAccount: recordId,
-      kSecAttrAccessGroup: sharedKeychainGroup,
-      kSecAttrSynchronizable: kCFBooleanTrue as Any,
-      kSecUseDataProtectionKeychain: kCFBooleanTrue as Any,
-      kSecReturnData: kCFBooleanTrue as Any,
-      kSecMatchLimit: kSecMatchLimitOne,
-    ]
-    var result: CFTypeRef?
-    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else {
-      return nil
-    }
-    return result as? Data
-  }
 }

--- a/apps/mobile/modules/local-connectivity/src/ZuseLocalConnectivityModule.ts
+++ b/apps/mobile/modules/local-connectivity/src/ZuseLocalConnectivityModule.ts
@@ -97,25 +97,6 @@ Native?.addListener("onDiscoveryStateChanged", (event) => {
 		listener(latestDiscoveryState);
 });
 
-export const proofForICloudTrustRecord = async (
-	recordId: string,
-	challenge: string,
-): Promise<string | null> =>
-	(await Native?.proofForTrustRecord(recordId, challenge)) ?? null;
-
-export const hasICloudTrustRecord = async (
-	recordId: string | null | undefined,
-): Promise<boolean> => {
-	if (
-		Native === null ||
-		typeof recordId !== "string" ||
-		recordId.length === 0
-	) {
-		return false;
-	}
-	return Native.hasTrustRecord(recordId);
-};
-
 export const onNearbyServicesChanged = (
 	listener: (services: readonly NearbyService[]) => void,
 ): (() => void) => {

--- a/apps/mobile/modules/local-connectivity/src/normalize-nearby-services.ts
+++ b/apps/mobile/modules/local-connectivity/src/normalize-nearby-services.ts
@@ -5,16 +5,11 @@ export type NearbyService = {
 	readonly type: string;
 	readonly domain: string;
 	readonly interfaceName?: string;
-	readonly trustRecordId?: string;
 	readonly tlsCertificatePin: string;
 };
 
-type NativeNearbyService = Omit<
-	NearbyService,
-	"routeId" | "interfaceName" | "trustRecordId"
-> & {
+type NativeNearbyService = Omit<NearbyService, "routeId" | "interfaceName"> & {
 	readonly interfaceName?: string | null;
-	readonly trustRecordId?: string | null;
 };
 
 const optionalString = (
@@ -42,7 +37,6 @@ export const normalizeNearbyServices = (
 	for (const raw of services) {
 		if (raw.tlsCertificatePin.length === 0) continue;
 		const interfaceName = optionalString(raw.interfaceName);
-		const trustRecordId = optionalString(raw.trustRecordId);
 		const service: NearbyService = {
 			id: raw.tlsCertificatePin,
 			// Browser generations and Bonjour "(2)" suffixes do not represent a
@@ -53,7 +47,6 @@ export const normalizeNearbyServices = (
 			domain: raw.domain,
 			tlsCertificatePin: raw.tlsCertificatePin,
 			...(interfaceName === undefined ? {} : { interfaceName }),
-			...(trustRecordId === undefined ? {} : { trustRecordId }),
 		};
 		const current = byCertificate.get(service.tlsCertificatePin);
 		if (

--- a/apps/mobile/src/lib/nearby-pairing.ts
+++ b/apps/mobile/src/lib/nearby-pairing.ts
@@ -222,8 +222,6 @@ export const startNearbyPairing = async (input: {
 	readonly ephemeralPublicKey: string;
 	readonly clientNonce: string;
 	readonly serverNonce: string;
-	readonly icloudTrustRecordId?: string;
-	readonly icloudTrustProof?: string;
 	readonly accountAssertion?: string;
 	readonly transportCertificatePin: string;
 }): Promise<NearbyPairingStart> => {
@@ -240,8 +238,6 @@ export const startNearbyPairing = async (input: {
 				ephemeralPublicKey: input.ephemeralPublicKey,
 				clientNonce: input.clientNonce,
 				serverNonce: input.serverNonce,
-				icloudTrustRecordId: input.icloudTrustRecordId,
-				icloudTrustProof: input.icloudTrustProof,
 				accountAssertion: input.accountAssertion,
 			}),
 		},

--- a/apps/mobile/test/unit/nearby-services.test.ts
+++ b/apps/mobile/test/unit/nearby-services.test.ts
@@ -15,7 +15,6 @@ const service = (
 	type: "_zuse._tcp",
 	domain: "local.",
 	interfaceName: "en0",
-	trustRecordId: null,
 	tlsCertificatePin: "certificate-a",
 	...overrides,
 });
@@ -74,11 +73,10 @@ describe("nearby service normalization", () => {
 
 	test("removes native nulls before they can reach string-only functions", () => {
 		const [result] = normalizeNearbyServices([
-			service({ interfaceName: null, trustRecordId: null }),
+			service({ interfaceName: null }),
 		]);
 
 		expect(result).not.toHaveProperty("interfaceName");
-		expect(result).not.toHaveProperty("trustRecordId");
 	});
 
 	test("formats Bonjour host names for people", () => {

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -1581,7 +1581,7 @@ export function BrowserPane() {
 						<p className="truncate text-muted-foreground">
 							{nativeCredentialError ??
 								nativeCredentialCapability?.reason ??
-								`Use the system password picker for ${passwordFieldOrigin}.`}
+								`Use the saved test login for ${passwordFieldOrigin}.`}
 						</p>
 					</div>
 					<button
@@ -1593,9 +1593,7 @@ export function BrowserPane() {
 						className="h-8 rounded-md bg-primary px-2.5 font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
 						onClick={() => void fillNativeCredential()}
 					>
-						{nativeCredentialBusy
-							? "Opening Passwords…"
-							: "Fill from Passwords"}
+						{nativeCredentialBusy ? "Filling…" : "Fill saved login"}
 					</button>
 				</section>
 			) : null}
@@ -1683,7 +1681,7 @@ export function BrowserPane() {
 							src="about:blank"
 							{...({
 								allowpopups: "true",
-								partition: "persist:zuse-browser",
+								partition: "zuse-browser",
 							} as Record<string, string>)}
 							style={{
 								display: !hasLoadedPage ? "none" : "flex",
@@ -2745,11 +2743,8 @@ async function runBrowserCommand(
 					);
 				}
 				const nativeBridge = window.zuse?.browser;
-				const nativeCapability =
-					await nativeBridge?.getNativeCredentialCapability?.();
 				const nativeWebContentsId = hooks.getWebContentsId();
 				if (
-					nativeCapability?.supported === true &&
 					nativeWebContentsId !== null &&
 					nativeBridge?.fillNativeCredential !== undefined
 				) {
@@ -2762,31 +2757,14 @@ async function runBrowserCommand(
 						return BrowserCommandResult.make({
 							id: req.id,
 							ok: true,
-							detail: `Filled the system credential for ${activeOrigin} and submitted the login form.`,
+							detail: `Filled the saved test credential for ${activeOrigin} and submitted the login form.`,
 						});
 					}
 					return fail(
-						nativeResult.error ??
-							"The system password picker was cancelled or unavailable.",
+						nativeResult.error ?? "The saved test credential is unavailable.",
 					);
 				}
-				// Pull the dummy secret out-of-band (renderer-only RPC) and inject it
-				// straight into the page. The password never returns to the agent —
-				// only the ok/detail below, which omit it.
-				const client = await getRpcClient();
-				const secret = await Effect.runPromise(
-					client["browser.fillForOrigin"]({ origin: command.origin }),
-				);
-				if (secret === null) {
-					return fail(
-						`No system or saved test credential is available for ${command.origin}. Sign in manually or add a test login in Settings → Browser.`,
-					);
-				}
-				const res = await runJsObject(
-					wv,
-					`(() => { const U = ${JSON.stringify(secret.username)}; const P = ${JSON.stringify(secret.password)}; const pw = document.querySelector('input[type="password"]'); if (!pw) return JSON.stringify({ ok:false, error:'No password field on this page — navigate to the login form first.' }); let user = document.querySelector('input[autocomplete="username"], input[type="email"], input[name*="user" i], input[name*="email" i], input[id*="user" i], input[id*="email" i]'); if (!user) { user = Array.from(document.querySelectorAll('input')).find((i) => /^(text|email|)$/.test(i.type)) || null; } const setVal = (el, v) => { const proto = el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype; const d = Object.getOwnPropertyDescriptor(proto, 'value'); if (d && d.set) d.set.call(el, v); else el.value = v; el.dispatchEvent(new Event('input', { bubbles:true })); el.dispatchEvent(new Event('change', { bubbles:true })); }; if (user) setVal(user, U); setVal(pw, P); const form = pw.form; if (form && typeof form.requestSubmit === 'function') { try { form.requestSubmit(); return JSON.stringify({ ok:true, detail:'Filled and submitted the login form.' }); } catch (e) {} } pw.dispatchEvent(new KeyboardEvent('keydown', { key:'Enter', keyCode:13, which:13, bubbles:true })); return JSON.stringify({ ok:true, detail:'Filled the saved credentials and pressed Enter.' }); })()`,
-				);
-				return resultFromJs(req.id, res, "Submitted the saved login.");
+				return fail("The browser surface is unavailable.");
 			}
 			case "Inspect": {
 				const target = await resolveBrowserTarget(

--- a/apps/renderer/src/components/composer/create-from-menu.tsx
+++ b/apps/renderer/src/components/composer/create-from-menu.tsx
@@ -30,6 +30,7 @@ import {
 import { Button } from "~/components/ui/button.tsx";
 import { overlaySurface } from "~/components/ui/overlay-surface";
 import { PopoverPrimitive } from "~/components/ui/popover";
+import { errorMessage } from "~/lib/error-message.ts";
 import { getRpcClient } from "~/lib/rpc-client.ts";
 import { cn } from "~/lib/utils";
 import { useUiStore } from "~/store/ui.ts";
@@ -199,9 +200,7 @@ export function CreateFromMenu({ folderId, onSelect }: CreateFromMenuProps) {
 						if (!cancelled) {
 							setLinearIssues([]);
 							setLinearError(
-								cause instanceof Error
-									? cause.message
-									: "Could not search Linear issues.",
+								errorMessage(cause, "Could not search Linear issues."),
 							);
 						}
 					}

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -652,10 +652,6 @@ function BrowserSettingsPagePane() {
 	const [selectedProfileId, setSelectedProfileId] = useState<
 		string | undefined
 	>();
-	const [credentialCapability, setCredentialCapability] = useState<{
-		supported: boolean;
-		reason?: string;
-	} | null>(null);
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [clearOpen, setClearOpen] = useState(false);
@@ -663,13 +659,9 @@ function BrowserSettingsPagePane() {
 	useEffect(() => {
 		let cancelled = false;
 		const browser = window.zuse?.browser;
-		void Promise.all([
-			browser?.getCookieImportStatus?.(),
-			browser?.getNativeCredentialCapability?.(),
-		]).then(([nextStatus, capability]) => {
+		void browser?.getCookieImportStatus?.().then((nextStatus) => {
 			if (cancelled) return;
 			if (nextStatus !== undefined) setStatus(nextStatus);
-			if (capability !== undefined) setCredentialCapability(capability);
 		});
 		return () => {
 			cancelled = true;
@@ -768,27 +760,12 @@ function BrowserSettingsPagePane() {
 			</SettingsGroup>
 
 			<SettingsGroup
-				title="Passwords and autofill"
-				description="Passwords are requested individually for the active website and never bulk imported."
-			>
-				<SettingsRow
-					title="System Passwords"
-					description={
-						credentialCapability?.supported
-							? "Available. Filling uses the macOS system confirmation flow for the active origin."
-							: (credentialCapability?.reason ??
-								"Checking native password capability…")
-					}
-				/>
-			</SettingsGroup>
-
-			<SettingsGroup
 				title="Privacy"
-				description="Built-in browser data stays in its dedicated persistent desktop partition."
+				description="Built-in browser data stays in an isolated in-memory partition. Explicitly imported cookies are encrypted with the app vault and restored on restart."
 			>
 				<SettingsRow
 					title="Browsing data"
-					description="Remove cookies, site storage, and cache from the built-in browser without changing other browsers."
+					description="Remove cookies, site storage, and cache from the current built-in browser session without changing other browsers."
 					action={
 						<Button
 							size="sm"
@@ -848,7 +825,7 @@ interface BrowserCredRow {
 
 /**
  * Browser settings — manage the DUMMY/TEST logins the agent browser autofills
- * via `browser_login`. Passwords go straight to the OS keychain (write-only
+ * via `browser_login`. Passwords go into the encrypted local vault (write-only
  * from here; the list RPC never returns them). The warning banner is
  * load-bearing: real credentials must never live here.
  */

--- a/apps/renderer/src/components/settings/linear-integrations-pane.tsx
+++ b/apps/renderer/src/components/settings/linear-integrations-pane.tsx
@@ -1,7 +1,7 @@
 import type { LinearConnection } from "@zuse/contracts";
 import { Effect } from "effect";
 import { useCallback, useEffect, useState } from "react";
-
+import { errorMessage } from "~/lib/error-message.ts";
 import { getRpcClient } from "~/lib/rpc-client.ts";
 import { Button } from "../ui/button.tsx";
 import { Card } from "../ui/card.tsx";
@@ -29,7 +29,7 @@ export function LinearIntegrationsPane() {
 			setError(null);
 		} catch (cause) {
 			setConnections([]);
-			setError(cause instanceof Error ? cause.message : String(cause));
+			setError(errorMessage(cause, "Could not load connected workspaces."));
 		}
 	}, []);
 
@@ -46,7 +46,7 @@ export function LinearIntegrationsPane() {
 			await Effect.runPromise(client["linear.connect"]({}));
 			await load();
 		} catch (cause) {
-			setError(cause instanceof Error ? cause.message : String(cause));
+			setError(errorMessage(cause, "Could not connect the workspace."));
 		} finally {
 			setBusy(null);
 		}
@@ -68,7 +68,7 @@ export function LinearIntegrationsPane() {
 			);
 			await load();
 		} catch (cause) {
-			setError(cause instanceof Error ? cause.message : String(cause));
+			setError(errorMessage(cause, "Could not disconnect the workspace."));
 		} finally {
 			setBusy(null);
 		}
@@ -127,16 +127,33 @@ export function LinearIntegrationsPane() {
 									<p className="truncate text-xs text-muted-foreground">
 										{connection.viewerName} · {connection.viewerEmail}
 									</p>
+									{connection.status === "reauthRequired" && (
+										<p className="mt-1 text-xs text-destructive">
+											Authorization expired. Reconnect this workspace.
+										</p>
+									)}
 								</div>
-								<Button
-									type="button"
-									variant="outline"
-									disabled={busy !== null}
-									loading={busy === connection.workspaceId}
-									onClick={() => void disconnect(connection)}
-								>
-									Disconnect
-								</Button>
+								<div className="flex items-center gap-2">
+									{connection.status === "reauthRequired" && (
+										<Button
+											type="button"
+											disabled={busy !== null}
+											loading={busy === "connect"}
+											onClick={() => void connect()}
+										>
+											Reconnect
+										</Button>
+									)}
+									<Button
+										type="button"
+										variant="outline"
+										disabled={busy !== null}
+										loading={busy === connection.workspaceId}
+										onClick={() => void disconnect(connection)}
+									>
+										Disconnect
+									</Button>
+								</div>
 							</div>
 						))}
 					</div>

--- a/apps/renderer/src/lib/error-message.ts
+++ b/apps/renderer/src/lib/error-message.ts
@@ -1,0 +1,14 @@
+export const errorMessage = (cause: unknown, fallback: string): string => {
+	if (
+		cause !== null &&
+		typeof cause === "object" &&
+		"reason" in cause &&
+		typeof cause.reason === "string" &&
+		cause.reason.trim() !== ""
+	) {
+		return cause.reason;
+	}
+	if (cause instanceof Error && cause.message.trim() !== "")
+		return cause.message;
+	return fallback;
+};

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,11 @@
 			"types": "./src/runtime.ts",
 			"import": "./src/runtime.ts",
 			"require": "./src/runtime.ts"
+		},
+		"./secure-storage-master-key": {
+			"types": "./src/secure-storage-master-key.ts",
+			"import": "./src/secure-storage-master-key.ts",
+			"require": "./src/secure-storage-master-key.ts"
 		}
 	},
 	"scripts": {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,6 +4,7 @@
  * not re-exported here is internal — keep the surface minimal.
  */
 export { AppPaths } from "./app-paths.ts";
-export { makeMainLayer, type MainLayerDeps } from "./runtime.ts";
+export { readBrowserCredentialFromVault } from "./provider/layers/credentials-service.ts";
+export { type MainLayerDeps, makeMainLayer } from "./runtime.ts";
 export { wsServerProtocolLayer } from "./transports/ws.ts";
 export { FolderPicker } from "./workspace/services/folder-picker.ts";

--- a/apps/server/src/linear/layers/linear-service.ts
+++ b/apps/server/src/linear/layers/linear-service.ts
@@ -46,6 +46,7 @@ const TokenBundleSchema = Schema.Struct({
 	viewerName: Schema.String,
 	viewerEmail: Schema.String,
 	connectedAt: Schema.String,
+	reauthRequired: Schema.optional(Schema.Boolean),
 });
 type TokenBundle = typeof TokenBundleSchema.Type;
 
@@ -157,7 +158,18 @@ const toConnection = (bundle: TokenBundle): LinearConnection =>
 		viewerName: bundle.viewerName,
 		viewerEmail: bundle.viewerEmail,
 		connectedAt: new Date(bundle.connectedAt),
+		status: bundle.reauthRequired === true ? "reauthRequired" : "connected",
 	});
+
+class LinearOAuthTokenError extends Error {
+	readonly status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = "LinearOAuthTokenError";
+		this.status = status;
+	}
+}
 
 const base64url = (bytes: Uint8Array): string =>
 	Buffer.from(bytes).toString("base64url");
@@ -191,7 +203,6 @@ const authorizeUrl = (
 
 interface PendingConnect {
 	readonly state: string;
-	readonly verifier: string;
 	readonly resolve: (url: string) => void;
 	readonly reject: (cause: Error) => void;
 }
@@ -206,8 +217,21 @@ const exchangeToken = async (
 		body: new URLSearchParams(params),
 	});
 	const value: unknown = await response.json().catch(() => null);
-	if (!response.ok)
-		throw new Error(`Linear OAuth failed (${response.status}).`);
+	if (!response.ok) {
+		const description =
+			value !== null &&
+			typeof value === "object" &&
+			typeof (value as { error_description?: unknown }).error_description ===
+				"string"
+				? (value as { error_description: string }).error_description
+				: null;
+		throw new LinearOAuthTokenError(
+			description === null
+				? `Linear OAuth failed (${response.status}).`
+				: `Linear OAuth failed: ${description}`,
+			response.status,
+		);
+	}
 	return Schema.decodeUnknownSync(TokenResponseSchema)(value);
 };
 
@@ -373,6 +397,10 @@ export const LinearServiceLive = Layer.effect(
 			workspaceId: string,
 		) {
 			const seed = yield* readBundle(workspaceId);
+			if (seed.reauthRequired === true)
+				return yield* Effect.fail(
+					fail("Linear authorization expired. Reconnect this workspace."),
+				);
 			if (seed.expiresAt - Date.now() > REFRESH_SKEW_MS) return seed;
 			let lock = refreshLocks.get(workspaceId);
 			if (lock === undefined) {
@@ -382,21 +410,40 @@ export const LinearServiceLive = Layer.effect(
 			return yield* lock.withPermits(1)(
 				Effect.gen(function* () {
 					const current = yield* readBundle(workspaceId);
+					if (current.reauthRequired === true)
+						return yield* Effect.fail(
+							fail("Linear authorization expired. Reconnect this workspace."),
+						);
 					if (current.expiresAt - Date.now() > REFRESH_SKEW_MS) return current;
-					const token = yield* Effect.tryPromise({
+					const tokenResult = yield* Effect.tryPromise({
 						try: () =>
 							exchangeToken(fetcher, {
 								grant_type: "refresh_token",
 								refresh_token: current.refreshToken,
 								client_id: CLIENT_ID,
 							}),
-						catch: (cause) => fail(errorMessage(cause)),
-					});
+						catch: (cause) => cause,
+					}).pipe(Effect.result);
+					if (tokenResult._tag === "Failure") {
+						if (
+							tokenResult.failure instanceof LinearOAuthTokenError &&
+							(tokenResult.failure.status === 400 ||
+								tokenResult.failure.status === 401)
+						) {
+							yield* persistBundle({ ...current, reauthRequired: true });
+							return yield* Effect.fail(
+								fail("Linear authorization expired. Reconnect this workspace."),
+							);
+						}
+						return yield* Effect.fail(fail(errorMessage(tokenResult.failure)));
+					}
+					const token = tokenResult.success;
 					return yield* persistBundle({
 						...current,
 						accessToken: token.access_token,
 						refreshToken: token.refresh_token,
 						expiresAt: Date.now() + token.expires_in * 1_000,
+						reauthRequired: false,
 					});
 				}),
 			);
@@ -438,6 +485,14 @@ export const LinearServiceLive = Layer.effect(
 					const parsed = new URL(url);
 					if (parsed.searchParams.get("state") !== current.state) {
 						current.reject(new Error("Linear OAuth state did not match."));
+					} else if (parsed.searchParams.has("error")) {
+						current.reject(
+							new Error(
+								parsed.searchParams.get("error_description") ??
+									parsed.searchParams.get("error") ??
+									"Linear connection was cancelled.",
+							),
+						);
 					} else {
 						current.resolve(url);
 					}
@@ -490,7 +545,6 @@ export const LinearServiceLive = Layer.effect(
 			const callback = new Promise<string>((resolve, reject) => {
 				pending = {
 					state: pkce.state,
-					verifier: pkce.verifier,
 					resolve,
 					reject,
 				};
@@ -500,13 +554,18 @@ export const LinearServiceLive = Layer.effect(
 				.pipe(Effect.mapError((cause) => fail(cause.reason)));
 			const callbackUrl = yield* Effect.tryPromise({
 				try: async () => {
-					const timeout = new Promise<never>((_, reject) =>
-						setTimeout(
-							() => reject(new Error("Linear connection timed out.")),
-							90_000,
-						),
-					);
-					return await Promise.race([callback, timeout]);
+					let timeoutId: ReturnType<typeof setTimeout> | undefined;
+					try {
+						const timeout = new Promise<never>((_, reject) => {
+							timeoutId = setTimeout(
+								() => reject(new Error("Linear connection timed out.")),
+								90_000,
+							);
+						});
+						return await Promise.race([callback, timeout]);
+					} finally {
+						if (timeoutId !== undefined) clearTimeout(timeoutId);
+					}
 				},
 				catch: (cause) => fail(errorMessage(cause)),
 			}).pipe(
@@ -556,6 +615,7 @@ export const LinearServiceLive = Layer.effect(
 				viewerName: viewer.viewer.name,
 				viewerEmail: viewer.viewer.email,
 				connectedAt: now,
+				reauthRequired: false,
 			};
 			yield* persistBundle(bundle);
 			return toConnection(bundle);

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -883,7 +883,7 @@ const BrowserRespond = MemoizeRpcs.toLayerHandler(
 		Effect.flatMap(BrowserBridgeService, (svc) => svc.respond(result)),
 );
 
-// Browser credentials — DUMMY/TEST logins kept in the keychain. A keychain
+// Browser credentials — DUMMY/TEST logins kept in the encrypted vault. A vault
 // failure is swallowed to a safe value (void / [] / null) rather than
 // surfacing a defect: a missing credential just means autofill no-ops.
 const BrowserSetCredential = MemoizeRpcs.toLayerHandler(
@@ -907,14 +907,6 @@ const BrowserRemoveCredential = MemoizeRpcs.toLayerHandler(
 	({ origin }) =>
 		Effect.flatMap(CredentialsService, (svc) => svc.removeBrowser(origin)).pipe(
 			Effect.catch(() => Effect.void),
-		),
-);
-
-const BrowserFillForOrigin = MemoizeRpcs.toLayerHandler(
-	"browser.fillForOrigin",
-	({ origin }) =>
-		Effect.flatMap(CredentialsService, (svc) => svc.getBrowser(origin)).pipe(
-			Effect.catch(() => Effect.succeed(null)),
 		),
 );
 
@@ -991,5 +983,4 @@ export const ProviderHandlersLayer = Layer.mergeAll(
 	BrowserSetCredential,
 	BrowserListCredentials,
 	BrowserRemoveCredential,
-	BrowserFillForOrigin,
 );

--- a/apps/server/src/provider/layers/credentials-service.ts
+++ b/apps/server/src/provider/layers/credentials-service.ts
@@ -1,333 +1,354 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import {
+	chmod,
+	mkdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+
 import type { ProviderId } from "@zuse/contracts";
 import { Effect, Layer } from "effect";
-import keytar from "keytar";
 
+import { AppPaths } from "../../app-paths.ts";
+import { secureStorageMasterKey } from "../../secure-storage-master-key.ts";
 import { CredentialsError } from "../errors.ts";
 import { CredentialsService } from "../services/credentials-service.ts";
 
-const SERVICE_NAME = "zuse";
-const LEGACY_SERVICE_NAME = "memoize";
+const VAULT_FILENAME = "secure-vault.json";
+const VAULT_AAD = Buffer.from("zuse-secure-vault:v1", "utf8");
 
-/**
- * Keychain entries are namespaced as `apiKey:<providerId>` under the
- * `zuse` service. Discovery queries these exact accounts instead of enumerating
- * the service: `findCredentials` decrypts every matching item, which can make
- * macOS prompt for unrelated browser, integration, auth, or MCP credentials.
- */
-const accountFor = (providerId: ProviderId): string => `apiKey:${providerId}`;
+interface BrowserCredential {
+	readonly username: string;
+	readonly password: string;
+}
 
-/**
- * Browser credentials share the `zuse` keychain service but use a separate
- * `browserCred:` prefix so they never collide with `apiKey:` entries. The
- * origin is normalized (scheme + host[:port]) so `https://x.com/login` and
- * `https://x.com/` resolve to the same saved credential.
- */
-const BROWSER_PREFIX = "browserCred:";
-const browserAccountFor = (origin: string): string =>
-	`${BROWSER_PREFIX}${normalizeOrigin(origin)}`;
+interface VaultContents {
+	readonly version: 1;
+	readonly providers: Partial<Record<ProviderId, string>>;
+	readonly browserCredentials: Record<string, BrowserCredential>;
+	readonly integrations: Record<string, Record<string, string>>;
+	readonly mcpOauth: Record<string, string>;
+}
 
-/**
- * Single keychain account holding the WorkOS session bundle (JSON). One per
- * installation — signing in overwrites it, signing out deletes it.
- */
-const WORKOS_SESSION_ACCOUNT = "workos:session";
-const integrationPrefix = (integration: string): string =>
-	`integration:${integration}:`;
-const integrationAccountFor = (
-	integration: string,
-	accountId: string,
-): string => `${integrationPrefix(integration)}${accountId}`;
+interface VaultEnvelope {
+	readonly version: 1;
+	readonly iv: string;
+	readonly ciphertext: string;
+	readonly tag: string;
+}
 
-/**
- * OAuth bundles for user MCP servers, one account per server descriptor
- * key (`mcpOAuth:claude:<name>`). No legacy-service promotion — the prefix
- * is new with this feature.
- */
-const MCP_OAUTH_PREFIX = "mcpOAuth:";
-const mcpOauthAccountFor = (serverKey: string): string =>
-	`${MCP_OAUTH_PREFIX}${serverKey}`;
+const emptyVault = (): VaultContents => ({
+	version: 1,
+	providers: {},
+	browserCredentials: {},
+	integrations: {},
+	mcpOauth: {},
+});
 
 const normalizeOrigin = (input: string): string => {
 	try {
 		return new URL(input).origin;
 	} catch {
-		// Not a full URL — best effort: strip any path/query and lowercase host.
-		return input.trim().replace(/\/.*$/, "").toLowerCase();
+		return input.trim().replace(/\/.*$/u, "").toLowerCase();
 	}
 };
 
-interface BrowserCred {
-	readonly username: string;
-	readonly password: string;
-}
+const isStringRecord = (value: unknown): value is Record<string, string> =>
+	value !== null &&
+	typeof value === "object" &&
+	Object.values(value).every((item) => typeof item === "string");
 
-const parseBrowserCred = (raw: string | null): BrowserCred | null => {
-	if (raw === null) return null;
+const isBrowserCredentialRecord = (
+	value: unknown,
+): value is Record<string, BrowserCredential> =>
+	value !== null &&
+	typeof value === "object" &&
+	Object.values(value).every(
+		(item) =>
+			item !== null &&
+			typeof item === "object" &&
+			typeof (item as Partial<BrowserCredential>).username === "string" &&
+			typeof (item as Partial<BrowserCredential>).password === "string",
+	);
+
+const isIntegrationRecord = (
+	value: unknown,
+): value is Record<string, Record<string, string>> =>
+	value !== null &&
+	typeof value === "object" &&
+	Object.values(value).every(isStringRecord);
+
+const parseVaultContents = (value: unknown): VaultContents => {
+	if (value === null || typeof value !== "object")
+		throw new Error("Secure storage is corrupt.");
+	const raw = value as Partial<VaultContents>;
+	if (
+		raw.version !== 1 ||
+		!isStringRecord(raw.providers) ||
+		!isBrowserCredentialRecord(raw.browserCredentials) ||
+		!isIntegrationRecord(raw.integrations) ||
+		!isStringRecord(raw.mcpOauth)
+	) {
+		throw new Error("Secure storage uses an unsupported format.");
+	}
+	return {
+		version: 1,
+		providers: { ...raw.providers },
+		browserCredentials: { ...raw.browserCredentials },
+		integrations: Object.fromEntries(
+			Object.entries(raw.integrations).map(([name, accounts]) => [
+				name,
+				{ ...accounts },
+			]),
+		),
+		mcpOauth: { ...raw.mcpOauth },
+	};
+};
+
+const decodeEnvelope = (raw: string): VaultEnvelope => {
+	const value = JSON.parse(raw) as Partial<VaultEnvelope>;
+	if (
+		value.version !== 1 ||
+		typeof value.iv !== "string" ||
+		typeof value.ciphertext !== "string" ||
+		typeof value.tag !== "string"
+	) {
+		throw new Error("Secure storage is corrupt.");
+	}
+	return value as VaultEnvelope;
+};
+
+const encryptVault = (contents: VaultContents, key: Buffer): VaultEnvelope => {
+	const iv = randomBytes(12);
+	const cipher = createCipheriv("aes-256-gcm", key, iv);
+	cipher.setAAD(VAULT_AAD);
+	const ciphertext = Buffer.concat([
+		cipher.update(JSON.stringify(contents), "utf8"),
+		cipher.final(),
+	]);
+	return {
+		version: 1,
+		iv: iv.toString("base64url"),
+		ciphertext: ciphertext.toString("base64url"),
+		tag: cipher.getAuthTag().toString("base64url"),
+	};
+};
+
+const decryptVault = (envelope: VaultEnvelope, key: Buffer): VaultContents => {
+	const decipher = createDecipheriv(
+		"aes-256-gcm",
+		key,
+		Buffer.from(envelope.iv, "base64url"),
+	);
+	decipher.setAAD(VAULT_AAD);
+	decipher.setAuthTag(Buffer.from(envelope.tag, "base64url"));
+	const plaintext = Buffer.concat([
+		decipher.update(Buffer.from(envelope.ciphertext, "base64url")),
+		decipher.final(),
+	]).toString("utf8");
+	return parseVaultContents(JSON.parse(plaintext) as unknown);
+};
+
+export const readBrowserCredentialFromVault = async (
+	userData: string,
+	origin: string,
+): Promise<BrowserCredential | null> => {
+	let raw: string;
 	try {
-		const obj = JSON.parse(raw) as Partial<BrowserCred>;
-		if (typeof obj.username === "string" && typeof obj.password === "string") {
-			return { username: obj.username, password: obj.password };
-		}
-	} catch {
-		// Corrupt entry — treat as absent.
+		raw = await readFile(join(userData, VAULT_FILENAME), "utf8");
+	} catch (cause) {
+		if (
+			typeof cause === "object" &&
+			cause !== null &&
+			(cause as { code?: unknown }).code === "ENOENT"
+		)
+			return null;
+		throw cause;
 	}
-	return null;
+	const contents = decryptVault(
+		decodeEnvelope(raw),
+		await secureStorageMasterKey(false),
+	);
+	return contents.browserCredentials[normalizeOrigin(origin)] ?? null;
 };
 
-const KNOWN_PROVIDERS: ReadonlyArray<ProviderId> = [
-	"claude",
-	"codex",
-	"grok",
-	"gemini",
-	"cursor",
-];
-
-const providerCache = new Map<ProviderId, string | null>();
-const browserCache = new Map<string, BrowserCred | null>();
-let configuredCache: ReadonlyArray<ProviderId> | null = null;
-let browserListCache: ReadonlyArray<{
-	origin: string;
-	username: string;
-}> | null = null;
-
-const invalidateProviderList = (): void => {
-	configuredCache = null;
-};
-
-const invalidateBrowserList = (): void => {
-	browserListCache = null;
-};
-
-const collectBrowser = (
-	entries: ReadonlyArray<{ account: string; password: string }>,
-): Array<{ origin: string; username: string }> => {
-	const out: Array<{ origin: string; username: string }> = [];
-	for (const { account, password } of entries) {
-		if (!account.startsWith(BROWSER_PREFIX)) continue;
-		const origin = account.slice(BROWSER_PREFIX.length);
-		const cred = parseBrowserCred(password);
-		out.push({ origin, username: cred?.username ?? "" });
-	}
-	return out;
-};
-
-const tryKeychain = <A>(
-	providerId: ProviderId | "*",
-	thunk: () => Promise<A>,
-): Effect.Effect<A, CredentialsError> =>
-	Effect.tryPromise({
-		try: thunk,
-		catch: (cause) =>
-			new CredentialsError({
-				providerId: providerId === "*" ? "" : providerId,
-				reason: cause instanceof Error ? cause.message : String(cause),
-				cause,
-			}),
+const toCredentialsError = (cause: unknown): CredentialsError =>
+	new CredentialsError({
+		providerId: "",
+		reason: cause instanceof Error ? cause.message : String(cause),
+		cause,
 	});
 
-const getPasswordWithLegacyPromotion = async (
-	account: string,
-): Promise<string | null> => {
-	const current = await keytar.getPassword(SERVICE_NAME, account);
-	if (current !== null) return current;
-
-	const legacy = await keytar.getPassword(LEGACY_SERVICE_NAME, account);
-	if (legacy !== null) {
-		await keytar.setPassword(SERVICE_NAME, account, legacy);
-	}
-	return legacy;
-};
-
-const findConfiguredProviders = async (): Promise<ProviderId[]> => {
-	const entries = await Promise.all(
-		KNOWN_PROVIDERS.map(async (providerId) => ({
-			providerId,
-			password: await getPasswordWithLegacyPromotion(accountFor(providerId)),
-		})),
-	);
-	return entries
-		.filter(({ password }) => password !== null)
-		.map(({ providerId }) => providerId);
-};
-
-export const CredentialsServiceLive = Layer.succeed(
+export const CredentialsServiceLive = Layer.effect(
 	CredentialsService,
-	CredentialsService.of({
-		get: (providerId) =>
-			providerCache.has(providerId)
-				? Effect.succeed(providerCache.get(providerId) ?? null)
-				: tryKeychain(providerId, () =>
-						getPasswordWithLegacyPromotion(accountFor(providerId)),
-					).pipe(
-						Effect.tap((value) =>
-							Effect.sync(() => {
-								providerCache.set(providerId, value);
-							}),
-						),
-					),
-		set: (providerId, apiKey) =>
-			tryKeychain(providerId, () =>
-				keytar.setPassword(SERVICE_NAME, accountFor(providerId), apiKey),
-			).pipe(
-				Effect.tap(() =>
-					Effect.sync(() => {
-						providerCache.set(providerId, apiKey);
-						invalidateProviderList();
-					}),
+	Effect.gen(function* () {
+		const { userData } = yield* AppPaths;
+		const vaultPath = join(userData, VAULT_FILENAME);
+		let cachedVault: VaultContents | null = null;
+		let writeTail = Promise.resolve();
+
+		const load = async (): Promise<VaultContents> => {
+			if (cachedVault !== null) return cachedVault;
+			let raw: string;
+			try {
+				raw = await readFile(vaultPath, "utf8");
+			} catch (cause) {
+				if (
+					typeof cause === "object" &&
+					cause !== null &&
+					(cause as { code?: unknown }).code === "ENOENT"
+				) {
+					cachedVault = emptyVault();
+					return cachedVault;
+				}
+				throw cause;
+			}
+			const key = await secureStorageMasterKey(false);
+			cachedVault = decryptVault(decodeEnvelope(raw), key);
+			return cachedVault;
+		};
+
+		const persist = async (contents: VaultContents): Promise<void> => {
+			const key = await secureStorageMasterKey();
+			await mkdir(userData, { recursive: true, mode: 0o700 });
+			const tmp = `${vaultPath}.tmp.${process.pid}.${Date.now()}`;
+			try {
+				await writeFile(tmp, JSON.stringify(encryptVault(contents, key)), {
+					mode: 0o600,
+				});
+				await chmod(tmp, 0o600);
+				await rename(tmp, vaultPath);
+				await chmod(vaultPath, 0o600);
+				cachedVault = contents;
+			} finally {
+				await rm(tmp, { force: true }).catch(() => {});
+			}
+		};
+
+		const read = <A>(
+			select: (contents: VaultContents) => A,
+		): Effect.Effect<A, CredentialsError> =>
+			Effect.tryPromise({
+				try: async () => select(await load()),
+				catch: toCredentialsError,
+			});
+
+		const mutate = (
+			update: (contents: VaultContents) => VaultContents,
+		): Effect.Effect<void, CredentialsError> =>
+			Effect.tryPromise({
+				try: async () => {
+					const operation = writeTail.then(async () => {
+						const current = await load();
+						await persist(update(current));
+					});
+					writeTail = operation.catch(() => {});
+					await operation;
+				},
+				catch: toCredentialsError,
+			});
+
+		return CredentialsService.of({
+			get: (providerId) =>
+				read((contents) => contents.providers[providerId] ?? null),
+			set: (providerId, apiKey) =>
+				mutate((contents) => ({
+					...contents,
+					providers: { ...contents.providers, [providerId]: apiKey },
+				})),
+			remove: (providerId) =>
+				mutate((contents) => {
+					const providers = { ...contents.providers };
+					delete providers[providerId];
+					return { ...contents, providers };
+				}),
+			listConfigured: () =>
+				read(
+					(contents) =>
+						Object.keys(contents.providers).filter(
+							(providerId): providerId is ProviderId =>
+								typeof contents.providers[providerId as ProviderId] ===
+								"string",
+						) as ReadonlyArray<ProviderId>,
 				),
-			),
-		remove: (providerId) =>
-			tryKeychain(
-				providerId,
-				async () =>
-					(await keytar.deletePassword(SERVICE_NAME, accountFor(providerId))) ||
-					(await keytar.deletePassword(
-						LEGACY_SERVICE_NAME,
-						accountFor(providerId),
-					)),
-			).pipe(
-				Effect.tap(() =>
-					Effect.sync(() => {
-						providerCache.delete(providerId);
-						invalidateProviderList();
-					}),
+			setBrowser: (origin, username, password) =>
+				mutate((contents) => ({
+					...contents,
+					browserCredentials: {
+						...contents.browserCredentials,
+						[normalizeOrigin(origin)]: { username, password },
+					},
+				})),
+			getBrowser: (origin) =>
+				read(
+					(contents) =>
+						contents.browserCredentials[normalizeOrigin(origin)] ?? null,
 				),
-				Effect.asVoid,
-			),
-		listConfigured: () =>
-			configuredCache !== null
-				? Effect.succeed(configuredCache)
-				: tryKeychain("*", findConfiguredProviders).pipe(
-						Effect.tap((value) =>
-							Effect.sync(() => {
-								configuredCache = value;
-							}),
-						),
-					),
-		setBrowser: (origin, username, password) =>
-			tryKeychain("*", () =>
-				keytar.setPassword(
-					SERVICE_NAME,
-					browserAccountFor(origin),
-					JSON.stringify({ username, password }),
+			removeBrowser: (origin) =>
+				mutate((contents) => {
+					const browserCredentials = { ...contents.browserCredentials };
+					delete browserCredentials[normalizeOrigin(origin)];
+					return { ...contents, browserCredentials };
+				}),
+			listBrowser: () =>
+				read((contents) =>
+					Object.entries(contents.browserCredentials)
+						.map(([origin, credential]) => ({
+							origin,
+							username: credential.username,
+						}))
+						.sort((a, b) => a.origin.localeCompare(b.origin)),
 				),
-			).pipe(
-				Effect.tap(() =>
-					Effect.sync(() => {
-						browserCache.set(normalizeOrigin(origin), { username, password });
-						invalidateBrowserList();
-					}),
+			// WorkOS sessions already use SessionStore. Deliberately do not touch
+			// legacy Keychain entries during startup migration.
+			getWorkosSession: () => Effect.succeed(null),
+			setWorkosSession: () => Effect.void,
+			removeWorkosSession: () => Effect.void,
+			getIntegration: (integration, accountId) =>
+				read(
+					(contents) => contents.integrations[integration]?.[accountId] ?? null,
 				),
-			),
-		getBrowser: (origin) =>
-			browserCache.has(normalizeOrigin(origin))
-				? Effect.succeed(browserCache.get(normalizeOrigin(origin)) ?? null)
-				: tryKeychain("*", () =>
-						getPasswordWithLegacyPromotion(browserAccountFor(origin)),
-					).pipe(
-						Effect.map(parseBrowserCred),
-						Effect.tap((value) =>
-							Effect.sync(() => {
-								browserCache.set(normalizeOrigin(origin), value);
-							}),
-						),
-					),
-		removeBrowser: (origin) =>
-			tryKeychain(
-				"*",
-				async () =>
-					(await keytar.deletePassword(
-						SERVICE_NAME,
-						browserAccountFor(origin),
-					)) ||
-					(await keytar.deletePassword(
-						LEGACY_SERVICE_NAME,
-						browserAccountFor(origin),
-					)),
-			).pipe(
-				Effect.tap(() =>
-					Effect.sync(() => {
-						browserCache.delete(normalizeOrigin(origin));
-						invalidateBrowserList();
-					}),
+			setIntegration: (integration, accountId, value) =>
+				mutate((contents) => ({
+					...contents,
+					integrations: {
+						...contents.integrations,
+						[integration]: {
+							...contents.integrations[integration],
+							[accountId]: value,
+						},
+					},
+				})),
+			removeIntegration: (integration, accountId) =>
+				mutate((contents) => {
+					const accounts = { ...contents.integrations[integration] };
+					delete accounts[accountId];
+					const integrations = { ...contents.integrations };
+					if (Object.keys(accounts).length === 0)
+						delete integrations[integration];
+					else integrations[integration] = accounts;
+					return { ...contents, integrations };
+				}),
+			listIntegrationAccounts: (integration) =>
+				read((contents) =>
+					Object.keys(contents.integrations[integration] ?? {}).sort(),
 				),
-				Effect.asVoid,
-			),
-		listBrowser: () =>
-			browserListCache !== null
-				? Effect.succeed(browserListCache)
-				: tryKeychain("*", async () => {
-						const current = collectBrowser(
-							await keytar.findCredentials(SERVICE_NAME),
-						);
-						if (current.length > 0) return current;
-						return collectBrowser(
-							await keytar.findCredentials(LEGACY_SERVICE_NAME),
-						);
-					}).pipe(
-						Effect.tap((value) =>
-							Effect.sync(() => {
-								browserListCache = value;
-							}),
-						),
-					),
-		getWorkosSession: () =>
-			tryKeychain("*", () =>
-				keytar.getPassword(SERVICE_NAME, WORKOS_SESSION_ACCOUNT),
-			),
-		setWorkosSession: (bundleJson) =>
-			tryKeychain("*", () =>
-				keytar.setPassword(SERVICE_NAME, WORKOS_SESSION_ACCOUNT, bundleJson),
-			),
-		removeWorkosSession: () =>
-			tryKeychain("*", () =>
-				keytar.deletePassword(SERVICE_NAME, WORKOS_SESSION_ACCOUNT),
-			).pipe(Effect.asVoid),
-		getIntegration: (integration, accountId) =>
-			tryKeychain("*", () =>
-				keytar.getPassword(
-					SERVICE_NAME,
-					integrationAccountFor(integration, accountId),
-				),
-			),
-		setIntegration: (integration, accountId, value) =>
-			tryKeychain("*", () =>
-				keytar.setPassword(
-					SERVICE_NAME,
-					integrationAccountFor(integration, accountId),
-					value,
-				),
-			),
-		removeIntegration: (integration, accountId) =>
-			tryKeychain("*", () =>
-				keytar.deletePassword(
-					SERVICE_NAME,
-					integrationAccountFor(integration, accountId),
-				),
-			).pipe(Effect.asVoid),
-		listIntegrationAccounts: (integration) =>
-			tryKeychain("*", async () => {
-				const prefix = integrationPrefix(integration);
-				return (await keytar.findCredentials(SERVICE_NAME))
-					.map(({ account }) => account)
-					.filter((account) => account.startsWith(prefix))
-					.map((account) => account.slice(prefix.length));
-			}),
-		getMcpOauth: (serverKey) =>
-			tryKeychain("*", () =>
-				keytar.getPassword(SERVICE_NAME, mcpOauthAccountFor(serverKey)),
-			),
-		setMcpOauth: (serverKey, bundleJson) =>
-			tryKeychain("*", () =>
-				keytar.setPassword(
-					SERVICE_NAME,
-					mcpOauthAccountFor(serverKey),
-					bundleJson,
-				),
-			),
-		removeMcpOauth: (serverKey) =>
-			tryKeychain("*", () =>
-				keytar.deletePassword(SERVICE_NAME, mcpOauthAccountFor(serverKey)),
-			).pipe(Effect.asVoid),
+			getMcpOauth: (serverKey) =>
+				read((contents) => contents.mcpOauth[serverKey] ?? null),
+			setMcpOauth: (serverKey, bundleJson) =>
+				mutate((contents) => ({
+					...contents,
+					mcpOauth: { ...contents.mcpOauth, [serverKey]: bundleJson },
+				})),
+			removeMcpOauth: (serverKey) =>
+				mutate((contents) => {
+					const mcpOauth = { ...contents.mcpOauth };
+					delete mcpOauth[serverKey];
+					return { ...contents, mcpOauth };
+				}),
+		});
 	}),
 );

--- a/apps/server/src/provider/services/credentials-service.ts
+++ b/apps/server/src/provider/services/credentials-service.ts
@@ -4,108 +4,107 @@ import { Context, type Effect } from "effect";
 import type { CredentialsError } from "../errors.ts";
 
 /**
- * OS-keychain-backed credential store keyed by `providerId`. Used by the SDK
- * adapters to retrieve API keys without ever surfacing them to renderer code.
+ * Encrypted-vault credential store keyed by `providerId`. The vault is
+ * protected by one cached OS-keychain master key; individual credentials never
+ * become Keychain entries. Used by SDK adapters without surfacing keys to the
+ * renderer.
  * Set via the `agent.setCredential` RPC; never returned over the wire — only
  * `listConfigured()` is renderer-visible, surfaced as the `hasApiKey` flag
  * on `AgentAvailability`. CLI-login credentials (the primary auth path)
  * never touch this service.
  */
 export interface CredentialsServiceShape {
-  readonly get: (
-    providerId: ProviderId,
-  ) => Effect.Effect<string | null, CredentialsError>;
-  readonly set: (
-    providerId: ProviderId,
-    apiKey: string,
-  ) => Effect.Effect<void, CredentialsError>;
-  readonly remove: (
-    providerId: ProviderId,
-  ) => Effect.Effect<void, CredentialsError>;
-  readonly listConfigured: () => Effect.Effect<
-    ReadonlyArray<ProviderId>,
-    CredentialsError
-  >;
+	readonly get: (
+		providerId: ProviderId,
+	) => Effect.Effect<string | null, CredentialsError>;
+	readonly set: (
+		providerId: ProviderId,
+		apiKey: string,
+	) => Effect.Effect<void, CredentialsError>;
+	readonly remove: (
+		providerId: ProviderId,
+	) => Effect.Effect<void, CredentialsError>;
+	readonly listConfigured: () => Effect.Effect<
+		ReadonlyArray<ProviderId>,
+		CredentialsError
+	>;
 
-  /**
-   * In-app agent browser credentials — DUMMY/TEST logins only. Keyed by web
-   * origin, namespaced `browserCred:<origin>` in the same keychain. Stored as
-   * `{ username, password }`. `listBrowser` deliberately drops the password so
-   * the settings UI only ever sees origin + username.
-   */
-  readonly setBrowser: (
-    origin: string,
-    username: string,
-    password: string,
-  ) => Effect.Effect<void, CredentialsError>;
-  readonly getBrowser: (
-    origin: string,
-  ) => Effect.Effect<
-    { username: string; password: string } | null,
-    CredentialsError
-  >;
-  readonly removeBrowser: (
-    origin: string,
-  ) => Effect.Effect<void, CredentialsError>;
-  readonly listBrowser: () => Effect.Effect<
-    ReadonlyArray<{ origin: string; username: string }>,
-    CredentialsError
-  >;
+	/**
+	 * In-app agent browser credentials — DUMMY/TEST logins only. Keyed by web
+	 * origin in the encrypted vault. Stored as
+	 * `{ username, password }`. `listBrowser` deliberately drops the password so
+	 * the settings UI only ever sees origin + username.
+	 */
+	readonly setBrowser: (
+		origin: string,
+		username: string,
+		password: string,
+	) => Effect.Effect<void, CredentialsError>;
+	readonly getBrowser: (
+		origin: string,
+	) => Effect.Effect<
+		{ username: string; password: string } | null,
+		CredentialsError
+	>;
+	readonly removeBrowser: (
+		origin: string,
+	) => Effect.Effect<void, CredentialsError>;
+	readonly listBrowser: () => Effect.Effect<
+		ReadonlyArray<{ origin: string; username: string }>,
+		CredentialsError
+	>;
 
-  /**
-   * WorkOS AuthKit session bundle (access + refresh tokens, expiry, and the
-   * non-secret profile) serialized as JSON under a single `workos:session`
-   * keychain account. Lives alongside `apiKey:` / `browserCred:` in the same
-   * `memoize` service. The tokens NEVER leave the server — only the AuthService
-   * reads this; the renderer sees a redacted `AuthState` over the wire.
-   */
-  readonly getWorkosSession: () => Effect.Effect<
-    string | null,
-    CredentialsError
-  >;
-  readonly setWorkosSession: (
-    bundleJson: string,
-  ) => Effect.Effect<void, CredentialsError>;
-  readonly removeWorkosSession: () => Effect.Effect<void, CredentialsError>;
+	/**
+	 * Legacy compatibility methods. WorkOS sessions now live in SessionStore;
+	 * the live implementation deliberately does not inspect old Keychain items.
+	 */
+	readonly getWorkosSession: () => Effect.Effect<
+		string | null,
+		CredentialsError
+	>;
+	readonly setWorkosSession: (
+		bundleJson: string,
+	) => Effect.Effect<void, CredentialsError>;
+	readonly removeWorkosSession: () => Effect.Effect<void, CredentialsError>;
 
 	/** Secret JSON bundles for native third-party integrations. */
-  readonly getIntegration: (
-    integration: string,
-    accountId: string,
-  ) => Effect.Effect<string | null, CredentialsError>;
-  readonly setIntegration: (
-    integration: string,
-    accountId: string,
-    value: string,
-  ) => Effect.Effect<void, CredentialsError>;
-  readonly removeIntegration: (
-    integration: string,
-    accountId: string,
-  ) => Effect.Effect<void, CredentialsError>;
+	readonly getIntegration: (
+		integration: string,
+		accountId: string,
+	) => Effect.Effect<string | null, CredentialsError>;
+	readonly setIntegration: (
+		integration: string,
+		accountId: string,
+		value: string,
+	) => Effect.Effect<void, CredentialsError>;
+	readonly removeIntegration: (
+		integration: string,
+		accountId: string,
+	) => Effect.Effect<void, CredentialsError>;
 	readonly listIntegrationAccounts: (
 		integration: string,
 	) => Effect.Effect<ReadonlyArray<string>, CredentialsError>;
 
 	/**
-   * OAuth token bundle for a user MCP server (claude-source servers Zuse
-   * authenticates itself — codex-source tokens live in Codex's own store).
-   * Keyed by the server's descriptor key (`claude:<name>`), namespaced
-   * `mcpOAuth:<key>`, stored as the JSON the MCP SDK's OAuthClientProvider
-   * round-trips (tokens + client registration). Never crosses the wire.
-   */
-  readonly getMcpOauth: (
-    serverKey: string,
-  ) => Effect.Effect<string | null, CredentialsError>;
-  readonly setMcpOauth: (
-    serverKey: string,
-    bundleJson: string,
-  ) => Effect.Effect<void, CredentialsError>;
+	 * OAuth token bundle for a user MCP server (claude-source servers Zuse
+	 * authenticates itself — codex-source tokens live in Codex's own store).
+	 * Keyed by the server's descriptor key (`claude:<name>`), namespaced
+	 * `mcpOAuth:<key>`, stored as the JSON the MCP SDK's OAuthClientProvider
+	 * round-trips (tokens + client registration). Never crosses the wire.
+	 */
+	readonly getMcpOauth: (
+		serverKey: string,
+	) => Effect.Effect<string | null, CredentialsError>;
+	readonly setMcpOauth: (
+		serverKey: string,
+		bundleJson: string,
+	) => Effect.Effect<void, CredentialsError>;
 	readonly removeMcpOauth: (
 		serverKey: string,
 	) => Effect.Effect<void, CredentialsError>;
 }
 
 export class CredentialsService extends Context.Service<
-  CredentialsService,
-  CredentialsServiceShape
+	CredentialsService,
+	CredentialsServiceShape
 >()("memoize/CredentialsService") {}

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -216,11 +216,14 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(AppPathsLayer),
 		Layer.provide(NodeServices.layer),
 	);
+	const CredentialsLayer = CredentialsServiceLive.pipe(
+		Layer.provide(AppPathsLayer),
+	);
 
 	// Auth owns the account transition that analytics uses to move between a
 	// random installation identity and a namespaced account hash.
 	const AuthLayer = AuthServiceLive.pipe(
-		Layer.provide(CredentialsServiceLive),
+		Layer.provide(CredentialsLayer),
 		Layer.provide(SessionStoreLive),
 		Layer.provide(AuthShellLayer),
 	);
@@ -307,7 +310,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 	const McpLayer = McpServiceLive.pipe(
 		Layer.provide(ConfigStoreLayer),
 		Layer.provide(RepositorySettingsLayer),
-		Layer.provide(CredentialsServiceLive),
+		Layer.provide(CredentialsLayer),
 		Layer.provide(BrowserBridgeLayer),
 		Layer.provide(MigratedSqlite),
 		Layer.provide(NodeServices.layer),
@@ -318,7 +321,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 	// WorkspaceService, and forwards the SDK's tool-permission callback to
 	// PermissionService.
 	const ProviderLayer = ProviderServiceLive.pipe(
-		Layer.provide(CredentialsServiceLive),
+		Layer.provide(CredentialsLayer),
 		Layer.provide(WorkspaceLayer),
 		Layer.provide(PermissionLayer),
 		Layer.provide(AttachmentLayer),
@@ -367,7 +370,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(LanAuthLayer),
 	);
 	const LinearLayer = LinearServiceLive.pipe(
-		Layer.provide(CredentialsServiceLive),
+		Layer.provide(CredentialsLayer),
 		Layer.provide(AuthShellLayer),
 		Layer.provide(AttachmentLayer),
 		Layer.provide(MigratedSqlite),
@@ -469,8 +472,8 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		PermissionLayer,
 		AttachmentLayer,
 		BrowserBridgeLayer,
-		// browser.* credential RPCs read/write the keychain directly.
-		CredentialsServiceLive,
+		// browser.* credential RPCs share the encrypted local vault.
+		CredentialsLayer,
 		SkillBridgeLayer,
 		DiagnosticsLayer,
 		LanAuthLayer,

--- a/apps/server/src/secure-storage-master-key.ts
+++ b/apps/server/src/secure-storage-master-key.ts
@@ -1,0 +1,41 @@
+import { randomBytes } from "node:crypto";
+
+import keytar from "keytar";
+
+const KEYCHAIN_SERVICE = "zuse-secure-storage";
+const KEYCHAIN_ACCOUNT = "vault-master-key-v1";
+
+let keyPromise: Promise<Buffer> | null = null;
+
+export const secureStorageMasterKey = (
+	createIfMissing = true,
+): Promise<Buffer> => {
+	if (keyPromise !== null) return keyPromise;
+	keyPromise = (async () => {
+		const existing = await keytar.getPassword(
+			KEYCHAIN_SERVICE,
+			KEYCHAIN_ACCOUNT,
+		);
+		if (existing !== null) {
+			const decoded = Buffer.from(existing, "base64url");
+			if (decoded.byteLength !== 32)
+				throw new Error("The secure storage key is invalid.");
+			return decoded;
+		}
+		if (!createIfMissing)
+			throw new Error(
+				"Secure storage cannot be opened because its master key is missing.",
+			);
+		const created = randomBytes(32);
+		await keytar.setPassword(
+			KEYCHAIN_SERVICE,
+			KEYCHAIN_ACCOUNT,
+			created.toString("base64url"),
+		);
+		return created;
+	})().catch((cause) => {
+		keyPromise = null;
+		throw cause;
+	});
+	return keyPromise;
+};

--- a/apps/server/src/usage/limits/claude-usage.ts
+++ b/apps/server/src/usage/limits/claude-usage.ts
@@ -1,8 +1,6 @@
-import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
 import type { ProviderUsageLimits, UsageLimitWindow } from "@zuse/contracts";
 
 import { normalizePercent, normalizeReset, unavailable } from "./shared.ts";
@@ -140,17 +138,10 @@ export const readClaudeAccessToken =
 				await readFile(join(homedir(), ".claude", ".credentials.json"), "utf8"),
 			);
 		} catch {
-			if (process.platform !== "darwin") return { reason: "no-credentials" };
-			try {
-				const { stdout } = await promisify(execFile)(
-					"/usr/bin/security",
-					["find-generic-password", "-s", "Claude Code-credentials", "-w"],
-					{ timeout: 3_000, maxBuffer: 1_000_000 },
-				);
-				return credentialFromBlob(stdout.trim());
-			} catch {
-				return { reason: "no-credentials" };
-			}
+			// Never fall back to macOS Keychain. Usage polling is passive and must
+			// not create a permission prompt simply because the CLI stores its
+			// credential somewhere other than its normal credentials file.
+			return { reason: "no-credentials" };
 		}
 	};
 

--- a/apps/server/test/unit/credentials-service.test.ts
+++ b/apps/server/test/unit/credentials-service.test.ts
@@ -1,5 +1,9 @@
-import { Effect } from "effect";
-import { describe, expect, it, type Mock, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Effect, Layer } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const keytar = vi.hoisted(() => ({
 	deletePassword: vi.fn(async () => false),
@@ -10,30 +14,68 @@ const keytar = vi.hoisted(() => ({
 
 vi.mock("keytar", () => ({ default: keytar }));
 
+import { AppPaths } from "../../src/app-paths.ts";
 import { CredentialsServiceLive } from "../../src/provider/layers/credentials-service.ts";
 import { CredentialsService } from "../../src/provider/services/credentials-service.ts";
 
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	vi.clearAllMocks();
+	for (const directory of temporaryDirectories.splice(0)) {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
 describe("CredentialsService", () => {
-	it("discovers API keys without decrypting unrelated keychain entries", async () => {
+	it("stores credentials in an encrypted vault behind one cached keychain key", async () => {
+		const userData = await mkdtemp(join(tmpdir(), "zuse-vault-test-"));
+		temporaryDirectories.push(userData);
 		keytar.findCredentials.mockRejectedValue(
 			new Error("would prompt for an unrelated integration credential"),
 		);
-		const credentialLookup = keytar.getPassword as unknown as Mock<
-			(service: string, account: string) => Promise<string | null>
-		>;
-		credentialLookup.mockImplementation(async (service, account) =>
-			service === "zuse" && account === "apiKey:codex" ? "" : null,
-		);
 
-		const configured = await Effect.runPromise(
+		const result = await Effect.runPromise(
 			Effect.gen(function* () {
 				const credentials = yield* CredentialsService;
-				return yield* credentials.listConfigured();
-			}).pipe(Effect.provide(CredentialsServiceLive)),
+				yield* credentials.set("codex", "provider-secret");
+				yield* credentials.setIntegration(
+					"linear",
+					"workspace-1",
+					"integration-secret",
+				);
+				return {
+					configured: yield* credentials.listConfigured(),
+					provider: yield* credentials.get("codex"),
+					integration: yield* credentials.getIntegration(
+						"linear",
+						"workspace-1",
+					),
+				};
+			}).pipe(
+				Effect.provide(
+					CredentialsServiceLive.pipe(
+						Layer.provide(Layer.succeed(AppPaths, AppPaths.of({ userData }))),
+					),
+				),
+			),
 		);
 
-		expect(configured).toEqual(["codex"]);
+		expect(result).toEqual({
+			configured: ["codex"],
+			provider: "provider-secret",
+			integration: "integration-secret",
+		});
 		expect(keytar.findCredentials).not.toHaveBeenCalled();
-		expect(keytar.getPassword).toHaveBeenCalledWith("zuse", "apiKey:codex");
+		expect(keytar.getPassword).toHaveBeenCalledTimes(1);
+		expect(keytar.getPassword).toHaveBeenCalledWith(
+			"zuse-secure-storage",
+			"vault-master-key-v1",
+		);
+		expect(keytar.setPassword).toHaveBeenCalledTimes(1);
+
+		const vault = await readFile(join(userData, "secure-vault.json"), "utf8");
+		expect(vault).not.toContain("provider-secret");
+		expect(vault).not.toContain("integration-secret");
 	});
 });

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "@zuse/server": "*",
         "@zuse/ssh": "*",
         "effect": "catalog:",
-        "electron": "42.1.0",
+        "electron": "42.4.1",
         "electron-builder": "^25.1.8",
         "fix-path": "^4.0.0",
         "sharp": "^0.34.1",
@@ -917,6 +917,8 @@
     "@effect/vitest": ["@effect/vitest@4.0.0-beta.97", "", { "peerDependencies": { "effect": "^4.0.0-beta.97", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-1dH6LBWSZyqnTV7ZO+yIpPGPf/xd7RtFfvQ4ZpTy9elzFN+wr1YBFpHSCr8+BfXOml6b8g9Mtj5eDy1qjbizUA=="],
 
     "@egjs/hammerjs": ["@egjs/hammerjs@2.0.17", "", { "dependencies": { "@types/hammerjs": "^2.0.36" } }, "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A=="],
+
+    "@electron-internal/extract-zip": ["@electron-internal/extract-zip@1.0.4", "", {}, "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 
@@ -1940,8 +1942,6 @@
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
-    "@types/yauzl": ["@types/yauzl@2.10.3", "http://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
-
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.1", "http://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/type-utils": "8.59.1", "@typescript-eslint/utils": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.1", "http://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA=="],
@@ -2670,7 +2670,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@42.1.0", "", { "dependencies": { "@electron/get": "^5.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-0szNwC/0dWtkvNce5j3ThiuL0TxBNrZN/BZhdOiGwbLreiD/+u3MGpkct4hA5Ycagb8MXjpEr5/oosi+FwuKRQ=="],
+    "electron": ["electron@42.4.1", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-8CYHJP5O4wFO+ycoJR98yy907MmPeo+vWXrzjxmGGgRNKqv8pOjjm+wphO0CCgQJnBU7+QUPSJS4QXhbKrO50w=="],
 
     "electron-builder": ["electron-builder@25.1.8", "", { "dependencies": { "app-builder-lib": "25.1.8", "builder-util": "25.1.7", "builder-util-runtime": "9.2.10", "chalk": "^4.1.2", "dmg-builder": "25.1.8", "fs-extra": "^10.1.0", "is-ci": "^3.0.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig=="],
 
@@ -2896,8 +2896,6 @@
 
     "extend": ["extend@3.0.2", "http://registry.npmjs.org/extend/-/extend-3.0.2.tgz", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
-    "extract-zip": ["extract-zip@2.0.1", "http://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
-
     "extsprintf": ["extsprintf@1.4.1", "", {}, "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="],
 
     "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
@@ -2917,8 +2915,6 @@
     "fb-dotslash": ["fb-dotslash@0.5.8", "", { "bin": { "dotslash": "bin/dotslash" } }, "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA=="],
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
-
-    "fd-slicer": ["fd-slicer@1.1.0", "http://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "http://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -3012,7 +3008,7 @@
 
     "get-proto": ["get-proto@1.0.1", "http://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
-    "get-stream": ["get-stream@5.2.0", "http://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+    "get-stream": ["get-stream@9.0.1", "http://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "http://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
@@ -3773,8 +3769,6 @@
     "pathe": ["pathe@2.0.3", "http://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pe-library": ["pe-library@0.4.1", "", {}, "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw=="],
-
-    "pend": ["pend@1.2.0", "http://registry.npmjs.org/pend/-/pend-1.2.0.tgz", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
@@ -4562,8 +4556,6 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "http://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "yauzl": ["yauzl@2.10.0", "http://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
-
     "yocto-queue": ["yocto-queue@0.1.0", "http://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yocto-spinner": ["yocto-spinner@1.1.0", "http://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.1.0.tgz", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA=="],
@@ -4894,6 +4886,8 @@
 
     "cacache/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
+    "cacheable-request/get-stream": ["get-stream@5.2.0", "http://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
     "chrome-launcher/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
 
     "chrome-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -4975,8 +4969,6 @@
     "eslint-plugin-import/tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
-
-    "execa/get-stream": ["get-stream@9.0.1", "http://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "expo-auth-session/expo-application": ["expo-application@57.0.1", "", { "peerDependencies": { "expo": "*" } }, "sha512-NyfeOjo/7df9PaeWXzKmRttMqVifG2tWdY04K+SEPzSHdnfjCDK5wBXZiWif7xTVnsnJbgLXGBLN0UuIcuFEBw=="],
 

--- a/docs/research/mac-client-connectivity.md
+++ b/docs/research/mac-client-connectivity.md
@@ -12,8 +12,7 @@ research remains deferred until nearby connections are reliable.
 
 ### User experience
 
-- A phone that proves the same Zuse account or possession of the Mac's
-  synchronized iCloud Keychain trust record is approved automatically.
+- A phone that proves the same Zuse account is approved automatically.
 - An unverified phone triggers a Mac approval sheet automatically. The sheet
   shows the phone label, a stable short device identifier, and a safety phrase
   that is also visible on the phone. The user compares the phrase and clicks
@@ -65,12 +64,10 @@ phone public key, nonce, and TLS certificate pin. The Mac verifies the relay
 signature and all bindings before approving automatically. The assertion is
 only a trust bootstrap; subsequent RPC traffic stays on the direct nearby path.
 
-Apple does not expose a general API that lets an app read and compare the two
-devices' Apple Accounts. The Apple-specific automatic path instead stores a
-per-Mac 256-bit trust record in a shared Keychain Access Group with
-`kSecAttrSynchronizable`; proof of possession is used without transmitting the
-secret. If the record is unavailable or delayed, the app falls back silently to
-the one-click Mac approval flow.
+The earlier synchronized-Keychain trust path was removed because it caused
+unexpected permission prompts and depended on ambient cross-device secret
+state. When account trust is unavailable, the app uses the explicit one-click
+Mac approval flow.
 
 ### Implemented local flow
 
@@ -79,10 +76,9 @@ the one-click Mac approval flow.
 2. The iOS native module browses Bonjour, monitors network paths, opens a local
    loopback proxy, and validates the advertised certificate pin in its TLS
    verification callback.
-3. A single discovered Mac is requested automatically. Account or synchronized
-   Keychain proof produces zero-touch approval. Otherwise the Mac shows the
-   phone label, cryptographic device identifier, and matching phrase with one
-   **Allow** action.
+3. A single discovered Mac is requested automatically. Account proof produces
+   zero-touch approval. Otherwise the Mac shows the phone label, cryptographic
+   device identifier, and matching phrase with one **Allow** action.
 4. The issued bearer credential is encrypted to the phone's persistent X25519
    key. The saved record contains stable Mac identity and certificate pins, not
    an IP address.

--- a/packages/contracts/src/browser.ts
+++ b/packages/contracts/src/browser.ts
@@ -186,9 +186,8 @@ export const BrowserCommand = Schema.Union([
 	/**
 	 * Autofill + submit the saved (DUMMY/TEST) credentials for this origin.
 	 * SECURITY: the command carries ONLY the origin — never the password. The
-	 * renderer pulls the secret out-of-band via `browser.fillForOrigin` and
-	 * injects it into the page, so the password never enters the agent's tool
-	 * args/results or the LLM context.
+	 * desktop main process injects the secret directly into the isolated page,
+	 * so it never enters renderer state, agent args/results, or LLM context.
 	 */
 	Schema.TaggedStruct("Login", { origin: Schema.String }),
 	Schema.TaggedStruct("Inspect", { target: BrowserTarget }),
@@ -216,18 +215,6 @@ export class BrowserCredentialSummary extends Schema.Class<BrowserCredentialSumm
 )({
 	origin: Schema.String,
 	username: Schema.String,
-}) {}
-
-/**
- * The actual secret, returned ONLY to the trusted renderer executor when it
- * handles a `Login` command. Never flows through the agent event stream, a
- * tool result, or the command broadcast.
- */
-export class BrowserCredentialSecret extends Schema.Class<BrowserCredentialSecret>(
-	"BrowserCredentialSecret",
-)({
-	username: Schema.String,
-	password: Schema.String,
 }) {}
 
 /**
@@ -309,9 +296,8 @@ export const BrowserRespondRpc = Rpc.make("browser.respond", {
 
 // ---------------------------------------------------------------------------
 // Browser credentials (DUMMY / TEST passwords only — see settings UI warning).
-// Stored in the OS keychain, namespaced by origin. Write-only from the UI's
-// perspective; the password is never returned to the settings UI, only to the
-// renderer's Login executor via `browser.fillForOrigin`.
+// Stored in the encrypted app vault. Write-only from the UI's perspective; the
+// password is injected into the isolated page by the desktop main process.
 // ---------------------------------------------------------------------------
 
 /** Save (or overwrite) the dummy credential for an origin. */
@@ -333,14 +319,4 @@ export const BrowserListCredentialsRpc = Rpc.make("browser.listCredentials", {
 export const BrowserRemoveCredentialRpc = Rpc.make("browser.removeCredential", {
 	payload: Schema.Struct({ origin: Schema.String }),
 	success: Schema.Void,
-});
-
-/**
- * Renderer-only: fetch the secret for an origin to inject into the page during
- * a Login command. Returns null when nothing is saved. NEVER call this from any
- * agent-facing path — the result is the cleartext dummy password.
- */
-export const BrowserFillForOriginRpc = Rpc.make("browser.fillForOrigin", {
-	payload: Schema.Struct({ origin: Schema.String }),
-	success: Schema.NullOr(BrowserCredentialSecret),
 });

--- a/packages/contracts/src/linear.ts
+++ b/packages/contracts/src/linear.ts
@@ -13,6 +13,7 @@ export class LinearConnection extends Schema.Class<LinearConnection>(
 	viewerName: Schema.String,
 	viewerEmail: Schema.String,
 	connectedAt: Schema.DateFromString,
+	status: Schema.Literals(["connected", "reauthRequired"]),
 }) {}
 
 export class LinearIssueRef extends Schema.Class<LinearIssueRef>(

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -25,7 +25,6 @@ import {
 } from "./auth.ts";
 import {
 	BrowserCommandsRpc,
-	BrowserFillForOriginRpc,
 	BrowserListCredentialsRpc,
 	BrowserRemoveCredentialRpc,
 	BrowserRespondRpc,
@@ -400,7 +399,6 @@ export const MemoizeRpcs = RpcGroup.make(
 	BrowserSetCredentialRpc,
 	BrowserListCredentialsRpc,
 	BrowserRemoveCredentialRpc,
-	BrowserFillForOriginRpc,
 	WorktreeCreateRpc,
 	WorktreeListRpc,
 	WorktreeGetRpc,

--- a/packages/contracts/test/unit/linear.test.ts
+++ b/packages/contracts/test/unit/linear.test.ts
@@ -77,6 +77,7 @@ describe("Linear wire contracts", () => {
 			viewerName: "Ada",
 			viewerEmail: "ada@example.com",
 			connectedAt: new Date("2026-01-01T00:00:00.000Z"),
+			status: "connected",
 		});
 		const encoded = Schema.encodeSync(LinearConnection)(connection);
 		expect(JSON.stringify(encoded)).not.toMatch(/access|refresh|token/i);


### PR DESCRIPTION
## What changed

- repairs integration OAuth callback, refresh, reconnect-required, issue-loading, and release configuration behavior
- consolidates provider, integration, MCP OAuth, and saved test-login secrets into an AES-256-GCM encrypted local vault backed by one app-owned Keychain master key
- removes passive Keychain scans, legacy entry reads, synchronized trust access, and the redundant persistent Chromium storage path
- limits browser safe-storage permission access to the explicit cookie-import action
- encrypts imported cookies, restores them into the isolated in-memory browser session, and synchronizes cookie rotation and logout changes
- keeps saved test-login secrets out of renderer state by filling the isolated browser page from the desktop main process
- improves reconnect and structured error messaging in the integration UI

## Why

Integration release builds were missing required client configuration, OAuth failures were not represented clearly, and multiple independent secure-storage paths could trigger repeated macOS Keychain prompts. Browser persistence also relied on a Chromium partition that could initialize another OS-backed secure-storage path.

## Impact

Users should see at most the app vault’s single Keychain access, plus a separate browser permission only when they explicitly import cookies. Existing legacy Keychain entries are deliberately not read or migrated, so affected integrations may require one reconnect.

## Validation

- Biome checks pass
- all 23 applicable workspace typecheck tasks pass
- server unit suite: 160 tests pass
- desktop browser-session tests: 5 tests pass
- mobile nearby-connectivity tests: 6 tests pass
- contract integration fixture tests pass

Two unrelated pre-existing server integration failures remain: an outdated database fixture and an existing provider-error expectation mismatch.