### PR TITLE
Polish badges and sidebar motion

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -209,7 +209,7 @@ function useAnimatedPanelVisibility(
 		});
 		const timeout = window.setTimeout(() => {
 			element?.classList.remove("fz-sidebar-panel-motion");
-		}, 200);
+		}, 240);
 		return () => {
 			window.cancelAnimationFrame(frame);
 			window.clearTimeout(timeout);
@@ -575,6 +575,16 @@ function MainShell() {
 					panelRef={leftPanelRef}
 					elementRef={leftPanelElementRef}
 					onResize={(size) => {
+						// Programmatic open/close emits the same resize events as a drag.
+						// The store already owns that state, so reflecting an intermediate
+						// animated size would immediately undo a close.
+						if (
+							leftPanelElementRef.current?.classList.contains(
+								"fz-sidebar-panel-motion",
+							)
+						) {
+							return;
+						}
 						const open = size.asPercentage > 0;
 						if (open !== leftSidebarOpen) setLeftSidebarOpen(open);
 					}}
@@ -775,6 +785,13 @@ function MainShell() {
 						// flip the sidebar open before the collapse effect runs.
 						if (prev === undefined) return;
 						if (selectedChatId === null) return;
+						if (
+							rightPanelElementRef.current?.classList.contains(
+								"fz-sidebar-panel-motion",
+							)
+						) {
+							return;
+						}
 						const open = size.asPercentage > 0;
 						if (open !== rightSidebarOpen) {
 							setRightSidebarOpenForChat(selectedChatId, open);

--- a/apps/renderer/src/components/ui/badge.tsx
+++ b/apps/renderer/src/components/ui/badge.tsx
@@ -7,7 +7,7 @@ import type React from "react";
 import { cn } from "~/lib/utils";
 
 export const badgeVariants = cva(
-	"relative inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-[0.1875rem] border border-transparent font-medium outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-3.5 sm:[&_svg:not([class*='size-'])]:size-3 [&_svg]:pointer-events-none [&_svg]:shrink-0 [button&,a&]:cursor-pointer [button&,a&]:pointer-coarse:after:absolute [button&,a&]:pointer-coarse:after:size-full [button&,a&]:pointer-coarse:after:min-h-11 [button&,a&]:pointer-coarse:after:min-w-11",
+	"relative inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-full font-medium outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-3 sm:[&_svg:not([class*='size-'])]:size-2.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [button&,a&]:cursor-pointer [button&,a&]:pointer-coarse:after:absolute [button&,a&]:pointer-coarse:after:size-full [button&,a&]:pointer-coarse:after:min-h-11 [button&,a&]:pointer-coarse:after:min-w-11",
 	{
 		defaultVariants: {
 			size: "default",
@@ -16,26 +16,22 @@ export const badgeVariants = cva(
 		variants: {
 			size: {
 				default:
-					"h-5.5 min-w-5.5 px-[calc(--spacing(1)-1px)] text-sm sm:h-4.5 sm:min-w-4.5 sm:text-xs",
-				lg: "h-6.5 min-w-6.5 px-[calc(--spacing(1.5)-1px)] text-base sm:h-5.5 sm:min-w-5.5 sm:text-sm",
-				sm: "h-5 min-w-5 rounded-[0.15625rem] px-[calc(--spacing(1)-1px)] text-xs sm:h-4 sm:min-w-4 sm:text-[.625rem]",
+					"h-5 min-w-5 px-1.5 text-xs sm:h-4 sm:min-w-4 sm:text-[.625rem]",
+				lg: "h-6 min-w-6 px-2 text-sm sm:h-5 sm:min-w-5 sm:text-xs",
+				sm: "h-4.5 min-w-4.5 px-1 text-[.625rem] sm:h-3.5 sm:min-w-3.5 sm:text-[.5625rem]",
 			},
 			variant: {
 				default:
-					"bg-primary text-primary-foreground [button&,a&]:hover:bg-primary/90",
+					"bg-primary/50 text-primary-foreground [button&,a&]:hover:bg-primary/60",
 				destructive:
-					"bg-destructive text-white [button&,a&]:hover:bg-destructive/90",
-				error:
-					"bg-alert-error-bg text-destructive-foreground ring-1 ring-inset ring-destructive/10",
-				info: "bg-alert-info-bg text-info-foreground ring-1 ring-inset ring-info/10",
-				outline:
-					"bg-muted text-foreground ring-1 ring-inset ring-border/45 [button&,a&]:hover:bg-accent",
+					"bg-destructive/50 text-white [button&,a&]:hover:bg-destructive/60",
+				error: "bg-alert-error-bg/50 text-destructive-foreground",
+				info: "bg-alert-info-bg/50 text-info-foreground",
+				outline: "bg-muted/50 text-foreground [button&,a&]:hover:bg-accent/60",
 				secondary:
-					"bg-secondary text-secondary-foreground [button&,a&]:hover:bg-secondary/90",
-				success:
-					"bg-alert-success-bg text-success ring-1 ring-inset ring-success/20",
-				warning:
-					"bg-alert-warning-bg text-warning-foreground ring-1 ring-inset ring-warning/10",
+					"bg-secondary/50 text-secondary-foreground [button&,a&]:hover:bg-secondary/60",
+				success: "bg-alert-success-bg/50 text-success",
+				warning: "bg-alert-warning-bg/50 text-warning-foreground",
 			},
 		},
 	},

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -515,7 +515,7 @@ body,
 /* Applied only while a sidebar is programmatically opened or closed, so
    manual resizing stays directly under the pointer. */
 .fz-sidebar-panel-motion {
-	transition: flex-grow 180ms cubic-bezier(0.645, 0.045, 0.355, 1);
+	transition: flex-grow 220ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What changed

- make shared badges rounder, smaller, borderless, and use translucent backgrounds
- give programmatic sidebar open and close a responsive, front-loaded easing curve
- ignore resize callbacks generated by sidebar animation while preserving direct drag resizing

## Why

The right sidebar could reopen while closing because intermediate animated resize events were reflected back into persisted open state. Badges also felt visually heavy and inconsistent with the compact interface.

## Impact

The right sidebar now closes predictably, manual resize behavior remains immediate, reduced-motion behavior is preserved, and shared badges have a cleaner visual hierarchy.

## Validation

- `bun --filter renderer check-types`
- `bun --filter renderer test:unit` (89 files, 443 tests)
- focused Biome checks for changed TypeScript
- `git diff --check`

Browser-level visual smoke was unavailable because no desktop browser renderer was connected.