### PR TITLE
Fix chat creation and workspace recovery regressions

### DIFF
--- a/apps/renderer/src/lib/chat-create-command-id.ts
+++ b/apps/renderer/src/lib/chat-create-command-id.ts
@@ -1,0 +1,10 @@
+import { CommandId } from "@zuse/contracts";
+
+/**
+ * A chat creation operation is durable across retries, but each explicit
+ * dispatch is a distinct immutable client command. Transport retries keep the
+ * returned id with their persisted command; a user or recovery retry calls
+ * this again and receives a fresh id for the same operation.
+ */
+export const nextChatCreateCommandId = (operationId: string): CommandId =>
+	CommandId.make(`chat-create:${operationId}:${crypto.randomUUID()}`);

--- a/apps/renderer/src/lib/session-actions.ts
+++ b/apps/renderer/src/lib/session-actions.ts
@@ -426,14 +426,12 @@ export const updateQueuedMessage = async (
 		);
 	} catch (cause) {
 		if (retryableFailure(ref, commandId)) return;
-		if (
-			isQueuedMessageNotFound(cause) &&
-			projectionFor(ref)?.queue.items.some((item) => item.id === queueId)
-		) {
-			await persistQueuedMessage(ref, queueId, input, {
-				ready: true,
-				providerId,
-			});
+		if (isQueuedMessageNotFound(cause)) {
+			// The queue stream may lag behind the server consuming or deleting this
+			// item. Not-found is authoritative convergence, not a provider failure:
+			// drop any stale optimistic row and never resurrect an already-run prompt.
+			updateQueue(ref, (items) => items.filter((item) => item.id !== queueId));
+			clearSessionCommandError(ref);
 			return;
 		}
 		if (previous !== undefined) {

--- a/apps/renderer/src/lib/session-timeline-client-bus.ts
+++ b/apps/renderer/src/lib/session-timeline-client-bus.ts
@@ -1383,12 +1383,17 @@ export const updateOptimisticSessionQueue = (
 	) => SessionTimelineProjection["queue"],
 ): boolean =>
 	rendererClientBus.overlay(sessionTimelineResourceKey(ref), {
+		initialData: emptyTimelineProjection(),
 		update: (projection) =>
 			SessionTimelineProjection.make({
 				...projection,
 				queue: update(projection.queue),
 			}),
 	});
+
+/** Restarts a retained provisional timeline after its session is acknowledged. */
+export const restartSessionTimeline = (ref: SessionRef): boolean =>
+	rendererClientBus.restart(sessionTimelineResourceKey(ref));
 
 export const retainSessionTimeline = (
 	ref: SessionRef,

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -18,6 +18,7 @@ import {
 	type WorktreeId,
 } from "@zuse/contracts";
 import { toastManager } from "../components/ui/toast.tsx";
+import { nextChatCreateCommandId } from "../lib/chat-create-command-id.ts";
 import {
 	cloudSummaryForChat,
 	optimisticallyUnarchiveCloudChat,
@@ -43,7 +44,10 @@ import {
 	sessionTimelineCache,
 	timelineReadingPositionStore,
 } from "../lib/session-timeline-cache.ts";
-import { getRendererClientBus } from "../lib/session-timeline-client-bus.ts";
+import {
+	getRendererClientBus,
+	restartSessionTimeline,
+} from "../lib/session-timeline-client-bus.ts";
 import { createAtomStore as create } from "../state/atom-store.ts";
 import { batchAtomUpdates } from "../state/registry.tsx";
 import { useArchivePreviewStore } from "./archive-preview.ts";
@@ -522,7 +526,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 				opts?.operationId ?? `create_${crypto.randomUUID()}`;
 			const initialPrompt = opts?.startupInput?.text.trim();
 			try {
-				const commandId = CommandId.make(`chat-create:${remoteOperationId}`);
+				const commandId = nextChatCreateCommandId(remoteOperationId);
 				const { result } = await dispatchChatCommand<unknown, ChatCreateResult>(
 					{
 						environmentId: targetEnvironmentId,
@@ -725,7 +729,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 		}
 		markRendererInteraction(initialSessionId, "first-atom-commit");
 		const environmentId = EnvironmentId.make(getActiveEnvironment());
-		const commandId = CommandId.make(`chat-create:${operationId}`);
+		const commandId = nextChatCreateCommandId(operationId);
 		let knownWorktreeId = optimisticWorktreeId;
 		try {
 			const workspacePolicy = await opts?.workspacePolicy;
@@ -811,6 +815,13 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 					),
 				},
 			}));
+			// Keep the pre-ack workspace card mounted until the worktree projection is
+			// hydrated. Clearing it first briefly exposes ChatView with an authoritative
+			// session but no worktree row, which mislabels the handoff as "Starting
+			// agent" even though workspace setup has only just completed.
+			if (chat.worktreeId !== null) {
+				await useWorktreesStore.getState().refresh(projectId);
+			}
 			// Land the new chat in front of the project's existing list and
 			// mark it active so the renderer immediately swaps to it.
 			set((s) => {
@@ -854,9 +865,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 						: s.selectedSessionByProject,
 				};
 			});
-			if (chat.worktreeId !== null) {
-				void useWorktreesStore.getState().refresh(projectId);
-			}
+			restartSessionTimeline({ environmentId, sessionId: initialSession.id });
 			return {
 				chatId: chat.id,
 				initialSessionId: initialSession.id,

--- a/apps/renderer/test/unit/chat-create-command-id.test.ts
+++ b/apps/renderer/test/unit/chat-create-command-id.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { nextChatCreateCommandId } from "../../src/lib/chat-create-command-id.ts";
+
+describe("chat create command identity", () => {
+	it("uses a fresh command id for each attempt of one durable operation", () => {
+		const operationId = "create_operation-1";
+		const initialAttempt = nextChatCreateCommandId(operationId);
+		const retryAttempt = nextChatCreateCommandId(operationId);
+
+		expect(initialAttempt).not.toBe(retryAttempt);
+		expect(initialAttempt).toMatch(
+			/^chat-create:create_operation-1:[0-9a-f-]{36}$/,
+		);
+		expect(retryAttempt).toMatch(
+			/^chat-create:create_operation-1:[0-9a-f-]{36}$/,
+		);
+	});
+});

--- a/apps/renderer/test/unit/chat-creation-handoff.test.ts
+++ b/apps/renderer/test/unit/chat-creation-handoff.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import chatsStoreSource from "../../src/store/chats.ts?raw";
+
+describe("chat creation handoff", () => {
+	it("hydrates a created worktree before removing the pending workspace card", () => {
+		const acknowledged = chatsStoreSource.indexOf(
+			'markRendererInteraction(initialSessionId, "entity-acknowledged")',
+		);
+		const authoritativeHandoff = chatsStoreSource.slice(acknowledged);
+		const hydrateWorktree = authoritativeHandoff.indexOf(
+			"await useWorktreesStore.getState().refresh(projectId)",
+		);
+		const clearPendingCreation = authoritativeHandoff.indexOf(
+			"pendingCreationByChat: Object.fromEntries",
+		);
+
+		expect(acknowledged).toBeGreaterThan(-1);
+		expect(hydrateWorktree).toBeGreaterThan(-1);
+		expect(clearPendingCreation).toBeGreaterThan(hydrateWorktree);
+	});
+});

--- a/apps/renderer/test/unit/chat-landing-progress.test.ts
+++ b/apps/renderer/test/unit/chat-landing-progress.test.ts
@@ -38,8 +38,10 @@ describe("chat landing progress", () => {
 
 	test("owns lifecycle polling behind the control-plane stream", () => {
 		expect(cloudChatsSource).toContain('control["cloud.workspaces.watch"]');
-		expect(cloudChatsSource).not.toContain("setTimeout");
 		expect(cloudChatsSource).not.toContain("while (");
+		// Deferred transcript pagination may schedule a task, but workspace
+		// lifecycle progress itself must remain stream-driven rather than polling.
+		expect(cloudChatsSource).toContain("completeOlderSessionMessages(ref)");
 	});
 
 	test("shows only cloud progress while a cloud workspace is starting", () => {

--- a/apps/renderer/test/unit/session-actions.test.ts
+++ b/apps/renderer/test/unit/session-actions.test.ts
@@ -1,12 +1,46 @@
-import { describe, expect, it } from "vitest";
+import {
+	ComposerInput,
+	EnvironmentId,
+	QueuedMessage,
+	QueuedMessageNotFoundError,
+	QueueState,
+	SessionId,
+	SessionTimelineProjection,
+} from "@zuse/contracts";
+import { Effect, Queue, Stream } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
 	classifyMessage,
 	isRecoveredPreAckSessionError,
 	optimisticQueuedMessageReady,
+	pendingSessionCommandError,
+	updateQueuedMessage,
 } from "../../src/lib/session-actions.ts";
+import {
+	getRendererClientBus,
+	resetSessionTimelineClientBusForTest,
+	retainSessionTimeline,
+	setSessionTimelineRpcClientForTest,
+} from "../../src/lib/session-timeline-client-bus.ts";
+
+const waitUntil = async (predicate: () => boolean): Promise<void> => {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+	throw new Error("condition was not reached");
+};
+
+const environmentId = EnvironmentId.make("session-actions-environment");
+const sessionId = SessionId.make("session-actions-session");
+const ref = { environmentId, sessionId } as const;
 
 describe("session actions", () => {
+	afterEach(() => {
+		resetSessionTimelineClientBusForTest();
+	});
+
 	it("classifies provider authentication failures once at the boundary", () => {
 		expect(classifyMessage("401 unauthorized", "codex")).toEqual({
 			kind: "auth",
@@ -52,5 +86,74 @@ describe("session actions", () => {
 				sync: "live",
 			}),
 		).toBe(false);
+	});
+
+	it("converges when a queued message was consumed before its final update", async () => {
+		const frames = Effect.runSync(Queue.unbounded());
+		let streamStarts = 0;
+		const input = ComposerInput.make({
+			text: "make pr",
+			attachments: [],
+			fileRefs: [],
+			skillRefs: [],
+		});
+		const queueId = "queue-consumed-before-update";
+		setSessionTimelineRpcClientForTest(
+			async () =>
+				({
+					"session.events": () => {
+						streamStarts += 1;
+						return Stream.fromQueue(frames);
+					},
+					"messages.queue.update": () =>
+						Effect.fail(new QueuedMessageNotFoundError({ sessionId, queueId })),
+				}) as never,
+		);
+
+		const retained = retainSessionTimeline(ref, "connect");
+		await waitUntil(() => streamStarts === 1);
+		Queue.offerUnsafe(frames, {
+			kind: "snapshot",
+			sessionId,
+			throughVersion: 0,
+			cursor: { epoch: "queue-epoch", version: 0 },
+			projection: SessionTimelineProjection.make({
+				messages: [],
+				status: "idle",
+				currentTurn: null,
+				queue: QueueState.make({
+					items: [
+						QueuedMessage.make({
+							id: queueId,
+							sessionId,
+							input,
+							position: 0,
+							createdAt: new Date(),
+							updatedAt: new Date(),
+							ready: false,
+						}),
+					],
+					paused: false,
+				}),
+				permissionMode: "default",
+				runtimeMode: "approval-required",
+			}),
+		});
+		await waitUntil(
+			() =>
+				getRendererClientBus().snapshot(retained.key).data?.queue.items
+					.length === 1,
+		);
+
+		await updateQueuedMessage(ref, queueId, input);
+
+		expect(
+			getRendererClientBus().snapshot(retained.key).data?.queue.items,
+		).toEqual([]);
+		expect(
+			getRendererClientBus().snapshot(retained.key).failedCommands,
+		).toEqual([]);
+		expect(pendingSessionCommandError(ref)).toBeNull();
+		retained.lease.release();
 	});
 });

--- a/apps/renderer/test/unit/session-timeline-client-bus.test.ts
+++ b/apps/renderer/test/unit/session-timeline-client-bus.test.ts
@@ -10,6 +10,7 @@ import {
 	Message,
 	MessageId,
 	PtyId,
+	QueuedMessage,
 	QueueState,
 	SessionId,
 	SessionNotFoundError,
@@ -28,9 +29,12 @@ import {
 	registerSessionTimelineOlderPageSynchronizer,
 	rehydrateRendererCommandPayload,
 	resetSessionTimelineClientBusForTest,
+	restartSessionTimeline,
 	retainSessionTimeline,
+	sessionTimelineResourceKey,
 	setSessionTimelineRpcClientForTest,
 	setSessionTimelineRpcSessionForTest,
+	updateOptimisticSessionQueue,
 } from "../../src/lib/session-timeline-client-bus.ts";
 
 const waitUntil = async (predicate: () => boolean): Promise<void> => {
@@ -260,11 +264,17 @@ describe("renderer session timeline ClientBus adapter", () => {
 		retained.lease.release();
 	});
 
-	it("keeps application stream errors resource-local", async () => {
+	it("restarts a provisional session timeline after its creation is acknowledged", async () => {
+		let streamStarts = 0;
+		const frames = Effect.runSync(Queue.unbounded());
 		setSessionTimelineRpcSessionForTest(async () => ({
 			client: {
-				"session.events": () =>
-					Stream.fail(new SessionNotFoundError({ sessionId })),
+				"session.events": () => {
+					streamStarts += 1;
+					return streamStarts === 1
+						? Stream.fail(new SessionNotFoundError({ sessionId }))
+						: Stream.fromQueue(frames);
+				},
 			} as never,
 			dispose: async () => undefined,
 		}));
@@ -276,7 +286,61 @@ describe("renderer session timeline ClientBus adapter", () => {
 		expect(getRendererClientBus().connection(environmentId).phase).toBe(
 			"connected",
 		);
+		expect(restartSessionTimeline(ref)).toBe(true);
+		await waitUntil(() => streamStarts === 2);
+		Queue.offerUnsafe(frames, {
+			kind: "snapshot",
+			sessionId,
+			throughVersion: 0,
+			cursor: { epoch: "created", version: 0 },
+			projection: SessionTimelineProjection.make({
+				messages: [],
+				status: "idle",
+				currentTurn: null,
+				queue: QueueState.make({ items: [], paused: false }),
+				permissionMode: "default",
+				runtimeMode: "approval-required",
+			}),
+		});
+		Queue.offerUnsafe(frames, {
+			kind: "synchronized",
+			sessionId,
+			throughVersion: 0,
+			cursor: { epoch: "created", version: 0 },
+		});
+		await waitUntil(
+			() => getRendererClientBus().snapshot(retained.key).sync === "live",
+		);
 		retained.lease.release();
+	});
+
+	it("seeds an empty provisional timeline with its startup queue item", () => {
+		const key = sessionTimelineResourceKey(ref);
+		getRendererClientBus().snapshot(key);
+		const queued = QueuedMessage.make({
+			id: "queue-startup",
+			sessionId,
+			input: ComposerInput.make({
+				text: "visible immediately",
+				attachments: [],
+				fileRefs: [],
+				skillRefs: [],
+				annotations: [],
+			}),
+			position: 0,
+			createdAt: new Date(1),
+			updatedAt: new Date(1),
+			ready: true,
+		});
+
+		expect(
+			updateOptimisticSessionQueue(ref, () =>
+				QueueState.make({ items: [queued], paused: false }),
+			),
+		).toBe(true);
+		expect(getRendererClientBus().snapshot(key).data?.queue.items).toEqual([
+			queued,
+		]);
 	});
 
 	it("prepares a woken environment on the same passive session", async () => {

--- a/apps/server/src/conversation/core/archive-operations.ts
+++ b/apps/server/src/conversation/core/archive-operations.ts
@@ -1164,8 +1164,12 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 					const archivedRows = yield* sql<{
 						readonly archived_worktree_json: string | null;
 					}>`
-            SELECT archived_worktree_json FROM chats WHERE id = ${chatId} LIMIT 1
-          `.pipe(Effect.orDie);
+			SELECT COALESCE(c.archived_worktree_json, j.snapshot_json) AS archived_worktree_json
+			FROM chats c
+			LEFT JOIN chat_archive_jobs j ON j.chat_id = c.id
+			WHERE c.id = ${chatId}
+			LIMIT 1
+		  `.pipe(Effect.orDie);
 					const archivedSnapshot = parseArchivedWorktreeSnapshot(
 						archivedRows[0]?.archived_worktree_json ?? null,
 					);
@@ -1235,9 +1239,9 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						return yield* Effect.fail(new ChatNotFoundError({ chatId }));
 					}
 
-					const snapshot = parseArchivedWorktreeSnapshot(
-						chatRow.archived_worktree_json,
-					);
+					const retainedSnapshotJson =
+						chatRow.archived_worktree_json ?? pendingJob?.snapshot_json ?? null;
+					const snapshot = parseArchivedWorktreeSnapshot(retainedSnapshotJson);
 					let restoredWorktree: Worktree | null = null;
 					let restorationUnavailable = false;
 					let restoredWorktreeId: WorktreeId | null =
@@ -1295,9 +1299,9 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 					});
 					if (restorationUnavailable) {
 						yield* sql`
-            UPDATE chats SET archived_worktree_json = ${chatRow.archived_worktree_json}
-            WHERE id = ${chatId}
-          `.pipe(Effect.orDie);
+			UPDATE chats SET archived_worktree_json = ${retainedSnapshotJson}
+			WHERE id = ${chatId}
+		  `.pipe(Effect.orDie);
 					}
 					const archivedSessions = yield* sql<{
 						readonly id: string;

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -1580,6 +1580,60 @@ describe("ConversationServices — chat & session lifecycle", () => {
 		});
 	});
 
+	it("restores from the archive job when the chat snapshot projection is missing", async () => {
+		await withRuntime(async (run) => {
+			const archived = await run(
+				Effect.flatMap(store, (service) =>
+					service.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+						worktreeId: TEST_WORKTREE_ID,
+					}),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.archiveChat(archived.chat.id),
+				),
+			);
+			await expect
+				.poll(() =>
+					run(
+						Effect.flatMap(store, (service) =>
+							service.getArchiveStatus(archived.chat.id),
+						),
+					),
+				)
+				.toMatchObject({ status: "completed" });
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					yield* sql`
+						UPDATE chats SET archived_worktree_json = NULL
+						WHERE id = ${archived.chat.id}
+					`;
+				}),
+			);
+
+			const restorable = await run(
+				Effect.flatMap(store, (service) =>
+					service.getChatDirectoryStatus(archived.chat.id),
+				),
+			);
+			const restored = await run(
+				Effect.flatMap(store, (service) =>
+					service.unarchiveChat(archived.chat.id),
+				),
+			);
+
+			expect(restorable).toEqual({ _tag: "restorable" });
+			expect(restored.worktree?.id).toBe(TEST_WORKTREE_ID);
+			expect(restored.chat.worktreeId).toBe(TEST_WORKTREE_ID);
+			expect(restored.directoryStatus).toEqual({ _tag: "available" });
+		});
+	});
+
 	it("returns the archived chat with only its original sessions for preview", async () => {
 		await withRuntime(async (run) => {
 			const created = await run(

--- a/packages/client-runtime/src/client-bus.ts
+++ b/packages/client-runtime/src/client-bus.ts
@@ -474,6 +474,29 @@ export class ClientBus<Client> {
 			.catch(() => undefined);
 	}
 
+	/**
+	 * Restarts one retained resource driver without reconnecting its environment.
+	 * This is used when a provisional resource becomes durable after an earlier
+	 * subscription was rejected by the server.
+	 */
+	restart<Key extends ResourceKey<unknown>>(key: Key): boolean {
+		if (this.disposed) return false;
+		const entry = this.entries.get(resourceKeyId(key));
+		const binding = this.environments.get(key.ref.environmentId);
+		if (
+			entry === undefined ||
+			binding === undefined ||
+			entry.activations.size === 0 ||
+			!requestsRuntime(entry) ||
+			binding.runtime.currentClient() === null
+		) {
+			return false;
+		}
+		this.stopDriver(entry);
+		this.startDriver(entry, binding);
+		return true;
+	}
+
 	/** Current generation-fenced client for bounded side requests. */
 	client(environmentId: EnvironmentId): Client | null {
 		return this.environment(environmentId).runtime.currentClient();

--- a/packages/client-runtime/test/unit/client-bus.test.ts
+++ b/packages/client-runtime/test/unit/client-bus.test.ts
@@ -228,6 +228,31 @@ describe("ClientBus", () => {
 		await bus.dispose();
 	});
 
+	it("restarts a retained resource after its provisional subscription fails", async () => {
+		let starts = 0;
+		let stops = 0;
+		const bus = new ClientBus<Client>({
+			resolver: immediateResolver(),
+			driverFor: () => ({
+				start: () => {
+					starts += 1;
+				},
+				stop: () => {
+					stops += 1;
+				},
+			}),
+		});
+		const lease = bus.retain(timelineKey, { activation: "connect" });
+		await waitUntil(() => starts === 1);
+
+		expect(bus.restart(timelineKey)).toBe(true);
+		expect(stops).toBe(1);
+		expect(starts).toBe(2);
+
+		lease.release();
+		await bus.dispose();
+	});
+
 	it("does not let a later cache-only lease weaken a live shared resource", async () => {
 		let resolves = 0;
 		let disposals = 0;

--- a/packages/git/src/worktree/worktree-service-live.ts
+++ b/packages/git/src/worktree/worktree-service-live.ts
@@ -384,10 +384,17 @@ export const WorktreeServiceLive = Layer.effect(
 		 * error. Mirrors `GitServiceLive.run` but stays self-contained so
 		 * domains remain independent.
 		 */
-		const runGit = (cwd: string, args: ReadonlyArray<string>) =>
+		const runGit = (
+			cwd: string,
+			args: ReadonlyArray<string>,
+			env?: Readonly<Record<string, string>>,
+		) =>
 			Effect.scoped(
 				Effect.gen(function* () {
-					const cmd = Command.make("git", args, { cwd });
+					const cmd = Command.make("git", args, {
+						cwd,
+						...(env === undefined ? {} : { env, extendEnv: true }),
+					});
 					const proc = yield* executor.spawn(cmd);
 					const stdout = yield* collectText(proc.stdout);
 					const stderr = yield* collectText(proc.stderr);
@@ -1109,14 +1116,15 @@ export const WorktreeServiceLive = Layer.effect(
 				return yield* Deferred.await(acquired.deferred);
 			});
 
-		const checkpointCommitArgs = (worktreeId: WorktreeId) => [
-			"commit",
+		const checkpointCommitTreeArgs = (tree: string, worktreeId: WorktreeId) => [
+			"commit-tree",
+			tree,
+			"-p",
+			"HEAD",
 			"-m",
 			"zuse: archive checkpoint",
 			"-m",
 			`Zuse-Archive-Checkpoint: ${worktreeId}`,
-			"--no-verify",
-			"--no-gpg-sign",
 		];
 
 		const isMissingIdentity = (reason: string): boolean => {
@@ -1233,7 +1241,81 @@ export const WorktreeServiceLive = Layer.effect(
 				),
 			);
 			let checkpointCreated = status.trim().length > 0;
-			if (!checkpointCreated) {
+			let archiveRef: string | null = null;
+			let archiveCommit: string;
+			if (checkpointCreated) {
+				const checkpointRef = `refs/zuse/archive/${worktreeId}`;
+				archiveRef = checkpointRef;
+				const temporaryIndex = Path.join(
+					os.tmpdir(),
+					`zuse-archive-index-${worktreeId}-${crypto.randomUUID()}`,
+				);
+				const indexEnv = { GIT_INDEX_FILE: temporaryIndex };
+				archiveCommit = yield* Effect.gen(function* () {
+					yield* runGit(row.path, ["read-tree", "HEAD"], indexEnv);
+					yield* runGit(row.path, ["add", "-A"], indexEnv);
+					const tree = (yield* runGit(
+						row.path,
+						["write-tree"],
+						indexEnv,
+					)).trim();
+					const existingCommit = yield* runGit(folder.path, [
+						"rev-parse",
+						"--verify",
+						"--quiet",
+						checkpointRef,
+					]).pipe(Effect.result);
+					if (existingCommit._tag === "Success") {
+						const existing = existingCommit.success.trim();
+						const [existingTree, existingParent, head, body] =
+							yield* Effect.all([
+								runGit(folder.path, ["rev-parse", `${existing}^{tree}`]),
+								runGit(folder.path, ["rev-parse", `${existing}^`]),
+								runGit(row.path, ["rev-parse", "HEAD"]),
+								runGit(folder.path, ["show", "-s", "--format=%B", existing]),
+							]);
+						if (
+							existingTree.trim() === tree &&
+							existingParent.trim() === head.trim() &&
+							body.includes(`Zuse-Archive-Checkpoint: ${worktreeId}`)
+						) {
+							return existing;
+						}
+					}
+					const commitArgs = checkpointCommitTreeArgs(tree, worktreeId);
+					let committed = yield* runGit(row.path, commitArgs).pipe(
+						Effect.result,
+					);
+					if (
+						committed._tag === "Failure" &&
+						isMissingIdentity(committed.failure)
+					) {
+						committed = yield* runGit(row.path, [
+							"-c",
+							"user.name=Zuse",
+							"-c",
+							"user.email=zuse@localhost",
+							...commitArgs,
+						]).pipe(Effect.result);
+					}
+					if (committed._tag === "Failure") {
+						return yield* Effect.fail(committed.failure);
+					}
+					const commit = committed.success.trim();
+					yield* runGit(folder.path, ["update-ref", checkpointRef, commit]);
+					return commit;
+				}).pipe(
+					Effect.mapError(
+						(reason) => new WorktreeCheckpointError({ worktreeId, reason }),
+					),
+					Effect.ensuring(
+						Effect.sync(() => {
+							fsSync.rmSync(temporaryIndex, { force: true });
+							fsSync.rmSync(`${temporaryIndex}.lock`, { force: true });
+						}),
+					),
+				);
+			} else {
 				const currentBody = yield* runGit(row.path, [
 					"show",
 					"-s",
@@ -1245,57 +1327,20 @@ export const WorktreeServiceLive = Layer.effect(
 					currentBody.success.includes(
 						`Zuse-Archive-Checkpoint: ${worktreeId}`,
 					);
-			}
-			if (status.trim().length > 0) {
-				yield* ensureRemovalAllowed;
-				yield* runGit(row.path, ["add", "-A"]).pipe(
+				archiveCommit = (yield* runGit(row.path, ["rev-parse", "HEAD"]).pipe(
 					Effect.mapError(
 						(reason) => new WorktreeCheckpointError({ worktreeId, reason }),
 					),
-				);
-				const committed = yield* runGit(
-					row.path,
-					checkpointCommitArgs(worktreeId),
-				).pipe(Effect.result);
-				if (committed._tag === "Failure") {
-					if (!isMissingIdentity(committed.failure)) {
-						return yield* Effect.fail(
-							new WorktreeCheckpointError({
-								worktreeId,
-								reason: committed.failure,
-							}),
-						);
-					}
-					yield* runGit(row.path, [
-						"-c",
-						"user.name=Zuse",
-						"-c",
-						"user.email=zuse@localhost",
-						...checkpointCommitArgs(worktreeId),
-					]).pipe(
-						Effect.mapError(
-							(reason) => new WorktreeCheckpointError({ worktreeId, reason }),
-						),
-					);
-				}
+				)).trim();
 			}
-
-			const archiveCommit = (yield* runGit(row.path, [
-				"rev-parse",
-				"HEAD",
-			]).pipe(
-				Effect.mapError(
-					(reason) => new WorktreeCheckpointError({ worktreeId, reason }),
-				),
-			)).trim();
+			yield* ensureRemovalAllowed;
 			const symbolicBranch = yield* runGit(row.path, [
 				"symbolic-ref",
 				"--quiet",
 				"--short",
 				"HEAD",
 			]).pipe(Effect.result);
-			let archiveRef: string | null = null;
-			if (symbolicBranch._tag === "Success") {
+			if (archiveRef === null && symbolicBranch._tag === "Success") {
 				const branch = symbolicBranch.success.trim();
 				const branchCommit = (yield* runGit(folder.path, [
 					"rev-parse",
@@ -1313,7 +1358,7 @@ export const WorktreeServiceLive = Layer.effect(
 						}),
 					);
 				}
-			} else {
+			} else if (archiveRef === null) {
 				archiveRef = `refs/zuse/archive/${worktreeId}`;
 				yield* ensureRemovalAllowed;
 				yield* runGit(folder.path, [

--- a/packages/git/test/integration/worktree/worktree-service-live.test.ts
+++ b/packages/git/test/integration/worktree/worktree-service-live.test.ts
@@ -355,13 +355,21 @@ describe("WorktreeServiceLive", () => {
 		const created = await run((service) => service.create(projectId));
 		writeFileSync(join(created.path, "dirty.txt"), "dirty\n");
 		const beforeArchive = git(created.path, "rev-parse", "HEAD");
+		const branchBeforeArchive = git(
+			repositoryRoot,
+			"rev-parse",
+			`refs/heads/${created.branch}`,
+		);
 
 		const checkpoint = await run((service) => service.archive(created.id));
 		expect(checkpoint).toMatchObject({
 			checkpointCreated: true,
-			archiveRef: null,
+			archiveRef: `refs/zuse/archive/${created.id}`,
 			branch: created.branch,
 		});
+		expect(
+			git(repositoryRoot, "rev-parse", `refs/heads/${created.branch}`),
+		).toBe(branchBeforeArchive);
 		expect(existsSync(created.path)).toBe(false);
 		expect(await run((service) => service.get(created.id))).toBeNull();
 		expect(
@@ -397,6 +405,21 @@ describe("WorktreeServiceLive", () => {
 				.filter((event) => event._tag === "status")
 				.map((event) => event.status),
 		).toContain("skipped");
+	});
+
+	test("archive checkpoint never moves an externally switched branch", async () => {
+		const created = await run((service) => service.create(projectId));
+		git(created.path, "switch", "-c", "externally-switched");
+		const branchHead = git(created.path, "rev-parse", "HEAD");
+		writeFileSync(join(created.path, "dirty-after-switch.txt"), "dirty\n");
+
+		const outcome = await run((service) => service.archive(created.id));
+
+		expect(outcome.archiveRef).toBe(`refs/zuse/archive/${created.id}`);
+		expect(
+			git(repositoryRoot, "rev-parse", "refs/heads/externally-switched"),
+		).toBe(branchHead);
+		expect(outcome.archiveCommit).not.toBe(branchHead);
 	});
 
 	test("archives a clean worktree without creating a checkpoint commit", async () => {
@@ -594,7 +617,7 @@ describe("WorktreeServiceLive", () => {
 		).toBe("Zuse <zuse@localhost>");
 	});
 
-	test("keeps a checkpoint committed when its branch advances while archived", async () => {
+	test("restores the checkpoint without overwriting a branch that advanced", async () => {
 		const created = await run((service) => service.create(projectId));
 		await run((service) =>
 			service.setupStream(created.id).pipe(Stream.runCollect),
@@ -620,8 +643,13 @@ describe("WorktreeServiceLive", () => {
 				createdAt: created.createdAt,
 			}),
 		);
-		expect(git(created.path, "rev-parse", "HEAD")).toBe(advancedCommit);
-		expect(git(created.path, "status", "--short")).toBe("");
+		expect(git(created.path, "rev-parse", "HEAD")).not.toBe(advancedCommit);
+		expect(git(created.path, "status", "--short")).toContain(
+			"?? checkpoint.txt",
+		);
+		expect(
+			git(repositoryRoot, "rev-parse", `refs/heads/${created.branch}`),
+		).toBe(advancedCommit);
 	});
 
 	test("manual removal checkpoints dirty work instead of rejecting it", async () => {
@@ -635,7 +663,13 @@ describe("WorktreeServiceLive", () => {
 
 		expect(await run((service) => service.get(created.id))).toBeNull();
 		expect(
-			git(repositoryRoot, "show", "-s", "--format=%B", created.branch),
+			git(
+				repositoryRoot,
+				"show",
+				"-s",
+				"--format=%B",
+				`refs/zuse/archive/${created.id}`,
+			),
 		).toContain(`Zuse-Archive-Checkpoint: ${created.id}`);
 	});
 

--- a/scripts/import-latest-prod-chat-to-dev.mjs
+++ b/scripts/import-latest-prod-chat-to-dev.mjs
@@ -6,50 +6,53 @@ import { dirname, join } from "node:path";
 
 const appSupport = join(homedir(), "Library", "Application Support");
 const prodDb =
-  process.env.ZUSE_PROD_SQLITE ?? join(appSupport, "Zuse Alpha", "zuse.sqlite");
+	process.env.ZUSE_PROD_SQLITE ?? join(appSupport, "Zuse Alpha", "zuse.sqlite");
 const devDb =
-  process.env.ZUSE_DEV_SQLITE ??
-  join(appSupport, "Zuse Alpha (Dev)", "zuse.sqlite");
+	process.env.ZUSE_DEV_SQLITE ??
+	join(appSupport, "Zuse Alpha (Dev)", "zuse.sqlite");
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 const backupDir = join(dirname(devDb), `debug-import-backup-${timestamp}`);
 
 function runSql(dbPath, sql) {
-  return execFileSync("sqlite3", ["-batch", dbPath, sql], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
+	return execFileSync("sqlite3", ["-batch", dbPath, sql], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
 }
 
 function quoteSql(value) {
-  return `'${value.replaceAll("'", "''")}'`;
+	return `'${value.replaceAll("'", "''")}'`;
 }
 
 function requireFile(path, label) {
-  if (!existsSync(path)) {
-    throw new Error(`${label} does not exist: ${path}`);
-  }
+	if (!existsSync(path)) {
+		throw new Error(`${label} does not exist: ${path}`);
+	}
 }
 
 function backupDevDatabase() {
-  mkdirSync(backupDir, { recursive: true });
-  for (const suffix of ["", "-wal", "-shm"]) {
-    const from = `${devDb}${suffix}`;
-    if (!existsSync(from)) continue;
-    copyFileSync(from, join(backupDir, `zuse.sqlite${suffix}`));
-  }
+	mkdirSync(backupDir, { recursive: true });
+	for (const suffix of ["", "-wal", "-shm"]) {
+		const from = `${devDb}${suffix}`;
+		if (!existsSync(from)) continue;
+		copyFileSync(from, join(backupDir, `zuse.sqlite${suffix}`));
+	}
 }
 
 function tableCount(dbPath, table, where) {
-  return runSql(dbPath, `SELECT count(*) FROM ${table} WHERE ${where};`);
+	return runSql(dbPath, `SELECT count(*) FROM ${table} WHERE ${where};`);
 }
 
 requireFile(prodDb, "Production SQLite database");
 requireFile(devDb, "Dev SQLite database");
 
-const chatId = runSql(
-  prodDb,
-  `
+const requestedChatId = process.env.ZUSE_IMPORT_CHAT_ID?.trim();
+const chatId =
+	requestedChatId ||
+	runSql(
+		prodDb,
+		`
   SELECT c.id
   FROM chats c
   JOIN sessions s ON s.chat_id = c.id
@@ -60,29 +63,65 @@ const chatId = runSql(
   ORDER BY c.updated_at DESC
   LIMIT 1;
   `,
-);
+	);
 
 if (!chatId) {
-  throw new Error(
-    "Could not find a production chat with codex and fable sessions.",
-  );
+	throw new Error(
+		"Could not find a production chat with codex and fable sessions.",
+	);
+}
+
+if (
+	runSql(
+		prodDb,
+		`SELECT count(*) FROM chats WHERE id = ${quoteSql(chatId)};`,
+	) !== "1"
+) {
+	throw new Error(`Production chat does not exist: ${chatId}`);
+}
+
+if (
+	runSql(
+		devDb,
+		`SELECT count(*) FROM chats WHERE id = ${quoteSql(chatId)};`,
+	) !== "0"
+) {
+	throw new Error(`Dev already contains chat: ${chatId}`);
 }
 
 const sessionIds = runSql(
-  prodDb,
-  `SELECT group_concat(id, ',') FROM sessions WHERE chat_id = ${quoteSql(chatId)};`,
+	prodDb,
+	`SELECT group_concat(id, ',') FROM sessions WHERE chat_id = ${quoteSql(chatId)};`,
 )
-  .split(",")
-  .filter(Boolean);
+	.split(",")
+	.filter(Boolean);
 
 if (sessionIds.length === 0) {
-  throw new Error(`Selected chat has no sessions: ${chatId}`);
+	throw new Error(`Selected chat has no sessions: ${chatId}`);
 }
+
+const sourceProject = JSON.parse(
+	runSql(
+		prodDb,
+		`SELECT json_object('id', p.id, 'path', p.path)
+		 FROM projects p
+		 JOIN chats c ON c.project_id = p.id
+		 WHERE c.id = ${quoteSql(chatId)};`,
+	),
+);
+const existingDevProjectId = runSql(
+	devDb,
+	`SELECT id FROM projects WHERE path = ${quoteSql(sourceProject.path)} LIMIT 1;`,
+);
+const targetProjectId = existingDevProjectId || sourceProject.id;
+const reusesDevProject = targetProjectId !== sourceProject.id;
 
 backupDevDatabase();
 
 const prodDbSql = quoteSql(prodDb);
 const chatIdSql = quoteSql(chatId);
+const sourceProjectIdSql = quoteSql(sourceProject.id);
+const targetProjectIdSql = quoteSql(targetProjectId);
 const importSql = `
 PRAGMA foreign_keys = ON;
 ATTACH DATABASE ${prodDbSql} AS prod;
@@ -105,22 +144,24 @@ SELECT attachment_id
 FROM prod.message_attachments
 WHERE message_id IN (SELECT id FROM selected_messages);
 
-INSERT OR REPLACE INTO projects
+INSERT OR IGNORE INTO projects
 SELECT p.*
 FROM prod.projects p
 JOIN prod.chats c ON c.project_id = p.id
-WHERE c.id = ${chatIdSql};
+WHERE c.id = ${chatIdSql}
+  AND p.id = ${targetProjectIdSql};
 
-INSERT OR REPLACE INTO worktrees
+INSERT OR IGNORE INTO worktrees
 SELECT DISTINCT w.*
 FROM prod.worktrees w
 WHERE w.id IN (
   SELECT worktree_id FROM prod.chats WHERE id = ${chatIdSql} AND worktree_id IS NOT NULL
   UNION
   SELECT worktree_id FROM prod.sessions WHERE id IN (SELECT id FROM selected_sessions) AND worktree_id IS NOT NULL
-);
+)
+  AND ${sourceProjectIdSql} = ${targetProjectIdSql};
 
-INSERT OR REPLACE INTO chats (
+INSERT INTO chats (
   id,
   project_id,
   worktree_id,
@@ -136,8 +177,8 @@ INSERT OR REPLACE INTO chats (
 )
 SELECT
   id,
-  project_id,
-  worktree_id,
+  ${targetProjectIdSql},
+  ${reusesDevProject ? "NULL" : "worktree_id"},
   title,
   NULL,
   archived_at,
@@ -150,7 +191,7 @@ SELECT
 FROM prod.chats
 WHERE id = ${chatIdSql};
 
-INSERT OR REPLACE INTO sessions (
+INSERT INTO sessions (
   id,
   project_id,
   title,
@@ -175,7 +216,7 @@ INSERT OR REPLACE INTO sessions (
 )
 SELECT
   id,
-  project_id,
+  ${targetProjectIdSql},
   title,
   provider_id,
   model,
@@ -187,7 +228,7 @@ SELECT
   resume_strategy,
   runtime_mode,
   agents_json,
-  worktree_id,
+  ${reusesDevProject ? "NULL" : "worktree_id"},
   permission_mode,
   tool_search,
   NULL,
@@ -281,16 +322,16 @@ runSql(devDb, importSql);
 const sessionWhere = `chat_id = ${quoteSql(chatId)}`;
 const importedSessions = Number(tableCount(devDb, "sessions", sessionWhere));
 const importedMessages = Number(
-  runSql(
-    devDb,
-    `SELECT count(*) FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE chat_id = ${chatIdSql});`,
-  ),
+	runSql(
+		devDb,
+		`SELECT count(*) FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE chat_id = ${chatIdSql});`,
+	),
 );
 const importedEvents = Number(
-  runSql(
-    devDb,
-    `SELECT count(*) FROM events WHERE stream_kind = 'session' AND stream_id IN (SELECT id FROM sessions WHERE chat_id = ${chatIdSql});`,
-  ),
+	runSql(
+		devDb,
+		`SELECT count(*) FROM events WHERE stream_kind = 'session' AND stream_id IN (SELECT id FROM sessions WHERE chat_id = ${chatIdSql});`,
+	),
 );
 
 console.log(`Imported production chat ${chatId}`);


### PR DESCRIPTION
## Summary

- keep new-chat retries idempotent at the operation level while assigning a fresh command identity to each explicit attempt
- preserve queued prompts and workspace-creation progress across the provisional-to-authoritative chat handoff
- converge consumed queued messages without showing false provider failures
- restore archived chats from retained job snapshots when the chat projection lost its snapshot
- checkpoint dirty worktrees through isolated Git refs so archiving never advances the currently checked-out branch
- make the production-to-Dev history importer reuse existing project paths instead of creating duplicate projects

## Validation

- renderer unit suite: 105 files, 479 tests passed
- ClientBus unit suite: 14 files, 106 tests passed
- conversation integration suite: 99 tests passed
- archive/worktree focused integration suite: 10 passed
- renderer, server, client-runtime, and Git TypeScript checks passed
- renderer state and architecture boundary checks passed
- changed-file Biome and `git diff --check` passed

## Baseline note

The complete Git worktree integration file still has four unrelated branch-rename failures present on `origin/main`; all archive/checkpoint tests affected by this PR pass.

