### PR TITLE
Add agent orchestration CLI

### DIFF
--- a/apps/desktop/resources/skills/zuse/SKILL.md
+++ b/apps/desktop/resources/skills/zuse/SKILL.md
@@ -132,6 +132,12 @@ Zuse's CLI uses the same project → workspace → chat → session model as MCP
 - `zuse session create --chat <id>` adds a session tab to an existing chat.
 - `zuse session send|read|mode|interrupt|resume --session <id>` operates on a
   specific provider conversation.
+- `zuse session model --session <id> --model <id>` changes only the model.
+  `session provider` is separate and only works before the first user message.
+- `zuse session fork --session <id> --message <id>` branches from any message
+  into a same-chat tab or a different chat. New-chat forks create a fresh
+  isolated worktree by default.
+- `zuse session transcript|plan --session <id>` retrieves handoff context.
 - `zuse thread create` aliases `chat create`; other `thread` actions alias the
   corresponding `session` action.
 
@@ -151,6 +157,15 @@ Context can be attached while creating a chat or session, or while sending:
 - `--file <project-relative-path>` adds a file or directory reference.
 - `--linear <issue-id>` adds prepared issue context; use
   `--linear-workspace <id>` when needed to disambiguate the workspace.
+- `--transcript <session-id>` exports another session and attaches it as a
+  Markdown context file. Add `--through-message <id>` to stop at a fork point.
+- `--plan <session-id>` attaches that session's latest proposed plan.
+
+For interactive parity, use `session plan-respond` to approve, cancel, or
+abandon a pending plan; `session answer` for pending agent questions; and the
+`session queue-*` commands for durable queued messages. Rename, archive,
+unarchive, delete, and workspace operations are also available. Deletion
+requires `--confirm`.
 
 Set the session posture with `--permission default|plan|accept-edits` and
 `--runtime approval-required|auto-accept-edits|auto-accept-edits-and-bash|full-access`.

--- a/apps/desktop/resources/skills/zuse/SKILL.md
+++ b/apps/desktop/resources/skills/zuse/SKILL.md
@@ -176,3 +176,9 @@ The default target is the local Zuse RPC server. For another connected
 computer, pass `--computer <id> --ws-url <url>` and `--token <token>` when the
 endpoint is protected. Do not print or persist tokens in logs, prompts, or
 committed files.
+
+Inside a `bun dev` repository, use the branch-local CLI source. It automatically
+discovers the active dev instance through its owner-readable, gitignored
+`.zuse/dev-instances/<instance>/cli-access.json` descriptor, including shifted
+ports and protected local RPC authentication. Do not read or print the
+descriptor yourself; let the CLI consume it.

--- a/apps/desktop/resources/skills/zuse/SKILL.md
+++ b/apps/desktop/resources/skills/zuse/SKILL.md
@@ -100,3 +100,64 @@ expected smoke flow is:
 
 If `zuse-orchestration` is not available, report that autonomy tools are not
 registered for this session instead of silently using another provider feature.
+
+## Agent CLI
+
+Use the `zuse` CLI when orchestration must run from a terminal, script, CI job,
+or an agent that does not have the in-session `zuse-orchestration` MCP server.
+The CLI emits exactly one JSON envelope on stdout, including failures. Discover
+the supported surface before automating it:
+
+```bash
+zuse commands
+zuse computer list
+zuse project list
+zuse model list
+```
+
+The object shape is stable and machine-readable:
+
+```json
+{"schemaVersion":1,"ok":true,"data":{}}
+```
+
+Failures set a non-zero exit code and return `ok: false` with an error `code`,
+`message`, and optional `details`. Check both the exit code and `ok`; never treat
+the presence of JSON as proof that a mutation succeeded.
+
+Zuse's CLI uses the same project → workspace → chat → session model as MCP:
+
+- `zuse chat create` creates a sidebar chat and selects `--workspace fresh`,
+  `main`, or an existing worktree ID.
+- `zuse session create --chat <id>` adds a session tab to an existing chat.
+- `zuse session send|read|mode|interrupt|resume --session <id>` operates on a
+  specific provider conversation.
+- `zuse thread create` aliases `chat create`; other `thread` actions alias the
+  corresponding `session` action.
+
+Resolve IDs with `chat list` and `session list` instead of guessing. Select a
+project by ID, exact name, or path with `--project`; it is only inferred when
+the current directory identifies exactly one registered project. Use
+`--provider` and `--model` after checking `model list`.
+
+For agent-safe input, prefer `--input-json '<object>'` or
+`--input-json @request.json`. Use `--prompt-file -` to read a prompt from stdin.
+Creation commands accept `--idempotency-key` so retrying after an uncertain
+transport result does not intentionally create duplicate work.
+
+Context can be attached while creating a chat or session, or while sending:
+
+- `--attach <path>` uploads an image; repeat it for multiple images.
+- `--file <project-relative-path>` adds a file or directory reference.
+- `--linear <issue-id>` adds prepared issue context; use
+  `--linear-workspace <id>` when needed to disambiguate the workspace.
+
+Set the session posture with `--permission default|plan|accept-edits` and
+`--runtime approval-required|auto-accept-edits|auto-accept-edits-and-bash|full-access`.
+Changing modes does not broaden the user's authorization for external or
+destructive actions.
+
+The default target is the local Zuse RPC server. For another connected
+computer, pass `--computer <id> --ws-url <url>` and `--token <token>` when the
+endpoint is protected. Do not print or persist tokens in logs, prompts, or
+committed files.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3063,6 +3063,14 @@ async function createMainWindow() {
 						}
 					},
 				},
