### PR TITLE
Bound diagnostic capture memory

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2714,6 +2714,7 @@ async function createMainWindow() {
 		Layer.launch(
 			makeMainLayer({
 				userData,
+				telemetryIdentity: { kind: "desktop", instance: "local" },
 				folderPicker,
 				serverProtocol,
 				additionalServerProtocols: [

--- a/apps/renderer/src/components/settings/diagnostics-pane.tsx
+++ b/apps/renderer/src/components/settings/diagnostics-pane.tsx
@@ -41,11 +41,15 @@ import {
 	DEFAULT_DIAGNOSTICS_PREFERENCES,
 	DIAGNOSTICS_PREFERENCES_KEY,
 	DIAGNOSTICS_RANGE_OPTIONS,
+	type DiagnosticsCaptureDuration,
 	type DiagnosticsPreferences,
 	type DiagnosticsSeverityFilter,
 	type DiagnosticsView,
+	diagnosticsCaptureErrorMessage,
+	diagnosticsCapturePayload,
 	diagnosticsSeveritySelection,
 	diagnosticsSince,
+	formatCaptureCountdown,
 	groupDiagnosticEvents,
 	parseDiagnosticsPreferences,
 	relatedDiagnosticEvents,
@@ -68,6 +72,13 @@ import {
 	FramePanel,
 	FrameTitle,
 } from "../ui/frame.tsx";
+import {
+	Select,
+	SelectItem,
+	SelectPopup,
+	SelectTrigger,
+	SelectValue,
+} from "../ui/select.tsx";
 
 const VIEW_OPTIONS: ReadonlyArray<{
 	readonly id: DiagnosticsView;
@@ -775,6 +786,10 @@ export function DiagnosticsPane() {
 	const [recordingBusy, setRecordingBusy] = useState<
 		"starting" | "stopping" | "exporting" | null
 	>(null);
+	const [captureDuration, setCaptureDuration] =
+		useState<DiagnosticsCaptureDuration>(5);
+	const [captureBusy, setCaptureBusy] = useState(false);
+	const [captureNow, setCaptureNow] = useState(Date.now());
 	const [selected, setSelected] = useState<DiagnosticEvent | null>(null);
 	const [selectedLagId, setSelectedLagId] = useState<string | null>(null);
 	const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
@@ -840,6 +855,12 @@ export function DiagnosticsPane() {
 			.catch(() => undefined);
 		return power.onState(setPowerState);
 	}, []);
+
+	useEffect(() => {
+		if (overview?.captureMode !== "full") return;
+		const timer = window.setInterval(() => setCaptureNow(Date.now()), 1_000);
+		return () => window.clearInterval(timer);
+	}, [overview?.captureMode]);
 
 	const refresh = useCallback(async () => {
 		setRefreshing(true);
@@ -1030,6 +1051,30 @@ export function DiagnosticsPane() {
 			);
 		} finally {
 			setExporting(false);
+		}
+	};
+
+	const updateCapture = async () => {
+		setCaptureBusy(true);
+		try {
+			const client = await getRpcClient();
+			const result = await Effect.runPromise(
+				client["diagnostics.capture"](
+					diagnosticsCapturePayload(
+						overview?.captureMode ?? "incident",
+						captureDuration,
+					),
+				),
+			);
+			setCaptureNow(Date.now());
+			setOverview((current) =>
+				current === null ? current : { ...current, ...result },
+			);
+			setError(null);
+		} catch (cause) {
+			setError(diagnosticsCaptureErrorMessage(cause));
+		} finally {
+			setCaptureBusy(false);
 		}
 	};
 
@@ -2221,7 +2266,7 @@ export function DiagnosticsPane() {
 								<p className="font-medium text-[10px]">Retention</p>
 								<p className="mt-1 font-mono text-sm tabular-nums">7 days</p>
 								<p className="mt-1 text-[9px] text-muted-foreground">
-									Events and one-minute resource rollups are pruned by age.
+									Incidents and five-minute operation rollups are pruned by age.
 								</p>
 							</div>
 							<div className="p-4">
@@ -2236,13 +2281,71 @@ export function DiagnosticsPane() {
 									Includes events and performance history on this device.
 								</p>
 							</div>
-							<div className="p-4">
-								<p className="font-medium text-[10px]">Capture</p>
-								<p className="mt-1 text-sm">
-									{overview?.capturePaused ? "Paused" : "Standard"}
-								</p>
-								<p className="mt-1 text-[9px] text-muted-foreground">
-									Secrets and conversation content are excluded by default.
+							<div className="min-h-[128px] p-4">
+								<div className="flex items-start justify-between gap-3">
+									<div>
+										<p className="font-medium text-[10px]">Incident capture</p>
+										<p className="mt-1 text-sm" aria-live="polite">
+											{overview?.captureMode === "full"
+												? "Full trace active"
+												: "On"}
+										</p>
+									</div>
+									{overview?.captureMode === "full" &&
+										overview.fullCaptureEndsAt && (
+											<span
+												className="font-mono text-[10px] text-warning tabular-nums"
+												role="timer"
+												aria-label="Full trace time remaining"
+											>
+												{formatCaptureCountdown(
+													overview.fullCaptureEndsAt,
+													captureNow,
+												)}
+											</span>
+										)}
+								</div>
+								<div className="mt-3 flex items-center gap-2">
+									<Select
+										value={String(captureDuration)}
+										disabled={captureBusy || overview?.captureMode === "full"}
+										onValueChange={(value) =>
+											setCaptureDuration(
+												Number(value) as DiagnosticsCaptureDuration,
+											)
+										}
+									>
+										<SelectTrigger
+											size="sm"
+											className="w-[78px] min-w-0"
+											aria-label="Full trace duration"
+										>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectPopup>
+											<SelectItem value="5">5 min</SelectItem>
+											<SelectItem value="15">15 min</SelectItem>
+											<SelectItem value="30">30 min</SelectItem>
+										</SelectPopup>
+									</Select>
+									<Button
+										size="sm"
+										variant={
+											overview?.captureMode === "full" ? "settings" : "default"
+										}
+										className="h-7 min-w-[104px] px-2.5 !text-[10px]"
+										loading={captureBusy}
+										disabled={overview === null || captureBusy}
+										onClick={() => void updateCapture()}
+									>
+										{overview?.captureMode === "full"
+											? "Stop full trace"
+											: "Start full trace"}
+									</Button>
+								</div>
+								<p className="mt-2 text-[9px] text-muted-foreground">
+									{formatCount.format(overview?.droppedEventCount ?? 0)} dropped
+									· Secrets and conversation content excluded.
 								</p>
 							</div>
 						</div>

--- a/apps/renderer/src/lib/diagnostics-view-model.ts
+++ b/apps/renderer/src/lib/diagnostics-view-model.ts
@@ -1,4 +1,8 @@
-import type { DiagnosticEvent, DiagnosticSeverity } from "@zuse/contracts";
+import type {
+	DiagnosticEvent,
+	DiagnosticSeverity,
+	DiagnosticsCapturePayload,
+} from "@zuse/contracts";
 
 export const DIAGNOSTICS_PREFERENCES_KEY =
 	"zuse.diagnostics.workspace-preferences.v1";
@@ -13,6 +17,35 @@ export const DIAGNOSTICS_VIEWS = [
 
 export type DiagnosticsView = (typeof DIAGNOSTICS_VIEWS)[number];
 export type DiagnosticsSeverityFilter = DiagnosticSeverity | "all";
+export type DiagnosticsCaptureDuration = Extract<
+	DiagnosticsCapturePayload,
+	{ readonly mode: "full" }
+>["durationMinutes"];
+
+export function diagnosticsCapturePayload(
+	mode: "incident" | "full",
+	durationMinutes: DiagnosticsCaptureDuration,
+): DiagnosticsCapturePayload {
+	return mode === "full"
+		? { mode: "incident" }
+		: { mode: "full", durationMinutes };
+}
+
+export function formatCaptureCountdown(endsAt: string, now: number): string {
+	const remainingSeconds = Math.max(
+		0,
+		Math.ceil((new Date(endsAt).getTime() - now) / 1_000),
+	);
+	const minutes = Math.floor(remainingSeconds / 60);
+	const seconds = remainingSeconds % 60;
+	return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export function diagnosticsCaptureErrorMessage(cause: unknown): string {
+	return cause instanceof Error
+		? cause.message
+		: "Diagnostic capture could not be changed.";
+}
 
 export type DiagnosticsPreferences = {
 	readonly view: DiagnosticsView;

--- a/apps/renderer/test/unit/diagnostics-view-model.test.ts
+++ b/apps/renderer/test/unit/diagnostics-view-model.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 
 import {
 	DEFAULT_DIAGNOSTICS_PREFERENCES,
+	diagnosticsCaptureErrorMessage,
+	diagnosticsCapturePayload,
 	diagnosticsSeveritySelection,
 	diagnosticsSince,
+	formatCaptureCountdown,
 	groupDiagnosticEvents,
 	parseDiagnosticsPreferences,
 	relatedDiagnosticEvents,
@@ -97,6 +100,37 @@ describe("diagnostics view model", () => {
 		);
 		expect(first).toBe("2026-07-29T11:00:00.000Z");
 		expect(second).toBe(first);
+	});
+
+	it("builds capture start and stop payloads and a stable expiry display", () => {
+		expect(diagnosticsCapturePayload("incident", 5)).toEqual({
+			mode: "full",
+			durationMinutes: 5,
+		});
+		expect(diagnosticsCapturePayload("full", 30)).toEqual({
+			mode: "incident",
+		});
+		expect(
+			formatCaptureCountdown(
+				"2026-08-03T12:05:00.000Z",
+				Date.parse("2026-08-03T12:00:01.000Z"),
+			),
+		).toBe("4:59");
+		expect(
+			formatCaptureCountdown(
+				"2026-08-03T12:00:00.000Z",
+				Date.parse("2026-08-03T12:00:01.000Z"),
+			),
+		).toBe("0:00");
+	});
+
+	it("keeps capture request errors actionable without exposing unknown values", () => {
+		expect(
+			diagnosticsCaptureErrorMessage(new Error("Capture unavailable")),
+		).toBe("Capture unavailable");
+		expect(diagnosticsCaptureErrorMessage({ secret: "hidden" })).toBe(
+			"Diagnostic capture could not be changed.",
+		);
 	});
 
 	it("groups repeated failures and preserves the newest representative", () => {

--- a/apps/server/src/app-paths.ts
+++ b/apps/server/src/app-paths.ts
@@ -1,5 +1,10 @@
 import { Context } from "effect";
 
+export interface TelemetryIdentity {
+	readonly kind: "desktop" | "serve";
+	readonly instance: string;
+}
+
 /**
  * OS-resolved paths the server needs at runtime. The Electron shim provides
  * the live values from `app.getPath("userData")`; a future headless server
@@ -7,8 +12,9 @@ import { Context } from "effect";
  * instead of importing electron themselves — that's the rule from ADR 0007.
  */
 export class AppPaths extends Context.Service<
-  AppPaths,
-  {
-    readonly userData: string;
-  }
+	AppPaths,
+	{
+		readonly userData: string;
+		readonly telemetryIdentity?: TelemetryIdentity;
+	}
 >()("memoize/AppPaths") {}

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -154,6 +154,7 @@ export const runHeadlessServer = (
 
 	const layer = makeMainLayer({
 		userData,
+		telemetryIdentity: { kind: "serve", instance: `${host}:${port}` },
 		// Headless has no native dialog; surfacing the prompt to a connected client
 		// is a later refinement. Returning null is the documented contract.
 		folderPicker: { pick: () => Effect.succeed(null) },

--- a/apps/server/src/diagnostics/handlers.ts
+++ b/apps/server/src/diagnostics/handlers.ts
@@ -37,6 +37,9 @@ const SignalProcess = MemoizeRpcs.toLayerHandler(
 const Ingest = MemoizeRpcs.toLayerHandler("diagnostics.ingest", (payload) =>
 	Effect.flatMap(DiagnosticsService, (svc) => svc.ingest(payload.events)),
 );
+const Capture = MemoizeRpcs.toLayerHandler("diagnostics.capture", (payload) =>
+	Effect.flatMap(DiagnosticsService, (svc) => svc.capture(payload)),
+);
 
 export const DiagnosticsHandlersLayer = Layer.mergeAll(
 	ExportBundle,
@@ -45,4 +48,5 @@ export const DiagnosticsHandlersLayer = Layer.mergeAll(
 	Processes,
 	SignalProcess,
 	Ingest,
+	Capture,
 );

--- a/apps/server/src/diagnostics/layers/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/layers/diagnostics-service.ts
@@ -1,21 +1,33 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import {
-	copyFileSync,
+	closeSync,
+	createReadStream,
 	existsSync,
 	mkdirSync,
+	openSync,
 	readdirSync,
 	readFileSync,
+	readSync,
 	statSync,
 	writeFileSync,
 } from "node:fs";
-import { appendFile, mkdir, rename, stat, unlink } from "node:fs/promises";
+import {
+	appendFile,
+	mkdir,
+	open,
+	rename,
+	stat,
+	unlink,
+} from "node:fs/promises";
 import { arch, platform, release } from "node:os";
 import { basename, join } from "node:path";
 import { promisify } from "node:util";
 import {
 	type AgentAvailability,
 	type DiagnosticEvent,
+	type DiagnosticsCapturePayload,
+	DiagnosticsCaptureResult,
 	DiagnosticsEventsResult,
 	DiagnosticsExportError,
 	DiagnosticsExportResult,
@@ -38,7 +50,7 @@ import {
 	sanitizeDiagnosticValue,
 } from "../diagnostics-model.ts";
 import { DiagnosticsService } from "../services/diagnostics-service.ts";
-import { createStoredZip } from "../zip-bundle.ts";
+import { writeStoredZip } from "../zip-bundle.ts";
 
 const MAX_RECENT_ERRORS = 20;
 const MAX_SESSION_EVENTS = 8;
@@ -47,6 +59,41 @@ const MAX_TEXT_PREVIEW = 240;
 const execFileAsync = promisify(execFile);
 const RUNTIME_RESOURCE_FILE_BYTES = 10 * 1024 * 1024;
 const RUNTIME_RESOURCE_FILE_COUNT = 3;
+const SUPPORT_READ_CHUNK_BYTES = 256 * 1024;
+
+function readNewestLinesSync(
+	path: string,
+	maxLines: number,
+	maxBytes: number,
+): { readonly lines: ReadonlyArray<string>; readonly truncated: boolean } {
+	const descriptor = openSync(path, "r");
+	try {
+		const fileSize = statSync(path).size;
+		let position = fileSize;
+		let bytesRead = 0;
+		let text = "";
+		while (position > 0 && bytesRead < maxBytes) {
+			const size = Math.min(
+				SUPPORT_READ_CHUNK_BYTES,
+				position,
+				maxBytes - bytesRead,
+			);
+			position -= size;
+			const buffer = Buffer.allocUnsafe(size);
+			const count = readSync(descriptor, buffer, 0, size, position);
+			text = buffer.subarray(0, count).toString("utf8") + text;
+			bytesRead += count;
+			if (text.split(/\r?\n/).length > maxLines + 1) break;
+		}
+		const allLines = text.split(/\r?\n/).filter(Boolean);
+		return {
+			lines: allLines.slice(-maxLines),
+			truncated: position > 0 || allLines.length > maxLines,
+		};
+	} finally {
+		closeSync(descriptor);
+	}
+}
 
 const diagnosticsError = (cause: unknown) =>
 	new DiagnosticsExportError({
@@ -165,9 +212,14 @@ async function readProcessTree(): Promise<DiagnosticsProcessesResult> {
 
 const appendRuntimeResourceSnapshot = async (
 	userData: string,
+	fileIdentity: string,
 	snapshot: DiagnosticsProcessesResult,
 ): Promise<void> => {
-	const path = join(userData, "logs", "diagnostics.runtime-resources.ndjson");
+	const path = join(
+		userData,
+		"logs",
+		`diagnostics.runtime-resources.${fileIdentity}.ndjson`,
+	);
 	await mkdir(join(userData, "logs"), { recursive: true });
 	const line = `${JSON.stringify({
 		kind: "runtime-processes",
@@ -251,53 +303,67 @@ const readPerformanceHistory = (
 	readonly parseErrors: number;
 	readonly truncated: boolean;
 } => {
-	const bases = [
-		join(userData, "logs", "diagnostics.host-resources.ndjson"),
-		join(userData, "logs", "diagnostics.runtime-resources.ndjson"),
-	];
-	const lines = bases
-		.flatMap((base) => [`${base}.2`, `${base}.1`, base])
-		.flatMap((path) => {
-			try {
-				return readFileSync(path, "utf8").split(/\r?\n/).filter(Boolean);
-			} catch {
-				return [];
-			}
-		});
-	let parseErrors = 0;
-	const parsed = lines.flatMap((line) => {
+	const bases = [join(userData, "logs", "diagnostics.host-resources.ndjson")];
+	const runtimePaths = (() => {
 		try {
-			const entry = JSON.parse(line) as {
-				readonly kind?: unknown;
-				readonly sample?: { readonly capturedAt?: unknown };
-			};
-			const capturedAt =
-				typeof entry.sample?.capturedAt === "string"
-					? entry.sample.capturedAt
-					: typeof (entry as { readonly capturedAt?: unknown }).capturedAt ===
-							"string"
-						? (entry as { readonly capturedAt: string }).capturedAt
-						: null;
-			if (
-				(entry.kind !== "sample" &&
-					entry.kind !== "lag" &&
-					entry.kind !== "runtime-processes") ||
-				capturedAt === null ||
-				(since !== undefined && capturedAt < since)
-			) {
-				return [];
-			}
-			return [sanitizeDiagnosticValue(entry)];
+			return readdirSync(join(userData, "logs"))
+				.filter((name) => name.startsWith("diagnostics.runtime-resources"))
+				.map((name) => join(userData, "logs", name));
 		} catch {
-			parseErrors += 1;
 			return [];
 		}
-	});
-	const entries = parsed.slice(-5_000);
+	})();
+	const candidates = [
+		...bases.flatMap((base) => [`${base}.2`, `${base}.1`, base]),
+		...runtimePaths,
+	];
+	let parseErrors = 0;
+	let truncated = false;
+	const entries: unknown[] = [];
+	for (const path of candidates) {
+		try {
+			const newest = readNewestLinesSync(
+				path,
+				5_000,
+				RUNTIME_RESOURCE_FILE_BYTES,
+			);
+			truncated ||= newest.truncated;
+			for (const line of newest.lines) {
+				try {
+					const entry = JSON.parse(line) as {
+						readonly kind?: unknown;
+						readonly sample?: { readonly capturedAt?: unknown };
+					};
+					const capturedAt =
+						typeof entry.sample?.capturedAt === "string"
+							? entry.sample.capturedAt
+							: typeof (entry as { readonly capturedAt?: unknown })
+										.capturedAt === "string"
+								? (entry as { readonly capturedAt: string }).capturedAt
+								: null;
+					if (
+						(entry.kind !== "sample" &&
+							entry.kind !== "lag" &&
+							entry.kind !== "runtime-processes") ||
+						capturedAt === null ||
+						(since !== undefined && capturedAt < since)
+					) {
+						continue;
+					}
+					entries.push(sanitizeDiagnosticValue(entry));
+					if (entries.length > 5_000) entries.splice(0, entries.length - 5_000);
+				} catch {
+					parseErrors += 1;
+				}
+			}
+		} catch {
+			// Missing resource history is normal.
+		}
+	}
 	return {
 		entries,
 		parseErrors,
-		truncated: parsed.length > entries.length,
+		truncated,
 	};
 };
 
@@ -406,9 +472,12 @@ function redactSessionEventFile(input: {
 	readonly projectId: string;
 	readonly path: string;
 }): SessionEventFile {
-	const text = readFileSync(input.path, "utf8");
-	const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
-	const events = lines.slice(-MAX_REDACTED_EVENTS_PER_FILE).flatMap((line) => {
+	const newest = readNewestLinesSync(
+		input.path,
+		MAX_REDACTED_EVENTS_PER_FILE,
+		5 * 1024 * 1024,
+	);
+	const events = newest.lines.flatMap((line) => {
 		try {
 			return [summarizeUnknown(JSON.parse(line) as unknown)];
 		} catch {
@@ -421,8 +490,8 @@ function redactSessionEventFile(input: {
 		projectId: input.projectId,
 		sessionId,
 		sourcePath: basename(input.path),
-		eventCount: lines.length,
-		truncated: lines.length > MAX_REDACTED_EVENTS_PER_FILE,
+		eventCount: newest.lines.length,
+		truncated: newest.truncated,
 		events,
 	};
 }
@@ -449,12 +518,45 @@ function prettyJson(value: unknown): string {
 	return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-function jsonByteLength(value: unknown): number {
-	return Buffer.byteLength(JSON.stringify(value));
-}
-
 function writeJson(path: string, value: unknown): void {
 	writeFileSync(path, prettyJson(value), "utf8");
+}
+
+async function writeDiagnosticEventsJson(
+	path: string,
+	input: {
+		readonly events: ReadonlyArray<DiagnosticEvent>;
+		readonly limit: number;
+		readonly truncated: boolean;
+		readonly truncatedEventCount: number;
+	},
+): Promise<void> {
+	const output = await open(path, "w");
+	try {
+		await output.write(
+			`{\n  "limit": ${input.limit},\n  "truncated": ${input.truncated},\n  "truncatedEventCount": ${input.truncatedEventCount},\n  "events": [`,
+		);
+		for (let index = 0; index < input.events.length; index += 100) {
+			const chunk = input.events
+				.slice(index, index + 100)
+				.map((event) => JSON.stringify(event))
+				.join(",\n    ");
+			await output.write(`${index === 0 ? "\n    " : ",\n    "}${chunk}`);
+		}
+		await output.write(`${input.events.length === 0 ? "" : "\n  "}]\n}\n`);
+	} finally {
+		await output.close();
+	}
+}
+
+async function sha256File(path: string): Promise<string> {
+	const hash = createHash("sha256");
+	for await (const chunk of createReadStream(path, {
+		highWaterMark: 64 * 1024,
+	})) {
+		hash.update(chunk as Buffer);
+	}
+	return hash.digest("hex");
 }
 
 function buildSummary(input: {
@@ -491,7 +593,11 @@ export const DiagnosticsServiceLive = Layer.effect(
 		const runtimeResourceTimer = setInterval(() => {
 			void readProcessTree()
 				.then((snapshot) =>
-					appendRuntimeResourceSnapshot(paths.userData, snapshot),
+					appendRuntimeResourceSnapshot(
+						paths.userData,
+						telemetry.fileIdentity,
+						snapshot,
+					),
 				)
 				.catch(() => undefined);
 		}, 60_000);
@@ -516,7 +622,8 @@ export const DiagnosticsServiceLive = Layer.effect(
 
 		const overview = (payload: { readonly since?: string }) =>
 			Effect.gen(function* () {
-				const version = telemetry.version();
+				const captureState = telemetry.captureState();
+				const version = telemetry.overviewVersion();
 				if (
 					overviewCache?.version === version &&
 					overviewCache.since === payload.since
@@ -525,7 +632,10 @@ export const DiagnosticsServiceLive = Layer.effect(
 				}
 				const all = telemetry.snapshot();
 				const events = filterDiagnosticEvents(all, { since: payload.since });
-				const aggregate = aggregateDiagnostics(events);
+				const aggregate = {
+					...aggregateDiagnostics(events),
+					topOperations: telemetry.operationSummaries(payload.since),
+				};
 				const storageBytes = yield* telemetry.storageBytes;
 				const status =
 					aggregate.fatalCount > 0 || aggregate.errorCount > 3
@@ -542,6 +652,9 @@ export const DiagnosticsServiceLive = Layer.effect(
 					unseenCount: aggregate.errorCount + aggregate.fatalCount,
 					storageBytes,
 					capturePaused: false,
+					...captureState,
+					droppedEventCount: telemetry.droppedEventCount(),
+					truncatedEventCount: telemetry.truncatedEventCount(),
 					previousRunUnclean: events.some(
 						(event) => event.source === "main.previousRunUnclean",
 					),
@@ -549,6 +662,14 @@ export const DiagnosticsServiceLive = Layer.effect(
 				overviewCache = { since: payload.since, version, value };
 				return value;
 			}).pipe(Effect.mapError(diagnosticsError));
+
+		const capture = (payload: DiagnosticsCapturePayload) =>
+			telemetry.setCapture(payload).pipe(
+				Effect.map(() =>
+					DiagnosticsCaptureResult.make(telemetry.captureState()),
+				),
+				Effect.mapError(diagnosticsError),
+			);
 
 		const events = (payload: {
 			readonly cursor?: string;
@@ -672,10 +793,16 @@ export const DiagnosticsServiceLive = Layer.effect(
 					});
 				}
 
-				const diagnosticEvents = filterDiagnosticEvents(telemetry.snapshot(), {
+				const exportedEvents = yield* telemetry.exportEvents({
 					since: payload.since,
 				});
-				const diagnosticAggregate = aggregateDiagnostics(diagnosticEvents);
+				const exportedOperationSummaries =
+					yield* telemetry.exportOperationSummaries(payload.since);
+				const diagnosticEvents = exportedEvents.events;
+				const diagnosticAggregate = {
+					...aggregateDiagnostics(diagnosticEvents),
+					topOperations: exportedOperationSummaries,
+				};
 				const traceSummary = {
 					latestFailures,
 					slowestSpans: diagnosticAggregate.slowestOperations,
@@ -685,6 +812,7 @@ export const DiagnosticsServiceLive = Layer.effect(
 							: [...commonFailureMap.values()].sort(
 									(left, right) => right.count - left.count,
 								),
+					operationSummaries: diagnosticAggregate.topOperations,
 				};
 				const recentErrors = {
 					errors: latestFailures,
@@ -737,13 +865,18 @@ export const DiagnosticsServiceLive = Layer.effect(
 				const performanceRecording = readLatestPerformanceRecording(
 					paths.userData,
 				);
+				const diagnosticEventsArtifact = {
+					events: diagnosticEvents,
+					limit: 25_000,
+					truncated: exportedEvents.truncated > 0,
+					truncatedEventCount: exportedEvents.truncated,
+				};
 				const artifacts: Record<string, unknown> = {
 					"trace-summary": traceSummary,
 					"recent-errors": recentErrors,
 					environment,
 					"provider-status": providerStatus,
 					"redacted-session-events": sessionEvents,
-					"diagnostic-events": { events: diagnosticEvents },
 					"performance-history": performanceHistory,
 					"process-snapshot": processSnapshot,
 					"redaction-report": redactionReport,
@@ -757,12 +890,6 @@ export const DiagnosticsServiceLive = Layer.effect(
 					);
 				}
 
-				const artifactSizes = Object.fromEntries(
-					Object.entries(artifacts).map(([name, artifact]) => [
-						name,
-						jsonByteLength(artifact),
-					]),
-				);
 				const diagnosticWarnings = [
 					latestFailures.length === 0
 						? "No persisted message errors were captured."
@@ -770,18 +897,10 @@ export const DiagnosticsServiceLive = Layer.effect(
 					payload.clientContext === undefined
 						? "No renderer client context was provided."
 						: null,
+					exportedEvents.truncated > 0
+						? `${exportedEvents.truncated} older diagnostic events were omitted.`
+						: null,
 				].filter((warning): warning is string => warning !== null);
-				const bundleSummary = {
-					diagnosticId,
-					generatedFor: "github-bug-report",
-					attachFileToIssue: true,
-					pasteJsonOnlyIfAttachmentFails: true,
-					artifactSizes,
-					diagnosticWarnings,
-				};
-				artifacts["bundle-summary"] = bundleSummary;
-				artifactSizes["bundle-summary"] = jsonByteLength(bundleSummary);
-
 				const included: ExtendedBundleArtifactName[] = [
 					"manifest",
 					"bundle-summary",
@@ -817,72 +936,84 @@ export const DiagnosticsServiceLive = Layer.effect(
 					latestFailures,
 					providerCount: providers.length,
 				});
-				const report = Buffer.from(
-					`# Diagnostic report\n\n\`\`\`\n${summary}\n\`\`\`\n`,
-				);
-				const artifactEntries = Object.entries(artifacts).map(
-					([name, artifact]) => ({
-						name: `${name}.json`,
-						data: Buffer.from(prettyJson(artifact)),
-					}),
-				);
-				const checksums = Object.fromEntries(
-					[{ name: "REPORT.md", data: report }, ...artifactEntries].map(
-						(entry) => [
-							entry.name,
-							createHash("sha256").update(entry.data).digest("hex"),
-						],
-					),
-				);
-				const manifest = {
-					app: "zuse",
-					version: packageJson.version,
-					createdAt: createdAt.toISOString(),
-					platform: `${platform()}-${arch()}`,
-					diagnosticId,
-					included,
-					redaction: {
-						default:
-							"content fields are excluded or summarized without previews",
-						rawPromptsIncluded: false,
-						rawTranscriptsIncluded: false,
-					},
-					checksums,
-				};
-
-				yield* Effect.try(() => {
-					writeJson(join(bundleDir, "manifest.json"), manifest);
-					writeJson(join(bundleDir, "bundle-summary.json"), bundleSummary);
-					writeJson(join(bundleDir, "trace-summary.json"), traceSummary);
-					writeJson(join(bundleDir, "recent-errors.json"), recentErrors);
-					writeJson(join(bundleDir, "environment.json"), environment);
-					writeJson(join(bundleDir, "provider-status.json"), providerStatus);
-					if (payload.clientContext !== undefined) {
-						writeJson(
-							join(bundleDir, "client-context.json"),
-							artifacts["client-context"],
-						);
+				yield* Effect.tryPromise(async () => {
+					const artifactFiles: Array<{ name: string; path: string }> = [];
+					for (const [name, artifact] of Object.entries(artifacts)) {
+						const artifactPath = join(bundleDir, `${name}.json`);
+						writeJson(artifactPath, artifact);
+						artifactFiles.push({ name: `${name}.json`, path: artifactPath });
 					}
-					writeJson(
-						join(bundleDir, "session-events-redacted.json"),
-						sessionEvents,
+					const diagnosticEventsPath = join(
+						bundleDir,
+						"diagnostic-events.json",
 					);
-				});
+					await writeDiagnosticEventsJson(
+						diagnosticEventsPath,
+						diagnosticEventsArtifact,
+					);
+					artifactFiles.push({
+						name: "diagnostic-events.json",
+						path: diagnosticEventsPath,
+					});
+					const reportPath = join(bundleDir, "REPORT.md");
+					writeFileSync(
+						reportPath,
+						`# Diagnostic report\n\n\`\`\`\n${summary}\n\`\`\`\n`,
+						"utf8",
+					);
+					artifactFiles.push({ name: "REPORT.md", path: reportPath });
 
-				yield* Effect.try(() => {
-					const entries = [
-						{
-							name: "manifest.json",
-							data: Buffer.from(prettyJson(manifest)),
+					const artifactSizes = Object.fromEntries(
+						await Promise.all(
+							artifactFiles.map(
+								async (entry) =>
+									[entry.name, (await stat(entry.path)).size] as const,
+							),
+						),
+					);
+					const bundleSummary = {
+						diagnosticId,
+						generatedFor: "github-bug-report",
+						attachFileToIssue: true,
+						pasteJsonOnlyIfAttachmentFails: true,
+						artifactSizes,
+						diagnosticWarnings,
+					};
+					const bundleSummaryPath = join(bundleDir, "bundle-summary.json");
+					writeJson(bundleSummaryPath, bundleSummary);
+					artifactFiles.push({
+						name: "bundle-summary.json",
+						path: bundleSummaryPath,
+					});
+					const checksums = Object.fromEntries(
+						await Promise.all(
+							artifactFiles.map(
+								async (entry) =>
+									[entry.name, await sha256File(entry.path)] as const,
+							),
+						),
+					);
+					const manifest = {
+						app: "zuse",
+						version: packageJson.version,
+						createdAt: createdAt.toISOString(),
+						platform: `${platform()}-${arch()}`,
+						diagnosticId,
+						included,
+						redaction: {
+							default:
+								"content fields are excluded or summarized without previews",
+							rawPromptsIncluded: false,
+							rawTranscriptsIncluded: false,
 						},
-						{
-							name: "REPORT.md",
-							data: report,
-						},
-						...artifactEntries,
-					];
-					writeFileSync(bundlePath, createStoredZip(entries));
-					copyFileSync(bundlePath, join(bundleDir, basename(bundlePath)));
+						checksums,
+					};
+					const manifestPath = join(bundleDir, "manifest.json");
+					writeJson(manifestPath, manifest);
+					await writeStoredZip(bundlePath, [
+						{ name: "manifest.json", path: manifestPath },
+						...artifactFiles,
+					]);
 				});
 				return DiagnosticsExportResult.make({
 					diagnosticId,
@@ -907,6 +1038,7 @@ export const DiagnosticsServiceLive = Layer.effect(
 			overview,
 			events,
 			ingest,
+			capture,
 			processes,
 			signalProcess,
 			exportBundle,

--- a/apps/server/src/diagnostics/services/diagnostics-service.ts
+++ b/apps/server/src/diagnostics/services/diagnostics-service.ts
@@ -1,6 +1,8 @@
 import type {
 	DiagnosticEvent,
 	DiagnosticSeverity,
+	DiagnosticsCapturePayload,
+	DiagnosticsCaptureResult,
 	DiagnosticsEventsResult,
 	DiagnosticsExportError,
 	DiagnosticsExportResult,
@@ -25,6 +27,9 @@ export interface DiagnosticsServiceShape {
 	readonly ingest: (
 		events: ReadonlyArray<DiagnosticEvent>,
 	) => Effect.Effect<void, DiagnosticsExportError>;
+	readonly capture: (
+		payload: DiagnosticsCapturePayload,
+	) => Effect.Effect<DiagnosticsCaptureResult, DiagnosticsExportError>;
 	readonly processes: Effect.Effect<
 		DiagnosticsProcessesResult,
 		DiagnosticsExportError

--- a/apps/server/src/diagnostics/zip-bundle.ts
+++ b/apps/server/src/diagnostics/zip-bundle.ts
@@ -1,3 +1,6 @@
+import { createReadStream } from "node:fs";
+import { open, stat } from "node:fs/promises";
+
 export interface ZipEntry {
 	readonly name: string;
 	readonly data: Buffer;
@@ -16,6 +19,79 @@ function crc32(data: Buffer): number {
 	for (const byte of data)
 		crc = (crc >>> 8) ^ (CRC_TABLE[(crc ^ byte) & 0xff] ?? 0);
 	return (crc ^ 0xffffffff) >>> 0;
+}
+
+async function fileCrc32(path: string): Promise<number> {
+	let crc = 0xffffffff;
+	for await (const chunk of createReadStream(path, {
+		highWaterMark: 64 * 1024,
+	})) {
+		for (const byte of chunk as Buffer)
+			crc = (crc >>> 8) ^ (CRC_TABLE[(crc ^ byte) & 0xff] ?? 0);
+	}
+	return (crc ^ 0xffffffff) >>> 0;
+}
+
+export interface ZipFileEntry {
+	readonly name: string;
+	readonly path: string;
+}
+
+export async function writeStoredZip(
+	path: string,
+	entries: ReadonlyArray<ZipFileEntry>,
+	options?: { readonly onArtifactChunk?: (bytes: number) => void },
+): Promise<void> {
+	const output = await open(path, "w");
+	const centralParts: Buffer[] = [];
+	let offset = 0;
+	try {
+		for (const entry of entries) {
+			const [file, checksum] = await Promise.all([
+				stat(entry.path),
+				fileCrc32(entry.path),
+			]);
+			const name = Buffer.from(entry.name.replaceAll("\\", "/"), "utf8");
+			const localHeader = Buffer.alloc(30);
+			localHeader.writeUInt32LE(0x04034b50, 0);
+			localHeader.writeUInt16LE(20, 4);
+			localHeader.writeUInt32LE(checksum, 14);
+			localHeader.writeUInt32LE(file.size, 18);
+			localHeader.writeUInt32LE(file.size, 22);
+			localHeader.writeUInt16LE(name.length, 26);
+			await output.write(localHeader);
+			await output.write(name);
+			for await (const chunk of createReadStream(entry.path, {
+				highWaterMark: 64 * 1024,
+			})) {
+				options?.onArtifactChunk?.((chunk as Buffer).length);
+				await output.write(chunk as Buffer);
+			}
+
+			const centralHeader = Buffer.alloc(46);
+			centralHeader.writeUInt32LE(0x02014b50, 0);
+			centralHeader.writeUInt16LE(20, 4);
+			centralHeader.writeUInt16LE(20, 6);
+			centralHeader.writeUInt32LE(checksum, 16);
+			centralHeader.writeUInt32LE(file.size, 20);
+			centralHeader.writeUInt32LE(file.size, 24);
+			centralHeader.writeUInt16LE(name.length, 28);
+			centralHeader.writeUInt32LE(offset, 42);
+			centralParts.push(centralHeader, name);
+			offset += localHeader.length + name.length + file.size;
+		}
+		const centralDirectory = Buffer.concat(centralParts);
+		await output.write(centralDirectory);
+		const end = Buffer.alloc(22);
+		end.writeUInt32LE(0x06054b50, 0);
+		end.writeUInt16LE(entries.length, 8);
+		end.writeUInt16LE(entries.length, 10);
+		end.writeUInt32LE(centralDirectory.length, 12);
+		end.writeUInt32LE(offset, 16);
+		await output.write(end);
+	} finally {
+		await output.close();
+	}
 }
 
 export function createStoredZip(entries: ReadonlyArray<ZipEntry>): Buffer {

--- a/apps/server/src/observability/telemetry-layer.ts
+++ b/apps/server/src/observability/telemetry-layer.ts
@@ -1,12 +1,4 @@
-import {
-	Cause,
-	Duration,
-	Effect,
-	Exit,
-	Layer,
-	type Option,
-	Tracer,
-} from "effect";
+import { Cause, Duration, Effect, Exit, Layer, Option, Tracer } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import {
 	OtlpExporter,
@@ -69,17 +61,27 @@ class TelemetrySpan implements Tracer.Span {
 	}
 
 	end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+		const failure = Exit.isFailure(exit)
+			? Cause.findErrorOption(exit.cause)
+			: undefined;
+		const normalStreamCompletion =
+			failure !== undefined &&
+			Option.isSome(failure) &&
+			Cause.isDone(failure.value);
+		const diagnosticExit = normalStreamCompletion
+			? Exit.succeed(undefined)
+			: exit;
 		this.status = {
 			_tag: "Ended",
 			startTime: this.options.startTime,
 			endTime,
-			exit,
+			exit: diagnosticExit,
 		};
 		this.delegate.end(
 			endTime,
-			Exit.isSuccess(exit)
-				? exit
-				: Exit.fail(telemetryCauseSummary(exit.cause).type),
+			Exit.isSuccess(diagnosticExit)
+				? diagnosticExit
+				: Exit.fail(telemetryCauseSummary(diagnosticExit.cause).type),
 		);
 		const durationMs =
 			Number(
@@ -87,19 +89,24 @@ class TelemetrySpan implements Tracer.Span {
 					? endTime - this.options.startTime
 					: 0n,
 			) / 1_000_000;
-		const outcome = Exit.isSuccess(exit)
-			? "success"
-			: Cause.hasInterruptsOnly(exit.cause)
-				? "interrupted"
-				: "failure";
+		const outcome = normalStreamCompletion
+			? "done"
+			: Exit.isSuccess(exit)
+				? "success"
+				: Cause.hasInterruptsOnly(exit.cause)
+					? "interrupted"
+					: "failure";
 		recordOperationMetrics({
 			operation: this.name,
 			category: telemetryCategoryForSpan(this.name),
-			outcome,
+			outcome: outcome === "done" ? "success" : outcome,
 			durationMs,
 			context: this.annotations,
 		});
+		const operation = { name: this.name, outcome, durationMs } as const;
+		this.store.recordOperation(operation);
 		if (!this.sampled || !shouldRecordLocally(this.name)) return;
+		if (!this.store.shouldRecordOperation(operation)) return;
 		this.store.record(
 			telemetryEventFromSpan({
 				name: this.name,
@@ -107,7 +114,7 @@ class TelemetrySpan implements Tracer.Span {
 				spanId: this.spanId,
 				startTime: this.options.startTime,
 				endTime,
-				exit,
+				exit: diagnosticExit,
 				attributes: this.attributes,
 				runId: this.store.runId,
 			}),

--- a/apps/server/src/observability/telemetry-store.ts
+++ b/apps/server/src/observability/telemetry-store.ts
@@ -1,17 +1,25 @@
-import { existsSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { createReadStream, existsSync, statSync } from "node:fs";
 import {
 	appendFile,
 	mkdir,
+	open,
+	readdir,
 	readFile,
 	rename,
 	stat,
 	unlink,
+	writeFile,
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { createInterface } from "node:readline";
 
 import {
+	type DiagnosticCaptureMode,
 	type DiagnosticEvent,
 	DiagnosticEvent as DiagnosticEventSchema,
+	type DiagnosticRuntimeKind,
+	type DiagnosticsCapturePayload,
 } from "@zuse/contracts";
 import { Context, Duration, Effect, Layer, Schema } from "effect";
 
@@ -21,100 +29,168 @@ import {
 	sanitizeDiagnosticText,
 } from "../diagnostics/diagnostics-model.ts";
 
-const MAX_EVENTS = 100_000;
-const MAX_FILE_BYTES = 20 * 1024 * 1024;
-const FILE_COUNT = 5;
+export const INCIDENT_EVENT_LIMIT = 5_000;
+export const FULL_TRACE_EVENT_LIMIT = 20_000;
+export const FULL_TRACE_BYTE_LIMIT = 10 * 1024 * 1024;
+export const SUPPORT_EVENT_LIMIT = 25_000;
+const INCIDENT_FILE_BYTES = 5 * 1024 * 1024;
+const INCIDENT_FILE_COUNT = 3;
 const RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+const ROLLUP_INTERVAL_MS = 5 * 60 * 1_000;
+const MAX_ROLLUPS = RETENTION_MS / ROLLUP_INTERVAL_MS;
+const MAX_OPERATIONS_PER_ROLLUP = 64;
 const PERSIST_BATCH_MS = 250;
-const PERSIST_BATCH_SIZE = 500;
-const MAX_PENDING_PERSISTENCE_EVENTS = 5_000;
+const PERSIST_BATCH_SIZE = 250;
+const MAX_PENDING_PERSISTENCE_EVENTS = 1_000;
+const READ_CHUNK_BYTES = 256 * 1024;
+const ROLLUP_FILE_BYTES = 32 * 1024 * 1024;
+const DURATION_BUCKETS = [
+	10,
+	25,
+	50,
+	100,
+	250,
+	500,
+	1_000,
+	2_500,
+	5_000,
+	10_000,
+	30_000,
+	60_000,
+	120_000,
+	300_000,
+	600_000,
+	1_800_000,
+	3_600_000,
+	21_600_000,
+	86_400_000,
+	Number.MAX_SAFE_INTEGER,
+];
+
+export type TelemetryOperationOutcome =
+	| "success"
+	| "failure"
+	| "interrupted"
+	| "done";
+
+export interface TelemetryOperation {
+	readonly name: string;
+	readonly durationMs: number;
+	readonly outcome: TelemetryOperationOutcome;
+}
+
+export interface OperationSummary {
+	readonly name: string;
+	readonly count: number;
+	readonly failureCount: number;
+	readonly averageDurationMs: number;
+	readonly p95DurationMs: number;
+	readonly maxDurationMs: number;
+}
+
+interface OperationCell {
+	count: number;
+	failureCount: number;
+	totalDurationMs: number;
+	maxDurationMs: number;
+	durationBuckets: number[];
+}
+
+interface OperationRollup {
+	readonly bucketStart: number;
+	readonly operations: Record<string, OperationCell>;
+	readonly migrationSource?: string;
+}
+
+interface PersistedEvent {
+	readonly path: string;
+	readonly event: DiagnosticEvent;
+}
 
 class EventRingBuffer {
-	private readonly values: Array<DiagnosticEvent | undefined>;
+	private readonly values: Array<
+		{ readonly event: DiagnosticEvent; readonly bytes: number } | undefined
+	>;
 	private start = 0;
 	private length = 0;
+	private bytes = 0;
 
 	constructor(
 		private readonly capacity: number,
-		initial: ReadonlyArray<DiagnosticEvent>,
+		private readonly byteCapacity = Number.POSITIVE_INFINITY,
 	) {
 		this.values = new Array(capacity);
-		this.pushMany(initial);
 	}
 
-	pushMany(events: ReadonlyArray<DiagnosticEvent>): void {
+	clear(): void {
+		this.values.fill(undefined);
+		this.start = 0;
+		this.length = 0;
+		this.bytes = 0;
+	}
+
+	pushMany(events: ReadonlyArray<DiagnosticEvent>): number {
+		let dropped = 0;
 		for (const event of events) {
-			const index = (this.start + this.length) % this.capacity;
-			this.values[index] = event;
-			if (this.length < this.capacity) {
-				this.length += 1;
-			} else {
-				this.start = (this.start + 1) % this.capacity;
+			const bytes = Buffer.byteLength(JSON.stringify(event)) + 1;
+			if (bytes > this.byteCapacity) {
+				dropped += 1;
+				continue;
 			}
+			while (
+				this.length > 0 &&
+				(this.length >= this.capacity || this.bytes + bytes > this.byteCapacity)
+			) {
+				const removed = this.values[this.start];
+				if (removed !== undefined) this.bytes -= removed.bytes;
+				this.values[this.start] = undefined;
+				this.start = (this.start + 1) % this.capacity;
+				this.length -= 1;
+				dropped += 1;
+			}
+			const index = (this.start + this.length) % this.capacity;
+			this.values[index] = { event, bytes };
+			this.length += 1;
+			this.bytes += bytes;
 		}
+		return dropped;
 	}
 
 	snapshot(): ReadonlyArray<DiagnosticEvent> {
 		const snapshot: DiagnosticEvent[] = [];
 		for (let offset = 0; offset < this.length; offset += 1) {
 			const value = this.values[(this.start + offset) % this.capacity];
-			if (value !== undefined) snapshot.push(value);
+			if (value !== undefined) snapshot.push(value.event);
 		}
 		return snapshot;
 	}
 }
 
 const retainedPaths = (path: string): ReadonlyArray<string> =>
-	Array.from({ length: FILE_COUNT }, (_, index) =>
+	Array.from({ length: INCIDENT_FILE_COUNT }, (_, index) =>
 		index === 0 ? path : `${path}.${index}`,
 	);
 
-const loadEvents = async (
-	path: string,
-): Promise<{ events: DiagnosticEvent[]; parseErrors: number }> => {
-	let parseErrors = 0;
-	const lines: string[] = [];
-	for (const file of [...retainedPaths(path)].reverse()) {
-		try {
-			const fileStat = await stat(file);
-			if (Date.now() - fileStat.mtimeMs > RETENTION_MS) {
-				await unlink(file).catch(() => undefined);
-				continue;
-			}
-			lines.push(...(await readFile(file, "utf8")).split(/\r?\n/));
-		} catch {
-			// Missing or unreadable telemetry files do not affect startup.
-		}
-	}
-	const offlinePath = join(dirname(path), "diagnostics.offline.ndjson");
-	try {
-		const offline = await readFile(offlinePath, "utf8");
-		if (offline.trim().length > 0) {
-			await mkdir(dirname(path), { recursive: true });
-			await appendFile(path, offline.endsWith("\n") ? offline : `${offline}\n`);
-			lines.push(...offline.split(/\r?\n/));
-		}
-		await unlink(offlinePath).catch(() => undefined);
-	} catch {
-		// An absent offline crash file is the normal path.
-	}
-	const events = lines
-		.filter(Boolean)
-		.slice(-MAX_EVENTS)
-		.flatMap((line) => {
-			try {
-				return [
-					Schema.decodeUnknownSync(DiagnosticEventSchema)(JSON.parse(line)),
-				];
-			} catch {
-				parseErrors += 1;
-				return [];
-			}
-		});
-	return { events, parseErrors };
-};
+const isIncidentEvent = (event: DiagnosticEvent): boolean =>
+	event.severity === "warn" ||
+	event.severity === "error" ||
+	event.severity === "fatal" ||
+	(event.durationMs ?? 0) >= 1_000;
 
-const sanitizeEvent = (event: DiagnosticEvent): DiagnosticEvent => {
+export const shouldPersistOperationEvent = (
+	operation: TelemetryOperation,
+	captureMode: DiagnosticCaptureMode,
+): boolean =>
+	captureMode === "full" ||
+	operation.outcome === "failure" ||
+	operation.outcome === "interrupted" ||
+	(operation.outcome !== "done" && operation.durationMs >= 1_000);
+
+const sanitizeEvent = (
+	event: DiagnosticEvent,
+	runtimeKind: DiagnosticRuntimeKind,
+	captureMode: DiagnosticCaptureMode,
+): DiagnosticEvent => {
 	const message = sanitizeDiagnosticText(event.message);
 	const detail =
 		event.detail === undefined
@@ -129,7 +205,135 @@ const sanitizeEvent = (event: DiagnosticEvent): DiagnosticEvent => {
 			category: event.category,
 			message,
 		}),
+		runtimeKind: event.runtimeKind ?? runtimeKind,
+		captureMode: event.captureMode ?? captureMode,
 	};
+};
+
+export const telemetryFileIdentity = (
+	kind: DiagnosticRuntimeKind,
+	instance: string,
+): string =>
+	`${kind}-${createHash("sha256").update(instance).digest("hex").slice(0, 12)}`;
+
+export const legacyMigrationSource = (
+	path: string,
+	size: number,
+	mtimeMs: number,
+): string =>
+	createHash("sha256")
+		.update(`${path}:${size}:${mtimeMs}`)
+		.digest("hex")
+		.slice(0, 24);
+
+const parseEventLine = (
+	line: string,
+): { readonly event?: DiagnosticEvent; readonly parseError: boolean } => {
+	try {
+		return {
+			event: Schema.decodeUnknownSync(DiagnosticEventSchema)(JSON.parse(line)),
+			parseError: false,
+		};
+	} catch {
+		return { parseError: true };
+	}
+};
+
+const readNewestLines = async (
+	path: string,
+	maxLines: number,
+	maxBytes: number,
+): Promise<string[]> => {
+	const handle = await open(path, "r");
+	try {
+		const file = await handle.stat();
+		let position = file.size;
+		let bytesRead = 0;
+		let text = "";
+		while (position > 0 && bytesRead < maxBytes) {
+			const size = Math.min(READ_CHUNK_BYTES, position, maxBytes - bytesRead);
+			position -= size;
+			const buffer = Buffer.allocUnsafe(size);
+			const result = await handle.read(buffer, 0, size, position);
+			text = buffer.subarray(0, result.bytesRead).toString("utf8") + text;
+			bytesRead += result.bytesRead;
+			const lines = text.split(/\r?\n/);
+			if (lines.length > maxLines + 1) break;
+		}
+		return text.split(/\r?\n/).filter(Boolean).slice(-maxLines);
+	} finally {
+		await handle.close();
+	}
+};
+
+const isRetainedEvent = (event: DiagnosticEvent, now = Date.now()): boolean => {
+	const createdAt = Date.parse(event.createdAt);
+	return Number.isFinite(createdAt) && now - createdAt <= RETENTION_MS;
+};
+
+const compactEventFile = async (
+	path: string,
+	cutoff: number,
+): Promise<void> => {
+	if (!existsSync(path)) return;
+	const temporaryPath = `${path}.${process.pid}.retention.tmp`;
+	const output = await open(temporaryPath, "w");
+	let retained = 0;
+	try {
+		try {
+			const reader = createInterface({
+				input: createReadStream(path),
+				crlfDelay: Number.POSITIVE_INFINITY,
+			});
+			for await (const line of reader) {
+				if (line.length === 0) continue;
+				const parsed = parseEventLine(line);
+				if (
+					parsed.event !== undefined &&
+					Date.parse(parsed.event.createdAt) >= cutoff
+				) {
+					await output.write(`${JSON.stringify(parsed.event)}\n`);
+					retained += 1;
+				}
+			}
+		} finally {
+			await output.close();
+		}
+		if (retained === 0) {
+			await unlink(path).catch(() => undefined);
+			await unlink(temporaryPath).catch(() => undefined);
+			return;
+		}
+		await rename(temporaryPath, path);
+	} catch (cause) {
+		await output.close().catch(() => undefined);
+		await unlink(temporaryPath).catch(() => undefined);
+		throw cause;
+	}
+};
+
+const readPersistedEventKeys = async (
+	paths: ReadonlyArray<string>,
+): Promise<Set<string>> => {
+	const keys = new Set<string>();
+	for (const path of paths) {
+		if (!existsSync(path)) continue;
+		try {
+			const reader = createInterface({
+				input: createReadStream(path),
+				crlfDelay: Number.POSITIVE_INFINITY,
+			});
+			for await (const line of reader) {
+				if (line.length === 0) continue;
+				const parsed = parseEventLine(line);
+				if (parsed.event !== undefined)
+					keys.add(`${parsed.event.runId}:${parsed.event.id}`);
+			}
+		} catch {
+			// A rotated file can disappear while a different runtime is exporting.
+		}
+	}
+	return keys;
 };
 
 const appendEvents = async (
@@ -144,9 +348,9 @@ const appendEvents = async (
 		.catch(() => 0);
 	if (
 		currentSize > 0 &&
-		currentSize + Buffer.byteLength(chunk) > MAX_FILE_BYTES
+		currentSize + Buffer.byteLength(chunk) > INCIDENT_FILE_BYTES
 	) {
-		for (let index = FILE_COUNT - 1; index >= 1; index -= 1) {
+		for (let index = INCIDENT_FILE_COUNT - 1; index >= 1; index -= 1) {
 			const source = index === 1 ? path : `${path}.${index - 1}`;
 			const target = `${path}.${index}`;
 			await unlink(target).catch(() => undefined);
@@ -156,13 +360,159 @@ const appendEvents = async (
 	await appendFile(path, chunk, "utf8");
 };
 
+const appendFullTraceEvents = async (
+	path: string,
+	events: ReadonlyArray<DiagnosticEvent>,
+): Promise<void> => {
+	if (events.length === 0) return;
+	await mkdir(dirname(path), { recursive: true });
+	const chunk = Buffer.from(
+		events.map((event) => `${JSON.stringify(event)}\n`).join(""),
+	);
+	const currentSize = await stat(path)
+		.then((value) => value.size)
+		.catch(() => 0);
+	if (currentSize + chunk.length <= FULL_TRACE_BYTE_LIMIT) {
+		await appendFile(path, chunk);
+		return;
+	}
+	const existing = await readFile(path).catch(() => Buffer.alloc(0));
+	const combined = Buffer.concat([existing, chunk]);
+	const bounded = combined.subarray(
+		Math.max(0, combined.length - FULL_TRACE_BYTE_LIMIT),
+	);
+	const firstNewline = bounded.indexOf(10);
+	const completeLines =
+		firstNewline >= 0 ? bounded.subarray(firstNewline + 1) : bounded;
+	const temporaryPath = `${path}.${process.pid}.tmp`;
+	await writeFile(temporaryPath, completeLines);
+	await rename(temporaryPath, path);
+};
+
+const emptyCell = (): OperationCell => ({
+	count: 0,
+	failureCount: 0,
+	totalDurationMs: 0,
+	maxDurationMs: 0,
+	durationBuckets: DURATION_BUCKETS.map(() => 0),
+});
+
+const mergeCell = (target: OperationCell, source: OperationCell): void => {
+	target.count += source.count;
+	target.failureCount += source.failureCount;
+	target.totalDurationMs += source.totalDurationMs;
+	target.maxDurationMs = Math.max(target.maxDurationMs, source.maxDurationMs);
+	for (let index = 0; index < target.durationBuckets.length; index += 1) {
+		target.durationBuckets[index] =
+			(target.durationBuckets[index] ?? 0) +
+			(source.durationBuckets[index] ?? 0);
+	}
+};
+
+const addOperationToRollup = (
+	rollup: OperationRollup,
+	operation: TelemetryOperation,
+	operationCount: number,
+): number => {
+	let name = operation.name;
+	let nextOperationCount = operationCount;
+	if (rollup.operations[name] === undefined) {
+		if (operationCount >= MAX_OPERATIONS_PER_ROLLUP) name = "other";
+		else nextOperationCount += 1;
+	}
+	const cell = rollup.operations[name] ?? emptyCell();
+	cell.count += 1;
+	if (operation.outcome === "failure" || operation.outcome === "interrupted")
+		cell.failureCount += 1;
+	cell.totalDurationMs += operation.durationMs;
+	cell.maxDurationMs = Math.max(cell.maxDurationMs, operation.durationMs);
+	const bucketIndex = DURATION_BUCKETS.findIndex(
+		(limit) => operation.durationMs <= limit,
+	);
+	if (bucketIndex >= 0)
+		cell.durationBuckets[bucketIndex] =
+			(cell.durationBuckets[bucketIndex] ?? 0) + 1;
+	rollup.operations[name] = cell;
+	return nextOperationCount;
+};
+
+const summariesFromRollups = (
+	rollups: ReadonlyArray<OperationRollup>,
+	since?: string,
+): ReadonlyArray<OperationSummary> => {
+	const sinceMs = since === undefined ? 0 : Date.parse(since);
+	const merged = new Map<string, OperationCell>();
+	for (const rollup of rollups) {
+		if (rollup.bucketStart + ROLLUP_INTERVAL_MS < sinceMs) continue;
+		for (const [name, cell] of Object.entries(rollup.operations)) {
+			const target = merged.get(name) ?? emptyCell();
+			mergeCell(target, cell);
+			merged.set(name, target);
+		}
+	}
+	return [...merged.entries()]
+		.map(([name, cell]) => {
+			const p95Target = Math.ceil(cell.count * 0.95);
+			let cumulative = 0;
+			let p95DurationMs = cell.maxDurationMs;
+			for (let index = 0; index < cell.durationBuckets.length; index += 1) {
+				cumulative += cell.durationBuckets[index] ?? 0;
+				if (cumulative >= p95Target) {
+					p95DurationMs = DURATION_BUCKETS[index] ?? cell.maxDurationMs;
+					break;
+				}
+			}
+			return {
+				name,
+				count: cell.count,
+				failureCount: cell.failureCount,
+				averageDurationMs:
+					cell.count === 0 ? 0 : cell.totalDurationMs / cell.count,
+				p95DurationMs,
+				maxDurationMs: cell.maxDurationMs,
+			};
+		})
+		.sort(
+			(left, right) =>
+				right.count - left.count || right.maxDurationMs - left.maxDurationMs,
+		)
+		.slice(0, 50);
+};
+
 export interface TelemetryStoreShape {
 	readonly runId: string;
 	readonly parseErrorCount: number;
+	readonly runtimeKind: DiagnosticRuntimeKind;
+	readonly fileIdentity: string;
 	readonly record: (event: DiagnosticEvent) => void;
 	readonly recordMany: (events: ReadonlyArray<DiagnosticEvent>) => void;
+	readonly recordOperation: (operation: TelemetryOperation) => void;
+	readonly shouldRecordOperation: (operation: TelemetryOperation) => boolean;
 	readonly snapshot: () => ReadonlyArray<DiagnosticEvent>;
+	readonly exportEvents: (input: {
+		readonly since?: string;
+		readonly limit?: number;
+	}) => Effect.Effect<{
+		readonly events: ReadonlyArray<DiagnosticEvent>;
+		readonly truncated: number;
+	}>;
+	readonly operationSummaries: (
+		since?: string,
+	) => ReadonlyArray<OperationSummary>;
+	readonly exportOperationSummaries: (
+		since?: string,
+	) => Effect.Effect<ReadonlyArray<OperationSummary>>;
+	readonly captureState: () => {
+		readonly captureMode: DiagnosticCaptureMode;
+		readonly fullCaptureEndsAt: string | null;
+	};
+	readonly setCapture: (
+		input: DiagnosticsCapturePayload,
+	) => Effect.Effect<void>;
+	readonly droppedEventCount: () => number;
+	readonly truncatedEventCount: () => number;
 	readonly version: () => number;
+	readonly overviewVersion: () => number;
 	readonly storageBytes: Effect.Effect<number>;
 	readonly flush: Effect.Effect<void>;
 }
@@ -176,21 +526,151 @@ export const TelemetryStoreLive = Layer.effect(
 	TelemetryStore,
 	Effect.gen(function* () {
 		const paths = yield* AppPaths;
-		const path = join(paths.userData, "logs", "diagnostics.events.ndjson");
-		const loaded = yield* Effect.tryPromise(() => loadEvents(path)).pipe(
-			Effect.orElseSucceed(() => ({
-				events: [] as DiagnosticEvent[],
-				parseErrors: 0,
-			})),
+		const identity = paths.telemetryIdentity ?? {
+			kind: "desktop" as const,
+			instance: "local",
+		};
+		const suffix = telemetryFileIdentity(identity.kind, identity.instance);
+		const logsDirectory = join(paths.userData, "logs");
+		const incidentPath = join(
+			logsDirectory,
+			`diagnostics.events.${suffix}.ndjson`,
+		);
+		const fullPath = join(
+			logsDirectory,
+			`diagnostics.full-trace.${suffix}.ndjson`,
+		);
+		const rollupPath = join(
+			logsDirectory,
+			`diagnostics.rollups.${suffix}.ndjson`,
 		);
 		const runId = `run_${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
-		const events = new EventRingBuffer(MAX_EVENTS, loaded.events);
-		let version = loaded.events.length;
-		const pendingPersistence: DiagnosticEvent[] = [];
+		const incidents = new EventRingBuffer(INCIDENT_EVENT_LIMIT);
+		const fullTrace = new EventRingBuffer(
+			FULL_TRACE_EVENT_LIMIT,
+			FULL_TRACE_BYTE_LIMIT,
+		);
+		const rollups: OperationRollup[] = [];
+		let parseErrorCount = 0;
+		let version = 0;
+		let overviewVersion = 0;
+		let droppedEventCount = 0;
+		let truncatedEventCount = 0;
+		let captureMode: DiagnosticCaptureMode = "incident";
+		let fullCaptureEndsAtMs: number | null = null;
+		let captureTimer: ReturnType<typeof setTimeout> | undefined;
+		let rollupTimer: ReturnType<typeof setTimeout> | undefined;
+		let currentOperationCount = 0;
+		let currentRollup: OperationRollup = {
+			bucketStart:
+				Math.floor(Date.now() / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS,
+			operations: {},
+		};
+		let rollupPersistence = Promise.resolve();
+		const boundedRollupText = (): string => {
+			const lines: string[] = [];
+			let bytes = 0;
+			for (let index = rollups.length - 1; index >= 0; index -= 1) {
+				const line = `${JSON.stringify(rollups[index])}\n`;
+				const lineBytes = Buffer.byteLength(line);
+				if (bytes + lineBytes > ROLLUP_FILE_BYTES) break;
+				lines.unshift(line);
+				bytes += lineBytes;
+			}
+			return lines.join("");
+		};
+
+		const loaded = yield* Effect.tryPromise(async () => {
+			const loadedEvents: DiagnosticEvent[] = [];
+			const loadedRollups: OperationRollup[] = [];
+			let errors = 0;
+			const now = Date.now();
+			for (const file of [...retainedPaths(incidentPath)].reverse()) {
+				try {
+					const fileStat = await stat(file);
+					if (now - fileStat.mtimeMs > RETENTION_MS) {
+						await unlink(file).catch(() => undefined);
+						continue;
+					}
+					for (const line of await readNewestLines(
+						file,
+						INCIDENT_EVENT_LIMIT,
+						INCIDENT_FILE_BYTES,
+					)) {
+						const parsed = parseEventLine(line);
+						if (
+							parsed.event !== undefined &&
+							isRetainedEvent(parsed.event, now)
+						)
+							loadedEvents.push(parsed.event);
+						if (parsed.parseError) errors += 1;
+					}
+				} catch {
+					// Missing telemetry files are normal on first launch.
+				}
+			}
+			try {
+				for (const line of await readNewestLines(
+					rollupPath,
+					MAX_ROLLUPS,
+					ROLLUP_FILE_BYTES,
+				)) {
+					try {
+						const parsed = JSON.parse(line) as OperationRollup;
+						if (Date.now() - parsed.bucketStart <= RETENTION_MS)
+							loadedRollups.push(parsed);
+					} catch {
+						errors += 1;
+					}
+				}
+			} catch {
+				// An absent rollup file is normal.
+			}
+			return { events: loadedEvents, rollups: loadedRollups, errors };
+		}).pipe(
+			Effect.orElseSucceed(() => ({
+				events: [] as DiagnosticEvent[],
+				rollups: [] as OperationRollup[],
+				errors: 0,
+			})),
+		);
+		incidents.pushMany(loaded.events.slice(-INCIDENT_EVENT_LIMIT));
+		rollups.push(...loaded.rollups.slice(-MAX_ROLLUPS));
+		parseErrorCount += loaded.errors;
+		version = incidents.snapshot().length;
+		if (existsSync(rollupPath)) {
+			rollupPersistence = (async () => {
+				await mkdir(logsDirectory, { recursive: true });
+				const temporaryPath = `${rollupPath}.${process.pid}.cleanup.tmp`;
+				await writeFile(temporaryPath, boundedRollupText(), "utf8");
+				await rename(temporaryPath, rollupPath);
+			})().catch(() => undefined);
+		}
+		const fileMaintenance = Promise.all(
+			[...retainedPaths(incidentPath), fullPath].map((path) =>
+				compactEventFile(path, Date.now() - RETENTION_MS),
+			),
+		).then(
+			() => undefined,
+			() => undefined,
+		);
+
+		const pendingPersistence: PersistedEvent[] = [];
 		let persistenceDrain: Promise<void> | undefined;
 		let persistTimer: ReturnType<typeof setTimeout> | undefined;
-		let droppedPersistenceEvents = 0;
-		let lastDropWarningAt = 0;
+
+		const expireCapture = (): void => {
+			if (
+				captureMode === "full" &&
+				fullCaptureEndsAtMs !== null &&
+				Date.now() >= fullCaptureEndsAtMs
+			) {
+				captureMode = "incident";
+				fullCaptureEndsAtMs = null;
+				captureTimer = undefined;
+				version += 1;
+			}
+		};
 
 		const startPersistenceDrain = (): void => {
 			if (persistTimer !== undefined) {
@@ -200,9 +680,21 @@ export const TelemetryStoreLive = Layer.effect(
 			if (persistenceDrain !== undefined || pendingPersistence.length === 0)
 				return;
 			persistenceDrain = (async () => {
+				await fileMaintenance;
 				while (pendingPersistence.length > 0) {
 					const batch = pendingPersistence.splice(0, PERSIST_BATCH_SIZE);
-					await appendEvents(path, batch).catch(() => undefined);
+					const byPath = new Map<string, DiagnosticEvent[]>();
+					for (const item of batch) {
+						const events = byPath.get(item.path);
+						if (events === undefined) byPath.set(item.path, [item.event]);
+						else events.push(item.event);
+					}
+					for (const [path, events] of byPath) {
+						await (path === fullPath
+							? appendFullTraceEvents(path, events)
+							: appendEvents(path, events)
+						).catch(() => undefined);
+					}
 				}
 			})().finally(() => {
 				persistenceDrain = undefined;
@@ -220,64 +712,451 @@ export const TelemetryStoreLive = Layer.effect(
 			persistTimer.unref?.();
 		};
 
+		const enqueue = (path: string, event: DiagnosticEvent): void => {
+			pendingPersistence.push({ path, event });
+			if (pendingPersistence.length > MAX_PENDING_PERSISTENCE_EVENTS) {
+				const count =
+					pendingPersistence.length - MAX_PENDING_PERSISTENCE_EVENTS;
+				pendingPersistence.splice(0, count);
+				droppedEventCount += count;
+			}
+			schedulePersistence();
+		};
+
 		const recordMany = (incoming: ReadonlyArray<DiagnosticEvent>): void => {
 			if (incoming.length === 0) return;
 			try {
-				const sanitized = incoming.map(sanitizeEvent);
-				events.pushMany(sanitized);
-				version += sanitized.length;
-				pendingPersistence.push(...sanitized);
-				if (pendingPersistence.length > MAX_PENDING_PERSISTENCE_EVENTS) {
-					const dropped =
-						pendingPersistence.length - MAX_PENDING_PERSISTENCE_EVENTS;
-					pendingPersistence.splice(0, dropped);
-					droppedPersistenceEvents += dropped;
-					const now = Date.now();
-					if (now - lastDropWarningAt >= 5_000) {
-						events.pushMany([
-							sanitizeEvent({
-								id: `telemetry_drop_${runId}_${version}`,
-								createdAt: new Date(now).toISOString(),
-								severity: "warn",
-								source: "server.telemetry",
-								category: "persistence",
-								message: "Telemetry persistence queue dropped events",
-								detail: `dropped=${droppedPersistenceEvents}`,
-								fingerprint: "telemetry-persistence-drop",
-								runId,
-								recoveryStatus: "unresolved",
-							}),
-						]);
-						droppedPersistenceEvents = 0;
-						lastDropWarningAt = now;
-						version += 1;
+				expireCapture();
+				for (const sourceEvent of incoming) {
+					if (!isRetainedEvent(sourceEvent)) continue;
+					const mode = isIncidentEvent(sourceEvent) ? "incident" : captureMode;
+					const event = sanitizeEvent(sourceEvent, identity.kind, mode);
+					if (isIncidentEvent(event)) {
+						truncatedEventCount += incidents.pushMany([event]);
+						enqueue(incidentPath, event);
+					} else if (captureMode === "full") {
+						truncatedEventCount += fullTrace.pushMany([event]);
+						enqueue(fullPath, event);
+					} else {
+						continue;
 					}
+					version += 1;
 				}
-				schedulePersistence();
 			} catch {
-				// Telemetry must never interrupt the application path it observes.
+				// Diagnostics must never interrupt the operation it observes.
 			}
 		};
 
+		const persistRollup = (rollup: OperationRollup): void => {
+			rollups.push(rollup);
+			rollups.sort((left, right) => left.bucketStart - right.bucketStart);
+			while (rollups.length > MAX_ROLLUPS) rollups.shift();
+			const line = `${JSON.stringify(rollup)}\n`;
+			rollupPersistence = rollupPersistence
+				.then(async () => {
+					await mkdir(logsDirectory, { recursive: true });
+					const currentSize = await stat(rollupPath)
+						.then((value) => value.size)
+						.catch(() => 0);
+					if (currentSize + Buffer.byteLength(line) <= ROLLUP_FILE_BYTES) {
+						await appendFile(rollupPath, line, "utf8");
+						return;
+					}
+					const temporaryPath = `${rollupPath}.${process.pid}.tmp`;
+					await writeFile(temporaryPath, boundedRollupText(), "utf8");
+					await rename(temporaryPath, rollupPath);
+				})
+				.catch(() => undefined);
+		};
+
+		const closeCurrentRollup = (): void => {
+			if (currentOperationCount === 0) return;
+			persistRollup(currentRollup);
+		};
+
+		const recordOperation = (operation: TelemetryOperation): void => {
+			expireCapture();
+			overviewVersion += 1;
+			const bucketStart =
+				Math.floor(Date.now() / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS;
+			if (bucketStart !== currentRollup.bucketStart) {
+				closeCurrentRollup();
+				currentRollup = { bucketStart, operations: {} };
+				currentOperationCount = 0;
+			}
+			currentOperationCount = addOperationToRollup(
+				currentRollup,
+				operation,
+				currentOperationCount,
+			);
+		};
+
+		const scheduleRollupBoundary = (): void => {
+			const now = Date.now();
+			const nextBoundary =
+				(Math.floor(now / ROLLUP_INTERVAL_MS) + 1) * ROLLUP_INTERVAL_MS;
+			rollupTimer = setTimeout(
+				() => {
+					const bucketStart =
+						Math.floor(Date.now() / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS;
+					if (bucketStart !== currentRollup.bucketStart) {
+						closeCurrentRollup();
+						currentRollup = { bucketStart, operations: {} };
+						currentOperationCount = 0;
+					}
+					scheduleRollupBoundary();
+				},
+				Math.max(1, nextBoundary - now),
+			);
+			rollupTimer.unref?.();
+		};
+		scheduleRollupBoundary();
+
 		const flush = Effect.promise(async () => {
+			await fileMaintenance;
 			startPersistenceDrain();
 			await persistenceDrain;
+			await rollupPersistence;
 		}).pipe(
 			Effect.timeoutOption(Duration.seconds(2)),
 			Effect.asVoid,
 			Effect.ignore,
 		);
-		yield* Effect.addFinalizer(() => flush);
+
+		const importOffline = async (): Promise<void> => {
+			if (identity.kind !== "desktop") return;
+			const offlinePath = join(logsDirectory, "diagnostics.offline.ndjson");
+			try {
+				for (const line of await readNewestLines(
+					offlinePath,
+					INCIDENT_EVENT_LIMIT,
+					INCIDENT_FILE_BYTES,
+				)) {
+					const parsed = parseEventLine(line);
+					if (parsed.event !== undefined) recordMany([parsed.event]);
+					if (parsed.parseError) parseErrorCount += 1;
+				}
+				startPersistenceDrain();
+				await persistenceDrain;
+				await unlink(offlinePath).catch(() => undefined);
+			} catch {
+				// An absent offline crash file is normal.
+			}
+		};
+
+		const migrateLegacy = async (): Promise<void> => {
+			await mkdir(logsDirectory, { recursive: true });
+			const lockPath = join(logsDirectory, "diagnostics.legacy-migration.lock");
+			let lock: Awaited<ReturnType<typeof open>> | undefined;
+			try {
+				lock = await open(lockPath, "wx");
+				await lock.writeFile(String(process.pid), "utf8");
+			} catch {
+				const ownerPid = await readFile(lockPath, "utf8")
+					.then((value) => Number(value))
+					.catch(() => Number.NaN);
+				const ownerIsValid = Number.isSafeInteger(ownerPid) && ownerPid > 0;
+				let ownerIsAlive = false;
+				if (ownerIsValid) {
+					try {
+						process.kill(ownerPid, 0);
+						ownerIsAlive = true;
+					} catch (cause) {
+						ownerIsAlive =
+							cause instanceof Error &&
+							"code" in cause &&
+							cause.code === "EPERM";
+					}
+				}
+				const stale = await stat(lockPath)
+					.then((value) => Date.now() - value.mtimeMs > 5 * 60_000)
+					.catch(() => false);
+				if (ownerIsAlive) return;
+				if (!ownerIsValid && !stale) return;
+				await unlink(lockPath).catch(() => undefined);
+				try {
+					lock = await open(lockPath, "wx");
+					await lock.writeFile(String(process.pid), "utf8");
+				} catch {
+					return;
+				}
+			}
+			try {
+				const migratingPaths: string[] = [];
+				await fileMaintenance;
+				startPersistenceDrain();
+				await persistenceDrain;
+				const existingEventKeys = await readPersistedEventKeys(
+					retainedPaths(incidentPath),
+				);
+				for (const event of incidents.snapshot())
+					existingEventKeys.add(`${event.runId}:${event.id}`);
+				const existingMigrationBuckets = new Set(
+					rollups.flatMap((rollup) =>
+						rollup.migrationSource === undefined
+							? []
+							: [`${rollup.migrationSource}:${rollup.bucketStart}`],
+					),
+				);
+				const migratedRollups = new Map<
+					string,
+					{ rollup: OperationRollup; operationCount: number }
+				>();
+				for (const legacyPath of [
+					...retainedPaths(join(logsDirectory, "diagnostics.events.ndjson")),
+				].reverse()) {
+					const migratingPath = `${legacyPath}.migrating`;
+					if (existsSync(legacyPath))
+						await rename(legacyPath, migratingPath).catch(() => undefined);
+					if (!existsSync(migratingPath)) continue;
+					migratingPaths.push(migratingPath);
+					const migratingStat = await stat(migratingPath);
+					const migrationSource = legacyMigrationSource(
+						migratingPath,
+						migratingStat.size,
+						migratingStat.mtimeMs,
+					);
+					const reader = createInterface({
+						input: createReadStream(migratingPath),
+						crlfDelay: Number.POSITIVE_INFINITY,
+					});
+					for await (const line of reader) {
+						if (line.length === 0) continue;
+						const parsed = parseEventLine(line);
+						if (parsed.event === undefined) {
+							parseErrorCount += 1;
+							continue;
+						}
+						const createdAt = Date.parse(parsed.event.createdAt);
+						if (
+							!Number.isFinite(createdAt) ||
+							Date.now() - createdAt > RETENTION_MS
+						)
+							continue;
+						if (isIncidentEvent(parsed.event)) {
+							const eventKey = `${parsed.event.runId}:${parsed.event.id}`;
+							if (!existingEventKeys.has(eventKey)) {
+								recordMany([parsed.event]);
+								existingEventKeys.add(eventKey);
+							}
+						}
+						if (parsed.event.durationMs !== undefined) {
+							const bucketStart =
+								Math.floor(createdAt / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS;
+							const migrationBucket = `${migrationSource}:${bucketStart}`;
+							if (existingMigrationBuckets.has(migrationBucket)) continue;
+							const migrated = migratedRollups.get(migrationBucket) ?? {
+								rollup: { bucketStart, operations: {}, migrationSource },
+								operationCount: 0,
+							};
+							migrated.operationCount = addOperationToRollup(
+								migrated.rollup,
+								{
+									name: parsed.event.message,
+									durationMs: parsed.event.durationMs,
+									outcome:
+										parsed.event.severity === "error" ||
+										parsed.event.severity === "fatal"
+											? "failure"
+											: "success",
+								},
+								migrated.operationCount,
+							);
+							migratedRollups.set(migrationBucket, migrated);
+						}
+					}
+				}
+				startPersistenceDrain();
+				await persistenceDrain;
+				for (const migrated of [...migratedRollups.values()].sort(
+					(left, right) => left.rollup.bucketStart - right.rollup.bucketStart,
+				)) {
+					persistRollup(migrated.rollup);
+					existingMigrationBuckets.add(
+						`${migrated.rollup.migrationSource}:${migrated.rollup.bucketStart}`,
+					);
+				}
+				await rollupPersistence;
+				for (const migratingPath of migratingPaths)
+					await unlink(migratingPath).catch(() => undefined);
+			} finally {
+				await lock.close().catch(() => undefined);
+				await unlink(lockPath).catch(() => undefined);
+			}
+		};
+
+		void importOffline().catch(() => undefined);
+		void migrateLegacy().catch(() => undefined);
+		yield* Effect.addFinalizer(() =>
+			Effect.gen(function* () {
+				if (captureTimer !== undefined) clearTimeout(captureTimer);
+				if (rollupTimer !== undefined) clearTimeout(rollupTimer);
+				closeCurrentRollup();
+				yield* flush;
+			}),
+		);
+
+		const snapshot = (): ReadonlyArray<DiagnosticEvent> => {
+			expireCapture();
+			return [...incidents.snapshot(), ...fullTrace.snapshot()]
+				.filter((event) => isRetainedEvent(event))
+				.sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+				.slice(-SUPPORT_EVENT_LIMIT);
+		};
 
 		return TelemetryStore.of({
 			runId,
-			parseErrorCount: loaded.parseErrors,
+			get parseErrorCount() {
+				return parseErrorCount;
+			},
+			runtimeKind: identity.kind,
+			fileIdentity: suffix,
 			record: (event) => recordMany([event]),
 			recordMany,
-			snapshot: () => events.snapshot(),
+			recordOperation,
+			shouldRecordOperation: (operation) => {
+				expireCapture();
+				const shouldRecord = shouldPersistOperationEvent(
+					operation,
+					captureMode,
+				);
+				return shouldRecord;
+			},
+			snapshot,
+			exportEvents: ({ since, limit = SUPPORT_EVENT_LIMIT }) =>
+				Effect.tryPromise(async () => {
+					const files = await readdir(logsDirectory).catch(() => []);
+					const candidates = files.filter(
+						(name) =>
+							/^diagnostics\.events\.(desktop|serve)-[a-f0-9]{12}\.ndjson(?:\.\d+)?$/.test(
+								name,
+							) ||
+							/^diagnostics\.full-trace\.(desktop|serve)-[a-f0-9]{12}\.ndjson$/.test(
+								name,
+							),
+					);
+					const newest = new Map<string, DiagnosticEvent>();
+					let relevant = 0;
+					const add = (event: DiagnosticEvent): void => {
+						if (!isRetainedEvent(event)) return;
+						if (since !== undefined && event.createdAt < since) return;
+						const key = `${event.runId}:${event.id}`;
+						if (!newest.has(key)) relevant += 1;
+						newest.set(key, event);
+						if (newest.size <= limit + 1_000) return;
+						const retained = [...newest.values()]
+							.sort((left, right) =>
+								left.createdAt.localeCompare(right.createdAt),
+							)
+							.slice(-limit);
+						newest.clear();
+						for (const retainedEvent of retained) {
+							const retainedKey = `${retainedEvent.runId}:${retainedEvent.id}`;
+							newest.set(retainedKey, retainedEvent);
+						}
+					};
+					for (const name of candidates) {
+						try {
+							const reader = createInterface({
+								input: createReadStream(join(logsDirectory, name)),
+								crlfDelay: Number.POSITIVE_INFINITY,
+							});
+							for await (const line of reader) {
+								const parsed = parseEventLine(line);
+								if (parsed.event !== undefined) add(parsed.event);
+							}
+						} catch {
+							// A runtime may rotate a candidate during export.
+						}
+					}
+					for (const event of snapshot()) add(event);
+					const deduplicated = [...newest.values()].sort((left, right) =>
+						left.createdAt.localeCompare(right.createdAt),
+					);
+					const events = deduplicated.slice(-limit);
+					return { events, truncated: Math.max(0, relevant - events.length) };
+				}),
+			operationSummaries: (since) =>
+				summariesFromRollups([...rollups, currentRollup], since),
+			exportOperationSummaries: (since) =>
+				Effect.tryPromise(async () => {
+					const files = (await readdir(logsDirectory).catch(() => [])).filter(
+						(name) => name.startsWith("diagnostics.rollups."),
+					);
+					const exportedRollups: OperationRollup[] = [];
+					for (const name of files) {
+						try {
+							const reader = createInterface({
+								input: createReadStream(join(logsDirectory, name)),
+								crlfDelay: Number.POSITIVE_INFINITY,
+							});
+							for await (const line of reader) {
+								try {
+									const rollup = JSON.parse(line) as OperationRollup;
+									if (Date.now() - rollup.bucketStart <= RETENTION_MS)
+										exportedRollups.push(rollup);
+									if (exportedRollups.length > MAX_ROLLUPS * 4)
+										exportedRollups.shift();
+								} catch {
+									// Invalid rollup lines are ignored during export.
+								}
+							}
+						} catch {
+							// A runtime may rotate a candidate during export.
+						}
+					}
+					exportedRollups.push(currentRollup);
+					return summariesFromRollups(exportedRollups, since);
+				}),
+			captureState: () => {
+				expireCapture();
+				return {
+					captureMode,
+					fullCaptureEndsAt:
+						fullCaptureEndsAtMs === null
+							? null
+							: new Date(fullCaptureEndsAtMs).toISOString(),
+				};
+			},
+			setCapture: (input) =>
+				Effect.promise(async () => {
+					await fileMaintenance;
+					if (captureTimer !== undefined) {
+						clearTimeout(captureTimer);
+						captureTimer = undefined;
+					}
+					if (input.mode === "incident") {
+						captureMode = "incident";
+						fullCaptureEndsAtMs = null;
+					} else {
+						for (
+							let index = pendingPersistence.length - 1;
+							index >= 0;
+							index -= 1
+						) {
+							if (pendingPersistence[index]?.path === fullPath)
+								pendingPersistence.splice(index, 1);
+						}
+						await persistenceDrain;
+						fullTrace.clear();
+						await mkdir(logsDirectory, { recursive: true });
+						await writeFile(fullPath, "", "utf8");
+						captureMode = "full";
+						fullCaptureEndsAtMs = Date.now() + input.durationMinutes * 60_000;
+						captureTimer = setTimeout(
+							expireCapture,
+							input.durationMinutes * 60_000,
+						);
+						captureTimer.unref?.();
+					}
+					version += 1;
+				}),
+			droppedEventCount: () => droppedEventCount,
+			truncatedEventCount: () => truncatedEventCount,
 			version: () => version,
+			overviewVersion: () => version + overviewVersion,
 			storageBytes: Effect.sync(() =>
-				retainedPaths(path)
+				[...retainedPaths(incidentPath), fullPath, rollupPath]
 					.filter(existsSync)
 					.reduce((total, file) => total + statSync(file).size, 0),
 			).pipe(Effect.orElseSucceed(() => 0)),

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -9,7 +9,7 @@ import { WorktreeServiceLive } from "@zuse/git/worktree-service-live";
 import { Effect, Layer } from "effect";
 import { RpcServer } from "effect/unstable/rpc";
 import { AnalyticsServiceLive } from "./analytics/layers/analytics-service.ts";
-import { AppPaths } from "./app-paths.ts";
+import { AppPaths, type TelemetryIdentity } from "./app-paths.ts";
 import { AttachmentServiceLive } from "./attachment/layers/attachment-service.ts";
 import { AuthServiceLive } from "./auth/layers/auth-service.ts";
 import { SessionStoreLive } from "./auth/layers/session-store.ts";
@@ -90,6 +90,7 @@ import {
  */
 export interface MainLayerDeps {
 	readonly userData: string;
+	readonly telemetryIdentity?: TelemetryIdentity;
 	readonly folderPicker: typeof FolderPicker.Service;
 	readonly serverProtocol: Layer.Layer<
 		RpcServer.Protocol,
@@ -124,7 +125,10 @@ export interface MainLayerDeps {
  * wiring inside this module.
  */
 export const makeMainLayer = (deps: MainLayerDeps) => {
-	const AppPathsLayer = Layer.succeed(AppPaths, { userData: deps.userData });
+	const AppPathsLayer = Layer.succeed(AppPaths, {
+		userData: deps.userData,
+		telemetryIdentity: deps.telemetryIdentity,
+	});
 	const TelemetryStoreLayer = TelemetryStoreLive.pipe(
 		Layer.provide(AppPathsLayer),
 	);

--- a/apps/server/test/unit/diagnostics-zip.test.ts
+++ b/apps/server/test/unit/diagnostics-zip.test.ts
@@ -1,6 +1,12 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { createStoredZip } from "../../src/diagnostics/zip-bundle.ts";
+import {
+	createStoredZip,
+	writeStoredZip,
+} from "../../src/diagnostics/zip-bundle.ts";
 
 describe("diagnostics zip bundle", () => {
 	it("creates a standard zip containing named artifacts", () => {
@@ -13,5 +19,30 @@ describe("diagnostics zip bundle", () => {
 		expect(zip.includes(Buffer.from("manifest.json"))).toBe(true);
 		expect(zip.includes(Buffer.from("REPORT.md"))).toBe(true);
 		expect(zip.subarray(-22, -18).toString("hex")).toBe("504b0506");
+	});
+
+	it("streams stored artifacts into a zip file", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-zip-"));
+		try {
+			const artifactPath = join(directory, "artifact.json");
+			const zipPath = join(directory, "bundle.zip");
+			writeFileSync(artifactPath, Buffer.alloc(2 * 1024 * 1024, 97));
+			const chunkSizes: number[] = [];
+			await writeStoredZip(
+				zipPath,
+				[{ name: "artifact.json", path: artifactPath }],
+				{
+					onArtifactChunk: (bytes) => chunkSizes.push(bytes),
+				},
+			);
+			const zip = readFileSync(zipPath);
+			expect(zip.subarray(0, 4).toString("hex")).toBe("504b0304");
+			expect(zip.includes(Buffer.from("artifact.json"))).toBe(true);
+			expect(zip.subarray(-22, -18).toString("hex")).toBe("504b0506");
+			expect(Math.max(...chunkSizes)).toBeLessThanOrEqual(64 * 1024);
+			expect(chunkSizes.length).toBeGreaterThan(1);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 });

--- a/apps/server/test/unit/telemetry-store.test.ts
+++ b/apps/server/test/unit/telemetry-store.test.ts
@@ -1,22 +1,29 @@
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
+	statSync,
+	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { DiagnosticEvent } from "@zuse/contracts";
-import { Effect, Layer } from "effect";
-import { describe, expect, it } from "vitest";
+import { Cause, Effect, Layer } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppPaths } from "../../src/app-paths.ts";
 import { TelemetryObservabilityLive } from "../../src/observability/telemetry-layer.ts";
 import {
+	legacyMigrationSource,
+	shouldPersistOperationEvent,
 	TelemetryStore,
 	TelemetryStoreLive,
+	telemetryFileIdentity,
 } from "../../src/observability/telemetry-store.ts";
 import { appendRelayDiagnostic } from "../../src/relay/relay-diagnostics.ts";
 
@@ -32,6 +39,17 @@ const event = (id: string): DiagnosticEvent => ({
 	runId: "run-test",
 	recoveryStatus: "unresolved",
 });
+
+const eventFile = (directory: string, kind = "desktop") =>
+	join(
+		directory,
+		"logs",
+		readdirSync(join(directory, "logs")).find((name) =>
+			name.startsWith(`diagnostics.events.${kind}-`),
+		) ?? "missing",
+	);
+
+afterEach(() => vi.useRealTimers());
 
 describe("telemetry store", () => {
 	it("serializes concurrent records, persists redacted data, and reloads it", async () => {
@@ -54,10 +72,7 @@ describe("telemetry store", () => {
 			);
 
 			expect(snapshot).toHaveLength(3);
-			const persisted = readFileSync(
-				join(directory, "logs", "diagnostics.events.ndjson"),
-				"utf8",
-			);
+			const persisted = readFileSync(eventFile(directory), "utf8");
 			expect(persisted).toContain("Bearer [REDACTED]");
 			expect(persisted).toContain("OPENAI_API_KEY=[REDACTED]");
 			expect(persisted).not.toContain("secret-value");
@@ -67,6 +82,7 @@ describe("telemetry store", () => {
 				Effect.scoped(
 					Effect.gen(function* () {
 						const store = yield* TelemetryStore;
+						yield* Effect.sleep("50 millis");
 						return store.snapshot();
 					}).pipe(Effect.provide(layer)),
 				),
@@ -77,7 +93,7 @@ describe("telemetry store", () => {
 		}
 	});
 
-	it("records completed Effect spans through the runtime tracer", async () => {
+	it("aggregates fast successful spans without retaining individual events", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "zuse-tracer-"));
 		const storeLayer = TelemetryStoreLive.pipe(
 			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
@@ -87,7 +103,7 @@ describe("telemetry store", () => {
 		);
 
 		try {
-			const events = await Effect.runPromise(
+			const result = await Effect.runPromise(
 				Effect.scoped(
 					Effect.gen(function* () {
 						yield* Effect.succeed("ok").pipe(
@@ -101,20 +117,97 @@ describe("telemetry store", () => {
 						);
 						const store = yield* TelemetryStore;
 						yield* store.flush;
-						return store.snapshot();
+						return {
+							events: store.snapshot(),
+							operations: store.operationSummaries(),
+						};
 					}).pipe(Effect.provide(telemetryLayer)),
 				),
 			);
 
-			expect(events).toHaveLength(1);
-			expect(events[0]).toMatchObject({
-				message: "provider.send",
-				category: "provider",
-				providerId: "codex",
-				sessionId: "session-1",
-				severity: "info",
-			});
-			expect(events[0]?.detail).not.toContain("private");
+			expect(result.events).toHaveLength(0);
+			expect(result.operations).toContainEqual(
+				expect.objectContaining({ name: "provider.send", count: 1 }),
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("treats Effect stream completion as a successful aggregate", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-done-span-"));
+		const storeLayer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		const telemetryLayer = TelemetryObservabilityLive.pipe(
+			Layer.provideMerge(storeLayer),
+		);
+		try {
+			const result = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						yield* Cause.done().pipe(
+							Effect.withSpan("provider.stream"),
+							Effect.exit,
+						);
+						const store = yield* TelemetryStore;
+						return {
+							events: store.snapshot(),
+							operations: store.operationSummaries(),
+						};
+					}).pipe(Effect.provide(telemetryLayer)),
+				),
+			);
+			expect(result.events).toHaveLength(0);
+			expect(result.operations).toContainEqual(
+				expect.objectContaining({
+					name: "provider.stream",
+					count: 1,
+					failureCount: 0,
+				}),
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("retains failing and interrupted Effect spans as incidents", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-incident-span-"));
+		const storeLayer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		const telemetryLayer = TelemetryObservabilityLive.pipe(
+			Layer.provideMerge(storeLayer),
+		);
+		try {
+			const events = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						yield* Effect.fail("unavailable").pipe(
+							Effect.withSpan("provider.failure"),
+							Effect.exit,
+						);
+						yield* Effect.interrupt.pipe(
+							Effect.withSpan("provider.interrupted"),
+							Effect.exit,
+						);
+						const store = yield* TelemetryStore;
+						return store.snapshot();
+					}).pipe(Effect.provide(telemetryLayer)),
+				),
+			);
+			expect(events).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						message: "provider.failure",
+						severity: "error",
+					}),
+					expect.objectContaining({
+						message: "provider.interrupted",
+						severity: "warn",
+					}),
+				]),
+			);
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}
@@ -176,6 +269,7 @@ describe("telemetry store", () => {
 				Effect.scoped(
 					Effect.gen(function* () {
 						const store = yield* TelemetryStore;
+						yield* Effect.sleep("50 millis");
 						return {
 							events: store.snapshot(),
 							parseErrors: store.parseErrorCount,
@@ -206,15 +300,538 @@ describe("telemetry store", () => {
 				Effect.scoped(
 					Effect.gen(function* () {
 						const store = yield* TelemetryStore;
+						yield* Effect.sleep("50 millis");
 						return store.snapshot();
 					}).pipe(Effect.provide(layer)),
 				),
 			);
 			expect(events.map((item) => item.id)).toContain("offline-crash");
 			expect(() => readFileSync(offlinePath, "utf8")).toThrow();
-			expect(
+			expect(readFileSync(eventFile(directory), "utf8")).toContain(
+				"offline-crash",
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("stream-migrates legacy logs without retaining routine trace noise", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-legacy-migration-"));
+		const logsDirectory = join(directory, "logs");
+		mkdirSync(logsDirectory, { recursive: true });
+		const routine = {
+			...event("routine"),
+			severity: "info" as const,
+			message: "sql.execute",
+			durationMs: 4,
+		};
+		writeFileSync(
+			join(logsDirectory, "diagnostics.events.ndjson"),
+			`${JSON.stringify(routine)}\n${JSON.stringify({
+				...event("incident"),
+				message: "provider.send",
+				durationMs: 12,
+			})}\n`,
+		);
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+
+		try {
+			const result = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						yield* Effect.sleep("100 millis");
+						yield* store.flush;
+						return {
+							events: store.snapshot(),
+							operations: store.operationSummaries(),
+						};
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(result.events.map((item) => item.id)).toEqual(["incident"]);
+			expect(result.operations).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "sql.execute", count: 1 }),
+					expect.objectContaining({ name: "provider.send", count: 1 }),
+				]),
+			);
+			expect(() =>
 				readFileSync(join(logsDirectory, "diagnostics.events.ndjson"), "utf8"),
-			).toContain("offline-crash");
+			).toThrow();
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("resumes legacy migration without duplicating persisted incidents or rollups", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-legacy-resume-"));
+		const logsDirectory = join(directory, "logs");
+		mkdirSync(logsDirectory, { recursive: true });
+		const createdAt = new Date().toISOString();
+		const routine = {
+			...event("routine-resume"),
+			createdAt,
+			severity: "info" as const,
+			message: "sql.execute",
+			durationMs: 4,
+		};
+		const incident = {
+			...event("incident-resume"),
+			createdAt,
+			message: "provider.send",
+			durationMs: 12,
+		};
+		const migratingPath = join(
+			logsDirectory,
+			"diagnostics.events.ndjson.migrating",
+		);
+		writeFileSync(
+			migratingPath,
+			`${JSON.stringify(routine)}\n${JSON.stringify(incident)}\n`,
+		);
+		const migratingStat = statSync(migratingPath);
+		const migrationSource = legacyMigrationSource(
+			migratingPath,
+			migratingStat.size,
+			migratingStat.mtimeMs,
+		);
+		const bucketStart =
+			Math.floor(Date.parse(createdAt) / (5 * 60_000)) * (5 * 60_000);
+		const operation = (durationMs: number) => ({
+			count: 1,
+			failureCount: 0,
+			totalDurationMs: durationMs,
+			maxDurationMs: durationMs,
+			durationBuckets: [0, 1],
+		});
+		writeFileSync(
+			join(
+				logsDirectory,
+				`diagnostics.rollups.${telemetryFileIdentity("desktop", "local")}.ndjson`,
+			),
+			`${JSON.stringify({
+				bucketStart,
+				migrationSource,
+				operations: {
+					"sql.execute": operation(4),
+					"provider.send": operation(12),
+				},
+			})}\n`,
+		);
+		writeFileSync(
+			join(
+				logsDirectory,
+				`diagnostics.events.${telemetryFileIdentity("desktop", "local")}.ndjson`,
+			),
+			[
+				{
+					...incident,
+					runtimeKind: "desktop",
+					captureMode: "incident",
+				},
+				...Array.from({ length: 5_001 }, (_, index) => ({
+					...event(`persisted-${index}`),
+					createdAt,
+				})),
+			]
+				.map((item) => JSON.stringify(item))
+				.join("\n"),
+		);
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+
+		try {
+			const result = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						for (let attempt = 0; attempt < 150; attempt += 1) {
+							if (!existsSync(migratingPath)) break;
+							yield* Effect.sleep("20 millis");
+						}
+						yield* store.flush;
+						return {
+							events: store.snapshot(),
+							exported: yield* store.exportEvents({}),
+							operations: store.operationSummaries(),
+						};
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(
+				result.exported.events.filter((item) => item.id === "incident-resume"),
+			).toHaveLength(1);
+			expect(result.events.some((item) => item.id === "incident-resume")).toBe(
+				false,
+			);
+			expect(result.events.at(-1)?.id).toBe("persisted-5000");
+			expect(result.operations).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "sql.execute", count: 1 }),
+					expect.objectContaining({ name: "provider.send", count: 1 }),
+				]),
+			);
+			expect(existsSync(migratingPath)).toBe(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("prunes identity-scoped incident files older than seven days", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-telemetry-retention-"));
+		const logsDirectory = join(directory, "logs");
+		mkdirSync(logsDirectory, { recursive: true });
+		const path = join(
+			logsDirectory,
+			`diagnostics.events.${telemetryFileIdentity("desktop", "local")}.ndjson`,
+		);
+		writeFileSync(path, `${JSON.stringify(event("expired"))}\n`);
+		const expiredAt = new Date(Date.now() - 8 * 24 * 60 * 60 * 1_000);
+		utimesSync(path, expiredAt, expiredAt);
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		try {
+			const events = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						yield* Effect.sleep("10 millis");
+						return store.snapshot();
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(events).toHaveLength(0);
+			expect(existsSync(path)).toBe(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("prunes expired events inside active incident and full-trace files", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-event-retention-"));
+		const logsDirectory = join(directory, "logs");
+		mkdirSync(logsDirectory, { recursive: true });
+		const suffix = telemetryFileIdentity("desktop", "local");
+		const incidentPath = join(
+			logsDirectory,
+			`diagnostics.events.${suffix}.ndjson`,
+		);
+		const fullPath = join(
+			logsDirectory,
+			`diagnostics.full-trace.${suffix}.ndjson`,
+		);
+		const expired = {
+			...event("expired-mixed"),
+			createdAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1_000).toISOString(),
+		};
+		const recent = event("recent-mixed");
+		writeFileSync(
+			incidentPath,
+			`${JSON.stringify(expired)}\n${JSON.stringify(recent)}\n`,
+		);
+		writeFileSync(fullPath, `${JSON.stringify(expired)}\n`);
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+
+		try {
+			const result = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						yield* Effect.sleep("100 millis");
+						yield* store.flush;
+						return {
+							events: store.snapshot(),
+							exported: yield* store.exportEvents({}),
+						};
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(result.events.map((item) => item.id)).toEqual(["recent-mixed"]);
+			expect(result.exported.events.map((item) => item.id)).toEqual([
+				"recent-mixed",
+			]);
+			expect(readFileSync(incidentPath, "utf8")).not.toContain("expired-mixed");
+			expect(existsSync(fullPath)).toBe(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps policy incidents and ignores normal stream completion", () => {
+		expect(
+			shouldPersistOperationEvent(
+				{ name: "fast", outcome: "success", durationMs: 20 },
+				"incident",
+			),
+		).toBe(false);
+		expect(
+			shouldPersistOperationEvent(
+				{ name: "slow", outcome: "success", durationMs: 1_000 },
+				"incident",
+			),
+		).toBe(true);
+		expect(
+			shouldPersistOperationEvent(
+				{ name: "failed", outcome: "failure", durationMs: 1 },
+				"incident",
+			),
+		).toBe(true);
+		expect(
+			shouldPersistOperationEvent(
+				{ name: "stream", outcome: "done", durationMs: 60_000 },
+				"incident",
+			),
+		).toBe(false);
+	});
+
+	it("keeps long-operation p95 distinct from the maximum", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-long-p95-"));
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		try {
+			const summary = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						for (let index = 0; index < 95; index += 1) {
+							store.recordOperation({
+								name: "provider.long",
+								outcome: "success",
+								durationMs: 40_000,
+							});
+						}
+						for (let index = 0; index < 5; index += 1) {
+							store.recordOperation({
+								name: "provider.long",
+								outcome: "success",
+								durationMs: 120_000,
+							});
+						}
+						return store.operationSummaries()[0];
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(summary).toMatchObject({
+				name: "provider.long",
+				count: 100,
+				p95DurationMs: 60_000,
+				maxDurationMs: 120_000,
+			});
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("bounds 100,000 routine operations in aggregate rollups", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-telemetry-stress-"));
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		try {
+			const result = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						for (let index = 0; index < 100_000; index += 1) {
+							store.recordOperation({
+								name: "sql.execute",
+								outcome: "success",
+								durationMs: 2,
+							});
+						}
+						return {
+							events: store.snapshot(),
+							operations: store.operationSummaries(),
+						};
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(result.events).toHaveLength(0);
+			expect(result.operations[0]).toMatchObject({
+				name: "sql.execute",
+				count: 100_000,
+			});
+			const files = readdirSync(join(directory, "logs"));
+			expect(files.some((name) => name.startsWith("diagnostics.events."))).toBe(
+				false,
+			);
+			const rollup = files.find((name) =>
+				name.startsWith("diagnostics.rollups."),
+			);
+			expect(rollup).toBeDefined();
+			expect(
+				statSync(join(directory, "logs", rollup ?? "missing")).size,
+			).toBeLessThan(32 * 1024 * 1024);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("persists a completed five-minute rollup without a later operation", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-03T00:00:00.000Z"));
+		const directory = mkdtempSync(join(tmpdir(), "zuse-rollup-boundary-"));
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		try {
+			await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						store.recordOperation({
+							name: "session.reconcile",
+							outcome: "success",
+							durationMs: 8,
+						});
+						vi.advanceTimersByTime(5 * 60_000 + 1);
+						yield* store.flush;
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			const rollup = readdirSync(join(directory, "logs")).find((name) =>
+				name.startsWith("diagnostics.rollups.desktop-"),
+			);
+			expect(rollup).toBeDefined();
+			expect(
+				readFileSync(join(directory, "logs", rollup ?? "missing"), "utf8"),
+			).toContain("session.reconcile");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("expires and overwrites a bounded full trace", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-03T00:00:00.000Z"));
+		const directory = mkdtempSync(join(tmpdir(), "zuse-full-trace-"));
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		try {
+			const result = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						yield* store.setCapture({ mode: "full", durationMinutes: 5 });
+						for (let index = 0; index < 21_000; index += 1) {
+							store.record({
+								...event(`routine-${index}`),
+								severity: "info",
+								durationMs: 5,
+							});
+						}
+						yield* store.flush;
+						const count = store.snapshot().length;
+						vi.setSystemTime(new Date("2026-08-03T00:05:01.000Z"));
+						return {
+							count,
+							capture: store.captureState(),
+							dropped: store.droppedEventCount(),
+							truncated: store.truncatedEventCount(),
+						};
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(result.count).toBe(20_000);
+			expect(result.capture.captureMode).toBe("incident");
+			expect(result.dropped).toBeGreaterThan(0);
+			expect(result.truncated).toBe(1_000);
+			const fullFile = join(
+				directory,
+				"logs",
+				readdirSync(join(directory, "logs")).find((name) =>
+					name.startsWith("diagnostics.full-trace."),
+				) ?? "missing",
+			);
+			expect(statSync(fullFile).size).toBeLessThanOrEqual(10 * 1024 * 1024);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("uses independent hashed files for desktop and Serve writers", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-runtime-identity-"));
+		try {
+			await Promise.all(
+				[
+					{ kind: "desktop" as const, instance: "local" },
+					{ kind: "serve" as const, instance: "127.0.0.1:4321" },
+				].map((telemetryIdentity) => {
+					const layer = TelemetryStoreLive.pipe(
+						Layer.provide(
+							Layer.succeed(AppPaths, {
+								userData: directory,
+								telemetryIdentity,
+							}),
+						),
+					);
+					return Effect.runPromise(
+						Effect.scoped(
+							Effect.gen(function* () {
+								const store = yield* TelemetryStore;
+								store.record(event(telemetryIdentity.kind));
+								yield* store.flush;
+							}).pipe(Effect.provide(layer)),
+						),
+					);
+				}),
+			);
+			const names = readdirSync(join(directory, "logs"));
+			expect(
+				names.some((name) => name.startsWith("diagnostics.events.desktop-")),
+			).toBe(true);
+			expect(
+				names.some((name) => name.startsWith("diagnostics.events.serve-")),
+			).toBe(true);
+			expect(names.join(" ")).not.toContain("127.0.0.1");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("exports only the 25,000 newest relevant events with truncation metadata", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-export-bound-"));
+		const logsDirectory = join(directory, "logs");
+		mkdirSync(logsDirectory, { recursive: true });
+		const path = join(
+			logsDirectory,
+			`diagnostics.events.${telemetryFileIdentity("desktop", "local")}.ndjson`,
+		);
+		const start = Date.parse("2026-08-03T00:00:00.000Z");
+		writeFileSync(
+			path,
+			Array.from({ length: 25_100 }, (_, index) =>
+				JSON.stringify({
+					...event(`export-${index}`),
+					createdAt: new Date(start + index).toISOString(),
+				}),
+			).join("\n"),
+		);
+		const layer = TelemetryStoreLive.pipe(
+			Layer.provide(Layer.succeed(AppPaths, { userData: directory })),
+		);
+		try {
+			const exported = await Effect.runPromise(
+				Effect.scoped(
+					Effect.gen(function* () {
+						const store = yield* TelemetryStore;
+						return yield* store.exportEvents({});
+					}).pipe(Effect.provide(layer)),
+				),
+			);
+			expect(exported.events).toHaveLength(25_000);
+			expect(exported.truncated).toBe(100);
+			expect(exported.events[0]?.id).toBe("export-100");
+			expect(exported.events.at(-1)?.id).toBe("export-25099");
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}

--- a/docs/specs/runtime-telemetry.md
+++ b/docs/specs/runtime-telemetry.md
@@ -12,14 +12,22 @@ are separate:
 
 ## Local capture
 
-The server installs one Effect tracer around the complete RPC runtime. RPC
-operations and explicitly instrumented provider boundaries are recorded as
-structured diagnostic events. Events are kept in memory for live queries and
-written asynchronously to rotating NDJSON files under the app data directory.
+The server installs one Effect tracer around the complete RPC runtime. Every
+operation updates a bounded five-minute aggregate with counts and duration
+histograms. Individual events are retained only for warnings, failures, genuine
+interruptions, and operations lasting at least one second.
 
-The store retains at most 100,000 events, rotates at 20 MB, keeps five files,
-and removes files older than seven days. Capture, serialization, rotation, and
-cleanup failures are isolated from normal application behavior.
+Incident capture retains at most 5,000 events. A user can temporarily enable a
+separate full trace for 5, 15, or 30 minutes; it retains at most 20,000 events
+and 10 MB, overwrites the previous debug capture, and automatically returns to
+incident capture. Seven days of five-minute operation rollups preserve counts,
+p95 timings, and maximum timings without retaining routine successful spans.
+
+Desktop and Serve processes write independent files whose names contain a
+hashed runtime identity. Startup uses bounded tail reads, while legacy shared
+logs are streamed through an incident-first migration in the background.
+Capture, serialization, migration, rotation, and cleanup failures are isolated
+from normal application behavior.
 
 Diagnostic polling RPCs are excluded from local span capture so opening the
 Diagnostics page cannot create a feedback loop.
@@ -31,7 +39,9 @@ message content, files, terminal output, environment values, credentials, URL
 query values, and raw command arguments are excluded. Failure causes and
 allowed string attributes are scrubbed again before persistence and export.
 
-Support bundles apply the existing second redaction pass.
+Support bundles apply the existing second redaction pass, merge runtime files,
+retain at most the newest 25,000 relevant events, report truncation, and stream
+artifacts into the ZIP.
 
 ## Optional OTLP export
 

--- a/packages/contracts/src/diagnostics.ts
+++ b/packages/contracts/src/diagnostics.ts
@@ -19,6 +19,12 @@ export const DiagnosticRecoveryStatus = Schema.Literals([
 ]);
 export type DiagnosticRecoveryStatus = typeof DiagnosticRecoveryStatus.Type;
 
+export const DiagnosticRuntimeKind = Schema.Literals(["desktop", "serve"]);
+export type DiagnosticRuntimeKind = typeof DiagnosticRuntimeKind.Type;
+
+export const DiagnosticCaptureMode = Schema.Literals(["incident", "full"]);
+export type DiagnosticCaptureMode = typeof DiagnosticCaptureMode.Type;
+
 export const DiagnosticEvent = Schema.Struct({
 	id: Schema.String,
 	createdAt: Schema.String,
@@ -37,6 +43,8 @@ export const DiagnosticEvent = Schema.Struct({
 	sessionId: Schema.optional(Schema.NullOr(Schema.String)),
 	providerId: Schema.optional(Schema.NullOr(Schema.String)),
 	durationMs: Schema.optional(Schema.Number),
+	runtimeKind: Schema.optional(DiagnosticRuntimeKind),
+	captureMode: Schema.optional(DiagnosticCaptureMode),
 });
 export type DiagnosticEvent = typeof DiagnosticEvent.Type;
 
@@ -67,6 +75,10 @@ export class DiagnosticsOverviewResult extends Schema.Class<DiagnosticsOverviewR
 	unseenCount: Schema.Number,
 	storageBytes: Schema.Number,
 	capturePaused: Schema.Boolean,
+	captureMode: DiagnosticCaptureMode,
+	fullCaptureEndsAt: Schema.NullOr(Schema.String),
+	droppedEventCount: Schema.Number,
+	truncatedEventCount: Schema.Number,
 	previousRunUnclean: Schema.Boolean,
 	latestIncidents: Schema.Array(DiagnosticEvent),
 	commonFailures: Schema.Array(DiagnosticFailureGroup),
@@ -119,6 +131,22 @@ export class DiagnosticsProcessesResult extends Schema.Class<DiagnosticsProcesse
 export class DiagnosticsSignalResult extends Schema.Class<DiagnosticsSignalResult>(
 	"DiagnosticsSignalResult",
 )({ signaled: Schema.Boolean, message: Schema.optional(Schema.String) }) {}
+
+export class DiagnosticsCaptureResult extends Schema.Class<DiagnosticsCaptureResult>(
+	"DiagnosticsCaptureResult",
+)({
+	captureMode: DiagnosticCaptureMode,
+	fullCaptureEndsAt: Schema.NullOr(Schema.String),
+}) {}
+
+export const DiagnosticsCapturePayload = Schema.Union([
+	Schema.Struct({ mode: Schema.Literal("incident") }),
+	Schema.Struct({
+		mode: Schema.Literal("full"),
+		durationMinutes: Schema.Literals([5, 15, 30]),
+	}),
+]);
+export type DiagnosticsCapturePayload = typeof DiagnosticsCapturePayload.Type;
 
 const DiagnosticArtifactName = Schema.String;
 const DiagnosticsLogEntry = Schema.Struct({
@@ -201,6 +229,12 @@ export const DiagnosticsSignalRpc = Rpc.make("diagnostics.signalProcess", {
 export const DiagnosticsIngestRpc = Rpc.make("diagnostics.ingest", {
 	payload: Schema.Struct({ events: Schema.Array(DiagnosticEvent) }),
 	success: Schema.Void,
+	error: DiagnosticsError,
+});
+
+export const DiagnosticsCaptureRpc = Rpc.make("diagnostics.capture", {
+	payload: DiagnosticsCapturePayload,
+	success: DiagnosticsCaptureResult,
 	error: DiagnosticsError,
 });
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -40,6 +40,7 @@ import {
 } from "./connect.ts";
 import { ContextSaveTextRpc } from "./context.ts";
 import {
+	DiagnosticsCaptureRpc,
 	DiagnosticsEventsRpc,
 	DiagnosticsExportRpc,
 	DiagnosticsIngestRpc,
@@ -445,6 +446,7 @@ export const MemoizeRpcs = RpcGroup.make(
 	DiagnosticsProcessesRpc,
 	DiagnosticsSignalRpc,
 	DiagnosticsIngestRpc,
+	DiagnosticsCaptureRpc,
 	KeybindingsGetRpc,
 	KeybindingsReplaceRpc,
 	KeybindingsStreamRpc,


### PR DESCRIPTION
## Summary

- switch diagnostics to incident-first event persistence while retaining bounded operation aggregates
- add temporary 5, 15, and 30 minute full-trace capture with automatic expiry
- isolate desktop and Serve telemetry writers with hashed runtime identities
- stream legacy migration, retention cleanup, and support-bundle artifacts with bounded reads and explicit truncation metadata
- add Diagnostics storage controls for capture duration, state, and expiry

## Root cause

Diagnostics retained roughly 100,000 events, primarily routine successful spans, then repeatedly copied, sorted, serialized, and reloaded the full set. This caused avoidable main-process memory growth and export spikes.

## Behavior

Routine successful operations now contribute to five-minute rollups without creating individual incident events. Failures, interruptions, warnings, and operations slower than one second remain visible. Normal Effect stream completion is treated as successful completion.

Incident capture is limited to 5,000 events. Temporary full traces are limited to 20,000 events and 10 MB. Support bundles merge runtime data and include at most the newest 25,000 relevant events.

## Validation

- server unit tests: 217 passed
- renderer unit tests: 318 passed
- desktop unit tests: 58 passed
- server, renderer, desktop, and contracts typechecks passed
- changed-file Biome checks passed
- desktop production build passed
- two independent code reviews found no remaining blockers

## Remaining packaged-runtime acceptance

- rerun the captured support-bundle gate
- run the packaged two-hour idle soak including sleep/wake, ten minutes with Diagnostics live, and a support-bundle export

The source implementation does not raise the V8 heap limit.