### PR TITLE
Enable local CLI access to desktop chats

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3238,14 +3238,13 @@ async function createMainWindow() {
 						}
 					},
 				},
-				...(isDevelopment && process.env.ZUSE_DEV_CLI_ACCESS_FILE
-					? {
-							devCliAccess: {
-								path: process.env.ZUSE_DEV_CLI_ACCESS_FILE,
-								wsUrl: `ws://127.0.0.1:${relayWsPort}/rpc`,
-							},
-						}
-					: {}),
+				cliAccess: {
+					path:
+						isDevelopment && process.env.ZUSE_DEV_CLI_ACCESS_FILE
+							? process.env.ZUSE_DEV_CLI_ACCESS_FILE
+							: Path.join(app.getPath("userData"), "cli-access.json"),
+					wsUrl: `ws://127.0.0.1:${relayWsPort}/rpc`,
+				},
 			}),
 		).pipe(
 			Effect.catchCause((cause) =>

--- a/apps/docs/content/docs/serve/agent-cli.mdx
+++ b/apps/docs/content/docs/serve/agent-cli.mdx
@@ -283,7 +283,7 @@ Use an idempotency key for creation commands whenever a transport failure might 
 
 `--project` accepts a project ID, exact name, or path. Zuse infers it only when the current directory belongs to exactly one registered project; otherwise the error response includes candidates.
 
-The CLI targets the local Zuse RPC server by default. When run from a repository using `bun dev`, the development desktop publishes its selected port and a dedicated credential to an owner-readable, gitignored `.zuse/dev-instances/<instance>/cli-access.json` descriptor. The branch-local CLI discovers it automatically, including when concurrent dev instances shifted away from port `8788`. It never prints the credential.
+The CLI targets the local Zuse RPC server by default. The installed desktop publishes its selected port and a dedicated credential to an owner-readable `cli-access.json` file in the Zuse user-data directory, which the CLI discovers automatically. When run from a repository using `bun dev`, the development desktop instead publishes an owner-readable, gitignored `.zuse/dev-instances/<instance>/cli-access.json` descriptor. Branch-local discovery supports concurrent development instances whose ports shifted away from `8788`. The CLI never prints either credential.
 
 Explicit `--ws-url`/`--token` options and `ZUSE_WS_URL`/`ZUSE_TOKEN` override development discovery. Outside a development checkout, the conventional installed-desktop endpoint remains the fallback.
 
@@ -298,7 +298,7 @@ zuse session list \
   --project <project-id>
 ```
 
-`ZUSE_WS_URL`, `ZUSE_TOKEN`, `ZUSE_PORT`, `ZUSE_DEV_INSTANCE`, and `ZUSE_DEV_CLI_ACCESS_FILE` are available for controlled automation environments. Do not print tokens, embed them in prompts, or commit them to the repository. Prefer environment-based secret injection where shell-history exposure matters.
+`ZUSE_WS_URL`, `ZUSE_TOKEN`, `ZUSE_PORT`, `ZUSE_USER_DATA_DIR`, `ZUSE_DEV_INSTANCE`, and `ZUSE_DEV_CLI_ACCESS_FILE` are available for controlled automation environments. Do not print tokens, embed them in prompts, or commit them to the repository. Prefer environment-based secret injection where shell-history exposure matters.
 
 ## Reliable automation sequence
 

--- a/apps/server/src/runtime.ts
+++ b/apps/server/src/runtime.ts
@@ -142,7 +142,7 @@ export interface MainLayerDeps {
 		readonly relayUrl: string;
 		readonly label?: string;
 	};
-	readonly devCliAccess?: {
+	readonly cliAccess?: {
 		readonly path: string;
 		readonly wsUrl: string;
 	};
@@ -212,9 +212,9 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		Layer.provide(MigratedSqlite),
 		Layer.provide(LanAuthConfigLayer),
 	);
-	const devCliAccess = deps.devCliAccess;
-	const DevCliAccessLayer =
-		devCliAccess === undefined
+	const cliAccess = deps.cliAccess;
+	const CliAccessLayer =
+		cliAccess === undefined
 			? Layer.empty
 			: Layer.effectDiscard(
 					Effect.gen(function* () {
@@ -222,13 +222,14 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 						const existing = yield* auth.listTokens();
 						for (const token of existing) {
 							if (
-								token.label === "Development CLI" &&
+								(token.label === "Local CLI" ||
+									token.label === "Development CLI") &&
 								token.revokedAt === undefined
 							)
 								yield* auth.revokeToken(token.id);
 						}
-						const minted = yield* auth.mintToken("Development CLI");
-						const { path: target, wsUrl } = devCliAccess;
+						const minted = yield* auth.mintToken("Local CLI");
+						const { path: target, wsUrl } = cliAccess;
 						const temporary = `${target}.${process.pid}.tmp`;
 						yield* Effect.promise(async () => {
 							await mkdir(dirname(target), { recursive: true });
@@ -676,6 +677,6 @@ export const makeMainLayer = (deps: MainLayerDeps) => {
 		AutoRelayLinkLayer,
 		CloudWorkspaceRuntimeLayer,
 		RuntimePerformanceLayer,
-		DevCliAccessLayer,
+		CliAccessLayer,
 	).pipe(Layer.provide(TelemetryLayer));
 };

--- a/bun.lock
+++ b/bun.lock
@@ -568,7 +568,7 @@
     },
     "packages/serve": {
       "name": "@zusehq/serve",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bin": {
         "zuse": "dist/bin.mjs",
       },
@@ -678,7 +678,7 @@
     },
     "packages/zusehq": {
       "name": "zusehq",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "bin": {
         "zusehq": "dist/bin.mjs",
       },

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zusehq/serve",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "One-command remote access for Zuse workspaces",
 	"license": "AGPL-3.0-only",
 	"type": "module",

--- a/packages/serve/src/agent-cli.ts
+++ b/packages/serve/src/agent-cli.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import {
 	basename,
 	dirname,
@@ -173,16 +174,39 @@ const promptFor = async (args: Args, message = false): Promise<string> => {
 	return file === "-" ? readStdin() : readFile(resolve(file), "utf8");
 };
 
-type DevCliAccess = {
+type LocalCliAccess = {
 	readonly schemaVersion: 1;
 	readonly wsUrl: string;
 	readonly token: string;
 };
-const devCliAccess = async (
+const installedCliAccessCandidates = (
 	env: NodeJS.ProcessEnv,
-): Promise<DevCliAccess | null> => {
+	platform = process.platform,
+): ReadonlyArray<string> => {
+	const configured = env.ZUSE_USER_DATA_DIR?.trim();
+	if (configured) return [join(resolve(configured), "cli-access.json")];
+	if (platform === "darwin")
+		return [
+			join(
+				homedir(),
+				"Library",
+				"Application Support",
+				"Zuse Alpha",
+				"cli-access.json",
+			),
+		];
+	if (platform === "win32" && env.APPDATA?.trim())
+		return [join(resolve(env.APPDATA), "Zuse Alpha", "cli-access.json")];
+	const config = env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
+	return [join(resolve(config), "Zuse Alpha", "cli-access.json")];
+};
+const localCliAccess = async (
+	env: NodeJS.ProcessEnv,
+): Promise<LocalCliAccess | null> => {
 	const explicit = env.ZUSE_DEV_CLI_ACCESS_FILE?.trim();
-	const candidates: string[] = explicit ? [resolve(explicit)] : [];
+	const candidates: string[] = explicit
+		? [resolve(explicit)]
+		: [...installedCliAccessCandidates(env)];
 	let cursor = resolve(process.cwd());
 	while (true) {
 		const instance = env.ZUSE_DEV_INSTANCE?.trim() || "default";
@@ -197,13 +221,13 @@ const devCliAccess = async (
 		try {
 			const parsed = JSON.parse(
 				await readFile(candidate, "utf8"),
-			) as Partial<DevCliAccess>;
+			) as Partial<LocalCliAccess>;
 			if (
 				parsed.schemaVersion === 1 &&
 				typeof parsed.wsUrl === "string" &&
 				typeof parsed.token === "string"
 			)
-				return parsed as DevCliAccess;
+				return parsed as LocalCliAccess;
 		} catch {
 			// Continue to the next repository ancestor.
 		}
@@ -225,7 +249,7 @@ const endpoint = async (
 	}
 	const access =
 		one(args, "ws-url") === undefined && env.ZUSE_WS_URL === undefined
-			? await devCliAccess(env)
+			? await localCliAccess(env)
 			: null;
 	const raw =
 		one(args, "ws-url") ??
@@ -1172,6 +1196,6 @@ export const __testing = {
 	execute,
 	commandManifest,
 	expandInputJson,
-	devCliAccess,
+	localCliAccess,
 	endpoint,
 };

--- a/packages/serve/test/agent-cli.test.ts
+++ b/packages/serve/test/agent-cli.test.ts
@@ -84,12 +84,40 @@ describe("agent CLI", () => {
 			}),
 		);
 		await expect(
-			__testing.devCliAccess({ ZUSE_DEV_CLI_ACCESS_FILE: accessFile }),
+			__testing.localCliAccess({ ZUSE_DEV_CLI_ACCESS_FILE: accessFile }),
 		).resolves.toEqual({
 			schemaVersion: 1,
 			wsUrl: "ws://127.0.0.1:8788/rpc",
 			token: "zt_development",
 		});
+	});
+
+	test("discovers the protected installed desktop RPC descriptor", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "zuse-cli-user-data-"));
+		const accessFile = join(directory, "cli-access.json");
+		await writeFile(
+			accessFile,
+			JSON.stringify({
+				schemaVersion: 1,
+				wsUrl: "ws://127.0.0.1:47837/rpc",
+				token: "zt_installed",
+			}),
+		);
+		await expect(
+			__testing.localCliAccess({ ZUSE_USER_DATA_DIR: directory }),
+		).resolves.toEqual({
+			schemaVersion: 1,
+			wsUrl: "ws://127.0.0.1:47837/rpc",
+			token: "zt_installed",
+		});
+		const endpoint = new URL(
+			await __testing.endpoint(__testing.parse(["chat", "list"]), {
+				ZUSE_USER_DATA_DIR: directory,
+			}),
+		);
+		expect(endpoint.origin).toBe("ws://127.0.0.1:47837");
+		expect(endpoint.pathname).toBe("/rpc");
+		expect(endpoint.searchParams.get("token")).toBe("zt_installed");
 	});
 
 	test("negotiates the current wire protocol with local dev RPC", async () => {

--- a/packages/zusehq/package.json
+++ b/packages/zusehq/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zusehq",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Run and manage Zuse remote workspaces",
 	"license": "AGPL-3.0-only",
 	"type": "module",
@@ -24,7 +24,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@zusehq/serve": "0.1.4"
+		"@zusehq/serve": "0.1.5"
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "*",


### PR DESCRIPTION
## Summary

- publish an owner-readable local CLI credential from the installed desktop without weakening the protected relay-capable listener
- discover the installed desktop credential automatically from the CLI
- release `@zusehq/serve@0.1.5` and `zusehq@0.1.3` with the production discovery path
- document installed and development credential discovery

## Root cause

The packaged desktop intentionally runs its relay-capable WebSocket listener in protected mode, including on loopback. The CLI knew the production port but only discovered credentials written by development instances, so local chat commands reached the correct listener without authorization.

## Validation

- Biome checks on changed TypeScript, JSON, and documentation
- `bun --filter @zusehq/serve test` (7/7)
- CLI, server, wrapper, and desktop typechecks
- CLI and wrapper builds
- frozen workspace install
- packed `@zusehq/serve@0.1.5` manifest and clean-install command-manifest smoke test
- `git diff --check`