### PR TITLE
Release v0.17.0

### DIFF
--- a/.claude/commands/release-new-version.md
+++ b/.claude/commands/release-new-version.md
@@ -1,4 +1,4 @@
-Release a new memoize version.
+Release a new Zuse version.
 
 Use the `release-new-version` skill from this repository.
 
@@ -8,4 +8,4 @@ If the user provided arguments, pass them through to `scripts/release-new-versio
 - `patch` -> `--kind=patch`
 - a semver version like `0.5.1` -> `--version=0.5.1`
 
-Follow the skill workflow exactly: inspect git state, pull `origin/main`, infer or ask for the bump level, update changelog/package metadata, verify, commit, push, and create the PR.
+Follow the skill workflow exactly: inspect git state, inventory and classify the release evidence, write curated user-facing notes, update changelog/package metadata, verify, commit, push, merge, tag, and verify the release artifacts.

--- a/.claude/skills/release-new-version/SKILL.md
+++ b/.claude/skills/release-new-version/SKILL.md
@@ -1,48 +1,78 @@
 ---
 name: release-new-version
-description: Release a new memoize version from this repository. Use when the user asks to release, bump versions, add changelogs, update the website changelog, create a release PR, or run the "Release New Version" slash command.
+description: Prepare and publish a new Zuse version with curated release notes, version metadata, a release PR, a version tag, and verified release artifacts.
 ---
 
 # Release New Version
 
-Run this skill from the memoize repository root.
+Run this skill from the Zuse repository root. A release request means carrying the workflow through the tag and release workflow when repository access and checks permit it.
+
+## Release Standard
+
+Release notes are a product summary, not a commit or PR dump. Every note must be supported by the diff, commit body, tests, or PR description.
+
+Use these sections in this order and omit empty sections:
+
+1. `Added` — a capability users can do now that they could not do before.
+2. `Changed` — a meaningful change to an existing workflow, behavior, performance characteristic, documentation surface, or compatibility guarantee.
+3. `Fixed` — a defect, regression, crash, reliability issue, or incorrect behavior that was corrected.
+
+Quality rules:
+
+- Start with the user-visible outcome; mention implementation detail only when it helps users act.
+- Do not paste raw commit titles, conventional-commit prefixes, PR numbers, or repository housekeeping.
+- Deduplicate related commits into one accurate product change.
+- Give an important new feature a complete explanation of what is available and why or where it matters. Do not reduce it to a PR reference.
+- Keep routine bullets to one sentence. An important feature may use two concise sentences in one bullet.
+- Exclude refactors, test-only work, dependency churn, and internal tooling unless they materially affect users or operators.
+- Use `Fixed`, not `Changed`, merely because a fix altered code.
 
 ## Workflow
 
-1. Inspect `git status --short --branch`. If the working tree is dirty, explain that release automation needs a clean tree unless the user explicitly wants those changes included.
-2. Pull the latest base with `git fetch --prune origin` and `git pull --ff-only origin main`.
-3. Compare commits since the current `apps/desktop/package.json` version tag, e.g. `git log --pretty=format:%s v0.5.0..HEAD`.
-4. Decide the version bump:
-   - major: several breaking or migration-heavy changes.
-   - minor: multiple user-visible features or workflow changes.
-   - patch: fixes, polish, or small internal changes.
-   - If the signal is mixed or ambiguous, ask the user for `major`, `minor`, `patch`, or an explicit semver version.
-5. Run the helper script:
+1. Inspect `git status --short --branch`. Do not mix unrelated dirty work into a release.
+2. Fetch `origin`, base the release on current `origin/main`, and confirm the package version tag exists.
+3. Build an evidence inventory from `git log`, `git diff --stat`, relevant diffs, and PR bodies between `v<current-version>` and `origin/main`. Inspect details for any important or ambiguous change.
+4. Choose the bump:
+   - major: breaking compatibility or migration requirements.
+   - minor: a meaningful new user-visible capability or workflow.
+   - patch: fixes, polish, documentation, or internal changes only.
+   - Ask only when the evidence does not support a clear choice and the user did not specify one.
+5. Draft a temporary Markdown notes file containing only the curated `### Added`, `### Changed`, and `### Fixed` sections. Show the proposed version and notes before mutation when the request is interactive.
+6. Run the helper with the explicit decision and curated notes:
 
 ```bash
-node scripts/release-new-version.mjs --yes
+node scripts/release-new-version.mjs --version=x.y.z --notes-file=/absolute/path/to/release-notes.md --yes
 ```
 
