### PR TITLE
Make Mac-backed E2B connectivity reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.7]
+
+### Fixed
+- Cloud workspace SSH now uses a stable Mac-installed bridge with atomic credentials, bounded transport behavior, and actionable access errors
+- One-way E2B file sync now stops cleanly across disconnects and shutdowns, refreshes access before retrying, and uses safer macOS-compatible rsync updates
+- Private localhost previews now reuse live forwards, recover from local port collisions, and close in-flight tunnels when environments disconnect
+- Zuse now reclaims only its own orphaned Cloudflare relay connectors and records connector ownership across restarts
+
 ## [0.20.6]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.20.7]
 
 ### Fixed
-- Cloud workspace SSH now uses a stable Mac-installed bridge with atomic credentials, bounded transport behavior, and actionable access errors
-- One-way E2B file sync now stops cleanly across disconnects and shutdowns, refreshes access before retrying, and uses safer macOS-compatible rsync updates
+- Cloud workspace SSH now survives app updates and restarts, times out cleanly, and distinguishes expired access, denied access, missing workspaces, and network failures
+- One-way E2B file sync now stops cleanly across disconnects and shutdowns, renews access before retrying, and updates Mac mirrors without exposing partial transfers
 - Private localhost previews now reuse live forwards, recover from local port collisions, and close in-flight tunnels when environments disconnect
-- Zuse now reclaims only its own orphaned Cloudflare relay connectors and records connector ownership across restarts
+- Mac relay connections no longer multiply after an unclean restart; Zuse reclaims only the Cloudflare connectors it owns
 
 ## [0.20.6]
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ settings.
 - Per-repo settings
 - Scoped `@`-mentions within a worktree
 
+### Cloud workspaces
+- Run invited coding-agent sessions in hosted E2B workspaces that continue when the desktop app closes
+- Open a workspace through its managed `ssh zuse-<workspace>` alias without exposing a public SSH listener
+- Keep a one-way, remote-authoritative Mac mirror under `~/.zuse/cloud/` that pauses on disconnect and resumes with fresh access
+- Open dev servers privately on Mac `localhost`; public E2B preview URLs remain an explicit copy action
+
 ### PR & Changes pane
 - PR tab with markdown rendering
 - Changes tab with diff view
@@ -142,7 +148,7 @@ apps/
   server/      All backend logic — Effect Layers
   web/         Next.js marketing site
 packages/
-  wire/        @zuse/contracts — typed RPC contracts + branded IDs
+  contracts/   @zuse/contracts — typed RPC contracts + branded IDs
   ui/          Shared React components
 specs/
   0.01-MVP/    Foundation
@@ -160,6 +166,7 @@ specs/
   session and ClientBus path shared by local, SSH, and cloud environments
 - [Unified computers](docs/specs/unified-computers.md) — environment and sandbox
   domain model