+				...(isDevelopment && process.env.ZUSE_DEV_CLI_ACCESS_FILE
+					? {
+							devCliAccess: {
+								path: process.env.ZUSE_DEV_CLI_ACCESS_FILE,
+								wsUrl: `ws://127.0.0.1:${relayWsPort}/rpc`,
+							},
+						}
+					: {}),
 			}),
 		).pipe(
 			Effect.catchCause((cause) =>

--- a/apps/docs/content/docs/composer/orchestration.mdx
+++ b/apps/docs/content/docs/composer/orchestration.mdx
@@ -6,7 +6,7 @@ order: 54
 platforms: [desktop, browser, mobile]
 providers: [claude, codex, grok, gemini]
 prerequisites: [/concepts/project-chat-session, /composer/modes-permissions]
-related: [/composer/subagents, /composer/modes-permissions, /composer/parallel-agents, /composer/monitor-delegated-work]
+related: [/composer/subagents, /composer/modes-permissions, /serve/agent-cli, /composer/parallel-agents, /composer/monitor-delegated-work]
 next: /composer/parallel-agents
 lastVerified: latest
 ---
@@ -47,6 +47,8 @@ For example:
 > Split this into an isolated implementation task and a same-checkout review tab. The implementation owns the parser and focused tests. The reviewer is read-only until the implementation reports back. Bring both results here, resolve disagreements, and show me the final verification before any pull request action.
 
 Zuse surfaces creation in the parent timeline. Use **Open chat** to inspect the delegated conversation directly. The coordinating agent can also read recent progress and deliver attributed follow-up instructions without copying the entire transcript by hand.
+
+For orchestration from a shell, automation, or an agent without the in-session MCP server, use the [agent CLI](/serve/agent-cli/). It exposes the same chat and session boundaries with structured JSON output, computer targeting, model selection, modes, and context attachments.
 
 ## Keep one integrator
 

--- a/apps/docs/content/docs/serve/agent-cli.mdx
+++ b/apps/docs/content/docs/serve/agent-cli.mdx
@@ -88,6 +88,49 @@ zuse session create \
 
 `thread create` aliases `chat create`. Other `thread` actions alias the corresponding session action. Prefer the explicit `chat` and `session` names in new automation because they preserve the application topology.
 
+## Change models and providers
+
+Changing a model does not change the provider:
+
+```bash
+zuse session model --project <project-id> --session <session-id> --model <model-id>
+```
+
+Provider switching is a distinct operation and requires a model from the new provider:
+
+```bash
+zuse session provider --project <project-id> --session <session-id> --provider claude --model <model-id>
+```
+
+Provider switching is accepted only before the session has its first user message. A mid-conversation provider change would discard provider-native context, so create a fork with the new provider when you need to hand an active conversation to another provider.
+
+## Fork from any message
+
+Use a message ID returned by `session read`. Fork into another tab in the source chat:
+
+```bash
+zuse session fork \
+  --project <project-id> \
+  --session <source-session-id> \
+  --message <message-id> \
+  --destination tab \
+  --title "Alternative approach"
+```
+
+Or create another chat and fresh isolated workspace, optionally selecting a different provider and model:
+
+```bash
+zuse session fork \
+  --project <project-id> \
+  --session <source-session-id> \
+  --message <message-id> \
+  --destination chat \
+  --provider codex \
+  --model <model-id>
+```
+
+New-chat forks create a fresh worktree by default, matching the graphical chat. Use `--workspace main` for the main checkout or `--workspace <worktree-id>` for an existing worktree. If fork creation fails after allocating a fresh worktree, the CLI attempts to remove that unused worktree. If the fork is at the source transcript's tail and the provider supports native continuation, the result reports `forkMode: "resume"`. Other forks report `forkMode: "copy"` and import the visible transcript through the selected message. The source may be any session in the selected project; it does not need to be the currently active chat.
+
 ## Send, interrupt, and resume
 
 ```bash
@@ -125,6 +168,99 @@ zuse session send \
 ```
 
 `--attach` uploads supported image files. `--file` accepts a project-relative file or directory and rejects paths outside the selected project. `--linear` resolves an exact issue identifier or ID and prepares its available context. Warnings from context preparation are returned in the success envelope.
+
+### Transcript and plan handoffs
+
+Retrieve transcript Markdown, optionally ending at a specific message:
+
+```bash
+zuse session transcript --project <project-id> --session <source-session-id>
+zuse session transcript --project <project-id> --session <source-session-id> --through-message <message-id>
+```
+
+Retrieve the most recent proposed plan:
+
+```bash
+zuse session plan --project <project-id> --session <planning-session-id>
+```
+
+To hand either artifact to another agent, attach it directly to any chat-create, session-create, session-send, or queue-add/update command:
+
+```bash
+zuse session send \
+  --project <project-id> \
+  --session <target-session-id> \
+  --message "Continue from these handoff materials." \
+  --transcript <source-session-id> \
+  --plan <planning-session-id>
+```
+
+Zuse exports each artifact to a Markdown file under the target workspace's gitignored `.context/files/` directory and sends it through the normal file-reference pipeline. Repeat `--transcript` or `--plan` to combine handoffs. `--through-message` applies to exported transcript attachments.
+
+## Plans and interactive questions
+
+Respond to a pending plan-review tool call:
+
+```bash
+zuse session plan-respond \
+  --project <project-id> \
+  --session <session-id> \
+  --tool-call <tool-call-id> \
+  --outcome approved
+```
+
+Outcomes are `approved`, `cancelled`, and `abandoned`. Add `--feedback <text>` when the outcome needs explanation.
+
+Answer a pending agent question using the question and option indexes returned by the session event:
+
+```bash
+zuse session answer \
+  --project <project-id> \
+  --session <session-id> \
+  --item <item-id> \
+  --answers-json '[{"questionIndex":0,"selected":[1]}]'
+```
+
+Each answer may include `other` text. The command resolves the same pending interaction shown by the graphical chat.
+
+## Durable message queue
+
+Use the session queue while an agent is running or when follow-up order matters:
+
+```bash
+zuse session queue-list --project <project-id> --session <session-id>
+zuse session queue-add --project <project-id> --session <session-id> --message "Run integration tests."
+zuse session queue-update --project <project-id> --session <session-id> --queue <queue-id> --message "Run focused integration tests."
+zuse session queue-delete --project <project-id> --session <session-id> --queue <queue-id>
+zuse session queue-reorder --project <project-id> --session <session-id> --queue <first-id> --queue <second-id>
+zuse session queue-run-next --project <project-id> --session <session-id> --queue <queue-id>
+zuse session queue-flush --project <project-id> --session <session-id>
+zuse session queue-resume --project <project-id> --session <session-id>
+```
+
+Queue add and update accept the same `--attach`, `--file`, `--linear`, `--transcript`, and `--plan` context options as a direct send. Use `--draft` to add an item that is not ready and `--no-flush` to prevent immediate idle auto-flush.
+
+## Rename, archive, and delete
+
+Chat and session lifecycle actions mirror their graphical equivalents:
+
+```bash
+zuse chat rename --project <project-id> --chat <chat-id> --title "New title"
+zuse chat archive --project <project-id> --chat <chat-id>
+zuse chat unarchive --project <project-id> --chat <chat-id>
+zuse session rename --project <project-id> --session <session-id> --title "Review"
+zuse session archive --project <project-id> --session <session-id>
+zuse session unarchive --project <project-id> --session <session-id>
+```
+
+Move an unstarted chat to the main checkout or another existing worktree with `chat workspace --workspace main|<worktree-id>`. Started chats remain locked to their workspace.
+
+Deletion is irreversible through the CLI and therefore requires explicit confirmation:
+
+```bash
+zuse chat delete --project <project-id> --chat <chat-id> --confirm
+zuse session delete --project <project-id> --session <session-id> --confirm
+```
 
 ## JSON input and stdin
 

--- a/apps/docs/content/docs/serve/agent-cli.mdx
+++ b/apps/docs/content/docs/serve/agent-cli.mdx
@@ -283,7 +283,11 @@ Use an idempotency key for creation commands whenever a transport failure might 
 
 `--project` accepts a project ID, exact name, or path. Zuse infers it only when the current directory belongs to exactly one registered project; otherwise the error response includes candidates.
 
-The CLI targets the local Zuse RPC server by default. To target another connected computer, first list computers, then provide its connection endpoint:
+The CLI targets the local Zuse RPC server by default. When run from a repository using `bun dev`, the development desktop publishes its selected port and a dedicated credential to an owner-readable, gitignored `.zuse/dev-instances/<instance>/cli-access.json` descriptor. The branch-local CLI discovers it automatically, including when concurrent dev instances shifted away from port `8788`. It never prints the credential.
+
+Explicit `--ws-url`/`--token` options and `ZUSE_WS_URL`/`ZUSE_TOKEN` override development discovery. Outside a development checkout, the conventional installed-desktop endpoint remains the fallback.
+
+To target another connected computer, first list computers, then provide its connection endpoint:
 
 ```bash
 zuse computer list
@@ -294,7 +298,7 @@ zuse session list \
   --project <project-id>
 ```
 
-`ZUSE_WS_URL`, `ZUSE_TOKEN`, and `ZUSE_PORT` are available for controlled automation environments. Do not print tokens, embed them in prompts, or commit them to the repository. Prefer environment-based secret injection where shell-history exposure matters.
+`ZUSE_WS_URL`, `ZUSE_TOKEN`, `ZUSE_PORT`, `ZUSE_DEV_INSTANCE`, and `ZUSE_DEV_CLI_ACCESS_FILE` are available for controlled automation environments. Do not print tokens, embed them in prompts, or commit them to the repository. Prefer environment-based secret injection where shell-history exposure matters.
 
 ## Reliable automation sequence
 

--- a/apps/docs/content/docs/serve/agent-cli.mdx
+++ b/apps/docs/content/docs/serve/agent-cli.mdx
@@ -1,0 +1,172 @@
+---
+title: "Agent CLI"
+description: "Control Zuse chats and sessions from scripts with structured JSON output."
+section: "Serve CLI"
+order: 5
+platforms: [serve, desktop]
+providers: [claude, codex, grok, gemini, opencode]
+prerequisites: [/serve, /concepts/project-chat-session]
+related: [/composer/orchestration, /composer/modes-permissions, /composer/context-attachments, /serve/command-reference]
+next: /composer/orchestration
+lastVerified: latest
+---
+
+
+The agent CLI controls Zuse from a terminal or automation process. It can discover computers, projects, and models; create and inspect chats and sessions; send messages; change modes; interrupt or resume work; and attach files, images, or issue context.
+
+Install the published executable globally for the examples below:
+
+<Command>npm install --global @zusehq/serve</Command>
+
+Run `npx @zusehq/serve` instead of `zuse` if you prefer an installless invocation.
+
+## Discover the surface
+
+Start with read-only discovery:
+
+```bash
+zuse commands
+zuse computer list
+zuse project list
+zuse model list
+```
+
+`zuse commands` returns the supported command manifest. List projects and models before creating work so automation uses IDs and choices returned by the connected server.
+
+## JSON contract
+
+Every agent command writes exactly one JSON object to standard output. Success uses:
+
+```json
+{"schemaVersion":1,"ok":true,"data":{}}
+```
+
+A failure writes a structured error and exits non-zero:
+
+```json
+{"schemaVersion":1,"ok":false,"error":{"code":"project_required","message":"--project is required when the project cannot be inferred uniquely.","details":{"candidates":[]}}}
+```
+
+Exit code `2` means invalid input, `3` means authentication or connection authorization failed, and other failures exit `1`. Automation must check both the process exit code and the `ok` field. Receiving parseable JSON does not mean a mutation succeeded.
+
+## Chats and sessions
+
+A chat is a sidebar item tied to a project and workspace. A session is one provider conversation tab inside a chat.
+
+```bash
+zuse chat list --project <project-id>
+zuse chat get --project <project-id> --chat <chat-id>
+zuse session list --project <project-id> --chat <chat-id>
+zuse session get --project <project-id> --session <session-id>
+zuse session read --project <project-id> --session <session-id> --limit 20
+```
+
+Create an isolated workspace and start its first session:
+
+```bash
+zuse chat create \
+  --project <project-id> \
+  --workspace fresh \
+  --title "Implement parser" \
+  --provider codex \
+  --model <model-id> \
+  --prompt "Implement the parser and run focused tests." \
+  --idempotency-key <unique-operation-id>
+```
+
+Use `--workspace main` for the main checkout or pass an existing worktree ID. Create another provider conversation in the same chat with:
+
+```bash
+zuse session create \
+  --project <project-id> \
+  --chat <chat-id> \
+  --provider codex \
+  --model <model-id> \
+  --prompt "Review the current diff without editing files." \
+  --idempotency-key <unique-session-id>
+```
+
+`thread create` aliases `chat create`. Other `thread` actions alias the corresponding session action. Prefer the explicit `chat` and `session` names in new automation because they preserve the application topology.
+
+## Send, interrupt, and resume
+
+```bash
+zuse session send --project <project-id> --session <session-id> --message "Run the failing test again."
+zuse session interrupt --project <project-id> --session <session-id>
+zuse session resume --project <project-id> --session <session-id>
+```
+
+Sending can also change the permission or runtime mode before delivering the message. Use `session mode` when no message is needed:
+
+```bash
+zuse session mode \
+  --project <project-id> \
+  --session <session-id> \
+  --permission plan \
+  --runtime approval-required
+```
+
+Permission values are `default`, `plan`, and `accept-edits`. Runtime values are `approval-required`, `auto-accept-edits`, `auto-accept-edits-and-bash`, and `full-access`. A mode change does not grant authority for unrelated external or destructive actions.
+
+## Attach context
+
+Creation and send commands accept repeatable context options:
+
+```bash
+zuse session send \
+  --project <project-id> \
+  --session <session-id> \
+  --message "Use these references." \
+  --attach ./screenshots/error.png \
+  --file src/parser.ts \
+  --file test/parser.test.ts \
+  --linear ENG-123 \
+  --linear-workspace <workspace-id>
+```
+
+`--attach` uploads supported image files. `--file` accepts a project-relative file or directory and rejects paths outside the selected project. `--linear` resolves an exact issue identifier or ID and prepares its available context. Warnings from context preparation are returned in the success envelope.
+
+## JSON input and stdin
+
+Pass a complete option object directly or from a file:
+
+```bash
+zuse session send --input-json '{"project":"<project-id>","session":"<session-id>","message":"Continue with the approved plan."}'
+zuse chat create --input-json @request.json
+```
+
+Array values become repeated options, which is useful for `file`, `attach`, and `linear`. Read a long prompt from stdin with `--prompt-file -`:
+
+```bash
+printf '%s' "$(<prompt.md)" | zuse chat create --project <project-id> --prompt-file - --idempotency-key <unique-operation-id>
+```
+
+Use an idempotency key for creation commands whenever a transport failure might cause a retry. Keep it stable for the same intended creation and generate a new key for genuinely new work.
+
+## Select a project and computer
+
+`--project` accepts a project ID, exact name, or path. Zuse infers it only when the current directory belongs to exactly one registered project; otherwise the error response includes candidates.
+
+The CLI targets the local Zuse RPC server by default. To target another connected computer, first list computers, then provide its connection endpoint:
+
+```bash
+zuse computer list
+zuse session list \
+  --computer <computer-id> \
+  --ws-url <wss-url> \
+  --token <access-token> \
+  --project <project-id>
+```
+
+`ZUSE_WS_URL`, `ZUSE_TOKEN`, and `ZUSE_PORT` are available for controlled automation environments. Do not print tokens, embed them in prompts, or commit them to the repository. Prefer environment-based secret injection where shell-history exposure matters.
+
+## Reliable automation sequence
+
+1. Run `computer list`, `project list`, and `model list`.
+2. Resolve returned IDs instead of relying on display text.
+3. Create the chat or session with a stable idempotency key.
+4. Require exit code `0` and `ok: true` before storing returned IDs.
+5. Fetch the created chat or session to verify its persisted state when the workflow is consequential.
+6. Use `session read` for progress and `session send` for follow-up instructions.
+
+For deciding when work needs an isolated workspace rather than a shared session tab, continue with [Agent orchestration](/composer/orchestration/).

--- a/apps/docs/content/docs/serve/command-reference.mdx
+++ b/apps/docs/content/docs/serve/command-reference.mdx
@@ -6,7 +6,7 @@ order: 3
 platforms: [serve]
 providers: []
 prerequisites: [/serve]
-related: [/serve/operations, /serve/status-json, /serve/troubleshooting]
+related: [/serve/operations, /serve/status-json, /serve/agent-cli, /serve/troubleshooting]
 next: /serve/status-json
 lastVerified: latest
 ---
@@ -65,5 +65,7 @@ Successful lifecycle commands print a short human-readable confirmation. `status
 <Callout title="Public surface">
 Only the commands and options on this page are supported for operators. Internal server transport flags are not a second public Serve CLI.
 </Callout>
+
+Agent automation uses a separate JSON-only command surface on the same executable. See the [agent CLI reference](/serve/agent-cli/).
 
 <NextStep href="/serve/status-json/" label="Automate status checks" />

--- a/apps/docs/test/docs.spec.ts
+++ b/apps/docs/test/docs.spec.ts
@@ -25,6 +25,12 @@ test("browser and orchestration guides render as linked documentation", async ({
 	await expect(
 		page.getByRole("link", { name: "Run agents in parallel" }).first(),
 	).toBeVisible();
+	await page.getByRole("link", { name: "agent CLI" }).first().click();
+	await expect(page).toHaveURL(/\/serve\/agent-cli/u);
+	await expect(page.getByRole("heading", { name: "Agent CLI" })).toBeVisible();
+	await expect(
+		page.getByText("zuse chat create", { exact: false }).first(),
+	).toBeVisible();
 });
 
 test("product links use the canonical website domain", async ({

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -1,3 +1,5 @@
+import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { NodeServices } from "@effect/platform-node";
 import type { AttachmentService } from "@zuse/agents/kernel/attachment-service";
 import { MemoizeRpcs } from "@zuse/contracts";
@@ -30,7 +32,7 @@ import { LanAuthServiceLive } from "./lan-auth/layers/lan-auth-service.ts";
 import type { LanAuthPolicy } from "./lan-auth/policy.ts";
 import {
 	LanAuthConfig,
-	type LanAuthService,
+	LanAuthService,
 } from "./lan-auth/services/lan-auth-service.ts";
 import { LinearServiceLive } from "./linear/layers/linear-service.ts";
 import { MachineControlServiceLive } from "./machine/machine-control-service.ts";
@@ -134,6 +136,10 @@ export interface MainLayerDeps {
 		readonly relayUrl: string;
 		readonly label?: string;
 	};
+	readonly devCliAccess?: {
+		readonly path: string;
+		readonly wsUrl: string;
+	};
 }
 
 /**
@@ -200,6 +206,36 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(MigratedSqlite),
 		Layer.provide(LanAuthConfigLayer),
 	);
+	const devCliAccess = deps.devCliAccess;
+	const DevCliAccessLayer =
+		devCliAccess === undefined
+			? Layer.empty
+			: Layer.effectDiscard(
+					Effect.gen(function* () {
+						const auth = yield* LanAuthService;
+						const existing = yield* auth.listTokens();
+						for (const token of existing) {
+							if (
+								token.label === "Development CLI" &&
+								token.revokedAt === undefined
+							)
+								yield* auth.revokeToken(token.id);
+						}
+						const minted = yield* auth.mintToken("Development CLI");
+						const { path: target, wsUrl } = devCliAccess;
+						const temporary = `${target}.${process.pid}.tmp`;
+						yield* Effect.promise(async () => {
+							await mkdir(dirname(target), { recursive: true });
+							await writeFile(
+								temporary,
+								`${JSON.stringify({ schemaVersion: 1, wsUrl, token: minted.token })}\n`,
+								{ mode: 0o600 },
+							);
+							await chmod(temporary, 0o600);
+							await rename(temporary, target);
+						});
+					}),
+				).pipe(Layer.provide(LanAuthLayer));
 	const ManagedTunnelLayer = ManagedTunnelRuntimeLive.pipe(
 		Layer.provide(NodeServices.layer),
 		Layer.provide(AppPathsLayer),
@@ -619,5 +655,6 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		UsagePoller,
 		AutoRelayLinkLayer,
 		RuntimePerformanceLayer,
+		DevCliAccessLayer,
 	).pipe(Layer.provide(TelemetryLayer));
 };

--- a/apps/server/src/skill/bundled-zuse-skill.ts
+++ b/apps/server/src/skill/bundled-zuse-skill.ts
@@ -50,71 +50,96 @@ expected smoke flow is:
 
 If \`zuse-orchestration\` is not available, report that orchestration tools are
 not registered for this session instead of silently using another provider feature.
+
+## Agent CLI
+
+Use the \`zuse\` CLI from terminals, scripts, CI jobs, or agents without the
+in-session orchestration MCP server. Run \`zuse commands\` to discover the
+supported surface. The CLI writes exactly one JSON envelope to stdout:
+\`{"schemaVersion":1,"ok":true,"data":{}}\`. Failures set a non-zero exit code
+and return \`ok: false\` with a structured error. Check both signals before
+reporting a mutation as successful.
+
+Use \`chat list|get|create\` for sidebar chats and workspaces. Use
+\`session list|get|create|read|send|mode|interrupt|resume\` for provider
+conversation tabs. Resolve IDs with list commands, select the project with
+\`--project\`, and check \`model list\` before selecting \`--provider\` and
+\`--model\`.
+
+Prefer \`--input-json\` or \`--input-json @request.json\` for automation and
+\`--idempotency-key\` for retryable creation. Context options are repeatable
+\`--attach\` images, project-relative \`--file\` references, and \`--linear\`
+issue context. Modes use \`--permission default|plan|accept-edits\` and
+\`--runtime approval-required|auto-accept-edits|auto-accept-edits-and-bash|full-access\`.
+
+The local server is the default computer. Remote targets require
+\`--computer <id> --ws-url <url>\` and, when protected, \`--token <token>\`.
+Never print or persist access tokens.
 `;
 
 const assetCandidates = (): string[] => {
-  const cwd = process.cwd();
-  const electronProcess = process as NodeJS.Process & {
-    readonly resourcesPath?: string;
-  };
-  const resourcesPath =
-    typeof electronProcess.resourcesPath === "string"
-      ? electronProcess.resourcesPath
-      : "";
-  return [
-    path.join(
-      cwd,
-      "apps",
-      "desktop",
-      "resources",
-      "skills",
-      "zuse",
-      "SKILL.md",
-    ),
-    path.join(resourcesPath, "app", "skills", "zuse", "SKILL.md"),
-    path.join(resourcesPath, "skills", "zuse", "SKILL.md"),
-  ].filter((candidate) => candidate.length > 0);
+	const cwd = process.cwd();
+	const electronProcess = process as NodeJS.Process & {
+		readonly resourcesPath?: string;
+	};
+	const resourcesPath =
+		typeof electronProcess.resourcesPath === "string"
+			? electronProcess.resourcesPath
+			: "";
+	return [
+		path.join(
+			cwd,
+			"apps",
+			"desktop",
+			"resources",
+			"skills",
+			"zuse",
+			"SKILL.md",
+		),
+		path.join(resourcesPath, "app", "skills", "zuse", "SKILL.md"),
+		path.join(resourcesPath, "skills", "zuse", "SKILL.md"),
+	].filter((candidate) => candidate.length > 0);
 };
 
 export const readBundledZuseSkill = (): string => {
-  for (const candidate of assetCandidates()) {
-    try {
-      return fsSync.readFileSync(candidate, "utf8");
-    } catch {
-      // Try the next dev/packaged location.
-    }
-  }
-  return FALLBACK_SKILL;
+	for (const candidate of assetCandidates()) {
+		try {
+			return fsSync.readFileSync(candidate, "utf8");
+		} catch {
+			// Try the next dev/packaged location.
+		}
+	}
+	return FALLBACK_SKILL;
 };
 
 export const bundledZuseSkillPath = (
-  providerId: ProviderId,
-  home = os.homedir(),
+	providerId: ProviderId,
+	home = os.homedir(),
 ): string | null => {
-  if (providerId === "claude") {
-    return path.join(home, ".claude", "skills", "zuse", "SKILL.md");
-  }
-  if (providerId === "codex") {
-    return path.join(home, ".codex", "skills", "zuse", "SKILL.md");
-  }
-  return null;
+	if (providerId === "claude") {
+		return path.join(home, ".claude", "skills", "zuse", "SKILL.md");
+	}
+	if (providerId === "codex") {
+		return path.join(home, ".codex", "skills", "zuse", "SKILL.md");
+	}
+	return null;
 };
 
 export const ensureBundledZuseSkillInstalled = (
-  providerId: ProviderId,
-  home = os.homedir(),
+	providerId: ProviderId,
+	home = os.homedir(),
 ): string | null => {
-  const target = bundledZuseSkillPath(providerId, home);
-  if (target === null) return null;
-  const content = readBundledZuseSkill();
-  try {
-    fsSync.mkdirSync(path.dirname(target), { recursive: true });
-    const existing = fsSync.existsSync(target)
-      ? fsSync.readFileSync(target, "utf8")
-      : null;
-    if (existing !== content) fsSync.writeFileSync(target, content, "utf8");
-  } catch {
-    return null;
-  }
-  return target;
+	const target = bundledZuseSkillPath(providerId, home);
+	if (target === null) return null;
+	const content = readBundledZuseSkill();
+	try {
+		fsSync.mkdirSync(path.dirname(target), { recursive: true });
+		const existing = fsSync.existsSync(target)
+			? fsSync.readFileSync(target, "utf8")
+			: null;
+		if (existing !== content) fsSync.writeFileSync(target, content, "utf8");
+	} catch {
+		return null;
+	}
+	return target;
 };

--- a/apps/server/src/skill/bundled-zuse-skill.ts
+++ b/apps/server/src/skill/bundled-zuse-skill.ts
@@ -89,6 +89,10 @@ archive, unarchive, and delete actions mirror the UI; deletion requires
 The local server is the default computer. Remote targets require
 \`--computer <id> --ws-url <url>\` and, when protected, \`--token <token>\`.
 Never print or persist access tokens.
+
+In a \`bun dev\` checkout, the branch-local CLI automatically discovers the
+active protected dev RPC through its owner-readable, gitignored instance
+descriptor. Do not read or print that credential file yourself.
 `;
 
 const assetCandidates = (): string[] => {

--- a/apps/server/src/skill/bundled-zuse-skill.ts
+++ b/apps/server/src/skill/bundled-zuse-skill.ts
@@ -66,11 +66,25 @@ conversation tabs. Resolve IDs with list commands, select the project with
 \`--project\`, and check \`model list\` before selecting \`--provider\` and
 \`--model\`.
 
+Use \`session model\` to change only the model. Provider switching is a
+separate \`session provider\` operation and is limited to sessions without a
+user message. \`session fork --session <id> --message <id>\` branches any
+conversation point into a same-chat tab or another chat; new-chat forks create
+a fresh isolated worktree by default. Retrieve handoff context with
+\`session transcript\` and \`session plan\`.
+
 Prefer \`--input-json\` or \`--input-json @request.json\` for automation and
 \`--idempotency-key\` for retryable creation. Context options are repeatable
 \`--attach\` images, project-relative \`--file\` references, and \`--linear\`
-issue context. Modes use \`--permission default|plan|accept-edits\` and
+issue context. \`--transcript <session-id>\` and \`--plan <session-id>\` save
+and attach Markdown handoff context to create, send, and queue commands. Modes use
+\`--permission default|plan|accept-edits\` and
 \`--runtime approval-required|auto-accept-edits|auto-accept-edits-and-bash|full-access\`.
+
+Use \`session plan-respond\`, \`session answer\`, and \`session queue-*\` for
+pending plans, questions, and durable queued messages. Chat/session rename,
+archive, unarchive, and delete actions mirror the UI; deletion requires
+\`--confirm\`.
 
 The local server is the default computer. Remote targets require
 \`--computer <id> --ws-url <url>\` and, when protected, \`--token <token>\`.

--- a/apps/server/test/unit/bundled-zuse-skill.test.ts
+++ b/apps/server/test/unit/bundled-zuse-skill.test.ts
@@ -27,13 +27,16 @@ describe("bundled Zuse skill installer", () => {
 			expect(codexPath).toBe(
 				join(home, ".codex", "skills", "zuse", "SKILL.md"),
 			);
-			expect(existsSync(claudePath!)).toBe(true);
-			expect(existsSync(codexPath!)).toBe(true);
+			if (claudePath === null || codexPath === null) {
+				throw new Error("Expected native skill paths for Claude and Codex.");
+			}
+			expect(existsSync(claudePath)).toBe(true);
+			expect(existsSync(codexPath)).toBe(true);
 
-			writeFileSync(claudePath!, "stale", "utf8");
+			writeFileSync(claudePath, "stale", "utf8");
 			ensureBundledZuseSkillInstalled("claude", home);
-			const installedClaudeSkill = readFileSync(claudePath!, "utf8");
-			const installedCodexSkill = readFileSync(codexPath!, "utf8");
+			const installedClaudeSkill = readFileSync(claudePath, "utf8");
+			const installedCodexSkill = readFileSync(codexPath, "utf8");
 			expect(installedClaudeSkill).toContain("name: zuse");
 			expect(installedClaudeSkill).toContain("zuse-orchestration");
 			expect(installedClaudeSkill).toContain("Workspaces vs chat threads");
@@ -41,6 +44,11 @@ describe("bundled Zuse skill installer", () => {
 			expect(installedClaudeSkill).toContain("list_models");
 			expect(installedClaudeSkill).toContain("create_thread");
 			expect(installedClaudeSkill).toContain("create_session");
+			expect(installedClaudeSkill).toContain("## Agent CLI");
+			expect(installedClaudeSkill).toContain("zuse commands");
+			expect(installedClaudeSkill).toContain("--input-json");
+			expect(installedClaudeSkill).toContain("--idempotency-key");
+			expect(installedClaudeSkill).toContain("--linear");
 			expect(installedClaudeSkill).not.toContain("create_chat");
 			expect(installedClaudeSkill).not.toContain("create_worktree");
 			expect(installedCodexSkill).toContain("zuse-orchestration");

--- a/apps/server/test/unit/bundled-zuse-skill.test.ts
+++ b/apps/server/test/unit/bundled-zuse-skill.test.ts
@@ -49,6 +49,10 @@ describe("bundled Zuse skill installer", () => {
 			expect(installedClaudeSkill).toContain("--input-json");
 			expect(installedClaudeSkill).toContain("--idempotency-key");
 			expect(installedClaudeSkill).toContain("--linear");
+			expect(installedClaudeSkill).toContain("session fork");
+			expect(installedClaudeSkill).toContain("session transcript");
+			expect(installedClaudeSkill).toContain("--transcript");
+			expect(installedClaudeSkill).toContain("session plan-respond");
 			expect(installedClaudeSkill).not.toContain("create_chat");
 			expect(installedClaudeSkill).not.toContain("create_worktree");
 			expect(installedCodexSkill).toContain("zuse-orchestration");

--- a/bun.lock
+++ b/bun.lock
@@ -553,16 +553,18 @@
         "zuse": "dist/bin.mjs",
       },
       "dependencies": {
-        "@zusehq/server": "0.1.1",
+        "@zusehq/server": "0.1.2",
         "effect": "catalog:",
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
         "@types/node": "catalog:",
+        "@zuse/client-runtime": "*",
         "@zuse/contracts": "*",
         "tsdown": "0.21.10",
         "typescript": "catalog:",
         "vite-plus": "0.2.5",
+        "vitest": "4.1.10",
       },
     },
     "packages/sqlite": {

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -34,6 +34,17 @@ zuse chat create --input-json @request.json
 zuse session send --input-json '{"project":"<project-id>","session":"<session-id>","message":"Continue with the approved plan."}'
 ```
 
+Fork and hand off conversations without copying large transcripts through the
+shell:
+
+```bash
+zuse session fork --project <project-id> --session <source-session-id> --message <message-id> --destination tab
+zuse session send --project <project-id> --session <target-session-id> --message "Continue this handoff." --transcript <source-session-id> --plan <planning-session-id>
+```
+
+Use `session model` to change only the active model. Provider changes remain a
+separate `session provider` command.
+
 Agent commands emit one versioned JSON envelope on stdout. Check both the exit
 code and the envelope's `ok` field before treating a mutation as successful.
 Creation commands support `--idempotency-key` for safe retries.

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -1,0 +1,42 @@
+# Zuse Serve
+
+`@zusehq/serve` runs a durable Zuse environment and provides a JSON-only CLI
+for agent orchestration.
+
+```bash
+npx @zusehq/serve
+```
+
+Install the package globally to use the shorter executable:
+
+```bash
+npm install --global @zusehq/serve
+zuse serve status
+```
+
+## Agent CLI
+
+Discover the available computers, projects, models, chats, and sessions:
+
+```bash
+zuse commands
+zuse computer list
+zuse project list
+zuse model list
+zuse chat list --project <project-id>
+zuse session list --project <project-id> --chat <chat-id>
+```
+
+Create work or send a message with structured input:
+
+```bash
+zuse chat create --input-json @request.json
+zuse session send --input-json '{"project":"<project-id>","session":"<session-id>","message":"Continue with the approved plan."}'
+```
+
+Agent commands emit one versioned JSON envelope on stdout. Check both the exit
+code and the envelope's `ok` field before treating a mutation as successful.
+Creation commands support `--idempotency-key` for safe retries.
+
+See the complete [agent CLI documentation](https://docs.zuse.sh/serve/agent-cli)
+and [Serve command reference](https://docs.zuse.sh/serve/command-reference).

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -30,18 +30,21 @@
 	],
 	"scripts": {
 		"build": "vp pack src/bin.ts src/cli.ts src/status.ts",
-		"check-types": "tsc --noEmit"
+		"check-types": "tsc --noEmit",
+		"test": "vitest run test"
 	},
 	"dependencies": {
 		"@zusehq/server": "0.1.2",
 		"effect": "catalog:"
 	},
 	"devDependencies": {
+		"@zuse/client-runtime": "*",
 		"@repo/typescript-config": "*",
 		"@types/node": "catalog:",
 		"@zuse/contracts": "*",
 		"tsdown": "0.21.10",
 		"typescript": "catalog:",
+		"vitest": "4.1.10",
 		"vite-plus": "0.2.5"
 	}
 }

--- a/packages/serve/src/agent-cli.ts
+++ b/packages/serve/src/agent-cli.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { readFile, stat } from "node:fs/promises";
-import { basename, isAbsolute, relative, resolve } from "node:path";
+import {
+	basename,
+	dirname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+} from "node:path";
 
 import { makeRpcClientSession } from "@zuse/client-runtime/connection";
 import { wsClientProtocolLayer } from "@zuse/client-runtime/ws-protocol";
@@ -162,7 +169,48 @@ const promptFor = async (args: Args, message = false): Promise<string> => {
 	return file === "-" ? readStdin() : readFile(resolve(file), "utf8");
 };
 
-const endpoint = (args: Args, env: NodeJS.ProcessEnv): string => {
+type DevCliAccess = {
+	readonly schemaVersion: 1;
+	readonly wsUrl: string;
+	readonly token: string;
+};
+const devCliAccess = async (
+	env: NodeJS.ProcessEnv,
+): Promise<DevCliAccess | null> => {
+	const explicit = env.ZUSE_DEV_CLI_ACCESS_FILE?.trim();
+	const candidates: string[] = explicit ? [resolve(explicit)] : [];
+	let cursor = resolve(process.cwd());
+	while (true) {
+		const instance = env.ZUSE_DEV_INSTANCE?.trim() || "default";
+		candidates.push(
+			join(cursor, ".zuse", "dev-instances", instance, "cli-access.json"),
+		);
+		const parent = dirname(cursor);
+		if (parent === cursor) break;
+		cursor = parent;
+	}
+	for (const candidate of candidates) {
+		try {
+			const parsed = JSON.parse(
+				await readFile(candidate, "utf8"),
+			) as Partial<DevCliAccess>;
+			if (
+				parsed.schemaVersion === 1 &&
+				typeof parsed.wsUrl === "string" &&
+				typeof parsed.token === "string"
+			)
+				return parsed as DevCliAccess;
+		} catch {
+			// Continue to the next repository ancestor.
+		}
+	}
+	return null;
+};
+
+const endpoint = async (
+	args: Args,
+	env: NodeJS.ProcessEnv,
+): Promise<string> => {
 	const computer = one(args, "computer") ?? "local";
 	if (computer !== "local" && one(args, "ws-url") === undefined) {
 		throw new CliError(
@@ -171,19 +219,25 @@ const endpoint = (args: Args, env: NodeJS.ProcessEnv): string => {
 			{ computer },
 		);
 	}
+	const access =
+		one(args, "ws-url") === undefined && env.ZUSE_WS_URL === undefined
+			? await devCliAccess(env)
+			: null;
 	const raw =
 		one(args, "ws-url") ??
 		env.ZUSE_WS_URL ??
+		access?.wsUrl ??
 		`ws://127.0.0.1:${env.ZUSE_PORT ?? "47837"}/rpc`;
 	const url = new URL(raw);
 	if (url.pathname === "/") url.pathname = "/rpc";
-	const token = one(args, "token") ?? env.ZUSE_TOKEN;
+	url.searchParams.set("wireVersion", String(WIRE_PROTOCOL_VERSION));
+	const token = one(args, "token") ?? env.ZUSE_TOKEN ?? access?.token;
 	if (token !== undefined) url.searchParams.set("token", token);
 	return url.toString();
 };
 
 const connect = async (args: Args, env: NodeJS.ProcessEnv) => {
-	const layer = wsClientProtocolLayer(endpoint(args, env));
+	const layer = wsClientProtocolLayer(await endpoint(args, env));
 	return makeRpcClientSession(layer, MemoizeRpcs, {
 		protocolVersion: WIRE_PROTOCOL_VERSION,
 		perform: (client, hello) => client["connect.handshake"](hello),
@@ -1086,4 +1140,11 @@ export const runAgentCli = async (
 	}
 };
 
-export const __testing = { parse, execute, commandManifest, expandInputJson };
+export const __testing = {
+	parse,
+	execute,
+	commandManifest,
+	expandInputJson,
+	devCliAccess,
+	endpoint,
+};

--- a/packages/serve/src/agent-cli.ts
+++ b/packages/serve/src/agent-cli.ts
@@ -11,6 +11,7 @@ import {
 	type FileRef,
 	type LinearIssueRef,
 	MemoizeRpcs,
+	type MessageId,
 	MODELS_BY_PROVIDER,
 	type PermissionMode,
 	type ProviderId,
@@ -199,16 +200,42 @@ const commandManifest = () => ({
 		"chat list",
 		"chat get",
 		"chat create",
+		"chat rename",
+		"chat archive",
+		"chat unarchive",
+		"chat delete",
+		"chat workspace",
 		"session list",
 		"session get",
 		"session create",
 		"session read",
 		"session send",
+		"session fork",
+		"session model",
+		"session provider",
+		"session rename",
+		"session archive",
+		"session unarchive",
+		"session delete",
+		"session transcript",
+		"session plan",
+		"session plan-respond",
+		"session answer",
+		"session queue-list",
+		"session queue-add",
+		"session queue-update",
+		"session queue-delete",
+		"session queue-reorder",
+		"session queue-run-next",
+		"session queue-flush",
+		"session queue-resume",
 		"session mode",
 		"session interrupt",
 		"session resume",
 	],
 	commonOptions: ["--computer", "--ws-url", "--token", "--project"],
+	contextOptions: ["--attach", "--file", "--linear", "--transcript", "--plan"],
+	deleteRequires: "--confirm",
 	schemaVersion: 1,
 });
 
@@ -291,6 +318,16 @@ const runtime = (args: Args): RuntimeMode => {
 };
 const asSessionId = (value: string): SessionId => value as SessionId;
 const asChatId = (value: string): ChatId => value as ChatId;
+const asMessageId = (value: string): MessageId => value as MessageId;
+
+const jsonObject = (value: string | undefined, name: string): unknown => {
+	const raw = required(value, name);
+	try {
+		return JSON.parse(raw);
+	} catch {
+		throw new CliError("invalid_input", `${name} must be valid JSON.`);
+	}
+};
 
 const mimeFor = (path: string): string => {
 	const ext = path.toLowerCase().split(".").at(-1);
@@ -314,7 +351,7 @@ const contextFor = async (
 	client: RpcClient,
 	args: Args,
 	sessionId: string,
-	project: { path: string },
+	project: { id: string; path: string },
 ) => {
 	const attachments: AttachmentRef[] = [];
 	const fileRefs: FileRef[] = [];
@@ -355,6 +392,61 @@ const contextFor = async (
 		});
 	}
 	const warnings: unknown[] = [];
+	for (const sourceSession of many(args, "transcript")) {
+		const source = await rpc(
+			client["session.get"]({ sessionId: asSessionId(sourceSession) }),
+		);
+		if (source.projectId !== project.id)
+			throw new CliError(
+				"project_session_mismatch",
+				"Transcript source must belong to the selected project.",
+			);
+		const throughMessage = one(args, "through-message");
+		const exported = await rpc(
+			client["session.exportTranscript"]({
+				sessionId: asSessionId(sourceSession),
+				...(throughMessage
+					? { uptoMessageId: asMessageId(throughMessage) }
+					: {}),
+			}),
+		);
+		const saved = await rpc(
+			client["context.saveText"]({
+				sessionId: asSessionId(sessionId),
+				text: exported.markdown,
+				ext: "md",
+				rootPath: project.path,
+			}),
+		);
+		fileRefs.push({ ...saved, kind: "file" });
+	}
+	for (const sourceSession of many(args, "plan")) {
+		const source = await rpc(
+			client["session.get"]({ sessionId: asSessionId(sourceSession) }),
+		);
+		if (source.projectId !== project.id)
+			throw new CliError(
+				"project_session_mismatch",
+				"Plan source must belong to the selected project.",
+			);
+		const { plan } = await rpc(
+			client["session.latestPlan"]({ sessionId: asSessionId(sourceSession) }),
+		);
+		if (plan === null)
+			throw new CliError(
+				"plan_not_found",
+				`Session ${sourceSession} has no proposed plan.`,
+			);
+		const saved = await rpc(
+			client["context.saveText"]({
+				sessionId: asSessionId(sessionId),
+				text: plan,
+				ext: "md",
+				rootPath: project.path,
+			}),
+		);
+		fileRefs.push({ ...saved, kind: "file" });
+	}
 	for (const issueSelector of many(args, "linear")) {
 		const workspace = one(args, "linear-workspace");
 		const result = await rpc(
@@ -486,6 +578,52 @@ const execute = async (
 					}),
 				),
 			};
+		if (group === "chat" && action === "rename")
+			return {
+				chat: await rpc(
+					client["chat.rename"]({
+						chatId: asChatId(required(one(args, "chat"), "--chat")),
+						title: required(one(args, "title"), "--title"),
+					}),
+				),
+			};
+		if (group === "chat" && action === "archive")
+			return {
+				result: await rpc(
+					client["chat.archive"]({
+						chatId: asChatId(required(one(args, "chat"), "--chat")),
+					}),
+				),
+			};
+		if (group === "chat" && action === "unarchive")
+			return {
+				result: await rpc(
+					client["chat.unarchive"]({
+						chatId: asChatId(required(one(args, "chat"), "--chat")),
+					}),
+				),
+			};
+		if (group === "chat" && action === "delete") {
+			if (!bool(args, "confirm"))
+				throw new CliError(
+					"confirmation_required",
+					"chat delete requires --confirm.",
+				);
+			const chatId = asChatId(required(one(args, "chat"), "--chat"));
+			await rpc(client["chat.delete"]({ chatId }));
+			return { chatId, deleted: true };
+		}
+		if (group === "chat" && action === "workspace") {
+			const workspace = required(one(args, "workspace"), "--workspace");
+			return {
+				chat: await rpc(
+					client["chat.setWorktree"]({
+						chatId: asChatId(required(one(args, "chat"), "--chat")),
+						worktreeId: workspace === "main" ? null : (workspace as WorktreeId),
+					}),
+				),
+			};
+		}
 		if (group === "session" && action === "list")
 			return {
 				sessions: (
@@ -510,6 +648,67 @@ const execute = async (
 					}),
 				),
 			};
+		if (group === "session" && action === "fork") {
+			const sourceSessionId = asSessionId(
+				required(one(args, "session") ?? args.positionals[2], "--session"),
+			);
+			const sourceSession = await rpc(
+				client["session.get"]({ sessionId: sourceSessionId }),
+			);
+			if (sourceSession.projectId !== project.id)
+				throw new CliError(
+					"project_session_mismatch",
+					"The source session does not belong to the selected project.",
+				);
+			const destination = one(args, "destination") ?? "tab";
+			if (destination !== "tab" && destination !== "chat")
+				throw new CliError(
+					"invalid_input",
+					"--destination must be tab or chat.",
+				);
+			if (one(args, "provider") && !one(args, "model"))
+				throw new CliError(
+					"invalid_input",
+					"Forking to another provider requires --model.",
+				);
+			const workspace = one(args, "workspace");
+			let createdWorktree: WorktreeId | null = null;
+			let worktreeId: WorktreeId | null | undefined;
+			if (destination === "chat") {
+				if (workspace === undefined || workspace === "fresh") {
+					const created = await rpc(
+						client["worktree.create"]({ projectId: project.id }),
+					);
+					createdWorktree = created.id;
+					worktreeId = created.id;
+				} else {
+					worktreeId = workspace === "main" ? null : (workspace as WorktreeId);
+				}
+			}
+			try {
+				return await rpc(
+					client["session.fork"]({
+						sourceSessionId,
+						fromMessageId: asMessageId(
+							required(one(args, "message"), "--message"),
+						),
+						destination,
+						...(one(args, "provider") ? { providerId: provider(args) } : {}),
+						...(one(args, "model") ? { model: one(args, "model") } : {}),
+						...(destination === "chat"
+							? { worktreeId: worktreeId ?? null }
+							: {}),
+						...(one(args, "title") ? { title: one(args, "title") } : {}),
+					}),
+				);
+			} catch (cause) {
+				if (createdWorktree !== null)
+					await rpc(
+						client["worktree.remove"]({ worktreeId: createdWorktree }),
+					).catch(() => undefined);
+				throw cause;
+			}
+		}
 		if (group === "chat" && action === "create") {
 			const p = provider(args);
 			const m = model(args, p);
@@ -608,6 +807,77 @@ const execute = async (
 				messages: limit !== undefined ? messages.slice(-limit) : messages,
 			};
 		}
+		if (group === "session" && action === "transcript")
+			return await rpc(
+				client["session.exportTranscript"]({
+					sessionId: selectedSessionId,
+					...(one(args, "through-message")
+						? {
+								uptoMessageId: asMessageId(
+									required(one(args, "through-message"), "--through-message"),
+								),
+							}
+						: {}),
+				}),
+			);
+		if (group === "session" && action === "plan")
+			return await rpc(
+				client["session.latestPlan"]({ sessionId: selectedSessionId }),
+			);
+		if (group === "session" && action === "model") {
+			await rpc(
+				client["session.setModel"]({
+					sessionId: selectedSessionId,
+					model: required(one(args, "model"), "--model"),
+				}),
+			);
+			return {
+				session: await rpc(
+					client["session.get"]({ sessionId: selectedSessionId }),
+				),
+			};
+		}
+		if (group === "session" && action === "provider") {
+			const nextProvider = provider(args);
+			await rpc(
+				client["session.setProvider"]({
+					sessionId: selectedSessionId,
+					providerId: nextProvider,
+					model: model(args, nextProvider),
+				}),
+			);
+			return {
+				session: await rpc(
+					client["session.get"]({ sessionId: selectedSessionId }),
+				),
+			};
+		}
+		if (group === "session" && action === "rename")
+			return {
+				session: await rpc(
+					client["session.rename"]({
+						sessionId: selectedSessionId,
+						title: required(one(args, "title"), "--title"),
+					}),
+				),
+			};
+		if (group === "session" && action === "archive") {
+			await rpc(client["session.archive"]({ sessionId: selectedSessionId }));
+			return { sessionId: selectedSessionId, archived: true };
+		}
+		if (group === "session" && action === "unarchive") {
+			await rpc(client["session.unarchive"]({ sessionId: selectedSessionId }));
+			return { sessionId: selectedSessionId, archived: false };
+		}
+		if (group === "session" && action === "delete") {
+			if (!bool(args, "confirm"))
+				throw new CliError(
+					"confirmation_required",
+					"session delete requires --confirm.",
+				);
+			await rpc(client["session.delete"]({ sessionId: selectedSessionId }));
+			return { sessionId: selectedSessionId, deleted: true };
+		}
 		if (group === "session" && action === "send") {
 			const context = await contextFor(
 				client,
@@ -642,6 +912,123 @@ const execute = async (
 				),
 				warnings: context.warnings,
 			};
+		}
+		if (group === "session" && action === "plan-respond") {
+			const outcome = required(one(args, "outcome"), "--outcome");
+			if (!["approved", "cancelled", "abandoned"].includes(outcome))
+				throw new CliError(
+					"invalid_input",
+					"--outcome must be approved, cancelled, or abandoned.",
+				);
+			await rpc(
+				client["session.plan.respond"]({
+					sessionId: selectedSessionId,
+					toolCallId: required(one(args, "tool-call"), "--tool-call"),
+					outcome: outcome as "approved" | "cancelled" | "abandoned",
+					...(one(args, "feedback") ? { feedback: one(args, "feedback") } : {}),
+				}),
+			);
+			return { sessionId: selectedSessionId, outcome };
+		}
+		if (group === "session" && action === "answer") {
+			const answers = jsonObject(one(args, "answers-json"), "--answers-json");
+			if (!Array.isArray(answers))
+				throw new CliError(
+					"invalid_input",
+					"--answers-json must contain an array.",
+				);
+			await rpc(
+				client["session.answerQuestion"]({
+					sessionId: selectedSessionId,
+					itemId: required(one(args, "item"), "--item"),
+					answers: answers as Array<{
+						questionIndex: number;
+						selected: number[];
+						other?: string;
+					}>,
+				}),
+			);
+			return { sessionId: selectedSessionId, answered: true };
+		}
+		if (group === "session" && action === "queue-list")
+			return await rpc(
+				client["messages.queue.list"]({ sessionId: selectedSessionId }),
+			);
+		if (
+			group === "session" &&
+			(action === "queue-add" || action === "queue-update")
+		) {
+			const context = await contextFor(
+				client,
+				args,
+				selectedSessionId,
+				project,
+			);
+			const input = composer(await promptFor(args, true), context);
+			if (action === "queue-add")
+				return {
+					item: await rpc(
+						client["messages.queue.add"]({
+							sessionId: selectedSessionId,
+							input,
+							...(one(args, "queue") ? { queueId: one(args, "queue") } : {}),
+							ready: !bool(args, "draft"),
+							flush: !bool(args, "no-flush"),
+						}),
+					),
+					warnings: context.warnings,
+				};
+			return {
+				item: await rpc(
+					client["messages.queue.update"]({
+						sessionId: selectedSessionId,
+						queueId: required(one(args, "queue"), "--queue"),
+						input,
+					}),
+				),
+				warnings: context.warnings,
+			};
+		}
+		if (group === "session" && action === "queue-delete") {
+			const queueId = required(one(args, "queue"), "--queue");
+			await rpc(
+				client["messages.queue.delete"]({
+					sessionId: selectedSessionId,
+					queueId,
+				}),
+			);
+			return { sessionId: selectedSessionId, queueId, deleted: true };
+		}
+		if (group === "session" && action === "queue-reorder")
+			return {
+				items: await rpc(
+					client["messages.queue.reorder"]({
+						sessionId: selectedSessionId,
+						queueIds: many(args, "queue"),
+					}),
+				),
+			};
+		if (group === "session" && action === "queue-run-next") {
+			const queueId = required(one(args, "queue"), "--queue");
+			await rpc(
+				client["messages.queue.runNext"]({
+					sessionId: selectedSessionId,
+					queueId,
+				}),
+			);
+			return { sessionId: selectedSessionId, queueId, started: true };
+		}
+		if (group === "session" && action === "queue-flush") {
+			await rpc(
+				client["messages.queue.flush"]({ sessionId: selectedSessionId }),
+			);
+			return { sessionId: selectedSessionId, flushed: true };
+		}
+		if (group === "session" && action === "queue-resume") {
+			await rpc(
+				client["messages.queue.resume"]({ sessionId: selectedSessionId }),
+			);
+			return { sessionId: selectedSessionId, resumed: true };
 		}
 		if (group === "session" && action === "mode") {
 			if (!one(args, "permission") && !one(args, "runtime"))

--- a/packages/serve/src/agent-cli.ts
+++ b/packages/serve/src/agent-cli.ts
@@ -1,0 +1,702 @@
+import { randomUUID } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import { basename, isAbsolute, relative, resolve } from "node:path";
+
+import { makeRpcClientSession } from "@zuse/client-runtime/connection";
+import { wsClientProtocolLayer } from "@zuse/client-runtime/ws-protocol";
+import {
+	type AttachmentRef,
+	type ChatId,
+	ComposerInput,
+	type FileRef,
+	type LinearIssueRef,
+	MemoizeRpcs,
+	MODELS_BY_PROVIDER,
+	type PermissionMode,
+	type ProviderId,
+	type RuntimeMode,
+	type SessionId,
+	WIRE_PROTOCOL_VERSION,
+	type WorktreeId,
+} from "@zuse/contracts";
+import { Effect } from "effect";
+
+type RpcClient = Awaited<ReturnType<typeof connect>>["client"];
+
+const GROUPS = new Set([
+	"commands",
+	"computer",
+	"project",
+	"model",
+	"chat",
+	"session",
+	"thread",
+]);
+export const isAgentCliCommand = (argv: ReadonlyArray<string>): boolean =>
+	argv[0] !== undefined && GROUPS.has(argv[0]);
+
+export class CliError extends Error {
+	constructor(
+		readonly code: string,
+		message: string,
+		readonly details?: unknown,
+	) {
+		super(message);
+	}
+}
+
+const success = (data: unknown): void => {
+	process.stdout.write(
+		`${JSON.stringify({ schemaVersion: 1, ok: true, data })}\n`,
+	);
+};
+
+const failure = (cause: unknown): void => {
+	const error =
+		cause instanceof CliError
+			? cause
+			: new CliError(
+					"internal_error",
+					cause instanceof Error ? cause.message : String(cause),
+				);
+	process.stdout.write(
+		`${JSON.stringify({
+			schemaVersion: 1,
+			ok: false,
+			error: {
+				code: error.code,
+				message: error.message,
+				...(error.details === undefined ? {} : { details: error.details }),
+			},
+		})}\n`,
+	);
+	process.exitCode =
+		error.code === "invalid_input" ? 2 : error.code === "unauthorized" ? 3 : 1;
+};
+
+type Args = {
+	readonly positionals: string[];
+	readonly flags: Map<string, string[]>;
+};
+const parse = (argv: ReadonlyArray<string>): Args => {
+	const positionals: string[] = [];
+	const flags = new Map<string, string[]>();
+	for (let i = 0; i < argv.length; i += 1) {
+		const value = argv[i];
+		if (value === undefined) break;
+		if (!value.startsWith("--")) {
+			positionals.push(value);
+			continue;
+		}
+		const [rawKey, inline] = value.slice(2).split("=", 2);
+		if (!rawKey)
+			throw new CliError("invalid_input", `Invalid option ${value}.`);
+		const next = argv[i + 1];
+		let optionValue = inline ?? "true";
+		if (inline === undefined && next !== undefined && !next.startsWith("--")) {
+			optionValue = next;
+			i += 1;
+		}
+		flags.set(rawKey, [...(flags.get(rawKey) ?? []), optionValue]);
+	}
+	return { positionals, flags };
+};
+const one = (args: Args, name: string): string | undefined =>
+	args.flags.get(name)?.at(-1);
+const many = (args: Args, name: string): string[] => args.flags.get(name) ?? [];
+const required = (value: string | undefined, name: string): string => {
+	if (!value) throw new CliError("invalid_input", `${name} is required.`);
+	return value;
+};
+const bool = (args: Args, name: string): boolean => one(args, name) === "true";
+const readStdin = async (): Promise<string> => {
+	const chunks: Buffer[] = [];
+	for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+	return Buffer.concat(chunks).toString("utf8");
+};
+const expandInputJson = async (
+	argv: ReadonlyArray<string>,
+): Promise<string[]> => {
+	const result = [...argv];
+	const index = result.findIndex(
+		(value) => value === "--input-json" || value.startsWith("--input-json="),
+	);
+	if (index < 0) return result;
+	const inline = result[index]?.split("=", 2)[1];
+	const source = inline ?? result[index + 1];
+	if (source === undefined)
+		throw new CliError(
+			"invalid_input",
+			"--input-json requires JSON, a file path prefixed with @, or - for stdin.",
+		);
+	const raw =
+		source === "-"
+			? await readStdin()
+			: source.startsWith("@")
+				? await readFile(resolve(source.slice(1)), "utf8")
+				: source;
+	let input: unknown;
+	try {
+		input = JSON.parse(raw);
+	} catch {
+		throw new CliError("invalid_input", "--input-json is not valid JSON.");
+	}
+	if (input === null || typeof input !== "object" || Array.isArray(input))
+		throw new CliError("invalid_input", "--input-json must contain an object.");
+	result.splice(index, inline === undefined ? 2 : 1);
+	for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+		for (const item of Array.isArray(value) ? value : [value]) {
+			if (item === false || item === null || item === undefined) continue;
+			result.push(`--${key}`, item === true ? "true" : String(item));
+		}
+	}
+	return result;
+};
+const promptFor = async (args: Args, message = false): Promise<string> => {
+	const direct =
+		one(args, message ? "message" : "prompt") ?? one(args, "prompt");
+	if (direct !== undefined) return direct;
+	const file = one(args, "prompt-file");
+	if (file === undefined) return "";
+	return file === "-" ? readStdin() : readFile(resolve(file), "utf8");
+};
+
+const endpoint = (args: Args, env: NodeJS.ProcessEnv): string => {
+	const computer = one(args, "computer") ?? "local";
+	if (computer !== "local" && one(args, "ws-url") === undefined) {
+		throw new CliError(
+			"computer_unavailable",
+			"A connected computer requires --ws-url and, when protected, --token.",
+			{ computer },
+		);
+	}
+	const raw =
+		one(args, "ws-url") ??
+		env.ZUSE_WS_URL ??
+		`ws://127.0.0.1:${env.ZUSE_PORT ?? "47837"}/rpc`;
+	const url = new URL(raw);
+	if (url.pathname === "/") url.pathname = "/rpc";
+	const token = one(args, "token") ?? env.ZUSE_TOKEN;
+	if (token !== undefined) url.searchParams.set("token", token);
+	return url.toString();
+};
+
+const connect = async (args: Args, env: NodeJS.ProcessEnv) => {
+	const layer = wsClientProtocolLayer(endpoint(args, env));
+	return makeRpcClientSession(layer, MemoizeRpcs, {
+		protocolVersion: WIRE_PROTOCOL_VERSION,
+		perform: (client, hello) => client["connect.handshake"](hello),
+	});
+};
+const rpc = <A>(effect: Effect.Effect<A, unknown>): Promise<A> =>
+	Effect.runPromise(effect);
+
+const commandManifest = () => ({
+	commands: [
+		"computer list",
+		"project list",
+		"model list",
+		"chat list",
+		"chat get",
+		"chat create",
+		"session list",
+		"session get",
+		"session create",
+		"session read",
+		"session send",
+		"session mode",
+		"session interrupt",
+		"session resume",
+	],
+	commonOptions: ["--computer", "--ws-url", "--token", "--project"],
+	schemaVersion: 1,
+});
+
+const resolveProject = async (client: RpcClient, args: Args) => {
+	const projects = await rpc(client["workspace.list"]({}));
+	const selector = one(args, "project");
+	if (!selector) {
+		if (projects.length === 1 && projects[0] !== undefined) return projects[0];
+		const cwd = resolve(process.cwd());
+		const matches = projects.filter(
+			(project) =>
+				cwd === resolve(project.path) ||
+				cwd.startsWith(`${resolve(project.path)}/`),
+		);
+		if (matches.length === 1 && matches[0] !== undefined) return matches[0];
+		throw new CliError(
+			"project_required",
+			"--project is required when the project cannot be inferred uniquely.",
+			{
+				candidates: projects.map(({ id, name, path }) => ({ id, name, path })),
+			},
+		);
+	}
+	const matches = projects.filter(
+		(p) =>
+			p.id === selector ||
+			p.name === selector ||
+			resolve(p.path) === resolve(selector),
+	);
+	if (matches.length !== 1)
+		throw new CliError(
+			matches.length ? "ambiguous_selector" : "project_not_found",
+			`Project selector matched ${matches.length} projects.`,
+			{ candidates: matches },
+		);
+	const match = matches[0];
+	if (match === undefined)
+		throw new CliError("project_not_found", "Project not found.");
+	return match;
+};
+
+const provider = (args: Args): ProviderId => {
+	const value = one(args, "provider") ?? "codex";
+	if (!(value in MODELS_BY_PROVIDER))
+		throw new CliError("invalid_provider", `Unknown provider ${value}.`, {
+			providers: Object.keys(MODELS_BY_PROVIDER),
+		});
+	return value as ProviderId;
+};
+const model = (args: Args, p: ProviderId): string =>
+	one(args, "model") ??
+	MODELS_BY_PROVIDER[p].find((m) => m.defaultModel)?.id ??
+	MODELS_BY_PROVIDER[p][0]?.id ??
+	"default";
+const permission = (args: Args): PermissionMode => {
+	const raw = one(args, "permission") ?? "default";
+	const value = raw === "accept-edits" ? "acceptEdits" : raw;
+	if (!["default", "plan", "acceptEdits"].includes(value))
+		throw new CliError(
+			"invalid_permission_mode",
+			`Unknown permission mode ${value}.`,
+		);
+	return value as PermissionMode;
+};
+const runtime = (args: Args): RuntimeMode => {
+	const value = one(args, "runtime") ?? "approval-required";
+	if (
+		![
+			"approval-required",
+			"auto-accept-edits",
+			"auto-accept-edits-and-bash",
+			"full-access",
+		].includes(value)
+	)
+		throw new CliError(
+			"invalid_runtime_mode",
+			`Unknown runtime mode ${value}.`,
+		);
+	return value as RuntimeMode;
+};
+const asSessionId = (value: string): SessionId => value as SessionId;
+const asChatId = (value: string): ChatId => value as ChatId;
+
+const mimeFor = (path: string): string => {
+	const ext = path.toLowerCase().split(".").at(-1);
+	const mime = {
+		png: "image/png",
+		jpg: "image/jpeg",
+		jpeg: "image/jpeg",
+		gif: "image/gif",
+		webp: "image/webp",
+		avif: "image/avif",
+	}[ext ?? ""];
+	if (!mime)
+		throw new CliError(
+			"unsupported_attachment",
+			`Unsupported image attachment: ${path}.`,
+		);
+	return mime;
+};
+
+const contextFor = async (
+	client: RpcClient,
+	args: Args,
+	sessionId: string,
+	project: { path: string },
+) => {
+	const attachments: AttachmentRef[] = [];
+	const fileRefs: FileRef[] = [];
+	for (const inputPath of many(args, "attach")) {
+		const absPath = resolve(inputPath);
+		const bytes = await readFile(absPath);
+		const mimeType = mimeFor(absPath);
+		const uploaded = await rpc(
+			client["attachments.upload"]({
+				sessionId: asSessionId(sessionId),
+				bytes,
+				mimeType,
+				originalName: basename(absPath),
+				rootPath: project.path,
+			}),
+		);
+		attachments.push({
+			id: uploaded.id,
+			mimeType: uploaded.mimeType,
+			originalName: basename(absPath),
+		});
+	}
+	for (const inputPath of many(args, "file")) {
+		const absPath = resolve(project.path, inputPath);
+		const relPath = relative(project.path, absPath);
+		if (relPath.startsWith("..") || isAbsolute(relPath))
+			throw new CliError(
+				"path_outside_project",
+				`${inputPath} is outside the selected project.`,
+			);
+		const info = await stat(absPath).catch(() => null);
+		if (!info)
+			throw new CliError("file_not_found", `${inputPath} does not exist.`);
+		fileRefs.push({
+			relPath,
+			absPath,
+			kind: info.isDirectory() ? "directory" : "file",
+		});
+	}
+	const warnings: unknown[] = [];
+	for (const issueSelector of many(args, "linear")) {
+		const workspace = one(args, "linear-workspace");
+		const result = await rpc(
+			client["linear.listIssues"]({
+				query: issueSelector,
+				...(workspace ? { workspaceIds: [workspace] } : {}),
+			}),
+		);
+		const matches = result.issues.filter(
+			(issue) =>
+				issue.identifier.toLowerCase() === issueSelector.toLowerCase() ||
+				issue.issueId === issueSelector,
+		);
+		if (matches.length !== 1)
+			throw new CliError(
+				matches.length ? "ambiguous_linear_issue" : "linear_issue_not_found",
+				`Linear selector matched ${matches.length} exact issues.`,
+				{ candidates: result.issues },
+			);
+		const issue = matches[0];
+		if (issue === undefined)
+			throw new CliError("linear_issue_not_found", "Linear issue not found.");
+		const prepared = await rpc(
+			client["linear.prepareContext"]({
+				sessionId: asSessionId(sessionId),
+				issues: [
+					{
+						workspaceId: issue.workspaceId,
+						issueId: issue.issueId,
+						identifier: issue.identifier,
+					} satisfies LinearIssueRef,
+				],
+				rootPath: project.path,
+			}),
+		);
+		fileRefs.push(
+			...prepared.files.map(({ relPath, absPath }) => ({
+				relPath,
+				absPath,
+				kind: "file" as const,
+			})),
+		);
+		attachments.push(...prepared.attachments);
+		warnings.push(...prepared.warnings);
+	}
+	return { attachments, fileRefs, warnings };
+};
+
+const composer = (
+	text: string,
+	context: Awaited<ReturnType<typeof contextFor>>,
+) =>
+	new ComposerInput({
+		text,
+		attachments: context.attachments,
+		fileRefs: context.fileRefs,
+		skillRefs: [],
+		annotations: [],
+	});
+
+const execute = async (
+	argv: ReadonlyArray<string>,
+	env: NodeJS.ProcessEnv,
+): Promise<unknown> => {
+	const args = parse(argv);
+	let [group, action] = args.positionals;
+	if (group === "commands") return commandManifest();
+	if (group === "thread") {
+		group = action === "create" ? "chat" : "session";
+	}
+	let session: Awaited<ReturnType<typeof connect>>;
+	try {
+		session = await connect(args, env);
+	} catch (cause) {
+		if (cause instanceof Error && cause.message.includes("SocketOpenError"))
+			throw new CliError(
+				"unauthorized",
+				"Could not open the Zuse RPC connection. Pass a connected --ws-url and --token, or target a loopback server running with local authentication.",
+			);
+		throw cause;
+	}
+	try {
+		const client = session.client;
+		if (group === "computer" && action === "list") {
+			const [current, connected] = await Promise.all([
+				rpc(client["connect.describe"]()),
+				rpc(client["environments.list"]()),
+			]);
+			return {
+				current,
+				computers: connected.environments,
+			};
+		}
+		if (group === "project" && action === "list")
+			return { projects: await rpc(client["workspace.list"]({})) };
+		if (group === "model" && action === "list") {
+			const availability = await rpc(
+				client["provider.availability"]({ refresh: bool(args, "refresh") }),
+			);
+			return {
+				providers: Object.entries(MODELS_BY_PROVIDER).map(
+					([providerId, models]) => ({
+						providerId,
+						availability:
+							availability.find((item) => item.providerId === providerId) ??
+							null,
+						models,
+					}),
+				),
+			};
+		}
+		const project = await resolveProject(client, args);
+		if (group === "chat" && action === "list")
+			return {
+				chats: await rpc(
+					client["chat.list"]({
+						projectId: project.id,
+						includeArchived: bool(args, "include-archived"),
+					}),
+				),
+			};
+		if (group === "chat" && action === "get")
+			return {
+				chat: await rpc(
+					client["chat.get"]({
+						chatId: asChatId(
+							required(one(args, "chat") ?? args.positionals[2], "--chat"),
+						),
+					}),
+				),
+			};
+		if (group === "session" && action === "list")
+			return {
+				sessions: (
+					await rpc(
+						client["session.list"]({
+							projectId: project.id,
+							includeArchived: bool(args, "include-archived"),
+						}),
+					)
+				).filter((s) => !one(args, "chat") || s.chatId === one(args, "chat")),
+			};
+		if (group === "session" && action === "get")
+			return {
+				session: await rpc(
+					client["session.get"]({
+						sessionId: asSessionId(
+							required(
+								one(args, "session") ?? args.positionals[2],
+								"--session",
+							),
+						),
+					}),
+				),
+			};
+		if (group === "chat" && action === "create") {
+			const p = provider(args);
+			const m = model(args, p);
+			const prompt = await promptFor(args);
+			const initialSessionId = asSessionId(`s_${randomUUID()}`);
+			const context = await contextFor(client, args, initialSessionId, project);
+			const workspace = one(args, "workspace") ?? "fresh";
+			const workspacePolicy =
+				workspace === "main"
+					? ({ _tag: "main" } as const)
+					: workspace === "fresh"
+						? ({ _tag: "fresh" } as const)
+						: ({
+								_tag: "existing",
+								worktreeId: workspace as WorktreeId,
+							} as const);
+			const created = await rpc(
+				client["chat.create"]({
+					operationId: one(args, "idempotency-key") ?? randomUUID(),
+					initialSessionId,
+					projectId: project.id,
+					providerId: p,
+					model: m,
+					title: one(args, "title"),
+					runtimeMode: runtime(args),
+					permissionMode: permission(args),
+					workspacePolicy,
+					...(prompt || context.attachments.length || context.fileRefs.length
+						? { startupInput: composer(prompt, context) }
+						: {}),
+					background: true,
+				}),
+			);
+			return { ...created, warnings: context.warnings };
+		}
+		if (group === "session" && action === "create") {
+			const p = provider(args);
+			const m = model(args, p);
+			const prompt = await promptFor(args);
+			const requestedSessionId =
+				one(args, "idempotency-key") ?? `s_${randomUUID()}`;
+			const context = await contextFor(
+				client,
+				args,
+				requestedSessionId,
+				project,
+			);
+			const created = await rpc(
+				client["session.create"]({
+					sessionId: asSessionId(requestedSessionId),
+					chatId: asChatId(required(one(args, "chat"), "--chat")),
+					providerId: p,
+					model: m,
+					title: one(args, "title"),
+					runtimeMode: runtime(args),
+					permissionMode: permission(args),
+				}),
+			);
+			if (prompt || context.attachments.length || context.fileRefs.length)
+				await rpc(
+					client["messages.send"]({
+						sessionId: created.id,
+						input: composer(prompt, context),
+					}),
+				);
+			return { session: created, warnings: context.warnings };
+		}
+		const selectedSessionId = asSessionId(
+			required(one(args, "session") ?? args.positionals[2], "--session"),
+		);
+		const selectedSession = await rpc(
+			client["session.get"]({ sessionId: selectedSessionId }),
+		);
+		if (selectedSession.projectId !== project.id)
+			throw new CliError(
+				"project_session_mismatch",
+				"The selected session does not belong to the selected project.",
+				{
+					sessionProjectId: selectedSession.projectId,
+					selectedProjectId: project.id,
+				},
+			);
+		if (group === "session" && action === "read") {
+			const limitRaw = one(args, "limit");
+			const limit = limitRaw === undefined ? undefined : Number(limitRaw);
+			if (limit !== undefined && (!Number.isInteger(limit) || limit < 0))
+				throw new CliError(
+					"invalid_input",
+					"--limit must be a non-negative integer.",
+				);
+			const messages = await rpc(
+				client["messages.list"]({ sessionId: selectedSessionId }),
+			);
+			return {
+				session: selectedSession,
+				messages: limit !== undefined ? messages.slice(-limit) : messages,
+			};
+		}
+		if (group === "session" && action === "send") {
+			const context = await contextFor(
+				client,
+				args,
+				selectedSessionId,
+				project,
+			);
+			const text = await promptFor(args, true);
+			if (one(args, "permission"))
+				await rpc(
+					client["session.setPermissionMode"]({
+						sessionId: selectedSessionId,
+						mode: permission(args),
+					}),
+				);
+			if (one(args, "runtime"))
+				await rpc(
+					client["session.setRuntimeMode"]({
+						sessionId: selectedSessionId,
+						runtimeMode: runtime(args),
+					}),
+				);
+			await rpc(
+				client["messages.send"]({
+					sessionId: selectedSessionId,
+					input: composer(text, context),
+				}),
+			);
+			return {
+				session: await rpc(
+					client["session.get"]({ sessionId: selectedSessionId }),
+				),
+				warnings: context.warnings,
+			};
+		}
+		if (group === "session" && action === "mode") {
+			if (!one(args, "permission") && !one(args, "runtime"))
+				throw new CliError(
+					"invalid_input",
+					"session mode requires --permission or --runtime.",
+				);
+			if (one(args, "permission"))
+				await rpc(
+					client["session.setPermissionMode"]({
+						sessionId: selectedSessionId,
+						mode: permission(args),
+					}),
+				);
+			if (one(args, "runtime"))
+				await rpc(
+					client["session.setRuntimeMode"]({
+						sessionId: selectedSessionId,
+						runtimeMode: runtime(args),
+					}),
+				);
+			return {
+				session: await rpc(
+					client["session.get"]({ sessionId: selectedSessionId }),
+				),
+			};
+		}
+		if (group === "session" && action === "interrupt") {
+			await rpc(client["messages.interrupt"]({ sessionId: selectedSessionId }));
+			return { sessionId: selectedSessionId, interrupted: true };
+		}
+		if (group === "session" && action === "resume")
+			return {
+				session: await rpc(
+					client["session.resume"]({ sessionId: selectedSessionId }),
+				),
+			};
+		throw new CliError(
+			"invalid_input",
+			`Unknown command: ${args.positionals.join(" ")}.`,
+		);
+	} finally {
+		await session.dispose();
+	}
+};
+
+export const runAgentCli = async (
+	argv: ReadonlyArray<string>,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<void> => {
+	try {
+		success(await execute(await expandInputJson(argv), env));
+	} catch (cause) {
+		failure(cause);
+	}
+};
+
+export const __testing = { parse, execute, commandManifest, expandInputJson };

--- a/packages/serve/src/cli.ts
+++ b/packages/serve/src/cli.ts
@@ -1,8 +1,14 @@
-import { runServePackageCli } from "@zusehq/server/serve-cli";
 import packageMetadata from "../package.json" with { type: "json" };
+import { isAgentCliCommand, runAgentCli } from "./agent-cli.ts";
 import type { ServeCli } from "./cli-types.ts";
 
-export const runServeCli: ServeCli = (argv, env = process.env): Promise<void> =>
-	runServePackageCli(argv, env, {
+export const runServeCli: ServeCli = async (
+	argv,
+	env = process.env,
+): Promise<void> => {
+	if (isAgentCliCommand(argv)) return runAgentCli(argv, env);
+	const { runServePackageCli } = await import("@zusehq/server/serve-cli");
+	return runServePackageCli(argv, env, {
 		packageVersion: packageMetadata.version,
 	});
+};

--- a/packages/serve/test/agent-cli.test.ts
+++ b/packages/serve/test/agent-cli.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import { __testing, isAgentCliCommand } from "../src/agent-cli.ts";
 
@@ -66,5 +69,45 @@ describe("agent CLI", () => {
 		expect(parsed.flags.get("session")).toEqual(["s_1"]);
 		expect(parsed.flags.get("file")).toEqual(["a.ts", "b.ts"]);
 		expect(parsed.flags.get("permission")).toEqual(["plan"]);
+	});
+
+	test("discovers the protected local dev RPC descriptor", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "zuse-cli-access-"));
+		const accessFile = join(directory, "cli-access.json");
+		await writeFile(
+			accessFile,
+			JSON.stringify({
+				schemaVersion: 1,
+				wsUrl: "ws://127.0.0.1:8788/rpc",
+				token: "zt_development",
+			}),
+		);
+		await expect(
+			__testing.devCliAccess({ ZUSE_DEV_CLI_ACCESS_FILE: accessFile }),
+		).resolves.toEqual({
+			schemaVersion: 1,
+			wsUrl: "ws://127.0.0.1:8788/rpc",
+			token: "zt_development",
+		});
+	});
+
+	test("negotiates the current wire protocol with local dev RPC", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "zuse-cli-endpoint-"));
+		const accessFile = join(directory, "cli-access.json");
+		await writeFile(
+			accessFile,
+			JSON.stringify({
+				schemaVersion: 1,
+				wsUrl: "ws://127.0.0.1:8788/rpc",
+				token: "zt_development",
+			}),
+		);
+		const endpoint = new URL(
+			await __testing.endpoint(__testing.parse(["computer", "list"]), {
+				ZUSE_DEV_CLI_ACCESS_FILE: accessFile,
+			}),
+		);
+		expect(endpoint.searchParams.get("wireVersion")).toBe("4");
+		expect(endpoint.searchParams.get("token")).toBe("zt_development");
 	});
 });

