### PR TITLE
fix(cloud): stabilize beta access checks

### DIFF
--- a/infra/relay/src/beta-access.ts
+++ b/infra/relay/src/beta-access.ts
@@ -27,6 +27,7 @@ export interface PostHogBetaAccessConfig {
 	readonly projectToken: string;
 	readonly flagKey: string;
 	readonly timeoutMs?: number;
+	readonly allowCacheMs?: number;
 }
 
 const FlagResponse = Schema.Struct({
@@ -44,8 +45,12 @@ const FlagResponse = Schema.Struct({
 export const makePostHogBetaAccess = (
 	config: PostHogBetaAccessConfig,
 	fetcher: typeof fetch = globalThis.fetch,
-): BetaAccessApi => ({
-	check: Effect.fn("BetaAccess.check")(function* (accountId: string) {
+): BetaAccessApi => {
+	const allowedUntil = new Map<string, number>();
+	const inFlight = new Map<string, Promise<void>>();
+	const evaluate = Effect.fn("BetaAccess.evaluate")(function* (
+		accountId: string,
+	) {
 		const response = yield* Effect.tryPromise({
 			try: () =>
 				fetcher(`${config.host.replace(/\/+$/u, "")}/flags/?v=2`, {
@@ -80,8 +85,40 @@ export const makePostHogBetaAccess = (
 			return yield* new BetaAccessUnavailable();
 		if (payload.flags[config.flagKey]?.enabled !== true)
 			return yield* new BetaAccessDenied();
-	}),
-});
+	});
+	return {
+		check: Effect.fn("BetaAccess.check")(function* (accountId: string) {
+			const now = yield* Effect.clockWith((clock) => clock.currentTimeMillis);
+			if ((allowedUntil.get(accountId) ?? 0) > now) return;
+			let pending = inFlight.get(accountId);
+			if (pending === undefined) {
+				pending = Effect.runPromise(
+					evaluate(accountId).pipe(
+						Effect.retry({
+							times: 1,
+							while: (cause) => cause instanceof BetaAccessUnavailable,
+						}),
+					),
+				).then(() => {
+					allowedUntil.set(accountId, now + (config.allowCacheMs ?? 60_000));
+				});
+				inFlight.set(accountId, pending);
+				const clearPending = () => {
+					if (inFlight.get(accountId) === pending) inFlight.delete(accountId);
+				};
+				void pending.then(clearPending, clearPending);
+			}
+			yield* Effect.tryPromise({
+				try: () => pending,
+				catch: (cause) =>
+					cause instanceof BetaAccessDenied ||
+					cause instanceof BetaAccessUnavailable
+						? cause
+						: new BetaAccessUnavailable(),
+			});
+		}),
+	};
+};
 
 export const PostHogBetaAccessLayer = (
 	config: PostHogBetaAccessConfig,

--- a/infra/relay/test/unit/beta-access.test.ts
+++ b/infra/relay/test/unit/beta-access.test.ts
@@ -46,6 +46,50 @@ describe("cloud beta access", () => {
 		});
 	});
 
+	test("shares concurrent evaluations and briefly caches an allowed account", async () => {
+		let calls = 0;
+		let resolveResponse: ((value: Response) => void) | undefined;
+		const access = makePostHogBetaAccess(
+			{ ...config, allowCacheMs: 60_000 },
+			() => {
+				calls += 1;
+				return new Promise<Response>((resolve) => {
+					resolveResponse = resolve;
+				});
+			},
+		);
+		const checks = Array.from({ length: 8 }, () =>
+			Effect.runPromise(access.check("user_allowed")),
+		);
+		expect(calls).toBe(1);
+		resolveResponse?.(
+			new Response(
+				JSON.stringify({
+					flags: { "zuse-cloud-beta-access": { enabled: true } },
+				}),
+			),
+		);
+		await Promise.all(checks);
+		await Effect.runPromise(access.check("user_allowed"));
+		expect(calls).toBe(1);
+	});
+
+	test("retries one unavailable evaluation before failing closed", async () => {
+		let calls = 0;
+		const access = makePostHogBetaAccess(config, () => {
+			calls += 1;
+			return calls === 1
+				? response({ flags: {} }, 503)
+				: response({
+						flags: { "zuse-cloud-beta-access": { enabled: true } },
+					});
+		});
+		await expect(Effect.runPromise(access.check("user_retry"))).resolves.toBe(
+			undefined,
+		);
+		expect(calls).toBe(2);
+	});
+
 	test("denies an absent or disabled flag", async () => {
 		for (const flags of [
 			{},


### PR DESCRIPTION
## Summary
- single-flight concurrent PostHog beta checks per WorkOS account
- retry one transient PostHog evaluation failure
- cache successful authorization for 60 seconds while denied accounts continue failing closed

## Evidence
A production-style 35-request settings burst returned one intermittent `cloud_beta_access_unavailable` before this change.

## Verification
- Biome on changed files
- 6 beta-access unit tests
- 33 Relay integration tests
- Relay type check

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0119fdc1-e41a-433b-a386-792a256c8983)
