### PR TITLE
Surface Codex provider status failures

### DIFF
--- a/apps/renderer/src/components/ui/toast.tsx
+++ b/apps/renderer/src/components/ui/toast.tsx
@@ -5,6 +5,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	Alert02Icon,
 	AlertCircleIcon,
+	Cancel01Icon,
 	CheckmarkCircle02Icon,
 	InformationCircleIcon,
 	Loading03Icon,
@@ -165,6 +166,16 @@ function Toasts({
 										{toast.actionProps.children}
 									</Toast.Action>
 								)}
+								<Toast.Close
+									aria-label="Dismiss notification"
+									className="-my-2 -mr-2 flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-offset-2 transition-colors duration-150 ease-out hover:text-foreground focus-visible:outline-2 focus-visible:outline-foreground/60"
+									data-slot="toast-close"
+								>
+									<HugeiconsIcon
+										icon={Cancel01Icon}
+										className="pointer-events-none size-4"
+									/>
+								</Toast.Close>
 							</Toast.Content>
 						</Toast.Root>
 					);

--- a/apps/renderer/src/lib/provider-status.ts
+++ b/apps/renderer/src/lib/provider-status.ts
@@ -33,6 +33,42 @@ export interface ProviderSummary {
   readonly actionable: boolean;
 }
 
