### PR TITLE
Release v0.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.4]
+
+### Changed
+- Cloud workspace settings now refresh when opened, focused, or after an action instead of continuously polling in the background
+
+### Fixed
+- Packaged desktop builds now connect to the production cloud service by default, preventing false subscription and invite-only errors caused by an unavailable staging endpoint
+- Cloud beta access remains reliable when several workspace requests start together, avoiding contradictory availability errors for an invited account
+
 ## [0.20.3]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.3",
+	"version": "0.20.4",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "0.20.4",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Cloud workspace settings now refresh when opened, focused, or after an action instead of continuously polling in the background"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Packaged desktop builds now connect to the production cloud service by default, preventing false subscription and invite-only errors caused by an unavailable staging endpoint",
+          "Cloud beta access remains reliable when several workspace requests start together, avoiding contradictory availability errors for an invited account"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.3",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.4 with release notes grouped by user-visible outcome.

### Changed
- Cloud workspace settings now refresh when opened, focused, or after an action instead of continuously polling in the background

### Fixed
- Packaged desktop builds now connect to the production cloud service by default, preventing false subscription and invite-only errors caused by an unavailable staging endpoint
- Cloud beta access remains reliable when several workspace requests start together, avoiding contradictory availability errors for an invited account

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.20.4 after this PR lands.