### PR TITLE
Release v0.20.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.13]
+
+### Changed
+- Cloud Workspaces now have unrestricted outbound internet access by default
+
+### Fixed
+- New production workspaces can sync repositories without failing to create `/home/repos`
+- Retry now wakes paused Cloud Workspace compute before reconnecting
+- Production and staging cloud-agent authentication are isolated so credentials cannot contaminate each other
+
 ## [0.20.12]
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.12",
+	"version": "0.20.13",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "0.20.13",
+    "sections": [
+      {
+        "title": "Changed",
+        "items": [
+          "Cloud Workspaces now have unrestricted outbound internet access by default"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "New production workspaces can sync repositories without failing to create `/home/repos`",
+          "Retry now wakes paused Cloud Workspace compute before reconnecting",
+          "Production and staging cloud-agent authentication are isolated so credentials cannot contaminate each other"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.12",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.12",
+      "version": "0.20.13",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Prepare Zuse v0.20.13 with release notes grouped by user-visible outcome.

### Changed
- Cloud Workspaces now have unrestricted outbound internet access by default

### Fixed
- New production workspaces can sync repositories without failing to create `/home/repos`
- Retry now wakes paused Cloud Workspace compute before reconnecting
- Production and staging cloud-agent authentication are isolated so credentials cannot contaminate each other

## Validation

- `bun run content:generate` in `apps/web`
- `bun run check-types`
- `bunx biome check apps/desktop/package.json`
- `git diff --check`

Release artifacts are produced by pushing tag v0.20.13 after this PR lands.
