### PR TITLE
Improve agent task and queue lifecycle

### DIFF
--- a/apps/renderer/src/components/chat-lookups.tsx
+++ b/apps/renderer/src/components/chat-lookups.tsx
@@ -1,74 +1,96 @@
 import type { AgentItemId, Message, UserQuestionAnswer } from "@zuse/contracts";
 import { createContext, useContext } from "react";
+import {
+	type SubagentReference,
+	subagentDisplayName,
+} from "~/lib/subagent-metadata";
+import type { SubagentWaitResult } from "~/lib/subagent-wait";
 
-export interface ToolResultRecord {
-  readonly output: unknown;
-  readonly isError: boolean;
-}
+export type ToolResultRecord = SubagentWaitResult;
 
 export interface ChatLookups {
-  readonly resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
-  readonly answersByItemId: ReadonlyMap<
-    AgentItemId,
-    ReadonlyArray<UserQuestionAnswer>
-  >;
+	readonly resultsByItemId: ReadonlyMap<AgentItemId, ToolResultRecord>;
+	readonly answersByItemId: ReadonlyMap<
+		AgentItemId,
+		ReadonlyArray<UserQuestionAnswer>
+	>;
+	readonly subagentsByTaskId: ReadonlyMap<string, SubagentReference>;
 }
 
 const EMPTY_RESULTS = new Map<AgentItemId, ToolResultRecord>();
 const EMPTY_ANSWERS = new Map<AgentItemId, ReadonlyArray<UserQuestionAnswer>>();
+const EMPTY_SUBAGENTS = new Map<string, SubagentReference>();
 
 const ChatLookupsContext = createContext<ChatLookups>({
-  resultsByItemId: EMPTY_RESULTS,
-  answersByItemId: EMPTY_ANSWERS,
+	resultsByItemId: EMPTY_RESULTS,
+	answersByItemId: EMPTY_ANSWERS,
+	subagentsByTaskId: EMPTY_SUBAGENTS,
 });
 
 export function ChatLookupsProvider({
-  value,
-  children,
+	value,
+	children,
 }: {
-  readonly value: ChatLookups;
-  readonly children: React.ReactNode;
+	readonly value: ChatLookups;
+	readonly children: React.ReactNode;
 }) {
-  return (
-    <ChatLookupsContext.Provider value={value}>
-      {children}
-    </ChatLookupsContext.Provider>
-  );
+	return (
+		<ChatLookupsContext.Provider value={value}>
+			{children}
+		</ChatLookupsContext.Provider>
+	);
 }
 
 export const useChatLookups = () => useContext(ChatLookupsContext);
 
 export function deriveChatLookups(
-  messages: ReadonlyArray<Message>,
+	messages: ReadonlyArray<Message>,
 ): ChatLookups {
-  const seenUseIds = new Set<AgentItemId>();
-  const resultsByItemId = new Map<AgentItemId, ToolResultRecord>();
-  const seenQuestionIds = new Set<AgentItemId>();
-  const answersByItemId = new Map<
-    AgentItemId,
-    ReadonlyArray<UserQuestionAnswer>
-  >();
+	const seenUseIds = new Set<AgentItemId>();
+	const resultsByItemId = new Map<AgentItemId, ToolResultRecord>();
+	const seenQuestionIds = new Set<AgentItemId>();
+	const answersByItemId = new Map<
+		AgentItemId,
+		ReadonlyArray<UserQuestionAnswer>
+	>();
+	const subagentsByTaskId = new Map<string, SubagentReference>();
 
-  for (const message of messages) {
-    if (message.content._tag === "tool_use") {
-      seenUseIds.add(message.content.itemId);
-    } else if (
-      message.content._tag === "tool_result" &&
-      seenUseIds.has(message.content.itemId)
-    ) {
-      resultsByItemId.set(message.content.itemId, {
-        output: message.content.output,
-        isError: message.content.isError,
-      });
-    } else if (message.content._tag === "user_question") {
-      seenQuestionIds.add(message.content.itemId);
-    } else if (
-      message.content._tag === "user_question_answer" &&
-      seenQuestionIds.has(message.content.itemId)
-    ) {
-      answersByItemId.set(message.content.itemId, message.content.answers);
-    }
-  }
+	for (const message of messages) {
+		if (message.content._tag === "tool_use") {
+			seenUseIds.add(message.content.itemId);
+			if (
+				(message.content.tool === "Agent" || message.content.tool === "Task") &&
+				message.content.input !== null &&
+				typeof message.content.input === "object"
+			) {
+				const input = message.content.input as Record<string, unknown>;
+				const taskId =
+					message.content.subagent?.childSessionId ??
+					(typeof input.task_id === "string" ? input.task_id : undefined);
+				if (taskId !== undefined) {
+					subagentsByTaskId.set(taskId, {
+						agentName: subagentDisplayName(input),
+					});
+				}
+			}
+		} else if (
+			message.content._tag === "tool_result" &&
+			seenUseIds.has(message.content.itemId)
+		) {
+			resultsByItemId.set(message.content.itemId, {
+				output: message.content.output,
+				isError: message.content.isError,
+				completedAt: message.createdAt,
+			});
+		} else if (message.content._tag === "user_question") {
+			seenQuestionIds.add(message.content.itemId);
+		} else if (
+			message.content._tag === "user_question_answer" &&
+			seenQuestionIds.has(message.content.itemId)
+		) {
+			answersByItemId.set(message.content.itemId, message.content.answers);
+		}
+	}
 
-  return { resultsByItemId, answersByItemId };
+	return { resultsByItemId, answersByItemId, subagentsByTaskId };
 }

--- a/apps/renderer/src/components/composer/queue-chip.tsx
+++ b/apps/renderer/src/components/composer/queue-chip.tsx
@@ -1,8 +1,8 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import {
+	ArrowTurnDownIcon,
 	Chat01Icon,
-	CornerDownRightIcon,
 	Delete02Icon,
 	DragDropVerticalIcon,
 	MoreHorizontalIcon,
@@ -126,27 +126,23 @@ export function QueueChip({
 									)}
 									aria-label={
 										running
-											? "Run queued message next"
+											? "Steer to queued message"
 											: "Send queued message now"
 									}
 								>
 									<HugeiconsIcon
-										icon={CornerDownRightIcon}
+										icon={ArrowTurnDownIcon}
 										className="size-3.5"
 									/>
 									<span className="text-[11px]">
-										{runningNow
-											? "Starting…"
-											: running
-												? "Run next"
-												: "Send now"}
+										{runningNow ? "Starting…" : running ? "Steer" : "Send now"}
 									</span>
 								</button>
 							}
 						/>
 						<TooltipPopup>
 							{running
-								? "Stop the current turn and run this next"
+								? "Steer the agent to this message next"
 								: "Send this message now"}
 						</TooltipPopup>
 					</Tooltip>
