### PR TITLE
Add one-command remote workspaces

### DIFF
--- a/apps/mobile/src/auth/config.ts
+++ b/apps/mobile/src/auth/config.ts
@@ -7,7 +7,7 @@
 export const WORKOS_API = "https://api.workos.com";
 
 export const workosClientId = (): string =>
-  process.env.EXPO_PUBLIC_WORKOS_CLIENT_ID ?? "";
+  process.env.EXPO_PUBLIC_WORKOS_CLIENT_ID ?? WORKOS_PUBLIC_CLIENT_ID;
 
 export const relayBaseUrl = (): string =>
   (process.env.EXPO_PUBLIC_ZUSE_RELAY_URL ?? "https://relay.stuff.md").replace(
@@ -17,3 +17,4 @@ export const relayBaseUrl = (): string =>
 
 /** App deep-link scheme (matches app.json `scheme`). */
 export const APP_SCHEME = "zuse";
+import { WORKOS_PUBLIC_CLIENT_ID } from "@zuse/contracts";

--- a/apps/renderer/src/components/browser-access-gate.tsx
+++ b/apps/renderer/src/components/browser-access-gate.tsx
@@ -1,4 +1,9 @@
+import {
+	environmentRoute,
+	parseEnvironmentRoute,
+} from "@zuse/client-runtime/environment-scope";
 import type { ConnectionSnapshot } from "@zuse/client-runtime/supervisor";
+import type { RelayEnvironmentRecord } from "@zuse/contracts";
 import {
 	type ReactNode,
 	useCallback,
@@ -11,6 +16,15 @@ import {
 	BrowserSessionError,
 	createBrowserSessionConnection,
 } from "../lib/browser-session.ts";
+import {
+	beginHostedSignIn,
+	completeHostedSignIn,
+	connectHostedEnvironment,
+	hostedSignedIn,
+	isHostedProduct,
+	listHostedEnvironments,
+	registerHostedClient,
+} from "../lib/hosted-connect.ts";
 import { rendererPlatformCapabilities } from "../lib/platform-capabilities.ts";
 import {
 	retryRendererRpcConnection,
@@ -26,6 +40,16 @@ type AccessState =
 			readonly description: string;
 			readonly retryable: boolean;
 	  };
+
+type HostedAccessState =
+	| { readonly status: "loading" }
+	| { readonly status: "signedOut" }
+	| {
+			readonly status: "select";
+			readonly environments: ReadonlyArray<RelayEnvironmentRecord>;
+	  }
+	| { readonly status: "ready" }
+	| { readonly status: "error"; readonly description: string };
 
 const errorCopy = (
 	cause: unknown,
@@ -142,7 +166,174 @@ function ConnectionBanner() {
 	);
 }
 
-export function BrowserAccessGate({
+function HostedAccessCard({
+	state,
+	retry,
+}: {
+	readonly state: Exclude<HostedAccessState, { readonly status: "ready" }>;
+	readonly retry: () => void;
+}) {
+	const title =
+		state.status === "loading"
+			? "Opening Zuse…"
+			: state.status === "signedOut"
+				? "Your computers, anywhere"
+				: state.status === "select"
+					? "Choose a computer"
+					: "Could not open this computer";
+	return (
+		<div className="flex min-h-dvh w-full items-center justify-center bg-background px-4 py-8 text-foreground">
+			<main
+				aria-busy={state.status === "loading"}
+				aria-live="polite"
+				className="w-full max-w-lg rounded-2xl border border-border/70 bg-card p-5 shadow-sm sm:p-6"
+			>
+				<p className="text-sm font-medium text-muted-foreground">Zuse</p>
+				<h1 className="mt-2 text-xl font-semibold">{title}</h1>
+				{state.status === "loading" ? (
+					<p className="mt-2 text-sm leading-6 text-muted-foreground">
+						Signing in and finding your served computers.
+					</p>
+				) : null}
+				{state.status === "signedOut" ? (
+					<>
+						<p className="mt-2 text-sm leading-6 text-muted-foreground">
+							Sign in to see and securely control the computers linked to your
+							account.
+						</p>
+						<button
+							className="mt-5 min-h-11 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							onClick={() => void beginHostedSignIn()}
+							type="button"
+						>
+							Sign in
+						</button>
+					</>
+				) : null}
+				{state.status === "select" ? (
+					<div className="mt-4 flex flex-col gap-2">
+						{state.environments.map((environment) => {
+							const online =
+								environment.lastHeartbeat !== undefined &&
+								Date.now() - environment.lastHeartbeat <= 90_000;
+							return (
+								<button
+									className="flex min-h-11 items-center gap-3 rounded-xl border border-border/70 px-3 py-2 text-left outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+									key={environment.environmentId}
+									onClick={() =>
+										window.location.assign(
+											environmentRoute(environment.environmentId),
+										)
+									}
+									type="button"
+								>
+									<span
+										aria-hidden="true"
+										className={`size-2.5 shrink-0 rounded-full ${
+											online ? "bg-emerald-500" : "bg-muted-foreground/35"
+										}`}
+									/>
+									<span className="min-w-0 flex-1">
+										<span className="block truncate text-sm font-medium">
+											{environment.label ?? "Unnamed computer"}
+										</span>
+										<span className="block truncate text-xs text-muted-foreground">
+											{online ? "Online" : "Offline"}
+											{environment.runtimeVersion
+												? ` · v${environment.runtimeVersion}`
+												: ""}
+										</span>
+									</span>
+								</button>
+							);
+						})}
+						{state.environments.length === 0 ? (
+							<p className="rounded-xl bg-muted px-3 py-4 text-sm text-muted-foreground">
+								No computers are served yet. Run <code>npx @zusehq/serve</code>{" "}
+								on a computer first.
+							</p>
+						) : null}
+					</div>
+				) : null}
+				{state.status === "error" ? (
+					<>
+						<p className="mt-2 text-sm leading-6 text-muted-foreground">
+							{state.description}
+						</p>
+						<button
+							className="mt-5 min-h-11 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							onClick={retry}
+							type="button"
+						>
+							Try again
+						</button>
+					</>
+				) : null}
+			</main>
+		</div>
+	);
+}
+
+function HostedAccessGate({ children }: { readonly children: ReactNode }) {
+	const [state, setState] = useState<HostedAccessState>({
+		status: "loading",
+	});
+	const connect = useCallback(async () => {
+		setState({ status: "loading" });
+		try {
+			await completeHostedSignIn();
+			if (!(await hostedSignedIn())) {
+				setState({ status: "signedOut" });
+				return;
+			}
+			const catalog = await listHostedEnvironments();
+			const route = parseEnvironmentRoute(window.location.pathname);
+			if (route === null) {
+				setState({ status: "select", environments: catalog.environments });
+				return;
+			}
+			const target = catalog.environments.find(
+				(environment) => environment.environmentId === route.environmentId,
+			);
+			if (target === undefined) {
+				setState({
+					status: "error",
+					description:
+						"This computer is not linked to your account. It may have been removed.",
+				});
+				return;
+			}
+			await registerHostedClient();
+			await connectHostedEnvironment(route.environmentId);
+			setState({ status: "ready" });
+		} catch (cause) {
+			const reason = cause instanceof Error ? cause.message : String(cause);
+			setState({
+				status: "error",
+				description:
+					reason === "computer_limit_reached"
+						? "This account has reached its served-computer limit."
+						: reason === "version_incompatible"
+							? "This computer needs a Zuse Serve update before it can connect."
+							: "Check that the computer is online, then try again.",
+			});
+		}
+	}, []);
+	useEffect(() => {
+		void connect();
+	}, [connect]);
+	if (state.status !== "ready") {
+		return <HostedAccessCard retry={() => void connect()} state={state} />;
+	}
+	return (
+		<>
+			{children}
+			<ConnectionBanner />
+		</>
+	);
+}
+
+function DirectBrowserAccessGate({
 	children,
 }: {
 	readonly children: ReactNode;
@@ -186,5 +377,17 @@ export function BrowserAccessGate({
 			{children}
 			{!rendererPlatformCapabilities().desktop && <ConnectionBanner />}
 		</>
+	);
+}
+
+export function BrowserAccessGate({
+	children,
+}: {
+	readonly children: ReactNode;
+}) {
+	return isHostedProduct() ? (
+		<HostedAccessGate>{children}</HostedAccessGate>
+	) : (
+		<DirectBrowserAccessGate>{children}</DirectBrowserAccessGate>
 	);
 }

--- a/apps/renderer/src/components/computer-switcher.tsx
+++ b/apps/renderer/src/components/computer-switcher.tsx
@@ -1,0 +1,184 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	ArrowDown01Icon,
+	ComputerIcon,
+} from "@hugeicons-pro/core-solid-rounded";
+import {
+	environmentRoute,
+	parseEnvironmentRoute,
+} from "@zuse/client-runtime/environment-scope";
+import type { RelayEnvironmentRecord } from "@zuse/contracts";
+import { Effect } from "effect";
+import { useEffect, useMemo, useState } from "react";
+
+import { getRpcClient } from "../lib/rpc-client.ts";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu.tsx";
+
+const APP_URL = "https://app.zuse.sh";
+const ONLINE_WINDOW_MS = 90_000;
+
+const routeEnvironmentId = (): string | null => {
+	return parseEnvironmentRoute(window.location.pathname)?.environmentId ?? null;
+};
+
+const relativeTime = (timestamp: number | undefined): string => {
+	if (timestamp === undefined) return "Never seen";
+	const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1_000));
+	if (seconds < 60) return "Just now";
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	return `${Math.round(hours / 24)}d ago`;
+};
+
+const openEnvironment = (environmentId: string): void => {
+	const url = `${APP_URL}${environmentRoute(environmentId)}`;
+	if (window.location.origin === APP_URL) {
+		window.location.assign(url);
+		return;
+	}
+	const bridge = window.zuse?.app;
+	if (bridge !== undefined) {
+		bridge.openExternal(url);
+		return;
+	}
+	window.open(url, "_blank", "noopener,noreferrer");
+};
+
+export function ComputerSwitcher() {
+	const [environments, setEnvironments] = useState<
+		ReadonlyArray<RelayEnvironmentRecord>
+	>([]);
+	const [localEnvironmentId, setLocalEnvironmentId] = useState<string | null>(
+		null,
+	);
+	const [failed, setFailed] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		const refresh = async () => {
+			try {
+				const client = await getRpcClient();
+				const [status, catalog] = await Promise.all([
+					Effect.runPromise(client["relay.status"]()),
+					Effect.runPromise(client["relay.environments"]()),
+				]);
+				if (cancelled) return;
+				setLocalEnvironmentId(status.environmentId ?? null);
+				setEnvironments(catalog.environments);
+				setFailed(false);
+			} catch {
+				if (!cancelled) setFailed(true);
+			}
+		};
+		void refresh();
+		const timer = window.setInterval(refresh, 30_000);
+		return () => {
+			cancelled = true;
+			window.clearInterval(timer);
+		};
+	}, []);
+
+	const selectedId = routeEnvironmentId() ?? localEnvironmentId;
+	const selected = useMemo(
+		() =>
+			environments.find(
+				(environment) => environment.environmentId === selectedId,
+			) ?? null,
+		[environments, selectedId],
+	);
+
+	if (failed && environments.length === 0) return null;
+
+	return (
+		<div className="border-b border-sidebar-border/40 px-2 py-2">
+			<Menu>
+				<MenuTrigger
+					aria-label="Switch computer"
+					className="flex min-h-11 w-full items-center gap-2 rounded-lg px-2 text-left outline-none transition-colors hover:bg-sidebar-accent/60 focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+				>
+					<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-accent text-sidebar-accent-foreground">
+						<HugeiconsIcon icon={ComputerIcon} className="size-4" />
+					</span>
+					<span className="min-w-0 flex-1">
+						<span className="block truncate text-xs font-medium">
+							{selected?.label ?? "This computer"}
+						</span>
+						<span className="block truncate text-[10px] text-muted-foreground">
+							{selected === null
+								? "Local workspace"
+								: selected.lastHeartbeat !== undefined &&
+										Date.now() - selected.lastHeartbeat <= ONLINE_WINDOW_MS
+									? "Online"
+									: `Offline · ${relativeTime(selected.lastHeartbeat)}`}
+						</span>
+					</span>
+					<HugeiconsIcon
+						aria-hidden="true"
+						icon={ArrowDown01Icon}
+						className="size-3.5 text-muted-foreground"
+					/>
+				</MenuTrigger>
+				<MenuPopup
+					align="start"
+					className="w-[min(22rem,calc(100vw-1rem))]"
+					side="bottom"
+				>
+					<div className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">
+						Computers
+					</div>
+					{environments.map((environment) => {
+						const online =
+							environment.lastHeartbeat !== undefined &&
+							Date.now() - environment.lastHeartbeat <= ONLINE_WINDOW_MS;
+						const active = environment.environmentId === selectedId;
+						return (
+							<MenuItem
+								className="min-h-11 items-start py-2"
+								key={environment.environmentId}
+								onClick={() =>
+									active
+										? undefined
+										: openEnvironment(environment.environmentId)
+								}
+							>
+								<span
+									aria-hidden="true"
+									className={`mt-1.5 size-2 shrink-0 rounded-full ${
+										online ? "bg-emerald-500" : "bg-muted-foreground/35"
+									}`}
+								/>
+								<span className="min-w-0 flex-1">
+									<span className="flex items-center gap-2">
+										<span className="truncate font-medium">
+											{environment.label ?? "Unnamed computer"}
+										</span>
+										{active ? (
+											<span className="text-[10px] text-muted-foreground">
+												Current
+											</span>
+										) : null}
+									</span>
+									<span className="block truncate text-[11px] text-muted-foreground">
+										{online
+											? "Online"
+											: relativeTime(environment.lastHeartbeat)}
+										{environment.runtimeVersion
+											? ` · v${environment.runtimeVersion}`
+											: ""}
+									</span>
+								</span>
+							</MenuItem>
+						);
+					})}
+					{environments.length === 0 ? (
+						<div className="px-2 py-3 text-xs text-muted-foreground">
+							No served computers are linked to this account yet.
+						</div>
+					) : null}
+				</MenuPopup>
+			</Menu>
+		</div>
+	);
+}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -51,6 +51,7 @@ import {
 	mergeChatAttentionStates,
 } from "~/lib/chat-attention-state";
 import { displayPath } from "~/lib/display-path";
+import { isHostedProduct, signOutHostedProduct } from "~/lib/hosted-connect.ts";
 import { cn, formatCompactNumber } from "~/lib/utils";
 import { dispatchCommand } from "../lib/commands.ts";
 import { noteSessionStatusForCompletionSound } from "../lib/completion-sounds.ts";
@@ -77,6 +78,7 @@ import { useUiStore } from "../store/ui.ts";
 import { useUsageLimitsStore } from "../store/usage-limits.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { BranchIcon, type BranchState } from "./branch-icon.tsx";
+import { ComputerSwitcher } from "./computer-switcher.tsx";
 import { ProjectAddMenu } from "./project-add-menu.tsx";
 import { RenameDialog } from "./rename-dialog.tsx";
 import { AgentActivityOrb } from "./ui/agent-activity-orb.tsx";
@@ -91,7 +93,9 @@ const sidebarErrorToastCache = {
 const initialsOf = (name: string): string => {
 	const parts = name.split(/[-_.\s]+/).filter(Boolean);
 	const letters =
-		parts.length >= 2 ? parts[0]![0]! + parts[1]![0]! : name.slice(0, 2);
+		parts.length >= 2
+			? `${parts[0]?.charAt(0) ?? ""}${parts[1]?.charAt(0) ?? ""}`
+			: name.slice(0, 2);
 	return letters.toUpperCase();
 };
 
@@ -426,6 +430,7 @@ export function ProjectsSidebar() {
 			tabIndex={-1}
 			className="flex h-full min-h-0 w-full flex-col bg-sidebar text-sidebar-foreground outline-none"
 		>
+			<ComputerSwitcher />
 			<SidebarActions />
 			<div className="flex items-center justify-between px-3 py-2 text-xs text-muted-foreground">
 				<span>Projects</span>
@@ -535,6 +540,34 @@ function SidebarAccount() {
 	// is fine and far better than showing nothing.
 	const initial = (name || user?.email || "?").charAt(0).toUpperCase();
 	const nameIsEmail = Boolean(user?.email && name === user.email);
+	if (isHostedProduct()) {
+		return (
+			<Menu>
+				<MenuTrigger
+					render={
+						<button
+							type="button"
+							className="flex min-h-11 w-full items-center gap-2 rounded-lg px-2 text-[11px] text-muted-foreground outline-none hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							<HugeiconsIcon icon={UserCircleIcon} className="size-4" />
+							<span className="min-w-0 flex-1 truncate text-left">
+								Zuse account
+							</span>
+						</button>
+					}
+				/>
+				<MenuPopup side="top" align="start" className="w-56">
+					<MenuItem
+						variant="destructive"
+						onClick={() => void signOutHostedProduct()}
+					>
+						<HugeiconsIcon icon={Logout01Icon} />
+						Sign out of this browser
+					</MenuItem>
+				</MenuPopup>
+			</Menu>
+		);
+	}
 
 	return (
 		<Menu>

--- a/apps/renderer/src/lib/browser-session.ts
+++ b/apps/renderer/src/lib/browser-session.ts
@@ -114,6 +114,14 @@ export const logoutBrowserSession = (): Promise<BrowserSessionStatus> =>
 	jsonRequest<BrowserSessionStatus>("/auth/logout", { method: "POST" });
 
 export const requestBrowserWebSocketUrl = async (): Promise<string> => {
+	const { hostedRpcEndpoint, isHostedProduct } = await import(
+		"./hosted-connect.ts"
+	);
+	if (isHostedProduct()) {
+		const endpoint = hostedRpcEndpoint();
+		if (endpoint === null) throw new Error("hosted_environment_not_selected");
+		return endpoint;
+	}
 	const result = await jsonRequest<{
 		readonly ticket: string;
 	}>("/auth/websocket-ticket", { method: "POST" });

--- a/apps/renderer/src/lib/hosted-connect.ts
+++ b/apps/renderer/src/lib/hosted-connect.ts
@@ -1,0 +1,454 @@
+import {
+	type RelayConnectGrant,
+	type RelayEnvironmentList,
+	RelayPaths,
+	WIRE_PROTOCOL_VERSION,
+	WORKOS_PUBLIC_CLIENT_ID,
+} from "@zuse/contracts";
+
+const WORKOS_API = "https://api.workos.com";
+const SESSION_KEY = "zuse.hosted.session.v1";
+const PKCE_KEY = "zuse.hosted.pkce.v1";
+const DEVICE_ID_KEY = "zuse.hosted.device-id.v1";
+const DPOP_DATABASE = "zuse-hosted-device";
+const DPOP_STORE = "keys";
+const DPOP_KEY = "account";
+
+type HostedSession = {
+	readonly accessToken: string;
+	readonly refreshToken: string;
+	readonly expiresAt: number;
+};
+
+type StoredDpopKey = {
+	readonly privateKey: CryptoKey;
+	readonly publicJwk: JsonWebKey;
+};
+
+let rpcEndpoint: string | null = null;
+let relayAccess: { readonly token: string; readonly expiresAt: number } | null =
+	null;
+
+const environment = (): Record<string, string | undefined> =>
+	(import.meta as { readonly env?: Record<string, string | undefined> }).env ??
+	{};
+
+export const isHostedProduct = (): boolean =>
+	environment().VITE_ZUSE_HOSTED === "1" ||
+	window.location.hostname === "app.zuse.sh";
+
+const clientId = (): string =>
+	environment().VITE_WORKOS_CLIENT_ID?.trim() || WORKOS_PUBLIC_CLIENT_ID;
+const relayUrl = (): string =>
+	(
+		environment().VITE_ZUSE_RELAY_URL?.trim() || "https://relay.stuff.md"
+	).replace(/\/$/u, "");
+
+const base64url = (input: Uint8Array): string => {
+	let raw = "";
+	for (const byte of input) raw += String.fromCharCode(byte);
+	return btoa(raw)
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replaceAll("=", "");
+};
+
+const randomBase64url = (bytes: number): string => {
+	const value = new Uint8Array(bytes);
+	crypto.getRandomValues(value);
+	return base64url(value);
+};
+
+const sha256 = async (value: string): Promise<string> =>
+	base64url(
+		new Uint8Array(
+			await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)),
+		),
+	);
+
+const jwtExpiry = (token: string): number => {
+	try {
+		const encoded = token.split(".")[1];
+		if (encoded === undefined) return Date.now() + 5 * 60_000;
+		const normalized = encoded.replaceAll("-", "+").replaceAll("_", "/");
+		const payload = JSON.parse(atob(normalized)) as { readonly exp?: unknown };
+		return typeof payload.exp === "number"
+			? payload.exp * 1_000
+			: Date.now() + 5 * 60_000;
+	} catch {
+		return Date.now() + 5 * 60_000;
+	}
+};
+
+const readSession = (): HostedSession | null => {
+	try {
+		const raw = sessionStorage.getItem(SESSION_KEY);
+		if (raw === null) return null;
+		const value = JSON.parse(raw) as Partial<HostedSession>;
+		return typeof value.accessToken === "string" &&
+			typeof value.refreshToken === "string" &&
+			typeof value.expiresAt === "number"
+			? (value as HostedSession)
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+const writeSession = (session: HostedSession): HostedSession => {
+	sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+	return session;
+};
+
+const authenticate = async (
+	body: Record<string, string>,
+): Promise<HostedSession> => {
+	const response = await fetch(`${WORKOS_API}/user_management/authenticate`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+		signal: AbortSignal.timeout(15_000),
+	});
+	const value = (await response.json().catch(() => ({}))) as {
+		readonly access_token?: unknown;
+		readonly refresh_token?: unknown;
+		readonly error?: unknown;
+	};
+	if (
+		!response.ok ||
+		typeof value.access_token !== "string" ||
+		typeof value.refresh_token !== "string"
+	) {
+		throw new Error(
+			typeof value.error === "string"
+				? value.error
+				: `workos_auth_${response.status}`,
+		);
+	}
+	return writeSession({
+		accessToken: value.access_token,
+		refreshToken: value.refresh_token,
+		expiresAt: jwtExpiry(value.access_token),
+	});
+};
+
+export const beginHostedSignIn = async (): Promise<void> => {
+	const configuredClientId = clientId();
+	if (configuredClientId.length === 0) {
+		throw new Error("hosted_auth_not_configured");
+	}
+	const verifier = randomBase64url(32);
+	const state = randomBase64url(16);
+	const returnPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+	sessionStorage.setItem(
+		PKCE_KEY,
+		JSON.stringify({ verifier, state, returnPath }),
+	);
+	const url = new URL(`${WORKOS_API}/user_management/authorize`);
+	url.searchParams.set("client_id", configuredClientId);
+	url.searchParams.set(
+		"redirect_uri",
+		`${window.location.origin}/auth/callback`,
+	);
+	url.searchParams.set("response_type", "code");
+	url.searchParams.set("provider", "authkit");
+	url.searchParams.set("code_challenge", await sha256(verifier));
+	url.searchParams.set("code_challenge_method", "S256");
+	url.searchParams.set("state", state);
+	window.location.assign(url.toString());
+};
+
+export const completeHostedSignIn = async (): Promise<boolean> => {
+	if (window.location.pathname !== "/auth/callback") return false;
+	const query = new URLSearchParams(window.location.search);
+	const code = query.get("code");
+	const returnedState = query.get("state");
+	const raw = sessionStorage.getItem(PKCE_KEY);
+	if (code === null || returnedState === null || raw === null) {
+		throw new Error("hosted_auth_callback_invalid");
+	}
+	const pending = JSON.parse(raw) as {
+		readonly verifier?: unknown;
+		readonly state?: unknown;
+		readonly returnPath?: unknown;
+	};
+	if (typeof pending.verifier !== "string" || pending.state !== returnedState) {
+		throw new Error("hosted_auth_state_mismatch");
+	}
+	await authenticate({
+		client_id: clientId(),
+		grant_type: "authorization_code",
+		code,
+		code_verifier: pending.verifier,
+	});
+	sessionStorage.removeItem(PKCE_KEY);
+	const returnPath =
+		typeof pending.returnPath === "string" &&
+		pending.returnPath.startsWith("/") &&
+		!pending.returnPath.startsWith("//")
+			? pending.returnPath
+			: "/";
+	window.history.replaceState(null, "", returnPath);
+	return true;
+};
+
+const accessToken = async (): Promise<string | null> => {
+	const session = readSession();
+	if (session === null) return null;
+	if (session.expiresAt - Date.now() > 60_000) return session.accessToken;
+	try {
+		return (
+			await authenticate({
+				client_id: clientId(),
+				grant_type: "refresh_token",
+				refresh_token: session.refreshToken,
+			})
+		).accessToken;
+	} catch {
+		sessionStorage.removeItem(SESSION_KEY);
+		return null;
+	}
+};
+
+const openDpopDatabase = (): Promise<IDBDatabase> =>
+	new Promise((resolve, reject) => {
+		const request = indexedDB.open(DPOP_DATABASE, 1);
+		request.onupgradeneeded = () => {
+			request.result.createObjectStore(DPOP_STORE);
+		};
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+
+const readDpopKey = async (): Promise<StoredDpopKey | null> => {
+	const db = await openDpopDatabase();
+	try {
+		return await new Promise((resolve, reject) => {
+			const request = db
+				.transaction(DPOP_STORE, "readonly")
+				.objectStore(DPOP_STORE)
+				.get(DPOP_KEY);
+			request.onsuccess = () =>
+				resolve((request.result as StoredDpopKey | undefined) ?? null);
+			request.onerror = () => reject(request.error);
+		});
+	} finally {
+		db.close();
+	}
+};
+
+const writeDpopKey = async (key: StoredDpopKey): Promise<void> => {
+	const db = await openDpopDatabase();
+	try {
+		await new Promise<void>((resolve, reject) => {
+			const request = db
+				.transaction(DPOP_STORE, "readwrite")
+				.objectStore(DPOP_STORE)
+				.put(key, DPOP_KEY);
+			request.onsuccess = () => resolve();
+			request.onerror = () => reject(request.error);
+		});
+	} finally {
+		db.close();
+	}
+};
+
+const dpopKey = async (): Promise<StoredDpopKey> => {
+	const existing = await readDpopKey();
+	if (existing !== null) return existing;
+	const generated = await crypto.subtle.generateKey(
+		{ name: "ECDSA", namedCurve: "P-256" },
+		true,
+		["sign", "verify"],
+	);
+	const privateJwk = await crypto.subtle.exportKey("jwk", generated.privateKey);
+	const publicJwk = await crypto.subtle.exportKey("jwk", generated.publicKey);
+	const privateKey = await crypto.subtle.importKey(
+		"jwk",
+		privateJwk,
+		{ name: "ECDSA", namedCurve: "P-256" },
+		false,
+		["sign"],
+	);
+	const stored = { privateKey, publicJwk };
+	await writeDpopKey(stored);
+	return stored;
+};
+
+const signDpopProof = async (input: {
+	readonly method: string;
+	readonly url: string;
+}): Promise<string> => {
+	const key = await dpopKey();
+	const header = base64url(
+		new TextEncoder().encode(
+			JSON.stringify({ alg: "ES256", typ: "dpop+jwt", jwk: key.publicJwk }),
+		),
+	);
+	const payload = base64url(
+		new TextEncoder().encode(
+			JSON.stringify({
+				htm: input.method,
+				htu: input.url,
+				jti: crypto.randomUUID(),
+				iat: Math.floor(Date.now() / 1_000),
+			}),
+		),
+	);
+	const unsigned = `${header}.${payload}`;
+	const signature = await crypto.subtle.sign(
+		{ name: "ECDSA", hash: "SHA-256" },
+		key.privateKey,
+		new TextEncoder().encode(unsigned),
+	);
+	return `${unsigned}.${base64url(new Uint8Array(signature))}`;
+};
+
+const relayFetch = async (
+	path: string,
+	init: {
+		readonly method: "POST";
+		readonly token?: string;
+		readonly body?: unknown;
+	},
+): Promise<Response> => {
+	const target = `${relayUrl()}${path}`;
+	const proof = await signDpopProof({ method: init.method, url: target });
+	const workosToken = init.token === undefined ? await accessToken() : null;
+	if (init.token === undefined && workosToken === null) {
+		throw new Error("hosted_signed_out");
+	}
+	return fetch(target, {
+		method: init.method,
+		headers: {
+			authorization:
+				init.token === undefined
+					? `Bearer ${workosToken}`
+					: `DPoP ${init.token}`,
+			dpop: proof,
+			...(init.body === undefined
+				? {}
+				: { "content-type": "application/json" }),
+		},
+		body: init.body === undefined ? undefined : JSON.stringify(init.body),
+	});
+};
+
+const ensureRelayAccess = async (): Promise<string> => {
+	if (relayAccess !== null && relayAccess.expiresAt - Date.now() > 60_000) {
+		return relayAccess.token;
+	}
+	const response = await relayFetch(RelayPaths.dpopToken, { method: "POST" });
+	const body = (await response.json().catch(() => ({}))) as {
+		readonly accessToken?: unknown;
+		readonly expiresIn?: unknown;
+		readonly error?: unknown;
+	};
+	if (!response.ok || typeof body.accessToken !== "string") {
+		throw new Error(
+			typeof body.error === "string"
+				? body.error
+				: `relay_token_${response.status}`,
+		);
+	}
+	relayAccess = {
+		token: body.accessToken,
+		expiresAt:
+			Date.now() +
+			(typeof body.expiresIn === "number" ? body.expiresIn : 30 * 60_000),
+	};
+	return relayAccess.token;
+};
+
+export const hostedSignedIn = async (): Promise<boolean> =>
+	(await accessToken()) !== null;
+
+export const listHostedEnvironments =
+	async (): Promise<RelayEnvironmentList> => {
+		const token = await accessToken();
+		if (token === null) throw new Error("hosted_signed_out");
+		const response = await fetch(`${relayUrl()}${RelayPaths.environments}`, {
+			headers: { authorization: `Bearer ${token}` },
+		});
+		if (!response.ok) throw new Error(`relay_environments_${response.status}`);
+		return (await response.json()) as RelayEnvironmentList;
+	};
+
+export const registerHostedClient = async (): Promise<void> => {
+	const token = await ensureRelayAccess();
+	const key = await dpopKey();
+	let deviceId = localStorage.getItem(DEVICE_ID_KEY);
+	if (deviceId === null) {
+		deviceId = crypto.randomUUID();
+		localStorage.setItem(DEVICE_ID_KEY, deviceId);
+	}
+	const target = `${relayUrl()}${RelayPaths.devices}`;
+	const response = await fetch(target, {
+		method: "POST",
+		headers: {
+			authorization: `DPoP ${token}`,
+			dpop: await signDpopProof({ method: "POST", url: target }),
+			"content-type": "application/json",
+		},
+		body: JSON.stringify({
+			deviceId,
+			platform: "web",
+			dpopJwk: key.publicJwk,
+		}),
+	});
+	if (!response.ok) throw new Error(`relay_device_${response.status}`);
+};
+
+export const connectHostedEnvironment = async (
+	environmentId: string,
+): Promise<RelayConnectGrant> => {
+	const token = await ensureRelayAccess();
+	const response = await relayFetch(RelayPaths.connect(environmentId), {
+		method: "POST",
+		token,
+		body: {
+			wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+			requireManaged: window.location.protocol === "https:",
+		},
+	});
+	const body = (await response.json().catch(() => ({}))) as
+		| RelayConnectGrant
+		| { readonly error?: unknown };
+	if (!response.ok || !("connectToken" in body)) {
+		throw new Error(
+			"error" in body && typeof body.error === "string"
+				? body.error
+				: `relay_connect_${response.status}`,
+		);
+	}
+	const url = new URL(body.endpoint.wsBaseUrl);
+	url.searchParams.set("token", body.connectToken);
+	url.searchParams.set("wireVersion", String(WIRE_PROTOCOL_VERSION));
+	rpcEndpoint = url.toString();
+	return body;
+};
+
+export const hostedRpcEndpoint = (): string | null => rpcEndpoint;
+
+export const signOutHostedProduct = async (): Promise<void> => {
+	const token = await accessToken();
+	const deviceId = localStorage.getItem(DEVICE_ID_KEY);
+	if (token !== null && deviceId !== null) {
+		await fetch(`${relayUrl()}${RelayPaths.client(deviceId)}`, {
+			method: "DELETE",
+			headers: { authorization: `Bearer ${token}` },
+		}).catch(() => undefined);
+	}
+	sessionStorage.removeItem(SESSION_KEY);
+	sessionStorage.removeItem(PKCE_KEY);
+	localStorage.removeItem(DEVICE_ID_KEY);
+	relayAccess = null;
+	rpcEndpoint = null;
+	await new Promise<void>((resolve) => {
+		const request = indexedDB.deleteDatabase(DPOP_DATABASE);
+		request.onsuccess = () => resolve();
+		request.onerror = () => resolve();
+		request.onblocked = () => resolve();
+	});
+	window.location.assign("/");
+};

--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -2,6 +2,7 @@ import {
 	makeRpcClientSession,
 	withWireProtocolVersion,
 } from "@zuse/client-runtime/connection";
+import { parseEnvironmentRoute } from "@zuse/client-runtime/environment-scope";
 import {
 	type ConnectionSnapshot,
 	type ConnectionSupervisorEntry,
@@ -28,15 +29,21 @@ type MemoizeClient = RpcClient.RpcClient<
 
 type RendererConnectionOptions =
 	| {
-			readonly key: "renderer";
+			readonly key: string;
 			readonly kind: "electron";
 			readonly bridge: RpcBridge;
 	  }
 	| {
-			readonly key: "renderer";
+			readonly key: string;
 			readonly kind: "websocket";
 			readonly wsUrl: string;
 	  };
+
+const rendererConnectionKey = (): string => {
+	if (typeof location === "undefined") return "environment:local";
+	const route = parseEnvironmentRoute(location.pathname);
+	return `environment:${route?.environmentId ?? "local"}`;
+};
 
 function resolveWebSocketUrl(): string {
 	const env = (
@@ -59,8 +66,12 @@ export function resolveRendererRpcTransportForTest(): {
 const connectionOptions = (): RendererConnectionOptions => {
 	const bridge = globalThis.window?.zuse ?? globalThis.window?.memoize;
 	return bridge
-		? { key: "renderer", kind: "electron", bridge: bridge.rpc }
-		: { key: "renderer", kind: "websocket", wsUrl: resolveWebSocketUrl() };
+		? { key: rendererConnectionKey(), kind: "electron", bridge: bridge.rpc }
+		: {
+				key: rendererConnectionKey(),
+				kind: "websocket",
+				wsUrl: resolveWebSocketUrl(),
+			};
 };
 
 let online = globalThis.navigator?.onLine ?? true;

--- a/apps/renderer/vercel.json
+++ b/apps/renderer/vercel.json
@@ -1,0 +1,11 @@
+{
+	"buildCommand": "cd ../.. && bun run --filter renderer build",
+	"outputDirectory": "dist",
+	"framework": "vite",
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/index.html"
+		}
+	]
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,6 +22,11 @@
 			"import": "./src/runtime.ts",
 			"require": "./src/runtime.ts"
 		},
+		"./serve-cli": {
+			"types": "./src/serve/package-cli.ts",
+			"import": "./dist/serve-cli.mjs",
+			"require": "./dist/serve-cli.mjs"
+		},
 		"./secure-storage-master-key": {
 			"types": "./src/secure-storage-master-key.ts",
 			"import": "./src/secure-storage-master-key.ts",

--- a/apps/server/src/auth/layers/auth-service.ts
+++ b/apps/server/src/auth/layers/auth-service.ts
@@ -4,6 +4,7 @@ import {
   AuthSession,
   type AuthState,
   AuthUser,
+  WORKOS_PUBLIC_CLIENT_ID,
 } from "@zuse/contracts";
 import {
   Deferred,
@@ -44,11 +45,11 @@ const SIGNED_OUT: AuthState = { _tag: "SignedOut" };
 
 /**
  * The build-time WorkOS client id. Public (safe to embed) — inlined by tsdown
- * `define` from `process.env.WORKOS_CLIENT_ID`. Empty when unconfigured, in
- * which case `signIn` fails with a clear message and the rest of the app keeps
- * working (auth is additive).
+ * `define` from `process.env.WORKOS_CLIENT_ID`, with the shared public AuthKit
+ * identifier as the source-mode and Serve fallback.
  */
-const CLIENT_ID = (process.env.WORKOS_CLIENT_ID ?? "").trim();
+const CLIENT_ID =
+  (process.env.WORKOS_CLIENT_ID ?? "").trim() || WORKOS_PUBLIC_CLIENT_ID;
 
 interface PendingSignIn {
   readonly deferred: Deferred.Deferred<SessionBundle, AuthFlowError>;

--- a/apps/server/src/auth/layers/workos-device-auth.ts
+++ b/apps/server/src/auth/layers/workos-device-auth.ts
@@ -1,0 +1,139 @@
+import {
+	type SessionBundle,
+	sessionBundleFromAuthenticateResponse,
+} from "./workos.ts";
+
+const WORKOS_API = "https://api.workos.com";
+const SLOW_DOWN_SECONDS = 5;
+
+export interface DeviceAuthorizationGrant {
+	readonly deviceCode: string;
+	readonly userCode: string;
+	readonly verificationUri: string;
+	readonly verificationUriComplete: string;
+	readonly expiresInSeconds: number;
+	readonly intervalSeconds: number;
+}
+
+interface DeviceAuthorizationOptions {
+	readonly fetcher?: typeof fetch;
+	readonly sleep?: (milliseconds: number) => Promise<void>;
+	readonly now?: () => number;
+}
+
+const expectString = (value: unknown, field: string): string => {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(
+			`WorkOS device authorization response was missing ${field}.`,
+		);
+	}
+	return value;
+};
+
+const expectPositiveNumber = (value: unknown, field: string): number => {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		throw new Error(
+			`WorkOS device authorization response had invalid ${field}.`,
+		);
+	}
+	return value;
+};
+
+const errorCode = (value: unknown): string | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const candidate = (value as { readonly error?: unknown }).error;
+	return typeof candidate === "string" ? candidate : null;
+};
+
+export const requestDeviceAuthorization = async (
+	clientId: string,
+	fetcher: typeof fetch = fetch,
+): Promise<DeviceAuthorizationGrant> => {
+	const response = await fetcher(
+		`${WORKOS_API}/user_management/authorize/device`,
+		{
+			method: "POST",
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({ client_id: clientId }),
+			signal: AbortSignal.timeout(15_000),
+		},
+	);
+	const body = (await response.json()) as unknown;
+	if (!response.ok) {
+		throw new Error(
+			`WorkOS device authorization failed (${response.status}): ${errorCode(body) ?? "unknown_error"}`,
+		);
+	}
+	if (typeof body !== "object" || body === null) {
+		throw new Error("WorkOS device authorization response was not an object.");
+	}
+	const value = body as Record<string, unknown>;
+	return {
+		deviceCode: expectString(value.device_code, "device_code"),
+		userCode: expectString(value.user_code, "user_code"),
+		verificationUri: expectString(value.verification_uri, "verification_uri"),
+		verificationUriComplete: expectString(
+			value.verification_uri_complete,
+			"verification_uri_complete",
+		),
+		expiresInSeconds: expectPositiveNumber(value.expires_in, "expires_in"),
+		intervalSeconds: expectPositiveNumber(value.interval, "interval"),
+	};
+};
+
+const defaultSleep = (milliseconds: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export const pollDeviceAuthorization = async (
+	clientId: string,
+	grant: DeviceAuthorizationGrant,
+	options: DeviceAuthorizationOptions = {},
+): Promise<SessionBundle> => {
+	const fetcher = options.fetcher ?? fetch;
+	const sleep = options.sleep ?? defaultSleep;
+	const now = options.now ?? Date.now;
+	const expiresAt = now() + grant.expiresInSeconds * 1_000;
+	let intervalSeconds = grant.intervalSeconds;
+
+	while (now() < expiresAt) {
+		const response = await fetcher(
+			`${WORKOS_API}/user_management/authenticate`,
+			{
+				method: "POST",
+				headers: { "content-type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					client_id: clientId,
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code: grant.deviceCode,
+				}),
+				signal: AbortSignal.timeout(15_000),
+			},
+		);
+		const body = (await response.json()) as unknown;
+		if (response.ok) {
+			return sessionBundleFromAuthenticateResponse(body);
+		}
+
+		const code = errorCode(body);
+		if (code === "authorization_pending") {
+			await sleep(intervalSeconds * 1_000);
+			continue;
+		}
+		if (code === "slow_down") {
+			intervalSeconds += SLOW_DOWN_SECONDS;
+			await sleep(intervalSeconds * 1_000);
+			continue;
+		}
+		if (code === "access_denied") {
+			throw new Error("Device authorization was denied.");
+		}
+		if (code === "expired_token") {
+			throw new Error("Device authorization expired.");
+		}
+		throw new Error(
+			`WorkOS device authorization failed (${response.status}): ${code ?? "unknown_error"}`,
+		);
+	}
+
+	throw new Error("Device authorization expired.");
+};

--- a/apps/server/src/auth/layers/workos.ts
+++ b/apps/server/src/auth/layers/workos.ts
@@ -211,6 +211,11 @@ const toBundle = (res: WorkosAuthenticateResponse): SessionBundle => ({
   },
 });
 
+/** Normalize the shared WorkOS token response used by browser and CLI auth. */
+export const sessionBundleFromAuthenticateResponse = (
+	value: unknown,
+): SessionBundle => toBundle(parseAuthenticateResponse(value));
+
 const authenticate = (
   body: Record<string, string>,
 ): Effect.Effect<SessionBundle, AuthTokenError> =>

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -195,6 +195,13 @@ export const runHeadlessServer = (
 			onCallbackUrl: () => Effect.void,
 		},
 		lanAuth: { policy, advertisedHost, port, pairingBootstrap },
+		autoRelayLink:
+			process.env.ZUSE_SERVE_AUTO_LINK === "1"
+				? {
+						relayUrl: process.env.ZUSE_RELAY_URL ?? "https://relay.stuff.md",
+						label: process.env.ZUSE_COMPUTER_NAME,
+					}
+				: undefined,
 	});
 
 	NodeRuntime.runMain(

--- a/apps/server/src/relay/cloudflared-install.ts
+++ b/apps/server/src/relay/cloudflared-install.ts
@@ -1,0 +1,155 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+	access,
+	chmod,
+	mkdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const VERSION = "2026.7.2";
+const RELEASE_BASE = `https://github.com/cloudflare/cloudflared/releases/download/${VERSION}`;
+
+export interface CloudflaredAsset {
+	readonly version: typeof VERSION;
+	readonly name: string;
+	readonly sha256: string;
+	readonly archive: boolean;
+}
+
+const ASSETS = {
+	"darwin:x64": {
+		name: "cloudflared-darwin-amd64.tgz",
+		sha256: "a5afb0ba3da859da47bebc9a918d5b196bf7e4aec23589419b46356731bcc75f",
+		archive: true,
+	},
+	"darwin:arm64": {
+		name: "cloudflared-darwin-arm64.tgz",
+		sha256: "0588df58494a6cadd38b9deb6078908a5054063c80784d92fdb8d4a5f3de1c67",
+		archive: true,
+	},
+	"linux:x64": {
+		name: "cloudflared-linux-amd64",
+		sha256: "ec905ea7b7e327ff8abdde8cb64697a2152de74dbcdbf6aec9db8364eb3886cd",
+		archive: false,
+	},
+	"linux:arm64": {
+		name: "cloudflared-linux-arm64",
+		sha256: "405df476437e027fc6d18729a5a77155c0a33a6082aeee60a799a688f3052e66",
+		archive: false,
+	},
+} as const;
+
+export const cloudflaredAsset = (
+	platform: NodeJS.Platform,
+	architecture: string,
+): CloudflaredAsset => {
+	if (platform !== "darwin" && platform !== "linux") {
+		throw new Error(`Unsupported platform for managed tunnel: ${platform}`);
+	}
+	if (architecture !== "x64" && architecture !== "arm64") {
+		throw new Error(
+			`Unsupported architecture for managed tunnel: ${architecture}`,
+		);
+	}
+	return { version: VERSION, ...ASSETS[`${platform}:${architecture}`] };
+};
+
+export const verifySha256 = (contents: Buffer, expected: string): void => {
+	const actual = createHash("sha256").update(contents).digest("hex");
+	if (actual !== expected) {
+		throw new Error(
+			`Managed tunnel binary checksum mismatch (expected ${expected}, got ${actual}).`,
+		);
+	}
+};
+
+const exists = async (path: string): Promise<boolean> => {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const ensurePinnedCloudflared = async (input: {
+	readonly userData: string;
+	readonly fetcher?: typeof fetch;
+	readonly platform?: NodeJS.Platform;
+	readonly architecture?: string;
+}): Promise<string> => {
+	const asset = cloudflaredAsset(
+		input.platform ?? process.platform,
+		input.architecture ?? process.arch,
+	);
+	const installDir = join(
+		input.userData,
+		"runtime",
+		"cloudflared",
+		asset.version,
+	);
+	const target = join(installDir, "cloudflared");
+	const installedChecksum = join(installDir, "cloudflared.sha256");
+	if (await exists(target)) {
+		const installed = await readFile(target);
+		const actual = createHash("sha256").update(installed).digest("hex");
+		const expected = asset.archive
+			? await readFile(installedChecksum, "utf8").catch(() => "")
+			: asset.sha256;
+		if (actual === expected.trim()) {
+			await chmod(target, 0o700);
+			return target;
+		}
+		await rm(target, { force: true });
+		await rm(installedChecksum, { force: true });
+	}
+
+	await mkdir(installDir, { recursive: true, mode: 0o700 });
+	const fetcher = input.fetcher ?? fetch;
+	const response = await fetcher(`${RELEASE_BASE}/${asset.name}`, {
+		signal: AbortSignal.timeout(120_000),
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Managed tunnel download failed (${response.status} ${response.statusText}).`,
+		);
+	}
+	const contents = Buffer.from(await response.arrayBuffer());
+	verifySha256(contents, asset.sha256);
+
+	const download = join(installDir, `${asset.name}.download`);
+	await writeFile(download, contents, { mode: 0o600 });
+	try {
+		if (asset.archive) {
+			const staging = join(installDir, `extract-${process.pid}-${Date.now()}`);
+			await mkdir(staging, { mode: 0o700 });
+			try {
+				await execFileAsync("tar", ["-xzf", download, "-C", staging]);
+				const extracted = join(staging, "cloudflared");
+				await chmod(extracted, 0o700);
+				await rename(extracted, target);
+				const installed = await readFile(target);
+				await writeFile(
+					installedChecksum,
+					createHash("sha256").update(installed).digest("hex"),
+					{ mode: 0o600 },
+				);
+			} finally {
+				await rm(staging, { recursive: true, force: true });
+			}
+		} else {
+			await chmod(download, 0o700);
+			await rename(download, target);
+		}
+	} finally {
+		await rm(download, { force: true });
+	}
+	return target;
+};

--- a/apps/server/src/relay/handlers.ts
+++ b/apps/server/src/relay/handlers.ts
@@ -1,6 +1,10 @@
+import {
+  ConnectAuthError,
+  MemoizeRpcs,
+  RelayControlError,
+  RelayLinkStatus,
+} from "@zuse/contracts";
 import { Effect, Layer } from "effect";
-
-import { ConnectAuthError, MemoizeRpcs, RelayLinkStatus } from "@zuse/contracts";
 
 import {
   RelayLinkService,
@@ -41,8 +45,37 @@ const RelayUnlink = MemoizeRpcs.toLayerHandler("relay.unlink", () =>
   }).pipe(Effect.mapError((error) => toConnectError(error.reason))),
 );
 
+const toRelayControlError = (reason: string): RelayControlError =>
+  new RelayControlError({ reason });
+
+const RelayEnvironments = MemoizeRpcs.toLayerHandler("relay.environments", () =>
+  Effect.gen(function* () {
+    const service = yield* RelayLinkService;
+    return yield* service.listEnvironments();
+  }).pipe(Effect.mapError((error) => toRelayControlError(error.reason))),
+);
+
+const RelayClients = MemoizeRpcs.toLayerHandler("relay.clients", () =>
+  Effect.gen(function* () {
+    const service = yield* RelayLinkService;
+    return yield* service.listClients();
+  }).pipe(Effect.mapError((error) => toRelayControlError(error.reason))),
+);
+
+const RelayRevokeClient = MemoizeRpcs.toLayerHandler(
+  "relay.revokeClient",
+  ({ clientId }) =>
+    Effect.gen(function* () {
+      const service = yield* RelayLinkService;
+      yield* service.revokeClient(clientId);
+    }).pipe(Effect.mapError((error) => toRelayControlError(error.reason))),
+);
+
 export const RelayHandlersLayer = Layer.mergeAll(
   RelayLink,
   RelayStatus,
   RelayUnlink,
+  RelayEnvironments,
+  RelayClients,
+  RelayRevokeClient,
 );

--- a/apps/server/src/relay/managed-tunnel-runtime.ts
+++ b/apps/server/src/relay/managed-tunnel-runtime.ts
@@ -1,11 +1,12 @@
+import fs from "node:fs";
+import { Context, Data, Effect, Fiber, Layer, Ref, Schedule } from "effect";
 import {
   ChildProcess as Command,
   ChildProcessSpawner as CommandExecutor,
 } from "effect/unstable/process";
-import { Context, Data, Effect, Fiber, Layer, Ref, Schedule } from "effect";
-import fs from "node:fs";
 
 import { AppPaths } from "../app-paths.ts";
+import { ensurePinnedCloudflared } from "./cloudflared-install.ts";
 import { appendRelayDiagnostic } from "./relay-diagnostics.ts";
 
 /**
@@ -30,9 +31,7 @@ export class ManagedTunnelRuntime extends Context.Service<
     /** Stop the connector if running. */
     readonly stop: () => Effect.Effect<void>;
   }
->()(
-  "zuse/ManagedTunnelRuntime",
-) {}
+>()("zuse/ManagedTunnelRuntime") {}
 
 const CLOUDFLARED = "cloudflared";
 const CLOUDFLARED_CANDIDATES = [
@@ -95,13 +94,20 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
         yield* log("cloudflared.resolve.fail", { candidate });
       }
 
-      yield* log("cloudflared.resolve.not_found");
-      return yield* Effect.fail(
-        new ManagedTunnelError({
-          reason:
-            "cloudflared_not_found: install cloudflared and ensure it is on PATH",
-        }),
-      );
+      yield* log("cloudflared.resolve.download_pinned");
+      const installed = yield* Effect.tryPromise({
+        try: () => ensurePinnedCloudflared({ userData: paths.userData }),
+        catch: (cause) =>
+          new ManagedTunnelError({
+            reason:
+              cause instanceof Error
+                ? `cloudflared_install_failed: ${cause.message}`
+                : `cloudflared_install_failed: ${String(cause)}`,
+          }),
+      });
+      yield* Ref.set(binaryRef, installed);
+      yield* log("cloudflared.resolve.download_ok", { installed });
+      return installed;
     });
 
     // Preflight: fail fast with a clear message if the binary is missing, so the

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -1,7 +1,10 @@
 import {
   DEFAULT_LOCAL_DESKTOP_PORT,
   type EnvironmentId,
+  type RelayAuthorizedClientList,
+  type RelayEnvironmentList,
   RelayPaths,
+  WIRE_PROTOCOL_VERSION,
 } from "@zuse/contracts";
 import { Clock, Context, Data, Effect, Fiber, Layer, Ref } from "effect";
 
@@ -19,6 +22,24 @@ import { ManagedTunnelRuntime } from "./managed-tunnel-runtime.ts";
 import { appendRelayDiagnostic } from "./relay-diagnostics.ts";
 
 const HEARTBEAT_INTERVAL = "30 seconds";
+const RUNTIME_METADATA = {
+  runtimeVersion: process.env.ZUSE_RUNTIME_VERSION?.trim() || "0.0.0",
+  wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+  capabilities: {
+    version: 1,
+    features: [
+      "agents",
+      "chats",
+      "files",
+      "diffs",
+      "terminals",
+      "approvals",
+      "questions",
+      "notifications",
+    ],
+  },
+  serviceState: "healthy",
+} as const;
 
 export class RelayLinkError extends Data.TaggedError("RelayLinkError")<{
   readonly reason: string;
@@ -49,6 +70,17 @@ export class RelayLinkService extends Context.Service<
     }) => Effect.Effect<RelayLinkStatusValue, RelayLinkError>;
     readonly status: () => Effect.Effect<RelayLinkStatusValue, RelayLinkError>;
     readonly unlink: () => Effect.Effect<void, RelayLinkError>;
+    readonly listEnvironments: () => Effect.Effect<
+      RelayEnvironmentList,
+      RelayLinkError
+    >;
+    readonly listClients: () => Effect.Effect<
+      RelayAuthorizedClientList,
+      RelayLinkError
+    >;
+    readonly revokeClient: (
+      clientId: string,
+    ) => Effect.Effect<void, RelayLinkError>;
   }
 >()("zuse/RelayLinkService") {}
 
@@ -87,6 +119,25 @@ const postJson = <A>(
             : { "content-type": "application/json" }),
         },
         body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+      });
+      if (!response.ok) {
+        throw new Error(await relayHttpErrorReason(response));
+      }
+      return (await response.json()) as A;
+    },
+    catch: (cause) =>
+      failRelay(cause instanceof Error ? cause.message : String(cause)),
+  });
+
+const accountJson = <A>(
+  url: string,
+  opts: { readonly bearer: string; readonly method?: "GET" | "DELETE" },
+): Effect.Effect<A, RelayLinkError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(url, {
+        method: opts.method ?? "GET",
+        headers: { authorization: `Bearer ${opts.bearer}` },
       });
       if (!response.ok) {
         throw new Error(await relayHttpErrorReason(response));
@@ -140,7 +191,7 @@ export const RelayLinkServiceLive: Layer.Layer<
     }) =>
       postJson(
         `${input.relayUrl}${RelayPaths.heartbeat(input.environmentId)}`,
-        { bearer: input.credential },
+        { bearer: input.credential, body: RUNTIME_METADATA },
       ).pipe(
         Effect.ignore,
         Effect.andThen(Effect.sleep(HEARTBEAT_INTERVAL)),
@@ -174,7 +225,7 @@ export const RelayLinkServiceLive: Layer.Layer<
         `${input.relayUrl}${RelayPaths.heartbeat(input.environmentId)}`,
         {
           bearer: input.credential,
-          body: { origin: computeOrigin(config) },
+          body: { origin: computeOrigin(config), ...RUNTIME_METADATA },
         },
       );
 
@@ -316,6 +367,7 @@ export const RelayLinkServiceLive: Layer.Layer<
               providerKind: "desktop",
               endpoint: computeEndpoint(config),
               label,
+              ...RUNTIME_METADATA,
               // Ask the relay to provision a managed Cloudflare tunnel so the
               // phone can reach this Mac from anywhere. If the relay has tunnels
               // disabled it simply returns no connector token and we stay on LAN.
@@ -443,6 +495,48 @@ export const RelayLinkServiceLive: Layer.Layer<
               },
             }),
           } satisfies RelayLinkStatusValue;
+        }),
+      listEnvironments: () =>
+        Effect.gen(function* () {
+          const cfg = yield* auth
+            .getRelayConfig()
+            .pipe(Effect.mapError((error) => failRelay(error.reason)));
+          if (cfg === null) return yield* Effect.fail(failRelay("not_linked"));
+          const token = yield* authService
+            .getAccessToken()
+            .pipe(Effect.mapError(() => failRelay("not_signed_in")));
+          return yield* accountJson<RelayEnvironmentList>(
+            `${cfg.relayUrl}${RelayPaths.environments}`,
+            { bearer: token },
+          );
+        }),
+      listClients: () =>
+        Effect.gen(function* () {
+          const cfg = yield* auth
+            .getRelayConfig()
+            .pipe(Effect.mapError((error) => failRelay(error.reason)));
+          if (cfg === null) return yield* Effect.fail(failRelay("not_linked"));
+          const token = yield* authService
+            .getAccessToken()
+            .pipe(Effect.mapError(() => failRelay("not_signed_in")));
+          return yield* accountJson<RelayAuthorizedClientList>(
+            `${cfg.relayUrl}${RelayPaths.clients}`,
+            { bearer: token },
+          );
+        }),
+      revokeClient: (clientId) =>
+        Effect.gen(function* () {
+          const cfg = yield* auth
+            .getRelayConfig()
+            .pipe(Effect.mapError((error) => failRelay(error.reason)));
+          if (cfg === null) return yield* Effect.fail(failRelay("not_linked"));
+          const token = yield* authService
+            .getAccessToken()
+            .pipe(Effect.mapError(() => failRelay("not_signed_in")));
+          yield* accountJson<{ readonly ok: boolean }>(
+            `${cfg.relayUrl}${RelayPaths.client(clientId)}`,
+            { bearer: token, method: "DELETE" },
+          );
         }),
       unlink: () =>
         Effect.gen(function* () {

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -44,7 +44,10 @@ import { TitleGeneratorLive } from "./provider/title-generator.ts";
 import { PtyServiceLive } from "./pty/layers/pty-service.ts";
 import { RelayActivityPublisherLive } from "./relay/activity-publisher.ts";
 import { ManagedTunnelRuntimeLive } from "./relay/managed-tunnel-runtime.ts";
-import { RelayLinkServiceLive } from "./relay/relay-link-service.ts";
+import {
+	RelayLinkService,
+	RelayLinkServiceLive,
+} from "./relay/relay-link-service.ts";
 import { RepositorySettingsServiceLive } from "./repository-settings/layers/repository-settings-service.ts";
 import { SkillBridgeLive } from "./skill/layers/skill-bridge.ts";
 import { SkillDiscoveryServiceLive } from "./skill/layers/skill-discovery.ts";
@@ -105,6 +108,10 @@ export interface MainLayerDeps {
 		readonly onNearbyPairingRequest?: (
 			request: import("./lan-auth/services/lan-auth-service.ts").NearbyPairingRequest,
 		) => void;
+	};
+	readonly autoRelayLink?: {
+		readonly relayUrl: string;
+		readonly label?: string;
 	};
 }
 
@@ -441,6 +448,19 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		),
 		Layer.provide(AppPathsLayer),
 	);
+	const autoRelayLink = deps.autoRelayLink;
+	const AutoRelayLinkLayer =
+		autoRelayLink === undefined
+			? Layer.empty
+			: Layer.effectDiscard(
+					Effect.gen(function* () {
+						const relay = yield* RelayLinkService;
+						const status = yield* relay.status();
+						if (!status.linked) {
+							yield* relay.link(autoRelayLink);
+						}
+					}),
+				).pipe(Layer.provide(RelayLinkLayer));
 
 	const HandlerSupportLayer = Layer.mergeAll(
 		AppPathsLayer,
@@ -521,5 +541,10 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(MigratedSqlite),
 		Layer.provide(AppPathsLayer),
 	);
-	return Layer.mergeAll(ServerLayer, NodeServices.layer, UsagePoller);
+	return Layer.mergeAll(
+		ServerLayer,
+		NodeServices.layer,
+		UsagePoller,
+		AutoRelayLinkLayer,
+	);
 };

--- a/apps/server/src/serve/command.ts
+++ b/apps/server/src/serve/command.ts
@@ -1,0 +1,56 @@
+export const ServeAction = [
+	"start",
+	"status",
+	"stop",
+	"update",
+	"logout",
+	"uninstall",
+] as const;
+export type ServeAction = (typeof ServeAction)[number];
+
+export interface ServeCommand {
+	readonly action: ServeAction;
+	readonly json: boolean;
+	readonly foreground: boolean;
+	readonly force: boolean;
+}
+
+const MANAGEMENT_ACTIONS = new Set<ServeAction>(ServeAction);
+
+export const parseServeCommand = (
+	argv: ReadonlyArray<string>,
+): ServeCommand => {
+	if (argv[0] !== "serve") {
+		throw new Error("Usage: zuse serve [status|stop|update|logout|uninstall]");
+	}
+
+	const rest = argv.slice(1);
+	const candidate = rest.find((part) => !part.startsWith("-"));
+	const action = candidate ?? "start";
+	if (!MANAGEMENT_ACTIONS.has(action as ServeAction)) {
+		throw new Error(`Unknown zuse serve command "${action}".`);
+	}
+
+	const flags = new Set(rest.filter((part) => part.startsWith("-")));
+	for (const flag of flags) {
+		if (!["--json", "--foreground", "--force"].includes(flag)) {
+			throw new Error(`Unknown zuse serve option "${flag}".`);
+		}
+	}
+	if (flags.has("--force") && action !== "update") {
+		throw new Error("--force is only valid with update.");
+	}
+	if (flags.has("--json") && action !== "status") {
+		throw new Error("--json is only valid with status.");
+	}
+	if (flags.has("--foreground") && action !== "start") {
+		throw new Error("--foreground is only valid when starting Zuse Serve.");
+	}
+
+	return {
+		action: action as ServeAction,
+		json: flags.has("--json"),
+		foreground: flags.has("--foreground"),
+		force: flags.has("--force"),
+	};
+};

--- a/apps/server/src/serve/device-login.ts
+++ b/apps/server/src/serve/device-login.ts
@@ -1,0 +1,69 @@
+import { Effect, Exit } from "effect";
+
+import { SessionStoreLive } from "../auth/layers/session-store.ts";
+import { refreshSession } from "../auth/layers/workos.ts";
+import {
+	type DeviceAuthorizationGrant,
+	pollDeviceAuthorization,
+	requestDeviceAuthorization,
+} from "../auth/layers/workos-device-auth.ts";
+import { SessionStore } from "../auth/services/session-store.ts";
+
+export interface ServeDeviceLoginOptions {
+	readonly clientId: string;
+	readonly onPrompt: (grant: DeviceAuthorizationGrant) => void | Promise<void>;
+}
+
+export const ensureServeSession = (
+	options: ServeDeviceLoginOptions,
+): Effect.Effect<{ readonly email: string }, Error> =>
+	Effect.gen(function* () {
+		if (options.clientId.trim().length === 0) {
+			return yield* Effect.fail(
+				new Error(
+					"Zuse Serve authentication is unavailable because WORKOS_CLIENT_ID is not configured.",
+				),
+			);
+		}
+		const store = yield* SessionStore;
+		const existing = yield* store
+			.read()
+			.pipe(Effect.mapError((cause) => new Error(cause.reason)));
+		if (existing !== null) {
+			if (existing.expiresAt - Date.now() > 60_000) {
+				return { email: existing.user.email };
+			}
+			const refreshed = yield* Effect.exit(
+				refreshSession(options.clientId, existing.refreshToken),
+			);
+			if (Exit.isSuccess(refreshed)) {
+				yield* store
+					.write(refreshed.value)
+					.pipe(Effect.mapError((cause) => new Error(cause.reason)));
+				return { email: refreshed.value.user.email };
+			}
+			yield* store
+				.clear()
+				.pipe(Effect.mapError((cause) => new Error(cause.reason)));
+		}
+
+		const grant = yield* Effect.tryPromise({
+			try: () => requestDeviceAuthorization(options.clientId),
+			catch: (cause) =>
+				cause instanceof Error ? cause : new Error(String(cause)),
+		});
+		yield* Effect.tryPromise({
+			try: async () => options.onPrompt(grant),
+			catch: (cause) =>
+				cause instanceof Error ? cause : new Error(String(cause)),
+		});
+		const session = yield* Effect.tryPromise({
+			try: () => pollDeviceAuthorization(options.clientId, grant),
+			catch: (cause) =>
+				cause instanceof Error ? cause : new Error(String(cause)),
+		});
+		yield* store
+			.write(session)
+			.pipe(Effect.mapError((cause) => new Error(cause.reason)));
+		return { email: session.user.email };
+	}).pipe(Effect.provide(SessionStoreLive));

--- a/apps/server/src/serve/package-cli.ts
+++ b/apps/server/src/serve/package-cli.ts
@@ -1,0 +1,447 @@
+import { spawn } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+import { homedir, hostname } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { WORKOS_PUBLIC_CLIENT_ID } from "@zuse/contracts";
+import { Effect } from "effect";
+
+import { SessionStoreLive } from "../auth/layers/session-store.ts";
+import { refreshSession, type SessionBundle } from "../auth/layers/workos.ts";
+import { SessionStore } from "../auth/services/session-store.ts";
+import { runHeadlessServer } from "../bin.ts";
+import { parseServeCommand } from "./command.ts";
+import { ensureServeSession } from "./device-login.ts";
+import {
+	installDurableServeRuntime,
+	latestServeRuntimeVersion,
+	readActiveServeRuntime,
+	writeActiveServeRuntime,
+} from "./runtime-installer.ts";
+import {
+	getServeServiceStatus,
+	installServeService,
+	resolveServeServicePaths,
+	startServeService,
+	stopServeService,
+	UnsupportedServiceManagerError,
+	uninstallServeService,
+} from "./service-manager.ts";
+
+const DEFAULT_RELAY_URL = "https://relay.stuff.md";
+const APP_URL = "https://app.zuse.sh";
+const workosClientId = (env: NodeJS.ProcessEnv): string =>
+	(env.WORKOS_CLIENT_ID ?? "").trim() || WORKOS_PUBLIC_CLIENT_ID;
+
+const resolveDataDir = (env: NodeJS.ProcessEnv): string => {
+	if (env.ZUSE_USER_DATA) return env.ZUSE_USER_DATA;
+	const xdg = env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
+	return join(xdg, "zuse");
+};
+
+const openBrowser = (url: string): void => {
+	const [command, args] =
+		process.platform === "darwin"
+			? (["open", [url]] as const)
+			: (["xdg-open", [url]] as const);
+	const child = spawn(command, args, { detached: true, stdio: "ignore" });
+	child.on("error", () => undefined);
+	child.unref();
+};
+
+const foregroundArgs = (dataDir: string): ReadonlyArray<string> => [
+	"serve",
+	"--data-dir",
+	dataDir,
+	"--auth",
+	"protected",
+];
+
+type LocalRelayConfig = {
+	readonly environmentId: string;
+	readonly relayUrl: string;
+	readonly tunnelHostname?: string;
+};
+
+const readLocalRelayConfig = (dataDir: string): LocalRelayConfig | null => {
+	try {
+		const database = new DatabaseSync(join(dataDir, "zuse.sqlite"), {
+			readOnly: true,
+		});
+		try {
+			const row = database
+				.prepare(
+					"SELECT environment_id, relay_url, tunnel_hostname FROM relay_config LIMIT 1",
+				)
+				.get() as
+				| {
+						readonly environment_id?: unknown;
+						readonly relay_url?: unknown;
+						readonly tunnel_hostname?: unknown;
+				  }
+				| undefined;
+			if (
+				typeof row?.environment_id !== "string" ||
+				typeof row.relay_url !== "string"
+			) {
+				return null;
+			}
+			return {
+				environmentId: row.environment_id,
+				relayUrl: row.relay_url,
+				tunnelHostname:
+					typeof row.tunnel_hostname === "string"
+						? row.tunnel_hostname
+						: undefined,
+			};
+		} finally {
+			database.close();
+		}
+	} catch {
+		return null;
+	}
+};
+
+const installedAgents = async (): Promise<ReadonlyArray<string>> => {
+	const candidates = [
+		["Codex", "codex"],
+		["Claude", "claude"],
+		["OpenCode", "opencode"],
+		["Grok", "grok"],
+	] as const;
+	const results = await Promise.all(
+		candidates.map(async ([label, executable]) => {
+			try {
+				const child = spawn(executable, ["--version"], {
+					stdio: "ignore",
+				});
+				const code = await new Promise<number | null>((resolve) => {
+					let settled = false;
+					const finish = (value: number | null) => {
+						if (settled) return;
+						settled = true;
+						clearTimeout(timer);
+						resolve(value);
+					};
+					const timer = setTimeout(() => {
+						child.kill("SIGTERM");
+						finish(null);
+					}, 2_000);
+					child.once("error", () => finish(null));
+					child.once("exit", finish);
+				});
+				return code === 0 ? label : null;
+			} catch {
+				return null;
+			}
+		}),
+	);
+	return results.filter((value) => value !== null);
+};
+
+const serverReachable = async (env: NodeJS.ProcessEnv): Promise<boolean> => {
+	try {
+		const port = Number(env.ZUSE_PORT ?? 4859);
+		const response = await fetch(`http://127.0.0.1:${port}/auth/session`, {
+			signal: AbortSignal.timeout(2_000),
+		});
+		return response.status < 500;
+	} catch {
+		return false;
+	}
+};
+
+const printStatus = async (
+	status: Awaited<ReturnType<typeof getServeServiceStatus>>,
+	options: {
+		readonly json: boolean;
+		readonly dataDir: string;
+		readonly env: NodeJS.ProcessEnv;
+	},
+): Promise<void> => {
+	const relay = readLocalRelayConfig(options.dataDir);
+	const [agents, reachable] = await Promise.all([
+		installedAgents(),
+		serverReachable(options.env),
+	]);
+	const value = {
+		schemaVersion: 1,
+		computer: hostname(),
+		service: status.running
+			? "running"
+			: status.installed
+				? "stopped"
+				: "missing",
+		tunnel: relay?.tunnelHostname === undefined ? "unavailable" : "configured",
+		runtimeVersion: options.env.ZUSE_RUNTIME_VERSION ?? "0.0.0",
+		agents,
+		reachable,
+		environmentId: relay?.environmentId ?? null,
+		durable: status.durable,
+		dataDir: options.dataDir,
+		appUrl: APP_URL,
+	};
+	if (options.json) {
+		console.log(JSON.stringify(value));
+		return;
+	}
+	console.log(`Computer   ${value.computer}`);
+	console.log(`Service    ${value.service}`);
+	console.log(`Tunnel     ${value.tunnel}`);
+	console.log(`Agents     ${value.agents.join(", ") || "None detected"}`);
+	console.log(`Status     ${value.reachable ? "Online" : "Unavailable"}`);
+	console.log(`Open       ${value.appUrl}`);
+};
+
+const waitForReachability = async (
+	env: NodeJS.ProcessEnv,
+	timeoutMs = 45_000,
+): Promise<boolean> => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await serverReachable(env)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 1_000));
+	}
+	return false;
+};
+
+const clearServeSession = (): Promise<void> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const store = yield* SessionStore;
+			yield* store.clear();
+		}).pipe(Effect.provide(SessionStoreLive)),
+	);
+
+const currentServeSession = (): Promise<SessionBundle | null> =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const store = yield* SessionStore;
+			return yield* store.read();
+		}).pipe(Effect.provide(SessionStoreLive)),
+	);
+
+const unlinkServeRegistration = async (
+	dataDir: string,
+	env: NodeJS.ProcessEnv,
+): Promise<void> => {
+	const relay = readLocalRelayConfig(dataDir);
+	if (relay === null) return;
+	let session = await currentServeSession();
+	if (session === null) {
+		throw new Error(
+			"Cannot revoke this computer because its account authorization is missing.",
+		);
+	}
+	if (session.expiresAt - Date.now() <= 60_000) {
+		const refreshed = await Effect.runPromise(
+			refreshSession(workosClientId(env), session.refreshToken),
+		);
+		session = refreshed;
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const store = yield* SessionStore;
+				yield* store.write(refreshed);
+			}).pipe(Effect.provide(SessionStoreLive)),
+		);
+	}
+	const response = await fetch(
+		`${relay.relayUrl}/v1/client/environment-unlink`,
+		{
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${session.accessToken}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ environmentId: relay.environmentId }),
+			signal: AbortSignal.timeout(15_000),
+		},
+	);
+	if (!response.ok && response.status !== 404) {
+		throw new Error(`Computer revocation failed (${response.status}).`);
+	}
+};
+
+export const runServePackageCli = async (
+	argv: ReadonlyArray<string>,
+	env: NodeJS.ProcessEnv = process.env,
+	options: { readonly packageVersion?: string } = {},
+): Promise<void> => {
+	const normalized = argv[0] === "serve" ? argv : ["serve", ...argv];
+	const command = parseServeCommand(normalized);
+	env.ZUSE_RUNTIME_VERSION = options.packageVersion ?? "0.0.0";
+	const dataDir = resolveDataDir(env);
+	const servicePaths = resolveServeServicePaths({ dataDir });
+
+	if (command.action === "start" && command.foreground) {
+		env.ZUSE_SERVE_AUTO_LINK = "1";
+		env.ZUSE_RELAY_URL = env.ZUSE_RELAY_URL ?? DEFAULT_RELAY_URL;
+		runHeadlessServer({
+			host: "127.0.0.1",
+			port: Number(env.ZUSE_PORT ?? 4859),
+			dataDir,
+			staticDir: undefined,
+			open: false,
+			policy: "protected",
+			pairing: true,
+		});
+		return;
+	}
+
+	if (command.action === "status") {
+		await printStatus(await getServeServiceStatus(servicePaths), {
+			json: command.json,
+			dataDir,
+			env,
+		});
+		return;
+	}
+
+	if (command.action === "stop") {
+		await stopServeService(servicePaths);
+		console.log("Zuse Serve is stopped.");
+		return;
+	}
+
+	if (command.action === "logout") {
+		await unlinkServeRegistration(dataDir, env);
+		await stopServeService(servicePaths).catch(() => undefined);
+		await clearServeSession();
+		console.log("Zuse Serve is signed out and stopped.");
+		return;
+	}
+
+	if (command.action === "uninstall") {
+		await uninstallServeService(servicePaths);
+		await rm(join(dataDir, "runtime"), { recursive: true, force: true });
+		console.log(
+			"Zuse Serve was uninstalled. Your workspaces were not deleted.",
+		);
+		return;
+	}
+
+	if (command.action === "update") {
+		if (!command.force) {
+			throw new Error(
+				"Automatic runtime updates require active-work readiness checks. Run with --force only when no agent or terminal work is active.",
+			);
+		}
+		const version = await latestServeRuntimeVersion();
+		const executable = await installDurableServeRuntime({ dataDir, version });
+		const previous = await readActiveServeRuntime(dataDir);
+		try {
+			await installServeService({ executable, paths: servicePaths });
+		} catch (cause) {
+			if (previous !== null) {
+				await installServeService({
+					executable: previous.executable,
+					paths: servicePaths,
+				}).catch(() => undefined);
+			}
+			throw cause;
+		}
+		if (!(await waitForReachability(env))) {
+			if (previous !== null) {
+				await installServeService({
+					executable: previous.executable,
+					paths: servicePaths,
+				});
+				await waitForReachability(env, 20_000);
+				throw new Error(
+					"The updated runtime failed its readiness check and Zuse restored the previous runtime.",
+				);
+			}
+			throw new Error(
+				"The updated runtime failed its readiness check. No previous runtime was available to restore.",
+			);
+		}
+		await writeActiveServeRuntime(dataDir, { version, executable });
+		console.log(`Zuse Serve was updated to ${version}.`);
+		return;
+	}
+
+	await mkdir(dataDir, { recursive: true, mode: 0o700 });
+	const session = await Effect.runPromise(
+		ensureServeSession({
+			clientId: workosClientId(env),
+			onPrompt: async (grant) => {
+				console.log("Authorize this computer");
+				console.log(`Code       ${grant.userCode}`);
+				console.log(`Open       ${grant.verificationUriComplete}`);
+				if (env.ZUSE_NO_OPEN !== "1")
+					openBrowser(grant.verificationUriComplete);
+			},
+		}),
+	);
+	const current = await getServeServiceStatus(servicePaths);
+	if (current.installed && !current.running) {
+		await startServeService(servicePaths);
+		if (!(await waitForReachability(env))) {
+			throw new Error(
+				"Zuse Serve started, but its local readiness check failed. Run `zuse serve status --json` for diagnostics.",
+			);
+		}
+		await printStatus(await getServeServiceStatus(servicePaths), {
+			json: false,
+			dataDir,
+			env,
+		});
+		return;
+	}
+
+	let installedExecutable: string;
+	try {
+		const packageVersion = options.packageVersion ?? "0.0.0";
+		installedExecutable =
+			packageVersion === "0.0.0"
+				? (process.argv[1] ?? process.execPath)
+				: await installDurableServeRuntime({
+						dataDir,
+						version: packageVersion,
+					});
+		await installServeService({
+			executable: installedExecutable,
+			paths: servicePaths,
+		});
+	} catch (cause) {
+		if (cause instanceof UnsupportedServiceManagerError) {
+			console.warn(`${cause.message} Starting in the foreground instead.`);
+			env.ZUSE_SERVE_AUTO_LINK = "1";
+			env.ZUSE_RELAY_URL = env.ZUSE_RELAY_URL ?? DEFAULT_RELAY_URL;
+			runHeadlessServer({
+				host: "127.0.0.1",
+				port: Number(env.ZUSE_PORT ?? 4859),
+				dataDir,
+				staticDir: undefined,
+				open: false,
+				policy: "protected",
+				pairing: true,
+			});
+			return;
+		}
+		throw cause;
+	}
+	const reachable = await waitForReachability(env);
+	if (!reachable) {
+		throw new Error(
+			"Zuse Serve was installed, but the background host did not become reachable. Run `zuse serve status --json` for diagnostics.",
+		);
+	}
+	await writeActiveServeRuntime(dataDir, {
+		version: options.packageVersion ?? "0.0.0",
+		executable: installedExecutable,
+	});
+
+	console.log("");
+	console.log("Zuse Serve is ready");
+	console.log("");
+	console.log(`Computer   ${hostname()}`);
+	console.log("Status     Online");
+	console.log(`Account    ${session.email}`);
+	const agents = await installedAgents();
+	console.log(`Agents     ${agents.join(", ") || "None detected"}`);
+	console.log(`Open       ${APP_URL}`);
+};
+
+export { foregroundArgs };

