### PR TITLE
Fix Linux agent and environment startup

### DIFF
--- a/apps/desktop/src/host/open-targets.ts
+++ b/apps/desktop/src/host/open-targets.ts
@@ -12,6 +12,19 @@ export type PortableOpenTarget = {
 	readonly args: (path: string) => ReadonlyArray<string>;
 };
 
+export const terminalShellCommand = (path: string): ReadonlyArray<string> => [
+	"-e",
+	"sh",
+	"-c",
+	`cd -- "$1" && exec "\${SHELL:-/bin/sh}" -l`,
+	"zuse-terminal",
+	path,
+];
+
+export const ghosttyWorkingDirectoryArgs = (
+	path: string,
+): ReadonlyArray<string> => [`--working-directory=${path}`];
+
 export type PortableOpenTargetView = {
 	readonly id: string;
 	readonly label: string;
@@ -54,13 +67,13 @@ const linuxTargets: ReadonlyArray<PortableOpenTarget> = [
 		id: "ghostty",
 		label: "Ghostty",
 		command: "ghostty",
-		args: (path) => ["--working-directory", path],
+		args: ghosttyWorkingDirectoryArgs,
 	},
 	{
 		id: "terminal",
 		label: "Terminal",
 		command: "x-terminal-emulator",
-		args: (path) => ["--working-directory", path],
+		args: terminalShellCommand,
 	},
 ];
 

--- a/apps/desktop/test/unit/host-adapters.test.ts
+++ b/apps/desktop/test/unit/host-adapters.test.ts
@@ -10,6 +10,29 @@ import {
 	parseNetstatListeners,
 	parseSsListeners,
 } from "../../src/host/local-port-inspector.ts";