@@ -165,6 +161,21 @@ export function QueueChip({
 						/>
 						<TooltipPopup>Edit</TooltipPopup>
 					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger
+							render={
+								<button
+									type="button"
+									onClick={() => drop(sessionId, item.id)}
+									className={cn(trayPillActionClass, "hover:text-destructive")}
+									aria-label="Remove queued message"
+								>
+									<HugeiconsIcon icon={Delete02Icon} className="size-3.5" />
+								</button>
+							}
+						/>
+						<TooltipPopup>Remove</TooltipPopup>
+					</Tooltip>
 					<Menu>
 						<MenuTrigger
 							render={
@@ -181,10 +192,6 @@ export function QueueChip({
 							}
 						/>
 						<MenuPopup align="end" sideOffset={4}>
-							<MenuItem onClick={() => void runNext()} disabled={runningNow}>
-								<HugeiconsIcon icon={CornerDownRightIcon} />
-								{running ? "Run next" : "Send now"}
-							</MenuItem>
 							<MenuItem
 								onClick={() => onMove(index, index - 1)}
 								disabled={index === 0}
@@ -198,10 +205,6 @@ export function QueueChip({
 							>
 								<ChevronDown />
 								Move down
-							</MenuItem>
-							<MenuItem onClick={() => drop(sessionId, item.id)}>
-								<HugeiconsIcon icon={Delete02Icon} />
-								Remove from queue
 							</MenuItem>
 						</MenuPopup>
 					</Menu>

--- a/apps/renderer/src/components/composer/queue-chip.tsx
+++ b/apps/renderer/src/components/composer/queue-chip.tsx
@@ -1,5 +1,4 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronDown, ChevronUp } from "lucide-react";
 import {
 	ArrowTurnDownIcon,
 	Chat01Icon,
@@ -8,7 +7,7 @@ import {
 	MoreHorizontalIcon,
 } from "@hugeicons-pro/core-solid-rounded";
 import type { QueuedMessage, SessionId } from "@zuse/contracts";
-import { Pencil } from "lucide-react";
+import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { useState } from "react";
 
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -1,5 +1,4 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import {
 	AlertCircleIcon,
 	Copy01Icon,
@@ -24,7 +23,11 @@ import type {
 	SessionId,
 	SkillRef,
 } from "@zuse/contracts";
-import { RefreshCw as RefreshIcon } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronRight,
+	RefreshCw as RefreshIcon,
+} from "lucide-react";
 import { memo, useEffect, useState } from "react";
 
 import { FileIcon } from "~/components/file-icon";

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -38,6 +38,7 @@ import {
 	effectiveSessionRuntimeState,
 	isSessionTurnActive,
 } from "~/lib/session-runtime-state";
+import { subagentTaskIdForBlockingWait } from "~/lib/subagent-wait";
 import { normalizeToolCallEnvelope } from "~/lib/tool-call-envelope";
 import {
 	openExternal,
@@ -88,6 +89,7 @@ import { MarkdownBody } from "./markdown-body.tsx";
 import {
 	ExitPlanModeRow,
 	OrchestrationThreadRow,
+	SubagentWaitRow,
 	ThinkingRow,
 	ToolRow,
 	UserInputRow,
@@ -218,7 +220,12 @@ function MessageRowImpl({
 				/>
 			);
 		case "tool_use":
-			return <ToolUseMessageRow content={message.content} />;
+			return (
+				<ToolUseMessageRow
+					content={message.content}
+					createdAt={message.createdAt}
+				/>
+			);
 		case "tool_result":
 			return <ToolResultMessageRow content={message.content} />;
 		case "user_question":
@@ -305,13 +312,29 @@ function ThinkingMessageRow({
 
 function ToolUseMessageRow({
 	content,
+	createdAt,
 }: {
 	content: MessageContent<"tool_use">;
+	createdAt: Date;
 }) {
-	const { resultsByItemId } = useChatLookups();
+	const { resultsByItemId, subagentsByTaskId } = useChatLookups();
 	const result = resultsByItemId.get(content.itemId);
 	if (content.tool === "ExitPlanMode") {
 		return <ExitPlanModeRow input={content.input} result={result} />;
+	}
+	if (content.tool === "TaskOutput") {
+		if (
+			subagentTaskIdForBlockingWait(content.input, subagentsByTaskId) !== null
+		) {
+			return (
+				<SubagentWaitRow
+					input={content.input}
+					result={result}
+					startedAt={createdAt}
+					subagentsByTaskId={subagentsByTaskId}
+				/>
+			);
+		}
 	}
 	const normalized = normalizeToolCallEnvelope(
 		content.tool,

--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -368,6 +368,9 @@ function ToolUseMessageRow({
 			tool={orch ?? normalized.tool}
 			input={normalized.input}
 			result={normalized.result}
+			presentation={
+				content.backgroundTask === undefined ? undefined : "background-task"
+			}
 		/>
 	);
 }

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -11,6 +11,7 @@ import {
 	Folder01Icon,
 	GlobeIcon,
 	PencilEdit01Icon,
+	PlayIcon,
 	Robot01Icon,
 	SearchIcon,
 	TerminalIcon,
@@ -690,12 +691,49 @@ const buildToolView = (
 	tool: string,
 	input: unknown,
 	result: ToolResult | undefined,
+	presentation?: "background-task",
 ): ToolView => {
 	const normalizedTool = normalizeToolName(tool);
 	const obj =
 		input !== null && typeof input === "object"
 			? (input as Record<string, unknown>)
 			: {};
+
+	if (presentation === "background-task") {
+		const cmd =
+			asString(obj.command) ?? asString(obj.cmd) ?? asString(obj.shell_command);
+		return {
+			icon: PlayIcon,
+			label: "Background Task",
+			detail:
+				cmd === null && result?.isError !== true ? undefined : (
+					<>
+						{cmd === null ? null : (
+							<span className="truncate rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+								{cmd}
+							</span>
+						)}
+						{result?.isError === true ? (
+							<span className="text-[11px] text-destructive">failed</span>
+						) : null}
+					</>
+				),
+			fallbackBody:
+				cmd === null ? (
+					<PreBlock text={stringifyJson(input)} />
+				) : (
+					<TerminalBlock
+						command={cmd}
+						output={
+							result === undefined
+								? undefined
+								: toResultText(result.output) || "(no output)"
+						}
+						isError={result?.isError}
+					/>
+				),
+		};
+	}
 
 	switch (normalizedTool) {
 		case "Bash":
@@ -1750,12 +1788,14 @@ export function ToolRow({
 	tool,
 	input,
 	result,
+	presentation,
 }: {
 	tool: string;
 	input: unknown;
 	result?: ToolResult;
+	presentation?: "background-task";
 }) {
-	const view = buildToolView(tool, input, result);
+	const view = buildToolView(tool, input, result, presentation);
 	const pending = result === undefined;
 
 	const sections: React.ReactNode[] = [];

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -24,9 +24,18 @@ import {
 	type UserQuestion,
 	type UserQuestionAnswer,
 } from "@zuse/contracts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { displayPath } from "~/lib/display-path";
 import { parseOrchestrationResult } from "~/lib/orchestration-tools";
+import type { SubagentReference } from "~/lib/subagent-metadata";
+import {
+	deriveSubagentWaitView,
+	formatSubagentWaitDuration,
+	type SubagentWaitResult,
+	type SubagentWaitView,
+	subagentWaitAccessibleTiming,
+	subagentWaitLabel,
+} from "~/lib/subagent-wait";
 import { toolImageDataUrl, toolImageResult } from "~/lib/tool-image-result";
 import { cn } from "~/lib/utils";
 import { useChatsStore } from "~/store/chats";
@@ -132,6 +141,7 @@ export const iconForTool = (tool: string): IconHandle => {
 interface ToolResult {
 	readonly output: unknown;
 	readonly isError: boolean;
+	readonly completedAt?: Date;
 }
 
 const stringifyJson = (value: unknown): string => {
@@ -852,10 +862,7 @@ const buildToolView = (
 					) : edits.length > 0 ? (
 						<div className="space-y-px">
 							{edits.map((edit, i) => (
-								<EditDiff
-									key={i}
-									edit={edit as FileEdit}
-								/>
+								<EditDiff key={i} edit={edit as FileEdit} />
 							))}
 						</div>
 					) : (
@@ -1799,6 +1806,75 @@ export function ToolRow({
 			hasContent={sections.length > 0}
 			body={sections.length > 0 ? sections : null}
 		/>
+	);
+}
+
+export function SubagentWaitRow({
+	input,
+	result,
+	startedAt,
+	subagentsByTaskId,
+}: {
+	readonly input: unknown;
+	readonly result: SubagentWaitResult | undefined;
+	readonly startedAt: Date;
+	readonly subagentsByTaskId: ReadonlyMap<string, SubagentReference>;
+}) {
+	const [now, setNow] = useState(() => new Date());
+	useEffect(() => {
+		if (result !== undefined) return;
+		const timer = window.setInterval(() => setNow(new Date()), 1000);
+		return () => window.clearInterval(timer);
+	}, [result]);
+
+	const view = deriveSubagentWaitView({
+		input,
+		result,
+		startedAt,
+		now,
+		subagentsByTaskId,
+	});
+	if (view === null) return null;
+
+	const label = subagentWaitLabel(view.status);
+	const output = result === undefined ? "" : toResultText(result.output);
+	const hasContent = output.length > 0 || result?.isError === true;
+	const resultText =
+		output.length > 0 ? output : result?.isError ? "(No error details.)" : "";
+
+	return (
+		<ExpandableIconRow
+			icon={Robot01Icon}
+			label={label}
+			pending={view.status === "waiting"}
+			detail={<SubagentWaitDetail view={view} />}
+			hasContent={hasContent}
+			body={
+				hasContent ? (
+					<PreBlock text={resultText} isError={result?.isError} />
+				) : null
+			}
+		/>
+	);
+}
+
+function SubagentWaitDetail({ view }: { readonly view: SubagentWaitView }) {
+	return (
+		<>
+			<span className="sr-only">{subagentWaitAccessibleTiming(view)}</span>
+			<span className="truncate text-muted-foreground" title={view.agentName}>
+				{view.agentName}
+			</span>
+			<span
+				aria-hidden="true"
+				className="min-w-[7.5rem] shrink-0 text-right tabular-nums text-[11px] text-muted-foreground/70"
+			>
+				{view.status === "waiting" && view.timeoutMs > 0
+					? `${formatSubagentWaitDuration(view.timeoutMs)} max · `
+					: null}
+				{formatSubagentWaitDuration(view.elapsedMs)}
+			</span>
+		</>
 	);
 }
 

--- a/apps/renderer/src/components/tool-row.tsx
+++ b/apps/renderer/src/components/tool-row.tsx
@@ -1,5 +1,4 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import {
 	Brain01Icon,
 	BrowserIcon,
@@ -25,6 +24,7 @@ import {
 	type UserQuestion,
 	type UserQuestionAnswer,
 } from "@zuse/contracts";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 import { displayPath } from "~/lib/display-path";
 import { parseOrchestrationResult } from "~/lib/orchestration-tools";

--- a/apps/renderer/src/lib/group-messages.ts
+++ b/apps/renderer/src/lib/group-messages.ts
@@ -1,58 +1,59 @@
 import type { AgentItemId, Message } from "@zuse/contracts";
+import { subagentDisplayName } from "./subagent-metadata.ts";
 
 export type RenderGroup =
-  | { readonly kind: "single"; readonly message: Message }
-  | {
-      readonly kind: "subagent";
-      readonly parent: Message;
-      readonly parentItemId: AgentItemId;
-      readonly agentName: string;
-      readonly prompt: string;
-      readonly modelRequested: string | undefined;
-      readonly childSessionId: string | undefined;
-      readonly presentation: "inline" | "detached";
-      readonly children: ReadonlyArray<Message>;
-      readonly summary: {
-        readonly text: string;
-        readonly turns: number;
-        readonly durationMs: number;
-        readonly model: string;
-        readonly isError: boolean;
-      } | null;
-    };
+	| { readonly kind: "single"; readonly message: Message }
+	| {
+			readonly kind: "subagent";
+			readonly parent: Message;
+			readonly parentItemId: AgentItemId;
+			readonly agentName: string;
+			readonly prompt: string;
+			readonly modelRequested: string | undefined;
+			readonly childSessionId: string | undefined;
+			readonly presentation: "inline" | "detached";
+			readonly children: ReadonlyArray<Message>;
+			readonly summary: {
+				readonly text: string;
+				readonly turns: number;
+				readonly durationMs: number;
+				readonly model: string;
+				readonly isError: boolean;
+			} | null;
+	  };
 
 export type DetachedSubagentGroup = Extract<
-  RenderGroup,
-  { readonly kind: "subagent" }
+	RenderGroup,
+	{ readonly kind: "subagent" }
 > & {
-  readonly childSessionId: string;
+	readonly childSessionId: string;
 };
 
 /** Detached subagents in transcript order, shared by the pane and shortcuts. */
 export const detachedSubagentGroups = (
-  messages: ReadonlyArray<Message>,
+	messages: ReadonlyArray<Message>,
 ): DetachedSubagentGroup[] =>
-  groupMessages(messages).flatMap((group) =>
-    group.kind === "subagent" &&
-    group.presentation === "detached" &&
-    group.childSessionId !== undefined
-      ? [{ ...group, childSessionId: group.childSessionId }]
-      : [],
-  );
+	groupMessages(messages).flatMap((group) =>
+		group.kind === "subagent" &&
+		group.presentation === "detached" &&
+		group.childSessionId !== undefined
+			? [{ ...group, childSessionId: group.childSessionId }]
+			: [],
+	);
 
 export const isAgentToolUse = (m: Message): boolean =>
-  (() => {
-    if (
-      m.content._tag !== "tool_use" ||
-      (m.content.tool !== "Agent" && m.content.tool !== "Task") ||
-      m.content.input === null ||
-      typeof m.content.input !== "object"
-    ) {
-      return false;
-    }
-    const input = m.content.input as Record<string, unknown>;
-    return typeof input.prompt === "string";
-  })();
+	(() => {
+		if (
+			m.content._tag !== "tool_use" ||
+			(m.content.tool !== "Agent" && m.content.tool !== "Task") ||
+			m.content.input === null ||
+			typeof m.content.input !== "object"
+		) {
+			return false;
+		}
+		const input = m.content.input as Record<string, unknown>;
+		return typeof input.prompt === "string";
+	})();
 
 /**
  * Walk the message log once and produce a flat render order where each
@@ -64,105 +65,114 @@ export const isAgentToolUse = (m: Message): boolean =>
  * rows feed the cost footer and never render in the timeline.
  */
 export function groupMessages(
-  messages: ReadonlyArray<Message>,
+	messages: ReadonlyArray<Message>,
 ): ReadonlyArray<RenderGroup> {
-  const out: RenderGroup[] = [];
+	const out: RenderGroup[] = [];
 
-  const childrenByParent = new Map<AgentItemId, Message[]>();
-  const summariesByItemId = new Map<AgentItemId, Message>();
-  const completedCompactionItemIds = new Set<AgentItemId>();
-  for (const m of messages) {
-    const c = m.content;
-    if (c._tag === "subagent_summary") {
-      summariesByItemId.set(c.itemId, m);
-      continue;
-    }
-    if (
-      c._tag === "context_compaction" &&
-      (c.status ?? "completed") === "completed"
-    ) {
-      completedCompactionItemIds.add(c.itemId);
-    }
-    if ("parentItemId" in c && c.parentItemId !== undefined) {
-      const list = childrenByParent.get(c.parentItemId) ?? [];
-      list.push(m);
-      childrenByParent.set(c.parentItemId, list);
-    }
-  }
+	const childrenByParent = new Map<AgentItemId, Message[]>();
+	const summariesByItemId = new Map<AgentItemId, Message>();
+	const canonicalAgentByItemId = new Map<
+		AgentItemId,
+		{ readonly parent: Message; readonly enriched: Message }
+	>();
+	const completedCompactionItemIds = new Set<AgentItemId>();
+	for (const m of messages) {
+		const c = m.content;
+		if (isAgentToolUse(m) && c._tag === "tool_use") {
+			const existing = canonicalAgentByItemId.get(c.itemId);
+			canonicalAgentByItemId.set(c.itemId, {
+				parent: existing?.parent ?? m,
+				enriched:
+					c.subagent !== undefined || existing === undefined
+						? m
+						: existing.enriched,
+			});
+		}
+		if (c._tag === "subagent_summary") {
+			summariesByItemId.set(c.itemId, m);
+			continue;
+		}
+		if (
+			c._tag === "context_compaction" &&
+			(c.status ?? "completed") === "completed"
+		) {
+			completedCompactionItemIds.add(c.itemId);
+		}
+		if ("parentItemId" in c && c.parentItemId !== undefined) {
+			const list = childrenByParent.get(c.parentItemId) ?? [];
+			list.push(m);
+			childrenByParent.set(c.parentItemId, list);
+		}
+	}
 
-  const agentItemIds = new Set<AgentItemId>();
-  for (const m of messages) {
-    if (isAgentToolUse(m) && m.content._tag === "tool_use") {
-      agentItemIds.add(m.content.itemId);
-    }
-  }
+	const agentItemIds = new Set<AgentItemId>();
+	for (const m of messages) {
+		if (isAgentToolUse(m) && m.content._tag === "tool_use") {
+			agentItemIds.add(m.content.itemId);
+		}
+	}
 
-  for (const m of messages) {
-    const c = m.content;
-    if (c._tag === "usage") continue;
-    if (c._tag === "subagent_summary") continue;
-    if (
-      c._tag === "context_compaction" &&
-      c.status === "in_progress" &&
-      completedCompactionItemIds.has(c.itemId)
-    ) {
-      continue;
-    }
-    if ("parentItemId" in c && c.parentItemId !== undefined) continue;
-    if (c._tag === "tool_result" && agentItemIds.has(c.itemId)) continue;
-    if (isAgentToolUse(m) && c._tag === "tool_use") {
-      const inputObj =
-        c.input !== null && typeof c.input === "object"
-          ? (c.input as Record<string, unknown>)
-          : {};
-      const description =
-        typeof inputObj.description === "string" &&
-        inputObj.description.trim().length > 0 &&
-        inputObj.description !== "Task"
-          ? (inputObj.description as string)
-          : undefined;
-      const subagentType =
-        typeof inputObj.subagent_type === "string"
-          ? (inputObj.subagent_type as string)
-          : undefined;
-      const agentName = description ?? subagentType ?? "agent";
-      const modelRequested =
-        typeof inputObj.model === "string"
-          ? (inputObj.model as string)
-          : undefined;
-      const prompt =
-        typeof inputObj.prompt === "string"
-          ? (inputObj.prompt as string)
-          : typeof inputObj.description === "string"
-            ? (inputObj.description as string)
-            : "";
-      const summaryRow = summariesByItemId.get(c.itemId);
-      const summary =
-        summaryRow !== undefined &&
-        summaryRow.content._tag === "subagent_summary"
-          ? {
-              text: summaryRow.content.summary,
-              turns: summaryRow.content.turns,
-              durationMs: summaryRow.content.durationMs,
-              model: summaryRow.content.model,
-              isError: summaryRow.content.isError,
-            }
-          : null;
-      out.push({
-        kind: "subagent",
-        parent: m,
-        parentItemId: c.itemId,
-        agentName,
-        prompt,
-        modelRequested,
-        childSessionId: c.subagent?.childSessionId,
-        presentation: c.subagent?.presentation ?? "inline",
-        children: childrenByParent.get(c.itemId) ?? [],
-        summary,
-      });
-      continue;
-    }
-    out.push({ kind: "single", message: m });
-  }
-  return out;
+	for (const m of messages) {
+		const c = m.content;
+		if (c._tag === "usage") continue;
+		if (c._tag === "subagent_summary") continue;
+		if (
+			c._tag === "context_compaction" &&
+			c.status === "in_progress" &&
+			completedCompactionItemIds.has(c.itemId)
+		) {
+			continue;
+		}
+		if ("parentItemId" in c && c.parentItemId !== undefined) continue;
+		if (c._tag === "tool_result" && agentItemIds.has(c.itemId)) continue;
+		if (isAgentToolUse(m) && c._tag === "tool_use") {
+			const canonical = canonicalAgentByItemId.get(c.itemId);
+			if (canonical === undefined || canonical.parent.id !== m.id) continue;
+			const enrichedContent = canonical.enriched.content;
+			if (enrichedContent._tag !== "tool_use") continue;
+			const inputObj =
+				enrichedContent.input !== null &&
+				typeof enrichedContent.input === "object"
+					? (enrichedContent.input as Record<string, unknown>)
+					: {};
+			const agentName = subagentDisplayName(inputObj);
+			const modelRequested =
+				typeof inputObj.model === "string"
+					? (inputObj.model as string)
+					: undefined;
+			const prompt =
+				typeof inputObj.prompt === "string"
+					? (inputObj.prompt as string)
+					: typeof inputObj.description === "string"
+						? (inputObj.description as string)
+						: "";
+			const summaryRow = summariesByItemId.get(enrichedContent.itemId);
+			const summary =
+				summaryRow !== undefined &&
+				summaryRow.content._tag === "subagent_summary"
+					? {
+							text: summaryRow.content.summary,
+							turns: summaryRow.content.turns,
+							durationMs: summaryRow.content.durationMs,
+							model: summaryRow.content.model,
+							isError: summaryRow.content.isError,
+						}
+					: null;
+			out.push({
+				kind: "subagent",
+				parent: canonical.parent,
+				parentItemId: enrichedContent.itemId,
+				agentName,
+				prompt,
+				modelRequested,
+				childSessionId: enrichedContent.subagent?.childSessionId,
+				presentation: enrichedContent.subagent?.presentation ?? "inline",
+				children: childrenByParent.get(enrichedContent.itemId) ?? [],
+				summary,
+			});
+			continue;
+		}
+		out.push({ kind: "single", message: m });
+	}
+	return out;
 }

--- a/apps/renderer/src/lib/subagent-metadata.ts
+++ b/apps/renderer/src/lib/subagent-metadata.ts
@@ -1,0 +1,20 @@
+export interface SubagentReference {
+	readonly agentName: string;
+}
+
+export function subagentDisplayName(input: unknown): string {
+	if (input === null || typeof input !== "object") return "agent";
+	const record = input as Record<string, unknown>;
+	const description =
+		typeof record.description === "string" &&
+		record.description.trim().length > 0 &&
+		record.description !== "Task"
+			? record.description.trim()
+			: undefined;
+	const subagentType =
+		typeof record.subagent_type === "string" &&
+		record.subagent_type.trim().length > 0
+			? record.subagent_type.trim()
+			: undefined;
+	return description ?? subagentType ?? "agent";
+}

--- a/apps/renderer/src/lib/subagent-wait.ts
+++ b/apps/renderer/src/lib/subagent-wait.ts
@@ -1,0 +1,81 @@
+import type { SubagentReference } from "./subagent-metadata.ts";
+
+export interface SubagentWaitResult {
+	readonly output: unknown;
+	readonly isError: boolean;
+	readonly completedAt: Date;
+}
+
+export function subagentTaskIdForBlockingWait(
+	input: unknown,
+	subagentsByTaskId: ReadonlyMap<string, SubagentReference>,
+): string | null {
+	if (input === null || typeof input !== "object") return null;
+	const record = input as Record<string, unknown>;
+	if (record.block !== true || typeof record.task_id !== "string") return null;
+	return subagentsByTaskId.has(record.task_id) ? record.task_id : null;
+}
+
+export interface SubagentWaitView {
+	readonly agentName: string;
+	readonly status: "waiting" | "finished" | "error";
+	readonly elapsedMs: number;
+	readonly timeoutMs: number;
+}
+
+export function formatSubagentWaitDuration(ms: number): string {
+	if (ms < 10_000) return `${(ms / 1000).toFixed(1)}s`;
+	if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+	const minutes = Math.floor(ms / 60_000);
+	const seconds = Math.round((ms - minutes * 60_000) / 1000);
+	return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+}
+
+export function subagentWaitLabel(status: SubagentWaitView["status"]): string {
+	if (status === "waiting") return "Waiting for subagent";
+	if (status === "error") return "Couldn’t wait for subagent";
+	return "Finished waiting for subagent";
+}
+
+export function subagentWaitAccessibleTiming(view: SubagentWaitView): string {
+	if (view.status === "waiting") {
+		return view.timeoutMs > 0
+			? `Maximum wait ${formatSubagentWaitDuration(view.timeoutMs)}.`
+			: "Waiting until the subagent responds.";
+	}
+	return `Wait duration ${formatSubagentWaitDuration(view.elapsedMs)}.`;
+}
+
+export function deriveSubagentWaitView({
+	input,
+	result,
+	startedAt,
+	now,
+	subagentsByTaskId,
+}: {
+	readonly input: unknown;
+	readonly result: SubagentWaitResult | undefined;
+	readonly startedAt: Date;
+	readonly now: Date;
+	readonly subagentsByTaskId: ReadonlyMap<string, SubagentReference>;
+}): SubagentWaitView | null {
+	const taskId = subagentTaskIdForBlockingWait(input, subagentsByTaskId);
+	if (taskId === null || input === null || typeof input !== "object")
+		return null;
+	const record = input as Record<string, unknown>;
+	const subagent = subagentsByTaskId.get(taskId);
+	if (subagent === undefined) return null;
+
+	const timeoutMs =
+		typeof record.timeout === "number" && Number.isFinite(record.timeout)
+			? Math.max(0, record.timeout)
+			: 0;
+	const endedAt = result?.completedAt ?? now;
+	return {
+		agentName: subagent.agentName,
+		status:
+			result === undefined ? "waiting" : result.isError ? "error" : "finished",
+		elapsedMs: Math.max(0, endedAt.getTime() - startedAt.getTime()),
+		timeoutMs,
+	};
+}

--- a/apps/renderer/test/unit/subagent-wait.test.ts
+++ b/apps/renderer/test/unit/subagent-wait.test.ts
@@ -1,0 +1,341 @@
+import type { AgentItemId, Message, SessionId } from "@zuse/contracts";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { deriveChatLookups } from "../../src/components/chat-lookups.tsx";
+import { SubagentWaitRow } from "../../src/components/tool-row.tsx";
+import { groupMessages } from "../../src/lib/group-messages.ts";
+import {
+	deriveSubagentWaitView,
+	formatSubagentWaitDuration,
+	subagentWaitAccessibleTiming,
+} from "../../src/lib/subagent-wait.ts";
+
+const sessionId = "session-subagent-wait" as SessionId;
+
+afterEach(() => vi.useRealTimers());
+
+function message(
+	id: string,
+	content: Message["content"],
+	createdAt: string,
+): Message {
+	return {
+		id,
+		sessionId,
+		role: "assistant",
+		content,
+		createdAt: new Date(createdAt),
+	} as Message;
+}
+
+describe("subagent waiting", () => {
+	it("links a blocking task wait to its named subagent", () => {
+		const messages = [
+			message(
+				"agent-started",
+				{
+					_tag: "tool_use",
+					itemId: "agent-tool-1" as AgentItemId,
+					tool: "Agent",
+					input: {
+						description: "Design revamp implementation plan",
+						prompt: "Design the implementation",
+						subagent_type: "Plan",
+						task_id: "task-1",
+					},
+					subagent: {
+						childSessionId: "task-1",
+						presentation: "detached",
+					},
+				},
+				"2026-08-09T10:00:00.000Z",
+			),
+			message(
+				"wait",
+				{
+					_tag: "tool_use",
+					itemId: "wait-tool-1" as AgentItemId,
+					tool: "TaskOutput",
+					input: { task_id: "task-1", block: true, timeout: 180_000 },
+				},
+				"2026-08-09T10:00:01.000Z",
+			),
+		];
+
+		const lookups = deriveChatLookups(messages);
+		expect(lookups.subagentsByTaskId.get("task-1")).toEqual({
+			agentName: "Design revamp implementation plan",
+		});
+
+		expect(
+			deriveSubagentWaitView({
+				input:
+					messages[1]?.content._tag === "tool_use"
+						? messages[1].content.input
+						: null,
+				result: undefined,
+				startedAt: messages[1]?.createdAt ?? new Date(0),
+				now: new Date("2026-08-09T10:00:02.900Z"),
+				subagentsByTaskId: lookups.subagentsByTaskId,
+			}),
+		).toEqual({
+			agentName: "Design revamp implementation plan",
+			status: "waiting",
+			elapsedMs: 1_900,
+			timeoutMs: 180_000,
+		});
+	});
+
+	it("links concurrent waits to their own subagents", () => {
+		const first = message(
+			"first-agent",
+			{
+				_tag: "tool_use",
+				itemId: "agent-tool-1" as AgentItemId,
+				tool: "Agent",
+				input: {
+					description: "Review API design",
+					prompt: "Review the API",
+					task_id: "task-1",
+				},
+				subagent: {
+					childSessionId: "task-1",
+					presentation: "detached",
+				},
+			},
+			"2026-08-09T10:00:00.000Z",
+		);
+		const second = message(
+			"second-agent",
+			{
+				_tag: "tool_use",
+				itemId: "agent-tool-2" as AgentItemId,
+				tool: "Agent",
+				input: {
+					description: "Check test coverage",
+					prompt: "Review the tests",
+					task_id: "task-2",
+				},
+				subagent: {
+					childSessionId: "task-2",
+					presentation: "detached",
+				},
+			},
+			"2026-08-09T10:00:00.100Z",
+		);
+
+		const references = deriveChatLookups([first, second]).subagentsByTaskId;
+		const startedAt = new Date("2026-08-09T10:00:01.000Z");
+		const now = new Date("2026-08-09T10:00:02.000Z");
+		expect(
+			deriveSubagentWaitView({
+				input: { task_id: "task-1", block: true, timeout: 10_000 },
+				result: undefined,
+				startedAt,
+				now,
+				subagentsByTaskId: references,
+			})?.agentName,
+		).toBe("Review API design");
+		expect(
+			deriveSubagentWaitView({
+				input: { task_id: "task-2", block: true, timeout: 10_000 },
+				result: undefined,
+				startedAt,
+				now,
+				subagentsByTaskId: references,
+			})?.agentName,
+		).toBe("Check test coverage");
+	});
+
+	it("keeps a resolved wait without claiming the subagent completed", () => {
+		const view = deriveSubagentWaitView({
+			input: { task_id: "task-1", block: true, timeout: 180_000 },
+			result: {
+				output: "Task is still running after the wait timed out",
+				isError: false,
+				completedAt: new Date("2026-08-09T10:00:04.250Z"),
+			},
+			startedAt: new Date("2026-08-09T10:00:01.000Z"),
+			now: new Date("2026-08-09T10:00:10.000Z"),
+			subagentsByTaskId: new Map([
+				["task-1", { agentName: "Plan implementation" }],
+			]),
+		});
+
+		expect(view).toEqual({
+			agentName: "Plan implementation",
+			status: "finished",
+			elapsedMs: 3_250,
+			timeoutMs: 180_000,
+		});
+	});
+
+	it("marks failed waits and freezes their elapsed duration", () => {
+		expect(
+			deriveSubagentWaitView({
+				input: { task_id: "task-1", block: true, timeout: 10_000 },
+				result: {
+					output: "Unable to read task output",
+					isError: true,
+					completedAt: new Date("2026-08-09T10:00:03.000Z"),
+				},
+				startedAt: new Date("2026-08-09T10:00:01.000Z"),
+				now: new Date("2026-08-09T10:01:00.000Z"),
+				subagentsByTaskId: new Map([
+					["task-1", { agentName: "Plan implementation" }],
+				]),
+			}),
+		).toMatchObject({ status: "error", elapsedMs: 2_000 });
+	});
+
+	it("leaves non-blocking task output on the generic tool path", () => {
+		expect(
+			deriveSubagentWaitView({
+				input: { task_id: "task-1", block: false, timeout: 1_000 },
+				result: undefined,
+				startedAt: new Date(0),
+				now: new Date(1_000),
+				subagentsByTaskId: new Map(),
+			}),
+		).toBeNull();
+	});
+
+	it("leaves an unknown task on the generic tool path", () => {
+		expect(
+			deriveSubagentWaitView({
+				input: { task_id: "missing", block: true, timeout: 1_000 },
+				result: undefined,
+				startedAt: new Date(0),
+				now: new Date(1_000),
+				subagentsByTaskId: new Map(),
+			}),
+		).toBeNull();
+	});
+
+	it("formats stable compact timing metadata", () => {
+		expect(formatSubagentWaitDuration(1_900)).toBe("1.9s");
+		expect(formatSubagentWaitDuration(180_000)).toBe("3m");
+		expect(formatSubagentWaitDuration(184_000)).toBe("3m 4s");
+	});
+
+	it("renders resolved and failed waits with accessible timing", () => {
+		const subagentsByTaskId = new Map([
+			["task-1", { agentName: "Plan implementation" }],
+		]);
+		const finished = renderToStaticMarkup(
+			createElement(SubagentWaitRow, {
+				input: { task_id: "task-1", block: true, timeout: 10_000 },
+				result: {
+					output: "Still running",
+					isError: false,
+					completedAt: new Date("2026-08-09T10:00:03.000Z"),
+				},
+				startedAt: new Date("2026-08-09T10:00:01.000Z"),
+				subagentsByTaskId,
+			}),
+		);
+		expect(finished).toContain("Finished waiting for subagent");
+		expect(finished).toContain("Wait duration 2.0s.");
+
+		const failed = renderToStaticMarkup(
+			createElement(SubagentWaitRow, {
+				input: { task_id: "task-1", block: true, timeout: 10_000 },
+				result: {
+					output: "",
+					isError: true,
+					completedAt: new Date("2026-08-09T10:00:03.000Z"),
+				},
+				startedAt: new Date("2026-08-09T10:00:01.000Z"),
+				subagentsByTaskId,
+			}),
+		);
+		expect(failed).toContain("Couldn’t wait for subagent");
+		expect(failed).toContain("cursor-pointer");
+	});
+
+	it("renders the active wait name, maximum, and current elapsed time", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-09T10:00:02.900Z"));
+		const active = renderToStaticMarkup(
+			createElement(SubagentWaitRow, {
+				input: { task_id: "task-1", block: true, timeout: 180_000 },
+				result: undefined,
+				startedAt: new Date("2026-08-09T10:00:01.000Z"),
+				subagentsByTaskId: new Map([
+					["task-1", { agentName: "Plan implementation" }],
+				]),
+			}),
+		);
+
+		expect(active).toContain("Waiting for subagent");
+		expect(active).toContain("Plan implementation");
+		expect(active).toContain("3m max · ");
+		expect(active).toContain("1.9s");
+		expect(active).toContain("Maximum wait 3m.");
+	});
+
+	it("keeps ticking elapsed time out of screen-reader announcements", () => {
+		const base = {
+			agentName: "Plan implementation",
+			status: "waiting" as const,
+			timeoutMs: 180_000,
+		};
+		expect(subagentWaitAccessibleTiming({ ...base, elapsedMs: 1_000 })).toBe(
+			"Maximum wait 3m.",
+		);
+		expect(subagentWaitAccessibleTiming({ ...base, elapsedMs: 9_000 })).toBe(
+			"Maximum wait 3m.",
+		);
+	});
+
+	it("renders one enriched subagent row for repeated lifecycle records", () => {
+		const itemId = "agent-tool-1" as AgentItemId;
+		const groups = groupMessages([
+			message(
+				"agent-request",
+				{
+					_tag: "tool_use",
+					itemId,
+					tool: "Agent",
+					input: {
+						prompt: "Design the implementation",
+						subagent_type: "Plan",
+						run_in_background: true,
+					},
+				},
+				"2026-08-09T10:00:00.000Z",
+			),
+			message(
+				"agent-started",
+				{
+					_tag: "tool_use",
+					itemId,
+					tool: "Agent",
+					input: {
+						description: "Design revamp implementation plan",
+						prompt: "Design the implementation",
+						subagent_type: "Plan",
+						run_in_background: true,
+						task_id: "task-1",
+					},
+					subagent: {
+						childSessionId: "task-1",
+						presentation: "detached",
+					},
+				},
+				"2026-08-09T10:00:00.100Z",
+			),
+		]);
+
+		expect(groups).toHaveLength(1);
+		expect(groups[0]).toMatchObject({
+			kind: "subagent",
+			parent: { id: "agent-request" },
+			agentName: "Design revamp implementation plan",
+			childSessionId: "task-1",
+			presentation: "detached",
+		});
+	});
+});

--- a/apps/server/src/conversation/core/conversation-message-mapping.ts
+++ b/apps/server/src/conversation/core/conversation-message-mapping.ts
@@ -189,6 +189,7 @@ export const eventToContent = (event: AgentEvent): MessageContent | null => {
 				tool: event.tool,
 				input: event.input,
 				parentItemId: event.parentItemId,
+				backgroundTask: event.backgroundTask,
 				subagent: event.subagent,
 			};
 		case "ToolResult":

--- a/apps/server/src/conversation/core/message-operations.ts
+++ b/apps/server/src/conversation/core/message-operations.ts
@@ -522,9 +522,12 @@ export const makeMessageOperations = Effect.fn("MessageOperations.make")(
 		const runStartupRecovery = <E>(catchUp: Effect.Effect<void, E>) =>
 			catchUp.pipe(
 				Effect.andThen(recoverStaleSessions),
-				Effect.catch((error) =>
+				// Queue entries are durable work. Reconcile them after session catch-up
+				// instead of relying on a process-local enqueue/settlement wake-up.
+				Effect.andThen(queueRuntime.reconcileReadyQueues),
+				Effect.catchCause((cause) =>
 					Effect.logError(
-						`[ConversationServices] startup recovery failed: ${String(error)}`,
+						`[ConversationServices] startup recovery failed: ${String(cause)}`,
 					),
 				),
 				Effect.ensuring(Deferred.succeed(startupRecoveryDone, undefined)),

--- a/apps/server/src/conversation/core/queue-service-runtime.ts
+++ b/apps/server/src/conversation/core/queue-service-runtime.ts
@@ -11,7 +11,7 @@ import {
 	type SessionNotFoundError,
 } from "@zuse/contracts";
 import type { SessionCommand } from "@zuse/domain/core/commands";
-import { Effect, type Scope, Semaphore } from "effect";
+import { Cause, Effect, Queue, type Scope, Semaphore } from "effect";
 import type { SqlClient } from "effect/unstable/sql";
 import type { QueueServiceShape } from "../services/conversation-services.ts";
 import { handoffToServiceScope } from "./service-scope.ts";
@@ -59,6 +59,8 @@ export interface QueueServiceRuntimeDeps {
 export interface QueueServiceRuntime {
 	readonly service: QueueServiceShape;
 	readonly flushAfterIdle: (sessionId: SessionId) => Effect.Effect<void>;
+	/** Reconcile durable ready work once startup catch-up has settled session state. */
+	readonly reconcileReadyQueues: Effect.Effect<void>;
 	readonly pauseAfterInterrupt: (sessionId: SessionId) => Effect.Effect<void>;
 	readonly shutdown: (sessionId: SessionId) => Effect.Effect<void>;
 }
@@ -88,6 +90,9 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 			resolveActiveTurn,
 		} = deps;
 		const flushLocks = new Map<SessionId, Semaphore.Semaphore>();
+		const drainRequests = yield* Queue.unbounded<SessionId>();
+		const retryAttempts = new Map<SessionId, number>();
+		const scheduledRetries = new Set<SessionId>();
 		const flushLock = (sessionId: SessionId): Semaphore.Semaphore => {
 			const existing = flushLocks.get(sessionId);
 			if (existing !== undefined) return existing;
@@ -171,7 +176,7 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 					if (existing[0] !== undefined) {
 						const item = queuedMessageFromRow(existing[0]);
 						if (item.ready && flush) {
-							yield* Effect.forkIn(requestFlush(sessionId), serviceScope);
+							yield* requestFlush(sessionId);
 						}
 						return item;
 					}
@@ -205,7 +210,7 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 				}
 				const item = queuedMessageFromRow(row);
 				if (item.ready && flush) {
-					yield* Effect.forkIn(requestFlush(sessionId), serviceScope);
+					yield* requestFlush(sessionId);
 				}
 				return item;
 			});
@@ -251,7 +256,7 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 					return yield* new QueuedMessageNotFoundError({ sessionId, queueId });
 				}
 				const item = queuedMessageFromRow(row);
-				yield* Effect.forkIn(requestFlush(sessionId), serviceScope);
+				yield* requestFlush(sessionId);
 				return item;
 			});
 
@@ -387,6 +392,8 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 
 		const flushHead = (sessionId: SessionId) =>
 			Effect.gen(function* () {
+				const session = yield* lookupSession(sessionId);
+				if (session.status === "error") return;
 				if (yield* isPaused(sessionId)) return;
 				const head = (yield* listRows(sessionId))[0];
 				if (head === undefined || !head.ready) return;
@@ -435,13 +442,51 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 			});
 
 		requestFlush = (sessionId) =>
-			lookupSession(sessionId).pipe(
-				Effect.andThen(resolveActiveTurn(sessionId)),
-				Effect.flatMap((activeTurnId) =>
-					activeTurnId === undefined ? flushAfterIdle(sessionId) : Effect.void,
+			Queue.offer(drainRequests, sessionId).pipe(Effect.asVoid);
+		const scheduleRetry = (sessionId: SessionId) =>
+			Effect.gen(function* () {
+				if (scheduledRetries.has(sessionId)) return;
+				const attempt = (retryAttempts.get(sessionId) ?? 0) + 1;
+				retryAttempts.set(sessionId, attempt);
+				scheduledRetries.add(sessionId);
+				const delayMs = Math.min(100 * 2 ** (attempt - 1), 10_000);
+				const retry = Effect.sleep(`${delayMs} millis`).pipe(
+					Effect.andThen(
+						Effect.sync(() => {
+							scheduledRetries.delete(sessionId);
+						}),
+					),
+					Effect.andThen(requestFlush(sessionId)),
+				);
+				yield* Effect.forkIn(retry, serviceScope);
+			});
+		const runAutomaticDrain = (sessionId: SessionId) =>
+			flushAfterIdle(sessionId).pipe(
+				Effect.tap(() =>
+					Effect.sync(() => {
+						retryAttempts.delete(sessionId);
+					}),
 				),
-				Effect.catch(() => Effect.void),
+				Effect.catchTag("SessionNotFoundError", () =>
+					Effect.sync(() => {
+						retryAttempts.delete(sessionId);
+						scheduledRetries.delete(sessionId);
+					}),
+				),
+				Effect.catchCause((cause) =>
+					Cause.hasInterruptsOnly(cause)
+						? Effect.failCause(cause)
+						: Effect.logError(
+								`[ConversationQueue] drain failed for ${sessionId}: ${String(cause)}`,
+							).pipe(Effect.andThen(scheduleRetry(sessionId))),
+				),
 			);
+		const drainWorker = Effect.forever(
+			Queue.take(drainRequests).pipe(Effect.flatMap(runAutomaticDrain)),
+		);
+		for (let index = 0; index < 4; index += 1) {
+			yield* Effect.forkIn(drainWorker, serviceScope);
+		}
 
 		const pauseAfterInterrupt = (sessionId: SessionId) =>
 			Effect.gen(function* () {
@@ -451,6 +496,23 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 			});
 
 		const shutdown = (_sessionId: SessionId) => Effect.void;
+		const reconcileReadyQueues = Effect.gen(function* () {
+			const sessions = yield* sql<{ readonly session_id: string }>`
+				SELECT DISTINCT q.session_id
+				FROM queued_messages q
+				INNER JOIN sessions s ON s.id = q.session_id
+				WHERE q.ready = 1
+					AND s.queue_paused = 0
+					AND s.archived_at IS NULL
+					AND s.status <> 'error'
+				ORDER BY q.session_id
+			`.pipe(Effect.orDie);
+			yield* Effect.forEach(
+				sessions,
+				(row) => runAutomaticDrain(SessionId.make(row.session_id)),
+				{ discard: true },
+			);
+		});
 
 		// One-time-compatible import: legacy rows become aggregate events before
 		// runtime mutations begin. The decider makes this restart-idempotent and
@@ -489,8 +551,8 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 
 		return {
 			service,
-			flushAfterIdle: (sessionId) =>
-				flushAfterIdle(sessionId).pipe(Effect.catch(() => Effect.void)),
+			flushAfterIdle: requestFlush,
+			reconcileReadyQueues,
 			pauseAfterInterrupt,
 			shutdown,
 		} satisfies QueueServiceRuntime;

--- a/apps/server/src/conversation/core/queue-service-runtime.ts
+++ b/apps/server/src/conversation/core/queue-service-runtime.ts
@@ -14,6 +14,7 @@ import type { SessionCommand } from "@zuse/domain/core/commands";
 import { Effect, type Scope, Semaphore } from "effect";
 import type { SqlClient } from "effect/unstable/sql";
 import type { QueueServiceShape } from "../services/conversation-services.ts";
+import { handoffToServiceScope } from "./service-scope.ts";
 
 interface QueuedMessageRow {
 	readonly id: string;
@@ -366,18 +367,21 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 						yield* runQueuedMessageWhileIdle(sessionId, queueId);
 						return;
 					}
-					yield* dispatchSessionCommandWithId(
-						sessionId,
-						`queue-run-next:${queueId}`,
-						{
-							_tag: "SteerQueuedTurn",
-							expectedTurnId: resolvedTurnId,
-							queueId,
-							successorTurnId: AgentTurnId.make(`turn_queued_${queueId}`),
-							requestedAt: Date.now(),
-						},
+					yield* handoffToServiceScope(
+						dispatchSessionCommandWithId(
+							sessionId,
+							`queue-run-next:${queueId}`,
+							{
+								_tag: "SteerQueuedTurn",
+								expectedTurnId: resolvedTurnId,
+								queueId,
+								successorTurnId: AgentTurnId.make(`turn_queued_${queueId}`),
+								requestedAt: Date.now(),
+							},
+						),
+						runSessionReactors,
+						serviceScope,
 					);
-					yield* runSessionReactors;
 				}),
 			);
 

--- a/apps/server/src/conversation/core/queue-service-runtime.ts
+++ b/apps/server/src/conversation/core/queue-service-runtime.ts
@@ -385,20 +385,36 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 				}),
 			);
 
+		const flushHead = (sessionId: SessionId) =>
+			Effect.gen(function* () {
+				if (yield* isPaused(sessionId)) return;
+				const head = (yield* listRows(sessionId))[0];
+				if (head === undefined || !head.ready) return;
+				const item = yield* claim(sessionId, head.id);
+				if (item !== null) yield* sendClaimed(item);
+			});
+
 		const flushQueuedMessages: QueueServiceShape["flushQueuedMessages"] = (
 			sessionId,
 		) =>
 			flushLock(sessionId).withPermits(1)(
 				Effect.gen(function* () {
-					yield* lookupSession(sessionId);
+					// Explicit flush preserves recovery of an atomically restored item.
 					const session = yield* lookupSession(sessionId);
 					if (session.status === "running" || session.status === "booting")
 						return;
-					if (yield* isPaused(sessionId)) return;
-					const head = (yield* listRows(sessionId))[0];
-					if (head === undefined || !head.ready) return;
-					const item = yield* claim(sessionId, head.id);
-					if (item !== null) yield* sendClaimed(item);
+					yield* flushHead(sessionId);
+				}),
+			);
+
+		const flushAfterIdle = (sessionId: SessionId) =>
+			flushLock(sessionId).withPermits(1)(
+				Effect.gen(function* () {
+					yield* lookupSession(sessionId);
+					// Automatic flushes use turn events as their authority. The session
+					// status projection can lag settlement in either direction.
+					if ((yield* resolveActiveTurn(sessionId)) !== undefined) return;
+					yield* flushHead(sessionId);
 				}),
 			);
 
@@ -420,10 +436,9 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 
 		requestFlush = (sessionId) =>
 			lookupSession(sessionId).pipe(
-				Effect.flatMap((session) =>
-					session.status === "idle"
-						? flushQueuedMessages(sessionId)
-						: Effect.void,
+				Effect.andThen(resolveActiveTurn(sessionId)),
+				Effect.flatMap((activeTurnId) =>
+					activeTurnId === undefined ? flushAfterIdle(sessionId) : Effect.void,
 				),
 				Effect.catch(() => Effect.void),
 			);
@@ -475,7 +490,7 @@ export const makeQueueServiceRuntime = Effect.fn("QueueServiceRuntime.make")(
 		return {
 			service,
 			flushAfterIdle: (sessionId) =>
-				flushQueuedMessages(sessionId).pipe(Effect.catch(() => Effect.void)),
+				flushAfterIdle(sessionId).pipe(Effect.catch(() => Effect.void)),
 			pauseAfterInterrupt,
 			shutdown,
 		} satisfies QueueServiceRuntime;

--- a/apps/server/src/conversation/core/service-scope.ts
+++ b/apps/server/src/conversation/core/service-scope.ts
@@ -1,0 +1,17 @@
+import { Effect, Fiber, type Scope } from "effect";
+
+/**
+ * Durably prepares work and hands its execution to the conversation service
+ * lifetime without leaving an interruptible gap between those two actions.
+ */
+export const handoffToServiceScope = <A, E, R, EPrepare, RPrepare>(
+	prepare: Effect.Effect<void, EPrepare, RPrepare>,
+	work: Effect.Effect<A, E, R>,
+	scope: Scope.Scope,
+): Effect.Effect<A, E | EPrepare, R | RPrepare> =>
+	Effect.uninterruptibleMask((restore) =>
+		prepare.pipe(
+			Effect.andThen(Effect.forkIn(work, scope)),
+			Effect.flatMap((fiber) => restore(Fiber.join(fiber))),
+		),
+	);

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -3377,7 +3377,7 @@ describe("ConversationServices — chat & session lifecycle", () => {
 			failProviderSend = false;
 			await run(
 				Effect.flatMap(store, (service) =>
-					service.flushQueuedMessages(created.initialSession.id),
+					service.resumeQueuedMessages(created.initialSession.id),
 				),
 			);
 			const messages = await run(
@@ -3606,6 +3606,55 @@ describe("ConversationServices — chat & session lifecycle", () => {
 		}
 	});
 
+	it("automatically sends a message queued while the active turn is booting", async () => {
+		const startBarrier = deferred<void>();
+		const eventsBarrier = deferred<void>();
+		providerStartBarrier = startBarrier.promise;
+		providerEventsBarrier = eventsBarrier.promise;
+		scriptedEvents = [{ _tag: "Completed", reason: "ended" }];
+		try {
+			await withRuntime(async (run) => {
+				const { initialSession } = await run(
+					Effect.flatMap(store, (s) =>
+						s.createChat({
+							projectId: PROJECT_ID,
+							providerId: "claude",
+							model: "claude-opus-4-8",
+							initialPrompt: "first turn",
+						}),
+					),
+				);
+				await run(
+					Effect.flatMap(store, (s) =>
+						s.addQueuedMessage(
+							initialSession.id,
+							new ComposerInput({
+								text: "queued during boot",
+								attachments: [],
+								fileRefs: [],
+								skillRefs: [],
+							}),
+						),
+					),
+				);
+
+				startBarrier.resolve();
+				providerStartBarrier = null;
+				eventsBarrier.resolve();
+
+				await expect
+					.poll(() =>
+						providerSentTexts.filter((text) => text === "queued during boot"),
+					)
+					.toEqual(["queued during boot"]);
+			});
+		} finally {
+			providerStartBarrier = null;
+			providerEventsBarrier = null;
+			scriptedEvents = [];
+		}
+	});
+
 	it("auto-flushes from authoritative turn state when status projection is stale", async () => {
 		await withRuntime(async (run) => {
 			const { initialSession } = await run(
@@ -3770,6 +3819,231 @@ describe("ConversationServices — chat & session lifecycle", () => {
 			);
 			expect(queue.items.map((item) => item.input.text)).toEqual(["wait"]);
 		});
+	});
+
+	it("keeps an errored queue blocked until explicit resume", async () => {
+		await withRuntime(async (run) => {
+			const { initialSession } = await run(
+				Effect.flatMap(store, (service) =>
+					service.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+					}),
+				),
+			);
+			await run(
+				Effect.flatMap(SessionDomain, (domain) =>
+					domain
+						.dispatch({
+							commandId: "test:error-before-queue",
+							streamId: initialSession.id,
+							command: {
+								_tag: "SetStatus",
+								status: "error",
+								updatedAt: Date.now(),
+							},
+						})
+						.pipe(Effect.asVoid),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.addQueuedMessage(
+						initialSession.id,
+						new ComposerInput({
+							text: "send after resume",
+							attachments: [],
+							fileRefs: [],
+							skillRefs: [],
+						}),
+					),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.flushQueuedMessages(initialSession.id),
+				),
+			);
+			let queue = await run(
+				Effect.flatMap(store, (service) =>
+					service.listQueuedMessages(initialSession.id),
+				),
+			);
+			expect(queue.items.map((item) => item.input.text)).toEqual([
+				"send after resume",
+			]);
+
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.resumeQueuedMessages(initialSession.id),
+				),
+			);
+			queue = await run(
+				Effect.flatMap(store, (service) =>
+					service.listQueuedMessages(initialSession.id),
+				),
+			);
+			expect(queue.items).toEqual([]);
+		});
+	});
+
+	it("reconciles a ready queue for an idle session after restart", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-idle-queue-restart-"));
+		const dbPath = join(directory, "test.sqlite");
+		const first = makeRuntime(dbPath);
+		const runFirst = <A>(effect: Effect.Effect<A, unknown, unknown>) =>
+			first.runPromise(effect as Effect.Effect<A, unknown, never>);
+		try {
+			await runFirst(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const now = new Date().toISOString();
+					yield* sql`
+						INSERT INTO projects (id, path, name, created_at, updated_at)
+						VALUES (${PROJECT_ID}, ${directory}, ${"Test"}, ${now}, ${now})
+					`;
+				}),
+			);
+			const { initialSession } = await runFirst(
+				Effect.flatMap(store, (service) =>
+					service.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+					}),
+				),
+			);
+			await runFirst(
+				Effect.flatMap(store, (service) =>
+					service.addQueuedMessage(
+						initialSession.id,
+						new ComposerInput({
+							text: "recover idle queue",
+							attachments: [],
+							fileRefs: [],
+							skillRefs: [],
+						}),
+						undefined,
+						true,
+						false,
+					),
+				),
+			);
+			const { initialSession: corruptSession } = await runFirst(
+				Effect.flatMap(store, (service) =>
+					service.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+					}),
+				),
+			);
+			await runFirst(
+				Effect.flatMap(store, (service) =>
+					service.addQueuedMessage(
+						corruptSession.id,
+						new ComposerInput({
+							text: "corrupt queue",
+							attachments: [],
+							fileRefs: [],
+							skillRefs: [],
+						}),
+						undefined,
+						true,
+						false,
+					),
+				),
+			);
+			const corruptSessionId =
+				corruptSession.id < initialSession.id
+					? corruptSession.id
+					: initialSession.id;
+			const healthySessionId =
+				corruptSessionId === corruptSession.id
+					? initialSession.id
+					: corruptSession.id;
+			const healthyText =
+				healthySessionId === initialSession.id
+					? "recover idle queue"
+					: "corrupt queue";
+			await runFirst(
+				Effect.flatMap(
+					SqlClient.SqlClient,
+					(sql) =>
+						sql`UPDATE queued_messages SET input_json = '{' WHERE session_id = ${corruptSessionId}`,
+				),
+			);
+			await first.dispose();
+
+			const restarted = makeRuntime(dbPath, false);
+			const runRestarted = <A>(effect: Effect.Effect<A, unknown, unknown>) =>
+				restarted.runPromise(effect as Effect.Effect<A, unknown, never>);
+			try {
+				await expect
+					.poll(() =>
+						runRestarted(
+							Effect.flatMap(store, (service) =>
+								service.listMessages(healthySessionId),
+							),
+						),
+					)
+					.toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({
+								role: "user",
+								content: expect.objectContaining({
+									text: healthyText,
+								}),
+							}),
+						]),
+					);
+				const queue = await runRestarted(
+					Effect.flatMap(store, (service) =>
+						service.listQueuedMessages(healthySessionId),
+					),
+				);
+				expect(queue.items).toEqual([]);
+
+				await runRestarted(
+					Effect.flatMap(
+						SqlClient.SqlClient,
+						(sql) =>
+							sql`UPDATE queued_messages
+								SET input_json = ${JSON.stringify({
+									text: "recovered corrupt queue",
+									attachments: [],
+									fileRefs: [],
+									skillRefs: [],
+								})}
+								WHERE session_id = ${corruptSessionId}`,
+					),
+				);
+				await expect
+					.poll(() =>
+						runRestarted(
+							Effect.flatMap(store, (service) =>
+								service.listMessages(corruptSessionId),
+							),
+						),
+					)
+					.toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({
+								role: "user",
+								content: expect.objectContaining({
+									text: "recovered corrupt queue",
+								}),
+							}),
+						]),
+					);
+			} finally {
+				await restarted.dispose();
+			}
+		} finally {
+			await first.dispose();
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 
 	it("keeps queued work durable when restart cannot correlate a stale running status", async () => {

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -149,6 +149,7 @@ let failProviderStart = false;
 let failProviderSend = false;
 let providerStartFailureReason = "scripted start failure";
 let providerStartBarrier: Promise<void> | null = null;
+let providerInterruptBarrier: Promise<void> | null = null;
 let testAutonomyLevel: AutonomyLevel = "approval-gated";
 let createdWorktreeCount = 0;
 let createdWorktrees = new Map<string, Worktree>();
@@ -216,7 +217,10 @@ const StubProviderLive = Layer.succeed(ProviderService, {
 						}),
 			),
 		),
-	interrupt: () => Effect.void,
+	interrupt: () =>
+		providerInterruptBarrier === null
+			? Effect.void
+			: Effect.promise(() => providerInterruptBarrier as Promise<void>),
 	close: (sessionId) =>
 		Effect.sync(() => {
 			activeProviderSessions.delete(sessionId);
@@ -641,6 +645,7 @@ beforeEach(() => {
 	failProviderSend = false;
 	providerStartFailureReason = "scripted start failure";
 	providerStartBarrier = null;
+	providerInterruptBarrier = null;
 	testAutonomyLevel = "approval-gated";
 	createdWorktreeCount = 0;
 	createdWorktrees = new Map();
@@ -3937,6 +3942,74 @@ describe("ConversationServices — chat & session lifecycle", () => {
 				_tag: "user",
 				text: "run this next",
 			});
+		});
+	});
+
+	it("starts a steered successor after the requesting client disconnects", async () => {
+		await withRuntime(async (run) => {
+			const interruptBarrier = deferred<void>();
+			providerInterruptBarrier = interruptBarrier.promise;
+			const { initialSession } = await run(
+				Effect.flatMap(store, (s) =>
+					s.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+						initialPrompt: "already running",
+					}),
+				),
+			);
+			const queued = await run(
+				Effect.flatMap(store, (s) =>
+					s.addQueuedMessage(
+						initialSession.id,
+						new ComposerInput({
+							text: "steer here",
+							attachments: [],
+							fileRefs: [],
+							skillRefs: [],
+						}),
+					),
+				),
+			);
+
+			await run(
+				Effect.gen(function* () {
+					const service = yield* store;
+					const sql = yield* SqlClient.SqlClient;
+					const requestFiber = yield* Effect.forkChild(
+						service.runQueuedMessageNext(initialSession.id, queued.id),
+					);
+					yield* Effect.gen(function* () {
+						const rows = yield* sql<{ readonly count: number }>`
+							SELECT COUNT(*) AS count FROM events
+							WHERE stream_id = ${initialSession.id}
+								AND type = 'TurnInterruptRequested'
+						`;
+						if ((rows[0]?.count ?? 0) === 0) {
+							return yield* Effect.fail("steer interrupt not requested");
+						}
+					}).pipe(
+						Effect.retry(
+							Schedule.max([
+								Schedule.spaced("10 millis"),
+								Schedule.recurs(100),
+							]),
+						),
+					);
+					yield* Fiber.interrupt(requestFiber);
+					yield* Effect.sync(() => interruptBarrier.resolve());
+					yield* Effect.tryPromise({
+						try: () =>
+							expect
+								.poll(() =>
+									providerSentTexts.filter((text) => text === "steer here"),
+								)
+								.toEqual(["steer here"]),
+						catch: (cause) => cause,
+					});
+				}),
+			);
 		});
 	});
 

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -150,6 +150,7 @@ let failProviderSend = false;
 let providerStartFailureReason = "scripted start failure";
 let providerStartBarrier: Promise<void> | null = null;
 let providerInterruptBarrier: Promise<void> | null = null;
+let providerEventsBarrier: Promise<void> | null = null;
 let testAutonomyLevel: AutonomyLevel = "approval-gated";
 let createdWorktreeCount = 0;
 let createdWorktrees = new Map<string, Worktree>();
@@ -232,7 +233,13 @@ const StubProviderLive = Layer.succeed(ProviderService, {
 				turnId: providerTurnIds.get(sessionId) ?? AgentTurnId.make("test-turn"),
 				event,
 			}));
-			return events.length === 0 ? Stream.never : Stream.fromIterable(events);
+			const stream =
+				events.length === 0 ? Stream.never : Stream.fromIterable(events);
+			return providerEventsBarrier === null
+				? stream
+				: Stream.fromEffect(
+						Effect.promise(() => providerEventsBarrier as Promise<void>),
+					).pipe(Stream.flatMap(() => stream));
 		}),
 	setCredential: () => Effect.succeed({ verification: "notChecked" }),
 	removeCredential: () => Effect.void,
@@ -646,6 +653,7 @@ beforeEach(() => {
 	providerStartFailureReason = "scripted start failure";
 	providerStartBarrier = null;
 	providerInterruptBarrier = null;
+	providerEventsBarrier = null;
 	testAutonomyLevel = "approval-gated";
 	createdWorktreeCount = 0;
 	createdWorktrees = new Map();
@@ -3551,6 +3559,139 @@ describe("ConversationServices — chat & session lifecycle", () => {
 				_tag: "user",
 				text: "queued one",
 			});
+		});
+	});
+
+	it("automatically sends the queue head when the active turn completes", async () => {
+		const eventsBarrier = deferred<void>();
+		providerEventsBarrier = eventsBarrier.promise;
+		scriptedEvents = [{ _tag: "Completed", reason: "ended" }];
+		try {
+			await withRuntime(async (run) => {
+				const { initialSession } = await run(
+					Effect.flatMap(store, (s) =>
+						s.createChat({
+							projectId: PROJECT_ID,
+							providerId: "claude",
+							model: "claude-opus-4-8",
+							initialPrompt: "first turn",
+						}),
+					),
+				);
+				await run(
+					Effect.flatMap(store, (s) =>
+						s.addQueuedMessage(
+							initialSession.id,
+							new ComposerInput({
+								text: "send automatically",
+								attachments: [],
+								fileRefs: [],
+								skillRefs: [],
+							}),
+						),
+					),
+				);
+
+				eventsBarrier.resolve();
+
+				await expect
+					.poll(() =>
+						providerSentTexts.filter((text) => text === "send automatically"),
+					)
+					.toEqual(["send automatically"]);
+			});
+		} finally {
+			providerEventsBarrier = null;
+			scriptedEvents = [];
+		}
+	});
+
+	it("auto-flushes from authoritative turn state when status projection is stale", async () => {
+		await withRuntime(async (run) => {
+			const { initialSession } = await run(
+				Effect.flatMap(store, (s) =>
+					s.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+					}),
+				),
+			);
+			await run(
+				Effect.flatMap(SessionDomain, (domain) =>
+					domain
+						.dispatch({
+							commandId: "stale-status-after-settlement",
+							streamId: initialSession.id,
+							command: {
+								_tag: "SetStatus",
+								status: "running",
+								updatedAt: Date.now(),
+							},
+						})
+						.pipe(Effect.asVoid),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (s) =>
+					s.addQueuedMessage(
+						initialSession.id,
+						new ComposerInput({
+							text: "send despite stale status",
+							attachments: [],
+							fileRefs: [],
+							skillRefs: [],
+						}),
+					),
+				),
+			);
+
+			await expect
+				.poll(() => providerSentTexts)
+				.toContain("send despite stale status");
+		});
+	});
+
+	it("does not flush while an authoritative turn is active despite stale idle status", async () => {
+		await withRuntime(async (run) => {
+			const { initialSession } = await run(
+				Effect.flatMap(store, (s) =>
+					s.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+						initialPrompt: "active turn",
+					}),
+				),
+			);
+			await run(
+				Effect.flatMap(
+					SqlClient.SqlClient,
+					(sql) =>
+						sql`UPDATE sessions SET status = 'idle' WHERE id = ${initialSession.id}`,
+				),
+			);
+			await run(
+				Effect.flatMap(store, (s) =>
+					s.addQueuedMessage(
+						initialSession.id,
+						new ComposerInput({
+							text: "must remain queued",
+							attachments: [],
+							fileRefs: [],
+							skillRefs: [],
+						}),
+					),
+				),
+			);
+
+			expect(providerSentTexts).toEqual(["active turn"]);
+			const queue = await run(
+				Effect.flatMap(store, (s) => s.listQueuedMessages(initialSession.id)),
+			);
+			expect(queue.items.map((item) => item.input.text)).toEqual([
+				"must remain queued",
+			]);
 		});
 	});
 

