### PR TITLE
Hide cloud machines in production

### DIFF
--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -1,6 +1,15 @@
 import type { IconSvgElement } from "@hugeicons/react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronLeft } from "lucide-react";
+import {
+	type AppearanceMode,
+	type BranchNamingStyle,
+	type CompletionSoundPreset,
+	type Folder,
+	type FolderId,
+	type ProviderId,
+	type RuntimeMode,
+	visibleModelsForProvider,
+} from "@zuse/contracts";
 import {
 	Alert01Icon,
 	BrowserIcon,
@@ -20,19 +29,10 @@ import {
 	Tick01Icon,
 	VolumeHighIcon,
 } from "@zuse/icons/solid-rounded";
-import {
-	type AppearanceMode,
-	type BranchNamingStyle,
-	type CompletionSoundPreset,
-	type Folder,
-	type FolderId,
-	type ProviderId,
-	type RuntimeMode,
-	visibleModelsForProvider,
-} from "@zuse/contracts";
 import { Effect } from "effect";
-import { Plus, RefreshCw as RefreshIcon } from "lucide-react";
+import { ChevronLeft, Plus, RefreshCw as RefreshIcon } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { cloudMachinesAvailable } from "~/lib/cloud-machines-availability.ts";
 import { displayPath } from "~/lib/display-path";
 import { hasHostCapability } from "~/lib/host-platform";
 import { rendererPlatformCapabilities } from "~/lib/platform-capabilities.ts";
@@ -171,9 +171,16 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
 	},
 ];
 
-const VISIBLE_RAIL: ReadonlyArray<RailItemBase> = import.meta.env.DEV
-	? TOP_RAIL
-	: TOP_RAIL.filter((i) => i.id !== "developer");
+const CLOUD_MACHINES_AVAILABLE = cloudMachinesAvailable({
+	desktop: rendererPlatformCapabilities().desktop,
+	development: import.meta.env.DEV,
+});
+
+const VISIBLE_RAIL: ReadonlyArray<RailItemBase> = TOP_RAIL.filter(
+	(item) =>
+		(item.id !== "developer" || import.meta.env.DEV) &&
+		(item.id !== "machines" || CLOUD_MACHINES_AVAILABLE),
+);
 
 /**
  * Two-pane settings surface. The left rail navigates between global
@@ -188,17 +195,19 @@ export function SettingsPage() {
 	const loadFolders = useWorkspaceStore((s) => s.load);
 	const desktop = rendererPlatformCapabilities().desktop;
 	const visibleSection: SettingsSection =
-		!desktop && section.kind === "machines" ? { kind: "general" } : section;
+		!CLOUD_MACHINES_AVAILABLE && section.kind === "machines"
+			? { kind: "general" }
+			: section;
 
 	useEffect(() => {
 		if (folders.length === 0) void loadFolders();
 	}, [folders.length, loadFolders]);
 
 	useEffect(() => {
-		if (!desktop && section.kind === "machines") {
+		if (!CLOUD_MACHINES_AVAILABLE && section.kind === "machines") {
 			setSection({ kind: "general" });
 		}
-	}, [desktop, section.kind, setSection]);
+	}, [section.kind, setSection]);
 
 	return (
 		<div className="settings-surface flex min-h-0 flex-1 flex-col bg-background [&_button[data-slot=button]:not([class*='size-'])]:h-7 [&_button[data-slot=button]:not([class*='size-'])]:text-[11px]">

--- a/apps/renderer/src/lib/cloud-machines-availability.ts
+++ b/apps/renderer/src/lib/cloud-machines-availability.ts
@@ -1,0 +1,7 @@
+export const cloudMachinesAvailable = ({
+	desktop,
+	development,
+}: {
+	readonly desktop: boolean;
+	readonly development: boolean;
+}): boolean => desktop && development;

--- a/apps/renderer/test/unit/cloud-machines-availability.test.ts
+++ b/apps/renderer/test/unit/cloud-machines-availability.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { cloudMachinesAvailable } from "../../src/lib/cloud-machines-availability.ts";
+
+describe("cloud machine availability", () => {
+	it("is hidden in production desktop builds", () => {
+		expect(cloudMachinesAvailable({ desktop: true, development: false })).toBe(
+			false,
+		);
+	});
+
+	it("remains available in desktop development builds", () => {
+		expect(cloudMachinesAvailable({ desktop: true, development: true })).toBe(
+			true,
+		);
+	});
+
+	it("is unavailable outside the desktop app", () => {
+		expect(cloudMachinesAvailable({ desktop: false, development: true })).toBe(
+			false,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- hide the cloud machines settings entry in production builds
- redirect stale or programmatic production navigation to General
- keep the capability available in desktop development builds

## Validation

- `bunx biome check apps/renderer/src/components/settings-page.tsx apps/renderer/src/lib/cloud-machines-availability.ts apps/renderer/test/unit/cloud-machines-availability.test.ts`
- `bun --filter renderer test:unit` — 91 files, 459 tests passed
- `bun --filter renderer check-types`
- `bun --filter renderer build` — bundle budgets passed