### PR TITLE
Fix worktree unarchive and startup reliability

### DIFF
--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -43,6 +43,7 @@ import {
 	useSessionCommandErrors,
 } from "../lib/session-actions.ts";
 import { timelineReadingPositionStore } from "../lib/session-timeline-cache.ts";
+import { restartProvisionalSessionTimeline } from "../lib/session-timeline-client-bus.ts";
 import { useRendererSessionTimeline } from "../lib/session-timeline-hooks.ts";
 import {
 	resolveInitialTimelineTarget,
@@ -111,6 +112,10 @@ export function ChatView({
 		environmentId,
 	);
 	const sessionRef = timeline.ref;
+	useEffect(() => {
+		if (cloudSummary !== null) return;
+		restartProvisionalSessionTimeline(sessionRef, timeline.view);
+	}, [cloudSummary, sessionRef, timeline.view.cursor, timeline.view.data]);
 	const errorKey = sessionCommandErrorKey(sessionRef);
 	const localError = useSessionCommandErrors(
 		(state) => state.errorByResource[errorKey] ?? null,

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -1671,6 +1671,9 @@ function ChatRow({ chat, projectRoot }: { chat: Chat; projectRoot: string }) {
 	const archiveProgress = useChatsStore(
 		(s) => s.archiveProgressByChat[chat.id] ?? null,
 	);
+	const isRestoring = useArchivePreviewStore(
+		(s) => s.restoringByChat[chat.id] === true,
+	);
 	const creationPending = useChatsStore(
 		(s) => s.pendingCreationByChat[chat.id] !== undefined,
 	);
@@ -1827,6 +1830,18 @@ function ChatRow({ chat, projectRoot }: { chat: Chat; projectRoot: string }) {
 		if (isArchiving) return;
 		void archiveChatWithConfirm(chat.id);
 	};
+	const restoreChat = () => {
+		if (isRestoring) return;
+		void unarchiveChat(chat.id).then((outcome) => {
+			if (!outcome.ok) {
+				toastManager.add({
+					type: "error",
+					title: "Chat could not be restored",
+					description: outcome.reason,
+				});
+			}
+		});
+	};
 
 	return (
 		<>
@@ -1913,11 +1928,11 @@ function ChatRow({ chat, projectRoot }: { chat: Chat; projectRoot: string }) {
 						</span>
 						<button
 							type="button"
-							disabled={isArchiving}
+							disabled={isArchiving || isRestoring}
 							onClick={(e) => {
 								e.stopPropagation();
 								if (isArchived) {
-									void unarchiveChat(chat.id);
+									restoreChat();
 								} else {
 									archiveChat();
 								}
@@ -1929,7 +1944,7 @@ function ChatRow({ chat, projectRoot }: { chat: Chat; projectRoot: string }) {
 							aria-label={`${primaryActionLabel} ${chat.title}`}
 							title={primaryActionLabel}
 						>
-							{isArchiving ? (
+							{isArchiving || isRestoring ? (
 								<Spinner className="size-3.5" />
 							) : (
 								<HugeiconsIcon icon={primaryActionIcon} className="size-3.5" />
@@ -1954,10 +1969,15 @@ function ChatRow({ chat, projectRoot }: { chat: Chat; projectRoot: string }) {
 					</MenuItem>
 					{isArchived ? (
 						<MenuItem
-							onClick={() => void unarchiveChat(chat.id)}
+							disabled={isRestoring}
+							onClick={restoreChat}
 							className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] hover:bg-sidebar-accent"
 						>
-							<HugeiconsIcon icon={ArchiveArrowUpIcon} className="size-3.5" />
+							{isRestoring ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<HugeiconsIcon icon={ArchiveArrowUpIcon} className="size-3.5" />
+							)}
 							Unarchive
 						</MenuItem>
 					) : (

--- a/apps/renderer/src/lib/git-workspace-client-bus.ts
+++ b/apps/renderer/src/lib/git-workspace-client-bus.ts
@@ -96,24 +96,37 @@ const prDescription = (info: GitPrInfo): string => {
 	return info.branch ?? "";
 };
 
+const notifiedPrTerminalStates = new Set<string>();
+
+const prTerminalStateKey = (ref: ExecutionRef, info: GitPrInfo): string => {
+	const identity =
+		info.url ??
+		`${ref.environmentId}:${ref.folderId}:${info.number ?? "unknown"}:${info.branch ?? "unknown"}:${info.baseBranch ?? "unknown"}`;
+	return `${identity}:${info.state}`;
+};
+
 const notifyPrStateTransition = (
+	ref: ExecutionRef,
 	previous: GitPrInfo | null | undefined,
 	next: GitPrInfo | null,
 ): void => {
 	if (
 		previous?.state !== "open" ||
 		next === null ||
-		next.state === previous.state
+		(next.state !== "merged" && next.state !== "closed")
 	) {
 		return;
 	}
+	const transitionKey = prTerminalStateKey(ref, next);
+	if (notifiedPrTerminalStates.has(transitionKey)) return;
+	notifiedPrTerminalStates.add(transitionKey);
 	if (next.state === "merged") {
 		toastManager.add({
 			type: "success",
 			title: `${prLabel(next)} merged`,
 			description: prDescription(next),
 		});
-	} else if (next.state === "closed") {
+	} else {
 		toastManager.add({
 			type: "info",
 			title: `${prLabel(next)} closed`,
@@ -304,7 +317,7 @@ const makeWorkspaceDriver = (): ResourceDriver<
 				}
 			}
 			const nextPr = pr.ok ? pr.value : (previous?.pr ?? null);
-			notifyPrStateTransition(previous?.pr, nextPr);
+			notifyPrStateTransition(ref, previous?.pr, nextPr);
 			return {
 				status: noRepository
 					? null
@@ -593,4 +606,5 @@ export const resetGitWorkspaceClientBusForTest = (): void => {
 	workspaceDriverStarts = 0;
 	workspaceRefreshers.clear();
 	patchRequests.clear();
+	notifiedPrTerminalStates.clear();
 };

--- a/apps/renderer/src/lib/session-timeline-client-bus.ts
+++ b/apps/renderer/src/lib/session-timeline-client-bus.ts
@@ -1401,6 +1401,21 @@ export const updateOptimisticSessionQueue = (
 export const restartSessionTimeline = (ref: SessionRef): boolean =>
 	rendererClientBus.restart(sessionTimelineResourceKey(ref));
 
+/**
+ * Repairs the creation race where an optimistic timeline exists before the
+ * durable session, but the creation acknowledgement tries to restart it before
+ * ChatView has retained a live driver. Calling this from the mounted consumer
+ * guarantees the resource has an owner; a real snapshot cursor makes the
+ * operation a no-op on ordinary chat mounts.
+ */
+export const restartProvisionalSessionTimeline = (
+	ref: SessionRef,
+	view: ResourceView<SessionTimelineProjection>,
+): boolean => {
+	if (view.data === null || view.cursor !== null) return false;
+	return restartSessionTimeline(ref);
+};
+
 export const retainSessionTimeline = (
 	ref: SessionRef,
 	activation: ResourceActivation,

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -1269,7 +1269,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 				const chat = chatReceipt.result;
 				const job = jobReceipt.result;
 				if (chat.archivedAt !== null) {
-					reconciled = { chat, cleanup: null, checkpoint: null, job };
+					reconciled = { chat, checkpoint: null, job };
 				} else {
 					definitiveFailure = true;
 				}
@@ -1527,6 +1527,17 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 				useUiStore.getState().setActiveMainTab("chat");
 				if (result.worktree !== null) {
 					void useWorktreesStore.getState().refresh(resolvedProjectId);
+					useWorktreesStore
+						.getState()
+						.subscribeSetup(resolvedProjectId, result.worktree.id);
+				}
+				if (result.restoreNotice === "branch-advanced") {
+					toastManager.add({
+						type: "warning",
+						title: "Branch changed while archived",
+						description:
+							"The worktree was restored at the latest branch tip. Archived changes remain safely stored for recovery.",
+					});
 				}
 				return { ok: true, ...result } as const;
 			} catch (err) {

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -169,7 +169,6 @@ type SessionsState = {
 	) => Promise<{ readonly ok: true } | { readonly ok: false; reason: string }>;
 	readonly refreshOne: (sessionId: SessionId) => Promise<void>;
 	readonly archive: (sessionId: SessionId) => Promise<void>;
-	readonly unarchive: (sessionId: SessionId) => Promise<void>;
 	readonly remove: (sessionId: SessionId) => Promise<void>;
 	readonly resume: (
 		sessionId: SessionId,
@@ -772,21 +771,6 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 					selectedSessionByProject,
 				};
 			});
-		} catch (err) {
-			set({ error: formatError(err) });
-		}
-	},
-	unarchive: async (sessionId) => {
-		set({ error: null });
-		try {
-			const commandId = nextCommandId("session-unarchive");
-			await dispatchTimelineCommand(
-				sessionId,
-				"session.unarchive",
-				commandId,
-				{ sessionId },
-				"never",
-			);
 		} catch (err) {
 			set({ error: formatError(err) });
 		}

--- a/apps/renderer/test/unit/git-workspace-client-bus.test.ts
+++ b/apps/renderer/test/unit/git-workspace-client-bus.test.ts
@@ -5,7 +5,8 @@ import {
 	WorktreeId,
 } from "@zuse/contracts";
 import { Effect, Queue, Stream } from "effect";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toastManager } from "../../src/components/ui/toast.tsx";
 import {
 	gitWorkspaceDriverStartsForTest,
 	gitWorkspaceResourceKey,
@@ -38,6 +39,7 @@ const ref = {
 
 describe("renderer Git workspace ClientBus adapter", () => {
 	afterEach(() => {
+		vi.restoreAllMocks();
 		resetGitWorkspaceClientBusForTest();
 		resetSessionTimelineClientBusForTest();
 	});
@@ -158,6 +160,99 @@ describe("renderer Git workspace ClientBus adapter", () => {
 
 		expect(first).not.toEqual(otherEnvironment);
 		expect(first).not.toEqual(otherRoot);
+	});
+
+	it("announces one PR terminal transition across multiple workspaces", async () => {
+		const queues = new Map<string, Queue.Queue<{ revision: number }>>();
+		let prState: "open" | "merged" = "open";
+		const prInfo = () => ({
+			state: prState,
+			branch: "feature",
+			baseBranch: "main",
+			additions: 1,
+			deletions: 0,
+			number: 2050,
+			url: "https://github.com/example/repo/pull/2050",
+			isDraft: false,
+			checks: "success" as const,
+			mergeable: "clean" as const,
+			checksTotal: 1,
+			checksRunning: 0,
+			checksPassing: 1,
+			checksFailing: 0,
+			autoMergeEnabled: false,
+		});
+		setSessionTimelineRpcClientForTest(
+			async () =>
+				({
+					"git.workspaceChanges": ({
+						worktreeId: requestedId,
+					}: {
+						readonly worktreeId?: WorktreeId | null;
+					}) => {
+						const queue = Effect.runSync(
+							Queue.unbounded<{ revision: number }>(),
+						);
+						queues.set(requestedId ?? "main", queue);
+						return Stream.fromQueue(queue);
+					},
+					"git.status": () =>
+						Effect.succeed({
+							branch: "feature",
+							ahead: 0,
+							behind: 0,
+							dirtyFiles: 0,
+						}),
+					"git.changes": () => Effect.succeed([]),
+					"git.prState": () => Effect.succeed(prInfo()),
+					"git.reviewSummary": () =>
+						Effect.succeed({
+							baseRef: "main",
+							headRef: "feature",
+							scope: "branch",
+							baseSha: "base",
+							headSha: "head",
+							files: [],
+							additions: 1,
+							deletions: 0,
+						}),
+					"git.reviewPatches": () => Stream.empty,
+					"git.prDetails": () =>
+						Effect.fail(new GitNotARepoError({ folderId })),
+				}) as never,
+		);
+		const addToast = vi.spyOn(toastManager, "add");
+		const otherRef = {
+			...ref,
+			worktreeId: WorktreeId.make("git-worktree-2"),
+			rootPath: "/project/worktree-2",
+		};
+		const first = retainGitWorkspace(ref);
+		const second = retainGitWorkspace(otherRef);
+		await waitUntil(() => queues.size === 2);
+		for (const queue of queues.values()) {
+			Queue.offerUnsafe(queue, { revision: 0 });
+		}
+		await waitUntil(
+			() =>
+				getRendererClientBus().snapshot(first.key).data?.pr?.state === "open" &&
+				getRendererClientBus().snapshot(second.key).data?.pr?.state === "open",
+		);
+
+		prState = "merged";
+		for (const queue of queues.values()) {
+			Queue.offerUnsafe(queue, { revision: 1 });
+		}
+		await waitUntil(
+			() =>
+				getRendererClientBus().snapshot(first.key).data?.pr?.state ===
+					"merged" &&
+				getRendererClientBus().snapshot(second.key).data?.pr?.state ===
+					"merged",
+		);
+		expect(addToast).toHaveBeenCalledTimes(1);
+		first.lease.release();
+		second.lease.release();
 	});
 
 	it("keeps a non-Git folder failure scoped to its Git resource", async () => {

--- a/apps/renderer/test/unit/session-timeline-client-bus.test.ts
+++ b/apps/renderer/test/unit/session-timeline-client-bus.test.ts
@@ -30,7 +30,7 @@ import {
 	registerSessionTimelineOlderPageSynchronizer,
 	rehydrateRendererCommandPayload,
 	resetSessionTimelineClientBusForTest,
-	restartSessionTimeline,
+	restartProvisionalSessionTimeline,
 	retainSessionTimeline,
 	sessionTimelineResourceKey,
 	setSessionTimelineRpcClientForTest,
@@ -287,7 +287,13 @@ describe("renderer session timeline ClientBus adapter", () => {
 		expect(getRendererClientBus().connection(environmentId).phase).toBe(
 			"connected",
 		);
-		expect(restartSessionTimeline(ref)).toBe(true);
+		// New-chat creation installs its optimistic queue before ChatView owns the
+		// stream. Reproduce that cursorless runtime projection here.
+		expect(updateOptimisticSessionQueue(ref, (queue) => queue)).toBe(true);
+		const provisional = getRendererClientBus().snapshot(retained.key);
+		expect(provisional.cursor).toBeNull();
+		expect(provisional.data).not.toBeNull();
+		expect(restartProvisionalSessionTimeline(ref, provisional)).toBe(true);
 		await waitUntil(() => streamStarts === 2);
 		Queue.offerUnsafe(frames, {
 			kind: "snapshot",
@@ -312,6 +318,12 @@ describe("renderer session timeline ClientBus adapter", () => {
 		await waitUntil(
 			() => getRendererClientBus().snapshot(retained.key).sync === "live",
 		);
+		expect(
+			restartProvisionalSessionTimeline(
+				ref,
+				getRendererClientBus().snapshot(retained.key),
+			),
+		).toBe(false);
 		retained.lease.release();
 	});
 

--- a/apps/server/src/conversation/core/archive-operations.ts
+++ b/apps/server/src/conversation/core/archive-operations.ts
@@ -8,6 +8,7 @@ import {
 	type FolderId,
 	SessionId,
 	type Worktree,
+	WorktreeArchiveSnapshot,
 	WorktreeCheckpointError,
 	WorktreeId,
 } from "@zuse/contracts";
@@ -21,6 +22,7 @@ import {
 	Effect,
 	Fiber,
 	FileSystem,
+	Option,
 	Path,
 	Ref,
 	Schema,
@@ -50,22 +52,30 @@ const WorktreeArchiveOutcomeSchema = Schema.Struct({
 	archiveRef: Schema.NullOr(Schema.String),
 	archivedContextPath: Schema.NullOr(Schema.String),
 	branch: Schema.String,
+	detachedHead: Schema.optional(Schema.Boolean),
+	branchProvenance: Schema.optional(
+		Schema.Literals(["pending", "automatic", "manual"]),
+	),
+	pokemonNumber: Schema.optional(Schema.NullOr(Schema.Number)),
 });
 const WorktreeCheckpointJournalDetailSchema = Schema.Struct({
-	id: Schema.String,
-	projectId: Schema.String,
-	path: Schema.String,
-	name: Schema.String,
-	branch: Schema.String,
-	baseBranch: Schema.String,
-	createdAt: Schema.String,
+	...WorktreeArchiveSnapshot.fields,
 	outcome: WorktreeArchiveOutcomeSchema,
 });
 const decodeWorktreeCheckpointJournalDetail = Schema.decodeUnknownEffect(
 	Schema.fromJsonString(WorktreeCheckpointJournalDetailSchema),
 );
+const ArchiveAcceptanceSessionsSchema = Schema.Array(
+	Schema.Struct({ id: Schema.String, archivedAt: Schema.Number }),
+);
+const decodeArchiveAcceptanceSessions = Schema.decodeUnknownOption(
+	Schema.fromJsonString(ArchiveAcceptanceSessionsSchema),
+);
 const checkpointSummary = (
-	outcome: WorktreeArchiveOutcome,
+	outcome: Pick<
+		WorktreeArchiveOutcome,
+		"archiveCommit" | "checkpointCreated" | "archiveRef" | "branch"
+	>,
 ): NonNullable<ChatArchiveResult["checkpoint"]> => ({
 	archiveCommit: outcome.archiveCommit,
 	checkpointCreated: outcome.checkpointCreated,
@@ -155,6 +165,22 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						if (existing !== undefined) return existing;
 						const created = yield* Semaphore.make(1);
 						locks.set(key, created);
+						return created;
+					}),
+				);
+				return yield* lock.withPermits(1)(effect);
+			});
+		const withWorktreeLock = <A, E, R>(
+			worktreeId: string,
+			effect: Effect.Effect<A, E, R>,
+		) =>
+			Effect.gen(function* () {
+				const lock = yield* worktreeLockGuard.withPermits(1)(
+					Effect.gen(function* () {
+						const existing = worktreeLocks.get(worktreeId);
+						if (existing !== undefined) return existing;
+						const created = yield* Semaphore.make(1);
+						worktreeLocks.set(worktreeId, created);
 						return created;
 					}),
 				);
@@ -251,6 +277,69 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 				Effect.orDie,
 				Effect.map((rows) => rows[0] ?? null),
 			);
+		const resolveArchivedWorktreeSnapshot = (
+			chatId: ChatId,
+			chatSnapshotJson: string | null,
+			jobRow: ArchiveJobRow | null,
+		) =>
+			Effect.gen(function* () {
+				const snapshot = parseArchivedWorktreeSnapshot(
+					chatSnapshotJson ?? jobRow?.snapshot_json ?? null,
+				);
+				if (jobRow === null) return snapshot;
+				const journalRows = yield* sql<{
+					readonly detail_json: string | null;
+				}>`
+					SELECT detail_json FROM reactor_effect_steps
+					WHERE effect_id = ${jobRow.command_id}
+					  AND step = 'worktree-checkpoint'
+					  AND status = 'completed'
+					LIMIT 1
+				`.pipe(Effect.orDie);
+				const detailJson = journalRows[0]?.detail_json;
+				if (detailJson == null) return snapshot;
+				const detail = yield* decodeWorktreeCheckpointJournalDetail(
+					detailJson,
+				).pipe(
+					Effect.mapError(
+						(cause) =>
+							new ChatArchiveWorktreeError({
+								chatId,
+								reason: `Stored checkpoint result is invalid: ${String(cause)}`,
+							}),
+					),
+				);
+				const base = snapshot ?? {
+					id: detail.id,
+					projectId: detail.projectId,
+					path: detail.path,
+					name: detail.name,
+					branch: detail.branch,
+					baseBranch: detail.baseBranch,
+					createdAt: detail.createdAt,
+				};
+				return {
+					...base,
+					...detail.outcome,
+				} satisfies typeof WorktreeArchiveSnapshot.Type;
+			});
+		const recordArchiveCheckpoint = (
+			chatIds: ReadonlyArray<ChatId>,
+			archivedWorktreeJson: string,
+		) =>
+			Effect.gen(function* () {
+				const recordedAt = yield* currentTimestamp;
+				yield* Effect.forEach(
+					chatIds,
+					(id) =>
+						dispatchChatCommand(id, {
+							_tag: "RecordArchiveCheckpoint",
+							archivedWorktreeJson,
+							recordedAt,
+						}),
+					{ discard: true },
+				);
+			});
 		const normalizeHandledArchiveFailure = (row: ArchiveJobRow) =>
 			Effect.gen(function* () {
 				if (
@@ -294,12 +383,7 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 			Effect.gen(function* () {
 				yield* lookupChat(chatId);
 				const row = yield* archiveJobRow(chatId);
-				// Repair jobs written by older cleanup workers that promoted an
-				// expected no-Git condition into a terminal failure. These jobs are
-				// already logically archived and must not advertise Force archive.
-				return row === null
-					? null
-					: archiveJobFromRow(yield* normalizeHandledArchiveFailure(row));
+				return row === null ? null : archiveJobFromRow(row);
 			});
 		const listArchiveJobs: ConversationOperations["listArchiveJobs"] = (
 			projectId,
@@ -314,9 +398,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
         ORDER BY j.updated_at DESC
 			`.pipe(
 				Effect.orDie,
-				Effect.flatMap((rows) =>
-					Effect.forEach(rows, normalizeHandledArchiveFailure),
-				),
 				Effect.map((rows) =>
 					rows
 						.filter(
@@ -527,22 +608,12 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						WorktreeId.make(row.worktree_id),
 					);
 					if (existing === null) {
-						const snapshot = parseArchivedWorktreeSnapshot(row.snapshot_json);
-						const journalRows = yield* sql<{
-							readonly detail_json: string | null;
-						}>`
-							SELECT detail_json FROM reactor_effect_steps
-							WHERE effect_id = ${row.command_id}
-							  AND step = 'worktree-checkpoint'
-							  AND status = 'completed'
-							LIMIT 1
-						`.pipe(Effect.orDie);
-						const detailJson = journalRows[0]?.detail_json;
-						if (
-							snapshot === null ||
-							detailJson === undefined ||
-							detailJson === null
-						) {
+						const restoredSnapshot = yield* resolveArchivedWorktreeSnapshot(
+							chatId,
+							null,
+							row,
+						);
+						if (restoredSnapshot === null) {
 							return yield* Effect.fail(
 								new ChatArchiveWorktreeError({
 									chatId,
@@ -551,46 +622,17 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 								}),
 							);
 						}
-						const detail = yield* decodeWorktreeCheckpointJournalDetail(
-							detailJson,
-						).pipe(
+						yield* worktrees.restore(restoredSnapshot).pipe(
 							Effect.mapError(
-								(cause) =>
+								(error) =>
 									new ChatArchiveWorktreeError({
 										chatId,
-										reason: `Stored checkpoint result is invalid: ${String(cause)}`,
+										reason: `Force archive could not restore the removed worktree: ${String(error)}`,
 									}),
 							),
 						);
-						const restoredSnapshot = { ...snapshot, ...detail.outcome };
-						yield* worktrees
-							.restore({
-								id: WorktreeId.make(restoredSnapshot.id),
-								projectId: restoredSnapshot.projectId as FolderId,
-								path: restoredSnapshot.path,
-								name: restoredSnapshot.name,
-								branch: restoredSnapshot.branch,
-								baseBranch: restoredSnapshot.baseBranch,
-								createdAt: new Date(restoredSnapshot.createdAt),
-								archiveCommit: restoredSnapshot.archiveCommit,
-								checkpointCreated: restoredSnapshot.checkpointCreated,
-								archiveRef: restoredSnapshot.archiveRef,
-								archivedContextPath: restoredSnapshot.archivedContextPath,
-							})
-							.pipe(
-								Effect.mapError(
-									(error) =>
-										new ChatArchiveWorktreeError({
-											chatId,
-											reason: `Force archive could not restore the removed worktree: ${String(error)}`,
-										}),
-								),
-							);
 						const restoredJson = JSON.stringify(restoredSnapshot);
-						yield* sql`
-							UPDATE chats SET archived_worktree_json = ${restoredJson}
-							WHERE id = ${chatId}
-						`.pipe(Effect.orDie);
+						yield* recordArchiveCheckpoint([chatId], restoredJson);
 						yield* sql`
 							UPDATE chat_archive_jobs SET snapshot_json = ${restoredJson}
 							WHERE chat_id = ${chatId}
@@ -664,10 +706,7 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						siblingSnapshot?.archiveRef !== undefined
 					) {
 						const completedSnapshot = JSON.stringify(siblingSnapshot);
-						yield* sql`
-							UPDATE chats SET archived_worktree_json = ${completedSnapshot}
-							WHERE id = ${chatId} AND archived_at IS NOT NULL
-						`.pipe(Effect.orDie);
+						yield* recordArchiveCheckpoint([chatId], completedSnapshot);
 						yield* sql`
 							UPDATE chat_archive_jobs SET snapshot_json = ${completedSnapshot}
 							WHERE chat_id = ${chatId}
@@ -701,10 +740,7 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 							...snapshot,
 							...detail.outcome,
 						});
-						yield* sql`
-              UPDATE chats SET archived_worktree_json = ${completedSnapshot}
-              WHERE id = ${chatId} AND archived_at IS NOT NULL
-            `.pipe(Effect.orDie);
+						yield* recordArchiveCheckpoint([chatId], completedSnapshot);
 						yield* sql`
               UPDATE chat_archive_jobs SET snapshot_json = ${completedSnapshot}
               WHERE chat_id = ${chatId}
@@ -828,22 +864,21 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 				if (!(yield* jobMayContinue(chatId))) return;
 				const completedSnapshot = JSON.stringify({ ...snapshot, ...outcome });
 				yield* sql`
-          UPDATE chats SET archived_worktree_json = ${completedSnapshot}
-          WHERE id = ${chatId} AND archived_at IS NOT NULL
-        `.pipe(Effect.orDie);
-				yield* sql`
 					UPDATE chat_archive_jobs SET snapshot_json = ${completedSnapshot}
 					WHERE chat_id = ${chatId}
 				`.pipe(Effect.orDie);
 				// Every archived chat sharing this checkout must inherit the same
 				// checkpoint. Later unarchives can then restore even though only one
 				// worker performed the destructive work.
-				yield* sql`
-					UPDATE chats SET archived_worktree_json = ${completedSnapshot}
-					WHERE id IN (
-						SELECT chat_id FROM chat_archive_jobs WHERE worktree_id = ${worktreeId}
-					) AND archived_at IS NOT NULL
+				const affectedChats = yield* sql<{ readonly id: string }>`
+					SELECT c.id FROM chats c
+					INNER JOIN chat_archive_jobs j ON j.chat_id = c.id
+					WHERE j.worktree_id = ${worktreeId} AND c.archived_at IS NOT NULL
 				`.pipe(Effect.orDie);
+				yield* recordArchiveCheckpoint(
+					affectedChats.map(({ id }) => ChatId.make(id)),
+					completedSnapshot,
+				);
 				yield* sql`
 					UPDATE chat_archive_jobs
 					SET snapshot_json = ${completedSnapshot},
@@ -864,16 +899,7 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 					row?.snapshot_json ?? null,
 				);
 				if (snapshot === null) return yield* runArchiveCleanup(chatId);
-				const lock = yield* worktreeLockGuard.withPermits(1)(
-					Effect.gen(function* () {
-						const existing = worktreeLocks.get(snapshot.id);
-						if (existing !== undefined) return existing;
-						const created = yield* Semaphore.make(1);
-						worktreeLocks.set(snapshot.id, created);
-						return created;
-					}),
-				);
-				yield* lock.withPermits(1)(runArchiveCleanup(chatId));
+				yield* withWorktreeLock(snapshot.id, runArchiveCleanup(chatId));
 			});
 
 		const scheduleArchiveCleanup = (chatId: ChatId) =>
@@ -921,7 +947,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 					const existing = yield* archiveJobRow(chatId);
 					return {
 						chat,
-						cleanup: null,
 						checkpoint: null,
 						job: existing === null ? null : archiveJobFromRow(existing),
 					};
@@ -1024,7 +1049,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 				yield* reactorEffects.complete(commandId);
 				return {
 					chat: yield* lookupChat(chatId),
-					cleanup: null,
 					checkpoint: null,
 					job,
 				};
@@ -1047,7 +1071,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 				if (detailJson === undefined || detailJson === null) {
 					return {
 						chat: yield* lookupChat(chatId),
-						cleanup: null,
 						checkpoint: null,
 						job: jobRow === null ? null : archiveJobFromRow(jobRow),
 					};
@@ -1065,7 +1088,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 				);
 				return {
 					chat: yield* lookupChat(chatId),
-					cleanup: null,
 					checkpoint: checkpointSummary(detail.outcome),
 					job: jobRow === null ? null : archiveJobFromRow(jobRow),
 				};
@@ -1107,7 +1129,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						const jobRow = yield* archiveJobRow(chatId);
 						return {
 							chat,
-							cleanup: null,
 							checkpoint: null,
 							job: jobRow === null ? null : archiveJobFromRow(jobRow),
 						};
@@ -1130,23 +1151,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 					return result;
 				}),
 			);
-		const stopUnavailableDirectoryResources = (
-			chatId: ChatId,
-			path: string | null,
-		) =>
-			Effect.gen(function* () {
-				const sessions = yield* sql<{ readonly id: string }>`
-						SELECT id FROM sessions WHERE chat_id = ${chatId}
-					`.pipe(Effect.orDie);
-				for (const row of sessions) {
-					const sessionId = SessionId.make(row.id);
-					yield* closeProvider(sessionId).pipe(Effect.ignore);
-					yield* interruptProviderFiber(sessionId).pipe(Effect.ignore);
-				}
-				if (path !== null)
-					yield* ptys.closeByCwdPrefix(path).pipe(Effect.ignore);
-			});
-
 		const getChatDirectoryStatus: ConversationOperations["getChatDirectoryStatus"] =
 			(chatId) =>
 				Effect.gen(function* () {
@@ -1158,7 +1162,6 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 							.exists(rootPath)
 							.pipe(Effect.orElseSucceed(() => false)));
 					if (!rootExists) {
-						yield* stopUnavailableDirectoryResources(chatId, rootPath);
 						return { _tag: "unavailable", reason: "project-missing" } as const;
 					}
 					const archivedRows = yield* sql<{
@@ -1194,13 +1197,9 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 							archivedSnapshot?.archiveCommit !== undefined ||
 							archivedSnapshot?.archiveRef !== undefined
 						) {
-							return { _tag: "restorable" } as const;
+							return { _tag: "available" } as const;
 						}
 					}
-					yield* stopUnavailableDirectoryResources(
-						chatId,
-						worktree?.path ?? archivedSnapshot?.path ?? null,
-					);
 					return { _tag: "unavailable", reason: "worktree-missing" } as const;
 				});
 
@@ -1239,55 +1238,47 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						return yield* Effect.fail(new ChatNotFoundError({ chatId }));
 					}
 
-					const retainedSnapshotJson =
-						chatRow.archived_worktree_json ?? pendingJob?.snapshot_json ?? null;
-					const snapshot = parseArchivedWorktreeSnapshot(retainedSnapshotJson);
+					const snapshot = yield* resolveArchivedWorktreeSnapshot(
+						chatId,
+						chatRow.archived_worktree_json,
+						pendingJob,
+					);
 					let restoredWorktree: Worktree | null = null;
-					let restorationUnavailable = false;
+					let restoreNotice: "branch-advanced" | undefined;
 					let restoredWorktreeId: WorktreeId | null =
 						chatRow.worktree_id === null
 							? null
 							: WorktreeId.make(chatRow.worktree_id);
 					if (snapshot !== null) {
-						const existing = yield* worktrees.get(WorktreeId.make(snapshot.id));
-						const existingIsIntact =
-							existing !== null &&
-							(yield* fs
-								.exists(existing.path)
-								.pipe(Effect.orElseSucceed(() => false)));
-						if (existing !== null && existingIsIntact) {
-							restoredWorktree = existing;
-							restoredWorktreeId = existing.id;
-						} else if (existing !== null) {
-							// Retain the original association and restoration snapshot without
-							// claiming that a missing checkout is usable.
-							restoredWorktreeId = existing.id;
-							restorationUnavailable = true;
-						} else {
-							// The archived snapshot is authoritative. A stale worktree_id can
-							// outlive checkout removal when SQLite foreign-key cleanup has not
-							// run yet; skipping restore here silently routes the chat to main.
-							const restoration = yield* worktrees
-								.restore({
-									id: WorktreeId.make(snapshot.id),
-									projectId: snapshot.projectId as FolderId,
-									path: snapshot.path,
-									name: snapshot.name,
-									branch: snapshot.branch,
-									baseBranch: snapshot.baseBranch,
-									createdAt: new Date(snapshot.createdAt),
-									archiveCommit: snapshot.archiveCommit,
-									checkpointCreated: snapshot.checkpointCreated,
-									archiveRef: snapshot.archiveRef,
-									archivedContextPath: snapshot.archivedContextPath,
-								})
-								.pipe(Effect.result);
-							if (restoration._tag === "Success") {
-								restoredWorktree = restoration.success;
-								restoredWorktreeId = restoredWorktree.id;
-							} else {
-								restorationUnavailable = true;
-							}
+						const restoration = yield* withWorktreeLock(
+							snapshot.id,
+							Effect.gen(function* () {
+								const existing = yield* worktrees.get(snapshot.id);
+								const existingIsIntact =
+									existing !== null &&
+									(yield* fs
+										.exists(existing.path)
+										.pipe(Effect.orElseSucceed(() => false)));
+								return existingIsIntact && existing !== null
+									? {
+											worktree: existing,
+											checkpoint: "already-present" as const,
+										}
+									: yield* worktrees.restore(snapshot);
+							}),
+						).pipe(
+							Effect.mapError(
+								(error) =>
+									new ChatArchiveWorktreeError({
+										chatId,
+										reason: error.reason,
+									}),
+							),
+						);
+						restoredWorktree = restoration.worktree;
+						restoredWorktreeId = restoration.worktree.id;
+						if (restoration.checkpoint === "branch-advanced") {
+							restoreNotice = "branch-advanced";
 						}
 					}
 
@@ -1297,17 +1288,25 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						unarchivedAt,
 						worktreeId: restoredWorktreeId,
 					});
-					if (restorationUnavailable) {
-						yield* sql`
-			UPDATE chats SET archived_worktree_json = ${retainedSnapshotJson}
-			WHERE id = ${chatId}
-		  `.pipe(Effect.orDie);
-					}
-					const archivedSessions = yield* sql<{
+					const allArchivedSessions = yield* sql<{
 						readonly id: string;
+						readonly archived_at: string;
 					}>`
-          SELECT id FROM sessions WHERE chat_id = ${chatId}
+						SELECT id, archived_at FROM sessions
+						WHERE chat_id = ${chatId} AND archived_at IS NOT NULL
         `.pipe(Effect.orDie);
+					const accepted = Option.getOrNull(
+						decodeArchiveAcceptanceSessions(
+							pendingJob?.acceptance_sessions_json ?? "",
+						),
+					);
+					const acceptedIds = new Set(accepted?.map(({ id }) => id) ?? []);
+					const archivedSessions =
+						acceptedIds.size > 0
+							? allArchivedSessions.filter(({ id }) => acceptedIds.has(id))
+							: allArchivedSessions.filter(
+									({ archived_at }) => archived_at === chatRow.archived_at,
+								);
 					for (const row of archivedSessions) {
 						const sessionId = SessionId.make(row.id);
 						if (restoredWorktreeId !== null) {
@@ -1328,6 +1327,9 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 								unarchivedAt,
 							});
 						}
+						yield* closeProvider(sessionId);
+						yield* interruptProviderFiber(sessionId);
+						yield* setStatus(sessionId, "idle");
 					}
 					const sessions = yield* sql<SessionRow>`
           SELECT id, project_id, title, title_provenance, provider_id, model, status,
@@ -1344,6 +1346,7 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 						sessions: sessions.map(sessionFromRow),
 						worktree: restoredWorktree,
 						directoryStatus: yield* getChatDirectoryStatus(chatId),
+						...(restoreNotice === undefined ? {} : { restoreNotice }),
 					};
 				}),
 			);
@@ -1394,6 +1397,15 @@ export const makeArchiveOperations = Effect.fn("ArchiveOperations.make")(
 					reactorInput.commandId,
 				);
 			});
+
+		const handledFailures = yield* sql<ArchiveJobRow>`
+			SELECT chat_id, command_id, status, phase, worktree_id, snapshot_json,
+			       acceptance_sessions_json, cleanup_output, error, updated_at
+			FROM chat_archive_jobs WHERE status = 'failed'
+		`.pipe(Effect.orDie);
+		yield* Effect.forEach(handledFailures, normalizeHandledArchiveFailure, {
+			discard: true,
+		});
 
 		const retainedArchiveJobs = yield* sql<ArchiveJobRow>`
 			SELECT chat_id, command_id, status, phase, worktree_id, snapshot_json,

--- a/apps/server/src/conversation/core/conversation-records.ts
+++ b/apps/server/src/conversation/core/conversation-records.ts
@@ -15,6 +15,7 @@ import {
 	RuntimeMode,
 	Session,
 	SessionId,
+	WorktreeArchiveSnapshot,
 	type WorktreeId,
 } from "@zuse/contracts";
 import type { MessageReadRecord } from "@zuse/domain/projectors/read-model";
@@ -66,35 +67,9 @@ export interface MessageRow {
 	readonly created_at: string;
 }
 
-export interface ArchivedWorktreeSnapshot {
-	readonly id: string;
-	readonly projectId: string;
-	readonly path: string;
-	readonly name: string;
-	readonly branch: string;
-	readonly baseBranch: string;
-	readonly createdAt: string;
-	readonly archiveCommit?: string;
-	readonly checkpointCreated?: boolean;
-	readonly archiveRef?: string | null;
-	readonly archivedContextPath?: string | null;
-}
-
-const ArchivedWorktreeSnapshotSchema = Schema.Struct({
-	id: Schema.String,
-	projectId: Schema.String,
-	path: Schema.String,
-	name: Schema.String,
-	branch: Schema.String,
-	baseBranch: Schema.String,
-	createdAt: Schema.String,
-	archiveCommit: Schema.optional(Schema.String),
-	checkpointCreated: Schema.optional(Schema.Boolean),
-	archiveRef: Schema.optional(Schema.NullOr(Schema.String)),
-	archivedContextPath: Schema.optional(Schema.NullOr(Schema.String)),
-});
+export type ArchivedWorktreeSnapshot = typeof WorktreeArchiveSnapshot.Type;
 const decodeArchivedWorktreeSnapshot = Schema.decodeUnknownOption(
-	Schema.fromJsonString(ArchivedWorktreeSnapshotSchema),
+	Schema.fromJsonString(WorktreeArchiveSnapshot),
 );
 const decodeAgents = Schema.decodeUnknownOption(
 	Schema.fromJsonString(Schema.Record(Schema.String, AgentDefinition)),

--- a/apps/server/src/conversation/layers/conversation-services.ts
+++ b/apps/server/src/conversation/layers/conversation-services.ts
@@ -3,9 +3,9 @@ import {
 	type ChatId,
 	type FolderId,
 	type ProviderId,
-	SessionId,
+	type SessionId,
 	SessionNotFoundError,
-	WorktreeId,
+	type WorktreeId,
 } from "@zuse/contracts";
 import type { ChatCommand } from "@zuse/domain/chat/commands";
 import type { SessionCommand } from "@zuse/domain/core/commands";
@@ -183,36 +183,6 @@ const ConversationRuntimeLive = Layer.effect(
         ALTER TABLE chats
           ADD COLUMN archived_worktree_json TEXT
       `.pipe(Effect.orDie);
-		}
-
-		// Worktree deletion can null the sessions read-model FK without changing
-		// domain state. Repair live projection drift through SessionDomain so the
-		// event log, read model, cursor reset, and subscribers stay coherent.
-		const driftedWorktreeSessions = yield* sql<{
-			readonly id: string;
-			readonly worktree_id: string;
-		}>`
-			SELECT s.id, c.worktree_id
-			FROM sessions s
-			INNER JOIN chats c ON c.id = s.chat_id
-			INNER JOIN worktrees w ON w.id = c.worktree_id
-			WHERE s.archived_at IS NULL
-			  AND c.archived_at IS NULL
-			  AND s.worktree_id IS NOT c.worktree_id
-		`.pipe(Effect.orDie);
-		if (driftedWorktreeSessions.length > 0) {
-			const repairedAt = yield* currentTimestamp;
-			yield* Effect.forEach(
-				driftedWorktreeSessions,
-				(row) =>
-					appendSessionCommand(SessionId.make(row.id), {
-						_tag: "SetWorktree",
-						worktreeId: WorktreeId.make(row.worktree_id),
-						updatedAt: repairedAt,
-						forceProjection: true,
-					}),
-				{ discard: true },
-			);
 		}
 
 		/**

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -7,6 +7,7 @@ import {
 import { safeModelId } from "@zuse/analytics";
 import {
 	AgentSessionStartError,
+	ChatArchiveWorktreeError,
 	type ChatCreationOperation,
 	ChatId,
 	ComposerInput,
@@ -928,7 +929,24 @@ const ChatArchive = MemoizeRpcs.toLayerHandler(
 		Effect.gen(function* () {
 			const svc = yield* ChatService;
 			const analytics = yield* AnalyticsService;
-			const result = yield* svc.archiveChat(chatId, force ?? false);
+			const result = yield* svc.archiveChat(chatId, force ?? false).pipe(
+				Effect.catchTags({
+					ChatArchiveScriptError: (error) =>
+						Effect.fail(
+							new ChatArchiveWorktreeError({
+								chatId,
+								reason: error.output || "Archive cleanup script failed.",
+							}),
+						),
+					ChatArchiveTimeoutError: (error) =>
+						Effect.fail(
+							new ChatArchiveWorktreeError({
+								chatId,
+								reason: error.output || "Archive cleanup script timed out.",
+							}),
+						),
+				}),
+			);
 			yield* analytics.capture("chat archived", { outcome: "completed" });
 			return result;
 		}),

--- a/apps/server/test/integration/conversation-services.test.ts
+++ b/apps/server/test/integration/conversation-services.test.ts
@@ -23,6 +23,7 @@ import {
 	SessionId,
 	Worktree,
 	WorktreeCheckpointError,
+	WorktreeRestoreError,
 } from "@zuse/contracts";
 import type { SessionEvent } from "@zuse/domain/core/events";
 import { ChatDomain } from "@zuse/domain/engine/chat-domain";
@@ -166,6 +167,7 @@ let createdWorktreeCount = 0;
 let createdWorktrees = new Map<string, Worktree>();
 let archivedWorktreeIds = new Set<string>();
 let restoredWorktreeCount = 0;
+let restoreWorktreeFailure = false;
 let archiveWorktreeBarrier: Promise<void> | null = null;
 let archiveWorktreeStarts = 0;
 let archiveWorktreeFailure: "git-missing" | null = null;
@@ -353,6 +355,9 @@ const StubWorktreeLive = Layer.succeed(WorktreeService, {
 				archivedContextPath: null,
 				branch:
 					worktreeId === TEST_WORKTREE_ID ? testWorktree.branch : "fixture",
+				detachedHead: false,
+				branchProvenance: "manual" as const,
+				pokemonNumber: null,
 			};
 			const markRemoved = Effect.gen(function* () {
 				if (allowRemoval !== undefined && !(yield* allowRemoval())) return;
@@ -365,18 +370,25 @@ const StubWorktreeLive = Layer.succeed(WorktreeService, {
 						Effect.as(outcome),
 					);
 		}),
-	finishArchiveRemoval: () => Effect.void,
 	remove: () => Effect.void,
 	rerunSetup: () => Effect.die("not used"),
 	setupStream: () => Stream.die("not used"),
 	startRun: () => Effect.die("not used"),
 	restore: (snapshot) =>
-		Effect.sync(() => {
+		Effect.gen(function* () {
 			restoredWorktreeCount += 1;
+			if (restoreWorktreeFailure) {
+				return yield* new WorktreeRestoreError({
+					worktreeId: snapshot.id,
+					reason: "simulated restore failure",
+				});
+			}
 			archivedWorktreeIds.delete(snapshot.id as string);
-			return snapshot.id === TEST_WORKTREE_ID
-				? testWorktree
-				: (createdWorktrees.get(snapshot.id as string) ?? testWorktree);
+			const worktree =
+				snapshot.id === TEST_WORKTREE_ID
+					? testWorktree
+					: (createdWorktrees.get(snapshot.id as string) ?? testWorktree);
+			return { worktree, checkpoint: "applied" as const };
 		}),
 });
 
@@ -681,6 +693,7 @@ beforeEach(() => {
 	createdWorktrees = new Map();
 	archivedWorktreeIds = new Set();
 	restoredWorktreeCount = 0;
+	restoreWorktreeFailure = false;
 	archiveWorktreeBarrier = null;
 	archiveWorktreeStarts = 0;
 	archiveWorktreeFailure = null;
@@ -1225,8 +1238,8 @@ describe("ConversationServices — chat & session lifecycle", () => {
 					error: null,
 				});
 
-			// Older workers reported a missing cwd as missing Git. Reading archive
-			// jobs repairs that durable state so clients stop offering Force archive.
+			// Read paths do not mutate failed jobs. Legacy normalization runs once
+			// during service startup instead.
 			await run(
 				Effect.gen(function* () {
 					const sql = yield* SqlClient.SqlClient;
@@ -1243,7 +1256,13 @@ describe("ConversationServices — chat & session lifecycle", () => {
 						service.listArchiveJobs(PROJECT_ID),
 					),
 				),
-			).resolves.toEqual([]);
+			).resolves.toEqual([
+				expect.objectContaining({
+					status: "failed",
+					phase: "failed",
+					error: "git is not installed",
+				}),
+			]);
 			await expect(
 				run(
 					Effect.flatMap(store, (service) =>
@@ -1251,9 +1270,9 @@ describe("ConversationServices — chat & session lifecycle", () => {
 					),
 				),
 			).resolves.toMatchObject({
-				status: "completed",
-				phase: "directory-missing",
-				error: null,
+				status: "failed",
+				phase: "failed",
+				error: "git is not installed",
 			});
 		});
 	});
@@ -1627,10 +1646,62 @@ describe("ConversationServices — chat & session lifecycle", () => {
 				),
 			);
 
-			expect(restorable).toEqual({ _tag: "restorable" });
+			expect(restorable).toEqual({ _tag: "available" });
 			expect(restored.worktree?.id).toBe(TEST_WORKTREE_ID);
 			expect(restored.chat.worktreeId).toBe(TEST_WORKTREE_ID);
 			expect(restored.directoryStatus).toEqual({ _tag: "available" });
+		});
+	});
+
+	it("keeps a chat archived when restore fails and allows retry", async () => {
+		await withRuntime(async (run) => {
+			const archived = await run(
+				Effect.flatMap(store, (service) =>
+					service.createChat({
+						projectId: PROJECT_ID,
+						providerId: "claude",
+						model: "claude-opus-4-8",
+						worktreeId: TEST_WORKTREE_ID,
+					}),
+				),
+			);
+			await run(
+				Effect.flatMap(store, (service) =>
+					service.archiveChat(archived.chat.id),
+				),
+			);
+			await expect
+				.poll(() => archivedWorktreeIds.has(TEST_WORKTREE_ID))
+				.toBe(true);
+
+			restoreWorktreeFailure = true;
+			await expect(
+				run(
+					Effect.flatMap(store, (service) =>
+						service.unarchiveChat(archived.chat.id),
+					),
+				),
+			).rejects.toMatchObject({
+				_tag: "ChatArchiveWorktreeError",
+				reason: "simulated restore failure",
+			});
+			await expect(
+				run(
+					Effect.flatMap(store, (service) => service.getChat(archived.chat.id)),
+				),
+			).resolves.toMatchObject({ archivedAt: expect.any(Date) });
+
+			restoreWorktreeFailure = false;
+			await expect(
+				run(
+					Effect.flatMap(store, (service) =>
+						service.unarchiveChat(archived.chat.id),
+					),
+				),
+			).resolves.toMatchObject({
+				chat: { archivedAt: null },
+				worktree: { id: TEST_WORKTREE_ID },
+			});
 		});
 	});
 

--- a/apps/server/test/integration/fs-write-receipts.test.ts
+++ b/apps/server/test/integration/fs-write-receipts.test.ts
@@ -53,7 +53,6 @@ const makeRuntime = (root: string) => {
 		get: () => Effect.succeed(null),
 		renameBranch: () => Effect.die("not used"),
 		archive: () => Effect.die("not used"),
-		finishArchiveRemoval: () => Effect.die("not used"),
 		remove: () => Effect.die("not used"),
 		rerunSetup: () => Effect.die("not used"),
 		setupStream: () => Stream.die("not used"),

--- a/apps/server/test/support/conversation-services-fixture-harness.ts
+++ b/apps/server/test/support/conversation-services-fixture-harness.ts
@@ -238,12 +238,14 @@ export const makeConversationFixtureRuntime = (
 				archiveRef: null,
 				archivedContextPath: null,
 				branch: "fixture",
+				detachedHead: false,
+				branchProvenance: "manual" as const,
+				pokemonNumber: null,
 			};
 			return recordCheckpoint === undefined
 				? Effect.succeed(outcome)
 				: recordCheckpoint(outcome).pipe(Effect.as(outcome));
 		},
-		finishArchiveRemoval: () => Effect.void,
 		remove: () => Effect.void,
 		rerunSetup: () => Effect.die("not used"),
 		setupStream: () => Stream.die("not used"),

--- a/packages/client-runtime/src/client-persistence.ts
+++ b/packages/client-runtime/src/client-persistence.ts
@@ -99,6 +99,16 @@ const canonicalJson = (value: unknown): string => {
 				if (ancestors.has(input)) {
 					throw new TypeError("Client command payloads cannot contain cycles");
 				}
+				// Binary RPC payloads (most notably attachment uploads) arrive here as
+				// Uint8Array instances. Object.keys() exposes one property per byte, so
+				// treating them as ordinary records creates an enormous intermediate JSON
+				// string before the command can even reach the transport. Hash the bytes
+				// directly so even the maximum-size attachment contributes a fixed-size
+				// value, and tag it so it cannot collide with an ordinary numeric-keyed
+				// object. The outer command fingerprint remains a SHA-256 identity.
+				if (input instanceof Uint8Array) {
+					return `Uint8Array(sha256:${bytesToHex(sha256(input))})`;
+				}
 				ancestors.add(input);
 				try {
 					const toJson = Reflect.get(input, "toJSON");

--- a/packages/client-runtime/test/unit/client-bus.test.ts
+++ b/packages/client-runtime/test/unit/client-bus.test.ts
@@ -162,6 +162,39 @@ class MemoryPersistence implements ClientPersistence {
 }
 
 describe("ClientBus", () => {
+	it("fingerprints binary payloads by bytes instead of enumerable indices", () => {
+		const binary = {
+			kind: "attachments.upload",
+			commandId: CommandId.make("command-binary"),
+			environmentId,
+			resource: timelineKey,
+			payload: { bytes: new Uint8Array([1, 2, 3]) },
+			retry: "never" as const,
+			createdAt: 1,
+		};
+
+		expect(
+			commandFingerprint({
+				...binary,
+				payload: { bytes: new Uint8Array([1, 2, 3]) },
+			}),
+		).toBe(commandFingerprint(binary));
+		expect(
+			commandFingerprint({
+				...binary,
+				payload: { bytes: new Uint8Array([1, 2, 4]) },
+			}),
+		).not.toBe(commandFingerprint(binary));
+		// Uint8Array's enumerable shape is { "0": 1, ... }. It must retain a
+		// distinct identity from a real application object with those keys.
+		expect(
+			commandFingerprint({
+				...binary,
+				payload: { bytes: { 0: 1, 1: 2, 2: 3 } },
+			}),
+		).not.toBe(commandFingerprint(binary));
+	});
+
 	it("shares one environment resolution and one keyed driver across retainers", async () => {
 		let resolves = 0;
 		let starts = 0;

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -922,28 +922,16 @@ export type ChatArchiveJob = typeof ChatArchiveJob.Type;
 
 export const ChatDirectoryStatus = Schema.Union([
 	Schema.TaggedStruct("available", {}),
-	Schema.TaggedStruct("restorable", {}),
 	Schema.TaggedStruct("unavailable", {
-		reason: Schema.Literals([
-			"project-missing",
-			"worktree-missing",
-			"restore-unavailable",
-		]),
+		reason: Schema.Literals(["project-missing", "worktree-missing"]),
 	}),
 ]);
 export type ChatDirectoryStatus = typeof ChatDirectoryStatus.Type;
 
 const ChatArchiveErrors = Schema.Union([
 	ChatNotFoundError,
-	ChatArchiveScriptError,
-	ChatArchiveTimeoutError,
 	ChatArchiveWorktreeError,
 ]);
-
-const ArchiveCleanupSummary = Schema.Struct({
-	ran: Schema.Boolean,
-	output: Schema.String,
-});
 
 const WorktreeCheckpointSummary = Schema.Struct({
 	archiveCommit: Schema.String,
@@ -954,7 +942,6 @@ const WorktreeCheckpointSummary = Schema.Struct({
 
 export const ChatArchiveResult = Schema.Struct({
 	chat: Chat,
-	cleanup: Schema.NullOr(ArchiveCleanupSummary),
 	checkpoint: Schema.NullOr(WorktreeCheckpointSummary),
 	job: Schema.NullOr(ChatArchiveJob),
 });
@@ -965,6 +952,7 @@ export const ChatUnarchiveResult = Schema.Struct({
 	sessions: Schema.Array(Session),
 	worktree: Schema.NullOr(Worktree),
 	directoryStatus: ChatDirectoryStatus,
+	restoreNotice: Schema.optional(Schema.Literal("branch-advanced")),
 });
 export type ChatUnarchiveResult = typeof ChatUnarchiveResult.Type;
 

--- a/packages/contracts/src/worktree.ts
+++ b/packages/contracts/src/worktree.ts
@@ -77,6 +77,29 @@ export class WorktreeRemoveError extends Schema.TaggedErrorClass<WorktreeRemoveE
 	{ worktreeId: WorktreeId, reason: Schema.String },
 ) {}
 
+export class WorktreeRestoreError extends Schema.TaggedErrorClass<WorktreeRestoreError>()(
+	"WorktreeRestoreError",
+	{ worktreeId: WorktreeId, reason: Schema.String },
+) {}
+
+export const WorktreeArchiveSnapshot = Schema.Struct({
+	id: WorktreeId,
+	projectId: FolderId,
+	path: Schema.String,
+	name: Schema.String,
+	branch: Schema.String,
+	baseBranch: Schema.String,
+	createdAt: Schema.DateFromString,
+	archiveCommit: Schema.optional(Schema.String),
+	checkpointCreated: Schema.optional(Schema.Boolean),
+	archiveRef: Schema.optional(Schema.NullOr(Schema.String)),
+	archivedContextPath: Schema.optional(Schema.NullOr(Schema.String)),
+	detachedHead: Schema.optional(Schema.Boolean),
+	branchProvenance: Schema.optional(NameProvenanceField),
+	pokemonNumber: Schema.optional(Schema.NullOr(Schema.Number)),
+});
+export type WorktreeArchiveSnapshot = typeof WorktreeArchiveSnapshot.Type;
+
 export class WorktreeCheckpointError extends Schema.TaggedErrorClass<WorktreeCheckpointError>()(
 	"WorktreeCheckpointError",
 	{ worktreeId: WorktreeId, reason: Schema.String },

--- a/packages/domain/src/chat/commands.ts
+++ b/packages/domain/src/chat/commands.ts
@@ -34,6 +34,10 @@ export const ChatCommand = Schema.Union([
 		archivedAt: Schema.Number,
 		archivedWorktreeJson: Schema.NullOr(Schema.String),
 	}),
+	Schema.TaggedStruct("RecordArchiveCheckpoint", {
+		archivedWorktreeJson: Schema.String,
+		recordedAt: Schema.Number,
+	}),
 	Schema.TaggedStruct("UnarchiveChat", {
 		unarchivedAt: Schema.Number,
 		worktreeId: Schema.NullOr(Schema.String),

--- a/packages/domain/src/chat/decider.ts
+++ b/packages/domain/src/chat/decider.ts
@@ -94,6 +94,10 @@ export const decideChat = (
 			return state.archived
 				? success([])
 				: success([{ ...command, _tag: "ChatArchived" }]);
+		case "RecordArchiveCheckpoint":
+			return state.archived
+				? success([{ ...command, _tag: "ChatArchiveCheckpointRecorded" }])
+				: success([]);
 		case "UnarchiveChat":
 			return state.archived
 				? success([{ ...command, _tag: "ChatUnarchived" }])

--- a/packages/domain/src/chat/events.ts
+++ b/packages/domain/src/chat/events.ts
@@ -37,6 +37,10 @@ export const ChatEvent = Schema.Union([
 		archivedAt: Schema.Number,
 		archivedWorktreeJson: Schema.NullOr(Schema.String),
 	}),
+	Schema.TaggedStruct("ChatArchiveCheckpointRecorded", {
+		archivedWorktreeJson: Schema.String,
+		recordedAt: Schema.Number,
+	}),
 	Schema.TaggedStruct("ChatUnarchived", {
 		unarchivedAt: Schema.Number,
 		worktreeId: Schema.NullOr(Schema.String),

--- a/packages/domain/src/chat/state.ts
+++ b/packages/domain/src/chat/state.ts
@@ -80,6 +80,12 @@ export const evolveChat = (state: ChatState, event: ChatEvent): ChatState => {
 				archivedWorktreeJson: event.archivedWorktreeJson,
 				version,
 			};
+		case "ChatArchiveCheckpointRecorded":
+			return {
+				...state,
+				archivedWorktreeJson: event.archivedWorktreeJson,
+				version,
+			};
 		case "ChatUnarchived":
 			return {
 				...state,

--- a/packages/domain/src/projectors/sql-chat-projector.ts
+++ b/packages/domain/src/projectors/sql-chat-projector.ts
@@ -97,6 +97,16 @@ export const makeSqlChatProjector = (
 				`;
 				return;
 			}
+			case "ChatArchiveCheckpointRecorded": {
+				const recordedAt = new Date(event.recordedAt).toISOString();
+				yield* sql`
+					UPDATE chats
+					SET archived_worktree_json = ${event.archivedWorktreeJson},
+						updated_at = ${recordedAt}
+					WHERE id = ${record.streamId} AND archived_at IS NOT NULL
+				`;
+				return;
+			}
 			case "ChatUnarchived": {
 				const unarchivedAt = new Date(event.unarchivedAt).toISOString();
 				yield* sql`

--- a/packages/domain/src/projectors/sql-session-projector.ts
+++ b/packages/domain/src/projectors/sql-session-projector.ts
@@ -115,9 +115,10 @@ export const makeSqlSessionProjector = (
 				const updatedAt = new Date(event.updatedAt).toISOString();
 				yield* sql`
 					UPDATE sessions
-					SET worktree_id = ${event.worktreeId}, cursor = NULL,
-						provider_event_cursor = NULL,
-						resume_strategy = 'none', updated_at = ${updatedAt}
+					SET cursor = CASE WHEN worktree_id IS ${event.worktreeId} THEN cursor ELSE NULL END,
+						provider_event_cursor = CASE WHEN worktree_id IS ${event.worktreeId} THEN provider_event_cursor ELSE NULL END,
+						resume_strategy = CASE WHEN worktree_id IS ${event.worktreeId} THEN resume_strategy ELSE 'none' END,
+						worktree_id = ${event.worktreeId}, updated_at = ${updatedAt}
 					WHERE id = ${record.streamId}
 				`;
 				return;

--- a/packages/domain/test/unit/chat/decider.test.ts
+++ b/packages/domain/test/unit/chat/decider.test.ts
@@ -141,6 +141,35 @@ describe("chat decider", () => {
 		expect(Result.getOrThrow(decideChat(state, unarchive))).toEqual([]);
 	});
 
+	test("records checkpoint metadata only while archived", () => {
+		const first = Result.getOrThrow(decideChat(initialChatState, created));
+		let state = evolveChats(initialChatState, first);
+		const command: ChatCommand = {
+			_tag: "RecordArchiveCheckpoint",
+			archivedWorktreeJson: '{"archiveCommit":"checkpoint"}',
+			recordedAt: 25,
+		};
+		expect(Result.getOrThrow(decideChat(state, command))).toEqual([]);
+
+		state = evolveChats(
+			state,
+			Result.getOrThrow(
+				decideChat(state, {
+					_tag: "ArchiveChat",
+					archivedAt: 20,
+					archivedWorktreeJson: null,
+				}),
+			),
+		);
+		const recorded = Result.getOrThrow(decideChat(state, command));
+		expect(recorded).toEqual([
+			{ ...command, _tag: "ChatArchiveCheckpointRecorded" },
+		]);
+		expect(evolveChats(state, recorded).archivedWorktreeJson).toBe(
+			command.archivedWorktreeJson,
+		);
+	});
+
 	test("emits one durable archive request until the archive settles", () => {
 		const first = decideChat(initialChatState, created);
 		if (Result.isFailure(first)) throw first.failure;

--- a/packages/git/src/worktree/archive-constants.ts
+++ b/packages/git/src/worktree/archive-constants.ts
@@ -1,0 +1,9 @@
+import type { WorktreeId } from "@zuse/contracts";
+
+export const ARCHIVE_CHECKPOINT_MESSAGE = "zuse: archive checkpoint";
+
+export const archiveCheckpointTrailer = (worktreeId: WorktreeId): string =>
+	`Zuse-Archive-Checkpoint: ${worktreeId}`;
+
+export const archiveRefForWorktree = (worktreeId: WorktreeId): string =>
+	`refs/zuse/archive/${worktreeId}`;

--- a/packages/git/src/worktree/worktree-service-live.ts
+++ b/packages/git/src/worktree/worktree-service-live.ts
@@ -18,6 +18,7 @@ import {
 	WorktreeId,
 	WorktreeNotFoundError,
 	WorktreeRemoveError,
+	WorktreeRestoreError,
 	WorktreeSetupChunk,
 	WorktreeSetupError,
 	type WorktreeSetupEvent,
@@ -41,6 +42,11 @@ import {
 	ChildProcessSpawner as CommandExecutor,
 } from "effect/unstable/process";
 import { SqlClient } from "effect/unstable/sql";
+import {
+	ARCHIVE_CHECKPOINT_MESSAGE,
+	archiveCheckpointTrailer,
+	archiveRefForWorktree,
+} from "./archive-constants.ts";
 import { linkIncludedFiles } from "./env-files.ts";
 import {
 	PokemonAssignment,
@@ -1122,9 +1128,9 @@ export const WorktreeServiceLive = Layer.effect(
 			"-p",
 			"HEAD",
 			"-m",
-			"zuse: archive checkpoint",
+			ARCHIVE_CHECKPOINT_MESSAGE,
 			"-m",
-			`Zuse-Archive-Checkpoint: ${worktreeId}`,
+			archiveCheckpointTrailer(worktreeId),
 		];
 
 		const isMissingIdentity = (reason: string): boolean => {
@@ -1244,7 +1250,7 @@ export const WorktreeServiceLive = Layer.effect(
 			let archiveRef: string | null = null;
 			let archiveCommit: string;
 			if (checkpointCreated) {
-				const checkpointRef = `refs/zuse/archive/${worktreeId}`;
+				const checkpointRef = archiveRefForWorktree(worktreeId);
 				archiveRef = checkpointRef;
 				const temporaryIndex = Path.join(
 					os.tmpdir(),
@@ -1277,7 +1283,7 @@ export const WorktreeServiceLive = Layer.effect(
 						if (
 							existingTree.trim() === tree &&
 							existingParent.trim() === head.trim() &&
-							body.includes(`Zuse-Archive-Checkpoint: ${worktreeId}`)
+							body.includes(archiveCheckpointTrailer(worktreeId))
 						) {
 							return existing;
 						}
@@ -1324,9 +1330,7 @@ export const WorktreeServiceLive = Layer.effect(
 				]).pipe(Effect.result);
 				checkpointCreated =
 					currentBody._tag === "Success" &&
-					currentBody.success.includes(
-						`Zuse-Archive-Checkpoint: ${worktreeId}`,
-					);
+					currentBody.success.includes(archiveCheckpointTrailer(worktreeId));
 				archiveCommit = (yield* runGit(row.path, ["rev-parse", "HEAD"]).pipe(
 					Effect.mapError(
 						(reason) => new WorktreeCheckpointError({ worktreeId, reason }),
@@ -1359,7 +1363,7 @@ export const WorktreeServiceLive = Layer.effect(
 					);
 				}
 			} else if (archiveRef === null) {
-				archiveRef = `refs/zuse/archive/${worktreeId}`;
+				archiveRef = archiveRefForWorktree(worktreeId);
 				yield* ensureRemovalAllowed;
 				yield* runGit(folder.path, [
 					"update-ref",
@@ -1436,7 +1440,13 @@ export const WorktreeServiceLive = Layer.effect(
 				checkpointCreated,
 				archiveRef,
 				archivedContextPath,
-				branch: row.branch,
+				branch:
+					symbolicBranch._tag === "Success"
+						? symbolicBranch.success.trim()
+						: row.branch,
+				detachedHead: symbolicBranch._tag === "Failure",
+				branchProvenance: row.branchProvenance,
+				pokemonNumber: row.pokemon?.number ?? null,
 			} satisfies WorktreeArchiveOutcome;
 			if (recordCheckpoint !== undefined) {
 				const recorded = yield* recordCheckpoint(outcome).pipe(Effect.result);
@@ -1479,132 +1489,206 @@ export const WorktreeServiceLive = Layer.effect(
 		});
 
 		const archive: WorktreeService["Service"]["archive"] = checkpointAndDelete;
-		const finishArchiveRemoval: WorktreeService["Service"]["finishArchiveRemoval"] =
-			(worktreeId) =>
-				Effect.gen(function* () {
-					const row = yield* get(worktreeId);
-					if (row === null) return;
-					const folder = yield* projects.find(row.projectId);
-					if (folder === null) {
-						return yield* Effect.fail(
-							new WorktreeRemoveError({
-								worktreeId,
-								reason: "project not found",
-							}),
-						);
-					}
-					yield* deleteCheckoutAndRow(row, folder.path);
-				});
 		const remove: WorktreeService["Service"]["remove"] = (worktreeId) =>
-			checkpointAndDelete(worktreeId).pipe(Effect.asVoid);
+			checkpointAndDelete(worktreeId).pipe(
+				Effect.tap((outcome) =>
+					outcome.archiveRef === null
+						? Effect.void
+						: Effect.logWarning(
+								`Removed worktree ${worktreeId}; archived changes remain at ${outcome.archiveRef}`,
+							),
+				),
+				Effect.asVoid,
+			);
 
 		const restore: WorktreeService["Service"]["restore"] = (
 			snapshot: WorktreeRestoreSnapshot,
 		) =>
 			Effect.gen(function* () {
+				const failRestore = (reason: string) =>
+					new WorktreeRestoreError({ worktreeId: snapshot.id, reason });
 				const folder = yield* projects.find(snapshot.projectId);
 				if (folder === null) {
-					return yield* Effect.fail(
-						new WorktreeRemoveError({
-							worktreeId: snapshot.id,
-							reason: "project not found",
-						}),
-					);
+					return yield* Effect.fail(failRestore("project not found"));
 				}
 
+				yield* runGit(folder.path, ["worktree", "prune"]).pipe(
+					Effect.mapError(failRestore),
+				);
 				const existing = yield* get(snapshot.id);
-				if (existing !== null) return existing;
+				if (existing !== null) {
+					const existingPathExists = yield* fs
+						.exists(existing.path)
+						.pipe(Effect.orElseSucceed(() => false));
+					if (existingPathExists) {
+						return {
+							worktree: existing,
+							checkpoint: "already-present" as const,
+						};
+					}
+					yield* sql`DELETE FROM worktrees WHERE id = ${snapshot.id}`.pipe(
+						Effect.mapError((error) =>
+							failRestore(
+								`stale worktree row cleanup failed: ${String(error)}`,
+							),
+						),
+					);
+				}
 
 				const targetExists = yield* fs
 					.exists(snapshot.path)
 					.pipe(Effect.catch(() => Effect.succeed(false)));
 				if (targetExists) {
 					return yield* Effect.fail(
-						new WorktreeRemoveError({
-							worktreeId: snapshot.id,
-							reason: `restore path already exists: ${snapshot.path}`,
-						}),
+						failRestore(`restore path already exists: ${snapshot.path}`),
 					);
 				}
 
-				const restoreRef = snapshot.archiveRef ?? snapshot.branch;
+				const checkpointRef = archiveRefForWorktree(snapshot.id);
+				const checkpointProbe = yield* runGit(folder.path, [
+					"rev-parse",
+					"--verify",
+					"--quiet",
+					checkpointRef,
+				]).pipe(Effect.result);
+				let checkpointCommit: string | null = null;
+				let checkpointParent: string | null = null;
+				if (checkpointProbe._tag === "Success") {
+					const candidate = checkpointProbe.success.trim();
+					const [body, parent] = yield* Effect.all([
+						runGit(folder.path, ["show", "-s", "--format=%B", candidate]),
+						runGit(folder.path, ["rev-parse", `${candidate}^`]),
+					]).pipe(Effect.mapError(failRestore));
+					if (body.includes(archiveCheckpointTrailer(snapshot.id))) {
+						checkpointCommit = candidate;
+						checkpointParent = parent.trim();
+					}
+				}
+
 				const branchExists = yield* runGit(folder.path, [
 					"rev-parse",
 					"--verify",
 					"--quiet",
-					snapshot.archiveRef ?? `refs/heads/${snapshot.branch}`,
+					`refs/heads/${snapshot.branch}`,
 				]).pipe(
 					Effect.map(() => true),
 					Effect.catch(() => Effect.succeed(false)),
 				);
-				if (!branchExists) {
-					return yield* Effect.fail(
-						new WorktreeRemoveError({
-							worktreeId: snapshot.id,
-							reason: `restore ref not found: ${restoreRef}`,
-						}),
-					);
-				}
+				const branchTip = branchExists
+					? (yield* runGit(folder.path, [
+							"rev-parse",
+							`refs/heads/${snapshot.branch}`,
+						]).pipe(Effect.mapError(failRestore))).trim()
+					: null;
 
-				const addArgs =
-					snapshot.archiveRef === null || snapshot.archiveRef === undefined
-						? ["worktree", "add", snapshot.path, snapshot.branch]
-						: [
-								"worktree",
-								"add",
-								"--detach",
-								snapshot.path,
-								snapshot.archiveRef,
-							];
-				const result = yield* runGit(folder.path, addArgs).pipe(Effect.result);
-				if (result._tag === "Failure") {
-					return yield* Effect.fail(
-						new WorktreeRemoveError({
-							worktreeId: snapshot.id,
-							reason: result.failure,
-						}),
-					);
-				}
-
-				let shouldResetCheckpoint = false;
-				if (
-					snapshot.checkpointCreated &&
-					snapshot.archiveCommit !== undefined
-				) {
-					const tip = (yield* runGit(snapshot.path, ["rev-parse", "HEAD"]).pipe(
-						Effect.mapError(
-							(reason) =>
-								new WorktreeRemoveError({ worktreeId: snapshot.id, reason }),
-						),
-					)).trim();
-					if (tip === snapshot.archiveCommit) {
-						const body = yield* runGit(snapshot.path, [
+				let checkpoint: "applied" | "none" | "branch-advanced" = "none";
+				let applyIsolatedCheckpoint = false;
+				let resetLegacyCheckpoint = false;
+				let addArgs: ReadonlyArray<string>;
+				if (checkpointCommit !== null && checkpointParent !== null) {
+					if (snapshot.detachedHead === true || !branchExists) {
+						addArgs = [
+							"worktree",
+							"add",
+							"--detach",
+							snapshot.path,
+							checkpointParent,
+						];
+						applyIsolatedCheckpoint = true;
+					} else if (branchTip === checkpointParent) {
+						addArgs = ["worktree", "add", snapshot.path, snapshot.branch];
+						applyIsolatedCheckpoint = true;
+					} else {
+						addArgs = ["worktree", "add", snapshot.path, snapshot.branch];
+						checkpoint = "branch-advanced";
+					}
+				} else if (branchExists) {
+					addArgs = ["worktree", "add", snapshot.path, snapshot.branch];
+					if (
+						snapshot.archiveRef == null &&
+						snapshot.checkpointCreated === true &&
+						snapshot.archiveCommit !== undefined &&
+						branchTip === snapshot.archiveCommit
+					) {
+						const body = yield* runGit(folder.path, [
 							"show",
 							"-s",
 							"--format=%B",
-							"HEAD",
-						]).pipe(
-							Effect.mapError(
-								(reason) =>
-									new WorktreeRemoveError({ worktreeId: snapshot.id, reason }),
-							),
-						);
-						shouldResetCheckpoint = body.includes(
-							`Zuse-Archive-Checkpoint: ${snapshot.id}`,
+							branchTip,
+						]).pipe(Effect.mapError(failRestore));
+						resetLegacyCheckpoint = body.includes(
+							archiveCheckpointTrailer(snapshot.id),
 						);
 					}
+				} else if (snapshot.archiveCommit !== undefined) {
+					addArgs = [
+						"worktree",
+						"add",
+						"--detach",
+						snapshot.path,
+						snapshot.archiveCommit,
+					];
+				} else {
+					return yield* Effect.fail(
+						failRestore(`restore branch not found: ${snapshot.branch}`),
+					);
+				}
+
+				const result = yield* runGit(folder.path, addArgs).pipe(Effect.result);
+				if (result._tag === "Failure") {
+					return yield* Effect.fail(failRestore(result.failure));
+				}
+				const rollbackCheckout = Effect.gen(function* () {
+					if (resetLegacyCheckpoint && snapshot.archiveCommit !== undefined) {
+						yield* runGit(snapshot.path, [
+							"reset",
+							"--hard",
+							snapshot.archiveCommit,
+						]).pipe(Effect.ignore);
+					}
+					yield* runGit(folder.path, [
+						"worktree",
+						"remove",
+						"--force",
+						"--force",
+						snapshot.path,
+					]).pipe(Effect.ignore);
+					yield* runGit(folder.path, ["worktree", "prune"]).pipe(Effect.ignore);
+				});
+
+				const materialized = yield* Effect.gen(function* () {
+					if (applyIsolatedCheckpoint && checkpointCommit !== null) {
+						yield* runGit(snapshot.path, [
+							"read-tree",
+							"-m",
+							"-u",
+							"HEAD",
+							checkpointCommit,
+						]);
+						yield* runGit(snapshot.path, ["reset", "--mixed", "HEAD"]);
+						checkpoint = "applied";
+					} else if (resetLegacyCheckpoint) {
+						yield* runGit(snapshot.path, ["reset", "--mixed", "HEAD~1"]);
+						checkpoint = "applied";
+					}
+				}).pipe(Effect.mapError(failRestore), Effect.result);
+				if (materialized._tag === "Failure") {
+					yield* rollbackCheckout;
+					return yield* Effect.fail(materialized.failure);
 				}
 
 				const archivedContextPath = snapshot.archivedContextPath ?? null;
 				const restoredContextPath = Path.join(snapshot.path, ".context");
 				let contextRestored = false;
 				if (archivedContextPath !== null) {
-					yield* moveDirectory(archivedContextPath, restoredContextPath).pipe(
-						Effect.mapError(
-							(reason) =>
-								new WorktreeRemoveError({ worktreeId: snapshot.id, reason }),
-						),
-					);
+					const contextMove = yield* moveDirectory(
+						archivedContextPath,
+						restoredContextPath,
+					).pipe(Effect.result);
+					if (contextMove._tag === "Failure") {
+						yield* rollbackCheckout;
+						return yield* Effect.fail(failRestore(contextMove.failure));
+					}
 					contextRestored = true;
 					const attachmentRestore = yield* sql`
             UPDATE attachments
@@ -1616,21 +1700,11 @@ export const WorktreeServiceLive = Layer.effect(
 						yield* moveDirectory(restoredContextPath, archivedContextPath).pipe(
 							Effect.ignore,
 						);
-						yield* runGit(folder.path, [
-							"worktree",
-							"remove",
-							"--force",
-							"--force",
-							snapshot.path,
-						]).pipe(Effect.ignore);
-						yield* runGit(folder.path, ["worktree", "prune"]).pipe(
-							Effect.ignore,
-						);
+						yield* rollbackCheckout;
 						return yield* Effect.fail(
-							new WorktreeRemoveError({
-								worktreeId: snapshot.id,
-								reason: `attachment path update failed: ${String(attachmentRestore.failure)}`,
-							}),
+							failRestore(
+								`attachment path update failed: ${String(attachmentRestore.failure)}`,
+							),
 						);
 					}
 				}
@@ -1649,80 +1723,48 @@ export const WorktreeServiceLive = Layer.effect(
 							Effect.ignore,
 						);
 					}
-					yield* runGit(folder.path, [
-						"worktree",
-						"remove",
-						"--force",
-						"--force",
-						snapshot.path,
-					]).pipe(Effect.ignore);
-					yield* runGit(folder.path, ["worktree", "prune"]).pipe(Effect.ignore);
+					yield* rollbackCheckout;
 				});
 
 				const createdAtIso = snapshot.createdAt.toISOString();
 				const inserted = yield* sql`
 		  INSERT INTO worktrees
-		    (id, project_id, path, name, branch, branch_provenance, base_branch, created_at,
-             setup_status, setup_output)
-          VALUES
-            (${snapshot.id}, ${snapshot.projectId}, ${snapshot.path},
-		     ${snapshot.name}, ${snapshot.branch}, 'manual', ${snapshot.baseBranch},
-			     ${createdAtIso}, 'pending', '')
+					 (id, project_id, path, name, branch, branch_provenance, base_branch, created_at,
+							 setup_status, setup_output, pokemon_number)
+						VALUES
+							(${snapshot.id}, ${snapshot.projectId}, ${snapshot.path},
+						 ${snapshot.name}, ${snapshot.branch}, ${snapshot.branchProvenance ?? "manual"}, ${snapshot.baseBranch},
+							 ${createdAtIso}, 'pending', '', ${snapshot.pokemonNumber ?? null})
         `.pipe(Effect.result);
 				if (inserted._tag === "Failure") {
 					yield* rollbackRestore;
 					return yield* Effect.fail(
-						new WorktreeRemoveError({
-							worktreeId: snapshot.id,
-							reason: `worktree row restore failed: ${String(inserted.failure)}`,
-						}),
+						failRestore(
+							`worktree row restore failed: ${String(inserted.failure)}`,
+						),
 					);
 				}
 
-				if (shouldResetCheckpoint) {
-					const reset = yield* runGit(snapshot.path, [
-						"reset",
-						"--mixed",
-						"HEAD~1",
-					]).pipe(Effect.result);
-					if (reset._tag === "Failure") {
-						yield* rollbackRestore;
-						return yield* Effect.fail(
-							new WorktreeRemoveError({
-								worktreeId: snapshot.id,
-								reason: reset.failure,
-							}),
-						);
-					}
-				}
-
-				if (snapshot.archiveRef !== null && snapshot.archiveRef !== undefined) {
+				if (applyIsolatedCheckpoint && checkpoint !== "branch-advanced") {
 					const deletedRef = yield* runGit(folder.path, [
 						"update-ref",
 						"-d",
-						snapshot.archiveRef,
+						checkpointRef,
 					]).pipe(Effect.result);
 					if (deletedRef._tag === "Failure") {
 						yield* rollbackRestore;
-						return yield* Effect.fail(
-							new WorktreeRemoveError({
-								worktreeId: snapshot.id,
-								reason: deletedRef.failure,
-							}),
-						);
+						return yield* Effect.fail(failRestore(deletedRef.failure));
 					}
 				}
 				const restored = yield* get(snapshot.id);
 				if (restored === null) {
+					yield* rollbackRestore;
 					return yield* Effect.fail(
-						new WorktreeRemoveError({
-							worktreeId: snapshot.id,
-							reason: "restored worktree row could not be loaded",
-						}),
+						failRestore("restored worktree row could not be loaded"),
 					);
 				}
 				yield* Effect.forkDetach(runSetupSafely(snapshot.id));
-				return restored;
+				return { worktree: restored, checkpoint };
 			});
 
 		const setupEnv = (
@@ -1985,7 +2027,6 @@ export const WorktreeServiceLive = Layer.effect(
 			get,
 			renameBranch,
 			archive,
-			finishArchiveRemoval,
 			remove,
 			restore,
 			rerunSetup,

--- a/packages/git/src/worktree/worktree-service.ts
+++ b/packages/git/src/worktree/worktree-service.ts
@@ -1,6 +1,7 @@
 import type {
 	FolderId,
 	Worktree,
+	WorktreeArchiveSnapshot,
 	WorktreeBranchRenameError,
 	WorktreeCheckpointError,
 	WorktreeCreateError,
@@ -8,24 +9,13 @@ import type {
 	WorktreeId,
 	WorktreeNotFoundError,
 	WorktreeRemoveError,
+	WorktreeRestoreError,
 	WorktreeSetupError,
 	WorktreeSetupEvent,
 } from "@zuse/contracts";
 import { Context, type Effect, type Stream } from "effect";
 
-export interface WorktreeRestoreSnapshot {
-	readonly id: WorktreeId;
-	readonly projectId: FolderId;
-	readonly path: string;
-	readonly name: string;
-	readonly branch: string;
-	readonly baseBranch: string;
-	readonly createdAt: Date;
-	readonly archiveCommit?: string;
-	readonly checkpointCreated?: boolean;
-	readonly archiveRef?: string | null;
-	readonly archivedContextPath?: string | null;
-}
+export type WorktreeRestoreSnapshot = WorktreeArchiveSnapshot;
 
 export interface WorktreeArchiveOutcome {
 	readonly archiveCommit: string;
@@ -33,6 +23,18 @@ export interface WorktreeArchiveOutcome {
 	readonly archiveRef: string | null;
 	readonly archivedContextPath: string | null;
 	readonly branch: string;
+	readonly detachedHead: boolean;
+	readonly branchProvenance: "pending" | "automatic" | "manual";
+	readonly pokemonNumber: number | null;
+}
+
+export interface WorktreeRestoreOutcome {
+	readonly worktree: Worktree;
+	readonly checkpoint:
+		| "applied"
+		| "none"
+		| "branch-advanced"
+		| "already-present";
 }
 
 export interface WorktreeServiceShape {
@@ -63,9 +65,6 @@ export interface WorktreeServiceShape {
 		WorktreeArchiveOutcome,
 		WorktreeNotFoundError | WorktreeCheckpointError | WorktreeRemoveError
 	>;
-	readonly finishArchiveRemoval: (
-		worktreeId: WorktreeId,
-	) => Effect.Effect<void, WorktreeRemoveError>;
 	readonly remove: (
 		worktreeId: WorktreeId,
 	) => Effect.Effect<
@@ -96,7 +95,7 @@ export interface WorktreeServiceShape {
 	>;
 	readonly restore: (
 		snapshot: WorktreeRestoreSnapshot,
-	) => Effect.Effect<Worktree, WorktreeRemoveError>;
+	) => Effect.Effect<WorktreeRestoreOutcome, WorktreeRestoreError>;
 }
 
 export class WorktreeService extends Context.Service<

--- a/packages/git/test/integration/worktree/worktree-service-live.test.ts
+++ b/packages/git/test/integration/worktree/worktree-service-live.test.ts
@@ -348,7 +348,10 @@ describe("WorktreeServiceLive", () => {
 		expect(await run((service) => service.get(created.id))).toBeNull();
 
 		const restored = await run((service) => service.restore(snapshot));
-		expect(restored).toMatchObject({ id: created.id, setupStatus: "pending" });
+		expect(restored).toMatchObject({
+			worktree: { id: created.id, setupStatus: "pending" },
+			checkpoint: "none",
+		});
 	});
 
 	test("archives dirty state as a checkpoint and restores it as uncommitted changes", async () => {
@@ -367,6 +370,8 @@ describe("WorktreeServiceLive", () => {
 			archiveRef: `refs/zuse/archive/${created.id}`,
 			branch: created.branch,
 		});
+		if (checkpoint.archiveRef === null) throw new Error("archive ref missing");
+		const checkpointRef = checkpoint.archiveRef;
 		expect(
 			git(repositoryRoot, "rev-parse", `refs/heads/${created.branch}`),
 		).toBe(branchBeforeArchive);
@@ -384,7 +389,6 @@ describe("WorktreeServiceLive", () => {
 
 		const restored = await run((service) =>
 			service.restore({
-				...checkpoint,
 				id: created.id,
 				projectId: created.projectId,
 				path: created.path,
@@ -394,9 +398,16 @@ describe("WorktreeServiceLive", () => {
 				createdAt: created.createdAt,
 			}),
 		);
-		expect(restored.setupStatus).toBe("pending");
+		expect(restored.worktree.setupStatus).toBe("pending");
+		expect(restored.checkpoint).toBe("applied");
 		expect(git(created.path, "rev-parse", "HEAD")).toBe(beforeArchive);
+		expect(git(created.path, "symbolic-ref", "--short", "HEAD")).toBe(
+			created.branch,
+		);
 		expect(git(created.path, "status", "--short")).toContain("?? dirty.txt");
+		expect(() =>
+			git(repositoryRoot, "rev-parse", "--verify", checkpointRef),
+		).toThrow();
 		const setupEvents = await run((service) =>
 			service.setupStream(created.id).pipe(Stream.runCollect),
 		);
@@ -414,6 +425,7 @@ describe("WorktreeServiceLive", () => {
 		writeFileSync(join(created.path, "dirty-after-switch.txt"), "dirty\n");
 
 		const outcome = await run((service) => service.archive(created.id));
+		if (outcome.archiveRef === null) throw new Error("archive ref missing");
 
 		expect(outcome.archiveRef).toBe(`refs/zuse/archive/${created.id}`);
 		expect(
@@ -490,7 +502,7 @@ describe("WorktreeServiceLive", () => {
 			outcome.archiveCommit,
 		);
 
-		await run((service) =>
+		const restored = await run((service) =>
 			service.restore({
 				...outcome,
 				id: created.id,
@@ -501,6 +513,7 @@ describe("WorktreeServiceLive", () => {
 				createdAt: created.createdAt,
 			}),
 		);
+		expect(restored.checkpoint).toBe("applied");
 		expect(git(created.path, "status", "--short")).toContain("?? detached.txt");
 		expect(() =>
 			git(repositoryRoot, "rev-parse", "--verify", archiveRef),
@@ -538,7 +551,7 @@ describe("WorktreeServiceLive", () => {
 		);
 		expect(archivedRows[0]?.abs_path).toBe(archivedFile);
 
-		await run((service) =>
+		const restored = await run((service) =>
 			service.restore({
 				...outcome,
 				id: created.id,
@@ -549,6 +562,7 @@ describe("WorktreeServiceLive", () => {
 				createdAt: created.createdAt,
 			}),
 		);
+		expect(restored.checkpoint).toBe("none");
 		expect(readFileSync(contextFile, "utf8")).toBe("context survives\n");
 		const restoredRows = await runSql(
 			(sql) =>
@@ -624,6 +638,7 @@ describe("WorktreeServiceLive", () => {
 		);
 		writeFileSync(join(created.path, "checkpoint.txt"), "checkpoint\n");
 		const outcome = await run((service) => service.archive(created.id));
+		if (outcome.archiveRef === null) throw new Error("archive ref missing");
 		const advancedPath = join(temporaryRoot, "advanced");
 		git(repositoryRoot, "worktree", "add", advancedPath, created.branch);
 		writeFileSync(join(advancedPath, "advanced.txt"), "advanced\n");
@@ -632,7 +647,7 @@ describe("WorktreeServiceLive", () => {
 		const advancedCommit = git(advancedPath, "rev-parse", "HEAD");
 		git(repositoryRoot, "worktree", "remove", advancedPath);
 
-		await run((service) =>
+		const restored = await run((service) =>
 			service.restore({
 				...outcome,
 				id: created.id,
@@ -643,9 +658,14 @@ describe("WorktreeServiceLive", () => {
 				createdAt: created.createdAt,
 			}),
 		);
-		expect(git(created.path, "rev-parse", "HEAD")).not.toBe(advancedCommit);
-		expect(git(created.path, "status", "--short")).toContain(
-			"?? checkpoint.txt",
+		expect(restored.checkpoint).toBe("branch-advanced");
+		expect(git(created.path, "rev-parse", "HEAD")).toBe(advancedCommit);
+		expect(git(created.path, "symbolic-ref", "--short", "HEAD")).toBe(
+			created.branch,
+		);
+		expect(git(created.path, "status", "--short")).toBe("");
+		expect(git(repositoryRoot, "rev-parse", outcome.archiveRef)).toBe(
+			outcome.archiveCommit,
 		);
 		expect(
 			git(repositoryRoot, "rev-parse", `refs/heads/${created.branch}`),


### PR DESCRIPTION
## Summary

- restore archived worktrees onto their original branch without orphaning dirty WIP, preserve archive checkpoints in domain events, and make restore failures retryable
- serialize unarchive against cleanup, restore only accepted sessions, preserve provider cursors on same-worktree rebinds, and restart setup observation in the renderer
- deduplicate repeated pull-request merge notifications across workspaces
- fingerprint binary command payloads in linear time so image uploads do not stall before transport
- recover provisional new-chat timelines from the mounted ChatView when the creation-time restart races its subscription

## Verification

- Biome checks on changed files
- renderer typecheck/state check and 482 unit tests
- client-runtime typecheck and 107 unit tests
- server typecheck and 531 tests
- contracts, domain, and git package typechecks
- domain unit tests and relevant git integration tests

## Notes

When an archived branch advanced independently, unarchive now preserves the WIP archive ref and reports a branch-advanced notice instead of applying it onto a detached HEAD.