--- a/packages/serve/test/agent-cli.test.ts
+++ b/packages/serve/test/agent-cli.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { __testing, isAgentCliCommand } from "../src/agent-cli.ts";
+
+describe("agent CLI", () => {
+	test("recognizes control-plane commands without stealing serve commands", () => {
+		expect(isAgentCliCommand(["chat", "list"])).toBe(true);
+		expect(isAgentCliCommand(["session", "send"])).toBe(true);
+		expect(isAgentCliCommand(["serve", "status"])).toBe(false);
+	});
+
+	test("parses repeatable and inline options", () => {
+		const parsed = __testing.parse([
+			"session",
+			"send",
+			"--session=s_1",
+			"--file",
+			"a.ts",
+			"--file",
+			"b.ts",
+			"--include-archived",
+		]);
+		expect(parsed.positionals).toEqual(["session", "send"]);
+		expect(parsed.flags.get("session")).toEqual(["s_1"]);
+		expect(parsed.flags.get("file")).toEqual(["a.ts", "b.ts"]);
+		expect(parsed.flags.get("include-archived")).toEqual(["true"]);
+	});
+
+	test("publishes a machine-readable command manifest", () => {
+		const manifest = __testing.commandManifest();
+		expect(manifest.schemaVersion).toBe(1);
+		expect(manifest.commands).toContain("chat create");
+		expect(manifest.commands).toContain("session mode");
+		expect(manifest.commands).toContain("session send");
+	});
+
+	test("expands JSON input into the same repeatable flag contract", async () => {
+		const argv = await __testing.expandInputJson([
+			"session",
+			"send",
+			"--input-json",
+			JSON.stringify({
+				session: "s_1",
+				file: ["a.ts", "b.ts"],
+				permission: "plan",
+			}),
+		]);
+		const parsed = __testing.parse(argv);
+		expect(parsed.flags.get("session")).toEqual(["s_1"]);
+		expect(parsed.flags.get("file")).toEqual(["a.ts", "b.ts"]);
+		expect(parsed.flags.get("permission")).toEqual(["plan"]);
+	});
+});

