### PR TITLE
Fix serve recovery lifecycle

### DIFF
--- a/apps/renderer/src/lib/browser-session.ts
+++ b/apps/renderer/src/lib/browser-session.ts
@@ -114,13 +114,11 @@ export const logoutBrowserSession = (): Promise<BrowserSessionStatus> =>
 	jsonRequest<BrowserSessionStatus>("/auth/logout", { method: "POST" });
 
 export const requestBrowserWebSocketUrl = async (): Promise<string> => {
-	const { hostedRpcEndpoint, isHostedProduct } = await import(
+	const { nextHostedRpcEndpoint, isHostedProduct } = await import(
 		"./hosted-connect.ts"
 	);
 	if (isHostedProduct()) {
-		const endpoint = hostedRpcEndpoint();
-		if (endpoint === null) throw new Error("hosted_environment_not_selected");
-		return endpoint;
+		return nextHostedRpcEndpoint();
 	}
 	const result = await jsonRequest<{
 		readonly ticket: string;

--- a/apps/renderer/src/lib/hosted-connect.ts
+++ b/apps/renderer/src/lib/hosted-connect.ts
@@ -26,9 +26,43 @@ type StoredDpopKey = {
 	readonly publicJwk: JsonWebKey;
 };
 
-let rpcEndpoint: string | null = null;
 let relayAccess: { readonly token: string; readonly expiresAt: number } | null =
 	null;
+
+export type HostedEndpointLease = {
+	readonly set: (environmentId: string, endpoint: string) => void;
+	readonly next: (
+		refresh: (environmentId: string) => Promise<void>,
+	) => Promise<string>;
+	readonly clear: () => void;
+};
+
+export const createHostedEndpointLease = (): HostedEndpointLease => {
+	let environmentId: string | null = null;
+	let endpoint: string | null = null;
+	return {
+		set: (nextEnvironmentId, nextEndpoint) => {
+			environmentId = nextEnvironmentId;
+			endpoint = nextEndpoint;
+		},
+		next: async (refresh) => {
+			if (environmentId === null) {
+				throw new Error("hosted_environment_not_selected");
+			}
+			if (endpoint === null) await refresh(environmentId);
+			if (endpoint === null) throw new Error("hosted_connect_grant_missing");
+			const leased = endpoint;
+			endpoint = null;
+			return leased;
+		},
+		clear: () => {
+			environmentId = null;
+			endpoint = null;
+		},
+	};
+};
+
+const rpcEndpointLease = createHostedEndpointLease();
 
 const environment = (): Record<string, string | undefined> =>
 	(import.meta as { readonly env?: Record<string, string | undefined> }).env ??
@@ -426,11 +460,14 @@ export const connectHostedEnvironment = async (
 	const url = new URL(body.endpoint.wsBaseUrl);
 	url.searchParams.set("token", body.connectToken);
 	url.searchParams.set("wireVersion", String(WIRE_PROTOCOL_VERSION));
-	rpcEndpoint = url.toString();
+	rpcEndpointLease.set(environmentId, url.toString());
 	return body;
 };
 
-export const hostedRpcEndpoint = (): string | null => rpcEndpoint;
+export const nextHostedRpcEndpoint = (): Promise<string> =>
+	rpcEndpointLease.next(async (environmentId) => {
+		await connectHostedEnvironment(environmentId);
+	});
 
 export const signOutHostedProduct = async (): Promise<void> => {
 	const token = await accessToken();
@@ -445,7 +482,7 @@ export const signOutHostedProduct = async (): Promise<void> => {
 	sessionStorage.removeItem(PKCE_KEY);
 	localStorage.removeItem(DEVICE_ID_KEY);
 	relayAccess = null;
-	rpcEndpoint = null;
+	rpcEndpointLease.clear();
 	await new Promise<void>((resolve) => {
 		const request = indexedDB.deleteDatabase(DPOP_DATABASE);
 		request.onsuccess = () => resolve();

--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -97,6 +97,13 @@ const supervisor = createConnectionSupervisor<
 							await requestBrowserWebSocketUrl(),
 							WIRE_PROTOCOL_VERSION,
 						),
+						{
+							onClose: (event) => {
+								rendererEntry?.reportFailure(
+									new Error(`WebSocket closed (${event.code}).`),
+								);
+							},
+						},
 					);
 		return makeRpcClientSession(protocolLayer, MemoizeRpcs, {
 			protocolVersion: WIRE_PROTOCOL_VERSION,

--- a/apps/renderer/test/unit/hosted-connect.test.ts
+++ b/apps/renderer/test/unit/hosted-connect.test.ts
@@ -1,11 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { hostedAuthTokenEndpoint } from "../../src/lib/hosted-connect.ts";
+import {
+	createHostedEndpointLease,
+	hostedAuthTokenEndpoint,
+} from "../../src/lib/hosted-connect.ts";
 
 describe("hosted authentication", () => {
 	it("exchanges browser tokens through the configured relay", () => {
 		expect(hostedAuthTokenEndpoint("http://127.0.0.1:8790/")).toBe(
 			"http://127.0.0.1:8790/v1/auth/token",
 		);
+	});
+
+	it("uses each connect grant once and refreshes it for reconnects", async () => {
+		const lease = createHostedEndpointLease();
+		const refresh = vi.fn(async (environmentId: string) => {
+			lease.set(environmentId, "wss://host.example/rpc?token=fresh");
+		});
+
+		lease.set("env-1", "wss://host.example/rpc?token=initial");
+
+		await expect(lease.next(refresh)).resolves.toBe(
+			"wss://host.example/rpc?token=initial",
+		);
+		await expect(lease.next(refresh)).resolves.toBe(
+			"wss://host.example/rpc?token=fresh",
+		);
+		expect(refresh).toHaveBeenCalledOnce();
+		expect(refresh).toHaveBeenCalledWith("env-1");
 	});
 });

--- a/apps/server/src/serve/command.ts
+++ b/apps/server/src/serve/command.ts
@@ -13,6 +13,7 @@ export interface ServeCommand {
 	readonly json: boolean;
 	readonly foreground: boolean;
 	readonly force: boolean;
+	readonly dataDir?: string;
 }
 
 const MANAGEMENT_ACTIONS = new Set<ServeAction>(ServeAction);
@@ -24,14 +25,34 @@ export const parseServeCommand = (
 		throw new Error("Usage: zuse serve [status|stop|update|logout|uninstall]");
 	}
 
-	const rest = argv.slice(1);
-	const candidate = rest.find((part) => !part.startsWith("-"));
-	const action = candidate ?? "start";
-	if (!MANAGEMENT_ACTIONS.has(action as ServeAction)) {
-		throw new Error(`Unknown zuse serve command "${action}".`);
+	const flags = new Set<string>();
+	let action: ServeAction = "start";
+	let actionProvided = false;
+	let dataDir: string | undefined;
+	for (let index = 1; index < argv.length; index += 1) {
+		const part = argv[index];
+		if (part === undefined) break;
+		if (part === "--data-dir") {
+			const value = argv[index + 1];
+			if (value === undefined || value.startsWith("-")) {
+				throw new Error("--data-dir requires a value.");
+			}
+			dataDir = value;
+			index += 1;
+			continue;
+		}
+		if (part.startsWith("-")) {
+			flags.add(part);
+			continue;
+		}
+		if (!actionProvided && MANAGEMENT_ACTIONS.has(part as ServeAction)) {
+			action = part as ServeAction;
+			actionProvided = true;
+			continue;
+		}
+		throw new Error(`Unknown zuse serve command "${part}".`);
 	}
 
-	const flags = new Set(rest.filter((part) => part.startsWith("-")));
 	for (const flag of flags) {
 		if (!["--json", "--foreground", "--force"].includes(flag)) {
 			throw new Error(`Unknown zuse serve option "${flag}".`);
@@ -52,5 +73,6 @@ export const parseServeCommand = (
 		json: flags.has("--json"),
 		foreground: flags.has("--foreground"),
 		force: flags.has("--force"),
+		dataDir,
 	};
 };

--- a/apps/server/src/serve/package-cli.ts
+++ b/apps/server/src/serve/package-cli.ts
@@ -34,7 +34,8 @@ const APP_URL = "https://app.zuse.sh";
 const workosClientId = (env: NodeJS.ProcessEnv): string =>
 	(env.WORKOS_CLIENT_ID ?? "").trim() || WORKOS_PUBLIC_CLIENT_ID;
 
-const resolveDataDir = (env: NodeJS.ProcessEnv): string => {
+const resolveDataDir = (env: NodeJS.ProcessEnv, override?: string): string => {
+	if (override !== undefined) return override;
 	if (env.ZUSE_USER_DATA) return env.ZUSE_USER_DATA;
 	const xdg = env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
 	return join(xdg, "zuse");
@@ -271,12 +272,19 @@ export const runServePackageCli = async (
 	const normalized = argv[0] === "serve" ? argv : ["serve", ...argv];
 	const command = parseServeCommand(normalized);
 	env.ZUSE_RUNTIME_VERSION = options.packageVersion ?? "0.0.0";
-	const dataDir = resolveDataDir(env);
+	env.ZUSE_RELAY_URL = env.ZUSE_RELAY_URL ?? DEFAULT_RELAY_URL;
+	const dataDir = resolveDataDir(env, command.dataDir);
+	env.ZUSE_USER_DATA = dataDir;
 	const servicePaths = resolveServeServicePaths({ dataDir });
+	const installService = (executable: string) =>
+		installServeService({
+			executable,
+			paths: servicePaths,
+			relayUrl: env.ZUSE_RELAY_URL,
+		});
 
 	if (command.action === "start" && command.foreground) {
 		env.ZUSE_SERVE_AUTO_LINK = "1";
-		env.ZUSE_RELAY_URL = env.ZUSE_RELAY_URL ?? DEFAULT_RELAY_URL;
 		runHeadlessServer({
 			host: "127.0.0.1",
 			port: Number(env.ZUSE_PORT ?? 4859),
@@ -331,22 +339,16 @@ export const runServePackageCli = async (
 		const executable = await installDurableServeRuntime({ dataDir, version });
 		const previous = await readActiveServeRuntime(dataDir);
 		try {
-			await installServeService({ executable, paths: servicePaths });
+			await installService(executable);
 		} catch (cause) {
 			if (previous !== null) {
-				await installServeService({
-					executable: previous.executable,
-					paths: servicePaths,
-				}).catch(() => undefined);
+				await installService(previous.executable).catch(() => undefined);
 			}
 			throw cause;
 		}
 		if (!(await waitForReachability(env))) {
 			if (previous !== null) {
-				await installServeService({
-					executable: previous.executable,
-					paths: servicePaths,
-				});
+				await installService(previous.executable);
 				await waitForReachability(env, 20_000);
 				throw new Error(
 					"The updated runtime failed its readiness check and Zuse restored the previous runtime.",
@@ -400,15 +402,11 @@ export const runServePackageCli = async (
 						dataDir,
 						version: packageVersion,
 					});
-		await installServeService({
-			executable: installedExecutable,
-			paths: servicePaths,
-		});
+		await installService(installedExecutable);
 	} catch (cause) {
 		if (cause instanceof UnsupportedServiceManagerError) {
 			console.warn(`${cause.message} Starting in the foreground instead.`);
 			env.ZUSE_SERVE_AUTO_LINK = "1";
-			env.ZUSE_RELAY_URL = env.ZUSE_RELAY_URL ?? DEFAULT_RELAY_URL;
 			runHeadlessServer({
 				host: "127.0.0.1",
 				port: Number(env.ZUSE_PORT ?? 4859),

--- a/apps/server/src/serve/service-manager.ts
+++ b/apps/server/src/serve/service-manager.ts
@@ -50,6 +50,42 @@ const run = async (
 	return { stdout: result.stdout, stderr: result.stderr };
 };
 
+export type ServeServiceCommandRunner = typeof run;
+
+const isMissingLaunchctlService = (cause: unknown): boolean => {
+	if (typeof cause !== "object" || cause === null) return false;
+	const error = cause as { readonly code?: unknown; readonly stderr?: unknown };
+	return (
+		error.code === 113 &&
+		typeof error.stderr === "string" &&
+		error.stderr.includes("Could not find service")
+	);
+};
+
+const bootoutLaunchAgent = async (input: {
+	readonly target: string;
+	readonly definitionPath: string;
+	readonly runCommand: ServeServiceCommandRunner;
+}): Promise<void> => {
+	try {
+		await input.runCommand("launchctl", [
+			"bootout",
+			input.target,
+			input.definitionPath,
+		]);
+	} catch (cause) {
+		try {
+			await input.runCommand("launchctl", [
+				"print",
+				`${input.target}/sh.zuse.serve`,
+			]);
+		} catch (probeCause) {
+			if (isMissingLaunchctlService(probeCause)) return;
+		}
+		throw cause;
+	}
+};
+
 export const resolveServeServicePaths = (input: {
 	readonly platform?: NodeJS.Platform;
 	readonly homeDir?: string;
@@ -111,6 +147,7 @@ const isSystemdUserAvailable = async (): Promise<boolean> => {
 export const installServeService = async (input: {
 	readonly executable: string;
 	readonly paths: ServeServicePaths;
+	readonly relayUrl?: string;
 }): Promise<ServeServiceStatus> => {
 	await mkdir(dirname(input.paths.definitionPath), { recursive: true });
 	await mkdir(input.paths.logDir, { recursive: true, mode: 0o700 });
@@ -122,16 +159,17 @@ export const installServeService = async (input: {
 			executable: input.executable,
 			dataDir: input.paths.dataDir,
 			logDir: input.paths.logDir,
+			relayUrl: input.relayUrl,
 		});
 		await writeFile(input.paths.definitionPath, definition.contents, {
 			mode: 0o600,
 		});
 		const target = launchctlTarget();
-		await run("launchctl", [
-			"bootout",
+		await bootoutLaunchAgent({
 			target,
-			input.paths.definitionPath,
-		]).catch(() => undefined);
+			definitionPath: input.paths.definitionPath,
+			runCommand: run,
+		});
 		await run("launchctl", ["bootstrap", target, input.paths.definitionPath]);
 		await run("launchctl", ["enable", `${target}/${definition.label}`]);
 		await run("launchctl", [
@@ -152,6 +190,7 @@ export const installServeService = async (input: {
 		executable: input.executable,
 		dataDir: input.paths.dataDir,
 		logDir: input.paths.logDir,
+		relayUrl: input.relayUrl,
 	});
 	await writeFile(input.paths.definitionPath, definition.contents, {
 		mode: 0o600,
@@ -163,30 +202,57 @@ export const installServeService = async (input: {
 
 export const startServeService = async (
 	paths: ServeServicePaths,
+	runCommand: ServeServiceCommandRunner = run,
 ): Promise<void> => {
 	if (paths.platform === "darwin") {
 		const target = launchctlTarget();
-		await run("launchctl", ["enable", `${target}/sh.zuse.serve`]);
-		await run("launchctl", ["kickstart", "-k", `${target}/sh.zuse.serve`]);
+		await runCommand("launchctl", ["enable", `${target}/sh.zuse.serve`]);
+		await runCommand("launchctl", [
+			"bootstrap",
+			target,
+			paths.definitionPath,
+		]).catch(async (cause) => {
+			try {
+				await runCommand("launchctl", ["print", `${target}/sh.zuse.serve`]);
+			} catch {
+				throw cause;
+			}
+		});
+		await runCommand("launchctl", [
+			"kickstart",
+			"-k",
+			`${target}/sh.zuse.serve`,
+		]);
 		return;
 	}
-	await run("systemctl", ["--user", "enable", "--now", "zuse-serve.service"]);
+	await runCommand("systemctl", [
+		"--user",
+		"enable",
+		"--now",
+		"zuse-serve.service",
+	]);
 };
 
 export const stopServeService = async (
 	paths: ServeServicePaths,
+	runCommand: ServeServiceCommandRunner = run,
 ): Promise<void> => {
 	if (paths.platform === "darwin") {
 		const target = launchctlTarget();
-		await run("launchctl", ["disable", `${target}/sh.zuse.serve`]);
-		await run("launchctl", [
-			"kill",
-			"SIGTERM",
-			`${target}/sh.zuse.serve`,
-		]).catch(() => undefined);
+		await runCommand("launchctl", ["disable", `${target}/sh.zuse.serve`]);
+		await bootoutLaunchAgent({
+			target,
+			definitionPath: paths.definitionPath,
+			runCommand,
+		});
 		return;
 	}
-	await run("systemctl", ["--user", "disable", "--now", "zuse-serve.service"]);
+	await runCommand("systemctl", [
+		"--user",
+		"disable",
+		"--now",
+		"zuse-serve.service",
+	]);
 };
 
 export const getServeServiceStatus = async (

--- a/apps/server/test/unit/serve-command.test.ts
+++ b/apps/server/test/unit/serve-command.test.ts
@@ -9,6 +9,7 @@ describe("zuse serve management commands", () => {
 			json: false,
 			foreground: false,
 			force: false,
+			dataDir: undefined,
 		});
 	});
 
@@ -18,6 +19,7 @@ describe("zuse serve management commands", () => {
 			json: true,
 			foreground: false,
 			force: false,
+			dataDir: undefined,
 		});
 	});
 
@@ -27,12 +29,31 @@ describe("zuse serve management commands", () => {
 			json: false,
 			foreground: true,
 			force: false,
+			dataDir: undefined,
 		});
 		expect(parseServeCommand(["serve", "update", "--force"])).toEqual({
 			action: "update",
 			json: false,
 			foreground: false,
 			force: true,
+			dataDir: undefined,
+		});
+	});
+
+	it("parses the data directory used by durable service definitions", () => {
+		expect(
+			parseServeCommand([
+				"serve",
+				"--foreground",
+				"--data-dir",
+				"/tmp/zuse-serve",
+			]),
+		).toEqual({
+			action: "start",
+			json: false,
+			foreground: true,
+			force: false,
+			dataDir: "/tmp/zuse-serve",
 		});
 	});
 
@@ -42,6 +63,9 @@ describe("zuse serve management commands", () => {
 		);
 		expect(() => parseServeCommand(["serve", "status", "--force"])).toThrow(
 			/--force is only valid with update/u,
+		);
+		expect(() => parseServeCommand(["serve", "--data-dir"])).toThrow(
+			/--data-dir requires a value/u,
 		);
 	});
 });

--- a/apps/server/test/unit/serve-service-definition.test.ts
+++ b/apps/server/test/unit/serve-service-definition.test.ts
@@ -12,6 +12,7 @@ describe("Zuse Serve service definitions", () => {
 			executable: "/opt/zuse/bin/zuse",
 			dataDir: "/Users/dev/.local/share/zuse",
 			logDir: "/Users/dev/Library/Logs/Zuse",
+			relayUrl: "http://127.0.0.1:8790",
 		});
 
 		expect(definition.label).toBe("sh.zuse.serve");
@@ -21,6 +22,9 @@ describe("Zuse Serve service definitions", () => {
 			"<string>/Users/dev/.local/share/zuse</string>",
 		);
 		expect(definition.contents).toContain("<key>KeepAlive</key>");
+		expect(definition.contents).toContain(
+			"<string>http://127.0.0.1:8790</string>",
+		);
 		expect(definition.contents).not.toMatch(/token|credential|authorization/iu);
 	});
 

--- a/apps/server/test/unit/serve-service-manager.test.ts
+++ b/apps/server/test/unit/serve-service-manager.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	type ServeServicePaths,
+	startServeService,
+	stopServeService,
+} from "../../src/serve/service-manager.ts";
+
+const paths: ServeServicePaths = {
+	platform: "darwin",
+	definitionPath: "/Users/dev/Library/LaunchAgents/sh.zuse.serve.plist",
+	dataDir: "/Users/dev/.local/share/zuse",
+	logDir: "/Users/dev/.local/share/zuse/logs",
+};
+
+describe("Zuse Serve service lifecycle", () => {
+	it("unloads a stopped macOS service and bootstraps it again on start", async () => {
+		const commands: Array<readonly [string, ReadonlyArray<string>]> = [];
+		const run = vi.fn(
+			async (executable: string, args: ReadonlyArray<string>) => {
+				commands.push([executable, args]);
+				return { stdout: "", stderr: "" };
+			},
+		);
+		const target = `gui/${process.getuid?.()}`;
+
+		await stopServeService(paths, run);
+		await startServeService(paths, run);
+
+		expect(commands).toEqual([
+			["launchctl", ["disable", `${target}/sh.zuse.serve`]],
+			[
+				"launchctl",
+				[
+					"bootout",
+					target,
+					"/Users/dev/Library/LaunchAgents/sh.zuse.serve.plist",
+				],
+			],
+			["launchctl", ["enable", `${target}/sh.zuse.serve`]],
+			[
+				"launchctl",
+				[
+					"bootstrap",
+					target,
+					"/Users/dev/Library/LaunchAgents/sh.zuse.serve.plist",
+				],
+			],
+			["launchctl", ["kickstart", "-k", `${target}/sh.zuse.serve`]],
+		]);
+	});
+
+	it("treats an already-unloaded macOS service as stopped", async () => {
+		const missingService = Object.assign(new Error("service not found"), {
+			code: 113,
+			stderr:
+				'Could not find service "sh.zuse.serve" in domain for user gui: 501',
+		});
+		const run = vi.fn(
+			async (_executable: string, args: ReadonlyArray<string>) => {
+				if (args[0] === "bootout") throw new Error("bootout failed");
+				if (args[0] === "print") throw missingService;
+				return { stdout: "", stderr: "" };
+			},
+		);
+
+		await expect(stopServeService(paths, run)).resolves.toBeUndefined();
+	});
+
+	it("reports a macOS unload failure while the service remains loaded", async () => {
+		const bootoutFailure = new Error("bootout failed");
+		const run = vi.fn(
+			async (_executable: string, args: ReadonlyArray<string>) => {
+				if (args[0] === "bootout") throw bootoutFailure;
+				return { stdout: "", stderr: "" };
+			},
+		);
+
+		await expect(stopServeService(paths, run)).rejects.toBe(bootoutFailure);
+	});
+
+	it("reports a macOS unload failure when service status is inconclusive", async () => {
+		const bootoutFailure = new Error("bootout failed");
+		const run = vi.fn(
+			async (_executable: string, args: ReadonlyArray<string>) => {
+				if (args[0] === "bootout") throw bootoutFailure;
+				if (args[0] === "print") throw new Error("launchd unavailable");
+				return { stdout: "", stderr: "" };
+			},
+		);
+
+		await expect(stopServeService(paths, run)).rejects.toBe(bootoutFailure);
+	});
+});

--- a/packages/client-runtime/src/ws-protocol.ts
+++ b/packages/client-runtime/src/ws-protocol.ts
@@ -27,7 +27,23 @@ export type WsProtocolLayerOptions = {
 		url: string,
 		protocols?: string | Array<string>,
 	) => globalThis.WebSocket;
+	readonly onClose?: (event: CloseEvent) => void;
 };
+
+type WebSocketConstructor = NonNullable<
+	WsProtocolLayerOptions["makeWebSocket"]
+>;
+
+export const observeWebSocketConstructor =
+	(
+		makeWebSocket: WebSocketConstructor,
+		onClose: (event: CloseEvent) => void,
+	): WebSocketConstructor =>
+	(url, protocols) => {
+		const socket = makeWebSocket(url, protocols);
+		socket.addEventListener("close", onClose, { once: true });
+		return socket;
+	};
 
 export const connectionKey = (host: string, port: number): string =>
 	`${host.trim()}:${port}`;
@@ -47,8 +63,16 @@ export const authenticatedWsUrl = (options: WsProtocolOptions): string => {
 export const wsClientProtocolLayer = (
 	endpoint: string | WsProtocolOptions,
 	options?: WsProtocolLayerOptions,
-): Layer.Layer<RpcClient.Protocol> =>
-	RpcClient.layerProtocolSocket().pipe(
+): Layer.Layer<RpcClient.Protocol> => {
+	const makeWebSocket =
+		options?.onClose === undefined
+			? options?.makeWebSocket
+			: observeWebSocketConstructor(
+					options.makeWebSocket ??
+						((url, protocols) => new globalThis.WebSocket(url, protocols)),
+					options.onClose,
+				);
+	return RpcClient.layerProtocolSocket().pipe(
 		Layer.provide(
 			Socket.layerWebSocket(
 				typeof endpoint === "string" ? endpoint : authenticatedWsUrl(endpoint),
@@ -56,9 +80,10 @@ export const wsClientProtocolLayer = (
 			),
 		),
 		Layer.provide(
-			options?.makeWebSocket === undefined
+			makeWebSocket === undefined
 				? Socket.layerWebSocketConstructorGlobal
-				: Layer.succeed(Socket.WebSocketConstructor, options.makeWebSocket),
+				: Layer.succeed(Socket.WebSocketConstructor, makeWebSocket),
 		),
 		Layer.provide(RpcSerialization.layerJson),
 	);
+};

--- a/packages/client-runtime/test/unit/ws-protocol.test.ts
+++ b/packages/client-runtime/test/unit/ws-protocol.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { authenticatedWsUrl } from "../../src/ws-protocol.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+	authenticatedWsUrl,
+	observeWebSocketConstructor,
+} from "../../src/ws-protocol.ts";
 
 describe("WebSocket client protocol", () => {
 	it("builds one authenticated wire-versioned endpoint for every client", () => {
@@ -9,7 +12,7 @@ describe("WebSocket client protocol", () => {
 				port: 8787,
 				token: " token-value ",
 			}),
-		).toBe("ws://127.0.0.1:8787/?token=token-value&wireVersion=2");
+		).toBe("ws://127.0.0.1:8787/?token=token-value&wireVersion=3");
 	});
 
 	it("prefers a managed base URL", () => {
@@ -19,6 +22,23 @@ describe("WebSocket client protocol", () => {
 				port: 1,
 				wsBaseUrl: "wss://environment.example/rpc",
 			}),
-		).toBe("wss://environment.example/rpc?wireVersion=2");
+		).toBe("wss://environment.example/rpc?wireVersion=3");
+	});
+
+	it("reports an established socket closing to the connection owner", () => {
+		const socket = new EventTarget();
+		const onClose = vi.fn();
+		const make = observeWebSocketConstructor(
+			() => socket as unknown as WebSocket,
+			onClose,
+		);
+
+		expect(make("wss://environment.example/rpc")).toBe(socket);
+		socket.dispatchEvent(new CloseEvent("close", { code: 1006 }));
+
+		expect(onClose).toHaveBeenCalledOnce();
+		expect(onClose).toHaveBeenCalledWith(
+			expect.objectContaining({ code: 1006 }),
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- consume hosted connection grants once and request a fresh short-lived grant for every reconnect attempt
- report established WebSocket closure to the existing connection supervisor
- correctly parse durable foreground service arguments and preserve the configured data directory and relay URL
- make macOS service install, stop, start, process restart, and reinstall idempotent while surfacing inconclusive unload failures

## Why

Hosted clients could remain stuck after the served host restarted because reconnect attempts reused an expired single-use grant and socket closure was not reported to the supervisor. The durable macOS service also misparsed its generated `--data-dir` arguments and used lifecycle ordering that could leave launchd state inconsistent.

## Validation

- Biome checks on all changed files
- client runtime unit tests: 47 passed
- server unit tests: 194 passed
- renderer unit tests: 248 passed
- client runtime, server, and renderer type checks passed
- local hosted reconnect recovered through fresh relay grants without a page reload
- rebuilt local CLI installed a real LaunchAgent, preserved the local relay and data directory, returned HTTP 200, recovered from forced process death with a new PID, completed stop/start, and uninstalled without deleting workspaces
- final standards and spec reviews found no remaining actionable issues

## Known baseline

The renderer production bundle check currently fails on `main` as well: isolated `main` measured 623.9 KiB initial JavaScript against a 500 KiB budget; this branch measured 625.6 KiB. No dependency patch is included because the reconnect investigation confirmed the socket library already reports close/error events and the missing behavior was in Zuse lifecycle ownership.