### PR TITLE
Release v0.15.7

### DIFF
--- a/.env.analytics.example
+++ b/.env.analytics.example
@@ -1,10 +1,13 @@
 # Public, ingest-only configuration (safe to embed in the matching app).
 ZUSE_POSTHOG_KEY=
 ZUSE_POSTHOG_HOST=https://us.i.posthog.com
+ZUSE_POSTHOG_ENABLE_DEV=0
 VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=https://us.i.posthog.com
+VITE_POSTHOG_ENABLE_DEV=0
 EXPO_PUBLIC_POSTHOG_KEY=
 EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+EXPO_PUBLIC_POSTHOG_ENABLE_DEV=0
 
 # Operations-only provisioning configuration. Never include these in a build.
 POSTHOG_PERSONAL_API_KEY=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
           # Analytics keys are injected at build time and never committed.
           ZUSE_POSTHOG_KEY: ${{ secrets.ZUSE_POSTHOG_KEY }}
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          NODE_ENV: production
         run: |
           test -n "$LINEAR_CLIENT_ID"
+          test -n "$ZUSE_POSTHOG_KEY"
+          test -n "$VITE_POSTHOG_KEY"
           bun run build
 
       - name: Package + sign + notarize + publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.7]
+
+### Changed
+- Fix analytics configuration across build modes
+
 ## [0.15.6]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "desktop",
   "type": "module",
   "productName": "Zuse (Beta)",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Zuse (Beta) desktop app",
   "private": true,
   "author": {

--- a/apps/desktop/scripts/main-bundle-startup-smoke.mjs
+++ b/apps/desktop/scripts/main-bundle-startup-smoke.mjs
@@ -1,9 +1,19 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const bundlePath = fileURLToPath(
 	new URL("../dist-electron/main.cjs", import.meta.url),
 );
+const expectedAnalyticsKey = process.env.ZUSE_POSTHOG_KEY?.trim();
+if (
+	expectedAnalyticsKey &&
+	!readFileSync(bundlePath, "utf8").includes(expectedAnalyticsKey)
+) {
+	throw new Error(
+		"Desktop main bundle is missing the configured analytics ingest key",
+	);
+}
 const result = spawnSync(process.execPath, [bundlePath], {
 	env: { ...process.env, ZUSE_MAIN_BUNDLE_SMOKE: "1" },
 	encoding: "utf8",

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -11,11 +11,9 @@ const desktopOutDir =
 
 // tsdown evaluates this config with its own loader (not the bun runtime), so
 // bun's automatic `.env` loading doesn't reach it. Read .env files ourselves
-// so both dev (`tsdown --watch`) and packaged builds inline the public WorkOS
-// client id. A real shell/CI env var always wins.
-const resolveClientId = (
-	name: "WORKOS_CLIENT_ID" | "LINEAR_CLIENT_ID",
-): string => {
+// so both dev (`tsdown --watch`) and packaged builds inline public build
+// configuration. A real shell/CI env var always wins.
+const resolveBuildEnv = (name: string): string => {
 	if (process.env[name]) return process.env[name];
 	const envPaths = [
 		resolve(process.cwd(), ".env"),
@@ -34,22 +32,32 @@ const resolveClientId = (
 	return "";
 };
 
-const WORKOS_CLIENT_ID = resolveClientId("WORKOS_CLIENT_ID");
-const LINEAR_CLIENT_ID = resolveClientId("LINEAR_CLIENT_ID");
+const WORKOS_CLIENT_ID = resolveBuildEnv("WORKOS_CLIENT_ID");
+const LINEAR_CLIENT_ID = resolveBuildEnv("LINEAR_CLIENT_ID");
+const ZUSE_POSTHOG_KEY = resolveBuildEnv("ZUSE_POSTHOG_KEY");
+const ZUSE_POSTHOG_HOST =
+	resolveBuildEnv("ZUSE_POSTHOG_HOST") || "https://us.i.posthog.com";
+const ZUSE_POSTHOG_ENABLE_DEV = resolveBuildEnv("ZUSE_POSTHOG_ENABLE_DEV");
+const NODE_ENV =
+	process.env.NODE_ENV === "production" ? "production" : "development";
 
 const shared = {
 	format: "cjs" as const,
 	outDir: desktopOutDir,
 	sourcemap: true,
 	outExtensions: () => ({ js: ".cjs" }),
-	// Inline the public WorkOS client id at build time so the bundled server
-	// (apps/server is alwaysBundle'd below) reads a concrete value — the
-	// packaged Electron process has no shell env. Empty when unset; AuthService
-	// then surfaces a clear "not configured" error and auth stays optional.
-	// Dev: `export WORKOS_CLIENT_ID=client_… ` before `bun run dev`.
+	// Inline public build configuration so the bundled server (apps/server is
+	// alwaysBundle'd below) reads concrete values. A packaged Electron process
+	// does not inherit the CI environment used to build it.
 	define: {
 		"process.env.WORKOS_CLIENT_ID": JSON.stringify(WORKOS_CLIENT_ID),
 		"process.env.LINEAR_CLIENT_ID": JSON.stringify(LINEAR_CLIENT_ID),
+		"process.env.ZUSE_POSTHOG_KEY": JSON.stringify(ZUSE_POSTHOG_KEY),
+		"process.env.ZUSE_POSTHOG_HOST": JSON.stringify(ZUSE_POSTHOG_HOST),
+		"process.env.ZUSE_POSTHOG_ENABLE_DEV": JSON.stringify(
+			ZUSE_POSTHOG_ENABLE_DEV,
+		),
+		"process.env.NODE_ENV": JSON.stringify(NODE_ENV),
 	},
 	// Workspace packages ship as raw .ts source — bundle them in instead of
 	// letting Node try to require() the .ts file at runtime.

--- a/apps/renderer/vite.config.ts
+++ b/apps/renderer/vite.config.ts
@@ -28,6 +28,7 @@ const fontPkgPath = require.resolve("@fontsource-variable/inter/package.json");
 const bunStoreRoot = dirname(dirname(dirname(dirname(dirname(fontPkgPath)))));
 
 export default defineConfig({
+	envDir: resolve(__dirname, "../.."),
 	define: {
 		"import.meta.env.VITE_APP_VERSION": JSON.stringify(desktopPackage.version),
 	},

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.15.7",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Fix analytics configuration across build modes"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.15.6",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/docs/specs/analytics.md
+++ b/docs/specs/analytics.md
@@ -4,6 +4,18 @@ Zuse Alpha collects default-on, pseudonymous product and reliability analytics f
 
 The implementation uses one production project and platform-specific public ingest keys. Development and tests are disabled unless an explicit test project is configured. Operations credentials are restricted to `scripts/provision-analytics.mjs` and must never be included in an app bundle.
 
+## Development
+
+Copy `.env.analytics.example` to the ignored root `.env`, add the public ingest
+keys, and set the matching `*_POSTHOG_ENABLE_DEV` values to `1`. Desktop
+development uses `ZUSE_POSTHOG_*` for backend events and `VITE_POSTHOG_*` for
+renderer events. For local Expo development, copy the same values into the
+ignored `apps/mobile/.env`; mobile uses `EXPO_PUBLIC_POSTHOG_*`.
+
+Leave the development flags at `0` when a developer should not send local
+activity. Production builds enable delivery from their build mode and do not
+depend on these flags.
+
 ## Privacy boundary
 
 Allowed events and properties are versioned in `packages/analytics`. Unknown events and properties are discarded. Known catalog models may use their normalized ID; custom models are recorded as `custom`. Tools are limited to `browser`, `shell`, `files`, `git`, `mcp`, `subagent`, and `other`.

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
 		"discord:enhance": "node --env-file=.env scripts/enhance-discord-community.mjs",
 		"discord:enhance:dry-run": "node --env-file=.env scripts/enhance-discord-community.mjs --dry-run",
 		"rebuild:pty": "cd apps/desktop && electron-rebuild -f -w node-pty",
-		"dist:mac": "bun run build:desktop && cd apps/desktop && bun run dist:mac",
-		"dist:mac:unsigned": "bun run build:desktop && cd apps/desktop && bun run dist:mac:unsigned"
+		"dist:mac": "NODE_ENV=production bun run build:desktop && cd apps/desktop && bun run dist:mac",
+		"dist:mac:unsigned": "NODE_ENV=production bun run build:desktop && cd apps/desktop && bun run dist:mac:unsigned"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",

--- a/scripts/check-renderer-bundle.mjs
+++ b/scripts/check-renderer-bundle.mjs
@@ -4,6 +4,21 @@ import { gzipSync } from "node:zlib";
 
 const dist = resolve(import.meta.dirname, "../apps/renderer/dist");
 const html = readFileSync(resolve(dist, "index.html"), "utf8");
+const expectedAnalyticsKey = process.env.VITE_POSTHOG_KEY?.trim();
+if (expectedAnalyticsKey) {
+	const hasAnalyticsKey = readdirSync(resolve(dist, "assets"))
+		.filter((asset) => asset.endsWith(".js"))
+		.some((asset) =>
+			readFileSync(resolve(dist, "assets", asset), "utf8").includes(
+				expectedAnalyticsKey,
+			),
+		);
+	if (!hasAnalyticsKey) {
+		throw new Error(
+			"Renderer bundle is missing the configured analytics ingest key",
+		);
+	}
+}
 const assets = [...html.matchAll(/(?:src|href)="\.\/([^"?]+\.(?:js|css))"/g)]
 	.map((match) => match[1])
 	.filter((asset, index, all) => all.indexOf(asset) === index);

--- a/turbo.json
+++ b/turbo.json
@@ -14,9 +14,16 @@
 			"env": [
 				"WORKOS_CLIENT_ID",
 				"LINEAR_CLIENT_ID",
+				"NODE_ENV",
 				"ZUSE_POSTHOG_KEY",
+				"ZUSE_POSTHOG_HOST",
+				"ZUSE_POSTHOG_ENABLE_DEV",
 				"VITE_POSTHOG_KEY",
-				"EXPO_PUBLIC_POSTHOG_KEY"
+				"VITE_POSTHOG_HOST",
+				"VITE_POSTHOG_ENABLE_DEV",
+				"EXPO_PUBLIC_POSTHOG_KEY",
+				"EXPO_PUBLIC_POSTHOG_HOST",
+				"EXPO_PUBLIC_POSTHOG_ENABLE_DEV"
 			],
 			"outputs": [".next/**", "!.next/cache/**", "dist/**", "dist-electron/**"]
 		},


### PR DESCRIPTION
## Summary
- release Zuse v0.15.7
- update CHANGELOG.md and package metadata
- keep the website Change Log page rendering release notes from CHANGELOG.md

## Test
- bun run check-types

Release artifacts are produced by pushing tag v0.15.7 after this PR lands.