--- a/packages/agents/src/drivers/claude.ts
+++ b/packages/agents/src/drivers/claude.ts
@@ -281,8 +281,10 @@ interface TranslateState {
 	pendingAgents: Map<string, PendingAgent>;
 	/** Maps SDK background task ids to their originating Agent tool use. */
 	backgroundTaskParents: Map<string, AgentItemId>;
-	/** SDK task ids that describe background shell jobs rather than subagents. */
-	localBackgroundTaskIds: Set<string>;
+	/** Shell inputs retained until the SDK classifies them as background. */
+	backgroundShellInputs: Map<string, unknown>;
+	/** SDK task ids mapped to their dedicated BackgroundTask timeline item. */
+	localBackgroundTasks: Map<string, AgentItemId>;
 	/**
 	 * Most recent `parent_tool_use_id` seen on an SDK message. The Claude
 	 * SDK's `canUseTool` callback signature does not include a parent id,
@@ -337,7 +339,8 @@ const newTranslateState = (): TranslateState => ({
 	emittedThinkingThisTurn: false,
 	pendingAgents: new Map(),
 	backgroundTaskParents: new Map(),
-	localBackgroundTaskIds: new Set(),
+	backgroundShellInputs: new Map(),
+	localBackgroundTasks: new Map(),
 	latestParentItemId: undefined,
 	askUserQuestionIds: new Set(),
 	exitPlanModeIds: new Set(),
@@ -636,6 +639,9 @@ const translate = (
 					// tool runs; we mirror that into our session row.
 					if (block.name === "ExitPlanMode") {
 						state.exitPlanModeIds.add(id as string);
+					}
+					if (block.name === "Bash") {
+						state.backgroundShellInputs.set(id as string, block.input);
 					}
 					// If this tool_use is the parent agent kicking off a sub-agent,
 					// remember it so the eventual paired tool_result can pop a
@@ -1006,8 +1012,35 @@ const translate = (
 	}
 	if (msg.type === "system" && msg.subtype === "task_started") {
 		if (msg.task_type === "local_bash") {
-			state.localBackgroundTaskIds.add(msg.task_id);
-			return [];
+			const itemId = `background_task_${msg.task_id}` as AgentItemId;
+			state.localBackgroundTasks.set(msg.task_id, itemId);
+			const originalInput =
+				msg.tool_use_id === undefined
+					? undefined
+					: state.backgroundShellInputs.get(msg.tool_use_id);
+			if (msg.tool_use_id !== undefined) {
+				state.backgroundShellInputs.delete(msg.tool_use_id);
+			}
+			const input =
+				originalInput !== null && typeof originalInput === "object"
+					? {
+							...(originalInput as Record<string, unknown>),
+							description: msg.description,
+							task_id: msg.task_id,
+						}
+					: {
+							description: msg.description,
+							task_id: msg.task_id,
+						};
+			return [
+				{
+					_tag: "ToolUse",
+					itemId,
+					tool: "Bash",
+					input,
+					backgroundTask: { taskId: msg.task_id },
+				},
+			];
 		}
 		if (msg.skip_transcript === true) return [];
 		const itemId = (msg.tool_use_id ?? `task_${msg.task_id}`) as AgentItemId;
@@ -1040,7 +1073,7 @@ const translate = (
 		];
 	}
 	if (msg.type === "system" && msg.subtype === "task_progress") {
-		if (state.localBackgroundTaskIds.has(msg.task_id)) return [];
+		if (state.localBackgroundTasks.has(msg.task_id)) return [];
 		const itemId =
 			(msg.tool_use_id as AgentItemId | undefined) ??
 			state.backgroundTaskParents.get(msg.task_id);
@@ -1057,13 +1090,24 @@ const translate = (
 		];
 	}
 	if (msg.type === "system" && msg.subtype === "task_notification") {
-		if (state.localBackgroundTaskIds.delete(msg.task_id)) return [];
+		const backgroundTaskItemId = state.localBackgroundTasks.get(msg.task_id);
+		if (backgroundTaskItemId !== undefined) {
+			return [
+				{
+					_tag: "ToolResult",
+					itemId: backgroundTaskItemId,
+					output: msg.summary,
+					isError: msg.status !== "completed",
+				},
+			];
+		}
 		if (msg.skip_transcript === true) return [];
 		const itemId =
 			(msg.tool_use_id as AgentItemId | undefined) ??
 			state.backgroundTaskParents.get(msg.task_id) ??
 			(`task_${msg.task_id}` as AgentItemId);
 		const pending = state.pendingAgents.get(itemId as string);
+		if (pending === undefined) return [];
 		const summary = msg.summary.trim();
 		const out: AgentEvent[] = [];
 		if (summary.length > 0) {

--- a/packages/agents/src/drivers/claude.ts
+++ b/packages/agents/src/drivers/claude.ts
@@ -281,6 +281,8 @@ interface TranslateState {
 	pendingAgents: Map<string, PendingAgent>;
 	/** Maps SDK background task ids to their originating Agent tool use. */
 	backgroundTaskParents: Map<string, AgentItemId>;
+	/** SDK task ids that describe background shell jobs rather than subagents. */
+	localBackgroundTaskIds: Set<string>;
 	/**
 	 * Most recent `parent_tool_use_id` seen on an SDK message. The Claude
 	 * SDK's `canUseTool` callback signature does not include a parent id,
@@ -324,8 +326,8 @@ interface TranslateState {
 	 * Set when the user interrupts the running turn (`handle.interrupt`). The SDK
 	 * ends an interrupted turn with an `error_during_execution` result, which
 	 * would otherwise surface as a bogus error bubble; while this flag is set the
-	 * translator emits an `Interrupted` event + `Completed reason:"interrupted"`
-	 * instead. Reset per turn once consumed.
+	 * translator emits an `Interrupted` event instead. The shared turn protocol
+	 * owns terminal synthesis. Reset per turn once consumed.
 	 */
 	interrupted: boolean;
 }
