### PR TITLE
Give cloud workspaces unrestricted internet access

### DIFF
--- a/infra/api/src/cloud-workspace-reconciler.ts
+++ b/infra/api/src/cloud-workspace-reconciler.ts
@@ -937,7 +937,10 @@ export const reconcileCloudPool = Effect.fn("reconcileCloudPool")(function* (
 					snapshotId: image.snapshotId as string,
 					timeoutSeconds: config.keepAliveTimeoutSeconds,
 					env: {},
-					network: { kind: "quarantined" },
+					// Workspace pools are user execution environments, not an identity
+					// re-key boundary. They need normal outbound internet from the moment
+					// they start so resumed agents cannot inherit a provider-level deny rule.
+					network: { kind: "open" },
 					onTimeout: "pause",
 				});
 				yield* store.savePool({
@@ -1097,46 +1100,43 @@ const restartWorkspaceRuntime = Effect.fn("restartCloudWorkspaceRuntime")(
 			revision: workspace.revision + 1,
 			updatedAtMs: nowMs,
 		});
-		yield* Effect.all(
-			[
-				provider.setNetwork(providerSandboxId, { kind: "open" }),
-				provider.replaceProcess(
-					providerSandboxId,
-					workspaceRuntimeProcessSelector(),
-					{
-						command: "/bin/bash",
-						args: ["-lc", WORKSPACE_RUNTIME_RESUME_SCRIPT],
-						cwd: "/home/zuse",
-						env: {
-							...project.cloudEnvironment,
-							ZUSE_CLOUD_WORKSPACE_ID: workspace.workspaceId,
-							ZUSE_RUNTIME_BOOT_TOKEN: boot.token,
-							ZUSE_API_URL: api.apiIssuer,
-							ZUSE_CLOUD_WORKSPACE_ROOT: workspaceRoot,
-							ZUSE_RUNTIME_KIND: "cloud-workspace",
-							ZUSE_HOST: "127.0.0.1",
-							ZUSE_PORT: "47837",
-							ZUSE_AUTH_POLICY: "protected",
-							ZUSE_ENABLE_PAIRING: "0",
-							ZUSE_MACHINE_RUNTIME_ROLE: "cloud-environment",
-							ZUSE_SERVER_READY_STDOUT: "1",
-							ZUSE_USER_DATA: "/home/zuse/.zuse-data",
-							ZUSE_RUNTIME_GENERATION: String(runtimeFence.runtimeGeneration),
-							ZUSE_GATEWAY_EPOCH: String(runtimeFence.gatewayEpoch),
-							...(config.runtimeManifestUrl === undefined
-								? {}
-								: {
-										ZUSE_RUNTIME_MANIFEST_URL: config.runtimeManifestUrl,
-										ZUSE_RUNTIME_PUBLIC_KEY_FILE:
-											RUNTIME_SIGNING_PUBLIC_JWK_FILE,
-										ZUSE_RUNTIME_WIRE_PROTOCOL: String(WIRE_PROTOCOL_VERSION),
-									}),
-						},
-						user: "zuse",
-					},
-				),
-			],
-			{ concurrency: "unbounded", discard: true },
+		// Network policy is part of runtime readiness, not a parallel best-effort
+		// side effect. Open egress before the agent process can make its first
+		// gateway or model-api request.
+		yield* provider.setNetwork(providerSandboxId, { kind: "open" });
+		yield* provider.replaceProcess(
+			providerSandboxId,
+			workspaceRuntimeProcessSelector(),
+			{
+				command: "/bin/bash",
+				args: ["-lc", WORKSPACE_RUNTIME_RESUME_SCRIPT],
+				cwd: "/home/zuse",
+				env: {
+					...project.cloudEnvironment,
+					ZUSE_CLOUD_WORKSPACE_ID: workspace.workspaceId,
+					ZUSE_RUNTIME_BOOT_TOKEN: boot.token,
+					ZUSE_API_URL: api.apiIssuer,
+					ZUSE_CLOUD_WORKSPACE_ROOT: workspaceRoot,
+					ZUSE_RUNTIME_KIND: "cloud-workspace",
+					ZUSE_HOST: "127.0.0.1",
+					ZUSE_PORT: "47837",
+					ZUSE_AUTH_POLICY: "protected",
+					ZUSE_ENABLE_PAIRING: "0",
+					ZUSE_MACHINE_RUNTIME_ROLE: "cloud-environment",
+					ZUSE_SERVER_READY_STDOUT: "1",
+					ZUSE_USER_DATA: "/home/zuse/.zuse-data",
+					ZUSE_RUNTIME_GENERATION: String(runtimeFence.runtimeGeneration),
+					ZUSE_GATEWAY_EPOCH: String(runtimeFence.gatewayEpoch),
+					...(config.runtimeManifestUrl === undefined
+						? {}
+						: {
+								ZUSE_RUNTIME_MANIFEST_URL: config.runtimeManifestUrl,
+								ZUSE_RUNTIME_PUBLIC_KEY_FILE: RUNTIME_SIGNING_PUBLIC_JWK_FILE,
+								ZUSE_RUNTIME_WIRE_PROTOCOL: String(WIRE_PROTOCOL_VERSION),
+							}),
+				},
+				user: "zuse",
+			},
 		);
 	},
 );
@@ -1408,18 +1408,12 @@ const reconcileWorkspaceRecord = Effect.fn("reconcileCloudWorkspace")(
 				},
 				user: "zuse",
 			});
