### PR TITLE
Remove ACP prompt timeouts

### DIFF
--- a/packages/acp/src/rpc-client.ts
+++ b/packages/acp/src/rpc-client.ts
@@ -14,7 +14,8 @@ export interface AcpRequestContext {
 }
 
 export interface AcpRequestOptions {
-	readonly timeoutMs?: number;
+	/** `null` keeps the request pending until it settles or is cancelled. */
+	readonly timeoutMs?: number | null;
 	readonly onAssignedId?: (id: number) => void;
 	readonly timeoutError?: (
 		context: AcpRequestContext & { readonly timeoutMs: number },
@@ -28,7 +29,7 @@ export interface AcpResponseOptions {
 type PendingRequest = AcpRequestContext & {
 	readonly resolve: (value: unknown) => void;
 	readonly reject: (cause: Error) => void;
-	readonly timer: ReturnType<typeof setTimeout>;
+	readonly timer: ReturnType<typeof setTimeout> | null;
 };
 
 export class AcpResponseError extends Error {
@@ -58,16 +59,20 @@ export class AcpRpcClient {
 		options: AcpRequestOptions = {},
 	): Promise<unknown> {
 		const id = this.nextId++;
-		const timeoutMs = options.timeoutMs ?? 30_000;
+		const timeoutMs =
+			options.timeoutMs === undefined ? 30_000 : options.timeoutMs;
 		options.onAssignedId?.(id);
 		const response = new Promise<unknown>((resolve, reject) => {
-			const timer = setTimeout(() => {
-				this.pending.delete(id);
-				reject(
-					options.timeoutError?.({ id, method, timeoutMs }) ??
-						new Error(`${method} timed out after ${timeoutMs}ms`),
-				);
-			}, timeoutMs);
+			const timer =
+				timeoutMs === null
+					? null
+					: setTimeout(() => {
+							this.pending.delete(id);
+							reject(
+								options.timeoutError?.({ id, method, timeoutMs }) ??
+									new Error(`${method} timed out after ${timeoutMs}ms`),
+							);
+						}, timeoutMs);
 			this.pending.set(id, { id, method, resolve, reject, timer });
 		});
 		try {
@@ -99,7 +104,7 @@ export class AcpRpcClient {
 		const pending = this.pending.get(message.id);
 		if (pending === undefined) return false;
 		this.pending.delete(message.id);
-		clearTimeout(pending.timer);
+		if (pending.timer !== null) clearTimeout(pending.timer);
 		if (message.error !== undefined) {
 			pending.reject(
 				options.mapError?.(message.error, pending) ??
@@ -119,14 +124,14 @@ export class AcpRpcClient {
 		const pending = this.pending.get(id);
 		if (pending === undefined) return null;
 		this.pending.delete(id);
-		clearTimeout(pending.timer);
+		if (pending.timer !== null) clearTimeout(pending.timer);
 		pending.reject(cause);
 		return { id, method: pending.method };
 	}
 
 	rejectAll(cause: Error): void {
 		for (const pending of this.pending.values()) {
-			clearTimeout(pending.timer);
+			if (pending.timer !== null) clearTimeout(pending.timer);
 			pending.reject(cause);
 		}
 		this.pending.clear();

--- a/packages/acp/test/unit/rpc-client.test.ts
+++ b/packages/acp/test/unit/rpc-client.test.ts
@@ -55,6 +55,7 @@ describe("AcpRpcClient", () => {
 			"session/prompt",
 			{},
 			{
+				timeoutMs: null,
 				onAssignedId: (assigned) => {
 					id = assigned;
 				},
@@ -97,5 +98,41 @@ describe("AcpRpcClient", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("keeps deadline-free requests pending until a response arrives", async () => {
+		vi.useFakeTimers();
+		try {
+			const client = new AcpRpcClient(() => {});
+			const response = client.request(
+				"session/prompt",
+				{},
+				{ timeoutMs: null },
+			);
+
+			await vi.advanceTimersByTimeAsync(300_001);
+			expect(client.pendingCount).toBe(1);
+			expect(
+				client.acceptResponse({
+					jsonrpc: "2.0",
+					id: 1,
+					result: { stopReason: "end_turn" },
+				}),
+			).toBe(true);
+			await expect(response).resolves.toEqual({ stopReason: "end_turn" });
+			expect(client.pendingCount).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("rejects deadline-free requests when the transport closes", async () => {
+		const client = new AcpRpcClient(() => {});
+		const response = client.request("session/prompt", {}, { timeoutMs: null });
+
+		client.rejectAll(new Error("transport closed"));
+
+		await expect(response).rejects.toThrow("transport closed");
+		expect(client.pendingCount).toBe(0);
 	});
 });

--- a/packages/agents/src/drivers/gemini.ts
+++ b/packages/agents/src/drivers/gemini.ts
@@ -294,19 +294,24 @@ export const startGeminiSession = (
 		const request = (
 			method: string,
 			params: unknown,
-			timeoutMs = 30_000,
+			timeoutMs: number | null = 30_000,
 			onAssignedId?: (id: number) => void,
 		): Promise<unknown> =>
 			rpc.request(method, params, {
 				timeoutMs,
 				onAssignedId,
-				timeoutError: () => {
-					const diagnostics = formatGeminiDiagnostics(diagnosticTail());
-					const detail = diagnostics.length > 0 ? ` — ${diagnostics}` : "";
-					return new Error(
-						`Gemini ACP ${method} timed out after ${timeoutMs}ms${detail}`,
-					);
-				},
+				...(timeoutMs === null
+					? {}
+					: {
+							timeoutError: () => {
+								const diagnostics = formatGeminiDiagnostics(diagnosticTail());
+								const detail =
+									diagnostics.length > 0 ? ` — ${diagnostics}` : "";
+								return new Error(
+									`Gemini ACP ${method} timed out after ${timeoutMs}ms${detail}`,
+								);
+							},
+						}),
 			});
 
 		const notify = (method: string, params: unknown): void => {
@@ -636,7 +641,7 @@ export const startGeminiSession = (
 									...(input.model !== undefined ? { model: input.model } : {}),
 								},
 							},
-							5 * 60_000,
+							null,
 							(id) => {
 								currentPromptRpcId = id;
 							},

--- a/packages/agents/src/drivers/grok.ts
+++ b/packages/agents/src/drivers/grok.ts
@@ -715,14 +715,18 @@ export const startGrokSession = (
 		const request = (
 			method: string,
 			params: unknown,
-			timeoutMs = 30_000,
+			timeoutMs: number | null = 30_000,
 			onAssignedId?: (id: number) => void,
 		): Promise<unknown> =>
 			rpc.request(method, params, {
 				timeoutMs,
 				onAssignedId,
-				timeoutError: () =>
-					new Error(`Grok ACP ${method} timed out after ${timeoutMs}ms`),
+				...(timeoutMs === null
+					? {}
+					: {
+							timeoutError: () =>
+								new Error(`Grok ACP ${method} timed out after ${timeoutMs}ms`),
+						}),
 			});
 
 		const notify = (method: string, params: unknown): void => {
@@ -1407,7 +1411,7 @@ export const startGrokSession = (
 								sessionId: sid,
 								prompt,
 							},
-							5 * 60_000,
+							null,
 							(id) => {
 								currentPromptRpcId = id;
 							},

--- a/packages/agents/src/drivers/kiro.ts
+++ b/packages/agents/src/drivers/kiro.ts
@@ -247,19 +247,24 @@ export const startKiroSession = (
 		const request = (
 			method: string,
 			params: unknown,
-			timeoutMs = 30_000,
+			timeoutMs: number | null = 30_000,
 			onAssignedId?: (id: number) => void,
 		): Promise<unknown> =>
 			rpc.request(method, params, {
 				timeoutMs,
 				onAssignedId,
-				timeoutError: () => {
-					const diagnostics = formatKiroDiagnostics(diagnosticTail());
-					const detail = diagnostics.length > 0 ? ` — ${diagnostics}` : "";
-					return new Error(
-						`Kiro ACP ${method} timed out after ${timeoutMs}ms${detail}`,
-					);
-				},
+				...(timeoutMs === null
+					? {}
+					: {
+							timeoutError: () => {
+								const diagnostics = formatKiroDiagnostics(diagnosticTail());
+								const detail =
+									diagnostics.length > 0 ? ` — ${diagnostics}` : "";
+								return new Error(
+									`Kiro ACP ${method} timed out after ${timeoutMs}ms${detail}`,
+								);
+							},
+						}),
 			});
 
 		const notify = (method: string, params: unknown): void => {
@@ -640,7 +645,7 @@ export const startKiroSession = (
 									...(modelId !== undefined ? { model: modelId } : {}),
 								},
 							},
-							5 * 60_000,
+							null,
 							(id) => {
 								currentPromptRpcId = id;
 							},


### PR DESCRIPTION
## Summary
- allow ACP requests to opt out of automatic deadlines with timeoutMs: null
- remove the five-minute session/prompt deadline for Grok, Gemini, and Kiro
- preserve finite handshake/configuration timeouts, interruption, and transport failure handling

## Testing
- ACP unit tests: 10 passed
- Agent unit tests: 222 passed
- ACP and agent type checks passed
- Biome and git diff checks passed

## Notes
- No automatic prompt replay was added because ACP prompts may perform non-idempotent file and shell operations.
- The conversation reliability system suite could not start in the cloud sandbox because the Amazon Linux login profile exposes which as a shell function while the hermetic harness requires an absolute executable path.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8aa5b233-a48d-4dea-931d-809d94b7cb64)
