### PR TITLE
Support platform-aware marketing downloads

### DIFF
--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -7,7 +7,7 @@ import { BlogCard } from "@/components/resources/blog-card";
 export const metadata = getSEO({
   title: "Blog",
   description:
-    "Release notes, changelog, and deep dives on Zuse (Beta) — the chat-first macOS workspace for AI coding agents.",
+    "Release notes, changelog, and deep dives on Zuse (Beta) — the chat-first desktop workspace for AI coding agents on macOS and Linux.",
   path: "/blog",
 });
 

--- a/apps/web/app/download/route.ts
+++ b/apps/web/app/download/route.ts
@@ -1,54 +1,54 @@
 import { NextResponse } from "next/server";
 
+import { resolveDownloadTarget, selectReleaseAsset } from "@/lib/download";
 import { RELEASES_URL } from "@/lib/site";
 
 const RELEASE_API_URL =
-  "https://api.github.com/repos/swarajbachu/zuse/releases/latest";
-
-type GitHubReleaseAsset = {
-  name?: unknown;
-  browser_download_url?: unknown;
-};
+	"https://api.github.com/repos/swarajbachu/zuse/releases/latest";
 
 type GitHubRelease = {
-  assets?: unknown;
+	assets?: unknown;
 };
 
 const FALLBACK_URL = RELEASES_URL;
 
-export async function GET() {
-  try {
-    const response = await fetch(RELEASE_API_URL, {
-      headers: {
-        Accept: "application/vnd.github+json",
-      },
-      next: { revalidate: 300 },
-    });
+const redirect = (url: string) =>
+	NextResponse.redirect(url, {
+		headers: { Vary: "User-Agent" },
+	});
 
-    if (!response.ok) {
-      return NextResponse.redirect(FALLBACK_URL);
-    }
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const target = resolveDownloadTarget({
+		platform: url.searchParams.get("platform"),
+		format: url.searchParams.get("format"),
+		userAgent: request.headers.get("user-agent"),
+	});
 
-    const release = (await response.json()) as GitHubRelease;
-    const assets = Array.isArray(release.assets) ? release.assets : [];
-    const dmg = assets.find((asset): asset is GitHubReleaseAsset => {
-      if (asset === null || typeof asset !== "object") return false;
+	if (target === null) return redirect(FALLBACK_URL);
 
-      const { name, browser_download_url } = asset as GitHubReleaseAsset;
-      return (
-        typeof name === "string" &&
-        typeof browser_download_url === "string" &&
-        name.endsWith(".dmg") &&
-        !name.endsWith(".dmg.blockmap")
-      );
-    });
+	try {
+		const response = await fetch(RELEASE_API_URL, {
+			headers: {
+				Accept: "application/vnd.github+json",
+			},
+			next: { revalidate: 300 },
+		});
 
-    if (typeof dmg?.browser_download_url === "string") {
-      return NextResponse.redirect(dmg.browser_download_url);
-    }
-  } catch {
-    // Fall through to the public releases page.
-  }
+		if (!response.ok) {
+			return redirect(FALLBACK_URL);
+		}
 
-  return NextResponse.redirect(FALLBACK_URL);
+		const release = (await response.json()) as GitHubRelease;
+		const assets = Array.isArray(release.assets) ? release.assets : [];
+		const installer = selectReleaseAsset(assets, target);
+
+		if (installer !== null) {
+			return redirect(installer.browser_download_url);
+		}
+	} catch {
+		// Fall through to the public releases page.
+	}
+
+	return redirect(FALLBACK_URL);
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,7 @@ import { Projects } from "@/components/projects";
 export const metadata = getSEO({
   title: "Token max every coding agent",
   description:
-    "Zuse (Beta) is a local-first macOS workspace for developers who want to code all day, max out their AI subscriptions, and ship more parallel attempts safely.",
+    "Zuse (Beta) is a local-first desktop workspace for macOS and Linux developers who want to code all day, max out their AI subscriptions, and ship more parallel attempts safely.",
   path: "/",
 });
 

--- a/apps/web/components/bento-one/index.tsx
+++ b/apps/web/components/bento-one/index.tsx
@@ -16,7 +16,7 @@ const features = [
   },
   {
     title: "Stay local and keep the margin",
-    body: "Bring your own keys. Chats stay in SQLite, keys stay in Keychain, and Zuse (Beta) adds no token markup.",
+    body: "Bring your own keys. Chats stay in SQLite, keys stay in your operating system's credential store, and Zuse (Beta) adds no token markup.",
   },
 ];
 

