### PR TITLE
Wake paused cloud workspaces from Retry

### DIFF
--- a/apps/renderer/src/components/cloud-connection-notice.tsx
+++ b/apps/renderer/src/components/cloud-connection-notice.tsx
@@ -1,5 +1,5 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { EnvironmentId } from "@zuse/contracts";
+import { type CloudChatSummary, EnvironmentId } from "@zuse/contracts";
 import { CloudIcon, RefreshIcon } from "@zuse/icons/solid-rounded";
 import { useAuth } from "../hooks/use-auth.ts";
 import { deriveCloudChatActivity } from "../lib/cloud-chat-activity.ts";
@@ -12,11 +12,9 @@ import {
 	useCloudChatCatalogStore,
 } from "../lib/cloud-workspace-catalog.ts";
 import { cloudTranscriptActivation } from "../lib/cloud-workspace-lifecycle.ts";
+import { ensureCloudWorkspaceAttached } from "../lib/cloud-workspaces.ts";
 import { useEnvironmentShellResource } from "../lib/environment-shell-client-bus.ts";
-import {
-	getRendererClientBus,
-	retryRendererEnvironmentConnection,
-} from "../lib/session-timeline-client-bus.ts";
+import { getRendererClientBus } from "../lib/session-timeline-client-bus.ts";
 import { useOptionalRendererSessionTimeline } from "../lib/session-timeline-hooks.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { ShimmerText } from "./ui/shimmer-text.tsx";
@@ -43,6 +41,16 @@ const copy: Record<
 		detail: "Your cached chat is still available.",
 	},
 };
+
+type AttachCloudWorkspace = (
+	summary: CloudChatSummary,
+	activation: "connect" | "wake",
+) => Promise<void>;
+
+export const retryCloudConnection = (
+	summary: CloudChatSummary,
+	attach: AttachCloudWorkspace = ensureCloudWorkspaceAttached,
+): Promise<void> => attach(summary, "wake");
 
 export function CloudConnectionNotice() {
 	const { signIn, signingIn, isSignedIn, isLoading } = useAuth();
@@ -90,8 +98,9 @@ export function CloudConnectionNotice() {
 		!betaCheckUnavailable
 	)
 		return null;
-	const retry = () =>
-		retryRendererEnvironmentConnection(EnvironmentId.make(summary.workspaceId));
+	const retry = () => {
+		void retryCloudConnection(summary).catch(() => undefined);
+	};
 	const value = inviteRequired
 		? {
 				title: "Zuse Cloud is invite-only",

--- a/apps/renderer/test/unit/cloud-connection-notice.test.ts
+++ b/apps/renderer/test/unit/cloud-connection-notice.test.ts
@@ -1,0 +1,15 @@
+import type { CloudChatSummary } from "@zuse/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { retryCloudConnection } from "../../src/components/cloud-connection-notice.tsx";
+
+describe("cloud connection notice", () => {
+	it("wakes a paused workspace when Retry is clicked", async () => {
+		const summary = { workspaceId: "workspace-1" } as CloudChatSummary;
+		const attach = vi.fn(async () => undefined);
+
+		await retryCloudConnection(summary, attach);
+
+		expect(attach).toHaveBeenCalledWith(summary, "wake");
+	});
+});


### PR DESCRIPTION
## Summary
- make the cloud connection Retry action explicitly acquire the shared workspace wake capability
- resume paused compute before reconnecting instead of retrying a sync-only transcript lease
- add a regression test for click-to-wake behavior

## Verification
- `bun run test:unit -- cloud-connection-notice.test.ts` (123 files, 561 tests passed)
- `bun run check-types` in `apps/renderer`
- Biome check on the changed source and test
- `git diff --check`