### PR TITLE
Use rebuilt production E2B template

### DIFF
--- a/infra/api/test/unit/deploy-safety.test.ts
+++ b/infra/api/test/unit/deploy-safety.test.ts
@@ -154,7 +154,7 @@ describe("api deployment safety", () => {
 			"zuse-cloud-sandbox-production",
 		);
 		expect(production.vars.E2B_TEMPLATE_VERSION).toBe(
-			"3d0c4a5a-d2fa-414b-9167-08b838c8f3bf",
+			"56e72d23-3e0f-4f26-8069-37a4035e39b4",
 		);
 		expect(production.vars.E2B_VCPU_COUNT).toBe("2");
 		expect(production.vars.E2B_MEMORY_MIB).toBe("4096");

--- a/infra/api/wrangler.production.jsonc
+++ b/infra/api/wrangler.production.jsonc
@@ -54,7 +54,7 @@
 		"CLOUD_WORKSPACE_RUNTIME_SIGNING_PUBLIC_JWK": "{\"crv\":\"Ed25519\",\"x\":\"58x6syowGjYSYg5rmy04aC1-gyXhsyqjIlGLYcTc6tc\",\"kty\":\"OKP\"}",
 		"E2B_ADAPTER_ENABLED": "true",
 		"E2B_TEMPLATE_ID": "zuse-cloud-sandbox-production",
-		"E2B_TEMPLATE_VERSION": "3d0c4a5a-d2fa-414b-9167-08b838c8f3bf",
+		"E2B_TEMPLATE_VERSION": "56e72d23-3e0f-4f26-8069-37a4035e39b4",
 		"E2B_VCPU_COUNT": "2",
 		"E2B_MEMORY_MIB": "4096",
 		"CLOUD_BILLING_ENFORCEMENT_ENABLED": "false",


### PR DESCRIPTION
## Summary
- select the production E2B template rebuilt from v0.20.12
- update the deployment safety assertion to pin the new immutable build

## Verification
- live E2B smoke test as `zuse`: `/home/repos` is writable and repository directory creation succeeds
- `bunx biome check infra/api/test/unit/deploy-safety.test.ts infra/api/wrangler.production.jsonc`
- `bun --cwd infra/api check-types`
- `bun --cwd infra/api test:unit deploy-safety.test.ts` (172 tests)

