### PR TITLE
fix(cloud): use active production relay domain

### DIFF
--- a/apps/mobile/CLOUD_AUTH.md
+++ b/apps/mobile/CLOUD_AUTH.md
@@ -10,7 +10,7 @@ Set these (e.g. in `.env` for local dev, or EAS secrets):
 
 ```
 EXPO_PUBLIC_WORKOS_CLIENT_ID=<the same WorkOS client the desktop uses>
-EXPO_PUBLIC_ZUSE_RELAY_URL=https://relay.zuse.sh
+EXPO_PUBLIC_ZUSE_RELAY_URL=https://relay.stuff.md
 ```
 
 The redirect URI is `zuse://auth` (from `app.json` `scheme`); register it in the

--- a/apps/mobile/test/unit/auth-config.test.ts
+++ b/apps/mobile/test/unit/auth-config.test.ts
@@ -18,7 +18,7 @@ describe("mobile relay configuration", () => {
 			"client_01KWGQ818571ARFATQ3G9AR2Y2",
 		);
 		expect(defaultRelayBaseUrl(true)).toBe("https://relay-staging.zuse.sh");
-		expect(defaultRelayBaseUrl(false)).toBe("https://relay.zuse.sh");
+		expect(defaultRelayBaseUrl(false)).toBe("https://relay.stuff.md");
 	});
 
 	it("pins internal builds to the staging identity and relay", async () => {

--- a/apps/mobile/test/unit/rpc/relay-client.test.ts
+++ b/apps/mobile/test/unit/rpc/relay-client.test.ts
@@ -16,7 +16,7 @@ describe("relay client errors", () => {
 		expect(
 			normalizeRelayError(
 				500,
-				"Worker threw exception | relay.zuse.sh | Cloudflare body{margin:0}",
+				"Worker threw exception | relay.stuff.md | Cloudflare body{margin:0}",
 				"relay_connect",
 			),
 		).toBe("relay_connect_500");

--- a/apps/renderer/src/components/settings/devices-pane.tsx
+++ b/apps/renderer/src/components/settings/devices-pane.tsx
@@ -23,7 +23,7 @@ import { UsingComputersCard } from "./remote-access/using-computers-card.tsx";
 
 const DEFAULT_RELAY_URL =
 	(import.meta.env.VITE_ZUSE_RELAY_URL as string | undefined) ??
-	"https://relay.zuse.sh";
+	"https://relay.stuff.md";
 
 /**
  * Remote-access settings data and mutations. Presentation is composed from

--- a/apps/renderer/test/unit/relay-url.test.ts
+++ b/apps/renderer/test/unit/relay-url.test.ts
@@ -8,7 +8,7 @@ describe("renderer relay URL", () => {
 			"https://relay-staging.zuse.sh",
 		);
 		expect(resolveRendererRelayUrl(undefined, false)).toBe(
-			"https://relay.zuse.sh",
+			"https://relay.stuff.md",
 		);
 	});
 

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -256,7 +256,7 @@ export const runHeadlessServer = (
 		autoRelayLink:
 			process.env.ZUSE_SERVE_AUTO_LINK === "1"
 				? {
-						relayUrl: process.env.ZUSE_RELAY_URL ?? "https://relay.zuse.sh",
+						relayUrl: process.env.ZUSE_RELAY_URL ?? "https://relay.stuff.md",
 						label: process.env.ZUSE_COMPUTER_NAME,
 					}
 				: undefined,

--- a/apps/server/src/serve/package-cli.ts
+++ b/apps/server/src/serve/package-cli.ts
@@ -41,7 +41,7 @@ export {
 	ServeTunnelState,
 } from "@zuse/contracts";
 
-const DEFAULT_RELAY_URL = "https://relay.zuse.sh";
+const DEFAULT_RELAY_URL = "https://relay.stuff.md";
 export const SERVE_HELP = `Zuse Serve
 
 Run and manage Zuse on this computer.

--- a/apps/server/src/serve/service-definition.ts
+++ b/apps/server/src/serve/service-definition.ts
@@ -33,7 +33,7 @@ export const launchAgentDefinition = (
 	input: ServeServiceDefinitionInput,
 ): LaunchAgentDefinition => {
 	const logDir = input.logDir ?? `${input.dataDir}/logs`;
-	const relayUrl = input.relayUrl ?? "https://relay.zuse.sh";
+	const relayUrl = input.relayUrl ?? "https://relay.stuff.md";
 	return {
 		label: "sh.zuse.serve",
 		contents: `<?xml version="1.0" encoding="UTF-8"?>
@@ -81,7 +81,7 @@ export const launchAgentDefinition = (
 export const systemdUserDefinition = (
 	input: ServeServiceDefinitionInput,
 ): SystemdUserDefinition => {
-	const relayUrl = input.relayUrl ?? "https://relay.zuse.sh";
+	const relayUrl = input.relayUrl ?? "https://relay.stuff.md";
 	return {
 		unitName: "zuse-serve.service",
 		contents: `[Unit]

--- a/apps/server/test/unit/cloud-runtime-assets.test.ts
+++ b/apps/server/test/unit/cloud-runtime-assets.test.ts
@@ -356,6 +356,6 @@ describe("cloud runtime assets", () => {
 		expect(workflow).toContain("--clobber");
 		expect(workflow).not.toContain("if: github.event_name != 'pull_request'");
 		expect(workflow).not.toContain("wrangler deploy");
-		expect(workflow).not.toContain("relay.zuse.sh");
+		expect(workflow).not.toContain("relay.stuff.md");
 	});
 });

--- a/apps/server/test/unit/machine-control-service.test.ts
+++ b/apps/server/test/unit/machine-control-service.test.ts
@@ -60,7 +60,7 @@ describe("machine control relay URL", () => {
 
 	it("uses production only for production or an explicit override", () => {
 		expect(resolveMachineRelayUrl({ NODE_ENV: "production" })).toBe(
-			"https://relay.zuse.sh",
+			"https://relay.stuff.md",
 		);
 		expect(
 			resolveMachineRelayUrl({

--- a/docs/cloud/operations.md
+++ b/docs/cloud/operations.md
@@ -12,7 +12,7 @@ Staging and production are isolated deployments:
 
 | Resource | Staging | Production |
 | --- | --- | --- |
-| Relay | `zuse-relay-staging`, `relay-staging.zuse.sh` | guarded production Worker, `relay.zuse.sh` |
+| Relay | `zuse-relay-staging`, `relay-staging.zuse.sh` | guarded production Worker, `relay.stuff.md` |
 | Wrangler config | default `infra/relay/wrangler.jsonc` | `infra/relay/wrangler.production.jsonc` |
 | Database | approved staging Neon identity | separately approved production identity |
 | Runtime channel | `cloud-runtime-staging` | signed `cloud-runtime-production` |

--- a/infra/relay/PRIVATE_BETA_PRODUCTION.md
+++ b/infra/relay/PRIVATE_BETA_PRODUCTION.md
@@ -16,7 +16,7 @@ not use this gate.
 2. In Polar production, create Cloud Workspace with a $40 monthly price. Create
    meter `zuse_cloud_overage_cent`, summing numeric metadata field `units`, and
    attach a recurring $0.01-per-unit price. Register
-   `https://relay.zuse.sh/v1/billing/webhook/polar` for the subscription events
+   `https://relay.stuff.md/v1/billing/webhook/polar` for the subscription events
    supported by the Polar adapter.
 3. In E2B production, build artifacts from the release commit, then publish the
    isolated production template:
@@ -28,7 +28,7 @@ not use this gate.
 
    Record the immutable build identifier from the CLI in
    `E2B_TEMPLATE_VERSION`. Register
-   `https://relay.zuse.sh/v1/cloud/billing/webhook/e2b` and verify a signed real
+   `https://relay.stuff.md/v1/cloud/billing/webhook/e2b` and verify a signed real
    delivery.
 4. A version tag publishes a separately signed runtime to
    `cloud-runtime-production`. Record that manifest URL and its production
@@ -64,7 +64,7 @@ guarded command requires the approved database identity in
 `production-database.json` and rejects staging:
 
 ```sh
-ZUSE_CONFIRM_PRODUCTION_DATABASE_MIGRATION=migrate-relay.zuse.sh \
+ZUSE_CONFIRM_PRODUCTION_DATABASE_MIGRATION=migrate-relay.stuff.md \
 DATABASE_URL=... \
 bun --cwd infra/relay db:migrate:production
 ```
@@ -73,7 +73,7 @@ The production deploy independently validates nonempty runtime, E2B, PostHog,
 Polar, R2, Hyperdrive, cutover, and secret configuration:
 
 ```sh
-ZUSE_CONFIRM_PRODUCTION_RELAY_DEPLOY=deploy-relay.zuse.sh \
+ZUSE_CONFIRM_PRODUCTION_RELAY_DEPLOY=deploy-relay.stuff.md \
 bun --cwd infra/relay deploy:production
 ```
 

--- a/infra/relay/README.md
+++ b/infra/relay/README.md
@@ -70,7 +70,7 @@ An intentional production deployment is guarded and requires both the explicit
 script and confirmation value:
 
 ```sh
-ZUSE_CONFIRM_PRODUCTION_RELAY_DEPLOY=deploy-relay.zuse.sh \
+ZUSE_CONFIRM_PRODUCTION_RELAY_DEPLOY=deploy-relay.stuff.md \
 	bun run deploy:production
 ```
 

--- a/infra/relay/scripts/deploy-production.mjs
+++ b/infra/relay/scripts/deploy-production.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 
 import { parse } from "jsonc-parser";
 
-const confirmation = "deploy-relay.zuse.sh";
+const confirmation = "deploy-relay.stuff.md";
 const configPath = "wrangler.production.jsonc";
 
 if (process.env.ZUSE_CONFIRM_PRODUCTION_RELAY_DEPLOY !== confirmation) {

--- a/infra/relay/scripts/migrate-database.mjs
+++ b/infra/relay/scripts/migrate-database.mjs
@@ -7,7 +7,7 @@ const STAGING_DATABASE_HOSTS = new Set([
 	"ep-wild-feather-a10yvwmg-pooler.ap-southeast-1.aws.neon.tech",
 ]);
 const STAGING_DATABASE_NAME = "frankdb";
-const PRODUCTION_CONFIRMATION = "migrate-relay.zuse.sh";
+const PRODUCTION_CONFIRMATION = "migrate-relay.stuff.md";
 const productionDatabase = JSON.parse(
 	readFileSync(new URL("../production-database.json", import.meta.url), "utf8"),
 );

--- a/infra/relay/test/unit/deploy-safety.test.ts
+++ b/infra/relay/test/unit/deploy-safety.test.ts
@@ -127,7 +127,7 @@ describe("relay deployment safety", () => {
 
 		expect(production.name).toBe("zuse-relay");
 		expect(production.routes).toEqual([
-			{ pattern: "relay.zuse.sh", custom_domain: true },
+			{ pattern: "relay.stuff.md", custom_domain: true },
 		]);
 		expect(production.vars.MACHINE_PROVIDER).toBe("fake");
 		expect(production.vars.HETZNER_ADAPTER_ENABLED).toBe("false");
@@ -260,7 +260,7 @@ describe("relay deployment safety", () => {
 					...process.env,
 					DATABASE_URL:
 						"postgresql://example.invalid/production?sslmode=require",
-					ZUSE_CONFIRM_PRODUCTION_DATABASE_MIGRATION: "migrate-relay.zuse.sh",
+					ZUSE_CONFIRM_PRODUCTION_DATABASE_MIGRATION: "migrate-relay.stuff.md",
 				},
 			},
 		);

--- a/infra/relay/wrangler.production.jsonc
+++ b/infra/relay/wrangler.production.jsonc
@@ -14,10 +14,10 @@
 			"fallthrough": true
 		}
 	],
-	"routes": [{ "pattern": "relay.zuse.sh", "custom_domain": true }],
+	"routes": [{ "pattern": "relay.stuff.md", "custom_domain": true }],
 	"triggers": { "crons": ["* * * * *"] },
 	"vars": {
-		"RELAY_ISSUER": "https://relay.zuse.sh",
+		"RELAY_ISSUER": "https://relay.stuff.md",
 		"WORKOS_ISSUER": "https://api.workos.com",
 		"WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KWGQ818571ARFATQ3G9AR2Y2",
 		"RELAY_MINT_PUBLIC_JWK": "{\"crv\":\"Ed25519\",\"x\":\"A2Ig1XwHKDznhyTbPD9IVTlJpaN4YImgQadx-Gl81Bs\",\"kty\":\"OKP\"}",

--- a/packages/contracts/src/deployment-profiles.json
+++ b/packages/contracts/src/deployment-profiles.json
@@ -1,6 +1,6 @@
 {
 	"production": {
-		"relayUrl": "https://relay.zuse.sh",
+		"relayUrl": "https://relay.stuff.md",
 		"workosPublicClientId": "client_01KWGQ818571ARFATQ3G9AR2Y2"
 	},
 	"staging": {


### PR DESCRIPTION
## Summary
- route production Relay through `relay.stuff.md`, which is already on Cloudflare DNS
- update production client defaults and issuer consistently
- keep staging unchanged

## Verification
- 32 focused endpoint and deployment tests
- targeted type checks: contracts, renderer, server, Relay
- Biome (three pre-existing warnings in devices-pane)

