### PR TITLE
Configure documentation deployment

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -27,16 +27,18 @@ Create a dedicated Vercel project for the docs site with these settings:
 | --- | --- |
 | Root Directory | `apps/docs` |
 | Framework Preset | Next.js |
-| Install Command | `bun install --frozen-lockfile` |
+| Include source files outside Root Directory | Off |
+| Install Command | `bun install` |
 | Build Command | `bun run build` |
 | Output Directory | Leave at the framework default |
 | Production Domain | `docs.zuse.sh` |
 
-Vercel detects Bun from the root `bun.lock` and the `packageManager` field in
-the root `package.json`. The install command runs from Vercel's prepared project
-checkout, so it must not include `cd ../..` or any other parent-directory
-traversal. Do not set the output directory to `.next`; the Next.js preset
-manages the deployment output.
+Keep the deployment scoped to `apps/docs`. If files outside the Root Directory
+are included, Bun discovers the repository workspace and attempts to install
+unrelated application packages, including private dependencies that the docs do
+not use. The install command must not include `cd ../..` or any other
+parent-directory traversal. Do not set the output directory to `.next`; the
+Next.js preset manages the deployment output.
 
 The Vercel project's Root Directory is a dashboard setting and cannot be set
 inside `vercel.json`. After changing it, redeploy the latest commit so the new

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -27,15 +27,16 @@ Create a dedicated Vercel project for the docs site with these settings:
 | --- | --- |
 | Root Directory | `apps/docs` |
 | Framework Preset | Next.js |
-| Install Command | Leave at the framework default |
+| Install Command | `bun install --frozen-lockfile` |
 | Build Command | `bun run build` |
 | Output Directory | Leave at the framework default |
 | Production Domain | `docs.zuse.sh` |
 
 Vercel detects Bun from the root `bun.lock` and the `packageManager` field in
-the root `package.json`. Leaving the install command at its default lets Vercel
-install the complete workspace from that lockfile. Do not set the output
-directory to `.next`; the Next.js preset manages the deployment output.
+the root `package.json`. The install command runs from Vercel's prepared project
+checkout, so it must not include `cd ../..` or any other parent-directory
+traversal. Do not set the output directory to `.next`; the Next.js preset
+manages the deployment output.
 
 The Vercel project's Root Directory is a dashboard setting and cannot be set
 inside `vercel.json`. After changing it, redeploy the latest commit so the new

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,0 +1,53 @@
+# Zuse documentation
+
+The documentation site is a Next.js application in the repository's Bun
+workspace.
+
+## Local development
+
+Install dependencies once from the repository root:
+
+```bash
+bun install --frozen-lockfile
+```
+
+Then start the docs app:
+
+```bash
+bun run --cwd apps/docs dev
+```
+
+The local site is available at `http://localhost:3002`.
+
+## Vercel project settings
+
+Create a dedicated Vercel project for the docs site with these settings:
+
+| Setting | Value |
+| --- | --- |
+| Root Directory | `apps/docs` |
+| Framework Preset | Next.js |
+| Install Command | Leave at the framework default |
+| Build Command | `bun run build` |
+| Output Directory | Leave at the framework default |
+| Production Domain | `docs.zuse.sh` |
+
+Vercel detects Bun from the root `bun.lock` and the `packageManager` field in
+the root `package.json`. Leaving the install command at its default lets Vercel
+install the complete workspace from that lockfile. Do not set the output
+directory to `.next`; the Next.js preset manages the deployment output.
+
+The Vercel project's Root Directory is a dashboard setting and cannot be set
+inside `vercel.json`. After changing it, redeploy the latest commit so the new
+working directory is applied.
+
+## Production build
+
+Run the same application build locally from the repository root:
+
+```bash
+bun run --cwd apps/docs build
+```
+
+No separate documentation CI workflow is required. Git-connected preview and
+production deployments are handled by the dedicated Vercel project.

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,5 +1,4 @@
 {
-	"framework": "nextjs",
-	"buildCommand": "bun run build",
-	"installCommand": "bun install"
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"framework": "nextjs"
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"framework": "nextjs",
-	"installCommand": "bun install --frozen-lockfile",
+	"installCommand": "bun install",
 	"buildCommand": "bun run build"
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"framework": "nextjs"
+	"framework": "nextjs",
+	"installCommand": "bun install --frozen-lockfile",
+	"buildCommand": "bun run build"
 }


### PR DESCRIPTION
## What changed

- configure the `zuse-docs` Vercel project with Root Directory `apps/docs`
- switch the project from its stale Astro preset to Next.js
- scope source and dependency installation to the docs app so unrelated private workspace packages are not fetched
- use `bun install`, `bun run build`, and the framework-managed output directory
- document the hosted project settings and local development commands

## Root causes

The hosted project was still configured for the previous app shape: repository Root Directory `.`, Astro, output directory `dist`, and commands beginning with `cd ../..`. That made the install command escape the checkout.

After correcting the root, Vercel still included files outside `apps/docs`, so Bun discovered the entire monorepo and attempted to install unrelated private application dependencies. Disabling outside-root source inclusion keeps the docs deployment self-contained.

## Validation

- reproduced the original missing-`package.json` failure
- verified the hosted `zuse-docs` project now reports `apps/docs`, Next.js, `bun install`, `bun run build`, and framework-default output
- `bun run --cwd apps/docs check-types`
- `bun run --cwd apps/docs build` (83 routes generated)
- Biome check for the changed configuration and documentation files
- Vercel preview completed successfully: https://zuse-docs-3yp8qg5e5-swarajbachus-projects.vercel.app