### PR TITLE
Release v0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3]
+
+### Fixed
+- Restored local projects and chats after upgrading when Local network access is disabled, and made project loading recoverable without deleting or replacing the local database
+
 ## [0.20.2]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.2",
+	"version": "0.20.3",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.20.3",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Restored local projects and chats after upgrading when Local network access is disabled, and made project loading recoverable without deleting or replacing the local database"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.2",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.2",
+      "version": "0.20.3",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.3 with release notes grouped by user-visible outcome.

### Fixed
- Restored local projects and chats after upgrading when Local network access is disabled, and made project loading recoverable without deleting or replacing the local database

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.20.3 after this PR lands.
