### PR TITLE
Publish Serve runtime under Zuse scope

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,65 +1,65 @@
 {
-  "name": "desktop",
-  "type": "module",
-  "productName": "Zuse (Beta)",
-  "version": "0.15.7",
-  "description": "Zuse (Beta) desktop app",
-  "private": true,
-  "author": {
-    "name": "Swaraj Bachu",
-    "email": "swarajkumar4444@gmail.com"
-  },
-  "homepage": "https://github.com/swarajbachu/zuse",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/swarajbachu/zuse.git"
-  },
-  "main": "dist-electron/main.cjs",
-  "scripts": {
-    "predev": "node scripts/build-local-connectivity-helper.mjs",
-    "dev": "bun run --parallel dev:bundle dev:electron",
-    "dev:bundle": "vp pack --watch",
-    "dev:electron": "node scripts/dev-electron.mjs",
-    "build": "vp pack && node scripts/main-bundle-startup-smoke.mjs",
-    "check-types": "tsc --noEmit",
-    "test": "vp test run test && node scripts/sqlite-runtime-smoke.mjs && node scripts/provider-sdk-runtime-smoke.mjs",
-    "test:unit": "vp test run test/unit",
-    "test:integration": "vp test run test/integration --passWithNoTests",
-    "postinstall": "electron-rebuild -f -o node-pty,keytar",
-    "icon": "node scripts/make-icon.mjs",
-    "native:build": "node scripts/build-local-connectivity-helper.mjs",
-    "native:build:universal": "node scripts/build-local-connectivity-helper.mjs --universal",
-    "predist:mac": "bun run native:build:universal",
-    "dist:mac": "electron-builder --mac --universal",
-    "predist:mac:unsigned": "bun run native:build:universal",
-    "dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
-  },
-  "dependencies": {
-    "@cursor/sdk": "1.0.23",
-    "electron-updater": "^6.3.9",
-    "keytar": "^7.9.0",
-    "node-pty": "^1.1.0",
-    "selfsigned": "^5.5.0",
-    "tree-sitter": "^0.21.1",
-    "tree-sitter-javascript": "^0.23.1",
-    "tree-sitter-json": "^0.24.8",
-    "tree-sitter-typescript": "^0.23.2"
-  },
-  "devDependencies": {
-    "@electron/rebuild": "^4.0.4",
-    "@zuse/server": "*",
-    "@zuse/ssh": "*",
-    "@zuse/contracts": "*",
-    "@repo/typescript-config": "*",
-    "@types/node": "catalog:",
-    "effect": "catalog:",
-    "electron-builder": "^25.1.8",
-    "electron": "42.4.1",
-    "fix-path": "^4.0.0",
-    "sharp": "^0.34.1",
-    "tsdown": "^0.21.10",
-    "typescript": "catalog:",
-    "vite-plus": "0.2.5",
-    "vitest": "catalog:"
-  }
+	"name": "desktop",
+	"type": "module",
+	"productName": "Zuse (Beta)",
+	"version": "0.15.7",
+	"description": "Zuse (Beta) desktop app",
+	"private": true,
+	"author": {
+		"name": "Swaraj Bachu",
+		"email": "swarajkumar4444@gmail.com"
+	},
+	"homepage": "https://github.com/swarajbachu/zuse",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/swarajbachu/zuse.git"
+	},
+	"main": "dist-electron/main.cjs",
+	"scripts": {
+		"predev": "node scripts/build-local-connectivity-helper.mjs",
+		"dev": "bun run --parallel dev:bundle dev:electron",
+		"dev:bundle": "vp pack --watch",
+		"dev:electron": "node scripts/dev-electron.mjs",
+		"build": "vp pack && node scripts/main-bundle-startup-smoke.mjs",
+		"check-types": "tsc --noEmit",
+		"test": "vp test run test && node scripts/sqlite-runtime-smoke.mjs && node scripts/provider-sdk-runtime-smoke.mjs",
+		"test:unit": "vp test run test/unit",
+		"test:integration": "vp test run test/integration --passWithNoTests",
+		"postinstall": "electron-rebuild -f -o node-pty,keytar",
+		"icon": "node scripts/make-icon.mjs",
+		"native:build": "node scripts/build-local-connectivity-helper.mjs",
+		"native:build:universal": "node scripts/build-local-connectivity-helper.mjs --universal",
+		"predist:mac": "bun run native:build:universal",
+		"dist:mac": "electron-builder --mac --universal",
+		"predist:mac:unsigned": "bun run native:build:universal",
+		"dist:mac:unsigned": "electron-builder --mac --universal -c.mac.identity=null --publish never"
+	},
+	"dependencies": {
+		"@cursor/sdk": "1.0.23",
+		"electron-updater": "^6.3.9",
+		"keytar": "^7.9.0",
+		"node-pty": "^1.1.0",
+		"selfsigned": "^5.5.0",
+		"tree-sitter": "^0.21.1",
+		"tree-sitter-javascript": "^0.23.1",
+		"tree-sitter-json": "^0.24.8",
+		"tree-sitter-typescript": "^0.23.2"
+	},
+	"devDependencies": {
+		"@electron/rebuild": "^4.0.4",
+		"@zusehq/server": "*",
+		"@zuse/ssh": "*",
+		"@zuse/contracts": "*",
+		"@repo/typescript-config": "*",
+		"@types/node": "catalog:",
+		"effect": "catalog:",
+		"electron-builder": "^25.1.8",
+		"electron": "42.4.1",
+		"fix-path": "^4.0.0",
+		"sharp": "^0.34.1",
+		"tsdown": "^0.21.10",
+		"typescript": "catalog:",
+		"vite-plus": "0.2.5",
+		"vitest": "catalog:"
+	}
 }

