### PR TITLE
Release v0.20.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.8]
+
+### Changed
+- The Zuse website now explains the agent workflow more clearly and publishes machine-readable product and API contracts for automated clients
+
+### Fixed
+- Desktop updates now open reliably instead of remaining on the startup screen. The loader now covers genuine settings readiness while the full application stays code-split for fast, budget-compliant startup
+
 ## [0.20.7]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.7",
+	"version": "0.20.8",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -17,10 +17,6 @@ import {
 	usePanelRef,
 } from "react-resizable-panels";
 import { PendingChatCreationSurface } from "./components/pending-chat-creation.tsx";
-import {
-	StartupSurface,
-	startupPresentation,
-} from "./components/startup-surface.tsx";
 import { TooltipProvider } from "./components/ui/tooltip.tsx";
 import { useChatDirectoryStatus } from "./hooks/use-chat-directory-status.ts";
 import { useKeybindingDispatch } from "./hooks/use-keybinding-dispatch.ts";
@@ -301,45 +297,18 @@ function AmbientSurfaces() {
 		</Suspense>
 	);
 }
-export function App() {
-	const settings = useSettingsStore((state) => ({
-		error: state.error,
-		loaded: state.loaded,
-		onboardingCompleted: state.onboardingCompleted,
-		origin: state.origin,
-		phase: state.phase,
-		retry: state.retry,
-	}));
-	useEffect(() => {
-		if (settings.phase === "synchronizing" || settings.phase === "live") {
-			markRendererStartupMilestone("rpc-connected");
-		}
-		if (!settings.loaded) return;
-		markRendererStartupMilestone(
-			settings.origin === "cache" ? "settings-cache-hydrated" : "settings-live",
-		);
-	}, [settings.loaded, settings.origin, settings.phase]);
-	const presentation = startupPresentation(settings);
-	if (presentation !== "ready") {
-		return (
-			<>
-				<AppearanceController />
-				<StartupSurface
-					error={settings.error}
-					phase={settings.phase}
-					onRetry={settings.retry}
-				/>
-			</>
-		);
-	}
-	return <ReadyApp onboardingCompleted={settings.onboardingCompleted} />;
-}
-
 /**
  * Owns cross-cutting concerns only after settings are available. Deferring
  * these subscriptions keeps the startup surface cheap and prevents fallback
  * settings from being observed as real product state.
  */
