### PR TITLE
Improve landing clarity and agent readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ yarn-error.log*
 !.zuse/settings.toml
 
 .gstack/
+.seo-cache/
 
 # Hugeicons migrate CLI artifacts (backups + HTML reports)
 apps/renderer/hugeicons-migrate-backup-*/

--- a/apps/web/app/api/openapi.json/route.ts
+++ b/apps/web/app/api/openapi.json/route.ts
@@ -1,0 +1,8 @@
+export {
+	DELETE,
+	GET,
+	OPTIONS,
+	PATCH,
+	POST,
+	PUT,
+} from "@/app/openapi.json/route";

--- a/apps/web/app/api/waitlist/route.test.ts
+++ b/apps/web/app/api/waitlist/route.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET, OPTIONS, POST, PUT } from "./route";
+
+const request = (body: string, contentType = "application/json") =>
+	new Request("https://zuse.sh/api/waitlist", {
+		method: "POST",
+		headers: { "Content-Type": contentType },
+		body,
+	});
+
+describe("waitlist API", () => {
+	const originalWebhook = process.env.WAITLIST_WEBHOOK_URL;
+
+	beforeEach(() => {
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+		delete process.env.WAITLIST_WEBHOOK_URL;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		if (originalWebhook) {
+			process.env.WAITLIST_WEBHOOK_URL = originalWebhook;
+		} else {
+			delete process.env.WAITLIST_WEBHOOK_URL;
+		}
+	});
+
+	it("rejects non-JSON requests with a structured error", async () => {
+		const response = await POST(request("email=a@b.com", "text/plain"));
+		expect(response.status).toBe(415);
+		expect(await response.json()).toMatchObject({
+			error: { code: "UNSUPPORTED_MEDIA_TYPE", resolution: expect.any(String) },
+		});
+	});
+
+	it("distinguishes malformed JSON from an invalid email", async () => {
+		const malformed = await POST(request("{"));
+		expect(malformed.status).toBe(400);
+		expect(await malformed.json()).toMatchObject({
+			error: { code: "INVALID_JSON" },
+		});
+
+		const invalidEmail = await POST(request('{"email":"nope"}'));
+		expect(invalidEmail.status).toBe(400);
+		expect(await invalidEmail.json()).toMatchObject({
+			error: { code: "INVALID_EMAIL" },
+		});
+	});
+
+	it("accepts JSON media types case-insensitively", async () => {
+		const response = await POST(
+			request('{"email":"nope"}', "Application/JSON; Charset=UTF-8"),
+		);
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: { code: "INVALID_EMAIL" },
+		});
+	});
+
+	it("returns an actionable unavailable response when no sink is configured", async () => {
+		const response = await POST(request('{"email":"dev@example.com"}'));
+		expect(response.status).toBe(503);
+		expect(await response.json()).toMatchObject({
+			error: { code: "SERVICE_UNAVAILABLE" },
+		});
+	});
+
+	it("forwards valid signups and preserves the success response", async () => {
+		process.env.WAITLIST_WEBHOOK_URL = "https://sink.example/waitlist";
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(new Response(null, { status: 204 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await POST(request('{"email":"dev@example.com"}'));
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://sink.example/waitlist",
+			expect.objectContaining({ method: "POST" }),
+		);
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		expect(JSON.parse(String(init.body))).toMatchObject({
+			email: "dev@example.com",
+			source: "zuse-cloud-waitlist",
+			timestamp: expect.any(String),
+		});
+	});
+
+	it("returns a structured upstream error without claiming success", async () => {
+		process.env.WAITLIST_WEBHOOK_URL = "https://sink.example/waitlist";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(null, { status: 500 })),
+		);
+
+		const response = await POST(request('{"email":"dev@example.com"}'));
+		expect(response.status).toBe(502);
+		expect(await response.json()).toMatchObject({
+			error: { code: "UPSTREAM_ERROR" },
+		});
+	});
+
+	it("returns the same structured error when the waitlist request throws", async () => {
+		process.env.WAITLIST_WEBHOOK_URL = "https://sink.example/waitlist";
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+		const response = await POST(request('{"email":"dev@example.com"}'));
+		expect(response.status).toBe(502);
+		expect(await response.json()).toMatchObject({
+			error: { code: "UPSTREAM_ERROR", resolution: expect.any(String) },
+		});
+	});
+
+	it("describes the supported method for GET callers", async () => {
+		const response = GET();
+		expect(response.status).toBe(405);
+		expect(response.headers.get("allow")).toBe("POST");
+		expect(await response.json()).toMatchObject({
+			error: { code: "METHOD_NOT_ALLOWED" },
+		});
+	});
+
+	it("returns structured errors for every unsupported method", async () => {
+		const response = PUT();
+		expect(response.status).toBe(405);
+		expect(response.headers.get("allow")).toBe("POST");
+		expect(await response.json()).toMatchObject({
+			error: { code: "METHOD_NOT_ALLOWED", resolution: expect.any(String) },
+		});
+	});
+
+	it("returns an explicit preflight contract", () => {
+		const response = OPTIONS();
+		expect(response.status).toBe(204);
+		expect(response.headers.get("access-control-allow-methods")).toBe("POST");
+	});
+});

--- a/apps/web/app/api/waitlist/route.ts
+++ b/apps/web/app/api/waitlist/route.ts
@@ -1,4 +1,5 @@
-import { NextResponse } from "next/server";
+import { jsonError } from "@/lib/api-error";
+import { methodNotAllowed, preflightResponse } from "@/lib/api-method";
 
 // Minimal cloud-waitlist capture: validate the email and forward it, with a
 // timestamp, to whatever webhook WAITLIST_WEBHOOK_URL points at (form
