### PR TITLE
Release CLI version 0.1.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -568,7 +568,7 @@
     },
     "packages/serve": {
       "name": "@zusehq/serve",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "zuse": "dist/bin.mjs",
       },

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zusehq/serve",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "One-command remote access for Zuse workspaces",
 	"license": "AGPL-3.0-only",
 	"type": "module",

--- a/packages/serve/test/agent-cli.test.ts
+++ b/packages/serve/test/agent-cli.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { WIRE_PROTOCOL_VERSION } from "@zuse/contracts";
 import { describe, expect, test } from "vitest";
 import { __testing, isAgentCliCommand } from "../src/agent-cli.ts";
 
@@ -107,7 +108,9 @@ describe("agent CLI", () => {
 				ZUSE_DEV_CLI_ACCESS_FILE: accessFile,
 			}),
 		);
-		expect(endpoint.searchParams.get("wireVersion")).toBe("4");
+		expect(endpoint.searchParams.get("wireVersion")).toBe(
+			String(WIRE_PROTOCOL_VERSION),
+		);
 		expect(endpoint.searchParams.get("token")).toBe("zt_development");
 	});
 });


### PR DESCRIPTION
## Summary

- publish the chat and session mutation compatibility updates in `@zusehq/serve@0.1.4`
- keep the CLI wire-protocol test synchronized with the shared protocol version

## Validation

- `bunx biome check packages/serve/package.json packages/serve/src/agent-cli.ts packages/serve/test/agent-cli.test.ts`
- `bun --filter @zusehq/serve check-types`
- `bun --filter @zusehq/serve test`
- `bun --filter @zusehq/serve build`
- `npm pack ./packages/serve`
- clean temporary `npm install` from the tarball
- packaged `zuse commands` smoke test (38 commands)