### PR TITLE
Fix stale sidebar projects and case-only duplicate imports

### DIFF
--- a/apps/renderer/src/lib/environment-shell-client-bus.ts
+++ b/apps/renderer/src/lib/environment-shell-client-bus.ts
@@ -81,35 +81,48 @@ let nextDriverEpoch = 0;
 const environmentRef = (key: ResourceKey<unknown>): EnvironmentRef | null =>
 	key.kind === "environment-shell" && !("folderId" in key.ref) ? key.ref : null;
 
-const foldersMatch = (
-	left: ReadonlyArray<Folder>,
-	right: ReadonlyArray<Folder>,
-): boolean =>
-	left.length === right.length &&
-	left.every((folder) => right.some((candidate) => candidate.id === folder.id));
-
-const resolveOrigins = async (
-	client: EnvironmentShellDriverClient,
-	folders: ReadonlyArray<Folder>,
+const reusedOrigins = (
 	previous: EnvironmentShellData | null,
-): Promise<Readonly<Record<string, GitOriginInfo | null>>> =>
-	previous !== null && foldersMatch(previous.folders, folders)
-		? previous.originsByFolder
+	folders: ReadonlyArray<Folder>,
+): Readonly<Record<string, GitOriginInfo | null>> =>
+	previous === null
+		? {}
 		: Object.fromEntries(
-				await Promise.all(
-					folders.map(async (folder) => {
-						const origin = await Effect.runPromise(
-							client["git.origin"]({ folderId: folder.id }),
-						).catch(() => null);
-						return [folder.id, origin] as const;
-					}),
+				folders.flatMap((folder) =>
+					folder.id in previous.originsByFolder
+						? ([
+								[folder.id, previous.originsByFolder[folder.id] ?? null],
+							] as const)
+						: [],
 				),
 			);
+
+const resolveMissingOrigins = async (
+	client: EnvironmentShellDriverClient,
+	folders: ReadonlyArray<Folder>,
+	known: Readonly<Record<string, GitOriginInfo | null>>,
+): Promise<Readonly<Record<string, GitOriginInfo | null>>> => {
+	const missing = folders.filter((folder) => !(folder.id in known));
+	if (missing.length === 0) return known;
+	const fetched = await Promise.all(
+		missing.map(async (folder) => {
+			const origin = await Effect.runPromise(
+				client["git.origin"]({ folderId: folder.id }),
+			).catch(() => null);
+			return [folder.id, origin] as const;
+		}),
+	);
+	return { ...known, ...Object.fromEntries(fetched) };
+};
 
 type EnvironmentShellInput =
 	| Readonly<{
 			type: "workspace";
 			folders: ReadonlyArray<Folder>;
+			originsByFolder: Readonly<Record<string, GitOriginInfo | null>>;
+	  }>
+	| Readonly<{
+			type: "origins";
 			originsByFolder: Readonly<Record<string, GitOriginInfo | null>>;
 	  }>
 	| Readonly<{
@@ -180,31 +193,45 @@ const shellInputs = (
 	let previous = initial;
 	return client["workspace.streamChanges"]({}).pipe(
 		Stream.switchMap((folders) => {
-			const workspace = Stream.fromEffect(
-				Effect.tryPromise({
-					try: async (): Promise<EnvironmentShellInput> => {
-						const originsByFolder = await resolveOrigins(
-							client,
-							folders,
-							previous,
-						);
-						previous = {
-							...(previous ?? emptyShell()),
-							folders,
-							originsByFolder,
-						};
-						return { type: "workspace", folders, originsByFolder };
-					},
-					catch: (cause) => cause,
-				}),
+			const originsByFolder = reusedOrigins(previous, folders);
+			previous = {
+				...(previous ?? emptyShell()),
+				folders,
+				originsByFolder,
+			};
+			const missing = folders.filter(
+				(folder) => !(folder.id in originsByFolder),
 			);
+			const origins =
+				missing.length === 0
+					? Stream.empty
+					: Stream.fromEffect(
+							Effect.tryPromise({
+								try: async (): Promise<EnvironmentShellInput> => {
+									const resolved = await resolveMissingOrigins(
+										client,
+										folders,
+										originsByFolder,
+									);
+									previous = {
+										...(previous ?? emptyShell()),
+										folders,
+										originsByFolder: resolved,
+									};
+									return { type: "origins", originsByFolder: resolved };
+								},
+								catch: (cause) => cause,
+							}),
+						);
 			return Stream.concat(
-				workspace,
+				Stream.succeed({
+					type: "workspace",
+					folders,
+					originsByFolder,
+				} satisfies EnvironmentShellInput),
 				Stream.mergeAll(
-					folders.map((folder) => projectInputs(client, folder)),
-					{
-						concurrency: "unbounded",
-					},
+					[origins, ...folders.map((folder) => projectInputs(client, folder))],
+					{ concurrency: "unbounded" },
 				),
 			);
 		}),
@@ -232,10 +259,12 @@ const upsertChat = (
 	);
 
 /**
- * One driver owns every environment-shell stream. Workspace frames switch the
- * qualified project subscriptions as one unit, and `runForEach` serializes all
- * reducer input so chat/session/creation summaries cannot race one another.
- * Each server stream subscribes before its snapshot, so switching the set of
+ * One driver owns every environment-shell stream. Workspace frames emit the
+ * folder list immediately so a hung `git.origin` cannot hide projects, then
+ * fill origins in the background. Those frames also switch the qualified
+ * project subscriptions as one unit, and `runForEach` serializes all reducer
+ * input so chat/session/creation summaries cannot race one another. Each
+ * server stream subscribes before its snapshot, so switching the set of
  * projects does not open a snapshot/live gap and requires no feature polling.
  */
 export const makeEnvironmentShellResourceDriver = (options: {
@@ -318,6 +347,14 @@ export const makeEnvironmentShellResourceDriver = (options: {
 							input.folders,
 							() => [],
 						),
+					};
+					emit();
+					return;
+				}
+				if (input.type === "origins") {
+					current = {
+						...current,
+						originsByFolder: input.originsByFolder,
 					};
 					emit();
 					return;

--- a/apps/renderer/src/lib/format-error.ts
+++ b/apps/renderer/src/lib/format-error.ts
@@ -20,6 +20,7 @@ const diagnosticErrorType = (value: unknown): string => {
 // fall through to a raw JSON dump like `{ "folderId": "…" }`. Map them to
 // human copy here so any surface that formats them stays readable.
 const TAG_MESSAGES: Record<string, string> = {
+	WorkspaceDuplicatePathError: "That folder is already in your workspace.",
 	GitNotARepoError: "This folder isn't a Git repository.",
 	DirectoryUnavailableError: "This directory is unavailable.",
 	GitFolderNotFoundError: "Project folder not found.",

--- a/apps/renderer/test/unit/cloud-workspace-error.test.ts
+++ b/apps/renderer/test/unit/cloud-workspace-error.test.ts
@@ -1,4 +1,7 @@
-import { CloudWorkspaceOpError } from "@zuse/contracts";
+import {
+	CloudWorkspaceOpError,
+	WorkspaceDuplicatePathError,
+} from "@zuse/contracts";
 import { describe, expect, test } from "vitest";
 import { formatError } from "../../src/lib/format-error.ts";
 
@@ -28,5 +31,15 @@ describe("cloud workspace errors", () => {
 				new CloudWorkspaceOpError({ code: "beta-access-unavailable" }),
 			),
 		).toBe("Cloud access could not be verified. Try again shortly.");
+	});
+});
+
+describe("workspace import errors", () => {
+	test("explains when a folder is already in the workspace", () => {
+		expect(
+			formatError(
+				new WorkspaceDuplicatePathError({ path: "/projects/already" }),
+			),
+		).toBe("That folder is already in your workspace.");
 	});
 });

--- a/apps/renderer/test/unit/environment-shell-client-bus.test.ts
+++ b/apps/renderer/test/unit/environment-shell-client-bus.test.ts
@@ -312,12 +312,79 @@ describe("environment shell ClientBus driver", () => {
 			EnvironmentShellDriverClient,
 			EnvironmentShellData
 		>);
-		Queue.offerUnsafe(workspace, [folder("one")]);
 		current = false;
+		Queue.offerUnsafe(workspace, [folder("one")]);
 		gate.resolve();
 		await Promise.resolve();
 		await Promise.resolve();
 		expect(emit).not.toHaveBeenCalled();
+		driver.stop();
+	});
+
+	it("emits the workspace folder list before git.origin resolves", async () => {
+		const workspace = Effect.runSync(
+			Queue.unbounded<ReadonlyArray<ReturnType<typeof folder>>>(),
+		);
+		const gate = Promise.withResolvers<void>();
+		const emitted: string[][] = [];
+		const origins: Array<Record<string, unknown>> = [];
+		const subscribedProjects: string[] = [];
+		const cachedOrigin = {
+			host: "github.com",
+			owner: "acme",
+			repo: "cached",
+		};
+		const driver = makeEnvironmentShellResourceDriver({
+			reportConnectionFailure: vi.fn(),
+		});
+		driver.start({
+			key: environmentShellResourceKey(ref),
+			client: {
+				"workspace.streamChanges": () => Stream.fromQueue(workspace),
+				"chat.streamChanges": ({
+					projectId,
+				}: {
+					readonly projectId: FolderId;
+				}) => {
+					subscribedProjects.push(`chat:${projectId}`);
+					return Stream.make({ _tag: "snapshot" as const, chats: [] });
+				},
+				"session.streamChanges": () => Stream.never,
+				"chat.creation.stream": () => Stream.never,
+				"git.origin": () => Effect.promise(() => gate.promise.then(() => null)),
+			} as unknown as EnvironmentShellDriverClient,
+			generation: 5,
+			data: {
+				folders: [folder("cached")],
+				originsByFolder: { cached: cachedOrigin },
+				chatsByProject: {},
+				sessionsByProject: {},
+				creationOperationsByProject: {},
+			},
+			cursor: null,
+			snapshot: () => null,
+			isCurrent: () => true,
+			emit: (update) => {
+				if (update.data !== undefined) {
+					emitted.push(update.data.folders.map(({ id }) => id));
+					origins.push(update.data.originsByFolder);
+				}
+				return true;
+			},
+		} satisfies ResourceDriverContext<
+			EnvironmentShellDriverClient,
+			EnvironmentShellData
+		>);
+		Queue.offerUnsafe(workspace, [folder("cached"), folder("fresh")]);
+		await vi.waitFor(() => expect(emitted[0]).toEqual(["cached", "fresh"]));
+		expect(subscribedProjects).toContain("chat:cached");
+		expect(subscribedProjects).toContain("chat:fresh");
+		expect(origins[0]).toEqual({ cached: cachedOrigin });
+		gate.resolve();
+		await vi.waitFor(() =>
+			expect(origins.at(-1)).toEqual({ cached: cachedOrigin, fresh: null }),
+		);
+		expect(emitted.at(-1)).toEqual(["cached", "fresh"]);
 		driver.stop();
 	});
 });

--- a/apps/server/src/persistence/migrations.ts
+++ b/apps/server/src/persistence/migrations.ts
@@ -52,6 +52,7 @@ import { Migration0048FsWriteReceipts } from "./migrations/0048_fs_write_receipt
 import { Migration0049ChatCreationStartupReady } from "./migrations/0049_chat_creation_startup_ready.ts";
 import { Migration0050DurableChatCreation } from "./migrations/0050_durable_chat_creation.ts";
 import { Migration0051LegacyChatCreationPhaseRepair } from "./migrations/0051_legacy_chat_creation_phase_repair.ts";
+import { Migration0052UniqueProjectPaths } from "./migrations/0052_unique_project_paths.ts";
 
 /**
  * Runs every numbered migration on boot. `fromRecord` keys must match
@@ -125,6 +126,7 @@ const MigrationDefinitions = {
 	"0050_durable_chat_creation": Migration0050DurableChatCreation,
 	"0051_legacy_chat_creation_phase_repair":
 		Migration0051LegacyChatCreationPhaseRepair,
+	"0052_unique_project_paths": Migration0052UniqueProjectPaths,
 } as const;
 
 /** Shipped 0.16 schema boundary, exported for upgrade compatibility tests. */

--- a/apps/server/src/persistence/migrations/0052_unique_project_paths.ts
+++ b/apps/server/src/persistence/migrations/0052_unique_project_paths.ts
@@ -1,0 +1,130 @@
+import { Effect } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+
+/**
+ * New registrations persist filesystem-canonical paths. Consolidate any exact
+ * duplicates written by older overlapping imports, then let SQLite arbitrate
+ * concurrent registrations across runtimes and processes.
+ *
+ * Case-only paths intentionally remain distinct: they may identify different
+ * directories on a case-sensitive filesystem. Workspace registration resolves
+ * legacy aliases through the filesystem before attempting an insert.
+ */
+export const Migration0052UniqueProjectPaths = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+
+	yield* sql`
+		CREATE TEMP TABLE project_path_duplicates AS
+		SELECT
+			project.id AS duplicate_id,
+			(
+				SELECT keeper.id
+				FROM projects AS keeper
+				WHERE keeper.path = project.path
+				ORDER BY keeper.created_at ASC, keeper.id ASC
+				LIMIT 1
+			) AS keeper_id
+		FROM projects AS project
+		WHERE project.id != (
+			SELECT keeper.id
+			FROM projects AS keeper
+			WHERE keeper.path = project.path
+			ORDER BY keeper.created_at ASC, keeper.id ASC
+			LIMIT 1
+		)
+	`;
+
+	// Settings are one-to-one. Prefer the keeper's row when both exist.
+	yield* sql`
+		DELETE FROM repository_settings
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+		  AND EXISTS (
+			SELECT 1
+			FROM project_path_duplicates AS duplicate
+			INNER JOIN repository_settings AS keeper_settings
+				ON keeper_settings.project_id = duplicate.keeper_id
+			WHERE duplicate.duplicate_id = repository_settings.project_id
+		  )
+	`;
+	yield* sql`
+		UPDATE repository_settings
+		SET project_id = (
+			SELECT keeper_id FROM project_path_duplicates
+			WHERE duplicate_id = repository_settings.project_id
+		)
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+
+	// A duplicated project can also have the same worktree path registered.
+	// Keep the keeper project's row and let ON DELETE SET NULL clear references
+	// to the redundant worktree before the duplicate project is removed.
+	yield* sql`
+		DELETE FROM worktrees
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+		  AND EXISTS (
+			SELECT 1
+			FROM project_path_duplicates AS duplicate
+			INNER JOIN worktrees AS keeper_worktree
+				ON keeper_worktree.project_id = duplicate.keeper_id
+				AND keeper_worktree.path = worktrees.path
+			WHERE duplicate.duplicate_id = worktrees.project_id
+		  )
+	`;
+	yield* sql`
+		UPDATE worktrees
+		SET project_id = (
+			SELECT keeper_id FROM project_path_duplicates
+			WHERE duplicate_id = worktrees.project_id
+		)
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+
+	yield* sql`
+		UPDATE sessions
+		SET project_id = (
+			SELECT keeper_id FROM project_path_duplicates
+			WHERE duplicate_id = sessions.project_id
+		)
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+	yield* sql`
+		UPDATE chats
+		SET project_id = (
+			SELECT keeper_id FROM project_path_duplicates
+			WHERE duplicate_id = chats.project_id
+		)
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+	yield* sql`
+		UPDATE permission_decisions
+		SET project_id = (
+			SELECT keeper_id FROM project_path_duplicates
+			WHERE duplicate_id = permission_decisions.project_id
+		)
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+	yield* sql`
+		UPDATE chat_creation_operations
+		SET project_id = (
+			SELECT keeper_id FROM project_path_duplicates
+			WHERE duplicate_id = chat_creation_operations.project_id
+		)
+		WHERE project_id IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+
+	yield* sql`
+		UPDATE app_state
+		SET value = (
+			SELECT keeper_id FROM project_path_duplicates
+			WHERE duplicate_id = app_state.value
+		)
+		WHERE key = 'selectedProjectId'
+		  AND value IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+	yield* sql`
+		DELETE FROM projects
+		WHERE id IN (SELECT duplicate_id FROM project_path_duplicates)
+	`;
+	yield* sql`DROP TABLE project_path_duplicates`;
+	yield* sql`CREATE UNIQUE INDEX idx_projects_path_unique ON projects(path)`;
+});

--- a/apps/server/src/workspace/layers/workspace-service.ts
+++ b/apps/server/src/workspace/layers/workspace-service.ts
@@ -34,7 +34,7 @@ export const WorkspaceServiceLive = Layer.effect(
 		const sql = yield* SqlClient.SqlClient;
 		const fs = yield* FileSystem.FileSystem;
 		const changes = yield* PubSub.unbounded<ReadonlyArray<Folder>>();
-		const registrationLock = yield* Semaphore.make(1);
+		const projectMutationLock = yield* Semaphore.make(1);
 
 		const list: WorkspaceService["Service"]["list"] = () =>
 			Effect.gen(function* () {
@@ -111,7 +111,7 @@ export const WorkspaceServiceLive = Layer.effect(
 					);
 				}
 
-				return yield* registrationLock.withPermits(1)(
+				return yield* projectMutationLock.withPermits(1)(
 					Effect.gen(function* () {
 						const existing = yield* findExistingByFilesystemIdentity(
 							canonical,
@@ -159,25 +159,27 @@ export const WorkspaceServiceLive = Layer.effect(
 			});
 
 		const remove: WorkspaceService["Service"]["remove"] = (folderId) =>
-			Effect.gen(function* () {
-				const existing = yield* sql<{ id: string }>`
+			projectMutationLock.withPermits(1)(
+				Effect.gen(function* () {
+					const existing = yield* sql<{ id: string }>`
           SELECT id FROM projects WHERE id = ${folderId} LIMIT 1
         `.pipe(Effect.orDie);
-				if (existing.length === 0) {
-					return yield* Effect.fail(new WorkspaceNotFoundError({ folderId }));
-				}
-				yield* sql`DELETE FROM projects WHERE id = ${folderId}`.pipe(
-					Effect.orDie,
-				);
-				// ON DELETE CASCADE on projects → sessions → messages handles the rest.
-				// If this was the selected project, clear the pointer so the persisted
-				// value never points to a missing id.
-				yield* sql`
+					if (existing.length === 0) {
+						return yield* Effect.fail(new WorkspaceNotFoundError({ folderId }));
+					}
+					yield* sql`DELETE FROM projects WHERE id = ${folderId}`.pipe(
+						Effect.orDie,
+					);
+					// ON DELETE CASCADE on projects → sessions → messages handles the rest.
+					// If this was the selected project, clear the pointer so the persisted
+					// value never points to a missing id.
+					yield* sql`
           DELETE FROM app_state
           WHERE key = ${SELECTED_KEY} AND value = ${folderId}
 			`.pipe(Effect.orDie);
-				yield* PubSub.publish(changes, yield* list());
-			});
+					yield* PubSub.publish(changes, yield* list());
+				}),
+			);
 
 		const streamChanges: WorkspaceService["Service"]["streamChanges"] = () =>
 			Stream.unwrap(

--- a/apps/server/src/workspace/layers/workspace-service.ts
+++ b/apps/server/src/workspace/layers/workspace-service.ts
@@ -5,7 +5,7 @@ import {
 	WorkspaceInvalidPathError,
 	WorkspaceNotFoundError,
 } from "@zuse/contracts";
-import { Effect, FileSystem, Layer, PubSub, Stream } from "effect";
+import { Effect, FileSystem, Layer, PubSub, Semaphore, Stream } from "effect";
 import { SqlClient } from "effect/unstable/sql";
 
 import { prepareProjectRegistration } from "../project-registration.ts";
@@ -34,6 +34,7 @@ export const WorkspaceServiceLive = Layer.effect(
 		const sql = yield* SqlClient.SqlClient;
 		const fs = yield* FileSystem.FileSystem;
 		const changes = yield* PubSub.unbounded<ReadonlyArray<Folder>>();
+		const registrationLock = yield* Semaphore.make(1);
 
 		const list: WorkspaceService["Service"]["list"] = () =>
 			Effect.gen(function* () {
@@ -54,6 +55,35 @@ export const WorkspaceServiceLive = Layer.effect(
           LIMIT 1
         `.pipe(Effect.orDie);
 				return rows.length > 0 ? rowToFolder(rows[0]!) : null;
+			});
+
+		const findExistingByFilesystemIdentity = (
+			canonical: string,
+			resolved: string,
+		) =>
+			Effect.gen(function* () {
+				const exactRows = yield* sql<ProjectRow>`
+          SELECT id, path, name, created_at
+          FROM projects
+          WHERE path = ${canonical}
+             OR path = ${resolved}
+          LIMIT 1
+        `.pipe(Effect.orDie);
+				const [exact] = exactRows;
+				if (exact !== undefined) return exact;
+
+				const rows = yield* sql<ProjectRow>`
+          SELECT id, path, name, created_at
+          FROM projects
+          ORDER BY created_at ASC
+        `.pipe(Effect.orDie);
+				for (const row of rows) {
+					const existingCanonical = yield* fs
+						.realPath(row.path)
+						.pipe(Effect.catch(() => Effect.succeed(null)));
+					if (existingCanonical === canonical) return row;
+				}
+				return null;
 			});
 
 		const add: WorkspaceService["Service"]["add"] = (rawPath) =>
@@ -81,41 +111,43 @@ export const WorkspaceServiceLive = Layer.effect(
 					);
 				}
 
-				const existingRows = yield* sql<ProjectRow>`
-          SELECT id, path, name, created_at
-          FROM projects
-          WHERE path = ${canonical}
-             OR path = ${resolved}
-             OR lower(path) = lower(${canonical})
-             OR lower(path) = lower(${resolved})
-          LIMIT 1
-        `.pipe(Effect.orDie);
-				if (existingRows.length > 0) {
-					return rowToFolder(existingRows[0]!);
-				}
+				return yield* registrationLock.withPermits(1)(
+					Effect.gen(function* () {
+						const existing = yield* findExistingByFilesystemIdentity(
+							canonical,
+							resolved,
+						);
+						if (existing !== null) return rowToFolder(existing);
 
-				yield* Effect.tryPromise({
-					try: () => prepareProjectRegistration(canonical),
-					catch: (cause) =>
-						new WorkspaceInvalidPathError({
-							path: canonical,
-							reason: `could not prepare project metadata: ${String(cause)}`,
-						}),
-				});
+						yield* Effect.tryPromise({
+							try: () => prepareProjectRegistration(canonical),
+							catch: (cause) =>
+								new WorkspaceInvalidPathError({
+									path: canonical,
+									reason: `could not prepare project metadata: ${String(cause)}`,
+								}),
+						});
 
-				const id = FolderId.make(crypto.randomUUID());
-				const name = Path.basename(canonical) || canonical;
-				const now = new Date();
-				const nowIso = now.toISOString();
+						const id = FolderId.make(crypto.randomUUID());
+						const name = Path.basename(canonical) || canonical;
+						const now = new Date();
+						const nowIso = now.toISOString();
 
-				yield* sql`
+						yield* sql`
           INSERT INTO projects (id, path, name, created_at, updated_at)
           VALUES (${id}, ${canonical}, ${name}, ${nowIso}, ${nowIso})
         `.pipe(Effect.orDie);
 
-				const folder = Folder.make({ id, path: canonical, name, addedAt: now });
-				yield* PubSub.publish(changes, yield* list());
-				return folder;
+						const folder = Folder.make({
+							id,
+							path: canonical,
+							name,
+							addedAt: now,
+						});
+						yield* PubSub.publish(changes, yield* list());
+						return folder;
+					}),
+				);
 			});
 
 		const remove: WorkspaceService["Service"]["remove"] = (folderId) =>

--- a/apps/server/src/workspace/layers/workspace-service.ts
+++ b/apps/server/src/workspace/layers/workspace-service.ts
@@ -2,7 +2,6 @@ import * as Path from "node:path";
 import {
 	Folder,
 	FolderId,
-	WorkspaceDuplicatePathError,
 	WorkspaceInvalidPathError,
 	WorkspaceNotFoundError,
 } from "@zuse/contracts";
@@ -60,12 +59,15 @@ export const WorkspaceServiceLive = Layer.effect(
 		const add: WorkspaceService["Service"]["add"] = (rawPath) =>
 			Effect.gen(function* () {
 				const resolved = Path.resolve(rawPath);
+				const canonical = yield* fs
+					.realPath(resolved)
+					.pipe(Effect.catch(() => Effect.succeed(resolved)));
 
-				const stat = yield* fs.stat(resolved).pipe(
+				const stat = yield* fs.stat(canonical).pipe(
 					Effect.mapError(
 						() =>
 							new WorkspaceInvalidPathError({
-								path: resolved,
+								path: canonical,
 								reason: "path does not exist",
 							}),
 					),
@@ -73,41 +75,42 @@ export const WorkspaceServiceLive = Layer.effect(
 				if (stat.type !== "Directory") {
 					return yield* Effect.fail(
 						new WorkspaceInvalidPathError({
-							path: resolved,
+							path: canonical,
 							reason: "path is not a directory",
 						}),
 					);
 				}
 
-				const dupes = yield* sql<{ id: string }>`
-          SELECT id FROM projects WHERE path = ${resolved} LIMIT 1
+				const existingRows = yield* sql<ProjectRow>`
+          SELECT id, path, name, created_at
+          FROM projects
+          WHERE path = ${canonical} OR path = ${resolved}
+          LIMIT 1
         `.pipe(Effect.orDie);
-				if (dupes.length > 0) {
-					return yield* Effect.fail(
-						new WorkspaceDuplicatePathError({ path: resolved }),
-					);
+				if (existingRows.length > 0) {
+					return rowToFolder(existingRows[0]!);
 				}
 
 				yield* Effect.tryPromise({
-					try: () => prepareProjectRegistration(resolved),
+					try: () => prepareProjectRegistration(canonical),
 					catch: (cause) =>
 						new WorkspaceInvalidPathError({
-							path: resolved,
+							path: canonical,
 							reason: `could not prepare project metadata: ${String(cause)}`,
 						}),
 				});
 
 				const id = FolderId.make(crypto.randomUUID());
-				const name = Path.basename(resolved) || resolved;
+				const name = Path.basename(canonical) || canonical;
 				const now = new Date();
 				const nowIso = now.toISOString();
 
 				yield* sql`
           INSERT INTO projects (id, path, name, created_at, updated_at)
-          VALUES (${id}, ${resolved}, ${name}, ${nowIso}, ${nowIso})
+          VALUES (${id}, ${canonical}, ${name}, ${nowIso}, ${nowIso})
         `.pipe(Effect.orDie);
 
-				const folder = Folder.make({ id, path: resolved, name, addedAt: now });
+				const folder = Folder.make({ id, path: canonical, name, addedAt: now });
 				yield* PubSub.publish(changes, yield* list());
 				return folder;
 			});

--- a/apps/server/src/workspace/layers/workspace-service.ts
+++ b/apps/server/src/workspace/layers/workspace-service.ts
@@ -84,7 +84,10 @@ export const WorkspaceServiceLive = Layer.effect(
 				const existingRows = yield* sql<ProjectRow>`
           SELECT id, path, name, created_at
           FROM projects
-          WHERE path = ${canonical} OR path = ${resolved}
+          WHERE path = ${canonical}
+             OR path = ${resolved}
+             OR lower(path) = lower(${canonical})
+             OR lower(path) = lower(${resolved})
           LIMIT 1
         `.pipe(Effect.orDie);
 				if (existingRows.length > 0) {

--- a/apps/server/src/workspace/layers/workspace-service.ts
+++ b/apps/server/src/workspace/layers/workspace-service.ts
@@ -136,14 +136,22 @@ export const WorkspaceServiceLive = Layer.effect(
 						yield* sql`
           INSERT INTO projects (id, path, name, created_at, updated_at)
           VALUES (${id}, ${canonical}, ${name}, ${nowIso}, ${nowIso})
+							ON CONFLICT(path) DO NOTHING
         `.pipe(Effect.orDie);
 
-						const folder = Folder.make({
-							id,
-							path: canonical,
-							name,
-							addedAt: now,
-						});
+						const registeredRows = yield* sql<ProjectRow>`
+							SELECT id, path, name, created_at
+							FROM projects
+							WHERE path = ${canonical}
+							LIMIT 1
+						`.pipe(Effect.orDie);
+						const [registered] = registeredRows;
+						if (registered === undefined) {
+							return yield* Effect.die(
+								new Error(`project registration did not persist ${canonical}`),
+							);
+						}
+						const folder = rowToFolder(registered);
 						yield* PubSub.publish(changes, yield* list());
 						return folder;
 					}),

--- a/apps/server/test/integration/migration-0045-upgrade.test.ts
+++ b/apps/server/test/integration/migration-0045-upgrade.test.ts
@@ -33,11 +33,17 @@ describe("migration 0045 upgrade compatibility", () => {
 				Effect.gen(function* () {
 					const sql = yield* SqlClient.SqlClient;
 					const createdAt = "2026-01-01T00:00:00.000Z";
+					const duplicateCreatedAt = "2026-01-01T00:00:01.000Z";
 					stage = "insert the legacy project";
 					yield* sql`
 						INSERT INTO projects (id, path, name, created_at, updated_at)
 						VALUES ('project-legacy', '/tmp/project-legacy', 'Legacy project',
 							${createdAt}, ${createdAt})
+					`;
+					yield* sql`
+						INSERT INTO projects (id, path, name, created_at, updated_at)
+						VALUES ('project-duplicate', '/tmp/project-legacy', 'Duplicate project',
+							${duplicateCreatedAt}, ${duplicateCreatedAt})
 					`;
 					stage = "insert the legacy chat";
 					yield* sql`
@@ -61,6 +67,22 @@ describe("migration 0045 upgrade compatibility", () => {
 					yield* sql`
 						UPDATE chats SET active_session_id = 'session-legacy'
 						WHERE id = 'chat-legacy'
+					`;
+					yield* sql`
+						INSERT INTO chats
+							(id, project_id, worktree_id, title, active_session_id,
+							 origin_session_id, archived_at, archived_worktree_json,
+							 last_message_at, last_read_at, created_at, updated_at)
+						VALUES ('chat-duplicate', 'project-duplicate', NULL, 'Duplicate chat',
+							NULL, NULL, NULL, NULL, ${createdAt}, ${createdAt},
+							${createdAt}, ${createdAt})
+					`;
+					yield* sql`
+						INSERT INTO sessions
+							(id, project_id, title, provider_id, model, status, chat_id,
+							 created_at, updated_at)
+						VALUES ('session-duplicate', 'project-duplicate', 'Duplicate chat',
+							'codex', 'gpt-5', 'idle', 'chat-duplicate', ${createdAt}, ${createdAt})
 					`;
 				}),
 			);
@@ -98,13 +120,36 @@ describe("migration 0045 upgrade compatibility", () => {
 						const newChats = yield* sql<{ readonly count: number }>`
 							SELECT COUNT(*) AS count FROM chats WHERE id = 'chat-new'
 						`;
-						return { integrity, counts, newChats };
+						const projectReferences = yield* sql<{
+							readonly project_id: string;
+						}>`
+							SELECT project_id FROM chats
+							UNION
+							SELECT project_id FROM sessions
+							ORDER BY project_id
+						`;
+						const indexes = yield* sql<{
+							readonly name: string;
+							readonly unique: number;
+						}>`PRAGMA index_list(projects)`;
+						return { integrity, counts, newChats, projectReferences, indexes };
 					}),
 				);
 
 				expect(result.integrity).toEqual([{ quick_check: "ok" }]);
-				expect(result.counts).toEqual([{ projects: 1, chats: 1, sessions: 1 }]);
+				expect(result.counts).toEqual([{ projects: 1, chats: 2, sessions: 2 }]);
 				expect(result.newChats).toEqual([{ count: 1 }]);
+				expect(result.projectReferences).toEqual([
+					{ project_id: "project-legacy" },
+				]);
+				expect(result.indexes).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							name: "idx_projects_path_unique",
+							unique: 1,
+						}),
+					]),
+				);
 			} finally {
 				await currentRuntime.dispose();
 			}

--- a/apps/server/test/integration/project-registration.test.ts
+++ b/apps/server/test/integration/project-registration.test.ts
@@ -130,7 +130,7 @@ describe("WorkspaceServiceLive project registration", () => {
 				yield* sql`
           CREATE TABLE projects (
             id TEXT PRIMARY KEY,
-            path TEXT NOT NULL,
+            path TEXT NOT NULL UNIQUE,
             name TEXT NOT NULL,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
@@ -189,6 +189,65 @@ describe("WorkspaceServiceLive project registration", () => {
 			Effect.flatMap(WorkspaceService, (workspace) => workspace.list()),
 		);
 		expect(listed).toHaveLength(1);
+	});
+
+	it("converges across separate workspace service instances", async () => {
+		const databaseDirectory = await fs.mkdtemp(
+			Path.join(os.tmpdir(), "zuse-workspace-add-database-"),
+		);
+		const filename = Path.join(databaseDirectory, "zuse.sqlite");
+		const makeRuntime = () => {
+			const SqlLive = sqliteLayer({ filename });
+			return ManagedRuntime.make(
+				Layer.mergeAll(
+					SqlLive,
+					WorkspaceServiceLive.pipe(
+						Layer.provide(SqlLive),
+						Layer.provide(NodeServices.layer),
+					),
+				),
+			);
+		};
+		const firstRuntime = makeRuntime();
+		const secondRuntime = makeRuntime();
+		try {
+			await firstRuntime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					yield* sql`
+						CREATE TABLE projects (
+							id TEXT PRIMARY KEY,
+							path TEXT NOT NULL UNIQUE,
+							name TEXT NOT NULL,
+							created_at TEXT NOT NULL,
+							updated_at TEXT NOT NULL
+						)
+					`;
+					yield* sql`
+						CREATE TABLE app_state (
+							key TEXT PRIMARY KEY,
+							value TEXT NOT NULL
+						)
+					`;
+				}),
+			);
+			const [first, second] = await Promise.all([
+				firstRuntime.runPromise(
+					Effect.flatMap(WorkspaceService, (workspace) => workspace.add(dir)),
+				),
+				secondRuntime.runPromise(
+					Effect.flatMap(WorkspaceService, (workspace) => workspace.add(dir)),
+				),
+			]);
+			expect(second.id).toBe(first.id);
+			const listed = await firstRuntime.runPromise(
+				Effect.flatMap(WorkspaceService, (workspace) => workspace.list()),
+			);
+			expect(listed).toHaveLength(1);
+		} finally {
+			await Promise.all([firstRuntime.dispose(), secondRuntime.dispose()]);
+			await fs.rm(databaseDirectory, { recursive: true, force: true });
+		}
 	});
 
 	it("keeps case-distinct directories separate on case-sensitive filesystems", async () => {

--- a/apps/server/test/integration/project-registration.test.ts
+++ b/apps/server/test/integration/project-registration.test.ts
@@ -175,6 +175,30 @@ describe("WorkspaceServiceLive project registration", () => {
 		);
 		expect(listed).toHaveLength(1);
 	});
+
+	it("returns the existing folder when the path differs only by case", async () => {
+		const existingId = "case-duplicate-folder";
+		const casedPath = dir.replace(/[^/]+$/, (segment) => segment.toUpperCase());
+		expect(casedPath).not.toBe(dir);
+		await runtime.runPromise(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient;
+				const now = new Date().toISOString();
+				yield* sql`
+          INSERT INTO projects (id, path, name, created_at, updated_at)
+          VALUES (${existingId}, ${casedPath}, ${Path.basename(dir)}, ${now}, ${now})
+        `;
+			}),
+		);
+		const folder = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.add(dir)),
+		);
+		expect(folder.id).toBe(existingId);
+		const listed = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.list()),
+		);
+		expect(listed).toHaveLength(1);
+	});
 });
 
 const exists = async (filePath: string): Promise<boolean> => {

--- a/apps/server/test/integration/project-registration.test.ts
+++ b/apps/server/test/integration/project-registration.test.ts
@@ -130,7 +130,7 @@ describe("WorkspaceServiceLive project registration", () => {
 				yield* sql`
           CREATE TABLE projects (
             id TEXT PRIMARY KEY,
-            path TEXT NOT NULL UNIQUE,
+            path TEXT NOT NULL,
             name TEXT NOT NULL,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
@@ -176,28 +176,38 @@ describe("WorkspaceServiceLive project registration", () => {
 		expect(listed).toHaveLength(1);
 	});
 
-	it("returns the existing folder when the path differs only by case", async () => {
-		const existingId = "case-duplicate-folder";
-		const casedPath = dir.replace(/[^/]+$/, (segment) => segment.toUpperCase());
-		expect(casedPath).not.toBe(dir);
-		await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				const now = new Date().toISOString();
-				yield* sql`
-          INSERT INTO projects (id, path, name, created_at, updated_at)
-          VALUES (${existingId}, ${casedPath}, ${Path.basename(dir)}, ${now}, ${now})
-        `;
-			}),
+	it("serializes overlapping imports of the same folder", async () => {
+		const [first, second] = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) =>
+				Effect.all([workspace.add(dir), workspace.add(dir)], {
+					concurrency: "unbounded",
+				}),
+			),
 		);
-		const folder = await runtime.runPromise(
-			Effect.flatMap(WorkspaceService, (workspace) => workspace.add(dir)),
-		);
-		expect(folder.id).toBe(existingId);
+		expect(second.id).toBe(first.id);
 		const listed = await runtime.runPromise(
 			Effect.flatMap(WorkspaceService, (workspace) => workspace.list()),
 		);
 		expect(listed).toHaveLength(1);
+	});
+
+	it("keeps case-distinct directories separate on case-sensitive filesystems", async () => {
+		const lower = Path.join(dir, "project");
+		const upper = Path.join(dir, "PROJECT");
+		await fs.mkdir(lower);
+		await fs.mkdir(upper, { recursive: true });
+		if ((await fs.realpath(lower)) === (await fs.realpath(upper))) return;
+
+		const [first, second] = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) =>
+				Effect.all([workspace.add(lower), workspace.add(upper)]),
+			),
+		);
+		expect(second.id).not.toBe(first.id);
+		const listed = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.list()),
+		);
+		expect(listed).toHaveLength(2);
 	});
 });
 

--- a/apps/server/test/integration/project-registration.test.ts
+++ b/apps/server/test/integration/project-registration.test.ts
@@ -191,6 +191,23 @@ describe("WorkspaceServiceLive project registration", () => {
 		expect(listed).toHaveLength(1);
 	});
 
+	it("serializes removal with re-import", async () => {
+		const existing = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.add(dir)),
+		);
+		const [, reimported] = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) =>
+				Effect.all([workspace.remove(existing.id), workspace.add(dir)], {
+					concurrency: "unbounded",
+				}),
+			),
+		);
+		const listed = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.list()),
+		);
+		expect(listed).toEqual([reimported]);
+	});
+
 	it("converges across separate workspace service instances", async () => {
 		const databaseDirectory = await fs.mkdtemp(
 			Path.join(os.tmpdir(), "zuse-workspace-add-database-"),

--- a/apps/server/test/integration/project-registration.test.ts
+++ b/apps/server/test/integration/project-registration.test.ts
@@ -160,6 +160,21 @@ describe("WorkspaceServiceLive project registration", () => {
 			".context\n",
 		);
 	});
+
+	it("returns the existing folder when the same path is added again", async () => {
+		const first = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.add(dir)),
+		);
+		const second = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.add(dir)),
+		);
+		expect(second.id).toBe(first.id);
+		expect(second.path).toBe(first.path);
+		const listed = await runtime.runPromise(
+			Effect.flatMap(WorkspaceService, (workspace) => workspace.list()),
+		);
+		expect(listed).toHaveLength(1);
+	});
 });
 
 const exists = async (filePath: string): Promise<boolean> => {

--- a/packages/git/src/git-service-live.ts
+++ b/packages/git/src/git-service-live.ts
@@ -770,12 +770,16 @@ export const GitServiceLive = Layer.effect(
 			);
 
 		// `git remote get-url origin` exits non-zero when no remote is set; we
-		// treat the resulting GitCommandError as "no origin" → null.
+		// treat the resulting GitCommandError as "no origin" → null. A hung git
+		// must not block workspace listing, so origin lookups time out like `gh`.
 		const origin: GitService["Service"]["origin"] = (folderId) =>
 			Effect.flatMap(resolvePath(folderId), (cwd) =>
 				run(folderId, cwd, ["remote", "get-url", "origin"]).pipe(
 					Effect.map((s) => parseRemoteUrl(s.trim())),
+					Effect.timeout("5 seconds"),
+					Effect.catchTag("TimeoutError", () => Effect.succeed(null)),
 					Effect.catchTag("GitCommandError", () => Effect.succeed(null)),
+					Effect.catchTag("GitNotARepoError", () => Effect.succeed(null)),
 				),
 			);
 


### PR DESCRIPTION
## Summary

- publish workspace folder snapshots before Git origin discovery completes
- resolve missing origins in the background and bound each origin lookup to five seconds
- make repeated project imports idempotent, including paths that differ only by casing
- preserve existing project IDs and selection behavior when a folder is re-imported

## Root cause

The production database could contain newly committed project rows while the sidebar remained on an older snapshot. The environment shell driver awaited all `git.origin` calls before emitting the workspace update, so one slow or hung repository blocked every newly added project from rendering. Separately, case-only filesystem aliases such as `GitHub` and `Github` could create duplicate project records.

## Verification

- `bunx biome check apps/renderer/src/lib/environment-shell-client-bus.ts apps/renderer/test/unit/environment-shell-client-bus.test.ts apps/server/src/workspace/layers/workspace-service.ts apps/server/test/integration/project-registration.test.ts packages/git/src/git-service-live.ts` (no errors; existing non-null-assertion warnings in workspace service)
- renderer: `bunx vp test run test/unit/environment-shell-client-bus.test.ts` (7 passed)
- server: `bunx vp test run test/integration/project-registration.test.ts` (9 passed)
- `git diff --check upstream/main...HEAD`

Renderer and server type-check commands were attempted but did not complete or produce diagnostics within the bounded verification window.