### PR TITLE
Preserve partial cloud repository connections

### DIFF
--- a/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
+++ b/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
@@ -304,7 +304,7 @@ export function CloudWorkspacePool() {
 				const chosen = githubRepos.filter((repo) =>
 					selectedRepos.includes(repo.nameWithOwner),
 				);
-				const connected = await Promise.all(
+				const results = await Promise.allSettled(
 					chosen.map((repo) =>
 						runControlPlane((client) =>
 							client["cloud.projects.connect"]({
@@ -314,17 +314,27 @@ export function CloudWorkspacePool() {
 								displayName: repo.nameWithOwner,
 								idempotencyKey: `settings-connect:${repo.nameWithOwner}:${repo.defaultBranch}`,
 							}),
-						),
+						).then((project) => ({ project, repo: repo.nameWithOwner })),
 					),
 				);
+				const connected = results.flatMap((result) =>
+					result.status === "fulfilled" ? [result.value] : [],
+				);
 				setProjects((current) => {
-					const ids = new Set(connected.map((project) => project.projectId));
+					const ids = new Set(
+						connected.map(({ project }) => project.projectId),
+					);
 					return [
 						...current.filter((project) => !ids.has(project.projectId)),
-						...connected,
+						...connected.map(({ project }) => project),
 					];
 				});
-				setSelectedRepos([]);
+				const connectedRepos = new Set(connected.map(({ repo }) => repo));
+				setSelectedRepos((current) =>
+					current.filter((repo) => !connectedRepos.has(repo)),
+				);
+				const failure = results.find((result) => result.status === "rejected");
+				if (failure?.status === "rejected") throw failure.reason;
 			},
 			setProjectError,
 		);


### PR DESCRIPTION
## Summary

- preserve successful project connections when another repository in the same batch fails
- remove successful repositories from the retry selection immediately
- keep only failed repositories selected so retry remains accurate and idempotent

Follow-up to #473 and addresses the unresolved batch-outcome review comment.

## Verification

- `bunx biome check apps/renderer/src/components/settings/cloud-workspace-pool.tsx`
- `bun --filter renderer check-types`
- renderer tests: 104 files, 475 tests passed

