### PR TITLE
fix: recover stale turns and interrupted chat creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The packaged `zusehq` CLI now discovers and authenticates to a foreground Serve process, reconnects after Serve restarts, and reports protocol mismatch, rejected credentials, and unavailable servers distinctly
+- Completed turns now clear stale working indicators after reconnects, and interrupted new-chat creation resumes from the durable outbox without losing or duplicating the chat, session, prompt, or workspace operation
 
 ## [0.20.13]
 

--- a/apps/desktop/test/unit/cloud-sync-service.test.ts
+++ b/apps/desktop/test/unit/cloud-sync-service.test.ts
@@ -124,9 +124,10 @@ describe("cloud sync service", () => {
 			hostAlias: "zuse-workspace_abc",
 			remotePath: "/home/zuse/workspace",
 		});
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		expect(runs.length).toBe(1);
-		expect(manager.status("workspace_abc").state).toBe("in-sync");
+		await vi.waitFor(() => {
+			expect(runs).toHaveLength(1);
+			expect(manager.status("workspace_abc").state).toBe("in-sync");
+		});
 		expect(manager.status("workspace_abc").lastSyncedAt).not.toBeNull();
 		await manager.dispose();
 	});
@@ -152,9 +153,10 @@ describe("cloud sync service", () => {
 			hostAlias: "zuse-workspace_old",
 			remotePath: "/home/zuse/workspace",
 		});
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		expect(fallbackRuns).toBe(1);
-		expect(manager.status("workspace_old").state).toBe("in-sync");
+		await vi.waitFor(() => {
+			expect(fallbackRuns).toBe(1);
+			expect(manager.status("workspace_old").state).toBe("in-sync");
+		});
 		await manager.dispose();
 	});
 
@@ -211,8 +213,9 @@ describe("cloud sync service", () => {
 			hostAlias: "zuse-workspace_abc",
 			remotePath: "/home/zuse/workspace",
 		});
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		expect(manager.status("workspace_abc").state).toBe("error");
+		await vi.waitFor(() =>
+			expect(manager.status("workspace_abc").state).toBe("error"),
+		);
 		expect(manager.status("workspace_abc").error).toContain(
 			"connection unexpectedly closed",
 		);

