### PR TITLE
Show private cloud beta in production desktop

### DIFF
--- a/apps/renderer/src/lib/cloud-machines-availability.ts
+++ b/apps/renderer/src/lib/cloud-machines-availability.ts
@@ -2,16 +2,12 @@ import { rendererPlatformCapabilities } from "./platform-capabilities.ts";
 
 export const cloudMachinesAvailable = ({
 	desktop,
-	development,
 }: {
 	readonly desktop: boolean;
-	readonly development: boolean;
-}): boolean => desktop && development;
+}): boolean => desktop;
 
-/** Cloud compute is an internal desktop beta. Every renderer entry point uses
- * this policy so production users cannot discover a partial cloud route. */
+/** Cloud compute is desktop-only. Relay owns private-beta authorization. */
 export const cloudWorkspaceBetaAvailable = (): boolean =>
 	cloudMachinesAvailable({
 		desktop: rendererPlatformCapabilities().desktop,
-		development: import.meta.env.DEV,
 	});

--- a/apps/renderer/test/unit/cloud-machines-availability.test.ts
+++ b/apps/renderer/test/unit/cloud-machines-availability.test.ts
@@ -2,21 +2,11 @@ import { describe, expect, it } from "vitest";
 import { cloudMachinesAvailable } from "../../src/lib/cloud-machines-availability.ts";
 
 describe("cloud machine availability", () => {
-	it("is hidden in production desktop builds", () => {
-		expect(cloudMachinesAvailable({ desktop: true, development: false })).toBe(
-			false,
-		);
-	});
-
-	it("remains available in desktop development builds", () => {
-		expect(cloudMachinesAvailable({ desktop: true, development: true })).toBe(
-			true,
-		);
+	it("is available in desktop builds", () => {
+		expect(cloudMachinesAvailable({ desktop: true })).toBe(true);
 	});
 
 	it("is unavailable outside the desktop app", () => {
-		expect(cloudMachinesAvailable({ desktop: false, development: true })).toBe(
-			false,
-		);
+		expect(cloudMachinesAvailable({ desktop: false })).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

- Expose Cloud Workspace entry points in production desktop builds.
- Keep non-desktop clients excluded.
- Leave invite authorization solely to Relay’s server-side PostHog gate.

## Verification

- `bunx biome check apps/renderer/src/lib/cloud-machines-availability.ts apps/renderer/test/unit/cloud-machines-availability.test.ts`
- `bun test apps/renderer/test/unit/cloud-machines-availability.test.ts`
- `bun --cwd apps/renderer check-types`

