### PR TITLE
feat(cloud): broker Codex auth per account

### DIFF
--- a/apps/renderer/src/components/message-row.tsx
+++ b/apps/renderer/src/components/message-row.tsx
@@ -32,13 +32,19 @@ import {
 import { memo, useEffect, useState } from "react";
 
 import { FileIcon } from "~/components/file-icon";
+import {
+	localProjectForCloudEnvironment,
+	useCloudChatCatalogStore,
+} from "~/lib/cloud-workspace-catalog.ts";
 import { useActiveEnvironmentEntities } from "~/lib/environment-entity-hooks.ts";
+import { openNewChatLanding } from "~/lib/open-new-chat-landing.ts";
 import {
 	orchestrationToolName,
 	parseOrchestrationResult,
 } from "~/lib/orchestration-tools";
 import { attachmentUrl } from "~/lib/platform-capabilities";
 import { resumeAfterProviderLogin } from "~/lib/provider-auth-recovery";
+import { isCloudWorkspaceEnvironment } from "~/lib/rpc-client.ts";
 import {
 	type ChatError,
 	classifyMessage,
@@ -998,6 +1004,83 @@ function ProviderAuthCard({
 	);
 }
 
+function CloudCodexAuthCard({
+	authMode,
+	environmentId,
+	onOpenCloudSettings,
+	onDismiss,
+}: {
+	authMode: "legacy-image" | "broker-v1" | "unknown";
+	environmentId: EnvironmentId;
+	onOpenCloudSettings: () => void;
+	onDismiss?: () => void;
+}) {
+	const replacementProjectId = localProjectForCloudEnvironment(environmentId);
+	const legacy = authMode === "legacy-image";
+	const broker = authMode === "broker-v1";
+	return (
+		<div className="px-4 py-2">
+			<div className="w-fit max-w-[80%] rounded-lg bg-alert-error-bg px-3 py-2.5 text-xs text-foreground">
+				<div className="flex items-center justify-between gap-2">
+					<span className="inline-flex items-center gap-1.5 font-medium">
+						<HugeiconsIcon
+							icon={AlertCircleIcon}
+							className="size-3.5 text-destructive"
+							aria-hidden
+						/>
+						{legacy
+							? "This cloud chat uses legacy Codex authentication"
+							: broker
+								? "Codex account needs reconnecting"
+								: "Codex authentication is unavailable"}
+					</span>
+					{onDismiss !== undefined && (
+						<button
+							type="button"
+							onClick={onDismiss}
+							className="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+						>
+							Dismiss
+						</button>
+					)}
+				</div>
+				<p className="mt-1.5 max-w-[32rem] text-[11px] leading-4 text-muted-foreground">
+					{legacy
+						? "Its copied refresh token cannot be recovered safely. Reconnect Codex once, then create a replacement cloud chat that uses account-level authentication."
+						: broker
+							? "Reconnect Codex once in Cloud Workspace settings. The login is shared by your new Codex cloud chats; this sandbox never stores the refresh token."
+							: "Open Cloud Workspace settings to restore the account-level Codex login. Zuse will identify legacy chats after cloud metadata finishes syncing."}
+				</p>
+				<div className="mt-2 flex flex-wrap items-center gap-1.5">
+					{legacy && replacementProjectId !== null ? (
+						<Button
+							type="button"
+							size="xs"
+							variant="outline"
+							onClick={() => openNewChatLanding(replacementProjectId)}
+						>
+							Create replacement chat
+						</Button>
+					) : null}
+					<Button
+						type="button"
+						size="xs"
+						variant={legacy ? "ghost" : "outline"}
+						onClick={onOpenCloudSettings}
+					>
+						<HugeiconsIcon
+							icon={Settings01Icon}
+							className="size-3"
+							aria-hidden
+						/>
+						Open Cloud Authentication
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 const GEMINI_UPGRADE_COMMAND = "npm i -g @google/gemini-cli@latest";
 
 const isGeminiAcpUpgradeError = (text: string): boolean =>
@@ -1074,6 +1157,13 @@ export function ErrorBubble({
 }) {
 	const setView = useUiStore((s) => s.setView);
 	const setSettingsSection = useUiStore((s) => s.setSettingsSection);
+	const cloudSummary = useCloudChatCatalogStore((state) =>
+		environmentId === undefined
+			? null
+			: (state.summaries.find(
+					(summary) => summary.workspaceId === environmentId,
+				) ?? null),
+	);
 
 	const onRetry = () => {
 		if (sessionId !== undefined && environmentId !== undefined) {
@@ -1090,6 +1180,10 @@ export function ErrorBubble({
 	const onOpenSettings = () => {
 		setView("settings");
 		setSettingsSection({ kind: "providers" });
+	};
+	const onOpenCloudSettings = () => {
+		setView("settings");
+		setSettingsSection({ kind: "machines" });
 	};
 
 	if (isGeminiAcpUpgradeError(error.message)) {
@@ -1167,6 +1261,20 @@ export function ErrorBubble({
 		error.providerId !== undefined &&
 		supportsProviderLogin(error.providerId)
 	) {
+		if (
+			error.providerId === "codex" &&
+			environmentId !== undefined &&
+			isCloudWorkspaceEnvironment(environmentId)
+		) {
+			return (
+				<CloudCodexAuthCard
+					authMode={cloudSummary?.codexAuthMode ?? "unknown"}
+					environmentId={environmentId}
+					onOpenCloudSettings={onOpenCloudSettings}
+					onDismiss={onDismiss}
+				/>
+			);
+		}
 		return (
 			<ProviderAuthCard
 				providerId={error.providerId}

--- a/apps/renderer/src/components/settings/cloud-workspace-auth.tsx
+++ b/apps/renderer/src/components/settings/cloud-workspace-auth.tsx
@@ -418,7 +418,7 @@ export function CloudWorkspaceAuth() {
 		<>
 			<CloudSettingsGroup
 				title="Agent authentication"
-				description="Authorize agents once for every new cloud chat. Credentials stay in your private account image."
+				description="Authorize agents once. One ChatGPT login is shared by all new Codex cloud chats; other provider credentials stay in your private account image."
 				action={
 					<span className="text-[11px] text-muted-foreground">
 						{loading
@@ -462,11 +462,14 @@ export function CloudWorkspaceAuth() {
 							title={LABEL[providerId]}
 							description={
 								providerStatus?.state === "connected"
-									? `Ready for new cloud chats via ${providerStatus.method ?? "provider authentication"}.`
+									? providerId === "codex" &&
+										providerStatus.method === "subscription"
+										? "One ChatGPT login is shared by all new Codex cloud chats."
+										: `Ready for new cloud chats via ${providerStatus.method ?? "provider authentication"}.`
 									: providerId === "claude"
 										? "Claude Code subscription, Anthropic API key, or custom endpoint."
 										: providerId === "codex"
-											? "ChatGPT subscription, OpenAI API key, or custom endpoint."
+											? "One account-level ChatGPT subscription login, OpenAI API key, or custom endpoint."
 											: providerId === "cursor"
 												? "Cursor API key for cloud chat sandboxes."
 												: "Grok device login, xAI API key, or custom endpoint."
@@ -536,7 +539,9 @@ export function CloudWorkspaceAuth() {
 						<DialogDescription>
 							{selectedProvider === null
 								? "Choose an authentication method."
-								: `Choose how new cloud sandboxes authenticate with ${LABEL[selectedProvider]}.`}
+								: selectedProvider === "codex"
+									? "Connect Codex once for your Zuse account. Compatible cloud chats receive short-lived access without copied refresh tokens."
+									: `Choose how new cloud sandboxes authenticate with ${LABEL[selectedProvider]}.`}
 						</DialogDescription>
 					</DialogHeader>
 					<form className="contents" onSubmit={submitProviderSetup}>

--- a/apps/renderer/src/lib/cloud-failure-presentation.ts
+++ b/apps/renderer/src/lib/cloud-failure-presentation.ts
@@ -58,6 +58,8 @@ const CATEGORY_KIND: Readonly<Record<string, CloudFailureKind>> = {
 	"sign-in-required": "sign-in-required",
 	"auth-required": "sign-in-required",
 	"authentication-required": "sign-in-required",
+	"codex-auth-reconnect-required": "sign-in-required",
+	"codex-auth-legacy-workspace": "sign-in-required",
 	"not-allowed": "sign-in-required",
 	"billing-blocked": "billing-blocked",
 	"billing-hold": "billing-blocked",
@@ -67,6 +69,7 @@ const CATEGORY_KIND: Readonly<Record<string, CloudFailureKind>> = {
 	"command-kind-not-supported": "update-required",
 	"command-schema-not-supported": "update-required",
 	"command-dependencies-not-supported": "update-required",
+	"codex-auth-update-required": "update-required",
 	"beta-access-required": "cloud-access-required",
 	"beta-access-unavailable": "cloud-access-unavailable",
 	"credential-required": "credentials-required",
@@ -81,6 +84,7 @@ const CATEGORY_KIND: Readonly<Record<string, CloudFailureKind>> = {
 	"reservation-expired": "interaction-expired",
 	"session-not-found": "session-unavailable",
 	"session-unavailable": "session-unavailable",
+	"codex-auth-reconnecting": "network",
 };
 
 const BLOCKED_KIND: Partial<
@@ -143,7 +147,7 @@ const causeKind = (cause: unknown): CloudFailureKind | null => {
 	const exactText = categoryKind(text.trim(), undefined);
 	if (exactText !== null) return exactText;
 	if (
-		/\b401\b|\bunauthorized\b|expired token|invalid_grant|signed?\s?out|sign\s?in required|please log ?in|please run \/login|not logged in|invalid authentication credentials|invalid api key|authorizationrequired|auth\(authorizationrequired\)|authentication (?:failed|required)/i.test(
+		/\b401\b|\bunauthorized\b|expired token|refresh token|invalid_grant|signed?\s?out|sign\s?in required|please log ?in|please run \/login|not logged in|invalid authentication credentials|invalid api key|authorizationrequired|auth\(authorizationrequired\)|authentication (?:failed|required)/i.test(
 			text,
 		)
 	)

--- a/apps/renderer/src/lib/cloud-workspaces.ts
+++ b/apps/renderer/src/lib/cloud-workspaces.ts
@@ -313,6 +313,7 @@ const refreshSummaryFromWorkspace = (
 	workspace: CloudWorkspace,
 ): CloudChatSummary => ({
 	...summary,
+	codexAuthMode: workspace.codexAuthMode,
 	state: workspace.state,
 	runtimeState: workspace.runtimeState,
 	statusCode: workspace.statusCode,
@@ -611,6 +612,7 @@ export const summaryFromLaunch = (input: {
 	title: input.title,
 	branch: input.workspace.branch,
 	providerId: input.workspace.providerId,
+	codexAuthMode: input.workspace.codexAuthMode,
 	agent: input.agent,
 	model: input.model,
 	runtimeMode: input.runtimeMode,

--- a/apps/renderer/test/unit/cloud-failure-presentation.test.ts
+++ b/apps/renderer/test/unit/cloud-failure-presentation.test.ts
@@ -85,6 +85,23 @@ describe("cloud failure presentation", () => {
 		expect(missing?.message).not.toContain("SessionNotFoundError");
 	});
 
+	it.each([
+		["codex-auth-reconnect-required", "sign-in-required"],
+		["codex-auth-legacy-workspace", "sign-in-required"],
+		["codex-auth-update-required", "update-required"],
+		["codex-auth-reconnecting", "network"],
+	] as const)("maps broker status %s to %s", (cause, kind) => {
+		expect(cloudFailurePresentation({ cause })).toMatchObject({ kind });
+	});
+
+	it("recognizes a consumed Codex refresh token as account authentication", () => {
+		expect(
+			cloudFailurePresentation({
+				cause: "refresh token was already used",
+			}),
+		).toMatchObject({ kind: "sign-in-required" });
+	});
+
 	it("presents a cached response to a missing session as an expired interaction", () => {
 		expect(
 			cloudInteractionFailure({

--- a/apps/renderer/test/unit/session-actions.test.ts
+++ b/apps/renderer/test/unit/session-actions.test.ts
@@ -55,6 +55,14 @@ describe("session actions", () => {
 		});
 	});
 
+	it("classifies broker reconnects as Codex authentication", () => {
+		expect(classifyMessage("codex-auth-reconnect-required", "codex")).toEqual({
+			kind: "auth",
+			providerId: "codex",
+			message: "codex-auth-reconnect-required",
+		});
+	});
+
 	it("classifies reconnect failures without clearing canonical data", () => {
 		expect(
 			classifyMessage("WebSocket closed while the laptop was offline"),

--- a/apps/server/src/api/cloud-codex-auth.ts
+++ b/apps/server/src/api/cloud-codex-auth.ts
@@ -1,0 +1,301 @@
+import type {
+	CodexChatgptAuthTokens,
+	CodexExternalAuthProvider,
+} from "@zuse/agents/drivers/codex-app-server-client";
+import {
+	type CodexGrantRefreshReason,
+	CodexGrantRequest,
+	type SealedCodexGrant,
+} from "@zuse/contracts";
+import { type CryptoKey, calculateJwkThumbprint, type JWK } from "jose";
+
+const PROACTIVE_REFRESH_WINDOW_MS = 5 * 60 * 1_000;
+const MINIMUM_GRANT_LIFETIME_MS = 60 * 1_000;
+
+export type CloudCodexAuthStatus =
+	| "initializing"
+	| "ready"
+	| "codex-auth-reconnecting"
+	| "codex-auth-reconnect-required"
+	| "codex-auth-update-required";
+
+interface CodexGrantPlaintext {
+	readonly zuseAccountId: string;
+	readonly workspaceId: string;
+	readonly runtimeGeneration: number;
+	readonly keyThumbprint: string;
+	readonly authorityIncarnationId: string;
+	readonly authorityEpoch: number;
+	readonly chatgptAccountId: string;
+	readonly chatgptPlanType: string | null;
+	readonly issuedAt: number;
+	readonly expiresAt: number;
+	readonly accessToken: string;
+}
+
+export interface CloudCodexAuthInput {
+	readonly zuseAccountId: string;
+	readonly workspaceId: string;
+	readonly runtimeGeneration: number;
+	readonly credentialPublicJwk: string;
+	readonly credentialPrivateKey: CryptoKey;
+	readonly issueGrant: (
+		request: CodexGrantRequest,
+	) => Promise<SealedCodexGrant>;
+	readonly onStatus?: (status: CloudCodexAuthStatus) => void;
+	readonly onConsumersRecovered?: (consumerIds: ReadonlyArray<string>) => void;
+}
+
+const fromBase64Url = (value: string): Uint8Array =>
+	new Uint8Array(Buffer.from(value, "base64url"));
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+const failureReason = (cause: unknown): string => {
+	if (isRecord(cause) && typeof cause.reason === "string") return cause.reason;
+	return cause instanceof Error ? cause.message : "";
+};
+
+const decodeGrantPlaintext = (value: unknown): CodexGrantPlaintext => {
+	if (!isRecord(value)) throw new Error("codex-auth-update-required");
+	for (const field of [
+		"zuseAccountId",
+		"workspaceId",
+		"keyThumbprint",
+		"authorityIncarnationId",
+		"chatgptAccountId",
+		"accessToken",
+	] as const)
+		if (typeof value[field] !== "string" || value[field].length === 0)
+			throw new Error("codex-auth-update-required");
+	for (const field of [
+		"runtimeGeneration",
+		"authorityEpoch",
+		"issuedAt",
+		"expiresAt",
+	] as const)
+		if (typeof value[field] !== "number" || !Number.isSafeInteger(value[field]))
+			throw new Error("codex-auth-update-required");
+	if (
+		value.chatgptPlanType !== null &&
+		typeof value.chatgptPlanType !== "string"
+	)
+		throw new Error("codex-auth-update-required");
+	return value as unknown as CodexGrantPlaintext;
+};
+
+const additionalData = (sealed: SealedCodexGrant): Uint8Array =>
+	new TextEncoder().encode(
+		JSON.stringify({
+			protocolVersion: sealed.protocolVersion,
+			requestId: sealed.requestId,
+			keyThumbprint: sealed.keyThumbprint,
+			authorityIncarnationId: sealed.authorityIncarnationId,
+			authorityEpoch: sealed.authorityEpoch,
+		}),
+	);
+
+const openGrant = async (
+	sealed: SealedCodexGrant,
+	privateKey: CryptoKey,
+): Promise<CodexGrantPlaintext> => {
+	const rawKey = await crypto.subtle.decrypt(
+		{ name: "RSA-OAEP" },
+		privateKey,
+		fromBase64Url(sealed.wrappedKey),
+	);
+	const contentKey = await crypto.subtle.importKey(
+		"raw",
+		rawKey,
+		{ name: "AES-GCM" },
+		false,
+		["decrypt"],
+	);
+	const ciphertext = Buffer.concat([
+		Buffer.from(sealed.ciphertext, "base64url"),
+		Buffer.from(sealed.tag, "base64url"),
+	]);
+	const plaintext = await crypto.subtle.decrypt(
+		{
+			name: "AES-GCM",
+			iv: fromBase64Url(sealed.iv),
+			additionalData: additionalData(sealed),
+			tagLength: 128,
+		},
+		contentKey,
+		ciphertext,
+	);
+	return decodeGrantPlaintext(
+		JSON.parse(new TextDecoder().decode(plaintext)) as unknown,
+	);
+};
+
+/**
+ * Workspace-scoped, memory-only Codex access-token cache. Refreshes are
+ * single-flight and every grant is generation/key/account fenced.
+ */
+export class CloudCodexAuth implements CodexExternalAuthProvider {
+	private cached: CodexChatgptAuthTokens | null = null;
+	private inFlight: Promise<CodexChatgptAuthTokens> | null = null;
+	private proactiveTimer: NodeJS.Timeout | null = null;
+	private recoveryTimer: NodeJS.Timeout | null = null;
+	private readonly blockedConsumers = new Set<string>();
+	private recoveryPending = false;
+	private readonly keyThumbprint: Promise<string>;
+
+	constructor(private readonly input: CloudCodexAuthInput) {
+		this.keyThumbprint = calculateJwkThumbprint(
+			JSON.parse(input.credentialPublicJwk) as JWK,
+		);
+	}
+
+	readonly getTokens = (request: {
+		readonly reason: CodexGrantRefreshReason;
+		readonly previousChatgptAccountId?: string;
+	}): Promise<CodexChatgptAuthTokens> => {
+		const nowMs = Date.now();
+		if (
+			request.reason !== "unauthorized" &&
+			this.cached !== null &&
+			this.cached.expiresAt > nowMs + PROACTIVE_REFRESH_WINDOW_MS
+		)
+			return Promise.resolve(this.cached);
+		if (this.inFlight !== null) return this.inFlight;
+		this.input.onStatus?.("codex-auth-reconnecting");
+		this.inFlight = this.refresh(request).finally(() => {
+			this.inFlight = null;
+		});
+		return this.inFlight;
+	};
+
+	async initialize(): Promise<void> {
+		await this.getTokens({ reason: "initial" });
+	}
+
+	close(): void {
+		if (this.proactiveTimer !== null) clearTimeout(this.proactiveTimer);
+		if (this.recoveryTimer !== null) clearTimeout(this.recoveryTimer);
+		this.proactiveTimer = null;
+		this.recoveryTimer = null;
+		this.cached = null;
+		this.blockedConsumers.clear();
+		this.recoveryPending = false;
+	}
+
+	readonly onDeliveryFailure = (input: {
+		readonly consumerId?: string;
+		readonly reason: string;
+	}): void => {
+		if (input.consumerId !== undefined)
+			this.blockedConsumers.add(input.consumerId);
+		this.recoveryPending = true;
+		this.input.onStatus?.(
+			input.reason.includes("reconnect-required")
+				? "codex-auth-reconnect-required"
+				: "codex-auth-reconnecting",
+		);
+		this.scheduleRecoveryRetry();
+	};
+
+	private async refresh(request: {
+		readonly reason: CodexGrantRefreshReason;
+		readonly previousChatgptAccountId?: string;
+	}): Promise<CodexChatgptAuthTokens> {
+		try {
+			const keyThumbprint = await this.keyThumbprint;
+			const requestId = crypto.randomUUID();
+			const sealed = await this.input.issueGrant(
+				new CodexGrantRequest({
+					requestId,
+					protocolVersion: 1,
+					runtimeGeneration: this.input.runtimeGeneration,
+					credentialPublicJwk: this.input.credentialPublicJwk,
+					reason: request.reason,
+					...(request.previousChatgptAccountId === undefined
+						? {}
+						: {
+								previousChatgptAccountId: request.previousChatgptAccountId,
+							}),
+				}),
+			);
+			if (
+				sealed.requestId !== requestId ||
+				sealed.keyThumbprint !== keyThumbprint
+			)
+				throw new Error("codex-auth-update-required");
+			const grant = await openGrant(sealed, this.input.credentialPrivateKey);
+			const nowMs = Date.now();
+			if (
+				grant.zuseAccountId !== this.input.zuseAccountId ||
+				grant.workspaceId !== this.input.workspaceId ||
+				grant.runtimeGeneration !== this.input.runtimeGeneration ||
+				grant.keyThumbprint !== keyThumbprint ||
+				grant.authorityIncarnationId !== sealed.authorityIncarnationId ||
+				grant.authorityEpoch !== sealed.authorityEpoch ||
+				grant.issuedAt > nowMs + 60_000 ||
+				grant.expiresAt <= nowMs + MINIMUM_GRANT_LIFETIME_MS
+			)
+				throw new Error("codex-auth-update-required");
+			if (
+				request.previousChatgptAccountId !== undefined &&
+				request.previousChatgptAccountId !== grant.chatgptAccountId
+			)
+				throw new Error("codex-auth-reconnect-required");
+			const tokens: CodexChatgptAuthTokens = {
+				accessToken: grant.accessToken,
+				chatgptAccountId: grant.chatgptAccountId,
+				chatgptPlanType: grant.chatgptPlanType,
+				expiresAt: grant.expiresAt,
+			};
+			this.cached = tokens;
+			this.scheduleProactiveRefresh(tokens.expiresAt);
+			if (this.recoveryTimer !== null) {
+				clearTimeout(this.recoveryTimer);
+				this.recoveryTimer = null;
+			}
+			if (this.recoveryPending) {
+				const consumers = [...this.blockedConsumers];
+				this.blockedConsumers.clear();
+				this.recoveryPending = false;
+				this.input.onConsumersRecovered?.(consumers);
+			}
+			this.input.onStatus?.("ready");
+			return tokens;
+		} catch (cause) {
+			const reason = failureReason(cause);
+			const status = reason.includes("reconnect-required")
+				? "codex-auth-reconnect-required"
+				: reason.includes("update-required")
+					? "codex-auth-update-required"
+					: "codex-auth-reconnecting";
+			this.input.onStatus?.(status);
+			if (status !== "codex-auth-update-required") {
+				this.recoveryPending = true;
+				this.scheduleRecoveryRetry();
+			}
+			throw cause;
+		}
+	}
+
+	private scheduleProactiveRefresh(expiresAt: number): void {
+		if (this.proactiveTimer !== null) clearTimeout(this.proactiveTimer);
+		const delay = Math.max(
+			1_000,
+			expiresAt - Date.now() - PROACTIVE_REFRESH_WINDOW_MS,
+		);
+		this.proactiveTimer = setTimeout(() => {
+			void this.getTokens({ reason: "proactive" }).catch(() => undefined);
+		}, delay);
+		this.proactiveTimer.unref();
+	}
+
+	private scheduleRecoveryRetry(): void {
+		if (this.recoveryTimer !== null) return;
+		this.recoveryTimer = setTimeout(() => {
+			this.recoveryTimer = null;
+			void this.getTokens({ reason: "proactive" }).catch(() => undefined);
+		}, 15_000);
+		this.recoveryTimer.unref();
+	}
+}

--- a/apps/server/src/api/cloud-workspace-runtime.ts
+++ b/apps/server/src/api/cloud-workspace-runtime.ts
@@ -12,6 +12,10 @@ import {
 import { dirname, join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import {
+	beforeCodexExternalAuthDeadline,
+	setDefaultCodexExternalAuthProvider,
+} from "@zuse/agents/drivers/codex-app-server-client";
+import {
 	type CloudMessageSendPayload,
 	type CloudMessageSendResult,
 	cloudCommandEligibility,
@@ -39,6 +43,7 @@ import {
 	RuntimeAcknowledgment,
 	RuntimeLease,
 	RuntimeMode,
+	SealedCodexGrant,
 	SessionId,
 	WIRE_PROTOCOL_VERSION,
 	WORKSPACE_GATEWAY_AUTH_EXPIRED_CLOSE,
@@ -85,13 +90,17 @@ import {
 	ChatService,
 	type ChatServiceShape,
 	MessageService,
+	SessionService,
+	type SessionServiceShape,
 } from "../conversation/services/conversation-services.ts";
 import { LanAuthService } from "../lan-auth/services/lan-auth-service.ts";
+import { isProviderAuthenticationRequired } from "../provider/provider-auth-failure.ts";
 import { CredentialsService } from "../provider/services/credentials-service.ts";
 import {
 	WorkspaceService,
 	type WorkspaceServiceShape,
 } from "../workspace/services/workspace-service.ts";
+import { CloudCodexAuth } from "./cloud-codex-auth.ts";
 import { cloudStorageIncarnationId } from "./cloud-storage-incarnation.ts";
 
 const CREDENTIALS_READY_MARKER = "/var/lib/zuse/workspace/credentials-ready";
@@ -219,6 +228,7 @@ export const bufferWorkspaceLocalFrame = (
 
 const BootstrapResponse = Schema.Struct({
 	workspaceId: Schema.String,
+	zuseAccountId: Schema.optional(Schema.String),
 	providerSandboxId: Schema.String,
 	runtimeCredential: Schema.String,
 	runtimeGatewayCredential: Schema.String,
@@ -229,6 +239,9 @@ const BootstrapResponse = Schema.Struct({
 	gatewayProtocol: Schema.String,
 	chatId: Schema.String,
 	initialSessionId: Schema.String,
+	codexAuthMode: Schema.optional(
+		Schema.Literals(["legacy-image", "broker-v1"]),
+	),
 	launchIntent: Schema.optional(
 		Schema.Struct({
 			commandId: Schema.String,
@@ -846,7 +859,18 @@ const requestJson = <A, I>(input: {
 			} catch {
 				throw fail("api_request_failed");
 			}
-			if (!response.ok) throw fail("api_http_rejected", response.status);
+			if (!response.ok) {
+				let reason = "api_http_rejected";
+				try {
+					const error = (await response.json()) as { readonly error?: unknown };
+					if (typeof error.error === "string" && error.error.length <= 128)
+						reason = error.error;
+				} catch {
+					// The status still carries the durable classification when an older API
+					// does not return its typed JSON error body.
+				}
+				throw fail(reason, response.status);
+			}
 			try {
 				return (await response.json()) as unknown;
 			} catch {
@@ -1735,6 +1759,44 @@ const waitForRepository = Effect.callback<void, CloudWorkspaceRuntimeError>(
 	},
 );
 
+const recoverCodexAuthFailedSessions = Effect.fn(
+	"CloudWorkspaceRuntime.recoverCodexAuthFailedSessions",
+)(function* (input: {
+	readonly workspaces: WorkspaceServiceShape;
+	readonly sessions: SessionServiceShape;
+	readonly messages: MessageService["Service"];
+	readonly consumerIds?: ReadonlyArray<string>;
+}) {
+	const consumerIds =
+		input.consumerIds === undefined ? null : new Set(input.consumerIds);
+	const folders = yield* input.workspaces.list();
+	const sessions = (yield* Effect.forEach(
+		folders,
+		(folder) => input.sessions.listSessions(folder.id, false),
+		{ concurrency: 2 },
+	)).flat();
+	yield* Effect.forEach(
+		sessions.filter(
+			(session) =>
+				session.providerId === "codex" &&
+				session.status === "error" &&
+				(consumerIds === null || consumerIds.has(session.id)),
+		),
+		(session) =>
+			input.messages.listMessages(session.id).pipe(
+				Effect.flatMap((history) => {
+					const last = history.at(-1)?.content;
+					return last?._tag === "error" &&
+						isProviderAuthenticationRequired(last.message)
+						? input.sessions.resumeSession(session.id).pipe(Effect.asVoid)
+						: Effect.void;
+				}),
+				Effect.catch(() => Effect.void),
+			),
+		{ concurrency: 2, discard: true },
+	);
+});
+
 const removeBootToken = (path: string | undefined) =>
 	path === undefined
 		? Effect.void
@@ -1851,6 +1913,7 @@ export const makeCloudWorkspaceRuntimeLayer = (
 	| WorkspaceService
 	| ChatService
 	| MessageService
+	| SessionService
 	| CredentialsService
 	| SessionDomain
 	| SqlClient.SqlClient
@@ -1863,6 +1926,7 @@ export const makeCloudWorkspaceRuntimeLayer = (
 					const workspaces = yield* WorkspaceService;
 					const chats = yield* ChatService;
 					const messages = yield* MessageService;
+					const sessions = yield* SessionService;
 					const sql = yield* SqlClient.SqlClient;
 					const credentials = yield* CredentialsService;
 					yield* installImageProviderSecrets(credentials);
@@ -1905,6 +1969,114 @@ export const makeCloudWorkspaceRuntimeLayer = (
 						generation: bootstrap.runtimeGeneration,
 						gatewayEpoch: bootstrap.gatewayEpoch,
 					};
+					yield* writeGithubBrokerState(config, runtimeCredential.credential);
+					yield* superviseRuntimeCredential({
+						config,
+						signingPrivateKey: signingKeyPair.privateKey,
+						state: runtimeCredential,
+					}).pipe(Effect.forkScoped({ startImmediately: true }));
+					if (bootstrap.codexAuthMode === "broker-v1") {
+						if (bootstrap.zuseAccountId === undefined)
+							return yield* Effect.fail(fail("codex-auth-update-required"));
+						const cloudCodexAuth = new CloudCodexAuth({
+							zuseAccountId: bootstrap.zuseAccountId,
+							workspaceId: config.workspaceId,
+							runtimeGeneration: bootstrap.runtimeGeneration,
+							credentialPublicJwk,
+							credentialPrivateKey: credentialKeyPair.privateKey,
+							issueGrant: (request) =>
+								Effect.runPromise(
+									Effect.suspend(() =>
+										requestJson({
+											schema: SealedCodexGrant,
+											url: `${config.apiUrl}${ApiPaths.cloudWorkspaceRuntimeCodexGrant(config.workspaceId)}`,
+											token: runtimeCredential.credential,
+											method: "POST",
+											body: request,
+											timeoutMs: 30_000,
+										}),
+									).pipe(
+										Effect.retry({
+											while: (error) =>
+												error.reason !== "codex-auth-update-required" &&
+												error.reason !== "codex-auth-reconnect-required" &&
+												error.reason !== "codex-auth-legacy-workspace" &&
+												error.reason !== "workspace_runtime_fenced" &&
+												error.reason !==
+													"runtime_credential_key_binding_mismatch",
+											schedule: cloudRuntimeRetrySchedule,
+										}),
+									),
+								),
+							onStatus: (status) =>
+								console.info("[cloud-codex-auth] status", { status }),
+							onConsumersRecovered: (consumerIds) => {
+								void Effect.runPromise(
+									recoverCodexAuthFailedSessions({
+										workspaces,
+										sessions,
+										messages,
+										...(consumerIds.length === 0 ? {} : { consumerIds }),
+									}).pipe(
+										Effect.catch((cause) =>
+											Effect.logWarning("Codex auth recovery scan failed", {
+												cause: String(cause),
+											}),
+										),
+									),
+								);
+							},
+						});
+						yield* Effect.acquireRelease(
+							Effect.tryPromise({
+								try: async () => {
+									let initialized = false;
+									try {
+										await beforeCodexExternalAuthDeadline(
+											cloudCodexAuth.initialize(),
+										);
+										initialized = true;
+									} catch (cause) {
+										const reason =
+											typeof cause === "object" &&
+											cause !== null &&
+											"reason" in cause &&
+											typeof cause.reason === "string"
+												? cause.reason
+												: cause instanceof Error
+													? cause.message
+													: "codex-auth-reconnecting";
+										if (reason === "codex-auth-update-required") throw cause;
+										console.warn("[cloud-codex-auth] initial grant deferred", {
+											reason,
+										});
+									}
+									setDefaultCodexExternalAuthProvider(cloudCodexAuth);
+									if (initialized) {
+										void Effect.runPromise(
+											recoverCodexAuthFailedSessions({
+												workspaces,
+												sessions,
+												messages,
+											}).pipe(Effect.catch(() => Effect.void)),
+										);
+									}
+									return cloudCodexAuth;
+								},
+								catch: (cause) =>
+									fail(
+										cause instanceof Error
+											? cause.message
+											: "codex-auth-reconnecting",
+									),
+							}),
+							(auth) =>
+								Effect.sync(() => {
+									auth.close();
+									setDefaultCodexExternalAuthProvider(null);
+								}),
+						);
+					}
 					const postCurrentRuntimeReady = (
 						phase: "repository-ready" | "agent-started" | "launch-failed",
 						launchCommandId?: string,
@@ -1921,12 +2093,6 @@ export const makeCloudWorkspaceRuntimeLayer = (
 								sessionHeadVersion,
 							),
 						);
-					yield* writeGithubBrokerState(config, runtimeCredential.credential);
-					yield* superviseRuntimeCredential({
-						config,
-						signingPrivateKey: signingKeyPair.privateKey,
-						state: runtimeCredential,
-					}).pipe(Effect.forkScoped({ startImmediately: true }));
 					const transcriptKey = yield* Effect.tryPromise({
 						try: async () => {
 							const decrypted = await compactDecrypt(

--- a/apps/server/src/conversation/core/conversation-input.ts
+++ b/apps/server/src/conversation/core/conversation-input.ts
@@ -114,9 +114,3 @@ export const formatProviderFailure = (cause: unknown): string => {
 	}
 	return String(cause);
 };
-
-/** Authentication failures cannot be recovered by restarting the provider. */
-export const looksLikeAuthFailure = (reason: string): boolean =>
-	/\b401\b|\bunauthorized\b|invalid authentication credentials|please run \/login|please log ?in|invalid api key|authentication failed|authorizationrequired/i.test(
-		reason,
-	);

--- a/apps/server/src/conversation/core/provider-reactor-handlers.ts
+++ b/apps/server/src/conversation/core/provider-reactor-handlers.ts
@@ -8,6 +8,7 @@ import {
 } from "@zuse/contracts";
 import type { SessionDomainApi } from "@zuse/domain/engine/session-domain";
 import { Cause, Effect } from "effect";
+import { isProviderAuthenticationRequired } from "../../provider/provider-auth-failure.ts";
 import type { makeReactorEffectJournal } from "../../provider/reactor-effect-journal.ts";
 import type { ProviderServiceShape } from "../../provider/services/provider-service.ts";
 import type { ConversationOperations } from "../services/conversation-services.ts";
@@ -19,9 +20,6 @@ import {
 	decodeProviderStartRequest,
 	decodeProviderTurnInput,
 } from "./provider-turn-request.ts";
-
-const isAuthenticationRequired = (reason: string): boolean =>
-	/\bauthentication required\b/i.test(reason);
 
 const PROVIDER_DELIVERY_OUTCOME_UNKNOWN =
 	"Zuse could not confirm whether the agent received this message before the runtime stopped. Zuse did not send it again to avoid a duplicate. Retry the message if no response appears.";
@@ -353,7 +351,7 @@ export const makeProviderReactorHandlers = (
 				// Authentication is recoverable through explicit resume, which replays
 				// this same durable turn. Completing the receipt prevents catch-up from
 				// racing that user-driven retry; other transient failures stay replayable.
-				if (!isAuthenticationRequired(restarted.error.reason)) {
+				if (!isProviderAuthenticationRequired(restarted.error.reason)) {
 					// ProviderService.send can fail only with AgentSessionNotFoundError,
 					// and ensureForTurn reports this branch only when its replacement send
 					// also never reached a live provider handle. That is positive evidence

--- a/apps/server/src/provider/provider-auth-failure.ts
+++ b/apps/server/src/provider/provider-auth-failure.ts
@@ -1,0 +1,8 @@
+/**
+ * Server-side source of truth for provider failures that are positively
+ * recoverable by refreshing authentication before another submission.
+ */
+export const isProviderAuthenticationRequired = (reason: string): boolean =>
+	/\b(?:authentication required|authorizationrequired|invalid authentication credentials|invalid api key)\b|please (?:run \/login|log ?in)|codex-auth-(?:reconnect-required|reconnecting)|refresh token (?:was already used|has expired|was revoked)|\b401 unauthorized\b/iu.test(
+		reason,
+	);

--- a/apps/server/src/voice/handlers.ts
+++ b/apps/server/src/voice/handlers.ts
@@ -3,7 +3,10 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Account } from "@zuse/agents/codex-generated/v2/Account";
 import type { GetAccountResponse } from "@zuse/agents/codex-generated/v2/GetAccountResponse";
-import { CodexAppServerClient } from "@zuse/agents/drivers/codex-app-server-client";
+import {
+	CodexAppServerClient,
+	getDefaultCodexExternalAuthTokens,
+} from "@zuse/agents/drivers/codex-app-server-client";
 import {
 	MemoizeRpcs,
 	VoiceFallbackTicketError,
@@ -66,6 +69,13 @@ const readAccountAuth = async (): Promise<AccountAuth> => {
 };
 
 const refreshCompatibleAccount = async (): Promise<AccountAuth> => {
+	const external = await getDefaultCodexExternalAuthTokens("proactive");
+	if (external !== null) {
+		return {
+			token: external.accessToken,
+			accountId: external.chatgptAccountId,
+		};
+	}
 	let client: CodexAppServerClient | null = null;
 	try {
 		client = await CodexAppServerClient.start({

--- a/apps/server/test/unit/cloud-codex-auth.test.ts
+++ b/apps/server/test/unit/cloud-codex-auth.test.ts
@@ -1,0 +1,177 @@
+import { randomBytes } from "node:crypto";
+import { type CodexGrantRequest, SealedCodexGrant } from "@zuse/contracts";
+import {
+	type CryptoKey,
+	calculateJwkThumbprint,
+	exportJWK,
+	generateKeyPair,
+	type JWK,
+} from "jose";
+import { describe, expect, test } from "vitest";
+import { CloudCodexAuth } from "../../src/api/cloud-codex-auth.ts";
+
+const base64url = (value: Uint8Array): string =>
+	Buffer.from(value).toString("base64url");
+
+const seal = async (input: {
+	readonly request: CodexGrantRequest;
+	readonly publicKey: CryptoKey;
+	readonly keyThumbprint: string;
+	readonly workspaceId?: string;
+}): Promise<SealedCodexGrant> => {
+	const authorityIncarnationId = "authority-storage-1";
+	const authorityEpoch = 3;
+	const aad = new TextEncoder().encode(
+		JSON.stringify({
+			protocolVersion: 1,
+			requestId: input.request.requestId,
+			keyThumbprint: input.keyThumbprint,
+			authorityIncarnationId,
+			authorityEpoch,
+		}),
+	);
+	const rawKey = randomBytes(32);
+	const iv = randomBytes(12);
+	const contentKey = await crypto.subtle.importKey(
+		"raw",
+		rawKey,
+		{ name: "AES-GCM" },
+		false,
+		["encrypt"],
+	);
+	const plaintext = new TextEncoder().encode(
+		JSON.stringify({
+			zuseAccountId: "account-1",
+			workspaceId: input.workspaceId ?? "workspace-1",
+			runtimeGeneration: 4,
+			keyThumbprint: input.keyThumbprint,
+			authorityIncarnationId,
+			authorityEpoch,
+			chatgptAccountId: "chatgpt-account-1",
+			chatgptPlanType: "pro",
+			issuedAt: Date.now(),
+			expiresAt: Date.now() + 60 * 60_000,
+			accessToken: "access-only-token",
+		}),
+	);
+	const encrypted = new Uint8Array(
+		await crypto.subtle.encrypt(
+			{ name: "AES-GCM", iv, additionalData: aad, tagLength: 128 },
+			contentKey,
+			plaintext,
+		),
+	);
+	return new SealedCodexGrant({
+		protocolVersion: 1,
+		requestId: input.request.requestId,
+		keyThumbprint: input.keyThumbprint,
+		authorityIncarnationId,
+		authorityEpoch,
+		wrappedKey: base64url(
+			new Uint8Array(
+				await crypto.subtle.encrypt(
+					{ name: "RSA-OAEP" },
+					input.publicKey,
+					rawKey,
+				),
+			),
+		),
+		iv: base64url(iv),
+		ciphertext: base64url(encrypted.slice(0, -16)),
+		tag: base64url(encrypted.slice(-16)),
+	});
+};
+
+const fixture = async () => {
+	const pair = await generateKeyPair("RSA-OAEP-256", { extractable: true });
+	const publicJwk = await exportJWK(pair.publicKey);
+	const credentialPublicJwk = JSON.stringify(publicJwk);
+	const keyThumbprint = await calculateJwkThumbprint(publicJwk as JWK);
+	return { pair, credentialPublicJwk, keyThumbprint };
+};
+
+describe("CloudCodexAuth", () => {
+	test("decrypts fenced grants and single-flights concurrent refreshes", async () => {
+		const { pair, credentialPublicJwk, keyThumbprint } = await fixture();
+		let issueCount = 0;
+		const recoveredConsumers: ReadonlyArray<string>[] = [];
+		const auth = new CloudCodexAuth({
+			zuseAccountId: "account-1",
+			workspaceId: "workspace-1",
+			runtimeGeneration: 4,
+			credentialPublicJwk,
+			credentialPrivateKey: pair.privateKey,
+			issueGrant: async (request) => {
+				issueCount += 1;
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				return seal({ request, publicKey: pair.publicKey, keyThumbprint });
+			},
+			onConsumersRecovered: (consumerIds) =>
+				recoveredConsumers.push(consumerIds),
+		});
+		auth.onDeliveryFailure({
+			consumerId: "session-1",
+			reason: "codex-auth-reconnect-required",
+		});
+
+		const [left, right] = await Promise.all([
+			auth.getTokens({ reason: "unauthorized" }),
+			auth.getTokens({ reason: "unauthorized" }),
+		]);
+
+		expect(issueCount).toBe(1);
+		expect(left).toEqual(right);
+		expect(left).toMatchObject({
+			accessToken: "access-only-token",
+			chatgptAccountId: "chatgpt-account-1",
+			chatgptPlanType: "pro",
+		});
+		expect(recoveredConsumers).toEqual([["session-1"]]);
+		auth.close();
+	});
+
+	test("rejects a grant sealed for another workspace", async () => {
+		const { pair, credentialPublicJwk, keyThumbprint } = await fixture();
+		const auth = new CloudCodexAuth({
+			zuseAccountId: "account-1",
+			workspaceId: "workspace-1",
+			runtimeGeneration: 4,
+			credentialPublicJwk,
+			credentialPrivateKey: pair.privateKey,
+			issueGrant: (request) =>
+				seal({
+					request,
+					publicKey: pair.publicKey,
+					keyThumbprint,
+					workspaceId: "workspace-2",
+				}),
+		});
+
+		await expect(auth.initialize()).rejects.toThrow(
+			"codex-auth-update-required",
+		);
+		auth.close();
+	});
+
+	test("preserves typed control-plane reconnect status", async () => {
+		const { pair, credentialPublicJwk } = await fixture();
+		const statuses: string[] = [];
+		const failure = { reason: "codex-auth-reconnect-required" };
+		const auth = new CloudCodexAuth({
+			zuseAccountId: "account-1",
+			workspaceId: "workspace-1",
+			runtimeGeneration: 4,
+			credentialPublicJwk,
+			credentialPrivateKey: pair.privateKey,
+			issueGrant: async () => Promise.reject(failure),
+			onStatus: (status) => statuses.push(status),
+		});
+
+		await expect(auth.initialize()).rejects.toBe(failure);
+		expect(statuses).toEqual([
+			"codex-auth-reconnecting",
+			"codex-auth-reconnect-required",
+		]);
+		auth.close();
+	});
+});

--- a/apps/server/test/unit/cloud-runtime-assets.test.ts
+++ b/apps/server/test/unit/cloud-runtime-assets.test.ts
@@ -37,6 +37,20 @@ describe("cloud runtime assets", () => {
 		expect(builder).not.toContain("ZUSE_REPOSITORY_URL");
 	});
 
+	test("keeps rotating Codex login out of broker-capable account images", async () => {
+		const builder = await readWorkspaceFile(
+			"infra/cloud-sandboxes/project-builder.sh",
+		);
+		const reconciler = await readWorkspaceFile(
+			"infra/api/src/cloud-workspace-reconciler.ts",
+		);
+		expect(builder).toContain("rm -f /home/zuse/.codex/auth.json");
+		expect(builder).toContain("ZUSE_CODEX_AUTH_DELIVERY_VERSION");
+		expect(builder).toContain("codexAuthDeliveryVersion");
+		expect(reconciler).toContain('"/home/zuse/.codex/auth.json"');
+		expect(reconciler).toContain("Codex auth delivery capability mismatch");
+	});
+
 	test("uses the image checkout directly without launch-time Git networking", async () => {
 		const bootstrap = await readWorkspaceFile(
 			"infra/cloud-sandboxes/workspace-bootstrap.sh",

--- a/apps/server/test/unit/provider-auth-failure.test.ts
+++ b/apps/server/test/unit/provider-auth-failure.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { isProviderAuthenticationRequired } from "../../src/provider/provider-auth-failure.ts";
+
+describe("provider auth failure classification", () => {
+	test.each([
+		"Authentication required",
+		"Auth(AuthorizationRequired)",
+		"codex-auth-reconnect-required",
+		"Your refresh token was already used",
+		"401 Unauthorized",
+		"Invalid authentication credentials",
+		"Please run /login",
+	])("recognizes %s as recoverable before another submission", (reason) => {
+		expect(isProviderAuthenticationRequired(reason)).toBe(true);
+	});
+
+	test("does not classify an uncertain provider failure as authentication", () => {
+		expect(
+			isProviderAuthenticationRequired(
+				"socket closed after request submission",
+			),
+		).toBe(false);
+	});
+});

--- a/docs/adr/0001-e2b-cloud-workspace-auth.md
+++ b/docs/adr/0001-e2b-cloud-workspace-auth.md
@@ -29,28 +29,37 @@ added projects.
    Promotion is atomic. Old snapshots and unclaimed pool sandboxes are deleted;
    already-running chats continue independently.
 4. Local Mac and persistent-machine authentication are unrelated and are never
-   inspected or imported. Codex and Grok device login run in the E2B setup
-   environment. Claude setup tokens/API keys and Cursor API keys are sealed to
-   that environment. A successful real CLI status check is required before the
-   state is included in the account image.
-5. Provider-owned subscription state and the restricted account-image secret
-   store may be present in this private snapshot. Provider CLIs own refresh in
-   each fork. Zuse does not synchronize refresh files between chats. Terminal
-   authentication failure marks the image/provider `auth-broken` and directs
-   the user to rebuild; it does not log out WorkOS or reconnect the sandbox.
-6. GitHub is the exception: users install the Zuse GitHub App and grant selected
+   inspected or imported. Codex and Grok device login run in the account-owned
+   E2B authentication authority. Claude setup tokens/API keys and Cursor API
+   keys are sealed to that environment. A successful managed-account read is
+   required for Codex subscription authentication; `codex login status` alone
+   is not considered proof that the token can be used.
+5. The authentication authority is the sole owner of a Codex subscription
+   refresh token. Broker-capable account images prove that `.codex/auth.json`
+   is absent before promotion. A workspace receives only a short-lived access
+   token sealed directly to its runtime key and supplies it to Codex in memory
+   through app-server external authentication. API routes only ciphertext.
+   Refresh is serialized in the authority, and account-image freshness ignores
+   brokered Codex rotation. Codex API-key/custom modes and other providers keep
+   their existing private-image behavior.
+6. Existing workspaces retain their immutable `legacy-image` authentication
+   mode. New subscription-backed workspaces opt into `broker-v1` only from an
+   image advertising `codexAuthDeliveryVersion: 1`. Lost authority storage
+   requires one account-level reconnect; it never triggers per-chat login or a
+   silent migration.
+7. GitHub is the exception: users install the Zuse GitHub App and grant selected
    repositories. Relay retains only installation metadata and mints short-lived
    installation access tokens when needed. These tokens are never baked into
    the image. Image builds receive a transient `GIT_ASKPASS` grant for checkout
    synchronization. The main image permanently preconfigures Git and `gh` with
    a credential broker; chat sandboxes lazily mint and cache a short-lived grant
    only when a GitHub command runs, then refresh it on demand.
-7. Normal create/resume has a p95 target below five seconds from user action to
+8. Normal create/resume has a p95 target below five seconds from user action to
    gateway connected and repository ready. Agent startup and explicit image
    builds are outside that setup SLO. Phase timestamps are retained for pool
    claim/fork, runtime connection, repository readiness, agent start, and first
    message acceptance.
-8. Relay placement follows the regional control-plane database. Cloud workspace
+9. Relay placement follows the regional control-plane database. Cloud workspace
    lifecycle requests contain several ordered writes, so running the Worker near
    users or E2B while Postgres is remote compounds network latency. Staging pins
    Relay to the database's AWS Singapore region; each deployment must configure
@@ -62,8 +71,9 @@ added projects.
   account image outdated and requires one update, not another project image.
 - Repository freshness is controlled by image update. There is intentionally no
   slow clone/fetch fallback when a repository is absent from the active image.
-- Credential duplication can eventually invalidate provider-native state. The
-  supported recovery is an explicit clean rebuild with a clear explanation.
+- Provider-native credentials other than brokered Codex subscription auth can
+  still become stale in retained legacy images. Brokered Codex recovery is one
+  account reconnect; a legacy chat offers creation of a replacement chat.
 - During atomic replacement a candidate snapshot may coexist briefly with the
   active snapshot. This is not a second maintained user image.
 

--- a/docs/cloud/architecture.md
+++ b/docs/cloud/architecture.md
@@ -13,6 +13,7 @@ desktop / mobile
 API Worker ---- Postgres (catalog, lifecycle, receipts, billing metadata)
 	|       |
 	|       +---- R2 (encrypted read-only transcript projections)
+	|       +---- account CloudAuthAuthority (sole Codex refresh owner)
 	|
 	+---- WorkspaceMailbox Durable Object (encrypted command coordination)
 	|                       |
@@ -50,6 +51,7 @@ idempotent command path and API removes it only after receipt.
 | --- | --- | --- |
 | ClientBus | Qualified cached projections, resource leases, command outbox, one connection supervisor per environment | Server authority, feature-specific sockets, inferred active environment |
 | API Worker | WorkOS auth, beta authorization, lifecycle, catalog, tickets, checkpoint metadata, billing | Normal transcript content, file state, terminal output |
+| CloudAuthAuthority | Account-level Codex refresh token, serialized managed refresh, access-grant sealing | Workspace session state, per-chat credential copies |
 | Postgres | Control-plane records, command receipts, lifecycle revisions, immutable billing ledger | Writable chat projection |
 | WorkspaceGateway Durable Object | Authenticated live attachments and opaque frame forwarding | Replay log, transcript, pending command buffer |
 | WorkspaceMailbox Durable Object | Encrypted command envelopes, ordering, leases, lifecycle status, encrypted terminal results | Command plaintext, transcript projection, provider state |

--- a/docs/cloud/security.md
+++ b/docs/cloud/security.md
@@ -63,6 +63,14 @@ data key; decryption and authoritative application happen in the runtime.
 
 - Repository and agent credentials are encrypted in the cloud credential vault
   and delivered only to the authenticated workspace runtime.
+- One account-scoped `CloudAuthAuthority` owns the Codex subscription refresh
+  token. It serializes managed refresh, then hybrid-encrypts an access-only
+  grant directly to the workspace runtime's enrolled RSA key. API and Durable
+  Objects never receive either plaintext token.
+- Broker-capable account images are rejected if `.codex/auth.json` exists.
+  Runtime access grants are memory-only, generation/key/account fenced, and
+  supplied through Codex app-server external authentication. Existing
+  `legacy-image` workspaces are never silently migrated.
 - The base template and prepared project snapshots are credential-free.
 - Project snapshot sanitation removes repository tokens, agent credentials,
   runtime identity, authorized keys, and shell history.

--- a/infra/api/drizzle/migrations/0017_cloud_codex_auth_broker.sql
+++ b/infra/api/drizzle/migrations/0017_cloud_codex_auth_broker.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "api_cloud_auth_authorities" (
+	"account_id" text PRIMARY KEY NOT NULL,
+	"provider" text NOT NULL,
+	"provider_sandbox_id" text,
+	"storage_incarnation_id" text NOT NULL,
+	"auth_epoch" bigint DEFAULT 1 NOT NULL,
+	"toolchain_version" text NOT NULL,
+	"state" text NOT NULL,
+	"provisioning_lease_owner" text,
+	"provisioning_lease_expires_at" bigint,
+	"revision" bigint DEFAULT 0 NOT NULL,
+	"created_at" bigint NOT NULL,
+	"updated_at" bigint NOT NULL,
+	CONSTRAINT "api_cloud_auth_authorities_state_check" CHECK ("api_cloud_auth_authorities"."state" IN ('provisioning', 'ready', 'error'))
+);
+--> statement-breakpoint
+CREATE INDEX "api_cloud_auth_authorities_state_idx" ON "api_cloud_auth_authorities" USING btree ("state", "provisioning_lease_expires_at");

--- a/infra/api/drizzle/migrations/meta/_journal.json
+++ b/infra/api/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
 			"when": 1787860800000,
 			"tag": "0016_api_naming",
 			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1788523200000,
+			"tag": "0017_cloud_codex_auth_broker",
+			"breakpoints": true
 		}
 	]
 }

--- a/infra/api/drizzle/schema.ts
+++ b/infra/api/drizzle/schema.ts
@@ -316,6 +316,40 @@ export const apiCloudGithubInstallations = pgTable(
 	],
 );
 
+/**
+ * Stable account-level provider authority locator. Its identity deliberately
+ * excludes the mutable sandbox template version.
+ */
+export const apiCloudAuthAuthorities = pgTable(
+	"api_cloud_auth_authorities",
+	{
+		accountId: text("account_id").primaryKey(),
+		provider: text("provider").notNull(),
+		providerSandboxId: text("provider_sandbox_id"),
+		storageIncarnationId: text("storage_incarnation_id").notNull(),
+		authEpoch: bigint("auth_epoch", { mode: "number" }).notNull().default(1),
+		toolchainVersion: text("toolchain_version").notNull(),
+		state: text("state").notNull(),
+		provisioningLeaseOwner: text("provisioning_lease_owner"),
+		provisioningLeaseExpiresAt: bigint("provisioning_lease_expires_at", {
+			mode: "number",
+		}),
+		revision: bigint("revision", { mode: "number" }).notNull().default(0),
+		createdAt: bigint("created_at", { mode: "number" }).notNull(),
+		updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
+	},
+	(table) => [
+		index("api_cloud_auth_authorities_state_idx").on(
+			table.state,
+			table.provisioningLeaseExpiresAt,
+		),
+		check(
+			"api_cloud_auth_authorities_state_check",
+			sql`${table.state} IN ('provisioning', 'ready', 'error')`,
+		),
+	],
+);
+
 export const apiCloudProjectBuilds = pgTable(
 	"api_cloud_project_builds",
 	{

--- a/infra/api/src/cloud-auth-authority.ts
+++ b/infra/api/src/cloud-auth-authority.ts
@@ -4,13 +4,16 @@ import {
 	type CloudAuthProvider,
 	CloudAuthProviderStatus,
 	CloudAuthStatus,
+	CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION,
+	type CodexGrantRefreshReason,
+	SealedCodexGrant,
 } from "@zuse/contracts";
 import {
 	type SandboxProviderAdapter,
 	SandboxProviders,
 } from "@zuse/sandbox-providers";
 import { Effect, Schedule } from "effect";
-
+import { CloudWorkspaceStore } from "./cloud-workspace-store.ts";
 import { ApiConfiguration } from "./config.ts";
 import { sha256Hex } from "./crypto.ts";
 import { badRequest, serviceUnavailable } from "./errors.ts";
@@ -18,13 +21,17 @@ import { badRequest, serviceUnavailable } from "./errors.ts";
 const AUTH_HOME = "/home/zuse/.zuse/cloud-auth";
 const AUTH_PUBLIC_JWK = `${AUTH_HOME}/public.jwk.json`;
 const AUTH_KEY_ID = `${AUTH_HOME}/key-id`;
+const AUTH_STORAGE_INCARNATION_ID = `${AUTH_HOME}/storage-incarnation-id`;
+const AUTH_CODEX_TOOLCHAIN_VERSION = `${AUTH_HOME}/codex-toolchain-version`;
 const AUTH_BOOTSTRAP_HOME = `${AUTH_HOME}/bootstrap`;
 const AUTH_INITIALIZER = `${AUTH_BOOTSTRAP_HOME}/initialize.mjs`;
 const AUTH_CONFIGURATOR = `${AUTH_BOOTSTRAP_HOME}/configure.mjs`;
 const AUTH_LOGIN = `${AUTH_BOOTSTRAP_HOME}/login.mjs`;
 const AUTH_CANCEL = `${AUTH_BOOTSTRAP_HOME}/cancel.mjs`;
 const AUTH_VERIFY = `${AUTH_BOOTSTRAP_HOME}/verify.mjs`;
+const AUTH_CODEX_GRANT = `${AUTH_BOOTSTRAP_HOME}/codex-grant.mjs`;
 const AUTH_TIMEOUT_SECONDS = 60 * 60;
+const AUTH_PROVISIONING_LEASE_MS = 2 * 60 * 1000;
 const PROVIDERS = ["claude", "codex", "cursor", "grok"] as const;
 const AUTH_STARTUP_RETRY = Schedule.addDelay(Schedule.recurs(20), () =>
 	Effect.succeed("250 millis"),
@@ -66,11 +73,13 @@ export const parseDeviceLoginOutput = (
 	};
 };
 
-const INITIALIZER_SOURCE = `import { createHash, generateKeyPairSync } from "node:crypto";
+const INITIALIZER_SOURCE = `import { spawnSync } from "node:child_process";
+import { createHash, generateKeyPairSync, randomBytes, randomUUID } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 const home = "/home/zuse/.zuse/cloud-auth";
 mkdirSync(home, { recursive: true, mode: 0o700 });
 mkdirSync(home + "/operations", { recursive: true, mode: 0o700 });
+mkdirSync(home + "/grant-cache", { recursive: true, mode: 0o700 });
 mkdirSync(home + "/providers", { recursive: true, mode: 0o700 });
 mkdirSync(home + "/status", { recursive: true, mode: 0o700 });
 chmodSync(home, 0o700);
@@ -86,6 +95,10 @@ if (!existsSync(privatePath) || !existsSync(publicPath)) {
 const publicJwk = JSON.parse(await import("node:fs/promises").then((fs) => fs.readFile(publicPath, "utf8")));
 const keyId = createHash("sha256").update(JSON.stringify(publicJwk)).digest("base64url");
 writeFileSync(home + "/key-id", keyId, { mode: 0o644 });
+if (!existsSync(home + "/storage-incarnation-id")) writeFileSync(home + "/storage-incarnation-id", randomUUID(), { mode: 0o600 });
+if (!existsSync(home + "/grant-fingerprint.key")) writeFileSync(home + "/grant-fingerprint.key", randomBytes(32).toString("base64url"), { mode: 0o600 });
+const codexVersion = spawnSync("codex", ["--version"], { encoding: "utf8" });
+writeFileSync(home + "/codex-toolchain-version", codexVersion.status === 0 ? codexVersion.stdout.trim() : "unavailable", { mode: 0o600 });
 `;
 
 const CONFIGURATOR_SOURCE = String.raw`import { constants, privateDecrypt } from "node:crypto";
@@ -178,6 +191,7 @@ await writeFile(path, JSON.stringify({ providerId: current.providerId, state: "c
 
 const VERIFY_SOURCE = `import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import readline from "node:readline";
 const home = "/home/zuse/.zuse/cloud-auth";
 const markerPath = process.argv[2];
 const providers = ["claude", "codex", "cursor", "grok"];
@@ -193,12 +207,35 @@ const verify = async (providerId) => {
     if (providerId === "cursor") env.CURSOR_API_KEY = credential.secret;
     if (providerId === "grok") { env.XAI_API_KEY = credential.secret; env.GROK_CODE_XAI_API_KEY = credential.secret; }
   }
-  const result = await new Promise((resolve) => {
+  const runStatus = () => new Promise((resolve) => {
     const child = spawn(command, args, { env, stdio: ["ignore", "ignore", "ignore"] });
     const timer = setTimeout(() => child.kill("SIGTERM"), 30000);
     child.once("error", (error) => { clearTimeout(timer); resolve({ code: 127, error: error.code === "ENOENT" ? "missing-tool" : "verification-failed" }); });
     child.once("exit", (code) => { clearTimeout(timer); resolve({ code: code ?? 1 }); });
   });
+  const readManagedCodexAccount = () => new Promise((resolve) => {
+    const child = spawn("codex", ["app-server", "--listen", "stdio://"], { stdio: ["pipe", "pipe", "ignore"] });
+    const lines = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+    let phase = "initialize";
+    let settled = false;
+    const finish = (result) => { if (settled) return; settled = true; clearTimeout(timer); lines.close(); child.kill("SIGTERM"); resolve(result); };
+    const timer = setTimeout(() => finish({ code: 1, error: "verification-timeout" }), 30000);
+    child.once("error", (error) => finish({ code: 127, error: error.code === "ENOENT" ? "missing-tool" : "verification-failed" }));
+    child.once("exit", (code) => { if (!settled && code !== 0) finish({ code: code ?? 1, error: "verification-failed" }); });
+    lines.on("line", (line) => {
+      let message;
+      try { message = JSON.parse(line); } catch { return; }
+      if (phase === "initialize" && message.id === 1) {
+        if (message.error !== undefined) return finish({ code: 1, error: "verification-failed" });
+        phase = "account";
+        child.stdin.write(JSON.stringify({ id: 2, method: "account/read", params: { refreshToken: false } }) + "\\n");
+      } else if (phase === "account" && message.id === 2) {
+        finish(message.error === undefined && message.result?.account?.type === "chatgpt" ? { code: 0 } : { code: 1, error: "managed-auth-unavailable" });
+      }
+    });
+    child.stdin.write(JSON.stringify({ id: 1, method: "initialize", params: { clientInfo: { name: "zuse-cloud-auth", version: "1" }, capabilities: { experimentalApi: true } } }) + "\\n");
+  });
+  const result = providerId === "codex" && credential.native === true ? await readManagedCodexAccount() : await runStatus();
   const state = result.code === 0 ? "connected" : result.error === "missing-tool" ? "missing-tool" : "expired";
   await writeFile(home + "/status/" + providerId + ".json", JSON.stringify({ providerId, method: credential.method, native: credential.native === true, state, verifiedAt: result.code === 0 ? credential.updatedAt ?? Date.now() : undefined, errorCode: result.code === 0 ? undefined : result.error ?? "verification-failed" }), { mode: 0o600 });
 };
@@ -207,13 +244,136 @@ await Promise.all(providers.map(verify));
 await writeFile(markerPath, "ready", { mode: 0o600 });
 `;
 
+export const CODEX_GRANT_SOURCE = String.raw`import { createCipheriv, createHmac, createPublicKey, constants, publicEncrypt, randomBytes } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import readline from "node:readline";
+const home = process.env.ZUSE_CLOUD_AUTH_HOME ?? "/home/zuse/.zuse/cloud-auth";
+const codexAuthFile = process.env.ZUSE_CODEX_AUTH_FILE ?? "/home/zuse/.codex/auth.json";
+const requestPath = process.argv[2];
+const resultPath = process.argv[3];
+const cachePath = process.argv[4];
+const input = JSON.parse(await readFile(requestPath, "utf8"));
+const writeResult = (value) => writeFile(resultPath, JSON.stringify(value), { mode: 0o600 });
+const requiredStrings = ["requestId", "accountId", "workspaceId", "credentialPublicJwk", "keyThumbprint", "authorityIncarnationId"];
+if (input.protocolVersion !== 1 || !Number.isSafeInteger(input.runtimeGeneration) || requiredStrings.some((key) => typeof input[key] !== "string" || input[key].length === 0)) {
+  await writeResult({ errorCode: "codex-auth-update-required" });
+  process.exit(0);
+}
+const incarnation = (await readFile(home + "/storage-incarnation-id", "utf8")).trim();
+if (incarnation !== input.authorityIncarnationId) {
+  await writeResult({ errorCode: "codex-auth-reconnect-required" });
+  process.exit(0);
+}
+const fingerprintKey = Buffer.from((await readFile(home + "/grant-fingerprint.key", "utf8")).trim(), "base64url");
+const fingerprintPayload = JSON.stringify({ protocolVersion: input.protocolVersion, requestId: input.requestId, accountId: input.accountId, workspaceId: input.workspaceId, runtimeGeneration: input.runtimeGeneration, credentialPublicJwk: input.credentialPublicJwk, keyThumbprint: input.keyThumbprint, reason: input.reason, previousChatgptAccountId: input.previousChatgptAccountId ?? null, authorityIncarnationId: input.authorityIncarnationId, authorityEpoch: input.authorityEpoch });
+const fingerprint = createHmac("sha256", fingerprintKey).update(fingerprintPayload).digest("base64url");
+try {
+  const cached = JSON.parse(await readFile(cachePath, "utf8"));
+  if (cached.fingerprint !== fingerprint) await writeResult({ errorCode: "codex_grant_request_id_reused" });
+  else await writeResult(cached);
+  process.exit(0);
+} catch {}
+const record = (value) => typeof value === "object" && value !== null ? value : {};
+const string = (value) => typeof value === "string" && value.length > 0 ? value : null;
+const decodeJwt = (token) => {
+  try { return record(JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString("utf8"))); } catch { return {}; }
+};
+const readManagedAuth = async () => {
+  const root = record(JSON.parse(await readFile(codexAuthFile, "utf8")));
+  const tokens = record(root.tokens);
+  const accessToken = string(tokens.access_token) ?? string(tokens.accessToken);
+  const refreshToken = string(tokens.refresh_token) ?? string(tokens.refreshToken);
+  if (accessToken === null || refreshToken === null) throw new Error("managed_auth_unavailable");
+  const accessClaims = decodeJwt(accessToken);
+  const idClaims = string(tokens.id_token) === null ? {} : decodeJwt(tokens.id_token);
+  const accessAuth = record(accessClaims["https://api.openai.com/auth"]);
+  const idAuth = record(idClaims["https://api.openai.com/auth"]);
+  const chatgptAccountId = string(tokens.account_id) ?? string(tokens.accountId) ?? string(accessAuth.chatgpt_account_id) ?? string(idAuth.chatgpt_account_id);
+  if (chatgptAccountId === null) throw new Error("managed_account_unavailable");
+  const chatgptPlanType = string(accessAuth.chatgpt_plan_type) ?? string(idAuth.chatgpt_plan_type);
+  const expiresAt = typeof accessClaims.exp === "number" ? accessClaims.exp * 1000 : 0;
+  return { accessToken, chatgptAccountId, chatgptPlanType, expiresAt };
+};
+const refreshManagedAuth = () => new Promise((resolve, reject) => {
+  const child = spawn("codex", ["app-server", "--listen", "stdio://"], { stdio: ["pipe", "pipe", "ignore"] });
+  const lines = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let phase = "initialize";
+  let settled = false;
+  let timer;
+  const finish = (error) => { if (settled) return; settled = true; clearTimeout(timer); lines.close(); child.kill("SIGTERM"); error === null ? resolve() : reject(error); };
+  timer = setTimeout(() => finish(new Error("refresh_timeout")), 8000);
+  child.once("error", finish);
+  child.once("exit", (code) => { if (code !== 0) finish(new Error("refresh_failed")); });
+  lines.on("line", (line) => {
+    let message;
+    try { message = JSON.parse(line); } catch { return; }
+    if (phase === "initialize" && message.id === 1) {
+      if (message.error !== undefined) return finish(new Error("refresh_initialize_failed"));
+      phase = "account";
+      child.stdin.write(JSON.stringify({ id: 2, method: "account/read", params: { refreshToken: true } }) + "\n");
+      return;
+    }
+    if (phase === "account" && message.id === 2) {
+      if (message.error !== undefined || message.result?.account?.type !== "chatgpt") return finish(new Error("managed_auth_unavailable"));
+      finish(null);
+    }
+  });
+  child.stdin.write(JSON.stringify({ id: 1, method: "initialize", params: { clientInfo: { name: "zuse-cloud-auth", version: "1" }, capabilities: { experimentalApi: true } } }) + "\n");
+});
+let auth;
+try {
+  auth = await readManagedAuth();
+  if (input.reason === "unauthorized" || auth.expiresAt <= Date.now() + 5 * 60 * 1000) {
+    await refreshManagedAuth();
+    auth = await readManagedAuth();
+  }
+} catch {
+  await writeResult({ errorCode: "codex-auth-reconnect-required" });
+  process.exit(0);
+}
+if (auth.expiresAt <= Date.now() + 60 * 1000 || (input.previousChatgptAccountId && input.previousChatgptAccountId !== auth.chatgptAccountId)) {
+  await writeResult({ errorCode: "codex-auth-reconnect-required" });
+  process.exit(0);
+}
+const publicJwk = JSON.parse(input.credentialPublicJwk);
+const key = createPublicKey({ key: publicJwk, format: "jwk" });
+const issuedAt = Date.now();
+const expiresAt = auth.expiresAt;
+const aadObject = { protocolVersion: 1, requestId: input.requestId, keyThumbprint: input.keyThumbprint, authorityIncarnationId: incarnation, authorityEpoch: input.authorityEpoch };
+const aad = Buffer.from(JSON.stringify(aadObject));
+const plaintext = Buffer.from(JSON.stringify({ zuseAccountId: input.accountId, workspaceId: input.workspaceId, runtimeGeneration: input.runtimeGeneration, keyThumbprint: input.keyThumbprint, authorityIncarnationId: incarnation, authorityEpoch: input.authorityEpoch, chatgptAccountId: auth.chatgptAccountId, chatgptPlanType: auth.chatgptPlanType, issuedAt, expiresAt, accessToken: auth.accessToken }));
+const contentKey = randomBytes(32);
+const iv = randomBytes(12);
+const cipher = createCipheriv("aes-256-gcm", contentKey, iv);
+cipher.setAAD(aad);
+const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+const sealed = { ...aadObject, wrappedKey: publicEncrypt({ key, oaepHash: "sha256", padding: constants.RSA_PKCS1_OAEP_PADDING }, contentKey).toString("base64url"), iv: iv.toString("base64url"), ciphertext: ciphertext.toString("base64url"), tag: cipher.getAuthTag().toString("base64url") };
+const output = { fingerprint, sealed };
+await writeFile(cachePath, JSON.stringify(output), { mode: 0o600, flag: "wx" }).catch(async (error) => { if (error.code !== "EEXIST") throw error; });
+const committed = JSON.parse(await readFile(cachePath, "utf8"));
+if (committed.fingerprint !== fingerprint) await writeResult({ errorCode: "codex_grant_request_id_reused" });
+else await writeResult(committed);
+`;
+
 type Authority = {
 	readonly provider: SandboxProviderAdapter;
 	readonly sandboxId: string;
 	readonly state: "running" | "paused";
+	readonly storageIncarnationId: string;
+	readonly authEpoch: number;
 };
 
 export const cloudAuthAuthorityLabel = (input: {
+	readonly accountId: string;
+	readonly apiIssuer: string;
+}) =>
+	sha256Hex(
+		`cloud-auth-authority-v3:${input.apiIssuer}:${input.accountId}`,
+	).pipe(Effect.map((digest) => `zuse-auth-${digest.slice(0, 32)}`));
+
+/** Previous label retained only for one-time authority adoption. */
+export const legacyCloudAuthAuthorityLabel = (input: {
 	readonly accountId: string;
 	readonly apiIssuer: string;
 	readonly templateVersion: string;
@@ -222,10 +382,22 @@ export const cloudAuthAuthorityLabel = (input: {
 		`cloud-auth-authority-v2:${input.apiIssuer}:${input.templateVersion}:${input.accountId}`,
 	).pipe(Effect.map((digest) => `zuse-auth-${digest.slice(0, 32)}`));
 
-const authorityLabel = (accountId: string, provider: SandboxProviderAdapter) =>
+const authorityLabel = (accountId: string) =>
 	Effect.gen(function* () {
 		const config = yield* ApiConfiguration;
 		return yield* cloudAuthAuthorityLabel({
+			accountId,
+			apiIssuer: config.apiIssuer,
+		});
+	});
+
+const legacyAuthorityLabel = (
+	accountId: string,
+	provider: SandboxProviderAdapter,
+) =>
+	Effect.gen(function* () {
+		const config = yield* ApiConfiguration;
+		return yield* legacyCloudAuthAuthorityLabel({
 			accountId,
 			apiIssuer: config.apiIssuer,
 			templateVersion: provider.templateVersion,
@@ -245,17 +417,75 @@ const recoverAuthority = Effect.fn("recoverCloudAuthAuthority")(function* (
 	accountId: string,
 ) {
 	const provider = yield* e2bProvider;
-	const label = yield* authorityLabel(accountId, provider);
-	const sandbox = yield* provider
-		.recoverByLabel(label)
-		.pipe(Effect.mapError(() => serviceUnavailable("cloud_auth_unavailable")));
-	return sandbox === null
-		? null
-		: ({
+	const store = yield* CloudWorkspaceStore;
+	const locator = yield* store.getCloudAuthAuthority(accountId);
+	if (locator?.providerSandboxId !== undefined) {
+		const sandbox = yield* provider
+			.inspect(locator.providerSandboxId)
+			.pipe(
+				Effect.mapError(() => serviceUnavailable("cloud_auth_unavailable")),
+			);
+		if (sandbox !== null)
+			return {
 				provider,
 				sandboxId: sandbox.providerSandboxId,
 				state: sandbox.state,
-			} satisfies Authority);
+				storageIncarnationId: locator.storageIncarnationId,
+				authEpoch: locator.authEpoch,
+			} satisfies Authority;
+		// A persisted locator is authoritative. Never guess after its storage is
+		// lost; the account must explicitly reconnect Codex.
+		return null;
+	}
+	const stable = yield* provider
+		.recoverByLabel(yield* authorityLabel(accountId))
+		.pipe(Effect.mapError(() => serviceUnavailable("cloud_auth_unavailable")));
+	const legacy =
+		stable === null
+			? yield* provider
+					.recoverByLabel(yield* legacyAuthorityLabel(accountId, provider))
+					.pipe(
+						Effect.mapError(() => serviceUnavailable("cloud_auth_unavailable")),
+					)
+			: null;
+	const sandbox = stable ?? legacy;
+	if (sandbox === null) return null;
+	const initialized = yield* initializeAuthority({
+		provider,
+		sandboxId: sandbox.providerSandboxId,
+		state: sandbox.state,
+		storageIncarnationId: crypto.randomUUID(),
+		authEpoch: 1,
+	});
+	const leaseOwner = crypto.randomUUID();
+	const nowMs = Date.now();
+	const claim = yield* store.claimCloudAuthAuthority({
+		accountId,
+		provider: provider.providerId,
+		candidateStorageIncarnationId: initialized.storageIncarnationId,
+		toolchainVersion: CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION,
+		leaseOwner,
+		nowMs,
+		leaseExpiresAtMs: nowMs + AUTH_PROVISIONING_LEASE_MS,
+	});
+	const record = claim.acquired
+		? yield* store.completeCloudAuthAuthorityProvisioning({
+				accountId,
+				providerSandboxId: sandbox.providerSandboxId,
+				storageIncarnationId: initialized.storageIncarnationId,
+				toolchainVersion: CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION,
+				leaseOwner,
+				nowMs: Date.now(),
+			})
+		: claim.record;
+	if (record?.providerSandboxId !== sandbox.providerSandboxId) return null;
+	return {
+		provider,
+		sandboxId: initialized.sandboxId,
+		state: initialized.state,
+		storageIncarnationId: record.storageIncarnationId,
+		authEpoch: record.authEpoch,
+	} satisfies Authority;
 });
 
 const readOptional = (
@@ -289,6 +519,7 @@ const initializeAuthority = Effect.fn("initializeCloudAuthAuthority")(
 				[AUTH_LOGIN, LOGIN_SOURCE],
 				[AUTH_CANCEL, CANCEL_SOURCE],
 				[AUTH_VERIFY, VERIFY_SOURCE],
+				[AUTH_CODEX_GRANT, CODEX_GRANT_SOURCE],
 			] as const,
 			([path, contents]) =>
 				authority.provider
@@ -328,7 +559,23 @@ const initializeAuthority = Effect.fn("initializeCloudAuthAuthority")(
 				),
 			);
 		yield* waitForFile(authority, AUTH_KEY_ID);
-		return authority;
+		const storageIncarnationId = yield* waitForFile(
+			authority,
+			AUTH_STORAGE_INCARNATION_ID,
+		);
+		const codexToolchainVersion = yield* waitForFile(
+			authority,
+			AUTH_CODEX_TOOLCHAIN_VERSION,
+		);
+		if (
+			!codexToolchainVersion
+				.split(/\s+/u)
+				.includes(CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION)
+		)
+			return yield* Effect.fail(
+				serviceUnavailable("codex-auth-update-required"),
+			);
+		return { ...authority, storageIncarnationId } satisfies Authority;
 	},
 );
 
@@ -344,38 +591,104 @@ const ensureRunning = Effect.fn("ensureCloudAuthAuthorityRunning")(function* (
 
 const provisionAuthority = Effect.fn("provisionCloudAuthAuthority")(function* (
 	accountId: string,
+	allowLostReplacement = false,
 ) {
 	const recovered = yield* recoverAuthority(accountId);
-	if (recovered !== null)
-		return yield* initializeAuthority(yield* ensureRunning(recovered));
-	const provider = yield* e2bProvider;
-	const label = yield* authorityLabel(accountId, provider);
-	const sandboxId = `auth_${(yield* sha256Hex(`${accountId}:${crypto.randomUUID()}`)).slice(0, 24)}`;
-	const created = yield* provider
-		.create({
-			sandboxId,
-			providerLabel: label,
-			metadata: { "zuse-purpose": "account-auth-authority" },
-			timeoutSeconds: AUTH_TIMEOUT_SECONDS,
-			env: {},
-			network: { kind: "open" },
-			onTimeout: "pause",
-		})
-		.pipe(
-			Effect.tapError((cause) =>
-				Effect.sync(() =>
-					console.warn("[cloud-auth] sandbox creation failed", {
-						providerCode: cause.code,
-					}),
-				),
-			),
-			Effect.mapError(() => serviceUnavailable("cloud_auth_provision_failed")),
+	if (recovered !== null) {
+		const initialized = yield* initializeAuthority(
+			yield* ensureRunning(recovered),
 		);
-	return yield* initializeAuthority({
+		if (initialized.storageIncarnationId === recovered.storageIncarnationId)
+			return initialized;
+		if (!allowLostReplacement)
+			return yield* Effect.fail(
+				serviceUnavailable("codex-auth-reconnect-required"),
+			);
+	}
+	const provider = yield* e2bProvider;
+	const store = yield* CloudWorkspaceStore;
+	const locator = yield* store.getCloudAuthAuthority(accountId);
+	const replacingLostAuthority = locator?.state === "ready";
+	if (replacingLostAuthority && !allowLostReplacement)
+		return yield* Effect.fail(
+			serviceUnavailable("codex-auth-reconnect-required"),
+		);
+	const leaseOwner = crypto.randomUUID();
+	const nowMs = Date.now();
+	const claim = yield* store.claimCloudAuthAuthority({
+		accountId,
+		provider: provider.providerId,
+		candidateStorageIncarnationId: crypto.randomUUID(),
+		toolchainVersion: CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION,
+		leaseOwner,
+		nowMs,
+		leaseExpiresAtMs: nowMs + AUTH_PROVISIONING_LEASE_MS,
+		replaceReady: replacingLostAuthority,
+	});
+	if (!claim.acquired) {
+		for (let attempt = 0; attempt < 40; attempt += 1) {
+			yield* Effect.sleep("250 millis");
+			const winner = yield* recoverAuthority(accountId);
+			if (winner !== null)
+				return yield* initializeAuthority(yield* ensureRunning(winner));
+		}
+		return yield* Effect.fail(
+			serviceUnavailable("cloud_auth_reconnect_required"),
+		);
+	}
+	const label = yield* authorityLabel(accountId);
+	const concurrent = yield* provider
+		.recoverByLabel(label)
+		.pipe(Effect.mapError(() => serviceUnavailable("cloud_auth_unavailable")));
+	const sandboxId = `auth_${(yield* sha256Hex(`${accountId}:${crypto.randomUUID()}`)).slice(0, 24)}`;
+	const created =
+		concurrent ??
+		(yield* provider
+			.create({
+				sandboxId,
+				providerLabel: label,
+				metadata: { "zuse-purpose": "account-auth-authority" },
+				timeoutSeconds: AUTH_TIMEOUT_SECONDS,
+				env: {},
+				network: { kind: "open" },
+				onTimeout: "pause",
+			})
+			.pipe(
+				Effect.tapError((cause) =>
+					Effect.sync(() =>
+						console.warn("[cloud-auth] sandbox creation failed", {
+							providerCode: cause.code,
+						}),
+					),
+				),
+				Effect.mapError(() =>
+					serviceUnavailable("cloud_auth_provision_failed"),
+				),
+			));
+	const initialized = yield* initializeAuthority({
 		provider,
 		sandboxId: created.providerSandboxId,
 		state: created.state,
+		storageIncarnationId: claim.record.storageIncarnationId,
+		authEpoch: claim.record.authEpoch,
 	});
+	const record = yield* store.completeCloudAuthAuthorityProvisioning({
+		accountId,
+		providerSandboxId: created.providerSandboxId,
+		storageIncarnationId: initialized.storageIncarnationId,
+		toolchainVersion: CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION,
+		leaseOwner,
+		nowMs: Date.now(),
+	});
+	if (record === null)
+		return yield* Effect.fail(
+			serviceUnavailable("cloud_auth_provision_conflict"),
+		);
+	return {
+		...initialized,
+		storageIncarnationId: record.storageIncarnationId,
+		authEpoch: record.authEpoch,
+	} satisfies Authority;
 });
 
 const decodeProviderStatus = (
@@ -436,6 +749,19 @@ const readCloudAuthStatus = Effect.fn("readCloudAuthStatus")(function* (
 		});
 	}
 	const authority = yield* initializeAuthority(yield* ensureRunning(recovered));
+	if (authority.storageIncarnationId !== recovered.storageIncarnationId)
+		return new CloudAuthStatus({
+			authorityState: "error",
+			providers: PROVIDERS.map(
+				(providerId) =>
+					new CloudAuthProviderStatus({
+						providerId,
+						state: "error",
+						errorCode: "codex-auth-reconnect-required",
+					}),
+			),
+			updatedAt: Date.now(),
+		});
 	if (verify) {
 		const verificationId = crypto.randomUUID();
 		const verificationMarker = `${AUTH_HOME}/operations/verify-${verificationId}.done`;
@@ -503,7 +829,9 @@ export const cloudAuthStatus = Effect.fn("cloudAuthStatus")(function* (
 export const provisionCloudAuth = Effect.fn("provisionCloudAuth")(function* (
 	accountId: string,
 ) {
-	yield* provisionAuthority(accountId);
+	// This RPC is an explicit account action, so it may replace a persisted
+	// authority locator only after the provider proves its storage is gone.
+	yield* provisionAuthority(accountId, true);
 	return yield* cloudAuthStatus(accountId);
 });
 
@@ -613,6 +941,13 @@ export const startCloudAuthLogin = Effect.fn("startCloudAuthLogin")(function* (
 	providerId: "codex" | "grok",
 ) {
 	const authority = yield* ensureRunning(yield* provisionAuthority(accountId));
+	if (providerId === "codex") {
+		yield* (yield* CloudWorkspaceStore).advanceCloudAuthEpoch({
+			accountId,
+			providerSandboxId: authority.sandboxId,
+			nowMs: Date.now(),
+		});
+	}
 	const operationId = crypto.randomUUID();
 	yield* authority.provider
 		.startProcess(authority.sandboxId, {
@@ -708,6 +1043,7 @@ if (credential?.native === true || providerId === "codex") await new Promise((re
   child.once("error", () => { clearTimeout(timer); resolve(); });
   child.once("exit", () => { clearTimeout(timer); resolve(); });
 });
+
 const imageSecretsPath = "/home/zuse/.zuse-image/provider-secrets.json";
 try {
   const imageSecrets = JSON.parse(await readFile(imageSecretsPath, "utf8"));
@@ -740,6 +1076,125 @@ await writeFile(${JSON.stringify(resultPath)}, "ready", { mode: 0o600 });`;
 	return new CloudAuthProviderStatus({ providerId, state: "disconnected" });
 });
 
+export interface IssueCodexGrantInput {
+	readonly accountId: string;
+	readonly workspaceId: string;
+	readonly runtimeGeneration: number;
+	readonly recipientPublicJwk: string;
+	readonly recipientKeyThumbprint: string;
+	readonly requestId: string;
+	readonly reason: CodexGrantRefreshReason;
+	readonly previousChatgptAccountId?: string;
+}
+
+/**
+ * The single account-level Codex token operation. The authority refreshes its
+ * native managed login under a process lock and seals an access-only grant
+ * directly to the enrolled runtime key. No plaintext token crosses this API.
+ */
+export const issueCodexGrant = Effect.fn("issueCodexGrant")(function* (
+	input: IssueCodexGrantInput,
+) {
+	if (
+		!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(
+			input.requestId,
+		) ||
+		input.recipientPublicJwk.length > 16_384 ||
+		(input.previousChatgptAccountId?.length ?? 0) > 256
+	)
+		return yield* Effect.fail(badRequest("invalid_codex_grant_request"));
+	const authority = yield* ensureRunning(
+		yield* provisionAuthority(input.accountId),
+	);
+	const operationId = crypto.randomUUID();
+	const requestPath = `${AUTH_HOME}/operations/codex-grant-${operationId}.request.json`;
+	const resultPath = `${AUTH_HOME}/operations/codex-grant-${operationId}.result.json`;
+	const cachePath = `${AUTH_HOME}/grant-cache/${input.requestId}.json`;
+	yield* authority.provider
+		.writeTextFile(
+			authority.sandboxId,
+			requestPath,
+			JSON.stringify({
+				protocolVersion: 1,
+				requestId: input.requestId,
+				accountId: input.accountId,
+				workspaceId: input.workspaceId,
+				runtimeGeneration: input.runtimeGeneration,
+				credentialPublicJwk: input.recipientPublicJwk,
+				keyThumbprint: input.recipientKeyThumbprint,
+				reason: input.reason,
+				...(input.previousChatgptAccountId === undefined
+					? {}
+					: { previousChatgptAccountId: input.previousChatgptAccountId }),
+				authorityIncarnationId: authority.storageIncarnationId,
+				authorityEpoch: authority.authEpoch,
+			}),
+			"zuse",
+		)
+		.pipe(Effect.mapError(() => serviceUnavailable("codex-auth-reconnecting")));
+	yield* authority.provider
+		.startProcess(authority.sandboxId, {
+			command: "flock",
+			args: [
+				"-x",
+				`${AUTH_HOME}/codex-refresh.lock`,
+				"node",
+				AUTH_CODEX_GRANT,
+				requestPath,
+				resultPath,
+				cachePath,
+			],
+			user: "zuse",
+			tag: `zuse-cloud-auth-codex-grant-${operationId}`,
+		})
+		.pipe(Effect.mapError(() => serviceUnavailable("codex-auth-reconnecting")));
+	const value = yield* waitForFile(authority, resultPath, 350);
+	let parsed: { readonly errorCode?: unknown; readonly sealed?: unknown };
+	try {
+		parsed = JSON.parse(value) as typeof parsed;
+	} catch {
+		return yield* Effect.fail(serviceUnavailable("codex_grant_invalid"));
+	}
+	if (typeof parsed.errorCode === "string")
+		return yield* Effect.fail(serviceUnavailable(parsed.errorCode));
+	const sealed = parsed.sealed as Record<string, unknown>;
+	const sealedString = (key: string, maxLength: number): string | null => {
+		const value = sealed?.[key];
+		return typeof value === "string" &&
+			value.length > 0 &&
+			value.length <= maxLength
+			? value
+			: null;
+	};
+	const wrappedKey = sealedString("wrappedKey", 8_192);
+	const iv = sealedString("iv", 128);
+	const ciphertext = sealedString("ciphertext", 32_768);
+	const tag = sealedString("tag", 128);
+	if (
+		sealed?.protocolVersion !== 1 ||
+		sealed.requestId !== input.requestId ||
+		sealed.keyThumbprint !== input.recipientKeyThumbprint ||
+		sealed.authorityIncarnationId !== authority.storageIncarnationId ||
+		sealed.authorityEpoch !== authority.authEpoch ||
+		wrappedKey === null ||
+		iv === null ||
+		ciphertext === null ||
+		tag === null
+	)
+		return yield* Effect.fail(serviceUnavailable("codex_grant_fence_mismatch"));
+	return new SealedCodexGrant({
+		protocolVersion: 1,
+		requestId: input.requestId,
+		keyThumbprint: input.recipientKeyThumbprint,
+		authorityIncarnationId: authority.storageIncarnationId,
+		authorityEpoch: authority.authEpoch,
+		wrappedKey,
+		iv,
+		ciphertext,
+		tag,
+	});
+});
+
 /**
  * Captures the provider-owned state created by official setup as the seed for
  * a clean private account image. The image builder removes authority keys and
@@ -759,4 +1214,7 @@ export const snapshotCloudAuthAuthority = Effect.fn(
 		);
 });
 
-export type CloudAuthAuthorityContext = SandboxProviders | ApiConfiguration;
+export type CloudAuthAuthorityContext =
+	| SandboxProviders
+	| ApiConfiguration
+	| CloudWorkspaceStore;

--- a/infra/api/src/cloud-workspace-reconciler.ts
+++ b/infra/api/src/cloud-workspace-reconciler.ts
@@ -210,6 +210,8 @@ export const snapshotSanitizationFailures = (input: {
 	readonly expectedTemplateVersion: string;
 	readonly configurationDigest: string;
 	readonly expectedConfigurationDigest: string;
+	readonly codexAuthDeliveryVersion?: number;
+	readonly expectedCodexAuthDeliveryVersion?: number;
 }): ReadonlyArray<string> => {
 	const failures = input.forbiddenPaths.filter(
 		(_path, index) => input.forbiddenResults[index] === true,
@@ -220,6 +222,8 @@ export const snapshotSanitizationFailures = (input: {
 		failures.push("runtime version mismatch");
 	if (input.configurationDigest !== input.expectedConfigurationDigest)
 		failures.push("configuration digest mismatch");
+	if (input.codexAuthDeliveryVersion !== input.expectedCodexAuthDeliveryVersion)
+		failures.push("Codex auth delivery capability mismatch");
 	return failures;
 };
 
@@ -668,6 +672,9 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudAccountImageBuild")(
 					env: {
 						ZUSE_TEMPLATE_VERSION: build.templateVersion,
 						ZUSE_CONFIGURATION_DIGEST: build.configurationDigest,
+						...(build.settings?.codexAuthDeliveryVersion === 1
+							? { ZUSE_CODEX_AUTH_DELIVERY_VERSION: "1" }
+							: {}),
 						ZUSE_REPOSITORY_CACHE_MAX_BYTES: String(
 							apiConfig.cloudRepositoryCacheMaxBytes,
 						),
@@ -794,6 +801,9 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudAccountImageBuild")(
 				"/home/zuse/.zuse-data",
 				"/home/zuse/.git-credentials",
 				"/home/zuse/.netrc",
+				...(build.settings?.codexAuthDeliveryVersion === 1
+					? ["/home/zuse/.codex/auth.json"]
+					: []),
 			];
 			const forbiddenResults = yield* Effect.forEach(forbiddenPaths, (path) =>
 				provider.pathExists(build.providerSandboxId as string, path, "zuse"),
@@ -813,6 +823,22 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudAccountImageBuild")(
 				"/var/lib/zuse/project-build/configuration-digest",
 				"zuse",
 			)).trim();
+			const manifest = yield* provider
+				.readTextFile(
+					build.providerSandboxId,
+					"/var/lib/zuse/account-image/manifest.json",
+					"zuse",
+				)
+				.pipe(
+					Effect.map((value) => {
+						try {
+							return JSON.parse(value) as Record<string, unknown>;
+						} catch {
+							return {};
+						}
+					}),
+					Effect.orElseSucceed(() => ({}) as Record<string, unknown>),
+				);
 			const sanitizationFailures = snapshotSanitizationFailures({
 				forbiddenPaths,
 				forbiddenResults,
@@ -821,6 +847,12 @@ const reconcileBuildRecord = Effect.fn("reconcileCloudAccountImageBuild")(
 				expectedTemplateVersion: build.templateVersion,
 				configurationDigest,
 				expectedConfigurationDigest: build.configurationDigest,
+				codexAuthDeliveryVersion:
+					typeof manifest.codexAuthDeliveryVersion === "number"
+						? manifest.codexAuthDeliveryVersion
+						: undefined,
+				expectedCodexAuthDeliveryVersion:
+					build.settings?.codexAuthDeliveryVersion === 1 ? 1 : undefined,
 			});
 			if (sanitizationFailures.length > 0) {
 				const sanitizationDiagnostic = `Snapshot validation failed: ${sanitizationFailures.join(", ")}.`;

--- a/infra/api/src/cloud-workspace-routes.ts
+++ b/infra/api/src/cloud-workspace-routes.ts
@@ -16,6 +16,7 @@ import {
 	CloudWorkspaceResumeRequest,
 	CloudWorkspaceRuntimeSummary,
 	CloudWorkspaceStartupTimings,
+	CodexGrantRequest,
 	DEFAULT_RUNTIME_MODE,
 	RuntimeAcknowledgment,
 	RuntimeMode,
@@ -33,6 +34,7 @@ import {
 	cloudAuthStatus,
 	configureCloudAuth,
 	disconnectCloudAuth,
+	issueCodexGrant,
 	pollCloudAuthLogin,
 	provisionCloudAuth,
 	startCloudAuthLogin,
@@ -458,7 +460,12 @@ export const isCloudAccountImageOutdated = (input: {
 		readonly state: string;
 		readonly updatedAtMs: number;
 	}>;
-	readonly providers: ReadonlyArray<{ readonly verifiedAt?: number }>;
+	readonly providers: ReadonlyArray<{
+		readonly providerId?: string;
+		readonly verifiedAt?: number;
+	}>;
+	readonly codexAuthDeliveryVersion?: 1;
+	readonly requiredCodexAuthDeliveryVersion?: 1;
 }) =>
 	input.projects.some(
 		(project) =>
@@ -467,10 +474,15 @@ export const isCloudAccountImageOutdated = (input: {
 	) ||
 	input.providers.some(
 		(status) =>
+			!(
+				input.codexAuthDeliveryVersion === 1 && status.providerId === "codex"
+			) &&
 			status.verifiedAt !== undefined &&
 			status.verifiedAt > input.imagePromotedAtMs,
 	) ||
-	input.imageTemplateVersion !== input.currentTemplateVersion;
+	input.imageTemplateVersion !== input.currentTemplateVersion ||
+	(input.requiredCodexAuthDeliveryVersion === 1 &&
+		input.codexAuthDeliveryVersion !== 1);
 
 export const selectActiveAccountImageBuild = (
 	builds: ReadonlyArray<CloudProjectBuildRecord>,
@@ -483,10 +495,33 @@ export const selectActiveAccountImageBuild = (
 			candidate.templateVersion === currentTemplateVersion,
 	);
 
+export const codexAuthModeForAccountBuild = (
+	build: CloudProjectBuildRecord,
+	brokerEnrollmentEnabled: boolean,
+): "legacy-image" | "broker-v1" => {
+	if (
+		!brokerEnrollmentEnabled ||
+		build.settings?.codexAuthDeliveryVersion !== 1
+	)
+		return "legacy-image";
+	const providers = build.settings.providers;
+	if (!Array.isArray(providers)) return "legacy-image";
+	return providers.some(
+		(provider) =>
+			typeof provider === "object" &&
+			provider !== null &&
+			Reflect.get(provider, "providerId") === "codex" &&
+			Reflect.get(provider, "method") === "subscription",
+	)
+		? "broker-v1"
+		: "legacy-image";
+};
+
 const cloudAccountImage = Effect.fn("cloudAccountImage")(function* (
 	accountId: string,
 ) {
 	const store = yield* CloudWorkspaceStore;
+	const apiConfiguration = yield* ApiConfiguration;
 	const sandboxProviders = yield* SandboxProviders;
 	const provider = sandboxProviders.availableProviders.find(
 		(candidate) => candidate.providerId === "e2b",
@@ -521,6 +556,10 @@ const cloudAccountImage = Effect.fn("cloudAccountImage")(function* (
 	}));
 	const authBroken = providers.some(
 		(status) =>
+			!(
+				active?.settings?.codexAuthDeliveryVersion === 1 &&
+				status.providerId === "codex"
+			) &&
 			status.method !== undefined &&
 			(status.state === "expired" || status.state === "error"),
 	);
@@ -532,6 +571,12 @@ const cloudAccountImage = Effect.fn("cloudAccountImage")(function* (
 			currentTemplateVersion: provider?.templateVersion,
 			projects,
 			providers,
+			...(active.settings?.codexAuthDeliveryVersion === 1
+				? { codexAuthDeliveryVersion: 1 as const }
+				: {}),
+			...(apiConfiguration.cloudCodexAuthBrokerEnrollmentEnabled
+				? { requiredCodexAuthDeliveryVersion: 1 as const }
+				: {}),
 		});
 	const latestFailedAfterActive =
 		latest?.state === "failed" &&
@@ -582,6 +627,9 @@ const cloudAccountImage = Effect.fn("cloudAccountImage")(function* (
 			createdAt: build.createdAtMs,
 			updatedAt: build.updatedAtMs,
 		})),
+		...(active?.settings?.codexAuthDeliveryVersion === 1
+			? { codexAuthDeliveryVersion: 1 as const }
+			: {}),
 		builtAt: active?.updatedAtMs,
 		updatedAt:
 			statusBuild?.updatedAtMs ??
@@ -664,6 +712,10 @@ const publicWorkspace = (workspace: CloudWorkspaceRecord) => ({
 	buildId: workspace.buildId,
 	imageGeneration: workspace.buildId,
 	providerId: workspace.provider,
+	codexAuthMode:
+		workspace.requestConfig.codexAuthMode === "broker-v1"
+			? ("broker-v1" as const)
+			: ("legacy-image" as const),
 	branch: workspace.branch,
 	baseRef: workspace.baseRef,
 	state: workspace.state,
@@ -713,6 +765,10 @@ export const publicCloudWorkspaceSummary = (
 			: workspace.branch),
 	branch: workspace.branch,
 	providerId: workspace.provider,
+	codexAuthMode:
+		workspace.requestConfig.codexAuthMode === "broker-v1"
+			? ("broker-v1" as const)
+			: ("legacy-image" as const),
 	agent:
 		typeof workspace.requestConfig.agent === "string"
 			? workspace.requestConfig.agent
@@ -883,6 +939,29 @@ const runtimeGeneration = (workspace: CloudWorkspaceRecord): number =>
 	typeof workspace.requestConfig.runtimeGeneration === "number"
 		? workspace.requestConfig.runtimeGeneration
 		: 1;
+
+export const codexGrantRuntimeBindingError = (
+	workspace: CloudWorkspaceRecord,
+	request: Pick<CodexGrantRequest, "runtimeGeneration">,
+	keyThumbprint: string,
+):
+	| "codex-auth-legacy-workspace"
+	| "workspace_runtime_fenced"
+	| "runtime_credential_key_binding_mismatch"
+	| null => {
+	if (workspace.requestConfig.codexAuthMode !== "broker-v1")
+		return "codex-auth-legacy-workspace";
+	if (request.runtimeGeneration !== runtimeGeneration(workspace))
+		return "workspace_runtime_fenced";
+	const receipt = runtimeBootstrapReceiptFromConfig(workspace.requestConfig);
+	if (
+		receipt === null ||
+		receipt.generation !== request.runtimeGeneration ||
+		receipt.credentialKeyThumbprint !== keyThumbprint
+	)
+		return "runtime_credential_key_binding_mismatch";
+	return null;
+};
 
 const attachMailboxLifecycle = (
 	response: Response,
@@ -1190,6 +1269,7 @@ export const routeCloudWorkspaceRequest = (
 			});
 			return json({
 				workspaceId,
+				zuseAccountId: workspace.accountId,
 				providerSandboxId,
 				runtimeCredential,
 				runtimeGatewayCredential,
@@ -1202,6 +1282,10 @@ export const routeCloudWorkspaceRequest = (
 				gatewayProtocol: WORKSPACE_GATEWAY_PROTOCOL,
 				chatId: workspace.chatId,
 				initialSessionId: workspace.initialSessionId,
+				codexAuthMode:
+					enrolled.workspace.requestConfig.codexAuthMode === "broker-v1"
+						? "broker-v1"
+						: "legacy-image",
 				runtimeGeneration: enrolled.receipt.generation,
 				gatewayEpoch: enrolled.receipt.gatewayEpoch,
 				runtimeCredentialExpiresAt:
@@ -1300,6 +1384,47 @@ export const routeCloudWorkspaceRequest = (
 				generation: receipt.generation,
 				gatewayEpoch: receipt.gatewayEpoch,
 			});
+		}
+
+		const runtimeCodexGrantMatch =
+			/^\/v1\/cloud\/workspaces\/([^/]+)\/runtime\/providers\/codex\/grant$/u.exec(
+				path,
+			);
+		if (method === "POST" && runtimeCodexGrantMatch !== null) {
+			const workspaceId = decodeURIComponent(runtimeCodexGrantMatch[1] ?? "");
+			const workspace = yield* requireRuntime(request, workspaceId, nowMs);
+			if (!apiConfiguration.cloudCodexAuthBrokerServingEnabled)
+				return yield* Effect.fail(
+					serviceUnavailable("codex-auth-update-required"),
+				);
+			const body = yield* decodeBody(CodexGrantRequest, request);
+			const publicJwk = yield* parseJwk(body.credentialPublicJwk);
+			const keyThumbprint = yield* runtimeCredentialKeyThumbprint(publicJwk);
+			const bindingError = codexGrantRuntimeBindingError(
+				workspace,
+				body,
+				keyThumbprint,
+			);
+			if (bindingError === "codex-auth-legacy-workspace")
+				return yield* Effect.fail(conflict(bindingError));
+			if (bindingError !== null)
+				return yield* Effect.fail(unauthorized(bindingError));
+			return json(
+				yield* issueCodexGrant({
+					accountId: workspace.accountId,
+					workspaceId,
+					runtimeGeneration: body.runtimeGeneration,
+					recipientPublicJwk: body.credentialPublicJwk,
+					recipientKeyThumbprint: keyThumbprint,
+					requestId: body.requestId,
+					reason: body.reason,
+					...(body.previousChatgptAccountId === undefined
+						? {}
+						: {
+								previousChatgptAccountId: body.previousChatgptAccountId,
+							}),
+				}),
+			);
 		}
 
 		const runtimeGithubCredentialMatch =
@@ -2202,6 +2327,10 @@ export const routeCloudWorkspaceRequest = (
 			const auth = yield* cloudAuthStatus(principal.accountId);
 			const authenticationChanged = auth.providers.some(
 				(status) =>
+					!(
+						apiConfiguration.cloudCodexAuthBrokerEnrollmentEnabled &&
+						status.providerId === "codex"
+					) &&
 					status.verifiedAt !== undefined &&
 					activeBuild !== null &&
 					status.verifiedAt > activeBuild.updatedAtMs,
@@ -2222,6 +2351,8 @@ export const routeCloudWorkspaceRequest = (
 				JSON.stringify({
 					mode: effectiveMode,
 					templateVersion: provider.templateVersion,
+					codexAuthDeliveryVersion:
+						apiConfiguration.cloudCodexAuthBrokerEnrollmentEnabled ? 1 : 0,
 					repositories: projects
 						.map((project) => ({
 							projectId: project.projectId,
@@ -2242,6 +2373,9 @@ export const routeCloudWorkspaceRequest = (
 				configurationDigest,
 				settings: {
 					mode: effectiveMode,
+					...(apiConfiguration.cloudCodexAuthBrokerEnrollmentEnabled
+						? { codexAuthDeliveryVersion: 1 }
+						: {}),
 					repositories: accountImageRepositories(projects),
 					providers: auth.providers.map((status) => ({
 						providerId: status.providerId,
@@ -2648,6 +2782,15 @@ export const routeCloudWorkspaceRequest = (
 			)
 				return yield* Effect.fail(conflict("cloud_project_not_ready"));
 			const build = accountBuild;
+			if (
+				apiConfiguration.cloudCodexAuthBrokerEnrollmentEnabled &&
+				build.settings?.codexAuthDeliveryVersion !== 1
+			)
+				return yield* Effect.fail(conflict("codex-auth-update-required"));
+			const codexAuthMode = codexAuthModeForAccountBuild(
+				build,
+				apiConfiguration.cloudCodexAuthBrokerEnrollmentEnabled,
+			);
 			const workspaceId = yield* randomToken("workspace", 12);
 			const chatId = `chat_${crypto.randomUUID()}`;
 			const initialSessionId = `s_${crypto.randomUUID()}`;
@@ -2707,6 +2850,7 @@ export const routeCloudWorkspaceRequest = (
 				requestConfig: {
 					title,
 					agent: body.agent,
+					codexAuthMode,
 					authGrantRequired: false,
 					model: body.model,
 					runtimeMode: body.runtimeMode ?? DEFAULT_RUNTIME_MODE,

--- a/infra/api/src/cloud-workspace-store.ts
+++ b/infra/api/src/cloud-workspace-store.ts
@@ -41,6 +41,26 @@ export interface CloudGithubInstallationRecord {
 	readonly updatedAtMs: number;
 }
 
+export interface CloudAuthAuthorityRecord {
+	readonly accountId: string;
+	readonly provider: string;
+	readonly providerSandboxId?: string;
+	readonly storageIncarnationId: string;
+	readonly authEpoch: number;
+	readonly toolchainVersion: string;
+	readonly state: "provisioning" | "ready" | "error";
+	readonly provisioningLeaseOwner?: string;
+	readonly provisioningLeaseExpiresAtMs?: number;
+	readonly revision: number;
+	readonly createdAtMs: number;
+	readonly updatedAtMs: number;
+}
+
+export interface CloudAuthAuthorityClaim {
+	readonly record: CloudAuthAuthorityRecord;
+	readonly acquired: boolean;
+}
+
 export interface CloudProjectBuildRecord {
 	readonly buildId: string;
 	readonly projectId: string;
@@ -317,6 +337,33 @@ export type CreateCloudWorkspaceOutcome =
 	  };
 
 export interface CloudWorkspaceStoreApi {
+	readonly getCloudAuthAuthority: (
+		accountId: string,
+	) => Effect.Effect<CloudAuthAuthorityRecord | null>;
+	readonly claimCloudAuthAuthority: (input: {
+		readonly accountId: string;
+		readonly provider: string;
+		readonly candidateStorageIncarnationId: string;
+		readonly toolchainVersion: string;
+		readonly leaseOwner: string;
+		readonly nowMs: number;
+		readonly leaseExpiresAtMs: number;
+		/** Explicit account reconnect may replace a ready locator whose storage is gone. */
+		readonly replaceReady?: boolean;
+	}) => Effect.Effect<CloudAuthAuthorityClaim>;
+	readonly completeCloudAuthAuthorityProvisioning: (input: {
+		readonly accountId: string;
+		readonly providerSandboxId: string;
+		readonly storageIncarnationId: string;
+		readonly toolchainVersion: string;
+		readonly leaseOwner: string;
+		readonly nowMs: number;
+	}) => Effect.Effect<CloudAuthAuthorityRecord | null>;
+	readonly advanceCloudAuthEpoch: (input: {
+		readonly accountId: string;
+		readonly providerSandboxId: string;
+		readonly nowMs: number;
+	}) => Effect.Effect<CloudAuthAuthorityRecord | null>;
 	readonly listGithubInstallations: (
 		accountId: string,
 	) => Effect.Effect<ReadonlyArray<CloudGithubInstallationRecord>>;
@@ -546,6 +593,7 @@ export class CloudWorkspaceStore extends Context.Service<
 >()("@zuse/api/CloudWorkspaceStore") {}
 
 interface MemoryState {
+	readonly authAuthorities: Map<string, CloudAuthAuthorityRecord>;
 	readonly githubInstallations: Map<string, CloudGithubInstallationRecord>;
 	readonly projects: Map<string, CloudProjectRecord>;
 	readonly builds: Map<string, CloudProjectBuildRecord>;
@@ -966,6 +1014,7 @@ export const CloudWorkspaceStoreMemory = Layer.effect(
 	CloudWorkspaceStore,
 	Effect.gen(function* () {
 		const state = yield* Ref.make<MemoryState>({
+			authAuthorities: new Map(),
 			githubInstallations: new Map(),
 			projects: new Map(),
 			builds: new Map(),
@@ -979,6 +1028,112 @@ export const CloudWorkspaceStoreMemory = Layer.effect(
 			lifecycleCommands: new Map(),
 		});
 		return CloudWorkspaceStore.of({
+			getCloudAuthAuthority: (accountId) =>
+				Ref.get(state).pipe(
+					Effect.map(
+						(current) => current.authAuthorities.get(accountId) ?? null,
+					),
+				),
+			claimCloudAuthAuthority: (input) =>
+				Ref.modify(
+					state,
+					(current): readonly [CloudAuthAuthorityClaim, MemoryState] => {
+						const existing = current.authAuthorities.get(input.accountId);
+						if (
+							(existing?.state === "ready" && input.replaceReady !== true) ||
+							(existing?.provisioningLeaseExpiresAtMs !== undefined &&
+								existing.provisioningLeaseExpiresAtMs > input.nowMs &&
+								existing.provisioningLeaseOwner !== input.leaseOwner)
+						)
+							return [{ record: existing, acquired: false }, current] as const;
+						const replacingReady =
+							existing?.state === "ready" && input.replaceReady === true;
+						const record: CloudAuthAuthorityRecord = {
+							accountId: input.accountId,
+							provider: input.provider,
+							storageIncarnationId: replacingReady
+								? input.candidateStorageIncarnationId
+								: (existing?.storageIncarnationId ??
+									input.candidateStorageIncarnationId),
+							authEpoch: replacingReady
+								? existing.authEpoch + 1
+								: (existing?.authEpoch ?? 1),
+							toolchainVersion: input.toolchainVersion,
+							state: "provisioning",
+							provisioningLeaseOwner: input.leaseOwner,
+							provisioningLeaseExpiresAtMs: input.leaseExpiresAtMs,
+							revision: (existing?.revision ?? -1) + 1,
+							createdAtMs: existing?.createdAtMs ?? input.nowMs,
+							updatedAtMs: input.nowMs,
+						};
+						return [
+							{ record, acquired: true },
+							{
+								...current,
+								authAuthorities: new Map(current.authAuthorities).set(
+									input.accountId,
+									record,
+								),
+							},
+						] as const;
+					},
+				),
+			completeCloudAuthAuthorityProvisioning: (input) =>
+				Ref.modify(state, (current) => {
+					const existing = current.authAuthorities.get(input.accountId);
+					if (
+						existing === undefined ||
+						(existing.state !== "ready" &&
+							existing.provisioningLeaseOwner !== input.leaseOwner)
+					)
+						return [null, current] as const;
+					const record: CloudAuthAuthorityRecord = {
+						...existing,
+						providerSandboxId: input.providerSandboxId,
+						storageIncarnationId: input.storageIncarnationId,
+						toolchainVersion: input.toolchainVersion,
+						state: "ready",
+						provisioningLeaseOwner: undefined,
+						provisioningLeaseExpiresAtMs: undefined,
+						revision: existing.revision + 1,
+						updatedAtMs: input.nowMs,
+					};
+					return [
+						record,
+						{
+							...current,
+							authAuthorities: new Map(current.authAuthorities).set(
+								input.accountId,
+								record,
+							),
+						},
+					] as const;
+				}),
+			advanceCloudAuthEpoch: (input) =>
+				Ref.modify(state, (current) => {
+					const existing = current.authAuthorities.get(input.accountId);
+					if (
+						existing?.state !== "ready" ||
+						existing.providerSandboxId !== input.providerSandboxId
+					)
+						return [null, current] as const;
+					const record: CloudAuthAuthorityRecord = {
+						...existing,
+						authEpoch: existing.authEpoch + 1,
+						revision: existing.revision + 1,
+						updatedAtMs: input.nowMs,
+					};
+					return [
+						record,
+						{
+							...current,
+							authAuthorities: new Map(current.authAuthorities).set(
+								input.accountId,
+								record,
+							),
+						},
+					] as const;
+				}),
 			listGithubInstallations: (accountId) =>
 				Ref.get(state).pipe(
 					Effect.map((current) =>
@@ -2287,6 +2442,8 @@ export const CloudWorkspaceStoreMemory = Layer.effect(
 							([, installation]) => installation.accountId !== accountId,
 						),
 					);
+					const authAuthorities = new Map(current.authAuthorities);
+					authAuthorities.delete(accountId);
 					const projects = new Map(
 						[...current.projects].filter(
 							([, project]) => project.accountId !== accountId,
@@ -2330,6 +2487,7 @@ export const CloudWorkspaceStoreMemory = Layer.effect(
 						true,
 						{
 							...current,
+							authAuthorities,
 							githubInstallations,
 							projects,
 							builds,
@@ -2411,6 +2569,22 @@ const buildFromRow = (row: Row): CloudProjectBuildRecord => ({
 	nextActionAtMs: numberValue(row.next_action_at),
 	leaseOwner: optionalString(row.lease_owner),
 	leaseExpiresAtMs: optionalNumber(row.lease_expires_at),
+	revision: numberValue(row.revision),
+	createdAtMs: numberValue(row.created_at),
+	updatedAtMs: numberValue(row.updated_at),
+});
+const authAuthorityFromRow = (row: Row): CloudAuthAuthorityRecord => ({
+	accountId: String(row.account_id),
+	provider: String(row.provider),
+	providerSandboxId: optionalString(row.provider_sandbox_id),
+	storageIncarnationId: String(row.storage_incarnation_id),
+	authEpoch: numberValue(row.auth_epoch),
+	toolchainVersion: String(row.toolchain_version),
+	state: row.state as CloudAuthAuthorityRecord["state"],
+	provisioningLeaseOwner: optionalString(row.provisioning_lease_owner),
+	provisioningLeaseExpiresAtMs: optionalNumber(
+		row.provisioning_lease_expires_at,
+	),
 	revision: numberValue(row.revision),
 	createdAtMs: numberValue(row.created_at),
 	updatedAtMs: numberValue(row.updated_at),
@@ -2561,6 +2735,89 @@ export const CloudWorkspaceStorePg: Layer.Layer<
 			);
 		};
 		return CloudWorkspaceStore.of({
+			getCloudAuthAuthority: (accountId) =>
+				orDie(
+					sql`SELECT * FROM api_cloud_auth_authorities WHERE account_id=${accountId}`.pipe(
+						Effect.map((rows) =>
+							rows[0] ? authAuthorityFromRow(rows[0] as Row) : null,
+						),
+					),
+				),
+			claimCloudAuthAuthority: (input) =>
+				orDie(
+					Effect.gen(function* () {
+						const rows = yield* sql`
+							INSERT INTO api_cloud_auth_authorities
+								(account_id, provider, storage_incarnation_id, auth_epoch,
+								 toolchain_version, state, provisioning_lease_owner,
+								 provisioning_lease_expires_at, revision, created_at, updated_at)
+							VALUES (${input.accountId}, ${input.provider},
+								${input.candidateStorageIncarnationId}, 1,
+								${input.toolchainVersion}, 'provisioning', ${input.leaseOwner},
+								${input.leaseExpiresAtMs}, 0, ${input.nowMs}, ${input.nowMs})
+							ON CONFLICT (account_id) DO UPDATE SET
+								provider=EXCLUDED.provider,
+								provider_sandbox_id=CASE WHEN ${input.replaceReady === true} THEN NULL ELSE api_cloud_auth_authorities.provider_sandbox_id END,
+								storage_incarnation_id=CASE WHEN ${input.replaceReady === true} THEN EXCLUDED.storage_incarnation_id ELSE api_cloud_auth_authorities.storage_incarnation_id END,
+								auth_epoch=CASE WHEN ${input.replaceReady === true} THEN api_cloud_auth_authorities.auth_epoch + 1 ELSE api_cloud_auth_authorities.auth_epoch END,
+								toolchain_version=EXCLUDED.toolchain_version,
+								state='provisioning',
+								provisioning_lease_owner=EXCLUDED.provisioning_lease_owner,
+								provisioning_lease_expires_at=EXCLUDED.provisioning_lease_expires_at,
+								revision=api_cloud_auth_authorities.revision + 1,
+								updated_at=EXCLUDED.updated_at
+							WHERE (${input.replaceReady === true} OR api_cloud_auth_authorities.state <> 'ready')
+								AND (api_cloud_auth_authorities.provisioning_lease_expires_at IS NULL
+									OR api_cloud_auth_authorities.provisioning_lease_expires_at <= ${input.nowMs}
+									OR api_cloud_auth_authorities.provisioning_lease_owner = ${input.leaseOwner})
+							RETURNING *
+						`;
+						const row =
+							rows[0] ??
+							(yield* sql`SELECT * FROM api_cloud_auth_authorities WHERE account_id=${input.accountId}`)[0];
+						const record = authAuthorityFromRow(row as Row);
+						return {
+							record,
+							acquired:
+								record.state === "provisioning" &&
+								record.provisioningLeaseOwner === input.leaseOwner,
+						};
+					}).pipe(sql.withTransaction),
+				),
+			completeCloudAuthAuthorityProvisioning: (input) =>
+				orDie(
+					sql`
+						UPDATE api_cloud_auth_authorities SET
+							provider_sandbox_id=${input.providerSandboxId},
+							storage_incarnation_id=${input.storageIncarnationId},
+							toolchain_version=${input.toolchainVersion},
+							state='ready', provisioning_lease_owner=NULL,
+							provisioning_lease_expires_at=NULL, revision=revision + 1,
+							updated_at=${input.nowMs}
+						WHERE account_id=${input.accountId}
+							AND (provisioning_lease_owner=${input.leaseOwner}
+								OR (state='ready' AND provider_sandbox_id=${input.providerSandboxId}))
+						RETURNING *
+					`.pipe(
+						Effect.map((rows) =>
+							rows[0] ? authAuthorityFromRow(rows[0] as Row) : null,
+						),
+					),
+				),
+			advanceCloudAuthEpoch: (input) =>
+				orDie(
+					sql`
+						UPDATE api_cloud_auth_authorities SET auth_epoch=auth_epoch + 1,
+							revision=revision + 1, updated_at=${input.nowMs}
+						WHERE account_id=${input.accountId} AND state='ready'
+							AND provider_sandbox_id=${input.providerSandboxId}
+						RETURNING *
+					`.pipe(
+						Effect.map((rows) =>
+							rows[0] ? authAuthorityFromRow(rows[0] as Row) : null,
+						),
+					),
+				),
 			listGithubInstallations: (accountId) =>
 				orDie(
 					sql`SELECT * FROM api_cloud_github_installations WHERE account_id=${accountId} ORDER BY created_at`.pipe(
@@ -3430,6 +3687,7 @@ export const CloudWorkspaceStorePg: Layer.Layer<
 						yield* sql`DELETE FROM api_cloud_project_builds WHERE account_id=${accountId}`;
 						yield* sql`DELETE FROM api_cloud_projects WHERE account_id=${accountId}`;
 						yield* sql`DELETE FROM api_cloud_github_installations WHERE account_id=${accountId}`;
+						yield* sql`DELETE FROM api_cloud_auth_authorities WHERE account_id=${accountId}`;
 						return true;
 					}).pipe(sql.withTransaction),
 				),

--- a/infra/api/src/config.ts
+++ b/infra/api/src/config.ts
@@ -53,6 +53,10 @@ export interface ApiConfig {
 	readonly cloudBillingCutoverAtMs?: number;
 	readonly cloudBillingPolarMeterId?: string;
 	readonly cloudCommandMailboxEnabled: boolean;
+	/** Allows newly-created workspaces to opt into broker-v1 Codex auth. */
+	readonly cloudCodexAuthBrokerEnrollmentEnabled: boolean;
+	/** Must remain enabled while any broker-v1 workspace exists. */
+	readonly cloudCodexAuthBrokerServingEnabled: boolean;
 	readonly cloudTranscriptObjects?: CloudTranscriptObjectStore;
 	readonly challengeTtlMs: number;
 	readonly connectTokenTtlMs: number;
@@ -89,6 +93,8 @@ const DEFAULTS = {
 	cloudBillingEnforcementEnabled: false,
 	cloudBillingExportEnabled: false,
 	cloudCommandMailboxEnabled: false,
+	cloudCodexAuthBrokerEnrollmentEnabled: false,
+	cloudCodexAuthBrokerServingEnabled: false,
 } as const;
 
 export const layer = (

--- a/infra/api/src/worker.ts
+++ b/infra/api/src/worker.ts
@@ -152,6 +152,8 @@ interface Env {
 	readonly CLOUD_BILLING_CUTOVER_AT?: string;
 	/** Additive rollout gate. Accepted rows continue draining when disabled. */
 	readonly CLOUD_COMMAND_MAILBOX_ENABLED?: string;
+	readonly CLOUD_CODEX_AUTH_BROKER_ENROLLMENT_ENABLED?: string;
+	readonly CLOUD_CODEX_AUTH_BROKER_SERVING_ENABLED?: string;
 }
 
 const flushMailboxLifecycleOutbox = (
@@ -413,6 +415,10 @@ const build = (env: Env): ReturnType<typeof makeApi> => {
 		cloudBillingEnforcementEnabled,
 		cloudBillingExportEnabled,
 		cloudCommandMailboxEnabled: env.CLOUD_COMMAND_MAILBOX_ENABLED === "true",
+		cloudCodexAuthBrokerEnrollmentEnabled:
+			env.CLOUD_CODEX_AUTH_BROKER_ENROLLMENT_ENABLED === "true",
+		cloudCodexAuthBrokerServingEnabled:
+			env.CLOUD_CODEX_AUTH_BROKER_SERVING_ENABLED === "true",
 		cloudBillingCutoverAtMs,
 		cloudBillingPolarMeterId: isConfigured(env.POLAR_CLOUD_OVERAGE_METER_ID)
 			? env.POLAR_CLOUD_OVERAGE_METER_ID

--- a/infra/api/test/unit/cloud-account-image-status.test.ts
+++ b/infra/api/test/unit/cloud-account-image-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+	codexAuthModeForAccountBuild,
 	isCloudAccountImageOutdated,
 	selectActiveAccountImageBuild,
 } from "../../src/cloud-workspace-routes.ts";
@@ -14,7 +15,10 @@ const imageStatus = (overrides: {
 		readonly state: string;
 		readonly updatedAtMs: number;
 	}>;
-	readonly providers?: ReadonlyArray<{ readonly verifiedAt?: number }>;
+	readonly providers?: ReadonlyArray<{
+		readonly providerId?: string;
+		readonly verifiedAt?: number;
+	}>;
 }) =>
 	isCloudAccountImageOutdated({
 		imagePromotedAtMs: 200,
@@ -38,6 +42,66 @@ describe("cloud account image status", () => {
 
 	test("is outdated when provider auth changes after promotion", () => {
 		expect(imageStatus({ providers: [{ verifiedAt: 201 }] })).toBe(true);
+	});
+
+	test("does not rebuild a broker image when account-level Codex auth rotates", () => {
+		expect(
+			isCloudAccountImageOutdated({
+				imagePromotedAtMs: 200,
+				imageTemplateVersion: "runtime-v2",
+				currentTemplateVersion: "runtime-v2",
+				projects: [{ state: "ready", updatedAtMs: 200 }],
+				providers: [
+					{ providerId: "codex", verifiedAt: 201 },
+					{ providerId: "claude", verifiedAt: 100 },
+				],
+				codexAuthDeliveryVersion: 1,
+			}),
+		).toBe(false);
+	});
+
+	test("marks a pre-broker image outdated when broker enrollment is required", () => {
+		expect(
+			isCloudAccountImageOutdated({
+				imagePromotedAtMs: 200,
+				imageTemplateVersion: "runtime-v2",
+				currentTemplateVersion: "runtime-v2",
+				projects: [{ state: "ready", updatedAtMs: 200 }],
+				providers: [],
+				requiredCodexAuthDeliveryVersion: 1,
+			}),
+		).toBe(true);
+	});
+
+	test("enrolls only subscription-backed Codex images in the broker", () => {
+		const build = (method: "subscription" | "api-key") =>
+			({
+				buildId: "build-1",
+				projectId: "project-1",
+				accountId: "account-1",
+				provider: "e2b",
+				templateVersion: "runtime-v2",
+				configurationDigest: "digest",
+				settings: {
+					codexAuthDeliveryVersion: 1,
+					providers: [{ providerId: "codex", method }],
+				},
+				state: "ready" as const,
+				idempotencyKey: "build-1",
+				nextActionAtMs: 0,
+				revision: 0,
+				createdAtMs: 0,
+				updatedAtMs: 0,
+			}) satisfies CloudProjectBuildRecord;
+		expect(codexAuthModeForAccountBuild(build("subscription"), true)).toBe(
+			"broker-v1",
+		);
+		expect(codexAuthModeForAccountBuild(build("api-key"), true)).toBe(
+			"legacy-image",
+		);
+		expect(codexAuthModeForAccountBuild(build("subscription"), false)).toBe(
+			"legacy-image",
+		);
 	});
 
 	test("is outdated when the runtime template changes", () => {

--- a/infra/api/test/unit/cloud-auth-authority.test.ts
+++ b/infra/api/test/unit/cloud-auth-authority.test.ts
@@ -1,33 +1,178 @@
+import { execFileSync } from "node:child_process";
+import {
+	constants,
+	createDecipheriv,
+	generateKeyPairSync,
+	privateDecrypt,
+} from "node:crypto";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Effect } from "effect";
 import { describe, expect, test } from "vitest";
 
 import {
+	CODEX_GRANT_SOURCE,
 	cloudAuthAuthorityLabel,
 	parseDeviceLoginOutput,
 } from "../../src/cloud-auth-authority.ts";
 
+const grantAdditionalData = (sealed: Record<string, unknown>): Buffer =>
+	Buffer.from(
+		JSON.stringify({
+			protocolVersion: sealed.protocolVersion,
+			requestId: sealed.requestId,
+			keyThumbprint: sealed.keyThumbprint,
+			authorityIncarnationId: sealed.authorityIncarnationId,
+			authorityEpoch: sealed.authorityEpoch,
+		}),
+	);
+
 describe("cloud auth authority identity", () => {
-	test("isolates the same account across deployments and template versions", async () => {
-		const label = (apiIssuer: string, templateVersion: string) =>
+	test("isolates deployments but remains stable across image updates", async () => {
+		const label = (apiIssuer: string) =>
 			Effect.runPromise(
 				cloudAuthAuthorityLabel({
 					accountId: "account_1",
 					apiIssuer,
-					templateVersion,
 				}),
 			);
-		const production = await label("https://api.zuse.sh", "production-build-2");
+		const production = await label("https://api.zuse.sh");
 
 		expect(production).toMatch(/^zuse-auth-[a-f0-9]{32}$/u);
-		await expect(
-			label("https://api.zuse.sh", "production-build-2"),
-		).resolves.toBe(production);
-		await expect(
-			label("https://api-staging.stuff.md", "production-build-2"),
-		).resolves.not.toBe(production);
-		await expect(
-			label("https://api.zuse.sh", "production-build-1"),
-		).resolves.not.toBe(production);
+		await expect(label("https://api.zuse.sh")).resolves.toBe(production);
+		await expect(label("https://api-staging.stuff.md")).resolves.not.toBe(
+			production,
+		);
+	});
+});
+
+describe("cloud auth authority Codex grants", () => {
+	test("seals access-only grants and idempotently rejects conflicting request reuse", () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-codex-grant-"));
+		try {
+			const authHome = join(directory, "authority");
+			const cacheDirectory = join(authHome, "grant-cache");
+			mkdirSync(cacheDirectory, { recursive: true });
+			writeFileSync(
+				join(authHome, "storage-incarnation-id"),
+				"authority-incarnation",
+			);
+			writeFileSync(
+				join(authHome, "grant-fingerprint.key"),
+				Buffer.alloc(32, 7).toString("base64url"),
+			);
+			const jwtPayload = Buffer.from(
+				JSON.stringify({
+					exp: Math.floor(Date.now() / 1_000) + 3_600,
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "chatgpt-account",
+						chatgpt_plan_type: "pro",
+					},
+				}),
+			).toString("base64url");
+			const accessToken = `e30.${jwtPayload}.signature`;
+			const authFile = join(directory, "auth.json");
+			writeFileSync(
+				authFile,
+				JSON.stringify({
+					tokens: {
+						access_token: accessToken,
+						refresh_token: "authority-only-refresh-token",
+						account_id: "chatgpt-account",
+					},
+				}),
+			);
+			const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+				modulusLength: 2048,
+			});
+			const scriptPath = join(directory, "codex-grant.mjs");
+			const requestPath = join(directory, "request.json");
+			const resultPath = join(directory, "result.json");
+			const cachePath = join(cacheDirectory, "request.json");
+			writeFileSync(scriptPath, CODEX_GRANT_SOURCE);
+			const request = {
+				protocolVersion: 1,
+				requestId: "550e8400-e29b-41d4-a716-446655440000",
+				accountId: "account-1",
+				workspaceId: "workspace-1",
+				runtimeGeneration: 3,
+				credentialPublicJwk: JSON.stringify(
+					publicKey.export({ format: "jwk" }),
+				),
+				keyThumbprint: "runtime-key-thumbprint",
+				reason: "initial",
+				authorityIncarnationId: "authority-incarnation",
+				authorityEpoch: 4,
+			};
+			writeFileSync(requestPath, JSON.stringify(request));
+			const run = () =>
+				execFileSync(
+					process.execPath,
+					[scriptPath, requestPath, resultPath, cachePath],
+					{
+						env: {
+							...process.env,
+							ZUSE_CLOUD_AUTH_HOME: authHome,
+							ZUSE_CODEX_AUTH_FILE: authFile,
+						},
+					},
+				);
+			run();
+			const firstText = readFileSync(resultPath, "utf8");
+			expect(firstText).not.toContain(accessToken);
+			expect(firstText).not.toContain("authority-only-refresh-token");
+			const first = JSON.parse(firstText) as {
+				readonly sealed: Record<string, unknown>;
+			};
+			const sealed = first.sealed;
+			const contentKey = privateDecrypt(
+				{
+					key: privateKey,
+					oaepHash: "sha256",
+					padding: constants.RSA_PKCS1_OAEP_PADDING,
+				},
+				Buffer.from(String(sealed.wrappedKey), "base64url"),
+			);
+			const decipher = createDecipheriv(
+				"aes-256-gcm",
+				contentKey,
+				Buffer.from(String(sealed.iv), "base64url"),
+			);
+			decipher.setAAD(grantAdditionalData(sealed));
+			decipher.setAuthTag(Buffer.from(String(sealed.tag), "base64url"));
+			const plaintext = JSON.parse(
+				Buffer.concat([
+					decipher.update(Buffer.from(String(sealed.ciphertext), "base64url")),
+					decipher.final(),
+				]).toString("utf8"),
+			) as Record<string, unknown>;
+			expect(plaintext).toMatchObject({
+				zuseAccountId: "account-1",
+				workspaceId: "workspace-1",
+				runtimeGeneration: 3,
+				accessToken,
+			});
+			run();
+			expect(readFileSync(resultPath, "utf8")).toBe(firstText);
+
+			writeFileSync(
+				requestPath,
+				JSON.stringify({ ...request, workspaceId: "workspace-conflict" }),
+			);
+			run();
+			expect(JSON.parse(readFileSync(resultPath, "utf8"))).toEqual({
+				errorCode: "codex_grant_request_id_reused",
+			});
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/infra/api/test/unit/cloud-codex-grant-route.test.ts
+++ b/infra/api/test/unit/cloud-codex-grant-route.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import { codexGrantRuntimeBindingError } from "../../src/cloud-workspace-routes.ts";
+import type { CloudWorkspaceRecord } from "../../src/cloud-workspace-store.ts";
+
+const workspace = (
+	overrides: Record<string, unknown> = {},
+): CloudWorkspaceRecord => ({
+	workspaceId: "workspace-1",
+	accountId: "account-1",
+	projectId: "project-1",
+	buildId: "image-1",
+	provider: "e2b",
+	runtimeState: "online",
+	chatId: "chat-1",
+	initialSessionId: "session-1",
+	branch: "main",
+	baseRef: "main",
+	state: "ready",
+	desiredState: "ready",
+	statusCode: "agent-running",
+	idempotencyKey: "create-1",
+	requestConfig: {
+		codexAuthMode: "broker-v1",
+		runtimeGeneration: 4,
+		runtimeBootstrapReceipt: {
+			workspaceId: "workspace-1",
+			bootTokenHash: "boot",
+			credentialKeyThumbprint: "runtime-key",
+			signingKeyThumbprint: "signing-key",
+			signingPublicJwk: "{}",
+			runtimeCredentialHash: "credential",
+			runtimeCredentialExpiresAtMs: 10_000,
+			generation: 4,
+			gatewayEpoch: 4,
+			sealedTranscriptKey: "sealed",
+			enrolledAtMs: 1,
+		},
+		...overrides,
+	},
+	nextActionAtMs: 10_000,
+	revision: 1,
+	createdAtMs: 1,
+	updatedAtMs: 1,
+	lastActivityAtMs: 1,
+});
+
+describe("Codex runtime grant binding", () => {
+	test("accepts only the enrolled generation and RSA key", () => {
+		expect(
+			codexGrantRuntimeBindingError(
+				workspace(),
+				{ runtimeGeneration: 4 },
+				"runtime-key",
+			),
+		).toBeNull();
+		expect(
+			codexGrantRuntimeBindingError(
+				workspace(),
+				{ runtimeGeneration: 5 },
+				"runtime-key",
+			),
+		).toBe("workspace_runtime_fenced");
+		expect(
+			codexGrantRuntimeBindingError(
+				workspace(),
+				{ runtimeGeneration: 4 },
+				"attacker-key",
+			),
+		).toBe("runtime_credential_key_binding_mismatch");
+	});
+
+	test("never upgrades a retained workspace without an immutable marker", () => {
+		expect(
+			codexGrantRuntimeBindingError(
+				workspace({ codexAuthMode: undefined }),
+				{ runtimeGeneration: 4 },
+				"runtime-key",
+			),
+		).toBe("codex-auth-legacy-workspace");
+	});
+});

--- a/infra/api/test/unit/cloud-workspace-store.test.ts
+++ b/infra/api/test/unit/cloud-workspace-store.test.ts
@@ -10,6 +10,120 @@ import {
 	workspaceSupportsCloudCommandMailbox,
 } from "../../src/cloud-workspace-store.ts";
 
+describe("cloud auth authority locator", () => {
+	test("serializes provisioning and fences epoch changes to the located sandbox", async () => {
+		const runtime = ManagedRuntime.make(CloudWorkspaceStoreMemory);
+		const store = await runtime.runPromise(CloudWorkspaceStore);
+		const first = await runtime.runPromise(
+			store.claimCloudAuthAuthority({
+				accountId: "account-auth",
+				provider: "e2b",
+				candidateStorageIncarnationId: "incarnation-1",
+				toolchainVersion: "0.144.5",
+				leaseOwner: "worker-1",
+				nowMs: 100,
+				leaseExpiresAtMs: 200,
+			}),
+		);
+		const contender = await runtime.runPromise(
+			store.claimCloudAuthAuthority({
+				accountId: "account-auth",
+				provider: "e2b",
+				candidateStorageIncarnationId: "incarnation-2",
+				toolchainVersion: "0.144.5",
+				leaseOwner: "worker-2",
+				nowMs: 150,
+				leaseExpiresAtMs: 250,
+			}),
+		);
+		expect(first.acquired).toBe(true);
+		expect(contender.acquired).toBe(false);
+		expect(contender.record.storageIncarnationId).toBe("incarnation-1");
+
+		const ready = await runtime.runPromise(
+			store.completeCloudAuthAuthorityProvisioning({
+				accountId: "account-auth",
+				providerSandboxId: "sandbox-authority",
+				storageIncarnationId: "incarnation-1",
+				toolchainVersion: "0.144.5",
+				leaseOwner: "worker-1",
+				nowMs: 160,
+			}),
+		);
+		expect(ready?.state).toBe("ready");
+		const protectedReady = await runtime.runPromise(
+			store.claimCloudAuthAuthority({
+				accountId: "account-auth",
+				provider: "e2b",
+				candidateStorageIncarnationId: "incarnation-ignored",
+				toolchainVersion: "0.144.5",
+				leaseOwner: "worker-2",
+				nowMs: 165,
+				leaseExpiresAtMs: 265,
+			}),
+		);
+		expect(protectedReady).toMatchObject({
+			acquired: false,
+			record: { providerSandboxId: "sandbox-authority", authEpoch: 1 },
+		});
+		const replacement = await runtime.runPromise(
+			store.claimCloudAuthAuthority({
+				accountId: "account-auth",
+				provider: "e2b",
+				candidateStorageIncarnationId: "incarnation-replacement",
+				toolchainVersion: "0.144.5",
+				leaseOwner: "worker-2",
+				nowMs: 166,
+				leaseExpiresAtMs: 266,
+				replaceReady: true,
+			}),
+		);
+		expect(replacement).toMatchObject({
+			acquired: true,
+			record: {
+				state: "provisioning",
+				storageIncarnationId: "incarnation-replacement",
+				authEpoch: 2,
+			},
+		});
+		expect(replacement.record.providerSandboxId).toBeUndefined();
+		const replacementReady = await runtime.runPromise(
+			store.completeCloudAuthAuthorityProvisioning({
+				accountId: "account-auth",
+				providerSandboxId: "sandbox-replacement",
+				storageIncarnationId: "incarnation-replacement",
+				toolchainVersion: "0.144.5",
+				leaseOwner: "worker-2",
+				nowMs: 168,
+			}),
+		);
+		expect(replacementReady).toMatchObject({
+			state: "ready",
+			providerSandboxId: "sandbox-replacement",
+			authEpoch: 2,
+		});
+		await expect(
+			runtime.runPromise(
+				store.advanceCloudAuthEpoch({
+					accountId: "account-auth",
+					providerSandboxId: "wrong-sandbox",
+					nowMs: 170,
+				}),
+			),
+		).resolves.toBeNull();
+		await expect(
+			runtime.runPromise(
+				store.advanceCloudAuthEpoch({
+					accountId: "account-auth",
+					providerSandboxId: "sandbox-replacement",
+					nowMs: 180,
+				}),
+			),
+		).resolves.toMatchObject({ authEpoch: 3 });
+		await runtime.dispose();
+	});
+});
+
 const project = {
 	projectId: "project-1",
 	accountId: "account-1",

--- a/infra/api/test/unit/deploy-safety.test.ts
+++ b/infra/api/test/unit/deploy-safety.test.ts
@@ -84,6 +84,8 @@ describe("api deployment safety", () => {
 		]);
 		expect(config.vars.API_ISSUER).toBe(STAGING_API_URL);
 		expect(config.vars.CLOUD_COMMAND_MAILBOX_ENABLED).toBe("true");
+		expect(config.vars.CLOUD_CODEX_AUTH_BROKER_ENROLLMENT_ENABLED).toBe("true");
+		expect(config.vars.CLOUD_CODEX_AUTH_BROKER_SERVING_ENABLED).toBe("true");
 		expect(`https://${config.routes[0]?.pattern}`).toBe(STAGING_API_URL);
 		expect(config.vars.MANAGED_TUNNEL_NAMESPACE).toBe("zenv-staging");
 		expect(config.vars.WORKOS_JWKS_URL).toBe(
@@ -156,6 +158,12 @@ describe("api deployment safety", () => {
 		]);
 		expect(production.vars.MACHINE_PROVIDER).toBe("fake");
 		expect(production.vars.CLOUD_COMMAND_MAILBOX_ENABLED).toBe("true");
+		expect(production.vars.CLOUD_CODEX_AUTH_BROKER_ENROLLMENT_ENABLED).toBe(
+			"false",
+		);
+		expect(production.vars.CLOUD_CODEX_AUTH_BROKER_SERVING_ENABLED).toBe(
+			"false",
+		);
 		expect(production.vars.HETZNER_ADAPTER_ENABLED).toBe("false");
 		expect(production.vars.MACHINE_LIVE_CHECKOUT_ENABLED).toBe("true");
 		expect(production.vars.MACHINE_RUNTIME_MANIFEST_URL).toBe("");

--- a/infra/api/test/unit/migration-safety.test.ts
+++ b/infra/api/test/unit/migration-safety.test.ts
@@ -58,6 +58,10 @@ const apiNamingMigrationUrl = new URL(
 	"../../drizzle/migrations/0016_api_naming.sql",
 	import.meta.url,
 );
+const cloudCodexAuthBrokerMigrationUrl = new URL(
+	"../../drizzle/migrations/0017_cloud_codex_auth_broker.sql",
+	import.meta.url,
+);
 
 describe("api migration reconciliation", () => {
 	test("keeps the main migration history before managed cloud machines", async () => {
@@ -86,7 +90,24 @@ describe("api migration reconciliation", () => {
 			{ idx: 14, tag: "0014_cloud_project_selection" },
 			{ idx: 15, tag: "0015_github_app_installations" },
 			{ idx: 16, tag: "0016_api_naming" },
+			{ idx: 17, tag: "0017_cloud_codex_auth_broker" },
 		]);
+	});
+
+	test("stores only authority location and fencing metadata", async () => {
+		const migration = await readFile(cloudCodexAuthBrokerMigrationUrl, "utf8");
+		expect(migration).toContain('CREATE TABLE "api_cloud_auth_authorities"');
+		for (const column of [
+			"provider_sandbox_id",
+			"storage_incarnation_id",
+			"auth_epoch",
+			"toolchain_version",
+			"provisioning_lease_owner",
+		])
+			expect(migration).toContain(`"${column}"`);
+		expect(migration).not.toMatch(
+			/access_token|refresh_token|auth_json|private_key/iu,
+		);
 	});
 
 	test("renames all current Relay relations without dropping data", async () => {

--- a/infra/api/wrangler.jsonc
+++ b/infra/api/wrangler.jsonc
@@ -28,6 +28,8 @@
 	"triggers": { "crons": ["* * * * *"] },
 	"vars": {
 		"CLOUD_COMMAND_MAILBOX_ENABLED": "true",
+		"CLOUD_CODEX_AUTH_BROKER_ENROLLMENT_ENABLED": "true",
+		"CLOUD_CODEX_AUTH_BROKER_SERVING_ENABLED": "true",
 		"API_ISSUER": "https://api-staging.stuff.md",
 		"WORKOS_ISSUER": "https://api.workos.com",
 		"WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KW6ZEZKVMZ0G429A89XZD83Q",

--- a/infra/api/wrangler.production.jsonc
+++ b/infra/api/wrangler.production.jsonc
@@ -23,6 +23,8 @@
 	"triggers": { "crons": ["* * * * *"] },
 	"vars": {
 		"CLOUD_COMMAND_MAILBOX_ENABLED": "true",
+		"CLOUD_CODEX_AUTH_BROKER_ENROLLMENT_ENABLED": "false",
+		"CLOUD_CODEX_AUTH_BROKER_SERVING_ENABLED": "false",
 		"API_ISSUER": "https://api.zuse.sh",
 		"WORKOS_ISSUER": "https://api.workos.com",
 		"WORKOS_JWKS_URL": "https://api.workos.com/sso/jwks/client_01KWGQ818571ARFATQ3G9AR2Y2",

--- a/infra/cloud-sandboxes/project-builder.sh
+++ b/infra/cloud-sandboxes/project-builder.sh
@@ -72,8 +72,9 @@ phase=cleaning-credentials
 rm -f /run/zuse-secrets/github-installation-*
 unset GIT_ASKPASS ZUSE_GIT_TOKEN_FILE
 
-# GitHub and runtime identity are never baked in. Agent credentials created in
-# this private account image are intentionally retained.
+# GitHub and runtime identity are never baked in. Broker-capable images retain
+# Codex configuration, skills, and MCP settings, but the rotating native login
+# remains solely in the account authority.
 phase=sanitizing-snapshot
 rm -rf /home/zuse/.config/gh /home/zuse/.zuse-data /home/zuse/.cache/zuse \
 	/tmp/zuse-* 2>/dev/null || true
@@ -85,6 +86,9 @@ fi
 rm -rf /home/zuse/.zuse/cloud-auth/operations /home/zuse/.zuse/cloud-auth/status
 rm -f /home/zuse/.zuse/cloud-auth/private.pem \
   /home/zuse/.zuse/cloud-auth/public.jwk.json /home/zuse/.zuse/cloud-auth/key-id
+if [[ "${ZUSE_CODEX_AUTH_DELIVERY_VERSION:-0}" == "1" ]]; then
+	rm -f /home/zuse/.codex/auth.json
+fi
 find /home/zuse -type f \( \
 	-name '.env' -o -name '.env.local' -o -name '.env.*.local' -o \
 	-name 'credentials.json' \
@@ -115,19 +119,21 @@ node --input-type=module -e '
     const [projectId, defaultBranch, sourceCommit, workspacePath] = line.split("\t");
     return { projectId, defaultBranch, sourceCommit, workspacePath };
   });
+  const codexAuthDeliveryVersion = process.env.ZUSE_CODEX_AUTH_DELIVERY_VERSION === "1" ? 1 : undefined;
   const providers = ["claude", "codex", "cursor", "grok"].map((providerId) => ({
     providerId,
     state: existsSync(`/home/zuse/.zuse/cloud-auth/providers/${providerId}.json`) ||
-      (providerId === "codex" && existsSync("/home/zuse/.codex/auth.json"))
+      (providerId === "codex" && codexAuthDeliveryVersion === undefined && existsSync("/home/zuse/.codex/auth.json"))
       ? "connected"
       : "disconnected",
   }));
   writeFileSync(process.argv[2], JSON.stringify({
-    schemaVersion: 1,
+    schemaVersion: codexAuthDeliveryVersion === 1 ? 2 : 1,
     runtimeVersion: process.env.ZUSE_TEMPLATE_VERSION,
     configurationDigest: process.env.ZUSE_CONFIGURATION_DIGEST,
     repositories: rows,
     providers,
+    ...(codexAuthDeliveryVersion === undefined ? {} : { codexAuthDeliveryVersion }),
   }), { mode: 0o600 });
 ' "$commit_manifest" /var/lib/zuse/account-image/manifest.json
 # Authority bookkeeping is not runtime authentication. Native provider homes

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"react-dom": "19.2.3"
 	},
 	"dependencies": {
-		"@openai/codex": "^0.144.5"
+		"@openai/codex": "0.144.5"
 	},
 	"patchedDependencies": {
 		"@legendapp/list@3.3.3": "patches/@legendapp%2Flist@3.3.3.patch",

--- a/packages/agents/src/drivers/codex-app-server-client.ts
+++ b/packages/agents/src/drivers/codex-app-server-client.ts
@@ -20,6 +20,68 @@ type ServerRequestHandler = (
 
 type NotificationHandler = (notification: ServerNotification) => void;
 
+export interface CodexChatgptAuthTokens {
+	readonly accessToken: string;
+	readonly chatgptAccountId: string;
+	readonly chatgptPlanType: string | null;
+	readonly expiresAt: number;
+}
+
+export interface CodexExternalAuthProvider {
+	readonly getTokens: (input: {
+		readonly reason: "initial" | "proactive" | "unauthorized";
+		readonly previousChatgptAccountId?: string;
+	}) => Promise<CodexChatgptAuthTokens>;
+	readonly onDeliveryFailure?: (input: {
+		readonly consumerId?: string;
+		readonly reason: string;
+	}) => void;
+}
+
+let defaultExternalAuthProvider: CodexExternalAuthProvider | null = null;
+
+/** One cloud runtime process owns one workspace, so every launch shares this. */
+export const setDefaultCodexExternalAuthProvider = (
+	provider: CodexExternalAuthProvider | null,
+): void => {
+	defaultExternalAuthProvider = provider;
+};
+
+export const CODEX_EXTERNAL_AUTH_CALLBACK_DEADLINE_MS = 8_000;
+
+export const beforeCodexExternalAuthDeadline = async <A>(
+	operation: Promise<A>,
+): Promise<A> => {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(
+					() => reject(new Error("codex-auth-reconnecting")),
+					CODEX_EXTERNAL_AUTH_CALLBACK_DEADLINE_MS,
+				);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+};
+
+/**
+ * Lets other Codex-backed capabilities in the same workspace runtime reuse the
+ * brokered, memory-only access grant without reaching into native auth files.
+ */
+export const getDefaultCodexExternalAuthTokens = async (
+	reason: "proactive" | "unauthorized",
+): Promise<CodexChatgptAuthTokens | null> => {
+	if (defaultExternalAuthProvider === null) return null;
+	return beforeCodexExternalAuthDeadline(
+		defaultExternalAuthProvider.getTokens({ reason }),
+	);
+};
+
 type CodexGoalRequestMethod =
 	| "thread/goal/get"
 	| "thread/goal/set"
@@ -120,7 +182,51 @@ export class CodexAppServerClient {
 		readonly onStderr?: (text: string) => void;
 		readonly onNotification: NotificationHandler;
 		readonly onServerRequest: ServerRequestHandler;
+		readonly externalAuthProvider?: CodexExternalAuthProvider;
+		/** Session identity used only to resume a proven auth-blocked consumer. */
+		readonly externalAuthConsumerId?: string;
 	}): Promise<CodexAppServerClient> {
+		const externalAuthProvider =
+			options.externalAuthProvider ?? defaultExternalAuthProvider;
+		const handleServerRequest: ServerRequestHandler = (request, respond) => {
+			if (
+				externalAuthProvider !== null &&
+				request.method === "account/chatgptAuthTokens/refresh"
+			) {
+				void beforeCodexExternalAuthDeadline(
+					externalAuthProvider.getTokens({
+						reason: "unauthorized",
+						...(request.params.previousAccountId === null ||
+						request.params.previousAccountId === undefined
+							? {}
+							: {
+									previousChatgptAccountId: request.params.previousAccountId,
+								}),
+					}),
+				)
+					.then((tokens) =>
+						respond({
+							accessToken: tokens.accessToken,
+							chatgptAccountId: tokens.chatgptAccountId,
+							chatgptPlanType: tokens.chatgptPlanType,
+						}),
+					)
+					.catch((cause) => {
+						externalAuthProvider.onDeliveryFailure?.({
+							...(options.externalAuthConsumerId === undefined
+								? {}
+								: { consumerId: options.externalAuthConsumerId }),
+							reason:
+								cause instanceof Error
+									? cause.message
+									: "codex-auth-reconnecting",
+						});
+						respond(null);
+					});
+				return;
+			}
+			options.onServerRequest(request, respond);
+		};
 		const child = spawn(
 			options.codexPath ?? "codex",
 			[...codexAppServerLaunchArgs(options.mcp)],
@@ -144,7 +250,7 @@ export class CodexAppServerClient {
 				platformOs: "",
 			},
 			options.onNotification,
-			options.onServerRequest,
+			handleServerRequest,
 		);
 		rl.on("line", (line) => bootstrap.handleLine(line));
 		child.stderr.on("data", (chunk) => {
@@ -193,6 +299,31 @@ export class CodexAppServerClient {
 							}),
 						]);
 			bootstrap.initializeResponse = init;
+			if (externalAuthProvider !== null) {
+				let tokens: CodexChatgptAuthTokens;
+				try {
+					tokens = await beforeCodexExternalAuthDeadline(
+						externalAuthProvider.getTokens({ reason: "initial" }),
+					);
+				} catch (cause) {
+					externalAuthProvider.onDeliveryFailure?.({
+						...(options.externalAuthConsumerId === undefined
+							? {}
+							: { consumerId: options.externalAuthConsumerId }),
+						reason:
+							cause instanceof Error
+								? cause.message
+								: "codex-auth-reconnecting",
+					});
+					throw cause;
+				}
+				await bootstrap.request("account/login/start", {
+					type: "chatgptAuthTokens",
+					accessToken: tokens.accessToken,
+					chatgptAccountId: tokens.chatgptAccountId,
+					chatgptPlanType: tokens.chatgptPlanType,
+				});
+			}
 			return bootstrap;
 		} catch (cause) {
 			bootstrap.close();

--- a/packages/agents/src/drivers/codex.ts
+++ b/packages/agents/src/drivers/codex.ts
@@ -1509,6 +1509,7 @@ export const startCodexSession = (
 			try: () =>
 				CodexAppServerClient.start({
 					codexPath,
+					externalAuthConsumerId: sessionId,
 					env: { ...process.env, ZUSE_MCP_TOKEN: mcpGatewaySession.token },
 					mcp: {
 						transport: "http",
@@ -1609,6 +1610,7 @@ export const startCodexSession = (
 					}
 					app = await CodexAppServerClient.start({
 						codexPath,
+						externalAuthConsumerId: sessionId,
 						env: process.env,
 						mcp: {
 							transport: "stdio",

--- a/packages/agents/test/unit/drivers/codex-app-server-client.test.ts
+++ b/packages/agents/test/unit/drivers/codex-app-server-client.test.ts
@@ -1,12 +1,24 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	CodexAppServerClient,
 	type CodexAppServerRequestError,
 	codexAppServerLaunchArgs,
+	getDefaultCodexExternalAuthTokens,
+	setDefaultCodexExternalAuthProvider,
 } from "@zuse/agents/drivers/codex-app-server-client";
+import { CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION } from "@zuse/contracts";
 import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
 
 describe("Codex app-server launch configuration", () => {
 	it("injects the app MCP server with process-scoped config overrides", () => {
@@ -84,7 +96,7 @@ lines.on("line", (line) => {
 				},
 			}
 		: { id: request.id, result };
-	process.stdout.write(JSON.stringify(response) + "\\n");
+process.stdout.write(JSON.stringify(response) + "\\n");
 });
 `,
 				{ mode: 0o755 },
@@ -104,6 +116,176 @@ lines.on("line", (line) => {
 			} satisfies Partial<CodexAppServerRequestError>);
 		} finally {
 			client?.close();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("Codex app-server external authentication", () => {
+	it("shares brokered tokens with non-session Codex capabilities without disk auth", async () => {
+		setDefaultCodexExternalAuthProvider({
+			getTokens: async ({ reason }) => ({
+				accessToken: `access-${reason}`,
+				chatgptAccountId: "chatgpt-account",
+				chatgptPlanType: "pro",
+				expiresAt: Date.now() + 3_600_000,
+			}),
+		});
+		try {
+			await expect(
+				getDefaultCodexExternalAuthTokens("proactive"),
+			).resolves.toMatchObject({ accessToken: "access-proactive" });
+		} finally {
+			setDefaultCodexExternalAuthProvider(null);
+		}
+	});
+
+	it("reports the exact auth-blocked session without falling back to native credentials", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-pinned-codex-blocked-"));
+		try {
+			const failures: Array<{ consumerId?: string; reason: string }> = [];
+			await expect(
+				CodexAppServerClient.start({
+					codexPath: require.resolve("@openai/codex/bin/codex.js"),
+					env: { ...process.env, CODEX_HOME: directory },
+					startupTimeoutMs: 5_000,
+					onNotification: () => {},
+					onServerRequest: () => {},
+					externalAuthConsumerId: "session-1",
+					externalAuthProvider: {
+						getTokens: async () =>
+							Promise.reject(new Error("codex-auth-reconnect-required")),
+						onDeliveryFailure: (failure) => failures.push(failure),
+					},
+				}),
+			).rejects.toThrow("codex-auth-reconnect-required");
+			expect(failures).toEqual([
+				{
+					consumerId: "session-1",
+					reason: "codex-auth-reconnect-required",
+				},
+			]);
+			expect(existsSync(join(directory, "auth.json"))).toBe(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("contract-tests the pinned Codex binary without persisting auth", async () => {
+		expect(
+			(require("@openai/codex/package.json") as { version: string }).version,
+		).toBe(CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION);
+		const directory = mkdtempSync(join(tmpdir(), "zuse-pinned-codex-auth-"));
+		let client: CodexAppServerClient | null = null;
+		try {
+			const payload = Buffer.from(
+				JSON.stringify({
+					email: "contract@example.com",
+					exp: Math.floor(Date.now() / 1_000) + 3_600,
+				}),
+			).toString("base64url");
+			const accessToken = `e30.${payload}.signature`;
+			client = await CodexAppServerClient.start({
+				codexPath: require.resolve("@openai/codex/bin/codex.js"),
+				env: { ...process.env, CODEX_HOME: directory },
+				startupTimeoutMs: 5_000,
+				onNotification: () => {},
+				onServerRequest: () => {},
+				externalAuthProvider: {
+					getTokens: async () => ({
+						accessToken,
+						chatgptAccountId: "chatgpt-account",
+						chatgptPlanType: "pro",
+						expiresAt: Date.now() + 3_600_000,
+					}),
+				},
+			});
+			await expect(
+				client.request("account/read", { refreshToken: false }),
+			).resolves.toMatchObject({
+				account: { type: "chatgpt" },
+			});
+			expect(existsSync(join(directory, "auth.json"))).toBe(false);
+		} finally {
+			client?.close();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("installs account tokens in memory and handles Codex refresh callbacks", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-app-server-auth-"));
+		const executable = join(directory, "fake-app-server.mjs");
+		const capture = join(directory, "capture.json");
+		let client: CodexAppServerClient | null = null;
+		try {
+			writeFileSync(
+				executable,
+				`#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+import readline from "node:readline";
+const capture = process.env.CAPTURE_PATH;
+const lines = readline.createInterface({ input: process.stdin });
+let login;
+lines.on("line", (line) => {
+	const message = JSON.parse(line);
+	if (message.method === "initialize") {
+		process.stdout.write(JSON.stringify({ id: message.id, result: { userAgent: "test", codexHome: "", platformFamily: "", platformOs: "" } }) + "\\n");
+		return;
+	}
+	if (message.method === "account/login/start") {
+		login = message.params;
+		process.stdout.write(JSON.stringify({ id: message.id, result: { type: "chatgptAuthTokens" } }) + "\\n");
+		process.stdout.write(JSON.stringify({ id: 99, method: "account/chatgptAuthTokens/refresh", params: { reason: "unauthorized", previousAccountId: "chatgpt-account" } }) + "\\n");
+		return;
+	}
+	if (message.id === 99 && message.method === undefined) {
+		writeFileSync(capture, JSON.stringify({ login, refresh: message.result }));
+	}
+});
+`,
+				{ mode: 0o755 },
+			);
+			let calls = 0;
+			setDefaultCodexExternalAuthProvider({
+				getTokens: async ({ reason }) => {
+					calls += 1;
+					return {
+						accessToken:
+							reason === "unauthorized" ? "refreshed-access" : "initial-access",
+						chatgptAccountId: "chatgpt-account",
+						chatgptPlanType: "pro",
+						expiresAt: Date.now() + 60_000,
+					};
+				},
+			});
+			client = await CodexAppServerClient.start({
+				codexPath: executable,
+				env: { ...process.env, CAPTURE_PATH: capture },
+				startupTimeoutMs: 2_000,
+				onNotification: () => {},
+				onServerRequest: () => {},
+			});
+			for (let attempt = 0; attempt < 100 && !existsSync(capture); attempt += 1)
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			const recorded = JSON.parse(readFileSync(capture, "utf8")) as {
+				login: Record<string, unknown>;
+				refresh: Record<string, unknown>;
+			};
+			expect(recorded.login).toEqual({
+				type: "chatgptAuthTokens",
+				accessToken: "initial-access",
+				chatgptAccountId: "chatgpt-account",
+				chatgptPlanType: "pro",
+			});
+			expect(recorded.refresh).toEqual({
+				accessToken: "refreshed-access",
+				chatgptAccountId: "chatgpt-account",
+				chatgptPlanType: "pro",
+			});
+			expect(calls).toBe(2);
+		} finally {
+			client?.close();
+			setDefaultCodexExternalAuthProvider(null);
 			rmSync(directory, { recursive: true, force: true });
 		}
 	});

--- a/packages/agents/test/unit/drivers/codex.test.ts
+++ b/packages/agents/test/unit/drivers/codex.test.ts
@@ -708,8 +708,9 @@ describe("codexWritableRootsForCwd", () => {
 
 describe("codexReasoningEffort", () => {
 	it("passes only the selected model's supported efforts through to Codex", () => {
-		expect(codexReasoningEffort("gpt-5.5", "xhigh")).toBe("xhigh");
+		expect(codexReasoningEffort("gpt-5.5", "xhigh")).toBeNull();
 		expect(codexReasoningEffort("gpt-5.5", "max")).toBeNull();
+		expect(codexReasoningEffort("gpt-5.6-sol", "xhigh")).toBe("xhigh");
 		expect(codexReasoningEffort("gpt-5.6-sol", "max")).toBe("max");
 		expect(codexReasoningEffort("gpt-5.6-terra", "ultra")).toBe("ultra");
 		expect(codexReasoningEffort("gpt-5.4", "xhigh")).toBeNull();

--- a/packages/contracts/src/api.ts
+++ b/packages/contracts/src/api.ts
@@ -123,6 +123,8 @@ export const ApiPaths = {
 		`/v1/cloud/workspaces/${encodeURIComponent(workspaceId)}/runtime/credentials/renew`,
 	cloudWorkspaceRuntimeGithubCredential: (workspaceId: string) =>
 		`/v1/cloud/workspaces/${encodeURIComponent(workspaceId)}/runtime/github-credential`,
+	cloudWorkspaceRuntimeCodexGrant: (workspaceId: string) =>
+		`/v1/cloud/workspaces/${encodeURIComponent(workspaceId)}/runtime/providers/codex/grant`,
 	cloudWorkspaceActivity: (workspaceId: string) =>
 		`/v1/cloud/workspaces/${encodeURIComponent(workspaceId)}/runtime/activity`,
 	cloudWorkspaceSummary: (workspaceId: string) =>

--- a/packages/contracts/src/cloud-auth.ts
+++ b/packages/contracts/src/cloud-auth.ts
@@ -2,6 +2,9 @@ import { Schema } from "effect";
 import { Rpc } from "effect/unstable/rpc";
 import { CloudWorkspaceOpError } from "./cloud-workspaces.ts";
 
+/** Codex release whose experimental external-auth protocol is contract-tested. */
+export const CODEX_EXTERNAL_AUTH_TOOLCHAIN_VERSION = "0.144.5";
+
 /** Agent providers that can be selected by an E2B cloud workspace. */
 export const CloudAuthProvider = Schema.Literals([
 	"claude",
@@ -37,6 +40,52 @@ export const CloudAuthAuthorityState = Schema.Literals([
 	"error",
 ]);
 export type CloudAuthAuthorityState = typeof CloudAuthAuthorityState.Type;
+
+export const CloudCodexAuthFailureCode = Schema.Literals([
+	"codex-auth-reconnecting",
+	"codex-auth-reconnect-required",
+	"codex-auth-update-required",
+	"codex-auth-legacy-workspace",
+	"codex-auth-outcome-unknown",
+]);
+export type CloudCodexAuthFailureCode = typeof CloudCodexAuthFailureCode.Type;
+
+export const CodexGrantRefreshReason = Schema.Literals([
+	"initial",
+	"proactive",
+	"unauthorized",
+]);
+export type CodexGrantRefreshReason = typeof CodexGrantRefreshReason.Type;
+
+export class CodexGrantRequest extends Schema.Class<CodexGrantRequest>(
+	"CodexGrantRequest",
+)({
+	requestId: Schema.String,
+	protocolVersion: Schema.Literal(1),
+	runtimeGeneration: Schema.Number,
+	credentialPublicJwk: Schema.String,
+	reason: CodexGrantRefreshReason,
+	previousChatgptAccountId: Schema.optional(Schema.String),
+}) {}
+
+/** API-routed ciphertext. Only the enrolled runtime RSA key can open it. */
+export class SealedCodexGrant extends Schema.Class<SealedCodexGrant>(
+	"SealedCodexGrant",
+)({
+	protocolVersion: Schema.Literal(1),
+	requestId: Schema.String,
+	keyThumbprint: Schema.String,
+	authorityIncarnationId: Schema.String,
+	authorityEpoch: Schema.Number,
+	/** RSA-OAEP wrapped AES-256 key, base64url. */
+	wrappedKey: Schema.String,
+	/** AES-GCM nonce, base64url. */
+	iv: Schema.String,
+	/** AES-GCM ciphertext, including no plaintext provider data. */
+	ciphertext: Schema.String,
+	/** AES-GCM authentication tag, base64url. */
+	tag: Schema.String,
+}) {}
 
 export class CloudAuthProviderStatus extends Schema.Class<CloudAuthProviderStatus>(
 	"CloudAuthProviderStatus",

--- a/packages/contracts/src/cloud-workspaces.ts
+++ b/packages/contracts/src/cloud-workspaces.ts
@@ -119,6 +119,17 @@ export const CloudWorkspaceRuntimeState = Schema.Literals([
 ]);
 export type CloudWorkspaceRuntimeState = typeof CloudWorkspaceRuntimeState.Type;
 
+/**
+ * Codex subscription authentication ownership for a cloud workspace. Missing
+ * values decode as `legacy-image`; retained workspaces are never silently
+ * migrated onto the broker protocol.
+ */
+export const CloudCodexAuthMode = Schema.Literals([
+	"legacy-image",
+	"broker-v1",
+]);
+export type CloudCodexAuthMode = typeof CloudCodexAuthMode.Type;
+
 export class CloudProviderOption extends Schema.Class<CloudProviderOption>(
 	"CloudProviderOption",
 )({
@@ -249,6 +260,7 @@ export class CloudAccountImage extends Schema.Class<CloudAccountImage>(
 	repositories: Schema.Array(CloudAccountImageRepository),
 	providers: Schema.Array(CloudAccountImageProvider),
 	builds: Schema.Array(CloudAccountImageBuildAttempt),
+	codexAuthDeliveryVersion: Schema.optional(Schema.Literal(1)),
 	builtAt: Schema.optional(Schema.Number),
 	updatedAt: Schema.Number,
 }) {}
@@ -280,6 +292,10 @@ export class CloudWorkspace extends Schema.Class<CloudWorkspace>(
 		Schema.withDecodingDefaultType(Effect.succeed("legacy")),
 	),
 	providerId: Schema.String,
+	codexAuthMode: CloudCodexAuthMode.pipe(
+		Schema.withConstructorDefault(Effect.succeed("legacy-image" as const)),
+		Schema.withDecodingDefaultType(Effect.succeed("legacy-image" as const)),
+	),
 	branch: Schema.String,
 	baseRef: Schema.String,
 	state: CloudWorkspaceState,
@@ -344,6 +360,10 @@ export class CloudChatSummary extends Schema.Class<CloudChatSummary>(
 	title: Schema.String,
 	branch: Schema.String,
 	providerId: Schema.String,
+	codexAuthMode: CloudCodexAuthMode.pipe(
+		Schema.withConstructorDefault(Effect.succeed("legacy-image" as const)),
+		Schema.withDecodingDefaultType(Effect.succeed("legacy-image" as const)),
+	),
 	agent: ProviderId,
 	model: Schema.String,
 	runtimeMode: RuntimeMode.pipe(

--- a/packages/contracts/test/unit/cloud-auth.test.ts
+++ b/packages/contracts/test/unit/cloud-auth.test.ts
@@ -6,6 +6,8 @@ import {
 	CloudAuthConfigureRequest,
 	CloudAuthProviderStatus,
 	CloudAuthStatus,
+	CodexGrantRequest,
+	SealedCodexGrant,
 } from "../../src/index.ts";
 
 describe("E2B cloud authentication contracts", () => {
@@ -90,5 +92,31 @@ describe("E2B cloud authentication contracts", () => {
 
 		expect(provider.accountLabel).toBe("xAI account");
 		expect("secret" in provider).toBe(false);
+	});
+
+	it("routes only fenced Codex grant ciphertext through the API", () => {
+		const request = Schema.decodeUnknownSync(CodexGrantRequest)({
+			requestId: "4d2e6635-0f48-4aca-9d58-9942f08b1659",
+			protocolVersion: 1,
+			runtimeGeneration: 4,
+			credentialPublicJwk: '{"kty":"RSA"}',
+			reason: "initial",
+		});
+		const sealed = Schema.decodeUnknownSync(SealedCodexGrant)({
+			protocolVersion: 1,
+			requestId: request.requestId,
+			keyThumbprint: "runtime-key",
+			authorityIncarnationId: "authority-storage",
+			authorityEpoch: 2,
+			wrappedKey: "wrapped",
+			iv: "nonce",
+			ciphertext: "opaque",
+			tag: "authenticated",
+		});
+
+		expect(JSON.stringify(sealed)).not.toMatch(
+			/accessToken|refreshToken|chatgptAccountId/,
+		);
+		expect(request.reason).toBe("initial");
 	});
 });


### PR DESCRIPTION
## Summary

- make the account CloudAuthAuthority the only owner of Codex subscription refresh tokens
- issue short-lived, access-only grants sealed directly to each fenced cloud runtime key
- authenticate every Codex app-server launch through one memory-only external-auth bridge
- keep existing workspaces explicitly legacy while enrolling compatible new workspaces behind staging rollout flags
- surface account reconnect/update/legacy states instead of per-sandbox login or generic connection failures

## Reliability and security

- persists the deployment/account authority locator, storage incarnation, auth epoch, toolchain version, and provisioning lease
- serializes managed refreshes with `flock` and idempotently fingerprints grant requests
- verifies the pinned Codex 0.144.5 external-auth protocol and rejects incompatible authority toolchains
- strips only `.codex/auth.json` from broker-capable account images while preserving Codex config, skills, and MCP settings
- caches grants in runtime memory with single-flight and proactive refresh, then resumes only sessions positively blocked on auth
- leaves production enrollment and serving disabled; staging enables both capabilities

## Validation

- all contracts, agents, API, server, and renderer type checks
- contracts: 140 tests
- agents: 249 tests
- API: 228 tests
- server: 384 tests
- renderer: 652 tests
- pinned Codex binary external-auth contract test, including no `auth.json` persistence
- architecture and API terminology checks
- renderer production build and bundle budgets
- server production bundle

## Stack

Stacked on #537. Existing retained chats remain `legacy-image`; a new account-image build is required before staging can create 
