### PR TITLE
Fix complete chat history streaming

### DIFF
--- a/apps/mobile/src/store/messages.ts
+++ b/apps/mobile/src/store/messages.ts
@@ -159,7 +159,7 @@ const publishTimeline = (liveKey: string, retained: RetainedTimeline): void => {
 				);
 				return {
 					...state,
-					[liveKey]: [...durable, ...pending].slice(-500),
+					[liveKey]: [...durable, ...pending],
 				};
 			});
 			patchQueue(liveKey, projection.queue.items);

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -43,7 +43,6 @@ import {
 	useSessionCommandErrors,
 } from "../lib/session-actions.ts";
 import { timelineReadingPositionStore } from "../lib/session-timeline-cache.ts";
-import { loadOlderSessionMessages } from "../lib/session-timeline-client-bus.ts";
 import { useRendererSessionTimeline } from "../lib/session-timeline-hooks.ts";
 import {
 	resolveInitialTimelineTarget,
@@ -327,10 +326,6 @@ export function ChatView({
 			setHasOutOfViewUpdates(true);
 		}
 	}, [endInset]);
-	const loadOlderMessages = useCallback(() => {
-		void loadOlderSessionMessages(sessionRef).catch(() => undefined);
-	}, [sessionRef]);
-
 	useEffect(() => {
 		let cancelled = false;
 		initializedSessionRef.current = null;
@@ -709,8 +704,6 @@ export function ChatView({
 								maintainVisibleContentPosition={{ data: true, size: true }}
 								contentInsetEndAdjustment={endInset}
 								onScroll={handleScroll}
-								onStartReached={loadOlderMessages}
-								onStartReachedThreshold={0.25}
 								className="h-full min-h-0 w-full flex-1 overflow-x-hidden pr-4 outline-none [overflow-anchor:none]"
 								data-pane="chat"
 								tabIndex={-1}

--- a/apps/renderer/src/lib/cloud-workspaces.ts
+++ b/apps/renderer/src/lib/cloud-workspaces.ts
@@ -43,6 +43,7 @@ import {
 } from "../lib/session-timeline-cache.ts";
 import {
 	addOptimisticSessionMessage,
+	completeOlderSessionMessages,
 	registerEnvironmentActivation,
 	registerSessionTimelineCheckpointSynchronizer,
 	registerSessionTimelineOlderPageSynchronizer,
@@ -134,6 +135,18 @@ const registerCloudEnvironmentResolver = (summary: CloudChatSummary): void => {
 				payload.cursor.version !== checkpoint.metadata.cursor.version
 			)
 				throw new Error("Cloud transcript checkpoint metadata mismatch");
+			if (
+				current.connection === "dormant" &&
+				payload.projection.olderMessageSequence != null
+			) {
+				// Let ClientBus publish the recent checkpoint first, then complete its
+				// canonical projection automatically from encrypted storage pages.
+				setTimeout(() => {
+					void completeOlderSessionMessages(ref).catch((cause) => {
+						useCloudChatsStore.setState({ error: formatError(cause) });
+					});
+				}, 0);
+			}
 			return {
 				data: payload.projection,
 				cursor: payload.cursor,

--- a/apps/renderer/src/lib/session-timeline-client-bus.ts
+++ b/apps/renderer/src/lib/session-timeline-client-bus.ts
@@ -126,7 +126,8 @@ class RendererTimelinePersistence implements ResourcePersistence {
 		if (
 			ref === null ||
 			sessionTimelineCache === null ||
-			value.cursor === null
+			value.cursor === null ||
+			(value.data as SessionTimelineProjection).olderMessageSequence != null
 		) {
 			return;
 		}
@@ -1250,7 +1251,7 @@ export const loadOlderSessionMessages = (
 		const applied = bus.update(key, {
 			expectedGeneration,
 			expectedCursor,
-			persist: true,
+			persist: page.olderMessageSequence === null,
 			update: (projection) => {
 				// A prior page can change this cursor without changing the stream
 				// cursor. Never apply a response to a different pagination head.
@@ -1284,6 +1285,40 @@ export const loadOlderSessionMessages = (
 	};
 	void request.then(clear, clear);
 	return request;
+};
+
+export const completeOlderSessionMessages = async (
+	ref: SessionRef,
+	options?: {
+		readonly maxAttempts?: number;
+		readonly retryDelay?: (attempt: number) => Promise<void>;
+	},
+): Promise<void> => {
+	const maxAttempts = options?.maxAttempts ?? 10;
+	const retryDelay =
+		options?.retryDelay ??
+		((attempt: number) =>
+			new Promise<void>((resolve) => {
+				setTimeout(resolve, Math.min(4_000, 100 * 2 ** attempt));
+			}));
+	let attempt = 0;
+	for (;;) {
+		try {
+			const result = await loadOlderSessionMessages(ref);
+			if (result.applied) {
+				attempt = 0;
+				if (!result.hasMore) return;
+				continue;
+			}
+		} catch (cause) {
+			if (attempt + 1 >= maxAttempts) throw cause;
+		}
+		if (attempt + 1 >= maxAttempts) {
+			throw new Error("Cloud transcript history remained unavailable");
+		}
+		await retryDelay(attempt);
+		attempt += 1;
+	}
 };
 
 export const dispatchSessionCommand = <Payload, Result>(input: {

--- a/apps/renderer/test/unit/session-timeline-client-bus.test.ts
+++ b/apps/renderer/test/unit/session-timeline-client-bus.test.ts
@@ -18,6 +18,7 @@ import {
 import { Effect, Queue, Stream } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	completeOlderSessionMessages,
 	getRendererClientBus,
 	loadOlderSessionMessages,
 	registerEnvironmentActivationForTest,
@@ -514,6 +515,7 @@ describe("renderer session timeline ClientBus adapter", () => {
 				pageCalls += 1;
 				expect(cursor).toEqual({ epoch: "r2-page", version: 8 });
 				expect(beforeSequence).toBe(20);
+				if (pageCalls === 1) return null;
 				return { messages: [older], olderMessageSequence: null };
 			},
 		);
@@ -523,12 +525,12 @@ describe("renderer session timeline ClientBus adapter", () => {
 				getRendererClientBus().snapshot(retained.key).origin === "checkpoint",
 		);
 
-		await expect(loadOlderSessionMessages(ref)).resolves.toEqual({
-			applied: true,
-			loaded: 1,
-			hasMore: false,
-		});
-		expect(pageCalls).toBe(1);
+		await expect(
+			completeOlderSessionMessages(ref, {
+				retryDelay: async () => undefined,
+			}),
+		).resolves.toBeUndefined();
+		expect(pageCalls).toBe(2);
 		expect(getRendererClientBus().snapshot(retained.key)).toMatchObject({
 			connection: "dormant",
 			data: { messages: [older], olderMessageSequence: null },

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -1181,6 +1181,20 @@ const SessionEvents = MemoizeRpcs.toLayerHandler(
 										version: frame.throughVersion,
 									},
 									olderMessageSequence: frame.olderMessageSequence,
+									totalMessageCount: frame.totalMessageCount,
+								};
+							}
+							if (frame.kind === "snapshot-chunk") {
+								return {
+									kind: "snapshot-chunk",
+									sessionId,
+									throughVersion: frame.throughVersion,
+									messages: frame.messages,
+									olderMessageSequence: frame.olderMessageSequence,
+									cursor: {
+										epoch: frame.streamEpoch,
+										version: frame.throughVersion,
+									},
 								};
 							}
 							if (frame.kind === "synchronized") {

--- a/packages/client-runtime/src/session-timeline-cache.ts
+++ b/packages/client-runtime/src/session-timeline-cache.ts
@@ -5,7 +5,7 @@ import {
 import { Result, Schema } from "effect";
 import { resourceRefKey, type SessionRef } from "./resource-ref.js";
 
-export const SESSION_TIMELINE_CACHE_SCHEMA_VERSION = 3;
+export const SESSION_TIMELINE_CACHE_SCHEMA_VERSION = 4;
 
 const EncodedSessionRef = Schema.Struct({
 	environmentId: Schema.String,
@@ -17,6 +17,18 @@ const EncodedSessionTimelineCacheEntryV2 = Schema.Struct({
 	sessionId: Schema.String,
 	ref: EncodedSessionRef,
 	appliedVersion: Schema.Number,
+	projection: SessionTimelineProjection,
+	savedAt: Schema.Number,
+	accessedAt: Schema.Number,
+	estimatedBytes: Schema.Number,
+});
+
+const EncodedSessionTimelineCacheEntryV3 = Schema.Struct({
+	schemaVersion: Schema.Literal(3),
+	/** IndexedDB keyPath retained across cache schema upgrades. */
+	sessionId: Schema.String,
+	ref: EncodedSessionRef,
+	cursor: SessionStreamCursor,
 	projection: SessionTimelineProjection,
 	savedAt: Schema.Number,
 	accessedAt: Schema.Number,
@@ -70,19 +82,39 @@ export const decodeSessionTimelineCacheEntry = (
 		value,
 	);
 	if (Result.isSuccess(current)) {
+		if (current.success.projection.olderMessageSequence != null) {
+			throw new Error("Incomplete session timeline cache entry");
+		}
 		const { sessionId: _storageKey, ...entry } = current.success;
 		return entry as SessionTimelineCacheEntry;
+	}
+	const previous = Schema.decodeUnknownResult(
+		EncodedSessionTimelineCacheEntryV3,
+	)(value);
+	if (Result.isSuccess(previous)) {
+		if (previous.success.projection.olderMessageSequence != null) {
+			throw new Error("Incomplete session timeline cache entry");
+		}
+		const { sessionId: _storageKey, ...entry } = previous.success;
+		return {
+			...entry,
+			schemaVersion: SESSION_TIMELINE_CACHE_SCHEMA_VERSION,
+		} as SessionTimelineCacheEntry;
 	}
 	const {
 		sessionId: _storageKey,
 		appliedVersion,
 		...legacy
 	} = Schema.decodeUnknownSync(EncodedSessionTimelineCacheEntryV2)(value);
-	return {
+	const migrated = {
 		...legacy,
 		schemaVersion: SESSION_TIMELINE_CACHE_SCHEMA_VERSION,
 		cursor: { epoch: "legacy", version: appliedVersion },
 	} as SessionTimelineCacheEntry;
+	if (migrated.projection.olderMessageSequence != null) {
+		throw new Error("Incomplete session timeline cache entry");
+	}
+	return migrated;
 };
 
 export const makeSessionTimelineCacheEntry = (input: {

--- a/packages/client-runtime/src/session-timeline-driver.ts
+++ b/packages/client-runtime/src/session-timeline-driver.ts
@@ -88,6 +88,7 @@ export const makeSessionTimelineResourceDriver = <
 			active = true;
 			const ref = context.key.ref;
 			let state = restoreSessionTimelineState(context.data, context.cursor);
+			let showingProgressiveSnapshot = false;
 			const cachedTurnMayBeStale =
 				state.projection !== null &&
 				(state.projection.currentTurn !== null ||
@@ -128,7 +129,10 @@ export const makeSessionTimelineResourceDriver = <
 					sessionId: ref.sessionId,
 					afterVersion: state.cursor?.version,
 					streamEpoch: state.cursor?.epoch,
-					hasProjection: state.projection !== null && !cachedTurnMayBeStale,
+					hasProjection:
+						state.projection !== null &&
+						state.projection.olderMessageSequence == null &&
+						!cachedTurnMayBeStale,
 				}),
 				(frame) =>
 					Effect.sync(() => {
@@ -145,8 +149,16 @@ export const makeSessionTimelineResourceDriver = <
 						const previous = state;
 						state = reduceSessionTimelineFrame(state, frame);
 						if (state === previous) return;
+						if (
+							frame.kind === "snapshot" &&
+							frame.totalMessageCount !== undefined &&
+							frame.totalMessageCount > frame.projection.messages.length
+						) {
+							showingProgressiveSnapshot = true;
+						}
 						const silentCatchUp =
 							catchingUp &&
+							!showingProgressiveSnapshot &&
 							frame.kind !== "synchronized" &&
 							state.phase !== "stale";
 						if (frame.kind === "synchronized") catchingUp = false;
@@ -158,7 +170,8 @@ export const makeSessionTimelineResourceDriver = <
 						const resetEpoch =
 							frame.kind === "snapshot" && previous.resetEpoch !== null;
 						const persist =
-							frame.kind === "synchronized" || isSettlement(frame);
+							(frame.kind === "synchronized" && state.phase === "live") ||
+							isSettlement(frame);
 						const accepted = context.emit({
 							...(dataChanged && state.projection !== null
 								? { data: state.projection }

--- a/packages/client-runtime/src/session-timeline.ts
+++ b/packages/client-runtime/src/session-timeline.ts
@@ -29,6 +29,8 @@ export type SessionTimelineState = Readonly<{
 	phase: SessionTimelinePhase;
 	error: string | null;
 	optimistic: OptimisticOverlay;
+	/** Declared full-history count while a snapshot series is assembling. */
+	snapshotMessageCount: number | null;
 }>;
 
 export const emptySessionTimelineState = (): SessionTimelineState => ({
@@ -39,6 +41,7 @@ export const emptySessionTimelineState = (): SessionTimelineState => ({
 	phase: "empty",
 	error: null,
 	optimistic: { messages: {} },
+	snapshotMessageCount: null,
 });
 
 export const restoreSessionTimelineState = (
@@ -217,7 +220,28 @@ export const reduceSessionTimelineFrame = (
 			appliedVersion: cursor.version,
 			phase: "synchronizing",
 			error: null,
+			snapshotMessageCount: frame.totalMessageCount ?? null,
 		};
+	}
+	if (frame.kind === "snapshot-chunk") {
+		const cursor = cursorForFrame(state, frame.throughVersion, frame.cursor);
+		if (
+			state.projection === null ||
+			state.cursor === null ||
+			state.cursor.epoch !== cursor.epoch ||
+			state.cursor.version !== cursor.version ||
+			cursor.version !== frame.throughVersion
+		) {
+			return invalidCursorState(
+				state,
+				`Snapshot chunk for ${cursor.epoch}:${frame.throughVersion} arrived without its snapshot`,
+			);
+		}
+		return prependSessionTimelineMessages(
+			state,
+			frame.messages,
+			frame.olderMessageSequence,
+		);
 	}
 	if (frame.kind === "synchronized") {
 		const cursor = cursorForFrame(state, frame.throughVersion, frame.cursor);
@@ -234,7 +258,21 @@ export const reduceSessionTimelineFrame = (
 				`Synchronization through ${cursor.epoch}:${frame.throughVersion} arrived at ${state.cursor?.epoch ?? "none"}:${state.cursor?.version ?? 0}`,
 			);
 		}
-		return { ...state, phase: "live", error: null };
+		if (
+			state.snapshotMessageCount !== null &&
+			state.projection.messages.length !== state.snapshotMessageCount
+		) {
+			return invalidCursorState(
+				state,
+				`Snapshot declared ${state.snapshotMessageCount} messages but assembled ${state.projection.messages.length}`,
+			);
+		}
+		return {
+			...state,
+			phase: "live",
+			error: null,
+			snapshotMessageCount: null,
+		};
 	}
 	if (frame.kind === "reset-required") {
 		if (state.resetEpoch === frame.cursor.epoch) return state;

--- a/packages/client-runtime/test/unit/session-timeline-driver.test.ts
+++ b/packages/client-runtime/test/unit/session-timeline-driver.test.ts
@@ -91,6 +91,66 @@ const harness = <Data>(input: {
 };
 
 describe("shared session timeline resource driver", () => {
+	it("renders the recent tail immediately while automatic history chunks complete", async () => {
+		const frames = Effect.runSync(Queue.unbounded<SessionTimelineFrame>());
+		const test = harness({
+			key,
+			client: { "session.events": () => Stream.fromQueue(frames) },
+			data: null,
+			cursor: null,
+		});
+		const driver = makeSessionTimelineResourceDriver({
+			reportFailure: () => undefined,
+		});
+		driver.start(test.context);
+		const recent = Message.make({
+			id: MessageId.make("message-recent"),
+			sessionId,
+			role: "assistant",
+			content: { _tag: "assistant", text: "recent" },
+			createdAt: new Date(2),
+		});
+		const older = Message.make({
+			id: MessageId.make("message-older"),
+			sessionId,
+			role: "user",
+			content: { _tag: "user", text: "older" },
+			createdAt: new Date(1),
+		});
+		Queue.offerUnsafe(frames, {
+			kind: "snapshot",
+			sessionId,
+			throughVersion: 2,
+			cursor: { epoch: "progressive", version: 2 },
+			projection: {
+				...projection,
+				messages: [recent],
+				olderMessageSequence: 2,
+			},
+			totalMessageCount: 2,
+		});
+		await waitUntil(() => test.view().data?.messages.length === 1);
+		expect(test.updates.at(-1)).toMatchObject({ persist: false });
+		Queue.offerUnsafe(frames, {
+			kind: "snapshot-chunk",
+			sessionId,
+			throughVersion: 2,
+			cursor: { epoch: "progressive", version: 2 },
+			messages: [older],
+			olderMessageSequence: null,
+		});
+		Queue.offerUnsafe(frames, {
+			kind: "synchronized",
+			sessionId,
+			throughVersion: 2,
+			cursor: { epoch: "progressive", version: 2 },
+		});
+		await waitUntil(() => test.view().sync === "live");
+		expect(test.view().data?.messages).toEqual([older, recent]);
+		expect(test.updates.at(-1)).toMatchObject({ persist: true });
+		driver.stop();
+	});
+
 	it("requests an authoritative snapshot for a cached active turn", async () => {
 		const requests: unknown[] = [];
 		const driver = makeSessionTimelineResourceDriver({
@@ -113,6 +173,33 @@ describe("shared session timeline resource driver", () => {
 		expect(requests[0]).toMatchObject({
 			afterVersion: 454,
 			streamEpoch: "cached",
+			hasProjection: false,
+		});
+		driver.stop();
+	});
+
+	it("requests an authoritative snapshot for an incomplete cached transcript", async () => {
+		const requests: unknown[] = [];
+		const driver = makeSessionTimelineResourceDriver({
+			reportFailure: () => undefined,
+		});
+		const test = harness({
+			key,
+			client: {
+				"session.events": (input) => {
+					requests.push(input);
+					return Stream.never;
+				},
+			},
+			data: { ...projection, olderMessageSequence: 20 },
+			cursor: { epoch: "cached-partial", version: 454 },
+		});
+
+		driver.start(test.context);
+		await waitUntil(() => requests.length === 1);
+		expect(requests[0]).toMatchObject({
+			afterVersion: 454,
+			streamEpoch: "cached-partial",
 			hasProjection: false,
 		});
 		driver.stop();

--- a/packages/client-runtime/test/unit/session-timeline.test.ts
+++ b/packages/client-runtime/test/unit/session-timeline.test.ts
@@ -164,6 +164,86 @@ describe("session timeline reducer", () => {
 		expect(live.phase).toBe("live");
 	});
 
+	it("completes a transcript from automatic snapshot chunks before going live", () => {
+		const newest = Message.make({
+			id: MessageId.make("message-262"),
+			sessionId,
+			role: "assistant",
+			content: { _tag: "assistant", text: "latest" },
+			createdAt: new Date(262),
+		});
+		const original = Message.make({
+			id: MessageId.make("message-1"),
+			sessionId,
+			role: "user",
+			content: { _tag: "user", text: "original prompt" },
+			createdAt: new Date(1),
+		});
+		const snap = reduceSessionTimelineFrame(emptySessionTimelineState(), {
+			kind: "snapshot",
+			sessionId,
+			throughVersion: 300,
+			cursor: cursor("epoch-complete", 300),
+			totalMessageCount: 262,
+			olderMessageSequence: 262,
+			projection: SessionTimelineProjection.make({
+				...projection,
+				messages: [newest],
+			}),
+		});
+		const complete = reduceSessionTimelineFrame(snap, {
+			kind: "snapshot-chunk",
+			sessionId,
+			throughVersion: 300,
+			cursor: cursor("epoch-complete", 300),
+			messages: [
+				original,
+				...Array.from({ length: 260 }, (_, index) =>
+					Message.make({
+						id: MessageId.make(`message-${index + 2}`),
+						sessionId,
+						role: "assistant",
+						content: { _tag: "assistant", text: `message ${index + 2}` },
+						createdAt: new Date(index + 2),
+					}),
+				),
+			],
+			olderMessageSequence: null,
+		});
+		const live = reduceSessionTimelineFrame(complete, {
+			kind: "synchronized",
+			sessionId,
+			throughVersion: 300,
+			cursor: cursor("epoch-complete", 300),
+		});
+
+		expect(live.phase).toBe("live");
+		expect(live.projection?.messages).toHaveLength(262);
+		expect(live.projection?.messages.at(0)?.id).toBe("message-1");
+		expect(live.projection?.messages.at(-1)?.id).toBe("message-262");
+		expect(live.projection?.olderMessageSequence).toBeNull();
+	});
+
+	it("rejects a synchronization barrier before every declared message arrives", () => {
+		const snapshot = reduceSessionTimelineFrame(emptySessionTimelineState(), {
+			kind: "snapshot",
+			sessionId,
+			throughVersion: 2,
+			cursor: { epoch: "epoch-incomplete", version: 2 },
+			projection,
+			totalMessageCount: 2,
+		});
+		const incomplete = reduceSessionTimelineFrame(snapshot, {
+			kind: "synchronized",
+			sessionId,
+			throughVersion: 2,
+			cursor: { epoch: "epoch-incomplete", version: 2 },
+		});
+
+		expect(incomplete.phase).toBe("stale");
+		expect(incomplete.error).toMatch(/declared 2 messages/i);
+	});
+
 	it("rejects gaps without advancing past missing durable state", () => {
 		const snap = reduceSessionTimelineFrame(emptySessionTimelineState(), {
 			kind: "snapshot",
@@ -454,9 +534,40 @@ describe("session timeline cache", () => {
 			estimatedBytes: 42,
 		});
 
-		expect(decoded.schemaVersion).toBe(3);
+		expect(decoded.schemaVersion).toBe(4);
 		expect(decoded.cursor).toEqual(cursor("legacy", 7));
 		expect(decoded.ref).toEqual({ environmentId: "local", sessionId });
+	});
+
+	it("rejects an incomplete legacy cache projection", () => {
+		expect(() =>
+			decodeSessionTimelineCacheEntry({
+				schemaVersion: 3,
+				sessionId: "session:local:session-1",
+				ref: { environmentId: "local", sessionId },
+				cursor: cursor("legacy-partial", 7),
+				projection: { ...projection, olderMessageSequence: 20 },
+				savedAt: 40,
+				accessedAt: 41,
+				estimatedBytes: 42,
+			}),
+		).toThrow(/incomplete/i);
+	});
+
+	it("rejects an incomplete current cache projection", () => {
+		const entry = makeSessionTimelineCacheEntry({
+			ref: { environmentId: EnvironmentId.make("local"), sessionId },
+			cursor: cursor("current-partial", 8),
+			projection: SessionTimelineProjection.make({
+				...projection,
+				olderMessageSequence: 20,
+			}),
+			now: 42,
+		});
+
+		expect(() =>
+			decodeSessionTimelineCacheEntry(encodeSessionTimelineCacheEntry(entry)),
+		).toThrow(/incomplete/i);
 	});
 
 	it("rejects entries from an unsupported schema", () => {

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -541,6 +541,17 @@ export const SessionTimelineFrame = Schema.Union([
 		cursor: Schema.optional(SessionStreamCursor),
 		/** Sequence immediately before the oldest included message, if any. */
 		olderMessageSequence: Schema.optional(Schema.NullOr(Schema.Number)),
+		/** Complete durable message count represented by this snapshot series. */
+		totalMessageCount: Schema.optional(Schema.Number),
+	}),
+	Schema.Struct({
+		kind: Schema.Literal("snapshot-chunk"),
+		sessionId: SessionId,
+		throughVersion: Schema.Number,
+		messages: Schema.Array(Message),
+		/** Sequence immediately before the oldest included message, if any. */
+		olderMessageSequence: Schema.NullOr(Schema.Number),
+		cursor: Schema.optional(SessionStreamCursor),
 	}),
 	Schema.Struct({
 		kind: Schema.Literal("event"),

--- a/packages/contracts/test/unit/schema.test.ts
+++ b/packages/contracts/test/unit/schema.test.ts
@@ -327,6 +327,17 @@ describe("Session round-trip", () => {
 });
 
 describe("Session timeline frame round-trip", () => {
+	it("round-trips an automatic historical snapshot chunk", () => {
+		roundTrip(SessionTimelineFrame, {
+			kind: "snapshot-chunk",
+			sessionId: "session-restored",
+			throughVersion: 3,
+			cursor: { epoch: "restore-2", version: 3 },
+			messages: [],
+			olderMessageSequence: null,
+		});
+	});
+
 	it("keeps reset cursor and head version together", () => {
 		roundTrip(SessionTimelineFrame, {
 			kind: "reset-required",

--- a/packages/domain/src/engine/session-domain.ts
+++ b/packages/domain/src/engine/session-domain.ts
@@ -1,5 +1,6 @@
 import type {
 	AgentSessionId,
+	Message,
 	SessionId,
 	SessionTimelineProjection,
 } from "@zuse/contracts";
@@ -8,6 +9,7 @@ import {
 	Crypto,
 	Effect,
 	Layer,
+	Option,
 	PubSub,
 	Result,
 	Schedule,
@@ -60,6 +62,14 @@ export type SessionSynchronizationRecord =
 			readonly streamEpoch: string;
 			readonly throughVersion: number;
 			readonly projection: SessionTimelineProjection;
+			readonly olderMessageSequence: number | null;
+			readonly totalMessageCount: number;
+	  }
+	| {
+			readonly kind: "snapshot-chunk";
+			readonly streamEpoch: string;
+			readonly throughVersion: number;
+			readonly messages: readonly Message[];
 			readonly olderMessageSequence: number | null;
 	  }
 	| {
@@ -301,79 +311,119 @@ export const makeSessionDomain = Effect.fn("SessionDomain.make")(function* (
 				// one SQLite read snapshot. Otherwise a commit between the version read
 				// and projection read could put version N+1 data in a version N frame;
 				// the buffered N+1 event would then be applied twice by the client.
-				const { prefix, throughVersion } = yield* sql.withTransaction(
-					Effect.gen(function* () {
-						const throughVersion =
-							yield* dispatchStorage.currentStreamVersion(streamId);
-						const retainedVersion = afterVersion ?? 0;
-						const epochMismatch =
-							retainedEpoch !== undefined && retainedEpoch !== streamEpoch;
-						let needsSnapshot =
-							!hasProjection ||
-							afterVersion === undefined ||
-							epochMismatch ||
-							retainedVersion > throughVersion ||
-							throughVersion - retainedVersion > maxDeltaEvents;
-						let captured: readonly StoredEvent[] = [];
-						if (!needsSnapshot) {
-							captured = yield* dispatchStorage.eventsInVersionRange(
-								streamId,
-								retainedVersion,
-								throughVersion,
+				const { prefix, throughVersion, historyCursor } =
+					yield* sql.withTransaction(
+						Effect.gen(function* () {
+							const throughVersion =
+								yield* dispatchStorage.currentStreamVersion(streamId);
+							const retainedVersion = afterVersion ?? 0;
+							const epochMismatch =
+								retainedEpoch !== undefined && retainedEpoch !== streamEpoch;
+							let needsSnapshot =
+								!hasProjection ||
+								afterVersion === undefined ||
+								epochMismatch ||
+								retainedVersion > throughVersion ||
+								throughVersion - retainedVersion > maxDeltaEvents;
+							let captured: readonly StoredEvent[] = [];
+							if (!needsSnapshot) {
+								captured = yield* dispatchStorage.eventsInVersionRange(
+									streamId,
+									retainedVersion,
+									throughVersion,
+								);
+								needsSnapshot =
+									captured.reduce(
+										(total, record) =>
+											total +
+											new TextEncoder().encode(
+												JSON.stringify({
+													kind: "event",
+													streamEpoch,
+													record,
+												}),
+											).byteLength,
+										0,
+									) > maxDeltaBytes;
+							}
+							const prefix: SessionSynchronizationRecord[] = [];
+							let historyCursor: number | null = null;
+							if (epochMismatch || retainedVersion > throughVersion) {
+								prefix.push({
+									kind: "reset-required",
+									streamEpoch,
+									throughVersion,
+									reason: epochMismatch ? "restored" : "cursor-invalid",
+								});
+							}
+							if (needsSnapshot) {
+								const snapshot = yield* readSessionTimelineSnapshot(
+									sql,
+									streamId as SessionId,
+								);
+								prefix.push({
+									kind: "snapshot",
+									streamEpoch,
+									throughVersion,
+									...snapshot,
+								});
+								historyCursor = snapshot.olderMessageSequence;
+							} else {
+								prefix.push(
+									...captured
+										.filter((record) => record.streamVersion > retainedVersion)
+										.map((record) => ({
+											kind: "event" as const,
+											streamEpoch,
+											record,
+										})),
+								);
+							}
+							return { prefix, throughVersion, historyCursor };
+						}),
+					);
+				// Emit the newest bounded projection immediately. Older immutable rows
+				// follow page-by-page so long local and cloud transcripts keep a fast
+				// first paint without coupling correctness to viewport scrolling.
+				const history =
+					historyCursor === null
+						? Stream.empty
+						: Stream.paginate(historyCursor, (pageBeforeSequence) =>
+								readSessionTimelineMessagePage(
+									sql,
+									streamId as SessionId,
+									pageBeforeSequence,
+								).pipe(
+									Effect.flatMap((page) => {
+										if (
+											page.olderMessageSequence !== null &&
+											page.olderMessageSequence >= pageBeforeSequence
+										) {
+											return Effect.die(
+												new Error(
+													`Session ${streamId} history cursor did not advance`,
+												),
+											);
+										}
+										const record: SessionSynchronizationRecord = {
+											kind: "snapshot-chunk",
+											streamEpoch,
+											throughVersion,
+											messages: page.items.map(({ message }) => message),
+											olderMessageSequence: page.olderMessageSequence,
+										};
+										return Effect.succeed([
+											[record],
+											Option.fromNullOr(page.olderMessageSequence),
+										] as const);
+									}),
+								),
 							);
-							needsSnapshot =
-								captured.reduce(
-									(total, record) =>
-										total +
-										new TextEncoder().encode(
-											JSON.stringify({
-												kind: "event",
-												streamEpoch,
-												record,
-											}),
-										).byteLength,
-									0,
-								) > maxDeltaBytes;
-						}
-						const prefix: SessionSynchronizationRecord[] = [];
-						if (epochMismatch || retainedVersion > throughVersion) {
-							prefix.push({
-								kind: "reset-required",
-								streamEpoch,
-								throughVersion,
-								reason: epochMismatch ? "restored" : "cursor-invalid",
-							});
-						}
-						if (needsSnapshot) {
-							const snapshot = yield* readSessionTimelineSnapshot(
-								sql,
-								streamId as SessionId,
-							);
-							prefix.push({
-								kind: "snapshot",
-								streamEpoch,
-								throughVersion,
-								...snapshot,
-							});
-						} else {
-							prefix.push(
-								...captured
-									.filter((record) => record.streamVersion > retainedVersion)
-									.map((record) => ({
-										kind: "event" as const,
-										streamEpoch,
-										record,
-									})),
-							);
-						}
-						prefix.push({
-							kind: "synchronized",
-							streamEpoch,
-							throughVersion,
-						});
-						return { prefix, throughVersion };
-					}),
-				);
+				const synchronized = Stream.succeed<SessionSynchronizationRecord>({
+					kind: "synchronized",
+					streamEpoch,
+					throughVersion,
+				});
 				let liveVersion = throughVersion;
 				const tail = decodeDurableNotifications(
 					Stream.fromSubscription(durableSubscription),
@@ -402,7 +452,10 @@ export const makeSessionDomain = Effect.fn("SessionDomain.make")(function* (
 						record,
 					})),
 				);
-				return Stream.concat(Stream.fromIterable(prefix), tail);
+				return Stream.concat(
+					Stream.fromIterable(prefix),
+					Stream.concat(history, Stream.concat(synchronized, tail)),
+				);
 			}),
 		);
 

--- a/packages/domain/src/queries/session-timeline-snapshot.ts
+++ b/packages/domain/src/queries/session-timeline-snapshot.ts
@@ -46,6 +46,7 @@ interface QueueRow {
 export type SessionTimelineSnapshot = {
 	readonly projection: SessionTimelineProjection;
 	readonly olderMessageSequence: number | null;
+	readonly totalMessageCount: number;
 };
 
 export type SessionTimelineMessagePage = {
@@ -119,6 +120,10 @@ export const readSessionTimelineSnapshot = Effect.fn(
 		return yield* Effect.die("Session query existed without a timeline head");
 	}
 	const messagePage = yield* readSessionTimelineMessagePage(sql, sessionId);
+	const messageCountRows = yield* sql<{ readonly count: number }>`
+		SELECT COUNT(*) AS count FROM messages WHERE session_id = ${sessionId}
+	`;
+	const totalMessageCount = messageCountRows[0]?.count ?? 0;
 	const messages = [...messagePage.items];
 	const queueRows = yield* sql<QueueRow>`
 		SELECT id, input_json, queue_order, created_at, updated_at, ready
@@ -230,6 +235,7 @@ export const readSessionTimelineSnapshot = Effect.fn(
 			olderMessageSequence,
 		}),
 		olderMessageSequence,
+		totalMessageCount,
 	};
 });
 

--- a/packages/domain/test/integration/engine/session-domain.test.ts
+++ b/packages/domain/test/integration/engine/session-domain.test.ts
@@ -510,6 +510,66 @@ describe("SessionDomain", () => {
 		).toEqual([1, 2]);
 	});
 
+	test("streams complete local history before the synchronization barrier", async () => {
+		const frames = await run(
+			Effect.gen(function* () {
+				yield* createDomainTestSchema();
+				const sql = yield* SqlClient.SqlClient;
+				yield* sql`
+					INSERT INTO chats (id, updated_at)
+					VALUES ('chat-1', '1970-01-01T00:00:00.000Z')
+				`;
+				const domain = yield* makeSessionDomain(sql, () =>
+					Effect.succeed("event-complete-history"),
+				);
+				yield* domain.dispatch({
+					commandId: "command-create-history",
+					streamId: "session-1",
+					command: createSessionCommand,
+				});
+				yield* Effect.forEach(
+					Array.from({ length: 262 }, (_, index) => index + 1),
+					(sequence) => sql`
+						INSERT INTO messages
+							(id, session_id, role, kind, content_json, parent_item_id,
+							 created_at, sequence)
+						VALUES
+							(${`message-${sequence}`}, 'session-1', 'assistant', 'assistant',
+							 ${JSON.stringify({ _tag: "assistant", text: `message ${sequence}` })},
+							 NULL, '2026-01-01T00:00:00.000Z', ${sequence})
+					`,
+					{ discard: true },
+				);
+				return [
+					...(yield* domain
+						.synchronizedEvents({
+							streamId: "session-1",
+							hasProjection: false,
+						})
+						.pipe(
+							Stream.takeUntil((frame) => frame.kind === "synchronized"),
+							Stream.runCollect,
+						)),
+				];
+			}),
+		);
+		const snapshot = frames[0];
+		expect(snapshot).toMatchObject({
+			kind: "snapshot",
+			totalMessageCount: 262,
+		});
+		const messages = frames.flatMap((frame) =>
+			frame.kind === "snapshot"
+				? frame.projection.messages
+				: frame.kind === "snapshot-chunk"
+					? frame.messages
+					: [],
+		);
+		expect(messages).toHaveLength(262);
+		expect(messages.at(-1)?.id).toBe("message-62");
+		expect(frames.at(-1)).toMatchObject({ kind: "synchronized" });
+	});
+
 	test("tails durable session events dispatched by another runtime", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "zuse-session-domain-sync-"));
 		const filename = join(directory, "shared.sqlite");


### PR DESCRIPTION
## Summary

- stream complete local and cloud chat history automatically in bounded snapshot chunks
- render the newest transcript tail first without relying on scroll-triggered pagination
- prevent partial timelines from being marked live or persisted in cache
- complete dormant cloud checkpoints from encrypted history pages with retry and surfaced failures
- retain full mobile message history instead of truncating it to 500 messages

## Root cause

Local snapshots were capped by both a 100-message page and a projection byte budget. Older history depended on viewport-triggered pagination, archived views had no equivalent completion path, and mobile applied an additional fixed-size slice. Partial cloud checkpoints could also be treated as complete at an equal stream cursor.

## Validation

- 103 focused tests passed
- Biome passed for all changed files
- renderer, mobile, server, contracts, domain, and client-runtime type checks passed
- two independent final reviews reported no remaining findings