### PR TITLE
Redesign auth, purchase, and integration callback pages

### DIFF
--- a/apps/desktop/src/auth-callback-page.ts
+++ b/apps/desktop/src/auth-callback-page.ts
@@ -1,0 +1,369 @@
+/**
+ * Pages served by the sign-in loopback (`127.0.0.1:8976-8979`). They render in
+ * the user's system browser, so they must be entirely self-contained: no
+ * scripts, no network fonts, no external assets — the loopback answers a single
+ * request and nothing else is fetchable. The markup is a hand-port of the
+ * product's Ticket (account sign-in) and Stamp (integration connect) surfaces to
+ * plain HTML + CSS.
+ */
+
+import { clampedText, escapeHtml } from "@zuse/utils/browser-page";
+
+export type AuthCallbackFlow = "account" | "linear";
+export type AuthCallbackOutcome = "success" | "error";
+
+export interface AuthCallbackPageInput {
+	readonly flow: AuthCallbackFlow;
+	readonly outcome: AuthCallbackOutcome;
+	/** Provider `error_description`; rendered escaped and truncated. */
+	readonly detail?: string | undefined;
+	/** Injectable clock so the rendered reference is testable. */
+	readonly nowMs?: number;
+}
+
+/** Providers echo arbitrary text in `error_description`. */
+const DETAIL_MAX_LENGTH = 180;
+
+const pad = (value: number): string => String(value).padStart(2, "0");
+
+const stampedAt = (
+	nowMs: number,
+): {
+	readonly date: string;
+	readonly issued: string;
+	readonly reference: string;
+} => {
+	const now = new Date(nowMs);
+	const day = `${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}`;
+	const time = `${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}`;
+	const date = `${now.getUTCFullYear()}.${pad(now.getUTCMonth() + 1)}.${pad(now.getUTCDate())}`;
+	return {
+		date,
+		issued: `${date} ${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}`,
+		reference: `ZS-${now.getUTCFullYear()}${day}-${time}`,
+	};
+};
+
+const BASE_STYLES = `
+:root{
+	color-scheme:light dark;
+	--bg:#f4f4f2;
+	--fg:#181713;
+	--muted:#6c6c64;
+	--grid:rgb(24 23 19 / 12%);
+	--accent:#caff00;
+	--font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;
+	--font-mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+}
+@media (prefers-color-scheme:dark){
+	:root{--bg:#0d0d0d;--fg:#f2f2f2;--muted:#9a9a93;--grid:rgb(242 242 242 / 9%)}
+}
+*{box-sizing:border-box}
+body{
+	margin:0;min-height:100vh;display:grid;place-items:center;gap:0;
+	padding:2.5rem 1.25rem;background:var(--bg);color:var(--fg);
+	font-family:var(--font-sans);-webkit-font-smoothing:antialiased;
+}
+.stage{position:relative;display:grid;justify-items:center;gap:2rem;width:100%}
+.stage::before{
+	content:"";position:fixed;inset:0;z-index:0;pointer-events:none;opacity:.55;
+	background-image:linear-gradient(var(--grid) 1px,transparent 1px),linear-gradient(90deg,var(--grid) 1px,transparent 1px);
+	background-size:24px 24px;
+	-webkit-mask-image:radial-gradient(circle at center,#000,transparent 74%);
+	mask-image:radial-gradient(circle at center,#000,transparent 74%);
+}
+.stage>*{position:relative;z-index:1}
+.hint{
+	display:grid;justify-items:center;gap:.75rem;text-align:center;max-width:26rem;
+}
+.hint p{margin:0;color:var(--muted);font-size:.8125rem;line-height:1.5}
+.open{
+	display:inline-flex;align-items:center;gap:.4rem;padding:.5rem .9rem;
+	border:1px solid color-mix(in srgb,var(--fg) 18%,transparent);border-radius:.625rem;
+	color:var(--fg);font-size:.75rem;font-weight:600;letter-spacing:.02em;text-decoration:none;
+	transition:border-color 160ms ease,transform 160ms ease;
+}
+.open:hover{border-color:color-mix(in srgb,var(--fg) 38%,transparent);transform:translateY(-1px)}
+.micro{
+	font-family:var(--font-mono);font-size:.4375rem;font-weight:700;line-height:1;
+	letter-spacing:.09em;text-transform:uppercase;opacity:.62;
+}
+@media (prefers-reduced-motion:reduce){
+	*{animation:none!important;transition:none!important}
+}
+`;
+
+const TICKET_STYLES = `
+.ticket-shell{
+	width:min(100%,18rem);
+	filter:drop-shadow(0 1px 1px rgb(15 15 15 / 10%)) drop-shadow(0 18px 26px rgb(15 15 15 / 13%));
+	transform:rotate(-1.4deg);
+	transition:transform 220ms cubic-bezier(0.23,1,0.32,1);
+	animation:ticket-in 420ms cubic-bezier(0.23,1,0.32,1) both;
+}
+.ticket-shell:hover{transform:rotate(0deg) scale(1.015)}
+@keyframes ticket-in{
+	from{opacity:0;transform:rotate(-1.4deg) translateY(14px)}
+	to{opacity:1;transform:rotate(-1.4deg) translateY(0)}
+}
+.ticket{
+	--corner:0px;--notch:13px;--stub:112px;
+	position:relative;display:grid;grid-template-rows:minmax(0,1fr) var(--stub);
+	min-height:29rem;color:var(--ink);
+	background:linear-gradient(145deg,rgb(255 255 255 / 14%),transparent 42%),var(--paper);
+	clip-path:polygon(
+		0 var(--corner),
+		var(--corner) 0,
+		calc(100% - var(--corner)) 0,
+		100% var(--corner),
+		100% calc(100% - var(--stub) - var(--notch)),
+		calc(100% - var(--notch)) calc(100% - var(--stub)),
+		100% calc(100% - var(--stub) + var(--notch)),
+		100% calc(100% - var(--corner)),
+		calc(100% - var(--corner)) 100%,
+		var(--corner) 100%,
+		0 calc(100% - var(--corner)),
+		0 calc(100% - var(--stub) + var(--notch)),
+		var(--notch) calc(100% - var(--stub)),
+		0 calc(100% - var(--stub) - var(--notch))
+	);
+}
+.ticket-body{
+	position:relative;display:grid;grid-template-rows:auto 1fr auto auto;gap:1rem;
+	padding:20px 21px 25px;min-height:0;overflow:hidden;
+}
+.ticket-body::after{
+	content:"";position:absolute;left:calc(var(--notch) + 6px);right:calc(var(--notch) + 6px);
+	bottom:0;border-bottom:1px dashed currentColor;opacity:.3;
+}
+.ticket-top{
+	display:flex;justify-content:space-between;gap:.75rem;
+	font-family:var(--font-mono);font-size:.4375rem;font-weight:700;line-height:1;
+	letter-spacing:.09em;text-transform:uppercase;opacity:.72;
+}
+.ticket-pattern{
+	align-self:stretch;min-height:64px;opacity:.16;
+	background:repeating-linear-gradient(45deg,currentColor 0 5px,transparent 5px 11px);
+}
+.ticket h1{
+	margin:0;font-size:1.75rem;font-weight:750;line-height:.84;
+	letter-spacing:-.05em;text-transform:uppercase;
+}
+.ticket p{
+	margin:.75rem 0 0;max-width:12rem;font-size:.5625rem;font-weight:600;
+	line-height:1.4;letter-spacing:-.01em;
+}
+.ticket-facts{display:grid;grid-template-columns:1fr 1fr;gap:.625rem;margin:0}
+.ticket-facts div{display:flex;flex-direction:column;gap:3px;min-width:0}
+.ticket-facts dt{
+	font-family:var(--font-mono);font-size:.375rem;font-weight:700;line-height:1;
+	letter-spacing:.09em;text-transform:uppercase;opacity:.62;
+}
+.ticket-facts dd{
+	margin:0;font-family:var(--font-mono);font-size:.5625rem;font-weight:700;
+	line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.ticket-stub{
+	display:flex;flex-direction:column;justify-content:space-between;gap:.875rem;
+	padding:20px 21px 18px;min-height:0;overflow:hidden;
+}
+.ticket-stub-row{display:flex;align-items:flex-start;justify-content:space-between;gap:1rem}
+.ticket-stub-row div{display:flex;flex-direction:column;gap:4px;min-width:0}
+.ticket-stub-row div:last-child{align-items:flex-end;text-align:right}
+.ticket-stub strong{font-size:.8125rem;font-weight:750;line-height:1;text-transform:uppercase}
+.ticket-stub .reference{
+	font-family:var(--font-mono);font-size:.5rem;font-weight:750;line-height:1;letter-spacing:-.02em;
+}
+.barcode{
+	height:22px;width:100%;
+	background:repeating-linear-gradient(90deg,currentColor 0 2px,transparent 2px 4px,currentColor 4px 5px,transparent 5px 8px,currentColor 8px 12px,transparent 12px 14px);
+}
+`;
+
+const STAMP_STYLES = `
+.stamp-shell{
+	width:min(100%,15rem);
+	filter:drop-shadow(0 1px 1px rgb(15 15 15 / 12%)) drop-shadow(0 12px 22px rgb(15 15 15 / 9%));
+	transform:rotate(-2deg);
+	transition:transform 200ms cubic-bezier(0.23,1,0.32,1);
+	animation:stamp-in 380ms cubic-bezier(0.23,1,0.32,1) both;
+}
+.stamp-shell:hover{transform:rotate(0deg) scale(1.015)}
+@keyframes stamp-in{
+	from{opacity:0;transform:rotate(-2deg) scale(.96)}
+	to{opacity:1;transform:rotate(-2deg) scale(1)}
+}
+.stamp{
+	--hole:5px;--pitch:22px;
+	position:relative;aspect-ratio:4/5;padding:13px;color:var(--ink);
+	background:linear-gradient(145deg,rgb(255 255 255 / 34%),transparent 42%),#fbfbf8;
+	-webkit-mask:
+		radial-gradient(var(--hole) at 50% 0,#0000 98%,#000) 50% 0/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 50% 100%,#0000 98%,#000) 50% 100%/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 0 50%,#0000 98%,#000) 0 50%/100% var(--pitch) repeat-y,
+		radial-gradient(var(--hole) at 100% 50%,#0000 98%,#000) 100% 50%/100% var(--pitch) repeat-y;
+	-webkit-mask-composite:source-in;
+	mask:
+		radial-gradient(var(--hole) at 50% 0,#0000 98%,#000) 50% 0/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 50% 100%,#0000 98%,#000) 50% 100%/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 0 50%,#0000 98%,#000) 0 50%/100% var(--pitch) repeat-y,
+		radial-gradient(var(--hole) at 100% 50%,#0000 98%,#000) 100% 50%/100% var(--pitch) repeat-y;
+	mask-composite:intersect;
+}
+.stamp-face{
+	position:relative;display:grid;grid-template-rows:auto 1fr auto;gap:.75rem;
+	height:100%;padding:12px 13px 11px;overflow:hidden;
+	background:var(--paper);
+	box-shadow:inset 0 0 0 1px rgb(24 23 19 / 16%);
+}
+.stamp-head{display:flex;align-items:flex-start;justify-content:space-between;gap:.75rem}
+.stamp-head strong{font-family:var(--font-mono);font-size:1.0625rem;font-weight:700;line-height:.8;letter-spacing:-.06em}
+.stamp-face h1{
+	margin:0;align-self:center;font-size:1.5rem;font-weight:750;line-height:.85;
+	letter-spacing:-.05em;text-transform:uppercase;
+}
+.stamp-face p{margin:.5rem 0 0;max-width:11rem;font-size:.5625rem;font-weight:600;line-height:1.4}
+.postmark{
+	position:absolute;right:14px;bottom:34px;display:grid;place-items:center;
+	width:92px;height:92px;border:2px solid currentColor;border-radius:50%;
+	opacity:.26;transform:rotate(-14deg);text-align:center;
+}
+.postmark::before{
+	content:"";position:absolute;inset:6px;border:1px dashed currentColor;border-radius:50%;
+}
+.postmark span{
+	font-family:var(--font-mono);font-size:.4375rem;font-weight:700;line-height:1.35;
+	letter-spacing:.08em;text-transform:uppercase;
+}
+`;
+
+const documentShell = (input: {
+	readonly title: string;
+	readonly styles: string;
+	readonly body: string;
+}): string =>
+	`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(input.title)}</title>
+<style>${BASE_STYLES}${input.styles}</style>
+</head>
+<body>
+${input.body}
+</body>
+</html>`;
+
+const openAppLink = `<a class="open" href="zuse://">Open Zuse</a>`;
+
+const ticket = (input: {
+	readonly outcome: AuthCallbackOutcome;
+	readonly detail: string | null;
+	readonly issued: string;
+	readonly reference: string;
+}): string => {
+	const success = input.outcome === "success";
+	const paper = success ? "#caff00" : "#ff7a6b";
+	const headline = success ? "You’re<br>signed in" : "Sign-in<br>didn’t finish";
+	const copy = success
+		? "Your Zuse account is ready. Head back to the app — you can close this tab."
+		: (input.detail ??
+			"The provider cancelled or rejected this sign-in. Return to Zuse and try again.");
+	return `<div class="ticket-shell">
+<article class="ticket" style="--paper:${paper};--ink:#181713" aria-label="Zuse sign-in ticket">
+<div class="ticket-body">
+<div class="ticket-top"><span>Zuse · Account</span><span>${success ? "Admitted" : "Void"}</span></div>
+<div class="ticket-pattern" aria-hidden="true"></div>
+<div>
+<h1>${headline}</h1>
+<p>${copy}</p>
+</div>
+<dl class="ticket-facts">
+<div><dt>Issued (UTC)</dt><dd>${escapeHtml(input.issued)}</dd></div>
+<div><dt>Status</dt><dd>${success ? "Signed in" : "Not signed in"}</dd></div>
+</dl>
+</div>
+<div class="ticket-stub">
+<div class="ticket-stub-row">
+<div><span class="micro">Admit</span><strong>${success ? "One" : "None"}</strong></div>
+<div><span class="micro">Reference</span><span class="reference">${escapeHtml(input.reference)}</span></div>
+</div>
+<div class="barcode" aria-hidden="true"></div>
+</div>
+</article>
+</div>`;
+};
+
+const stamp = (input: {
+	readonly outcome: AuthCallbackOutcome;
+	readonly detail: string | null;
+	readonly date: string;
+	readonly reference: string;
+}): string => {
+	const success = input.outcome === "success";
+	const paper = success ? "#caff00" : "#ff7a6b";
+	const copy = success
+		? "Linear is connected to Zuse. You can close this tab."
+		: (input.detail ??
+			"Linear did not finish connecting. Return to Zuse and try again.");
+	return `<div class="stamp-shell">
+<article class="stamp" style="--ink:#181713" aria-label="Linear integration stamp">
+<div class="stamp-face" style="--paper:${paper}">
+<div class="stamp-head"><span class="micro">Zuse · Integration</span><strong>${success ? "01" : "00"}</strong></div>
+<div>
+<h1>Linear</h1>
+<p>${copy}</p>
+</div>
+<span class="micro">${escapeHtml(input.reference)}</span>
+<div class="postmark" aria-hidden="true"><span>${success ? "Connected" : "Declined"}<br>${escapeHtml(input.date)}</span></div>
+</div>
+</article>
+</div>`;
+};
+
+export const renderAuthCallbackPage = (
+	input: AuthCallbackPageInput,
+): string => {
+	const detail = clampedText(input.detail, DETAIL_MAX_LENGTH);
+	const { date, issued, reference } = stampedAt(input.nowMs ?? Date.now());
+	const success = input.outcome === "success";
+	const isLinear = input.flow === "linear";
+	const artwork = isLinear
+		? stamp({ date, detail, outcome: input.outcome, reference })
+		: ticket({ detail, issued, outcome: input.outcome, reference });
+	const title = isLinear
+		? success
+			? "Linear connected · Zuse"
+			: "Linear not connected · Zuse"
+		: success
+			? "Signed in · Zuse"
+			: "Sign-in failed · Zuse";
+	const hint = success
+		? "Zuse already picked this up — there is nothing else to do here."
+		: "Nothing was changed. Start the flow again from Zuse.";
+	return documentShell({
+		body: `<main class="stage">
+${artwork}
+<div class="hint">
+<p>${hint}</p>
+${openAppLink}
+</div>
+</main>`,
+		styles: isLinear ? STAMP_STYLES : TICKET_STYLES,
+		title,
+	});
+};
+
+export const renderNotFoundPage = (): string =>
+	documentShell({
+		body: `<main class="stage">
+<div class="hint">
+<p><strong>Nothing here.</strong></p>
+<p>This address only answers Zuse sign-in callbacks.</p>
+${openAppLink}
+</div>
+</main>`,
+		styles: "",
+		title: "Not found · Zuse",
+	});

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -68,6 +68,7 @@ import {
 	type TailnetDiagnosticEvent,
 	type TailnetShareOptions,
 } from "@zuse/tailnet";
