### PR TITLE
Release v0.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.4]
+
+### Fixed
+- Kept built-in MCP tools authenticated when a running chat replaces its provider session, so orchestration can continue in the same chat without re-authenticating or starting over
+
 ## [0.18.3]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.18.3",
+	"version": "0.18.4",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.18.4",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Kept built-in MCP tools authenticated when a running chat replaces its provider session, so orchestration can continue in the same chat without re-authenticating or starting over"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.18.3",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.18.3",
+      "version": "0.18.4",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Fixed

- Kept built-in MCP tools authenticated when a running chat replaces its provider session, so orchestration can continue in the same chat without re-authenticating or starting over.

## Validation

- `bun run check-types`