### PR TITLE
Replace stale downloaded updates

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -179,6 +179,7 @@ import { TailnetEnvironmentManager } from "./tailnet/environment-service.ts";
 import {
 	getIsInstallingUpdate,
 	getLastStatus,
+	installPendingUpdateOnQuit,
 	onStatusChange,
 	registerUpdaterDemo,
 	startAutoUpdater,
@@ -3614,15 +3615,29 @@ const finishQuitAfterSshCleanup = (event: {
 	});
 };
 
+const beginPendingUpdateInstall = (event: Electron.Event): boolean => {
+	if (!installPendingUpdateOnQuit()) return false;
+	event.preventDefault();
+	return true;
+};
+
 app.on("before-quit", (event) => {
 	// An update-driven quit (user picked "Restart now") or an already-confirmed
 	// quit passes straight through — the user has opted in, and re-prompting
 	// would strand the relaunch.
-	if (quitConfirmed || getIsInstallingUpdate()) {
+	if (getIsInstallingUpdate()) {
+		finishQuitAfterSshCleanup(event);
+		return;
+	}
+	if (quitConfirmed) {
+		// On macOS, stage only after quit is allowed so a newer release can
+		// supersede an older download without bypassing the running-agent guard.
+		if (beginPendingUpdateInstall(event)) return;
 		finishQuitAfterSshCleanup(event);
 		return;
 	}
 	if (runningAgentCount <= 0) {
+		if (beginPendingUpdateInstall(event)) return;
 		finishQuitAfterSshCleanup(event);
 		return;
 	}

--- a/apps/desktop/src/updater-policy.ts
+++ b/apps/desktop/src/updater-policy.ts
@@ -1,0 +1,19 @@
+import type { UpdateStatus } from "@zuse/contracts";
+
+export function shouldAutoInstallUpdateOnQuit(
+	platform: NodeJS.Platform,
+): boolean {
+	return platform !== "darwin";
+}
+
+export function shouldInstallPendingUpdateOnQuit(options: {
+	platform: NodeJS.Platform;
+	status: UpdateStatus;
+	installing: boolean;
+}): boolean {
+	return (
+		options.platform === "darwin" &&
+		options.status.kind === "ready" &&
+		!options.installing
+	);
+}

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -1,10 +1,3 @@
-import { app, ipcMain, type BrowserWindow } from "electron";
-import {
-  autoUpdater,
-  type ProgressInfo,
-  type UpdateInfo,
-} from "electron-updater";
-
 import {
   UPDATE_CHECK_CHANNEL,
   UPDATE_DOWNLOAD_CHANNEL,
@@ -12,12 +5,22 @@ import {
   UPDATE_STATUS_CHANNEL,
   type UpdateStatus,
 } from "@zuse/contracts";
+import { app, type BrowserWindow, ipcMain } from "electron";
+import {
+  autoUpdater,
+  type ProgressInfo,
+  type UpdateInfo,
+} from "electron-updater";
 import {
   automaticUpdateRetryDelay,
   isTransientUpdateCheckError,
   updateCheckErrorMessage,
   updateDownloadErrorMessage,
 } from "./updater-errors.ts";
+import {
+  shouldAutoInstallUpdateOnQuit,
+  shouldInstallPendingUpdateOnQuit,
+} from "./updater-policy.ts";
 
 // electron-updater talks to the GitHub Releases feed configured in
 // apps/desktop/electron-builder.yml (`publish.provider: github`). It reads
@@ -55,6 +58,30 @@ let installingUpdate = false;
  */
 export function getIsInstallingUpdate(): boolean {
   return installingUpdate;
+}
+
+/**
+ * On macOS we deliberately do not let electron-updater hand a download to
+ * Squirrel until the app is actually quitting. Squirrel keeps the first
+ * staged update for the lifetime of the process, which otherwise means a
+ * newer release discovered later cannot replace it.
+ *
+ * Returns true when the caller must prevent the current quit event. The
+ * updater will start a fresh quit after Squirrel has staged the latest file.
+ */
+export function installPendingUpdateOnQuit(): boolean {
+  if (
+    !shouldInstallPendingUpdateOnQuit({
+      platform: process.platform,
+      status: lastStatus,
+      installing: installingUpdate,
+    })
+  ) {
+    return false;
+  }
+
+  installUpdate();
+  return true;
 }
 
 /**
@@ -250,7 +277,13 @@ export function startAutoUpdater(window: BrowserWindow): void {
   // "Restart" button we still install on next quit so the update isn't
   // stranded forever.
   autoUpdater.autoDownload = true;
-  autoUpdater.autoInstallOnAppQuit = true;
+  // Squirrel.Mac cannot supersede an update it has already staged during the
+  // current process. Keep downloads in electron-updater's replaceable cache
+  // on macOS, then stage the latest one from the before-quit handler. Other
+  // platforms can safely retain electron-updater's normal install-on-quit.
+  autoUpdater.autoInstallOnAppQuit = shouldAutoInstallUpdateOnQuit(
+    process.platform,
+  );
 
   autoUpdater.on("checking-for-update", () => {
     clearStallTimer();

--- a/apps/desktop/test/unit/updater-policy.test.ts
+++ b/apps/desktop/test/unit/updater-policy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	shouldAutoInstallUpdateOnQuit,
+	shouldInstallPendingUpdateOnQuit,
+} from "../../src/updater-policy.ts";
+
+describe("desktop updater policy", () => {
+	it("keeps macOS downloads replaceable until the app quits", () => {
+		expect(shouldAutoInstallUpdateOnQuit("darwin")).toBe(false);
+		expect(shouldAutoInstallUpdateOnQuit("win32")).toBe(true);
+		expect(shouldAutoInstallUpdateOnQuit("linux")).toBe(true);
+	});
+
+	it("stages a ready macOS update when the user quits", () => {
+		expect(
+			shouldInstallPendingUpdateOnQuit({
+				platform: "darwin",
+				status: { kind: "ready", version: "0.18.5" },
+				installing: false,
+			}),
+		).toBe(true);
+	});
+
+	it("does not intercept quit without a ready macOS update", () => {
+		expect(
+			shouldInstallPendingUpdateOnQuit({
+				platform: "darwin",
+				status: { kind: "downloading", percent: 50, bytesPerSecond: 1_000 },
+				installing: false,
+			}),
+		).toBe(false);
+		expect(
+			shouldInstallPendingUpdateOnQuit({
+				platform: "linux",
+				status: { kind: "ready", version: "0.18.5" },
+				installing: false,
+			}),
+		).toBe(false);
+		expect(
+			shouldInstallPendingUpdateOnQuit({
+				platform: "darwin",
+				status: { kind: "ready", version: "0.18.5" },
+				installing: true,
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/renderer/src/components/update-banner.tsx
+++ b/apps/renderer/src/components/update-banner.tsx
@@ -1,9 +1,6 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import {
-	Alert01Icon,
-	CircleArrowUp01Icon,
-} from "@zuse/icons/solid-rounded";
 import type { UpdateStatus } from "@zuse/contracts";
+import { Alert01Icon, CircleArrowUp01Icon } from "@zuse/icons/solid-rounded";
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
@@ -29,8 +26,7 @@ import { useSessionRuntimeStore } from "~/store/session-runtime.ts";
  * On `ready` the user picks one of:
  *  - **Restart now** — installs + relaunches immediately. If agents are still
  *    running we confirm first ("N agents are running — restart anyway?").
- *  - **Restart later** — dismiss; electron-updater installs on next quit
- *    (`autoInstallOnAppQuit = true`).
+ *  - **Restart later** — dismiss; the main process installs on next quit.
  *  - **Restart when idle** — installs automatically once no agents are running.
  */
 export function UpdateBanner() {


### PR DESCRIPTION
## What changed

- keep downloaded macOS updates replaceable until the app actually quits
- stage the latest cached update during the quit flow
- preserve running-agent quit protection and Restart later behavior
- add focused updater policy coverage

## Why

The macOS updater staged the first downloaded release immediately. If another release arrived before restart, the newly downloaded version could not supersede the already staged update, forcing users to install twice.

## Validation

- Biome checks for changed files
- 17 focused updater tests
- desktop TypeScript check
- git diff check