### PR TITLE
feat: add sidebar project groups and drag reorder

### DIFF
--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -821,7 +821,7 @@ function UserProjectGroup({
 					anchorRef.current = { getBoundingClientRect: () => rect };
 					setMenuOpen(true);
 				}}
-				className="group relative flex cursor-grab items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] transition-colors hover:bg-sidebar-accent/30 active:cursor-grabbing"
+				className="group relative flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] transition-colors hover:bg-sidebar-accent/30 active:cursor-grabbing"
 			>
 				<DropLine line={dropLine} />
 				<HugeiconsIcon
@@ -1523,7 +1523,7 @@ function LogicalCatalogGroup({
 		<li>
 			<div
 				className={cn(
-					"group relative flex min-h-7 cursor-grab items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-sidebar-accent/30 motion-reduce:transition-none active:cursor-grabbing",
+					"group relative flex min-h-7 cursor-pointer items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-sidebar-accent/30 motion-reduce:transition-none active:cursor-grabbing",
 					nested && "ms-0",
 				)}
 				{...dragProps}
@@ -1913,7 +1913,7 @@ function ProjectGroup({
 								}
 							}}
 							className={cn(
-								"group relative flex cursor-grab items-center gap-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/40 focus-visible:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing",
+								"group relative flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/40 focus-visible:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing",
 								nested && "ms-0",
 							)}
 						>

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -418,7 +418,10 @@ export function ProjectsSidebar() {
 			) : null}
 			<SidebarErrorToasts />
 
-			<ul className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
+			<ul
+				data-sidebar-scroll
+				className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-1.5"
+			>
 				{desktopCatalogEnabled ? (
 					<>
 						{catalogViewState === "loading" ? (
@@ -480,7 +483,6 @@ export function ProjectsSidebar() {
 										})
 									}
 									onDissolve={() => organize.dissolveGroup(node.group.id)}
-									onSkipClick={organize.consumeSkipClick}
 									onSetIconColor={(color) =>
 										organize.setGroupIconColor(node.group.id, color)
 									}
@@ -507,7 +509,6 @@ export function ProjectsSidebar() {
 													key,
 													node.group.id,
 												)}
-												onSkipClick={organize.consumeSkipClick}
 												onToggleExpanded={onToggleExpanded}
 												onToggleKey={onToggleKey}
 												onSelect={select}
@@ -536,7 +537,6 @@ export function ProjectsSidebar() {
 											expanded={expanded}
 											dropLine={organize.dropLineFor(node.key)}
 											dragProps={organize.projectDragProps(node.key, null)}
-											onSkipClick={organize.consumeSkipClick}
 											onToggleExpanded={onToggleExpanded}
 											onToggleKey={onToggleKey}
 											onSelect={select}
@@ -585,7 +585,6 @@ export function ProjectsSidebar() {
 										})
 									}
 									onDissolve={() => organize.dissolveGroup(node.group.id)}
-									onSkipClick={organize.consumeSkipClick}
 									onSetIconColor={(color) =>
 										organize.setGroupIconColor(node.group.id, color)
 									}
@@ -609,7 +608,6 @@ export function ProjectsSidebar() {
 													folder.id,
 													node.group.id,
 												)}
-												onSkipClick={organize.consumeSkipClick}
 												onToggleExpanded={onToggleExpanded}
 												onSelect={select}
 												onRemove={remove}
