### PR TITLE
fix: restore OpenCode provider inventory

### DIFF
--- a/apps/renderer/src/components/opencode-provider-manager.tsx
+++ b/apps/renderer/src/components/opencode-provider-manager.tsx
@@ -2,6 +2,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import type { OpencodeInventoryProvider } from "@zuse/contracts";
 import {
 	Add01Icon,
+	AlertCircleIcon,
 	ArrowUpRight01Icon,
 	Cancel01Icon,
 	CheckmarkCircle02Icon,
@@ -59,6 +60,7 @@ import {
 export function OpencodeProviderManager() {
 	const inventory = useOpencodeInventory((s) => s.inventory);
 	const invLoading = useOpencodeInventory((s) => s.loading);
+	const invError = useOpencodeInventory((s) => s.error);
 	const ensureLoaded = useOpencodeInventory((s) => s.ensureLoaded);
 	const refreshInventory = useOpencodeInventory((s) => s.refresh);
 
@@ -80,6 +82,7 @@ export function OpencodeProviderManager() {
 				connected={connected}
 				loading={invLoading}
 				loaded={inventory !== null}
+				error={invError}
 				onRefresh={refresh}
 			/>
 			{connected.length > 0 && (
@@ -173,12 +176,14 @@ function ProvidersSection({
 	connected,
 	loading,
 	loaded,
+	error,
 	onRefresh,
 }: {
 	providers: ReadonlyArray<OpencodeInventoryProvider>;
 	connected: ReadonlyArray<OpencodeInventoryProvider>;
 	loading: boolean;
 	loaded: boolean;
+	error: string | null;
 	onRefresh: () => void;
 }) {
 	return (
@@ -188,9 +193,11 @@ function ProvidersSection({
 					<span className="text-xs font-semibold text-foreground">
 						Providers
 					</span>
-					<span className="text-[11px] text-muted-foreground/70">
-						{connected.length} configured
-					</span>
+					{loaded && (
+						<span className="text-[11px] text-muted-foreground/70">
+							{connected.length} configured
+						</span>
+					)}
 				</div>
 				<button
 					type="button"
@@ -207,7 +214,26 @@ function ProvidersSection({
 				</button>
 			</div>
 
-			{!loaded ? (
+			{!loaded && error !== null && !loading ? (
+				<div className="flex flex-col gap-2 rounded-lg border border-border/50 bg-background/40 px-3 py-3">
+					<div className="flex items-start gap-2 text-xs text-muted-foreground">
+						<HugeiconsIcon
+							icon={AlertCircleIcon}
+							className="mt-0.5 size-3.5 shrink-0"
+							aria-hidden
+						/>
+						<span className="min-w-0 leading-snug">{error}</span>
+					</div>
+					<Button
+						size="xs"
+						variant="outline"
+						className="self-start"
+						onClick={onRefresh}
+					>
+						Retry
+					</Button>
+				</div>
+			) : !loaded ? (
 				<div className="flex items-center gap-2 rounded-lg border border-border/50 bg-background/40 px-3 py-3 text-xs text-muted-foreground">
 					<HugeiconsIcon
 						icon={Loading02Icon}

--- a/apps/server/src/provider/availability.ts
+++ b/apps/server/src/provider/availability.ts
@@ -217,6 +217,27 @@ export const selectNewestCliPathCandidate = (
 };
 
 /**
+ * Install locations `which -a` can miss. GUI apps inherit a login PATH that
+ * often omits native-installer dirs; OpenCode's official installer drops the
+ * binary at `~/.opencode/bin/opencode`.
+ */
+export const extraWellKnownCliPaths = (
+  cliBinary: string,
+): ReadonlyArray<string> => {
+  if (cliBinary === "opencode") {
+    return [join(homedir(), ".opencode", "bin", "opencode")];
+  }
+  return [];
+};
+
+/**
+ * Codex has a managed-shim collision; OpenCode has a Homebrew formula that
+ * ships a different `opencode` binary (0.0.x, no `serve`) earlier on PATH
+ * than the native 1.x install. Both need newest-version selection.
+ */
+const CLI_BINARIES_SELECT_NEWEST = new Set(["codex", "opencode"]);
+
+/**
  * Resolve the absolute path to a provider's CLI binary on PATH, or `null` if
  * not found. Used by `ProviderService.start` to feed the SDK's
  * `pathToClaudeCodeExecutable` option (the SDK ships its own bundled CLI as
@@ -232,14 +253,26 @@ export const resolveCliPath = (
       Effect.timeoutOption(PROBE_TIMEOUT),
       Effect.catch(() => Effect.succeedNone),
     );
-    if (result._tag !== "Some" || result.value.exitCode !== 0) return null;
-    const candidates = splitCommandPaths(result.value.stdout);
-    if (cliBinary !== "codex") {
+    const fromWhich =
+      result._tag === "Some" && result.value.exitCode === 0
+        ? splitCommandPaths(result.value.stdout)
+        : [];
+    const candidates = [
+      ...new Set([...fromWhich, ...extraWellKnownCliPaths(cliBinary)]),
+    ];
+    if (candidates.length === 0) return null;
+    if (!CLI_BINARIES_SELECT_NEWEST.has(cliBinary)) {
       return selectCliPathCandidate(cliBinary, candidates);
     }
-    const eligible = [...new Set(candidates)].filter(
-      (candidate) => !isManagedCodexShimPath(normalizeCommandPath(candidate)),
-    );
+
+    const fromWhichSet = new Set(fromWhich);
+    const eligible =
+      cliBinary === "codex"
+        ? candidates.filter(
+            (candidate) =>
+              !isManagedCodexShimPath(normalizeCommandPath(candidate)),
+          )
+        : candidates;
     const versioned = yield* Effect.forEach(
       eligible,
       (path) =>
@@ -248,7 +281,12 @@ export const resolveCliPath = (
         ),
       { concurrency: "unbounded" },
     );
-    return selectNewestCliPathCandidate(versioned);
+    // Well-known extras that aren't on PATH and don't actually run are noise.
+    const usable = versioned.filter(
+      (candidate) =>
+        candidate.version !== null || fromWhichSet.has(candidate.path),
+    );
+    return selectNewestCliPathCandidate(usable);
   });
 
 export interface CliVersion {
@@ -1023,14 +1061,12 @@ const probeKiroAccount: Effect.Effect<
   return { authStatus: "unauthenticated" } satisfies AccountInfo;
 });
 
-// OpenCode stores per-provider credentials in `~/.local/share/opencode/auth.json`
-// after `opencode auth login <provider>`. Each top-level key is a provider id
-// (anthropic, openai, …) and the value carries the access token or API key.
-// We treat a non-empty file with at least one entry as "authenticated"; the
-// renderer then surfaces "Connected to N providers" once we wire the
-// dynamic inventory in. Falling back to the directory presence check
-// matches the Gemini/Cursor pattern when the file is missing but the CLI
-// has been installed.
+// OpenCode stores per-provider credentials in `$XDG_DATA_HOME/opencode/auth.json`
+// (default `~/.local/share/opencode/auth.json`) after `opencode auth login`.
+// Each top-level key is a provider id (anthropic, openai, …) and the value
+// carries the access token or API key. We treat a non-empty file with at
+// least one entry as "authenticated"; the renderer then surfaces
+// "Connected to N providers" once we wire the dynamic inventory in.
 interface OpencodeAuthBlob {
   readonly [providerId: string]: unknown;
 }
@@ -1064,7 +1100,10 @@ const probeOpencodeAccount: Effect.Effect<
   FileSystem.FileSystem
 > = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
-  const authPath = join(homedir(), ".local", "share", "opencode", "auth.json");
+  const xdg = process.env.XDG_DATA_HOME?.trim();
+  const dataHome =
+    xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share");
+  const authPath = join(dataHome, "opencode", "auth.json");
   const exists = yield* fs
     .exists(authPath)
     .pipe(Effect.catch(() => Effect.succeed(false)));

--- a/apps/server/test/unit/availability.test.ts
+++ b/apps/server/test/unit/availability.test.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -5,6 +7,7 @@ import {
 	claudeAuthTestHelpers,
 	compareCliVersion,
 	deriveLatestAdvisory,
+	extraWellKnownCliPaths,
 	grokAuthTestHelpers,
 	MIN_CODEX_CLI_VERSION,
 	MIN_GROK_CLI_VERSION,
@@ -371,6 +374,34 @@ describe("selectNewestCliPathCandidate", () => {
 				{ path: "/second/codex", version: null },
 			]),
 		).toBe("/first/codex");
+	});
+
+	it("selects a current OpenCode binary over a colliding older PATH hit", () => {
+		expect(
+			selectNewestCliPathCandidate([
+				{
+					path: "/opt/homebrew/bin/opencode",
+					version: parseCliVersion("0.0.55"),
+				},
+				{
+					path: "/Users/me/.opencode/bin/opencode",
+					version: parseCliVersion("1.18.19"),
+				},
+			]),
+		).toBe("/Users/me/.opencode/bin/opencode");
+	});
+});
+
+describe("extraWellKnownCliPaths", () => {
+	it("adds OpenCode's native installer location", () => {
+		expect(extraWellKnownCliPaths("opencode")).toEqual([
+			join(homedir(), ".opencode", "bin", "opencode"),
+		]);
+	});
+
+	it("does not invent extra paths for other CLIs", () => {
+		expect(extraWellKnownCliPaths("claude")).toEqual([]);
+		expect(extraWellKnownCliPaths("codex")).toEqual([]);
 	});
 });
 

--- a/packages/agents/src/drivers/opencode.ts
+++ b/packages/agents/src/drivers/opencode.ts
@@ -201,6 +201,24 @@ interface OpencodeServerProcess {
 	readonly url: string;
 }
 
+const stopOpencodeChild = (
+	child: ChildProcessWithoutNullStreams,
+): void => {
+	try {
+		if (process.platform !== "win32" && child.pid !== undefined) {
+			process.kill(-child.pid, "SIGTERM");
+			return;
+		}
+		child.kill("SIGTERM");
+	} catch {
+		try {
+			child.kill("SIGTERM");
+		} catch {
+			// ignore — child may already be gone
+		}
+	}
+};
+
 /**
  * Spawn `opencode serve` on a fresh local port and wait for the URL it
  * prints to stdout. Resolves with the running child + the resolved URL.
@@ -244,11 +262,7 @@ const spawnOpencodeServer = (
 				const timer = setTimeout(() => {
 					if (settled) return;
 					settled = true;
-					try {
-						child.kill("SIGTERM");
-					} catch {
-						// ignore — child may already be gone
-					}
+					stopOpencodeChild(child);
 					const stderrTail = stderrBuf.trim().slice(-512);
 					reject(
 						new Error(
@@ -1269,11 +1283,7 @@ export const startOpencodeSession = (
 					} catch {
 						// ignore
 					}
-					try {
-						server.child.kill("SIGTERM");
-					} catch {
-						// ignore — child may already be gone
-					}
+					stopOpencodeChild(server.child);
 					yield* Queue.end(events);
 				}),
 			setPermissionMode: (mode) =>
@@ -1296,24 +1306,47 @@ export const startOpencodeSession = (
 // down as soon as both SDK calls return.
 // ---------------------------------------------------------------------------
 
-const filterPrimaryAgents = (
-	agents: ReadonlyArray<SdkAgent>,
+const asNonEmptyString = (value: unknown): string | null =>
+	typeof value === "string" && value.length > 0 ? value : null;
+
+interface InventoryAgentSource {
+	readonly name: unknown;
+	readonly mode: unknown;
+	readonly description?: string | null;
+	readonly hidden?: boolean | null;
+}
+
+/**
+ * OpenCode 1.18 sends `description: null` and `hidden: true` on internal
+ * agents (compaction/summary/title). Our inventory schema is `string |
+ * undefined` and the picker only wants user-facing primary agents.
+ */
+export const filterPrimaryAgents = (
+	agents: ReadonlyArray<InventoryAgentSource>,
 ): ReadonlyArray<OpencodeInventoryAgent> =>
-	agents
-		.filter((a) => a.mode === "primary" || a.mode === "all")
-		.map((a) => ({
-			name: a.name,
-			mode: a.mode as "primary" | "all",
-			...(a.description !== undefined ? { description: a.description } : {}),
-		}));
+	agents.flatMap((a) => {
+		if (a.mode !== "primary" && a.mode !== "all") return [];
+		if (a.hidden === true) return [];
+		const name = asNonEmptyString(a.name);
+		if (name === null) return [];
+		return [
+			{
+				name,
+				mode: a.mode,
+				...(typeof a.description === "string" && a.description.length > 0
+					? { description: a.description }
+					: {}),
+			},
+		];
+	});
 
 interface InventoryProviderModel {
-	readonly id: string;
-	readonly name: string;
+	readonly id?: unknown;
+	readonly name?: unknown;
 	// Opencode SDK v1 typings don't expose `variants`, but the wire
 	// protocol does carry it on each model — `Object.keys` of this map gives
 	// the variant names (e.g. `["high", "medium", "low"]`).
-	readonly variants?: Record<string, unknown>;
+	readonly variants?: Record<string, unknown> | null;
 	readonly status?: "alpha" | "beta" | "deprecated" | "active";
 	readonly capabilities?: {
 		readonly toolcall?: boolean;
@@ -1321,11 +1354,11 @@ interface InventoryProviderModel {
 }
 
 interface InventoryProvider {
-	readonly id: string;
-	readonly name: string;
+	readonly id?: unknown;
+	readonly name?: unknown;
 	// Env var(s) the provider's key is read from (e.g. `["OPENAI_API_KEY"]`).
-	readonly env?: ReadonlyArray<string>;
-	readonly models: { readonly [key: string]: InventoryProviderModel };
+	readonly env?: ReadonlyArray<unknown> | null;
+	readonly models?: { readonly [key: string]: InventoryProviderModel | null } | null;
 }
 
 /**
@@ -1367,56 +1400,97 @@ const RETIRED_OPENCODE_MODEL_IDS = new Set(["claude-opus-4-5"]);
 export const isUsableOpencodeInventoryModel = (
 	m: InventoryProviderModel,
 ): boolean => {
-	if (RETIRED_OPENCODE_MODEL_IDS.has(m.id)) return false;
+	const id = asNonEmptyString(m.id);
+	if (id === null) return false;
+	if (RETIRED_OPENCODE_MODEL_IDS.has(id)) return false;
 	if (m.status !== undefined && m.status !== "active") return false;
 	if (m.capabilities?.toolcall === false) return false;
 	return true;
 };
 
-const collectInventoryProviders = (
+export const collectInventoryProviders = (
 	all: ReadonlyArray<InventoryProvider>,
 	connected: ReadonlyArray<string>,
 	customIds: ReadonlySet<string>,
 	docById: ReadonlyMap<string, string>,
 ): ReadonlyArray<OpencodeInventoryProvider> => {
 	const connectedSet = new Set(connected);
-	return (
-		all
-			.map((p) => {
-				const isConnected = connectedSet.has(p.id);
-				return {
-					id: p.id,
-					name: p.name,
-					connected: isConnected,
-					custom: customIds.has(p.id),
-					apiKeyEnv: p.env?.[0] ?? "",
-					apiKeyUrl: docById.get(p.id) ?? "",
-					// Only enumerate models for connected providers. The catalog carries
-					// ~150 providers with thousands of models between them; shipping every
-					// unconnected provider's full model list would bloat the RPC payload
-					// and the renderer's localStorage cache. The picker only ever renders
-					// connected providers' models, and connecting one triggers a refresh
-					// that fills them in.
-					models: isConnected
-						? Object.values(p.models)
-								.filter(isUsableOpencodeInventoryModel)
-								.map((m) => ({
-									id: `${p.id}/${m.id}`,
-									label: m.name,
-									variants: Object.keys(m.variants ?? {}),
-								}))
-								.sort((a, b) => a.label.localeCompare(b.label))
-						: [],
-				};
-			})
-			// Connected providers first (each with usable models), then the rest of
-			// the catalog alphabetically for the "add provider" browser.
-			.sort((a, b) => {
-				if (a.connected !== b.connected) return a.connected ? -1 : 1;
-				return a.name.localeCompare(b.name);
-			})
-	);
+	const providers: OpencodeInventoryProvider[] = [];
+	for (const p of all) {
+		const id = asNonEmptyString(p.id);
+		if (id === null) continue;
+		const name = asNonEmptyString(p.name) ?? id;
+		const isConnected = connectedSet.has(id);
+		const env0 = p.env?.[0];
+		const modelsMap =
+			p.models !== null && typeof p.models === "object" ? p.models : {};
+		providers.push({
+			id,
+			name,
+			connected: isConnected,
+			custom: customIds.has(id),
+			apiKeyEnv: typeof env0 === "string" ? env0 : "",
+			apiKeyUrl: docById.get(id) ?? "",
+			// Only enumerate models for connected providers. The catalog carries
+			// ~150 providers with thousands of models between them; shipping every
+			// unconnected provider's full model list would bloat the RPC payload
+			// and the renderer's localStorage cache. The picker only ever renders
+			// connected providers' models, and connecting one triggers a refresh
+			// that fills them in.
+			models: isConnected
+				? Object.values(modelsMap)
+						.filter(
+							(m): m is InventoryProviderModel =>
+								m !== null && typeof m === "object",
+						)
+						.filter(isUsableOpencodeInventoryModel)
+						.flatMap((m) => {
+							const modelId = asNonEmptyString(m.id);
+							if (modelId === null) return [];
+							const variants =
+								m.variants !== null && typeof m.variants === "object"
+									? Object.keys(m.variants).filter((key) => key.length > 0)
+									: [];
+							return [
+								{
+									id: `${id}/${modelId}`,
+									label: asNonEmptyString(m.name) ?? modelId,
+									variants,
+								},
+							];
+						})
+						.sort((a, b) => a.label.localeCompare(b.label))
+				: [],
+		});
+	}
+	// Connected providers first (each with usable models), then the rest of
+	// the catalog alphabetically for the "add provider" browser.
+	return providers.sort((a, b) => {
+		if (a.connected !== b.connected) return a.connected ? -1 : 1;
+		return a.name.localeCompare(b.name);
+	});
 };
+
+const INVENTORY_RPC_TIMEOUT_MS = 20_000;
+
+const raceTimeout = <T>(
+	promise: Promise<T>,
+	ms: number,
+	message: string,
+): Promise<T> =>
+	new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(message)), ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(err: unknown) => {
+				clearTimeout(timer);
+				reject(err);
+			},
+		);
+	});
 
 export const loadOpencodeInventory = (
 	opencodePath: string,
@@ -1434,52 +1508,61 @@ export const loadOpencodeInventory = (
 			const client = createOpencodeClient({ baseUrl: proc.url });
 			const customIds = new Set(customProviders.map((p) => p.id));
 			try {
-				const [providersResp, agentsResp, docById] = await Promise.all([
-					client.provider.list({ throwOnError: true }),
-					client.app.agents({ throwOnError: true }),
-					fetchModelsDevDocs(),
-				]);
+				const [providersResp, agentsResp, docById] = await raceTimeout(
+					Promise.all([
+						client.provider.list({ throwOnError: true }),
+						client.app.agents({ throwOnError: true }),
+						fetchModelsDevDocs(),
+					]),
+					INVENTORY_RPC_TIMEOUT_MS,
+					`Timed out after ${INVENTORY_RPC_TIMEOUT_MS}ms waiting for opencode inventory`,
+				);
 				const providersData = providersResp.data;
 				const agentsData = agentsResp.data;
+				const allProviders = Array.isArray(providersData?.all)
+					? (providersData.all as ReadonlyArray<InventoryProvider>)
+					: [];
+				const connectedProviders = Array.isArray(providersData?.connected)
+					? providersData.connected.filter(
+							(id): id is string => typeof id === "string",
+						)
+					: [];
 				if (providersData !== undefined) {
 					dlog(
-						`inventory: connected providers [${providersData.connected.join(", ")}]`,
+						`inventory: connected providers [${connectedProviders.join(", ")}]`,
 					);
 					dlog(
-						`inventory: all providers [${providersData.all.map((p) => `${p.id}(${Object.keys(p.models).length} models)`).join(", ")}]`,
+						`inventory: all providers [${allProviders
+							.map(
+								(p) =>
+									`${String(p.id)}(${p.models && typeof p.models === "object" ? Object.keys(p.models).length : 0} models)`,
+							)
+							.join(", ")}]`,
 					);
 				} else {
 					dlog(`inventory: provider.list() returned undefined`);
 				}
-				if (agentsData !== undefined) {
+				if (Array.isArray(agentsData)) {
 					dlog(
 						`inventory: agents [${agentsData.map((a) => `${a.name}(${a.mode})`).join(", ")}]`,
 					);
 				}
-				const providers =
-					providersData === undefined
-						? []
-						: collectInventoryProviders(
-								providersData.all as ReadonlyArray<InventoryProvider>,
-								providersData.connected,
-								customIds,
-								docById,
-							);
-				const agents =
-					agentsData === undefined
-						? []
-						: filterPrimaryAgents(agentsData as ReadonlyArray<SdkAgent>);
+				const providers = collectInventoryProviders(
+					allProviders,
+					connectedProviders,
+					customIds,
+					docById,
+				);
+				const agents = Array.isArray(agentsData)
+					? filterPrimaryAgents(agentsData as ReadonlyArray<SdkAgent>)
+					: [];
 				dlog(
 					`inventory: returning ${providers.length} providers, ${agents.length} agents`,
 				);
 				ddump(`  inventory.result`, { providers, agents });
 				return { providers, agents } satisfies OpencodeInventory;
 			} finally {
-				try {
-					proc.child.kill("SIGTERM");
-				} catch {
-					// ignore — child may already be gone
-				}
+				stopOpencodeChild(proc.child);
 			}
 		},
 		catch: (cause) =>
@@ -1509,11 +1592,7 @@ const withOpencodeServer = <A>(
 			try {
 				return await fn(client);
 			} finally {
-				try {
-					proc.child.kill("SIGTERM");
-				} catch {
-					// ignore — child may already be gone
-				}
+				stopOpencodeChild(proc.child);
 			}
 		},
 		catch: (cause) =>

--- a/packages/agents/test/unit/drivers/opencode-inventory.test.ts
+++ b/packages/agents/test/unit/drivers/opencode-inventory.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isUsableOpencodeInventoryModel } from "../../../src/drivers/opencode.ts";
+import {
+	collectInventoryProviders,
+	filterPrimaryAgents,
+	isUsableOpencodeInventoryModel,
+} from "../../../src/drivers/opencode.ts";
 
 describe("OpenCode model inventory", () => {
 	it("removes retired Opus 4.5 while keeping current tool-capable models", () => {
@@ -17,5 +21,91 @@ describe("OpenCode model inventory", () => {
 				capabilities: { toolcall: true },
 			}),
 		).toBe(true);
+	});
+
+	it("omits null descriptions and hidden internal agents", () => {
+		expect(
+			filterPrimaryAgents([
+				{ name: "build", mode: "primary", description: "Build" },
+				{ name: "plan", mode: "primary", description: null },
+				{ name: "autoaccept", mode: "primary", hidden: false },
+				{ name: "compaction", mode: "primary", description: null, hidden: true },
+				{ name: "explore", mode: "all" },
+				{ name: "hidden", mode: "subagent", description: "ignored" },
+			]),
+		).toEqual([
+			{ name: "build", mode: "primary", description: "Build" },
+			{ name: "plan", mode: "primary" },
+			{ name: "autoaccept", mode: "primary" },
+			{ name: "explore", mode: "all" },
+		]);
+	});
+
+	it("coerces messy provider.list() rows into schema-safe inventory", () => {
+		expect(
+			collectInventoryProviders(
+				[
+					{
+						id: "openai",
+						name: "OpenAI",
+						env: ["OPENAI_API_KEY"],
+						models: {
+							"gpt-4o": {
+								id: "gpt-4o",
+								name: "GPT-4o",
+								status: "active",
+								capabilities: { toolcall: true },
+								variants: { high: {}, medium: {} },
+							},
+							tts: {
+								id: "tts",
+								name: "TTS",
+								status: "active",
+								capabilities: { toolcall: false },
+							},
+							broken: null,
+						},
+					},
+					{
+						id: "weird",
+						name: null,
+						env: null,
+						models: null,
+					},
+					{
+						id: null,
+						name: "skip me",
+					},
+				],
+				["openai", "weird"],
+				new Set(),
+				new Map([["openai", "https://platform.openai.com"]]),
+			),
+		).toEqual([
+			{
+				id: "openai",
+				name: "OpenAI",
+				connected: true,
+				custom: false,
+				apiKeyEnv: "OPENAI_API_KEY",
+				apiKeyUrl: "https://platform.openai.com",
+				models: [
+					{
+						id: "openai/gpt-4o",
+						label: "GPT-4o",
+						variants: ["high", "medium"],
+					},
+				],
+			},
+			{
+				id: "weird",
+				name: "weird",
+				connected: true,
+				custom: false,
+				apiKeyEnv: "",
+				apiKeyUrl: "",
+				models: [],
+			},
+		]);
 	});
 });

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -1661,7 +1661,9 @@ export type OpencodeInventoryProvider = typeof OpencodeInventoryProvider.Type;
 export const OpencodeInventoryAgent = Schema.Struct({
   name: Schema.String,
   mode: Schema.Literals(["primary", "all"]),
-  description: Schema.optional(Schema.String),
+  // OpenCode 1.18 serializes missing descriptions as JSON null. Optional
+  // string rejects that; NullOr lets encode/decode survive the wire shape.
+  description: Schema.optional(Schema.NullOr(Schema.String)),
 });
 export type OpencodeInventoryAgent = typeof OpencodeInventoryAgent.Type;
 


### PR DESCRIPTION
## Summary

OpenCode settings showed "Connected to N providers" from `auth.json` while the provider list stayed on "Loading providers…" forever.

Two separate failures stacked:

1. **Wrong CLI.** `which -a opencode` preferred Homebrew `opencode` 0.0.55, which is a different binary with no `serve`. Zuse needs the native 1.x install (`~/.opencode/bin/opencode`).
2. **1.18 wire shape.** After picking the real CLI, inventory encode died on `agents[n].description: null`. Hidden internal agents (`compaction`, `summary`, `title`) and messy `provider.list()` rows (null `name`/`env`/`models`/`variants`) could fail the same RPC.

The UI also treated `inventory === null` as loading, so a failed fetch never surfaced.

This change:

- Selects the newest OpenCode CLI, including the native installer path even when it is not on PATH
- Shows inventory errors with Retry instead of an infinite spinner
- Sanitizes OpenCode 1.18 agents/providers before RPC encode (null descriptions, hidden agents, missing model maps)
- Times out hung inventory SDK calls and tears down detached `opencode serve` process groups
- Honors `XDG_DATA_HOME` when probing OpenCode `auth.json`

## Validation

- Reproduced Homebrew 0.0.55 (`opencode serve --hostname` exits with `unknown flag`) vs native 1.18.19 (`opencode server listening on http://127.0.0.1:…`)
- Dumped live 1.18 `/provider` and `/agent` JSON; confirmed `description: null` and `hidden: true` on internal agents
- `packages/agents` inventory unit tests
- `apps/server` availability unit tests
- Typecheck: `packages/agents`, `packages/contracts`, `apps/server`, `apps/renderer`

Could not click through the Electron settings UI from this session; retry in the desktop app is the remaining live check.

## Provenance

- External implementation or source consulted: No
- Usage: Behavior only
- Source URL and revision:
- Applicable license:
- Required notice added or updated: N/A