### PR TITLE
Detect Notched MacBooks Across Scaled Resolutions

### DIFF
--- a/apps/desktop/src/notch-display.ts
+++ b/apps/desktop/src/notch-display.ts
@@ -1,68 +1,87 @@
 export type NotchDisplayLike = {
-  readonly bounds: { readonly width: number; readonly height: number };
-  readonly size?: { readonly width: number; readonly height: number };
-  readonly scaleFactor: number;
-  readonly internal?: boolean;
+	readonly bounds: { readonly width: number; readonly height: number };
+	readonly size?: { readonly width: number; readonly height: number };
+	readonly scaleFactor: number;
+	readonly internal?: boolean;
 };
 
 export type NotchDisplaySupport =
-  | { readonly supported: true; readonly reason: "supported" }
-  | {
-      readonly supported: false;
-      readonly reason: "not-macos" | "no-notched-display";
-    };
+	| { readonly supported: true; readonly reason: "supported" }
+	| {
+			readonly supported: false;
+			readonly reason: "not-macos" | "no-notched-display";
+	  };
 
-const NOTCHED_MACBOOK_SIZES = new Set([
-  "3024x1964",
-  "3456x2234",
-  "2560x1664",
-  "2880x1864",
-]);
+/**
+ * Notched MacBook Liquid Retina panels are ~3:2:
+ *   13" Air  2560×1664  (1.538)
+ *   15" Air  2880×1864  (1.545)
+ *   14" Pro  3024×1964  (1.540)
+ *   16" Pro  3456×2234  (1.547)
+ * Pre-notch built-in MacBooks are 16:10 (1.6). iMacs are 16:9 (1.778).
+ *
+ * Electron reports DIP `size`/`bounds`, not native panel pixels. A 13" Air M2
+ * on "More Space" is 1710×1112 @2x (backing 3420×2224), not 2560×1664, so an
+ * allowlist of native sizes fails on any non-default scaling. Aspect ratio is
+ * invariant under those scaled modes.
+ */
+const NOTCHED_ASPECT_MIN = 1.53;
+const NOTCHED_ASPECT_MAX = 1.56;
 
-const sizeKey = (width: number, height: number): string => {
-  const w = Math.round(width);
-  const h = Math.round(height);
-  return w >= h ? `${w}x${h}` : `${h}x${w}`;
+const isFinitePositiveSize = (
+	size: { readonly width: number; readonly height: number } | undefined,
+): size is { readonly width: number; readonly height: number } =>
+	size !== undefined &&
+	Number.isFinite(size.width) &&
+	Number.isFinite(size.height) &&
+	size.width !== 0 &&
+	size.height !== 0;
+
+const aspectRatio = (width: number, height: number): number => {
+	const w = Math.abs(width);
+	const h = Math.abs(height);
+	const min = Math.min(w, h);
+	return min === 0 ? 0 : Math.max(w, h) / min;
+};
+
+const isNotchedMacBookSize = (width: number, height: number): boolean => {
+	const aspect = aspectRatio(width, height);
+	return aspect >= NOTCHED_ASPECT_MIN && aspect <= NOTCHED_ASPECT_MAX;
 };
 
 export const isLikelyNotchedMacBookDisplay = (
-  display: NotchDisplayLike,
+	display: NotchDisplayLike,
 ): boolean => {
-  if (display.internal !== true) return false;
-  const candidates = [
-    display.size,
-    display.bounds,
-    {
-      width: display.bounds.width * display.scaleFactor,
-      height: display.bounds.height * display.scaleFactor,
-    },
-  ].filter(
-    (size): size is { readonly width: number; readonly height: number } =>
-      size !== undefined &&
-      Number.isFinite(size.width) &&
-      Number.isFinite(size.height),
-  );
-  return candidates.some((size) =>
-    NOTCHED_MACBOOK_SIZES.has(sizeKey(size.width, size.height)),
-  );
+	if (display.internal !== true) return false;
+	const candidates = [
+		display.size,
+		display.bounds,
+		{
+			width: display.bounds.width * display.scaleFactor,
+			height: display.bounds.height * display.scaleFactor,
+		},
+	].filter(isFinitePositiveSize);
+	return candidates.some((size) =>
+		isNotchedMacBookSize(size.width, size.height),
+	);
 };
 
 export const detectNotchDisplaySupport = (
-  platform: NodeJS.Platform,
-  displays: ReadonlyArray<NotchDisplayLike>,
+	platform: NodeJS.Platform,
+	displays: ReadonlyArray<NotchDisplayLike>,
 ): NotchDisplaySupport => {
-  if (platform !== "darwin") {
-    return { supported: false, reason: "not-macos" };
-  }
-  return displays.some(isLikelyNotchedMacBookDisplay)
-    ? { supported: true, reason: "supported" }
-    : { supported: false, reason: "no-notched-display" };
+	if (platform !== "darwin") {
+		return { supported: false, reason: "not-macos" };
+	}
+	return displays.some(isLikelyNotchedMacBookDisplay)
+		? { supported: true, reason: "supported" }
+		: { supported: false, reason: "no-notched-display" };
 };
 
 export const findNotchedDisplay = <T extends NotchDisplayLike>(
-  platform: NodeJS.Platform,
-  displays: ReadonlyArray<T>,
+	platform: NodeJS.Platform,
+	displays: ReadonlyArray<T>,
 ): T | null => {
-  if (platform !== "darwin") return null;
-  return displays.find(isLikelyNotchedMacBookDisplay) ?? null;
+	if (platform !== "darwin") return null;
+	return displays.find(isLikelyNotchedMacBookDisplay) ?? null;
 };

--- a/apps/desktop/src/notch-tray-controller.ts
+++ b/apps/desktop/src/notch-tray-controller.ts
@@ -188,8 +188,9 @@ export class NotchTrayController {
   }
 
   private targetTop(display: Display): number {
-    const menuBarInset = Math.max(0, display.workArea.y - display.bounds.y);
-    return display.bounds.y - menuBarInset;
+    // Anchor to the display top so the cap fills the notch. Subtracting
+    // workArea.y (the menu-bar inset) hid the tray behind the camera housing.
+    return display.bounds.y;
   }
 
   private resizeAndPosition(): void {

--- a/apps/desktop/test/unit/notch-display.test.ts
+++ b/apps/desktop/test/unit/notch-display.test.ts
@@ -28,6 +28,44 @@ describe("notch display detection", () => {
 		});
 	});
 
