### PR TITLE
Restore analytics event delivery

### DIFF
--- a/apps/renderer/src/lib/analytics.ts
+++ b/apps/renderer/src/lib/analytics.ts
@@ -2,13 +2,13 @@ import {
 	ActiveTimeTracker,
 	type AnalyticsEventName,
 	type AnalyticsProperties,
-	isAnalyticsEventName,
 	sanitizeAnalyticsProperties,
 } from "@zuse/analytics";
 import type { AnalyticsContext } from "@zuse/contracts";
 import { Effect, Fiber, Stream } from "effect";
 
 import { createDeferredRuntime } from "./deferred-runtime.ts";
+import { sanitizePostHogEvent } from "./posthog-event.ts";
 import { getRpcClient } from "./rpc-client.ts";
 
 type AnalyticsSdk = typeof import("posthog-js/dist/module.slim")["default"];
@@ -77,27 +77,7 @@ const applyContext = (context: AnalyticsContext) => {
 				opt_out_capturing_by_default: !context.enabled,
 				bootstrap: { distinctID: context.distinctId },
 				persistence: "localStorage",
-				before_send: (event) => {
-					if (!event || typeof event.event !== "string") return null;
-					if (event.event.startsWith("$")) {
-						if (event.event !== "$identify") return null;
-						const properties = event.properties ?? {};
-						event.properties = {
-							distinct_id: properties.distinct_id,
-							$anon_distinct_id: properties.$anon_distinct_id,
-						};
-						return event;
-					}
-					if (!isAnalyticsEventName(event.event)) return null;
-					const distinctId = event.properties?.distinct_id;
-					event.properties = sanitizeAnalyticsProperties(
-						event.event,
-						event.properties ?? {},
-					);
-					if (typeof distinctId === "string")
-						event.properties.distinct_id = distinctId;
-					return event;
-				},
+				before_send: sanitizePostHogEvent,
 			}),
 		);
 		initialized = true;

--- a/apps/renderer/src/lib/posthog-event.ts
+++ b/apps/renderer/src/lib/posthog-event.ts
@@ -1,0 +1,35 @@
+import {
+	isAnalyticsEventName,
+	sanitizeAnalyticsProperties,
+} from "@zuse/analytics";
+
+interface PostHogEventEnvelope {
+	event: string;
+	properties?: Record<string, unknown>;
+}
+
+export const sanitizePostHogEvent = <Event extends PostHogEventEnvelope>(
+	event: Event | null,
+): Event | null => {
+	if (!event || typeof event.event !== "string") return null;
+	const ingestToken = event.properties?.token;
+	if (event.event.startsWith("$")) {
+		if (event.event !== "$identify") return null;
+		const properties = event.properties ?? {};
+		event.properties = {
+			...(typeof ingestToken === "string" ? { token: ingestToken } : {}),
+			distinct_id: properties.distinct_id,
+			$anon_distinct_id: properties.$anon_distinct_id,
+		};
+		return event;
+	}
+	if (!isAnalyticsEventName(event.event)) return null;
+	const distinctId = event.properties?.distinct_id;
+	event.properties = sanitizeAnalyticsProperties(
+		event.event,
+		event.properties ?? {},
+	);
+	if (typeof ingestToken === "string") event.properties.token = ingestToken;
+	if (typeof distinctId === "string") event.properties.distinct_id = distinctId;
+	return event;
+};

--- a/apps/renderer/test/unit/posthog-event.test.ts
+++ b/apps/renderer/test/unit/posthog-event.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizePostHogEvent } from "../../src/lib/posthog-event.ts";
+
+describe("PostHog event privacy boundary", () => {
+	it("preserves required ingest metadata while removing unsafe properties", () => {
+		const event = sanitizePostHogEvent({
+			event: "app opened",
+			properties: {
+				token: "public-ingest-token",
+				distinct_id: "anonymous_test",
+				launch_type: "standard",
+				prompt: "must not leave the app",
+			},
+		});
+
+		expect(event?.properties).toMatchObject({
+			token: "public-ingest-token",
+			distinct_id: "anonymous_test",
+			launch_type: "standard",
+			analytics_schema_version: 2,
+		});
+		expect(event?.properties).not.toHaveProperty("prompt");
+	});
+
+	it("keeps identify ingestion metadata without leaking profile properties", () => {
+		const event = sanitizePostHogEvent({
+			event: "$identify",
+			properties: {
+				token: "public-ingest-token",
+				distinct_id: "account_test",
+				$anon_distinct_id: "anonymous_test",
+				email: "private@example.com",
+			},
+		});
+
+		expect(event?.properties).toEqual({
+			token: "public-ingest-token",
+			distinct_id: "account_test",
+			$anon_distinct_id: "anonymous_test",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- preserve the public ingest token required by the analytics SDK
- keep the existing event-property privacy allowlist intact
- cover product and identify envelopes with regression tests

## Root cause
The SDK adds its public ingest token before the `before_send` hook. The privacy sanitizer removed the `token` property, and the current SDK drops events when that required ingestion property disappears.

## Verification
- `bun --filter renderer test:unit`
- `bun --filter renderer check-types`
- `bunx biome check apps/renderer/src/lib/analytics.ts apps/renderer/src/lib/posthog-event.ts apps/renderer/test/unit/posthog-event.test.ts`
- `NODE_ENV=production bun --filter renderer build`