### PR TITLE
Release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0]
+
+### Added
+- Added a machine-readable `zuse agent` CLI for automating projects, chats, sessions, models, messages, attachments, transcripts, plans, handoffs, and forks, with secure discovery of local development instances
+- Added Grok 4.6 to the model picker and updated current Grok aliases to use it while preserving explicit Grok 4.5 selection
+
+### Fixed
+- macOS now installs the newest downloaded update on quit instead of potentially staging an older cached release first
+
 ## [0.18.4]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.18.4",
+	"version": "0.19.0",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.19.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Added a machine-readable `zuse agent` CLI for automating projects, chats, sessions, models, messages, attachments, transcripts, plans, handoffs, and forks, with secure discovery of local development instances",
+          "Added Grok 4.6 to the model picker and updated current Grok aliases to use it while preserving explicit Grok 4.5 selection"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+        "macOS now installs the newest downloaded update on quit instead of potentially staging an older cached release first"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.18.4",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.18.4",
+      "version": "0.19.0",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.19.0 with release notes grouped by user-visible outcome.

### Added
- Added a machine-readable `zuse agent` CLI for automating projects, chats, sessions, models, messages, attachments, transcripts, plans, handoffs, and forks, with secure discovery of local development instances
- Added Grok 4.6 to the model picker and updated current Grok aliases to use it while preserving explicit Grok 4.5 selection

### Fixed
- macOS now installs the newest downloaded update on quit instead of potentially staging an older cached release first

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.19.0 after this PR lands.
