### PR TITLE
Restore local workspaces after 0.20 upgrade

### DIFF
--- a/apps/renderer/src/components/project-setup-dialog.tsx
+++ b/apps/renderer/src/components/project-setup-dialog.tsx
@@ -87,6 +87,15 @@ export function ProjectSetupDialog({
 		() => entries.filter((entry) => entry.status === "connected"),
 		[entries],
 	);
+	const catalogInitializing = useEnvironmentCatalogStore(
+		(state) => state.initializing,
+	);
+	const catalogInitializationError = useEnvironmentCatalogStore(
+		(state) => state.initializationError,
+	);
+	const initializeCatalog = useEnvironmentCatalogStore(
+		(state) => state.initialize,
+	);
 	const [mode, setMode] = useState<ProjectSetupMode>(initialMode);
 	const [environmentId, setEnvironmentId] = useState(
 		initialEnvironmentId ?? getLocalEnvironmentId(),
@@ -118,6 +127,7 @@ export function ProjectSetupDialog({
 	useEffect(() => {
 		if (
 			!open ||
+			connected.length === 0 ||
 			(mode !== "create" && (mode !== "clone" || sourceUrl !== undefined))
 		)
 			return;
@@ -141,7 +151,18 @@ export function ProjectSetupDialog({
 		return () => {
 			cancelled = true;
 		};
-	}, [open, mode, environmentId, sourceUrl]);
+	}, [open, mode, environmentId, sourceUrl, connected.length]);
+
+	useEffect(() => {
+		if (!open) return;
+		if (connected.some((entry) => entry.environmentId === environmentId))
+			return;
+		const nextEnvironment = connected[0];
+		if (nextEnvironment === undefined) return;
+		setEnvironmentId(nextEnvironment.environmentId);
+		setParent("");
+		setParentReady(false);
+	}, [open, connected, environmentId]);
 
 	const selectedEnvironment = connected.find(
 		(entry) => entry.environmentId === environmentId,
@@ -151,6 +172,7 @@ export function ProjectSetupDialog({
 		mode === "clone" ? (sourceName ?? cloneName(url)) : name.trim();
 	const canSubmit =
 		!submitting &&
+		selectedEnvironment !== undefined &&
 		(mode === "clone"
 			? url.trim().length > 0 && parent.trim().length > 0 && parentReady
 			: mode === "create"
@@ -217,6 +239,7 @@ export function ProjectSetupDialog({
 							<span>Create on</span>
 							<Select
 								value={environmentId}
+								disabled={connected.length === 0}
 								onValueChange={(value) => {
 									if (value !== null) {
 										setEnvironmentId(value);
@@ -247,6 +270,32 @@ export function ProjectSetupDialog({
 								</SelectPopup>
 							</Select>
 						</div>
+						{connected.length === 0 ? (
+							<div
+								className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-[11px]"
+								role="alert"
+							>
+								<p className="font-medium text-foreground">
+									This computer is unavailable.
+								</p>
+								<p className="mt-1 text-muted-foreground">
+									{catalogInitializationError ??
+										"Wait for the local workspace to finish loading."}
+								</p>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									className="mt-2"
+									disabled={catalogInitializing}
+									onClick={() => {
+										void initializeCatalog().catch(() => undefined);
+									}}
+								>
+									{catalogInitializing ? "Retrying…" : "Retry connection"}
+								</Button>
+							</div>
+						) : null}
 
 						{mode === "choose" ? (
 							<div className="grid gap-2 sm:grid-cols-3">
@@ -255,6 +304,7 @@ export function ProjectSetupDialog({
 									label="Quick start"
 									description="Create from a template"
 									accent="violet"
+									disabled={connected.length === 0}
 									onClick={() => setMode("create")}
 								/>
 								<SetupChoice
@@ -262,6 +312,7 @@ export function ProjectSetupDialog({
 									label="Clone repository"
 									description="Clone with Git or GitHub"
 									accent="blue"
+									disabled={connected.length === 0}
 									onClick={() => setMode("clone")}
 								/>
 								<SetupChoice
@@ -269,6 +320,7 @@ export function ProjectSetupDialog({
 									label="Existing folder"
 									description="Open a project on disk"
 									accent="amber"
+									disabled={connected.length === 0}
 									onClick={() => setMode("existing")}
 								/>
 							</div>
@@ -411,7 +463,7 @@ export function ProjectSetupDialog({
 							</>
 						) : null}
 
-						{mode !== "choose" ? (
+						{mode !== "choose" && selectedEnvironment !== undefined ? (
 							<div className="flex flex-col gap-1.5 text-xs font-medium">
 								<span>
 									{mode === "existing" ? "Project folder" : "Parent folder"}
@@ -489,12 +541,14 @@ function SetupChoice({
 	label,
 	description,
 	accent,
+	disabled,
 	onClick,
 }: {
 	readonly art: "quick" | "github" | "folder";
 	readonly label: string;
 	readonly description: string;
 	readonly accent: "violet" | "blue" | "amber";
+	readonly disabled: boolean;
 	readonly onClick: () => void;
 }) {
 	const accentClass = {
@@ -507,8 +561,9 @@ function SetupChoice({
 	return (
 		<button
 			type="button"
+			disabled={disabled}
 			onClick={onClick}
-			className={`group flex min-h-40 flex-col overflow-hidden rounded-xl border border-border bg-muted/20 text-left outline-none transition-[border-color,background-color] duration-150 focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none ${accentClass}`}
+			className={`group flex min-h-40 flex-col overflow-hidden rounded-xl border border-border bg-muted/20 text-left outline-none transition-[border-color,background-color] duration-150 focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none ${accentClass}`}
 		>
 			<AsciiProjectArt variant={art} accent={accent} />
 			<span className="flex w-full flex-col gap-0.5 border-t border-border/70 px-3 py-2.5">

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -113,6 +113,7 @@ import {
 } from "../store/chats.ts";
 import {
 	type EnvironmentCatalogEntry,
+	environmentCatalogViewState,
 	useEnvironmentCatalogStore,
 } from "../store/environment-catalog.ts";
 import { useRegisterPane } from "../store/pane-focus.ts";
@@ -256,6 +257,11 @@ export function ProjectsSidebar() {
 	const initializeEnvironmentCatalog = useEnvironmentCatalogStore(
 		(s) => s.initialize,
 	);
+	const catalogInitialized = useEnvironmentCatalogStore((s) => s.initialized);
+	const catalogInitializing = useEnvironmentCatalogStore((s) => s.initializing);
+	const catalogInitializationError = useEnvironmentCatalogStore(
+		(s) => s.initializationError,
+	);
 
 	const {
 		chatsByProject,
@@ -336,6 +342,13 @@ export function ProjectsSidebar() {
 			shellViews,
 		],
 	);
+	const catalogViewState = environmentCatalogViewState({
+		initialized: catalogInitialized,
+		initializing: catalogInitializing,
+		initializationError: catalogInitializationError,
+		projectCount: logicalGroups.length,
+		projectsLoading: loading,
+	});
 
 	return (
 		<aside
@@ -374,7 +387,31 @@ export function ProjectsSidebar() {
 			<ul className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
 				{desktopCatalogEnabled ? (
 					<>
-						{logicalGroups.length === 0 && !loading ? (
+						{catalogViewState === "loading" ? (
+							<li
+								className="flex items-center justify-center gap-2 px-3 py-4 text-[13px] text-muted-foreground"
+								aria-busy="true"
+							>
+								<Spinner className="size-3.5" />
+								Loading projects…
+							</li>
+						) : null}
+						{catalogViewState === "unavailable" ? (
+							<li className="px-3 py-4 text-center text-[13px] text-muted-foreground">
+								<p role="alert">This computer couldn’t load its projects.</p>
+								<p className="mt-1 text-[12px]">{catalogInitializationError}</p>
+								<button
+									type="button"
+									className="mt-2 rounded-md border border-sidebar-border px-2.5 py-1 text-[12px] text-sidebar-foreground hover:bg-sidebar-accent"
+									onClick={() => {
+										void initializeEnvironmentCatalog().catch(() => undefined);
+									}}
+								>
+									Retry
+								</button>
+							</li>
+						) : null}
+						{catalogViewState === "empty" ? (
 							<li className="px-3 py-4 text-center text-[13px] text-muted-foreground">
 								No projects yet. Click + to add one.
 							</li>

--- a/apps/renderer/src/store/environment-catalog.ts
+++ b/apps/renderer/src/store/environment-catalog.ts
@@ -349,6 +349,8 @@ type EnvironmentCatalogState = {
 	readonly entries: ReadonlyArray<EnvironmentCatalogEntry>;
 	readonly activeEnvironmentId: string;
 	readonly initialized: boolean;
+	readonly initializing: boolean;
+	readonly initializationError: string | null;
 	readonly hiddenRelayEnvironmentIds: ReadonlyArray<string>;
 	initialize: () => Promise<void>;
 	syncAccountEnvironments: () => Promise<void>;
@@ -466,6 +468,52 @@ export const cloudConnectionFailure = (cause: unknown): Error => {
 	if (/timeout|timed out|network|socket|connect|unreachable/u.test(normalized))
 		return new Error(`Endpoint reachability failed: ${detail}`);
 	return new Error(`Secure connection failed: ${detail}`);
+};
+
+export const loadOptionalEnvironmentSources = async (input: {
+	readonly sshProfiles: Promise<ReadonlyArray<RemoteEnvironmentProfile>>;
+	readonly tailnetProfiles: Promise<ReadonlyArray<TailnetEnvironmentProfile>>;
+	readonly relayEnvironments: Promise<
+		Readonly<{ environments: ReadonlyArray<RelayEnvironmentRecord> }>
+	>;
+}): Promise<{
+	readonly profiles: ReadonlyArray<RemoteEnvironmentProfile>;
+	readonly tailnetProfiles: ReadonlyArray<TailnetEnvironmentProfile>;
+	readonly relayEnvironments: ReadonlyArray<RelayEnvironmentRecord>;
+}> => {
+	const [sshResult, tailnetResult, relayResult] = await Promise.allSettled([
+		input.sshProfiles,
+		input.tailnetProfiles,
+		input.relayEnvironments,
+	]);
+	return {
+		profiles: sshResult.status === "fulfilled" ? sshResult.value : [],
+		tailnetProfiles:
+			tailnetResult.status === "fulfilled" ? tailnetResult.value : [],
+		relayEnvironments:
+			relayResult.status === "fulfilled" ? relayResult.value.environments : [],
+	};
+};
+
+export type EnvironmentCatalogViewState =
+	| "loading"
+	| "unavailable"
+	| "empty"
+	| "ready";
+
+export const environmentCatalogViewState = (input: {
+	readonly initialized: boolean;
+	readonly initializing: boolean;
+	readonly initializationError: string | null;
+	readonly projectCount: number;
+	readonly projectsLoading: boolean;
+}): EnvironmentCatalogViewState => {
+	if (!input.initialized) {
+		return !input.initializing && input.initializationError !== null
+			? "unavailable"
+			: "loading";
+	}
+	return input.projectCount === 0 && !input.projectsLoading ? "empty" : "ready";
 };
 
 export const createConnectionAttemptCoordinator = () => {
@@ -838,82 +886,107 @@ export const useEnvironmentCatalogStore = create<EnvironmentCatalogState>(
 			entries: [],
 			activeEnvironmentId: LOCAL_ENVIRONMENT_KEY,
 			initialized: false,
+			initializing: false,
+			initializationError: null,
 			hiddenRelayEnvironmentIds: [],
 			initialize: () => {
 				return initializeOnce(get().initialized, async () => {
-					const localClient = await runtimeOperationClient(
-						LOCAL_ENVIRONMENT_KEY,
-					);
-					const [descriptor, profiles, tailnetProfiles] = await Promise.all([
-						Effect.runPromise(localClient["connect.describe"]()),
-						window.zuse?.ssh?.listProfiles() ?? Promise.resolve([]),
-						window.zuse?.tailnet?.listProfiles() ?? Promise.resolve([]),
-					]);
-					registerLocalEnvironment(descriptor.environmentId);
-					setActiveEnvironment(descriptor.environmentId);
-					const relayEnvironments = await Effect.runPromise(
-						localClient["environments.list"](),
-					).catch(() => ({ environments: [] as const }));
-					const profileEnvironmentIds = new Set(
-						[...profiles, ...tailnetProfiles].map(
-							(profile) => profile.environmentId,
-						),
-					);
-					const hiddenRelayEnvironmentIds = readHiddenRelayEnvironmentIds();
-					const hiddenRelayIds = new Set(hiddenRelayEnvironmentIds);
-					const accountRelayEnvironments =
-						relayEnvironments.environments.filter(
-							(environment) =>
-								environment.environmentId !== descriptor.environmentId &&
-								!profileEnvironmentIds.has(environment.environmentId),
+					set({ initializing: true, initializationError: null });
+					try {
+						const localClient = await runtimeOperationClient(
+							LOCAL_ENVIRONMENT_KEY,
 						);
-					// Record every account relay environment — including hidden ones —
-					// so retry and unhide can reconnect without re-fetching the list.
-					for (const environment of accountRelayEnvironments) {
-						relayRecords.set(environment.environmentId, environment);
-					}
-					const visibleRelayEnvironments = accountRelayEnvironments.filter(
-						(environment) => !hiddenRelayIds.has(environment.environmentId),
-					);
-					set({
-						activeEnvironmentId: descriptor.environmentId,
-						hiddenRelayEnvironmentIds,
-						entries: orderEnvironmentCatalog([
-							{
-								connectionKind: "local",
-								environmentId: descriptor.environmentId,
-								profileId: null,
-								label: descriptor.label ?? "This computer",
-								target: null,
-								descriptor,
-								status: "offline",
-								error: null,
-							},
-							...visibleRelayEnvironments.map(relayEntry),
-							...profiles.map(profileEntry),
-							...tailnetProfiles.map(tailnetProfileEntry),
-						]),
-					});
-					for (const entry of get().entries) {
-						retainShell(entryKey(entry), entry.environmentId, "cache-only");
-					}
-					const localEntry = get().entries.find(
-						(entry) => entry.connectionKind === "local",
-					);
-					if (localEntry !== undefined) {
-						const runtime = retainShell(
+						const descriptor = await Effect.runPromise(
+							localClient["connect.describe"](),
+						);
+						registerLocalEnvironment(descriptor.environmentId);
+						setActiveEnvironment(descriptor.environmentId);
+
+						const hiddenRelayEnvironmentIds = readHiddenRelayEnvironmentIds();
+						const localEntry: EnvironmentCatalogEntry = {
+							connectionKind: "local",
+							environmentId: descriptor.environmentId,
+							profileId: null,
+							label: descriptor.label ?? "This computer",
+							target: null,
+							descriptor,
+							status: "offline",
+							error: null,
+						};
+						set({
+							activeEnvironmentId: descriptor.environmentId,
+							hiddenRelayEnvironmentIds,
+							entries: [localEntry],
+						});
+
+						const localRuntime = retainShell(
 							entryKey(localEntry),
 							localEntry.environmentId,
 							"connect",
 						);
 						await activateRuntime(
 							entryKey(localEntry),
-							runtime,
+							localRuntime,
 							localEntry.environmentId,
 							undefined,
 						);
+						set({ initialized: true, initializationError: null });
+
+						// Remote catalogs are optional. A corrupt saved profile or an
+						// unavailable account service must never hide the local workspace.
+						const { profiles, tailnetProfiles, relayEnvironments } =
+							await loadOptionalEnvironmentSources({
+								sshProfiles:
+									window.zuse?.ssh?.listProfiles() ?? Promise.resolve([]),
+								tailnetProfiles:
+									window.zuse?.tailnet?.listProfiles() ?? Promise.resolve([]),
+								relayEnvironments: Effect.runPromise(
+									localClient["environments.list"](),
+								),
+							});
+						const profileEnvironmentIds = new Set(
+							[...profiles, ...tailnetProfiles].map(
+								(profile) => profile.environmentId,
+							),
+						);
+						const hiddenRelayIds = new Set(hiddenRelayEnvironmentIds);
+						const accountRelayEnvironments = relayEnvironments.filter(
+							(environment) =>
+								environment.environmentId !== descriptor.environmentId &&
+								!profileEnvironmentIds.has(environment.environmentId),
+						);
+						for (const environment of accountRelayEnvironments) {
+							relayRecords.set(environment.environmentId, environment);
+						}
+						const optionalEntries = [
+							...accountRelayEnvironments
+								.filter(
+									(environment) =>
+										!hiddenRelayIds.has(environment.environmentId),
+								)
+								.map(relayEntry),
+							...profiles.map(profileEntry),
+							...tailnetProfiles.map(tailnetProfileEntry),
+						];
+						set((state) => ({
+							entries: orderEnvironmentCatalog([
+								...state.entries.filter(
+									(entry) => entry.connectionKind === "local",
+								),
+								...optionalEntries,
+							]),
+						}));
+						for (const entry of optionalEntries) {
+							retainShell(entryKey(entry), entry.environmentId, "cache-only");
+						}
+					} catch (cause) {
+						const message = errorMessage(cause);
+						set({ initialized: false, initializationError: message });
+						useWorkspaceStore.setState({ loading: false, error: message });
+						throw cause;
+					} finally {
+						set({ initializing: false });
 					}
-					set({ initialized: true });
 				});
 			},
 			syncAccountEnvironments: async () => {

--- a/apps/renderer/test/unit/environment-catalog.test.ts
+++ b/apps/renderer/test/unit/environment-catalog.test.ts
@@ -45,6 +45,8 @@ import {
 	cloudConnectionFailure,
 	createConnectionAttemptCoordinator,
 	type EnvironmentCatalogEntry,
+	environmentCatalogViewState,
+	loadOptionalEnvironmentSources,
 	orderEnvironmentCatalog,
 	projectEnvironmentShell,
 	validateSshTarget,
@@ -288,6 +290,50 @@ describe("environment catalog", () => {
 				entry("Remote", "remote", "connected"),
 			]).map(({ label }) => label),
 		).toEqual(["Local", "Relay", "Remote", "Offline"]);
+	});
+
+	it("isolates optional computer discovery failures", async () => {
+		const sources = await loadOptionalEnvironmentSources({
+			sshProfiles: Promise.reject(new Error("corrupt SSH profiles")),
+			tailnetProfiles: Promise.resolve([]),
+			relayEnvironments: Promise.reject(new Error("account unavailable")),
+		});
+
+		expect(sources).toEqual({
+			profiles: [],
+			tailnetProfiles: [],
+			relayEnvironments: [],
+		});
+	});
+
+	it("never presents initialization failures as an empty project catalog", () => {
+		expect(
+			environmentCatalogViewState({
+				initialized: false,
+				initializing: false,
+				initializationError: "Local connection failed",
+				projectCount: 0,
+				projectsLoading: false,
+			}),
+		).toBe("unavailable");
+		expect(
+			environmentCatalogViewState({
+				initialized: false,
+				initializing: true,
+				initializationError: null,
+				projectCount: 0,
+				projectsLoading: false,
+			}),
+		).toBe("loading");
+		expect(
+			environmentCatalogViewState({
+				initialized: true,
+				initializing: false,
+				initializationError: null,
+				projectCount: 0,
+				projectsLoading: false,
+			}),
+		).toBe("empty");
 	});
 
 	it("replaces an in-flight connection attempt that never became ready", async () => {

--- a/apps/server/src/lan-auth/advertised-endpoints.ts
+++ b/apps/server/src/lan-auth/advertised-endpoints.ts
@@ -1,131 +1,150 @@
 import {
-  AdvertisedEndpoint,
-  type AdvertisedEndpointHostedHttpsCompatibility,
-  type AdvertisedEndpointReachability,
-  type AdvertisedEndpointStatus,
+	AdvertisedEndpoint,
+	type AdvertisedEndpointHostedHttpsCompatibility,
+	type AdvertisedEndpointReachability,
+	type AdvertisedEndpointStatus,
+	EnvironmentEndpoint,
 } from "@zuse/contracts";
 
 import type { LanAuthConfigShape } from "./services/lan-auth-service.ts";
 
 export interface RelayEndpointConfig {
-  readonly tunnelHostname?: string;
-  readonly linked: boolean;
-  readonly heartbeatActive: boolean;
+	readonly tunnelHostname?: string;
+	readonly linked: boolean;
+	readonly heartbeatActive: boolean;
 }
 
 const isLoopbackHost = (host: string): boolean =>
-  host === "127.0.0.1" || host === "::1" || host === "localhost";
+	host === "127.0.0.1" || host === "::1" || host === "localhost";
 
 const isHttpsEndpoint = (httpBaseUrl: string, wsBaseUrl: string): boolean =>
-  httpBaseUrl.startsWith("https://") && wsBaseUrl.startsWith("wss://");
+	httpBaseUrl.startsWith("https://") && wsBaseUrl.startsWith("wss://");
 
 const compatibilityFor = (
-  httpBaseUrl: string,
-  wsBaseUrl: string,
+	httpBaseUrl: string,
+	wsBaseUrl: string,
 ): AdvertisedEndpointHostedHttpsCompatibility =>
-  isHttpsEndpoint(httpBaseUrl, wsBaseUrl)
-    ? "compatible"
-    : "mixed-content-blocked";
+	isHttpsEndpoint(httpBaseUrl, wsBaseUrl)
+		? "compatible"
+		: "mixed-content-blocked";
 
 const defaultRank = (endpoint: AdvertisedEndpoint): number => {
-  if (isHttpsEndpoint(endpoint.httpBaseUrl, endpoint.wsBaseUrl)) return 0;
-  if (endpoint.reachability === "lan") return 1;
-  if (endpoint.reachability === "loopback") return 2;
-  return 3;
+	if (isHttpsEndpoint(endpoint.httpBaseUrl, endpoint.wsBaseUrl)) return 0;
+	if (endpoint.reachability === "lan") return 1;
+	if (endpoint.reachability === "loopback") return 2;
+	return 3;
 };
 
 const withDefault = (
-  endpoints: ReadonlyArray<AdvertisedEndpoint>,
+	endpoints: ReadonlyArray<AdvertisedEndpoint>,
 ): ReadonlyArray<AdvertisedEndpoint> => {
-  if (endpoints.length === 0) return endpoints;
-  const defaultId = [...endpoints].sort(
-    (a, b) => defaultRank(a) - defaultRank(b),
-  )[0]!.id;
-  return endpoints.map((endpoint) =>
-    AdvertisedEndpoint.make({
-      ...endpoint,
-      isDefault: endpoint.id === defaultId,
-    }),
-  );
+	const defaultEndpoint = [...endpoints].sort(
+		(a, b) => defaultRank(a) - defaultRank(b),
+	)[0];
+	if (defaultEndpoint === undefined) return endpoints;
+	const defaultId = defaultEndpoint.id;
+	return endpoints.map((endpoint) =>
+		AdvertisedEndpoint.make({
+			...endpoint,
+			isDefault: endpoint.id === defaultId,
+		}),
+	);
 };
 
 const coreEndpoint = (input: {
-  readonly id: string;
-  readonly label: string;
-  readonly host: string;
-  readonly port: number;
-  readonly reachability: AdvertisedEndpointReachability;
+	readonly id: string;
+	readonly label: string;
+	readonly host: string;
+	readonly port: number;
+	readonly reachability: AdvertisedEndpointReachability;
 }): AdvertisedEndpoint =>
-  AdvertisedEndpoint.make({
-    id: input.id,
-    label: input.label,
-    providerKind: "core",
-    httpBaseUrl: `http://${input.host}:${input.port}`,
-    wsBaseUrl: `ws://${input.host}:${input.port}`,
-    reachability: input.reachability,
-    compatibility: { hostedHttpsApp: "mixed-content-blocked" },
-    status: "available",
-    isDefault: false,
-  });
+	AdvertisedEndpoint.make({
+		id: input.id,
+		label: input.label,
+		providerKind: "core",
+		httpBaseUrl: `http://${input.host}:${input.port}`,
+		wsBaseUrl: `ws://${input.host}:${input.port}`,
+		reachability: input.reachability,
+		compatibility: { hostedHttpsApp: "mixed-content-blocked" },
+		status: "available",
+		isDefault: false,
+	});
 
 export const buildAdvertisedEndpoints = (input: {
-  readonly lan: LanAuthConfigShape;
-  readonly relay?: RelayEndpointConfig | null;
+	readonly lan: LanAuthConfigShape;
+	readonly relay?: RelayEndpointConfig | null;
 }): ReadonlyArray<AdvertisedEndpoint> => {
-  const endpoints: AdvertisedEndpoint[] = [];
-  const port = input.lan.port;
+	const endpoints: AdvertisedEndpoint[] = [];
+	const port = input.lan.port;
 
-  if (port !== null) {
-    const advertisedHost = input.lan.advertisedHost;
-    if (advertisedHost !== null && !isLoopbackHost(advertisedHost)) {
-      endpoints.push(
-        coreEndpoint({
-          id: "core:lan",
-          label: "LAN",
-          host: advertisedHost,
-          port,
-          reachability: "lan",
-        }),
-      );
-    }
+	if (port !== null) {
+		const advertisedHost = input.lan.advertisedHost;
+		if (advertisedHost !== null && !isLoopbackHost(advertisedHost)) {
+			endpoints.push(
+				coreEndpoint({
+					id: "core:lan",
+					label: "LAN",
+					host: advertisedHost,
+					port,
+					reachability: "lan",
+				}),
+			);
+		}
 
-    endpoints.push(
-      coreEndpoint({
-        id: "core:loopback",
-        label: "This Mac",
-        host: "127.0.0.1",
-        port,
-        reachability: "loopback",
-      }),
-    );
-  }
+		endpoints.push(
+			coreEndpoint({
+				id: "core:loopback",
+				label: "This Mac",
+				host: "127.0.0.1",
+				port,
+				reachability: "loopback",
+			}),
+		);
+	}
 
-  const tunnelHostname = input.relay?.tunnelHostname?.trim();
-  if (tunnelHostname) {
-    const httpBaseUrl = `https://${tunnelHostname}`;
-    const wsBaseUrl = `wss://${tunnelHostname}`;
-    const status: AdvertisedEndpointStatus =
-      input.relay?.linked === true
-        ? input.relay.heartbeatActive
-          ? "available"
-          : "unknown"
-        : "unavailable";
-    endpoints.push(
-      AdvertisedEndpoint.make({
-        id: "tunnel:managed-relay",
-        label: "Managed tunnel",
-        providerKind: "tunnel",
-        httpBaseUrl,
-        wsBaseUrl,
-        reachability: "tunnel",
-        compatibility: {
-          hostedHttpsApp: compatibilityFor(httpBaseUrl, wsBaseUrl),
-        },
-        status,
-        isDefault: false,
-      }),
-    );
-  }
+	const tunnelHostname = input.relay?.tunnelHostname?.trim();
+	if (tunnelHostname) {
+		const httpBaseUrl = `https://${tunnelHostname}`;
+		const wsBaseUrl = `wss://${tunnelHostname}`;
+		const status: AdvertisedEndpointStatus =
+			input.relay?.linked === true
+				? input.relay.heartbeatActive
+					? "available"
+					: "unknown"
+				: "unavailable";
+		endpoints.push(
+			AdvertisedEndpoint.make({
+				id: "tunnel:managed-relay",
+				label: "Managed tunnel",
+				providerKind: "tunnel",
+				httpBaseUrl,
+				wsBaseUrl,
+				reachability: "tunnel",
+				compatibility: {
+					hostedHttpsApp: compatibilityFor(httpBaseUrl, wsBaseUrl),
+				},
+				status,
+				isDefault: false,
+			}),
+		);
+	}
 
-  return withDefault(endpoints);
+	return withDefault(endpoints);
+};
+
+/**
+ * Resolve the descriptor endpoint from the same ranked endpoint set exposed to
+ * clients. Keeping this selection here prevents local-only desktop runtimes
+ * from being rejected even though their loopback server is available.
+ */
+export const resolveDefaultEnvironmentEndpoint = (
+	endpoints: ReadonlyArray<AdvertisedEndpoint>,
+): EnvironmentEndpoint | null => {
+	const endpoint = endpoints.find((candidate) => candidate.isDefault);
+	return endpoint === undefined
+		? null
+		: EnvironmentEndpoint.make({
+				httpBaseUrl: endpoint.httpBaseUrl,
+				wsBaseUrl: endpoint.wsBaseUrl,
+			});
 };

--- a/apps/server/src/lan-auth/handlers.ts
+++ b/apps/server/src/lan-auth/handlers.ts
@@ -1,7 +1,6 @@
 import {
 	ConnectAuthError,
 	EnvironmentDescriptor,
-	EnvironmentEndpoint,
 	MemoizeRpcs,
 	NearbyPairingRequest,
 	PairingError,
@@ -12,7 +11,10 @@ import {
 } from "@zuse/contracts";
 import { Effect, Layer } from "effect";
 
-import { buildAdvertisedEndpoints } from "./advertised-endpoints.ts";
+import {
+	buildAdvertisedEndpoints,
+	resolveDefaultEnvironmentEndpoint,
+} from "./advertised-endpoints.ts";
 import { defaultEnvironmentLabel } from "./environment-label.ts";
 import { LanAuthConfig, LanAuthService } from "./services/lan-auth-service.ts";
 
@@ -95,18 +97,19 @@ const ConnectDescribe = MemoizeRpcs.toLayerHandler("connect.describe", () =>
 		const auth = yield* LanAuthService;
 		const config = yield* LanAuthConfig;
 		const relayConfig = yield* auth.getRelayConfig();
-		const endpoint =
-			relayConfig?.tunnelHostname !== undefined
-				? EnvironmentEndpoint.make({
-						httpBaseUrl: `https://${relayConfig.tunnelHostname}`,
-						wsBaseUrl: `wss://${relayConfig.tunnelHostname}`,
-					})
-				: config.advertisedHost !== null && config.port !== null
-					? EnvironmentEndpoint.make({
-							httpBaseUrl: `http://${config.advertisedHost}:${config.port}`,
-							wsBaseUrl: `ws://${config.advertisedHost}:${config.port}`,
-						})
-					: null;
+		const relay =
+			relayConfig === null
+				? null
+				: {
+						linked: true,
+						heartbeatActive: true,
+						tunnelHostname: relayConfig.tunnelHostname,
+					};
+		const advertisedEndpoints = buildAdvertisedEndpoints({
+			lan: config,
+			relay,
+		});
+		const endpoint = resolveDefaultEnvironmentEndpoint(advertisedEndpoints);
 
 		if (endpoint === null) {
 			return yield* Effect.fail(
@@ -119,17 +122,7 @@ const ConnectDescribe = MemoizeRpcs.toLayerHandler("connect.describe", () =>
 			providerKind: "desktop",
 			endpoint,
 			label: yield* defaultEnvironmentLabel(),
-			advertisedEndpoints: buildAdvertisedEndpoints({
-				lan: config,
-				relay:
-					relayConfig === null
-						? null
-						: {
-								linked: true,
-								heartbeatActive: true,
-								tunnelHostname: relayConfig.tunnelHostname,
-							},
-			}),
+			advertisedEndpoints,
 		});
 	}).pipe(
 		Effect.mapError((error) =>

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -64,7 +64,7 @@ import { Migration0049ChatCreationStartupReady } from "./migrations/0049_chat_cr
  * Add new migrations by appending entries. Never edit a shipped migration —
  * supersede it with a new id.
  */
-const MigrationDefinitions = {
+const MigrationDefinitionsThrough0045 = {
 	"0001_initial": Migration0001Initial,
 	"0002_permissions": Migration0002Permissions,
 	"0003_resume_and_export": Migration0003ResumeAndExport,
@@ -112,11 +112,22 @@ const MigrationDefinitions = {
 	"0043_name_provenance": Migration0043NameProvenance,
 	"0044_chat_creation_operations": Migration0044ChatCreationOperations,
 	"0045_chat_catalog_revision": Migration0045ChatCatalogRevision,
+} as const;
+
+const MigrationDefinitions = {
+	...MigrationDefinitionsThrough0045,
 	"0046_session_timeline_head": Migration0046SessionTimelineHead,
 	"0047_message_checkpoints": Migration0047MessageCheckpoints,
 	"0048_fs_write_receipts": Migration0048FsWriteReceipts,
 	"0049_chat_creation_startup_ready": Migration0049ChatCreationStartupReady,
 } as const;
+
+/** Shipped 0.16 schema boundary, exported for upgrade compatibility tests. */
+export const MigrationsThrough0045Live = Layer.effectDiscard(
+	Migrator.make({})({
+		loader: Migrator.fromRecord(MigrationDefinitionsThrough0045),
+	}),
+);
 
 export const MigrationsLive = Layer.effectDiscard(
 	Migrator.make({})({

--- a/apps/server/test/integration/lan-auth-service.test.ts
+++ b/apps/server/test/integration/lan-auth-service.test.ts
@@ -5,7 +5,10 @@ import { TestClock } from "effect/testing";
 import { SqlClient } from "effect/unstable/sql";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { describe, expect, it } from "vitest";
-import { buildAdvertisedEndpoints } from "../../src/lan-auth/advertised-endpoints.ts";
+import {
+	buildAdvertisedEndpoints,
+	resolveDefaultEnvironmentEndpoint,
+} from "../../src/lan-auth/advertised-endpoints.ts";
 import { LanAuthServiceLive } from "../../src/lan-auth/layers/lan-auth-service.ts";
 import { resolveAuthPolicy } from "../../src/lan-auth/policy.ts";
 import {
@@ -121,7 +124,7 @@ describe("LanAuthService", () => {
 				}),
 			);
 			expect(rows).toHaveLength(1);
-			expect(rows[0]!.token_hash).not.toBe(minted.token);
+			expect(rows[0]?.token_hash).not.toBe(minted.token);
 			expect(JSON.stringify(rows)).not.toContain(minted.token);
 		});
 	});
@@ -153,7 +156,7 @@ describe("LanAuthService", () => {
 			).toBe(false);
 			expect(JSON.stringify(summaries)).not.toContain("token_hash");
 			expect(JSON.stringify(summaries)).not.toContain(minted.token);
-			expect(summaries[0]!.revokedAt).toBeInstanceOf(Date);
+			expect(summaries[0]?.revokedAt).toBeInstanceOf(Date);
 		});
 	});
 
@@ -671,6 +674,39 @@ describe("LanAuthService", () => {
 		expect(endpoints.find((endpoint) => endpoint.isDefault)?.id).toBe(
 			"core:lan",
 		);
+	});
+
+	it("describes a local-only runtime through its loopback endpoint", () => {
+		const endpoint = resolveDefaultEnvironmentEndpoint(
+			buildAdvertisedEndpoints({
+				lan: {
+					policy: "protected",
+					advertisedHost: null,
+					port: 8787,
+					pairingBootstrap: false,
+				},
+			}),
+		);
+
+		expect(endpoint).toMatchObject({
+			httpBaseUrl: "http://127.0.0.1:8787",
+			wsBaseUrl: "ws://127.0.0.1:8787",
+		});
+	});
+
+	it("keeps truly unconfigured runtimes undescribable", () => {
+		expect(
+			resolveDefaultEnvironmentEndpoint(
+				buildAdvertisedEndpoints({
+					lan: {
+						policy: "protected",
+						advertisedHost: null,
+						port: null,
+						pairingBootstrap: false,
+					},
+				}),
+			),
+		).toBeNull();
 	});
 });
 

--- a/apps/server/test/integration/migration-0045-upgrade.test.ts
+++ b/apps/server/test/integration/migration-0045-upgrade.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { layer as sqliteLayer } from "@zuse/sqlite";
+import { Effect, Layer, ManagedRuntime } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+import { describe, expect, it } from "vitest";
+import {
+	MigrationsLive,
+	MigrationsThrough0045Live,
+} from "../../src/persistence/migrations.ts";
+
+const migratedRuntime = (
+	filename: string,
+	migrations: typeof MigrationsLive,
+) => {
+	const sqlite = sqliteLayer({ filename, disableWAL: true });
+	return ManagedRuntime.make(
+		Layer.merge(sqlite, migrations.pipe(Layer.provide(sqlite))),
+	);
+};
+
+describe("migration 0045 upgrade compatibility", () => {
+	it("preserves projects, chats, and sessions and accepts a new chat", async () => {
+		let stage = "initialize migration-0045 database";
+		const directory = mkdtempSync(join(tmpdir(), "zuse-migration-0045-"));
+		const filename = join(directory, "zuse.sqlite");
+		const legacyRuntime = migratedRuntime(filename, MigrationsThrough0045Live);
+
+		try {
+			stage = "insert migration-0045 rows";
+			await legacyRuntime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const createdAt = "2026-01-01T00:00:00.000Z";
+					stage = "insert the legacy project";
+					yield* sql`
+						INSERT INTO projects (id, path, name, created_at, updated_at)
+						VALUES ('project-legacy', '/tmp/project-legacy', 'Legacy project',
+							${createdAt}, ${createdAt})
+					`;
+					stage = "insert the legacy chat";
+					yield* sql`
+						INSERT INTO chats
+							(id, project_id, worktree_id, title, active_session_id,
+							 origin_session_id, archived_at, archived_worktree_json,
+							 last_message_at, last_read_at, created_at, updated_at)
+						VALUES ('chat-legacy', 'project-legacy', NULL, 'Legacy chat',
+							NULL, NULL, NULL, NULL, ${createdAt}, ${createdAt},
+							${createdAt}, ${createdAt})
+					`;
+					stage = "insert the legacy session";
+					yield* sql`
+						INSERT INTO sessions
+							(id, project_id, title, provider_id, model, status, chat_id,
+							 created_at, updated_at)
+						VALUES ('session-legacy', 'project-legacy', 'Legacy chat', 'codex',
+							'gpt-5', 'idle', 'chat-legacy', ${createdAt}, ${createdAt})
+					`;
+					stage = "link the legacy chat session";
+					yield* sql`
+						UPDATE chats SET active_session_id = 'session-legacy'
+						WHERE id = 'chat-legacy'
+					`;
+				}),
+			);
+			await legacyRuntime.dispose();
+
+			stage = "run current migrations";
+			const currentRuntime = migratedRuntime(filename, MigrationsLive);
+			try {
+				stage = "verify upgraded rows";
+				const result = await currentRuntime.runPromise(
+					Effect.gen(function* () {
+						const sql = yield* SqlClient.SqlClient;
+						const integrity = yield* sql<{ readonly quick_check: string }>`
+							PRAGMA quick_check
+						`;
+						const counts = yield* sql<{
+							readonly projects: number;
+							readonly chats: number;
+							readonly sessions: number;
+						}>`
+							SELECT
+								(SELECT COUNT(*) FROM projects) AS projects,
+								(SELECT COUNT(*) FROM chats) AS chats,
+								(SELECT COUNT(*) FROM sessions) AS sessions
+						`;
+						const createdAt = "2026-01-02T00:00:00.000Z";
+						yield* sql`
+							INSERT INTO chats
+								(id, project_id, worktree_id, title, active_session_id,
+								 origin_session_id, archived_at, archived_worktree_json,
+								 last_message_at, last_read_at, created_at, updated_at)
+							VALUES ('chat-new', 'project-legacy', NULL, 'New chat', NULL,
+								NULL, NULL, NULL, NULL, ${createdAt}, ${createdAt}, ${createdAt})
+						`;
+						const newChats = yield* sql<{ readonly count: number }>`
+							SELECT COUNT(*) AS count FROM chats WHERE id = 'chat-new'
+						`;
+						return { integrity, counts, newChats };
+					}),
+				);
+
+				expect(result.integrity).toEqual([{ quick_check: "ok" }]);
+				expect(result.counts).toEqual([{ projects: 1, chats: 1, sessions: 1 }]);
+				expect(result.newChats).toEqual([{ count: 1 }]);
+			} finally {
+				await currentRuntime.dispose();
+			}
+		} catch (cause) {
+			throw new Error(`Upgrade test failed while attempting to ${stage}.`, {
+				cause,
+			});
+		} finally {
+			await legacyRuntime.dispose();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- resolve `connect.describe` from the shared advertised endpoint list so local-only desktop runtimes use the loopback endpoint
- initialize the local environment and hydrate its workspaces before optional SSH, Tailnet, and account discovery
- distinguish catalog loading, unavailable, and empty states with retry/error UI
- disable Add Project actions when no computer is connected, preventing duplicate `workspace.add` requests
- add migration-45 upgrade coverage proving projects, chats, and sessions survive and new chats can be created

No RPC schemas or persisted user data are changed.

## Diagnostics

The affected 0.20.0 installation reported `ConnectAuthError` from `connect.describe`. Subsequent attempts to add the same folders returned `WorkspaceDuplicatePathError`, confirming the project rows remained in SQLite and the failure was catalog initialization rather than data deletion.

## Validation

- server integration: 25 files / 213 tests passed
- renderer unit: 102 files / 471 tests passed
- repository type checks: 31 packages passed
- changed-file Biome check passed
- desktop production build and startup smoke passed
- migration-45 upgrade test passes `PRAGMA quick_check`, preserves project/chat/session row counts, and inserts a new chat

## Existing unrelated failures

- repository-wide `bun run lint` reports existing formatting/lint failures outside the changed files
- desktop suite has one date-sensitive `performance-history-store` retention failure; 121 other desktop tests pass

Supersedes #486 after renaming the head branch.