+	it("detects a 13-inch MacBook Air at default and scaled resolutions", () => {
+		expect(isLikelyNotchedMacBookDisplay(display(2560, 1664))).toBe(true);
+		expect(isLikelyNotchedMacBookDisplay(display(1280, 832))).toBe(true);
+		expect(isLikelyNotchedMacBookDisplay(display(1470, 956))).toBe(true);
+		expect(isLikelyNotchedMacBookDisplay(display(1710, 1112))).toBe(true);
+	});
+
+	it("detects the Electron Display object from a 13-inch Air M2 on More Space", () => {
+		const airM2: NotchDisplayLike = {
+			bounds: { width: 1710, height: 1112 },
+			size: { width: 1710, height: 1112 },
+			scaleFactor: 2,
+			internal: true,
+		};
+		expect(isLikelyNotchedMacBookDisplay(airM2)).toBe(true);
+		expect(detectNotchDisplaySupport("darwin", [airM2])).toEqual({
+			supported: true,
+			reason: "supported",
+		});
+	});
+
+	it("detects other notched MacBook scaled modes", () => {
+		expect(isLikelyNotchedMacBookDisplay(display(2880, 1864))).toBe(true);
+		expect(isLikelyNotchedMacBookDisplay(display(1440, 934))).toBe(true);
+		expect(isLikelyNotchedMacBookDisplay(display(1800, 1169))).toBe(true);
+		expect(isLikelyNotchedMacBookDisplay(display(2056, 1329))).toBe(true);
+	});
+
+	it("rejects pre-notch 16:10 built-in MacBooks", () => {
+		expect(isLikelyNotchedMacBookDisplay(display(2560, 1600))).toBe(false);
+		expect(isLikelyNotchedMacBookDisplay(display(1440, 900))).toBe(false);
+	});
+
+	it("rejects 16:9 built-in displays such as iMacs", () => {
+		expect(isLikelyNotchedMacBookDisplay(display(4480, 2520))).toBe(false);
+		expect(isLikelyNotchedMacBookDisplay(display(1920, 1080))).toBe(false);
+	});
+
 	it("rejects external displays with matching dimensions", () => {
 		expect(isLikelyNotchedMacBookDisplay(display(1512, 982, 2, false))).toBe(
 			false,


### PR DESCRIPTION
Anchor the notch tray to the display top so it covers the camera housing correctly. Add coverage for scaled MacBook resolutions and reject non-notched display aspect ratios.
