### PR TITLE
Add private cloud web previews

### DIFF
--- a/.github/workflows/cloud-runtime-staging.yml
+++ b/.github/workflows/cloud-runtime-staging.yml
@@ -50,7 +50,7 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             enabled=true
           elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$REQUESTED_PUBLICATION" == "true" ]]; then
-            if [[ "$GITHUB_REF" != "refs/heads/swarajbachu/managed-vps-cloud-provisioning" ]]; then
+            if [[ "$GITHUB_REF" != "refs/heads/swarajbachu/relay-web-preview" ]]; then
               echo "Ref $GITHUB_REF is not authorized to publish the staging runtime" >&2
               exit 1
             fi

--- a/.github/workflows/cloud-runtime-staging.yml
+++ b/.github/workflows/cloud-runtime-staging.yml
@@ -72,7 +72,16 @@ jobs:
       - name: Install workspace dependencies
         env:
           HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
-        run: bun install --frozen-lockfile
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 6m bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [[ "$attempt" == "3" ]]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Generate ephemeral verification signing key
         if: steps.publication.outputs.enabled != 'true'

--- a/.github/workflows/cloud-runtime-staging.yml
+++ b/.github/workflows/cloud-runtime-staging.yml
@@ -70,11 +70,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential libsecret-1-dev python3
 
       - name: Install workspace dependencies
-        env:
-          HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
         run: |
           for attempt in 1 2 3; do
-            if timeout 6m bun install --frozen-lockfile; then
+            if timeout 6m bun install --frozen-lockfile --filter @zusehq/server; then
               exit 0
             fi
             if [[ "$attempt" == "3" ]]; then

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -121,6 +121,7 @@ if (
 	fixPath();
 }
 
