### PR TITLE
Release zusehq version 0.1.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -678,12 +678,12 @@
     },
     "packages/zusehq": {
       "name": "zusehq",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "zusehq": "dist/bin.mjs",
       },
       "dependencies": {
-        "@zusehq/serve": "0.1.1",
+        "@zusehq/serve": "0.1.4",
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
@@ -5438,8 +5438,6 @@
 
     "zip-stream/readable-stream": ["readable-stream@3.6.2", "http://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "zusehq/@zusehq/serve": ["@zusehq/serve@0.1.1", "", { "dependencies": { "@zusehq/server": "0.1.1" }, "bin": { "zuse": "dist/bin.mjs" } }, "sha512-TUwHH+NHUE7jNEPc9fLt/pWWGdtt1vZ2BOdyFYojjMLXWwUNpOO1OApbhQCEqyfnBWAzYbKMAFkCqBvlAyR+IQ=="],
-
     "zxing-wasm/type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
 
     "@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.3", "http://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
@@ -6145,8 +6143,6 @@
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "http://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "zip-stream/archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "zusehq/@zusehq/serve/@zusehq/server": ["@zusehq/server@0.1.1", "", { "dependencies": { "keytar": "^7.9.0", "node-pty": "^1.1.0", "tree-sitter": "^0.21.1", "tree-sitter-javascript": "^0.23.0", "tree-sitter-json": "^0.24.0", "tree-sitter-typescript": "^0.23.0" }, "bin": { "zuse": "dist/bin.mjs" } }, "sha512-k9NWYyreDz4t6oob4y8cnq/qqKkzZq7Z54TKEBPQhWn9aV6sX+x649hUrUAGBrrPYyi6j3abht6A9SkRLMu2sg=="],
 
     "@babel/core/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "http://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/packages/zusehq/package.json
+++ b/packages/zusehq/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zusehq",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Run and manage Zuse remote workspaces",
 	"license": "AGPL-3.0-only",
 	"type": "module",
@@ -24,7 +24,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zusehq/serve": "0.1.1"
+		"@zusehq/serve": "0.1.4"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",


### PR DESCRIPTION
## Summary

- release `zusehq@0.1.2`
- update the wrapper to use the chat-compatible `@zusehq/serve@0.1.4` CLI

## Validation

- `bunx biome check packages/zusehq/package.json packages/zusehq/src/bin.ts`
- `bun --filter zusehq check-types`
- `bun --filter zusehq build`
- `npm pack ./packages/zusehq`
- clean temporary tarball install
- packaged `zusehq commands` smoke test (38 commands)