### PR TITLE
Release v0.20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.10]
+
+### Fixed
+- New chats no longer get stuck when attachment or generated-context finalization races the startup worker; the completed input is handed off to the durable queue and starts exactly once
+- Plain startup prompts no longer appear in both the transcript and queue, persist twice, or show a false “you interrupted” pause during workspace setup
+- Startup progress no longer lingers after the agent has begun responding
+
 ## [0.20.9]
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.9",
+	"version": "0.20.10",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -138,6 +138,7 @@ import {
 	annotationsForSession,
 	useAnnotationsStore,
 } from "../store/annotations.ts";
+import { useChatsStore } from "../store/chats.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
 import {
 	composerDraftKeyForSession,
@@ -247,6 +248,11 @@ export function ChatComposer({
 			sessionId,
 		});
 	const isDraft = onDraftSubmit !== undefined;
+	const creationInProgress = useChatsStore((state) =>
+		session.chatId === null
+			? false
+			: state.pendingCreationByChat[session.chatId] !== undefined,
+	);
 	const [reasoningLevel, setReasoningLevel] = useState<string | null>(null);
 	// Provider features the installed CLI supports (from the availability
 	// probe). Codex goal mode is version-gated; Grok advertises it natively.
@@ -1306,6 +1312,7 @@ export function ChatComposer({
 								<QueueTray
 									environmentId={qualifiedEnvironmentId}
 									sessionId={sessionId}
+									creationInProgress={creationInProgress}
 									waitingForSandbox={
 										cloudSummary !== null &&
 										cloudWorkspaceIsStarting(cloudSummary)

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -195,10 +195,11 @@ const formatThreadRelative = (date: Date): string => {
  *
  * Renders a centered "What should we build in <project>?" headline above a
  * mini composer + project picker + starter-prompt list. On submit we call
- * `useChatsStore.create()` with the typed input held in the startup queue; the
- * chat store auto-selects the new session, which causes `MainShell` to
- * swap this surface for `<ChatView />` + `<ChatComposer />` on the next
- * render.
+ * `useChatsStore.create()` with the typed input. Plain prompts become the
+ * atomic initial turn; structured or still-materializing inputs use the
+ * startup queue. The chat store auto-selects the new session, which causes
+ * `MainShell` to swap this surface for `<ChatView />` + `<ChatComposer />` on
+ * the next render.
  */
 export function ChatLanding() {
 	const { originsByFolder: origins } = useActiveEnvironmentEntities();
@@ -1078,18 +1079,6 @@ export function ChatLanding() {
 			setSubmitting(false);
 			return;
 		}
-		if (
-			useChatsStore.getState().pendingCreationByChat[result.chatId] !==
-			undefined
-		) {
-			// An ambiguous transport interruption leaves the retry-safe chat command
-			// in the outbox. The pending-creation surface owns the UI until replay
-			// produces the durable chat/session; never issue session-scoped follow-up
-			// commands against its provisional id.
-			useSessionsStore.getState().clearDraft();
-			setSubmitting(false);
-			return;
-		}
 		const worktreeId = result.worktreeId;
 		setPendingWorktreeId(worktreeId);
 		const sessionId = result.initialSessionId;
@@ -1182,7 +1171,7 @@ export function ChatLanding() {
 				}
 			}
 		}
-		if (startupQueueId !== null) {
+		if (startupNeedsPreparation && startupQueueId !== null) {
 			// Finalization is the release edge. If the provider became ready first,
 			// this update requests a drain; if the user deleted the item meanwhile,
 			// the server returns not-found and the item is never resurrected.

--- a/apps/renderer/src/components/chat-view.tsx
+++ b/apps/renderer/src/components/chat-view.tsx
@@ -218,6 +218,10 @@ export function ChatView({
 			? null
 			: (state.pendingCreationByChat[session.chatId] ?? null),
 	);
+	useEffect(() => {
+		if (!providerOutputStarted || session.chatId === null) return;
+		useChatsStore.getState().completeCreation(session.chatId);
+	}, [providerOutputStarted, session.chatId]);
 	const cloudSetupActive =
 		cloudSummary !== null && cloudWorkspaceIsStarting(cloudSummary);
 	const agentStarting = resolveAgentStarting({

--- a/apps/renderer/src/components/composer/queue-tray.tsx
+++ b/apps/renderer/src/components/composer/queue-tray.tsx
@@ -14,10 +14,12 @@ export function QueueTray({
 	sessionId,
 	environmentId,
 	waitingForSandbox = false,
+	creationInProgress = false,
 }: {
 	sessionId: SessionId;
 	environmentId: EnvironmentId;
 	readonly waitingForSandbox?: boolean;
+	readonly creationInProgress?: boolean;
 }) {
 	const timeline = useRendererSessionTimeline(
 		sessionId,
@@ -46,7 +48,7 @@ export function QueueTray({
 		);
 	};
 
-	const showPausedPill = paused && !running;
+	const showPausedPill = paused && !running && !creationInProgress;
 
 	return (
 		<div ref={listRef}>

--- a/apps/renderer/src/components/worktree-setup-card.tsx
+++ b/apps/renderer/src/components/worktree-setup-card.tsx
@@ -138,6 +138,7 @@ export function WorktreeSetupCard({
 				hasWorktree,
 				setupDone,
 			}));
+	if (providerOutputStarted) return null;
 	if (cloudSummary !== null) {
 		const resumeLifecycle =
 			cloudSummary.state === "paused" ||

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -17,6 +17,7 @@ import {
 	SessionId,
 	type WorktreeId,
 } from "@zuse/contracts";
+import { composerInputStartsDirectTurn } from "@zuse/domain/conversation/startup-input";
 import { toastManager } from "../components/ui/toast.tsx";
 import { nextChatCreateCommandId } from "../lib/chat-create-command-id.ts";
 import {
@@ -98,6 +99,12 @@ const dispatchChatCommand = <Payload, Result>(input: {
 		payload: input.payload,
 		retry: input.retry,
 	});
+
+export const chatStartupUsesQueue = (
+	input: ComposerInput | undefined,
+	ready: boolean,
+): boolean =>
+	input !== undefined && (!ready || !composerInputStartsDirectTurn(input));
 
 type ChatCreateResult = Readonly<{
 	chat: Chat;
@@ -181,6 +188,8 @@ type ChatsState = {
 		preserveFocus?: boolean,
 	) => Promise<boolean>;
 	readonly continueCreation: (chatId: ChatId) => Promise<boolean>;
+	/** Provider output proves the startup lifecycle crossed into a live turn. */
+	readonly completeCreation: (chatId: ChatId) => void;
 	readonly discardCreation: (chatId: ChatId) => void;
 	readonly archiveProgressByChat: Record<string, ChatArchiveProgressPhase>;
 	readonly error: string | null;
@@ -761,7 +770,11 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 								[projectId]: initialSessionId,
 							},
 			}));
-			if (opts?.startupInput !== undefined && opts.reusePending !== true) {
+			if (
+				opts?.startupInput !== undefined &&
+				chatStartupUsesQueue(opts?.startupInput, opts?.startupReady ?? true) &&
+				opts?.reusePending !== true
+			) {
 				startupQueueId = queueSessionMessage(
 					{
 						environmentId: EnvironmentId.make(getActiveEnvironment()),
@@ -1123,6 +1136,21 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 		}));
 		if (recovered.phase === "failed") return false;
 		return get().retryCreation(chatId, true);
+	},
+	completeCreation: (chatId) => {
+		const creation = get().pendingCreationByChat[chatId];
+		if (creation === undefined) return;
+		set((state) => ({
+			creatingByProject: {
+				...state.creatingByProject,
+				[creation.projectId]: false,
+			},
+			pendingCreationByChat: Object.fromEntries(
+				Object.entries(state.pendingCreationByChat).filter(
+					([id]) => id !== chatId,
+				),
+			),
+		}));
 	},
 	discardCreation: (chatId) => {
 		const creation = get().pendingCreationByChat[chatId];

--- a/apps/renderer/test/unit/chat-creation-handoff.test.ts
+++ b/apps/renderer/test/unit/chat-creation-handoff.test.ts
@@ -1,6 +1,7 @@
 import {
 	type ChatCreationOperation,
 	ChatId,
+	ComposerInput,
 	FolderId,
 	SessionId,
 } from "@zuse/contracts";
@@ -17,8 +18,10 @@ import {
 } from "../../src/components/worktree-setup-card.tsx";
 import { selectChatSurface } from "../../src/lib/chat-surface-selection.ts";
 import {
+	chatStartupUsesQueue,
 	chatStoreErrorMessage,
 	restorePendingCreation,
+	useChatsStore,
 } from "../../src/store/chats.ts";
 
 const operation = (
@@ -54,6 +57,34 @@ const operation = (
 });
 
 describe("chat creation handoff", () => {
+	it("does not queue a ready plain-text startup turn", () => {
+		const input = ComposerInput.make({
+			text: "Start once",
+			attachments: [],
+			fileRefs: [],
+			skillRefs: [],
+			annotations: [],
+		});
+
+		expect(chatStartupUsesQueue(input, true)).toBe(false);
+		expect(chatStartupUsesQueue(input, false)).toBe(true);
+		expect(
+			chatStartupUsesQueue(
+				ComposerInput.make({
+					...input,
+					attachments: [
+						{
+							id: "pending-attachment",
+							mimeType: "image/png",
+							originalName: "startup.png",
+						},
+					],
+				}),
+				true,
+			),
+		).toBe(true);
+	});
+
 	it("keeps the composer-bearing session surface mounted during creation", () => {
 		expect(
 			selectChatSurface({
@@ -68,6 +99,25 @@ describe("chat creation handoff", () => {
 		expect(restored.creation.phase).toBe("running_setup");
 		expect(restored.creation.prompt).toBe("Fix the lifecycle");
 		expect(restored.session.status).toBe("booting");
+	});
+
+	it("clears stale optimistic creation state once provider output starts", () => {
+		const restored = restorePendingCreation(operation("starting_agent"));
+		useChatsStore.setState({
+			creatingByProject: { [restored.creation.projectId]: true },
+			pendingCreationByChat: {
+				[restored.creation.chatId]: restored.creation,
+			},
+		});
+
+		useChatsStore.getState().completeCreation(restored.creation.chatId);
+
+		expect(
+			useChatsStore.getState().pendingCreationByChat[restored.creation.chatId],
+		).toBeUndefined();
+		expect(
+			useChatsStore.getState().creatingByProject[restored.creation.projectId],
+		).toBe(false);
 	});
 
 	it("keeps setup failures recoverable in place", () => {

--- a/apps/server/src/conversation/core/chat-startup-intent.ts
+++ b/apps/server/src/conversation/core/chat-startup-intent.ts
@@ -1,7 +1,11 @@
 import { ComposerInput, type SessionId } from "@zuse/contracts";
+import { composerInputStartsDirectTurn } from "@zuse/domain/conversation/startup-input";
 import { Effect } from "effect";
 import type { SqlClient } from "effect/unstable/sql";
-import type { QueueTransactionServiceShape } from "../services/conversation-services.ts";
+import type {
+	QueueServiceShape,
+	QueueTransactionServiceShape,
+} from "../services/conversation-services.ts";
 
 export interface ChatStartupIntent {
 	readonly operationId: string;
@@ -58,7 +62,7 @@ export const persistChatStartupIntent = Effect.fn(
 		FROM chat_creation_operations
 		WHERE operation_id = ${intent.operationId}
 		LIMIT 1
-	`;
+	`.pipe(Effect.orDie);
 	if (operations[0]?.status === "succeeded") return false;
 
 	// The internal queue transaction boundary owns the SessionDomain append and
@@ -79,4 +83,76 @@ export const persistChatStartupIntent = Effect.fn(
 			`.pipe(Effect.asVoid, Effect.orDie),
 	);
 	return true;
+});
+
+/**
+ * Finalize a held startup item even when the background creation worker has
+ * not inserted it yet. The operation row is the durable proof that this queue
+ * id is expected; unrelated not-found updates still remain authoritative.
+ */
+export const updateQueuedMessageWithStartupHandoff = Effect.fn(
+	"ChatCreation.updateQueuedMessageWithStartupHandoff",
+)(function* (
+	queue: QueueServiceShape,
+	queueTransaction: QueueTransactionServiceShape,
+	sql: SqlClient.SqlClient,
+	commandId: string,
+	sessionId: SessionId,
+	queueId: string,
+	input: ComposerInput,
+) {
+	return yield* queue
+		.updateQueuedMessage(commandId, sessionId, queueId, input)
+		.pipe(
+			Effect.catchTag("QueuedMessageNotFoundError", (notFound) =>
+				Effect.gen(function* () {
+					const operations = yield* sql<{
+						readonly operation_id: string;
+						readonly phase: string;
+						readonly startup_input_json: string | null;
+						readonly startup_ready: number;
+						readonly status: string;
+					}>`
+						SELECT operation_id, phase, status,
+						       startup_input_json, startup_ready
+						FROM chat_creation_operations
+						WHERE initial_session_id = ${sessionId}
+						  AND startup_queue_id = ${queueId}
+						LIMIT 1
+					`.pipe(Effect.orDie);
+					const operation = operations[0];
+					const originalInput =
+						operation?.startup_input_json === null ||
+						operation?.startup_input_json === undefined
+							? null
+							: ComposerInput.make(JSON.parse(operation.startup_input_json));
+					if (
+						operation === undefined ||
+						operation.status === "failed" ||
+						operation.phase === "failed" ||
+						operation.phase === "cancelled" ||
+						(operation.startup_ready !== 0 &&
+							originalInput !== null &&
+							composerInputStartsDirectTurn(originalInput))
+					) {
+						return yield* notFound;
+					}
+					if (operation.status !== "succeeded") {
+						yield* persistChatStartupIntent(queueTransaction, sql, {
+							operationId: operation.operation_id,
+							sessionId,
+							input,
+							queueId,
+							ready: true,
+						});
+					}
+					return yield* queue.updateQueuedMessage(
+						commandId,
+						sessionId,
+						queueId,
+						input,
+					);
+				}),
+			),
+		);
 });

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -26,6 +26,7 @@ import {
 	type SessionTimelineFrame,
 	WorktreeId,
 } from "@zuse/contracts";
+import { composerInputStartsDirectTurn } from "@zuse/domain/conversation/startup-input";
 import { SessionDomain } from "@zuse/domain/engine/session-domain";
 import { SqlSessionQueries } from "@zuse/domain/queries/sql-session-queries";
 import { GitService } from "@zuse/git/git-service";
@@ -39,6 +40,7 @@ import { ConfigStoreService } from "../config-store/services/config-store-servic
 import {
 	decodeChatStartupIntent,
 	persistChatStartupIntent,
+	updateQueuedMessageWithStartupHandoff,
 } from "../conversation/core/chat-startup-intent.ts";
 import { messageFromRecord } from "../conversation/core/conversation-records.ts";
 import { timelineEventFromDomain } from "../conversation/core/conversation-timeline-projection.ts";
@@ -567,14 +569,6 @@ const sha256 = (value: string): Effect.Effect<string> =>
 		).join("");
 	});
 
-const directStartupInput = (input: ComposerInput | undefined): boolean =>
-	input !== undefined &&
-	input.text.trim().length > 0 &&
-	input.attachments.length === 0 &&
-	input.fileRefs.length === 0 &&
-	input.skillRefs.length === 0 &&
-	input.annotations.length === 0;
-
 const creationPhaseStatus = (
 	phase: ChatCreationOperation["phase"],
 ):
@@ -780,7 +774,8 @@ const ChatCreate = MemoizeRpcs.toLayerHandler(
 										);
 							const useDirectTurn =
 								durableOperation.startup_ready !== 0 &&
-								directStartupInput(storedInput);
+								storedInput !== undefined &&
+								composerInputStartsDirectTurn(storedInput);
 							const initialPrompt = useDirectTurn
 								? storedInput?.text.trim()
 								: input.initialPrompt;
@@ -1947,9 +1942,20 @@ const MessagesQueueAdd = MemoizeRpcs.toLayerHandler(
 const MessagesQueueUpdate = MemoizeRpcs.toLayerHandler(
 	"messages.queue.update",
 	({ commandId, sessionId, queueId, input }) =>
-		Effect.flatMap(QueueService, (svc) =>
-			svc.updateQueuedMessage(commandId, sessionId, queueId, input),
-		),
+		Effect.gen(function* () {
+			const queue = yield* QueueService;
+			const queueTransaction = yield* QueueTransactionService;
+			const sql = yield* SqlClient.SqlClient;
+			return yield* updateQueuedMessageWithStartupHandoff(
+				queue,
+				queueTransaction,
+				sql,
+				commandId,
+				sessionId,
+				queueId,
+				input,
+			);
+		}),
 );
 
 const MessagesQueueDelete = MemoizeRpcs.toLayerHandler(

--- a/apps/server/test/integration/chat-startup-intent.test.ts
+++ b/apps/server/test/integration/chat-startup-intent.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
 	chatStartupCommandId,
 	persistChatStartupIntent,
+	updateQueuedMessageWithStartupHandoff,
 } from "../../src/conversation/core/chat-startup-intent.ts";
 import { QueueTransactionService } from "../../src/conversation/services/conversation-services.ts";
 import {
@@ -235,6 +236,112 @@ describe("durable chat startup intent", () => {
 			);
 			expect(held.items).toHaveLength(1);
 			expect(held.items[0]?.ready).toBe(false);
+		} finally {
+			await runtime.dispose();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("finalizes startup input that arrives before the held row is inserted", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-chat-startup-race-"));
+		const runtime = makeConversationFixtureRuntime(
+			join(directory, "fixture.sqlite"),
+			[],
+		);
+		const run = <A>(
+			effect: Effect.Effect<
+				A,
+				unknown,
+				TestConversation | QueueTransactionService | SqlClient.SqlClient
+			>,
+		): Promise<A> =>
+			runtime.runPromise(effect as Effect.Effect<A, unknown, never>);
+
+		try {
+			const operationId = "operation-early-finalization";
+			const chatId = ChatId.make("chat-early-finalization");
+			const sessionId = SessionId.make("session-early-finalization");
+			const queueId = "queue-early-finalization";
+			const finalizedInput = ComposerInput.make({
+				...startupInput,
+				attachments: [
+					{
+						id: "session-early-finalization-attachment",
+						mimeType: "image/png",
+						originalName: "startup.png",
+					},
+				],
+			});
+			await run(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const now = new Date().toISOString();
+					yield* sql`
+						ALTER TABLE chat_creation_operations
+						ADD COLUMN phase TEXT NOT NULL DEFAULT 'persisted'
+					`;
+					yield* sql`
+						INSERT INTO projects (id, path, name, created_at, updated_at)
+						VALUES (${FIXTURE_PROJECT_ID}, ${FIXTURE_PROJECT_PATH}, ${"Fixture"}, ${now}, ${now})
+					`;
+					yield* sql`
+						INSERT INTO chat_creation_operations (
+							operation_id, chat_id, initial_session_id, project_id,
+							provider_id, model, runtime_mode, permission_mode,
+							startup_input_json, startup_queue_id, startup_ready,
+							workspace_policy, status, phase, created_at, updated_at
+						) VALUES (
+							${operationId}, ${chatId}, ${sessionId}, ${FIXTURE_PROJECT_ID},
+							${"claude"}, ${"fixture-model"}, ${"approval-required"}, ${"default"},
+							${JSON.stringify(startupInput)}, ${queueId}, 0,
+							${"main"}, ${"creating_chat"}, ${"starting_agent"}, ${now}, ${now}
+						)
+					`;
+				}),
+			);
+			await run(
+				Effect.flatMap(TestConversation, (service) =>
+					service.createChat({
+						chatId,
+						initialSessionId: sessionId,
+						projectId: FIXTURE_PROJECT_ID,
+						providerId: "claude",
+						model: "fixture-model",
+						background: true,
+					}),
+				),
+			);
+
+			const updated = await run(
+				Effect.gen(function* () {
+					const service = yield* TestConversation;
+					const queueTransaction = yield* QueueTransactionService;
+					const sql = yield* SqlClient.SqlClient;
+					return yield* updateQueuedMessageWithStartupHandoff(
+						service,
+						queueTransaction,
+						sql,
+						"queue-update-early-finalization",
+						sessionId,
+						queueId,
+						finalizedInput,
+					);
+				}),
+			);
+			const operation = await run(
+				Effect.flatMap(
+					SqlClient.SqlClient,
+					(sql) =>
+						sql<{ readonly status: string }>`
+						SELECT status FROM chat_creation_operations
+						WHERE operation_id = ${operationId}
+					`,
+				),
+			);
+
+			expect(updated.ready).toBe(true);
+			expect(updated.input).toEqual(finalizedInput);
+			expect(operation).toEqual([{ status: "succeeded" }]);
 		} finally {
 			await runtime.dispose();
 			rmSync(directory, { recursive: true, force: true });

--- a/apps/server/test/unit/chat-startup-intent.test.ts
+++ b/apps/server/test/unit/chat-startup-intent.test.ts
@@ -1,4 +1,8 @@
-import { ComposerInput, SessionId } from "@zuse/contracts";
+import {
+	ComposerInput,
+	QueuedMessageNotFoundError,
+	SessionId,
+} from "@zuse/contracts";
 import { Effect } from "effect";
 import type { SqlClient } from "effect/unstable/sql";
 import { describe, expect, it, vi } from "vitest";
@@ -6,8 +10,12 @@ import {
 	chatStartupCommandId,
 	decodeChatStartupIntent,
 	persistChatStartupIntent,
+	updateQueuedMessageWithStartupHandoff,
 } from "../../src/conversation/core/chat-startup-intent.ts";
-import type { QueueTransactionServiceShape } from "../../src/conversation/services/conversation-services.ts";
+import type {
+	QueueServiceShape,
+	QueueTransactionServiceShape,
+} from "../../src/conversation/services/conversation-services.ts";
 
 const sessionId = SessionId.make("session-1");
 const input = ComposerInput.make({
@@ -52,6 +60,52 @@ describe("chat startup intent", () => {
 				startupReady: false,
 			}),
 		).toMatchObject({ ready: false });
+	});
+
+	it("never resurrects an atomic direct turn as a queued duplicate", async () => {
+		const queue = {
+			updateQueuedMessage: vi.fn(() =>
+				Effect.fail(
+					new QueuedMessageNotFoundError({
+						sessionId,
+						queueId: "startup-queue-direct",
+					}),
+				),
+			),
+		} as unknown as QueueServiceShape;
+		const queueTransaction = {
+			addQueuedMessageTransactionally: vi.fn(),
+		} as unknown as QueueTransactionServiceShape;
+		const sqlTag = () =>
+			Effect.succeed([
+				{
+					operation_id: "operation-direct",
+					phase: "starting_agent",
+					startup_input_json: JSON.stringify(input),
+					startup_ready: 1,
+					status: "pending",
+				},
+			]);
+		const sql = Object.assign(sqlTag, {
+			withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+		}) as unknown as SqlClient.SqlClient;
+
+		const failure = await Effect.runPromise(
+			updateQueuedMessageWithStartupHandoff(
+				queue,
+				queueTransaction,
+				sql,
+				"queue-update-direct",
+				sessionId,
+				"startup-queue-direct",
+				input,
+			).pipe(Effect.flip),
+		);
+
+		expect(failure._tag).toBe("QueuedMessageNotFoundError");
+		expect(
+			queueTransaction.addQueuedMessageTransactionally,
+		).not.toHaveBeenCalled();
 	});
 
 	it("persists the stable queue command before marking creation successful", async () => {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "0.20.10",
+    "sections": [
+      {
+        "title": "Fixed",
+        "items": [
+          "New chats no longer get stuck when attachment or generated-context finalization races the startup worker; the completed input is handed off to the durable queue and starts exactly once",
+          "Plain startup prompts no longer appear in both the transcript and queue, persist twice, or show a false “you interrupted” pause during workspace setup",
+          "Startup progress no longer lingers after the agent has begun responding"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.9",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.9",
+      "version": "0.20.10",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -8,6 +8,7 @@
 		"./chat/decider": "./src/chat/decider.ts",
 		"./chat/events": "./src/chat/events.ts",
 		"./chat/state": "./src/chat/state.ts",
+		"./conversation/startup-input": "./src/conversation/startup-input.ts",
 		"./core/commands": "./src/core/commands.ts",
 		"./core/decider": "./src/core/decider.ts",
 		"./core/events": "./src/core/events.ts",

--- a/packages/domain/src/conversation/startup-input.ts
+++ b/packages/domain/src/conversation/startup-input.ts
@@ -1,0 +1,13 @@
+import type { ComposerInput } from "@zuse/contracts";
+
+/**
+ * Whether chat creation can persist this input as its atomic initial turn.
+ * Structured context uses the startup queue because attachments and references
+ * may need to be materialized after the chat itself is acknowledged.
+ */
+export const composerInputStartsDirectTurn = (input: ComposerInput): boolean =>
+	input.text.trim().length > 0 &&
+	input.attachments.length === 0 &&
+	input.fileRefs.length === 0 &&
+	input.skillRefs.length === 0 &&
+	input.annotations.length === 0;


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.10 with release notes grouped by user-visible outcome.

### Fixed
- New chats no longer get stuck when attachment or generated-context finalization races the startup worker; the completed input is handed off to the durable queue and starts exactly once
- Plain startup prompts no longer appear in both the transcript and queue, persist twice, or show a false “you interrupted” pause during workspace setup
- Startup progress no longer lingers after the agent has begun responding

## Validation

- `bun run check-types`

Release artifacts are produced by pushing tag v0.20.10 after this PR lands.