+import {
+	ghosttyWorkingDirectoryArgs,
+	terminalShellCommand,
+} from "../../src/host/open-targets.ts";
+
+describe("Linux open targets", () => {
+	it("passes Ghostty's working directory as one option", () => {
+		expect(ghosttyWorkingDirectoryArgs("/tmp/a repo")).toEqual([
+			"--working-directory=/tmp/a repo",
+		]);
+	});
+
+	it("opens the portable terminal in the requested directory", () => {
+		expect(terminalShellCommand("/tmp/a repo")).toEqual([
+			"-e",
+			"sh",
+			"-c",
+			`cd -- "$1" && exec "\${SHELL:-/bin/sh}" -l`,
+			"zuse-terminal",
+			"/tmp/a repo",
+		]);
+	});
+});
 
 describe("browser cookie host adapter", () => {
 	it("discovers XDG, Snap, and Flatpak Chromium profiles on Linux", () => {

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -395,15 +395,6 @@ export const ProviderServiceLive = Layer.effect(
 								executor,
 							),
 						);
-						if (mcpProxyCommand === null) {
-							return yield* Effect.fail(
-								new AgentSessionStartError({
-									providerId: "grok",
-									reason:
-										"Bun was not found on PATH. It is required for the MCP compatibility transport.",
-								}),
-							);
-						}
 						providerHandle = yield* startGrokSession(
 							driverInput,
 							cwd,
@@ -416,7 +407,7 @@ export const ProviderServiceLive = Layer.effect(
 								Effect.runPromiseWith(runtime)(
 									browserBridge.send(sessionId, command),
 								),
-							mcpProxyCommand,
+							mcpProxyCommand ?? process.execPath,
 							orchestrationTools,
 							resumeCursor,
 							providerEventCursor,
@@ -539,15 +530,6 @@ export const ProviderServiceLive = Layer.effect(
 								executor,
 							),
 						);
-						if (mcpProxyCommand === null) {
-							return yield* Effect.fail(
-								new AgentSessionStartError({
-									providerId: "codex",
-									reason:
-										"Bun was not found on PATH. It is required for the MCP compatibility transport.",
-								}),
-							);
-						}
 						for (const name of legacyAppOwnedCodexServerNames(
 							readNativeServers({
 								cwd,
@@ -589,7 +571,7 @@ export const ProviderServiceLive = Layer.effect(
 								Effect.runPromiseWith(runtime)(
 									browserBridge.send(sessionId, command),
 								),
-							mcpProxyCommand,
+							mcpProxyCommand ?? process.execPath,
 							orchestrationTools,
 							resumeCursor,
 						).pipe(Effect.provideService(AttachmentService, attachmentService));

--- a/packages/agents/src/kernel/stdio-mcp-fallback.ts
+++ b/packages/agents/src/kernel/stdio-mcp-fallback.ts
@@ -39,15 +39,17 @@ export const makeStdioMcpFallback = (
 	readonly ensure: () => Promise<ReadonlyArray<StdioMcpServerConfig>>;
 	readonly close: () => Promise<void>;
 } => {
+	const usesBun = basename(options.command).includes("bun");
 	const config: StdioMcpServerConfig = {
 		name: "zuse",
-		command: basename(options.command).includes("bun")
-			? options.command
-			: process.execPath,
+		command: usesBun ? options.command : process.execPath,
 		args: [childPath()],
 		env: [
 			{ name: "ZUSE_APP_MCP_URL", value: options.endpoint },
 			{ name: "ZUSE_APP_MCP_TOKEN", value: options.token },
+			...(usesBun
+				? []
+				: [{ name: "ELECTRON_RUN_AS_NODE", value: "1" } as const]),
 		],
 	};
 	return {

--- a/packages/git/src/worktree/worktree-service-live.ts
+++ b/packages/git/src/worktree/worktree-service-live.ts
@@ -121,6 +121,23 @@ const truncateOutput = (value: string): string =>
 		? value
 		: value.slice(value.length - MAX_SETUP_OUTPUT);
 
+export const shellCommandForPlatform = (
+	platform: NodeJS.Platform,
+	env: NodeJS.ProcessEnv,
+): { readonly command: string; readonly args: ReadonlyArray<string> } => {
+	if (platform === "win32") {
+		return {
+			command: env.COMSPEC?.trim() || "cmd.exe",
+			args: ["/d", "/s", "/c"],
+		};
+	}
+	return {
+		command:
+			env.SHELL?.trim() || (platform === "darwin" ? "/bin/zsh" : "/bin/sh"),
+		args: ["-lc"],
+	};
+};
+
 const readIfExists = async (path: string): Promise<Buffer | null> => {
 	try {
 		return await fs.readFile(path);
@@ -240,14 +257,22 @@ export const WorktreeServiceLive = Layer.effect(
 			}) {
 				return yield* Effect.scoped(
 					Effect.gen(function* () {
-						const command = Command.make("/bin/zsh", ["-lc", script], {
-							cwd,
-							env: { ...env },
-							extendEnv: true,
-							stdin: "ignore",
-						});
-						const process = yield* executor.spawn(command);
-						const output = yield* process.all.pipe(
+						const shell = shellCommandForPlatform(
+							process.platform,
+							process.env,
+						);
+						const command = Command.make(
+							shell.command,
+							[...shell.args, script],
+							{
+								cwd,
+								env: { ...env },
+								extendEnv: true,
+								stdin: "ignore",
+							},
+						);
+						const childProcess = yield* executor.spawn(command);
+						const output = yield* childProcess.all.pipe(
 							Stream.decodeText({ encoding: "utf-8" }),
 							Stream.runFold(
 								() => "",
@@ -258,7 +283,7 @@ export const WorktreeServiceLive = Layer.effect(
 								},
 							),
 						);
-						const exitCode = yield* process.exitCode;
+						const exitCode = yield* childProcess.exitCode;
 						return { exitCode, output } as const;
 					}),
 				).pipe(Effect.timeout(SETUP_TIMEOUT_MS));

--- a/packages/git/test/unit/worktree/shell-command.test.ts
+++ b/packages/git/test/unit/worktree/shell-command.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { shellCommandForPlatform } from "../../../src/worktree/worktree-service-live.ts";
+
+describe("worktree script shell", () => {
+	it("uses the configured shell on Linux", () => {
+		expect(
+			shellCommandForPlatform("linux", { SHELL: "/usr/bin/fish" }),
+		).toEqual({
+			command: "/usr/bin/fish",
+			args: ["-lc"],
+		});
+	});
+
+	it("falls back to a portable POSIX shell on Linux", () => {
+		expect(shellCommandForPlatform("linux", {})).toEqual({
+			command: "/bin/sh",
+			args: ["-lc"],
+		});
+	});
+
+	it("keeps zsh as the macOS fallback", () => {
+		expect(shellCommandForPlatform("darwin", {})).toEqual({
+			command: "/bin/zsh",
+			args: ["-lc"],
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- allow Codex and Grok sessions to start without requiring Bun solely for the MCP compatibility fallback
- run the packaged MCP proxy through Electron's Node mode when Bun is unavailable
- open Ghostty and the system terminal in the selected project or worktree directory on Linux
- run worktree setup and run scripts with the configured user shell, with portable platform fallbacks
- add Linux-focused terminal and shell-selection coverage

## Root cause

Linux setup scripts were hard-coded to `/bin/zsh`, terminal launch arguments assumed unsupported shared working-directory flags, and provider startup failed eagerly when Bun was not on `PATH` even though the packaged runtime can execute the fallback proxy.

## Impact

Linux users can start Codex, open external terminals at the correct workspace path, and configure isolated per-worktree setup environments without installing zsh or Bun as incidental runtime dependencies.

## Validation

- Biome checks on all changed files
- type checks for desktop, server, agents, and git packages
- agents unit suite: 219 tests
- focused desktop and shell-selection tests: 10 tests
- worktree integration suite: 21 tests