-Use `--kind=major`, `--kind=minor`, `--kind=patch`, or `--version=x.y.z` when the user gave a specific choice.
+Use `--kind=major`, `--kind=minor`, or `--kind=patch` instead of `--version` when appropriate. The helper can generate a categorized fallback, but important releases must use curated notes.
 
-## What The Script Does
-
-- Pulls from `origin/main`.
-- Updates `apps/desktop/package.json` and `bun.lock`.
-- Adds a new `CHANGELOG.md` entry when one is missing.
-- Stages changelog, package metadata, the website changelog page, and this skill.
-- Runs `bun run check-types`.
-- Commits the release changes.
-- Pushes the branch.
-- Creates a GitHub PR against `main`.
-
-## After The PR Lands
-
-The repository release workflow is tag-driven. Create and push `vX.Y.Z` from `main` after merge to build, notarize, and publish the draft GitHub Release:
+7. Inspect the resulting `CHANGELOG.md`, generated website changelog, commit, and PR. Confirm category accuracy, user-facing explanations, the version, and the exact checks run.
+8. Wait for required PR checks, merge using repository policy, update from `origin/main`, and tag the exact merged release commit:
 
 ```bash
-git checkout main
-git pull --ff-only origin main
-git tag vX.Y.Z
+git fetch --prune origin
+git tag vX.Y.Z origin/main
 git push origin vX.Y.Z
 ```
+
+9. Verify the tag-triggered release workflow succeeds and that the expected GitHub Release and artifacts exist. If anything is still running or blocked, report it as pending rather than done.
+
+## What The Helper Does
+
+- Refuses a dirty tree and pulls the latest `origin/main`.
+- Determines and validates the next semantic version.
+- Moves curated `Unreleased` notes into the new release and cleanly groups fallback notes as `Added`, `Changed`, and `Fixed`.
+- Updates `apps/desktop/package.json`, `bun.lock`, `CHANGELOG.md`, and the website changelog data.
+- Runs the website content generator and `bun run check-types`.
+- Commits, pushes the release branch, and creates a PR whose summary reflects the actual release notes.
+
+## Completion Report
+
+Report release state with explicit outcomes:
+
+- version and bump reason;
+- release-note highlights by category;
+- validation commands and results;
+- PR and merge state;
+- tag and release-workflow state;
+- published artifacts, or the precise remaining blocker.

--- a/.codex/commands/release-new-version.md
+++ b/.codex/commands/release-new-version.md
@@ -1,4 +1,4 @@
-Release a new memoize version.
+Release a new Zuse version.
 
 Use the `release-new-version` skill from this repository.
 
