### PR TITLE
fix(cloud): allow production flag latency

### DIFF
--- a/infra/relay/src/beta-access.ts
+++ b/infra/relay/src/beta-access.ts
@@ -27,7 +27,6 @@ export interface PostHogBetaAccessConfig {
 	readonly projectToken: string;
 	readonly flagKey: string;
 	readonly timeoutMs?: number;
-	readonly allowCacheMs?: number;
 }
 
 const FlagResponse = Schema.Struct({
@@ -45,12 +44,8 @@ const FlagResponse = Schema.Struct({
 export const makePostHogBetaAccess = (
 	config: PostHogBetaAccessConfig,
 	fetcher: typeof fetch = globalThis.fetch,
-): BetaAccessApi => {
-	const allowedUntil = new Map<string, number>();
-	const inFlight = new Map<string, Promise<void>>();
-	const evaluate = Effect.fn("BetaAccess.evaluate")(function* (
-		accountId: string,
-	) {
+): BetaAccessApi => ({
+	check: Effect.fn("BetaAccess.check")(function* (accountId: string) {
 		const response = yield* Effect.tryPromise({
 			try: () =>
 				fetcher(`${config.host.replace(/\/+$/u, "")}/flags/?v=2`, {
@@ -65,7 +60,7 @@ export const makePostHogBetaAccess = (
 						geoip_disable: true,
 						flag_keys_to_evaluate: [config.flagKey],
 					}),
-					signal: AbortSignal.timeout(config.timeoutMs ?? 1_500),
+					signal: AbortSignal.timeout(config.timeoutMs ?? 5_000),
 				}),
 			catch: () => new BetaAccessUnavailable(),
 		});
@@ -85,40 +80,8 @@ export const makePostHogBetaAccess = (
 			return yield* new BetaAccessUnavailable();
 		if (payload.flags[config.flagKey]?.enabled !== true)
 			return yield* new BetaAccessDenied();
-	});
-	return {
-		check: Effect.fn("BetaAccess.check")(function* (accountId: string) {
-			const now = yield* Effect.clockWith((clock) => clock.currentTimeMillis);
-			if ((allowedUntil.get(accountId) ?? 0) > now) return;
-			let pending = inFlight.get(accountId);
-			if (pending === undefined) {
-				pending = Effect.runPromise(
-					evaluate(accountId).pipe(
-						Effect.retry({
-							times: 1,
-							while: (cause) => cause instanceof BetaAccessUnavailable,
-						}),
-					),
-				).then(() => {
-					allowedUntil.set(accountId, now + (config.allowCacheMs ?? 60_000));
-				});
-				inFlight.set(accountId, pending);
-				const clearPending = () => {
-					if (inFlight.get(accountId) === pending) inFlight.delete(accountId);
-				};
-				void pending.then(clearPending, clearPending);
-			}
-			yield* Effect.tryPromise({
-				try: () => pending,
-				catch: (cause) =>
-					cause instanceof BetaAccessDenied ||
-					cause instanceof BetaAccessUnavailable
-						? cause
-						: new BetaAccessUnavailable(),
-			});
-		}),
-	};
-};
+	}),
+});
 
 export const PostHogBetaAccessLayer = (
 	config: PostHogBetaAccessConfig,

--- a/infra/relay/test/unit/beta-access.test.ts
+++ b/infra/relay/test/unit/beta-access.test.ts
@@ -46,50 +46,6 @@ describe("cloud beta access", () => {
 		});
 	});
 
-	test("shares concurrent evaluations and briefly caches an allowed account", async () => {
-		let calls = 0;
-		let resolveResponse: ((value: Response) => void) | undefined;
-		const access = makePostHogBetaAccess(
-			{ ...config, allowCacheMs: 60_000 },
-			() => {
-				calls += 1;
-				return new Promise<Response>((resolve) => {
-					resolveResponse = resolve;
-				});
-			},
-		);
-		const checks = Array.from({ length: 8 }, () =>
-			Effect.runPromise(access.check("user_allowed")),
-		);
-		expect(calls).toBe(1);
-		resolveResponse?.(
-			new Response(
-				JSON.stringify({
-					flags: { "zuse-cloud-beta-access": { enabled: true } },
-				}),
-			),
-		);
-		await Promise.all(checks);
-		await Effect.runPromise(access.check("user_allowed"));
-		expect(calls).toBe(1);
-	});
-
-	test("retries one unavailable evaluation before failing closed", async () => {
-		let calls = 0;
-		const access = makePostHogBetaAccess(config, () => {
-			calls += 1;
-			return calls === 1
-				? response({ flags: {} }, 503)
-				: response({
-						flags: { "zuse-cloud-beta-access": { enabled: true } },
-					});
-		});
-		await expect(Effect.runPromise(access.check("user_retry"))).resolves.toBe(
-			undefined,
-		);
-		expect(calls).toBe(2);
-	});
-
 	test("denies an absent or disabled flag", async () => {
 		for (const flags of [
 			{},


### PR DESCRIPTION
## Summary
- replace the ineffective per-isolate beta-access cache and retry with one five-second PostHog evaluation window
- remove 81 net lines from the prior mitigation
- preserve fail-closed behavior for unavailable and denied evaluations

## Evidence
Production successes reached roughly two seconds, while every failure landed at roughly 3.1 seconds from two consecutive 1.5-second timeouts.

## Verification
- Biome on changed files
- 4 beta-access unit tests
- 33 Relay integration tests
- Relay type check

