### PR TITLE
Fix CLI package dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -242,7 +242,7 @@
     },
     "apps/server": {
       "name": "@zusehq/server",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "keytar": "^7.9.0",
         "node-pty": "^1.1.0",
@@ -271,7 +271,7 @@
         "@zuse/sqlite": "*",
         "@zuse/tailnet": "*",
         "@zuse/utils": "*",
-        "effect": "catalog:",
+        "effect": "4.0.0-beta.102",
         "fuzzysort": "catalog:",
         "jose": "^6.2.3",
         "smol-toml": "^1.3.1",

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zusehq/serve",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "One-command remote access for Zuse workspaces",
 	"license": "AGPL-3.0-only",
 	"type": "module",
@@ -35,7 +35,7 @@
 	},
 	"dependencies": {
 		"@zusehq/server": "0.1.2",
-		"effect": "catalog:"
+		"effect": "4.0.0-beta.102"
 	},
 	"devDependencies": {
 		"@zuse/client-runtime": "*",


### PR DESCRIPTION
## Summary

- bump `@zusehq/serve` to `0.1.3`
- replace the monorepo-only `effect` catalog dependency with its registry version
- keep the published CLI manifest installable through npm and `npx`

## Root cause

The `0.1.2` package retained `"effect": "catalog:"` in its published manifest. npm does not support workspace catalog specifiers when installing a public package, so clean `npx` installs failed with `EUNSUPPORTEDPROTOCOL`.

## Validation

- `bun run --filter @zusehq/serve test`
- `bun run --filter @zusehq/serve check-types`
- `bun run --filter @zusehq/serve build`
- packed tarball installed in an empty temporary directory
- public `npx --yes @zusehq/serve@0.1.3 commands` returned the JSON manifest with 38 commands

## Publication

- `@zusehq/server@0.1.2` published
- `@zusehq/serve@0.1.2` published but cannot be clean-installed because of the catalog specifier
- `@zusehq/serve@0.1.3` published and verified; it is the current `latest` version