### PR TITLE
Release v0.20.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- The hosted control plane is now named API across desktop, mobile, Serve, runtime assets, and operations tooling, with production served from `api.zuse.sh` and staging from `api-staging.stuff.md`
-- Cloud database and local configuration names migrate transactionally from `relay_*` to `api_*` without discarding billing, workspace, installation, or audit data
-- The shared GitHub App callback now brokers allowlisted staging installation state through the production API hostname
+## [0.20.12]
 
-### Removed
-- The old `relay.stuff.md` and `relay-staging.stuff.md` hostnames and Relay-named public environment variables are no longer supported
+### Added
+- Keep your Mac awake automatically while local agents or authenticated remote clients are active, or choose Always or Off in General settings; the sidebar now also shows the active-agent count
+
+### Changed
+- Cloud Workspaces and remote access now connect through `api.zuse.sh`; this update is required because the retired `relay.stuff.md` hostname is no longer supported
+
+### Fixed
+- Resumed Cloud Workspaces no longer remain stuck authenticating because of stale credential markers, and gateway authentication now gets a fresh timeout after enrollment
+- OpenCode provider settings now select the correct installed CLI, handle OpenCode 1.18 inventory responses reliably, and show a retryable error instead of an endless loading state
+- New chats now honor repository permission defaults and stop cleanly after a denied permission request
 
 ## [0.20.11]
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.11",
+	"version": "0.20.12",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,19 +1,25 @@
 [
   {
-    "version": "Unreleased",
+    "version": "0.20.12",
     "sections": [
       {
-        "title": "Changed",
+        "title": "Added",
         "items": [
-          "The hosted control plane is now named API across desktop, mobile, Serve, runtime assets, and operations tooling, with production served from `api.zuse.sh` and staging from `api-staging.stuff.md`",
-          "Cloud database and local configuration names migrate transactionally from `relay_*` to `api_*` without discarding billing, workspace, installation, or audit data",
-          "The shared GitHub App callback now brokers allowlisted staging installation state through the production API hostname"
+          "Keep your Mac awake automatically while local agents or authenticated remote clients are active, or choose Always or Off in General settings; the sidebar now also shows the active-agent count"
         ]
       },
       {
-        "title": "Removed",
+        "title": "Changed",
         "items": [
-          "The old `relay.stuff.md` and `relay-staging.stuff.md` hostnames and Relay-named public environment variables are no longer supported"
+          "Cloud Workspaces and remote access now connect through `api.zuse.sh`; this update is required because the retired `relay.stuff.md` hostname is no longer supported"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Resumed Cloud Workspaces no longer remain stuck authenticating because of stale credential markers, and gateway authentication now gets a fresh timeout after enrollment",
+          "OpenCode provider settings now select the correct installed CLI, handle OpenCode 1.18 inventory responses reliably, and show a retryable error instead of an endless loading state",
+          "New chats now honor repository permission defaults and stop cleanly after a denied permission request"
         ]
       }
     ]

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.11",
+      "version": "0.20.12",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.12 with release notes grouped by user-visible outcome.

### Added

- Keep your Mac awake automatically while local agents or authenticated remote clients are active, or choose Always or Off in General settings; the sidebar now also shows the active-agent count.

### Changed

- Cloud Workspaces and remote access now connect through `api.zuse.sh`; this update is required because the retired `relay.stuff.md` hostname is no longer supported.

### Fixed

- Resumed Cloud Workspaces no longer remain stuck authenticating because of stale credential markers, and gateway authentication now gets a fresh timeout after enrollment.
- OpenCode provider settings now select the correct installed CLI, handle OpenCode 1.18 inventory responses reliably, and show a retryable error instead of an endless loading state.
- New chats now honor repository permission defaults and stop cleanly after a denied permission request.

## Validation

- `bun run check-types` (31/31 tasks)
- Focused Cloud Workspace, OpenCode availability, and macOS awake behavior tests (89 passed)
- Applicable Biome check and `git diff --check`

Release artifacts are produced by pushing tag v0.20.12 after this PR lands.

