### PR TITLE
Polish project setup actions

### DIFF
--- a/apps/renderer/src/components/environment-path-browser.tsx
+++ b/apps/renderer/src/components/environment-path-browser.tsx
@@ -89,6 +89,13 @@ export function EnvironmentPathBrowser({
 		event.preventDefault();
 		void browse(value);
 	};
+	const changePath = (path: string): void => {
+		// Invalidate an in-flight browse immediately. Otherwise its normalized
+		// response can overwrite a newer path while the user is still typing it.
+		requestGeneration.current += 1;
+		onReadyChange?.(false);
+		onChange(path);
+	};
 
 	const useNativePicker = async (): Promise<void> => {
 		const picked = await pickEnvironmentFolder(environmentId);
@@ -104,7 +111,7 @@ export function EnvironmentPathBrowser({
 				<Input
 					id="project-parent-path"
 					value={value}
-					onChange={(event) => onChange(event.currentTarget.value)}
+					onChange={(event) => changePath(event.currentTarget.value)}
 					placeholder="~/Developer"
 					spellCheck={false}
 					autoComplete="off"

--- a/apps/renderer/src/components/project-setup-dialog.tsx
+++ b/apps/renderer/src/components/project-setup-dialog.tsx
@@ -3,8 +3,8 @@ import type {
 	ProjectTemplate,
 	Folder as WorkspaceFolder,
 } from "@zuse/contracts";
-import { FilePlus2, Folder, GitFork, Lock } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { Check, Folder, Lock } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
 	addEnvironmentFolder,
@@ -51,6 +51,16 @@ const joinPreview = (parent: string, name: string): string => {
 };
 
 const nameValid = (name: string): boolean => /^[a-z0-9][a-z0-9-_]*$/.test(name);
+
+type DitherColor = readonly [red: number, green: number, blue: number];
+
+const DITHER_COLORS = {
+	amber: [255, 150, 50],
+	blue: [53, 143, 243],
+	grey: [92, 92, 100],
+	pink: [255, 30, 86],
+	violet: [150, 110, 255],
+} as const satisfies Record<string, DitherColor>;
 
 export function ProjectSetupDialog({
 	open,
@@ -241,18 +251,24 @@ export function ProjectSetupDialog({
 						{mode === "choose" ? (
 							<div className="grid gap-2 sm:grid-cols-3">
 								<SetupChoice
-									icon={GitFork}
-									label="Clone repository"
-									onClick={() => setMode("clone")}
-								/>
-								<SetupChoice
-									icon={FilePlus2}
+									art="quick"
 									label="Quick start"
+									description="Create from a template"
+									accent="violet"
 									onClick={() => setMode("create")}
 								/>
 								<SetupChoice
-									icon={Folder}
+									art="github"
+									label="Clone repository"
+									description="Clone with Git or GitHub"
+									accent="blue"
+									onClick={() => setMode("clone")}
+								/>
+								<SetupChoice
+									art="folder"
 									label="Existing folder"
+									description="Open a project on disk"
+									accent="amber"
 									onClick={() => setMode("existing")}
 								/>
 							</div>
@@ -342,21 +358,47 @@ export function ProjectSetupDialog({
 								</div>
 								<fieldset className="grid grid-cols-3 gap-2">
 									<legend className="sr-only">Project template</legend>
-									{(["empty", "nextjs", "turborepo"] as const).map((value) => (
-										<button
-											key={value}
-											type="button"
-											onClick={() => setTemplate(value)}
-											aria-pressed={template === value}
-											className={`min-h-11 rounded-lg border px-3 py-2 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring ${template === value ? "border-foreground/30 bg-accent" : "border-border bg-muted/30 hover:bg-accent/60"}`}
-										>
-											{value === "empty"
+									{(["empty", "nextjs", "turborepo"] as const).map((value) => {
+										const label =
+											value === "empty"
 												? "Empty"
 												: value === "nextjs"
 													? "Next.js"
-													: "Turborepo"}
-										</button>
-									))}
+													: "Turborepo";
+										const ditherColor: DitherColor =
+											value === "turborepo"
+												? DITHER_COLORS.pink
+												: value === "nextjs"
+													? DITHER_COLORS.blue
+													: DITHER_COLORS.grey;
+										const selected = template === value;
+										const selectedClass =
+											value === "turborepo"
+												? "border-[#ff1e56]/70 bg-[#ff1e56]/[0.07] ring-1 ring-inset ring-[#ff1e56]/30"
+												: value === "nextjs"
+													? "border-sky-400/70 bg-sky-400/[0.07] ring-1 ring-inset ring-sky-400/30"
+													: "border-foreground/60 bg-foreground/[0.04] ring-1 ring-inset ring-foreground/25";
+										return (
+											<button
+												key={value}
+												type="button"
+												onClick={() => setTemplate(value)}
+												aria-pressed={selected}
+												className={`group relative isolate flex min-h-11 items-center justify-center gap-2 overflow-hidden rounded-lg border px-3 py-2 text-xs outline-none transition-[border-color,background-color,box-shadow] duration-150 focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none ${selected ? selectedClass : "border-border"}`}
+											>
+												<DitherField color={ditherColor} active={selected} />
+												<span className="relative flex items-center gap-2">
+													<TemplateLogo template={value} />
+													<span>{label}</span>
+												</span>
+												{selected ? (
+													<span className="absolute right-2 flex size-4 items-center justify-center rounded-full bg-background/80 shadow-sm ring-1 ring-current/20">
+														<Check aria-hidden="true" className="size-2.5" />
+													</span>
+												) : null}
+											</button>
+										);
+									})}
 								</fieldset>
 								<div className="flex min-h-11 items-center gap-2 text-xs">
 									<CheckboxInput
@@ -443,22 +485,241 @@ export function ProjectSetupDialog({
 }
 
 function SetupChoice({
-	icon: Icon,
+	art,
 	label,
+	description,
+	accent,
 	onClick,
 }: {
-	readonly icon: typeof Folder;
+	readonly art: "quick" | "github" | "folder";
 	readonly label: string;
+	readonly description: string;
+	readonly accent: "violet" | "blue" | "amber";
 	readonly onClick: () => void;
 }) {
+	const accentClass = {
+		violet:
+			"hover:border-violet-500/30 hover:bg-violet-500/[0.04] [--choice-accent:theme(colors.violet.500)]",
+		blue: "hover:border-sky-500/30 hover:bg-sky-500/[0.04] [--choice-accent:theme(colors.sky.500)]",
+		amber:
+			"hover:border-amber-500/30 hover:bg-amber-500/[0.04] [--choice-accent:theme(colors.amber.500)]",
+	}[accent];
 	return (
 		<button
 			type="button"
 			onClick={onClick}
-			className="flex min-h-24 flex-col items-start justify-between rounded-xl border border-border bg-muted/30 p-3 text-left text-xs font-medium outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+			className={`group flex min-h-40 flex-col overflow-hidden rounded-xl border border-border bg-muted/20 text-left outline-none transition-[border-color,background-color] duration-150 focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none ${accentClass}`}
 		>
-			<Icon className="size-4 text-muted-foreground" />
-			{label}
+			<AsciiProjectArt variant={art} accent={accent} />
+			<span className="flex w-full flex-col gap-0.5 border-t border-border/70 px-3 py-2.5">
+				<span className="text-xs font-medium text-foreground">{label}</span>
+				<span className="text-[10px] font-normal text-muted-foreground">
+					{description}
+				</span>
+			</span>
 		</button>
+	);
+}
+
+function AsciiProjectArt({
+	variant,
+	accent,
+}: {
+	readonly variant: "quick" | "github" | "folder";
+	readonly accent: "violet" | "blue" | "amber";
+}) {
+	const color: DitherColor =
+		accent === "violet"
+			? DITHER_COLORS.violet
+			: accent === "blue"
+				? DITHER_COLORS.blue
+				: DITHER_COLORS.amber;
+	return (
+		<span
+			aria-hidden="true"
+			className="relative flex min-h-24 w-full flex-1 items-center justify-center overflow-hidden bg-muted/30 text-foreground/75"
+		>
+			<DitherField color={color} />
+			{variant === "quick" ? (
+				<span className="relative flex items-center gap-3">
+					<NextJsLogo className="size-10 transition-colors duration-150 group-hover:text-foreground motion-reduce:transition-none" />
+					<span className="h-8 w-px bg-border" />
+					<TurborepoLogo className="size-10 text-muted-foreground transition-colors duration-150 group-hover:text-[#ff1e56] motion-reduce:transition-none" />
+				</span>
+			) : variant === "github" ? (
+				<GitHubLogo className="relative size-11 transition-colors duration-150 group-hover:text-[#6e40c9] motion-reduce:transition-none" />
+			) : (
+				<Folder className="relative size-11 fill-current stroke-[1.25] text-muted-foreground transition-colors duration-150 group-hover:text-amber-500 motion-reduce:transition-none" />
+			)}
+		</span>
+	);
+}
+
+const BAYER_4 = [
+	[0, 8, 2, 10],
+	[12, 4, 14, 6],
+	[3, 11, 1, 9],
+	[15, 7, 13, 5],
+] as const;
+
+function DitherField({
+	color,
+	active = false,
+}: {
+	readonly color: DitherColor;
+	readonly active?: boolean;
+}) {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		const button = canvas?.closest("button");
+		const context = canvas?.getContext("2d");
+		if (canvas == null || button == null || context == null) return;
+
+		let columns = 0;
+		let rows = 0;
+		const restingIntensity = active ? 0.65 : 0;
+		let intensity = restingIntensity;
+		let target = restingIntensity;
+		let hovered = false;
+		let animationFrame = 0;
+		const reducedMotion = window.matchMedia?.(
+			"(prefers-reduced-motion: reduce)",
+		).matches;
+
+		const paint = (): void => {
+			context.clearRect(0, 0, columns, rows);
+			for (let y = 0; y < rows; y += 1) {
+				const density = 0.25 + 0.75 * ((y + 0.5) / rows);
+				for (let x = 0; x < columns; x += 1) {
+					const threshold = (BAYER_4[y & 3]?.[x & 3] ?? 0) / 16;
+					const lit = density > threshold - 0.1 * intensity;
+					const strength = (0.3 + density * 0.7) * (1 + 0.22 * intensity);
+					const alpha = Math.min(1, lit ? strength : strength * 0.4);
+					context.fillStyle = `rgba(${Math.round(color[0] * strength)}, ${Math.round(color[1] * strength)}, ${Math.round(color[2] * strength)}, ${alpha})`;
+					context.fillRect(x, y, 1, 1);
+				}
+			}
+		};
+
+		const tick = (): void => {
+			const distance = target - intensity;
+			if (Math.abs(distance) < 0.01) {
+				intensity = target;
+				paint();
+				animationFrame = 0;
+				return;
+			}
+			intensity += distance * 0.16;
+			paint();
+			animationFrame = window.requestAnimationFrame(tick);
+		};
+		const setTarget = (next: number): void => {
+			target = next;
+			if (reducedMotion) {
+				intensity = next;
+				paint();
+			} else if (animationFrame === 0) {
+				animationFrame = window.requestAnimationFrame(tick);
+			}
+		};
+		const resize = (): void => {
+			const bounds = button.getBoundingClientRect();
+			columns = Math.max(4, Math.round(bounds.width / 2));
+			rows = Math.max(4, Math.round(bounds.height / 2));
+			canvas.width = columns;
+			canvas.height = rows;
+			paint();
+		};
+		const enter = (): void => {
+			hovered = true;
+			setTarget(1);
+		};
+		const leave = (): void => {
+			hovered = false;
+			setTarget(restingIntensity);
+		};
+		const down = (): void => setTarget(1.5);
+		const up = (): void => setTarget(hovered ? 1 : restingIntensity);
+
+		resize();
+		button.addEventListener("pointerenter", enter);
+		button.addEventListener("pointerleave", leave);
+		button.addEventListener("pointerdown", down);
+		button.addEventListener("pointerup", up);
+		button.addEventListener("pointercancel", up);
+		const resizeObserver = new ResizeObserver(resize);
+		resizeObserver.observe(button);
+
+		return () => {
+			if (animationFrame !== 0) window.cancelAnimationFrame(animationFrame);
+			button.removeEventListener("pointerenter", enter);
+			button.removeEventListener("pointerleave", leave);
+			button.removeEventListener("pointerdown", down);
+			button.removeEventListener("pointerup", up);
+			button.removeEventListener("pointercancel", up);
+			resizeObserver.disconnect();
+		};
+	}, [active, color]);
+
+	return (
+		<canvas
+			ref={canvasRef}
+			className="pointer-events-none absolute inset-0 h-full w-full opacity-45"
+			style={{ imageRendering: "pixelated" }}
+		/>
+	);
+}
+
+function GitHubLogo({ className }: { readonly className?: string }) {
+	return (
+		<svg
+			aria-hidden="true"
+			className={className}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+		>
+			<path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+		</svg>
+	);
+}
+
+function TemplateLogo({ template }: { readonly template: ProjectTemplate }) {
+	if (template === "nextjs") return <NextJsLogo className="size-4" />;
+	if (template === "turborepo") {
+		return <TurborepoLogo className="size-4 text-[#ff1e56]" />;
+	}
+	return (
+		<span
+			aria-hidden="true"
+			className="size-4 rounded-[4px] border border-current opacity-70"
+		/>
+	);
+}
+
+function NextJsLogo({ className }: { readonly className?: string }) {
+	return (
+		<svg
+			aria-hidden="true"
+			className={className}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+		>
+			<path d="M18.665 21.978A11.94 11.94 0 0 1 12 24C5.377 24 0 18.623 0 12S5.377 0 12 0s12 5.377 12 12c0 3.583-1.574 6.801-4.067 9.001L9.219 7.2H7.2v9.596h1.615V9.251l9.85 12.727Zm-3.332-8.533 1.6 2.061V7.2h-1.6v6.245Z" />
+		</svg>
+	);
+}
+
+function TurborepoLogo({ className }: { readonly className?: string }) {
+	return (
+		<svg
+			aria-hidden="true"
+			className={className}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+		>
+			<path d="M11.991 4.196A7.802 7.802 0 1 0 19.789 12a7.81 7.81 0 0 0-7.798-7.804Zm0 11.843A4.039 4.039 0 1 1 16.026 12a4.042 4.042 0 0 1-4.035 4.039Zm.653-13.125V0C18.973.339 24 5.582 24 12s-5.027 11.66-11.356 12v-2.914c4.717-.337 8.452-4.281 8.452-9.086s-3.735-8.749-8.452-9.086ZM5.113 17.959a9.08 9.08 0 0 1-2.2-5.305H0a11.95 11.95 0 0 0 3.051 7.367l2.062-2.062ZM11.337 24v-2.914a9.08 9.08 0 0 1-5.302-2.202l-2.06 2.063A11.96 11.96 0 0 0 11.337 24Z" />
+		</svg>
 	);
 }

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -395,6 +395,9 @@ export function ProjectsSidebar() {
 	const activeEnvironmentId = useEnvironmentCatalogStore(
 		(s) => s.activeEnvironmentId,
 	);
+	const initializeEnvironmentCatalog = useEnvironmentCatalogStore(
+		(s) => s.initialize,
+	);
 
 	const sessionsByProject = useSessionsStore((s) => s.sessionsByProject);
 
@@ -408,6 +411,15 @@ export function ProjectsSidebar() {
 	useEffect(() => {
 		void load();
 	}, [load]);
+
+	const desktopCatalogEnabled = window.zuse?.ssh !== undefined;
+
+	useEffect(() => {
+		if (!desktopCatalogEnabled) return;
+		void initializeEnvironmentCatalog().catch((cause) =>
+			console.error("[zuse] environment catalog initialize failed", cause),
+		);
+	}, [desktopCatalogEnabled, initializeEnvironmentCatalog]);
 
 	// Auto-expand the selected project so newly opened workspaces immediately
 	// reveal their session list.
@@ -461,7 +473,9 @@ export function ProjectsSidebar() {
 		onToggleKey(environmentProjectKey(environmentId, id));
 	};
 
-	const desktopCatalogEnabled = window.zuse?.ssh !== undefined;
+	const showComputerControls =
+		desktopCatalogEnabled &&
+		catalogEntries.filter((entry) => entry.status === "connected").length > 1;
 
 	// One merged timeline: computers never form sections. The same repo across
 	// machines collapses into one logical group; the computer is a row property.
@@ -504,17 +518,19 @@ export function ProjectsSidebar() {
 				</Suspense>
 			)}
 			<SidebarActions />
-			<div className="flex items-center justify-between px-2.5 py-1.5 text-[12px] text-muted-foreground">
-				<span>{desktopCatalogEnabled ? "Computers" : "Projects"}</span>
-				{desktopCatalogEnabled ? (
+			{showComputerControls ? (
+				<div className="flex items-center justify-between px-2.5 py-1.5 text-[12px] text-muted-foreground">
+					<span>Computers</span>
 					<Suspense fallback={<span className="size-8" />}>
 						<ComputerSwitcher />
 					</Suspense>
-				) : (
-					<ProjectAddMenu />
-				)}
+				</div>
+			) : null}
+			<div className="flex items-center justify-between px-2.5 py-1.5 text-[12px] text-muted-foreground">
+				<span>Projects</span>
+				<ProjectAddMenu />
 			</div>
-			{desktopCatalogEnabled ? (
+			{showComputerControls ? (
 				<CatalogConnectionNotice entries={catalogEntries} />
 			) : null}
 			<SidebarErrorToasts />


### PR DESCRIPTION
## What changed

- restore the Projects add control and setup-dialog host in the desktop sidebar
- show computer controls only when multiple computers are connected
- refresh the project setup chooser with branded template marks and irregular, color-aware dither treatments
- preserve user-entered folder paths while asynchronous directory browsing is in flight

## Why

The computer control had replaced the project add control on desktop. The global New Project command could update dialog state, but no dialog host was mounted, so the action appeared broken and Quick Start was inaccessible. The path browser could also apply an older normalized response over a newer value while the user was typing.

## Impact

New Project and Quick Start are accessible again, the sidebar stays focused when only one computer is live, setup choices are easier to scan, and absolute paths such as `/projects` are no longer overwritten by stale browse responses.

## Validation

- `bunx biome check apps/renderer/src/components/environment-path-browser.tsx apps/renderer/src/components/project-setup-dialog.tsx apps/renderer/src/components/projects-sidebar.tsx`
- `bun --filter renderer check-types`
- `bun --filter renderer test:unit` (92 files, 462 tests)
- `git diff --check`
