### PR TITLE
Attribute renderer stall causes

### DIFF
--- a/apps/desktop/test/unit/performance-history-store.test.ts
+++ b/apps/desktop/test/unit/performance-history-store.test.ts
@@ -66,6 +66,17 @@ describe("PerformanceHistoryStore", () => {
 			kind: "long-task",
 			durationMs: 250,
 			source: "renderer",
+			attribution: {
+				cause: "script",
+				label: "handleSend",
+				confidence: "high",
+				blockingDurationMs: 180,
+				scriptFunction: "handleSend",
+				scriptSource: "chat-view.js",
+				recentActions: ["pointer.button"],
+				activeWorkloads: ["agent"],
+				relatedOperations: ["rpc:messages.queue.add"],
+			},
 		};
 		store.recordLag(lag);
 		await store.flush();

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -3,6 +3,7 @@ import type {
 	DiagnosticSeverity,
 	DiagnosticsOverviewResult,
 	DiagnosticsProcessesResult,
+	LagSample,
 	PerformanceHistory,
 	PowerMonitorState,
 	PowerRecordingDurationMinutes,
@@ -547,6 +548,210 @@ function IncidentDetails({
 	);
 }
 
+function ContextList({
+	label,
+	values,
+}: {
+	readonly label: string;
+	readonly values: ReadonlyArray<string>;
+}) {
+	return (
+		<div className="min-w-0 rounded-md border border-border/45 bg-muted/20 p-2.5">
+			<p className="text-[10px] text-muted-foreground uppercase tracking-wider">
+				{label}
+			</p>
+			<p className="mt-1.5 break-words font-mono text-[10px] leading-4">
+				{values.length > 0 ? values.join(" · ") : "None captured"}
+			</p>
+		</div>
+	);
+}
+
+function StallWorkspace({
+	samples,
+	selectedId,
+	onSelect,
+	copiedKey,
+	onCopy,
+}: {
+	readonly samples: ReadonlyArray<LagSample>;
+	readonly selectedId: string | null;
+	readonly onSelect: (id: string) => void;
+	readonly copiedKey: string | null;
+	readonly onCopy: (key: string, text: string) => void;
+}) {
+	const ordered = [...samples]
+		.sort((left, right) => right.capturedAt.localeCompare(left.capturedAt))
+		.slice(0, 24);
+	const selected =
+		ordered.find((sample) => sample.id === selectedId) ?? ordered[0] ?? null;
+	const attribution = selected?.attribution;
+	const details =
+		selected === null
+			? ""
+			: [
+					`Stall: ${selected.id}`,
+					`Captured: ${selected.capturedAt}`,
+					`Duration: ${selected.durationMs.toFixed(1)} ms`,
+					`Type: ${selected.kind}`,
+					`Cause: ${attribution?.label ?? "Unattributed"}`,
+					`Confidence: ${attribution?.confidence ?? "low"}`,
+					attribution?.blockingDurationMs === undefined
+						? null
+						: `Blocking: ${attribution.blockingDurationMs.toFixed(1)} ms`,
+					attribution?.styleLayoutDurationMs === undefined
+						? null
+						: `Style/layout: ${attribution.styleLayoutDurationMs.toFixed(1)} ms`,
+					attribution?.scriptFunction
+						? `Function: ${attribution.scriptFunction}`
+						: null,
+					attribution?.scriptSource
+						? `Source: ${attribution.scriptSource}${attribution.scriptPosition === undefined ? "" : `:${attribution.scriptPosition}`}`
+						: null,
+					attribution?.recentActions.length
+						? `Recent actions: ${attribution.recentActions.join(", ")}`
+						: null,
+					attribution?.activeWorkloads.length
+						? `Active workloads: ${attribution.activeWorkloads.join(", ")}`
+						: null,
+					attribution?.relatedOperations.length
+						? `Related operations: ${attribution.relatedOperations.join(", ")}`
+						: null,
+				]
+					.filter(Boolean)
+					.join("\n");
+
+	return (
+		<section className="min-w-0 border-t border-border/45">
+			<div className="flex min-h-10 items-center justify-between gap-3 border-b border-border/45 px-4 py-2.5">
+				<div>
+					<h3 className="font-medium text-[11px]">Stall cause timeline</h3>
+					<p className="mt-0.5 text-[10px] text-muted-foreground">
+						Sanitized script, layout, action, and workload attribution. React
+						commit timing is added in development builds.
+					</p>
+				</div>
+				<span className="font-mono text-[10px] text-muted-foreground tabular-nums">
+					{ordered.length} retained
+				</span>
+			</div>
+			{selected === null ? (
+				<div className="min-h-[280px]">
+					<EmptyState
+						title="No interface stalls"
+						description="Stalls of at least 100 ms will appear with the strongest locally available cause."
+					/>
+				</div>
+			) : (
+				<div className="grid min-h-[280px] lg:grid-cols-[minmax(260px,0.85fr)_minmax(0,1.35fr)] lg:divide-x lg:divide-border/45">
+					<fieldset className="max-h-[360px] divide-y divide-border/40 overflow-auto">
+						<legend className="sr-only">Interface stalls</legend>
+						{ordered.map((sample) => {
+							const active = sample.id === selected.id;
+							return (
+								<button
+									key={sample.id}
+									type="button"
+									aria-pressed={active}
+									onClick={() => onSelect(sample.id)}
+									className={cn(
+										"grid min-h-11 w-full grid-cols-[minmax(0,1fr)_auto] gap-3 px-4 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring pointer-coarse:min-h-11",
+										active ? "bg-muted/70" : "hover:bg-muted/35",
+									)}
+								>
+									<span className="min-w-0">
+										<span className="block truncate font-medium text-[11px]">
+											{sample.attribution?.label ?? sample.name ?? sample.kind}
+										</span>
+										<span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+											{sample.attribution?.cause ?? sample.kind} ·{" "}
+											{sample.attribution?.confidence ?? "low"} confidence
+										</span>
+									</span>
+									<span className="text-right">
+										<span className="block font-mono text-[11px] tabular-nums">
+											{formatDuration(sample.durationMs)}
+										</span>
+										<span className="mt-0.5 block font-mono text-[10px] text-muted-foreground tabular-nums">
+											{relativeTime(sample.capturedAt)}
+										</span>
+									</span>
+								</button>
+							);
+						})}
+					</fieldset>
+					<div className="border-t border-border/45 p-4 lg:border-t-0">
+						<div className="flex items-start justify-between gap-3">
+							<div className="min-w-0">
+								<p className="truncate font-medium text-xs">
+									{attribution?.label ?? "Cause unavailable"}
+								</p>
+								<p className="mt-1 text-[10px] text-muted-foreground">
+									{attribution?.confidence ?? "low"} confidence ·{" "}
+									{selected.kind}
+								</p>
+							</div>
+							<CopyButton
+								copyKey={`stall:${selected.id}`}
+								copiedKey={copiedKey}
+								onCopy={onCopy}
+								label="Copy"
+								text={details}
+							/>
+						</div>
+						<div className="mt-4 grid grid-cols-2 gap-x-5 gap-y-2 text-[10px]">
+							<span className="text-muted-foreground">Total duration</span>
+							<span className="text-right font-mono tabular-nums">
+								{formatDuration(selected.durationMs)}
+							</span>
+							<span className="text-muted-foreground">
+								Main-thread blocking
+							</span>
+							<span className="text-right font-mono tabular-nums">
+								{attribution?.blockingDurationMs === undefined
+									? "Unavailable"
+									: formatDuration(attribution.blockingDurationMs)}
+							</span>
+							<span className="text-muted-foreground">Style and layout</span>
+							<span className="text-right font-mono tabular-nums">
+								{attribution?.styleLayoutDurationMs === undefined
+									? "Unavailable"
+									: formatDuration(attribution.styleLayoutDurationMs)}
+							</span>
+							<span className="text-muted-foreground">Script</span>
+							<span className="truncate text-right font-mono">
+								{attribution?.scriptSource === undefined
+									? "Unavailable"
+									: `${attribution.scriptSource}${attribution.scriptPosition === undefined ? "" : `:${attribution.scriptPosition}`}`}
+							</span>
+							<span className="text-muted-foreground">Function</span>
+							<span className="truncate text-right font-mono">
+								{attribution?.scriptFunction ??
+									attribution?.scriptInvoker ??
+									"Unavailable"}
+							</span>
+						</div>
+						<div className="mt-4 grid gap-3 sm:grid-cols-3">
+							<ContextList
+								label="Recent actions"
+								values={attribution?.recentActions ?? []}
+							/>
+							<ContextList
+								label="Active workloads"
+								values={attribution?.activeWorkloads ?? []}
+							/>
+							<ContextList
+								label="Related operations"
+								values={attribution?.relatedOperations ?? []}
+							/>
+						</div>
+					</div>
+				</div>
+			)}
+		</section>
+	);
+}
+
 export function DiagnosticsPane() {
 	const initialPreferences = useRef(readPreferences()).current;
 	const mainLogsIngestedRef = useRef(false);
@@ -571,6 +776,7 @@ export function DiagnosticsPane() {
 		"starting" | "stopping" | "exporting" | null
 	>(null);
 	const [selected, setSelected] = useState<DiagnosticEvent | null>(null);
+	const [selectedLagId, setSelectedLagId] = useState<string | null>(null);
 	const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
 	const [mobileDetailsOpen, setMobileDetailsOpen] = useState(false);
 	const [view, setView] = useState<DiagnosticsView>(initialPreferences.view);
@@ -1643,6 +1849,13 @@ export function DiagnosticsPane() {
 								className="stroke-destructive"
 							/>
 						</div>
+						<StallWorkspace
+							samples={lagSamples}
+							selectedId={selectedLagId}
+							onSelect={setSelectedLagId}
+							copiedKey={copiedKey}
+							onCopy={copyText}
+						/>
 						<div className="grid border-t border-border/45 lg:grid-cols-2 lg:divide-x lg:divide-border/45">
 							<section className="min-w-0">
 								<div className="border-b border-border/45 px-4 py-2.5">

--- a/apps/renderer/src/hooks/use-report-runtime-activity.ts
+++ b/apps/renderer/src/hooks/use-report-runtime-activity.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import {
 	getPowerRuntimeActivity,
+	setPowerActiveAgentCount,
 	subscribePowerRuntimeActivity,
 } from "../lib/power-runtime-activity.ts";
 import { useMessagesStore } from "../store/messages.ts";
@@ -27,6 +28,7 @@ export function useReportRuntimeActivity(): void {
 			const count = countRunning(useMessagesStore.getState());
 			if (count !== lastRunningCount) {
 				lastRunningCount = count;
+				setPowerActiveAgentCount(count);
 				window.zuse?.updates?.reportRunningCount(count);
 			}
 			const runtimeActivity = getPowerRuntimeActivity();

--- a/apps/renderer/src/lib/diagnostics-recorder.ts
+++ b/apps/renderer/src/lib/diagnostics-recorder.ts
@@ -1,4 +1,10 @@
 import type { PowerInteractionMeasurement } from "@zuse/contracts";
+import { getPowerRuntimeActivity } from "./power-runtime-activity.ts";
+import { setRendererRpcLagReporter } from "./rpc-stall-instrumentation.ts";
+import {
+	getActiveStallOperations,
+	type StallContext,
+} from "./stall-context.ts";
 
 export type DiagnosticLogLevel = "debug" | "info" | "warn" | "error";
 
@@ -27,6 +33,16 @@ const powerInteractions: PowerInteractionMeasurement[] = [];
 let installed = false;
 let flushTimer: number | null = null;
 let flushing = false;
+let reportReactCommit:
+	| ((input: {
+			readonly id: string;
+			readonly phase: "mount" | "update" | "nested-update";
+			readonly actualDurationMs: number;
+			readonly baseDurationMs: number;
+	  }) => void)
+	| null = null;
+let reportOperationLag: ((name: string, durationMs: number) => void) | null =
+	null;
 
 function pushBounded<T>(items: T[], item: T, limit: number): void {
 	items.push(item);
@@ -167,6 +183,35 @@ export function getDiagnosticUiActions(): ReadonlyArray<DiagnosticUiAction> {
 	return uiActions.slice();
 }
 
+export function getRendererStallContext(): StallContext {
+	const cutoff = Date.now() - 5_000;
+	const activity = getPowerRuntimeActivity();
+	const activeWorkloads = [
+		...(activity.activeAgents > 0 ? ["agent"] : []),
+		...(activity.activeTerminals > 0 ? ["terminal"] : []),
+		...(activity.activeBrowserSessions > 0 ? ["browser"] : []),
+		...(activity.browserRecordings > 0 ? ["browser-recording"] : []),
+		...(activity.indexing ? ["indexing"] : []),
+	];
+	return {
+		recentActions: uiActions
+			.filter((item) => Date.parse(item.createdAt) >= cutoff)
+			.slice(-8)
+			.map((item) => item.action),
+		activeWorkloads,
+		relatedOperations: [...getActiveStallOperations()],
+	};
+}
+
+export function recordReactCommit(
+	id: string,
+	phase: "mount" | "update" | "nested-update",
+	actualDurationMs: number,
+	baseDurationMs: number,
+): void {
+	reportReactCommit?.({ id, phase, actualDurationMs, baseDurationMs });
+}
+
 export function recordPowerInteraction(name: string, durationMs: number): void {
 	if (!/^chat\.[a-z0-9._-]{1,100}$/i.test(name)) return;
 	if (!Number.isFinite(durationMs) || durationMs < 0) return;
@@ -193,19 +238,63 @@ export function getPowerInteractionMeasurements(
 export function installRendererDiagnostics(): void {
 	if (installed || typeof window === "undefined") return;
 	installed = true;
+	document.addEventListener(
+		"pointerdown",
+		(event) => {
+			const element = event.target instanceof Element ? event.target : null;
+			const role = element?.closest("[role]")?.getAttribute("role");
+			const tag = element
+				?.closest("button,a,input,textarea,[role]")
+				?.tagName.toLowerCase();
+			recordUiAction(`pointer.${role ?? tag ?? "surface"}`);
+		},
+		{ capture: true, passive: true },
+	);
+	document.addEventListener(
+		"keydown",
+		(event) => {
+			const action =
+				event.key === "Enter"
+					? "keyboard.submit"
+					: event.key === "Escape"
+						? "keyboard.dismiss"
+						: event.key.startsWith("Arrow")
+							? "keyboard.navigate"
+							: event.metaKey || event.ctrlKey
+								? "keyboard.shortcut"
+								: null;
+			if (action !== null) recordUiAction(action);
+		},
+		{ capture: true },
+	);
 	void import("./renderer-lag-monitor.ts")
-		.then(({ installRendererLagMonitor }) => {
-			installRendererLagMonitor((samples) => {
+		.then(async ({ installRendererLagMonitor }) => {
+			const { createOperationLagSample, createReactCommitLagSample } =
+				await import("./stall-attribution.ts");
+			const reportSamples = (
+				samples: ReadonlyArray<import("@zuse/contracts").LagSample>,
+			) => {
 				window.zuse?.power?.reportLagSamples?.(samples);
-				for (const sample of samples.filter((item) => item.durationMs >= 500)) {
-					recordDiagnosticEvent({
-						level: "warn",
-						source: "renderer.lag",
-						message: sample.name ?? `renderer.${sample.kind}`,
-						detail: `durationMs=${sample.durationMs.toFixed(1)}`,
-					});
-				}
+			};
+			reportReactCommit = (input) => {
+				const sample = createReactCommitLagSample({
+					...input,
+					context: getRendererStallContext(),
+				});
+				if (sample !== null) reportSamples([sample]);
+			};
+			reportOperationLag = (name, durationMs) => {
+				const sample = createOperationLagSample({
+					name,
+					durationMs,
+					context: getRendererStallContext(),
+				});
+				if (sample !== null) reportSamples([sample]);
+			};
+			setRendererRpcLagReporter((name, durationMs) => {
+				reportOperationLag?.(name, durationMs);
 			});
+			installRendererLagMonitor(reportSamples, getRendererStallContext);
 		})
 		.catch(() => undefined);
 

--- a/apps/renderer/src/lib/performance-marks.ts
+++ b/apps/renderer/src/lib/performance-marks.ts
@@ -1,5 +1,4 @@
 import {
-	recordDiagnosticEvent,
 	recordPowerInteraction,
 	recordUiAction,
 } from "./diagnostics-recorder.ts";
@@ -37,22 +36,13 @@ export function markRendererInteraction(
 	if (elapsed !== undefined) recordPowerInteraction(`chat.${stage}`, elapsed);
 }
 
+/**
+ * Compatibility shim for the three interaction-marking call sites that used
+ * to own RPC timing. The shared client boundary now measures every unary RPC.
+ */
 export async function trackRendererRpc<A>(
-	name: string,
+	_name: string,
 	operation: () => Promise<A>,
 ): Promise<A> {
-	const startedAt = performance.now();
-	try {
-		return await operation();
-	} finally {
-		const durationMs = performance.now() - startedAt;
-		if (durationMs >= 250) {
-			recordDiagnosticEvent({
-				level: durationMs >= 1_000 ? "warn" : "info",
-				source: "renderer.rpc.slow",
-				message: name,
-				detail: `durationMs=${durationMs.toFixed(1)}`,
-			});
-		}
-	}
+	return operation();
 }

--- a/apps/renderer/src/lib/power-runtime-activity.ts
+++ b/apps/renderer/src/lib/power-runtime-activity.ts
@@ -1,4 +1,5 @@
 export interface PowerRuntimeActivity {
+	readonly activeAgents: number;
 	readonly activeTerminals: number;
 	readonly browserSessions: number;
 	readonly activeBrowserSessions: number;
@@ -7,6 +8,7 @@ export interface PowerRuntimeActivity {
 }
 
 let activity: PowerRuntimeActivity = {
+	activeAgents: 0,
 	activeTerminals: 0,
 	browserSessions: 0,
 	activeBrowserSessions: 0,
@@ -27,6 +29,7 @@ export const subscribePowerRuntimeActivity = (
 
 const publish = (next: PowerRuntimeActivity): void => {
 	if (
+		next.activeAgents === activity.activeAgents &&
 		next.activeTerminals === activity.activeTerminals &&
 		next.browserSessions === activity.browserSessions &&
 		next.activeBrowserSessions === activity.activeBrowserSessions &&
@@ -37,6 +40,10 @@ const publish = (next: PowerRuntimeActivity): void => {
 	}
 	activity = next;
 	for (const listener of listeners) listener();
+};
+
+export const setPowerActiveAgentCount = (count: number): void => {
+	publish({ ...activity, activeAgents: Math.max(0, count) });
 };
 
 export const setPowerActiveTerminalCount = (count: number): void => {

--- a/apps/renderer/src/lib/renderer-lag-monitor.ts
+++ b/apps/renderer/src/lib/renderer-lag-monitor.ts
@@ -1,4 +1,10 @@
 import type { LagKind, LagSample } from "@zuse/contracts";
+import {
+	createFallbackStallAttribution,
+	createLongAnimationFrameSample,
+	type LongAnimationFrameEntry,
+} from "./stall-attribution.ts";
+import type { StallContext } from "./stall-context.ts";
 
 export interface RendererLagInput {
 	readonly kind: LagKind;
@@ -11,6 +17,7 @@ export interface RendererLagInput {
 
 export function createRendererLagSample(
 	input: RendererLagInput,
+	context?: StallContext,
 ): LagSample | null {
 	if (!input.visible || !Number.isFinite(input.durationMs)) return null;
 	if (input.durationMs < 100) return null;
@@ -27,11 +34,21 @@ export function createRendererLagSample(
 		durationMs,
 		source: "renderer",
 		name: `renderer.${input.kind}`,
+		...(context === undefined
+			? {}
+			: {
+					attribution: createFallbackStallAttribution(
+						input.kind,
+						input.name,
+						context,
+					),
+				}),
 	};
 }
 
 export function installRendererLagMonitor(
 	report: (samples: ReadonlyArray<LagSample>) => void,
+	readContext: () => StallContext,
 ): () => void {
 	const observers: PerformanceObserver[] = [];
 	const queued: LagSample[] = [];
@@ -61,15 +78,35 @@ export function installRendererLagMonitor(
 
 	if (typeof PerformanceObserver !== "undefined") {
 		const supported = PerformanceObserver.supportedEntryTypes ?? [];
-		if (supported.includes("longtask")) {
+		const supportsLongAnimationFrame = supported.includes(
+			"long-animation-frame",
+		);
+		if (supportsLongAnimationFrame) {
 			const observer = new PerformanceObserver((list) => {
 				for (const entry of list.getEntries()) {
 					enqueue(
-						createRendererLagSample({
-							kind: "long-task",
-							durationMs: entry.duration,
-							visible: visible(),
-						}),
+						createLongAnimationFrameSample(
+							entry as unknown as LongAnimationFrameEntry,
+							readContext(),
+						),
+					);
+				}
+			});
+			observer.observe({ type: "long-animation-frame", buffered: true });
+			observers.push(observer);
+		}
+		if (!supportsLongAnimationFrame && supported.includes("longtask")) {
+			const observer = new PerformanceObserver((list) => {
+				for (const entry of list.getEntries()) {
+					enqueue(
+						createRendererLagSample(
+							{
+								kind: "long-task",
+								durationMs: entry.duration,
+								visible: visible(),
+							},
+							readContext(),
+						),
 					);
 				}
 			});
@@ -80,11 +117,14 @@ export function installRendererLagMonitor(
 			const observer = new PerformanceObserver((list) => {
 				for (const entry of list.getEntries()) {
 					enqueue(
-						createRendererLagSample({
-							kind: "input-latency",
-							durationMs: entry.duration,
-							visible: visible(),
-						}),
+						createRendererLagSample(
+							{
+								kind: "input-latency",
+								durationMs: entry.duration,
+								visible: visible(),
+							},
+							readContext(),
+						),
 					);
 				}
 			});
@@ -93,6 +133,12 @@ export function installRendererLagMonitor(
 		}
 	}
 
+	const supportsLongAnimationFrame =
+		typeof PerformanceObserver !== "undefined" &&
+		(PerformanceObserver.supportedEntryTypes?.includes(
+			"long-animation-frame",
+		) ??
+			false);
 	let animationFrame: number | null = null;
 	let animationProbeTimer: number | null = null;
 	const scheduleAnimationProbe = () => {
@@ -108,17 +154,21 @@ export function installRendererLagMonitor(
 			animationFrame = requestAnimationFrame((timestamp) => {
 				animationFrame = null;
 				enqueue(
-					createRendererLagSample({
-						kind: "animation-stall",
-						durationMs: timestamp - requestedAt,
-						visible: visible() && requestedGeneration === visibilityGeneration,
-					}),
+					createRendererLagSample(
+						{
+							kind: "animation-stall",
+							durationMs: timestamp - requestedAt,
+							visible:
+								visible() && requestedGeneration === visibilityGeneration,
+						},
+						readContext(),
+					),
 				);
 				scheduleAnimationProbe();
 			});
 		}, 1_000);
 	};
-	scheduleAnimationProbe();
+	if (!supportsLongAnimationFrame) scheduleAnimationProbe();
 
 	return () => {
 		disposed = true;

--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -20,6 +20,7 @@ import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
 import type { RpcBridge } from "./bridge.ts";
 import { requestBrowserWebSocketUrl } from "./browser-session.ts";
 import { electronClientProtocolLayer } from "./electron-client-protocol.ts";
+import { instrumentRendererRpcClient } from "./rpc-stall-instrumentation.ts";
 import { wsClientProtocolLayer } from "./ws-client-protocol.ts";
 
 type MemoizeClient = RpcClient.RpcClient<
@@ -98,10 +99,12 @@ const supervisor = createConnectionSupervisor<
 							WIRE_PROTOCOL_VERSION,
 						),
 					);
-		return makeRpcClientSession(protocolLayer, MemoizeRpcs, {
-			protocolVersion: WIRE_PROTOCOL_VERSION,
-			perform: (client, hello) => client["connect.handshake"](hello),
-		});
+		return instrumentRendererRpcClient(
+			await makeRpcClientSession(protocolLayer, MemoizeRpcs, {
+				protocolVersion: WIRE_PROTOCOL_VERSION,
+				perform: (client, hello) => client["connect.handshake"](hello),
+			}),
+		);
 	},
 	isRetryableCommandError: isRpcClientError,
 });

--- a/apps/renderer/src/lib/rpc-stall-instrumentation.ts
+++ b/apps/renderer/src/lib/rpc-stall-instrumentation.ts
@@ -1,0 +1,69 @@
+import { Effect } from "effect";
+
+import { beginStallOperation } from "./stall-context.ts";
+
+type RpcLagReporter = (name: string, durationMs: number) => void;
+
+let reportRpcLag: RpcLagReporter | null = null;
+const pendingReports: Array<{
+	readonly name: string;
+	readonly durationMs: number;
+}> = [];
+
+export const setRendererRpcLagReporter = (
+	reporter: RpcLagReporter | null,
+): void => {
+	reportRpcLag = reporter;
+	if (reporter === null) return;
+	for (const item of pendingReports.splice(0, pendingReports.length)) {
+		reporter(item.name, item.durationMs);
+	}
+};
+
+const isSafeRpcName = (value: string): boolean =>
+	/^[a-z0-9._-]{1,100}$/i.test(value);
+
+export const instrumentRendererRpcClient = <Client extends object>(
+	client: Client,
+): Client => {
+	const wrappers = new Map<PropertyKey, unknown>();
+	return new Proxy(client, {
+		get(target, property, receiver) {
+			const value = Reflect.get(target, property, receiver);
+			if (
+				typeof property !== "string" ||
+				!isSafeRpcName(property) ||
+				typeof value !== "function"
+			) {
+				return value;
+			}
+			const cached = wrappers.get(property);
+			if (cached !== undefined) return cached;
+			const wrapped = (...args: ReadonlyArray<unknown>) => {
+				const result = Reflect.apply(value, target, args);
+				if (!Effect.isEffect(result)) return result;
+				return Effect.suspend(() => {
+					const startedAt = performance.now();
+					const finishOperation = beginStallOperation(`rpc:${property}`);
+					return result.pipe(
+						Effect.ensuring(
+							Effect.sync(() => {
+								finishOperation();
+								const durationMs = performance.now() - startedAt;
+								if (durationMs < 100) return;
+								if (reportRpcLag !== null) {
+									reportRpcLag(property, durationMs);
+									return;
+								}
+								pendingReports.push({ name: property, durationMs });
+								if (pendingReports.length > 20) pendingReports.shift();
+							}),
+						),
+					);
+				});
+			};
+			wrappers.set(property, wrapped);
+			return wrapped;
+		},
+	});
+};

--- a/apps/renderer/src/lib/stall-attribution.ts
+++ b/apps/renderer/src/lib/stall-attribution.ts
@@ -1,0 +1,263 @@
+import type {
+	LagSample,
+	PerformanceConfidence,
+	StallAttribution,
+} from "@zuse/contracts";
+import type { StallContext } from "./stall-context.ts";
+
+const STALL_THRESHOLD_MS = 100;
+const MAX_STALL_MS = 60_000;
+const CONTEXT_LIMIT = 8;
+
+interface LongAnimationFrameScript {
+	readonly duration?: number;
+	readonly forcedStyleAndLayoutDuration?: number;
+	readonly invoker?: string;
+	readonly invokerType?: string;
+	readonly sourceFunctionName?: string;
+	readonly sourceURL?: string;
+	readonly sourceCharPosition?: number;
+}
+
+export interface LongAnimationFrameEntry {
+	readonly startTime?: number;
+	readonly duration: number;
+	readonly blockingDuration?: number;
+	readonly renderStart?: number;
+	readonly styleAndLayoutStart?: number;
+	readonly scripts?: ReadonlyArray<LongAnimationFrameScript>;
+}
+
+interface SampleFactories {
+	readonly now?: () => string;
+	readonly id?: () => string;
+}
+
+const finite = (value: number | undefined): value is number =>
+	typeof value === "number" && Number.isFinite(value);
+
+const round = (value: number): number =>
+	Math.round(Math.max(0, value) * 10) / 10;
+
+const boundedDuration = (value: number): number =>
+	Math.min(MAX_STALL_MS, round(value));
+
+const safeLabel = (value: string | undefined, fallback: string): string => {
+	const sanitized = (value ?? "")
+		.replace(/[^a-zA-Z0-9_.$: -]+/g, ".")
+		.replace(/\.{2,}/g, ".")
+		.replace(/^[.\s]+|[.\s]+$/g, "")
+		.slice(0, 120);
+	return sanitized || fallback;
+};
+
+const safeSource = (value: string | undefined): string | undefined => {
+	if (!value) return undefined;
+	const scheme = value.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
+	if (
+		scheme !== undefined &&
+		scheme !== "http" &&
+		scheme !== "https" &&
+		scheme !== "file"
+	) {
+		return undefined;
+	}
+	const withoutQuery = value.split(/[?#]/, 1)[0] ?? "";
+	const basename = withoutQuery.split(/[\\/]/).filter(Boolean).at(-1);
+	if (!basename) return undefined;
+	return safeLabel(basename, "script");
+};
+
+const boundedContext = (values: ReadonlyArray<string>): string[] =>
+	values.slice(-CONTEXT_LIMIT).map((value) => safeLabel(value, "activity"));
+
+const attributionContext = (
+	context: StallContext,
+): Pick<
+	StallAttribution,
+	"recentActions" | "activeWorkloads" | "relatedOperations"
+> => ({
+	recentActions: boundedContext(context.recentActions),
+	activeWorkloads: boundedContext(context.activeWorkloads),
+	relatedOperations: boundedContext(context.relatedOperations),
+});
+
+const makeId = (prefix: string): string =>
+	`${prefix}_${Date.now().toString(36)}_${crypto.randomUUID?.().slice(0, 8) ?? "renderer"}`;
+
+export function createFallbackStallAttribution(
+	kind: LagSample["kind"],
+	name: string | undefined,
+	context: StallContext,
+): StallAttribution {
+	const input = kind === "input-latency";
+	const rpc = kind === "rpc";
+	return {
+		cause: input ? "input-handler" : rpc ? "rpc" : "unknown",
+		label: input
+			? "Delayed input response"
+			: rpc
+				? safeLabel(name, "RPC operation")
+				: "Browser timing unavailable",
+		confidence: input || rpc ? "medium" : "low",
+		...attributionContext(context),
+	};
+}
+
+export function createLongAnimationFrameSample(
+	entry: LongAnimationFrameEntry,
+	context: StallContext,
+	factories: SampleFactories = {},
+): LagSample | null {
+	if (!finite(entry.duration) || entry.duration < STALL_THRESHOLD_MS)
+		return null;
+	const scripts = (entry.scripts ?? []).filter((script) =>
+		finite(script.duration),
+	);
+	const script = [...scripts].sort(
+		(left, right) => (right.duration ?? 0) - (left.duration ?? 0),
+	)[0];
+	const scriptDuration = finite(script?.duration) ? script.duration : 0;
+	const styleLayoutDuration = scripts.reduce(
+		(total, item) =>
+			total +
+			(finite(item.forcedStyleAndLayoutDuration)
+				? item.forcedStyleAndLayoutDuration
+				: 0),
+		0,
+	);
+	const scriptFunction = safeLabel(
+		script?.sourceFunctionName,
+		safeLabel(script?.invoker, "Unknown script"),
+	);
+	const styleDominates =
+		styleLayoutDuration >= STALL_THRESHOLD_MS &&
+		styleLayoutDuration >= scriptDuration * 0.4;
+	const cause = styleDominates
+		? ("style-layout" as const)
+		: script === undefined
+			? ("unknown" as const)
+			: ("script" as const);
+	const label =
+		cause === "style-layout"
+			? `Forced style/layout in ${scriptFunction}`
+			: cause === "script"
+				? scriptFunction
+				: "Unattributed renderer work";
+	const confidence: PerformanceConfidence =
+		script?.sourceFunctionName || script?.sourceURL
+			? "high"
+			: script?.invoker
+				? "medium"
+				: "low";
+	const startTime = finite(entry.startTime) ? entry.startTime : 0;
+	const renderDuration =
+		finite(entry.renderStart) && entry.renderStart >= startTime
+			? Math.max(0, startTime + entry.duration - entry.renderStart)
+			: undefined;
+	const attribution: StallAttribution = {
+		cause,
+		label,
+		confidence,
+		...(finite(entry.blockingDuration)
+			? { blockingDurationMs: boundedDuration(entry.blockingDuration) }
+			: {}),
+		...(renderDuration === undefined
+			? {}
+			: { renderDurationMs: boundedDuration(renderDuration) }),
+		...(styleLayoutDuration > 0
+			? { styleLayoutDurationMs: boundedDuration(styleLayoutDuration) }
+			: {}),
+		...(script?.invoker
+			? { scriptInvoker: safeLabel(script.invoker, "script") }
+			: {}),
+		...(script?.sourceFunctionName
+			? {
+					scriptFunction: safeLabel(script.sourceFunctionName, "anonymous"),
+				}
+			: {}),
+		...(safeSource(script?.sourceURL) === undefined
+			? {}
+			: { scriptSource: safeSource(script?.sourceURL) }),
+		...(finite(script?.sourceCharPosition)
+			? { scriptPosition: Math.max(0, Math.round(script.sourceCharPosition)) }
+			: {}),
+		...attributionContext(context),
+	};
+	return {
+		id: factories.id?.() ?? makeId("lag_loaf"),
+		capturedAt: factories.now?.() ?? new Date().toISOString(),
+		kind: "long-animation-frame",
+		durationMs: boundedDuration(entry.duration),
+		source: "renderer",
+		name: "renderer.long-animation-frame",
+		attribution,
+	};
+}
+
+export interface ReactCommitInput {
+	readonly id: string;
+	readonly phase: "mount" | "update" | "nested-update";
+	readonly actualDurationMs: number;
+	readonly baseDurationMs: number;
+	readonly context: StallContext;
+	readonly now?: () => string;
+	readonly sampleId?: () => string;
+}
+
+export function createReactCommitLagSample(
+	input: ReactCommitInput,
+): LagSample | null {
+	if (
+		!finite(input.actualDurationMs) ||
+		input.actualDurationMs < STALL_THRESHOLD_MS
+	) {
+		return null;
+	}
+	const label = `${safeLabel(input.id, "React root")} ${input.phase}`;
+	return {
+		id: input.sampleId?.() ?? makeId("lag_react"),
+		capturedAt: input.now?.() ?? new Date().toISOString(),
+		kind: "react-commit",
+		durationMs: boundedDuration(input.actualDurationMs),
+		source: "renderer",
+		name: "renderer.react-commit",
+		attribution: {
+			cause: "react-render",
+			label,
+			confidence: input.id ? "high" : "medium",
+			reactPhase: input.phase,
+			reactBaseDurationMs: boundedDuration(input.baseDurationMs),
+			...attributionContext(input.context),
+		},
+	};
+}
+
+export function createOperationLagSample(input: {
+	readonly name: string;
+	readonly durationMs: number;
+	readonly context: StallContext;
+	readonly now?: () => string;
+	readonly sampleId?: () => string;
+}): LagSample | null {
+	if (!finite(input.durationMs) || input.durationMs < STALL_THRESHOLD_MS) {
+		return null;
+	}
+	const label = /^[a-z0-9._-]{1,100}$/i.test(input.name)
+		? input.name
+		: "RPC operation";
+	return {
+		id: input.sampleId?.() ?? makeId("lag_rpc"),
+		capturedAt: input.now?.() ?? new Date().toISOString(),
+		kind: "rpc",
+		durationMs: boundedDuration(input.durationMs),
+		source: "renderer",
+		name: "renderer.rpc",
+		attribution: {
+			cause: "rpc",
+			label,
+			confidence: "high",
+			...attributionContext(input.context),
+		},
+	};
+}

--- a/apps/renderer/src/lib/stall-context.ts
+++ b/apps/renderer/src/lib/stall-context.ts
@@ -1,0 +1,26 @@
+const CONTEXT_LIMIT = 8;
+const activeOperations = new Map<number, string>();
+let nextOperationId = 0;
+
+export interface StallContext {
+	readonly recentActions: ReadonlyArray<string>;
+	readonly activeWorkloads: ReadonlyArray<string>;
+	readonly relatedOperations: ReadonlyArray<string>;
+}
+
+export const getActiveStallOperations = (): ReadonlyArray<string> =>
+	[...activeOperations.values()].slice(-CONTEXT_LIMIT);
+
+export const beginStallOperation = (label: string): (() => void) => {
+	const id = nextOperationId;
+	nextOperationId += 1;
+	activeOperations.set(
+		id,
+		/^(?:rpc|render|workload):[a-z0-9._-]{1,100}$/i.test(label)
+			? label
+			: "operation",
+	);
+	return () => {
+		activeOperations.delete(id);
+	};
+};

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -12,6 +12,7 @@ import {
 	installRendererDiagnostics,
 	persistFatalRendererDiagnostic,
 	recordDiagnosticEvent,
+	recordReactCommit,
 	summarizeDiagnosticError,
 } from "./lib/diagnostics-recorder.ts";
 import { AppAtomProvider } from "./state/registry.tsx";
@@ -86,6 +87,18 @@ function RootCrashFallback({ error }: { readonly error: Error }) {
 	);
 }
 
+function ApplicationProviders() {
+	return (
+		<AppAtomProvider>
+			<ToastProvider>
+				<BrowserAccessGate>
+					<App />
+				</BrowserAccessGate>
+			</ToastProvider>
+		</AppAtomProvider>
+	);
+}
+
 ReactDOM.createRoot(root).render(
 	<React.StrictMode>
 		<ErrorBoundary
@@ -106,13 +119,18 @@ ReactDOM.createRoot(root).render(
 				});
 			}}
 		>
-			<AppAtomProvider>
-				<ToastProvider>
-					<BrowserAccessGate>
-						<App />
-					</BrowserAccessGate>
-				</ToastProvider>
-			</AppAtomProvider>
+			{import.meta.env.DEV ? (
+				<React.Profiler
+					id="app.root"
+					onRender={(id, phase, actualDuration, baseDuration) => {
+						recordReactCommit(id, phase, actualDuration, baseDuration);
+					}}
+				>
+					<ApplicationProviders />
+				</React.Profiler>
+			) : (
+				<ApplicationProviders />
+			)}
 		</ErrorBoundary>
 	</React.StrictMode>,
 );

--- a/apps/renderer/test/unit/power-runtime-activity.test.ts
+++ b/apps/renderer/test/unit/power-runtime-activity.test.ts
@@ -5,6 +5,7 @@ import {
 	reportPowerBrowserRecordingStarted,
 	reportPowerBrowserRecordingStopped,
 	reportPowerBrowserSession,
+	setPowerActiveAgentCount,
 	setPowerActiveTerminalCount,
 	setPowerIndexing,
 	subscribePowerRuntimeActivity,
@@ -15,6 +16,7 @@ describe("power runtime activity", () => {
 		const listener = vi.fn();
 		const unsubscribe = subscribePowerRuntimeActivity(listener);
 
+		setPowerActiveAgentCount(3);
 		setPowerActiveTerminalCount(2);
 		reportPowerBrowserSession("one", true);
 		reportPowerBrowserSession("two", false);
@@ -22,13 +24,14 @@ describe("power runtime activity", () => {
 		setPowerIndexing(true);
 
 		expect(getPowerRuntimeActivity()).toEqual({
+			activeAgents: 3,
 			activeTerminals: 2,
 			browserSessions: 2,
 			activeBrowserSessions: 1,
 			browserRecordings: 1,
 			indexing: true,
 		});
-		expect(listener).toHaveBeenCalledTimes(5);
+		expect(listener).toHaveBeenCalledTimes(6);
 
 		unsubscribe();
 		reportPowerBrowserSession("one", null);
@@ -36,8 +39,9 @@ describe("power runtime activity", () => {
 		reportPowerBrowserRecordingStopped();
 		setPowerIndexing(false);
 		setPowerActiveTerminalCount(0);
+		setPowerActiveAgentCount(0);
 
-		expect(listener).toHaveBeenCalledTimes(5);
+		expect(listener).toHaveBeenCalledTimes(6);
 	});
 
 	it("never reports negative counts", () => {
@@ -45,6 +49,7 @@ describe("power runtime activity", () => {
 		setPowerActiveTerminalCount(-1);
 
 		expect(getPowerRuntimeActivity()).toEqual({
+			activeAgents: 0,
 			activeTerminals: 0,
 			browserSessions: 0,
 			activeBrowserSessions: 0,

--- a/apps/renderer/test/unit/renderer-lag-monitor.test.ts
+++ b/apps/renderer/test/unit/renderer-lag-monitor.test.ts
@@ -43,4 +43,31 @@ describe("renderer lag classification", () => {
 			name: "renderer.input-latency",
 		});
 	});
+
+	test("retains safe context when detailed browser timing is unavailable", () => {
+		expect(
+			createRendererLagSample(
+				{
+					kind: "long-task",
+					durationMs: 250,
+					visible: true,
+					now: () => "2026-07-31T00:00:00.000Z",
+					id: () => "lag-4",
+				},
+				{
+					recentActions: ["keyboard.navigate"],
+					activeWorkloads: ["agent"],
+					relatedOperations: ["rpc:workspace.list"],
+				},
+			),
+		).toMatchObject({
+			attribution: {
+				cause: "unknown",
+				confidence: "low",
+				recentActions: ["keyboard.navigate"],
+				activeWorkloads: ["agent"],
+				relatedOperations: ["rpc:workspace.list"],
+			},
+		});
+	});
 });

--- a/apps/renderer/test/unit/rpc-stall-instrumentation.test.ts
+++ b/apps/renderer/test/unit/rpc-stall-instrumentation.test.ts
@@ -1,0 +1,49 @@
+import { Effect } from "effect";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+	instrumentRendererRpcClient,
+	setRendererRpcLagReporter,
+} from "../../src/lib/rpc-stall-instrumentation.ts";
+import { getActiveStallOperations } from "../../src/lib/stall-context.ts";
+
+afterEach(() => {
+	setRendererRpcLagReporter(null);
+	vi.restoreAllMocks();
+});
+
+describe("renderer RPC stall instrumentation", () => {
+	test("measures every unary RPC at the shared client boundary", async () => {
+		const reports: Array<{ name: string; durationMs: number }> = [];
+		let now = 100;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		setRendererRpcLagReporter((name, durationMs) => {
+			reports.push({ name, durationMs });
+		});
+		const client = instrumentRendererRpcClient({
+			"workspace.list": () =>
+				Effect.sync(() => {
+					expect(getActiveStallOperations()).toContain("rpc:workspace.list");
+					now = 340;
+					return ["workspace"];
+				}),
+		});
+
+		expect(await Effect.runPromise(client["workspace.list"]())).toEqual([
+			"workspace",
+		]);
+		expect(reports).toEqual([{ name: "workspace.list", durationMs: 240 }]);
+		expect(getActiveStallOperations()).toEqual([]);
+	});
+
+	test("does not treat stream-like or invalid client properties as unary RPCs", () => {
+		const streamLike = { _tag: "Stream" };
+		const client = instrumentRendererRpcClient({
+			"session.stream": () => streamLike,
+			"unsafe?prompt=private": () => Effect.void,
+		});
+
+		expect(client["session.stream"]()).toBe(streamLike);
+		expect(client["unsafe?prompt=private"]()).toBe(Effect.void);
+	});
+});

--- a/apps/renderer/test/unit/stall-attribution.test.ts
+++ b/apps/renderer/test/unit/stall-attribution.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	createFallbackStallAttribution,
+	createLongAnimationFrameSample,
+	createReactCommitLagSample,
+} from "../../src/lib/stall-attribution.ts";
+import {
+	beginStallOperation,
+	getActiveStallOperations,
+} from "../../src/lib/stall-context.ts";
+
+const context = {
+	recentActions: ["pointer.button", "chat.first-react-commit"],
+	activeWorkloads: ["agent", "terminal"],
+	relatedOperations: ["rpc:messages.queue.add"],
+};
+
+describe("stall attribution", () => {
+	test("attributes a long frame to its slowest sanitized script entry point", () => {
+		const sample = createLongAnimationFrameSample(
+			{
+				duration: 640,
+				blockingDuration: 520,
+				renderStart: 590,
+				styleAndLayoutStart: 610,
+				scripts: [
+					{
+						duration: 480,
+						forcedStyleAndLayoutDuration: 12,
+						invoker: "DOMWindow.onclick",
+						invokerType: "event-listener",
+						sourceFunctionName: "handleSend",
+						sourceURL:
+							"https://app.invalid/assets/chat-view.js?token=secret#fragment",
+						sourceCharPosition: 4312,
+					},
+				],
+			},
+			context,
+			{
+				now: () => "2026-07-31T00:00:00.000Z",
+				id: () => "lag-loaf-1",
+			},
+		);
+
+		expect(sample).toEqual(
+			expect.objectContaining({
+				id: "lag-loaf-1",
+				kind: "long-animation-frame",
+				durationMs: 640,
+				attribution: expect.objectContaining({
+					cause: "script",
+					label: "handleSend",
+					confidence: "high",
+					blockingDurationMs: 520,
+					scriptSource: "chat-view.js",
+					scriptFunction: "handleSend",
+					recentActions: context.recentActions,
+					activeWorkloads: context.activeWorkloads,
+					relatedOperations: context.relatedOperations,
+				}),
+			}),
+		);
+		expect(sample?.attribution?.scriptSource).not.toContain("secret");
+	});
+
+	test("drops inline script URLs instead of persisting their contents", () => {
+		const sample = createLongAnimationFrameSample(
+			{
+				duration: 180,
+				scripts: [
+					{
+						duration: 160,
+						sourceFunctionName: "inlineWork",
+						sourceURL: "data:text/javascript,secretPrompt%3Dhello",
+					},
+				],
+			},
+			{ recentActions: [], activeWorkloads: [], relatedOperations: [] },
+		);
+
+		expect(sample?.attribution?.scriptSource).toBeUndefined();
+	});
+
+	test("prefers forced style and layout when it dominates the frame", () => {
+		const sample = createLongAnimationFrameSample(
+			{
+				duration: 420,
+				blockingDuration: 300,
+				renderStart: 180,
+				styleAndLayoutStart: 190,
+				scripts: [
+					{
+						duration: 260,
+						forcedStyleAndLayoutDuration: 210,
+						invoker: "ResizeObserver",
+						invokerType: "user-callback",
+						sourceFunctionName: "measurePane",
+						sourceURL: "file:///Users/private/project/assets/layout.js",
+						sourceCharPosition: 100,
+					},
+				],
+			},
+			{ recentActions: [], activeWorkloads: [], relatedOperations: [] },
+			{
+				now: () => "2026-07-31T00:00:00.000Z",
+				id: () => "lag-loaf-2",
+			},
+		);
+
+		expect(sample?.attribution).toEqual(
+			expect.objectContaining({
+				cause: "style-layout",
+				label: "Forced style/layout in measurePane",
+				confidence: "high",
+				styleLayoutDurationMs: 210,
+				scriptSource: "layout.js",
+			}),
+		);
+	});
+
+	test("records only slow React commits with component-safe labels", () => {
+		expect(
+			createReactCommitLagSample({
+				id: "chat.timeline#private",
+				phase: "update",
+				actualDurationMs: 99,
+				baseDurationMs: 500,
+				context,
+			}),
+		).toBeNull();
+
+		expect(
+			createReactCommitLagSample({
+				id: "chat.timeline#private",
+				phase: "update",
+				actualDurationMs: 180,
+				baseDurationMs: 500,
+				context,
+				now: () => "2026-07-31T00:00:00.000Z",
+				sampleId: () => "lag-react-1",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				id: "lag-react-1",
+				kind: "react-commit",
+				attribution: expect.objectContaining({
+					cause: "react-render",
+					label: "chat.timeline.private update",
+					confidence: "high",
+					reactPhase: "update",
+					reactBaseDurationMs: 500,
+				}),
+			}),
+		);
+	});
+
+	test("tracks only currently active sanitized operations", () => {
+		const finishValid = beginStallOperation("rpc:chat.send");
+		const finishInvalid = beginStallOperation("rpc:chat.send?prompt=private");
+		expect(getActiveStallOperations()).toEqual(["rpc:chat.send", "operation"]);
+		finishValid();
+		finishInvalid();
+		expect(getActiveStallOperations()).toEqual([]);
+	});
+
+	test("keeps context when detailed browser attribution is unavailable", () => {
+		expect(
+			createFallbackStallAttribution("long-task", undefined, {
+				recentActions: ["keyboard.navigate"],
+				activeWorkloads: ["agent"],
+				relatedOperations: ["rpc:session.list"],
+			}),
+		).toMatchObject({
+			cause: "unknown",
+			label: "Browser timing unavailable",
+			confidence: "low",
+			recentActions: ["keyboard.navigate"],
+			activeWorkloads: ["agent"],
+			relatedOperations: ["rpc:session.list"],
+		});
+	});
+});

--- a/packages/contracts/src/power.ts
+++ b/packages/contracts/src/power.ts
@@ -114,6 +114,7 @@ export class PowerSnapshot extends Schema.Class<PowerSnapshot>("PowerSnapshot")(
 
 export const LagKind = Schema.Literals([
 	"long-task",
+	"long-animation-frame",
 	"animation-stall",
 	"input-latency",
 	"react-commit",
@@ -123,6 +124,49 @@ export const LagKind = Schema.Literals([
 ]);
 export type LagKind = typeof LagKind.Type;
 
+export const StallCause = Schema.Literals([
+	"script",
+	"style-layout",
+	"react-render",
+	"input-handler",
+	"rpc",
+	"event-loop",
+	"gc",
+	"workload",
+	"unknown",
+]);
+export type StallCause = typeof StallCause.Type;
+
+const SanitizedStallText = Schema.String.check(
+	Schema.isMaxLength(120),
+	Schema.isPattern(/^[a-zA-Z0-9_.$: -]*$/),
+);
+const SanitizedStallContext = Schema.Array(SanitizedStallText).check(
+	Schema.isMaxLength(8),
+);
+
+export class StallAttribution extends Schema.Class<StallAttribution>(
+	"StallAttribution",
+)({
+	cause: StallCause,
+	label: SanitizedStallText,
+	confidence: PerformanceConfidence,
+	blockingDurationMs: Schema.optional(Schema.Number),
+	renderDurationMs: Schema.optional(Schema.Number),
+	styleLayoutDurationMs: Schema.optional(Schema.Number),
+	scriptInvoker: Schema.optional(SanitizedStallText),
+	scriptFunction: Schema.optional(SanitizedStallText),
+	scriptSource: Schema.optional(SanitizedStallText),
+	scriptPosition: Schema.optional(Schema.Number),
+	reactPhase: Schema.optional(
+		Schema.Literals(["mount", "update", "nested-update"]),
+	),
+	reactBaseDurationMs: Schema.optional(Schema.Number),
+	recentActions: SanitizedStallContext,
+	activeWorkloads: SanitizedStallContext,
+	relatedOperations: SanitizedStallContext,
+}) {}
+
 export class LagSample extends Schema.Class<LagSample>("LagSample")({
 	id: Schema.String,
 	capturedAt: Schema.String,
@@ -131,6 +175,7 @@ export class LagSample extends Schema.Class<LagSample>("LagSample")({
 	source: Schema.Literals(["renderer", "main", "server"]),
 	name: Schema.optional(Schema.String),
 	sessionId: Schema.optional(Schema.NullOr(Schema.String)),
+	attribution: Schema.optional(StallAttribution),
 }) {}
 
 export class WorkloadInterval extends Schema.Class<WorkloadInterval>(

--- a/packages/contracts/test/unit/power.test.ts
+++ b/packages/contracts/test/unit/power.test.ts
@@ -1,0 +1,50 @@
+import { Schema } from "effect";
+import { describe, expect, test } from "vitest";
+
+import { LagSample } from "../../src/power.ts";
+
+const attributedLag = {
+	id: "lag-1",
+	capturedAt: "2026-07-31T00:00:00.000Z",
+	kind: "long-animation-frame",
+	durationMs: 200,
+	source: "renderer",
+	attribution: {
+		cause: "script",
+		label: "handleSend",
+		confidence: "high",
+		scriptSource: "chat-view.js",
+		recentActions: ["pointer.button"],
+		activeWorkloads: ["agent"],
+		relatedOperations: ["rpc:chat.create"],
+	},
+} as const;
+
+describe("LagSample", () => {
+	test("accepts bounded sanitized stall attribution", () => {
+		expect(Schema.decodeUnknownSync(LagSample)(attributedLag)).toMatchObject(
+			attributedLag,
+		);
+	});
+
+	test("rejects oversized or unsafe renderer attribution at the IPC boundary", () => {
+		expect(() =>
+			Schema.decodeUnknownSync(LagSample)({
+				...attributedLag,
+				attribution: {
+					...attributedLag.attribution,
+					label: "x".repeat(121),
+				},
+			}),
+		).toThrow();
+		expect(() =>
+			Schema.decodeUnknownSync(LagSample)({
+				...attributedLag,
+				attribution: {
+					...attributedLag.attribution,
+					recentActions: ["pointer.button", "prompt=private/value"],
+				},
+			}),
+		).toThrow();
+	});
+});

--- a/tests/system/test/desktop/electron-power.desktop.test.ts
+++ b/tests/system/test/desktop/electron-power.desktop.test.ts
@@ -119,6 +119,12 @@ describe("Electron performance measurement bridge", () => {
 							stopRecording: () => Promise<
 								import("@zuse/contracts").PowerMonitorState
 							>;
+							reportLagSamples: (
+								samples: ReadonlyArray<import("@zuse/contracts").LagSample>,
+							) => void;
+							getHistory: (
+								since: number,
+							) => Promise<import("@zuse/contracts").PerformanceHistory>;
 							exportLatestRecording: (
 								interactions: ReadonlyArray<
 									import("@zuse/contracts").PowerInteractionMeasurement
@@ -130,6 +136,65 @@ describe("Electron performance measurement bridge", () => {
 				const power = target.zuse?.power;
 				if (power === undefined) throw new Error("power bridge missing");
 				const initial = await power.getState();
+				const supportsLongAnimationFrames =
+					PerformanceObserver.supportedEntryTypes.includes(
+						"long-animation-frame",
+					);
+				await new Promise<void>((resolve) => {
+					requestAnimationFrame(() => {
+						const startedAt = performance.now();
+						while (performance.now() - startedAt < 180) {
+							// Deliberately block one frame to exercise the real observer.
+						}
+						resolve();
+					});
+				});
+				let observedLongAnimationFrame = false;
+				const observedFrameDeadline = Date.now() + 5_000;
+				while (
+					!observedLongAnimationFrame &&
+					Date.now() < observedFrameDeadline
+				) {
+					const history = await power.getHistory(Date.now() - 60_000);
+					observedLongAnimationFrame = history.lagSamples.some(
+						(sample) => sample.kind === "long-animation-frame",
+					);
+					if (!observedLongAnimationFrame) {
+						await new Promise((resolve) => setTimeout(resolve, 25));
+					}
+				}
+				power.reportLagSamples([
+					{
+						id: "lag-attributed-system",
+						capturedAt: new Date().toISOString(),
+						kind: "long-animation-frame",
+						durationMs: 640,
+						source: "renderer",
+						name: "renderer.long-animation-frame",
+						attribution: {
+							cause: "script",
+							label: "handleSend",
+							confidence: "high",
+							blockingDurationMs: 520,
+							scriptFunction: "handleSend",
+							scriptSource: "chat-view.js",
+							recentActions: ["pointer.button"],
+							activeWorkloads: ["agent"],
+							relatedOperations: ["rpc:messages.queue.add"],
+						},
+					},
+				]);
+				let attributedLag: import("@zuse/contracts").LagSample | undefined;
+				const lagDeadline = Date.now() + 5_000;
+				while (attributedLag === undefined && Date.now() < lagDeadline) {
+					const history = await power.getHistory(Date.now() - 60_000);
+					attributedLag = history.lagSamples.find(
+						(sample) => sample.id === "lag-attributed-system",
+					);
+					if (attributedLag === undefined) {
+						await new Promise((resolve) => setTimeout(resolve, 25));
+					}
+				}
 				let firstEvents = 0;
 				let secondEvents = 0;
 				const unsubscribeFirst = power.onState(() => {
@@ -151,9 +216,13 @@ describe("Electron performance measurement bridge", () => {
 				await new Promise((resolve) => setTimeout(resolve, 25));
 				return {
 					hasInitialSnapshot: initial.latestSnapshot !== null,
+					supportsLongAnimationFrames,
+					observedLongAnimationFrame,
 					active: active.activeRecording !== null,
 					completed: completed.latestRecording !== null,
 					sampleCount: completed.latestRecording?.summary.sampleCount ?? 0,
+					attributedCause: attributedLag?.attribution?.cause ?? null,
+					attributedSource: attributedLag?.attribution?.scriptSource ?? null,
 					firstEventsAfterUnsubscribe: firstEvents - firstEventsAtUnsubscribe,
 					secondEventsAfterFirstUnsubscribe,
 					secondEventsAfterUnsubscribe:
@@ -163,13 +232,35 @@ describe("Electron performance measurement bridge", () => {
 
 			expect(result).toMatchObject({
 				hasInitialSnapshot: true,
+				supportsLongAnimationFrames: true,
+				observedLongAnimationFrame: true,
 				active: true,
 				completed: true,
 				sampleCount: 1,
+				attributedCause: "script",
+				attributedSource: "chat-view.js",
 				firstEventsAfterUnsubscribe: 0,
 				secondEventsAfterUnsubscribe: 0,
 			});
 			expect(result.secondEventsAfterFirstUnsubscribe).toBeGreaterThan(0);
+
+			await electron.page.keyboard.press("Meta+,");
+			await electron.page
+				.getByRole("button", { name: "Diagnostics", exact: true })
+				.click();
+			await electron.page
+				.getByRole("button", { name: "Performance", exact: true })
+				.click();
+			await electron.page
+				.getByText("Stall cause timeline", { exact: true })
+				.waitFor({ state: "visible" });
+			await electron.page
+				.getByRole("button", { name: /handleSend/ })
+				.first()
+				.click();
+			await electron.page
+				.getByText("chat-view.js", { exact: true })
+				.waitFor({ state: "visible" });
 
 			const recordingDeadline = Date.now() + 5_000;
 			while (

--- a/tests/system/test/system/performance-diagnostics.system.test.ts
+++ b/tests/system/test/system/performance-diagnostics.system.test.ts
@@ -11,14 +11,36 @@ describe("performance diagnostics artifacts", () => {
 			mkdirSync(logs, { recursive: true });
 			writeFileSync(
 				scope.path("user-data", "logs", "diagnostics.host-resources.ndjson"),
-				`${JSON.stringify({
-					kind: "sample",
-					sample: {
-						capturedAt: "2026-07-31T00:00:00.000Z",
-						totalCpuPercent: 12.5,
-						totalMemoryBytes: 1024,
-					},
-				})}\n`,
+				[
+					JSON.stringify({
+						kind: "sample",
+						sample: {
+							capturedAt: "2026-07-31T00:00:00.000Z",
+							totalCpuPercent: 12.5,
+							totalMemoryBytes: 1024,
+						},
+					}),
+					JSON.stringify({
+						kind: "lag",
+						sample: {
+							id: "lag-export",
+							capturedAt: "2026-07-31T00:01:00.000Z",
+							kind: "long-animation-frame",
+							durationMs: 420,
+							source: "renderer",
+							attribution: {
+								cause: "script",
+								label: "handleSend",
+								confidence: "high",
+								scriptSource: "chat-view.js",
+								recentActions: ["pointer.button"],
+								activeWorkloads: ["agent"],
+								relatedOperations: [],
+							},
+						},
+					}),
+					"",
+				].join("\n"),
 			);
 			const server = await scope.server();
 			const rpc = await scope.rpc(server.endpoint);
@@ -32,6 +54,10 @@ describe("performance diagnostics artifacts", () => {
 			expect(exported.included).toContain("performance-history");
 			expect(zip.includes(Buffer.from("performance-history.json"))).toBe(true);
 			expect(zip.includes(Buffer.from('"totalCpuPercent": 12.5'))).toBe(true);
+			expect(zip.includes(Buffer.from('"cause": "script"'))).toBe(true);
+			expect(zip.includes(Buffer.from('"scriptSource": "chat-view.js"'))).toBe(
+				true,
+			);
 			await rpc.dispose();
 		});
 	}, 30_000);


### PR DESCRIPTION
## What changed

- captures Long Animation Frame details and identifies the slowest sanitized script entry point or dominant forced style/layout work
- preserves low-confidence action, workload, and operation context on platforms that only expose fallback timing APIs
- measures slow unary renderer RPCs once at the shared client boundary instead of relying on selected call sites
- correlates active agents, terminals, browser activity, recording, and indexing with retained lag samples
- adds a compact master-detail stall timeline to Diagnostics → Performance with cause, confidence, duration breakdown, function/source position, recent actions, workloads, and copyable details
- persists and exports the typed attribution through the existing local performance history and support-bundle paths

## Reliability and privacy

- rejects inline and non-file/network script schemes rather than persisting their contents
- stores only sanitized script basenames and bounded allowlisted-character labels; URL paths, queries, fragments, input values, terminal output, prompts, and transcripts are not retained
- validates attribution lengths, character sets, and context counts again at the desktop IPC decode boundary
- avoids duplicate frame samples when Long Animation Frame support exists and removes duplicate slow-RPC diagnostic events
- keeps React commit timing development-only because the standard production React build disables profiler callbacks; packaged builds rely on production Long Animation Frame attribution rather than silently claiming React-specific timing

## Validation

- renderer unit suite: 58 files / 261 tests passed
- desktop unit suite: 14 files / 53 tests passed
- contracts, renderer, desktop, server, and system type checks passed
- focused contract boundary tests passed
- Electron power/stall UI smoke test and support-bundle system test passed
- applicable Biome checks and `git diff --check` passed
- desktop production build passed (existing Effect CommonJS `import.meta` warning remains)
- renderer production compilation passed; the existing initial-JS budget gate still fails at 628.2 KiB gzip versus 500 KiB (merged baseline was about 627.5 KiB)

## Existing baseline failures

The complete contracts unit suite still has four unrelated round-trip failures because current default provenance fields are re-encoded into older fixtures. The new power contract tests pass.