### PR TITLE
Add macOS Caffeine mode and active-agent status

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ settings.
 - Resizable panes
 - Top bar with active session info
 - PTY terminal (xterm.js + node-pty)
+- macOS Keep Mac awake modes: Auto while an agent or authenticated remote
+  client is active, Always, or Off, with live status in General settings
 
 ### Persistence & distribution
 - SQLite stores projects, sessions, messages, tool calls across restarts
@@ -196,6 +198,10 @@ bun run dist:linux:unsigned
 ```
 
 Requires: Bun 1.3.10+, Node.js ≥ 22.13, and macOS or x64 Linux.
+
+Changes to the macOS awake controller require the
+[physical MacBook release check](docs/testing/mac-computer-awake.md), including
+assertion and best-effort closed-lid verification.
 
 The default install uses the public icon set and does not require registry
 credentials. Contributors can clone the repository and run the commands above

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -21,6 +21,7 @@ copied; it records where comparison influenced a decision:
 | [#71](https://github.com/swarajbachu/zuse/pull/71) | Keybinding parser structure and settings interaction patterns; persistence and implementation remain project-specific. |
 | [#72](https://github.com/swarajbachu/zuse/pull/72) | Per-model capability descriptors used as a product/API pattern. |
 | [#111](https://github.com/swarajbachu/zuse/pull/111) | Model catalog, aliases, and capability presentation were cross-checked for feature parity. |
+| [#525](https://github.com/swarajbachu/zuse/pull/525) | macOS awake behavior follows Orca's public Electron power-blocker and `caffeinate` approach; the implementation is project-specific. |
 
 [PR #79](https://github.com/swarajbachu/zuse/pull/79) separately records a
 deliberate move to a custom diff presentation so the product would have its own

--- a/apps/desktop/src/computer-awake-controller.ts
+++ b/apps/desktop/src/computer-awake-controller.ts
@@ -1,0 +1,320 @@
+import { spawn as nodeSpawn } from "node:child_process";
+
+import type { ComputerAwakeMode, ComputerAwakeStatus } from "@zuse/contracts";
+
+export const CAFFEINATE_RETRY_BASE_MS = 1_000;
+export const CAFFEINATE_RETRY_MAX_MS = 30_000;
+
+type Logger = Pick<Console, "debug" | "warn">;
+
+export interface PowerSaveBlockerLike {
+	readonly start: (type: "prevent-app-suspension") => number;
+	readonly stop: (id: number) => boolean | undefined;
+	readonly isStarted: (id: number) => boolean;
+}
+
+export interface PowerResumeSource {
+	readonly on: (event: "resume", listener: () => void) => void;
+	readonly off: (event: "resume", listener: () => void) => void;
+}
+
+interface CaffeinateProcess {
+	readonly kill: () => boolean;
+	on(event: "error", listener: (error: Error) => void): void;
+	on(
+		event: "exit",
+		listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+	): void;
+	off(event: "error", listener: (error: Error) => void): void;
+	off(
+		event: "exit",
+		listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+	): void;
+}
+
+type SpawnCaffeinate = (
+	command: string,
+	args: ReadonlyArray<string>,
+	options: { readonly stdio: "ignore"; readonly windowsHide: true },
+) => CaffeinateProcess;
+
+export interface ComputerAwakeControllerOptions {
+	readonly blocker: PowerSaveBlockerLike;
+	readonly initialMode?: ComputerAwakeMode;
+	readonly logger?: Logger;
+	readonly platform?: NodeJS.Platform;
+	readonly powerMonitor?: PowerResumeSource | null;
+	readonly spawn?: SpawnCaffeinate;
+	readonly setTimeout?: typeof globalThis.setTimeout;
+	readonly clearTimeout?: typeof globalThis.clearTimeout;
+}
+
+const count = (value: number): number =>
+	Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+
+export class ComputerAwakeController {
+	private mode: ComputerAwakeMode;
+	private activeAgents = 0;
+	private remoteClients = 0;
+	private blockerId: number | null = null;
+	private caffeinate: CaffeinateProcess | null = null;
+	private caffeinateCleanup: (() => void) | null = null;
+	private retryTimer: ReturnType<typeof setTimeout> | null = null;
+	private electronWarning: string | null = null;
+	private caffeinateWarning: string | null = null;
+	private caffeinateRetryAttempt = 0;
+	private disposed = false;
+	private readonly listeners = new Set<(status: ComputerAwakeStatus) => void>();
+	private readonly logger: Logger;
+	private readonly platform: NodeJS.Platform;
+	private readonly spawn: SpawnCaffeinate;
+	private readonly setTimer: typeof globalThis.setTimeout;
+	private readonly clearTimer: typeof globalThis.clearTimeout;
+	private readonly removeResumeListener: (() => void) | null;
+
+	constructor(private readonly options: ComputerAwakeControllerOptions) {
+		this.mode = options.initialMode ?? "auto";
+		this.logger = options.logger ?? console;
+		this.platform = options.platform ?? process.platform;
+		this.spawn = options.spawn ?? (nodeSpawn as unknown as SpawnCaffeinate);
+		this.setTimer = options.setTimeout ?? globalThis.setTimeout;
+		this.clearTimer = options.clearTimeout ?? globalThis.clearTimeout;
+		const source = options.powerMonitor ?? null;
+		if (source === null) {
+			this.removeResumeListener = null;
+		} else {
+			const resume = () => this.refresh("resume");
+			source.on("resume", resume);
+			this.removeResumeListener = () => source.off("resume", resume);
+		}
+		this.refresh("initialize");
+	}
+
+	getStatus(): ComputerAwakeStatus {
+		const supported = this.platform === "darwin";
+		const electronBlockerActive = this.isElectronBlockerActive();
+		const caffeinateActive = this.caffeinate !== null;
+		return {
+			supported,
+			mode: this.mode,
+			active:
+				supported &&
+				this.shouldActivate() &&
+				(electronBlockerActive || caffeinateActive),
+			activeAgents: this.activeAgents,
+			remoteClients: this.remoteClients,
+			electronBlockerActive,
+			caffeinateActive,
+			warning:
+				supported && this.shouldActivate()
+					? [this.electronWarning, this.caffeinateWarning]
+							.filter((item): item is string => item !== null)
+							.join(" ") || null
+					: null,
+		};
+	}
+
+	setMode(mode: ComputerAwakeMode): void {
+		if (this.mode === mode) return;
+		this.mode = mode;
+		this.refresh("mode-change");
+	}
+
+	setActiveAgents(value: number): void {
+		const next = count(value);
+		if (next === this.activeAgents) return;
+		this.activeAgents = next;
+		this.refresh("agent-count");
+	}
+
+	setRemoteClients(value: number): void {
+		const next = count(value);
+		if (next === this.remoteClients) return;
+		this.remoteClients = next;
+		this.refresh("remote-count");
+	}
+
+	subscribe(listener: (status: ComputerAwakeStatus) => void): () => void {
+		this.listeners.add(listener);
+		listener(this.getStatus());
+		return () => this.listeners.delete(listener);
+	}
+
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.removeResumeListener?.();
+		this.clearRetry();
+		this.stopCaffeinate();
+		this.stopElectronBlocker();
+		this.listeners.clear();
+	}
+
+	private shouldActivate(): boolean {
+		return (
+			this.mode === "always" ||
+			(this.mode === "auto" &&
+				(this.activeAgents > 0 || this.remoteClients > 0))
+		);
+	}
+
+	private refresh(reason: string): void {
+		if (this.disposed) return;
+		if (this.platform !== "darwin" || !this.shouldActivate()) {
+			this.electronWarning = null;
+			this.caffeinateWarning = null;
+			this.clearRetry();
+			this.stopCaffeinate();
+			this.stopElectronBlocker();
+			this.publish();
+			return;
+		}
+		this.startElectronBlocker(reason);
+		this.startCaffeinate(reason);
+		this.publish();
+	}
+
+	private isElectronBlockerActive(): boolean {
+		if (this.blockerId === null) return false;
+		try {
+			if (this.options.blocker.isStarted(this.blockerId)) {
+				this.electronWarning = null;
+				return true;
+			}
+			this.blockerId = null;
+		} catch (cause) {
+			this.electronWarning =
+				"Electron could not verify the system-awake assertion.";
+			this.logger.warn("[computer-awake] failed to inspect Electron blocker", {
+				cause,
+			});
+			return true;
+		}
+		return false;
+	}
+
+	private startElectronBlocker(reason: string): void {
+		if (this.isElectronBlockerActive()) return;
+		try {
+			this.blockerId = this.options.blocker.start("prevent-app-suspension");
+			if (!this.isElectronBlockerActive()) {
+				this.electronWarning =
+					"Electron could not hold the system-awake assertion.";
+			} else {
+				this.electronWarning = null;
+			}
+		} catch (cause) {
+			this.blockerId = null;
+			this.electronWarning =
+				"Electron could not hold the system-awake assertion.";
+			this.logger.warn("[computer-awake] failed to start Electron blocker", {
+				reason,
+				cause,
+			});
+		}
+	}
+
+	private stopElectronBlocker(): void {
+		if (this.blockerId === null) return;
+		const id = this.blockerId;
+		try {
+			this.options.blocker.stop(id);
+		} catch (cause) {
+			this.logger.warn("[computer-awake] failed to stop Electron blocker", {
+				cause,
+			});
+		}
+		if (!this.isElectronBlockerActive()) this.blockerId = null;
+	}
+
+	private startCaffeinate(reason: string): void {
+		if (this.caffeinate !== null || this.retryTimer !== null) return;
+		let child: CaffeinateProcess;
+		try {
+			child = this.spawn("/usr/bin/caffeinate", ["-i", "-s"], {
+				stdio: "ignore",
+				windowsHide: true,
+			});
+		} catch (cause) {
+			this.handleCaffeinateFailure(reason, cause);
+			return;
+		}
+		this.caffeinate = child;
+		let finished = false;
+		const fail = (detail: unknown) => {
+			if (finished || this.caffeinate !== child) return;
+			finished = true;
+			this.detachCaffeinate();
+			this.caffeinate = null;
+			this.handleCaffeinateFailure(reason, detail);
+		};
+		const onError = (error: Error) => fail(error);
+		const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
+			fail({ code, signal });
+		child.on("error", onError);
+		child.on("exit", onExit);
+		this.caffeinateCleanup = () => {
+			child.off("error", onError);
+			child.off("exit", onExit);
+		};
+		this.caffeinateWarning = null;
+	}
+
+	private handleCaffeinateFailure(reason: string, cause: unknown): void {
+		this.caffeinateWarning =
+			"Closed-lid sleep prevention is unavailable; idle-sleep prevention may still be active.";
+		this.logger.warn("[computer-awake] caffeinate assertion failed", {
+			reason,
+			cause,
+		});
+		this.scheduleRetry();
+		this.publish();
+	}
+
+	private scheduleRetry(): void {
+		if (this.retryTimer !== null || !this.shouldActivate() || this.disposed)
+			return;
+		const delay = Math.min(
+			CAFFEINATE_RETRY_MAX_MS,
+			CAFFEINATE_RETRY_BASE_MS * 2 ** this.caffeinateRetryAttempt,
+		);
+		this.caffeinateRetryAttempt += 1;
+		this.retryTimer = this.setTimer(() => {
+			this.retryTimer = null;
+			this.refresh("caffeinate-retry");
+		}, delay);
+		this.retryTimer.unref?.();
+	}
+
+	private clearRetry(): void {
+		if (this.retryTimer !== null) {
+			this.clearTimer(this.retryTimer);
+			this.retryTimer = null;
+		}
+		this.caffeinateRetryAttempt = 0;
+	}
+
+	private detachCaffeinate(): void {
+		this.caffeinateCleanup?.();
+		this.caffeinateCleanup = null;
+	}
+
+	private stopCaffeinate(): void {
+		if (this.caffeinate === null) return;
+		const child = this.caffeinate;
+		this.caffeinate = null;
+		this.detachCaffeinate();
+		try {
+			child.kill();
+		} catch (cause) {
+			this.logger.debug("[computer-awake] caffeinate was already stopped", {
+				cause,
+			});
+		}
+	}
+
+	private publish(): void {
+		const status = this.getStatus();
+		for (const listener of this.listeners) listener(status);
+	}
+}

--- a/apps/desktop/src/computer-awake-preference.ts
+++ b/apps/desktop/src/computer-awake-preference.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ComputerAwakeMode } from "@zuse/contracts";
+
+const PREFERENCE_FILE = "computer-awake.json";
+export const DEFAULT_COMPUTER_AWAKE_MODE: ComputerAwakeMode = "auto";
+
+const preferencePath = (userData: string): string =>
+	join(userData, PREFERENCE_FILE);
+
+const isComputerAwakeMode = (value: unknown): value is ComputerAwakeMode =>
+	value === "off" || value === "auto" || value === "always";
+
+export const readComputerAwakePreference = async (
+	userData: string,
+): Promise<ComputerAwakeMode> => {
+	try {
+		const parsed: unknown = JSON.parse(
+			await readFile(preferencePath(userData), "utf8"),
+		);
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			"mode" in parsed &&
+			isComputerAwakeMode(parsed.mode)
+		) {
+			return parsed.mode;
+		}
+	} catch {
+		// Missing and corrupt preferences intentionally use the product default.
+	}
+	return DEFAULT_COMPUTER_AWAKE_MODE;
+};
+
+export const writeComputerAwakePreference = async (
+	userData: string,
+	mode: ComputerAwakeMode,
+): Promise<void> => {
+	await mkdir(userData, { recursive: true });
+	const destination = preferencePath(userData);
+	const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+	await writeFile(temporary, `${JSON.stringify({ mode }, null, 2)}\n`, {
+		encoding: "utf8",
+		mode: 0o600,
+	});
+	await rename(temporary, destination);
+};

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -26,6 +26,13 @@ import { promisify } from "node:util";
 import {
 	AGENTS_RUNNING_COUNT_CHANNEL,
 	AuthFlowError,
+	COMPUTER_AWAKE_GET_STATUS_CHANNEL,
+	COMPUTER_AWAKE_SET_MODE_CHANNEL,
+	COMPUTER_AWAKE_STATE_CHANNEL,
+	COMPUTER_AWAKE_SUBSCRIBE_CHANNEL,
+	COMPUTER_AWAKE_UNSUBSCRIBE_CHANNEL,
+	type ComputerAwakeMode,
+	type ComputerAwakeStatus,
 	type DeepEnergySummary,
 	EnsureSshEnvironmentInput,
 	EnsureTailnetEnvironmentInput,
@@ -87,6 +94,7 @@ import {
 	powerMonitor as nativePowerMonitor,
 	nativeTheme,
 	net,
+	powerSaveBlocker,
 	protocol,
 	session,
 	shell,
@@ -140,6 +148,11 @@ import {
 	restoreImportedBrowserCookies,
 	watchImportedBrowserCookies,
 } from "./browser-session-service.ts";
+import { ComputerAwakeController } from "./computer-awake-controller.ts";
+import {
+	readComputerAwakePreference,
+	writeComputerAwakePreference,
+} from "./computer-awake-preference.ts";
 import {
 	type DeepEnergyProfileHandle,
 	startDeepEnergyProfile,
@@ -645,7 +658,81 @@ let localConnectivityHelper: ChildProcessWithoutNullStreams | null = null;
 let localConnectivityRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let localConnectivityRestartAttempt = 0;
 let localConnectivityStopping = false;
+let computerAwakeController: ComputerAwakeController | null = null;
+let remoteComputerAwakeConnections = 0;
+const computerAwakeSubscribers = new Set<number>();
 const desktopProcessStartedAt = performance.now();
+
+const unsupportedComputerAwakeStatus = (): ComputerAwakeStatus => ({
+	supported: false,
+	mode: "off",
+	active: false,
+	activeAgents: 0,
+	remoteClients: 0,
+	electronBlockerActive: false,
+	caffeinateActive: false,
+	warning: null,
+});
+
+const currentComputerAwakeStatus = (): ComputerAwakeStatus =>
+	computerAwakeController?.getStatus() ?? unsupportedComputerAwakeStatus();
+
+const broadcastComputerAwakeStatus = (status: ComputerAwakeStatus): void => {
+	for (const webContentsId of [...computerAwakeSubscribers]) {
+		const target = webContentsModule.fromId(webContentsId);
+		if (target === undefined || target.isDestroyed()) {
+			computerAwakeSubscribers.delete(webContentsId);
+			continue;
+		}
+		target.send(COMPUTER_AWAKE_STATE_CHANNEL, status);
+	}
+};
+
+const retainRemoteComputerAwakeConnection = (): (() => void) => {
+	remoteComputerAwakeConnections += 1;
+	computerAwakeController?.setRemoteClients(remoteComputerAwakeConnections);
+	let retained = true;
+	return () => {
+		if (!retained) return;
+		retained = false;
+		remoteComputerAwakeConnections = Math.max(
+			0,
+			remoteComputerAwakeConnections - 1,
+		);
+		computerAwakeController?.setRemoteClients(remoteComputerAwakeConnections);
+	};
+};
+
+ipcMain.handle(COMPUTER_AWAKE_GET_STATUS_CHANNEL, currentComputerAwakeStatus);
+
+ipcMain.handle(
+	COMPUTER_AWAKE_SET_MODE_CHANNEL,
+	async (_event, rawMode: unknown): Promise<ComputerAwakeStatus> => {
+		if (rawMode !== "off" && rawMode !== "auto" && rawMode !== "always") {
+			throw new Error("Invalid computer-awake mode");
+		}
+		const mode: ComputerAwakeMode = rawMode;
+		const controller = computerAwakeController;
+		if (controller === null || process.platform !== "darwin") {
+			return currentComputerAwakeStatus();
+		}
+		await writeComputerAwakePreference(app.getPath("userData"), mode);
+		controller.setMode(mode);
+		return controller.getStatus();
+	},
+);
+
+ipcMain.on(COMPUTER_AWAKE_SUBSCRIBE_CHANNEL, (event) => {
+	computerAwakeSubscribers.add(event.sender.id);
+	event.sender.once("destroyed", () => {
+		computerAwakeSubscribers.delete(event.sender.id);
+	});
+	event.sender.send(COMPUTER_AWAKE_STATE_CHANNEL, currentComputerAwakeStatus());
+});
+
+ipcMain.on(COMPUTER_AWAKE_UNSUBSCRIBE_CHANNEL, (event) => {
+	computerAwakeSubscribers.delete(event.sender.id);
+});
 
 const readySshEnvironmentManager = async (): Promise<SshEnvironmentManager> => {
 	const manager = sshEnvironmentManager;
@@ -1022,6 +1109,7 @@ ipcMain.on(POWER_UNSUBSCRIBE_CHANNEL, (event) => {
 
 ipcMain.on(POWER_REPORT_WORKLOAD_CHANNEL, (_event, payload: unknown) => {
 	powerWorkload = sanitizePowerWorkload(payload);
+	computerAwakeController?.setActiveAgents(powerWorkload.activeAgents);
 	if (powerMeasurementMonitor?.getState().activeRecording !== null) {
 		powerMeasurementMonitor?.sampleNow();
 	}
@@ -3180,6 +3268,7 @@ async function createMainWindow() {
 		staticDir: isDevelopment ? undefined : rendererDistDir(),
 		devServerUrl: isDevelopment ? DEV_SERVER_URL : undefined,
 		onDiagnostic: appendRemoteConnectionLog,
+		onAuthenticatedConnection: retainRemoteComputerAwakeConnection,
 	});
 	const nearbyWsProtocol =
 		nearbyTls === null
@@ -3192,6 +3281,7 @@ async function createMainWindow() {
 					onDiagnostic: appendRemoteConnectionLog,
 					onListening: ({ port }) =>
 						startLocalConnectivityHelper(port, systemHostname, nearbyTls.pin),
+					onAuthenticatedConnection: retainRemoteComputerAwakeConnection,
 				});
 	appendRemoteConnectionLog("desktop.runtime.start", {
 		relayWsPort,
@@ -3805,6 +3895,16 @@ void app.whenReady().then(async () => {
 	if (initialDeepLink !== undefined) handleAuthCallback(initialDeepLink);
 
 	registerZuseProtocol();
+	if (process.platform === "darwin") {
+		const mode = await readComputerAwakePreference(app.getPath("userData"));
+		computerAwakeController = new ComputerAwakeController({
+			blocker: powerSaveBlocker,
+			initialMode: mode,
+			powerMonitor: nativePowerMonitor,
+		});
+		computerAwakeController.setRemoteClients(remoteComputerAwakeConnections);
+		computerAwakeController.subscribe(broadcastComputerAwakeStatus);
+	}
 	notchTray = new NotchTrayController({
 		preloadPath: Path.join(__dirname, "preload.cjs"),
 		devServerUrl: DEV_SERVER_URL,
@@ -3985,6 +4085,9 @@ app.on("before-quit", (event) => {
 // fires after an un-prevented `before-quit`, so a cancelled quit leaves the
 // tray untouched.
 app.on("will-quit", () => {
+	computerAwakeController?.dispose();
+	computerAwakeController = null;
+	computerAwakeSubscribers.clear();
 	if (gotSingleInstanceLock) {
 		try {
 			fsSync.unlinkSync(runMarkerPath);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,6 +1,13 @@
 import {
 	AGENTS_RUNNING_COUNT_CHANNEL,
 	type CloudWorkspaceSshAccess,
+	COMPUTER_AWAKE_GET_STATUS_CHANNEL,
+	COMPUTER_AWAKE_SET_MODE_CHANNEL,
+	COMPUTER_AWAKE_STATE_CHANNEL,
+	COMPUTER_AWAKE_SUBSCRIBE_CHANNEL,
+	COMPUTER_AWAKE_UNSUBSCRIBE_CHANNEL,
+	type ComputerAwakeMode,
+	type ComputerAwakeStatus,
 	IPC_CHANNEL,
 	type LagSample,
 	type PerformanceHistory,
@@ -30,6 +37,7 @@ import { contextBridge, type IpcRendererEvent, ipcRenderer } from "electron";
 import { createHostDescriptor } from "./host/descriptor.ts";
 
 let powerStateSubscriberCount = 0;
+let computerAwakeSubscriberCount = 0;
 
 /**
  * Preload bridge — the only seam between the renderer and the main process.
@@ -550,6 +558,39 @@ const bridge = {
 		},
 		reportWorkload: (workload: PowerWorkloadState) => {
 			ipcRenderer.send(POWER_REPORT_WORKLOAD_CHANNEL, workload);
+		},
+	},
+	computerAwake: {
+		getStatus: () =>
+			ipcRenderer.invoke(
+				COMPUTER_AWAKE_GET_STATUS_CHANNEL,
+			) as Promise<ComputerAwakeStatus>,
+		setMode: (mode: ComputerAwakeMode) =>
+			ipcRenderer.invoke(
+				COMPUTER_AWAKE_SET_MODE_CHANNEL,
+				mode,
+			) as Promise<ComputerAwakeStatus>,
+		onChanged: (handler: (status: ComputerAwakeStatus) => void) => {
+			const wrapped = (_event: IpcRendererEvent, status: ComputerAwakeStatus) =>
+				handler(status);
+			ipcRenderer.on(COMPUTER_AWAKE_STATE_CHANNEL, wrapped);
+			computerAwakeSubscriberCount += 1;
+			if (computerAwakeSubscriberCount === 1) {
+				ipcRenderer.send(COMPUTER_AWAKE_SUBSCRIBE_CHANNEL);
+			}
+			let subscribed = true;
+			return () => {
+				if (!subscribed) return;
+				subscribed = false;
+				ipcRenderer.off(COMPUTER_AWAKE_STATE_CHANNEL, wrapped);
+				computerAwakeSubscriberCount = Math.max(
+					0,
+					computerAwakeSubscriberCount - 1,
+				);
+				if (computerAwakeSubscriberCount === 0) {
+					ipcRenderer.send(COMPUTER_AWAKE_UNSUBSCRIBE_CHANNEL);
+				}
+			};
 		},
 	},
 	menu: {

--- a/apps/desktop/test/unit/computer-awake-controller.test.ts
+++ b/apps/desktop/test/unit/computer-awake-controller.test.ts
@@ -1,0 +1,212 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	CAFFEINATE_RETRY_BASE_MS,
+	CAFFEINATE_RETRY_MAX_MS,
+	ComputerAwakeController,
+} from "../../src/computer-awake-controller.ts";
+
+const makeBlocker = () => {
+	const active = new Set<number>();
+	let nextId = 1;
+	return {
+		active,
+		start: vi.fn(() => {
+			const id = nextId++;
+			active.add(id);
+			return id;
+		}),
+		stop: vi.fn((id: number) => active.delete(id)),
+		isStarted: vi.fn((id: number) => active.has(id)),
+	};
+};
+
+class FakeCaffeinate extends EventEmitter {
+	readonly kill = vi.fn(() => true);
+}
+
+const makeResumeSource = () => {
+	const listeners = new Set<() => void>();
+	return {
+		on: vi.fn((_event: "resume", listener: () => void) =>
+			listeners.add(listener),
+		),
+		off: vi.fn((_event: "resume", listener: () => void) =>
+			listeners.delete(listener),
+		),
+		resume: () => {
+			for (const listener of listeners) listener();
+		},
+	};
+};
+
+const makeHarness = (overrides: Record<string, unknown> = {}) => {
+	const blocker = makeBlocker();
+	const children: FakeCaffeinate[] = [];
+	const spawn = vi.fn(() => {
+		const child = new FakeCaffeinate();
+		children.push(child);
+		return child;
+	});
+	const powerMonitor = makeResumeSource();
+	const controller = new ComputerAwakeController({
+		blocker,
+		platform: "darwin",
+		powerMonitor,
+		spawn,
+		logger: { debug: vi.fn(), warn: vi.fn() },
+		...overrides,
+	});
+	return { blocker, children, controller, powerMonitor, spawn };
+};
+
+describe("ComputerAwakeController", () => {
+	afterEach(() => vi.useRealTimers());
+
+	it("is idle in Auto until a local agent or remote client is active", () => {
+		const { blocker, children, controller, spawn } = makeHarness();
+		expect(controller.getStatus()).toMatchObject({
+			mode: "auto",
+			active: false,
+		});
+
+		controller.setActiveAgents(1);
+		expect(blocker.start).toHaveBeenCalledWith("prevent-app-suspension");
+		expect(spawn).toHaveBeenCalledWith("/usr/bin/caffeinate", ["-i", "-s"], {
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		expect(controller.getStatus()).toMatchObject({
+			active: true,
+			activeAgents: 1,
+			electronBlockerActive: true,
+			caffeinateActive: true,
+		});
+
+		controller.setRemoteClients(1);
+		controller.setRemoteClients(1);
+		controller.setActiveAgents(1);
+		expect(blocker.start).toHaveBeenCalledOnce();
+		expect(spawn).toHaveBeenCalledOnce();
+		controller.setActiveAgents(0);
+		expect(children[0]?.kill).not.toHaveBeenCalled();
+		controller.setRemoteClients(0);
+		expect(children[0]?.kill).toHaveBeenCalledOnce();
+		expect(blocker.stop).toHaveBeenCalledOnce();
+		expect(controller.getStatus().active).toBe(false);
+	});
+
+	it("supports Always and releases immediately when switched Off", () => {
+		const { blocker, children, controller } = makeHarness({
+			initialMode: "always",
+		});
+		expect(controller.getStatus().active).toBe(true);
+
+		controller.setMode("off");
+		expect(blocker.stop).toHaveBeenCalledOnce();
+		expect(children[0]?.kill).toHaveBeenCalledOnce();
+		expect(controller.getStatus()).toMatchObject({
+			mode: "off",
+			active: false,
+		});
+	});
+
+	it("does nothing on unsupported platforms", () => {
+		const blocker = makeBlocker();
+		const spawn = vi.fn();
+		const controller = new ComputerAwakeController({
+			blocker,
+			platform: "linux",
+			initialMode: "always",
+			spawn,
+		});
+
+		expect(controller.getStatus()).toMatchObject({
+			supported: false,
+			active: false,
+		});
+		expect(blocker.start).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("reconciles a lost Electron assertion after resume", () => {
+		const { blocker, powerMonitor } = makeHarness({
+			initialMode: "always",
+		});
+		blocker.active.clear();
+
+		powerMonitor.resume();
+
+		expect(blocker.start).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps caffeinate active when the Electron assertion fails", () => {
+		const blocker = makeBlocker();
+		blocker.start.mockImplementation(() => {
+			throw new Error("blocker failed");
+		});
+		const { controller, spawn } = makeHarness({
+			blocker,
+			initialMode: "always",
+		});
+
+		expect(spawn).toHaveBeenCalledOnce();
+		expect(controller.getStatus()).toMatchObject({
+			active: true,
+			electronBlockerActive: false,
+			caffeinateActive: true,
+		});
+		expect(controller.getStatus().warning).toContain("Electron");
+	});
+
+	it("keeps Electron active and retries an unexpected caffeinate failure", () => {
+		vi.useFakeTimers();
+		const { blocker, children, controller, spawn } = makeHarness({
+			initialMode: "always",
+		});
+		children[0]?.emit("error", new Error("caffeinate failed"));
+
+		expect(controller.getStatus()).toMatchObject({
+			active: true,
+			electronBlockerActive: true,
+			caffeinateActive: false,
+		});
+		expect(controller.getStatus().warning).toContain("Closed-lid");
+		vi.advanceTimersByTime(CAFFEINATE_RETRY_BASE_MS);
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(blocker.start).toHaveBeenCalledOnce();
+	});
+
+	it("backs off repeated caffeinate failures up to a bounded delay", () => {
+		vi.useFakeTimers();
+		const { children, spawn } = makeHarness({ initialMode: "always" });
+		const delays = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000];
+
+		for (const [index, delay] of delays.entries()) {
+			children[index]?.emit("error", new Error(`failure ${index}`));
+			vi.advanceTimersByTime(delay - 1);
+			expect(spawn).toHaveBeenCalledTimes(index + 1);
+			vi.advanceTimersByTime(1);
+			expect(spawn).toHaveBeenCalledTimes(index + 2);
+		}
+
+		expect(delays.at(-1)).toBe(CAFFEINATE_RETRY_MAX_MS);
+	});
+
+	it("disposes listeners, assertions, and retry timers once", () => {
+		vi.useFakeTimers();
+		const { children, controller, powerMonitor, spawn } = makeHarness({
+			initialMode: "always",
+		});
+		children[0]?.emit("exit", 1, null);
+
+		controller.dispose();
+		controller.dispose();
+		vi.advanceTimersByTime(CAFFEINATE_RETRY_BASE_MS);
+
+		expect(powerMonitor.off).toHaveBeenCalledOnce();
+		expect(spawn).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/desktop/test/unit/computer-awake-preference.test.ts
+++ b/apps/desktop/test/unit/computer-awake-preference.test.ts
@@ -1,0 +1,40 @@
+import { mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+	readComputerAwakePreference,
+	writeComputerAwakePreference,
+} from "../../src/computer-awake-preference.ts";
+
+describe("computer awake preference", () => {
+	it("defaults missing and malformed preferences to auto", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "zuse-awake-pref-"));
+		await expect(readComputerAwakePreference(directory)).resolves.toBe("auto");
+
+		await writeFile(join(directory, "computer-awake.json"), "not json", "utf8");
+		await expect(readComputerAwakePreference(directory)).resolves.toBe("auto");
+
+		await writeFile(
+			join(directory, "computer-awake.json"),
+			JSON.stringify({ mode: "timed" }),
+			"utf8",
+		);
+		await expect(readComputerAwakePreference(directory)).resolves.toBe("auto");
+	});
+
+	it("persists a validated host mode atomically", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "zuse-awake-pref-"));
+		await writeComputerAwakePreference(directory, "always");
+
+		await expect(readComputerAwakePreference(directory)).resolves.toBe(
+			"always",
+		);
+		await expect(
+			readFile(join(directory, "computer-awake.json"), "utf8"),
+		).resolves.toContain('"mode": "always"');
+		await expect(readdir(directory)).resolves.toEqual(["computer-awake.json"]);
+	});
+});

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -55,7 +55,10 @@ import {
 } from "~/composer/draft-attachments";
 import { applyPreparedLinearContext } from "~/composer/linear-context-input";
 import { uploadAttachment } from "~/lib/attachments";
-import { resolveChatWorkspacePolicy } from "~/lib/auto-worktree";
+import {
+	resolveChatRuntimeMode,
+	resolveChatWorkspacePolicy,
+} from "~/lib/auto-worktree";
 import { chatLandingProgress } from "~/lib/chat-landing-progress";
 import { cloudWorkspaceBetaAvailable } from "~/lib/cloud-machines-availability.ts";
 import {
@@ -222,7 +225,6 @@ export function ChatLanding() {
 	const defaultModelByProvider = useSettingsStore(
 		(s) => s.defaultModelByProvider,
 	);
-	const defaultRuntimeMode = useSettingsStore((s) => s.defaultRuntimeMode);
 	const defaultAutoCreateWorktree = useSettingsStore(
 		(s) => s.defaultAutoCreateWorktree,
 	);
@@ -546,6 +548,7 @@ export function ChatLanding() {
 	// edits the user makes inside the composer mutate the draft in place, so we
 	// must not clobber them on unrelated default-settings changes.
 	useLayoutEffect(() => {
+		let cancelled = false;
 		// A create-from source is scoped to the project it was picked in, and a
 		// "Run on" override to the draft it was picked for.
 		setCreateSource(null);
@@ -556,15 +559,27 @@ export function ChatLanding() {
 			clearDraft();
 			return;
 		}
-		beginDraft({
-			projectId: draftFolderId,
-			providerId: defaultProviderId,
-			model:
-				defaultModelByProvider[defaultProviderId] ??
-				defaultModelFor(defaultProviderId),
-			runtimeMode: defaultRuntimeMode,
-		});
-		return () => clearDraft();
+		clearDraft();
+		const draftEnvironmentId = EnvironmentId.make(
+			remoteAnchor?.member.environmentId ?? activeEnvironmentId,
+		);
+		void resolveChatRuntimeMode(draftEnvironmentId, draftFolderId).then(
+			(runtimeMode) => {
+				if (cancelled) return;
+				beginDraft({
+					projectId: draftFolderId,
+					providerId: defaultProviderId,
+					model:
+						defaultModelByProvider[defaultProviderId] ??
+						defaultModelFor(defaultProviderId),
+					runtimeMode,
+				});
+			},
+		);
+		return () => {
+			cancelled = true;
+			clearDraft();
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [activeEnvironmentId, selectedFolderId, remoteAnchor]);
 

--- a/apps/renderer/src/components/main-tabs.tsx
+++ b/apps/renderer/src/components/main-tabs.tsx
@@ -20,6 +20,7 @@ import {
 	type AgentActivityState,
 	deriveAgentActivityState,
 } from "../lib/agent-activity-state.ts";
+import { resolveChatRuntimeMode } from "../lib/auto-worktree.ts";
 import { deriveChatAttentionState } from "../lib/chat-attention-state.ts";
 import { closeChatTab } from "../lib/close-chat-tab.ts";
 import { useActiveEnvironmentEntities } from "../lib/environment-entity-hooks.ts";
@@ -257,7 +258,11 @@ export function MainTabs({ projectId, environmentId, emptyLabel }: Props) {
 					{projectId !== null &&
 						activeChatId !== null &&
 						pendingCreationByChat[activeChatId] === undefined && (
-							<NewChatTabButton chatId={activeChatId} />
+							<NewChatTabButton
+								chatId={activeChatId}
+								environmentId={environmentId}
+								projectId={projectId}
+							/>
 						)}
 				</div>
 			</header>
@@ -389,8 +394,12 @@ export function ChatTabButton({
 
 function NewChatTabButton({
 	chatId,
+	environmentId,
+	projectId,
 }: {
 	chatId: import("@zuse/contracts").ChatId;
+	environmentId: EnvironmentId;
+	projectId: FolderId | null;
 }) {
 	const refresh = useProvidersStore((s) => s.refresh);
 	const create = useSessionsStore((s) => s.create);
@@ -399,7 +408,6 @@ function NewChatTabButton({
 	const defaultModelByProvider = useSettingsStore(
 		(s) => s.defaultModelByProvider,
 	);
-	const defaultRuntimeMode = useSettingsStore((s) => s.defaultRuntimeMode);
 
 	// Creates a new session inside the active chat. Worktree is inherited
 	// from the chat row server-side. Skip the awaited provider refresh when
@@ -413,8 +421,12 @@ function NewChatTabButton({
 		const model =
 			defaultModelByProvider[defaultProviderId] ??
 			defaultModelFor(defaultProviderId);
+		const runtimeMode =
+			projectId === null
+				? useSettingsStore.getState().defaultRuntimeMode
+				: await resolveChatRuntimeMode(environmentId, projectId);
 		void create(chatId, defaultProviderId, model, {
-			runtimeMode: defaultRuntimeMode,
+			runtimeMode,
 		});
 	};
 

--- a/apps/renderer/src/components/permission-card.tsx
+++ b/apps/renderer/src/components/permission-card.tsx
@@ -7,7 +7,10 @@ import type {
 import { useCallback, useEffect } from "react";
 
 import { cn } from "~/lib/utils";
-import { decideEnvironmentPermission } from "../lib/environment-permissions-client-bus.ts";
+import {
+	decideEnvironmentPermission,
+	denyEnvironmentPermissionAndInterrupt,
+} from "../lib/environment-permissions-client-bus.ts";
 
 const kindHeadline = (kind: PermissionKind): string => {
 	switch (kind._tag) {
@@ -61,8 +64,6 @@ const ALWAYS_ALLOW_FOLDER: PermissionDecision = {
 	_tag: "AlwaysAllow",
 	scope: "folder",
 };
-const DENY: PermissionDecision = { _tag: "Deny" };
-
 export function PermissionCard({
 	head,
 	queueSize,
@@ -77,13 +78,17 @@ export function PermissionCard({
 			decideEnvironmentPermission(requestId, decision, environmentId),
 		[environmentId],
 	);
+	const deny = useCallback(
+		() => denyEnvironmentPermissionAndInterrupt(head, environmentId),
+		[environmentId, head],
+	);
 	const persistentDisabled = head.forcePrompt;
 
 	useEffect(() => {
 		const onKey = (e: KeyboardEvent) => {
 			if (e.key === "Escape") {
 				e.preventDefault();
-				void decide(head.id, DENY);
+				void deny();
 				return;
 			}
 			if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
@@ -94,7 +99,7 @@ export function PermissionCard({
 		};
 		document.addEventListener("keydown", onKey);
 		return () => document.removeEventListener("keydown", onKey);
-	}, [head.id, decide]);
+	}, [head.id, decide, deny]);
 
 	return (
 		<div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
@@ -122,7 +127,7 @@ export function PermissionCard({
 			<div className="mt-4 flex flex-wrap items-center justify-end gap-1">
 				<button
 					type="button"
-					onClick={() => void decide(head.id, DENY)}
+					onClick={() => void deny()}
 					className="rounded-md px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground"
 					title="Esc"
 				>

--- a/apps/renderer/src/components/projects-sidebar.tsx
+++ b/apps/renderer/src/components/projects-sidebar.tsx
@@ -25,6 +25,7 @@ import {
 	Login03Icon,
 	Logout01Icon,
 	PencilIcon,
+	Robot01Icon,
 	ServerStack01Icon,
 	Settings01Icon,
 	SquareLock01Icon,
@@ -40,21 +41,13 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	useSyncExternalStore,
 } from "react";
-import { BlurredEmail } from "~/components/blurred-email.tsx";
 import { TypewriterText } from "~/components/typewriter-text.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
-import {
-	Menu,
-	MenuItem,
-	MenuPopup,
-	MenuSeparator,
-	MenuShortcut,
-	MenuTrigger,
-} from "~/components/ui/menu";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { toastManager } from "~/components/ui/toast.tsx";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
-import { UsageLimitsMenuItems } from "~/components/usage/usage-limits-submenu";
 import { useAuth } from "~/hooks/use-auth.ts";
 import {
 	type ChatAttentionState,
@@ -89,6 +82,11 @@ import {
 } from "../lib/environment-shell-client-bus.ts";
 import { useGitWorkspaceResource } from "../lib/git-workspace-client-bus.ts";
 import { openNewChatLanding } from "../lib/open-new-chat-landing.ts";
+import {
+	activeAgentCountLabel,
+	getPowerRuntimeActivity,
+	subscribePowerRuntimeActivity,
+} from "../lib/power-runtime-activity.ts";
 import { branchStateFor, diffStatsFor } from "../lib/pr-branch-state.ts";
 import {
 	buildLogicalProjectGroups,
@@ -120,7 +118,7 @@ import { useRegisterPane } from "../store/pane-focus.ts";
 import { subscribeSessionTerminals } from "../store/session-runtime.ts";
 import { useSessionsStore } from "../store/sessions.ts";
 import { useUiStore } from "../store/ui.ts";
-import { useUsageLimitsStore } from "../store/usage-limits.ts";
+import { useUsageStore } from "../store/usage.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 import { EMPTY_WORKTREES, useWorktreesStore } from "../store/worktrees.ts";
 import { openAddComputerDialog } from "./add-computer-dialog.tsx";
@@ -558,17 +556,66 @@ function SidebarActionRow({
 }
 
 function SidebarFooter() {
+	const setView = useUiStore((state) => state.setView);
+	const openUsage = useUiStore((state) => state.openUsage);
+	const prefetchUsage = useUsageStore((state) => state.prefetch);
+
 	return (
-		<div className="flex flex-col gap-0.5 border-t border-sidebar-border/40 px-1.5 py-1">
+		<div className="flex h-10 items-center justify-between border-t border-sidebar-border/40 px-2">
 			<SidebarAccount />
+			<div className="flex items-center gap-0.5">
+				<SidebarAgentCount />
+				<SidebarFooterIcon
+					icon={Analytics01Icon}
+					label="Usage"
+					onPointerEnter={() => void prefetchUsage(null)}
+					onFocus={() => void prefetchUsage(null)}
+					onClick={() => openUsage("global")}
+				/>
+				<SidebarFooterIcon
+					icon={Settings01Icon}
+					label="Settings"
+					onClick={() => setView("settings")}
+				/>
+			</div>
 		</div>
 	);
 }
 
+function SidebarAgentCount() {
+	const activeAgents = useSyncExternalStore(
+		subscribePowerRuntimeActivity,
+		() => getPowerRuntimeActivity().activeAgents,
+		() => 0,
+	);
+	const label = activeAgentCountLabel(activeAgents);
+
+	return (
+		<Tooltip>
+			<TooltipTrigger
+				render={
+					<span
+						role="status"
+						aria-label={label}
+						className="inline-flex h-7 min-w-7 items-center justify-center gap-1 rounded-md px-1.5 text-sm leading-none tabular-nums text-muted-foreground"
+					>
+						{activeAgents > 0 ? (
+							<AgentActivityOrb state="working" label={label} />
+						) : (
+							<HugeiconsIcon icon={Robot01Icon} className="size-3.5" />
+						)}
+						<span>{activeAgents}</span>
+					</span>
+				}
+			/>
+			<TooltipPopup side="top">{label}</TooltipPopup>
+		</Tooltip>
+	);
+}
+
 /**
- * Bottom-of-sidebar account control. Signed out → a "Sign in" button. Signed
- * in → avatar + name that opens a menu (Account settings, Sign out). Auth is
- * optional, so this is the primary place to discover sign-in after onboarding.
+ * Compact account affordance. Account details and sign-out live in General
+ * settings, keeping the sidebar footer free of a second navigation menu.
  */
 function SidebarAccount() {
 	const {
@@ -579,17 +626,11 @@ function SidebarAccount() {
 		name,
 		signingIn,
 		signIn,
-		signOut,
 	} = useAuth();
 	const setView = useUiStore((s) => s.setView);
 	const setSettingsSection = useUiStore((s) => s.setSettingsSection);
-	const refreshUsageLimits = useUsageLimitsStore((s) => s.refresh);
 
-	// Always render an affordance. Until auth state resolves (or whenever signed
-	// out) we show "Sign in" — a brief flash to the signed-in row on cold load
-	// is fine and far better than showing nothing.
 	const initial = (name || user?.email || "?").charAt(0).toUpperCase();
-	const nameIsEmail = Boolean(user?.email && name === user.email);
 	if (isHostedProduct()) {
 		return (
 			<Menu>
@@ -625,21 +666,35 @@ function SidebarAccount() {
 		);
 	}
 
+	const label = isUnavailable
+		? "Account unavailable"
+		: isLoading
+			? "Loading account"
+			: isSignedIn
+				? "Profile"
+				: signingIn
+					? "Signing in"
+					: "Sign in";
+	const openAccount = () => {
+		if (isLoading || isUnavailable || signingIn) return;
+		if (!isSignedIn) {
+			void signIn();
+			return;
+		}
+		setSettingsSection({ kind: "general" });
+		setView("settings");
+	};
+
 	return (
-		<Menu>
-			<MenuTrigger
+		<Tooltip>
+			<TooltipTrigger
 				render={
 					<button
 						type="button"
-						onPointerEnter={() => {
-							// Force-refresh so Kiro OIDC misses cannot stick in the
-							// soft 60s cache (token is short-lived).
-							void refreshUsageLimits(true);
-						}}
-						onFocus={() => {
-							void refreshUsageLimits(true);
-						}}
-						className="flex w-full items-center gap-2 rounded-lg px-2 py-1 text-[12px] text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+						onClick={openAccount}
+						disabled={isLoading || isUnavailable || signingIn}
+						aria-label={label}
+						className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
 					>
 						{isSignedIn ? (
 							<Avatar className="size-5 text-[10px]">
@@ -651,60 +706,49 @@ function SidebarAccount() {
 								</AvatarFallback>
 							</Avatar>
 						) : isLoading ? (
-							<HugeiconsIcon icon={UserCircleIcon} className="size-3.5" />
+							<HugeiconsIcon icon={UserCircleIcon} className="size-4" />
 						) : (
-							<HugeiconsIcon icon={Login03Icon} className="size-3.5" />
-						)}
-						{isUnavailable ? (
-							<span>Account unavailable</span>
-						) : isLoading ? (
-							<span>Loading account…</span>
-						) : !isSignedIn ? (
-							<span>{signingIn ? "Signing in…" : "Sign in"}</span>
-						) : nameIsEmail && user?.email ? (
-							<BlurredEmail email={user.email} />
-						) : (
-							<span className="min-w-0 flex-1 truncate text-left">{name}</span>
+							<HugeiconsIcon icon={Login03Icon} className="size-4" />
 						)}
 					</button>
 				}
 			/>
-			<MenuPopup side="top" align="start" className="w-64">
-				{!isSignedIn && !isLoading ? (
-					<>
-						<MenuItem disabled={signingIn} onClick={() => void signIn()}>
-							<HugeiconsIcon icon={Login03Icon} />
-							Sign in
-						</MenuItem>
-						<MenuSeparator />
-					</>
-				) : (
-					<MenuItem
-						onClick={() => {
-							setSettingsSection({ kind: "general" });
-							setView("settings");
-						}}
+			<TooltipPopup side="top">{label}</TooltipPopup>
+		</Tooltip>
+	);
+}
+
+function SidebarFooterIcon({
+	icon,
+	label,
+	onClick,
+	onPointerEnter,
+	onFocus,
+}: {
+	icon: IconSvgElement;
+	label: string;
+	onClick: () => void;
+	onPointerEnter?: () => void;
+	onFocus?: () => void;
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger
+				render={
+					<button
+						type="button"
+						onClick={onClick}
+						onPointerEnter={onPointerEnter}
+						onFocus={onFocus}
+						aria-label={label}
+						className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 					>
-						<HugeiconsIcon icon={UserCircleIcon} />
-						Account settings
-					</MenuItem>
-				)}
-				<UsageLimitsMenuItems />
-				<MenuItem onClick={() => setView("settings")}>
-					<HugeiconsIcon icon={Settings01Icon} />
-					Settings<MenuShortcut>{formatShortcut("settings")}</MenuShortcut>
-				</MenuItem>
-				{isSignedIn ? (
-					<>
-						<MenuSeparator />
-						<MenuItem variant="destructive" onClick={() => void signOut()}>
-							<HugeiconsIcon icon={Logout01Icon} />
-							Sign out
-						</MenuItem>
-					</>
-				) : null}
-			</MenuPopup>
-		</Menu>
+						<HugeiconsIcon icon={icon} className="size-4" />
+					</button>
+				}
+			/>
+			<TooltipPopup side="top">{label}</TooltipPopup>
+		</Tooltip>
 	);
 }
 

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -5,6 +5,8 @@ import {
 	type BranchNamingStyle,
 	CommandId,
 	type CompletionSoundPreset,
+	type ComputerAwakeMode,
+	type ComputerAwakeStatus,
 	EnvironmentId,
 	type Folder,
 	type FolderId,
@@ -35,7 +37,7 @@ import { ChevronLeft, Plus, RefreshCw as RefreshIcon } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cloudWorkspaceBetaAvailable } from "~/lib/cloud-machines-availability.ts";
 import { displayPath } from "~/lib/display-path";
-import { hasHostCapability } from "~/lib/host-platform";
+import { hasHostCapability, isMacHost } from "~/lib/host-platform";
 import { rendererPlatformCapabilities } from "~/lib/platform-capabilities.ts";
 import { isInitialProviderAvailabilityLoading } from "~/lib/provider-status";
 
@@ -51,6 +53,10 @@ import {
 	playCompletionSound,
 	prepareCompletionSound,
 } from "../lib/completion-sounds.ts";
+import {
+	computerAwakeModeDescription,
+	computerAwakeStatusText,
+} from "../lib/computer-awake.ts";
 import { dispatchEnvironmentShellCommand } from "../lib/environment-shell-client-bus.ts";
 import { PROVIDER_LABEL } from "../lib/provider-labels.ts";
 import { useSettingsStore } from "../lib/settings-client-bus.ts";
@@ -989,6 +995,102 @@ const APPEARANCE_OPTIONS: ReadonlyArray<{
 	{ value: "dark", label: "Dark" },
 ];
 
+const COMPUTER_AWAKE_OPTIONS: ReadonlyArray<{
+	readonly value: ComputerAwakeMode;
+	readonly label: string;
+}> = [
+	{ value: "off", label: "Off" },
+	{ value: "auto", label: "Auto" },
+	{ value: "always", label: "Always" },
+];
+
+function ComputerAwakeSettings() {
+	const [status, setStatus] = useState<ComputerAwakeStatus | null>(null);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const awake = window.zuse?.computerAwake;
+		if (awake === undefined) return;
+		let mounted = true;
+		const unsubscribe = awake.onChanged((next) => {
+			if (mounted) setStatus(next);
+		});
+		void awake
+			.getStatus()
+			.then((next) => {
+				if (mounted) setStatus(next);
+			})
+			.catch((cause) => {
+				if (mounted)
+					setError(cause instanceof Error ? cause.message : String(cause));
+			});
+		return () => {
+			mounted = false;
+			unsubscribe();
+		};
+	}, []);
+
+	if (!isMacHost()) return null;
+
+	const mode = status?.mode ?? "auto";
+	const setMode = async (next: ComputerAwakeMode): Promise<void> => {
+		const awake = window.zuse?.computerAwake;
+		if (awake === undefined || saving) return;
+		setSaving(true);
+		setError(null);
+		try {
+			setStatus(await awake.setMode(next));
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<SettingsGroup
+			title="Power"
+			description="Keep this Mac available for local agents and remote control."
+		>
+			<SettingsRow
+				title="Keep Mac awake"
+				description={computerAwakeModeDescription(mode)}
+				action={
+					<Select
+						value={mode}
+						onValueChange={(value) => void setMode(value as ComputerAwakeMode)}
+						items={COMPUTER_AWAKE_OPTIONS}
+					>
+						<SelectTrigger
+							className="h-7 w-28"
+							disabled={saving}
+							aria-label="Keep Mac awake"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectPopup>
+							{COMPUTER_AWAKE_OPTIONS.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectPopup>
+					</Select>
+				}
+			>
+				<div className="flex flex-col gap-1 text-[11px] leading-snug text-muted-foreground">
+					<p>{error ?? computerAwakeStatusText(status)}</p>
+					<p>
+						The display may turn off. Closed-lid operation is best effort and
+						depends on macOS hardware and power policy.
+					</p>
+				</div>
+			</SettingsRow>
+		</SettingsGroup>
+	);
+}
+
 function GeneralPane() {
 	const appearanceMode = useSettingsStore((s) => s.appearanceMode);
 	const setAppearanceMode = useSettingsStore((s) => s.setAppearanceMode);
@@ -1180,6 +1282,8 @@ function GeneralPane() {
 					}
 				/>
 			</SettingsGroup>
+
+			<ComputerAwakeSettings />
 
 			<SettingsGroup title="Notifications">
 				<SettingsRow

--- a/apps/renderer/src/hooks/use-report-runtime-activity.ts
+++ b/apps/renderer/src/hooks/use-report-runtime-activity.ts
@@ -1,6 +1,7 @@
 import { EnvironmentId, type PowerWorkloadState } from "@zuse/contracts";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useActiveEnvironmentEntities } from "../lib/environment-entity-hooks.ts";
+import { localRuntimeEnvironmentId } from "../lib/computer-awake.ts";
+import { useEnvironmentEntities } from "../lib/environment-entity-hooks.ts";
 import {
 	getPowerRuntimeActivity,
 	setPowerActiveAgentCount,
@@ -12,19 +13,19 @@ import { useEnvironmentCatalogStore } from "../store/environment-catalog.ts";
 
 /** Mirror privacy-safe active workload counts to desktop-owned services. */
 export function useReportRuntimeActivity(): void {
-	const { sessionsByProject } = useActiveEnvironmentEntities();
-	const activeEnvironmentId = useEnvironmentCatalogStore(
-		(state) => state.activeEnvironmentId,
+	const localEnvironmentId = useEnvironmentCatalogStore((state) =>
+		localRuntimeEnvironmentId(state.entries, state.activeEnvironmentId),
 	);
+	const { sessionsByProject } = useEnvironmentEntities(localEnvironmentId);
 	const timelineRefs = useMemo(
 		() =>
 			Object.values(sessionsByProject)
 				.flat()
 				.map((session) => ({
-					environmentId: EnvironmentId.make(activeEnvironmentId),
+					environmentId: EnvironmentId.make(localEnvironmentId),
 					sessionId: session.id,
 				})),
-		[activeEnvironmentId, sessionsByProject],
+		[localEnvironmentId, sessionsByProject],
 	);
 	const timelines = useRendererSessionTimelines(timelineRefs, "cache-only");
 	const runningCount = useMemo(

--- a/apps/renderer/src/lib/auto-worktree.ts
+++ b/apps/renderer/src/lib/auto-worktree.ts
@@ -2,6 +2,8 @@ import type {
 	ChatWorkspacePolicy,
 	EnvironmentId,
 	FolderId,
+	RepositorySettings,
+	RuntimeMode,
 } from "@zuse/contracts";
 
 import {
@@ -9,6 +11,34 @@ import {
 	useRepositorySettingsStore,
 } from "../store/repository-settings.ts";
 import { useSettingsStore } from "./settings-client-bus.ts";
+
+const repositorySettingsFor = async (
+	environmentId: EnvironmentId,
+	projectId: FolderId,
+): Promise<RepositorySettings | null> => {
+	const repositorySettings = useRepositorySettingsStore.getState();
+	return (
+		repositorySettings.byProject[
+			repositorySettingsKey(environmentId, projectId)
+		] ?? (await repositorySettings.refresh(environmentId, projectId))
+	);
+};
+
+export const effectiveChatRuntimeMode = (
+	globalDefault: RuntimeMode,
+	repositorySettings: Pick<RepositorySettings, "defaultRuntimeMode"> | null,
+): RuntimeMode => repositorySettings?.defaultRuntimeMode ?? globalDefault;
+
+/** Resolve the repository override before creating a new chat/session. */
+export async function resolveChatRuntimeMode(
+	environmentId: EnvironmentId,
+	projectId: FolderId,
+): Promise<RuntimeMode> {
+	return effectiveChatRuntimeMode(
+		useSettingsStore.getState().defaultRuntimeMode,
+		await repositorySettingsFor(environmentId, projectId),
+	);
+}
 
 /**
  * Resolve the worktree a freshly-created chat should run in. When per-repo
@@ -26,11 +56,7 @@ export async function resolveChatWorkspacePolicy(
 	projectId: FolderId,
 ): Promise<ChatWorkspacePolicy> {
 	const settings = useSettingsStore.getState();
-	const repositorySettings = useRepositorySettingsStore.getState();
-	const repoSettings =
-		repositorySettings.byProject[
-			repositorySettingsKey(environmentId, projectId)
-		] ?? (await repositorySettings.refresh(environmentId, projectId));
+	const repoSettings = await repositorySettingsFor(environmentId, projectId);
 	const shouldAutoCreate =
 		repoSettings?.autoCreateWorktree === true ||
 		settings.defaultAutoCreateWorktree === true;

--- a/apps/renderer/src/lib/bridge.ts
+++ b/apps/renderer/src/lib/bridge.ts
@@ -1,5 +1,7 @@
 import type {
 	CloudWorkspaceSshAccess,
+	ComputerAwakeMode,
+	ComputerAwakeStatus,
 	DiscoveredSshHost,
 	EnsureSshEnvironmentInput,
 	EnsureTailnetEnvironmentInput,
@@ -180,6 +182,14 @@ export interface PowerBridge {
 	readonly clearHistory: () => Promise<void>;
 	readonly reportLagSamples: (samples: ReadonlyArray<LagSample>) => void;
 	readonly reportWorkload: (workload: PowerWorkloadState) => void;
+}
+
+export interface ComputerAwakeBridge {
+	readonly getStatus: () => Promise<ComputerAwakeStatus>;
+	readonly setMode: (mode: ComputerAwakeMode) => Promise<ComputerAwakeStatus>;
+	readonly onChanged: (
+		handler: (status: ComputerAwakeStatus) => void,
+	) => () => void;
 }
 
 /**
@@ -478,6 +488,7 @@ export interface ZuseBridge {
 	readonly network?: NetworkBridge;
 	readonly updates?: UpdatesBridge;
 	readonly power?: PowerBridge;
+	readonly computerAwake?: ComputerAwakeBridge;
 	readonly browser?: BrowserBridge;
 	readonly notch?: NotchBridge;
 	readonly ssh?: SshBridge;

--- a/apps/renderer/src/lib/close-chat-tab.ts
+++ b/apps/renderer/src/lib/close-chat-tab.ts
@@ -1,12 +1,15 @@
 import {
 	defaultModelFor,
+	EnvironmentId,
 	type FolderId,
 	type Session,
 	type SessionId,
 } from "@zuse/contracts";
 
+import { useEnvironmentCatalogStore } from "../store/environment-catalog.ts";
 import { useProvidersStore } from "../store/providers.ts";
 import { useSessionsStore } from "../store/sessions.ts";
+import { resolveChatRuntimeMode } from "./auto-worktree.ts";
 import { activeSessionsByProject } from "./environment-entities.ts";
 import { useSettingsStore } from "./settings-client-bus.ts";
 
@@ -70,8 +73,14 @@ export const closeChatTab = async (sessionId: SessionId): Promise<void> => {
 	const providerId = settings.defaultProviderId;
 	const model =
 		settings.defaultModelByProvider[providerId] ?? defaultModelFor(providerId);
+	const runtimeMode = await resolveChatRuntimeMode(
+		EnvironmentId.make(
+			useEnvironmentCatalogStore.getState().activeEnvironmentId,
+		),
+		projectId,
+	);
 	await sessions.archive(currentSession.id);
 	await sessions.create(currentSession.chatId, providerId, model, {
-		runtimeMode: settings.defaultRuntimeMode,
+		runtimeMode,
 	});
 };

--- a/apps/renderer/src/lib/commands.ts
+++ b/apps/renderer/src/lib/commands.ts
@@ -11,6 +11,7 @@ import { useSessionsStore } from "../store/sessions";
 import { rightPaneKey, useUiStore } from "../store/ui";
 import { useWorkspaceStore } from "../store/workspace";
 import { captureAnalytics } from "./analytics";
+import { resolveChatRuntimeMode } from "./auto-worktree.ts";
 import { localProjectForCloudChat } from "./cloud-workspace-catalog.ts";
 import {
 	activeChatsByProject,
@@ -97,8 +98,16 @@ async function newTabInActiveChat(): Promise<void> {
 	const fresh = useSettingsStore.getState();
 	const model =
 		fresh.defaultModelByProvider[providerId] ?? defaultModelFor(providerId);
+	const projectId = useWorkspaceStore.getState().selectedFolderId;
+	const environmentId = EnvironmentId.make(
+		useEnvironmentCatalogStore.getState().activeEnvironmentId,
+	);
+	const runtimeMode =
+		projectId === null
+			? fresh.defaultRuntimeMode
+			: await resolveChatRuntimeMode(environmentId, projectId);
 	await useSessionsStore.getState().create(chatId, providerId, model, {
-		runtimeMode: fresh.defaultRuntimeMode,
+		runtimeMode,
 	});
 }
 

--- a/apps/renderer/src/lib/computer-awake.ts
+++ b/apps/renderer/src/lib/computer-awake.ts
@@ -1,0 +1,43 @@
+import type { ComputerAwakeMode, ComputerAwakeStatus } from "@zuse/contracts";
+
+export const computerAwakeModeDescription = (
+	mode: ComputerAwakeMode,
+): string => {
+	switch (mode) {
+		case "off":
+			return "Allows this Mac to sleep normally, even while agents are working.";
+		case "auto":
+			return "Keeps this Mac awake while a local agent is working or an authenticated remote client is connected.";
+		case "always":
+			return "Keeps this Mac awake whenever Zuse is open.";
+	}
+};
+
+export const localRuntimeEnvironmentId = (
+	entries: ReadonlyArray<{
+		readonly connectionKind: string;
+		readonly environmentId: string;
+	}>,
+	activeEnvironmentId: string,
+): string =>
+	entries.find((entry) => entry.connectionKind === "local")?.environmentId ??
+	activeEnvironmentId;
+
+export const computerAwakeStatusText = (
+	status: ComputerAwakeStatus | null,
+): string => {
+	if (status === null) return "Checking macOS power state…";
+	const agentCount = `${status.activeAgents} local ${status.activeAgents === 1 ? "agent" : "agents"} running`;
+	if (status.warning !== null) return `${agentCount} · ${status.warning}`;
+	if (status.mode === "off")
+		return `${agentCount} · Inactive — normal macOS sleep behavior.`;
+	if (status.active) {
+		if (status.mode === "always")
+			return `${agentCount} · Active — Always mode.`;
+		if (status.remoteClients > 0) {
+			return `${agentCount} · Active — ${status.remoteClients} remote ${status.remoteClients === 1 ? "client" : "clients"} connected.`;
+		}
+		return `${agentCount} · Active — agent work in progress.`;
+	}
+	return `${agentCount} · Inactive — Auto starts for agents and remote clients.`;
+};

--- a/apps/renderer/src/lib/environment-entity-hooks.ts
+++ b/apps/renderer/src/lib/environment-entity-hooks.ts
@@ -7,11 +7,8 @@ import {
 } from "./environment-entities.ts";
 import { useEnvironmentShellResource } from "./environment-shell-client-bus.ts";
 
-/** Active environment entities come directly from its one ClientBus shell. */
-export const useActiveEnvironmentEntities = () => {
-	const environmentId = useEnvironmentCatalogStore(
-		(state) => state.activeEnvironmentId,
-	);
+/** Environment entities come directly from that environment's ClientBus shell. */
+export const useEnvironmentEntities = (environmentId: string) => {
 	const view = useEnvironmentShellResource(
 		EnvironmentId.make(environmentId),
 		"connect",
@@ -26,6 +23,14 @@ export const useActiveEnvironmentEntities = () => {
 			view.data?.sessionsByProject ?? EMPTY_SESSIONS_BY_PROJECT,
 		creationOperationsByProject: view.data?.creationOperationsByProject ?? {},
 	};
+};
+
+/** Active environment entities come directly from its one ClientBus shell. */
+export const useActiveEnvironmentEntities = () => {
+	const environmentId = useEnvironmentCatalogStore(
+		(state) => state.activeEnvironmentId,
+	);
+	return useEnvironmentEntities(environmentId);
 };
 
 /** Reactive lookup against the active environment's canonical shell cell. */

--- a/apps/renderer/src/lib/environment-permissions-client-bus.ts
+++ b/apps/renderer/src/lib/environment-permissions-client-bus.ts
@@ -19,6 +19,7 @@ import { Cause, Effect, Fiber, Stream } from "effect";
 import { useMemo } from "react";
 import { useEnvironmentCatalogStore } from "../store/environment-catalog.ts";
 import { isRpcClientTransportError, type MemoizeClient } from "./rpc-client.ts";
+import { interruptSession } from "./session-actions.ts";
 import {
 	getRendererClientBus,
 	registerRendererResourceDriver,
@@ -192,6 +193,19 @@ export const decideEnvironmentPermission = async (
 		}
 		throw cause;
 	}
+};
+
+/** A user denial rejects the requested action and ends that agent turn. */
+export const denyEnvironmentPermissionAndInterrupt = async (
+	request: Pick<PermissionRequest, "id" | "sessionId">,
+	environmentId: EnvironmentId,
+): Promise<void> => {
+	await decideEnvironmentPermission(
+		request.id,
+		{ _tag: "Deny" },
+		environmentId,
+	);
+	await interruptSession({ environmentId, sessionId: request.sessionId });
 };
 
 const activeKey = () =>

--- a/apps/renderer/src/lib/power-runtime-activity.ts
+++ b/apps/renderer/src/lib/power-runtime-activity.ts
@@ -7,6 +7,9 @@ export interface PowerRuntimeActivity {
 	readonly indexing: boolean;
 }
 
+export const activeAgentCountLabel = (count: number): string =>
+	`${count} local ${count === 1 ? "agent" : "agents"} running`;
+
 let activity: PowerRuntimeActivity = {
 	activeAgents: 0,
 	activeTerminals: 0,

--- a/apps/renderer/test/unit/chat-runtime-mode.test.ts
+++ b/apps/renderer/test/unit/chat-runtime-mode.test.ts
@@ -1,0 +1,25 @@
+import type { RepositorySettings } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import { effectiveChatRuntimeMode } from "../../src/lib/auto-worktree.ts";
+
+describe("effectiveChatRuntimeMode", () => {
+	it("uses a repository permission override for new chats", () => {
+		expect(
+			effectiveChatRuntimeMode("approval-required", {
+				defaultRuntimeMode: "full-access",
+			} as RepositorySettings),
+		).toBe("full-access");
+	});
+
+	it("falls back to the global permission default", () => {
+		expect(
+			effectiveChatRuntimeMode("auto-accept-edits", {
+				defaultRuntimeMode: null,
+			} as RepositorySettings),
+		).toBe("auto-accept-edits");
+		expect(effectiveChatRuntimeMode("approval-required", null)).toBe(
+			"approval-required",
+		);
+	});
+});

--- a/apps/renderer/test/unit/computer-awake.test.ts
+++ b/apps/renderer/test/unit/computer-awake.test.ts
@@ -1,0 +1,65 @@
+import type { ComputerAwakeStatus } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+	computerAwakeModeDescription,
+	computerAwakeStatusText,
+	localRuntimeEnvironmentId,
+} from "../../src/lib/computer-awake.ts";
+
+const status = (
+	overrides: Partial<ComputerAwakeStatus> = {},
+): ComputerAwakeStatus => ({
+	supported: true,
+	mode: "auto",
+	active: false,
+	activeAgents: 0,
+	remoteClients: 0,
+	electronBlockerActive: false,
+	caffeinateActive: false,
+	warning: null,
+	...overrides,
+});
+
+describe("computer awake renderer behavior", () => {
+	it("explains each mode in terms of when the Mac stays awake", () => {
+		expect(computerAwakeModeDescription("off")).toContain("sleep normally");
+		expect(computerAwakeModeDescription("auto")).toBe(
+			"Keeps this Mac awake while a local agent is working or an authenticated remote client is connected.",
+		);
+		expect(computerAwakeModeDescription("always")).toContain(
+			"whenever Zuse is open",
+		);
+	});
+
+	it("reports the local environment even when a remote environment is active", () => {
+		expect(
+			localRuntimeEnvironmentId(
+				[
+					{ connectionKind: "relay", environmentId: "remote" },
+					{ connectionKind: "local", environmentId: "this-mac" },
+				],
+				"remote",
+			),
+		).toBe("this-mac");
+	});
+
+	it("presents active triggers and degraded assertion state", () => {
+		expect(
+			computerAwakeStatusText(
+				status({ active: true, activeAgents: 2, remoteClients: 1 }),
+			),
+		).toBe("2 local agents running · Active — 1 remote client connected.");
+		expect(
+			computerAwakeStatusText(status({ warning: "Closed-lid unavailable." })),
+		).toBe("0 local agents running · Closed-lid unavailable.");
+		expect(computerAwakeStatusText(status())).toBe(
+			"0 local agents running · Inactive — Auto starts for agents and remote clients.",
+		);
+		expect(
+			computerAwakeStatusText(
+				status({ mode: "off", activeAgents: 3, remoteClients: 1 }),
+			),
+		).toBe("3 local agents running · Inactive — normal macOS sleep behavior.");
+	});
+});

--- a/apps/renderer/test/unit/environment-permissions-client-bus.test.ts
+++ b/apps/renderer/test/unit/environment-permissions-client-bus.test.ts
@@ -1,8 +1,11 @@
-import { EnvironmentId } from "@zuse/contracts";
+import { EnvironmentId, SessionId } from "@zuse/contracts";
 import { Effect } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { decideEnvironmentPermission } from "../../src/lib/environment-permissions-client-bus.ts";
+import {
+	decideEnvironmentPermission,
+	denyEnvironmentPermissionAndInterrupt,
+} from "../../src/lib/environment-permissions-client-bus.ts";
 import {
 	resetSessionTimelineClientBusForTest,
 	setSessionTimelineRpcClientForTest,
@@ -37,5 +40,31 @@ describe("environment permissions ClientBus adapter", () => {
 
 		expect(resolvedEnvironments).toEqual([cloudEnvironmentId]);
 		expect(decisions).toBe(1);
+	});
+
+	it("stops the same session after denying its permission request", async () => {
+		const environmentId = EnvironmentId.make("denied-permission-environment");
+		const sessionId = SessionId.make("denied-permission-session");
+		const calls: string[] = [];
+		setSessionTimelineRpcClientForTest(
+			async () =>
+				({
+					"permission.decide": () => {
+						calls.push("deny");
+						return Effect.succeed(undefined);
+					},
+					"messages.interrupt": () => {
+						calls.push("interrupt");
+						return Effect.succeed(undefined);
+					},
+				}) as never,
+		);
+
+		await denyEnvironmentPermissionAndInterrupt(
+			{ id: "permission-denied", sessionId },
+			environmentId,
+		);
+
+		expect(calls).toEqual(["deny", "interrupt"]);
 	});
 });

--- a/apps/renderer/test/unit/power-runtime-activity.test.ts
+++ b/apps/renderer/test/unit/power-runtime-activity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+	activeAgentCountLabel,
 	getPowerRuntimeActivity,
 	reportPowerBrowserRecordingStarted,
 	reportPowerBrowserRecordingStopped,
@@ -12,6 +13,12 @@ import {
 } from "../../src/lib/power-runtime-activity.ts";
 
 describe("power runtime activity", () => {
+	it("formats the footer agent count", () => {
+		expect(activeAgentCountLabel(0)).toBe("0 local agents running");
+		expect(activeAgentCountLabel(1)).toBe("1 local agent running");
+		expect(activeAgentCountLabel(3)).toBe("3 local agents running");
+	});
+
 	it("publishes lightweight workload counts and cleans up subscriptions", () => {
 		const listener = vi.fn();
 		const unsubscribe = subscribePowerRuntimeActivity(listener);

--- a/apps/server/src/transports/ws.ts
+++ b/apps/server/src/transports/ws.ts
@@ -84,6 +84,12 @@ export type WsServerProtocolOptions = {
 	readonly maxPayloadBytes?: number;
 	readonly onDiagnostic?: WsDiagnostic;
 	readonly onListening?: (address: WsServerListeningAddress) => void;
+	/**
+	 * Desktop-host lifecycle seam for accepted remote RPC sockets. The callback
+	 * runs only after authentication and protocol-version checks pass; its
+	 * returned release function runs exactly once when that socket closes.
+	 */
+	readonly onAuthenticatedConnection?: () => () => void;
 	readonly onPairing?: (pairing: {
 		readonly browserUrl: string;
 		readonly baseUrl: string;
@@ -576,7 +582,27 @@ export const wsServerProtocolLayer = (
 						426,
 					);
 				}
-				return yield* httpEffect;
+				// Upgrade here so lifecycle accounting starts only after Node has
+				// accepted the WebSocket. The RPC helper receives the already-created
+				// socket through a request view and continues to own its full lifetime.
+				const socket = yield* Effect.orDie(request.upgrade);
+				const upgradedRequest = new Proxy(request, {
+					get(target, property) {
+						return property === "upgrade"
+							? Effect.succeed(socket)
+							: Reflect.get(target, property, target);
+					},
+				});
+				const release = opts.onAuthenticatedConnection?.();
+				return yield* httpEffect.pipe(
+					Effect.provideService(
+						HttpServerRequest.HttpServerRequest,
+						upgradedRequest,
+					),
+					Effect.ensuring(
+						release === undefined ? Effect.void : Effect.sync(release),
+					),
+				);
 			});
 
 			const router = yield* HttpRouter.make;

--- a/apps/server/test/integration/ws-auth.test.ts
+++ b/apps/server/test/integration/ws-auth.test.ts
@@ -11,7 +11,7 @@ import { PingResult, PingRpc, WIRE_PROTOCOL_VERSION } from "@zuse/contracts";
 import { layer as sqliteLayer } from "@zuse/sqlite";
 import { Effect, Layer, ManagedRuntime, Schema } from "effect";
 import { Rpc, RpcGroup, RpcServer } from "effect/unstable/rpc";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { LanAuthServiceLive } from "../../src/lan-auth/layers/lan-auth-service.ts";
 import type { LanAuthPolicy } from "../../src/lan-auth/policy.ts";
@@ -77,6 +77,7 @@ const makeRuntime = (opts: {
 		event: string,
 		fields?: Record<string, unknown>,
 	) => void;
+	readonly onAuthenticatedConnection?: () => () => void;
 }) => {
 	const SqlLive = sqliteLayer({ filename: ":memory:" });
 	const Migrated = Layer.effectDiscard(
@@ -132,6 +133,7 @@ const makeRuntime = (opts: {
 		compression: opts.compression,
 		maxPayloadBytes: opts.maxPayloadBytes,
 		onDiagnostic: opts.onDiagnostic,
+		onAuthenticatedConnection: opts.onAuthenticatedConnection,
 	}).pipe(Layer.provide(Layer.merge(LanAuthLayer, AttachmentLayer)));
 	const ServerLayer = RpcServer.layer(TestRpcs).pipe(
 		Layer.provide(Layer.merge(PingHandler, LargePayloadHandler)),
@@ -522,16 +524,19 @@ describe("WS LAN auth", () => {
 
 	it("rejects unauthenticated protected requests before upgrade", async () => {
 		const port = await freePort();
+		const connected = vi.fn(() => vi.fn());
 		const runtime = makeRuntime({
 			policy: "protected",
 			port,
 			pairingBootstrap: true,
+			onAuthenticatedConnection: connected,
 		});
 		try {
 			await runtime.runPromise(Effect.void);
 			const response = await fetch(`http://127.0.0.1:${port}/`);
 			expect(response.status).toBe(401);
 			await expect(upgradeStatus(port, "/")).resolves.toBe(401);