+import { listLocalServers } from "@zuse/utils/local-port-inspector";
 import { makeBatchedLogWriter } from "./batched-log-writer.ts";
 import { type BatteryStatus, readBatteryStatus } from "./battery-status.ts";
 import {
@@ -137,7 +138,6 @@ import {
 	startDeepEnergyProfile,
 } from "./deep-energy-profiler.ts";
 import { createBufferedChannel, isPairingDeepLink } from "./deep-link.ts";
-import { listLocalServers } from "./host/local-port-inspector.ts";
 import {
 	listPortableOpenTargets,
 	openPathWithPortableTarget,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -19,6 +19,7 @@ import {
 	type PowerMonitorState,
 	type PowerRecordingDurationMinutes,
 	type PowerWorkloadState,
+	type PreviewServer,
 	UPDATE_CHECK_CHANNEL,
 	UPDATE_DOWNLOAD_CHANNEL,
 	UPDATE_INSTALL_CHANNEL,
@@ -183,7 +184,7 @@ const bridge = {
 			} | null>,
 		listLocalServers: () =>
 			ipcRenderer.invoke("browser:listLocalServers") as Promise<
-				ReadonlyArray<{ name: string; port: number }>
+				ReadonlyArray<PreviewServer>
 			>,
 		saveRecording: (bytes: Uint8Array, mimeType: string, durationMs: number) =>
 			ipcRenderer.invoke(

--- a/apps/desktop/test/unit/host-adapters.test.ts
+++ b/apps/desktop/test/unit/host-adapters.test.ts
@@ -1,15 +1,13 @@
 import { readdir, readFile } from "node:fs/promises";
 import Path from "node:path";
 import { fileURLToPath } from "node:url";
-
-import { describe, expect, it } from "vitest";
-
-import { createBrowserCookieHostAdapter } from "../../src/host/browser-cookie.ts";
 import {
 	parseLsofListeners,
 	parseNetstatListeners,
 	parseSsListeners,
-} from "../../src/host/local-port-inspector.ts";
+} from "@zuse/utils/local-port-inspector";
+import { describe, expect, it } from "vitest";
+import { createBrowserCookieHostAdapter } from "../../src/host/browser-cookie.ts";
 import {
 	ghosttyWorkingDirectoryArgs,
 	terminalShellCommand,

--- a/apps/renderer/src/components/browser-pane.tsx
+++ b/apps/renderer/src/components/browser-pane.tsx
@@ -12,6 +12,7 @@ import {
 	type BrowserTarget,
 	type BrowserViewportMode,
 	type ChatId,
+	type PreviewServer,
 	type SessionId,
 } from "@zuse/contracts";
 import { Effect, Fiber, Schedule, Stream } from "effect";
@@ -20,6 +21,7 @@ import {
 	ChevronLeft,
 	ChevronRight,
 	Eraser,
+	ExternalLink,
 	MousePointer2,
 	MousePointerClick,
 	PencilLine,
@@ -33,6 +35,7 @@ import {
 	type ComponentType,
 	type ReactNode,
 	type PointerEvent as ReactPointerEvent,
+	useCallback,
 	useEffect,
 	useRef,
 	useState,
@@ -42,7 +45,6 @@ import type {
 	BrowserCookieImportStatus,
 	BrowserInputAction,
 	CdpCommandOutcome,
-	LocalServerSummary,
 	NetworkQueryResult,
 } from "../lib/bridge.ts";
 import {
@@ -54,11 +56,18 @@ import {
 	type BrowserRecordingArtifact,
 	BrowserRecordingController,
 } from "../lib/browser-recording.ts";
+import { openExternal } from "../lib/platform-capabilities.ts";
 import { reportPowerBrowserSession } from "../lib/power-runtime-activity.ts";
-import { getRpcClient } from "../lib/rpc-client.ts";
+import {
+	localPreviewUrl,
+	type PreviewUiError,
+	previewErrorDetails,
+} from "../lib/preview-routing.ts";
+import { getLocalEnvironmentId, getRpcClient } from "../lib/rpc-client.ts";
 import { useAnnotationsStore } from "../store/annotations.ts";
 import { useAttachmentsStore } from "../store/attachments.ts";
 import { useChatsStore } from "../store/chats.ts";
+import { useEnvironmentCatalogStore } from "../store/environment-catalog.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
 import { AgentCursor, type AgentCursorIntent } from "./agent-cursor.tsx";
@@ -130,13 +139,6 @@ const annotationTools: ReadonlyArray<{
 	{ id: "region", label: "Region", icon: SquareDashedMousePointer },
 	{ id: "draw", label: "Draw", icon: PencilLine },
 	{ id: "erase", label: "Erase", icon: Eraser },
-];
-
-const fallbackLocalServers: ReadonlyArray<LocalServerSummary> = [
-	{ name: "T3 Code", port: 3773 },
-	{ name: "Vite", port: 5173 },
-	{ name: "Zuse", port: 5733 },
-	{ name: "Next.js", port: 3000 },
 ];
 
 const newAnnotationId = (prefix: string): string => {
@@ -439,6 +441,16 @@ export function BrowserPane({
 	readonly sessionId: SessionId | null;
 	readonly visible: boolean;
 }) {
+	const activeEnvironmentId = useEnvironmentCatalogStore(
+		(state) => state.activeEnvironmentId,
+	);
+	const activeEnvironmentLabel = useEnvironmentCatalogStore(
+		(state) =>
+			state.entries.find(
+				(entry) => entry.environmentId === state.activeEnvironmentId,
+			)?.label ?? "Remote computer",
+	);
+	const previewIsLocal = activeEnvironmentId === getLocalEnvironmentId();
 	useEffect(() => {
 		reportPowerBrowserSession(chatId, false);
 		return () => reportPowerBrowserSession(chatId, null);
@@ -463,6 +475,7 @@ export function BrowserPane({
 	// (Click/Type/Hover/Press fall back to the previous synthetic behaviour so
 	// we never silently no-op if the bridge somehow doesn't load).
 	const webContentsIdRef = useRef<number | null>(null);
+	const previewRefreshGenerationRef = useRef(0);
 	const recordingRef = useRef(new BrowserRecordingController());
 	const actionTimelineRef = useRef<BrowserActionEvent[]>([]);
 	const agentOverlaysRef = useRef<BrowserOverlayShape[]>([]);
@@ -549,8 +562,14 @@ export function BrowserPane({
 		useState<BrowserAnnotationStroke | null>(null);
 	const [annotationComment, setAnnotationComment] = useState("");
 	const [attachingAnnotation, setAttachingAnnotation] = useState(false);
-	const [localServers, setLocalServers] =
-		useState<ReadonlyArray<LocalServerSummary>>(fallbackLocalServers);
+	const [previewServers, setPreviewServers] = useState<
+		ReadonlyArray<PreviewServer>
+	>([]);
+	const [previewServersLoading, setPreviewServersLoading] = useState(true);
+	const [previewPortOpening, setPreviewPortOpening] = useState<number | null>(
+		null,
+	);
+	const [previewError, setPreviewError] = useState<PreviewUiError | null>(null);
 	const hasLoadedPage = url !== "" && url !== "about:blank";
 	const viewportPreviewScale =
 		viewport.mode === "fill" ||
@@ -799,16 +818,45 @@ export function BrowserPane({
 		);
 	};
 
+	const refreshPreviewServers = useCallback(async (): Promise<void> => {
+		const generation = previewRefreshGenerationRef.current + 1;
+		previewRefreshGenerationRef.current = generation;
+		setPreviewServers([]);
+		setPreviewServersLoading(true);
+		setPreviewPortOpening(null);
+		setPreviewError(null);
+		try {
+			if (previewIsLocal) {
+				const servers =
+					(await window.zuse?.browser?.listLocalServers?.()) ?? [];
+				if (previewRefreshGenerationRef.current === generation) {
+					setPreviewServers(servers);
+				}
+				return;
+			}
+			const client = await getRpcClient(activeEnvironmentId);
+			const result = await Effect.runPromise(client["preview.servers.list"]());
+			if (previewRefreshGenerationRef.current === generation) {
+				setPreviewServers(result.servers);
+			}
+		} catch {
+			if (previewRefreshGenerationRef.current === generation) {
+				setPreviewServers([]);
+				setPreviewError({
+					message: `Servers on ${activeEnvironmentLabel} could not be checked.`,
+					approvalUrl: null,
+				});
+			}
+		} finally {
+			if (previewRefreshGenerationRef.current === generation) {
+				setPreviewServersLoading(false);
+			}
+		}
+	}, [activeEnvironmentId, activeEnvironmentLabel, previewIsLocal]);
+
 	useEffect(() => {
-		let cancelled = false;
-		void window.zuse?.browser?.listLocalServers?.().then((servers) => {
-			if (cancelled || servers.length === 0) return;
-			setLocalServers(servers);
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, []);
+		void refreshPreviewServers();
+	}, [refreshPreviewServers]);
 
 	// Wire navigation lifecycle events onto the underlying webview element.
 	// We attach via `addEventListener` because the webview tag isn't a real
@@ -1092,6 +1140,43 @@ export function BrowserPane({
 				void wv.loadURL(resolved).catch(() => {});
 			} catch {
 				wv.src = resolved;
+			}
+		}
+	};
+
+	const openPreviewServer = async (server: PreviewServer): Promise<void> => {
+		if (previewIsLocal) {
+			navigate(localPreviewUrl(server.port));
+			return;
+		}
+		setPreviewPortOpening(server.port);
+		setPreviewError(null);
+		const environmentId = activeEnvironmentId;
+		try {
+			const client = await getRpcClient(environmentId);
+			const result = await Effect.runPromise(
+				client["preview.forward"]({ port: server.port }),
+			);
+			if (
+				useEnvironmentCatalogStore.getState().activeEnvironmentId !==
+				environmentId
+			) {
+				return;
+			}
+			navigate(result.url);
+		} catch (error) {
+			if (
+				useEnvironmentCatalogStore.getState().activeEnvironmentId ===
+				environmentId
+			) {
+				setPreviewError(previewErrorDetails(error));
+			}
+		} finally {
+			if (
+				useEnvironmentCatalogStore.getState().activeEnvironmentId ===
+				environmentId
+			) {
+				setPreviewPortOpening(null);
 			}
 		}
 	};
@@ -1545,6 +1630,13 @@ export function BrowserPane({
 				>
 					<HugeiconsIcon icon={StarIcon} className="size-3.5" />
 				</ToolbarButton>
+				<ToolbarButton
+					onClick={() => void openExternal(url)}
+					disabled={!hasLoadedPage}
+					ariaLabel="Open in default browser"
+				>
+					<ExternalLink className="size-3.5" strokeWidth={1.8} />
+				</ToolbarButton>
 				<input
 					type="text"
 					value={inputValue}
@@ -1754,7 +1846,22 @@ export function BrowserPane({
 				className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-muted/20"
 			>
 				{!hasLoadedPage ? (
-					<BrowserEmptyState servers={localServers} onOpen={navigate} />
+					<BrowserEmptyState
+						computerLabel={previewIsLocal ? "This Mac" : activeEnvironmentLabel}
+						error={previewError}
+						loading={previewServersLoading}
+						onApprove={
+							previewError?.approvalUrl === null ||
+							previewError?.approvalUrl === undefined
+								? undefined
+								: () => void openExternal(previewError.approvalUrl ?? "")
+						}
+						onOpen={(server) => void openPreviewServer(server)}
+						onRefresh={() => void refreshPreviewServers()}
+						openingPort={previewPortOpening}
+						remote={!previewIsLocal}
+						servers={previewServers}
+					/>
 				) : null}
 				<div
 					className="relative shrink-0"
@@ -3732,42 +3839,128 @@ function BrowserAgentOverlay({
 }
 
 function BrowserEmptyState({
+	computerLabel,
+	error,
+	loading,
+	onApprove,
 	servers,
 	onOpen,
+	onRefresh,
+	openingPort,
+	remote,
 }: {
-	servers: ReadonlyArray<LocalServerSummary>;
-	onOpen: (url: string) => void;
+	computerLabel: string;
+	error: PreviewUiError | null;
+	loading: boolean;
+	onApprove?: () => void;
+	servers: ReadonlyArray<PreviewServer>;
+	onOpen: (server: PreviewServer) => void;
+	onRefresh: () => void;
+	openingPort: number | null;
+	remote: boolean;
 }) {
-	const rows = servers.length > 0 ? servers : fallbackLocalServers;
 	return (
 		<div className="absolute inset-0 z-10 overflow-auto bg-background px-8 py-10">
 			<div className="mx-auto max-w-3xl">
-				<div className="mb-5 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
-					<Server className="size-4" strokeWidth={1.8} />
-					Local servers
+				<div className="mb-5 flex min-h-9 items-center gap-3">
+					<div className="min-w-0 flex-1">
+						<div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+							<Server className="size-4" strokeWidth={1.8} />
+							Servers on {computerLabel}
+						</div>
+						<p className="mt-1 text-muted-foreground text-xs">
+							{remote
+								? "Open a private preview from this cloud computer."
+								: "Open a development server running on this Mac."}
+						</p>
+					</div>
+					<button
+						type="button"
+						aria-label={`Refresh servers on ${computerLabel}`}
+						className="grid size-8 shrink-0 place-items-center rounded-md text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60 pointer-coarse:size-11"
+						disabled={loading}
+						onClick={onRefresh}
+					>
+						<RefreshCw
+							className={
+								loading
+									? "size-3.5 animate-spin motion-reduce:animate-none"
+									: "size-3.5"
+							}
+						/>
+					</button>
 				</div>
-				<div className="overflow-hidden rounded-xl border border-border/70 bg-card/70">
-					{rows.map((server) => (
-						<button
-							key={`${server.name}-${server.port}`}
-							type="button"
-							onClick={() => onOpen(`http://localhost:${server.port}`)}
-							className="flex w-full items-center gap-4 border-b border-border/60 px-4 py-3 text-left last:border-b-0 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-						>
-							<span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
-								<Server className="size-4" strokeWidth={1.8} />
-							</span>
-							<span className="grid min-w-0 flex-1">
-								<span className="truncate text-sm font-semibold text-foreground">
-									{server.name}
+				{error !== null ? (
+					<div
+						className="mb-3 flex min-h-10 items-center gap-3 rounded-lg border border-destructive/15 bg-alert-error-bg px-3 py-2 text-destructive-foreground text-xs"
+						role="alert"
+					>
+						<span className="min-w-0 flex-1">{error.message}</span>
+						{onApprove !== undefined ? (
+							<button
+								type="button"
+								className="h-7 shrink-0 rounded-md border border-destructive/20 bg-background/60 px-2.5 font-medium outline-none hover:bg-background focus-visible:ring-2 focus-visible:ring-ring/60 pointer-coarse:min-h-11"
+								onClick={onApprove}
+							>
+								Approve
+							</button>
+						) : null}
+					</div>
+				) : null}
+				<div
+					className="overflow-hidden rounded-xl border border-border/70 bg-card/70"
+					aria-busy={loading}
+					aria-live="polite"
+				>
+					{loading && servers.length === 0 ? (
+						<div className="flex min-h-20 items-center justify-center text-muted-foreground text-xs">
+							Checking {computerLabel}…
+						</div>
+					) : null}
+					{!loading && servers.length === 0 ? (
+						<div className="flex min-h-28 flex-col items-center justify-center gap-1.5 px-6 text-center">
+							<p className="font-medium text-sm">No web servers detected</p>
+							<p className="max-w-sm text-muted-foreground text-xs">
+								Start a server in the terminal, then refresh this list.
+							</p>
+						</div>
+					) : null}
+					{servers.map((server) => {
+						const opening = openingPort === server.port;
+						return (
+							<button
+								key={`${server.name}-${server.port}`}
+								type="button"
+								disabled={openingPort !== null}
+								onClick={() => onOpen(server)}
+								className="flex min-h-16 w-full items-center gap-4 border-b border-border/60 px-4 py-3 text-left outline-none last:border-b-0 hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-wait disabled:opacity-70"
+							>
+								<span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
+									<Server className="size-4" strokeWidth={1.8} />
 								</span>
-								<span className="text-sm text-muted-foreground">
-									localhost:{server.port}
+								<span className="grid min-w-0 flex-1">
+									<span className="truncate text-sm font-semibold text-foreground">
+										{server.name}
+									</span>
+									<span className="text-sm text-muted-foreground">
+										localhost:{server.port}
+									</span>
 								</span>
-							</span>
-							<span className="size-2.5 rounded-full bg-emerald-500" />
-						</button>
-					))}
+								<span className="flex w-24 shrink-0 items-center justify-end gap-2 text-muted-foreground text-xs">
+									{opening ? (
+										<>
+											<RefreshCw className="size-3.5 animate-spin motion-reduce:animate-none" />
+											Opening…
+										</>
+									) : remote ? (
+										"Private preview"
+									) : (
+										<span className="size-2.5 rounded-full bg-emerald-500" />
+									)}
+								</span>
+							</button>
+						);
+					})}
 				</div>
 			</div>
 		</div>

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -12,6 +12,7 @@ import type {
 	PowerMonitorState,
 	PowerRecordingDurationMinutes,
 	PowerWorkloadState,
+	PreviewServer,
 	RemoteEnvironmentProfile,
 	SshEnvironmentConnection,
 	TailnetEnvironmentConnection,
@@ -250,10 +251,7 @@ export interface BrowserCookieImportStatus {
 	readonly message?: string;
 }
 
-export interface LocalServerSummary {
-	readonly name: string;
-	readonly port: number;
-}
+export type LocalServerSummary = PreviewServer;
 
 export interface BrowserBridge {
 	/**

--- a/apps/renderer/src/lib/preview-routing.ts
+++ b/apps/renderer/src/lib/preview-routing.ts
@@ -1,0 +1,50 @@
+import { PreviewOpError } from "@zuse/contracts";
+
+export type PreviewUiError = {
+	readonly message: string;
+	readonly approvalUrl: string | null;
+};
+
+const PREVIEW_ERROR_MESSAGES: Record<string, string> = {
+	"invalid-port": "That port cannot be opened as a preview.",
+	"server-not-found": "The server stopped. Start it again, then refresh.",
+	"server-not-http": "That listener is not an HTTP development server.",
+	"private-network-required":
+		"Turn on Private networking in Cloud Space, then retry.",
+	"private-network-permission-required":
+		"Preview sharing needs one-time network permission on the cloud machine.",
+	"private-preview-approval-required":
+		"Approve private HTTPS for this network, then retry.",
+	"preview-unavailable": "The private preview could not be opened.",
+};
+
+const safeApprovalUrl = (value: string | undefined): string | null => {
+	if (value === undefined) return null;
+	try {
+		const url = new URL(value);
+		return url.protocol === "https:" &&
+			url.hostname === "login.tailscale.com" &&
+			(url.pathname === "/f/serve" ||
+				url.pathname.startsWith("/admin/feature/"))
+			? url.toString()
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+export const previewErrorDetails = (error: unknown): PreviewUiError => {
+	const code = error instanceof PreviewOpError ? error.code : null;
+	return {
+		message:
+			(code === null ? undefined : PREVIEW_ERROR_MESSAGES[code]) ??
+			"The private preview could not be opened.",
+		approvalUrl:
+			error instanceof PreviewOpError
+				? safeApprovalUrl(error.approvalUrl)
+				: null,
+	};
+};
+
+export const localPreviewUrl = (port: number): string =>
+	`http://localhost:${port}`;

--- a/apps/renderer/test/unit/preview-routing.test.ts
+++ b/apps/renderer/test/unit/preview-routing.test.ts
@@ -1,0 +1,47 @@
+import { PreviewOpError } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+	localPreviewUrl,
+	previewErrorDetails,
+} from "../../src/lib/preview-routing.ts";
+
+describe("preview routing", () => {
+	it("maps private-network setup failures to a specific recovery action", () => {
+		expect(
+			previewErrorDetails(
+				new PreviewOpError({ code: "private-network-required" }),
+			),
+		).toEqual({
+			message: "Turn on Private networking in Cloud Space, then retry.",
+			approvalUrl: null,
+		});
+	});
+
+	it("preserves only the safe feature-approval URL", () => {
+		const approvalUrl = "https://login.tailscale.com/f/serve?node=example";
+		expect(
+			previewErrorDetails(
+				new PreviewOpError({
+					code: "private-preview-approval-required",
+					approvalUrl,
+				}),
+			),
+		).toEqual({
+			message: "Approve private HTTPS for this network, then retry.",
+			approvalUrl,
+		});
+		expect(
+			previewErrorDetails(
+				new PreviewOpError({
+					code: "private-preview-approval-required",
+					approvalUrl: "https://example.test/steal-session",
+				}),
+			).approvalUrl,
+		).toBeNull();
+	});
+
+	it("keeps local previews on loopback", () => {
+		expect(localPreviewUrl(3001)).toBe("http://localhost:3001");
+	});
+});

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -48,7 +48,10 @@
 		"test:live-agents": "vitest run --config vitest.live.config.ts"
 	},
 	"dependencies": {
+		"bindings": "1.5.0",
+		"file-uri-to-path": "1.0.0",
 		"keytar": "^7.9.0",
+		"node-gyp-build": "4.8.4",
 		"node-pty": "^1.1.0",
 		"strip-ansi": "^7.2.0",
 		"tree-sitter": "^0.21.1",

--- a/apps/server/src/handlers.ts
+++ b/apps/server/src/handlers.ts
@@ -14,6 +14,7 @@ import { MachineHandlersLayer } from "./machine/handlers.ts";
 import { McpHandlersLayer } from "./mcp/handlers.ts";
 import { PingHandlersLayer } from "./ping/handlers.ts";
 import { PokemonHandlersLayer } from "./pokemon/handlers.ts";
+import { PreviewHandlersLayer } from "./preview/handlers.ts";
 import { ProviderHandlersLayer } from "./provider/handlers.ts";
 import { PtyHandlersLayer } from "./pty/handlers.ts";
 import { RelayHandlersLayer } from "./relay/handlers.ts";
@@ -45,6 +46,7 @@ export const HandlersLayer = Layer.mergeAll(
 	RepositorySettingsHandlersLayer,
 	ConfigStoreHandlersLayer,
 	ProviderHandlersLayer,
+	PreviewHandlersLayer,
 	McpHandlersLayer,
 	FsHandlersLayer,
 	AttachmentHandlersLayer,

--- a/apps/server/src/preview/handlers.ts
+++ b/apps/server/src/preview/handlers.ts
@@ -1,0 +1,34 @@
+import { MemoizeRpcs, PreviewOpError } from "@zuse/contracts";
+import { Effect, Layer } from "effect";
+
+import { PreviewService, type PreviewServiceError } from "./preview-service.ts";
+
+const withPreview = <A>(
+	run: (
+		service: PreviewService["Service"],
+	) => Effect.Effect<A, PreviewServiceError>,
+) =>
+	Effect.gen(function* () {
+		const service = yield* PreviewService;
+		return yield* run(service);
+	}).pipe(
+		Effect.mapError(
+			(error) =>
+				new PreviewOpError({
+					code: error.code,
+					approvalUrl: error.approvalUrl,
+				}),
+		),
+	);
+
+const ListServers = MemoizeRpcs.toLayerHandler("preview.servers.list", () =>
+	withPreview((service) =>
+		service.listServers().pipe(Effect.map((servers) => ({ servers }))),
+	),
+);
+
+const Forward = MemoizeRpcs.toLayerHandler("preview.forward", ({ port }) =>
+	withPreview((service) => service.forward(port)),
+);
+
+export const PreviewHandlersLayer = Layer.mergeAll(ListServers, Forward);

--- a/apps/server/src/preview/preview-service.ts
+++ b/apps/server/src/preview/preview-service.ts
@@ -1,3 +1,4 @@
+import { Socket } from "node:net";
 import type {
 	PreviewErrorCode,
 	PreviewForwardResult,
@@ -16,7 +17,8 @@ import {
 import { Context, Effect, Layer } from "effect";
 
 const MINIMUM_PREVIEW_PORT = 1_024;
-const HTTP_PROBE_TIMEOUT_MS = 2_500;
+const HTTP_PROBE_TIMEOUT_MS = 1_000;
+const HTTP_RESPONSE_PREFIX_LENGTH = "HTTP/".length;
 
 export class PreviewServiceError {
 	readonly _tag = "PreviewServiceError";
@@ -56,20 +58,34 @@ const isAllowedPreviewPort = (port: number, zusePort: number): boolean =>
 	port !== zusePort;
 
 export const probeLoopbackHttp = async (port: number): Promise<boolean> => {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), HTTP_PROBE_TIMEOUT_MS);
-	try {
-		await fetch(`http://127.0.0.1:${port}/`, {
-			method: "HEAD",
-			redirect: "manual",
-			signal: controller.signal,
+	return new Promise<boolean>((resolve) => {
+		const socket = new Socket();
+		let settled = false;
+		let responsePrefix = "";
+		const timeout = setTimeout(() => finish(false), HTTP_PROBE_TIMEOUT_MS);
+		const finish = (http: boolean): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			socket.destroy();
+			resolve(http);
+		};
+
+		socket.once("error", () => finish(false));
+		socket.once("close", () => finish(false));
+		socket.on("data", (chunk: Buffer) => {
+			responsePrefix += chunk.toString("latin1");
+			if (responsePrefix.length >= HTTP_RESPONSE_PREFIX_LENGTH) {
+				finish(responsePrefix.startsWith("HTTP/"));
+			}
 		});
-		return true;
-	} catch {
-		return false;
-	} finally {
-		clearTimeout(timeout);
-	}
+		socket.once("connect", () => {
+			socket.write(
+				"OPTIONS * HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+			);
+		});
+		socket.connect(port, "127.0.0.1");
+	});
 };
 
 const safePreviewServers = async (

--- a/apps/server/src/preview/preview-service.ts
+++ b/apps/server/src/preview/preview-service.ts
@@ -1,0 +1,182 @@
+import type {
+	PreviewErrorCode,
+	PreviewForwardResult,
+	PreviewServer,
+} from "@zuse/contracts";
+import {
+	isTailnetOperatorPermissionError,
+	parseTailnetStatus,
+	runTailnetCommand,
+	type TailnetCommandRunner,
+} from "@zuse/tailnet";
+import {
+	type LocalServerSummary,
+	listLocalServers,
+} from "@zuse/utils/local-port-inspector";
+import { Context, Effect, Layer } from "effect";
+
+const MINIMUM_PREVIEW_PORT = 1_024;
+const HTTP_PROBE_TIMEOUT_MS = 2_500;
+
+export class PreviewServiceError {
+	readonly _tag = "PreviewServiceError";
+
+	constructor(
+		readonly code: PreviewErrorCode,
+		readonly approvalUrl?: string,
+	) {}
+}
+
+export interface PreviewServiceShape {
+	readonly listServers: () => Effect.Effect<
+		ReadonlyArray<PreviewServer>,
+		PreviewServiceError
+	>;
+	readonly forward: (
+		port: number,
+	) => Effect.Effect<PreviewForwardResult, PreviewServiceError>;
+}
+
+export class PreviewService extends Context.Service<
+	PreviewService,
+	PreviewServiceShape
+>()("zuse/PreviewService") {}
+
+export interface PreviewServiceDependencies {
+	readonly listListeners: () => Promise<ReadonlyArray<LocalServerSummary>>;
+	readonly probeHttp: (port: number) => Promise<boolean>;
+	readonly runTailnet: TailnetCommandRunner;
+	readonly zusePort: number;
+}
+
+const isAllowedPreviewPort = (port: number, zusePort: number): boolean =>
+	Number.isInteger(port) &&
+	port >= MINIMUM_PREVIEW_PORT &&
+	port <= 65_535 &&
+	port !== zusePort;
+
+export const probeLoopbackHttp = async (port: number): Promise<boolean> => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), HTTP_PROBE_TIMEOUT_MS);
+	try {
+		await fetch(`http://127.0.0.1:${port}/`, {
+			method: "HEAD",
+			redirect: "manual",
+			signal: controller.signal,
+		});
+		return true;
+	} catch {
+		return false;
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+const safePreviewServers = async (
+	dependencies: PreviewServiceDependencies,
+): Promise<ReadonlyArray<PreviewServer>> => {
+	const listeners = (await dependencies.listListeners()).filter((server) =>
+		isAllowedPreviewPort(server.port, dependencies.zusePort),
+	);
+	const probes = await Promise.all(
+		listeners.map(async (server) => ({
+			server,
+			http: await dependencies.probeHttp(server.port),
+		})),
+	);
+	return probes
+		.filter((result) => result.http)
+		.map(({ server }) => ({ name: server.name, port: server.port }));
+};
+
+export const makePreviewService = (
+	dependencies: PreviewServiceDependencies,
+): PreviewServiceShape => {
+	let commandTail = Promise.resolve();
+	const exclusive = <A>(operation: () => Promise<A>): Promise<A> => {
+		const result = commandTail.then(operation, operation);
+		commandTail = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	};
+
+	return PreviewService.of({
+		listServers: () =>
+			Effect.tryPromise({
+				try: () => safePreviewServers(dependencies),
+				catch: () => new PreviewServiceError("preview-unavailable"),
+			}),
+		forward: (port) =>
+			Effect.tryPromise({
+				try: () =>
+					exclusive(async () => {
+						if (!isAllowedPreviewPort(port, dependencies.zusePort)) {
+							throw new PreviewServiceError("invalid-port");
+						}
+						const listeners = await dependencies.listListeners();
+						if (!listeners.some((server) => server.port === port)) {
+							throw new PreviewServiceError("server-not-found");
+						}
+						if (!(await dependencies.probeHttp(port))) {
+							throw new PreviewServiceError("server-not-http");
+						}
+
+						const status = await dependencies.runTailnet(["status", "--json"]);
+						if (status.code !== 0) {
+							throw new PreviewServiceError("private-network-required");
+						}
+						const parsed = parseTailnetStatus(status.stdout);
+						if (parsed.backendState !== "Running" || parsed.dnsName === null) {
+							throw new PreviewServiceError("private-network-required");
+						}
+
+						const served = await dependencies.runTailnet(
+							[
+								"serve",
+								"--bg",
+								"--yes",
+								`--https=${port}`,
+								`http://127.0.0.1:${port}`,
+							],
+							15_000,
+						);
+						if (served.approvalUrl !== undefined) {
+							throw new PreviewServiceError(
+								"private-preview-approval-required",
+								served.approvalUrl,
+							);
+						}
+						if (served.code !== 0) {
+							const output = `${served.stderr}\n${served.stdout}`;
+							throw new PreviewServiceError(
+								isTailnetOperatorPermissionError(output)
+									? "private-network-permission-required"
+									: "preview-unavailable",
+							);
+						}
+
+						return {
+							port,
+							url: `https://${parsed.dnsName}:${port}`,
+							transport: "private-network" as const,
+						};
+					}),
+				catch: (cause) =>
+					cause instanceof PreviewServiceError
+						? cause
+						: new PreviewServiceError("preview-unavailable"),
+			}),
+	});
+};
+
+export const PreviewServiceLive: Layer.Layer<PreviewService> = Layer.succeed(
+	PreviewService,
+	makePreviewService({
+		listListeners: listLocalServers,
+		probeHttp: probeLoopbackHttp,
+		runTailnet: runTailnetCommand,
+		zusePort: Number(process.env.ZUSE_PORT ?? "47837"),
+	}),
+);

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -49,6 +49,7 @@ import { MigrationsLive } from "./persistence/migrations.ts";
 import { NdjsonLoggerLive } from "./persistence/ndjson-logger.ts";
 import { SqliteLive } from "./persistence/sqlite.ts";
 import { PokemonServiceLive } from "./pokemon/layers/pokemon-service.ts";
+import { PreviewServiceLive } from "./preview/preview-service.ts";
 import { BrowserBridgeServiceLive } from "./provider/layers/browser-bridge-service.ts";
 import { PermissionServiceLive } from "./provider/layers/permission-service.ts";
 import { ProviderServiceLive } from "./provider/layers/provider-service.ts";
@@ -555,6 +556,7 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		FileSearchLayer,
 		ProjectScaffoldLayer,
 		ProviderLayer,
+		PreviewServiceLive,
 		McpLayer,
 		SessionDomainLayer,
 		ConversationServicesLayer,

--- a/apps/server/test/unit/cloud-runtime-assets.test.ts
+++ b/apps/server/test/unit/cloud-runtime-assets.test.ts
@@ -272,6 +272,18 @@ describe("cloud runtime assets", () => {
 		expect(build).not.toContain("releases.invalid");
 	});
 
+	test("declares native runtime loader packages in the server workspace", async () => {
+		const packageJson = JSON.parse(
+			await readWorkspaceFile("apps/server/package.json"),
+		) as { dependencies?: Record<string, string> };
+
+		expect(packageJson.dependencies).toMatchObject({
+			bindings: "1.5.0",
+			"file-uri-to-path": "1.0.0",
+			"node-gyp-build": "4.8.4",
+		});
+	});
+
 	test("gates automatic and explicit staging publication without deploying production", async () => {
 		const workflow = await readWorkspaceFile(
 			".github/workflows/cloud-runtime-staging.yml",

--- a/apps/server/test/unit/cloud-runtime-assets.test.ts
+++ b/apps/server/test/unit/cloud-runtime-assets.test.ts
@@ -285,9 +285,7 @@ describe("cloud runtime assets", () => {
 			'"$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main"',
 		);
 		expect(workflow).toContain("publish_staging:");
-		expect(workflow).toContain(
-			"refs/heads/swarajbachu/managed-vps-cloud-provisioning",
-		);
+		expect(workflow).toContain("refs/heads/swarajbachu/relay-web-preview");
 		expect(workflow.match(/id: publication/gu)).toHaveLength(1);
 		expect(
 			workflow.match(/steps\.publication\.outputs\.enabled == 'true'/gu),

--- a/apps/server/test/unit/preview-service.test.ts
+++ b/apps/server/test/unit/preview-service.test.ts
@@ -1,0 +1,120 @@
+import type { TailnetCommandResult } from "@zuse/tailnet";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { makePreviewService } from "../../src/preview/preview-service.ts";
+
+const commandResult = (
+	stdout = "",
+	code = 0,
+	stderr = "",
+): TailnetCommandResult => ({ stdout, stderr, code });
+
+const runningStatus = JSON.stringify({
+	BackendState: "Running",
+	Self: { DNSName: "Build-Box.Example.ts.net." },
+});
+
+describe("preview service", () => {
+	it("lists only loopback HTTP servers and hides the Zuse control port", async () => {
+		const service = makePreviewService({
+			listListeners: async () => [
+				{ name: "node", port: 3001 },
+				{ name: "postgres", port: 5432 },
+				{ name: "zuse", port: 47837 },
+			],
+			probeHttp: async (port) => port === 3001,
+			runTailnet: async () => commandResult(),
+			zusePort: 47837,
+		});
+
+		await expect(Effect.runPromise(service.listServers())).resolves.toEqual([
+			{ name: "node", port: 3001 },
+		]);
+	});
+
+	it("creates a private HTTPS route for a running dev server", async () => {
+		const calls: ReadonlyArray<string>[] = [];
+		const service = makePreviewService({
+			listListeners: async () => [{ name: "node", port: 3001 }],
+			probeHttp: async () => true,
+			runTailnet: async (args) => {
+				calls.push(args);
+				return args[0] === "status"
+					? commandResult(runningStatus)
+					: commandResult();
+			},
+			zusePort: 47837,
+		});
+
+		await expect(Effect.runPromise(service.forward(3001))).resolves.toEqual({
+			port: 3001,
+			url: "https://build-box.example.ts.net:3001",
+			transport: "private-network",
+		});
+		expect(calls).toEqual([
+			["status", "--json"],
+			["serve", "--bg", "--yes", "--https=3001", "http://127.0.0.1:3001"],
+		]);
+	});
+
+	it("rejects missing and non-HTTP listeners before changing networking", async () => {
+		let commands = 0;
+		const service = makePreviewService({
+			listListeners: async () => [{ name: "postgres", port: 5432 }],
+			probeHttp: async () => false,
+			runTailnet: async () => {
+				commands += 1;
+				return commandResult();
+			},
+			zusePort: 47837,
+		});
+
+		await expect(
+			Effect.runPromise(service.forward(3001)),
+		).rejects.toMatchObject({
+			code: "server-not-found",
+		});
+		await expect(
+			Effect.runPromise(service.forward(5432)),
+		).rejects.toMatchObject({
+			code: "server-not-http",
+		});
+		expect(commands).toBe(0);
+	});
+
+	it("returns a stable setup error when private networking is unavailable", async () => {
+		const service = makePreviewService({
+			listListeners: async () => [{ name: "node", port: 3001 }],
+			probeHttp: async () => true,
+			runTailnet: async () => commandResult("", 1, "not logged in"),
+			zusePort: 47837,
+		});
+
+		await expect(
+			Effect.runPromise(service.forward(3001)),
+		).rejects.toMatchObject({
+			code: "private-network-required",
+		});
+	});
+
+	it("surfaces feature approval without exposing command output", async () => {
+		const approvalUrl = "https://login.tailscale.com/f/serve?node=example";
+		const service = makePreviewService({
+			listListeners: async () => [{ name: "node", port: 3001 }],
+			probeHttp: async () => true,
+			runTailnet: async (args) =>
+				args[0] === "status"
+					? commandResult(runningStatus)
+					: { ...commandResult("private-output"), approvalUrl },
+			zusePort: 47837,
+		});
+
+		await expect(
+			Effect.runPromise(service.forward(3001)),
+		).rejects.toMatchObject({
+			code: "private-preview-approval-required",
+			approvalUrl,
+		});
+	});
+});

--- a/apps/server/test/unit/preview-service.test.ts
+++ b/apps/server/test/unit/preview-service.test.ts
@@ -1,8 +1,13 @@
+import { createServer } from "node:http";
+import { createServer as createTcpServer, type Socket } from "node:net";
 import type { TailnetCommandResult } from "@zuse/tailnet";
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
-import { makePreviewService } from "../../src/preview/preview-service.ts";
+import {
+	makePreviewService,
+	probeLoopbackHttp,
+} from "../../src/preview/preview-service.ts";
 
 const commandResult = (
 	stdout = "",
@@ -16,6 +21,62 @@ const runningStatus = JSON.stringify({
 });
 
 describe("preview service", () => {
+	it("detects HTTP without waiting for an application route", async () => {
+		const server = createServer((request, response) => {
+			if (request.method === "OPTIONS" && request.url === "*") {
+				response.writeHead(204);
+				response.end();
+			}
+		});
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		const address = server.address();
+		if (address === null || typeof address === "string") {
+			throw new Error("Test server did not bind a TCP port");
+		}
+
+		try {
+			const startedAt = performance.now();
+			await expect(probeLoopbackHttp(address.port)).resolves.toBe(true);
+			expect(performance.now() - startedAt).toBeLessThan(1_000);
+		} finally {
+			server.closeAllConnections();
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) =>
+					error === undefined ? resolve() : reject(error),
+				),
+			);
+		}
+	});
+
+	it("does not expose a non-HTTP listener as a preview", async () => {
+		const connections = new Set<Socket>();
+		const server = createTcpServer((socket) => {
+			connections.add(socket);
+			socket.once("close", () => connections.delete(socket));
+			socket.end("NOT-HTTP\n");
+		});
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		const address = server.address();
+		if (address === null || typeof address === "string") {
+			throw new Error("Test server did not bind a TCP port");
+		}
+
+		try {
+			await expect(probeLoopbackHttp(address.port)).resolves.toBe(false);
+		} finally {
+			for (const connection of connections) connection.destroy();
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) =>
+					error === undefined ? resolve() : reject(error),
+				),
+			);
+		}
+	});
+
 	it("lists only loopback HTTP servers and hides the Zuse control port", async () => {
 		const service = makePreviewService({
 			listListeners: async () => [

--- a/bun.lock
+++ b/bun.lock
@@ -241,7 +241,10 @@
       "name": "@zusehq/server",
       "version": "0.1.2",
       "dependencies": {
+        "bindings": "1.5.0",
+        "file-uri-to-path": "1.0.0",
         "keytar": "^7.9.0",
+        "node-gyp-build": "4.8.4",
         "node-pty": "^1.1.0",
         "strip-ansi": "^7.2.0",
         "tree-sitter": "^0.21.1",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -27,6 +27,7 @@ export * from "./permission.ts";
 export * from "./ping.ts";
 export * from "./pokemon.ts";
 export * from "./power.ts";
+export * from "./preview.ts";
 export * from "./pty.ts";
 export * from "./relay.ts";
 export * from "./repository-settings.ts";

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -1,0 +1,61 @@
+import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
+
+/** A loopback HTTP server detected on the environment that owns the project. */
+export class PreviewServer extends Schema.Class<PreviewServer>("PreviewServer")(
+	{
+		name: Schema.String,
+		port: Schema.Number,
+	},
+) {}
+
+export class PreviewServerList extends Schema.Class<PreviewServerList>(
+	"PreviewServerList",
+)({
+	servers: Schema.Array(PreviewServer),
+}) {}
+
+export const PreviewErrorCode = Schema.Literals([
+	"invalid-port",
+	"server-not-found",
+	"server-not-http",
+	"private-network-required",
+	"private-network-permission-required",
+	"private-preview-approval-required",
+	"preview-unavailable",
+]);
+export type PreviewErrorCode = typeof PreviewErrorCode.Type;
+
+export class PreviewOpError extends Schema.TaggedErrorClass<PreviewOpError>()(
+	"PreviewOpError",
+	{
+		code: PreviewErrorCode,
+		approvalUrl: Schema.optional(Schema.String),
+	},
+) {}
+
+export class PreviewForwardRequest extends Schema.Class<PreviewForwardRequest>(
+	"PreviewForwardRequest",
+)({
+	port: Schema.Number,
+}) {}
+
+export class PreviewForwardResult extends Schema.Class<PreviewForwardResult>(
+	"PreviewForwardResult",
+)({
+	port: Schema.Number,
+	url: Schema.String,
+	transport: Schema.Literal("private-network"),
+}) {}
+
+export const PreviewServersListRpc = Rpc.make("preview.servers.list", {
+	payload: Schema.Void,
+	success: PreviewServerList,
+	error: PreviewOpError,
+});
+
+export const PreviewForwardRpc = Rpc.make("preview.forward", {
+	payload: PreviewForwardRequest,
+	success: PreviewForwardResult,
+	error: PreviewOpError,
+});

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -161,6 +161,7 @@ import {
 } from "./permission.ts";
 import { PingRpc } from "./ping.ts";
 import { PokemonEnsureSpriteCachedRpc, PokemonPokedexRpc } from "./pokemon.ts";
+import { PreviewForwardRpc, PreviewServersListRpc } from "./preview.ts";
 import {
 	PtyCloseRpc,
 	PtyOpenRpc,
@@ -487,6 +488,8 @@ export const MemoizeRpcs = RpcGroup.make(
 	BrowserSetCredentialRpc,
 	BrowserListCredentialsRpc,
 	BrowserRemoveCredentialRpc,
+	PreviewServersListRpc,
+	PreviewForwardRpc,
 	WorktreeCreateRpc,
 	WorktreeListRpc,
 	WorktreeGetRpc,

--- a/packages/contracts/test/unit/preview.test.ts
+++ b/packages/contracts/test/unit/preview.test.ts
@@ -1,0 +1,32 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+import {
+	PreviewForwardRequest,
+	PreviewForwardResult,
+	PreviewServerList,
+} from "../../src/index.ts";
+
+describe("preview contracts", () => {
+	it("decodes environment servers without exposing host addresses", () => {
+		const list = Schema.decodeUnknownSync(PreviewServerList)({
+			servers: [{ name: "node", port: 3001 }],
+		});
+
+		expect(list.servers).toEqual([{ name: "node", port: 3001 }]);
+		expect(JSON.stringify(list)).not.toContain("178.104");
+	});
+
+	it("keeps the forwarded target private-network scoped", () => {
+		expect(
+			Schema.decodeUnknownSync(PreviewForwardRequest)({ port: 3001 }),
+		).toEqual({ port: 3001 });
+		expect(
+			Schema.decodeUnknownSync(PreviewForwardResult)({
+				port: 3001,
+				url: "https://build-box.example.ts.net:3001",
+				transport: "private-network",
+			}),
+		).toMatchObject({ transport: "private-network" });
+	});
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,6 +6,7 @@
 	"exports": {
 		"./drainable-worker": "./src/drainable-worker.ts",
 		"./keyed-worker": "./src/keyed-worker.ts",
+		"./local-port-inspector": "./src/local-port-inspector.ts",
 		"./proposed-plan": "./src/proposed-plan.ts",
 		"./push-bus": "./src/push-bus.ts",
 		"./readiness": "./src/readiness.ts",

--- a/packages/utils/src/local-port-inspector.ts
+++ b/packages/utils/src/local-port-inspector.ts
@@ -58,7 +58,7 @@ export const parseNetstatListeners = (
 	return [...byPort].map(([port, name]) => ({ name, port }));
 };
 
-const parseProcListeners = (
+export const parseProcListeners = (
 	contents: string,
 ): ReadonlyArray<LocalServerSummary> => {
 	const ports = new Set<number>();


### PR DESCRIPTION
## What changed

- detect HTTP development servers on the selected local or cloud computer
- create private HTTPS previews for cloud ports through the existing private-network connection
- open previews inside the Browser tab or in the default desktop browser
- share the cross-platform port inspector between desktop and Linux runtimes
- authorize this follow-up branch to publish the staging runtime channel

## Why

Cloud projects could start development servers, but the desktop Browser tab only inspected ports on the local Mac. Remote ports therefore appeared unavailable even while the server was healthy on the cloud machine.

The initial remote probe also loaded the application root. A valid development server whose root route was still compiling or blocked could exceed the RPC response window. Preview detection now performs a bounded protocol-level HTTP handshake without executing application routes, while continuing to reject non-HTTP listeners.

The staging runtime build now installs only the server workspace dependency graph, retries transient registry failures, and explicitly declares every native loader copied into the runtime artifact.

## Validation

- Biome checks for all changed source files
- contract, utility, server, renderer, and desktop type checks
- contract tests: 92 passed
- utility tests: 18 passed
- server tests: 281 passed
- renderer tests: 446 passed
- changed desktop adapter tests: 7 passed
- renderer production build
- server runtime bundle build

The staging runtime publication remains manual and branch-restricted. Production deployment is unchanged.