+export function App() {
+	const onboardingCompleted = useSettingsStore(
+		(state) => state.onboardingCompleted,
+	);
+	return <ReadyApp onboardingCompleted={onboardingCompleted} />;
+}
+
 function ReadyApp({
 	onboardingCompleted,
 }: {

--- a/apps/renderer/src/application-bootstrap.tsx
+++ b/apps/renderer/src/application-bootstrap.tsx
@@ -1,9 +1,9 @@
 import { lazy, Suspense } from "react";
 import { StartupSurface } from "./components/startup-surface.tsx";
 
-const Application = lazy(() =>
-	import("./application.tsx").then((module) => ({
-		default: module.Application,
+const StartupApplication = lazy(() =>
+	import("./startup-application.tsx").then((module) => ({
+		default: module.StartupApplication,
 	})),
 );
 
@@ -16,7 +16,7 @@ export function ApplicationBootstrapFallback() {
 export function ApplicationBootstrap() {
 	return (
 		<Suspense fallback={<ApplicationBootstrapFallback />}>
-			<Application />
+			<StartupApplication />
 		</Suspense>
 	);
 }

--- a/apps/renderer/src/startup-application.tsx
+++ b/apps/renderer/src/startup-application.tsx
@@ -1,0 +1,60 @@
+import { lazy, Suspense, useEffect } from "react";
+import {
+	StartupSurface,
+	startupPresentation,
+} from "./components/startup-surface.tsx";
+import { AppearanceController } from "./lib/appearance.tsx";
+import { markRendererStartupMilestone } from "./lib/performance-marks.ts";
+import { useSettingsStore } from "./lib/settings-client-bus.ts";
+
+const Application = lazy(() =>
+	import("./application.tsx").then((module) => ({
+		default: module.Application,
+	})),
+);
+
+export function StartupApplication() {
+	const settings = useSettingsStore((state) => ({
+		error: state.error,
+		loaded: state.loaded,
+		origin: state.origin,
+		phase: state.phase,
+		retry: state.retry,
+	}));
+	useEffect(() => {
+		if (settings.phase === "synchronizing" || settings.phase === "live") {
+			markRendererStartupMilestone("rpc-connected");
+		}
+		if (!settings.loaded) return;
+		markRendererStartupMilestone(
+			settings.origin === "cache" ? "settings-cache-hydrated" : "settings-live",
+		);
+	}, [settings.loaded, settings.origin, settings.phase]);
+
+	if (startupPresentation(settings) !== "ready") {
+		return (
+			<>
+				<AppearanceController />
+				<StartupSurface
+					error={settings.error}
+					phase={settings.phase}
+					onRetry={settings.retry}
+				/>
+			</>
+		);
+	}
+
+	return (
+		<Suspense
+			fallback={
+				<StartupSurface
+					error={null}
+					phase="initial-loading"
+					onRetry={settings.retry}
+				/>
+			}
+		>
+			<Application />
+		</Suspense>
+	);
+}

--- a/apps/renderer/test/unit/application-bootstrap.test.tsx
+++ b/apps/renderer/test/unit/application-bootstrap.test.tsx
@@ -1,15 +1,32 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { ApplicationBootstrapFallback } from "../../src/application-bootstrap.tsx";
+const { useSettingsStore } = vi.hoisted(() => ({
+	useSettingsStore: vi.fn(
+		(selector: (state: Record<string, unknown>) => unknown) =>
+			selector({
+				error: null,
+				loaded: false,
+				onboardingCompleted: false,
+				origin: "none",
+				phase: "initial-loading",
+				retry: vi.fn(),
+			}),
+	),
+}));
+
+vi.mock("../../src/lib/settings-client-bus.ts", () => ({ useSettingsStore }));
+vi.mock("../../src/lib/appearance.tsx", () => ({
+	AppearanceController: () => null,
+}));
+
+import { StartupApplication } from "../../src/startup-application.tsx";
 
 describe("application bootstrap", () => {
-	it("reserves the full application viewport while the runtime loads", () => {
-		const markup = renderToStaticMarkup(<ApplicationBootstrapFallback />);
+	it("mounts settings readiness before the full application chunk", () => {
+		const markup = renderToStaticMarkup(<StartupApplication />);
 
-		expect(markup).toContain('aria-busy="true"');
+		expect(useSettingsStore).toHaveBeenCalledOnce();
 		expect(markup).toContain('aria-label="Loading Zuse"');
-		expect(markup).toContain("h-dvh");
-		expect(markup).toContain("w-screen");
 	});
 });

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "0.20.8",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "The Zuse website now explains the agent workflow more clearly and publishes machine-readable product and API contracts for automated clients"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Desktop updates now open reliably instead of remaining on the startup screen. The loader now covers genuine settings readiness while the full application stays code-split for fast, budget-compliant startup"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.7",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.7",
+      "version": "0.20.8",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/scripts/check-renderer-bundle.mjs
+++ b/scripts/check-renderer-bundle.mjs
@@ -27,6 +27,19 @@ const manifest = JSON.parse(
 	readFileSync(resolve(dist, ".vite/manifest.json"), "utf8"),
 );
 const assets = collectEntryAssets(manifest, "index.html");
+const startupAssets = collectRouteAssets(
+	manifest,
+	"index.html",
+	"src/startup-application.tsx",
+);
+const hasStartupSettings = startupAssets.some((asset) =>
+	asset.includes("settings-client-bus-"),
+);
+if (!hasStartupSettings) {
+	throw new Error(
+		"Renderer startup chunk must include settings readiness before loading the full application; otherwise packaged builds can remain stuck before opening RPC.",
+	);
+}
 const defaultRouteAssets = collectRouteAssets(
 	manifest,
 	"index.html",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.8 with release notes grouped by user-visible outcome.

### Changed
- The Zuse website now explains the agent workflow more clearly and publishes machine-readable product and API contracts for automated clients

### Fixed
- Desktop updates now open reliably instead of remaining on the startup screen. The loader now covers genuine settings readiness while the full application stays code-split for fast, budget-compliant startup

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.20.8 after this PR lands.
