### PR TITLE
Prepare Serve packages for npm

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,10 +1,16 @@
 {
 	"name": "@zuse/server",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"private": false,
 	"type": "module",
 	"bin": {
 		"zuse": "./dist/bin.mjs"
+	},
+	"engines": {
+		"node": ">=22.5.0"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"files": [
 		"dist"
@@ -43,40 +49,40 @@
 		"test:live-agents": "vitest run ./test/live/agent-smoke.live.ts"
 	},
 	"dependencies": {
+		"keytar": "^7.9.0",
+		"node-pty": "^1.1.0",
+		"tree-sitter": "^0.21.1",
+		"tree-sitter-javascript": "^0.23.0",
+		"tree-sitter-json": "^0.24.0",
+		"tree-sitter-typescript": "^0.23.0"
+	},
+	"devDependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.2.126",
 		"@cursor/sdk": "1.0.23",
+		"@effect/vitest": "catalog:",
+		"@effect/platform-node": "catalog:",
 		"@modelcontextprotocol/sdk": "^1.0.0",
+		"@repo/typescript-config": "*",
+		"@types/node": "catalog:",
 		"@zuse/agents": "*",
 		"@zuse/analytics": "*",
+		"@zuse/contracts": "*",
 		"@zuse/domain": "*",
 		"@zuse/git": "*",
-		"@effect/platform-node": "catalog:",
 		"@zuse/index": "*",
 		"@zuse/pokemon-data": "*",
 		"@zuse/sqlite": "*",
-		"@zuse/contracts": "*",
 		"@zuse/utils": "*",
 		"effect": "catalog:",
 		"fuzzysort": "catalog:",
 		"jose": "^6.2.3",
-		"keytar": "^7.9.0",
-		"node-pty": "^1.1.0",
 		"smol-toml": "^1.3.1",
-		"tree-sitter": "^0.21.1",
-		"tree-sitter-javascript": "^0.23.0",
-		"tree-sitter-json": "^0.24.0",
-		"tree-sitter-typescript": "^0.23.0",
 		"tokenmaxer": "*",
-		"zod": "^4.0.0"
-	},
-	"devDependencies": {
-		"@effect/vitest": "catalog:",
-		"@repo/typescript-config": "*",
-		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"tsx": "4.23.0",
 		"tsdown": "0.21.10",
 		"vite-plus": "0.2.5",
-		"vitest": "catalog:"
+		"vitest": "catalog:",
+		"zod": "^4.0.0"
 	}
 }

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,11 +1,17 @@
 {
 	"name": "@zusehq/serve",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "One-command remote access for Zuse workspaces",
 	"license": "MIT",
 	"type": "module",
 	"bin": {
 		"zuse": "./dist/bin.mjs"
+	},
+	"engines": {
+		"node": ">=22.5.0"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"exports": {
 		"./cli": {
@@ -22,7 +28,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zuse/server": "0.0.0"
+		"@zuse/server": "0.1.0"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",

--- a/packages/zusehq/package.json
+++ b/packages/zusehq/package.json
@@ -1,11 +1,14 @@
 {
 	"name": "zusehq",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Run and manage Zuse remote workspaces",
 	"license": "MIT",
 	"type": "module",
 	"bin": {
 		"zusehq": "./dist/bin.mjs"
+	},
+	"engines": {
+		"node": ">=22.5.0"
 	},
 	"files": [
 		"dist"
@@ -21,7 +24,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zusehq/serve": "0.0.0"
+		"@zusehq/serve": "0.1.0"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",


### PR DESCRIPTION
## Summary
- publish the Serve runtime, bootstrap, and short command alias as version 0.1.0
- declare the supported Node.js runtime
- keep only native runtime modules in the published server dependency graph

## Verification
- server and renderer production build
- focused type checks and Biome checks
- npm pack for all three packages
- clean install into an empty directory
- native keychain and terminal module load checks
- `zusehq serve status --json` from the packed install