--- a/apps/server/src/serve/runtime-installer.ts
+++ b/apps/server/src/serve/runtime-installer.ts
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process";
+import {
+	access,
+	mkdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const packageSpecifier = (version: string): string =>
+	`@zusehq/serve@${version}`;
+
+export const durableRuntimeExecutable = (
+	dataDir: string,
+	version: string,
+): string =>
+	join(
+		dataDir,
+		"runtime",
+		version,
+		"node_modules",
+		"@zusehq",
+		"serve",
+		"dist",
+		"bin.mjs",
+	);
+
+export const installDurableServeRuntime = async (input: {
+	readonly dataDir: string;
+	readonly version: string;
+	readonly npmExecutable?: string;
+}): Promise<string> => {
+	if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u.test(input.version)) {
+		throw new Error(`Invalid Zuse Serve runtime version: ${input.version}`);
+	}
+	const executable = durableRuntimeExecutable(input.dataDir, input.version);
+	try {
+		await access(executable);
+		return executable;
+	} catch {
+		// Install below.
+	}
+	const prefix = join(input.dataDir, "runtime", input.version);
+	await mkdir(prefix, { recursive: true, mode: 0o700 });
+	await execFileAsync(input.npmExecutable ?? "npm", [
+		"install",
+		"--prefix",
+		prefix,
+		"--no-audit",
+		"--no-fund",
+		"--save-exact",
+		packageSpecifier(input.version),
+	]);
+	await access(executable);
+	return executable;
+};
+
+export const latestServeRuntimeVersion = async (
+	fetcher: typeof fetch = fetch,
+): Promise<string> => {
+	const response = await fetcher(
+		"https://registry.npmjs.org/@zusehq%2Fserve/latest",
+		{ signal: AbortSignal.timeout(15_000) },
+	);
+	const body = (await response.json().catch(() => ({}))) as {
+		readonly version?: unknown;
+	};
+	if (!response.ok || typeof body.version !== "string") {
+		throw new Error(`Unable to resolve the latest Serve runtime.`);
+	}
+	return body.version;
+};
+
+export interface ActiveServeRuntime {
+	readonly version: string;
+	readonly executable: string;
+}
+
+const activeRuntimePath = (dataDir: string): string =>
+	join(dataDir, "runtime", "active.json");
+
+export const readActiveServeRuntime = async (
+	dataDir: string,
+): Promise<ActiveServeRuntime | null> => {
+	try {
+		const value = JSON.parse(
+			await readFile(activeRuntimePath(dataDir), "utf8"),
+		) as Partial<ActiveServeRuntime>;
+		return typeof value.version === "string" &&
+			typeof value.executable === "string"
+			? (value as ActiveServeRuntime)
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+export const writeActiveServeRuntime = async (
+	dataDir: string,
+	runtime: ActiveServeRuntime,
+): Promise<void> => {
+	const directory = join(dataDir, "runtime");
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const target = activeRuntimePath(dataDir);
+	const temporary = `${target}.${process.pid}.tmp`;
+	await writeFile(temporary, JSON.stringify(runtime), { mode: 0o600 });
+	try {
+		await rename(temporary, target);
+	} finally {
+		await rm(temporary, { force: true });
+	}
+};

--- a/apps/server/src/serve/service-definition.ts
+++ b/apps/server/src/serve/service-definition.ts
@@ -1,0 +1,105 @@
+export interface ServeServiceDefinitionInput {
+	readonly nodeExecutable: string;
+	readonly executable: string;
+	readonly dataDir: string;
+	readonly logDir?: string;
+	readonly relayUrl?: string;
+}
+
+export interface LaunchAgentDefinition {
+	readonly label: "sh.zuse.serve";
+	readonly contents: string;
+}
+
+export interface SystemdUserDefinition {
+	readonly unitName: "zuse-serve.service";
+	readonly contents: string;
+}
+
+const escapeXml = (value: string): string =>
+	value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&apos;");
+
+const quoteSystemd = (value: string): string =>
+	`"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+
+export const launchAgentDefinition = (
+	input: ServeServiceDefinitionInput,
+): LaunchAgentDefinition => {
+	const logDir = input.logDir ?? `${input.dataDir}/logs`;
+	const relayUrl = input.relayUrl ?? "https://relay.stuff.md";
+	return {
+		label: "sh.zuse.serve",
+		contents: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>sh.zuse.serve</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escapeXml(input.nodeExecutable)}</string>
+    <string>${escapeXml(input.executable)}</string>
+    <string>serve</string>
+    <string>--foreground</string>
+    <string>--data-dir</string>
+    <string>${escapeXml(input.dataDir)}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ZUSE_SERVE_AUTO_LINK</key>
+    <string>1</string>
+    <key>ZUSE_RELAY_URL</key>
+    <string>${escapeXml(relayUrl)}</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(`${logDir}/serve.log`)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(`${logDir}/serve.error.log`)}</string>
+</dict>
+</plist>
+`,
+	};
+};
+
+export const systemdUserDefinition = (
+	input: ServeServiceDefinitionInput,
+): SystemdUserDefinition => {
+	const relayUrl = input.relayUrl ?? "https://relay.stuff.md";
+	return {
+		unitName: "zuse-serve.service",
+		contents: `[Unit]
+Description=Zuse Serve
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${quoteSystemd(input.nodeExecutable)} ${quoteSystemd(input.executable)} serve --foreground --data-dir ${quoteSystemd(input.dataDir)}
+Environment=ZUSE_SERVE_AUTO_LINK=1
+Environment=ZUSE_RELAY_URL=${quoteSystemd(relayUrl)}
+Restart=on-failure
+RestartSec=3
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=${quoteSystemd(input.dataDir)}
+
+[Install]
+WantedBy=default.target
+`,
+	};
+};

