### PR TITLE
Fix MCP session replacement auth race

### DIFF
--- a/packages/agents/src/mcp-gateway/index.ts
+++ b/packages/agents/src/mcp-gateway/index.ts
@@ -513,18 +513,28 @@ export const issueMcpGatewaySession = async (
 			bearer_token_env_var: "ZUSE_MCP_TOKEN",
 			enabled: true,
 		},
-		close: () => revokeMcpGatewaySession(input.sessionId),
+		close: () => revokeMcpGatewaySessionRecord(input.sessionId, hash),
 	};
+};
+
+const revokeMcpGatewaySessionRecord = async (
+	sessionId: string,
+	expectedTokenHash?: string,
+): Promise<void> => {
+	const record = recordsBySession.get(sessionId);
+	if (
+		record === undefined ||
+		(expectedTokenHash !== undefined && record.tokenHash !== expectedTokenHash)
+	) {
+		return;
+	}
+	recordsBySession.delete(sessionId);
+	recordsByHash.delete(record.tokenHash);
 };
 
 export const revokeMcpGatewaySession = async (
 	sessionId: string,
-): Promise<void> => {
-	const record = recordsBySession.get(sessionId);
-	if (record === undefined) return;
-	recordsBySession.delete(sessionId);
-	recordsByHash.delete(record.tokenHash);
-};
+): Promise<void> => revokeMcpGatewaySessionRecord(sessionId);
 
 export const revokeAllMcpGatewaySessions = async (): Promise<void> => {
 	recordsBySession.clear();

--- a/packages/agents/test/integration/mcp-gateway.test.ts
+++ b/packages/agents/test/integration/mcp-gateway.test.ts
@@ -144,6 +144,50 @@ describe("MCP gateway", () => {
 		).toBe(401);
 	});
 
+	test("an obsolete session handle cannot revoke its replacement", async () => {
+		const first = await issueMcpGatewaySession({
+			sessionId: "replacement-test",
+			scopes: { browser: false, orchestration: true },
+			ctx: {
+				orchestration: {
+					deps: baseDeps,
+					requestPermission: async () => ({ _tag: "AllowOnce" }),
+					getRuntimeMode: () => "full-access",
+					getPermissionMode: () => "default",
+				},
+			},
+		});
+		const replacement = await issueMcpGatewaySession({
+			sessionId: "replacement-test",
+			scopes: { browser: false, orchestration: true },
+			ctx: {
+				orchestration: {
+					deps: baseDeps,
+					requestPermission: async () => ({ _tag: "AllowOnce" }),
+					getRuntimeMode: () => "full-access",
+					getPermissionMode: () => "default",
+				},
+			},
+		});
+
+		await first.close();
+
+		expect(
+			(await callTool(replacement.endpoint, replacement.token, "whoami", {}))
+				.status,
+		).toBe(200);
+		expect(
+			(
+				await callTool(
+					replacement.endpoint,
+					replacement.token,
+					"list_threads",
+					{},
+				)
+			).status,
+		).toBe(200);
+	});
+
 	test("returns 404 for unknown paths", async () => {
 		const issued = await issueMcpGatewaySession({
 			sessionId: "scope-test",


### PR DESCRIPTION
## Summary

- prevent obsolete provider handles from revoking a replacement MCP gateway session
- keep orchestration identity and thread tools authenticated through same-session restarts
- cover the replacement lifecycle with an integration regression test

## Root cause

MCP gateway cleanup revoked records by session ID alone. When a replacement token was issued before an older provider handle finished closing, the obsolete handle deleted the new token and subsequent tool calls returned HTTP 401. Cleanup now verifies token ownership before revocation.

## Validation

- `bun --filter @zuse/agents test:integration`
- `bun run check-types`
- `bunx biome check packages/agents/src/mcp-gateway/index.ts packages/agents/test/integration/mcp-gateway.test.ts`