### PR TITLE
Fix sidebar tab transition behavior

### DIFF
--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -37,6 +37,10 @@ import {
 import { useActiveSessionById } from "./lib/environment-entity-hooks.ts";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { useSettingsStore } from "./lib/settings-client-bus.ts";
+import {
+	type SidebarVisibilitySnapshot,
+	shouldAnimateSidebarVisibility,
+} from "./lib/sidebar-panel-motion.ts";
 import { shouldMountRightPane } from "./shell/right-pane-lifecycle.ts";
 import { useChatsStore } from "./store/chats.ts";
 import { useEnvironmentCatalogStore } from "./store/environment-catalog.ts";
@@ -201,10 +205,18 @@ function useAnimatedPanelVisibility(
 	elementRef: RefObject<HTMLDivElement | null>,
 	open: boolean,
 	expandedSize?: string,
+	contextKey = "global",
 ) {
 	const expandedSizeRef = useRef(expandedSize);
+	const previousVisibilityRef = useRef<SidebarVisibilitySnapshot>(undefined);
 	expandedSizeRef.current = expandedSize;
 	useEffect(() => {
+		const nextVisibility = { contextKey, open };
+		const animate = shouldAnimateSidebarVisibility(
+			previousVisibilityRef.current,
+			nextVisibility,
+		);
+		previousVisibilityRef.current = nextVisibility;
 		const panel = panelRef.current;
 		if (panel === null) return;
 		const element = elementRef.current;
@@ -213,7 +225,7 @@ function useAnimatedPanelVisibility(
 			return;
 		}
 
-		element?.classList.add("fz-sidebar-panel-motion");
+		if (animate) element?.classList.add("fz-sidebar-panel-motion");
 		const frame = window.requestAnimationFrame(() => {
 			if (open) {
 				panel.expand();
@@ -224,15 +236,17 @@ function useAnimatedPanelVisibility(
 				panel.collapse();
 			}
 		});
-		const timeout = window.setTimeout(() => {
-			element?.classList.remove("fz-sidebar-panel-motion");
-		}, 240);
+		const timeout = animate
+			? window.setTimeout(() => {
+					element?.classList.remove("fz-sidebar-panel-motion");
+				}, 240)
+			: undefined;
 		return () => {
 			window.cancelAnimationFrame(frame);
-			window.clearTimeout(timeout);
+			if (timeout !== undefined) window.clearTimeout(timeout);
 			element?.classList.remove("fz-sidebar-panel-motion");
 		};
-	}, [elementRef, panelRef, open]);
+	}, [contextKey, elementRef, panelRef, open]);
 }
 
 function SurfaceFallback() {
@@ -569,6 +583,7 @@ function MainShell() {
 		rightPanelElementRef,
 		rightSidebarOpen,
 		`${rightSidebarWidth}%`,
+		selectedChatKey ?? "no-chat",
 	);
 
 	return (

--- a/apps/renderer/src/lib/sidebar-panel-motion.ts
+++ b/apps/renderer/src/lib/sidebar-panel-motion.ts
@@ -1,0 +1,16 @@
+export interface SidebarVisibilitySnapshot {
+	readonly contextKey: string;
+	readonly open: boolean;
+}
+
+/** Only direct visibility changes inside one sidebar context should animate. */
+export function shouldAnimateSidebarVisibility(
+	previous: SidebarVisibilitySnapshot | undefined,
+	next: SidebarVisibilitySnapshot,
+): boolean {
+	return (
+		previous !== undefined &&
+		previous.contextKey === next.contextKey &&
+		previous.open !== next.open
+	);
+}

--- a/apps/renderer/test/unit/sidebar-panel-motion.test.ts
+++ b/apps/renderer/test/unit/sidebar-panel-motion.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { shouldAnimateSidebarVisibility } from "../../src/lib/sidebar-panel-motion.ts";
+
+describe("shouldAnimateSidebarVisibility", () => {
+	it("animates visibility changes within the same sidebar context", () => {
+		expect(
+			shouldAnimateSidebarVisibility(
+				{ contextKey: "chat-a", open: false },
+				{ contextKey: "chat-a", open: true },
+			),
+		).toBe(true);
+	});
+
+	it("does not animate visibility changes caused by switching tabs", () => {
+		expect(
+			shouldAnimateSidebarVisibility(
+				{ contextKey: "chat-a", open: false },
+				{ contextKey: "chat-b", open: true },
+			),
+		).toBe(false);
+	});
+
+	it("does not animate initial sidebar synchronization", () => {
+		expect(
+			shouldAnimateSidebarVisibility(undefined, {
+				contextKey: "chat-a",
+				open: true,
+			}),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
## What changed

- distinguish direct sidebar visibility toggles from chat context changes
- restore each chat's saved right-sidebar state without a transition when switching tabs
- keep the existing open and close animation for toggles within the active chat
- add regression coverage for toggles, tab switches, and initial synchronization

## Why

The right-sidebar state is scoped per chat, but the animation hook previously observed only the resulting open state. Selecting a chat with a different saved state therefore looked identical to an explicit sidebar toggle and triggered an unwanted animation.

## Impact

Switching tabs now feels immediate and stable, while intentional sidebar open and close actions retain their existing motion.

## Validation

- `bunx biome check apps/renderer/src/app.tsx apps/renderer/src/lib/sidebar-panel-motion.ts apps/renderer/test/unit/sidebar-panel-motion.test.ts`
- `bun run --cwd apps/renderer test:unit -- sidebar-panel-motion.test.ts` (103 files, 474 tests passed)
- `bun run --cwd apps/renderer check-types`
- `git diff --check origin/main...HEAD`
