### PR TITLE
fix(cloud): restore packaged production access

### DIFF
--- a/apps/renderer/src/components/settings/cloud-machines-pane.tsx
+++ b/apps/renderer/src/components/settings/cloud-machines-pane.tsx
@@ -7,7 +7,6 @@ import {
 	type MachineSshKey,
 	type SshMode,
 } from "@zuse/contracts";
-import { Effect } from "effect";
 import { ExternalLink, KeyRound, LoaderCircle, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../hooks/use-auth.ts";
@@ -26,11 +25,10 @@ import {
 	cloudMachineProgressSteps,
 } from "../../lib/cloud-machine-progress.ts";
 import { selectActiveCloudMachine } from "../../lib/cloud-machine-selection.ts";
-import { hostedAccountId } from "../../lib/hosted-connect.ts";
-import { openExternal } from "../../lib/platform-capabilities.ts";
 import { runControlPlane } from "../../lib/control-plane-client.ts";
 import { dispatchEnvironmentShellCommand } from "../../lib/environment-shell-client-bus.ts";
-import { getRpcClient } from "../../lib/rpc-client.ts";
+import { hostedAccountId } from "../../lib/hosted-connect.ts";
+import { openExternal } from "../../lib/platform-capabilities.ts";
 import { switchToEnvironment } from "../../lib/switch-environment.ts";
 import { useEnvironmentCatalogStore } from "../../store/environment-catalog.ts";
 import { useUiStore } from "../../store/ui.ts";
@@ -236,13 +234,9 @@ export function CloudMachinesPane() {
 			return;
 		}
 		void load();
-		const timer = window.setInterval(() => void load(), 5_000);
 		const handleFocus = () => void load();
 		window.addEventListener("focus", handleFocus);
-		return () => {
-			window.clearInterval(timer);
-			window.removeEventListener("focus", handleFocus);
-		};
+		return () => window.removeEventListener("focus", handleFocus);
 	}, [authLoading, isSignedIn, load]);
 
 	const beginPurchase = async () => {
@@ -371,9 +365,10 @@ export function CloudMachinesPane() {
 
 	useEffect(() => {
 		void refreshRuntimeStatus();
+		if (runtimeStatus?.state !== "updating") return;
 		const interval = window.setInterval(
 			() => void refreshRuntimeStatus(),
-			runtimeStatus?.state === "updating" ? 2_000 : 30_000,
+			2_000,
 		);
 		return () => window.clearInterval(interval);
 	}, [refreshRuntimeStatus, runtimeStatus?.state]);

--- a/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
+++ b/apps/renderer/src/components/settings/cloud-workspace-pool.tsx
@@ -278,8 +278,9 @@ export function CloudWorkspacePool() {
 		if (authLoading || !isSignedIn) return;
 		void load();
 		void loadGithubRepos();
-		const timer = window.setInterval(() => void load(), 5_000);
-		return () => window.clearInterval(timer);
+		const handleFocus = () => void load();
+		window.addEventListener("focus", handleFocus);
+		return () => window.removeEventListener("focus", handleFocus);
 	}, [authLoading, isSignedIn, load, loadGithubRepos]);
 
 	const run = async (

--- a/apps/server/src/machine/machine-control-service.ts
+++ b/apps/server/src/machine/machine-control-service.ts
@@ -36,7 +36,6 @@ import {
 	RelayConnectGrant,
 	RelayEnvironmentList,
 	RelayPaths,
-	STAGING_RELAY_URL,
 } from "@zuse/contracts";
 import {
 	Context,
@@ -211,11 +210,7 @@ export const streamCloudWorkspaceLifecycle = (
 
 export const resolveMachineRelayUrl = (
 	env: Readonly<Record<string, string | undefined>> = process.env,
-): string =>
-	(
-		env.ZUSE_RELAY_URL ??
-		(env.NODE_ENV === "production" ? PRODUCTION_RELAY_URL : STAGING_RELAY_URL)
-	).replace(/\/+$/u, "");
+): string => (env.ZUSE_RELAY_URL ?? PRODUCTION_RELAY_URL).replace(/\/+$/u, "");
 
 export const mapRelayErrorCode = (
 	status: number,

--- a/apps/server/test/unit/machine-control-service.test.ts
+++ b/apps/server/test/unit/machine-control-service.test.ts
@@ -52,13 +52,13 @@ describe("machine control relay URL", () => {
 		);
 	});
 
-	it("uses staging outside packaged production", () => {
+	it("defaults to production when packaged Electron has no runtime NODE_ENV", () => {
 		expect(resolveMachineRelayUrl({ NODE_ENV: "development" })).toBe(
-			"https://relay-staging.zuse.sh",
+			"https://relay.stuff.md",
 		);
 	});
 
-	it("uses production only for production or an explicit override", () => {
+	it("uses an explicit Relay override for development and staging", () => {
 		expect(resolveMachineRelayUrl({ NODE_ENV: "production" })).toBe(
 			"https://relay.stuff.md",
 		);

--- a/infra/relay/src/beta-access.ts
+++ b/infra/relay/src/beta-access.ts
@@ -27,6 +27,7 @@ export interface PostHogBetaAccessConfig {
 	readonly projectToken: string;
 	readonly flagKey: string;
 	readonly timeoutMs?: number;
+	readonly cache?: Pick<Cache, "match" | "put">;
 }
 
 const FlagResponse = Schema.Struct({
@@ -44,8 +45,34 @@ const FlagResponse = Schema.Struct({
 export const makePostHogBetaAccess = (
 	config: PostHogBetaAccessConfig,
 	fetcher: typeof fetch = globalThis.fetch,
-): BetaAccessApi => ({
-	check: Effect.fn("BetaAccess.check")(function* (accountId: string) {
+): BetaAccessApi => {
+	const cacheKey = (accountId: string) =>
+		new Request(
+			`https://beta-access.zuse.internal/${encodeURIComponent(config.flagKey)}/${analyticsAccountId(accountId)}`,
+		);
+	const readCache = async (accountId: string) => {
+		try {
+			const response = await config.cache?.match(cacheKey(accountId));
+			return response === undefined
+				? undefined
+				: (await response.text()) === "1";
+		} catch {
+			return undefined;
+		}
+	};
+	const writeCache = async (accountId: string, allowed: boolean) => {
+		try {
+			await config.cache?.put(
+				cacheKey(accountId),
+				new Response(allowed ? "1" : "0", {
+					headers: { "cache-control": "max-age=60" },
+				}),
+			);
+		} catch {}
+	};
+	const evaluate = Effect.fn("BetaAccess.evaluate")(function* (
+		accountId: string,
+	) {
 		const response = yield* Effect.tryPromise({
 			try: () =>
 				fetcher(`${config.host.replace(/\/+$/u, "")}/flags/?v=2`, {
@@ -78,10 +105,29 @@ export const makePostHogBetaAccess = (
 			payload.flags[config.flagKey]?.failed === true
 		)
 			return yield* new BetaAccessUnavailable();
-		if (payload.flags[config.flagKey]?.enabled !== true)
-			return yield* new BetaAccessDenied();
-	}),
-});
+		const allowed = payload.flags[config.flagKey]?.enabled === true;
+		yield* Effect.promise(() => writeCache(accountId, allowed));
+		if (!allowed) return yield* new BetaAccessDenied();
+	});
+	return {
+		check: Effect.fn("BetaAccess.check")(function* (accountId: string) {
+			const cached = yield* Effect.promise(() => readCache(accountId));
+			if (cached !== undefined)
+				return cached ? undefined : yield* new BetaAccessDenied();
+			return yield* evaluate(accountId).pipe(
+				Effect.catchTag("BetaAccessUnavailable", () =>
+					Effect.promise(() => readCache(accountId)).pipe(
+						Effect.flatMap((decision) =>
+							decision === true
+								? Effect.void
+								: Effect.fail(new BetaAccessUnavailable()),
+						),
+					),
+				),
+			);
+		}),
+	};
+};
 
 export const PostHogBetaAccessLayer = (
 	config: PostHogBetaAccessConfig,

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -247,6 +247,7 @@ const build = (env: Env): ReturnType<typeof makeRelay> => {
 				host: env.POSTHOG_HOST as string,
 				projectToken: env.POSTHOG_PROJECT_TOKEN as string,
 				flagKey: env.POSTHOG_CLOUD_BETA_FLAG_KEY as string,
+				cache: (caches as CacheStorage & { readonly default: Cache }).default,
 			})
 		: BetaAccessAllowAll;
 	const machineProvider = resolveMachineProviderRuntime(env, {

--- a/infra/relay/test/unit/beta-access.test.ts
+++ b/infra/relay/test/unit/beta-access.test.ts
@@ -23,6 +23,18 @@ const response = (body: unknown, status = 200) =>
 		}),
 	);
 
+const decisionCache = () => {
+	const values = new Map<string, Response>();
+	return {
+		match: (request: RequestInfo | URL) =>
+			Promise.resolve(values.get(String(request))?.clone()),
+		put: (request: RequestInfo | URL, response: Response) => {
+			values.set(String(request), response.clone());
+			return Promise.resolve();
+		},
+	};
+};
+
 describe("cloud beta access", () => {
 	test("evaluates only the configured flag with the verified account id", async () => {
 		let body: unknown;
@@ -56,6 +68,24 @@ describe("cloud beta access", () => {
 				Effect.runPromise(access.check("user_denied")),
 			).rejects.toBeInstanceOf(BetaAccessDenied);
 		}
+	});
+
+	test("shares one short-lived decision across relay requests", async () => {
+		const cache = decisionCache();
+		let evaluations = 0;
+		const fetcher = () => {
+			evaluations += 1;
+			return response({
+				flags: { "zuse-cloud-beta-access": { enabled: true } },
+			});
+		};
+		await Effect.runPromise(
+			makePostHogBetaAccess({ ...config, cache }, fetcher).check("user_cached"),
+		);
+		await Effect.runPromise(
+			makePostHogBetaAccess({ ...config, cache }, fetcher).check("user_cached"),
+		);
+		expect(evaluations).toBe(1);
 	});
 
 	test("fails closed when evaluation is unavailable or invalid", async () => {


### PR DESCRIPTION
## Summary
- default packaged desktop control-plane requests to production when runtime `NODE_ENV` is absent
- keep development/staging explicit through `ZUSE_RELAY_URL`
- remove continuous settings polling; refresh on entry, focus, and completed commands
- poll runtime status only while an update is actively progressing
- cache each verified WorkOS beta decision at the Cloudflare edge for 60 seconds
- reuse a successful concurrent decision when a parallel PostHog check times out

## Root causes
1. Packaged Electron does not export `NODE_ENV`, so the ambient fallback selected the dead staging Relay.
2. Each settings load independently evaluated PostHog, producing contradictory 200/503 results during fan-out.

## Verification
- Biome (7 changed files)
- Server and renderer TypeScript checks
- Machine relay URL unit tests: 6
- Relay unit tests: 143
- Relay integration tests: 33
- Production Relay burst after deploy: 60/60 successful (before: 15/20)