### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0]
+
+### Added
+- Run coding agents in invite-only Zuse Cloud workspaces, with guided GitHub repository setup, encrypted credentials and transcripts, secure reconnects, pause/resume/archive controls, SSH access, and one-way local file sync
+- View Cloud usage and control overage spending under the `$40/month` plan, including `$35` of attributable E2B compute and additional provider cost plus 5%
+- Control installed desktop chats from the Zuse CLI through secure local credential discovery
+
+### Changed
+- Chats now use one durable, environment-scoped realtime state path, so agents continue after the client closes and cached transcripts appear immediately before bounded live catch-up
+- Sign-in, integration, and purchase callbacks now use polished, accessible status pages with accurate success and failure states
+
+### Fixed
+- Cloud workspaces now recover reliably across bootstrap failures, stale runtime registrations, paused chats, reconnects, and runtime upgrades
+- Cloud repository onboarding preserves successful connections when another repository fails, making retries targeted and idempotent
+- Published CLI packages now install cleanly and can authenticate to packaged desktop builds
+
 ## [0.19.0]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,33 @@
 [
   {
+    "version": "0.20.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Run coding agents in invite-only Zuse Cloud workspaces, with guided GitHub repository setup, encrypted credentials and transcripts, secure reconnects, pause/resume/archive controls, SSH access, and one-way local file sync",
+          "View Cloud usage and control overage spending under the `$40/month` plan, including `$35` of attributable E2B compute and additional provider cost plus 5%",
+          "Control installed desktop chats from the Zuse CLI through secure local credential discovery"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Chats now use one durable, environment-scoped realtime state path, so agents continue after the client closes and cached transcripts appear immediately before bounded live catch-up",
+          "Sign-in, integration, and purchase callbacks now use polished, accessible status pages with accurate success and failure states"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Cloud workspaces now recover reliably across bootstrap failures, stale runtime registrations, paused chats, reconnects, and runtime upgrades",
+          "Cloud repository onboarding preserves successful connections when another repository fails, making retries targeted and idempotent",
+          "Published CLI packages now install cleanly and can authenticate to packaged desktop builds"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.19.0",
     "sections": [
       {
@@ -12,7 +40,7 @@
       {
         "title": "Fixed",
         "items": [
-        "macOS now installs the newest downloaded update on quit instead of potentially staging an older cached release first"
+          "macOS now installs the newest downloaded update on quit instead of potentially staging an older cached release first"
         ]
       }
     ]

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.0 with release notes grouped by user-visible outcome.

### Added
- Run coding agents in invite-only Zuse Cloud workspaces, with guided GitHub repository setup, encrypted credentials and transcripts, secure reconnects, pause/resume/archive controls, SSH access, and one-way local file sync
- View Cloud usage and control overage spending under the `$40/month` plan, including `$35` of attributable E2B compute and additional provider cost plus 5%
- Control installed desktop chats from the Zuse CLI through secure local credential discovery

### Changed
- Chats now use one durable, environment-scoped realtime state path, so agents continue after the client closes and cached transcripts appear immediately before bounded live catch-up
- Sign-in, integration, and purchase callbacks now use polished, accessible status pages with accurate success and failure states

### Fixed
- Cloud workspaces now recover reliably across bootstrap failures, stale runtime registrations, paused chats, reconnects, and runtime upgrades
- Cloud repository onboarding preserves successful connections when another repository fails, making retries targeted and idempotent
- Published CLI packages now install cleanly and can authenticate to packaged desktop builds

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.20.0 after this PR lands.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0119fdc1-e41a-433b-a386-792a256c8983)
