### PR TITLE
Release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1]
+
+### Fixed
+- Cloud machines no longer appear in production settings until the feature is ready for release, while development builds retain access for testing
+
 ## [0.18.0]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.18.1",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Cloud machines no longer appear in production settings until the feature is ready for release, while development builds retain access for testing"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.18.0",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.18.1 with release notes grouped by user-visible outcome.

### Fixed
- Cloud machines no longer appear in production settings until the feature is ready for release, while development builds retain access for testing

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.18.1 after this PR lands.