### PR TITLE
Fix cloud workspace bootstrap recovery

### DIFF
--- a/.github/workflows/cloud-runtime-staging.yml
+++ b/.github/workflows/cloud-runtime-staging.yml
@@ -50,7 +50,7 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             enabled=true
           elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$REQUESTED_PUBLICATION" == "true" ]]; then
-            if [[ "$GITHUB_REF" != "refs/heads/swarajbachu/e2b-integration-feasibility" ]]; then
+            if [[ "$GITHUB_REF" != "refs/heads/swarajbachu/untitled-v1" ]]; then
               echo "Ref $GITHUB_REF is not authorized to publish the staging runtime" >&2
               exit 1
             fi

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -30,6 +30,7 @@ import {
 import { AppearanceController } from "./lib/appearance.tsx";
 import { installClientBusOnlineBridge } from "./lib/client-bus-online.ts";
 import { closeActiveChatTab } from "./lib/close-chat-tab.ts";
+import { useCloudChatSummaryForSession } from "./lib/cloud-workspaces.ts";
 import { useActiveSessionById } from "./lib/environment-entity-hooks.ts";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { useSettingsStore } from "./lib/settings-client-bus.ts";
@@ -386,15 +387,19 @@ function MainShell() {
 	const selectedFolderId = useWorkspaceStore((s) => s.selectedFolderId);
 	const selectedSessionId = useSessionsStore((s) => s.selectedSessionId);
 	const selectedChatId = useChatsStore((s) => s.selectedChatId);
+	const selectedCloudSummary = useCloudChatSummaryForSession(selectedSessionId);
+	const selectedEnvironmentId = EnvironmentId.make(
+		selectedCloudSummary?.workspaceId ?? activeEnvironmentId,
+	);
 	const selectedChatRef = useMemo(
 		() =>
 			selectedChatId === null
 				? null
 				: {
-						environmentId: EnvironmentId.make(activeEnvironmentId),
+						environmentId: selectedEnvironmentId,
 						chatId: selectedChatId,
 					},
-		[activeEnvironmentId, selectedChatId],
+		[selectedChatId, selectedEnvironmentId],
 	);
 	const selectedChatKey =
 		selectedChatRef === null ? null : rightPaneKey(selectedChatRef);
@@ -405,7 +410,7 @@ function MainShell() {
 	);
 	const selectedSession = useActiveSessionById(selectedSessionId);
 	const directoryStatus = useChatDirectoryStatus(
-		EnvironmentId.make(activeEnvironmentId),
+		selectedEnvironmentId,
 		pendingCreation === null ? (selectedSession?.chatId ?? null) : null,
 	);
 	const directoryUnavailable = directoryStatus?._tag === "unavailable";
@@ -620,7 +625,7 @@ function MainShell() {
 						{showMainTabs ? (
 							<Suspense fallback={<TabsFallback />}>
 								<MainTabs
-									environmentId={EnvironmentId.make(activeEnvironmentId)}
+									environmentId={selectedEnvironmentId}
 									projectId={selectedFolderId}
 									emptyLabel={emptyTabLabel}
 								/>
@@ -643,7 +648,7 @@ function MainShell() {
 										<Suspense fallback={<SurfaceFallback />}>
 											<ChatView
 												sessionId={selectedSessionId}
-												environmentId={EnvironmentId.make(activeEnvironmentId)}
+												environmentId={selectedEnvironmentId}
 												endInset={composerInset}
 											/>
 										</Suspense>
@@ -677,9 +682,7 @@ function MainShell() {
 													<ChatComposer
 														key={selectedSession.id}
 														session={selectedSession}
-														environmentId={EnvironmentId.make(
-															activeEnvironmentId,
-														)}
+														environmentId={selectedEnvironmentId}
 														constrain={false}
 														directoryUnavailable={directoryUnavailable}
 													/>

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -178,6 +178,12 @@ const cloudFailureRank = (statusCode: string): number => {
 
 export const cloudFailureMessage = (statusCode: string): string => {
 	switch (statusCode) {
+		case "updating-runtime-failed":
+			return "The secure runtime is incompatible with the cloud control plane. Retry after the cloud service finishes updating.";
+		case "starting-runtime-failed":
+			return "The secure runtime could not start. Retry will create a clean sandbox.";
+		case "syncing-repository-failed":
+			return "The sandbox started, but the repository could not be prepared. Retry will create a clean sandbox.";
 		case "runtime-connection-timeout":
 			return "The sandbox started, but its secure runtime did not connect in time.";
 		case "provider-sandbox-missing":

--- a/apps/renderer/src/lib/cloud-workspace-catalog.ts
+++ b/apps/renderer/src/lib/cloud-workspace-catalog.ts
@@ -91,6 +91,39 @@ export const registerCloudChat = (
 	}));
 };
 
+/**
+ * Reconciles a successful `scope=all` response. Relay owns catalog membership,
+ * so a workspace omitted from that authoritative response was deleted and must
+ * not survive as a renderer-only history row. Versions for workspaces which
+ * are still present remain monotonic.
+ */
+export const reconcileCloudChatCatalog = (
+	incoming: ReadonlyArray<CloudChatSummary>,
+): ReadonlyArray<CloudChatSummary> => {
+	const incomingIds = new Set(incoming.map((summary) => summary.workspaceId));
+	const previous = useCloudChatCatalogStore.getState();
+	const removed = previous.summaries.filter(
+		(summary) => !incomingIds.has(summary.workspaceId),
+	);
+	const summaries = incoming.flatMap((summary) => {
+		const current = previous.summaries.find(
+			(candidate) => candidate.workspaceId === summary.workspaceId,
+		);
+		return mergeCloudChatSummaries(current === undefined ? [] : [current], [
+			summary,
+		]);
+	});
+	useCloudChatCatalogStore.setState({
+		summaries: sortSummaries(summaries),
+		localProjectByEnvironment: Object.fromEntries(
+			Object.entries(previous.localProjectByEnvironment).filter(
+				([environmentId]) => incomingIds.has(environmentId),
+			),
+		),
+	});
+	return removed;
+};
+
 export const cloudSummaryForChat = (chatId: string): CloudChatSummary | null =>
 	useCloudChatCatalogStore
 		.getState()

--- a/apps/renderer/src/lib/cloud-workspaces.ts
+++ b/apps/renderer/src/lib/cloud-workspaces.ts
@@ -24,6 +24,7 @@ import {
 import { registerEnvironmentWake } from "../lib/session-timeline-client-bus.ts";
 import { createAtomStore as create } from "../state/atom-store.ts";
 import { useChatsStore } from "../store/chats.ts";
+import { useSessionsStore } from "../store/sessions.ts";
 import {
 	cloudSummaryForChat,
 	cloudSummaryForEnvironment,
@@ -31,6 +32,7 @@ import {
 	compareCloudChatSummaryVersion,
 	localProjectForCloudChat,
 	localProjectForCloudEnvironment,
+	reconcileCloudChatCatalog,
 	registerCloudChat,
 	registerCloudChatCatalogRefresh,
 	useCloudChatCatalogStore,
@@ -319,6 +321,58 @@ export const summaryFromLaunch = (input: {
 	updatedAt: input.workspace.updatedAt,
 });
 
+const removeDeletedCloudPlaceholders = (
+	removed: ReadonlyArray<CloudChatSummary>,
+): void => {
+	if (removed.length === 0) return;
+	const chatIds = new Set(removed.map((summary) => summary.chatId));
+	const sessionIds = new Set(
+		removed.map((summary) => summary.initialSessionId),
+	);
+	overlayActiveEnvironmentShell((shell) => ({
+		...shell,
+		chatsByProject: Object.fromEntries(
+			Object.entries(shell.chatsByProject).map(([projectId, chats]) => [
+				projectId,
+				chats.filter((chat) => !chatIds.has(chat.id)),
+			]),
+		),
+		sessionsByProject: Object.fromEntries(
+			Object.entries(shell.sessionsByProject).map(([projectId, sessions]) => [
+				projectId,
+				sessions.filter((session) => !sessionIds.has(session.id)),
+			]),
+		),
+	}));
+	useChatsStore.setState((state) => ({
+		selectedChatId:
+			state.selectedChatId !== null && chatIds.has(state.selectedChatId)
+				? null
+				: state.selectedChatId,
+		selectedChatByProject: Object.fromEntries(
+			Object.entries(state.selectedChatByProject).map(([projectId, chatId]) => [
+				projectId,
+				chatId !== null && chatIds.has(chatId) ? null : chatId,
+			]),
+		),
+	}));
+	useSessionsStore.setState((state) => ({
+		selectedSessionId:
+			state.selectedSessionId !== null &&
+			sessionIds.has(state.selectedSessionId)
+				? null
+				: state.selectedSessionId,
+		selectedSessionByProject: Object.fromEntries(
+			Object.entries(state.selectedSessionByProject).map(
+				([projectId, sessionId]) => [
+					projectId,
+					sessionId !== null && sessionIds.has(sessionId) ? null : sessionId,
+				],
+			),
+		),
+	}));
+};
+
 export const useCloudChatsStore = create<CloudChatsState>((set) => ({
 	loading: false,
 	error: null,
@@ -331,6 +385,7 @@ export const useCloudChatsStore = create<CloudChatsState>((set) => ({
 				const result = await Effect.runPromise(
 					client["cloud.chats.list"]({ scope: "all" }),
 				);
+				removeDeletedCloudPlaceholders(reconcileCloudChatCatalog(result.chats));
 				for (const summary of result.chats) {
 					registerCloudChat(summary);
 					const accepted =
@@ -364,13 +419,15 @@ export const useCloudChatsStore = create<CloudChatsState>((set) => ({
 registerCloudChatCatalogRefresh(() => useCloudChatsStore.getState().hydrate());
 
 export const useCloudChatSummaryForSession = (
-	sessionId: SessionId,
+	sessionId: SessionId | null,
 ): CloudChatSummary | null => {
-	const registered = cloudSummaryForSession(sessionId);
-	return useCloudChatCatalogStore(
-		(state) =>
-			state.summaries.find(
-				(summary) => summary.initialSessionId === sessionId,
-			) ?? registered,
+	const registered =
+		sessionId === null ? null : cloudSummaryForSession(sessionId);
+	return useCloudChatCatalogStore((state) =>
+		sessionId === null
+			? null
+			: (state.summaries.find(
+					(summary) => summary.initialSessionId === sessionId,
+				) ?? registered),
 	);
 };

--- a/apps/renderer/test/unit/cloud-chat-registry.test.ts
+++ b/apps/renderer/test/unit/cloud-chat-registry.test.ts
@@ -14,6 +14,7 @@ import {
 	cloudSummaryForSession,
 	compareCloudChatSummaryVersion,
 	localProjectForCloudChat,
+	reconcileCloudChatCatalog,
 	registerCloudChat,
 	useCloudChatCatalogStore,
 } from "../../src/lib/cloud-workspace-catalog.ts";
@@ -167,5 +168,36 @@ describe("cloud chat catalog", () => {
 			summaryRevision: 4,
 			sessionHeadVersion: 8,
 		});
+	});
+
+	it("removes deleted workspaces during authoritative reconciliation", () => {
+		const retained = summary({
+			workspaceId: "environment-a",
+			chatId: "chat-a",
+			sessionId: "session-a",
+			revision: 2,
+		});
+		const deleted = summary({
+			workspaceId: "environment-b",
+			chatId: "chat-b",
+			sessionId: "session-b",
+			revision: 1,
+		});
+		registerCloudChat(retained, FolderId.make("local-project-a"));
+		registerCloudChat(deleted, FolderId.make("local-project-b"));
+
+		const removed = reconcileCloudChatCatalog([
+			summary({
+				workspaceId: "environment-a",
+				chatId: "chat-a",
+				sessionId: "session-a",
+				revision: 1,
+			}),
+		]);
+
+		expect(removed).toEqual([deleted]);
+		expect(cloudSummaryForEnvironment("environment-a")).toBe(retained);
+		expect(cloudSummaryForEnvironment("environment-b")).toBeNull();
+		expect(localProjectForCloudChat("chat-b")).toBeNull();
 	});
 });

--- a/apps/server/scripts/runtime-updater.mjs
+++ b/apps/server/scripts/runtime-updater.mjs
@@ -466,12 +466,20 @@ try {
 			targetRuntimeVersion: manifest.version,
 		});
 	}
-} catch {
+} catch (cause) {
+	const diagnostic =
+		cause instanceof Error ? cause.message : "Unknown runtime update failure";
+	// The workspace bootstrap redirects stderr into its durable status directory.
+	// Keep this deliberately compact and secret-free: fetch errors and validation
+	// failures do not contain the boot token or provider credentials, while the
+	// message is essential for distinguishing a rollout mismatch from bad bytes.
+	console.error(`Runtime update failed: ${diagnostic}`);
 	await writeStatus({
 		...lastStatus,
 		state: "failed",
 		phase: "failed",
 		failureCode,
+		diagnostic,
 	});
 	process.exitCode = 1;
 } finally {

--- a/apps/server/src/relay/cloud-workspace-runtime.ts
+++ b/apps/server/src/relay/cloud-workspace-runtime.ts
@@ -885,12 +885,6 @@ export const makeCloudWorkspaceRuntimeLayer = (
 					);
 
 					yield* waitForRepository;
-					repositoryReady = true;
-					yield* postReady(
-						config,
-						runtimeCredential.credential,
-						"repository-ready",
-					).pipe(Effect.retry(cloudRuntimeRetrySchedule));
 					const launchIntent = bootstrap.launchIntent;
 					if (launchIntent !== undefined) {
 						const started = yield* startCloudWorkspaceLaunchIntent({
@@ -924,7 +918,20 @@ export const makeCloudWorkspaceRuntimeLayer = (
 									),
 								),
 						).pipe(Effect.retry(cloudRuntimeRetrySchedule));
+					} else {
+						// A resumed workspace already has its durable chat/session. A newly
+						// launched workspace does not become attachable until the launch
+						// intent above has created them and Relay has atomically recorded its
+						// receipt. Advertising repository-ready before that point lets the
+						// client timeline race the session transaction and reconnect-loop on
+						// SessionNotFoundError.
+						yield* postReady(
+							config,
+							runtimeCredential.credential,
+							"repository-ready",
+						).pipe(Effect.retry(cloudRuntimeRetrySchedule));
 					}
+					repositoryReady = true;
 					yield* summaryPublisher
 						.publish("initial")
 						.pipe(Effect.retry(cloudRuntimeRetrySchedule));

--- a/apps/server/src/relay/cloud-workspace-runtime.ts
+++ b/apps/server/src/relay/cloud-workspace-runtime.ts
@@ -95,6 +95,37 @@ export const runtimeReadyPhaseOnGatewayOpen = (
 	repositoryReady: boolean,
 ): "repository-ready" | null => (repositoryReady ? "repository-ready" : null);
 
+const LOCAL_RPC_HANDOFF_MAX_FRAMES = 32;
+const LOCAL_RPC_HANDOFF_MAX_BYTES = 256 * 1024;
+
+export type WorkspaceLocalFrameQueue = {
+	readonly frames: Array<string | ArrayBuffer>;
+	bytes: number;
+};
+
+/**
+ * The gateway owns no replay buffer, but a newly announced client can send its
+ * RPC handshake before the runtime's localhost socket reaches OPEN. Keep only
+ * that short, bounded handoff window in the authoritative runtime process.
+ */
+export const bufferWorkspaceLocalFrame = (
+	queue: WorkspaceLocalFrameQueue,
+	payload: string | ArrayBuffer,
+): boolean => {
+	const bytes =
+		typeof payload === "string"
+			? new TextEncoder().encode(payload).byteLength
+			: payload.byteLength;
+	if (
+		queue.frames.length >= LOCAL_RPC_HANDOFF_MAX_FRAMES ||
+		queue.bytes + bytes > LOCAL_RPC_HANDOFF_MAX_BYTES
+	)
+		return false;
+	queue.frames.push(payload);
+	queue.bytes += bytes;
+	return true;
+};
+
 const BootstrapResponse = Schema.Struct({
 	workspaceId: Schema.String,
 	runtimeCredential: Schema.String,
@@ -697,6 +728,10 @@ export const makeCloudWorkspaceRuntimeLayer = (
 						);
 
 					const localSockets = new Map<string, WebSocket>();
+					const pendingLocalFrames = new Map<
+						string,
+						WorkspaceLocalFrameQueue
+					>();
 					let gateway: WebSocket | null = null;
 					let repositoryReady = false;
 					const sendGateway = (message: unknown) => {
@@ -709,12 +744,24 @@ export const makeCloudWorkspaceRuntimeLayer = (
 					};
 					const openLocal = (connectionId: string) => {
 						if (localSockets.has(connectionId)) return;
+						pendingLocalFrames.set(connectionId, { frames: [], bytes: 0 });
 						const url = new URL(`ws://127.0.0.1:${config.localPort}`);
 						url.searchParams.set("token", localCredential.token);
 						url.searchParams.set("wireVersion", String(WIRE_PROTOCOL_VERSION));
 						const socket = new WebSocket(url);
 						socket.binaryType = "arraybuffer";
 						localSockets.set(connectionId, socket);
+						socket.addEventListener(
+							"open",
+							() => {
+								if (localSockets.get(connectionId) !== socket) return;
+								const pending = pendingLocalFrames.get(connectionId);
+								pendingLocalFrames.delete(connectionId);
+								if (pending === undefined) return;
+								for (const payload of pending.frames) socket.send(payload);
+							},
+							{ once: true },
+						);
 						socket.addEventListener("message", (event) => {
 							publishActivity();
 							if (
@@ -744,6 +791,7 @@ export const makeCloudWorkspaceRuntimeLayer = (
 							// not terminate its successor.
 							if (localSockets.get(connectionId) !== socket) return;
 							localSockets.delete(connectionId);
+							pendingLocalFrames.delete(connectionId);
 							// The gateway deliberately has no replay buffer. Closing the
 							// disposable client makes its one supervisor reconnect and
 							// resume every retained resource from a durable cursor.
@@ -777,13 +825,21 @@ export const makeCloudWorkspaceRuntimeLayer = (
 									if (frame?.direction !== "client") return;
 									publishActivity();
 									const local = localSockets.get(frame.connectionId);
-									// No frame buffer lives in either gateway. A client that wins
-									// the local-open race reconnects and resumes from its cursor.
+									const pending = pendingLocalFrames.get(frame.connectionId);
+									// No frame buffer lives in the gateway. The runtime holds only
+									// the bounded localhost-open handoff for this connection.
 									if (local?.readyState === WebSocket.OPEN) {
 										local.send(frame.payload);
+									} else if (
+										local?.readyState === WebSocket.CONNECTING &&
+										pending !== undefined &&
+										bufferWorkspaceLocalFrame(pending, frame.payload)
+									) {
+										// The localhost socket will flush this frame in order on OPEN.
 									} else {
 										local?.close(1013, "local runtime synchronizing");
 										localSockets.delete(frame.connectionId);
+										pendingLocalFrames.delete(frame.connectionId);
 										sendGateway({
 											type: "client.close",
 											connectionId: frame.connectionId,
@@ -809,6 +865,7 @@ export const makeCloudWorkspaceRuntimeLayer = (
 								) {
 									localSockets.get(message.connectionId)?.close();
 									localSockets.delete(message.connectionId);
+									pendingLocalFrames.delete(message.connectionId);
 								}
 							});
 						},
@@ -819,6 +876,7 @@ export const makeCloudWorkspaceRuntimeLayer = (
 								gateway = null;
 								for (const socket of localSockets.values()) socket.close();
 								localSockets.clear();
+								pendingLocalFrames.clear();
 							}),
 						),
 					);

--- a/apps/server/test/unit/cloud-runtime-assets.test.ts
+++ b/apps/server/test/unit/cloud-runtime-assets.test.ts
@@ -336,9 +336,7 @@ describe("cloud runtime assets", () => {
 			'"$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main"',
 		);
 		expect(workflow).toContain("publish_staging:");
-		expect(workflow).toContain(
-			"refs/heads/swarajbachu/e2b-integration-feasibility",
-		);
+		expect(workflow).toContain("refs/heads/swarajbachu/untitled-v1");
 		expect(workflow.match(/id: publication/gu)).toHaveLength(1);
 		expect(
 			workflow.match(/steps\.publication\.outputs\.enabled == 'true'/gu),

--- a/apps/server/test/unit/cloud-runtime-assets.test.ts
+++ b/apps/server/test/unit/cloud-runtime-assets.test.ts
@@ -256,6 +256,11 @@ describe("cloud runtime assets", () => {
 		expect(updater).toContain("const fetchWithRetry");
 		expect(updater).toContain("AbortSignal.timeout");
 		expect(updater).toContain("Runtime hash is invalid");
+		expect(updater).toContain("Runtime update failed:");
+		expect(updater).toContain("diagnostic,");
+		expect(updater).toContain(
+			'cause instanceof Error ? cause.message : "Unknown runtime update failure"',
+		);
 		expect(updater).toContain("signal: AbortSignal.timeout(2_000)");
 		expect(updater).toContain("const expectedWireProtocol = Number(");
 		expect(updater).toContain("wireProtocol.min > expectedWireProtocol");

--- a/apps/server/test/unit/cloud-workspace-runtime.test.ts
+++ b/apps/server/test/unit/cloud-workspace-runtime.test.ts
@@ -3,6 +3,7 @@ import { TestClock } from "effect/testing";
 import { generateKeyPair, jwtVerify } from "jose";
 import { describe, expect, it, vi } from "vitest";
 import {
+	bufferWorkspaceLocalFrame,
 	makeCloudRuntimeSummaryPublisher,
 	retryCloudWorkspaceBootstrap,
 	runtimeCredentialRenewalDelayMs,
@@ -97,6 +98,20 @@ describe("cloud workspace bootstrap", () => {
 	it("announces readiness when a preserved runtime reconnects", () => {
 		expect(runtimeReadyPhaseOnGatewayOpen(false)).toBeNull();
 		expect(runtimeReadyPhaseOnGatewayOpen(true)).toBe("repository-ready");
+	});
+
+	it("buffers the localhost RPC handshake only within a bounded handoff", () => {
+		const queue = { frames: [] as Array<string | ArrayBuffer>, bytes: 0 };
+		expect(bufferWorkspaceLocalFrame(queue, "handshake")).toBe(true);
+		expect(
+			bufferWorkspaceLocalFrame(queue, new Uint8Array([1, 2]).buffer),
+		).toBe(true);
+		expect(queue.frames).toEqual(["handshake", new Uint8Array([1, 2]).buffer]);
+		expect(queue.bytes).toBe(11);
+		expect(bufferWorkspaceLocalFrame(queue, new ArrayBuffer(256 * 1024))).toBe(
+			false,
+		);
+		expect(queue.frames).toHaveLength(2);
 	});
 
 	it("renews a runtime credential at half-life", () => {

--- a/infra/relay/src/cloud-workspace-reconciler.ts
+++ b/infra/relay/src/cloud-workspace-reconciler.ts
@@ -27,6 +27,24 @@ const RESTORE_READY = "/var/lib/zuse/workspace-restore/ready";
 const RESTORE_FAILED = "/var/lib/zuse/workspace-restore/failed";
 const WORKSPACE_RUNTIME_BOOT_TOKEN_FILE =
 	"/run/zuse-secrets/workspace-runtime-boot-token";
+const PROJECT_BUILD_DIAGNOSTIC_FILE = "/tmp/zuse-project-builder-diagnostic";
+const PROJECT_BUILD_DIAGNOSTIC_MAX_LENGTH = 2_048;
+
+export const sanitizeProjectBuildDiagnostic = (value: string): string => {
+	const sanitized = value
+		.replaceAll(/\b(?:https?|ssh):\/\/\S+/giu, "[redacted-url]")
+		.replaceAll(/\bBearer\s+\S+/giu, "Bearer [redacted]")
+		.replaceAll(
+			/\b(?:gh[oprsu]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/gu,
+			"[redacted-token]",
+		)
+		.replaceAll(
+			/\b((?:api[_-]?key|access[_-]?token|auth[_-]?token|password|secret|token)\s*[=:]\s*)\S+/giu,
+			"$1[redacted]",
+		)
+		.trim();
+	return sanitized.slice(-PROJECT_BUILD_DIAGNOSTIC_MAX_LENGTH);
+};
 
 class CloudWorkspaceLeaseLostError extends Data.TaggedError(
 	"CloudWorkspaceLeaseLostError",
@@ -273,7 +291,7 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudProjectBuild")(function* (
 				command: "/bin/bash",
 				args: [
 					"-lc",
-					'set +e; /usr/local/bin/zuse-project-builder >/var/lib/zuse/project-build/build.log 2>&1; code=$?; printf \'%s\\n\' "$code" >/tmp/zuse-project-builder-exit-code; touch /tmp/zuse-project-builder-exited; exit "$code"',
+					`set +e; /usr/local/bin/zuse-project-builder >/var/lib/zuse/project-build/build.log 2>&1; code=$?; tail -c 4096 /var/lib/zuse/project-build/build.log >${PROJECT_BUILD_DIAGNOSTIC_FILE} 2>/dev/null || true; printf '%s\\n' "$code" >/tmp/zuse-project-builder-exit-code; touch /tmp/zuse-project-builder-exited; exit "$code"`,
 				],
 				env: {
 					ZUSE_REPOSITORY_URL: project.repositoryUrl,
@@ -342,6 +360,27 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudProjectBuild")(function* (
 				: /^[a-z][a-z0-9-]{0,63}$/.test(reportedFailurePhase)
 					? `project-${reportedFailurePhase}-failed`
 					: "project-setup-failed";
+			const diagnostic = buildTimedOut
+				? "Project build timed out before completion."
+				: yield* provider
+						.readTextFile(
+							build.providerSandboxId,
+							PROJECT_BUILD_DIAGNOSTIC_FILE,
+							"zuse",
+						)
+						.pipe(
+							Effect.map(sanitizeProjectBuildDiagnostic),
+							Effect.catchTag("SandboxProviderError", () =>
+								Effect.succeed("Project builder exited without a diagnostic."),
+							),
+						);
+			yield* Effect.sync(() =>
+				console.warn("[cloud-workspace] project build failed", {
+					buildId: build.buildId,
+					failureCode,
+					diagnostic,
+				}),
+			);
 			yield* provider.kill(build.providerSandboxId).pipe(Effect.ignore);
 			const previous = yield* store.getActiveBuild(
 				build.projectId,

--- a/infra/relay/src/cloud-workspace-reconciler.ts
+++ b/infra/relay/src/cloud-workspace-reconciler.ts
@@ -46,6 +46,12 @@ export const sanitizeProjectBuildDiagnostic = (value: string): string => {
 	return sanitized.slice(-PROJECT_BUILD_DIAGNOSTIC_MAX_LENGTH);
 };
 
+export const reusableAccountBuildSnapshot = (
+	build: CloudProjectBuildRecord | null,
+	templateVersion: string,
+): string | undefined =>
+	build?.templateVersion === templateVersion ? build.snapshotId : undefined;
+
 class CloudWorkspaceLeaseLostError extends Data.TaggedError(
 	"CloudWorkspaceLeaseLostError",
 )<{ readonly workspaceId: string }> {}
@@ -250,9 +256,13 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudProjectBuild")(function* (
 			build.accountId,
 			build.provider,
 		);
+		const reusableSnapshotId = reusableAccountBuildSnapshot(
+			previousAccountBuild,
+			build.templateVersion,
+		);
 		const sandbox =
 			existing ??
-			(previousAccountBuild?.snapshotId === undefined
+			(reusableSnapshotId === undefined
 				? yield* provider
 						.create({
 							sandboxId: build.buildId,
@@ -267,12 +277,15 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudProjectBuild")(function* (
 						.fork({
 							sandboxId: build.buildId,
 							providerLabel: label,
-							snapshotId: previousAccountBuild.snapshotId,
+							snapshotId: reusableSnapshotId,
 							timeoutSeconds: config.createTimeoutSeconds,
 							env: {},
 							onTimeout: "terminate",
 						})
 						.pipe(Effect.orDie));
+		yield* provider
+			.setNetwork(sandbox.providerSandboxId, { kind: "open" })
+			.pipe(Effect.orDie);
 		if (gitPayload !== null) {
 			yield* provider.writeTextFile(
 				sandbox.providerSandboxId,

--- a/infra/relay/src/cloud-workspace-routes.ts
+++ b/infra/relay/src/cloud-workspace-routes.ts
@@ -744,7 +744,8 @@ export const routeCloudWorkspaceRequest = (
 				nowMs,
 			);
 			const alreadyLaunched =
-				typeof enrolled.workspace.requestConfig.sessionHeadVersion === "number";
+				typeof enrolled.workspace.requestConfig.sessionHeadVersion ===
+					"number" || enrolled.workspace.statusCode === "agent-starting";
 			if (launchIntentRecord === null && !alreadyLaunched)
 				return yield* Effect.fail(conflict("cloud_workspace_launch_failed"));
 			const launchIntent =
@@ -909,6 +910,18 @@ export const routeCloudWorkspaceRequest = (
 			if (outcome.kind === "workspace-missing")
 				return yield* Effect.fail(notFound("cloud_workspace_not_found"));
 			if (outcome.kind === "applied") {
+				if (
+					workspace.statusCode === "agent-starting" &&
+					outcome.summary.sessionHeadVersion > 0
+				) {
+					yield* store.completeLaunchIntent({
+						workspaceId,
+						commandId: `launch:${workspaceId}`,
+						sessionHeadVersion: outcome.summary.sessionHeadVersion,
+						nowMs,
+						nextActionAtMs: nowMs + idlePauseMs,
+					});
+				}
 				const active = yield* recordWorkspaceActivity(workspace);
 				if (
 					active !== null &&
@@ -980,14 +993,21 @@ export const routeCloudWorkspaceRequest = (
 			if (agentStarted) {
 				if (
 					body.launchCommandId === undefined ||
+					typeof body.sessionHeadVersion !== "number" ||
 					!Number.isSafeInteger(body.sessionHeadVersion) ||
-					(body.sessionHeadVersion ?? -1) < 0 ||
-					!(yield* store.acknowledgeLaunchIntent(
-						workspaceId,
-						body.launchCommandId,
-					))
+					body.sessionHeadVersion < 0
 				)
 					return yield* Effect.fail(conflict("launch_intent_receipt_rejected"));
+				const completion = yield* store.completeLaunchIntent({
+					workspaceId,
+					commandId: body.launchCommandId,
+					sessionHeadVersion: body.sessionHeadVersion,
+					nowMs,
+					nextActionAtMs: nowMs + idlePauseMs,
+				});
+				if (completion.kind !== "completed")
+					return yield* Effect.fail(conflict("launch_intent_receipt_rejected"));
+				return json(publicWorkspace(completion.workspace));
 			}
 			const updated: CloudWorkspaceRecord = {
 				...workspace,

--- a/infra/relay/src/cloud-workspace-routes.ts
+++ b/infra/relay/src/cloud-workspace-routes.ts
@@ -324,7 +324,10 @@ export const failedWorkspaceResumeTarget = (
 	workspace: Pick<CloudWorkspaceRecord, "providerSandboxId" | "statusCode">,
 ) =>
 	workspace.providerSandboxId === undefined ||
-	workspace.statusCode === "provider-sandbox-missing"
+	workspace.statusCode === "provider-sandbox-missing" ||
+	/^(?:initializing|updating-runtime|starting-runtime|syncing-repository|setup)-failed$/u.test(
+		workspace.statusCode,
+	)
 		? ({ state: "queued", providerSandboxId: undefined } as const)
 		: ({
 				state: "resuming",

--- a/infra/relay/src/cloud-workspace-routes.ts
+++ b/infra/relay/src/cloud-workspace-routes.ts
@@ -674,6 +674,25 @@ export const routeCloudWorkspaceRequest = (
 				return updated;
 			},
 		);
+		const repairAcknowledgedLaunch = Effect.fn("repairAcknowledgedLaunch")(
+			function* (workspace: CloudWorkspaceRecord, sessionHeadVersion = 0) {
+				if (workspace.statusCode !== "agent-starting") return workspace;
+				const launchIntent = yield* store.getLaunchIntent(
+					workspace.workspaceId,
+					nowMs,
+				);
+				if (launchIntent !== null) return workspace;
+				const completion = yield* store.completeLaunchIntent({
+					workspaceId: workspace.workspaceId,
+					commandId: `launch:${workspace.workspaceId}`,
+					sessionHeadVersion,
+					nowMs,
+					nextActionAtMs: nowMs + idlePauseMs,
+				});
+				if (completion.kind === "completed") return completion.workspace;
+				return (yield* store.getWorkspace(workspace.workspaceId)) ?? workspace;
+			},
+		);
 		const bootstrapMatch =
 			/^\/v1\/cloud\/workspaces\/([^/]+)\/runtime\/bootstrap$/u.exec(path);
 		if (method === "POST" && bootstrapMatch !== null) {
@@ -1186,13 +1205,17 @@ export const routeCloudWorkspaceRequest = (
 							store.getProject(workspace.projectId),
 							store.getRuntimeSummary(workspace.workspaceId),
 						]);
+						const repaired = yield* repairAcknowledgedLaunch(
+							workspace,
+							runtimeSummary?.sessionHeadVersion ?? 0,
+						);
 						return project === null
 							? null
 							: publicCloudWorkspaceSummary(
-									workspace,
+									repaired,
 									project,
 									false,
-									workspace.lastActivityAtMs,
+									repaired.lastActivityAtMs,
 									runtimeSummary,
 								);
 					}),
@@ -1342,11 +1365,14 @@ export const routeCloudWorkspaceRequest = (
 		}
 
 		if (method === "GET" && path === RelayPaths.cloudWorkspaces) {
+			const workspaces = yield* store.listWorkspaces(
+				principal.accountId,
+				url.searchParams.get("projectId") ?? undefined,
+			);
 			return json({
-				workspaces: (yield* store.listWorkspaces(
-					principal.accountId,
-					url.searchParams.get("projectId") ?? undefined,
-				)).map(publicWorkspace),
+				workspaces: yield* Effect.forEach(workspaces, (workspace) =>
+					repairAcknowledgedLaunch(workspace).pipe(Effect.map(publicWorkspace)),
+				),
 			});
 		}
 
@@ -1357,7 +1383,7 @@ export const routeCloudWorkspaceRequest = (
 			);
 			if (workspace === null || workspace.accountId !== principal.accountId)
 				return yield* Effect.fail(notFound("cloud_workspace_not_found"));
-			return json(publicWorkspace(workspace));
+			return json(publicWorkspace(yield* repairAcknowledgedLaunch(workspace)));
 		}
 
 		const connectionTicketMatch =

--- a/infra/relay/src/cloud-workspace-store.ts
+++ b/infra/relay/src/cloud-workspace-store.ts
@@ -121,6 +121,19 @@ export type RuntimeSummaryWriteOutcome =
 	| { readonly kind: "rejected-generation" }
 	| { readonly kind: "workspace-missing" };
 
+export type CompleteLaunchIntentOutcome =
+	| { readonly kind: "completed"; readonly workspace: CloudWorkspaceRecord }
+	| { readonly kind: "rejected" }
+	| { readonly kind: "workspace-missing" };
+
+export interface CompleteLaunchIntentInput {
+	readonly workspaceId: string;
+	readonly commandId: string;
+	readonly sessionHeadVersion: number;
+	readonly nowMs: number;
+	readonly nextActionAtMs: number;
+}
+
 export interface RuntimeCredentialRenewalReceipt {
 	readonly workspaceId: string;
 	readonly requestId: string;
@@ -314,10 +327,9 @@ export interface CloudWorkspaceStoreApi {
 		workspaceId: string,
 		nowMs: number,
 	) => Effect.Effect<CloudWorkspaceLaunchIntentRecord | null>;
-	readonly acknowledgeLaunchIntent: (
-		workspaceId: string,
-		commandId: string,
-	) => Effect.Effect<boolean>;
+	readonly completeLaunchIntent: (
+		input: CompleteLaunchIntentInput,
+	) => Effect.Effect<CompleteLaunchIntentOutcome>;
 	readonly enrollRuntimeBoot: (
 		input: RuntimeBootstrapEnrollmentInput,
 	) => Effect.Effect<RuntimeBootstrapEnrollmentOutcome | null>;
@@ -408,6 +420,62 @@ const workspaceRuntimeGeneration = (workspace: CloudWorkspaceRecord): number =>
 	typeof workspace.requestConfig.runtimeGeneration === "number"
 		? workspace.requestConfig.runtimeGeneration
 		: Math.max(1, workspace.credentialEpoch + 1);
+
+const recordOrEmpty = (value: unknown): Readonly<Record<string, unknown>> =>
+	typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Readonly<Record<string, unknown>>)
+		: {};
+
+const completeLaunchWorkspace = (
+	workspace: CloudWorkspaceRecord,
+	input: CompleteLaunchIntentInput,
+): CloudWorkspaceRecord => {
+	const startupTimings = recordOrEmpty(workspace.requestConfig.startupTimings);
+	const requestedAt =
+		typeof startupTimings.requestedAt === "number"
+			? startupTimings.requestedAt
+			: undefined;
+	return {
+		...workspace,
+		runtimeState: "online",
+		state: "ready",
+		statusCode: "agent-running",
+		requestConfig: {
+			...workspace.requestConfig,
+			sessionHeadVersion: Math.max(
+				typeof workspace.requestConfig.sessionHeadVersion === "number"
+					? workspace.requestConfig.sessionHeadVersion
+					: 0,
+				input.sessionHeadVersion,
+			),
+			startupTimings: {
+				...startupTimings,
+				connectedAt: startupTimings.connectedAt ?? input.nowMs,
+				repositoryReadyAt: startupTimings.repositoryReadyAt ?? input.nowMs,
+				agentStartedAt: startupTimings.agentStartedAt ?? input.nowMs,
+				...(requestedAt === undefined
+					? {}
+					: {
+							launchDurationMs:
+								startupTimings.launchDurationMs ?? input.nowMs - requestedAt,
+						}),
+			},
+		},
+		nextActionAtMs: input.nextActionAtMs,
+		runningSinceMs: workspace.runningSinceMs ?? input.nowMs,
+		revision: workspace.revision + 1,
+		updatedAtMs: input.nowMs,
+		lastActivityAtMs: input.nowMs,
+	};
+};
+
+const canRecoverMissingLaunchIntent = (
+	workspace: CloudWorkspaceRecord,
+	input: CompleteLaunchIntentInput,
+): boolean =>
+	input.commandId === `launch:${workspace.workspaceId}` &&
+	(workspace.statusCode === "agent-starting" ||
+		typeof workspace.requestConfig.sessionHeadVersion === "number");
 
 export const CloudWorkspaceStoreMemory = Layer.effect(
 	CloudWorkspaceStore,
@@ -660,14 +728,38 @@ export const CloudWorkspaceStoreMemory = Layer.effect(
 						},
 					] as const;
 				}),
-			acknowledgeLaunchIntent: (workspaceId, commandId) =>
-				Ref.modify(state, (current) => {
-					const intent = current.launchIntents.get(workspaceId);
-					if (intent?.commandId !== commandId) return [false, current] as const;
-					const launchIntents = new Map(current.launchIntents);
-					launchIntents.delete(workspaceId);
-					return [true, { ...current, launchIntents }] as const;
-				}),
+			completeLaunchIntent: (input) =>
+				Ref.modify<MemoryState, CompleteLaunchIntentOutcome>(
+					state,
+					(current) => {
+						const workspace = current.workspaces.get(input.workspaceId);
+						if (workspace === undefined)
+							return [{ kind: "workspace-missing" }, current] as const;
+						const intent = current.launchIntents.get(input.workspaceId);
+						if (
+							intent?.commandId !== input.commandId &&
+							!(
+								intent === undefined &&
+								canRecoverMissingLaunchIntent(workspace, input)
+							)
+						)
+							return [{ kind: "rejected" }, current] as const;
+						const completed = completeLaunchWorkspace(workspace, input);
+						const launchIntents = new Map(current.launchIntents);
+						launchIntents.delete(input.workspaceId);
+						return [
+							{ kind: "completed", workspace: completed },
+							{
+								...current,
+								workspaces: new Map(current.workspaces).set(
+									input.workspaceId,
+									completed,
+								),
+								launchIntents,
+							},
+						] as const;
+					},
+				),
 			claimWorkspace: (workspaceId, leaseOwner, nowMs, leaseExpiresAtMs) =>
 				Ref.modify(state, (current) => {
 					const workspace = current.workspaces.get(workspaceId);
@@ -1503,11 +1595,31 @@ export const CloudWorkspaceStorePg: Layer.Layer<
 								};
 					}).pipe(sql.withTransaction),
 				),
-			acknowledgeLaunchIntent: (workspaceId, commandId) =>
+			completeLaunchIntent: (input) =>
 				orDie(
-					sql`DELETE FROM relay_cloud_workspace_launch_intents WHERE workspace_id=${workspaceId} AND command_id=${commandId} RETURNING workspace_id`.pipe(
-						Effect.map((rows) => rows.length === 1),
-					),
+					Effect.gen(function* () {
+						const rows =
+							yield* sql`SELECT * FROM relay_cloud_workspaces WHERE workspace_id=${input.workspaceId} FOR UPDATE`;
+						const row = rows[0];
+						if (row === undefined)
+							return { kind: "workspace-missing" as const };
+						const workspace = workspaceFromRow(row as Row);
+						const intents =
+							yield* sql`SELECT command_id FROM relay_cloud_workspace_launch_intents WHERE workspace_id=${input.workspaceId} FOR UPDATE`;
+						const intentCommandId = intents[0]?.command_id;
+						if (
+							intentCommandId !== input.commandId &&
+							!(
+								intentCommandId === undefined &&
+								canRecoverMissingLaunchIntent(workspace, input)
+							)
+						)
+							return { kind: "rejected" as const };
+						const completed = completeLaunchWorkspace(workspace, input);
+						yield* sql`UPDATE relay_cloud_workspaces SET runtime_state=${completed.runtimeState}, state=${completed.state}, status_code=${completed.statusCode}, request_config=${JSON.stringify(completed.requestConfig)}::jsonb, next_action_at=${completed.nextActionAtMs}, running_since=${completed.runningSinceMs ?? null}, revision=${completed.revision}, updated_at=${completed.updatedAtMs}, last_activity_at=${completed.lastActivityAtMs} WHERE workspace_id=${input.workspaceId}`;
+						yield* sql`DELETE FROM relay_cloud_workspace_launch_intents WHERE workspace_id=${input.workspaceId}`;
+						return { kind: "completed" as const, workspace: completed };
+					}).pipe(sql.withTransaction),
 				),
 			enrollRuntimeBoot: (input) =>
 				orDie(

--- a/infra/relay/test/unit/cloud-workspace-reconciler.test.ts
+++ b/infra/relay/test/unit/cloud-workspace-reconciler.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from "vitest";
 import { CloudCredentialVault } from "../../src/cloud-credential-vault.ts";
 import {
 	reconcileCloudWorkspace,
+	reusableAccountBuildSnapshot,
 	sanitizeProjectBuildDiagnostic,
 	WORKSPACE_ARCHIVE_SCRIPT,
 	WORKSPACE_RUNTIME_PROCESS_PATTERN,
@@ -14,6 +15,7 @@ import {
 	WORKSPACE_RUNTIME_RESUME_SCRIPT,
 } from "../../src/cloud-workspace-reconciler.ts";
 import {
+	type CloudProjectBuildRecord,
 	type CloudWorkspaceRecord,
 	CloudWorkspaceStore,
 	CloudWorkspaceStoreMemory,
@@ -148,6 +150,18 @@ describe("cloud workspace reconciler", () => {
 		expect(diagnostic).not.toContain("ghp_");
 		expect(diagnostic).not.toContain("github.com/acme/private");
 		expect(diagnostic.length).toBeLessThanOrEqual(2_048);
+	});
+
+	test("reuses account snapshots only from the current template", () => {
+		const build = {
+			templateVersion: "old-template",
+			snapshotId: "old-snapshot",
+		} as CloudProjectBuildRecord;
+
+		expect(reusableAccountBuildSnapshot(build, "new-template")).toBeUndefined();
+		expect(reusableAccountBuildSnapshot(build, "old-template")).toBe(
+			"old-snapshot",
+		);
 	});
 
 	test("archive quiesces the current versioned runtime before bundling", () => {

--- a/infra/relay/test/unit/cloud-workspace-reconciler.test.ts
+++ b/infra/relay/test/unit/cloud-workspace-reconciler.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from "vitest";
 import { CloudCredentialVault } from "../../src/cloud-credential-vault.ts";
 import {
 	reconcileCloudWorkspace,
+	sanitizeProjectBuildDiagnostic,
 	WORKSPACE_ARCHIVE_SCRIPT,
 	WORKSPACE_RUNTIME_PROCESS_PATTERN,
 	WORKSPACE_RUNTIME_RESUME_COMMAND,
@@ -137,6 +138,18 @@ const seedWorkspace = Effect.fn("seedArchiveWorkspace")(function* (
 });
 
 describe("cloud workspace reconciler", () => {
+	test("bounds and redacts project builder diagnostics", () => {
+		const diagnostic = sanitizeProjectBuildDiagnostic(
+			`clone https://user:password@github.com/acme/private.git\nAuthorization: Bearer secret-token\nGITHUB_TOKEN=ghp_${"x".repeat(40)}\n${"a".repeat(3_000)}`,
+		);
+
+		expect(diagnostic).not.toContain("password");
+		expect(diagnostic).not.toContain("secret-token");
+		expect(diagnostic).not.toContain("ghp_");
+		expect(diagnostic).not.toContain("github.com/acme/private");
+		expect(diagnostic.length).toBeLessThanOrEqual(2_048);
+	});
+
 	test("archive quiesces the current versioned runtime before bundling", () => {
 		expect(WORKSPACE_ARCHIVE_SCRIPT).toContain(
 			WORKSPACE_RUNTIME_PROCESS_PATTERN,

--- a/infra/relay/test/unit/cloud-workspace-resume-policy.test.ts
+++ b/infra/relay/test/unit/cloud-workspace-resume-policy.test.ts
@@ -51,4 +51,19 @@ describe("failed cloud workspace resume policy", () => {
 			}),
 		).toEqual({ state: "queued", providerSandboxId: undefined });
 	});
+
+	test("replaces an incomplete sandbox after bootstrap fails before the repository is ready", () => {
+		for (const statusCode of [
+			"initializing-failed",
+			"updating-runtime-failed",
+			"starting-runtime-failed",
+			"syncing-repository-failed",
+		] as const)
+			expect(
+				failedWorkspaceResumeTarget({
+					providerSandboxId: "sandbox-incomplete",
+					statusCode,
+				}),
+			).toEqual({ state: "queued", providerSandboxId: undefined });
+	});
 });

--- a/infra/relay/test/unit/cloud-workspace-store.test.ts
+++ b/infra/relay/test/unit/cloud-workspace-store.test.ts
@@ -98,24 +98,6 @@ describe("cloud workspace store", () => {
 			workspaceId: workspace.workspaceId,
 			commandId: `launch:${workspace.workspaceId}`,
 		});
-		expect(
-			await runtime.runPromise(
-				store.acknowledgeLaunchIntent(workspace.workspaceId, "launch:wrong"),
-			),
-		).toBe(false);
-		expect(
-			await runtime.runPromise(
-				store.acknowledgeLaunchIntent(
-					workspace.workspaceId,
-					`launch:${workspace.workspaceId}`,
-				),
-			),
-		).toBe(true);
-		expect(
-			await runtime.runPromise(
-				store.getLaunchIntent(workspace.workspaceId, 200),
-			),
-		).toBeNull();
 		const claimed = await runtime.runPromise(
 			store.claimWorkspace(workspace.workspaceId, "worker-a", 100, 200),
 		);
@@ -687,11 +669,79 @@ describe("cloud workspace store", () => {
 	test("consumes a launch intent only after its matching receipt", async () => {
 		const runtime = ManagedRuntime.make(CloudWorkspaceStoreMemory);
 		const store = await runtime.runPromise(CloudWorkspaceStore);
+		await runtime.runPromise(store.connectProject(project));
+		await runtime.runPromise(store.createBuild(build));
+		const workspace = {
+			workspaceId: "workspace-launch-completion",
+			accountId: "account-1",
+			projectId: project.projectId,
+			buildId: build.buildId,
+			provider: build.provider,
+			runtimeState: "online" as const,
+			chatId: "chat-launch-completion",
+			initialSessionId: "session-launch-completion",
+			branch: "task/launch-completion",
+			baseRef: "origin/main",
+			state: "ready" as const,
+			desiredState: "ready" as const,
+			statusCode: "agent-starting",
+			credentialEpoch: 0,
+			idempotencyKey: "workspace-launch-completion-key",
+			requestConfig: { startupTimings: { requestedAt: 100 } },
+			nextActionAtMs: 100,
+			revision: 2,
+			createdAtMs: 100,
+			updatedAtMs: 200,
+			lastActivityAtMs: 200,
+		};
+		await runtime.runPromise(
+			store.createWorkspace(workspace, startCommand(workspace.workspaceId)),
+		);
 		expect(
 			await runtime.runPromise(
-				store.acknowledgeLaunchIntent("workspace-1", "launch:wrong"),
+				store.completeLaunchIntent({
+					workspaceId: workspace.workspaceId,
+					commandId: "launch:wrong",
+					sessionHeadVersion: 15,
+					nowMs: 300,
+					nextActionAtMs: 10_000,
+				}),
 			),
-		).toBe(false);
+		).toEqual({ kind: "rejected" });
+		const completed = await runtime.runPromise(
+			store.completeLaunchIntent({
+				workspaceId: workspace.workspaceId,
+				commandId: `launch:${workspace.workspaceId}`,
+				sessionHeadVersion: 15,
+				nowMs: 300,
+				nextActionAtMs: 10_000,
+			}),
+		);
+		expect(completed).toMatchObject({
+			kind: "completed",
+			workspace: {
+				statusCode: "agent-running",
+				requestConfig: { sessionHeadVersion: 15 },
+			},
+		});
+		expect(
+			await runtime.runPromise(
+				store.getLaunchIntent(workspace.workspaceId, 400),
+			),
+		).toBeNull();
+		const replay = await runtime.runPromise(
+			store.completeLaunchIntent({
+				workspaceId: workspace.workspaceId,
+				commandId: `launch:${workspace.workspaceId}`,
+				sessionHeadVersion: 15,
+				nowMs: 400,
+				nextActionAtMs: 10_000,
+			}),
+		);
+		expect(replay).toMatchObject({
+			kind: "completed",
+			workspace: { statusCode: "agent-running" },
+		});
 		await runtime.dispose();
 	});
 

--- a/packages/client-runtime/src/client-bus.ts
+++ b/packages/client-runtime/src/client-bus.ts
@@ -154,8 +154,29 @@ const strongestActivation = (
 const requestsNetwork = (entry: ResourceEntry): boolean =>
 	strongestActivation(entry.activations.values()) !== "cache-only";
 
-const messageOf = (cause: unknown): string =>
-	cause instanceof Error ? cause.message : String(cause);
+const messageOf = (cause: unknown): string => {
+	if (cause instanceof Error && cause.message.trim().length > 0) {
+		return cause.message;
+	}
+	if (typeof cause === "object" && cause !== null) {
+		const record = cause as Readonly<Record<string, unknown>>;
+		const tag = typeof record._tag === "string" ? record._tag : null;
+		const reason = typeof record.reason === "string" ? record.reason : null;
+		if (tag !== null) {
+			return reason !== null && reason.trim().length > 0
+				? `${tag}: ${reason}`
+				: tag;
+		}
+		try {
+			const encoded = JSON.stringify(cause);
+			if (encoded !== undefined && encoded !== "{}") return encoded;
+		} catch {
+			// Fall through to the generic representation below.
+		}
+	}
+	const fallback = String(cause);
+	return fallback.trim().length > 0 ? fallback : "Unknown command failure";
+};
 
 const cursorEquals = (
 	left: ResourceCursor | null,

--- a/packages/client-runtime/test/unit/client-bus.test.ts
+++ b/packages/client-runtime/test/unit/client-bus.test.ts
@@ -1037,4 +1037,38 @@ describe("ClientBus", () => {
 		);
 		await bus.dispose();
 	});
+
+	it("preserves tagged command failures whose Error message is empty", async () => {
+		const bus = new ClientBus<Client>({
+			resolver: immediateResolver(),
+			commandExecutor: {
+				execute: async () => {
+					const failure = new Error("") as Error & {
+						readonly _tag: string;
+						readonly sessionId: string;
+					};
+					Object.assign(failure, {
+						_tag: "SessionNotFoundError",
+						sessionId: "session-1",
+					});
+					throw failure;
+				},
+			},
+		});
+		await expect(
+			bus.dispatch({
+				kind: "test.mutate",
+				commandId: CommandId.make("tagged-failure"),
+				environmentId,
+				resource: timelineKey,
+				payload: {},
+				retry: "never",
+				createdAt: Date.now(),
+			}),
+		).rejects.toMatchObject({ _tag: "SessionNotFoundError" });
+		expect(bus.snapshot(timelineKey).failedCommands.at(-1)?.error).toBe(
+			"SessionNotFoundError",
+		);
+		await bus.dispose();
+	});
 });


### PR DESCRIPTION
## Summary

- surface durable runtime updater diagnostics for E2B bootstrap failures
- replace incomplete sandboxes when retrying pre-repository bootstrap failures
- show actionable cloud startup errors instead of raw lifecycle codes

## Root cause

The protocol-5 runtime was published after #470 merged while the staging Relay still passed protocol 4. The updater correctly rejected the mismatch, but swallowed its diagnostic. Retrying then attempted to launch from `/home/zuse/workspace`, which had never been created.

## Validation

- targeted Biome checks
- 15 focused cloud runtime/Relay tests
- Relay typecheck
- renderer typecheck
- live E2B reproduction: updater fails with protocol 4 and succeeds with protocol 5

The staging Relay was also deployed from merged main to align it with the published runtime.

