### PR TITLE
Allow chats in projects without Git

### DIFF
--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -1337,6 +1337,8 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 						: (s.selectedChatByProject[creation.projectId] ?? null),
 			},
 		}));
+		useTerminalsStore.getState().disposeChat(chatId);
+		useUiStore.getState().clearChatPanels(chatId);
 	},
 	rename: async (chatId, title) => {
 		set({ error: null });
@@ -1434,6 +1436,11 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 	},
 	archive: async (chatId, force = false) => {
 		set({ error: null });
+		const provisional = get().pendingCreationByChat[chatId];
+		if (provisional?.phase === "failed") {
+			get().discardCreation(chatId);
+			return { ok: true } as const;
+		}
 		const projectIdBeforeArchive = findChatProject(
 			get().chatsByProject,
 			chatId,
@@ -1707,6 +1714,10 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 	},
 	remove: async (chatId) => {
 		set({ error: null });
+		if (get().pendingCreationByChat[chatId]?.phase === "failed") {
+			get().discardCreation(chatId);
+			return;
+		}
 		try {
 			const client = await getRpcClient();
 			await Effect.runPromise(client["chat.delete"]({ chatId }));

--- a/apps/renderer/test/unit/chats-store.test.ts
+++ b/apps/renderer/test/unit/chats-store.test.ts
@@ -160,6 +160,7 @@ describe("chats store selection", () => {
 			chatsByProject: { [projectId]: [chat] },
 			selectedChatId: null,
 			selectedChatByProject: {},
+			pendingCreationByChat: {},
 			archiveProgressByChat: {},
 			error: null,
 			archive: initialChatsState.archive,
@@ -446,6 +447,59 @@ describe("chats store selection", () => {
 		expect(
 			useChatsStore.getState().pendingCreationByChat[failedChatId ?? ""],
 		).toBeUndefined();
+	});
+
+	it.each([
+		"archive",
+		"remove",
+	] as const)("discards a failed provisional chat through %s without calling durable chat RPCs", async (action) => {
+		const discard = vi.fn(() => Effect.succeed({ discarded: true }));
+		const archive = vi.fn(() => Effect.fail(new Error("unexpected archive")));
+		const remove = vi.fn(() => Effect.fail(new Error("unexpected delete")));
+		rpcClientFactory.mockReturnValue({
+			"chat.create": () => Effect.fail(new Error("not a git repository")),
+			"chat.creation.discard": discard,
+			"chat.archive": archive,
+			"chat.delete": remove,
+		});
+
+		await useChatsStore
+			.getState()
+			.create(projectId, session.providerId, session.model, {
+				workspacePolicy: { _tag: "fresh" },
+				workspaceRequested: true,
+			});
+		const failedChatId = useChatsStore.getState().selectedChatId;
+		expect(failedChatId).not.toBeNull();
+
+		if (action === "archive") {
+			await expect(
+				useChatsStore.getState().archive(failedChatId as ChatId),
+			).resolves.toEqual({ ok: true });
+		} else {
+			await useChatsStore.getState().remove(failedChatId as ChatId);
+		}
+
+		await vi.waitFor(() => expect(discard).toHaveBeenCalledOnce());
+		expect(archive).not.toHaveBeenCalled();
+		expect(remove).not.toHaveBeenCalled();
+		expect(
+			useChatsStore.getState().pendingCreationByChat[failedChatId ?? ""],
+		).toBeUndefined();
+		expect(
+			useChatsStore
+				.getState()
+				.chatsByProject[projectId]?.some(
+					(candidate) => candidate.id === failedChatId,
+				),
+		).toBe(false);
+		expect(
+			useSessionsStore
+				.getState()
+				.sessionsByProject[projectId]?.some(
+					(candidate) => candidate.chatId === failedChatId,
+				),
+		).toBe(false);
 	});
 
 	it("restores a durable failed creation without changing navigation", async () => {

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -22,6 +22,7 @@ import {
 	WorktreeId,
 } from "@zuse/contracts";
 import { SessionDomain } from "@zuse/domain/engine/session-domain";
+import { GitService } from "@zuse/git/git-service";
 import { WorktreeService } from "@zuse/git/worktree-service";
 import { KeyedEffectSerialWorker } from "@zuse/utils/keyed-worker";
 import { Effect, Layer, Result, Schedule, Stream } from "effect";
@@ -455,11 +456,35 @@ const ChatCreate = MemoizeRpcs.toLayerHandler("chat.create", (input) =>
 			const svc = yield* ChatService;
 			const analytics = yield* AnalyticsService;
 			const sql = yield* SqlClient.SqlClient;
-			const policy =
+			const requestedPolicy =
 				input.workspacePolicy?._tag ??
 				(input.worktreeId === null || input.worktreeId === undefined
 					? "main"
 					: "existing");
+			const policy =
+				requestedPolicy === "fresh"
+					? yield* Effect.flatMap(GitService, (git) =>
+							git.isRepository(input.projectId),
+						).pipe(
+							Effect.map((isRepository) =>
+								isRepository ? ("fresh" as const) : ("main" as const),
+							),
+							Effect.catchTags({
+								GitNotARepoError: () => Effect.succeed("main" as const),
+								GitNotInstalledError: () => Effect.succeed("main" as const),
+							}),
+							Effect.mapError(
+								(error) =>
+									new SessionStartError({
+										providerId: input.providerId,
+										reason:
+											"reason" in error
+												? String(error.reason)
+												: "The Git repository could not be inspected.",
+									}),
+							),
+						)
+					: requestedPolicy;
 			if (
 				input.operationId !== undefined &&
 				input.chatId !== undefined &&
@@ -500,8 +525,16 @@ const ChatCreate = MemoizeRpcs.toLayerHandler("chat.create", (input) =>
 						LIMIT 1
 					`.pipe(Effect.orDie);
 			const durableWorktreeId = operationRows[0]?.worktree_id ?? null;
+			if (input.operationId !== undefined && policy === "main") {
+				yield* sql`
+					UPDATE chat_creation_operations
+					SET workspace_policy = 'main', worktree_id = NULL,
+					    updated_at = ${new Date().toISOString()}
+					WHERE operation_id = ${input.operationId}
+				`.pipe(Effect.orDie);
+			}
 			const worktreeId =
-				input.workspacePolicy?._tag === "fresh"
+				policy === "fresh"
 					? yield* Effect.gen(function* () {
 							const requestedId =
 								durableWorktreeId === null
@@ -552,9 +585,9 @@ const ChatCreate = MemoizeRpcs.toLayerHandler("chat.create", (input) =>
 							}
 							return created.id;
 						})
-					: input.workspacePolicy?._tag === "existing"
+					: policy === "existing" && input.workspacePolicy?._tag === "existing"
 						? input.workspacePolicy.worktreeId
-						: input.workspacePolicy?._tag === "main"
+						: policy === "main"
 							? null
 							: (input.worktreeId ?? null);
 			if (input.operationId !== undefined && policy !== "fresh") {

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -356,6 +356,7 @@ const StubWorktreeLive = Layer.succeed(WorktreeService, {
 // The first-turn auto-namer may fire for chats with a worktree. Tests here
 // do not exercise branch naming, so these stubs only satisfy the layer graph.
 const StubGitLive = Layer.succeed(GitService, {
+	isRepository: () => Effect.succeed(true),
 	log: () => Effect.die("not used"),
 	status: () => Effect.die("not used"),
 	branches: () => Effect.die("not used"),

--- a/apps/server/test/support/conversation-services-fixture-harness.ts
+++ b/apps/server/test/support/conversation-services-fixture-harness.ts
@@ -297,6 +297,7 @@ const makeRuntime = (
 	});
 
 	const StubGitLive = Layer.succeed(GitService, {
+		isRepository: () => Effect.succeed(true),
 		log: () => Effect.die("not used"),
 		status: () => Effect.die("not used"),
 		branches: () => Effect.die("not used"),

--- a/packages/git/src/git-service-live.ts
+++ b/packages/git/src/git-service-live.ts
@@ -628,6 +628,14 @@ export const GitServiceLive = Layer.effect(
 				]).pipe(Effect.map(parseLogOutput)),
 			);
 
+		const isRepository: GitService["Service"]["isRepository"] = (folderId) =>
+			Effect.flatMap(resolvePath(folderId), (cwd) =>
+				run(folderId, cwd, ["rev-parse", "--is-inside-work-tree"]).pipe(
+					Effect.map((output) => output.trim() === "true"),
+					Effect.catchTag("GitNotARepoError", () => Effect.succeed(false)),
+				),
+			);
+
 		const status: GitService["Service"]["status"] = (folderId, worktreeId) =>
 			Effect.flatMap(resolvePathForWorktree(folderId, worktreeId), (cwd) =>
 				run(folderId, cwd, [
@@ -2428,6 +2436,7 @@ export const GitServiceLive = Layer.effect(
 				);
 
 		return {
+			isRepository,
 			log,
 			status,
 			branches,

--- a/packages/git/src/git-service.ts
+++ b/packages/git/src/git-service.ts
@@ -32,6 +32,14 @@ type GitFailure =
 	| GitFolderNotFoundError;
 
 export interface GitServiceShape {
+	/**
+	 * Cheap repository capability probe for workflows that can degrade to a
+	 * plain project directory. A missing Git repository resolves to `false`;
+	 * missing folders, Git itself, and other command failures stay typed errors.
+	 */
+	readonly isRepository: (
+		folderId: FolderId,
+	) => Effect.Effect<boolean, GitFailure>;
 	readonly log: (
 		folderId: FolderId,
 		limit: number,

--- a/packages/git/test/integration/git-service-live.test.ts
+++ b/packages/git/test/integration/git-service-live.test.ts
@@ -131,6 +131,21 @@ describe("GitServiceLive", () => {
 		expect(untrackedDiff.patch).toContain("+++ b/new.txt");
 	});
 
+	test("distinguishes Git repositories from plain directories", async () => {
+		const plainDirectory = join(temporaryRoot, "plain-directory");
+		mkdirSync(plainDirectory);
+
+		await expect(
+			run((service) => service.isRepository(folderId)),
+		).resolves.toBe(true);
+		await expect(
+			run(
+				(service) => service.isRepository(folderId),
+				makeLayer({ root: plainDirectory }),
+			),
+		).resolves.toBe(false);
+	});
+
 	test("commits changes and pushes the current branch", async () => {
 		const remote = join(temporaryRoot, "remote.git");
 		git(temporaryRoot, "init", "--bare", remote);


### PR DESCRIPTION
## Summary
- fall back from fresh worktrees to the project directory when Git is uninitialized or unavailable
- persist the effective main-directory policy so retries and restart recovery stay consistent
- discard failed provisional chats through the creation lifecycle instead of issuing archive/delete RPCs for nonexistent records

## Validation
- renderer chat store tests: 30 passed
- server conversation integration tests: 87 passed
- focused Git repository probe test: passed
- server and Git package type checks: passed
- Biome checks on changed files: passed

## Notes
- the full renderer type check is blocked in this cloud environment by unavailable private HugeIcons packages
- the full Git integration file has one unrelated existing push-failure expectation mismatch; the new focused probe test passes

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2aabaedb-92b6-47a4-998b-2a7857c19b27)