@@ -8,11 +9,30 @@ import { NextResponse } from "next/server";
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function POST(request: Request) {
+	const mediaType = request.headers
+		.get("content-type")
+		?.split(";", 1)[0]
+		?.trim()
+		.toLowerCase();
+	if (mediaType !== "application/json") {
+		return jsonError(
+			415,
+			"UNSUPPORTED_MEDIA_TYPE",
+			"This endpoint only accepts JSON.",
+			"Set Content-Type to application/json and send an object with an email field.",
+		);
+	}
+
 	let email: unknown;
 	try {
 		({ email } = await request.json());
 	} catch {
-		return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+		return jsonError(
+			400,
+			"INVALID_JSON",
+			"The request body is not valid JSON.",
+			'Send a JSON object such as {"email":"developer@example.com"}.',
+		);
 	}
 
 	if (
@@ -20,18 +40,22 @@ export async function POST(request: Request) {
 		!EMAIL_RE.test(email) ||
 		email.length > 254
 	) {
-		return NextResponse.json(
-			{ error: "Enter a valid email address." },
-			{ status: 400 },
+		return jsonError(
+			400,
+			"INVALID_EMAIL",
+			"The email field must contain a valid email address.",
+			"Provide a valid email address no longer than 254 characters.",
 		);
 	}
 
 	const webhook = process.env.WAITLIST_WEBHOOK_URL;
 	if (!webhook) {
 		console.error("WAITLIST_WEBHOOK_URL is not configured");
-		return NextResponse.json(
-			{ error: "The waitlist is not accepting signups right now." },
-			{ status: 503 },
+		return jsonError(
+			503,
+			"SERVICE_UNAVAILABLE",
+			"The waitlist is not accepting signups right now.",
+			"Try again later or follow the Zuse changelog for availability updates.",
 		);
 	}
 
@@ -47,18 +71,30 @@ export async function POST(request: Request) {
 		});
 		if (!response.ok) {
 			console.error(`Waitlist webhook responded ${response.status}`);
-			return NextResponse.json(
-				{ error: "Could not save your signup. Please try again." },
-				{ status: 502 },
+			return jsonError(
+				502,
+				"UPSTREAM_ERROR",
+				"The waitlist service could not save the signup.",
+				"Retry the request later. Do not assume the email was registered.",
 			);
 		}
 	} catch (error) {
 		console.error("Waitlist webhook request failed", error);
-		return NextResponse.json(
-			{ error: "Could not save your signup. Please try again." },
-			{ status: 502 },
+		return jsonError(
+			502,
+			"UPSTREAM_ERROR",
+			"The waitlist service could not save the signup.",
+			"Retry the request later. Do not assume the email was registered.",
 		);
 	}
 
-	return NextResponse.json({ ok: true });
+	return Response.json({ ok: true });
 }
+
+const unsupportedMethod = () => methodNotAllowed(["POST"]);
+
+export const GET = unsupportedMethod;
+export const PUT = unsupportedMethod;
+export const PATCH = unsupportedMethod;
+export const DELETE = unsupportedMethod;
+export const OPTIONS = () => preflightResponse(["POST"]);

--- a/apps/web/app/developers/page.tsx
+++ b/apps/web/app/developers/page.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import { Container } from "@/components/container";
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+	title: "Developer Resources",
+	description:
+		"Zuse developer documentation, OpenAPI specification, agent instructions, API availability, and local MCP integration details.",
+	path: "/developers",
+	keywords: [
+		"Zuse developer resources",
+		"Zuse API",
+		"Zuse OpenAPI",
+		"Zuse MCP server",
+		"Zuse documentation",
+	],
+});
+
+const resources = [
+	{
+		title: "Documentation",
+		description:
+			"Set up Zuse, configure repositories, and understand local workspace behavior.",
+		href: "https://docs.zuse.sh",
+		label: "Read Zuse documentation",
+	},
+	{
+		title: "OpenAPI specification",
+		description:
+			"Inspect the complete, typed contract for the public Zuse website API.",
+		href: "/openapi.json",
+		label: "Open openapi.json",
+	},
+	{
+		title: "Agent instructions",
+		description:
+			"Read when an agent should use Zuse, how to discover resources, and current product boundaries.",
+		href: "/llms.txt",
+		label: "Open llms.txt",
+	},
+	{
+		title: "Local MCP integration",
+		description:
+			"The open-source MCP server connects compatible clients to the installed Zuse desktop app over stdio.",
+		href: "https://github.com/swarajbachu/zuse/tree/main/apps/mcp-server",
+		label: "View MCP server source",
+	},
+];
+
+export default function DevelopersPage() {
+	return (
+		<main>
+			<Container className="py-32 md:py-40">
+				<div className="max-w-3xl">
+					<p className="text-primary font-mono text-sm font-medium">
+						For developers and agents
+					</p>
+					<h1 className="text-heading mt-3 font-display text-4xl font-semibold tracking-tight text-balance md:text-6xl">
+						Zuse developer resources
+					</h1>
+					<p className="text-muted-foreground mt-6 text-base leading-7 md:text-lg">
+						Machine-readable contracts and direct documentation for building
+						with, integrating, or accurately describing Zuse.
+					</p>
+				</div>
+
+				<div className="border-border mt-14 grid border-t md:grid-cols-2">
+					{resources.map((resource) => (
+						<section
+							key={resource.title}
+							className="border-border border-b py-8 md:px-8 md:odd:border-r md:odd:pl-0"
+						>
+							<h2 className="text-heading text-lg font-semibold">
+								{resource.title}
+							</h2>
+							<p className="text-muted-foreground mt-3 text-sm leading-6">
+								{resource.description}
+							</p>
+							<Link
+								href={resource.href}
+								className="text-primary mt-5 inline-flex text-sm font-medium underline underline-offset-4"
+							>
+								{resource.label}
+							</Link>
+						</section>
+					))}
+				</div>
+
+				<div className="mt-14 grid gap-10 md:grid-cols-3">
+					<section>
+						<h2 className="text-heading text-base font-semibold">Public API</h2>
+						<p className="text-muted-foreground mt-3 text-sm leading-6">
+							The public web API currently contains one endpoint for registering
+							Zuse Cloud interest. It does not expose repositories or sessions.
+						</p>
+					</section>
+					<section>
+						<h2 className="text-heading text-base font-semibold">
+							Authentication
+						</h2>
+						<p className="text-muted-foreground mt-3 text-sm leading-6">
+							The waitlist endpoint requires no authentication. Agent-provider
+							credentials remain in each developer&apos;s local tools and are
+							not part of the public web API.
+						</p>
+					</section>
+					<section>
+						<h2 className="text-heading text-base font-semibold">Webhooks</h2>
+						<p className="text-muted-foreground mt-3 text-sm leading-6">
+							Zuse does not currently publish a webhook API. Any future webhook
+							contract will be added to the OpenAPI specification first.
+						</p>
+					</section>
+				</div>
+			</Container>
+		</main>
+	);
+}

--- a/apps/web/app/home.md/route.ts
+++ b/apps/web/app/home.md/route.ts
@@ -1,7 +1,7 @@
-import { LLMS_TEXT } from "@/lib/agent-content";
+import { HOME_MARKDOWN } from "@/lib/agent-content";
 
 export function GET() {
-	return new Response(LLMS_TEXT, {
+	return new Response(HOME_MARKDOWN, {
 		headers: {
 			"Cache-Control": "public, max-age=0, s-maxage=3600",
 			"Content-Type": "text/markdown; charset=utf-8",

--- a/apps/web/app/machine-routes.test.ts
+++ b/apps/web/app/machine-routes.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { GET as getHomepageMarkdown } from "./home.md/route";
+import { GET as getLlmsText } from "./llms.txt/route";
+import {
+	GET as getOpenApi,
+	OPTIONS as getOpenApiOptions,
+	POST as postOpenApi,
+} from "./openapi.json/route";
+import sitemap from "./sitemap";
+
+describe("machine-readable routes", () => {
+	it("serves homepage and instruction Markdown with cache-safe negotiation headers", async () => {
+		for (const response of [getHomepageMarkdown(), getLlmsText()]) {
+			expect(response.status).toBe(200);
+			expect(response.headers.get("content-type")).toContain("text/markdown");
+			expect(response.headers.get("vary")).toContain("Accept");
+			expect((await response.text()).length).toBeGreaterThan(500);
+		}
+	});
+
+	it("publishes a cross-origin-readable OpenAPI document", async () => {
+		const response = getOpenApi();
+		expect(response.status).toBe(200);
+		expect(response.headers.get("access-control-allow-origin")).toBe("*");
+		expect(await response.json()).toMatchObject({ openapi: "3.1.0" });
+	});
+
+	it("returns structured errors and an explicit preflight contract for OpenAPI", async () => {
+		const unsupported = postOpenApi();
+		expect(unsupported.status).toBe(405);
+		expect(await unsupported.json()).toMatchObject({
+			error: { code: "METHOD_NOT_ALLOWED", resolution: expect.any(String) },
+		});
+
+		const preflight = getOpenApiOptions();
+		expect(preflight.status).toBe(204);
+		expect(preflight.headers.get("access-control-allow-methods")).toBe("GET");
+	});
+
+	it("includes Zuse developer resources in the sitemap", () => {
+		expect(sitemap().some((entry) => entry.url.endsWith("/developers"))).toBe(
+			true,
+		);
+	});
+});

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { Container } from "@/components/container";
+import { getSEO } from "@/lib/seo";
+
+export const metadata = getSEO({
+	absoluteTitle: "Page not found | Zuse",
+	description: "Find the Zuse page or developer resource you were looking for.",
+	path: "/404",
+	noIndex: true,
+});
+
+const recoveryLinks = [
+	{ href: "/", label: "Homepage" },
+	{ href: "/developers", label: "Developer resources" },
+	{ href: "/llms.txt", label: "Agent instructions" },
+	{ href: "/sitemap.xml", label: "Site map" },
+	{ href: "https://docs.zuse.sh", label: "Documentation" },
+];
+
+export default function NotFound() {
+	return (
+		<main>
+			<Container className="flex min-h-[65vh] flex-col justify-center py-32">
+				<p className="text-primary font-mono text-sm font-medium">404</p>
+				<h1 className="text-heading mt-3 font-display text-4xl font-semibold tracking-tight md:text-6xl">
+					Page not found
+				</h1>
+				<p className="text-muted-foreground mt-5 max-w-xl text-base leading-7">
+					That Zuse path does not exist. Continue with one of these verified
+					resources.
+				</p>
+				<nav
+					aria-label="404 recovery links"
+					className="mt-8 flex flex-wrap gap-3"
+				>
+					{recoveryLinks.map((link) => (
+						<Link
+							key={link.href}
+							href={link.href}
+							className="border-border text-heading hover:border-primary/50 hover:bg-muted rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
+						>
+							{link.label}
+						</Link>
+					))}
+				</nav>
+			</Container>
+		</main>
+	);
+}

--- a/apps/web/app/openapi.json/route.ts
+++ b/apps/web/app/openapi.json/route.ts
@@ -1,0 +1,19 @@
+import { methodNotAllowed, preflightResponse } from "@/lib/api-method";
+import { openApiDocument } from "@/lib/openapi";
+
+export function GET() {
+	return Response.json(openApiDocument, {
+		headers: {
+			"Access-Control-Allow-Origin": "*",
+			"Cache-Control": "public, max-age=0, s-maxage=3600",
+		},
+	});
+}
+
+const unsupportedMethod = () => methodNotAllowed(["GET"]);
+
+export const POST = unsupportedMethod;
+export const PUT = unsupportedMethod;
+export const PATCH = unsupportedMethod;
+export const DELETE = unsupportedMethod;
+export const OPTIONS = () => preflightResponse(["GET"]);

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,9 +6,9 @@ import { HomepageStructuredData } from "@/components/seo/homepage-structured-dat
 import { getSEO } from "@/lib/seo";
 
 export const metadata = getSEO({
-	absoluteTitle: "Zuse — Open-source autonomous coding workspace",
+	absoluteTitle: "Zuse — All your coding agents in one workspace",
 	description:
-		"Run autonomous coding agents locally or in live cloud workspaces with Zuse. Plan, code, test, review diffs, and prepare pull requests using your existing AI subscriptions.",
+		"Run coding agents side by side, carry context between them, and isolate every task in its own git worktree with Zuse.",
 	path: "/",
 	keywords: [
 		"open source coding agent",

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -11,6 +11,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 1,
 		},
 		{
+			url: `${siteConfig.url}/developers`,
+			lastModified: now,
+			changeFrequency: "monthly",
+			priority: 0.8,
+		},
+		{
 			url: `${siteConfig.url}/changelog`,
 			lastModified: now,
 			changeFrequency: "weekly",

--- a/apps/web/components/cloud-teaser/waitlist-form.tsx
+++ b/apps/web/components/cloud-teaser/waitlist-form.tsx
@@ -27,11 +27,13 @@ export const WaitlistForm = () => {
 			});
 			if (!response.ok) {
 				const body = (await response.json().catch(() => null)) as {
-					error?: string;
+					error?: string | { message?: string };
 				} | null;
+				const message =
+					typeof body?.error === "string" ? body.error : body?.error?.message;
 				setStatus({
 					state: "error",
-					message: body?.error ?? "Something went wrong. Please try again.",
+					message: message ?? "Something went wrong. Please try again.",
 				});
 				return;
 			}

--- a/apps/web/components/faq/index.tsx
+++ b/apps/web/components/faq/index.tsx
@@ -12,9 +12,19 @@ import { GITHUB_URL } from "@/lib/site";
 
 const data = [
 	{
+		question: "What does Zuse actually do?",
+		answer:
+			"Zuse puts your coding agents, repositories, terminals, files, and diffs in one workspace. You can run several tasks in parallel, keep each one isolated in its own git worktree, and carry selected context from one agent session to another.",
+	},
+	{
+		question: "What happens when I want to switch agents?",
+		answer:
+			"You choose the next provider instead of Zuse silently routing your message. Start or fork a session, then attach the plan, transcript, diff, or files the next agent needs. If one subscription reaches its limit, you can continue with another provider you have access to.",
+	},
+	{
 		question: "Which agents are supported?",
 		answer:
-			"Zuse wraps seven coding agent CLIs in one workspace: Claude Code, Codex, Cursor, Gemini, Grok, OpenCode, and Kiro. You can run them side by side and switch providers without leaving the app.",
+			"Zuse supports seven coding-agent CLIs in one workspace. Connect the providers you use, run them side by side, and choose which provider handles each session.",
 	},
 	{
 		question: "Do I need my own API keys or subscriptions?",

--- a/apps/web/components/footer/index.tsx
+++ b/apps/web/components/footer/index.tsx
@@ -23,6 +23,7 @@ import {
 const data = {
 	Product: [
 		{ label: "Download", href: DOWNLOAD_URL },
+		{ label: "Developers", href: "/developers" },
 		{ label: "Change Log", href: "/changelog" },
 		{ label: "Blog", href: "/blog" },
 		{ label: "Privacy Policy", href: "/privacy" },

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Button as DownloadButton } from "@/components/button";
 import { ZuseInteractiveDemo } from "@/components/demo/zuse-interactive-demo";
 import { HorizontalLine } from "./line";
@@ -13,16 +14,21 @@ export const Hero = () => {
 					Open source · Cloud beta live
 				</span>
 				<h1 className="text-heading mt-5 max-w-[18ch] font-display text-4xl font-semibold leading-[1.04] tracking-tight text-balance md:text-6xl lg:text-7xl">
-					Run every coding agent from{" "}
-					<span className="text-primary">one desktop</span>
+					All your coding agents.{" "}
+					<span className="text-primary">One workspace.</span>
 				</h1>
 				<p className="text-muted-foreground mt-6 max-w-[58ch] text-base leading-7 text-pretty md:text-lg">
-					The open-source autonomous coding workspace for local and cloud
-					agents. Give it an issue—Zuse plans, codes, tests, and prepares the
-					pull request with the subscriptions you already pay for.
+					Run agents side by side, carry context between them, and keep every
+					task isolated in its own git worktree.
 				</p>
-				<div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
+				<div className="mt-8 flex flex-col items-center gap-4 sm:flex-row">
 					<DownloadButton />
+					<Link
+						href="/#workflow"
+						className="text-heading focus-visible:ring-heading/60 inline-flex min-h-11 items-center rounded-lg px-3 text-sm font-medium underline decoration-border underline-offset-4 transition-colors duration-200 hover:decoration-primary focus-visible:ring-2 focus-visible:outline-none"
+					>
+						See how it works
+					</Link>
 				</div>
 				<p className="text-muted-foreground mt-3 text-xs">
 					Free in beta · no token markup

--- a/apps/web/components/landing/product-showcase.tsx
+++ b/apps/web/components/landing/product-showcase.tsx
@@ -2,17 +2,33 @@ import { Features as WorktreeFeatures } from "@/components/tpl/agenforce/compone
 import { FeaturesSecondary } from "@/components/tpl/agenforce/components/features-secondary";
 import { FeaturesTertiary } from "@/components/tpl/agenforce/components/features-tertiary";
 import { LogoCloud } from "@/components/tpl/agenforce/components/logo-cloud";
-import { AgenticIntelligence } from "@/components/tpl/nodus/components/agentic-intelligence";
-import { Benefits } from "@/components/tpl/nodus/components/benefits";
 import { HowItWorks } from "@/components/tpl/nodus/components/how-it-works";
 import { FeaturesOne } from "@/components/tpl/saas/components/features-one";
 import { FeaturesTwo } from "@/components/tpl/saas/components/features-two";
-import { EdgeComputing } from "@/components/tpl/saas/components/features-two/edge-computing";
+import { WorkflowOverview } from "./workflow-overview";
 
 export function ProductShowcase() {
 	return (
 		<div id="features" className="scroll-mt-24">
+			<WorkflowOverview />
+			<Divider />
 			<LogoCloud />
+			<Divider />
+
+			<section aria-labelledby="handoff-heading">
+				<ShowcaseHeader
+					id="handoff-heading"
+					eyebrow="Agent handoff"
+					title="Continue the work with another agent"
+					description="Fork a session or start a new provider with the plan, transcript, and files it needs. You choose what moves forward."
+				/>
+				<FeaturesSecondary />
+			</section>
+
+			<Divider />
+			<WorktreeFeatures />
+			<Divider />
+			<HowItWorks />
 			<Divider />
 
 			<section aria-labelledby="review-heading">
@@ -28,30 +44,9 @@ export function ProductShowcase() {
 			<Divider />
 			<FeaturesOne />
 			<Divider />
-			<WorktreeFeatures />
-			<Divider />
-			<Benefits />
-			<Divider />
 			<div id="cloud" className="scroll-mt-24">
 				<FeaturesTwo />
 			</div>
-			<Divider />
-			<EdgeComputing />
-			<Divider />
-			<AgenticIntelligence />
-			<Divider />
-			<HowItWorks />
-
-			<Divider />
-			<section aria-labelledby="handoff-heading">
-				<ShowcaseHeader
-					id="handoff-heading"
-					eyebrow="Smart handoff"
-					title="Use the right model for each stage"
-					description="Plan, implement, and review with separate provider sessions while carrying forward only the context each one needs."
-				/>
-				<FeaturesSecondary />
-			</section>
 		</div>
 	);
 }

--- a/apps/web/components/landing/workflow-overview.tsx
+++ b/apps/web/components/landing/workflow-overview.tsx
@@ -1,0 +1,73 @@
+import {
+	IconArrowsShuffle,
+	IconGitBranch,
+	IconGitPullRequest,
+} from "@tabler/icons-react";
+
+const steps = [
+	{
+		number: "01",
+		title: "Bring the agents you already use",
+		description:
+			"Connect your existing coding-agent subscriptions and choose the right provider for each session.",
+		icon: IconArrowsShuffle,
+	},
+	{
+		number: "02",
+		title: "Run work in parallel",
+		description:
+			"Give every task its own chat, branch, and git worktree so multiple attempts never overwrite each other.",
+		icon: IconGitBranch,
+	},
+	{
+		number: "03",
+		title: "Carry context, then review",
+		description:
+			"Continue with another agent using the plan, transcript, or files it needs, then inspect the diff before anything ships.",
+		icon: IconGitPullRequest,
+	},
+] as const;
+
+export function WorkflowOverview() {
+	return (
+		<section id="workflow" className="scroll-mt-24 px-4 py-16 md:px-8 md:py-24">
+			<header className="mx-auto max-w-3xl text-center">
+				<p className="text-primary font-mono text-[11px] font-semibold uppercase tracking-[0.18em]">
+					How Zuse works
+				</p>
+				<h2 className="text-heading mt-3 text-3xl font-semibold tracking-tight text-balance md:text-5xl">
+					One repo. Many agents. No lost context.
+				</h2>
+				<p className="text-muted-foreground mx-auto mt-5 max-w-2xl text-base leading-7 text-pretty md:text-lg">
+					Zuse keeps every agent session connected to the code, branch, and
+					review state it belongs to.
+				</p>
+			</header>
+
+			<ol className="border-border bg-border mx-auto mt-12 grid max-w-5xl gap-px overflow-hidden rounded-2xl border md:grid-cols-3">
+				{steps.map((step) => {
+					const Icon = step.icon;
+
+					return (
+						<li key={step.number} className="bg-background p-6 md:p-8">
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground font-mono text-xs">
+									{step.number}
+								</span>
+								<span className="bg-primary/10 text-primary grid size-9 place-items-center rounded-lg">
+									<Icon aria-hidden="true" className="size-4.5" />
+								</span>
+							</div>
+							<h3 className="text-heading mt-8 text-lg font-semibold tracking-tight">
+								{step.title}
+							</h3>
+							<p className="text-muted-foreground mt-3 text-sm leading-6">
+								{step.description}
+							</p>
+						</li>
+					);
+				})}
+			</ol>
+		</section>
+	);
+}

--- a/apps/web/components/navbar.tsx
+++ b/apps/web/components/navbar.tsx
@@ -21,8 +21,9 @@ import { DISCORD_URL, GITHUB_URL } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 const navItems = [
+	{ label: "How it works", href: "/#workflow" },
 	{ label: "Docs", href: "/docs" },
-	{ label: "Waitlist", href: "/#cloud-interest" },
+	{ label: "Cloud", href: "/#cloud-interest" },
 	{ label: "Changelog", href: "/changelog" },
 ];
 

--- a/apps/web/components/tpl/agenforce/components/features/index.tsx
+++ b/apps/web/components/tpl/agenforce/components/features/index.tsx
@@ -14,11 +14,11 @@ export const Features = () => {
 				className="flex xl:flex-row flex-col xl:items-baseline-last justify-between gap-10"
 			>
 				<Heading className="text-center lg:text-left">
-					The best worktree <br /> management, anywhere.
+					Parallel work without <br /> branch chaos.
 				</Heading>
 				<Subheading className="text-center lg:text-left mx-auto lg:mx-0">
-					Every run gets an isolated branch and working tree. See its agent,
-					files, tests, review state, handoff evidence, and cleanup status.
+					Every task gets an isolated branch and working tree. Run several
+					agents at once without mixing their changes together.
 				</Subheading>
 			</div>
 			<div className="grid grid-cols-1 lg:grid-cols-3 gap-4 my-10 md:my-20">

--- a/apps/web/components/tpl/saas/components/features-two/index.tsx
+++ b/apps/web/components/tpl/saas/components/features-two/index.tsx
@@ -16,11 +16,11 @@ export function FeaturesTwo() {
 		<Container className="px-4 py-10 md:py-20 lg:py-28">
 			<div className="mx-auto mb-16 max-w-2xl text-center">
 				<Heading as="h2" className="mb-4">
-					Deploy agents across every platform
+					Keep agent work moving anywhere
 				</Heading>
 				<Subheading className="text-balance">
-					Run agents from desktop today, persistent cloud workspaces in beta,
-					and a mobile companion coming soon.
+					Run agents from your desktop today, keep them working in persistent
+					cloud environments, and follow them from mobile soon.
 				</Subheading>
 			</div>
 

--- a/apps/web/lib/agent-content.test.ts
+++ b/apps/web/lib/agent-content.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { HOME_MARKDOWN, LLMS_TEXT, NOT_FOUND_MARKDOWN } from "./agent-content";
+
+describe("agent-facing content", () => {
+	it("publishes a substantial, structured Markdown homepage", () => {
+		expect(HOME_MARKDOWN.length).toBeGreaterThan(1500);
+		expect(HOME_MARKDOWN).toMatch(/^# Zuse/m);
+		expect(HOME_MARKDOWN).toMatch(/^## How Zuse works/m);
+		expect(HOME_MARKDOWN).toMatch(/^### 1\. Start a task/m);
+		expect(HOME_MARKDOWN).toContain("/developers");
+	});
+
+	it("tells agents when to use Zuse and how to discover its contract", () => {
+		expect(LLMS_TEXT).toMatch(/^## When to use Zuse/m);
+		expect(LLMS_TEXT).toMatch(/^## How agents should interact/m);
+		expect(LLMS_TEXT).toContain("/openapi.json");
+		expect(LLMS_TEXT).toContain("/sitemap.xml");
+	});
+
+	it("gives agents recovery links in a Markdown 404", () => {
+		expect(NOT_FOUND_MARKDOWN).toMatch(/^# 404/m);
+		for (const path of ["/sitemap.xml", "/llms.txt", "/developers"]) {
+			expect(NOT_FOUND_MARKDOWN).toContain(path);
+		}
+	});
+});

--- a/apps/web/lib/agent-content.ts
+++ b/apps/web/lib/agent-content.ts
@@ -1,0 +1,90 @@
+import { siteConfig } from "@/lib/seo";
+
+export const HOME_MARKDOWN = `# Zuse — All your coding agents in one workspace
+
+Zuse is an open-source desktop workspace for running and managing coding agents across real Git repositories. Use Claude Code, Codex, Cursor, Gemini, Grok, OpenCode, and Kiro from one place while keeping conversations, files, terminal output, diffs, checks, and pull-request context attached to the work.
+
+## How Zuse works
+
+### 1. Start a task with the right agent
+
+Open a repository, choose an installed coding agent, and describe the work. Zuse uses the subscriptions and provider tools you already have instead of selling a separate pool of model credits.
+
+### 2. Work safely in parallel
+
+Each task can run in its own Git worktree, so several agents can edit the same repository without sharing an unstable working directory. Zuse keeps every session persistent and makes its branch, changes, commands, permissions, and results visible.
+
+### 3. Review and continue the work
+
+Inspect diffs, terminal output, checks, browser runs, and pull-request state in the same workspace. Continue with another supported agent when a different model is better suited to the next step, without manually reconstructing the repository context.
+
+## Best-fit use cases
+
+- Run multiple coding tasks in parallel without branch collisions.
+- Keep long-running agent sessions organized across repositories.
+- Review what an agent changed before merging it.
+- Move a coding task between supported agent tools while retaining its workspace context.
+- Use local agents today and prepare for remote workflows as Zuse Cloud develops.
+
+## Product availability
+
+The macOS desktop application is available now. Cloud and mobile experiences are under development and should not be treated as generally available.
+
+## Learn more
+
+- [Download Zuse](${siteConfig.url}/download)
+- [Developer resources](${siteConfig.url}/developers)
+- [Documentation](https://docs.zuse.sh)
+- [Source code](https://github.com/swarajbachu/zuse)
+- [Changelog](${siteConfig.url}/changelog)
+- [Machine-readable site guide](${siteConfig.url}/llms.txt)
+- [OpenAPI specification](${siteConfig.url}/openapi.json)
+`;
+
+export const LLMS_TEXT = `# Zuse
+
+> ${siteConfig.description}
+
+Zuse brings supported coding agents into one desktop workspace. It keeps conversations, files, Git worktrees, terminal output, browser results, checks, and pull-request context together. The macOS desktop app is available now; cloud and mobile experiences are still under development.
+
+## When to use Zuse
+
+Use Zuse when a developer needs to run multiple coding-agent tasks in parallel, isolate those tasks in Git worktrees, inspect agent changes before merging, keep long-running sessions organized, or continue repository work with another supported agent. Do not describe Zuse as a model provider, a token reseller, or a fully autonomous hosted software-engineering service.
+
+## How agents should interact
+
+- For a product overview, request the homepage with \`Accept: text/markdown\` or read ${siteConfig.url}/home.md.
+- Use ${siteConfig.url}/developers to discover current developer resources and availability.
+- Read ${siteConfig.url}/openapi.json before calling the public web API.
+- The public web API is currently limited to cloud-waitlist registration. It does not expose desktop sessions, repositories, or provider credentials.
+- Zuse's local MCP integration uses stdio and the installed desktop application; it is not a public hosted HTTP endpoint.
+
+## Primary links
+
+- Website: ${siteConfig.url}
+- Markdown homepage: ${siteConfig.url}/home.md
+- Developer resources: ${siteConfig.url}/developers
+- OpenAPI: ${siteConfig.url}/openapi.json
+- Sitemap: ${siteConfig.url}/sitemap.xml
+- Documentation: https://docs.zuse.sh
+- Source code: https://github.com/swarajbachu/zuse
+- Changelog: ${siteConfig.url}/changelog
+- Download: ${siteConfig.url}/download
+
+## Supported agents
+
+Claude Code, Codex, Cursor, Gemini, Grok, OpenCode, and Kiro.
+`;
+
+export const NOT_FOUND_MARKDOWN = `# 404 — Page not found
+
+The requested Zuse path does not exist.
+
+## Where to look next
+
+- [Site map](${siteConfig.url}/sitemap.xml)
+- [Agent instructions](${siteConfig.url}/llms.txt)
+- [Developer resources](${siteConfig.url}/developers)
+- [Documentation](https://docs.zuse.sh)
+- [Homepage](${siteConfig.url})
+`;

--- a/apps/web/lib/api-error.test.ts
+++ b/apps/web/lib/api-error.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { jsonError } from "./api-error";
+
+describe("jsonError", () => {
+	it("returns an actionable JSON error envelope", async () => {
+		const response = jsonError(
+			404,
+			"NOT_FOUND",
+			"Missing endpoint.",
+			"Read /openapi.json.",
+		);
+
+		expect(response.status).toBe(404);
+		expect(response.headers.get("content-type")).toContain("application/json");
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(await response.json()).toEqual({
+			error: {
+				code: "NOT_FOUND",
+				message: "Missing endpoint.",
+				resolution: "Read /openapi.json.",
+			},
+		});
+	});
+});

--- a/apps/web/lib/api-error.ts
+++ b/apps/web/lib/api-error.ts
@@ -1,0 +1,37 @@
+export type ApiErrorCode =
+	| "INVALID_EMAIL"
+	| "INVALID_JSON"
+	| "METHOD_NOT_ALLOWED"
+	| "NOT_FOUND"
+	| "NOT_ACCEPTABLE"
+	| "SERVICE_UNAVAILABLE"
+	| "UNSUPPORTED_MEDIA_TYPE"
+	| "UPSTREAM_ERROR";
+
+export type ApiErrorBody = {
+	error: {
+		code: ApiErrorCode;
+		message: string;
+		resolution: string;
+	};
+};
+
+export const jsonError = (
+	status: number,
+	code: ApiErrorCode,
+	message: string,
+	resolution: string,
+	headers?: HeadersInit,
+) =>
+	Response.json(
+		{
+			error: { code, message, resolution },
+		} satisfies ApiErrorBody,
+		{
+			status,
+			headers: {
+				"Cache-Control": "no-store",
+				...headers,
+			},
+		},
+	);

--- a/apps/web/lib/api-method.ts
+++ b/apps/web/lib/api-method.ts
@@ -1,0 +1,21 @@
+import { jsonError } from "@/lib/api-error";
+
+export const methodNotAllowed = (allowedMethods: readonly string[]) =>
+	jsonError(
+		405,
+		"METHOD_NOT_ALLOWED",
+		"This API endpoint does not support the requested HTTP method.",
+		`Use one of the supported methods: ${allowedMethods.join(", ")}.`,
+		{ Allow: allowedMethods.join(", ") },
+	);
+
+export const preflightResponse = (allowedMethods: readonly string[]) =>
+	new Response(null, {
+		status: 204,
+		headers: {
+			Allow: allowedMethods.join(", "),
+			"Access-Control-Allow-Headers": "Content-Type",
+			"Access-Control-Allow-Methods": allowedMethods.join(", "),
+			"Access-Control-Allow-Origin": "*",
+		},
+	});

--- a/apps/web/lib/content-negotiation.test.ts
+++ b/apps/web/lib/content-negotiation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { appendVary, negotiateContent } from "./content-negotiation";
+
+describe("negotiateContent", () => {
+	it.each([
+		[null, "html"],
+		["", "html"],
+		["*/*", "html"],
+		["text/html", "html"],
+		["text/markdown", "markdown"],
+		["text/markdown, text/html;q=0.8", "markdown"],
+		["text/markdown;q=0.5, text/html;q=0.9", "html"],
+		["text/*;q=0.7, text/markdown;q=0.9", "markdown"],
+		["text/markdown;q=0, */*;q=1", "html"],
+		["application/xml", "unsupported"],
+	] as const)("negotiates %s as %s", (accept, expected) => {
+		expect(negotiateContent(accept)).toBe(expected);
+	});
+});
+
+describe("appendVary", () => {
+	it("merges values without duplicating header names", () => {
+		expect(appendVary("RSC, Accept", "accept")).toBe("RSC, Accept");
+		expect(appendVary(null, "Accept")).toBe("Accept");
+	});
+});

--- a/apps/web/lib/content-negotiation.ts
+++ b/apps/web/lib/content-negotiation.ts
@@ -1,0 +1,120 @@
+export type ContentRepresentation = "html" | "markdown" | "unsupported";
+
+type MediaRange = {
+	type: string;
+	subtype: string;
+	quality: number;
+	index: number;
+};
+
+type Match = {
+	quality: number;
+	specificity: number;
+	index: number;
+};
+
+const parseAccept = (accept: string): MediaRange[] =>
+	accept
+		.split(",")
+		.map((part, index) => {
+			const [mediaType = "", ...parameters] = part
+				.trim()
+				.toLowerCase()
+				.split(";");
+			const [type = "", subtype = ""] = mediaType.trim().split("/");
+			const qualityParameter = parameters
+				.map((parameter) => parameter.trim())
+				.find((parameter) => parameter.startsWith("q="));
+			const parsedQuality = qualityParameter
+				? Number.parseFloat(qualityParameter.slice(2))
+				: 1;
+
+			return {
+				type,
+				subtype,
+				quality:
+					Number.isFinite(parsedQuality) &&
+					parsedQuality >= 0 &&
+					parsedQuality <= 1
+						? parsedQuality
+						: 0,
+				index,
+			};
+		})
+		.filter((range) => range.type && range.subtype);
+
+const bestMatch = (
+	ranges: MediaRange[],
+	type: string,
+	subtype: string,
+): Match | undefined => {
+	let best: Match | undefined;
+
+	for (const range of ranges) {
+		if (range.type !== "*" && range.type !== type) continue;
+		if (range.subtype !== "*" && range.subtype !== subtype) continue;
+
+		const specificity = range.type === "*" ? 0 : range.subtype === "*" ? 1 : 2;
+		const candidate = {
+			quality: range.quality,
+			specificity,
+			index: range.index,
+		};
+
+		if (
+			!best ||
+			candidate.specificity > best.specificity ||
+			(candidate.specificity === best.specificity &&
+				candidate.quality > best.quality) ||
+			(candidate.specificity === best.specificity &&
+				candidate.quality === best.quality &&
+				candidate.index < best.index)
+		) {
+			best = candidate;
+		}
+	}
+
+	return best;
+};
+
+export const negotiateContent = (
+	acceptHeader: string | null,
+): ContentRepresentation => {
+	if (!acceptHeader?.trim()) return "html";
+
+	const ranges = parseAccept(acceptHeader);
+	const htmlMatch = bestMatch(ranges, "text", "html");
+	const markdownMatch = bestMatch(ranges, "text", "markdown");
+	const html = htmlMatch?.quality === 0 ? undefined : htmlMatch;
+	const markdown = markdownMatch?.quality === 0 ? undefined : markdownMatch;
+
+	if (!html && !markdown) return "unsupported";
+	if (!markdown) return "html";
+	if (!html) return "markdown";
+
+	if (markdown.quality !== html.quality) {
+		return markdown.quality > html.quality ? "markdown" : "html";
+	}
+	if (markdown.specificity !== html.specificity) {
+		return markdown.specificity > html.specificity ? "markdown" : "html";
+	}
+
+	// Wildcards match both representations equally, so keep the web default.
+	return markdown.index < html.index && markdown.specificity > 0
+		? "markdown"
+		: "html";
+};
+
+export const appendVary = (
+	currentValue: string | null,
+	value: string,
+): string => {
+	const values = new Map<string, string>();
+	for (const item of [...(currentValue?.split(",") ?? []), value]) {
+		const trimmed = item.trim();
+		if (trimmed && !values.has(trimmed.toLowerCase())) {
+			values.set(trimmed.toLowerCase(), trimmed);
+		}
+	}
+	return [...values.values()].join(", ");
+};

--- a/apps/web/lib/openapi.test.ts
+++ b/apps/web/lib/openapi.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { openApiDocument } from "./openapi";
+
+describe("Zuse OpenAPI document", () => {
+	it("uses OpenAPI 3.1 and documents the public waitlist operation", () => {
+		expect(openApiDocument.openapi).toBe("3.1.0");
+		const operation = openApiDocument.paths["/api/waitlist"].post;
+		expect(operation.operationId).toBe("registerCloudWaitlistInterest");
+		expect(operation.description.length).toBeGreaterThan(40);
+		expect(operation.requestBody.required).toBe(true);
+		expect(operation.responses["200"].description).toBeTruthy();
+		expect(operation.responses["400"].description).toBeTruthy();
+	});
+
+	it("defines typed request, success, and actionable error schemas", () => {
+		const { schemas } = openApiDocument.components;
+		expect(schemas.WaitlistRequest.properties.email).toMatchObject({
+			type: "string",
+			format: "email",
+			maxLength: 254,
+		});
+		expect(schemas.WaitlistSuccess.properties.ok).toMatchObject({
+			type: "boolean",
+			const: true,
+		});
+		expect(schemas.ErrorDetail.required).toEqual([
+			"code",
+			"message",
+			"resolution",
+		]);
+	});
+
+	it("keeps every operation id unique and every operation described", () => {
+		const operations = Object.values(openApiDocument.paths).flatMap((path) =>
+			Object.values(path),
+		);
+		const operationIds = operations.map((operation) => operation.operationId);
+		expect(new Set(operationIds).size).toBe(operationIds.length);
+		for (const operation of operations) {
+			expect(operation.description).toBeTruthy();
+		}
+	});
+});

--- a/apps/web/lib/openapi.ts
+++ b/apps/web/lib/openapi.ts
@@ -1,0 +1,122 @@
+import { siteConfig } from "@/lib/seo";
+
+const errorResponse = (description: string) => ({
+	description,
+	content: {
+		"application/json": {
+			schema: { $ref: "#/components/schemas/ErrorResponse" },
+		},
+	},
+});
+
+export const openApiDocument = {
+	openapi: "3.1.0",
+	info: {
+		title: "Zuse Public Web API",
+		version: "1.0.0",
+		description:
+			"The machine-readable contract for Zuse's public website API. The current API only registers interest in Zuse Cloud; desktop sessions and provider credentials are not exposed over this API.",
+	},
+	servers: [{ url: siteConfig.url, description: "Zuse website" }],
+	paths: {
+		"/api/waitlist": {
+			post: {
+				operationId: "registerCloudWaitlistInterest",
+				summary: "Register interest in Zuse Cloud",
+				description:
+					"Submits an email address for Zuse Cloud beta updates. This endpoint does not create an account or grant product access.",
+				requestBody: {
+					required: true,
+					description: "The email address to register.",
+					content: {
+						"application/json": {
+							schema: { $ref: "#/components/schemas/WaitlistRequest" },
+						},
+					},
+				},
+				responses: {
+					"200": {
+						description: "The email address was registered successfully.",
+						content: {
+							"application/json": {
+								schema: { $ref: "#/components/schemas/WaitlistSuccess" },
+							},
+						},
+					},
+					"400": errorResponse(
+						"The request body is invalid JSON or contains an invalid email address.",
+					),
+					"415": errorResponse(
+						"The request does not use the application/json media type.",
+					),
+					"502": errorResponse(
+						"The configured waitlist service rejected or could not receive the signup.",
+					),
+					"503": errorResponse(
+						"Waitlist registration is temporarily unavailable.",
+					),
+				},
+			},
+		},
+	},
+	components: {
+		schemas: {
+			WaitlistRequest: {
+				type: "object",
+				description: "A request to receive Zuse Cloud beta updates.",
+				additionalProperties: false,
+				required: ["email"],
+				properties: {
+					email: {
+						type: "string",
+						format: "email",
+						maxLength: 254,
+						description: "The email address to register.",
+					},
+				},
+			},
+			WaitlistSuccess: {
+				type: "object",
+				description: "Confirms that the signup was accepted.",
+				additionalProperties: false,
+				required: ["ok"],
+				properties: {
+					ok: {
+						type: "boolean",
+						const: true,
+						description: "Always true when registration succeeds.",
+					},
+				},
+			},
+			ErrorDetail: {
+				type: "object",
+				description: "A structured, actionable API error.",
+				additionalProperties: false,
+				required: ["code", "message", "resolution"],
+				properties: {
+					code: {
+						type: "string",
+						description: "A stable, machine-readable error identifier.",
+					},
+					message: {
+						type: "string",
+						description: "A concise explanation of the error.",
+					},
+					resolution: {
+						type: "string",
+						description: "The action a caller can take to resolve the error.",
+					},
+				},
+			},
+			ErrorResponse: {
+				type: "object",
+				description: "The error envelope returned by the Zuse public web API.",
+				additionalProperties: false,
+				required: ["error"],
+				properties: {
+					error: { $ref: "#/components/schemas/ErrorDetail" },
+				},
+			},
+		},
+	},
+} as const;

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -13,7 +13,7 @@ export const DISCORD_URL = "https://discord.gg/cvGpmMGd5";
 export const DOWNLOAD_URL = "/download";
 
 export const TAGLINE =
-	"The open-source autonomous coding workspace for local and cloud agents.";
+	"All your coding agents in one workspace, with isolated tasks and shared context.";
 
 // The coding agents Zuse wraps. Used by the agent strip.
 export const AGENTS = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
 		"start": "next start --port 3001",
 		"lint": "eslint",
 		"content:generate": "fumadocs-mdx",
-		"check-types": "bun run content:generate && tsc --noEmit"
+		"check-types": "bun run content:generate && tsc --noEmit",
+		"test": "vitest run",
+		"test:unit": "vitest run"
 	},
 	"dependencies": {
 		"@repo/ui": "workspace:*",
@@ -41,6 +43,7 @@
 		"eslint-config-next": "16.0.3",
 		"prettier-plugin-tailwindcss": "^0.7.2",
 		"tailwindcss": "^4",
-		"typescript": "^5"
+		"typescript": "^5",
+		"vitest": "catalog:"
 	}
 }

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { proxy } from "./proxy";
+
+const makeRequest = (path: string, accept?: string) =>
+	new NextRequest(`https://zuse.sh${path}`, {
+		headers: accept ? { Accept: accept } : undefined,
+	});
+
+describe("proxy", () => {
+	it("serves the homepage Markdown representation at the same URL", () => {
+		const response = proxy(makeRequest("/", "text/markdown"));
+		expect(response.status).toBe(200);
+		expect(response.headers.get("x-middleware-rewrite")).toBe(
+			"https://zuse.sh/home.md",
+		);
+		expect(response.headers.get("vary")).toContain("Accept");
+		expect(response.headers.get("link")).toContain("text/markdown");
+	});
+
+	it("keeps HTML as the browser default and marks the cache variant", () => {
+		const response = proxy(makeRequest("/", "text/html, */*;q=0.8"));
+		expect(response.status).toBe(200);
+		expect(response.headers.get("x-middleware-next")).toBe("1");
+		expect(response.headers.get("vary")).toBe("Accept, Accept-Encoding");
+	});
+
+	it("returns a structured 406 for unsupported homepage media types", async () => {
+		const response = proxy(makeRequest("/", "application/xml"));
+		expect(response.status).toBe(406);
+		expect(await response.json()).toMatchObject({
+			error: { code: "NOT_ACCEPTABLE", resolution: expect.any(String) },
+		});
+	});
+
+	it("returns a recoverable Markdown 404 for unknown paths", async () => {
+		const response = proxy(
+			makeRequest("/path-that-does-not-exist", "text/markdown"),
+		);
+		expect(response.status).toBe(404);
+		expect(response.headers.get("content-type")).toContain("text/markdown");
+		expect(await response.text()).toContain("/sitemap.xml");
+	});
+
+	it("returns structured JSON for unknown API routes", async () => {
+		const response = proxy(makeRequest("/api/path-that-does-not-exist"));
+		expect(response.status).toBe(404);
+		expect(response.headers.get("content-type")).toContain("application/json");
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: "NOT_FOUND",
+				resolution: expect.stringContaining("openapi"),
+			},
+		});
+	});
+
+	it("allows the documentation root to reach its configured redirect", () => {
+		const response = proxy(makeRequest("/docs", "text/markdown"));
+		expect(response.status).toBe(200);
+		expect(response.headers.get("x-middleware-next")).toBe("1");
+	});
+});

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,111 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { NOT_FOUND_MARKDOWN } from "@/lib/agent-content";
+import { jsonError } from "@/lib/api-error";
+import { appendVary, negotiateContent } from "@/lib/content-negotiation";
+
+const MARKDOWN_ALTERNATE = '</home.md>; rel="alternate"; type="text/markdown"';
+
+const knownPage = (pathname: string) =>
+	pathname === "/" ||
+	pathname === "/blog" ||
+	pathname.startsWith("/blog/") ||
+	pathname === "/changelog" ||
+	pathname === "/developers" ||
+	pathname === "/privacy" ||
+	pathname === "/docs" ||
+	pathname.startsWith("/docs/");
+
+const publicMachineRoute = (pathname: string) =>
+	pathname === "/download" ||
+	pathname === "/home.md" ||
+	pathname === "/llms.txt" ||
+	pathname === "/manifest.webmanifest" ||
+	pathname === "/openapi.json" ||
+	pathname === "/robots.txt" ||
+	pathname === "/sitemap.xml";
+
+const publicApiRoute = (pathname: string) =>
+	pathname === "/api/openapi.json" || pathname === "/api/waitlist";
+
+const withNegotiationHeaders = (response: NextResponse) => {
+	response.headers.set(
+		"Vary",
+		appendVary(response.headers.get("Vary"), "Accept"),
+	);
+	response.headers.set(
+		"Vary",
+		appendVary(response.headers.get("Vary"), "Accept-Encoding"),
+	);
+	response.headers.set("Link", MARKDOWN_ALTERNATE);
+	return response;
+};
+
+export function proxy(request: NextRequest) {
+	const { pathname } = request.nextUrl;
+
+	if (pathname.startsWith("/api/") && !publicApiRoute(pathname)) {
+		return jsonError(
+			404,
+			"NOT_FOUND",
+			"The requested Zuse API endpoint does not exist.",
+			"Read /openapi.json for the complete public API surface.",
+		);
+	}
+
+	if (
+		pathname === "/" &&
+		(request.method === "GET" || request.method === "HEAD")
+	) {
+		const representation = negotiateContent(request.headers.get("accept"));
+
+		if (representation === "markdown") {
+			return withNegotiationHeaders(
+				NextResponse.rewrite(new URL("/home.md", request.url)),
+			);
+		}
+		if (representation === "unsupported") {
+			const response = jsonError(
+				406,
+				"NOT_ACCEPTABLE",
+				"The homepage is available as HTML or Markdown.",
+				"Send Accept: text/html or Accept: text/markdown.",
+				{ Vary: "Accept, Accept-Encoding", Link: MARKDOWN_ALTERNATE },
+			);
+			return response;
+		}
+
+		return withNegotiationHeaders(NextResponse.next());
+	}
+
+	const isKnownRoute =
+		knownPage(pathname) ||
+		publicMachineRoute(pathname) ||
+		publicApiRoute(pathname) ||
+		pathname.startsWith("/_next/") ||
+		pathname === "/favicon.ico" ||
+		pathname === "/icon.png" ||
+		pathname === "/apple-icon.png" ||
+		pathname === "/og.png" ||
+		pathname === "/app-icon.png";
+
+	if (
+		!isKnownRoute &&
+		(request.method === "GET" || request.method === "HEAD") &&
+		negotiateContent(request.headers.get("accept")) === "markdown"
+	) {
+		return new Response(NOT_FOUND_MARKDOWN, {
+			status: 404,
+			headers: {
+				"Cache-Control": "no-store",
+				"Content-Type": "text/markdown; charset=utf-8",
+				Vary: "Accept, Accept-Encoding",
+			},
+		});
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	matcher: "/:path*",
+};

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			"@": fileURLToPath(new URL(".", import.meta.url)),
+		},
+	},
+});

--- a/bun.lock
+++ b/bun.lock
@@ -327,6 +327,7 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4",
         "typescript": "^5",
+        "vitest": "catalog:",
       },
     },
     "infra/relay": {


### PR DESCRIPTION
## Summary

- Clarify the homepage around one workspace, parallel worktrees, agent handoff, review, and a simpler three-step workflow.
- Publish a substantial Markdown homepage through `Accept: text/markdown`, expanded `llms.txt` guidance, real HTML and Markdown 404 recovery, and a branded developer-resource index.
- Publish an OpenAPI 3.1 contract at `/openapi.json` and `/api/openapi.json` with typed schemas and unique operation IDs.
- Return structured JSON API errors with stable codes, messages, and resolution hints, including unsupported methods and unknown API routes.
- Add sitemap/footer discovery and cache-safe Markdown negotiation headers.

## Test Coverage

- 44 web tests pass across content negotiation, proxy routing, API errors, waitlist behavior, machine-readable routes, OpenAPI schemas, and recovery content.
- Optimized local runtime was also verified with raw HTTP requests for HTML, Markdown, 404s, OpenAPI, developer resources, unsupported representations, and API error envelopes.
- Remaining recommendation: add a durable production-server integration suite for composed Next routing and final response headers.

## Pre-Landing Review

- Fixed exact media-type parsing for JSON requests.
- Fixed `/docs` so Markdown requests still reach the configured documentation redirect.
- Fixed unsupported API methods so known endpoints return structured JSON rather than empty framework responses.
- No unresolved critical code findings.

## Design Review

- Landing changes preserve the existing visual system and replace dense feature detail with a clearer workflow narrative.
- Desktop and mobile layouts were previously checked locally; no new visual infrastructure was introduced.

## Scope

The official hosted readiness report remains 61/100 until this branch is deployed and rescanned. Brand search visibility, apex-versus-www canonicalization, and external indexing still require deployment or product decisions.

## Verification

- [x] `bun install --frozen-lockfile`
- [x] `bun --filter web test` — 44 passed
- [x] `bun --filter web check-types`
- [x] Biome check on all changed files
- [x] `bun --filter web build`
- [x] `git diff --check origin/main`
