### PR TITLE
Fix duplicate projects and restore Quick Start

### DIFF
--- a/apps/renderer/src/components/project-add-menu.tsx
+++ b/apps/renderer/src/components/project-add-menu.tsx
@@ -1,7 +1,11 @@
 import { Plus } from "lucide-react";
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense } from "react";
 
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import {
+	openProjectSetupDialog,
+	useProjectSetupDialogStore,
+} from "../lib/project-setup-dialog-state.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
 import { TooltipShortcut } from "./projects-sidebar.tsx";
 
@@ -13,7 +17,8 @@ const ProjectSetupDialog = lazy(() =>
 );
 
 export function ProjectAddMenu() {
-	const [open, setOpen] = useState(false);
+	const open = useProjectSetupDialogStore((state) => state.open);
+	const setOpen = useProjectSetupDialogStore((state) => state.setOpen);
 
 	return (
 		<>
@@ -24,7 +29,7 @@ export function ProjectAddMenu() {
 							type="button"
 							className="rounded p-1 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
 							aria-label="Add project"
-							onClick={() => setOpen(true)}
+							onClick={openProjectSetupDialog}
 							onFocus={() => void loadProjectSetupDialog()}
 							onPointerEnter={() => void loadProjectSetupDialog()}
 						>

--- a/apps/renderer/src/lib/commands.ts
+++ b/apps/renderer/src/lib/commands.ts
@@ -11,6 +11,7 @@ import { useUiStore } from "../store/ui";
 import { useWorkspaceStore } from "../store/workspace";
 import { captureAnalytics } from "./analytics";
 import { openNewChatLanding } from "./open-new-chat-landing.ts";
+import { openProjectSetupDialog } from "./project-setup-dialog-state.ts";
 import { activeChatId, orderedChatTabs } from "./tab-order";
 
 /* ────────────────────────── Navigation helpers ──────────────────────────
@@ -137,7 +138,7 @@ const HANDLERS: Record<Command, () => void> = {
 		openNewChatLanding(projectId);
 	},
 	"open-project": () => {
-		void useWorkspaceStore.getState().add();
+		openProjectSetupDialog();
 	},
 	settings: () => {
 		const ui = useUiStore.getState();

--- a/apps/renderer/src/lib/environment-projects.ts
+++ b/apps/renderer/src/lib/environment-projects.ts
@@ -6,7 +6,7 @@ import type {
 } from "@zuse/contracts";
 import { Effect } from "effect";
 import { useEnvironmentCatalogStore } from "../store/environment-catalog.ts";
-import { useWorkspaceStore } from "../store/workspace.ts";
+import { registerFolder, useWorkspaceStore } from "../store/workspace.ts";
 import { getRpcClient, getVerifiedRpcClient } from "./rpc-client.ts";
 
 const messageOf = (cause: unknown): string => {
@@ -42,12 +42,7 @@ const registerResult = async (
 ): Promise<void> => {
 	const catalog = useEnvironmentCatalogStore.getState();
 	if (catalog.activeEnvironmentId === environmentId) {
-		useWorkspaceStore.setState((state) => ({
-			folders: state.folders.some((item) => item.id === folder.id)
-				? state.folders
-				: [...state.folders, folder],
-			selectedFolderId: folder.id,
-		}));
+		useWorkspaceStore.setState((state) => registerFolder(state, folder));
 		await run(environmentId, (client) =>
 			client["workspace.setSelected"]({ folderId: folder.id }),
 		).catch(() => undefined);

--- a/apps/renderer/src/lib/project-setup-dialog-state.ts
+++ b/apps/renderer/src/lib/project-setup-dialog-state.ts
@@ -1,0 +1,17 @@
+import { createAtomStore as create } from "../state/atom-store.ts";
+
+type ProjectSetupDialogState = {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+};
+
+export const useProjectSetupDialogStore = create<ProjectSetupDialogState>(
+	(set) => ({
+		open: false,
+		setOpen: (open) => set({ open }),
+	}),
+);
+
+export const openProjectSetupDialog = (): void => {
+	useProjectSetupDialogStore.setState({ open: true });
+};

--- a/apps/renderer/src/store/workspace.ts
+++ b/apps/renderer/src/store/workspace.ts
@@ -1,83 +1,95 @@
+import type {
+	Folder,
+	FolderId,
+	GithubRepoSummary,
+	ProjectTemplate,
+} from "@zuse/contracts";
 import { Effect } from "effect";
+import { getRpcClient } from "../lib/rpc-client.ts";
 import { createAtomStore as create } from "../state/atom-store.ts";
 import { stopProjectChatStream } from "./chat-commands.ts";
 
-import type {
-  Folder,
-  FolderId,
-  GithubRepoSummary,
-  ProjectTemplate,
-} from "@zuse/contracts";
-
-import { getRpcClient } from "../lib/rpc-client.ts";
-
 type WorkspaceState = {
-  folders: ReadonlyArray<Folder>;
-  selectedFolderId: FolderId | null;
-  loading: boolean;
-  error: string | null;
-  /**
-   * Recent GitHub repos surfaced from `gh repo list`, used by the Clone
-   * dialog. `null` = "haven't fetched yet", `[]` = "fetched and empty
-   * (or gh missing)" so the dialog can show the right hint.
-   */
-  recentGithubRepos: ReadonlyArray<GithubRepoSummary> | null;
-  /** Loading flag so the Clone dialog can render a spinner under recents. */
-  recentGithubReposLoading: boolean;
-  /** Cached gh auth result — `null` until probed. */
-  ghAuthenticated: boolean | null;
-  load: () => Promise<void>;
-  add: () => Promise<void>;
-  remove: (folderId: FolderId) => Promise<void>;
-  select: (folderId: FolderId) => Promise<void>;
-  /**
-   * Ask the host for an OS folder picker. Returns the absolute path the
-   * user chose, or `null` if they cancelled. Used by the Clone /
-   * Quick-start dialogs to populate their Location/Parent fields.
-   */
-  pickFolder: () => Promise<string | null>;
-  /** Refresh the recents + auth probes; safe to call repeatedly. */
-  loadGithubContext: () => Promise<void>;
-  /**
-   * Clone `url` into `<parent>/<derived-name>`. Returns the new Folder
-   * on success, throws (rejects) on failure so the dialog can render
-   * the error inline.
-   */
-  cloneRepo: (url: string, parent: string) => Promise<Folder>;
-  /**
-   * Scaffold a new project and register it. Throws on failure so the
-   * dialog can render `WorkspaceCreateFailedError.reason`.
-   */
-  createProject: (params: {
-    name: string;
-    parent: string;
-    template: ProjectTemplate;
-    alsoCreateGithubRepo: boolean;
-  }) => Promise<Folder>;
+	folders: ReadonlyArray<Folder>;
+	selectedFolderId: FolderId | null;
+	loading: boolean;
+	error: string | null;
+	/**
+	 * Recent GitHub repos surfaced from `gh repo list`, used by the Clone
+	 * dialog. `null` = "haven't fetched yet", `[]` = "fetched and empty
+	 * (or gh missing)" so the dialog can show the right hint.
+	 */
+	recentGithubRepos: ReadonlyArray<GithubRepoSummary> | null;
+	/** Loading flag so the Clone dialog can render a spinner under recents. */
+	recentGithubReposLoading: boolean;
+	/** Cached gh auth result — `null` until probed. */
+	ghAuthenticated: boolean | null;
+	load: () => Promise<void>;
+	add: () => Promise<void>;
+	remove: (folderId: FolderId) => Promise<void>;
+	select: (folderId: FolderId) => Promise<void>;
+	/**
+	 * Ask the host for an OS folder picker. Returns the absolute path the
+	 * user chose, or `null` if they cancelled. Used by the Clone /
+	 * Quick-start dialogs to populate their Location/Parent fields.
+	 */
+	pickFolder: () => Promise<string | null>;
+	/** Refresh the recents + auth probes; safe to call repeatedly. */
+	loadGithubContext: () => Promise<void>;
+	/**
+	 * Clone `url` into `<parent>/<derived-name>`. Returns the new Folder
+	 * on success, throws (rejects) on failure so the dialog can render
+	 * the error inline.
+	 */
+	cloneRepo: (url: string, parent: string) => Promise<Folder>;
+	/**
+	 * Scaffold a new project and register it. Throws on failure so the
+	 * dialog can render `WorkspaceCreateFailedError.reason`.
+	 */
+	createProject: (params: {
+		name: string;
+		parent: string;
+		template: ProjectTemplate;
+		alsoCreateGithubRepo: boolean;
+	}) => Promise<Folder>;
+};
+
+export const registerFolder = (
+	state: Pick<WorkspaceState, "folders" | "selectedFolderId">,
+	folder: Folder,
+): Pick<WorkspaceState, "folders" | "selectedFolderId"> => {
+	const existing = state.folders.find(
+		(existing) => existing.id === folder.id || existing.path === folder.path,
+	);
+	return {
+		folders:
+			existing === undefined ? [...state.folders, folder] : state.folders,
+		selectedFolderId: existing?.id ?? folder.id,
+	};
 };
 
 const persistSelection = async (folderId: FolderId | null): Promise<void> => {
-  try {
-    const client = await getRpcClient();
-    await Effect.runPromise(client["workspace.setSelected"]({ folderId }));
-  } catch {
-    // best-effort persistence; the in-memory store already updated
-  }
+	try {
+		const client = await getRpcClient();
+		await Effect.runPromise(client["workspace.setSelected"]({ folderId }));
+	} catch {
+		// best-effort persistence; the in-memory store already updated
+	}
 };
 
 const formatError = (err: unknown): string => {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "object" && err !== null) {
-    // TaggedErrors travel over RPC carrying `_tag` plus their schema
-    // fields. Prefer the human-readable ones over the bare tag — the
-    // dialog inline-renders this string verbatim.
-    const obj = err as Record<string, unknown>;
-    if (typeof obj.reason === "string" && obj.reason.length > 0) {
-      return obj.reason;
-    }
-    if (typeof obj._tag === "string") return obj._tag;
-  }
-  return String(err);
+	if (err instanceof Error) return err.message;
+	if (typeof err === "object" && err !== null) {
+		// TaggedErrors travel over RPC carrying `_tag` plus their schema
+		// fields. Prefer the human-readable ones over the bare tag — the
+		// dialog inline-renders this string verbatim.
+		const obj = err as Record<string, unknown>;
+		if (typeof obj.reason === "string" && obj.reason.length > 0) {
+			return obj.reason;
+		}
+		if (typeof obj._tag === "string") return obj._tag;
+	}
+	return String(err);
 };
 
 /**
@@ -87,151 +99,142 @@ const formatError = (err: unknown): string => {
  * has no surface for inline errors.
  */
 const rethrow = (err: unknown): never => {
-  throw new Error(formatError(err));
+	throw new Error(formatError(err));
 };
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
-  folders: [],
-  selectedFolderId: null,
-  loading: false,
-  error: null,
-  recentGithubRepos: null,
-  recentGithubReposLoading: false,
-  ghAuthenticated: null,
-  load: async () => {
-    set({ loading: true, error: null });
-    try {
-      const client = await getRpcClient();
-      const [folders, persisted] = await Promise.all([
-        Effect.runPromise(client["workspace.list"]({})),
-        Effect.runPromise(client["workspace.getSelected"]({})),
-      ]);
-      // Prefer the persisted selection if its folder still exists; otherwise
-      // pick the first folder so the UI is never in a "have folders, none
-      // selected" limbo on cold start.
-      const selected =
-        persisted !== null && folders.some((f) => f.id === persisted)
-          ? persisted
-          : (folders[0]?.id ?? null);
-      set({ folders, selectedFolderId: selected, loading: false });
-      // If we fell back to first-folder, persist that so the next launch
-      // restores the same one without re-running the fallback.
-      if (selected !== persisted) await persistSelection(selected);
-    } catch (err) {
-      set({ error: formatError(err), loading: false });
-    }
-  },
-  add: async () => {
-    set({ error: null });
-    try {
-      const client = await getRpcClient();
-      const path = await Effect.runPromise(client["workspace.pickFolder"]({}));
-      if (path === null) return;
-      const folder = await Effect.runPromise(client["workspace.add"]({ path }));
-      set((s) => ({
-        folders: [...s.folders, folder],
-        selectedFolderId: folder.id,
-      }));
-      await persistSelection(folder.id);
-    } catch (err) {
-      set({ error: formatError(err) });
-    }
-  },
-  remove: async (folderId) => {
-    set({ error: null });
-    try {
-      const client = await getRpcClient();
-      await Effect.runPromise(client["workspace.remove"]({ folderId }));
+	folders: [],
+	selectedFolderId: null,
+	loading: false,
+	error: null,
+	recentGithubRepos: null,
+	recentGithubReposLoading: false,
+	ghAuthenticated: null,
+	load: async () => {
+		set({ loading: true, error: null });
+		try {
+			const client = await getRpcClient();
+			const [folders, persisted] = await Promise.all([
+				Effect.runPromise(client["workspace.list"]({})),
+				Effect.runPromise(client["workspace.getSelected"]({})),
+			]);
+			// Prefer the persisted selection if its folder still exists; otherwise
+			// pick the first folder so the UI is never in a "have folders, none
+			// selected" limbo on cold start.
+			const selected =
+				persisted !== null && folders.some((f) => f.id === persisted)
+					? persisted
+					: (folders[0]?.id ?? null);
+			set({ folders, selectedFolderId: selected, loading: false });
+			// If we fell back to first-folder, persist that so the next launch
+			// restores the same one without re-running the fallback.
+			if (selected !== persisted) await persistSelection(selected);
+		} catch (err) {
+			set({ error: formatError(err), loading: false });
+		}
+	},
+	add: async () => {
+		set({ error: null });
+		try {
+			const client = await getRpcClient();
+			const path = await Effect.runPromise(client["workspace.pickFolder"]({}));
+			if (path === null) return;
+			const folder = await Effect.runPromise(client["workspace.add"]({ path }));
+			set((s) => registerFolder(s, folder));
+			await persistSelection(folder.id);
+		} catch (err) {
+			set({ error: formatError(err) });
+		}
+	},
+	remove: async (folderId) => {
+		set({ error: null });
+		try {
+			const client = await getRpcClient();
+			await Effect.runPromise(client["workspace.remove"]({ folderId }));
 			await stopProjectChatStream(folderId);
-      const nextSelected = (() => {
-        const s = get();
-        const folders = s.folders.filter((f) => f.id !== folderId);
-        const selectedFolderId =
-          s.selectedFolderId === folderId
-            ? (folders[0]?.id ?? null)
-            : s.selectedFolderId;
-        set({ folders, selectedFolderId });
-        return { selectedFolderId, changed: s.selectedFolderId === folderId };
-      })();
-      if (nextSelected.changed)
-        await persistSelection(nextSelected.selectedFolderId);
-    } catch (err) {
-      set({ error: formatError(err) });
-    }
-  },
-  select: async (folderId) => {
-    if (get().selectedFolderId === folderId) return;
-    set({ selectedFolderId: folderId });
-    await persistSelection(folderId);
-  },
-  pickFolder: async () => {
-    try {
-      const client = await getRpcClient();
-      return await Effect.runPromise(client["workspace.pickFolder"]({}));
-    } catch {
-      return null;
-    }
-  },
-  loadGithubContext: async () => {
-    // Mark the recents list as in-flight so the dialog doesn't flash
-    // "no repos" while we're still fetching the first time.
-    set({ recentGithubReposLoading: true });
-    try {
-      const client = await getRpcClient();
-      const [repos, auth] = await Promise.all([
-        Effect.runPromise(client["workspace.listGithubRepos"]({ limit: 30 })),
-        Effect.runPromise(client["workspace.ghAuthStatus"]({})),
-      ]);
-      set({
-        recentGithubRepos: repos,
-        ghAuthenticated: auth.authenticated,
-        recentGithubReposLoading: false,
-      });
-    } catch {
-      set({
-        recentGithubRepos: [],
-        ghAuthenticated: false,
-        recentGithubReposLoading: false,
-      });
-    }
-  },
-  cloneRepo: async (url, parent) => {
-    set({ error: null });
-    try {
-      const client = await getRpcClient();
-      const folder = await Effect.runPromise(
-        client["workspace.cloneRepo"]({ url, parent }),
-      );
-      set((s) => ({
-        folders: [...s.folders, folder],
-        selectedFolderId: folder.id,
-      }));
-      await persistSelection(folder.id);
-      return folder;
-    } catch (err) {
-      return rethrow(err);
-    }
-  },
-  createProject: async ({ name, parent, template, alsoCreateGithubRepo }) => {
-    set({ error: null });
-    try {
-      const client = await getRpcClient();
-      const folder = await Effect.runPromise(
-        client["workspace.createProject"]({
-          name,
-          parent,
-          template,
-          alsoCreateGithubRepo,
-        }),
-      );
-      set((s) => ({
-        folders: [...s.folders, folder],
-        selectedFolderId: folder.id,
-      }));
-      await persistSelection(folder.id);
-      return folder;
-    } catch (err) {
-      return rethrow(err);
-    }
-  },
+			const nextSelected = (() => {
+				const s = get();
+				const folders = s.folders.filter((f) => f.id !== folderId);
+				const selectedFolderId =
+					s.selectedFolderId === folderId
+						? (folders[0]?.id ?? null)
+						: s.selectedFolderId;
+				set({ folders, selectedFolderId });
+				return { selectedFolderId, changed: s.selectedFolderId === folderId };
+			})();
+			if (nextSelected.changed)
+				await persistSelection(nextSelected.selectedFolderId);
+		} catch (err) {
+			set({ error: formatError(err) });
+		}
+	},
+	select: async (folderId) => {
+		if (get().selectedFolderId === folderId) return;
+		set({ selectedFolderId: folderId });
+		await persistSelection(folderId);
+	},
+	pickFolder: async () => {
+		try {
+			const client = await getRpcClient();
+			return await Effect.runPromise(client["workspace.pickFolder"]({}));
+		} catch {
+			return null;
+		}
+	},
+	loadGithubContext: async () => {
+		// Mark the recents list as in-flight so the dialog doesn't flash
+		// "no repos" while we're still fetching the first time.
+		set({ recentGithubReposLoading: true });
+		try {
+			const client = await getRpcClient();
+			const [repos, auth] = await Promise.all([
+				Effect.runPromise(client["workspace.listGithubRepos"]({ limit: 30 })),
+				Effect.runPromise(client["workspace.ghAuthStatus"]({})),
+			]);
+			set({
+				recentGithubRepos: repos,
+				ghAuthenticated: auth.authenticated,
+				recentGithubReposLoading: false,
+			});
+		} catch {
+			set({
+				recentGithubRepos: [],
+				ghAuthenticated: false,
+				recentGithubReposLoading: false,
+			});
+		}
+	},
+	cloneRepo: async (url, parent) => {
+		set({ error: null });
+		try {
+			const client = await getRpcClient();
+			const folder = await Effect.runPromise(
+				client["workspace.cloneRepo"]({ url, parent }),
+			);
+			set((s) => registerFolder(s, folder));
+			await persistSelection(folder.id);
+			return folder;
+		} catch (err) {
+			return rethrow(err);
+		}
+	},
+	createProject: async ({ name, parent, template, alsoCreateGithubRepo }) => {
+		set({ error: null });
+		try {
+			const client = await getRpcClient();
+			const folder = await Effect.runPromise(
+				client["workspace.createProject"]({
+					name,
+					parent,
+					template,
+					alsoCreateGithubRepo,
+				}),
+			);
+			set((s) => registerFolder(s, folder));
+			await persistSelection(folder.id);
+			return folder;
+		} catch (err) {
+			return rethrow(err);
+		}
+	},
 }));