+import { BROWSER_PAGE_HEADERS } from "@zuse/utils/browser-page";
 import {
 	CredentialsServiceLive,
 	makeMainLayer,
@@ -94,6 +95,11 @@ import {
 import fixPath from "fix-path";
 import selfsigned from "selfsigned";
 import { ZUSE_APP_VERSION } from "./app-version.ts";
+import {
+	type AuthCallbackFlow,
+	renderAuthCallbackPage,
+	renderNotFoundPage,
+} from "./auth-callback-page.ts";
 import {
 	createTitleBarOverlay,
 	createWindowTitleBarOptions,
@@ -403,8 +409,8 @@ app.setAsDefaultProtocolClient("zuse");
 const AUTH_LOOPBACK_PORTS = [8976, 8977, 8978, 8979] as const;
 // Both dev and packaged use the loopback as the WorkOS redirect_uri. It's the
 // RFC 8252 native-app pattern and gives a strictly better sign-in finish:
-//   - the browser lands on a real HTML page ("Signed in, you can close this
-//     tab") instead of a dead `zuse://` URL that leaves the tab hanging, and
+//   - the browser lands on a real HTML page (see `auth-callback-page.ts`)
+//     instead of a dead `zuse://` URL that leaves the tab hanging, and
 //   - no OS "Open in Zuse (Beta)?" prompt — the browser hits localhost and the
 //     already-running app answers directly, no deep-link handoff needed.
 // The `zuse://auth/callback` scheme handler stays registered below as a
@@ -439,16 +445,24 @@ let pendingAuthUrls: string[] = [];
 let deliverLinearUrl: ((url: string) => void) | null = null;
 let pendingLinearUrls: string[] = [];
 
-const handleAuthCallback = (url: string): void => {
-	let isLinear = false;
+// Single source of truth for callback routing: both the loopback server and the
+// deep-link handler classify a callback the same way.
+const authCallbackFlowOf = (parsed: URL): AuthCallbackFlow =>
+	parsed.pathname === "/linear/callback" || parsed.hostname === "linear"
+		? "linear"
+		: "account";
+
+const authCallbackFlow = (url: string): AuthCallbackFlow => {
 	try {
-		const parsed = new URL(url);
-		isLinear =
-			parsed.pathname === "/linear/callback" || parsed.hostname === "linear";
+		return authCallbackFlowOf(new URL(url));
 	} catch {
 		// Invalid callback URLs are delivered to the account flow and rejected there.
+		return "account";
 	}
-	if (isLinear) {
+};
+
+const handleAuthCallback = (url: string): void => {
+	if (authCallbackFlow(url) === "linear") {
 		if (deliverLinearUrl !== null) deliverLinearUrl(url);
 		else pendingLinearUrls.push(url);
 		return;
@@ -511,17 +525,23 @@ const startAuthLoopback = async (): Promise<void> => {
 			parsed.pathname !== "/callback" &&
 			parsed.pathname !== "/linear/callback"
 		) {
-			res.writeHead(404);
-			res.end("Not found");
+			res.writeHead(404, BROWSER_PAGE_HEADERS);
+			res.end(renderNotFoundPage());
 			return;
 		}
+		// The provider reports failures on the callback itself (`error=...`). The
+		// URL is still delivered to the app either way — the flow's own validation
+		// owns the rejection; the page only mirrors what the browser was told.
+		const failure = parsed.searchParams.get("error");
 		handleAuthCallback(parsed.toString());
-		res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+		res.writeHead(200, BROWSER_PAGE_HEADERS);
 		res.end(
-			`<!doctype html><meta charset="utf-8"><title>Zuse (Beta)</title>` +
-				`<body style="font-family:-apple-system,system-ui,sans-serif;background:#0b0b0c;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">` +
-				`<div style="text-align:center"><h2 style="font-weight:600">Signed in</h2>` +
-				`<p style="color:#a3a3a3">You can close this tab and return to Zuse (Beta).</p></div>`,
+			renderAuthCallbackPage({
+				detail:
+					parsed.searchParams.get("error_description") ?? failure ?? undefined,
+				flow: authCallbackFlowOf(parsed),
+				outcome: failure === null ? "success" : "error",
+			}),
 		);
 		focusMainWindow();
 	});

--- a/apps/desktop/test/unit/auth-callback-page.test.ts
+++ b/apps/desktop/test/unit/auth-callback-page.test.ts
@@ -1,0 +1,96 @@
+import { BROWSER_PAGE_HEADERS } from "@zuse/utils/browser-page";
+import { describe, expect, it } from "vitest";
+
+import {
+	renderAuthCallbackPage,
+	renderNotFoundPage,
+} from "../../src/auth-callback-page.ts";
+
+const nowMs = Date.parse("2026-08-14T10:11:12.000Z");
+
+describe("auth callback page", () => {
+	it("issues a signed-in ticket for the account flow", () => {
+		const page = renderAuthCallbackPage({
+			flow: "account",
+			nowMs,
+			outcome: "success",
+		});
+
+		expect(page).toContain("signed in");
+		expect(page).toContain("ZS-20260814-1011");
+		expect(page).toContain("Signed in · Zuse");
+		expect(page).not.toContain("Linear");
+	});
+
+	it("voids the ticket and shows the provider reason on failure", () => {
+		const page = renderAuthCallbackPage({
+			detail: "The user denied the request.",
+			flow: "account",
+			nowMs,
+			outcome: "error",
+		});
+
+		expect(page).toContain("didn’t finish");
+		expect(page).toContain("The user denied the request.");
+		expect(page).toContain("Void");
+		expect(page).not.toContain("Admitted");
+	});
+
+	it("stamps the Linear flow instead of ticketing it", () => {
+		const page = renderAuthCallbackPage({
+			flow: "linear",
+			nowMs,
+			outcome: "success",
+		});
+
+		expect(page).toContain("Linear");
+		expect(page).toContain("Linear connected · Zuse");
+		expect(page).toContain("2026.08.14");
+		expect(page).not.toContain("Admit");
+	});
+
+	it("escapes provider-supplied text", () => {
+		const page = renderAuthCallbackPage({
+			detail: '<script>alert("x")</script>',
+			flow: "account",
+			nowMs,
+			outcome: "error",
+		});
+
+		expect(page).not.toContain("<script>alert");
+		expect(page).toContain("&lt;script&gt;");
+	});
+
+	it("clamps runaway provider messages", () => {
+		const page = renderAuthCallbackPage({
+			detail: "x".repeat(400),
+			flow: "linear",
+			nowMs,
+			outcome: "error",
+		});
+
+		expect(page).toContain(`${"x".repeat(179)}…`);
+		expect(page).not.toContain("x".repeat(181));
+	});
+
+	it("stays self-contained and theme aware", () => {
+		for (const page of [
+			renderAuthCallbackPage({ flow: "account", nowMs, outcome: "success" }),
+			renderAuthCallbackPage({ flow: "linear", nowMs, outcome: "success" }),
+			renderNotFoundPage(),
+		]) {
+			expect(page).not.toMatch(/(?:src|href)="https?:/u);
+			expect(page).not.toContain("<script");
+			expect(page).toContain("prefers-color-scheme:dark");
+			expect(page).toContain("prefers-reduced-motion:reduce");
+		}
+	});
+
+	it("keeps callback responses uncacheable", () => {
+		expect(BROWSER_PAGE_HEADERS["cache-control"]).toBe("no-store");
+		expect(BROWSER_PAGE_HEADERS["referrer-policy"]).toBe("no-referrer");
+		expect(BROWSER_PAGE_HEADERS["content-security-policy"]).toContain(
+			"default-src 'none'",
+		);
+	});
+});

--- a/apps/server/src/mcp/mcp-callback-page.ts
+++ b/apps/server/src/mcp/mcp-callback-page.ts
@@ -1,0 +1,167 @@
+/**
+ * Page served by the MCP OAuth loopback listener. It renders in the user's
+ * system browser after they approve (or deny) an MCP server, so it must be
+ * entirely self-contained: no scripts, no network fonts, no external assets.
+ * The markup is a hand-port of the product's Stamp surface — the same treatment
+ * the desktop app uses for integration connects — to plain HTML + CSS.
+ */
+
+import { clampedText } from "@zuse/utils/browser-page";
+
+export type McpCallbackOutcome = "success" | "error";
+
+export interface McpCallbackPageInput {
+	readonly outcome: McpCallbackOutcome;
+	/** Host of the MCP server being authorized. */
+	readonly serverLabel?: string | undefined;
+	/** Provider `error`/`error_description`; rendered escaped and truncated. */
+	readonly detail?: string | undefined;
+	/** Injectable clock so the rendered postmark is testable. */
+	readonly nowMs?: number;
+}
+
+/** Server labels and provider error text are both untrusted here. */
+const MAX_TEXT_LENGTH = 180;
+
+const pad = (value: number): string => String(value).padStart(2, "0");
+
+const postmarkDate = (nowMs: number): string => {
+	const now = new Date(nowMs);
+	return `${now.getUTCFullYear()}.${pad(now.getUTCMonth() + 1)}.${pad(now.getUTCDate())}`;
+};
+
+const STYLES = `
+:root{
+	color-scheme:light dark;
+	--bg:#f4f4f2;
+	--fg:#181713;
+	--muted:#6c6c64;
+	--grid:rgb(24 23 19 / 12%);
+	--font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;
+	--font-mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+}
+@media (prefers-color-scheme:dark){
+	:root{--bg:#0d0d0d;--fg:#f2f2f2;--muted:#9a9a93;--grid:rgb(242 242 242 / 9%)}
+}
+*{box-sizing:border-box}
+body{
+	margin:0;min-height:100vh;display:grid;place-items:center;
+	padding:2.5rem 1.25rem;background:var(--bg);color:var(--fg);
+	font-family:var(--font-sans);-webkit-font-smoothing:antialiased;
+}
+.stage{position:relative;display:grid;justify-items:center;gap:2rem;width:100%}
+.stage::before{
+	content:"";position:fixed;inset:0;z-index:0;pointer-events:none;opacity:.55;
+	background-image:linear-gradient(var(--grid) 1px,transparent 1px),linear-gradient(90deg,var(--grid) 1px,transparent 1px);
+	background-size:24px 24px;
+	-webkit-mask-image:radial-gradient(circle at center,#000,transparent 74%);
+	mask-image:radial-gradient(circle at center,#000,transparent 74%);
+}
+.stage>*{position:relative;z-index:1}
+.hint{display:grid;justify-items:center;gap:.5rem;text-align:center;max-width:26rem}
+.hint p{margin:0;color:var(--muted);font-size:.8125rem;line-height:1.5}
+.micro{
+	font-family:var(--font-mono);font-size:.4375rem;font-weight:700;line-height:1;
+	letter-spacing:.09em;text-transform:uppercase;opacity:.62;
+}
+.stamp-shell{
+	width:min(100%,15rem);
+	filter:drop-shadow(0 1px 1px rgb(15 15 15 / 12%)) drop-shadow(0 12px 22px rgb(15 15 15 / 9%));
+	transform:rotate(-2deg);
+	transition:transform 200ms cubic-bezier(0.23,1,0.32,1);
+	animation:stamp-in 380ms cubic-bezier(0.23,1,0.32,1) both;
+}
+.stamp-shell:hover{transform:rotate(0deg) scale(1.015)}
+@keyframes stamp-in{
+	from{opacity:0;transform:rotate(-2deg) scale(.96)}
+	to{opacity:1;transform:rotate(-2deg) scale(1)}
+}
+.stamp{
+	--hole:5px;--pitch:22px;
+	position:relative;aspect-ratio:4/5;padding:13px;color:#181713;
+	background:linear-gradient(145deg,rgb(255 255 255 / 34%),transparent 42%),#fbfbf8;
+	-webkit-mask:
+		radial-gradient(var(--hole) at 50% 0,#0000 98%,#000) 50% 0/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 50% 100%,#0000 98%,#000) 50% 100%/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 0 50%,#0000 98%,#000) 0 50%/100% var(--pitch) repeat-y,
+		radial-gradient(var(--hole) at 100% 50%,#0000 98%,#000) 100% 50%/100% var(--pitch) repeat-y;
+	-webkit-mask-composite:source-in;
+	mask:
+		radial-gradient(var(--hole) at 50% 0,#0000 98%,#000) 50% 0/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 50% 100%,#0000 98%,#000) 50% 100%/var(--pitch) 100% repeat-x,
+		radial-gradient(var(--hole) at 0 50%,#0000 98%,#000) 0 50%/100% var(--pitch) repeat-y,
+		radial-gradient(var(--hole) at 100% 50%,#0000 98%,#000) 100% 50%/100% var(--pitch) repeat-y;
+	mask-composite:intersect;
+}
+.stamp-face{
+	position:relative;display:grid;grid-template-rows:auto 1fr auto;gap:.75rem;
+	height:100%;padding:12px 13px 11px;overflow:hidden;background:var(--paper);
+	box-shadow:inset 0 0 0 1px rgb(24 23 19 / 16%);
+}
+.stamp-head{display:flex;align-items:flex-start;justify-content:space-between;gap:.75rem}
+.stamp-head strong{
+	font-family:var(--font-mono);font-size:1.0625rem;font-weight:700;line-height:.8;letter-spacing:-.06em;
+}
+.stamp-face h1{
+	margin:0;align-self:center;font-size:1.5rem;font-weight:750;line-height:.85;
+	letter-spacing:-.05em;text-transform:uppercase;
+}
+.stamp-face p{
+	margin:.5rem 0 0;max-width:11rem;font-size:.5625rem;font-weight:600;line-height:1.4;
+	overflow-wrap:anywhere;
+}
+.postmark{
+	position:absolute;right:14px;bottom:34px;display:grid;place-items:center;
+	width:92px;height:92px;border:2px solid currentColor;border-radius:50%;
+	opacity:.26;transform:rotate(-14deg);text-align:center;
+}
+.postmark::before{content:"";position:absolute;inset:6px;border:1px dashed currentColor;border-radius:50%}
+.postmark span{
+	font-family:var(--font-mono);font-size:.4375rem;font-weight:700;line-height:1.35;
+	letter-spacing:.08em;text-transform:uppercase;
+}
+@media (prefers-reduced-motion:reduce){
+	*{animation:none!important;transition:none!important}
+}
+`;
+
+export const renderMcpCallbackPage = (input: McpCallbackPageInput): string => {
+	const success = input.outcome === "success";
+	const label = clampedText(input.serverLabel, MAX_TEXT_LENGTH);
+	const detail = clampedText(input.detail, MAX_TEXT_LENGTH);
+	const date = postmarkDate(input.nowMs ?? Date.now());
+	const paper = success ? "#caff00" : "#ff7a6b";
+	const copy = success
+		? `${label ?? "This MCP server"} is authorized for Zuse. You can close this tab.`
+		: (detail ??
+			`${label ?? "This MCP server"} did not finish authorizing. Return to Zuse and try again.`);
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${success ? "MCP server connected" : "MCP server not connected"} · Zuse</title>
+<style>${STYLES}</style>
+</head>
+<body>
+<main class="stage">
+<div class="stamp-shell">
+<article class="stamp" aria-label="MCP integration stamp">
+<div class="stamp-face" style="--paper:${paper}">
+<div class="stamp-head"><span class="micro">Zuse · MCP</span><strong>${success ? "01" : "00"}</strong></div>
+<div>
+<h1>${success ? "Connected" : "Not<br>connected"}</h1>
+<p>${copy}</p>
+</div>
+<span class="micro">${label ?? "MCP server"}</span>
+<div class="postmark" aria-hidden="true"><span>${success ? "Authorized" : "Declined"}<br>${date}</span></div>
+</div>
+</article>
+</div>
+<div class="hint">
+<p>${success ? "Zuse already picked this up — there is nothing else to do here." : "Nothing was changed. Start the connection again from Zuse."}</p>
+</div>
+</main>
+</body>
+</html>`;
+};

--- a/apps/server/src/mcp/mcp-oauth.ts
+++ b/apps/server/src/mcp/mcp-oauth.ts
@@ -10,7 +10,10 @@ import type {
 	OAuthClientMetadata,
 	OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { BROWSER_PAGE_HEADERS } from "@zuse/utils/browser-page";
 import { Effect } from "effect";
+
+import { renderMcpCallbackPage } from "./mcp-callback-page.ts";
 
 /**
  * Everything the MCP SDK's OAuthClientProvider needs to persist between
@@ -84,16 +87,15 @@ const makeProvider = (options: {
 });
 
 const CALLBACK_PATH = "/callback";
-const CALLBACK_PAGE = `<!doctype html><meta charset="utf-8"><title>Zuse</title>
-<body style="font-family:system-ui;display:grid;place-items:center;height:100vh;margin:0">
-<p>You're connected. You can close this tab and return to Zuse.</p></body>`;
 
 /**
  * One loopback HTTP listener per flow, on an ephemeral 127.0.0.1 port —
  * the same shape the WorkOS dev flow uses. Resolves with the `code` query
  * param of the first `/callback` hit.
  */
-const listenForCallback = (): Promise<{
+const listenForCallback = (
+	serverLabel: string | undefined,
+): Promise<{
 	redirectUrl: string;
 	waitForCode: Promise<string>;
 	close: () => void;
@@ -111,9 +113,23 @@ const listenForCallback = (): Promise<{
 				res.writeHead(404).end();
 				return;
 			}
-			res.writeHead(200, { "content-type": "text/html" }).end(CALLBACK_PAGE);
+			// Classify before responding: a denied authorization must not be shown
+			// the "connected" page.
 			const code = url.searchParams.get("code");
 			const error = url.searchParams.get("error");
+			const failure =
+				code === null
+					? (url.searchParams.get("error_description") ??
+						error ??
+						"The authorization response had no code.")
+					: null;
+			res.writeHead(200, BROWSER_PAGE_HEADERS).end(
+				renderMcpCallbackPage({
+					detail: failure ?? undefined,
+					outcome: failure === null ? "success" : "error",
+					serverLabel,
+				}),
+			);
 			if (code !== null) resolveCode(code);
 			else {
 				rejectCode(
@@ -138,6 +154,17 @@ const listenForCallback = (): Promise<{
 
 const CODE_TIMEOUT_MS = 300_000;
 
+/** Host of the MCP server, for the callback page. Falls back to the raw URL. */
+const mcpServerLabel = (serverUrl: string): string | undefined => {
+	const trimmed = serverUrl.trim();
+	if (trimmed.length === 0) return undefined;
+	try {
+		return new URL(trimmed).host || trimmed;
+	} catch {
+		return trimmed;
+	}
+};
+
 /**
  * Full OAuth 2.1 flow for a claude-source http server: metadata discovery,
  * dynamic client registration, PKCE, loopback redirect. The SDK's `auth()`
@@ -153,7 +180,9 @@ export const runMcpOauthFlow = (options: {
 	Effect.tryPromise({
 		try: async () => {
 			const bundle = parseBundle(await options.store.load());
-			const listener = await listenForCallback();
+			const listener = await listenForCallback(
+				mcpServerLabel(options.serverUrl),
+			);
 			try {
 				const provider = makeProvider({
 					bundle,

--- a/apps/server/test/unit/mcp-callback-page.test.ts
+++ b/apps/server/test/unit/mcp-callback-page.test.ts
@@ -1,0 +1,67 @@
+import { BROWSER_PAGE_HEADERS } from "@zuse/utils/browser-page";
+import { describe, expect, it } from "vitest";
+
+import { renderMcpCallbackPage } from "../../src/mcp/mcp-callback-page.ts";
+
+const nowMs = Date.parse("2026-08-14T10:11:12.000Z");
+
+describe("mcp callback page", () => {
+	it("stamps the authorized server", () => {
+		const page = renderMcpCallbackPage({
+			nowMs,
+			outcome: "success",
+			serverLabel: "mcp.example.com",
+		});
+
+		expect(page).toContain("Connected");
+		expect(page).toContain("mcp.example.com");
+		expect(page).toContain("Authorized");
+		expect(page).toContain("2026.08.14");
+	});
+
+	it("reports a denied authorization instead of a connected stamp", () => {
+		const page = renderMcpCallbackPage({
+			detail: "access_denied",
+			nowMs,
+			outcome: "error",
+			serverLabel: "mcp.example.com",
+		});
+
+		expect(page).toContain("Not<br>connected");
+		expect(page).toContain("access_denied");
+		expect(page).toContain("Declined");
+	});
+
+	it("works without a server label", () => {
+		const page = renderMcpCallbackPage({ nowMs, outcome: "success" });
+
+		expect(page).toContain("This MCP server is authorized");
+		expect(page).not.toContain("undefined");
+	});
+
+	it("escapes provider-supplied text", () => {
+		const page = renderMcpCallbackPage({
+			detail: '<script>alert("x")</script>',
+			nowMs,
+			outcome: "error",
+			serverLabel: "<img src=x>",
+		});
+
+		expect(page).not.toContain("<script>alert");
+		expect(page).not.toContain("<img src=x>");
+		expect(page).toContain("&lt;script&gt;");
+	});
+
+	it("stays self-contained and theme aware", () => {
+		const page = renderMcpCallbackPage({ nowMs, outcome: "success" });
+
+		expect(page).not.toMatch(/(?:src|href)="https?:/u);
+		expect(page).not.toContain("<script");
+		expect(page).toContain("prefers-color-scheme:dark");
+		expect(page).toContain("prefers-reduced-motion:reduce");
+		expect(BROWSER_PAGE_HEADERS["cache-control"]).toBe("no-store");
+		expect(BROWSER_PAGE_HEADERS["content-security-policy"]).toContain(
+			"default-src 'none'",
+		);
+	});
+});

--- a/infra/relay/src/checkout-complete-page.ts
+++ b/infra/relay/src/checkout-complete-page.ts
@@ -1,0 +1,252 @@
+/**
+ * Page the billing provider redirects to after checkout. It renders in the
+ * customer's browser straight off the worker, so it must be entirely
+ * self-contained: no scripts, no network fonts, no external assets. The markup
+ * is a hand-port of the product's Receipt Printer surface to plain HTML + CSS.
+ *
+ * Everything interpolated here is either a constant or a value validated by the
+ * caller against the offer catalog / the billing provider — and escaped.
+ */
+
+import { clampedText, escapeHtml } from "@zuse/utils/browser-page";
+
+export type CheckoutCompleteStatus = "paid" | "pending" | "failed";
+
+export interface CheckoutCompletePageInput {
+	/** Purchased product, already resolved from the provider or the catalog. */
+	readonly productName: string;
+	readonly status: CheckoutCompleteStatus;
+	readonly amount?: { readonly cents: number; readonly currency: string };
+	/** Short, human-quotable reference derived from the checkout id. */
+	readonly orderRef?: string;
+	readonly purchasedAtMs?: number;
+}
+
+/** Product names and order references come from the billing provider. */
+const MAX_TEXT_LENGTH = 60;
+
+const pad = (value: number): string => String(value).padStart(2, "0");
+
+const formatDate = (nowMs: number): string => {
+	const now = new Date(nowMs);
+	return `${now.getUTCFullYear()}.${pad(now.getUTCMonth() + 1)}.${pad(now.getUTCDate())} ${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())} UTC`;
+};
+
+/** Minor units → display amount. Zero-decimal currencies are not in use here. */
+const formatAmount = (amount: {
+	readonly cents: number;
+	readonly currency: string;
+}): string => {
+	const currency = amount.currency.trim().toUpperCase().slice(0, 3);
+	const value = (amount.cents / 100).toFixed(2);
+	return escapeHtml(`${currency === "USD" ? "$" : `${currency} `}${value}`);
+};
+
+const STATUS_LABEL: Readonly<Record<CheckoutCompleteStatus, string>> = {
+	failed: "Not completed",
+	paid: "Paid",
+	pending: "Awaiting confirmation",
+};
+
+const STATUS_COPY: Readonly<Record<CheckoutCompleteStatus, string>> = {
+	failed:
+		"This checkout did not complete. Nothing was charged — start it again from Zuse.",
+	paid: "Your subscription is active. Zuse picks it up automatically — you can close this tab.",
+	pending:
+		"We're waiting for the payment to confirm. Zuse picks it up automatically — you can close this tab.",
+};
+
+const STYLES = `
+:root{
+	color-scheme:light dark;
+	--bg:#efeeea;
+	--fg:#181713;
+	--muted:#6c6c64;
+	--grid:rgb(24 23 19 / 12%);
+	--accent:#caff00;
+	--shell:#2a2a27;
+	--shell-edge:#181713;
+	--screen:#141412;
+	--screen-fg:#f2f2ee;
+	--paper:#ffffff;
+	--ink:#181713;
+	--font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;
+	--font-mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+}
+@media (prefers-color-scheme:dark){
+	:root{--bg:#0d0d0d;--fg:#f2f2f2;--muted:#9a9a93;--grid:rgb(242 242 242 / 9%);--shell:#232320;--shell-edge:#0a0a09}
+}
+*{box-sizing:border-box}
+body{
+	margin:0;min-height:100vh;display:grid;place-items:start center;
+	padding:3rem 1.25rem 4rem;background:var(--bg);color:var(--fg);
+	font-family:var(--font-sans);-webkit-font-smoothing:antialiased;
+}
+.stage{position:relative;display:grid;justify-items:center;width:100%;max-width:24rem}
+.stage::before{
+	content:"";position:fixed;inset:0;z-index:0;pointer-events:none;opacity:.55;
+	background-image:linear-gradient(var(--grid) 1px,transparent 1px),linear-gradient(90deg,var(--grid) 1px,transparent 1px);
+	background-size:24px 24px;
+	-webkit-mask-image:radial-gradient(circle at center,#000,transparent 74%);
+	mask-image:radial-gradient(circle at center,#000,transparent 74%);
+}
+.stage>*{position:relative;z-index:1}
+.printer{
+	position:relative;z-index:2;width:100%;padding:.75rem .75rem 2rem;
+	border:1px solid var(--shell-edge);border-radius:1.5rem;background:var(--shell);
+	box-shadow:0 20px 36px -20px rgb(10 10 9 / 55%),0 6px 14px -8px rgb(10 10 9 / 34%),
+		inset 0 1px 0 rgb(255 255 255 / 10%),inset 0 -1px 0 rgb(10 10 9 / 55%);
+}
+.printer-head{
+	display:flex;align-items:center;justify-content:space-between;gap:.75rem;
+	padding:.25rem .5rem .75rem;color:rgb(242 242 238 / 62%);
+}
+.screen{
+	position:relative;padding:1rem;border:1px solid var(--shell-edge);border-radius:.75rem;
+	background:var(--screen);color:var(--screen-fg);
+	box-shadow:inset 0 0 24px 4px rgb(10 10 9 / 52%);
+}
+.screen-row{display:flex;align-items:center;gap:.5rem}
+.screen-row span{font-size:.75rem;font-weight:500;line-height:1}
+.spinner{
+	width:14px;height:14px;flex:none;border-radius:50%;
+	border:2px solid rgb(242 242 238 / 25%);border-top-color:var(--accent);
+	animation:spin 900ms linear infinite;
+}
+.dot{width:14px;height:14px;flex:none;border-radius:50%;background:var(--accent)}
+.dot.failed{background:#ff7a6b}
+@keyframes spin{to{transform:rotate(360deg)}}
+.slot{
+	position:absolute;left:1.5rem;right:1.5rem;bottom:.75rem;height:8px;border-radius:.25rem;
+	background:var(--shell-edge);box-shadow:inset 0 1px 2px rgb(0 0 0 / 60%);
+}
+.output{position:relative;z-index:1;width:calc(100% - 3rem);margin-top:-1rem;overflow:hidden}
+.output::before{
+	content:"";position:absolute;left:0;right:0;top:0;height:8px;z-index:2;
+	background:rgb(10 10 9 / 55%);filter:blur(6px);
+}
+.receipt{
+	--tooth:14px;
+	position:relative;padding:1.75rem 1.5rem 2.25rem;background:var(--paper);color:var(--ink);
+	font-family:var(--font-mono);
+	background-image:repeating-linear-gradient(180deg,rgb(24 23 19 / 3%) 0 1px,transparent 1px 3px);
+	box-shadow:inset 0 0 0 1px rgb(24 23 19 / 12%);
+	-webkit-mask:conic-gradient(from -45deg at bottom,#0000,#000 1deg 89deg,#0000 90deg) 50%/var(--tooth) 100% repeat-x;
+	mask:conic-gradient(from -45deg at bottom,#0000,#000 1deg 89deg,#0000 90deg) 50%/var(--tooth) 100% repeat-x;
+	animation:feed 1.9s linear both;
+}
+@keyframes feed{
+	0%{transform:translateY(calc(-100% + 2px))}
+	7.5%{transform:translateY(-91%)}
+	10.5%{transform:translateY(-91%)}
+	18%{transform:translateY(-81%)}
+	21%{transform:translateY(-81%)}
+	28.5%{transform:translateY(-70%)}
+	31.5%{transform:translateY(-70%)}
+	39%{transform:translateY(-58%)}
+	42%{transform:translateY(-58%)}
+	49.5%{transform:translateY(-45%)}
+	52.5%{transform:translateY(-45%)}
+	60%{transform:translateY(-32%)}
+	63%{transform:translateY(-32%)}
+	70.5%{transform:translateY(-20%)}
+	73.5%{transform:translateY(-20%)}
+	81%{transform:translateY(-10%)}
+	84%{transform:translateY(-10%)}
+	91.5%{transform:translateY(-3%)}
+	94.5%{transform:translateY(-3%)}
+	100%{transform:translateY(0)}
+}
+.receipt h1{
+	margin:0;font-family:var(--font-sans);font-size:1.375rem;font-weight:750;
+	line-height:.9;letter-spacing:-.05em;text-transform:uppercase;
+}
+.receipt-meta{
+	display:flex;justify-content:space-between;gap:.75rem;margin-top:.75rem;
+	font-size:.5rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;opacity:.6;
+}
+.rule{margin:1rem 0;border-top:1px dashed currentColor;opacity:.35}
+.line{display:flex;align-items:baseline;justify-content:space-between;gap:1rem;font-size:.75rem}
+.line+.line{margin-top:.5rem}
+.line .label{font-weight:600;overflow-wrap:anywhere}
+.line .value{font-weight:700;white-space:nowrap}
+.total{font-size:.9375rem;font-weight:750}
+.status{
+	display:inline-block;margin-top:1rem;padding:.25rem .5rem;
+	font-size:.5625rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
+	background:var(--accent);color:#181713;
+}
+.status.failed{background:#ff7a6b}
+.receipt p{margin:1rem 0 0;font-size:.625rem;line-height:1.5;opacity:.72}
+.receipt .barcode{
+	height:26px;margin-top:1.25rem;
+	background:repeating-linear-gradient(90deg,currentColor 0 2px,transparent 2px 4px,currentColor 4px 5px,transparent 5px 8px,currentColor 8px 12px,transparent 12px 14px);
+}
+.micro{
+	font-family:var(--font-mono);font-size:.4375rem;font-weight:700;line-height:1;
+	letter-spacing:.09em;text-transform:uppercase;
+}
+.hint{margin-top:2rem;max-width:22rem;text-align:center;color:var(--muted);font-size:.8125rem;line-height:1.5}
+@media (prefers-reduced-motion:reduce){
+	*{animation:none!important;transition:none!important}
+	.receipt{transform:none}
+}
+`;
+
+export const renderCheckoutCompletePage = (
+	input: CheckoutCompletePageInput,
+): string => {
+	const failed = input.status === "failed";
+	const date = formatDate(input.purchasedAtMs ?? Date.now());
+	const amount = input.amount === undefined ? null : formatAmount(input.amount);
+	const product =
+		clampedText(input.productName, MAX_TEXT_LENGTH) ?? "Zuse subscription";
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${failed ? "Checkout not completed" : "Checkout complete"} · Zuse</title>
+<style>${STYLES}</style>
+</head>
+<body>
+<main class="stage">
+<div class="printer">
+<div class="printer-head"><span class="micro">Zuse · Billing</span><span class="micro">${escapeHtml(date)}</span></div>
+<div class="screen">
+<div class="screen-row">
+${
+	input.status === "pending"
+		? `<span class="spinner" aria-hidden="true"></span>`
+		: `<span class="dot${failed ? " failed" : ""}" aria-hidden="true"></span>`
+}
+<span role="status">${STATUS_LABEL[input.status]}</span>
+</div>
+</div>
+<div class="slot" aria-hidden="true"></div>
+</div>
+<div class="output">
+<article class="receipt" aria-label="Zuse purchase receipt">
+<h1>Zuse</h1>
+<div class="receipt-meta">
+<span>${input.orderRef === undefined ? "Zuse subscription" : `Order ${clampedText(input.orderRef, MAX_TEXT_LENGTH)}`}</span>
+<span>${escapeHtml(date)}</span>
+</div>
+<div class="rule"></div>
+<div class="line"><span class="label">${product}</span>${amount === null ? "" : `<span class="value">${amount}</span>`}</div>
+${
+	amount === null
+		? ""
+		: `<div class="rule"></div>
+<div class="line total"><span class="label">Total</span><span class="value">${amount}</span></div>`
+}
+<span class="status${failed ? " failed" : ""}">${STATUS_LABEL[input.status]}</span>
+<p>${STATUS_COPY[input.status]}</p>
+<div class="barcode" aria-hidden="true"></div>
+</article>
+</div>
+<p class="hint">${failed ? "Nothing was charged." : "Provisioning starts automatically once payment is confirmed."}</p>
+</main>
+</body>
+</html>`;
+};

--- a/infra/relay/src/crypto.ts
+++ b/infra/relay/src/crypto.ts
@@ -474,6 +474,76 @@ export const verifyAccessToken = (input: {
 		};
 	});
 
+export interface CheckoutReceiptTicketClaims {
+	readonly accountId: string;
+	readonly offerId: string;
+}
+
+/**
+ * Mint the ticket carried on a checkout success URL. The buyer's browser is the
+ * only party that ever holds it, so the completion page can prove which account
+ * a checkout belongs to without an authenticated session.
+ */
+export const signCheckoutReceiptTicket = (input: {
+	readonly mintPrivateJwk: JWK;
+	readonly issuer: string;
+	readonly accountId: string;
+	readonly offerId: string;
+	readonly ttlMs: number;
+	readonly nowMs: number;
+}): Effect.Effect<string, RelayError> =>
+	Effect.gen(function* () {
+		const key = yield* importEd25519(input.mintPrivateJwk, "sign");
+		return yield* Effect.tryPromise({
+			try: () =>
+				new SignJWT({ offerId: input.offerId })
+					.setProtectedHeader({ alg: "EdDSA", typ: "checkout-receipt+jwt" })
+					.setIssuer(input.issuer)
+					.setAudience(CHECKOUT_RECEIPT_AUDIENCE)
+					.setSubject(input.accountId)
+					.setIssuedAt(Math.floor(input.nowMs / 1000))
+					.setExpirationTime(Math.floor((input.nowMs + input.ttlMs) / 1000))
+					.sign(key),
+			catch: () => badRequest("checkout_ticket_sign_failed"),
+		});
+	});
+
+const CHECKOUT_RECEIPT_AUDIENCE = "zuse-checkout-receipt";
+
+/** Verify signature, issuer, and expiry of a checkout receipt ticket. */
+export const verifyCheckoutReceiptTicket = (input: {
+	readonly token: string;
+	readonly mintPublicJwk: JWK;
+	readonly issuer: string;
+	readonly nowMs: number;
+}): Effect.Effect<CheckoutReceiptTicketClaims, RelayError> =>
+	Effect.gen(function* () {
+		const key = yield* importEd25519(input.mintPublicJwk, "verify");
+		const verified = yield* Effect.tryPromise({
+			try: () =>
+				jwtVerify(input.token, key, {
+					issuer: input.issuer,
+					audience: CHECKOUT_RECEIPT_AUDIENCE,
+					typ: "checkout-receipt+jwt",
+					currentDate: new Date(input.nowMs),
+				}),
+			catch: () => unauthorized("invalid_checkout_ticket"),
+		});
+		const payload = verified.payload as {
+			readonly sub?: unknown;
+			readonly offerId?: unknown;
+		};
+		if (
+			typeof payload.sub !== "string" ||
+			payload.sub.length === 0 ||
+			typeof payload.offerId !== "string" ||
+			payload.offerId.length === 0
+		) {
+			return yield* Effect.fail(unauthorized("checkout_ticket_malformed"));
+		}
+		return { accountId: payload.sub, offerId: payload.offerId };
+	});
+
 export const parseJwk = (value: string): Effect.Effect<JWK, RelayError> =>
 	Effect.try({
 		try: () => JSON.parse(value) as JWK,

--- a/infra/relay/src/machine-routes.ts
+++ b/infra/relay/src/machine-routes.ts
@@ -1,4 +1,7 @@
-import { BillingProviders } from "@zuse/billing-providers";
+import {
+	BillingProviders,
+	type CheckoutSummary,
+} from "@zuse/billing-providers";
 import {
 	BillingCheckoutRequest,
 	CLOUD_WORKSPACE_OFFER_ID,
@@ -11,10 +14,12 @@ import {
 	RelayPaths,
 } from "@zuse/contracts";
 import { MachineProviders } from "@zuse/machine-providers";
-import { Clock, Effect, Schema } from "effect";
+import { BROWSER_PAGE_HEADERS } from "@zuse/utils/browser-page";
+import { Clock, Effect, Redacted, Schema } from "effect";
 
 import { requireWorkos } from "./auth.ts";
 import { cancelProviderSubscription } from "./billing-operations.ts";
+import { renderCheckoutCompletePage } from "./checkout-complete-page.ts";
 import { ensureCloudBillingPeriod } from "./cloud-billing-period.ts";
 import type { CloudBillingStore } from "./cloud-billing-store.ts";
 import { RelayConfiguration } from "./config.ts";
@@ -22,6 +27,8 @@ import {
 	parseJwk,
 	randomToken,
 	sha256Hex,
+	signCheckoutReceiptTicket,
+	verifyCheckoutReceiptTicket,
 	verifyEnvironmentLinkProof,
 } from "./crypto.ts";
 import {
@@ -78,31 +85,107 @@ const json = (body: unknown, status = 200): Response =>
 		headers: { "content-type": "application/json" },
 	});
 
-const checkoutComplete = (): Response =>
-	new Response(
-		`<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Checkout submitted - Zuse</title>
-<style>
-:root{color-scheme:dark}*{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;background:#0d0d0d;color:#f2f2f2;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.card{width:min(30rem,calc(100% - 2rem));padding:2rem;border:1px solid #303030;border-radius:1rem;background:#191919}h1{margin:0;font-size:1.5rem;line-height:1.25}p{margin:1rem 0 0;color:#aaa;line-height:1.5}.status{color:#caff00}
-</style>
-</head>
-<body><main class="card"><h1><span class="status">Checkout submitted.</span> Return to Zuse.</h1><p>We are waiting for payment confirmation. Your cloud machine will appear automatically when provisioning begins. You can close this tab.</p></main></body>
-</html>`,
-		{
-			status: 200,
-			headers: {
-				"cache-control": "no-store",
-				"content-security-policy":
-					"default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'",
-				"content-type": "text/html; charset=utf-8",
-				"x-content-type-options": "nosniff",
-			},
-		},
+/** Polar substitutes this in the success URL; treat an unsubstituted one as absent. */
+const CHECKOUT_ID_PLACEHOLDER = "{CHECKOUT_ID}";
+const CHECKOUT_ID_MAX_LENGTH = 128;
+
+/** How long the completion page will still show a real order. */
+const CHECKOUT_RECEIPT_TICKET_TTL_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * Where the provider sends the customer after payment. `ticket` is the
+ * relay-signed proof of which account started this checkout — the completion
+ * page is unauthenticated, so it is the only thing that authorizes an order
+ * lookup. `{CHECKOUT_ID}` is interpolated by the provider and must not be
+ * URL-encoded.
+ */
+export const checkoutSuccessUrl = (
+	issuer: string,
+	offerId: string,
+	ticket: string,
+): string => {
+	const target = new URL(RelayPaths.billingCheckoutComplete, issuer);
+	target.searchParams.set("offer", offerId);
+	target.searchParams.set("t", ticket);
+	return `${target.toString()}&checkout_id=${CHECKOUT_ID_PLACEHOLDER}`;
+};
+
+/** Offers the checkout-complete page will name. Anything else renders generic. */
+const knownOfferId = (offerId: string | null): string | null =>
+	offerId !== null &&
+	(offerId === CLOUD_WORKSPACE_OFFER_ID ||
+		findMachineOffer(offerId) !== undefined)
+		? offerId
+		: null;
+
+const catalogProductName = (offerId: string | null): string =>
+	offerId === CLOUD_WORKSPACE_OFFER_ID
+		? "Zuse Cloud Workspace"
+		: (findMachineOffer(offerId ?? "")?.displayName ?? "Zuse subscription");
+
+const orderReference = (checkoutId: string): string =>
+	`ZS-${checkoutId
+		.replaceAll(/[^A-Za-z0-9]/gu, "")
+		.slice(-8)
+		.toUpperCase()}`;
+
+/**
+ * Best-effort order lookup for the post-purchase page. The account comes from
+ * the verified receipt ticket, never from the query string, and the adapter
+ * drops checkouts owned by anyone else. The page is a courtesy surface, so a
+ * slow or unavailable billing provider degrades to the offer catalog instead of
+ * failing the response.
+ */
+const lookupCheckoutSummary = (input: {
+	readonly checkoutId: string;
+	readonly accountId: string;
+}): Effect.Effect<CheckoutSummary | null, never, BillingProviders> =>
+	Effect.gen(function* () {
+		const billingProviders = yield* BillingProviders;
+		const billing = yield* billingProviders.getDefault;
+		return yield* billing.getCheckout(input);
+	}).pipe(
+		Effect.timeout("2 seconds"),
+		Effect.orElseSucceed(() => null),
 	);
+
+const checkoutComplete = (input: {
+	readonly offerId: string | null;
+	readonly summary: CheckoutSummary | null;
+}): Response => {
+	const offer = findMachineOffer(input.offerId ?? "");
+	const catalogAmount =
+		offer === undefined
+			? undefined
+			: { cents: offer.monthlyPriceCents, currency: offer.currency };
+	// Only an order the ticket holder owns gets a reference printed on it.
+	const orderRef =
+		input.summary === null
+			? undefined
+			: orderReference(input.summary.checkoutId);
+	return new Response(
+		renderCheckoutCompletePage({
+			...(input.summary?.amountCents === undefined
+				? catalogAmount === undefined
+					? {}
+					: { amount: catalogAmount }
+				: {
+						amount: {
+							cents: input.summary.amountCents,
+							currency: input.summary.currency,
+						},
+					}),
+			...(orderRef === undefined ? {} : { orderRef }),
+			...(input.summary === null
+				? {}
+				: { purchasedAtMs: input.summary.createdAtMs }),
+			productName:
+				input.summary?.productName ?? catalogProductName(input.offerId),
+			status: input.summary?.status ?? "pending",
+		}),
+		{ status: 200, headers: { ...BROWSER_PAGE_HEADERS } },
+	);
+};
 
 const matchBillingWebhookPath = (
 	path: string,
@@ -451,7 +534,44 @@ export const routeMachineRequest = (
 		const store = yield* MachineStore;
 
 		if (method === "GET" && path === RelayPaths.billingCheckoutComplete) {
-			return checkoutComplete();
+			// Anyone can open this URL, so the page is rendered from the relay's own
+			// signed ticket: without it (or with an expired one) the visitor gets the
+			// generic catalog receipt and no provider lookup happens at all.
+			const relayConfig = yield* RelayConfiguration;
+			const ticketParam = url.searchParams.get("t");
+			const ticket =
+				ticketParam === null
+					? null
+					: yield* parseJwk(relayConfig.mintPublicKey).pipe(
+							Effect.flatMap((mintPublicJwk) =>
+								verifyCheckoutReceiptTicket({
+									issuer: relayConfig.relayIssuer,
+									mintPublicJwk,
+									nowMs,
+									token: ticketParam,
+								}),
+							),
+							Effect.orElseSucceed(() => null),
+						);
+			const checkoutParam = url.searchParams.get("checkout_id");
+			const checkoutId =
+				checkoutParam === null ||
+				checkoutParam === CHECKOUT_ID_PLACEHOLDER ||
+				checkoutParam.length === 0 ||
+				checkoutParam.length > CHECKOUT_ID_MAX_LENGTH
+					? null
+					: checkoutParam;
+			const summary =
+				ticket === null || checkoutId === null
+					? null
+					: yield* lookupCheckoutSummary({
+							accountId: ticket.accountId,
+							checkoutId,
+						});
+			return checkoutComplete({
+				offerId: knownOfferId(ticket?.offerId ?? url.searchParams.get("offer")),
+				summary,
+			});
 		}
 
 		const billingWebhookMatch = matchBillingWebhookPath(path);
@@ -922,14 +1042,25 @@ export const routeMachineRequest = (
 					serviceUnavailable("billing_provider_unavailable"),
 				),
 			);
+			const receiptTicket = yield* signCheckoutReceiptTicket({
+				accountId: principal.accountId,
+				issuer: relayConfig.relayIssuer,
+				mintPrivateJwk: yield* parseJwk(
+					Redacted.value(relayConfig.mintPrivateKey),
+				),
+				nowMs,
+				offerId: body.offerId,
+				ttlMs: CHECKOUT_RECEIPT_TICKET_TTL_MS,
+			});
 			const checkoutUrl = yield* billing
 				.checkout({
 					accountId: principal.accountId,
 					offerId: body.offerId,
-					successUrl: new URL(
-						RelayPaths.billingCheckoutComplete,
+					successUrl: checkoutSuccessUrl(
 						relayConfig.relayIssuer,
-					).toString(),
+						body.offerId,
+						receiptTicket,
+					),
 				})
 				.pipe(
 					Effect.mapError(() =>

--- a/infra/relay/test/integration/relay.test.ts
+++ b/infra/relay/test/integration/relay.test.ts
@@ -1,5 +1,6 @@
 import {
 	type BillingProviderAdapter,
+	BillingProviderError,
 	BillingProviders,
 	BillingProvidersManual,
 } from "@zuse/billing-providers";
@@ -434,11 +435,31 @@ describe("@zuse/relay", () => {
 					readonly successUrl: string;
 			  }
 			| undefined;
+		let checkoutLookups: ReadonlyArray<{
+			readonly checkoutId: string;
+			readonly accountId: string;
+		}> = [];
 		const billing: BillingProviderAdapter = {
 			providerId: "billing-test",
 			checkout: (input) => {
 				checkoutInput = input;
 				return Effect.succeed("https://billing.test/checkout");
+			},
+			// Mirrors a real adapter: the checkout belongs to `user_a` only.
+			getCheckout: (input) => {
+				checkoutLookups = [...checkoutLookups, input];
+				return Effect.succeed(
+					input.accountId === "user_a"
+						? {
+								amountCents: 1_900,
+								checkoutId: input.checkoutId,
+								createdAtMs: Date.parse("2026-08-14T10:11:12.000Z"),
+								currency: "usd",
+								productName: "Persistent Standard",
+								status: "paid" as const,
+							}
+						: null,
+				);
 			},
 			verifyEvent: () => Effect.die("unused"),
 			reconcileSubscription: () => Effect.die("unused"),
@@ -472,18 +493,150 @@ describe("@zuse/relay", () => {
 			expect(await response.json()).toEqual({
 				checkoutUrl: "https://billing.test/checkout",
 			});
-			expect(checkoutInput).toEqual({
+			expect(checkoutInput).toMatchObject({
 				accountId: "user_a",
 				offerId: "persistent-standard-v1",
-				successUrl: `${RELAY_ISSUER}${RelayPaths.billingCheckoutComplete}`,
 			});
+			const successUrl = new URL(checkoutInput?.successUrl ?? "");
+			expect(`${successUrl.origin}${successUrl.pathname}`).toBe(
+				`${RELAY_ISSUER}${RelayPaths.billingCheckoutComplete}`,
+			);
+			expect(successUrl.searchParams.get("offer")).toBe(
+				"persistent-standard-v1",
+			);
+			// The provider interpolates this itself, so it must not be encoded.
+			expect(checkoutInput?.successUrl).toContain("&checkout_id={CHECKOUT_ID}");
+			const receiptTicket = successUrl.searchParams.get("t") ?? "";
+			expect(receiptTicket.length).toBeGreaterThan(0);
+
+			const completeUrl = (params: Record<string, string>): string => {
+				const target = new URL(
+					`${RELAY_ISSUER}${RelayPaths.billingCheckoutComplete}`,
+				);
+				for (const [key, value] of Object.entries(params)) {
+					target.searchParams.set(key, value);
+				}
+				return target.toString();
+			};
 
 			const completion = await billingRelay.fetch(
-				new Request(`${RELAY_ISSUER}${RelayPaths.billingCheckoutComplete}`),
+				new Request(
+					completeUrl({
+						checkout_id: "checkout_abcdef123456",
+						t: receiptTicket,
+					}),
+				),
 			);
+			const completionPage = await completion.text();
 			expect(completion.status).toBe(200);
 			expect(completion.headers.get("content-type")).toContain("text/html");
-			expect(await completion.text()).toContain("Return to Zuse");
+			expect(completion.headers.get("cache-control")).toBe("no-store");
+			expect(checkoutLookups).toEqual([
+				{ accountId: "user_a", checkoutId: "checkout_abcdef123456" },
+			]);
+			expect(completionPage).toContain("Persistent Standard");
+			expect(completionPage).toContain("$19.00");
+			expect(completionPage).toContain("Paid");
+
+			// Without the relay-signed ticket nothing is looked up at all, so a
+			// stolen checkout id discloses nothing.
+			const unticketed = await billingRelay.fetch(
+				new Request(completeUrl({ checkout_id: "checkout_abcdef123456" })),
+			);
+			const unticketedPage = await unticketed.text();
+			expect(unticketed.status).toBe(200);
+			expect(checkoutLookups).toHaveLength(1);
+			expect(unticketedPage).toContain("Awaiting confirmation");
+			expect(unticketedPage).not.toContain("ZS-EF123456");
+
+			// A forged or expired ticket is treated the same as none.
+			const forged = await billingRelay.fetch(
+				new Request(
+					completeUrl({
+						checkout_id: "checkout_abcdef123456",
+						t: `${receiptTicket.slice(0, -4)}AAAA`,
+					}),
+				),
+			);
+			expect(forged.status).toBe(200);
+			expect(checkoutLookups).toHaveLength(1);
+			expect(await forged.text()).toContain("Awaiting confirmation");
+
+			// An unsubstituted placeholder must not be looked up, and the page still
+			// names the purchase from the ticket's offer.
+			const placeholderCompletion = await billingRelay.fetch(
+				new Request(
+					completeUrl({ checkout_id: "{CHECKOUT_ID}", t: receiptTicket }),
+				),
+			);
+			const placeholderPage = await placeholderCompletion.text();
+			expect(placeholderCompletion.status).toBe(200);
+			expect(checkoutLookups).toHaveLength(1);
+			expect(placeholderPage).toContain("Persistent Standard");
+			expect(placeholderPage).toContain("Awaiting confirmation");
+		} finally {
+			await billingRelay.dispose();
+		}
+	});
+
+	test("keeps the completion page useful when the billing lookup fails", async () => {
+		let successUrl = "";
+		const billing: BillingProviderAdapter = {
+			providerId: "billing-test",
+			checkout: (input) => {
+				successUrl = input.successUrl;
+				return Effect.succeed("https://billing.test/checkout");
+			},
+			getCheckout: () =>
+				new BillingProviderError({ code: "provider-unavailable" }),
+			verifyEvent: () => Effect.die("unused"),
+			reconcileSubscription: () => Effect.die("unused"),
+			cancel: () => Effect.void,
+			customerPortal: () => Effect.succeed("https://billing.test/portal"),
+		};
+		const billingRelay = makeRelay(
+			await makeLayer(
+				undefined,
+				BillingProviders.layer({
+					adapters: [billing],
+					defaultProviderId: billing.providerId,
+				}).pipe(Layer.orDie),
+				true,
+			),
+		);
+
+		try {
+			await billingRelay.fetch(
+				new Request(`${RELAY_ISSUER}${RelayPaths.billingCheckout}`, {
+					method: "POST",
+					headers: {
+						authorization: "Bearer test-token:user_a",
+						"content-type": "application/json",
+					},
+					body: JSON.stringify({ offerId: "persistent-standard-v1" }),
+				}),
+			);
+			const ticket = new URL(successUrl).searchParams.get("t") ?? "";
+			const completion = await billingRelay.fetch(
+				new Request(
+					`${RELAY_ISSUER}${RelayPaths.billingCheckoutComplete}?checkout_id=checkout_abcdef123456&t=${encodeURIComponent(ticket)}`,
+				),
+			);
+			const page = await completion.text();
+			expect(completion.status).toBe(200);
+			expect(page).toContain("Persistent Standard");
+			expect(page).toContain("Awaiting confirmation");
+
+			// Unknown offers are never echoed back into the page.
+			const hostile = await billingRelay.fetch(
+				new Request(
+					`${RELAY_ISSUER}${RelayPaths.billingCheckoutComplete}?offer=${encodeURIComponent("<script>alert(1)</script>")}`,
+				),
+			);
+			const hostilePage = await hostile.text();
+			expect(hostile.status).toBe(200);
+			expect(hostilePage).not.toContain("<script>alert");
+			expect(hostilePage).toContain("Zuse subscription");
 		} finally {
 			await billingRelay.dispose();
 		}
@@ -499,6 +652,7 @@ describe("@zuse/relay", () => {
 				checkoutInput = input;
 				return Effect.succeed("https://billing.test/sandbox-checkout");
 			},
+			getCheckout: () => Effect.succeed(null),
 			verifyEvent: () => Effect.die("unused"),
 			reconcileSubscription: () => Effect.die("unused"),
 			cancel: () => Effect.void,
@@ -545,6 +699,7 @@ describe("@zuse/relay", () => {
 		const billing: BillingProviderAdapter = {
 			providerId: "billing-test",
 			checkout: () => Effect.succeed("https://billing.test/replacement"),
+			getCheckout: () => Effect.succeed(null),
 			verifyEvent: (request) =>
 				Effect.promise(async () => {
 					const body = (await request.json()) as {
@@ -644,6 +799,7 @@ describe("@zuse/relay", () => {
 		const billing: BillingProviderAdapter = {
 			providerId: "billing-test",
 			checkout: () => Effect.succeed("https://billing.test/checkout"),
+			getCheckout: () => Effect.succeed(null),
 			verifyEvent: (request) =>
 				Effect.promise(async () => {
 					const body = (await request.json()) as {

--- a/infra/relay/test/unit/checkout-complete-page.test.ts
+++ b/infra/relay/test/unit/checkout-complete-page.test.ts
@@ -1,0 +1,78 @@
+import { BROWSER_PAGE_HEADERS } from "@zuse/utils/browser-page";
+import { describe, expect, test } from "vitest";
+
+import { renderCheckoutCompletePage } from "../../src/checkout-complete-page.ts";
+
+const purchasedAtMs = Date.parse("2026-08-14T10:11:12.000Z");
+
+describe("checkout completion page", () => {
+	test("renders the purchased order", () => {
+		const page = renderCheckoutCompletePage({
+			amount: { cents: 1_900, currency: "usd" },
+			orderRef: "ZS-EF123456",
+			productName: "Persistent Standard",
+			purchasedAtMs,
+			status: "paid",
+		});
+
+		expect(page).toContain("Persistent Standard");
+		expect(page).toContain("$19.00");
+		expect(page).toContain("ZS-EF123456");
+		expect(page).toContain("2026.08.14 10:11 UTC");
+		expect(page).toContain("Paid");
+	});
+
+	test("degrades to a courtesy receipt without order details", () => {
+		const page = renderCheckoutCompletePage({
+			productName: "Zuse subscription",
+			purchasedAtMs,
+			status: "pending",
+		});
+
+		expect(page).toContain("Zuse subscription");
+		expect(page).toContain("Awaiting confirmation");
+		expect(page).not.toContain("NaN");
+		expect(page).not.toContain("undefined");
+	});
+
+	test("states plainly when the checkout did not complete", () => {
+		const page = renderCheckoutCompletePage({
+			productName: "Zuse subscription",
+			purchasedAtMs,
+			status: "failed",
+		});
+
+		expect(page).toContain("Not completed");
+		expect(page).toContain("Nothing was charged");
+	});
+
+	test("escapes provider-supplied text", () => {
+		const page = renderCheckoutCompletePage({
+			orderRef: "<img src=x>",
+			productName: '<script>alert("x")</script>',
+			purchasedAtMs,
+			status: "paid",
+		});
+
+		expect(page).not.toContain("<script>alert");
+		expect(page).not.toContain("<img src=x>");
+		expect(page).toContain("&lt;script&gt;");
+	});
+
+	test("stays self-contained and theme aware", () => {
+		const page = renderCheckoutCompletePage({
+			productName: "Persistent Standard",
+			purchasedAtMs,
+			status: "paid",
+		});
+
+		expect(page).not.toMatch(/(?:src|href)="https?:/u);
+		expect(page).not.toContain("<script");
+		expect(page).toContain("prefers-color-scheme:dark");
+		expect(page).toContain("prefers-reduced-motion:reduce");
+		expect(BROWSER_PAGE_HEADERS["cache-control"]).toBe("no-store");
+		expect(BROWSER_PAGE_HEADERS["content-security-policy"]).toContain(
+			"default-src 'none'",
+		);
+	});
+});

--- a/infra/relay/test/unit/machine-reconciler.test.ts
+++ b/infra/relay/test/unit/machine-reconciler.test.ts
@@ -247,6 +247,7 @@ describe("machine reconciler", () => {
 		const billing: BillingProviderAdapter = {
 			providerId: "billing-test",
 			checkout: () => new BillingProviderError({ code: "checkout-disabled" }),
+			getCheckout: () => Effect.succeed(null),
 			verifyEvent: () =>
 				new BillingProviderError({ code: "checkout-disabled" }),
 			reconcileSubscription: () =>
@@ -319,6 +320,7 @@ describe("machine reconciler", () => {
 		const billing: BillingProviderAdapter = {
 			providerId: "billing-test",
 			checkout: () => new BillingProviderError({ code: "checkout-disabled" }),
+			getCheckout: () => Effect.succeed(null),
 			verifyEvent: () =>
 				new BillingProviderError({ code: "checkout-disabled" }),
 			reconcileSubscription: () =>

--- a/packages/billing-providers/README.md
+++ b/packages/billing-providers/README.md
@@ -1,8 +1,8 @@
 # Billing provider adapters
 
-This package owns the billing-provider seam and registry. Checkout, webhook
-verification, subscription reconciliation, cancellation, and customer portals
-are implemented by `BillingProviderAdapter`s.
+This package owns the billing-provider seam and registry. Checkout, checkout
+lookup, webhook verification, subscription reconciliation, cancellation, and
+customer portals are implemented by `BillingProviderAdapter`s.
 
 Each adapter must:
 
@@ -10,6 +10,10 @@ Each adapter must:
 - keep product/price mapping private to the adapter;
 - verify webhook signatures before decoding provider events;
 - normalize subscriptions to `ReconciledSubscription`;
+- normalize checkout sessions to `CheckoutSummary`, resolving `null` for
+  unknown ids **and for checkouts owned by another account**, and omitting
+  customer identity — a checkout id is browser-visible and it feeds the
+  unauthenticated post-purchase page;
 - make cancellation idempotent;
 - keep credentials and raw provider payloads inside the adapter.
 

--- a/packages/billing-providers/src/index.ts
+++ b/packages/billing-providers/src/index.ts
@@ -26,6 +26,20 @@ export interface ReconciledSubscription {
 	readonly paidThrough?: number;
 }
 
+/**
+ * Display-only view of a checkout session, used by the post-purchase page.
+ * Deliberately free of customer identity: it is rendered on an unauthenticated
+ * page keyed by the provider's checkout id.
+ */
+export interface CheckoutSummary {
+	readonly checkoutId: string;
+	readonly productName?: string;
+	readonly amountCents: number;
+	readonly currency: string;
+	readonly status: "paid" | "pending" | "failed";
+	readonly createdAtMs: number;
+}
+
 export interface BillingProviderAdapter {
 	readonly providerId: string;
 	readonly checkout: (input: {
@@ -34,6 +48,16 @@ export interface BillingProviderAdapter {
 		readonly successUrl: string;
 		readonly fulfillmentMetadata?: Readonly<Record<string, string>>;
 	}) => Effect.Effect<string, BillingProviderError>;
+	/**
+	 * Look up one checkout session **owned by `accountId`**. Resolves `null`
+	 * when the provider has no such session or it belongs to another account —
+	 * a checkout id is browser-visible, so ownership is enforced here rather
+	 * than trusted from the caller.
+	 */
+	readonly getCheckout: (input: {
+		readonly checkoutId: string;
+		readonly accountId: string;
+	}) => Effect.Effect<CheckoutSummary | null, BillingProviderError>;
 	readonly verifyEvent: (
 		request: Request,
 	) => Effect.Effect<
@@ -82,6 +106,9 @@ export class BillingProviders extends Context.Service<
 export const BillingProviderManual: BillingProviderAdapter = {
 	providerId: "manual",
 	checkout: () => new BillingProviderError({ code: "checkout-disabled" }),
+	// Manual billing never creates checkout sessions, so there is nothing to
+	// look up — the post-purchase page falls back to the offer catalog.
+	getCheckout: () => Effect.succeed(null),
 	verifyEvent: () => new BillingProviderError({ code: "checkout-disabled" }),
 	reconcileSubscription: () =>
 		new BillingProviderError({ code: "checkout-disabled" }),

--- a/packages/billing-providers/src/polar.ts
+++ b/packages/billing-providers/src/polar.ts
@@ -4,6 +4,7 @@ import { Effect, Predicate, Redacted } from "effect";
 import {
 	type BillingProviderAdapter,
 	BillingProviderError,
+	type CheckoutSummary,
 	type ReconciledSubscription,
 } from "./index.ts";
 
@@ -37,6 +38,23 @@ export interface PolarSubscription {
 	};
 }
 
+export interface PolarCheckout {
+	readonly id: string;
+	readonly status:
+		| "open"
+		| "expired"
+		| "confirmed"
+		| "succeeded"
+		| "failed"
+		| (string & {});
+	readonly totalAmount: number;
+	readonly currency: string;
+	readonly createdAt: Date;
+	readonly product: { readonly name: string } | null;
+	readonly externalCustomerId?: string | null;
+	readonly customer?: { readonly externalId?: string | null } | null;
+}
+
 export interface PolarBillingClient {
 	readonly createCheckout: (input: {
 		readonly products: ReadonlyArray<string>;
@@ -45,6 +63,7 @@ export interface PolarBillingClient {
 		readonly metadata: Readonly<Record<string, string>>;
 		readonly allowTrial: false;
 	}) => Promise<{ readonly url: string }>;
+	readonly getCheckout: (checkoutId: string) => Promise<PolarCheckout | null>;
 	readonly getSubscription: (
 		subscriptionId: string,
 	) => Promise<PolarSubscription | null>;
@@ -93,6 +112,14 @@ const makeSdkClient = (config: PolarBillingConfig): PolarBillingClient => {
 				metadata: { ...input.metadata },
 				allowTrial: input.allowTrial,
 			}),
+		getCheckout: async (checkoutId) => {
+			try {
+				return await polar.checkouts.get({ id: checkoutId });
+			} catch (error) {
+				if (isNotFound(error)) return null;
+				throw error;
+			}
+		},
 		getSubscription: async (subscriptionId) => {
 			try {
 				return await polar.subscriptions.get({ id: subscriptionId });
@@ -165,6 +192,28 @@ const normalizeStatus = (
 	}
 };
 
+/**
+ * A checkout id travels through the buyer's browser, so a lookup is only ever
+ * answered for the account Polar recorded as the checkout's customer.
+ */
+const isOwnedBy = (checkout: PolarCheckout, accountId: string): boolean =>
+	(checkout.externalCustomerId ?? checkout.customer?.externalId ?? null) ===
+	accountId;
+
+const normalizeCheckoutStatus = (
+	status: PolarCheckout["status"],
+): CheckoutSummary["status"] => {
+	switch (status) {
+		case "succeeded":
+			return "paid";
+		case "open":
+		case "confirmed":
+			return "pending";
+		default:
+			return "failed";
+	}
+};
+
 const makeOfferProductIndex = (
 	offerProducts: PolarBillingConfig["offerProducts"],
 ): ReadonlyMap<string, string> => {
@@ -219,6 +268,26 @@ export const makePolarBillingProvider = (
 				catch: providerFailure,
 			});
 		},
+		getCheckout: (input) =>
+			Effect.tryPromise({
+				try: () => client.getCheckout(input.checkoutId),
+				catch: providerFailure,
+			}).pipe(
+				Effect.map((checkout) =>
+					checkout === null || !isOwnedBy(checkout, input.accountId)
+						? null
+						: ({
+								amountCents: checkout.totalAmount,
+								checkoutId: checkout.id,
+								createdAtMs: checkout.createdAt.getTime(),
+								currency: checkout.currency,
+								status: normalizeCheckoutStatus(checkout.status),
+								...(checkout.product === null
+									? {}
+									: { productName: checkout.product.name }),
+							} satisfies CheckoutSummary),
+				),
+			),
 		verifyEvent: (request) =>
 			Effect.gen(function* () {
 				const eventId = request.headers.get("webhook-id");

--- a/packages/billing-providers/test/unit/polar.test.ts
+++ b/packages/billing-providers/test/unit/polar.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
 	makePolarBillingProvider,
 	type PolarBillingClient,
+	type PolarCheckout,
 	type PolarSubscription,
 } from "../../src/polar.ts";
 
@@ -18,6 +19,18 @@ const subscription = (
 	customer: { externalId: "account_1" },
 });
 
+const checkout = (
+	status: PolarCheckout["status"] = "succeeded",
+): PolarCheckout => ({
+	id: "checkout_abcdef123456",
+	status,
+	totalAmount: 1_900,
+	currency: "usd",
+	createdAt: new Date("2026-08-14T10:11:12.000Z"),
+	product: { name: "Persistent Standard" },
+	externalCustomerId: "account_1",
+});
+
 const makeClient = () => {
 	const calls = {
 		checkouts: [] as ReadonlyArray<unknown>,
@@ -27,11 +40,17 @@ const makeClient = () => {
 		sessions: [] as ReadonlyArray<string>,
 	};
 	let current: PolarSubscription | null = subscription();
+	let currentCheckout: PolarCheckout | null = checkout();
+	let checkoutFailure: Error | null = null;
 	const client: PolarBillingClient = {
 		createCheckout: (input) => {
 			calls.checkouts = [...calls.checkouts, input];
 			return Promise.resolve({ url: "https://sandbox.example/checkout" });
 		},
+		getCheckout: () =>
+			checkoutFailure === null
+				? Promise.resolve(currentCheckout)
+				: Promise.reject(checkoutFailure),
 		getSubscription: () => Promise.resolve(current),
 		revokeSubscription: (subscriptionId) => {
 			calls.revocations = [...calls.revocations, subscriptionId];
@@ -55,6 +74,12 @@ const makeClient = () => {
 	return {
 		calls,
 		client,
+		setCheckout: (value: PolarCheckout | null) => {
+			currentCheckout = value;
+		},
+		setCheckoutFailure: (value: Error | null) => {
+			checkoutFailure = value;
+		},
 		setSubscription: (value: PolarSubscription | null) => {
 			current = value;
 		},
@@ -285,6 +310,88 @@ describe("Polar billing provider", () => {
 
 		expect(eventError.code).toBe("invalid-event");
 		expect(subscriptionError.code).toBe("provider-unavailable");
+	});
+
+	test("summarizes a checkout session for the post-purchase page", async () => {
+		const fake = makeClient();
+		const provider = makePolarBillingProvider(config, { client: fake.client });
+
+		const summary = await Effect.runPromise(
+			provider.getCheckout({
+				accountId: "account_1",
+				checkoutId: "checkout_abcdef123456",
+			}),
+		);
+
+		expect(summary).toEqual({
+			amountCents: 1_900,
+			checkoutId: "checkout_abcdef123456",
+			createdAtMs: new Date("2026-08-14T10:11:12.000Z").getTime(),
+			currency: "usd",
+			productName: "Persistent Standard",
+			status: "paid",
+		});
+	});
+
+	test("reports unsettled and unknown checkouts without failing", async () => {
+		const fake = makeClient();
+		const provider = makePolarBillingProvider(config, { client: fake.client });
+
+		const lookup = { accountId: "account_1", checkoutId: "checkout_1" };
+		fake.setCheckout(checkout("confirmed"));
+		const pending = await Effect.runPromise(provider.getCheckout(lookup));
+		fake.setCheckout(checkout("expired"));
+		const expired = await Effect.runPromise(provider.getCheckout(lookup));
+		fake.setCheckout(null);
+		const missing = await Effect.runPromise(provider.getCheckout(lookup));
+
+		expect(pending?.status).toBe("pending");
+		expect(expired?.status).toBe("failed");
+		expect(missing).toBeNull();
+	});
+
+	test("refuses to summarize another account's checkout", async () => {
+		const fake = makeClient();
+		const provider = makePolarBillingProvider(config, { client: fake.client });
+
+		const stolen = await Effect.runPromise(
+			provider.getCheckout({
+				accountId: "account_2",
+				checkoutId: "checkout_abcdef123456",
+			}),
+		);
+
+		expect(stolen).toBeNull();
+
+		// Older checkouts carry the identity on the customer instead.
+		fake.setCheckout({
+			...checkout(),
+			externalCustomerId: null,
+			customer: { externalId: "account_1" },
+		});
+		await expect(
+			Effect.runPromise(
+				provider.getCheckout({
+					accountId: "account_1",
+					checkoutId: "checkout_abcdef123456",
+				}),
+			),
+		).resolves.toMatchObject({ productName: "Persistent Standard" });
+	});
+
+	test("surfaces checkout lookup transport failures", async () => {
+		const fake = makeClient();
+		const provider = makePolarBillingProvider(config, { client: fake.client });
+		fake.setCheckoutFailure(new Error("network"));
+
+		const exit = await Effect.runPromiseExit(
+			provider.getCheckout({
+				accountId: "account_1",
+				checkoutId: "checkout_1",
+			}),
+		);
+
+		expect(exit._tag).toBe("Failure");
 	});
 
 	test("rejects ambiguous product mappings at startup", () => {

--- a/packages/billing-providers/test/unit/registry.test.ts
+++ b/packages/billing-providers/test/unit/registry.test.ts
@@ -8,6 +8,7 @@ import {
 const adapter = (providerId: string): BillingProviderAdapter => ({
 	providerId,
 	checkout: () => Effect.succeed(`${providerId}:checkout`),
+	getCheckout: () => Effect.succeed(null),
 	verifyEvent: () => Effect.die("unused"),
 	reconcileSubscription: () => Effect.die("unused"),
 	cancel: () => Effect.void,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"type": "module",
 	"exports": {
+		"./browser-page": "./src/browser-page.ts",
 		"./cloud-transcript-crypto": "./src/cloud-transcript-crypto.ts",
 		"./drainable-worker": "./src/drainable-worker.ts",
 		"./keyed-worker": "./src/keyed-worker.ts",

--- a/packages/utils/src/browser-page.ts
+++ b/packages/utils/src/browser-page.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared primitives for the browser-facing pages the product serves from its
+ * loopback listeners and the relay worker (sign-in, integration connect,
+ * checkout complete). The pages themselves stay next to the code that serves
+ * them — the runtimes have no common view layer — but sanitization and response
+ * hardening are one behavior and live here so a fix lands everywhere at once.
+ */
+
+const HTML_ESCAPES: Readonly<Record<string, string>> = {
+	'"': "&quot;",
+	"&": "&amp;",
+	"'": "&#39;",
+	"<": "&lt;",
+	">": "&gt;",
+};
+
+/** Escape a value for interpolation into HTML text or a quoted attribute. */
+export const escapeHtml = (value: string): string =>
+	value.replaceAll(/["&'<>]/gu, (character) => HTML_ESCAPES[character] ?? "");
+
+/**
+ * Trim, clamp, and escape untrusted text (provider error descriptions, product
+ * names). Returns `null` when nothing is left, so callers can fall back to
+ * their own copy instead of rendering an empty slot.
+ */
+export const clampedText = (
+	value: string | undefined,
+	maxLength: number,
+): string | null => {
+	const trimmed = value?.trim() ?? "";
+	if (trimmed.length === 0) return null;
+	return escapeHtml(
+		trimmed.length > maxLength
+			? `${trimmed.slice(0, maxLength - 1)}…`
+			: trimmed,
+	);
+};
+
+/**
+ * Response headers for every browser-facing page. These URLs carry
+ * authorization codes and checkout ids, so nothing is cached, referred, or
+ * framed, and the pages are built to need no resource beyond inline styles.
+ */
+export const BROWSER_PAGE_HEADERS: Readonly<Record<string, string>> = {
+	"cache-control": "no-store",
+	"content-security-policy":
+		"default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'",
+	"content-type": "text/html; charset=utf-8",
+	"referrer-policy": "no-referrer",
+	"x-content-type-options": "nosniff",
+};

--- a/packages/utils/test/unit/browser-page.test.ts
+++ b/packages/utils/test/unit/browser-page.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	BROWSER_PAGE_HEADERS,
+	clampedText,
+	escapeHtml,
+} from "../../src/browser-page.js";
+
+describe("browser page helpers", () => {
+	test("escapes every character that can break out of markup", () => {
+		expect(escapeHtml(`<script>alert("x" & 'y')</script>`)).toBe(
+			"&lt;script&gt;alert(&quot;x&quot; &amp; &#39;y&#39;)&lt;/script&gt;",
+		);
+		expect(escapeHtml("plain text")).toBe("plain text");
+	});
+
+	test("clamps, trims, and escapes untrusted text", () => {
+		expect(clampedText("  spaced  ", 60)).toBe("spaced");
+		expect(clampedText("<b>", 60)).toBe("&lt;b&gt;");
+		expect(clampedText("x".repeat(10), 5)).toBe(`${"x".repeat(4)}…`);
+	});
+
+	test("treats empty and missing text as absent", () => {
+		expect(clampedText(undefined, 60)).toBeNull();
+		expect(clampedText("   ", 60)).toBeNull();
+	});
+
+	test("keeps callback responses uncacheable and resource-free", () => {
+		expect(BROWSER_PAGE_HEADERS["cache-control"]).toBe("no-store");
+		expect(BROWSER_PAGE_HEADERS["referrer-policy"]).toBe("no-referrer");
+		expect(BROWSER_PAGE_HEADERS["x-content-type-options"]).toBe("nosniff");
+		expect(BROWSER_PAGE_HEADERS["content-security-policy"]).toContain(
+			"default-src 'none'",
+		);
+	});
+});


### PR DESCRIPTION
## What changed

The three browser-facing callback pages — the last thing a user sees before returning to the app — were unstyled inline HTML strings. They are now designed surfaces, each self-contained (no scripts, no network fonts, no external assets), light/dark via `prefers-color-scheme`, reduced-motion aware, and served with `no-store` + CSP + `nosniff` + `no-referrer`. Every interpolated value is escaped and clamped.

**Account sign-in → Ticket** (`apps/desktop/src/auth-callback-page.ts`). Lime "ADMIT ONE → SIGNED IN" ticket with clip-path notches, dashed perforation and barcode stub. New red **VOID** variant when the provider returns `error=` — the loopback previously rendered "Signed in" regardless of outcome. Branded 404 replaces the bare `Not found`, and callback classification (`/callback` vs `/linear/callback`) is now one helper shared by the loopback and the deep-link handler.

**Linear + MCP connect → Stamp** (`apps/server/src/mcp/mcp-callback-page.ts`, plus the Linear variant in the desktop module). Perforated stamp with postmark. Fixes a real bug: `mcp-oauth.ts` wrote the "You're connected" page *before* checking `code`/`error`, so a denied authorization still showed success.

**Purchase → Receipt printer** (`infra/relay/src/checkout-complete-page.ts`). Printer shell with a status screen and the receipt feeding out on load. It now shows the actual order: relay builds the success URL as `…/checkout/complete?offer=<id>&checkout_id={CHECKOUT_ID}`, and `BillingProviderAdapter` gains `getCheckout` (implemented against `polar.checkouts.get`) returning a PII-free `CheckoutSummary` → product name, amount, order ref, date, PAID / AWAITING CONFIRMATION. The lookup is best-effort: 2s timeout, then offer-catalog fallback, then generic copy — the page never 500s and never blocks on billing. The `offer` param is validated against the catalog, so nothing from the query string is echoed back.

## Validation

- Typechecks clean: desktop, server, relay, billing-providers. Biome clean on all touched files. `check-architecture-boundaries` passes.
- relay 154/154 (new coverage for the success URL, real-order rendering, provider-failure fallback, and an `offer=<script>` injection attempt), billing-providers 10/10 (`getCheckout` mapping / 404 / transport failure), new page suites: desktop 7, server 5.
- All seven page variants rendered in headless Chrome and inspected in light and dark.
- Pre-existing sandbox-only failures, unrelated to this change: `browser-session-service` and `tailnet-environment-service` (missing `libsecret`), `mcp-claude-status` (node-pty native build skipped), `performance-history-store` (fails on an untouched module).

## Note for review

The Linear and MCP stamps knowingly duplicate ~40 lines of CSS: the pages stay inline per runtime by design, since the Cloudflare Worker, Electron main and Node server share no React/Tailwind build. Worth extracting if a third stamp surface appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

