### PR TITLE
fix(billing): enable cloud workspace checkout

### DIFF
--- a/infra/relay/src/billing-config.ts
+++ b/infra/relay/src/billing-config.ts
@@ -82,10 +82,7 @@ export const resolveBillingRuntime = (
 			adapters: [BillingProviderManual, polar],
 			defaultProviderId: polar.providerId,
 		}).pipe(Layer.orDie),
-		liveCheckoutEnabled:
-			env.MACHINE_LIVE_CHECKOUT_ENABLED === "true" &&
-			(config.environment === "sandbox" ||
-				env.POLAR_VPS_SALES_APPROVED === "true"),
+		liveCheckoutEnabled: env.MACHINE_LIVE_CHECKOUT_ENABLED === "true",
 		polarConfigured: true,
 	};
 };

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -287,7 +287,9 @@ const build = (env: Env): ReturnType<typeof makeRelay> => {
 	);
 	const persistentCheckoutReady =
 		billing.liveCheckoutEnabled &&
-		(env.POLAR_ENVIRONMENT === "sandbox" || machineProvider.productionReady);
+		(env.POLAR_ENVIRONMENT === "sandbox" ||
+			(env.POLAR_VPS_SALES_APPROVED === "true" &&
+				machineProvider.productionReady));
 	const sandboxOperational =
 		availableSandboxProviderIds.size > 0 &&
 		isConfigured(

--- a/infra/relay/test/unit/billing-config.test.ts
+++ b/infra/relay/test/unit/billing-config.test.ts
@@ -44,7 +44,7 @@ describe("relay billing configuration", () => {
 		expect(providers.defaultProviderId).toBe("polar");
 	});
 
-	test("allows sandbox checkout while production requires sales approval", () => {
+	test("enables configured checkout independently of VPS sales approval", () => {
 		expect(
 			resolveBillingRuntime(configuredEnvironment).liveCheckoutEnabled,
 		).toBe(true);
@@ -53,14 +53,14 @@ describe("relay billing configuration", () => {
 				...configuredEnvironment,
 				POLAR_ENVIRONMENT: "production",
 			}).liveCheckoutEnabled,
-		).toBe(false);
+		).toBe(true);
 		expect(
 			resolveBillingRuntime({
 				...configuredEnvironment,
 				POLAR_ENVIRONMENT: "production",
-				POLAR_VPS_SALES_APPROVED: "true",
+				MACHINE_LIVE_CHECKOUT_ENABLED: "false",
 			}).liveCheckoutEnabled,
-		).toBe(true);
+		).toBe(false);
 	});
 
 	test("maps the optional cloud workspace subscription product", async () => {

--- a/infra/relay/test/unit/deploy-safety.test.ts
+++ b/infra/relay/test/unit/deploy-safety.test.ts
@@ -131,7 +131,7 @@ describe("relay deployment safety", () => {
 		]);
 		expect(production.vars.MACHINE_PROVIDER).toBe("fake");
 		expect(production.vars.HETZNER_ADAPTER_ENABLED).toBe("false");
-		expect(production.vars.MACHINE_LIVE_CHECKOUT_ENABLED).toBe("false");
+		expect(production.vars.MACHINE_LIVE_CHECKOUT_ENABLED).toBe("true");
 		expect(production.vars.MACHINE_RUNTIME_MANIFEST_URL).toBe("");
 		expect(production.vars.MACHINE_RUNTIME_SIGNING_PUBLIC_JWK).toBe("");
 		expect(production.vars).not.toHaveProperty("SANDBOX_DEFAULT_PROVIDER");

--- a/infra/relay/wrangler.production.jsonc
+++ b/infra/relay/wrangler.production.jsonc
@@ -32,7 +32,7 @@
 		"CF_ZONE_ID": "1ebb00c5fd61050e9f48ce1c791a29da",
 
 		"MACHINE_MANUAL_ENTITLEMENTS": "false",
-		"MACHINE_LIVE_CHECKOUT_ENABLED": "false",
+		"MACHINE_LIVE_CHECKOUT_ENABLED": "true",
 		"MACHINE_PROVIDER": "fake",
 		"HETZNER_ADAPTER_ENABLED": "false",
 		"HETZNER_API_BASE_URL": "https://api.hetzner.cloud/v1",


### PR DESCRIPTION
## Summary
- enable the production Cloud Workspace subscription checkout
- separate SaaS checkout readiness from persistent-machine sales approval
- keep persistent-machine checkout disabled until its provider and sales approval are ready

## Root cause
The production checkout switch was still false, and the shared billing gate incorrectly required the unrelated VPS approval for every Polar product.

## Verification
- Biome (5 changed files)
- Relay TypeScript
- billing/deployment/Relay integration tests: 46