### PR TITLE
Release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1]
+
+### Changed
+- Downloads now select the correct macOS or Linux installer automatically, with a dedicated `.deb` option for Debian and Ubuntu users
+- File editing and change review now share a cleaner annotation experience, including multi-line selection and gutter-based comment creation
+
+### Fixed
+- Annotation deletion now works reliably across sessions and revealed comments
+- Linux users can now start Codex and Grok without Bun, open Ghostty or the system terminal in the selected workspace, and run isolated worktree setup scripts without requiring zsh
+
 ## [0.17.0]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "0.17.1",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Downloads now select the correct macOS or Linux installer automatically, with a dedicated `.deb` option for Debian and Ubuntu users",
+          "File editing and change review now share a cleaner annotation experience, including multi-line selection and gutter-based comment creation"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Annotation deletion now works reliably across sessions and revealed comments",
+          "Linux users can now start Codex and Grok without Bun, open Ghostty or the system terminal in the selected workspace, and run isolated worktree setup scripts without requiring zsh"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.17.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.17.1 with release notes grouped by user-visible outcome.

### Changed

- Downloads now select the correct macOS or Linux installer automatically, with a dedicated `.deb` option for Debian and Ubuntu users.
- File editing and change review now share a cleaner annotation experience, including multi-line selection and gutter-based comment creation.

### Fixed

- Annotation deletion now works reliably across sessions and revealed comments.
- Linux users can now start Codex and Grok without Bun, open Ghostty or the system terminal in the selected workspace, and run isolated worktree setup scripts without requiring zsh.

## Validation

- `bun install --frozen-lockfile`
- `bun run check-types`
- release metadata and generated website changelog inspected

Release artifacts are produced by pushing tag v0.17.1 after this PR lands.