@@ -8,4 +8,4 @@ If the user provided arguments, pass them through to `scripts/release-new-versio
 - `patch` -> `--kind=patch`
 - a semver version like `0.5.1` -> `--version=0.5.1`
 
-Follow the skill workflow exactly: inspect git state, pull `origin/main`, infer or ask for the bump level, update changelog/package metadata, verify, commit, push, and create the PR.
+Follow the skill workflow exactly: inspect git state, inventory and classify the release evidence, write curated user-facing notes, update changelog/package metadata, verify, commit, push, merge, tag, and verify the release artifacts.

--- a/.codex/skills/release-new-version/SKILL.md
+++ b/.codex/skills/release-new-version/SKILL.md
@@ -1,48 +1,78 @@
 ---
 name: release-new-version
-description: Release a new memoize version from this repository. Use when the user asks to release, bump versions, add changelogs, update the website changelog, create a release PR, or run the "Release New Version" slash command.
+description: Prepare and publish a new Zuse version with curated release notes, version metadata, a release PR, a version tag, and verified release artifacts.
 ---
 
 # Release New Version
 
-Run this skill from the memoize repository root.
+Run this skill from the Zuse repository root. A release request means carrying the workflow through the tag and release workflow when repository access and checks permit it.
+
+## Release Standard
+
+Release notes are a product summary, not a commit or PR dump. Every note must be supported by the diff, commit body, tests, or PR description.
+
+Use these sections in this order and omit empty sections:
+
+1. `Added` — a capability users can do now that they could not do before.
+2. `Changed` — a meaningful change to an existing workflow, behavior, performance characteristic, documentation surface, or compatibility guarantee.
+3. `Fixed` — a defect, regression, crash, reliability issue, or incorrect behavior that was corrected.
+
+Quality rules:
+
+- Start with the user-visible outcome; mention implementation detail only when it helps users act.
+- Do not paste raw commit titles, conventional-commit prefixes, PR numbers, or repository housekeeping.
+- Deduplicate related commits into one accurate product change.
+- Give an important new feature a complete explanation of what is available and why or where it matters. Do not reduce it to a PR reference.
+- Keep routine bullets to one sentence. An important feature may use two concise sentences in one bullet.
+- Exclude refactors, test-only work, dependency churn, and internal tooling unless they materially affect users or operators.
+- Use `Fixed`, not `Changed`, merely because a fix altered code.
 
 ## Workflow
 
-1. Inspect `git status --short --branch`. If the working tree is dirty, explain that release automation needs a clean tree unless the user explicitly wants those changes included.
-2. Pull the latest base with `git fetch --prune origin` and `git pull --ff-only origin main`.
-3. Compare commits since the current `apps/desktop/package.json` version tag, e.g. `git log --pretty=format:%s v0.5.0..HEAD`.
-4. Decide the version bump:
-   - major: several breaking or migration-heavy changes.
-   - minor: multiple user-visible features or workflow changes.
-   - patch: fixes, polish, or small internal changes.
-   - If the signal is mixed or ambiguous, ask the user for `major`, `minor`, `patch`, or an explicit semver version.
-5. Run the helper script:
+1. Inspect `git status --short --branch`. Do not mix unrelated dirty work into a release.
+2. Fetch `origin`, base the release on current `origin/main`, and confirm the package version tag exists.
+3. Build an evidence inventory from `git log`, `git diff --stat`, relevant diffs, and PR bodies between `v<current-version>` and `origin/main`. Inspect details for any important or ambiguous change.
+4. Choose the bump:
+   - major: breaking compatibility or migration requirements.
+   - minor: a meaningful new user-visible capability or workflow.
+   - patch: fixes, polish, documentation, or internal changes only.
+   - Ask only when the evidence does not support a clear choice and the user did not specify one.
+5. Draft a temporary Markdown notes file containing only the curated `### Added`, `### Changed`, and `### Fixed` sections. Show the proposed version and notes before mutation when the request is interactive.
+6. Run the helper with the explicit decision and curated notes:
 
 ```bash
-node scripts/release-new-version.mjs --yes
+node scripts/release-new-version.mjs --version=x.y.z --notes-file=/absolute/path/to/release-notes.md --yes
 ```
 
-Use `--kind=major`, `--kind=minor`, `--kind=patch`, or `--version=x.y.z` when the user gave a specific choice.
+Use `--kind=major`, `--kind=minor`, or `--kind=patch` instead of `--version` when appropriate. The helper can generate a categorized fallback, but important releases must use curated notes.
 
-## What The Script Does
-
-- Pulls from `origin/main`.
-- Updates `apps/desktop/package.json` and `bun.lock`.
-- Adds a new `CHANGELOG.md` entry when one is missing.
-- Stages changelog, package metadata, the website changelog page, and this skill.
-- Runs `bun run check-types`.
-- Commits the release changes.
-- Pushes the branch.
-- Creates a GitHub PR against `main`.
-
-## After The PR Lands
-
-The repository release workflow is tag-driven. Create and push `vX.Y.Z` from `main` after merge to build, notarize, and publish the draft GitHub Release:
+7. Inspect the resulting `CHANGELOG.md`, generated website changelog, commit, and PR. Confirm category accuracy, user-facing explanations, the version, and the exact checks run.
+8. Wait for required PR checks, merge using repository policy, update from `origin/main`, and tag the exact merged release commit:
 
 ```bash
-git checkout main
-git pull --ff-only origin main
-git tag vX.Y.Z
+git fetch --prune origin
+git tag vX.Y.Z origin/main
 git push origin vX.Y.Z
 ```