@@ -335,6 +337,7 @@ const newTranslateState = (): TranslateState => ({
 	emittedThinkingThisTurn: false,
 	pendingAgents: new Map(),
 	backgroundTaskParents: new Map(),
+	localBackgroundTaskIds: new Set(),
 	latestParentItemId: undefined,
 	askUserQuestionIds: new Set(),
 	exitPlanModeIds: new Set(),
@@ -978,7 +981,6 @@ const translate = (
 			// bubble, and skip the failed-result handling below.
 			if (state.interrupted) {
 				out.push({ _tag: "Interrupted" });
-				out.push({ _tag: "Completed", reason: "interrupted" });
 				state.interrupted = false;
 				state.emittedAuthError = false;
 				return out;
@@ -1003,6 +1005,10 @@ const translate = (
 		return out;
 	}
 	if (msg.type === "system" && msg.subtype === "task_started") {
+		if (msg.task_type === "local_bash") {
+			state.localBackgroundTaskIds.add(msg.task_id);
+			return [];
+		}
 		if (msg.skip_transcript === true) return [];
 		const itemId = (msg.tool_use_id ?? `task_${msg.task_id}`) as AgentItemId;
 		const existing = state.pendingAgents.get(itemId as string);
@@ -1034,6 +1040,7 @@ const translate = (
 		];
 	}
 	if (msg.type === "system" && msg.subtype === "task_progress") {
+		if (state.localBackgroundTaskIds.has(msg.task_id)) return [];
 		const itemId =
 			(msg.tool_use_id as AgentItemId | undefined) ??
 			state.backgroundTaskParents.get(msg.task_id);
@@ -1050,6 +1057,7 @@ const translate = (
 		];
 	}
 	if (msg.type === "system" && msg.subtype === "task_notification") {
+		if (state.localBackgroundTaskIds.delete(msg.task_id)) return [];
 		if (msg.skip_transcript === true) return [];
 		const itemId =
 			(msg.tool_use_id as AgentItemId | undefined) ??
@@ -1839,15 +1847,11 @@ export const startClaudeSession = (
 				Effect.sync(() => {
 					// If the SDK threw out of the `for await` because the user
 					// interrupted (rather than yielding an `error_during_execution`
-					// result), surface the muted interrupted badge, not an error. Emit a
-					// non-error completion too so the turn isn't left pinned at running.
+					// result), surface the muted interrupted badge, not an error. The
+					// shared turn protocol synthesizes the terminal completion.
 					if (translateState.interrupted) {
 						translateState.interrupted = false;
 						Queue.offerUnsafe(events, { _tag: "Interrupted" });
-						Queue.offerUnsafe(events, {
-							_tag: "Completed",
-							reason: "interrupted",
-						});
 						return;
 					}
 					Queue.offerUnsafe(events, {

--- a/packages/agents/test/unit/drivers/claude-background-agent.test.ts
+++ b/packages/agents/test/unit/drivers/claude-background-agent.test.ts
@@ -72,6 +72,17 @@ describe("Claude background agents", () => {
 				itemId: "background-shell-1",
 				tool: "Bash",
 			}),
+			expect.objectContaining({
+				_tag: "ToolUse",
+				itemId: "background_task_background-task-1",
+				tool: "Bash",
+				backgroundTask: { taskId: "background-task-1" },
+				input: expect.objectContaining({
+					command: "npm run dev",
+					description: "Restart dev server",
+					task_id: "background-task-1",
+				}),
+			}),
 		]);
 		expect(events.some((event) => event._tag === "SubagentSummary")).toBe(
 			false,
@@ -83,7 +94,16 @@ describe("Claude background agents", () => {
 					event.parentItemId === "background-shell-1",
 			),
 		).toBe(false);
-		expect(events.some((event) => event._tag === "ToolResult")).toBe(true);
+		expect(events.filter((event) => event._tag === "ToolResult")).toEqual([
+			expect.objectContaining({
+				itemId: "background_task_background-task-1",
+				isError: false,
+			}),
+			expect.objectContaining({
+				itemId: "background-shell-1",
+				isError: false,
+			}),
+		]);
 	});
 
 	it("normalizes structured task lifecycle events as one detached run", () => {
@@ -178,5 +198,70 @@ describe("Claude background agents", () => {
 					event.parentItemId === "agent-tool-1",
 			),
 		).toHaveLength(2);
+	});
+
+	it("does not guess that an unknown task notification is a subagent", () => {
+		const events = translateClaudeSdkMessages([
+			sdk({
+				type: "system",
+				subtype: "task_notification",
+				task_id: "unknown-task",
+				tool_use_id: "unknown-tool",
+				status: "failed",
+				output_file: "/private/internal/output.txt",
+				summary: "Task stopped",
+				usage: { total_tokens: 0, tool_uses: 0, duration_ms: 100 },
+			}),
+		]);
+
+		expect(events).toEqual([]);
+	});
+
+	it("marks a failed local background task as an error without agent events", () => {
+		const events = translateClaudeSdkMessages([
+			sdk({
+				type: "assistant",
+				parent_tool_use_id: null,
+				message: {
+					content: [
+						{
+							type: "tool_use",
+							id: "failed-shell",
+							name: "Bash",
+							input: { command: "npm run dev" },
+						},
+					],
+				},
+			}),
+			sdk({
+				type: "system",
+				subtype: "task_started",
+				task_id: "failed-task",
+				tool_use_id: "failed-shell",
+				description: "Start dev server",
+				task_type: "local_bash",
+			}),
+			sdk({
+				type: "system",
+				subtype: "task_notification",
+				task_id: "failed-task",
+				tool_use_id: "failed-shell",
+				status: "failed",
+				output_file: "/private/internal/output.txt",
+				summary: "Process exited",
+				usage: { total_tokens: 0, tool_uses: 1, duration_ms: 200 },
+			}),
+		]);
+
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				_tag: "ToolResult",
+				itemId: "background_task_failed-task",
+				isError: true,
+			}),
+		);
+		expect(events.some((event) => event._tag === "SubagentSummary")).toBe(
+			false,
+		);
 	});
 });

--- a/packages/agents/test/unit/drivers/claude-background-agent.test.ts
+++ b/packages/agents/test/unit/drivers/claude-background-agent.test.ts
@@ -5,6 +5,87 @@ import { describe, expect, it } from "vitest";
 const sdk = (value: unknown): SDKMessage => value as SDKMessage;
 
 describe("Claude background agents", () => {
+	it("keeps local background shell tasks out of the subagent lifecycle", () => {
+		const events = translateClaudeSdkMessages([
+			sdk({
+				type: "assistant",
+				parent_tool_use_id: null,
+				message: {
+					content: [
+						{
+							type: "tool_use",
+							id: "background-shell-1",
+							name: "Bash",
+							input: { command: "npm run dev", run_in_background: true },
+						},
+					],
+				},
+			}),
+			sdk({
+				type: "system",
+				subtype: "task_started",
+				task_id: "background-task-1",
+				tool_use_id: "background-shell-1",
+				description: "Restart dev server",
+				task_type: "local_bash",
+				prompt: "Restart dev server",
+				skip_transcript: true,
+			}),
+			sdk({
+				type: "system",
+				subtype: "task_progress",
+				task_id: "background-task-1",
+				tool_use_id: "background-shell-1",
+				description: "Waiting for dev server",
+				usage: { total_tokens: 0, tool_uses: 1, duration_ms: 500 },
+			}),
+			sdk({
+				type: "system",
+				subtype: "task_notification",
+				task_id: "background-task-1",
+				tool_use_id: "background-shell-1",
+				status: "completed",
+				output_file: "/private/internal/output.txt",
+				summary: "Dev server is ready",
+				usage: { total_tokens: 0, tool_uses: 1, duration_ms: 1200 },
+				skip_transcript: true,
+			}),
+			sdk({
+				type: "user",
+				parent_tool_use_id: null,
+				message: {
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "background-shell-1",
+							content: "Dev server is ready",
+							is_error: false,
+						},
+					],
+				},
+			}),
+		]);
+
+		expect(events.filter((event) => event._tag === "ToolUse")).toEqual([
+			expect.objectContaining({
+				_tag: "ToolUse",
+				itemId: "background-shell-1",
+				tool: "Bash",
+			}),
+		]);
+		expect(events.some((event) => event._tag === "SubagentSummary")).toBe(
+			false,
+		);
+		expect(
+			events.some(
+				(event) =>
+					event._tag === "AssistantMessage" &&
+					event.parentItemId === "background-shell-1",
+			),
+		).toBe(false);
+		expect(events.some((event) => event._tag === "ToolResult")).toBe(true);
+	});
+
 	it("normalizes structured task lifecycle events as one detached run", () => {
 		const events = translateClaudeSdkMessages([
 			sdk({

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -432,6 +432,11 @@ const ToolUseEvent = Schema.TaggedStruct("ToolUse", {
   tool: Schema.String,
   input: Schema.Unknown,
   parentItemId: Schema.optional(AgentItemId),
+  backgroundTask: Schema.optional(
+    Schema.Struct({
+      taskId: Schema.String,
+    }),
+  ),
   subagent: Schema.optional(
     Schema.Struct({
       childSessionId: Schema.String,

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -229,6 +229,11 @@ const ToolUseContent = Schema.TaggedStruct("tool_use", {
 	tool: Schema.String,
 	input: Schema.Unknown,
 	parentItemId: Schema.optional(AgentItemId),
+	backgroundTask: Schema.optional(
+		Schema.Struct({
+			taskId: Schema.String,
+		}),
+	),
 	subagent: Schema.optional(
 		Schema.Struct({
 			childSessionId: Schema.String,


### PR DESCRIPTION
## What changed

- distinguish foreground sub-agent waits from long-running background tasks in the transcript
- make queued steering durable and expose Steer, Edit, and Remove actions directly on queue items
- replace lossy queue wake-ups with a shared mailbox and per-session serialization
- reconcile durable ready queue entries during startup and retry transient failures without starving other sessions
- preserve paused and errored queue boundaries until explicit resume

## Why

Queued messages could remain stuck after an agent visibly completed because delivery depended on a process-local one-shot wake-up. Background task events could also be rendered as sub-agent activity, and steering could stop the current turn without reliably handing off the queued successor.

The queue is now treated as durable work: normal lifecycle events enqueue drain requests, startup catch-up reconciles missed work, and failures are retried with capped exponential backoff. Task rendering uses provider event semantics to keep background work separate from sub-agent waiting.

## User impact

Queued messages should send automatically across providers, including after restart or transient failure. Steering remains durable across disconnects, and background tasks are shown separately from sub-agent waits.

## Validation

- server typecheck
- 196 server integration tests
- 463 renderer tests
- 231 agent package tests
- focused Biome checks on changed renderer files

The repository-wide server suite still has the pre-existing telemetry export failure: expected 25,000 events but received 0.