+			expect(connected).not.toHaveBeenCalled();
 		} finally {
 			await disposeRuntime(runtime);
 		}
@@ -543,6 +548,12 @@ describe("WS LAN auth", () => {
 			readonly event: string;
 			readonly fields: Record<string, unknown>;
 		}> = [];
+		const releases: Array<ReturnType<typeof vi.fn>> = [];
+		const connected = vi.fn(() => {
+			const release = vi.fn();
+			releases.push(release);
+			return release;
+		});
 		const runtime = makeRuntime({
 			policy: "protected",
 			port,
@@ -550,6 +561,7 @@ describe("WS LAN auth", () => {
 			onDiagnostic: (event, fields = {}) => {
 				diagnostics.push({ event, fields });
 			},
+			onAuthenticatedConnection: connected,
 		});
 		try {
 			const pairing = await runtime.runPromise(
@@ -611,6 +623,13 @@ describe("WS LAN auth", () => {
 					`/rpc?token=${encodeURIComponent(body.token)}&wireVersion=${WIRE_PROTOCOL_VERSION}`,
 				),
 			).resolves.toBe(101);
+			await vi.waitFor(() => {
+				expect(connected).toHaveBeenCalledTimes(2);
+				expect(releases).toHaveLength(2);
+				expect(
+					releases.every((release) => release.mock.calls.length === 1),
+				).toBe(true);
+			});
 			const authDiagnostics = diagnostics.filter(
 				(entry) =>
 					entry.event === "ws.request" || entry.event.startsWith("ws.auth."),

--- a/docs/testing/mac-computer-awake.md
+++ b/docs/testing/mac-computer-awake.md
@@ -1,0 +1,22 @@
+# macOS computer-awake release check
+
+Run this check on a physical MacBook before a macOS release that changes the
+computer-awake controller. Automated tests verify assertion ownership, but a VM
+cannot verify lid behavior.
+
+1. Connect the MacBook to power and open Zuse Settings → General → Power.
+2. Select **Auto**, start an agent turn, and confirm the row reports the agent
+   trigger as active.
+3. Run `pmset -g assertions` and confirm Zuse/Electron has an idle-sleep
+   assertion and `/usr/bin/caffeinate -i -s` is running.
+4. Close the lid for at least two minutes, reopen it, and confirm the agent made
+   progress without a reconnect or session restart.
+5. Let the turn finish and close every remote browser/mobile client. Confirm the
+   row becomes inactive, the `caffeinate` process exits, and the Zuse assertion
+   disappears from `pmset -g assertions`.
+6. Repeat Always → Off and confirm Off releases both assertions immediately.
+
+Closed-lid operation is best effort. Record the Mac model, macOS version, power
+source, and whether an external display was attached. Do not change
+`pmset disablesleep`; Zuse does not install a privileged helper or override the
+user's global sleep policy.

--- a/packages/contracts/src/power.ts
+++ b/packages/contracts/src/power.ts
@@ -17,6 +17,34 @@ export const POWER_GET_HISTORY_CHANNEL = "zuse:power-get-history" as const;
 export const POWER_CLEAR_HISTORY_CHANNEL = "zuse:power-clear-history" as const;
 export const POWER_RECORDING_DURATION_MINUTES = [5, 15, 30] as const;
 
+export const COMPUTER_AWAKE_STATE_CHANNEL =
+	"zuse:computer-awake-state" as const;
+export const COMPUTER_AWAKE_GET_STATUS_CHANNEL =
+	"zuse:computer-awake-get-status" as const;
+export const COMPUTER_AWAKE_SET_MODE_CHANNEL =
+	"zuse:computer-awake-set-mode" as const;
+export const COMPUTER_AWAKE_SUBSCRIBE_CHANNEL =
+	"zuse:computer-awake-subscribe" as const;
+export const COMPUTER_AWAKE_UNSUBSCRIBE_CHANNEL =
+	"zuse:computer-awake-unsubscribe" as const;
+
+export const ComputerAwakeMode = Schema.Literals(["off", "auto", "always"]);
+export type ComputerAwakeMode = typeof ComputerAwakeMode.Type;
+
+/** Host-owned macOS sleep-inhibition state exposed through the preload bridge. */
+export class ComputerAwakeStatus extends Schema.Class<ComputerAwakeStatus>(
+	"ComputerAwakeStatus",
+)({
+	supported: Schema.Boolean,
+	mode: ComputerAwakeMode,
+	active: Schema.Boolean,
+	activeAgents: Schema.Number,
+	remoteClients: Schema.Number,
+	electronBlockerActive: Schema.Boolean,
+	caffeinateActive: Schema.Boolean,
+	warning: Schema.NullOr(Schema.String),
+}) {}
+
 export const PowerSource = Schema.Literals(["battery", "ac", "unknown"]);
 export type PowerSource = typeof PowerSource.Type;
 

--- a/packages/contracts/test/unit/power.test.ts
+++ b/packages/contracts/test/unit/power.test.ts
@@ -1,7 +1,11 @@
 import { Schema } from "effect";
 import { describe, expect, test } from "vitest";
 
-import { LagSample } from "../../src/power.ts";
+import {
+	ComputerAwakeMode,
+	ComputerAwakeStatus,
+	LagSample,
+} from "../../src/power.ts";
 
 const attributedLag = {
 	id: "lag-1",
@@ -46,5 +50,26 @@ describe("LagSample", () => {
 				},
 			}),
 		).toThrow();
+	});
+});
+
+describe("ComputerAwakeStatus", () => {
+	test("accepts the host status and rejects unknown modes", () => {
+		expect(Schema.decodeUnknownSync(ComputerAwakeMode)("auto")).toBe("auto");
+		expect(() =>
+			Schema.decodeUnknownSync(ComputerAwakeMode)("timed"),
+		).toThrow();
+		expect(
+			Schema.decodeUnknownSync(ComputerAwakeStatus)({
+				supported: true,
+				mode: "always",
+				active: true,
+				activeAgents: 0,
+				remoteClients: 0,
+				electronBlockerActive: true,
+				caffeinateActive: true,
+				warning: null,
+			}),
+		).toMatchObject({ mode: "always", active: true });
 	});
 });

--- a/tests/system/test/desktop/electron-power.desktop.test.ts
+++ b/tests/system/test/desktop/electron-power.desktop.test.ts
@@ -7,6 +7,109 @@ import { launchElectronApp } from "../../src/electron-app.ts";
 import { withSystemTest } from "../../src/system-scope.ts";
 
 describe("Electron performance measurement bridge", () => {
+	it.runIf(process.platform === "darwin")(
+		"starts and releases the macOS awake assertion through the preload bridge",
+		async () => {
+			await withSystemTest("zuse-electron-awake-", async (scope) => {
+				const userData = scope.path("user-data");
+				mkdirSync(userData, { recursive: true });
+				const server = await scope.server();
+				const rpc = await scope.rpc(server.endpoint);
+				await Effect.runPromise(
+					rpc.client["settings.update"]({
+						patch: { onboardingCompleted: true },
+					}),
+				);
+				await rpc.dispose();
+				await server.stop();
+				const provider = installFakeAcpProvider({ root: scope.root });
+				const electron = await scope.acquire(
+					() =>
+						launchElectronApp({
+							root: scope.root,
+							userData,
+							providerBinDirectory: provider.binDirectory,
+						}),
+					(value) => value.close(),
+				);
+
+				await electron.page.evaluate(async () => {
+					const target = window as typeof window & {
+						zuse?: {
+							computerAwake?: {
+								setMode: (
+									mode: "off" | "always",
+								) => Promise<import("@zuse/contracts").ComputerAwakeStatus>;
+							};
+						};
+					};
+					await target.zuse?.computerAwake?.setMode("off");
+				});
+				await electron.app.evaluate(({ powerSaveBlocker }) => {
+					const root = globalThis as typeof globalThis & {
+						__zuseAwakeProbe?: {
+							starts: number[];
+							stops: number[];
+						};
+					};
+					root.__zuseAwakeProbe = { starts: [], stops: [] };
+					const start = powerSaveBlocker.start.bind(powerSaveBlocker);
+					const stop = powerSaveBlocker.stop.bind(powerSaveBlocker);
+					powerSaveBlocker.start = ((type) => {
+						const id = start(type);
+						root.__zuseAwakeProbe?.starts.push(id);
+						return id;
+					}) as typeof powerSaveBlocker.start;
+					powerSaveBlocker.stop = ((id) => {
+						root.__zuseAwakeProbe?.stops.push(id);
+						return stop(id);
+					}) as typeof powerSaveBlocker.stop;
+				});
+
+				const active = await electron.page.evaluate(async () => {
+					const target = window as typeof window & {
+						zuse?: {
+							computerAwake?: {
+								setMode: (
+									mode: "off" | "always",
+								) => Promise<import("@zuse/contracts").ComputerAwakeStatus>;
+							};
+						};
+					};
+					return target.zuse?.computerAwake?.setMode("always");
+				});
+				expect(active).toMatchObject({
+					supported: true,
+					mode: "always",
+					active: true,
+					electronBlockerActive: true,
+				});
+				const inactive = await electron.page.evaluate(async () => {
+					const target = window as typeof window & {
+						zuse?: {
+							computerAwake?: {
+								setMode: (
+									mode: "off" | "always",
+								) => Promise<import("@zuse/contracts").ComputerAwakeStatus>;
+							};
+						};
+					};
+					return target.zuse?.computerAwake?.setMode("off");
+				});
+				expect(inactive).toMatchObject({ mode: "off", active: false });
+				const probe = await electron.app.evaluate(() => {
+					const root = globalThis as typeof globalThis & {
+						__zuseAwakeProbe?: { starts: number[]; stops: number[] };
+					};
+					return root.__zuseAwakeProbe;
+				});
+				expect(probe?.starts).toHaveLength(1);
+				expect(probe?.stops).toEqual(probe?.starts);
+			});
+		},
+		40_000,
+	);
+
 	it("samples locally, records on demand, and removes renderer subscriptions", async () => {
 		await withSystemTest("zuse-electron-power-", async (scope) => {
 			const userData = scope.path("user-data");


### PR DESCRIPTION
## Summary

- add macOS Keep Mac awake modes: Off, Auto, and Always
- keep one Electron suspension blocker and a managed caffeinate process, with independent health reporting, retry, resume reconciliation, and quit cleanup
- activate Auto for local agent work or authenticated remote clients, persist the host preference atomically, and expose status through preload
- add a compact General settings selector with mode-specific explanations and live trigger/degraded status
- simplify the sidebar footer with direct profile, usage, and settings actions plus an active-agent count
- respect repository permission defaults for new chats and stop the turn after a permission denial

## Verification

- Biome checks passed for all changed files
- full monorepo type checks passed: 31/31 tasks
- renderer unit tests passed: 560
- contracts unit tests passed: 138
- server integration tests passed: 223
- focused desktop Caffeine tests passed: 10
- architecture tests passed: 8/8
- renderer production build and bundle budgets passed

## Known environment limitations

- the macOS Electron power assertion system test is included but cannot execute in this Linux cloud workspace; physical Mac verification is documented in docs/testing/mac-computer-awake.md
- the full desktop unit suite has one unrelated date-sensitive failure in performance-history-store.test.ts because its fixed July 2026 fixture is now outside the retention window
- the Electron system suite also requires a display server, which this cloud workspace does not provide

## Manual release check

Before a macOS release, verify Auto, Always, and Off on a physical MacBook, including pmset assertions and best-effort closed-lid behavior, using docs/testing/mac-computer-awake.md.

## Provenance

- External implementation consulted: Yes
- Usage: Behavior only
- Source: https://github.com/stablyai/orca/blob/bc98655a3965fe350f77acb14bf4a53f26c5408c/src/main/agent-awake-service.ts
- Applicable license: MIT
- Required notice updated: Yes, in THIRD_PARTY_NOTICES.md

## Documentation

- README.md: documents the macOS Keep Mac awake modes and links the physical MacBook release check
- THIRD_PARTY_NOTICES.md: records Orca as the behavior reference for PR #525
- docs/testing/mac-computer-awake.md: documents assertion, mode-transition, and best-effort closed-lid verification