### PR TITLE
Make Zuse Serve setup reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,29 @@ instructions are in [Install on Linux](#install-on-linux).
 
 ---
 
+## Zuse Serve
+
+Run coding agents on this computer and connect to it from
+[code.zuse.sh](https://code.zuse.sh):
+
+```bash
+npx zusehq serve
+```
+
+The command opens a device-authorization flow, installs a durable background
+service, and waits for the remote tunnel to register before reporting the
+computer as online. Check it at any time with:
+
+```bash
+npx zusehq serve status --json
+```
+
+Use the public `zusehq` package for setup and management. The
+`@zusehq/server` workspace is an internal runtime package and its development
+entrypoint only starts a loopback server.
+
+---
+
 ## License and acknowledgements
 
 Except where third-party terms apply, Zuse's source code is licensed under the

--- a/apps/server/src/serve/package-cli.ts
+++ b/apps/server/src/serve/package-cli.ts
@@ -29,6 +29,7 @@ import {
 	getServeServiceStatus,
 	installServeService,
 	resolveServeServicePaths,
+	startServeService,
 	stopServeService,
 	UnsupportedServiceManagerError,
 	uninstallServeService,
@@ -292,6 +293,27 @@ export const activateServeRuntimeUpdate = async (input: {
 export const removeServeRuntime = (dataDir: string): Promise<void> =>
 	rm(join(dataDir, "runtime"), { recursive: true, force: true });
 
+export const waitForRelayConfiguration = async (
+	dataDir: string,
+	timeoutMs = 45_000,
+	pollIntervalMs = 1_000,
+): Promise<LocalRelayConfig | null> => {
+	const deadline = Date.now() + timeoutMs;
+	let relay = readLocalRelayConfig(dataDir);
+	while (relay?.tunnelHostname === undefined && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+		relay = readLocalRelayConfig(dataDir);
+	}
+	return relay?.tunnelHostname === undefined ? null : relay;
+};
+
+const requireRemoteReadiness = async (dataDir: string): Promise<void> => {
+	if ((await waitForRelayConfiguration(dataDir)) !== null) return;
+	throw new Error(
+		"Zuse Serve started locally, but remote tunnel registration did not complete. Run `zusehq serve status --json` for diagnostics.",
+	);
+};
+
 const clearServeSession = (): Promise<void> =>
 	Effect.runPromise(
 		Effect.gen(function* () {
@@ -456,6 +478,23 @@ export const runServePackageCli = async (
 			},
 		}),
 	);
+	const current = await getServeServiceStatus(servicePaths);
+	if (current.installed && !current.running) {
+		await startServeService(servicePaths);
+		if (!(await waitForReachability(env))) {
+			throw new Error(
+				"Zuse Serve started, but its local readiness check failed. Run `zusehq serve status --json` for diagnostics.",
+			);
+		}
+		await requireRemoteReadiness(dataDir);
+		await printStatus(await getServeServiceStatus(servicePaths), {
+			json: false,
+			dataDir,
+			env,
+		});
+		return;
+	}
+
 	let installedExecutable: string;
 	try {
 		const packageVersion = options.packageVersion ?? "0.0.0";
@@ -487,9 +526,10 @@ export const runServePackageCli = async (
 	const reachable = await waitForReachability(env);
 	if (!reachable) {
 		throw new Error(
-			"Zuse Serve was installed, but the background host did not become reachable. Run `zuse serve status --json` for diagnostics.",
+			"Zuse Serve was installed, but the background host did not become reachable. Run `zusehq serve status --json` for diagnostics.",
 		);
 	}
+	await requireRemoteReadiness(dataDir);
 	await writeActiveServeRuntime(dataDir, {
 		version: options.packageVersion ?? "0.0.0",
 		executable: installedExecutable,

--- a/apps/server/test/unit/serve-relay-readiness.test.ts
+++ b/apps/server/test/unit/serve-relay-readiness.test.ts
@@ -1,0 +1,38 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import { waitForRelayConfiguration } from "../../src/serve/package-cli.ts";
+
+describe("Zuse Serve relay readiness", () => {
+	it("returns the configured environment after tunnel registration", async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), "zuse-relay-ready-"));
+		const database = new DatabaseSync(join(dataDir, "zuse.sqlite"));
+		database.exec(`
+			CREATE TABLE relay_config (
+				environment_id TEXT NOT NULL,
+				relay_url TEXT NOT NULL,
+				tunnel_hostname TEXT
+			);
+			INSERT INTO relay_config VALUES (
+				'env_test',
+				'https://relay.example.test',
+				'env-test.example.test'
+			);
+		`);
+		database.close();
+
+		await expect(waitForRelayConfiguration(dataDir, 50, 1)).resolves.toEqual({
+			environmentId: "env_test",
+			relayUrl: "https://relay.example.test",
+			tunnelHostname: "env-test.example.test",
+		});
+	});
+
+	it("times out while registration is absent", async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), "zuse-relay-missing-"));
+		await expect(waitForRelayConfiguration(dataDir, 5, 1)).resolves.toBeNull();
+	});
+});

--- a/packages/zusehq/package.json
+++ b/packages/zusehq/package.json
@@ -21,7 +21,9 @@
 	],
 	"scripts": {
 		"build": "vp pack src/bin.ts",
-		"check-types": "tsc --noEmit"
+		"check-types": "tsc --noEmit",
+		"test": "vp test run test/unit",
+		"test:unit": "vp test run test/unit"
 	},
 	"dependencies": {
 		"@zusehq/serve": "0.1.1"

--- a/packages/zusehq/src/bin.ts
+++ b/packages/zusehq/src/bin.ts
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
-import { runServeCli } from "@zusehq/serve/cli";
+import { assertSupportedNodeVersion } from "./node-version.js";
 
-runServeCli(process.argv.slice(2), process.env).catch((cause) => {
+const run = async (): Promise<void> => {
+	assertSupportedNodeVersion();
+	const { runServeCli } = await import("@zusehq/serve/cli");
+	await runServeCli(process.argv.slice(2), process.env);
+};
+
+run().catch((cause) => {
 	console.error(cause instanceof Error ? cause.message : String(cause));
 	process.exitCode = 1;
 });

--- a/packages/zusehq/src/node-version.ts
+++ b/packages/zusehq/src/node-version.ts
@@ -1,0 +1,17 @@
+export const MINIMUM_NODE_MAJOR = 22;
+
+export const nodeMajorVersion = (version: string): number | null => {
+	const [major] = version.replace(/^v/u, "").split(".");
+	if (major === undefined || !/^\d+$/u.test(major)) return null;
+	return Number(major);
+};
+
+export const assertSupportedNodeVersion = (
+	version: string = process.versions.node,
+): void => {
+	const major = nodeMajorVersion(version);
+	if (major !== null && major >= MINIMUM_NODE_MAJOR) return;
+	throw new Error(
+		`Zuse requires Node.js ${MINIMUM_NODE_MAJOR} or newer (current: ${version}). Install a current Node.js LTS release, then run \`npx zusehq serve\` again.`,
+	);
+};

--- a/packages/zusehq/test/unit/node-version.test.ts
+++ b/packages/zusehq/test/unit/node-version.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	assertSupportedNodeVersion,
+	nodeMajorVersion,
+} from "../../src/node-version.ts";
+
+describe("zusehq Node.js version guard", () => {
+	it("accepts supported Node.js releases", () => {
+		expect(() => assertSupportedNodeVersion("22.5.0")).not.toThrow();
+		expect(() => assertSupportedNodeVersion("24.18.1")).not.toThrow();
+	});
+
+	it("rejects old and malformed versions with actionable guidance", () => {
+		expect(() => assertSupportedNodeVersion("18.19.1")).toThrow(
+			/Node\.js 22 or newer.*npx zusehq serve/u,
+		);
+		expect(() => assertSupportedNodeVersion("unknown")).toThrow(
+			/current: unknown/u,
+		);
+	});
+
+	it("parses optional v-prefixed versions", () => {
+		expect(nodeMajorVersion("v24.18.1")).toBe(24);
+		expect(nodeMajorVersion("unknown")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- document the supported `npx zusehq serve` setup and status workflow
- reject unsupported Node.js versions before loading the Node 22-only server runtime
- wait for persisted relay/tunnel registration before reporting a new computer online
- point all Serve output at the canonical `https://code.zuse.sh` client

## Root cause

The repository documented Node 18 even though the Serve runtime imports `node:sqlite` and requires Node 22+. The public `zusehq` CLI also imported the server runtime before it could provide an actionable compatibility error. Separately, installation treated local HTTP reachability as sufficient readiness, so it could print `Status Online` while the relay configuration was still absent and the hosted browser correctly showed the computer as offline.

## Impact

Users now get the correct one-line command and a clear Node upgrade message. Fresh installations only report success after the remote tunnel is registered, making CLI output agree with the hosted client.

## Validation

- scoped Biome checks passed
- `bun run check-types` passed across 25 packages
- server unit suite passed: 38 files, 202 tests
- zusehq unit suite passed: 1 file, 3 tests
- zusehq package build passed
- built CLI executed under Node 18 and returned the actionable Node 22+ message before loading `node:sqlite`
