### PR TITLE
Allow Forks from Any Message

### DIFF
--- a/apps/renderer/src/components/archived-chat-timeline.tsx
+++ b/apps/renderer/src/components/archived-chat-timeline.tsx
@@ -3,8 +3,8 @@ import type { FolderId, Message, SessionId } from "@zuse/contracts";
 import { useCallback, useMemo } from "react";
 
 import {
-  type ChatTimelineRow,
-  deriveChatTimelineRows,
+	type ChatTimelineRow,
+	deriveChatTimelineRows,
 } from "../lib/chat-timeline-rows.ts";
 import { ChatLookupsProvider, deriveChatLookups } from "./chat-lookups.tsx";
 import { FileChipProvider } from "./file-chip.tsx";
@@ -13,93 +13,104 @@ import { SubagentRow } from "./subagent-row.tsx";
 import { TurnSummary } from "./turn-summary.tsx";
 
 export function ArchivedChatTimeline({
-  projectId,
-  sessionId,
-  messages,
+	projectId,
+	sessionId,
+	messages,
 }: {
-  readonly projectId: FolderId;
-  readonly sessionId: SessionId;
-  readonly messages: ReadonlyArray<Message>;
+	readonly projectId: FolderId;
+	readonly sessionId: SessionId;
+	readonly messages: ReadonlyArray<Message>;
 }) {
-  const rows = useMemo(
-    () =>
-      deriveChatTimelineRows({
-        messages,
-        inFlight: false,
-        awaitingPlanApproval: false,
-      }),
-    [messages],
-  );
-  const lookups = useMemo(() => deriveChatLookups(messages), [messages]);
-  const renderRow = useCallback(
-    ({ item }: { item: ChatTimelineRow }) => (
-      <ArchivedTimelineRow row={item} sessionId={sessionId} />
-    ),
-    [sessionId],
-  );
+	const rows = useMemo(
+		() =>
+			deriveChatTimelineRows({
+				messages,
+				inFlight: false,
+				awaitingPlanApproval: false,
+			}),
+		[messages],
+	);
+	const lookups = useMemo(() => deriveChatLookups(messages), [messages]);
+	const renderRow = useCallback(
+		({ item }: { item: ChatTimelineRow }) => (
+			<ArchivedTimelineRow
+				row={item}
+				sessionId={sessionId}
+				projectId={projectId}
+			/>
+		),
+		[projectId, sessionId],
+	);
 
-  return (
-    <FileChipProvider folderId={projectId} worktreeId={null}>
-      <ChatLookupsProvider value={lookups}>
-        <LegendList<ChatTimelineRow>
-          key={sessionId}
-          data={rows}
-          keyExtractor={(row) => row.id}
-          getItemType={(row) => row.kind}
-          renderItem={renderRow}
-          estimatedItemSize={96}
-          initialScrollAtEnd
-          maintainVisibleContentPosition={{ data: true, size: false }}
-          className="h-full min-h-0 flex-1 overflow-x-hidden outline-none"
-          aria-label="Archived chat transcript"
-          tabIndex={0}
-          ListHeaderComponent={<div className="h-2" />}
-          ListFooterComponent={<div className="h-2" />}
-        />
-      </ChatLookupsProvider>
-    </FileChipProvider>
-  );
+	return (
+		<FileChipProvider folderId={projectId} worktreeId={null}>
+			<ChatLookupsProvider value={lookups}>
+				<LegendList<ChatTimelineRow>
+					key={sessionId}
+					data={rows}
+					keyExtractor={(row) => row.id}
+					getItemType={(row) => row.kind}
+					renderItem={renderRow}
+					estimatedItemSize={96}
+					initialScrollAtEnd
+					maintainVisibleContentPosition={{ data: true, size: false }}
+					className="h-full min-h-0 flex-1 overflow-x-hidden outline-none"
+					aria-label="Archived chat transcript"
+					tabIndex={0}
+					ListHeaderComponent={<div className="h-2" />}
+					ListFooterComponent={<div className="h-2" />}
+				/>
+			</ChatLookupsProvider>
+		</FileChipProvider>
+	);
 }
 
 function ArchivedTimelineRow({
-  row,
-  sessionId,
+	row,
+	sessionId,
+	projectId,
 }: {
-  readonly row: ChatTimelineRow;
-  readonly sessionId: SessionId;
+	readonly row: ChatTimelineRow;
+	readonly sessionId: SessionId;
+	readonly projectId: FolderId;
 }) {
-  switch (row.kind) {
-    case "message":
-      return (
-        <MessageRow
-          message={row.message}
-          sessionId={sessionId}
-          readOnly
-          showAssistantCommands={row.showAssistantCommands}
-        />
-      );
-    case "subagent":
-      return (
-        <SubagentRow
-          agentToolUseId={row.parentItemId}
-          agentName={row.agentName}
-          prompt={row.prompt}
-          modelRequested={row.modelRequested}
-          childSessionId={row.childSessionId}
-          presentation={row.presentation}
-          children={row.children}
-          summary={row.summary}
-          readOnly
-        />
-      );
-    case "turn-summary":
-      return (
-        <TurnSummary
-          body={row.body}
-          showAssistantCommands={row.showAssistantCommands}
-        />
-      );
-    case "working":
-      return null;
-  }
+	switch (row.kind) {
+		case "message":
+			return (
+				<MessageRow
+					message={row.message}
+					sessionId={sessionId}
+					readOnly
+					forkDestination="chat"
+					sourceProjectId={projectId}
+					showAssistantCommands={row.showAssistantCommands}
+				/>
+			);
+		case "subagent":
+			return (
+				<SubagentRow
+					agentToolUseId={row.parentItemId}
+					agentName={row.agentName}
+					prompt={row.prompt}
+					modelRequested={row.modelRequested}
+					childSessionId={row.childSessionId}
+					presentation={row.presentation}
+					children={row.children}
+					summary={row.summary}
+					readOnly
+				/>
+			);
+		case "turn-summary":
+			return (
+				<TurnSummary
+					body={row.body}
+					sessionId={sessionId}
+					forkDestination="chat"
+					sourceProjectId={projectId}
+					showAssistantCommands={row.showAssistantCommands}
+				/>
+			);
+		case "working":
+			return null;
+	}
 }

