### PR TITLE
Fix hosted browser authentication flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage
 
 # Vercel
 .vercel
+.wrangler/
 
 # Build Outputs
 .next/

--- a/apps/renderer/src/lib/hosted-connect.ts
+++ b/apps/renderer/src/lib/hosted-connect.ts
@@ -1,4 +1,5 @@
 import {
+	type RelayAuthTokenGrant,
 	type RelayConnectGrant,
 	type RelayEnvironmentList,
 	RelayPaths,
@@ -100,13 +101,16 @@ const writeSession = (session: HostedSession): HostedSession => {
 	return session;
 };
 
+export const hostedAuthTokenEndpoint = (baseUrl = relayUrl()): string =>
+	`${baseUrl.replace(/\/$/u, "")}${RelayPaths.authToken}`;
+
 const authenticate = async (
-	body: Record<string, string>,
+	grant: RelayAuthTokenGrant,
 ): Promise<HostedSession> => {
-	const response = await fetch(`${WORKOS_API}/user_management/authenticate`, {
+	const response = await fetch(hostedAuthTokenEndpoint(), {
 		method: "POST",
 		headers: { "content-type": "application/json" },
-		body: JSON.stringify(body),
+		body: JSON.stringify(grant),
 		signal: AbortSignal.timeout(15_000),
 	});
 	const value = (await response.json().catch(() => ({}))) as {
@@ -176,10 +180,9 @@ export const completeHostedSignIn = async (): Promise<boolean> => {
 		throw new Error("hosted_auth_state_mismatch");
 	}
 	await authenticate({
-		client_id: clientId(),
-		grant_type: "authorization_code",
+		grantType: "authorization_code",
 		code,
-		code_verifier: pending.verifier,
+		codeVerifier: pending.verifier,
 	});
 	sessionStorage.removeItem(PKCE_KEY);
 	const returnPath =
@@ -199,9 +202,8 @@ const accessToken = async (): Promise<string | null> => {
 	try {
 		return (
 			await authenticate({
-				client_id: clientId(),
-				grant_type: "refresh_token",
-				refresh_token: session.refreshToken,
+				grantType: "refresh_token",
+				refreshToken: session.refreshToken,
 			})
 		).accessToken;
 	} catch {

--- a/apps/renderer/test/unit/hosted-connect.test.ts
+++ b/apps/renderer/test/unit/hosted-connect.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { hostedAuthTokenEndpoint } from "../../src/lib/hosted-connect.ts";
+
+describe("hosted authentication", () => {
+	it("exchanges browser tokens through the configured relay", () => {
+		expect(hostedAuthTokenEndpoint("http://127.0.0.1:8790/")).toBe(
+			"http://127.0.0.1:8790/v1/auth/token",
+		);
+	});
+});

--- a/apps/renderer/test/unit/vite-config.test.ts
+++ b/apps/renderer/test/unit/vite-config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { rendererProxy } from "../../vite-proxy.ts";
+
+describe("rendererProxy", () => {
+	it("keeps hosted authentication callbacks in the renderer", () => {
+		expect(rendererProxy(true, "http://127.0.0.1:8788")).not.toHaveProperty(
+			"/auth",
+		);
+	});
+
+	it("preserves the authentication proxy for direct browser access", () => {
+		expect(rendererProxy(false, "http://127.0.0.1:8788")).toHaveProperty(
+			"/auth",
+		);
+	});
+});

--- a/apps/renderer/vite-proxy.ts
+++ b/apps/renderer/vite-proxy.ts
@@ -1,0 +1,8 @@
+export const rendererProxy = (
+	hosted: boolean,
+	rpcTarget: string,
+): Record<string, { readonly target: string; readonly ws?: boolean }> => ({
+	...(hosted ? {} : { "/auth": { target: rpcTarget } }),
+	"/assets/attachments": { target: rpcTarget },
+	"/rpc": { target: rpcTarget, ws: true },
+});

--- a/apps/renderer/vite.config.ts
+++ b/apps/renderer/vite.config.ts
@@ -6,6 +6,8 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, searchForWorkspaceRoot } from "vite-plus";
 
+import { rendererProxy } from "./vite-proxy.ts";
+
 const port = Number(process.env.PORT ?? 5733);
 const host = process.env.HOST?.trim() || "localhost";
 const rpcPort = Number(process.env.ZUSE_DESKTOP_WS_PORT ?? 8788);
@@ -65,11 +67,7 @@ export default defineConfig({
 		host,
 		port,
 		strictPort: true,
-		proxy: {
-			"/auth": { target: rpcTarget },
-			"/assets/attachments": { target: rpcTarget },
-			"/rpc": { target: rpcTarget, ws: true },
-		},
+		proxy: rendererProxy(hostedBuild, rpcTarget),
 		fs: {
 			allow: [searchForWorkspaceRoot(process.cwd()), bunStoreRoot],
 		},

--- a/infra/relay/src/auth.ts
+++ b/infra/relay/src/auth.ts
@@ -2,41 +2,52 @@ import { Clock, Effect, Redacted } from "effect";
 
 import { RelayConfiguration } from "./config.ts";
 import {
-  parseJwk,
-  sha256Hex,
-  signAccessToken,
-  verifyAccessToken,
-  verifyDpopProof,
+	parseJwk,
+	sha256Hex,
+	signAccessToken,
+	verifyAccessToken,
+	verifyDpopProof,
 } from "./crypto.ts";
 import { forbidden, type RelayError, unauthorized } from "./errors.ts";
 import { RelayStore } from "./store.ts";
 import { type WorkosPrincipal, WorkosVerifier } from "./workos.ts";
 
 export const RELAY_SCOPES = {
-  status: "environment:status",
-  connect: "environment:connect",
-  register: "mobile:registration",
+	status: "environment:status",
+	connect: "environment:connect",
+	register: "mobile:registration",
 } as const;
 
 export type RelayScope = (typeof RELAY_SCOPES)[keyof typeof RELAY_SCOPES];
 
+const canonicalRelayRequestUrl = (
+	request: Request,
+	relayIssuer: string,
+): string => {
+	const requestUrl = new URL(request.url);
+	return new URL(
+		`${requestUrl.pathname}${requestUrl.search}`,
+		`${relayIssuer.replace(/\/+$/u, "")}/`,
+	).toString();
+};
+
 /** Require a valid WorkOS access token (Authorization: Bearer …). */
 export const requireWorkos = (
-  request: Request,
+	request: Request,
 ): Effect.Effect<WorkosPrincipal, RelayError, WorkosVerifier> =>
-  Effect.gen(function* () {
-    const header = request.headers.get("authorization") ?? "";
-    const match = /^Bearer (.+)$/i.exec(header);
-    if (match === null) {
-      return yield* Effect.fail(unauthorized("missing_bearer"));
-    }
-    const token = match[1];
-    if (token === undefined) {
-      return yield* Effect.fail(unauthorized("missing_bearer"));
-    }
-    const verifier = yield* WorkosVerifier;
-    return yield* verifier.verify(token);
-  });
+	Effect.gen(function* () {
+		const header = request.headers.get("authorization") ?? "";
+		const match = /^Bearer (.+)$/i.exec(header);
+		if (match === null) {
+			return yield* Effect.fail(unauthorized("missing_bearer"));
+		}
+		const token = match[1];
+		if (token === undefined) {
+			return yield* Effect.fail(unauthorized("missing_bearer"));
+		}
+		const verifier = yield* WorkosVerifier;
+		return yield* verifier.verify(token);
+	});
 
 /**
  * Require a valid per-environment credential (Authorization: Bearer zenv_…),
@@ -44,39 +55,39 @@ export const requireWorkos = (
  * credential must be active and belong to the environment named in the path.
  */
 export const requireEnvironmentCredential = (
-  request: Request,
-  environmentId: string,
+	request: Request,
+	environmentId: string,
 ): Effect.Effect<
-  { readonly accountId: string; readonly environmentId: string },
-  RelayError,
-  RelayStore
+	{ readonly accountId: string; readonly environmentId: string },
+	RelayError,
+	RelayStore
 > =>
-  Effect.gen(function* () {
-    const store = yield* RelayStore;
-    const header = request.headers.get("authorization") ?? "";
-    const match = /^Bearer (zenv_.+)$/i.exec(header);
-    if (match === null) {
-      return yield* Effect.fail(unauthorized("missing_environment_credential"));
-    }
-    const secret = match[1];
-    if (secret === undefined) {
-      return yield* Effect.fail(unauthorized("missing_environment_credential"));
-    }
-    const hash = yield* sha256Hex(secret);
-    const credential = yield* store.findActiveCredentialByHash(hash);
-    if (credential === null) {
-      return yield* Effect.fail(unauthorized("invalid_environment_credential"));
-    }
-    if (credential.environmentId !== environmentId) {
-      return yield* Effect.fail(forbidden("credential_environment_mismatch"));
-    }
-    return { accountId: credential.accountId, environmentId };
-  });
+	Effect.gen(function* () {
+		const store = yield* RelayStore;
+		const header = request.headers.get("authorization") ?? "";
+		const match = /^Bearer (zenv_.+)$/i.exec(header);
+		if (match === null) {
+			return yield* Effect.fail(unauthorized("missing_environment_credential"));
+		}
+		const secret = match[1];
+		if (secret === undefined) {
+			return yield* Effect.fail(unauthorized("missing_environment_credential"));
+		}
+		const hash = yield* sha256Hex(secret);
+		const credential = yield* store.findActiveCredentialByHash(hash);
+		if (credential === null) {
+			return yield* Effect.fail(unauthorized("invalid_environment_credential"));
+		}
+		if (credential.environmentId !== environmentId) {
+			return yield* Effect.fail(forbidden("credential_environment_mismatch"));
+		}
+		return { accountId: credential.accountId, environmentId };
+	});
 
 export interface DpopPrincipal {
-  readonly accountId: string;
-  readonly thumbprint: string;
-  readonly scope: ReadonlyArray<string>;
+	readonly accountId: string;
+	readonly thumbprint: string;
+	readonly scope: ReadonlyArray<string>;
 }
 
 /**
@@ -86,121 +97,121 @@ export interface DpopPrincipal {
  * and the proof key thumbprint must match the token's `cnf.jkt`.
  */
 export const requireDpop = (
-  request: Request,
-  scope: RelayScope,
+	request: Request,
+	scope: RelayScope,
 ): Effect.Effect<
-  DpopPrincipal,
-  RelayError,
-  WorkosVerifier | RelayStore | RelayConfiguration
+	DpopPrincipal,
+	RelayError,
+	WorkosVerifier | RelayStore | RelayConfiguration
 > =>
-  Effect.gen(function* () {
-    const config = yield* RelayConfiguration;
-    const store = yield* RelayStore;
-    const nowMs = yield* Clock.currentTimeMillis;
+	Effect.gen(function* () {
+		const config = yield* RelayConfiguration;
+		const store = yield* RelayStore;
+		const nowMs = yield* Clock.currentTimeMillis;
 
-    const authHeader = request.headers.get("authorization") ?? "";
-    const tokenMatch = /^DPoP (.+)$/i.exec(authHeader);
-    const proof = request.headers.get("dpop");
-    if (tokenMatch === null || proof === null) {
-      return yield* Effect.fail(unauthorized("missing_dpop"));
-    }
-    const token = tokenMatch[1];
-    if (token === undefined) {
-      return yield* Effect.fail(unauthorized("missing_dpop"));
-    }
+		const authHeader = request.headers.get("authorization") ?? "";
+		const tokenMatch = /^DPoP (.+)$/i.exec(authHeader);
+		const proof = request.headers.get("dpop");
+		if (tokenMatch === null || proof === null) {
+			return yield* Effect.fail(unauthorized("missing_dpop"));
+		}
+		const token = tokenMatch[1];
+		if (token === undefined) {
+			return yield* Effect.fail(unauthorized("missing_dpop"));
+		}
 
-    const mintPublicJwk = yield* parseJwk(config.mintPublicKey);
-    const claims = yield* verifyAccessToken({
-      token,
-      mintPublicJwk,
-      issuer: config.relayIssuer,
-    });
-    if (!claims.scope.includes(scope)) {
-      return yield* Effect.fail(unauthorized("insufficient_scope"));
-    }
+		const mintPublicJwk = yield* parseJwk(config.mintPublicKey);
+		const claims = yield* verifyAccessToken({
+			token,
+			mintPublicJwk,
+			issuer: config.relayIssuer,
+		});
+		if (!claims.scope.includes(scope)) {
+			return yield* Effect.fail(unauthorized("insufficient_scope"));
+		}
 
-    const dpop = yield* verifyDpopProof({
-      proof,
-      method: request.method.toUpperCase(),
-      url: request.url,
-      nowMs,
-    });
-    if (dpop.thumbprint !== claims.thumbprint) {
-      return yield* Effect.fail(unauthorized("dpop_key_mismatch"));
-    }
-    if (yield* store.isDpopThumbprintRevoked(dpop.thumbprint)) {
-      return yield* Effect.fail(unauthorized("client_revoked"));
-    }
+		const dpop = yield* verifyDpopProof({
+			proof,
+			method: request.method.toUpperCase(),
+			url: canonicalRelayRequestUrl(request, config.relayIssuer),
+			nowMs,
+		});
+		if (dpop.thumbprint !== claims.thumbprint) {
+			return yield* Effect.fail(unauthorized("dpop_key_mismatch"));
+		}
+		if (yield* store.isDpopThumbprintRevoked(dpop.thumbprint)) {
+			return yield* Effect.fail(unauthorized("client_revoked"));
+		}
 
-    const fresh = yield* store.consumeDpopProof({
-      thumbprint: dpop.thumbprint,
-      jti: dpop.jti,
-      issuedAtMs: dpop.issuedAtMs,
-      expiresAtMs: nowMs + 5 * 60 * 1000,
-    });
-    if (!fresh) {
-      return yield* Effect.fail(unauthorized("dpop_replayed"));
-    }
+		const fresh = yield* store.consumeDpopProof({
+			thumbprint: dpop.thumbprint,
+			jti: dpop.jti,
+			issuedAtMs: dpop.issuedAtMs,
+			expiresAtMs: nowMs + 5 * 60 * 1000,
+		});
+		if (!fresh) {
+			return yield* Effect.fail(unauthorized("dpop_replayed"));
+		}
 
-    return {
-      accountId: claims.accountId,
-      thumbprint: dpop.thumbprint,
-      scope: claims.scope,
-    };
-  });
+		return {
+			accountId: claims.accountId,
+			thumbprint: dpop.thumbprint,
+			scope: claims.scope,
+		};
+	});
 
 /**
  * Exchange a WorkOS token + a DPoP proof for a short-lived, DPoP-bound access
  * token. This is the `POST /v1/client/dpop-token` grant.
  */
 export const mintAccessToken = (
-  request: Request,
-  scopes: ReadonlyArray<RelayScope>,
+	request: Request,
+	scopes: ReadonlyArray<RelayScope>,
 ): Effect.Effect<
-  { readonly accessToken: string; readonly expiresInMs: number },
-  RelayError,
-  WorkosVerifier | RelayStore | RelayConfiguration
+	{ readonly accessToken: string; readonly expiresInMs: number },
+	RelayError,
+	WorkosVerifier | RelayStore | RelayConfiguration
 > =>
-  Effect.gen(function* () {
-    const config = yield* RelayConfiguration;
-    const store = yield* RelayStore;
-    const nowMs = yield* Clock.currentTimeMillis;
+	Effect.gen(function* () {
+		const config = yield* RelayConfiguration;
+		const store = yield* RelayStore;
+		const nowMs = yield* Clock.currentTimeMillis;
 
-    const principal = yield* requireWorkos(request);
-    const proof = request.headers.get("dpop");
-    if (proof === null) {
-      return yield* Effect.fail(unauthorized("missing_dpop"));
-    }
-    const dpop = yield* verifyDpopProof({
-      proof,
-      method: request.method.toUpperCase(),
-      url: request.url,
-      nowMs,
-    });
-    if (yield* store.isDpopThumbprintRevoked(dpop.thumbprint)) {
-      return yield* Effect.fail(unauthorized("client_revoked"));
-    }
-    const fresh = yield* store.consumeDpopProof({
-      thumbprint: dpop.thumbprint,
-      jti: dpop.jti,
-      issuedAtMs: dpop.issuedAtMs,
-      expiresAtMs: nowMs + 5 * 60 * 1000,
-    });
-    if (!fresh) {
-      return yield* Effect.fail(unauthorized("dpop_replayed"));
-    }
+		const principal = yield* requireWorkos(request);
+		const proof = request.headers.get("dpop");
+		if (proof === null) {
+			return yield* Effect.fail(unauthorized("missing_dpop"));
+		}
+		const dpop = yield* verifyDpopProof({
+			proof,
+			method: request.method.toUpperCase(),
+			url: canonicalRelayRequestUrl(request, config.relayIssuer),
+			nowMs,
+		});
+		if (yield* store.isDpopThumbprintRevoked(dpop.thumbprint)) {
+			return yield* Effect.fail(unauthorized("client_revoked"));
+		}
+		const fresh = yield* store.consumeDpopProof({
+			thumbprint: dpop.thumbprint,
+			jti: dpop.jti,
+			issuedAtMs: dpop.issuedAtMs,
+			expiresAtMs: nowMs + 5 * 60 * 1000,
+		});
+		if (!fresh) {
+			return yield* Effect.fail(unauthorized("dpop_replayed"));
+		}
 
-    const mintPrivateJwk = yield* parseJwk(
-      Redacted.value(config.mintPrivateKey),
-    );
-    const accessToken = yield* signAccessToken({
-      mintPrivateJwk,
-      issuer: config.relayIssuer,
-      accountId: principal.accountId,
-      thumbprint: dpop.thumbprint,
-      scope: scopes,
-      ttlMs: config.accessTokenTtlMs,
-      nowMs,
-    });
-    return { accessToken, expiresInMs: config.accessTokenTtlMs };
-  });
+		const mintPrivateJwk = yield* parseJwk(
+			Redacted.value(config.mintPrivateKey),
+		);
+		const accessToken = yield* signAccessToken({
+			mintPrivateJwk,
+			issuer: config.relayIssuer,
+			accountId: principal.accountId,
+			thumbprint: dpop.thumbprint,
+			scope: scopes,
+			ttlMs: config.accessTokenTtlMs,
+			nowMs,
+		});
+		return { accessToken, expiresInMs: config.accessTokenTtlMs };
+	});

--- a/infra/relay/src/handler.ts
+++ b/infra/relay/src/handler.ts
@@ -1,4 +1,5 @@
-import { Clock, Effect, Redacted } from "effect";
+import { RelayAuthTokenGrant } from "@zuse/contracts";
+import { Clock, Effect, Redacted, Schema } from "effect";
 
 import { AccountIdentity } from "./account-identity.ts";
 
@@ -22,8 +23,8 @@ import {
 	conflict,
 	gone,
 	notFound,
-	serviceUnavailable,
 	type RelayError,
+	serviceUnavailable,
 } from "./errors.ts";
 import { ManagedTunnelProvider } from "./managed-tunnel.ts";
 import { PushDelivery } from "./push.ts";
@@ -34,7 +35,7 @@ import {
 	type ProviderKind,
 	RelayStore,
 } from "./store.ts";
-import type { WorkosVerifier } from "./workos.ts";
+import { WorkosVerifier } from "./workos.ts";
 
 export type RelayContext =
 	| AccountIdentity
@@ -194,7 +195,47 @@ const route = (
 		const store = yield* RelayStore;
 		const push = yield* PushDelivery;
 		const accountIdentity = yield* AccountIdentity;
+		const workos = yield* WorkosVerifier;
 		const nowMs = yield* Clock.currentTimeMillis;
+
+		if (method === "POST" && path === "/v1/auth/token") {
+			const untrustedBody = yield* readJson<unknown>(request);
+			const body = yield* Effect.try({
+				try: () => Schema.decodeUnknownSync(RelayAuthTokenGrant)(untrustedBody),
+				catch: () => badRequest("invalid_auth_grant"),
+			});
+			if (
+				body.grantType === "authorization_code" &&
+				typeof body.code === "string" &&
+				body.code.length > 0 &&
+				body.code.length <= 2_048 &&
+				typeof body.codeVerifier === "string" &&
+				body.codeVerifier.length >= 43 &&
+				body.codeVerifier.length <= 128
+			) {
+				return json(
+					yield* workos.exchangeToken({
+						grantType: body.grantType,
+						code: body.code,
+						codeVerifier: body.codeVerifier,
+					}),
+				);
+			}
+			if (
+				body.grantType === "refresh_token" &&
+				typeof body.refreshToken === "string" &&
+				body.refreshToken.length > 0 &&
+				body.refreshToken.length <= 8_192
+			) {
+				return json(
+					yield* workos.exchangeToken({
+						grantType: body.grantType,
+						refreshToken: body.refreshToken,
+					}),
+				);
+			}
+			return yield* Effect.fail(badRequest("invalid_auth_grant"));
+		}
 
 		// 1. Issue a link challenge (desktop, WorkOS-authenticated).
 		if (

--- a/infra/relay/src/workos.ts
+++ b/infra/relay/src/workos.ts
@@ -1,13 +1,21 @@
+import type {
+	RelayAuthTokenGrant,
+	RelayAuthTokenResponse,
+} from "@zuse/contracts";
 import { Context, Effect, Layer } from "effect";
 import { createRemoteJWKSet, jwtVerify } from "jose";
-
-import { unauthorized, type RelayError } from "./errors.ts";
 import { RelayConfiguration } from "./config.ts";
+import {
+	badRequest,
+	type RelayError,
+	serviceUnavailable,
+	unauthorized,
+} from "./errors.ts";
 
 /** The account identity proven by a verified WorkOS access token. */
 export interface WorkosPrincipal {
-  readonly accountId: string;
-  readonly orgId: string | undefined;
+	readonly accountId: string;
+	readonly orgId: string | undefined;
 }
 
 /**
@@ -16,187 +24,265 @@ export interface WorkosPrincipal {
  * A service so tests can inject a fake verifier without hitting WorkOS.
  */
 export class WorkosVerifier extends Context.Service<
-  WorkosVerifier,
-  {
-    readonly verify: (
-      token: string,
-    ) => Effect.Effect<WorkosPrincipal, RelayError>;
-  }
+	WorkosVerifier,
+	{
+		readonly verify: (
+			token: string,
+		) => Effect.Effect<WorkosPrincipal, RelayError>;
+		readonly exchangeToken: (
+			grant: RelayAuthTokenGrant,
+		) => Effect.Effect<RelayAuthTokenResponse, RelayError>;
+	}
 >()("@zuse/relay/WorkosVerifier") {}
 
 export const acceptedWorkosIssuers = (issuer: string): string[] => {
-  const trimmed = issuer.trim();
-  const withoutSlash = trimmed.replace(/\/+$/, "");
-  const withSlash = `${withoutSlash}/`;
-  return withoutSlash === withSlash ? [trimmed] : [withoutSlash, withSlash];
+	const trimmed = issuer.trim();
+	const withoutSlash = trimmed.replace(/\/+$/, "");
+	const withSlash = `${withoutSlash}/`;
+	return withoutSlash === withSlash ? [trimmed] : [withoutSlash, withSlash];
 };
 
 export const isAcceptedWorkosIssuer = (
-  tokenIssuer: string,
-  configuredIssuer: string,
+	tokenIssuer: string,
+	configuredIssuer: string,
 ): boolean => {
-  const base = configuredIssuer.trim().replace(/\/+$/, "");
-  return (
-    tokenIssuer === base ||
-    tokenIssuer === `${base}/` ||
-    tokenIssuer.startsWith(`${base}/user_management/`)
-  );
+	const base = configuredIssuer.trim().replace(/\/+$/, "");
+	return (
+		tokenIssuer === base ||
+		tokenIssuer === `${base}/` ||
+		tokenIssuer.startsWith(`${base}/user_management/`)
+	);
 };
 
 export const expectedWorkosClientId = (jwksUrl: string): string | undefined => {
-  try {
-    const url = new URL(jwksUrl);
-    const match = /\/jwks\/([^/]+)$/.exec(url.pathname);
-    return match?.[1];
-  } catch {
-    return undefined;
-  }
+	try {
+		const url = new URL(jwksUrl);
+		const match = /\/jwks\/([^/]+)$/.exec(url.pathname);
+		return match?.[1];
+	} catch {
+		return undefined;
+	}
 };
 
 const decodeJwtPart = (part: string): Record<string, unknown> | null => {
-  try {
-    const padded = part.padEnd(
-      part.length + ((4 - (part.length % 4)) % 4),
-      "=",
-    );
-    const json = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
-    const value = JSON.parse(json) as unknown;
-    return typeof value === "object" && value !== null
-      ? (value as Record<string, unknown>)
-      : null;
-  } catch {
-    return null;
-  }
+	try {
+		const padded = part.padEnd(
+			part.length + ((4 - (part.length % 4)) % 4),
+			"=",
+		);
+		const json = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+		const value = JSON.parse(json) as unknown;
+		return typeof value === "object" && value !== null
+			? (value as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
 };
 
 const logWorkosVerifyFailure = (
-  token: string,
-  config: {
-    readonly workosIssuer: string;
-    readonly workosJwksUrl: string;
-    readonly acceptedIssuers: readonly string[];
-  },
-  cause: unknown,
+	token: string,
+	config: {
+		readonly workosIssuer: string;
+		readonly workosJwksUrl: string;
+		readonly acceptedIssuers: readonly string[];
+	},
+	cause: unknown,
 ): void => {
-  const parts = token.split(".");
-  const header = parts[0] === undefined ? null : decodeJwtPart(parts[0]);
-  const payload = parts[1] === undefined ? null : decodeJwtPart(parts[1]);
-  console.warn("[zuse-relay] WorkOS token verification failed", {
-    configuredIssuer: config.workosIssuer,
-    acceptedIssuers: config.acceptedIssuers,
-    jwksUrl: config.workosJwksUrl,
-    tokenHeader: {
-      alg: header?.alg,
-      kid: header?.kid,
-      typ: header?.typ,
-    },
-    tokenClaims: {
-      iss: payload?.iss,
-      client_id: payload?.client_id,
-      aud: payload?.aud,
-      exp: payload?.exp,
-      iat: payload?.iat,
-    },
-    cause:
-      cause instanceof Error
-        ? { name: cause.name, message: cause.message }
-        : String(cause),
-  });
+	const parts = token.split(".");
+	const header = parts[0] === undefined ? null : decodeJwtPart(parts[0]);
+	const payload = parts[1] === undefined ? null : decodeJwtPart(parts[1]);
+	console.warn("[zuse-relay] WorkOS token verification failed", {
+		configuredIssuer: config.workosIssuer,
+		acceptedIssuers: config.acceptedIssuers,
+		jwksUrl: config.workosJwksUrl,
+		tokenHeader: {
+			alg: header?.alg,
+			kid: header?.kid,
+			typ: header?.typ,
+		},
+		tokenClaims: {
+			iss: payload?.iss,
+			client_id: payload?.client_id,
+			aud: payload?.aud,
+			exp: payload?.exp,
+			iat: payload?.iat,
+		},
+		cause:
+			cause instanceof Error
+				? { name: cause.name, message: cause.message }
+				: String(cause),
+	});
 };
 
 /** Production verifier: validates the JWT against WorkOS's JWKS. */
 export const WorkosVerifierLive: Layer.Layer<
-  WorkosVerifier,
-  never,
-  RelayConfiguration
+	WorkosVerifier,
+	never,
+	RelayConfiguration
 > = Layer.effect(
-  WorkosVerifier,
-  Effect.gen(function* () {
-    const config = yield* RelayConfiguration;
-    const jwks = createRemoteJWKSet(new URL(config.workosJwksUrl));
-    const issuers = acceptedWorkosIssuers(config.workosIssuer);
-    const expectedClientId = expectedWorkosClientId(config.workosJwksUrl);
-    return {
-      verify: (token) =>
-        Effect.gen(function* () {
-          const verified = yield* Effect.tryPromise({
-            try: () => jwtVerify(token, jwks),
-            catch: (cause) => {
-              logWorkosVerifyFailure(
-                token,
-                {
-                  workosIssuer: config.workosIssuer,
-                  workosJwksUrl: config.workosJwksUrl,
-                  acceptedIssuers: issuers,
-                },
-                cause,
-              );
-              return unauthorized("invalid_workos_token");
-            },
-          });
-          const payload = verified.payload as {
-            readonly iss?: unknown;
-            readonly sub?: unknown;
-            readonly client_id?: unknown;
-            readonly org_id?: unknown;
-            readonly organization_id?: unknown;
-          };
-          if (
-            typeof payload.iss !== "string" ||
-            !isAcceptedWorkosIssuer(payload.iss, config.workosIssuer)
-          ) {
-            logWorkosVerifyFailure(
-              token,
-              {
-                workosIssuer: config.workosIssuer,
-                workosJwksUrl: config.workosJwksUrl,
-                acceptedIssuers: issuers,
-              },
-              new Error("unexpected WorkOS issuer claim"),
-            );
-            return yield* Effect.fail(unauthorized("invalid_workos_token"));
-          }
-          if (
-            expectedClientId !== undefined &&
-            payload.client_id !== expectedClientId
-          ) {
-            logWorkosVerifyFailure(
-              token,
-              {
-                workosIssuer: config.workosIssuer,
-                workosJwksUrl: config.workosJwksUrl,
-                acceptedIssuers: issuers,
-              },
-              new Error("unexpected WorkOS client_id claim"),
-            );
-            return yield* Effect.fail(unauthorized("invalid_workos_token"));
-          }
-          if (typeof payload.sub !== "string") {
-            return yield* Effect.fail(unauthorized("workos_token_no_subject"));
-          }
-          const orgId =
-            typeof payload.org_id === "string"
-              ? payload.org_id
-              : typeof payload.organization_id === "string"
-                ? payload.organization_id
-                : undefined;
-          return { accountId: payload.sub, orgId };
-        }),
-    };
-  }),
+	WorkosVerifier,
+	Effect.gen(function* () {
+		const config = yield* RelayConfiguration;
+		const jwks = createRemoteJWKSet(new URL(config.workosJwksUrl));
+		const issuers = acceptedWorkosIssuers(config.workosIssuer);
+		const expectedClientId = expectedWorkosClientId(config.workosJwksUrl);
+		return {
+			exchangeToken: Effect.fn("WorkosVerifier.exchangeToken")(
+				function* (grant) {
+					if (expectedClientId === undefined) {
+						return yield* Effect.fail(
+							serviceUnavailable("workos_auth_not_configured"),
+						);
+					}
+					const response = yield* Effect.tryPromise({
+						try: () =>
+							fetch("https://api.workos.com/user_management/authenticate", {
+								method: "POST",
+								headers: { "content-type": "application/json" },
+								body: JSON.stringify(
+									grant.grantType === "authorization_code"
+										? {
+												client_id: expectedClientId,
+												grant_type: grant.grantType,
+												code: grant.code,
+												code_verifier: grant.codeVerifier,
+											}
+										: {
+												client_id: expectedClientId,
+												grant_type: grant.grantType,
+												refresh_token: grant.refreshToken,
+											},
+								),
+								signal: AbortSignal.timeout(15_000),
+							}),
+						catch: () => serviceUnavailable("workos_auth_unavailable"),
+					});
+					const body = yield* Effect.tryPromise({
+						try: () => response.json() as Promise<Record<string, unknown>>,
+						catch: () => serviceUnavailable("workos_auth_invalid_response"),
+					});
+					if (!response.ok) {
+						return yield* Effect.fail(
+							badRequest(
+								typeof body.error === "string"
+									? body.error
+									: "workos_auth_rejected",
+							),
+						);
+					}
+					if (
+						typeof body.access_token !== "string" ||
+						typeof body.refresh_token !== "string"
+					) {
+						return yield* Effect.fail(
+							serviceUnavailable("workos_auth_invalid_response"),
+						);
+					}
+					return {
+						access_token: body.access_token,
+						refresh_token: body.refresh_token,
+					};
+				},
+			),
+			verify: (token) =>
+				Effect.gen(function* () {
+					const verified = yield* Effect.tryPromise({
+						try: () => jwtVerify(token, jwks),
+						catch: (cause) => {
+							logWorkosVerifyFailure(
+								token,
+								{
+									workosIssuer: config.workosIssuer,
+									workosJwksUrl: config.workosJwksUrl,
+									acceptedIssuers: issuers,
+								},
+								cause,
+							);
+							return unauthorized("invalid_workos_token");
+						},
+					});
+					const payload = verified.payload as {
+						readonly iss?: unknown;
+						readonly sub?: unknown;
+						readonly client_id?: unknown;
+						readonly org_id?: unknown;
+						readonly organization_id?: unknown;
+					};
+					if (
+						typeof payload.iss !== "string" ||
+						!isAcceptedWorkosIssuer(payload.iss, config.workosIssuer)
+					) {
+						logWorkosVerifyFailure(
+							token,
+							{
+								workosIssuer: config.workosIssuer,
+								workosJwksUrl: config.workosJwksUrl,
+								acceptedIssuers: issuers,
+							},
+							new Error("unexpected WorkOS issuer claim"),
+						);
+						return yield* Effect.fail(unauthorized("invalid_workos_token"));
+					}
+					if (
+						expectedClientId !== undefined &&
+						payload.client_id !== expectedClientId
+					) {
+						logWorkosVerifyFailure(
+							token,
+							{
+								workosIssuer: config.workosIssuer,
+								workosJwksUrl: config.workosJwksUrl,
+								acceptedIssuers: issuers,
+							},
+							new Error("unexpected WorkOS client_id claim"),
+						);
+						return yield* Effect.fail(unauthorized("invalid_workos_token"));
+					}
+					if (typeof payload.sub !== "string") {
+						return yield* Effect.fail(unauthorized("workos_token_no_subject"));
+					}
+					const orgId =
+						typeof payload.org_id === "string"
+							? payload.org_id
+							: typeof payload.organization_id === "string"
+								? payload.organization_id
+								: undefined;
+					return { accountId: payload.sub, orgId };
+				}),
+		};
+	}),
 );
 
 /** Test verifier: accepts `test-token:<accountId>[:<orgId>]`. */
 export const WorkosVerifierTest: Layer.Layer<WorkosVerifier> = Layer.succeed(
-  WorkosVerifier,
-  {
-    verify: (token) =>
-      Effect.gen(function* () {
-        const match = /^test-token:([^:]+)(?::(.+))?$/.exec(token);
-        if (match === null) {
-          return yield* Effect.fail(unauthorized("invalid_workos_token"));
-        }
-        return { accountId: match[1]!, orgId: match[2] };
-      }),
-  },
+	WorkosVerifier,
+	{
+		exchangeToken: (grant) =>
+			grant.grantType === "authorization_code"
+				? grant.code === "test-code" && grant.codeVerifier === "v".repeat(43)
+					? Effect.succeed({
+							access_token: "test-access-token",
+							refresh_token: "test-refresh-token",
+						})
+					: Effect.fail(badRequest("invalid_grant"))
+				: grant.refreshToken === "test-refresh-token"
+					? Effect.succeed({
+							access_token: "test-access-token",
+							refresh_token: "test-refresh-token-rotated",
+						})
+					: Effect.fail(badRequest("invalid_grant")),
+		verify: (token) =>
+			Effect.gen(function* () {
+				const match = /^test-token:([^:]+)(?::(.+))?$/.exec(token);
+				if (match === null) {
+					return yield* Effect.fail(unauthorized("invalid_workos_token"));
+				}
+				const accountId = match[1];
+				if (accountId === undefined) {
+					return yield* Effect.fail(unauthorized("invalid_workos_token"));
+				}
+				return { accountId, orgId: match[2] };
+			}),
+	},
 );

--- a/infra/relay/test/integration/relay.test.ts
+++ b/infra/relay/test/integration/relay.test.ts
@@ -220,6 +220,75 @@ beforeEach(async () => {
 });
 
 describe("@zuse/relay", () => {
+	test("brokers browser PKCE token exchanges without exposing a general proxy", async () => {
+		const response = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/auth/token`, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					origin: "https://app.zuse.sh",
+				},
+				body: JSON.stringify({
+					grantType: "authorization_code",
+					code: "test-code",
+					codeVerifier: "v".repeat(43),
+				}),
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("access-control-allow-origin")).toBe(
+			"https://app.zuse.sh",
+		);
+		expect(await response.json()).toEqual({
+			access_token: "test-access-token",
+			refresh_token: "test-refresh-token",
+		});
+
+		const refreshResponse = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/auth/token`, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					origin: "https://app.zuse.sh",
+				},
+				body: JSON.stringify({
+					grantType: "refresh_token",
+					refreshToken: "test-refresh-token",
+				}),
+			}),
+		);
+
+		expect(refreshResponse.status).toBe(200);
+		expect(await refreshResponse.json()).toEqual({
+			access_token: "test-access-token",
+			refresh_token: "test-refresh-token-rotated",
+		});
+	});
+
+	test("verifies DPoP against the public relay URL behind a rewritten worker URL", async () => {
+		const device = (await ec()) as KeyPair;
+		const jwk = await exportJWK(device.publicKey);
+		const publicUrl = `${RELAY_ISSUER}/v1/client/dpop-token`;
+		const response = await relay.fetch(
+			new Request("http://worker.internal/v1/client/dpop-token", {
+				method: "POST",
+				headers: {
+					authorization: "Bearer test-token:user_proxy",
+					dpop: await dpopProof(device, jwk, {
+						method: "POST",
+						url: publicUrl,
+					}),
+				},
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			accessToken: expect.any(String),
+		});
+	});
+
 	test("allows the hosted product origin without opening relay CORS broadly", async () => {
 		const allowed = await relay.fetch(
 			new Request(`${RELAY_ISSUER}/v1/environments`, {

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -27,6 +27,7 @@ import { EnvironmentId } from "./ids.ts";
 
 /** Paths, centralised so client + relay never drift. */
 export const RelayPaths = {
+	authToken: "/v1/auth/token",
 	linkChallenges: "/v1/client/environment-link-challenges",
 	links: "/v1/client/environment-links",
 	/** Unlink (WorkOS bearer): deprovisions the managed tunnel + removes the env. */
@@ -46,6 +47,25 @@ export const RelayPaths = {
 	agentActivity: (environmentId: string) =>
 		`/v1/environments/${encodeURIComponent(environmentId)}/agent-activity`,
 } as const;
+
+export const RelayAuthTokenGrant = Schema.Union([
+	Schema.Struct({
+		grantType: Schema.Literal("authorization_code"),
+		code: Schema.String,
+		codeVerifier: Schema.String,
+	}),
+	Schema.Struct({
+		grantType: Schema.Literal("refresh_token"),
+		refreshToken: Schema.String,
+	}),
+]);
+export type RelayAuthTokenGrant = typeof RelayAuthTokenGrant.Type;
+
+export const RelayAuthTokenResponse = Schema.Struct({
+	access_token: Schema.String,
+	refresh_token: Schema.String,
+});
+export type RelayAuthTokenResponse = typeof RelayAuthTokenResponse.Type;
 
 /** DPoP access-token scopes the relay recognises. */
 export const RelayScope = Schema.Literals([

--- a/packages/contracts/test/unit/schema.test.ts
+++ b/packages/contracts/test/unit/schema.test.ts
@@ -15,6 +15,7 @@ import {
 	Message,
 	MODELS_BY_PROVIDER,
 	PokemonPokedexEntry,
+	RelayAuthTokenGrant,
 	RelayEnvironmentList,
 	RelayLinkStatus,
 	RepositorySettingsFile,
@@ -220,6 +221,29 @@ describe("RelayLinkStatus advertised endpoint compatibility", () => {
 				},
 			],
 		});
+	});
+});
+
+describe("RelayAuthTokenGrant", () => {
+	it("accepts authorization-code and refresh-token grants", () => {
+		roundTrip(RelayAuthTokenGrant, {
+			grantType: "authorization_code",
+			code: "code",
+			codeVerifier: "verifier",
+		});
+		roundTrip(RelayAuthTokenGrant, {
+			grantType: "refresh_token",
+			refreshToken: "refresh-token",
+		});
+	});
+
+	it("rejects incomplete grants", () => {
+		expect(() =>
+			Schema.decodeUnknownSync(RelayAuthTokenGrant)({
+				grantType: "authorization_code",
+				code: "code",
+			}),
+		).toThrow();
 	});
 });
 


### PR DESCRIPTION
## What changed

- keep the hosted renderer callback route in the browser instead of forwarding it to desktop RPC
- broker authorization-code and refresh-token exchanges through the relay so browser authentication is not blocked by upstream CORS
- verify DPoP proofs against the configured public relay URL behind worker URL rewriting
- share the auth grant contract across renderer and relay, bound the upstream authentication request to 15 seconds, and add focused coverage
- ignore generated local worker state

## Root cause

The hosted development proxy forwarded `/auth/callback` to desktop RPC, and direct browser token exchange depended on an upstream response that does not permit browser CORS. Local worker URL rewriting also made valid DPoP proofs appear to target the wrong URL.

## Impact

Hosted browser sign-in now completes through the local callback, discovers the linked computer, and opens the environment-scoped workspace while preserving direct-browser development behavior.

## Validation

- relay: 25 tests passed
- renderer: 239 tests passed
- contracts, relay, and renderer typechecks passed
- Biome passed on all changed files
- Aside local acceptance passed: sign-in callback, computer picker, scoped workspace route, live workspace rendering, and reload persistence
- the contracts schema suite still has four unrelated baseline round-trip failures caused by default provenance fields; the new auth grant tests pass