### PR TITLE
Refine compact workspace interface

### DIFF
--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -1,7 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import { router, Stack } from "expo-router";
 import {
-	BarChart3,
 	Bell,
 	HardDrive,
 	LogOut,
@@ -13,14 +12,7 @@ import {
 	UserRound,
 } from "lucide-react-native";
 import { useEffect, useMemo, useState } from "react";
-import {
-	ActivityIndicator,
-	Alert,
-	ScrollView,
-	Switch,
-	Text,
-	View,
-} from "react-native";
+import { ActivityIndicator, Alert, ScrollView, Text, View } from "react-native";
 
 import { ListRow, ListSection } from "~/components/ui/list";
 import { captureMobileAnalytics } from "~/lib/analytics";
@@ -30,7 +22,6 @@ import { successTap } from "~/lib/haptics";
 import { clearDownloadedMobileData } from "~/lib/mobile-data";
 import { registerCurrentDeviceForPush } from "~/notifications/push";
 import { downloadedCacheSize } from "~/offline/cache";
-import { analyticsEnabledAtom, setAnalyticsEnabled } from "~/store/analytics";
 import {
 	authAccountAtom,
 	authBusyAtom,
@@ -67,7 +58,6 @@ const formatBytes = (bytes: number | null): string => {
 };
 
 export default function SettingsScreen() {
-	const analyticsEnabled = useAtomValue(analyticsEnabledAtom);
 	const account = useAtomValue(authAccountAtom);
 	const hydrated = useAtomValue(authHydratedAtom);
 	const busy = useAtomValue(authBusyAtom);
@@ -314,24 +304,6 @@ export default function SettingsScreen() {
 						/>
 					</ListSection>
 				)}
-
-				<ListSection
-					header="Privacy"
-					footer="Shares pseudonymous feature use, model choices, active time, reliability, and standard geographic enrichment. Prompts, responses, code, paths, and account details are never included."
-				>
-					<ListRow
-						analyticsId="settings.share-usage-analytics"
-						icon={BarChart3}
-						iconTone="neutral"
-						title="Share usage analytics"
-						subtitle={analyticsEnabled ? "On" : "Off"}
-						chevron={false}
-						accessibilityRole="switch"
-						accessibilityState={{ checked: analyticsEnabled }}
-						trailing={<Switch pointerEvents="none" value={analyticsEnabled} />}
-						onPress={() => void setAnalyticsEnabled(!analyticsEnabled)}
-					/>
-				</ListSection>
 
 				<ListSection
 					header="Storage"

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -12,10 +12,9 @@ import Constants from "expo-constants";
 import * as Crypto from "expo-crypto";
 import { getCalendars } from "expo-localization";
 import * as SecureStore from "expo-secure-store";
-import PostHog, { PostHogPersistedProperty } from "posthog-react-native";
+import PostHog from "posthog-react-native";
 import { AppState, Platform } from "react-native";
 
-const ENABLED_KEY = "zuse.mobile.analytics.enabled.v1";
 const ANONYMOUS_ID_KEY = "zuse.mobile.analytics.anonymous-id.v1";
 const IDENTITY_KIND_KEY = "zuse.mobile.analytics.identity-kind.v1";
 const PROJECT_KEY = (process.env.EXPO_PUBLIC_POSTHOG_KEY ?? "").trim();
@@ -151,9 +150,8 @@ const installActivityTracking = () => {
 
 export const hydrateMobileAnalytics = async (
 	accountId: string | null,
-): Promise<boolean> => {
-	const storedEnabled = await SecureStore.getItemAsync(ENABLED_KEY);
-	enabled = storedEnabled === null ? true : storedEnabled === "true";
+): Promise<void> => {
+	enabled = true;
 	const previousKind = await SecureStore.getItemAsync(IDENTITY_KIND_KEY);
 	if (accountId) {
 		distinctId = analyticsAccountId(accountId);
@@ -169,23 +167,6 @@ export const hydrateMobileAnalytics = async (
 	}
 	activityCleanup?.();
 	activityCleanup = installActivityTracking();
-	return enabled;
-};
-
-export const setMobileAnalyticsEnabled = async (
-	next: boolean,
-): Promise<void> => {
-	enabled = next;
-	await SecureStore.setItemAsync(ENABLED_KEY, String(next));
-	if (next) {
-		const instance = makeClient();
-		await instance?.optIn();
-	} else if (client) {
-		await client.optOut();
-		client.setPersistedProperty(PostHogPersistedProperty.Queue, null);
-		await client.shutdown(1_000);
-		client = null;
-	}
 };
 
 export const setMobileAnalyticsAccount = async (

--- a/apps/mobile/src/store/analytics.ts
+++ b/apps/mobile/src/store/analytics.ts
@@ -1,27 +1,17 @@
 import { Atom } from "effect/unstable/reactivity";
 
-import {
-	hydrateMobileAnalytics,
-	setMobileAnalyticsEnabled,
-} from "~/lib/analytics";
+import { hydrateMobileAnalytics } from "~/lib/analytics";
 
 import { authAccountAtom } from "./auth";
 import { appAtomRegistry, batchAtomUpdates } from "./registry";
 
-export const analyticsEnabledAtom = Atom.make(true).pipe(Atom.keepAlive);
 export const analyticsHydratedAtom = Atom.make(false).pipe(Atom.keepAlive);
 
 export const hydrateAnalytics = async (): Promise<void> => {
 	if (appAtomRegistry.get(analyticsHydratedAtom)) return;
 	const accountId = appAtomRegistry.get(authAccountAtom)?.id ?? null;
-	const enabled = await hydrateMobileAnalytics(accountId);
+	await hydrateMobileAnalytics(accountId);
 	batchAtomUpdates(() => {
-		appAtomRegistry.set(analyticsEnabledAtom, enabled);
 		appAtomRegistry.set(analyticsHydratedAtom, true);
 	});
-};
-
-export const setAnalyticsEnabled = async (enabled: boolean): Promise<void> => {
-	appAtomRegistry.set(analyticsEnabledAtom, enabled);
-	await setMobileAnalyticsEnabled(enabled);
 };

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -1,5 +1,13 @@
 import { Effect } from "effect";
-import { lazy, Suspense, useEffect, useLayoutEffect, useState } from "react";
+import {
+	lazy,
+	type RefObject,
+	Suspense,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 import {
 	Group,
 	Panel,
@@ -164,19 +172,35 @@ const UsageDashboard = lazy(() =>
 );
 
 /**
- * Sidebars snap to their requested state. These controls are used frequently;
- * avoiding a resize loop keeps navigation responsive under stream pressure.
+ * Animate only programmatic open/close changes. Drag resizing remains direct,
+ * and the browser handles the short flex transition outside React's render loop.
  */
 function usePanelCollapse(
 	panelRef: ReturnType<typeof usePanelRef>,
+	elementRef: RefObject<HTMLDivElement | null>,
 	open: boolean,
 ) {
 	useEffect(() => {
 		const panel = panelRef.current;
 		if (panel === null) return;
-		if (open && panel.isCollapsed()) panel.expand();
-		if (!open && !panel.isCollapsed()) panel.collapse();
-	}, [panelRef, open]);
+		const element = elementRef.current;
+		const shouldChange = open ? panel.isCollapsed() : !panel.isCollapsed();
+		if (!shouldChange) return;
+
+		element?.classList.add("fz-sidebar-panel-motion");
+		const frame = window.requestAnimationFrame(() => {
+			if (open) panel.expand();
+			else panel.collapse();
+		});
+		const timeout = window.setTimeout(() => {
+			element?.classList.remove("fz-sidebar-panel-motion");
+		}, 200);
+		return () => {
+			window.cancelAnimationFrame(frame);
+			window.clearTimeout(timeout);
+			element?.classList.remove("fz-sidebar-panel-motion");
+		};
+	}, [elementRef, panelRef, open]);
 }
 
 function SurfaceFallback() {
@@ -481,6 +505,7 @@ function MainShell() {
 	// open/close via the library's imperative resize() (see the hook). v4 has no
 	// `onCollapse` prop — we peek the imperative handle through `panelRef`.
 	const leftPanelRef = usePanelRef();
+	const leftPanelElementRef = useRef<HTMLDivElement>(null);
 	const rightPanelRef = usePanelRef();
 
 	// The composer floats over the timeline (glass) — measure it so the list
@@ -499,7 +524,7 @@ function MainShell() {
 		setComposerInset(composerNode.offsetHeight);
 		return () => ro.disconnect();
 	}, [composerNode]);
-	usePanelCollapse(leftPanelRef, leftSidebarOpen);
+	usePanelCollapse(leftPanelRef, leftPanelElementRef, leftSidebarOpen);
 	useLayoutEffect(() => {
 		const panel = rightPanelRef.current;
 		if (panel === null) return;
@@ -522,15 +547,16 @@ function MainShell() {
 			>
 				<Panel
 					id="projects"
-					defaultSize="20%"
+					defaultSize="232px"
 					// Keep project and chat labels usable when the pane is open. A
 					// collapsed pane may still rest at 0; stale near-zero expanded
 					// widths from persisted layouts are clamped to this minimum.
-					minSize="280px"
-					maxSize="40%"
+					minSize="200px"
+					maxSize="300px"
 					collapsible
 					collapsedSize="0%"
 					panelRef={leftPanelRef}
+					elementRef={leftPanelElementRef}
 					onResize={(size) => {
 						const open = size.asPercentage > 0;
 						if (open !== leftSidebarOpen) setLeftSidebarOpen(open);
@@ -579,7 +605,7 @@ function MainShell() {
 								// All that progress is surfaced inline by `WorktreeSetupCard`
 								// at the top of the timeline, with the composer pinned at the
 								// bottom (no full-screen takeover).
-								<div className="chat-session-layout flex min-h-0 min-w-0 flex-1">
+								<div className="chat-session-layout relative flex min-h-0 min-w-0 flex-1">
 									<div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
 										<Suspense fallback={<SurfaceFallback />}>
 											<ChatView
@@ -597,7 +623,7 @@ function MainShell() {
 											/>
 											<div
 												ref={setComposerNode}
-												className="pointer-events-auto mx-auto w-full max-w-[var(--chat-reading-column)]"
+												className="pointer-events-auto mx-auto w-full max-w-[var(--chat-reading-column)] pt-1"
 											>
 												<Suspense fallback={null}>
 													<CliUpgradeBanner
@@ -627,25 +653,17 @@ function MainShell() {
 									</div>
 									{environmentSummaryAvailable ? (
 										<div
-											className={`shrink-0 overflow-hidden transition-[width,opacity] duration-150 ease-[cubic-bezier(0.165,0.84,0.44,1)] motion-reduce:transition-none ${
+											className={`pointer-events-none absolute right-2 top-2 z-20 max-h-[calc(100%-1rem)] transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.165,0.84,0.44,1)] motion-reduce:transition-none ${
 												showEnvironmentSummary
-													? "w-[18.75rem] opacity-100"
-													: "w-0 opacity-0"
+													? "translate-x-0 opacity-100"
+													: "translate-x-2 opacity-0"
 											}`}
 											aria-hidden={!showEnvironmentSummary}
 											inert={!showEnvironmentSummary}
 										>
-											<div
-												className={`w-[18.75rem] transition-transform duration-150 ease-[cubic-bezier(0.165,0.84,0.44,1)] motion-reduce:transition-none ${
-													showEnvironmentSummary
-														? "translate-x-0"
-														: "translate-x-3"
-												}`}
-											>
-												<Suspense fallback={null}>
-													<EnvironmentSummary />
-												</Suspense>
-											</div>
+											<Suspense fallback={null}>
+												<EnvironmentSummary />
+											</Suspense>
 										</div>
 									) : null}
 								</div>

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -4,7 +4,6 @@ import {
 	type RefObject,
 	Suspense,
 	useEffect,
-	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";
@@ -175,22 +174,33 @@ const UsageDashboard = lazy(() =>
  * Animate only programmatic open/close changes. Drag resizing remains direct,
  * and the browser handles the short flex transition outside React's render loop.
  */
-function usePanelCollapse(
+function useAnimatedPanelVisibility(
 	panelRef: ReturnType<typeof usePanelRef>,
 	elementRef: RefObject<HTMLDivElement | null>,
 	open: boolean,
+	expandedSize?: string,
 ) {
+	const expandedSizeRef = useRef(expandedSize);
+	expandedSizeRef.current = expandedSize;
 	useEffect(() => {
 		const panel = panelRef.current;
 		if (panel === null) return;
 		const element = elementRef.current;
 		const shouldChange = open ? panel.isCollapsed() : !panel.isCollapsed();
-		if (!shouldChange) return;
+		if (!shouldChange) {
+			return;
+		}
 
 		element?.classList.add("fz-sidebar-panel-motion");
 		const frame = window.requestAnimationFrame(() => {
-			if (open) panel.expand();
-			else panel.collapse();
+			if (open) {
+				panel.expand();
+				if (expandedSizeRef.current !== undefined) {
+					panel.resize(expandedSizeRef.current);
+				}
+			} else {
+				panel.collapse();
+			}
 		});
 		const timeout = window.setTimeout(() => {
 			element?.classList.remove("fz-sidebar-panel-motion");
@@ -429,7 +439,7 @@ function MainShell() {
 		selectedSessionId !== null &&
 		activeMainTab === "chat";
 	const showEnvironmentSummary =
-		environmentSummaryAvailable && environmentSummaryOpen && !rightSidebarOpen;
+		environmentSummaryAvailable && environmentSummaryOpen;
 
 	// Switching projects closes the file tab — its path wouldn't resolve
 	// under the new project's root anyway.
@@ -507,6 +517,7 @@ function MainShell() {
 	const leftPanelRef = usePanelRef();
 	const leftPanelElementRef = useRef<HTMLDivElement>(null);
 	const rightPanelRef = usePanelRef();
+	const rightPanelElementRef = useRef<HTMLDivElement>(null);
 
 	// The composer floats over the timeline (glass) — measure it so the list
 	// can pad its scroll range and the last message clears the overlay.
@@ -524,17 +535,17 @@ function MainShell() {
 		setComposerInset(composerNode.offsetHeight);
 		return () => ro.disconnect();
 	}, [composerNode]);
-	usePanelCollapse(leftPanelRef, leftPanelElementRef, leftSidebarOpen);
-	useLayoutEffect(() => {
-		const panel = rightPanelRef.current;
-		if (panel === null) return;
-		if (!rightSidebarOpen) {
-			if (!panel.isCollapsed()) panel.collapse();
-			return;
-		}
-		if (panel.isCollapsed()) panel.expand();
-		panel.resize(`${rightSidebarWidth}%`);
-	}, [rightPanelRef, rightSidebarOpen, rightSidebarWidth]);
+	useAnimatedPanelVisibility(
+		leftPanelRef,
+		leftPanelElementRef,
+		leftSidebarOpen,
+	);
+	useAnimatedPanelVisibility(
+		rightPanelRef,
+		rightPanelElementRef,
+		rightSidebarOpen,
+		`${rightSidebarWidth}%`,
+	);
 
 	return (
 		<div className="flex h-dvh max-h-dvh min-h-0 w-screen overflow-hidden text-foreground">
@@ -750,6 +761,7 @@ function MainShell() {
 					collapsible
 					collapsedSize="0%"
 					panelRef={rightPanelRef}
+					elementRef={rightPanelElementRef}
 					onResize={(size, _id, prev) => {
 						// Ignore the initial mount call (prev === undefined). The right
 						// dock defaults to closed (`rightSidebarOpen: false`); the

--- a/apps/renderer/src/components/api-key-row.tsx
+++ b/apps/renderer/src/components/api-key-row.tsx
@@ -245,13 +245,13 @@ export function ApiKeyRow({
 						aria-describedby={
 							persistedFeedback !== null ? feedbackId : undefined
 						}
-						className="h-9 rounded-md pe-10"
+						className="pe-8"
 					/>
 					<button
 						type="button"
 						onClick={() => setReveal((current) => !current)}
 						disabled={busy}
-						className="absolute end-0 top-1/2 flex size-9 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-3px]"
+						className="absolute end-0 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-3px]"
 						aria-label={reveal ? "Hide API key" : "Reveal API key"}
 					>
 						<HugeiconsIcon
@@ -263,7 +263,7 @@ export function ApiKeyRow({
 				</div>
 				<Button
 					type="submit"
-					size="sm"
+					size="default"
 					disabled={busy || value.trim().length === 0}
 				>
 					{busy ? "Verifying…" : required ? "Verify and save" : "Save"}
@@ -271,7 +271,7 @@ export function ApiKeyRow({
 				{required && hasKey && (
 					<Button
 						type="button"
-						size="sm"
+						size="default"
 						variant="ghost"
 						disabled={busy}
 						onClick={() => {

--- a/apps/renderer/src/components/assistant-message-actions.tsx
+++ b/apps/renderer/src/components/assistant-message-actions.tsx
@@ -54,10 +54,7 @@ export function AssistantMessageActions({
 			messageId={messageId}
 			forkDestination={forkDestination}
 			sourceProjectId={sourceProjectId}
-			className={cn(
-				"opacity-0 transition-opacity duration-150 ease-out group-hover/assistant:opacity-100 group-focus-within/assistant:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100",
-				className,
-			)}
+			className={className}
 		/>
 	);
 }

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1363,7 +1363,7 @@ export function ChatComposer({
 												type="button"
 												onClick={() => fileInputRef.current?.click()}
 												aria-label="Attach files"
-												className="flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+											className="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
 											>
 												<HugeiconsIcon
 													icon={AttachmentIcon}
@@ -1571,7 +1571,7 @@ function FastModeToggle({ sessionId }: { sessionId: SessionId }) {
 						}
 						aria-pressed={enabled}
 						className={cn(
-							"flex h-6 items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
+							"flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors",
 							enabled
 								? "bg-amber-400/20 text-amber-700 hover:bg-amber-400/30 dark:bg-amber-300/15 dark:text-amber-200 dark:hover:bg-amber-300/25"
 								: "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
@@ -1623,7 +1623,7 @@ function PlanModeToggle({
 						aria-label={isPlan ? "Exit plan mode" : "Enter plan mode"}
 						aria-pressed={isPlan}
 						className={cn(
-							"flex h-6 items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
+							"flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors",
 							isPlan
 								? "bg-rose-400/20 text-rose-700 hover:bg-rose-400/30 dark:bg-rose-300/15 dark:text-rose-200 dark:hover:bg-rose-300/25"
 								: "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
@@ -1661,7 +1661,7 @@ function GoalModeToggle({
 						aria-label={active ? "Send next message as goal" : "Set goal"}
 						aria-pressed={active}
 						className={cn(
-							"flex h-6 items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
+							"flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors",
 							active
 								? "bg-amber-400/20 text-amber-700 hover:bg-amber-400/30 dark:bg-amber-300/15 dark:text-amber-200 dark:hover:bg-amber-300/25"
 								: hasGoal
@@ -2006,7 +2006,7 @@ function ReasoningPicker({
 		<Menu>
 			<MenuTrigger
 				className={cn(
-					"flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] transition-colors data-[popup-open]:bg-muted/60",
+					"flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors data-[popup-open]:bg-muted/60",
 					isUltracode
 						? "bg-gradient-to-r from-rose-400/90 via-amber-300/90 via-emerald-400/90 via-sky-400/90 to-violet-400/90 text-white shadow-sm/10 hover:opacity-95"
 						: "text-foreground hover:bg-muted/60",

--- a/apps/renderer/src/components/chat-turn-navigator.tsx
+++ b/apps/renderer/src/components/chat-turn-navigator.tsx
@@ -214,7 +214,7 @@ export function ChatTurnNavigator({
 			data-chat-turn-navigator
 			aria-hidden={hasSpace ? undefined : true}
 			className={cn(
-				"pointer-events-none absolute right-0 top-0 z-20",
+				"pointer-events-none absolute right-2 top-2 z-20",
 				!hasSpace && "invisible",
 			)}
 		>
@@ -249,24 +249,24 @@ export function ChatTurnNavigator({
 						openFromReaderIntent(true);
 					}}
 					className={cn(
-						"group/nav pointer-events-auto relative flex items-center justify-end bg-transparent",
-						coarsePointer ? "size-11" : "h-12 w-11",
+						"group/nav pointer-events-auto relative flex items-start justify-end bg-transparent",
+						coarsePointer ? "h-28 w-11" : "h-28 w-10",
 						"text-muted-foreground/50 outline-none transition-colors duration-150",
 						"hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
 					)}
 				>
 					<div
-						className="relative flex h-5 w-7 origin-right flex-col items-end justify-start gap-1 transition-transform duration-150 ease-out group-hover/nav:scale-x-[1.08] group-focus-visible/nav:scale-x-[1.08] motion-reduce:transition-none"
+						className="relative flex w-7 flex-col items-end justify-start gap-1"
 						aria-hidden
 					>
 						{railTurns.map((turn) => (
 							<span
 								key={turn.messageId}
 								className={cn(
-									"min-h-[1.25px] max-h-[3.5px] w-7 flex-1 origin-right rounded-full bg-current transition-[transform,opacity] duration-150 ease-out motion-reduce:transition-none",
+									"h-0.5 w-5 shrink-0 rounded-full transition-colors duration-150 motion-reduce:transition-none",
 									turn.messageId === activeMessageId
-										? "scale-x-100 scale-y-[1.2] opacity-100"
-										: "scale-x-[0.72] scale-y-100 opacity-60",
+										? "bg-primary"
+										: "bg-muted-foreground/35",
 								)}
 							/>
 						))}

--- a/apps/renderer/src/components/environment-summary.tsx
+++ b/apps/renderer/src/components/environment-summary.tsx
@@ -3,26 +3,29 @@ import {
 	Alert01Icon,
 	CheckListIcon,
 	Clock01Icon,
-	ComputerTerminal01Icon,
-	GitBranchIcon,
 	GitCompareIcon,
 	GitMergeIcon,
 	GitPullRequestIcon,
 	Loading02Icon,
 	Tick02Icon,
 } from "@hugeicons-pro/core-solid-rounded";
-import type { GitPrCheckRun, Message } from "@zuse/contracts";
+import type { GitBranchInfo, GitPrCheckRun, Message } from "@zuse/contracts";
 import { latestProposedPlanMarkdown } from "@zuse/utils/proposed-plan";
-import { useMemo, useState } from "react";
+import { Effect } from "effect";
+import { ArrowLeftRight, Cloud, Laptop, MonitorSmartphone } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
 import { deriveEnvironmentPrRows } from "../lib/branch-workflow.ts";
 import { displayPath } from "../lib/display-path.ts";
+import { formatError } from "../lib/format-error.ts";
 import { detachedSubagentGroups } from "../lib/group-messages.ts";
+import { getRpcClient } from "../lib/rpc-client.ts";
 import {
 	effectiveSessionRuntimeState,
 	isSessionTurnActive,
 } from "../lib/session-runtime-state.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
+import { gitDiffStatKey, useGitDiffStatStore } from "../store/git-diff-stat.ts";
 import { gitStatusKey, useGitStatusStore } from "../store/git-status.ts";
 import { useMessagesStore } from "../store/messages.ts";
 import { prDetailsKey, usePrDetailsStore } from "../store/pr-details.ts";
@@ -33,10 +36,17 @@ import { useUiStore } from "../store/ui.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { SubagentAvatar } from "./subagent-identity.tsx";
 import {
+	BranchMenuButton,
 	FixActionsButton,
 	ResolveConflictsButton,
-	WorkflowActions,
 } from "./top-bar.tsx";
+import {
+	Menu,
+	MenuItem,
+	MenuPopup,
+	MenuSeparator,
+	MenuTrigger,
+} from "./ui/menu.tsx";
 import {
 	PreviewCard,
 	PreviewCardPopup,
@@ -44,8 +54,11 @@ import {
 } from "./ui/preview-card.tsx";
 
 const rowClass =
-	"group flex min-h-9 w-full min-w-0 items-center gap-2 rounded-lg px-2.5 text-left text-[13px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60";
+	"group flex min-h-7 w-full min-w-0 items-center gap-2 rounded-md px-2.5 text-left text-xs text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60";
 const EMPTY_MESSAGES: ReadonlyArray<Message> = [];
+
+const compactNumber = (value: number): string =>
+	new Intl.NumberFormat("en", { notation: "compact" }).format(value);
 
 const latestAssistantText = (
 	messages: ReadonlyArray<Message>,
@@ -66,6 +79,16 @@ export function EnvironmentSummary() {
 	const status = useGitStatusStore((s) =>
 		folderId ? (s.byKey[gitStatusKey(folderId, worktreeId)] ?? null) : null,
 	);
+	const diffStat = useGitDiffStatStore((s) =>
+		folderId ? (s.byKey[gitDiffStatKey(folderId, worktreeId)] ?? null) : null,
+	);
+	const hydrateDiffStat = useGitDiffStatStore((s) => s.hydrate);
+	const [branches, setBranches] = useState<ReadonlyArray<GitBranchInfo>>([]);
+	const [branchesLoading, setBranchesLoading] = useState(false);
+	const [branchError, setBranchError] = useState<string | null>(null);
+	useEffect(() => {
+		if (folderId !== null) void hydrateDiffStat(folderId, worktreeId);
+	}, [folderId, hydrateDiffStat, worktreeId]);
 	const pr = usePrStateStore((s) =>
 		folderId ? (s.byKey[prStateKey(folderId, worktreeId)] ?? null) : null,
 	);
@@ -126,14 +149,68 @@ export function EnvironmentSummary() {
 			) ?? null
 		);
 	});
+	const branchLabel = status?.branch ?? worktree?.branch ?? "Loading branch…";
+	const refreshBranches = async (): Promise<void> => {
+		if (folderId === null) return;
+		setBranchesLoading(true);
+		setBranchError(null);
+		try {
+			const client = await getRpcClient();
+			setBranches(
+				await Effect.runPromise(
+					client["git.branches"]({ folderId, worktreeId }),
+				),
+			);
+		} catch (error) {
+			setBranchError(formatError(error));
+		} finally {
+			setBranchesLoading(false);
+		}
+	};
+	useEffect(() => {
+		void refreshBranches();
+		// The active branch is the refresh boundary for this menu.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [branchLabel, folderId, worktreeId]);
+	const switchToBranch = async (branch: GitBranchInfo): Promise<void> => {
+		if (folderId === null || branch.current) return;
+		if (
+			(status?.dirtyFiles ?? 0) > 0 &&
+			!window.confirm(
+				`Switch branches with ${status?.dirtyFiles ?? 0} uncommitted changes? Git may refuse if they conflict.`,
+			)
+		)
+			return;
+		setBranchesLoading(true);
+		setBranchError(null);
+		try {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["git.switchBranch"]({
+					folderId,
+					worktreeId,
+					branch: branch.name,
+					remote: branch.remote,
+				}),
+			);
+			void useGitStatusStore.getState().refresh(folderId, worktreeId);
+			void usePrStateStore.getState().refresh(folderId, worktreeId);
+			void hydrateDiffStat(folderId, worktreeId);
+			await refreshBranches();
+		} catch (error) {
+			setBranchError(formatError(error));
+		} finally {
+			setBranchesLoading(false);
+		}
+	};
+	const openDevices = () => {
+		const ui = useUiStore.getState();
+		ui.setSettingsSection({ kind: "devices" });
+		ui.setView("settings");
+	};
 
 	if (ctx.status !== "ready") return null;
 
-	const checkoutLabel =
-		ctx.rootKind === "worktree"
-			? `Worktree ${worktree?.name ?? "preparing…"}`
-			: "Main checkout";
-	const branchLabel = status?.branch ?? worktree?.branch ?? "Loading branch…";
 	const changesLabel =
 		status === null
 			? "Changes"
@@ -202,9 +279,9 @@ export function EnvironmentSummary() {
 	return (
 		<aside
 			aria-label="Environment summary"
-			className="ml-3 mt-3 w-72 shrink-0 self-start rounded-3xl border border-border/70 bg-card/80 p-1.5 shadow-sm"
+			className="pointer-events-auto max-h-[calc(100dvh-7rem)] w-72 shrink-0 overflow-y-auto rounded-2xl border border-border/70 bg-card/95 p-1 shadow-overlay-sm backdrop-blur-xl"
 		>
-			<h2 className="px-2.5 pb-1 pt-1.5 text-xs font-medium text-muted-foreground">
+			<h2 className="px-2 pb-1 pt-0.5 text-xs font-medium text-muted-foreground">
 				Environment
 			</h2>
 			<button
@@ -214,49 +291,86 @@ export function EnvironmentSummary() {
 			>
 				<HugeiconsIcon icon={GitCompareIcon} className="size-4 shrink-0" />
 				<span className="min-w-0 flex-1 truncate">{changesLabel}</span>
-			</button>
-			<div className={rowClass} title={displayPath(ctx.rootPath)}>
-				<HugeiconsIcon
-					icon={ComputerTerminal01Icon}
-					className="size-4 shrink-0 text-muted-foreground"
-				/>
-				<span className="min-w-0 flex-1 truncate">{checkoutLabel}</span>
-			</div>
-			<div className={rowClass}>
-				<HugeiconsIcon
-					icon={GitBranchIcon}
-					className="size-4 shrink-0 text-muted-foreground"
-				/>
-				<span className="min-w-0 flex-1 truncate" title={branchLabel}>
-					{branchLabel}
-				</span>
-				{status !== null && (status.ahead > 0 || status.behind > 0) ? (
-					<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
-						{status.ahead > 0 ? `↑${status.ahead}` : ""}
-						{status.behind > 0 ? ` ↓${status.behind}` : ""}
+				{diffStat !== null ? (
+					<span className="flex shrink-0 items-center gap-1 font-mono text-[11px] tabular-nums">
+						<span className="text-[var(--accent-green)]">
+							+{compactNumber(diffStat.additions)}
+						</span>
+						<span className="text-[var(--accent-red)]">
+							−{compactNumber(diffStat.deletions)}
+						</span>
 					</span>
 				) : null}
-			</div>
-			<div className={`${rowClass} justify-between`}>
-				<button
-					type="button"
-					className="flex min-h-9 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md text-left outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
-					onClick={openPullRequest}
+			</button>
+			<Menu>
+				<MenuTrigger
+					className={`${rowClass} hover:bg-muted/60 data-[popup-open]:bg-muted/60`}
+					title={displayPath(ctx.rootPath)}
 				>
-					<HugeiconsIcon
-						icon={prStatus.icon}
-						className={`size-4 shrink-0 ${prStatus.className}`}
-						aria-label={prStatus.label}
-					/>
-					<span className="min-w-0 flex-1 truncate">{prLabel}</span>
-				</button>
-				<WorkflowActions
-					compact
-					includeRun={false}
-					includeHealthActions={false}
-					presentation="inline"
+					<Laptop className="size-4 shrink-0 text-muted-foreground" />
+					<span className="min-w-0 flex-1 truncate">Local</span>
+					<span className="size-1.5 rounded-full bg-[var(--accent-green)]" />
+				</MenuTrigger>
+				<MenuPopup
+					side="left"
+					align="start"
+					sideOffset={8}
+					className="min-w-64 p-1"
+				>
+					<div className="px-2 py-1 text-[11px] font-medium text-muted-foreground">
+						Run in
+					</div>
+					<MenuItem className="gap-2 px-2 py-1.5 text-xs">
+						<Laptop className="size-3.5" />
+						<span className="flex-1">This Mac</span>
+						<span className="text-[10px] text-[var(--accent-green)]">
+							Active
+						</span>
+					</MenuItem>
+					<MenuItem disabled className="gap-2 px-2 py-1.5 text-xs">
+						<Cloud className="size-3.5" />
+						<span className="flex-1">Cloud environment</span>
+						<span className="text-[10px]">Not connected</span>
+					</MenuItem>
+					<MenuSeparator />
+					<MenuItem onClick={openDevices} className="gap-2 px-2 py-1.5 text-xs">
+						<MonitorSmartphone className="size-3.5" />
+						<span className="flex-1">Connected devices</span>
+					</MenuItem>
+					<MenuItem onClick={openDevices} className="gap-2 px-2 py-1.5 text-xs">
+						<ArrowLeftRight className="size-3.5" />
+						<span className="flex-1">Worktree handoff</span>
+					</MenuItem>
+				</MenuPopup>
+			</Menu>
+			<BranchMenuButton
+				branchLabel={branchLabel}
+				branches={branches}
+				canRename={false}
+				className={`${rowClass} max-w-none justify-start hover:bg-muted/60 data-[popup-open]:bg-muted/60`}
+				popupSide="left"
+				dirtyFiles={status?.dirtyFiles ?? 0}
+				error={branchError}
+				loading={branchesLoading}
+				onOpen={() => void refreshBranches()}
+				onRename={() => {}}
+				onSwitch={(branch) => void switchToBranch(branch)}
+			/>
+			<button
+				type="button"
+				className={`${rowClass} justify-between hover:bg-muted/60`}
+				onClick={openPullRequest}
+			>
+				<HugeiconsIcon
+					icon={prStatus.icon}
+					className={`size-4 shrink-0 ${prStatus.className}`}
+					aria-label={prStatus.label}
 				/>
-			</div>
+				<span className="min-w-0 flex-1 truncate">{prLabel}</span>
+				<span className="shrink-0 text-[10px] text-muted-foreground">
+					{pr?.state === "none" ? "Create PR" : "Open"}
+				</span>
+			</button>
 			{prRows.checks !== null ? (
 				<div className={`${rowClass} justify-between`}>
 					<PreviewCard onOpenChange={hydrateChecks}>
@@ -264,11 +378,14 @@ export function EnvironmentSummary() {
 							render={
 								<button
 									type="button"
-									className="flex min-h-9 min-w-0 flex-1 items-center gap-2 rounded-md text-left outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+									className="flex min-h-7 min-w-0 flex-1 items-center gap-2 rounded-md text-left outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
 									onClick={() => revealPanel("pr")}
 								>
 									<ChecksStatusIcon kind={prRows.checks.kind} />
 									<span className="min-w-0 flex-1 truncate">
+										GitHub Actions
+									</span>
+									<span className="shrink-0 text-[10px] text-muted-foreground">
 										{prRows.checks.label}
 									</span>
 								</button>
@@ -291,12 +408,14 @@ export function EnvironmentSummary() {
 						</PreviewCardPopup>
 					</PreviewCard>
 					{prRows.checks.canFix && folderId !== null ? (
-						<FixActionsButton
-							presentation="inline"
-							folderId={folderId}
-							worktreeId={worktreeId}
-							disabled={sessionId === null}
-						/>
+						<span className="pointer-events-none shrink-0 opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 motion-reduce:transition-none">
+							<FixActionsButton
+								presentation="inline"
+								folderId={folderId}
+								worktreeId={worktreeId}
+								disabled={sessionId === null}
+							/>
+						</span>
 					) : null}
 				</div>
 			) : null}
@@ -304,7 +423,7 @@ export function EnvironmentSummary() {
 				<div className={`${rowClass} justify-between`}>
 					<button
 						type="button"
-						className="flex min-h-9 min-w-0 flex-1 items-center gap-2 rounded-md text-left outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+						className="flex min-h-7 min-w-0 flex-1 items-center gap-2 rounded-md text-left outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
 						onClick={() => revealPanel("pr")}
 					>
 						<HugeiconsIcon
@@ -313,21 +432,26 @@ export function EnvironmentSummary() {
 						/>
 						<span className="min-w-0 flex-1 truncate">Merge conflicts</span>
 					</button>
-					<ResolveConflictsButton presentation="inline" />
+					<span className="pointer-events-none shrink-0 opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 motion-reduce:transition-none">
+						<ResolveConflictsButton presentation="inline" />
+					</span>
 				</div>
 			) : null}
 			{planAvailable ? (
-				<button
-					type="button"
-					className={`${rowClass} hover:bg-muted/60`}
-					onClick={() => revealPanel("plan")}
-				>
-					<HugeiconsIcon
-						icon={CheckListIcon}
-						className="size-4 shrink-0 text-primary"
-					/>
-					<span className="min-w-0 flex-1 truncate">Plan</span>
-				</button>
+				<>
+					<div className="mx-2 my-1 border-border/60 border-t" />
+					<button
+						type="button"
+						className={`${rowClass} hover:bg-muted/60`}
+						onClick={() => revealPanel("plan")}
+					>
+						<HugeiconsIcon
+							icon={CheckListIcon}
+							className="size-4 shrink-0 text-primary"
+						/>
+						<span className="min-w-0 flex-1 truncate">Plan</span>
+					</button>
+				</>
 			) : null}
 			{subagents.length > 0 ? (
 				<section className="mx-2 mt-2 border-border/70 border-t px-0.5 pb-1 pt-3">

--- a/apps/renderer/src/components/jump-to-latest-pill.tsx
+++ b/apps/renderer/src/components/jump-to-latest-pill.tsx
@@ -33,8 +33,8 @@ export function JumpToLatestPill({
 				onClick={onClick}
 				aria-label="Jump to latest"
 				className={cn(
-					"pointer-events-auto relative inline-flex min-h-8 items-center gap-1.5 rounded-lg before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-['']",
-					"border border-border/60 bg-card px-3 py-1 text-xs text-muted-foreground shadow-overlay-sm",
+					"pointer-events-auto relative inline-flex min-h-6 items-center gap-1 rounded-md before:absolute before:-inset-y-1 before:inset-x-0 before:content-['']",
+					"border border-border/60 bg-card px-2 py-0.5 text-[10px] text-muted-foreground shadow-overlay-sm",
 					"transition-[background-color,border-color,color] duration-150 hover:border-border hover:bg-card hover:text-foreground motion-reduce:transition-none",
 					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
 				)}
@@ -45,7 +45,7 @@ export function JumpToLatestPill({
 						aria-hidden
 					/>
 				) : (
-					<HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5" />
+					<HugeiconsIcon icon={ArrowDown01Icon} className="size-3" />
 				)}
 				<span>Jump to latest</span>
 			</button>

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -158,7 +158,7 @@ export function MainTabs({ projectId, emptyLabel }: Props) {
 					onRename={(title) => renameSession(renamingSession.id, title)}
 				/>
 			) : null}
-			<header className="flex h-10 min-w-0 max-w-full shrink-0 items-stretch overflow-hidden border-b border-border">
+			<header className="flex h-8 min-w-0 max-w-full shrink-0 items-stretch overflow-hidden border-b border-border">
 				<div className="flex min-w-0 flex-1 items-stretch gap-1 overflow-x-auto overflow-y-hidden px-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 					{changesTabOpen ? (
 						<FileTabButton
@@ -269,7 +269,7 @@ function TabButton({
 			type="button"
 			onClick={onClick}
 			title={title ?? label}
-			className={`relative flex max-w-[280px] shrink-0 items-center gap-2 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
+			className={`relative flex max-w-[160px] shrink-0 items-center gap-1.5 px-2 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-1.5 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
 				active
 					? "text-foreground after:bg-foreground"
 					: "text-muted-foreground hover:text-foreground after:bg-transparent"
@@ -309,7 +309,7 @@ export function ChatTabButton({
 }) {
 	return (
 		<div
-			className={`group relative flex max-w-[280px] shrink-0 items-center gap-1.5 px-3 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
+			className={`group relative flex max-w-[160px] shrink-0 items-center gap-1 px-2 text-[12px] transition-colors after:pointer-events-none after:absolute after:inset-x-1.5 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
 				active
 					? "text-foreground after:bg-foreground"
 					: "text-muted-foreground hover:text-foreground after:bg-transparent"
@@ -346,29 +346,31 @@ export function ChatTabButton({
 					<TypewriterText text={label} className="truncate" />
 				</span>
 			</button>
-			<button
-				type="button"
-				onClick={(event) => {
-					event.stopPropagation();
-					onRename();
-				}}
-				aria-label={`Rename ${label}`}
-				title="Rename session"
-				className="relative z-10 rounded p-1 opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100 focus-visible:opacity-100"
-			>
-				<HugeiconsIcon icon={PencilEdit01Icon} className="size-3" />
-			</button>
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					onClose();
-				}}
-				aria-label="Close chat"
-				className="relative z-10 rounded p-0.5 opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100"
-			>
-				<X className="size-3" strokeWidth={1.8} />
-			</button>
+			<div className="absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center rounded bg-background/90 p-0.5 opacity-0 shadow-[-8px_0_8px_var(--background)] transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+				<button
+					type="button"
+					onClick={(event) => {
+						event.stopPropagation();
+						onRename();
+					}}
+					aria-label={`Rename ${label}`}
+					title="Rename session"
+					className="rounded p-0.5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+				>
+					<HugeiconsIcon icon={PencilEdit01Icon} className="size-3" />
+				</button>
+				<button
+					type="button"
+					onClick={(event) => {
+						event.stopPropagation();
+						onClose();
+					}}
+					aria-label="Close chat"
+					className="rounded p-0.5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+				>
+					<X className="size-3" strokeWidth={1.8} />
+				</button>
+			</div>
 		</div>
 	);
 }
@@ -445,7 +447,7 @@ function FileTabButton({
 }) {
 	return (
 		<div
-			className={`group relative flex max-w-[280px] shrink-0 items-center gap-1.5 px-3 text-[12px] leading-none transition-colors after:pointer-events-none after:absolute after:inset-x-2 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
+			className={`group relative flex max-w-[160px] shrink-0 items-center gap-1 px-2 text-[12px] leading-none transition-colors after:pointer-events-none after:absolute after:inset-x-1.5 after:-bottom-px after:h-[2px] after:rounded-full after:transition-colors ${
 				active
 					? "text-foreground after:bg-foreground"
 					: "text-muted-foreground hover:text-foreground after:bg-transparent"
@@ -472,7 +474,7 @@ function FileTabButton({
 				type="button"
 				onClick={onClose}
 				aria-label={closeLabel}
-				className="relative z-10 rounded p-0.5 opacity-0 transition-opacity hover:bg-foreground/10 group-hover:opacity-100"
+				className="absolute right-1 top-1/2 z-10 -translate-y-1/2 rounded bg-background/90 p-0.5 text-muted-foreground opacity-0 shadow-[-8px_0_8px_var(--background)] transition-opacity hover:bg-foreground/10 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
 			>
 				<X className="size-3" strokeWidth={1.8} />
 			</button>

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -181,10 +181,7 @@ function MessageRowImpl({
 					text={message.content.text}
 					origin={message.content.origin}
 					goal={message.content.goal}
-					messageId={message.id}
-					sessionId={sessionId}
-					forkDestination={forkDestination}
-					sourceProjectId={sourceProjectId}
+					createdAt={message.createdAt}
 				/>
 			);
 		case "user_rich":
@@ -197,10 +194,7 @@ function MessageRowImpl({
 					annotations={message.content.annotations}
 					origin={message.content.origin}
 					goal={message.content.goal}
-					messageId={message.id}
-					sessionId={sessionId}
-					forkDestination={forkDestination}
-					sourceProjectId={sourceProjectId}
+					createdAt={message.createdAt}
 				/>
 			);
 		case "assistant":
@@ -471,10 +465,7 @@ function UserBubble({
 	annotations,
 	origin,
 	goal = false,
-	messageId,
-	sessionId,
-	forkDestination,
-	sourceProjectId,
+	createdAt,
 }: {
 	text: string;
 	attachments?: ReadonlyArray<AttachmentRef>;
@@ -483,10 +474,7 @@ function UserBubble({
 	annotations?: ReadonlyArray<ComposerAnnotation>;
 	origin?: MessageOrigin;
 	goal?: boolean;
-	messageId: Message["id"];
-	sessionId?: SessionId;
-	forkDestination?: ForkDestination;
-	sourceProjectId?: FolderId;
+	createdAt?: Date;
 }) {
 	const hasAnnotations = annotations !== undefined && annotations.length > 0;
 	const revealAnnotation = useRevealAnnotation();
@@ -507,11 +495,11 @@ function UserBubble({
 	const truncate = (name: string): string =>
 		name.length > 28 ? `${name.slice(0, 25)}...` : name;
 	return (
-		<div className="group/message flex justify-end px-4 py-2">
+		<div className="group/message flex justify-end px-3 py-1.5">
 			<div className="flex max-w-[80%] flex-col items-end">
 				<div
 					data-chat-user-bubble
-					className="rounded-2xl rounded-tr-sm bg-user-bubble px-3 py-2 text-sm text-user-bubble-foreground"
+					className="rounded-xl rounded-tr-sm bg-user-bubble px-2.5 py-1.5 text-xs leading-relaxed text-user-bubble-foreground"
 				>
 					{origin !== undefined ? (
 						<button
@@ -656,12 +644,8 @@ function UserBubble({
 				</div>
 				<MessageActions
 					text={display || text}
-					sessionId={sessionId}
-					messageId={messageId}
-					forkLabel="message"
-					forkDestination={forkDestination}
-					sourceProjectId={sourceProjectId}
-					className="mt-1 opacity-0 transition-opacity duration-150 ease-out group-hover/message:opacity-100 group-focus-within/message:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100"
+					createdAt={createdAt}
+					className="mt-1"
 				/>
 			</div>
 		</div>
@@ -688,7 +672,7 @@ function AssistantBubble({
 	return (
 		<div
 			data-chat-assistant-bubble
-			className="group/assistant px-[var(--chat-assistant-gutter,1rem)] py-2"
+			className="group/assistant px-[var(--chat-assistant-gutter,0.75rem)] py-1.5"
 		>
 			<div className="max-w-full">
 				<MarkdownBody className="chat-assistant-markdown">{text}</MarkdownBody>

--- a/apps/renderer/src/components/model-picker.tsx
+++ b/apps/renderer/src/components/model-picker.tsx
@@ -457,7 +457,7 @@ export function ModelPicker(props: ModelPickerProps) {
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger
-				className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-foreground hover:bg-muted/60 data-[popup-open]:bg-muted/60"
+				className="flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs text-foreground hover:bg-muted/60 data-[popup-open]:bg-muted/60"
 				aria-label="Change model"
 				title="Change model — applies to next message"
 			>

--- a/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
+++ b/apps/renderer/src/components/onboarding/onboarding-wizard.tsx
@@ -115,13 +115,16 @@ export function OnboardingWizard() {
 			</div>
 
 			{/* Drag region so users can move the Electron window. */}
-			<div className="h-9 shrink-0 [-webkit-app-region:drag]" />
+			<div className="h-8 shrink-0 [-webkit-app-region:drag]" />
 
-			<div className="flex min-h-0 flex-1 items-center justify-center px-6 pb-12">
-				<div className="flex w-full max-w-xl flex-col gap-6">
+			<div className="flex min-h-0 flex-1 items-center justify-center px-5 pb-8">
+				<div className="flex w-full max-w-xl flex-col gap-4">
 					<StepIndicator stepIndex={stepIndex} />
 
-					<div className="min-h-[24rem] px-1 py-2">
+					<div
+						key={stepId}
+						className="compact-step-enter min-h-[20rem] px-1 py-1.5"
+					>
 						{stepId === "welcome" && <WelcomeStep />}
 						{stepId === "signin" && <SigninStep />}
 						{stepId === "maximize" && <MaximizeStep />}
@@ -141,7 +144,7 @@ export function OnboardingWizard() {
 								onClick={goBack}
 								disabled={isFirst}
 								className={cn(
-									"rounded-lg px-3 text-muted-foreground hover:text-foreground",
+									"px-2.5 text-muted-foreground hover:text-foreground",
 									isFirst && "invisible",
 								)}
 							>
@@ -155,7 +158,7 @@ export function OnboardingWizard() {
 										variant="ghost"
 										size="sm"
 										onClick={goNext}
-										className="rounded-lg px-3 text-muted-foreground hover:text-foreground"
+										className="px-2.5 text-muted-foreground hover:text-foreground"
 									>
 										Skip
 									</Button>
@@ -165,7 +168,7 @@ export function OnboardingWizard() {
 									size="default"
 									onClick={goNext}
 									disabled={!canAdvance}
-									className="rounded-lg px-5"
+									className="px-4"
 								>
 									{isFirst ? "Get started" : "Continue"}
 									<HugeiconsIcon icon={ArrowRight01Icon} />
@@ -181,7 +184,7 @@ export function OnboardingWizard() {
 
 function StepIndicator({ stepIndex }: { stepIndex: number }) {
 	return (
-		<div className="flex items-center justify-center gap-1.5">
+		<div className="flex items-center justify-center gap-1">
 			{STEPS.map((id, i) => {
 				const active = i === stepIndex;
 				const done = i < stepIndex;
@@ -189,10 +192,10 @@ function StepIndicator({ stepIndex }: { stepIndex: number }) {
 					<span
 						key={id}
 						className={cn(
-							"h-1 rounded-full transition-all duration-300",
-							active && "w-8 bg-foreground",
-							done && "w-4 bg-foreground/60",
-							!active && !done && "w-4 bg-foreground/15",
+							"h-0.5 rounded-full transition-[width,background-color] duration-180",
+							active && "w-6 bg-foreground",
+							done && "w-3 bg-foreground/60",
+							!active && !done && "w-3 bg-foreground/15",
 						)}
 					/>
 				);

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -450,13 +450,13 @@ export function ProjectsSidebar() {
 		>
 			<ComputerSwitcher />
 			<SidebarActions />
-			<div className="flex items-center justify-between px-3 py-2 text-xs text-muted-foreground">
+			<div className="flex items-center justify-between px-2.5 py-1.5 text-[11px] text-muted-foreground">
 				<span>Projects</span>
 				<ProjectAddMenu />
 			</div>
 			<SidebarErrorToasts />
 
-			<ul className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2">
+			<ul className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
 				{folders.length === 0 && !loading && (
 					<li className="px-3 py-4 text-center text-xs text-muted-foreground">
 						No projects yet. Click + to add one.
@@ -490,7 +490,7 @@ export function ProjectsSidebar() {
  */
 function SidebarActions() {
 	return (
-		<div className="flex flex-col gap-0.5 border-b border-sidebar-border/40 px-2 pb-2 pt-2">
+		<div className="flex flex-col gap-0.5 border-b border-sidebar-border/40 px-1.5 py-1.5">
 			<SidebarActionRow
 				icon={Edit01Icon}
 				label="New chat"
@@ -521,7 +521,7 @@ function SidebarActionRow({
 		<button
 			type="button"
 			onClick={onClick}
-			className="flex min-h-7 w-full items-center gap-2 rounded-lg px-2 py-1 text-left text-sm text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			className="flex min-h-6 w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-left text-[11px] text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 		>
 			<HugeiconsIcon icon={icon} className="size-4 shrink-0" />
 			<span className="min-w-0 flex-1 truncate">{label}</span>
@@ -536,7 +536,7 @@ function SidebarActionRow({
 
 function SidebarFooter() {
 	return (
-		<div className="flex flex-col gap-0.5 border-t border-sidebar-border/40 px-2 py-1.5">
+		<div className="flex flex-col gap-0.5 border-t border-sidebar-border/40 px-1.5 py-1">
 			<SidebarAccount />
 		</div>
 	);
@@ -565,7 +565,7 @@ function SidebarAccount() {
 					render={
 						<button
 							type="button"
-							className="flex min-h-11 w-full items-center gap-2 rounded-lg px-2 text-[11px] text-muted-foreground outline-none hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-ring"
+							className="flex min-h-7 w-full items-center gap-1.5 rounded-md px-2 text-[11px] text-muted-foreground outline-none hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-ring"
 						>
 							<HugeiconsIcon icon={UserCircleIcon} className="size-4" />
 							<span className="min-w-0 flex-1 truncate text-left">
@@ -799,7 +799,7 @@ function ProjectGroup({
 							onToggleExpanded();
 						}
 					}}
-					className="group flex cursor-pointer items-center gap-2 px-3 py-2.5 transition-colors hover:bg-sidebar-accent/30 rounded-md"
+					className="group flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/30"
 				>
 					{/* Single 20px slot holds avatar (idle) and chevron (hover). Both
               live in the same grid cell so the row never reflows; opacity
@@ -839,7 +839,7 @@ function ProjectGroup({
 						/>
 					</div>
 					<span
-						className="min-w-0 flex-1 truncate text-sm"
+						className="min-w-0 flex-1 truncate text-[11px]"
 						title={
 							origin
 								? `${origin.owner}/${origin.repo} · ${displayPath(path)}`
@@ -1236,7 +1236,7 @@ function ChatRow({ chat }: { chat: Chat }) {
 						}
 					}}
 					className={cn(
-						"group flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-xs transition-colors",
+						"group flex min-h-6 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[11px] transition-colors",
 						isSelected && "bg-sidebar-accent text-sidebar-accent-foreground",
 						!isSelected &&
 							isArchived &&

--- a/apps/renderer/src/components/provider-updates-toast.tsx
+++ b/apps/renderer/src/components/provider-updates-toast.tsx
@@ -115,19 +115,17 @@ export function ProviderUpdatesToast() {
 		<div
 			role="status"
 			className={cn(
-				"fixed right-4 bottom-24 z-50 flex w-[320px] flex-col gap-3 p-4",
+				"compact-notification fixed right-3 bottom-20 z-50 flex w-[288px] flex-col gap-2.5 p-3",
 				overlaySurface,
 			)}
 		>
-			<div className="flex items-start gap-3">
-				<span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
-					<HugeiconsIcon icon={CircleArrowUp01Icon} className="size-4" />
+			<div className="flex items-start gap-2">
+				<span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-foreground">
+					<HugeiconsIcon icon={CircleArrowUp01Icon} className="size-3.5" />
 				</span>
 				<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-					<span className="text-[13px] font-medium text-foreground">
-						{title}
-					</span>
-					<span className="text-[12px] leading-snug text-muted-foreground">
+					<span className="text-xs font-medium text-foreground">{title}</span>
+					<span className="text-[11px] leading-snug text-muted-foreground">
 						{detail}
 					</span>
 				</div>
@@ -146,15 +144,11 @@ export function ProviderUpdatesToast() {
 					size="xs"
 					variant="ghost"
 					onClick={recordDismissed}
-					className="rounded-full text-[11px]"
+					className="text-[10px]"
 				>
 					Dismiss
 				</Button>
-				<Button
-					size="xs"
-					onClick={onReview}
-					className="rounded-full text-[11px]"
-				>
+				<Button size="xs" onClick={onReview} className="text-[10px]">
 					Review in settings
 				</Button>
 			</div>

--- a/apps/renderer/src/components/right-pane.tsx
+++ b/apps/renderer/src/components/right-pane.tsx
@@ -328,7 +328,7 @@ export function RightPane({
 			{visiblePanels.length > 0 ? (
 				<div
 					ref={dockTabsRef}
-					className="flex h-9 shrink-0 items-center gap-0.5 overflow-x-auto px-1 text-xs"
+					className="flex h-8 shrink-0 items-center gap-0.5 overflow-x-auto px-1 text-[11px]"
 				>
 					{visiblePanels.map((panel) => (
 						<PanelTab

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -184,7 +184,7 @@ export function SettingsPage() {
 	}, [folders.length, loadFolders]);
 
 	return (
-		<div className="settings-surface flex min-h-0 flex-1 flex-col bg-background">
+		<div className="settings-surface flex min-h-0 flex-1 flex-col bg-background [&_button[data-slot=button]:not([class*='size-'])]:h-7 [&_button[data-slot=button]:not([class*='size-'])]:text-[11px]">
 			<header className="flex h-8 shrink-0 items-center px-3 text-xs text-muted-foreground [-webkit-app-region:drag]">
 				<div className="w-16 shrink-0" />
 				<button
@@ -199,10 +199,10 @@ export function SettingsPage() {
 			</header>
 			<div className="flex min-h-0 flex-1">
 				<Rail section={section} onSelect={setSection} folders={folders} />
-				<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-6">
+				<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-5">
 					<div
 						className={cn(
-							"mx-auto flex w-full flex-col gap-8",
+							"mx-auto flex w-full flex-col gap-4",
 							section.kind === "diagnostics"
 								? "max-w-6xl"
 								: section.kind === "pokedex"
@@ -395,7 +395,7 @@ function SectionTitle({
 	}, [section, folders]);
 	return (
 		<div className="flex min-w-0 items-center gap-1.5">
-			<h1 className="truncate text-base font-semibold tracking-tight text-foreground">
+			<h1 className="truncate text-sm font-semibold tracking-tight text-foreground">
 				{title}
 			</h1>
 			{subtitle && <InfoTip content={subtitle} />}
@@ -1374,7 +1374,7 @@ function ProvidersPane() {
 									aria-selected={selected}
 									onClick={() => setSelectedProvider(pid)}
 									className={cn(
-										"flex min-h-9 shrink-0 items-center gap-2 border-b px-2.5 text-sm transition-colors",
+										"flex min-h-7 shrink-0 items-center gap-1.5 border-b px-2 text-xs transition-colors",
 										selected
 											? "border-primary text-foreground"
 											: "border-transparent text-muted-foreground hover:text-foreground",
@@ -1438,10 +1438,10 @@ function ProvidersPane() {
 									role="radio"
 									aria-checked={selected}
 									onClick={() => setDefaultProvider(pid)}
-									className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+									className="group flex min-h-9 w-full items-center gap-2.5 px-3 py-2 text-left transition-colors hover:bg-muted/40"
 								>
 									<ProviderIcon providerId={pid} className="size-4 shrink-0" />
-									<span className="flex-1 truncate text-sm font-medium text-foreground">
+									<span className="flex-1 truncate text-xs font-medium text-foreground">
 										{PROVIDER_LABEL[pid]}
 									</span>
 									<RadioCheck active={selected} />
@@ -1597,7 +1597,7 @@ export function SettingsCardHeader({
 	trailing?: React.ReactNode;
 }) {
 	return (
-		<header className="flex h-10 shrink-0 items-center gap-2 px-4 text-muted-foreground">
+		<header className="flex h-8 shrink-0 items-center gap-2 px-3 text-muted-foreground">
 			{Icon && <HugeiconsIcon icon={Icon} className="size-3.5" aria-hidden />}
 			<span className="min-w-0 flex-1 truncate text-[11px] font-medium text-muted-foreground">
 				{title}
@@ -1630,8 +1630,8 @@ export function SettingsRow({
 	children?: React.ReactNode;
 }) {
 	return (
-		<div className={cn("flex flex-col gap-3 px-4 py-3", className)}>
-			<div className="flex items-start gap-3">
+		<div className={cn("flex flex-col gap-2 px-3 py-2.5", className)}>
+			<div className="flex items-start gap-2.5">
 				{Icon && (
 					<HugeiconsIcon
 						icon={Icon}
@@ -1640,14 +1640,14 @@ export function SettingsRow({
 					/>
 				)}
 				<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-					<div className="text-sm font-medium text-foreground">{title}</div>
+					<div className="text-xs font-medium text-foreground">{title}</div>
 					{description && (
 						<div className="text-[11px] leading-snug text-muted-foreground">
 							{description}
 						</div>
 					)}
 				</div>
-				{action && <div className="shrink-0 pt-0.5">{action}</div>}
+				{action && <div className="shrink-0">{action}</div>}
 			</div>
 			{children}
 		</div>

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -184,8 +184,8 @@ export function SettingsPage() {
 	}, [folders.length, loadFolders]);
 
 	return (
-		<div className="flex min-h-0 flex-1 flex-col bg-background">
-			<header className="flex h-9 shrink-0 items-center px-3 text-xs text-muted-foreground [-webkit-app-region:drag]">
+		<div className="settings-surface flex min-h-0 flex-1 flex-col bg-background">
+			<header className="flex h-8 shrink-0 items-center px-3 text-xs text-muted-foreground [-webkit-app-region:drag]">
 				<div className="w-16 shrink-0" />
 				<button
 					type="button"
@@ -199,10 +199,10 @@ export function SettingsPage() {
 			</header>
 			<div className="flex min-h-0 flex-1">
 				<Rail section={section} onSelect={setSection} folders={folders} />
-				<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-10 py-8">
+				<div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-6">
 					<div
 						className={cn(
-							"mx-auto flex w-full flex-col gap-10",
+							"mx-auto flex w-full flex-col gap-8",
 							section.kind === "diagnostics"
 								? "max-w-6xl"
 								: section.kind === "pokedex"
@@ -229,7 +229,7 @@ function Rail({
 	folders: ReadonlyArray<Folder>;
 }) {
 	return (
-		<nav className="flex w-56 shrink-0 flex-col gap-5 border-r border-border/40 bg-sidebar px-2.5 py-4 text-sm text-sidebar-foreground">
+		<nav className="flex w-52 shrink-0 flex-col gap-3 border-r border-border/40 bg-sidebar px-2.5 py-3 text-xs text-sidebar-foreground">
 			<div className="flex flex-col gap-0.5">
 				{VISIBLE_RAIL.map((item) => {
 					const active =
@@ -301,7 +301,7 @@ function RailButton({
 			onClick={onClick}
 			title={title}
 			className={cn(
-				"flex min-h-7 items-center gap-2 rounded-lg px-2 py-1 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+				"flex min-h-7 items-center gap-2 rounded-md px-2.5 py-1 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
 				active
 					? "bg-sidebar-accent text-sidebar-accent-foreground"
 					: "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
@@ -917,8 +917,6 @@ function GeneralPane() {
 	const setCompletionSoundPreset = useSettingsStore(
 		(s) => s.setCompletionSoundPreset,
 	);
-	const analyticsEnabled = useSettingsStore((s) => s.analyticsEnabled);
-	const setAnalyticsEnabled = useSettingsStore((s) => s.setAnalyticsEnabled);
 	const branchNamingStyle = useSettingsStore((s) => s.branchNamingStyle);
 	const setBranchNamingStyle = useSettingsStore((s) => s.setBranchNamingStyle);
 	const branchNamingPrefix = useSettingsStore((s) => s.branchNamingPrefix);
@@ -1181,48 +1179,6 @@ function GeneralPane() {
 						</Button>
 					</div>
 				</SettingsRow>
-			</SettingsGroup>
-
-			<SettingsGroup
-				title="Privacy"
-				description="Control pseudonymous product and reliability analytics."
-			>
-				<button
-					type="button"
-					role="switch"
-					aria-checked={analyticsEnabled}
-					data-analytics-id="settings.share-usage-analytics"
-					onClick={() => setAnalyticsEnabled(!analyticsEnabled)}
-					className="flex w-full items-center gap-3 px-4 py-3 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/70"
-				>
-					<div className="min-w-0 flex-1">
-						<div className="text-sm font-medium text-foreground">
-							Share usage analytics
-						</div>
-						<div className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
-							Share pseudonymous feature use, model choices, active time, and
-							reliability data. Prompts, responses, code, paths, and account
-							details are never included. Standard geographic enrichment is
-							applied by our analytics processor.
-						</div>
-					</div>
-					<span
-						aria-hidden
-						className={cn(
-							"relative h-5 w-8 shrink-0 rounded-full p-0.5 ring-1 transition-colors",
-							analyticsEnabled
-								? "bg-primary ring-primary/60"
-								: "bg-[#1f2123] ring-white/10",
-						)}
-					>
-						<span
-							className={cn(
-								"block size-3.5 rounded-full bg-white ring-1 ring-black/10 transition-transform dark:bg-[#484a4d]",
-								analyticsEnabled && "translate-x-[14px]",
-							)}
-						/>
-					</span>
-				</button>
 			</SettingsGroup>
 
 			<SettingsGroup

--- a/apps/renderer/src/components/settings-repository.tsx
+++ b/apps/renderer/src/components/settings-repository.tsx
@@ -49,14 +49,14 @@ export function RepositorySettings({ projectId }: { projectId: FolderId }) {
 
 	if (folder === undefined) {
 		return (
-			<p className="text-sm text-muted-foreground">
+			<p className="text-xs text-muted-foreground">
 				Project no longer exists. Pick another from the sidebar.
 			</p>
 		);
 	}
 
 	if (settings === null) {
-		return <p className="text-sm text-muted-foreground">Loading settings…</p>;
+		return <p className="text-xs text-muted-foreground">Loading settings…</p>;
 	}
 
 	return (
@@ -252,10 +252,10 @@ function ProviderOverrideSection({
 									role="radio"
 									aria-checked={selected}
 									onClick={() => onPickProvider(pid)}
-									className="group flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-muted/40"
+									className="group flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors hover:bg-muted/40"
 								>
 									<ProviderIcon providerId={pid} className="size-4 shrink-0" />
-									<span className="flex-1 truncate text-sm font-medium text-foreground">
+									<span className="flex-1 truncate text-xs font-medium text-foreground">
 										{PROVIDER_LABEL[pid]}
 									</span>
 									<RadioCheck active={selected} />
@@ -279,10 +279,10 @@ function ProviderOverrideSection({
 														role="radio"
 														aria-checked={isCurrentModel}
 														onClick={() => onPickModel(m.id)}
-														className="group flex items-center gap-3 py-1.5 text-left"
+														className="group flex items-center gap-2.5 py-1 text-left"
 													>
 														<RadioCheck active={isCurrentModel} />
-														<span className="text-sm text-foreground">
+														<span className="text-xs text-foreground">
 															{m.label}
 														</span>
 													</button>
@@ -296,7 +296,7 @@ function ProviderOverrideSection({
 					})}
 				</div>
 			) : (
-				<p className="rounded-lg border border-border/40 bg-background/60 px-3 py-2.5 text-sm text-muted-foreground">
+				<p className="rounded-lg border border-border/40 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
 					Inheriting{" "}
 					<span className="text-foreground">
 						{PROVIDER_LABEL[globalProviderId]} · {globalModelLabel}
@@ -343,17 +343,17 @@ function RuntimeModeOverrideSection({
 								role="radio"
 								aria-checked={selected}
 								onClick={() => onChange(mode)}
-								className="group flex w-full items-start gap-3 border-b border-border/40 px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-muted/40"
+								className="group flex w-full items-start gap-2.5 border-b border-border/40 px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-muted/40"
 							>
 								<HugeiconsIcon
 									icon={m.Icon}
 									className="mt-0.5 size-4 shrink-0 text-muted-foreground"
 								/>
 								<span className="flex min-w-0 flex-1 flex-col gap-0.5">
-									<span className="text-sm font-medium text-foreground">
+									<span className="text-xs font-medium text-foreground">
 										{m.label}
 									</span>
-									<span className="text-xs leading-snug text-muted-foreground">
+									<span className="text-[11px] leading-snug text-muted-foreground">
 										{m.description}
 									</span>
 								</span>
@@ -363,7 +363,7 @@ function RuntimeModeOverrideSection({
 					})}
 				</div>
 			) : (
-				<p className="rounded-lg border border-border/40 bg-background/60 px-3 py-2.5 text-sm text-muted-foreground">
+				<p className="rounded-lg border border-border/40 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
 					Inheriting{" "}
 					<span className="text-foreground">{MODE_META[globalMode].label}</span>
 				</p>
@@ -436,7 +436,7 @@ function WorktreeSection({
 
 			<div className="flex flex-col">
 				{sorted.length === 0 ? (
-					<p className="px-4 py-8 text-center text-xs text-muted-foreground">
+					<p className="px-3 py-6 text-center text-[11px] text-muted-foreground">
 						No worktrees yet. Zuse (Beta) creates one for you when you start a
 						new chat.
 					</p>
@@ -445,7 +445,7 @@ function WorktreeSection({
 						{sorted.map((wt) => (
 							<li
 								key={wt.id}
-								className="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/20"
+								className="grid grid-cols-[auto_1fr_auto] items-center gap-2.5 px-3 py-2.5 transition-colors hover:bg-muted/20"
 							>
 								<HugeiconsIcon
 									icon={GitBranchIcon}
@@ -455,7 +455,7 @@ function WorktreeSection({
 									className="flex min-w-0 flex-col gap-0.5"
 									title={displayPath(wt.path)}
 								>
-									<span className="truncate text-sm font-medium text-foreground">
+									<span className="truncate text-xs font-medium text-foreground">
 										{wt.name}
 									</span>
 									<span className="truncate font-mono text-[11px] text-muted-foreground">
@@ -482,11 +482,13 @@ function WorktreeSection({
 				)}
 			</div>
 
-			<div className="px-4 py-3">
+			<div className="px-3 py-2.5">
 				{pendingError !== null ? (
-					<p className="text-xs leading-relaxed text-red-400">{pendingError}</p>
+					<p className="text-[11px] leading-relaxed text-red-400">
+						{pendingError}
+					</p>
 				) : (
-					<p className="text-xs leading-relaxed text-muted-foreground">
+					<p className="text-[11px] leading-relaxed text-muted-foreground">
 						Git worktrees for this repo. Each lives under
 						~/.zuse/&lt;repo&gt;/&lt;name&gt;/ on disk.
 					</p>
@@ -576,12 +578,12 @@ function ScriptsSection({
 				placeholder={'rm -rf node_modules .next\npkill -f "next dev" || true'}
 				onChange={onArchiveScriptChange}
 			/>
-			<div className="px-4 py-3.5">
+			<div className="px-3 py-2.5">
 				<div className="mb-2">
-					<p className="text-sm font-medium text-foreground">
+					<p className="text-xs font-medium text-foreground">
 						Environment variables
 					</p>
-					<p className="text-xs text-muted-foreground">
+					<p className="text-[11px] text-muted-foreground">
 						KEY=value pairs passed to setup, run, and archive scripts.
 					</p>
 				</div>
@@ -597,8 +599,8 @@ function ScriptsSection({
 				value={fileIncludeGlobs}
 				onChange={onFileIncludeGlobsChange}
 			/>
-			<div className="px-4 py-3">
-				<p className="text-xs leading-relaxed text-muted-foreground">
+			<div className="px-3 py-2.5">
+				<p className="text-[11px] leading-relaxed text-muted-foreground">
 					Want to hand-edit or share repository settings? Use{" "}
 					<span className="font-mono">.zuse/settings.toml</span>.
 				</p>
@@ -620,12 +622,12 @@ function FileIncludesEditor({
 		if (draft !== value) onChange(draft);
 	};
 	return (
-		<div className="px-4 py-3.5">
+		<div className="px-3 py-2.5">
 			<div className="mb-2">
-				<p className="text-sm font-medium text-foreground">
+				<p className="text-xs font-medium text-foreground">
 					Worktree file includes
 				</p>
-				<p className="text-xs text-muted-foreground">
+				<p className="text-[11px] text-muted-foreground">
 					One pattern per line, linked from the main checkout into each new
 					worktree.
 				</p>
@@ -661,11 +663,11 @@ function ScriptEditor({
 		if ((value ?? "") !== (next ?? "")) onChange(next);
 	};
 	return (
-		<div className="px-4 py-3.5">
+		<div className="px-3 py-2.5">
 			<div className="mb-2 flex items-start justify-between gap-3">
 				<div className="min-w-0">
-					<p className="text-sm font-medium text-foreground">{title}</p>
-					<p className="text-xs text-muted-foreground">{description}</p>
+					<p className="text-xs font-medium text-foreground">{title}</p>
+					<p className="text-[11px] text-muted-foreground">{description}</p>
 				</div>
 				<span className="rounded-md border border-border/40 bg-muted/40 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground">
 					shell
@@ -694,7 +696,7 @@ function CodeTextarea({
 			<Textarea
 				spellCheck={false}
 				className={cn(
-					"resize-y border-0 bg-transparent px-3 py-2.5 font-mono text-xs leading-5 shadow-none outline-none placeholder:text-muted-foreground/50 focus-visible:ring-0",
+					"resize-y border-0 bg-transparent px-3 py-2 font-mono text-[11px] leading-4 shadow-none outline-none placeholder:text-muted-foreground/50 focus-visible:ring-0",
 					minHeightClassName,
 					className,
 				)}

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -330,16 +330,18 @@ export function DevicesPane() {
 		pairing === null ? null : preferredBrowserPairingUrl(pairing, status);
 
 	return (
-		<section className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-4 text-[13px]">
+		<section className="flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto p-3 text-xs">
 			<Frame>
-				<FramePanel className="space-y-2.5 p-2.5">
-					<div className="flex items-start gap-3">
-						<div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
+				<FramePanel className="space-y-2 p-2.5">
+					<div className="flex items-start gap-2.5">
+						<div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted">
 							<Wifi className="size-4" aria-hidden />
 						</div>
 						<div className="min-w-0 flex-1">
-							<FrameTitle>{deviceAccessCopy.localTitle}</FrameTitle>
-							<p className="mt-1 text-xs text-muted-foreground">
+							<FrameTitle className="text-xs font-medium">
+								{deviceAccessCopy.localTitle}
+							</FrameTitle>
+							<p className="mt-0.5 text-[11px] text-muted-foreground">
 								{networkEnabled
 									? "Use this environment from a web browser or the mobile app on this network."
 									: "Enable network access to connect a browser or another device."}
@@ -355,12 +357,12 @@ export function DevicesPane() {
 							{networkEnabled ? "On" : "Off"}
 						</span>
 					</div>
-					<p className="text-xs text-muted-foreground">
+					<p className="text-[11px] text-muted-foreground">
 						This computer owns the projects, files, agents, and terminals. Each
 						connected client gets revocable access from a one-time link.
 					</p>
 				</FramePanel>
-				<FrameFooter className="flex flex-wrap justify-end gap-2 px-2.5 py-2">
+				<FrameFooter className="flex flex-wrap justify-end gap-1.5 px-2.5 py-1.5">
 					{!canManageNetwork ? (
 						<p className="text-right text-xs text-muted-foreground">
 							Network access is managed from the desktop app.
@@ -425,12 +427,12 @@ export function DevicesPane() {
 						</div>
 						<div className="flex min-w-0 flex-col justify-center gap-2.5">
 							<div>
-								<FrameTitle>
+								<FrameTitle className="text-xs font-medium">
 									{pairingTarget === "browser"
 										? "Connect a web browser"
 										: "Connect the mobile app"}
 								</FrameTitle>
-								<p className="mt-1 text-xs text-muted-foreground">
+								<p className="mt-0.5 text-[11px] text-muted-foreground">
 									This one-time link expires in five minutes. Access remains
 									until you revoke the connected device below.
 								</p>
@@ -504,13 +506,15 @@ export function DevicesPane() {
 
 			{hasActiveTokens && (
 				<Frame>
-					<FramePanel className="space-y-2.5 p-2.5">
-						<FrameTitle>{deviceAccessCopy.pairedTitle}</FrameTitle>
+					<FramePanel className="space-y-2 p-2.5">
+						<FrameTitle className="text-xs font-medium">
+							{deviceAccessCopy.pairedTitle}
+						</FrameTitle>
 						<div className="flex flex-col gap-2">
 							{identifiedDevices.map((token) => (
 								<div
 									key={token.id}
-									className="flex min-h-11 items-center gap-3 rounded-lg border border-border/50 bg-muted/20 px-3 py-2"
+									className="flex min-h-9 items-center gap-2.5 rounded-md border border-border/50 bg-muted/20 px-2.5 py-1.5"
 								>
 									{accessDeviceKind(token) === "browser" ? (
 										<Monitor
@@ -524,13 +528,13 @@ export function DevicesPane() {
 										/>
 									)}
 									<div className="min-w-0 flex-1">
-										<p className="truncate text-sm font-medium">
+										<p className="truncate text-xs font-medium">
 											{token.label ??
 												(accessDeviceKind(token) === "browser"
 													? "Web browser"
 													: "Mobile device")}
 										</p>
-										<p className="text-xs text-muted-foreground">
+										<p className="text-[11px] text-muted-foreground">
 											{token.lastUsedAt
 												? `Last connected ${token.lastUsedAt.toLocaleString()}`
 												: "Not connected yet"}
@@ -546,16 +550,16 @@ export function DevicesPane() {
 								</div>
 							))}
 							{legacyCredentials.length > 0 && (
-								<div className="flex min-h-11 items-center gap-3 rounded-lg border border-border/50 bg-muted/20 px-3 py-2">
+								<div className="flex min-h-9 items-center gap-2.5 rounded-md border border-border/50 bg-muted/20 px-2.5 py-1.5">
 									<Smartphone
 										className="size-4 shrink-0 text-muted-foreground"
 										aria-hidden
 									/>
 									<div className="min-w-0 flex-1">
-										<p className="truncate text-sm font-medium">
+										<p className="truncate text-xs font-medium">
 											Older device access
 										</p>
-										<p className="text-xs text-muted-foreground">
+										<p className="text-[11px] text-muted-foreground">
 											{legacyCredentials.length} access credential
 											{legacyCredentials.length === 1 ? "" : "s"} from an
 											earlier version
@@ -576,7 +580,7 @@ export function DevicesPane() {
 			)}
 
 			<Frame>
-				<FramePanel className="space-y-2.5 p-2.5">
+				<FramePanel className="space-y-2 p-2.5">
 					<div className="flex items-center gap-2">
 						<span
 							className={
@@ -586,23 +590,25 @@ export function DevicesPane() {
 							}
 							aria-hidden
 						/>
-						<FrameTitle>{deviceAccessCopy.remoteTitle}</FrameTitle>
+						<FrameTitle className="text-xs font-medium">
+							{deviceAccessCopy.remoteTitle}
+						</FrameTitle>
 					</div>
 					{linked ? (
-						<p className="text-xs text-muted-foreground">
+						<p className="text-[11px] text-muted-foreground">
 							{remoteReady
 								? `Ready. Use ${status?.label ?? "this computer"} from a browser or mobile device away from this Wi-Fi.`
 								: "Linked to your account. Remote access will resume when this computer reconnects."}
 						</p>
 					) : (
 						<>
-							<p className="text-xs text-muted-foreground">
+							<p className="text-[11px] text-muted-foreground">
 								Optional. Sign in to reach this environment from a browser or
 								mobile device away from this Wi-Fi.
 							</p>
 							<label
 								htmlFor="device-computer-label"
-								className="flex flex-col gap-2 text-sm font-medium"
+								className="flex flex-col gap-1.5 text-xs font-medium"
 							>
 								Computer name (optional)
 								<Input
@@ -619,7 +625,7 @@ export function DevicesPane() {
 						separate environment and prints its own web link.
 					</p>
 				</FramePanel>
-				<FrameFooter className="flex justify-end px-2.5 py-2">
+				<FrameFooter className="flex justify-end px-2.5 py-1.5">
 					<Button
 						size="xs"
 						variant={linked ? "destructive-outline" : "default"}

--- a/apps/renderer/src/components/settings/linear-integrations-pane.tsx
+++ b/apps/renderer/src/components/settings/linear-integrations-pane.tsx
@@ -1,18 +1,14 @@
 import type { LinearConnection } from "@zuse/contracts";
 import { Effect } from "effect";
+import { Info } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { errorMessage } from "~/lib/error-message.ts";
 import { getRpcClient } from "~/lib/rpc-client.ts";
 import { Button } from "../ui/button.tsx";
 import { Card } from "../ui/card.tsx";
-import {
-	Frame,
-	FrameDescription,
-	FrameFooter,
-	FrameHeader,
-	FrameTitle,
-} from "../ui/frame.tsx";
+import { Frame, FrameHeader, FrameTitle } from "../ui/frame.tsx";
 import { Spinner } from "../ui/spinner.tsx";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip.tsx";
 
 export function LinearIntegrationsPane() {
 	const [connections, setConnections] =
@@ -73,58 +69,81 @@ export function LinearIntegrationsPane() {
 			setBusy(null);
 		}
 	};
-	const hasConnections = connections !== null && connections.length > 0;
-
 	return (
 		<Frame>
-			<FrameHeader className="gap-1 px-4 py-3">
-				<FrameTitle>Linear</FrameTitle>
-				<FrameDescription>
-					Select tickets when creating a chat. Ticket details, comments, and
-					images are copied into the session workspace.
-				</FrameDescription>
+			<FrameHeader className="px-2 py-1.5">
+				<FrameTitle className="text-[13px] font-medium">
+					Integrations
+				</FrameTitle>
 			</FrameHeader>
-
-			<Card className="mx-1 overflow-hidden rounded-md">
+			<Card className="overflow-hidden">
+				<div className="flex min-h-10 items-center gap-2 border-border/50 border-b px-3 py-2">
+					<div className="grid size-7 shrink-0 place-items-center rounded-md border border-border/60 bg-muted/40 text-xs font-semibold">
+						L
+					</div>
+					<div className="flex min-w-0 flex-1 items-center gap-1.5">
+						<p className="truncate text-xs font-medium">Linear</p>
+						<Tooltip>
+							<TooltipTrigger
+								render={
+									<button
+										type="button"
+										aria-label="About the Linear integration"
+										className="text-muted-foreground/55 hover:text-muted-foreground"
+									>
+										<Info className="size-3.5" />
+									</button>
+								}
+							/>
+							<TooltipPopup className="max-w-64">
+								Select tickets when creating a chat. Ticket details, comments,
+								and images are copied into the session workspace.
+							</TooltipPopup>
+						</Tooltip>
+					</div>
+					<Button
+						type="button"
+						size="sm"
+						onClick={() => void connect()}
+						disabled={busy !== null}
+						loading={busy === "connect"}
+					>
+						{connections !== null && connections.length > 0
+							? "Add workspace"
+							: "Connect"}
+					</Button>
+				</div>
 				{error !== null && (
 					<p
 						role="alert"
-						className="border-b border-border/60 px-4 py-3 text-xs text-destructive"
+						className="border-border/60 border-b px-3 py-2 text-[11px] text-destructive"
 					>
 						{error}
 					</p>
 				)}
 
 				{connections === null ? (
-					<div className="grid min-h-32 place-items-center">
+					<div className="grid min-h-16 place-items-center">
 						<Spinner className="size-4 text-muted-foreground" />
 					</div>
 				) : connections.length === 0 ? (
-					<div className="flex min-h-36 flex-col items-center justify-center gap-3 p-6 text-center">
-						<p className="text-sm text-muted-foreground">
+					<div className="px-3 py-4 text-center">
+						<p className="text-[11px] text-muted-foreground">
 							No Linear workspaces connected yet.
 						</p>
-						<Button
-							type="button"
-							onClick={() => void connect()}
-							disabled={busy !== null}
-							loading={busy === "connect"}
-						>
-							Connect workspace
-						</Button>
 					</div>
 				) : (
 					<div className="divide-y divide-border/60">
 						{connections.map((connection) => (
 							<div
 								key={connection.workspaceId}
-								className="flex items-center justify-between gap-4 p-4"
+								className="flex items-center justify-between gap-3 px-3 py-2.5"
 							>
 								<div className="min-w-0">
-									<p className="truncate text-sm font-medium">
+									<p className="truncate text-xs font-medium">
 										{connection.workspaceName}
 									</p>
-									<p className="truncate text-xs text-muted-foreground">
+									<p className="truncate text-[11px] text-muted-foreground">
 										{connection.viewerName} · {connection.viewerEmail}
 									</p>
 									{connection.status === "reauthRequired" && (
@@ -137,6 +156,7 @@ export function LinearIntegrationsPane() {
 									{connection.status === "reauthRequired" && (
 										<Button
 											type="button"
+											size="sm"
 											disabled={busy !== null}
 											loading={busy === "connect"}
 											onClick={() => void connect()}
@@ -146,6 +166,7 @@ export function LinearIntegrationsPane() {
 									)}
 									<Button
 										type="button"
+										size="sm"
 										variant="outline"
 										disabled={busy !== null}
 										loading={busy === connection.workspaceId}
@@ -159,19 +180,6 @@ export function LinearIntegrationsPane() {
 					</div>
 				)}
 			</Card>
-
-			{hasConnections && (
-				<FrameFooter className="flex justify-end px-4 py-3">
-					<Button
-						type="button"
-						onClick={() => void connect()}
-						disabled={busy !== null}
-						loading={busy === "connect"}
-					>
-						Add workspace
-					</Button>
-				</FrameFooter>
-			)}
 		</Frame>
 	);
 }

--- a/apps/renderer/src/components/subagents-pane.tsx
+++ b/apps/renderer/src/components/subagents-pane.tsx
@@ -53,21 +53,21 @@ export function SubagentsPane({
 			);
 		return (
 			<div className="flex min-h-0 flex-1 flex-col">
-				<div className="flex h-11 shrink-0 items-center gap-2 border-b border-border/60 px-3">
+				<div className="flex h-8 shrink-0 items-center gap-1.5 border-b border-border/60 px-2">
 					<button
 						type="button"
 						aria-label="Back to subagents"
 						onClick={() => selectSubagent(null)}
-						className="grid size-8 shrink-0 place-items-center rounded text-muted-foreground hover:bg-muted/50 hover:text-foreground focus-visible:outline focus-visible:outline-1"
+						className="grid size-6 shrink-0 place-items-center rounded text-muted-foreground hover:bg-muted/50 hover:text-foreground focus-visible:outline focus-visible:outline-1"
 					>
 						<HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
 					</button>
 					<SubagentAvatar name={selected.agentName} size="sm" />
-					<span className="min-w-0 flex-1 truncate text-sm font-medium">
+					<span className="min-w-0 flex-1 truncate text-xs font-medium">
 						{selected.agentName}
 					</span>
 				</div>
-				<div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+				<div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
 					<SubagentTranscript messages={selected.children} />
 					{selected.summary?.text && !summaryAlreadyInTranscript ? (
 						<MessageRow
@@ -86,7 +86,7 @@ export function SubagentsPane({
 	const active = groups.filter((group) => group.summary === null);
 	const done = groups.filter((group) => group.summary !== null);
 	return (
-		<div className="min-h-0 flex-1 overflow-y-auto px-3 py-4">
+		<div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
 			<AgentSection title="Active" groups={active} onSelect={selectSubagent} />
 			<AgentSection
 				title={`Done · ${done.length}`}

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -20,7 +20,7 @@ import { ShimmerText } from "./ui/shimmer-text.tsx";
  */
 function TerminalPlaceholder({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-background text-sm text-muted-foreground">
+    <div className="flex h-full w-full items-center justify-center bg-background text-xs text-muted-foreground">
       {children}
     </div>
   );
@@ -120,7 +120,7 @@ export function PtyTerminal({
   return (
     <div
       ref={containerRef}
-      className="h-full w-full min-w-0 overflow-hidden bg-background px-2.5 py-2"
+      className="h-full w-full min-w-0 overflow-hidden bg-background px-2 py-1.5"
     />
   );
 }

--- a/apps/renderer/src/components/top-bar.tsx
+++ b/apps/renderer/src/components/top-bar.tsx
@@ -3,6 +3,7 @@ import {
 	Alert01Icon,
 	ArchiveArrowDownIcon,
 	ArrowDown01Icon,
+	ArrowRight01Icon,
 	Copy01Icon,
 	GitBranchIcon,
 	GitMergeIcon,
@@ -17,6 +18,7 @@ import {
 	PanelRightOpenIcon,
 	PencilEdit01Icon,
 	PlayIcon,
+	Search01Icon,
 	Tick01Icon,
 	Upload01Icon,
 	Wrench01Icon,
@@ -71,6 +73,7 @@ import {
 } from "./glass-action.tsx";
 import { OpenTargetIcon } from "./open-target-icon.tsx";
 import { TooltipShortcut } from "./projects-sidebar.tsx";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar.tsx";
 import { ErrorBoundary } from "./ui/error-boundary.tsx";
 import {
 	Menu,
@@ -103,7 +106,7 @@ const openExternal = (url: string): void => {
 };
 
 const SECTION_CLASS =
-	"flex h-9 shrink-0 items-center gap-1.5 border-b border-border text-xs [-webkit-app-region:drag]";
+	"flex h-8 shrink-0 items-center gap-1 border-b border-border text-[11px] [-webkit-app-region:drag]";
 const ACTION_CLASS = "[-webkit-app-region:no-drag]";
 const ICON_BUTTON_CLASS = `${ACTION_CLASS} flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground`;
 const NATIVE_CONTROLS_INSET_CLASS =
@@ -218,6 +221,7 @@ export function TopBarMain() {
 	// stale-branch flash during the swap.
 	const branchLabel = status?.branch ?? null;
 	const repoLabel = originLabel ?? folder?.name ?? "No repository";
+	const originOwner = originLabel?.split("/", 1)[0] ?? null;
 	const showLeftToggle = !leftSidebarOpen;
 	// When the left panel is open its own header carries the traffic-light
 	// gutter, so this section starts flush. When it's collapsed we slide the
@@ -310,7 +314,7 @@ export function TopBarMain() {
 
 	return (
 		<header
-			className={`${SECTION_CLASS} ${leftPad} ${rightSidebarOpen ? "pr-1" : NATIVE_CONTROLS_INSET_CLASS}`}
+			className={`${SECTION_CLASS} ${leftPad} bg-muted/20 ${rightSidebarOpen ? "pr-1" : NATIVE_CONTROLS_INSET_CLASS}`}
 		>
 			{showLeftToggle ? (
 				<Tooltip>
@@ -336,20 +340,38 @@ export function TopBarMain() {
 			) : null}
 			<div className={`flex min-w-0 flex-1 items-center ${ACTION_CLASS}`}>
 				{hasSession ? (
-					<div className="flex min-w-0 max-w-[min(620px,100%)] items-center gap-1.5 text-xs">
+					<nav
+						aria-label="Repository location"
+						className="flex min-w-0 max-w-[min(460px,100%)] items-center gap-1 text-[11px]"
+					>
+						<Avatar className="mr-0.5 size-4 shrink-0 rounded-sm">
+							{originOwner !== null ? (
+								<AvatarImage
+									src={`https://github.com/${encodeURIComponent(originOwner)}.png?size=32`}
+									alt=""
+								/>
+							) : null}
+							<AvatarFallback className="rounded-sm bg-foreground/8 text-[8px] text-muted-foreground">
+								{repoLabel.slice(0, 1).toUpperCase()}
+							</AvatarFallback>
+						</Avatar>
 						<span
-							className="truncate font-medium text-foreground"
+							className="max-w-44 truncate font-medium text-foreground/90"
 							title={repoLabel}
 						>
 							{repoLabel}
 						</span>
 						{branchLabel ? (
 							<>
-								<span className="shrink-0 text-muted-foreground/70">/</span>
+								<HugeiconsIcon
+									icon={ArrowRight01Icon}
+									className="size-3 shrink-0 text-muted-foreground/50"
+								/>
 								<BranchMenuButton
 									branchLabel={branchLabel}
 									branches={branches}
 									canRename={worktreeId !== null}
+									className="min-w-0 max-w-52 px-1 py-0 text-[11px] font-normal text-muted-foreground hover:text-foreground"
 									dirtyFiles={status?.dirtyFiles ?? 0}
 									error={branchError}
 									loading={branchesLoading}
@@ -362,7 +384,7 @@ export function TopBarMain() {
 								/>
 							</>
 						) : null}
-					</div>
+					</nav>
 				) : null}
 			</div>
 			{renameOpen &&
@@ -441,10 +463,12 @@ export function TopBarMain() {
 	);
 }
 
-function BranchMenuButton({
+export function BranchMenuButton({
 	branchLabel,
 	branches,
 	canRename,
+	className,
+	popupSide = "bottom",
 	dirtyFiles,
 	error,
 	loading,
@@ -455,6 +479,8 @@ function BranchMenuButton({
 	branchLabel: string;
 	branches: ReadonlyArray<GitBranchInfo>;
 	canRename: boolean;
+	className?: string;
+	popupSide?: "bottom" | "left";
 	dirtyFiles: number;
 	error: string | null;
 	loading: boolean;
@@ -462,14 +488,22 @@ function BranchMenuButton({
 	onRename: () => void;
 	onSwitch: (branch: GitBranchInfo) => void;
 }) {
-	const localBranches = branches.filter((b) => b.kind === "local");
-	const remoteBranches = branches.filter((b) => b.kind === "remote");
+	const [branchQuery, setBranchQuery] = useState("");
+	const normalizedQuery = branchQuery.trim().toLocaleLowerCase();
+	const matchingBranches = branches.filter((branch) => {
+		if (normalizedQuery.length === 0) return true;
+		return [branch.name, branch.remote, branch.upstream].some((value) =>
+			value?.toLocaleLowerCase().includes(normalizedQuery),
+		);
+	});
+	const localBranches = matchingBranches.filter((b) => b.kind === "local");
+	const remoteBranches = matchingBranches.filter((b) => b.kind === "remote");
 
 	return (
-		<Menu>
+		<Menu onOpenChange={(open) => !open && setBranchQuery("")}>
 			<MenuTrigger
 				onClick={onOpen}
-				className="flex max-w-64 items-center gap-1 rounded-sm px-1.5 py-0.5 font-medium text-foreground outline-none hover:bg-foreground/5 data-[popup-open]:bg-foreground/5"
+				className={`flex items-center gap-1 rounded-sm px-1.5 py-0.5 font-medium text-foreground outline-none hover:bg-foreground/5 data-[popup-open]:bg-foreground/5 ${className ?? "max-w-64"}`}
 				aria-label="Switch branch"
 			>
 				<HugeiconsIcon
@@ -494,7 +528,12 @@ function BranchMenuButton({
 					/>
 				)}
 			</MenuTrigger>
-			<MenuPopup align="center" className="min-w-64">
+			<MenuPopup
+				side={popupSide}
+				sideOffset={popupSide === "left" ? 8 : 4}
+				align="center"
+				className="w-72"
+			>
 				{error !== null ? (
 					<div className="max-w-72 px-2 py-1.5 text-[11px] leading-snug text-[var(--accent-red)]">
 						{error}
@@ -512,54 +551,80 @@ function BranchMenuButton({
 						<MenuSeparator />
 					</>
 				) : null}
-				<MenuSectionLabel>Local branches</MenuSectionLabel>
-				{localBranches.length > 0 ? (
-					localBranches.map((branch) => (
-						<MenuItem
-							key={`local:${branch.name}`}
-							disabled={branch.current || loading}
-							onClick={() => onSwitch(branch)}
-							className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
-						>
-							<HugeiconsIcon
-								icon={Tick01Icon}
-								className={`size-3.5 ${branch.current ? "opacity-100" : "opacity-0"}`}
-							/>
-							<span className="min-w-0 flex-1 truncate">{branch.name}</span>
-							{branch.upstream !== null ? (
-								<span className="max-w-28 truncate text-[10px] text-muted-foreground">
-									{branch.upstream}
-								</span>
-							) : null}
-						</MenuItem>
-					))
-				) : (
-					<div className="px-2 py-1.5 text-xs text-muted-foreground">
-						No local branches
-					</div>
-				)}
-				{remoteBranches.length > 0 ? (
-					<>
-						<MenuSeparator />
-						<MenuSectionLabel>Remote branches</MenuSectionLabel>
-						{remoteBranches.map((branch) => (
+				<div className="sticky top-0 z-10 bg-glass px-1 pb-1">
+					<label className="flex h-7 items-center gap-1.5 rounded-md border border-border/70 bg-background/50 px-2 focus-within:border-ring/60">
+						<HugeiconsIcon
+							icon={Search01Icon}
+							className="size-3.5 shrink-0 text-muted-foreground"
+						/>
+						<span className="sr-only">Search branches</span>
+						<input
+							type="search"
+							value={branchQuery}
+							onChange={(event) => setBranchQuery(event.target.value)}
+							onKeyDown={(event) => {
+								if (event.key !== "Escape") event.stopPropagation();
+							}}
+							placeholder="Search branches"
+							className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground/70"
+						/>
+					</label>
+				</div>
+				<div className="max-h-56 overflow-y-auto overscroll-contain">
+					<MenuSectionLabel>Local branches</MenuSectionLabel>
+					{localBranches.length > 0 ? (
+						localBranches.map((branch) => (
 							<MenuItem
-								key={`remote:${branch.remote ?? branch.name}`}
-								disabled={loading}
+								key={`local:${branch.name}`}
+								disabled={branch.current || loading}
 								onClick={() => onSwitch(branch)}
 								className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
 							>
-								<HugeiconsIcon icon={GitBranchIcon} className="size-3.5" />
+								<HugeiconsIcon
+									icon={Tick01Icon}
+									className={`size-3.5 ${branch.current ? "opacity-100" : "opacity-0"}`}
+								/>
 								<span className="min-w-0 flex-1 truncate">{branch.name}</span>
-								{branch.remote !== null ? (
+								{branch.upstream !== null ? (
 									<span className="max-w-28 truncate text-[10px] text-muted-foreground">
-										{branch.remote}
+										{branch.upstream}
 									</span>
 								) : null}
 							</MenuItem>
-						))}
-					</>
-				) : null}
+						))
+					) : normalizedQuery.length === 0 ? (
+						<div className="px-2 py-1.5 text-xs text-muted-foreground">
+							No local branches
+						</div>
+					) : null}
+					{remoteBranches.length > 0 ? (
+						<>
+							<MenuSeparator />
+							<MenuSectionLabel>Remote branches</MenuSectionLabel>
+							{remoteBranches.map((branch) => (
+								<MenuItem
+									key={`remote:${branch.remote ?? branch.name}`}
+									disabled={loading}
+									onClick={() => onSwitch(branch)}
+									className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs hover:bg-sidebar-accent"
+								>
+									<HugeiconsIcon icon={GitBranchIcon} className="size-3.5" />
+									<span className="min-w-0 flex-1 truncate">{branch.name}</span>
+									{branch.remote !== null ? (
+										<span className="max-w-28 truncate text-[10px] text-muted-foreground">
+											{branch.remote}
+										</span>
+									) : null}
+								</MenuItem>
+							))}
+						</>
+					) : null}
+					{matchingBranches.length === 0 ? (
+						<div className="px-2 py-5 text-center text-xs text-muted-foreground">
+							No matching branches
+						</div>
+					) : null}
+				</div>
 			</MenuPopup>
 		</Menu>
 	);

--- a/apps/renderer/src/components/ui/accordion.tsx
+++ b/apps/renderer/src/components/ui/accordion.tsx
@@ -34,7 +34,7 @@ export function AccordionTrigger({
 		<AccordionPrimitive.Header className="flex">
 			<AccordionPrimitive.Trigger
 				className={cn(
-					"flex flex-1 cursor-pointer items-start justify-between gap-4 rounded-md py-4 text-left font-medium text-sm outline-none transition-all focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-64 data-panel-open:*:data-[slot=accordion-indicator]:rotate-180",
+					"flex min-h-7 flex-1 cursor-pointer items-center justify-between gap-2 rounded-md py-1.5 text-left font-medium text-xs outline-none transition-[color,background-color] duration-150 focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-64 data-panel-open:*:data-[slot=accordion-indicator]:rotate-180",
 					className,
 				)}
 				data-slot="accordion-trigger"
@@ -58,11 +58,11 @@ export function AccordionPanel({
 }: AccordionPrimitive.Panel.Props): React.ReactElement {
 	return (
 		<AccordionPrimitive.Panel
-			className="h-(--accordion-panel-height) overflow-hidden text-muted-foreground text-sm transition-[height] duration-200 ease-in-out data-ending-style:h-0 data-starting-style:h-0"
+			className="h-(--accordion-panel-height) overflow-hidden text-muted-foreground text-xs transition-[height] duration-180 ease-out data-ending-style:h-0 data-starting-style:h-0 motion-reduce:duration-80"
 			data-slot="accordion-panel"
 			{...props}
 		>
-			<div className={cn("pt-0 pb-4", className)}>{children}</div>
+			<div className={cn("pt-0 pb-2.5", className)}>{children}</div>
 		</AccordionPrimitive.Panel>
 	);
 }

--- a/apps/renderer/src/components/ui/button.tsx
+++ b/apps/renderer/src/components/ui/button.tsx
@@ -4,101 +4,100 @@ import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
-import { cn } from "~/lib/utils";
 import { Spinner } from "~/components/ui/spinner";
+import { cn } from "~/lib/utils";
 
 export const buttonVariants = cva(
-  "relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-lg border font-medium text-base outline-none transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 data-loading:select-none data-loading:text-transparent sm:text-sm [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
-  {
-    defaultVariants: {
-      size: "default",
-      variant: "default",
-    },
-    variants: {
-      size: {
-        default: "h-9 px-[calc(--spacing(3)-1px)] sm:h-8",
-        icon: "size-9 sm:size-8",
-        "icon-lg": "size-10 sm:size-9",
-        "icon-sm": "size-8 sm:size-7",
-        "icon-xl":
-          "size-11 sm:size-10 [&_svg:not([class*='size-'])]:size-5 sm:[&_svg:not([class*='size-'])]:size-4.5",
-        "icon-xs":
-          "size-7 rounded-md before:rounded-[calc(var(--radius-md)-1px)] sm:size-6 not-in-data-[slot=input-group]:[&_svg:not([class*='size-'])]:size-4 sm:not-in-data-[slot=input-group]:[&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-10 px-[calc(--spacing(3.5)-1px)] sm:h-9",
-        sm: "h-8 gap-1.5 px-[calc(--spacing(2.5)-1px)] sm:h-7",
-        xl: "h-11 px-[calc(--spacing(4)-1px)] text-lg sm:h-10 sm:text-base [&_svg:not([class*='size-'])]:size-5 sm:[&_svg:not([class*='size-'])]:size-4.5",
-        xs: "h-7 gap-1 rounded-md px-[calc(--spacing(2)-1px)] text-sm before:rounded-[calc(var(--radius-md)-1px)] sm:h-6 sm:text-xs [&_svg:not([class*='size-'])]:size-4 sm:[&_svg:not([class*='size-'])]:size-3.5",
-      },
-      variant: {
-        default:
-          "not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] border-primary bg-primary text-primary-foreground shadow-primary/24 shadow-xs hover:bg-primary/90 data-pressed:bg-primary/90 *:data-[slot=button-loading-indicator]:text-primary-foreground [:active,[data-pressed]]:inset-shadow-[0_1px_--theme(--color-black/8%)] [:disabled,:active,[data-pressed]]:shadow-none btn-lime-embodied",
-        destructive:
-          "not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] border-destructive bg-destructive text-white shadow-destructive/24 shadow-xs hover:bg-destructive/90 data-pressed:bg-destructive/90 *:data-[slot=button-loading-indicator]:text-white [:active,[data-pressed]]:inset-shadow-[0_1px_--theme(--color-black/8%)] [:disabled,:active,[data-pressed]]:shadow-none",
-        "destructive-outline":
-          "border-transparent bg-alert-error-bg text-destructive-foreground shadow-xs/5 ring-1 ring-inset ring-destructive/10 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] hover:bg-alert-error-bg data-pressed:bg-alert-error-bg *:data-[slot=button-loading-indicator]:text-foreground dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/5%)] [:disabled,:active,[data-pressed]]:shadow-none",
-        ghost:
-          "border-transparent text-foreground hover:bg-accent data-pressed:bg-accent *:data-[slot=button-loading-indicator]:text-foreground",
-        link: "border-transparent text-foreground underline-offset-4 hover:underline data-pressed:underline *:data-[slot=button-loading-indicator]:text-foreground",
-        outline:
-          "border-transparent bg-muted not-dark:bg-clip-padding text-foreground shadow-xs/5 ring-1 ring-inset ring-border/45 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] hover:bg-accent data-pressed:bg-accent *:data-[slot=button-loading-indicator]:text-foreground dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/5%)] [:disabled,:active,[data-pressed]]:shadow-none",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/90 data-pressed:bg-secondary/90 *:data-[slot=button-loading-indicator]:text-secondary-foreground [:active,[data-pressed]]:bg-secondary/80",
+	"relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-md border font-medium text-xs outline-none transition-[background-color,border-color,color,box-shadow] duration-150 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 data-loading:select-none data-loading:text-transparent [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
+	{
+		defaultVariants: {
+			size: "default",
+			variant: "default",
+		},
+		variants: {
+			size: {
+				default: "h-7 px-[calc(--spacing(2.5)-1px)]",
+				icon: "size-7",
+				"icon-lg": "size-8",
+				"icon-sm": "size-6",
+				"icon-xl": "size-9 [&_svg:not([class*='size-'])]:size-4",
+				"icon-xs":
+					"size-6 not-in-data-[slot=input-group]:[&_svg:not([class*='size-'])]:size-3",
+				lg: "h-8 px-[calc(--spacing(3)-1px)]",
+				sm: "h-6 gap-1 px-[calc(--spacing(2)-1px)] text-[11px]",
+				xl: "h-9 px-[calc(--spacing(3.5)-1px)] text-[13px] [&_svg:not([class*='size-'])]:size-4",
+				xs: "h-6 gap-1 px-[calc(--spacing(1.5)-1px)] text-[10px] [&_svg:not([class*='size-'])]:size-3",
+			},
+			variant: {
+				default:
+					"not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] border-primary bg-primary text-primary-foreground shadow-primary/24 shadow-xs hover:bg-primary/90 data-pressed:bg-primary/90 *:data-[slot=button-loading-indicator]:text-primary-foreground [:active,[data-pressed]]:inset-shadow-[0_1px_--theme(--color-black/8%)] [:disabled,:active,[data-pressed]]:shadow-none btn-lime-embodied",
+				destructive:
+					"not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] border-destructive bg-destructive text-white shadow-destructive/24 shadow-xs hover:bg-destructive/90 data-pressed:bg-destructive/90 *:data-[slot=button-loading-indicator]:text-white [:active,[data-pressed]]:inset-shadow-[0_1px_--theme(--color-black/8%)] [:disabled,:active,[data-pressed]]:shadow-none",
+				"destructive-outline":
+					"border-transparent bg-alert-error-bg text-destructive-foreground shadow-xs/5 ring-1 ring-inset ring-destructive/10 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] hover:bg-alert-error-bg data-pressed:bg-alert-error-bg *:data-[slot=button-loading-indicator]:text-foreground dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/5%)] [:disabled,:active,[data-pressed]]:shadow-none",
+				ghost:
+					"border-transparent text-foreground hover:bg-accent data-pressed:bg-accent *:data-[slot=button-loading-indicator]:text-foreground",
+				link: "border-transparent text-foreground underline-offset-4 hover:underline data-pressed:underline *:data-[slot=button-loading-indicator]:text-foreground",
+				outline:
+					"border-transparent bg-muted not-dark:bg-clip-padding text-foreground shadow-xs/5 ring-1 ring-inset ring-border/45 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] hover:bg-accent data-pressed:bg-accent *:data-[slot=button-loading-indicator]:text-foreground dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/5%)] [:disabled,:active,[data-pressed]]:shadow-none",
+				secondary:
+					"border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/90 data-pressed:bg-secondary/90 *:data-[slot=button-loading-indicator]:text-secondary-foreground [:active,[data-pressed]]:bg-secondary/80",
 
-        /* Subtle glass button (glassmorphic secondary) */
-        subtle:
-          "h-10 rounded-[10px] border border-white/10 bg-neutral-primary-reverted-5 px-[10px] text-sm font-semibold text-foreground shadow-[0_2px_1.5px_-0.5px_rgba(0,0,0,0.03),inset_0_2px_3px_0_rgba(255,255,255,0.03)] backdrop-blur-[12px] hover:bg-white/8 active:bg-white/12 data-pressed:bg-white/12 *:data-[slot=button-loading-indicator]:text-foreground before:hidden",
+				/* Subtle glass button (glassmorphic secondary) */
+				subtle:
+					"rounded-md border border-white/10 bg-neutral-primary-reverted-5 px-2.5 text-xs font-semibold text-foreground shadow-none backdrop-blur-[12px] hover:bg-white/8 active:bg-white/12 data-pressed:bg-white/12 *:data-[slot=button-loading-indicator]:text-foreground before:hidden",
 
-        /* Settings: flat translucent action button used on settings rows. */
-        settings:
-          "rounded-[10px] border-white/8 bg-neutral-primary-reverted-20 text-foreground/90 shadow-none hover:bg-white/14 active:bg-white/16 data-pressed:bg-white/16 *:data-[slot=button-loading-indicator]:text-foreground before:hidden",
-      },
-    },
-  },
+				/* Settings: flat translucent action button used on settings rows. */
+			settings:
+				"h-7 rounded-md border-white/8 bg-neutral-primary-reverted-20 px-2.5 text-xs text-foreground/90 shadow-none hover:bg-white/14 active:bg-white/16 data-pressed:bg-white/16 *:data-[slot=button-loading-indicator]:text-foreground before:hidden",
+			},
+		},
+	},
 );
 
 export interface ButtonProps extends useRender.ComponentProps<"button"> {
-  variant?: VariantProps<typeof buttonVariants>["variant"];
-  size?: VariantProps<typeof buttonVariants>["size"];
-  loading?: boolean;
+	variant?: VariantProps<typeof buttonVariants>["variant"];
+	size?: VariantProps<typeof buttonVariants>["size"];
+	loading?: boolean;
 }
 
 export function Button({
-  className,
-  variant,
-  size,
-  render,
-  children,
-  loading = false,
-  disabled: disabledProp,
-  ...props
+	className,
+	variant,
+	size,
+	render,
+	children,
+	loading = false,
+	disabled: disabledProp,
+	...props
 }: ButtonProps): React.ReactElement {
-  const isDisabled: boolean = Boolean(loading || disabledProp);
-  const typeValue: React.ButtonHTMLAttributes<HTMLButtonElement>["type"] =
-    render ? undefined : "button";
+	const isDisabled: boolean = Boolean(loading || disabledProp);
+	const typeValue: React.ButtonHTMLAttributes<HTMLButtonElement>["type"] =
+		render ? undefined : "button";
 
-  const defaultProps = {
-    children: (
-      <>
-        {children}
-        {loading && (
-          <Spinner
-            className="pointer-events-none absolute"
-            data-slot="button-loading-indicator"
-          />
-        )}
-      </>
-    ),
-    className: cn(buttonVariants({ className, size, variant })),
-    "aria-disabled": loading || undefined,
-    "data-loading": loading ? "" : undefined,
-    "data-slot": "button",
-    disabled: isDisabled,
-    type: typeValue,
-  };
+	const defaultProps = {
+		children: (
+			<>
+				{children}
+				{loading && (
+					<Spinner
+						className="pointer-events-none absolute"
+						data-slot="button-loading-indicator"
+					/>
+				)}
+			</>
+		),
+		className: cn(buttonVariants({ className, size, variant })),
+		"aria-disabled": loading || undefined,
+		"data-loading": loading ? "" : undefined,
+		"data-slot": "button",
+		disabled: isDisabled,
+		type: typeValue,
+	};
 
-  return useRender({
-    defaultTagName: "button",
-    props: mergeProps<"button">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "button",
+		props: mergeProps<"button">(defaultProps, props),
+		render,
+	});
 }

--- a/apps/renderer/src/components/ui/card.tsx
+++ b/apps/renderer/src/components/ui/card.tsx
@@ -6,248 +6,248 @@ import type React from "react";
 import { cn } from "~/lib/utils";
 
 export function Card({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] dark:shadow-xs/5 dark:before:shadow-[0_-1px_--theme(--color-white/5%)]",
-      className,
-    ),
-    "data-slot": "card",
-  };
+	const defaultProps = {
+		className: cn(
+			"relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] dark:shadow-xs/5 dark:before:shadow-[0_-1px_--theme(--color-white/5%)]",
+			className,
+		),
+		"data-slot": "card",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardFrame({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground [--clip-bottom:-1rem] [--clip-top:-1rem] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:bg-muted/72 has-data-[slot=table-container]:overflow-hidden *:data-[slot=card]:-m-px *:data-[slot=table-container]:-m-px *:data-[slot=table-container]:w-[calc(100%+2px)] *:not-first:data-[slot=card]:rounded-t-md *:not-last:data-[slot=card]:rounded-b-md *:data-[slot=card]:bg-clip-padding *:data-[slot=card]:shadow-none *:data-[slot=card]:before:hidden *:not-first:data-[slot=card]:before:rounded-t-[calc(var(--radius-md)-1px)] *:not-last:data-[slot=card]:before:rounded-b-[calc(var(--radius-md)-1px)] dark:shadow-xs/5 dark:before:shadow-[0_-1px_--theme(--color-white/5%)] *:data-[slot=card]:[clip-path:inset(var(--clip-top)_1px_var(--clip-bottom)_1px_round_calc(var(--radius-lg)-1px))] *:data-[slot=card]:last:[--clip-bottom:1px] *:data-[slot=card]:first:[--clip-top:1px]",
-      className,
-    ),
-    "data-slot": "card-frame",
-  };
+	const defaultProps = {
+		className: cn(
+			"relative flex flex-col rounded-lg border border-border/70 bg-card not-dark:bg-clip-padding text-card-foreground [--clip-bottom:-1rem] [--clip-top:-1rem] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:bg-muted/72 has-data-[slot=table-container]:overflow-hidden *:data-[slot=card]:-m-px *:data-[slot=table-container]:-m-px *:data-[slot=table-container]:w-[calc(100%+2px)] *:not-first:data-[slot=card]:rounded-t-md *:not-last:data-[slot=card]:rounded-b-md *:data-[slot=card]:bg-clip-padding *:data-[slot=card]:shadow-none *:data-[slot=card]:before:hidden *:not-first:data-[slot=card]:before:rounded-t-[calc(var(--radius-md)-1px)] *:not-last:data-[slot=card]:before:rounded-b-[calc(var(--radius-md)-1px)] dark:shadow-xs/5 dark:before:shadow-[0_-1px_--theme(--color-white/5%)] *:data-[slot=card]:[clip-path:inset(var(--clip-top)_1px_var(--clip-bottom)_1px_round_calc(var(--radius-lg)-1px))] *:data-[slot=card]:last:[--clip-bottom:1px] *:data-[slot=card]:first:[--clip-top:1px]",
+			className,
+		),
+		"data-slot": "card-frame",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardFrameHeader({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "relative flex grid auto-rows-min grid-rows-[auto_auto] flex-col items-start gap-x-4 px-6 py-4 has-data-[slot=card-frame-action]:grid-cols-[1fr_auto]",
-      className,
-    ),
-    "data-slot": "card-frame-header",
-  };
+	const defaultProps = {
+		className: cn(
+			"relative flex grid auto-rows-min grid-rows-[auto_auto] flex-col items-start gap-x-3 px-4 py-3 has-data-[slot=card-frame-action]:grid-cols-[1fr_auto]",
+			className,
+		),
+		"data-slot": "card-frame-header",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardFrameTitle({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn("self-center font-semibold text-sm", className),
-    "data-slot": "card-frame-title",
-  };
+	const defaultProps = {
+		className: cn("self-center font-semibold text-sm", className),
+		"data-slot": "card-frame-title",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardFrameDescription({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn("self-center text-muted-foreground text-sm", className),
-    "data-slot": "card-frame-description",
-  };
+	const defaultProps = {
+		className: cn("self-center text-muted-foreground text-sm", className),
+		"data-slot": "card-frame-description",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardFrameAction({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "col-start-2 nth-3:row-span-2 nth-3:row-start-1 inline-flex self-center justify-self-end",
-      className,
-    ),
-    "data-slot": "card-frame-action",
-  };
+	const defaultProps = {
+		className: cn(
+			"col-start-2 nth-3:row-span-2 nth-3:row-start-1 inline-flex self-center justify-self-end",
+			className,
+		),
+		"data-slot": "card-frame-action",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardFrameFooter({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn("px-6 py-4", className),
-    "data-slot": "card-frame-footer",
-  };
+	const defaultProps = {
+		className: cn("px-4 py-3", className),
+		"data-slot": "card-frame-footer",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardHeader({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 p-6 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-4 has-data-[slot=card-action]:grid-cols-[1fr_auto]",
-      className,
-    ),
-    "data-slot": "card-header",
-  };
+	const defaultProps = {
+		className: cn(
+			"grid auto-rows-min grid-rows-[auto_auto] items-start gap-1 p-4 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pb-3 has-data-[slot=card-action]:grid-cols-[1fr_auto]",
+			className,
+		),
+		"data-slot": "card-header",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardTitle({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn("font-semibold text-lg leading-none", className),
-    "data-slot": "card-title",
-  };
+	const defaultProps = {
+		className: cn("font-semibold text-[13px] leading-none", className),
+		"data-slot": "card-title",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardDescription({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn("text-muted-foreground text-sm", className),
-    "data-slot": "card-description",
-  };
+	const defaultProps = {
+		className: cn("text-muted-foreground text-[11px]", className),
+		"data-slot": "card-description",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardAction({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "col-start-2 row-span-2 row-start-1 inline-flex self-start justify-self-end",
-      className,
-    ),
-    "data-slot": "card-action",
-  };
+	const defaultProps = {
+		className: cn(
+			"col-start-2 row-span-2 row-start-1 inline-flex self-start justify-self-end",
+			className,
+		),
+		"data-slot": "card-action",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardPanel({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "flex-1 p-6 in-[[data-slot=card]:has(>[data-slot=card-header]:not(.border-b))]:pt-0 in-[[data-slot=card]:has(>[data-slot=card-footer]:not(.border-t))]:pb-0",
-      className,
-    ),
-    "data-slot": "card-panel",
-  };
+	const defaultProps = {
+		className: cn(
+			"flex-1 p-4 in-[[data-slot=card]:has(>[data-slot=card-header]:not(.border-b))]:pt-0 in-[[data-slot=card]:has(>[data-slot=card-footer]:not(.border-t))]:pb-0",
+			className,
+		),
+		"data-slot": "card-panel",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function CardFooter({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "flex items-center p-6 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pt-4",
-      className,
-    ),
-    "data-slot": "card-footer",
-  };
+	const defaultProps = {
+		className: cn(
+			"flex items-center p-4 in-[[data-slot=card]:has(>[data-slot=card-panel])]:pt-3",
+			className,
+		),
+		"data-slot": "card-footer",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export { CardPanel as CardContent };

--- a/apps/renderer/src/components/ui/dialog.tsx
+++ b/apps/renderer/src/components/ui/dialog.tsx
@@ -5,210 +5,210 @@ import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { X } from "lucide-react";
 import type React from "react";
-import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
 import { ScrollArea } from "~/components/ui/scroll-area";
+import { cn } from "~/lib/utils";
 
 export const DialogCreateHandle: typeof DialogPrimitive.createHandle =
-  DialogPrimitive.createHandle;
+	DialogPrimitive.createHandle;
 
 export const Dialog: typeof DialogPrimitive.Root = DialogPrimitive.Root;
 
 export const DialogPortal: typeof DialogPrimitive.Portal =
-  DialogPrimitive.Portal;
+	DialogPrimitive.Portal;
 
 export function DialogTrigger(
-  props: DialogPrimitive.Trigger.Props,
+	props: DialogPrimitive.Trigger.Props,
 ): React.ReactElement {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 export function DialogClose(
-  props: DialogPrimitive.Close.Props,
+	props: DialogPrimitive.Close.Props,
 ): React.ReactElement {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 export function DialogBackdrop({
-  className,
-  ...props
+	className,
+	...props
 }: DialogPrimitive.Backdrop.Props): React.ReactElement {
-  return (
-    <DialogPrimitive.Backdrop
-      className={cn(
-        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
-        className,
-      )}
-      data-slot="dialog-backdrop"
-      {...props}
-    />
-  );
+	return (
+		<DialogPrimitive.Backdrop
+			className={cn(
+				"fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-opacity duration-180 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:duration-80",
+				className,
+			)}
+			data-slot="dialog-backdrop"
+			{...props}
+		/>
+	);
 }
 
 export function DialogViewport({
-  className,
-  ...props
+	className,
+	...props
 }: DialogPrimitive.Viewport.Props): React.ReactElement {
-  return (
-    <DialogPrimitive.Viewport
-      className={cn(
-        "fixed inset-0 z-50 grid grid-rows-[1fr_auto_3fr] justify-items-center p-4",
-        className,
-      )}
-      data-slot="dialog-viewport"
-      {...props}
-    />
-  );
+	return (
+		<DialogPrimitive.Viewport
+			className={cn(
+				"fixed inset-0 z-50 grid grid-rows-[1fr_auto_3fr] justify-items-center p-4",
+				className,
+			)}
+			data-slot="dialog-viewport"
+			{...props}
+		/>
+	);
 }
 
 export function DialogPopup({
-  className,
-  children,
-  showCloseButton = true,
-  bottomStickOnMobile = true,
-  closeProps,
-  portalProps,
-  ...props
+	className,
+	children,
+	showCloseButton = true,
+	bottomStickOnMobile = true,
+	closeProps,
+	portalProps,
+	...props
 }: DialogPrimitive.Popup.Props & {
-  showCloseButton?: boolean;
-  bottomStickOnMobile?: boolean;
-  closeProps?: DialogPrimitive.Close.Props;
-  portalProps?: DialogPrimitive.Portal.Props;
+	showCloseButton?: boolean;
+	bottomStickOnMobile?: boolean;
+	closeProps?: DialogPrimitive.Close.Props;
+	portalProps?: DialogPrimitive.Portal.Props;
 }): React.ReactElement {
-  return (
-    <DialogPortal {...portalProps}>
-      <DialogBackdrop />
-      <DialogViewport
-        className={cn(
-          bottomStickOnMobile &&
-            "max-sm:grid-rows-[1fr_auto] max-sm:p-0 max-sm:pt-12",
-        )}
-      >
-        <DialogPrimitive.Popup
-          className={cn(
-            "relative row-start-2 flex max-h-full min-h-0 w-full min-w-0 max-w-lg origin-center flex-col rounded-2xl bg-popover text-popover-foreground opacity-[calc(1-var(--nested-dialogs))] shadow-overlay-lg outline-none transition-[scale,opacity,translate] duration-200 ease-in-out will-change-transform data-ending-style:opacity-0 data-starting-style:opacity-0 sm:scale-[calc(1-0.1*var(--nested-dialogs))] sm:data-ending-style:scale-98 sm:data-starting-style:scale-98 dark:border dark:border-white/10",
-            bottomStickOnMobile &&
-              "max-sm:max-w-none max-sm:origin-bottom max-sm:rounded-none max-sm:border-x-0 max-sm:border-t max-sm:border-b-0 max-sm:data-ending-style:translate-y-4 max-sm:data-starting-style:translate-y-4 max-sm:before:hidden max-sm:before:rounded-none",
-            className,
-          )}
-          data-slot="dialog-popup"
-          {...props}
-        >
-          {children}
-          {showCloseButton && (
-            <DialogPrimitive.Close
-              aria-label="Close"
-              className="absolute end-2 top-2"
-              render={<Button size="icon" variant="ghost" />}
-              {...closeProps}
-            >
-              <X />
-            </DialogPrimitive.Close>
-          )}
-        </DialogPrimitive.Popup>
-      </DialogViewport>
-    </DialogPortal>
-  );
+	return (
+		<DialogPortal {...portalProps}>
+			<DialogBackdrop />
+			<DialogViewport
+				className={cn(
+					bottomStickOnMobile &&
+						"max-sm:grid-rows-[1fr_auto] max-sm:p-0 max-sm:pt-12",
+				)}
+			>
+				<DialogPrimitive.Popup
+					className={cn(
+						"relative row-start-2 flex max-h-full min-h-0 w-full min-w-0 max-w-lg origin-center flex-col rounded-xl bg-popover text-popover-foreground opacity-[calc(1-var(--nested-dialogs))] shadow-overlay-lg outline-none transition-[scale,opacity,translate] duration-180 ease-out will-change-transform data-ending-style:opacity-0 data-starting-style:opacity-0 sm:scale-[calc(1-0.1*var(--nested-dialogs))] sm:data-ending-style:scale-98 sm:data-starting-style:scale-98 motion-reduce:duration-80 motion-reduce:transform-none dark:border dark:border-white/10",
+						bottomStickOnMobile &&
+							"max-sm:max-w-none max-sm:origin-bottom max-sm:rounded-none max-sm:border-x-0 max-sm:border-t max-sm:border-b-0 max-sm:data-ending-style:translate-y-4 max-sm:data-starting-style:translate-y-4 max-sm:before:hidden max-sm:before:rounded-none",
+						className,
+					)}
+					data-slot="dialog-popup"
+					{...props}
+				>
+					{children}
+					{showCloseButton && (
+						<DialogPrimitive.Close
+							aria-label="Close"
+							className="absolute end-2 top-2"
+							render={<Button size="icon" variant="ghost" />}
+							{...closeProps}
+						>
+							<X />
+						</DialogPrimitive.Close>
+					)}
+				</DialogPrimitive.Popup>
+			</DialogViewport>
+		</DialogPortal>
+	);
 }
 
 export function DialogHeader({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "flex flex-col gap-2 p-5 in-[[data-slot=dialog-popup]:has([data-slot=dialog-panel])]:pb-3 max-sm:pb-4",
-      className,
-    ),
-    "data-slot": "dialog-header",
-  };
+	const defaultProps = {
+		className: cn(
+			"flex flex-col gap-1.5 p-4 in-[[data-slot=dialog-popup]:has([data-slot=dialog-panel])]:pb-2.5 max-sm:pb-3",
+			className,
+		),
+		"data-slot": "dialog-header",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function DialogFooter({
-  className,
-  render,
-  ...props
+	className,
+	render,
+	...props
 }: useRender.ComponentProps<"div">): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/72 px-5 py-3.5 sm:flex-row sm:justify-end sm:rounded-b-[calc(var(--radius-2xl)-1px)]",
-      className,
-    ),
-    "data-slot": "dialog-footer",
-  };
+	const defaultProps = {
+		className: cn(
+			"flex flex-col-reverse gap-1.5 border-t border-border/60 bg-muted/72 px-4 py-2.5 sm:flex-row sm:justify-end sm:rounded-b-[calc(var(--radius-xl)-1px)]",
+			className,
+		),
+		"data-slot": "dialog-footer",
+	};
 
-  return useRender({
-    defaultTagName: "div",
-    props: mergeProps<"div">(defaultProps, props),
-    render,
-  });
+	return useRender({
+		defaultTagName: "div",
+		props: mergeProps<"div">(defaultProps, props),
+		render,
+	});
 }
 
 export function DialogTitle({
-  className,
-  ...props
+	className,
+	...props
 }: DialogPrimitive.Title.Props): React.ReactElement {
-  return (
-    <DialogPrimitive.Title
-      className={cn(
-        "font-heading font-semibold text-xl leading-none",
-        className,
-      )}
-      data-slot="dialog-title"
-      {...props}
-    />
-  );
+	return (
+		<DialogPrimitive.Title
+			className={cn(
+				"font-heading font-semibold text-[15px] leading-none",
+				className,
+			)}
+			data-slot="dialog-title"
+			{...props}
+		/>
+	);
 }
 
 export function DialogDescription({
-  className,
-  ...props
+	className,
+	...props
 }: DialogPrimitive.Description.Props): React.ReactElement {
-  return (
-    <DialogPrimitive.Description
-      className={cn("text-muted-foreground text-sm", className)}
-      data-slot="dialog-description"
-      {...props}
-    />
-  );
+	return (
+		<DialogPrimitive.Description
+			className={cn("text-muted-foreground text-[11px]", className)}
+			data-slot="dialog-description"
+			{...props}
+		/>
+	);
 }
 
 export function DialogPanel({
-  className,
-  scrollFade = true,
-  render,
-  ...props
+	className,
+	scrollFade = true,
+	render,
+	...props
 }: useRender.ComponentProps<"div"> & {
-  scrollFade?: boolean;
+	scrollFade?: boolean;
 }): React.ReactElement {
-  const defaultProps = {
-    className: cn(
-      "p-5 in-[[data-slot=dialog-popup]:has([data-slot=dialog-header])]:pt-1",
-      className,
-    ),
-    "data-slot": "dialog-panel",
-  };
+	const defaultProps = {
+		className: cn(
+			"p-4 in-[[data-slot=dialog-popup]:has([data-slot=dialog-header])]:pt-1",
+			className,
+		),
+		"data-slot": "dialog-panel",
+	};
 
-  return (
-    <ScrollArea scrollFade={scrollFade}>
-      {useRender({
-        defaultTagName: "div",
-        props: mergeProps<"div">(defaultProps, props),
-        render,
-      })}
-    </ScrollArea>
-  );
+	return (
+		<ScrollArea scrollFade={scrollFade}>
+			{useRender({
+				defaultTagName: "div",
+				props: mergeProps<"div">(defaultProps, props),
+				render,
+			})}
+		</ScrollArea>
+	);
 }
 
 export {
-  DialogPrimitive,
-  DialogBackdrop as DialogOverlay,
-  DialogPopup as DialogContent,
+	DialogBackdrop as DialogOverlay,
+	DialogPopup as DialogContent,
+	DialogPrimitive,
 };

--- a/apps/renderer/src/components/ui/field.tsx
+++ b/apps/renderer/src/components/ui/field.tsx
@@ -5,76 +5,76 @@ import type React from "react";
 import { cn } from "~/lib/utils";
 
 export function Field({
-  className,
-  ...props
+	className,
+	...props
 }: FieldPrimitive.Root.Props): React.ReactElement {
-  return (
-    <FieldPrimitive.Root
-      className={cn("flex flex-col items-start gap-2", className)}
-      data-slot="field"
-      {...props}
-    />
-  );
+	return (
+		<FieldPrimitive.Root
+			className={cn("flex flex-col items-start gap-1.5", className)}
+			data-slot="field"
+			{...props}
+		/>
+	);
 }
 
 export function FieldLabel({
-  className,
-  ...props
+	className,
+	...props
 }: FieldPrimitive.Label.Props): React.ReactElement {
-  return (
-    <FieldPrimitive.Label
-      className={cn(
-        "inline-flex items-center gap-2 font-medium text-base/4.5 text-foreground data-disabled:opacity-64 sm:text-sm/4",
-        className,
-      )}
-      data-slot="field-label"
-      {...props}
-    />
-  );
+	return (
+		<FieldPrimitive.Label
+			className={cn(
+				"inline-flex items-center gap-1.5 font-medium text-xs/4 text-foreground data-disabled:opacity-64",
+				className,
+			)}
+			data-slot="field-label"
+			{...props}
+		/>
+	);
 }
 
 export function FieldItem({
-  className,
-  ...props
+	className,
+	...props
 }: FieldPrimitive.Item.Props): React.ReactElement {
-  return (
-    <FieldPrimitive.Item
-      className={cn("flex", className)}
-      data-slot="field-item"
-      {...props}
-    />
-  );
+	return (
+		<FieldPrimitive.Item
+			className={cn("flex", className)}
+			data-slot="field-item"
+			{...props}
+		/>
+	);
 }
 
 export function FieldDescription({
-  className,
-  ...props
+	className,
+	...props
 }: FieldPrimitive.Description.Props): React.ReactElement {
-  return (
-    <FieldPrimitive.Description
-      className={cn("text-muted-foreground text-xs", className)}
-      data-slot="field-description"
-      {...props}
-    />
-  );
+	return (
+		<FieldPrimitive.Description
+			className={cn("text-muted-foreground text-xs", className)}
+			data-slot="field-description"
+			{...props}
+		/>
+	);
 }
 
 export function FieldError({
-  className,
-  ...props
+	className,
+	...props
 }: FieldPrimitive.Error.Props): React.ReactElement {
-  return (
-    <FieldPrimitive.Error
-      className={cn("text-destructive-foreground text-xs", className)}
-      data-slot="field-error"
-      {...props}
-    />
-  );
+	return (
+		<FieldPrimitive.Error
+			className={cn("text-destructive-foreground text-xs", className)}
+			data-slot="field-error"
+			{...props}
+		/>
+	);
 }
 
 export const FieldControl: typeof FieldPrimitive.Control =
-  FieldPrimitive.Control;
+	FieldPrimitive.Control;
 export const FieldValidity: typeof FieldPrimitive.Validity =
-  FieldPrimitive.Validity;
+	FieldPrimitive.Validity;
 
 export { FieldPrimitive };

--- a/apps/renderer/src/components/ui/input.tsx
+++ b/apps/renderer/src/components/ui/input.tsx
@@ -5,64 +5,63 @@ import type * as React from "react";
 import { cn } from "~/lib/utils";
 
 export type InputProps = Omit<
-  InputPrimitive.Props & React.RefAttributes<HTMLInputElement>,
-  "size"
+	InputPrimitive.Props & React.RefAttributes<HTMLInputElement>,
+	"size"
 > & {
-  size?: "sm" | "default" | "lg" | number;
-  unstyled?: boolean;
-  nativeInput?: boolean;
+	size?: "sm" | "default" | "lg" | number;
+	unstyled?: boolean;
+	nativeInput?: boolean;
 };
 
 export function Input({
-  className,
-  size = "default",
-  unstyled = false,
-  nativeInput = false,
-  style,
-  ...props
+	className,
+	size = "default",
+	unstyled = false,
+	nativeInput = false,
+	style,
+	...props
 }: InputProps): React.ReactElement {
-  const inputClassName = cn(
-    "h-8.5 w-full min-w-0 rounded-[inherit] px-[calc(--spacing(3)-1px)] leading-8.5 outline-none [transition:background-color_5000000s_ease-in-out_0s] placeholder:text-muted-foreground/72 sm:h-7.5 sm:leading-7.5",
-    size === "sm" &&
-      "h-7.5 px-[calc(--spacing(2.5)-1px)] leading-7.5 sm:h-6.5 sm:leading-6.5",
-    size === "lg" && "h-9.5 leading-9.5 sm:h-8.5 sm:leading-8.5",
-    props.type === "search" &&
-      "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none [&::-webkit-search-results-button]:appearance-none [&::-webkit-search-results-decoration]:appearance-none",
-    props.type === "file" &&
-      "text-muted-foreground file:me-3 file:bg-transparent file:font-medium file:text-foreground file:text-sm",
-  );
+	const inputClassName = cn(
+		"h-7 w-full min-w-0 rounded-[inherit] px-[calc(--spacing(2.5)-1px)] leading-7 outline-none [transition:background-color_5000000s_ease-in-out_0s] placeholder:text-muted-foreground/72",
+		size === "sm" && "h-6 px-[calc(--spacing(2)-1px)] leading-6",
+		size === "lg" && "h-8 leading-8",
+		props.type === "search" &&
+			"[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none [&::-webkit-search-results-button]:appearance-none [&::-webkit-search-results-decoration]:appearance-none",
+		props.type === "file" &&
+			"text-muted-foreground file:me-3 file:bg-transparent file:font-medium file:text-foreground file:text-sm",
+	);
 
-  return (
-    <span
-      className={
-        cn(
-          !unstyled &&
-            "relative inline-flex w-full rounded-lg border border-input bg-background not-dark:bg-clip-padding text-base text-foreground shadow-xs/5 ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] not-has-disabled:not-has-focus-visible:not-has-aria-invalid:before:shadow-[0_1px_--theme(--color-black/4%)] has-focus-visible:has-aria-invalid:border-destructive/64 has-focus-visible:has-aria-invalid:ring-destructive/16 has-aria-invalid:border-destructive/36 has-focus-visible:border-ring has-autofill:bg-foreground/4 has-disabled:opacity-64 has-[:disabled,:focus-visible,[aria-invalid]]:shadow-none has-focus-visible:ring-[3px] sm:text-sm dark:bg-input/32 dark:has-autofill:bg-foreground/8 dark:has-aria-invalid:ring-destructive/24 dark:not-has-disabled:not-has-focus-visible:not-has-aria-invalid:before:shadow-[0_-1px_--theme(--color-white/6%)]",
-          className,
-        ) || undefined
-      }
-      data-size={size}
-      data-slot="input-control"
-    >
-      {nativeInput ? (
-        <input
-          className={inputClassName}
-          data-slot="input"
-          size={typeof size === "number" ? size : undefined}
-          style={typeof style === "function" ? undefined : style}
-          {...props}
-        />
-      ) : (
-        <InputPrimitive
-          className={inputClassName}
-          data-slot="input"
-          size={typeof size === "number" ? size : undefined}
-          style={style}
-          {...props}
-        />
-      )}
-    </span>
-  );
+	return (
+		<span
+			className={
+				cn(
+					!unstyled &&
+						"relative inline-flex w-full rounded-md border border-input bg-background not-dark:bg-clip-padding text-xs text-foreground shadow-none ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] has-focus-visible:has-aria-invalid:border-destructive/64 has-focus-visible:has-aria-invalid:ring-destructive/16 has-aria-invalid:border-destructive/36 has-focus-visible:border-ring has-autofill:bg-foreground/4 has-disabled:opacity-64 has-focus-visible:ring-2 dark:bg-input/32 dark:has-autofill:bg-foreground/8 dark:has-aria-invalid:ring-destructive/24",
+					className,
+				) || undefined
+			}
+			data-size={size}
+			data-slot="input-control"
+		>
+			{nativeInput ? (
+				<input
+					className={inputClassName}
+					data-slot="input"
+					size={typeof size === "number" ? size : undefined}
+					style={typeof style === "function" ? undefined : style}
+					{...props}
+				/>
+			) : (
+				<InputPrimitive
+					className={inputClassName}
+					data-slot="input"
+					size={typeof size === "number" ? size : undefined}
+					style={style}
+					{...props}
+				/>
+			)}
+		</span>
+	);
 }
 
 export { InputPrimitive };

--- a/apps/renderer/src/components/ui/menu.tsx
+++ b/apps/renderer/src/components/ui/menu.tsx
@@ -60,13 +60,13 @@ export function MenuPopup({
 			>
 				<MenuPrimitive.Popup
 					className={cn(
-						"relative flex not-[class*='w-']:min-w-32 origin-(--transform-origin) rounded-2xl bg-glass border-glass text-popover-foreground outline-none focus:outline-none",
+						"relative flex not-[class*='w-']:min-w-28 origin-(--transform-origin) rounded-lg bg-glass border-glass text-popover-foreground outline-none focus:outline-none",
 						className,
 					)}
 					data-slot="menu-popup"
 					{...props}
 				>
-					<div className="max-h-(--available-height) w-full overflow-y-auto rounded-2xl p-1.5">
+					<div className="max-h-(--available-height) w-full overflow-y-auto rounded-lg p-1">
 						{children}
 					</div>
 				</MenuPrimitive.Popup>
@@ -93,7 +93,7 @@ export function MenuItem({
 	return (
 		<MenuPrimitive.Item
 			className={cn(
-				"flex min-h-7 cursor-default select-none items-center gap-2 rounded-lg px-2 py-0.5 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-inset:ps-8 data-[variant=destructive]:text-destructive-foreground data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-6 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
+				"flex min-h-6 cursor-default select-none items-center gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-inset:ps-7 data-[variant=destructive]:text-destructive-foreground data-highlighted:text-accent-foreground data-disabled:opacity-64 [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-3.5 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
 				className,
 			)}
 			data-inset={inset}

--- a/apps/renderer/src/components/ui/select.tsx
+++ b/apps/renderer/src/components/ui/select.tsx
@@ -16,7 +16,7 @@ import { cn } from "~/lib/utils";
 export const Select: typeof SelectPrimitive.Root = SelectPrimitive.Root;
 
 export const selectTriggerVariants = cva(
-	"relative inline-flex min-h-9 w-full min-w-36 select-none items-center justify-between gap-2 rounded-lg border border-input bg-background not-dark:bg-clip-padding px-[calc(--spacing(3)-1px)] text-left text-base text-foreground shadow-xs/5 outline-none ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 focus-visible:border-ring focus-visible:ring-[3px] aria-invalid:border-destructive/36 focus-visible:aria-invalid:border-destructive/64 focus-visible:aria-invalid:ring-destructive/16 data-disabled:pointer-events-none data-disabled:opacity-64 sm:min-h-8 sm:text-sm dark:bg-input/32 dark:aria-invalid:ring-destructive/24 dark:not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 [[data-disabled],:focus-visible,[aria-invalid],[data-pressed]]:shadow-none",
+	"relative inline-flex min-h-7 w-full min-w-28 select-none items-center justify-between gap-1.5 rounded-md border border-input bg-background px-[calc(--spacing(2.5)-1px)] text-left text-xs text-foreground shadow-none outline-none ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 focus-visible:border-ring focus-visible:ring-2 aria-invalid:border-destructive/36 focus-visible:aria-invalid:border-destructive/64 focus-visible:aria-invalid:ring-destructive/16 data-disabled:pointer-events-none data-disabled:opacity-64 dark:bg-input/32 dark:aria-invalid:ring-destructive/24 [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 	{
 		defaultVariants: {
 			size: "default",
@@ -24,14 +24,14 @@ export const selectTriggerVariants = cva(
 		variants: {
 			size: {
 				default: "",
-				lg: "min-h-10 sm:min-h-9",
-				sm: "min-h-8 gap-1.5 px-[calc(--spacing(2.5)-1px)] sm:min-h-7",
+				lg: "min-h-8",
+				sm: "min-h-6 gap-1 px-[calc(--spacing(2)-1px)] text-[11px]",
 			},
 		},
 	},
 );
 
-export const selectTriggerIconClassName = "-me-1 size-4.5 opacity-80 sm:size-4";
+export const selectTriggerIconClassName = "-me-1 size-3.5 opacity-80";
 
 export interface SelectButtonProps extends useRender.ComponentProps<"button"> {
 	size?: VariantProps<typeof selectTriggerVariants>["size"];
@@ -157,10 +157,10 @@ export function SelectPopup({
 							className="relative size-4.5 sm:size-4"
 						/>
 					</SelectPrimitive.ScrollUpArrow>
-					<div className="relative h-full min-w-(--anchor-width) rounded-xl bg-glass border-glass">
+					<div className="relative h-full min-w-(--anchor-width) rounded-lg bg-glass border-glass">
 						<SelectPrimitive.List
 							className={cn(
-								"max-h-(--available-height) overflow-y-auto rounded-xl p-1.5",
+								"max-h-(--available-height) overflow-y-auto rounded-lg p-1",
 								className,
 							)}
 							data-slot="select-list"
@@ -191,7 +191,7 @@ export function SelectItem({
 	return (
 		<SelectPrimitive.Item
 			className={cn(
-				"grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-lg py-1 ps-2 pe-4 text-base outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				"grid min-h-6 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1rem)] cursor-default grid-cols-[0.875rem_1fr] items-center gap-1.5 rounded-md py-0.5 ps-1.5 pe-3 text-xs outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 [&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 				className,
 			)}
 			data-slot="select-item"

--- a/apps/renderer/src/components/ui/table.tsx
+++ b/apps/renderer/src/components/ui/table.tsx
@@ -4,135 +4,135 @@ import { cn } from "~/lib/utils";
 export type TableVariant = "default" | "card";
 
 export function Table({
-  className,
-  variant = "default",
-  ...props
+	className,
+	variant = "default",
+	...props
 }: React.ComponentProps<"table"> & {
-  variant?: TableVariant;
+	variant?: TableVariant;
 }): React.ReactElement {
-  return (
-    <div
-      className="relative w-full overflow-x-auto"
-      data-slot="table-container"
-      data-variant={variant}
-    >
-      <table
-        className={cn(
-          "w-full caption-bottom in-data-[variant=card]:border-separate in-data-[variant=card]:border-spacing-0 text-sm",
-          className,
-        )}
-        data-slot="table"
-        {...props}
-      />
-    </div>
-  );
+	return (
+		<div
+			className="relative w-full overflow-x-auto"
+			data-slot="table-container"
+			data-variant={variant}
+		>
+			<table
+				className={cn(
+					"w-full caption-bottom in-data-[variant=card]:border-separate in-data-[variant=card]:border-spacing-0 text-xs",
+					className,
+				)}
+				data-slot="table"
+				{...props}
+			/>
+		</div>
+	);
 }
 
 export function TableHeader({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<"thead">): React.ReactElement {
-  return (
-    <thead
-      className={cn("[&_tr]:border-b", className)}
-      data-slot="table-header"
-      {...props}
-    />
-  );
+	return (
+		<thead
+			className={cn("[&_tr]:border-b", className)}
+			data-slot="table-header"
+			{...props}
+		/>
+	);
 }
 
 export function TableBody({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<"tbody">): React.ReactElement {
-  return (
-    <tbody
-      className={cn(
-        "relative in-data-[variant=card]:rounded-xl in-data-[variant=card]:shadow-xs/5 before:pointer-events-none before:absolute before:inset-px not-in-data-[variant=card]:before:hidden before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/8%)] [&_tr:last-child]:border-0 in-data-[variant=card]:*:[tr]:border-0 in-data-[variant=card]:*:[tr]:*:[td]:border-b in-data-[variant=card]:*:[tr]:*:[td]:bg-card in-data-[variant=card]:*:[tr]:first:*:[td]:first:rounded-ss-xl in-data-[variant=card]:*:[tr]:*:[td]:first:border-s in-data-[variant=card]:*:[tr]:first:*:[td]:border-t in-data-[variant=card]:*:[tr]:last:*:[td]:last:rounded-ee-xl in-data-[variant=card]:*:[tr]:*:[td]:last:border-e in-data-[variant=card]:*:[tr]:first:*:[td]:last:rounded-se-xl in-data-[variant=card]:*:[tr]:last:*:[td]:first:rounded-es-xl in-data-[variant=card]:*:[tr]:hover:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-black)_2%)] in-data-[variant=card]:*:[tr]:data-[state=selected]:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-black)_4%)] dark:in-data-[variant=card]:*:[tr]:data-[state=selected]:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-white)_4%)] dark:in-data-[variant=card]:*:[tr]:hover:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-white)_2%)]",
-        className,
-      )}
-      data-slot="table-body"
-      {...props}
-    />
-  );
+	return (
+		<tbody
+			className={cn(
+				"relative in-data-[variant=card]:rounded-xl in-data-[variant=card]:shadow-xs/5 before:pointer-events-none before:absolute before:inset-px not-in-data-[variant=card]:before:hidden before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/8%)] [&_tr:last-child]:border-0 in-data-[variant=card]:*:[tr]:border-0 in-data-[variant=card]:*:[tr]:*:[td]:border-b in-data-[variant=card]:*:[tr]:*:[td]:bg-card in-data-[variant=card]:*:[tr]:first:*:[td]:first:rounded-ss-xl in-data-[variant=card]:*:[tr]:*:[td]:first:border-s in-data-[variant=card]:*:[tr]:first:*:[td]:border-t in-data-[variant=card]:*:[tr]:last:*:[td]:last:rounded-ee-xl in-data-[variant=card]:*:[tr]:*:[td]:last:border-e in-data-[variant=card]:*:[tr]:first:*:[td]:last:rounded-se-xl in-data-[variant=card]:*:[tr]:last:*:[td]:first:rounded-es-xl in-data-[variant=card]:*:[tr]:hover:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-black)_2%)] in-data-[variant=card]:*:[tr]:data-[state=selected]:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-black)_4%)] dark:in-data-[variant=card]:*:[tr]:data-[state=selected]:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-white)_4%)] dark:in-data-[variant=card]:*:[tr]:hover:*:[td]:bg-[color-mix(in_srgb,var(--card),var(--color-white)_2%)]",
+				className,
+			)}
+			data-slot="table-body"
+			{...props}
+		/>
+	);
 }
 
 export function TableFooter({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<"tfoot">): React.ReactElement {
-  return (
-    <tfoot
-      className={cn(
-        "border-t in-data-[variant=card]:border-none bg-transparent not-in-data-[variant=card]:bg-[color-mix(in_srgb,var(--card),var(--color-black)_2%)] font-medium dark:not-in-data-[variant=card]:bg-[color-mix(in_srgb,var(--card),var(--color-white)_2%)] [&>tr]:last:border-b-0",
-        className,
-      )}
-      data-slot="table-footer"
-      {...props}
-    />
-  );
+	return (
+		<tfoot
+			className={cn(
+				"border-t in-data-[variant=card]:border-none bg-transparent not-in-data-[variant=card]:bg-[color-mix(in_srgb,var(--card),var(--color-black)_2%)] font-medium dark:not-in-data-[variant=card]:bg-[color-mix(in_srgb,var(--card),var(--color-white)_2%)] [&>tr]:last:border-b-0",
+				className,
+			)}
+			data-slot="table-footer"
+			{...props}
+		/>
+	);
 }
 
 export function TableRow({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<"tr">): React.ReactElement {
-  return (
-    <tr
-      className={cn(
-        "relative border-b not-in-data-[variant=card]:hover:bg-[color-mix(in_srgb,var(--background),var(--color-black)_2%)] not-in-data-[variant=card]:data-[state=selected]:bg-[color-mix(in_srgb,var(--background),var(--color-black)_4%)] dark:not-in-data-[variant=card]:data-[state=selected]:bg-[color-mix(in_srgb,var(--background),var(--color-white)_4%)] dark:not-in-data-[variant=card]:hover:bg-[color-mix(in_srgb,var(--background),var(--color-white)_2%)]",
-        className,
-      )}
-      data-slot="table-row"
-      {...props}
-    />
-  );
+	return (
+		<tr
+			className={cn(
+				"relative border-b not-in-data-[variant=card]:hover:bg-[color-mix(in_srgb,var(--background),var(--color-black)_2%)] not-in-data-[variant=card]:data-[state=selected]:bg-[color-mix(in_srgb,var(--background),var(--color-black)_4%)] dark:not-in-data-[variant=card]:data-[state=selected]:bg-[color-mix(in_srgb,var(--background),var(--color-white)_4%)] dark:not-in-data-[variant=card]:hover:bg-[color-mix(in_srgb,var(--background),var(--color-white)_2%)]",
+				className,
+			)}
+			data-slot="table-row"
+			{...props}
+		/>
+	);
 }
 
 export function TableHead({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<"th">): React.ReactElement {
-  return (
-    <th
-      className={cn(
-        "h-10 whitespace-nowrap px-2.5 text-left align-middle font-medium text-muted-foreground leading-none has-[[role=checkbox]]:w-px last:has-[[role=checkbox]]:ps-0 first:has-[[role=checkbox]]:pe-0",
-        className,
-      )}
-      data-slot="table-head"
-      {...props}
-    />
-  );
+	return (
+		<th
+			className={cn(
+				"h-7 whitespace-nowrap px-2 text-left align-middle font-medium text-muted-foreground leading-none has-[[role=checkbox]]:w-px last:has-[[role=checkbox]]:ps-0 first:has-[[role=checkbox]]:pe-0",
+				className,
+			)}
+			data-slot="table-head"
+			{...props}
+		/>
+	);
 }
 
 export function TableCell({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<"td">): React.ReactElement {
-  return (
-    <td
-      className={cn(
-        "whitespace-nowrap bg-clip-padding p-2.5 in-data-[slot=table-footer]:py-3.5 align-middle leading-none in-data-[variant=card]:first:ps-[calc(--spacing(2.5)-1px)] in-data-[variant=card]:last:pe-[calc(--spacing(2.5)-1px)] has-[[role=checkbox]]:w-px last:has-[[role=checkbox]]:ps-0 first:has-[[role=checkbox]]:pe-0",
-        className,
-      )}
-      data-slot="table-cell"
-      {...props}
-    />
-  );
+	return (
+		<td
+			className={cn(
+				"h-7 whitespace-nowrap bg-clip-padding px-2 py-1 in-data-[slot=table-footer]:py-2 align-middle leading-none in-data-[variant=card]:first:ps-[calc(--spacing(2)-1px)] in-data-[variant=card]:last:pe-[calc(--spacing(2)-1px)] has-[[role=checkbox]]:w-px last:has-[[role=checkbox]]:ps-0 first:has-[[role=checkbox]]:pe-0",
+				className,
+			)}
+			data-slot="table-cell"
+			{...props}
+		/>
+	);
 }
 
 export function TableCaption({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<"caption">): React.ReactElement {
-  return (
-    <caption
-      className={cn(
-        "in-data-[variant=card]:my-4 mt-4 text-muted-foreground text-sm",
-        className,
-      )}
-      data-slot="table-caption"
-      {...props}
-    />
-  );
+	return (
+		<caption
+			className={cn(
+				"in-data-[variant=card]:my-4 mt-4 text-muted-foreground text-sm",
+				className,
+			)}
+			data-slot="table-caption"
+			{...props}
+		/>
+	);
 }

--- a/apps/renderer/src/components/ui/tabs.tsx
+++ b/apps/renderer/src/components/ui/tabs.tsx
@@ -7,83 +7,83 @@ import { cn } from "~/lib/utils";
 export type TabsVariant = "default" | "underline";
 
 export function Tabs({
-  className,
-  ...props
+	className,
+	...props
 }: TabsPrimitive.Root.Props): React.ReactElement {
-  return (
-    <TabsPrimitive.Root
-      className={cn(
-        "flex flex-col gap-2 data-[orientation=vertical]:flex-row",
-        className,
-      )}
-      data-slot="tabs"
-      {...props}
-    />
-  );
+	return (
+		<TabsPrimitive.Root
+			className={cn(
+				"flex flex-col gap-1.5 data-[orientation=vertical]:flex-row",
+				className,
+			)}
+			data-slot="tabs"
+			{...props}
+		/>
+	);
 }
 
 export function TabsList({
-  variant = "default",
-  className,
-  children,
-  ...props
+	variant = "default",
+	className,
+	children,
+	...props
 }: TabsPrimitive.List.Props & {
-  variant?: TabsVariant;
+	variant?: TabsVariant;
 }): React.ReactElement {
-  return (
-    <TabsPrimitive.List
-      className={cn(
-        "relative z-0 flex w-fit items-center justify-center gap-x-0.5 text-muted-foreground",
-        "data-[orientation=vertical]:flex-col",
-        variant === "default"
-          ? "rounded-lg bg-muted p-0.5 text-muted-foreground/72"
-          : "data-[orientation=vertical]:px-1 data-[orientation=horizontal]:py-1 *:data-[slot=tabs-tab]:hover:bg-accent",
-        className,
-      )}
-      data-slot="tabs-list"
-      {...props}
-    >
-      {children}
-      <TabsPrimitive.Indicator
-        className={cn(
-          "absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) transition-[width,translate] duration-200 ease-in-out",
-          variant === "underline"
-            ? "z-10 bg-primary data-[orientation=horizontal]:h-0.5 data-[orientation=vertical]:w-0.5 data-[orientation=vertical]:-translate-x-px data-[orientation=horizontal]:translate-y-px"
-            : "-z-1 rounded-md bg-background shadow-sm/5 dark:bg-input",
-        )}
-        data-slot="tab-indicator"
-      />
-    </TabsPrimitive.List>
-  );
+	return (
+		<TabsPrimitive.List
+			className={cn(
+				"relative z-0 flex w-fit items-center justify-center gap-x-0.5 text-muted-foreground",
+				"data-[orientation=vertical]:flex-col",
+				variant === "default"
+					? "rounded-md bg-muted p-0.5 text-muted-foreground/72"
+					: "data-[orientation=vertical]:px-1 data-[orientation=horizontal]:py-1 *:data-[slot=tabs-tab]:hover:bg-accent",
+				className,
+			)}
+			data-slot="tabs-list"
+			{...props}
+		>
+			{children}
+			<TabsPrimitive.Indicator
+				className={cn(
+					"absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) transition-[width,translate] duration-200 ease-in-out",
+					variant === "underline"
+						? "z-10 bg-primary data-[orientation=horizontal]:h-0.5 data-[orientation=vertical]:w-0.5 data-[orientation=vertical]:-translate-x-px data-[orientation=horizontal]:translate-y-px"
+						: "-z-1 rounded-md bg-background shadow-sm/5 dark:bg-input",
+				)}
+				data-slot="tab-indicator"
+			/>
+		</TabsPrimitive.List>
+	);
 }
 
 export function TabsTab({
-  className,
-  ...props
+	className,
+	...props
 }: TabsPrimitive.Tab.Props): React.ReactElement {
-  return (
-    <TabsPrimitive.Tab
-      className={cn(
-        "relative flex h-9 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-[calc(--spacing(2.5)-1px)] font-medium text-base outline-none transition-[color,background-color,box-shadow] hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:text-foreground data-disabled:opacity-64 sm:h-8 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
-        className,
-      )}
-      data-slot="tabs-tab"
-      {...props}
-    />
-  );
+	return (
+		<TabsPrimitive.Tab
+			className={cn(
+				"relative flex h-6 shrink-0 grow cursor-pointer items-center justify-center gap-1 whitespace-nowrap rounded-sm border border-transparent px-[calc(--spacing(2)-1px)] font-medium text-[11px] outline-none transition-[color,background-color,box-shadow] duration-150 hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:text-foreground data-disabled:opacity-64 [&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
+				className,
+			)}
+			data-slot="tabs-tab"
+			{...props}
+		/>
+	);
 }
 
 export function TabsPanel({
-  className,
-  ...props
+	className,
+	...props
 }: TabsPrimitive.Panel.Props): React.ReactElement {
-  return (
-    <TabsPrimitive.Panel
-      className={cn("flex-1 outline-none", className)}
-      data-slot="tabs-content"
-      {...props}
-    />
-  );
+	return (
+		<TabsPrimitive.Panel
+			className={cn("flex-1 outline-none", className)}
+			data-slot="tabs-content"
+			{...props}
+		/>
+	);
 }
 
-export { TabsPrimitive, TabsTab as TabsTrigger, TabsPanel as TabsContent };
+export { TabsPanel as TabsContent, TabsPrimitive, TabsTab as TabsTrigger };

--- a/apps/renderer/src/components/ui/textarea.tsx
+++ b/apps/renderer/src/components/ui/textarea.tsx
@@ -6,53 +6,51 @@ import type * as React from "react";
 import { cn } from "~/lib/utils";
 
 export type TextareaProps = React.ComponentPropsWithoutRef<"textarea"> &
-  React.RefAttributes<HTMLTextAreaElement> & {
-    size?: "sm" | "default" | "lg" | number;
-    unstyled?: boolean;
-  };
+	React.RefAttributes<HTMLTextAreaElement> & {
+		size?: "sm" | "default" | "lg" | number;
+		unstyled?: boolean;
+	};
 
 export function Textarea({
-  className,
-  size = "default",
-  unstyled = false,
-  ref,
-  ...props
+	className,
+	size = "default",
+	unstyled = false,
+	ref,
+	...props
 }: TextareaProps): React.ReactElement {
-  return (
-    <span
-      className={
-        cn(
-          !unstyled &&
-            "relative inline-flex w-full rounded-lg border border-input bg-background not-dark:bg-clip-padding text-base text-foreground shadow-xs/5 ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] has-focus-visible:has-aria-invalid:border-destructive/64 has-focus-visible:has-aria-invalid:ring-destructive/16 has-aria-invalid:border-destructive/36 has-focus-visible:border-ring has-disabled:opacity-64 has-[:disabled,:focus-visible,[aria-invalid]]:shadow-none has-focus-visible:ring-[3px] not-has-disabled:has-not-focus-visible:not-has-aria-invalid:before:shadow-[0_1px_--theme(--color-black/4%)] sm:text-sm dark:bg-input/32 dark:has-aria-invalid:ring-destructive/24 dark:not-has-disabled:has-not-focus-visible:not-has-aria-invalid:before:shadow-[0_-1px_--theme(--color-white/6%)]",
-          className,
-        ) || undefined
-      }
-      data-size={size}
-      data-slot="textarea-control"
-    >
-      <FieldPrimitive.Control
-        ref={ref}
-        value={props.value}
-        defaultValue={props.defaultValue}
-        disabled={props.disabled}
-        id={props.id}
-        name={props.name}
-        render={(defaultProps: React.ComponentProps<"textarea">) => (
-          <textarea
-            className={cn(
-              "field-sizing-content min-h-17.5 w-full rounded-[inherit] px-[calc(--spacing(3)-1px)] py-[calc(--spacing(1.5)-1px)] outline-none max-sm:min-h-20.5",
-              size === "sm" &&
-                "min-h-16.5 px-[calc(--spacing(2.5)-1px)] py-[calc(--spacing(1)-1px)] max-sm:min-h-19.5",
-              size === "lg" &&
-                "min-h-18.5 py-[calc(--spacing(2)-1px)] max-sm:min-h-21.5",
-            )}
-            data-slot="textarea"
-            {...mergeProps(defaultProps, props)}
-          />
-        )}
-      />
-    </span>
-  );
+	return (
+		<span
+			className={
+				cn(
+					!unstyled &&
+						"relative inline-flex w-full rounded-md border border-input bg-background text-xs text-foreground shadow-none ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] has-focus-visible:has-aria-invalid:border-destructive/64 has-focus-visible:has-aria-invalid:ring-destructive/16 has-aria-invalid:border-destructive/36 has-focus-visible:border-ring has-disabled:opacity-64 has-focus-visible:ring-2 dark:bg-input/32 dark:has-aria-invalid:ring-destructive/24",
+					className,
+				) || undefined
+			}
+			data-size={size}
+			data-slot="textarea-control"
+		>
+			<FieldPrimitive.Control
+				ref={ref}
+				value={props.value}
+				defaultValue={props.defaultValue}
+				disabled={props.disabled}
+				id={props.id}
+				name={props.name}
+				render={(defaultProps: React.ComponentProps<"textarea">) => (
+					<textarea
+						className={cn(
+							"field-sizing-content min-h-14 w-full rounded-[inherit] px-[calc(--spacing(2.5)-1px)] py-1.5 outline-none",
+							size === "sm" && "min-h-12 px-[calc(--spacing(2)-1px)] py-1",
+							size === "lg" && "min-h-16 py-2",
+						)}
+						data-slot="textarea"
+						{...mergeProps(defaultProps, props)}
+					/>
+				)}
+			/>
+		</span>
+	);
 }
 
 export { FieldPrimitive };

--- a/apps/renderer/src/components/ui/toast.tsx
+++ b/apps/renderer/src/components/ui/toast.tsx
@@ -88,7 +88,7 @@ function Toasts({
 						<Toast.Root
 							key={toast.id}
 							className={cn(
-								"absolute z-[calc(9999-var(--toast-index))] h-(--toast-calc-height) w-full select-none rounded-lg border bg-[color-mix(in_srgb,var(--popover),var(--color-black)_calc(1%*max(0,var(--toast-index,0))))] not-dark:bg-clip-padding text-popover-foreground shadow-lg/5 [transition:transform_.5s_cubic-bezier(.22,1,.36,1),opacity_.5s,height_.15s,background-color_.5s] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-expanded:bg-popover dark:bg-[color-mix(in_srgb,var(--popover),var(--color-black)_calc(6%*max(0,var(--toast-index,0))))] dark:data-expanded:bg-popover dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+								"absolute z-[calc(9999-var(--toast-index))] h-(--toast-calc-height) w-full select-none rounded-lg border bg-[color-mix(in_srgb,var(--popover),var(--color-black)_calc(1%*max(0,var(--toast-index,0))))] not-dark:bg-clip-padding text-popover-foreground shadow-lg/5 [transition:transform_180ms_cubic-bezier(.165,.84,.44,1),opacity_140ms_ease-in,height_140ms_ease-out,background-color_150ms_ease] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-expanded:bg-popover motion-reduce:[transition-duration:80ms] dark:bg-[color-mix(in_srgb,var(--popover),var(--color-black)_calc(6%*max(0,var(--toast-index,0))))] dark:data-expanded:bg-popover dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
 								// Base positioning using data-position
 								"data-[position*=right]:right-0 data-[position*=right]:left-auto",
 								"data-[position*=left]:right-auto data-[position*=left]:left-0",
@@ -133,7 +133,7 @@ function Toasts({
 							swipeDirection={swipeDirection}
 							toast={toast}
 						>
-							<Toast.Content className="pointer-events-auto flex items-center justify-between gap-1.5 overflow-hidden px-3.5 py-3 text-sm transition-opacity duration-250 data-behind:not-data-expanded:pointer-events-none data-behind:opacity-0 data-expanded:opacity-100">
+							<Toast.Content className="pointer-events-auto flex items-center justify-between gap-1.5 overflow-hidden px-3 py-2.5 text-xs transition-opacity duration-150 data-behind:not-data-expanded:pointer-events-none data-behind:opacity-0 data-expanded:opacity-100">
 								<div className="flex gap-2">
 									{Icon && (
 										<div
@@ -168,7 +168,7 @@ function Toasts({
 								)}
 								<Toast.Close
 									aria-label="Dismiss notification"
-									className="-my-2 -mr-2 flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-offset-2 transition-colors duration-150 ease-out hover:text-foreground focus-visible:outline-2 focus-visible:outline-foreground/60"
+									className="-my-2 -mr-2 flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-offset-2 transition-colors duration-150 ease-out pointer-coarse:min-h-11 pointer-coarse:min-w-11 hover:text-foreground focus-visible:outline-2 focus-visible:outline-foreground/60"
 									data-slot="toast-close"
 								>
 									<HugeiconsIcon

--- a/apps/renderer/src/components/update-banner.tsx
+++ b/apps/renderer/src/components/update-banner.tsx
@@ -122,26 +122,26 @@ export function UpdateBanner() {
 		<div
 			role="status"
 			className={cn(
-				"fixed right-4 bottom-4 z-50 flex w-[320px] flex-col gap-3 p-4",
+				"compact-notification fixed right-3 bottom-3 z-50 flex w-[288px] flex-col gap-2.5 p-3",
 				overlaySurface,
 			)}
 		>
-			<div className="flex items-start gap-3">
-				<span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
+			<div className="flex items-start gap-2">
+				<span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-foreground">
 					<HugeiconsIcon
 						icon={isError ? Alert01Icon : CircleArrowUp01Icon}
-						className="size-4"
+						className="size-3.5"
 					/>
 				</span>
 				<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-					<span className="text-[13px] font-medium text-foreground">
+					<span className="text-xs font-medium text-foreground">
 						{isError
 							? "Update failed"
 							: confirming
 								? "Agents are running"
 								: "Update available"}
 					</span>
-					<span className="text-[12px] leading-snug text-muted-foreground">
+					<span className="text-[11px] leading-snug text-muted-foreground">
 						{isError && status.message}
 						{status.kind === "ready" &&
 							!confirming &&

--- a/apps/renderer/src/lib/codemirror/composer-theme.ts
+++ b/apps/renderer/src/lib/codemirror/composer-theme.ts
@@ -12,7 +12,7 @@ export const composerTheme: Extension = EditorView.theme(
     "&": {
       backgroundColor: "transparent",
       color: "inherit",
-      fontSize: "13px",
+      fontSize: "12px",
     },
     "&.cm-focused": {
       outline: "none",
@@ -20,11 +20,11 @@ export const composerTheme: Extension = EditorView.theme(
     ".cm-scroller": {
       fontFamily:
         "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif",
-      lineHeight: "1.55",
+      lineHeight: "1.5",
       overflowX: "hidden",
     },
     ".cm-content": {
-      padding: "8px 4px",
+      padding: "7px 4px",
       caretColor: "currentColor",
     },
     ".cm-line": {

--- a/apps/renderer/src/lib/terminal-registry.ts
+++ b/apps/renderer/src/lib/terminal-registry.ts
@@ -504,9 +504,9 @@ function makeLive(
   const term = new Terminal({
     fontFamily:
       '"SF Mono", "JetBrains Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
-    fontSize: 13,
+    fontSize: 11,
     fontWeight: "400",
-    lineHeight: 1.24,
+    lineHeight: 1.2,
     letterSpacing: 0,
     cursorBlink: true,
     cursorStyle: "bar",

--- a/apps/renderer/src/store/settings.ts
+++ b/apps/renderer/src/store/settings.ts
@@ -35,43 +35,43 @@ const DEFAULT_AUTONOMY_LEVEL: AutonomyLevel = "approval-gated";
 const DEFAULT_BRANCH_NAMING_STYLE: BranchNamingStyle = "username-slug";
 
 const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
-  "claude",
-  "codex",
-  "grok",
-  "cursor",
-  "gemini",
-  "opencode",
+	"claude",
+	"codex",
+	"grok",
+	"cursor",
+	"gemini",
+	"opencode",
 ];
 
 const seedModels = (): Record<ProviderId, string> => ({
-  claude: defaultModelFor("claude"),
-  codex: defaultModelFor("codex"),
-  grok: defaultModelFor("grok"),
-  cursor: defaultModelFor("cursor"),
-  gemini: defaultModelFor("gemini"),
-  opencode: defaultModelFor("opencode"),
+	claude: defaultModelFor("claude"),
+	codex: defaultModelFor("codex"),
+	grok: defaultModelFor("grok"),
+	cursor: defaultModelFor("cursor"),
+	gemini: defaultModelFor("gemini"),
+	opencode: defaultModelFor("opencode"),
 });
 
 const seedProviderEnabled = (): Record<ProviderId, boolean> => {
-  const out = {} as Record<ProviderId, boolean>;
-  for (const id of PROVIDER_IDS) out[id] = true;
-  return out;
+	const out = {} as Record<ProviderId, boolean>;
+	for (const id of PROVIDER_IDS) out[id] = true;
+	return out;
 };
 
 const seedModelEnabledByProvider = defaultModelEnabledByProvider;
 
 const mergeModelEnabled = (
-  input: Partial<Record<ProviderId, Partial<Record<string, boolean>>>>,
+	input: Partial<Record<ProviderId, Partial<Record<string, boolean>>>>,
 ): ModelEnabledByProvider => {
-  const base = seedModelEnabledByProvider();
-  for (const id of PROVIDER_IDS) {
-    const providerFlags = input[id];
-    if (providerFlags === undefined) continue;
-    for (const [modelId, value] of Object.entries(providerFlags)) {
-      if (typeof value === "boolean") base[id][modelId] = value;
-    }
-  }
-  return base;
+	const base = seedModelEnabledByProvider();
+	for (const id of PROVIDER_IDS) {
+		const providerFlags = input[id];
+		if (providerFlags === undefined) continue;
+		for (const [modelId, value] of Object.entries(providerFlags)) {
+			if (typeof value === "boolean") base[id][modelId] = value;
+		}
+	}
+	return base;
 };
 
 const OLD_SETTINGS_KEY = "memoize.settings.v1";
@@ -80,158 +80,154 @@ const MERGE_PREFS_KEY = "zuse.mergePrefs.v1";
 const OLD_MERGE_PREFS_KEYS = ["memoize.mergePrefs.v1"] as const;
 
 const fallbackSnapshot = (): SettingsSlice => ({
-  defaultProviderId: DEFAULT_PROVIDER,
-  defaultModelByProvider: seedModels(),
-  defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
-  defaultAutoCreateWorktree: true,
+	defaultProviderId: DEFAULT_PROVIDER,
+	defaultModelByProvider: seedModels(),
+	defaultRuntimeMode: DEFAULT_RUNTIME_MODE,
+	defaultAutoCreateWorktree: true,
 	defaultAutonomyLevel: DEFAULT_AUTONOMY_LEVEL,
 	completionSoundEnabled: false,
 	completionSoundPreset: "chime",
-	analyticsEnabled: true,
 	appearanceMode: "dark",
 	onboardingCompleted: false,
 	providerEnabled: seedProviderEnabled(),
-  modelEnabledByProvider: seedModelEnabledByProvider(),
-  opencodeProviderVisible: {},
-  opencodeModelVisibleByProvider: {},
-  opencodeCustomProviders: [],
-  branchNamingStyle: DEFAULT_BRANCH_NAMING_STYLE,
-  branchNamingPrefix: "",
-  mergePrefs: { method: "merge", deleteBranch: false },
-  notchTrayEnabled: false,
-  notchTrayPinned: false,
+	modelEnabledByProvider: seedModelEnabledByProvider(),
+	opencodeProviderVisible: {},
+	opencodeModelVisibleByProvider: {},
+	opencodeCustomProviders: [],
+	branchNamingStyle: DEFAULT_BRANCH_NAMING_STYLE,
+	branchNamingPrefix: "",
+	mergePrefs: { method: "merge", deleteBranch: false },
+	notchTrayEnabled: false,
+	notchTrayPinned: false,
 });
 
 const sliceFromFile = (file: SettingsFile): SettingsSlice => {
-  const models: Record<ProviderId, string> = {
-    ...seedModels(),
-    ...file.defaultModelByProvider,
-  };
-  // Re-run resolveModelSlug on every emit so a stale alias doesn't sneak
-  // back through a follow-up edit to the JSON file.
-  for (const id of Object.keys(models) as ProviderId[]) {
-    models[id] = resolveModelSlug(id, models[id]);
-  }
-  return {
-    defaultProviderId: file.defaultProviderId,
-    defaultModelByProvider: models,
-    defaultRuntimeMode: file.defaultRuntimeMode,
-    defaultAutoCreateWorktree: file.defaultAutoCreateWorktree,
+	const models: Record<ProviderId, string> = {
+		...seedModels(),
+		...file.defaultModelByProvider,
+	};
+	// Re-run resolveModelSlug on every emit so a stale alias doesn't sneak
+	// back through a follow-up edit to the JSON file.
+	for (const id of Object.keys(models) as ProviderId[]) {
+		models[id] = resolveModelSlug(id, models[id]);
+	}
+	return {
+		defaultProviderId: file.defaultProviderId,
+		defaultModelByProvider: models,
+		defaultRuntimeMode: file.defaultRuntimeMode,
+		defaultAutoCreateWorktree: file.defaultAutoCreateWorktree,
 		defaultAutonomyLevel: file.defaultAutonomyLevel,
 		completionSoundEnabled: file.completionSoundEnabled,
 		completionSoundPreset: file.completionSoundPreset,
-		analyticsEnabled: file.analyticsEnabled,
 		appearanceMode: file.appearanceMode,
 		onboardingCompleted: file.onboardingCompleted,
 		providerEnabled: {
-      ...seedProviderEnabled(),
-      ...file.providerEnabled,
-    },
-    modelEnabledByProvider: mergeModelEnabled(file.modelEnabledByProvider),
-    opencodeProviderVisible: { ...file.opencodeProviderVisible },
-    opencodeModelVisibleByProvider: Object.fromEntries(
-      Object.entries(file.opencodeModelVisibleByProvider).map(([k, v]) => [
-        k,
-        { ...v },
-      ]),
-    ),
-    opencodeCustomProviders: file.opencodeCustomProviders.map((p) => ({
-      ...p,
-      models: p.models.map((m) => ({ ...m })),
-    })),
-    branchNamingStyle: file.branchNamingStyle,
-    branchNamingPrefix: file.branchNamingPrefix,
-    mergePrefs: file.mergePrefs,
-    notchTrayEnabled: file.notchTrayEnabled,
-    notchTrayPinned: file.notchTrayPinned,
-  };
+			...seedProviderEnabled(),
+			...file.providerEnabled,
+		},
+		modelEnabledByProvider: mergeModelEnabled(file.modelEnabledByProvider),
+		opencodeProviderVisible: { ...file.opencodeProviderVisible },
+		opencodeModelVisibleByProvider: Object.fromEntries(
+			Object.entries(file.opencodeModelVisibleByProvider).map(([k, v]) => [
+				k,
+				{ ...v },
+			]),
+		),
+		opencodeCustomProviders: file.opencodeCustomProviders.map((p) => ({
+			...p,
+			models: p.models.map((m) => ({ ...m })),
+		})),
+		branchNamingStyle: file.branchNamingStyle,
+		branchNamingPrefix: file.branchNamingPrefix,
+		mergePrefs: file.mergePrefs,
+		notchTrayEnabled: file.notchTrayEnabled,
+		notchTrayPinned: file.notchTrayPinned,
+	};
 };
 
 interface SettingsSlice {
-  readonly defaultProviderId: ProviderId;
-  readonly defaultModelByProvider: Record<ProviderId, string>;
-  readonly defaultRuntimeMode: RuntimeMode;
-  readonly defaultAutoCreateWorktree: boolean;
+	readonly defaultProviderId: ProviderId;
+	readonly defaultModelByProvider: Record<ProviderId, string>;
+	readonly defaultRuntimeMode: RuntimeMode;
+	readonly defaultAutoCreateWorktree: boolean;
 	readonly defaultAutonomyLevel: AutonomyLevel;
 	readonly completionSoundEnabled: boolean;
 	readonly completionSoundPreset: CompletionSoundPreset;
-	readonly analyticsEnabled: boolean;
 	readonly appearanceMode: AppearanceMode;
 	readonly onboardingCompleted: boolean;
 	readonly providerEnabled: Record<ProviderId, boolean>;
-  readonly modelEnabledByProvider: ModelEnabledByProvider;
-  /** OpenCode sub-provider visibility in the model picker (id → shown). */
-  readonly opencodeProviderVisible: Record<string, boolean>;
-  /** OpenCode per-sub-provider model visibility (providerId → modelId → shown). */
-  readonly opencodeModelVisibleByProvider: Record<
-    string,
-    Record<string, boolean>
-  >;
-  readonly opencodeCustomProviders: ReadonlyArray<OpencodeCustomProvider>;
-  readonly branchNamingStyle: BranchNamingStyle;
-  readonly branchNamingPrefix: string;
-  readonly mergePrefs: { method: GitMergeMethod; deleteBranch: boolean };
-  readonly notchTrayEnabled: boolean;
-  readonly notchTrayPinned: boolean;
+	readonly modelEnabledByProvider: ModelEnabledByProvider;
+	/** OpenCode sub-provider visibility in the model picker (id → shown). */
+	readonly opencodeProviderVisible: Record<string, boolean>;
+	/** OpenCode per-sub-provider model visibility (providerId → modelId → shown). */
+	readonly opencodeModelVisibleByProvider: Record<
+		string,
+		Record<string, boolean>
+	>;
+	readonly opencodeCustomProviders: ReadonlyArray<OpencodeCustomProvider>;
+	readonly branchNamingStyle: BranchNamingStyle;
+	readonly branchNamingPrefix: string;
+	readonly mergePrefs: { method: GitMergeMethod; deleteBranch: boolean };
+	readonly notchTrayEnabled: boolean;
+	readonly notchTrayPinned: boolean;
 }
 
 type SettingsState = SettingsSlice & {
-  /** True once the first RPC fetch has resolved. Used by gates that need
-   *  to wait before reading defaults (e.g. onboarding). */
-  readonly loaded: boolean;
-  readonly hydrate: () => Promise<void>;
-  readonly setDefaultProvider: (providerId: ProviderId) => void;
-  readonly setDefaultModel: (providerId: ProviderId, model: string) => void;
-  /**
-   * Set both the default provider and that provider's default model in one
-   * patch. The model picker treats picking a model as a single user action;
-   * sending two separate RPCs raced on the server's atomic-write tmp file.
-   */
-  readonly setDefaultProviderAndModel: (
-    providerId: ProviderId,
-    model: string,
-  ) => void;
-  readonly setDefaultRuntimeMode: (mode: RuntimeMode) => void;
-  readonly setDefaultAutoCreateWorktree: (value: boolean) => void;
+	/** True once the first RPC fetch has resolved. Used by gates that need
+	 *  to wait before reading defaults (e.g. onboarding). */
+	readonly loaded: boolean;
+	readonly hydrate: () => Promise<void>;
+	readonly setDefaultProvider: (providerId: ProviderId) => void;
+	readonly setDefaultModel: (providerId: ProviderId, model: string) => void;
+	/**
+	 * Set both the default provider and that provider's default model in one
+	 * patch. The model picker treats picking a model as a single user action;
+	 * sending two separate RPCs raced on the server's atomic-write tmp file.
+	 */
+	readonly setDefaultProviderAndModel: (
+		providerId: ProviderId,
+		model: string,
+	) => void;
+	readonly setDefaultRuntimeMode: (mode: RuntimeMode) => void;
+	readonly setDefaultAutoCreateWorktree: (value: boolean) => void;
 	readonly setDefaultAutonomyLevel: (level: AutonomyLevel) => void;
 	readonly setCompletionSoundEnabled: (value: boolean) => void;
 	readonly setCompletionSoundPreset: (preset: CompletionSoundPreset) => void;
-	readonly setAnalyticsEnabled: (value: boolean) => void;
 	readonly setAppearanceMode: (mode: AppearanceMode) => void;
 	readonly setOnboardingCompleted: (value: boolean) => void;
 	readonly setProviderEnabled: (providerId: ProviderId, value: boolean) => void;
-  readonly setModelEnabled: (
-    providerId: ProviderId,
-    modelId: string,
-    value: boolean,
-  ) => void;
-  readonly setOpencodeProviderVisible: (
-    providerId: string,
-    value: boolean,
-  ) => void;
-  readonly setOpencodeModelVisible: (
-    providerId: string,
-    modelId: string,
-    value: boolean,
-  ) => void;
-  readonly setBranchNamingStyle: (style: BranchNamingStyle) => void;
-  readonly setBranchNamingPrefix: (prefix: string) => void;
-  readonly setMergePrefs: (prefs: {
-    method: GitMergeMethod;
-    deleteBranch: boolean;
-  }) => void;
-  readonly setNotchTrayEnabled: (value: boolean) => void;
-  readonly setNotchTrayPinned: (value: boolean) => void;
+	readonly setModelEnabled: (
+		providerId: ProviderId,
+		modelId: string,
+		value: boolean,
+	) => void;
+	readonly setOpencodeProviderVisible: (
+		providerId: string,
+		value: boolean,
+	) => void;
+	readonly setOpencodeModelVisible: (
+		providerId: string,
+		modelId: string,
+		value: boolean,
+	) => void;
+	readonly setBranchNamingStyle: (style: BranchNamingStyle) => void;
+	readonly setBranchNamingPrefix: (prefix: string) => void;
+	readonly setMergePrefs: (prefs: {
+		method: GitMergeMethod;
+		deleteBranch: boolean;
+	}) => void;
+	readonly setNotchTrayEnabled: (value: boolean) => void;
+	readonly setNotchTrayPinned: (value: boolean) => void;
 };
 
 let streamFiber: Fiber.Fiber<unknown, unknown> | null = null;
 
 const stopStream = async () => {
-  if (streamFiber !== null) {
-    const f = streamFiber;
-    streamFiber = null;
-    await Effect.runPromise(Fiber.interrupt(f));
-  }
+	if (streamFiber !== null) {
+		const f = streamFiber;
+		streamFiber = null;
+		await Effect.runPromise(Fiber.interrupt(f));
+	}
 };
 
 /**
@@ -242,300 +238,292 @@ const stopStream = async () => {
  * localStorage afterwards so the renderer doesn't carry stale data.
  */
 const migrateLocalStorageOnce = async (): Promise<SettingsFile | null> => {
-  if (typeof window === "undefined") return null;
-  const settingsV1Raw = window.localStorage.getItem(OLD_SETTINGS_KEY);
-  const subagentsRaw = window.localStorage.getItem(OLD_SUBAGENTS_KEY);
-  if (settingsV1Raw === null && subagentsRaw === null) return null;
-  try {
-    const client = await getRpcClient();
-    const file = await Effect.runPromise(
-      client["settings.migrateLocalStorage"]({
-        settingsV1Raw: settingsV1Raw ?? undefined,
-        subagentsRaw: subagentsRaw ?? undefined,
-      }),
-    );
-    window.localStorage.removeItem(OLD_SETTINGS_KEY);
-    window.localStorage.removeItem(OLD_SUBAGENTS_KEY);
-    return file;
-  } catch {
-    // If the RPC fails (rare — main is up by now), leave localStorage in
-    // place so the next reload can retry. The store falls back to defaults.
-    return null;
-  }
+	if (typeof window === "undefined") return null;
+	const settingsV1Raw = window.localStorage.getItem(OLD_SETTINGS_KEY);
+	const subagentsRaw = window.localStorage.getItem(OLD_SUBAGENTS_KEY);
+	if (settingsV1Raw === null && subagentsRaw === null) return null;
+	try {
+		const client = await getRpcClient();
+		const file = await Effect.runPromise(
+			client["settings.migrateLocalStorage"]({
+				settingsV1Raw: settingsV1Raw ?? undefined,
+				subagentsRaw: subagentsRaw ?? undefined,
+			}),
+		);
+		window.localStorage.removeItem(OLD_SETTINGS_KEY);
+		window.localStorage.removeItem(OLD_SUBAGENTS_KEY);
+		return file;
+	} catch {
+		// If the RPC fails (rare — main is up by now), leave localStorage in
+		// place so the next reload can retry. The store falls back to defaults.
+		return null;
+	}
 };
 
 const migrateMergePrefsOnce = async (
-  file: SettingsFile,
+	file: SettingsFile,
 ): Promise<SettingsFile> => {
-  if (typeof window === "undefined") return file;
-  const raw = readStorageWithLegacy(
-    window.localStorage,
-    MERGE_PREFS_KEY,
-    OLD_MERGE_PREFS_KEYS,
-  );
-  if (raw === null) return file;
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const method =
-      parsed.method === "merge" ||
-      parsed.method === "squash" ||
-      parsed.method === "rebase"
-        ? parsed.method
-        : file.mergePrefs.method;
-    const mergePrefs = {
-      method,
-      deleteBranch:
-        typeof parsed.deleteBranch === "boolean"
-          ? parsed.deleteBranch
-          : file.mergePrefs.deleteBranch,
-    };
-    const client = await getRpcClient();
-    const next = await Effect.runPromise(
-      client["settings.update"]({ patch: { mergePrefs } }),
-    );
-    removeStorageKeys(
-      window.localStorage,
-      MERGE_PREFS_KEY,
-      OLD_MERGE_PREFS_KEYS,
-    );
-    return next;
-  } catch {
-    return file;
-  }
+	if (typeof window === "undefined") return file;
+	const raw = readStorageWithLegacy(
+		window.localStorage,
+		MERGE_PREFS_KEY,
+		OLD_MERGE_PREFS_KEYS,
+	);
+	if (raw === null) return file;
+	try {
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		const method =
+			parsed.method === "merge" ||
+			parsed.method === "squash" ||
+			parsed.method === "rebase"
+				? parsed.method
+				: file.mergePrefs.method;
+		const mergePrefs = {
+			method,
+			deleteBranch:
+				typeof parsed.deleteBranch === "boolean"
+					? parsed.deleteBranch
+					: file.mergePrefs.deleteBranch,
+		};
+		const client = await getRpcClient();
+		const next = await Effect.runPromise(
+			client["settings.update"]({ patch: { mergePrefs } }),
+		);
+		removeStorageKeys(
+			window.localStorage,
+			MERGE_PREFS_KEY,
+			OLD_MERGE_PREFS_KEYS,
+		);
+		return next;
+	} catch {
+		return file;
+	}
 };
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
-  ...fallbackSnapshot(),
-  loaded: false,
+	...fallbackSnapshot(),
+	loaded: false,
 
-  hydrate: async () => {
-    // Drain any pre-existing localStorage first so a successful migration
-    // is visible on the very first `settings.get` we do below.
-    await migrateLocalStorageOnce();
+	hydrate: async () => {
+		// Drain any pre-existing localStorage first so a successful migration
+		// is visible on the very first `settings.get` we do below.
+		await migrateLocalStorageOnce();
 
-    try {
-      const client = await getRpcClient();
-      const file = await migrateMergePrefsOnce(
-        await Effect.runPromise(client["settings.get"]()),
-      );
-      set({ ...sliceFromFile(file), loaded: true });
+		try {
+			const client = await getRpcClient();
+			const file = await migrateMergePrefsOnce(
+				await Effect.runPromise(client["settings.get"]()),
+			);
+			set({ ...sliceFromFile(file), loaded: true });
 
-      await stopStream();
-      streamFiber = Effect.runFork(
-        Stream.runForEach(client["settings.stream"](), (next) =>
-          Effect.sync(() => set(sliceFromFile(next))),
-        ),
-      );
-    } catch {
-      set({ loaded: true });
-    }
-  },
+			await stopStream();
+			streamFiber = Effect.runFork(
+				Stream.runForEach(client["settings.stream"](), (next) =>
+					Effect.sync(() => set(sliceFromFile(next))),
+				),
+			);
+		} catch {
+			set({ loaded: true });
+		}
+	},
 
-  setDefaultProvider: (providerId) => {
-    set({ defaultProviderId: providerId });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { defaultProviderId: providerId } }),
-      );
-    })();
-  },
-  setDefaultModel: (providerId, model) => {
-    const next = { ...get().defaultModelByProvider, [providerId]: model };
-    set({ defaultModelByProvider: next });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { defaultModelByProvider: next } }),
-      );
-    })();
-  },
-  setDefaultProviderAndModel: (providerId, model) => {
-    const next = { ...get().defaultModelByProvider, [providerId]: model };
-    set({ defaultProviderId: providerId, defaultModelByProvider: next });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({
-          patch: {
-            defaultProviderId: providerId,
-            defaultModelByProvider: next,
-          },
-        }),
-      );
-    })();
-  },
-  setDefaultRuntimeMode: (mode) => {
-    set({ defaultRuntimeMode: mode });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { defaultRuntimeMode: mode } }),
-      );
-    })();
-  },
-  setDefaultAutoCreateWorktree: (value) => {
-    set({ defaultAutoCreateWorktree: value });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({
-          patch: { defaultAutoCreateWorktree: value },
-        }),
-      );
-    })();
-  },
-  setDefaultAutonomyLevel: (level) => {
-    set({ defaultAutonomyLevel: level });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({
-          patch: { defaultAutonomyLevel: level },
-        }),
-      );
-    })();
-  },
-  setCompletionSoundEnabled: (value) => {
-    set({ completionSoundEnabled: value });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { completionSoundEnabled: value } }),
-      );
-    })();
-  },
-  setCompletionSoundPreset: (preset) => {
-    set({ completionSoundPreset: preset });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { completionSoundPreset: preset } }),
+	setDefaultProvider: (providerId) => {
+		set({ defaultProviderId: providerId });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { defaultProviderId: providerId } }),
 			);
 		})();
 	},
-	setAnalyticsEnabled: (value) => {
-		set({ analyticsEnabled: value });
-		void getRpcClient().then((client) =>
-			Effect.runPromise(
-				client["settings.update"]({ patch: { analyticsEnabled: value } }),
-			),
-		);
+	setDefaultModel: (providerId, model) => {
+		const next = { ...get().defaultModelByProvider, [providerId]: model };
+		set({ defaultModelByProvider: next });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { defaultModelByProvider: next } }),
+			);
+		})();
+	},
+	setDefaultProviderAndModel: (providerId, model) => {
+		const next = { ...get().defaultModelByProvider, [providerId]: model };
+		set({ defaultProviderId: providerId, defaultModelByProvider: next });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({
+					patch: {
+						defaultProviderId: providerId,
+						defaultModelByProvider: next,
+					},
+				}),
+			);
+		})();
+	},
+	setDefaultRuntimeMode: (mode) => {
+		set({ defaultRuntimeMode: mode });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { defaultRuntimeMode: mode } }),
+			);
+		})();
+	},
+	setDefaultAutoCreateWorktree: (value) => {
+		set({ defaultAutoCreateWorktree: value });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({
+					patch: { defaultAutoCreateWorktree: value },
+				}),
+			);
+		})();
+	},
+	setDefaultAutonomyLevel: (level) => {
+		set({ defaultAutonomyLevel: level });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({
+					patch: { defaultAutonomyLevel: level },
+				}),
+			);
+		})();
+	},
+	setCompletionSoundEnabled: (value) => {
+		set({ completionSoundEnabled: value });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { completionSoundEnabled: value } }),
+			);
+		})();
+	},
+	setCompletionSoundPreset: (preset) => {
+		set({ completionSoundPreset: preset });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { completionSoundPreset: preset } }),
+			);
+		})();
 	},
 	setAppearanceMode: (mode) => {
 		set({ appearanceMode: mode });
 		void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { appearanceMode: mode } }),
-      );
-    })();
-  },
-  setOnboardingCompleted: (value) => {
-    set({ onboardingCompleted: value });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { onboardingCompleted: value } }),
-      );
-    })();
-  },
-  setProviderEnabled: (providerId, value) => {
-    const next = { ...get().providerEnabled, [providerId]: value };
-    set({ providerEnabled: next });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { providerEnabled: next } }),
-      );
-    })();
-  },
-  setModelEnabled: (providerId, modelId, value) => {
-    const current = get().modelEnabledByProvider;
-    const next: ModelEnabledByProvider = {
-      ...current,
-      [providerId]: {
-        ...current[providerId],
-        [modelId]: value,
-      },
-    };
-    set({ modelEnabledByProvider: next });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { modelEnabledByProvider: next } }),
-      );
-    })();
-  },
-  setOpencodeProviderVisible: (providerId, value) => {
-    const next = { ...get().opencodeProviderVisible, [providerId]: value };
-    set({ opencodeProviderVisible: next });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { opencodeProviderVisible: next } }),
-      );
-    })();
-  },
-  setOpencodeModelVisible: (providerId, modelId, value) => {
-    const current = get().opencodeModelVisibleByProvider;
-    const next: Record<string, Record<string, boolean>> = {
-      ...current,
-      [providerId]: { ...current[providerId], [modelId]: value },
-    };
-    set({ opencodeModelVisibleByProvider: next });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({
-          patch: { opencodeModelVisibleByProvider: next },
-        }),
-      );
-    })();
-  },
-  setBranchNamingStyle: (style) => {
-    set({ branchNamingStyle: style });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { branchNamingStyle: style } }),
-      );
-    })();
-  },
-  setBranchNamingPrefix: (prefix) => {
-    set({ branchNamingPrefix: prefix });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { branchNamingPrefix: prefix } }),
-      );
-    })();
-  },
-  setMergePrefs: (mergePrefs) => {
-    set({ mergePrefs });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { mergePrefs } }),
-      );
-    })();
-  },
-  setNotchTrayEnabled: (value) => {
-    set({ notchTrayEnabled: value });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { notchTrayEnabled: value } }),
-      );
-    })();
-  },
-  setNotchTrayPinned: (value) => {
-    set({ notchTrayPinned: value });
-    void (async () => {
-      const client = await getRpcClient();
-      await Effect.runPromise(
-        client["settings.update"]({ patch: { notchTrayPinned: value } }),
-      );
-    })();
-  },
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { appearanceMode: mode } }),
+			);
+		})();
+	},
+	setOnboardingCompleted: (value) => {
+		set({ onboardingCompleted: value });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { onboardingCompleted: value } }),
+			);
+		})();
+	},
+	setProviderEnabled: (providerId, value) => {
+		const next = { ...get().providerEnabled, [providerId]: value };
+		set({ providerEnabled: next });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { providerEnabled: next } }),
+			);
+		})();
+	},
+	setModelEnabled: (providerId, modelId, value) => {
+		const current = get().modelEnabledByProvider;
+		const next: ModelEnabledByProvider = {
+			...current,
+			[providerId]: {
+				...current[providerId],
+				[modelId]: value,
+			},
+		};
+		set({ modelEnabledByProvider: next });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { modelEnabledByProvider: next } }),
+			);
+		})();
+	},
+	setOpencodeProviderVisible: (providerId, value) => {
+		const next = { ...get().opencodeProviderVisible, [providerId]: value };
+		set({ opencodeProviderVisible: next });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { opencodeProviderVisible: next } }),
+			);
+		})();
+	},
+	setOpencodeModelVisible: (providerId, modelId, value) => {
+		const current = get().opencodeModelVisibleByProvider;
+		const next: Record<string, Record<string, boolean>> = {
+			...current,
+			[providerId]: { ...current[providerId], [modelId]: value },
+		};
+		set({ opencodeModelVisibleByProvider: next });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({
+					patch: { opencodeModelVisibleByProvider: next },
+				}),
+			);
+		})();
+	},
+	setBranchNamingStyle: (style) => {
+		set({ branchNamingStyle: style });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { branchNamingStyle: style } }),
+			);
+		})();
+	},
+	setBranchNamingPrefix: (prefix) => {
+		set({ branchNamingPrefix: prefix });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { branchNamingPrefix: prefix } }),
+			);
+		})();
+	},
+	setMergePrefs: (mergePrefs) => {
+		set({ mergePrefs });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { mergePrefs } }),
+			);
+		})();
+	},
+	setNotchTrayEnabled: (value) => {
+		set({ notchTrayEnabled: value });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { notchTrayEnabled: value } }),
+			);
+		})();
+	},
+	setNotchTrayPinned: (value) => {
+		set({ notchTrayPinned: value });
+		void (async () => {
+			const client = await getRpcClient();
+			await Effect.runPromise(
+				client["settings.update"]({ patch: { notchTrayPinned: value } }),
+			);
+		})();
+	},
 }));

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -9,20 +9,20 @@
 html,
 body,
 #root {
-  height: 100%;
+	height: 100%;
 }
 
 * {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 .xterm-viewport::-webkit-scrollbar {
-  width: 8px;
+	width: 8px;
 }
 .xterm-viewport::-webkit-scrollbar-thumb {
-  background: var(--bg-overlay);
-  border-radius: 4px;
+	background: var(--bg-overlay);
+	border-radius: 4px;
 }
 
 @theme inline {
@@ -113,9 +113,9 @@ body,
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
 
-  --radius-sm: calc(var(--radius) * 0.45);
-  --radius-md: calc(var(--radius) * 0.65);
-  --radius-lg: calc(var(--radius) * 0.85);
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
   --radius-xl: var(--radius);
   --radius-2xl: calc(var(--radius) * 1.15);
   --radius-3xl: calc(var(--radius) * 1.35);
@@ -205,291 +205,384 @@ body,
 /* Pure neutral grays on a paper-white surface; the chartreuse primary is the
    only color in the UI. */
 :root {
-  /* Electron Window Controls Overlay reports the native button strip through
+	/* Electron Window Controls Overlay reports the native button strip through
      these env() values. It resolves to zero in browsers and on macOS. */
-  --zuse-window-controls-right-inset: calc(
-    100vw - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100vw)
-  );
-  --radius: 0.875rem;
-  --lime: hsl(72 92% 48%);
-  --brand-highlight: hsl(72 92% 48%);
-  --brand-highlight-muted: hsl(74 70% 58%);
+	--zuse-window-controls-right-inset: calc(
+		100vw -
+		env(titlebar-area-x, 0px) -
+		env(titlebar-area-width, 100vw)
+	);
+	/* Desktop density system: 24px rows, 28px text controls, 8px rhythm. */
+	--radius: 0.625rem;
+	--density-row: 1.5rem;
+	--density-control: 1.75rem;
+	--density-chrome: 2rem;
+	--density-gap: 0.5rem;
+	--text-ui: 0.75rem;
+	--text-ui-sm: 0.6875rem;
+	--text-ui-xs: 0.625rem;
+	--text-ui-meta: 0.5625rem;
+	--text-code: 0.6875rem;
+	--motion-enter: 180ms;
+	--motion-exit: 140ms;
+	--ease-compact-out: cubic-bezier(0.165, 0.84, 0.44, 1);
+	--lime: hsl(72 92% 48%);
+	--brand-highlight: hsl(72 92% 48%);
+	--brand-highlight-muted: hsl(74 70% 58%);
 
-  --background: hsl(0 0% 98%);
-  --foreground: hsl(0 0% 9%);
+	--background: hsl(0 0% 98%);
+	--foreground: hsl(0 0% 9%);
 
-  --bg-subtle: hsl(0 0% 96%);
-  --bg-elevated: hsl(0 0% 92%);
-  --bg-overlay: hsl(0 0% 84%);
-  --text-faint: hsl(0 0% 46%);
+	--bg-subtle: hsl(0 0% 96%);
+	--bg-elevated: hsl(0 0% 92%);
+	--bg-overlay: hsl(0 0% 84%);
+	--text-faint: hsl(0 0% 46%);
 
-  /* Chip surface — sits on top of cards/bubbles, must stay visibly darker than
+	/* Chip surface — sits on top of cards/bubbles, must stay visibly darker than
      --card so the pill reads as inset against the composer card. */
-  --chip-bg: hsl(0 0% 91%);
+	--chip-bg: hsl(0 0% 91%);
 
-  --card: hsl(0 0% 100%);
-  --card-foreground: var(--foreground);
-  --popover: hsl(0 0% 100%);
-  --popover-foreground: var(--foreground);
+	--card: hsl(0 0% 100%);
+	--card-foreground: var(--foreground);
+	--popover: hsl(0 0% 100%);
+	--popover-foreground: var(--foreground);
 
-  --primary: var(--lime);
-  --primary-foreground: hsl(72 82% 6%);
+	--primary: var(--lime);
+	--primary-foreground: hsl(72 82% 6%);
 
-  --accent-pink: hsl(339 84% 48%);
-  --accent-green: hsl(131 52% 42%);
-  --accent-blue: hsl(220 76% 54%);
-  --accent-amber: hsl(18 86% 52%);
-  --accent-red: hsl(0 74% 56%);
-  --accent-zinc: hsl(0 0% 42%);
+	--accent-pink: hsl(339 84% 48%);
+	--accent-green: hsl(131 52% 42%);
+	--accent-blue: hsl(220 76% 54%);
+	--accent-amber: hsl(18 86% 52%);
+	--accent-red: hsl(0 74% 56%);
+	--accent-zinc: hsl(0 0% 42%);
 
-  --file-icon-gray: #6c6c71;
-  --file-icon-red: #d52c36;
-  --file-icon-vermilion: #d5512f;
-  --file-icon-orange: #d47628;
-  --file-icon-yellow: #d5a910;
-  --file-icon-green: #199f43;
-  --file-icon-teal: #17a5af;
-  --file-icon-cyan: #1ca1c7;
-  --file-icon-blue: #1a85d4;
-  --file-icon-indigo: #693acf;
-  --file-icon-purple: #a631be;
-  --file-icon-pink: #d32a61;
-  --file-icon-mauve: #594c5b;
+	--file-icon-gray: #6c6c71;
+	--file-icon-red: #d52c36;
+	--file-icon-vermilion: #d5512f;
+	--file-icon-orange: #d47628;
+	--file-icon-yellow: #d5a910;
+	--file-icon-green: #199f43;
+	--file-icon-teal: #17a5af;
+	--file-icon-cyan: #1ca1c7;
+	--file-icon-blue: #1a85d4;
+	--file-icon-indigo: #693acf;
+	--file-icon-purple: #a631be;
+	--file-icon-pink: #d32a61;
+	--file-icon-mauve: #594c5b;
 
-  --secondary: hsl(0 0% 93%);
-  --secondary-foreground: var(--foreground);
-  --muted: hsl(0 0% 92%);
-  --muted-foreground: hsl(0 0% 38%);
-  --accent: hsl(0 0% 92.5%);
-  --accent-foreground: hsl(0 0% 11%);
+	--secondary: hsl(0 0% 93%);
+	--secondary-foreground: var(--foreground);
+	--muted: hsl(0 0% 92%);
+	--muted-foreground: hsl(0 0% 38%);
+	--accent: hsl(0 0% 92.5%);
+	--accent-foreground: hsl(0 0% 11%);
 
-  --destructive: hsl(0 74% 50%);
-  --destructive-foreground: hsl(0 0% 99%);
-  --success: hsl(131 52% 42%);
-  --success-foreground: hsl(0 0% 99%);
-  --warning: hsl(42 84% 47%);
-  --warning-foreground: hsl(0 0% 9%);
-  --info: hsl(220 76% 54%);
-  --info-foreground: hsl(0 0% 99%);
+	--destructive: hsl(0 74% 50%);
+	--destructive-foreground: hsl(0 0% 99%);
+	--success: hsl(131 52% 42%);
+	--success-foreground: hsl(0 0% 99%);
+	--warning: hsl(42 84% 47%);
+	--warning-foreground: hsl(0 0% 9%);
+	--info: hsl(220 76% 54%);
+	--info-foreground: hsl(0 0% 99%);
 
-  --alert-error-bg: hsl(0 72% 95%);
-  --alert-warning-bg: hsl(42 80% 92%);
-  --alert-info-bg: hsl(220 72% 94%);
-  --alert-success-bg: hsl(131 46% 92%);
+	--alert-error-bg: hsl(0 72% 95%);
+	--alert-warning-bg: hsl(42 80% 92%);
+	--alert-info-bg: hsl(220 72% 94%);
+	--alert-success-bg: hsl(131 46% 92%);
 
-  --border: hsl(0 0% 88%);
-  --input: hsl(0 0% 88%);
-  --ring: var(--lime);
+	--border: hsl(0 0% 88%);
+	--input: hsl(0 0% 88%);
+	--ring: var(--lime);
 
-  --sidebar: hsl(0 0% 98%);
-  --sidebar-foreground: hsl(0 0% 12%);
-  --sidebar-primary: var(--lime);
-  --sidebar-primary-foreground: hsl(72 82% 6%);
-  --sidebar-accent: hsl(0 0% 91.5%);
-  --sidebar-accent-foreground: hsl(0 0% 13%);
-  --sidebar-border: hsl(0 0% 90%);
-  --sidebar-ring: var(--lime);
+	--sidebar: hsl(0 0% 98%);
+	--sidebar-foreground: hsl(0 0% 12%);
+	--sidebar-primary: var(--lime);
+	--sidebar-primary-foreground: hsl(72 82% 6%);
+	--sidebar-accent: hsl(0 0% 91.5%);
+	--sidebar-accent-foreground: hsl(0 0% 13%);
+	--sidebar-border: hsl(0 0% 90%);
+	--sidebar-ring: var(--lime);
 
-  --chart-1: var(--lime);
-  --chart-2: hsl(131 52% 42%);
-  --chart-3: hsl(18 86% 52%);
-  --chart-4: hsl(220 76% 54%);
-  --chart-5: hsl(0 74% 56%);
+	--chart-1: var(--lime);
+	--chart-2: hsl(131 52% 42%);
+	--chart-3: hsl(18 86% 52%);
+	--chart-4: hsl(220 76% 54%);
+	--chart-5: hsl(0 74% 56%);
 
-  /* Chat bubble + prose. Independent of `primary` so we can keep button
+	/* Chat bubble + prose. Independent of `primary` so we can keep button
      primary punchy without bleaching message text. */
-  --user-bubble: hsl(0 0% 93.5%);
-  --user-bubble-foreground: hsl(0 0% 12%);
-  --message-text: hsl(0 0% 18%);
-  --message-heading: hsl(0 0% 9%);
-  --message-code: hsl(0 0% 24%);
-  --message-code-bg: hsl(0 0% 93%);
-  --message-pre-bg: hsl(0 0% 96%);
-  --message-quote: hsl(0 0% 40%);
-  --message-rule: hsl(0 0% 88%);
+	--user-bubble: hsl(0 0% 93.5%);
+	--user-bubble-foreground: hsl(0 0% 12%);
+	--message-text: hsl(0 0% 18%);
+	--message-heading: hsl(0 0% 9%);
+	--message-code: hsl(0 0% 24%);
+	--message-code-bg: hsl(0 0% 93%);
+	--message-pre-bg: hsl(0 0% 96%);
+	--message-quote: hsl(0 0% 40%);
+	--message-rule: hsl(0 0% 88%);
 
-  --syntax-keyword: hsl(276 66% 42%);
-  --syntax-string: hsl(131 48% 34%);
-  --syntax-number: hsl(38 82% 38%);
-  --syntax-function: hsl(220 70% 44%);
-  --syntax-type: hsl(190 68% 34%);
-  --syntax-attribute: hsl(339 70% 43%);
-  --syntax-tag: hsl(0 70% 45%);
+	--syntax-keyword: hsl(276 66% 42%);
+	--syntax-string: hsl(131 48% 34%);
+	--syntax-number: hsl(38 82% 38%);
+	--syntax-function: hsl(220 70% 44%);
+	--syntax-type: hsl(190 68% 34%);
+	--syntax-attribute: hsl(339 70% 43%);
+	--syntax-tag: hsl(0 70% 45%);
 
-  /* Overlay elevation. Raw box-shadow values (consumed by .shadow-overlay*
+	/* Overlay elevation. Raw box-shadow values (consumed by .shadow-overlay*
      and .border-glass) so they survive the light-mode --tw-shadow kill in
      @layer base. Light leads with a 1px ring that doubles as the border. */
-  --shadow-overlay-sm: 0 0 0 1px hsl(0 0% 0% / 0.05),
-    0 2px 6px hsl(0 0% 0% / 0.08);
-  --shadow-overlay: 0 0 0 1px hsl(0 0% 0% / 0.05),
-    0 2px 4px hsl(0 0% 0% / 0.05), 0 8px 16px -4px hsl(0 0% 0% / 0.07),
-    0 20px 32px -8px hsl(0 0% 0% / 0.08);
-  --shadow-overlay-lg: 0 0 0 1px hsl(0 0% 0% / 0.05),
-    0 8px 16px -4px hsl(0 0% 0% / 0.1), 0 32px 64px -12px hsl(0 0% 0% / 0.18);
+	--shadow-overlay-sm:
+		0 0 0 1px hsl(0 0% 0% / 0.05), 0 2px 6px hsl(0 0% 0% / 0.08);
+	--shadow-overlay:
+		0 0 0 1px hsl(0 0% 0% / 0.05),
+		0 2px 4px hsl(0 0% 0% / 0.05), 0 8px 16px -4px hsl(0 0% 0% / 0.07),
+		0 20px 32px -8px hsl(0 0% 0% / 0.08);
+	--shadow-overlay-lg:
+		0 0 0 1px hsl(0 0% 0% / 0.05), 0 8px 16px -4px hsl(0 0% 0% / 0.1),
+		0 32px 64px -12px hsl(0 0% 0% / 0.18);
 }
 
 .dark {
-  /* Pure neutral grays; the bright lime primary is the only color. */
-  --lime: hsl(72 98% 54%);
-  --brand-highlight: hsl(72 98% 54%);
-  --brand-highlight-muted: hsl(73 96% 72%);
+	/* Pure neutral grays; the bright lime primary is the only color. */
+	--lime: hsl(72 98% 54%);
+	--brand-highlight: hsl(72 98% 54%);
+	--brand-highlight-muted: hsl(73 96% 72%);
 
-  --background: hsl(0 0% 6%);
-  --foreground: hsl(0 0% 93%);
+	--background: hsl(0 0% 6%);
+	--foreground: hsl(0 0% 93%);
 
-  --bg-subtle: hsl(0 0% 10%);
-  --bg-elevated: hsl(0 0% 13%);
-  --bg-overlay: hsl(0 0% 22%);
-  --text-faint: hsl(0 0% 43%);
+	--bg-subtle: hsl(0 0% 10%);
+	--bg-elevated: hsl(0 0% 13%);
+	--bg-overlay: hsl(0 0% 22%);
+	--text-faint: hsl(0 0% 43%);
 
-  /* Chip surface — kept darker than --card so pills read as inset on the
+	/* Chip surface — kept darker than --card so pills read as inset on the
      composer surface. */
-  --chip-bg: hsl(0 0% 10%);
+	--chip-bg: hsl(0 0% 10%);
 
-  --card: hsl(0 0% 12%);
-  --card-foreground: var(--foreground);
+	--card: hsl(0 0% 12%);
+	--card-foreground: var(--foreground);
 
-  /* Popover sits just below card so the glass border/shadow has something to
+	/* Popover sits just below card so the glass border/shadow has something to
      bite on. */
-  --popover: hsl(0 0% 11%);
-  --popover-foreground: hsl(0 0% 93%);
+	--popover: hsl(0 0% 11%);
+	--popover-foreground: hsl(0 0% 93%);
 
-  --primary: var(--lime);
-  --primary-foreground: hsl(72 82% 5%);
+	--primary: var(--lime);
+	--primary-foreground: hsl(72 82% 5%);
 
-  --accent-pink: hsl(339 96% 52%);
-  --accent-green: hsl(131 72% 59%);
-  --accent-blue: hsl(220 96% 68%);
-  --accent-amber: hsl(18 96% 62%);
-  --accent-red: hsl(0 84% 60%);
-  --accent-zinc: hsl(0 0% 63%);
+	--accent-pink: hsl(339 96% 52%);
+	--accent-green: hsl(131 72% 59%);
+	--accent-blue: hsl(220 96% 68%);
+	--accent-amber: hsl(18 96% 62%);
+	--accent-red: hsl(0 84% 60%);
+	--accent-zinc: hsl(0 0% 63%);
 
-  --file-icon-gray: #adadb1;
-  --file-icon-red: #ff6762;
-  --file-icon-vermilion: #ff8c5b;
-  --file-icon-orange: #ffa359;
-  --file-icon-yellow: #ffd452;
-  --file-icon-green: #5ecc71;
-  --file-icon-teal: #64d1db;
-  --file-icon-cyan: #68cdf2;
-  --file-icon-blue: #69b1ff;
-  --file-icon-indigo: #9d6afb;
-  --file-icon-purple: #d568ea;
-  --file-icon-pink: #ff678d;
-  --file-icon-mauve: #79697b;
+	--file-icon-gray: #adadb1;
+	--file-icon-red: #ff6762;
+	--file-icon-vermilion: #ff8c5b;
+	--file-icon-orange: #ffa359;
+	--file-icon-yellow: #ffd452;
+	--file-icon-green: #5ecc71;
+	--file-icon-teal: #64d1db;
+	--file-icon-cyan: #68cdf2;
+	--file-icon-blue: #69b1ff;
+	--file-icon-indigo: #9d6afb;
+	--file-icon-purple: #d568ea;
+	--file-icon-pink: #ff678d;
+	--file-icon-mauve: #79697b;
 
-  --secondary: hsl(0 0% 10%);
-  --secondary-foreground: hsl(0 0% 93%);
+	--secondary: hsl(0 0% 10%);
+	--secondary-foreground: hsl(0 0% 93%);
 
-  /* Muted + accent sit ABOVE --card/--popover so hover/selected states and
+	/* Muted + accent sit ABOVE --card/--popover so hover/selected states and
      muted surfaces read clearly against cards and the 6% background. */
-  --muted: hsl(0 0% 20%);
-  --muted-foreground: hsl(0 0% 68%);
+	--muted: hsl(0 0% 20%);
+	--muted-foreground: hsl(0 0% 68%);
 
-  --accent: hsl(0 0% 20%);
-  --accent-foreground: hsl(0 0% 93%);
+	--accent: hsl(0 0% 20%);
+	--accent-foreground: hsl(0 0% 93%);
 
-  --destructive: hsl(0 84% 52%);
-  --destructive-foreground: hsl(0 0% 100%);
+	--destructive: hsl(0 84% 52%);
+	--destructive-foreground: hsl(0 0% 100%);
 
-  --success: hsl(131 72% 59%);
-  --success-foreground: hsl(130 66% 10%);
+	--success: hsl(131 72% 59%);
+	--success-foreground: hsl(130 66% 10%);
 
-  --warning: hsl(360 15% 22%);
-  --warning-foreground: hsl(0 0% 93%);
+	--warning: hsl(360 15% 22%);
+	--warning-foreground: hsl(0 0% 93%);
 
-  --info: hsl(220 96% 68%);
-  --info-foreground: hsl(217 45% 14%);
+	--info: hsl(220 96% 68%);
+	--info-foreground: hsl(217 45% 14%);
 
-  --alert-error-bg: hsl(0 54% 18%);
-  --alert-warning-bg: hsl(360 15% 22%);
-  --alert-info-bg: hsl(217 45% 18%);
-  --alert-success-bg: hsl(130 64% 11%);
+	--alert-error-bg: hsl(0 54% 18%);
+	--alert-warning-bg: hsl(360 15% 22%);
+	--alert-info-bg: hsl(217 45% 18%);
+	--alert-success-bg: hsl(130 64% 11%);
 
-  --border: hsl(0 0% 100% / 0.1);
-  --input: hsl(0 0% 100% / 0.2);
-  --ring: var(--lime);
+	--border: hsl(0 0% 100% / 0.1);
+	--input: hsl(0 0% 100% / 0.2);
+	--ring: var(--lime);
 
-  --sidebar: hsl(0 0% 10%);
-  --sidebar-foreground: hsl(0 0% 100% / 0.9);
+	--sidebar: hsl(0 0% 10%);
+	--sidebar-foreground: hsl(0 0% 100% / 0.9);
 
-  --sidebar-primary: var(--lime);
-  --sidebar-primary-foreground: hsl(72 82% 5%);
+	--sidebar-primary: var(--lime);
+	--sidebar-primary-foreground: hsl(72 82% 5%);
 
-  --sidebar-accent: hsl(0 0% 100% / 0.05);
-  --sidebar-accent-foreground: hsl(0 0% 100% / 0.9);
+	--sidebar-accent: hsl(0 0% 100% / 0.05);
+	--sidebar-accent-foreground: hsl(0 0% 100% / 0.9);
 
-  --sidebar-border: hsl(0 0% 100% / 0.1);
-  --sidebar-ring: var(--lime);
+	--sidebar-border: hsl(0 0% 100% / 0.1);
+	--sidebar-ring: var(--lime);
 
-  /* Subtle glass button tokens */
-  --color-neutral-primary-reverted-5: #ffffff0d;
-  --color-neutral-primary-reverted-20: #ffffff14;
-  --color-white-3: #ffffff08;
+	/* Subtle glass button tokens */
+	--color-neutral-primary-reverted-5: #ffffff0d;
+	--color-neutral-primary-reverted-20: #ffffff14;
+	--color-white-3: #ffffff08;
 
-  --chart-1: var(--lime);
-  --chart-2: hsl(131 72% 59%);
-  --chart-3: hsl(18 96% 62%);
-  --chart-4: hsl(220 96% 68%);
-  --chart-5: hsl(0 84% 60%);
+	--chart-1: var(--lime);
+	--chart-2: hsl(131 72% 59%);
+	--chart-3: hsl(18 96% 62%);
+	--chart-4: hsl(220 96% 68%);
+	--chart-5: hsl(0 84% 60%);
 
-  --user-bubble: hsl(0 0% 13%);
-  --user-bubble-foreground: hsl(0 0% 93%);
-  --message-text: hsl(0 0% 90%);
-  --message-heading: hsl(0 0% 94%);
-  --message-code: hsl(72 90% 64%);
-  --message-code-bg: hsl(0 0% 10%);
-  --message-pre-bg: hsl(0 0% 10%);
-  --message-quote: hsl(0 0% 64%);
-  --message-rule: hsl(0 0% 22%);
+	--user-bubble: hsl(0 0% 13%);
+	--user-bubble-foreground: hsl(0 0% 93%);
+	--message-text: hsl(0 0% 90%);
+	--message-heading: hsl(0 0% 94%);
+	--message-code: hsl(72 90% 64%);
+	--message-code-bg: hsl(0 0% 10%);
+	--message-pre-bg: hsl(0 0% 10%);
+	--message-quote: hsl(0 0% 64%);
+	--message-rule: hsl(0 0% 22%);
 
-  --syntax-keyword: #c084fc;
-  --syntax-string: #86efac;
-  --syntax-number: #fbbf24;
-  --syntax-function: #7dd3fc;
-  --syntax-type: #67e8f9;
-  --syntax-attribute: #fda4af;
-  --syntax-tag: #f87171;
+	--syntax-keyword: #c084fc;
+	--syntax-string: #86efac;
+	--syntax-number: #fbbf24;
+	--syntax-function: #7dd3fc;
+	--syntax-type: #67e8f9;
+	--syntax-attribute: #fda4af;
+	--syntax-tag: #f87171;
 
-  /* Overlay elevation — deeper on dark since borders carry the edge. */
-  --shadow-overlay-sm: 0 4px 8px -2px hsl(0 0% 0% / 0.4);
-  --shadow-overlay: 0 6px 12px -3px hsl(0 0% 0% / 0.4),
-    0 16px 32px -8px hsl(0 0% 0% / 0.35);
-  --shadow-overlay-lg: 0 12px 24px -6px hsl(0 0% 0% / 0.5),
-    0 40px 80px -16px hsl(0 0% 0% / 0.45);
+	/* Overlay elevation — deeper on dark since borders carry the edge. */
+	--shadow-overlay-sm: 0 4px 8px -2px hsl(0 0% 0% / 0.4);
+	--shadow-overlay:
+		0 6px 12px -3px hsl(0 0% 0% / 0.4), 0 16px 32px -8px hsl(0 0% 0% / 0.35);
+	--shadow-overlay-lg:
+		0 12px 24px -6px hsl(0 0% 0% / 0.5), 0 40px 80px -16px hsl(0 0% 0% / 0.45);
 }
 @layer base {
-  html:not(.dark) *,
-  html:not(.dark) *::before,
-  html:not(.dark) *::after {
-    --tw-shadow: 0 0 #0000 !important;
-    --tw-shadow-colored: 0 0 #0000 !important;
-    --tw-inset-shadow: 0 0 #0000 !important;
-  }
+	html:not(.dark) *,
+	html:not(.dark) *::before,
+	html:not(.dark) *::after {
+		--tw-shadow: 0 0 #0000 !important;
+		--tw-shadow-colored: 0 0 #0000 !important;
+		--tw-inset-shadow: 0 0 #0000 !important;
+	}
 
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply text-foreground;
-    /* Solid app background — the macOS vibrancy look read as washed-out,
+	* {
+		@apply border-border outline-ring/50;
+	}
+	body {
+		@apply text-foreground;
+		font-family: var(--font-sans);
+		font-size: var(--text-ui);
+		line-height: 1.35;
+		/* Solid app background — the macOS vibrancy look read as washed-out,
        especially in light mode, so panes paint flat theme colors instead. */
-    background-color: var(--background);
-  }
-  code,
-  kbd,
-  samp,
-  pre {
-    font-family: var(--font-mono);
-  }
+		background-color: var(--background);
+	}
+	code,
+	kbd,
+	samp,
+	pre {
+		font-family: var(--font-mono);
+	}
 
-  /* Icon weight: every 24x24 icon (hugeicons stroke set, lucide, inline
+	/* Icon weight: every 24x24 icon (hugeicons stroke set, lucide, inline
      glyphs) renders at stroke-width 1 for a consistently light line. The
      CSS property beats the per-path stroke-width="1.5" presentation attr. */
-  svg[viewBox="0 0 24 24"],
-  svg[viewBox="0 0 24 24"] [stroke-width] {
-    stroke-width: 1;
-  }
+	svg[viewBox="0 0 24 24"],
+	svg[viewBox="0 0 24 24"] [stroke-width] {
+		stroke-width: 1;
+	}
+}
+
+/* Applied only while the projects sidebar is programmatically opened or
+   closed, so manual resizing stays directly under the pointer. */
+.fz-sidebar-panel-motion {
+	transition: flex-grow 180ms cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.fz-sidebar-panel-motion {
+		transition: none;
+	}
+}
+
+@layer components {
+	/* Shared recipes for renderer-owned rows and toolbars. */
+	.compact-row {
+		min-height: var(--density-row);
+		gap: var(--density-gap);
+		padding-inline: var(--density-gap);
+		border-radius: var(--radius-md);
+		font-size: var(--text-ui);
+	}
+
+	.compact-toolbar {
+		min-height: var(--density-chrome);
+		gap: 0.375rem;
+		padding-inline: var(--density-gap);
+	}
+
+	.compact-section-label {
+		font-size: var(--text-ui-xs);
+		font-weight: 500;
+		letter-spacing: 0.02em;
+		color: var(--muted-foreground);
+	}
+
+	.compact-notification {
+		animation: compact-notification-in var(--motion-enter)
+			var(--ease-compact-out) both;
+	}
+
+	.compact-step-enter {
+		animation: compact-step-in-forward 160ms ease-out both;
+	}
+}
+
+@keyframes compact-notification-in {
+	from {
+		opacity: 0;
+		transform: translateY(8px);
+	}
+}
+
+@keyframes compact-step-in-forward {
+	from {
+		opacity: 0;
+		transform: translateX(6px);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.compact-notification,
+	.compact-step-enter {
+		animation-duration: 80ms !important;
+		animation-name: compact-fade-in !important;
+	}
+}
+
+@keyframes compact-fade-in {
+	from {
+		opacity: 0;
+	}
 }
 
 /* `@pierre/diffs` ships with stock GitHub-style fire-engine red / spring
@@ -499,94 +592,94 @@ body,
    package's final computed base token transparent in `lib/diffs-theme.ts`, so
    these inherited detail tokens blend into the surrounding pane. */
 @layer components {
-  .chat-session-layout {
-    --chat-reading-column: 56rem;
-    --chat-row-gutter: 0.75rem;
-    --chat-assistant-gutter: 1rem;
-  }
+	.chat-session-layout {
+		--chat-reading-column: 56rem;
+		--chat-row-gutter: 0.625rem;
+		--chat-assistant-gutter: 0.75rem;
+	}
 
-  .fz-diff {
-    --fz-diff-header-bg: var(--background);
+	.fz-diff {
+		--fz-diff-header-bg: var(--background);
 
-    /* Surfaces — drop the diff onto the same neutral the pane uses so it
+		/* Surfaces — drop the diff onto the same neutral the pane uses so it
        reads as part of the app, not a bolted-on widget. Pierre computes
        its buffer / context / gutter tints from `--diffs-bg` mixed with a
        `--diffs-mixer` (`#fff` in dark), which pushes toward zinc. We
        override the computed values directly to keep everything anchored
        on the app's `--background`. */
-    --diffs-light-bg: var(--background);
-    --diffs-dark-bg: var(--background);
-    --diffs-light: var(--foreground);
-    --diffs-dark: var(--foreground);
-    --diffs-bg-buffer-override: var(--background);
-    --diffs-bg-context-override: var(--background);
-    --diffs-bg-context-gutter-override: var(--bg-subtle);
-    --diffs-bg-separator-override: var(--border);
+		--diffs-light-bg: var(--background);
+		--diffs-dark-bg: var(--background);
+		--diffs-light: var(--foreground);
+		--diffs-dark: var(--foreground);
+		--diffs-bg-buffer-override: var(--background);
+		--diffs-bg-context-override: var(--background);
+		--diffs-bg-context-gutter-override: var(--bg-subtle);
+		--diffs-bg-separator-override: var(--border);
 
-    /* Add leans hard on the app's lime --primary — true yellow-chartreuse,
+		/* Add leans hard on the app's lime --primary — true yellow-chartreuse,
        not teal. Delete stays warm rose so a glance still tells add from
        delete. The text colors land on the marker / line text; the
        backgrounds are a faint wash of the same hue against the app bg so
        a + row reads as "a hint of lime" rather than "a green band." */
-    --diffs-added-light: oklch(0.55 0.2 108);
-    --diffs-added-dark: oklch(0.88 0.2 115);
-    --diffs-deleted-light: oklch(0.55 0.2 22);
-    --diffs-deleted-dark: oklch(0.78 0.15 20);
-    --diffs-modified-light: oklch(0.7 0.13 80);
-    --diffs-modified-dark: oklch(0.82 0.11 82);
+		--diffs-added-light: oklch(0.55 0.2 108);
+		--diffs-added-dark: oklch(0.88 0.2 115);
+		--diffs-deleted-light: oklch(0.55 0.2 22);
+		--diffs-deleted-dark: oklch(0.78 0.15 20);
+		--diffs-modified-light: oklch(0.7 0.13 80);
+		--diffs-modified-dark: oklch(0.82 0.11 82);
 
-    --diffs-bg-addition-override: color-mix(
-      in oklab,
-      var(--diffs-added-dark) 10%,
-      var(--background)
-    );
-    --diffs-bg-addition-emphasis-override: color-mix(
-      in oklab,
-      var(--diffs-added-dark) 20%,
-      var(--background)
-    );
-    --diffs-bg-addition-number-override: color-mix(
-      in oklab,
-      var(--diffs-added-dark) 14%,
-      var(--bg-subtle)
-    );
-    --diffs-bg-deletion-override: color-mix(
-      in oklab,
-      var(--diffs-deleted-dark) 10%,
-      var(--background)
-    );
-    --diffs-bg-deletion-emphasis-override: color-mix(
-      in oklab,
-      var(--diffs-deleted-dark) 20%,
-      var(--background)
-    );
-    --diffs-bg-deletion-number-override: color-mix(
-      in oklab,
-      var(--diffs-deleted-dark) 14%,
-      var(--bg-subtle)
-    );
+		--diffs-bg-addition-override: color-mix(
+			in oklab,
+			var(--diffs-added-dark) 10%,
+			var(--background)
+		);
+		--diffs-bg-addition-emphasis-override: color-mix(
+			in oklab,
+			var(--diffs-added-dark) 20%,
+			var(--background)
+		);
+		--diffs-bg-addition-number-override: color-mix(
+			in oklab,
+			var(--diffs-added-dark) 14%,
+			var(--bg-subtle)
+		);
+		--diffs-bg-deletion-override: color-mix(
+			in oklab,
+			var(--diffs-deleted-dark) 10%,
+			var(--background)
+		);
+		--diffs-bg-deletion-emphasis-override: color-mix(
+			in oklab,
+			var(--diffs-deleted-dark) 20%,
+			var(--background)
+		);
+		--diffs-bg-deletion-number-override: color-mix(
+			in oklab,
+			var(--diffs-deleted-dark) 14%,
+			var(--bg-subtle)
+		);
 
-    /* Typography — same monospace token as the rest of the app, slightly
+		/* Typography — same monospace token as the rest of the app, slightly
        smaller than Pierre's default so a diff doesn't dwarf the chat. */
-    --diffs-font-family: var(--font-mono);
-    --diffs-font-size: 12px;
-    --diffs-line-height: 18px;
+		--diffs-font-family: var(--font-mono);
+		--diffs-font-size: 12px;
+		--diffs-line-height: 18px;
 
-    /* Line selection (Pierre 1.2 native selection, used by the diff-tab
+		/* Line selection (Pierre 1.2 native selection, used by the diff-tab
        annotate flow). Tint the staged rows / gutter with the app primary so
        selecting lines to comment matches the rest of the UI. */
-    --diffs-selection-color-override: var(--primary);
-    --diffs-bg-selection-override: color-mix(
-      in oklab,
-      var(--primary) 22%,
-      transparent
-    );
-    --diffs-bg-selection-number-override: color-mix(
-      in oklab,
-      var(--primary) 40%,
-      transparent
-    );
-  }
+		--diffs-selection-color-override: var(--primary);
+		--diffs-bg-selection-override: color-mix(
+			in oklab,
+			var(--primary) 22%,
+			transparent
+		);
+		--diffs-bg-selection-number-override: color-mix(
+			in oklab,
+			var(--primary) 40%,
+			transparent
+		);
+	}
 }
 
 /* `@pierre/trees` renders the file tree into a shadow root and reads
@@ -596,37 +689,37 @@ body,
    rose-delete / amber-modified hues as the diff so an "M"/"A"/dot badge reads
    the same everywhere. */
 @layer components {
-  .fz-tree {
-    --trees-bg-override: var(--background);
-    --trees-fg-override: var(--foreground);
-    --trees-fg-muted-override: var(--muted-foreground);
-    --trees-bg-muted-override: var(--bg-subtle);
-    --trees-border-color-override: var(--border);
-    --trees-accent-override: var(--primary);
-    --trees-selected-bg-override: var(--sidebar-accent);
-    --trees-selected-fg-override: var(--foreground);
-    /* No bright focus ring / selection border — the active row reads through a
+	.fz-tree {
+		--trees-bg-override: var(--background);
+		--trees-fg-override: var(--foreground);
+		--trees-fg-muted-override: var(--muted-foreground);
+		--trees-bg-muted-override: var(--bg-subtle);
+		--trees-border-color-override: var(--border);
+		--trees-accent-override: var(--primary);
+		--trees-selected-bg-override: var(--sidebar-accent);
+		--trees-selected-fg-override: var(--foreground);
+		/* No bright focus ring / selection border — the active row reads through a
        subtle background instead of a loud lime box. */
-    --trees-selected-focused-border-color-override: transparent;
-    --trees-focus-ring-color-override: transparent;
-    /* Drop the vertical indent guide lines for a cleaner, flat tree. */
-    --trees-indent-guide-bg-override: transparent;
+		--trees-selected-focused-border-color-override: transparent;
+		--trees-focus-ring-color-override: transparent;
+		/* Drop the vertical indent guide lines for a cleaner, flat tree. */
+		--trees-indent-guide-bg-override: transparent;
 
-    /* Git-status badge colors, matched to the diff palette. */
-    --trees-status-added-override: oklch(0.88 0.2 115);
-    --trees-status-modified-override: oklch(0.82 0.11 82);
-    --trees-status-deleted-override: oklch(0.78 0.15 20);
-    --trees-status-renamed-override: oklch(0.82 0.11 82);
-    --trees-status-untracked-override: oklch(0.88 0.2 115);
-    --trees-status-ignored-override: var(--muted-foreground);
+		/* Git-status badge colors, matched to the diff palette. */
+		--trees-status-added-override: oklch(0.88 0.2 115);
+		--trees-status-modified-override: oklch(0.82 0.11 82);
+		--trees-status-deleted-override: oklch(0.78 0.15 20);
+		--trees-status-renamed-override: oklch(0.82 0.11 82);
+		--trees-status-untracked-override: oklch(0.88 0.2 115);
+		--trees-status-ignored-override: var(--muted-foreground);
 
-    /* Exact Hugeicons Folder01 (closed) and Folder02 (open) paths. The two
+		/* Exact Hugeicons Folder01 (closed) and Folder02 (open) paths. The two
        masks preserve the icons' original muted base / full-strength foreground
        treatment while inheriting the tree's current text color. */
-    --fz-folder-01: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M7.08264 2.24996C8.11205 2.24951 8.82373 2.24919 9.4626 2.48876C10.8581 3.01205 11.4704 4.25121 11.9425 5.20636C12.0838 5.48909 12.3409 6.0027 12.4128 6.11563C12.4348 6.15255 12.5044 6.22817 12.6064 6.23531C12.7396 6.24908 12.92 6.25 13.2361 6.25L16.7905 6.25C17.8095 6.24999 18.6312 6.24998 19.2905 6.31705C19.9711 6.38628 20.5613 6.53313 21.0834 6.88199C21.4929 7.15559 21.8444 7.50715 22.118 7.91661C22.4669 8.43872 22.6137 9.02893 22.683 9.70949C22.75 10.3688 22.75 11.2733 22.75 12.2923C22.75 14.012 22.75 15.3602 22.6408 16.4336C22.5295 17.5283 22.2983 18.4202 21.781 19.1945C21.3614 19.8224 20.8224 20.3614 20.1945 20.781C19.4202 21.2983 18.5283 21.5295 17.4336 21.6408C16.3602 21.75 15.012 21.75 13.2923 21.75H11.9426C9.63423 21.75 7.82519 21.75 6.41371 21.5603C4.96897 21.366 3.82895 20.9607 2.93414 20.0659C2.03933 19.1711 1.63399 18.031 1.43975 16.5863C1.24998 15.1748 1.24999 13.3658 1.25 11.0574V7.90951C1.24999 7.26419 1.24999 6.71057 1.26997 6.23531C1.27719 6.0634 1.28704 5.90174 1.30044 5.7497C1.35242 5.15996 1.46238 4.64388 1.7254 4.17258C2.06428 3.56534 2.56533 3.06428 3.17258 2.7254C3.64388 2.46238 4.15996 2.35243 4.7497 2.30044C5.32205 2.24999 6.2039 2.24995 7.08264 2.24996Z'/%3E%3C/svg%3E");
-    --fz-folder-02-background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M20.3201 10.3679C21.1491 10.4898 21.8892 10.7615 22.3622 11.4571C22.8359 12.1536 22.8144 12.9409 22.6198 13.7542C22.432 14.5395 22.0405 15.5138 21.5612 16.7069L21.5611 16.707C21.2076 17.5871 20.582 19.1443 20.2833 19.702C19.9714 20.2844 19.6166 20.7557 19.0967 21.1061C18.577 21.4565 18.0065 21.6092 17.3484 21.6811C16.7179 21.7501 15.9426 21.7501 14.9903 21.75L6.82564 21.75C5.53437 21.7501 4.48102 21.7501 3.67955 21.6322C2.85055 21.5103 2.11046 21.2386 1.63746 20.543C1.16382 19.8465 1.18526 19.0592 1.37984 18.2459C1.56772 17.4605 2.29668 15.6461 2.77606 14.453C3.12961 13.5729 3.41769 12.8558 3.71637 12.2981C4.02829 11.7157 4.38309 11.2444 4.90302 10.8939C5.42272 10.5436 5.99323 10.3909 6.65124 10.319C7.28177 10.25 8.05707 10.25 9.00939 10.25H17.174C18.4653 10.25 19.5187 10.25 20.3201 10.3679Z'/%3E%3C/svg%3E");
-    --fz-folder-02-foreground: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M7.14203 2.25009C8.02697 2.25009 8.86433 2.64958 9.41958 3.33668L10.8985 5.16676L15.9142 5.16676C16.5634 5.16674 17.1089 5.16673 17.5553 5.2031C18.0221 5.24113 18.4657 5.32371 18.8867 5.53764C19.5288 5.86387 20.0509 6.38443 20.3781 7.02471C20.5926 7.44457 20.6754 7.88689 20.7136 8.35232C20.75 8.79744 20.75 9.34143 20.75 9.98875V10.448C20.6101 10.4157 20.4665 10.3895 20.3201 10.3679C19.5187 10.25 18.4653 10.2501 17.1741 10.2501H9.00944C8.05712 10.2501 7.28177 10.2501 6.65124 10.319C5.99323 10.391 5.42272 10.5437 4.90302 10.894C4.38309 11.2445 4.02829 11.7157 3.71637 12.2981C3.41769 12.8558 3.12961 13.5729 2.77606 14.453C2.29668 15.6462 1.56772 17.4606 1.37984 18.2459C1.32416 18.4787 1.28265 18.7093 1.26287 18.9362C1.2544 18.8847 1.25 18.8318 1.25 18.7779V7.61054C1.24999 6.93793 1.24998 6.38272 1.28207 5.92856C1.31534 5.45753 1.38658 5.02223 1.56632 4.60478C1.96071 3.68878 2.6928 2.95878 3.61142 2.56551C4.02949 2.38653 4.46387 2.31532 4.93624 2.28208C5.39091 2.25008 5.94776 2.25008 6.62538 2.25009H7.14203Z'/%3E%3C/svg%3E");
-  }
+		--fz-folder-01: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M7.08264 2.24996C8.11205 2.24951 8.82373 2.24919 9.4626 2.48876C10.8581 3.01205 11.4704 4.25121 11.9425 5.20636C12.0838 5.48909 12.3409 6.0027 12.4128 6.11563C12.4348 6.15255 12.5044 6.22817 12.6064 6.23531C12.7396 6.24908 12.92 6.25 13.2361 6.25L16.7905 6.25C17.8095 6.24999 18.6312 6.24998 19.2905 6.31705C19.9711 6.38628 20.5613 6.53313 21.0834 6.88199C21.4929 7.15559 21.8444 7.50715 22.118 7.91661C22.4669 8.43872 22.6137 9.02893 22.683 9.70949C22.75 10.3688 22.75 11.2733 22.75 12.2923C22.75 14.012 22.75 15.3602 22.6408 16.4336C22.5295 17.5283 22.2983 18.4202 21.781 19.1945C21.3614 19.8224 20.8224 20.3614 20.1945 20.781C19.4202 21.2983 18.5283 21.5295 17.4336 21.6408C16.3602 21.75 15.012 21.75 13.2923 21.75H11.9426C9.63423 21.75 7.82519 21.75 6.41371 21.5603C4.96897 21.366 3.82895 20.9607 2.93414 20.0659C2.03933 19.1711 1.63399 18.031 1.43975 16.5863C1.24998 15.1748 1.24999 13.3658 1.25 11.0574V7.90951C1.24999 7.26419 1.24999 6.71057 1.26997 6.23531C1.27719 6.0634 1.28704 5.90174 1.30044 5.7497C1.35242 5.15996 1.46238 4.64388 1.7254 4.17258C2.06428 3.56534 2.56533 3.06428 3.17258 2.7254C3.64388 2.46238 4.15996 2.35243 4.7497 2.30044C5.32205 2.24999 6.2039 2.24995 7.08264 2.24996Z'/%3E%3C/svg%3E");
+		--fz-folder-02-background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M20.3201 10.3679C21.1491 10.4898 21.8892 10.7615 22.3622 11.4571C22.8359 12.1536 22.8144 12.9409 22.6198 13.7542C22.432 14.5395 22.0405 15.5138 21.5612 16.7069L21.5611 16.707C21.2076 17.5871 20.582 19.1443 20.2833 19.702C19.9714 20.2844 19.6166 20.7557 19.0967 21.1061C18.577 21.4565 18.0065 21.6092 17.3484 21.6811C16.7179 21.7501 15.9426 21.7501 14.9903 21.75L6.82564 21.75C5.53437 21.7501 4.48102 21.7501 3.67955 21.6322C2.85055 21.5103 2.11046 21.2386 1.63746 20.543C1.16382 19.8465 1.18526 19.0592 1.37984 18.2459C1.56772 17.4605 2.29668 15.6461 2.77606 14.453C3.12961 13.5729 3.41769 12.8558 3.71637 12.2981C4.02829 11.7157 4.38309 11.2444 4.90302 10.8939C5.42272 10.5436 5.99323 10.3909 6.65124 10.319C7.28177 10.25 8.05707 10.25 9.00939 10.25H17.174C18.4653 10.25 19.5187 10.25 20.3201 10.3679Z'/%3E%3C/svg%3E");
+		--fz-folder-02-foreground: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M7.14203 2.25009C8.02697 2.25009 8.86433 2.64958 9.41958 3.33668L10.8985 5.16676L15.9142 5.16676C16.5634 5.16674 17.1089 5.16673 17.5553 5.2031C18.0221 5.24113 18.4657 5.32371 18.8867 5.53764C19.5288 5.86387 20.0509 6.38443 20.3781 7.02471C20.5926 7.44457 20.6754 7.88689 20.7136 8.35232C20.75 8.79744 20.75 9.34143 20.75 9.98875V10.448C20.6101 10.4157 20.4665 10.3895 20.3201 10.3679C19.5187 10.25 18.4653 10.2501 17.1741 10.2501H9.00944C8.05712 10.2501 7.28177 10.2501 6.65124 10.319C5.99323 10.391 5.42272 10.5437 4.90302 10.894C4.38309 11.2445 4.02829 11.7157 3.71637 12.2981C3.41769 12.8558 3.12961 13.5729 2.77606 14.453C2.29668 15.6462 1.56772 17.4606 1.37984 18.2459C1.32416 18.4787 1.28265 18.7093 1.26287 18.9362C1.2544 18.8847 1.25 18.8318 1.25 18.7779V7.61054C1.24999 6.93793 1.24998 6.38272 1.28207 5.92856C1.31534 5.45753 1.38658 5.02223 1.56632 4.60478C1.96071 3.68878 2.6928 2.95878 3.61142 2.56551C4.02949 2.38653 4.46387 2.31532 4.93624 2.28208C5.39091 2.25008 5.94776 2.25008 6.62538 2.25009H7.14203Z'/%3E%3C/svg%3E");
+	}
 }
 
 /* Assistant message prose. Tuned for long-read comfort: body sits a touch
@@ -634,424 +727,421 @@ body,
    typographic rhythm (margins, line-height, list indents) calmed down so a
    long answer reads like a published doc instead of a wall of bold tags. */
 @layer components {
-  .fz-prose {
-    color: var(--message-text);
-    font-size: 0.9rem;
-    line-height: 1.62;
-    word-break: break-word;
-  }
-  .fz-prose > :first-child {
-    margin-top: 0;
-  }
-  .fz-prose > :last-child {
-    margin-bottom: 0;
-  }
-  .fz-prose p {
-    margin: 0.6em 0;
-  }
-  .fz-prose h1,
-  .fz-prose h2,
-  .fz-prose h3,
-  .fz-prose h4,
-  .fz-prose h5,
-  .fz-prose h6 {
-    color: var(--message-heading);
-    font-weight: 600;
-    line-height: 1.3;
-    letter-spacing: 0;
-    margin: 1.35em 0 0.45em;
-  }
-  .fz-prose h1 {
-    font-size: 1.4em;
-  }
-  .fz-prose h2 {
-    font-size: 1.2em;
-  }
-  .fz-prose h3 {
-    font-size: 1.05em;
-  }
-  .fz-prose h4,
-  .fz-prose h5,
-  .fz-prose h6 {
-    font-size: 1em;
-  }
-  .fz-prose strong {
-    color: var(--message-heading);
-    font-weight: 600;
-  }
-  .fz-prose a {
-    color: color-mix(in oklch, var(--info) 78%, var(--foreground));
-    text-decoration: underline;
-    text-decoration-color: color-mix(in oklch, var(--info) 36%, transparent);
-    text-underline-offset: 0.2em;
-  }
-  .fz-prose a:hover {
-    color: color-mix(in oklch, var(--info) 88%, var(--foreground));
-    text-decoration-color: color-mix(in oklch, var(--info) 68%, transparent);
-  }
-  .fz-prose ul,
-  .fz-prose ol {
-    margin: 0.6em 0;
-    padding-left: 1.4em;
-  }
-  .fz-prose li {
-    margin: 0.2em 0;
-  }
-  .fz-prose li::marker {
-    color: var(--text-faint);
-  }
-  .fz-prose blockquote {
-    margin: 0.8em 0;
-    padding: 0.2em 0 0.2em 0.9em;
-    border-left: 2px solid
-      color-mix(in oklch, var(--primary) 36%, var(--message-rule));
-    color: var(--message-quote);
-    font-style: normal;
-  }
-  .fz-prose hr {
-    border: 0;
-    border-top: 1px solid var(--message-rule);
-    margin: 1.2em 0;
-  }
-  .fz-prose code {
-    font-family: var(--font-mono);
-    font-size: 0.86em;
-    color: color-mix(in oklch, var(--foreground) 90%, transparent);
-    background-color: var(--message-code-bg);
-    border: 1px solid color-mix(in oklch, var(--border) 45%, transparent);
-    box-shadow: none;
-    padding: 0.08em 0.34em;
-    border-radius: 0.4rem;
-  }
-  .dark .fz-prose code {
-    background-color: color-mix(
-      in oklch,
-      var(--bg-elevated) 34%,
-      var(--background)
-    );
-    box-shadow:
-      inset 0 1px 0 color-mix(in oklch, white 4%, transparent),
-      0 1px 2px color-mix(in oklch, black 22%, transparent);
-  }
-  .fz-prose pre {
-    background-color: color-mix(
-      in oklch,
-      var(--message-pre-bg) 90%,
-      var(--background)
-    );
-    border: 1px solid var(--message-rule);
-    border-radius: 0.75rem;
-    padding: 0.85em 1em;
-    margin: 0.8em 0;
-    overflow-x: auto;
-    font-size: 0.84em;
-    line-height: 1.55;
-  }
-  .fz-prose pre code {
-    color: var(--message-text);
-    background: transparent;
-    border: 0;
-    box-shadow: none;
-    padding: 0;
-    font-size: inherit;
-  }
-  .fz-prose .markdown-code-block {
-    margin: 0.9em 0;
-  }
-  /* Assistant code stays aligned with the reading column on the left, but
+	.fz-prose {
+		color: var(--message-text);
+		font-size: 0.8125rem;
+		line-height: 1.55;
+		word-break: break-word;
+	}
+	.fz-prose > :first-child {
+		margin-top: 0;
+	}
+	.fz-prose > :last-child {
+		margin-bottom: 0;
+	}
+	.fz-prose p {
+		margin: 0.5em 0;
+	}
+	.fz-prose h1,
+	.fz-prose h2,
+	.fz-prose h3,
+	.fz-prose h4,
+	.fz-prose h5,
+	.fz-prose h6 {
+		color: var(--message-heading);
+		font-weight: 600;
+		line-height: 1.3;
+		letter-spacing: 0;
+		margin: 1.15em 0 0.4em;
+	}
+	.fz-prose h1 {
+		font-size: 1.4em;
+	}
+	.fz-prose h2 {
+		font-size: 1.2em;
+	}
+	.fz-prose h3 {
+		font-size: 1.05em;
+	}
+	.fz-prose h4,
+	.fz-prose h5,
+	.fz-prose h6 {
+		font-size: 1em;
+	}
+	.fz-prose strong {
+		color: var(--message-heading);
+		font-weight: 600;
+	}
+	.fz-prose a {
+		color: color-mix(in oklch, var(--info) 78%, var(--foreground));
+		text-decoration: underline;
+		text-decoration-color: color-mix(in oklch, var(--info) 36%, transparent);
+		text-underline-offset: 0.2em;
+	}
+	.fz-prose a:hover {
+		color: color-mix(in oklch, var(--info) 88%, var(--foreground));
+		text-decoration-color: color-mix(in oklch, var(--info) 68%, transparent);
+	}
+	.fz-prose ul,
+	.fz-prose ol {
+		margin: 0.6em 0;
+		padding-left: 1.4em;
+	}
+	.fz-prose li {
+		margin: 0.2em 0;
+	}
+	.fz-prose li::marker {
+		color: var(--text-faint);
+	}
+	.fz-prose blockquote {
+		margin: 0.8em 0;
+		padding: 0.2em 0 0.2em 0.9em;
+		border-left: 2px solid
+			color-mix(in oklch, var(--primary) 36%, var(--message-rule));
+		color: var(--message-quote);
+		font-style: normal;
+	}
+	.fz-prose hr {
+		border: 0;
+		border-top: 1px solid var(--message-rule);
+		margin: 1.2em 0;
+	}
+	.fz-prose code {
+		font-family: var(--font-mono);
+		font-size: 0.86em;
+		color: color-mix(in oklch, var(--foreground) 90%, transparent);
+		background-color: var(--message-code-bg);
+		border: 1px solid color-mix(in oklch, var(--border) 45%, transparent);
+		box-shadow: none;
+		padding: 0.08em 0.34em;
+		border-radius: 0.4rem;
+	}
+	.dark .fz-prose code {
+		background-color: color-mix(
+			in oklch,
+			var(--bg-elevated) 34%,
+			var(--background)
+		);
+		box-shadow:
+			inset 0 1px 0 color-mix(in oklch, white 4%, transparent),
+			0 1px 2px color-mix(in oklch, black 22%, transparent);
+	}
+	.fz-prose pre {
+		background-color: color-mix(
+			in oklch,
+			var(--message-pre-bg) 90%,
+			var(--background)
+		);
+		border: 1px solid var(--message-rule);
+		border-radius: 0.75rem;
+		padding: 0.85em 1em;
+		margin: 0.8em 0;
+		overflow-x: auto;
+		font-size: 0.84em;
+		line-height: 1.55;
+	}
+	.fz-prose pre code {
+		color: var(--message-text);
+		background: transparent;
+		border: 0;
+		box-shadow: none;
+		padding: 0;
+		font-size: inherit;
+	}
+	.fz-prose .markdown-code-block {
+		margin: 0.9em 0;
+	}
+	/* Assistant code stays aligned with the reading column on the left, but
      reaches the transcript edge on the right. The scroll thumb therefore
      lives at the pane edge instead of floating beside the centered column. */
-  .chat-assistant-markdown > .markdown-code-block {
-    width: calc(
-      100cqw -
-      max(
-        var(--chat-row-gutter),
-        (100cqw - var(--chat-reading-column)) / 2
-      ) -
-      var(--chat-assistant-gutter)
-    );
-  }
-  .fz-prose .markdown-mermaid-block {
-    position: relative;
-    margin: 0.9em 0;
-    padding: 0;
-    overflow: hidden;
-    border: 1px solid color-mix(in oklch, var(--message-rule) 82%, transparent);
-    border-radius: 0.6rem;
-    background-color: var(--background);
-  }
-  .fz-prose .markdown-mermaid-block-error {
-    padding: 1rem 1rem 0;
-  }
-  .fz-prose .markdown-mermaid-loading,
-  .fz-prose .markdown-mermaid-error {
-    color: var(--text-muted);
-    font-size: 0.9em;
-  }
-  .fz-prose .markdown-mermaid-error {
-    color: color-mix(in oklch, var(--destructive) 78%, var(--foreground));
-  }
-  .markdown-mermaid-svg {
-    min-width: max-content;
-  }
-  .markdown-mermaid-svg svg {
-    display: block;
-    height: auto;
-    max-width: none;
-    margin: 0 auto;
-    overflow: visible;
-    shape-rendering: geometricPrecision;
-    text-rendering: geometricPrecision;
-  }
-  .markdown-mermaid-svg svg text,
-  .markdown-mermaid-svg svg tspan {
-    text-rendering: geometricPrecision;
-  }
-  .markdown-mermaid-zoom-label {
-    display: inline-flex;
-    min-width: 3.3rem;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.74rem;
-    line-height: 1;
-  }
-  .markdown-mermaid-shell {
-    position: relative;
-    display: flex;
-    min-height: 0;
-    min-width: 0;
-    flex: 1;
-    flex-direction: column;
-    background-color: var(--message-pre-bg);
-  }
-  .markdown-mermaid-shell-inline {
-    height: min(58vh, 520px);
-    min-height: 260px;
-  }
-  .markdown-mermaid-shell-dialog {
-    min-height: 0;
-  }
-  .markdown-mermaid-viewer-controls {
-    position: absolute;
-    top: 0.55rem;
-    right: 0.55rem;
-    z-index: 2;
-    display: inline-flex;
-    flex-shrink: 0;
-    align-items: center;
-    gap: 0.2rem;
-    padding: 0.15rem;
-    border: 1px solid var(--message-rule);
-    border-radius: 0.55rem;
-    background-color: var(--popover);
-    box-shadow: none;
-  }
-  .markdown-mermaid-viewer {
-    position: relative;
-    display: grid;
-    min-height: 0;
-    flex: 1;
-    place-items: center;
-    overflow: auto;
-    background-color: var(--message-pre-bg);
-    cursor: grab;
-    touch-action: none;
-    user-select: none;
-  }
-  .markdown-mermaid-viewer:active {
-    cursor: grabbing;
-  }
-  .markdown-mermaid-viewer-canvas {
-    min-width: max-content;
-    padding: 2rem;
-    border-radius: 0.7rem;
-    background-color: var(--message-pre-bg);
-    zoom: var(--markdown-mermaid-scale);
-  }
-  .markdown-mermaid-viewer-canvas .markdown-mermaid-svg {
-    min-width: 0;
-  }
-  .markdown-mermaid-viewer-canvas svg {
-    max-width: none;
-  }
-  .markdown-mermaid-pan-hint {
-    pointer-events: none;
-    position: absolute;
-    right: 0.9rem;
-    bottom: 0.9rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    border: 1px solid var(--message-rule);
-    border-radius: 0.45rem;
-    color: var(--text-muted);
-    background-color: var(--popover);
-  }
-  .dark .markdown-mermaid-shell,
-  .dark .markdown-mermaid-viewer,
-  .dark .markdown-mermaid-viewer-canvas {
-    background-color: #09090b;
-  }
-  .dark .markdown-mermaid-viewer-controls {
-    border-color: #3f3f46;
-    background-color: #18181b;
-    box-shadow: 0 10px 28px rgb(0 0 0 / 0.28);
-  }
-  .dark .markdown-mermaid-pan-hint {
-    border-color: #3f3f46;
-    background-color: #18181b;
-  }
-  .fz-prose .markdown-code-block code,
-  .fz-prose .markdown-code-block pre code,
-  .fz-prose .code-block-shiki code {
-    color: inherit;
-    background: transparent;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-    padding: 0;
-    font-size: inherit;
-  }
-  /* Rounded tables. `border-collapse: separate` so the outer radius works;
+	.chat-assistant-markdown > .markdown-code-block {
+		width: calc(
+			100cqw -
+			max(var(--chat-row-gutter), (100cqw - var(--chat-reading-column)) / 2) -
+			var(--chat-assistant-gutter)
+		);
+	}
+	.fz-prose .markdown-mermaid-block {
+		position: relative;
+		margin: 0.9em 0;
+		padding: 0;
+		overflow: hidden;
+		border: 1px solid color-mix(in oklch, var(--message-rule) 82%, transparent);
+		border-radius: 0.6rem;
+		background-color: var(--background);
+	}
+	.fz-prose .markdown-mermaid-block-error {
+		padding: 1rem 1rem 0;
+	}
+	.fz-prose .markdown-mermaid-loading,
+	.fz-prose .markdown-mermaid-error {
+		color: var(--text-muted);
+		font-size: 0.9em;
+	}
+	.fz-prose .markdown-mermaid-error {
+		color: color-mix(in oklch, var(--destructive) 78%, var(--foreground));
+	}
+	.markdown-mermaid-svg {
+		min-width: max-content;
+	}
+	.markdown-mermaid-svg svg {
+		display: block;
+		height: auto;
+		max-width: none;
+		margin: 0 auto;
+		overflow: visible;
+		shape-rendering: geometricPrecision;
+		text-rendering: geometricPrecision;
+	}
+	.markdown-mermaid-svg svg text,
+	.markdown-mermaid-svg svg tspan {
+		text-rendering: geometricPrecision;
+	}
+	.markdown-mermaid-zoom-label {
+		display: inline-flex;
+		min-width: 3.3rem;
+		align-items: center;
+		justify-content: center;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+		font-size: 0.74rem;
+		line-height: 1;
+	}
+	.markdown-mermaid-shell {
+		position: relative;
+		display: flex;
+		min-height: 0;
+		min-width: 0;
+		flex: 1;
+		flex-direction: column;
+		background-color: var(--message-pre-bg);
+	}
+	.markdown-mermaid-shell-inline {
+		height: min(58vh, 520px);
+		min-height: 260px;
+	}
+	.markdown-mermaid-shell-dialog {
+		min-height: 0;
+	}
+	.markdown-mermaid-viewer-controls {
+		position: absolute;
+		top: 0.55rem;
+		right: 0.55rem;
+		z-index: 2;
+		display: inline-flex;
+		flex-shrink: 0;
+		align-items: center;
+		gap: 0.2rem;
+		padding: 0.15rem;
+		border: 1px solid var(--message-rule);
+		border-radius: 0.55rem;
+		background-color: var(--popover);
+		box-shadow: none;
+	}
+	.markdown-mermaid-viewer {
+		position: relative;
+		display: grid;
+		min-height: 0;
+		flex: 1;
+		place-items: center;
+		overflow: auto;
+		background-color: var(--message-pre-bg);
+		cursor: grab;
+		touch-action: none;
+		user-select: none;
+	}
+	.markdown-mermaid-viewer:active {
+		cursor: grabbing;
+	}
+	.markdown-mermaid-viewer-canvas {
+		min-width: max-content;
+		padding: 2rem;
+		border-radius: 0.7rem;
+		background-color: var(--message-pre-bg);
+		zoom: var(--markdown-mermaid-scale);
+	}
+	.markdown-mermaid-viewer-canvas .markdown-mermaid-svg {
+		min-width: 0;
+	}
+	.markdown-mermaid-viewer-canvas svg {
+		max-width: none;
+	}
+	.markdown-mermaid-pan-hint {
+		pointer-events: none;
+		position: absolute;
+		right: 0.9rem;
+		bottom: 0.9rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		border: 1px solid var(--message-rule);
+		border-radius: 0.45rem;
+		color: var(--text-muted);
+		background-color: var(--popover);
+	}
+	.dark .markdown-mermaid-shell,
+	.dark .markdown-mermaid-viewer,
+	.dark .markdown-mermaid-viewer-canvas {
+		background-color: #09090b;
+	}
+	.dark .markdown-mermaid-viewer-controls {
+		border-color: #3f3f46;
+		background-color: #18181b;
+		box-shadow: 0 10px 28px rgb(0 0 0 / 0.28);
+	}
+	.dark .markdown-mermaid-pan-hint {
+		border-color: #3f3f46;
+		background-color: #18181b;
+	}
+	.fz-prose .markdown-code-block code,
+	.fz-prose .markdown-code-block pre code,
+	.fz-prose .code-block-shiki code {
+		color: inherit;
+		background: transparent;
+		border: 0;
+		border-radius: 0;
+		box-shadow: none;
+		padding: 0;
+		font-size: inherit;
+	}
+	/* Rounded tables. `border-collapse: separate` so the outer radius works;
      cells draw only inner dividers (right + bottom), the table draws the
      outer border, and corner cells round their own backgrounds. */
-  .fz-prose table {
-    width: auto;
-    border-collapse: separate;
-    border-spacing: 0;
-    margin: 0.8em 0;
-    font-size: 0.92em;
-    border: 1px solid var(--message-rule);
-    border-radius: 0.75rem;
-  }
-  .fz-prose th,
-  .fz-prose td {
-    border-right: 1px solid var(--message-rule);
-    border-bottom: 1px solid var(--message-rule);
-    padding: 0.4em 0.7em;
-    text-align: left;
-  }
-  .fz-prose tr > th:last-child,
-  .fz-prose tr > td:last-child {
-    border-right: 0;
-  }
-  .fz-prose tr:last-child > th,
-  .fz-prose tr:last-child > td {
-    border-bottom: 0;
-  }
-  .fz-prose tr:first-child > th:first-child,
-  .fz-prose tr:first-child > td:first-child {
-    border-top-left-radius: calc(0.75rem - 1px);
-  }
-  .fz-prose tr:first-child > th:last-child,
-  .fz-prose tr:first-child > td:last-child {
-    border-top-right-radius: calc(0.75rem - 1px);
-  }
-  .fz-prose tr:last-child > th:first-child,
-  .fz-prose tr:last-child > td:first-child {
-    border-bottom-left-radius: calc(0.75rem - 1px);
-  }
-  .fz-prose tr:last-child > th:last-child,
-  .fz-prose tr:last-child > td:last-child {
-    border-bottom-right-radius: calc(0.75rem - 1px);
-  }
-  .fz-prose th {
-    color: var(--message-heading);
-    font-weight: 600;
-    background-color: color-mix(
-      in oklch,
-      var(--message-pre-bg) 72%,
-      var(--background)
-    );
-  }
+	.fz-prose table {
+		width: auto;
+		border-collapse: separate;
+		border-spacing: 0;
+		margin: 0.8em 0;
+		font-size: 0.92em;
+		border: 1px solid var(--message-rule);
+		border-radius: 0.75rem;
+	}
+	.fz-prose th,
+	.fz-prose td {
+		border-right: 1px solid var(--message-rule);
+		border-bottom: 1px solid var(--message-rule);
+		padding: 0.4em 0.7em;
+		text-align: left;
+	}
+	.fz-prose tr > th:last-child,
+	.fz-prose tr > td:last-child {
+		border-right: 0;
+	}
+	.fz-prose tr:last-child > th,
+	.fz-prose tr:last-child > td {
+		border-bottom: 0;
+	}
+	.fz-prose tr:first-child > th:first-child,
+	.fz-prose tr:first-child > td:first-child {
+		border-top-left-radius: calc(0.75rem - 1px);
+	}
+	.fz-prose tr:first-child > th:last-child,
+	.fz-prose tr:first-child > td:last-child {
+		border-top-right-radius: calc(0.75rem - 1px);
+	}
+	.fz-prose tr:last-child > th:first-child,
+	.fz-prose tr:last-child > td:first-child {
+		border-bottom-left-radius: calc(0.75rem - 1px);
+	}
+	.fz-prose tr:last-child > th:last-child,
+	.fz-prose tr:last-child > td:last-child {
+		border-bottom-right-radius: calc(0.75rem - 1px);
+	}
+	.fz-prose th {
+		color: var(--message-heading);
+		font-weight: 600;
+		background-color: color-mix(
+			in oklch,
+			var(--message-pre-bg) 72%,
+			var(--background)
+		);
+	}
 }
 
 /* Composer atomic chips. Filled tag that visually replaces the underlying
    token (e.g. `@apps/foo.ts`) with an icon + label. Sized to sit on the
    prose baseline without disturbing line-height. */
 @layer components {
-  .fz-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.12rem 0.5rem 0.12rem 0.18rem;
-    margin: 0 0.15rem;
-    border: 1px solid color-mix(in srgb, var(--border), transparent 55%);
-    border-radius: 0.45rem;
-    background-color: var(--chip-bg);
-    box-shadow: none;
-    color: var(--foreground);
-    font-size: 0.85em;
-    line-height: 1.1;
-    /* Center the chip against the surrounding text line instead of hanging
+	.fz-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.12rem 0.5rem 0.12rem 0.18rem;
+		margin: 0 0.15rem;
+		border: 1px solid color-mix(in srgb, var(--border), transparent 55%);
+		border-radius: 0.45rem;
+		background-color: var(--chip-bg);
+		box-shadow: none;
+		color: var(--foreground);
+		font-size: 0.85em;
+		line-height: 1.1;
+		/* Center the chip against the surrounding text line instead of hanging
        below the baseline — keeps chips and typed text on one visual line. */
-    vertical-align: middle;
-    transform: translateY(-0.06em);
-    user-select: none;
-    white-space: nowrap;
-  }
-  .fz-chip-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.4em;
-    height: 1.4em;
-    border-radius: 0.25rem;
-    background-color: color-mix(
-      in oklch,
-      var(--chip-bg) 60%,
-      var(--foreground) 6%
-    );
-    flex-shrink: 0;
-  }
-  .fz-chip-iconimg {
-    width: 1em;
-    height: 1em;
-    object-fit: contain;
-  }
-  .fz-chip-thumb {
-    width: 1.4em;
-    height: 1.4em;
-    object-fit: cover;
-    border-radius: 0.25rem;
-  }
-  .fz-chip-divider {
-    display: none;
-  }
-  .fz-chip-label {
-    color: var(--foreground);
-  }
-  .fz-chip[data-kind="file"] {
-    cursor: pointer;
-  }
-  .fz-chip[data-kind="file"]:hover,
-  .fz-chip[data-kind="image"]:hover {
-    background-color: color-mix(
-      in oklch,
-      var(--chip-bg) 80%,
-      var(--foreground) 4%
-    );
-    box-shadow: none;
-  }
-  .dark .fz-chip {
-    box-shadow:
-      0 1px 0 color-mix(in oklch, white 4%, transparent) inset,
-      0 1px 2px color-mix(in oklch, black 22%, transparent);
-  }
-  .dark .fz-chip[data-kind="file"]:hover,
-  .dark .fz-chip[data-kind="image"]:hover {
-    box-shadow:
-      0 1px 0 color-mix(in oklch, white 6%, transparent) inset,
-      0 2px 5px color-mix(in oklch, black 24%, transparent);
-  }
-  /* Image-thumb chips: thumbnail fills the icon slot with no inner bg. */
-  .fz-chip[data-kind="image"] .fz-chip-icon:has(.fz-chip-thumb) {
-    background-color: transparent;
-  }
+		vertical-align: middle;
+		transform: translateY(-0.06em);
+		user-select: none;
+		white-space: nowrap;
+	}
+	.fz-chip-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.4em;
+		height: 1.4em;
+		border-radius: 0.25rem;
+		background-color: color-mix(
+			in oklch,
+			var(--chip-bg) 60%,
+			var(--foreground) 6%
+		);
+		flex-shrink: 0;
+	}
+	.fz-chip-iconimg {
+		width: 1em;
+		height: 1em;
+		object-fit: contain;
+	}
+	.fz-chip-thumb {
+		width: 1.4em;
+		height: 1.4em;
+		object-fit: cover;
+		border-radius: 0.25rem;
+	}
+	.fz-chip-divider {
+		display: none;
+	}
+	.fz-chip-label {
+		color: var(--foreground);
+	}
+	.fz-chip[data-kind="file"] {
+		cursor: pointer;
+	}
+	.fz-chip[data-kind="file"]:hover,
+	.fz-chip[data-kind="image"]:hover {
+		background-color: color-mix(
+			in oklch,
+			var(--chip-bg) 80%,
+			var(--foreground) 4%
+		);
+		box-shadow: none;
+	}
+	.dark .fz-chip {
+		box-shadow:
+			0 1px 0 color-mix(in oklch, white 4%, transparent) inset,
+			0 1px 2px color-mix(in oklch, black 22%, transparent);
+	}
+	.dark .fz-chip[data-kind="file"]:hover,
+	.dark .fz-chip[data-kind="image"]:hover {
+		box-shadow:
+			0 1px 0 color-mix(in oklch, white 6%, transparent) inset,
+			0 2px 5px color-mix(in oklch, black 24%, transparent);
+	}
+	/* Image-thumb chips: thumbnail fills the icon slot with no inner bg. */
+	.fz-chip[data-kind="image"] .fz-chip-icon:has(.fz-chip-thumb) {
+		background-color: transparent;
+	}
 }
 
 /* ============================================================
@@ -1061,250 +1151,251 @@ body,
 /* Lime glow utilities. All alpha layers derived from --lime via color-mix
    so re-toning the accent (in .dark { --lime: … }) propagates here. */
 @layer components {
-  .neon-lime {
-    color: var(--lime);
-    text-shadow: none;
-  }
+	.neon-lime {
+		color: var(--lime);
+		text-shadow: none;
+	}
 
-  .shadow-lime-glow {
-    box-shadow: 0 0 0 1px color-mix(in oklch, var(--lime) 24%, transparent);
-  }
+	.shadow-lime-glow {
+		box-shadow: 0 0 0 1px color-mix(in oklch, var(--lime) 24%, transparent);
+	}
 
-  .shadow-lime-glow-strong {
-    box-shadow: 0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent);
-  }
+	.shadow-lime-glow-strong {
+		box-shadow: 0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent);
+	}
 
-  /* Overlay elevation classes — raw box-shadow so they work in light mode
+	/* Overlay elevation classes — raw box-shadow so they work in light mode
      despite the --tw-shadow kill in @layer base. */
-  .shadow-overlay {
-    box-shadow: var(--shadow-overlay);
-  }
-  .shadow-overlay-sm {
-    box-shadow: var(--shadow-overlay-sm);
-  }
-  .shadow-overlay-lg {
-    box-shadow: var(--shadow-overlay-lg);
-  }
+	.shadow-overlay {
+		box-shadow: var(--shadow-overlay);
+	}
+	.shadow-overlay-sm {
+		box-shadow: var(--shadow-overlay-sm);
+	}
+	.shadow-overlay-lg {
+		box-shadow: var(--shadow-overlay-lg);
+	}
 
-  /* Glass surface for anchored popups (menus, popovers, selects).
+	/* Glass surface for anchored popups (menus, popovers, selects).
      Dark: translucent popover + blur + dual ring (inner white highlight,
      outer black seam) + elevation, all in one box-shadow stack.
      Light: glass reads muddy, so it degrades to an opaque white panel whose
      edge comes from the 1px ring baked into --shadow-overlay. */
-  .bg-glass {
-    background-color: var(--popover);
-    color: var(--popover-foreground);
-  }
-  .dark .bg-glass {
-    background-color: color-mix(in oklab, var(--popover) 70%, transparent);
-    backdrop-filter: blur(14px) saturate(1.1);
-  }
-  /* Composer surface: subtler glass than menus — mostly opaque so typing
+	.bg-glass {
+		background-color: var(--popover);
+		color: var(--popover-foreground);
+	}
+	.dark .bg-glass {
+		background-color: color-mix(in oklab, var(--popover) 70%, transparent);
+		backdrop-filter: blur(14px) saturate(1.1);
+	}
+	/* Composer surface: subtler glass than menus — mostly opaque so typing
      stays legible, but timeline text scrolling underneath shows through
      faintly. */
-  /* The Frame is the ONLY painted layer of the composer (the inner Card is
+	/* The Frame is the ONLY painted layer of the composer (the inner Card is
      bg-transparent) — stacking translucent layers just re-opacifies the
      whole thing and defeats the glass. The tint lives on a ::before overlay
      so no bg-* utility on the element can override it (utilities layer
      always beats components layer; pair with bg-transparent at call site). */
-  .composer-glass {
-    position: relative;
-    backdrop-filter: blur(20px) saturate(1.05);
-  }
-  .composer-glass::before {
-    content: "";
-    pointer-events: none;
-    position: absolute;
-    inset: 0;
-    /* Below ALL children (footer buttons included) — backdrop-filter gives
+	.composer-glass {
+		position: relative;
+		backdrop-filter: blur(20px) saturate(1.05);
+	}
+	.composer-glass::before {
+		content: "";
+		pointer-events: none;
+		position: absolute;
+		inset: 0;
+		/* Below ALL children (footer buttons included) — backdrop-filter gives
        the Frame its own stacking context, so -1 stays inside it. */
-    z-index: -1;
-    border-radius: inherit;
-    background-color: color-mix(in oklab, var(--secondary) 80%, transparent);
-  }
-  .dark .composer-glass::before {
-    background-color: color-mix(in oklab, var(--secondary) 58%, transparent);
-  }
+		z-index: -1;
+		border-radius: inherit;
+		background-color: color-mix(in oklab, var(--secondary) 80%, transparent);
+	}
+	.dark .composer-glass::before {
+		background-color: color-mix(in oklab, var(--secondary) 58%, transparent);
+	}
 
-  .border-glass {
-    box-shadow: var(--shadow-overlay);
-  }
-  .dark .border-glass {
-    box-shadow:
-      inset 0 0 0 1px hsl(0 0% 100% / 0.1),
-      0 0 0 0.5px hsl(0 0% 0% / 0.8),
-      var(--shadow-overlay);
-  }
+	.border-glass {
+		box-shadow: var(--shadow-overlay);
+	}
+	.dark .border-glass {
+		box-shadow:
+			inset 0 0 0 1px hsl(0 0% 100% / 0.1),
+			0 0 0 0.5px hsl(0 0% 0% / 0.8),
+			var(--shadow-overlay);
+	}
 
-  /* Embodied primary button */
-  .btn-lime-embodied {
-    transition:
-      box-shadow 120ms cubic-bezier(0.23, 1, 0.32, 1),
-      transform 80ms cubic-bezier(0.23, 1, 0.32, 1),
-      background-color 120ms ease;
-  }
-  .btn-lime-embodied:hover:not(:disabled):not([data-loading]) {
-    box-shadow: var(--tw-shadow, 0 0 #0000);
-    transform: translateY(-0.5px);
-  }
-  .btn-lime-embodied:active:not(:disabled):not([data-loading]),
-  .btn-lime-embodied[data-pressed]:not(:disabled):not([data-loading]) {
-    transform: translateY(0.5px) scale(0.985);
-    box-shadow: var(--tw-shadow, 0 0 #0000);
-  }
+	/* Embodied primary button */
+	.btn-lime-embodied {
+		transition:
+			box-shadow 120ms cubic-bezier(0.23, 1, 0.32, 1),
+			transform 80ms cubic-bezier(0.23, 1, 0.32, 1),
+			background-color 120ms ease;
+	}
+	.btn-lime-embodied:hover:not(:disabled):not([data-loading]) {
+		box-shadow: var(--tw-shadow, 0 0 #0000);
+		transform: translateY(-0.5px);
+	}
+	.btn-lime-embodied:active:not(:disabled):not([data-loading]),
+	.btn-lime-embodied[data-pressed]:not(:disabled):not([data-loading]) {
+		transform: translateY(0.5px) scale(0.985);
+		box-shadow: var(--tw-shadow, 0 0 #0000);
+	}
 
-  /* Framed card polish — ensure inner FramePanels get the full layered
+	/* Framed card polish — ensure inner FramePanels get the full layered
      bevel treatment when nested inside the main shell Frames. */
-  [data-slot="frame"] [data-slot="card"] {
-    box-shadow: var(--tw-shadow, 0 0 #0000);
-  }
+	[data-slot="frame"] [data-slot="card"] {
+		box-shadow: var(--tw-shadow, 0 0 #0000);
+	}
 
-  /* Tinted glass surfaces (PR card states, status buttons). Reads --tone
+	/* Tinted glass surfaces (PR card states, status buttons). Reads --tone
      from a per-instance CSS var, e.g.
        <div class="glass-tone" style={{ "--tone": "var(--accent-blue)" }}>
      The bg + inset highlight + text color all derive from one var so we
      never duplicate per-tone classes. */
-  .glass-tone {
-    background-color: color-mix(in oklch, var(--tone) 15%, transparent);
-    /* Light mode: bias toward the near-black foreground so tinted labels
+	.glass-tone {
+		background-color: color-mix(in oklch, var(--tone) 15%, transparent);
+		/* Light mode: bias toward the near-black foreground so tinted labels
        stay crisp on pale tinted fills instead of pastel-on-pastel. */
-    color: color-mix(in oklch, var(--tone) 48%, var(--foreground));
-    box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--tone) 22%, transparent);
-    backdrop-filter: blur(12px);
-  }
-  .glass-tone:hover:not(:disabled) {
-    background-color: color-mix(in oklch, var(--tone) 20%, transparent);
-  }
-  .glass-tone:active:not(:disabled) {
-    background-color: color-mix(in oklch, var(--tone) 26%, transparent);
-  }
+		color: color-mix(in oklch, var(--tone) 48%, var(--foreground));
+		box-shadow: inset 0 0 0 1px
+			color-mix(in oklch, var(--tone) 22%, transparent);
+		backdrop-filter: blur(12px);
+	}
+	.glass-tone:hover:not(:disabled) {
+		background-color: color-mix(in oklch, var(--tone) 20%, transparent);
+	}
+	.glass-tone:active:not(:disabled) {
+		background-color: color-mix(in oklch, var(--tone) 26%, transparent);
+	}
 
-  /* Untinted glass — same shape, neutral palette. Used for secondary actions. */
-  .glass-neutral {
-    background-color: var(--color-neutral-primary-reverted-5);
-    color: var(--foreground);
-    box-shadow: none;
-    backdrop-filter: blur(12px);
-  }
-  .glass-neutral:hover:not(:disabled) {
-    background-color: var(--color-neutral-primary-reverted-20);
-  }
-  .glass-neutral:active:not(:disabled) {
-    background-color: rgba(255, 255, 255, 0.16);
-  }
+	/* Untinted glass — same shape, neutral palette. Used for secondary actions. */
+	.glass-neutral {
+		background-color: var(--color-neutral-primary-reverted-5);
+		color: var(--foreground);
+		box-shadow: none;
+		backdrop-filter: blur(12px);
+	}
+	.glass-neutral:hover:not(:disabled) {
+		background-color: var(--color-neutral-primary-reverted-20);
+	}
+	.glass-neutral:active:not(:disabled) {
+		background-color: rgba(255, 255, 255, 0.16);
+	}
 
-  .dark .neon-lime {
-    text-shadow:
-      0 0 4px color-mix(in oklch, var(--lime) 25%, transparent),
-      0 0 12px color-mix(in oklch, var(--lime) 15%, transparent);
-  }
+	.dark .neon-lime {
+		text-shadow:
+			0 0 4px color-mix(in oklch, var(--lime) 25%, transparent),
+			0 0 12px color-mix(in oklch, var(--lime) 15%, transparent);
+	}
 
-  .dark .shadow-lime-glow {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 20%, transparent),
-      0 0 10px color-mix(in oklch, var(--lime) 25%, transparent),
-      0 0 24px color-mix(in oklch, var(--lime) 15%, transparent);
-  }
+	.dark .shadow-lime-glow {
+		box-shadow:
+			0 0 0 1px color-mix(in oklch, var(--lime) 20%, transparent),
+			0 0 10px color-mix(in oklch, var(--lime) 25%, transparent),
+			0 0 24px color-mix(in oklch, var(--lime) 15%, transparent);
+	}
 
-  .dark .shadow-lime-glow-strong {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent),
-      0 0 14px color-mix(in oklch, var(--lime) 36%, transparent),
-      0 0 32px color-mix(in oklch, var(--lime) 24%, transparent);
-  }
+	.dark .shadow-lime-glow-strong {
+		box-shadow:
+			0 0 0 1px color-mix(in oklch, var(--lime) 32%, transparent),
+			0 0 14px color-mix(in oklch, var(--lime) 36%, transparent),
+			0 0 32px color-mix(in oklch, var(--lime) 24%, transparent);
+	}
 
-  .dark .btn-lime-embodied:hover:not(:disabled):not([data-loading]) {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 25%, transparent),
-      0 0 12px color-mix(in oklch, var(--lime) 32%, transparent),
-      var(--tw-shadow, 0 0 #0000);
-  }
+	.dark .btn-lime-embodied:hover:not(:disabled):not([data-loading]) {
+		box-shadow:
+			0 0 0 1px color-mix(in oklch, var(--lime) 25%, transparent),
+			0 0 12px color-mix(in oklch, var(--lime) 32%, transparent),
+			var(--tw-shadow, 0 0 #0000);
+	}
 
-  .dark .btn-lime-embodied:active:not(:disabled):not([data-loading]),
-  .dark .btn-lime-embodied[data-pressed]:not(:disabled):not([data-loading]) {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--lime) 15%, transparent),
-      0 0 6px color-mix(in oklch, var(--lime) 20%, transparent),
-      var(--tw-shadow, 0 0 #0000);
-  }
+	.dark .btn-lime-embodied:active:not(:disabled):not([data-loading]),
+	.dark .btn-lime-embodied[data-pressed]:not(:disabled):not([data-loading]) {
+		box-shadow:
+			0 0 0 1px color-mix(in oklch, var(--lime) 15%, transparent),
+			0 0 6px color-mix(in oklch, var(--lime) 20%, transparent),
+			var(--tw-shadow, 0 0 #0000);
+	}
 
-  .dark [data-slot="frame"] [data-slot="card"] {
-    box-shadow:
-      0 1px 0 oklch(1 0 0 / 0.035) inset,
-      0 -1px 0 oklch(0 0 0 / 0.25) inset,
-      var(--tw-shadow, 0 0 #0000);
-  }
+	.dark [data-slot="frame"] [data-slot="card"] {
+		box-shadow:
+			0 1px 0 oklch(1 0 0 / 0.035) inset,
+			0 -1px 0 oklch(0 0 0 / 0.25) inset,
+			var(--tw-shadow, 0 0 #0000);
+	}
 
-  .dark .glass-tone {
-    color: color-mix(in oklch, var(--tone) 88%, white);
-    box-shadow:
-      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.04),
-      inset 0 1px 0 0 color-mix(in oklch, var(--tone) 24%, transparent),
-      inset 0 2px 3px 0 color-mix(in oklch, var(--tone) 14%, transparent);
-  }
+	.dark .glass-tone {
+		color: color-mix(in oklch, var(--tone) 88%, white);
+		box-shadow:
+			0 2px 1.5px -0.5px rgba(0, 0, 0, 0.04),
+			inset 0 1px 0 0 color-mix(in oklch, var(--tone) 24%, transparent),
+			inset 0 2px 3px 0 color-mix(in oklch, var(--tone) 14%, transparent);
+	}
 
-  .dark .glass-neutral {
-    box-shadow:
-      0 2px 1.5px -0.5px rgba(0, 0, 0, 0.03),
-      inset 0 2px 3px 0 rgba(255, 255, 255, 0.03);
-  }
+	.dark .glass-neutral {
+		box-shadow:
+			0 2px 1.5px -0.5px rgba(0, 0, 0, 0.03),
+			inset 0 2px 3px 0 rgba(255, 255, 255, 0.03);
+	}
 }
 
 /* Lime focus ring override for inputs/selects when inside dark framed surfaces */
 @layer base {
-  .dark .focus-lime-ring:focus-visible,
-  .dark [data-slot="input-control"]:has(:focus-visible) {
-    --ring: oklch(0.82 0.17 102 / 0.55);
-  }
+	.dark .focus-lime-ring:focus-visible,
+	.dark [data-slot="input-control"]:has(:focus-visible) {
+		--ring: oklch(0.82 0.17 102 / 0.55);
+	}
 }
 
 /* Shiki output container — line numbers gutter + padding + font.
    Shiki emits `<pre class="shiki ..."><code><span class="line" data-line>…`. */
 @layer components {
-  .code-block-shiki pre {
-    margin: 0;
-    padding: 6px 0;
-    /* CodeBlock draws its own frame; kill the .fz-prose pre card styling so
+	.code-block-shiki pre {
+		margin: 0;
+		padding: 6px 0;
+		/* CodeBlock draws its own frame; kill the .fz-prose pre card styling so
        fenced blocks don't render as a card inside a card. */
-    border: 0;
-    border-radius: 0;
-    background: transparent !important;
-    color: var(--message-text);
-    font-family: var(
-      --font-mono,
-      ui-monospace,
-      SFMono-Regular,
-      Menlo,
-      monospace
-    );
-    font-size: 12px;
-    line-height: 1.3;
-  }
-  .code-block-shiki code {
-    display: block;
-    width: max-content;
-    min-width: 100%;
-  }
-  .code-block-shiki .line {
-    display: block;
-    min-height: 1.3em;
-    padding: 0 10px;
-  }
-  /* Scrollbar polish — match xterm-viewport style. */
-  .code-block-scroll::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  .code-block-scroll::-webkit-scrollbar-thumb {
-    background: transparent;
-    border-radius: 999px;
-  }
-  .code-block-scroll:hover::-webkit-scrollbar-thumb,
-  .code-block-scroll:focus::-webkit-scrollbar-thumb {
-    background: var(--bg-overlay);
-  }
-  .code-block-scroll::-webkit-scrollbar-track,
-  .code-block-scroll::-webkit-scrollbar-corner {
-    background: transparent;
-  }
+		border: 0;
+		border-radius: 0;
+		background: transparent !important;
+		color: var(--message-text);
+		font-family: var(
+			--font-mono,
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			monospace
+		);
+		font-size: 12px;
+		line-height: 1.3;
+	}
+	.code-block-shiki code {
+		display: block;
+		width: max-content;
+		min-width: 100%;
+	}
+	.code-block-shiki .line {
+		display: block;
+		min-height: 1.3em;
+		padding: 0 10px;
+	}
+	/* Scrollbar polish — match xterm-viewport style. */
+	.code-block-scroll::-webkit-scrollbar {
+		width: 6px;
+		height: 6px;
+	}
+	.code-block-scroll::-webkit-scrollbar-thumb {
+		background: transparent;
+		border-radius: 999px;
+	}
+	.code-block-scroll:hover::-webkit-scrollbar-thumb,
+	.code-block-scroll:focus::-webkit-scrollbar-thumb {
+		background: var(--bg-overlay);
+	}
+	.code-block-scroll::-webkit-scrollbar-track,
+	.code-block-scroll::-webkit-scrollbar-corner {
+		background: transparent;
+	}
 }

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -512,8 +512,8 @@ body,
 	}
 }
 
-/* Applied only while the projects sidebar is programmatically opened or
-   closed, so manual resizing stays directly under the pointer. */
+/* Applied only while a sidebar is programmatically opened or closed, so
+   manual resizing stays directly under the pointer. */
 .fz-sidebar-panel-motion {
 	transition: flex-grow 180ms cubic-bezier(0.645, 0.045, 0.355, 1);
 }

--- a/apps/server/src/analytics/layers/analytics-service.ts
+++ b/apps/server/src/analytics/layers/analytics-service.ts
@@ -23,7 +23,6 @@ import { SqlClient } from "effect/unstable/sql";
 
 import { AppPaths } from "../../app-paths.ts";
 import { AuthService } from "../../auth/services/auth-service.ts";
-import { ConfigStoreService } from "../../config-store/services/config-store-service.ts";
 import { AnalyticsService } from "../services/analytics-service.ts";
 
 const POSTHOG_KEY = (process.env.ZUSE_POSTHOG_KEY ?? "").trim();
@@ -79,7 +78,6 @@ export const AnalyticsServiceLive = Layer.effect(
 		const sql = yield* SqlClient.SqlClient;
 		const fileSystem = yield* FileSystem.FileSystem;
 		const paths = yield* AppPaths;
-		const settings = yield* ConfigStoreService;
 		const auth = yield* AuthService;
 		const contextPubSub = yield* PubSub.unbounded<SharedAnalyticsContext>();
 		const flushLock = yield* Semaphore.make(1);
@@ -104,11 +102,10 @@ export const AnalyticsServiceLive = Layer.effect(
 			),
 		);
 
-		const initialSettings = yield* settings.getSettings();
 		const initialAuth = yield* auth.getSession();
 		const initialAnonymousId = yield* loadAnonymousId;
 		const initialContext = AnalyticsContext.make({
-			enabled: initialSettings.analyticsEnabled,
+			enabled: true,
 			distinctId:
 				initialAuth._tag === "SignedIn"
 					? analyticsAccountId(initialAuth.session.user.id)
@@ -128,23 +125,6 @@ export const AnalyticsServiceLive = Layer.effect(
 						: Effect.void,
 				),
 			);
-
-		const purge = sql`DELETE FROM analytics_outbox`.pipe(
-			Effect.asVoid,
-			Effect.catch(() => Effect.void),
-		);
-
-		yield* Stream.runForEach(settings.settingsChanges(), (nextSettings) =>
-			Effect.gen(function* () {
-				const current = yield* Ref.get(contextRef);
-				const next = AnalyticsContext.make({
-					...current,
-					enabled: nextSettings.analyticsEnabled,
-				});
-				yield* publishContext(next);
-				if (!next.enabled) yield* purge;
-			}),
-		).pipe(Effect.forkScoped);
 
 		yield* Stream.runForEach(auth.sessionChanges(), (authState) =>
 			Effect.gen(function* () {
@@ -262,11 +242,15 @@ export const AnalyticsServiceLive = Layer.effect(
 			const deadline = Date.now() + 10_000;
 			while (Date.now() < deadline) {
 				const now = new Date().toISOString();
-				const before = yield* sql<{ readonly count: number }>`SELECT COUNT(*) AS count
+				const before = yield* sql<{
+					readonly count: number;
+				}>`SELECT COUNT(*) AS count
 					FROM analytics_outbox WHERE next_attempt_at <= ${now}`;
 				if ((before[0]?.count ?? 0) === 0) return;
 				yield* flush;
-				const after = yield* sql<{ readonly count: number }>`SELECT COUNT(*) AS count
+				const after = yield* sql<{
+					readonly count: number;
+				}>`SELECT COUNT(*) AS count
 					FROM analytics_outbox WHERE next_attempt_at <= ${new Date().toISOString()}`;
 				// A failed batch is deferred by `flush`; do not spin during shutdown.
 				if ((after[0]?.count ?? 0) >= (before[0]?.count ?? 0)) return;

--- a/apps/server/src/config-store/layers/config-store-service.ts
+++ b/apps/server/src/config-store/layers/config-store-service.ts
@@ -5,9 +5,9 @@ import * as NodePath from "node:path";
 import {
 	type AppearanceMode,
 	type BranchNamingStyle,
-  type Command,
-  type CompletionSoundPreset,
-  defaultModelEnabledByProvider,
+	type Command,
+	type CompletionSoundPreset,
+	defaultModelEnabledByProvider,
 	defaultModelFor,
 	type KeybindingRule,
 	KeybindingsFile,
@@ -32,8 +32,8 @@ import {
 
 import { AppPaths } from "../../app-paths.ts";
 import {
-  ConfigStoreService,
-  type ConfigStoreServiceShape,
+	ConfigStoreService,
+	type ConfigStoreServiceShape,
 } from "../services/config-store-service.ts";
 
 /**
@@ -49,150 +49,149 @@ const USER_CONFIG_DIRNAME = ".zuse";
 const DEV_USER_CONFIG_DIRNAME = ".zuse-dev";
 
 const PROVIDER_IDS: ProviderId[] = [
-  "claude",
-  "codex",
-  "grok",
-  "cursor",
-  "gemini",
-  "opencode",
+	"claude",
+	"codex",
+	"grok",
+	"cursor",
+	"gemini",
+	"opencode",
 ];
 
 const seedModels = (): Record<ProviderId, string> => ({
-  claude: defaultModelFor("claude"),
-  codex: defaultModelFor("codex"),
-  grok: defaultModelFor("grok"),
-  cursor: defaultModelFor("cursor"),
-  gemini: defaultModelFor("gemini"),
-  opencode: defaultModelFor("opencode"),
+	claude: defaultModelFor("claude"),
+	codex: defaultModelFor("codex"),
+	grok: defaultModelFor("grok"),
+	cursor: defaultModelFor("cursor"),
+	gemini: defaultModelFor("gemini"),
+	opencode: defaultModelFor("opencode"),
 });
 
 const seedProviderEnabled = (): Record<ProviderId, boolean> => {
-  const out = {} as Record<ProviderId, boolean>;
-  for (const id of PROVIDER_IDS) out[id] = true;
-  return out;
+	const out = {} as Record<ProviderId, boolean>;
+	for (const id of PROVIDER_IDS) out[id] = true;
+	return out;
 };
 
 const seedModelEnabledByProvider = defaultModelEnabledByProvider;
 
 const freshSettings = (): SettingsFile =>
-  SettingsFile.make({
-    schemaVersion: 1,
-    defaultProviderId: "claude",
-    defaultModelByProvider: seedModels(),
-    defaultRuntimeMode: "approval-required",
-    // Worktrees on by default: each new chat runs on its own branch so parallel
-    // agents stay isolated. Per-repo settings can still opt a repo out.
-    defaultAutoCreateWorktree: true,
-    defaultAutonomyLevel: "approval-gated",
-    onboardingCompleted: false,
+	SettingsFile.make({
+		schemaVersion: 1,
+		defaultProviderId: "claude",
+		defaultModelByProvider: seedModels(),
+		defaultRuntimeMode: "approval-required",
+		// Worktrees on by default: each new chat runs on its own branch so parallel
+		// agents stay isolated. Per-repo settings can still opt a repo out.
+		defaultAutoCreateWorktree: true,
+		defaultAutonomyLevel: "approval-gated",
+		onboardingCompleted: false,
 		appearanceMode: "dark",
 		completionSoundEnabled: false,
 		completionSoundPreset: "chime",
-		analyticsEnabled: true,
 		providerEnabled: seedProviderEnabled(),
 		modelEnabledByProvider: seedModelEnabledByProvider(),
 		opencodeProviderVisible: {},
-    opencodeModelVisibleByProvider: {},
-    opencodeCustomProviders: [],
-    mcpDisabledServers: [],
-    subagents: { enableForNewSessions: true, presets: {} },
-    branchNamingStyle: "username-slug",
-    branchNamingPrefix: "",
-    mergePrefs: { method: "merge", deleteBranch: false },
-    notchTrayEnabled: false,
-    notchTrayPinned: false,
-  });
+		opencodeModelVisibleByProvider: {},
+		opencodeCustomProviders: [],
+		mcpDisabledServers: [],
+		subagents: { enableForNewSessions: true, presets: {} },
+		branchNamingStyle: "username-slug",
+		branchNamingPrefix: "",
+		mergePrefs: { method: "merge", deleteBranch: false },
+		notchTrayEnabled: false,
+		notchTrayPinned: false,
+	});
 
 const freshKeybindings = (): KeybindingsFile =>
-  KeybindingsFile.make({ schemaVersion: 1, rules: [] });
+	KeybindingsFile.make({ schemaVersion: 1, rules: [] });
 
 const serialize = (value: unknown): string =>
-  `${JSON.stringify(value, null, 2)}\n`;
+	`${JSON.stringify(value, null, 2)}\n`;
 
 /* ───────────── parse helpers — tolerant of legacy / missing fields ───────────── */
 
 const isProviderId = (v: unknown): v is ProviderId =>
-  v === "claude" ||
-  v === "codex" ||
-  v === "grok" ||
-  v === "cursor" ||
-  v === "gemini" ||
-  v === "opencode";
+	v === "claude" ||
+	v === "codex" ||
+	v === "grok" ||
+	v === "cursor" ||
+	v === "gemini" ||
+	v === "opencode";
 
 const isRuntimeMode = (v: unknown): v is SettingsFile["defaultRuntimeMode"] =>
-  v === "approval-required" ||
-  v === "auto-accept-edits" ||
-  v === "auto-accept-edits-and-bash" ||
-  v === "full-access";
+	v === "approval-required" ||
+	v === "auto-accept-edits" ||
+	v === "auto-accept-edits-and-bash" ||
+	v === "full-access";
 
 const isAutonomyLevel = (
-  v: unknown,
+	v: unknown,
 ): v is SettingsFile["defaultAutonomyLevel"] =>
-  v === "off" || v === "approval-gated" || v === "autonomous";
+	v === "off" || v === "approval-gated" || v === "autonomous";
 
 const isCompletionSoundPreset = (v: unknown): v is CompletionSoundPreset =>
-  v === "chime" ||
-  v === "soft" ||
-  v === "pop" ||
-  v === "bell" ||
-  v === "rise" ||
-  v === "bloom";
+	v === "chime" ||
+	v === "soft" ||
+	v === "pop" ||
+	v === "bell" ||
+	v === "rise" ||
+	v === "bloom";
 
 const isAppearanceMode = (v: unknown): v is AppearanceMode =>
-  v === "system" || v === "light" || v === "dark";
+	v === "system" || v === "light" || v === "dark";
 
 const isBranchNamingStyle = (v: unknown): v is BranchNamingStyle =>
-  v === "username-slug" || v === "slug" || v === "feat-slug" || v === "custom";
+	v === "username-slug" || v === "slug" || v === "feat-slug" || v === "custom";
 
 const isMergeMethod = (v: unknown): v is MergePrefs["method"] =>
-  v === "merge" || v === "squash" || v === "rebase";
+	v === "merge" || v === "squash" || v === "rebase";
 
 const isCommand = (v: unknown): v is Command =>
-  v === "new-chat" ||
-  v === "open-project" ||
-  v === "settings" ||
-  v === "close-tab" ||
-  v === "toggle-left-sidebar" ||
-  v === "toggle-right-sidebar" ||
-  v === "toggle-terminal" ||
-  v === "focus-composer" ||
-  v === "next-tab" ||
-  v === "prev-tab" ||
-  v === "select-tab-1" ||
-  v === "select-tab-2" ||
-  v === "select-tab-3" ||
-  v === "select-tab-4" ||
-  v === "select-tab-5" ||
-  v === "select-tab-6" ||
-  v === "select-tab-7" ||
-  v === "select-tab-8" ||
-  v === "select-last-tab" ||
-  v === "new-tab" ||
-  v === "next-chat" ||
-  v === "prev-chat" ||
-  v === "next-panel" ||
-  v === "prev-panel" ||
-  v === "focus-next-pane" ||
-  v === "focus-prev-pane" ||
-  v === "open-chat-switcher" ||
-  v === "composer.submit" ||
-  v === "composer.newline" ||
-  v === "composer.forceSubmit" ||
-  v === "composer.togglePlanMode" ||
-  v === "editor.save" ||
-  v === "editor.annotate";
+	v === "new-chat" ||
+	v === "open-project" ||
+	v === "settings" ||
+	v === "close-tab" ||
+	v === "toggle-left-sidebar" ||
+	v === "toggle-right-sidebar" ||
+	v === "toggle-terminal" ||
+	v === "focus-composer" ||
+	v === "next-tab" ||
+	v === "prev-tab" ||
+	v === "select-tab-1" ||
+	v === "select-tab-2" ||
+	v === "select-tab-3" ||
+	v === "select-tab-4" ||
+	v === "select-tab-5" ||
+	v === "select-tab-6" ||
+	v === "select-tab-7" ||
+	v === "select-tab-8" ||
+	v === "select-last-tab" ||
+	v === "new-tab" ||
+	v === "next-chat" ||
+	v === "prev-chat" ||
+	v === "next-panel" ||
+	v === "prev-panel" ||
+	v === "focus-next-pane" ||
+	v === "focus-prev-pane" ||
+	v === "open-chat-switcher" ||
+	v === "composer.submit" ||
+	v === "composer.newline" ||
+	v === "composer.forceSubmit" ||
+	v === "composer.togglePlanMode" ||
+	v === "editor.save" ||
+	v === "editor.annotate";
 
 const isDevConfigProfile = (): boolean =>
-  process.env.ZUSE_CONFIG_PROFILE?.trim() === "dev" ||
-  process.env.ZUSE_DEV_CONFIG?.trim() === "1" ||
-  Boolean(process.env.VITE_DEV_SERVER_URL?.trim());
+	process.env.ZUSE_CONFIG_PROFILE?.trim() === "dev" ||
+	process.env.ZUSE_DEV_CONFIG?.trim() === "1" ||
+	Boolean(process.env.VITE_DEV_SERVER_URL?.trim());
 
 const defaultUserConfigDirname = (): string =>
-  isDevConfigProfile() ? DEV_USER_CONFIG_DIRNAME : USER_CONFIG_DIRNAME;
+	isDevConfigProfile() ? DEV_USER_CONFIG_DIRNAME : USER_CONFIG_DIRNAME;
 
 const resolveUserConfigDir = (join: (a: string, b: string) => string): string =>
-  process.env.ZUSE_CONFIG_DIR?.trim() ||
-  join(homedir(), defaultUserConfigDirname());
+	process.env.ZUSE_CONFIG_DIR?.trim() ||
+	join(homedir(), defaultUserConfigDirname());
 
 /**
  * Re-shape an arbitrary parsed JSON value onto a `SettingsFile`, falling
@@ -200,717 +199,708 @@ const resolveUserConfigDir = (join: (a: string, b: string) => string): string =>
  * on disk — it can be hand-edited and might be from an older schema.
  */
 const coerceSettings = (raw: unknown): SettingsFile => {
-  const base = freshSettings();
-  if (raw === null || typeof raw !== "object") return base;
-  const obj = raw as Record<string, unknown>;
+	const base = freshSettings();
+	if (raw === null || typeof raw !== "object") return base;
+	const obj = raw as Record<string, unknown>;
 
-  const provider = isProviderId(obj.defaultProviderId)
-    ? obj.defaultProviderId
-    : base.defaultProviderId;
+	const provider = isProviderId(obj.defaultProviderId)
+		? obj.defaultProviderId
+		: base.defaultProviderId;
 
-  const inputModels =
-    typeof obj.defaultModelByProvider === "object" &&
-    obj.defaultModelByProvider !== null
-      ? (obj.defaultModelByProvider as Record<string, unknown>)
-      : {};
-  const models: Record<ProviderId, string> = { ...base.defaultModelByProvider };
-  for (const id of PROVIDER_IDS) {
-    const v = inputModels[id];
-    if (typeof v === "string" && v.length > 0) {
-      models[id] = resolveModelSlug(id, v);
-    }
-  }
+	const inputModels =
+		typeof obj.defaultModelByProvider === "object" &&
+		obj.defaultModelByProvider !== null
+			? (obj.defaultModelByProvider as Record<string, unknown>)
+			: {};
+	const models: Record<ProviderId, string> = { ...base.defaultModelByProvider };
+	for (const id of PROVIDER_IDS) {
+		const v = inputModels[id];
+		if (typeof v === "string" && v.length > 0) {
+			models[id] = resolveModelSlug(id, v);
+		}
+	}
 
-  const runtime = isRuntimeMode(obj.defaultRuntimeMode)
-    ? obj.defaultRuntimeMode
-    : base.defaultRuntimeMode;
+	const runtime = isRuntimeMode(obj.defaultRuntimeMode)
+		? obj.defaultRuntimeMode
+		: base.defaultRuntimeMode;
 
-  const autoWorktree =
-    typeof obj.defaultAutoCreateWorktree === "boolean"
-      ? obj.defaultAutoCreateWorktree
-      : base.defaultAutoCreateWorktree;
+	const autoWorktree =
+		typeof obj.defaultAutoCreateWorktree === "boolean"
+			? obj.defaultAutoCreateWorktree
+			: base.defaultAutoCreateWorktree;
 
-  const autonomy = isAutonomyLevel(obj.defaultAutonomyLevel)
-    ? obj.defaultAutonomyLevel
-    : base.defaultAutonomyLevel;
+	const autonomy = isAutonomyLevel(obj.defaultAutonomyLevel)
+		? obj.defaultAutonomyLevel
+		: base.defaultAutonomyLevel;
 
-  const onboarding =
-    typeof obj.onboardingCompleted === "boolean"
-      ? obj.onboardingCompleted
-      : base.onboardingCompleted;
+	const onboarding =
+		typeof obj.onboardingCompleted === "boolean"
+			? obj.onboardingCompleted
+			: base.onboardingCompleted;
 
-  const appearanceMode = isAppearanceMode(obj.appearanceMode)
-    ? obj.appearanceMode
-    : base.appearanceMode;
+	const appearanceMode = isAppearanceMode(obj.appearanceMode)
+		? obj.appearanceMode
+		: base.appearanceMode;
 
-  const completionSoundEnabled =
-    typeof obj.completionSoundEnabled === "boolean"
-      ? obj.completionSoundEnabled
-      : base.completionSoundEnabled;
+	const completionSoundEnabled =
+		typeof obj.completionSoundEnabled === "boolean"
+			? obj.completionSoundEnabled
+			: base.completionSoundEnabled;
 
-  const completionSoundPreset = isCompletionSoundPreset(
-    obj.completionSoundPreset,
-  )
+	const completionSoundPreset = isCompletionSoundPreset(
+		obj.completionSoundPreset,
+	)
 		? obj.completionSoundPreset
 		: base.completionSoundPreset;
-
-	// Deliberately default missing legacy values to enabled. The setting is
-	// still immediately reversible from both desktop and mobile clients.
-	const analyticsEnabled =
-		typeof obj.analyticsEnabled === "boolean" ? obj.analyticsEnabled : true;
 
 	const providerEnabled: Record<ProviderId, boolean> = {
 		...base.providerEnabled,
 	};
-  if (typeof obj.providerEnabled === "object" && obj.providerEnabled !== null) {
-    const flags = obj.providerEnabled as Record<string, unknown>;
-    for (const id of PROVIDER_IDS) {
-      const v = flags[id];
-      if (typeof v === "boolean") providerEnabled[id] = v;
-    }
-  }
+	if (typeof obj.providerEnabled === "object" && obj.providerEnabled !== null) {
+		const flags = obj.providerEnabled as Record<string, unknown>;
+		for (const id of PROVIDER_IDS) {
+			const v = flags[id];
+			if (typeof v === "boolean") providerEnabled[id] = v;
+		}
+	}
 
-  const modelEnabledByProvider = seedModelEnabledByProvider();
-  if (
-    typeof obj.modelEnabledByProvider === "object" &&
-    obj.modelEnabledByProvider !== null
-  ) {
-    const byProvider = obj.modelEnabledByProvider as Record<string, unknown>;
-    for (const id of PROVIDER_IDS) {
-      const providerModels = byProvider[id];
-      if (typeof providerModels !== "object" || providerModels === null) {
-        continue;
-      }
-      const flags = providerModels as Record<string, unknown>;
-      const knownModelIds = new Set(MODELS_BY_PROVIDER[id].map((m) => m.id));
-      for (const [modelId, value] of Object.entries(flags)) {
-        if (!knownModelIds.has(modelId)) continue;
-        if (typeof value === "boolean") {
-          modelEnabledByProvider[id][modelId] = value;
-        }
-      }
-    }
-  }
+	const modelEnabledByProvider = seedModelEnabledByProvider();
+	if (
+		typeof obj.modelEnabledByProvider === "object" &&
+		obj.modelEnabledByProvider !== null
+	) {
+		const byProvider = obj.modelEnabledByProvider as Record<string, unknown>;
+		for (const id of PROVIDER_IDS) {
+			const providerModels = byProvider[id];
+			if (typeof providerModels !== "object" || providerModels === null) {
+				continue;
+			}
+			const flags = providerModels as Record<string, unknown>;
+			const knownModelIds = new Set(MODELS_BY_PROVIDER[id].map((m) => m.id));
+			for (const [modelId, value] of Object.entries(flags)) {
+				if (!knownModelIds.has(modelId)) continue;
+				if (typeof value === "boolean") {
+					modelEnabledByProvider[id][modelId] = value;
+				}
+			}
+		}
+	}
 
-  // OpenCode provider-manager fields. Keyed by opencode sub-provider id
-  // (free-form strings), so unlike the maps above we don't restrict to a
-  // known key set — just validate value shapes and drop anything malformed.
-  const opencodeProviderVisible: Record<string, boolean> = {};
-  if (
-    typeof obj.opencodeProviderVisible === "object" &&
-    obj.opencodeProviderVisible !== null
-  ) {
-    for (const [k, v] of Object.entries(
-      obj.opencodeProviderVisible as Record<string, unknown>,
-    )) {
-      if (typeof v === "boolean") opencodeProviderVisible[k] = v;
-    }
-  }
+	// OpenCode provider-manager fields. Keyed by opencode sub-provider id
+	// (free-form strings), so unlike the maps above we don't restrict to a
+	// known key set — just validate value shapes and drop anything malformed.
+	const opencodeProviderVisible: Record<string, boolean> = {};
+	if (
+		typeof obj.opencodeProviderVisible === "object" &&
+		obj.opencodeProviderVisible !== null
+	) {
+		for (const [k, v] of Object.entries(
+			obj.opencodeProviderVisible as Record<string, unknown>,
+		)) {
+			if (typeof v === "boolean") opencodeProviderVisible[k] = v;
+		}
+	}
 
-  const opencodeModelVisibleByProvider: Record<
-    string,
-    Record<string, boolean>
-  > = {};
-  if (
-    typeof obj.opencodeModelVisibleByProvider === "object" &&
-    obj.opencodeModelVisibleByProvider !== null
-  ) {
-    for (const [pid, models] of Object.entries(
-      obj.opencodeModelVisibleByProvider as Record<string, unknown>,
-    )) {
-      if (typeof models !== "object" || models === null) continue;
-      const flags: Record<string, boolean> = {};
-      for (const [mid, v] of Object.entries(
-        models as Record<string, unknown>,
-      )) {
-        if (typeof v === "boolean") flags[mid] = v;
-      }
-      opencodeModelVisibleByProvider[pid] = flags;
-    }
-  }
+	const opencodeModelVisibleByProvider: Record<
+		string,
+		Record<string, boolean>
+	> = {};
+	if (
+		typeof obj.opencodeModelVisibleByProvider === "object" &&
+		obj.opencodeModelVisibleByProvider !== null
+	) {
+		for (const [pid, models] of Object.entries(
+			obj.opencodeModelVisibleByProvider as Record<string, unknown>,
+		)) {
+			if (typeof models !== "object" || models === null) continue;
+			const flags: Record<string, boolean> = {};
+			for (const [mid, v] of Object.entries(
+				models as Record<string, unknown>,
+			)) {
+				if (typeof v === "boolean") flags[mid] = v;
+			}
+			opencodeModelVisibleByProvider[pid] = flags;
+		}
+	}
 
-  const opencodeCustomProviders: {
-    id: string;
-    name: string;
-    baseURL: string;
-    npm: string;
-    models: { id: string; name: string }[];
-  }[] = [];
-  if (Array.isArray(obj.opencodeCustomProviders)) {
-    for (const item of obj.opencodeCustomProviders) {
-      if (typeof item !== "object" || item === null) continue;
-      const p = item as Record<string, unknown>;
-      if (
-        typeof p.id !== "string" ||
-        typeof p.name !== "string" ||
-        typeof p.baseURL !== "string"
-      ) {
-        continue;
-      }
-      const models: { id: string; name: string }[] = [];
-      if (Array.isArray(p.models)) {
-        for (const m of p.models) {
-          if (typeof m !== "object" || m === null) continue;
-          const mm = m as Record<string, unknown>;
-          if (typeof mm.id === "string" && typeof mm.name === "string") {
-            models.push({ id: mm.id, name: mm.name });
-          }
-        }
-      }
-      opencodeCustomProviders.push({
-        id: p.id,
-        name: p.name,
-        baseURL: p.baseURL,
-        // Legacy entries (pre-type-picker) default to OpenAI-compatible.
-        npm:
-          typeof p.npm === "string" && p.npm.length > 0
-            ? p.npm
-            : "@ai-sdk/openai-compatible",
-        models,
-      });
-    }
-  }
+	const opencodeCustomProviders: {
+		id: string;
+		name: string;
+		baseURL: string;
+		npm: string;
+		models: { id: string; name: string }[];
+	}[] = [];
+	if (Array.isArray(obj.opencodeCustomProviders)) {
+		for (const item of obj.opencodeCustomProviders) {
+			if (typeof item !== "object" || item === null) continue;
+			const p = item as Record<string, unknown>;
+			if (
+				typeof p.id !== "string" ||
+				typeof p.name !== "string" ||
+				typeof p.baseURL !== "string"
+			) {
+				continue;
+			}
+			const models: { id: string; name: string }[] = [];
+			if (Array.isArray(p.models)) {
+				for (const m of p.models) {
+					if (typeof m !== "object" || m === null) continue;
+					const mm = m as Record<string, unknown>;
+					if (typeof mm.id === "string" && typeof mm.name === "string") {
+						models.push({ id: mm.id, name: mm.name });
+					}
+				}
+			}
+			opencodeCustomProviders.push({
+				id: p.id,
+				name: p.name,
+				baseURL: p.baseURL,
+				// Legacy entries (pre-type-picker) default to OpenAI-compatible.
+				npm:
+					typeof p.npm === "string" && p.npm.length > 0
+						? p.npm
+						: "@ai-sdk/openai-compatible",
+				models,
+			});
+		}
+	}
 
-  const mcpDisabledServers: string[] = [];
-  if (Array.isArray(obj.mcpDisabledServers)) {
-    for (const item of obj.mcpDisabledServers) {
-      if (typeof item === "string" && item.length > 0) {
-        mcpDisabledServers.push(item);
-      }
-    }
-  }
+	const mcpDisabledServers: string[] = [];
+	if (Array.isArray(obj.mcpDisabledServers)) {
+		for (const item of obj.mcpDisabledServers) {
+			if (typeof item === "string" && item.length > 0) {
+				mcpDisabledServers.push(item);
+			}
+		}
+	}
 
-  let subagents = base.subagents;
-  if (typeof obj.subagents === "object" && obj.subagents !== null) {
-    const sub = obj.subagents as Record<string, unknown>;
-    const enable =
-      typeof sub.enableForNewSessions === "boolean"
-        ? sub.enableForNewSessions
-        : true;
-    const presets: Record<string, SubagentPresetState> = {};
-    if (typeof sub.presets === "object" && sub.presets !== null) {
-      for (const [key, val] of Object.entries(
-        sub.presets as Record<string, unknown>,
-      )) {
-        if (typeof val !== "object" || val === null) continue;
-        const ps = val as Record<string, unknown>;
-        presets[key] = {
-          enabled: typeof ps.enabled === "boolean" ? ps.enabled : true,
-          overrides:
-            typeof ps.overrides === "object" && ps.overrides !== null
-              ? (ps.overrides as SubagentPresetState["overrides"])
-              : {},
-        };
-      }
-    }
-    subagents = { enableForNewSessions: enable, presets };
-  }
+	let subagents = base.subagents;
+	if (typeof obj.subagents === "object" && obj.subagents !== null) {
+		const sub = obj.subagents as Record<string, unknown>;
+		const enable =
+			typeof sub.enableForNewSessions === "boolean"
+				? sub.enableForNewSessions
+				: true;
+		const presets: Record<string, SubagentPresetState> = {};
+		if (typeof sub.presets === "object" && sub.presets !== null) {
+			for (const [key, val] of Object.entries(
+				sub.presets as Record<string, unknown>,
+			)) {
+				if (typeof val !== "object" || val === null) continue;
+				const ps = val as Record<string, unknown>;
+				presets[key] = {
+					enabled: typeof ps.enabled === "boolean" ? ps.enabled : true,
+					overrides:
+						typeof ps.overrides === "object" && ps.overrides !== null
+							? (ps.overrides as SubagentPresetState["overrides"])
+							: {},
+				};
+			}
+		}
+		subagents = { enableForNewSessions: enable, presets };
+	}
 
-  const branchNamingStyle = isBranchNamingStyle(obj.branchNamingStyle)
-    ? obj.branchNamingStyle
-    : base.branchNamingStyle;
+	const branchNamingStyle = isBranchNamingStyle(obj.branchNamingStyle)
+		? obj.branchNamingStyle
+		: base.branchNamingStyle;
 
-  const branchNamingPrefix =
-    typeof obj.branchNamingPrefix === "string"
-      ? obj.branchNamingPrefix
-      : base.branchNamingPrefix;
+	const branchNamingPrefix =
+		typeof obj.branchNamingPrefix === "string"
+			? obj.branchNamingPrefix
+			: base.branchNamingPrefix;
 
-  let mergePrefs = base.mergePrefs;
-  if (typeof obj.mergePrefs === "object" && obj.mergePrefs !== null) {
-    const prefs = obj.mergePrefs as Record<string, unknown>;
-    mergePrefs = {
-      method: isMergeMethod(prefs.method)
-        ? prefs.method
-        : base.mergePrefs.method,
-      deleteBranch:
-        typeof prefs.deleteBranch === "boolean"
-          ? prefs.deleteBranch
-          : base.mergePrefs.deleteBranch,
-    };
-  }
+	let mergePrefs = base.mergePrefs;
+	if (typeof obj.mergePrefs === "object" && obj.mergePrefs !== null) {
+		const prefs = obj.mergePrefs as Record<string, unknown>;
+		mergePrefs = {
+			method: isMergeMethod(prefs.method)
+				? prefs.method
+				: base.mergePrefs.method,
+			deleteBranch:
+				typeof prefs.deleteBranch === "boolean"
+					? prefs.deleteBranch
+					: base.mergePrefs.deleteBranch,
+		};
+	}
 
-  const notchTrayEnabled =
-    typeof obj.notchTrayEnabled === "boolean"
-      ? obj.notchTrayEnabled
-      : base.notchTrayEnabled;
+	const notchTrayEnabled =
+		typeof obj.notchTrayEnabled === "boolean"
+			? obj.notchTrayEnabled
+			: base.notchTrayEnabled;
 
-  const notchTrayPinned =
-    typeof obj.notchTrayPinned === "boolean"
-      ? obj.notchTrayPinned
-      : base.notchTrayPinned;
+	const notchTrayPinned =
+		typeof obj.notchTrayPinned === "boolean"
+			? obj.notchTrayPinned
+			: base.notchTrayPinned;
 
-  return SettingsFile.make({
-    schemaVersion: 1,
-    defaultProviderId: provider,
-    defaultModelByProvider: models,
-    defaultRuntimeMode: runtime,
-    defaultAutoCreateWorktree: autoWorktree,
-    defaultAutonomyLevel: autonomy,
-    onboardingCompleted: onboarding,
+	return SettingsFile.make({
+		schemaVersion: 1,
+		defaultProviderId: provider,
+		defaultModelByProvider: models,
+		defaultRuntimeMode: runtime,
+		defaultAutoCreateWorktree: autoWorktree,
+		defaultAutonomyLevel: autonomy,
+		onboardingCompleted: onboarding,
 		appearanceMode,
 		completionSoundEnabled,
 		completionSoundPreset,
-		analyticsEnabled,
 		providerEnabled,
 		modelEnabledByProvider,
 		opencodeProviderVisible,
-    opencodeModelVisibleByProvider,
-    opencodeCustomProviders,
-    mcpDisabledServers,
-    subagents,
-    branchNamingStyle,
-    branchNamingPrefix,
-    mergePrefs,
-    notchTrayEnabled,
-    notchTrayPinned,
-  });
+		opencodeModelVisibleByProvider,
+		opencodeCustomProviders,
+		mcpDisabledServers,
+		subagents,
+		branchNamingStyle,
+		branchNamingPrefix,
+		mergePrefs,
+		notchTrayEnabled,
+		notchTrayPinned,
+	});
 };
 
 const coerceKeybindings = (raw: unknown): KeybindingsFile => {
-  if (raw === null || typeof raw !== "object") return freshKeybindings();
-  const obj = raw as Record<string, unknown>;
-  const inRules = Array.isArray(obj.rules) ? obj.rules : [];
-  const rules: KeybindingRule[] = [];
-  for (const item of inRules) {
-    if (typeof item !== "object" || item === null) continue;
-    const r = item as Record<string, unknown>;
-    if (typeof r.key !== "string" || !isCommand(r.command)) continue;
-    // Keep the original strings; the renderer / matcher revalidates on parse.
-    const rule: KeybindingRule = {
-      key: r.key,
-      command: r.command,
-      when: typeof r.when === "string" ? r.when : undefined,
-    };
-    rules.push(rule);
-    if (rules.length >= MAX_KEYBINDING_RULES) break;
-  }
-  return KeybindingsFile.make({ schemaVersion: 1, rules });
+	if (raw === null || typeof raw !== "object") return freshKeybindings();
+	const obj = raw as Record<string, unknown>;
+	const inRules = Array.isArray(obj.rules) ? obj.rules : [];
+	const rules: KeybindingRule[] = [];
+	for (const item of inRules) {
+		if (typeof item !== "object" || item === null) continue;
+		const r = item as Record<string, unknown>;
+		if (typeof r.key !== "string" || !isCommand(r.command)) continue;
+		// Keep the original strings; the renderer / matcher revalidates on parse.
+		const rule: KeybindingRule = {
+			key: r.key,
+			command: r.command,
+			when: typeof r.when === "string" ? r.when : undefined,
+		};
+		rules.push(rule);
+		if (rules.length >= MAX_KEYBINDING_RULES) break;
+	}
+	return KeybindingsFile.make({ schemaVersion: 1, rules });
 };
 
 export const configStoreTestHelpers = {
-  coerceSettings,
-  userConfigDir: () => resolveUserConfigDir(NodePath.join),
+	coerceSettings,
+	userConfigDir: () => resolveUserConfigDir(NodePath.join),
 };
 
 /* ────────────────────────── Service implementation ──────────────────────────── */
 
 export const ConfigStoreServiceLive = Layer.effect(
-  ConfigStoreService,
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const pathSvc = yield* Path.Path;
-    const { userData } = yield* AppPaths;
-    const userConfigDir = resolveUserConfigDir(pathSvc.join);
+	ConfigStoreService,
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathSvc = yield* Path.Path;
+		const { userData } = yield* AppPaths;
+		const userConfigDir = resolveUserConfigDir(pathSvc.join);
 
-    yield* fs.makeDirectory(userData, { recursive: true }).pipe(Effect.orDie);
-    yield* fs
-      .makeDirectory(userConfigDir, { recursive: true })
-      .pipe(Effect.orDie);
+		yield* fs.makeDirectory(userData, { recursive: true }).pipe(Effect.orDie);
+		yield* fs
+			.makeDirectory(userConfigDir, { recursive: true })
+			.pipe(Effect.orDie);
 
-    const settingsPath = pathSvc.join(userConfigDir, SETTINGS_FILENAME);
-    const keybindingsPath = pathSvc.join(userConfigDir, KEYBINDINGS_FILENAME);
-    const legacySettingsPath = pathSvc.join(userData, SETTINGS_FILENAME);
-    const legacyKeybindingsPath = pathSvc.join(userData, KEYBINDINGS_FILENAME);
+		const settingsPath = pathSvc.join(userConfigDir, SETTINGS_FILENAME);
+		const keybindingsPath = pathSvc.join(userConfigDir, KEYBINDINGS_FILENAME);
+		const legacySettingsPath = pathSvc.join(userData, SETTINGS_FILENAME);
+		const legacyKeybindingsPath = pathSvc.join(userData, KEYBINDINGS_FILENAME);
 
-    /**
-     * Read a JSON file from disk, returning the parsed object or `null` if
-     * the file doesn't exist / is malformed. Other I/O failures bubble out.
-     */
-    const readJsonOrNull = (absPath: string): Effect.Effect<unknown | null> =>
-      Effect.gen(function* () {
-        const exists = yield* fs.exists(absPath).pipe(Effect.orDie);
-        if (!exists) return null;
-        const text = yield* fs.readFileString(absPath).pipe(Effect.orDie);
-        try {
-          return JSON.parse(text);
-        } catch {
-          return null;
-        }
-      });
+		/**
+		 * Read a JSON file from disk, returning the parsed object or `null` if
+		 * the file doesn't exist / is malformed. Other I/O failures bubble out.
+		 */
+		const readJsonOrNull = (absPath: string): Effect.Effect<unknown | null> =>
+			Effect.gen(function* () {
+				const exists = yield* fs.exists(absPath).pipe(Effect.orDie);
+				if (!exists) return null;
+				const text = yield* fs.readFileString(absPath).pipe(Effect.orDie);
+				try {
+					return JSON.parse(text);
+				} catch {
+					return null;
+				}
+			});
 
-    // One semaphore per path. Concurrent writes to the same file (e.g. the
-    // model-picker firing `defaultProviderId` and `defaultModelByProvider`
-    // back-to-back; or migrateLocalStorage racing the first updateSettings)
-    // would otherwise both pick the same `<path>.tmp` and the second
-    // rename ENOENTs because the first already renamed the tmp away.
-    const writeLocks = new Map<string, Semaphore.Semaphore>();
-    const lockFor = (absPath: string): Effect.Effect<Semaphore.Semaphore> =>
-      Effect.gen(function* () {
-        const existing = writeLocks.get(absPath);
-        if (existing) return existing;
-        const sem = yield* Semaphore.make(1);
-        writeLocks.set(absPath, sem);
-        return sem;
-      });
+		// One semaphore per path. Concurrent writes to the same file (e.g. the
+		// model-picker firing `defaultProviderId` and `defaultModelByProvider`
+		// back-to-back; or migrateLocalStorage racing the first updateSettings)
+		// would otherwise both pick the same `<path>.tmp` and the second
+		// rename ENOENTs because the first already renamed the tmp away.
+		const writeLocks = new Map<string, Semaphore.Semaphore>();
+		const lockFor = (absPath: string): Effect.Effect<Semaphore.Semaphore> =>
+			Effect.gen(function* () {
+				const existing = writeLocks.get(absPath);
+				if (existing) return existing;
+				const sem = yield* Semaphore.make(1);
+				writeLocks.set(absPath, sem);
+				return sem;
+			});
 
-    /**
-     * Atomic write — write the contents to a unique `<absPath>.<rand>.tmp`
-     * and rename over the target so a crash during write never leaves a
-     * partial file. Serialised per-path so concurrent callers don't race
-     * on the tmp filename.
-     */
-    const writeAtomically = (
-      absPath: string,
-      contents: string,
-    ): Effect.Effect<void> =>
-      Effect.gen(function* () {
-        const sem = yield* lockFor(absPath);
-        yield* sem.withPermits(1)(
-          Effect.gen(function* () {
-            const tmp = `${absPath}.${randomBytes(6).toString("hex")}.tmp`;
-            yield* fs.writeFileString(tmp, contents).pipe(Effect.orDie);
-            yield* fs.rename(tmp, absPath).pipe(Effect.orDie);
-          }),
-        );
-      });
+		/**
+		 * Atomic write — write the contents to a unique `<absPath>.<rand>.tmp`
+		 * and rename over the target so a crash during write never leaves a
+		 * partial file. Serialised per-path so concurrent callers don't race
+		 * on the tmp filename.
+		 */
+		const writeAtomically = (
+			absPath: string,
+			contents: string,
+		): Effect.Effect<void> =>
+			Effect.gen(function* () {
+				const sem = yield* lockFor(absPath);
+				yield* sem.withPermits(1)(
+					Effect.gen(function* () {
+						const tmp = `${absPath}.${randomBytes(6).toString("hex")}.tmp`;
+						yield* fs.writeFileString(tmp, contents).pipe(Effect.orDie);
+						yield* fs.rename(tmp, absPath).pipe(Effect.orDie);
+					}),
+				);
+			});
 
-    const settingsExists = yield* fs.exists(settingsPath).pipe(Effect.orDie);
-    const keybindingsExists = yield* fs
-      .exists(keybindingsPath)
-      .pipe(Effect.orDie);
+		const settingsExists = yield* fs.exists(settingsPath).pipe(Effect.orDie);
+		const keybindingsExists = yield* fs
+			.exists(keybindingsPath)
+			.pipe(Effect.orDie);
 
-    const initialSettingsRaw = settingsExists
-      ? yield* readJsonOrNull(settingsPath)
-      : yield* readJsonOrNull(legacySettingsPath);
-    const initialKeybindingsRaw = keybindingsExists
-      ? yield* readJsonOrNull(keybindingsPath)
-      : yield* readJsonOrNull(legacyKeybindingsPath);
+		const initialSettingsRaw = settingsExists
+			? yield* readJsonOrNull(settingsPath)
+			: yield* readJsonOrNull(legacySettingsPath);
+		const initialKeybindingsRaw = keybindingsExists
+			? yield* readJsonOrNull(keybindingsPath)
+			: yield* readJsonOrNull(legacyKeybindingsPath);
 
-    const initialSettings = coerceSettings(initialSettingsRaw);
-    const initialKeybindings = coerceKeybindings(initialKeybindingsRaw);
+		const initialSettings = coerceSettings(initialSettingsRaw);
+		const initialKeybindings = coerceKeybindings(initialKeybindingsRaw);
 
-    // Persist defaults on first launch so the file is hand-editable
-    // immediately. If the user already had a file, leave it alone unless our
-    // coerce step rewrote a stale slug — in which case write the cleaned
-    // version back so it sticks.
-    const initialSettingsSerialized = serialize(initialSettings);
-    const initialKeybindingsSerialized = serialize(initialKeybindings);
-    if (
-      !settingsExists ||
-      initialSettingsRaw === null ||
-      serialize(initialSettingsRaw) !== initialSettingsSerialized
-    ) {
-      yield* writeAtomically(settingsPath, initialSettingsSerialized);
-    }
-    if (!keybindingsExists || initialKeybindingsRaw === null) {
-      yield* writeAtomically(keybindingsPath, initialKeybindingsSerialized);
-    }
+		// Persist defaults on first launch so the file is hand-editable
+		// immediately. If the user already had a file, leave it alone unless our
+		// coerce step rewrote a stale slug — in which case write the cleaned
+		// version back so it sticks.
+		const initialSettingsSerialized = serialize(initialSettings);
+		const initialKeybindingsSerialized = serialize(initialKeybindings);
+		if (
+			!settingsExists ||
+			initialSettingsRaw === null ||
+			serialize(initialSettingsRaw) !== initialSettingsSerialized
+		) {
+			yield* writeAtomically(settingsPath, initialSettingsSerialized);
+		}
+		if (!keybindingsExists || initialKeybindingsRaw === null) {
+			yield* writeAtomically(keybindingsPath, initialKeybindingsSerialized);
+		}
 
-    const settingsRef = yield* Ref.make<SettingsFile>(initialSettings);
-    const keybindingsRef = yield* Ref.make<KeybindingsFile>(initialKeybindings);
+		const settingsRef = yield* Ref.make<SettingsFile>(initialSettings);
+		const keybindingsRef = yield* Ref.make<KeybindingsFile>(initialKeybindings);
 
-    // Hubs broadcast to every subscriber (renderer stream consumers, the
-    // desktop menu-rebuild hook). Unbounded is fine — payloads are small and
-    // change events are rare.
-    const settingsHub = yield* PubSub.unbounded<SettingsFile>();
-    const keybindingsHub = yield* PubSub.unbounded<KeybindingsFile>();
+		// Hubs broadcast to every subscriber (renderer stream consumers, the
+		// desktop menu-rebuild hook). Unbounded is fine — payloads are small and
+		// change events are rare.
+		const settingsHub = yield* PubSub.unbounded<SettingsFile>();
+		const keybindingsHub = yield* PubSub.unbounded<KeybindingsFile>();
 
-    /**
-     * "Last serialized contents" — used to suppress no-op fs.watch events
-     * (we just wrote the same content) and to detect genuine external edits.
-     */
-    let lastSettingsContent = initialSettingsSerialized;
-    let lastKeybindingsContent = initialKeybindingsSerialized;
+		/**
+		 * "Last serialized contents" — used to suppress no-op fs.watch events
+		 * (we just wrote the same content) and to detect genuine external edits.
+		 */
+		let lastSettingsContent = initialSettingsSerialized;
+		let lastKeybindingsContent = initialKeybindingsSerialized;
 
-    const publishSettings = (next: SettingsFile, serialized: string) =>
-      Effect.gen(function* () {
-        lastSettingsContent = serialized;
-        yield* Ref.set(settingsRef, next);
-        yield* PubSub.publish(settingsHub, next);
-      });
+		const publishSettings = (next: SettingsFile, serialized: string) =>
+			Effect.gen(function* () {
+				lastSettingsContent = serialized;
+				yield* Ref.set(settingsRef, next);
+				yield* PubSub.publish(settingsHub, next);
+			});
 
-    const publishKeybindings = (next: KeybindingsFile, serialized: string) =>
-      Effect.gen(function* () {
-        lastKeybindingsContent = serialized;
-        yield* Ref.set(keybindingsRef, next);
-        yield* PubSub.publish(keybindingsHub, next);
-      });
+		const publishKeybindings = (next: KeybindingsFile, serialized: string) =>
+			Effect.gen(function* () {
+				lastKeybindingsContent = serialized;
+				yield* Ref.set(keybindingsRef, next);
+				yield* PubSub.publish(keybindingsHub, next);
+			});
 
-    /* ──────────────── fs.watch — pick up external hand-edits ──────────────── */
+		/* ──────────────── fs.watch — pick up external hand-edits ──────────────── */
 
-    let settingsDebounce: NodeJS.Timeout | null = null;
-    let keybindingsDebounce: NodeJS.Timeout | null = null;
+		let settingsDebounce: NodeJS.Timeout | null = null;
+		let keybindingsDebounce: NodeJS.Timeout | null = null;
 
-    const reReadSettings = (): void => {
-      Effect.runFork(
-        Effect.gen(function* () {
-          const raw = yield* readJsonOrNull(settingsPath);
-          if (raw === null) return;
-          const serialized = serialize(raw);
-          if (serialized === lastSettingsContent) return;
-          const next = coerceSettings(raw);
-          yield* publishSettings(next, serialize(next));
-        }),
-      );
-    };
+		const reReadSettings = (): void => {
+			Effect.runFork(
+				Effect.gen(function* () {
+					const raw = yield* readJsonOrNull(settingsPath);
+					if (raw === null) return;
+					const serialized = serialize(raw);
+					if (serialized === lastSettingsContent) return;
+					const next = coerceSettings(raw);
+					yield* publishSettings(next, serialize(next));
+				}),
+			);
+		};
 
-    const reReadKeybindings = (): void => {
-      Effect.runFork(
-        Effect.gen(function* () {
-          const raw = yield* readJsonOrNull(keybindingsPath);
-          if (raw === null) return;
-          const serialized = serialize(raw);
-          if (serialized === lastKeybindingsContent) return;
-          const next = coerceKeybindings(raw);
-          yield* publishKeybindings(next, serialize(next));
-        }),
-      );
-    };
+		const reReadKeybindings = (): void => {
+			Effect.runFork(
+				Effect.gen(function* () {
+					const raw = yield* readJsonOrNull(keybindingsPath);
+					if (raw === null) return;
+					const serialized = serialize(raw);
+					if (serialized === lastKeybindingsContent) return;
+					const next = coerceKeybindings(raw);
+					yield* publishKeybindings(next, serialize(next));
+				}),
+			);
+		};
 
-    const watchers: fsSync.FSWatcher[] = [];
-    // Watch the user config directory, not the files themselves — atomic
-    // rename swaps the inode out from under a per-file watcher and the
-    // events stop arriving. Directory-level watch survives that.
-    try {
-      const w = fsSync.watch(userConfigDir, (_eventType, filename) => {
-        if (filename === SETTINGS_FILENAME) {
-          if (settingsDebounce !== null) clearTimeout(settingsDebounce);
-          settingsDebounce = setTimeout(() => {
-            settingsDebounce = null;
-            reReadSettings();
-          }, WATCH_DEBOUNCE_MS);
-        } else if (filename === KEYBINDINGS_FILENAME) {
-          if (keybindingsDebounce !== null) clearTimeout(keybindingsDebounce);
-          keybindingsDebounce = setTimeout(() => {
-            keybindingsDebounce = null;
-            reReadKeybindings();
-          }, WATCH_DEBOUNCE_MS);
-        }
-      });
-      w.on("error", () => {
-        /* watcher dying is best-effort; the in-memory ref stays correct */
-      });
-      watchers.push(w);
-    } catch {
-      // Userdata not watchable (sandboxed FS, network mount). The RPC
-      // surface still works; only external hand-edits go un-noticed.
-    }
+		const watchers: fsSync.FSWatcher[] = [];
+		// Watch the user config directory, not the files themselves — atomic
+		// rename swaps the inode out from under a per-file watcher and the
+		// events stop arriving. Directory-level watch survives that.
+		try {
+			const w = fsSync.watch(userConfigDir, (_eventType, filename) => {
+				if (filename === SETTINGS_FILENAME) {
+					if (settingsDebounce !== null) clearTimeout(settingsDebounce);
+					settingsDebounce = setTimeout(() => {
+						settingsDebounce = null;
+						reReadSettings();
+					}, WATCH_DEBOUNCE_MS);
+				} else if (filename === KEYBINDINGS_FILENAME) {
+					if (keybindingsDebounce !== null) clearTimeout(keybindingsDebounce);
+					keybindingsDebounce = setTimeout(() => {
+						keybindingsDebounce = null;
+						reReadKeybindings();
+					}, WATCH_DEBOUNCE_MS);
+				}
+			});
+			w.on("error", () => {
+				/* watcher dying is best-effort; the in-memory ref stays correct */
+			});
+			watchers.push(w);
+		} catch {
+			// Userdata not watchable (sandboxed FS, network mount). The RPC
+			// surface still works; only external hand-edits go un-noticed.
+		}
 
-    yield* Effect.addFinalizer(() =>
-      Effect.sync(() => {
-        if (settingsDebounce !== null) clearTimeout(settingsDebounce);
-        if (keybindingsDebounce !== null) clearTimeout(keybindingsDebounce);
-        for (const w of watchers) {
-          try {
-            w.close();
-          } catch {
-            /* ignore */
-          }
-        }
-      }),
-    );
+		yield* Effect.addFinalizer(() =>
+			Effect.sync(() => {
+				if (settingsDebounce !== null) clearTimeout(settingsDebounce);
+				if (keybindingsDebounce !== null) clearTimeout(keybindingsDebounce);
+				for (const w of watchers) {
+					try {
+						w.close();
+					} catch {
+						/* ignore */
+					}
+				}
+			}),
+		);
 
-    /* ────────────────────────── Public API ─────────────────────────────── */
+		/* ────────────────────────── Public API ─────────────────────────────── */
 
-    const getSettings: ConfigStoreServiceShape["getSettings"] = () =>
-      Ref.get(settingsRef);
+		const getSettings: ConfigStoreServiceShape["getSettings"] = () =>
+			Ref.get(settingsRef);
 
-    const updateSettings: ConfigStoreServiceShape["updateSettings"] = (patch) =>
-      Effect.gen(function* () {
-        const cur = yield* Ref.get(settingsRef);
-        const next: SettingsFile = SettingsFile.make({
-          schemaVersion: 1,
-          defaultProviderId: patch.defaultProviderId ?? cur.defaultProviderId,
-          defaultModelByProvider:
-            patch.defaultModelByProvider ?? cur.defaultModelByProvider,
-          defaultRuntimeMode:
-            patch.defaultRuntimeMode ?? cur.defaultRuntimeMode,
-          defaultAutoCreateWorktree:
-            patch.defaultAutoCreateWorktree ?? cur.defaultAutoCreateWorktree,
-          defaultAutonomyLevel:
-            patch.defaultAutonomyLevel ?? cur.defaultAutonomyLevel,
-          onboardingCompleted:
-            patch.onboardingCompleted ?? cur.onboardingCompleted,
-          appearanceMode: patch.appearanceMode ?? cur.appearanceMode,
-          completionSoundEnabled:
+		const updateSettings: ConfigStoreServiceShape["updateSettings"] = (patch) =>
+			Effect.gen(function* () {
+				const cur = yield* Ref.get(settingsRef);
+				const next: SettingsFile = SettingsFile.make({
+					schemaVersion: 1,
+					defaultProviderId: patch.defaultProviderId ?? cur.defaultProviderId,
+					defaultModelByProvider:
+						patch.defaultModelByProvider ?? cur.defaultModelByProvider,
+					defaultRuntimeMode:
+						patch.defaultRuntimeMode ?? cur.defaultRuntimeMode,
+					defaultAutoCreateWorktree:
+						patch.defaultAutoCreateWorktree ?? cur.defaultAutoCreateWorktree,
+					defaultAutonomyLevel:
+						patch.defaultAutonomyLevel ?? cur.defaultAutonomyLevel,
+					onboardingCompleted:
+						patch.onboardingCompleted ?? cur.onboardingCompleted,
+					appearanceMode: patch.appearanceMode ?? cur.appearanceMode,
+					completionSoundEnabled:
 						patch.completionSoundEnabled ?? cur.completionSoundEnabled,
 					completionSoundPreset:
 						patch.completionSoundPreset ?? cur.completionSoundPreset,
-					analyticsEnabled: patch.analyticsEnabled ?? cur.analyticsEnabled,
 					providerEnabled: patch.providerEnabled ?? cur.providerEnabled,
 					modelEnabledByProvider:
 						patch.modelEnabledByProvider ?? cur.modelEnabledByProvider,
-          opencodeProviderVisible:
-            patch.opencodeProviderVisible ?? cur.opencodeProviderVisible,
-          opencodeModelVisibleByProvider:
-            patch.opencodeModelVisibleByProvider ??
-            cur.opencodeModelVisibleByProvider,
-          opencodeCustomProviders:
-            patch.opencodeCustomProviders ?? cur.opencodeCustomProviders,
-          mcpDisabledServers:
-            patch.mcpDisabledServers ?? cur.mcpDisabledServers,
-          subagents: patch.subagents ?? cur.subagents,
-          branchNamingStyle: patch.branchNamingStyle ?? cur.branchNamingStyle,
-          branchNamingPrefix:
-            patch.branchNamingPrefix ?? cur.branchNamingPrefix,
-          mergePrefs: patch.mergePrefs ?? cur.mergePrefs,
-          notchTrayEnabled: patch.notchTrayEnabled ?? cur.notchTrayEnabled,
-          notchTrayPinned: patch.notchTrayPinned ?? cur.notchTrayPinned,
-        });
-        const serialized = serialize(next);
-        yield* writeAtomically(settingsPath, serialized);
-        yield* publishSettings(next, serialized);
-        return next;
-      });
+					opencodeProviderVisible:
+						patch.opencodeProviderVisible ?? cur.opencodeProviderVisible,
+					opencodeModelVisibleByProvider:
+						patch.opencodeModelVisibleByProvider ??
+						cur.opencodeModelVisibleByProvider,
+					opencodeCustomProviders:
+						patch.opencodeCustomProviders ?? cur.opencodeCustomProviders,
+					mcpDisabledServers:
+						patch.mcpDisabledServers ?? cur.mcpDisabledServers,
+					subagents: patch.subagents ?? cur.subagents,
+					branchNamingStyle: patch.branchNamingStyle ?? cur.branchNamingStyle,
+					branchNamingPrefix:
+						patch.branchNamingPrefix ?? cur.branchNamingPrefix,
+					mergePrefs: patch.mergePrefs ?? cur.mergePrefs,
+					notchTrayEnabled: patch.notchTrayEnabled ?? cur.notchTrayEnabled,
+					notchTrayPinned: patch.notchTrayPinned ?? cur.notchTrayPinned,
+				});
+				const serialized = serialize(next);
+				yield* writeAtomically(settingsPath, serialized);
+				yield* publishSettings(next, serialized);
+				return next;
+			});
 
-    const settingsChanges: ConfigStoreServiceShape["settingsChanges"] = () =>
-      Stream.unwrap(
-        Effect.gen(function* () {
-          const sub = yield* PubSub.subscribe(settingsHub);
-          const cur = yield* Ref.get(settingsRef);
-          return Stream.concat(Stream.make(cur), Stream.fromSubscription(sub));
-        }),
-      );
+		const settingsChanges: ConfigStoreServiceShape["settingsChanges"] = () =>
+			Stream.unwrap(
+				Effect.gen(function* () {
+					const sub = yield* PubSub.subscribe(settingsHub);
+					const cur = yield* Ref.get(settingsRef);
+					return Stream.concat(Stream.make(cur), Stream.fromSubscription(sub));
+				}),
+			);
 
-    /**
-     * Migration is conservative: we only overlay the localStorage values
-     * onto the *current* settings if the user hasn't already meaningfully
-     * customised the file. The first call after a renderer reload supplies
-     * the payload; subsequent calls find onboardingCompleted=true (the
-     * common "I've already migrated" tell) or any differing field and
-     * leave things alone. This protects against the renderer accidentally
-     * shipping a stale localStorage blob after the user has changed
-     * settings on disk.
-     */
-    const migrateLocalStorage: ConfigStoreServiceShape["migrateLocalStorage"] =
-      (payload) =>
-        Effect.gen(function* () {
-          const cur = yield* Ref.get(settingsRef);
-          const baseline = freshSettings();
-          const currentLooksFresh =
-            cur.defaultProviderId === baseline.defaultProviderId &&
-            cur.defaultRuntimeMode === baseline.defaultRuntimeMode &&
-            cur.defaultAutoCreateWorktree ===
+		/**
+		 * Migration is conservative: we only overlay the localStorage values
+		 * onto the *current* settings if the user hasn't already meaningfully
+		 * customised the file. The first call after a renderer reload supplies
+		 * the payload; subsequent calls find onboardingCompleted=true (the
+		 * common "I've already migrated" tell) or any differing field and
+		 * leave things alone. This protects against the renderer accidentally
+		 * shipping a stale localStorage blob after the user has changed
+		 * settings on disk.
+		 */
+		const migrateLocalStorage: ConfigStoreServiceShape["migrateLocalStorage"] =
+			(payload) =>
+				Effect.gen(function* () {
+					const cur = yield* Ref.get(settingsRef);
+					const baseline = freshSettings();
+					const currentLooksFresh =
+						cur.defaultProviderId === baseline.defaultProviderId &&
+						cur.defaultRuntimeMode === baseline.defaultRuntimeMode &&
+						cur.defaultAutoCreateWorktree ===
 							baseline.defaultAutoCreateWorktree &&
 						cur.completionSoundEnabled === baseline.completionSoundEnabled &&
 						cur.completionSoundPreset === baseline.completionSoundPreset &&
-						cur.analyticsEnabled === baseline.analyticsEnabled &&
 						cur.appearanceMode === baseline.appearanceMode &&
 						cur.onboardingCompleted === false &&
 						Object.keys(cur.subagents.presets).length === 0 &&
-            cur.mergePrefs.method === baseline.mergePrefs.method &&
-            cur.mergePrefs.deleteBranch === baseline.mergePrefs.deleteBranch &&
-            cur.notchTrayEnabled === baseline.notchTrayEnabled &&
-            cur.notchTrayPinned === baseline.notchTrayPinned;
-          if (!currentLooksFresh) return cur;
+						cur.mergePrefs.method === baseline.mergePrefs.method &&
+						cur.mergePrefs.deleteBranch === baseline.mergePrefs.deleteBranch &&
+						cur.notchTrayEnabled === baseline.notchTrayEnabled &&
+						cur.notchTrayPinned === baseline.notchTrayPinned;
+					if (!currentLooksFresh) return cur;
 
-          let provider: SettingsFile["defaultProviderId"] =
-            cur.defaultProviderId;
-          let models: SettingsFile["defaultModelByProvider"] =
-            cur.defaultModelByProvider;
-          let runtime: SettingsFile["defaultRuntimeMode"] =
-            cur.defaultRuntimeMode;
-          let autoWorktree: boolean = cur.defaultAutoCreateWorktree;
-          let onboarding: boolean = cur.onboardingCompleted;
-          let appearanceMode: SettingsFile["appearanceMode"] =
-            cur.appearanceMode;
-          let providerEnabled: SettingsFile["providerEnabled"] =
-            cur.providerEnabled;
-          let modelEnabledByProvider: SettingsFile["modelEnabledByProvider"] =
-            cur.modelEnabledByProvider;
-          let subagents: SettingsFile["subagents"] = cur.subagents;
-          let completionSoundEnabled = cur.completionSoundEnabled;
-          let completionSoundPreset = cur.completionSoundPreset;
+					let provider: SettingsFile["defaultProviderId"] =
+						cur.defaultProviderId;
+					let models: SettingsFile["defaultModelByProvider"] =
+						cur.defaultModelByProvider;
+					let runtime: SettingsFile["defaultRuntimeMode"] =
+						cur.defaultRuntimeMode;
+					let autoWorktree: boolean = cur.defaultAutoCreateWorktree;
+					let onboarding: boolean = cur.onboardingCompleted;
+					let appearanceMode: SettingsFile["appearanceMode"] =
+						cur.appearanceMode;
+					let providerEnabled: SettingsFile["providerEnabled"] =
+						cur.providerEnabled;
+					let modelEnabledByProvider: SettingsFile["modelEnabledByProvider"] =
+						cur.modelEnabledByProvider;
+					let subagents: SettingsFile["subagents"] = cur.subagents;
+					let completionSoundEnabled = cur.completionSoundEnabled;
+					let completionSoundPreset = cur.completionSoundPreset;
 
-          if (
-            payload.settingsV1Raw !== undefined &&
-            payload.settingsV1Raw.length > 0
-          ) {
-            try {
-              const parsed = JSON.parse(payload.settingsV1Raw) as Record<
-                string,
-                unknown
-              >;
-              const fromLs = coerceSettings(parsed);
-              provider = fromLs.defaultProviderId;
-              models = fromLs.defaultModelByProvider;
-              runtime = fromLs.defaultRuntimeMode;
-              autoWorktree = fromLs.defaultAutoCreateWorktree;
-              onboarding = fromLs.onboardingCompleted;
-              appearanceMode = fromLs.appearanceMode;
-              completionSoundEnabled = fromLs.completionSoundEnabled;
-              completionSoundPreset = fromLs.completionSoundPreset;
-              providerEnabled = fromLs.providerEnabled;
-              modelEnabledByProvider = fromLs.modelEnabledByProvider;
-            } catch {
-              /* swallow — keep current values */
-            }
-          }
+					if (
+						payload.settingsV1Raw !== undefined &&
+						payload.settingsV1Raw.length > 0
+					) {
+						try {
+							const parsed = JSON.parse(payload.settingsV1Raw) as Record<
+								string,
+								unknown
+							>;
+							const fromLs = coerceSettings(parsed);
+							provider = fromLs.defaultProviderId;
+							models = fromLs.defaultModelByProvider;
+							runtime = fromLs.defaultRuntimeMode;
+							autoWorktree = fromLs.defaultAutoCreateWorktree;
+							onboarding = fromLs.onboardingCompleted;
+							appearanceMode = fromLs.appearanceMode;
+							completionSoundEnabled = fromLs.completionSoundEnabled;
+							completionSoundPreset = fromLs.completionSoundPreset;
+							providerEnabled = fromLs.providerEnabled;
+							modelEnabledByProvider = fromLs.modelEnabledByProvider;
+						} catch {
+							/* swallow — keep current values */
+						}
+					}
 
-          if (
-            payload.subagentsRaw !== undefined &&
-            payload.subagentsRaw.length > 0
-          ) {
-            try {
-              // Zustand persist wraps state as `{state: {...}, version: N}`.
-              const wrapper = JSON.parse(payload.subagentsRaw) as {
-                readonly state?: Record<string, unknown>;
-              };
-              const state = wrapper?.state ?? {};
-              const fromLs = coerceSettings({ subagents: state });
-              subagents = fromLs.subagents;
-            } catch {
-              /* swallow */
-            }
-          }
+					if (
+						payload.subagentsRaw !== undefined &&
+						payload.subagentsRaw.length > 0
+					) {
+						try {
+							// Zustand persist wraps state as `{state: {...}, version: N}`.
+							const wrapper = JSON.parse(payload.subagentsRaw) as {
+								readonly state?: Record<string, unknown>;
+							};
+							const state = wrapper?.state ?? {};
+							const fromLs = coerceSettings({ subagents: state });
+							subagents = fromLs.subagents;
+						} catch {
+							/* swallow */
+						}
+					}
 
-          const merged = SettingsFile.make({
-            schemaVersion: 1,
-            defaultProviderId: provider,
-            defaultModelByProvider: models,
-            defaultRuntimeMode: runtime,
-            defaultAutoCreateWorktree: autoWorktree,
-            // Autonomy has no localStorage predecessor — preserve current.
-            defaultAutonomyLevel: cur.defaultAutonomyLevel,
-            onboardingCompleted: onboarding,
+					const merged = SettingsFile.make({
+						schemaVersion: 1,
+						defaultProviderId: provider,
+						defaultModelByProvider: models,
+						defaultRuntimeMode: runtime,
+						defaultAutoCreateWorktree: autoWorktree,
+						// Autonomy has no localStorage predecessor — preserve current.
+						defaultAutonomyLevel: cur.defaultAutonomyLevel,
+						onboardingCompleted: onboarding,
 						appearanceMode,
 						completionSoundEnabled,
 						completionSoundPreset,
-						analyticsEnabled: cur.analyticsEnabled,
 						providerEnabled,
 						modelEnabledByProvider,
 						opencodeProviderVisible: cur.opencodeProviderVisible,
-            opencodeModelVisibleByProvider: cur.opencodeModelVisibleByProvider,
-            opencodeCustomProviders: cur.opencodeCustomProviders,
-            mcpDisabledServers: cur.mcpDisabledServers,
-            subagents,
-            branchNamingStyle: cur.branchNamingStyle,
-            branchNamingPrefix: cur.branchNamingPrefix,
-            mergePrefs: cur.mergePrefs,
-            notchTrayEnabled: cur.notchTrayEnabled,
-            notchTrayPinned: cur.notchTrayPinned,
-          });
+						opencodeModelVisibleByProvider: cur.opencodeModelVisibleByProvider,
+						opencodeCustomProviders: cur.opencodeCustomProviders,
+						mcpDisabledServers: cur.mcpDisabledServers,
+						subagents,
+						branchNamingStyle: cur.branchNamingStyle,
+						branchNamingPrefix: cur.branchNamingPrefix,
+						mergePrefs: cur.mergePrefs,
+						notchTrayEnabled: cur.notchTrayEnabled,
+						notchTrayPinned: cur.notchTrayPinned,
+					});
 
-          const serialized = serialize(merged);
-          yield* writeAtomically(settingsPath, serialized);
-          yield* publishSettings(merged, serialized);
-          return merged;
-        });
+					const serialized = serialize(merged);
+					yield* writeAtomically(settingsPath, serialized);
+					yield* publishSettings(merged, serialized);
+					return merged;
+				});
 
-    const getKeybindings: ConfigStoreServiceShape["getKeybindings"] = () =>
-      Ref.get(keybindingsRef);
+		const getKeybindings: ConfigStoreServiceShape["getKeybindings"] = () =>
+			Ref.get(keybindingsRef);
 
-    const replaceKeybindings: ConfigStoreServiceShape["replaceKeybindings"] = (
-      rules,
-    ) =>
-      Effect.gen(function* () {
-        const clamped =
-          rules.length > MAX_KEYBINDING_RULES
-            ? rules.slice(rules.length - MAX_KEYBINDING_RULES)
-            : rules;
-        const next = KeybindingsFile.make({
-          schemaVersion: 1,
-          rules: [...clamped],
-        });
-        const serialized = serialize(next);
-        yield* writeAtomically(keybindingsPath, serialized);
-        yield* publishKeybindings(next, serialized);
-        return next;
-      });
+		const replaceKeybindings: ConfigStoreServiceShape["replaceKeybindings"] = (
+			rules,
+		) =>
+			Effect.gen(function* () {
+				const clamped =
+					rules.length > MAX_KEYBINDING_RULES
+						? rules.slice(rules.length - MAX_KEYBINDING_RULES)
+						: rules;
+				const next = KeybindingsFile.make({
+					schemaVersion: 1,
+					rules: [...clamped],
+				});
+				const serialized = serialize(next);
+				yield* writeAtomically(keybindingsPath, serialized);
+				yield* publishKeybindings(next, serialized);
+				return next;
+			});
 
-    const keybindingsChanges: ConfigStoreServiceShape["keybindingsChanges"] =
-      () =>
-        Stream.unwrap(
+		const keybindingsChanges: ConfigStoreServiceShape["keybindingsChanges"] =
+			() =>
+				Stream.unwrap(
 					Effect.gen(function* () {
 						const sub = yield* PubSub.subscribe(keybindingsHub);
 						const cur = yield* Ref.get(keybindingsRef);
@@ -921,14 +911,14 @@ export const ConfigStoreServiceLive = Layer.effect(
 					}),
 				);
 
-    return {
-      getSettings,
-      updateSettings,
-      settingsChanges,
-      migrateLocalStorage,
-      getKeybindings,
-      replaceKeybindings,
-      keybindingsChanges,
-    } satisfies ConfigStoreServiceShape;
-  }),
+		return {
+			getSettings,
+			updateSettings,
+			settingsChanges,
+			migrateLocalStorage,
+			getKeybindings,
+			replaceKeybindings,
+			keybindingsChanges,
+		} satisfies ConfigStoreServiceShape;
+	}),
 );

--- a/apps/server/test/integration/config-store.test.ts
+++ b/apps/server/test/integration/config-store.test.ts
@@ -144,13 +144,6 @@ describe("config-store settings coercion", () => {
 		expect(settings.notchTrayEnabled).toBe(true);
 		expect(settings.notchTrayPinned).toBe(true);
 	});
-
-	it("enables analytics for legacy files and preserves an explicit opt-out", () => {
-		expect(coerceSettings({}).analyticsEnabled).toBe(true);
-		expect(coerceSettings({ analyticsEnabled: false }).analyticsEnabled).toBe(
-			false,
-		);
-	});
 });
 
 describe("config-store user JSON storage", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -83,8 +83,6 @@ export class SettingsFile extends Schema.Class<SettingsFile>("SettingsFile")({
 	appearanceMode: AppearanceMode,
 	completionSoundEnabled: Schema.Boolean,
 	completionSoundPreset: CompletionSoundPreset,
-	/** Share pseudonymous product and reliability analytics. Defaults on. */
-	analyticsEnabled: Schema.Boolean,
 	/**
 	 * Per-provider on/off toggle from the Providers settings card. Defaults
 	 * to `true` for every provider; flipping it to `false` filters the
@@ -173,7 +171,6 @@ export const SettingsPatch = Schema.Struct({
 	appearanceMode: Schema.optional(AppearanceMode),
 	completionSoundEnabled: Schema.optional(Schema.Boolean),
 	completionSoundPreset: Schema.optional(CompletionSoundPreset),
-	analyticsEnabled: Schema.optional(Schema.Boolean),
 	providerEnabled: Schema.optional(Schema.Record(ProviderId, Schema.Boolean)),
 	modelEnabledByProvider: Schema.optional(
 		Schema.Record(ProviderId, Schema.Record(Schema.String, Schema.Boolean)),

--- a/packages/contracts/test/unit/schema.test.ts
+++ b/packages/contracts/test/unit/schema.test.ts
@@ -625,7 +625,6 @@ describe("SettingsFile round-trip", () => {
 			appearanceMode: "system",
 			completionSoundEnabled: true,
 			completionSoundPreset: "bloom",
-			analyticsEnabled: false,
 			providerEnabled: {
 				claude: true,
 				codex: true,


### PR DESCRIPTION
## What changed

- establishes a denser desktop sizing system across shared controls, settings, chat, composer, terminal, and sidebars
- rebuilds the environment summary as a compact overlay with change statistics, execution location, branch switching and filtering, pull request actions, workflow status, and connected-device handoff entry points
- tightens repository breadcrumbs and session tabs with predictable truncation and overlay actions
- improves conversation navigation with fixed-size turn markers, persistent message actions, compact timestamps, and a smaller jump-to-latest control
- narrows and animates the projects sidebar while preserving direct manual resizing and reduced-motion behavior

## Why

The workspace chrome had inconsistent sizing and several controls reserved more room than their visible content needed. Long repository, branch, session, and message metadata could crowd the main working surface, while some hover actions caused layout changes.

This pass gives the desktop UI a consistent compact rhythm, keeps actions discoverable without shifting content, and preserves more space for the conversation and editor.

## Validation

- renderer typecheck
- mobile typecheck
- server typecheck
- contracts typecheck
- 343 renderer unit tests
- 412 server tests
- 78 contracts unit tests
- renderer production build and bundle budgets
- Biome checks on changed implementation files
- `git diff --check`