--- a/apps/desktop/src/browser-session-service.ts
+++ b/apps/desktop/src/browser-session-service.ts
@@ -11,7 +11,7 @@ import { homedir, tmpdir } from "node:os";
 import * as Path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
-import { secureStorageMasterKey } from "@zuse/server/secure-storage-master-key";
+import { secureStorageMasterKey } from "@zusehq/server/secure-storage-master-key";
 import type { Cookie, Session } from "electron";
 import keytar from "keytar";
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,7 +17,7 @@ import {
 	makeMainLayer,
 	readBrowserCredentialFromVault,
 	wsServerProtocolLayer,
-} from "@zuse/server";
+} from "@zusehq/server";
 import { Cause, Effect, Fiber, Layer } from "effect";
 import { RpcSerialization } from "effect/unstable/rpc";
 import {

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -67,7 +67,7 @@ const shared = {
 		alwaysBundle: [
 			"@zuse/contracts",
 			"@zuse/agents",
-			"@zuse/server",
+			"@zusehq/server",
 			"@zuse/sqlite",
 			"@zuse/index",
 			"@zuse/ssh",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "@zuse/server",
+	"name": "@zusehq/server",
 	"version": "0.1.0",
 	"private": false,
 	"type": "module",
 	"bin": {
-		"zuse": "./dist/bin.mjs"
+		"zuse": "dist/bin.mjs"
 	},
 	"engines": {
 		"node": ">=22.5.0"

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -4,7 +4,7 @@
  * deps without Electron: file-backed AppPaths resolved from env/XDG, a no-op
  * FolderPicker, and the WebSocket transport. This same binary is what runs on
  * an SSH dev-box and (later) on a cloud container — there is no laptop
- * assumption anywhere in `@zuse/server` (ADR 0007).
+ * assumption anywhere in `@zusehq/server` (ADR 0007).
  *
  * Per ADR 0007, transport modules live under `transports/` — never inside a
  * service domain. The factory (`makeMainLayer`) is re-exported so the Electron

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Public surface of `@zuse/server`. The Electron shim consumes this; a
+ * Public surface of `@zusehq/server`. The Electron shim consumes this; a
  * future headless server boot script (`bin.ts`) re-exports it too. Anything
  * not re-exported here is internal — keep the surface minimal.
  */

--- a/apps/server/src/linear/services/linear-service.ts
+++ b/apps/server/src/linear/services/linear-service.ts
@@ -74,4 +74,4 @@ export interface LinearServiceShape {
 export class LinearService extends Context.Service<
 	LinearService,
 	LinearServiceShape
->()("@zuse/server/linear/LinearService") {}
+>()("@zusehq/server/linear/LinearService") {}

--- a/apps/server/tsdown.config.ts
+++ b/apps/server/tsdown.config.ts
@@ -17,7 +17,7 @@ const shared = {
 			"@zuse/git/**",
 			"@zuse/index",
 			"@zuse/pokemon-data",
-			"@zuse/server",
+			"@zusehq/server",
 			"@zuse/sqlite",
 			"@zuse/utils",
 			"@zuse/utils/**",

--- a/bun.lock
+++ b/bun.lock
@@ -39,8 +39,8 @@
         "@repo/typescript-config": "*",
         "@types/node": "catalog:",
         "@zuse/contracts": "*",
-        "@zuse/server": "*",
         "@zuse/ssh": "*",
+        "@zusehq/server": "*",
         "effect": "catalog:",
         "electron": "42.4.1",
         "electron-builder": "^25.1.8",
@@ -219,16 +219,27 @@
       },
     },
     "apps/server": {
-      "name": "@zuse/server",
-      "version": "0.0.0",
+      "name": "@zusehq/server",
+      "version": "0.1.0",
       "bin": {
-        "zuse": "./dist/bin.mjs",
+        "zuse": "dist/bin.mjs",
       },
       "dependencies": {
+        "keytar": "^7.9.0",
+        "node-pty": "^1.1.0",
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-javascript": "^0.23.0",
+        "tree-sitter-json": "^0.24.0",
+        "tree-sitter-typescript": "^0.23.0",
+      },
+      "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.126",
         "@cursor/sdk": "1.0.23",
         "@effect/platform-node": "catalog:",
+        "@effect/vitest": "catalog:",
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "@repo/typescript-config": "*",
+        "@types/node": "catalog:",
         "@zuse/agents": "*",
         "@zuse/analytics": "*",
         "@zuse/contracts": "*",
@@ -241,25 +252,14 @@
         "effect": "catalog:",
         "fuzzysort": "catalog:",
         "jose": "^6.2.3",
-        "keytar": "^7.9.0",
-        "node-pty": "^1.1.0",
         "smol-toml": "^1.3.1",
         "tokenmaxer": "*",
-        "tree-sitter": "^0.21.1",
-        "tree-sitter-javascript": "^0.23.0",
-        "tree-sitter-json": "^0.24.0",
-        "tree-sitter-typescript": "^0.23.0",
-        "zod": "^4.0.0",
-      },
-      "devDependencies": {
-        "@effect/vitest": "catalog:",
-        "@repo/typescript-config": "*",
-        "@types/node": "catalog:",
         "tsdown": "0.21.10",
         "tsx": "4.23.0",
         "typescript": "catalog:",
         "vite-plus": "0.2.5",
         "vitest": "catalog:",
+        "zod": "^4.0.0",
       },
     },
     "apps/web": {
@@ -473,12 +473,12 @@
     },
     "packages/serve": {
       "name": "@zusehq/serve",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "bin": {
         "zuse": "./dist/bin.mjs",
       },
       "dependencies": {
-        "@zuse/server": "0.0.0",
+        "@zusehq/server": "0.0.0",
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
@@ -565,7 +565,7 @@
     },
     "packages/zusehq": {
       "name": "zusehq",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "bin": {
         "zusehq": "./dist/bin.mjs",
       },
@@ -2160,8 +2160,6 @@
 
     "@zuse/relay": ["@zuse/relay@workspace:infra/relay"],
 
-    "@zuse/server": ["@zuse/server@workspace:apps/server"],
-
     "@zuse/sqlite": ["@zuse/sqlite@workspace:packages/sqlite"],
 
     "@zuse/ssh": ["@zuse/ssh@workspace:packages/ssh"],
@@ -2173,6 +2171,8 @@
     "@zuse/utils": ["@zuse/utils@workspace:packages/utils"],
 
     "@zusehq/serve": ["@zusehq/serve@workspace:packages/serve"],
+
+    "@zusehq/server": ["@zusehq/server@workspace:apps/server"],
 
     "abbrev": ["abbrev@4.0.0", "http://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
 

--- a/packages/contracts/src/connect.ts
+++ b/packages/contracts/src/connect.ts
@@ -10,7 +10,7 @@ export const DEFAULT_LOCAL_DESKTOP_PORT = 47837;
 // Environment abstraction
 // ---------------------------------------------------------------------------
 //
-// An *environment* is a host running `@zuse/server`. The same headless server
+// An *environment* is a host running `@zusehq/server`. The same headless server
 // binary runs on the laptop, on an SSH dev-box, or on a cloud container — only
 // `providerKind` and the endpoint differ. Clients (desktop renderer, mobile,
 // browser) pick an environment without caring where it physically runs, which

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"type": "module",
 	"bin": {
-		"zuse": "./dist/bin.mjs"
+		"zuse": "dist/bin.mjs"
 	},
 	"engines": {
 		"node": ">=22.5.0"
@@ -28,7 +28,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zuse/server": "0.1.0"
+		"@zusehq/server": "0.1.0"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",

--- a/packages/serve/src/cli.ts
+++ b/packages/serve/src/cli.ts
@@ -1,4 +1,4 @@
-import { runServePackageCli } from "@zuse/server/serve-cli";
+import { runServePackageCli } from "@zusehq/server/serve-cli";
 import packageMetadata from "../package.json" with { type: "json" };
 import type { ServeCli } from "./cli-types.ts";
 

--- a/packages/serve/tsdown.config.ts
+++ b/packages/serve/tsdown.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 	sourcemap: true,
 	dts: false,
 	deps: {
-		alwaysBundle: [/.*/u, "@zuse/server", "@zuse/server/**"],
+		alwaysBundle: [/.*/u, "@zusehq/server", "@zusehq/server/**"],
 		neverBundle: [
 			"bindings",
 			"keytar",

--- a/packages/zusehq/package.json
+++ b/packages/zusehq/package.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"type": "module",
 	"bin": {
-		"zusehq": "./dist/bin.mjs"
+		"zusehq": "dist/bin.mjs"
 	},
 	"engines": {
 		"node": ">=22.5.0"

--- a/specs/0.01-MVP/decisions/0005-package-layout.md
+++ b/specs/0.01-MVP/decisions/0005-package-layout.md
@@ -106,7 +106,7 @@ apps/server/src/                          # NEW — main-process service impleme
   app-paths.ts, runtime.ts, handlers.ts, bin.ts
 
 apps/desktop/src/                          # thin Electron shim
-  main.ts                                  # imports makeMainLayer from @zuse/server
+  main.ts                                  # imports makeMainLayer from @zusehq/server
   preload.ts
   ipc/electron-server-protocol.ts          # transport stays in apps/desktop
 

--- a/specs/0.01-MVP/decisions/0007-server-as-code-only-app.md
+++ b/specs/0.01-MVP/decisions/0007-server-as-code-only-app.md
@@ -39,7 +39,7 @@ apps/
                                 # Tomorrow: WS server boot.
   desktop/                      # thin Electron shim
     src/
-      main.ts                   # Electron lifecycle. Imports runtime from @zuse/server.
+      main.ts                   # Electron lifecycle. Imports runtime from @zusehq/server.
       preload.ts                # contextBridge
       ipc/                      # electron-server-protocol — Electron-bound transport
   renderer/                     # React UI

--- a/specs/remote-multiclient/README.md
+++ b/specs/remote-multiclient/README.md
@@ -4,7 +4,7 @@ Status: In progress
 Started: 2026-06-30
 
 Make Zuse drivable by the desktop, a **mobile app**, a **browser**, and **remote /
-cloud dev-boxes** — all against the *same* `@zuse/server` over WebSocket, reachable from
+cloud dev-boxes** — all against the *same* `@zusehq/server` over WebSocket, reachable from
 anywhere, with clean reconnect and offline support.
 
 This folder is the source of truth for the initiative. Companion docs:
@@ -15,7 +15,7 @@ This folder is the source of truth for the initiative. Companion docs:
 
 ## 1. Guiding principle: additive, not a rewrite
 
-`@zuse/server` is already an Effect app (`@effect/rpc`, `@effect/sql`,
+`@zusehq/server` is already an Effect app (`@effect/rpc`, `@effect/sql`,
 `@effect/platform-node`). [ADR 0007](../0.01-MVP/decisions/0007-server-as-code-only-app.md)
 already mandates **zero `electron` imports in `apps/server`**, a pure `makeMainLayer(deps)`
 factory, and a **pluggable transport** (`electron-server-protocol.ts` implements
@@ -73,7 +73,7 @@ unchanged** — `messages` effectively *becomes a projection*.
   `@effect/sql-sqlite-node`→node:sqlite shim if one fits).
 
 ### D3 — Environment abstraction (`providerKind`)
-An **environment** is "a host running `@zuse/server`," a first-class entity with
+An **environment** is "a host running `@zusehq/server`," a first-class entity with
 `providerKind: "desktop" | "ssh" | "cloud"` and an endpoint `{ httpBaseUrl, wsBaseUrl }`.
 Everything above the transport — persistence, projector, providers, **git worktree
 management** — is host-agnostic (ADR 0007; worktrees are on-disk checkouts under the
@@ -133,7 +133,7 @@ One server, multiple process shapes, multiple client surfaces, one control plane
    Browser ───────┤  WebSocket (RpcClient), direct to the environment
    Desktop ───────┤
                   ▼
-         ┌──────── @zuse/server — "an environment" ────────┐
+         ┌──────── @zusehq/server — "an environment" ────────┐
          │  events → projector → messages/sessions/chats    │   the SAME binary, by providerKind:
          │  (node:sqlite)                                   │     · desktop → laptop (IPC, or WS+tunnel)
          │  RpcServer.Protocol: Electron IPC | WebSocket    │     · ssh     → remote dev-box, tunneled

--- a/specs/remote-multiclient/parallel-handoffs.md
+++ b/specs/remote-multiclient/parallel-handoffs.md
@@ -14,7 +14,7 @@ first — every track assumes it.
 ## Shared preamble (every agent must read)
 
 ```
-You are working in the Zuse monorepo (Electron coding-agent app; package @zuse/server).
+You are working in the Zuse monorepo (Electron coding-agent app; package @zusehq/server).
 Repo: Bun workspaces + Turbo. apps/* and packages/* and infra/*. Effect.ts everywhere.
 
 NON-NEGOTIABLE conventions:
@@ -27,7 +27,7 @@ NON-NEGOTIABLE conventions:
 - Branch names + PR titles describe the FEATURE only. Do NOT name any external/reference
   repository anywhere — not in code, comments, commits, branch names, or PR text.
 - Gate your work on: bunx turbo build lint check-types test (scoped to your package).
-  Use the real package names: @zuse/server, @zuse/contracts, renderer, desktop.
+  Use the real package names: @zusehq/server, @zuse/contracts, renderer, desktop.
 
 ALREADY LANDED (do not redo; build on these):
 - packages/contracts: MessageEnvelope { sequence, message }; optional `sinceSequence` on
@@ -125,7 +125,7 @@ messages.stream success type; B only reads wire. Land the wire flip in your bran
 
 ```
 Branch: remote-multiclient-ws-client
-Goal: let the renderer talk to @zuse/server over WebSocket (browser mode) while keeping
+Goal: let the renderer talk to @zusehq/server over WebSocket (browser mode) while keeping
 the Electron IPC path for the desktop. Server WS transport is already done.
 
 Read first: specs/remote-multiclient/README.md Appendix A.3.

--- a/specs/remote-multiclient/spec.html
+++ b/specs/remote-multiclient/spec.html
@@ -113,7 +113,7 @@
 
 <main>
   <h1>Remote &amp; Multi-Client</h1>
-  <p class="lead">One <code>@zuse/server</code> driven by the desktop, a mobile app, a browser, and remote / cloud dev-boxes — over WebSocket, reachable from anywhere, with gap-free reconnect and offline support.</p>
+  <p class="lead">One <code>@zusehq/server</code> driven by the desktop, a mobile app, a browser, and remote / cloud dev-boxes — over WebSocket, reachable from anywhere, with gap-free reconnect and offline support.</p>
   <div class="meta">
     <span>Status: <b>In progress</b></span>
     <span>Started: 2026-06-30</span>
@@ -123,10 +123,10 @@
 
   <!-- ============================ SUMMARY ============================ -->
   <h2 id="summary">Executive summary</h2>
-  <p>Zuse today is a single Electron process: the renderer talks to <code>@zuse/server</code> over Electron IPC, chats live in SQLite as mutable CRUD rows, and live updates come from an in-memory pub/sub. We want the same server to be driven by <b>many clients</b> (desktop, mobile, browser) running on <b>many hosts</b> (laptop, SSH dev-box, cloud container) — all over one WebSocket contract.</p>
+  <p>Zuse today is a single Electron process: the renderer talks to <code>@zusehq/server</code> over Electron IPC, chats live in SQLite as mutable CRUD rows, and live updates come from an in-memory pub/sub. We want the same server to be driven by <b>many clients</b> (desktop, mobile, browser) running on <b>many hosts</b> (laptop, SSH dev-box, cloud container) — all over one WebSocket contract.</p>
   <div class="box key">
     <div class="t">The central insight</div>
-    <p style="margin:0">This is <b>additive, not a rewrite.</b> <code>@zuse/server</code> is already an Effect app on <code>@effect/rpc</code> / <code>@effect/sql</code> / <code>@effect/platform-node</code>. <a href="../0.01-MVP/decisions/0007-server-as-code-only-app.md">ADR 0007</a> already forbids <code>electron</code> imports in <code>apps/server</code>, mandates a pure <code>makeMainLayer(deps)</code> factory, and makes the transport pluggable. The base server stays. We add a WebSocket transport, an event-sourced sync core, a cloud relay, an Expo client, and SSH launch — each an independent track.</p>
+    <p style="margin:0">This is <b>additive, not a rewrite.</b> <code>@zusehq/server</code> is already an Effect app on <code>@effect/rpc</code> / <code>@effect/sql</code> / <code>@effect/platform-node</code>. <a href="../0.01-MVP/decisions/0007-server-as-code-only-app.md">ADR 0007</a> already forbids <code>electron</code> imports in <code>apps/server</code>, mandates a pure <code>makeMainLayer(deps)</code> factory, and makes the transport pluggable. The base server stays. We add a WebSocket transport, an event-sourced sync core, a cloud relay, an Expo client, and SSH launch — each an independent track.</p>
   </div>
   <p>The single genuine architectural gap is <b>persistence</b>: mutable CRUD + in-memory pub/sub cannot give a mobile client gap-free reconnect, offline snapshots, or multi-writer ordering. We close it with <b>event sourcing</b> (an append-only log with a global <code>sequence</code>, projected into the existing tables) and, in the same pass, swap the SQLite driver to Node's built-in <b><code>node:sqlite</code></b> so one persistence layer runs identically under Electron and headless Node.</p>
 
@@ -138,7 +138,7 @@
   <table>
     <tr><th>Package</th><th>Role</th></tr>
     <tr><td><code>apps/desktop</code></td><td>Electron main + preload; builds with tsdown → <code>dist-electron/*.cjs</code>; owns the Electron-specific glue (windows, menus, the IPC transport).</td></tr>
-    <tr><td><code>apps/server</code> (<code>@zuse/server</code>)</td><td>All backend logic as a transport-agnostic Effect library: persistence, providers/drivers, git, pty, worktrees, permissions, credentials, code-index bridge, RPC handlers.</td></tr>
+    <tr><td><code>apps/server</code> (<code>@zusehq/server</code>)</td><td>All backend logic as a transport-agnostic Effect library: persistence, providers/drivers, git, pty, worktrees, permissions, credentials, code-index bridge, RPC handlers.</td></tr>
     <tr><td><code>apps/renderer</code></td><td>React UI; consumes the RPC client; no durable local state.</td></tr>
     <tr><td><code>packages/contracts</code> (<code>@zuse/contracts</code>)</td><td>The entire RPC surface (~100 methods) as <code>@effect/rpc</code> + Schema definitions. Transport-agnostic.</td></tr>
     <tr><td><code>apps/web</code>, <code>apps/mcp-server</code>, <code>packages/index</code>, …</td><td>Marketing site, MCP transport for the index engine, code-index service, etc.</td></tr>
@@ -190,7 +190,7 @@ Electron main
   <h2 id="future">2 · Where we're going</h2>
 
   <h3 id="future-env">The environment model</h3>
-  <p>The organizing idea of the end-state is the <b>environment</b>: "a host running <code>@zuse/server</code>." It is a first-class entity with a <code>providerKind</code> and an endpoint. The exact same server binary backs all three kinds:</p>
+  <p>The organizing idea of the end-state is the <b>environment</b>: "a host running <code>@zusehq/server</code>." It is a first-class entity with a <code>providerKind</code> and an endpoint. The exact same server binary backs all three kinds:</p>
   <table>
     <tr><th><code>providerKind</code></th><th>Where the server runs</th><th>How clients reach it</th></tr>
     <tr><td><code>"desktop"</code></td><td>The user's laptop</td><td>Electron IPC in-process; or WS + managed tunnel for remote reach</td></tr>
@@ -210,7 +210,7 @@ Electron main
   Browser ────┤   WebSocket (RpcClient) — DIRECT to the environment
   Desktop ────┤
               ▼
-     ┌──────────── @zuse/server — "an environment" ────────────┐
+     ┌──────────── @zusehq/server — "an environment" ────────────┐
      │  events ─► projector ─► messages / sessions / chats      │   one binary, by providerKind
      │  (node:sqlite)                                           │     · desktop → laptop
      │  RpcServer.Protocol:  Electron IPC | WebSocket           │     · ssh     → remote dev-box
@@ -506,7 +506,7 @@ export const wsClientProtocolLayer = (url) =&gt;
   <!-- ============================ GLOSSARY ============================ -->
   <h2 id="glossary">Glossary</h2>
   <table>
-    <tr><td><b>Environment</b></td><td>A host running <code>@zuse/server</code>; has a <code>providerKind</code> + endpoint.</td></tr>
+    <tr><td><b>Environment</b></td><td>A host running <code>@zusehq/server</code>; has a <code>providerKind</code> + endpoint.</td></tr>
     <tr><td><b>Projection</b></td><td>A read-optimized table derived deterministically from the event log.</td></tr>
     <tr><td><b><code>sequence</code></b></td><td>Global monotonic cursor (events PK); the unit of resume.</td></tr>
     <tr><td><b><code>stream_version</code></b></td><td>Per-stream counter; the optimistic-concurrency guard for multi-writer ordering.</td></tr>


### PR DESCRIPTION
## Summary
- publish the server runtime under the owned Zuse npm organization
- update workspace imports and documentation to the canonical runtime package name
- normalize executable paths for npm publication

## Verification
- server, desktop, bootstrap, and alias type checks
- focused Biome checks
- server and renderer production build
- npm pack for all three packages
- clean tarball installation
- native keychain and terminal module load checks
- packed alias status command