--- a/apps/server/src/serve/service-manager.ts
+++ b/apps/server/src/serve/service-manager.ts
@@ -1,0 +1,241 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+import {
+	launchAgentDefinition,
+	systemdUserDefinition,
+} from "./service-definition.ts";
+
+const execFileAsync = promisify(execFile);
+
+export type SupportedServePlatform = "darwin" | "linux";
+
+export interface ServeServicePaths {
+	readonly platform: SupportedServePlatform;
+	readonly definitionPath: string;
+	readonly dataDir: string;
+	readonly logDir: string;
+}
+
+export interface ServeServiceStatus {
+	readonly installed: boolean;
+	readonly running: boolean;
+	readonly durable: boolean;
+	readonly detail?: string;
+}
+
+export class UnsupportedServiceManagerError extends Error {
+	readonly name = "UnsupportedServiceManagerError";
+}
+
+const fileExists = async (path: string): Promise<boolean> => {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const run = async (
+	executable: string,
+	args: ReadonlyArray<string>,
+): Promise<{ readonly stdout: string; readonly stderr: string }> => {
+	const result = await execFileAsync(executable, [...args], {
+		encoding: "utf8",
+	});
+	return { stdout: result.stdout, stderr: result.stderr };
+};
+
+export const resolveServeServicePaths = (input: {
+	readonly platform?: NodeJS.Platform;
+	readonly homeDir?: string;
+	readonly dataDir: string;
+}): ServeServicePaths => {
+	const platform = input.platform ?? process.platform;
+	const homeDir = input.homeDir ?? homedir();
+	if (platform === "darwin") {
+		return {
+			platform,
+			definitionPath: join(
+				homeDir,
+				"Library",
+				"LaunchAgents",
+				"sh.zuse.serve.plist",
+			),
+			dataDir: input.dataDir,
+			logDir: join(input.dataDir, "logs"),
+		};
+	}
+	if (platform === "linux") {
+		return {
+			platform,
+			definitionPath: join(
+				homeDir,
+				".config",
+				"systemd",
+				"user",
+				"zuse-serve.service",
+			),
+			dataDir: input.dataDir,
+			logDir: join(input.dataDir, "logs"),
+		};
+	}
+	throw new UnsupportedServiceManagerError(
+		`Zuse Serve background installation is not supported on ${platform}.`,
+	);
+};
+
+const launchctlTarget = (): string => {
+	const uid = process.getuid?.();
+	if (uid === undefined) {
+		throw new UnsupportedServiceManagerError(
+			"Unable to determine the current macOS user.",
+		);
+	}
+	return `gui/${uid}`;
+};
+
+const isSystemdUserAvailable = async (): Promise<boolean> => {
+	try {
+		await run("systemctl", ["--user", "show-environment"]);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const installServeService = async (input: {
+	readonly executable: string;
+	readonly paths: ServeServicePaths;
+}): Promise<ServeServiceStatus> => {
+	await mkdir(dirname(input.paths.definitionPath), { recursive: true });
+	await mkdir(input.paths.logDir, { recursive: true, mode: 0o700 });
+	await mkdir(input.paths.dataDir, { recursive: true, mode: 0o700 });
+
+	if (input.paths.platform === "darwin") {
+		const definition = launchAgentDefinition({
+			nodeExecutable: process.execPath,
+			executable: input.executable,
+			dataDir: input.paths.dataDir,
+			logDir: input.paths.logDir,
+		});
+		await writeFile(input.paths.definitionPath, definition.contents, {
+			mode: 0o600,
+		});
+		const target = launchctlTarget();
+		await run("launchctl", [
+			"bootout",
+			target,
+			input.paths.definitionPath,
+		]).catch(() => undefined);
+		await run("launchctl", ["bootstrap", target, input.paths.definitionPath]);
+		await run("launchctl", ["enable", `${target}/${definition.label}`]);
+		await run("launchctl", [
+			"kickstart",
+			"-k",
+			`${target}/${definition.label}`,
+		]);
+		return { installed: true, running: true, durable: true };
+	}
+
+	if (!(await isSystemdUserAvailable())) {
+		throw new UnsupportedServiceManagerError(
+			"This Linux session does not provide systemd user services.",
+		);
+	}
+	const definition = systemdUserDefinition({
+		nodeExecutable: process.execPath,
+		executable: input.executable,
+		dataDir: input.paths.dataDir,
+		logDir: input.paths.logDir,
+	});
+	await writeFile(input.paths.definitionPath, definition.contents, {
+		mode: 0o600,
+	});
+	await run("systemctl", ["--user", "daemon-reload"]);
+	await run("systemctl", ["--user", "enable", "--now", definition.unitName]);
+	return { installed: true, running: true, durable: true };
+};
+
+export const startServeService = async (
+	paths: ServeServicePaths,
+): Promise<void> => {
+	if (paths.platform === "darwin") {
+		const target = launchctlTarget();
+		await run("launchctl", ["enable", `${target}/sh.zuse.serve`]);
+		await run("launchctl", ["kickstart", "-k", `${target}/sh.zuse.serve`]);
+		return;
+	}
+	await run("systemctl", ["--user", "enable", "--now", "zuse-serve.service"]);
+};
+
+export const stopServeService = async (
+	paths: ServeServicePaths,
+): Promise<void> => {
+	if (paths.platform === "darwin") {
+		const target = launchctlTarget();
+		await run("launchctl", ["disable", `${target}/sh.zuse.serve`]);
+		await run("launchctl", [
+			"kill",
+			"SIGTERM",
+			`${target}/sh.zuse.serve`,
+		]).catch(() => undefined);
+		return;
+	}
+	await run("systemctl", ["--user", "disable", "--now", "zuse-serve.service"]);
+};
+
+export const getServeServiceStatus = async (
+	paths: ServeServicePaths,
+): Promise<ServeServiceStatus> => {
+	const installed = await fileExists(paths.definitionPath);
+	if (!installed) return { installed: false, running: false, durable: true };
+	try {
+		if (paths.platform === "darwin") {
+			const target = launchctlTarget();
+			await run("launchctl", ["print", `${target}/sh.zuse.serve`]);
+		} else {
+			await run("systemctl", [
+				"--user",
+				"is-active",
+				"--quiet",
+				"zuse-serve.service",
+			]);
+		}
+		return { installed: true, running: true, durable: true };
+	} catch (cause) {
+		return {
+			installed: true,
+			running: false,
+			durable: true,
+			detail: cause instanceof Error ? cause.message : String(cause),
+		};
+	}
+};
+
+export const uninstallServeService = async (
+	paths: ServeServicePaths,
+): Promise<void> => {
+	if (paths.platform === "darwin") {
+		await run("launchctl", [
+			"bootout",
+			launchctlTarget(),
+			paths.definitionPath,
+		]).catch(() => undefined);
+	} else {
+		await run("systemctl", [
+			"--user",
+			"disable",
+			"--now",
+			"zuse-serve.service",
+		]).catch(() => undefined);
+	}
+	await rm(paths.definitionPath, { force: true });
+	if (paths.platform === "linux") {
+		await run("systemctl", ["--user", "daemon-reload"]).catch(() => undefined);
+	}
+};

--- a/apps/server/test/unit/cloudflared-install.test.ts
+++ b/apps/server/test/unit/cloudflared-install.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	cloudflaredAsset,
+	verifySha256,
+} from "../../src/relay/cloudflared-install.ts";
+
+describe("cloudflared installer", () => {
+	test("pins supported platform assets and checksums", () => {
+		expect(cloudflaredAsset("darwin", "arm64")).toMatchObject({
+			version: "2026.7.2",
+			name: "cloudflared-darwin-arm64.tgz",
+			sha256:
+				"0588df58494a6cadd38b9deb6078908a5054063c80784d92fdb8d4a5f3de1c67",
+		});
+		expect(cloudflaredAsset("linux", "x64")).toMatchObject({
+			name: "cloudflared-linux-amd64",
+			sha256:
+				"ec905ea7b7e327ff8abdde8cb64697a2152de74dbcdbf6aec9db8364eb3886cd",
+		});
+	});
+
+	test("rejects unsupported operating systems and architectures", () => {
+		expect(() => cloudflaredAsset("win32", "x64")).toThrow(
+			/unsupported platform/i,
+		);
+		expect(() => cloudflaredAsset("linux", "riscv64")).toThrow(
+			/unsupported architecture/i,
+		);
+	});
+
+	test("rejects content whose checksum does not match", () => {
+		expect(() => verifySha256(Buffer.from("tampered"), "0".repeat(64))).toThrow(
+			/checksum mismatch/i,
+		);
+	});
+});

--- a/apps/server/test/unit/runtime-installer.test.ts
+++ b/apps/server/test/unit/runtime-installer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	durableRuntimeExecutable,
+	latestServeRuntimeVersion,
+} from "../../src/serve/runtime-installer.ts";
+
+describe("Serve runtime installer", () => {
+	test("uses a versioned durable executable path", () => {
+		expect(durableRuntimeExecutable("/data/zuse", "1.2.3")).toBe(
+			"/data/zuse/runtime/1.2.3/node_modules/@zusehq/serve/dist/bin.mjs",
+		);
+	});
+
+	test("reads the latest version from the package registry", async () => {
+		const version = await latestServeRuntimeVersion(
+			async () =>
+				new Response(JSON.stringify({ version: "1.4.0" }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		expect(version).toBe("1.4.0");
+	});
+});

--- a/apps/server/test/unit/serve-command.test.ts
+++ b/apps/server/test/unit/serve-command.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { parseServeCommand } from "../../src/serve/command.ts";
+
+describe("zuse serve management commands", () => {
+	it("starts serving when no management command is provided", () => {
+		expect(parseServeCommand(["serve"])).toEqual({
+			action: "start",
+			json: false,
+			foreground: false,
+			force: false,
+		});
+	});
+
+	it("parses status JSON output", () => {
+		expect(parseServeCommand(["serve", "status", "--json"])).toEqual({
+			action: "status",
+			json: true,
+			foreground: false,
+			force: false,
+		});
+	});
+
+	it("supports explicit foreground and forced update modes", () => {
+		expect(parseServeCommand(["serve", "--foreground"])).toEqual({
+			action: "start",
+			json: false,
+			foreground: true,
+			force: false,
+		});
+		expect(parseServeCommand(["serve", "update", "--force"])).toEqual({
+			action: "update",
+			json: false,
+			foreground: false,
+			force: true,
+		});
+	});
+
+	it("rejects unsupported commands and misplaced flags", () => {
+		expect(() => parseServeCommand(["serve", "restart"])).toThrow(
+			/Unknown zuse serve command/u,
+		);
+		expect(() => parseServeCommand(["serve", "status", "--force"])).toThrow(
+			/--force is only valid with update/u,
+		);
+	});
+});

--- a/apps/server/test/unit/serve-service-definition.test.ts
+++ b/apps/server/test/unit/serve-service-definition.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	launchAgentDefinition,
+	systemdUserDefinition,
+} from "../../src/serve/service-definition.ts";
+
+describe("Zuse Serve service definitions", () => {
+	it("creates a restartable macOS LaunchAgent without embedding credentials", () => {
+		const definition = launchAgentDefinition({
+			nodeExecutable: "/opt/node/bin/node",
+			executable: "/opt/zuse/bin/zuse",
+			dataDir: "/Users/dev/.local/share/zuse",
+			logDir: "/Users/dev/Library/Logs/Zuse",
+		});
+
+		expect(definition.label).toBe("sh.zuse.serve");
+		expect(definition.contents).toContain("<string>serve</string>");
+		expect(definition.contents).toContain("<string>--foreground</string>");
+		expect(definition.contents).toContain(
+			"<string>/Users/dev/.local/share/zuse</string>",
+		);
+		expect(definition.contents).toContain("<key>KeepAlive</key>");
+		expect(definition.contents).not.toMatch(/token|credential|authorization/iu);
+	});
+
+	it("creates a hardened Linux systemd user service", () => {
+		const definition = systemdUserDefinition({
+			nodeExecutable: "/opt/node/bin/node",
+			executable: "/home/dev/.local/bin/zuse",
+			dataDir: "/home/dev/.local/share/zuse",
+		});
+
+		expect(definition.unitName).toBe("zuse-serve.service");
+		expect(definition.contents).toContain(
+			'ExecStart="/opt/node/bin/node" "/home/dev/.local/bin/zuse" serve --foreground --data-dir "/home/dev/.local/share/zuse"',
+		);
+		expect(definition.contents).toContain("Restart=on-failure");
+		expect(definition.contents).toContain("NoNewPrivileges=true");
+		expect(definition.contents).not.toMatch(/token|credential|authorization/iu);
+	});
+});

--- a/apps/server/test/unit/workos-device-auth.test.ts
+++ b/apps/server/test/unit/workos-device-auth.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	pollDeviceAuthorization,
+	requestDeviceAuthorization,
+} from "../../src/auth/layers/workos-device-auth.ts";
+
+const ACCESS_TOKEN = "eyJhbGciOiJub25lIn0.eyJleHAiOjQxMDcyMDM2MDB9.signature";
+
+describe("WorkOS device authorization", () => {
+	it("requests a browserless device code", async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const fetcher: typeof fetch = async (input, init) => {
+			requests.push({ url: String(input), init });
+			return Response.json({
+				device_code: "device-secret",
+				user_code: "ABCD-EFGH",
+				verification_uri: "https://auth.example/device",
+				verification_uri_complete:
+					"https://auth.example/device?user_code=ABCD-EFGH",
+				expires_in: 300,
+				interval: 5,
+			});
+		};
+
+		const grant = await requestDeviceAuthorization("client_123", fetcher);
+
+		expect(grant).toEqual({
+			deviceCode: "device-secret",
+			userCode: "ABCD-EFGH",
+			verificationUri: "https://auth.example/device",
+			verificationUriComplete:
+				"https://auth.example/device?user_code=ABCD-EFGH",
+			expiresInSeconds: 300,
+			intervalSeconds: 5,
+		});
+		expect(requests[0]?.url).toContain("/user_management/authorize/device");
+		expect(String(requests[0]?.init?.body)).toBe("client_id=client_123");
+	});
+
+	it("respects pending and slowdown responses before returning a session", async () => {
+		const delays: number[] = [];
+		let attempt = 0;
+		const fetcher: typeof fetch = async () => {
+			attempt += 1;
+			if (attempt === 1) {
+				return Response.json(
+					{ error: "authorization_pending" },
+					{ status: 400 },
+				);
+			}
+			if (attempt === 2) {
+				return Response.json({ error: "slow_down" }, { status: 400 });
+			}
+			return Response.json({
+				access_token: ACCESS_TOKEN,
+				refresh_token: "refresh-token",
+				user: { id: "user_123", email: "dev@example.com" },
+			});
+		};
+
+		const session = await pollDeviceAuthorization(
+			"client_123",
+			{
+				deviceCode: "device-secret",
+				userCode: "ABCD-EFGH",
+				verificationUri: "https://auth.example/device",
+				verificationUriComplete:
+					"https://auth.example/device?user_code=ABCD-EFGH",
+				expiresInSeconds: 300,
+				intervalSeconds: 5,
+			},
+			{
+				fetcher,
+				sleep: async (milliseconds) => {
+					delays.push(milliseconds);
+				},
+				now: () => 0,
+			},
+		);
+
+		expect(delays).toEqual([5_000, 10_000]);
+		expect(session.user.email).toBe("dev@example.com");
+		expect(session.refreshToken).toBe("refresh-token");
+	});
+
+	it("fails immediately when the user denies authorization", async () => {
+		const fetcher: typeof fetch = async () =>
+			Response.json({ error: "access_denied" }, { status: 400 });
+
+		await expect(
+			pollDeviceAuthorization(
+				"client_123",
+				{
+					deviceCode: "device-secret",
+					userCode: "ABCD-EFGH",
+					verificationUri: "https://auth.example/device",
+					verificationUriComplete: "https://auth.example/device?user_code=x",
+					expiresInSeconds: 300,
+					intervalSeconds: 5,
+				},
+				{ fetcher, sleep: async () => {}, now: () => 0 },
+			),
+		).rejects.toThrow(/denied/u);
+	});
+});

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -52,7 +52,11 @@ export default defineConfig([
 	},
 	{
 		...shared,
-		entry: { index: "src/index.ts", runtime: "src/runtime.ts" },
+		entry: {
+			index: "src/index.ts",
+			runtime: "src/runtime.ts",
+			"serve-cli": "src/serve/package-cli.ts",
+		},
 		dts: false,
 	},
 ]);

