### PR TITLE
Add Grok 4.6 model support

### DIFF
--- a/apps/server/test/integration/config-store.test.ts
+++ b/apps/server/test/integration/config-store.test.ts
@@ -106,6 +106,7 @@ describe("config-store settings coercion", () => {
 		expect(settings.modelEnabledByProvider.codex["gpt-5.6-luna"]).toBe(true);
 		expect(settings.modelEnabledByProvider.codex["gpt-5.5"]).toBe(true);
 		expect(settings.modelEnabledByProvider.codex["gpt-5.3-codex"]).toBe(false);
+		expect(settings.modelEnabledByProvider.grok["grok-4.6"]).toBe(true);
 		expect(settings.modelEnabledByProvider.grok["grok-4.5"]).toBe(true);
 	});
 

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -1212,6 +1212,13 @@ export const MODELS_BY_PROVIDER: Record<
       supportsWebSearch: "queryOnly",
     },
     {
+      id: "grok-4.6",
+      label: "Grok 4.6",
+      badgeLabel: "New",
+      supportsPlanMode: true,
+      supportsWebSearch: "queryOnly",
+    },
+    {
       id: "grok-4.5",
       label: "Grok 4.5",
       supportsPlanMode: true,
@@ -1555,8 +1562,9 @@ export const MODEL_ALIASES_BY_PROVIDER: Record<
     "gpt-5": "gpt-5.5",
   },
   grok: {
+    "grok-4.6-latest": "grok-4.6",
     "grok-4.5-latest": "grok-4.5",
-    "grok-build-latest": "grok-4.5",
+    "grok-build-latest": "grok-4.6",
   },
   gemini: {
     "gemini-3-pro": "gemini-3-pro-preview",

--- a/packages/contracts/test/unit/schema.test.ts
+++ b/packages/contracts/test/unit/schema.test.ts
@@ -828,14 +828,19 @@ describe("model visibility helpers", () => {
 		).toBe(true);
 	});
 
-	it("surfaces Grok 4.5 without changing the Grok default", () => {
+	it("surfaces current Grok models without changing the Grok default", () => {
 		expect(defaultModelFor("grok")).toBe("grok-build");
+		expect(MODELS_BY_PROVIDER.grok.some((m) => m.id === "grok-4.6")).toBe(true);
+		expect(
+			visibleModelsForProvider("grok").some((m) => m.id === "grok-4.6"),
+		).toBe(true);
 		expect(MODELS_BY_PROVIDER.grok.some((m) => m.id === "grok-4.5")).toBe(true);
 		expect(
 			visibleModelsForProvider("grok").some((m) => m.id === "grok-4.5"),
 		).toBe(true);
+		expect(resolveModelSlug("grok", "grok-4.6-latest")).toBe("grok-4.6");
 		expect(resolveModelSlug("grok", "grok-4.5-latest")).toBe("grok-4.5");
-		expect(resolveModelSlug("grok", "grok-build-latest")).toBe("grok-4.5");
+		expect(resolveModelSlug("grok", "grok-build-latest")).toBe("grok-4.6");
 	});
 
 	it("can include a hidden selected model without making all hidden models visible", () => {


### PR DESCRIPTION
## Summary
- add Grok 4.6 to the shared model picker catalog
- resolve current Grok aliases to Grok 4.6 while preserving the explicit 4.5 alias
- seed Grok 4.6 as visible in existing settings

## Validation
- `grok models` (confirmed `grok-4.6` is available and default)
- live `grok-4.6` single-turn smoke
- `bun --filter @zuse/contracts test:unit`
- `bun --filter @zuse/contracts check-types`
- `bun --filter @zusehq/server test:integration -- config-store.test.ts`
- `bun run check-types`
- `git diff --check`

## Known baseline
- focused Biome check reports existing whole-file formatting and non-null assertion findings in `packages/contracts/src/agent.ts`; no new finding is introduced by this change.