### PR TITLE
Release v0.20.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.5]
+
+### Fixed
+- Cloud Workspace checkout now activates subscriptions reliably and automatically grants access to signed-in accounts that purchased through a checkout link
+- Cloud workspaces no longer stop during startup when Codex usage lookup times out
+- Local projects, chats, and saved WorkOS account state no longer disappear when an individual project has a Git error; the local computer remains connected
+- Add Project stays visually stable during GitHub outages, explains that GitHub is unavailable, preserves manual repository URLs, and provides scoped Retry actions
+- The notch tray now detects scaled MacBook displays and aligns with the physical camera housing
+
 ## [0.20.4]
 
 ### Changed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.4",
+	"version": "0.20.5",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.20.5",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Cloud Workspace checkout now activates subscriptions reliably and automatically grants access to signed-in accounts that purchased through a checkout link",
+          "Cloud workspaces no longer stop during startup when Codex usage lookup times out",
+          "Local projects, chats, and saved WorkOS account state no longer disappear when an individual project has a Git error; the local computer remains connected",
+          "Add Project stays visually stable during GitHub outages, explains that GitHub is unavailable, preserves manual repository URLs, and provides scoped Retry actions",
+          "The notch tray now detects scaled MacBook displays and aligns with the physical camera housing"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.4",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.4",
+      "version": "0.20.5",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.5 with release notes grouped by user-visible outcome.

### Fixed
- Cloud Workspace checkout now activates subscriptions reliably and automatically grants access to signed-in accounts that purchased through a checkout link
- Cloud workspaces no longer stop during startup when Codex usage lookup times out
- Local projects, chats, and saved WorkOS account state no longer disappear when an individual project has a Git error; the local computer remains connected
- Add Project stays visually stable during GitHub outages, explains that GitHub is unavailable, preserves manual repository URLs, and provides scoped Retry actions
- The notch tray now detects scaled MacBook displays and aligns with the physical camera housing

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.20.5 after this PR lands.

