### PR TITLE
fix(runtime): prevent usage timeout from stopping cloud workspaces

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -199,12 +199,15 @@ export function ChatView({
 		() => (
 			<>
 				<div className="px-[var(--chat-row-gutter,0.75rem)]">
-					<WorktreeSetupCard agentStarting={agentStarting ? true : undefined} />
+					<WorktreeSetupCard
+						agentStarting={agentStarting ? true : undefined}
+						providerOutputStarted={providerOutputStarted}
+					/>
 				</div>
 				<div className="h-2" />
 			</>
 		),
-		[agentStarting],
+		[agentStarting, providerOutputStarted],
 	);
 	const turns = useMemo(() => deriveChatTurnNavigationEntries(rows), [rows]);
 	const latestUserMessageId = useMemo(

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -63,8 +63,10 @@ export type SetupCardData = {
  */
 export function WorktreeSetupCard({
 	agentStarting,
+	providerOutputStarted = false,
 }: {
 	readonly agentStarting?: boolean;
+	readonly providerOutputStarted?: boolean;
 } = {}) {
 	const ctx = useActiveContext();
 	const selectedChatId = useChatsStore((state) => state.selectedChatId);
@@ -130,6 +132,7 @@ export function WorktreeSetupCard({
 			}));
 	if (
 		cloudSummary !== null &&
+		!providerOutputStarted &&
 		cloudSummary.startupPhase !== "running" &&
 		cloudSummary.state !== "paused" &&
 		cloudSummary.state !== "resuming" &&

--- a/apps/renderer/src/lib/cloud-workspaces.ts
+++ b/apps/renderer/src/lib/cloud-workspaces.ts
@@ -1,3 +1,4 @@
+import type { SessionRef } from "@zuse/client-runtime/resource-ref";
 import type { ResourceView } from "@zuse/client-runtime/resource-state";
 import type { SessionTimelineProjection } from "@zuse/contracts";
 import {
@@ -10,6 +11,8 @@ import {
 	EnvironmentId,
 	type FolderId,
 	type GitOriginInfo,
+	Message,
+	MessageId,
 	type ProviderId,
 	Session,
 	type SessionId,
@@ -39,6 +42,7 @@ import {
 	timelineReadingPositionStore,
 } from "../lib/session-timeline-cache.ts";
 import {
+	addOptimisticSessionMessage,
 	registerEnvironmentActivation,
 	registerSessionTimelineCheckpointSynchronizer,
 	registerSessionTimelineOlderPageSynchronizer,
@@ -291,7 +295,7 @@ export const cloudSessionPlaceholder = (
 export const stageCloudChat = (
 	summary: CloudChatSummary,
 	projectId: FolderId,
-	_firstMessage?: string,
+	firstMessage?: string,
 ): void => {
 	const previous = cloudSummaryForEnvironment(summary.workspaceId);
 	if (
@@ -342,6 +346,21 @@ export const stageCloudChat = (
 			],
 		},
 	}));
+	if (firstMessage !== undefined) {
+		addOptimisticSessionMessage(
+			{
+				environmentId: EnvironmentId.make(accepted.workspaceId),
+				sessionId: accepted.initialSessionId,
+			} satisfies SessionRef,
+			Message.make({
+				id: MessageId.make(`launch:${accepted.workspaceId}:message`),
+				sessionId: accepted.initialSessionId,
+				role: "user",
+				content: { _tag: "user", text: firstMessage, goal: false },
+				createdAt: now,
+			}),
+		);
+	}
 	useChatsStore.setState({ error: null });
 };
 

--- a/apps/server/src/usage/limits/codex-usage.ts
+++ b/apps/server/src/usage/limits/codex-usage.ts
@@ -75,9 +75,10 @@ export const mapCodexRateLimits = (
 
 export const fetchCodexUsage = async (): Promise<ProviderUsageLimits> => {
 	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const timedOut = Symbol("timed-out");
 	try {
-		const timeoutPromise = new Promise<never>((_, reject) => {
-			timeout = setTimeout(() => reject(new Error("timeout")), 5_000);
+		const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
+			timeout = setTimeout(() => resolve(timedOut), 5_000);
 		});
 		const result = await withCodexControlClient("codex", (client) =>
 			Promise.race([
@@ -85,6 +86,7 @@ export const fetchCodexUsage = async (): Promise<ProviderUsageLimits> => {
 				timeoutPromise,
 			]),
 		);
+		if (result === timedOut) return unavailable("codex", "error");
 		return mapCodexRateLimits(result);
 	} catch {
 		return unavailable("codex", "error");

--- a/infra/relay/src/machine-store.ts
+++ b/infra/relay/src/machine-store.ts
@@ -562,7 +562,8 @@ export const MachineStoreMemory = Layer.effect(
 						if (
 							machine === undefined &&
 							input.entitlement.status === "active" &&
-							input.entitlement.offerId !== undefined
+							input.entitlement.offerId !== undefined &&
+							input.sameKindOfferIds.length > 0
 						) {
 							const recoverable = [...machines.values()].find(
 								(item) =>
@@ -1112,7 +1113,8 @@ export const MachineStorePg: Layer.Layer<
 						if (
 							machine === undefined &&
 							input.entitlement.status === "active" &&
-							input.entitlement.offerId !== undefined
+							input.entitlement.offerId !== undefined &&
+							input.sameKindOfferIds.length > 0
 						) {
 							const recoverableRows = yield* sql<MachineRow>`
 								SELECT * FROM relay_machines


### PR DESCRIPTION
## Summary
- make the Codex usage timeout resolve to an unavailable result instead of creating a rejecting timer
- prevent a detached timeout from becoming an unhandled rejection that terminates the cloud runtime

## Production diagnosis
The failed E2B sandbox completed allocation, enrollment, repository setup, and runtime-ready. Its runtime then exited with the uncaught 5-second timeout from `codex-usage.ts`, causing bootstrap to record `ready-failed`.

## Checks
- `bunx biome check apps/server/src/usage/limits/codex-usage.ts infra/relay/src/machine-store.ts`
- 56 targeted tests passed
- server and Relay type checks passed