### PR TITLE
Release v0.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.3]
+
+### Changed
+- Performance diagnostics now use readable dithered charts with hover values and restrained motion
+
+### Fixed
+- Restored New Project and Quick Start from the desktop sidebar, while preventing in-progress folder lookups from overwriting newer paths
+- Agent permission requests now work reliably for Kiro and Grok while honoring Zuse's permission modes and policies
+
 ## [0.18.2]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.18.2",
+	"version": "0.18.3",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.18.3",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Performance diagnostics now use readable dithered charts with hover values and restrained motion"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Restored New Project and Quick Start from the desktop sidebar, while preventing in-progress folder lookups from overwriting newer paths",
+          "Agent permission requests now work reliably for Kiro and Grok while honoring Zuse's permission modes and policies"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.18.2",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.18.2",
+      "version": "0.18.3",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.18.3 with release notes grouped by user-visible outcome.

### Changed
- Performance diagnostics now use readable dithered charts with hover values and restrained motion

### Fixed
- Restored New Project and Quick Start from the desktop sidebar, while preventing in-progress folder lookups from overwriting newer paths
- Agent permission requests now work reliably for Kiro and Grok while honoring Zuse's permission modes and policies

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.18.3 after this PR lands.