--- a/bun.lock
+++ b/bun.lock
@@ -478,7 +478,7 @@
         "zuse": "./dist/bin.mjs",
       },
       "dependencies": {
-        "@zuse/server": "*",
+        "@zuse/server": "0.0.0",
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
@@ -561,6 +561,23 @@
         "@repo/typescript-config": "*",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+    },
+    "packages/zusehq": {
+      "name": "zusehq",
+      "version": "0.0.0",
+      "bin": {
+        "zusehq": "./dist/bin.mjs",
+      },
+      "dependencies": {
+        "@zusehq/serve": "0.0.0",
+      },
+      "devDependencies": {
+        "@repo/typescript-config": "*",
+        "@types/node": "catalog:",
+        "tsdown": "0.21.10",
+        "typescript": "catalog:",
+        "vite-plus": "0.2.5",
       },
     },
     "tests/system": {
@@ -4596,6 +4613,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "http://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "zusehq": ["zusehq@workspace:packages/zusehq"],
 
     "zwitch": ["zwitch@2.0.4", "http://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -471,6 +471,23 @@
         "typescript": "catalog:",
       },
     },
+    "packages/serve": {
+      "name": "@zusehq/serve",
+      "version": "0.0.0",
+      "bin": {
+        "zuse": "./dist/bin.mjs",
+      },
+      "dependencies": {
+        "@zuse/server": "*",
+      },
+      "devDependencies": {
+        "@repo/typescript-config": "*",
+        "@types/node": "catalog:",
+        "tsdown": "0.21.10",
+        "typescript": "catalog:",
+        "vite-plus": "0.2.5",
+      },
+    },
     "packages/sqlite": {
       "name": "@zuse/sqlite",
       "version": "0.0.0",
@@ -2137,6 +2154,8 @@
     "@zuse/testkit": ["@zuse/testkit@workspace:tests/testkit"],
 
     "@zuse/utils": ["@zuse/utils@workspace:packages/utils"],
+
+    "@zusehq/serve": ["@zusehq/serve@workspace:packages/serve"],
 
     "abbrev": ["abbrev@4.0.0", "http://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
 

--- a/infra/relay/drizzle/migrations/0002_absurd_leader.sql
+++ b/infra/relay/drizzle/migrations/0002_absurd_leader.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "relay_revoked_dpop_keys" (
+	"thumbprint" text PRIMARY KEY NOT NULL,
+	"revoked_at" bigint NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "relay_devices" DROP CONSTRAINT "relay_devices_platform_check";--> statement-breakpoint
+ALTER TABLE "relay_devices" ADD COLUMN "dpop_thumbprint" text;--> statement-breakpoint
+UPDATE "relay_devices" SET "dpop_thumbprint" = "device_id" WHERE "dpop_thumbprint" IS NULL;--> statement-breakpoint
+ALTER TABLE "relay_devices" ALTER COLUMN "dpop_thumbprint" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "relay_environments" ADD COLUMN "runtime_version" text;--> statement-breakpoint
+ALTER TABLE "relay_environments" ADD COLUMN "wire_protocol_version" bigint;--> statement-breakpoint
+ALTER TABLE "relay_environments" ADD COLUMN "capabilities" jsonb;--> statement-breakpoint
+ALTER TABLE "relay_environments" ADD COLUMN "service_state" text;--> statement-breakpoint
+ALTER TABLE "relay_devices" ADD CONSTRAINT "relay_devices_platform_check" CHECK ("relay_devices"."platform" IN ('ios', 'android', 'web', 'desktop'));--> statement-breakpoint
+ALTER TABLE "relay_environments" ADD CONSTRAINT "relay_environments_service_state_check" CHECK ("relay_environments"."service_state" IS NULL OR "relay_environments"."service_state" IN ('starting', 'healthy', 'degraded', 'stopped', 'updating'));

--- a/infra/relay/drizzle/migrations/meta/0002_snapshot.json
+++ b/infra/relay/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,557 @@
+{
+  "id": "85c0c36a-f242-466e-ac8c-6383c96612ee",
+  "prevId": "a05aa020-1884-476e-8454-f395ddf974a5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.relay_agent_activity": {
+      "name": "relay_agent_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "relay_agent_activity_env_idx": {
+          "name": "relay_agent_activity_env_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relay_agent_activity_kind_check": {
+          "name": "relay_agent_activity_kind_check",
+          "value": "\"relay_agent_activity\".\"kind\" IN ('approval-needed', 'question-needed', 'completed', 'error', 'running')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.relay_devices": {
+      "name": "relay_devices",
+      "schema": "",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_jwk": {
+          "name": "dpop_jwk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_thumbprint": {
+          "name": "dpop_thumbprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "relay_devices_account_idx": {
+          "name": "relay_devices_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relay_devices_platform_check": {
+          "name": "relay_devices_platform_check",
+          "value": "\"relay_devices\".\"platform\" IN ('ios', 'android', 'web', 'desktop')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.relay_dpop_proofs": {
+      "name": "relay_dpop_proofs",
+      "schema": "",
+      "columns": {
+        "thumbprint": {
+          "name": "thumbprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "relay_dpop_proofs_expiry_idx": {
+          "name": "relay_dpop_proofs_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relay_dpop_proofs_thumbprint_jti_pk": {
+          "name": "relay_dpop_proofs_thumbprint_jti_pk",
+          "columns": [
+            "thumbprint",
+            "jti"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relay_environment_credentials": {
+      "name": "relay_environment_credentials",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_hash": {
+          "name": "credential_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relay_environment_credentials_env_idx": {
+          "name": "relay_environment_credentials_env_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "relay_environment_credentials_environment_id_relay_environments_environment_id_fk": {
+          "name": "relay_environment_credentials_environment_id_relay_environments_environment_id_fk",
+          "tableFrom": "relay_environment_credentials",
+          "tableTo": "relay_environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "environment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relay_environments": {
+      "name": "relay_environments",
+      "schema": "",
+      "columns": {
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_public_key": {
+          "name": "environment_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_base_url": {
+          "name": "http_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ws_base_url": {
+          "name": "ws_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tunnel_hostname": {
+          "name": "tunnel_hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_record_id": {
+          "name": "dns_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tunnel_status": {
+          "name": "tunnel_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wire_protocol_version": {
+          "name": "wire_protocol_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_state": {
+          "name": "service_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relay_environments_account_idx": {
+          "name": "relay_environments_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relay_environments_provider_kind_check": {
+          "name": "relay_environments_provider_kind_check",
+          "value": "\"relay_environments\".\"provider_kind\" IN ('desktop', 'ssh', 'cloud')"
+        },
+        "relay_environments_tunnel_status_check": {
+          "name": "relay_environments_tunnel_status_check",
+          "value": "\"relay_environments\".\"tunnel_status\" IS NULL OR \"relay_environments\".\"tunnel_status\" IN ('reserved', 'ready')"
+        },
+        "relay_environments_service_state_check": {
+          "name": "relay_environments_service_state_check",
+          "value": "\"relay_environments\".\"service_state\" IS NULL OR \"relay_environments\".\"service_state\" IN ('starting', 'healthy', 'degraded', 'stopped', 'updating')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.relay_link_challenges": {
+      "name": "relay_link_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relay_issuer": {
+          "name": "relay_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relay_link_challenges_account_idx": {
+          "name": "relay_link_challenges_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relay_revoked_dpop_keys": {
+      "name": "relay_revoked_dpop_keys",
+      "schema": "",
+      "columns": {
+        "thumbprint": {
+          "name": "thumbprint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/infra/relay/drizzle/migrations/meta/_journal.json
+++ b/infra/relay/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783337014409,
       "tag": "0001_next_catseye",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785356077643,
+      "tag": "0002_absurd_leader",
+      "breakpoints": true
     }
   ]
 }

--- a/infra/relay/drizzle/schema.ts
+++ b/infra/relay/drizzle/schema.ts
@@ -43,6 +43,10 @@ export const relayEnvironments = pgTable(
     tunnelStatus: text("tunnel_status"),
     linkedAt: bigint("linked_at", { mode: "number" }).notNull(),
     lastSeenAt: bigint("last_seen_at", { mode: "number" }),
+    runtimeVersion: text("runtime_version"),
+    wireProtocolVersion: bigint("wire_protocol_version", { mode: "number" }),
+    capabilities: jsonb("capabilities"),
+    serviceState: text("service_state"),
   },
   (table) => [
     index("relay_environments_account_idx").on(table.accountId),
@@ -54,6 +58,10 @@ export const relayEnvironments = pgTable(
       "relay_environments_tunnel_status_check",
       sql`${table.tunnelStatus} IS NULL OR ${table.tunnelStatus} IN ('reserved', 'ready')`,
     ),
+    check(
+      "relay_environments_service_state_check",
+      sql`${table.serviceState} IS NULL OR ${table.serviceState} IN ('starting', 'healthy', 'degraded', 'stopped', 'updating')`,
+    ),
   ],
 );
 
@@ -63,7 +71,9 @@ export const relayEnvironmentCredentials = pgTable(
     credentialId: text("credential_id").primaryKey(),
     environmentId: text("environment_id")
       .notNull()
-      .references(() => relayEnvironments.environmentId, { onDelete: "cascade" }),
+      .references(() => relayEnvironments.environmentId, {
+        onDelete: "cascade",
+      }),
     accountId: text("account_id").notNull(),
     credentialHash: text("credential_hash").notNull(),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),
@@ -82,16 +92,22 @@ export const relayDevices = pgTable(
     platform: text("platform").notNull(),
     pushToken: text("push_token"),
     dpopJwk: jsonb("dpop_jwk"),
+    dpopThumbprint: text("dpop_thumbprint").notNull(),
     updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
   },
   (table) => [
     index("relay_devices_account_idx").on(table.accountId),
     check(
       "relay_devices_platform_check",
-      sql`${table.platform} IN ('ios', 'android', 'web')`,
+      sql`${table.platform} IN ('ios', 'android', 'web', 'desktop')`,
     ),
   ],
 );
+
+export const relayRevokedDpopKeys = pgTable("relay_revoked_dpop_keys", {
+  thumbprint: text("thumbprint").primaryKey(),
+  revokedAt: bigint("revoked_at", { mode: "number" }).notNull(),
+});
 
 export const relayDpopProofs = pgTable(
   "relay_dpop_proofs",
@@ -119,7 +135,10 @@ export const relayAgentActivity = pgTable(
     occurredAt: bigint("occurred_at", { mode: "number" }).notNull(),
   },
   (table) => [
-    index("relay_agent_activity_env_idx").on(table.environmentId, table.occurredAt),
+    index("relay_agent_activity_env_idx").on(
+      table.environmentId,
+      table.occurredAt,
+    ),
     check(
       "relay_agent_activity_kind_check",
       sql`${table.kind} IN ('approval-needed', 'question-needed', 'completed', 'error', 'running')`,

--- a/infra/relay/src/auth.ts
+++ b/infra/relay/src/auth.ts
@@ -8,9 +8,9 @@ import {
   verifyAccessToken,
   verifyDpopProof,
 } from "./crypto.ts";
-import { forbidden, unauthorized, type RelayError } from "./errors.ts";
+import { forbidden, type RelayError, unauthorized } from "./errors.ts";
 import { RelayStore } from "./store.ts";
-import { WorkosVerifier, type WorkosPrincipal } from "./workos.ts";
+import { type WorkosPrincipal, WorkosVerifier } from "./workos.ts";
 
 export const RELAY_SCOPES = {
   status: "environment:status",
@@ -23,19 +23,19 @@ export type RelayScope = (typeof RELAY_SCOPES)[keyof typeof RELAY_SCOPES];
 /** Require a valid WorkOS access token (Authorization: Bearer …). */
 export const requireWorkos = (
   request: Request,
-): Effect.Effect<
-  WorkosPrincipal,
-  RelayError,
-  WorkosVerifier
-> =>
+): Effect.Effect<WorkosPrincipal, RelayError, WorkosVerifier> =>
   Effect.gen(function* () {
     const header = request.headers.get("authorization") ?? "";
     const match = /^Bearer (.+)$/i.exec(header);
     if (match === null) {
       return yield* Effect.fail(unauthorized("missing_bearer"));
     }
+    const token = match[1];
+    if (token === undefined) {
+      return yield* Effect.fail(unauthorized("missing_bearer"));
+    }
     const verifier = yield* WorkosVerifier;
-    return yield* verifier.verify(match[1]!);
+    return yield* verifier.verify(token);
   });
 
 /**
@@ -58,7 +58,11 @@ export const requireEnvironmentCredential = (
     if (match === null) {
       return yield* Effect.fail(unauthorized("missing_environment_credential"));
     }
-    const hash = yield* sha256Hex(match[1]!);
+    const secret = match[1];
+    if (secret === undefined) {
+      return yield* Effect.fail(unauthorized("missing_environment_credential"));
+    }
+    const hash = yield* sha256Hex(secret);
     const credential = yield* store.findActiveCredentialByHash(hash);
     if (credential === null) {
       return yield* Effect.fail(unauthorized("invalid_environment_credential"));
@@ -100,10 +104,14 @@ export const requireDpop = (
     if (tokenMatch === null || proof === null) {
       return yield* Effect.fail(unauthorized("missing_dpop"));
     }
+    const token = tokenMatch[1];
+    if (token === undefined) {
+      return yield* Effect.fail(unauthorized("missing_dpop"));
+    }
 
     const mintPublicJwk = yield* parseJwk(config.mintPublicKey);
     const claims = yield* verifyAccessToken({
-      token: tokenMatch[1]!,
+      token,
       mintPublicJwk,
       issuer: config.relayIssuer,
     });
@@ -119,6 +127,9 @@ export const requireDpop = (
     });
     if (dpop.thumbprint !== claims.thumbprint) {
       return yield* Effect.fail(unauthorized("dpop_key_mismatch"));
+    }
+    if (yield* store.isDpopThumbprintRevoked(dpop.thumbprint)) {
+      return yield* Effect.fail(unauthorized("client_revoked"));
     }
 
     const fresh = yield* store.consumeDpopProof({
@@ -166,6 +177,9 @@ export const mintAccessToken = (
       url: request.url,
       nowMs,
     });
+    if (yield* store.isDpopThumbprintRevoked(dpop.thumbprint)) {
+      return yield* Effect.fail(unauthorized("client_revoked"));
+    }
     const fresh = yield* store.consumeDpopProof({
       thumbprint: dpop.thumbprint,
       jti: dpop.jti,
@@ -176,7 +190,9 @@ export const mintAccessToken = (
       return yield* Effect.fail(unauthorized("dpop_replayed"));
     }
 
-    const mintPrivateJwk = yield* parseJwk(Redacted.value(config.mintPrivateKey));
+    const mintPrivateJwk = yield* parseJwk(
+      Redacted.value(config.mintPrivateKey),
+    );
     const accessToken = yield* signAccessToken({
       mintPrivateJwk,
       issuer: config.relayIssuer,

--- a/infra/relay/src/config.ts
+++ b/infra/relay/src/config.ts
@@ -40,6 +40,8 @@ export interface RelayConfig {
 	readonly connectTokenTtlMs: number;
 	readonly accessTokenTtlMs: number;
 	readonly presenceStaleMs: number;
+	readonly maxEnvironmentsPerAccount: number | null;
+	readonly allowedBrowserOrigins: ReadonlyArray<string>;
 	readonly managedTunnel?: ManagedTunnelConfig;
 }
 
@@ -53,6 +55,8 @@ const DEFAULTS = {
 	connectTokenTtlMs: 60 * 1000,
 	accessTokenTtlMs: 30 * 60 * 1000,
 	presenceStaleMs: 90 * 1000,
+	maxEnvironmentsPerAccount: 5 as number | null,
+	allowedBrowserOrigins: ["https://app.zuse.sh"] as ReadonlyArray<string>,
 } as const;
 
 export const layer = (

--- a/infra/relay/src/errors.ts
+++ b/infra/relay/src/errors.ts
@@ -26,5 +26,8 @@ export const badRequest = (code: string, detail?: string): RelayError =>
 export const gone = (code: string, detail?: string): RelayError =>
 	new RelayError({ code, status: 410, detail });
 
+export const conflict = (code: string, detail?: string): RelayError =>
+	new RelayError({ code, status: 409, detail });
+
 export const serviceUnavailable = (code: string, detail?: string): RelayError =>
 	new RelayError({ code, status: 503, detail });

--- a/infra/relay/src/handler.ts
+++ b/infra/relay/src/handler.ts
@@ -17,7 +17,14 @@ import {
 	signConnectToken,
 	verifyEnvironmentLinkProof,
 } from "./crypto.ts";
-import { badRequest, gone, notFound, type RelayError } from "./errors.ts";
+import {
+	badRequest,
+	conflict,
+	gone,
+	notFound,
+	serviceUnavailable,
+	type RelayError,
+} from "./errors.ts";
 import { ManagedTunnelProvider } from "./managed-tunnel.ts";
 import { PushDelivery } from "./push.ts";
 import {
@@ -43,6 +50,29 @@ const json = (body: unknown, status = 200): Response =>
 		headers: { "content-type": "application/json" },
 	});
 
+const withBrowserCors = (
+	response: Response,
+	request: Request,
+	allowedOrigins: ReadonlyArray<string>,
+): Response => {
+	const origin = request.headers.get("origin");
+	if (origin === null || !allowedOrigins.includes(origin)) return response;
+	const headers = new Headers(response.headers);
+	headers.set("access-control-allow-origin", origin);
+	headers.set("access-control-allow-credentials", "true");
+	headers.set("access-control-allow-methods", "GET, POST, DELETE, OPTIONS");
+	headers.set(
+		"access-control-allow-headers",
+		"authorization, content-type, dpop",
+	);
+	headers.set("vary", "Origin");
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+};
+
 const readJson = <A>(request: Request): Effect.Effect<A, RelayError> =>
 	Effect.tryPromise({
 		try: () => request.json() as Promise<A>,
@@ -53,7 +83,42 @@ const isProviderKind = (value: unknown): value is ProviderKind =>
 	value === "desktop" || value === "ssh" || value === "cloud";
 
 const isPlatform = (value: unknown): value is DevicePlatform =>
-	value === "ios" || value === "android" || value === "web";
+	value === "ios" ||
+	value === "android" ||
+	value === "web" ||
+	value === "desktop";
+
+const isServiceState = (
+	value: unknown,
+): value is EnvironmentRecord["serviceState"] =>
+	value === "starting" ||
+	value === "healthy" ||
+	value === "degraded" ||
+	value === "stopped" ||
+	value === "updating";
+
+const isCapabilityManifest = (
+	value: unknown,
+): value is {
+	readonly version: 1;
+	readonly features: ReadonlyArray<string>;
+} => {
+	if (value === null || typeof value !== "object") return false;
+	const candidate = value as {
+		readonly version?: unknown;
+		readonly features?: unknown;
+	};
+	return (
+		candidate.version === 1 &&
+		Array.isArray(candidate.features) &&
+		candidate.features.every(
+			(feature) =>
+				typeof feature === "string" &&
+				feature.length > 0 &&
+				feature.length <= 64,
+		)
+	);
+};
 
 const isActivityKind = (value: unknown): value is ActivityKind =>
 	value === "approval-needed" ||
@@ -169,6 +234,10 @@ const route = (
 					readonly wsBaseUrl?: string;
 				};
 				readonly label?: string;
+				readonly runtimeVersion?: string;
+				readonly wireProtocolVersion?: number;
+				readonly capabilities?: unknown;
+				readonly serviceState?: string;
 				readonly managedTunnel?: boolean;
 				readonly origin?: {
 					readonly localHttpHost?: string;
@@ -186,6 +255,19 @@ const route = (
 				typeof body.endpoint?.wsBaseUrl !== "string"
 			) {
 				return yield* Effect.fail(badRequest("invalid_environment"));
+			}
+			if (
+				(body.runtimeVersion !== undefined &&
+					(typeof body.runtimeVersion !== "string" ||
+						body.runtimeVersion.length > 64)) ||
+				(body.wireProtocolVersion !== undefined &&
+					(!Number.isInteger(body.wireProtocolVersion) ||
+						body.wireProtocolVersion < 1)) ||
+				(body.capabilities !== undefined &&
+					!isCapabilityManifest(body.capabilities)) ||
+				(body.serviceState !== undefined && !isServiceState(body.serviceState))
+			) {
+				return yield* Effect.fail(badRequest("invalid_environment_metadata"));
 			}
 
 			const challenge = yield* store.consumeChallenge(
@@ -208,17 +290,27 @@ const route = (
 				relayIssuer: config.relayIssuer,
 			});
 
-			yield* store.upsertEnvironment({
-				environmentId: body.environmentId,
-				accountId: principal.accountId,
-				orgId: principal.orgId,
-				providerKind: body.providerKind,
-				label: body.label,
-				environmentPublicKey: body.environmentPublicKey,
-				httpBaseUrl: body.endpoint.httpBaseUrl,
-				wsBaseUrl: body.endpoint.wsBaseUrl,
-				linkedAtMs: nowMs,
-			});
+			const registered = yield* store.registerEnvironment(
+				{
+					environmentId: body.environmentId,
+					accountId: principal.accountId,
+					orgId: principal.orgId,
+					providerKind: body.providerKind,
+					label: body.label,
+					environmentPublicKey: body.environmentPublicKey,
+					httpBaseUrl: body.endpoint.httpBaseUrl,
+					wsBaseUrl: body.endpoint.wsBaseUrl,
+					linkedAtMs: nowMs,
+					runtimeVersion: body.runtimeVersion,
+					wireProtocolVersion: body.wireProtocolVersion,
+					capabilities: body.capabilities,
+					serviceState: body.serviceState,
+				},
+				config.maxEnvironmentsPerAccount,
+			);
+			if (!registered) {
+				return yield* Effect.fail(conflict("computer_limit_reached"));
+			}
 
 			const credentialSecret = yield* randomToken("zenv");
 			const credentialId = yield* randomToken("cred", 8);
@@ -326,6 +418,19 @@ const route = (
 					providerKind: environment.providerKind,
 					endpoint: publicEndpoint(environment),
 					linkedAt: environment.linkedAtMs,
+					runtimeVersion: environment.runtimeVersion,
+					wireProtocolVersion: environment.wireProtocolVersion,
+					capabilities: environment.capabilities,
+					serviceState: environment.serviceState,
+					endpointHealth: {
+						lan: "unknown",
+						managed:
+							environment.tunnelStatus === "ready"
+								? "available"
+								: "unavailable",
+						checkedAt: nowMs,
+					},
+					lastHeartbeat: environment.lastSeenAtMs,
 				})),
 			});
 		}
@@ -355,14 +460,39 @@ const route = (
 			if (typeof body.deviceId !== "string" || !isPlatform(body.platform)) {
 				return yield* Effect.fail(badRequest("invalid_device"));
 			}
-			yield* store.upsertDevice({
+			const registered = yield* store.upsertDevice({
 				deviceId: body.deviceId,
 				accountId: principal.accountId,
 				platform: body.platform,
 				pushToken: body.pushToken,
 				dpopJwk: body.dpopJwk,
+				dpopThumbprint: principal.thumbprint,
 				updatedAtMs: nowMs,
 			});
+			if (!registered) {
+				return yield* Effect.fail(conflict("client_id_conflict"));
+			}
+			return json({ ok: true });
+		}
+
+		if (method === "GET" && path === "/v1/clients") {
+			const principal = yield* requireWorkos(request);
+			const devices = yield* store.listDevices(principal.accountId);
+			return json({
+				clients: devices.map((device) => ({
+					clientId: device.deviceId,
+					platform: device.platform,
+					lastSeenAt: device.updatedAtMs,
+				})),
+			});
+		}
+
+		const clientMatch = /^\/v1\/clients\/([^/]+)$/.exec(path);
+		if (method === "DELETE" && clientMatch !== null) {
+			const principal = yield* requireWorkos(request);
+			const clientId = decodeURIComponent(clientMatch[1] ?? "");
+			const revoked = yield* store.revokeDevice(clientId, principal.accountId);
+			if (!revoked) return yield* Effect.fail(notFound());
 			return json({ ok: true });
 		}
 
@@ -422,6 +552,8 @@ const route = (
 			) {
 				return yield* Effect.fail(notFound());
 			}
+			let requestedWireVersion: number | undefined;
+			let requireManaged = false;
 			let localPairing:
 				| {
 						readonly serverNonce: string;
@@ -431,12 +563,29 @@ const route = (
 				| undefined;
 			if (request.headers.get("content-type")?.includes("application/json")) {
 				const body = yield* readJson<{
+					readonly wireProtocolVersion?: unknown;
+					readonly requireManaged?: unknown;
 					readonly localPairing?: {
 						readonly serverNonce?: unknown;
 						readonly devicePublicKey?: unknown;
 						readonly transportCertificatePin?: unknown;
 					};
 				}>(request);
+				if (
+					(body.wireProtocolVersion !== undefined &&
+						(typeof body.wireProtocolVersion !== "number" ||
+							!Number.isInteger(body.wireProtocolVersion) ||
+							body.wireProtocolVersion < 1)) ||
+					(body.requireManaged !== undefined &&
+						typeof body.requireManaged !== "boolean")
+				) {
+					return yield* Effect.fail(badRequest("invalid_connect_request"));
+				}
+				requestedWireVersion =
+					typeof body.wireProtocolVersion === "number"
+						? body.wireProtocolVersion
+						: undefined;
+				requireManaged = body.requireManaged === true;
 				if (body.localPairing !== undefined) {
 					const { serverNonce, devicePublicKey, transportCertificatePin } =
 						body.localPairing;
@@ -461,6 +610,22 @@ const route = (
 						transportCertificatePin,
 					};
 				}
+			}
+			if (
+				requestedWireVersion !== undefined &&
+				environment.wireProtocolVersion !== undefined &&
+				requestedWireVersion !== environment.wireProtocolVersion
+			) {
+				return yield* Effect.fail(conflict("version_incompatible"));
+			}
+			if (
+				environment.serviceState === "degraded" ||
+				environment.serviceState === "stopped"
+			) {
+				return yield* Effect.fail(serviceUnavailable("service_unhealthy"));
+			}
+			if (requireManaged && environment.tunnelHostname === undefined) {
+				return yield* Effect.fail(serviceUnavailable("tunnel_unavailable"));
 			}
 			const connectToken = yield* signConnectToken({
 				mintPrivateJwk: yield* parseJwk(Redacted.value(config.mintPrivateKey)),
@@ -494,9 +659,29 @@ const route = (
 				?.toLowerCase()
 				.includes("application/json");
 			if (hasJsonBody === true) {
-				const body = yield* readJson<{ readonly origin?: unknown }>(request);
-				if (!isLoopbackOrigin(body.origin)) {
+				const body = yield* readJson<{
+					readonly origin?: unknown;
+					readonly runtimeVersion?: unknown;
+					readonly wireProtocolVersion?: unknown;
+					readonly capabilities?: unknown;
+					readonly serviceState?: unknown;
+				}>(request);
+				if (body.origin !== undefined && !isLoopbackOrigin(body.origin)) {
 					return yield* Effect.fail(badRequest("invalid_tunnel_origin"));
+				}
+				if (
+					(body.runtimeVersion !== undefined &&
+						(typeof body.runtimeVersion !== "string" ||
+							body.runtimeVersion.length > 64)) ||
+					(body.wireProtocolVersion !== undefined &&
+						(typeof body.wireProtocolVersion !== "number" ||
+							!Number.isInteger(body.wireProtocolVersion))) ||
+					(body.capabilities !== undefined &&
+						!isCapabilityManifest(body.capabilities)) ||
+					(body.serviceState !== undefined &&
+						!isServiceState(body.serviceState))
+				) {
+					return yield* Effect.fail(badRequest("invalid_environment_metadata"));
 				}
 				const environment = yield* store.getEnvironment(environmentId);
 				if (
@@ -505,21 +690,38 @@ const route = (
 				) {
 					return yield* Effect.fail(notFound());
 				}
-				const tunnel = yield* ManagedTunnelProvider;
-				if (!tunnel.enabled) {
-					return yield* Effect.fail(badRequest("managed_tunnel_disabled"));
+				if (body.origin !== undefined) {
+					const tunnel = yield* ManagedTunnelProvider;
+					if (!tunnel.enabled) {
+						return yield* Effect.fail(badRequest("managed_tunnel_disabled"));
+					}
+					const provisioned = yield* tunnel.provision({
+						accountId: principal.accountId,
+						environmentId,
+						origin: body.origin,
+					});
+					yield* store.setTunnelAllocation(environmentId, {
+						tunnelHostname: provisioned.tunnelHostname,
+						tunnelId: provisioned.tunnelId,
+						dnsRecordId: provisioned.dnsRecordId,
+						tunnelStatus: "ready",
+					});
 				}
-				const provisioned = yield* tunnel.provision({
-					accountId: principal.accountId,
-					environmentId,
-					origin: body.origin,
+				yield* store.touchEnvironment(environmentId, nowMs, {
+					runtimeVersion:
+						typeof body.runtimeVersion === "string"
+							? body.runtimeVersion
+							: undefined,
+					wireProtocolVersion:
+						typeof body.wireProtocolVersion === "number"
+							? body.wireProtocolVersion
+							: undefined,
+					capabilities: body.capabilities,
+					serviceState: isServiceState(body.serviceState)
+						? body.serviceState
+						: undefined,
 				});
-				yield* store.setTunnelAllocation(environmentId, {
-					tunnelHostname: provisioned.tunnelHostname,
-					tunnelId: provisioned.tunnelId,
-					dnsRecordId: provisioned.dnsRecordId,
-					tunnelStatus: "ready",
-				});
+				return json({ ok: true });
 			}
 			yield* store.touchEnvironment(environmentId, nowMs);
 			return json({ ok: true });
@@ -583,16 +785,32 @@ const route = (
 export const handleRequest = (
 	request: Request,
 ): Effect.Effect<Response, never, RelayContext> =>
-	route(request).pipe(
+	Effect.gen(function* () {
+		const config = yield* RelayConfiguration;
+		if (request.method.toUpperCase() === "OPTIONS") {
+			return withBrowserCors(
+				new Response(null, { status: 204 }),
+				request,
+				config.allowedBrowserOrigins,
+			);
+		}
+		const response = yield* route(request);
+		return withBrowserCors(response, request, config.allowedBrowserOrigins);
+	}).pipe(
 		Effect.catch((error: RelayError) =>
-			Effect.succeed(
-				json(
-					error.detail === undefined
-						? { error: error.code }
-						: { error: error.code, detail: error.detail },
-					error.status,
-				),
-			),
+			Effect.gen(function* () {
+				const config = yield* RelayConfiguration;
+				return withBrowserCors(
+					json(
+						error.detail === undefined
+							? { error: error.code }
+							: { error: error.code, detail: error.detail },
+						error.status,
+					),
+					request,
+					config.allowedBrowserOrigins,
+				);
+			}),
 		),
 		Effect.catchDefect((defect) =>
 			Effect.sync(() => {

--- a/infra/relay/src/store.ts
+++ b/infra/relay/src/store.ts
@@ -2,7 +2,13 @@ import { Context, Effect, Layer, Ref } from "effect";
 import { SqlClient } from "effect/unstable/sql";
 
 export type ProviderKind = "desktop" | "ssh" | "cloud";
-export type DevicePlatform = "ios" | "android" | "web";
+export type DevicePlatform = "ios" | "android" | "web" | "desktop";
+export type ServiceState =
+	| "starting"
+	| "healthy"
+	| "degraded"
+	| "stopped"
+	| "updating";
 export type ActivityKind =
 	| "approval-needed"
 	| "question-needed"
@@ -33,6 +39,10 @@ export interface EnvironmentRecord {
 	readonly tunnelStatus?: "reserved" | "ready";
 	readonly linkedAtMs: number;
 	readonly lastSeenAtMs?: number;
+	readonly runtimeVersion?: string;
+	readonly wireProtocolVersion?: number;
+	readonly capabilities?: unknown;
+	readonly serviceState?: ServiceState;
 }
 
 export interface TunnelAllocation {
@@ -57,6 +67,7 @@ export interface DeviceRecord {
 	readonly platform: DevicePlatform;
 	readonly pushToken?: string;
 	readonly dpopJwk?: unknown;
+	readonly dpopThumbprint: string;
 	readonly updatedAtMs: number;
 }
 
@@ -78,9 +89,10 @@ export interface RelayStoreApi {
 		challengeId: string,
 		accountId: string,
 	) => Effect.Effect<LinkChallengeRecord | null>;
-	readonly upsertEnvironment: (
+	readonly registerEnvironment: (
 		environment: EnvironmentRecord,
-	) => Effect.Effect<void>;
+		maxEnvironmentsPerAccount: number | null,
+	) => Effect.Effect<boolean>;
 	readonly listEnvironments: (
 		accountId: string,
 	) => Effect.Effect<ReadonlyArray<EnvironmentRecord>>;
@@ -90,6 +102,12 @@ export interface RelayStoreApi {
 	readonly touchEnvironment: (
 		environmentId: string,
 		lastSeenAtMs: number,
+		metadata?: {
+			readonly runtimeVersion?: string;
+			readonly wireProtocolVersion?: number;
+			readonly capabilities?: unknown;
+			readonly serviceState?: ServiceState;
+		},
 	) => Effect.Effect<void>;
 	/** Persist the managed-tunnel allocation for an environment. */
 	readonly setTunnelAllocation: (
@@ -111,10 +129,17 @@ export interface RelayStoreApi {
 	readonly findActiveCredentialByHash: (
 		credentialHash: string,
 	) => Effect.Effect<CredentialRecord | null>;
-	readonly upsertDevice: (device: DeviceRecord) => Effect.Effect<void>;
+	readonly upsertDevice: (device: DeviceRecord) => Effect.Effect<boolean>;
 	readonly listDevices: (
 		accountId: string,
 	) => Effect.Effect<ReadonlyArray<DeviceRecord>>;
+	readonly revokeDevice: (
+		deviceId: string,
+		accountId: string,
+	) => Effect.Effect<boolean>;
+	readonly isDpopThumbprintRevoked: (
+		thumbprint: string,
+	) => Effect.Effect<boolean>;
 	/** Returns true if the (thumbprint, jti) was fresh; false if it was a replay. */
 	readonly consumeDpopProof: (input: {
 		readonly thumbprint: string;
@@ -142,6 +167,7 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
 		const environments = yield* Ref.make(new Map<string, EnvironmentRecord>());
 		const credentials = yield* Ref.make(new Map<string, CredentialRecord>());
 		const devices = yield* Ref.make(new Map<string, DeviceRecord>());
+		const revokedDpopThumbprints = yield* Ref.make(new Set<string>());
 		const dpop = yield* Ref.make(new Set<string>());
 		const activities = yield* Ref.make<ActivityRecord[]>([]);
 
@@ -159,10 +185,33 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
 					next.delete(challengeId);
 					return [found, next];
 				}),
-			upsertEnvironment: (environment) =>
-				Ref.update(environments, (map) =>
-					new Map(map).set(environment.environmentId, environment),
-				),
+			registerEnvironment: (environment, maxEnvironmentsPerAccount) =>
+				Ref.modify(environments, (map) => {
+					const current = map.get(environment.environmentId);
+					if (
+						current !== undefined &&
+						current.accountId !== environment.accountId
+					) {
+						return [false, map];
+					}
+					const accountCount = [...map.values()].filter(
+						(candidate) => candidate.accountId === environment.accountId,
+					).length;
+					if (
+						current === undefined &&
+						maxEnvironmentsPerAccount !== null &&
+						accountCount >= maxEnvironmentsPerAccount
+					) {
+						return [false, map];
+					}
+					return [
+						true,
+						new Map(map).set(environment.environmentId, {
+							...current,
+							...environment,
+						}),
+					];
+				}),
 			listEnvironments: (accountId) =>
 				Ref.get(environments).pipe(
 					Effect.map((map) =>
@@ -173,11 +222,15 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
 				Ref.get(environments).pipe(
 					Effect.map((map) => map.get(environmentId) ?? null),
 				),
-			touchEnvironment: (environmentId, lastSeenAtMs) =>
+			touchEnvironment: (environmentId, lastSeenAtMs, metadata) =>
 				Ref.update(environments, (map) => {
 					const found = map.get(environmentId);
 					if (found === undefined) return map;
-					return new Map(map).set(environmentId, { ...found, lastSeenAtMs });
+					return new Map(map).set(environmentId, {
+						...found,
+						...metadata,
+						lastSeenAtMs,
+					});
 				}),
 			setTunnelAllocation: (environmentId, allocation) =>
 				Ref.update(environments, (map) => {
@@ -237,7 +290,13 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
 					),
 				),
 			upsertDevice: (device) =>
-				Ref.update(devices, (map) => new Map(map).set(device.deviceId, device)),
+				Ref.modify(devices, (map) => {
+					const current = map.get(device.deviceId);
+					if (current !== undefined && current.accountId !== device.accountId) {
+						return [false, map];
+					}
+					return [true, new Map(map).set(device.deviceId, device)];
+				}),
 			listDevices: (accountId) =>
 				Ref.get(devices).pipe(
 					Effect.map((map) =>
@@ -245,6 +304,28 @@ export const RelayStoreMemory: Layer.Layer<RelayStore> = Layer.effect(
 							(device) => device.accountId === accountId,
 						),
 					),
+				),
+			revokeDevice: (deviceId, accountId) =>
+				Ref.modify(devices, (map) => {
+					const found = map.get(deviceId);
+					if (found === undefined || found.accountId !== accountId) {
+						return [null, map] as const;
+					}
+					const next = new Map(map);
+					next.delete(deviceId);
+					return [found.dpopThumbprint, next] as const;
+				}).pipe(
+					Effect.flatMap((thumbprint) =>
+						thumbprint === null
+							? Effect.succeed(false)
+							: Ref.update(revokedDpopThumbprints, (set) =>
+									new Set(set).add(thumbprint),
+								).pipe(Effect.as(true)),
+					),
+				),
+			isDpopThumbprintRevoked: (thumbprint) =>
+				Ref.get(revokedDpopThumbprints).pipe(
+					Effect.map((set) => set.has(thumbprint)),
 				),
 			consumeDpopProof: (input) =>
 				Ref.modify(dpop, (set) => {
@@ -316,6 +397,10 @@ interface EnvironmentRow {
 	readonly tunnel_status: "reserved" | "ready" | null;
 	readonly linked_at: number;
 	readonly last_seen_at: number | null;
+	readonly runtime_version: string | null;
+	readonly wire_protocol_version: number | null;
+	readonly capabilities: unknown;
+	readonly service_state: ServiceState | null;
 }
 
 const toEnvironment = (row: EnvironmentRow): EnvironmentRecord => ({
@@ -334,6 +419,13 @@ const toEnvironment = (row: EnvironmentRow): EnvironmentRecord => ({
 	linkedAtMs: Number(row.linked_at),
 	lastSeenAtMs:
 		row.last_seen_at === null ? undefined : Number(row.last_seen_at),
+	runtimeVersion: row.runtime_version ?? undefined,
+	wireProtocolVersion:
+		row.wire_protocol_version === null
+			? undefined
+			: Number(row.wire_protocol_version),
+	capabilities: row.capabilities ?? undefined,
+	serviceState: row.service_state ?? undefined,
 });
 
 export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
@@ -382,29 +474,69 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
 							}),
 						),
 					),
-				upsertEnvironment: (env) =>
+				registerEnvironment: (env, maxEnvironmentsPerAccount) =>
 					orDie(
-						sql`
-            INSERT INTO relay_environments
-              (environment_id, account_id, org_id, provider_kind, label,
-               environment_public_key, http_base_url, ws_base_url, tunnel_hostname,
-               linked_at, last_seen_at)
-            VALUES (
-              ${env.environmentId}, ${env.accountId}, ${env.orgId ?? null},
-              ${env.providerKind}, ${env.label ?? null}, ${env.environmentPublicKey},
-              ${env.httpBaseUrl}, ${env.wsBaseUrl}, ${env.tunnelHostname ?? null},
-              ${env.linkedAtMs}, ${env.lastSeenAtMs ?? null}
+						sql<{ readonly registered: boolean }>`
+            WITH account_lock AS (
+              SELECT pg_advisory_xact_lock(
+                hashtextextended(${env.accountId}, 0)
+              )
+            ), allowed AS (
+              SELECT 1
+              FROM account_lock
+              WHERE (
+                EXISTS (
+                  SELECT 1 FROM relay_environments
+                  WHERE environment_id = ${env.environmentId}
+                    AND account_id = ${env.accountId}
+                )
+                OR (
+                  NOT EXISTS (
+                    SELECT 1 FROM relay_environments
+                    WHERE environment_id = ${env.environmentId}
+                  )
+                  AND (
+                    ${maxEnvironmentsPerAccount}::bigint IS NULL
+                    OR (
+                      SELECT COUNT(*) FROM relay_environments
+                      WHERE account_id = ${env.accountId}
+                    ) < ${maxEnvironmentsPerAccount}::bigint
+                  )
+                )
+              )
+            ), registered AS (
+              INSERT INTO relay_environments
+                (environment_id, account_id, org_id, provider_kind, label,
+                 environment_public_key, http_base_url, ws_base_url,
+                 tunnel_hostname, linked_at, last_seen_at, runtime_version,
+                 wire_protocol_version, capabilities, service_state)
+              SELECT
+                ${env.environmentId}, ${env.accountId}, ${env.orgId ?? null},
+                ${env.providerKind}, ${env.label ?? null},
+                ${env.environmentPublicKey}, ${env.httpBaseUrl},
+                ${env.wsBaseUrl}, ${env.tunnelHostname ?? null},
+                ${env.linkedAtMs}, ${env.lastSeenAtMs ?? null},
+                ${env.runtimeVersion ?? null}, ${env.wireProtocolVersion ?? null},
+                ${env.capabilities === undefined ? null : JSON.stringify(env.capabilities)},
+                ${env.serviceState ?? null}
+              FROM allowed
+              ON CONFLICT (environment_id) DO UPDATE SET
+                org_id = EXCLUDED.org_id,
+                provider_kind = EXCLUDED.provider_kind,
+                label = EXCLUDED.label,
+                environment_public_key = EXCLUDED.environment_public_key,
+                http_base_url = EXCLUDED.http_base_url,
+                ws_base_url = EXCLUDED.ws_base_url,
+                linked_at = EXCLUDED.linked_at,
+                runtime_version = EXCLUDED.runtime_version,
+                wire_protocol_version = EXCLUDED.wire_protocol_version,
+                capabilities = EXCLUDED.capabilities,
+                service_state = EXCLUDED.service_state
+              WHERE relay_environments.account_id = EXCLUDED.account_id
+              RETURNING environment_id
             )
-            ON CONFLICT (environment_id) DO UPDATE SET
-              account_id = EXCLUDED.account_id,
-              org_id = EXCLUDED.org_id,
-              provider_kind = EXCLUDED.provider_kind,
-              label = EXCLUDED.label,
-              environment_public_key = EXCLUDED.environment_public_key,
-              http_base_url = EXCLUDED.http_base_url,
-              ws_base_url = EXCLUDED.ws_base_url,
-              linked_at = EXCLUDED.linked_at
-          `.pipe(Effect.asVoid),
+            SELECT EXISTS(SELECT 1 FROM registered) AS registered
+          `.pipe(Effect.map((rows) => rows[0]?.registered === true)),
 					),
 				listEnvironments: (accountId) =>
 					orDie(
@@ -422,10 +554,19 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
 							Effect.map((rows) => (rows[0] ? toEnvironment(rows[0]) : null)),
 						),
 					),
-				touchEnvironment: (environmentId, lastSeenAtMs) =>
+				touchEnvironment: (environmentId, lastSeenAtMs, metadata) =>
 					orDie(
 						sql`
-            UPDATE relay_environments SET last_seen_at = ${lastSeenAtMs}
+            UPDATE relay_environments SET
+              last_seen_at = ${lastSeenAtMs},
+              runtime_version = COALESCE(${metadata?.runtimeVersion ?? null}, runtime_version),
+              wire_protocol_version = COALESCE(${metadata?.wireProtocolVersion ?? null}, wire_protocol_version),
+              capabilities = COALESCE(${
+								metadata?.capabilities === undefined
+									? null
+									: JSON.stringify(metadata.capabilities)
+							}, capabilities),
+              service_state = COALESCE(${metadata?.serviceState ?? null}, service_state)
             WHERE environment_id = ${environmentId}
           `.pipe(Effect.asVoid),
 					),
@@ -501,22 +642,26 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
 					),
 				upsertDevice: (device) =>
 					orDie(
-						sql`
+						sql<{ readonly device_id: string }>`
             INSERT INTO relay_devices
-              (device_id, account_id, platform, push_token, dpop_jwk, updated_at)
+              (device_id, account_id, platform, push_token, dpop_jwk,
+               dpop_thumbprint, updated_at)
             VALUES (
               ${device.deviceId}, ${device.accountId}, ${device.platform},
               ${device.pushToken ?? null},
               ${device.dpopJwk === undefined ? null : JSON.stringify(device.dpopJwk)},
+              ${device.dpopThumbprint},
               ${device.updatedAtMs}
             )
             ON CONFLICT (device_id) DO UPDATE SET
-              account_id = EXCLUDED.account_id,
               platform = EXCLUDED.platform,
               push_token = EXCLUDED.push_token,
               dpop_jwk = EXCLUDED.dpop_jwk,
+              dpop_thumbprint = EXCLUDED.dpop_thumbprint,
               updated_at = EXCLUDED.updated_at
-          `.pipe(Effect.asVoid),
+            WHERE relay_devices.account_id = EXCLUDED.account_id
+            RETURNING device_id
+          `.pipe(Effect.map((rows) => rows.length > 0)),
 					),
 				listDevices: (accountId) =>
 					orDie(
@@ -526,6 +671,7 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
 							readonly platform: DevicePlatform;
 							readonly push_token: string | null;
 							readonly dpop_jwk: unknown;
+							readonly dpop_thumbprint: string;
 							readonly updated_at: number;
 						}>`
               SELECT * FROM relay_devices WHERE account_id = ${accountId}
@@ -537,10 +683,36 @@ export const RelayStorePg: Layer.Layer<RelayStore, never, SqlClient.SqlClient> =
 									platform: row.platform,
 									pushToken: row.push_token ?? undefined,
 									dpopJwk: row.dpop_jwk ?? undefined,
+									dpopThumbprint: row.dpop_thumbprint,
 									updatedAtMs: Number(row.updated_at),
 								})),
 							),
 						),
+					),
+				revokeDevice: (deviceId, accountId) =>
+					orDie(
+						sql<{ readonly dpop_thumbprint: string }>`
+              WITH revoked AS (
+                DELETE FROM relay_devices
+                WHERE device_id = ${deviceId} AND account_id = ${accountId}
+                RETURNING dpop_thumbprint
+              ), blocked AS (
+                INSERT INTO relay_revoked_dpop_keys (thumbprint, revoked_at)
+                SELECT dpop_thumbprint, ${Date.now()} FROM revoked
+                ON CONFLICT (thumbprint) DO NOTHING
+                RETURNING thumbprint
+              )
+              SELECT dpop_thumbprint FROM revoked
+            `.pipe(Effect.map((rows) => rows.length > 0)),
+					),
+				isDpopThumbprintRevoked: (thumbprint) =>
+					orDie(
+						sql<{ readonly revoked: boolean }>`
+              SELECT EXISTS(
+                SELECT 1 FROM relay_revoked_dpop_keys
+                WHERE thumbprint = ${thumbprint}
+              ) AS revoked
+            `.pipe(Effect.map((rows) => rows[0]?.revoked === true)),
 					),
 				consumeDpopProof: (input) =>
 					orDie(

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -22,6 +22,8 @@ interface Env {
 	readonly WORKOS_API_KEY?: string;
 	readonly RELAY_MINT_PRIVATE_JWK: string;
 	readonly RELAY_MINT_PUBLIC_JWK: string;
+	readonly MAX_ENVIRONMENTS_PER_ACCOUNT?: string;
+	readonly ALLOWED_BROWSER_ORIGINS?: string;
 	// Managed Cloudflare tunnel (optional — absent disables provisioning).
 	readonly CF_API_TOKEN?: string;
 	readonly CF_ACCOUNT_ID?: string;
@@ -63,6 +65,7 @@ export const hyperdrivePoolConfig = (connectionString: string): PoolConfig => ({
 });
 
 const build = (env: Env): ReturnType<typeof makeRelay> => {
+	const configuredLimit = Number(env.MAX_ENVIRONMENTS_PER_ACCOUNT ?? "5");
 	const configLayer = Config.layer({
 		relayIssuer: env.RELAY_ISSUER,
 		workosJwksUrl: env.WORKOS_JWKS_URL,
@@ -72,6 +75,16 @@ const build = (env: Env): ReturnType<typeof makeRelay> => {
 			: undefined,
 		mintPrivateKey: Redacted.make(env.RELAY_MINT_PRIVATE_JWK),
 		mintPublicKey: env.RELAY_MINT_PUBLIC_JWK,
+		maxEnvironmentsPerAccount:
+			Number.isInteger(configuredLimit) && configuredLimit > 0
+				? configuredLimit
+				: null,
+		allowedBrowserOrigins: (
+			env.ALLOWED_BROWSER_ORIGINS ?? "https://app.zuse.sh"
+		)
+			.split(",")
+			.map((value) => value.trim())
+			.filter((value) => value.length > 0),
 		managedTunnel: managedTunnelConfig(env),
 	});
 	const dbLayer = PgClient.layerFrom(

--- a/infra/relay/test/integration/relay.test.ts
+++ b/infra/relay/test/integration/relay.test.ts
@@ -76,6 +76,7 @@ let identityDeletes: string[];
 
 const makeLayer = async (
 	managedTunnel?: Config.ManagedTunnelConfig,
+	maxEnvironmentsPerAccount?: number,
 ): Promise<Layer.Layer<RelayContext>> => {
 	mintKey = (await eddsa()) as KeyPair;
 	const configLayer = Config.layer({
@@ -87,6 +88,7 @@ const makeLayer = async (
 		),
 		mintPublicKey: JSON.stringify(await exportJWK(mintKey.publicKey)),
 		managedTunnel,
+		maxEnvironmentsPerAccount,
 	});
 	const pushLayer = Layer.succeed(
 		PushDelivery,
@@ -116,10 +118,12 @@ const makeLayer = async (
 	);
 };
 
-const linkEnvironment = async (input: {
+const requestEnvironmentLink = async (input: {
 	account: string;
 	environmentId: string;
-}): Promise<{ envKey: KeyPair; credential: string }> => {
+	runtimeVersion?: string;
+	wireProtocolVersion?: number;
+}): Promise<{ envKey: KeyPair; response: Response }> => {
 	const bearer = `test-token:${input.account}`;
 	const challengeRes = await relay.fetch(
 		new Request(`${RELAY_ISSUER}/v1/client/environment-link-challenges`, {
@@ -156,9 +160,26 @@ const linkEnvironment = async (input: {
 					wsBaseUrl: "ws://127.0.0.1:8787/rpc",
 				},
 				label: "Test Mac",
+				runtimeVersion: input.runtimeVersion,
+				wireProtocolVersion: input.wireProtocolVersion,
+				capabilities: {
+					version: 1,
+					features: ["agents", "files", "terminals"],
+				},
+				serviceState: "healthy",
 			}),
 		}),
 	);
+	return { envKey, response: linkRes };
+};
+
+const linkEnvironment = async (input: {
+	account: string;
+	environmentId: string;
+	runtimeVersion?: string;
+	wireProtocolVersion?: number;
+}): Promise<{ envKey: KeyPair; credential: string }> => {
+	const { envKey, response: linkRes } = await requestEnvironmentLink(input);
 	expect(linkRes.status).toBe(200);
 	const linked = (await linkRes.json()) as { environmentCredential: string };
 	return { envKey, credential: linked.environmentCredential };
@@ -199,6 +220,141 @@ beforeEach(async () => {
 });
 
 describe("@zuse/relay", () => {
+	test("allows the hosted product origin without opening relay CORS broadly", async () => {
+		const allowed = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/environments`, {
+				method: "OPTIONS",
+				headers: { origin: "https://app.zuse.sh" },
+			}),
+		);
+		expect(allowed.status).toBe(204);
+		expect(allowed.headers.get("access-control-allow-origin")).toBe(
+			"https://app.zuse.sh",
+		);
+
+		const denied = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/environments`, {
+				method: "OPTIONS",
+				headers: { origin: "https://untrusted.test" },
+			}),
+		);
+		expect(denied.headers.get("access-control-allow-origin")).toBeNull();
+	});
+
+	test("enforces the account computer limit without blocking an existing computer", async () => {
+		relay = makeRelay(await makeLayer(undefined, 1));
+		await linkEnvironment({
+			account: "user_limit",
+			environmentId: "env_first",
+		});
+
+		const second = await requestEnvironmentLink({
+			account: "user_limit",
+			environmentId: "env_second",
+		});
+		expect(second.response.status).toBe(409);
+		expect(await second.response.json()).toEqual({
+			error: "computer_limit_reached",
+		});
+
+		const same = await requestEnvironmentLink({
+			account: "user_limit",
+			environmentId: "env_first",
+		});
+		expect(same.response.status).toBe(200);
+	});
+
+	test("lists runtime and capability metadata without workspace content", async () => {
+		await linkEnvironment({
+			account: "user_metadata",
+			environmentId: "env_metadata",
+			runtimeVersion: "1.4.0",
+		});
+		const response = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/environments`, {
+				headers: { authorization: "Bearer test-token:user_metadata" },
+			}),
+		);
+		const body = (await response.json()) as {
+			environments: ReadonlyArray<Record<string, unknown>>;
+		};
+		expect(body.environments).toHaveLength(1);
+		expect(body.environments[0]).toMatchObject({
+			environmentId: "env_metadata",
+			runtimeVersion: "1.4.0",
+			serviceState: "healthy",
+			capabilities: {
+				version: 1,
+				features: ["agents", "files", "terminals"],
+			},
+		});
+		expect(JSON.stringify(body)).not.toContain("transcript");
+		expect(JSON.stringify(body)).not.toContain("toolOutput");
+	});
+
+	test("lists and revokes one browser without affecting the account", async () => {
+		await linkEnvironment({
+			account: "user_clients",
+			environmentId: "env_clients",
+		});
+		const device = (await ec()) as KeyPair;
+		const jwk = await exportJWK(device.publicKey);
+		const accessToken = await mintAccess("user_clients", device, jwk);
+		const devicesUrl = `${RELAY_ISSUER}/v1/mobile/devices`;
+		const registered = await relay.fetch(
+			new Request(devicesUrl, {
+				method: "POST",
+				headers: {
+					authorization: `DPoP ${accessToken}`,
+					dpop: await dpopProof(device, jwk, {
+						method: "POST",
+						url: devicesUrl,
+					}),
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					deviceId: "browser_one",
+					platform: "web",
+					dpopJwk: jwk,
+				}),
+			}),
+		);
+		expect(registered.status).toBe(200);
+
+		const listed = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/clients`, {
+				headers: { authorization: "Bearer test-token:user_clients" },
+			}),
+		);
+		expect(await listed.json()).toMatchObject({
+			clients: [{ clientId: "browser_one", platform: "web" }],
+		});
+
+		const revoked = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/clients/browser_one`, {
+				method: "DELETE",
+				headers: { authorization: "Bearer test-token:user_clients" },
+			}),
+		);
+		expect(revoked.status).toBe(200);
+
+		const statusUrl = `${RELAY_ISSUER}/v1/environments/env_clients/status`;
+		const afterRevocation = await relay.fetch(
+			new Request(statusUrl, {
+				method: "POST",
+				headers: {
+					authorization: `DPoP ${accessToken}`,
+					dpop: await dpopProof(device, jwk, {
+						method: "POST",
+						url: statusUrl,
+					}),
+				},
+			}),
+		);
+		expect(afterRevocation.status).toBe(401);
+		expect(await afterRevocation.json()).toEqual({ error: "client_revoked" });
+	});
+
 	test("links an environment, reports presence, and mints a connect token", async () => {
 		const { environmentId } = { environmentId: "env_1" };
 		const { credential } = await linkEnvironment({
@@ -275,6 +431,58 @@ describe("@zuse/relay", () => {
 			serverNonce: "discovery-nonce",
 			devicePublicKey: "D".repeat(43),
 			transportCertificatePin: "T".repeat(43),
+		});
+	});
+
+	test("returns stable route and wire compatibility errors", async () => {
+		const environmentId = "env_compatibility";
+		await linkEnvironment({
+			account: "user_compatibility",
+			environmentId,
+			wireProtocolVersion: 2,
+		});
+		const device = (await ec()) as KeyPair;
+		const jwk = await exportJWK(device.publicKey);
+		const accessToken = await mintAccess("user_compatibility", device, jwk);
+		const connectUrl = `${RELAY_ISSUER}/v1/environments/${environmentId}/connect`;
+
+		const incompatibleRequest = new Request(connectUrl, {
+			method: "POST",
+			headers: {
+				authorization: `DPoP ${accessToken}`,
+				dpop: await dpopProof(device, jwk, {
+					method: "POST",
+					url: connectUrl,
+				}),
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ wireProtocolVersion: 1 }),
+		});
+		const incompatible = await relay.fetch(incompatibleRequest);
+		expect(incompatible.status).toBe(409);
+		expect(await incompatible.json()).toEqual({
+			error: "version_incompatible",
+		});
+
+		const managedRequest = new Request(connectUrl, {
+			method: "POST",
+			headers: {
+				authorization: `DPoP ${accessToken}`,
+				dpop: await dpopProof(device, jwk, {
+					method: "POST",
+					url: connectUrl,
+				}),
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				wireProtocolVersion: 2,
+				requireManaged: true,
+			}),
+		});
+		const unavailable = await relay.fetch(managedRequest);
+		expect(unavailable.status).toBe(503);
+		expect(await unavailable.json()).toEqual({
+			error: "tunnel_unavailable",
 		});
 	});
 

--- a/infra/relay/wrangler.jsonc
+++ b/infra/relay/wrangler.jsonc
@@ -21,6 +21,8 @@
     "WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KWGQ818571ARFATQ3G9AR2Y2",
     // Public key only — the matching private key is a secret (RELAY_MINT_PRIVATE_JWK).
     "RELAY_MINT_PUBLIC_JWK": "{\"crv\":\"Ed25519\",\"x\":\"A2Ig1XwHKDznhyTbPD9IVTlJpaN4YImgQadx-Gl81Bs\",\"kty\":\"OKP\"}",
+    "MAX_ENVIRONMENTS_PER_ACCOUNT": "5",
+    "ALLOWED_BROWSER_ORIGINS": "https://app.zuse.sh",
 
     // Managed Cloudflare tunnel provisioning. Set all four to enable per-Mac
     // tunnels; leave any unset to disable (the relay then advertises the LAN

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -7,6 +7,7 @@
 		"./chat-threads": "./src/chat-threads.ts",
 		"./command-dispatch": "./src/command-dispatch.ts",
 		"./connection": "./src/connection.ts",
+		"./environment-scope": "./src/environment-scope.ts",
 		"./plan-interactions": "./src/plan-interactions.ts",
 		"./session-timeline": "./src/session-timeline.ts",
 		"./session-timeline-cache": "./src/session-timeline-cache.ts",

--- a/packages/client-runtime/src/environment-scope.ts
+++ b/packages/client-runtime/src/environment-scope.ts
@@ -1,0 +1,55 @@
+export type EnvironmentRoute =
+	| {
+			readonly environmentId: string;
+			readonly kind: "environment";
+			readonly resourceId: null;
+	  }
+	| {
+			readonly environmentId: string;
+			readonly kind: "chat" | "project";
+			readonly resourceId: string;
+	  };
+
+const encode = encodeURIComponent;
+
+export const environmentRoute = (
+	environmentId: string,
+	target?: { readonly threadId?: string; readonly projectId?: string },
+): string => {
+	const root = `/e/${encode(environmentId)}`;
+	if (target?.threadId !== undefined) {
+		return `${root}/chat/${encode(target.threadId)}`;
+	}
+	if (target?.projectId !== undefined) {
+		return `${root}/project/${encode(target.projectId)}`;
+	}
+	return root;
+};
+
+export const parseEnvironmentRoute = (
+	pathname: string,
+): EnvironmentRoute | null => {
+	const parts = pathname.split("/").filter(Boolean);
+	if (parts[0] !== "e" || parts[1] === undefined) return null;
+	const environmentId = decodeURIComponent(parts[1]);
+	if (parts.length === 2) {
+		return { environmentId, kind: "environment", resourceId: null };
+	}
+	if (
+		(parts[2] === "chat" || parts[2] === "project") &&
+		parts[3] !== undefined
+	) {
+		return {
+			environmentId,
+			kind: parts[2],
+			resourceId: decodeURIComponent(parts[3]),
+		};
+	}
+	return null;
+};
+
+export const scopedCacheKey = (
+	environmentId: string,
+	kind: string,
+	id: string,
+): string => `${environmentId}:${kind}:${id}`;

--- a/packages/client-runtime/test/unit/environment-scope.test.ts
+++ b/packages/client-runtime/test/unit/environment-scope.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	environmentRoute,
+	parseEnvironmentRoute,
+	scopedCacheKey,
+} from "../../src/environment-scope.ts";
+
+describe("environment scope", () => {
+	test("round trips hosted environment routes", () => {
+		expect(environmentRoute("env/a", { threadId: "thread b" })).toBe(
+			"/e/env%2Fa/chat/thread%20b",
+		);
+		expect(parseEnvironmentRoute("/e/env%2Fa/chat/thread%20b")).toEqual({
+			environmentId: "env/a",
+			kind: "chat",
+			resourceId: "thread b",
+		});
+	});
+
+	test("requires environment identity in cache keys", () => {
+		expect(scopedCacheKey("env_one", "project", "same-id")).toBe(
+			"env_one:project:same-id",
+		);
+		expect(scopedCacheKey("env_two", "project", "same-id")).toBe(
+			"env_two:project:same-id",
+		);
+	});
+
+	test("does not treat unscoped paths as a remote environment", () => {
+		expect(parseEnvironmentRoute("/chat/thread")).toBeNull();
+	});
+});

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -1,6 +1,9 @@
 import { Rpc } from "effect/unstable/rpc";
 import { Schema } from "effect";
 
+/** Public AuthKit client identifier shared by all Zuse clients. */
+export const WORKOS_PUBLIC_CLIENT_ID = "client_01KWGQ818571ARFATQ3G9AR2Y2";
+
 /**
  * WorkOS AuthKit identity — the first user-account primitive in Zuse.
  *

--- a/packages/contracts/src/connect.ts
+++ b/packages/contracts/src/connect.ts
@@ -1,5 +1,5 @@
-import { Rpc } from "effect/unstable/rpc";
 import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
 
 import { EnvironmentId } from "./ids.ts";
 
@@ -92,6 +92,48 @@ export class AdvertisedEndpoint extends Schema.Class<AdvertisedEndpoint>(
   isDefault: Schema.Boolean,
 }) {}
 
+export const CapabilityFeature = Schema.Literals([
+  "agents",
+  "chats",
+  "files",
+  "diffs",
+  "terminals",
+  "approvals",
+  "questions",
+  "previews",
+  "notifications",
+  "runtime-update",
+]);
+export type CapabilityFeature = typeof CapabilityFeature.Type;
+
+export class CapabilityManifest extends Schema.Class<CapabilityManifest>(
+  "CapabilityManifest",
+)({
+  version: Schema.Literal(1),
+  features: Schema.Array(CapabilityFeature),
+}) {}
+
+export const EnvironmentServiceState = Schema.Literals([
+  "starting",
+  "healthy",
+  "degraded",
+  "stopped",
+  "updating",
+]);
+export type EnvironmentServiceState = typeof EnvironmentServiceState.Type;
+
+export class EnvironmentEndpointHealth extends Schema.Class<EnvironmentEndpointHealth>(
+  "EnvironmentEndpointHealth",
+)({
+  lan: Schema.optional(
+    Schema.Literals(["available", "unavailable", "unknown"]),
+  ),
+  managed: Schema.optional(
+    Schema.Literals(["available", "unavailable", "unknown"]),
+  ),
+  checkedAt: Schema.Number,
+}) {}
+
 /**
  * Everything a client needs to identify and reach an environment. Keyed by
  * `environmentId` (never by "this laptop"), so the relay and clients treat
@@ -105,6 +147,12 @@ export class EnvironmentDescriptor extends Schema.Class<EnvironmentDescriptor>(
   endpoint: EnvironmentEndpoint,
   advertisedEndpoints: Schema.optional(Schema.Array(AdvertisedEndpoint)),
   label: Schema.optional(Schema.String),
+  runtimeVersion: Schema.optional(Schema.String),
+  wireProtocolVersion: Schema.optional(Schema.Number),
+  capabilities: Schema.optional(CapabilityManifest),
+  serviceState: Schema.optional(EnvironmentServiceState),
+  endpointHealth: Schema.optional(EnvironmentEndpointHealth),
+  lastHeartbeat: Schema.optional(Schema.Number),
 }) {}
 
 // ---------------------------------------------------------------------------

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -1,6 +1,13 @@
 import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
 
-import { EnvironmentEndpoint, ProviderKind } from "./connect.ts";
+import {
+	CapabilityManifest,
+	EnvironmentEndpoint,
+	EnvironmentEndpointHealth,
+	EnvironmentServiceState,
+	ProviderKind,
+} from "./connect.ts";
 import { EnvironmentId } from "./ids.ts";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +34,8 @@ export const RelayPaths = {
 	environments: "/v1/environments",
 	dpopToken: "/v1/client/dpop-token",
 	devices: "/v1/mobile/devices",
+	clients: "/v1/clients",
+	client: (clientId: string) => `/v1/clients/${encodeURIComponent(clientId)}`,
 	account: "/v1/account",
 	status: (environmentId: string) =>
 		`/v1/environments/${encodeURIComponent(environmentId)}/status`,
@@ -74,6 +83,10 @@ export class RelayLinkRequest extends Schema.Class<RelayLinkRequest>(
 	providerKind: ProviderKind,
 	endpoint: EnvironmentEndpoint,
 	label: Schema.optional(Schema.String),
+	runtimeVersion: Schema.optional(Schema.String),
+	wireProtocolVersion: Schema.optional(Schema.Number),
+	capabilities: Schema.optional(CapabilityManifest),
+	serviceState: Schema.optional(EnvironmentServiceState),
 }) {}
 
 export class RelayLinkResponse extends Schema.Class<RelayLinkResponse>(
@@ -98,6 +111,12 @@ export class RelayEnvironmentRecord extends Schema.Class<RelayEnvironmentRecord>
 	providerKind: ProviderKind,
 	endpoint: Schema.optional(EnvironmentEndpoint),
 	linkedAt: Schema.Number,
+	runtimeVersion: Schema.optional(Schema.String),
+	wireProtocolVersion: Schema.optional(Schema.Number),
+	capabilities: Schema.optional(CapabilityManifest),
+	serviceState: Schema.optional(EnvironmentServiceState),
+	endpointHealth: Schema.optional(EnvironmentEndpointHealth),
+	lastHeartbeat: Schema.optional(Schema.Number),
 }) {}
 
 export class RelayEnvironmentList extends Schema.Class<RelayEnvironmentList>(
@@ -152,7 +171,45 @@ export class RelayDeviceRegistration extends Schema.Class<RelayDeviceRegistratio
 	"RelayDeviceRegistration",
 )({
 	deviceId: Schema.String,
-	platform: Schema.Literals(["ios", "android", "web"]),
+	platform: Schema.Literals(["ios", "android", "web", "desktop"]),
 	pushToken: Schema.optional(Schema.String),
 	dpopJwk: Schema.optional(Schema.Unknown),
 }) {}
+
+export class RelayAuthorizedClient extends Schema.Class<RelayAuthorizedClient>(
+	"RelayAuthorizedClient",
+)({
+	clientId: Schema.String,
+	platform: Schema.Literals(["ios", "android", "web", "desktop"]),
+	label: Schema.optional(Schema.String),
+	lastSeenAt: Schema.Number,
+}) {}
+
+export class RelayAuthorizedClientList extends Schema.Class<RelayAuthorizedClientList>(
+	"RelayAuthorizedClientList",
+)({
+	clients: Schema.Array(RelayAuthorizedClient),
+}) {}
+
+export class RelayControlError extends Schema.TaggedErrorClass<RelayControlError>()(
+	"RelayControlError",
+	{ reason: Schema.String },
+) {}
+
+export const RelayEnvironmentsRpc = Rpc.make("relay.environments", {
+	payload: Schema.Void,
+	success: RelayEnvironmentList,
+	error: RelayControlError,
+});
+
+export const RelayClientsRpc = Rpc.make("relay.clients", {
+	payload: Schema.Void,
+	success: RelayAuthorizedClientList,
+	error: RelayControlError,
+});
+
+export const RelayRevokeClientRpc = Rpc.make("relay.revokeClient", {
+	payload: Schema.Struct({ clientId: Schema.String }),
+	success: Schema.Void,
+	error: RelayControlError,
+});

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -132,6 +132,11 @@ import {
 	PtyWriteRpc,
 } from "./pty.ts";
 import {
+	RelayClientsRpc,
+	RelayEnvironmentsRpc,
+	RelayRevokeClientRpc,
+} from "./relay.ts";
+import {
 	RepositorySettingsGetRpc,
 	RepositorySettingsUpdateRpc,
 } from "./repository-settings.ts";
@@ -257,6 +262,9 @@ export const MemoizeRpcs = RpcGroup.make(
 	RelayLinkRpc,
 	RelayStatusRpc,
 	RelayUnlinkRpc,
+	RelayEnvironmentsRpc,
+	RelayClientsRpc,
+	RelayRevokeClientRpc,
 	WorkspaceAddRpc,
 	WorkspaceListRpc,
 	WorkspaceRemoveRpc,

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@zusehq/serve",
+	"version": "0.0.0",
+	"description": "One-command remote access for Zuse workspaces",
+	"license": "MIT",
+	"type": "module",
+	"bin": {
+		"zuse": "./dist/bin.mjs"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "vp pack src/bin.ts",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@zuse/server": "0.0.0"
+	},
+	"devDependencies": {
+		"@repo/typescript-config": "*",
+		"@types/node": "catalog:",
+		"tsdown": "0.21.10",
+		"typescript": "catalog:",
+		"vite-plus": "0.2.5"
+	}
+}

--- a/packages/serve/src/bin.ts
+++ b/packages/serve/src/bin.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { runServePackageCli } from "@zuse/server/serve-cli";
+import packageMetadata from "../package.json" with { type: "json" };
+
+runServePackageCli(process.argv.slice(2), process.env, {
+	packageVersion: packageMetadata.version,
+}).catch((cause) => {
+	console.error(cause instanceof Error ? cause.message : String(cause));
+	process.exitCode = 1;
+});

--- a/packages/serve/src/cli-types.ts
+++ b/packages/serve/src/cli-types.ts
@@ -1,0 +1,6 @@
+export type ServeCli = (
+	argv: ReadonlyArray<string>,
+	env?: NodeJS.ProcessEnv,
+) => Promise<void>;
+
+export declare const runServeCli: ServeCli;

--- a/packages/serve/src/cli.ts
+++ b/packages/serve/src/cli.ts
@@ -1,0 +1,8 @@
+import { runServePackageCli } from "@zuse/server/serve-cli";
+import packageMetadata from "../package.json" with { type: "json" };
+import type { ServeCli } from "./cli-types.ts";
+
+export const runServeCli: ServeCli = (argv, env = process.env): Promise<void> =>
+	runServePackageCli(argv, env, {
+		packageVersion: packageMetadata.version,
+	});

--- a/packages/serve/tsconfig.json
+++ b/packages/serve/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "@repo/typescript-config/base.json",
+	"compilerOptions": {
+		"lib": ["ES2022"],
+		"module": "Preserve",
+		"moduleResolution": "Bundler",
+		"target": "ES2022",
+		"types": ["node"],
+		"noEmit": true,
+		"allowImportingTsExtensions": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/serve/tsdown.config.ts
+++ b/packages/serve/tsdown.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/bin.ts"],
+	format: "esm",
+	outDir: "dist",
+	outExtensions: () => ({ js: ".mjs" }),
+	sourcemap: true,
+	dts: false,
+	deps: {
+		alwaysBundle: [/.*/u, "@zuse/server", "@zuse/server/**"],
+		neverBundle: [
+			"bindings",
+			"keytar",
+			"node-pty",
+			"tree-sitter",
+			"tree-sitter-javascript",
+			"tree-sitter-json",
+			"tree-sitter-typescript",
+		],
+		onlyImport: [
+			"bindings",
+			"keytar",
+			"node-pty",
+			"tree-sitter",
+			"tree-sitter-javascript",
+			"tree-sitter-json",
+			"tree-sitter-typescript",
+		],
+	},
+});

--- a/packages/zusehq/package.json
+++ b/packages/zusehq/package.json
@@ -1,28 +1,27 @@
 {
-	"name": "@zusehq/serve",
+	"name": "zusehq",
 	"version": "0.0.0",
-	"description": "One-command remote access for Zuse workspaces",
+	"description": "Run and manage Zuse remote workspaces",
 	"license": "MIT",
 	"type": "module",
 	"bin": {
-		"zuse": "./dist/bin.mjs"
-	},
-	"exports": {
-		"./cli": {
-			"types": "./src/cli-types.ts",
-			"import": "./dist/cli.mjs"
-		}
+		"zusehq": "./dist/bin.mjs"
 	},
 	"files": [
-		"dist",
-		"src/cli-types.ts"
+		"dist"
+	],
+	"keywords": [
+		"zuse",
+		"coding-agent",
+		"remote-development",
+		"developer-tools"
 	],
 	"scripts": {
-		"build": "vp pack src/bin.ts src/cli.ts",
+		"build": "vp pack src/bin.ts",
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zuse/server": "0.0.0"
+		"@zusehq/serve": "0.0.0"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",

--- a/packages/zusehq/src/bin.ts
+++ b/packages/zusehq/src/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { runServeCli } from "./cli.ts";
+import { runServeCli } from "@zusehq/serve/cli";
 
 runServeCli(process.argv.slice(2), process.env).catch((cause) => {
 	console.error(cause instanceof Error ? cause.message : String(cause));

--- a/packages/zusehq/tsconfig.json
+++ b/packages/zusehq/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@repo/typescript-config/base.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"types": ["node"],
+		"noEmit": true
+	},
+	"include": ["src/**/*.ts", "tsdown.config.ts"]
+}

--- a/packages/zusehq/tsdown.config.ts
+++ b/packages/zusehq/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/bin.ts"],
+	format: "esm",
+	outDir: "dist",
+	outExtensions: () => ({ js: ".mjs" }),
+	sourcemap: true,
+	dts: false,
+	deps: {
+		neverBundle: ["@zusehq/serve", "@zusehq/serve/**"],
+	},
+});


### PR DESCRIPTION
## Summary

Adds the first end-to-end Zuse Serve implementation for registering a computer once and opening its workspace remotely from another authenticated client.

- publishes the canonical `@zusehq/serve` bootstrap and the discoverable `zusehq` alias package
- supports both `npx @zusehq/serve` and `npx zusehq serve` through one shared CLI implementation
- keeps canonical runtime version selection inside `@zusehq/serve` so alias releases cannot select the wrong runtime
- adds browserless WorkOS device authorization with refresh repair
- installs durable macOS LaunchAgent and Linux systemd user services
- downloads a pinned, checksum-verified managed tunnel runtime
- adds environment metadata, transactional computer limits, DPoP client identities, revocation, and stable route errors to the relay
- adds hosted browser authentication, environment-scoped routes and connections, and an account-level computer switcher
- preserves each computer as the authority for its own projects, chats, files, terminals, credentials, and database

## User impact

After the matching packages and infrastructure are deployed, a user can run `npx zusehq serve` or `npx @zusehq/serve`, approve the displayed code, and have that computer appear in the hosted product. Workspace traffic connects directly to the selected computer instead of using the relay as a data plane.

## Validation

- server typecheck
- relay typecheck
- client-runtime typecheck
- contracts typecheck
- renderer typecheck
- mobile typecheck
- server unit tests: 174 passed
- relay tests: 23 passed
- client-runtime unit tests: 46 passed
- renderer unit tests: 236 passed
- canonical and alias package typechecks and production builds
- exact alias invocation: `npx --no-install zusehq serve status --json`
- dry-run npm tarballs for both public packages
- server and renderer production builds

## Deployment boundaries

This PR does not publish packages or deploy production infrastructure. The `zusehq` name is currently unclaimed in the public npm registry, but it is not reserved until the first publish. Publish `@zuse/server` and `@zusehq/serve` before `zusehq`.

The relay migration, hosted renderer, managed-tunnel configuration, and two-computer cellular/reboot acceptance must be completed before presenting the command as generally available.

Preview sharing and automatic non-forced active-work-safe runtime updates remain capability-gated.