### PR TITLE
Polish changes review and diff theming

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -26,7 +26,7 @@
 		"@hugeicons-pro/core-stroke-rounded": "4.2.2",
 		"@hugeicons/react": "^1.1.7",
 		"@legendapp/list": "3.3.3",
-		"@pierre/diffs": "1.3.2",
+		"@pierre/diffs": "1.3.3",
 		"@pierre/trees": "1.0.0-beta.5",
 		"@xterm/addon-fit": "^0.11.0",
 		"@xterm/addon-webgl": "^0.19.0",

--- a/apps/renderer/src/components/changes-review.tsx
+++ b/apps/renderer/src/components/changes-review.tsx
@@ -51,6 +51,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../hooks/use-auth.ts";
+import { useResolvedAppearance } from "../lib/appearance.tsx";
 import { formatError } from "../lib/format-error.ts";
 import {
 	getReviewAnnotationAnchor,
@@ -275,6 +276,7 @@ function ChangesReviewReady({
 		(state) => state.selectedSessionId,
 	);
 	const { user: authUser, name: authName } = useAuth();
+	const resolvedAppearance = useResolvedAppearance();
 	const [repositoryAuthor, setRepositoryAuthor] =
 		useState<AnnotationAuthor | null>(null);
 	useEffect(() => {
@@ -873,6 +875,7 @@ function ChangesReviewReady({
 
 	const reviewOptions = useMemo<CodeViewOptions<AnnotationMetadata>>(
 		() => ({
+			themeType: resolvedAppearance,
 			diffStyle: preferences.diffStyle,
 			overflow: preferences.wrap ? "wrap" : "scroll",
 			disableLineNumbers: !preferences.lineNumbers,
@@ -884,13 +887,14 @@ function ChangesReviewReady({
 			controlledSelection: true,
 			lineHoverHighlight: "number",
 			hunkSeparators: "line-info",
+			layout: { paddingTop: 0, paddingBottom: 12, gap: 8 },
 			onGutterUtilityClick(range, context) {
 				if (context.item.type === "diff") {
 					createAnnotationDraft(range, context.item.id);
 				}
 			},
 		}),
-		[createAnnotationDraft, preferences],
+		[createAnnotationDraft, preferences, resolvedAppearance],
 	);
 
 	if (summary === null && loading) {
@@ -1012,7 +1016,7 @@ function ChangesReviewReady({
 						renderHeaderMetadata={renderHeaderMetadata}
 						renderAnnotation={renderAnnotation}
 						options={reviewOptions}
-						className="h-full overflow-auto overscroll-contain px-3 py-3"
+						className="fz-diff h-full overflow-auto overscroll-contain px-3"
 					/>
 				)}
 				{selectedConflict !== null ? (
@@ -1043,6 +1047,7 @@ function ConflictReview({
 	readonly onResolved: () => Promise<void>;
 	readonly onClose: () => void;
 }) {
+	const resolvedAppearance = useResolvedAppearance();
 	const [contents, setContents] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [remaining, setRemaining] = useState(0);
@@ -1111,11 +1116,12 @@ function ConflictReview({
 	);
 	const conflictOptions = useMemo<UnresolvedFileReactOptions<undefined>>(
 		() => ({
+			themeType: resolvedAppearance,
 			diffIndicators: "bars",
 			overflow: "wrap",
 			hunkSeparators: "line-info",
 		}),
-		[],
+		[resolvedAppearance],
 	);
 
 	return (
@@ -1208,7 +1214,7 @@ function ConflictReview({
 								</div>
 							);
 						}}
-						className="mx-auto block w-full max-w-[1400px] overflow-hidden rounded-lg bg-card/30 shadow-sm ring-1 ring-border/50"
+						className="fz-diff mx-auto block w-full max-w-[1400px] overflow-hidden rounded-lg bg-card/30 shadow-sm ring-1 ring-border/50"
 					/>
 				)}
 			</div>

--- a/apps/renderer/src/components/changes-review.tsx
+++ b/apps/renderer/src/components/changes-review.tsx
@@ -79,7 +79,6 @@ type ReviewPreferences = {
 	readonly diffStyle: "split" | "unified";
 	readonly wrap: boolean;
 	readonly lineNumbers: boolean;
-	readonly backgrounds: boolean;
 	readonly indicators: "bars" | "classic" | "none";
 };
 
@@ -89,7 +88,6 @@ const DEFAULT_PREFERENCES: ReviewPreferences = {
 	diffStyle: "split",
 	wrap: true,
 	lineNumbers: true,
-	backgrounds: true,
 	indicators: "bars",
 };
 
@@ -876,10 +874,10 @@ function ChangesReviewReady({
 	const reviewOptions = useMemo<CodeViewOptions<AnnotationMetadata>>(
 		() => ({
 			...diffTheme,
+			disableBackground: true,
 			diffStyle: preferences.diffStyle,
 			overflow: preferences.wrap ? "wrap" : "scroll",
 			disableLineNumbers: !preferences.lineNumbers,
-			disableBackground: !preferences.backgrounds,
 			diffIndicators: preferences.indicators,
 			stickyHeaders: true,
 			enableLineSelection: true,
@@ -1117,6 +1115,7 @@ function ConflictReview({
 	const conflictOptions = useMemo<UnresolvedFileReactOptions<undefined>>(
 		() => ({
 			...diffTheme,
+			disableBackground: true,
 			diffIndicators: "bars",
 			overflow: "wrap",
 			hunkSeparators: "line-info",
@@ -1360,11 +1359,6 @@ function DisplaySettings({
 				>
 					<PopoverPrimitive.Popup className="w-60 rounded-lg border border-border/70 bg-popover p-3 text-popover-foreground shadow-xl/15 outline-none">
 						<div className="flex flex-col gap-1">
-							<DisplaySwitch
-								label="Backgrounds"
-								checked={preferences.backgrounds}
-								onCheckedChange={(backgrounds) => onChange({ backgrounds })}
-							/>
 							<DisplaySwitch
 								label="Line numbers"
 								checked={preferences.lineNumbers}

--- a/apps/renderer/src/components/changes-review.tsx
+++ b/apps/renderer/src/components/changes-review.tsx
@@ -40,6 +40,7 @@ import {
 	Copy,
 	EyeOff,
 	FilePenLine,
+	LoaderCircle,
 	MoreHorizontal,
 	PanelTop,
 	RotateCcw,
@@ -893,7 +894,7 @@ function ChangesReviewReady({
 	);
 
 	if (summary === null && loading) {
-		return <ReviewState title="Preparing branch review…" />;
+		return <ReviewState title="Preparing review" loading />;
 	}
 	if (summary === null) {
 		return <ReviewState title={error ?? "No review is available."} />;
@@ -1119,7 +1120,7 @@ function ConflictReview({
 
 	return (
 		<div className="absolute inset-0 z-20 flex min-h-0 flex-col bg-background">
-			<div className="flex h-11 shrink-0 items-center gap-2 border-b border-border/60 px-3">
+			<div className="flex h-12 shrink-0 items-center gap-2 border-b border-border/50 px-3">
 				<button
 					type="button"
 					onClick={onClose}
@@ -1129,9 +1130,16 @@ function ConflictReview({
 				>
 					<ChevronRight className="size-4 rotate-180" />
 				</button>
-				<CircleAlert className="size-3.5 shrink-0 text-amber-400" />
-				<span className="min-w-0 truncate font-mono text-xs">{file.path}</span>
-				<span className="ml-auto shrink-0 text-[11px] tabular-nums text-muted-foreground">
+				<CircleAlert className="size-3.5 shrink-0 text-rose-400" />
+				<div className="min-w-0">
+					<div className="truncate text-xs font-medium">
+						Resolve {file.path.slice(file.path.lastIndexOf("/") + 1)}
+					</div>
+					<div className="truncate text-[10px] text-muted-foreground">
+						{file.path}
+					</div>
+				</div>
+				<span className="ml-auto shrink-0 rounded-md bg-foreground/5 px-2 py-1 text-[10px] tabular-nums text-muted-foreground">
 					{saving
 						? "Saving resolution…"
 						: `${remaining} conflict${remaining === 1 ? "" : "s"} remaining`}
@@ -1146,7 +1154,7 @@ function ConflictReview({
 				{error !== null && contents === null ? (
 					<ReviewState title={error} />
 				) : contents === null ? (
-					<ReviewState title="Loading conflict…" />
+					<ReviewState title="Loading conflict" loading />
 				) : (
 					<UnresolvedFile
 						file={{ name: file.path, contents }}
@@ -1187,22 +1195,20 @@ function ConflictReview({
 								}
 							};
 							return (
-								<div className="flex items-center gap-1.5 px-2 py-1 text-[11px] text-muted-foreground">
+								<div className="m-1.5 flex w-fit items-center rounded-md bg-background/80 p-0.5 shadow-sm ring-1 ring-border/60">
 									<ConflictAction onClick={() => resolve("current")}>
-										Accept current
+										Keep current
 									</ConflictAction>
-									<span className="text-border">|</span>
 									<ConflictAction onClick={() => resolve("incoming")}>
-										Accept incoming
+										Keep incoming
 									</ConflictAction>
-									<span className="text-border">|</span>
 									<ConflictAction onClick={() => resolve("both")}>
-										Accept both
+										Keep both
 									</ConflictAction>
 								</div>
 							);
 						}}
-						className="mx-auto block w-full max-w-[1400px] overflow-hidden rounded-lg border border-border/60"
+						className="mx-auto block w-full max-w-[1400px] overflow-hidden rounded-lg bg-card/30 shadow-sm ring-1 ring-border/50"
 					/>
 				)}
 			</div>
@@ -1221,17 +1227,28 @@ function ConflictAction({
 		<button
 			type="button"
 			onClick={onClick}
-			className="rounded px-1 py-0.5 text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+			className="h-7 rounded px-2 text-[10px] font-medium text-muted-foreground outline-none hover:bg-foreground/5 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring"
 		>
 			{children}
 		</button>
 	);
 }
 
-function ReviewState({ title }: { readonly title: string }) {
+function ReviewState({
+	title,
+	loading = false,
+}: {
+	readonly title: string;
+	readonly loading?: boolean;
+}) {
 	return (
-		<div className="grid h-full place-items-center px-8 text-center text-sm text-muted-foreground">
-			{title}
+		<div className="grid h-full min-h-40 place-items-center px-8 text-center">
+			<div className="flex flex-col items-center gap-2 text-xs text-muted-foreground">
+				{loading ? (
+					<LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+				) : null}
+				<span>{title}</span>
+			</div>
 		</div>
 	);
 }

--- a/apps/renderer/src/components/changes-review.tsx
+++ b/apps/renderer/src/components/changes-review.tsx
@@ -874,7 +874,6 @@ function ChangesReviewReady({
 	const reviewOptions = useMemo<CodeViewOptions<AnnotationMetadata>>(
 		() => ({
 			...diffTheme,
-			disableBackground: true,
 			diffStyle: preferences.diffStyle,
 			overflow: preferences.wrap ? "wrap" : "scroll",
 			disableLineNumbers: !preferences.lineNumbers,
@@ -1115,7 +1114,6 @@ function ConflictReview({
 	const conflictOptions = useMemo<UnresolvedFileReactOptions<undefined>>(
 		() => ({
 			...diffTheme,
-			disableBackground: true,
 			diffIndicators: "bars",
 			overflow: "wrap",
 			hunkSeparators: "line-info",

--- a/apps/renderer/src/components/changes-review.tsx
+++ b/apps/renderer/src/components/changes-review.tsx
@@ -11,7 +11,7 @@ import type {
 	SelectedLineRange,
 	UnresolvedFile as UnresolvedFileInstance,
 } from "@pierre/diffs";
-import { DEFAULT_THEMES, processFile } from "@pierre/diffs";
+import { processFile } from "@pierre/diffs";
 import { Editor } from "@pierre/diffs/edit";
 import {
 	CodeView,
@@ -51,7 +51,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../hooks/use-auth.ts";
-import { useResolvedAppearance } from "../lib/appearance.tsx";
+import { useZuseDiffTheme, ZUSE_DIFF_THEMES } from "../lib/diffs-theme.ts";
 import { formatError } from "../lib/format-error.ts";
 import {
 	getReviewAnnotationAnchor,
@@ -103,7 +103,7 @@ const REVIEW_POOL_OPTIONS: WorkerPoolOptions = {
 };
 
 const REVIEW_HIGHLIGHTER_OPTIONS: WorkerInitializationRenderOptions = {
-	theme: DEFAULT_THEMES,
+	theme: ZUSE_DIFF_THEMES,
 	langs: ["css", "go", "python", "rust", "sh", "swift", "tsx", "typescript"],
 	preferredHighlighter: "shiki-wasm",
 };
@@ -276,7 +276,7 @@ function ChangesReviewReady({
 		(state) => state.selectedSessionId,
 	);
 	const { user: authUser, name: authName } = useAuth();
-	const resolvedAppearance = useResolvedAppearance();
+	const diffTheme = useZuseDiffTheme();
 	const [repositoryAuthor, setRepositoryAuthor] =
 		useState<AnnotationAuthor | null>(null);
 	useEffect(() => {
@@ -875,7 +875,7 @@ function ChangesReviewReady({
 
 	const reviewOptions = useMemo<CodeViewOptions<AnnotationMetadata>>(
 		() => ({
-			themeType: resolvedAppearance,
+			...diffTheme,
 			diffStyle: preferences.diffStyle,
 			overflow: preferences.wrap ? "wrap" : "scroll",
 			disableLineNumbers: !preferences.lineNumbers,
@@ -894,7 +894,7 @@ function ChangesReviewReady({
 				}
 			},
 		}),
-		[createAnnotationDraft, preferences, resolvedAppearance],
+		[createAnnotationDraft, diffTheme, preferences],
 	);
 
 	if (summary === null && loading) {
@@ -1047,7 +1047,7 @@ function ConflictReview({
 	readonly onResolved: () => Promise<void>;
 	readonly onClose: () => void;
 }) {
-	const resolvedAppearance = useResolvedAppearance();
+	const diffTheme = useZuseDiffTheme();
 	const [contents, setContents] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [remaining, setRemaining] = useState(0);
@@ -1116,12 +1116,12 @@ function ConflictReview({
 	);
 	const conflictOptions = useMemo<UnresolvedFileReactOptions<undefined>>(
 		() => ({
-			themeType: resolvedAppearance,
+			...diffTheme,
 			diffIndicators: "bars",
 			overflow: "wrap",
 			hunkSeparators: "line-info",
 		}),
-		[resolvedAppearance],
+		[diffTheme],
 	);
 
 	return (

--- a/apps/renderer/src/components/diff-pane.tsx
+++ b/apps/renderer/src/components/diff-pane.tsx
@@ -6,11 +6,6 @@ import {
 	Tick02Icon,
 	Upload01Icon,
 } from "@hugeicons-pro/core-solid-rounded";
-import type { GitStatus, GitStatusEntry } from "@pierre/trees";
-import {
-	FileTree as StructuredFileTree,
-	useFileTree,
-} from "@pierre/trees/react";
 import type {
 	CodeAnnotation,
 	FolderId,
@@ -23,19 +18,13 @@ import type {
 } from "@zuse/contracts";
 import { Effect } from "effect";
 import {
-	CircleAlert,
+	FileWarning,
 	MessageSquareText,
 	Pencil,
 	Sparkles,
 	Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import {
-	Group,
-	Panel,
-	Separator,
-	useDefaultLayout,
-} from "react-resizable-panels";
 import { getRpcClient } from "../lib/rpc-client.ts";
 import { useAnnotationsStore } from "../store/annotations.ts";
 import { gitChangesKey, useGitChangesStore } from "../store/git-changes.ts";
@@ -49,6 +38,7 @@ import {
 	REVIEW_VIEWED_STORAGE_KEY,
 	reviewFingerprint,
 } from "./changes-review.tsx";
+import { FileIcon } from "./file-icon.tsx";
 import { GitInitCta } from "./git-init-cta.tsx";
 import {
 	AlertDialog,
@@ -67,9 +57,6 @@ const basename = (path: string): string => {
 };
 
 const EMPTY_REVIEW_PATCHES: Readonly<Record<string, GitReviewPatch>> = {};
-const NAVIGATOR_PANEL_IDS = ["conflicts", "changes"];
-const NAVIGATOR_PANEL_GROUP_ID = "zuse.review.navigator.v1";
-
 type RevertRequest =
 	| { readonly type: "all" }
 	| {
@@ -150,15 +137,6 @@ export function DiffPane({
 		"files",
 	);
 	const [viewedRevision, setViewedRevision] = useState(0);
-	const {
-		defaultLayout: navigatorDefaultLayout,
-		onLayoutChanged: onNavigatorLayoutChanged,
-	} = useDefaultLayout({
-		id: NAVIGATOR_PANEL_GROUP_ID,
-		panelIds: NAVIGATOR_PANEL_IDS,
-		storage: typeof window === "undefined" ? undefined : window.localStorage,
-	});
-
 	useEffect(() => {
 		const refreshViewed = () => setViewedRevision((value) => value + 1);
 		window.addEventListener("zuse-review-viewed", refreshViewed);
@@ -180,7 +158,12 @@ export function DiffPane({
 	}, [folderId, worktreeId, hydratePrDetails, refreshChanges, refreshReview]);
 
 	if (folderId === null) {
-		return <Empty>Select a project to see its changes.</Empty>;
+		return (
+			<Indicator
+				title="No project selected"
+				body="Select a project to view its changed files."
+			/>
+		);
 	}
 
 	const refreshAll = async () => {
@@ -348,50 +331,36 @@ export function DiffPane({
 									<GitInitCta folderId={folderId} worktreeId={worktreeId} />
 								</div>
 							) : reviewLoading && review === null ? (
-								<Indicator title="Loading branch changes…" />
+								<Indicator title="Loading changes" loading />
 							) : reviewFiles.length === 0 ? (
-								<Indicator title="No branch changes" />
+								<Indicator
+									title="No changes"
+									body="Your branch is up to date with its base."
+								/>
 							) : conflictFiles.length > 0 ? (
-								<Group
-									id={NAVIGATOR_PANEL_GROUP_ID}
-									orientation="vertical"
-									defaultLayout={navigatorDefaultLayout}
-									onLayoutChanged={onNavigatorLayoutChanged}
-									resizeTargetMinimumSize={{ fine: 12, coarse: 28 }}
-									className="min-h-0 flex-1"
-								>
-									<Panel id="conflicts" defaultSize="35%" minSize="88px">
-										<NavigatorSection
-											title="Conflicts"
-											count={conflictFiles.length}
-											files={conflictFiles}
-											onSelect={openChanges}
-											conflict
-											className="h-full"
-										/>
-									</Panel>
-									<Separator
-										aria-label="Resize Conflicts and Changes"
-										title="Drag to resize Conflicts and Changes"
-										className="group relative h-1 cursor-row-resize bg-transparent outline-none after:absolute after:inset-x-0 after:top-1/2 after:h-px after:-translate-y-1/2 after:bg-border/60 after:transition-colors hover:after:bg-foreground/25 active:after:bg-foreground/40 focus-visible:after:bg-foreground/40"
+								<div className="min-h-0 flex-1 overflow-y-auto py-1">
+									<NavigatorSection
+										title="Merge changes"
+										count={conflictFiles.length}
+										files={conflictFiles}
+										onSelect={openChanges}
+										conflict
 									/>
-									<Panel id="changes" defaultSize="65%" minSize="88px">
-										<NavigatorSection
-											title="Changes"
-											count={changedFiles.length}
-											files={changedFiles}
-											onSelect={openChanges}
-											className="h-full"
-										/>
-									</Panel>
-								</Group>
+									<div className="my-1 h-px bg-border/50" />
+									<NavigatorSection
+										title="Changes"
+										count={changedFiles.length}
+										files={changedFiles}
+										onSelect={openChanges}
+									/>
+								</div>
 							) : (
 								<NavigatorSection
 									title="Changes"
 									count={changedFiles.length}
 									files={changedFiles}
 									onSelect={openChanges}
-									className="min-h-0 flex-1"
+									className="min-h-0 flex-1 overflow-y-auto py-1"
 								/>
 							)}
 						</div>
@@ -610,21 +579,23 @@ function RevertChangesDialog({
 	);
 }
 
-const treeStatusFor = (kind: GitChangeKind): GitStatus => {
+const fileStatusFor = (
+	kind: GitChangeKind,
+): { readonly label: string; readonly className: string } => {
 	switch (kind) {
 		case "added":
 		case "copied":
-			return "added";
-		case "deleted":
-			return "deleted";
-		case "renamed":
-			return "renamed";
 		case "untracked":
-			return "untracked";
-		case "ignored":
-			return "ignored";
+			return {
+				label: "A",
+				className: "bg-emerald-500/10 text-emerald-500",
+			};
+		case "deleted":
+			return { label: "D", className: "bg-rose-500/10 text-rose-500" };
+		case "renamed":
+			return { label: "R", className: "bg-sky-500/10 text-sky-500" };
 		default:
-			return "modified";
+			return { label: "M", className: "bg-amber-500/10 text-amber-500" };
 	}
 };
 
@@ -664,30 +635,21 @@ function NavigatorSection({
 	if (files.length === 0) {
 		return (
 			<section className={`flex min-h-0 flex-col ${className}`}>
-				<div className="flex h-7 shrink-0 items-center gap-1.5 px-3 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+				<div className="flex h-8 shrink-0 items-center gap-1.5 px-3 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
 					<span>{title}</span>
 					<span className="tabular-nums">{count}</span>
-				</div>
-				<div className="px-3 py-2 text-[11px] text-muted-foreground">
-					No other changed files
 				</div>
 			</section>
 		);
 	}
 	return (
 		<section className={`flex min-h-0 flex-col ${className}`}>
-			<div className="flex h-7 shrink-0 items-center gap-1.5 px-3 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-				{conflict ? <CircleAlert className="size-3 text-amber-400" /> : null}
-				<span className={conflict ? "text-amber-300" : ""}>{title}</span>
-				<span className="ml-auto tabular-nums">{count}</span>
+			<div className="flex h-8 shrink-0 items-center gap-1.5 px-3 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+				{conflict ? <FileWarning className="size-3 text-rose-400" /> : null}
+				<span className={conflict ? "text-foreground" : ""}>{title}</span>
+				<span className="tabular-nums">{count}</span>
 			</div>
-			<div className="min-h-0 flex-1 overflow-hidden">
-				<ChangesNavigatorTree
-					key={files.map((file) => `${file.path}:${file.kind}`).join("\0")}
-					files={files}
-					onSelect={onSelect}
-				/>
-			</div>
+			<ChangedFilesList files={files} onSelect={onSelect} conflict={conflict} />
 		</section>
 	);
 }
@@ -732,40 +694,64 @@ function ExternalFeedbackCard({
 	);
 }
 
-function ChangesNavigatorTree({
+function ChangedFilesList({
 	files,
 	onSelect,
+	conflict,
 }: {
 	readonly files: readonly GitReviewFile[];
 	readonly onSelect: (path: string) => void;
+	readonly conflict: boolean;
 }) {
-	const paths = useMemo(() => files.map((file) => file.path), [files]);
-	const gitStatus = useMemo<GitStatusEntry[]>(
-		() =>
-			files.map((file) => ({
-				path: file.path,
-				status: treeStatusFor(file.kind),
-			})),
-		[files],
-	);
-	const { model } = useFileTree({
-		paths,
-		gitStatus,
-		density: "compact",
-		icons: "complete",
-		initialExpansion: 3,
-		initialVisibleRowCount: 50,
-		onSelectionChange: (selectedPaths) => {
-			const path = selectedPaths[0];
-			if (selectedPaths.length === 1 && path !== undefined) onSelect(path);
-		},
-	});
 	return (
-		<StructuredFileTree
-			model={model}
-			aria-label="Changed files"
-			className="h-full min-h-0"
-		/>
+		<ul aria-label={conflict ? "Files with merge conflicts" : "Changed files"}>
+			{files.map((file) => {
+				const name = basename(file.path);
+				const directory = file.path.slice(
+					0,
+					Math.max(0, file.path.length - name.length - 1),
+				);
+				const status = fileStatusFor(file.kind);
+				return (
+					<li key={file.path}>
+						<button
+							type="button"
+							onClick={() => onSelect(file.path)}
+							aria-label={
+								conflict
+									? `Resolve merge conflict in ${file.path}`
+									: `Open changes for ${file.path}`
+							}
+							className="group flex h-8 w-full items-center gap-2 px-3 text-left outline-none hover:bg-foreground/[0.045] focus-visible:bg-foreground/[0.06] focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+						>
+							<span
+								className={`grid size-5 shrink-0 place-items-center rounded text-[10px] font-semibold ${
+									conflict ? "bg-rose-500/10 text-rose-400" : status.className
+								}`}
+								aria-hidden="true"
+							>
+								{conflict ? "!" : status.label}
+							</span>
+							<FileIcon name={name} kind="file" className="size-4 shrink-0" />
+							<span className="min-w-0 truncate text-xs text-foreground">
+								{name}
+							</span>
+							{directory.length > 0 ? (
+								<span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground/70">
+									{directory}
+								</span>
+							) : (
+								<span className="flex-1" />
+							)}
+							<span className="shrink-0 font-mono text-[10px] tabular-nums">
+								<span className="text-emerald-500">+{file.additions}</span>{" "}
+								<span className="text-rose-500">−{file.deletions}</span>
+							</span>
+						</button>
+					</li>
+				);
+			})}
+		</ul>
 	);
 }
 
@@ -982,21 +968,32 @@ const formatErr = (err: unknown): string => {
 	return String(err);
 };
 
-function Indicator({ title, body }: { title: string; body?: string }) {
+function Indicator({
+	title,
+	body,
+	loading = false,
+}: {
+	title: string;
+	body?: string;
+	loading?: boolean;
+}) {
 	return (
-		<div className="flex flex-col gap-0.5">
-			<span className="font-medium text-foreground">{title}</span>
-			{body !== undefined ? (
-				<span className="text-muted-foreground">{body}</span>
-			) : null}
+		<div className="grid min-h-32 flex-1 place-items-center px-6 py-10 text-center">
+			<div className="flex max-w-64 flex-col items-center gap-1.5">
+				{loading ? (
+					<HugeiconsIcon
+						icon={Loading02Icon}
+						className="mb-1 size-4 animate-spin text-muted-foreground"
+						aria-hidden="true"
+					/>
+				) : null}
+				<span className="text-xs font-medium text-foreground">{title}</span>
+				{body !== undefined ? (
+					<span className="text-[11px] leading-4 text-muted-foreground">
+						{body}
+					</span>
+				) : null}
+			</div>
 		</div>
-	);
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-	return (
-		<p className="px-3 py-6 text-center text-xs text-muted-foreground">
-			{children}
-		</p>
 	);
 }

--- a/apps/renderer/src/components/file-editor.tsx
+++ b/apps/renderer/src/components/file-editor.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ShimmerText } from "~/components/ui/shimmer-text";
 import { cn } from "~/lib/utils";
 import { useAuth } from "../hooks/use-auth.ts";
+import { useZuseDiffTheme } from "../lib/diffs-theme.ts";
 import { classifyGit } from "../lib/git-rpc.ts";
 import {
 	bytesForImageContent,
@@ -299,6 +300,7 @@ function PierreEditBody({
 	hidden: boolean;
 	onClose: () => void;
 }) {
+	const diffTheme = useZuseDiffTheme();
 	const setFileDirty = useUiStore((s) => s.setFileDirty);
 	const [state, setState] = useState<EditorState>({ status: "loading" });
 	const [conflict, setConflict] = useState<string | null>(null);
@@ -553,7 +555,7 @@ function PierreEditBody({
 			)}
 			<SavingIndicator saving={saving} />
 			{state.status === "text" ? (
-				<div className="min-h-0 flex-1 overflow-auto p-3">
+				<div className="fz-diff min-h-0 flex-1 overflow-auto p-3">
 					<EditProvider createEditor={createPierreEditor}>
 						<File<FileAnnotationMetadata>
 							key={annotationRevision}
@@ -602,6 +604,7 @@ function PierreEditBody({
 								) : null
 							}
 							options={{
+								...diffTheme,
 								disableFileHeader: true,
 								overflow: "scroll",
 								lineHoverHighlight: "number",
@@ -748,6 +751,7 @@ function DiffViewBody({
 }: {
 	openFile: Extract<OpenFile, { kind: "text" }>;
 }) {
+	const diffTheme = useZuseDiffTheme();
 	const [state, setState] = useState<DiffState>({ status: "loading" });
 	// Bumped after an in-place `git init` from the no-repo CTA so the diff
 	// re-fetches without the user toggling Edit/Diff to force a remount.
@@ -779,12 +783,13 @@ function DiffViewBody({
 
 	const diffOptions = useMemo(
 		() => ({
+			...diffTheme,
 			enableLineSelection: true,
 			enableGutterUtility: true,
 			lineHoverHighlight: "number" as const,
 			onGutterUtilityClick,
 		}),
-		[onGutterUtilityClick],
+		[diffTheme, onGutterUtilityClick],
 	);
 
 	const lineAnnotations = useMemo<DiffLineAnnotation<{ kind: "editor" }>[]>(

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -1,9 +1,9 @@
 import { createPatch, structuredPatch } from "diff";
 import { lazy, Suspense, useMemo } from "react";
+import { useZuseDiffTheme } from "../lib/diffs-theme.ts";
 import { isPatchDiffRenderable } from "../lib/patch-diff.ts";
 import { FileIcon } from "./file-icon.tsx";
 
-const UNIFIED_DIFF_OPTIONS = { diffStyle: "unified" } as const;
 const PatchDiff = lazy(() =>
 	import("@pierre/diffs/react").then((module) => ({
 		default: module.PatchDiff,
@@ -218,6 +218,7 @@ export function UnifiedPatchDiff({
   kind?: string;
   showHeader?: boolean;
 }) {
+  const diffTheme = useZuseDiffTheme();
   if (patch.trim().length === 0) {
     return (
       <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
@@ -244,14 +245,14 @@ export function UnifiedPatchDiff({
       ) : null}
 
       <div
-        className="fz-diff code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
+        className="fz-diff code-block-scroll overflow-auto text-[12px] leading-[1.45]"
         style={{ maxHeight: 420 }}
       >
         {renderable ? (
 					<Suspense fallback={<RawPatchBlock patch={normalizedPatch} />}>
           <PatchDiff
             patch={normalizedPatch}
-            options={UNIFIED_DIFF_OPTIONS}
+            options={{ ...diffTheme, diffStyle: "unified" }}
             disableWorkerPool
           />
 					</Suspense>
@@ -279,6 +280,7 @@ export function EditDiff({
   edit: FileEdit;
   showHeader?: boolean;
 }) {
+  const diffTheme = useZuseDiffTheme();
   const patchText = useMemo(() => editToPatch(edit), [edit]);
   if (patchText.trim().length === 0 || edit.oldText === edit.newText) {
     return (
@@ -313,13 +315,13 @@ export function EditDiff({
       ) : null}
 
       <div
-        className="fz-diff code-block-scroll overflow-auto bg-muted/15 text-[12px] leading-[1.45]"
+        className="fz-diff code-block-scroll overflow-auto text-[12px] leading-[1.45]"
         style={{ maxHeight: 420 }}
       >
 				<Suspense fallback={<RawPatchBlock patch={patchText} />}>
         <PatchDiff
           patch={patchText}
-          options={UNIFIED_DIFF_OPTIONS}
+          options={{ ...diffTheme, diffStyle: "unified" }}
           disableWorkerPool
         />
 				</Suspense>

--- a/apps/renderer/src/components/inline-diff.tsx
+++ b/apps/renderer/src/components/inline-diff.tsx
@@ -3,6 +3,7 @@ import { lazy, Suspense, useMemo } from "react";
 import { useZuseDiffTheme } from "../lib/diffs-theme.ts";
 import { isPatchDiffRenderable } from "../lib/patch-diff.ts";
 import { FileIcon } from "./file-icon.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
 
 const PatchDiff = lazy(() =>
 	import("@pierre/diffs/react").then((module) => ({
@@ -211,12 +212,10 @@ export function UnifiedPatchDiff({
   path,
   patch,
   kind = "edit",
-  showHeader = false,
 }: {
   path: string;
   patch: string;
   kind?: string;
-  showHeader?: boolean;
 }) {
   const diffTheme = useZuseDiffTheme();
   if (patch.trim().length === 0) {
@@ -228,21 +227,37 @@ export function UnifiedPatchDiff({
   }
 
   const name = basename(path);
+  const stats = patchStats([{ file_path: path, kind, patch }]);
   const renderable = isPatchDiffRenderable(patch);
   const normalizedPatch = normalizePatchForDiffViewer(path, patch);
   return (
     <div className="overflow-hidden rounded-md border border-border/60">
-      {showHeader ? (
-        <div className="flex items-center gap-2 border-b border-border/40 bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+      <div className="flex items-center gap-2 border-b border-border/40 bg-muted px-2 py-1 text-[11px] text-muted-foreground">
           <FileIcon
             name={name}
             kind="file"
             className="inline-flex size-3.5 shrink-0"
           />
-          <span className="truncate font-mono text-foreground/80">{name}</span>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="truncate font-mono text-foreground/80">
+                  {name}
+                </span>
+              }
+            />
+            <TooltipPopup>{path}</TooltipPopup>
+          </Tooltip>
           <span className="text-muted-foreground">{kind}</span>
-        </div>
-      ) : null}
+          {stats.added > 0 ? (
+            <span className="ml-auto text-emerald-400 tabular-nums">
+              +{stats.added}
+            </span>
+          ) : null}
+          {stats.removed > 0 ? (
+            <span className="text-red-400 tabular-nums">-{stats.removed}</span>
+          ) : null}
+      </div>
 
       <div
         className="fz-diff code-block-scroll overflow-auto text-[12px] leading-[1.45]"
@@ -252,7 +267,11 @@ export function UnifiedPatchDiff({
 					<Suspense fallback={<RawPatchBlock patch={normalizedPatch} />}>
           <PatchDiff
             patch={normalizedPatch}
-            options={{ ...diffTheme, diffStyle: "unified" }}
+            options={{
+              ...diffTheme,
+              diffStyle: "unified",
+              disableFileHeader: true,
+            }}
             disableWorkerPool
           />
 					</Suspense>
@@ -275,10 +294,8 @@ export function UnifiedPatchDiff({
  */
 export function EditDiff({
   edit,
-  showHeader = false,
 }: {
   edit: FileEdit;
-  showHeader?: boolean;
 }) {
   const diffTheme = useZuseDiffTheme();
   const patchText = useMemo(() => editToPatch(edit), [edit]);
@@ -295,14 +312,23 @@ export function EditDiff({
 
   return (
     <div className="overflow-hidden rounded-md border border-border/60">
-      {showHeader ? (
-        <div className="flex items-center gap-2 border-b border-border/40 bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+      <div className="flex items-center gap-2 border-b border-border/40 bg-muted px-2 py-1 text-[11px] text-muted-foreground">
           <FileIcon
             name={name}
             kind="file"
             className="inline-flex size-3.5 shrink-0"
           />
-          <span className="truncate font-mono text-foreground/80">{name}</span>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="truncate font-mono text-foreground/80">
+                  {name}
+                </span>
+              }
+            />
+            <TooltipPopup>{edit.path}</TooltipPopup>
+          </Tooltip>
+          <span className="text-muted-foreground">{edit.mode === "create" ? "add" : "update"}</span>
           {stats.added > 0 ? (
             <span className="ml-auto text-emerald-400 tabular-nums">
               +{stats.added}
@@ -311,8 +337,7 @@ export function EditDiff({
           {stats.removed > 0 ? (
             <span className="text-red-400 tabular-nums">-{stats.removed}</span>
           ) : null}
-        </div>
-      ) : null}
+      </div>
 
       <div
         className="fz-diff code-block-scroll overflow-auto text-[12px] leading-[1.45]"
@@ -321,7 +346,11 @@ export function EditDiff({
 				<Suspense fallback={<RawPatchBlock patch={patchText} />}>
         <PatchDiff
           patch={patchText}
-          options={{ ...diffTheme, diffStyle: "unified" }}
+          options={{
+            ...diffTheme,
+            diffStyle: "unified",
+            disableFileHeader: true,
+          }}
           disableWorkerPool
         />
 				</Suspense>

--- a/apps/renderer/src/components/tool-file-block.tsx
+++ b/apps/renderer/src/components/tool-file-block.tsx
@@ -1,0 +1,71 @@
+import type { FileContents } from "@pierre/diffs";
+import { File } from "@pierre/diffs/react";
+import { useMemo } from "react";
+import { useZuseDiffTheme } from "../lib/diffs-theme.ts";
+import { cn } from "../lib/utils.ts";
+import { CopyButton } from "./copy-button.tsx";
+import { FileIcon } from "./file-icon.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
+
+const basename = (path: string): string => {
+	const index = path.lastIndexOf("/");
+	return index === -1 ? path : path.slice(index + 1);
+};
+
+export function ToolFileBlock({
+	path,
+	text,
+	isError = false,
+}: {
+	readonly path: string;
+	readonly text: string;
+	readonly isError?: boolean;
+}) {
+	const diffTheme = useZuseDiffTheme();
+	const name = basename(path);
+	const file = useMemo<FileContents>(
+		() => ({ name, contents: text }),
+		[name, text],
+	);
+
+	return (
+		<div
+			className={cn(
+				"fz-diff code-block-scroll max-h-[420px] overflow-auto rounded-lg border",
+				isError ? "border-alert-error-bg" : "border-border/50",
+			)}
+		>
+			<File
+				file={file}
+				options={{ ...diffTheme, overflow: "scroll" }}
+				renderCustomHeader={() => (
+					<div className="flex min-h-9 w-full items-center gap-2 px-2 text-[11px] text-muted-foreground">
+						<Tooltip>
+							<TooltipTrigger
+								render={
+									<div className="flex min-w-0 flex-1 items-center gap-2">
+										<FileIcon
+											name={name}
+											kind="file"
+											className="inline-flex size-3.5 shrink-0 items-center justify-center"
+										/>
+										<span className="truncate font-mono text-foreground/80">
+											{name}
+										</span>
+									</div>
+								}
+							/>
+							<TooltipPopup>{path}</TooltipPopup>
+						</Tooltip>
+						<CopyButton
+							text={text}
+							label={`Copy ${name}`}
+							className="size-5 rounded text-muted-foreground/60 hover:bg-muted/60"
+						/>
+					</div>
+				)}
+				disableWorkerPool
+			/>
+		</div>
+	);
+}

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -35,7 +35,6 @@ import { useSessionsStore } from "~/store/sessions";
 import { type FileView, useUiStore } from "~/store/ui";
 import { useWorkspaceStore } from "~/store/workspace";
 import { useWorktreesStore } from "~/store/worktrees";
-import { CodeBlock } from "./code-block.tsx";
 import { resolveFileOpenTarget, useFileChipContext } from "./file-chip.tsx";
 import { FileIcon } from "./file-icon.tsx";
 import {
@@ -48,6 +47,7 @@ import {
 	UnifiedPatchDiff,
 } from "./inline-diff.tsx";
 import { MarkdownBody } from "./markdown-body.tsx";
+import { ToolFileBlock } from "./tool-file-block.tsx";
 import { Button } from "./ui/button.tsx";
 import { ShimmerText } from "./ui/shimmer-text.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip.tsx";
@@ -678,14 +678,6 @@ interface ToolView {
 	readonly fallbackBody?: React.ReactNode;
 }
 
-// Line-count derived from a tool result's textual output. Used by Read /
-// Grep / Glob to summarise "how much did this return?" in the collapsed row.
-const lineCountOf = (output: unknown): number => {
-	const text = toResultText(output);
-	if (text.length === 0) return 0;
-	return text.split("\n").length;
-};
-
 const buildToolView = (
 	tool: string,
 	input: unknown,
@@ -779,47 +771,27 @@ const buildToolView = (
 			};
 		}
 
-		case "Read": {
+		case "Read":
+		case "ReadFile": {
 			const path = asString(obj.file_path);
-			const offset = typeof obj.offset === "number" ? obj.offset : null;
-			const limit = typeof obj.limit === "number" ? obj.limit : null;
-			const range =
-				offset !== null || limit !== null
-					? `lines ${offset ?? 1}–${(offset ?? 1) + (limit ?? 0) - 1}`
-					: null;
 			const pending = result === undefined;
-			const lines = result !== undefined ? lineCountOf(result.output) : null;
-			const linesSuffix =
-				lines !== null
-					? lines === 0
-						? "empty"
-						: `${lines} line${lines === 1 ? "" : "s"}`
-					: null;
 			return {
 				icon: File01Icon,
 				label: pending ? "Reading" : "Read",
-				detail:
-					path !== null ? (
-						<MutedFilePath path={path} suffix={linesSuffix} />
-					) : undefined,
-				inputPanel:
-					path !== null ? (
-						<p className="font-mono text-[11px] text-muted-foreground break-all">
-							{path}
-							{range !== null ? ` · ${range}` : null}
-						</p>
-					) : undefined,
-				resultPanel: (result) => {
-					const text = toResultText(result.output);
-					if (path === null) {
-						return (
-							<PreBlock text={truncate(text, 4000)} isError={result.isError} />
-						);
-					}
-					return (
-						<CodeBlock filename={path} text={text} isError={result.isError} />
-					);
-				},
+				detail: path !== null ? <MutedFilePath path={path} /> : undefined,
+				fallbackBody:
+					result === undefined ? undefined : path === null ? (
+						<PreBlock
+							text={truncate(toResultText(result.output), 4000)}
+							isError={result.isError}
+						/>
+					) : (
+						<ToolFileBlock
+							path={path}
+							text={toResultText(result.output)}
+							isError={result.isError}
+						/>
+					),
 			};
 		}
 

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -848,7 +848,6 @@ const buildToolView = (
 									path={patch.file_path}
 									patch={patch.patch}
 									kind={patch.kind}
-									showHeader={patches.length > 1}
 								/>
 							))}
 						</div>
@@ -858,7 +857,6 @@ const buildToolView = (
 								<EditDiff
 									key={i}
 									edit={edit as FileEdit}
-									showHeader={edits.length > 1}
 								/>
 							))}
 						</div>

--- a/apps/renderer/src/lib/diffs-theme.ts
+++ b/apps/renderer/src/lib/diffs-theme.ts
@@ -9,26 +9,7 @@ import { useResolvedAppearance } from "./appearance.tsx";
  */
 export const ZUSE_DIFF_THEMES = DEFAULT_THEMES;
 
-/**
- * Pierre renders its theme inside Shadow DOM and declares the base colors on
- * `:host`. Inherited custom properties therefore cannot replace those values.
- * `unsafeCSS` is the library's documented highest-priority styling escape hatch;
- * keep this override intentionally small and restricted to the host tokens.
- */
-const ZUSE_DIFF_UNSAFE_CSS = `
-:host {
-  --diffs-light-bg: var(--background);
-  --diffs-dark-bg: var(--background);
-  --diffs-light: var(--foreground);
-  --diffs-dark: var(--foreground);
-  background-color: var(--background);
-}
-`;
-
-type ZuseDiffThemeOptions = Pick<
-	BaseCodeOptions,
-	"theme" | "themeType" | "unsafeCSS"
->;
+type ZuseDiffThemeOptions = Pick<BaseCodeOptions, "theme" | "themeType">;
 
 export function useZuseDiffTheme(): ZuseDiffThemeOptions {
 	const themeType = useResolvedAppearance();
@@ -36,7 +17,6 @@ export function useZuseDiffTheme(): ZuseDiffThemeOptions {
 		() => ({
 			theme: ZUSE_DIFF_THEMES,
 			themeType,
-			unsafeCSS: ZUSE_DIFF_UNSAFE_CSS,
 		}),
 		[themeType],
 	);

--- a/apps/renderer/src/lib/diffs-theme.ts
+++ b/apps/renderer/src/lib/diffs-theme.ts
@@ -22,6 +22,10 @@ const ZUSE_DIFF_UNSAFE_CSS = `
   --diffs-bg-context-override: transparent;
   background-color: transparent;
 }
+
+[data-diffs-header] {
+  background-color: var(--fz-diff-header-bg);
+}
 `;
 
 type ZuseDiffThemeOptions = Pick<

--- a/apps/renderer/src/lib/diffs-theme.ts
+++ b/apps/renderer/src/lib/diffs-theme.ts
@@ -1,0 +1,43 @@
+import { type BaseCodeOptions, DEFAULT_THEMES } from "@pierre/diffs";
+import { useMemo } from "react";
+import { useResolvedAppearance } from "./appearance.tsx";
+
+/**
+ * The worker pool owns syntax-theme registration, so keep one stable light/dark
+ * pair for every review renderer. Individual components only select the active
+ * half through `themeType`.
+ */
+export const ZUSE_DIFF_THEMES = DEFAULT_THEMES;
+
+/**
+ * Pierre renders its theme inside Shadow DOM and declares the base colors on
+ * `:host`. Inherited custom properties therefore cannot replace those values.
+ * `unsafeCSS` is the library's documented highest-priority styling escape hatch;
+ * keep this override intentionally small and restricted to the host tokens.
+ */
+const ZUSE_DIFF_UNSAFE_CSS = `
+:host {
+  --diffs-light-bg: var(--background);
+  --diffs-dark-bg: var(--background);
+  --diffs-light: var(--foreground);
+  --diffs-dark: var(--foreground);
+  background-color: var(--background);
+}
+`;
+
+type ZuseDiffThemeOptions = Pick<
+	BaseCodeOptions,
+	"theme" | "themeType" | "unsafeCSS"
+>;
+
+export function useZuseDiffTheme(): ZuseDiffThemeOptions {
+	const themeType = useResolvedAppearance();
+	return useMemo(
+		() => ({
+			theme: ZUSE_DIFF_THEMES,
+			themeType,
+			unsafeCSS: ZUSE_DIFF_UNSAFE_CSS,
+		}),
+		[themeType],
+	);
+}

--- a/apps/renderer/src/lib/diffs-theme.ts
+++ b/apps/renderer/src/lib/diffs-theme.ts
@@ -9,7 +9,25 @@ import { useResolvedAppearance } from "./appearance.tsx";
  */
 export const ZUSE_DIFF_THEMES = DEFAULT_THEMES;
 
-type ZuseDiffThemeOptions = Pick<BaseCodeOptions, "theme" | "themeType">;
+/**
+ * The renderer paints its host, code, gutters, and separators from the
+ * computed `--diffs-bg` token. Making that final token transparent lets the
+ * surrounding Zuse pane own the surface while preserving syntax and change
+ * highlighting from the selected Shiki theme.
+ */
+const ZUSE_DIFF_UNSAFE_CSS = `
+:host {
+  --diffs-bg: transparent;
+  --diffs-bg-buffer-override: transparent;
+  --diffs-bg-context-override: transparent;
+  background-color: transparent;
+}
+`;
+
+type ZuseDiffThemeOptions = Pick<
+	BaseCodeOptions,
+	"theme" | "themeType" | "unsafeCSS"
+>;
 
 export function useZuseDiffTheme(): ZuseDiffThemeOptions {
 	const themeType = useResolvedAppearance();
@@ -17,6 +35,7 @@ export function useZuseDiffTheme(): ZuseDiffThemeOptions {
 		() => ({
 			theme: ZUSE_DIFF_THEMES,
 			themeType,
+			unsafeCSS: ZUSE_DIFF_UNSAFE_CSS,
 		}),
 		[themeType],
 	);

--- a/apps/renderer/src/lib/diffs-theme.ts
+++ b/apps/renderer/src/lib/diffs-theme.ts
@@ -26,6 +26,14 @@ const ZUSE_DIFF_UNSAFE_CSS = `
 [data-diffs-header] {
   background-color: var(--fz-diff-header-bg);
 }
+
+/* The package colors the gutter utility glyph with --diffs-bg. Our base is
+   intentionally transparent, so give the annotation action an explicit app
+   surface and foreground instead of allowing the plus icon to disappear. */
+[data-utility-button] {
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+}
 `;
 
 type ZuseDiffThemeOptions = Pick<

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -495,9 +495,9 @@ body,
 /* `@pierre/diffs` ships with stock GitHub-style fire-engine red / spring
    green and pure white/black surfaces. That reads as a separate widget
    bolted onto the app. Override its public detail tokens here so the diff
-   uses the app's neutrals and softer change colors. The base host colors are
-   injected by `lib/diffs-theme.ts` because the library redeclares those
-   inside its shadow root. */
+   uses the app's neutrals and softer change colors. Review renderers use the
+   package's `disableBackground` option so their base surface stays transparent
+   and these inherited detail tokens blend into the surrounding pane. */
 @layer components {
   .chat-session-layout {
     --chat-reading-column: 56rem;

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -506,6 +506,8 @@ body,
   }
 
   .fz-diff {
+    --fz-diff-header-bg: var(--background);
+
     /* Surfaces — drop the diff onto the same neutral the pane uses so it
        reads as part of the app, not a bolted-on widget. Pierre computes
        its buffer / context / gutter tints from `--diffs-bg` mixed with a

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -495,9 +495,9 @@ body,
 /* `@pierre/diffs` ships with stock GitHub-style fire-engine red / spring
    green and pure white/black surfaces. That reads as a separate widget
    bolted onto the app. Override its public detail tokens here so the diff
-   uses the app's neutrals and softer change colors. Review renderers use the
-   package's `disableBackground` option so their base surface stays transparent
-   and these inherited detail tokens blend into the surrounding pane. */
+   uses the app's neutrals and softer change colors. Review renderers make the
+   package's final computed base token transparent in `lib/diffs-theme.ts`, so
+   these inherited detail tokens blend into the surrounding pane. */
 @layer components {
   .chat-session-layout {
     --chat-reading-column: 56rem;

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -494,10 +494,10 @@ body,
 
 /* `@pierre/diffs` ships with stock GitHub-style fire-engine red / spring
    green and pure white/black surfaces. That reads as a separate widget
-   bolted onto the app. Override the public CSS variables so the diff
-   inherits the app's stone-warm + slate-cool neutrals and uses softer,
-   teal-leaning add / rose-leaning delete colors. The custom properties
-   cascade into the shadow DOM Pierre renders into. */
+   bolted onto the app. Override its public detail tokens here so the diff
+   uses the app's neutrals and softer change colors. The base host colors are
+   injected by `lib/diffs-theme.ts` because the library redeclares those
+   inside its shadow root. */
 @layer components {
   .chat-session-layout {
     --chat-reading-column: 56rem;

--- a/bun.lock
+++ b/bun.lock
@@ -189,7 +189,7 @@
         "@hugeicons-pro/core-stroke-rounded": "4.2.2",
         "@hugeicons/react": "^1.1.7",
         "@legendapp/list": "3.3.3",
-        "@pierre/diffs": "1.3.2",
+        "@pierre/diffs": "1.3.3",
         "@pierre/trees": "1.0.0-beta.5",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
@@ -1446,7 +1446,7 @@
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.3.2", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.0", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-+aSaxN/fGwmegUF/UVkXOOA8Run+sYOqhqTc1JvlieoYXsW/9KykOIR88FvgXjesI0MGZJLsX8dthn3+x2kymA=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.3", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.0", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-LPoRv3vkfhrZbdRe/aPhJFjD1XK2JD9ALAdvral6ThG3qAcMDSytGbAXk3WQlt5+AZDOQXflHQwBWhw+89Ttzg=="],
 
     "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 


### PR DESCRIPTION
## Summary

- simplify the Changes navigator into a compact flat file list with clearer conflict grouping and resolution actions
- clean up Review loading, empty, and file presentation states
- share app-aware diff theming across Review, conflict resolution, file editing, and file diff surfaces
- keep code surfaces blended with the surrounding pane while preserving opaque file headers during scrolling
- update `@pierre/diffs` to 1.3.3

## Root cause

The diff renderer paints multiple surfaces inside Shadow DOM from its computed `--diffs-bg` token. App-level CSS alone could not reliably blend those surfaces, and making the final token transparent also affected sticky file headers. The shared adapter now makes code surfaces transparent while explicitly painting headers with the app background.

## Validation

- `bunx biome check` on changed TypeScript and package files
- `bun --filter renderer check-types`
- `bun --filter renderer test` — 75 files, 352 tests passed
- `bun --filter renderer build`
- `git diff --check`
- isolated Electron runtime inspection confirmed the diff host resolves to a transparent background