--- a/apps/desktop/test/unit/performance-history-store.test.ts
+++ b/apps/desktop/test/unit/performance-history-store.test.ts
@@ -58,7 +58,8 @@ describe("PerformanceHistoryStore", () => {
 	test("retains lag samples and ignores corrupted lines", async () => {
 		const directory = await mkdtemp(join(tmpdir(), "zuse-performance-"));
 		const path = join(directory, "diagnostics.host-resources.ndjson");
-		const store = new PerformanceHistoryStore({ path });
+		const now = () => Date.UTC(2026, 6, 31, 1);
+		const store = new PerformanceHistoryStore({ path, now });
 		await store.initialize();
 		const lag: LagSample = {
 			id: "lag-1",
@@ -81,7 +82,7 @@ describe("PerformanceHistoryStore", () => {
 		store.recordLag(lag);
 		await store.flush();
 
-		const restored = new PerformanceHistoryStore({ path });
+		const restored = new PerformanceHistoryStore({ path, now });
 		await restored.initialize();
 		expect(restored.getHistory(0).lagSamples).toEqual([lag]);
 	});

--- a/apps/renderer/src/lib/auto-worktree.ts
+++ b/apps/renderer/src/lib/auto-worktree.ts
@@ -1,5 +1,4 @@
 import type {
-	ChatWorkspacePolicy,
 	EnvironmentId,
 	FolderId,
 	RepositorySettings,
@@ -38,27 +37,4 @@ export async function resolveChatRuntimeMode(
 		useSettingsStore.getState().defaultRuntimeMode,
 		await repositorySettingsFor(environmentId, projectId),
 	);
-}
-
-/**
- * Resolve the worktree a freshly-created chat should run in. When per-repo
- * (`autoCreateWorktree`) or global (`defaultAutoCreateWorktree`) auto-create
- * is on, this asks the server-owned bootstrap to create a fresh worktree;
- * otherwise the chat runs in the main checkout.
- *
- * Shared by every chat-creation entry point — the sidebar "New chat" button
- * and the landing screen — so they can't drift: a divergence here is exactly
- * what left landing-screen chats stranded in the main repo while the UI
- * promised a fresh worktree.
- */
-export async function resolveChatWorkspacePolicy(
-	environmentId: EnvironmentId,
-	projectId: FolderId,
-): Promise<ChatWorkspacePolicy> {
-	const settings = useSettingsStore.getState();
-	const repoSettings = await repositorySettingsFor(environmentId, projectId);
-	const shouldAutoCreate =
-		repoSettings?.autoCreateWorktree === true ||
-		settings.defaultAutoCreateWorktree === true;
-	return shouldAutoCreate ? { _tag: "fresh" } : { _tag: "main" };
 }

--- a/apps/renderer/src/lib/session-timeline-hooks.ts
+++ b/apps/renderer/src/lib/session-timeline-hooks.ts
@@ -62,7 +62,7 @@ const EMPTY_TIMELINE_VIEW: ResourceView<SessionTimelineProjection> = {
 	failedCommands: [],
 };
 
-const runtimeFromResource = (
+export const runtimeFromResource = (
 	view: ResourceView<SessionTimelineProjection>,
 	fallback: SessionRuntimeState,
 ): SessionRuntimeState => {
@@ -73,18 +73,22 @@ const runtimeFromResource = (
 	) {
 		return "stopping";
 	}
-	const runtime =
-		view.data === null ? fallback : runtimeStateFromTimeline(view.data);
-	if (runtime !== "idle") return runtime;
-	if (
+	const pendingSend =
 		view.pendingCommands.some((command) => command.kind === "messages.send") &&
 		(view.data === null ||
 			view.data.messages.findLast(
 				(message) => message.role === "user" || message.role === "assistant",
-			)?.role === "user")
+			)?.role === "user");
+	if (pendingSend) return "starting";
+	if (
+		(view.connection !== "connected" || view.sync !== "live") &&
+		(fallback === "idle" || fallback === "failed")
 	) {
-		return "starting";
+		return fallback;
 	}
+	const runtime =
+		view.data === null ? fallback : runtimeStateFromTimeline(view.data);
+	if (runtime !== "idle") return runtime;
 	return "idle";
 };
 

--- a/apps/renderer/src/store/chats.ts
+++ b/apps/renderer/src/store/chats.ts
@@ -5,7 +5,7 @@ import {
 	type ChatCreationOperation,
 	ChatId,
 	type ChatUnarchiveResult,
-	type ChatWorkspacePolicy,
+	type ChatWorkspaceRequestPolicy,
 	CommandId,
 	ComposerInput,
 	EnvironmentId,
@@ -319,10 +319,8 @@ type ChatsState = {
 			 */
 			readonly environmentId?: string;
 			readonly runtimeMode?: RuntimeMode;
-			readonly worktreeId?: WorktreeId | null | Promise<WorktreeId | null>;
-			readonly workspacePolicy?:
-				| ChatWorkspacePolicy
-				| Promise<ChatWorkspacePolicy>;
+			readonly worktreeId?: WorktreeId | null;
+			readonly workspacePolicy?: ChatWorkspaceRequestPolicy;
 			readonly permissionMode?: PermissionMode;
 			readonly toolSearch?: boolean;
 			readonly startupInput?: ComposerInput;
@@ -400,7 +398,7 @@ export type PendingChatCreation = {
 	readonly prompt: string | null;
 	readonly workspaceRequested: boolean;
 	readonly worktreeId: WorktreeId | null;
-	readonly workspacePolicy: ChatWorkspacePolicy | null;
+	readonly workspacePolicy: ChatWorkspaceRequestPolicy | null;
 	readonly phase: ChatCreationOperation["phase"];
 	readonly failureStage: ChatCreationOperation["failureStage"];
 	readonly retryable: boolean;
@@ -748,8 +746,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 		markRendererInteraction(initialSessionId, "click");
 		const now = new Date();
 		const title = opts?.title?.trim() || "New chat";
-		const optimisticWorktreeId =
-			opts?.worktreeId instanceof Promise ? null : (opts?.worktreeId ?? null);
+		const optimisticWorktreeId = opts?.worktreeId ?? null;
 		const optimisticChat = Chat.make({
 			id: chatId,
 			projectId,
@@ -806,10 +803,7 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 			prompt: opts?.startupInput?.text.trim() || null,
 			workspaceRequested: opts?.workspaceRequested === true,
 			worktreeId: optimisticWorktreeId,
-			workspacePolicy:
-				opts?.workspacePolicy instanceof Promise
-					? null
-					: (opts?.workspacePolicy ?? null),
+			workspacePolicy: opts?.workspacePolicy ?? null,
 			phase: "persisted",
 			failureStage: null,
 			retryable: true,
@@ -911,8 +905,8 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 		const commandId = nextChatCreateCommandId(operationId);
 		let knownWorktreeId = optimisticWorktreeId;
 		try {
-			const workspacePolicy = await opts?.workspacePolicy;
-			const worktreeId = await (opts?.worktreeId ?? null);
+			const workspacePolicy = opts?.workspacePolicy;
+			const worktreeId = opts?.worktreeId ?? null;
 			knownWorktreeId =
 				workspacePolicy?._tag === "existing"
 					? workspacePolicy.worktreeId
@@ -925,7 +919,8 @@ export const useChatsStore = create<ChatsState>((set, get) => ({
 						worktreeId: knownWorktreeId,
 						workspacePolicy: workspacePolicy ?? null,
 						workspaceRequested:
-							workspacePolicy === undefined
+							workspacePolicy === undefined ||
+							workspacePolicy._tag === "automatic"
 								? (s.pendingCreationByChat[chatId] ?? pendingCreation)
 										.workspaceRequested
 								: workspacePolicy._tag !== "main",

--- a/apps/renderer/test/unit/chat-landing-progress.test.ts
+++ b/apps/renderer/test/unit/chat-landing-progress.test.ts
@@ -10,9 +10,20 @@ import queueChipSource from "../../src/components/composer/queue-chip.tsx?raw";
 import workspacePickerSource from "../../src/components/composer/workspace-picker.tsx?raw";
 import { chatLandingProgress } from "../../src/lib/chat-landing-progress.ts";
 import cloudChatsSource from "../../src/lib/cloud-workspaces.ts?raw";
+import chatStoreSource from "../../src/store/chats.ts?raw";
 import externalThreadsSource from "../../src/store/external-threads.ts?raw";
 
 describe("chat landing progress", () => {
+	test("dispatches the selected workspace mode without a settings preflight", () => {
+		expect(chatLandingSource).toContain(
+			"workspacePolicy: workspacePolicyForMode(workspaceMode)",
+		);
+		expect(chatStoreSource).not.toContain(
+			"const workspacePolicy = await opts?.workspacePolicy",
+		);
+		expect(chatStoreSource).not.toContain("Promise<ChatWorkspace");
+	});
+
 	test("keeps provider thread imports out of the landing-page content", () => {
 		expect(chatLandingSource).not.toContain("ContinueThreadsSection");
 		expect(chatLandingSource).not.toContain("Continue Threads");

--- a/apps/renderer/test/unit/session-runtime-state.test.ts
+++ b/apps/renderer/test/unit/session-runtime-state.test.ts
@@ -1,4 +1,9 @@
-import { CommandId } from "@zuse/contracts";
+import {
+	AgentTurnId,
+	CommandId,
+	QueueState,
+	SessionTimelineProjection,
+} from "@zuse/contracts";
 import { describe, expect, it } from "vitest";
 import {
 	effectiveSessionRuntimeState,
@@ -6,8 +11,113 @@ import {
 	isSessionRuntimeBusy,
 	runtimeStateFromStatus,
 } from "../../src/lib/session-runtime-state.ts";
+import { runtimeFromResource } from "../../src/lib/session-timeline-hooks.ts";
 
 describe("session runtime state", () => {
+	it("clears a stale running timeline from an authoritative idle summary", () => {
+		const projection = SessionTimelineProjection.make({
+			messages: [],
+			status: "running",
+			currentTurn: {
+				turnId: AgentTurnId.make("turn-stale-after-disconnect"),
+				phase: "running",
+			},
+			queue: QueueState.make({ items: [], paused: false }),
+			permissionMode: "default",
+			runtimeMode: "approval-required",
+		});
+
+		const view: Parameters<typeof runtimeFromResource>[0] = {
+			data: projection,
+			origin: "cache",
+			connection: "offline",
+			sync: "cached",
+			generation: 2,
+			cursor: { epoch: "stale", version: 4 },
+			pendingCommands: [],
+			failedCommands: [],
+		};
+		const runtime = runtimeFromResource(view, "idle");
+		expect(runtime).toBe("idle");
+		expect(isSessionRuntimeBusy(runtime)).toBe(false);
+		expect(runtimeFromResource(view, "failed")).toBe("failed");
+	});
+
+	it("keeps pending local commands authoritative while reconnecting", () => {
+		expect(
+			runtimeFromResource(
+				{
+					data: null,
+					origin: "none",
+					connection: "connecting",
+					sync: "synchronizing",
+					generation: 2,
+					cursor: null,
+					pendingCommands: [
+						{
+							commandId: CommandId.make("message-send:reconnecting"),
+							kind: "messages.send",
+							submittedAt: 1,
+						},
+					],
+					failedCommands: [],
+				},
+				"idle",
+			),
+		).toBe("starting");
+		expect(
+			runtimeFromResource(
+				{
+					data: null,
+					origin: "none",
+					connection: "connecting",
+					sync: "synchronizing",
+					generation: 2,
+					cursor: null,
+					pendingCommands: [
+						{
+							commandId: CommandId.make("interrupt:reconnecting"),
+							kind: "messages.interrupt",
+							submittedAt: 1,
+						},
+					],
+					failedCommands: [],
+				},
+				"idle",
+			),
+		).toBe("stopping");
+	});
+
+	it("keeps a live timeline authoritative over a lagging idle summary", () => {
+		const projection = SessionTimelineProjection.make({
+			messages: [],
+			status: "running",
+			currentTurn: {
+				turnId: AgentTurnId.make("turn-live"),
+				phase: "running",
+			},
+			queue: QueueState.make({ items: [], paused: false }),
+			permissionMode: "default",
+			runtimeMode: "approval-required",
+		});
+
+		expect(
+			runtimeFromResource(
+				{
+					data: projection,
+					origin: "runtime",
+					connection: "connected",
+					sync: "live",
+					generation: 3,
+					cursor: { epoch: "live", version: 5 },
+					pendingCommands: [],
+					failedCommands: [],
+				},
+				"idle",
+			),
+		).toBe("running");
+	});
+
 	it("treats booting as busy before a running event arrives", () => {
 		const state = runtimeStateFromStatus("booting");
 		expect(state).toBe("starting");

--- a/apps/server/src/conversation/core/chat-workspace-policy.ts
+++ b/apps/server/src/conversation/core/chat-workspace-policy.ts
@@ -1,0 +1,25 @@
+import type {
+	ChatWorkspacePolicy,
+	ChatWorkspaceRequestPolicy,
+	WorktreeId,
+} from "@zuse/contracts";
+
+export const resolveChatWorkspacePolicyRequest = (input: {
+	readonly request: ChatWorkspaceRequestPolicy | undefined;
+	readonly legacyWorktreeId: WorktreeId | null | undefined;
+	readonly defaultAutoCreateWorktree: boolean;
+	readonly repositoryAutoCreateWorktree: boolean;
+}): ChatWorkspacePolicy => {
+	const request =
+		input.request ??
+		(input.legacyWorktreeId === null || input.legacyWorktreeId === undefined
+			? { _tag: "main" as const }
+			: {
+					_tag: "existing" as const,
+					worktreeId: input.legacyWorktreeId,
+				});
+	if (request._tag !== "automatic") return request;
+	return input.defaultAutoCreateWorktree || input.repositoryAutoCreateWorktree
+		? { _tag: "fresh" }
+		: { _tag: "main" };
+};

--- a/apps/server/src/provider/handlers.ts
+++ b/apps/server/src/provider/handlers.ts
@@ -12,6 +12,7 @@ import {
 	ChatCreationConflictError,
 	type ChatCreationOperation,
 	ChatId,
+	type ChatWorkspacePolicy,
 	ComposerInput,
 	CredentialStoreError,
 	FolderId,
@@ -42,6 +43,7 @@ import {
 	persistChatStartupIntent,
 	updateQueuedMessageWithStartupHandoff,
 } from "../conversation/core/chat-startup-intent.ts";
+import { resolveChatWorkspacePolicyRequest } from "../conversation/core/chat-workspace-policy.ts";
 import { messageFromRecord } from "../conversation/core/conversation-records.ts";
 import { timelineEventFromDomain } from "../conversation/core/conversation-timeline-projection.ts";
 import { handoffToServiceScope } from "../conversation/core/service-scope.ts";
@@ -53,6 +55,7 @@ import {
 	SessionService,
 	TranscriptService,
 } from "../conversation/services/conversation-services.ts";
+import { RepositorySettingsService } from "../repository-settings/services/repository-settings-service.ts";
 import { resolveCliPath, resolveUpdateCommand } from "./availability.ts";
 import { BrowserBridgeService } from "./services/browser-bridge-service.ts";
 import { CredentialsService } from "./services/credentials-service.ts";
@@ -631,15 +634,31 @@ const ChatCreate = MemoizeRpcs.toLayerHandler(
 						const queueTransaction = yield* QueueTransactionService;
 						const analytics = yield* AnalyticsService;
 						const sql = yield* SqlClient.SqlClient;
-						const requestedPolicy =
-							input.workspacePolicy?._tag ??
-							(input.worktreeId === null || input.worktreeId === undefined
-								? "main"
-								: "existing");
-						// Repository inspection is part of workspace preparation. Keeping it
-						// after the durable acknowledgement is what makes Send responsive even
-						// when Git or the remote is slow.
-						const policy = requestedPolicy;
+						let resolvedWorkspacePolicy: ChatWorkspacePolicy;
+						if (input.workspacePolicy?._tag === "automatic") {
+							const configStore = yield* ConfigStoreService;
+							const repositorySettings = yield* RepositorySettingsService;
+							const globalSettings = yield* configStore.getSettings();
+							const repository = yield* repositorySettings.get(input.projectId);
+							resolvedWorkspacePolicy = resolveChatWorkspacePolicyRequest({
+								request: input.workspacePolicy,
+								legacyWorktreeId: input.worktreeId,
+								defaultAutoCreateWorktree:
+									globalSettings.defaultAutoCreateWorktree,
+								repositoryAutoCreateWorktree: repository.autoCreateWorktree,
+							});
+						} else {
+							resolvedWorkspacePolicy = resolveChatWorkspacePolicyRequest({
+								request: input.workspacePolicy,
+								legacyWorktreeId: input.worktreeId,
+								defaultAutoCreateWorktree: false,
+								repositoryAutoCreateWorktree: false,
+							});
+						}
+						// The renderer has already placed this request in its durable outbox.
+						// Resolve settings here so reconnects never strand an optimistic session
+						// before chat.create is dispatchable; Git work stays in the worker below.
+						const policy = resolvedWorkspacePolicy._tag;
 						const requestFingerprint =
 							input.operationId === undefined
 								? null
@@ -672,9 +691,9 @@ const ChatCreate = MemoizeRpcs.toLayerHandler(
 								policy === "fresh"
 									? WorktreeId.make(crypto.randomUUID())
 									: policy === "existing"
-										? input.workspacePolicy?._tag === "existing"
-											? input.workspacePolicy.worktreeId
-											: (input.worktreeId ?? null)
+										? resolvedWorkspacePolicy._tag === "existing"
+											? resolvedWorkspacePolicy.worktreeId
+											: null
 										: null;
 							yield* sql`
 				INSERT INTO chat_creation_operations (

--- a/apps/server/src/voice/handlers.ts
+++ b/apps/server/src/voice/handlers.ts
@@ -112,7 +112,7 @@ const upload = async (
 		const form = new FormData();
 		form.append(
 			"file",
-			new Blob([bytes], { type: mimeType }),
+			new Blob([Uint8Array.from(bytes)], { type: mimeType }),
 			mimeType.includes("mp4") ? "recording.m4a" : "recording.audio",
 		);
 		const response = await fetch(TRANSCRIPTION_ENDPOINT, {

--- a/apps/server/test/unit/chat-workspace-policy.test.ts
+++ b/apps/server/test/unit/chat-workspace-policy.test.ts
@@ -1,0 +1,63 @@
+import { WorktreeId } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+import { resolveChatWorkspacePolicyRequest } from "../../src/conversation/core/chat-workspace-policy.ts";
+
+describe("chat workspace request policy", () => {
+	it.each([
+		[true, false],
+		[false, true],
+	] as const)("resolves automatic to fresh for global=%s repository=%s", (defaultAutoCreateWorktree, repositoryAutoCreateWorktree) => {
+		expect(
+			resolveChatWorkspacePolicyRequest({
+				request: { _tag: "automatic" },
+				legacyWorktreeId: null,
+				defaultAutoCreateWorktree,
+				repositoryAutoCreateWorktree,
+			}),
+		).toEqual({ _tag: "fresh" });
+	});
+
+	it("resolves automatic to main when auto creation is disabled", () => {
+		expect(
+			resolveChatWorkspacePolicyRequest({
+				request: { _tag: "automatic" },
+				legacyWorktreeId: null,
+				defaultAutoCreateWorktree: false,
+				repositoryAutoCreateWorktree: false,
+			}),
+		).toEqual({ _tag: "main" });
+	});
+
+	it("preserves explicit and legacy workspace choices", () => {
+		const worktreeId = WorktreeId.make("worktree-existing");
+		for (const request of [
+			{ _tag: "fresh" as const },
+			{ _tag: "main" as const },
+		]) {
+			expect(
+				resolveChatWorkspacePolicyRequest({
+					request,
+					legacyWorktreeId: null,
+					defaultAutoCreateWorktree: true,
+					repositoryAutoCreateWorktree: true,
+				}),
+			).toEqual(request);
+		}
+		expect(
+			resolveChatWorkspacePolicyRequest({
+				request: { _tag: "existing", worktreeId },
+				legacyWorktreeId: null,
+				defaultAutoCreateWorktree: true,
+				repositoryAutoCreateWorktree: true,
+			}),
+		).toEqual({ _tag: "existing", worktreeId });
+		expect(
+			resolveChatWorkspacePolicyRequest({
+				request: undefined,
+				legacyWorktreeId: worktreeId,
+				defaultAutoCreateWorktree: false,
+				repositoryAutoCreateWorktree: false,
+			}),
+		).toEqual({ _tag: "existing", worktreeId });
+	});
+});

--- a/packages/agents/test/unit/drivers/codex.test.ts
+++ b/packages/agents/test/unit/drivers/codex.test.ts
@@ -708,7 +708,7 @@ describe("codexWritableRootsForCwd", () => {
 
 describe("codexReasoningEffort", () => {
 	it("passes only the selected model's supported efforts through to Codex", () => {
-		expect(codexReasoningEffort("gpt-5.5", "xhigh")).toBe("xhigh");
+		expect(codexReasoningEffort("gpt-5.6-sol", "xhigh")).toBe("xhigh");
 		expect(codexReasoningEffort("gpt-5.5", "max")).toBeNull();
 		expect(codexReasoningEffort("gpt-5.6-sol", "max")).toBe("max");
 		expect(codexReasoningEffort("gpt-5.6-terra", "ultra")).toBe("ultra");

--- a/packages/client-runtime/src/client-bus.ts
+++ b/packages/client-runtime/src/client-bus.ts
@@ -731,7 +731,13 @@ export class ClientBus<Client> {
 			});
 			if (connection.phase === "connected" && requestsRuntime(entry)) {
 				this.startDriver(entry, binding);
-			} else if (entry.driverGeneration !== 0) this.stopDriver(entry);
+			} else if (entry.driverGeneration !== 0) {
+				this.setView(entry, {
+					...entry.view,
+					sync: entry.view.data === null ? "empty" : "cached",
+				});
+				this.stopDriver(entry);
+			}
 		}
 		if (
 			connection.phase === "connected" &&

--- a/packages/client-runtime/test/unit/client-bus.test.ts
+++ b/packages/client-runtime/test/unit/client-bus.test.ts
@@ -786,6 +786,51 @@ describe("ClientBus", () => {
 		await bus.dispose();
 	});
 
+	it("persists automatic chat creation before server-side policy resolution", async () => {
+		const persistence = new MemoryPersistence();
+		const resolution = deferred<void>();
+		const commandId = CommandId.make("chat-create:automatic");
+		let executing = false;
+		const bus = new ClientBus<Client>({
+			resolver: immediateResolver(),
+			persistence,
+			commandExecutor: {
+				execute: async (_client, command) => {
+					executing = true;
+					expect(
+						persistence.outbox.get(command.commandId)?.command,
+					).toMatchObject({
+						kind: "chat.create",
+						payload: { workspacePolicy: { _tag: "automatic" } },
+					});
+					await resolution.promise;
+					return {
+						commandId: command.commandId,
+						receivedAt: 2,
+						result: "created",
+					};
+				},
+			},
+		});
+
+		const receipt = bus.dispatch({
+			kind: "chat.create",
+			commandId,
+			environmentId,
+			resource: timelineKey,
+			payload: { workspacePolicy: { _tag: "automatic" } },
+			retry: "safe",
+			createdAt: 1,
+		});
+		await waitUntil(() => executing);
+		expect(persistence.outbox.has(commandId)).toBe(true);
+
+		resolution.resolve();
+		await expect(receipt).resolves.toMatchObject({ result: "created" });
+		expect(persistence.outbox.has(commandId)).toBe(false);
+		await bus.dispose();
+	});
+
 	it("rejects an in-flight command ID collision before executing another payload", async () => {
 		const persistence = new MemoryPersistence();
 		const gate = deferred<void>();
@@ -1117,6 +1162,9 @@ describe("ClientBus", () => {
 	it("routes transport command failures through the environment supervisor", async () => {
 		const scheduled: Array<() => void> = [];
 		let resolves = 0;
+		let driverContext: ResourceDriverContext<Client, Timeline> | null = null;
+		const driverContexts: Array<ResourceDriverContext<Client, Timeline>> = [];
+		let syncAtDriverStop: string | null = null;
 		const bus = new ClientBus<Client>({
 			resolver: immediateResolver(() => {
 				resolves += 1;
@@ -1130,6 +1178,15 @@ describe("ClientBus", () => {
 					throw new Error("socket closed");
 				},
 			},
+			driverFor: () => ({
+				start: (context) => {
+					driverContext = context as ResourceDriverContext<Client, Timeline>;
+					driverContexts.push(driverContext);
+				},
+				stop: () => {
+					syncAtDriverStop = bus.snapshot(timelineKey).sync;
+				},
+			}),
 			runtime: {
 				random: () => 0,
 				schedule: (_delayMs, task) => {
@@ -1140,6 +1197,16 @@ describe("ClientBus", () => {
 		});
 		const lease = bus.retain(timelineKey, { activation: "connect" });
 		await waitUntil(() => bus.connection(environmentId).phase === "connected");
+		await waitUntil(() => driverContext !== null);
+		const activeDriver = driverContext as unknown as ResourceDriverContext<
+			Client,
+			Timeline
+		>;
+		activeDriver.emit({
+			data: { text: "still running" },
+			cursor: { epoch: "connected", version: 1 },
+			sync: "live",
+		});
 		await expect(
 			bus.dispatch({
 				kind: "test.mutate",
@@ -1152,11 +1219,24 @@ describe("ClientBus", () => {
 			}),
 		).rejects.toThrow("socket closed");
 		expect(bus.connection(environmentId).phase).toBe("offline");
+		expect(bus.snapshot(timelineKey).sync).toBe("cached");
+		expect(syncAtDriverStop).toBe("cached");
 		expect(scheduled).toHaveLength(1);
 
 		scheduled[0]?.();
 		await waitUntil(() => bus.connection(environmentId).phase === "connected");
+		await waitUntil(() => driverContexts.length === 2);
+		driverContexts[1]?.emit({
+			data: { text: "latest server snapshot" },
+			cursor: { epoch: "reconnected", version: 1 },
+			resetEpoch: true,
+			sync: "live",
+		});
 		expect(resolves).toBe(2);
+		expect(bus.snapshot(timelineKey)).toMatchObject({
+			data: { text: "latest server snapshot" },
+			sync: "live",
+		});
 		lease.release();
 		await bus.dispose();
 	});

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -1004,6 +1004,20 @@ export const ChatWorkspacePolicy = Schema.Union([
 ]);
 export type ChatWorkspacePolicy = typeof ChatWorkspacePolicy.Type;
 
+/**
+ * Client intent for workspace placement. `automatic` keeps settings resolution
+ * on the server so a renderer reconnect cannot strand creation before the
+ * durable command is dispatched. Persisted creation operations always store a
+ * concrete `ChatWorkspacePolicy`.
+ */
+export const ChatWorkspaceRequestPolicy = Schema.Union([
+	Schema.TaggedStruct("automatic", {}),
+	Schema.TaggedStruct("fresh", {}),
+	Schema.TaggedStruct("existing", { worktreeId: WorktreeId }),
+	Schema.TaggedStruct("main", {}),
+]);
+export type ChatWorkspaceRequestPolicy = typeof ChatWorkspaceRequestPolicy.Type;
+
 export const ChatCreationPhase = Schema.Literals([
 	"persisted",
 	"creating_workspace",
@@ -1122,7 +1136,7 @@ export const ChatCreateRpc = Rpc.make("chat.create", {
 		runtimeMode: Schema.optional(RuntimeMode),
 		worktreeId: Schema.optional(Schema.NullOr(WorktreeId)),
 		/** Server-owned workspace bootstrap. Supersedes `worktreeId` when set. */
-		workspacePolicy: Schema.optional(ChatWorkspacePolicy),
+		workspacePolicy: Schema.optional(ChatWorkspaceRequestPolicy),
 		startupInput: Schema.optional(ComposerInput),
 		startupQueueId: Schema.optional(Schema.String),
 		/** False while attachment or generated context preparation is pending. */


### PR DESCRIPTION
## Summary

- demote retained client resources on disconnect and reconcile stale running timelines with authoritative terminal session summaries
- dispatch chat creation without reconnect-sensitive settings preflight; support server-side `automatic` workspace policy resolution while persisting only concrete policies and preserving the original idempotency fingerprint
- add regression coverage for reconnect recovery, durable outbox ordering, workspace policy resolution, and optimistic pending commands
- stabilize stale time/model fixtures and cloud-sync timing checks found by the full preflight suite; normalize voice upload bytes for the repository-wide TypeScript `BlobPart` contract

The rebased `main` branch now has an explicit Local/Worktree composer selector, so renderer creation requests immediately send that concrete user selection. The new `automatic` request variant remains available for callers that delegate settings resolution to the server.

## Validation

- `bun run test:unit` — 26/26 tasks passed
- `bun run test:integration` — 21/21 tasks passed
- `bun run check-types` — 31/31 tasks passed
- `bun run build:desktop` — passed
- applicable Biome checks and `git diff --check` — passed
- focused server unit suite — 58 files, 347 tests passed

Manual production reproduction was not run from this cloud VM; lifecycle behavior is covered with deterministic unit and integration tests.

## Provenance

- External implementation or source consulted: No
- Usage: Behavior only
- Required notice added or updated: N/A

