### PR TITLE
Harden provider process lifecycle

### DIFF
--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -368,7 +368,7 @@ function TabButton({
 	);
 }
 
-function ChatTabButton({
+export function ChatTabButton({
 	active,
 	label,
 	title,
@@ -430,14 +430,8 @@ function ChatTabButton({
 						/>
 					)}
 				</span>
-				<span
-					className="min-w-0 truncate leading-none"
-					aria-live={booting ? "polite" : undefined}
-				>
-					<TypewriterText
-						text={booting ? "Starting agent…" : label}
-						className="truncate"
-					/>
+				<span className="min-w-0 truncate leading-none">
+					<TypewriterText text={label} className="truncate" />
 				</span>
 			</button>
 			<button

--- a/apps/renderer/test/unit/main-tabs.test.tsx
+++ b/apps/renderer/test/unit/main-tabs.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatTabButton } from "../../src/components/main-tabs.tsx";
+
+describe("ChatTabButton", () => {
+	it("keeps the established title visible while a new turn starts", () => {
+		const markup = renderToStaticMarkup(
+			<ChatTabButton
+				active
+				label="Stable Session Title"
+				providerId="codex"
+				booting
+				running={false}
+				activityState="working"
+				awaitingPermission={false}
+				awaitingPlanApproval={false}
+				onClick={vi.fn()}
+				onClose={vi.fn()}
+				onRename={vi.fn()}
+			/>,
+		);
+
+		expect(markup).toContain("Stable Session Title");
+		expect(markup).not.toContain('class="truncate">Starting agent');
+	});
+});

--- a/apps/server/src/external-thread/layers/external-thread-service.ts
+++ b/apps/server/src/external-thread/layers/external-thread-service.ts
@@ -8,7 +8,8 @@ import type { ThreadReadResponse } from "@zuse/agents/codex-generated/v2/ThreadR
 import type { UserInput } from "@zuse/agents/codex-generated/v2/UserInput";
 import { translateClaudeSdkMessages } from "@zuse/agents/drivers/claude";
 import { translateCodexItem } from "@zuse/agents/drivers/codex";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import type { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import { withCodexControlClient } from "@zuse/agents/drivers/codex-control-client";
 import {
   ContinueExternalThreadResult,
   defaultModelFor,
@@ -225,52 +226,40 @@ const discoverCodexViaAppServer = (limit: number) =>
   Effect.gen(function* () {
     const codexPath = yield* resolveCliPath("codex");
     if (codexPath === null) return [] as ReadonlyArray<DiscoveredThread>;
-    const app = yield* Effect.tryPromise({
+    const response = yield* Effect.tryPromise({
       try: () =>
-        CodexAppServerClient.start({
-          codexPath,
-          onNotification: () => {},
-          onServerRequest: (_request, respond) => respond(null),
-        }),
-      catch: () => null,
-    });
-    if (app === null) return [] as ReadonlyArray<DiscoveredThread>;
-    try {
-      const response = yield* Effect.tryPromise({
-        try: () =>
+        withCodexControlClient(codexPath, (app) =>
           app.request<ThreadListResponse>("thread/list", {
             limit,
             sortKey: "updated_at",
             sortDirection: "desc",
             archived: false,
           }),
-        catch: () => null,
-      });
-      if (response === null) return [] as ReadonlyArray<DiscoveredThread>;
-      return response.data
-        .filter((thread) => thread.cwd.length > 0)
-        .map(
-          (thread): DiscoveredThread => ({
-            id: `codex:${thread.id}`,
-            providerId: "codex",
-            title: clamp(
-              thread.name ?? thread.preview ?? "Codex conversation",
-              96,
-            ),
-            preview: clamp(
-              thread.preview ?? thread.name ?? "Codex conversation",
-              140,
-            ),
-            projectPath: thread.cwd,
-            updatedAt: new Date(thread.updatedAt * 1000),
-            sourcePath: thread.path,
-            cursor: thread.id,
-            resumeStrategy: "codex-thread-id",
-          }),
-        );
-    } finally {
-      app.close();
-    }
+        ),
+      catch: () => null,
+    });
+    if (response === null) return [] as ReadonlyArray<DiscoveredThread>;
+    return response.data
+      .filter((thread) => thread.cwd.length > 0)
+      .map(
+        (thread): DiscoveredThread => ({
+          id: `codex:${thread.id}`,
+          providerId: "codex",
+          title: clamp(
+            thread.name ?? thread.preview ?? "Codex conversation",
+            96,
+          ),
+          preview: clamp(
+            thread.preview ?? thread.name ?? "Codex conversation",
+            140,
+          ),
+          projectPath: thread.cwd,
+          updatedAt: new Date(thread.updatedAt * 1000),
+          sourcePath: thread.path,
+          cursor: thread.id,
+          resumeStrategy: "codex-thread-id",
+        }),
+      );
   });
 
 const discoverCodexFromIndex = (): ReadonlyArray<DiscoveredThread> => {
@@ -364,140 +353,125 @@ const codexUserInputText = (input: UserInput): string | null => {
   }
 };
 
+const readCodexTranscriptMessages = async (
+  app: CodexAppServerClient,
+  cursor: string,
+): Promise<ReadonlyArray<MessageContent>> => {
+  const response = await app
+    .request<ThreadReadResponse>("thread/read", {
+      threadId: cursor,
+      includeTurns: true,
+    })
+    .catch(() => null);
+  if (response === null) return [];
+
+  const out: MessageContent[] = [];
+  for (const turn of response.thread.turns) {
+    for (const item of turn.items) {
+      if (item.type === "userMessage") {
+        const text = item.content
+          .flatMap((input) => {
+            const fragment = codexUserInputText(input);
+            return fragment === null ? [] : [fragment];
+          })
+          .join("\n")
+          .trim();
+        if (text.length > 0) out.push({ _tag: "user", text, goal: false });
+        continue;
+      }
+      if (item.type === "collabAgentToolCall" && item.tool === "spawnAgent") {
+        const childSessionId = item.receiverThreadIds[0];
+        if (childSessionId === undefined) continue;
+        const parentItemId = item.id as import("@zuse/contracts").AgentItemId;
+        const childResponse = await app
+          .request<ThreadReadResponse>("thread/read", {
+            threadId: childSessionId,
+            includeTurns: true,
+          })
+          .catch(() => null);
+        const childThread = childResponse?.thread ?? null;
+        const agentName =
+          childThread?.name ??
+          childThread?.agentNickname ??
+          item.prompt?.split("\n", 1)[0]?.slice(0, 80) ??
+          "Subagent";
+        out.push({
+          _tag: "tool_use",
+          itemId: parentItemId,
+          tool: "Agent",
+          input: {
+            prompt: item.prompt ?? "",
+            description: agentName,
+            model: item.model ?? "inherit",
+          },
+          subagent: { childSessionId, presentation: "detached" },
+        });
+        let summary = "";
+        let durationMs = 0;
+        let turns = 0;
+        let isError = false;
+        for (const childTurn of childThread?.turns ?? []) {
+          turns += 1;
+          durationMs += childTurn.durationMs ?? 0;
+          isError ||= childTurn.status === "failed";
+          for (const childItem of childTurn.items) {
+            if (childItem.type === "userMessage") continue;
+            for (const phase of ["started", "completed"] as const) {
+              for (const event of translateCodexItem(childItem, phase)) {
+                const nested =
+                  event._tag === "AssistantMessage" ||
+                  event._tag === "Thinking" ||
+                  event._tag === "ToolUse" ||
+                  event._tag === "ToolResult"
+                    ? { ...event, parentItemId }
+                    : null;
+                if (nested === null) continue;
+                if (nested._tag === "AssistantMessage") summary = nested.text;
+                const content = eventToContent(nested);
+                if (content !== null) out.push(content);
+              }
+            }
+          }
+        }
+        out.push({
+          _tag: "subagent_summary",
+          itemId: parentItemId,
+          agentName,
+          model: item.model ?? "inherit",
+          turns,
+          durationMs,
+          summary,
+          isError,
+          childSessionId,
+          presentation: "detached",
+        });
+        continue;
+      }
+      for (const phase of ["started", "completed"] as const) {
+        for (const event of translateCodexItem(item, phase)) {
+          const content = eventToContent(event);
+          if (content !== null) out.push(content);
+        }
+      }
+    }
+    if (turn.status === "failed" && turn.error !== null) {
+      out.push({ _tag: "error", message: turn.error.message });
+    }
+  }
+  return out;
+};
+
 const codexTranscriptMessages = (cursor: string) =>
   Effect.gen(function* () {
     const codexPath = yield* resolveCliPath("codex");
     if (codexPath === null) return [];
-    const app = yield* Effect.tryPromise({
+    return yield* Effect.tryPromise({
       try: () =>
-        CodexAppServerClient.start({
-          codexPath,
-          onNotification: () => {},
-          onServerRequest: (_request, respond) => respond(null),
-        }),
-      catch: () => null,
+        withCodexControlClient(codexPath, (app) =>
+          readCodexTranscriptMessages(app, cursor),
+        ),
+      catch: () => [],
     });
-    if (app === null) return [];
-    try {
-      const response = yield* Effect.tryPromise({
-        try: () =>
-          app.request<ThreadReadResponse>("thread/read", {
-            threadId: cursor,
-            includeTurns: true,
-          }),
-        catch: () => null,
-      });
-      if (response === null) return [];
-      const out: MessageContent[] = [];
-      for (const turn of response.thread.turns) {
-        for (const item of turn.items) {
-          if (item.type === "userMessage") {
-            const text = item.content
-              .flatMap((input) => {
-                const fragment = codexUserInputText(input);
-                return fragment === null ? [] : [fragment];
-              })
-              .join("\n")
-              .trim();
-            if (text.length > 0) {
-              out.push({ _tag: "user", text, goal: false });
-            }
-            continue;
-          }
-          if (
-            item.type === "collabAgentToolCall" &&
-            item.tool === "spawnAgent"
-          ) {
-            const childSessionId = item.receiverThreadIds[0];
-            if (childSessionId === undefined) continue;
-            const parentItemId =
-              item.id as import("@zuse/contracts").AgentItemId;
-            const childResponse = yield* Effect.tryPromise({
-              try: () =>
-                app.request<ThreadReadResponse>("thread/read", {
-                  threadId: childSessionId,
-                  includeTurns: true,
-                }),
-              catch: () => null,
-            });
-            const childThread = childResponse?.thread ?? null;
-            const agentName =
-              childThread?.name ??
-              childThread?.agentNickname ??
-              item.prompt?.split("\n", 1)[0]?.slice(0, 80) ??
-              "Subagent";
-            out.push({
-              _tag: "tool_use",
-              itemId: parentItemId,
-              tool: "Agent",
-              input: {
-                prompt: item.prompt ?? "",
-                description: agentName,
-                model: item.model ?? "inherit",
-              },
-              subagent: { childSessionId, presentation: "detached" },
-            });
-            let summary = "";
-            let durationMs = 0;
-            let turns = 0;
-            let isError = false;
-            for (const childTurn of childThread?.turns ?? []) {
-              turns += 1;
-              durationMs += childTurn.durationMs ?? 0;
-              isError ||= childTurn.status === "failed";
-              for (const childItem of childTurn.items) {
-                if (childItem.type === "userMessage") continue;
-                for (const phase of ["started", "completed"] as const) {
-                  for (const event of translateCodexItem(childItem, phase)) {
-                    const nested =
-                      event._tag === "AssistantMessage" ||
-                      event._tag === "Thinking" ||
-                      event._tag === "ToolUse" ||
-                      event._tag === "ToolResult"
-                        ? { ...event, parentItemId }
-                        : null;
-                    if (nested === null) continue;
-                    if (nested._tag === "AssistantMessage") {
-                      summary = nested.text;
-                    }
-                    const content = eventToContent(nested);
-                    if (content !== null) out.push(content);
-                  }
-                }
-              }
-            }
-            out.push({
-              _tag: "subagent_summary",
-              itemId: parentItemId,
-              agentName,
-              model: item.model ?? "inherit",
-              turns,
-              durationMs,
-              summary,
-              isError,
-              childSessionId,
-              presentation: "detached",
-            });
-            continue;
-          }
-          for (const phase of ["started", "completed"] as const) {
-            for (const event of translateCodexItem(item, phase)) {
-              const content = eventToContent(event);
-              if (content !== null) out.push(content);
-            }
-          }
-        }
-        if (turn.status === "failed" && turn.error !== null) {
-          out.push({
-            _tag: "error",
-            message: turn.error.message,
-          });
-        }
-      }
-      return out;
-    } finally {
-      app.close();
-    }
   }).pipe(Effect.catch(() => Effect.succeed([])));
 
 const toExternalThread = (thread: DiscoveredThread): ExternalThread =>

--- a/apps/server/src/mcp/codex-status.ts
+++ b/apps/server/src/mcp/codex-status.ts
@@ -7,6 +7,7 @@ import type { PluginDetail } from "@zuse/agents/codex-generated/v2/PluginDetail"
 import type { PluginListResponse } from "@zuse/agents/codex-generated/v2/PluginListResponse";
 import type { PluginReadResponse } from "@zuse/agents/codex-generated/v2/PluginReadResponse";
 import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import { withCodexControlClient } from "@zuse/agents/drivers/codex-control-client";
 import { Effect } from "effect";
 
 export interface CodexConnectorSnapshot {
@@ -64,6 +65,16 @@ const withCodexApp = <A>(
 				app.close();
 			}
 		},
+		catch: (cause) =>
+			cause instanceof Error ? cause : new Error(String(cause)),
+	});
+
+const withCodexControl = <A>(
+	codexPath: string | null,
+	run: (app: CodexAppServerClient) => Promise<A>,
+): Effect.Effect<A, Error> =>
+	Effect.tryPromise({
+		try: () => withCodexControlClient(codexPath, run),
 		catch: (cause) =>
 			cause instanceof Error ? cause : new Error(String(cause)),
 	});
@@ -170,7 +181,7 @@ export const readCodexLiveMcpSnapshot = (
 	codexPath: string | null,
 	cwd: string | null,
 ): Effect.Effect<CodexLiveMcpSnapshot, Error> =>
-	withCodexApp(codexPath, async (app) => {
+	withCodexControl(codexPath, async (app) => {
 		const [statuses, apps, plugins] = await Promise.all([
 			listMcpStatuses(app),
 			app

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import type { PlanType } from "@zuse/agents/codex-generated/PlanType";
 import type { Account } from "@zuse/agents/codex-generated/v2/Account";
 import type { GetAccountResponse } from "@zuse/agents/codex-generated/v2/GetAccountResponse";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import { withCodexControlClient } from "@zuse/agents/drivers/codex-control-client";
 import {
   AgentAvailability,
   type CliVersionStatus,
@@ -184,6 +184,29 @@ export const selectCliPathCandidate = (
   );
 };
 
+export const selectNewestCliPathCandidate = (
+  candidates: ReadonlyArray<{
+    readonly path: string;
+    readonly version: CliVersion | null;
+  }>,
+): string | null => {
+  const first = candidates[0];
+  if (first === undefined) return null;
+  const versioned = candidates.filter(
+    (candidate): candidate is { readonly path: string; readonly version: CliVersion } =>
+      candidate.version !== null,
+  );
+  const firstVersioned = versioned[0];
+  if (firstVersioned === undefined) return first.path;
+  let newest = firstVersioned;
+  for (const candidate of versioned.slice(1)) {
+    if (compareCliVersion(candidate.version, newest.version) > 0) {
+      newest = candidate;
+    }
+  }
+  return newest.path;
+};
+
 /**
  * Resolve the absolute path to a provider's CLI binary on PATH, or `null` if
  * not found. Used by `ProviderService.start` to feed the SDK's
@@ -201,10 +224,22 @@ export const resolveCliPath = (
       Effect.catch(() => Effect.succeedNone),
     );
     if (result._tag !== "Some" || result.value.exitCode !== 0) return null;
-    return selectCliPathCandidate(
-      cliBinary,
-      splitCommandPaths(result.value.stdout),
+    const candidates = splitCommandPaths(result.value.stdout);
+    if (cliBinary !== "codex") {
+      return selectCliPathCandidate(cliBinary, candidates);
+    }
+    const eligible = [...new Set(candidates)].filter(
+      (candidate) => !isManagedCodexShimPath(normalizeCommandPath(candidate)),
     );
+    const versioned = yield* Effect.forEach(
+      eligible,
+      (path) =>
+        probeCliVersion(path).pipe(
+          Effect.map((version) => ({ path, version })),
+        ),
+      { concurrency: "unbounded" },
+    );
+    return selectNewestCliPathCandidate(versioned);
   });
 
 export interface CliVersion {
@@ -573,11 +608,9 @@ const codexAccountLabel = (account: Account): string | undefined => {
   }
 };
 
-const ACCOUNT_PROBE_TIMEOUT_MS = 5_000;
-
 /**
- * Spawn a short-lived `codex app-server`, call `account/read`, and pull
- * email + plan label off the response. Always resolves to an `AccountInfo`
+ * Read `account/read` through the shared control client and pull email + plan
+ * label off the response. Always resolves to an `AccountInfo`
  * — spawn failures, timeouts, and protocol errors all flow through to a
  * tagged "unknown" result with the error message in `statusMessage` so the
  * UI can show "Needs attention" without crashing the whole availability
@@ -585,17 +618,10 @@ const ACCOUNT_PROBE_TIMEOUT_MS = 5_000;
  */
 const probeCodexAccount = (codexPath: string): Effect.Effect<AccountInfo> =>
   Effect.promise(async () => {
-    let client: CodexAppServerClient | null = null;
     try {
-      client = await CodexAppServerClient.start({
+      const response = await withCodexControlClient(
         codexPath,
-        startupTimeoutMs: ACCOUNT_PROBE_TIMEOUT_MS,
-        onNotification: () => {},
-        onServerRequest: (_req, respond) => respond(null),
-      });
-      const response = await client.request<GetAccountResponse>(
-        "account/read",
-        {},
+        (client) => client.request<GetAccountResponse>("account/read", {}),
       );
       if (response.account === null) {
         return {
@@ -621,10 +647,6 @@ const probeCodexAccount = (codexPath: string): Effect.Effect<AccountInfo> =>
         statusMessage:
           err instanceof Error ? err.message : "Could not verify Codex auth",
       } satisfies AccountInfo;
-    } finally {
-      // Kill the child process — without this the `codex app-server`
-      // subprocess leaks for several minutes per probe.
-      client?.close();
     }
   });
 

--- a/apps/server/src/skill/codex-skill-batcher.ts
+++ b/apps/server/src/skill/codex-skill-batcher.ts
@@ -1,0 +1,52 @@
+type SkillListEntry<Skill> = {
+	readonly cwd: string;
+	readonly skills: ReadonlyArray<Skill>;
+};
+
+type WaitingRequest<Skill> = {
+	readonly resolve: (skills: ReadonlyArray<Skill>) => void;
+	readonly reject: (cause: unknown) => void;
+};
+
+export interface CodexSkillBatcher<Skill> {
+	readonly load: (cwd: string) => Promise<ReadonlyArray<Skill>>;
+}
+
+/** Batches adjacent project hydration into one provider-native skills read. */
+export const createCodexSkillBatcher = <Skill>(
+	list: (
+		cwds: ReadonlyArray<string>,
+	) => Promise<ReadonlyArray<SkillListEntry<Skill>>>,
+	delayMs: number,
+): CodexSkillBatcher<Skill> => {
+	const waiting = new Map<string, Array<WaitingRequest<Skill>>>();
+	let timer: ReturnType<typeof setTimeout> | null = null;
+
+	const flush = async (): Promise<void> => {
+		timer = null;
+		const batch = new Map(waiting);
+		waiting.clear();
+		try {
+			const entries = await list([...batch.keys()]);
+			const byCwd = new Map(entries.map((entry) => [entry.cwd, entry.skills]));
+			for (const [cwd, requests] of batch) {
+				const skills = byCwd.get(cwd) ?? [];
+				for (const request of requests) request.resolve(skills);
+			}
+		} catch (cause) {
+			for (const requests of batch.values()) {
+				for (const request of requests) request.reject(cause);
+			}
+		}
+	};
+
+	return {
+		load: (cwd) =>
+			new Promise((resolve, reject) => {
+				const requests = waiting.get(cwd) ?? [];
+				requests.push({ resolve, reject });
+				waiting.set(cwd, requests);
+				if (timer === null) timer = setTimeout(() => void flush(), delayMs);
+			}),
+	};
+};

--- a/apps/server/src/skill/layers/skill-bridge.ts
+++ b/apps/server/src/skill/layers/skill-bridge.ts
@@ -6,6 +6,7 @@ import { Effect, Layer, PubSub, Stream } from "effect";
 
 import { SessionService } from "../../conversation/services/conversation-services.ts";
 import { WorkspaceService } from "../../workspace/services/workspace-service.ts";
+import { shouldRefreshSkillsForWatch } from "../skill-watch-filter.ts";
 import { SkillBridge } from "../services/skill-bridge.ts";
 import { SkillDiscoveryService } from "../services/skill-discovery.ts";
 
@@ -45,7 +46,8 @@ const watchRoots = (
 
   const watchers: fsSync.FSWatcher[] = [];
   let timer: NodeJS.Timeout | null = null;
-  const fire = (): void => {
+  const fire = (_event: string, filename: string | Buffer | null): void => {
+    if (!shouldRefreshSkillsForWatch(providerId, filename)) return;
     if (timer !== null) clearTimeout(timer);
     // Debounce: editors save by writing twice or rotating files; coalesce
     // a flurry into a single discovery pass.

--- a/apps/server/src/skill/layers/skill-discovery.ts
+++ b/apps/server/src/skill/layers/skill-discovery.ts
@@ -1,9 +1,10 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import { withCodexControlClient } from "@zuse/agents/drivers/codex-control-client";
 import { type ProviderId, Skill } from "@zuse/contracts";
 import { Effect, FileSystem, Layer } from "effect";
 import { ensureBundledZuseSkillInstalled } from "../bundled-zuse-skill.ts";
+import { createCodexSkillBatcher } from "../codex-skill-batcher.ts";
 import { SkillDiscoveryService } from "../services/skill-discovery.ts";
 
 interface RawSkill {
@@ -11,6 +12,15 @@ interface RawSkill {
   readonly description: string;
   readonly argumentHint: string;
   readonly filePath: string;
+}
+
+interface CodexSkillMetadata {
+  readonly name: string;
+  readonly description: string;
+  readonly shortDescription?: string;
+  readonly path: string;
+  readonly scope: "user" | "repo" | "system" | "admin";
+  readonly enabled: boolean;
 }
 
 /**
@@ -118,6 +128,20 @@ export const SkillDiscoveryServiceLive = Layer.effect(
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const home = os.homedir();
+    const codexSkills = createCodexSkillBatcher<CodexSkillMetadata>(
+      (cwds) =>
+        withCodexControlClient(null, (client) =>
+          client
+            .request<{
+              data: ReadonlyArray<{
+                cwd: string;
+                skills: ReadonlyArray<CodexSkillMetadata>;
+              }>;
+            }>("skills/list", { cwds, forceReload: false })
+            .then((response) => response.data),
+        ),
+      25,
+    );
 
     /**
      * Walk a Claude skills root. Skills can be either:
@@ -256,43 +280,20 @@ export const SkillDiscoveryServiceLive = Layer.effect(
         ensureBundledZuseSkillInstalled("codex", home);
         const viaAppServer = yield* Effect.tryPromise({
           try: async (): Promise<ReadonlyArray<Skill>> => {
-            const client = await CodexAppServerClient.start({
-              codexPath: null,
-              onNotification: () => undefined,
-              onServerRequest: (_request, respond) => respond({}),
-            });
-            try {
-              const response = await client.request<{
-                data: ReadonlyArray<{
-                  cwd: string;
-                  skills: ReadonlyArray<{
-                    name: string;
-                    description: string;
-                    shortDescription?: string;
-                    path: string;
-                    scope: "user" | "repo" | "system" | "admin";
-                    enabled: boolean;
-                  }>;
-                }>;
-              }>("skills/list", { cwds: [projectCwd], forceReload: false });
-              return response.data.flatMap((entry) =>
-                entry.skills
-                  .filter((skill) => skill.enabled)
-                  .map((skill) =>
-                    Skill.make({
-                      name: skill.name,
-                      scope: skill.scope === "repo" ? "project" : "global",
-                      description:
-                        skill.shortDescription ?? skill.description ?? "",
-                      arguments: [],
-                      filePath: skill.path,
-                      providerId: "codex",
-                    }),
-                  ),
+            const skills = await codexSkills.load(projectCwd);
+            return skills
+              .filter((skill) => skill.enabled)
+              .map((skill) =>
+                Skill.make({
+                  name: skill.name,
+                  scope: skill.scope === "repo" ? "project" : "global",
+                  description:
+                    skill.shortDescription ?? skill.description ?? "",
+                  arguments: [],
+                  filePath: skill.path,
+                  providerId: "codex",
+                }),
               );
-            } finally {
-              client.close();
-            }
           },
           catch: (cause) => cause,
         }).pipe(Effect.catch(() => Effect.succeed(null)));

--- a/apps/server/src/skill/skill-watch-filter.ts
+++ b/apps/server/src/skill/skill-watch-filter.ts
@@ -1,0 +1,11 @@
+import type { ProviderId } from "@zuse/contracts";
+
+/** Provider-managed refreshes must not recursively invalidate discovery. */
+export const shouldRefreshSkillsForWatch = (
+	providerId: ProviderId,
+	filename: string | Buffer | null,
+): boolean => {
+	if (providerId !== "codex" || filename === null) return true;
+	const normalized = filename.toString().replaceAll("\\", "/");
+	return normalized !== ".system" && !normalized.startsWith(".system/");
+};

--- a/apps/server/src/usage/limits/codex-usage.ts
+++ b/apps/server/src/usage/limits/codex-usage.ts
@@ -1,4 +1,4 @@
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import { withCodexControlClient } from "@zuse/agents/drivers/codex-control-client";
 import type { ProviderUsageLimits, UsageLimitWindow } from "@zuse/contracts";
 
 import { normalizePercent, normalizeReset, unavailable } from "./shared.ts";
@@ -74,27 +74,21 @@ export const mapCodexRateLimits = (
 };
 
 export const fetchCodexUsage = async (): Promise<ProviderUsageLimits> => {
-	let client: CodexAppServerClient | null = null;
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 	try {
-		client = await CodexAppServerClient.start({
-			codexPath: "codex",
-			startupTimeoutMs: 5_000,
-			onNotification: () => {},
-			onServerRequest: (_request, respond) => respond(null),
-		});
 		const timeoutPromise = new Promise<never>((_, reject) => {
 			timeout = setTimeout(() => reject(new Error("timeout")), 5_000);
 		});
-		const result = await Promise.race([
-			client.request<unknown>("account/rateLimits/read", {}),
-			timeoutPromise,
-		]);
+		const result = await withCodexControlClient("codex", (client) =>
+			Promise.race([
+				client.request<unknown>("account/rateLimits/read", {}),
+				timeoutPromise,
+			]),
+		);
 		return mapCodexRateLimits(result);
 	} catch {
 		return unavailable("codex", "error");
 	} finally {
 		if (timeout !== undefined) clearTimeout(timeout);
-		client?.close();
 	}
 };

--- a/apps/server/test/unit/availability.test.ts
+++ b/apps/server/test/unit/availability.test.ts
@@ -11,6 +11,7 @@ import {
 	parseCliVersion,
 	resolveCodexCapabilities,
 	selectCliPathCandidate,
+	selectNewestCliPathCandidate,
 } from "../../src/provider/availability.ts";
 
 const { parseGrokAuthJson, extractTier, decodeJwtPayload } =
@@ -325,6 +326,32 @@ describe("selectCliPathCandidate", () => {
 				"/Users/me/.local/bin/claude",
 			]),
 		).toBe("/opt/homebrew/bin/claude");
+	});
+});
+
+describe("selectNewestCliPathCandidate", () => {
+	it("selects the newest installed Codex binary instead of the first PATH match", () => {
+		expect(
+			selectNewestCliPathCandidate([
+				{
+					path: "/Users/me/.nvm/bin/codex",
+					version: parseCliVersion("codex-cli 0.145.0"),
+				},
+				{
+					path: "/Applications/ChatGPT.app/Contents/Resources/codex",
+					version: parseCliVersion("codex-cli 0.146.0-alpha.9.2"),
+				},
+			]),
+		).toBe("/Applications/ChatGPT.app/Contents/Resources/codex");
+	});
+
+	it("keeps PATH order when versions cannot be determined", () => {
+		expect(
+			selectNewestCliPathCandidate([
+				{ path: "/first/codex", version: null },
+				{ path: "/second/codex", version: null },
+			]),
+		).toBe("/first/codex");
 	});
 });
 

--- a/apps/server/test/unit/codex-skill-batcher.test.ts
+++ b/apps/server/test/unit/codex-skill-batcher.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createCodexSkillBatcher } from "../../src/skill/codex-skill-batcher.ts";
+
+describe("Codex skill batcher", () => {
+	test("coalesces adjacent projects and preserves per-project results", async () => {
+		vi.useFakeTimers();
+		const list = vi.fn(async (cwds: ReadonlyArray<string>) =>
+			cwds.map((cwd) => ({ cwd, skills: [`skill:${cwd}`] })),
+		);
+		const batcher = createCodexSkillBatcher(list, 25);
+
+		const first = batcher.load("/one");
+		const second = batcher.load("/two");
+		const duplicate = batcher.load("/one");
+		await vi.advanceTimersByTimeAsync(25);
+
+		await expect(Promise.all([first, second, duplicate])).resolves.toEqual([
+			["skill:/one"],
+			["skill:/two"],
+			["skill:/one"],
+		]);
+		expect(list).toHaveBeenCalledOnce();
+		expect(list).toHaveBeenCalledWith(["/one", "/two"]);
+		vi.useRealTimers();
+	});
+});

--- a/apps/server/test/unit/skill-watch-filter.test.ts
+++ b/apps/server/test/unit/skill-watch-filter.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+
+import { shouldRefreshSkillsForWatch } from "../../src/skill/skill-watch-filter.ts";
+
+describe("skill watch filter", () => {
+	test("ignores provider-managed system skill refreshes only", () => {
+		expect(shouldRefreshSkillsForWatch("codex", ".system")).toBe(false);
+		expect(shouldRefreshSkillsForWatch("codex", ".system/skill/SKILL.md")).toBe(
+			false,
+		);
+		expect(shouldRefreshSkillsForWatch("codex", "custom/SKILL.md")).toBe(true);
+		expect(shouldRefreshSkillsForWatch("claude", ".system/SKILL.md")).toBe(
+			true,
+		);
+	});
+});

--- a/docs/architecture/provider-process-lifecycle.md
+++ b/docs/architecture/provider-process-lifecycle.md
@@ -1,0 +1,61 @@
+# Provider process lifecycle
+
+Provider integrations have two distinct runtime planes. Keeping them separate
+prevents dashboard reads from competing with interactive sessions or mutating a
+provider's shared state concurrently.
+
+## Management plane
+
+Availability, account, usage, model, skill, connector, and external-thread
+reads belong to the management plane.
+
+- Cache and single-flight equivalent reads at the owning server module.
+- When a provider exposes a multiplexable control protocol, lease a shared
+  client from `@zuse/agents/kernel/shared-resource-pool`.
+- Key resources by every setting that changes process identity, including the
+  binary and provider home.
+- Batch provider-native multi-project reads when the protocol supports them.
+- Release the final lease promptly and close the resource after a short idle
+  window.
+- Provider-managed filesystem updates must not recursively invalidate the read
+  that caused them.
+
+The generic pool owns creation coalescing, leases, retry after failed startup,
+idle teardown, and disposal. A provider adapter owns launch arguments,
+protocol requests, error classification, and diagnostic filtering.
+
+## Session plane
+
+Interactive chat sessions remain isolated unless the provider explicitly
+guarantees session-safe multiplexing with independent configuration and event
+routing. Session processes own notifications, approvals, tools, credentials,
+and teardown for one conversation.
+
+Management clients must never carry session-scoped MCP configuration or event
+handlers. Session clients must not be reused for background probes.
+
+## Mutations
+
+Login, OAuth, configuration writes, installs, and enable/disable operations are
+not shared reads. They use an isolated scoped client unless a provider offers a
+transactional mutation interface with explicit serialization guarantees.
+
+## Diagnostics
+
+- Capture provider stderr at the adapter seam.
+- Preserve the first actionable message immediately.
+- Coalesce repeated messages by stable category within a bounded time window.
+- Never include credentials, full payloads, or user content in process logs.
+- Startup timeouts and process exits must reject pending requests and permit a
+  clean retry; they must not leave a poisoned pool entry.
+
+## Adding a provider
+
+1. Classify each operation as management read, session work, or mutation.
+2. Reuse the existing availability and usage snapshot coordinators.
+3. Use a shared resource only when the provider protocol is genuinely
+   multiplexable; otherwise use a bounded one-shot process behind single-flight
+   caching.
+4. Keep protocol-specific behavior inside the provider adapter.
+5. Test concurrent creation, failed startup retry, isolation by configuration,
+   teardown, and log coalescing through the adapter's interface.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -12,6 +12,7 @@
 		"./user-mcp/*": "./src/user-mcp/*.ts",
 		"./kernel/attachment-service": "./src/kernel/attachment-service.ts",
 		"./kernel/driver": "./src/kernel/driver.ts",
+		"./kernel/shared-resource-pool": "./src/kernel/shared-resource-pool.ts",
 		"./kernel/turn-protocol": "./src/kernel/turn-protocol.ts",
 		"./kernel/permission-policy": "./src/kernel/permission-policy.ts",
 		"./kernel/policy": "./src/kernel/policy.ts",

--- a/packages/agents/src/drivers/codex-app-server-client.ts
+++ b/packages/agents/src/drivers/codex-app-server-client.ts
@@ -4,6 +4,7 @@ import type { ClientRequest } from "@zuse/agents/codex-generated/ClientRequest";
 import type { InitializeResponse } from "@zuse/agents/codex-generated/InitializeResponse";
 import type { ServerNotification } from "@zuse/agents/codex-generated/ServerNotification";
 import type { ServerRequest } from "@zuse/agents/codex-generated/ServerRequest";
+import { reportCodexStderr } from "./codex-stderr-reporter.ts";
 
 type RequestId = number;
 
@@ -116,6 +117,7 @@ export class CodexAppServerClient {
 		readonly env?: NodeJS.ProcessEnv;
 		readonly mcp?: CodexAppMcpLaunchConfig;
 		readonly startupTimeoutMs?: number;
+		readonly onStderr?: (text: string) => void;
 		readonly onNotification: NotificationHandler;
 		readonly onServerRequest: ServerRequestHandler;
 	}): Promise<CodexAppServerClient> {
@@ -147,7 +149,9 @@ export class CodexAppServerClient {
 		rl.on("line", (line) => bootstrap.handleLine(line));
 		child.stderr.on("data", (chunk) => {
 			const text = String(chunk).trim();
-			if (text.length > 0) console.warn(`[codex-app-server] ${text}`);
+			if (text.length === 0) return;
+			if (options.onStderr !== undefined) options.onStderr(text);
+			else reportCodexStderr(text);
 		});
 		// Without this listener, a spawn-time failure (ENOENT when codex isn't on
 		// PATH, EACCES on a non-executable file) becomes an uncaught exception
@@ -243,7 +247,7 @@ export class CodexAppServerClient {
 		try {
 			parsed = JSON.parse(line);
 		} catch {
-			console.warn(`[codex-app-server] non-json stdout: ${line}`);
+			reportCodexStderr(`non-json stdout: ${line}`);
 			return;
 		}
 		if (!isRecord(parsed)) return;

--- a/packages/agents/src/drivers/codex-control-client.ts
+++ b/packages/agents/src/drivers/codex-control-client.ts
@@ -1,0 +1,57 @@
+import { createSharedResourcePool } from "@zuse/agents/kernel/shared-resource-pool";
+import { CodexAppServerClient } from "./codex-app-server-client.ts";
+
+interface CodexControlClientKey {
+	readonly codexPath: string | null;
+	readonly codexHome: string | null;
+}
+
+const IDLE_TIMEOUT_MS = 5_000;
+const STARTUP_TIMEOUT_MS = 10_000;
+const keys = new Map<string, CodexControlClientKey>();
+const pool = createSharedResourcePool<string, CodexAppServerClient>({
+	create: (key) => {
+		const config = keys.get(key);
+		if (config === undefined) {
+			return Promise.reject(
+				new Error(`Unknown Codex control client key: ${key}`),
+			);
+		}
+		return CodexAppServerClient.start({
+			codexPath: config.codexPath,
+			startupTimeoutMs: STARTUP_TIMEOUT_MS,
+			onNotification: () => undefined,
+			onServerRequest: (_request, respond) => respond({}),
+		});
+	},
+	idleTimeoutMs: IDLE_TIMEOUT_MS,
+});
+
+const controlClientKey = (codexPath: string | null): string => {
+	const pathKey =
+		codexPath === null || /(^|[/\\])codex$/.test(codexPath)
+			? "<default>"
+			: codexPath;
+	const key = JSON.stringify({
+		path: pathKey,
+		codexHome: process.env.CODEX_HOME?.trim() || null,
+	});
+	const previous = keys.get(key);
+	const config = {
+		// Preserve an explicitly resolved binary path even though the default
+		// command and an absolute path ending in `/codex` share one pool identity.
+		codexPath: codexPath ?? previous?.codexPath ?? null,
+		codexHome: process.env.CODEX_HOME?.trim() || null,
+	} satisfies CodexControlClientKey;
+	keys.set(key, config);
+	return key;
+};
+
+/**
+ * Leases the shared read-only control-plane client. Interactive sessions and
+ * operations requiring notifications must continue to own isolated clients.
+ */
+export const withCodexControlClient = async <Result>(
+	codexPath: string | null,
+	run: (client: CodexAppServerClient) => Promise<Result>,
+): Promise<Result> => pool.use(controlClientKey(codexPath), run);

--- a/packages/agents/src/drivers/codex-stderr-reporter.ts
+++ b/packages/agents/src/drivers/codex-stderr-reporter.ts
@@ -1,0 +1,91 @@
+const LOG_DEDUP_WINDOW_MS = 30_000;
+
+// Codex uses tracing's pretty formatter for interactive app-server processes.
+// Strip its terminal styling before deriving a stable diagnostic identity.
+const ANSI_CONTROL_SEQUENCE =
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI terminal control sequences are the intended input.
+	/\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g;
+
+const stripTerminalFormatting = (line: string): string =>
+	line.replace(ANSI_CONTROL_SEQUENCE, "");
+
+const jsonLogCategory = (line: string): string | null => {
+	try {
+		const parsed = JSON.parse(line) as {
+			readonly target?: unknown;
+			readonly fields?: { readonly message?: unknown };
+		};
+		if (
+			typeof parsed.target !== "string" ||
+			typeof parsed.fields?.message !== "string"
+		) {
+			return null;
+		}
+		return `${parsed.target}: ${parsed.fields.message}`;
+	} catch {
+		return null;
+	}
+};
+
+const stderrCategory = (line: string): string | null => {
+	const stable = stripTerminalFormatting(jsonLogCategory(line) ?? line);
+	if (
+		stable.includes("rmcp::transport::worker") &&
+		stable.includes("Auth(AuthorizationRequired)")
+	) {
+		return null;
+	}
+	if (stable.includes("codex_core_skills::loader")) return "skill-loader";
+	if (stable.includes("codex_core_skills::service")) return "skill-installer";
+	if (stable.includes("initialize sqlite state runtime"))
+		return "state-runtime";
+	if (stable.includes("rmcp::transport::worker")) return "mcp-transport";
+	if (stable.includes("codex_models_manager::cache")) return "models-cache";
+	return stable
+		.replace(/^\d{4}-\d{2}-\d{2}T\S+\s+/, "")
+		.replaceAll(
+			/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi,
+			"<id>",
+		);
+};
+
+export const createDeduplicatingStderrReporter = (
+	options: {
+		readonly now?: () => number;
+		readonly warn?: (message: string) => void;
+		readonly windowMs?: number;
+	} = {},
+): ((text: string) => void) => {
+	const now = options.now ?? Date.now;
+	const warn = options.warn ?? console.warn;
+	const windowMs = options.windowMs ?? LOG_DEDUP_WINDOW_MS;
+	const state = new Map<string, { lastLoggedAt: number; suppressed: number }>();
+
+	return (text) => {
+		for (const rawLine of text.split(/\r?\n/)) {
+			const line = rawLine.trim();
+			if (line.length === 0) continue;
+			const category = stderrCategory(line);
+			if (category === null) continue;
+			const previous = state.get(category);
+			const timestamp = now();
+			if (
+				previous !== undefined &&
+				timestamp - previous.lastLoggedAt < windowMs
+			) {
+				previous.suppressed += 1;
+				continue;
+			}
+			if (previous !== undefined && previous.suppressed > 0) {
+				warn(
+					`[codex-app-server] suppressed ${previous.suppressed} repeated ${category} messages`,
+				);
+			}
+			warn(`[codex-app-server] ${line}`);
+			state.set(category, { lastLoggedAt: timestamp, suppressed: 0 });
+		}
+	};
+};
+
+/** Process-wide reporter shared by control, mutation, and session clients. */
+export const reportCodexStderr = createDeduplicatingStderrReporter();

--- a/packages/agents/src/drivers/codex.ts
+++ b/packages/agents/src/drivers/codex.ts
@@ -42,6 +42,7 @@ import {
 	CodexAppServerClient,
 	CodexAppServerRequestError,
 } from "./codex-app-server-client.ts";
+import { reportCodexStderr } from "./codex-stderr-reporter.ts";
 import {
 	type CompactSnapshot,
 	finishCompactEvent,
@@ -1397,7 +1398,9 @@ export const startCodexSession = (
 						void handleServerRequest(request)
 							.then(respond)
 							.catch((cause) => {
-								console.warn("[codex-app-server] request failed", cause);
+								reportCodexStderr(
+									`request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+								);
 								respond(defaultServerRequestResponse(request));
 							});
 					},
@@ -1493,7 +1496,9 @@ export const startCodexSession = (
 							void handleServerRequest(request)
 								.then(respond)
 								.catch((cause) => {
-									console.warn("[codex-app-server] request failed", cause);
+									reportCodexStderr(
+										`request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+									);
 									respond(defaultServerRequestResponse(request));
 								});
 						},

--- a/packages/agents/src/kernel/shared-resource-pool.ts
+++ b/packages/agents/src/kernel/shared-resource-pool.ts
@@ -1,0 +1,108 @@
+export interface CloseableResource {
+	readonly close: () => void | Promise<void>;
+}
+
+interface ResourceEntry<Resource extends CloseableResource> {
+	readonly resource: Promise<Resource>;
+	leases: number;
+	idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export interface SharedResourcePool<Key, Resource extends CloseableResource> {
+	readonly use: <Result>(
+		key: Key,
+		run: (resource: Resource) => Promise<Result>,
+	) => Promise<Result>;
+	readonly dispose: () => Promise<void>;
+}
+
+/**
+ * Owns keyed, multiplexable provider resources behind lease-based idle
+ * teardown. Concurrent callers share initialization; distinct provider
+ * configurations remain isolated; failed starts are evicted for retry.
+ */
+export const createSharedResourcePool = <
+	Key,
+	Resource extends CloseableResource,
+>(options: {
+	readonly create: (key: Key) => Promise<Resource>;
+	readonly idleTimeoutMs: number;
+}): SharedResourcePool<Key, Resource> => {
+	const entries = new Map<Key, ResourceEntry<Resource>>();
+	let disposed = false;
+
+	const closeEntry = async (
+		key: Key,
+		entry: ResourceEntry<Resource>,
+	): Promise<void> => {
+		if (entry.idleTimer !== null) {
+			clearTimeout(entry.idleTimer);
+			entry.idleTimer = null;
+		}
+		if (entries.get(key) === entry) entries.delete(key);
+		try {
+			const resource = await entry.resource;
+			await resource.close();
+		} catch {
+			// Failed creation has no live resource to close. Provider shutdown is
+			// best-effort and must not turn process teardown into an unhandled error.
+		}
+	};
+
+	const scheduleIdleClose = (
+		key: Key,
+		entry: ResourceEntry<Resource>,
+	): void => {
+		if (entry.leases !== 0 || entry.idleTimer !== null || disposed) return;
+		entry.idleTimer = setTimeout(() => {
+			entry.idleTimer = null;
+			if (entry.leases !== 0 || entries.get(key) !== entry) return;
+			void closeEntry(key, entry);
+		}, options.idleTimeoutMs);
+		entry.idleTimer.unref?.();
+	};
+
+	const use = async <Result>(
+		key: Key,
+		run: (resource: Resource) => Promise<Result>,
+	): Promise<Result> => {
+		if (disposed) throw new Error("Shared resource pool is disposed");
+
+		let entry = entries.get(key);
+		if (entry === undefined) {
+			entry = {
+				resource: options.create(key),
+				leases: 0,
+				idleTimer: null,
+			};
+			entries.set(key, entry);
+			void entry.resource.catch(() => {
+				if (entries.get(key) === entry) entries.delete(key);
+			});
+		}
+
+		if (entry.idleTimer !== null) {
+			clearTimeout(entry.idleTimer);
+			entry.idleTimer = null;
+		}
+		entry.leases += 1;
+		try {
+			const resource = await entry.resource;
+			if (disposed) throw new Error("Shared resource pool is disposed");
+			return await run(resource);
+		} finally {
+			entry.leases -= 1;
+			scheduleIdleClose(key, entry);
+		}
+	};
+
+	const dispose = async (): Promise<void> => {
+		if (disposed) return;
+		disposed = true;
+		const active = [...entries.entries()];
+		entries.clear();
+		await Promise.all(active.map(([key, entry]) => closeEntry(key, entry)));
+	};
+
+	return { use, dispose };
+};

--- a/packages/agents/test/unit/drivers/codex-control-client.test.ts
+++ b/packages/agents/test/unit/drivers/codex-control-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createDeduplicatingStderrReporter } from "../../../src/drivers/codex-stderr-reporter.ts";
+
+describe("Codex app-server stderr", () => {
+	test("logs one message per noisy category and reports suppression", () => {
+		let now = 0;
+		const warn = vi.fn();
+		const report = createDeduplicatingStderrReporter({
+			now: () => now,
+			warn,
+			windowMs: 1_000,
+		});
+
+		report("2026-08-01T00:00:00Z ERROR codex_core_skills::loader: first");
+		report("2026-08-01T00:00:01Z ERROR codex_core_skills::loader: second");
+		expect(warn).toHaveBeenCalledTimes(1);
+
+		now = 1_001;
+		report("2026-08-01T00:00:02Z ERROR codex_core_skills::loader: third");
+		expect(warn).toHaveBeenNthCalledWith(
+			2,
+			"[codex-app-server] suppressed 1 repeated skill-loader messages",
+		);
+		expect(warn).toHaveBeenCalledTimes(3);
+	});
+
+	test("deduplicates structured diagnostics with different timestamps", () => {
+		const warn = vi.fn();
+		const report = createDeduplicatingStderrReporter({ warn });
+		const diagnostic = (timestamp: string) =>
+			JSON.stringify({
+				timestamp,
+				level: "WARN",
+				fields: { message: "unknown feature key in config" },
+				target: "provider_features",
+			});
+
+		report(diagnostic("2026-08-01T00:00:00Z"));
+		report(diagnostic("2026-08-01T00:00:01Z"));
+
+		expect(warn).toHaveBeenCalledOnce();
+	});
+
+	test("deduplicates ANSI-formatted pretty diagnostics by subsystem", () => {
+		const warn = vi.fn();
+		const report = createDeduplicatingStderrReporter({ warn });
+
+		report(
+			"\u001b[2m2026-08-01T16:33:09.703858Z\u001b[0m \u001b[31mERROR\u001b[0m \u001b[2mrmcp::transport::worker\u001b[0m: worker quit with fatal: first failure",
+		);
+		report(
+			"\u001b[2m2026-08-01T16:33:10.968916Z\u001b[0m \u001b[31mERROR\u001b[0m \u001b[2mrmcp::transport::worker\u001b[0m: worker quit with fatal: another failure",
+		);
+		report(
+			"\u001b[2m2026-08-01T16:33:14.620708Z\u001b[0m \u001b[31mERROR\u001b[0m \u001b[2mcodex_models_manager::cache\u001b[0m: stale cache",
+		);
+		report(
+			"\u001b[2m2026-08-01T16:33:21.798475Z\u001b[0m \u001b[31mERROR\u001b[0m \u001b[2mcodex_models_manager::cache\u001b[0m: stale cache again",
+		);
+
+		expect(warn).toHaveBeenCalledTimes(2);
+	});
+
+	test("ignores expected MCP authorization discovery failures", () => {
+		const warn = vi.fn();
+		const report = createDeduplicatingStderrReporter({ warn });
+
+		report(
+			"\u001b[2m2026-08-01T16:49:31.223078Z\u001b[0m \u001b[31mERROR\u001b[0m \u001b[2mrmcp::transport::worker\u001b[0m: worker quit with fatal: Transport channel closed, when Auth(AuthorizationRequired)",
+		);
+
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/packages/agents/test/unit/kernel/shared-resource-pool.test.ts
+++ b/packages/agents/test/unit/kernel/shared-resource-pool.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createSharedResourcePool } from "../../../src/kernel/shared-resource-pool.ts";
+
+describe("shared resource pool", () => {
+	test("coalesces concurrent creation and closes after the last lease is idle", async () => {
+		vi.useFakeTimers();
+		const close = vi.fn();
+		const create = vi.fn(async (key: string) => ({ close, key }));
+		const pool = createSharedResourcePool({ create, idleTimeoutMs: 5_000 });
+
+		await expect(
+			Promise.all([
+				pool.use("default", async (resource) => resource.key),
+				pool.use("default", async (resource) => resource.key),
+			]),
+		).resolves.toEqual(["default", "default"]);
+		expect(create).toHaveBeenCalledOnce();
+
+		await vi.advanceTimersByTimeAsync(4_999);
+		await pool.use("default", async () => undefined);
+		await vi.advanceTimersByTimeAsync(4_999);
+		expect(close).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(close).toHaveBeenCalledOnce();
+		vi.useRealTimers();
+	});
+
+	test("isolates keys and retries failed creation", async () => {
+		const close = vi.fn();
+		const create = vi
+			.fn<(key: string) => Promise<{ close: () => void; key: string }>>()
+			.mockRejectedValueOnce(new Error("startup failed"))
+			.mockImplementation(async (key) => ({ close, key }));
+		const pool = createSharedResourcePool({ create, idleTimeoutMs: 5_000 });
+
+		await expect(pool.use("a", async () => undefined)).rejects.toThrow(
+			"startup failed",
+		);
+		await expect(pool.use("a", async (resource) => resource.key)).resolves.toBe(
+			"a",
+		);
+		await expect(pool.use("b", async (resource) => resource.key)).resolves.toBe(
+			"b",
+		);
+		expect(create).toHaveBeenCalledTimes(3);
+	});
+
+	test("dispose closes all resources and rejects new leases", async () => {
+		const closes = new Map<string, ReturnType<typeof vi.fn>>();
+		const pool = createSharedResourcePool({
+			create: async (key: string) => {
+				const close = vi.fn();
+				closes.set(key, close);
+				return { close };
+			},
+			idleTimeoutMs: 60_000,
+		});
+
+		await Promise.all([
+			pool.use("a", async () => undefined),
+			pool.use("b", async () => undefined),
+		]);
+		await pool.dispose();
+
+		expect(closes.get("a")).toHaveBeenCalledOnce();
+		expect(closes.get("b")).toHaveBeenCalledOnce();
+		await expect(pool.use("a", async () => undefined)).rejects.toThrow(
+			"disposed",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- add a generic leased resource pool and shared Codex management client for read-only control-plane work
- batch skill discovery and ignore provider-managed filesystem churn to prevent process and log storms
- centralize bounded Codex stderr classification, including ANSI diagnostics and expected OAuth discovery states
- choose the newest installed Codex binary to keep shared model-cache schemas compatible
- keep established chat-tab titles stable while turns start
- document the management, session, and mutation lifecycle boundaries for provider integrations

## Root cause

Independent background features launched short-lived provider processes concurrently, while provider-managed skill writes recursively invalidated discovery. Interactive and management clients also forwarded raw provider stderr, and multiple installed Codex versions shared one model cache despite incompatible schemas. The tab title additionally reused runtime startup text as its animated label, replaying the reveal on every turn.

## Impact

Background reads now share a keyed, leased client with failed-start recovery and idle teardown. Session and mutation processes remain isolated. Repeated diagnostics are bounded without hiding actionable first occurrences, expected authorization discovery is not presented as an app failure, and established titles remain visually stable.

## Validation

- renderer typecheck
- renderer unit tests: 64 files, 309 tests
- server typecheck
- server unit tests: 37 files, 200 tests
- agents typecheck
- agents unit tests: 30 files, 217 tests
- Biome check on changed/new focused files
- `git diff --check`