+
+9. Verify the tag-triggered release workflow succeeds and that the expected GitHub Release and artifacts exist. If anything is still running or blocked, report it as pending rather than done.
+
+## What The Helper Does
+
+- Refuses a dirty tree and pulls the latest `origin/main`.
+- Determines and validates the next semantic version.
+- Moves curated `Unreleased` notes into the new release and cleanly groups fallback notes as `Added`, `Changed`, and `Fixed`.
+- Updates `apps/desktop/package.json`, `bun.lock`, `CHANGELOG.md`, and the website changelog data.
+- Runs the website content generator and `bun run check-types`.
+- Commits, pushes the release branch, and creates a PR whose summary reflects the actual release notes.
+
+## Completion Report
+
+Report release state with explicit outcomes:
+
+- version and bump reason;
+- release-note highlights by category;
+- validation commands and results;
+- PR and merge state;
+- tag and release-workflow state;
+- published artifacts, or the precise remaining blocker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0]
+
+### Added
+- Run Zuse natively on x64 Linux with `.deb` and AppImage installers, Linux-native credential storage and browser integration, platform-aware desktop controls, and automatic Linux builds in every release
+- Use the new documentation site for end-to-end guidance on setup, providers, projects and worktrees, remote access, browser workflows, mobile use, and recovery
+
 ### Changed
-- Move the hosted app to `code.zuse.sh` and restore browser relay CORS
-- Publish Serve runtime `0.1.1` with background data-directory support
+- Navigate long conversations by turn while streaming responses, code blocks, and reading position remain stable during updates
+- Move the hosted app to `code.zuse.sh` and update Serve `0.1.1` to preserve its background data-directory state
+- Publish the project license and third-party attribution notices across distributed packages
+
+### Fixed
+- Restore hosted workspace connectivity and reliable thread and state discovery between desktop and Serve runtimes
+- Prevent diagnostics and telemetry capture from growing without bounds while preserving useful export data
 
 ## [0.16.1]
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.16.1",
+	"version": "0.17.0",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "0.17.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Run Zuse natively on x64 Linux with `.deb` and AppImage installers, Linux-native credential storage and browser integration, platform-aware desktop controls, and automatic Linux builds in every release",
+          "Use the new documentation site for end-to-end guidance on setup, providers, projects and worktrees, remote access, browser workflows, mobile use, and recovery"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Navigate long conversations by turn while streaming responses, code blocks, and reading position remain stable during updates",
+          "Move the hosted app to `code.zuse.sh` and update Serve `0.1.1` to preserve its background data-directory state",
+          "Publish the project license and third-party attribution notices across distributed packages"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Restore hosted workspace connectivity and reliable thread and state discovery between desktop and Serve runtimes",
+          "Prevent diagnostics and telemetry capture from growing without bounds while preserving useful export data"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.16.1",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/scripts/release-new-version.mjs
+++ b/scripts/release-new-version.mjs
@@ -1,181 +1,351 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const dryRun = process.argv.includes("--dry-run");
 const explicitVersion = readArg("--version");
 const releaseKind = readArg("--kind");
+const notesFileArg = readArg("--notes-file");
 const yes = process.argv.includes("--yes");