+export interface ProviderStatusNotice {
+  readonly key: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+/**
+ * Return a global notice only when the Codex binary exists but its app-server
+ * status probe could not produce a definitive auth result. Install, update,
+ * and sign-in states already have dedicated provider-card treatments.
+ */
+export function getProviderStatusNotice(
+  availability: ReadonlyArray<AgentAvailability>,
+): ProviderStatusNotice | null {
+  const codex = availability.find((item) => item.providerId === "codex");
+  if (
+    codex?.authStatus !== "unknown" ||
+    codex.statusMessage === undefined ||
+    codex.statusMessage.trim().length === 0
+  ) {
+    return null;
+  }
+
+  const statusMessage = codex.statusMessage.trim();
+  const description = /tim(?:e|ed) ?out|timeout/i.test(statusMessage)
+    ? "Timed out while checking Codex app-server provider status."
+    : /failed to initialize (?:sqlite )?state runtime/i.test(statusMessage)
+      ? "Codex app-server couldn't initialize local session state. Try again in a moment."
+      : statusMessage;
+  return {
+    key: "codex-provider-status",
+    title: "Codex provider status",
+    description,
+  };
+}
+
 export function isInitialProviderAvailabilityLoading(
   loading: boolean,
   availabilityLoaded: boolean,

--- a/apps/renderer/src/store/providers.ts
+++ b/apps/renderer/src/store/providers.ts
@@ -4,10 +4,11 @@ import type {
   ProviderId,
 } from "@zuse/contracts";
 import { Effect } from "effect";
-import { createAtomStore as create } from "../state/atom-store.ts";
-
+import { toastManager } from "../components/ui/toast.tsx";
 import { formatError } from "../lib/format-error.ts";
+import { getProviderStatusNotice } from "../lib/provider-status.ts";
 import { getRpcClient } from "../lib/rpc-client.ts";
+import { createAtomStore as create } from "../state/atom-store.ts";
 
 // Stable reference for the "no capabilities" case so the `capabilitiesFor`
 // selector doesn't return a fresh array each call (which would churn the
@@ -25,6 +26,29 @@ export const IDLE_PROVIDER_UPDATE_STATE: ProviderUpdateState = {
 };
 
 let pendingAvailabilityLoad: Promise<void> | null = null;
+let activeProviderStatusNotice: string | null = null;
+
+const notifyProviderStatus = (
+  availability: ReadonlyArray<AgentAvailability>,
+): void => {
+  const notice = getProviderStatusNotice(availability);
+  if (notice === null) {
+    activeProviderStatusNotice = null;
+    return;
+  }
+
+  const fingerprint = `${notice.key}:${notice.description}`;
+  if (activeProviderStatusNotice === fingerprint) return;
+  activeProviderStatusNotice = fingerprint;
+  toastManager.add({
+    id: notice.key,
+    type: "error",
+    priority: "high",
+    timeout: 8_000,
+    title: notice.title,
+    description: notice.description,
+  });
+};
 
 /**
  * Renderer-side cache of provider availability + the credentials sheet
@@ -90,6 +114,7 @@ export const useProvidersStore = create<ProvidersState>((set, get) => ({
         client["provider.availability"]({ refresh: force }),
       );
       set({ availability: list, loading: false, availabilityLoaded: true });
+      notifyProviderStatus(list);
     } catch (err) {
       set({ error: formatError(err), loading: false });
     }

--- a/apps/renderer/test/unit/provider-status.test.ts
+++ b/apps/renderer/test/unit/provider-status.test.ts
@@ -6,13 +6,22 @@ const rpc = vi.hoisted(() => ({
 	availability: vi.fn(),
 }));
 
+const toast = vi.hoisted(() => ({
+	add: vi.fn(),
+}));
+
 vi.mock("../../src/lib/rpc-client.ts", () => ({
 	getRpcClient: async () => ({
 		"provider.availability": rpc.availability,
 	}),
 }));
 
+vi.mock("../../src/components/ui/toast.tsx", () => ({
+	toastManager: toast,
+}));
+
 import {
+	getProviderStatusNotice,
 	getProviderSummary,
 	isInitialProviderAvailabilityLoading,
 } from "../../src/lib/provider-status.ts";
@@ -75,6 +84,7 @@ describe("provider update state", () => {
 describe("provider availability loading", () => {
 	beforeEach(() => {
 		rpc.availability.mockReset();
+		toast.add.mockReset();
 		useProvidersStore.setState({
 			availability: [],
 			loading: false,
@@ -104,6 +114,33 @@ describe("provider availability loading", () => {
 		expect(rpc.availability).toHaveBeenCalledWith({ refresh: true });
 	});
 
+	it("notifies when the Codex app-server status probe times out", async () => {
+		rpc.availability.mockReturnValue(
+			Effect.succeed([
+				{
+					...availabilityFor("codex", "Codex"),
+					cliLoggedIn: false,
+					authStatus: "unknown",
+					status: "warning",
+					statusMessage: "timeout waiting for child process to exit",
+				},
+			]),
+		);
+
+		await useProvidersStore.getState().refresh();
+		await useProvidersStore.getState().refresh();
+
+		expect(toast.add).toHaveBeenCalledWith({
+			id: "codex-provider-status",
+			type: "error",
+			priority: "high",
+			timeout: 8_000,
+			title: "Codex provider status",
+			description: "Timed out while checking Codex app-server provider status.",
+		});
+		expect(toast.add).toHaveBeenCalledTimes(1);
+	});
+
 	it("only treats global loading as card loading before availability has loaded", () => {
 		expect(isInitialProviderAvailabilityLoading(true, false)).toBe(true);
 		expect(isInitialProviderAvailabilityLoading(true, true)).toBe(false);
@@ -131,6 +168,52 @@ describe("provider availability loading", () => {
 
 		expect(summary.statusKey).toBe("loading");
 		expect(summary.headline).toBe("Checking…");
+	});
+});
+
+describe("provider status notice", () => {
+	it("does not report a healthy Codex provider", () => {
+		expect(
+			getProviderStatusNotice([availabilityFor("codex", "Codex")]),
+		).toBeNull();
+	});
+
+	it("preserves a non-timeout Codex probe failure", () => {
+		expect(
+			getProviderStatusNotice([
+				{
+					...availabilityFor("codex", "Codex"),
+					cliLoggedIn: false,
+					authStatus: "unknown",
+					status: "warning",
+					statusMessage: "Codex app-server exited before replying.",
+				},
+			]),
+		).toEqual({
+			key: "codex-provider-status",
+			title: "Codex provider status",
+			description: "Codex app-server exited before replying.",
+		});
+	});
+
+	it("explains a local Codex state initialization failure", () => {
+		expect(
+			getProviderStatusNotice([
+				{
+					...availabilityFor("codex", "Codex"),
+					cliLoggedIn: false,
+					authStatus: "unknown",
+					status: "warning",
+					statusMessage:
+						"failed to initialize sqlite state runtime under /Users/example/.codex",
+				},
+			]),
+		).toEqual({
+			key: "codex-provider-status",
+			title: "Codex provider status",
+			description:
+				"Codex app-server couldn't initialize local session state. Try again in a moment.",
+		});
 	});
 });
 


### PR DESCRIPTION
## What changed

- show a high-priority, deduplicated toast when the Codex app-server provider probe cannot determine status
- translate timeout and local state initialization failures into concise user-facing messages
- add an accessible dismiss control to standard notifications
- cover healthy, timeout, local-state, fallback, and duplicate-refresh behavior with regression tests

## Why

Provider availability failures were stored in renderer state but only surfaced inside provider settings. When Codex session startup or its status probe failed, users could experience an apparently unresponsive new-session flow without visible feedback.

The notice remains factual and does not claim an upstream outage. It distinguishes a provider-status timeout from a local app-server state initialization failure.

## Impact

Users now receive actionable feedback when Codex cannot be checked, while healthy providers remain silent and repeated refreshes do not spam notifications.

## Validation

- renderer type check
- renderer unit suite: 242 tests passed
- Biome lint/static checks on changed files
- live Electron visual and accessibility-tree verification