@@ -634,7 +632,6 @@ export function ProjectsSidebar() {
 											expanded={expanded}
 											dropLine={organize.dropLineFor(folder.id)}
 											dragProps={organize.projectDragProps(folder.id, null)}
-											onSkipClick={organize.consumeSkipClick}
 											onToggleExpanded={onToggleExpanded}
 											onSelect={select}
 											onRemove={remove}
@@ -776,7 +773,6 @@ function UserProjectGroup({
 	onToggleCollapsed,
 	onRename,
 	onDissolve,
-	onSkipClick,
 	onSetIconColor,
 	children,
 }: {
@@ -788,7 +784,6 @@ function UserProjectGroup({
 	onToggleCollapsed: () => void;
 	onRename: () => void;
 	onDissolve: () => void;
-	onSkipClick: () => boolean;
 	onSetIconColor: (color: ProjectIconColorId | null) => void;
 	children: ReactNode;
 }) {
@@ -805,7 +800,6 @@ function UserProjectGroup({
 				tabIndex={0}
 				{...dragProps}
 				onClick={() => {
-					if (onSkipClick()) return;
 					onToggleCollapsed();
 				}}
 				onKeyDown={(event) => {
@@ -821,7 +815,7 @@ function UserProjectGroup({
 					anchorRef.current = { getBoundingClientRect: () => rect };
 					setMenuOpen(true);
 				}}
-				className="group relative flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] transition-colors hover:bg-sidebar-accent/30 active:cursor-grabbing"
+				className="group relative flex cursor-pointer select-none items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] transition-colors hover:bg-sidebar-accent/30"
 			>
 				<DropLine line={dropLine} />
 				<HugeiconsIcon
@@ -896,7 +890,6 @@ function SidebarLogicalRow({
 	nested = false,
 	dropLine,
 	dragProps,
-	onSkipClick,
 	onToggleExpanded,
 	onToggleKey,
 	onSelect,
@@ -924,7 +917,6 @@ function SidebarLogicalRow({
 	nested?: boolean;
 	dropLine: SidebarDropLine | null;
 	dragProps: ReturnType<Organize["projectDragProps"]>;
-	onSkipClick: () => boolean;
 	onToggleExpanded: (environmentId: string, id: FolderId) => void;
 	onToggleKey: (key: string) => void;
 	onSelect: (folderId: FolderId) => Promise<void>;
@@ -959,7 +951,6 @@ function SidebarLogicalRow({
 				nested={nested}
 				dropLine={dropLine}
 				dragProps={dragProps}
-				onSkipClick={onSkipClick}
 				organize={organize}
 				projectKey={group.key}
 				onSelect={() => void onSelect(folder.id)}
@@ -977,7 +968,6 @@ function SidebarLogicalRow({
 			nested={nested}
 			dropLine={dropLine}
 			dragProps={dragProps}
-			onSkipClick={onSkipClick}
 			onToggle={() => onToggleKey(group.key)}
 		/>
 	);
@@ -994,7 +984,6 @@ function SidebarFolderRow({
 	nested = false,
 	dropLine,
 	dragProps,
-	onSkipClick,
 	onToggleExpanded,
 	onSelect,
 	onRemove,
@@ -1020,7 +1009,6 @@ function SidebarFolderRow({
 	nested?: boolean;
 	dropLine: SidebarDropLine | null;
 	dragProps: ReturnType<Organize["projectDragProps"]>;
-	onSkipClick: () => boolean;
 	onToggleExpanded: (environmentId: string, id: FolderId) => void;
 	onSelect: (folderId: FolderId) => Promise<void>;
 	onRemove: (folderId: FolderId) => Promise<void>;
@@ -1046,7 +1034,6 @@ function SidebarFolderRow({
 			nested={nested}
 			dropLine={dropLine}
 			dragProps={dragProps}
-			onSkipClick={onSkipClick}
 			organize={organize}
 			projectKey={folder.id}
 			onSelect={() => void onSelect(folder.id)}
@@ -1500,7 +1487,6 @@ function LogicalCatalogGroup({
 	nested = false,
 	dropLine = null,
 	dragProps,
-	onSkipClick,
 }: {
 	group: LogicalProjectGroup;
 	isExpanded: boolean;
@@ -1508,7 +1494,6 @@ function LogicalCatalogGroup({
 	nested?: boolean;
 	dropLine?: SidebarDropLine | null;
 	dragProps?: ReturnType<Organize["projectDragProps"]>;
-	onSkipClick?: () => boolean;
 }) {
 	const preferred = preferredGroupMember(group);
 	const rows = remoteChatRows(group);
@@ -1523,7 +1508,7 @@ function LogicalCatalogGroup({
 		<li>
 			<div
 				className={cn(
-					"group relative flex min-h-7 cursor-pointer items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-sidebar-accent/30 motion-reduce:transition-none active:cursor-grabbing",
+					"group relative flex min-h-7 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-sidebar-accent/30 motion-reduce:transition-none",
 					nested && "ms-0",
 				)}
 				{...dragProps}
@@ -1535,7 +1520,6 @@ function LogicalCatalogGroup({
 					aria-controls={listId}
 					className="flex min-w-0 flex-1 items-center gap-1.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
 					onClick={() => {
-						if (onSkipClick?.()) return;
 						onToggle();
 					}}
 				>
@@ -1724,7 +1708,6 @@ function ProjectGroup({
 	nested = false,
 	dropLine = null,
 	dragProps,
-	onSkipClick,
 	organize,
 	projectKey,
 }: {
@@ -1751,7 +1734,6 @@ function ProjectGroup({
 	nested?: boolean;
 	dropLine?: SidebarDropLine | null;
 	dragProps?: ReturnType<Organize["projectDragProps"]>;
-	onSkipClick?: () => boolean;
 	organize?: Organize;
 	projectKey?: string;
 }) {
@@ -1903,7 +1885,6 @@ function ProjectGroup({
 								setMenuOpen(true);
 							}}
 							onClick={() => {
-								if (onSkipClick?.()) return;
 								onToggleExpanded();
 							}}
 							onKeyDown={(e) => {
@@ -1913,7 +1894,7 @@ function ProjectGroup({
 								}
 							}}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/40 focus-visible:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing",
+								"group relative flex cursor-pointer select-none items-center gap-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/40 focus-visible:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
 								nested && "ms-0",
 							)}
 						>

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -4,6 +4,7 @@ import {
 	type ChatId,
 	type CloudChatSummary,
 	EnvironmentId,
+	type Folder,
 	type FolderId,
 	type GitOriginInfo,
 	type ProviderId,
@@ -33,8 +34,8 @@ import {
 } from "@zuse/icons/solid-rounded";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import {
-	Fragment,
 	lazy,
+	type ReactNode,
 	Suspense,
 	useEffect,
 	useMemo,
@@ -42,10 +43,17 @@ import {
 	useState,
 	useSyncExternalStore,
 } from "react";
+import { createPortal } from "react-dom";
 import { TypewriterText } from "~/components/typewriter-text.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { CompactEmptyState } from "~/components/ui/compact-empty-state";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
+import {
+	Menu,
+	MenuItem,
+	MenuPopup,
+	MenuSeparator,
+	MenuTrigger,
+} from "~/components/ui/menu";
 import { toastManager } from "~/components/ui/toast.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useAuth } from "~/hooks/use-auth.ts";
@@ -104,7 +112,16 @@ import {
 	useRendererSessionTimelines,
 } from "../lib/session-timeline-hooks.ts";
 import { formatShortcut } from "../lib/shortcuts.ts";
+import {
+	PROJECT_ICON_COLOR_IDS,
+	PROJECT_ICON_COLOR_STYLES,
+	type ProjectIconColorId,
+} from "../lib/sidebar-project-icon.ts";
 import { switchToEnvironment } from "../lib/switch-environment.ts";
+import {
+	type SidebarDropLine,
+	useSidebarOrganize,
+} from "../lib/use-sidebar-organize.ts";
 import { useArchivePreviewStore } from "../store/archive-preview.ts";
 import {
 	archiveChatWithConfirm,
@@ -344,6 +361,14 @@ export function ProjectsSidebar() {
 			shellViews,
 		],
 	);
+	const projectKeys = useMemo(
+		() =>
+			desktopCatalogEnabled
+				? logicalGroups.map((group) => group.key)
+				: folders.map((folder) => folder.id),
+		[desktopCatalogEnabled, folders, logicalGroups],
+	);
+	const organize = useSidebarOrganize(projectKeys);
 	const catalogViewState = environmentCatalogViewState({
 		initialized: catalogInitialized,
 		initializing: catalogInitializing,
@@ -379,7 +404,14 @@ export function ProjectsSidebar() {
 			) : null}
 			<div className="flex items-center justify-between px-2.5 py-1.5 text-[12px] text-muted-foreground">
 				<span>Projects</span>
-				<ProjectAddMenu />
+				<div className="flex items-center">
+					<NewProjectGroupButton
+						onCreate={() =>
+							organize.setGroupDialog({ kind: "create", projectKeys: [] })
+						}
+					/>
+					<ProjectAddMenu />
+				</div>
 			</div>
 			{showComputerControls ? (
 				<CatalogConnectionNotice entries={catalogEntries} />
@@ -421,53 +453,96 @@ export function ProjectsSidebar() {
 								/>
 							</li>
 						) : null}
-						{logicalGroups.map((group) => {
-							const activeMember = group.members.find(
-								(member) => member.isActive,
-							);
-							const folder =
-								activeMember === undefined
-									? undefined
-									: folders.find((f) => f.id === activeMember.folderId);
-							if (activeMember !== undefined && folder !== undefined) {
-								return (
-									<ProjectGroup
-										key={group.key}
-										id={folder.id}
-										name={folder.name}
-										path={folder.path}
-										origin={origins[folder.id] ?? null}
-										isExpanded={
-											expanded[
-												environmentProjectKey(activeEnvironmentId, folder.id)
-											] === true
-										}
-										chats={chatsByProject[folder.id] ?? []}
-										projectSessions={sessionsByProject[folder.id] ?? []}
-										remoteChats={remoteChatRows(group)}
-										cloudChats={cloudChats.filter(
-											(chat) =>
-												chat.repositoryIdentity ===
-												repositoryIdentityForOrigin(origins[folder.id]),
-										)}
-										environmentId={EnvironmentId.make(activeEnvironmentId)}
-										onSelect={() => void select(folder.id)}
-										onToggleExpanded={() =>
-											onToggleExpanded(activeEnvironmentId, folder.id)
-										}
-										onRemove={() => void remove(folder.id)}
-									/>
-								);
-							}
-							return (
-								<LogicalCatalogGroup
-									key={group.key}
-									group={group}
-									isExpanded={expanded[group.key] === true}
-									onToggle={() => onToggleKey(group.key)}
-								/>
-							);
-						})}
+						{organize.nodes.map((node) =>
+							node.kind === "group" ? (
+								<UserProjectGroup
+									key={organize.sidebarGroupItemKey(node.group.id)}
+									group={node.group}
+									dropLine={organize.dropLineFor(
+										organize.sidebarGroupItemKey(node.group.id),
+									)}
+									dragProps={organize.groupDragProps(node.group.id)}
+									onToggleCollapsed={() =>
+										organize.setGroupCollapsed(
+											node.group.id,
+											!node.group.collapsed,
+										)
+									}
+									onRename={() =>
+										organize.setGroupDialog({
+											kind: "rename",
+											groupId: node.group.id,
+											name: node.group.name,
+										})
+									}
+									onDissolve={() => organize.dissolveGroup(node.group.id)}
+									onSkipClick={organize.consumeSkipClick}
+									onSetIconColor={(color) =>
+										organize.setGroupIconColor(node.group.id, color)
+									}
+								>
+									{node.group.projectKeys.map((key) => {
+										const logical = logicalGroups.find(
+											(group) => group.key === key,
+										);
+										if (logical === undefined) return null;
+										return (
+											<SidebarLogicalRow
+												key={key}
+												group={logical}
+												folders={folders}
+												origins={origins}
+												chatsByProject={chatsByProject}
+												sessionsByProject={sessionsByProject}
+												cloudChats={cloudChats}
+												activeEnvironmentId={activeEnvironmentId}
+												expanded={expanded}
+												nested
+												dropLine={organize.dropLineFor(key)}
+												dragProps={organize.projectDragProps(
+													key,
+													node.group.id,
+												)}
+												onSkipClick={organize.consumeSkipClick}
+												onToggleExpanded={onToggleExpanded}
+												onToggleKey={onToggleKey}
+												onSelect={select}
+												onRemove={remove}
+												organize={organize}
+											/>
+										);
+									})}
+								</UserProjectGroup>
+							) : (
+								(() => {
+									const logical = logicalGroups.find(
+										(group) => group.key === node.key,
+									);
+									if (logical === undefined) return null;
+									return (
+										<SidebarLogicalRow
+											key={node.key}
+											group={logical}
+											folders={folders}
+											origins={origins}
+											chatsByProject={chatsByProject}
+											sessionsByProject={sessionsByProject}
+											cloudChats={cloudChats}
+											activeEnvironmentId={activeEnvironmentId}
+											expanded={expanded}
+											dropLine={organize.dropLineFor(node.key)}
+											dragProps={organize.projectDragProps(node.key, null)}
+											onSkipClick={organize.consumeSkipClick}
+											onToggleExpanded={onToggleExpanded}
+											onToggleKey={onToggleKey}
+											onSelect={select}
+											onRemove={remove}
+											organize={organize}
+										/>
+									);
+								})()
+							),
+						)}
 					</>
 				) : (
 					<>
@@ -479,38 +554,486 @@ export function ProjectsSidebar() {
 								/>
 							</li>
 						) : null}
-						{folders.map((folder) => (
-							<ProjectGroup
-								key={folder.id}
-								id={folder.id}
-								name={folder.name}
-								path={folder.path}
-								origin={origins[folder.id] ?? null}
-								isExpanded={
-									expanded[
-										environmentProjectKey(activeEnvironmentId, folder.id)
-									] === true
-								}
-								chats={chatsByProject[folder.id] ?? []}
-								projectSessions={sessionsByProject[folder.id] ?? []}
-								cloudChats={cloudChats.filter(
-									(chat) =>
-										chat.repositoryIdentity ===
-										repositoryIdentityForOrigin(origins[folder.id]),
-								)}
-								environmentId={EnvironmentId.make(activeEnvironmentId)}
-								onSelect={() => void select(folder.id)}
-								onToggleExpanded={() =>
-									onToggleExpanded(activeEnvironmentId, folder.id)
-								}
-								onRemove={() => void remove(folder.id)}
-							/>
-						))}
+						{organize.nodes.map((node) =>
+							node.kind === "group" ? (
+								<UserProjectGroup
+									key={organize.sidebarGroupItemKey(node.group.id)}
+									group={node.group}
+									dropLine={organize.dropLineFor(
+										organize.sidebarGroupItemKey(node.group.id),
+									)}
+									dragProps={organize.groupDragProps(node.group.id)}
+									onToggleCollapsed={() =>
+										organize.setGroupCollapsed(
+											node.group.id,
+											!node.group.collapsed,
+										)
+									}
+									onRename={() =>
+										organize.setGroupDialog({
+											kind: "rename",
+											groupId: node.group.id,
+											name: node.group.name,
+										})
+									}
+									onDissolve={() => organize.dissolveGroup(node.group.id)}
+									onSkipClick={organize.consumeSkipClick}
+									onSetIconColor={(color) =>
+										organize.setGroupIconColor(node.group.id, color)
+									}
+								>
+									{node.group.projectKeys.map((key) => {
+										const folder = folders.find((entry) => entry.id === key);
+										if (folder === undefined) return null;
+										return (
+											<SidebarFolderRow
+												key={folder.id}
+												folder={folder}
+												origins={origins}
+												chatsByProject={chatsByProject}
+												sessionsByProject={sessionsByProject}
+												cloudChats={cloudChats}
+												activeEnvironmentId={activeEnvironmentId}
+												expanded={expanded}
+												nested
+												dropLine={organize.dropLineFor(folder.id)}
+												dragProps={organize.projectDragProps(
+													folder.id,
+													node.group.id,
+												)}
+												onSkipClick={organize.consumeSkipClick}
+												onToggleExpanded={onToggleExpanded}
+												onSelect={select}
+												onRemove={remove}
+												organize={organize}
+											/>
+										);
+									})}
+								</UserProjectGroup>
+							) : (
+								(() => {
+									const folder = folders.find((entry) => entry.id === node.key);
+									if (folder === undefined) return null;
+									return (
+										<SidebarFolderRow
+											key={folder.id}
+											folder={folder}
+											origins={origins}
+											chatsByProject={chatsByProject}
+											sessionsByProject={sessionsByProject}
+											cloudChats={cloudChats}
+											activeEnvironmentId={activeEnvironmentId}
+											expanded={expanded}
+											dropLine={organize.dropLineFor(folder.id)}
+											dragProps={organize.projectDragProps(folder.id, null)}
+											onSkipClick={organize.consumeSkipClick}
+											onToggleExpanded={onToggleExpanded}
+											onSelect={select}
+											onRemove={remove}
+											organize={organize}
+										/>
+									);
+								})()
+							),
+						)}
 					</>
 				)}
 			</ul>
 			<SidebarFooter />
+			{organize.groupDialog !== null ? (
+				<Suspense fallback={null}>
+					<RenameDialog
+						open
+						title={
+							organize.groupDialog.kind === "create"
+								? "New project group"
+								: "Rename group"
+						}
+						description={
+							organize.groupDialog.kind === "create"
+								? "Name a group to collect projects in the sidebar."
+								: "This name is only shown in the sidebar."
+						}
+						label="Group name"
+						value={
+							organize.groupDialog.kind === "rename"
+								? organize.groupDialog.name
+								: "New group"
+						}
+						onOpenChange={(open) => {
+							if (!open) organize.setGroupDialog(null);
+						}}
+						onRename={async (name) => {
+							const dialog = organize.groupDialog;
+							if (dialog === null) return;
+							if (dialog.kind === "create") {
+								organize.createGroup(name, dialog.projectKeys);
+							} else {
+								organize.renameGroup(dialog.groupId, name);
+							}
+							organize.setGroupDialog(null);
+						}}
+					/>
+				</Suspense>
+			) : null}
 		</aside>
+	);
+}
+
+function NewProjectGroupButton({ onCreate }: { onCreate: () => void }) {
+	return (
+		<Tooltip>
+			<TooltipTrigger
+				render={
+					<button
+						type="button"
+						className="rounded p-1 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+						aria-label="New project group"
+						onClick={onCreate}
+					>
+						<HugeiconsIcon icon={FolderAddIcon} className="size-3.5" />
+					</button>
+				}
+			/>
+			<TooltipPopup>New group</TooltipPopup>
+		</Tooltip>
+	);
+}
+
+type Organize = ReturnType<typeof useSidebarOrganize>;
+
+function IconColorPicker({
+	value,
+	onChange,
+}: {
+	value?: ProjectIconColorId;
+	onChange: (color: ProjectIconColorId | null) => void;
+}) {
+	return (
+		<div className="px-2 py-1.5">
+			<div className="mb-1.5 text-[11px] text-muted-foreground">Icon color</div>
+			<div className="flex flex-wrap gap-1.5">
+				<button
+					type="button"
+					aria-label="Default icon color"
+					aria-pressed={value === undefined}
+					onClick={() => onChange(null)}
+					className={cn(
+						"size-4 rounded-full border border-border bg-muted",
+						value === undefined && "ring-2 ring-foreground/70",
+					)}
+				/>
+				{PROJECT_ICON_COLOR_IDS.map((id) => (
+					<button
+						key={id}
+						type="button"
+						aria-label={`${id} icon color`}
+						aria-pressed={value === id}
+						onClick={() => onChange(id)}
+						className={cn(
+							"size-4 rounded-full",
+							PROJECT_ICON_COLOR_STYLES[id].swatch,
+							value === id && "ring-2 ring-foreground/70",
+						)}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function DropLine({ line }: { line: SidebarDropLine | null }) {
+	if (line === null) return null;
+	if (line === "into") {
+		return (
+			<span className="pointer-events-none absolute inset-0 rounded-md ring-1 ring-foreground/40" />
+		);
+	}
+	return (
+		<span
+			className={cn(
+				"pointer-events-none absolute inset-x-2 h-0.5 rounded bg-foreground/80",
+				line === "before" ? "-top-0.5" : "-bottom-0.5",
+			)}
+		/>
+	);
+}
+
+function UserProjectGroup({
+	group,
+	dropLine,
+	dragProps,
+	onToggleCollapsed,
+	onRename,
+	onDissolve,
+	onSkipClick,
+	onSetIconColor,
+	children,
+}: {
+	group: Organize["groups"][number];
+	dropLine: SidebarDropLine | null;
+	dragProps: ReturnType<Organize["groupDragProps"]>;
+	onToggleCollapsed: () => void;
+	onRename: () => void;
+	onDissolve: () => void;
+	onSkipClick: () => boolean;
+	onSetIconColor: (color: ProjectIconColorId | null) => void;
+	children: ReactNode;
+}) {
+	const [menuOpen, setMenuOpen] = useState(false);
+	const anchorRef = useRef<{ getBoundingClientRect: () => DOMRect } | null>(
+		null,
+	);
+	const Chevron = group.collapsed ? ChevronRight : ChevronDown;
+	return (
+		<li>
+			{/* biome-ignore lint/a11y/useSemanticElements: nested menu + drag handle. */}
+			<div
+				role="button"
+				tabIndex={0}
+				{...dragProps}
+				onClick={() => {
+					if (onSkipClick()) return;
+					onToggleCollapsed();
+				}}
+				onKeyDown={(event) => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						onToggleCollapsed();
+					}
+				}}
+				onContextMenu={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					const rect = new DOMRect(event.clientX, event.clientY, 0, 0);
+					anchorRef.current = { getBoundingClientRect: () => rect };
+					setMenuOpen(true);
+				}}
+				className="group relative flex cursor-grab items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] transition-colors hover:bg-sidebar-accent/30 active:cursor-grabbing"
+			>
+				<DropLine line={dropLine} />
+				<HugeiconsIcon
+					icon={Folder01Icon}
+					className={cn(
+						"size-3.5 shrink-0",
+						group.iconColor === undefined
+							? "text-muted-foreground"
+							: PROJECT_ICON_COLOR_STYLES[group.iconColor].icon,
+					)}
+				/>
+				<span className="min-w-0 flex-1 truncate">{group.name}</span>
+				<span className="tabular-nums text-[10px] text-muted-foreground/70">
+					{group.projectKeys.length}
+				</span>
+				<Chevron
+					aria-hidden="true"
+					className="size-3.5 text-muted-foreground opacity-0 group-hover:opacity-100"
+				/>
+			</div>
+			<Menu open={menuOpen} onOpenChange={setMenuOpen}>
+				<MenuPopup
+					anchor={anchorRef.current ?? undefined}
+					align="start"
+					side="bottom"
+					className="min-w-[180px]"
+				>
+					<MenuItem onClick={onRename}>
+						<HugeiconsIcon icon={PencilIcon} className="size-3.5" />
+						Rename
+					</MenuItem>
+					<MenuSeparator />
+					<IconColorPicker value={group.iconColor} onChange={onSetIconColor} />
+					<MenuSeparator />
+					<MenuItem onClick={onDissolve}>
+						<HugeiconsIcon icon={Delete02Icon} className="size-3.5" />
+						Ungroup
+					</MenuItem>
+				</MenuPopup>
+			</Menu>
+			{group.collapsed ? null : (
+				<ul className="ms-2 flex flex-col gap-0.5 border-s border-sidebar-border/50 ps-1">
+					{group.projectKeys.length === 0 ? (
+						<li className="px-2 py-1 text-[12px] text-muted-foreground">
+							Drag projects here
+						</li>
+					) : (
+						children
+					)}
+				</ul>
+			)}
+		</li>
+	);
+}
+
+function SidebarLogicalRow({
+	group,
+	folders,
+	origins,
+	chatsByProject,
+	sessionsByProject,
+	cloudChats,
+	activeEnvironmentId,
+	expanded,
+	nested = false,
+	dropLine,
+	dragProps,
+	onSkipClick,
+	onToggleExpanded,
+	onToggleKey,
+	onSelect,
+	onRemove,
+	organize,
+}: {
+	group: LogicalProjectGroup;
+	folders: ReturnType<typeof useWorkspaceStore.getState>["folders"];
+	origins: Readonly<Record<string, GitOriginInfo | null>>;
+	chatsByProject: Readonly<Record<string, ReadonlyArray<Chat>>>;
+	sessionsByProject: Readonly<
+		Record<
+			string,
+			ReadonlyArray<{
+				readonly id: SessionId;
+				readonly chatId: ChatId;
+				readonly archivedAt: Date | null;
+				readonly status: SessionStatus;
+			}>
+		>
+	>;
+	cloudChats: ReadonlyArray<CloudChatSummary>;
+	activeEnvironmentId: string;
+	expanded: Record<string, boolean>;
+	nested?: boolean;
+	dropLine: SidebarDropLine | null;
+	dragProps: ReturnType<Organize["projectDragProps"]>;
+	onSkipClick: () => boolean;
+	onToggleExpanded: (environmentId: string, id: FolderId) => void;
+	onToggleKey: (key: string) => void;
+	onSelect: (folderId: FolderId) => Promise<void>;
+	onRemove: (folderId: FolderId) => Promise<void>;
+	organize: Organize;
+}) {
+	const activeMember = group.members.find((member) => member.isActive);
+	const folder =
+		activeMember === undefined
+			? undefined
+			: folders.find((entry) => entry.id === activeMember.folderId);
+	if (activeMember !== undefined && folder !== undefined) {
+		return (
+			<ProjectGroup
+				id={folder.id}
+				name={folder.name}
+				path={folder.path}
+				origin={origins[folder.id] ?? null}
+				isExpanded={
+					expanded[environmentProjectKey(activeEnvironmentId, folder.id)] ===
+					true
+				}
+				chats={chatsByProject[folder.id] ?? []}
+				projectSessions={sessionsByProject[folder.id] ?? []}
+				remoteChats={remoteChatRows(group)}
+				cloudChats={cloudChats.filter(
+					(chat) =>
+						chat.repositoryIdentity ===
+						repositoryIdentityForOrigin(origins[folder.id]),
+				)}
+				environmentId={EnvironmentId.make(activeEnvironmentId)}
+				nested={nested}
+				dropLine={dropLine}
+				dragProps={dragProps}
+				onSkipClick={onSkipClick}
+				organize={organize}
+				projectKey={group.key}
+				onSelect={() => void onSelect(folder.id)}
+				onToggleExpanded={() =>
+					onToggleExpanded(activeEnvironmentId, folder.id)
+				}
+				onRemove={() => void onRemove(folder.id)}
+			/>
+		);
+	}
+	return (
+		<LogicalCatalogGroup
+			group={group}
+			isExpanded={expanded[group.key] === true}
+			nested={nested}
+			dropLine={dropLine}
+			dragProps={dragProps}
+			onSkipClick={onSkipClick}
+			onToggle={() => onToggleKey(group.key)}
+		/>
+	);
+}
+
+function SidebarFolderRow({
+	folder,
+	origins,
+	chatsByProject,
+	sessionsByProject,
+	cloudChats,
+	activeEnvironmentId,
+	expanded,
+	nested = false,
+	dropLine,
+	dragProps,
+	onSkipClick,
+	onToggleExpanded,
+	onSelect,
+	onRemove,
+	organize,
+}: {
+	folder: Folder;
+	origins: Readonly<Record<string, GitOriginInfo | null>>;
+	chatsByProject: Readonly<Record<string, ReadonlyArray<Chat>>>;
+	sessionsByProject: Readonly<
+		Record<
+			string,
+			ReadonlyArray<{
+				readonly id: SessionId;
+				readonly chatId: ChatId;
+				readonly archivedAt: Date | null;
+				readonly status: SessionStatus;
+			}>
+		>
+	>;
+	cloudChats: ReadonlyArray<CloudChatSummary>;
+	activeEnvironmentId: string;
+	expanded: Record<string, boolean>;
+	nested?: boolean;
+	dropLine: SidebarDropLine | null;
+	dragProps: ReturnType<Organize["projectDragProps"]>;
+	onSkipClick: () => boolean;
+	onToggleExpanded: (environmentId: string, id: FolderId) => void;
+	onSelect: (folderId: FolderId) => Promise<void>;
+	onRemove: (folderId: FolderId) => Promise<void>;
+	organize: Organize;
+}) {
+	return (
+		<ProjectGroup
+			id={folder.id}
+			name={folder.name}
+			path={folder.path}
+			origin={origins[folder.id] ?? null}
+			isExpanded={
+				expanded[environmentProjectKey(activeEnvironmentId, folder.id)] === true
+			}
+			chats={chatsByProject[folder.id] ?? []}
+			projectSessions={sessionsByProject[folder.id] ?? []}
+			cloudChats={cloudChats.filter(
+				(chat) =>
+					chat.repositoryIdentity ===
+					repositoryIdentityForOrigin(origins[folder.id]),
+			)}
+			environmentId={EnvironmentId.make(activeEnvironmentId)}
+			nested={nested}
+			dropLine={dropLine}
+			dragProps={dragProps}
+			onSkipClick={onSkipClick}
+			organize={organize}
+			projectKey={folder.id}
+			onSelect={() => void onSelect(folder.id)}
+			onToggleExpanded={() => onToggleExpanded(activeEnvironmentId, folder.id)}
+			onRemove={() => void onRemove(folder.id)}
+		/>
 	);
 }
 
@@ -955,10 +1478,18 @@ function LogicalCatalogGroup({
 	group,
 	isExpanded,
 	onToggle,
+	nested = false,
+	dropLine = null,
+	dragProps,
+	onSkipClick,
 }: {
 	group: LogicalProjectGroup;
 	isExpanded: boolean;
 	onToggle: () => void;
+	nested?: boolean;
+	dropLine?: SidebarDropLine | null;
+	dragProps?: ReturnType<Organize["projectDragProps"]>;
+	onSkipClick?: () => boolean;
 }) {
 	const preferred = preferredGroupMember(group);
 	const rows = remoteChatRows(group);
@@ -970,59 +1501,68 @@ function LogicalCatalogGroup({
 		.join(", ");
 
 	return (
-		<Fragment>
-			<li>
-				<div className="group flex min-h-7 items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-sidebar-accent/30 motion-reduce:transition-none">
+		<li>
+			<div
+				className={cn(
+					"group relative flex min-h-7 cursor-grab items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-sidebar-accent/30 motion-reduce:transition-none active:cursor-grabbing",
+					nested && "ms-0",
+				)}
+				{...dragProps}
+			>
+				<DropLine line={dropLine} />
+				<button
+					type="button"
+					aria-expanded={isExpanded}
+					aria-controls={listId}
+					className="flex min-w-0 flex-1 items-center gap-1.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					onClick={() => {
+						if (onSkipClick?.()) return;
+						onToggle();
+					}}
+				>
+					<span className="relative grid size-5 shrink-0 place-items-center">
+						<Avatar className="col-start-1 row-start-1 size-5 rounded transition-opacity duration-150 ease-out group-hover:opacity-0 motion-reduce:transition-none">
+							{avatarUrl !== null && (
+								<AvatarImage src={avatarUrl} alt={group.displayName} />
+							)}
+							<AvatarFallback className="rounded text-[10px]">
+								{initialsOf(group.origin?.owner ?? group.displayName)}
+							</AvatarFallback>
+						</Avatar>
+						<Chevron
+							aria-hidden="true"
+							className="col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 motion-reduce:transition-none"
+						/>
+					</span>
+					<span className="min-w-0 flex-1 truncate text-[12px]">
+						{group.displayName}
+					</span>
+				</button>
+				{group.environmentPresence === "remote-only" ? (
+					<RemoteComputerIndicator label={memberLabels} />
+				) : null}
+				{preferred?.connected ? (
 					<button
 						type="button"
-						aria-expanded={isExpanded}
-						aria-controls={listId}
-						className="flex min-w-0 flex-1 items-center gap-1.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
-						onClick={onToggle}
+						aria-label={`New chat in ${group.displayName}`}
+						onPointerDown={(event) => event.stopPropagation()}
+						className="rounded-md p-1 text-muted-foreground opacity-0 outline-none transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:transition-none"
+						onClick={(event) => {
+							event.stopPropagation();
+							void switchToEnvironment({
+								environmentId: preferred.environmentId,
+								folderId: preferred.folderId,
+							}).then((result) => {
+								if (result.switched && result.selectedFolderId !== null)
+									openNewChatLanding(result.selectedFolderId);
+							});
+						}}
 					>
-						<span className="relative grid size-5 shrink-0 place-items-center">
-							<Avatar className="col-start-1 row-start-1 size-5 rounded transition-opacity duration-150 ease-out group-hover:opacity-0 motion-reduce:transition-none">
-								{avatarUrl !== null && (
-									<AvatarImage src={avatarUrl} alt={group.displayName} />
-								)}
-								<AvatarFallback className="rounded text-[10px]">
-									{initialsOf(group.origin?.owner ?? group.displayName)}
-								</AvatarFallback>
-							</Avatar>
-							<Chevron
-								aria-hidden="true"
-								className="col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 motion-reduce:transition-none"
-							/>
-						</span>
-						<span className="min-w-0 flex-1 truncate text-[12px]">
-							{group.displayName}
-						</span>
+						<HugeiconsIcon icon={Edit01Icon} className="size-3.5" />
 					</button>
-					{group.environmentPresence === "remote-only" ? (
-						<RemoteComputerIndicator label={memberLabels} />
-					) : null}
-					{preferred?.connected ? (
-						<button
-							type="button"
-							aria-label={`New chat in ${group.displayName}`}
-							className="rounded-md p-1 text-muted-foreground opacity-0 outline-none transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:transition-none"
-							onClick={(event) => {
-								event.stopPropagation();
-								void switchToEnvironment({
-									environmentId: preferred.environmentId,
-									folderId: preferred.folderId,
-								}).then((result) => {
-									if (result.switched && result.selectedFolderId !== null)
-										openNewChatLanding(result.selectedFolderId);
-								});
-							}}
-						>
-							<HugeiconsIcon icon={Edit01Icon} className="size-3.5" />
-						</button>
-					) : null}
-				</div>
-			</li>
-			<li id={listId} className="list-none" hidden={!isExpanded}>
+				) : null}
+			</div>
+			<div id={listId} hidden={!isExpanded}>
 				<ul aria-label={`${group.displayName} chats`}>
 					{rows.length === 0 ? (
 						<li className="px-12 py-1 text-[12px] text-muted-foreground">
@@ -1038,8 +1578,8 @@ function LogicalCatalogGroup({
 						/>
 					))}
 				</ul>
-			</li>
-		</Fragment>
+			</div>
+		</li>
 	);
 }
 
@@ -1162,6 +1702,12 @@ function ProjectGroup({
 	onSelect,
 	onToggleExpanded,
 	onRemove,
+	nested = false,
+	dropLine = null,
+	dragProps,
+	onSkipClick,
+	organize,
+	projectKey,
 }: {
 	id: FolderId;
 	name: string;
@@ -1183,6 +1729,12 @@ function ProjectGroup({
 	onSelect: () => void;
 	onToggleExpanded: () => void;
 	onRemove: () => void;
+	nested?: boolean;
+	dropLine?: SidebarDropLine | null;
+	dragProps?: ReturnType<Organize["projectDragProps"]>;
+	onSkipClick?: () => boolean;
+	organize?: Organize;
+	projectKey?: string;
 }) {
 	const displayName = origin?.repo ?? name;
 	const avatarUrl = avatarUrlFor(origin);
@@ -1194,11 +1746,6 @@ function ProjectGroup({
 	const hiddenArchivedChatIds = useChatsStore(
 		(state) => state.hiddenArchivedChatIds,
 	);
-	const [menuOpen, setMenuOpen] = useState(false);
-	const anchorRef = useRef<{ getBoundingClientRect: () => DOMRect } | null>(
-		null,
-	);
-
 	const openRepositorySettings = () => {
 		setSettingsSection({ kind: "repository", projectId: id });
 		setView("settings");
@@ -1214,14 +1761,6 @@ function ProjectGroup({
 	const openProjectUsage = () => {
 		onSelect();
 		openUsage("project");
-	};
-
-	const onContextMenu = (e: React.MouseEvent) => {
-		e.preventDefault();
-		e.stopPropagation();
-		const rect = new DOMRect(e.clientX, e.clientY, 0, 0);
-		anchorRef.current = { getBoundingClientRect: () => rect };
-		setMenuOpen(true);
 	};
 
 	const visibleChats = useMemo(() => {
@@ -1319,129 +1858,168 @@ function ProjectGroup({
 	]);
 	const showHeaderAttention = headerAttention !== "idle" && !isExpanded;
 
+	const [menuOpen, setMenuOpen] = useState(false);
+	const anchorRef = useRef<{ getBoundingClientRect: () => DOMRect } | null>(
+		null,
+	);
 	const Chevron = isExpanded ? ChevronDown : ChevronRight;
 
 	return (
-		<Fragment>
+		<li>
 			{/* Project header toggles expansion only. Explicit actions below select
           the project when they need project context. */}
-			<li>
-				<Tooltip>
-					<TooltipTrigger
-						render={
-							/* biome-ignore lint/a11y/useSemanticElements: this row contains nested action buttons. */
-							<div
-								role="button"
-								tabIndex={0}
-								onContextMenu={onContextMenu}
-								onClick={() => {
+			<Tooltip>
+				<TooltipTrigger
+					render={
+						/* biome-ignore lint/a11y/useSemanticElements: this row contains nested action buttons. */
+						<div
+							role="button"
+							tabIndex={0}
+							{...dragProps}
+							onContextMenu={(event) => {
+								event.preventDefault();
+								event.stopPropagation();
+								const rect = new DOMRect(event.clientX, event.clientY, 0, 0);
+								anchorRef.current = { getBoundingClientRect: () => rect };
+								setMenuOpen(true);
+							}}
+							onClick={() => {
+								if (onSkipClick?.()) return;
+								onToggleExpanded();
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" || e.key === " ") {
+									e.preventDefault();
 									onToggleExpanded();
-								}}
-								onKeyDown={(e) => {
-									if (e.key === "Enter" || e.key === " ") {
-										e.preventDefault();
-										onToggleExpanded();
-									}
-								}}
-								className="group flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/40 focus-visible:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-							>
-								{/* Single 20px slot holds avatar (idle) and chevron (hover). Both
+								}
+							}}
+							className={cn(
+								"group relative flex cursor-grab items-center gap-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/40 focus-visible:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing",
+								nested && "ms-0",
+							)}
+						>
+							<DropLine line={dropLine} />
+							{/* Single 20px slot holds avatar (idle) and chevron (hover). Both
               live in the same grid cell so the row never reflows; opacity
               fades between them. motion-reduce drops the transition. */}
-								<div className="relative grid size-5 shrink-0 place-items-center">
-									<Avatar
-										className={cn(
-											"col-start-1 row-start-1 size-5 rounded transition-opacity duration-150 ease-out",
-											"group-hover:opacity-0 motion-reduce:transition-none",
-											showHeaderAttention && "opacity-0",
-										)}
-									>
-										{avatarUrl !== null && (
-											<AvatarImage src={avatarUrl} alt={displayName} />
-										)}
-										<AvatarFallback className="rounded text-[10px]">
-											{fallbackText}
-										</AvatarFallback>
-									</Avatar>
-									{showHeaderAttention && (
-										<ChatAttentionIcon
-											state={headerAttention}
-											className={cn(
-												"col-start-1 row-start-1 transition-opacity duration-150 ease-out",
-												"group-hover:opacity-0 motion-reduce:transition-none",
-											)}
-											context="project"
-										/>
+							<div className="relative grid size-5 shrink-0 place-items-center">
+								<Avatar
+									className={cn(
+										"col-start-1 row-start-1 size-5 rounded transition-opacity duration-150 ease-out",
+										"group-hover:opacity-0 motion-reduce:transition-none",
+										showHeaderAttention && "opacity-0",
 									)}
-									<Chevron
-										aria-hidden="true"
-										className={cn(
-											"col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
-											"group-hover:opacity-100 motion-reduce:transition-none",
-										)}
-									/>
-								</div>
-								<span
-									className="min-w-0 flex-1 truncate text-[12px]"
-									title={
-										origin
-											? `${origin.owner}/${origin.repo} · ${displayPath(path)}`
-											: displayPath(path)
-									}
 								>
-									{displayName}
-								</span>
-								<Tooltip>
-									<TooltipTrigger
-										render={
-											<button
-												type="button"
-												onClick={(event) => {
-													event.stopPropagation();
-													openRepositorySettings();
-												}}
-												className="rounded-md p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:transition-none"
-												aria-label={`Settings for ${displayName}`}
-											>
-												<HugeiconsIcon
-													icon={Settings01Icon}
-													className="size-3.5"
-												/>
-											</button>
-										}
+									{avatarUrl !== null && (
+										<AvatarImage src={avatarUrl} alt={displayName} />
+									)}
+									<AvatarFallback className="rounded text-[10px]">
+										{fallbackText}
+									</AvatarFallback>
+								</Avatar>
+								{showHeaderAttention && (
+									<ChatAttentionIcon
+										state={headerAttention}
+										className={cn(
+											"col-start-1 row-start-1 transition-opacity duration-150 ease-out",
+											"group-hover:opacity-0 motion-reduce:transition-none",
+										)}
+										context="project"
 									/>
-									<TooltipPopup>Repository settings</TooltipPopup>
-								</Tooltip>
-								<NewChatButton projectId={id} />
+								)}
+								<Chevron
+									aria-hidden="true"
+									className={cn(
+										"col-start-1 row-start-1 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-150 ease-out",
+										"group-hover:opacity-100 motion-reduce:transition-none",
+									)}
+								/>
 							</div>
-						}
-					/>
-					<TooltipPopup
-						side="right"
-						align="start"
-						sideOffset={8}
-						className="border border-border/60 bg-popover/95 shadow-overlay-md backdrop-blur-xl"
-					>
-						<SidebarProjectHoverCard
-							name={displayName}
-							path={path}
-							chatCount={chatRows.length}
-						/>
-					</TooltipPopup>
-				</Tooltip>
-
-				<ProjectContextMenu
-					open={menuOpen}
-					anchor={anchorRef.current}
-					onOpenSettings={openRepositorySettings}
-					onOpenArchives={openArchives}
-					onOpenUsage={openProjectUsage}
-					onRemove={onRemove}
-					onOpenChange={setMenuOpen}
+							<span
+								className="min-w-0 flex-1 truncate text-[12px]"
+								title={
+									origin
+										? `${origin.owner}/${origin.repo} · ${displayPath(path)}`
+										: displayPath(path)
+								}
+							>
+								{displayName}
+							</span>
+							<Tooltip>
+								<TooltipTrigger
+									render={
+										<button
+											type="button"
+											onClick={(event) => {
+												event.stopPropagation();
+												openRepositorySettings();
+											}}
+											className="rounded-md p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:transition-none"
+											onPointerDown={(event) => event.stopPropagation()}
+											aria-label={`Settings for ${displayName}`}
+										>
+											<HugeiconsIcon
+												icon={Settings01Icon}
+												className="size-3.5"
+											/>
+										</button>
+									}
+								/>
+								<TooltipPopup>Repository settings</TooltipPopup>
+							</Tooltip>
+							<NewChatButton projectId={id} />
+						</div>
+					}
 				/>
-			</li>
+				<TooltipPopup
+					side="right"
+					align="start"
+					sideOffset={8}
+					className="border border-border/60 bg-popover/95 shadow-overlay-md backdrop-blur-xl"
+				>
+					<SidebarProjectHoverCard
+						name={displayName}
+						path={path}
+						chatCount={chatRows.length}
+					/>
+				</TooltipPopup>
+			</Tooltip>
 
-			<li className="list-none" hidden={!isExpanded}>
+			<ProjectContextMenu
+				open={menuOpen}
+				anchor={anchorRef.current}
+				onOpenChange={setMenuOpen}
+				onOpenSettings={openRepositorySettings}
+				onOpenArchives={openArchives}
+				onOpenUsage={openProjectUsage}
+				onRemove={onRemove}
+				groups={organize?.groups ?? []}
+				currentGroupId={
+					projectKey === undefined
+						? null
+						: (organize?.inGroupId(projectKey) ?? null)
+				}
+				onNewGroup={
+					projectKey === undefined
+						? undefined
+						: () =>
+								organize?.setGroupDialog({
+									kind: "create",
+									projectKeys: [projectKey],
+								})
+				}
+				onAddToGroup={
+					projectKey === undefined
+						? undefined
+						: (groupId) => organize?.addToGroup(projectKey, groupId)
+				}
+				onRemoveFromGroup={
+					projectKey === undefined
+						? undefined
+						: () => organize?.removeFromGroup(projectKey)
+				}
+			/>
+			<div hidden={!isExpanded}>
 				<ul aria-label={`${displayName} chats`}>
 					{chatRows.length === 0 && (
 						<li className="px-12 py-1 text-[12px] text-muted-foreground">
@@ -1471,8 +2049,8 @@ function ProjectGroup({
 						),
 					)}
 				</ul>
-			</li>
-		</Fragment>
+			</div>
+		</li>
 	);
 }
 
@@ -1643,30 +2221,106 @@ function CloudChatRow({
 	);
 }
 
+function AddToGroupFlyout({
+	groups,
+	onAddToGroup,
+	onClose,
+}: {
+	groups: Organize["groups"];
+	onAddToGroup: (groupId: string) => void;
+	onClose: () => void;
+}) {
+	const itemRef = useRef<HTMLDivElement>(null);
+	const [open, setOpen] = useState(false);
+	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+	const closeTimer = useRef<number | null>(null);
+
+	const show = () => {
+		if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+		const rect = itemRef.current?.getBoundingClientRect();
+		if (rect !== undefined) {
+			setPos({ top: rect.top, left: rect.right + 4 });
+		}
+		setOpen(true);
+	};
+	const hide = () => {
+		closeTimer.current = window.setTimeout(() => setOpen(false), 120);
+	};
+
+	return (
+		<div
+			ref={itemRef}
+			onPointerEnter={show}
+			onPointerLeave={hide}
+			className="flex min-h-7 w-full cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] hover:bg-accent hover:text-accent-foreground"
+		>
+			<HugeiconsIcon icon={Folder01Icon} className="size-3.5" />
+			<span className="min-w-0 flex-1">Add to group</span>
+			<ChevronRight className="size-3.5 opacity-80" />
+			{open && pos !== null
+				? createPortal(
+						<div
+							onPointerEnter={show}
+							onPointerLeave={hide}
+							className="fixed z-50 min-w-[160px] rounded-lg border-glass bg-glass p-1 text-popover-foreground"
+							style={{ top: pos.top, left: pos.left }}
+						>
+							{groups.map((group) => (
+								<button
+									key={group.id}
+									type="button"
+									onClick={() => {
+										onAddToGroup(group.id);
+										onClose();
+									}}
+									className="flex min-h-7 w-full items-center rounded-lg px-2 py-1.5 text-left text-[13px] hover:bg-accent hover:text-accent-foreground"
+								>
+									{group.name}
+								</button>
+							))}
+						</div>,
+						document.body,
+					)
+				: null}
+		</div>
+	);
+}
+
 function ProjectContextMenu({
 	open,
 	anchor,
+	onOpenChange,
 	onOpenSettings,
 	onOpenArchives,
 	onOpenUsage,
 	onRemove,
-	onOpenChange,
+	groups,
+	currentGroupId,
+	onNewGroup,
+	onAddToGroup,
+	onRemoveFromGroup,
 }: {
 	open: boolean;
 	anchor: { getBoundingClientRect: () => DOMRect } | null;
+	onOpenChange: (open: boolean) => void;
 	onOpenSettings: () => void;
 	onOpenArchives: () => void;
 	onOpenUsage: () => void;
 	onRemove: () => void;
-	onOpenChange: (open: boolean) => void;
+	groups: Organize["groups"];
+	currentGroupId: string | null;
+	onNewGroup?: () => void;
+	onAddToGroup?: (groupId: string) => void;
+	onRemoveFromGroup?: () => void;
 }) {
+	const otherGroups = groups.filter((group) => group.id !== currentGroupId);
 	return (
-		<Menu open={open} onOpenChange={onOpenChange}>
+		<Menu open={open} onOpenChange={onOpenChange} modal={false}>
 			<MenuPopup
 				anchor={anchor ?? undefined}
 				align="start"
 				side="bottom"
-				className="min-w-[180px]"
+				className="min-w-[196px]"
 			>
 				<MenuItem
 					onClick={onOpenSettings}
@@ -1689,6 +2343,32 @@ function ProjectContextMenu({
 					<HugeiconsIcon icon={Analytics01Icon} className="size-3.5" />
 					Usage
 				</MenuItem>
+				<MenuSeparator />
+				{onNewGroup !== undefined ? (
+					<MenuItem
+						onClick={onNewGroup}
+						className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] hover:bg-sidebar-accent"
+					>
+						<HugeiconsIcon icon={FolderAddIcon} className="size-3.5" />
+						New group
+					</MenuItem>
+				) : null}
+				{onAddToGroup !== undefined && otherGroups.length > 0 ? (
+					<AddToGroupFlyout
+						groups={otherGroups}
+						onAddToGroup={onAddToGroup}
+						onClose={() => onOpenChange(false)}
+					/>
+				) : null}
+				{currentGroupId !== null && onRemoveFromGroup !== undefined ? (
+					<MenuItem
+						onClick={onRemoveFromGroup}
+						className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] hover:bg-sidebar-accent"
+					>
+						Remove from group
+					</MenuItem>
+				) : null}
+				<MenuSeparator />
 				<MenuItem
 					onClick={onRemove}
 					className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] text-red-300 hover:bg-red-500/20"
@@ -1739,6 +2419,7 @@ function NewChatButton({ projectId }: { projectId: FolderId }) {
 					<button
 						type="button"
 						onClick={onClick}
+						onPointerDown={(event) => event.stopPropagation()}
 						className="rounded-md p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:transition-none"
 						aria-label="New chat"
 					>

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -462,6 +462,10 @@ export function ProjectsSidebar() {
 										organize.sidebarGroupItemKey(node.group.id),
 									)}
 									dragProps={organize.groupDragProps(node.group.id)}
+									emptyDropActive={organize.isEmptyGroupDropActive(
+										node.group.id,
+									)}
+									emptyDropProps={organize.emptyGroupDropProps(node.group.id)}
 									onToggleCollapsed={() =>
 										organize.setGroupCollapsed(
 											node.group.id,
@@ -563,6 +567,10 @@ export function ProjectsSidebar() {
 										organize.sidebarGroupItemKey(node.group.id),
 									)}
 									dragProps={organize.groupDragProps(node.group.id)}
+									emptyDropActive={organize.isEmptyGroupDropActive(
+										node.group.id,
+									)}
+									emptyDropProps={organize.emptyGroupDropProps(node.group.id)}
 									onToggleCollapsed={() =>
 										organize.setGroupCollapsed(
 											node.group.id,
@@ -763,6 +771,8 @@ function UserProjectGroup({
 	group,
 	dropLine,
 	dragProps,
+	emptyDropActive,
+	emptyDropProps,
 	onToggleCollapsed,
 	onRename,
 	onDissolve,
@@ -773,6 +783,8 @@ function UserProjectGroup({
 	group: Organize["groups"][number];
 	dropLine: SidebarDropLine | null;
 	dragProps: ReturnType<Organize["groupDragProps"]>;
+	emptyDropActive: boolean;
+	emptyDropProps: ReturnType<Organize["emptyGroupDropProps"]>;
 	onToggleCollapsed: () => void;
 	onRename: () => void;
 	onDissolve: () => void;
@@ -853,7 +865,14 @@ function UserProjectGroup({
 			{group.collapsed ? null : (
 				<ul className="ms-2 flex flex-col gap-0.5 border-s border-sidebar-border/50 ps-1">
 					{group.projectKeys.length === 0 ? (
-						<li className="px-2 py-1 text-[12px] text-muted-foreground">
+						<li
+							{...emptyDropProps}
+							className={cn(
+								"rounded-md px-2 py-1 text-[12px] text-muted-foreground transition-colors",
+								emptyDropActive &&
+									"bg-sidebar-accent text-sidebar-accent-foreground ring-1 ring-inset ring-foreground/30",
+							)}
+						>
 							Drag projects here
 						</li>
 					) : (

--- a/apps/renderer/src/lib/sidebar-pointer-drag.ts
+++ b/apps/renderer/src/lib/sidebar-pointer-drag.ts
@@ -1,0 +1,150 @@
+type Point = { readonly clientX: number; readonly clientY: number };
+
+/** Keep sidebar drags in the renderer so the browser's native DnD cursor
+ * cannot replace the grabbing cursor while moving between drop targets. */
+export const startSidebarPointerDrag = (
+	element: HTMLElement,
+	start: PointerEvent,
+	callbacks: {
+		readonly onMove: (point: Point) => void;
+		readonly onDrop: (point: Point) => void;
+		readonly onEnd: () => void;
+	},
+): (() => void) => {
+	const doc = element.ownerDocument;
+	const view = doc.defaultView;
+	if (view === null) return () => {};
+	let dragging = false;
+	let ended = false;
+	let preview: HTMLElement | null = null;
+	let clickTimer: number | undefined;
+	let scrollFrame: number | undefined;
+	let point: Point = start;
+	const scrollArea = element.closest<HTMLElement>("[data-sidebar-scroll]");
+	const scroll = () => {
+		scrollFrame = undefined;
+		if (ended || scrollArea === null) return;
+		const rect = scrollArea.getBoundingClientRect();
+		if (point.clientX < rect.left || point.clientX > rect.right) return;
+		const velocity =
+			point.clientY < rect.top + 28
+				? -8
+				: point.clientY > rect.bottom - 28
+					? 8
+					: 0;
+		const previous = scrollArea.scrollTop;
+		scrollArea.scrollTop += velocity;
+		if (scrollArea.scrollTop === previous) return;
+		callbacks.onMove(point);
+		scrollFrame = view.requestAnimationFrame(scroll);
+	};
+	const preventClick = (event: MouseEvent) => {
+		event.preventDefault();
+		event.stopPropagation();
+	};
+	const removeClickGuard = () => {
+		view.clearTimeout(clickTimer);
+		doc.removeEventListener("click", preventClick, { capture: true });
+		view.removeEventListener("pointerup", releaseClickGuard);
+		view.removeEventListener("pointerdown", removeClickGuard, {
+			capture: true,
+		});
+	};
+	const releaseClickGuard = () => {
+		clickTimer = view.setTimeout(removeClickGuard, 0);
+	};
+	const finish = () => {
+		if (ended) return;
+		ended = true;
+		view.removeEventListener("pointermove", onMove);
+		view.removeEventListener("pointerup", onUp);
+		view.removeEventListener("pointercancel", onCancel);
+		view.removeEventListener("keydown", onKeyDown, { capture: true });
+		view.removeEventListener("blur", finish);
+		element.removeEventListener("lostpointercapture", finish);
+		if (scrollFrame !== undefined) view.cancelAnimationFrame(scrollFrame);
+		if (element.hasPointerCapture(start.pointerId))
+			element.releasePointerCapture(start.pointerId);
+		if (dragging) {
+			doc.documentElement.removeAttribute("data-sidebar-dragging");
+			preview?.remove();
+			// Keep the click guard through release, including after Escape/blur.
+			view.addEventListener("pointerup", releaseClickGuard, { once: true });
+			view.addEventListener("pointerdown", removeClickGuard, {
+				once: true,
+				capture: true,
+			});
+		}
+		callbacks.onEnd();
+	};
+	const onMove = (event: PointerEvent) => {
+		if (event.pointerId !== start.pointerId) return;
+		if ((event.buttons & 1) === 0) {
+			finish();
+			return;
+		}
+		if (!dragging) {
+			if (
+				Math.hypot(
+					event.clientX - start.clientX,
+					event.clientY - start.clientY,
+				) < 5
+			)
+				return;
+			dragging = true;
+			element.setPointerCapture(start.pointerId);
+			element.addEventListener("lostpointercapture", finish);
+			doc.documentElement.setAttribute("data-sidebar-dragging", "");
+			doc.addEventListener("click", preventClick, true);
+			const rect = element.getBoundingClientRect();
+			preview = element.cloneNode(true) as HTMLElement;
+			preview.removeAttribute("id");
+			preview.setAttribute("aria-hidden", "true");
+			preview.inert = true;
+			Object.assign(preview.style, {
+				position: "fixed",
+				left: `${rect.left}px`,
+				top: `${rect.top}px`,
+				width: `${rect.width}px`,
+				pointerEvents: "none",
+				opacity: "0.75",
+				zIndex: "9999",
+			});
+			doc.body.append(preview);
+		}
+		event.preventDefault();
+		point = event;
+		if (preview !== null)
+			preview.style.transform = `translate(${event.clientX - start.clientX}px, ${event.clientY - start.clientY}px)`;
+		callbacks.onMove(event);
+		if (scrollFrame === undefined)
+			scrollFrame = view.requestAnimationFrame(scroll);
+	};
+	const onUp = (event: PointerEvent) => {
+		if (event.pointerId !== start.pointerId) return;
+		try {
+			if (dragging) callbacks.onDrop(event);
+		} finally {
+			finish();
+			releaseClickGuard();
+		}
+	};
+	const onCancel = (event: PointerEvent) => {
+		if (event.pointerId === start.pointerId) finish();
+	};
+	const onKeyDown = (event: KeyboardEvent) => {
+		if (event.key !== "Escape") return;
+		event.preventDefault();
+		event.stopPropagation();
+		finish();
+	};
+	view.addEventListener("pointermove", onMove, { passive: false });
+	view.addEventListener("pointerup", onUp);
+	view.addEventListener("pointercancel", onCancel);
+	view.addEventListener("keydown", onKeyDown, true);
+	view.addEventListener("blur", finish);
+	return () => {
+		finish();
+		removeClickGuard();
+	};
+};

--- a/apps/renderer/src/lib/sidebar-project-icon.ts
+++ b/apps/renderer/src/lib/sidebar-project-icon.ts
@@ -1,0 +1,34 @@
+export const PROJECT_ICON_COLOR_IDS = [
+	"rose",
+	"orange",
+	"amber",
+	"emerald",
+	"teal",
+	"sky",
+	"indigo",
+	"violet",
+	"pink",
+] as const;
+
+export type ProjectIconColorId = (typeof PROJECT_ICON_COLOR_IDS)[number];
+
+export const isProjectIconColorId = (
+	value: unknown,
+): value is ProjectIconColorId =>
+	typeof value === "string" &&
+	(PROJECT_ICON_COLOR_IDS as ReadonlyArray<string>).includes(value);
+
+export const PROJECT_ICON_COLOR_STYLES: Record<
+	ProjectIconColorId,
+	{ readonly swatch: string; readonly icon: string }
+> = {
+	rose: { swatch: "bg-rose-400", icon: "text-rose-500" },
+	orange: { swatch: "bg-orange-400", icon: "text-orange-500" },
+	amber: { swatch: "bg-amber-400", icon: "text-amber-500" },
+	emerald: { swatch: "bg-emerald-400", icon: "text-emerald-500" },
+	teal: { swatch: "bg-teal-400", icon: "text-teal-500" },
+	sky: { swatch: "bg-sky-400", icon: "text-sky-500" },
+	indigo: { swatch: "bg-indigo-400", icon: "text-indigo-500" },
+	violet: { swatch: "bg-violet-400", icon: "text-violet-500" },
+	pink: { swatch: "bg-pink-400", icon: "text-pink-500" },
+};

--- a/apps/renderer/src/lib/sidebar-project-layout.ts
+++ b/apps/renderer/src/lib/sidebar-project-layout.ts
@@ -54,6 +54,15 @@ export type SidebarDropTarget =
 	  }
 	| { readonly kind: "group-end"; readonly groupId: string };
 
+export const sidebarProjectRowAcceptsDrop = (
+	source: SidebarDragSource,
+	groupId: string | null,
+): boolean => source.kind === "project" || groupId === null;
+
+export const sidebarEmptyGroupAcceptsDrop = (
+	source: SidebarDragSource,
+): boolean => source.kind === "project";
+
 const unique = (keys: ReadonlyArray<string>): string[] => {
 	const seen = new Set<string>();
 	const out: string[] = [];

--- a/apps/renderer/src/lib/sidebar-project-layout.ts
+++ b/apps/renderer/src/lib/sidebar-project-layout.ts
@@ -1,0 +1,382 @@
+/**
+ * User-defined sidebar organization: a stable top-level order of projects
+ * and named groups. Distinct from `project-groups.ts`, which collapses the
+ * same git origin across computers into one logical row.
+ *
+ * Keys are whatever the sidebar already uses as a row identity (logical
+ * group key, or folder id when the catalog is off). Unknown keys are
+ * dropped; newly seen projects append.
+ */
+
+import {
+	isProjectIconColorId,
+	type ProjectIconColorId,
+} from "./sidebar-project-icon.ts";
+
+export type SidebarProjectGroup = {
+	readonly id: string;
+	readonly name: string;
+	readonly collapsed: boolean;
+	readonly projectKeys: ReadonlyArray<string>;
+	readonly iconColor?: ProjectIconColorId;
+};
+
+export type SidebarProjectLayout = {
+	readonly order: ReadonlyArray<string>;
+	readonly groups: ReadonlyArray<SidebarProjectGroup>;
+};
+
+export const EMPTY_SIDEBAR_PROJECT_LAYOUT: SidebarProjectLayout = {
+	order: [],
+	groups: [],
+};
+
+export const sidebarGroupItemKey = (id: string): string => `group:${id}`;
+
+export const parseSidebarGroupItemKey = (key: string): string | null =>
+	key.startsWith("group:") ? key.slice("group:".length) : null;
+
+export type SidebarLayoutNode =
+	| { readonly kind: "project"; readonly key: string }
+	| { readonly kind: "group"; readonly group: SidebarProjectGroup };
+
+export type SidebarDragSource =
+	| { readonly kind: "project"; readonly key: string }
+	| { readonly kind: "group"; readonly id: string };
+
+export type SidebarDropTarget =
+	| { readonly kind: "before"; readonly itemKey: string }
+	| { readonly kind: "end" }
+	| {
+			readonly kind: "group-before";
+			readonly groupId: string;
+			readonly projectKey: string;
+	  }
+	| { readonly kind: "group-end"; readonly groupId: string };
+
+const unique = (keys: ReadonlyArray<string>): string[] => {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const key of keys) {
+		if (key.length === 0 || seen.has(key)) continue;
+		seen.add(key);
+		out.push(key);
+	}
+	return out;
+};
+
+const groupMap = (
+	layout: SidebarProjectLayout,
+): Map<string, SidebarProjectGroup> => {
+	const map = new Map<string, SidebarProjectGroup>();
+	for (const group of layout.groups) map.set(group.id, group);
+	return map;
+};
+
+const projectGroupId = (
+	layout: SidebarProjectLayout,
+	projectKey: string,
+): string | null => {
+	for (const group of layout.groups) {
+		if (group.projectKeys.includes(projectKey)) return group.id;
+	}
+	return null;
+};
+
+const removeProject = (
+	layout: SidebarProjectLayout,
+	projectKey: string,
+): SidebarProjectLayout => ({
+	...layout,
+	order: layout.order.filter((key) => key !== projectKey),
+	groups: layout.groups.map((group) => ({
+		...group,
+		projectKeys: group.projectKeys.filter((key) => key !== projectKey),
+	})),
+});
+
+const insertBefore = (
+	keys: ReadonlyArray<string>,
+	item: string,
+	before: string | null,
+): string[] => {
+	const without = keys.filter((key) => key !== item);
+	if (before === null) return [...without, item];
+	const index = without.indexOf(before);
+	if (index < 0) return [...without, item];
+	return [...without.slice(0, index), item, ...without.slice(index)];
+};
+
+export const materializeSidebarLayout = (
+	projectKeys: ReadonlyArray<string>,
+	layout: SidebarProjectLayout,
+): ReadonlyArray<SidebarLayoutNode> => {
+	const known = new Set(projectKeys);
+	const used = new Set<string>();
+	const groups = new Map<string, SidebarProjectGroup>();
+	for (const group of layout.groups) {
+		groups.set(group.id, {
+			...group,
+			projectKeys: unique(group.projectKeys.filter((key) => known.has(key))),
+		});
+	}
+
+	const nodes: SidebarLayoutNode[] = [];
+	const seenGroups = new Set<string>();
+	for (const item of layout.order) {
+		const groupId = parseSidebarGroupItemKey(item);
+		if (groupId !== null) {
+			const group = groups.get(groupId);
+			if (group === undefined || seenGroups.has(groupId)) continue;
+			seenGroups.add(groupId);
+			for (const key of group.projectKeys) used.add(key);
+			nodes.push({ kind: "group", group });
+			continue;
+		}
+		if (!known.has(item) || used.has(item)) continue;
+		used.add(item);
+		nodes.push({ kind: "project", key: item });
+	}
+
+	for (const group of groups.values()) {
+		if (seenGroups.has(group.id)) continue;
+		seenGroups.add(group.id);
+		for (const key of group.projectKeys) used.add(key);
+		nodes.push({ kind: "group", group });
+	}
+
+	for (const key of projectKeys) {
+		if (used.has(key)) continue;
+		nodes.push({ kind: "project", key });
+	}
+
+	return nodes;
+};
+
+export const createSidebarGroup = (
+	layout: SidebarProjectLayout,
+	input: {
+		readonly id: string;
+		readonly name: string;
+		readonly projectKeys: ReadonlyArray<string>;
+	},
+): SidebarProjectLayout => {
+	const name = input.name.trim();
+	if (name.length === 0) return layout;
+	const insertIndexes = input.projectKeys
+		.map((key) => layout.order.indexOf(key))
+		.filter((index) => index >= 0);
+	let next = layout;
+	for (const key of input.projectKeys) next = removeProject(next, key);
+	const group: SidebarProjectGroup = {
+		id: input.id,
+		name,
+		collapsed: false,
+		projectKeys: unique(input.projectKeys),
+	};
+	const itemKey = sidebarGroupItemKey(group.id);
+	const insertAt =
+		insertIndexes.length === 0 ? next.order.length : Math.min(...insertIndexes);
+	const order = [...next.order];
+	order.splice(Math.min(insertAt, order.length), 0, itemKey);
+	return {
+		...next,
+		order: unique(order),
+		groups: [...next.groups, group],
+	};
+};
+
+export const renameSidebarGroup = (
+	layout: SidebarProjectLayout,
+	groupId: string,
+	name: string,
+): SidebarProjectLayout => {
+	const trimmed = name.trim();
+	if (trimmed.length === 0) return layout;
+	return {
+		...layout,
+		groups: layout.groups.map((group) =>
+			group.id === groupId ? { ...group, name: trimmed } : group,
+		),
+	};
+};
+
+export const setSidebarGroupCollapsed = (
+	layout: SidebarProjectLayout,
+	groupId: string,
+	collapsed: boolean,
+): SidebarProjectLayout => ({
+	...layout,
+	groups: layout.groups.map((group) =>
+		group.id === groupId ? { ...group, collapsed } : group,
+	),
+});
+
+export const dissolveSidebarGroup = (
+	layout: SidebarProjectLayout,
+	groupId: string,
+): SidebarProjectLayout => {
+	const group = groupMap(layout).get(groupId);
+	if (group === undefined) return layout;
+	const itemKey = sidebarGroupItemKey(groupId);
+	const order = layout.order.filter((key) => key !== itemKey);
+	const insertAt = layout.order.indexOf(itemKey);
+	const nextOrder =
+		insertAt < 0
+			? [...order, ...group.projectKeys]
+			: [
+					...order.slice(0, insertAt),
+					...group.projectKeys,
+					...order.slice(insertAt),
+				];
+	return {
+		...layout,
+		order: unique(nextOrder),
+		groups: layout.groups.filter((entry) => entry.id !== groupId),
+	};
+};
+
+export const moveSidebarItem = (
+	layout: SidebarProjectLayout,
+	source: SidebarDragSource,
+	target: SidebarDropTarget,
+): SidebarProjectLayout => {
+	if (source.kind === "group") {
+		if (target.kind === "group-before" || target.kind === "group-end") {
+			return layout;
+		}
+		const itemKey = sidebarGroupItemKey(source.id);
+		if (
+			!layout.order.includes(itemKey) &&
+			!layout.groups.some((g) => g.id === source.id)
+		) {
+			return layout;
+		}
+		const before =
+			target.kind === "end"
+				? null
+				: target.itemKey === itemKey
+					? null
+					: target.itemKey;
+		if (target.kind === "before" && target.itemKey === itemKey) return layout;
+		return {
+			...layout,
+			order: insertBefore(layout.order, itemKey, before),
+		};
+	}
+
+	if (target.kind === "before" && target.itemKey === source.key) return layout;
+	if (target.kind === "group-before" && target.projectKey === source.key) {
+		return layout;
+	}
+
+	const next = removeProject(layout, source.key);
+
+	if (target.kind === "before" || target.kind === "end") {
+		const before = target.kind === "end" ? null : target.itemKey;
+		return {
+			...next,
+			order: insertBefore(next.order, source.key, before),
+		};
+	}
+
+	const group = groupMap(next).get(target.groupId);
+	if (group === undefined) return layout;
+	const projectKeys =
+		target.kind === "group-end"
+			? [...group.projectKeys, source.key]
+			: insertBefore(group.projectKeys, source.key, target.projectKey);
+	return {
+		...next,
+		groups: next.groups.map((entry) =>
+			entry.id === target.groupId ? { ...entry, projectKeys } : entry,
+		),
+	};
+};
+
+export const projectGroupIdFor = projectGroupId;
+
+export const snapshotSidebarOrder = (
+	projectKeys: ReadonlyArray<string>,
+	layout: SidebarProjectLayout,
+): SidebarProjectLayout => {
+	const nodes = materializeSidebarLayout(projectKeys, layout);
+	return {
+		...layout,
+		order: nodes.map((node) =>
+			node.kind === "group" ? sidebarGroupItemKey(node.group.id) : node.key,
+		),
+		groups: nodes.flatMap((node) =>
+			node.kind === "group" ? [node.group] : [],
+		),
+	};
+};
+
+export const setSidebarGroupIconColor = (
+	layout: SidebarProjectLayout,
+	groupId: string,
+	color: ProjectIconColorId | null,
+): SidebarProjectLayout => ({
+	...layout,
+	groups: layout.groups.map((group) => {
+		if (group.id !== groupId) return group;
+		if (color === null) {
+			const { iconColor: _removed, ...rest } = group;
+			return rest;
+		}
+		return { ...group, iconColor: color };
+	}),
+});
+
+export const parseSidebarProjectLayout = (
+	value: unknown,
+): SidebarProjectLayout => {
+	if (value === null || typeof value !== "object") {
+		return EMPTY_SIDEBAR_PROJECT_LAYOUT;
+	}
+	const record = value as {
+		readonly order?: unknown;
+		readonly groups?: unknown;
+		readonly iconColors?: unknown;
+	};
+	const order = Array.isArray(record.order)
+		? unique(
+				record.order.filter((key): key is string => typeof key === "string"),
+			)
+		: [];
+	const legacyColors: Record<string, ProjectIconColorId> = {};
+	if (record.iconColors !== null && typeof record.iconColors === "object") {
+		for (const [key, color] of Object.entries(
+			record.iconColors as Record<string, unknown>,
+		)) {
+			if (isProjectIconColorId(color)) legacyColors[key] = color;
+		}
+	}
+	const groups: SidebarProjectGroup[] = [];
+	if (Array.isArray(record.groups)) {
+		for (const entry of record.groups) {
+			if (entry === null || typeof entry !== "object") continue;
+			const group = entry as Record<string, unknown>;
+			if (typeof group.id !== "string" || group.id.length === 0) continue;
+			if (typeof group.name !== "string") continue;
+			const projectKeys = Array.isArray(group.projectKeys)
+				? unique(
+						group.projectKeys.filter(
+							(key): key is string => typeof key === "string",
+						),
+					)
+				: [];
+			const iconColor = isProjectIconColorId(group.iconColor)
+				? group.iconColor
+				: (legacyColors[group.id] ?? undefined);
+			groups.push({
+				id: group.id,
+				name: group.name,
+				collapsed: group.collapsed === true,
+				projectKeys,
+				...(iconColor !== undefined ? { iconColor } : {}),
+			});
+		}
+	}
+	return { order, groups };
+};

--- a/apps/renderer/src/lib/use-sidebar-organize.ts
+++ b/apps/renderer/src/lib/use-sidebar-organize.ts
@@ -1,0 +1,229 @@
+import { type DragEvent, useMemo, useRef, useState } from "react";
+import { useSidebarProjectLayoutStore } from "../store/sidebar-project-layout.ts";
+import {
+	materializeSidebarLayout,
+	projectGroupIdFor,
+	type SidebarDragSource,
+	type SidebarDropTarget,
+	type SidebarLayoutNode,
+	sidebarGroupItemKey,
+} from "./sidebar-project-layout.ts";
+
+export type SidebarDropLine = "before" | "after" | "into";
+
+export type SidebarGroupDialog =
+	| { readonly kind: "create"; readonly projectKeys: ReadonlyArray<string> }
+	| {
+			readonly kind: "rename";
+			readonly groupId: string;
+			readonly name: string;
+	  };
+
+const itemKeyOf = (node: SidebarLayoutNode): string =>
+	node.kind === "group" ? sidebarGroupItemKey(node.group.id) : node.key;
+
+export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
+	const layout = useSidebarProjectLayoutStore((s) => s.layout);
+	const move = useSidebarProjectLayoutStore((s) => s.move);
+	const createGroup = useSidebarProjectLayoutStore((s) => s.createGroup);
+	const renameGroup = useSidebarProjectLayoutStore((s) => s.renameGroup);
+	const setGroupCollapsed = useSidebarProjectLayoutStore(
+		(s) => s.setGroupCollapsed,
+	);
+	const dissolveGroup = useSidebarProjectLayoutStore((s) => s.dissolveGroup);
+	const setGroupIconColor = useSidebarProjectLayoutStore(
+		(s) => s.setGroupIconColor,
+	);
+
+	const nodes = useMemo(
+		() => materializeSidebarLayout(projectKeys, layout),
+		[layout, projectKeys],
+	);
+
+	const dragSourceRef = useRef<SidebarDragSource | null>(null);
+	const skipClickRef = useRef(false);
+	const [drop, setDrop] = useState<{
+		readonly key: string;
+		readonly line: SidebarDropLine;
+	} | null>(null);
+	const [groupDialog, setGroupDialog] = useState<SidebarGroupDialog | null>(
+		null,
+	);
+
+	const topAfter = (index: number): SidebarDropTarget => {
+		const next = nodes[index + 1];
+		return next === undefined
+			? { kind: "end" }
+			: { kind: "before", itemKey: itemKeyOf(next) };
+	};
+
+	const clearDrag = (): void => {
+		dragSourceRef.current = null;
+		setDrop(null);
+	};
+
+	const applyDrop = (target: SidebarDropTarget): void => {
+		const source = dragSourceRef.current;
+		if (source === null) return;
+		move(source, target, projectKeys);
+		skipClickRef.current = true;
+		clearDrag();
+	};
+
+	const consumeSkipClick = (): boolean => {
+		if (!skipClickRef.current) return false;
+		skipClickRef.current = false;
+		return true;
+	};
+
+	const projectDragProps = (key: string, groupId: string | null) => {
+		const nodeIndex = nodes.findIndex((node) =>
+			node.kind === "project"
+				? node.key === key
+				: node.group.projectKeys.includes(key),
+		);
+		const node = nodes[nodeIndex];
+		const innerIndex =
+			node?.kind === "group" ? node.group.projectKeys.indexOf(key) : -1;
+		const nextInGroup =
+			node?.kind === "group"
+				? node.group.projectKeys[innerIndex + 1]
+				: undefined;
+		const before: SidebarDropTarget =
+			groupId === null
+				? { kind: "before", itemKey: key }
+				: { kind: "group-before", groupId, projectKey: key };
+		const after: SidebarDropTarget =
+			groupId === null
+				? nodeIndex >= 0
+					? topAfter(nodeIndex)
+					: { kind: "end" }
+				: nextInGroup === undefined
+					? { kind: "group-end", groupId }
+					: {
+							kind: "group-before",
+							groupId,
+							projectKey: nextInGroup,
+						};
+
+		return {
+			draggable: true,
+			onDragStart: (event: DragEvent<HTMLElement>) => {
+				dragSourceRef.current = { kind: "project", key };
+				event.dataTransfer.effectAllowed = "move";
+				event.dataTransfer.setData("text/plain", key);
+			},
+			onDragOver: (event: DragEvent<HTMLElement>) => {
+				if (dragSourceRef.current === null) return;
+				event.preventDefault();
+				event.stopPropagation();
+				event.dataTransfer.dropEffect = "move";
+				const rect = event.currentTarget.getBoundingClientRect();
+				const line: SidebarDropLine =
+					event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+				setDrop((current) =>
+					current?.key === key && current.line === line
+						? current
+						: { key, line },
+				);
+			},
+			onDrop: (event: DragEvent<HTMLElement>) => {
+				event.preventDefault();
+				event.stopPropagation();
+				const rect = event.currentTarget.getBoundingClientRect();
+				applyDrop(event.clientY < rect.top + rect.height / 2 ? before : after);
+			},
+			onDragEnd: () => clearDrag(),
+		};
+	};
+
+	const groupDragProps = (id: string) => {
+		const itemKey = sidebarGroupItemKey(id);
+		const nodeIndex = nodes.findIndex(
+			(node) => node.kind === "group" && node.group.id === id,
+		);
+		return {
+			draggable: true,
+			onDragStart: (event: DragEvent<HTMLElement>) => {
+				dragSourceRef.current = { kind: "group", id };
+				event.dataTransfer.effectAllowed = "move";
+				event.dataTransfer.setData("text/plain", itemKey);
+			},
+			onDragOver: (event: DragEvent<HTMLElement>) => {
+				if (dragSourceRef.current === null) return;
+				event.preventDefault();
+				event.stopPropagation();
+				event.dataTransfer.dropEffect = "move";
+				const rect = event.currentTarget.getBoundingClientRect();
+				const y = (event.clientY - rect.top) / rect.height;
+				const source = dragSourceRef.current;
+				const line: SidebarDropLine =
+					source.kind === "project" && y > 0.28 && y < 0.78
+						? "into"
+						: y < 0.5
+							? "before"
+							: "after";
+				setDrop((current) =>
+					current?.key === itemKey && current.line === line
+						? current
+						: { key: itemKey, line },
+				);
+			},
+			onDrop: (event: DragEvent<HTMLElement>) => {
+				event.preventDefault();
+				event.stopPropagation();
+				const rect = event.currentTarget.getBoundingClientRect();
+				const y = (event.clientY - rect.top) / rect.height;
+				const source = dragSourceRef.current;
+				if (source?.kind === "project" && y > 0.28 && y < 0.78) {
+					applyDrop({ kind: "group-end", groupId: id });
+					return;
+				}
+				applyDrop(
+					y < 0.5
+						? { kind: "before", itemKey }
+						: nodeIndex >= 0
+							? topAfter(nodeIndex)
+							: { kind: "end" },
+				);
+			},
+			onDragEnd: () => clearDrag(),
+		};
+	};
+
+	const dropLineFor = (key: string): SidebarDropLine | null =>
+		drop?.key === key ? drop.line : null;
+
+	return {
+		nodes,
+		groups: layout.groups,
+		dropLineFor,
+		projectDragProps,
+		groupDragProps,
+		consumeSkipClick,
+		inGroupId: (projectKey: string) => projectGroupIdFor(layout, projectKey),
+		groupDialog,
+		setGroupDialog,
+		createGroup: (name: string, keys: ReadonlyArray<string>) => {
+			createGroup(
+				{ id: crypto.randomUUID(), name, projectKeys: keys },
+				projectKeys,
+			);
+		},
+		renameGroup,
+		setGroupCollapsed,
+		dissolveGroup: (groupId: string) => dissolveGroup(groupId, projectKeys),
+		addToGroup: (projectKey: string, groupId: string) => {
+			move(
+				{ kind: "project", key: projectKey },
+				{ kind: "group-end", groupId },
+				projectKeys,
+			);
+		},
+		removeFromGroup: (projectKey: string) => {
+			move({ kind: "project", key: projectKey }, { kind: "end" }, projectKeys);
+		},
+		sidebarGroupItemKey,
+		setGroupIconColor,
+	};
+};

--- a/apps/renderer/src/lib/use-sidebar-organize.ts
+++ b/apps/renderer/src/lib/use-sidebar-organize.ts
@@ -1,5 +1,13 @@
-import { type DragEvent, useMemo, useRef, useState } from "react";
+import {
+	type DragEvent,
+	type PointerEvent,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useSidebarProjectLayoutStore } from "../store/sidebar-project-layout.ts";
+import { startSidebarPointerDrag } from "./sidebar-pointer-drag.ts";
 import {
 	materializeSidebarLayout,
 	projectGroupIdFor,
@@ -24,6 +32,17 @@ export type SidebarGroupDialog =
 const itemKeyOf = (node: SidebarLayoutNode): string =>
 	node.kind === "group" ? sidebarGroupItemKey(node.group.id) : node.key;
 
+type Drop = {
+	readonly key: string;
+	readonly line: SidebarDropLine;
+	readonly target: SidebarDropTarget;
+};
+type DropResolver = (
+	source: SidebarDragSource,
+	element: HTMLElement,
+	clientY: number,
+) => Drop | null;
+
 const emptyGroupDropKey = (groupId: string): string => `empty-group:${groupId}`;
 
 export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
@@ -44,8 +63,9 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 		[layout, projectKeys],
 	);
 
-	const dragSourceRef = useRef<SidebarDragSource | null>(null);
-	const skipClickRef = useRef(false);
+	const cancelDragRef = useRef<(() => void) | null>(null);
+	const dropTargets = useRef(new WeakMap<HTMLElement, DropResolver>());
+	useEffect(() => () => cancelDragRef.current?.(), []);
 	const [drop, setDrop] = useState<{
 		readonly key: string;
 		readonly line: SidebarDropLine;
@@ -62,23 +82,66 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 	};
 
 	const clearDrag = (): void => {
-		dragSourceRef.current = null;
 		setDrop(null);
 	};
 
-	const applyDrop = (target: SidebarDropTarget): void => {
-		const source = dragSourceRef.current;
-		if (source === null) return;
-		move(source, target, projectKeys);
-		skipClickRef.current = true;
-		clearDrag();
-	};
+	const targetProps = (resolve: DropResolver) => ({
+		ref: (element: HTMLElement | null) => {
+			if (element !== null) dropTargets.current.set(element, resolve);
+		},
+	});
 
-	const consumeSkipClick = (): boolean => {
-		if (!skipClickRef.current) return false;
-		skipClickRef.current = false;
-		return true;
-	};
+	const sourceProps = (source: SidebarDragSource) => ({
+		draggable: false,
+		onDragStart: (event: DragEvent<HTMLElement>) => event.preventDefault(),
+		onPointerDown: (event: PointerEvent<HTMLElement>) => {
+			if (
+				!event.isPrimary ||
+				event.button !== 0 ||
+				event.pointerType === "touch"
+			)
+				return;
+			const element = event.currentTarget;
+			cancelDragRef.current?.();
+			const targetAt = (point: {
+				clientX: number;
+				clientY: number;
+			}): Drop | null => {
+				let target = element.ownerDocument.elementFromPoint(
+					point.clientX,
+					point.clientY,
+				);
+				while (target !== null) {
+					if (target instanceof HTMLElement) {
+						const resolve = dropTargets.current.get(target);
+						if (resolve !== undefined)
+							return resolve(source, target, point.clientY);
+					}
+					target = target.parentElement;
+				}
+				return null;
+			};
+			cancelDragRef.current = startSidebarPointerDrag(
+				element,
+				event.nativeEvent,
+				{
+					onMove: (point) => {
+						const next = targetAt(point);
+						setDrop((current) =>
+							current?.key === next?.key && current?.line === next?.line
+								? current
+								: next,
+						);
+					},
+					onDrop: (point) => {
+						const next = targetAt(point);
+						if (next !== null) move(source, next.target, projectKeys);
+					},
+					onEnd: clearDrag,
+				},
+			);
+		},
+	});
 
 	const projectDragProps = (key: string, groupId: string | null) => {
 		const nodeIndex = nodes.findIndex((node) =>
@@ -111,79 +174,26 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 						};
 
 		return {
-			draggable: true,
-			onDragStart: (event: DragEvent<HTMLElement>) => {
-				dragSourceRef.current = { kind: "project", key };
-				event.dataTransfer.effectAllowed = "move";
-				event.dataTransfer.setData("text/plain", key);
-			},
-			onDragOver: (event: DragEvent<HTMLElement>) => {
-				const source = dragSourceRef.current;
-				if (source === null) return;
-				if (!sidebarProjectRowAcceptsDrop(source, groupId)) {
-					setDrop(null);
-					return;
-				}
-				event.preventDefault();
-				event.stopPropagation();
-				event.dataTransfer.dropEffect = "move";
-				const rect = event.currentTarget.getBoundingClientRect();
-				const line: SidebarDropLine =
-					event.clientY < rect.top + rect.height / 2 ? "before" : "after";
-				setDrop((current) =>
-					current?.key === key && current.line === line
-						? current
-						: { key, line },
-				);
-			},
-			onDrop: (event: DragEvent<HTMLElement>) => {
-				const source = dragSourceRef.current;
-				if (source === null) return;
-				if (!sidebarProjectRowAcceptsDrop(source, groupId)) {
-					clearDrag();
-					return;
-				}
-				event.preventDefault();
-				event.stopPropagation();
-				const rect = event.currentTarget.getBoundingClientRect();
-				applyDrop(event.clientY < rect.top + rect.height / 2 ? before : after);
-			},
-			onDragEnd: () => clearDrag(),
+			...sourceProps({ kind: "project", key }),
+			...targetProps((source, element, clientY) => {
+				if (!sidebarProjectRowAcceptsDrop(source, groupId)) return null;
+				const rect = element.getBoundingClientRect();
+				const line = clientY < rect.top + rect.height / 2 ? "before" : "after";
+				return { key, line, target: line === "before" ? before : after };
+			}),
 		};
 	};
 
-	const emptyGroupDropProps = (groupId: string) => {
-		const dropKey = emptyGroupDropKey(groupId);
-		return {
-			onDragOver: (event: DragEvent<HTMLElement>) => {
-				const source = dragSourceRef.current;
-				if (source === null || !sidebarEmptyGroupAcceptsDrop(source)) {
-					setDrop(null);
-					return;
-				}
-				event.preventDefault();
-				event.stopPropagation();
-				event.dataTransfer.dropEffect = "move";
-				setDrop((current) =>
-					current?.key === dropKey && current.line === "into"
-						? current
-						: { key: dropKey, line: "into" },
-				);
-			},
-			onDrop: (event: DragEvent<HTMLElement>) => {
-				const source = dragSourceRef.current;
-				if (source === null || !sidebarEmptyGroupAcceptsDrop(source)) {
-					clearDrag();
-					return;
-				}
-				event.preventDefault();
-				event.stopPropagation();
-				applyDrop({ kind: "group-end", groupId });
-			},
-			onDragLeave: () =>
-				setDrop((current) => (current?.key === dropKey ? null : current)),
-		};
-	};
+	const emptyGroupDropProps = (groupId: string) =>
+		targetProps((source) =>
+			sidebarEmptyGroupAcceptsDrop(source)
+				? {
+						key: emptyGroupDropKey(groupId),
+						line: "into",
+						target: { kind: "group-end", groupId },
+					}
+				: null,
+		);
 
 	const groupDragProps = (id: string) => {
 		const itemKey = sidebarGroupItemKey(id);
@@ -191,51 +201,26 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 			(node) => node.kind === "group" && node.group.id === id,
 		);
 		return {
-			draggable: true,
-			onDragStart: (event: DragEvent<HTMLElement>) => {
-				dragSourceRef.current = { kind: "group", id };
-				event.dataTransfer.effectAllowed = "move";
-				event.dataTransfer.setData("text/plain", itemKey);
-			},
-			onDragOver: (event: DragEvent<HTMLElement>) => {
-				if (dragSourceRef.current === null) return;
-				event.preventDefault();
-				event.stopPropagation();
-				event.dataTransfer.dropEffect = "move";
-				const rect = event.currentTarget.getBoundingClientRect();
-				const y = (event.clientY - rect.top) / rect.height;
-				const source = dragSourceRef.current;
-				const line: SidebarDropLine =
+			...sourceProps({ kind: "group", id }),
+			...targetProps((source, element, clientY) => {
+				const rect = element.getBoundingClientRect();
+				const y = (clientY - rect.top) / rect.height;
+				const line =
 					source.kind === "project" && y > 0.28 && y < 0.78
 						? "into"
 						: y < 0.5
 							? "before"
 							: "after";
-				setDrop((current) =>
-					current?.key === itemKey && current.line === line
-						? current
-						: { key: itemKey, line },
-				);
-			},
-			onDrop: (event: DragEvent<HTMLElement>) => {
-				event.preventDefault();
-				event.stopPropagation();
-				const rect = event.currentTarget.getBoundingClientRect();
-				const y = (event.clientY - rect.top) / rect.height;
-				const source = dragSourceRef.current;
-				if (source?.kind === "project" && y > 0.28 && y < 0.78) {
-					applyDrop({ kind: "group-end", groupId: id });
-					return;
-				}
-				applyDrop(
-					y < 0.5
-						? { kind: "before", itemKey }
-						: nodeIndex >= 0
-							? topAfter(nodeIndex)
-							: { kind: "end" },
-				);
-			},
-			onDragEnd: () => clearDrag(),
+				const target: SidebarDropTarget =
+					line === "into"
+						? { kind: "group-end", groupId: id }
+						: line === "before"
+							? { kind: "before", itemKey }
+							: nodeIndex >= 0
+								? topAfter(nodeIndex)
+								: { kind: "end" };
+				return { key: itemKey, line, target };
+			}),
 		};
 	};
 
@@ -251,7 +236,6 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 		emptyGroupDropProps,
 		isEmptyGroupDropActive: (groupId: string) =>
 			drop?.key === emptyGroupDropKey(groupId) && drop.line === "into",
-		consumeSkipClick,
 		inGroupId: (projectKey: string) => projectGroupIdFor(layout, projectKey),
 		groupDialog,
 		setGroupDialog,

--- a/apps/renderer/src/lib/use-sidebar-organize.ts
+++ b/apps/renderer/src/lib/use-sidebar-organize.ts
@@ -6,7 +6,9 @@ import {
 	type SidebarDragSource,
 	type SidebarDropTarget,
 	type SidebarLayoutNode,
+	sidebarEmptyGroupAcceptsDrop,
 	sidebarGroupItemKey,
+	sidebarProjectRowAcceptsDrop,
 } from "./sidebar-project-layout.ts";
 
 export type SidebarDropLine = "before" | "after" | "into";
@@ -21,6 +23,8 @@ export type SidebarGroupDialog =
 
 const itemKeyOf = (node: SidebarLayoutNode): string =>
 	node.kind === "group" ? sidebarGroupItemKey(node.group.id) : node.key;
+
+const emptyGroupDropKey = (groupId: string): string => `empty-group:${groupId}`;
 
 export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 	const layout = useSidebarProjectLayoutStore((s) => s.layout);
@@ -114,7 +118,12 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 				event.dataTransfer.setData("text/plain", key);
 			},
 			onDragOver: (event: DragEvent<HTMLElement>) => {
-				if (dragSourceRef.current === null) return;
+				const source = dragSourceRef.current;
+				if (source === null) return;
+				if (!sidebarProjectRowAcceptsDrop(source, groupId)) {
+					setDrop(null);
+					return;
+				}
 				event.preventDefault();
 				event.stopPropagation();
 				event.dataTransfer.dropEffect = "move";
@@ -128,12 +137,51 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 				);
 			},
 			onDrop: (event: DragEvent<HTMLElement>) => {
+				const source = dragSourceRef.current;
+				if (source === null) return;
+				if (!sidebarProjectRowAcceptsDrop(source, groupId)) {
+					clearDrag();
+					return;
+				}
 				event.preventDefault();
 				event.stopPropagation();
 				const rect = event.currentTarget.getBoundingClientRect();
 				applyDrop(event.clientY < rect.top + rect.height / 2 ? before : after);
 			},
 			onDragEnd: () => clearDrag(),
+		};
+	};
+
+	const emptyGroupDropProps = (groupId: string) => {
+		const dropKey = emptyGroupDropKey(groupId);
+		return {
+			onDragOver: (event: DragEvent<HTMLElement>) => {
+				const source = dragSourceRef.current;
+				if (source === null || !sidebarEmptyGroupAcceptsDrop(source)) {
+					setDrop(null);
+					return;
+				}
+				event.preventDefault();
+				event.stopPropagation();
+				event.dataTransfer.dropEffect = "move";
+				setDrop((current) =>
+					current?.key === dropKey && current.line === "into"
+						? current
+						: { key: dropKey, line: "into" },
+				);
+			},
+			onDrop: (event: DragEvent<HTMLElement>) => {
+				const source = dragSourceRef.current;
+				if (source === null || !sidebarEmptyGroupAcceptsDrop(source)) {
+					clearDrag();
+					return;
+				}
+				event.preventDefault();
+				event.stopPropagation();
+				applyDrop({ kind: "group-end", groupId });
+			},
+			onDragLeave: () =>
+				setDrop((current) => (current?.key === dropKey ? null : current)),
 		};
 	};
 
@@ -200,6 +248,9 @@ export const useSidebarOrganize = (projectKeys: ReadonlyArray<string>) => {
 		dropLineFor,
 		projectDragProps,
 		groupDragProps,
+		emptyGroupDropProps,
+		isEmptyGroupDropActive: (groupId: string) =>
+			drop?.key === emptyGroupDropKey(groupId) && drop.line === "into",
 		consumeSkipClick,
 		inGroupId: (projectKey: string) => projectGroupIdFor(layout, projectKey),
 		groupDialog,

--- a/apps/renderer/src/store/sidebar-project-layout.ts
+++ b/apps/renderer/src/store/sidebar-project-layout.ts
@@ -1,0 +1,100 @@
+import type { ProjectIconColorId } from "../lib/sidebar-project-icon.ts";
+import {
+	createSidebarGroup,
+	dissolveSidebarGroup,
+	EMPTY_SIDEBAR_PROJECT_LAYOUT,
+	moveSidebarItem,
+	parseSidebarProjectLayout,
+	renameSidebarGroup,
+	type SidebarDragSource,
+	type SidebarDropTarget,
+	type SidebarProjectLayout,
+	setSidebarGroupCollapsed,
+	setSidebarGroupIconColor,
+	snapshotSidebarOrder,
+} from "../lib/sidebar-project-layout.ts";
+import { createAtomStore as create } from "../state/atom-store.ts";
+
+const STORAGE_KEY = "zuse.sidebar.project-layout.v1";
+
+const readLayout = (): SidebarProjectLayout => {
+	if (typeof window === "undefined") return EMPTY_SIDEBAR_PROJECT_LAYOUT;
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (raw === null) return EMPTY_SIDEBAR_PROJECT_LAYOUT;
+		return parseSidebarProjectLayout(JSON.parse(raw));
+	} catch {
+		return EMPTY_SIDEBAR_PROJECT_LAYOUT;
+	}
+};
+
+const writeLayout = (layout: SidebarProjectLayout): void => {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+	} catch {
+		// cache is best-effort
+	}
+};
+
+type State = {
+	readonly layout: SidebarProjectLayout;
+	readonly move: (
+		source: SidebarDragSource,
+		target: SidebarDropTarget,
+		projectKeys: ReadonlyArray<string>,
+	) => void;
+	readonly createGroup: (
+		input: {
+			readonly id: string;
+			readonly name: string;
+			readonly projectKeys: ReadonlyArray<string>;
+		},
+		projectKeys: ReadonlyArray<string>,
+	) => void;
+	readonly renameGroup: (groupId: string, name: string) => void;
+	readonly setGroupCollapsed: (groupId: string, collapsed: boolean) => void;
+	readonly dissolveGroup: (
+		groupId: string,
+		projectKeys: ReadonlyArray<string>,
+	) => void;
+	readonly setGroupIconColor: (
+		groupId: string,
+		color: ProjectIconColorId | null,
+	) => void;
+};
+
+export const useSidebarProjectLayoutStore = create<State>((set, get) => {
+	const commit = (
+		layout: SidebarProjectLayout,
+		projectKeys?: ReadonlyArray<string>,
+	): void => {
+		const next =
+			projectKeys === undefined
+				? layout
+				: snapshotSidebarOrder(projectKeys, layout);
+		writeLayout(next);
+		set({ layout: next });
+	};
+	return {
+		layout: readLayout(),
+		move: (source, target, projectKeys) => {
+			commit(moveSidebarItem(get().layout, source, target), projectKeys);
+		},
+		createGroup: (input, projectKeys) => {
+			commit(createSidebarGroup(get().layout, input), projectKeys);
+		},
+		renameGroup: (groupId, name) => {
+			commit(renameSidebarGroup(get().layout, groupId, name));
+		},
+		setGroupCollapsed: (groupId, collapsed) => {
+			commit(setSidebarGroupCollapsed(get().layout, groupId, collapsed));
+		},
+		dissolveGroup: (groupId, projectKeys) => {
+			commit(dissolveSidebarGroup(get().layout, groupId), projectKeys);
+		},
+		setGroupIconColor: (groupId, color) => {
+			commit(setSidebarGroupIconColor(get().layout, groupId, color));
+		},
+	};
+});

--- a/apps/renderer/src/styles.css
+++ b/apps/renderer/src/styles.css
@@ -530,6 +530,13 @@ body,
 	}
 }
 
+/* The drag gesture owns the cursor, including over child buttons and gaps. */
+html[data-sidebar-dragging],
+html[data-sidebar-dragging] * {
+	cursor: grabbing;
+	user-select: none;
+}
+
 /* Applied only while a sidebar is programmatically opened or closed, so
    manual resizing stays directly under the pointer. */
 .fz-sidebar-panel-motion {

--- a/apps/renderer/test/unit/sidebar-pointer-drag.test.ts
+++ b/apps/renderer/test/unit/sidebar-pointer-drag.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startSidebarPointerDrag } from "../../src/lib/sidebar-pointer-drag.ts";
+
+const pointer = (type: string, x = 10, overrides = {}) =>
+	Object.assign(new Event(type, { cancelable: true }), {
+		pointerId: 1,
+		buttons: 1,
+		clientX: x,
+		clientY: 10,
+		...overrides,
+	}) as PointerEvent;
+
+const fixture = () => {
+	vi.useFakeTimers();
+	const attributes = new Map<string, string>();
+	const view = Object.assign(new EventTarget(), {
+		setTimeout,
+		clearTimeout,
+		requestAnimationFrame: vi.fn(() => 1),
+		cancelAnimationFrame: vi.fn(),
+	});
+	const preview = {
+		style: {},
+		removeAttribute: vi.fn(),
+		setAttribute: vi.fn(),
+		remove: vi.fn(),
+	};
+	const doc = Object.assign(new EventTarget(), {
+		defaultView: view,
+		documentElement: {
+			setAttribute: (name: string, value: string) =>
+				attributes.set(name, value),
+			removeAttribute: (name: string) => attributes.delete(name),
+		},
+		body: { append: vi.fn() },
+	});
+	let captured = false;
+	const element = Object.assign(new EventTarget(), {
+		ownerDocument: doc,
+		closest: () => null,
+		setPointerCapture: () => {
+			captured = true;
+		},
+		hasPointerCapture: () => captured,
+		releasePointerCapture: () => {
+			captured = false;
+		},
+		getBoundingClientRect: () => ({ left: 0, top: 0, width: 200, height: 30 }),
+		cloneNode: () => preview,
+	});
+	const callbacks = { onMove: vi.fn(), onDrop: vi.fn(), onEnd: vi.fn() };
+	const cleanup = startSidebarPointerDrag(
+		element as unknown as HTMLElement,
+		pointer("pointerdown"),
+		callbacks,
+	);
+	return { view, doc, preview, attributes, callbacks, cleanup };
+};
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("sidebar pointer drag", () => {
+	it("keeps a normal accordion click below the drag threshold", () => {
+		const f = fixture();
+		f.view.dispatchEvent(pointer("pointermove", 12));
+		f.view.dispatchEvent(pointer("pointerup", 12, { buttons: 0 }));
+		expect(f.attributes.has("data-sidebar-dragging")).toBe(false);
+		expect(f.callbacks.onMove).not.toHaveBeenCalled();
+		expect(f.callbacks.onDrop).not.toHaveBeenCalled();
+		expect(f.doc.dispatchEvent(new Event("click", { cancelable: true }))).toBe(
+			true,
+		);
+		f.cleanup();
+	});
+
+	it("holds the drag cursor across moves and clears it on drop without toggling a header", () => {
+		const f = fixture();
+		f.view.dispatchEvent(pointer("pointermove", 30));
+		f.view.dispatchEvent(pointer("pointermove", 200));
+		expect(f.attributes.has("data-sidebar-dragging")).toBe(true);
+		expect(f.callbacks.onMove).toHaveBeenCalledTimes(2);
+		f.view.dispatchEvent(pointer("pointerup", 200, { buttons: 0 }));
+		expect(f.callbacks.onDrop).toHaveBeenCalledOnce();
+		expect(f.attributes.has("data-sidebar-dragging")).toBe(false);
+		expect(f.preview.remove).toHaveBeenCalledOnce();
+		expect(f.doc.dispatchEvent(new Event("click", { cancelable: true }))).toBe(
+			false,
+		);
+		vi.runAllTimers();
+		expect(f.doc.dispatchEvent(new Event("click", { cancelable: true }))).toBe(
+			true,
+		);
+		f.cleanup();
+	});
+
+	it.each([
+		"escape",
+		"blur",
+		"pointercancel",
+		"unmount",
+	])("cleans up %s without committing a move", (reason) => {
+		const f = fixture();
+		f.view.dispatchEvent(pointer("pointermove", 30));
+		if (reason === "unmount") f.cleanup();
+		else if (reason === "escape")
+			f.view.dispatchEvent(
+				Object.assign(new Event("keydown"), { key: "Escape" }),
+			);
+		else f.view.dispatchEvent(pointer(reason));
+		expect(f.attributes.has("data-sidebar-dragging")).toBe(false);
+		expect(f.preview.remove).toHaveBeenCalledOnce();
+		f.view.dispatchEvent(pointer("pointerup", 30, { buttons: 0 }));
+		expect(f.callbacks.onDrop).not.toHaveBeenCalled();
+		expect(f.callbacks.onEnd).toHaveBeenCalledOnce();
+		f.cleanup();
+	});
+
+	it("ignores unrelated pointers and removes listeners after cleanup", () => {
+		const f = fixture();
+		f.view.dispatchEvent(pointer("pointermove", 30, { pointerId: 2 }));
+		expect(f.attributes.has("data-sidebar-dragging")).toBe(false);
+		f.cleanup();
+		f.view.dispatchEvent(pointer("pointermove", 30));
+		expect(f.callbacks.onMove).not.toHaveBeenCalled();
+	});
+});

--- a/apps/renderer/test/unit/sidebar-project-layout.test.ts
+++ b/apps/renderer/test/unit/sidebar-project-layout.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+	createSidebarGroup,
+	dissolveSidebarGroup,
+	EMPTY_SIDEBAR_PROJECT_LAYOUT,
+	materializeSidebarLayout,
+	moveSidebarItem,
+	parseSidebarProjectLayout,
+	renameSidebarGroup,
+	setSidebarGroupCollapsed,
+	setSidebarGroupIconColor,
+	sidebarGroupItemKey,
+} from "../../src/lib/sidebar-project-layout.ts";
+
+const keys = ["alpha", "beta", "gamma"] as const;
+
+describe("materializeSidebarLayout", () => {
+	it("appends unseen projects in the given order", () => {
+		expect(
+			materializeSidebarLayout(keys, EMPTY_SIDEBAR_PROJECT_LAYOUT),
+		).toEqual([
+			{ kind: "project", key: "alpha" },
+			{ kind: "project", key: "beta" },
+			{ kind: "project", key: "gamma" },
+		]);
+	});
+
+	it("drops removed projects and keeps a saved order", () => {
+		expect(
+			materializeSidebarLayout(["gamma", "alpha"], {
+				order: ["beta", "gamma", "alpha"],
+				groups: [],
+			}),
+		).toEqual([
+			{ kind: "project", key: "gamma" },
+			{ kind: "project", key: "alpha" },
+		]);
+	});
+
+	it("nests grouped projects under the group node", () => {
+		const layout = createSidebarGroup(EMPTY_SIDEBAR_PROJECT_LAYOUT, {
+			id: "g1",
+			name: "Work",
+			projectKeys: ["alpha", "gamma"],
+		});
+		const nodes = materializeSidebarLayout(keys, {
+			...layout,
+			order: [sidebarGroupItemKey("g1"), "beta"],
+		});
+		expect(nodes).toEqual([
+			{
+				kind: "group",
+				group: {
+					id: "g1",
+					name: "Work",
+					collapsed: false,
+					projectKeys: ["alpha", "gamma"],
+				},
+			},
+			{ kind: "project", key: "beta" },
+		]);
+	});
+});
+
+describe("moveSidebarItem", () => {
+	it("reorders top-level projects", () => {
+		const layout = {
+			order: ["alpha", "beta", "gamma"],
+			groups: [],
+		};
+		expect(
+			materializeSidebarLayout(
+				keys,
+				moveSidebarItem(
+					layout,
+					{ kind: "project", key: "gamma" },
+					{
+						kind: "before",
+						itemKey: "alpha",
+					},
+				),
+			).map((node) => (node.kind === "project" ? node.key : node.group.id)),
+		).toEqual(["gamma", "alpha", "beta"]);
+	});
+
+	it("moves a project into a group", () => {
+		const grouped = createSidebarGroup(
+			{ order: ["alpha", "beta", "gamma"], groups: [] },
+			{ id: "g1", name: "Work", projectKeys: ["alpha"] },
+		);
+		const moved = moveSidebarItem(
+			grouped,
+			{ kind: "project", key: "beta" },
+			{ kind: "group-end", groupId: "g1" },
+		);
+		const group = materializeSidebarLayout(keys, moved)[0];
+		expect(group).toMatchObject({
+			kind: "group",
+			group: { projectKeys: ["alpha", "beta"] },
+		});
+	});
+
+	it("does not nest a group inside another group", () => {
+		const two = createSidebarGroup(
+			createSidebarGroup(
+				{ order: ["alpha", "beta"], groups: [] },
+				{ id: "g1", name: "A", projectKeys: ["alpha"] },
+			),
+			{ id: "g2", name: "B", projectKeys: ["beta"] },
+		);
+		expect(
+			moveSidebarItem(
+				two,
+				{ kind: "group", id: "g2" },
+				{ kind: "group-end", groupId: "g1" },
+			),
+		).toEqual(two);
+	});
+});
+
+describe("createSidebarGroup / dissolveSidebarGroup", () => {
+	it("replaces the first selected project with the group", () => {
+		const layout = createSidebarGroup(
+			{ order: ["alpha", "beta", "gamma"], groups: [] },
+			{ id: "g1", name: "Work", projectKeys: ["beta"] },
+		);
+		expect(layout.order).toEqual(["alpha", sidebarGroupItemKey("g1"), "gamma"]);
+	});
+
+	it("returns grouped projects to the group's former slot", () => {
+		const grouped = createSidebarGroup(
+			{ order: ["alpha", "beta", "gamma"], groups: [] },
+			{ id: "g1", name: "Work", projectKeys: ["beta", "gamma"] },
+		);
+		expect(dissolveSidebarGroup(grouped, "g1").order).toEqual([
+			"alpha",
+			"beta",
+			"gamma",
+		]);
+	});
+
+	it("renames and collapses without touching membership", () => {
+		const grouped = createSidebarGroup(
+			{ order: ["alpha"], groups: [] },
+			{ id: "g1", name: "Work", projectKeys: ["alpha"] },
+		);
+		const renamed = renameSidebarGroup(grouped, "g1", "  Client  ");
+		expect(renamed.groups[0]?.name).toBe("Client");
+		expect(
+			setSidebarGroupCollapsed(renamed, "g1", true).groups[0]?.collapsed,
+		).toBe(true);
+	});
+});
+
+describe("parseSidebarProjectLayout", () => {
+	it("ignores malformed payloads", () => {
+		expect(parseSidebarProjectLayout(null)).toEqual(
+			EMPTY_SIDEBAR_PROJECT_LAYOUT,
+		);
+		expect(
+			parseSidebarProjectLayout({ order: [1, "ok"], groups: "nope" }),
+		).toEqual({
+			order: ["ok"],
+			groups: [],
+		});
+	});
+
+	it("reads a group's icon color", () => {
+		expect(
+			parseSidebarProjectLayout({
+				order: ["group:g1"],
+				groups: [
+					{
+						id: "g1",
+						name: "Work",
+						collapsed: false,
+						projectKeys: ["alpha"],
+						iconColor: "rose",
+					},
+				],
+			}).groups[0]?.iconColor,
+		).toBe("rose");
+	});
+});
+
+describe("setSidebarGroupIconColor", () => {
+	it("sets and clears color on the group, not on projects", () => {
+		const grouped = createSidebarGroup(
+			{ order: ["alpha", "beta"], groups: [] },
+			{ id: "g1", name: "Work", projectKeys: ["alpha"] },
+		);
+		const colored = setSidebarGroupIconColor(grouped, "g1", "teal");
+		expect(colored.groups[0]?.iconColor).toBe("teal");
+		expect(colored.order).toEqual(grouped.order);
+		expect(
+			setSidebarGroupIconColor(colored, "g1", null).groups[0]?.iconColor,
+		).toBeUndefined();
+	});
+});

--- a/apps/renderer/test/unit/sidebar-project-layout.test.ts
+++ b/apps/renderer/test/unit/sidebar-project-layout.test.ts
@@ -9,7 +9,9 @@ import {
 	renameSidebarGroup,
 	setSidebarGroupCollapsed,
 	setSidebarGroupIconColor,
+	sidebarEmptyGroupAcceptsDrop,
 	sidebarGroupItemKey,
+	sidebarProjectRowAcceptsDrop,
 } from "../../src/lib/sidebar-project-layout.ts";
 
 const keys = ["alpha", "beta", "gamma"] as const;
@@ -115,6 +117,23 @@ describe("moveSidebarItem", () => {
 				{ kind: "group-end", groupId: "g1" },
 			),
 		).toEqual(two);
+	});
+});
+
+describe("sidebar drag targets", () => {
+	it("does not advertise nested project targets for group drags", () => {
+		const group = { kind: "group", id: "g1" } as const;
+		expect(sidebarProjectRowAcceptsDrop(group, "g2")).toBe(false);
+		expect(sidebarProjectRowAcceptsDrop(group, null)).toBe(true);
+	});
+
+	it("accepts only projects in an empty group", () => {
+		expect(
+			sidebarEmptyGroupAcceptsDrop({ kind: "project", key: "alpha" }),
+		).toBe(true);
+		expect(sidebarEmptyGroupAcceptsDrop({ kind: "group", id: "g1" })).toBe(
+			false,
+		);
 	});
 });
 

--- a/apps/renderer/vite.config.ts
+++ b/apps/renderer/vite.config.ts
@@ -78,6 +78,8 @@ export default defineConfig({
 			...iconAliases,
 			"~": fileURLToPath(new URL("./src", import.meta.url)),
 		},
+		// One React instance across workspace packages and @base-ui entry
+		// points. A second copy makes `useEffect` read a null dispatcher.
 		dedupe: ["react", "react-dom"],
 	},
 	optimizeDeps: {


### PR DESCRIPTION
## Summary

The left sidebar listed projects in a fixed order with no way to cluster related repos.

This change lets you:

- Hold and drag projects (and groups) to reorder the list
- Create named groups, nest multiple projects in one group, and collapse them
- Add a project from its context menu via **Add to group**, or drag it onto a group
- Color a group's folder icon with a preset (right-click the group). Project avatars stay unchanged
- Persist order, groups, collapse state, and folder color in localStorage

User groups are separate from catalog "same git origin across computers" rows. Unknown keys drop; newly seen projects append.

Also dedupes React in the renderer Vite config. A second prebundled copy made Base UI menus crash with `useEffect` on a null dispatcher.

## Validation

- `apps/renderer` unit tests, including `test/unit/sidebar-project-layout.test.ts`
- `apps/renderer` `check-types`
- Biome check on the touched files
- Clicked through drag, grouping, the add-to-group flyout, and group folder colors in the desktop app during development

Could not re-verify the live Electron UI after the last group-icon-only color pass from this session.

## Provenance

- External implementation or source consulted: No
- Usage: Behavior only
- Source URL and revision:
- Applicable license:
- Required notice added or updated: N/A