--- a/apps/web/components/blogs/blog-cta-section.tsx
+++ b/apps/web/components/blogs/blog-cta-section.tsx
@@ -7,7 +7,7 @@ export const BlogCtaSection = () => {
       <Container className="flex items-center justify-center pt-30 pb-50">
         <div className="flex w-full max-w-200 flex-col gap-6">
           <span className="text-foreground -tracking-sm text-3xl leading-10 font-medium">
-            Token max every coding agent from one Mac app.
+            Token max every coding agent from one desktop app.
           </span>
           <span className="-tracking-xs text-muted-foreground text-base leading-6 font-medium">
             Zuse (Beta) is for power users running Claude Code, Codex, Cursor,
@@ -16,7 +16,8 @@ export const BlogCtaSection = () => {
           </span>
           <span className="-tracking-xs text-muted-foreground text-base leading-6 font-medium">
             It is local-first by design: chats in SQLite on disk, keys in the
-            macOS Keychain. Bring your own keys and run it free during beta.
+            operating system credential store. Bring your own keys and run it
+            free during beta.
           </span>
           <div>
             <Button />

--- a/apps/web/components/button.tsx
+++ b/apps/web/components/button.tsx
@@ -1,65 +1,65 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { DOWNLOAD_URL } from "@/lib/site";
+import { cn } from "@/lib/utils";
 
 /**
- * Primary CTA. Renders a link (defaults to the Mac download). Keeps the
- * sliding box micro-interaction while using a real Apple logo.
+ * Primary CTA. The default route selects the latest installer for the
+ * visitor's OS while keeping the visible label stable during hydration.
  */
 export const Button = ({
-  text = "Download for Mac",
-  href = DOWNLOAD_URL,
-  showIcon = true,
-  containerClassName,
+	text = "Download Zuse",
+	href = DOWNLOAD_URL,
+	showIcon = true,
+	containerClassName,
 }: {
-  text?: string;
-  href?: string;
-  showIcon?: boolean;
-  containerClassName?: string;
+	text?: string;
+	href?: string;
+	showIcon?: boolean;
+	containerClassName?: string;
 }) => {
-  const external = href.startsWith("http");
-  return (
-    <Link
-      href={href}
-      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-      className={cn(
-        "group relative flex w-fit cursor-pointer items-center gap-2 rounded-lg border border-white/20 bg-black py-2 pr-4 pl-11 tracking-tight",
-        containerClassName,
-      )}
-    >
-      <Box showIcon={showIcon} />
-      <div className="absolute -inset-px rounded-lg bg-white/15 transition-[clip-path] duration-400 ease-out [clip-path:inset(0_100%_0_0)] group-hover:[clip-path:inset(0_0%_0_0)]" />
-      <span className="inline-block text-white transition-transform duration-400 group-hover:-translate-x-8">
-        {text}
-      </span>
-    </Link>
-  );
+	const external = href.startsWith("http");
+	return (
+		<Link
+			href={href}
+			{...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+			className={cn(
+				"group relative flex w-fit cursor-pointer items-center gap-2 rounded-lg border border-white/20 bg-black py-2 pr-4 pl-11 tracking-tight",
+				containerClassName,
+			)}
+		>
+			<Box showIcon={showIcon} />
+			<div className="absolute -inset-px rounded-lg bg-white/15 transition-[clip-path] duration-400 ease-out [clip-path:inset(0_100%_0_0)] group-hover:[clip-path:inset(0_0%_0_0)]" />
+			<span className="inline-block text-white transition-transform duration-400 group-hover:-translate-x-8">
+				{text}
+			</span>
+		</Link>
+	);
 };
 
 const Box = ({ showIcon }: { showIcon?: boolean }) => {
-  return (
-    <div
-      data-slot="button-box"
-      className="bg-primary absolute inset-y-0 left-1 z-40 my-auto flex size-8 items-center justify-center rounded-[5px] transition-all duration-400 ease-out group-hover:left-[calc(100%-2.3rem)] group-hover:rotate-180 group-hover:transform"
-    >
-      {showIcon && (
-        <AppleLogo className="size-5 text-black transition-transform duration-400 ease-out group-hover:rotate-180" />
-      )}
-    </div>
-  );
+	return (
+		<div
+			data-slot="button-box"
+			className="bg-primary absolute inset-y-0 left-1 z-40 my-auto flex size-8 items-center justify-center rounded-[5px] transition-all duration-400 ease-out group-hover:left-[calc(100%-2.3rem)] group-hover:rotate-180 group-hover:transform"
+		>
+			{showIcon && (
+				<DownloadIcon className="size-5 text-black transition-transform duration-400 ease-out group-hover:rotate-180" />
+			)}
+		</div>
+	);
 };
 
-const AppleLogo = ({ className }: { className?: string }) => {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      className={className}
-      fill="currentColor"
-    >
-      <path d="M17.05 12.44c-.03-2.42 1.98-3.58 2.07-3.64-1.13-1.65-2.88-1.87-3.49-1.9-1.47-.15-2.9.87-3.65.87-.77 0-1.94-.85-3.19-.83-1.64.02-3.16.96-4 2.43-1.71 2.96-.44 7.32 1.2 9.72.82 1.17 1.78 2.47 3.03 2.43 1.22-.05 1.68-.78 3.15-.78 1.46 0 1.89.78 3.18.76 1.32-.02 2.15-1.18 2.94-2.36.94-1.34 1.32-2.66 1.34-2.73-.03-.01-2.55-.98-2.58-3.97ZM14.67 5.34c.66-.82 1.11-1.94.99-3.06-.96.04-2.16.66-2.85 1.47-.61.7-1.16 1.86-1.02 2.95 1.08.08 2.19-.55 2.88-1.36Z" />
-    </svg>
-  );
+const DownloadIcon = ({ className }: { className?: string }) => {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			aria-hidden="true"
+			className={className}
+			fill="currentColor"
+		>
+			<path d="M11 3a1 1 0 1 1 2 0v10.59l3.3-3.3a1 1 0 1 1 1.4 1.42l-5 5a1 1 0 0 1-1.4 0l-5-5a1 1 0 0 1 1.4-1.42l3.3 3.3V3ZM5 19a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H6a1 1 0 0 1-1-1Z" />
+		</svg>
+	);
 };

--- a/apps/web/components/comparison/index.tsx
+++ b/apps/web/components/comparison/index.tsx
@@ -33,7 +33,7 @@ const cardsData: InfoCardsProps[] = [
   {
     title: "Local-first control",
     description:
-      "Chats and worktrees persist in local SQLite. Your keys live in the macOS Keychain, not our servers.",
+      "Chats and worktrees persist in local SQLite. Your keys live in your operating system's credential store, not our servers.",
     icon: <HandsIcon />,
   },
 ];

--- a/apps/web/components/faq/cta-card.tsx
+++ b/apps/web/components/faq/cta-card.tsx
@@ -5,7 +5,7 @@ export const CTACard = () => {
     <div className="bg-card flex flex-col gap-8 rounded-3xl border border-white/10 px-6 py-8 shadow-card-md w-full lg:max-w-lg">
       <div className="flex flex-col gap-3">
         <span className="font-medium text-foreground text-2xl leading-8 -tracking-sm">
-          Ready to token max on your Mac?
+          Ready to token max on your machine?
         </span>
         <span className="font-medium text-muted-foreground text-base -tracking-xs leading-6">
           Bring your own keys, keep everything local, and run more useful agent
@@ -13,7 +13,7 @@ export const CTACard = () => {
         </span>
       </div>
       <div>
-        <Button text="Download for Mac" />
+        <Button />
       </div>
     </div>
   );

--- a/apps/web/components/faq/index.tsx
+++ b/apps/web/components/faq/index.tsx
@@ -38,9 +38,9 @@ const data = [
 			"Your chats, project data, and keys stay local, and model requests go only to the providers you configure. Default-on pseudonymous usage analytics measure features, model choices, active time, and reliability with standard geographic enrichment; they never include prompts, responses, code, paths, commands, account details, or error stacks. You can turn analytics off immediately in desktop or mobile Settings.",
 	},
 	{
-		question: "Is it macOS only?",
+		question: "Which operating systems are supported?",
     answer:
-      "For now, yes. Zuse (Beta) is a native macOS desktop app and ships as a universal build for both Apple Silicon and Intel. Other platforms may come later.",
+      "Zuse (Beta) ships for macOS and x64 Linux. The Download button selects the macOS disk image or Linux AppImage automatically, and Debian and Ubuntu users can also get the .deb package from GitHub Releases.",
   },
   {
     question: "How much does it cost?",

--- a/apps/web/components/footer/index.tsx
+++ b/apps/web/components/footer/index.tsx
@@ -63,9 +63,9 @@ export const Footer = () => {
           <div className="relative z-10 grid min-h-112 grid-cols-1 gap-8 px-6 py-10 md:px-15 md:py-16 lg:grid-cols-[1fr_520px] lg:items-start">
             <div className="flex flex-col gap-8">
               <div className="text-natural-white -tracking-lg w-full max-w-135 justify-center text-[32px] font-medium md:text-5xl md:leading-14 lg:text-[56px] lg:leading-16">
-                Token max every coding agent from one Mac app
+                Token max every coding agent from one desktop app
               </div>
-              <Button text="Download for Mac" />
+              <Button />
             </div>
             <div className="relative hidden min-h-76 overflow-hidden rounded-3xl bg-[#101113] p-5 shadow-card-xl lg:block">
               <div className="absolute inset-0 bg-[linear-gradient(to_right,#24272A_1px,transparent_1px),linear-gradient(to_bottom,#24272A_1px,transparent_1px)] bg-size-[44px_44px] opacity-40" />
@@ -89,7 +89,7 @@ export const Footer = () => {
                 </div>
                 <Link
                   href={DOWNLOAD_URL}
-                  aria-label="Download Zuse (Beta) for Mac"
+                  aria-label="Download Zuse (Beta) for your operating system"
                   className="bg-primary text-primary-foreground shadow-card-md inline-flex size-12 items-center justify-center rounded-xl"
                 >
                   <ArrowRightLongerIcon className="scale-125" />
@@ -132,10 +132,10 @@ export const Footer = () => {
             <div className="flex flex-col gap-4">
               <Logo className="size-8" />
               <span className="text-muted-foreground text-sm leading-5">
-                Token max every coding agent from one local Mac workspace.
+                Token max every coding agent from one local desktop workspace.
               </span>
               <div>
-                <Button text="Download for Mac" />
+                <Button />
               </div>
             </div>
             <div className="grid grid-cols-2 gap-10 md:grid-cols-4 md:gap-0">

--- a/apps/web/components/hero/index.tsx
+++ b/apps/web/components/hero/index.tsx
@@ -103,7 +103,7 @@ export const Hero = () => {
                 </h2>
                 <Button containerClassName="mt-6 md:mt-8" />
                 <p className="text-natural-white/50 mt-3 text-xs">
-                  macOS app · BYOK · no token markup
+                  macOS + Linux · BYOK · no token markup
                 </p>
               </div>
             </div>

--- a/apps/web/components/resources/index.tsx
+++ b/apps/web/components/resources/index.tsx
@@ -15,7 +15,7 @@ const data: CardData[] = [
   {
     title: "Bring your own keys",
     description:
-      "Your API keys stay in the macOS Keychain. Zuse (Beta) is not a reseller and never marks up your model usage.",
+      "Your API keys stay in your operating system's credential store. Zuse (Beta) is not a reseller and never marks up your model usage.",
     time: "4 min read",
     image: "/assets/blog-preview-keys-clean.svg",
     href: "/blog/bring-your-own-keys",
@@ -39,7 +39,7 @@ const data: CardData[] = [
   {
     title: "Local-first by design",
     description:
-      "SQLite on disk, keys in the Keychain, no account required. Your work stays on your machine.",
+      "SQLite on disk, keys in the operating system credential store, no account required. Your work stays on your machine.",
     time: "4 min read",
     image: "/assets/blog-preview-local-clean.svg",
     href: "/blog/local-first-by-design",
@@ -47,7 +47,7 @@ const data: CardData[] = [
   {
     title: "Zuse Alpha is now in public alpha",
     description:
-      "A chat-first macOS app that wraps every coding agent CLI in one project-aware workspace. Free during alpha.",
+      "How Zuse launched its original public alpha as one project-aware workspace for coding agent CLIs.",
     time: "4 min read",
     image: "/assets/blog-preview-alpha-clean.svg",
     href: "/blog/memoize-public-alpha",
@@ -68,8 +68,8 @@ export const Resources = () => {
             <FilterBadge>BYOK</FilterBadge>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {data.map((card, index) => (
-              <BlogCard key={index} card={card} />
+            {data.map((card) => (
+              <BlogCard key={card.href} card={card} />
             ))}
           </div>
         </div>

--- a/apps/web/content/blog/bring-your-own-keys.mdx
+++ b/apps/web/content/blog/bring-your-own-keys.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Bring your own keys: why Zuse (Beta) never resells tokens"
-description: "Your API keys stay in the macOS Keychain. Zuse (Beta) is not a reseller and never marks up your model usage."
+description: "Your API keys stay in your operating system's credential store. Zuse (Beta) is not a reseller and never marks up your model usage."
 date: "2026-06-04"
 timeToRead: "4 min read"
 authorName: "Zuse (Beta) team"
@@ -24,7 +24,7 @@ Zuse (Beta) does not do that. You bring your own keys or your own provider subsc
 
 ## Where your keys live
 
-API keys are stored in the macOS Keychain, encrypted by the OS. They are not synced to a server, not logged, and not sent anywhere except the provider you are calling. Zuse (Beta) is local-first by design: your chats and project data live in a local SQLite database on your machine.
+API keys are stored in your operating system's credential store — macOS Keychain or Linux Secret Service — and protected by the OS. They are not synced to a server, not logged, and not sent anywhere except the provider you are calling. Zuse (Beta) is local-first by design: your chats and project data live in a local SQLite database on your machine.
 
 ---
 
@@ -62,7 +62,7 @@ With your own keys, provider dashboards remain the source of truth. Rate limits,
 
 Every additional system that handles credentials becomes a system you have to trust. A hosted token reseller has to store or mint access on your behalf, associate usage with your account, and defend that infrastructure. For many products that is a reasonable trade. For a coding agent workspace, the safer default is to avoid taking custody in the first place.
 
-Zuse (Beta) stores provider keys in the macOS Keychain because that is the native place for application secrets on a Mac. The operating system encrypts the items and controls access. The app can read a key when it needs to call the provider you configured, but the key is not uploaded to a Zuse (Beta) service for billing. There is no remote Zuse (Beta) account that can be compromised to retrieve your provider credentials, and there is no token broker where your requests have to pass through a vendor-controlled gateway.
+Zuse (Beta) stores provider keys in the operating system's credential store because that is the right place for application secrets. It uses Keychain on macOS and Secret Service on Linux, so the operating system controls access. The app can read a key when it needs to call the provider you configured, but the key is not uploaded to a Zuse (Beta) service for billing. There is no remote Zuse (Beta) account that can be compromised to retrieve your provider credentials, and there is no token broker where your requests have to pass through a vendor-controlled gateway.
 
 That does not mean model requests are private from the provider. If you send a prompt to a hosted model, that provider receives it. BYOK is not magic privacy dust. The point is narrower and more concrete: your request goes to the provider you chose, under the account and policy you control, without an extra application vendor proxying the exchange for markup. That is a smaller trust boundary, and smaller trust boundaries are easier to reason about.
 
@@ -80,4 +80,4 @@ The deeper reason for BYOK is alignment. A coding agent app should make it easy 
 
 Zuse (Beta) is built around that bias. The chat timeline shows tool calls and output instead of turning the session into a mystery. The changes pane makes diffs reviewable before they become commits. Worktrees isolate experiments so one agent's attempt does not silently bleed into another. BYOK fits the same pattern: keep the important mechanics visible, keep ownership close to the developer, and avoid inventing a dependency where the platform does not need one.
 
-There will still be teams that prefer centralized procurement, pooled credits, or a fully hosted product. That is fine. Zuse (Beta) is for the teams and individual developers who want the opposite shape: a Mac app that runs locally, respects the provider relationships they already have, and does not turn model access into a markup layer. If the app earns trust, it should be because it improves the work, not because it controls the meter.
+There will still be teams that prefer centralized procurement, pooled credits, or a fully hosted product. That is fine. Zuse (Beta) is for the teams and individual developers who want the opposite shape: a desktop app that runs locally, respects the provider relationships they already have, and does not turn model access into a markup layer. If the app earns trust, it should be because it improves the work, not because it controls the meter.

--- a/apps/web/content/blog/know-your-token-spend.mdx
+++ b/apps/web/content/blog/know-your-token-spend.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Know your token spend"
-description: "Tokenmaxer reads your agent CLI logs and unifies token counts and dollar cost by day, source, model, and session. All of it stays on your Mac."
+description: "Tokenmaxer reads your agent CLI logs and unifies token counts and dollar cost by day, source, model, and session. All of it stays on your machine."
 date: "2026-06-21"
 timeToRead: "6 min read"
 authorName: "Zuse (Beta) team"
@@ -87,11 +87,11 @@ The same totals are useful in different shapes depending on what you are trying 
 
 ## Local by default
 
-Tokenmaxer is built on the same principle as the rest of Zuse (Beta): it runs on your Mac, and your data stays there.
+Tokenmaxer is built on the same principle as the rest of Zuse (Beta): it runs on your machine, and your data stays there.
 
 Reading token usage could easily have been a cloud feature. Upload the logs, crunch them on a server, render a dashboard. That is the normal shape for analytics, and it is exactly the shape we did not want for a tool that reads your coding history.
 
-So Tokenmaxer reads the CLI logs on disk and aggregates them on your machine. Nothing is uploaded. Your prompts are not sent anywhere to be counted. The session contents — which are full of your code, your file paths, your internal context — never leave the Mac just so a number can be totaled. The logs were already there; Tokenmaxer simply reads them where they sit.
+So Tokenmaxer reads the CLI logs on disk and aggregates them on your machine. Nothing is uploaded. Your prompts are not sent anywhere to be counted. The session contents — which are full of your code, your file paths, your internal context — never leave your computer just so a number can be totaled. The logs were already there; Tokenmaxer simply reads them where they sit.
 
 This matters more than it might for a usage dashboard, because agent logs are unusually sensitive. They contain fragments of source, command output, file names, and the shape of what you are building. A token counter has no business shipping that off the machine. Local-first is not a slogan we apply selectively; it applies to the analytics too.
 

--- a/apps/web/content/blog/local-first-by-design.mdx
+++ b/apps/web/content/blog/local-first-by-design.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Local-first by design"
-description: "SQLite on disk, keys in the Keychain, no account required. Your work stays on your machine."
+description: "SQLite on disk, keys in the operating system credential store, no account required. Your work stays on your machine."
 date: "2026-05-12"
 timeToRead: "4 min read"
 authorName: "Zuse (Beta) team"
@@ -18,7 +18,7 @@ labels:
 
 > **Update — July 22, 2026:** Zuse (Beta) now sends default-on pseudonymous product and reliability analytics. It never includes prompts, responses, code, paths, commands, account details, or error stacks, and can be disabled immediately in Settings. Standard geographic enrichment applies. The local storage and provider data path described below is unchanged.
 
-Zuse (Beta) runs on your Mac, not in our cloud. There is no account to create before you can use it, no server holding your chat history, and no telemetry pulling your code off the machine.
+Zuse (Beta) runs on your computer, not in our cloud. There is no account to create before you can use it, no server holding your chat history, and no telemetry pulling your code off the machine.
 
 Local-first is not a feature we bolted on. It is how the app is built.
 
@@ -27,7 +27,7 @@ Local-first is not a feature we bolted on. It is how the app is built.
 ## What lives where
 
 - Chats, projects, and settings are stored in a local SQLite database on disk.
-- API keys live in the macOS Keychain, encrypted by the OS.
+- API keys live in the operating system credential store — Keychain on macOS or Secret Service on Linux.
 - Model requests go directly from your machine to the provider you configured.
 
 That is the data path for your work. Separate pseudonymous usage events are sent to our analytics processor under the privacy boundary above.
@@ -52,7 +52,7 @@ Local-first means we cannot inspect your work. Aggregated reliability events can
 
 It is easy for software to say "privacy first" while still depending on a remote account for the product to function. The app may store a cache locally, but the source of truth lives on a server. The server knows which projects you opened, which conversations you had, which files were attached, and which model requests passed through the system. That design can be appropriate for collaboration-heavy web products. It is not the default we wanted for a coding agent workspace.
 
-Zuse (Beta) starts from the opposite assumption. The Mac app should be useful as a local tool. The project is on your disk. The git repository is on your disk. Chat history and settings are stored locally. Provider credentials are stored by the operating system. The app does not need a Zuse (Beta)-hosted account before you can begin using it, and it does not need to copy your repository metadata to a backend just to render the sidebar.
+Zuse (Beta) starts from the opposite assumption. The desktop app should be useful as a local tool. The project is on your disk. The git repository is on your disk. Chat history and settings are stored locally. Provider credentials are stored by the operating system. The app does not need a Zuse (Beta)-hosted account before you can begin using it, and it does not need to copy your repository metadata to a backend just to render the sidebar.
 
 That matters because coding agents sit unusually close to sensitive material. They read source code, configuration files, logs, test fixtures, issue descriptions, and sometimes proprietary design notes. Even if a vendor promises careful handling, centralizing all of that context creates a larger target and a larger policy surface. Local-first does not remove every risk, but it removes a whole class of vendor custody from the core workflow.
 
@@ -72,9 +72,9 @@ A local database also makes the app easier to reason about. Your data has a conc
 
 There are engineering responsibilities that come with this choice. Migrations must be careful. Schema changes must account for partially updated developer machines. Queries must work with the production SQLite driver, not just a convenient test client. We treat that as part of building a serious local app. A local-first product still needs disciplined persistence; it just applies that discipline close to the user.
 
-## Keys belong in the Keychain
+## Keys belong in the operating system credential store
 
-Provider keys are secrets, and macOS already has a native system for application secrets: the Keychain. Storing keys there means encryption and access control are handled by the operating system instead of by a custom file format in the app. Zuse (Beta) reads the key when it needs to call the provider you selected, but it does not sync that key to a Zuse (Beta) backend.
+Provider keys are secrets, and desktop operating systems already provide secure stores for application secrets. Zuse (Beta) uses Keychain on macOS and Secret Service on Linux, so access is handled by the operating system instead of by a custom file format in the app. Zuse (Beta) reads the key when it needs to call the provider you selected, but it does not sync that key to a Zuse (Beta) backend.
 
 This is important for both individuals and teams. An individual developer can experiment without creating yet another vendor account. A team can use provider-side controls for spend, rotation, and revocation. If a key needs to be replaced, the owner can rotate it through the provider dashboard and update the local app. There is no support queue required to detach your model access from Zuse (Beta).
 

--- a/apps/web/content/blog/memoize-public-alpha.mdx
+++ b/apps/web/content/blog/memoize-public-alpha.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Zuse Alpha is now in public alpha"
-description: "A chat-first macOS app that wraps every coding agent CLI in one project-aware workspace. Free during alpha."
+description: "How Zuse launched its original public alpha as one project-aware workspace for coding agent CLIs."
 date: "2026-06-16"
 timeToRead: "4 min read"
 authorName: "Zuse Alpha team"

--- a/apps/web/lib/download.test.ts
+++ b/apps/web/lib/download.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveDownloadTarget, selectReleaseAsset } from "./download";
+
+describe("resolveDownloadTarget", () => {
+	test("selects the macOS installer for a desktop Mac browser", () => {
+		expect(
+			resolveDownloadTarget({
+				platform: null,
+				format: null,
+				userAgent:
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+			}),
+		).toBe("macos");
+	});
+
+	test("selects the AppImage for a desktop Linux browser", () => {
+		expect(
+			resolveDownloadTarget({
+				platform: null,
+				format: null,
+				userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+			}),
+		).toBe("linux-appimage");
+	});
+
+	test("supports an explicit Linux deb request", () => {
+		expect(
+			resolveDownloadTarget({
+				platform: "linux",
+				format: "deb",
+				userAgent: null,
+			}),
+		).toBe("linux-deb");
+	});
+
+	test("does not send mobile or unsupported clients a desktop installer", () => {
+		expect(
+			resolveDownloadTarget({
+				platform: null,
+				format: null,
+				userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel 10)",
+			}),
+		).toBeNull();
+		expect(
+			resolveDownloadTarget({
+				platform: null,
+				format: null,
+				userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+			}),
+		).toBeNull();
+	});
+});
+
+describe("selectReleaseAsset", () => {
+	const assets = [
+		{
+			name: "Zuse-0.16.0-universal.dmg.blockmap",
+			browser_download_url: "https://example.com/mac.blockmap",
+		},
+		{
+			name: "Zuse-0.16.0-universal.dmg",
+			browser_download_url: "https://example.com/mac.dmg",
+		},
+		{
+			name: "Zuse-0.16.0-linux-x86_64.AppImage",
+			browser_download_url: "https://example.com/linux.AppImage",
+		},
+		{
+			name: "Zuse-0.16.0-linux-amd64.deb",
+			browser_download_url: "https://example.com/linux.deb",
+		},
+	];
+
+	test("selects the requested installer format", () => {
+		expect(selectReleaseAsset(assets, "macos")?.name).toMatch(/\.dmg$/);
+		expect(selectReleaseAsset(assets, "linux-appimage")?.name).toMatch(
+			/\.AppImage$/,
+		);
+		expect(selectReleaseAsset(assets, "linux-deb")?.name).toMatch(/\.deb$/);
+	});
+
+	test("returns null when the release does not contain the requested format", () => {
+		expect(selectReleaseAsset([], "linux-appimage")).toBeNull();
+	});
+});

--- a/apps/web/lib/download.ts
+++ b/apps/web/lib/download.ts
@@ -1,0 +1,68 @@
+export type DownloadTarget = "macos" | "linux-appimage" | "linux-deb";
+
+export type ReleaseAsset = {
+	name: string;
+	browser_download_url: string;
+};
+
+const isMobileUserAgent = (userAgent: string) =>
+	/android|iphone|ipad|ipod|mobile/i.test(userAgent);
+
+export const resolveDownloadTarget = ({
+	platform,
+	format,
+	userAgent,
+}: {
+	platform: string | null;
+	format: string | null;
+	userAgent: string | null;
+}): DownloadTarget | null => {
+	const requestedPlatform = platform?.toLowerCase();
+	const requestedFormat = format?.toLowerCase();
+
+	if (["mac", "macos", "darwin"].includes(requestedPlatform ?? "")) {
+		return "macos";
+	}
+
+	if (requestedPlatform === "linux") {
+		return requestedFormat === "deb" ? "linux-deb" : "linux-appimage";
+	}
+
+	if (isMobileUserAgent(userAgent ?? "")) return null;
+	if (/linux|x11/i.test(userAgent ?? "")) return "linux-appimage";
+	if (/macintosh|mac os x/i.test(userAgent ?? "")) return "macos";
+
+	return null;
+};
+
+const extensionForTarget: Record<DownloadTarget, string> = {
+	macos: ".dmg",
+	"linux-appimage": ".appimage",
+	"linux-deb": ".deb",
+};
+
+export const selectReleaseAsset = (
+	assets: unknown[],
+	target: DownloadTarget,
+): ReleaseAsset | null => {
+	const extension = extensionForTarget[target];
+
+	for (const asset of assets) {
+		if (asset === null || typeof asset !== "object") continue;
+
+		const { name, browser_download_url } = asset as {
+			name?: unknown;
+			browser_download_url?: unknown;
+		};
+
+		if (
+			typeof name === "string" &&
+			typeof browser_download_url === "string" &&
+			name.toLowerCase().endsWith(extension)
+		) {
+			return { name, browser_download_url };
+		}
+	}
+
+	return null;
+};

--- a/apps/web/lib/seo.ts
+++ b/apps/web/lib/seo.ts
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const siteConfig = {
   name: "Zuse (Beta)",
   description:
-    "Zuse (Beta) helps power users token max Claude Code, Codex, Cursor, Gemini, Grok and OpenCode from one local Mac workspace with worktrees, diffs, and no token markup.",
+    "Zuse (Beta) helps power users token max Claude Code, Codex, Cursor, Gemini, Grok and OpenCode from one local desktop workspace with worktrees, diffs, and no token markup.",
   // Override in production via NEXT_PUBLIC_SITE_URL.
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://zuse.sh",
   ogImage: "/og.png",

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -6,11 +6,11 @@ export const SITE_NAME = "Zuse (Beta)";
 export const GITHUB_URL = "https://github.com/swarajbachu/zuse";
 export const RELEASES_URL = "https://github.com/swarajbachu/zuse/releases";
 
-// Stable site route that redirects to the latest signed `.dmg`.
+// Stable site route that redirects to the latest installer for the visitor's OS.
 export const DOWNLOAD_URL = "/download";
 
 export const TAGLINE =
-  "Token max every coding agent from one local Mac workspace.";
+  "Token max every coding agent from one local desktop workspace.";
 
 // The coding agents Zuse (Beta) wraps. Used by the logo cloud / brands marquee.
 export const AGENTS = [


### PR DESCRIPTION
## Summary

- make the current marketing site copy platform-neutral across the landing page, SEO, FAQ, footer, resources, and evergreen articles
- route `/download` to the latest macOS DMG or Linux AppImage based on the visitor's desktop OS, with explicit Linux `.deb` support
- replace the Apple-specific download CTA with a stable cross-platform label and icon
- fall back to GitHub Releases for mobile, unsupported, unknown, or failed artifact lookups

## Why

Linux desktop support is shipped, but the marketing site still described Zuse as macOS-only and the download route always selected a DMG. That misled Linux visitors and sent them an unusable installer.

## Impact

macOS visitors keep receiving the latest DMG, Linux visitors now receive the latest x86_64 AppImage, Debian and Ubuntu users can request the `.deb`, and unsupported clients no longer receive the wrong desktop artifact.

## Validation

- `bunx vitest run apps/web/lib/download.test.ts` — 6 tests passed
- `bun --filter web check-types`
- `bun --filter web build`
- focused Biome check on the new download selector, route, tests, and CTA
- live built-server redirect checks against release v0.17.0: macOS → DMG, Linux → AppImage, Windows → Releases fallback