### PR TITLE
fix(billing): persist cloud workspace entitlements

### DIFF
--- a/infra/relay/src/machine-store.ts
+++ b/infra/relay/src/machine-store.ts
@@ -562,7 +562,8 @@ export const MachineStoreMemory = Layer.effect(
 						if (
 							machine === undefined &&
 							input.entitlement.status === "active" &&
-							input.entitlement.offerId !== undefined
+							input.entitlement.offerId !== undefined &&
+							input.sameKindOfferIds.length > 0
 						) {
 							const recoverable = [...machines.values()].find(
 								(item) =>
@@ -1112,7 +1113,8 @@ export const MachineStorePg: Layer.Layer<
 						if (
 							machine === undefined &&
 							input.entitlement.status === "active" &&
-							input.entitlement.offerId !== undefined
+							input.entitlement.offerId !== undefined &&
+							input.sameKindOfferIds.length > 0
 						) {
 							const recoverableRows = yield* sql<MachineRow>`
 								SELECT * FROM relay_machines


### PR DESCRIPTION
## Summary
- skip persistent-machine recovery lookup for non-machine Cloud Workspace entitlements
- prevent the SQL adapter from generating an empty `IN ()` clause

## Production verification
- applied the guarded production migration
- deployed the exact fix commit to Relay production
- replayed the existing signed Polar `subscription.active` event
- verified the account now has one active Cloud Workspace entitlement

## Checks
- `bunx biome check infra/relay/src/machine-store.ts`
- `bunx vitest run infra/relay/test/unit/machine-store.test.ts infra/relay/test/integration/relay.test.ts` (36 passed)
- `bun --cwd infra/relay check-types`