### PR TITLE
Improve cloud workspace onboarding

### DIFF
--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -51,11 +51,11 @@ import {
 	playCompletionSound,
 	prepareCompletionSound,
 } from "../lib/completion-sounds.ts";
-import { PROVIDER_LABEL } from "../lib/provider-labels.ts";
 import { dispatchEnvironmentShellCommand } from "../lib/environment-shell-client-bus.ts";
+import { PROVIDER_LABEL } from "../lib/provider-labels.ts";
 import { useSettingsStore } from "../lib/settings-client-bus.ts";
-import { useProvidersStore } from "../store/providers.ts";
 import { useEnvironmentCatalogStore } from "../store/environment-catalog.ts";
+import { useProvidersStore } from "../store/providers.ts";
 import { type SettingsSection, useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { BlurredEmail } from "./blurred-email.tsx";
@@ -135,7 +135,7 @@ const TOP_RAIL: ReadonlyArray<RailItemBase> = [
 	},
 	{
 		id: "machines",
-		label: "Cloud Sandbox · Beta",
+		label: "Cloud workspaces · Beta",
 		Icon: ConnectIcon,
 		section: { kind: "machines" },
 	},
@@ -391,9 +391,9 @@ function SectionTitle({
 		}
 		if (section.kind === "machines") {
 			return {
-				title: "Cloud Sandbox · Beta",
+				title: "Cloud workspaces · Beta",
 				subtitle:
-					"Connect repositories and run isolated cloud workspaces while this desktop beta is enabled.",
+					"Connect GitHub and your coding agents, then keep work running when this app is closed.",
 			};
 		}
 		if (section.kind === "browser") {
@@ -688,7 +688,7 @@ function BrowserTestLoginsPane() {
 
 	const load = async () => {
 		const { result: list } = await dispatchEnvironmentShellCommand<
-			{},
+			Record<string, never>,
 			ReadonlyArray<BrowserCredRow>
 		>({
 			environmentId,

--- a/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
+++ b/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
@@ -9,7 +9,6 @@ import {
 	type LocalAccountDescriptor,
 } from "@zuse/contracts";
 import {
-	Check,
 	ChevronDown,
 	Cloud,
 	GitBranch,
@@ -17,19 +16,22 @@ import {
 	RefreshCw,
 	X,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../hooks/use-auth.ts";
 import { cloudWorkspaceAccessPresentation } from "../../lib/cloud-workspace-access.ts";
 import { runControlPlane } from "../../lib/control-plane-client.ts";
 import { listEnvironmentGithubRepos } from "../../lib/environment-projects.ts";
 import { openExternal } from "../../lib/platform-capabilities.ts";
 import { getLocalEnvironmentId } from "../../lib/rpc-client.ts";
-import { cn } from "../../lib/utils.ts";
 import { Badge } from "../ui/badge.tsx";
 import { Button } from "../ui/button.tsx";
-import { Input } from "../ui/input.tsx";
-import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover.tsx";
-import { CloudSettingsGroup, CloudSettingsRow } from "./cloud-settings-ui.tsx";
+import {
+	Select,
+	SelectItem,
+	SelectPopup,
+	SelectTrigger,
+} from "../ui/select.tsx";
+import { CloudSettingsRow } from "./cloud-settings-ui.tsx";
 
 const stateVariant = (
 	state: CloudWorkspace["state"],
@@ -64,6 +66,7 @@ function CredentialRow({
 	const connected = credential?.state === "connected";
 	return (
 		<CloudSettingsRow
+			className="px-0"
 			title={label}
 			description={
 				connected
@@ -96,20 +99,16 @@ function CredentialRow({
 			}
 		>
 			{connected ? null : (
-				<div className="grid gap-1.5 rounded-md border border-border/40 bg-muted/25 p-2 sm:grid-cols-2">
-					<div className="flex items-center gap-2 text-[11px]">
-						<span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px]">
-							1
-						</span>
+				<ol className="mt-2 grid gap-1.5 text-[11px] sm:grid-cols-2">
+					<li className="flex items-center gap-2">
+						<span className="text-muted-foreground">1.</span>
 						<span>
 							Run{" "}
 							<code className="rounded bg-muted px-1 py-0.5">{command}</code>
 						</span>
-					</div>
-					<div className="flex items-center gap-2 text-[11px]">
-						<span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px]">
-							2
-						</span>
+					</li>
+					<li className="flex items-center gap-2">
+						<span className="text-muted-foreground">2.</span>
 						<span
 							className={localAccount?.detected ? "text-success" : undefined}
 						>
@@ -117,10 +116,37 @@ function CredentialRow({
 								? `${localAccount.accountLabel ?? "Account"} found — transfer it.`
 								: "Return here after sign-in; Zuse detects it automatically."}
 						</span>
-					</div>
-				</div>
+					</li>
+				</ol>
 			)}
 		</CloudSettingsRow>
+	);
+}
+
+function SetupSection({
+	title,
+	description,
+	action,
+	children,
+}: {
+	readonly title: string;
+	readonly description: string;
+	readonly action?: ReactNode;
+	readonly children: ReactNode;
+}) {
+	return (
+		<section className="border-border border-t py-5 first:border-t-0 first:pt-1">
+			<div className="flex items-start gap-4">
+				<div className="min-w-0 flex-1">
+					<h3 className="text-sm font-medium">{title}</h3>
+					<p className="mt-1 text-[11px] leading-4 text-muted-foreground">
+						{description}
+					</p>
+				</div>
+				{action}
+			</div>
+			<div className="mt-3">{children}</div>
+		</section>
 	);
 }
 
@@ -147,8 +173,6 @@ export function CloudWorkspacePool() {
 	const [githubAuthenticated, setGithubAuthenticated] = useState(false);
 	const [reposLoading, setReposLoading] = useState(false);
 	const [selectedRepos, setSelectedRepos] = useState<ReadonlyArray<string>>([]);
-	const [repoSearch, setRepoSearch] = useState("");
-	const [repoPickerOpen, setRepoPickerOpen] = useState(false);
 	const [busy, setBusy] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [projectError, setProjectError] = useState<string | null>(null);
@@ -319,7 +343,7 @@ export function CloudWorkspacePool() {
 								defaultBranch: repo.defaultBranch,
 								visibility: repo.isPrivate ? "private" : "public",
 								displayName: repo.nameWithOwner,
-								idempotencyKey: crypto.randomUUID(),
+								idempotencyKey: `settings-connect:${repo.nameWithOwner}:${repo.defaultBranch}`,
 							}),
 						),
 					),
@@ -358,24 +382,37 @@ export function CloudWorkspacePool() {
 				disconnected,
 			]);
 		});
+	const prepareProject = (project: CloudProject) =>
+		run(`build:${project.projectId}`, async () => {
+			await Promise.all(
+				providers.map((provider) =>
+					runControlPlane((client) =>
+						client["cloud.projects.prepare"]({
+							projectId: project.projectId,
+							providerId: provider.providerId,
+							idempotencyKey: `settings-build:${project.projectId}:${provider.providerId}:${project.updatedAt}`,
+						}),
+					),
+				),
+			);
+		});
 
 	if (authLoading) return null;
 	if (!isSignedIn) {
 		return (
-			<CloudSettingsGroup
+			<SetupSection
 				title="Cloud Workspace · Beta"
 				description="Your saved chats remain available on this device. Sign in again to access cloud compute and billing."
+				action={
+					<Button size="xs" loading={signingIn} onClick={() => void signIn()}>
+						Sign in
+					</Button>
+				}
 			>
-				<CloudSettingsRow
-					title="Session expired"
-					description="Your account session could not be renewed. You do not need to sign out first."
-					action={
-						<Button size="xs" loading={signingIn} onClick={() => void signIn()}>
-							Sign in
-						</Button>
-					}
-				/>
-			</CloudSettingsGroup>
+				<p className="text-[11px] text-muted-foreground">
+					Your account session expired. You do not need to sign out first.
+				</p>
+			</SetupSection>
 		);
 	}
 	const credentialFor = (kind: "github" | "claude" | "codex") =>
@@ -389,23 +426,9 @@ export function CloudWorkspacePool() {
 	const availableRepos = githubRepos.filter(
 		(repo) => !connectedIdentities.has(repo.nameWithOwner.toLowerCase()),
 	);
-	const filteredRepos = availableRepos.filter((repo) => {
-		const query = repoSearch.trim().toLowerCase();
-		return (
-			query.length === 0 ||
-			repo.nameWithOwner.toLowerCase().includes(query) ||
-			repo.description?.toLowerCase().includes(query) === true
-		);
-	});
-	const agentsConnected = (["claude", "codex"] as const).filter(
-		(kind) => credentialFor(kind)?.state === "connected",
-	).length;
-	const setupSteps = [
-		{ label: "Cloud access", complete: subscribed && serviceAvailable },
-		{ label: "GitHub", complete: githubConnected },
-		{ label: "Repositories", complete: projects.length > 0 },
-		{ label: "Agents", complete: agentsConnected > 0 },
-	] as const;
+	const unfinishedProjects = projects.filter(
+		(project) => project.state !== "ready",
+	);
 
 	return (
 		<>
@@ -417,78 +440,35 @@ export function CloudWorkspacePool() {
 					{error}
 				</div>
 			)}
-			<div className="grid grid-cols-4 gap-1 rounded-lg border border-border/50 bg-muted/20 p-1.5">
-				{setupSteps.map((step, index) => (
-					<div
-						key={step.label}
-						className={cn(
-							"flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-[10px]",
-							step.complete ? "text-foreground" : "text-muted-foreground",
-						)}
-					>
-						<span
-							className={cn(
-								"flex size-4 shrink-0 items-center justify-center rounded-full border text-[9px]",
-								step.complete &&
-									"border-success/40 bg-alert-success-bg text-success",
-							)}
-						>
-							{step.complete ? <Check className="size-2.5" /> : index + 1}
-						</span>
-						<span className="truncate">{step.label}</span>
-					</div>
-				))}
-			</div>
-
-			<CloudSettingsGroup
-				title="1 · Cloud access"
+			<SetupSection
+				title="Cloud access"
 				description="Cloud workspaces keep agents running when this app or your laptop is offline."
 				action={
-					<Badge
-						variant={
-							subscribed
-								? serviceAvailable
-									? "success"
-									: "warning"
-								: "outline"
-						}
-					>
-						{subscribed
-							? serviceAvailable
-								? "Ready"
-								: "Update required"
-							: "$20 / month"}
-					</Badge>
+					subscribed ? (
+						<Badge variant={serviceAvailable ? "success" : "warning"}>
+							{serviceAvailable ? "Ready" : "Update required"}
+						</Badge>
+					) : (
+						<Button
+							size="xs"
+							loading={busy === "checkout"}
+							onClick={() => void checkout()}
+						>
+							Subscribe · $20/month
+						</Button>
+					)
 				}
 			>
-				<CloudSettingsRow
-					title={
-						subscribed ? "Cloud workspace is ready" : "Enable Cloud Workspace"
-					}
-					description={
-						subscribed
-							? "Each chat gets an isolated workspace. Compute pauses when it is not needed."
-							: "Subscribe once, then connect GitHub and the coding agents you already use."
-					}
-					action={
-						subscribed ? (
-							<Cloud className="size-4 text-success" aria-hidden />
-						) : (
-							<Button
-								size="xs"
-								loading={busy === "checkout"}
-								onClick={() => void checkout()}
-							>
-								Subscribe
-							</Button>
-						)
-					}
-				/>
-			</CloudSettingsGroup>
+				<p className="flex items-center gap-2 text-[11px] text-muted-foreground">
+					<Cloud className="size-3.5" aria-hidden />
+					Each chat gets an isolated workspace. Compute pauses when it is not
+					needed.
+				</p>
+			</SetupSection>
 
 			{subscribed && serviceAvailable ? (
-				<CloudSettingsGroup
-					title="2 · Connect GitHub"
+				<SetupSection
+					title="Connect GitHub"
 					description="Use your existing GitHub CLI login; no repository URLs or access tokens to paste."
 				>
 					<CredentialRow
@@ -503,28 +483,30 @@ export function CloudWorkspacePool() {
 						onConnect={connectCredential}
 						onDisconnect={disconnectCredential}
 					/>
-				</CloudSettingsGroup>
+				</SetupSection>
 			) : null}
 
 			{subscribed && serviceAvailable ? (
-				<CloudSettingsGroup
-					title="3 · Choose repositories"
-					description="Pick from GitHub. Zuse uses each repository's visibility and default branch automatically."
+				<SetupSection
+					title="Repositories"
+					description="Choose repositories from GitHub, then build the cloud images used to start new workspaces."
 				>
-					<CloudSettingsRow
-						title="Repositories available to cloud chats"
-						description={
-							githubAuthenticated
-								? "Select one or more repositories, then connect them together."
-								: "Run gh auth login on this Mac, then refresh."
-						}
-					>
+					<div className="space-y-2.5">
+						<p className="text-[11px] text-muted-foreground">
+							{githubAuthenticated
+								? "Select one or more repositories. Existing agents keep running while new images build."
+								: "Run gh auth login on this Mac, then refresh."}
+						</p>
 						<div className="flex items-center gap-2">
-							<Popover open={repoPickerOpen} onOpenChange={setRepoPickerOpen}>
-								<PopoverTrigger
-									disabled={!githubConnected || !githubAuthenticated}
-									className="flex h-8 min-w-52 flex-1 items-center justify-between rounded-md border border-border/50 bg-muted/40 px-2.5 text-xs text-foreground outline-none hover:bg-muted/70 disabled:opacity-50"
-								>
+							<Select
+								value=""
+								disabled={!githubConnected || !githubAuthenticated}
+								onValueChange={(value) => {
+									if (value !== null && !selectedRepos.includes(value))
+										setSelectedRepos((current) => [...current, value]);
+								}}
+							>
+								<SelectTrigger className="min-h-8 flex-1 border-border">
 									<span>
 										{reposLoading
 											? "Loading repositories…"
@@ -532,64 +514,24 @@ export function CloudWorkspacePool() {
 												? "Select repositories"
 												: `${selectedRepos.length} selected`}
 									</span>
-									<ChevronDown className="size-3.5 text-muted-foreground" />
-								</PopoverTrigger>
-								<PopoverPopup
-									align="start"
-									className="w-96 p-1 [&_[data-slot=popover-viewport]]:p-0"
-								>
-									<div className="border-border/40 border-b p-2">
-										<Input
-											value={repoSearch}
-											onChange={(event) =>
-												setRepoSearch(event.currentTarget.value)
-											}
-											placeholder="Search your repositories"
-											autoFocus
-										/>
-									</div>
-									<div className="max-h-64 overflow-y-auto p-1">
-										{filteredRepos.length === 0 ? (
-											<p className="px-2 py-6 text-center text-[11px] text-muted-foreground">
-												No unconnected repositories found.
-											</p>
-										) : (
-											filteredRepos.map((repo) => {
-												const selected = selectedRepos.includes(
-													repo.nameWithOwner,
-												);
-												return (
-													<button
-														key={repo.nameWithOwner}
-														type="button"
-														className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/60"
-														onClick={() =>
-															setSelectedRepos((current) =>
-																selected
-																	? current.filter(
-																			(name) => name !== repo.nameWithOwner,
-																		)
-																	: [...current, repo.nameWithOwner],
-															)
-														}
-													>
-														<GitBranch className="size-3.5 shrink-0" />
-														<span className="min-w-0 flex-1 truncate text-xs">
-															{repo.nameWithOwner}
-														</span>
-														{repo.isPrivate ? (
-															<Lock className="size-3 text-muted-foreground" />
-														) : null}
-														{selected ? (
-															<Check className="size-3.5 text-success" />
-														) : null}
-													</button>
-												);
-											})
-										)}
-									</div>
-								</PopoverPopup>
-							</Popover>
+								</SelectTrigger>
+								<SelectPopup>
+									{availableRepos.map((repo) => (
+										<SelectItem
+											key={repo.nameWithOwner}
+											value={repo.nameWithOwner}
+										>
+											<GitBranch aria-hidden />
+											<span className="flex min-w-0 items-center gap-2">
+												<span className="truncate">{repo.nameWithOwner}</span>
+												{repo.isPrivate ? (
+													<Lock className="ml-auto" aria-label="Private" />
+												) : null}
+											</span>
+										</SelectItem>
+									))}
+								</SelectPopup>
+							</Select>
 							<Button
 								size="icon-lg"
 								variant="ghost"
@@ -599,19 +541,11 @@ export function CloudWorkspacePool() {
 							>
 								<RefreshCw aria-hidden />
 							</Button>
-							<Button
-								size="sm"
-								loading={busy === "connect"}
-								disabled={selectedRepos.length === 0}
-								onClick={() => void connectProjects()}
-							>
-								Connect
-							</Button>
 						</div>
 						{selectedRepos.length === 0 ? null : (
 							<div className="flex flex-wrap gap-1.5">
 								{selectedRepos.map((name) => (
-									<Badge key={name} variant="outline" size="lg">
+									<Badge key={name} variant="secondary" size="lg">
 										<GitBranch aria-hidden />
 										{name}
 										<button
@@ -629,28 +563,96 @@ export function CloudWorkspacePool() {
 								))}
 							</div>
 						)}
+						<div className="flex items-center gap-3">
+							<Button
+								size="sm"
+								loading={busy === "connect"}
+								disabled={selectedRepos.length === 0}
+								onClick={() => void connectProjects()}
+							>
+								{selectedRepos.length === 0
+									? "Build repositories"
+									: `Build ${selectedRepos.length} ${selectedRepos.length === 1 ? "repository" : "repositories"}`}
+							</Button>
+							<p className="text-[11px] text-muted-foreground">
+								{selectedRepos.length === 0
+									? "Select repositories to create their cloud images."
+									: "Creates a clean image for every repository and available compute provider. You can leave while it builds."}
+							</p>
+						</div>
 						{projects.length === 0 ? null : (
-							<div className="flex flex-wrap gap-1.5 border-border/40 border-t pt-2">
+							<div className="flex flex-wrap gap-1.5 pt-1">
 								{projects.map((project) => (
-									<Badge key={project.projectId} variant="success" size="lg">
-										<Check aria-hidden />
+									<Badge key={project.projectId} variant="secondary" size="lg">
+										<GitBranch aria-hidden />
 										{project.displayName}
 									</Badge>
 								))}
 							</div>
 						)}
-					</CloudSettingsRow>
+						{unfinishedProjects.length === 0 ? null : (
+							<div className="overflow-hidden rounded-lg border border-border">
+								<div className="px-3 py-2 text-xs font-medium">
+									{unfinishedProjects.some(
+										(project) => project.state === "preparing",
+									)
+										? "Building cloud images…"
+										: "Cloud image build needs attention"}
+								</div>
+								<div className="divide-y divide-border border-border border-t">
+									{unfinishedProjects.map((project) => (
+										<div
+											key={project.projectId}
+											className="flex items-center gap-3 px-3 py-2 text-[11px]"
+										>
+											<span className="min-w-0 flex-1 truncate">
+												{project.displayName}
+											</span>
+											<Badge
+												variant={
+													project.state === "failed"
+														? "error"
+														: project.state === "preparing"
+															? "warning"
+															: "outline"
+												}
+											>
+												{project.state === "failed"
+													? "Failed"
+													: project.state === "preparing"
+														? "Building"
+														: "Not built"}
+											</Badge>
+											{project.state !== "preparing" ? (
+												<Button
+													size="xs"
+													variant="ghost"
+													loading={busy === `build:${project.projectId}`}
+													disabled={providers.length === 0}
+													onClick={() => void prepareProject(project)}
+												>
+													{project.state === "failed"
+														? "Retry build"
+														: "Build now"}
+												</Button>
+											) : null}
+										</div>
+									))}
+								</div>
+							</div>
+						)}
+					</div>
 					{projectError === null ? null : (
-						<p role="alert" className="px-3 pb-3 text-xs text-destructive">
+						<p role="alert" className="mt-2 text-xs text-destructive">
 							{projectError}
 						</p>
 					)}
-				</CloudSettingsGroup>
+				</SetupSection>
 			) : null}
 
 			{subscribed && serviceAvailable ? (
-				<CloudSettingsGroup
-					title="4 · Connect your agents"
+				<SetupSection
+					title="Agents"
 					description="Prepare the provider locally, then transfer only its credential to cloud workspaces."
 				>
 					<CredentialRow
@@ -677,17 +679,17 @@ export function CloudWorkspacePool() {
 						onConnect={connectCredential}
 						onDisconnect={disconnectCredential}
 					/>
-				</CloudSettingsGroup>
+				</SetupSection>
 			) : null}
 
 			{subscribed && serviceAvailable && workspaces.length > 0 ? (
-				<details className="group rounded-lg border border-border/40 bg-muted/10">
+				<details className="group rounded-lg border border-border">
 					<summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-[11px] text-muted-foreground">
 						<ChevronDown className="size-3 transition-transform group-open:rotate-180" />
 						Workspace activity
 						<Badge variant="outline">{workspaces.length}</Badge>
 					</summary>
-					<div className="divide-y divide-border/40 border-border/40 border-t">
+					<div className="divide-y divide-border border-border border-t">
 						{workspaces.map((workspace) => (
 							<CloudSettingsRow
 								key={workspace.workspaceId}

--- a/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
+++ b/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
@@ -9,6 +9,7 @@ import {
 	type LocalAccountDescriptor,
 } from "@zuse/contracts";
 import {
+	Check,
 	ChevronDown,
 	Cloud,
 	GitBranch,
@@ -16,7 +17,7 @@ import {
 	RefreshCw,
 	X,
 } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../hooks/use-auth.ts";
 import { cloudWorkspaceAccessPresentation } from "../../lib/cloud-workspace-access.ts";
 import { runControlPlane } from "../../lib/control-plane-client.ts";
@@ -25,13 +26,9 @@ import { openExternal } from "../../lib/platform-capabilities.ts";
 import { getLocalEnvironmentId } from "../../lib/rpc-client.ts";
 import { Badge } from "../ui/badge.tsx";
 import { Button } from "../ui/button.tsx";
-import {
-	Select,
-	SelectItem,
-	SelectPopup,
-	SelectTrigger,
-} from "../ui/select.tsx";
-import { CloudSettingsRow } from "./cloud-settings-ui.tsx";
+import { Input } from "../ui/input.tsx";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover.tsx";
+import { CloudSettingsGroup, CloudSettingsRow } from "./cloud-settings-ui.tsx";
 
 const stateVariant = (
 	state: CloudWorkspace["state"],
@@ -66,7 +63,6 @@ function CredentialRow({
 	const connected = credential?.state === "connected";
 	return (
 		<CloudSettingsRow
-			className="px-0"
 			title={label}
 			description={
 				connected
@@ -122,34 +118,6 @@ function CredentialRow({
 		</CloudSettingsRow>
 	);
 }
-
-function SetupSection({
-	title,
-	description,
-	action,
-	children,
-}: {
-	readonly title: string;
-	readonly description: string;
-	readonly action?: ReactNode;
-	readonly children: ReactNode;
-}) {
-	return (
-		<section className="border-border border-t py-5 first:border-t-0 first:pt-1">
-			<div className="flex items-start gap-4">
-				<div className="min-w-0 flex-1">
-					<h3 className="text-sm font-medium">{title}</h3>
-					<p className="mt-1 text-[11px] leading-4 text-muted-foreground">
-						{description}
-					</p>
-				</div>
-				{action}
-			</div>
-			<div className="mt-3">{children}</div>
-		</section>
-	);
-}
-
 export function CloudWorkspacePool() {
 	const { isLoading: authLoading, isSignedIn, signIn, signingIn } = useAuth();
 	const [entitlementSubscribed, setEntitlementSubscribed] = useState(false);
@@ -173,6 +141,7 @@ export function CloudWorkspacePool() {
 	const [githubAuthenticated, setGithubAuthenticated] = useState(false);
 	const [reposLoading, setReposLoading] = useState(false);
 	const [selectedRepos, setSelectedRepos] = useState<ReadonlyArray<string>>([]);
+	const [repoSearch, setRepoSearch] = useState("");
 	const [busy, setBusy] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [projectError, setProjectError] = useState<string | null>(null);
@@ -400,7 +369,7 @@ export function CloudWorkspacePool() {
 	if (authLoading) return null;
 	if (!isSignedIn) {
 		return (
-			<SetupSection
+			<CloudSettingsGroup
 				title="Cloud Workspace · Beta"
 				description="Your saved chats remain available on this device. Sign in again to access cloud compute and billing."
 				action={
@@ -409,10 +378,11 @@ export function CloudWorkspacePool() {
 					</Button>
 				}
 			>
-				<p className="text-[11px] text-muted-foreground">
-					Your account session expired. You do not need to sign out first.
-				</p>
-			</SetupSection>
+				<CloudSettingsRow
+					title="Sign in to continue"
+					description="Your account session expired. You do not need to sign out first."
+				/>
+			</CloudSettingsGroup>
 		);
 	}
 	const credentialFor = (kind: "github" | "claude" | "codex") =>
@@ -426,6 +396,15 @@ export function CloudWorkspacePool() {
 	const availableRepos = githubRepos.filter(
 		(repo) => !connectedIdentities.has(repo.nameWithOwner.toLowerCase()),
 	);
+	const normalizedRepoSearch = repoSearch.trim().toLowerCase();
+	const filteredRepos =
+		normalizedRepoSearch.length === 0
+			? availableRepos
+			: availableRepos.filter(
+					(repo) =>
+						repo.nameWithOwner.toLowerCase().includes(normalizedRepoSearch) ||
+						repo.description?.toLowerCase().includes(normalizedRepoSearch),
+				);
 	const unfinishedProjects = projects.filter(
 		(project) => project.state !== "ready",
 	);
@@ -440,7 +419,7 @@ export function CloudWorkspacePool() {
 					{error}
 				</div>
 			)}
-			<SetupSection
+			<CloudSettingsGroup
 				title="Cloud access"
 				description="Cloud workspaces keep agents running when this app or your laptop is offline."
 				action={
@@ -459,15 +438,19 @@ export function CloudWorkspacePool() {
 					)
 				}
 			>
-				<p className="flex items-center gap-2 text-[11px] text-muted-foreground">
-					<Cloud className="size-3.5" aria-hidden />
-					Each chat gets an isolated workspace. Compute pauses when it is not
-					needed.
-				</p>
-			</SetupSection>
+				<CloudSettingsRow
+					title={
+						subscribed ? "Cloud workspace is ready" : "Enable Cloud Workspace"
+					}
+					description="Each chat gets an isolated workspace. Compute pauses when it is not needed."
+					action={
+						<Cloud className="size-4 text-muted-foreground" aria-hidden />
+					}
+				/>
+			</CloudSettingsGroup>
 
 			{subscribed && serviceAvailable ? (
-				<SetupSection
+				<CloudSettingsGroup
 					title="Connect GitHub"
 					description="Use your existing GitHub CLI login; no repository URLs or access tokens to paste."
 				>
@@ -483,57 +466,96 @@ export function CloudWorkspacePool() {
 						onConnect={connectCredential}
 						onDisconnect={disconnectCredential}
 					/>
-				</SetupSection>
+				</CloudSettingsGroup>
 			) : null}
 
 			{subscribed && serviceAvailable ? (
-				<SetupSection
+				<CloudSettingsGroup
 					title="Repositories"
 					description="Choose repositories from GitHub, then build the cloud images used to start new workspaces."
 				>
-					<div className="space-y-2.5">
+					<div className="space-y-2.5 px-3 py-2.5">
 						<p className="text-[11px] text-muted-foreground">
 							{githubAuthenticated
-								? "Select one or more repositories. Existing agents keep running while new images build."
+								? "Select repositories, then build their cloud images."
 								: "Run gh auth login on this Mac, then refresh."}
 						</p>
-						<div className="flex items-center gap-2">
-							<Select
-								value=""
-								disabled={!githubConnected || !githubAuthenticated}
-								onValueChange={(value) => {
-									if (value !== null && !selectedRepos.includes(value))
-										setSelectedRepos((current) => [...current, value]);
-								}}
-							>
-								<SelectTrigger className="min-h-8 flex-1 border-border">
-									<span>
+						<div className="flex items-center gap-1.5">
+							<Popover>
+								<PopoverTrigger
+									disabled={!githubConnected || !githubAuthenticated}
+									className="flex h-7 w-64 max-w-full items-center justify-between rounded-md border border-input bg-background px-2.5 text-xs text-foreground outline-none hover:bg-muted disabled:opacity-50"
+								>
+									<span className="truncate">
 										{reposLoading
 											? "Loading repositories…"
 											: selectedRepos.length === 0
 												? "Select repositories"
 												: `${selectedRepos.length} selected`}
 									</span>
-								</SelectTrigger>
-								<SelectPopup>
-									{availableRepos.map((repo) => (
-										<SelectItem
-											key={repo.nameWithOwner}
-											value={repo.nameWithOwner}
-										>
-											<GitBranch aria-hidden />
-											<span className="flex min-w-0 items-center gap-2">
-												<span className="truncate">{repo.nameWithOwner}</span>
-												{repo.isPrivate ? (
-													<Lock className="ml-auto" aria-label="Private" />
-												) : null}
-											</span>
-										</SelectItem>
-									))}
-								</SelectPopup>
-							</Select>
+									<ChevronDown className="size-3.5 text-muted-foreground" />
+								</PopoverTrigger>
+								<PopoverPopup
+									align="start"
+									className="w-80 [&_[data-slot=popover-viewport]]:p-1"
+								>
+									<Input
+										size="sm"
+										type="search"
+										value={repoSearch}
+										onChange={(event) =>
+											setRepoSearch(event.currentTarget.value)
+										}
+										placeholder="Search repositories"
+										autoFocus
+									/>
+									<div className="mt-1 max-h-48 overflow-y-auto">
+										{filteredRepos.length === 0 ? (
+											<p className="px-2 py-4 text-center text-[11px] text-muted-foreground">
+												No repositories found.
+											</p>
+										) : (
+											filteredRepos.map((repo) => {
+												const selected = selectedRepos.includes(
+													repo.nameWithOwner,
+												);
+												return (
+													<button
+														key={repo.nameWithOwner}
+														type="button"
+														className="flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-xs hover:bg-muted"
+														onClick={() =>
+															setSelectedRepos((current) =>
+																selected
+																	? current.filter(
+																			(name) => name !== repo.nameWithOwner,
+																		)
+																	: [...current, repo.nameWithOwner],
+															)
+														}
+													>
+														<GitBranch className="size-3.5 shrink-0" />
+														<span className="min-w-0 flex-1 truncate">
+															{repo.nameWithOwner}
+														</span>
+														{repo.isPrivate ? (
+															<Lock
+																className="size-3 text-muted-foreground"
+																aria-label="Private"
+															/>
+														) : null}
+														{selected ? (
+															<Check className="size-3.5 text-success" />
+														) : null}
+													</button>
+												);
+											})
+										)}
+									</div>
+								</PopoverPopup>
+							</Popover>
 							<Button
-								size="icon-lg"
+								size="icon"
 								variant="ghost"
 								aria-label="Refresh GitHub repositories"
 								loading={reposLoading}
@@ -545,7 +567,7 @@ export function CloudWorkspacePool() {
 						{selectedRepos.length === 0 ? null : (
 							<div className="flex flex-wrap gap-1.5">
 								{selectedRepos.map((name) => (
-									<Badge key={name} variant="secondary" size="lg">
+									<Badge key={name} variant="secondary">
 										<GitBranch aria-hidden />
 										{name}
 										<button
@@ -583,7 +605,7 @@ export function CloudWorkspacePool() {
 						{projects.length === 0 ? null : (
 							<div className="flex flex-wrap gap-1.5 pt-1">
 								{projects.map((project) => (
-									<Badge key={project.projectId} variant="secondary" size="lg">
+									<Badge key={project.projectId} variant="secondary">
 										<GitBranch aria-hidden />
 										{project.displayName}
 									</Badge>
@@ -641,17 +663,17 @@ export function CloudWorkspacePool() {
 								</div>
 							</div>
 						)}
+						{projectError === null ? null : (
+							<p role="alert" className="mt-2 text-xs text-destructive">
+								{projectError}
+							</p>
+						)}
 					</div>
-					{projectError === null ? null : (
-						<p role="alert" className="mt-2 text-xs text-destructive">
-							{projectError}
-						</p>
-					)}
-				</SetupSection>
+				</CloudSettingsGroup>
 			) : null}
 
 			{subscribed && serviceAvailable ? (
-				<SetupSection
+				<CloudSettingsGroup
 					title="Agents"
 					description="Prepare the provider locally, then transfer only its credential to cloud workspaces."
 				>
@@ -679,7 +701,7 @@ export function CloudWorkspacePool() {
 						onConnect={connectCredential}
 						onDisconnect={disconnectCredential}
 					/>
-				</SetupSection>
+				</CloudSettingsGroup>
 			) : null}
 
 			{subscribed && serviceAvailable && workspaces.length > 0 ? (

--- a/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
+++ b/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
@@ -5,25 +5,30 @@ import {
 	type CloudProviderOption,
 	type CloudWorkspace,
 	CloudWorkspaceOpError,
+	type GithubRepoSummary,
 	type LocalAccountDescriptor,
 } from "@zuse/contracts";
-import { ExternalLink, Plus } from "lucide-react";
-import { Fragment, useCallback, useEffect, useState } from "react";
+import {
+	Check,
+	ChevronDown,
+	Cloud,
+	GitBranch,
+	Lock,
+	RefreshCw,
+	X,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../hooks/use-auth.ts";
 import { cloudWorkspaceAccessPresentation } from "../../lib/cloud-workspace-access.ts";
 import { runControlPlane } from "../../lib/control-plane-client.ts";
-import { formatError } from "../../lib/format-error.ts";
+import { listEnvironmentGithubRepos } from "../../lib/environment-projects.ts";
 import { openExternal } from "../../lib/platform-capabilities.ts";
+import { getLocalEnvironmentId } from "../../lib/rpc-client.ts";
+import { cn } from "../../lib/utils.ts";
 import { Badge } from "../ui/badge.tsx";
 import { Button } from "../ui/button.tsx";
 import { Input } from "../ui/input.tsx";
-import {
-	Select,
-	SelectItem,
-	SelectPopup,
-	SelectTrigger,
-	SelectValue,
-} from "../ui/select.tsx";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover.tsx";
 import { CloudSettingsGroup, CloudSettingsRow } from "./cloud-settings-ui.tsx";
 
 const stateVariant = (
@@ -36,6 +41,88 @@ const stateVariant = (
 			: state === "paused" || state === "archived"
 				? "outline"
 				: "warning";
+
+function CredentialRow({
+	kind,
+	label,
+	command,
+	credential,
+	localAccount,
+	busy,
+	onConnect,
+	onDisconnect,
+}: {
+	readonly kind: "github" | "claude" | "codex";
+	readonly label: string;
+	readonly command: string;
+	readonly credential: CloudCredentialConnection | undefined;
+	readonly localAccount: LocalAccountDescriptor | undefined;
+	readonly busy: boolean;
+	readonly onConnect: (kind: "github" | "claude" | "codex") => unknown;
+	readonly onDisconnect: (kind: "github" | "claude" | "codex") => unknown;
+}) {
+	const connected = credential?.state === "connected";
+	return (
+		<CloudSettingsRow
+			title={label}
+			description={
+				connected
+					? `${credential.accountLabel ?? "Your account"} is ready in new cloud workspaces.`
+					: "Set up the account on this Mac, then transfer it securely to Zuse Cloud."
+			}
+			action={
+				connected ? (
+					<>
+						<Badge variant="success">Connected</Badge>
+						<Button
+							size="xs"
+							variant="ghost"
+							loading={busy}
+							onClick={() => void onDisconnect(kind)}
+						>
+							Disconnect
+						</Button>
+					</>
+				) : (
+					<Button
+						size="xs"
+						loading={busy}
+						disabled={!localAccount?.detected}
+						onClick={() => void onConnect(kind)}
+					>
+						Transfer to cloud
+					</Button>
+				)
+			}
+		>
+			{connected ? null : (
+				<div className="grid gap-1.5 rounded-md border border-border/40 bg-muted/25 p-2 sm:grid-cols-2">
+					<div className="flex items-center gap-2 text-[11px]">
+						<span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px]">
+							1
+						</span>
+						<span>
+							Run{" "}
+							<code className="rounded bg-muted px-1 py-0.5">{command}</code>
+						</span>
+					</div>
+					<div className="flex items-center gap-2 text-[11px]">
+						<span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px]">
+							2
+						</span>
+						<span
+							className={localAccount?.detected ? "text-success" : undefined}
+						>
+							{localAccount?.detected
+								? `${localAccount.accountLabel ?? "Account"} found — transfer it.`
+								: "Return here after sign-in; Zuse detects it automatically."}
+						</span>
+					</div>
+				</div>
+			)}
+		</CloudSettingsRow>
+	);
+}
 
 export function CloudWorkspacePool() {
 	const { isLoading: authLoading, isSignedIn, signIn, signingIn } = useAuth();
@@ -54,12 +141,14 @@ export function CloudWorkspacePool() {
 	const [localAccounts, setLocalAccounts] = useState<
 		ReadonlyArray<LocalAccountDescriptor>
 	>([]);
-	const [repositoryUrl, setRepositoryUrl] = useState("");
-	const [defaultBranch, setDefaultBranch] = useState("main");
-	const [repositoryVisibility, setRepositoryVisibility] = useState<
-		"public" | "private"
-	>("public");
-	const [selectedProvider, setSelectedProvider] = useState("");
+	const [githubRepos, setGithubRepos] = useState<
+		ReadonlyArray<GithubRepoSummary>
+	>([]);
+	const [githubAuthenticated, setGithubAuthenticated] = useState(false);
+	const [reposLoading, setReposLoading] = useState(false);
+	const [selectedRepos, setSelectedRepos] = useState<ReadonlyArray<string>>([]);
+	const [repoSearch, setRepoSearch] = useState("");
+	const [repoPickerOpen, setRepoPickerOpen] = useState(false);
 	const [busy, setBusy] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [projectError, setProjectError] = useState<string | null>(null);
@@ -68,6 +157,22 @@ export function CloudWorkspacePool() {
 		serviceAvailable,
 	});
 	const subscribed = access.subscribed;
+	const loadGithubRepos = useCallback(async () => {
+		setReposLoading(true);
+		try {
+			const result = await listEnvironmentGithubRepos(
+				getLocalEnvironmentId(),
+				100,
+			);
+			setGithubRepos(result.repos);
+			setGithubAuthenticated(result.authenticated);
+		} catch {
+			setGithubRepos([]);
+			setGithubAuthenticated(false);
+		} finally {
+			setReposLoading(false);
+		}
+	}, []);
 
 	const load = useCallback(async () => {
 		if (!isSignedIn) return;
@@ -120,10 +225,6 @@ export function CloudWorkspacePool() {
 			setServiceAvailable(relayAvailable);
 			if (providerResult.status === "fulfilled") {
 				setProviders(providerResult.value.providers);
-				setSelectedProvider(
-					(current) =>
-						current || providerResult.value.providers[0]?.providerId || "",
-				);
 			}
 			if (projectResult.status === "fulfilled")
 				setProjects(projectResult.value.projects);
@@ -157,9 +258,10 @@ export function CloudWorkspacePool() {
 	useEffect(() => {
 		if (authLoading || !isSignedIn) return;
 		void load();
+		void loadGithubRepos();
 		const timer = window.setInterval(() => void load(), 5_000);
 		return () => window.clearInterval(timer);
-	}, [authLoading, isSignedIn, load]);
+	}, [authLoading, isSignedIn, load, loadGithubRepos]);
 
 	const run = async (
 		name: string,
@@ -180,14 +282,12 @@ export function CloudWorkspacePool() {
 					: name === "connect" &&
 							cause instanceof CloudWorkspaceOpError &&
 							cause.code === "invalid-request"
-						? "Enter a repository like github.com/owner/repository and a valid default branch."
+						? "One of these repositories could not be connected. Refresh GitHub and try again."
 						: name.startsWith("credential:") &&
 								cause instanceof CloudWorkspaceOpError &&
 								cause.code === "invalid-request"
 							? "No signed-in local account could be imported. Sign in on this Mac and try again."
-							: name.startsWith("agent:")
-								? formatError(cause)
-								: "That cloud action could not be completed. Try again.";
+							: "That cloud action could not be completed. Try again.";
 			if (onError === undefined) setError(message);
 			else onError(message);
 		} finally {
@@ -203,24 +303,35 @@ export function CloudWorkspacePool() {
 			await openExternal(result.checkoutUrl);
 		});
 
-	const connectProject = () => {
+	const connectProjects = () => {
 		setProjectError(null);
 		return run(
 			"connect",
 			async () => {
-				const project = await runControlPlane((client) =>
-					client["cloud.projects.connect"]({
-						repositoryUrl: repositoryUrl.trim(),
-						defaultBranch: defaultBranch.trim(),
-						visibility: repositoryVisibility,
-						idempotencyKey: crypto.randomUUID(),
-					}),
+				const chosen = githubRepos.filter((repo) =>
+					selectedRepos.includes(repo.nameWithOwner),
 				);
-				setProjects((current) => [
-					...current.filter((item) => item.projectId !== project.projectId),
-					project,
-				]);
-				setRepositoryUrl("");
+				const connected = await Promise.all(
+					chosen.map((repo) =>
+						runControlPlane((client) =>
+							client["cloud.projects.connect"]({
+								repositoryUrl: repo.httpsUrl,
+								defaultBranch: repo.defaultBranch,
+								visibility: repo.isPrivate ? "private" : "public",
+								displayName: repo.nameWithOwner,
+								idempotencyKey: crypto.randomUUID(),
+							}),
+						),
+					),
+				);
+				setProjects((current) => {
+					const ids = new Set(connected.map((project) => project.projectId));
+					return [
+						...current.filter((project) => !ids.has(project.projectId)),
+						...connected,
+					];
+				});
+				setSelectedRepos([]);
 			},
 			setProjectError,
 		);
@@ -267,6 +378,34 @@ export function CloudWorkspacePool() {
 			</CloudSettingsGroup>
 		);
 	}
+	const credentialFor = (kind: "github" | "claude" | "codex") =>
+		credentials.find((item) => item.kind === kind);
+	const githubConnected = credentialFor("github")?.state === "connected";
+	const connectedIdentities = new Set(
+		projects.map((project) =>
+			project.repositoryIdentity.replace(/^github\.com\//u, "").toLowerCase(),
+		),
+	);
+	const availableRepos = githubRepos.filter(
+		(repo) => !connectedIdentities.has(repo.nameWithOwner.toLowerCase()),
+	);
+	const filteredRepos = availableRepos.filter((repo) => {
+		const query = repoSearch.trim().toLowerCase();
+		return (
+			query.length === 0 ||
+			repo.nameWithOwner.toLowerCase().includes(query) ||
+			repo.description?.toLowerCase().includes(query) === true
+		);
+	});
+	const agentsConnected = (["claude", "codex"] as const).filter(
+		(kind) => credentialFor(kind)?.state === "connected",
+	).length;
+	const setupSteps = [
+		{ label: "Cloud access", complete: subscribed && serviceAvailable },
+		{ label: "GitHub", complete: githubConnected },
+		{ label: "Repositories", complete: projects.length > 0 },
+		{ label: "Agents", complete: agentsConnected > 0 },
+	] as const;
 
 	return (
 		<>
@@ -278,292 +417,291 @@ export function CloudWorkspacePool() {
 					{error}
 				</div>
 			)}
+			<div className="grid grid-cols-4 gap-1 rounded-lg border border-border/50 bg-muted/20 p-1.5">
+				{setupSteps.map((step, index) => (
+					<div
+						key={step.label}
+						className={cn(
+							"flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-[10px]",
+							step.complete ? "text-foreground" : "text-muted-foreground",
+						)}
+					>
+						<span
+							className={cn(
+								"flex size-4 shrink-0 items-center justify-center rounded-full border text-[9px]",
+								step.complete &&
+									"border-success/40 bg-alert-success-bg text-success",
+							)}
+						>
+							{step.complete ? <Check className="size-2.5" /> : index + 1}
+						</span>
+						<span className="truncate">{step.label}</span>
+					</div>
+				))}
+			</div>
+
 			<CloudSettingsGroup
-				title="Cloud Workspace · Beta"
-				description="Connect repositories once, then create an isolated sandbox and branch for each task."
+				title="1 · Cloud access"
+				description="Cloud workspaces keep agents running when this app or your laptop is offline."
 				action={
-					<Badge variant={subscribed ? "success" : "outline"}>
+					<Badge
+						variant={
+							subscribed
+								? serviceAvailable
+									? "success"
+									: "warning"
+								: "outline"
+						}
+					>
 						{subscribed
 							? serviceAvailable
-								? "Active"
+								? "Ready"
 								: "Update required"
 							: "$20 / month"}
 					</Badge>
 				}
 			>
-				{subscribed ? (
-					<CloudSettingsRow
-						title="Workspace entitlement"
-						description={
-							serviceAvailable
-								? "Includes repository connections and metered cloud workspaces. Compute providers are selected when a workspace is created."
-								: "Your paid access is intact. Update the relay before using the new workspace pool."
-						}
-						action={
-							<Badge variant={serviceAvailable ? "success" : "warning"}>
-								{serviceAvailable ? "Subscribed" : "Relay update required"}
-							</Badge>
-						}
-					/>
-				) : (
-					<CloudSettingsRow
-						title="Cloud workspace access"
-						description="Subscribe once. You can connect multiple repositories and choose an available compute provider for each task."
-						action={
+				<CloudSettingsRow
+					title={
+						subscribed ? "Cloud workspace is ready" : "Enable Cloud Workspace"
+					}
+					description={
+						subscribed
+							? "Each chat gets an isolated workspace. Compute pauses when it is not needed."
+							: "Subscribe once, then connect GitHub and the coding agents you already use."
+					}
+					action={
+						subscribed ? (
+							<Cloud className="size-4 text-success" aria-hidden />
+						) : (
 							<Button
 								size="xs"
 								loading={busy === "checkout"}
 								onClick={() => void checkout()}
 							>
-								<ExternalLink aria-hidden />
 								Subscribe
 							</Button>
-						}
-					/>
-				)}
+						)
+					}
+				/>
 			</CloudSettingsGroup>
 
 			{subscribed && serviceAvailable ? (
 				<CloudSettingsGroup
-					title="Cloud Access"
-					description="Account-level Git and agent credentials are supplied to authorized workspaces with a versioned credential epoch."
+					title="2 · Connect GitHub"
+					description="Use your existing GitHub CLI login; no repository URLs or access tokens to paste."
 				>
-					{(["github", "claude", "codex"] as const).map((kind) => {
-						const credential = credentials.find((item) => item.kind === kind);
-						const localAccount = localAccounts.find(
-							(item) => item.providerId === kind,
-						);
-						return (
-							<CloudSettingsRow
-								key={kind}
-								title={
-									kind === "github"
-										? "GitHub"
-										: kind === "claude"
-											? "Claude"
-											: "Codex"
-								}
-								description={
-									credential?.state === "connected"
-										? `${credential.accountLabel ?? "This account"} is connected to cloud and ready for new workspaces.`
-										: "Connect once to use this account in new cloud workspaces."
-								}
-								action={
-									credential?.state === "connected" ? (
-										<div className="flex min-h-11 items-center gap-2">
-											<Badge variant="success">Connected</Badge>
-											<Button
-												size="xs"
-												variant="ghost"
-												loading={busy === `credential:${kind}`}
-												onClick={() => void disconnectCredential(kind)}
-											>
-												Disconnect
-											</Button>
-										</div>
-									) : (
-										<div className="flex min-h-11 items-center gap-2">
-											<Badge
-												variant={localAccount?.detected ? "success" : "outline"}
-											>
-												{localAccount?.detected
-													? (localAccount.accountLabel ?? "Signed in")
-													: "Sign in on this Mac"}
-											</Badge>
-											<Button
-												size="xs"
-												loading={busy === `credential:${kind}`}
-												disabled={!localAccount?.detected}
-												onClick={() => void connectCredential(kind)}
-											>
-												Import from this Mac
-											</Button>
-										</div>
-									)
-								}
-							/>
-						);
-					})}
+					<CredentialRow
+						kind="github"
+						label="GitHub"
+						command="gh auth login"
+						credential={credentialFor("github")}
+						localAccount={localAccounts.find(
+							(account) => account.providerId === "github",
+						)}
+						busy={busy === "credential:github"}
+						onConnect={connectCredential}
+						onDisconnect={disconnectCredential}
+					/>
 				</CloudSettingsGroup>
 			) : null}
 
 			{subscribed && serviceAvailable ? (
 				<CloudSettingsGroup
-					title="Connected projects"
-					description="Connected repositories are cached automatically. Dependencies remain workspace-owned and are never installed while caching."
+					title="3 · Choose repositories"
+					description="Pick from GitHub. Zuse uses each repository's visibility and default branch automatically."
 				>
-					<form
-						className="grid gap-2 p-3 sm:grid-cols-[minmax(0,1fr)_9rem_8rem_auto]"
-						onSubmit={(event) => {
-							event.preventDefault();
-							void connectProject();
-						}}
+					<CloudSettingsRow
+						title="Repositories available to cloud chats"
+						description={
+							githubAuthenticated
+								? "Select one or more repositories, then connect them together."
+								: "Run gh auth login on this Mac, then refresh."
+						}
 					>
-						<label className="sr-only" htmlFor="cloud-repository-url">
-							Repository URL
-						</label>
-						<Input
-							id="cloud-repository-url"
-							value={repositoryUrl}
-							onChange={(event) => setRepositoryUrl(event.target.value)}
-							placeholder="https://github.com/org/repository"
-							inputMode="url"
-							autoComplete="off"
-							spellCheck={false}
-						/>
-						<Select
-							value={repositoryVisibility}
-							onValueChange={(value) => {
-								if (value === "public" || value === "private")
-									setRepositoryVisibility(value);
-							}}
-						>
-							<SelectTrigger aria-label="Repository visibility">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectPopup>
-								<SelectItem value="public">Public</SelectItem>
-								<SelectItem value="private">Private</SelectItem>
-							</SelectPopup>
-						</Select>
-						<label className="sr-only" htmlFor="cloud-default-branch">
-							Default branch
-						</label>
-						<Input
-							id="cloud-default-branch"
-							value={defaultBranch}
-							onChange={(event) => setDefaultBranch(event.target.value)}
-							placeholder="main"
-							autoComplete="off"
-							spellCheck={false}
-						/>
-						<Button
-							type="submit"
-							size="sm"
-							loading={busy === "connect"}
-							disabled={
-								repositoryUrl.trim().length === 0 ||
-								defaultBranch.trim().length === 0
-							}
-						>
-							<Plus aria-hidden />
-							Connect
-						</Button>
-					</form>
+						<div className="flex items-center gap-2">
+							<Popover open={repoPickerOpen} onOpenChange={setRepoPickerOpen}>
+								<PopoverTrigger
+									disabled={!githubConnected || !githubAuthenticated}
+									className="flex h-8 min-w-52 flex-1 items-center justify-between rounded-md border border-border/50 bg-muted/40 px-2.5 text-xs text-foreground outline-none hover:bg-muted/70 disabled:opacity-50"
+								>
+									<span>
+										{reposLoading
+											? "Loading repositories…"
+											: selectedRepos.length === 0
+												? "Select repositories"
+												: `${selectedRepos.length} selected`}
+									</span>
+									<ChevronDown className="size-3.5 text-muted-foreground" />
+								</PopoverTrigger>
+								<PopoverPopup
+									align="start"
+									className="w-96 p-1 [&_[data-slot=popover-viewport]]:p-0"
+								>
+									<div className="border-border/40 border-b p-2">
+										<Input
+											value={repoSearch}
+											onChange={(event) =>
+												setRepoSearch(event.currentTarget.value)
+											}
+											placeholder="Search your repositories"
+											autoFocus
+										/>
+									</div>
+									<div className="max-h-64 overflow-y-auto p-1">
+										{filteredRepos.length === 0 ? (
+											<p className="px-2 py-6 text-center text-[11px] text-muted-foreground">
+												No unconnected repositories found.
+											</p>
+										) : (
+											filteredRepos.map((repo) => {
+												const selected = selectedRepos.includes(
+													repo.nameWithOwner,
+												);
+												return (
+													<button
+														key={repo.nameWithOwner}
+														type="button"
+														className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/60"
+														onClick={() =>
+															setSelectedRepos((current) =>
+																selected
+																	? current.filter(
+																			(name) => name !== repo.nameWithOwner,
+																		)
+																	: [...current, repo.nameWithOwner],
+															)
+														}
+													>
+														<GitBranch className="size-3.5 shrink-0" />
+														<span className="min-w-0 flex-1 truncate text-xs">
+															{repo.nameWithOwner}
+														</span>
+														{repo.isPrivate ? (
+															<Lock className="size-3 text-muted-foreground" />
+														) : null}
+														{selected ? (
+															<Check className="size-3.5 text-success" />
+														) : null}
+													</button>
+												);
+											})
+										)}
+									</div>
+								</PopoverPopup>
+							</Popover>
+							<Button
+								size="icon-lg"
+								variant="ghost"
+								aria-label="Refresh GitHub repositories"
+								loading={reposLoading}
+								onClick={() => void loadGithubRepos()}
+							>
+								<RefreshCw aria-hidden />
+							</Button>
+							<Button
+								size="sm"
+								loading={busy === "connect"}
+								disabled={selectedRepos.length === 0}
+								onClick={() => void connectProjects()}
+							>
+								Connect
+							</Button>
+						</div>
+						{selectedRepos.length === 0 ? null : (
+							<div className="flex flex-wrap gap-1.5">
+								{selectedRepos.map((name) => (
+									<Badge key={name} variant="outline" size="lg">
+										<GitBranch aria-hidden />
+										{name}
+										<button
+											type="button"
+											aria-label={`Remove ${name}`}
+											onClick={() =>
+												setSelectedRepos((current) =>
+													current.filter((item) => item !== name),
+												)
+											}
+										>
+											<X className="size-3" />
+										</button>
+									</Badge>
+								))}
+							</div>
+						)}
+						{projects.length === 0 ? null : (
+							<div className="flex flex-wrap gap-1.5 border-border/40 border-t pt-2">
+								{projects.map((project) => (
+									<Badge key={project.projectId} variant="success" size="lg">
+										<Check aria-hidden />
+										{project.displayName}
+									</Badge>
+								))}
+							</div>
+						)}
+					</CloudSettingsRow>
 					{projectError === null ? null : (
 						<p role="alert" className="px-3 pb-3 text-xs text-destructive">
 							{projectError}
 						</p>
 					)}
-					{projects.length === 0 ? (
-						<CloudSettingsRow
-							title="No repositories connected"
-							description="Connect a repository to use it in a cloud workspace."
-							action={<Badge variant="outline">Empty</Badge>}
-						/>
-					) : (
-						projects.map((project) => {
-							const projectWorkspaces = workspaces.filter(
-								(workspace) => workspace.projectId === project.projectId,
-							);
-							return (
-								<Fragment key={project.projectId}>
-									<CloudSettingsRow
-										title={project.displayName}
-										description={`${project.repositoryIdentity} · ${project.defaultBranch}`}
-										action={
-											<div className="flex min-h-11 items-center gap-2">
-												<Badge variant="success">Ready</Badge>
-											</div>
-										}
-									/>
-									{projectWorkspaces.map((workspace) => (
-										<CloudSettingsRow
-											key={workspace.workspaceId}
-											title={`↳ ${workspace.branch}`}
-											description={`${providers.find((provider) => provider.providerId === workspace.providerId)?.displayName ?? workspace.providerId} · ${workspace.statusCode}`}
-											action={
-												<div className="flex min-h-11 items-center gap-2">
-													<Badge variant={stateVariant(workspace.state)}>
-														{workspace.state}
-													</Badge>
-													{workspace.state === "ready" ? (
-														<Button
-															size="xs"
-															variant="ghost"
-															onClick={() =>
-																void run(
-																	`pause:${workspace.workspaceId}`,
-																	async () => {
-																		await runControlPlane((client) =>
-																			client["cloud.workspaces.pause"]({
-																				workspaceId: workspace.workspaceId,
-																			}),
-																		);
-																	},
-																)
-															}
-														>
-															Pause
-														</Button>
-													) : workspace.state === "paused" ? (
-														<Button
-															size="xs"
-															variant="ghost"
-															onClick={() =>
-																void run(
-																	`resume:${workspace.workspaceId}`,
-																	async () => {
-																		await runControlPlane((client) =>
-																			client["cloud.workspaces.resume"]({
-																				workspaceId: workspace.workspaceId,
-																			}),
-																		);
-																	},
-																)
-															}
-														>
-															Resume
-														</Button>
-													) : null}
-												</div>
-											}
-										/>
-									))}
-								</Fragment>
-							);
-						})
-					)}
-					{providers.length > 0 ? (
-						<div className="p-3 pt-0">
-							<label className="block space-y-1" htmlFor="cloud-provider">
-								<span className="text-[11px] font-medium">
-									Compute provider
-								</span>
-								<Select
-									value={selectedProvider}
-									onValueChange={(value) => {
-										if (value !== null) setSelectedProvider(value);
-									}}
-								>
-									<SelectTrigger id="cloud-provider" className="min-h-11">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectPopup>
-										{providers.map((provider) => (
-											<SelectItem
-												key={provider.providerId}
-												value={provider.providerId}
-											>
-												{provider.displayName}
-											</SelectItem>
-										))}
-									</SelectPopup>
-								</Select>
-							</label>
-						</div>
-					) : null}
 				</CloudSettingsGroup>
+			) : null}
+
+			{subscribed && serviceAvailable ? (
+				<CloudSettingsGroup
+					title="4 · Connect your agents"
+					description="Prepare the provider locally, then transfer only its credential to cloud workspaces."
+				>
+					<CredentialRow
+						kind="claude"
+						label="Claude Code"
+						command="claude auth login"
+						credential={credentialFor("claude")}
+						localAccount={localAccounts.find(
+							(account) => account.providerId === "claude",
+						)}
+						busy={busy === "credential:claude"}
+						onConnect={connectCredential}
+						onDisconnect={disconnectCredential}
+					/>
+					<CredentialRow
+						kind="codex"
+						label="Codex"
+						command="codex login"
+						credential={credentialFor("codex")}
+						localAccount={localAccounts.find(
+							(account) => account.providerId === "codex",
+						)}
+						busy={busy === "credential:codex"}
+						onConnect={connectCredential}
+						onDisconnect={disconnectCredential}
+					/>
+				</CloudSettingsGroup>
+			) : null}
+
+			{subscribed && serviceAvailable && workspaces.length > 0 ? (
+				<details className="group rounded-lg border border-border/40 bg-muted/10">
+					<summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-[11px] text-muted-foreground">
+						<ChevronDown className="size-3 transition-transform group-open:rotate-180" />
+						Workspace activity
+						<Badge variant="outline">{workspaces.length}</Badge>
+					</summary>
+					<div className="divide-y divide-border/40 border-border/40 border-t">
+						{workspaces.map((workspace) => (
+							<CloudSettingsRow
+								key={workspace.workspaceId}
+								title={workspace.branch}
+								description={`${providers.find((provider) => provider.providerId === workspace.providerId)?.displayName ?? workspace.providerId} · ${workspace.statusCode}`}
+								action={
+									<Badge variant={stateVariant(workspace.state)}>
+										{workspace.state}
+									</Badge>
+								}
+							/>
+						))}
+					</div>
+				</details>
 			) : null}
 		</>
 	);

--- a/apps/renderer/src/lib/environment-projects.ts
+++ b/apps/renderer/src/lib/environment-projects.ts
@@ -110,6 +110,7 @@ export const createEnvironmentProject = async (
 
 export const listEnvironmentGithubRepos = (
 	environmentId: string,
+	limit = 30,
 ): Promise<{
 	readonly repos: ReadonlyArray<GithubRepoSummary>;
 	readonly authenticated: boolean;
@@ -118,7 +119,7 @@ export const listEnvironmentGithubRepos = (
 		run<{ readonly limit: number }, ReadonlyArray<GithubRepoSummary>>(
 			environmentId,
 			"workspace.listGithubRepos",
-			{ limit: 30 },
+			{ limit },
 		),
 		run<Record<string, never>, { readonly authenticated: boolean }>(
 			environmentId,

--- a/apps/server/src/workspace/layers/project-scaffold-live.ts
+++ b/apps/server/src/workspace/layers/project-scaffold-live.ts
@@ -428,7 +428,7 @@ export const ProjectScaffoldLive = Layer.effect(
 						"repo",
 						"list",
 						"--json",
-						"nameWithOwner,description,sshUrl,url,isPrivate,updatedAt",
+						"nameWithOwner,description,sshUrl,url,isPrivate,defaultBranchRef,updatedAt",
 						"--limit",
 						String(safeLimit),
 					],
@@ -456,10 +456,15 @@ export const ProjectScaffoldLive = Layer.effect(
 						typeof r.sshUrl !== "string" ||
 						typeof r.url !== "string" ||
 						typeof r.isPrivate !== "boolean" ||
+						r.defaultBranchRef === null ||
+						typeof r.defaultBranchRef !== "object" ||
 						typeof r.updatedAt !== "string"
 					) {
 						continue;
 					}
+					const defaultBranch = (r.defaultBranchRef as Record<string, unknown>)
+						.name;
+					if (typeof defaultBranch !== "string") continue;
 					out.push(
 						GithubRepoSummary.make({
 							nameWithOwner: r.nameWithOwner,
@@ -470,6 +475,7 @@ export const ProjectScaffoldLive = Layer.effect(
 							sshUrl: r.sshUrl,
 							httpsUrl: r.url,
 							isPrivate: r.isPrivate,
+							defaultBranch,
 							updatedAt: new Date(r.updatedAt),
 						}),
 					);

--- a/packages/contracts/src/workspace.ts
+++ b/packages/contracts/src/workspace.ts
@@ -94,6 +94,7 @@ export class GithubRepoSummary extends Schema.Class<GithubRepoSummary>(
 	sshUrl: Schema.String,
 	httpsUrl: Schema.String,
 	isPrivate: Schema.Boolean,
+	defaultBranch: Schema.String,
 	updatedAt: Schema.DateFromString,
 }) {}
 


### PR DESCRIPTION
## Summary

- replace manual repository entry with GitHub-backed searchable repository selection
- clarify cloud access, credential transfer, image build, retry, and provider setup states
- restore the shared Frame/Card settings design system with compact repository controls
- retain workspace activity as secondary information at the bottom of cloud settings

## Verification

- `bunx biome check apps/renderer/src/components/settings/cloud-workspace-pool.tsx`
- `bun --filter renderer check-types`
- renderer tests: 104 files, 475 tests passed

