### PR TITLE
Release v0.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.6]
+
+### Fixed
+- Complete local, archived, cloud, and mobile chat histories now load automatically instead of stopping at a recent subset or depending on scroll-triggered pagination
+- New chats keep their queued prompt and workspace-creation progress visible, and explicit retries no longer collide with the original command identity
+- Consumed queued messages no longer reappear as false provider errors
+- Archiving dirty worktrees no longer advances the checked-out Git branch, and unarchive can recover from the retained archive-job snapshot
+- Switching chats restores each chat's sidebar state without an unwanted transition
+
 ## [0.20.5]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.5",
+	"version": "0.20.6",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.20.6",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "Complete local, archived, cloud, and mobile chat histories now load automatically instead of stopping at a recent subset or depending on scroll-triggered pagination",
+          "New chats keep their queued prompt and workspace-creation progress visible, and explicit retries no longer collide with the original command identity",
+          "Consumed queued messages no longer reappear as false provider errors",
+          "Archiving dirty worktrees no longer advances the checked-out Git branch, and unarchive can recover from the retained archive-job snapshot",
+          "Switching chats restores each chat's sidebar state without an unwanted transition"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.5",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.5",
+      "version": "0.20.6",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.6 with release notes grouped by user-visible outcome.

### Fixed
- Complete local, archived, cloud, and mobile chat histories now load automatically instead of stopping at a recent subset or depending on scroll-triggered pagination
- New chats keep their queued prompt and workspace-creation progress visible, and explicit retries no longer collide with the original command identity
- Consumed queued messages no longer reappear as false provider errors
- Archiving dirty worktrees no longer advances the checked-out Git branch, and unarchive can recover from the retained archive-job snapshot
- Switching chats restores each chat's sidebar state without an unwanted transition

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.20.6 after this PR lands.

