### PR TITLE
Fix cloud workspace startup and access reliability

### DIFF
--- a/apps/desktop/src/sync/cloud-sync-service.ts
+++ b/apps/desktop/src/sync/cloud-sync-service.ts
@@ -83,7 +83,7 @@ export const rsyncArgs = (input: {
 	...GENERATED_SYNC_EXCLUDES.map((path) => `--exclude=${path}/`),
 	...(input.gitignoreFilter ? ["--filter=:- .gitignore"] : []),
 	...(!input.gitignoreFilter
-		? ["--rsync-path=rsync --filter=':- .gitignore'"]
+		? ["--rsync-path=rsync --filter=:-_.gitignore"]
 		: []),
 	"-e",
 	`ssh -F "${input.sshConfigPath}"`,

--- a/apps/desktop/test/unit/cloud-sync-service.test.ts
+++ b/apps/desktop/test/unit/cloud-sync-service.test.ts
@@ -55,7 +55,7 @@ describe("cloud sync service", () => {
 				sshConfigPath: "/c",
 				gitignoreFilter: false,
 			}),
-		).toContain("--rsync-path=rsync --filter=':- .gitignore'");
+		).toContain("--rsync-path=rsync --filter=:-_.gitignore");
 	});
 
 	test("gitignore filter only with GNU rsync", () => {

--- a/apps/renderer/src/components/cloud-workspace-info.tsx
+++ b/apps/renderer/src/components/cloud-workspace-info.tsx
@@ -25,6 +25,7 @@ import {
 	useCloudSyncStatus,
 } from "../lib/cloud-sync-client-bus.ts";
 import { useCloudChatCatalogStore } from "../lib/cloud-workspace-catalog.ts";
+import { isCloudWorkspaceReady } from "../lib/cloud-workspace-lifecycle.ts";
 import { runControlPlane } from "../lib/control-plane-client.ts";
 import { displayPath } from "../lib/display-path.ts";
 import { errorMessage } from "../lib/error-message.ts";
@@ -165,7 +166,7 @@ export function CloudWorkspaceOpenSshMenu({
 		ReadonlyArray<OpenTarget>
 	>([]);
 	if (!cloudSshSupported() || summary === null) return null;
-	const running = summary.state === "ready";
+	const running = isCloudWorkspaceReady(summary);
 	const syncEnabled = syncPrefs?.enabled !== false;
 
 	const toggleSync = async (): Promise<void> => {

--- a/apps/renderer/src/lib/cloud-ssh-client-bus.ts
+++ b/apps/renderer/src/lib/cloud-ssh-client-bus.ts
@@ -1,8 +1,12 @@
-import type { MachineSshKey } from "@zuse/contracts";
+import { CommandId, EnvironmentId, type MachineSshKey } from "@zuse/contracts";
 
 import { type CloudSshPrepared, getAppBridge } from "./bridge.ts";
 import { runControlPlane } from "./control-plane-client.ts";
-import { dispatchEnvironmentShellCommand } from "./environment-shell-client-bus.ts";
+import {
+	dispatchEnvironmentShellCommand,
+	retainEnvironmentShell,
+} from "./environment-shell-client-bus.ts";
+import { getRendererClientBus } from "./session-timeline-client-bus.ts";
 
 /**
  * Orchestrates SSH access to a cloud workspace:
@@ -22,46 +26,108 @@ const requestSshAccess = (workspaceId: string) =>
 		client["cloud.workspaces.sshAccess"]({ workspaceId }),
 	);
 
+const SSH_GATEWAY_READY_TIMEOUT_MS = 30_000;
+
+const waitForWorkspaceGateway = (
+	environmentId: EnvironmentId,
+	key: ReturnType<typeof retainEnvironmentShell>["key"],
+): Promise<void> => {
+	const bus = getRendererClientBus();
+	if (bus.client(environmentId) !== null) return Promise.resolve();
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		let unsubscribe: () => void = () => undefined;
+		const finish = (cause?: Error): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			unsubscribe();
+			if (cause === undefined) resolve();
+			else reject(cause);
+		};
+		const check = (): void => {
+			if (bus.client(environmentId) !== null) {
+				finish();
+				return;
+			}
+			const connection = bus.connection(environmentId);
+			if (
+				connection.phase === "blocked-auth" ||
+				connection.phase === "update-required" ||
+				connection.phase === "revoked"
+			) {
+				finish(
+					new Error(
+						connection.error ??
+							"The cloud workspace gateway is not available for SSH.",
+					),
+				);
+			}
+		};
+		const timeout = setTimeout(() => {
+			const connection = bus.connection(environmentId);
+			finish(
+				new Error(
+					connection.error ??
+						"Timed out waiting for the cloud workspace gateway.",
+				),
+			);
+		}, SSH_GATEWAY_READY_TIMEOUT_MS);
+		unsubscribe = bus.subscribe(key, check);
+		check();
+	});
+};
+
 export const prepareCloudWorkspaceSsh = async (
 	workspaceId: string,
 ): Promise<CloudSshPrepared> => {
 	const app = getAppBridge();
 	if (app?.cloudSshPrepare === undefined || app.openSshTarget === undefined)
 		throw new Error("SSH access requires the Zuse desktop app.");
-	let access: Awaited<ReturnType<typeof requestSshAccess>>;
+	const environmentId = EnvironmentId.make(workspaceId);
+	const retained = retainEnvironmentShell({ environmentId }, "wake");
 	try {
-		access = await requestSshAccess(workspaceId);
-	} catch (cause) {
-		// The relay rejects unknown routes while SSH support is still rolling
-		// out; surface that as a capability gap instead of a raw RPC error.
-		const detail = cause instanceof Error ? cause.message : String(cause);
-		throw new Error(
-			`SSH access is not available for this workspace yet — the cloud service and workspace image need the SSH update.${
-				detail.length > 0 && detail !== "{}" ? ` (${detail})` : ""
-			}`,
-		);
+		// A relay workspace can report ready before its renderer gateway lease has
+		// finished reconnecting. SSH and rsync both require that live client for
+		// key authorization, so keep a transient wake lease through the command.
+		await waitForWorkspaceGateway(environmentId, retained.key);
+		let access: Awaited<ReturnType<typeof requestSshAccess>>;
+		try {
+			access = await requestSshAccess(workspaceId);
+		} catch (cause) {
+			// The relay rejects unknown routes while SSH support is still rolling
+			// out; surface that as a capability gap instead of a raw RPC error.
+			const detail = cause instanceof Error ? cause.message : String(cause);
+			throw new Error(
+				`SSH access is not available for this workspace yet — the cloud service and workspace image need the SSH update.${
+					detail.length > 0 && detail !== "{}" ? ` (${detail})` : ""
+				}`,
+			);
+		}
+		const prepared = await app.cloudSshPrepare({
+			workspaceId: access.workspaceId,
+			wsUrl: access.wsUrl,
+			ticket: access.ticket,
+			expiresAt: access.expiresAt,
+			user: access.user,
+			workspacePath: access.workspacePath,
+		});
+		if (prepared === null)
+			throw new Error("Could not prepare SSH access on this device.");
+		// Idempotent: the sandbox host service dedupes keys by fingerprint.
+		await dispatchEnvironmentShellCommand<
+			{ publicKey: string; label?: string },
+			MachineSshKey
+		>({
+			environmentId,
+			kind: "machine.sshKeys.add",
+			commandId: CommandId.make(`cloud-ssh-key:${crypto.randomUUID()}`),
+			payload: { publicKey: prepared.publicKey, label: "zuse-desktop" },
+		});
+		return prepared;
+	} finally {
+		retained.lease.release();
 	}
-	const prepared = await app.cloudSshPrepare({
-		workspaceId: access.workspaceId,
-		wsUrl: access.wsUrl,
-		ticket: access.ticket,
-		expiresAt: access.expiresAt,
-		user: access.user,
-		workspacePath: access.workspacePath,
-	});
-	if (prepared === null)
-		throw new Error("Could not prepare SSH access on this device.");
-	// Idempotent: the sandbox host service dedupes keys by fingerprint.
-	await dispatchEnvironmentShellCommand<
-		{ publicKey: string; label?: string },
-		MachineSshKey
-	>({
-		environmentId: workspaceId as never,
-		kind: "machine.sshKeys.add",
-		commandId: crypto.randomUUID() as never,
-		payload: { publicKey: prepared.publicKey, label: "zuse-desktop" },
-	});
-	return prepared;
 };
 
 export type CloudSshTarget = "cursor" | "zed" | "terminal";

--- a/apps/renderer/src/lib/session-timeline-client-bus.ts
+++ b/apps/renderer/src/lib/session-timeline-client-bus.ts
@@ -1342,8 +1342,13 @@ export const dispatchSessionCommand = <Payload, Result>(input: {
 export const addOptimisticSessionMessage = (
 	ref: SessionRef,
 	message: Message,
-): boolean =>
-	rendererClientBus.overlay(sessionTimelineResourceKey(ref), {
+): boolean => {
+	const key = sessionTimelineResourceKey(ref);
+	// Cloud launches stage their durable chat before any transcript consumer is
+	// mounted. Materialize the canonical cell so their first optimistic message
+	// is not discarded during that handoff.
+	rendererClientBus.snapshot(key);
+	return rendererClientBus.overlay(key, {
 		initialData: emptyTimelineProjection(),
 		update: (projection) => {
 			const index = projection.messages.findIndex(
@@ -1360,6 +1365,7 @@ export const addOptimisticSessionMessage = (
 			return SessionTimelineProjection.make({ ...projection, messages });
 		},
 	});
+};
 
 export const removeOptimisticSessionMessage = (
 	ref: SessionRef,

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -815,12 +815,12 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 					),
 				},
 			}));
-			// Keep the pre-ack workspace card mounted until the worktree projection is
-			// hydrated. Clearing it first briefly exposes ChatView with an authoritative
-			// session but no worktree row, which mislabels the handoff as "Starting
-			// agent" even though workspace setup has only just completed.
+			// Refresh the worktree projection without gating the acknowledged chat.
+			// This side request can be delayed independently of chat creation; awaiting
+			// it leaves the provisional setup surface mounted while the real turn runs
+			// behind it, so the transcript only appears after a navigation remount.
 			if (chat.worktreeId !== null) {
-				await useWorktreesStore.getState().refresh(projectId);
+				void useWorktreesStore.getState().refresh(projectId);
 			}
 			// Land the new chat in front of the project's existing list and
 			// mark it active so the renderer immediately swaps to it.

--- a/apps/renderer/test/unit/chat-creation-handoff.test.ts
+++ b/apps/renderer/test/unit/chat-creation-handoff.test.ts
@@ -2,20 +2,27 @@ import { describe, expect, it } from "vitest";
 import chatsStoreSource from "../../src/store/chats.ts?raw";
 
 describe("chat creation handoff", () => {
-	it("hydrates a created worktree before removing the pending workspace card", () => {
+	it("does not gate an acknowledged chat on worktree hydration", () => {
 		const acknowledged = chatsStoreSource.indexOf(
 			'markRendererInteraction(initialSessionId, "entity-acknowledged")',
 		);
 		const authoritativeHandoff = chatsStoreSource.slice(acknowledged);
 		const hydrateWorktree = authoritativeHandoff.indexOf(
-			"await useWorktreesStore.getState().refresh(projectId)",
+			"void useWorktreesStore.getState().refresh(projectId)",
 		);
 		const clearPendingCreation = authoritativeHandoff.indexOf(
 			"pendingCreationByChat: Object.fromEntries",
+		);
+		const restartTimeline = authoritativeHandoff.indexOf(
+			"restartSessionTimeline({ environmentId, sessionId: initialSession.id })",
 		);
 
 		expect(acknowledged).toBeGreaterThan(-1);
 		expect(hydrateWorktree).toBeGreaterThan(-1);
 		expect(clearPendingCreation).toBeGreaterThan(hydrateWorktree);
+		expect(authoritativeHandoff.slice(0, clearPendingCreation)).not.toContain(
+			"await useWorktreesStore.getState().refresh(projectId)",
+		);
+		expect(restartTimeline).toBeGreaterThan(clearPendingCreation);
 	});
 });

--- a/apps/renderer/test/unit/cloud-ssh-readiness.test.ts
+++ b/apps/renderer/test/unit/cloud-ssh-readiness.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import cloudSshSource from "../../src/lib/cloud-ssh-client-bus.ts?raw";
+
+describe("cloud SSH readiness", () => {
+	it("keeps a wake lease until the gateway authorizes the desktop key", () => {
+		const retainGateway = cloudSshSource.indexOf("retainEnvironmentShell(");
+		const waitForGateway = cloudSshSource.indexOf(
+			"await waitForWorkspaceGateway(environmentId, retained.key)",
+		);
+		const requestAccess = cloudSshSource.indexOf(
+			"access = await requestSshAccess(workspaceId)",
+		);
+		const authorizeKey = cloudSshSource.indexOf(
+			"await dispatchEnvironmentShellCommand<",
+		);
+		const releaseGateway = cloudSshSource.indexOf("retained.lease.release()");
+
+		expect(retainGateway).toBeGreaterThan(-1);
+		expect(waitForGateway).toBeGreaterThan(retainGateway);
+		expect(requestAccess).toBeGreaterThan(waitForGateway);
+		expect(authorizeKey).toBeGreaterThan(requestAccess);
+		expect(releaseGateway).toBeGreaterThan(authorizeKey);
+	});
+});

--- a/apps/renderer/test/unit/session-timeline-client-bus.test.ts
+++ b/apps/renderer/test/unit/session-timeline-client-bus.test.ts
@@ -19,6 +19,7 @@ import {
 import { Effect, Queue, Stream } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	addOptimisticSessionMessage,
 	completeOlderSessionMessages,
 	getRendererClientBus,
 	loadOlderSessionMessages,
@@ -340,6 +341,22 @@ describe("renderer session timeline ClientBus adapter", () => {
 		).toBe(true);
 		expect(getRendererClientBus().snapshot(key).data?.queue.items).toEqual([
 			queued,
+		]);
+	});
+
+	it("seeds a cloud launch message before its first timeline consumer mounts", () => {
+		const key = sessionTimelineResourceKey(ref);
+		const message = Message.make({
+			id: MessageId.make("cloud-launch-message"),
+			sessionId,
+			role: "user",
+			content: { _tag: "user", text: "visible during startup", goal: false },
+			createdAt: new Date(1),
+		});
+
+		expect(addOptimisticSessionMessage(ref, message)).toBe(true);
+		expect(getRendererClientBus().snapshot(key).data?.messages).toEqual([
+			message,
 		]);
 	});
 

--- a/infra/relay/src/cloud-workspace-reconciler.ts
+++ b/infra/relay/src/cloud-workspace-reconciler.ts
@@ -138,20 +138,18 @@ class CloudWorkspaceLeaseLostError extends Data.TaggedError(
 type SaveClaimedWorkspace = (
 	workspace: CloudWorkspaceRecord,
 ) => Effect.Effect<void, CloudWorkspaceLeaseLostError>;
-const WORKSPACE_RUNTIME_PROCESS = {
+export const WORKSPACE_RUNTIME_PROCESS_SELECTOR = {
 	tag: "zuse-runtime",
 	legacyCommandMarkers: [
 		"zuse-workspace-bootstrap",
 		"/opt/zuse/current/bin.mjs serve",
 		"/usr/local/bin/zuse serve",
 	],
+	// E2B tags the process started through envd, but the bootstrap process can
+	// leave an untagged runtime child behind when it is killed. Always sweep the
+	// matching command tree before binding the replacement gateway port.
+	legacyCleanup: "matching-command",
 } as const;
-const workspaceRuntimeProcessSelector = (workspace: CloudWorkspaceRecord) => ({
-	...WORKSPACE_RUNTIME_PROCESS,
-	...(workspace.requestConfig.runtimeProcessManaged === true
-		? {}
-		: { legacyCleanup: "matching-command" as const }),
-});
 export const WORKSPACE_RUNTIME_RESUME_SCRIPT = `set -e; runtime=/opt/zuse/current/bin.mjs; fallback=/usr/local/bin/zuse; rm -f /var/lib/zuse/workspace/failed; if [ -n "\${ZUSE_RUNTIME_MANIFEST_URL:-}" ] && [ -f "\${ZUSE_RUNTIME_PUBLIC_KEY_FILE:-}" ]; then ZUSE_RUNTIME_INSTALL_ONLY=1 ZUSE_RUNTIME_SKIP_TOOLCHAIN=1 ZUSE_RUNTIME_WIRE_PROTOCOL="\${ZUSE_RUNTIME_WIRE_PROTOCOL:?}" node /usr/local/lib/zuse/runtime-updater.mjs >/var/lib/zuse/workspace/runtime-update.log 2>&1; fi; if [ -f "$runtime" ]; then exec node "$runtime" serve; else exec "$fallback" serve; fi`;
 const providerLabel = (kind: "build" | "workspace", id: string): string =>
 	`zuse-cloud-${kind}-${id.replace(/[^A-Za-z0-9-]/gu, "-")}`.slice(0, 63);
@@ -783,7 +781,7 @@ const restartWorkspaceRuntime = Effect.fn("restartCloudWorkspaceRuntime")(
 		});
 		yield* provider.replaceProcess(
 			providerSandboxId,
-			workspaceRuntimeProcessSelector(workspace),
+			WORKSPACE_RUNTIME_PROCESS_SELECTOR,
 			{
 				command: "/bin/bash",
 				args: ["-lc", WORKSPACE_RUNTIME_RESUME_SCRIPT],
@@ -1058,7 +1056,7 @@ const reconcileWorkspaceRecord = Effect.fn("reconcileCloudWorkspace")(
 			});
 			yield* provider.startProcess(sandbox.providerSandboxId, {
 				command: "/usr/local/bin/zuse-workspace-bootstrap",
-				tag: WORKSPACE_RUNTIME_PROCESS.tag,
+				tag: WORKSPACE_RUNTIME_PROCESS_SELECTOR.tag,
 				cwd: "/home/zuse",
 				env: {
 					...project.cloudEnvironment,
@@ -1252,7 +1250,7 @@ const reconcileWorkspaceRecord = Effect.fn("reconcileCloudWorkspace")(
 				});
 				yield* provider.replaceProcess(
 					workspace.providerSandboxId,
-					workspaceRuntimeProcessSelector(workspace),
+					WORKSPACE_RUNTIME_PROCESS_SELECTOR,
 					{
 						command: "/bin/bash",
 						args: ["-lc", "exec /usr/local/bin/zuse-workspace-bootstrap"],

--- a/infra/relay/test/unit/cloud-workspace-reconciler.test.ts
+++ b/infra/relay/test/unit/cloud-workspace-reconciler.test.ts
@@ -11,6 +11,7 @@ import {
 	reconcileCloudWorkspace,
 	reusableAccountBuildSnapshot,
 	sanitizeProjectBuildDiagnostic,
+	WORKSPACE_RUNTIME_PROCESS_SELECTOR,
 	WORKSPACE_RUNTIME_RESUME_SCRIPT,
 } from "../../src/cloud-workspace-reconciler.ts";
 import {
@@ -149,6 +150,13 @@ describe("cloud workspace reconciler", () => {
 		expect(WORKSPACE_RUNTIME_RESUME_SCRIPT).toContain(
 			"/usr/local/lib/zuse/runtime-updater.mjs",
 		);
+	});
+
+	test("cleans matching runtime children on every replacement", () => {
+		expect(WORKSPACE_RUNTIME_PROCESS_SELECTOR).toMatchObject({
+			tag: "zuse-runtime",
+			legacyCleanup: "matching-command",
+		});
 	});
 
 	test("bounds and redacts project builder diagnostics", () => {

--- a/packages/sandbox-providers/src/e2b.ts
+++ b/packages/sandbox-providers/src/e2b.ts
@@ -466,10 +466,8 @@ export const makeE2bSandboxProvider = (
 				Effect.mapError(() => providerError("transient")),
 			);
 			const legacyMarkers = selector.legacyCommandMarkers ?? [];
-			let taggedProcessFound = false;
 			const replaced = listed.processes.filter((process) => {
 				if (process.tag === selector.tag) {
-					taggedProcessFound = true;
 					return true;
 				}
 				const command = [
@@ -510,7 +508,6 @@ export const makeE2bSandboxProvider = (
 			);
 			const cleanupLegacyCommands =
 				selector.legacyCleanup === "matching-command" &&
-				!taggedProcessFound &&
 				legacyMarkers.length > 0;
 			const replacement = cleanupLegacyCommands
 				? {

--- a/packages/sandbox-providers/test/unit/e2b.test.ts
+++ b/packages/sandbox-providers/test/unit/e2b.test.ts
@@ -513,6 +513,77 @@ describe("E2B sandbox provider", () => {
 		).not.toContain("proc_uid");
 	});
 
+	test("cleans untagged runtime children after killing a tagged parent", async () => {
+		const detail = {
+			sandboxID: "sbx_1",
+			state: "running",
+			domain: "custom.e2b.app",
+			envdAccessToken: "envd-secret",
+		};
+		const http = makeHttp([
+			{ status: 200, body: detail },
+			{
+				status: 201,
+				body: { sandboxID: "sbx_1", envdAccessToken: "envd-secret" },
+			},
+			{
+				status: 200,
+				body: {
+					processes: [
+						{
+							config: {
+								cmd: "/usr/local/bin/zuse-workspace-bootstrap",
+								args: [],
+							},
+							pid: 41,
+							tag: "zuse-runtime",
+						},
+					],
+				},
+			},
+			{ status: 200, body: {} },
+			{ status: 200, body: detail },
+			{
+				status: 200,
+				rawBody: connectJsonResponse({ event: { start: { pid: 42 } } }),
+			},
+		]);
+		const adapter = makeAdapter(http.client);
+
+		await Effect.runPromise(
+			adapter.replaceProcess(
+				"sbx_1",
+				{
+					tag: "zuse-runtime",
+					legacyCommandMarkers: [
+						"zuse-workspace-bootstrap",
+						"/opt/zuse/current/bin.mjs serve",
+					],
+					legacyCleanup: "matching-command",
+				},
+				{ command: "/opt/zuse/current/bin.mjs", args: ["serve"] },
+			),
+		);
+
+		expect(http.calls[3]?.url).toContain("/process.Process/SendSignal");
+		expect(decodeConnectJsonBody(http.calls[5]?.init?.body)).toMatchObject({
+			process: {
+				cmd: "/bin/bash",
+				args: [
+					"-lc",
+					expect.stringContaining('[[ "$command" == *"$marker"* ]]'),
+					"zuse-runtime-legacy-cleanup",
+					"2",
+					"zuse-workspace-bootstrap",
+					"/opt/zuse/current/bin.mjs serve",
+					"/opt/zuse/current/bin.mjs",
+					"serve",
+				],
+			},
+			tag: "zuse-runtime",
+		});
+	});
+
 	test("rejects a process stream that does not confirm the process started", async () => {
 		const http = makeHttp([
 			{


### PR DESCRIPTION
## Summary

- show acknowledged chats and optimistic launch messages immediately during workspace startup
- keep the cloud gateway alive while preparing SSH access, and only enable access when runtime readiness is authoritative
- fix remote rsync gitignore filter argument encoding
- remove orphaned runtime children before replacing a resumed E2B gateway process

## Validation

- `bun vitest run` across 6 affected test files (62 tests)
- renderer, desktop, sandbox-provider, and relay type checks
- renderer state architecture check
- Biome on all 13 changed files
- `git diff --check origin/main...HEAD`

