### PR TITLE
Fix project dialog connection jitter

### DIFF
--- a/apps/renderer/src/components/project-setup-dialog.tsx
+++ b/apps/renderer/src/components/project-setup-dialog.tsx
@@ -96,6 +96,9 @@ export function ProjectSetupDialog({
 	const initializeCatalog = useEnvironmentCatalogStore(
 		(state) => state.initialize,
 	);
+	const retryEnvironment = useEnvironmentCatalogStore(
+		(state) => state.retryEnvironment,
+	);
 	const [mode, setMode] = useState<ProjectSetupMode>(initialMode);
 	const [environmentId, setEnvironmentId] = useState(
 		initialEnvironmentId ?? getLocalEnvironmentId(),
@@ -109,7 +112,11 @@ export function ProjectSetupDialog({
 	const [repos, setRepos] = useState<ReadonlyArray<GithubRepoSummary>>([]);
 	const [ghAuthenticated, setGhAuthenticated] = useState(false);
 	const [loadingRepos, setLoadingRepos] = useState(false);
+	const [reposError, setReposError] = useState(false);
+	const [reposRequest, setReposRequest] = useState(0);
 	const [submitting, setSubmitting] = useState(false);
+	const [retryingConnection, setRetryingConnection] = useState(false);
+	const [retryFailure, setRetryFailure] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -122,6 +129,9 @@ export function ProjectSetupDialog({
 		setName("");
 		setError(null);
 		setSubmitting(false);
+		setRetryingConnection(false);
+		setRetryFailure(null);
+		setReposError(false);
 	}, [open, initialMode, initialEnvironmentId, sourceUrl]);
 
 	useEffect(() => {
@@ -133,6 +143,7 @@ export function ProjectSetupDialog({
 			return;
 		let cancelled = false;
 		setLoadingRepos(true);
+		setReposError(false);
 		void listEnvironmentGithubRepos(environmentId)
 			.then((result) => {
 				if (cancelled) return;
@@ -142,7 +153,7 @@ export function ProjectSetupDialog({
 			.catch(() => {
 				if (!cancelled) {
 					setRepos([]);
-					setGhAuthenticated(false);
+					setReposError(true);
 				}
 			})
 			.finally(() => {
@@ -151,7 +162,7 @@ export function ProjectSetupDialog({
 		return () => {
 			cancelled = true;
 		};
-	}, [open, mode, environmentId, sourceUrl, connected.length]);
+	}, [open, mode, environmentId, sourceUrl, connected.length, reposRequest]);
 
 	useEffect(() => {
 		if (!open) return;
@@ -167,6 +178,14 @@ export function ProjectSetupDialog({
 	const selectedEnvironment = connected.find(
 		(entry) => entry.environmentId === environmentId,
 	);
+	const localEnvironment = entries.find(
+		(entry) => entry.connectionKind === "local",
+	);
+	const unavailableMessage =
+		retryFailure ??
+		localEnvironment?.error ??
+		catalogInitializationError ??
+		"Wait for the local workspace to finish loading.";
 	const local = environmentId === getLocalEnvironmentId();
 	const projectName =
 		mode === "clone" ? (sourceName ?? cloneName(url)) : name.trim();
@@ -213,6 +232,20 @@ export function ProjectSetupDialog({
 	const handleOpenChange = (next: boolean): void => {
 		if (!next && submitting) return;
 		onOpenChange(next);
+	};
+
+	const retryConnection = async (): Promise<void> => {
+		if (retryingConnection) return;
+		setRetryingConnection(true);
+		setRetryFailure(null);
+		try {
+			if (localEnvironment === undefined) await initializeCatalog();
+			else await retryEnvironment(localEnvironment.environmentId);
+		} catch (cause) {
+			setRetryFailure(cause instanceof Error ? cause.message : String(cause));
+		} finally {
+			setRetryingConnection(false);
+		}
 	};
 
 	return (
@@ -279,20 +312,21 @@ export function ProjectSetupDialog({
 									This computer is unavailable.
 								</p>
 								<p className="mt-1 text-muted-foreground">
-									{catalogInitializationError ??
-										"Wait for the local workspace to finish loading."}
+									{unavailableMessage}
 								</p>
 								<Button
 									type="button"
 									variant="outline"
 									size="sm"
-									className="mt-2"
-									disabled={catalogInitializing}
+									className="mt-2 min-w-28"
+									disabled={catalogInitializing || retryingConnection}
 									onClick={() => {
-										void initializeCatalog().catch(() => undefined);
+										void retryConnection();
 									}}
 								>
-									{catalogInitializing ? "Retrying…" : "Retry connection"}
+									{catalogInitializing || retryingConnection
+										? "Retrying…"
+										: "Retry connection"}
 								</Button>
 							</div>
 						) : null}
@@ -353,12 +387,30 @@ export function ProjectSetupDialog({
 									</div>
 								)}
 								{sourceUrl === undefined &&
-								(loadingRepos || repos.length > 0 || !ghAuthenticated) ? (
-									<div className="max-h-28 overflow-y-auto rounded-lg border border-border">
+								(loadingRepos ||
+									reposError ||
+									repos.length > 0 ||
+									!ghAuthenticated) ? (
+									<div className="max-h-28 min-h-11 overflow-y-auto rounded-lg border border-border">
 										{loadingRepos ? (
 											<p className="p-3 text-xs text-muted-foreground">
 												Loading repositories…
 											</p>
+										) : reposError ? (
+											<div className="flex min-h-11 items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
+												<span className="min-w-0 flex-1">
+													GitHub is unavailable. You can still paste a
+													repository URL.
+												</span>
+												<Button
+													type="button"
+													variant="outline"
+													size="sm"
+													onClick={() => setReposRequest((value) => value + 1)}
+												>
+													Retry
+												</Button>
+											</div>
 										) : repos.length > 0 ? (
 											repos.map((repo) => (
 												<button

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -571,7 +571,16 @@ function SidebarFooter() {
  * optional, so this is the primary place to discover sign-in after onboarding.
  */
 function SidebarAccount() {
-	const { isSignedIn, user, name, signingIn, signIn, signOut } = useAuth();
+	const {
+		isSignedIn,
+		isLoading,
+		isUnavailable,
+		user,
+		name,
+		signingIn,
+		signIn,
+		signOut,
+	} = useAuth();
 	const setView = useUiStore((s) => s.setView);
 	const setSettingsSection = useUiStore((s) => s.setSettingsSection);
 	const refreshUsageLimits = useUsageLimitsStore((s) => s.refresh);
@@ -641,10 +650,16 @@ function SidebarAccount() {
 									{initial}
 								</AvatarFallback>
 							</Avatar>
+						) : isLoading ? (
+							<HugeiconsIcon icon={UserCircleIcon} className="size-3.5" />
 						) : (
 							<HugeiconsIcon icon={Login03Icon} className="size-3.5" />
 						)}
-						{!isSignedIn ? (
+						{isUnavailable ? (
+							<span>Account unavailable</span>
+						) : isLoading ? (
+							<span>Loading account…</span>
+						) : !isSignedIn ? (
 							<span>{signingIn ? "Signing in…" : "Sign in"}</span>
 						) : nameIsEmail && user?.email ? (
 							<BlurredEmail email={user.email} />
@@ -655,7 +670,7 @@ function SidebarAccount() {
 				}
 			/>
 			<MenuPopup side="top" align="start" className="w-64">
-				{!isSignedIn ? (
+				{!isSignedIn && !isLoading ? (
 					<>
 						<MenuItem disabled={signingIn} onClick={() => void signIn()}>
 							<HugeiconsIcon icon={Login03Icon} />

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -1000,6 +1000,8 @@ function GeneralPane() {
 	const {
 		user,
 		isSignedIn,
+		isLoading,
+		isUnavailable,
 		signIn,
 		signOut,
 		signingIn,
@@ -1101,6 +1103,15 @@ function GeneralPane() {
 							Sign out
 						</Button>
 					</div>
+				) : isLoading ? (
+					<SettingsRow
+						title={isUnavailable ? "Account unavailable" : "Checking account…"}
+						description={
+							isUnavailable
+								? "Reconnect this computer to load the existing WorkOS session."
+								: "Loading the saved WorkOS session from this computer."
+						}
+					/>
 				) : (
 					<SettingsRow
 						title="Not signed in"

--- a/apps/renderer/src/hooks/use-auth.ts
+++ b/apps/renderer/src/hooks/use-auth.ts
@@ -12,6 +12,8 @@ export interface UseAuth {
 	readonly user: AuthUser | null;
 	readonly isSignedIn: boolean;
 	readonly isLoading: boolean;
+	/** The local computer failed before canonical WorkOS state could load. */
+	readonly isUnavailable: boolean;
 	readonly signingIn: boolean;
 	readonly error: string | null;
 	/** Effective display name (override → WorkOS name → email). */
@@ -42,11 +44,19 @@ export function useAuth(): UseAuth {
 	const signOut = useAuthStore((s) => s.signOut);
 
 	const user = state?._tag === "SignedIn" ? state.session.user : null;
+	const isUnavailable =
+		state === null &&
+		(auth.connection === "offline" ||
+			auth.connection === "failed" ||
+			auth.connection === "blocked-auth" ||
+			auth.connection === "update-required" ||
+			auth.connection === "revoked");
 
 	return {
 		user,
 		isSignedIn: state?._tag === "SignedIn",
 		isLoading: state === null,
+		isUnavailable,
 		signingIn,
 		error,
 		name: displayName.trim() || profileName(user),

--- a/apps/renderer/src/lib/git-workspace-client-bus.ts
+++ b/apps/renderer/src/lib/git-workspace-client-bus.ts
@@ -211,7 +211,23 @@ const makeInvalidatedDriver = <Data>(options: {
 				context.client["git.workspaceChanges"]({
 					folderId: ref.folderId,
 					worktreeId: ref.worktreeId,
-				}),
+				}).pipe(
+					// A plain folder, a removed checkout, or a missing Git binary is a
+					// resource-level capability failure. Materialize that state through
+					// the normal snapshot loader and keep the invalidation stream alive;
+					// escalating a typed Git error would disconnect every resource on the
+					// computer (including auth and the project catalog).
+					Stream.catchTags({
+						GitNotARepoError: () =>
+							Stream.concat(Stream.make({ revision: 0 }), Stream.never),
+						GitNotInstalledError: () =>
+							Stream.concat(Stream.make({ revision: 0 }), Stream.never),
+						GitCommandError: () =>
+							Stream.concat(Stream.make({ revision: 0 }), Stream.never),
+						GitFolderNotFoundError: () =>
+							Stream.concat(Stream.make({ revision: 0 }), Stream.never),
+					}),
+				),
 				() => Effect.sync(() => void schedule()),
 			).pipe(
 				Effect.andThen(

--- a/apps/renderer/src/store/environment-catalog.ts
+++ b/apps/renderer/src/store/environment-catalog.ts
@@ -1177,6 +1177,19 @@ export const useEnvironmentCatalogStore = create<EnvironmentCatalogState>(
 				await connectProfile(profileId);
 			},
 			retryEnvironment: async (environmentId) => {
+				const entry = get().entries.find(
+					(candidate) => candidate.environmentId === environmentId,
+				);
+				if (entry?.connectionKind === "local") {
+					const catalogKey = entryKey(entry);
+					const runtime = retainShell(catalogKey, environmentId, "connect");
+					patchEntry(catalogKey, { status: "connecting", error: null });
+					getRendererClientBus().retryConnection(
+						EnvironmentId.make(environmentId),
+					);
+					await runtime.lease.activate("connect");
+					return;
+				}
 				const environment = relayRecords.get(environmentId);
 				const local = get().entries.find(
 					(entry) => entry.connectionKind === "local",

--- a/apps/renderer/test/unit/git-workspace-client-bus.test.ts
+++ b/apps/renderer/test/unit/git-workspace-client-bus.test.ts
@@ -1,4 +1,9 @@
-import { EnvironmentId, FolderId, WorktreeId } from "@zuse/contracts";
+import {
+	EnvironmentId,
+	FolderId,
+	GitNotARepoError,
+	WorktreeId,
+} from "@zuse/contracts";
 import { Effect, Queue, Stream } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -153,5 +158,38 @@ describe("renderer Git workspace ClientBus adapter", () => {
 
 		expect(first).not.toEqual(otherEnvironment);
 		expect(first).not.toEqual(otherRoot);
+	});
+
+	it("keeps a non-Git folder failure scoped to its Git resource", async () => {
+		const notARepository = () =>
+			Effect.fail(new GitNotARepoError({ folderId }));
+		setSessionTimelineRpcClientForTest(
+			async () =>
+				({
+					"git.workspaceChanges": () =>
+						Stream.fail(new GitNotARepoError({ folderId })),
+					"git.status": notARepository,
+					"git.changes": notARepository,
+					"git.prState": notARepository,
+					"git.reviewSummary": notARepository,
+					"git.reviewPatches": () => Stream.never,
+					"git.prDetails": notARepository,
+				}) as never,
+		);
+
+		const retained = retainGitWorkspace(ref);
+		await waitUntil(
+			() => getRendererClientBus().snapshot(retained.key).data !== null,
+		);
+
+		expect(getRendererClientBus().snapshot(retained.key)).toMatchObject({
+			connection: "connected",
+			sync: "live",
+			data: {
+				noRepository: true,
+				error: { tag: "GitNotARepoError" },
+			},
+		});
+		retained.lease.release();
 	});
 });


### PR DESCRIPTION
## Summary
- keep typed Git/project failures scoped to the affected Git resource instead of disconnecting the whole local computer
- preserve truthful WorkOS loading/unavailable states and make local-computer Retry reconnect the live runtime
- stabilize Add Project during failures and show a fixed GitHub-unavailable state with Retry when repository discovery is down

## Diagnostics
The attached affected-machine diagnostics showed repeated `GitNotARepoError` failures from `git.workspaceChanges` followed by interruptions of project, chat, and WorkOS streams. The screen recording showed the resulting computer-picker churn, dialog jitter, and misleading Sign in state.

## Validation
- `bun run test:unit -- git-workspace-client-bus.test.ts environment-catalog.test.ts` from `apps/renderer` (102 files, 472 tests passed)
- `bun run check-types` (35-package workspace passed)
- targeted Biome checks on all changed files
- `bun run build` from `apps/desktop` (bundle and main startup smoke passed)

## Lint note
`bun run lint` remains blocked by the repository's existing Biome backlog outside this diff; all changed files pass Biome.
