### PR TITLE
Isolate cloud auth authorities by environment

### DIFF
--- a/infra/api/src/cloud-auth-authority.ts
+++ b/infra/api/src/cloud-auth-authority.ts
@@ -11,6 +11,7 @@ import {
 } from "@zuse/sandbox-providers";
 import { Effect, Schedule } from "effect";
 
+import { ApiConfiguration } from "./config.ts";
 import { sha256Hex } from "./crypto.ts";
 import { badRequest, serviceUnavailable } from "./errors.ts";
 
@@ -212,10 +213,24 @@ type Authority = {
 	readonly state: "running" | "paused";
 };
 
-const authorityLabel = (accountId: string) =>
-	sha256Hex(`cloud-auth-authority-v1:${accountId}`).pipe(
-		Effect.map((digest) => `zuse-auth-${digest.slice(0, 32)}`),
-	);
+export const cloudAuthAuthorityLabel = (input: {
+	readonly accountId: string;
+	readonly apiIssuer: string;
+	readonly templateVersion: string;
+}) =>
+	sha256Hex(
+		`cloud-auth-authority-v2:${input.apiIssuer}:${input.templateVersion}:${input.accountId}`,
+	).pipe(Effect.map((digest) => `zuse-auth-${digest.slice(0, 32)}`));
+
+const authorityLabel = (accountId: string, provider: SandboxProviderAdapter) =>
+	Effect.gen(function* () {
+		const config = yield* ApiConfiguration;
+		return yield* cloudAuthAuthorityLabel({
+			accountId,
+			apiIssuer: config.apiIssuer,
+			templateVersion: provider.templateVersion,
+		});
+	});
 
 const e2bProvider = Effect.gen(function* () {
 	const providers = yield* SandboxProviders;
@@ -230,7 +245,7 @@ const recoverAuthority = Effect.fn("recoverCloudAuthAuthority")(function* (
 	accountId: string,
 ) {
 	const provider = yield* e2bProvider;
-	const label = yield* authorityLabel(accountId);
+	const label = yield* authorityLabel(accountId, provider);
 	const sandbox = yield* provider
 		.recoverByLabel(label)
 		.pipe(Effect.mapError(() => serviceUnavailable("cloud_auth_unavailable")));
@@ -334,7 +349,7 @@ const provisionAuthority = Effect.fn("provisionCloudAuthAuthority")(function* (
 	if (recovered !== null)
 		return yield* initializeAuthority(yield* ensureRunning(recovered));
 	const provider = yield* e2bProvider;
-	const label = yield* authorityLabel(accountId);
+	const label = yield* authorityLabel(accountId, provider);
 	const sandboxId = `auth_${(yield* sha256Hex(`${accountId}:${crypto.randomUUID()}`)).slice(0, 24)}`;
 	const created = yield* provider
 		.create({
@@ -744,4 +759,4 @@ export const snapshotCloudAuthAuthority = Effect.fn(
 		);
 });
 
-export type CloudAuthAuthorityContext = SandboxProviders;
+export type CloudAuthAuthorityContext = SandboxProviders | ApiConfiguration;

--- a/infra/api/test/unit/cloud-auth-authority.test.ts
+++ b/infra/api/test/unit/cloud-auth-authority.test.ts
@@ -1,6 +1,35 @@
+import { Effect } from "effect";
 import { describe, expect, test } from "vitest";
 
-import { parseDeviceLoginOutput } from "../../src/cloud-auth-authority.ts";
+import {
+	cloudAuthAuthorityLabel,
+	parseDeviceLoginOutput,
+} from "../../src/cloud-auth-authority.ts";
+
+describe("cloud auth authority identity", () => {
+	test("isolates the same account across deployments and template versions", async () => {
+		const label = (apiIssuer: string, templateVersion: string) =>
+			Effect.runPromise(
+				cloudAuthAuthorityLabel({
+					accountId: "account_1",
+					apiIssuer,
+					templateVersion,
+				}),
+			);
+		const production = await label("https://api.zuse.sh", "production-build-2");
+
+		expect(production).toMatch(/^zuse-auth-[a-f0-9]{32}$/u);
+		await expect(
+			label("https://api.zuse.sh", "production-build-2"),
+		).resolves.toBe(production);
+		await expect(
+			label("https://api-staging.stuff.md", "production-build-2"),
+		).resolves.not.toBe(production);
+		await expect(
+			label("https://api.zuse.sh", "production-build-1"),
+		).resolves.not.toBe(production);
+	});
+});
 
 describe("cloud auth device-login output", () => {
 	test("extracts the official Codex URL and one-time code through ANSI styling", () => {


### PR DESCRIPTION
## Root cause
Production rebuilds recovered an account auth authority using a label derived only from the account ID. Staging and production share the E2B project, so production forked a stale `account-auth-*` snapshot based on another template while recording the current production template version. The snapshot lacks `/home/repos`, causing every rebuild to fail during repository sync.

## Fix
- include API issuer and immutable template version in auth-authority identity
- prevent cross-environment and cross-template snapshot recovery
- cover stable identity plus issuer/template isolation

## Verification
- reproduced the exact failure by launching E2B snapshot `account-auth-image_fe-vtuqlxggcnhdo`
- direct production template create and fresh snapshot fork both permit `zuse` to create `/home/repos/*`
- `bunx biome check infra/api/src/cloud-auth-authority.ts infra/api/test/unit/cloud-auth-authority.test.ts`
- API unit tests: 173 passed
- full monorepo type-check: 31/31 passed