--- a/packages/serve/test/agent-cli.test.ts
+++ b/packages/serve/test/agent-cli.test.ts
@@ -31,6 +31,24 @@ describe("agent CLI", () => {
 		expect(manifest.commands).toContain("chat create");
 		expect(manifest.commands).toContain("session mode");
 		expect(manifest.commands).toContain("session send");
+		expect(manifest.commands).toContain("session fork");
+		expect(manifest.commands).toContain("session model");
+		expect(manifest.commands).toContain("session provider");
+		expect(manifest.commands).toContain("session transcript");
+		expect(manifest.commands).toContain("session plan");
+		expect(manifest.commands).toContain("session plan-respond");
+		expect(manifest.commands).toContain("session answer");
+		expect(manifest.commands).toContain("session queue-add");
+		expect(manifest.commands).toContain("chat archive");
+		expect(manifest.commands).toContain("chat workspace");
+		expect(manifest.contextOptions).toEqual([
+			"--attach",
+			"--file",
+			"--linear",
+			"--transcript",
+			"--plan",
+		]);
+		expect(manifest.deleteRequires).toBe("--confirm");
 	});
 
 	test("expands JSON input into the same repeatable flag contract", async () => {

--- a/packages/serve/tsdown.config.ts
+++ b/packages/serve/tsdown.config.ts
@@ -1,14 +1,22 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["src/bin.ts", "src/cli.ts", "src/status.ts"],
+	entry: ["src/bin.ts", "src/cli.ts", "src/status.ts", "src/agent-cli.ts"],
 	format: "esm",
 	outDir: "dist",
 	outExtensions: () => ({ js: ".mjs" }),
 	sourcemap: true,
 	dts: false,
 	deps: {
-		alwaysBundle: [/.*/u, "@zusehq/server", "@zusehq/server/**"],
+		alwaysBundle: [
+			/.*/u,
+			"@zuse/client-runtime",
+			"@zuse/client-runtime/**",
+			"@zuse/contracts",
+			"@zuse/contracts/**",
+			"@zusehq/server",
+			"@zusehq/server/**",
+		],
 		neverBundle: [
 			"bindings",
 			"keytar",

--- a/scripts/dev-instance.mjs
+++ b/scripts/dev-instance.mjs
@@ -73,6 +73,7 @@ const instanceResources = (repoRoot, instance) => {
 	return {
 		instanceRoot,
 		userDataDir: resolve(instanceRoot, "user-data"),
+		cliAccessFile: resolve(instanceRoot, "cli-access.json"),
 		packDir: resolve(
 			repoRoot,
 			"apps",
@@ -85,7 +86,7 @@ const instanceResources = (repoRoot, instance) => {
 };
 
 const defaultInstanceResources = (repoRoot) => ({
-	instanceRoot: undefined,
+	instanceRoot: resolve(repoRoot, ".zuse", "dev-instances", "default"),
 	userDataDir: undefined,
 	packDir: resolve(
 		repoRoot,
@@ -94,6 +95,13 @@ const defaultInstanceResources = (repoRoot) => ({
 		".dev-instances",
 		"default",
 		"dist-electron",
+	),
+	cliAccessFile: resolve(
+		repoRoot,
+		".zuse",
+		"dev-instances",
+		"default",
+		"cli-access.json",
 	),
 });
 
@@ -176,16 +184,21 @@ export const withScannedPorts = async (
 				const portsShifted =
 					rendererPort !== initial.rendererPort ||
 					websocketPort !== initial.websocketPort;
+				const shiftedResources = portsShifted
+					? instanceResources(
+							initial.repoRoot,
+							`${initial.instance}-p${rendererPort}`,
+						)
+					: null;
 				return {
 					...initial,
-					...(portsShifted
-						? {
-								packDir: instanceResources(
-									initial.repoRoot,
-									`${initial.instance}-p${rendererPort}`,
-								).packDir,
-							}
-						: {}),
+					...(shiftedResources === null
+						? {}
+						: {
+								instanceRoot: shiftedResources.instanceRoot,
+								packDir: shiftedResources.packDir,
+								cliAccessFile: shiftedResources.cliAccessFile,
+							}),
 					...(initial.userDataExplicit
 						? { userDataDir: initial.userDataDir }
 						: {}),
@@ -195,13 +208,16 @@ export const withScannedPorts = async (
 				};
 			}
 			const instance = validateInstance(`port-${rendererPort}`);
+			const resources =
+				rendererPort === RENDERER_BASE_PORT &&
+				websocketPort === WEBSOCKET_BASE_PORT
+					? defaultInstanceResources(initial.repoRoot)
+					: instanceResources(initial.repoRoot, instance);
 			return {
 				...initial,
-				packDir:
-					rendererPort === RENDERER_BASE_PORT &&
-					websocketPort === WEBSOCKET_BASE_PORT
-						? defaultInstanceResources(initial.repoRoot).packDir
-						: instanceResources(initial.repoRoot, instance).packDir,
+				instanceRoot: resources.instanceRoot,
+				packDir: resources.packDir,
+				cliAccessFile: resources.cliAccessFile,
 				...(initial.userDataExplicit
 					? { userDataDir: initial.userDataDir }
 					: {}),

--- a/scripts/dev-instance.test.mjs
+++ b/scripts/dev-instance.test.mjs
@@ -34,6 +34,7 @@ test("named instances produce deterministic isolated resources", () => {
 	assert.equal(first.websocketPort, second.websocketPort);
 	assert.match(first.userDataDir, /review\/user-data$/u);
 	assert.match(first.packDir, /review\/dist-electron$/u);
+	assert.match(first.cliAccessFile, /review\/cli-access\.json$/u);
 });
 
 test("the first unnamed instance preserves the existing development profile", () => {
@@ -46,6 +47,7 @@ test("the first unnamed instance preserves the existing development profile", ()
 	assert.equal(instance.websocketPort, 8788);
 	assert.equal(instance.userDataDir, undefined);
 	assert.match(instance.packDir, /default\/dist-electron$/u);
+	assert.match(instance.cliAccessFile, /default\/cli-access\.json$/u);
 	assert.equal(
 		devInstanceDiagnostics(instance).dataDirectory,
 		"Electron default (existing Zuse Alpha (Dev) profile)",
@@ -92,6 +94,7 @@ test("scans paired ports forward and fails occupied explicit overrides", async (
 	assert.equal(scanned.websocketPort, 8790);
 	assert.equal(scanned.userDataDir, initial.userDataDir);
 	assert.match(scanned.packDir, /scan-p5735\/dist-electron$/u);
+	assert.match(scanned.cliAccessFile, /scan-p5735\/cli-access\.json$/u);
 
 	const explicit = initialDevInstance({
 		argv: ["--instance", "busy"],

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -100,6 +100,7 @@ const sharedEnv = {
 	ZUSE_DEV_INSTANCE: instance.instance,
 	ZUSE_DEV_STARTED_AT: String(devStartedAt),
 	ZUSE_DESKTOP_WS_PORT: String(instance.websocketPort),
+	ZUSE_DEV_CLI_ACCESS_FILE: instance.cliAccessFile,
 	...(instance.userDataDir ? { ZUSE_USER_DATA_DIR: instance.userDataDir } : {}),
 	ZUSE_DESKTOP_OUT_DIR: instance.packDir,
 	ZUSE_DESKTOP_DIR: resolve(repoRoot, "apps", "desktop"),


### PR DESCRIPTION
## Summary

- add a machine-readable JSON CLI for projects, chats, sessions, models, modes, messages, attachments, transcripts, plans, handoffs, and forks
- expose the CLI through the existing Zuse executable and package build
- add secure automatic discovery of the protected branch-local RPC started by `bun dev`, including concurrent dev-instance ports and wire-protocol negotiation
- document the automation contract in product docs and the bundled Zuse skill

## Why

Agents need a reliable way to perform the same orchestration operations available in the desktop chat without depending on production RPC state or interpreting error responses as successful mutations.

The local-development connection previously defaulted to the installed desktop port and omitted the required wire version. This caused a valid authenticated connection to be rejected during protocol negotiation and surfaced as a misleading authorization error.

## Impact

Automation can select projects, chats, sessions, providers and models; create and steer conversations; change permission and runtime modes; attach context; read transcripts and plans; and fork sessions into tabs or new chats. Inside a checkout running `bun dev`, the CLI securely discovers the active local RPC without manually passing a URL or token.

## Validation

- `bun run --filter @zusehq/serve test`
- `bun run --filter @zusehq/serve check-types`
- `bun run --filter @zusehq/serve build`
- `bun run --filter @zusehq/server check-types`
- `bun run --filter desktop check-types`
- `bun run --filter docs check-types`
- `bun run --filter docs check-links`
- `bun run test:dev-runner`
- focused bundled Zuse skill tests
- Biome checks and `git diff --check`
- live `bun dev` smoke tests for computer, project, model and chat listing, message delivery, agent response, tab fork, and new-chat fork

## Known issue

A live smoke test found that `chat create --prompt` creates the chat successfully but does not deliver its startup prompt. Sending the same prompt with `session send` works, and both fork paths work. This draft keeps that limitation visible for follow-up before readiness.