### PR TITLE
fix: recover queued messages after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Cloud sandbox images now preconfigure authenticated Git and GitHub CLI access, lazily minting and caching renewable repository credentials only when a GitHub command runs
+- Composer queues now stay held while the app is offline, resume on reconnect, and keep local desktop transports from being marked offline when only browser network connectivity drops
 - Cloud text messages can now be accepted while compute sleeps, wake the workspace through a durable encrypted mailbox, survive client/runtime restarts without duplicate provider sends, and report queued, cancelled, expired, or unknown outcomes explicitly
 - Cloud chats now automatically reconnect a failed client when the control plane reports that sandbox compute is ready, instead of showing a dead chat beside a working cloud terminal
 - The packaged `zusehq` CLI now discovers and authenticates to a foreground Serve process, reconnects after Serve restarts, and reports protocol mismatch, rejected credentials, and unavailable servers distinctly

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -39,6 +39,7 @@ import {
 import { useActiveSessionById } from "./lib/environment-entity-hooks.ts";
 import { useGitWorkspaceResource } from "./lib/git-workspace-client-bus.ts";
 import { markRendererStartupMilestone } from "./lib/performance-marks.ts";
+import { installQueueOnlineRecovery } from "./lib/queue-recovery.ts";
 import { getRpcClient } from "./lib/rpc-client.ts";
 import { useSettingsStore } from "./lib/settings-client-bus.ts";
 import {
@@ -316,6 +317,7 @@ function ReadyApp({
 	readonly onboardingCompleted: boolean;
 }) {
 	useEffect(() => installClientBusOnlineBridge(), []);
+	useEffect(() => installQueueOnlineRecovery(), []);
 	useEffect(() => {
 		let stop: (() => void) | undefined;
 		void startDesktopAnalytics().then((cleanup) => {

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -129,6 +129,7 @@ import {
 } from "../lib/environment-permissions-client-bus.ts";
 import { useEnvironmentShellResource } from "../lib/environment-shell-client-bus.ts";
 import { subscribeKeybindings } from "../lib/keybindings-client-bus.ts";
+import { usePlatformOnline } from "../lib/network-status.ts";
 import {
 	interruptSession,
 	queueSessionMessage,
@@ -161,6 +162,7 @@ import { AnnotationTray } from "./composer/annotation-tray.tsx";
 import { ComposerChipOverlay } from "./composer/composer-chip-overlay.tsx";
 import { ContextTray } from "./composer/context-tray.tsx";
 import { FileTagPopover } from "./composer/file-tag-popover.tsx";
+import { NoConnectionTray } from "./composer/no-connection-tray.tsx";
 import {
 	EMULATED_PLAN_APPROVAL_PROMPT,
 	PlanApprovalTray,
@@ -336,8 +338,15 @@ export function ChatComposer({
 			...options,
 			providerId: session.providerId,
 		});
+	const platformOnline = usePlatformOnline();
+	// A message queued while offline must wait for the network. The server has
+	// no connectivity signal, so its immediate flush is suppressed here and the
+	// held queue drains through the shared online-edge recovery.
 	const queue = (input: ComposerInput) =>
-		queueSessionMessage(goalRef, input, { providerId: session.providerId });
+		queueSessionMessage(goalRef, input, {
+			providerId: session.providerId,
+			...(platformOnline ? {} : { flush: false }),
+		});
 	const saveComposerDraft = useComposerDraftsStore((s) => s.save);
 	const clearComposerDraft = useComposerDraftsStore((s) => s.clear);
 
@@ -1125,6 +1134,7 @@ export function ChatComposer({
 							hasQueuedMessage: hasQueued,
 							runtimeStarting: !isCloudSession && runtimeState === "starting",
 							timelineLive: timeline.view.sync === "live",
+							platformOffline: !platformOnline,
 						}),
 					})
 				: null;
@@ -1309,72 +1319,75 @@ export function ChatComposer({
 						/>
 					) : null}
 					<div className="relative">
-						{!isDraft ? (
-							<div
-								className={cn(
-									composerTraySurfaceClass,
-									"relative z-10 rounded-b-none rounded-t-[1.2rem] empty:hidden",
-								)}
-							>
-								<PlanApprovalTray
-									environmentId={qualifiedEnvironmentId}
-									sessionId={sessionId}
-									emulatedPlanReady={emulatedPlanReady}
-									onApproveEmulatedPlan={approveEmulatedPlan}
-									onCancelEmulatedPlan={cancelEmulatedPlan}
-								/>
-								{goalCapable && goal !== null ? (
-									<GoalBanner
-										goal={goal}
-										inPlanMode={inPlanMode}
-										onPause={() =>
-											void setSessionGoal({
-												ref: goalRef,
-												goal: {
-													status:
-														goal.status === "active" ? "paused" : "active",
-												},
-											}).catch(() => undefined)
-										}
-										onSave={(objective, tokenBudget) =>
-											void setSessionGoal({
-												ref: goalRef,
-												goal: {
-													objective,
-													status: "active",
-													tokenBudget,
-												},
-											}).catch(() => undefined)
-										}
-										onClear={() =>
-											void clearSessionGoal({ ref: goalRef }).catch(
-												() => undefined,
-											)
-										}
-									/>
-								) : null}
-								<ContextTray
-									environmentId={qualifiedEnvironmentId}
-									sessionId={sessionId}
-								/>
-								{!inPlanMode ? (
-									<ProjectPlanTray
+						<div
+							className={cn(
+								composerTraySurfaceClass,
+								"relative z-10 rounded-b-none rounded-t-[1.2rem] empty:hidden",
+							)}
+						>
+							<NoConnectionTray />
+							{!isDraft ? (
+								<>
+									<PlanApprovalTray
 										environmentId={qualifiedEnvironmentId}
-										key={sessionId}
+										sessionId={sessionId}
+										emulatedPlanReady={emulatedPlanReady}
+										onApproveEmulatedPlan={approveEmulatedPlan}
+										onCancelEmulatedPlan={cancelEmulatedPlan}
+									/>
+									{goalCapable && goal !== null ? (
+										<GoalBanner
+											goal={goal}
+											inPlanMode={inPlanMode}
+											onPause={() =>
+												void setSessionGoal({
+													ref: goalRef,
+													goal: {
+														status:
+															goal.status === "active" ? "paused" : "active",
+													},
+												}).catch(() => undefined)
+											}
+											onSave={(objective, tokenBudget) =>
+												void setSessionGoal({
+													ref: goalRef,
+													goal: {
+														objective,
+														status: "active",
+														tokenBudget,
+													},
+												}).catch(() => undefined)
+											}
+											onClear={() =>
+												void clearSessionGoal({ ref: goalRef }).catch(
+													() => undefined,
+												)
+											}
+										/>
+									) : null}
+									<ContextTray
+										environmentId={qualifiedEnvironmentId}
 										sessionId={sessionId}
 									/>
-								) : null}
-								<QueueTray
-									environmentId={qualifiedEnvironmentId}
-									sessionId={sessionId}
-									creationInProgress={creationInProgress}
-									waitingForSandbox={
-										cloudSummary !== null &&
-										cloudWorkspaceIsStarting(cloudSummary)
-									}
-								/>
-							</div>
-						) : null}
+									{!inPlanMode ? (
+										<ProjectPlanTray
+											environmentId={qualifiedEnvironmentId}
+											key={sessionId}
+											sessionId={sessionId}
+										/>
+									) : null}
+									<QueueTray
+										environmentId={qualifiedEnvironmentId}
+										sessionId={sessionId}
+										creationInProgress={creationInProgress}
+										waitingForSandbox={
+											cloudSummary !== null &&
+											cloudWorkspaceIsStarting(cloudSummary)
+										}
+									/>
+								</>
+							) : null}
+						</div>
 						{editingQueuedItem !== null ? (
 							<div className="mb-1 flex h-7 items-center justify-between rounded-md bg-muted/35 px-2.5 text-xs text-muted-foreground">
 								<span>Editing queued message</span>

--- a/apps/renderer/src/components/composer/no-connection-tray.tsx
+++ b/apps/renderer/src/components/composer/no-connection-tray.tsx
@@ -1,0 +1,27 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import { WifiDisconnected01Icon } from "@zuse/icons/stroke-rounded";
+
+import { usePlatformOnline } from "../../lib/network-status.ts";
+import { TrayPill } from "./tray-pill.tsx";
+
+/**
+ * The one offline notice, attached to the composer like the queue and plan
+ * trays. It reflects platform connectivity only: the local desktop keeps
+ * working over IPC, and network-backed environments carry their own notices.
+ */
+export function NoConnectionTray() {
+	const online = usePlatformOnline();
+	if (online) return null;
+	return (
+		<TrayPill
+			flush
+			role="status"
+			aria-live="polite"
+			icon={
+				<HugeiconsIcon icon={WifiDisconnected01Icon} className="size-3.5" />
+			}
+			title="No connection"
+			subtitle="Cloud and remote computers reconnect when you're back online."
+		/>
+	);
+}

--- a/apps/renderer/src/components/composer/queue-tray.tsx
+++ b/apps/renderer/src/components/composer/queue-tray.tsx
@@ -1,5 +1,11 @@
 import type { EnvironmentId, SessionId } from "@zuse/contracts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { usePlatformOnline } from "../../lib/network-status.ts";
+import {
+	canResumeQueue,
+	holdQueueUntilOnline,
+	queueHoldReason,
+} from "../../lib/queue-recovery.ts";
 import {
 	reorderSessionQueue,
 	resumeSessionQueue,
@@ -34,6 +40,22 @@ export function QueueTray({
 	// Animate add / remove / reorder of queued rows. Clean default ease, no
 	// spring — keeps the tray feeling crisp rather than bouncy.
 	const listRef = useAutoAnimate<HTMLDivElement>();
+	const holdReason = queueHoldReason({ paused, runtime: timeline.runtime });
+	const resumable = canResumeQueue({
+		itemCount: items.length,
+		paused,
+		runtime: timeline.runtime,
+		creationInProgress,
+		waitingForSandbox,
+	});
+	// Messages queued while offline, or held by a turn that failed offline,
+	// should just go once the network is back. Register the queue with the
+	// shared recovery so it drains even after the user opens another chat.
+	const online = usePlatformOnline();
+	useEffect(() => {
+		if (!online && resumable)
+			holdQueueUntilOnline({ environmentId, sessionId });
+	}, [online, resumable, environmentId, sessionId]);
 	if (items.length === 0) return null;
 
 	const move = (from: number, to: number) => {
@@ -48,17 +70,25 @@ export function QueueTray({
 		);
 	};
 
-	const showPausedPill = paused && !running && !creationInProgress;
+	const showHeldPill = holdReason !== null && !running && !creationInProgress;
 
 	return (
 		<div ref={listRef}>
 			<div className="border-b border-border/40 px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
-				{waitingForSandbox ? "Waiting for sandbox" : "Queued"}
+				{waitingForSandbox
+					? "Waiting for sandbox"
+					: online
+						? "Queued"
+						: "Waiting for connection"}
 			</div>
-			{showPausedPill ? (
+			{showHeldPill ? (
 				<TrayPill
 					flush
-					title="Queue paused because you interrupted"
+					title={
+						holdReason === "paused"
+							? "Queue paused because you interrupted"
+							: "Queue held because the last turn failed"
+					}
 					actions={
 						<button
 							type="button"

--- a/apps/renderer/src/lib/client-bus-online.ts
+++ b/apps/renderer/src/lib/client-bus-online.ts
@@ -1,19 +1,21 @@
+import { isPlatformOnline, subscribePlatformOnline } from "./network-status.ts";
 import { getRendererClientBus } from "./session-timeline-client-bus.ts";
 
 let installed = false;
 
 /**
- * Wake the one ClientBus connection supervisor on a browser online edge.
+ * Wake the one ClientBus connection supervisor on a platform online edge.
  * Cached resources remain visible while offline; this only bypasses a pending
  * retry delay and cannot create per-feature reconnect loops.
  */
 export const installClientBusOnlineBridge = (): (() => void) => {
 	if (installed || typeof window === "undefined") return () => undefined;
 	installed = true;
-	const retry = () => getRendererClientBus().retryRetainedConnections();
-	window.addEventListener("online", retry);
+	const unsubscribe = subscribePlatformOnline(() => {
+		if (isPlatformOnline()) getRendererClientBus().retryRetainedConnections();
+	});
 	return () => {
-		window.removeEventListener("online", retry);
+		unsubscribe();
 		installed = false;
 	};
 };

--- a/apps/renderer/src/lib/composer-delivery.ts
+++ b/apps/renderer/src/lib/composer-delivery.ts
@@ -61,7 +61,9 @@ export const waitingCloudMessagePresentation = (
 
 /**
  * A live turn still owns queue semantics. A disconnected local/SSH session also
- * queues until its runtime stream is authoritative. Cloud sessions are
+ * queues until its runtime stream is authoritative, and so does a local session
+ * while the platform is offline: the agent provider needs the network, so the
+ * message waits in the queue and drains on the online edge. Cloud sessions are
  * different: their control-plane mailbox is authoritative while compute sleeps,
  * so lack of a live stream must not divert a new turn back to live RPC.
  */
@@ -71,11 +73,12 @@ export const shouldQueueComposerMessage = (input: {
 	readonly hasQueuedMessage: boolean;
 	readonly runtimeStarting: boolean;
 	readonly timelineLive: boolean;
+	readonly platformOffline: boolean;
 }): boolean =>
 	input.turnInFlight ||
 	input.hasQueuedMessage ||
 	input.runtimeStarting ||
-	(!input.isCloudSession && !input.timelineLive);
+	(!input.isCloudSession && (!input.timelineLive || input.platformOffline));
 
 /** Keep the recoverable draft intact until the mailbox (or live runtime) acks. */
 export const commitAcceptedComposerDelivery = async (

--- a/apps/renderer/src/lib/network-status.ts
+++ b/apps/renderer/src/lib/network-status.ts
@@ -1,0 +1,39 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * The renderer's single mirror of `navigator.onLine`. Connection supervisors
+ * consult it only for transports that cross the network; the composer banner
+ * renders from it directly.
+ */
+let online = globalThis.navigator?.onLine ?? true;
+const listeners = new Set<() => void>();
+
+export const isPlatformOnline = (): boolean => online;
+
+export const subscribePlatformOnline = (listener: () => void): (() => void) => {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+};
+
+const setOnline = (next: boolean): void => {
+	if (online === next) return;
+	online = next;
+	for (const listener of listeners) listener();
+};
+
+export const setPlatformOnlineForTest = setOnline;
+
+/** Reads the mirror directly for the server snapshot so static-markup tests can flip it. */
+export const usePlatformOnline = (): boolean =>
+	useSyncExternalStore(
+		subscribePlatformOnline,
+		isPlatformOnline,
+		isPlatformOnline,
+	);
+
+if (typeof window !== "undefined") {
+	window.addEventListener("online", () => setOnline(true));
+	window.addEventListener("offline", () => setOnline(false));
+}

--- a/apps/renderer/src/lib/queue-recovery.ts
+++ b/apps/renderer/src/lib/queue-recovery.ts
@@ -1,0 +1,76 @@
+import type { SessionRef } from "@zuse/client-runtime/resource-ref";
+
+import { isPlatformOnline, subscribePlatformOnline } from "./network-status.ts";
+import { resumeSessionQueue } from "./session-actions.ts";
+import type { SessionRuntimeState } from "./session-runtime-state.ts";
+
+export type QueueRecoveryInput = Readonly<{
+	itemCount: number;
+	paused: boolean;
+	runtime: SessionRuntimeState;
+	creationInProgress: boolean;
+	waitingForSandbox: boolean;
+}>;
+
+/**
+ * The server never drains a queue on its own once a turn settles in error, so
+ * a held queue needs an explicit resume. Interrupts pause the queue; a failed
+ * turn leaves it held without a pause flag.
+ */
+export const queueHoldReason = (
+	input: Pick<QueueRecoveryInput, "paused" | "runtime">,
+): "paused" | "failed" | null =>
+	input.paused ? "paused" : input.runtime === "failed" ? "failed" : null;
+
+/**
+ * Whether the queue can be resumed without racing a live turn. Used both for
+ * the tray's Resume pill and for the automatic resume on a network online edge.
+ */
+export const canResumeQueue = (input: QueueRecoveryInput): boolean =>
+	input.itemCount > 0 &&
+	!input.creationInProgress &&
+	!input.waitingForSandbox &&
+	input.runtime !== "running" &&
+	input.runtime !== "stopping" &&
+	input.runtime !== "starting";
+
+const heldQueues = new Map<string, SessionRef>();
+const heldKey = (ref: SessionRef): string =>
+	`${ref.environmentId} ${ref.sessionId}`;
+
+/**
+ * Remember a queue that is waiting for the network. Messages queued while
+ * offline skip the server's immediate flush, so something must resume them
+ * once the platform is back online, even if the user has moved to another chat.
+ */
+export const holdQueueUntilOnline = (ref: SessionRef): void => {
+	heldQueues.set(heldKey(ref), ref);
+};
+
+export const heldQueueRefsForTest = (): ReadonlyArray<SessionRef> => [
+	...heldQueues.values(),
+];
+
+export const clearHeldQueuesForTest = (): void => {
+	heldQueues.clear();
+};
+
+/** Resume every held queue on the next offline-to-online edge. */
+export const installQueueOnlineRecovery = (
+	resume: (ref: SessionRef) => Promise<void> = resumeSessionQueue,
+): (() => void) => {
+	let wasOnline = isPlatformOnline();
+	return subscribePlatformOnline(() => {
+		const nowOnline = isPlatformOnline();
+		const cameOnline = nowOnline && !wasOnline;
+		wasOnline = nowOnline;
+		if (!cameOnline) return;
+		const refs = [...heldQueues.values()];
+		heldQueues.clear();
+		for (const ref of refs) {
+			void resume(ref).catch(() => {
+				heldQueues.set(heldKey(ref), ref);
+			});
+		}
+	});
+};

--- a/apps/renderer/src/lib/rpc-client.ts
+++ b/apps/renderer/src/lib/rpc-client.ts
@@ -28,6 +28,7 @@ import { requestBrowserWebSocketUrl } from "./browser-session.ts";
 import { cloudFailurePresentation } from "./cloud-failure-presentation.ts";
 import { recordDiagnosticEvent } from "./diagnostics-recorder.ts";
 import { electronClientProtocolLayer } from "./electron-client-protocol.ts";
+import { isPlatformOnline, subscribePlatformOnline } from "./network-status.ts";
 import {
 	LOCAL_RENDERER_STORAGE_SCOPE,
 	setActiveEnvironmentStorageScope,
@@ -73,6 +74,11 @@ export type PassiveRendererSessionHooks = Readonly<{
 }>;
 
 export const LOCAL_ENVIRONMENT_KEY = "local";
+
+/** Only WebSocket transports cross the network; the Electron bridge is in-process. */
+export const connectionRequiresNetwork = (
+	options: Pick<RendererConnectionOptions, "kind">,
+): boolean => options.kind === "websocket";
 
 const environmentConnections = new Map<string, RendererConnectionOptions>();
 type CloudWorkspaceRegistration = {
@@ -245,6 +251,18 @@ const optionsForEnvironment = (
 	return connectionOptions();
 };
 
+/**
+ * Whether reaching this environment depends on the network. Unknown ids are
+ * treated as network-backed: cloud workspaces register their transport inside
+ * the resolver's prepare step, after the platform offline check runs.
+ */
+export const environmentRequiresNetwork = (environmentId: string): boolean => {
+	const options =
+		environmentConnections.get(environmentId) ??
+		(environmentId === LOCAL_ENVIRONMENT_KEY ? connectionOptions() : undefined);
+	return options === undefined || connectionRequiresNetwork(options);
+};
+
 const prepareRendererConnectionOptions = async (
 	options: RendererConnectionOptions,
 ): Promise<RendererConnectionOptions> => {
@@ -262,7 +280,6 @@ const prepareRendererConnectionOptions = async (
 		: { ...options, wsUrl: await options.refreshWsUrl() };
 };
 
-let online = globalThis.navigator?.onLine ?? true;
 export const RENDERER_WEBSOCKET_OPEN_TIMEOUT = "3 seconds" as const;
 
 export const isIgnorableRendererFailure = (cause: unknown): boolean =>
@@ -327,7 +344,8 @@ const supervisor = createConnectionSupervisor<
 >({
 	keyOf: (options) => options.key,
 	prepareOptions: prepareRendererConnectionOptions,
-	isOnline: () => online,
+	isOnline: isPlatformOnline,
+	requiresNetwork: connectionRequiresNetwork,
 	isIgnorableFailure: isIgnorableRendererFailure,
 	maxAutomaticAttempts: 6,
 	schedule: (delayMs, reconnect) => {
@@ -730,15 +748,9 @@ export const disposeRpcClient = async (): Promise<void> => {
 	await supervisor.dispose();
 };
 
+subscribePlatformOnline(() => supervisor.setOnline(isPlatformOnline()));
+
 if (typeof window !== "undefined") {
-	window.addEventListener("online", () => {
-		online = true;
-		supervisor.setOnline(true);
-	});
-	window.addEventListener("offline", () => {
-		online = false;
-		supervisor.setOnline(false);
-	});
 	window.addEventListener("pagehide", () => {
 		void disposeRpcClient();
 	});

--- a/apps/renderer/src/lib/session-timeline-client-bus.ts
+++ b/apps/renderer/src/lib/session-timeline-client-bus.ts
@@ -39,8 +39,10 @@ import {
 } from "./client-command-outbox.ts";
 import { cloudCommandTransport } from "./cloud-command-transport.ts";
 import { cloudFailurePresentation } from "./cloud-failure-presentation.ts";
+import { isPlatformOnline } from "./network-status.ts";
 import {
 	acquireRendererRpcSession,
+	environmentRequiresNetwork,
 	isAuthCodedConnectionError,
 	isCloudWorkspaceEnvironment,
 	isRpcClientTransportError,
@@ -1038,7 +1040,12 @@ export const registerEnvironmentActivation = (
 	};
 };
 
-const faultFor = (cause: unknown): EnvironmentFault => {
+/** Classify a transport failure; `networkOffline` is true only when the
+ * environment's transport crosses the network and the platform is offline. */
+export const environmentFaultFor = (
+	cause: unknown,
+	networkOffline: boolean,
+): EnvironmentFault => {
 	const code =
 		typeof cause === "object" && cause !== null && "code" in cause
 			? String(cause.code)
@@ -1049,20 +1056,28 @@ const faultFor = (cause: unknown): EnvironmentFault => {
 		(cause instanceof Error && cause.message !== ""
 			? cause.message
 			: (presentation?.kind ?? String(cause)));
-	const phase: EnvironmentFault["phase"] =
-		globalThis.navigator?.onLine === false
-			? "offline"
-			: presentation?.kind === "update-required"
-				? "update-required"
-				: presentation?.kind === "cloud-access-required" ||
-						presentation?.kind === "cloud-access-unavailable"
-					? "revoked"
-					: isAuthCodedConnectionError(cause) ||
-							presentation?.kind === "sign-in-required"
-						? "blocked-auth"
-						: "failed";
+	const phase: EnvironmentFault["phase"] = networkOffline
+		? "offline"
+		: presentation?.kind === "update-required"
+			? "update-required"
+			: presentation?.kind === "cloud-access-required" ||
+					presentation?.kind === "cloud-access-unavailable"
+				? "revoked"
+				: isAuthCodedConnectionError(cause) ||
+						presentation?.kind === "sign-in-required"
+					? "blocked-auth"
+					: "failed";
 	return { phase, message };
 };
+
+const faultFor = (
+	environmentId: EnvironmentId,
+	cause: unknown,
+): EnvironmentFault =>
+	environmentFaultFor(
+		cause,
+		environmentRequiresNetwork(environmentId) && !isPlatformOnline(),
+	);
 
 const environmentResolver: EnvironmentResolver<MemoizeClient> = {
 	resolve: (environmentId, activation) =>
@@ -1080,7 +1095,11 @@ const environmentResolver: EnvironmentResolver<MemoizeClient> = {
 						pendingFault = cause;
 						return;
 					}
-					reportPassiveSessionFault(environmentId, faultFor(cause), generation);
+					reportPassiveSessionFault(
+						environmentId,
+						faultFor(environmentId, cause),
+						generation,
+					);
 				});
 				try {
 					await registered?.prepareClient?.(session.client);
@@ -1102,14 +1121,14 @@ const environmentResolver: EnvironmentResolver<MemoizeClient> = {
 						queueMicrotask(() => {
 							reportPassiveSessionFault(
 								environmentId,
-								faultFor(fault),
+								faultFor(environmentId, fault),
 								activeGeneration,
 							);
 						});
 					},
 				};
 			},
-			catch: faultFor,
+			catch: (cause) => faultFor(environmentId, cause),
 		}),
 };
 
@@ -1163,11 +1182,12 @@ const createBus = (): ClientBus<MemoizeClient> => {
 			cloudCommandEligibility(kind) !== undefined
 				? cloudCommandTransport
 				: undefined,
-		commandFaultFor: (cause) =>
-			isRpcClientTransportError(cause) ? faultFor(cause) : null,
+		commandFaultFor: (cause, environmentId) =>
+			isRpcClientTransportError(cause) ? faultFor(environmentId, cause) : null,
 		commandReflected: sessionMessageCommandReflected,
 		runtime: {
-			isOnline: () => globalThis.navigator?.onLine !== false,
+			isOnline: isPlatformOnline,
+			requiresNetwork: environmentRequiresNetwork,
 		},
 		synchronizer: {
 			synchronize: async <Data>(
@@ -1190,7 +1210,10 @@ const createBus = (): ClientBus<MemoizeClient> => {
 					if (!isRpcClientTransportError(cause)) return;
 					bus.reportConnectionFault(
 						environmentId,
-						{ phase: "failed", message: faultFor(cause).message },
+						{
+							phase: "failed",
+							message: faultFor(environmentId, cause).message,
+						},
 						generation,
 					);
 				}) as ResourceDriver<MemoizeClient, unknown>;

--- a/apps/renderer/test/unit/composer-delivery.test.ts
+++ b/apps/renderer/test/unit/composer-delivery.test.ts
@@ -46,6 +46,7 @@ describe("composer cloud delivery routing", () => {
 				hasQueuedMessage: false,
 				runtimeStarting: false,
 				timelineLive: false,
+				platformOffline: false,
 			}),
 		).toBe(false);
 	});
@@ -58,6 +59,7 @@ describe("composer cloud delivery routing", () => {
 				hasQueuedMessage: false,
 				runtimeStarting: false,
 				timelineLive: true,
+				platformOffline: false,
 			}),
 		).toBe(true);
 	});
@@ -70,8 +72,32 @@ describe("composer cloud delivery routing", () => {
 				hasQueuedMessage: false,
 				runtimeStarting: false,
 				timelineLive: false,
+				platformOffline: false,
 			}),
 		).toBe(true);
+	});
+
+	it("holds a local send in the queue while the platform is offline", () => {
+		expect(
+			shouldQueueComposerMessage({
+				isCloudSession: false,
+				turnInFlight: false,
+				hasQueuedMessage: false,
+				runtimeStarting: false,
+				timelineLive: true,
+				platformOffline: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldQueueComposerMessage({
+				isCloudSession: true,
+				turnInFlight: false,
+				hasQueuedMessage: false,
+				runtimeStarting: false,
+				timelineLive: true,
+				platformOffline: true,
+			}),
+		).toBe(false);
 	});
 
 	it("clears a draft only after delivery acceptance", async () => {

--- a/apps/renderer/test/unit/no-connection-tray.test.tsx
+++ b/apps/renderer/test/unit/no-connection-tray.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it } from "vitest";
+import { NoConnectionTray } from "../../src/components/composer/no-connection-tray.tsx";
+import { setPlatformOnlineForTest } from "../../src/lib/network-status.ts";
+
+describe("NoConnectionTray", () => {
+	afterEach(() => {
+		setPlatformOnlineForTest(true);
+	});
+
+	it("renders nothing while the platform is online", () => {
+		setPlatformOnlineForTest(true);
+		expect(renderToStaticMarkup(<NoConnectionTray />)).toBe("");
+	});
+
+	it("shows the No connection pill while offline", () => {
+		setPlatformOnlineForTest(false);
+		const markup = renderToStaticMarkup(<NoConnectionTray />);
+		expect(markup).toContain("No connection");
+		expect(markup).toContain('role="status"');
+	});
+
+	it("renders as a flush composer tray row", () => {
+		setPlatformOnlineForTest(false);
+		const markup = renderToStaticMarkup(<NoConnectionTray />);
+		expect(markup).toContain("border-b border-border/35");
+		expect(markup).not.toContain("bg-alert-error-bg");
+	});
+});

--- a/apps/renderer/test/unit/provider-status.test.ts
+++ b/apps/renderer/test/unit/provider-status.test.ts
@@ -12,6 +12,7 @@ const toast = vi.hoisted(() => ({
 
 vi.mock("../../src/lib/rpc-client.ts", () => ({
 	LOCAL_ENVIRONMENT_KEY: "local",
+	environmentRequiresNetwork: () => false,
 	getActiveEnvironment: () => "local",
 }));
 

--- a/apps/renderer/test/unit/queue-recovery.test.ts
+++ b/apps/renderer/test/unit/queue-recovery.test.ts
@@ -1,0 +1,94 @@
+import { EnvironmentId, SessionId } from "@zuse/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { setPlatformOnlineForTest } from "../../src/lib/network-status.ts";
+import {
+	canResumeQueue,
+	clearHeldQueuesForTest,
+	heldQueueRefsForTest,
+	holdQueueUntilOnline,
+	installQueueOnlineRecovery,
+	queueHoldReason,
+} from "../../src/lib/queue-recovery.ts";
+
+describe("queue recovery", () => {
+	afterEach(() => {
+		setPlatformOnlineForTest(true);
+		clearHeldQueuesForTest();
+	});
+
+	it("reports why a queue is held", () => {
+		expect(queueHoldReason({ paused: true, runtime: "idle" })).toBe("paused");
+		expect(queueHoldReason({ paused: false, runtime: "failed" })).toBe(
+			"failed",
+		);
+		expect(queueHoldReason({ paused: true, runtime: "failed" })).toBe("paused");
+		expect(queueHoldReason({ paused: false, runtime: "idle" })).toBeNull();
+	});
+
+	it("resumes only a non-empty queue on a settled session", () => {
+		const base = {
+			itemCount: 1,
+			paused: false,
+			creationInProgress: false,
+			waitingForSandbox: false,
+		};
+		expect(canResumeQueue({ ...base, runtime: "failed" })).toBe(true);
+		expect(canResumeQueue({ ...base, runtime: "idle" })).toBe(true);
+		expect(canResumeQueue({ ...base, runtime: "running" })).toBe(false);
+		expect(canResumeQueue({ ...base, runtime: "stopping" })).toBe(false);
+		expect(canResumeQueue({ ...base, runtime: "starting" })).toBe(false);
+		expect(canResumeQueue({ ...base, runtime: "idle", itemCount: 0 })).toBe(
+			false,
+		);
+		expect(
+			canResumeQueue({ ...base, runtime: "idle", creationInProgress: true }),
+		).toBe(false);
+		expect(
+			canResumeQueue({ ...base, runtime: "idle", waitingForSandbox: true }),
+		).toBe(false);
+	});
+
+	it("resumes held queues once on the online edge", async () => {
+		const resumed: string[] = [];
+		setPlatformOnlineForTest(false);
+		const uninstall = installQueueOnlineRecovery(async (ref) => {
+			resumed.push(ref.sessionId);
+		});
+		const ref = {
+			environmentId: EnvironmentId.make("env_local"),
+			sessionId: SessionId.make("session_held"),
+		};
+		holdQueueUntilOnline(ref);
+		holdQueueUntilOnline(ref);
+		expect(heldQueueRefsForTest()).toHaveLength(1);
+
+		setPlatformOnlineForTest(true);
+		await Promise.resolve();
+		expect(resumed).toEqual(["session_held"]);
+		expect(heldQueueRefsForTest()).toHaveLength(0);
+
+		setPlatformOnlineForTest(false);
+		setPlatformOnlineForTest(true);
+		expect(resumed).toEqual(["session_held"]);
+		uninstall();
+	});
+
+	it("keeps a held queue registered when resume fails", async () => {
+		setPlatformOnlineForTest(false);
+		const ref = {
+			environmentId: EnvironmentId.make("env_local"),
+			sessionId: SessionId.make("session_retry"),
+		};
+		const uninstall = installQueueOnlineRecovery(async () => {
+			throw new Error("resume failed");
+		});
+		holdQueueUntilOnline(ref);
+
+		setPlatformOnlineForTest(true);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(heldQueueRefsForTest()).toEqual([ref]);
+		uninstall();
+	});
+});

--- a/apps/renderer/test/unit/rpc-client.test.ts
+++ b/apps/renderer/test/unit/rpc-client.test.ts
@@ -15,6 +15,8 @@ const {
 	acquireRendererRpcSession,
 	canReuseCloudWorkspaceTicket,
 	clearCloudWorkspaceRuntimeRecovery,
+	connectionRequiresNetwork,
+	environmentRequiresNetwork,
 	cloudWorkspaceRequiresRuntimeRecovery,
 	cloudWorkspaceRuntimeRecoveryCommandId,
 	requestCloudWorkspaceRuntimeRecovery,
@@ -25,6 +27,7 @@ const {
 	refreshCloudWorkspaceConnectionWithRecovery,
 	RENDERER_WEBSOCKET_OPEN_TIMEOUT,
 	registerLocalEnvironment,
+	registerWebSocketEnvironment,
 	resolveRendererRpcTransportForTest,
 	setActiveEnvironment,
 	shouldReconnectRendererConnection,
@@ -93,6 +96,24 @@ describe("renderer RPC transport selection", () => {
 		});
 
 		expect(resolveRendererRpcTransportForTest()).toEqual({ kind: "electron" });
+	});
+
+	it("treats only WebSocket transports as network-backed", () => {
+		Object.defineProperty(globalThis, "window", {
+			value: { zuse: { rpc: {} } },
+			configurable: true,
+		});
+
+		expect(connectionRequiresNetwork({ kind: "electron" })).toBe(false);
+		expect(connectionRequiresNetwork({ kind: "websocket" })).toBe(true);
+
+		registerLocalEnvironment("env_local");
+		registerWebSocketEnvironment("env_ssh", "ws://example.test/rpc");
+
+		expect(environmentRequiresNetwork("local")).toBe(false);
+		expect(environmentRequiresNetwork("env_local")).toBe(false);
+		expect(environmentRequiresNetwork("env_ssh")).toBe(true);
+		expect(environmentRequiresNetwork("env_unknown")).toBe(true);
 	});
 
 	it("classifies coded auth rejections that carry no message text", async () => {

--- a/apps/renderer/test/unit/session-timeline-client-bus.test.ts
+++ b/apps/renderer/test/unit/session-timeline-client-bus.test.ts
@@ -31,6 +31,7 @@ import { sessionMessageCommandReflected } from "../../src/lib/session-message-in
 import {
 	addOptimisticSessionMessage,
 	completeOlderSessionMessages,
+	environmentFaultFor,
 	getRendererClientBus,
 	loadOlderSessionMessages,
 	registerEnvironmentActivationForTest,
@@ -941,5 +942,25 @@ describe("renderer session timeline ClientBus adapter", () => {
 		});
 		lease.release();
 		unregister();
+	});
+});
+
+describe("environmentFaultFor", () => {
+	it("classifies a transport failure as failed unless the environment's network is down", () => {
+		const closed = new Error("WebSocket closed (1006).");
+		expect(environmentFaultFor(closed, false)).toEqual({
+			phase: "failed",
+			message: "WebSocket closed (1006).",
+		});
+		expect(environmentFaultFor(closed, true).phase).toBe("offline");
+	});
+
+	it("keeps auth-coded rejections as blocked-auth", () => {
+		expect(
+			environmentFaultFor(
+				new CloudWorkspaceOpError({ code: "not-allowed" }),
+				false,
+			).phase,
+		).toBe("blocked-auth");
 	});
 });

--- a/packages/client-runtime/src/client-bus.ts
+++ b/packages/client-runtime/src/client-bus.ts
@@ -146,7 +146,10 @@ export type ClientBusOptions<Client> = Readonly<{
 		kind: string,
 	) => CloudCommandTransport | undefined;
 	/** Maps transport-level command failures into the shared connection state. */
-	commandFaultFor?: (cause: unknown) => EnvironmentFault | null;
+	commandFaultFor?: (
+		cause: unknown,
+		environmentId: EnvironmentId,
+	) => EnvironmentFault | null;
 	/** Proves that an applied command is present in its authoritative resource. */
 	commandReflected?: (
 		command: ClientCommand,
@@ -1685,7 +1688,9 @@ export class ClientBus<Client> {
 					try {
 						executionReceipt = await executor.execute(client, command);
 					} catch (cause) {
-						const fault = this.options.commandFaultFor?.(cause) ?? null;
+						const fault =
+							this.options.commandFaultFor?.(cause, command.environmentId) ??
+							null;
 						if (fault !== null) {
 							binding.runtime.reportFault(fault, generation);
 						} else {

--- a/packages/client-runtime/src/environment-runtime.ts
+++ b/packages/client-runtime/src/environment-runtime.ts
@@ -30,6 +30,11 @@ export interface EnvironmentResolver<Client> {
 
 export type EnvironmentRuntimeOptions = Readonly<{
 	isOnline?: () => boolean;
+	/**
+	 * Whether this environment's transport crosses the network. Environments
+	 * reached in-process ignore platform offline edges. Default: true.
+	 */
+	requiresNetwork?: (environmentId: EnvironmentId) => boolean;
 	schedule?: (delayMs: number, task: () => void) => () => void;
 	random?: () => number;
 }>;
@@ -151,7 +156,7 @@ export class EnvironmentRuntime<Client> {
 			this.retryAttempt = 0;
 		}
 		this.clearRetry();
-		if ((this.options.isOnline?.() ?? true) === false) {
+		if (this.platformOffline()) {
 			this.emit({ phase: "offline", error: null });
 			this.scheduleRetry();
 			return Promise.reject(new Error("offline"));
@@ -222,6 +227,14 @@ export class EnvironmentRuntime<Client> {
 		this.closeCurrent();
 		await this.disposeInFlight;
 		this.listeners.clear();
+	}
+
+	/** Platform connectivity only gates environments reached over the network. */
+	private platformOffline(): boolean {
+		return (
+			(this.options.requiresNetwork?.(this.environmentId) ?? true) &&
+			(this.options.isOnline?.() ?? true) === false
+		);
 	}
 
 	private async resolveDesired(): Promise<Client | null> {

--- a/packages/client-runtime/src/supervisor.ts
+++ b/packages/client-runtime/src/supervisor.ts
@@ -56,6 +56,12 @@ export type ConnectionSupervisorDeps<Options, Client> = {
 	readonly createClient: (options: Options) => Promise<ClientSession<Client>>;
 	readonly validateClient?: (client: Client) => Promise<void>;
 	readonly isOnline: () => boolean;
+	/**
+	 * Whether this connection's transport crosses the network. In-process
+	 * transports (an Electron IPC bridge) ignore platform offline edges.
+	 * Default: true.
+	 */
+	readonly requiresNetwork?: (options: Options) => boolean;
 	readonly schedule: (delayMs: number, fn: () => void) => () => void;
 	readonly classifyError?: (cause: unknown) => "auth" | "transient";
 	readonly isRetryableCommandError?: (cause: unknown) => boolean;
@@ -146,7 +152,7 @@ class SupervisorEntryImpl<Options, Client>
 		this.options = options;
 		this.state = {
 			key,
-			status: deps.isOnline() ? "connecting" : "offline",
+			status: this.isOnline() ? "connecting" : "offline",
 			generation: 0,
 			attempt: 0,
 			error: null,
@@ -164,11 +170,11 @@ class SupervisorEntryImpl<Options, Client>
 		this.clearRetry();
 		this.invalidateClient();
 		this.emit({
-			status: this.deps.isOnline() ? "reconnecting" : "offline",
+			status: this.isOnline() ? "reconnecting" : "offline",
 			attempt: 0,
 			error: null,
 		});
-		if (this.deps.isOnline()) void this.ensureClient().catch(() => undefined);
+		if (this.isOnline()) void this.ensureClient().catch(() => undefined);
 	}
 
 	snapshot(): ConnectionSnapshot {
@@ -246,7 +252,7 @@ class SupervisorEntryImpl<Options, Client>
 	retryNow(): void {
 		if (this.removed) return;
 		this.clearRetry();
-		if (!this.deps.isOnline()) {
+		if (!this.isOnline()) {
 			this.emit({ status: "offline", error: null });
 			return;
 		}
@@ -262,6 +268,7 @@ class SupervisorEntryImpl<Options, Client>
 	setOnline(online: boolean): void {
 		if (this.removed) return;
 		if (!online) {
+			if (!this.needsNetwork()) return;
 			this.clearRetry();
 			this.invalidateClient();
 			this.emit({ status: "offline", error: null });
@@ -286,9 +293,18 @@ class SupervisorEntryImpl<Options, Client>
 		this.diagnostic("entry.removed");
 	}
 
+	private needsNetwork(): boolean {
+		return this.deps.requiresNetwork?.(this.options) ?? true;
+	}
+
+	/** Platform connectivity only gates transports that cross the network. */
+	private isOnline(): boolean {
+		return !this.needsNetwork() || this.deps.isOnline();
+	}
+
 	private async ensureClient(): Promise<Client> {
 		if (this.removed) throw new Error("connection removed");
-		if (!this.deps.isOnline()) {
+		if (!this.isOnline()) {
 			this.emit({ status: "offline", error: null });
 			throw new Error("offline");
 		}
@@ -359,7 +375,7 @@ class SupervisorEntryImpl<Options, Client>
 	}
 
 	private markFailure(cause: unknown): void {
-		if (!this.deps.isOnline()) {
+		if (!this.isOnline()) {
 			this.emit({ status: "offline", error: null });
 			return;
 		}

--- a/packages/client-runtime/test/unit/client-bus.test.ts
+++ b/packages/client-runtime/test/unit/client-bus.test.ts
@@ -783,6 +783,33 @@ describe("ClientBus", () => {
 		await bus.dispose();
 	});
 
+	it("passes the command's environment to commandFaultFor", async () => {
+		const faultFor = vi.fn(() => null);
+		const bus = new ClientBus<Client>({
+			resolver: immediateResolver(),
+			persistence: new MemoryPersistence(),
+			commandExecutor: {
+				execute: async () => {
+					throw new Error("socket closed");
+				},
+			},
+			commandFaultFor: faultFor,
+		});
+		await expect(
+			bus.dispatch({
+				kind: "messages.send",
+				commandId: CommandId.make("command-fault-environment"),
+				environmentId,
+				resource: timelineKey,
+				payload: { text: "hello" },
+				retry: "safe" as const,
+				createdAt: 1,
+			}),
+		).rejects.toThrow("socket closed");
+		expect(faultFor).toHaveBeenCalledWith(expect.any(Error), environmentId);
+		await bus.dispose();
+	});
+
 	it("persists safe commands before send and removes them after receipt", async () => {
 		const persistence = new MemoryPersistence();
 		const commandId = CommandId.make("command-1");

--- a/packages/client-runtime/test/unit/environment-runtime.test.ts
+++ b/packages/client-runtime/test/unit/environment-runtime.test.ts
@@ -453,6 +453,47 @@ describe("EnvironmentRuntimeRegistry", () => {
 		await registry.dispose();
 	});
 
+	it("resolves a network-free environment while the platform is offline", async () => {
+		let resolves = 0;
+		const scheduled: Array<{ task: () => void; cancelled: boolean }> = [];
+		const registry = new EnvironmentRuntimeRegistry<{ id: number }>(
+			{
+				resolve: () =>
+					Effect.sync(() => ({
+						client: { id: ++resolves },
+						dispose: async () => undefined,
+					})),
+			},
+			{
+				isOnline: () => false,
+				requiresNetwork: (environmentId) =>
+					environmentId !== "environment-local",
+				schedule: (_delay, task) => {
+					const item = { task, cancelled: false };
+					scheduled.push(item);
+					return () => {
+						item.cancelled = true;
+					};
+				},
+			},
+		);
+		const local = registry.get(EnvironmentId.make("environment-local"));
+		const localLease = local.retain("connect");
+		await waitUntil(() => local.snapshot().phase === "connected");
+		expect(resolves).toBe(1);
+		expect(scheduled).toHaveLength(0);
+
+		const remote = registry.get(EnvironmentId.make("environment-remote"));
+		const remoteLease = remote.retain("connect");
+		await waitUntil(() => remote.snapshot().phase === "offline");
+		expect(resolves).toBe(1);
+		expect(scheduled).toHaveLength(1);
+
+		localLease.release();
+		remoteLease.release();
+		await registry.dispose();
+	});
+
 	it("recomputes activation per lease and closes after final network downgrade", async () => {
 		const activations: string[] = [];
 		let disposals = 0;

--- a/packages/client-runtime/test/unit/supervisor.test.ts
+++ b/packages/client-runtime/test/unit/supervisor.test.ts
@@ -37,6 +37,7 @@ const makeHarness = (input?: {
 		previous: Options,
 		next: Options,
 	) => boolean;
+	requiresNetwork?: (options: Options) => boolean;
 }) => {
 	let online = input?.online ?? true;
 	let nextId = 0;
@@ -47,6 +48,7 @@ const makeHarness = (input?: {
 	const supervisor = createConnectionSupervisor<Options, Client>({
 		keyOf: (options) => options.key,
 		isOnline: () => online,
+		requiresNetwork: input?.requiresNetwork,
 		maxAutomaticAttempts: input?.maxAutomaticAttempts,
 		prepareOptions: input?.prepareOptions,
 		isRetryableCommandError: input?.isRetryableCommandError,
@@ -119,6 +121,65 @@ describe("connection supervisor", () => {
 			{ id: 1 },
 		]);
 		expect(calls).toBe(1);
+	});
+
+	test("keeps a network-free connection alive across platform offline edges", async () => {
+		const harness = makeHarness({
+			requiresNetwork: (options) => options.key !== "local",
+		});
+		const entry = harness.supervisor.get({ key: "local" });
+		const client = await runClient(entry.getClient());
+		expect(entry.snapshot()).toMatchObject({
+			status: "connected",
+			generation: 1,
+		});
+
+		harness.setOnline(false);
+
+		expect(entry.snapshot()).toMatchObject({
+			status: "connected",
+			generation: 1,
+		});
+		expect(harness.disposed).toEqual([]);
+		expect(harness.scheduled).toEqual([]);
+		await expect(runClient(entry.getClient())).resolves.toBe(client);
+
+		harness.setOnline(true);
+		expect(entry.snapshot()).toMatchObject({
+			status: "connected",
+			generation: 1,
+		});
+		expect(harness.created).toHaveLength(1);
+	});
+
+	test("connects a network-free connection while the platform is offline", async () => {
+		const harness = makeHarness({
+			online: false,
+			requiresNetwork: () => false,
+		});
+		const entry = harness.supervisor.get({ key: "local" });
+		expect(entry.snapshot().status).toBe("connecting");
+		await expect(runClient(entry.getClient())).resolves.toEqual({ id: 1 });
+		expect(entry.snapshot().status).toBe("connected");
+	});
+
+	test("gates only network connections on the platform online state", async () => {
+		const harness = makeHarness({
+			requiresNetwork: (options) => options.key === "remote",
+		});
+		const local = harness.supervisor.get({ key: "local" });
+		const remote = harness.supervisor.get({ key: "remote" });
+		const localClient = await runClient(local.getClient());
+		const remoteClient = await runClient(remote.getClient());
+
+		harness.setOnline(false);
+
+		expect(remote.snapshot().status).toBe("offline");
+		await waitUntil(() => harness.disposed.length === 1);
+		expect(harness.disposed).toEqual([remoteClient.id]);
+		await expect(runClient(remote.getClient())).rejects.toThrow("offline");
+		expect(local.snapshot().status).toBe("connected");
+		await expect(runClient(local.getClient())).resolves.toBe(localClient);
 	});
 
 	test("starts offline and connects on online wakeup without consuming retries", async () => {


### PR DESCRIPTION
## Summary

- Adds a shared renderer platform-connectivity store and uses it for the client bus online bridge, RPC supervisor, and composer UI.
- Keeps local/in-process transports available when browser network connectivity drops, while still marking websocket-backed environments offline.
- Queues composer sends while offline without flushing immediately, shows a compact no-connection tray, and resumes held queues on reconnect.
- Adds regression coverage for offline queue delivery, queue recovery, connection fault classification, and network-gated supervisor/runtime behavior.

## Test Coverage

All new code paths have focused unit coverage:

- `network-status.ts`: platform online mirror and subscriptions covered through queue recovery and no-connection tray tests.
- `queue-recovery.ts`: held reason, resumability guards, reconnect resume, duplicate coalescing, and failed resume retention covered.
- `supervisor.ts` / `environment-runtime.ts`: network-required versus in-process transport behavior covered.
- Renderer client bus/RPC paths: offline classification and command-fault environment routing covered.

Tests: existing unit suite plus 2 new renderer test files.

## Pre-Landing Review

One reliability issue was found and fixed before commit: held queues were cleared before `resumeSessionQueue` completed, so a transient resume failure could drop automatic recovery. The queue is now re-registered on resume failure, with a regression test.

## Design Review

Frontend files changed. Lite review found no blocking design issues. The new no-connection tray uses the existing composer `TrayPill` surface and compact tray sizing.

## Eval Results

No prompt-related files changed, evals skipped.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] `bun --filter renderer test:unit` - 141 files, 700 tests passed
- [x] `bun --filter @zuse/client-runtime test:unit` - 15 files, 147 tests passed
- [x] `bun --filter renderer check-types`
- [x] `bun --filter @zuse/client-runtime check-types`
- [x] `bun --filter renderer build`
- [x] `bunx biome check <branch files>` - passed with warnings only

## Notes

- `bun run lint` across the full repo currently fails on pre-existing Biome diagnostics in unrelated files, including `tools/index-eval`, `apps/web/tsconfig.json`, `apps/desktop/build/icon.svg`, and package config formatting. Scoped Biome checking for the PR files completed successfully.
- This repository has no root `VERSION` file, so no version bump was made. `CHANGELOG.md` was updated under Unreleased.

Generated with OpenAI Codex.


## Documentation

- CHANGELOG.md: updated under Unreleased for offline queue recovery and local transport connectivity behavior.
- README.md, CLAUDE.md, AGENTS.md, DESIGN.md, CONTEXT-MAP.md, THIRD_PARTY_NOTICES.md, and .github/pull_request_template.md: reviewed, no factual updates needed for this runtime/UI reliability fix.