+const sectionOrder = ["Added", "Changed", "Fixed"];
 
 function readArg(name) {
-  const prefix = `${name}=`;
-  const inline = process.argv.find((arg) => arg.startsWith(prefix));
-  if (inline) return inline.slice(prefix.length);
-  const index = process.argv.indexOf(name);
-  return index >= 0 ? process.argv[index + 1] : undefined;
+	const prefix = `${name}=`;
+	const inline = process.argv.find((arg) => arg.startsWith(prefix));
+	if (inline) return inline.slice(prefix.length);
+	const index = process.argv.indexOf(name);
+	return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
 function git(args) {
-  return execFileSync("git", args, {
-    cwd: root,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
+	return execFileSync("git", args, {
+		cwd: root,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
 }
 
 function run(command, args, cwd = root) {
-  const rendered = [command, ...args].join(" ");
-  if (dryRun) {
-    console.log(`[dry-run] ${rendered}`);
-    return "";
-  }
-  return execFileSync(command, args, {
-    cwd,
-    encoding: "utf8",
-    stdio: "inherit",
-  });
+	const rendered = [command, ...args].join(" ");
+	if (dryRun) {
+		console.log(`[dry-run] ${rendered}`);
+		return "";
+	}
+	return execFileSync(command, args, {
+		cwd,
+		encoding: "utf8",
+		stdio: "inherit",
+	});
+}
+
+function write(relativePath, contents) {
+	if (dryRun) {
+		console.log(`[dry-run] write ${relativePath}`);
+		return;
+	}
+	writeFileSync(join(root, relativePath), contents);
 }
 
 function currentBranch() {
-  return git(["branch", "--show-current"]);
+	return git(["branch", "--show-current"]);
 }
 
 function parseVersion(version) {
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) throw new Error(`Expected semver version, got ${version}`);
-  return match.slice(1).map(Number);
+	const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+	if (!match) throw new Error(`Expected semver version, got ${version}`);
+	return match.slice(1).map(Number);
 }
 
 function bumpVersion(version, kind) {
-  const [major, minor, patch] = parseVersion(version);
-  if (kind === "major") return `${major + 1}.0.0`;
-  if (kind === "minor") return `${major}.${minor + 1}.0`;
-  if (kind === "patch") return `${major}.${minor}.${patch + 1}`;
-  throw new Error(`Unknown release kind: ${kind}`);
+	const [major, minor, patch] = parseVersion(version);
+	if (kind === "major") return `${major + 1}.0.0`;
+	if (kind === "minor") return `${major}.${minor + 1}.0`;
+	if (kind === "patch") return `${major}.${minor}.${patch + 1}`;
+	throw new Error(`Unknown release kind: ${kind}`);
+}
+
+function compareVersions(left, right) {
+	const leftParts = parseVersion(left);
+	const rightParts = parseVersion(right);
+	for (let index = 0; index < leftParts.length; index += 1) {
+		const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+		if (difference !== 0) return difference;
+	}
+	return 0;
 }
 
 function inferKind(messages) {
-  const breaking = messages.filter((message) =>
-    /\b(breaking|rename|remove|drop|migration|major)\b/i.test(message),
-  );
-  const features = messages.filter((message) =>
-    /\b(add|adds|added|support|new|stream|gate|custom|mode|feature)\b/i.test(
-      message,
-    ),
-  );
-  const fixes = messages.filter((message) =>
-    /\b(fix|fixed|patch|bug|crash|correct)\b/i.test(message),
-  );
+	const breaking = messages.filter((message) =>
+		/\b(breaking|rename|remove|drop|migration|major)\b/i.test(message),
+	);
+	const features = messages.filter((message) =>
+		/\b(add|adds|added|introduce|launch|support|new|enable|feature)\b/i.test(
+			message,
+		),
+	);
+	const fixes = messages.filter((message) =>
+		/\b(fix|fixed|patch|bug|crash|correct|restore|prevent)\b/i.test(message),
+	);
 
-  if (breaking.length >= 2) return { kind: "minor", confidence: "low" };
-  if (features.length >= 2) return { kind: "minor", confidence: "high" };
-  if (fixes.length > 0 && features.length === 0) {
-    return { kind: "patch", confidence: "high" };
-  }
-  return { kind: "patch", confidence: "low" };
+	if (breaking.length > 0) return { kind: "major", confidence: "low" };
+	if (features.length > 0) return { kind: "minor", confidence: "high" };
+	if (fixes.length > 0) return { kind: "patch", confidence: "high" };
+	return { kind: "patch", confidence: "low" };
 }
 
 function updateJsonVersion(relativePath, nextVersion) {
-  const file = join(root, relativePath);
-  const json = JSON.parse(readFileSync(file, "utf8"));
-  json.version = nextVersion;
-  writeFileSync(file, `${JSON.stringify(json, null, 2)}\n`);
+	const json = JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+	json.version = nextVersion;
+	write(relativePath, `${JSON.stringify(json, null, "\t")}\n`);
 }
 
 function replaceInFile(relativePath, before, after) {
-  const file = join(root, relativePath);
-  const source = readFileSync(file, "utf8");
-  if (!source.includes(before)) {
-    throw new Error(`${relativePath} did not contain expected text: ${before}`);
-  }
-  writeFileSync(file, source.replace(before, after));
+	const source = readFileSync(join(root, relativePath), "utf8");
+	if (!source.includes(before)) {
+		throw new Error(`${relativePath} did not contain expected text: ${before}`);
+	}
+	write(relativePath, source.replace(before, after));
 }
 
-function releaseNotes(version, commits) {
-  const lines = commits.map((commit) => `- ${commit}`);
-  return `## [${version}]\n\n### Changed\n${lines.join("\n")}\n\n`;
+function cleanSummary(summary) {
+	const withoutPrefix = summary.replace(
+		/^(feat|fix|docs|perf|refactor|chore|build|ci|test)(\([^)]*\))?!?:\s*/i,
+		"",
+	);
+	const withoutPr = withoutPrefix.replace(/\s*\(#\d+\)\s*$/, "").trim();
+	if (!withoutPr) return "";
+	return `${withoutPr[0]?.toUpperCase()}${withoutPr.slice(1)}`.replace(
+		/[.;]$/,
+		"",
+	);
+}
+
+function categoryFor(summary) {
+	if (
+		/^(fix|fixed|restore|prevent|avoid|correct|resolve|repair)\b/i.test(summary)
+	) {
+		return "Fixed";
+	}
+	if (
+		/^(add|adds|added|introduce|launch|support|enable|ship|create)\b/i.test(
+			summary,
+		)
+	) {
+		return "Added";
+	}
+	return "Changed";
+}
+
+function emptySections() {
+	return new Map(sectionOrder.map((section) => [section, []]));
+}
+
+function addUnique(sections, section, item) {
+	const cleaned = cleanSummary(item);
+	if (!cleaned) return;
+	const normalized = cleaned
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim();
+	const existing = [...sections.values()].flat();
+	const duplicate = existing.some(
+		(candidate) =>
+			candidate
+				.toLowerCase()
+				.replace(/[^a-z0-9]+/g, " ")
+				.trim() === normalized,
+	);
+	if (!duplicate) sections.get(section)?.push(cleaned);
+}
+
+function parseSections(source, label, strict = false) {
+	const sections = emptySections();
+	let currentSection;
+
+	for (const rawLine of source.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line) continue;
+		const heading = line.match(/^###\s+(.+)$/);
+		if (heading) {
+			const title = heading[1];
+			if (!sectionOrder.includes(title)) {
+				throw new Error(
+					`${label} contains unsupported section "${title}". Use Added, Changed, or Fixed.`,
+				);
+			}
+			currentSection = title;
+			continue;
+		}
+		if (!currentSection || !line.startsWith("- ")) {
+			if (strict) {
+				throw new Error(
+					`${label} must contain only ### section headings and release-note bullets.`,
+				);
+			}
+			continue;
+		}
+		addUnique(sections, currentSection, line.slice(2));
+	}
+
+	if (strict && [...sections.values()].every((items) => items.length === 0)) {
+		throw new Error(`${label} does not contain any release-note bullets.`);
+	}
+	return sections;
+}
+
+function mergeFallbackNotes(changelog, commits) {
+	const marker = "## [Unreleased]";
+	const markerStart = changelog.indexOf(marker);
+	if (markerStart < 0) throw new Error("CHANGELOG.md is missing [Unreleased].");
+	const contentStart = markerStart + marker.length;
+	const nextRelease = changelog.indexOf("\n## [", contentStart);
+	const unreleased = changelog.slice(
+		contentStart,
+		nextRelease < 0 ? changelog.length : nextRelease,
+	);
+	const sections = parseSections(unreleased, "CHANGELOG.md [Unreleased]");
+	for (const commit of commits) {
+		addUnique(sections, categoryFor(commit), commit);
+	}
+	return sections;
+}
+
+function formatSections(sections) {
+	return sectionOrder
+		.filter((section) => (sections.get(section)?.length ?? 0) > 0)
+		.map(
+			(section) =>
+				`### ${section}\n${sections
+					.get(section)
+					?.map((item) => `- ${item}`)
+					.join("\n")}`,
+		)
+		.join("\n\n");
+}
+
+function replaceUnreleased(changelog, version, formattedNotes) {
+	const marker = "## [Unreleased]";
+	const markerStart = changelog.indexOf(marker);
+	if (markerStart < 0) throw new Error("CHANGELOG.md is missing [Unreleased].");
+	const contentStart = markerStart + marker.length;
+	const nextRelease = changelog.indexOf("\n## [", contentStart);
+	const suffix = nextRelease < 0 ? "" : changelog.slice(nextRelease);
+	const prefix = changelog.slice(0, contentStart);
+	return `${prefix}\n\n## [${version}]\n\n${formattedNotes}${suffix.replace(/^\n*/, "\n\n")}`;
+}
+
+function notesFilePath(value) {
+	if (!value) return undefined;
+	return isAbsolute(value) ? value : resolve(root, value);
 }
 
 const status = git(["status", "--porcelain"]);
 if (status) {
-  throw new Error("Working tree is dirty. Commit, stash, or discard changes first.");
+	throw new Error(
+		"Working tree is dirty. Commit, stash, or discard changes first.",
+	);
 }
 
 run("git", ["fetch", "--prune", "origin"]);
 run("git", ["pull", "--ff-only", "origin", "main"]);
 
 const desktopPkg = JSON.parse(
-  readFileSync(join(root, "apps/desktop/package.json"), "utf8"),
+	readFileSync(join(root, "apps/desktop/package.json"), "utf8"),
 );
 const currentVersion = desktopPkg.version;
 const latestTag = `v${currentVersion}`;
+git(["rev-parse", "--verify", `refs/tags/${latestTag}`]);
 const log = git(["log", "--pretty=format:%s", `${latestTag}..HEAD`]);
 const commits = log.split("\n").filter(Boolean);
 
 if (commits.length === 0 && !explicitVersion) {
-  throw new Error(`No commits found after ${latestTag}.`);
+	throw new Error(`No commits found after ${latestTag}.`);
 }
 
 const inferred = inferKind(commits);
 if (!explicitVersion && inferred.confidence === "low" && !releaseKind && !yes) {
-  throw new Error(
-    `Release kind is ambiguous. Re-run with --kind=major, --kind=minor, --kind=patch, or --version=x.y.z.\n` +
-      `Inferred ${inferred.kind} from ${commits.length} commits.`,
-  );
+	throw new Error(
+		`Release kind is ambiguous. Re-run with --kind=major, --kind=minor, --kind=patch, or --version=x.y.z.\n` +
+			`Inferred ${inferred.kind} from ${commits.length} commits.`,
+	);
 }
 
 const nextVersion =
-  explicitVersion ?? bumpVersion(currentVersion, releaseKind ?? inferred.kind);
+	explicitVersion ?? bumpVersion(currentVersion, releaseKind ?? inferred.kind);
+parseVersion(nextVersion);
+if (compareVersions(nextVersion, currentVersion) <= 0) {
+	throw new Error(
+		`Next version must be greater than current version ${currentVersion}.`,
+	);
+}
 
-if (currentBranch() === "main") {
-  run("git", ["checkout", "-b", `release-v${nextVersion}`]);
+const changelog = readFileSync(join(root, "CHANGELOG.md"), "utf8");
+const notesPath = notesFilePath(notesFileArg);
+const sections = notesPath
+	? parseSections(readFileSync(notesPath, "utf8"), notesPath, true)
+	: mergeFallbackNotes(changelog, commits);
+const formattedNotes = formatSections(sections);
+if (!formattedNotes) throw new Error("No release notes were produced.");
+
+console.log(`\nRelease v${nextVersion}\n\n${formattedNotes}\n`);
+
+if (currentBranch() === "main" || currentBranch() === "") {
+	run("git", ["checkout", "-b", `codex/release-v${nextVersion}`]);
 }
 
 updateJsonVersion("apps/desktop/package.json", nextVersion);
 replaceInFile(
-  "bun.lock",
-  `"apps/desktop": {\n      "name": "desktop",\n      "version": "${currentVersion}",`,
-  `"apps/desktop": {\n      "name": "desktop",\n      "version": "${nextVersion}",`,
+	"bun.lock",
+	`"apps/desktop": {\n      "name": "desktop",\n      "version": "${currentVersion}",`,
+	`"apps/desktop": {\n      "name": "desktop",\n      "version": "${nextVersion}",`,
+);
+write(
+	"CHANGELOG.md",
+	replaceUnreleased(changelog, nextVersion, formattedNotes),
 );
 
-const changelog = readFileSync(join(root, "CHANGELOG.md"), "utf8");
-if (!changelog.includes(`## [${nextVersion}]`)) {
-  writeFileSync(
-    join(root, "CHANGELOG.md"),
-    changelog.replace("## [Unreleased]\n\n", `## [Unreleased]\n\n${releaseNotes(nextVersion, commits)}`),
-  );
-}
-
 run("node", ["scripts/generate-website-changelog.mjs"]);
-run("bunx", ["fumadocs-mdx"], join(root, "apps/web"));
+run("bun", ["run", "content:generate"], join(root, "apps/web"));
 run("bun", ["run", "check-types"]);
-run("git", ["add", "CHANGELOG.md", "apps/desktop/package.json", "bun.lock", "apps/web", "scripts/release-new-version.mjs", ".codex/skills/release-new-version"]);
+run("git", [
+	"add",
+	"CHANGELOG.md",
+	"apps/desktop/package.json",
+	"bun.lock",
+	"apps/web",
+	"scripts/release-new-version.mjs",
+	".codex/skills/release-new-version",
+	".claude/skills/release-new-version",
+	".codex/commands/release-new-version.md",
+	".claude/commands/release-new-version.md",
+]);
 run("git", ["commit", "-m", `Release v${nextVersion}`]);
 run("git", ["push", "-u", "origin", "HEAD"]);
 
 const prBody = `## Summary
-- release Zuse v${nextVersion}
-- update CHANGELOG.md and package metadata
-- keep the website Change Log page rendering release notes from CHANGELOG.md
 
-## Test
-- bun run check-types
+Prepare Zuse v${nextVersion} with release notes grouped by user-visible outcome.
+
+${formattedNotes}
+
+## Validation
+
+- \`bun run check-types\`
 
 Release artifacts are produced by pushing tag v${nextVersion} after this PR lands.`;
 
 run("gh", [
-  "pr",
-  "create",
-  "--base",
-  "main",
-  "--fill",
-  "--title",
-  `Release v${nextVersion}`,
-  "--body",
-  prBody,
+	"pr",
+	"create",
+	"--base",
+	"main",
+	"--title",
+	`Release v${nextVersion}`,
+	"--body",
+	prBody,
 ]);
 
 console.log(`Prepared release PR for v${nextVersion}.`);


### PR DESCRIPTION
## Summary

Prepare Zuse v0.17.0 with release notes grouped by user-visible outcome, and make the release workflow produce clearer, evidence-based notes for future versions.

### Added
- Run Zuse natively on x64 Linux with `.deb` and AppImage installers, Linux-native credential storage and browser integration, platform-aware desktop controls, and automatic Linux builds in every release
- Use the new documentation site for end-to-end guidance on setup, providers, projects and worktrees, remote access, browser workflows, mobile use, and recovery

### Changed
- Navigate long conversations by turn while streaming responses, code blocks, and reading position remain stable during updates
- Move the hosted app to `code.zuse.sh` and update Serve `0.1.1` to preserve its background data-directory state
- Publish the project license and third-party attribution notices across distributed packages
- Curate future release notes by user-visible impact, enforce Added/Changed/Fixed categories, and include actual highlights in release PRs

### Fixed
- Restore hosted workspace connectivity and reliable thread and state discovery between desktop and Serve runtimes
- Prevent diagnostics and telemetry capture from growing without bounds while preserving useful export data
- Generate website content from the web workspace so release checks resolve the declared local dependency graph

## Validation

- `node --check scripts/release-new-version.mjs`
- `biome check scripts/release-new-version.mjs apps/desktop/package.json`
- `bun run content:generate` in `apps/web`
- `bun run check-types` — 26/26 tasks passed

Release artifacts are produced by pushing tag v0.17.0 after this PR lands.