-			// The boot credential is authorized in API before the detached process
-			// can enroll. Opening the claimed sandbox's network and starting that
-			// process are independent E2B operations, so neither extends the other.
-			yield* Effect.all(
-				[
-					warmSandbox !== null || recovered !== null
-						? provider.setNetwork(sandbox.providerSandboxId, { kind: "open" })
-						: Effect.void,
-					startRuntime,
-				],
-				{ concurrency: "unbounded", discard: true },
-			);
+			// Assert the workspace invariant on every allocation path before the
+			// runtime starts. A recovered or formerly pooled sandbox may retain the
+			// policy from its original creation or resume, and starting these in
+			// parallel races the agent's first gateway and model-api requests.
+			yield* provider.setNetwork(sandbox.providerSandboxId, { kind: "open" });
+			yield* startRuntime;
 			return;
 		}
 

--- a/infra/api/test/unit/cloud-workspace-reconciler.test.ts
+++ b/infra/api/test/unit/cloud-workspace-reconciler.test.ts
@@ -305,7 +305,7 @@ describe("cloud workspace reconciler", () => {
 		expect(result.sandboxes.has("warm-incomplete-retry")).toBe(false);
 		expect(result.resumeInputs).toHaveLength(0);
 		expect(result.network.get("fake-workspace-incomplete-retry")).toEqual({
-			kind: "quarantined",
+			kind: "open",
 		});
 	});
 

--- a/packages/sandbox-providers/README.md
+++ b/packages/sandbox-providers/README.md
@@ -15,9 +15,10 @@ Each adapter must:
 - normalize vendor failures to `SandboxProviderError`;
 - treat kill and snapshot deletion as idempotent;
 - keep credentials and raw provider payloads inside the adapter;
-- start every fork with egress blocked at the provider level and expose a
-  single-call `setNetwork` that writes the complete final policy (ADR 0033:
-  the quarantine barrier is provider-enforced and never a caller choice).
+- apply the caller's complete network policy at creation and expose a
+  single-call `setNetwork` that replaces that policy. Cloud workspace callers
+  use unrestricted egress; live-identity forks may still require the
+  quarantine-first re-key boundary from ADR 0033.
 
 `SandboxProviderAdapter.resolveEndpoint` returns provider-neutral HTTPS and
 WebSocket URLs — sandbox providers supply reachability directly, unlike
@@ -39,8 +40,8 @@ for every registered adapter.
 
 1. Add one provider adapter module and export it from `package.json`.
 2. Test the complete `SandboxProviderAdapter` interface using a fake HTTP
-   client, including timeout recovery, idempotent deletion, and the
-   fork-starts-quarantined invariant.
+   client, including timeout recovery, idempotent deletion, and preservation
+   of the caller-selected network policy.
 3. Add api configuration following the pattern in
    `infra/api/src/machine-provider-modules`.
 
@@ -49,8 +50,9 @@ for every registered adapter.
 `@zuse/sandbox-providers/e2b` provides the `e2b` adapter. It talks to the
 E2B REST API directly over `fetch` (no vendor SDK, so it runs in workerd) and
 authenticates with the `x-api-key` header. Forks are created from a snapshot
-ID and always pass `allow_internet_access: false`; the network is opened by
-`setNetwork` after enrollment re-keys the fork. Snapshot deletion goes
-through the provider's template store. The quarantine capability this adapter
-relies on was verified live in
+ID and apply the requested network policy at creation. Cloud workspace pools
+pass `allow_internet_access: true` and assert the open policy again when a
+workspace claims an allocation. Snapshot deletion goes through the provider's
+template store. The optional quarantine capability used by live-identity
+forks was verified in
 `specs/cloud-platform/research/quarantined-fork-verification.md`.

--- a/packages/sandbox-providers/src/testing.ts
+++ b/packages/sandbox-providers/src/testing.ts
@@ -133,7 +133,7 @@ const makeSandboxProvidersFakeFromControl = (
 					create({
 						sandboxId: input.sandboxId,
 						providerLabel: input.providerLabel,
-						network: { kind: "quarantined" },
+						network: input.network,
 						timeoutSeconds: input.timeoutSeconds,
 						onTimeout: input.onTimeout,
 					}),

--- a/specs/cloud-platform/decisions/0034-open-cloud-workspace-egress.md
+++ b/specs/cloud-platform/decisions/0034-open-cloud-workspace-egress.md
@@ -1,0 +1,16 @@
+# ADR 0034 — Cloud workspaces start with unrestricted egress
+
+Date: 2026-08-30
+Status: Accepted
+
+Cloud workspace account-image forks and prewarmed pools start with unrestricted
+outbound internet access, and workspace allocation asserts that open policy on
+every fresh, pooled, recovered, and resumed sandbox. Coding agents need stable
+access to model APIs, package registries, Git hosts, and arbitrary user-selected
+services; a provider-level quarantine can otherwise leave the control plane
+reporting a healthy runtime while the agent and desktop connection both fail.
+
+This narrows ADR 0033's quarantine-first rule to forks that inherit a live
+machine identity and must re-key before network access. Cloud workspace image
+and pool forks are user execution environments and do not use that quarantine
+boundary.


### PR DESCRIPTION
## Summary
- create prewarmed cloud workspace pools with unrestricted outbound internet
- sequence E2B network opening before initial runtime start and resume
- preserve caller-selected network policies in the sandbox-provider fake
- record the cloud-workspace egress decision in ADR 0034

## Verification
- `bunx vitest run test/unit/cloud-workspace-reconciler.test.ts` (14 passed)
- `bunx vitest run test/unit/e2b.test.ts` (30 passed)
- API unit suite (173 passed)
- affected package type checks
- monorepo type check (31/31)
- Biome on affected source files

## Note
The full-repository Biome command still reports pre-existing formatting/lint failures outside this diff; affected files pass.

