### PR TITLE
Fix hosted Serve connectivity and state discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Move the hosted app to `code.zuse.sh` and restore browser relay CORS
+- Publish Serve runtime `0.1.1` with background data-directory support
+
 ## [0.16.0]
 
 ### Changed

--- a/apps/renderer/src/components/computer-switcher.tsx
+++ b/apps/renderer/src/components/computer-switcher.tsx
@@ -7,14 +7,13 @@ import {
 	environmentRoute,
 	parseEnvironmentRoute,
 } from "@zuse/client-runtime/environment-scope";
-import type { RelayEnvironmentRecord } from "@zuse/contracts";
+import { HOSTED_APP_URL, type RelayEnvironmentRecord } from "@zuse/contracts";
 import { Effect } from "effect";
 import { useEffect, useMemo, useState } from "react";
 
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu.tsx";
 
-const APP_URL = "https://app.zuse.sh";
 const ONLINE_WINDOW_MS = 90_000;
 
 const routeEnvironmentId = (): string | null => {
@@ -33,8 +32,8 @@ const relativeTime = (timestamp: number | undefined): string => {
 };
 
 const openEnvironment = (environmentId: string): void => {
-	const url = `${APP_URL}${environmentRoute(environmentId)}`;
-	if (window.location.origin === APP_URL) {
+	const url = `${HOSTED_APP_URL}${environmentRoute(environmentId)}`;
+	if (window.location.origin === HOSTED_APP_URL) {
 		window.location.assign(url);
 		return;
 	}

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -574,10 +574,16 @@ function SidebarAccount() {
 						</button>
 					}
 				/>
-				<MenuPopup side="top" align="start" className="w-56">
+				<MenuPopup
+					side="top"
+					align="start"
+					sideOffset={6}
+					className="w-(--anchor-width) rounded-xl"
+				>
 					<MenuItem
 						variant="destructive"
 						onClick={() => void signOutHostedProduct()}
+						className="min-h-9 rounded-lg px-2.5 text-xs"
 					>
 						<HugeiconsIcon icon={Logout01Icon} />
 						Sign out of this browser

--- a/apps/renderer/src/lib/hosted-connect.ts
+++ b/apps/renderer/src/lib/hosted-connect.ts
@@ -1,4 +1,5 @@
 import {
+	HOSTED_APP_URL,
 	type RelayAuthTokenGrant,
 	type RelayConnectGrant,
 	type RelayEnvironmentList,
@@ -68,9 +69,10 @@ const environment = (): Record<string, string | undefined> =>
 	(import.meta as { readonly env?: Record<string, string | undefined> }).env ??
 	{};
 
-export const isHostedProduct = (): boolean =>
-	environment().VITE_ZUSE_HOSTED === "1" ||
-	window.location.hostname === "app.zuse.sh";
+export const isHostedProduct = (
+	locationOrigin = window.location.origin,
+): boolean =>
+	environment().VITE_ZUSE_HOSTED === "1" || locationOrigin === HOSTED_APP_URL;
 
 const clientId = (): string =>
 	environment().VITE_WORKOS_CLIENT_ID?.trim() || WORKOS_PUBLIC_CLIENT_ID;

--- a/apps/renderer/test/unit/hosted-connect.test.ts
+++ b/apps/renderer/test/unit/hosted-connect.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	createHostedEndpointLease,
 	hostedAuthTokenEndpoint,
+	isHostedProduct,
 } from "../../src/lib/hosted-connect.ts";
 
 describe("hosted authentication", () => {
@@ -10,6 +11,11 @@ describe("hosted authentication", () => {
 		expect(hostedAuthTokenEndpoint("http://127.0.0.1:8790/")).toBe(
 			"http://127.0.0.1:8790/v1/auth/token",
 		);
+	});
+
+	it("recognizes the canonical hosted product domain", () => {
+		expect(isHostedProduct("https://code.zuse.sh")).toBe(true);
+		expect(isHostedProduct("https://app.zuse.sh")).toBe(false);
 	});
 
 	it("uses each connect grant once and refreshes it for reconnects", async () => {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zusehq/server",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"private": false,
 	"type": "module",
 	"bin": {

--- a/apps/server/src/external-thread/layers/external-thread-service.ts
+++ b/apps/server/src/external-thread/layers/external-thread-service.ts
@@ -279,9 +279,14 @@ const rolloutFilesByThreadId = async (
   roots: ReadonlyArray<string>,
   targetIds: ReadonlySet<string>,
 ): Promise<ReadonlyMap<string, string>> => {
+  if (targetIds.size === 0) return new Map();
+  const now = Date.now();
+  for (const [key, entry] of rolloutFilesCache) {
+    if (entry.expiresAt <= now) rolloutFilesCache.delete(key);
+  }
   const cacheKey = `${roots.join("\0")}\0${[...targetIds].sort().join("\0")}`;
   const cached = rolloutFilesCache.get(cacheKey);
-  if (cached !== undefined && cached.expiresAt > Date.now()) {
+  if (cached !== undefined) {
     return cached.files;
   }
   const files = new Map<string, string>();
@@ -317,9 +322,14 @@ const rolloutFilesByThreadId = async (
     }
   }
   rolloutFilesCache.set(cacheKey, {
-    expiresAt: Date.now() + 30_000,
+    expiresAt: now + 30_000,
     files,
   });
+  while (rolloutFilesCache.size > 32) {
+    const oldestKey = rolloutFilesCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    rolloutFilesCache.delete(oldestKey);
+  }
   return files;
 };
 

--- a/apps/server/src/external-thread/layers/external-thread-service.ts
+++ b/apps/server/src/external-thread/layers/external-thread-service.ts
@@ -1,7 +1,19 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  closeSync,
+  createReadStream,
+  type Dirent,
+  existsSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  statSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { createInterface } from "node:readline";
+import { readdir as readDirectory } from "node:fs/promises";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { ThreadListResponse } from "@zuse/agents/codex-generated/v2/ThreadListResponse";
 import type { ThreadReadResponse } from "@zuse/agents/codex-generated/v2/ThreadReadResponse";
@@ -109,6 +121,7 @@ const rowText = (row: Record<string, unknown>): string | null => {
 const isSystemLikeText = (text: string): boolean =>
   text.includes("<system_instruction>") ||
   text.includes("<task-notification>") ||
+  text.startsWith("<app-context>") ||
   text.startsWith("You are working inside ");
 
 const isMeaningfulConversationText = (
@@ -262,34 +275,146 @@ const discoverCodexViaAppServer = (limit: number) =>
       );
   });
 
-const discoverCodexFromIndex = (): ReadonlyArray<DiscoveredThread> => {
-  const file = path.join(homedir(), ".codex", "session_index.jsonl");
+const rolloutFilesByThreadId = async (
+  roots: ReadonlyArray<string>,
+  targetIds: ReadonlySet<string>,
+): Promise<ReadonlyMap<string, string>> => {
+  const cacheKey = `${roots.join("\0")}\0${[...targetIds].sort().join("\0")}`;
+  const cached = rolloutFilesCache.get(cacheKey);
+  if (cached !== undefined && cached.expiresAt > Date.now()) {
+    return cached.files;
+  }
+  const files = new Map<string, string>();
+  const pending = roots.filter(existsSync).reverse();
+  const remaining = new Set(targetIds);
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    if (directory === undefined) break;
+    let entries: Dirent<string>[];
+    try {
+      entries = await readDirectory(directory, {
+        withFileTypes: true,
+        encoding: "utf8",
+      });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      const match = entry.name.match(
+        /([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})\.jsonl$/u,
+      );
+      const id = match?.[1];
+      if (id === undefined || !remaining.has(id)) continue;
+      files.set(id, entryPath);
+      remaining.delete(id);
+      if (remaining.size === 0) pending.length = 0;
+    }
+  }
+  rolloutFilesCache.set(cacheKey, {
+    expiresAt: Date.now() + 30_000,
+    files,
+  });
+  return files;
+};
+
+const rolloutFilesCache = new Map<
+  string,
+  { readonly expiresAt: number; readonly files: ReadonlyMap<string, string> }
+>();
+
+const rolloutCwd = (file: string | undefined): string => {
+  if (file === undefined) return "";
+  let handle: number | null = null;
+  try {
+    handle = openSync(file, "r");
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (total < 1024 * 1024) {
+      const buffer = Buffer.allocUnsafe(16 * 1024);
+      const length = readSync(handle, buffer, 0, buffer.length, total);
+      if (length === 0) break;
+      const newline = buffer.subarray(0, length).indexOf(10);
+      const chunk =
+        newline === -1
+          ? buffer.subarray(0, length)
+          : buffer.subarray(0, newline);
+      chunks.push(chunk);
+      total += length;
+      if (newline !== -1) break;
+    }
+    const firstRow = asRecord(
+      JSON.parse(Buffer.concat(chunks).toString("utf8")),
+    );
+    if (firstString(firstRow?.["type"]) !== "session_meta") return "";
+    return firstString(asRecord(firstRow?.["payload"])?.["cwd"]) ?? "";
+  } catch {
+    return "";
+  } finally {
+    if (handle !== null) closeSync(handle);
+  }
+};
+
+export const discoverCodexFromIndex = async (
+  file = path.join(homedir(), ".codex", "session_index.jsonl"),
+  rolloutRoots: ReadonlyArray<string> = [
+    path.join(homedir(), ".codex", "sessions"),
+    path.join(homedir(), ".codex", "archived_sessions"),
+  ],
+  limit = 100,
+): Promise<ReadonlyArray<DiscoveredThread>> => {
   if (!existsSync(file)) return [];
-  return parseJsonLines(file).flatMap(
-    (row): ReadonlyArray<DiscoveredThread> => {
-      const id = firstString(row["id"]);
-      if (id === null) return [];
-      const title = firstString(row["thread_name"]) ?? "Codex conversation";
-      const updated = firstString(row["updated_at"]);
-      const updatedAt =
-        updated === null || Number.isNaN(new Date(updated).getTime())
-          ? new Date(0)
-          : new Date(updated);
-      return [
-        {
-          id: `codex:${id}`,
-          providerId: "codex",
-          title: clamp(title, 96),
-          preview: clamp(title, 140),
-          projectPath: "",
-          updatedAt,
-          sourcePath: file,
-          cursor: id,
-          resumeStrategy: "codex-thread-id",
-        },
-      ];
-    },
+  const rowTime = (row: Record<string, unknown>): number => {
+    const value = firstString(row["updated_at"]);
+    if (value === null) return 0;
+    const time = new Date(value).getTime();
+    return Number.isNaN(time) ? 0 : time;
+  };
+  const newestRowById = new Map<string, Record<string, unknown>>();
+  for (const row of parseJsonLines(file)) {
+    const id = firstString(row["id"]);
+    if (id === null) continue;
+    const current = newestRowById.get(id);
+    if (current === undefined || rowTime(row) > rowTime(current)) {
+      newestRowById.set(id, row);
+    }
+  }
+  const rows = [...newestRowById.values()]
+    .sort((left, right) => rowTime(right) - rowTime(left))
+    .slice(0, limit);
+  const rolloutFiles = await rolloutFilesByThreadId(
+    rolloutRoots,
+    new Set(rows.flatMap((row) => firstString(row["id"]) ?? [])),
   );
+  return rows.flatMap((row): ReadonlyArray<DiscoveredThread> => {
+    const id = firstString(row["id"]);
+    if (id === null) return [];
+    const rolloutFile = rolloutFiles.get(id);
+    const title = firstString(row["thread_name"]) ?? "Codex conversation";
+    const updated = firstString(row["updated_at"]);
+    const updatedAt =
+      updated === null || Number.isNaN(new Date(updated).getTime())
+        ? new Date(0)
+        : new Date(updated);
+    return [
+      {
+        id: `codex:${id}`,
+        providerId: "codex",
+        title: clamp(title, 96),
+        preview: clamp(title, 140),
+        projectPath: rolloutCwd(rolloutFile),
+        updatedAt,
+        sourcePath: rolloutFile ?? file,
+        cursor: id,
+        resumeStrategy: "codex-thread-id",
+      },
+    ];
+  });
 };
 
 export const claudeTranscriptMessages = (
@@ -474,6 +599,73 @@ const codexTranscriptMessages = (cursor: string) =>
     });
   }).pipe(Effect.catch(() => Effect.succeed([])));
 
+const isCodexInjectedContextText = (text: string): boolean =>
+  isSystemLikeText(text) ||
+  text.startsWith("<recommended_plugins>") ||
+  text.startsWith("# AGENTS.md instructions") ||
+  text.startsWith("<environment_context>");
+
+const codexRolloutMessage = (
+  row: Record<string, unknown>,
+): MessageContent | null => {
+  if (firstString(row["type"]) !== "response_item") return null;
+  const payload = asRecord(row["payload"]);
+  if (payload === null || firstString(payload["type"]) !== "message") {
+    return null;
+  }
+  const role = firstString(payload["role"]);
+  if (role !== "user" && role !== "assistant") return null;
+  const content = payload["content"];
+  if (!Array.isArray(content)) return null;
+  const text = content
+    .flatMap((block) => {
+      const record = asRecord(block);
+      if (record === null) return [];
+      const type = firstString(record["type"]);
+      if (type !== "input_text" && type !== "output_text" && type !== "text") {
+        return [];
+      }
+      const value = firstString(record["text"]);
+      if (
+        value === null ||
+        (role === "user" && isCodexInjectedContextText(value))
+      ) {
+        return [];
+      }
+      return [value];
+    })
+    .join("\n")
+    .trim();
+  if (text.length === 0) return null;
+  return role === "user"
+    ? { _tag: "user", text, goal: false }
+    : { _tag: "assistant", text };
+};
+
+export const codexRolloutTranscriptMessages = async (
+  sourcePath: string | null | undefined,
+): Promise<ReadonlyArray<MessageContent>> => {
+  if (sourcePath === null || sourcePath === undefined) return [];
+  const messages: MessageContent[] = [];
+  const lines = createInterface({
+    input: createReadStream(sourcePath, { encoding: "utf8" }),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+  for await (const line of lines) {
+    try {
+      const row = asRecord(JSON.parse(line));
+      if (row === null) continue;
+      const message = codexRolloutMessage(row);
+      if (message === null) continue;
+      messages.push(message);
+      if (messages.length > 2_000) messages.shift();
+    } catch {
+      // Ignore partial or non-JSON rows without discarding the rest of the rollout.
+    }
+  }
+  return messages;
+};
+
 const toExternalThread = (thread: DiscoveredThread): ExternalThread =>
   ExternalThread.make({
     ...thread,
@@ -634,11 +826,16 @@ export const ExternalThreadServiceLive = Layer.effect(
 
     const list: ExternalThreadService["Service"]["list"] = (limit) =>
       Effect.gen(function* () {
+        const discoverCodexFallback = () =>
+          Effect.promise(() =>
+            discoverCodexFromIndex(undefined, undefined, limit),
+          );
         const codex = yield* discoverCodexViaAppServer(limit).pipe(
           Effect.provideService(CommandExecutor.ChildProcessSpawner, executor),
-          Effect.catch(() => Effect.succeed(discoverCodexFromIndex())),
+          Effect.catch(discoverCodexFallback),
         );
-        const codexRows = codex.length > 0 ? codex : discoverCodexFromIndex();
+        const codexRows =
+          codex.length > 0 ? codex : yield* discoverCodexFallback();
         const rows = dedupeExternalThreads(
           [...discoverClaudeThreads(), ...codexRows].map(toExternalThread),
         );
@@ -681,12 +878,22 @@ export const ExternalThreadServiceLive = Layer.effect(
               .pipe(Effect.orDie);
           }
         } else if (providerId === "codex") {
-          const imported = yield* codexTranscriptMessages(input.cursor).pipe(
+          const fromAppServer = yield* codexTranscriptMessages(
+            input.cursor,
+          ).pipe(
             Effect.provideService(
               CommandExecutor.ChildProcessSpawner,
               executor,
             ),
           );
+          const imported =
+            fromAppServer.length > 0
+              ? fromAppServer
+              : yield* Effect.promise(() =>
+                  codexRolloutTranscriptMessages(input.sourcePath).catch(
+                    () => [] as ReadonlyArray<MessageContent>,
+                  ),
+                );
           if (imported.length > 0) {
             importedMessages = yield* messages
               .importExternalMessages(result.initialSession.id, imported)

--- a/apps/server/src/relay/relay-link-service.ts
+++ b/apps/server/src/relay/relay-link-service.ts
@@ -22,24 +22,25 @@ import { ManagedTunnelRuntime } from "./managed-tunnel-runtime.ts";
 import { appendRelayDiagnostic } from "./relay-diagnostics.ts";
 
 const HEARTBEAT_INTERVAL = "30 seconds";
-const RUNTIME_METADATA = {
-  runtimeVersion: process.env.ZUSE_RUNTIME_VERSION?.trim() || "0.0.0",
-  wireProtocolVersion: WIRE_PROTOCOL_VERSION,
-  capabilities: {
-    version: 1,
-    features: [
-      "agents",
-      "chats",
-      "files",
-      "diffs",
-      "terminals",
-      "approvals",
-      "questions",
-      "notifications",
-    ],
-  },
-  serviceState: "healthy",
-} as const;
+export const relayRuntimeMetadata = () =>
+  ({
+    runtimeVersion: process.env.ZUSE_RUNTIME_VERSION?.trim() || "0.0.0",
+    wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+    capabilities: {
+      version: 1,
+      features: [
+        "agents",
+        "chats",
+        "files",
+        "diffs",
+        "terminals",
+        "approvals",
+        "questions",
+        "notifications",
+      ],
+    },
+    serviceState: "healthy",
+  }) as const;
 
 export class RelayLinkError extends Data.TaggedError("RelayLinkError")<{
   readonly reason: string;
@@ -195,7 +196,7 @@ export const RelayLinkServiceLive: Layer.Layer<
     }) =>
       postJson(
         `${input.relayUrl}${RelayPaths.heartbeat(input.environmentId)}`,
-        { bearer: input.credential, body: RUNTIME_METADATA },
+        { bearer: input.credential, body: relayRuntimeMetadata() },
       ).pipe(
         Effect.ignore,
         Effect.andThen(Effect.sleep(HEARTBEAT_INTERVAL)),
@@ -229,7 +230,7 @@ export const RelayLinkServiceLive: Layer.Layer<
         `${input.relayUrl}${RelayPaths.heartbeat(input.environmentId)}`,
         {
           bearer: input.credential,
-          body: { origin: computeOrigin(config), ...RUNTIME_METADATA },
+          body: { origin: computeOrigin(config), ...relayRuntimeMetadata() },
         },
       );
 
@@ -371,7 +372,7 @@ export const RelayLinkServiceLive: Layer.Layer<
               providerKind: "desktop",
               endpoint: computeEndpoint(config),
               label,
-              ...RUNTIME_METADATA,
+              ...relayRuntimeMetadata(),
               // Ask the relay to provision a managed Cloudflare tunnel so the
               // phone can reach this Mac from anywhere. If the relay has tunnels
               // disabled it simply returns no connector token and we stay on LAN.

--- a/apps/server/src/serve/package-cli.ts
+++ b/apps/server/src/serve/package-cli.ts
@@ -23,7 +23,6 @@ import {
 	getServeServiceStatus,
 	installServeService,
 	resolveServeServicePaths,
-	startServeService,
 	stopServeService,
 	UnsupportedServiceManagerError,
 	uninstallServeService,
@@ -33,10 +32,24 @@ const DEFAULT_RELAY_URL = "https://relay.stuff.md";
 const workosClientId = (env: NodeJS.ProcessEnv): string =>
 	(env.WORKOS_CLIENT_ID ?? "").trim() || WORKOS_PUBLIC_CLIENT_ID;
 
-const resolveDataDir = (env: NodeJS.ProcessEnv, override?: string): string => {
+export const resolveServeDataDir = (
+	env: NodeJS.ProcessEnv,
+	override?: string,
+	runtime: {
+		readonly platform?: NodeJS.Platform;
+		readonly homeDir?: string;
+	} = {},
+): string => {
 	if (override !== undefined) return override;
 	if (env.ZUSE_USER_DATA) return env.ZUSE_USER_DATA;
-	const xdg = env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
+	if (env.ZUSE_USER_DATA_DIR) return env.ZUSE_USER_DATA_DIR;
+	if (env.MEMOIZE_USER_DATA_DIR) return env.MEMOIZE_USER_DATA_DIR;
+	const platform = runtime.platform ?? process.platform;
+	const homeDir = runtime.homeDir ?? homedir();
+	if (platform === "darwin") {
+		return join(homeDir, "Library", "Application Support", "Zuse Alpha");
+	}
+	const xdg = env.XDG_DATA_HOME ?? join(homeDir, ".local", "share");
 	return join(xdg, "zuse");
 };
 
@@ -272,7 +285,7 @@ export const runServePackageCli = async (
 	const command = parseServeCommand(normalized);
 	env.ZUSE_RUNTIME_VERSION = options.packageVersion ?? "0.0.0";
 	env.ZUSE_RELAY_URL = env.ZUSE_RELAY_URL ?? DEFAULT_RELAY_URL;
-	const dataDir = resolveDataDir(env, command.dataDir);
+	const dataDir = resolveServeDataDir(env, command.dataDir);
 	env.ZUSE_USER_DATA = dataDir;
 	const servicePaths = resolveServeServicePaths({ dataDir });
 	const installService = (executable: string) =>
@@ -375,22 +388,6 @@ export const runServePackageCli = async (
 			},
 		}),
 	);
-	const current = await getServeServiceStatus(servicePaths);
-	if (current.installed && !current.running) {
-		await startServeService(servicePaths);
-		if (!(await waitForReachability(env))) {
-			throw new Error(
-				"Zuse Serve started, but its local readiness check failed. Run `zuse serve status --json` for diagnostics.",
-			);
-		}
-		await printStatus(await getServeServiceStatus(servicePaths), {
-			json: false,
-			dataDir,
-			env,
-		});
-		return;
-	}
-
 	let installedExecutable: string;
 	try {
 		const packageVersion = options.packageVersion ?? "0.0.0";

--- a/apps/server/src/serve/package-cli.ts
+++ b/apps/server/src/serve/package-cli.ts
@@ -4,7 +4,7 @@ import { homedir, hostname } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { WORKOS_PUBLIC_CLIENT_ID } from "@zuse/contracts";
+import { HOSTED_APP_URL, WORKOS_PUBLIC_CLIENT_ID } from "@zuse/contracts";
 import { Effect } from "effect";
 
 import { SessionStoreLive } from "../auth/layers/session-store.ts";
@@ -30,7 +30,6 @@ import {
 } from "./service-manager.ts";
 
 const DEFAULT_RELAY_URL = "https://relay.stuff.md";
-const APP_URL = "https://app.zuse.sh";
 const workosClientId = (env: NodeJS.ProcessEnv): string =>
 	(env.WORKOS_CLIENT_ID ?? "").trim() || WORKOS_PUBLIC_CLIENT_ID;
 
@@ -181,7 +180,7 @@ const printStatus = async (
 		environmentId: relay?.environmentId ?? null,
 		durable: status.durable,
 		dataDir: options.dataDir,
-		appUrl: APP_URL,
+		appUrl: HOSTED_APP_URL,
 	};
 	if (options.json) {
 		console.log(JSON.stringify(value));
@@ -439,7 +438,7 @@ export const runServePackageCli = async (
 	console.log(`Account    ${session.email}`);
 	const agents = await installedAgents();
 	console.log(`Agents     ${agents.join(", ") || "None detected"}`);
-	console.log(`Open       ${APP_URL}`);
+	console.log(`Open       ${HOSTED_APP_URL}`);
 };
 
 export { foregroundArgs };

--- a/apps/server/test/integration/external-thread-discovery.test.ts
+++ b/apps/server/test/integration/external-thread-discovery.test.ts
@@ -157,6 +157,25 @@ describe("external thread discovery", () => {
 		}
 	});
 
+	it("returns immediately when the discovery limit is zero", async () => {
+		const root = mkdtempSync(path.join(tmpdir(), "zuse-codex-threads-"));
+		try {
+			const indexFile = path.join(root, "session_index.jsonl");
+			writeFileSync(
+				indexFile,
+				JSON.stringify({
+					id: "thread-a",
+					thread_name: "Thread A",
+					updated_at: "2026-08-03",
+				}),
+			);
+
+			expect(await discoverCodexFromIndex(indexFile, [root], 0)).toEqual([]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("imports user and assistant messages from a Codex rollout fallback", async () => {
 		const root = mkdtempSync(path.join(tmpdir(), "zuse-codex-rollout-"));
 		try {

--- a/apps/server/test/integration/external-thread-discovery.test.ts
+++ b/apps/server/test/integration/external-thread-discovery.test.ts
@@ -6,11 +6,213 @@ import { describe, expect, it } from "vitest";
 
 import {
 	claudeTranscriptMessages,
+	codexRolloutTranscriptMessages,
 	dedupeExternalThreads,
 	discoverClaudeThreads,
+	discoverCodexFromIndex,
 } from "../../src/external-thread/layers/external-thread-service.ts";
 
 describe("external thread discovery", () => {
+	it("recovers Codex project paths from rollout metadata when index fallback is used", async () => {
+		const root = mkdtempSync(path.join(tmpdir(), "zuse-codex-threads-"));
+		try {
+			const indexFile = path.join(root, "session_index.jsonl");
+			const sessionsRoot = path.join(root, "sessions");
+			const threadId = "019fc0e8-8cc6-7c82-b809-cd841076e930";
+			const rolloutDir = path.join(sessionsRoot, "2026", "08", "02");
+			const rolloutFile = path.join(
+				rolloutDir,
+				`rollout-2026-08-02T05-18-20-${threadId}.jsonl`,
+			);
+			mkdirSync(rolloutDir, { recursive: true });
+			writeFileSync(
+				indexFile,
+				JSON.stringify({
+					id: threadId,
+					thread_name: "Fix analytics tracking",
+					updated_at: "2026-08-02T05:18:20.245857Z",
+				}),
+			);
+			writeFileSync(
+				rolloutFile,
+				`${JSON.stringify({
+					type: "session_meta",
+					payload: {
+						id: threadId,
+						cwd: "/Users/dev/Developer/forkzero",
+					},
+				})}\n`,
+			);
+
+			const threads = await discoverCodexFromIndex(indexFile, [sessionsRoot]);
+
+			expect(threads).toHaveLength(1);
+			expect(threads[0]).toMatchObject({
+				cursor: threadId,
+				projectPath: "/Users/dev/Developer/forkzero",
+				sourcePath: rolloutFile,
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("recovers archived Codex project paths from rollout metadata", async () => {
+		const root = mkdtempSync(path.join(tmpdir(), "zuse-codex-threads-"));
+		try {
+			const indexFile = path.join(root, "session_index.jsonl");
+			const activeRoot = path.join(root, "sessions");
+			const archivedRoot = path.join(root, "archived_sessions");
+			const threadId = "019fbe50-fc6e-7531-bc9b-0320ced73ac4";
+			const rolloutFile = path.join(
+				archivedRoot,
+				`rollout-2026-08-01T22-43-26-${threadId}.jsonl`,
+			);
+			mkdirSync(archivedRoot, { recursive: true });
+			writeFileSync(
+				indexFile,
+				JSON.stringify({
+					id: threadId,
+					thread_name: "Fix remote sync",
+					updated_at: "2026-08-01T17:13:34.727629Z",
+				}),
+			);
+			writeFileSync(
+				rolloutFile,
+				`${JSON.stringify({
+					type: "session_meta",
+					payload: { id: threadId, cwd: "/Users/dev/Developer/forkzero" },
+				})}\n`,
+			);
+
+			const threads = await discoverCodexFromIndex(indexFile, [
+				activeRoot,
+				archivedRoot,
+			]);
+
+			expect(threads[0]).toMatchObject({
+				projectPath: "/Users/dev/Developer/forkzero",
+				sourcePath: rolloutFile,
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reads a large session metadata row without matching unrelated cwd text", async () => {
+		const root = mkdtempSync(path.join(tmpdir(), "zuse-codex-threads-"));
+		try {
+			const indexFile = path.join(root, "session_index.jsonl");
+			const sessionsRoot = path.join(root, "sessions");
+			const threadId = "019fc0e8-8cc6-7c82-b809-cd841076e931";
+			const rolloutFile = path.join(sessionsRoot, `${threadId}.jsonl`);
+			mkdirSync(sessionsRoot, { recursive: true });
+			writeFileSync(
+				indexFile,
+				JSON.stringify({ id: threadId, thread_name: "Large metadata" }),
+			);
+			writeFileSync(
+				rolloutFile,
+				`${JSON.stringify({
+					type: "session_meta",
+					payload: {
+						id: threadId,
+						metadata: `embedded \\"cwd\\":\"/wrong\" ${"x".repeat(20_000)}`,
+						cwd: "/Users/dev/Developer/correct",
+					},
+				})}\n`,
+			);
+
+			const threads = await discoverCodexFromIndex(indexFile, [sessionsRoot]);
+
+			expect(threads[0]?.projectPath).toBe("/Users/dev/Developer/correct");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("deduplicates index rows before applying the discovery limit", async () => {
+		const root = mkdtempSync(path.join(tmpdir(), "zuse-codex-threads-"));
+		try {
+			const indexFile = path.join(root, "session_index.jsonl");
+			writeFileSync(
+				indexFile,
+				[
+					{ id: "thread-a", thread_name: "Old A", updated_at: "2026-08-01" },
+					{ id: "thread-b", thread_name: "Thread B", updated_at: "2026-08-02" },
+					{ id: "thread-a", thread_name: "New A", updated_at: "2026-08-03" },
+				]
+					.map((row) => JSON.stringify(row))
+					.join("\n"),
+			);
+
+			const threads = await discoverCodexFromIndex(indexFile, [], 2);
+
+			expect(threads.map((thread) => thread.title)).toEqual([
+				"New A",
+				"Thread B",
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("imports user and assistant messages from a Codex rollout fallback", async () => {
+		const root = mkdtempSync(path.join(tmpdir(), "zuse-codex-rollout-"));
+		try {
+			const rolloutFile = path.join(root, "rollout.jsonl");
+			writeFileSync(
+				rolloutFile,
+				[
+					JSON.stringify({
+						type: "response_item",
+						payload: {
+							type: "message",
+							role: "developer",
+							content: [{ type: "input_text", text: "Internal setup" }],
+						},
+					}),
+					JSON.stringify({
+						type: "response_item",
+						payload: {
+							type: "message",
+							role: "user",
+							content: [
+								{ type: "input_text", text: "<recommended_plugins>hidden" },
+								{
+									type: "input_text",
+									text: "# AGENTS.md instructions\nhidden",
+								},
+								{ type: "input_text", text: "<environment_context>hidden" },
+								{ type: "input_text", text: "<app-context>hidden" },
+								{ type: "input_text", text: "<system_instruction>hidden" },
+								{ type: "input_text", text: "<task-notification>hidden" },
+								{ type: "input_text", text: "Fix the project list" },
+							],
+						},
+					}),
+					JSON.stringify({
+						type: "response_item",
+						payload: {
+							type: "message",
+							role: "assistant",
+							content: [
+								{ type: "output_text", text: "I found the split profile." },
+							],
+						},
+					}),
+				].join("\n"),
+			);
+
+			expect(await codexRolloutTranscriptMessages(rolloutFile)).toEqual([
+				{ _tag: "user", text: "Fix the project list", goal: false },
+				{ _tag: "assistant", text: "I found the split profile." },
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps only the newest row for each external thread id", () => {
 		const makeThread = (id: string, updatedAt: string) =>
 			ExternalThread.make({

--- a/apps/server/test/unit/relay-link-service.test.ts
+++ b/apps/server/test/unit/relay-link-service.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { relayRuntimeMetadata } from "../../src/relay/relay-link-service.ts";
+
+const originalRuntimeVersion = process.env.ZUSE_RUNTIME_VERSION;
+
+afterEach(() => {
+	if (originalRuntimeVersion === undefined) {
+		delete process.env.ZUSE_RUNTIME_VERSION;
+		return;
+	}
+	process.env.ZUSE_RUNTIME_VERSION = originalRuntimeVersion;
+});
+
+describe("relay runtime metadata", () => {
+	it("reads the runtime version when the heartbeat is created", () => {
+		process.env.ZUSE_RUNTIME_VERSION = "0.1.1";
+		expect(relayRuntimeMetadata().runtimeVersion).toBe("0.1.1");
+
+		process.env.ZUSE_RUNTIME_VERSION = "0.1.2";
+		expect(relayRuntimeMetadata().runtimeVersion).toBe("0.1.2");
+	});
+});

--- a/apps/server/test/unit/serve-package-cli.test.ts
+++ b/apps/server/test/unit/serve-package-cli.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveServeDataDir } from "../../src/serve/package-cli.ts";
+
+describe("serve data directory", () => {
+	it("uses the stable desktop profile on macOS", () => {
+		expect(
+			resolveServeDataDir({}, undefined, {
+				platform: "darwin",
+				homeDir: "/Users/dev",
+			}),
+		).toBe("/Users/dev/Library/Application Support/Zuse Alpha");
+	});
+
+	it("preserves explicit data-directory overrides", () => {
+		expect(
+			resolveServeDataDir(
+				{ ZUSE_USER_DATA: "/tmp/from-env" },
+				"/tmp/explicit",
+				{ platform: "darwin", homeDir: "/Users/dev" },
+			),
+		).toBe("/tmp/explicit");
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -221,7 +221,7 @@
     },
     "apps/server": {
       "name": "@zusehq/server",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "zuse": "dist/bin.mjs",
       },
@@ -475,7 +475,7 @@
     },
     "packages/serve": {
       "name": "@zusehq/serve",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "zuse": "dist/bin.mjs",
       },
@@ -567,7 +567,7 @@
     },
     "packages/zusehq": {
       "name": "zusehq",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "zusehq": "dist/bin.mjs",
       },

--- a/infra/relay/src/config.ts
+++ b/infra/relay/src/config.ts
@@ -1,3 +1,4 @@
+import { HOSTED_APP_URL } from "@zuse/contracts";
 import { Context, Layer, type Redacted } from "effect";
 
 /**
@@ -56,7 +57,7 @@ const DEFAULTS = {
 	accessTokenTtlMs: 30 * 60 * 1000,
 	presenceStaleMs: 90 * 1000,
 	maxEnvironmentsPerAccount: 5 as number | null,
-	allowedBrowserOrigins: ["https://app.zuse.sh"] as ReadonlyArray<string>,
+	allowedBrowserOrigins: [HOSTED_APP_URL] as ReadonlyArray<string>,
 } as const;
 
 export const layer = (

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -1,4 +1,5 @@
 import { PgClient } from "@effect/sql-pg";
+import { HOSTED_APP_URL } from "@zuse/contracts";
 import { Effect, Layer, Redacted } from "effect";
 import { Pool, type PoolConfig } from "pg";
 import { AccountIdentityLive } from "./account-identity.ts";
@@ -79,9 +80,7 @@ const build = (env: Env): ReturnType<typeof makeRelay> => {
 			Number.isInteger(configuredLimit) && configuredLimit > 0
 				? configuredLimit
 				: null,
-		allowedBrowserOrigins: (
-			env.ALLOWED_BROWSER_ORIGINS ?? "https://app.zuse.sh"
-		)
+		allowedBrowserOrigins: (env.ALLOWED_BROWSER_ORIGINS ?? HOSTED_APP_URL)
 			.split(",")
 			.map((value) => value.trim())
 			.filter((value) => value.length > 0),

--- a/infra/relay/test/integration/relay.test.ts
+++ b/infra/relay/test/integration/relay.test.ts
@@ -226,7 +226,7 @@ describe("@zuse/relay", () => {
 				method: "POST",
 				headers: {
 					"content-type": "application/json",
-					origin: "https://app.zuse.sh",
+					origin: "https://code.zuse.sh",
 				},
 				body: JSON.stringify({
 					grantType: "authorization_code",
@@ -238,7 +238,7 @@ describe("@zuse/relay", () => {
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get("access-control-allow-origin")).toBe(
-			"https://app.zuse.sh",
+			"https://code.zuse.sh",
 		);
 		expect(await response.json()).toEqual({
 			access_token: "test-access-token",
@@ -250,7 +250,7 @@ describe("@zuse/relay", () => {
 				method: "POST",
 				headers: {
 					"content-type": "application/json",
-					origin: "https://app.zuse.sh",
+					origin: "https://code.zuse.sh",
 				},
 				body: JSON.stringify({
 					grantType: "refresh_token",
@@ -293,12 +293,12 @@ describe("@zuse/relay", () => {
 		const allowed = await relay.fetch(
 			new Request(`${RELAY_ISSUER}/v1/environments`, {
 				method: "OPTIONS",
-				headers: { origin: "https://app.zuse.sh" },
+				headers: { origin: "https://code.zuse.sh" },
 			}),
 		);
 		expect(allowed.status).toBe(204);
 		expect(allowed.headers.get("access-control-allow-origin")).toBe(
-			"https://app.zuse.sh",
+			"https://code.zuse.sh",
 		);
 
 		const denied = await relay.fetch(
@@ -308,6 +308,14 @@ describe("@zuse/relay", () => {
 			}),
 		);
 		expect(denied.headers.get("access-control-allow-origin")).toBeNull();
+
+		const legacy = await relay.fetch(
+			new Request(`${RELAY_ISSUER}/v1/environments`, {
+				method: "OPTIONS",
+				headers: { origin: "https://app.zuse.sh" },
+			}),
+		);
+		expect(legacy.headers.get("access-control-allow-origin")).toBeNull();
 	});
 
 	test("enforces the account computer limit without blocking an existing computer", async () => {

--- a/infra/relay/wrangler.jsonc
+++ b/infra/relay/wrangler.jsonc
@@ -22,7 +22,7 @@
     // Public key only — the matching private key is a secret (RELAY_MINT_PRIVATE_JWK).
     "RELAY_MINT_PUBLIC_JWK": "{\"crv\":\"Ed25519\",\"x\":\"A2Ig1XwHKDznhyTbPD9IVTlJpaN4YImgQadx-Gl81Bs\",\"kty\":\"OKP\"}",
     "MAX_ENVIRONMENTS_PER_ACCOUNT": "5",
-    "ALLOWED_BROWSER_ORIGINS": "https://app.zuse.sh",
+    "ALLOWED_BROWSER_ORIGINS": "https://code.zuse.sh",
 
     // Managed Cloudflare tunnel provisioning. Set all four to enable per-Mac
     // tunnels; leave any unset to disable (the relay then advertises the LAN

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -1,8 +1,11 @@
-import { Rpc } from "effect/unstable/rpc";
 import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
 
 /** Public AuthKit client identifier shared by all Zuse clients. */
 export const WORKOS_PUBLIC_CLIENT_ID = "client_01KWGQ818571ARFATQ3G9AR2Y2";
+
+/** Canonical hosted product origin shared by Serve and browser clients. */
+export const HOSTED_APP_URL = "https://code.zuse.sh";
 
 /**
  * WorkOS AuthKit identity — the first user-account primitive in Zuse.
@@ -20,11 +23,11 @@ export const WORKOS_PUBLIC_CLIENT_ID = "client_01KWGQ818571ARFATQ3G9AR2Y2";
 
 /** Non-secret identity surfaced to the renderer for display. */
 export class AuthUser extends Schema.Class<AuthUser>("AuthUser")({
-  id: Schema.String,
-  email: Schema.String,
-  firstName: Schema.NullOr(Schema.String),
-  lastName: Schema.NullOr(Schema.String),
-  profilePictureUrl: Schema.NullOr(Schema.String),
+	id: Schema.String,
+	email: Schema.String,
+	firstName: Schema.NullOr(Schema.String),
+	lastName: Schema.NullOr(Schema.String),
+	profilePictureUrl: Schema.NullOr(Schema.String),
 }) {}
 
 /**
@@ -34,9 +37,9 @@ export class AuthUser extends Schema.Class<AuthUser>("AuthUser")({
  * (non-org) sign-ins.
  */
 export class AuthSession extends Schema.Class<AuthSession>("AuthSession")({
-  user: AuthUser,
-  organizationId: Schema.NullOr(Schema.String),
-  expiresAt: Schema.Number,
+	user: AuthUser,
+	organizationId: Schema.NullOr(Schema.String),
+	expiresAt: Schema.Number,
 }) {}
 
 /**
@@ -46,21 +49,21 @@ export class AuthSession extends Schema.Class<AuthSession>("AuthSession")({
  * sign-in / sign-out / refresh.
  */
 export const AuthState = Schema.Union([
-  Schema.TaggedStruct("SignedOut", {}),
-  Schema.TaggedStruct("SignedIn", { session: AuthSession }),
+	Schema.TaggedStruct("SignedOut", {}),
+	Schema.TaggedStruct("SignedIn", { session: AuthSession }),
 ]);
 export type AuthState = typeof AuthState.Type;
 
 /** The OAuth flow failed (config missing, network, token exchange, bad callback). */
 export class AuthFlowError extends Schema.TaggedErrorClass<AuthFlowError>()(
-  "AuthFlowError",
-  { reason: Schema.String },
+	"AuthFlowError",
+	{ reason: Schema.String },
 ) {}
 
 /** The user closed the browser / never completed sign-in before the timeout. */
 export class AuthCancelledError extends Schema.TaggedErrorClass<AuthCancelledError>()(
-  "AuthCancelledError",
-  {},
+	"AuthCancelledError",
+	{},
 ) {}
 
 // ---------------------------------------------------------------------------
@@ -73,8 +76,8 @@ export class AuthCancelledError extends Schema.TaggedErrorClass<AuthCancelledErr
  * `SignedOut` so the renderer can always render a definite state.
  */
 export const AuthGetSessionRpc = Rpc.make("auth.getSession", {
-  payload: Schema.Struct({}),
-  success: AuthState,
+	payload: Schema.Struct({}),
+	success: AuthState,
 });
 
 /**
@@ -84,15 +87,15 @@ export const AuthGetSessionRpc = Rpc.make("auth.getSession", {
  * `SignedIn` state.
  */
 export const AuthSignInRpc = Rpc.make("auth.signIn", {
-  payload: Schema.Struct({}),
-  success: AuthState,
-  error: Schema.Union([AuthFlowError, AuthCancelledError]),
+	payload: Schema.Struct({}),
+	success: AuthState,
+	error: Schema.Union([AuthFlowError, AuthCancelledError]),
 });
 
 /** Clear the stored session and broadcast `SignedOut`. */
 export const AuthSignOutRpc = Rpc.make("auth.signOut", {
-  payload: Schema.Struct({}),
-  success: Schema.Void,
+	payload: Schema.Struct({}),
+	success: Schema.Void,
 });
 
 /**
@@ -101,7 +104,7 @@ export const AuthSignOutRpc = Rpc.make("auth.signOut", {
  * call, a sign-out, or a background refresh all propagate to every view.
  */
 export const AuthSessionChangesRpc = Rpc.make("auth.sessionChanges", {
-  payload: Schema.Struct({}),
-  success: AuthState,
-  stream: true,
+	payload: Schema.Struct({}),
+	success: AuthState,
+	stream: true,
 });

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zusehq/serve",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "One-command remote access for Zuse workspaces",
 	"license": "MIT",
 	"type": "module",
@@ -28,7 +28,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zusehq/server": "0.1.0"
+		"@zusehq/server": "0.1.1"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",

--- a/packages/zusehq/package.json
+++ b/packages/zusehq/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zusehq",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Run and manage Zuse remote workspaces",
 	"license": "MIT",
 	"type": "module",
@@ -24,7 +24,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zusehq/serve": "0.1.0"
+		"@zusehq/serve": "0.1.1"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,19 @@
 	"buildCommand": "VITE_ZUSE_HOSTED=1 bun run --filter renderer build",
 	"outputDirectory": "apps/renderer/dist",
 	"framework": "vite",
+	"redirects": [
+		{
+			"source": "/:path*",
+			"has": [
+				{
+					"type": "host",
+					"value": "app.zuse.sh"
+				}
+			],
+			"destination": "https://code.zuse.sh/:path*",
+			"permanent": true
+		}
+	],
 	"rewrites": [
 		{
 			"source": "/(.*)",


### PR DESCRIPTION
## Summary

- make hosted browser connections use the production relay contract and canonical `code.zuse.sh` application URL
- report the installed Serve runtime version instead of the workspace package version
- let hosted Serve discover projects and resumable threads from the desktop application's canonical data directory
- bound and expire external thread discovery caches, including an immediate zero-limit fast path
- retain `app.zuse.sh` as the compatibility redirect while making `code.zuse.sh` the default

## Root cause

The background Serve process and the desktop application could resolve different data directories, so a remotely reachable host still appeared to have no projects and could not reliably resume desktop threads. The browser connection path also had relay/CORS and runtime-reporting mismatches that made a running tunnel appear unavailable.

## Impact

After updating to `zusehq@0.1.1`, a paired browser can reach the host, see desktop projects, and continue eligible threads. Discovery remains bounded under repeated requests and the account menu stays within the viewport.

## Validation

- `bun --filter @zusehq/server check-types`
- server test suite: 60 files, 393 tests passed
- focused external-thread discovery suite: 10 tests passed
- production builds for `@zusehq/server`, `@zusehq/serve`, and `zusehq`
- clean registry install of `zusehq@0.1.1` with all three package versions verified as `0.1.1`
- published CLI status: `runtimeVersion: 0.1.1`, `reachable: true`, `appUrl: https://code.zuse.sh`
- production browser smoke: project discovery, thread continuation, and account-menu placement
