### PR TITLE
Require published release notes

### DIFF
--- a/.claude/commands/release-new-version.md
+++ b/.claude/commands/release-new-version.md
@@ -8,4 +8,4 @@ If the user provided arguments, pass them through to `scripts/release-new-versio
 - `patch` -> `--kind=patch`
 - a semver version like `0.5.1` -> `--version=0.5.1`
 
-Follow the skill workflow exactly: inspect git state, inventory and classify the release evidence, write curated user-facing notes, update changelog/package metadata, verify, commit, push, merge, tag, and verify the release artifacts.
+Follow the skill workflow exactly: inspect git state, inventory and classify the release evidence, write curated user-facing notes, update changelog/package metadata, verify, commit, push, merge, tag, publish the notes on the public release, and verify the release artifacts.

--- a/.claude/skills/release-new-version/SKILL.md
+++ b/.claude/skills/release-new-version/SKILL.md
@@ -56,6 +56,14 @@ git push origin vX.Y.Z
 ```
 
 9. Verify the tag-triggered release workflow succeeds and that the expected GitHub Release and artifacts exist. If anything is still running or blocked, report it as pending rather than done.
+10. After artifact publication finishes, publish the same curated notes on the public GitHub Release and read the release back to verify its title, body, tag, and assets:
+
+```bash
+gh release edit vX.Y.Z --title "Zuse X.Y.Z" --notes-file /absolute/path/to/release-notes.md
+gh release view vX.Y.Z --json name,body,tagName,url,assets
+```
+
+An empty release body, raw commit dump, or PR-only description is incomplete. The public release must explain important features and preserve the `Added`, `Changed`, and `Fixed` grouping.
 
 ## What The Helper Does
 
@@ -75,4 +83,4 @@ Report release state with explicit outcomes:
 - validation commands and results;
 - PR and merge state;
 - tag and release-workflow state;
-- published artifacts, or the precise remaining blocker.
+- public release page and published artifacts, or the precise remaining blocker.

--- a/.codex/commands/release-new-version.md
+++ b/.codex/commands/release-new-version.md
@@ -8,4 +8,4 @@ If the user provided arguments, pass them through to `scripts/release-new-versio
 - `patch` -> `--kind=patch`
 - a semver version like `0.5.1` -> `--version=0.5.1`
 
-Follow the skill workflow exactly: inspect git state, inventory and classify the release evidence, write curated user-facing notes, update changelog/package metadata, verify, commit, push, merge, tag, and verify the release artifacts.
+Follow the skill workflow exactly: inspect git state, inventory and classify the release evidence, write curated user-facing notes, update changelog/package metadata, verify, commit, push, merge, tag, publish the notes on the public release, and verify the release artifacts.

--- a/.codex/skills/release-new-version/SKILL.md
+++ b/.codex/skills/release-new-version/SKILL.md
@@ -56,6 +56,14 @@ git push origin vX.Y.Z
 ```
 
 9. Verify the tag-triggered release workflow succeeds and that the expected GitHub Release and artifacts exist. If anything is still running or blocked, report it as pending rather than done.
+10. After artifact publication finishes, publish the same curated notes on the public GitHub Release and read the release back to verify its title, body, tag, and assets:
+
+```bash
+gh release edit vX.Y.Z --title "Zuse X.Y.Z" --notes-file /absolute/path/to/release-notes.md
+gh release view vX.Y.Z --json name,body,tagName,url,assets
+```
+
+An empty release body, raw commit dump, or PR-only description is incomplete. The public release must explain important features and preserve the `Added`, `Changed`, and `Fixed` grouping.
 
 ## What The Helper Does
 
@@ -75,4 +83,4 @@ Report release state with explicit outcomes:
 - validation commands and results;
 - PR and merge state;
 - tag and release-workflow state;
-- published artifacts, or the precise remaining blocker.
+- public release page and published artifacts, or the precise remaining blocker.


### PR DESCRIPTION
## Summary

- require every public GitHub Release to carry the same curated notes as the changelog
- treat empty, raw-commit, or PR-only release descriptions as incomplete
- verify the published release title, body, tag, and assets before reporting completion

## Validation

- `git diff --check`
- verified the rule against the published Zuse 0.17.0 release