+- [Context map](CONTEXT-MAP.md) — domain contexts and their ownership relationships
 
 ---
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2004,14 +2004,17 @@ async function createMainWindow() {
 		)
 			return null;
 		try {
-			return await prepareCloudSshAccess({
-				workspaceId: access.workspaceId,
-				wsUrl: access.wsUrl,
-				ticket: access.ticket,
-				expiresAt: access.expiresAt,
-				user: access.user,
-				workspacePath: access.workspacePath,
-			});
+			return await prepareCloudSshAccess(
+				{
+					workspaceId: access.workspaceId,
+					wsUrl: access.wsUrl,
+					ticket: access.ticket,
+					expiresAt: access.expiresAt,
+					user: access.user,
+					workspacePath: access.workspacePath,
+				},
+				{ isPackaged: app.isPackaged },
+			);
 		} catch (cause) {
 			recordMainDiagnostic("error", "cloud-ssh.prepare", [cause]);
 			return null;
@@ -3839,9 +3842,15 @@ const finishQuitAfterSshCleanup = (event: {
 	if (sshQuitCleanupInProgress) return;
 	sshQuitCleanupInProgress = true;
 	const manager = sshEnvironmentManager;
+	const runtime = runtimeFiber;
+	runtimeFiber = null;
 	void Promise.allSettled([
+		cloudSyncManager.dispose(),
 		portForwardManager.closeAll(),
 		manager?.close() ?? Promise.resolve(),
+		runtime === null
+			? Promise.resolve()
+			: Effect.runPromise(Fiber.interrupt(runtime)),
 	]).finally(() => {
 		if (sshEnvironmentManager === manager) sshEnvironmentManager = null;
 		sshQuitCleanupComplete = true;

--- a/apps/desktop/src/ssh/cloud-ssh-service.ts
+++ b/apps/desktop/src/ssh/cloud-ssh-service.ts
@@ -1,8 +1,17 @@
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+	chmod,
+	mkdir,
+	readdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, sep } from "node:path";
+import { dirname, isAbsolute, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -32,6 +41,11 @@ const INCLUDE_MARKER = "# Zuse cloud workspaces (managed include)";
 const sshRoot = (): string => join(homedir(), ".zuse", "ssh");
 const keyPath = (): string => join(sshRoot(), "id_ed25519");
 const ticketsDir = (): string => join(sshRoot(), "tickets");
+const bridgeDir = (): string => join(sshRoot(), "bridge");
+const installedBridgePath = (): string =>
+	join(bridgeDir(), "ssh-bridge-child.cjs");
+const bridgeLauncherPath = (): string => join(bridgeDir(), "launch");
+let infrastructureSetup: Promise<string> | null = null;
 
 /** The managed ssh config that declares every `zuse-*` cloud host alias. */
 export const cloudSshConfigPath = (): string => join(sshRoot(), "config");
@@ -48,6 +62,85 @@ const resolveBridgeScript = (): string => {
 		`${sep}app.asar.unpacked${sep}`,
 	);
 	return existsSync(unpacked) ? unpacked : bundled;
+};
+
+const shellQuote = (value: string): string =>
+	`'${value.replaceAll("'", `'"'"'`)}'`;
+
+export interface CloudSshBridgeRuntime {
+	readonly executable: string;
+	readonly electronRunAsNode: boolean;
+}
+
+export const cloudSshBridgeLauncher = (
+	runtime: CloudSshBridgeRuntime,
+	bridgePath: string,
+): string => {
+	const environment = runtime.electronRunAsNode
+		? "env ELECTRON_RUN_AS_NODE=1 "
+		: "";
+	return `#!/bin/sh\nexec ${environment}${shellQuote(runtime.executable)} ${shellQuote(bridgePath)} "$@"\n`;
+};
+
+export const resolveCloudSshBridgeRuntime = async (
+	isPackaged: boolean,
+): Promise<CloudSshBridgeRuntime> => {
+	if (isPackaged) {
+		return { executable: process.execPath, electronRunAsNode: true };
+	}
+	const { stdout } = await execFileAsync("node", ["-p", "process.execPath"]);
+	const executable = stdout.trim();
+	if (!isAbsolute(executable) || !existsSync(executable)) {
+		throw new Error("Could not resolve a stable Node.js executable for SSH");
+	}
+	return { executable, electronRunAsNode: false };
+};
+
+/** Replace a private file without exposing a partially-written credential. */
+export const atomicWritePrivateFile = async (
+	path: string,
+	contents: string | Buffer,
+	mode: number,
+): Promise<void> => {
+	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+	const temporaryPath = `${path}.tmp-${process.pid}-${randomUUID()}`;
+	try {
+		await writeFile(temporaryPath, contents, { mode, flag: "wx" });
+		await chmod(temporaryPath, mode);
+		await rename(temporaryPath, path);
+		await chmod(path, mode);
+	} finally {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+	}
+};
+
+export const pruneExpiredCloudSshTickets = async (
+	directory = ticketsDir(),
+	now = Date.now(),
+): Promise<void> => {
+	let names: string[];
+	try {
+		names = await readdir(directory);
+	} catch {
+		return;
+	}
+	await Promise.all(
+		names
+			.filter((name) => name.endsWith(".json"))
+			.map(async (name) => {
+				const path = join(directory, name);
+				try {
+					const ticket = JSON.parse(await readFile(path, "utf8")) as {
+						expiresAt?: unknown;
+					};
+					if (typeof ticket.expiresAt === "number" && ticket.expiresAt > now)
+						return;
+				} catch {
+					// Invalid managed tickets cannot be used and are safe to prune.
+				}
+				await rm(path, { force: true });
+			}),
+	);
 };
 
 export const ensureCloudSshKeypair = async (): Promise<string> => {
@@ -76,6 +169,7 @@ export const managedSshConfig = (bridgeCommand: string): string =>
 		"\tUser zuse",
 		`\tIdentityFile ${keyPath()}`,
 		"\tIdentitiesOnly yes",
+		"\tConnectTimeout 15",
 		"\tStrictHostKeyChecking accept-new",
 		`\tUserKnownHostsFile ${join(sshRoot(), "known_hosts")}`,
 		`\tProxyCommand ${bridgeCommand} %n`,
@@ -99,7 +193,8 @@ const ensureUserConfigInclude = async (): Promise<void> => {
 		? await readFile(configPath, "utf8")
 		: "";
 	const updated = withUserConfigInclude(existing, cloudSshConfigPath());
-	if (updated !== null) await writeFile(configPath, updated, { mode: 0o600 });
+	if (updated !== null)
+		await atomicWritePrivateFile(configPath, updated, 0o600);
 };
 
 /**
@@ -109,22 +204,53 @@ const ensureUserConfigInclude = async (): Promise<void> => {
  */
 export const prepareCloudSshAccess = async (
 	access: CloudWorkspaceSshAccess,
+	options: {
+		readonly isPackaged?: boolean;
+		readonly runtime?: CloudSshBridgeRuntime;
+		readonly bridgeSourcePath?: string;
+	} = {},
 ): Promise<CloudSshPrepared> => {
-	const publicKey = await ensureCloudSshKeypair();
-	const bridgeCommand = `env ELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${resolveBridgeScript()}"`;
-	await writeFile(cloudSshConfigPath(), managedSshConfig(bridgeCommand), {
-		mode: 0o600,
-	});
-	await ensureUserConfigInclude();
-	await mkdir(ticketsDir(), { recursive: true, mode: 0o700 });
-	await writeFile(
+	if (!/^[A-Za-z0-9_-]+$/u.test(access.workspaceId))
+		throw new Error("Invalid cloud workspace identifier");
+	if (infrastructureSetup === null) {
+		const setup = (async () => {
+			const publicKey = await ensureCloudSshKeypair();
+			const runtime =
+				options.runtime ??
+				(await resolveCloudSshBridgeRuntime(options.isPackaged ?? false));
+			const bridgeSource = await readFile(
+				options.bridgeSourcePath ?? resolveBridgeScript(),
+			);
+			await atomicWritePrivateFile(installedBridgePath(), bridgeSource, 0o700);
+			await atomicWritePrivateFile(
+				bridgeLauncherPath(),
+				cloudSshBridgeLauncher(runtime, installedBridgePath()),
+				0o700,
+			);
+			await atomicWritePrivateFile(
+				cloudSshConfigPath(),
+				managedSshConfig(shellQuote(bridgeLauncherPath())),
+				0o600,
+			);
+			await ensureUserConfigInclude();
+			await mkdir(ticketsDir(), { recursive: true, mode: 0o700 });
+			await pruneExpiredCloudSshTickets();
+			return publicKey;
+		})().catch((cause) => {
+			infrastructureSetup = null;
+			throw cause;
+		});
+		infrastructureSetup = setup;
+	}
+	const publicKey = await infrastructureSetup;
+	await atomicWritePrivateFile(
 		join(ticketsDir(), `${access.workspaceId}.json`),
 		JSON.stringify({
 			wsUrl: access.wsUrl,
 			ticket: access.ticket,
 			expiresAt: access.expiresAt,
 		}),
-		{ mode: 0o600 },
+		0o600,
 	);
 	const hostAlias = cloudSshHostAlias(access.workspaceId);
 	return {

--- a/apps/desktop/src/ssh/ssh-bridge-child.ts
+++ b/apps/desktop/src/ssh/ssh-bridge-child.ts
@@ -11,6 +11,8 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { sanitizedSshBridgeFailure } from "./ssh-bridge-errors";
+
 interface TicketFile {
 	wsUrl?: unknown;
 	ticket?: unknown;
@@ -22,12 +24,61 @@ const fail = (message: string): never => {
 	process.exit(1);
 };
 
+const configuredTimeout = Number.parseInt(
+	process.env.ZUSE_SSH_BRIDGE_CONNECT_TIMEOUT_MS ?? "",
+	10,
+);
+const CONNECT_TIMEOUT_MS =
+	Number.isFinite(configuredTimeout) && configuredTimeout > 0
+		? configuredTimeout
+		: 15_000;
+const BUFFER_LOW_WATERMARK_BYTES = 1024 * 1024;
+const BUFFER_HIGH_WATERMARK_BYTES = 8 * 1024 * 1024;
+const BUFFER_HARD_LIMIT_BYTES = 32 * 1024 * 1024;
+
+const errorDetail = (event: Event): string => {
+	const candidate = event as Event & {
+		readonly message?: unknown;
+		readonly error?: { readonly message?: unknown };
+	};
+	if (typeof candidate.message === "string") return candidate.message;
+	if (typeof candidate.error?.message === "string")
+		return candidate.error.message;
+	return "";
+};
+
+const diagnoseHandshakeFailure = async (url: URL): Promise<string> => {
+	try {
+		const diagnosticUrl = new URL(url);
+		diagnosticUrl.protocol =
+			diagnosticUrl.protocol === "wss:" ? "https:" : "http:";
+		const response = await fetch(diagnosticUrl, {
+			signal: AbortSignal.timeout(5_000),
+			redirect: "error",
+		});
+		const reader = response.body?.getReader();
+		let detail = `${response.status}`;
+		if (reader !== undefined) {
+			const { value } = await reader.read();
+			await reader.cancel().catch(() => undefined);
+			if (value !== undefined) {
+				detail = `${detail} ${Buffer.from(value)
+					.subarray(0, 4_096)
+					.toString("utf8")}`;
+			}
+		}
+		return detail;
+	} catch (cause) {
+		return cause instanceof Error ? cause.message : "network failure";
+	}
+};
+
 const main = (): void => {
 	const alias = process.argv[2] ?? "";
 	const workspaceId = alias.startsWith("zuse-")
 		? alias.slice("zuse-".length)
 		: alias;
-	if (workspaceId.length === 0) {
+	if (!/^[A-Za-z0-9_-]+$/u.test(workspaceId)) {
 		fail("zuse ssh bridge: missing workspace host alias");
 		return;
 	}
@@ -52,7 +103,9 @@ const main = (): void => {
 		typeof parsed.ticket !== "string" ||
 		typeof parsed.expiresAt !== "number"
 	) {
-		fail(`zuse ssh bridge: invalid ticket file at ${ticketPath}`);
+		fail(
+			"zuse ssh bridge: the managed SSH access ticket is invalid. Refresh workspace access in Zuse.",
+		);
 		return;
 	}
 	if (parsed.expiresAt <= Date.now()) {
@@ -61,43 +114,169 @@ const main = (): void => {
 		);
 		return;
 	}
-	const url = new URL(parsed.wsUrl);
+	let url: URL;
+	try {
+		url = new URL(parsed.wsUrl);
+		if (url.protocol !== "wss:" && url.protocol !== "ws:") throw new Error();
+	} catch {
+		fail(
+			"zuse ssh bridge: the managed SSH access ticket is invalid. Refresh workspace access in Zuse.",
+		);
+		return;
+	}
 	url.searchParams.set("ticket", parsed.ticket);
 	const ws = new WebSocket(url.toString());
 	ws.binaryType = "arraybuffer";
 	const pendingStdin: Array<Buffer> = [];
+	let pendingStdinBytes = 0;
+	const pendingStdout: Array<Buffer> = [];
+	let pendingStdoutBytes = 0;
+	let stdoutWriting = false;
 	let connected = false;
-	ws.addEventListener("open", () => {
-		connected = true;
-		for (const chunk of pendingStdin) ws.send(chunk);
-		pendingStdin.length = 0;
-	});
-	ws.addEventListener("message", (event) => {
-		const data: unknown = event.data;
-		process.stdout.write(
-			typeof data === "string"
-				? Buffer.from(data)
-				: Buffer.from(data as ArrayBuffer),
-		);
-	});
-	ws.addEventListener("close", () => process.exit(0));
-	ws.addEventListener("error", () => {
-		fail(
-			"zuse ssh bridge: connection to the cloud workspace failed. Make sure the workspace is running in Zuse.",
-		);
-	});
-	process.stdin.on("data", (chunk: Buffer) => {
-		if (connected) ws.send(chunk);
-		else pendingStdin.push(chunk);
-	});
-	process.stdin.on("end", () => {
+	let ending = false;
+	let settled = false;
+	let backpressureTimer: NodeJS.Timeout | undefined;
+	const connectionTimer = setTimeout(() => {
+		settled = true;
 		try {
 			ws.close();
 		} catch {
-			// Already closed.
+			// The socket never opened.
 		}
-		process.exit(0);
+		fail(sanitizedSshBridgeFailure({ timedOut: true }));
+	}, CONNECT_TIMEOUT_MS);
+
+	const stopBackpressureTimer = (): void => {
+		if (backpressureTimer !== undefined) clearInterval(backpressureTimer);
+		backpressureTimer = undefined;
+	};
+	const failConnection = (message: string): never => {
+		settled = true;
+		clearTimeout(connectionTimer);
+		stopBackpressureTimer();
+		process.stdin.pause();
+		return fail(message);
+	};
+	const diagnoseConnection = (detail: string): void => {
+		settled = true;
+		clearTimeout(connectionTimer);
+		stopBackpressureTimer();
+		process.stdin.pause();
+		void diagnoseHandshakeFailure(url).then((diagnostic) =>
+			fail(
+				sanitizedSshBridgeFailure({
+					detail: `${detail} ${diagnostic}`,
+				}),
+			),
+		);
+	};
+	const monitorWebSocketBackpressure = (): void => {
+		if (ws.bufferedAmount > BUFFER_HARD_LIMIT_BYTES) {
+			failConnection(
+				"zuse ssh bridge: the cloud connection stopped accepting data.",
+			);
+		}
+		if (ws.bufferedAmount <= BUFFER_HIGH_WATERMARK_BYTES) return;
+		process.stdin.pause();
+		if (backpressureTimer !== undefined) return;
+		backpressureTimer = setInterval(() => {
+			if (ws.bufferedAmount > BUFFER_HARD_LIMIT_BYTES) {
+				failConnection(
+					"zuse ssh bridge: the cloud connection stopped accepting data.",
+				);
+			}
+			if (ws.bufferedAmount <= BUFFER_LOW_WATERMARK_BYTES) {
+				stopBackpressureTimer();
+				process.stdin.resume();
+			}
+		}, 10);
+	};
+	const send = (chunk: Buffer): void => {
+		try {
+			ws.send(chunk);
+			monitorWebSocketBackpressure();
+		} catch {
+			failConnection(
+				sanitizedSshBridgeFailure({ detail: "network send failed" }),
+			);
+		}
+	};
+	const flushStdout = (): void => {
+		if (stdoutWriting) return;
+		const chunk = pendingStdout.shift();
+		if (chunk === undefined) return;
+		stdoutWriting = true;
+		pendingStdoutBytes -= chunk.byteLength;
+		process.stdout.write(chunk, () => {
+			stdoutWriting = false;
+			flushStdout();
+		});
+	};
+	ws.addEventListener("open", () => {
+		clearTimeout(connectionTimer);
+		connected = true;
+		for (const chunk of pendingStdin) send(chunk);
+		pendingStdin.length = 0;
+		pendingStdinBytes = 0;
 	});
+	ws.addEventListener("message", (event) => {
+		const data: unknown = event.data;
+		const chunk =
+			typeof data === "string"
+				? Buffer.from(data)
+				: Buffer.from(data as ArrayBuffer);
+		pendingStdoutBytes += chunk.byteLength;
+		if (pendingStdoutBytes > BUFFER_HARD_LIMIT_BYTES) {
+			failConnection(
+				"zuse ssh bridge: the local SSH client stopped accepting data.",
+			);
+		}
+		pendingStdout.push(chunk);
+		flushStdout();
+	});
+	ws.addEventListener("close", (event) => {
+		clearTimeout(connectionTimer);
+		stopBackpressureTimer();
+		if (settled) return;
+		settled = true;
+		if (ending && event.code === 1000) process.exit(0);
+		fail(sanitizedSshBridgeFailure({ closeCode: event.code }));
+	});
+	ws.addEventListener("error", (event) => {
+		if (settled) return;
+		diagnoseConnection(errorDetail(event));
+	});
+	process.stdin.on("data", (chunk: Buffer) => {
+		if (connected) {
+			send(chunk);
+			return;
+		}
+		pendingStdinBytes += chunk.byteLength;
+		if (pendingStdinBytes > BUFFER_HIGH_WATERMARK_BYTES) {
+			failConnection(
+				"zuse ssh bridge: too much data was buffered before connecting.",
+			);
+		}
+		pendingStdin.push(chunk);
+	});
+	process.stdin.on("end", () => {
+		ending = true;
+		try {
+			ws.close(1000);
+		} catch {
+			process.exit(connected ? 0 : 1);
+		}
+	});
+	for (const signal of ["SIGINT", "SIGTERM"] as const) {
+		process.on(signal, () => {
+			ending = true;
+			try {
+				ws.close(1000);
+			} finally {
+				setTimeout(() => process.exit(0), 1_000).unref();
+			}
+		});
+	}
 };
 
 main();

--- a/apps/desktop/src/ssh/ssh-bridge-errors.ts
+++ b/apps/desktop/src/ssh/ssh-bridge-errors.ts
@@ -1,0 +1,38 @@
+export interface SshBridgeFailure {
+	readonly detail?: string;
+	readonly closeCode?: number;
+	readonly timedOut?: boolean;
+}
+
+/** Convert transport failures into actionable messages without leaking URLs/tickets. */
+export const sanitizedSshBridgeFailure = ({
+	detail = "",
+	closeCode,
+	timedOut = false,
+}: SshBridgeFailure): string => {
+	const normalized = detail.toLowerCase();
+	if (timedOut || normalized.includes("timed out")) {
+		return "zuse ssh bridge: connection timed out. Check the network and resume the workspace in Zuse.";
+	}
+	if (
+		normalized.includes("401") ||
+		normalized.includes("unauthorized") ||
+		normalized.includes("invalid ticket")
+	) {
+		return "zuse ssh bridge: SSH access was rejected. Refresh workspace access in Zuse.";
+	}
+	if (normalized.includes("403") || normalized.includes("forbidden")) {
+		return "zuse ssh bridge: this device is not authorized for the cloud workspace. Refresh access in Zuse.";
+	}
+	if (
+		normalized.includes("sandbox was not found") ||
+		normalized.includes("sandbox not found") ||
+		normalized.includes("workspace was not found")
+	) {
+		return "zuse ssh bridge: the cloud workspace is not running. Resume it in Zuse and try again.";
+	}
+	if (closeCode !== undefined && closeCode !== 1000) {
+		return `zuse ssh bridge: the cloud connection closed unexpectedly (code ${closeCode}). Resume the workspace in Zuse or refresh access.`;
+	}
+	return "zuse ssh bridge: could not reach the cloud workspace. Check the network and workspace status in Zuse.";
+};

--- a/apps/desktop/src/sync/cloud-sync-service.ts
+++ b/apps/desktop/src/sync/cloud-sync-service.ts
@@ -34,6 +34,8 @@ const PERIODIC_FALLBACK_MS = 60_000;
 const ERROR_BACKOFF_MIN_MS = 5_000;
 const ERROR_BACKOFF_MAX_MS = 60_000;
 const TICKET_STALE_MARGIN_MS = 10 * 60_000;
+const TRANSFER_INACTIVITY_TIMEOUT_MS = 30_000;
+const TRANSFER_TERMINATE_GRACE_MS = 2_000;
 const GENERATED_SYNC_EXCLUDES = [
 	"node_modules",
 	".cache",
@@ -41,6 +43,7 @@ const GENERATED_SYNC_EXCLUDES = [
 	".next/cache",
 	"__pycache__",
 	".pytest_cache",
+	".zuse-rsync-partial",
 ] as const;
 
 export type CloudSyncState = "idle" | "syncing" | "in-sync" | "error";
@@ -52,8 +55,8 @@ export interface CloudSyncStatus {
 	readonly localPath: string | null;
 	readonly lastSyncedAt: number | null;
 	readonly error: string | null;
-	/** The SSH ticket is missing or near expiry; the renderer should refresh it. */
-	readonly ticketStale: boolean;
+	/** Access is near expiry or the SSH transport failed and must be refreshed. */
+	readonly accessRefreshRequired: boolean;
 }
 
 export interface CloudSyncConfigureInput {
@@ -79,7 +82,10 @@ export const rsyncArgs = (input: {
 	readonly gitignoreFilter: boolean;
 }): ReadonlyArray<string> => [
 	"-az",
-	"--delete",
+	"--delay-updates",
+	"--delete-delay",
+	"--partial-dir=.zuse-rsync-partial",
+	"--timeout=30",
 	"--exclude=.git/",
 	`--exclude=${SYNC_MARKER_FILE}`,
 	...GENERATED_SYNC_EXCLUDES.map((path) => `--exclude=${path}/`),
@@ -98,11 +104,13 @@ interface SyncEntry {
 	state: CloudSyncState;
 	lastSyncedAt: number | null;
 	error: string | null;
-	ticketStale: boolean;
+	accessRefreshRequired: boolean;
 	running: boolean;
 	rerunRequested: boolean;
 	backoffMs: number;
 	timer: NodeJS.Timeout | null;
+	abortController: AbortController | null;
+	completion: Promise<void> | null;
 }
 
 const ticketPath = (workspaceId: string): string =>
@@ -149,9 +157,11 @@ export class CloudSyncManager {
 		private readonly notify: (status: CloudSyncStatus) => void,
 		private readonly runRsync: (
 			args: ReadonlyArray<string>,
+			signal?: AbortSignal,
 		) => Promise<{ code: number; stderr: string }> = defaultRunRsync,
 		private readonly runLegacySync: (
 			input: CloudSyncConfigureInput,
+			signal?: AbortSignal,
 		) => Promise<{ code: number; stderr: string }> = defaultRunLegacySync,
 	) {}
 
@@ -164,15 +174,18 @@ export class CloudSyncManager {
 			localPath: entry?.config.localPath ?? null,
 			lastSyncedAt: entry?.lastSyncedAt ?? null,
 			error: entry?.error ?? null,
-			ticketStale: entry?.ticketStale ?? false,
+			accessRefreshRequired: entry?.accessRefreshRequired ?? false,
 		};
 	}
 
 	async configure(input: CloudSyncConfigureInput): Promise<CloudSyncStatus> {
 		const existing = this.entries.get(input.workspaceId);
-		if (existing !== undefined) this.clearTimers(existing);
-		if (!input.enabled) {
+		if (existing !== undefined) {
 			this.entries.delete(input.workspaceId);
+			this.cancelEntry(existing);
+			await existing.completion;
+		}
+		if (!input.enabled) {
 			const status = this.status(input.workspaceId);
 			this.notify(status);
 			return status;
@@ -182,11 +195,13 @@ export class CloudSyncManager {
 			state: existing?.state === "in-sync" ? "in-sync" : "idle",
 			lastSyncedAt: existing?.lastSyncedAt ?? null,
 			error: null,
-			ticketStale: false,
+			accessRefreshRequired: false,
 			running: false,
 			rerunRequested: false,
 			backoffMs: ERROR_BACKOFF_MIN_MS,
 			timer: null,
+			abortController: null,
+			completion: null,
 		};
 		this.entries.set(input.workspaceId, entry);
 		const guard = await this.guardLocalPath(input);
@@ -196,7 +211,7 @@ export class CloudSyncManager {
 			this.publish(input.workspaceId);
 			return this.status(input.workspaceId);
 		}
-		void this.sync(input.workspaceId);
+		this.launchSync(input.workspaceId);
 		return this.status(input.workspaceId);
 	}
 
@@ -207,9 +222,17 @@ export class CloudSyncManager {
 		this.schedule(workspaceId, entry, DEBOUNCE_MS);
 	}
 
-	dispose(): void {
-		for (const entry of this.entries.values()) this.clearTimers(entry);
+	async dispose(): Promise<void> {
+		const entries = [...this.entries.values()];
+		for (const entry of entries) this.cancelEntry(entry);
 		this.entries.clear();
+		await Promise.all(entries.map((entry) => entry.completion));
+	}
+
+	private cancelEntry(entry: SyncEntry): void {
+		this.clearTimers(entry);
+		entry.abortController?.abort();
+		entry.abortController = null;
 	}
 
 	private clearTimers(entry: SyncEntry): void {
@@ -221,9 +244,22 @@ export class CloudSyncManager {
 		this.clearTimers(entry);
 		entry.timer = setTimeout(() => {
 			entry.timer = null;
-			void this.sync(workspaceId);
+			this.launchSync(workspaceId);
 		}, delay);
 		entry.timer.unref?.();
+	}
+
+	private launchSync(workspaceId: string): void {
+		const entry = this.entries.get(workspaceId);
+		if (entry === undefined || !entry.config.enabled) return;
+		if (entry.running) {
+			entry.rerunRequested = true;
+			return;
+		}
+		const operation = this.sync(workspaceId).finally(() => {
+			if (entry.completion === operation) entry.completion = null;
+		});
+		entry.completion = operation;
 	}
 
 	private async guardLocalPath(
@@ -264,13 +300,16 @@ export class CloudSyncManager {
 	private async sync(workspaceId: string): Promise<void> {
 		const entry = this.entries.get(workspaceId);
 		if (entry === undefined || !entry.config.enabled) return;
-		if (entry.running) {
-			entry.rerunRequested = true;
-			return;
-		}
 		entry.running = true;
 		entry.state = "syncing";
-		entry.ticketStale = !(await ticketFresh(workspaceId));
+		const abortController = new AbortController();
+		entry.abortController = abortController;
+		entry.accessRefreshRequired = !(await ticketFresh(workspaceId));
+		if (
+			abortController.signal.aborted ||
+			this.entries.get(workspaceId) !== entry
+		)
+			return;
 		this.publish(workspaceId);
 		let nextDelay = PERIODIC_FALLBACK_MS;
 		try {
@@ -281,33 +320,44 @@ export class CloudSyncManager {
 				sshConfigPath: cloudSshConfigPath(),
 				gitignoreFilter: await this.resolveGitignoreFilter(),
 			});
-			let result = await this.runRsync(args);
-			if (result.code !== 0 && remoteRsyncMissing(result.stderr))
-				result = await this.runLegacySync(entry.config);
+			if (abortController.signal.aborted) return;
+			let result = await this.runRsync(args, abortController.signal);
+			if (
+				!abortController.signal.aborted &&
+				result.code !== 0 &&
+				remoteRsyncMissing(result.stderr)
+			)
+				result = await this.runLegacySync(entry.config, abortController.signal);
 			if (this.entries.get(workspaceId) !== entry) return;
 			if (result.code === 0) {
 				entry.state = "in-sync";
 				entry.error = null;
 				entry.lastSyncedAt = Date.now();
 				entry.backoffMs = ERROR_BACKOFF_MIN_MS;
+				entry.accessRefreshRequired = false;
 			} else {
 				entry.state = "error";
 				entry.error = result.stderr.trim().split("\n").slice(-3).join("\n");
+				if (sshTransportFailed(result.stderr))
+					entry.accessRefreshRequired = true;
 				nextDelay = entry.backoffMs;
 				entry.backoffMs = Math.min(entry.backoffMs * 2, ERROR_BACKOFF_MAX_MS);
 			}
 		} catch (cause) {
+			if (abortController.signal.aborted) return;
 			entry.state = "error";
 			entry.error = cause instanceof Error ? cause.message : String(cause);
 			nextDelay = entry.backoffMs;
 			entry.backoffMs = Math.min(entry.backoffMs * 2, ERROR_BACKOFF_MAX_MS);
 		} finally {
+			if (entry.abortController === abortController)
+				entry.abortController = null;
 			entry.running = false;
 			if (this.entries.get(workspaceId) === entry) {
 				this.publish(workspaceId);
 				if (entry.rerunRequested) {
 					entry.rerunRequested = false;
-					void this.sync(workspaceId);
+					this.launchSync(workspaceId);
 				} else if (entry.timer === null) {
 					this.schedule(workspaceId, entry, nextDelay);
 				}
@@ -318,27 +368,64 @@ export class CloudSyncManager {
 
 const defaultRunRsync = (
 	args: ReadonlyArray<string>,
+	signal?: AbortSignal,
 ): Promise<{ code: number; stderr: string }> =>
 	new Promise((resolve, reject) => {
 		const child = spawn("rsync", [...args], {
 			stdio: ["ignore", "ignore", "pipe"],
 		});
 		let stderr = "";
+		let settled = false;
+		let forcedTermination: NodeJS.Timeout | null = null;
+		const finish = (result: { code: number; stderr: string }): void => {
+			if (settled) return;
+			settled = true;
+			if (forcedTermination !== null) clearTimeout(forcedTermination);
+			signal?.removeEventListener("abort", abort);
+			resolve(result);
+		};
+		const fail = (cause: Error): void => {
+			if (settled) return;
+			settled = true;
+			if (forcedTermination !== null) clearTimeout(forcedTermination);
+			signal?.removeEventListener("abort", abort);
+			reject(cause);
+		};
+		const abort = (): void => {
+			child.kill("SIGTERM");
+			forcedTermination = setTimeout(
+				() => child.kill("SIGKILL"),
+				TRANSFER_TERMINATE_GRACE_MS,
+			);
+			forcedTermination.unref?.();
+		};
 		child.stderr.on("data", (chunk: Buffer) => {
 			stderr = `${stderr}${chunk.toString()}`.slice(-4_096);
 		});
-		child.once("error", reject);
-		child.once("close", (code) => resolve({ code: code ?? 1, stderr }));
+		child.once("error", (cause) => {
+			if (signal?.aborted) finish({ code: 1, stderr: "Sync cancelled." });
+			else fail(cause);
+		});
+		child.once("close", (code) =>
+			finish({
+				code: signal?.aborted ? 1 : (code ?? 1),
+				stderr: signal?.aborted ? "Sync cancelled." : stderr,
+			}),
+		);
+		if (signal?.aborted) abort();
+		else signal?.addEventListener("abort", abort, { once: true });
 	});
 
 /** Compatibility path for workspaces created before rsync entered the image. */
 const defaultRunLegacySync = async (
 	input: CloudSyncConfigureInput,
+	signal?: AbortSignal,
 ): Promise<{ code: number; stderr: string }> => {
 	const staging = await mkdtemp(`${input.localPath}.incoming-`);
 	try {
-		const result = await streamTarArchive(input, staging);
+		const result = await streamTarArchive(input, staging, signal);
 		if (result.code !== 0) return result;
+		if (signal?.aborted) return { code: 1, stderr: "Sync cancelled." };
 		for (const name of await readdir(input.localPath)) {
 			if (name !== SYNC_MARKER_FILE)
 				await rm(join(input.localPath, name), { recursive: true, force: true });
@@ -354,8 +441,9 @@ const defaultRunLegacySync = async (
 const streamTarArchive = (
 	input: CloudSyncConfigureInput,
 	staging: string,
+	signal?: AbortSignal,
 ): Promise<{ code: number; stderr: string }> =>
-	new Promise((resolve, reject) => {
+	new Promise((resolve) => {
 		const remote = spawn(
 			"ssh",
 			[
@@ -379,23 +467,56 @@ const streamTarArchive = (
 			stdio: ["pipe", "ignore", "pipe"],
 		});
 		let stderr = "";
+		let settled = false;
+		let inactivityTimer: NodeJS.Timeout;
+		const terminate = (reason?: string): void => {
+			if (reason !== undefined) stderr = reason;
+			remote.kill("SIGTERM");
+			local.kill("SIGTERM");
+			const forced = setTimeout(() => {
+				remote.kill("SIGKILL");
+				local.kill("SIGKILL");
+			}, TRANSFER_TERMINATE_GRACE_MS);
+			forced.unref?.();
+		};
+		const abort = (): void => terminate();
+		const resetInactivity = (): void => {
+			clearTimeout(inactivityTimer);
+			inactivityTimer = setTimeout(
+				() =>
+					terminate(
+						"Sync timed out after 30 seconds without transferred data.",
+					),
+				TRANSFER_INACTIVITY_TIMEOUT_MS,
+			);
+			inactivityTimer.unref?.();
+		};
 		const appendError = (chunk: Buffer) => {
 			stderr = `${stderr}${chunk.toString()}`.slice(-4_096);
+			resetInactivity();
 		};
 		remote.stderr.on("data", appendError);
 		local.stderr.on("data", appendError);
+		remote.stdout.on("data", resetInactivity);
 		remote.stdout.pipe(local.stdin);
 		let remoteCode: number | null = null;
 		let localCode: number | null = null;
 		const finish = () => {
-			if (remoteCode === null || localCode === null) return;
+			if (settled || remoteCode === null || localCode === null) return;
+			settled = true;
+			clearTimeout(inactivityTimer);
+			signal?.removeEventListener("abort", abort);
 			resolve({
-				code: remoteCode === 0 && localCode === 0 ? 0 : 1,
-				stderr,
+				code: !signal?.aborted && remoteCode === 0 && localCode === 0 ? 0 : 1,
+				stderr: signal?.aborted ? "Sync cancelled." : stderr,
 			});
 		};
-		remote.once("error", reject);
-		local.once("error", reject);
+		remote.once("error", (cause) => {
+			terminate(cause.message);
+		});
+		local.once("error", (cause) => {
+			terminate(cause.message);
+		});
 		remote.once("close", (code) => {
 			remoteCode = code ?? 1;
 			finish();
@@ -404,4 +525,12 @@ const streamTarArchive = (
 			localCode = code ?? 1;
 			finish();
 		});
+		resetInactivity();
+		if (signal?.aborted) abort();
+		else signal?.addEventListener("abort", abort, { once: true });
 	});
+
+export const sshTransportFailed = (stderr: string): boolean =>
+	/(?:zuse ssh bridge:|permission denied|connection (?:unexpectedly )?(?:closed|reset|timed out)|kex_exchange_identification|broken pipe|no route to host|could not resolve hostname)/iu.test(
+		stderr,
+	);

--- a/apps/desktop/src/tunnels/port-forward-service.ts
+++ b/apps/desktop/src/tunnels/port-forward-service.ts
@@ -60,21 +60,36 @@ const tunnelAlive = (handle: TunnelHandle): boolean =>
 
 const forwardKey = (environmentId: string, remotePort: number): string =>
 	`${environmentId}:${remotePort}`;
+const MAX_LOCAL_PORT_CANDIDATES = 5;
+
+export const retryableLocalBindFailure = (cause: unknown): boolean => {
+	const detail = cause instanceof Error ? cause.message : String(cause);
+	return /(?:bind(?:ing)? failed|address already in use|cannot listen|could not request local forwarding)/iu.test(
+		detail,
+	);
+};
 
 type ForwardEntry = {
 	readonly summary: PortForwardSummary;
 	readonly handle: TunnelHandle;
 };
 
+type PendingForward = {
+	readonly environmentId: string;
+	cancelled: boolean;
+	operation: Promise<PortForwardSummary>;
+};
+
 export class PortForwardManager {
 	private readonly forwards = new Map<string, ForwardEntry>();
-	private readonly pending = new Map<string, Promise<PortForwardSummary>>();
+	private readonly pending = new Map<string, PendingForward>();
 
 	constructor(
 		private readonly openForwardTunnel: OpenForwardTunnel = defaultOpenForwardTunnel,
 		private readonly isLocalPortFree: (
 			port: number,
 		) => Promise<boolean> = localPortFree,
+		private readonly allocateLocalPort: () => number = randomLocalPort,
 	) {}
 
 	/** Idempotent: an existing live forward for the same port is returned. */
@@ -89,33 +104,66 @@ export class PortForwardManager {
 			return Promise.resolve(existing.summary);
 		}
 		const inFlight = this.pending.get(key);
-		if (inFlight !== undefined) return inFlight;
-		const operation = this.connect(key, input).finally(() => {
-			if (this.pending.get(key) === operation) this.pending.delete(key);
+		if (inFlight !== undefined) return inFlight.operation;
+		const pending: PendingForward = {
+			environmentId: input.environmentId,
+			cancelled: false,
+			operation: Promise.resolve({
+				environmentId: input.environmentId,
+				remotePort: input.remotePort,
+				localPort: 0,
+			}),
+		};
+		const operation = this.connect(key, input).then(async (summary) => {
+			if (!pending.cancelled) return summary;
+			const opened = this.forwards.get(key);
+			this.forwards.delete(key);
+			await opened?.handle.close();
+			throw new Error("Port forward closed before it became ready.");
 		});
-		this.pending.set(key, operation);
-		return operation;
+		pending.operation = operation.finally(() => {
+			if (this.pending.get(key) === pending) this.pending.delete(key);
+		});
+		this.pending.set(key, pending);
+		return pending.operation;
 	}
 
 	async close(environmentId: string, remotePort: number): Promise<void> {
 		const key = forwardKey(environmentId, remotePort);
+		const pending = this.pending.get(key);
+		if (pending !== undefined) pending.cancelled = true;
 		const entry = this.forwards.get(key);
 		this.forwards.delete(key);
-		await entry?.handle.close();
+		await Promise.allSettled([
+			entry?.handle.close() ?? Promise.resolve(),
+			pending?.operation ?? Promise.resolve(),
+		]);
 	}
 
 	async closeForEnvironment(environmentId: string): Promise<void> {
+		const pending = [...this.pending.values()].filter(
+			(entry) => entry.environmentId === environmentId,
+		);
+		for (const entry of pending) entry.cancelled = true;
 		const entries = [...this.forwards.entries()].filter(
 			([, entry]) => entry.summary.environmentId === environmentId,
 		);
 		for (const [key] of entries) this.forwards.delete(key);
-		await Promise.all(entries.map(([, entry]) => entry.handle.close()));
+		await Promise.allSettled([
+			...entries.map(([, entry]) => entry.handle.close()),
+			...pending.map((entry) => entry.operation),
+		]);
 	}
 
 	async closeAll(): Promise<void> {
+		const pending = [...this.pending.values()];
+		for (const entry of pending) entry.cancelled = true;
 		const entries = [...this.forwards.values()];
 		this.forwards.clear();
-		await Promise.all(entries.map((entry) => entry.handle.close()));
+		await Promise.allSettled([
+			...entries.map((entry) => entry.handle.close()),
+			...pending.map((entry) => entry.operation),
+		]);
 	}
 
 	list(environmentId?: string): ReadonlyArray<PortForwardSummary> {
@@ -137,29 +185,35 @@ export class PortForwardManager {
 			readonly remotePort: number;
 		},
 	): Promise<PortForwardSummary> {
-		// Prefer the remote port locally so the tunneled URL matches the dev
-		// server's own; fall back to a random port when it is taken.
-		const preferred = (await this.isLocalPortFree(input.remotePort))
-			? input.remotePort
-			: randomLocalPort();
-		let handle: TunnelHandle;
-		try {
-			handle = await this.openForwardTunnel({
-				target: input.target,
-				remotePort: input.remotePort,
-				localPort: preferred,
-			});
-		} catch (cause) {
-			// The preferred port can be taken between the probe and ssh's bind
-			// (ExitOnForwardFailure makes that loss visible); retry once on a
-			// random port before surfacing the failure.
-			if (preferred !== input.remotePort) throw cause;
-			handle = await this.openForwardTunnel({
-				target: input.target,
-				remotePort: input.remotePort,
-				localPort: randomLocalPort(),
-			});
+		// Prefer the matching port, then try a bounded set of verified random
+		// candidates. ExitOnForwardFailure still catches the bind race between
+		// the probe and ssh taking ownership of the port.
+		const candidates = [input.remotePort];
+		for (
+			let draws = 0;
+			candidates.length < MAX_LOCAL_PORT_CANDIDATES && draws < 20;
+			draws += 1
+		) {
+			const candidate = this.allocateLocalPort();
+			if (!candidates.includes(candidate)) candidates.push(candidate);
 		}
+		let handle: TunnelHandle | null = null;
+		let lastFailure: unknown = new Error("No local port was available.");
+		for (const localPort of candidates) {
+			if (!(await this.isLocalPortFree(localPort))) continue;
+			try {
+				handle = await this.openForwardTunnel({
+					target: input.target,
+					remotePort: input.remotePort,
+					localPort,
+				});
+				break;
+			} catch (cause) {
+				lastFailure = cause;
+				if (!retryableLocalBindFailure(cause)) throw cause;
+			}
+		}
+		if (handle === null) throw lastFailure;
 		const entry: ForwardEntry = {
 			summary: {
 				environmentId: input.environmentId,

--- a/apps/desktop/test/unit/cloud-ssh-service.test.ts
+++ b/apps/desktop/test/unit/cloud-ssh-service.test.ts
@@ -1,11 +1,18 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import {
+	atomicWritePrivateFile,
+	cloudSshBridgeLauncher,
 	cloudSshHostAlias,
 	managedSshConfig,
+	pruneExpiredCloudSshTickets,
 	sshTargetLaunch,
 	withUserConfigInclude,
 } from "../../src/ssh/cloud-ssh-service.ts";
+import { sanitizedSshBridgeFailure } from "../../src/ssh/ssh-bridge-errors.ts";
 
 describe("cloud ssh service", () => {
 	test("managed config wires the bridge as ProxyCommand for zuse-* hosts", () => {
@@ -30,6 +37,62 @@ describe("cloud ssh service", () => {
 		expect(
 			withUserConfigInclude(first ?? "", "/home/u/.zuse/ssh/config"),
 		).toBeNull();
+	});
+
+	test("stable launcher quotes paths and selects the packaged runtime mode", () => {
+		expect(
+			cloudSshBridgeLauncher(
+				{
+					executable: "/Applications/Zuse Alpha.app/Contents/MacOS/Zuse Alpha",
+					electronRunAsNode: true,
+				},
+				"/Users/me/.zuse/ssh/bridge/ssh-bridge-child.cjs",
+			),
+		).toBe(
+			"#!/bin/sh\nexec env ELECTRON_RUN_AS_NODE=1 '/Applications/Zuse Alpha.app/Contents/MacOS/Zuse Alpha' '/Users/me/.zuse/ssh/bridge/ssh-bridge-child.cjs' \"$@\"\n",
+		);
+	});
+
+	test("private files replace atomically with owner-only permissions", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "zuse-ssh-atomic-"));
+		const path = join(directory, "bridge", "launch");
+		await atomicWritePrivateFile(path, "first", 0o700);
+		await atomicWritePrivateFile(path, "second", 0o700);
+		expect(await readFile(path, "utf8")).toBe("second");
+		expect((await stat(path)).mode & 0o777).toBe(0o700);
+	});
+
+	test("expired and invalid managed tickets are pruned", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "zuse-ssh-tickets-"));
+		await mkdir(directory, { recursive: true });
+		await writeFile(join(directory, "fresh.json"), '{"expiresAt":2000}');
+		await writeFile(join(directory, "expired.json"), '{"expiresAt":999}');
+		await writeFile(join(directory, "invalid.json"), "not-json");
+		await pruneExpiredCloudSshTickets(directory, 1_000);
+		expect(await readFile(join(directory, "fresh.json"), "utf8")).toContain(
+			"2000",
+		);
+		await expect(readFile(join(directory, "expired.json"))).rejects.toThrow();
+		await expect(readFile(join(directory, "invalid.json"))).rejects.toThrow();
+	});
+
+	test("bridge failures are sanitized and actionable", () => {
+		expect(
+			sanitizedSshBridgeFailure({ detail: "Unexpected server response: 401" }),
+		).toContain("rejected");
+		expect(
+			sanitizedSshBridgeFailure({ detail: "The sandbox was not found" }),
+		).toContain("not running");
+		expect(sanitizedSshBridgeFailure({ detail: "502 Bad Gateway" })).toContain(
+			"could not reach",
+		);
+		expect(sanitizedSshBridgeFailure({ timedOut: true })).toContain(
+			"timed out",
+		);
+		expect(sanitizedSshBridgeFailure({ closeCode: 1006 })).toContain("1006");
+		expect(
+			sanitizedSshBridgeFailure({ detail: "wss://secret/?ticket=secret" }),
+		).not.toContain("secret");
 	});
 
 	test("ssh target launches", () => {

--- a/apps/desktop/test/unit/cloud-sync-service.test.ts
+++ b/apps/desktop/test/unit/cloud-sync-service.test.ts
@@ -11,6 +11,7 @@ import {
 	remoteRsyncMissing,
 	rsyncArgs,
 	SYNC_MARKER_FILE,
+	sshTransportFailed,
 	supportsGitignoreFilter,
 } from "../../src/sync/cloud-sync-service.ts";
 
@@ -32,7 +33,10 @@ describe("cloud sync service", () => {
 		});
 		expect(args).toEqual([
 			"-az",
-			"--delete",
+			"--delay-updates",
+			"--delete-delay",
+			"--partial-dir=.zuse-rsync-partial",
+			"--timeout=30",
 			"--exclude=.git/",
 			`--exclude=${SYNC_MARKER_FILE}`,
 			"--exclude=node_modules/",
@@ -41,6 +45,7 @@ describe("cloud sync service", () => {
 			"--exclude=.next/cache/",
 			"--exclude=__pycache__/",
 			"--exclude=.pytest_cache/",
+			"--exclude=.zuse-rsync-partial/",
 			"--filter=:- .gitignore",
 			"-e",
 			'ssh -F "/home/u/.zuse/ssh/config"',
@@ -56,6 +61,12 @@ describe("cloud sync service", () => {
 				gitignoreFilter: false,
 			}),
 		).toContain("--rsync-path=rsync --filter=:-_.gitignore");
+	});
+
+	test("recognizes SSH transport failures that require fresh access", () => {
+		expect(sshTransportFailed("zuse ssh bridge: access rejected")).toBe(true);
+		expect(sshTransportFailed("kex_exchange_identification failed")).toBe(true);
+		expect(sshTransportFailed("repository file vanished")).toBe(false);
 	});
 
 	test("gitignore filter only with GNU rsync", () => {
@@ -93,7 +104,7 @@ describe("cloud sync service", () => {
 		});
 		expect(status.state).toBe("error");
 		expect(status.error).toContain("not empty");
-		manager.dispose();
+		await manager.dispose();
 	});
 
 	test("syncs an empty directory and reaches in-sync", async () => {
@@ -117,7 +128,7 @@ describe("cloud sync service", () => {
 		expect(runs.length).toBe(1);
 		expect(manager.status("workspace_abc").state).toBe("in-sync");
 		expect(manager.status("workspace_abc").lastSyncedAt).not.toBeNull();
-		manager.dispose();
+		await manager.dispose();
 	});
 
 	test("falls back for old sandboxes without rsync", async () => {
@@ -144,7 +155,7 @@ describe("cloud sync service", () => {
 		await new Promise((resolve) => setTimeout(resolve, 50));
 		expect(fallbackRuns).toBe(1);
 		expect(manager.status("workspace_old").state).toBe("in-sync");
-		manager.dispose();
+		await manager.dispose();
 	});
 
 	test("preserves a pending change debounce when a sync completes", async () => {
@@ -178,7 +189,7 @@ describe("cloud sync service", () => {
 			);
 			await vi.advanceTimersByTimeAsync(1_600);
 			await vi.waitFor(() => expect(runs).toBe(2));
-			manager.dispose();
+			await manager.dispose();
 		} finally {
 			vi.useRealTimers();
 		}
@@ -205,6 +216,7 @@ describe("cloud sync service", () => {
 		expect(manager.status("workspace_abc").error).toContain(
 			"connection unexpectedly closed",
 		);
+		expect(manager.status("workspace_abc").accessRefreshRequired).toBe(true);
 		await manager.configure({
 			workspaceId: "workspace_abc",
 			enabled: false,
@@ -214,6 +226,41 @@ describe("cloud sync service", () => {
 		});
 		expect(manager.status("workspace_abc").enabled).toBe(false);
 		expect(manager.status("workspace_abc").state).toBe("idle");
-		manager.dispose();
+		await manager.dispose();
+	});
+
+	test("cancels an in-flight transfer when sync is disabled", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "zuse-sync-"));
+		let observedSignal: AbortSignal | undefined;
+		const manager = new CloudSyncManager(
+			() => {},
+			async (_args, signal) => {
+				observedSignal = signal;
+				return new Promise((resolve) => {
+					signal?.addEventListener(
+						"abort",
+						() => resolve({ code: 1, stderr: "cancelled" }),
+						{ once: true },
+					);
+				});
+			},
+		);
+		await manager.configure({
+			workspaceId: "workspace_cancel",
+			enabled: true,
+			localPath: dir,
+			hostAlias: "zuse-workspace_cancel",
+			remotePath: "/home/zuse/workspace",
+		});
+		await vi.waitFor(() => expect(observedSignal).toBeDefined());
+		await manager.configure({
+			workspaceId: "workspace_cancel",
+			enabled: false,
+			localPath: dir,
+			hostAlias: "zuse-workspace_cancel",
+			remotePath: "/home/zuse/workspace",
+		});
+		expect(observedSignal?.aborted).toBe(true);
+		expect(manager.status("workspace_cancel").enabled).toBe(false);
 	});
 });

--- a/apps/desktop/test/unit/port-forward-service.test.ts
+++ b/apps/desktop/test/unit/port-forward-service.test.ts
@@ -3,156 +3,214 @@ import type { TunnelHandle } from "@zuse/ssh";
 import { describe, expect, it } from "vitest";
 
 import {
-  PortForwardManager,
-  type PortForwardTarget,
+	PortForwardManager,
+	type PortForwardTarget,
+	retryableLocalBindFailure,
 } from "../../src/tunnels/port-forward-service.ts";
 
 const sshTarget: PortForwardTarget = {
-  kind: "ssh",
-  target: { alias: "devbox", hostname: "devbox", username: null, port: null },
+	kind: "ssh",
+	target: { alias: "devbox", hostname: "devbox", username: null, port: null },
 };
 
 type FakeProcess = EventEmitter & {
-  exitCode: number | null;
-  signalCode: NodeJS.Signals | null;
+	exitCode: number | null;
+	signalCode: NodeJS.Signals | null;
 };
 
 const fakeTunnel = (
-  localPort: number,
-  remotePort: number,
+	localPort: number,
+	remotePort: number,
 ): { handle: TunnelHandle; process: FakeProcess; closed: () => boolean } => {
-  const process = Object.assign(new EventEmitter(), {
-    exitCode: null,
-    signalCode: null,
-  }) as FakeProcess;
-  let closed = false;
-  const handle = {
-    localPort,
-    remotePort,
-    process,
-    wsBaseUrl: `ws://127.0.0.1:${localPort}/rpc`,
-    close: async () => {
-      closed = true;
-      process.exitCode = 0;
-      process.emit("exit", 0, null);
-    },
-  } as unknown as TunnelHandle;
-  return { handle, process, closed: () => closed };
+	const process = Object.assign(new EventEmitter(), {
+		exitCode: null,
+		signalCode: null,
+	}) as FakeProcess;
+	let closed = false;
+	const handle = {
+		localPort,
+		remotePort,
+		process,
+		wsBaseUrl: `ws://127.0.0.1:${localPort}/rpc`,
+		close: async () => {
+			closed = true;
+			process.exitCode = 0;
+			process.emit("exit", 0, null);
+		},
+	} as unknown as TunnelHandle;
+	return { handle, process, closed: () => closed };
 };
 
 describe("PortForwardManager", () => {
-  it("prefers the remote port locally and is idempotent while alive", async () => {
-    const opened: number[] = [];
-    const manager = new PortForwardManager(
-      async (input) => {
-        opened.push(input.localPort);
-        return fakeTunnel(input.localPort, input.remotePort).handle;
-      },
-      async () => true,
-    );
-    const first = await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 3000,
-    });
-    const second = await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 3000,
-    });
-    expect(first).toEqual({
-      environmentId: "env-a",
-      remotePort: 3000,
-      localPort: 3000,
-    });
-    expect(second).toBe(first);
-    expect(opened).toEqual([3000]);
-  });
+	it("retries port bind failures but not SSH access failures", () => {
+		expect(retryableLocalBindFailure(new Error("bind failed"))).toBe(true);
+		expect(
+			retryableLocalBindFailure(new Error("zuse ssh bridge: access rejected")),
+		).toBe(false);
+	});
 
-  it("falls back to a random local port when the preferred one is taken", async () => {
-    const manager = new PortForwardManager(
-      async (input) => fakeTunnel(input.localPort, input.remotePort).handle,
-      async () => false,
-    );
-    const forward = await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 3000,
-    });
-    expect(forward.localPort).not.toBe(3000);
-    expect(forward.localPort).toBeGreaterThanOrEqual(20_000);
-  });
+	it("prefers the remote port locally and is idempotent while alive", async () => {
+		const opened: number[] = [];
+		const manager = new PortForwardManager(
+			async (input) => {
+				opened.push(input.localPort);
+				return fakeTunnel(input.localPort, input.remotePort).handle;
+			},
+			async () => true,
+		);
+		const first = await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		const second = await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		expect(first).toEqual({
+			environmentId: "env-a",
+			remotePort: 3000,
+			localPort: 3000,
+		});
+		expect(second).toBe(first);
+		expect(opened).toEqual([3000]);
+	});
 
-  it("retries once on a random port when the preferred bind is lost", async () => {
-    const attempts: number[] = [];
-    const manager = new PortForwardManager(
-      async (input) => {
-        attempts.push(input.localPort);
-        if (attempts.length === 1) throw new Error("bind failed");
-        return fakeTunnel(input.localPort, input.remotePort).handle;
-      },
-      async () => true,
-    );
-    const forward = await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 3000,
-    });
-    expect(attempts[0]).toBe(3000);
-    expect(forward.localPort).not.toBe(3000);
-  });
+	it("falls back to a random local port when the preferred one is taken", async () => {
+		const manager = new PortForwardManager(
+			async (input) => fakeTunnel(input.localPort, input.remotePort).handle,
+			async (port) => port !== 3000,
+		);
+		const forward = await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		expect(forward.localPort).not.toBe(3000);
+		expect(forward.localPort).toBeGreaterThanOrEqual(20_000);
+	});
 
-  it("evicts dead tunnels and reopens on the next request", async () => {
-    let openCount = 0;
-    const processes: FakeProcess[] = [];
-    const manager = new PortForwardManager(
-      async (input) => {
-        openCount += 1;
-        const tunnel = fakeTunnel(input.localPort, input.remotePort);
-        processes.push(tunnel.process);
-        return tunnel.handle;
-      },
-      async () => true,
-    );
-    await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 3000,
-    });
-    processes.at(-1)?.emit("exit", 1, null);
-    expect(manager.list("env-a")).toEqual([]);
-    await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 3000,
-    });
-    expect(openCount).toBe(2);
-  });
+	it("retries once on a random port when the preferred bind is lost", async () => {
+		const attempts: number[] = [];
+		const manager = new PortForwardManager(
+			async (input) => {
+				attempts.push(input.localPort);
+				if (attempts.length === 1) throw new Error("bind failed");
+				return fakeTunnel(input.localPort, input.remotePort).handle;
+			},
+			async () => true,
+		);
+		const forward = await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		expect(attempts[0]).toBe(3000);
+		expect(forward.localPort).not.toBe(3000);
+	});
 
-  it("closes every forward that belongs to an environment", async () => {
-    const manager = new PortForwardManager(
-      async (input) => fakeTunnel(input.localPort, input.remotePort).handle,
-      async () => true,
-    );
-    await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 3000,
-    });
-    await manager.open({
-      environmentId: "env-a",
-      target: sshTarget,
-      remotePort: 8080,
-    });
-    await manager.open({
-      environmentId: "env-b",
-      target: sshTarget,
-      remotePort: 5173,
-    });
-    await manager.closeForEnvironment("env-a");
-    expect(manager.list("env-a")).toEqual([]);
-    expect(manager.list("env-b")).toHaveLength(1);
-    await manager.closeAll();
-    expect(manager.list()).toEqual([]);
-  });
+	it("bounds verified allocation retries across repeated port collisions", async () => {
+		const attempts: number[] = [];
+		let candidate = 20_000;
+		const manager = new PortForwardManager(
+			async (input) => {
+				attempts.push(input.localPort);
+				throw new Error("bind failed");
+			},
+			async () => true,
+			() => candidate++,
+		);
+		await expect(
+			manager.open({
+				environmentId: "env-a",
+				target: sshTarget,
+				remotePort: 3000,
+			}),
+		).rejects.toThrow("bind failed");
+		expect(attempts).toEqual([3000, 20_000, 20_001, 20_002, 20_003]);
+	});
+
+	it("evicts dead tunnels and reopens on the next request", async () => {
+		let openCount = 0;
+		const processes: FakeProcess[] = [];
+		const manager = new PortForwardManager(
+			async (input) => {
+				openCount += 1;
+				const tunnel = fakeTunnel(input.localPort, input.remotePort);
+				processes.push(tunnel.process);
+				return tunnel.handle;
+			},
+			async () => true,
+		);
+		await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		processes.at(-1)?.emit("exit", 1, null);
+		expect(manager.list("env-a")).toEqual([]);
+		await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		expect(openCount).toBe(2);
+	});
+
+	it("closes every forward that belongs to an environment", async () => {
+		const manager = new PortForwardManager(
+			async (input) => fakeTunnel(input.localPort, input.remotePort).handle,
+			async () => true,
+		);
+		await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		await manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 8080,
+		});
+		await manager.open({
+			environmentId: "env-b",
+			target: sshTarget,
+			remotePort: 5173,
+		});
+		await manager.closeForEnvironment("env-a");
+		expect(manager.list("env-a")).toEqual([]);
+		expect(manager.list("env-b")).toHaveLength(1);
+		await manager.closeAll();
+		expect(manager.list()).toEqual([]);
+	});
+
+	it("closes an in-flight forward when its environment disconnects", async () => {
+		let resolveOpen: (handle: TunnelHandle) => void = () => undefined;
+		let markOpenStarted: () => void = () => undefined;
+		const openStarted = new Promise<void>((resolve) => {
+			markOpenStarted = resolve;
+		});
+		const tunnel = fakeTunnel(3000, 3000);
+		const manager = new PortForwardManager(
+			() =>
+				new Promise<TunnelHandle>((resolve) => {
+					resolveOpen = resolve;
+					markOpenStarted();
+				}),
+			async () => true,
+		);
+		const opening = manager.open({
+			environmentId: "env-a",
+			target: sshTarget,
+			remotePort: 3000,
+		});
+		await openStarted;
+		const closing = manager.closeForEnvironment("env-a");
+		resolveOpen(tunnel.handle);
+		await closing;
+		await expect(opening).rejects.toThrow("closed before it became ready");
+		expect(tunnel.closed()).toBe(true);
+		expect(manager.list("env-a")).toEqual([]);
+	});
 });

--- a/apps/desktop/test/unit/ssh-bridge-child.test.ts
+++ b/apps/desktop/test/unit/ssh-bridge-child.test.ts
@@ -1,0 +1,138 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const servers: Array<ReturnType<typeof createServer>> = [];
+const sockets = new Set<Socket>();
+
+afterEach(async () => {
+	for (const socket of sockets) socket.destroy();
+	sockets.clear();
+	await Promise.all(
+		servers
+			.splice(0)
+			.map((server) => new Promise<void>((done) => server.close(() => done()))),
+	);
+});
+
+const listen = async (
+	server: ReturnType<typeof createServer>,
+): Promise<number> =>
+	new Promise((resolvePort) => {
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (address === null || typeof address === "string")
+				throw new Error("bind");
+			resolvePort(address.port);
+		});
+	});
+
+const runBridge = async (port: number, timeoutMs: number) => {
+	const home = await mkdtemp(join(tmpdir(), "zuse-bridge-child-"));
+	const tickets = join(home, ".zuse", "ssh", "tickets");
+	await mkdir(tickets, { recursive: true });
+	await writeFile(
+		join(tickets, "workspace_a.json"),
+		JSON.stringify({
+			wsUrl: `ws://127.0.0.1:${port}/ssh`,
+			ticket: "private-ticket",
+			expiresAt: Date.now() + 60_000,
+		}),
+	);
+	return new Promise<{ code: number | null; stderr: string }>(
+		(done, reject) => {
+			const child = spawn(
+				process.execPath,
+				[
+					"--import",
+					"tsx",
+					fileURLToPath(
+						new URL("../../src/ssh/ssh-bridge-child.ts", import.meta.url),
+					),
+					"zuse-workspace_a",
+				],
+				{
+					env: {
+						...process.env,
+						HOME: home,
+						ZUSE_SSH_BRIDGE_CONNECT_TIMEOUT_MS: String(timeoutMs),
+					},
+					stdio: ["pipe", "ignore", "pipe"],
+				},
+			);
+			let stderr = "";
+			child.stderr.on("data", (chunk: Buffer) => {
+				stderr += chunk.toString();
+			});
+			child.once("error", reject);
+			child.once("close", (code) => done({ code, stderr }));
+		},
+	);
+};
+
+describe("ssh bridge child", () => {
+	it("times out a connection that never completes its WebSocket handshake", async () => {
+		const server = createServer();
+		servers.push(server);
+		server.on("connection", (socket) => {
+			sockets.add(socket);
+			socket.once("close", () => sockets.delete(socket));
+		});
+		server.on("upgrade", () => undefined);
+		const result = await runBridge(await listen(server), 50);
+		expect(result.code).toBe(1);
+		expect(result.stderr).toContain("connection timed out");
+		expect(result.stderr).not.toContain("private-ticket");
+	});
+
+	it("returns a nonzero exit for an abnormal WebSocket close", async () => {
+		const server = createServer();
+		servers.push(server);
+		server.on("connection", (socket) => {
+			sockets.add(socket);
+			socket.once("close", () => sockets.delete(socket));
+		});
+		server.on("upgrade", (request, socket) => {
+			const key = request.headers["sec-websocket-key"];
+			if (typeof key !== "string") return socket.destroy();
+			const accept = createHash("sha1")
+				.update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+				.digest("base64");
+			socket.write(
+				`HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`,
+			);
+			socket.write(Buffer.from([0x88, 0x02, 0x03, 0xf3]));
+			setTimeout(() => socket.end(), 10);
+		});
+		const result = await runBridge(await listen(server), 1_000);
+		expect(result.code).toBe(1);
+		expect(result.stderr).toContain("1011");
+	});
+
+	it("diagnoses a missing sandbox without exposing its ticket", async () => {
+		const server = createServer((_request, response) => {
+			response.writeHead(502, { "content-type": "application/json" });
+			response.end('{"message":"The sandbox was not found"}');
+		});
+		servers.push(server);
+		server.on("connection", (socket) => {
+			sockets.add(socket);
+			socket.once("close", () => sockets.delete(socket));
+		});
+		server.on("upgrade", (_request, socket) => {
+			socket.end(
+				'HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: 43\r\n\r\n{"message":"The sandbox was not found"}',
+			);
+		});
+		const result = await runBridge(await listen(server), 1_000);
+		expect(result.code).toBe(1);
+		expect(result.stderr).toContain("workspace is not running");
+		expect(result.stderr).not.toContain("private-ticket");
+	});
+});

--- a/apps/renderer/src/components/cloud-workspace-info.tsx
+++ b/apps/renderer/src/components/cloud-workspace-info.tsx
@@ -24,7 +24,10 @@ import {
 	enableCloudSync,
 	useCloudSyncStatus,
 } from "../lib/cloud-sync-client-bus.ts";
-import { useCloudChatCatalogStore } from "../lib/cloud-workspace-catalog.ts";
+import {
+	cloudSyncPreferenceEnabled,
+	useCloudChatCatalogStore,
+} from "../lib/cloud-workspace-catalog.ts";
 import { isCloudWorkspaceReady } from "../lib/cloud-workspace-lifecycle.ts";
 import { runControlPlane } from "../lib/control-plane-client.ts";
 import { displayPath } from "../lib/display-path.ts";
@@ -167,7 +170,7 @@ export function CloudWorkspaceOpenSshMenu({
 	>([]);
 	if (!cloudSshSupported() || summary === null) return null;
 	const running = isCloudWorkspaceReady(summary);
-	const syncEnabled = syncPrefs?.enabled !== false;
+	const syncEnabled = cloudSyncPreferenceEnabled(syncPrefs);
 
 	const toggleSync = async (): Promise<void> => {
 		if (syncBusy) return;

--- a/apps/renderer/src/components/terminal-pane.tsx
+++ b/apps/renderer/src/components/terminal-pane.tsx
@@ -261,7 +261,7 @@ export function PtyTerminal({
 	return (
 		<div
 			ref={containerRef}
-			className="h-full w-full min-w-0 overflow-hidden bg-background px-2 py-1.5"
+			className="h-full w-full min-w-0 overflow-hidden bg-background px-2 pb-1.5"
 		/>
 	);
 }

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -148,7 +148,7 @@ export interface CloudSyncStatus {
 	readonly localPath: string | null;
 	readonly lastSyncedAt: number | null;
 	readonly error: string | null;
-	readonly ticketStale: boolean;
+	readonly accessRefreshRequired: boolean;
 }
 
 export interface UpdatesBridge {

--- a/apps/renderer/src/lib/cloud-ssh-client-bus.ts
+++ b/apps/renderer/src/lib/cloud-ssh-client-bus.ts
@@ -1,6 +1,7 @@
 import { CommandId, EnvironmentId, type MachineSshKey } from "@zuse/contracts";
 
 import { type CloudSshPrepared, getAppBridge } from "./bridge.ts";
+import { cloudSummaryForEnvironment } from "./cloud-workspace-catalog.ts";
 import { runControlPlane } from "./control-plane-client.ts";
 import {
 	dispatchEnvironmentShellCommand,
@@ -27,6 +28,36 @@ const requestSshAccess = (workspaceId: string) =>
 	);
 
 const SSH_GATEWAY_READY_TIMEOUT_MS = 30_000;
+const preparing = new Map<string, Promise<CloudSshPrepared>>();
+
+export const cloudSshMissingSandboxFailure = (cause: unknown): boolean => {
+	if (
+		typeof cause === "object" &&
+		cause !== null &&
+		"code" in cause &&
+		cause.code === "not-found"
+	)
+		return true;
+	const detail = cause instanceof Error ? cause.message : String(cause);
+	return /(?:sandbox|workspace) (?:was )?not found|missing sandbox/iu.test(
+		detail,
+	);
+};
+
+/**
+ * Runtimes predating the MachineSshKey constructor fix authorize and persist
+ * the key, then fail while encoding the otherwise-valid response. Accept only
+ * that exact rolling-upgrade failure; all transport and authorization errors
+ * must still fail preparation.
+ */
+export const legacyMachineSshKeyEncodingFailure = (cause: unknown): boolean => {
+	const detail = cause instanceof Error ? cause.message : String(cause);
+	return (
+		detail.includes("Expected MachineSshKey") &&
+		detail.includes('"fingerprint"') &&
+		detail.includes('"publicKey"')
+	);
+};
 
 const waitForWorkspaceGateway = (
 	environmentId: EnvironmentId,
@@ -78,13 +109,22 @@ const waitForWorkspaceGateway = (
 	});
 };
 
-export const prepareCloudWorkspaceSsh = async (
+const prepareCloudWorkspaceSshOnce = async (
 	workspaceId: string,
 ): Promise<CloudSshPrepared> => {
 	const app = getAppBridge();
 	if (app?.cloudSshPrepare === undefined || app.openSshTarget === undefined)
 		throw new Error("SSH access requires the Zuse desktop app.");
 	const environmentId = EnvironmentId.make(workspaceId);
+	if (getRendererClientBus().client(environmentId) === null) {
+		const summary = cloudSummaryForEnvironment(workspaceId);
+		if (summary !== null) {
+			const { ensureCloudWorkspaceAttached } = await import(
+				"./cloud-workspaces.ts"
+			);
+			await ensureCloudWorkspaceAttached(summary, "wake");
+		}
+	}
 	const retained = retainEnvironmentShell({ environmentId }, "wake");
 	try {
 		// A relay workspace can report ready before its renderer gateway lease has
@@ -95,14 +135,31 @@ export const prepareCloudWorkspaceSsh = async (
 		try {
 			access = await requestSshAccess(workspaceId);
 		} catch (cause) {
-			// The relay rejects unknown routes while SSH support is still rolling
-			// out; surface that as a capability gap instead of a raw RPC error.
-			const detail = cause instanceof Error ? cause.message : String(cause);
-			throw new Error(
-				`SSH access is not available for this workspace yet — the cloud service and workspace image need the SSH update.${
-					detail.length > 0 && detail !== "{}" ? ` (${detail})` : ""
-				}`,
-			);
+			if (cloudSshMissingSandboxFailure(cause)) {
+				const summary = cloudSummaryForEnvironment(workspaceId);
+				if (summary !== null) {
+					const { requestCloudWorkspaceRuntimeRecovery } = await import(
+						"./rpc-client.ts"
+					);
+					requestCloudWorkspaceRuntimeRecovery(workspaceId);
+					const { ensureCloudWorkspaceAttached } = await import(
+						"./cloud-workspaces.ts"
+					);
+					await ensureCloudWorkspaceAttached(summary, "wake");
+					access = await requestSshAccess(workspaceId);
+				} else {
+					throw cause;
+				}
+			} else {
+				// The relay rejects unknown routes while SSH support is still rolling
+				// out; surface that as a capability gap instead of a raw RPC error.
+				const detail = cause instanceof Error ? cause.message : String(cause);
+				throw new Error(
+					`SSH access is not available for this workspace yet — the cloud service and workspace image need the SSH update.${
+						detail.length > 0 && detail !== "{}" ? ` (${detail})` : ""
+					}`,
+				);
+			}
 		}
 		const prepared = await app.cloudSshPrepare({
 			workspaceId: access.workspaceId,
@@ -115,19 +172,38 @@ export const prepareCloudWorkspaceSsh = async (
 		if (prepared === null)
 			throw new Error("Could not prepare SSH access on this device.");
 		// Idempotent: the sandbox host service dedupes keys by fingerprint.
-		await dispatchEnvironmentShellCommand<
-			{ publicKey: string; label?: string },
-			MachineSshKey
-		>({
-			environmentId,
-			kind: "machine.sshKeys.add",
-			commandId: CommandId.make(`cloud-ssh-key:${crypto.randomUUID()}`),
-			payload: { publicKey: prepared.publicKey, label: "zuse-desktop" },
-		});
+		try {
+			await dispatchEnvironmentShellCommand<
+				{ publicKey: string; label?: string },
+				MachineSshKey
+			>({
+				environmentId,
+				kind: "machine.sshKeys.add",
+				commandId: CommandId.make(`cloud-ssh-key:${crypto.randomUUID()}`),
+				payload: { publicKey: prepared.publicKey, label: "zuse-desktop" },
+				retry: "safe",
+			});
+		} catch (cause) {
+			if (!legacyMachineSshKeyEncodingFailure(cause)) throw cause;
+		}
 		return prepared;
 	} finally {
 		retained.lease.release();
 	}
+};
+
+/** Share one ticket/key authorization flow across sync, editors, and previews. */
+export const prepareCloudWorkspaceSsh = (
+	workspaceId: string,
+): Promise<CloudSshPrepared> => {
+	const existing = preparing.get(workspaceId);
+	if (existing !== undefined) return existing;
+	let prepared: Promise<CloudSshPrepared>;
+	prepared = prepareCloudWorkspaceSshOnce(workspaceId).finally(() => {
+		if (preparing.get(workspaceId) === prepared) preparing.delete(workspaceId);
+	});
+	preparing.set(workspaceId, prepared);
+	return prepared;
 };
 
 export type CloudSshTarget = "cursor" | "zed" | "terminal";

--- a/apps/renderer/src/lib/cloud-sync-client-bus.ts
+++ b/apps/renderer/src/lib/cloud-sync-client-bus.ts
@@ -5,7 +5,12 @@ import { useEnvironmentCatalogStore } from "../store/environment-catalog.ts";
 import { type CloudSyncStatus, getAppBridge } from "./bridge.ts";
 import { prepareCloudWorkspaceSsh } from "./cloud-ssh-client-bus.ts";
 import {
+	CloudSyncLifecycleQueue,
+	reconcileAutomaticCloudSyncs,
+} from "./cloud-sync-lifecycle.ts";
+import {
 	cloudSummaryForEnvironment,
+	cloudSyncPreferenceEnabled,
 	cloudSyncPrefsFor,
 	setCloudSyncPrefs,
 	useCloudChatCatalogStore,
@@ -44,7 +49,7 @@ const setLocalStatus = (
 		localPath: previous?.localPath ?? null,
 		lastSyncedAt: previous?.lastSyncedAt ?? null,
 		error: previous?.error ?? null,
-		ticketStale: previous?.ticketStale ?? false,
+		accessRefreshRequired: previous?.accessRefreshRequired ?? false,
 		...patch,
 	});
 	emit();
@@ -55,6 +60,26 @@ interface ActiveSync {
 	stopped: boolean;
 }
 const active = new Map<string, ActiveSync>();
+const lifecycleQueue = new CloudSyncLifecycleQueue();
+const ACCESS_REFRESH_BACKOFF_MS = 1_000;
+const accessRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+const cancelAccessRefresh = (workspaceId: string): void => {
+	const timer = accessRefreshTimers.get(workspaceId);
+	if (timer !== undefined) clearTimeout(timer);
+	accessRefreshTimers.delete(workspaceId);
+};
+
+const scheduleAccessRefresh = (workspaceId: string): void => {
+	if (accessRefreshTimers.has(workspaceId) || !active.has(workspaceId)) return;
+	const timer = setTimeout(() => {
+		accessRefreshTimers.delete(workspaceId);
+		void prepareCloudWorkspaceSsh(workspaceId)
+			.then(() => getAppBridge()?.cloudSyncRequest?.(workspaceId))
+			.catch(() => undefined);
+	}, ACCESS_REFRESH_BACKOFF_MS);
+	accessRefreshTimers.set(workspaceId, timer);
+};
 
 const resolveWorkspaceFolderId = async (
 	workspaceId: string,
@@ -94,7 +119,7 @@ const startWatcher = (workspaceId: string, entry: ActiveSync): void => {
 	entry.fiber = Effect.runFork(program);
 };
 
-const startSync = async (workspaceId: string): Promise<void> => {
+const startSyncNow = async (workspaceId: string): Promise<void> => {
 	if (active.has(workspaceId)) return;
 	const entry: ActiveSync = { fiber: null, stopped: false };
 	active.set(workspaceId, entry);
@@ -136,6 +161,9 @@ const startSync = async (workspaceId: string): Promise<void> => {
 	}
 };
 
+const startSync = (workspaceId: string): Promise<void> =>
+	lifecycleQueue.run(workspaceId, () => startSyncNow(workspaceId));
+
 export const cloudSyncLocalPath = async (
 	workspaceId: string,
 ): Promise<string | null> => {
@@ -149,7 +177,8 @@ export const cloudSyncLocalPath = async (
 			)) ?? null);
 };
 
-const stopSync = async (workspaceId: string): Promise<void> => {
+const stopSyncNow = async (workspaceId: string): Promise<void> => {
+	cancelAccessRefresh(workspaceId);
 	const entry = active.get(workspaceId);
 	active.delete(workspaceId);
 	if (entry !== undefined) {
@@ -174,6 +203,9 @@ const stopSync = async (workspaceId: string): Promise<void> => {
 	}
 };
 
+const stopSync = (workspaceId: string): Promise<void> =>
+	lifecycleQueue.run(workspaceId, () => stopSyncNow(workspaceId));
+
 export const enableCloudSync = async (workspaceId: string): Promise<void> => {
 	setCloudSyncPrefs(workspaceId, { enabled: true });
 	await startSync(workspaceId);
@@ -192,22 +224,15 @@ const wire = (): void => {
 	getAppBridge()?.onCloudSyncStatus?.((status) => {
 		statuses.set(status.workspaceId, status);
 		emit();
-		// A stale ticket means rsync will soon fail auth: refresh it through the
-		// normal prepare flow, which re-stages the ticket file for the bridge.
-		if (status.enabled && status.ticketStale && active.has(status.workspaceId))
-			void prepareCloudWorkspaceSsh(status.workspaceId).catch(() => undefined);
+		if (
+			status.enabled &&
+			status.accessRefreshRequired &&
+			active.has(status.workspaceId)
+		)
+			scheduleAccessRefresh(status.workspaceId);
 	});
 	const startAutomaticSyncs = () => {
 		const summaries = useCloudChatCatalogStore.getState().summaries;
-		for (const workspaceId of active.keys()) {
-			if (
-				!summaries.some(
-					(summary) =>
-						summary.workspaceId === workspaceId && summary.state !== "archived",
-				)
-			)
-				void stopSync(workspaceId);
-		}
 		const connected = new Set(
 			useEnvironmentCatalogStore
 				.getState()
@@ -217,15 +242,15 @@ const wire = (): void => {
 				)
 				.map((entry) => entry.environmentId),
 		);
-		for (const summary of summaries) {
-			if (
-				summary.state !== "archived" &&
-				connected.has(summary.workspaceId) &&
-				cloudSyncPrefsFor(summary.workspaceId)?.enabled !== false &&
-				!active.has(summary.workspaceId)
-			)
-				void startSync(summary.workspaceId);
-		}
+		reconcileAutomaticCloudSyncs({
+			summaries,
+			connectedWorkspaceIds: connected,
+			activeWorkspaceIds: new Set(active.keys()),
+			enabled: (workspaceId) =>
+				cloudSyncPreferenceEnabled(cloudSyncPrefsFor(workspaceId)),
+			start: (workspaceId) => void startSync(workspaceId),
+			stop: (workspaceId) => void stopSync(workspaceId),
+		});
 	};
 	useEnvironmentCatalogStore.subscribe(startAutomaticSyncs);
 	useCloudChatCatalogStore.subscribe(startAutomaticSyncs);

--- a/apps/renderer/src/lib/cloud-sync-lifecycle.ts
+++ b/apps/renderer/src/lib/cloud-sync-lifecycle.ts
@@ -1,0 +1,53 @@
+/** Reconcile live sync workers with persisted preferences and connectivity. */
+export const reconcileAutomaticCloudSyncs = (input: {
+	readonly summaries: ReadonlyArray<{
+		readonly workspaceId: string;
+		readonly state: string;
+	}>;
+	readonly connectedWorkspaceIds: ReadonlySet<string>;
+	readonly activeWorkspaceIds: ReadonlySet<string>;
+	readonly enabled: (workspaceId: string) => boolean;
+	readonly start: (workspaceId: string) => void;
+	readonly stop: (workspaceId: string) => void;
+}): void => {
+	const available = new Set(
+		input.summaries
+			.filter((summary) => summary.state !== "archived")
+			.map((summary) => summary.workspaceId),
+	);
+	for (const workspaceId of input.activeWorkspaceIds) {
+		if (
+			!available.has(workspaceId) ||
+			!input.connectedWorkspaceIds.has(workspaceId)
+		)
+			input.stop(workspaceId);
+	}
+	for (const summary of input.summaries) {
+		if (
+			summary.state !== "archived" &&
+			input.connectedWorkspaceIds.has(summary.workspaceId) &&
+			input.enabled(summary.workspaceId) &&
+			!input.activeWorkspaceIds.has(summary.workspaceId)
+		)
+			input.start(summary.workspaceId);
+	}
+};
+
+/** Serialize start/stop work per workspace so reconnects cannot race teardown. */
+export class CloudSyncLifecycleQueue {
+	private readonly pending = new Map<string, Promise<void>>();
+
+	run(workspaceId: string, operation: () => Promise<void>): Promise<void> {
+		const previous = this.pending.get(workspaceId) ?? Promise.resolve();
+		let current: Promise<void>;
+		current = previous
+			.catch(() => undefined)
+			.then(operation)
+			.finally(() => {
+				if (this.pending.get(workspaceId) === current)
+					this.pending.delete(workspaceId);
+			});
+		this.pending.set(workspaceId, current);
+		return current;
+	}
+}

--- a/apps/renderer/src/lib/cloud-workspace-catalog.ts
+++ b/apps/renderer/src/lib/cloud-workspace-catalog.ts
@@ -13,6 +13,11 @@ export type CloudSyncPrefs = Readonly<{
 	enabled: boolean;
 }>;
 
+/** Preserve the existing default-on behavior until a user explicitly disables sync. */
+export const cloudSyncPreferenceEnabled = (
+	prefs: CloudSyncPrefs | null | undefined,
+): boolean => prefs?.enabled !== false;
+
 type CloudChatCatalogState = Readonly<{
 	summaries: ReadonlyArray<CloudChatSummary>;
 	localProjectByEnvironment: Readonly<Record<string, FolderId>>;

--- a/apps/renderer/src/lib/port-forward-client.ts
+++ b/apps/renderer/src/lib/port-forward-client.ts
@@ -5,6 +5,13 @@ import {
 	isCloudWorkspaceEnvironment,
 } from "./rpc-client.ts";
 
+export const cloudAccessForwardFailure = (cause: unknown): boolean => {
+	const detail = cause instanceof Error ? cause.message : String(cause);
+	return /(?:zuse ssh bridge:|permission denied|connection (?:unexpectedly )?(?:closed|reset|timed out)|kex_exchange_identification|no route to host|could not resolve hostname|tunnel timed out before it became ready)/iu.test(
+		detail,
+	);
+};
+
 /**
  * Ensure a dev server port on the given environment is reachable locally and
  * return the local port to open. Local environments need no forward; cloud
@@ -21,14 +28,31 @@ export const ensurePortForward = async (
 	if (tunnels === undefined) {
 		throw new Error("Previewing remote servers requires the Zuse desktop app.");
 	}
+	const live = (await tunnels.list(environmentId)).find(
+		(forward) => forward.remotePort === remotePort,
+	);
+	if (live !== undefined) return live.localPort;
 	if (isCloudWorkspaceEnvironment(environmentId)) {
 		await prepareCloudWorkspaceSsh(environmentId);
-		const forward = await tunnels.open({
-			environmentId,
-			remotePort,
-			cloudWorkspaceId: environmentId,
-		});
-		return forward.localPort;
+		try {
+			const forward = await tunnels.open({
+				environmentId,
+				remotePort,
+				cloudWorkspaceId: environmentId,
+			});
+			return forward.localPort;
+		} catch (cause) {
+			if (!cloudAccessForwardFailure(cause)) throw cause;
+			// A bridge can fail after its ticket was prepared (for example when the
+			// workspace paused between those operations). Refresh credentials once.
+			await prepareCloudWorkspaceSsh(environmentId);
+			const forward = await tunnels.open({
+				environmentId,
+				remotePort,
+				cloudWorkspaceId: environmentId,
+			});
+			return forward.localPort;
+		}
 	}
 	const forward = await tunnels.open({ environmentId, remotePort });
 	return forward.localPort;

--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -93,6 +93,16 @@ const invalidateCloudWorkspaceTicket = (workspaceId: string): void => {
 	if (registration !== undefined) registration.connection = null;
 };
 
+/** Queue one idempotent resume/reconcile when the provider confirms runtime loss. */
+export const requestCloudWorkspaceRuntimeRecovery = (
+	workspaceId: string,
+): void => {
+	invalidateCloudWorkspaceTicket(workspaceId);
+	if (!cloudWorkspaceRuntimeRecoveryCommands.has(workspaceId)) {
+		cloudWorkspaceRuntimeRecoveryCommands.set(workspaceId, crypto.randomUUID());
+	}
+};
+
 const recordCloudWorkspaceGatewayClose = (
 	workspaceId: string,
 	close: Pick<WebSocketCloseInfo, "code">,
@@ -118,12 +128,7 @@ const recordCloudWorkspaceGatewayClose = (
 		missingBeforeFirstHandshake ||
 		abnormalCloseCount >= 2
 	) {
-		if (!cloudWorkspaceRuntimeRecoveryCommands.has(workspaceId)) {
-			cloudWorkspaceRuntimeRecoveryCommands.set(
-				workspaceId,
-				crypto.randomUUID(),
-			);
-		}
+		requestCloudWorkspaceRuntimeRecovery(workspaceId);
 	}
 };
 

--- a/apps/renderer/test/unit/cloud-ssh-client-bus.test.ts
+++ b/apps/renderer/test/unit/cloud-ssh-client-bus.test.ts
@@ -1,0 +1,172 @@
+import { Effect } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	accessRequests: 0,
+	prepareRequests: 0,
+	keyRequests: 0,
+	keyFailure: null as unknown,
+	keyRetry: null as string | null,
+	clientReady: true,
+	attachRequests: 0,
+	accessFailure: null as unknown,
+	recoveryRequests: 0,
+}));
+
+vi.mock("../../src/lib/bridge.ts", () => ({
+	getAppBridge: () => ({
+		cloudSshPrepare: async () => {
+			mocks.prepareRequests += 1;
+			return {
+				hostAlias: "zuse-workspace_a",
+				sshCommand: "ssh zuse-workspace_a",
+				publicKey: "ssh-ed25519 public",
+				remotePath: "/home/zuse/workspace",
+			};
+		},
+		openSshTarget: async () => true,
+	}),
+}));
+
+vi.mock("../../src/lib/control-plane-client.ts", () => ({
+	runControlPlane: async (
+		operation: (client: unknown) => Effect.Effect<unknown>,
+	) =>
+		Effect.runPromise(
+			operation({
+				"cloud.workspaces.sshAccess": () =>
+					Effect.promise(async () => {
+						mocks.accessRequests += 1;
+						if (mocks.accessFailure !== null) {
+							const failure = mocks.accessFailure;
+							mocks.accessFailure = null;
+							throw failure;
+						}
+						await new Promise((resolve) => setTimeout(resolve, 10));
+						return {
+							workspaceId: "workspace_a",
+							wsUrl: "wss://relay.example/ssh",
+							ticket: "ticket",
+							expiresAt: Date.now() + 60_000,
+							user: "zuse",
+							workspacePath: "/home/zuse/workspace",
+						};
+					}),
+			}),
+		),
+}));
+
+vi.mock("../../src/lib/environment-shell-client-bus.ts", () => ({
+	retainEnvironmentShell: () => ({
+		key: "test-key",
+		lease: { release: () => undefined },
+	}),
+	dispatchEnvironmentShellCommand: async (input: { retry?: string }) => {
+		mocks.keyRequests += 1;
+		mocks.keyRetry = input.retry ?? null;
+		if (mocks.keyFailure !== null) throw mocks.keyFailure;
+		return {};
+	},
+}));
+
+vi.mock("../../src/lib/session-timeline-client-bus.ts", () => ({
+	getRendererClientBus: () => ({
+		client: () => (mocks.clientReady ? {} : null),
+		subscribe: () => () => {},
+	}),
+}));
+
+vi.mock("../../src/lib/cloud-workspace-catalog.ts", () => ({
+	cloudSummaryForEnvironment: () => ({ workspaceId: "workspace_a" }),
+}));
+
+vi.mock("../../src/lib/cloud-workspaces.ts", () => ({
+	ensureCloudWorkspaceAttached: async () => {
+		mocks.attachRequests += 1;
+		mocks.clientReady = true;
+	},
+}));
+
+vi.mock("../../src/lib/rpc-client.ts", () => ({
+	requestCloudWorkspaceRuntimeRecovery: () => {
+		mocks.recoveryRequests += 1;
+	},
+}));
+
+import {
+	cloudSshMissingSandboxFailure,
+	prepareCloudWorkspaceSsh,
+} from "../../src/lib/cloud-ssh-client-bus.ts";
+
+describe("cloud SSH access", () => {
+	beforeEach(() => {
+		mocks.accessRequests = 0;
+		mocks.prepareRequests = 0;
+		mocks.keyRequests = 0;
+		mocks.keyFailure = null;
+		mocks.keyRetry = null;
+		mocks.clientReady = true;
+		mocks.attachRequests = 0;
+		mocks.accessFailure = null;
+		mocks.recoveryRequests = 0;
+	});
+
+	it("prepares access single-flight per workspace", async () => {
+		const [first, second] = await Promise.all([
+			prepareCloudWorkspaceSsh("workspace_a"),
+			prepareCloudWorkspaceSsh("workspace_a"),
+		]);
+		expect(second).toEqual(first);
+		expect(mocks.accessRequests).toBe(1);
+		expect(mocks.prepareRequests).toBe(1);
+		expect(mocks.keyRequests).toBe(1);
+		expect(mocks.keyRetry).toBe("safe");
+	});
+
+	it("reattaches a disconnected workspace before preparing access", async () => {
+		mocks.clientReady = false;
+
+		await expect(
+			prepareCloudWorkspaceSsh("workspace_a"),
+		).resolves.toMatchObject({
+			hostAlias: "zuse-workspace_a",
+		});
+		expect(mocks.attachRequests).toBe(1);
+	});
+
+	it("accepts the legacy response-encoding failure after key authorization", async () => {
+		mocks.keyFailure =
+			'Expected MachineSshKey, got {"fingerprint":"SHA256:test","publicKey":"ssh-ed25519 public"}';
+
+		await expect(
+			prepareCloudWorkspaceSsh("workspace_a"),
+		).resolves.toMatchObject({
+			hostAlias: "zuse-workspace_a",
+		});
+		expect(mocks.keyRequests).toBe(1);
+	});
+
+	it("identifies only missing-sandbox failures for lifecycle recovery", () => {
+		expect(
+			cloudSshMissingSandboxFailure(new Error("sandbox was not found")),
+		).toBe(true);
+		expect(cloudSshMissingSandboxFailure({ code: "not-found" })).toBe(true);
+		expect(cloudSshMissingSandboxFailure(new Error("502 Bad Gateway"))).toBe(
+			false,
+		);
+		expect(cloudSshMissingSandboxFailure(new Error("request timed out"))).toBe(
+			false,
+		);
+	});
+
+	it("reconciles an explicitly missing sandbox before retrying once", async () => {
+		mocks.accessFailure = { code: "not-found" };
+
+		await expect(
+			prepareCloudWorkspaceSsh("workspace_a"),
+		).resolves.toMatchObject({ hostAlias: "zuse-workspace_a" });
+		expect(mocks.accessRequests).toBe(2);
+		expect(mocks.recoveryRequests).toBe(1);
+		expect(mocks.attachRequests).toBe(1);
+	});
+});

--- a/apps/renderer/test/unit/cloud-sync-lifecycle.test.ts
+++ b/apps/renderer/test/unit/cloud-sync-lifecycle.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	CloudSyncLifecycleQueue,
+	reconcileAutomaticCloudSyncs,
+} from "../../src/lib/cloud-sync-lifecycle.ts";
+import { cloudSyncPreferenceEnabled } from "../../src/lib/cloud-workspace-catalog.ts";
+
+describe("cloud sync connection lifecycle", () => {
+	it("preserves default-on sync until the user disables it", () => {
+		expect(cloudSyncPreferenceEnabled(undefined)).toBe(true);
+		expect(cloudSyncPreferenceEnabled(null)).toBe(true);
+		expect(cloudSyncPreferenceEnabled({ enabled: false })).toBe(false);
+		expect(cloudSyncPreferenceEnabled({ enabled: true })).toBe(true);
+	});
+
+	it("stops on disconnect and starts again when connected without changing prefs", () => {
+		const start = vi.fn();
+		const stop = vi.fn();
+		const summaries = [{ workspaceId: "workspace_a", state: "ready" }];
+		reconcileAutomaticCloudSyncs({
+			summaries,
+			connectedWorkspaceIds: new Set(),
+			activeWorkspaceIds: new Set(["workspace_a"]),
+			enabled: () => true,
+			start,
+			stop,
+		});
+		expect(stop).toHaveBeenCalledWith("workspace_a");
+		expect(start).not.toHaveBeenCalled();
+
+		stop.mockClear();
+		reconcileAutomaticCloudSyncs({
+			summaries,
+			connectedWorkspaceIds: new Set(["workspace_a"]),
+			activeWorkspaceIds: new Set(),
+			enabled: () => true,
+			start,
+			stop,
+		});
+		expect(start).toHaveBeenCalledWith("workspace_a");
+		expect(stop).not.toHaveBeenCalled();
+	});
+
+	it("serializes disconnect teardown before reconnect setup", async () => {
+		const queue = new CloudSyncLifecycleQueue();
+		const events: string[] = [];
+		let releaseStop: () => void = () => undefined;
+		const stop = queue.run(
+			"workspace_a",
+			() =>
+				new Promise<void>((resolve) => {
+					events.push("stop-started");
+					releaseStop = () => {
+						events.push("stop-finished");
+						resolve();
+					};
+				}),
+		);
+		const start = queue.run("workspace_a", async () => {
+			events.push("start");
+		});
+		await vi.waitFor(() => expect(events).toEqual(["stop-started"]));
+		releaseStop();
+		await Promise.all([stop, start]);
+		expect(events).toEqual(["stop-started", "stop-finished", "start"]);
+	});
+});

--- a/apps/renderer/test/unit/port-forward-client.test.ts
+++ b/apps/renderer/test/unit/port-forward-client.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	prepare: vi.fn(),
+	open: vi.fn(),
+	list: vi.fn(),
+}));
+
+vi.mock("../../src/lib/bridge.ts", () => ({
+	getTunnelsBridge: () => ({
+		list: mocks.list,
+		open: mocks.open,
+	}),
+}));
+
+vi.mock("../../src/lib/cloud-ssh-client-bus.ts", () => ({
+	prepareCloudWorkspaceSsh: mocks.prepare,
+}));
+
+vi.mock("../../src/lib/rpc-client.ts", () => ({
+	getLocalEnvironmentId: () => "local",
+	isCloudWorkspaceEnvironment: () => true,
+}));
+
+import { ensurePortForward } from "../../src/lib/port-forward-client.ts";
+
+describe("port forward client", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("reuses a live localhost forward before refreshing cloud access", async () => {
+		mocks.list.mockResolvedValue([
+			{ environmentId: "workspace_a", remotePort: 3000, localPort: 31_234 },
+		]);
+		expect(await ensurePortForward("workspace_a", 3000)).toBe(31_234);
+		expect(mocks.prepare).not.toHaveBeenCalled();
+		expect(mocks.open).not.toHaveBeenCalled();
+	});
+
+	it("performs at most one credential-refresh retry", async () => {
+		mocks.list.mockResolvedValue([]);
+		mocks.prepare.mockResolvedValue({});
+		mocks.open
+			.mockRejectedValueOnce(new Error("zuse ssh bridge: connection failed"))
+			.mockResolvedValueOnce({
+				environmentId: "workspace_a",
+				remotePort: 3000,
+				localPort: 30_000,
+			});
+		expect(await ensurePortForward("workspace_a", 3000)).toBe(30_000);
+		expect(mocks.prepare).toHaveBeenCalledTimes(2);
+		expect(mocks.open).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not refresh credentials for local port allocation failures", async () => {
+		mocks.list.mockResolvedValue([]);
+		mocks.prepare.mockResolvedValue({});
+		mocks.open.mockRejectedValue(new Error("bind: Address already in use"));
+		await expect(ensurePortForward("workspace_a", 3000)).rejects.toThrow(
+			"Address already in use",
+		);
+		expect(mocks.prepare).toHaveBeenCalledTimes(1);
+		expect(mocks.open).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/renderer/test/unit/rpc-client.test.ts
+++ b/apps/renderer/test/unit/rpc-client.test.ts
@@ -13,6 +13,7 @@ const {
 	clearCloudWorkspaceRuntimeRecovery,
 	cloudWorkspaceRequiresRuntimeRecovery,
 	cloudWorkspaceRuntimeRecoveryCommandId,
+	requestCloudWorkspaceRuntimeRecovery,
 	isAuthCodedConnectionError,
 	isIgnorableRendererFailure,
 	isRpcClientTransportError,
@@ -231,6 +232,16 @@ describe("renderer RPC transport selection", () => {
 			acquireRendererRpcSession("workspace-expired", { hooks }),
 		).rejects.toThrow("HTTP 401");
 		expect(events).toEqual(["create-rejected", "invalidate:workspace-expired"]);
+	});
+
+	it("queues one recovery command for an explicit missing provider runtime", () => {
+		const workspaceId = "workspace-provider-missing";
+		requestCloudWorkspaceRuntimeRecovery(workspaceId);
+		const commandId = cloudWorkspaceRuntimeRecoveryCommandId(workspaceId);
+		expect(commandId).toBeTypeOf("string");
+		requestCloudWorkspaceRuntimeRecovery(workspaceId);
+		expect(cloudWorkspaceRuntimeRecoveryCommandId(workspaceId)).toBe(commandId);
+		clearCloudWorkspaceRuntimeRecovery(workspaceId);
 	});
 
 	it("marks a cloud runtime for recovery after the gateway proves it is absent", async () => {

--- a/apps/server/src/machine/machine-host-service.ts
+++ b/apps/server/src/machine/machine-host-service.ts
@@ -11,12 +11,12 @@ import {
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import type {
-	MachinePrivateNetworkStatus,
+import type { MachinePrivateNetworkStatus, SshMode } from "@zuse/contracts";
+import {
+	MachineRuntimeStatus,
 	MachineSshKey,
-	SshMode,
+	RelayPaths,
 } from "@zuse/contracts";
-import { MachineRuntimeStatus, RelayPaths } from "@zuse/contracts";
 import { Context, Effect, Layer, Schema } from "effect";
 
 import { AppPaths } from "../app-paths.ts";
@@ -151,11 +151,11 @@ const fingerprint = (publicKey: string): string => {
 
 const sshKey = (publicKey: string): MachineSshKey => {
 	const fields = publicKey.split(/\s+/u);
-	return {
+	return new MachineSshKey({
 		fingerprint: fingerprint(publicKey),
 		publicKey,
 		label: fields.slice(2).join(" ") || undefined,
-	};
+	});
 };
 
 const run = (
@@ -381,9 +381,12 @@ export const MachineHostServiceLive: Layer.Layer<
 				}),
 			addSshKey: (publicKey, label) =>
 				effect(async () => {
-					const key = normalizedKey(
-						label === undefined ? publicKey : `${publicKey} ${label}`,
-					);
+					const normalized = normalizedKey(publicKey);
+					const [kind, encoded] = normalized.split(/\s+/u);
+					const key =
+						label === undefined
+							? normalized
+							: normalizedKey(`${kind} ${encoded} ${label}`);
 					const record = sshKey(key);
 					const keys = await readKeys();
 					if (!keys.some((item) => item.fingerprint === record.fingerprint)) {

--- a/apps/server/src/relay/managed-tunnel-runtime.ts
+++ b/apps/server/src/relay/managed-tunnel-runtime.ts
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { dirname, join } from "node:path";
+import { promisify } from "node:util";
 import {
 	Context,
 	Data,
@@ -52,9 +54,22 @@ const CLOUDFLARED_CANDIDATES = [
 	"/opt/homebrew/bin/cloudflared",
 	"/usr/local/bin/cloudflared",
 ] as const;
+const execFileAsync = promisify(execFile);
+const CONNECTOR_TERMINATE_GRACE_MS = 2_000;
 
 export const managedTunnelTokenPath = (userData: string): string =>
 	join(userData, "relay", "cloudflared-token");
+
+export const managedTunnelOwnershipPath = (userData: string): string =>
+	join(userData, "relay", "cloudflared-owner.json");
+
+export interface ManagedTunnelOwnership {
+	readonly pid: number;
+	readonly binary: string;
+	readonly tokenPath: string;
+	readonly launchId: string;
+	readonly startedAt: number;
+}
 
 export const managedTunnelRunArgs = (
 	tokenPath: string,
@@ -86,6 +101,145 @@ export const writeManagedTunnelToken = async (
 	}
 };
 
+const atomicWritePrivateJson = async (
+	path: string,
+	value: unknown,
+): Promise<void> => {
+	const directory = dirname(path);
+	await fs.promises.mkdir(directory, { recursive: true, mode: 0o700 });
+	await fs.promises.chmod(directory, 0o700);
+	const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await fs.promises.writeFile(temporaryPath, JSON.stringify(value), {
+			flag: "wx",
+			mode: 0o600,
+		});
+		await fs.promises.rename(temporaryPath, path);
+		await fs.promises.chmod(path, 0o600);
+	} finally {
+		await fs.promises.rm(temporaryPath, { force: true });
+	}
+};
+
+export const commandMatchesManagedTunnel = (
+	command: string,
+	tokenPath: string,
+): boolean => {
+	const marker = "--token-file";
+	const markerIndex = command.lastIndexOf(marker);
+	if (markerIndex < 0) return false;
+	const commandPrefix = command.slice(0, markerIndex).trim();
+	if (!/(?:^|\/)cloudflared\s/u.test(`${commandPrefix} `)) return false;
+	const argument = command.slice(markerIndex + marker.length).trim();
+	return (
+		argument === tokenPath ||
+		argument === `'${tokenPath}'` ||
+		argument === `"${tokenPath}"`
+	);
+};
+
+export const managedTunnelProcessIds = async (
+	tokenPath: string,
+): Promise<ReadonlyArray<number>> => {
+	const { stdout } = await execFileAsync(
+		"ps",
+		["-ww", "-axo", "pid=,command="],
+		{
+			maxBuffer: 10 * 1024 * 1024,
+		},
+	);
+	return stdout
+		.split("\n")
+		.map((line) => /^(\s*\d+)\s+(.+)$/u.exec(line))
+		.filter((match): match is RegExpExecArray => match !== null)
+		.filter((match) => commandMatchesManagedTunnel(match[2] ?? "", tokenPath))
+		.map((match) => Number.parseInt(match[1] ?? "", 10))
+		.filter((pid) => Number.isSafeInteger(pid) && pid > 0);
+};
+
+const processRunning = (pid: number): boolean => {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (cause) {
+		return (cause as NodeJS.ErrnoException).code === "EPERM";
+	}
+};
+
+const waitForProcessExit = async (
+	pid: number,
+	timeoutMs: number,
+	isRunning = processRunning,
+) => {
+	const deadline = Date.now() + timeoutMs;
+	while (isRunning(pid) && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	return !isRunning(pid);
+};
+
+/** Terminate only connectors whose final token-file argument exactly matches. */
+export const terminateManagedTunnelProcesses = async (
+	tokenPath: string,
+	options: {
+		readonly processIds?: (tokenPath: string) => Promise<ReadonlyArray<number>>;
+		readonly kill?: (pid: number, signal: NodeJS.Signals) => void;
+		readonly isRunning?: (pid: number) => boolean;
+		readonly graceMs?: number;
+	} = {},
+): Promise<ReadonlyArray<number>> => {
+	const pids = await (options.processIds ?? managedTunnelProcessIds)(tokenPath);
+	const kill = options.kill ?? process.kill;
+	const isRunning = options.isRunning ?? processRunning;
+	for (const pid of pids) {
+		try {
+			kill(pid, "SIGTERM");
+		} catch (cause) {
+			if ((cause as NodeJS.ErrnoException).code !== "ESRCH") throw cause;
+		}
+	}
+	await Promise.all(
+		pids.map(async (pid) => {
+			if (
+				await waitForProcessExit(
+					pid,
+					options.graceMs ?? CONNECTOR_TERMINATE_GRACE_MS,
+					isRunning,
+				)
+			)
+				return;
+			try {
+				kill(pid, "SIGKILL");
+			} catch (cause) {
+				if ((cause as NodeJS.ErrnoException).code !== "ESRCH") throw cause;
+			}
+		}),
+	);
+	return pids;
+};
+
+export const writeManagedTunnelOwnership = async (
+	path: string,
+	ownership: ManagedTunnelOwnership,
+): Promise<void> => atomicWritePrivateJson(path, ownership);
+
+const clearManagedTunnelOwnership = async (
+	path: string,
+	launchId?: string,
+): Promise<void> => {
+	if (launchId !== undefined) {
+		try {
+			const current = JSON.parse(await fs.promises.readFile(path, "utf8")) as {
+				launchId?: unknown;
+			};
+			if (current.launchId !== launchId) return;
+		} catch {
+			// A missing or invalid ownership file is already unowned.
+		}
+	}
+	await fs.promises.rm(path, { force: true });
+};
+
 export const ManagedTunnelRuntimeLive: Layer.Layer<
 	ManagedTunnelRuntime,
 	never,
@@ -97,6 +251,7 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
 		const paths = yield* AppPaths;
 		const telemetry = yield* TelemetryStore;
 		const tokenPath = managedTunnelTokenPath(paths.userData);
+		const ownershipPath = managedTunnelOwnershipPath(paths.userData);
 		const fiberRef = yield* Ref.make<Fiber.Fiber<void> | null>(null);
 		const binaryRef = yield* Ref.make<string | null>(null);
 		const lifecycleLock = yield* Semaphore.make(1);
@@ -176,7 +331,31 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
 						{ stdout: "inherit", stderr: "inherit" },
 					);
 					const proc = yield* executor.spawn(command);
-					yield* log("cloudflared.process.started", { binary });
+					const launchId = randomUUID();
+					yield* Effect.tryPromise({
+						try: () =>
+							writeManagedTunnelOwnership(ownershipPath, {
+								pid: proc.pid,
+								binary,
+								tokenPath,
+								launchId,
+								startedAt: Date.now(),
+							}),
+						catch: () =>
+							new ManagedTunnelError({
+								reason: "cloudflared_ownership_write_failed",
+							}),
+					});
+					yield* Effect.addFinalizer(() =>
+						Effect.promise(() =>
+							clearManagedTunnelOwnership(ownershipPath, launchId),
+						).pipe(Effect.ignore),
+					);
+					yield* log("cloudflared.process.started", {
+						binary,
+						pid: proc.pid,
+						launchId,
+					});
 					const exitCode = yield* proc.exitCode;
 					yield* log("cloudflared.process.exited", { binary, exitCode });
 				}),
@@ -186,6 +365,20 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
 			const existing = yield* Ref.get(fiberRef);
 			if (existing !== null) yield* Fiber.interrupt(existing);
 			yield* Ref.set(fiberRef, null);
+			yield* Effect.tryPromise({
+				try: () => terminateManagedTunnelProcesses(tokenPath),
+				catch: () =>
+					new ManagedTunnelError({
+						reason: "cloudflared_process_cleanup_failed",
+					}),
+			});
+			yield* Effect.tryPromise({
+				try: () => clearManagedTunnelOwnership(ownershipPath),
+				catch: () =>
+					new ManagedTunnelError({
+						reason: "cloudflared_ownership_cleanup_failed",
+					}),
+			});
 			yield* Effect.tryPromise({
 				try: () => fs.promises.rm(tokenPath, { force: true }),
 				catch: () =>
@@ -224,6 +417,24 @@ export const ManagedTunnelRuntimeLive: Layer.Layer<
 					yield* log("cloudflared.start.ok");
 				}),
 			);
+
+		// Recover connectors left behind when the previous app process could not
+		// run its finalizers. Exact token-path matching leaves all other tunnels alone.
+		const recovered = yield* Effect.tryPromise(async () => {
+			const terminated = await terminateManagedTunnelProcesses(tokenPath);
+			await clearManagedTunnelOwnership(ownershipPath);
+			return terminated;
+		}).pipe(
+			Effect.catch((cause) =>
+				log("cloudflared.startup.recovery_failed", {
+					reason: cause instanceof Error ? cause.message : String(cause),
+				}).pipe(Effect.as([] as ReadonlyArray<number>)),
+			),
+		);
+		if (recovered.length > 0)
+			yield* log("cloudflared.startup.recovered", {
+				processCount: recovered.length,
+			});
 
 		// Ensure the connector is torn down when the runtime scope closes.
 		yield* Effect.addFinalizer(() =>

--- a/apps/server/test/unit/machine-host-service.test.ts
+++ b/apps/server/test/unit/machine-host-service.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { MachineRuntimeStatus } from "@zuse/contracts";
+import { MachineRuntimeStatus, MachineSshKey } from "@zuse/contracts";
 import { Effect, Layer, Schema } from "effect";
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -62,8 +62,8 @@ describe("machine host SSH keys", () => {
 		const result = await Effect.runPromise(
 			Effect.gen(function* () {
 				const host = yield* MachineHostService;
-				const added = yield* host.addSshKey(publicKey);
-				yield* host.addSshKey(publicKey);
+				const added = yield* host.addSshKey(publicKey, "zuse-desktop");
+				yield* host.addSshKey(publicKey, "zuse-desktop");
 				const listed = yield* host.listSshKeys();
 				yield* host.removeSshKey(added.fingerprint);
 				return {
@@ -75,6 +75,8 @@ describe("machine host SSH keys", () => {
 		);
 
 		expect(result.added.fingerprint).toMatch(/^SHA256:/u);
+		expect(result.added.label).toBe("zuse-desktop");
+		expect(() => Schema.encodeSync(MachineSshKey)(result.added)).not.toThrow();
 		expect(result.listed).toHaveLength(1);
 		expect(result.afterRemove).toEqual([]);
 		expect((await stat(authorizedKeys)).mode & 0o777).toBe(0o600);

--- a/apps/server/test/unit/managed-tunnel-runtime.test.ts
+++ b/apps/server/test/unit/managed-tunnel-runtime.test.ts
@@ -17,10 +17,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { AppPaths } from "../../src/app-paths.ts";
 import { TelemetryStoreLive } from "../../src/observability/telemetry-store.ts";
 import {
+	commandMatchesManagedTunnel,
 	ManagedTunnelRuntime,
 	ManagedTunnelRuntimeLive,
+	managedTunnelOwnershipPath,
 	managedTunnelRunArgs,
 	managedTunnelTokenPath,
+	terminateManagedTunnelProcesses,
+	writeManagedTunnelOwnership,
 	writeManagedTunnelToken,
 } from "../../src/relay/managed-tunnel-runtime.ts";
 
@@ -122,6 +126,69 @@ describe("managed tunnel runtime", () => {
 		expect((await stat(dirname(tokenPath))).mode & 0o777).toBe(0o700);
 	});
 
+	it("matches only the exact Zuse token-file command", () => {
+		const tokenPath =
+			"/Users/me/Library/Application Support/Zuse/relay/cloudflared-token";
+		expect(
+			commandMatchesManagedTunnel(
+				`/opt/homebrew/bin/cloudflared tunnel run --token-file ${tokenPath}`,
+				tokenPath,
+			),
+		).toBe(true);
+		expect(
+			commandMatchesManagedTunnel(
+				`/opt/homebrew/bin/cloudflared tunnel run --token-file ${tokenPath}-other`,
+				tokenPath,
+			),
+		).toBe(false);
+		expect(
+			commandMatchesManagedTunnel(
+				`other-daemon --token-file ${tokenPath}`,
+				tokenPath,
+			),
+		).toBe(false);
+	});
+
+	it("uses graceful termination before a bounded forced kill", async () => {
+		const running = new Set([41, 42]);
+		const signals: Array<[number, NodeJS.Signals]> = [];
+		await terminateManagedTunnelProcesses("/exact/token", {
+			processIds: async () => [41, 42],
+			isRunning: (pid) => running.has(pid),
+			kill: (pid, signal) => {
+				signals.push([pid, signal]);
+				if (pid === 41 || signal === "SIGKILL") running.delete(pid);
+			},
+			graceMs: 0,
+		});
+		expect(signals).toEqual([
+			[41, "SIGTERM"],
+			[42, "SIGTERM"],
+			[42, "SIGKILL"],
+		]);
+	});
+
+	it("clears a stale ownership record when the runtime starts", async () => {
+		const userData = await mkdtemp(join(tmpdir(), "zuse-tunnel-runtime-"));
+		temporaryDirectories.push(userData);
+		const ownershipPath = managedTunnelOwnershipPath(userData);
+		await writeManagedTunnelOwnership(ownershipPath, {
+			pid: 999_999,
+			binary: "/usr/local/bin/cloudflared",
+			tokenPath: managedTunnelTokenPath(userData),
+			launchId: "stale-launch",
+			startedAt: 1,
+		});
+		await Effect.runPromise(
+			Effect.scoped(
+				Effect.gen(function* () {
+					yield* ManagedTunnelRuntime;
+				}).pipe(Effect.provide(makeRuntimeLayer(userData, []))),
+			),
+		);
+		await expect(access(ownershipPath)).rejects.toThrow();
+	});
+
 	it("serializes concurrent starts and removes the token on stop", async () => {
 		const userData = await mkdtemp(join(tmpdir(), "zuse-tunnel-runtime-"));
 		temporaryDirectories.push(userData);
@@ -140,6 +207,19 @@ describe("managed tunnel runtime", () => {
 						.filter((record) => record.args.includes("run"))
 						.map((record) => record.args);
 					expect(connectorArgs).toHaveLength(2);
+					const ownership = JSON.parse(
+						yield* Effect.promise(() =>
+							readFile(managedTunnelOwnershipPath(userData), "utf8"),
+						),
+					) as { pid: number; tokenPath: string; launchId: string };
+					expect(ownership.pid).toBeGreaterThan(0);
+					expect(ownership.tokenPath).toBe(managedTunnelTokenPath(userData));
+					expect(ownership.launchId).not.toBe("");
+					expect(
+						(yield* Effect.promise(() =>
+							stat(managedTunnelOwnershipPath(userData)),
+						)).mode & 0o777,
+					).toBe(0o600);
 					expect(JSON.stringify(connectorArgs)).not.toContain("first-secret");
 					expect(JSON.stringify(connectorArgs)).not.toContain("second-secret");
 					yield* runtime.stop();
@@ -149,6 +229,9 @@ describe("managed tunnel runtime", () => {
 		);
 
 		await expect(access(managedTunnelTokenPath(userData))).rejects.toThrow();
+		await expect(
+			access(managedTunnelOwnershipPath(userData)),
+		).rejects.toThrow();
 		const logDirectory = join(userData, "logs");
 		const diagnostics = (
 			await Promise.all(

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.6",
+      "version": "0.20.7",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/docs/cloud/user-guide.md
+++ b/docs/cloud/user-guide.md
@@ -68,6 +68,15 @@ local synced checkout, normally under `~/.zuse/cloud/<repository>/<branch>`.
 Generated dependency and cache directories such as `node_modules` are not
 copied from cloud; install or generate them locally when needed.
 
+The local checkout is a one-way, remote-authoritative mirror. Local edits are
+not uploaded and may be overwritten by the next sync. Zuse stops the transfer
+when the environment disconnects, keeps the enabled preference, and prepares
+fresh access before syncing again after reconnect.
+
+Open via SSH uses the managed `ssh zuse-<workspace>` host alias and does not
+publish an SSH listener. Dev-server previews open through a private forward on
+Mac `localhost`; copying a public E2B preview URL remains a separate action.
+
 Transcript checkpoints do not back up the repository filesystem. While a chat
 is active or archived, the E2B sandbox holds its complete workspace. R2 holds
 only the encrypted transcript projection.

--- a/infra/relay/src/cloud-workspace-routes.ts
+++ b/infra/relay/src/cloud-workspace-routes.ts
@@ -2208,16 +2208,20 @@ export const routeCloudWorkspaceRequest = (
 					"zuse",
 				)
 				.pipe(
-					Effect.mapError(() =>
-						serviceUnavailable("cloud_workspace_ssh_unavailable"),
+					Effect.mapError((error) =>
+						error.code === "not-found"
+							? notFound("cloud_workspace_sandbox_not_found")
+							: serviceUnavailable("cloud_workspace_ssh_unavailable"),
 					),
 				);
 			const offer = yield* SandboxOfferConfiguration;
 			const endpoint = yield* provider
 				.resolveEndpoint(workspace.providerSandboxId, offer.port)
 				.pipe(
-					Effect.mapError(() =>
-						serviceUnavailable("cloud_workspace_ssh_unavailable"),
+					Effect.mapError((error) =>
+						error.code === "not-found"
+							? notFound("cloud_workspace_sandbox_not_found")
+							: serviceUnavailable("cloud_workspace_ssh_unavailable"),
 					),
 				);
 			yield* recordWorkspaceActivity(workspace);


### PR DESCRIPTION
## Summary

- install a stable, atomic SSH bridge under ~/.zuse and classify bridge failures without leaking credentials
- serialize cloud access preparation and sync lifecycle recovery across disconnects, missing sandboxes, and access refreshes
- reuse and safely tear down localhost forwards, including in-flight connections and bounded port collision retries
- make one-way rsync and legacy transfers cancellable and macOS-compatible
- persist managed Cloudflare connector ownership and reclaim only exact-path Zuse orphans
- bump the desktop release to 0.20.7

## Validation

- changed-file Biome: 29 files passed
- workspace type checks: 31 targets passed
- desktop connectivity tests: 29 passed
- renderer connectivity and recovery tests: 25 passed
- server tunnel and SSH-key tests: 10 passed
- Relay test suite: 202 passed
- desktop production build passed and emitted the bundled ssh-bridge-child.cjs asset

## Known repository baseline failures

- the full repository test command stops in packages/agents because the existing gpt-5.5 xhigh expectation no longer matches the current model inventory; the focused test reproduces this outside the changed files
- repository-wide Biome currently reports pre-existing diagnostics in unrelated files; all files changed by this PR pass Biome

## Documentation

- README.md: added Cloud Workspace SSH, one-way Mac mirror, and private localhost preview behavior; corrected the contracts package path and linked the context map
- docs/cloud/user-guide.md: documented remote-authoritative sync, reconnect renewal, managed SSH aliases, and private versus public previews
- CHANGELOG.md: polished the v0.20.7 notes around user-visible recovery and restart behavior