--- a/apps/renderer/src/components/assistant-message-actions.tsx
+++ b/apps/renderer/src/components/assistant-message-actions.tsx
@@ -1,4 +1,9 @@
-import type { MessageId, SessionId } from "@zuse/contracts";
+import type {
+	FolderId,
+	ForkDestination,
+	MessageId,
+	SessionId,
+} from "@zuse/contracts";
 
 import { cn } from "~/lib/utils";
 import { CopyButton } from "./copy-button.tsx";
@@ -24,6 +29,8 @@ export function AssistantMessageActions({
 	sessionId,
 	messageId,
 	showMessageCommands = false,
+	forkDestination,
+	sourceProjectId,
 	className,
 }: {
 	readonly text: string;
@@ -32,24 +39,65 @@ export function AssistantMessageActions({
 	readonly sessionId?: SessionId;
 	readonly messageId?: MessageId;
 	readonly showMessageCommands?: boolean;
+	readonly forkDestination?: ForkDestination;
+	readonly sourceProjectId?: FolderId;
 	readonly className?: string;
 }) {
 	if (!showMessageCommands) return null;
 
 	return (
-		<div
+		<MessageActions
+			text={text}
+			createdAt={createdAt}
+			elapsed={elapsed}
+			sessionId={sessionId}
+			messageId={messageId}
+			forkDestination={forkDestination}
+			sourceProjectId={sourceProjectId}
 			className={cn(
-				"flex items-center gap-1 opacity-0 transition-opacity duration-150 ease-out group-hover/assistant:opacity-100 group-focus-within/assistant:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100",
+				"opacity-0 transition-opacity duration-150 ease-out group-hover/assistant:opacity-100 group-focus-within/assistant:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100",
 				className,
 			)}
-		>
+		/>
+	);
+}
+
+export function MessageActions({
+	text,
+	createdAt,
+	elapsed,
+	sessionId,
+	messageId,
+	forkLabel = "response",
+	forkDestination,
+	sourceProjectId,
+	className,
+}: {
+	readonly text: string;
+	readonly createdAt?: Date;
+	readonly elapsed?: string;
+	readonly sessionId?: SessionId;
+	readonly messageId?: MessageId;
+	readonly forkLabel?: "message" | "response";
+	readonly forkDestination?: ForkDestination;
+	readonly sourceProjectId?: FolderId;
+	readonly className?: string;
+}) {
+	return (
+		<div className={cn("flex items-center gap-1", className)}>
 			<CopyButton
 				text={text}
 				label="Copy message"
 				className="active:scale-[0.97] [@media(pointer:coarse)]:size-11"
 			/>
 			{sessionId !== undefined && messageId !== undefined ? (
-				<ForkButton sourceSessionId={sessionId} fromMessageId={messageId} />
+				<ForkButton
+					sourceSessionId={sessionId}
+					fromMessageId={messageId}
+					label={forkLabel}
+					fixedDestination={forkDestination}
+					sourceProjectId={sourceProjectId}
+				/>
 			) : null}
 			{createdAt !== undefined ? (
 				<Tooltip>

--- a/apps/renderer/src/components/fork-menu.tsx
+++ b/apps/renderer/src/components/fork-menu.tsx
@@ -1,7 +1,13 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Loading02Icon } from "@hugeicons-pro/core-solid-rounded";
 import { GitBranchIcon } from "@hugeicons-pro/core-stroke-rounded";
-import type { MessageId, SessionId, Worktree } from "@zuse/contracts";
+import type {
+	FolderId,
+	ForkDestination,
+	MessageId,
+	SessionId,
+	Worktree,
+} from "@zuse/contracts";
 import { useState } from "react";
 
 import { getSessionById, useSessionsStore } from "../store/sessions.ts";
@@ -54,22 +60,32 @@ function ForkSplitIcon({ className }: { readonly className?: string }) {
 export function ForkButton({
 	sourceSessionId,
 	fromMessageId,
+	label = "response",
+	fixedDestination,
+	sourceProjectId,
 }: {
 	readonly sourceSessionId: SessionId;
 	readonly fromMessageId: MessageId;
+	readonly label?: "message" | "response";
+	readonly fixedDestination?: ForkDestination;
+	readonly sourceProjectId?: FolderId;
 }) {
 	const [forking, setForking] = useState(false);
 	const fork = useSessionsStore((state) => state.fork);
 
-	const run = async (destination: "tab" | "chat") => {
+	const run = async (destination: ForkDestination) => {
 		if (forking) return;
 		setForking(true);
 
 		let createdWorktree: Worktree | null = null;
+		let projectId = sourceProjectId ?? null;
 		try {
 			if (destination === "chat") {
-				const source = getSessionById(sourceSessionId);
-				if (source === null) {
+				if (projectId === null) {
+					const source = getSessionById(sourceSessionId);
+					projectId = source?.projectId ?? null;
+				}
+				if (projectId === null) {
 					toastManager.add({
 						title: "Fork failed",
 						description: "The source session is no longer available.",
@@ -77,9 +93,7 @@ export function ForkButton({
 					});
 					return;
 				}
-				createdWorktree = await useWorktreesStore
-					.getState()
-					.create(source.projectId);
+				createdWorktree = await useWorktreesStore.getState().create(projectId);
 				if (createdWorktree === null) {
 					toastManager.add({
 						title: "Worktree creation failed",
@@ -99,13 +113,10 @@ export function ForkButton({
 				worktreeId: createdWorktree?.id,
 			});
 			if (result === null) {
-				if (createdWorktree !== null) {
-					const source = getSessionById(sourceSessionId);
-					if (source !== null) {
-						await useWorktreesStore
-							.getState()
-							.remove(source.projectId, createdWorktree.id);
-					}
+				if (createdWorktree !== null && projectId !== null) {
+					await useWorktreesStore
+						.getState()
+						.remove(projectId, createdWorktree.id);
 				}
 				toastManager.add({
 					title: "Fork failed",
@@ -122,7 +133,7 @@ export function ForkButton({
 				description:
 					result.forkMode === "resume"
 						? "The new branch continues with full agent memory."
-						: "The conversation through this response was copied into the new branch.",
+						: `The conversation through this ${label} was copied into the new branch.`,
 				type: "success",
 			});
 		} finally {
@@ -137,7 +148,7 @@ export function ForkButton({
 					render={
 						<MenuTrigger
 							disabled={forking}
-							aria-label="Fork from this response"
+							aria-label={`Fork from this ${label}`}
 							className="inline-grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground/70 outline-none hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.97] data-[popup-open]:bg-muted/50 data-[popup-open]:text-foreground [@media(pointer:coarse)]:size-11"
 						>
 							{forking ? (
@@ -152,43 +163,47 @@ export function ForkButton({
 						</MenuTrigger>
 					}
 				/>
-				<TooltipPopup>Fork from this response</TooltipPopup>
+				<TooltipPopup>Fork from this {label}</TooltipPopup>
 			</Tooltip>
 			<MenuPopup align="start" className="min-w-52 bg-glass border-glass">
-				<Tooltip>
-					<TooltipTrigger
-						render={
-							<MenuItem
-								onClick={() => void run("tab")}
-								className="gap-2.5 px-2 py-1.5"
-							>
-								<ForkSplitIcon className="size-4" />
-								<span>Fork in this chat</span>
-							</MenuItem>
-						}
-					/>
-					<TooltipPopup side="right" align="start" className="max-w-64">
-						Open a new session tab that shares this chat and its current
-						worktree.
-					</TooltipPopup>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger
-						render={
-							<MenuItem
-								onClick={() => void run("chat")}
-								className="gap-2.5 px-2 py-1.5"
-							>
-								<HugeiconsIcon icon={GitBranchIcon} className="size-4" />
-								<span>Fork into a new worktree</span>
-							</MenuItem>
-						}
-					/>
-					<TooltipPopup side="right" align="start" className="max-w-64">
-						Create a separate chat in an isolated Git worktree for parallel
-						work.
-					</TooltipPopup>
-				</Tooltip>
+				{fixedDestination !== "chat" ? (
+					<Tooltip>
+						<TooltipTrigger
+							render={
+								<MenuItem
+									onClick={() => void run("tab")}
+									className="gap-2.5 px-2 py-1.5"
+								>
+									<ForkSplitIcon className="size-4" />
+									<span>Fork in this chat</span>
+								</MenuItem>
+							}
+						/>
+						<TooltipPopup side="right" align="start" className="max-w-64">
+							Open a new session tab that shares this chat and its current
+							worktree.
+						</TooltipPopup>
+					</Tooltip>
+				) : null}
+				{fixedDestination !== "tab" ? (
+					<Tooltip>
+						<TooltipTrigger
+							render={
+								<MenuItem
+									onClick={() => void run("chat")}
+									className="gap-2.5 px-2 py-1.5"
+								>
+									<HugeiconsIcon icon={GitBranchIcon} className="size-4" />
+									<span>Fork into a new worktree</span>
+								</MenuItem>
+							}
+						/>
+						<TooltipPopup side="right" align="start" className="max-w-64">
+							Create a separate chat in an isolated Git worktree for parallel
+							work.
+						</TooltipPopup>
+					</Tooltip>
+				) : null}
 			</MenuPopup>
 		</Menu>
 	);

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -17,6 +17,8 @@ import type {
 	CodeAnnotation,
 	ComposerAnnotation,
 	FileRef,
+	FolderId,
+	ForkDestination,
 	Message,
 	MessageOrigin,
 	ProviderId,
@@ -56,9 +58,11 @@ import { useSessionRuntimeStore } from "~/store/session-runtime";
 import { useSessionsStore } from "~/store/sessions";
 import { useUiStore } from "~/store/ui";
 import { useRevealAnnotation } from "./annotation/annotation-navigation.ts";
-import { AssistantMessageActions } from "./assistant-message-actions.tsx";
+import {
+	AssistantMessageActions,
+	MessageActions,
+} from "./assistant-message-actions.tsx";
 import { useChatLookups } from "./chat-lookups.tsx";
-import { CopyButton } from "./copy-button.tsx";
 import { AnnotationFileChip, FileChip } from "./file-chip.tsx";
 import { ProviderIcon } from "./provider-icons.tsx";
 
@@ -160,11 +164,15 @@ function MessageRowImpl({
 	sessionId,
 	readOnly = false,
 	showAssistantCommands = false,
+	forkDestination,
+	sourceProjectId,
 }: {
 	message: Message;
 	sessionId?: SessionId;
 	readOnly?: boolean;
 	showAssistantCommands?: boolean;
+	forkDestination?: ForkDestination;
+	sourceProjectId?: FolderId;
 }) {
 	switch (message.content._tag) {
 		case "user":
@@ -173,6 +181,10 @@ function MessageRowImpl({
 					text={message.content.text}
 					origin={message.content.origin}
 					goal={message.content.goal}
+					messageId={message.id}
+					sessionId={sessionId}
+					forkDestination={forkDestination}
+					sourceProjectId={sourceProjectId}
 				/>
 			);
 		case "user_rich":
@@ -185,6 +197,10 @@ function MessageRowImpl({
 					annotations={message.content.annotations}
 					origin={message.content.origin}
 					goal={message.content.goal}
+					messageId={message.id}
+					sessionId={sessionId}
+					forkDestination={forkDestination}
+					sourceProjectId={sourceProjectId}
 				/>
 			);
 		case "assistant":
@@ -193,7 +209,9 @@ function MessageRowImpl({
 					text={message.content.text}
 					createdAt={message.createdAt}
 					messageId={message.id}
-					sessionId={readOnly ? undefined : sessionId}
+					sessionId={sessionId}
+					forkDestination={forkDestination}
+					sourceProjectId={sourceProjectId}
 					showMessageCommands={showAssistantCommands}
 				/>
 			);
@@ -453,6 +471,10 @@ function UserBubble({
 	annotations,
 	origin,
 	goal = false,
+	messageId,
+	sessionId,
+	forkDestination,
+	sourceProjectId,
 }: {
 	text: string;
 	attachments?: ReadonlyArray<AttachmentRef>;
@@ -461,6 +483,10 @@ function UserBubble({
 	annotations?: ReadonlyArray<ComposerAnnotation>;
 	origin?: MessageOrigin;
 	goal?: boolean;
+	messageId: Message["id"];
+	sessionId?: SessionId;
+	forkDestination?: ForkDestination;
+	sourceProjectId?: FolderId;
 }) {
 	const hasAnnotations = annotations !== undefined && annotations.length > 0;
 	const revealAnnotation = useRevealAnnotation();
@@ -482,155 +508,161 @@ function UserBubble({
 		name.length > 28 ? `${name.slice(0, 25)}...` : name;
 	return (
 		<div className="group/message flex justify-end px-4 py-2">
-			<div
-				data-chat-user-bubble
-				className="relative max-w-[80%] rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 pr-9 text-sm text-user-bubble-foreground"
-			>
-				<CopyButton
-					text={display || text}
-					label="Copy message"
-					className="absolute right-2 top-1.5 size-5 text-user-bubble-foreground/50 opacity-60 hover:bg-background/10 hover:text-user-bubble-foreground hover:opacity-100 focus-visible:opacity-100"
-				/>
-				{origin !== undefined ? (
-					<button
-						type="button"
-						disabled={!originChatLoaded}
-						onClick={() => useChatsStore.getState().select(origin.chatId)}
-						className="mb-1.5 flex items-center gap-1.5 text-[11px] text-user-bubble-foreground/65 hover:text-user-bubble-foreground disabled:cursor-default"
-						title={
-							originChatLoaded
-								? "Open the sender's chat"
-								: "Sender chat not loaded"
-						}
-					>
-						<ProviderIcon providerId={origin.providerId} className="size-3" />
-						<span>
-							Sent by {PROVIDER_LABEL_FOR_ERROR[origin.providerId]} from another
-							chat
-						</span>
-					</button>
-				) : null}
-				{hasAnnotations ? (
-					<ol className="mb-2 space-y-1">
-						{(annotations ?? []).map((a, i) => (
-							<li key={a.id}>
-								<button
-									type="button"
-									onClick={() => {
-										if (!isBrowserAnnotation(a)) revealAnnotation(a);
-									}}
-									disabled={isBrowserAnnotation(a)}
-									className="flex w-full min-w-0 items-start gap-2 rounded-lg border border-user-bubble-foreground/12 bg-background/10 px-2 py-1.5 text-left text-xs hover:bg-background/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-user-bubble-foreground/30"
-									title={
-										isBrowserAnnotation(a)
-											? "Browser annotation"
-											: "Open annotation"
-									}
-								>
-									<span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-background/20 text-[10px] font-semibold tabular-nums">
-										{i + 1}
-									</span>
-									<span className="grid min-w-0 flex-1 gap-1">
-										{isBrowserAnnotation(a) ? (
-											<span className="min-w-0 truncate font-medium">
-												{browserAnnotationMeta(a)}
-											</span>
-										) : (
-											<AnnotationFileChip annotation={a as CodeAnnotation} />
-										)}
-										<span className="min-w-0 break-words leading-snug">
-											{a.comment}
-										</span>
-									</span>
-								</button>
-							</li>
-						))}
-					</ol>
-				) : null}
-				{hasChips ? (
-					<div className="mb-1.5 flex flex-wrap items-center gap-1.5">
-						{(attachments ?? []).map((a) => {
-							const isImage = a.mimeType.startsWith("image/");
-							const src = attachmentUrl(a.id);
-							const className =
-								"inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]";
-							const inner = (
-								<>
-									{isImage ? (
-										<img
-											src={src}
-											alt=""
-											className="size-4 rounded object-cover"
-										/>
-									) : (
-										<FileIcon
-											name={a.originalName}
-											kind="file"
-											className="inline-flex size-4 shrink-0 items-center justify-center"
-										/>
-									)}
-									<span className="truncate">{truncate(a.originalName)}</span>
-								</>
-							);
-							if (isImage) {
-								return (
+			<div className="flex max-w-[80%] flex-col items-end">
+				<div
+					data-chat-user-bubble
+					className="rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 text-sm text-user-bubble-foreground"
+				>
+					{origin !== undefined ? (
+						<button
+							type="button"
+							disabled={!originChatLoaded}
+							onClick={() => useChatsStore.getState().select(origin.chatId)}
+							className="mb-1.5 flex items-center gap-1.5 text-[11px] text-user-bubble-foreground/65 hover:text-user-bubble-foreground disabled:cursor-default"
+							title={
+								originChatLoaded
+									? "Open the sender's chat"
+									: "Sender chat not loaded"
+							}
+						>
+							<ProviderIcon providerId={origin.providerId} className="size-3" />
+							<span>
+								Sent by {PROVIDER_LABEL_FOR_ERROR[origin.providerId]} from
+								another chat
+							</span>
+						</button>
+					) : null}
+					{hasAnnotations ? (
+						<ol className="mb-2 space-y-1">
+							{(annotations ?? []).map((a, i) => (
+								<li key={a.id}>
 									<button
-										key={a.id}
 										type="button"
-										title={a.originalName}
-										className={className}
-										onClick={() =>
-											useUiStore.getState().openFileInTab({
-												kind: "image",
-												src,
-												name: a.originalName,
-											})
+										onClick={() => {
+											if (!isBrowserAnnotation(a)) revealAnnotation(a);
+										}}
+										disabled={isBrowserAnnotation(a)}
+										className="flex w-full min-w-0 items-start gap-2 rounded-lg border border-user-bubble-foreground/12 bg-background/10 px-2 py-1.5 text-left text-xs hover:bg-background/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-user-bubble-foreground/30"
+										title={
+											isBrowserAnnotation(a)
+												? "Browser annotation"
+												: "Open annotation"
 										}
 									>
-										{inner}
+										<span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-background/20 text-[10px] font-semibold tabular-nums">
+											{i + 1}
+										</span>
+										<span className="grid min-w-0 flex-1 gap-1">
+											{isBrowserAnnotation(a) ? (
+												<span className="min-w-0 truncate font-medium">
+													{browserAnnotationMeta(a)}
+												</span>
+											) : (
+												<AnnotationFileChip annotation={a as CodeAnnotation} />
+											)}
+											<span className="min-w-0 break-words leading-snug">
+												{a.comment}
+											</span>
+										</span>
 									</button>
+								</li>
+							))}
+						</ol>
+					) : null}
+					{hasChips ? (
+						<div className="mb-1.5 flex flex-wrap items-center gap-1.5">
+							{(attachments ?? []).map((a) => {
+								const isImage = a.mimeType.startsWith("image/");
+								const src = attachmentUrl(a.id);
+								const className =
+									"inline-flex items-center gap-1.5 rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 hover:bg-[color-mix(in_oklch,var(--chip-bg)_80%,var(--foreground)_4%)] hover:text-foreground dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]";
+								const inner = (
+									<>
+										{isImage ? (
+											<img
+												src={src}
+												alt=""
+												className="size-4 rounded object-cover"
+											/>
+										) : (
+											<FileIcon
+												name={a.originalName}
+												kind="file"
+												className="inline-flex size-4 shrink-0 items-center justify-center"
+											/>
+										)}
+										<span className="truncate">{truncate(a.originalName)}</span>
+									</>
 								);
-							}
-							return (
-								<a
-									key={a.id}
-									href={src}
-									target="_blank"
-									rel="noreferrer"
-									title={a.originalName}
-									className={className}
+								if (isImage) {
+									return (
+										<button
+											key={a.id}
+											type="button"
+											title={a.originalName}
+											className={className}
+											onClick={() =>
+												useUiStore.getState().openFileInTab({
+													kind: "image",
+													src,
+													name: a.originalName,
+												})
+											}
+										>
+											{inner}
+										</button>
+									);
+								}
+								return (
+									<a
+										key={a.id}
+										href={src}
+										target="_blank"
+										rel="noreferrer"
+										title={a.originalName}
+										className={className}
+									>
+										{inner}
+									</a>
+								);
+							})}
+							{(fileRefs ?? []).map((f) => (
+								<FileChip
+									key={f.relPath}
+									relPath={f.relPath}
+									absPath={f.absPath}
+									kind={f.kind}
+								/>
+							))}
+							{(skillRefs ?? []).map((s) => (
+								<span
+									key={s.name}
+									className="inline-flex items-center rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]"
 								>
-									{inner}
-								</a>
-							);
-						})}
-						{(fileRefs ?? []).map((f) => (
-							<FileChip
-								key={f.relPath}
-								relPath={f.relPath}
-								absPath={f.absPath}
-								kind={f.kind}
-							/>
-						))}
-						{(skillRefs ?? []).map((s) => (
-							<span
-								key={s.name}
-								className="inline-flex items-center rounded-md border border-border/45 bg-[var(--chip-bg)] px-1.5 py-0.5 text-[11px] text-foreground/90 dark:shadow-[inset_0_1px_0_color-mix(in_oklch,white_4%,transparent),0_1px_2px_color-mix(in_oklch,black_22%,transparent)]"
-							>
-								/{s.name}
-							</span>
-						))}
-					</div>
-				) : null}
-				{display.length > 0 ? (
-					<div className="whitespace-pre-wrap break-words">{display}</div>
-				) : null}
-				{goal ? (
-					<div className="mt-2 flex items-center gap-1.5 text-xs text-user-bubble-foreground/65">
-						<HugeiconsIcon icon={DashboardSpeedIcon} className="size-3.5" />
-						<span>Sent as goal</span>
-					</div>
-				) : null}
+									/{s.name}
+								</span>
+							))}
+						</div>
+					) : null}
+					{display.length > 0 ? (
+						<div className="whitespace-pre-wrap break-words">{display}</div>
+					) : null}
+					{goal ? (
+						<div className="mt-2 flex items-center gap-1.5 text-xs text-user-bubble-foreground/65">
+							<HugeiconsIcon icon={DashboardSpeedIcon} className="size-3.5" />
+							<span>Sent as goal</span>
+						</div>
+					) : null}
+				</div>
+				<MessageActions
+					text={display || text}
+					sessionId={sessionId}
+					messageId={messageId}
+					forkLabel="message"
+					forkDestination={forkDestination}
+					sourceProjectId={sourceProjectId}
+					className="mt-1 opacity-0 transition-opacity duration-150 ease-out group-hover/message:opacity-100 group-focus-within/message:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100"
+				/>
 			</div>
 		</div>
 	);
@@ -641,12 +673,16 @@ function AssistantBubble({
 	createdAt,
 	messageId,
 	sessionId,
+	forkDestination,
+	sourceProjectId,
 	showMessageCommands,
 }: {
 	text: string;
 	createdAt?: Date;
 	messageId: Message["id"];
 	sessionId?: SessionId;
+	forkDestination?: ForkDestination;
+	sourceProjectId?: FolderId;
 	showMessageCommands: boolean;
 }) {
 	return (
@@ -658,6 +694,8 @@ function AssistantBubble({
 					createdAt={createdAt}
 					messageId={messageId}
 					sessionId={sessionId}
+					forkDestination={forkDestination}
+					sourceProjectId={sourceProjectId}
 					showMessageCommands={showMessageCommands}
 					className="mt-1"
 				/>

--- a/apps/renderer/src/components/turn-summary.tsx
+++ b/apps/renderer/src/components/turn-summary.tsx
@@ -5,9 +5,15 @@ import {
 	BubbleChatIcon,
 	Wrench01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
-import type { Message, SessionId } from "@zuse/contracts";
+import type {
+	FolderId,
+	ForkDestination,
+	Message,
+	SessionId,
+} from "@zuse/contracts";
 import { memo, useMemo, useState } from "react";
 import { cn } from "~/lib/utils";
+import { isForkableAssistantMessage } from "../lib/chat-timeline-rows.ts";
 import { groupMessages } from "../lib/group-messages.ts";
 
 import { AssistantMessageActions } from "./assistant-message-actions.tsx";
@@ -71,8 +77,9 @@ const aggregateFileStats = (body: ReadonlyArray<Message>): FileStat[] => {
 
 const findFinalAssistant = (body: ReadonlyArray<Message>): Message | null => {
 	for (let i = body.length - 1; i >= 0; i--) {
-		const m = body[i]!;
-		if (m.content._tag === "assistant") return m;
+		const m = body[i];
+		if (m === undefined) continue;
+		if (isForkableAssistantMessage(m)) return m;
 	}
 	return null;
 };
@@ -91,10 +98,14 @@ function TurnSummaryImpl({
 	body,
 	sessionId,
 	showAssistantCommands = false,
+	forkDestination,
+	sourceProjectId,
 }: {
 	body: ReadonlyArray<Message>;
 	sessionId?: SessionId;
 	showAssistantCommands?: boolean;
+	forkDestination?: ForkDestination;
+	sourceProjectId?: FolderId;
 }) {
 	const [expanded, setExpanded] = useState(false);
 	const [filesExpanded, setFilesExpanded] = useState(false);
@@ -115,9 +126,11 @@ function TurnSummaryImpl({
 	const fileStats = useMemo(() => aggregateFileStats(body), [body]);
 
 	const duration = useMemo(() => {
-		if (body.length === 0) return 0;
-		const start = body[0]!.createdAt.getTime();
-		const end = body[body.length - 1]!.createdAt.getTime();
+		const first = body[0];
+		const last = body.at(-1);
+		if (first === undefined || last === undefined) return 0;
+		const start = first.createdAt.getTime();
+		const end = last.createdAt.getTime();
 		return Math.max(0, end - start);
 	}, [body]);
 
@@ -224,7 +237,17 @@ function TurnSummaryImpl({
 				<div className="py-1">
 					{detailGroups.map((group) =>
 						group.kind === "single" ? (
-							<MessageRow key={group.message.id} message={group.message} />
+							<MessageRow
+								key={group.message.id}
+								message={group.message}
+								sessionId={sessionId}
+								forkDestination={forkDestination}
+								sourceProjectId={sourceProjectId}
+								showAssistantCommands={
+									showAssistantCommands &&
+									isForkableAssistantMessage(group.message)
+								}
+							/>
 						) : (
 							<SubagentRow
 								key={group.parent.id}
@@ -252,6 +275,8 @@ function TurnSummaryImpl({
 							createdAt={finalAssistant.createdAt}
 							messageId={finalAssistant.id}
 							sessionId={sessionId}
+							forkDestination={forkDestination}
+							sourceProjectId={sourceProjectId}
 							showMessageCommands={showAssistantCommands}
 							elapsed={formatElapsed(duration)}
 							className="mt-1"

--- a/apps/renderer/src/lib/chat-timeline-rows.ts
+++ b/apps/renderer/src/lib/chat-timeline-rows.ts
@@ -67,6 +67,12 @@ export function rowAnchorMessageId(row: ChatTimelineRow): string | null {
 
 export { normalizeTimelineMessages };
 
+export const isForkableAssistantMessage = (message: Message): boolean =>
+	message.content._tag === "assistant" &&
+	message.content.text.trim().length > 0 &&
+	(!("parentItemId" in message.content) ||
+		message.content.parentItemId === undefined);
+
 export function deriveChatTimelineRows({
 	messages,
 	inFlight,
@@ -77,15 +83,13 @@ export function deriveChatTimelineRows({
 	readonly awaitingPlanApproval: boolean;
 }): ChatTimelineRow[] {
 	const normalizedMessages = normalizeTimelineMessages(messages);
-	const actionableAssistantMessageId = inFlight
-		? null
-		: (normalizedMessages.findLast(
-				(message) =>
-					message.content._tag === "assistant" &&
-					message.content.text.trim().length > 0 &&
-					(!("parentItemId" in message.content) ||
-						message.content.parentItemId === undefined),
-			)?.id ?? null);
+	const lastMessage = normalizedMessages.at(-1);
+	const streamingAssistantMessageId =
+		inFlight &&
+		lastMessage !== undefined &&
+		isForkableAssistantMessage(lastMessage)
+			? lastMessage.id
+			: null;
 	const turns: Array<{
 		user: Message | null;
 		body: Message[];
@@ -108,6 +112,9 @@ export function deriveChatTimelineRows({
 	for (const [index, turn] of turns.entries()) {
 		const isLastTurn = index === turns.length - 1;
 		const isLive = inFlight && isLastTurn;
+		const showAssistantCommands = (message: Message): boolean =>
+			isForkableAssistantMessage(message) &&
+			message.id !== streamingAssistantMessageId;
 
 		if (turn.user !== null) {
 			rows.push({
@@ -165,16 +172,14 @@ export function deriveChatTimelineRows({
 					id: `message:${message.id}`,
 					message,
 					enterUser: false,
-					showAssistantCommands: message.id === actionableAssistantMessageId,
+					showAssistantCommands: showAssistantCommands(message),
 				});
 			}
 			rows.push({
 				kind: "turn-summary",
 				id: `summary:${turn.user?.id ?? `turn-${index}`}`,
 				body: summaryBody,
-				showAssistantCommands: summaryBody.some(
-					(message) => message.id === actionableAssistantMessageId,
-				),
+				showAssistantCommands: summaryBody.some(showAssistantCommands),
 			});
 			continue;
 		}
@@ -186,8 +191,7 @@ export function deriveChatTimelineRows({
 					id: `message:${group.message.id}`,
 					message: group.message,
 					enterUser: false,
-					showAssistantCommands:
-						group.message.id === actionableAssistantMessageId,
+					showAssistantCommands: showAssistantCommands(group.message),
 				});
 			} else {
 				rows.push({

--- a/apps/renderer/test/unit/chat-timeline-rows.test.ts
+++ b/apps/renderer/test/unit/chat-timeline-rows.test.ts
@@ -55,7 +55,11 @@ describe("chat timeline rows", () => {
 		});
 
 		expect(resolveLatestUserMessageId(rows)).toBe("u1");
-		expect(rowAnchorMessageId(rows[0]!)).toBe("u1");
+		const firstRow = rows[0];
+		expect(firstRow).toBeDefined();
+		expect(firstRow === undefined ? null : rowAnchorMessageId(firstRow)).toBe(
+			"u1",
+		);
 	});
 
 	it("moves the anchor when a later user message appears before assistant output", () => {
@@ -101,7 +105,7 @@ describe("chat timeline rows", () => {
 		expect(second.map((row) => row.id)).toEqual(first.map((row) => row.id));
 	});
 
-	it("enables assistant commands only on the final completed response", () => {
+	it("enables assistant commands on every completed response", () => {
 		const rows = deriveChatTimelineRows({
 			messages: [
 				message("u1", { _tag: "user", text: "first" }),
@@ -121,27 +125,58 @@ describe("chat timeline rows", () => {
 			assistantRows.map((row) =>
 				row.kind === "message" ? row.showAssistantCommands : false,
 			),
-		).toEqual([false, true]);
+		).toEqual([true, true]);
 	});
 
-	it("keeps assistant commands hidden until the active turn completes", () => {
+	it("keeps only the active response commands hidden until its turn completes", () => {
 		const rows = deriveChatTimelineRows({
 			messages: [
-				message("u1", { _tag: "user", text: "prompt" }),
-				message("a1", { _tag: "assistant", text: "partial reply" }),
+				message("u1", { _tag: "user", text: "first prompt" }),
+				message("a1", { _tag: "assistant", text: "completed reply" }),
+				message("u2", { _tag: "user", text: "active prompt" }),
+				message("a2", { _tag: "assistant", text: "partial reply" }),
 			],
 			inFlight: true,
 			awaitingPlanApproval: false,
 		});
 
+		const assistantRows = rows.filter(
+			(row) =>
+				row.kind === "message" && row.message.content._tag === "assistant",
+		);
 		expect(
-			rows.some(
-				(row) =>
-					row.kind === "message" &&
-					row.message.content._tag === "assistant" &&
-					row.showAssistantCommands,
+			assistantRows.map((row) =>
+				row.kind === "message" ? row.showAssistantCommands : false,
 			),
-		).toBe(false);
+		).toEqual([true, false]);
+	});
+
+	it("keeps earlier assistant messages actionable during a live turn", () => {
+		const rows = deriveChatTimelineRows({
+			messages: [
+				message("u1", { _tag: "user", text: "active prompt" }),
+				message("a1", { _tag: "assistant", text: "intermediate update" }),
+				message("t1", {
+					_tag: "tool_use",
+					itemId: "call-1" as never,
+					tool: "Read",
+					input: { file_path: "/repo/a.ts" },
+				}),
+				message("a2", { _tag: "assistant", text: "partial reply" }),
+			],
+			inFlight: true,
+			awaitingPlanApproval: false,
+		});
+
+		const assistantRows = rows.filter(
+			(row) =>
+				row.kind === "message" && row.message.content._tag === "assistant",
+		);
+		expect(
+			assistantRows.map((row) =>
+				row.kind === "message" ? row.showAssistantCommands : false,
+			),
+		).toEqual([true, false]);
 	});
 
 	it("collapses duplicate tool_use rows with the same provider item id", () => {
@@ -187,9 +222,7 @@ describe("chat timeline rows", () => {
 		const summary = rows.find((row) => row.kind === "turn-summary");
 		expect(summary?.kind).toBe("turn-summary");
 		expect(
-			summary?.kind === "turn-summary"
-				? summary.showAssistantCommands
-				: false,
+			summary?.kind === "turn-summary" ? summary.showAssistantCommands : false,
 		).toBe(true);
 		expect(
 			summary?.kind === "turn-summary"


### PR DESCRIPTION
## Summary

- expose fork actions on every user message and completed top-level assistant response
- support historical responses inside summarized turns and earlier completed messages while a later response is streaming
- allow archived-message forks into a new isolated worktree
- centralize user and assistant message actions with keyboard, reduced-motion, and coarse-pointer support

## Root cause

The server already accepted an exact source message ID and copied the transcript through that row. The renderer reduced the whole timeline to one actionable assistant message ID, so only the latest completed response received the fork control.

## User impact

Users can branch from the exact point where an earlier idea, request, or response appeared without losing or rewriting the later conversation. The currently streaming response remains unavailable until it is stable.

## Validation

- `biome check` on all seven changed renderer files
- `bun --filter renderer check-types`
- `bun --filter renderer test` — 317 tests passed
- focused server fork integration tests — 3 passed
- independent standards and spec review passes

## Validation boundary

The broader server integration suite has unrelated baseline/environment failures; the focused fork integration coverage passes.