--- a/apps/renderer/test/unit/workspace-store.test.ts
+++ b/apps/renderer/test/unit/workspace-store.test.ts
@@ -1,0 +1,42 @@
+import { Folder, FolderId } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+import { registerFolder } from "../../src/store/workspace.ts";
+
+const folder = (id: string, path: string) =>
+	Folder.make({
+		id: FolderId.make(id),
+		path,
+		name: path.split("/").at(-1) ?? path,
+		addedAt: new Date("2026-08-12T00:00:00.000Z"),
+	});
+
+describe("registerFolder", () => {
+	it("does not append a streamed folder again when the add request resolves", () => {
+		const existing = folder("project-1", "/projects/test");
+		expect(
+			registerFolder({ folders: [existing], selectedFolderId: null }, existing),
+		).toEqual({ folders: [existing], selectedFolderId: existing.id });
+	});
+
+	it("keeps selection aligned when the same path has a canonical existing id", () => {
+		const existing = folder("project-1", "/projects/test");
+		const duplicate = folder("project-2", "/projects/test");
+		expect(
+			registerFolder(
+				{ folders: [existing], selectedFolderId: null },
+				duplicate,
+			),
+		).toEqual({ folders: [existing], selectedFolderId: existing.id });
+	});
+
+	it("appends a different project", () => {
+		const existing = folder("project-1", "/projects/one");
+		const added = folder("project-2", "/projects/two");
+		expect(
+			registerFolder(
+				{ folders: [existing], selectedFolderId: existing.id },
+				added,
+			),
+		).toEqual({ folders: [existing, added], selectedFolderId: added.id });
+	});
+});


### PR DESCRIPTION
## Summary

- Prevent duplicate project entries when the workspace stream races the add response.
- Restore Quick Start through the shared Add Project dialog for sidebar, menu, and keyboard entry points.
- Keep the selected project aligned with the canonical deduplicated project.

## Root cause

The live workspace stream could register a project before the add request returned, after which the client appended the same project again. The global Open Project command also bypassed the setup dialog and opened the folder picker directly.

## Validation

- `bunx biome check` on changed files
- `bun --filter renderer test:unit` (92 files, 462 tests)
- `bun --filter renderer check-types`
- `git diff --check`
